### PR TITLE
docs: add Landmark product spec, implementation plan

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -76,9 +76,14 @@ reference.
 browsers, job descriptions, AI agents that follow team standards, and
 progression plans that make growth tangible.
 
-**Guide** will connect these systems into context-aware AI assistance —
-onboarding, career advice, and problem-solving grounded in the team's actual
-framework, not generic best practices.
+**Guide** is the AI agent that understands the framework deeply enough to reason
+about it — onboarding new engineers, advising on career growth, and assessing
+engineering activity against the team's actual skill expectations.
+
+**Landmark** helps engineers see their own growth by connecting what they
+produce on GitHub — pull requests, reviews, design documents — back to the
+framework. And it helps organizations see whether their engineering systems
+support the practices the framework describes.
 
 **Basecamp** gives engineers a personal operations center — scheduled AI tasks
 that sync information, prepare briefings, and organize knowledge so engineers

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Documentation
-description: Technical documentation for the FIT suite — Map, Pathway, Guide, and Basecamp.
+description: Technical documentation for the FIT suite — Map, Pathway, Guide, Landmark, and Basecamp.
 layout: product
 toc: false
 hero:

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,49 +1,58 @@
 ---
 title: Guide
-description: Find your bearing — AI-powered onboarding and career advice grounded in your organization's engineering framework.
+description: Find your bearing — an AI agent that understands your engineering framework and helps you navigate it.
 layout: product
 toc: false
 hero:
   image: /assets/heros/guide.svg
   alt: An engineer, an AI robot holding a compass, and a business professional gathered together, finding their bearings
-  subtitle: Find your bearing. Guide is the AI assistant that helps engineers orient quickly — onboarding to new teams, getting career advice, and solving problems with context from your organization's skills framework.
+  subtitle: Find your bearing. Guide is an AI agent that understands your organization's skills, levels, and career paths — helping engineers onboard, grow, and stay on course.
   cta:
     - label: Coming soon
       href: /docs/
       secondary: true
 ---
 
-> The Guide doesn't carry you — it shows you which way to go. Powered by the
-> same skills framework that defines your career path, Guide provides
-> context-aware AI assistance that understands your engineering organization. It
-> helps new engineers onboard, existing engineers grow, and teams orient around
-> shared expectations.
+> The Guide doesn't carry you — it shows you which way to go. Most AI
+> assistants give generic advice. Guide understands your organization's actual
+> engineering framework — the skills, levels, behaviours, and expectations that
+> define what good looks like in your team. That context changes everything.
 
-### What Guide will offer
+### What Guide is
 
-- AI-powered onboarding that understands your team's skill framework
-- Career advice grounded in your organization's actual level expectations
-- Contextual help that references the right skills and behaviours
-- Problem-solving assistance that knows your team's conventions
-- Growth recommendations based on gap analysis between current and target roles
+Guide is an AI agent that reasons about your engineering framework. It
+understands your skills, levels, behaviours, disciplines, tracks, and career
+progression — not as static text, but as structured data it can think about in
+context.
 
----
+Ask Guide a question and it answers with your framework in mind:
 
-### The Vision
+- "What should I focus on to reach the next level?" — Guide knows your current
+  role, your target, and the specific skills that change between them
+- "How does our team approach code review?" — Guide references your team's
+  actual review standards, not generic best practices
+- "I'm new — where do I start?" — Guide walks you through your team's skill
+  expectations and conventions for your level
 
-Guide operates at the intersection of three knowledge sources:
+### What Guide does
 
-1. **Your skills framework** — the Map data that defines what "good" looks like
-2. **Your team context** — conventions, patterns, and preferences
-3. **The engineer's profile** — where they are and where they want to go
-
-By combining these, Guide provides advice that's specific to your organization
-rather than generic best practices.
+- **Onboarding** — helps new engineers orient in unfamiliar teams, grounded in
+  the team's actual skill framework and level expectations
+- **Career advice** — recommends growth areas based on gap analysis between
+  where you are and where you want to go
+- **Skill assessment** — observes engineering activity and interprets it against
+  the framework, giving Landmark the judgement it needs to match evidence to
+  markers
+- **Contextual help** — references the right skills, behaviours, and
+  conventions for your level when you need guidance
+- **Problem-solving** — assists with engineering decisions informed by your
+  team's standards and patterns
 
 ---
 
 ### Stay Updated
 
 Guide is currently in development. The foundation is being built in the Map,
-Pathway, and Basecamp products. When these are mature, Guide will connect them
-into a unified AI experience for engineering teams.
+Pathway, and Basecamp products. When these are mature, Guide will bring them
+together — an AI assistant that understands not just engineering in general, but
+engineering at your organization.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ hero:
   image: /assets/heros/welcome.svg
   alt: An engineer in a hoodie, an AI robot, and a business professional wave hello
   title: Empowered engineers<br>deliver lasting impact.
-  subtitle: Map, Pathway, Guide, and Basecamp — an open-source suite that helps organizations define great engineering, support career growth, and give every engineer the clarity to do their best work in the field.
+  subtitle: Map, Pathway, Guide, Landmark, and Basecamp — an open-source suite that helps organizations define great engineering, support career growth, and give every engineer the clarity to do their best work in the field.
   cta:
     - label: Explore the suite
       href: /docs/
@@ -50,8 +50,8 @@ progression plans — in the browser or from the CLI.
 
 ### Guide
 
-Find your bearing. AI-powered onboarding and career advice that helps engineers
-orient in unfamiliar terrain.
+Find your bearing. An AI agent that understands your engineering framework —
+onboarding, career advice, and growth guidance.
 
 <div class="btn btn-ghost">Learn more</div>
 </a>

--- a/specs/landmark/plan.md
+++ b/specs/landmark/plan.md
@@ -1,0 +1,540 @@
+# Plan: Landmark GitHub App
+
+Implement Landmark as a Supabase-backed GitHub App that collects engineering
+activity from GitHub Organizations, uses Guide to interpret artifacts against
+skill markers, and produces two views: personal evidence for engineers and
+practice patterns for teams.
+
+## Architecture
+
+```
+GitHub Organization
+  │
+  │ webhook events
+  ▼
+Edge Function (ingestion)
+  │
+  ├──→ Supabase Storage    /events/YYYY/MM/DD/{delivery_id}.json
+  │    (raw payloads)
+  │
+  └──→ Postgres            events (thin index)
+       (structured data)
+                           ┌──────────────────────┐
+                           │  pg_cron (scheduled)  │
+                           │  extracts artifacts   │
+                           │  from raw events      │
+                           └──────────┬───────────┘
+                                      ▼
+                                  artifacts
+                                      │
+                      ┌───────────────┤ on-demand or nightly
+                      ▼               ▼
+                   Guide           evidence
+               (interpretation)  (cached results)
+                                      │
+                      ┌───────────────┴───────────────┐
+                      ▼                               ▼
+               personal evidence              practice patterns
+              (engineer sees own)           (team-level, anonymous)
+```
+
+Three distinct phases, each running at its own cadence:
+
+1. **Ingestion** — real-time. Edge Function receives webhook, writes raw
+   payload to Storage, inserts index row into Postgres. Returns 200
+   immediately.
+
+2. **Extraction** — scheduled. A pg_cron job processes unextracted events,
+   reads raw payloads from Storage, and writes structured artifacts to
+   Postgres. Runs every few minutes.
+
+3. **Interpretation** — on-demand with caching. When an engineer queries their
+   own evidence, Guide assesses their unscored artifacts against markers.
+   Results are cached in the evidence table. An optional nightly job pre-warms
+   evidence for the full roster.
+
+## Access Model
+
+Landmark produces two views with different access rules. This is not a
+configuration option — it is the architecture.
+
+### Personal Evidence
+
+An engineer sees their own artifacts and Guide's interpretation of them.
+Nobody else sees this view unless the engineer shares it.
+
+- Queried by the engineer themselves via CLI
+- Scoped to their GitHub username — the CLI resolves this from git config or
+  explicit `--user` flag
+- No manager access, no admin override, no "view as" capability
+- The engineer can export their evidence to share in career conversations —
+  this is a deliberate act, not a default
+
+### Practice Patterns
+
+Engineering leadership sees aggregate patterns across a team, capability, or
+organization. No individuals named.
+
+- Queried by team or capability: `fit-landmark practice system_design --team platform`
+- Shows proportions and trends, not lists of people
+- "Most feature PRs include architecture sections" — not "Alice's PRs include
+  architecture sections"
+- Minimum team size for aggregate queries: 5 engineers. Below this threshold,
+  patterns could identify individuals by elimination.
+
+### Supabase Row-Level Security
+
+RLS policies enforce the access model at the database level. Even if someone
+writes a custom query, the database enforces visibility.
+
+```sql
+-- Engineers can only see their own evidence
+CREATE POLICY evidence_self_only ON evidence
+  FOR SELECT
+  USING (
+    artifact_id IN (
+      SELECT id FROM artifacts WHERE person = current_setting('app.github_user')
+    )
+  );
+
+-- Practice pattern views use aggregate functions only
+-- No policy needed — the view definition enforces anonymity
+CREATE VIEW practice_patterns AS
+  SELECT
+    skill_id,
+    level,
+    marker_index,
+    marker_text,
+    team,
+    count(*) FILTER (WHERE matched) AS matched_count,
+    count(*) AS total_count
+  FROM evidence
+  JOIN artifacts ON evidence.artifact_id = artifacts.id
+  JOIN roster ON artifacts.person = roster.github
+  GROUP BY skill_id, level, marker_index, marker_text, team
+  HAVING count(DISTINCT artifacts.person) >= 5;
+```
+
+The `HAVING` clause enforces the minimum team size. The view never exposes
+individual artifact IDs, person names, or specific PRs.
+
+## Phase 1: Ingestion
+
+### GitHub App Setup
+
+Register a GitHub App with these webhook event subscriptions:
+
+| Event                        | Why                                       |
+| ---------------------------- | ----------------------------------------- |
+| `pull_request`               | PR opened, closed, merged, edited         |
+| `pull_request_review`        | Reviews submitted                         |
+| `pull_request_review_comment`| Inline review comments                    |
+| `issue_comment`              | PR-level conversation (issues + PRs)      |
+| `push`                       | Commit activity on default branches       |
+
+The app requires **read-only** permissions:
+
+| Permission       | Access    |
+| ---------------- | --------- |
+| Pull requests    | Read      |
+| Contents         | Read      |
+| Metadata         | Read      |
+| Members          | Read      |
+
+No write permissions. Landmark never modifies repositories. It does not post
+comments, set status checks, or create annotations. It collects and stays
+silent.
+
+### Edge Function: Webhook Handler
+
+The Edge Function does three things sequentially:
+
+1. Validate the webhook signature (`X-Hub-Signature-256`)
+2. Write the raw JSON payload to Storage
+3. Insert a thin index row into Postgres
+
+```
+POST /functions/v1/github-webhook
+
+  1. Verify HMAC-SHA256 signature against app secret
+  2. Store raw payload:
+     Storage path: /events/{YYYY}/{MM}/{DD}/{delivery_id}.json
+     Content-Type: application/json
+  3. Insert index row:
+     INSERT INTO events (delivery_id, event_type, action, repo, sender, org, created_at, storage_path)
+  4. Return 200
+```
+
+The function does not parse event contents beyond the top-level fields needed
+for the index row. All semantic extraction happens later.
+
+### Storage Layout
+
+Raw payloads partitioned by date for efficient replay targeting:
+
+```
+/events
+  /2026
+    /02
+      /27
+        /a1b2c3d4-e5f6.json    (20-50KB each)
+        /f7g8h9i0-j1k2.json
+      /28
+        /...
+    /03
+      /...
+```
+
+Retention: indefinite. At ~1GB/day for a 1,000-developer organization, annual
+storage cost is under $100. Raw events are the source of truth — all downstream
+tables can be rebuilt from them.
+
+### Events Table (Postgres Index)
+
+```sql
+CREATE TABLE events (
+  delivery_id   UUID PRIMARY KEY,
+  event_type    TEXT NOT NULL,     -- 'pull_request', 'pull_request_review', etc.
+  action        TEXT,              -- 'opened', 'submitted', 'created', etc.
+  repo          TEXT NOT NULL,     -- 'org/repo-name'
+  sender        TEXT NOT NULL,     -- GitHub username
+  org           TEXT NOT NULL,     -- GitHub organization
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  storage_path  TEXT NOT NULL,     -- '/events/2026/02/27/{delivery_id}.json'
+  extracted     BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE INDEX idx_events_extraction ON events (extracted, created_at)
+  WHERE NOT extracted;
+CREATE INDEX idx_events_sender ON events (sender, created_at);
+CREATE INDEX idx_events_repo ON events (repo, created_at);
+CREATE INDEX idx_events_type ON events (event_type, created_at);
+```
+
+Small rows (~200 bytes). At 30,000 events/day: ~2.2GB/year of index data.
+
+## Phase 2: Extraction
+
+A scheduled job reads unextracted events, fetches their raw payloads from
+Storage, and writes structured artifacts to Postgres.
+
+### Extraction Job
+
+Runs via pg_cron or a Supabase scheduled Edge Function, every 5 minutes:
+
+```
+1. SELECT delivery_id, event_type, action, storage_path
+   FROM events
+   WHERE NOT extracted
+   ORDER BY created_at
+   LIMIT 500
+
+2. For each event:
+   a. Fetch raw payload from Storage
+   b. Extract artifact fields based on event_type
+   c. Upsert into artifacts table
+   d. Mark event as extracted
+
+3. UPDATE events SET extracted = true
+   WHERE delivery_id IN (...)
+```
+
+### What Gets Extracted
+
+Each event type produces a different artifact shape. The extraction logic is a
+set of deterministic field mappings — no LLM, no heuristics beyond structural
+parsing.
+
+| Event type                    | Artifact type | Key fields extracted                                           |
+| ----------------------------- | ------------- | -------------------------------------------------------------- |
+| `pull_request.opened`         | `pr`          | title, body, author, files, additions, deletions, base branch  |
+| `pull_request.closed/merged`  | `pr` (update) | merged, merged_by, merge_commit, time-to-merge                |
+| `pull_request_review`         | `review`      | reviewer, body, state (approved/changes_requested/commented)   |
+| `pull_request_review_comment` | `comment`     | commenter, body, path, position, in_reply_to                  |
+| `issue_comment` (on PR)       | `discussion`  | commenter, body, PR reference                                 |
+| `push`                        | `push`        | pusher, commits (sha, message), ref, before/after              |
+
+### Artifacts Table
+
+```sql
+CREATE TABLE artifacts (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  person        TEXT NOT NULL,         -- GitHub username
+  repo          TEXT NOT NULL,
+  artifact_type TEXT NOT NULL,         -- 'pr', 'review', 'comment', 'discussion', 'push'
+  external_id   TEXT NOT NULL,         -- 'pr:org/repo#342', 'review:org/repo#342/1'
+  external_url  TEXT,                  -- GitHub permalink
+  created_at    TIMESTAMPTZ NOT NULL,  -- event timestamp, not insertion time
+  metadata      JSONB NOT NULL,        -- type-specific fields
+  UNIQUE (external_id)
+);
+
+CREATE INDEX idx_artifacts_person ON artifacts (person, created_at);
+CREATE INDEX idx_artifacts_repo ON artifacts (repo, created_at);
+CREATE INDEX idx_artifacts_type ON artifacts (artifact_type, created_at);
+```
+
+The `external_id` ensures idempotency — multiple events for the same PR
+(opened, synchronize, edited) upsert the same artifact row with updated
+metadata rather than creating duplicates.
+
+### Roster Table
+
+Loaded from `landmark.yaml` via CLI or API. Maps GitHub usernames to Pathway
+job profiles.
+
+```sql
+CREATE TABLE roster (
+  github        TEXT PRIMARY KEY,
+  discipline    TEXT NOT NULL,
+  level         TEXT NOT NULL,
+  track         TEXT,
+  team          TEXT,                  -- team name for practice pattern grouping
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+The `team` field groups engineers for practice pattern queries. Teams are the
+organizational unit — "platform", "payments", "mobile". Aggregate views use
+this field to scope patterns. Teams with fewer than 5 members are excluded from
+aggregate queries to prevent identification by elimination.
+
+```
+$ fit-landmark roster sync landmark.yaml
+  Synced 142 roster entries across 12 teams.
+  3 new, 2 updated, 0 removed.
+```
+
+## Phase 3: Interpretation
+
+Guide runs on-demand. When an engineer queries their own evidence, Landmark
+checks which artifacts have been interpreted and which haven't. Uninterpreted
+artifacts are sent to Guide with the relevant markers. Results are cached.
+
+### Personal Evidence Flow
+
+```
+fit-landmark evidence --skill system_design
+  │
+  1. Resolve current user → @alice (from git config)
+  2. Look up @alice in roster → se, L3, platform
+  3. Derive skill expectations from Pathway → system_design at working level
+  4. Load markers for system_design.working.human
+  5. SELECT artifacts WHERE person = 'alice'
+     AND artifact_type IN ('pr', 'review', 'comment')
+     AND NOT EXISTS (cached evidence for this artifact + marker set)
+  6. For each uninterpreted artifact:
+     → Send to Guide: artifact metadata + markers + skill context
+     ← Receive: which markers this artifact relates to, with rationale
+  7. INSERT INTO evidence (artifact, marker, rationale)
+  8. Return evidence for @alice + system_design, grouped by artifact
+```
+
+Steps 1–5 are cheap Postgres queries. Step 6 is the LLM call — it only runs
+for artifacts that haven't been interpreted yet. Subsequent queries for the same
+skill hit the cache.
+
+The output groups by artifact, not by marker. The engineer sees their work
+first, then how it relates to the framework — not a checklist of markers with
+pass/fail status.
+
+### Practice Pattern Flow
+
+```
+fit-landmark practice system_design --team platform
+  │
+  1. Look up all roster entries WHERE team = 'platform'
+  2. Verify team size >= 5 (refuse if below threshold)
+  3. Derive skill expectations for each person's job profile
+  4. Aggregate evidence across all team members:
+     - For each marker: what proportion of the team shows evidence?
+     - Trend: is evidence for this marker increasing or decreasing?
+  5. Return anonymous summary with proportions and trends
+```
+
+The query never returns individual names, artifact IDs, or PR links. It returns
+statements about the team as a system: "most feature PRs include architecture
+sections" or "few PRs document multiple approaches considered."
+
+When evidence is weak for a marker, the output asks a process question — not
+"who isn't doing this?" but "does the engineering process support this
+practice?"
+
+### Nightly Batch
+
+An optional pg_cron job runs interpretation for the full roster. Same logic as
+the personal evidence flow but iterates over all roster entries:
+
+```
+For each person in roster:
+  For each skill in their job profile:
+    Run the evidence flow (skips already-cached interpretation)
+```
+
+This pre-warms the cache so that morning queries are instant. It also ensures
+practice pattern views have fresh data. The job can be scheduled for off-peak
+hours (e.g., 3 AM) and rate-limited to control LLM costs.
+
+The nightly batch produces evidence rows visible only to the individual
+engineer. It does not generate reports, send notifications, or surface results
+to anyone else.
+
+### Evidence Table
+
+```sql
+CREATE TABLE evidence (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  artifact_id   UUID NOT NULL REFERENCES artifacts(id),
+  skill_id      TEXT NOT NULL,         -- 'system_design'
+  level         TEXT NOT NULL,         -- 'working'
+  marker_index  INT NOT NULL,          -- which marker in the array
+  marker_text   TEXT NOT NULL,         -- the marker string (for audit)
+  matched       BOOLEAN NOT NULL,      -- does this artifact relate to this marker?
+  rationale     TEXT,                  -- Guide's reasoning (visible to the engineer)
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (artifact_id, skill_id, level, marker_index)
+);
+
+CREATE INDEX idx_evidence_artifact ON evidence (artifact_id);
+CREATE INDEX idx_evidence_skill ON evidence (skill_id, level);
+```
+
+The unique constraint ensures one interpretation per artifact per marker. When
+markers change (new version of the framework), evidence rows for the old marker
+text become stale — the nightly job or next on-demand query regenerates them.
+
+Note: the `confidence` column from the earlier design was removed. A numeric
+confidence score invites ranking and thresholding — exactly the kind of
+quantification that turns evidence into scores. Guide's `rationale` text is
+sufficient. The engineer reads the reasoning and decides for themselves.
+
+## Event Replay
+
+Raw events in Storage are the source of truth. The `artifacts` table is a
+materialized view that can be rebuilt when extraction heuristics change.
+
+### Why Replay
+
+Extraction logic will evolve. Examples:
+
+- A new artifact type is added (e.g., extracting linked design docs from PR
+  bodies)
+- The PR artifact starts capturing `requested_reviewers` to track review
+  assignment patterns
+- The comment extractor improves thread-grouping logic to better identify
+  discussion resolution
+
+When heuristics change, the existing artifacts table reflects the old logic.
+Replay re-extracts from raw events using the new logic.
+
+### Replay Process
+
+```
+fit-landmark replay [--since DATE] [--event-type TYPE] [--dry-run]
+```
+
+1. Query the events index for the target range:
+   ```sql
+   SELECT delivery_id, storage_path
+   FROM events
+   WHERE created_at >= :since
+     AND (:event_type IS NULL OR event_type = :event_type)
+   ORDER BY created_at
+   ```
+
+2. Fetch each raw payload from Storage
+
+3. Run the current extraction logic over it — same code path as the scheduled
+   extraction job
+
+4. Upsert into artifacts (external_id ensures idempotency — existing rows are
+   updated, not duplicated)
+
+5. Invalidate downstream evidence for affected artifacts:
+   ```sql
+   DELETE FROM evidence
+   WHERE artifact_id IN (
+     SELECT id FROM artifacts WHERE external_id = ANY(:affected_ids)
+   )
+   ```
+
+The next on-demand query or nightly batch regenerates evidence using Guide
+against the updated artifacts.
+
+### Replay at Scale
+
+For a full replay of 1 year of events (~10M events, ~365GB of raw payloads):
+
+- Storage reads are cheap — Supabase Storage is S3-compatible, bulk reads are
+  pennies
+- Extraction is CPU-bound but fast — deterministic field mapping, no LLM
+- The bottleneck is Postgres write throughput for artifact upserts — batch in
+  groups of 100–500, run over hours not minutes
+- Evidence invalidation is a bulk DELETE — fast with the artifact_id index
+
+Partial replays (last 30 days, specific event type) are the common case and
+complete in minutes.
+
+### Replay Safety
+
+- Replay is idempotent. Running it twice with the same parameters produces the
+  same artifacts.
+- Replay does not touch the events index or raw Storage — those are immutable.
+- Evidence is invalidated, not silently replaced. The absence of evidence is
+  visible in queries until Guide re-interprets.
+- `--dry-run` shows what would change without writing.
+
+## Data Model Summary
+
+```
+events (index)           1:1     Storage (raw payloads)
+  │
+  │ extraction
+  ▼
+artifacts               N:1     roster (people → jobs, teams)
+  │
+  │ interpretation (Guide)
+  ▼
+evidence
+  │
+  ├──→ personal evidence     (engineer sees own, RLS-enforced)
+  └──→ practice patterns     (team aggregate, anonymous, min 5 members)
+```
+
+| Table     | Growth rate         | Retention | Rebuildable from    |
+| --------- | ------------------- | --------- | ------------------- |
+| events    | ~30k rows/day       | Permanent | —                   |
+| Storage   | ~1GB/day            | Permanent | —                   |
+| artifacts | ~5k rows/day        | Permanent | events + Storage    |
+| evidence  | On-demand           | Until invalidated | artifacts + Guide |
+| roster    | Manual updates      | Current   | landmark.yaml       |
+
+## Supabase Project Structure
+
+```
+supabase/
+  functions/
+    github-webhook/         Edge Function — ingestion endpoint
+  migrations/
+    001_events.sql          events table + indexes
+    002_artifacts.sql       artifacts table + indexes
+    003_roster.sql          roster table (with team column)
+    004_evidence.sql        evidence table + indexes
+    005_extraction_cron.sql pg_cron job for artifact extraction
+    006_rls_policies.sql    row-level security for personal evidence
+    007_practice_views.sql  aggregate views for practice patterns
+```
+
+## Implementation Order
+
+1. Supabase project setup and database migrations
+2. GitHub App registration (webhook URL, permissions, events)
+3. Webhook Edge Function (signature validation, Storage write, index insert)
+4. Extraction job (pg_cron, raw event → artifact mapping)
+5. Roster sync CLI with team column (`fit-landmark roster sync`)
+6. RLS policies for personal evidence isolation
+7. Personal evidence flow (`fit-landmark evidence`)
+8. Practice pattern aggregate views and CLI (`fit-landmark practice`)
+9. Evidence caching and invalidation
+10. Replay CLI (`fit-landmark replay`)
+11. Nightly batch job

--- a/specs/landmark/spec.md
+++ b/specs/landmark/spec.md
@@ -1,0 +1,377 @@
+# Landmark
+
+Help engineers see their own growth. Help organizations improve the systems
+that support it.
+
+```
+@forwardimpact/landmark    CLI: fit-landmark
+```
+
+## Why
+
+| Product      | Question it answers                             |
+| ------------ | ----------------------------------------------- |
+| **Map**      | What does the terrain look like?                |
+| **Pathway**  | Where am I going?                               |
+| **Guide**    | How do I get there?                             |
+| **Basecamp** | What do I need day-to-day?                      |
+| **Landmark** | _What does my work actually show?_              |
+
+Map defines skills. Pathway charts the route through them. Guide coaches.
+Basecamp handles daily ops. But none of them connect the work engineers already
+do back to the framework that describes what good looks like.
+
+The evidence is already there — in pull requests, code reviews, design
+documents, architecture decisions. Landmark makes it visible. Not to judge
+individuals, but to help engineers reflect on their own growth and to help
+organizations see whether their engineering systems create the conditions for
+that growth to happen.
+
+When nobody on a team produces design trade-off documentation, the question
+isn't "why aren't these engineers doing this?" The question is "does our process
+give engineers the time, the templates, the examples, and the review culture to
+do this well?" The skill definition describes what good looks like. The landmark
+is the evidence on the ground that tells you whether the system supports it.
+
+## Design Principles
+
+These aren't guardrails bolted onto an inspection tool. They are the
+architecture.
+
+**Engineers own their evidence.** Landmark's primary user is the engineer. They
+see their own work reflected against the framework. They decide what to share,
+when, and with whom. Self-reflection is the default mode — everything else
+requires the engineer's participation.
+
+**Improve the system, not the individual.** When a skill shows weak evidence
+across a team, the cause is almost always in the process — not enough time for
+design work, no examples to follow, no review culture that values it. Landmark
+surfaces patterns that point to system improvements. Individual evidence exists
+to support the engineer's own growth, not to produce scorecards for management.
+
+**GitHub is one window, not the whole picture.** A great deal of engineering
+skill is invisible on GitHub: the hallway conversation that prevented a bad
+design, the quiet mentoring that doesn't happen in PR comments, the decision
+not to build something. Landmark sees artifacts. It does not see the full
+practice. The framework captures both — Landmark captures what it can, and
+makes no claim about the rest.
+
+**Show the work, not a score.** Evidence is presented as artifacts with
+context — "here is a PR where you documented trade-offs" — not as a filled
+progress bar. Numbers invite gaming. Narratives invite reflection.
+
+## What
+
+Landmark is a GitHub App. Organizations install it on their GitHub Organization,
+and it collects engineering activity — pull requests, reviews, commits,
+discussions. Guide then reads that activity against skill markers from the
+framework, producing two views:
+
+1. **Personal evidence** — an engineer's own work, reflected against the markers
+   for their role. Self-directed. The engineer explores their own artifacts and
+   sees which practices show up in their work.
+
+2. **Practice patterns** — team-level and organization-level views of which
+   engineering practices show strong evidence and which don't. This is where
+   process improvement starts. Nobody is named — the patterns describe the
+   system, not the people in it.
+
+### Roster
+
+To connect GitHub activity to the framework, Landmark reads a **roster** — a
+config file that maps GitHub usernames to Pathway job definitions. Organizations
+export this from their HR system or maintain it by hand.
+
+```yaml
+# landmark.yaml
+roster:
+  - github: alice
+    job: { discipline: se, level: L3, track: platform }
+  - github: bob
+    job: { discipline: se, level: L4 }
+  - github: carol
+    job: { discipline: se, level: L3, track: dx }
+```
+
+The roster tells Landmark what skill profile to reflect against. Alice is an L3
+Software Engineer on the platform track — Pathway derives her skill
+expectations, and Landmark shows her the evidence in her own GitHub activity
+that relates to those expectations.
+
+Agents appear in the roster the same way. A bot account maps to an agent
+profile, and the same markers apply to its PRs.
+
+### The GitHub App
+
+The app receives GitHub webhook events as they happen — no polling, no batch
+jobs. When a PR is opened, reviewed, merged, or commented on, Landmark receives
+the event and stores the relevant facts.
+
+The app collects. It does not act on repositories — no comments, no status
+checks, no annotations on PRs. It does not surface results inside GitHub. All
+output is through the CLI, where the engineer controls what they see.
+
+### Collector and Interpreter
+
+Landmark has two parts.
+
+The **collector** is the GitHub App. It receives events, extracts structured
+facts, and stores them. This is deterministic — anyone can see exactly what was
+collected and when.
+
+The **interpreter** is Guide. Landmark passes collected artifacts to Guide along
+with the relevant skill markers, and Guide reads the artifacts in context: does
+this PR description show trade-off analysis? Do these review comments explain
+reasoning, not just point out problems?
+
+```
+GitHub Events → Collector (deterministic) → Guide (interpretation) → Evidence
+```
+
+The collector is cheap, repeatable, and auditable. The interpretation is an LLM
+judgement — making that explicit means the reasoning is visible and reviewable.
+The engineer sees not just "this artifact relates to this marker" but Guide's
+rationale for why.
+
+### Markers
+
+A marker is a concrete, observable indicator of a skill at a proficiency level.
+Not a description of the skill — a description of what you can **see** when
+someone has it.
+
+| Skill description (Map)              | Marker (Landmark)                                                   |
+| ------------------------------------ | ------------------------------------------------------------------- |
+| "You design systems independently"   | "Authored a design doc accepted without requiring senior rewrite"   |
+| "You write well-tested code"         | "PRs include tests that cover the changed behaviour, not just lines"|
+| "You mentor others through review"   | "Review comments explain the *why*, not just the *what*"            |
+
+Markers live in the same YAML capability files as skills, following the
+co-located file principle:
+
+```yaml
+skills:
+  - id: system_design
+    name: System Design
+    human:
+      description: ...
+      levelDescriptions:
+        working: You design systems independently
+    agent:
+      name: system-design
+      description: ...
+    markers:
+      working:
+        human:
+          - Authored a design doc accepted without requiring senior rewrite
+          - Led a technical discussion that resolved a design disagreement
+          - Identified trade-offs for at least two viable approaches
+        agent:
+          - Produced a design doc that passes review without structural rework
+          - Decomposed a feature into components with clear interface boundaries
+          - Selected appropriate patterns with documented trade-off rationale
+```
+
+Markers are **installation-specific**. The same skill at the same level may have
+different markers in different organizations, because observable evidence depends
+on context. The skill definition is universal. The marker is local.
+
+### Evidence
+
+Evidence is a GitHub artifact that Guide has read against a marker. It is
+linked, not copied — Landmark points to the PR, the review comment, the
+commit. The artifact stays where it was produced, always current and verifiable.
+
+### How Engineers Use Landmark
+
+The primary flow is self-directed. An engineer asks to see their own evidence
+for a skill. Landmark shows them the artifacts from their recent work that
+relate to the markers for that skill, with Guide's interpretation of each.
+
+The engineer reads the evidence and reflects: "yes, I do this consistently" or
+"I haven't done much of this lately — why not?" That second question is where
+the value is. Maybe the answer is personal — they haven't had the right
+opportunities. Maybe it's systemic — the team doesn't create space for it.
+Either way, the engineer owns the insight.
+
+An engineer can choose to bring their evidence into a career conversation with
+their manager. This is opt-in. The evidence is preparation for a conversation,
+not a replacement for one. A good engineering manager doesn't need a dashboard
+to know their team — they have conversations. Landmark gives both parties a
+shared, concrete starting point.
+
+### How Organizations Use Landmark
+
+The second view is aggregate. Across a team, a capability area, or the whole
+organization: which engineering practices show strong evidence and which don't?
+
+This is where process improvement starts. If trade-off documentation is absent
+across an entire team, the system isn't supporting the practice. Maybe design
+time isn't allocated. Maybe there are no examples to follow. Maybe the review
+culture doesn't ask for it. The aggregate view points to where the process
+needs attention — without naming individuals, without producing league tables,
+without creating fear.
+
+## Positioning
+
+```
+map → libpathway → pathway
+  ↘               ↗
+   guide → landmark
+  ↗
+map
+```
+
+- **Map** defines skills, levels, behaviours — the data model
+- **libpathway** derives jobs and agent profiles from Map data
+- **Guide** is the AI agent that traverses Map and Pathway data — the
+  interpretation layer
+- **Landmark** collects GitHub activity and uses Guide to read it against
+  markers. It depends on Guide for all interpretation.
+- **Pathway** presents career progression, now with reflective evidence from
+  Landmark
+- **Basecamp** generates supplementary evidence (meeting notes, email
+  decisions) that Landmark can reference alongside GitHub activity
+
+## Design
+
+### Name
+
+**Landmark** — a recognizable, fixed reference point used to confirm position.
+No metaphor to decode.
+
+| Product  | Metaphor                | Provides               |
+| -------- | ----------------------- | ---------------------- |
+| Map      | The surveyed territory  | Data model             |
+| Pathway  | The mountain trail      | Career progression     |
+| Guide    | The compass bearing     | Coaching and direction |
+| Basecamp | The shelter and supplies| Daily operations       |
+| Landmark | The cairn on the trail  | Evidence markers       |
+
+### Icon: The Cairn
+
+Three stacked stones, viewed from the side. Organic shapes, not geometric
+circles. Top stone smallest, bottom largest.
+
+- 24 x 24px grid, 2px padding
+- 2px stroke, round caps and joins
+- No fill (consistent with Map, Pathway, Basecamp)
+- Hand-drawn feel with micro-variations in stone outlines
+
+**Flat variant:** Three overlapping rounded shapes stacked vertically,
+center-aligned. Simplified for favicons and tab bars.
+
+### Emoji
+
+🪨
+
+### Hero Scene: "Checking the Cairn"
+
+The trio (Engineer, AI Agent, Business Stakeholder) paused on a trail at a
+cairn. The Engineer compares a notebook against the cairn. The AI Agent points
+at it. The Stakeholder looks at the notebook, nodding.
+
+Trail runs left to right. Cairn slightly right of center. Trio left of center,
+oriented toward it. Distant mountain peaks in background with trail continuing
+beyond.
+
+### Visual Language
+
+| Attribute   | Value                                                     |
+| ----------- | --------------------------------------------------------- |
+| Metaphor    | Cairns, stacked stones, trail markers, triangulation      |
+| Tone        | "See the work. Improve the system."                       |
+| Terrain     | Rocky trail sections with deliberate marker placements    |
+| Empty state | Single stone on the ground, unstacked — awaiting evidence |
+
+### Taglines
+
+- Primary: **"See your own growth. Improve the system."**
+- Secondary: "Observable markers for engineering practice."
+- CTA: "Reflect on your work."
+
+## CLI
+
+The GitHub App collects activity continuously. The CLI queries what's been
+collected. Two views: personal evidence and practice patterns.
+
+```
+Landmark — Observable markers for engineering practice.
+
+Usage:
+  fit-landmark evidence [--skill]          Show your own evidence
+  fit-landmark practice <skill> [--team]   Show practice patterns across a team
+  fit-landmark marker <skill> [--level]    Show markers for a skill
+  fit-landmark roster                      Show the current roster
+  fit-landmark validate                    Validate marker definitions
+```
+
+### Personal Evidence
+
+The default command shows the engineer their own work. No arguments needed — it
+uses their GitHub username and roster entry.
+
+```
+$ fit-landmark evidence --skill system_design
+
+  Your evidence: System Design (working level)
+
+  PR #342 "Redesign authentication flow"
+    Design doc with component diagram in PR description. Approved by two
+    reviewers without structural rework.
+    → relates to: design doc accepted without senior rewrite
+
+  PR #342 review thread
+    Resolved caching vs. session debate. Posted trade-off comparison and
+    the team converged on session approach.
+    → relates to: led a technical discussion that resolved a design disagreement
+
+  No recent artifacts relate to:
+    → identified trade-offs for at least two viable approaches
+```
+
+The output shows artifacts and context — what happened, in the engineer's own
+work. No scores, no counts, no progress bars. The engineer reads it and draws
+their own conclusions.
+
+### Practice Patterns
+
+The aggregate view shows how a practice appears across a team. No individuals
+named.
+
+```
+$ fit-landmark practice system_design --team platform
+
+  System Design practice — Platform team (last quarter)
+
+  Strong evidence:
+    Design documents in PRs — most feature PRs include architecture sections
+    Review quality — review threads regularly discuss design rationale
+
+  Weak evidence:
+    Trade-off analysis — few PRs document multiple approaches considered
+    Consider: do engineers have time for design exploration before
+    implementation begins?
+
+  Based on 47 feature PRs and 156 reviews from 12 engineers.
+```
+
+This view is for engineering leadership. It points to where the system supports
+good practice and where it doesn't. It asks questions about the process, not
+about the people.
+
+## Summary
+
+| Attribute      | Value                                                 |
+| -------------- | ----------------------------------------------------- |
+| Package        | `@forwardimpact/landmark`                             |
+| CLI            | `fit-landmark`                                        |
+| Delivery       | GitHub App installed on GitHub Organizations          |
+| Icon           | Cairn (three stacked stones)                          |
+| Emoji          | 🪨                                                    |
+| Hero scene     | "Checking the Cairn"                                  |
+| Tagline        | "See your own growth. Improve the system."            |
+| Depends on     | `@forwardimpact/guide` (interpretation), `@forwardimpact/map` (markers) |
+| Input          | GitHub webhook events + roster (people → job profiles)|
+| For engineers  | Self-directed evidence, preparation for career conversations |
+| For teams      | Practice patterns, process improvement signals        |
+| For agents     | Same markers, same evidence, same interpretation      |


### PR DESCRIPTION
Landmark is a GitHub App that helps engineers see their own growth and helps organizations improve the systems that support it. It collects engineering activity via webhooks and uses Guide to interpret artifacts against skill markers from the framework.

Product spec (specs/landmark/spec.md):
- Two views: personal evidence (self-directed, RLS-enforced) and practice patterns (anonymous team-level aggregates)
- Engineers own their evidence — self-reflection is the default mode
- GitHub App collects passively; CLI queries what's been collected
- Roster config maps GitHub usernames to Pathway job profiles
- Design artifacts: cairn icon, "Checking the Cairn" hero scene

Implementation plan (specs/landmark/plan.md):
- Supabase architecture: Edge Function ingestion, S3 raw event storage, Postgres structured data, pg_cron extraction
- Three phases: real-time ingestion, scheduled extraction, on-demand Guide interpretation with caching and optional nightly batch
- Event replay from raw Storage payloads when extraction heuristics change, with downstream evidence invalidation
- Access model with RLS policies, minimum 5-member team threshold for aggregate queries, no individual scorecards

Guide repositioning (docs/guide/):
- Rewritten as an AI agent that reasons about the engineering framework
- Serves as direct assistant for engineers and interpretation layer for other products (Landmark routes through Guide for inference)

Also updates homepage, about page, and docs index to include Landmark in the product suite.

https://claude.ai/code/session_01NAyWhXLfp8RPgiWNbfwR3a