### PR TITLE
feat(landmark): organization, repositories, and survey schema design

### DIFF
--- a/specs/landmark/plan.md
+++ b/specs/landmark/plan.md
@@ -50,7 +50,7 @@ Three distinct phases, each running at its own cadence:
 3. **Interpretation** — on-demand with caching. When an engineer queries their
    own evidence, Guide assesses their unscored artifacts against markers.
    Results are cached in the evidence table. An optional nightly job pre-warms
-   evidence for the full roster.
+   evidence for the full organization.
 
 ## Access Model
 
@@ -75,7 +75,7 @@ Engineering leadership sees aggregate patterns across a team, capability, or
 organization. No individuals named.
 
 - Queried by team or capability:
-  `fit-landmark practice system_design --team platform`
+  `fit-landmark practice system_design --manager carol`
 - Shows proportions and trends, not lists of people
 - "Most feature PRs include architecture sections" — not "Alice's PRs include
   architecture sections"
@@ -105,13 +105,13 @@ CREATE VIEW practice_patterns AS
     level,
     marker_index,
     marker_text,
-    team,
+    org.manager,
     count(*) FILTER (WHERE matched) AS matched_count,
     count(*) AS total_count
   FROM evidence
   JOIN artifacts ON evidence.artifact_id = artifacts.id
-  JOIN roster ON artifacts.person = roster.github
-  GROUP BY skill_id, level, marker_index, marker_text, team
+  JOIN organization org ON artifacts.person = org.github
+  GROUP BY skill_id, level, marker_index, marker_text, org.manager
   HAVING count(DISTINCT artifacts.person) >= 5;
 ```
 
@@ -278,32 +278,91 @@ The `external_id` ensures idempotency — multiple events for the same PR (opene
 synchronize, edited) upsert the same artifact row with updated metadata rather
 than creating duplicates.
 
-### Roster Table
+### Organization Table
 
-Loaded from `landmark.yaml` via CLI or API. Maps GitHub usernames to Pathway job
-profiles.
+Loaded from `organization.yaml` via CLI or API. Maps GitHub usernames to Pathway
+job profiles and line managers.
 
 ```sql
-CREATE TABLE roster (
+CREATE TABLE organization (
   github        TEXT PRIMARY KEY,
+  name          TEXT NOT NULL,
   discipline    TEXT NOT NULL,
   level         TEXT NOT NULL,
   track         TEXT,
-  team          TEXT,                  -- team name for practice pattern grouping
+  manager       TEXT REFERENCES organization(github),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_organization_manager ON organization (manager);
+```
+
+Each person links to their line manager by GitHub username. A team is a manager
+and their direct reports — there is no separate team entity. Carol's team is
+everyone whose `manager` field is `carol`. Aggregate views use this relationship
+to scope patterns. Teams with fewer than 5 members are excluded from aggregate
+queries to prevent identification by elimination.
+
+The top of the hierarchy has `manager` set to NULL.
+
+```
+$ fit-landmark org sync organization.yaml
+  Synced 142 people, 3 levels of hierarchy.
+  3 new, 2 updated, 0 removed.
+```
+
+### Repository Table
+
+Loaded from `repositories.yaml`. Maps GitHub repos to optional capability areas.
+
+```sql
+CREATE TABLE repositories (
+  id            TEXT PRIMARY KEY,     -- 'org/repo-name'
+  capabilities  TEXT[],               -- optional capability IDs
   updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 ```
 
-The `team` field groups engineers for practice pattern queries. Teams are the
-organizational unit — "platform", "payments", "mobile". Aggregate views use this
-field to scope patterns. Teams with fewer than 5 members are excluded from
-aggregate queries to prevent identification by elimination.
+The `capabilities` array is optional — repositories without capability tags
+still produce artifacts and evidence. When present, capability tags let Guide
+infer what kind of work a repository exercises.
 
+### Survey Tables
+
+Survey definitions and aggregate results, loaded from YAML files.
+
+```sql
+CREATE TABLE surveys (
+  id            TEXT PRIMARY KEY,
+  name          TEXT NOT NULL,
+  period_start  DATE NOT NULL,
+  period_end    DATE NOT NULL,
+  scale_min     INT NOT NULL DEFAULT 1,
+  scale_max     INT NOT NULL DEFAULT 5,
+  scale_labels  JSONB,                -- { "1": "Strongly Disagree", ... }
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE survey_results (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  survey_id     TEXT NOT NULL REFERENCES surveys(id),
+  manager       TEXT NOT NULL REFERENCES organization(github),
+  respondents   INT NOT NULL,
+  ratings       JSONB NOT NULL,       -- { "driver_id": { "mean": 4.1, "distribution": [0,1,1,3,3] } }
+  UNIQUE (survey_id, manager)
+);
+
+CREATE INDEX idx_survey_results_survey ON survey_results (survey_id);
+CREATE INDEX idx_survey_results_manager ON survey_results (manager);
 ```
-$ fit-landmark roster sync landmark.yaml
-  Synced 142 roster entries across 12 teams.
-  3 new, 2 updated, 0 removed.
-```
+
+Survey results are aggregate Likert scores per manager (team) per driver.
+Individual responses stay anonymous — only team-level aggregation is stored. The
+`manager` field references the organization table, identifying the team as the
+manager's direct reports.
+
+The `ratings` JSONB contains keys matching driver IDs from Map, each with a
+`mean` and `distribution` array (count of responses at each scale point).
 
 ## Phase 3: Interpretation
 
@@ -317,7 +376,7 @@ artifacts are sent to Guide with the relevant markers. Results are cached.
 fit-landmark evidence --skill system_design
   │
   1. Resolve current user → @alice (from git config)
-  2. Look up @alice in roster → se, L3, platform
+  2. Look up @alice in organization → se, L3, platform
   3. Derive skill expectations from Pathway → system_design at working level
   4. Load markers for system_design.working.human
   5. SELECT artifacts WHERE person = 'alice'
@@ -341,15 +400,17 @@ pass/fail status.
 ### Practice Pattern Flow
 
 ```
-fit-landmark practice system_design --team platform
+fit-landmark practice system_design --manager carol
   │
-  1. Look up all roster entries WHERE team = 'platform'
+  1. Look up all organization entries WHERE manager = 'carol'
   2. Verify team size >= 5 (refuse if below threshold)
   3. Derive skill expectations for each person's job profile
   4. Aggregate evidence across all team members:
      - For each marker: what proportion of the team shows evidence?
      - Trend: is evidence for this marker increasing or decreasing?
-  5. Return anonymous summary with proportions and trends
+  5. Look up survey results WHERE manager = 'carol' (most recent period)
+     - If available: include driver ratings for contributing skills
+  6. Return anonymous summary with proportions, trends, and survey context
 ```
 
 The query never returns individual names, artifact IDs, or PR links. It returns
@@ -358,15 +419,17 @@ sections" or "few PRs document multiple approaches considered."
 
 When evidence is weak for a marker, the output asks a process question — not
 "who isn't doing this?" but "does the engineering process support this
-practice?"
+practice?" When survey data is available, the output correlates perception
+(survey ratings) with observable evidence (Landmark artifacts) through the
+driver's contributing skills.
 
 ### Nightly Batch
 
-An optional pg_cron job runs interpretation for the full roster. Same logic as
-the personal evidence flow but iterates over all roster entries:
+An optional pg_cron job runs interpretation for the full organization. Same
+logic as the personal evidence flow but iterates over all organization entries:
 
 ```
-For each person in roster:
+For each person in organization:
   For each skill in their job profile:
     Run the evidence flow (skips already-cached interpretation)
 ```
@@ -492,23 +555,26 @@ events (index)           1:1     Storage (raw payloads)
   │
   │ extraction
   ▼
-artifacts               N:1     roster (people → jobs, teams)
-  │
+artifacts               N:1     organization (people → jobs → managers)
+  │                             repositories (repos → capabilities)
   │ interpretation (Guide)
   ▼
-evidence
+evidence ←──────────────────── survey_results (perception per manager/driver)
   │
   ├──→ personal evidence     (engineer sees own, RLS-enforced)
-  └──→ practice patterns     (team aggregate, anonymous, min 5 members)
+  └──→ practice patterns     (team aggregate + survey context, anonymous, min 5)
 ```
 
-| Table     | Growth rate    | Retention         | Rebuildable from  |
-| --------- | -------------- | ----------------- | ----------------- |
-| events    | ~30k rows/day  | Permanent         | —                 |
-| Storage   | ~1GB/day       | Permanent         | —                 |
-| artifacts | ~5k rows/day   | Permanent         | events + Storage  |
-| evidence  | On-demand      | Until invalidated | artifacts + Guide |
-| roster    | Manual updates | Current           | landmark.yaml     |
+| Table          | Growth rate    | Retention         | Rebuildable from     |
+| -------------- | -------------- | ----------------- | -------------------- |
+| events         | ~30k rows/day  | Permanent         | —                    |
+| Storage        | ~1GB/day       | Permanent         | —                    |
+| artifacts      | ~5k rows/day   | Permanent         | events + Storage     |
+| evidence       | On-demand      | Until invalidated | artifacts + Guide    |
+| organization   | Manual updates | Current           | organization.yaml    |
+| repositories   | Manual updates | Current           | repositories.yaml    |
+| surveys        | Quarterly      | Permanent         | survey YAML files    |
+| survey_results | Quarterly      | Permanent         | survey result files  |
 
 ## Supabase Project Structure
 
@@ -518,12 +584,14 @@ supabase/
     github-webhook/         Edge Function — ingestion endpoint
   migrations/
     001_events.sql          events table + indexes
-    002_artifacts.sql       artifacts table + indexes
-    003_roster.sql          roster table (with team column)
-    004_evidence.sql        evidence table + indexes
-    005_extraction_cron.sql pg_cron job for artifact extraction
-    006_rls_policies.sql    row-level security for personal evidence
-    007_practice_views.sql  aggregate views for practice patterns
+    002_organization.sql    organization table (people → jobs → managers)
+    003_repositories.sql    repositories table (repos → capabilities)
+    004_artifacts.sql       artifacts table + indexes
+    005_evidence.sql        evidence table + indexes
+    006_surveys.sql         surveys + survey_results tables
+    007_extraction_cron.sql pg_cron job for artifact extraction
+    008_rls_policies.sql    row-level security for personal evidence
+    009_practice_views.sql  aggregate views for practice patterns
 ```
 
 ## Implementation Order
@@ -532,7 +600,8 @@ supabase/
 2. GitHub App registration (webhook URL, permissions, events)
 3. Webhook Edge Function (signature validation, Storage write, index insert)
 4. Extraction job (pg_cron, raw event → artifact mapping)
-5. Roster sync CLI with team column (`fit-landmark roster sync`)
+5. Organization sync CLI (`fit-landmark org sync`)
+5b. Repository and survey data loading
 6. RLS policies for personal evidence isolation
 7. Personal evidence flow (`fit-landmark evidence`)
 8. Practice pattern aggregate views and CLI (`fit-landmark practice`)

--- a/specs/landmark/spec.md
+++ b/specs/landmark/spec.md
@@ -76,30 +76,153 @@ framework, producing two views:
    process improvement starts. Nobody is named — the patterns describe the
    system, not the people in it.
 
-### Roster
+### Organization
 
-To connect GitHub activity to the framework, Landmark reads a **roster** — a
-config file that maps GitHub usernames to Pathway job definitions. Organizations
-export this from their HR system or maintain it by hand.
+To connect GitHub activity to the framework, Landmark reads an **organization**
+— a flat list of people that maps GitHub usernames to Pathway job definitions
+and line managers. Organizations export this from their HR system or maintain it
+by hand.
 
 ```yaml
-# landmark.yaml
-roster:
-  - github: alice
-    job: { discipline: se, level: L3, track: platform }
-  - github: bob
-    job: { discipline: se, level: L4 }
-  - github: carol
-    job: { discipline: se, level: L3, track: dx }
+# organization.yaml
+- github: alice
+  name: Alice Smith
+  job: { discipline: se, level: L3, track: platform }
+  manager: carol
+- github: bob
+  name: Bob Jones
+  job: { discipline: se, level: L4 }
+  manager: carol
+- github: carol
+  name: Carol Davis
+  job: { discipline: em, level: L4 }
+  manager: dave
+- github: dave
+  name: Dave Wilson
+  job: { discipline: em, level: L5 }
 ```
 
-The roster tells Landmark what skill profile to reflect against. Alice is an L3
-Software Engineer on the platform track — Pathway derives her skill
+Each person links to their line manager by GitHub username. This single link
+builds the full organizational hierarchy — Carol manages Alice and Bob, Dave
+manages Carol. A team is not a separate entity. A team is a manager and their
+direct reports. Carol's team is Alice and Bob. Dave's team is Carol (and
+transitively, Carol's reports).
+
+The organization tells Landmark what skill profile to reflect against. Alice is
+an L3 Software Engineer on the platform track — Pathway derives her skill
 expectations, and Landmark shows her the evidence in her own GitHub activity
 that relates to those expectations.
 
-Agents appear in the roster the same way. A bot account maps to an agent
+Agents appear in the organization the same way. A bot account maps to an agent
 profile, and the same markers apply to its PRs.
+
+Map defines the schema for organization data. Landmark owns the data itself —
+the actual people, their jobs, and their reporting lines are
+installation-specific and live in Landmark's database, synced from the YAML
+file.
+
+### Repositories
+
+Landmark tracks which GitHub repositories the organization works in.
+Repositories can optionally be tagged with the capability areas they exercise.
+This lets Guide reason about what kind of work happens where without needing
+markers on every PR.
+
+```yaml
+# repositories.yaml
+- id: org/platform-core
+  capabilities: [scale, reliability]
+- id: org/checkout-service
+  capabilities: [delivery]
+- id: org/design-system
+```
+
+The `capabilities` mapping is optional — not all repos need to be tagged.
+Untagged repos still produce artifacts and evidence; they just lack the
+capability signal that helps Guide connect repository activity to specific
+skill areas.
+
+When capability tags are present, Guide can infer context: "Alice works mostly
+in platform-core, which exercises scale and reliability capabilities." This
+complements the explicit marker-based interpretation with structural context
+about where work happens.
+
+Map defines the schema for repository data. Like organization data, the actual
+repository list is installation-specific and lives in Landmark.
+
+### Surveys
+
+Landmark accepts developer experience survey results as structured data input.
+Surveys measure how engineers perceive the productivity drivers already defined
+in Map — the same drivers that link to contributing skills and behaviours.
+
+A survey defines the instrument:
+
+```yaml
+# surveys/2026-q1.yaml
+id: 2026_q1
+name: Q1 2026 Developer Experience Survey
+period:
+  start: 2026-01-01
+  end: 2026-03-31
+scale:
+  min: 1
+  max: 5
+  labels:
+    1: Strongly Disagree
+    2: Disagree
+    3: Neutral
+    4: Agree
+    5: Strongly Agree
+```
+
+Survey results are aggregate Likert scores per team per driver. Individual
+responses stay anonymous — Landmark only sees team-level aggregation. The team
+key points to a manager in the organization, whose direct reports form the
+team:
+
+```yaml
+# survey-results/2026-q1.yaml
+survey: 2026_q1
+results:
+  - manager: carol
+    respondents: 8
+    ratings:
+      clear_direction:      { mean: 4.1, distribution: [0, 1, 1, 3, 3] }
+      say_on_priorities:    { mean: 3.2, distribution: [1, 2, 2, 2, 1] }
+      requirements_quality: { mean: 2.4, distribution: [2, 3, 2, 1, 0] }
+      ease_of_release:      { mean: 4.3, distribution: [0, 0, 1, 3, 4] }
+  - manager: dave
+    respondents: 14
+    ratings:
+      clear_direction:      { mean: 3.8, distribution: [0, 2, 4, 5, 3] }
+      requirements_quality: { mean: 3.1, distribution: [1, 3, 4, 4, 2] }
+```
+
+The `distribution` array gives the count of responses at each scale point
+(1 through 5), preserving the shape of opinion without individual attribution.
+
+This is where surveys and Landmark evidence meet. Guide can traverse from a
+weak survey score on `requirements_quality` to the contributing skills
+(`stakeholder_management`, `technical_writing`, `architecture_design`), to the
+markers for those skills, to the evidence (or lack of evidence) in the team's
+GitHub activity. The survey gives perception. Landmark gives observable
+evidence. The drivers link them through contributing skills.
+
+```
+Survey: Carol's team rated requirements_quality at 2.4/5
+  → Driver: requirements_quality
+    → Contributing skills: stakeholder_management, technical_writing
+      → Markers for those skills at the team's expected levels
+        → Landmark evidence: few PRs show design docs in Carol's team's repos
+
+Diagnosis: The team perceives requirements quality as poor.
+The evidence corroborates — design documentation is sparse.
+The contributing skills point to where investment would help.
+```
+
+Map defines the schema for surveys and survey results. The data itself lives in
+Landmark, loaded from YAML files or an HR integration.
 
 ### The GitHub App
 
@@ -298,17 +421,20 @@ collected. Two views: personal evidence and practice patterns.
 Landmark — Observable markers for engineering practice.
 
 Usage:
-  fit-landmark evidence [--skill]          Show your own evidence
-  fit-landmark practice <skill> [--team]   Show practice patterns across a team
-  fit-landmark marker <skill> [--level]    Show markers for a skill
-  fit-landmark roster                      Show the current roster
-  fit-landmark validate                    Validate marker definitions
+  fit-landmark evidence [--skill]             Show your own evidence
+  fit-landmark practice <skill> [--manager]   Show practice patterns across a team
+  fit-landmark marker <skill> [--level]       Show markers for a skill
+  fit-landmark org                            Show the organization
+  fit-landmark org sync <file>                Sync organization from YAML
+  fit-landmark survey <id>                    Show survey results
+  fit-landmark survey load <file>             Load survey results from YAML
+  fit-landmark validate                       Validate markers and data
 ```
 
 ### Personal Evidence
 
 The default command shows the engineer their own work. No arguments needed — it
-uses their GitHub username and roster entry.
+uses their GitHub username and organization entry.
 
 ```
 $ fit-landmark evidence --skill system_design
@@ -339,9 +465,9 @@ The aggregate view shows how a practice appears across a team. No individuals
 named.
 
 ```
-$ fit-landmark practice system_design --team platform
+$ fit-landmark practice system_design --manager carol
 
-  System Design practice — Platform team (last quarter)
+  System Design practice — Carol's team (last quarter)
 
   Strong evidence:
     Design documents in PRs — most feature PRs include architecture sections
@@ -352,26 +478,59 @@ $ fit-landmark practice system_design --team platform
     Consider: do engineers have time for design exploration before
     implementation begins?
 
-  Based on 47 feature PRs and 156 reviews from 12 engineers.
+  Based on 47 feature PRs and 156 reviews from 8 engineers.
 ```
+
+The `--manager` flag identifies a team by its manager — Carol's team is her
+direct reports. This is the only way to scope practice patterns. There is no
+separate team entity.
 
 This view is for engineering leadership. It points to where the system supports
 good practice and where it doesn't. It asks questions about the process, not
 about the people.
 
+When survey data is available for the same manager and period, the practice
+view includes it:
+
+```
+$ fit-landmark practice system_design --manager carol
+
+  System Design practice — Carol's team (last quarter)
+
+  Survey context (Q1 2026):
+    requirements_quality: 2.4/5 — team perceives requirements quality as poor
+    → contributing skills: stakeholder_management, technical_writing,
+      architecture_design
+
+  Strong evidence:
+    Design documents in PRs — most feature PRs include architecture sections
+    Review quality — review threads regularly discuss design rationale
+
+  Weak evidence:
+    Trade-off analysis — few PRs document multiple approaches considered
+    Consider: do engineers have time for design exploration before
+    implementation begins?
+
+  The survey and evidence align: the team perceives requirements quality as
+  poor, and design documentation in PRs is sparse. The contributing skills
+  point to where investment would help.
+```
+
 ## Summary
 
-| Attribute     | Value                                                                   |
-| ------------- | ----------------------------------------------------------------------- |
-| Package       | `@forwardimpact/landmark`                                               |
-| CLI           | `fit-landmark`                                                          |
-| Delivery      | GitHub App installed on GitHub Organizations                            |
-| Icon          | Cairn (three stacked stones)                                            |
-| Emoji         | 🪨                                                                      |
-| Hero scene    | "Checking the Cairn"                                                    |
-| Tagline       | "See your own growth. Improve the system."                              |
-| Depends on    | `@forwardimpact/guide` (interpretation), `@forwardimpact/map` (markers) |
-| Input         | GitHub webhook events + roster (people → job profiles)                  |
-| For engineers | Self-directed evidence, preparation for career conversations            |
-| For teams     | Practice patterns, process improvement signals                          |
-| For agents    | Same markers, same evidence, same interpretation                        |
+| Attribute     | Value                                                                    |
+| ------------- | ------------------------------------------------------------------------ |
+| Package       | `@forwardimpact/landmark`                                                |
+| CLI           | `fit-landmark`                                                           |
+| Delivery      | GitHub App installed on GitHub Organizations                             |
+| Icon          | Cairn (three stacked stones)                                             |
+| Emoji         | 🪨                                                                       |
+| Hero scene    | "Checking the Cairn"                                                     |
+| Tagline       | "See your own growth. Improve the system."                               |
+| Depends on    | `@forwardimpact/guide` (interpretation), `@forwardimpact/map` (schemas)  |
+| Input         | GitHub events + organization (people → jobs → managers) + survey results |
+| Schema (Map)  | Organization, repositories, surveys, survey results, markers             |
+| Data          | Installation-specific, owned by Landmark                                 |
+| For engineers | Self-directed evidence, preparation for career conversations             |
+| For teams     | Practice patterns + survey context, process improvement signals          |
+| For agents    | Same markers, same evidence, same interpretation                         |


### PR DESCRIPTION
Replace roster with organization — a flat list of people with manager links that builds the org hierarchy. Teams are derived from the org chart (a team = a manager's direct reports), not a standalone entity.

Add repositories with optional capability mapping and developer experience survey results as Likert-scale data on Map's productivity drivers. Survey perception + Landmark evidence corroborate through contributing skills.

Map owns the schema definitions; Landmark owns the data.

https://claude.ai/code/session_01VxcBQuYqSkw8G3FwogTazY