### PR TITLE
Simplify Map product page copy

### DIFF
--- a/docs/map/index.md
+++ b/docs/map/index.md
@@ -23,7 +23,7 @@ hero:
 ### What you get
 
 - Framework definitions for skills, behaviours, levels, disciplines, and tracks
-- A flat `Organization` people model (`name`, `email`, `github_username`, `manager`)
+- A simple people directory with reporting structure
 - Team views derived from reporting hierarchy (manager-rooted subtrees)
 - GitHub activity data for objective marker evidence analysis
 - GetDX snapshot imports for quarterly developer-experience results


### PR DESCRIPTION
## Summary
- Replace technical field-level detail on the Map product page with plain language
- "A flat `Organization` people model (`name`, `email`, `github_username`, `manager`)" → "A simple people directory with reporting structure"

## Test plan
- [ ] Verify the product page renders correctly on the website

https://claude.ai/code/session_016FbJhG4hCPCwTtYQYDov4H