### PR TITLE
fix(website): prevent content overflow on mobile docs pages

### DIFF
--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -327,8 +327,10 @@ strong {
 
 .page-content {
   max-width: 680px;
+  min-width: 0;
   margin: 0 auto;
   padding: calc(56px + var(--space-12)) var(--space-6) var(--space-12);
+  overflow-wrap: break-word;
 }
 
 .page-content ul,
@@ -377,6 +379,9 @@ strong {
   border-collapse: collapse;
   margin: var(--space-6) 0;
   font-size: var(--text-small-size);
+  display: block;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .page-content th {
@@ -760,6 +765,7 @@ pre code {
 
 .with-toc > .page-content {
   max-width: none;
+  min-width: 0;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
Tables with wide content (e.g. Query Functions on /docs/map/) overflowed the viewport on mobile. Add horizontal scroll to tables via display:block + overflow-x:auto, set min-width:0 on page-content to prevent grid blowout, and enable overflow-wrap:break-word for long inline text.

https://claude.ai/code/session_01QVNkt5S6BBpwBaFT3ZnKPT