### PR TITLE
docs(landmark,summit): create v3 specs from gap analysis synthesis

### DIFF
--- a/specs/080-landmark-product/spec.v3.md
+++ b/specs/080-landmark-product/spec.v3.md
@@ -1,0 +1,458 @@
+# Landmark v3
+
+Thin analysis of engineering-system signals from Map — now a decision engine,
+not just a dashboard. Surfaces recommendations, engineer voice, initiative
+impact, and cross-product insights.
+
+```
+@forwardimpact/landmark    CLI: fit-landmark
+```
+
+## Changes from v2
+
+| Change | Source | Gaps Closed |
+|--------|--------|-------------|
+| Surface Summit growth recommendations in health view | Gap analysis v2 Gap 1 (too passive) | Landmark becomes a decision engine, not just a dashboard |
+| Add engineer voice via GetDX Snapshot comments | Gap analysis v2 Gap 3 (no engineer voice) | Engineers speak through the system, not just about them |
+| Add `initiative impact` view | Gap analysis v2 Gap 5 (incomplete feedback loop) | Full action-to-outcome loop: initiative → score change |
+| Define explicit audience tiers per view | Gap analysis v2 Gap 2 (privacy model) | Right information for right audience |
+| Add `voice` command group | Gap analysis v2 Gap 3 | Snapshot comments surfaced alongside evidence and health |
+
+## Why
+
+Landmark answers one question: **what do the signals say about how engineering
+is functioning — and what should we do about it?**
+
+v2 made Landmark a comprehensive read-only view: evidence, readiness, timelines,
+initiatives, coverage. But a dashboard that shows problems without suggesting
+actions is a dashboard managers check occasionally, not a tool that changes how
+they lead.
+
+v3 makes three shifts:
+
+1. **From presentation to recommendation.** When Landmark shows a gap with a
+   poor driver score, it now says what Summit would suggest — "Dan or Carol
+   could develop incident_response." The architectural purity of "Landmark only
+   reads" was costing user impact. No LLM calls needed — Landmark imports
+   Summit's growth logic directly.
+
+2. **From talking about engineers to talking with them.** GetDX Snapshots
+   already capture the engineer's voice — open-ended comments where developers
+   describe blockers, frustrations, and context. Landmark surfaces these
+   comments alongside health and evidence views. The system no longer only talks
+   _about_ engineers; it amplifies what they're _saying_.
+
+3. **From analysis-to-action to full loop.** v2 added initiative tracking. v3
+   closes the second half: did completed initiatives actually move the scores
+   they targeted? A join between initiative completion timestamps and snapshot
+   score deltas — no LLM needed.
+
+Key simplification remains unchanged:
+
+- We continue using **GetDX** as the survey and developer experience platform.
+- Map ingests GetDX snapshot aggregates, comments, and initiative data.
+- Map also stores GitHub activity and marker definitions in capability YAML.
+- **Guide** (the LLM agent) interprets artifacts against markers and writes
+  evidence to Map.
+- Landmark reads, recommends, and presents; it does not collect surveys or call
+  LLMs.
+
+Landmark consumes Map's **activity layer** (`activity/queries/`) for all
+operational data. It also imports from Map's **pure layer** (`src/`) for
+framework schema and marker definitions.
+
+## Audience Model
+
+v3 defines explicit audiences per view. The privacy model matches the audience,
+not a blanket aggregation rule.
+
+| Audience | Views | Privacy model |
+|----------|-------|---------------|
+| **Engineer** (own data) | `evidence`, `readiness`, `timeline`, `coverage`, `voice --email` (own) | Full individual detail — it's your data |
+| **Manager** (1:1 tool) | `health`, `growth-recs`, `readiness`, `timeline`, `practiced`, `voice --manager` | Individual specificity for direct reports — managers already see Pathway profiles |
+| **Director** (planning tool) | `snapshot`, `coverage`, `practiced`, `initiative`, `voice --manager` (aggregated) | Aggregated team views — named growth recommendations removed at this scope |
+
+The manager already knows who their three L3s are. Aggregation at the manager
+level doesn't protect privacy — it obscures actionability. For directors viewing
+multiple teams, aggregation provides meaningful anonymity.
+
+## Scope
+
+### In scope
+
+Everything from v1 and v2, plus:
+
+- **v3:** Import Summit's growth alignment logic to surface recommendations
+  inline in health views.
+- **v3:** Read GetDX Snapshot comments from Map for engineer voice views.
+- **v3:** Compute initiative impact by joining initiative completion dates to
+  snapshot score deltas.
+- **v3:** Apply audience-appropriate privacy to all views.
+
+### Out of scope
+
+- Survey distribution or response collection.
+- Owning ingestion pipelines.
+- Owning roster data structures (unified person model lives in Map).
+- Interpreting artifacts against markers (Guide's responsibility).
+- Making LLM calls of any kind.
+- Access control enforcement (deferred — Map owns schema-level access policies
+  in a later phase; Landmark inherits whatever Map provides).
+- Self-assessment capture (requires a write path — belongs in Basecamp or
+  Pathway).
+- Abstracting away the GetDX dependency (may be addressed in a future version).
+
+## Data Contracts
+
+Landmark consumes everything from v1 and v2, plus:
+
+### v3 additions
+
+- `activity.getdx_snapshot_comments` (new table, from GetDX `snapshots.comments.list` API)
+  - `snapshot_id` (FK to `getdx_snapshots`)
+  - `email` (respondent)
+  - `text` (open-ended comment)
+  - `timestamp`
+  - `team_id` (FK to `getdx_teams`, derived from respondent's team membership)
+- Summit's growth alignment logic (imported as a library dependency, not a
+  service call — Summit's team gap analysis and growth candidate matching run
+  locally)
+- Driver-to-snapshot-score delta computation (join `getdx_initiatives` completion
+  dates against `getdx_snapshot_team_scores` across snapshots)
+
+### Existing contracts (v1 + v2, unchanged)
+
+- `activity.organization_people` (unified person model)
+- `activity.getdx_teams`, `activity.getdx_snapshots`,
+  `activity.getdx_snapshot_team_scores`
+- `activity.github_events`, `activity.github_artifacts`
+- `activity.evidence` (written by Guide)
+- `activity.getdx_initiatives` (v2)
+- Marker definitions from Map capability YAML
+- Driver definitions from Map (`drivers.yaml`)
+- libskill derivation logic (v2)
+
+Team semantics unchanged: a team is defined by a manager email.
+
+### GetDX Snapshot Comments as Engineer Voice
+
+GetDX Snapshots collect two categories of developer input that serve as the
+engineer's voice:
+
+1. **Perceptual measures** — how developers feel about tools, workflows, and
+   processes. These capture pain, friction, and toil.
+2. **Open-ended comments** — free-text responses where developers describe
+   blockers, context, and frustrations in their own words.
+
+The `snapshots.comments.list` API returns comments with email, text, and
+timestamp. Map ingests these into `activity.getdx_snapshot_comments`. Landmark
+surfaces them alongside health and evidence views.
+
+This is the "voice of the engineers" without building a custom write path.
+GetDX already asks developers what's blocking them, what they'd most like
+improved, and how they experience their engineering environment. Landmark's job
+is to connect those voices to the capability and evidence data that explains
+_why_ they're saying it.
+
+Comments are individual-level data (attributed by email). The audience model
+governs visibility:
+- Engineers see their own comments in context.
+- Managers see comments from their direct reports.
+- Directors see aggregated comment themes, not individual attribution.
+
+### Markers
+
+Unchanged from v1. Markers are concrete, observable indicators of a skill at a
+proficiency level, living in Map's capability YAML files.
+
+### Evidence Pipeline
+
+Unchanged from v1.
+
+```
+GitHub Events → Map (storage) → extraction → github_artifacts
+                                                │
+                                         Guide (interprets)
+                                                │
+                                         activity.evidence
+                                                │
+                                         Landmark (presents + recommends)
+```
+
+## Product Behavior
+
+### Organization views
+
+Unchanged from v1.
+
+### Snapshot views
+
+Unchanged from v1.
+
+### Marker evidence views
+
+Unchanged from v1.
+
+### Trend views
+
+Unchanged from v1.
+
+### v2: Promotion readiness view
+
+Unchanged from v2.
+
+### v2: Individual growth timeline
+
+Unchanged from v2.
+
+### v2: Initiative tracking
+
+Unchanged from v2.
+
+### v2: Evidence coverage metrics
+
+Unchanged from v2.
+
+### v2: Practiced capability view
+
+Unchanged from v2.
+
+### v3: Growth recommendations in health view
+
+The health view joins objective marker evidence with GetDX snapshot outcomes.
+v3 extends it with actionable recommendations imported from Summit's growth
+alignment logic.
+
+When health shows a gap aligned with a poorly-scoring GetDX driver, Landmark
+now surfaces who could develop that skill and what the team impact would be.
+
+```
+$ fit-landmark health --manager alice@example.com
+
+  Platform team — health view
+
+  Driver: reliability (35th percentile, vs_org: -12)
+    Contributing skills: incident_response, observability
+    Evidence: 0 artifacts for incident_response, 2 for observability
+    GetDX comments: "We had two incidents last month with no runbook"
+                    "On-call is painful — nobody knows the alerting setup"
+
+    ⮕ Recommendation: Dan (L2) or Carol (L3) could develop incident_response.
+      Growing from foundational to working closes the team's critical gap.
+      (Summit growth alignment: high impact)
+
+  Driver: cognitive_load (28th percentile, vs_org: -8)
+    Contributing skills: technical_debt_management
+    Evidence: derived depth 2, evidenced depth 0 — skill exists on paper,
+             not practiced
+    GetDX comments: "Deploy pipeline takes 45 minutes, nobody wants to touch it"
+
+    ⮕ Recommendation: technical_debt_management is derived but not practiced.
+      Bob (L4) holds working level — could mentor Alice or Carol.
+      (Summit growth alignment: high impact, outcome-weighted)
+```
+
+Implementation: Landmark imports Summit's growth computation as a library
+function. Given a team roster and Map data, it returns growth recommendations
+ranked by impact. Landmark calls this function and renders recommendations
+inline. No service call, no network — same process, same data.
+
+This crosses the v1/v2 architectural boundary where "Landmark only presents."
+The boundary was costing user impact. Recommendations are deterministic (no
+LLM), computed from the same data Landmark already reads, and rendered in
+context where the manager needs them. The alternative — telling the manager to
+switch to Summit — loses context and breaks flow.
+
+### v3: Engineer voice
+
+Surface GetDX Snapshot comments alongside evidence and health views to give
+engineers a voice in the system.
+
+**Voice command group:**
+
+```
+$ fit-landmark voice --manager alice@example.com
+
+  Platform team — engineer voice (Snapshot 2024-Q3)
+
+  Most discussed themes:
+    Deploy pipeline        4 comments   "45 min deploys", "afraid to deploy"
+    On-call experience     3 comments   "no runbooks", "alerting is broken"
+    Code review turnaround 2 comments   "PRs sit for days"
+
+  Aligned with health signals:
+    reliability driver (35th pctl) ← on-call comments confirm capability gap
+    cognitive_load driver (28th pctl) ← deploy pipeline comments confirm friction
+```
+
+```
+$ fit-landmark voice --email dan@example.com
+
+  Dan's snapshot comments (last 4 snapshots):
+
+  2024-Q3: "On-call last week was rough — no runbook for the payment service"
+  2024-Q2: "Would love to learn more about observability tooling"
+  2024-Q1: "Build times are getting worse, hard to stay in flow"
+  2023-Q4: (no comment)
+
+  Context from evidence:
+    Dan has 0 evidence for incident_response, 1 for observability (foundational)
+    His comments align with the team's reliability gap.
+```
+
+The voice view connects what engineers _say_ (GetDX comments) with what the
+system _observes_ (evidence, driver scores). This makes the system
+bidirectional: it doesn't just analyze engineers — it amplifies their
+perspective.
+
+**Integration with health view:** When `health` shows a poorly-scoring driver,
+it now includes representative comments from the team's snapshot responses (as
+shown in the health example above). Comments are matched to drivers via the
+snapshot structure — each comment is associated with the driver/factor context
+in which it was submitted.
+
+**"What is blocking you?"** GetDX Snapshots ask developers to rank which items
+they'd most like to see improved. Combined with open-ended comments, this
+provides a structured answer to "what is blocking you?" that Landmark can
+present alongside structural capability data. The snapshot's perceptual measures
+capture how developers _feel_ about their environment; the comments capture
+_why_.
+
+### v3: Initiative impact
+
+Close the full feedback loop: did completed initiatives actually move the
+scores they targeted?
+
+```
+$ fit-landmark initiative impact --manager alice@example.com
+
+  Completed initiatives — outcome correlation
+
+  "Reduce deploy pipeline time" (completed 2024-Q2)
+    Target driver: cognitive_load
+    Score before: 28th percentile (2024-Q1 snapshot)
+    Score after:  45th percentile (2024-Q3 snapshot)
+    Change: +17 percentile points
+    Engineer voice: "Deploys are much faster now" (Q3 comment)
+
+  "Establish incident response runbooks" (completed 2024-Q3)
+    Target driver: reliability
+    Score before: 35th percentile (2024-Q2 snapshot)
+    Score after:  (awaiting next snapshot)
+    Change: pending
+
+  "Improve code review SLAs" (in progress, 60% complete)
+    Target driver: code_review
+    Score trend: 52nd → 55th → 58th (improving during initiative)
+```
+
+Implementation: join `getdx_initiatives` (with completion dates and linked
+scorecard/driver) against `getdx_snapshot_team_scores` across the snapshot
+before and after completion. The delta is a simple percentile difference. No
+causal claim — just correlation. "The initiative completed and the score
+moved" is informative without being misleading.
+
+This closes the full Deming cycle: Analysis → Decision → Action → Outcome →
+Analysis. v2 closed the first half (analysis → action via initiative tracking).
+v3 closes the second half (action → outcome via score delta).
+
+## CLI
+
+```
+Landmark — analysis and recommendations on top of Map data.
+
+Usage:
+  fit-landmark org show
+  fit-landmark org team --manager <email>
+  fit-landmark snapshot list
+  fit-landmark snapshot show --snapshot <id> [--manager <email>]
+  fit-landmark snapshot trend --item <item_id> [--manager <email>]
+  fit-landmark snapshot compare --snapshot <id> [--manager <email>]
+  fit-landmark evidence [--skill <skill_id>] [--email <email>]
+  fit-landmark practice [--skill <skill_id>] [--manager <email>]
+  fit-landmark marker <skill> [--level <level>]
+  fit-landmark health [--manager <email>]
+
+v2 commands:
+  fit-landmark readiness --email <email> [--target <level>]
+  fit-landmark timeline --email <email> [--skill <skill_id>]
+  fit-landmark initiative list [--manager <email>]
+  fit-landmark initiative show --id <id>
+  fit-landmark coverage --email <email>
+  fit-landmark practiced --manager <email>
+
+v3 commands:
+  fit-landmark voice --manager <email>
+  fit-landmark voice --email <email>
+  fit-landmark initiative impact [--manager <email>]
+```
+
+v3 changes to existing commands:
+
+- `health` now includes inline growth recommendations from Summit's logic and
+  representative GetDX Snapshot comments per driver.
+
+## Positioning
+
+```
+                    Pure layer           Activity layer
+                  +------------------+-------------------------+
+GetDX + GitHub --> |   Map (src/)       |   Map (activity/)          |
+                  |   schema, markers  |   ingest, store, query     |
+                  +---------+--------+----------+------------+
+                            |                  |
+                         Guide              Landmark ← Summit (growth logic)
+                      (interprets)    (presents + recommends)
+```
+
+Landmark is no longer purely a presentation layer. v3 imports Summit's growth
+alignment computation to surface recommendations inline. This is a deliberate
+architectural choice: the user impact of contextual recommendations outweighs
+the elegance of strict separation.
+
+Map owns data. Guide owns interpretation. Landmark owns presentation and
+contextual recommendation. Summit owns team-level planning and what-if
+scenarios.
+
+The boundary between Landmark and Summit remains clear:
+- **Landmark** answers "what do the signals say and what could you do about it?"
+- **Summit** answers "what can this team do and how should we change it?"
+
+Landmark borrows Summit's growth logic to avoid forcing the manager to context-
+switch between tools. Summit retains its full planning surface (what-if, compare,
+trajectory).
+
+## Summary
+
+| Attribute     | Value                                         |
+| ------------- | --------------------------------------------- |
+| Package       | `@forwardimpact/landmark`                     |
+| CLI           | `fit-landmark`                                |
+| Role          | Analysis and recommendation layer on Map      |
+| Survey source | GetDX (external platform)                     |
+| Data store    | Map (single source of truth)                  |
+| Org model     | Unified person model (email PK, job profiles) |
+| Team model    | Derived from manager email subtree            |
+
+### v2 additions (unchanged)
+
+| Attribute         | Value                                                    |
+| ----------------- | -------------------------------------------------------- |
+| Readiness view    | Marker checklist against next-level requirements         |
+| Timeline view     | Quarterly evidence aggregation per skill per person      |
+| Initiative views  | GetDX Initiatives via Map, linked to health view         |
+| Coverage metrics  | Interpreted/total artifact ratio per person              |
+| Practiced view    | Evidenced depth alongside derived depth per team skill   |
+| New dependency    | libskill derivation (for readiness marker resolution)    |
+| New data contract | `activity.getdx_initiatives` (from GetDX Initiatives API)|
+
+### v3 additions
+
+| Attribute              | Value                                                      |
+| ---------------------- | ---------------------------------------------------------- |
+| Growth recommendations | Summit growth logic imported, surfaced inline in health    |
+| Engineer voice         | GetDX Snapshot comments surfaced via `voice` command group |
+| Initiative impact      | Score delta before/after initiative completion              |
+| Audience model         | Explicit per-view privacy: engineer, manager, director     |
+| New dependency         | Summit growth alignment logic (library import)             |
+| New data contract      | `activity.getdx_snapshot_comments` (from GetDX comments API)|

--- a/specs/090-summit-product/spec.v3.md
+++ b/specs/090-summit-product/spec.v3.md
@@ -1,0 +1,472 @@
+# Summit v3
+
+Help teams see their collective capability. Help leaders build teams that can
+deliver. Now with team trajectory, allocation-aware project teams, and explicit
+audience model.
+
+```
+@forwardimpact/summit    CLI: fit-summit
+```
+
+## Changes from v2
+
+| Change | Source | Gaps Closed |
+|--------|--------|-------------|
+| Add `trajectory` command for team capability over time | Gap analysis v2 Gap 6 (no team health trajectory) | Team capability evolution visible quarter over quarter |
+| Add allocation percentages to project teams | Gap analysis v2 Gap 7 (cross-functional teams undertreated) | Split-time engineers modeled accurately across teams |
+| Define explicit audience tiers per view | Gap analysis v2 Gap 2 (privacy model) | Right information for right audience |
+| Export growth logic as importable library function | Gap analysis v2 Gap 1 (Landmark too passive) | Landmark can surface growth recommendations inline |
+
+## Why
+
+| Product      | Question it answers                                     |
+| ------------ | ------------------------------------------------------- |
+| **Map**      | What does the terrain look like?                        |
+| **Pathway**  | Where am I going?                                       |
+| **Basecamp** | What do I need day-to-day?                              |
+| **Landmark** | What do the signals say — and what should I do about it?|
+| **Summit**   | _Can this team reach the peak?_                         |
+
+Map defines skills. Pathway charts individual routes. Basecamp handles daily
+ops. Landmark presents signals and recommends actions. But none of them answer
+the question engineering leaders ask most often: "Does this team have the
+capability to deliver what we need — and is it getting stronger or weaker?"
+
+v2 added practiced capability (derived vs evidenced), outcome-weighted growth,
+and project-based teams. These strengthened Summit's point-in-time analysis. But
+leaders also need trajectory — is this team improving quarter over quarter, or
+slowly eroding?
+
+v3 makes two shifts:
+
+1. **From snapshot to trajectory.** Summit can now show how team coverage changed
+   over time as people joined, left, grew, or were promoted. This turns Summit
+   from a planning tool into a planning + tracking tool, which is where real
+   stickiness lives.
+
+2. **From binary team membership to allocation-aware.** Real engineers split time
+   across teams. "Alice is 60% Platform, 40% Migration" changes the capability
+   calculus. v3 models allocation percentages so coverage analysis reflects how
+   engineers actually work.
+
+## Design Principles
+
+**Teams are systems, not collections.** Unchanged. Summit models the team as a
+system with emergent properties from composition.
+
+**Plan forward, don't measure backward.** Extended. Summit still emphasizes
+prospective planning, but `trajectory` adds a retrospective dimension: "where
+has this team been?" informs "where is it going?" Past trajectory is a planning
+input, not a performance metric.
+
+**No required external dependencies.** Unchanged. Core Summit runs locally with
+Map data and a roster. Evidence, GetDX data, and trajectory are optional
+enhancements.
+
+**Capability, not performance.** Unchanged. Summit describes what a team _can_
+do, not how well it's doing it.
+
+**Privacy through aggregation — with audience awareness.** Refined. v3 defines
+explicit audiences:
+
+| Audience | Views | Privacy model |
+|----------|-------|---------------|
+| **Engineer** | `growth` (own team) | Sees team gaps and which growth directions help — no peer names at other levels |
+| **Manager** (1:1 tool) | `coverage`, `risks`, `growth`, `trajectory`, `what-if` | Individual specificity for direct reports — managers already see Pathway profiles |
+| **Director** (planning tool) | `coverage`, `risks`, `compare`, `trajectory`, `what-if` | Aggregated team views — named growth recommendations removed at this scope |
+
+The manager already knows their team. Named growth recommendations ("Dan or
+Carol could develop incident_response") are appropriate for 1:1 conversations.
+For directors viewing across teams, Summit omits individual names and shows only
+structural gaps and coverage counts.
+
+## What
+
+Summit is a CLI tool that reads a team roster and produces capability analysis.
+Everything from v1 and v2 is retained.
+
+### Three Views (v1)
+
+1. **Capability coverage** — heatmap of collective proficiency.
+2. **Structural risks** — SPOFs, critical gaps, concentration risks.
+3. **What-if scenarios** — simulate roster changes before making them.
+
+### v1: Growth Alignment
+
+Connect team needs to individual growth opportunities.
+
+### v2 Additions
+
+4. **Practiced capability** — `--evidenced` flag shows derived vs evidenced
+   depth.
+5. **Outcome-weighted growth** — `--outcomes` flag weights recommendations by
+   GetDX driver scores.
+6. **Project-based teams** — team definitions beyond manager hierarchy.
+
+### v3 Additions
+
+7. **Team trajectory** — how team capability coverage changed over time.
+8. **Allocation-aware project teams** — model split-time engineers.
+9. **Growth logic export** — Summit's growth computation available as an
+   importable library function for Landmark.
+
+### Team Roster
+
+Summit reads team composition from one of three sources (unchanged from v2):
+
+1. **Map's unified person model** — `organization_people` table.
+2. **Local YAML file** — offline planning and hypothetical scenarios.
+3. **Project-based YAML** — cross-functional teams referencing org model.
+
+### v3: Allocation Percentages in Project Teams
+
+```yaml
+# summit.yaml — v3 project teams with allocation
+projects:
+  migration-q2:
+    - email: alice@example.com
+      allocation: 0.6                  # 60% on this project
+    - email: frank@example.com
+      allocation: 1.0                  # full-time
+    - email: grace@example.com
+      allocation: 0.4                  # 40% on this project
+    - name: Ivan
+      job: { discipline: se, level: L4, track: platform }
+      allocation: 1.0                  # hypothetical full-time member
+```
+
+When `allocation` is present, Summit weights that person's contribution to
+coverage accordingly. An engineer at 40% allocation contributes less effective
+depth than one at 100%. The coverage view reflects this:
+
+```
+$ fit-summit coverage --project migration-q2
+
+  Migration Q2 — 4 members (3.0 FTE)
+
+  Capability: Scale
+    system_design             ██████████  effective depth: 2.6 at working+
+    api_design                ████████░░  effective depth: 2.0 at working+
+
+  Capability: Reliability
+    incident_response         ██░░░░░░░░  effective depth: 0.4 at working+
+    observability             ████░░░░░░  effective depth: 1.0 at working+
+```
+
+Effective depth is the sum of allocations for engineers at working level or
+above. When Grace is 40% allocated and holds working-level incident_response,
+the project gets 0.4 effective depth — meaning it can't rely on her full-time
+for that capability.
+
+**Allocation defaults to 1.0** when omitted. Existing summit.yaml files work
+unchanged. Allocation applies only to project teams — reporting teams always
+represent full membership.
+
+**Risks with allocation:** Single point of failure analysis considers
+allocation. A skill held by one person at 0.4 allocation is a higher risk than
+one held by a person at 1.0. The risk view surfaces this:
+
+```
+$ fit-summit risks --project migration-q2
+
+  Migration Q2 — structural risks
+
+  Single points of failure:
+    incident_response — only Grace (L3, 40% allocated)
+    Effective availability: 0.4 FTE. High risk at partial allocation.
+```
+
+### Capability Coverage
+
+Unchanged from v1/v2 for reporting teams. For project teams with allocation,
+coverage shows effective depth as described above.
+
+### v2: Practiced Capability
+
+Unchanged from v2.
+
+### Structural Risks
+
+Unchanged from v1/v2 for reporting teams. For project teams, risks incorporate
+allocation as described above.
+
+### What-If Scenarios
+
+Unchanged from v1. What-if works with project teams and respects allocation:
+
+```
+$ fit-summit what-if --project migration-q2 --add "{ discipline: se, level: L3, track: platform }" --allocation 0.5
+
+  Adding an L3 Platform SE (50% allocated) to Migration Q2:
+
+  Capability changes:
+    + incident_response         effective depth: 0.4 → 0.9
+    + observability             effective depth: 1.0 → 1.5
+
+  Risk changes:
+    - incident_response         no longer single point of failure (with redundancy)
+```
+
+### Growth Alignment
+
+Unchanged from v1.
+
+### v2: Outcome-Weighted Growth
+
+Unchanged from v2.
+
+### v3: Team Trajectory
+
+Show how team capability coverage evolved over time as the roster changed.
+
+```
+$ fit-summit trajectory platform
+
+  Platform team — capability trajectory
+
+  Roster changes:
+    2024-Q1: 4 engineers (Dan joined)
+    2024-Q2: 5 engineers (Eve joined)
+    2024-Q3: 5 engineers (Carol promoted L3 → L4)
+    2024-Q4: 4 engineers (Bob departed)
+
+  Coverage evolution:
+                          Q1    Q2    Q3    Q4    Trend
+    task_decomposition     2     3     3     3     ─
+    incident_response      0     0     0     0     ⚠ persistent gap
+    system_design          2     4     4     3     ↓ declining (departure)
+    capacity_planning      0     1     1     0     ↓ lost (departure)
+    observability          1     1     1     1     ─
+
+  Summary:
+    Coverage improved Q1→Q2 (Eve's hire filled scale skills).
+    Carol's promotion strengthened delivery but didn't address reliability.
+    Bob's departure in Q4 created new critical gaps in capacity_planning
+    and reduced system_design redundancy.
+
+    Persistent gap: incident_response has been uncovered for 4 quarters.
+    Consider prioritizing this in hiring or growth planning.
+```
+
+**Data source:** Trajectory requires historical roster snapshots. Summit
+computes trajectory from one of two sources:
+
+1. **Map's activity layer** — if Map stores historical `organization_people`
+   snapshots (roster at each quarter boundary), Summit reads them directly.
+2. **Git history of summit.yaml** — if using a local roster file tracked in
+   version control, Summit can read prior versions to reconstruct roster
+   changes.
+
+When neither historical source is available, Summit shows current-state only
+with a note: "Historical roster data not available. Trajectory requires
+quarterly roster snapshots in Map or version-controlled summit.yaml."
+
+**Trajectory with evidence:**
+
+```
+$ fit-summit trajectory platform --evidenced
+
+  Coverage evolution (derived / evidenced):
+                          Q1        Q2        Q3        Q4
+    task_decomposition     2/1       3/2       3/3       3/3    ↑ evidence catching up
+    incident_response      0/0       0/0       0/0       0/0    ⚠ persistent gap
+    system_design          2/2       4/3       4/4       3/3    ─ practiced
+    technical_debt_mgmt    2/0       2/0       2/1       2/1    ~ slowly improving
+```
+
+This answers "is this team getting stronger or weaker?" — the question the gap
+analysis identified as unanswerable in v2.
+
+### v3: Growth Logic Export
+
+Summit's growth alignment computation is available as an importable library
+function for use by Landmark (and potentially other consumers).
+
+```js
+// Summit exports this function from its public API
+import { computeGrowthAlignment } from '@forwardimpact/summit'
+
+const recommendations = computeGrowthAlignment({
+  team,           // array of { email, job }
+  mapData,        // Map data (skills, capabilities)
+  evidence,       // optional: evidence aggregates
+  driverScores,   // optional: GetDX driver scores
+})
+// Returns: [{ skill, impact, candidates: [{ name, currentLevel, targetLevel }], driverContext? }]
+```
+
+This function encapsulates Summit's growth logic: identify team gaps, rank by
+impact (critical gap > SPOF reduction > coverage strengthening), match candidates
+based on proximity to the target level, and optionally weight by driver scores.
+
+Landmark imports this function and renders its output inline in the health view.
+No service boundary crossed — same process, same data.
+
+## Positioning
+
+```
+map → libskill → pathway
+              ↓
+           summit ──→ (growth logic) ──→ landmark
+```
+
+- **Map** defines skills, levels, behaviours — the data model
+- **libskill** derives individual job profiles and skill matrices
+- **Summit** aggregates individual matrices into team-level analysis
+- **Summit → Landmark** exports growth logic for contextual recommendations
+- **Pathway** presents individual career progression
+- **Summit** presents collective capability, planning, and trajectory
+
+v3 creates a deliberate dependency from Landmark to Summit's growth logic. This
+is a one-way export: Summit provides a pure function, Landmark calls it.
+Summit does not depend on Landmark.
+
+### Comparison with Landmark
+
+| Dimension        | Landmark                              | Summit                                    |
+| ---------------- | ------------------------------------- | ----------------------------------------- |
+| **Orientation**  | Retrospective + recommendation        | Prospective + trajectory                  |
+| **Input**        | Map activity layer                    | Map unified person model or YAML          |
+| **Dependencies** | Map (activity + pure), Summit (growth)| Map + libskill (+ optional activity data) |
+| **Runs where**   | Local CLI                             | Local CLI, instant                        |
+| **Focus**        | Individual evidence + team signals    | Team composition + planning               |
+| **Output**       | Signals, recommendations, voice       | Coverage, risks, scenarios, trajectory    |
+| **Determinism**  | Deterministic (reads evidence)        | Fully deterministic                       |
+| **Cost**         | Zero runtime cost                     | Zero runtime cost                         |
+| **Privacy**      | Audience-aware (engineer/manager/dir) | Audience-aware (engineer/manager/dir)     |
+| **Question**     | "What do signals say & what to do?"   | "Can this team deliver & is it improving?"|
+
+v3 creates a deliberate overlap: Summit's `trajectory` shows team evolution
+over time while Landmark's `timeline` shows individual evidence evolution.
+Both use historical data but answer different questions — Landmark tracks what
+a person demonstrated, Summit tracks what a team could do.
+
+## Design
+
+### Name, Icon, Emoji, Hero Scene, Visual Language, Taglines
+
+All unchanged from v1.
+
+## CLI
+
+```
+Summit — Team capability planning from skill data.
+
+Usage:
+  fit-summit coverage <team>                    Show capability coverage
+  fit-summit risks <team>                       Show structural risks
+  fit-summit what-if <team> [options]           Simulate roster changes
+  fit-summit growth <team>                      Show growth alignment
+  fit-summit compare <team1> <team2>            Compare two teams
+  fit-summit roster                             Show current roster
+  fit-summit validate                           Validate roster file
+
+Options:
+  --roster <path>         Path to summit.yaml (default: derive from Map org)
+  --data <path>           Path to Map data (default: from @forwardimpact/map)
+  --format <type>         Output format: text, json, markdown (default: text)
+
+v2 options:
+  --evidenced             Include practiced capability from Map evidence data
+  --outcomes              Weight growth recommendations by GetDX driver scores
+  --project <name>        Use a project team from summit.yaml projects section
+
+v3 commands:
+  fit-summit trajectory <team>                  Show team capability over time
+
+v3 options:
+  --allocation <pct>      Allocation percentage for --add in what-if (default: 1.0)
+  --quarters <n>          Number of quarters to show in trajectory (default: 4)
+```
+
+### What-If Options
+
+```
+  fit-summit what-if <team> --add "<job>"             Add a hypothetical person
+  fit-summit what-if <team> --remove <name>           Remove someone
+  fit-summit what-if <team> --move <name> --to <team> Move between teams
+  fit-summit what-if <team> --promote <name>          Simulate level promotion
+  fit-summit what-if <team> --focus <capability>      Filter to capability
+
+v3:
+  fit-summit what-if <team> --add "<job>" --allocation <pct>   Add with allocation
+```
+
+### JSON Output
+
+All views support `--format json`. v3 additions to JSON output:
+
+```
+$ fit-summit trajectory platform --format json
+{
+  "team": "platform",
+  "quarters": [
+    {
+      "quarter": "2024-Q1",
+      "members": 4,
+      "rosterChanges": [{ "type": "join", "name": "Dan" }],
+      "coverage": {
+        "task_decomposition": { "depth": 2 },
+        "incident_response": { "depth": 0 },
+        "system_design": { "depth": 2 }
+      }
+    }
+  ],
+  "persistentGaps": ["incident_response"],
+  "trends": {
+    "system_design": "declining",
+    "incident_response": "persistent_gap"
+  }
+}
+```
+
+```
+$ fit-summit coverage --project migration-q2 --format json
+{
+  "team": "migration-q2",
+  "type": "project",
+  "members": 4,
+  "effectiveFte": 3.0,
+  "coverage": {
+    "system_design": { "derivedDepth": 3, "effectiveDepth": 2.6 },
+    "incident_response": { "derivedDepth": 1, "effectiveDepth": 0.4 }
+  }
+}
+```
+
+## Summary
+
+| Attribute     | Value                                                    |
+| ------------- | -------------------------------------------------------- |
+| Package       | `@forwardimpact/summit`                                  |
+| CLI           | `fit-summit`                                             |
+| Delivery      | Local CLI tool, npm package                              |
+| Icon          | Mountain peak with flag                                  |
+| Emoji         | ⛰️                                                       |
+| Hero scene    | "Planning the Ascent"                                    |
+| Tagline       | "See your team's capability. Plan the ascent."           |
+| Depends on    | `@forwardimpact/map`, `@forwardimpact/libskill`          |
+| Input         | Map unified person model or local YAML + Map data        |
+| For leaders   | Capability coverage, structural risks, staffing planning |
+| For teams     | Growth alignment, what-if scenarios, trajectory          |
+| For engineers | Understanding which growth directions help the team      |
+| Runtime cost  | Zero — local computation, fully deterministic            |
+
+### v2 additions (unchanged)
+
+| Attribute              | Value                                                     |
+| ---------------------- | --------------------------------------------------------- |
+| Practiced capability   | `--evidenced` flag on `coverage` and `risks`              |
+| Outcome-weighted growth| `--outcomes` flag on `growth`                             |
+| Project teams          | `projects` section in summit.yaml, `--project` CLI flag   |
+| Optional dependency    | Map activity layer (evidence, GetDX scores) — opt-in only |
+
+### v3 additions
+
+| Attribute              | Value                                                        |
+| ---------------------- | ------------------------------------------------------------ |
+| Team trajectory        | `trajectory` command showing coverage evolution over quarters|
+| Allocation-aware teams | `allocation` field in project team YAML, effective depth     |
+| Growth logic export    | `computeGrowthAlignment` function exported for Landmark      |
+| Audience model         | Explicit per-view privacy: engineer, manager, director       |
+| Historical data        | Reads quarterly roster snapshots from Map or git history     |


### PR DESCRIPTION
Address all findings from gap-analysis.v2.md:

Landmark v3:
- Gap 1 (too passive): Health view now surfaces Summit growth recommendations
  inline — Landmark becomes a decision engine, not just a dashboard
- Gap 2 (privacy model): Explicit audience tiers (engineer/manager/director)
  with appropriate privacy per view
- Gap 3 (no engineer voice): GetDX Snapshot comments surfaced via new `voice`
  command group — the system now amplifies what engineers say rather than only
  talking about them
- Gap 5 (incomplete feedback loop): New `initiative impact` view shows whether
  completed initiatives actually moved the targeted driver scores

Summit v3:
- Gap 6 (no team trajectory): New `trajectory` command shows team coverage
  evolution over quarters as people join, leave, grow, or are promoted
- Gap 7 (cross-functional teams undertreated): Allocation percentages model
  split-time engineers accurately across project teams
- Gap 2 (privacy model): Matching audience tiers as Landmark
- Growth logic exported as importable function for Landmark consumption

Gap 4 (GetDX dependency) acknowledged but intentionally deferred — staying
with GetDX without abstracting it per product decision.

https://claude.ai/code/session_01KNkpFBexu3HP183L3VF8BJ