### PR TITLE
Review and rewrite data resolution specs, add lib skills audit

### DIFF
--- a/specs/120-data-resolution/plan.md
+++ b/specs/120-data-resolution/plan.md
@@ -33,15 +33,24 @@ findData(baseName, homeDir) {
   if (found) return found;
 
   const homePath = path.join(homeDir, ".fit", baseName);
-  if (fs.existsSync(homePath)) return homePath;
+  if (existsSync(homePath)) return homePath;
 
   throw new Error(
-    `No ${baseName} directory found. Use --data=<path> to specify location.`,
+    `No ${baseName} directory found from ${cwd} or ${homePath}.`,
   );
 }
 ```
 
-Uses `findUpward` from CWD (walks up to 3 parents), then checks `~/.fit/{baseName}/`.
+Uses `findUpward` from CWD (walks up to 3 parents), then checks
+`~/.fit/{baseName}/`.
+
+**Sync fs note:** This method uses `existsSync` for the HOME check, consistent
+with `findUpward` which also uses `existsSync` rather than the injected async
+`this.#fs`. Both methods are synchronous path-resolution operations where async
+I/O adds complexity without benefit.
+
+**Error message:** The error describes the problem without referencing CLI flags.
+Each caller adds its own `--data` guidance when catching the error.
 
 ### 2. Add tests in `libraries/libutil/test/finder.test.js`
 
@@ -59,119 +68,134 @@ Uses real temp directories (matching the existing test pattern with `tempDir`).
 
 - **Delete** local `resolveDataPath` function (lines 340–381)
 - **Remove** `PATHWAY_DATA` env var support
-- **Import** `Finder` from `@forwardimpact/libutil` and `homedir` from `os`
+- **Import** `Finder` from `@forwardimpact/libutil`, `homedir` from `os`,
+  `createLogger` from `@forwardimpact/libtelemetry`
 - **Change** call site (~line 407):
 
 ```js
 import { Finder } from "@forwardimpact/libutil";
 import { homedir } from "os";
+import { createLogger } from "@forwardimpact/libtelemetry";
+import fs from "fs/promises";
 
 // In main():
 let dataDir;
 if (options.data) {
   dataDir = resolve(options.data);
 } else {
+  const logger = createLogger("pathway");
   const finder = new Finder(fs, logger, process);
-  dataDir = join(finder.findData("data", homedir()), "pathway");
+  try {
+    dataDir = join(finder.findData("data", homedir()), "pathway");
+  } catch {
+    throw new Error(
+      "No data directory found. Use --data=<path> to specify location.",
+    );
+  }
 }
 ```
 
-Note: pathway already has a logger or can use a minimal one. If no logger
-exists in the CLI entry point, create one or use `createMockLogger` — check
-what's available. Alternatively, if the CLI doesn't already have a logger,
-the simplest path is to create a `createLogger("cli")` or use the existing
-imports.
+**Logger:** fit-pathway currently has no logger. Create one via
+`createLogger("pathway")` from libtelemetry. The Finder constructor requires
+it. The logger instance can be reused if pathway adds logging elsewhere later.
 
 ### 4. Modify `products/map/bin/fit-map.js`
 
 - **Delete** `dirExists` helper (lines 54–61) and `findDataDir` (lines 66–91)
-- **Import** `Finder` from `@forwardimpact/libutil` and `homedir` from `os`
+- **Import** `Finder` from `@forwardimpact/libutil`, `homedir` from `os`,
+  `createLogger` from `@forwardimpact/libtelemetry`
 - **Change** call sites:
 
 ```js
 let dataDir;
 if (options.data) {
   const resolved = resolve(options.data);
-  if (!(await dirExists(resolved))) {
+  try {
+    await fs.access(resolved);
+  } catch {
     throw new Error(`Data directory not found: ${options.data}`);
   }
   dataDir = resolved;
 } else {
+  const logger = createLogger("map");
   const finder = new Finder(fs, logger, process);
-  dataDir = join(finder.findData("data", homedir()), "pathway");
+  try {
+    dataDir = join(finder.findData("data", homedir()), "pathway");
+  } catch {
+    throw new Error(
+      "No data directory found. Use --data=<path> to specify location.",
+    );
+  }
 }
 ```
+
+**Note:** The old `dirExists` helper is replaced with `fs.access` for the
+explicit `--data` path check. The auto-discovery path uses Finder directly.
 
 ### 5. Modify `products/guide/bin/fit-guide.js`
 
 - **Import** `Finder` from `@forwardimpact/libutil` and `homedir` from `os`
-- **Add** data path resolution:
+- **Add** `--data` flag to CLI argument parsing
+- **Add** data path resolution using the existing `logger` (fit-guide already
+  creates one via `createLogger("cli")`):
 
 ```js
-const finder = new Finder(fs, logger, process);
-const dataDir = finder.findData("data", homedir());
+import { Finder } from "@forwardimpact/libutil";
+import { homedir } from "os";
+
+// After existing logger/config setup:
+let dataDir;
+if (options.data) {
+  dataDir = resolve(options.data);
+} else {
+  const finder = new Finder(fs, logger, process);
+  try {
+    dataDir = finder.findData("data", homedir());
+  } catch {
+    throw new Error(
+      "No data directory found. Use --data=<path> to specify location.",
+    );
+  }
+}
 ```
 
-Makes the base data path available for guide's resource/index loading.
+**Consumer:** The resolved `dataDir` is passed to guide's `DataLoader` for
+loading framework YAML files (disciplines, capabilities, behaviours) directly
+from disk, enabling guide to interpret artifacts against skill markers without
+requiring the gRPC agent service to be running.
 
-### 6. Improve libs-\* skill files for capability-oriented discovery
+### 6. Change `fit-universe` output to `data/`
 
-During initial planning for this feature, `Finder` was not discovered or
-considered because the `libs-system-utilities` skill only lists
-`countTokens`, `generateHash`, `generateUuid` as libutil's main API. The
-`Finder` class, `BundleDownloader`, `Retry`, `execLine`, `updateEnvFile`, and
-`waitFor` are all absent — making them invisible to agents scanning skills for
-relevant capabilities.
+The generation pipeline currently writes to `examples/` subdirectories. Change
+all output paths to write to `data/` instead:
 
-The root cause is structural: the **Libraries** table lists API names (classes,
-functions) rather than describing capabilities. An agent planning "data path
-resolution" searches for concepts like "find directories" or "upward traversal"
-— not `Finder`. Listing `Finder` helps only if you already know it exists.
+#### `libraries/libuniverse/pipeline.js`
 
-#### Approach: capability-oriented Libraries table
+Replace output path prefixes:
 
-Replace the current `Main API` column with a `Capabilities` column that
-describes what the library can do in task-oriented language. Keep API names in
-a separate `Key Exports` column so both discovery paths work.
+| Before | After |
+|--------|-------|
+| `examples/organizational/` | `data/knowledge/` |
+| `examples/pathway/` | `data/pathway/` |
+| `examples/activity/` | `data/activity/` |
+| `examples/personal/` | `data/personal/` |
 
-**Before** (API inventory):
+#### `libraries/libuniverse/bin/fit-universe.js`
 
-```
-| Library | Main API                                      | Purpose                   |
-| ------- | --------------------------------------------- | ------------------------- |
-| libutil | `countTokens`, `generateHash`, `generateUuid` | Token counting, hashing … |
-```
+Update hardcoded `examples/activity/raw/` and `examples/activity/evidence.json`
+paths to `data/activity/raw/` and `data/activity/evidence.json`.
 
-**After** (capability-oriented):
+#### `Makefile`
 
-```
-| Library | Capabilities                                                          | Key Exports                                                            |
-| ------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| libutil | Path resolution and upward directory search, bundle download and      | `Finder`, `BundleDownloader`, `TarExtractor`, `Retry`,                 |
-|         | extraction, retry with backoff, child process execution, token        | `ProcessorBase`, `countTokens`, `generateHash`, `execLine`,            |
-|         | counting, hashing, env file management                               | `updateEnvFile`, `waitFor`                                             |
-```
+- **`data-init`**: Remove the conditional copy from `examples/organizational/`
+  to `data/knowledge/`. The `generate` targets now write directly to `data/`.
+  Keep the directory creation step.
+- **`generate` targets**: No command changes needed — the pipeline code handles
+  the new paths.
 
-#### Apply consistently across all six skill files
+#### `examples/universe.dsl`
 
-For each `libs-*` skill file:
-
-1. **Libraries table** — replace `Main API` + `Purpose` columns with
-   `Capabilities` + `Key Exports`. Capabilities use task-oriented language
-   that matches how agents search ("store files to cloud", "evaluate access
-   policies", "resolve project paths"). Key Exports lists all public classes
-   and functions from the library's `index.js`.
-2. **Decision Guide** — expand to cover the full API surface, not just the
-   most common classes. Add entries for newly surfaced capabilities (e.g.
-   `Finder.findUpward` vs `findData` vs `findProjectRoot`).
-3. **DI Wiring** — ensure every class with a constructor is documented. Fix
-   incorrect claims like libutil's "Pure functions — no DI, no classes."
-
-#### Verification for skill files
-
-For each library in each skill file, diff the `Key Exports` column against the
-library's `index.js` exports. Every public export should appear. Run
-`grep "^export" libraries/{lib}/index.js` to enumerate.
+Stays at `examples/universe.dsl`. This is an input file, not output.
 
 ## Files
 
@@ -179,17 +203,19 @@ library's `index.js` exports. Every public export should appear. Run
 |------|--------|
 | `libraries/libutil/finder.js` | Add `findData` method |
 | `libraries/libutil/test/finder.test.js` | Add `findData` test cases |
-| `products/pathway/bin/fit-pathway.js` | Replace local resolution |
+| `products/pathway/bin/fit-pathway.js` | Replace local resolution, add logger |
 | `products/map/bin/fit-map.js` | Replace local resolution |
-| `products/guide/bin/fit-guide.js` | Add data path resolution |
-| `.claude/skills/libs-system-utilities/SKILL.md` | Surface full libutil API |
-| `.claude/skills/libs-*/SKILL.md` | Audit all six for missing exports |
+| `products/guide/bin/fit-guide.js` | Add data path resolution, add `--data` flag |
+| `libraries/libuniverse/pipeline.js` | Change output paths from `examples/` to `data/` |
+| `libraries/libuniverse/bin/fit-universe.js` | Change output paths from `examples/` to `data/` |
+| `Makefile` | Remove `examples/ → data/` copy step from `data-init` |
 
 ## Verification
 
 1. `node --test libraries/libutil/test/finder.test.js` — new + existing tests pass
 2. `npm test` — all tests pass
-3. `npx fit-map validate` — finds `data/pathway/` via upward traversal
-4. `npx fit-pathway skill --list` — works from monorepo root
-5. `npx fit-map validate --data=./examples/pathway` — CLI flag override works
-6. `npm run lint && npm run format` — clean
+3. `make generate` — writes to `data/` not `examples/`
+4. `npx fit-map validate` — finds `data/pathway/` via upward traversal
+5. `npx fit-pathway skill --list` — works from monorepo root
+6. `npx fit-map validate --data=/some/path` — CLI flag override works
+7. `npm run lint && npm run format` — clean

--- a/specs/120-data-resolution/spec.md
+++ b/specs/120-data-resolution/spec.md
@@ -9,18 +9,26 @@ Three CLI products need to resolve a data directory:
   multiple CWD fallbacks including `examples/` directories.
 - **fit-map** has a 4-candidate discovery function with no env var or home
   directory support.
-- **fit-guide** has no data path resolution at all — it relies on service
-  infrastructure but cannot find local data files (resources, indices).
+- **fit-guide** resolves data indirectly through `libstorage` (which uses
+  `Finder.findUpward` internally), but cannot resolve the pathway data
+  directory for loading framework YAML files directly without the service
+  infrastructure running.
 
 Each product reimplements resolution with different priority orders, different
 env vars, and different fallback candidates. There is no way for a user to set
 the data directory once and have it apply to all `fit-*` commands.
 
+A secondary problem: `fit-universe` generates synthetic data into `examples/`
+while the running application reads from `data/`. This split forces fallback
+logic in every CLI to check both locations and a copy step in `make data-init`.
+
 ## Goal
 
-Extend the existing `Finder` class in libutil with a `findData` method that
-every `fit-*` CLI uses to resolve the base data directory, with a consistent
-resolution order.
+1. Extend the existing `Finder` class in libutil with a `findData` method that
+   every `fit-*` CLI uses to resolve the base data directory, with a consistent
+   resolution order.
+2. Change `fit-universe` to generate directly into `data/` so there is one
+   canonical data location.
 
 ## Resolution Order
 
@@ -31,23 +39,44 @@ resolution order.
 The method returns the **base** data path (e.g. `data/`). Each product appends
 its own subdirectory (e.g. `pathway/`).
 
+Upward traversal walks up to 3 parent directories. This is a behavioral change
+from the old CWD-only checks — running `fit-pathway` from `products/pathway/`
+will now find `data/` at the monorepo root. This is intentional: it matches how
+`libstorage` already resolves paths via `Finder.findUpward` and allows CLIs to
+work from any subdirectory within the monorepo.
+
 ## What Changes
 
 | Before | After |
 |--------|-------|
-| `PATHWAY_DATA` env var (pathway only) | Dropped (use `--data` flag) |
+| `PATHWAY_DATA` env var (pathway only) | Dropped — clean break, no replacement |
 | `~/.fit/pathway/data` home path | `~/.fit/data/` (products append suffix) |
-| `examples/pathway/`, `examples/` fallbacks | Dropped — use `--data` or create `./data/` |
+| `examples/pathway/`, `examples/` fallbacks | Dropped — `fit-universe` writes to `data/` |
+| `fit-universe` outputs to `examples/` | Outputs to `data/` |
+| `make data-init` copies examples → data | No copy step needed |
 | fit-map: no home fallback | Full resolution via Finder |
-| fit-guide: no data path at all | Full resolution via Finder |
+| fit-guide: indirect via libstorage only | Direct resolution via Finder for framework data |
 | Three bespoke implementations | One method on Finder |
 
 ## Why
 
 - **Consistency** — one resolution order across all products.
+- **One data location** — `data/` is the single source, not `examples/` with
+  fallbacks and copy steps.
 - **Reuse** — Finder already handles upward path traversal for libstorage;
   data path resolution is the same pattern with a HOME fallback.
-- **fit-guide needs it** — currently cannot find local data files without
+- **fit-guide needs it** — currently cannot load framework YAML files without
   service infrastructure running.
 - **Fewer bugs** — one implementation to maintain instead of three diverging
   copies.
+
+## Migration
+
+- **`PATHWAY_DATA` env var**: Removed without replacement. Users who set this
+  in `.bashrc` or CI must switch to `--data=<path>` or place data in `data/`
+  or `~/.fit/data/`. No deprecation shim — clean break.
+- **`examples/` as output**: `fit-universe` writes to `data/` instead. The
+  `examples/universe.dsl` input file stays where it is. Existing `examples/`
+  output directories become stale and should be removed after migration.
+- **`make data-init` copy step**: The `examples/organizational/ → data/knowledge/`
+  copy is replaced by `fit-universe` writing directly to `data/knowledge/`.

--- a/specs/130-improve-lib-skills/plan.md
+++ b/specs/130-improve-lib-skills/plan.md
@@ -1,0 +1,142 @@
+# 130: Implementation Plan
+
+## Approach
+
+For each of the six `libs-*` skill files, apply three changes:
+
+1. **Libraries table** — replace the `Main API` + `Purpose` columns with
+   `Capabilities` + `Key Exports`. Capabilities use task-oriented language
+   that matches how agents search. Key Exports lists all public classes and
+   functions from the library's `index.js`.
+2. **Decision Guide** — expand to cover the full API surface. Add entries for
+   newly surfaced capabilities.
+3. **DI Wiring** — ensure every class with a constructor is documented with
+   its actual parameter names. Fix incorrect claims.
+
+## Verification method
+
+For each library in each skill file, diff the `Key Exports` column against the
+library's `index.js` exports. Every public export should appear. Enumerate with:
+
+```sh
+grep "^export" libraries/{lib}/index.js
+```
+
+## Changes
+
+### 1. `.claude/skills/libs-system-utilities/SKILL.md`
+
+**Libraries table — fix names and surface missing exports:**
+
+| Library | Fix |
+|---------|-----|
+| libutil | `generateUuid` → `generateUUID`. Add `Finder`, `BundleDownloader`, `TarExtractor`, `ZipExtractor`, `ProcessorBase`, `Retry`, `createRetry`, `createBundleDownloader`, `execLine`, `updateEnvFile`, `waitFor`, `parseJsonBody`, `createTokenizer`. |
+| libsecret | `createJwt` → `generateJWT`, `setEnvVar` → `updateEnvFile`. Add `readEnvFile`, `getOrGenerateSecret`, `generateBase64Secret`, `generateHash`, `generateUUID`. |
+| libsupervise | Add `OneshotProcess`, `ProcessState`, `createSupervisionTree`. |
+| librc | Add `waitForSocket`. |
+| libcodegen | `TypeGenerator` → `CodegenTypes`, `ServiceGenerator` → `CodegenServices`. Add `CodegenBase`, `CodegenDefinitions`. |
+
+**Capabilities column examples:**
+
+```
+| Library      | Capabilities                                            | Key Exports                                    |
+| ------------ | ------------------------------------------------------- | ---------------------------------------------- |
+| libutil      | Path resolution and upward directory search, bundle     | Finder, BundleDownloader, TarExtractor,        |
+|              | download and extraction, retry with backoff, child      | ZipExtractor, ProcessorBase, Retry, createRetry|
+|              | process execution, token counting, hashing, env file    | createBundleDownloader, countTokens,           |
+|              | management, JSON body parsing                           | createTokenizer, generateHash, generateUUID,   |
+|              |                                                         | execLine, updateEnvFile, waitFor, parseJsonBody |
+```
+
+**DI Wiring — fix incorrect claim:**
+
+Current claim: "libutil: Pure functions — no DI, no classes."
+Actual: libutil exports `Finder`, `BundleDownloader`, `TarExtractor`,
+`ZipExtractor`, `ProcessorBase`, `Retry` — all classes with constructor
+injection. Document `Finder(fs, logger, process)`,
+`BundleDownloader(createStorage, finder, logger, extractor)`,
+`Retry(logger, options)`.
+
+### 2. `.claude/skills/libs-data-persistence/SKILL.md`
+
+**Libraries table — fix names and surface missing exports:**
+
+| Library | Fix |
+|---------|-----|
+| libstorage | `parseJsonl` → `fromJsonLines`. Add `LocalStorage`, `S3Storage`, `SupabaseStorage`, `toJsonLines`, `fromJson`, `toJson`, `isJsonLines`, `isJson`. |
+| libindex | `Index` → `IndexBase`. |
+| libpolicy | `PolicyIndex` → `Policy`, `createPolicyIndex` → `createPolicy`. |
+| libgraph | `PREFIXES` → `RDF_PREFIXES`. Remove `GraphIndex` (not exported). Add `isWildcard`, `parseGraphQuery`, `ShaclSerializer`. |
+| libvector | Remove `VectorIndex`, `VectorProcessor` (not exported from index.js). Add `calculateDotProduct` as the only public export. Note that VectorIndex and VectorProcessor must be imported directly from their modules. |
+| libresource | Add `toType`, `toIdentifier`. |
+
+### 3. `.claude/skills/libs-llm-orchestration/SKILL.md`
+
+**Libraries table — fix names and surface missing exports:**
+
+| Library | Fix |
+|---------|-----|
+| libllm | Add `createLlmApi`, `createProxyAwareFetch`, `normalizeVector`, `DEFAULT_BASE_URL`. |
+| libmemory | `WindowBuilder` → `MemoryWindow`. Remove `createWindow` (does not exist). Add `getModelBudget`. |
+| libagent | `AgentAction` → `AgentHands`. |
+| libprompt | No changes (correct). |
+
+**DI Wiring — fix class names:**
+
+`WindowBuilder(deps)` → `MemoryWindow(deps)`. Update constructor signature to
+match actual parameter names.
+
+### 4. `.claude/skills/libs-service-infrastructure/SKILL.md`
+
+**Libraries table — fix names and surface missing exports:**
+
+| Library | Fix |
+|---------|-----|
+| librpc | `RpcServer` → `Server`, `RpcClient` → `Client`, `createClientFactory` → `createClient`. Add `Rpc`, `Interceptor`, `HmacAuth`, `createGrpc`, `createAuth`, `services`, `clients`, `createTracer`. |
+| libconfig | `serviceConfig` → `createServiceConfig`, `extensionConfig` → `createExtensionConfig`, `scriptConfig` → `createScriptConfig`. Add `createInitConfig`, `createConfig`, `Config`. |
+| libtelemetry | Remove `Tracer` (not exported from index.js — import from `./tracer.js` directly). Add `Observer`, `createObserver`. Note the direct import path for Tracer. |
+| libtype | No changes (correct). |
+| libharness | Clarify that exports come from `./fixture/index.js` and `./mock/index.js` submodules. |
+
+### 5. `.claude/skills/libs-synthetic-data/SKILL.md`
+
+**Libraries table — surface missing exports:**
+
+| Library | Fix |
+|---------|-----|
+| libsyntheticgen | Add `createDslParser`, `createEntityGenerator`, `collectProseKeys`, `FakerTool`, `createFakerTool`, `SyntheaTool`, `createSyntheaTool`, `SdvTool`, `createSdvTool`. |
+| libsyntheticprose | Add `createProseEngine`, `loadSchemas`. |
+| libsyntheticrender | Add `createRenderer`, `validateCrossContent`, `formatContent`, `generateDrugs`, `generatePlatforms`, `assignLinks`, `validateLinks`, `validateHTML`, `renderDataset`. |
+
+### 6. `.claude/skills/libs-web-presentation/SKILL.md`
+
+**Libraries table — surface missing exports:**
+
+| Library | Fix |
+|---------|-----|
+| libui | Add reactive functions (`createReactive`, `createComputed`, `bind`), error classes (`NotFoundError`, `InvalidCombinationError`, `DataLoadError`), `withErrorBoundary`, `createPagesRouter`, `createSlideRouter`, `markdownToHtml`, `getItemsByIds`. List DOM helpers as a group ("40+ element functions: div, span, h1–h4, p, a, ul, li, table, etc.") rather than individually. |
+| libformat | Add `createHtmlFormatter`, `createTerminalFormatter`. |
+| libweb | Add `createValidationMiddleware`, `createCorsMiddleware`, `createAuthMiddleware`. |
+| libdoc | No changes (correct). |
+| libtemplate | No changes (correct). |
+
+## Files
+
+| File | Action |
+|------|--------|
+| `.claude/skills/libs-system-utilities/SKILL.md` | Fix names, surface exports, fix DI claims |
+| `.claude/skills/libs-data-persistence/SKILL.md` | Fix names, surface exports |
+| `.claude/skills/libs-llm-orchestration/SKILL.md` | Fix names, surface exports, fix DI wiring |
+| `.claude/skills/libs-service-infrastructure/SKILL.md` | Fix names, surface exports |
+| `.claude/skills/libs-synthetic-data/SKILL.md` | Surface exports |
+| `.claude/skills/libs-web-presentation/SKILL.md` | Surface exports |
+
+## Verification
+
+For each of the six skill files:
+
+1. Run `grep "^export" libraries/{lib}/index.js` for every library in the file
+2. Confirm every public export appears in the `Key Exports` column
+3. Confirm every name in `Key Exports` matches the actual export name exactly
+4. Confirm DI Wiring section uses actual class names and constructor signatures
+5. `npm run format -- .claude/skills/` — formatting clean

--- a/specs/130-improve-lib-skills/spec.md
+++ b/specs/130-improve-lib-skills/spec.md
@@ -1,0 +1,73 @@
+# 130: Improve Library Skill Files
+
+## Problem
+
+The six `libs-*` skill files are the primary way agents discover library
+capabilities. When an agent plans a task like "resolve data directories," it
+searches skill files for concepts like "find directories" or "upward traversal."
+If the skill file only lists `countTokens`, `generateHash`, `generateUuid` as
+libutil's API, the agent will never discover `Finder` — and will reimplement
+the capability from scratch.
+
+An audit of all six skill files against the actual `index.js` exports reveals
+three categories of problems:
+
+### 1. Wrong names
+
+Skill files reference classes and functions that no longer exist under those
+names. An agent that tries to import `WindowBuilder` from libmemory will get a
+runtime error — the actual export is `MemoryWindow`.
+
+| Skill file | Claims | Actual export |
+|------------|--------|---------------|
+| libs-data-persistence | `parseJsonl` | `fromJsonLines` |
+| libs-data-persistence | `Index` | `IndexBase` |
+| libs-data-persistence | `PolicyIndex`, `createPolicyIndex` | `Policy`, `createPolicy` |
+| libs-data-persistence | `PREFIXES` | `RDF_PREFIXES` |
+| libs-data-persistence | `VectorIndex`, `VectorProcessor` | Not exported (only `calculateDotProduct`) |
+| libs-llm-orchestration | `WindowBuilder` | `MemoryWindow` |
+| libs-llm-orchestration | `AgentAction` | `AgentHands` |
+| libs-service-infrastructure | `RpcServer`, `RpcClient` | `Server`, `Client` |
+| libs-service-infrastructure | `serviceConfig`, `extensionConfig`, `scriptConfig` | `createServiceConfig`, `createExtensionConfig`, `createScriptConfig` |
+| libs-system-utilities | `generateUuid` | `generateUUID` |
+| libs-system-utilities | `createJwt` | `generateJWT` |
+| libs-system-utilities | `setEnvVar` | `updateEnvFile` |
+| libs-system-utilities | `TypeGenerator`, `ServiceGenerator` | `CodegenTypes`, `CodegenServices` |
+
+### 2. Missing exports
+
+Skill files list a handful of "main" exports and omit the rest. Agents cannot
+use capabilities they cannot see.
+
+| Library | Listed | Missing from skill file |
+|---------|--------|------------------------|
+| libutil | 3 functions | `Finder`, `BundleDownloader`, `TarExtractor`, `ZipExtractor`, `ProcessorBase`, `Retry`, `createRetry`, `createBundleDownloader`, `execLine`, `updateEnvFile`, `waitFor`, `parseJsonBody`, `createTokenizer` |
+| libstorage | 2 exports | `LocalStorage`, `S3Storage`, `SupabaseStorage`, `fromJsonLines`, `toJsonLines`, `fromJson`, `toJson`, `isJsonLines`, `isJson` |
+| libllm | 1 class | `createLlmApi`, `createProxyAwareFetch`, `normalizeVector`, `DEFAULT_BASE_URL` |
+| libui | 3 functions | 40+ DOM helpers, `createReactive`, `createComputed`, `bind`, error classes, `createPagesRouter`, `createSlideRouter`, `markdownToHtml` |
+| libsyntheticgen | 3 exports | `createDslParser`, `createEntityGenerator`, `FakerTool`, `SyntheaTool`, `SdvTool` and their factories |
+| libsyntheticrender | 3 exports | `createRenderer`, `validateCrossContent`, `formatContent`, `generateDrugs`, `generatePlatforms`, `renderDataset`, `validateHTML` |
+
+### 3. API-oriented rather than capability-oriented
+
+The Libraries tables list class and function names (`Finder`, `countTokens`)
+rather than describing what the library can do ("upward directory search,"
+"token counting"). An agent searching for "find directories" will not match
+`Finder` unless it already knows the name. Capability-oriented descriptions
+enable concept-based discovery.
+
+## Goal
+
+Make every `libs-*` skill file an accurate, complete, capability-oriented index
+of its libraries so that agents can discover the right tool for any task without
+prior knowledge of API names.
+
+## Why
+
+- **Correct discovery** — agents find existing capabilities instead of
+  reimplementing them.
+- **No runtime errors** — agents import what actually exists, not stale names.
+- **Concept search** — capability descriptions match how agents plan ("store
+  files to cloud" finds libstorage, "evaluate access policies" finds libpolicy).
+- **DI compliance** — accurate wiring examples prevent agents from violating
+  the OO+DI architecture.


### PR DESCRIPTION
## Summary

- **Rewrite `specs/120-data-resolution/`** — critically reviewed spec and plan, addressed 12 issues inline: fixed fit-guide characterization, resolved `examples/` workflow by generating into `data/` directly, specified logger dependencies concretely, added `--data` flag for guide, fixed `dirExists` contradiction, made error messages domain-appropriate, and documented migration costs for `PATHWAY_DATA` removal.
- **Create `specs/130-improve-lib-skills/`** — extracted skill file audit (removed as scope creep from 120) into its own spec. Audited all 6 `libs-*` skill files against actual `index.js` exports, documenting 13 wrong export names, 50+ missing exports, and API-oriented tables that block concept-based agent discovery. Plan provides per-file fix instructions with verification method.

## Test plan

- [ ] Review `specs/120-data-resolution/spec.md` for accurate problem statement and migration plan
- [ ] Review `specs/120-data-resolution/plan.md` for implementation correctness
- [ ] Review `specs/130-improve-lib-skills/spec.md` audit findings against current `index.js` exports
- [ ] Review `specs/130-improve-lib-skills/plan.md` per-file fixes for completeness

https://claude.ai/code/session_01BwyHZJ3ypz5RUeze8jAmdy