### PR TITLE
fix(security): address XSS, command injection, and dependency vulnerabilities

### DIFF
--- a/.claude/skills/fit-guide/SKILL.md
+++ b/.claude/skills/fit-guide/SKILL.md
@@ -366,10 +366,11 @@ make rc-start
 
 ### Ingest New Knowledge
 
-1. Generate HTML files (e.g., `npx fit-universe --cached` writes directly to `data/knowledge/`)
+1. Generate HTML files (e.g., `npx fit-universe --cached` writes directly to
+   `data/knowledge/`)
 2. Run `make process-resources` to create resources
-4. Run `make process-graphs` to build graph index
-5. Run `make process-vectors` to build vector index (requires TEI)
+3. Run `make process-graphs` to build graph index
+4. Run `make process-vectors` to build vector index (requires TEI)
 
 ## Verification
 

--- a/.claude/skills/fit-pathway/SKILL.md
+++ b/.claude/skills/fit-pathway/SKILL.md
@@ -166,7 +166,8 @@ npx fit-pathway skill <id> --agent  # Output as agent SKILL.md format
 The CLI resolves data via `Finder.findData` from `@forwardimpact/libutil`:
 
 1. `--data=<path>` flag (explicit override)
-2. Upward traversal from CWD — `findUpward` looking for `data/` (up to 3 parents)
+2. Upward traversal from CWD — `findUpward` looking for `data/` (up to 3
+   parents)
 3. `~/.fit/data/` (user-global fallback)
 
 The method returns the base `data/` path; pathway appends `pathway/`.

--- a/.claude/skills/fit-universe/SKILL.md
+++ b/.claude/skills/fit-universe/SKILL.md
@@ -40,12 +40,12 @@ npx fit-universe --universe=path     # Custom universe file
 
 Use `--only=<type>` to generate a single content type:
 
-| Type       | Output Directory   | Contents                        |
-| ---------- | ------------------ | ------------------------------- |
-| `html`     | `data/knowledge`   | Articles, guides, FAQs, courses |
-| `pathway`  | `data/pathway`     | YAML framework files            |
-| `raw`      | `data/activity`    | Roster, GitHub events, evidence |
-| `markdown` | `data/personal`    | Briefings, notes, KB content    |
+| Type       | Output Directory | Contents                        |
+| ---------- | ---------------- | ------------------------------- |
+| `html`     | `data/knowledge` | Articles, guides, FAQs, courses |
+| `pathway`  | `data/pathway`   | YAML framework files            |
+| `raw`      | `data/activity`  | Roster, GitHub events, evidence |
+| `markdown` | `data/personal`  | Briefings, notes, KB content    |
 
 ### Prose Modes
 

--- a/libraries/libcodegen/bin/fit-codegen.js
+++ b/libraries/libcodegen/bin/fit-codegen.js
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import fsAsync from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { parseArgs } from "node:util";
 
 import protoLoader from "@grpc/proto-loader";
@@ -42,10 +42,13 @@ async function createBundle(sourcePath) {
 
   // Create tar.gz archive using system tar command
   try {
-    const directoriesArg = directories.join(" ");
-    execSync(`tar -czf "${bundlePath}" -C "${sourcePath}" ${directoriesArg}`, {
-      stdio: "pipe",
-    });
+    execFileSync(
+      "tar",
+      ["-czf", bundlePath, "-C", sourcePath, ...directories],
+      {
+        stdio: "pipe",
+      },
+    );
   } catch (error) {
     throw new Error(`Failed to create bundle: ${error.message}`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2047,13 +2047,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.6.tgz",
-      "integrity": "sha512-YrXu+UnfC8IdARa4ZkrpcyuRmA/TVgYW6Lcdtvi34NQgRjM1hTirNirN+rGb+s/kNomby8oJiIAu0KNbiZC7PA==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.1",
-        "fast-xml-parser": "5.3.6",
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2365,9 +2365,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2667,9 +2667,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -3387,9 +3387,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
-      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3852,9 +3852,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -5197,9 +5197,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5372,10 +5372,10 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -5384,7 +5384,24 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5458,9 +5475,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5565,9 +5582,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.7.tgz",
-      "integrity": "sha512-FjiwU9HaHW6YB3H4a1sFudnv93lvydNjz2lmyUXR6IwKhGI+bgL3SOZrBGn6kvvX2pJvhEkGSGjyTHN47O4rqA==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5614,9 +5631,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6340,9 +6357,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6675,6 +6692,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-inside": {
@@ -7162,14 +7194,14 @@
       }
     },
     "node_modules/serve": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.5.tgz",
-      "integrity": "sha512-Qn/qMkzCcMFVPb60E/hQy+iRLpiU8PamOfOSYoAHmmF+fFFmpPpqa6Oci2iWYpTdOUM3VF+TINud7CfbQnsZbA==",
+      "version": "14.2.6",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+      "integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@zeit/schemas": "2.36.0",
-        "ajv": "8.12.0",
+        "ajv": "8.18.0",
         "arg": "5.0.2",
         "boxen": "7.0.0",
         "chalk": "5.0.1",
@@ -7177,7 +7209,7 @@
         "clipboardy": "3.0.0",
         "compression": "1.8.1",
         "is-port-reachable": "4.0.0",
-        "serve-handler": "6.1.6",
+        "serve-handler": "6.1.7",
         "update-check": "1.5.4"
       },
       "bin": {
@@ -7188,16 +7220,16 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
-      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
         "mime-types": "2.1.18",
-        "minimatch": "3.1.2",
+        "minimatch": "3.1.5",
         "path-is-inside": "1.0.2",
         "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
@@ -7211,23 +7243,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/serve/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/serve/node_modules/chalk": {
@@ -7417,9 +7432,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "funding": [
         {
           "type": "github",
@@ -7642,9 +7657,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -7923,9 +7938,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/products/pathway/src/commands/update.js
+++ b/products/pathway/src/commands/update.js
@@ -9,7 +9,7 @@
 import { cp, mkdir, rm, readFile, writeFile, access } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
-import { execFileSync, execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { createDataLoader } from "@forwardimpact/map/loader";
 
 const INSTALL_DIR = join(homedir(), ".fit", "pathway");
@@ -112,9 +112,13 @@ export async function runUpdateCommand({ dataDir: _dataDir, options }) {
     // 6. Update global pathway package if version changed
     if (oldVersion !== newVersion) {
       console.log(`   Updating pathway ${oldVersion} → ${newVersion}...`);
-      execSync(`npm install -g @forwardimpact/pathway@${newVersion}`, {
-        stdio: "ignore",
-      });
+      execFileSync(
+        "npm",
+        ["install", "-g", `@forwardimpact/pathway@${newVersion}`],
+        {
+          stdio: "ignore",
+        },
+      );
       console.log("   ✓ Global package updated");
     }
 

--- a/products/pathway/src/lib/radar.js
+++ b/products/pathway/src/lib/radar.js
@@ -3,6 +3,20 @@
  */
 
 /**
+ * Escape HTML special characters to prevent XSS
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
  * @typedef {Object} RadarDataPoint
  * @property {string} label - Label for this axis
  * @property {number} value - Current value
@@ -393,9 +407,9 @@ export class RadarChart {
     const y = event.clientY - rect.top;
 
     this.tooltip.innerHTML = `
-      <strong>${data.label}</strong><br>
+      <strong>${escapeHtml(data.label)}</strong><br>
       Value: ${data.value}/${data.maxValue}
-      ${data.description ? `<br><small>${data.description}</small>` : ""}
+      ${data.description ? `<br><small>${escapeHtml(data.description)}</small>` : ""}
     `;
 
     this.tooltip.style.left = `${x + 10}px`;
@@ -815,9 +829,9 @@ export class ComparisonRadarChart {
     const typeLabel = type === "current" ? "Current" : "Target";
 
     this.tooltip.innerHTML = `
-      <strong>${data.label}</strong><br>
+      <strong>${escapeHtml(data.label)}</strong><br>
       ${typeLabel}: ${data.value}/${data.maxValue}
-      ${data.description ? `<br><small>${data.description}</small>` : ""}
+      ${data.description ? `<br><small>${escapeHtml(data.description)}</small>` : ""}
     `;
 
     this.tooltip.style.left = `${x + 10}px`;
@@ -844,7 +858,7 @@ export class ComparisonRadarChart {
           : "<span style='color: #94a3b8'>No change</span>";
 
     this.tooltip.innerHTML = `
-      <strong>${currentData.label}</strong><br>
+      <strong>${escapeHtml(currentData.label)}</strong><br>
       Current: ${currentData.value}/${currentData.maxValue}<br>
       Target: ${targetData.value}/${targetData.maxValue}<br>
       ${diffText}

--- a/products/pathway/src/slide-main.js
+++ b/products/pathway/src/slide-main.js
@@ -54,6 +54,20 @@ function showLoading() {
 }
 
 /**
+ * Escape HTML special characters to prevent XSS
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
  * Render error slide
  * @param {string} title
  * @param {string} message
@@ -62,8 +76,8 @@ function renderError(title, message) {
   const container = getSlideContent();
   container.innerHTML = `
     <div class="slide-error">
-      <h1>${title}</h1>
-      <p>${message}</p>
+      <h1>${escapeHtml(title)}</h1>
+      <p>${escapeHtml(message)}</p>
       <a href="#/">← Back to Index</a>
     </div>
   `;


### PR DESCRIPTION
- Add HTML escaping to radar chart tooltips and slide error display to
  prevent XSS via framework data (radar.js, slide-main.js)
- Replace execSync shell string concatenation with execFileSync array
  arguments in fit-codegen.js and update.js to prevent command injection
- Run npm audit fix to update hono, undici, fast-xml-parser, yaml, ajv,
  and @hono/node-server to patched versions

https://claude.ai/code/session_01SaPJ1YBf43A1orS3Z6ypLz