### PR TITLE
docs(specs): add spec and plan for automated Dependabot triage workflow

### DIFF
--- a/specs/140-dependabot-triage-workflow/plan.md
+++ b/specs/140-dependabot-triage-workflow/plan.md
@@ -1,0 +1,156 @@
+# 140: Implementation Plan
+
+## Approach
+
+Add a single workflow file that installs Claude Code on a schedule and runs it
+with a prompt that activates the `dependabot-triage` skill. No other files
+change.
+
+## New File
+
+### `.github/workflows/dependabot-triage.yml`
+
+```yaml
+name: Dependabot Triage
+
+on:
+  schedule:
+    # Every 3 days at 06:00 UTC (Mon, Thu, Sun pattern across weeks)
+    - cron: "0 6 */3 * *"
+  workflow_dispatch: # Manual trigger for testing or on-demand triage
+
+permissions:
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Triage Dependabot PRs
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        run: |
+          claude --print --allowedTools "Bash,Read,Glob,Grep,Write,Edit" \
+            "/dependabot-triage"
+```
+
+## Design Decisions
+
+### Why `claude --print`
+
+The `--print` flag runs Claude Code in non-interactive mode — it accepts the
+prompt, executes the task, prints the output, and exits. This is the correct
+mode for CI where there is no interactive terminal.
+
+### Why `--allowedTools`
+
+Explicitly listing allowed tools avoids interactive permission prompts that would
+hang the CI runner. The triage skill needs `Bash` (for `gh` CLI commands, `npm
+audit`, `git` operations), `Read`/`Glob`/`Grep` (for inspecting workflow files
+and policy documents), and `Write`/`Edit` (for fixing policy violations on fix
+branches).
+
+### Why `npm ci` before Claude Code
+
+The workspace must be fully installed so that Claude Code can run `npm audit`,
+`npm ls`, and other npm commands during triage. The `npm ci` step also ensures
+the lock file is present for audit checks.
+
+### Why a PAT instead of `GITHUB_TOKEN`
+
+Two reasons:
+
+1. **Recursive trigger prevention.** GitHub does not trigger workflows on events
+   created by `GITHUB_TOKEN`. When Claude Code creates a fix PR, CI must run on
+   that PR. A PAT allows this.
+2. **Cross-branch operations.** The triage skill creates fix branches, pushes
+   commits, and creates PRs. While `GITHUB_TOKEN` can technically do some of
+   this with `contents: write`, the combination of merge + close + create-PR +
+   push requires a PAT for reliability.
+
+### Why every 3 days
+
+Dependabot opens PRs weekly. Running every 3 days ensures each PR is triaged
+within a few days of creation without burning excessive CI minutes. The
+`workflow_dispatch` trigger allows immediate triage when needed.
+
+### Why `/dependabot-triage` as the prompt
+
+Claude Code's skill system recognizes slash-command invocations. The
+`dependabot-triage` skill's frontmatter and instructions are comprehensive
+enough that a simple invocation triggers the full workflow — list PRs, evaluate
+policies, take action, report.
+
+## Secrets Setup
+
+### 1. Anthropic API Key
+
+1. Go to [console.anthropic.com](https://console.anthropic.com/) and create an
+   API key (or use an existing one).
+2. In the GitHub repository, go to **Settings > Secrets and variables >
+   Actions**.
+3. Click **New repository secret**.
+4. Name: `ANTHROPIC_API_KEY`, Value: the API key (starts with `sk-ant-`).
+
+The key needs access to Claude Sonnet or Opus. Triage sessions typically use
+moderate token counts (reading PR diffs, policy files, running commands), so
+cost per run should be modest.
+
+### 2. GitHub PAT
+
+1. Go to **GitHub Settings > Developer settings > Fine-grained personal access
+   tokens** (or use a classic PAT).
+2. Create a token scoped to the `forwardimpact/monorepo` repository with these
+   permissions:
+   - **Contents**: Read and write
+   - **Pull requests**: Read and write
+   - **Actions**: Read
+   - **Metadata**: Read (granted by default)
+3. In the GitHub repository, go to **Settings > Secrets and variables >
+   Actions**.
+4. Click **New repository secret**.
+5. Name: `GH_TOKEN`, Value: the token.
+
+**Token expiry:** Fine-grained tokens have a maximum lifetime (typically 1
+year). Set a calendar reminder to rotate before expiry.
+
+**Alternative — GitHub App:** For longer-lived automation, create a GitHub App
+with the same permissions, install it on the repository, and use
+`actions/create-github-app-token` to generate short-lived tokens in the
+workflow. This avoids PAT expiry concerns but adds setup complexity.
+
+## Files
+
+| File                                        | Action |
+| ------------------------------------------- | ------ |
+| `.github/workflows/dependabot-triage.yml`   | Create |
+
+## Verification
+
+1. Push the workflow file to `main`.
+2. Go to **Actions > Dependabot Triage** and click **Run workflow** (manual
+   dispatch).
+3. Confirm the job installs Claude Code, runs the triage prompt, and correctly
+   evaluates open Dependabot PRs.
+4. Verify that merged PRs are squash-merged, fix PRs trigger CI, and closed PRs
+   have policy violation comments.
+5. Wait for the next scheduled run and confirm it executes automatically.

--- a/specs/140-dependabot-triage-workflow/spec.md
+++ b/specs/140-dependabot-triage-workflow/spec.md
@@ -1,0 +1,84 @@
+# 140: Automated Dependabot Triage Workflow
+
+## Problem
+
+Dependabot opens PRs weekly for both npm packages and GitHub Actions. These PRs
+accumulate because triage requires a human to remember to run the
+`dependabot-triage` skill manually. The skill itself is comprehensive — it
+evaluates 8 policy checks, merges clean PRs, fixes minor violations, and closes
+bad ones — but it sits idle until someone invokes it.
+
+The gap is not the triage logic but the trigger. A scheduled GitHub Actions
+workflow can close this gap by launching Claude Code on a timer and letting the
+existing skill do the work.
+
+## Why
+
+- **PRs go stale.** Dependabot opens new PRs weekly. Without regular triage,
+  they pile up, creating merge conflicts and security exposure from unpatched
+  dependencies.
+- **Human trigger is unreliable.** The skill exists but depends on someone
+  remembering to run it. Automating the trigger makes triage consistent.
+- **The skill already works.** No new triage logic is needed. The
+  `dependabot-triage` skill handles policy evaluation, CI checks, merging,
+  fixing, and closing. The workflow just needs to invoke it.
+- **Reduced toil.** Routine dependency updates (patch/minor bumps that pass all
+  checks) should not require human attention. The workflow handles them
+  automatically and only leaves genuinely ambiguous cases for review.
+
+## What
+
+A single GitHub Actions workflow file that:
+
+1. **Runs on a schedule** — every 3 days via `cron`, with manual
+   `workflow_dispatch` as a fallback.
+2. **Installs Claude Code** — uses `npm install -g @anthropic-ai/claude-code` in
+   the runner.
+3. **Launches a Claude Code session** — runs `claude` with a prompt that
+   triggers the `dependabot-triage` skill to process all open Dependabot PRs.
+4. **Authenticates with GitHub** — uses a GitHub token with sufficient
+   permissions to read PRs, merge, close, create branches, and push commits.
+5. **Authenticates with Anthropic** — uses an API key secret to power the Claude
+   session.
+
+The workflow does not modify the existing skill, add new triage logic, or change
+any repository code. It is a pure automation trigger.
+
+## Scope
+
+### In scope
+
+- New workflow file: `.github/workflows/dependabot-triage.yml`
+- Documentation of required secrets and permissions
+- Cron schedule configuration
+
+### Out of scope
+
+- Changes to the `dependabot-triage` skill itself
+- Changes to `dependabot.yml` configuration
+- Changes to any other workflow files
+- New libraries, products, or scripts
+
+## Required Secrets
+
+| Secret              | Purpose                                           |
+| ------------------- | ------------------------------------------------- |
+| `ANTHROPIC_API_KEY` | Authenticates Claude Code with the Anthropic API  |
+| `GH_TOKEN`         | GitHub PAT or fine-grained token for PR operations |
+
+The built-in `GITHUB_TOKEN` is insufficient because Claude Code needs to create
+branches, push commits, create PRs, merge PRs, and close PRs — operations that
+require a PAT when the actor is a workflow. Using `GITHUB_TOKEN` would also
+prevent triggering downstream CI on PRs created by the workflow (GitHub prevents
+recursive workflow triggers from `GITHUB_TOKEN`).
+
+## Permissions Model
+
+The `GH_TOKEN` (PAT) needs:
+
+- **Pull requests**: read and write (list, merge, close, comment, create)
+- **Contents**: read and write (fetch branches, push fix branches)
+- **Actions**: read (check CI status via `gh pr checks`)
+
+The workflow itself declares minimal `permissions:` at the job level since the
+PAT provides the actual authorization.


### PR DESCRIPTION
Defines a GitHub Actions workflow that runs Claude Code on a schedule
to triage Dependabot PRs using the existing dependabot-triage skill.

https://claude.ai/code/session_01Fp2mdEeAxMrWQP4aVSdK2i