### PR TITLE
feat(chore): add automated dependabot triage workflow

### DIFF
--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -1,0 +1,41 @@
+name: Claude Prompt
+description: Install Claude Code and run a prompt in non-interactive mode
+
+inputs:
+  prompt:
+    description: The prompt to send to Claude Code
+    required: true
+  allowed-tools:
+    description: Comma-separated list of tools to allow without prompting
+    required: false
+    default: "Bash,Read,Glob,Grep,Write,Edit"
+  model:
+    description: Claude model to use
+    required: false
+    default: "opus"
+  max-turns:
+    description: Maximum number of agentic turns
+    required: false
+    default: "50"
+
+runs:
+  using: composite
+  steps:
+    - name: Install Claude Code
+      shell: bash
+      run: npm install -g @anthropic-ai/claude-code
+
+    - name: Configure Git identity
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Run Claude Code
+      shell: bash
+      run: |
+        claude --print \
+          --model "${{ inputs.model }}" \
+          --max-turns "${{ inputs.max-turns }}" \
+          --allowedTools "${{ inputs.allowed-tools }}" \
+          "${{ inputs.prompt }}"

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -1,0 +1,39 @@
+name: Dependabot Triage
+
+on:
+  schedule:
+    # Every 3 days at 06:17 UTC (off-minute to avoid :00 stampede)
+    - cron: "17 6 */3 * *"
+  workflow_dispatch: # Manual trigger for testing or on-demand triage
+
+concurrency:
+  group: dependabot-triage
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Triage Dependabot PRs
+        uses: ./.github/actions/claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.CLAUDE_GH_PAT }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          prompt: "/dependabot-triage"
+          model: "opus"
+          max-turns: "50"


### PR DESCRIPTION
Add a reusable composite action (.github/actions/claude-prompt/) that
installs Claude Code and runs a prompt in non-interactive mode, and a
scheduled workflow that invokes the dependabot-triage skill every 3 days
to automatically triage Dependabot PRs.

https://claude.ai/code/session_017Y4kjvkNwy3WNAMHzdCpSs