### PR TITLE
feat(specs): add STATUS file for tracking spec lifecycle

### DIFF
--- a/.claude/skills/implement-spec/SKILL.md
+++ b/.claude/skills/implement-spec/SKILL.md
@@ -73,7 +73,11 @@ Break the plan into ordered, atomic tasks. Each task should:
 Use TodoWrite to track progress. Group related changes that must land together
 (e.g., schema + data + code for the same feature).
 
-### 5. Implement step by step
+### 5. Update STATUS
+
+Set the spec's status to `active` in `specs/STATUS` before starting work.
+
+### 6. Implement step by step
 
 For each task:
 
@@ -86,7 +90,7 @@ For each task:
    the repository's git workflow (`type(scope): subject`). Commit after each
    verified step — do not batch unrelated changes.
 
-### 6. Final verification
+### 7. Final verification
 
 After all tasks are complete:
 
@@ -94,7 +98,8 @@ After all tasks are complete:
 2. Run any spec-specific verification commands mentioned in the plan.
 3. Review the full diff (`git diff` from the starting point) against the spec's
    success criteria. Confirm every criterion is met.
-4. Push all commits to the remote branch.
+4. **Update STATUS.** Set the spec's status to `done` in `specs/STATUS`.
+5. Push all commits to the remote branch.
 
 ## Handling Problems
 

--- a/.claude/skills/write-spec/SKILL.md
+++ b/.claude/skills/write-spec/SKILL.md
@@ -87,7 +87,8 @@ on these qualities:
    the current state before proposing changes.
 3. **Write the spec.** Focus on WHAT and WHY. Do not include implementation
    details — those go in the plan.
-4. **Review the spec.** Present it to the user for feedback. Stop here unless
+4. **Update STATUS.** Add the spec to `specs/STATUS` with status `draft`.
+5. **Review the spec.** Present it to the user for feedback. Stop here unless
    the user also asked for a plan.
 
 ### Writing a plan
@@ -98,4 +99,5 @@ on these qualities:
    Understand the current state before proposing changes.
 3. **Write the plan.** Translate the approved spec into concrete steps. Each
    step should be independently verifiable.
-4. **Review the plan.** Present it to the user for approval before implementing.
+4. **Update STATUS.** Set the spec's status to `planned` in `specs/STATUS`.
+5. **Review the plan.** Present it to the user for approval before implementing.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -1,0 +1,34 @@
+# Spec Status Tracker
+#
+# Statuses:  draft → planned → active → done
+#
+#   draft    Spec or plan incomplete, competing versions unresolved
+#   planned  Spec and plan approved, ready for implementation
+#   active   Implementation in progress
+#   done     Implemented
+#
+# Format: {id}\t{status}
+# Update this file when creating, planning, or implementing a spec.
+
+010	done
+020	done
+030	done
+040	done
+050	done
+051	done
+052	done
+060	done
+061	done
+062	done
+063	done
+070	done
+080	draft
+090	draft
+100	done
+110	done
+120	done
+130	done
+140	done
+150	planned
+160	done
+170	draft


### PR DESCRIPTION
Add specs/STATUS with four statuses (draft → planned → active → done).
Update write-spec and implement-spec skills to maintain it. Assessed
all 22 specs against the codebase and recorded their status.

https://claude.ai/code/session_01Lw3cDACqt13MYA7rbukURM