### PR TITLE
fix(security): XSS escape, align yaml version, pin claude-code

### DIFF
--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Install Claude Code
       shell: bash
-      run: npm install -g @anthropic-ai/claude-code
+      run: npm install -g @anthropic-ai/claude-code@2.1.87
 
     - name: Configure Git identity
       shell: bash

--- a/libraries/libtool/package.json
+++ b/libraries/libtool/package.json
@@ -26,7 +26,7 @@
     "@forwardimpact/libtype": "^0.1.63",
     "@forwardimpact/libutil": "^0.1.60",
     "protobufjs": "^7.5.4",
-    "yaml": "^2.3.4"
+    "yaml": "^2.8.3"
   },
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -820,7 +820,7 @@
         "@forwardimpact/libtype": "^0.1.63",
         "@forwardimpact/libutil": "^0.1.60",
         "protobufjs": "^7.5.4",
-        "yaml": "^2.3.4"
+        "yaml": "^2.8.3"
       },
       "bin": {
         "fit-process-tools": "bin/fit-process-tools.js"

--- a/products/pathway/src/handout-main.js
+++ b/products/pathway/src/handout-main.js
@@ -39,6 +39,20 @@ import {
 import { sortTracksByName } from "./formatters/track/shared.js";
 
 /**
+ * Escape HTML special characters to prevent XSS
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/**
  * Create a chapter cover page
  * @param {Object} params
  * @param {string} params.emojiIcon - Chapter emoji
@@ -425,7 +439,7 @@ async function init() {
     container.innerHTML = `
       <div class="slide-error">
         <h1>Initialization Error</h1>
-        <p>${error.message}</p>
+        <p>${escapeHtml(String(error.message))}</p>
       </div>
     `;
     hideLoading();


### PR DESCRIPTION
## Summary

Security audit findings — three incremental fixes:

- **XSS fix** in `products/pathway/src/handout-main.js`: `error.message` was interpolated into `innerHTML` without escaping. Added `escapeHtml()` function (matching the pattern already used in `slide-main.js`).
- **Dependency alignment** in `libraries/libtool/package.json`: `yaml` version `^2.3.4` bumped to `^2.8.3` to align with all other workspaces per dependency policy.
- **Supply chain pin** in `.github/actions/claude/action.yml`: `@anthropic-ai/claude-code` was installed without version pinning. Pinned to `2.1.87`.

## Audit context

Full audit also identified items requiring specs (not addressed in this PR):
- Wildcard CORS in Supabase Edge Function (`cors.ts`)
- Shell command execution patterns in librc/libsupervise
- Gitleaks binary checksum verification in CI

## Test plan

- [ ] `npm run lint` passes (no new warnings)
- [ ] `npm run test` passes (40 pre-existing failures unchanged)
- [ ] Verify `escapeHtml` escapes `<script>` tags in error messages
- [ ] Verify `npm ls yaml` shows no `invalid` markers after version alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)