### PR TITLE
fix(ci): harden supply chain

### DIFF
--- a/.github/actions/audit/action.yml
+++ b/.github/actions/audit/action.yml
@@ -24,7 +24,11 @@ runs:
       shell: bash
       run: |
         GITLEAKS_VERSION="8.24.3"
-        curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz
+        GITLEAKS_SHA256="9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c"
+        curl -sSfL -o gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+        echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+        tar xzf gitleaks.tar.gz
+        rm gitleaks.tar.gz
         sudo mv gitleaks /usr/local/bin/
 
     - name: Secret scanning

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Install Claude Code
       shell: bash
-      run: npm install -g @anthropic-ai/claude-code
+      run: npm install -g @anthropic-ai/claude-code@2.1.87
 
     - name: Configure Git identity
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,14 @@ generated/
 !**/.env.*.example
 !**/.env.example
 
+# Private keys and certificates
+*.pem
+*.key
+*.p8
+*.p12
+*.pfx
+*.jks
+
 # Local config (use *.example.* templates)
 **/config/config.json
 **/config/tools.yml


### PR DESCRIPTION
## Summary

Three incremental supply chain hardening fixes:

- **Pin claude-code version in CI**: Changed `npm install -g @anthropic-ai/claude-code` to `@anthropic-ai/claude-code@2.1.87` in `.github/actions/claude/action.yml`. Unpinned npm installs in CI allow a compromised or malicious package version to execute in workflows.
- **Verify gitleaks checksum**: Added SHA256 checksum verification to the gitleaks binary download in `.github/actions/audit/action.yml`. The previous download piped curl output directly to tar without integrity verification, leaving the audit toolchain vulnerable to MITM or CDN compromise.
- **Gitignore private key files**: Added `*.pem`, `*.key`, `*.p8`, `*.p12`, `*.pfx`, `*.jks` patterns to `.gitignore`. These file types commonly contain private keys and certificates that should never be committed.

## Test plan

- [ ] CI passes on this branch (no functional changes, only hardening)
- [ ] Verify `.github/actions/claude/action.yml` installs the pinned version
- [ ] Verify `.github/actions/audit/action.yml` checksum step fails on tampered binary
- [ ] Verify `.gitignore` excludes key file patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)