### PR TITLE
fix(security): ensure audit agent files both fix and spec PRs

### DIFF
--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -35,22 +35,65 @@ pinning an action SHA, adding a missing audit gate, fixing a lint rule override.
 
 When a finding requires larger or structural changes — new infrastructure,
 architectural shifts, policy redesigns, multi-file refactors — do not implement
-it. Instead, open a pull request containing a spec (`specs/{feature}/spec.md`)
-that describes the problem and the proposed solution. A human will review the
-spec and collaborate on planning the implementation.
+it. Instead, write a spec (`specs/{feature}/spec.md`) describing the problem and
+the proposed solution.
+
+## Pull request workflow
+
+Every audit produces **two categories** of output. Each category gets its own
+PR on an **independent branch created from `main`**. Never combine fixes and
+specs in the same branch or PR.
+
+### 1. Incremental fixes → `fix()` PR
+
+- Branch naming: `fix/security-audit-YYYY-MM-DD`
+- Commit type: `fix(security): <subject>`
+- Contains only small, self-contained changes (dependency bumps, SHA pins,
+  lint fixes, missing audit gates, XSS escaping, etc.)
+- One PR per audit run — batch all incremental fixes together
+
+### 2. Specs for larger findings → `spec()` PR(s)
+
+- Branch naming: `spec/security-<finding-name>`
+- Commit type: `spec(security): <subject>`
+- Contains a spec document (`specs/{NNN}-{kebab-case-name}/spec.md`) written
+  using the `write-spec` skill
+- One PR per distinct finding — do not batch unrelated specs together
+- **This is mandatory.** If the audit identifies findings that require broader
+  changes, you MUST create spec PRs for them. Do not merely list them in the
+  fix PR body and move on.
+
+### Branch independence
+
+Each PR must be on its own branch created directly from `main`:
+
+```
+git checkout main
+git checkout -b fix/security-audit-YYYY-MM-DD   # for fixes
+# ... commit and push, open PR
+
+git checkout main
+git checkout -b spec/security-<finding-name>     # for each spec
+# ... commit and push, open PR
+```
+
+Never branch from a fix branch to create a spec branch or vice versa.
 
 ## Approach
 
-- Read the repository's CONTRIBUTING.md and security policies before acting
-- Evaluate each issue against the established policies — do not invent new rules
-- For incremental issues: fix directly, commit, and open a PR
-- For larger issues: write a spec and open a PR for review
-- Produce a clear summary of actions taken and any remaining items
+1. Read the repository's CONTRIBUTING.md and security policies before acting
+2. Perform the full audit — collect all findings before making any changes
+3. Categorize each finding as incremental (fixable now) or structural (needs spec)
+4. Create a fix branch from `main`, apply all incremental fixes, open a fix PR
+5. For each structural finding: create a spec branch from `main`, write the spec
+   using the `write-spec` skill, open a spec PR
+6. Produce a clear summary of all PRs opened
 
 ## Rules
 
 - Never bypass pre-commit hooks or CI checks
 - Never weaken existing security policies
 - Follow the SHA pinning policy for GitHub Actions — never change a pin to a tag
-- When fixing issues, create a new branch from the source branch
+- Always create branches from `main` — never from another audit branch
 - Always explain the rationale for closing a PR
+- Never skip spec PRs — if findings need specs, file them

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -90,3 +90,16 @@ How to perform a review:
 - Grep for common vulnerability patterns: `eval(`, `child_process.exec(`,
   `innerHTML`, `dangerouslySetInnerHTML`, `new Function(`, unsanitized template
   literals in SQL/shell contexts.
+
+## 8. Output Requirements
+
+Every audit must produce **both** output categories when applicable:
+
+1. **Incremental fixes** — Commit with `fix(security):` on a `fix/` branch and
+   open a PR. Batch all small fixes into a single PR.
+2. **Specs for structural findings** — Commit with `spec(security):` on a
+   `spec/` branch and open a PR per finding. Use the `write-spec` skill to
+   produce `specs/{NNN}-{name}/spec.md`.
+
+Do not list structural findings in the fix PR body without also filing spec PRs.
+Each PR must be on an independent branch from `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,15 @@ All changes go through pull requests — never push directly to `main`.
 
 Format: `type(scope): subject`
 
-**Types**: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `perf`
-**Scope**: package name (`map`, `libskill`, `libui`, `pathway`, `basecamp`).
+**Types**: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `perf`,
+`spec`
+**Scope**: package name (`map`, `libskill`, `libui`, `pathway`, `basecamp`), or
+domain area (`security`) for specs.
 **Breaking**: add `!` after scope.
+
+`spec` is for new specification documents in `specs/`. Use when proposing a
+change that requires design review before implementation (e.g.
+`spec(security): Supabase edge function hardening`).
 
 ### Before Committing
 


### PR DESCRIPTION
The security-engineer agent was only creating fix PRs in 2 of 3 audit
runs — structural findings were documented in the fix PR body but spec
PRs were never opened. This updates the agent definition and audit skill
to mandate separate PRs for each category on independent branches from
main, and adds spec() as a conventional commit type.

https://claude.ai/code/session_01J2dEXACZ3avy5awYB4kYfc