### PR TITLE
feat: add spec review step to spec-driven development process

### DIFF
--- a/.claude/skills/implement-spec/SKILL.md
+++ b/.claude/skills/implement-spec/SKILL.md
@@ -14,7 +14,7 @@ changes methodically.
 
 ## When to Use
 
-- A spec and plan exist and are approved for implementation
+- A spec and plan exist with STATUS `planned` (has passed review)
 - The user says "implement spec NNN" or "execute the plan for NNN"
 - Resuming a partially completed implementation
 

--- a/.claude/skills/review-spec/SKILL.md
+++ b/.claude/skills/review-spec/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: review-spec
+description: >
+  Review a spec (and plan, if present) against quality criteria, then approve it
+  or request changes. Use when a spec is in draft or review status and needs
+  formal evaluation before implementation.
+---
+
+# Review Spec
+
+Evaluate a specification and its plan against quality criteria, then advance it
+toward implementation or send it back for revision. This is the gate between
+writing and implementing.
+
+## When to Use
+
+- A spec exists and the user wants it reviewed before implementation
+- The user says "review spec NNN" or "is spec NNN ready?"
+- A spec's STATUS is `draft` or `review` and needs a decision
+
+## Process
+
+### 1. Read the spec directory
+
+Read every file in `specs/{NNN}-*/` — `spec.md`, all `plan*.md` files, and any
+supporting documents.
+
+### 2. Evaluate the spec
+
+Assess `spec.md` against these criteria:
+
+- **Problem is clear.** The reader can feel the pain or see the opportunity.
+  Evidence is provided — errors, metrics, audit findings, examples.
+- **Scope is specific.** Affected files, APIs, entities, or behaviours are
+  named. What is and is not included is explicit.
+- **Success is verifiable.** "Done" is defined in terms someone can test — a
+  command to run, a behaviour to observe, a property to check.
+- **No implementation leakage.** The spec describes WHAT and WHY, not HOW. If
+  implementation details have crept in, flag them.
+
+### 3. Evaluate the plan (if present)
+
+Assess `plan.md` (or plan variants) against these criteria:
+
+- **Approach is stated.** The overall strategy and rationale come before
+  individual changes.
+- **Changes are concrete.** Exact file paths, functions, and before/after code
+  are shown where they clarify intent.
+- **Blast radius is visible.** Which files are created, modified, or deleted is
+  easy to see.
+- **Ordering is explicit.** Dependencies between changes are stated and the
+  order is justified.
+- **Decisions are explained.** Non-obvious choices include brief rationale.
+
+### 4. Decide and update STATUS
+
+If all criteria are met, approve. If any criterion falls short, request changes.
+
+| Situation | Action |
+|-----------|--------|
+| Spec + plan approved | Set status to `planned` |
+| Spec approved, no plan yet | Keep status at `review` (plan still needed) |
+| Changes requested | Set status to `draft` |
+
+## What NOT to Do
+
+- **Do not rewrite the spec or plan.** This skill evaluates — it does not
+  author. If changes are needed, return the status to `draft` for `write-spec`.
+- **Do not approve without reading.** Every criterion must be checked against
+  the actual content.

--- a/.claude/skills/write-spec/SKILL.md
+++ b/.claude/skills/write-spec/SKILL.md
@@ -88,8 +88,10 @@ on these qualities:
 3. **Write the spec.** Focus on WHAT and WHY. Do not include implementation
    details — those go in the plan.
 4. **Update STATUS.** Add the spec to `specs/STATUS` with status `draft`.
-5. **Review the spec.** Present it to the user for feedback. Stop here unless
-   the user also asked for a plan.
+5. **Present the spec.** Share it with the user for feedback. Iterate until they
+   are satisfied, then set status to `review` — signalling it is ready for
+   formal evaluation via `review-spec`. Stop here unless the user also asked for
+   a plan.
 
 ### Writing a plan
 
@@ -99,5 +101,6 @@ on these qualities:
    Understand the current state before proposing changes.
 3. **Write the plan.** Translate the approved spec into concrete steps. Each
    step should be independently verifiable.
-4. **Update STATUS.** Set the spec's status to `planned` in `specs/STATUS`.
-5. **Review the plan.** Present it to the user for approval before implementing.
+4. **Update STATUS.** Set the spec's status to `review` in `specs/STATUS`.
+5. **Present the plan.** Share it with the user for feedback. Formal approval
+   via `review-spec` advances the status to `planned`.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -1,14 +1,15 @@
 # Spec Status Tracker
 #
-# Statuses:  draft → planned → active → done
+# Statuses:  draft → review → planned → active → done
 #
-#   draft    Spec or plan incomplete, competing versions unresolved
-#   planned  Spec and plan approved, ready for implementation
+#   draft    Spec or plan incomplete, still being written
+#   review   Ready for review, not yet approved
+#   planned  Reviewed and approved, ready for implementation
 #   active   Implementation in progress
 #   done     Implemented
 #
 # Format: {id}\t{status}
-# Update this file when creating, planning, or implementing a spec.
+# Update this file when creating, planning, reviewing, or implementing a spec.
 
 010	done
 020	done


### PR DESCRIPTION
Introduces a `review` status between `draft` and `planned`, and a new
`review-spec` skill that autonomously evaluates specs against quality
criteria before approving them for implementation.

https://claude.ai/code/session_01161WsVkGMN3kAW4DWhgXp5