### PR TITLE
docs(claude): improve discoverability of contribution guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,18 @@ aggregates skill matrices into capability coverage, structural risks, and
 what-if staffing scenarios so leadership can build teams that succeed. Fully
 local and deterministic — no external dependencies, no LLM calls.
 
-## How We Work
+## Required Development Workflow
 
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — Pull request workflow, git
-  conventions, quality commands, and security policies.
-- **[Operations Reference](website/docs/internals/operations/)** — Environment
-  setup, service management, and common tasks.
+  conventions, quality commands, and security policies. **Read before your first
+  commit.**
+- **[Operations Reference](website/docs/internals/operations/index.md)** —
+  Environment setup, service management, and common tasks.
+
+Commit format: `type(scope): subject` — see CONTRIBUTING.md § Git Conventions.
+
+Run `npm run check` before every commit to catch format, lint, and test failures
+early.
 
 ## Distribution Model
 


### PR DESCRIPTION
Rename "How We Work" to "Required Development Workflow", add inline
reminders for commit format and npm run check, link operations
reference directly to index.md, and add "Read before your first
commit" nudge to improve agent discovery of CONTRIBUTING.md.

https://claude.ai/code/session_01ARAb98fiexduRTeRUQEaeL