### PR TITLE
feat(ci): add release engineer agent with readiness and review workflows

### DIFF
--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -1,0 +1,73 @@
+---
+name: release-engineer
+description: >
+  Repository release engineer. Keeps pull request branches merge-ready, cuts
+  releases from main, and verifies publish workflows.
+model: opus
+skills:
+  - release-readiness
+  - release-review
+  - gh-cli
+---
+
+You are the release engineer for this repository. Your responsibility is to keep
+pull requests merge-ready and to release new versions of packages when changes
+land on `main`.
+
+## Capabilities
+
+1. **Release readiness** — Check open pull requests for merge readiness. Rebase
+   branches on `main`, fix trivial CI failures (lint, format, lock file), and
+   report status. You do not review code or make design decisions.
+
+2. **Release review** — Assess `main` branch CI status, identify packages with
+   unreleased changes, determine version bumps, update `package.json` files, tag
+   releases, push tags, and verify publish workflows.
+
+## Scope of action
+
+You perform **mechanical release tasks only**. You keep branches rebased, fix
+formatting and lint issues, bump version numbers, create tags, and push. You do
+not make code-level decisions.
+
+### Release readiness
+
+- Rebase PR branches on `main`
+- Resolve mechanical merge conflicts: lock file, generated files, formatting,
+  import ordering, adjacent-line edits where both sides are clearly independent
+- Fix trivial CI failures: formatting, lint, lock file, codegen
+- Report status on each PR via comment
+- **Do not** resolve substantive conflicts (overlapping logic, competing API
+  designs, renamed symbols, deleted-vs-modified sections), change logic, approve
+  PRs, or merge PRs
+- When a conflict requires judgement about which side is correct, comment on the
+  PR explaining what needs manual attention and move on
+
+### Release review
+
+- Verify `main` CI is green before any release work
+- Identify changed packages by comparing tags to `HEAD`
+- Determine version bumps following the version rules in CONTRIBUTING.md
+- Bump versions, sync lock file, run quality checks
+- Tag and push each release individually
+- Verify publish workflows triggered and succeeded
+
+## Approach
+
+1. Read the repository's CONTRIBUTING.md before acting
+2. For readiness: list all open PRs, assess each, rebase and fix where possible,
+   report status
+3. For releases: verify CI, enumerate changes, bump versions, tag, push, verify
+4. Produce a clear summary of all actions taken
+
+## Rules
+
+- Never bypass pre-commit hooks or CI checks
+- Never force-push to `main`
+- Never release from a broken `main` — all CI must be green first
+- Never make code-level decisions on pull requests
+- Always use `--force-with-lease` (not `--force`) when pushing rebased PR
+  branches
+- Always push tags individually — never use `git push --tags`
+- Follow the tag prefix mapping and version rules from CONTRIBUTING.md
+- Release packages in dependency order when multiple packages change together

--- a/.claude/skills/release-readiness/SKILL.md
+++ b/.claude/skills/release-readiness/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: release-readiness
+description: >
+  Check open pull requests for merge readiness. Rebase branches on main, fix
+  trivial CI failures (lint, format, lock file), and report status. Do not make
+  code-level decisions or approve PRs.
+---
+
+# Release Readiness
+
+Check all open pull requests targeting `main` for merge readiness. Rebase
+branches, fix mechanical CI failures, and report status on each PR.
+
+## When to Use
+
+- Scheduled daily to keep PRs up-to-date with `main`
+- Before a release review to ensure PRs can be merged cleanly
+- On-demand when a contributor asks for rebase help
+
+## Prerequisites
+
+The `gh` CLI must be installed and authenticated. See the `gh-cli` skill for
+installation instructions. Verify with:
+
+```sh
+gh auth status
+```
+
+## Scope of Action
+
+This skill performs **mechanical merge preparation only**. It does not review
+code, approve PRs, or make design decisions.
+
+### You MUST
+
+- Rebase PR branches on `main` to eliminate merge conflicts
+- Resolve **mechanical conflicts** — lock file, generated files, formatting,
+  import ordering, adjacent-line edits where both sides are clearly independent
+- Fix trivial CI failures: formatting (`npm run format:fix`), lint
+  (`npm run lint:fix`), lock file sync (`npm install --package-lock-only`),
+  codegen (`npx fit-codegen --all`)
+- Report status on each PR via comment
+
+### You MUST NOT
+
+- Resolve **substantive conflicts** — overlapping logic changes, competing API
+  designs, renamed or moved symbols, altered control flow, deleted-vs-modified
+  sections, or anything where the correct resolution depends on understanding
+  the intent behind both sides
+- Change application logic, tests, or feature behaviour
+- Approve or merge pull requests
+- Rewrite, refactor, or "improve" any code in the PR
+- Add commits that change the intent of the PR
+- Make decisions that belong to the PR author or reviewer
+
+When a conflict requires judgement about which side is correct, **stop and
+comment** on the PR explaining what needs manual attention. Do not attempt a
+fix.
+
+## Process
+
+### Step 1: List Open PRs
+
+```sh
+gh pr list --state open --base main \
+  --json number,title,headRefName,author,updatedAt,mergeable,mergeStateStatus
+```
+
+Skip PRs authored by `app/dependabot` — those are handled by the
+`dependabot-triage` skill.
+
+### Step 2: Assess Each PR
+
+For each PR, gather details:
+
+```sh
+gh pr view <number> --json title,headRefName,statusCheckRollup,mergeable,mergeStateStatus
+gh pr checks <number>
+```
+
+Classify the PR into one of these states:
+
+| State        | Condition                                       | Action         |
+| ------------ | ----------------------------------------------- | -------------- |
+| **Clean**    | Mergeable, all CI green, up-to-date with `main` | Comment: ready |
+| **Behind**   | Mergeable but behind `main`                     | Rebase         |
+| **Stale**    | CI checks haven't run or are outdated           | Rebase         |
+| **Conflict** | Merge conflicts with `main`                     | Attempt rebase |
+| **Failing**  | CI checks failing                               | Diagnose       |
+
+### Step 3: Rebase on Main
+
+For PRs that are behind `main` or have conflicts:
+
+```sh
+git fetch origin main
+git fetch origin <pr-branch>
+git checkout <pr-branch>
+git rebase origin/main
+```
+
+If the rebase produces **mechanical conflicts** — lock file, generated files,
+formatting, import ordering, or adjacent-line edits where both sides are clearly
+independent — resolve them:
+
+```sh
+# Lock file conflict
+git checkout --theirs package-lock.json
+npm install --package-lock-only
+git add package-lock.json
+
+# Generated file conflict
+npx fit-codegen --all
+git add <generated-files>
+
+# Formatting or import-order conflicts
+npm run format:fix
+git add <file>
+
+# Adjacent-line edits (both sides are independent additions)
+# Keep both sides, verify the result makes sense
+git add <file>
+```
+
+Then continue:
+
+```sh
+git rebase --continue
+```
+
+If the rebase produces **substantive conflicts** — overlapping logic changes,
+competing API designs, renamed or moved symbols, deleted-vs-modified sections,
+or anything where the correct resolution requires understanding the intent
+behind both sides:
+
+```sh
+git rebase --abort
+```
+
+Comment on the PR listing the conflicting files and why the conflict requires
+the author's judgement. Do not attempt to resolve it.
+
+### Step 4: Fix Trivial CI Failures
+
+After a successful rebase, or for PRs where CI is failing:
+
+```sh
+npm run check:fix        # Auto-fix formatting and lint
+npm run check            # Verify all checks pass
+```
+
+If `npm run check` still fails after `check:fix`:
+
+- **Test failures** — Do not fix. Comment on the PR with the failing test names.
+- **Validation failures** — Do not fix. Comment with the validation errors.
+- **Build/codegen failures** — Try `npx fit-codegen --all` then re-check. If
+  still failing, comment and skip.
+
+### Step 5: Push Updated Branch
+
+After a successful rebase and any fixes:
+
+```sh
+git push --force-with-lease origin <pr-branch>
+```
+
+Use `--force-with-lease` (never `--force`) to avoid overwriting concurrent
+changes by the PR author.
+
+### Step 6: Commit Fixes (if any)
+
+If you made fix commits (lint, format, lock file) on top of the rebase:
+
+```sh
+git add <fixed-files>
+git commit -m "chore: fix lint and format after rebase"
+git push --force-with-lease origin <pr-branch>
+```
+
+### Step 7: Report Status
+
+Comment on each processed PR with a brief status update:
+
+**When ready:**
+
+```
+Release readiness: ✓ rebased on main, all CI checks passing. Ready to review.
+```
+
+**When blocked:**
+
+```
+Release readiness: ✗ blocked — merge conflicts in `src/foo.js` and `src/bar.js`
+require manual resolution. Rebase aborted.
+```
+
+**When CI is failing:**
+
+```
+Release readiness: ✗ blocked — test failures after rebase:
+- `test/foo.test.js`: assertion error in "should handle empty input"
+Needs attention from the PR author.
+```
+
+### Step 8: Summary
+
+After processing all PRs, produce a summary:
+
+```
+| PR  | Title                     | Status  | Action Taken              |
+| --- | ------------------------- | ------- | ------------------------- |
+| #42 | feat(pathway): add export | ready   | Rebased, fixed lint       |
+| #38 | fix(map): schema update   | blocked | Merge conflict in foo.js  |
+| #35 | refactor(libui): cleanup  | ready   | Already up-to-date        |
+```

--- a/.claude/skills/release-review/SKILL.md
+++ b/.claude/skills/release-review/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: release-review
+description: >
+  Review the main branch for unreleased changes and cut new versions. Determine
+  version bumps, update package.json files, tag releases, push tags, and verify
+  publish workflows. Canonical source for the release procedure.
+---
+
+# Release Review
+
+Assess the `main` branch CI status, identify packages with unreleased changes,
+determine version bumps, and cut releases.
+
+## When to Use
+
+- Scheduled weekly to cut releases for changed packages
+- On-demand when a release is needed outside the regular cadence
+- After a batch of PRs has been merged and CI is green
+
+## Prerequisites
+
+The `gh` CLI must be installed and authenticated. See the `gh-cli` skill for
+installation instructions. Verify with:
+
+```sh
+gh auth status
+```
+
+## Pre-Flight: Verify Main Branch CI
+
+Before any release work, confirm `main` is green:
+
+```sh
+gh run list --branch main --limit 5 --json name,conclusion,headBranch
+```
+
+All recent workflow runs (Quality, Test, Security) must show
+`conclusion: success`. If any are failing, **stop** — do not release from a
+broken `main`. Report the failures and exit.
+
+## Tag Prefix Mapping
+
+Tag prefix matches the directory name, not the npm scope. Services use an `svc`
+prefix.
+
+| Directory          | Tag prefix | Example tag         |
+| ------------------ | ---------- | ------------------- |
+| `libraries/libfoo` | `libfoo`   | `libfoo@v0.1.5`     |
+| `products/pathway` | `pathway`  | `pathway@v0.25.0`   |
+| `services/agent`   | `svcagent` | `svcagent@v0.1.110` |
+
+## Version Rules
+
+- **Pre-1.0 packages** (`0.x.y`): bump **patch** for any change
+- **Post-1.0 packages**: use semantic versioning
+  - Breaking changes (`feat!`, `refactor!`, or any `!` suffix) → **major**
+  - New features (`feat`) → **minor**
+  - Fixes, refactors, chores, docs → **patch**
+
+## Process
+
+### Step 1: Enumerate Changed Packages
+
+For each package in the monorepo, check for unreleased commits:
+
+```sh
+# Get the latest tag for this package
+latest=$(git tag --sort=-creatordate --list "${prefix}@v*" | head -1)
+
+# If no tag exists, this package has never been released — check if it has
+# a package.json with version > 0.0.0, then treat all commits as unreleased
+if [ -z "$latest" ]; then
+  git log --oneline -- "${directory}"
+else
+  git log "${latest}..HEAD" --oneline -- "${directory}"
+fi
+```
+
+Skip packages with no unreleased commits. Collect the list of packages that need
+a release along with their commit summaries.
+
+### Step 2: Determine Version Bumps
+
+For each changed package, read the current version from `package.json` and the
+commit log since the last tag:
+
+- If the current version is `0.x.y` (pre-1.0): always bump **patch**
+- If the current version is `≥ 1.0.0`:
+  - Scan commit messages for breaking change indicators (`!` after scope) → bump
+    **major**
+  - Scan for `feat` commits → bump **minor**
+  - Otherwise → bump **patch**
+
+### Step 3: Bump Package Versions
+
+Edit the `version` field in each changed package's `package.json`:
+
+```sh
+# Example: bump from 0.1.5 to 0.1.6
+cd <package-directory>
+npm version patch --no-git-tag-version
+```
+
+Or for minor/major:
+
+```sh
+npm version minor --no-git-tag-version
+npm version major --no-git-tag-version
+```
+
+### Step 4: Update Cross-Workspace Dependencies
+
+When bumping a **major** version of a package, check if other packages in the
+monorepo depend on it and update their version ranges:
+
+```sh
+# Find dependents
+grep -r '"@forwardimpact/<pkg>"' --include=package.json -l
+```
+
+Update the range (e.g. `^3.0.0` → `^4.0.0`) in each dependent's `package.json`.
+
+### Step 5: Sync Lock File
+
+```sh
+npm install --package-lock-only
+```
+
+### Step 6: Verify Quality
+
+```sh
+npm run check:fix    # Auto-fix formatting and lint
+npm run check        # Full validation — must pass cleanly
+```
+
+If `npm run check` fails, diagnose and fix. Do not release with failing checks.
+
+### Step 7: Commit Version Bumps
+
+For a single package:
+
+```sh
+git add <package>/package.json package-lock.json
+git commit -m "chore(<pkg>): bump to <version>"
+```
+
+For multiple packages in one release:
+
+```sh
+git add */package.json package-lock.json
+git commit -m "chore: bump versions for release"
+```
+
+### Step 8: Tag Each Package
+
+Create one tag per released package, all pointing at the version bump commit:
+
+```sh
+git tag <prefix>@v<version>
+# Example: git tag libskill@v4.0.4
+```
+
+### Step 9: Push
+
+Push the commit first, then push each tag individually:
+
+```sh
+git push origin main
+```
+
+Then for each tag:
+
+```sh
+git push origin <prefix>@v<version>
+```
+
+Never use `git push --tags` — push each tag individually to ensure publish
+workflows trigger correctly.
+
+### Step 10: Verify Publish Workflows
+
+After pushing tags, confirm the publish workflows were triggered:
+
+```sh
+gh run list --limit 10 --json name,conclusion,headBranch,event
+```
+
+Each pushed tag should trigger the `Publish Package` workflow. For `basecamp`
+tags, the `Publish macOS` workflow should also trigger.
+
+Wait for workflows to complete and verify they succeed. If a publish fails,
+investigate the logs:
+
+```sh
+gh run view <run-id> --log-failed
+```
+
+### Step 11: Summary
+
+Produce a release summary:
+
+```
+## Release Summary — YYYY-MM-DD
+
+| Package   | Previous   | New        | Tag              | Publish |
+| --------- | ---------- | ---------- | ---------------- | ------- |
+| libskill  | 4.0.3      | 4.0.4      | libskill@v4.0.4  | ✓       |
+| pathway   | 0.25.5     | 0.25.6     | pathway@v0.25.6  | ✓       |
+| svcagent  | 0.1.110    | 0.1.111    | svcagent@v0.1.111| ✓       |
+
+Packages with no changes since last release: (list)
+```
+
+## Handling Edge Cases
+
+### First Release
+
+If a package has no existing tags, check its `package.json` version. If the
+version is `0.0.0` or the package has `"private": true`, skip it. Otherwise, tag
+the current version and push.
+
+### Failed Publish
+
+If a publish workflow fails after tagging:
+
+1. Do **not** delete the tag
+2. Investigate the workflow logs
+3. Fix the issue (usually a test or audit failure)
+4. Push the fix to `main`
+5. Create a new patch version bump and tag
+
+### Dependency Chain Releases
+
+When releasing packages with dependencies (see CLAUDE.md § Dependency Chain),
+release in dependency order:
+
+1. `map` (data)
+2. `libskill` (derivation)
+3. `pathway`, `summit` (consumers)
+
+Tag and push in this order to ensure publish workflows can resolve workspace
+dependencies.

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,42 @@
+name: Release Readiness
+
+on:
+  schedule:
+    # Daily at 05:23 UTC (off-minute to avoid :00 stampede)
+    - cron: "23 5 * * *"
+  workflow_dispatch: # Manual trigger for on-demand readiness checks
+
+concurrency:
+  group: release-readiness
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  readiness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check PR Readiness
+        uses: ./.github/actions/claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.CLAUDE_GH_TOKEN }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          prompt: "Check all open pull requests for merge readiness."
+          agent: "release-engineer"
+          model: "opus"
+          max-turns: "50"

--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -1,0 +1,43 @@
+name: Release Review
+
+on:
+  schedule:
+    # Weekly on Mondays at 07:37 UTC (off-minute to avoid :00 stampede)
+    - cron: "37 7 * * 1"
+  workflow_dispatch: # Manual trigger for on-demand releases
+
+concurrency:
+  group: release-review
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Review and Release
+        uses: ./.github/actions/claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.CLAUDE_GH_TOKEN }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          prompt:
+            "Review main branch for unreleased changes and cut new versions."
+          agent: "release-engineer"
+          model: "opus"
+          max-turns: "50"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,27 +80,8 @@ scope:
 **Version rules** — pre-1.0 packages (`0.x.y`) bump patch for any change.
 Post-1.0 packages use semver: breaking=major, feat=minor, fix/refactor=patch.
 
-**Finding changed packages:**
-
-```sh
-# For each package, compare latest tag to HEAD:
-latest=$(git tag --sort=-creatordate --list "${prefix}@v*" | head -1)
-git log "${latest}..HEAD" --oneline -- "${directory}"
-```
-
-**Release steps:**
-
-1. Commit all pending code changes first (version bumps go in a separate commit)
-2. Bump `version` in each changed `package.json`
-3. Update cross-workspace deps when bumping a major version (e.g. pathway's dep
-   on libskill: `^3.0.0` → `^4.0.0`)
-4. Run `npm install --package-lock-only` to sync `package-lock.json`
-5. Run `npm run check:fix` to ensure formatting and lint pass
-6. Commit: `chore({pkg}): bump to {version}` (or batch:
-   `chore: bump versions for release`)
-7. Tag at the final commit: `git tag {pkg}@v{version}`
-8. Push commits, then push each tag individually (not `--tags`)
-9. Verify each workflow: `gh run list --limit <n>`
+The release engineer agent handles version bumps, tagging, and publishing. See
+`.claude/skills/release-review` for the full release procedure.
 
 ## Quality Commands
 
@@ -160,3 +141,5 @@ restating the rules. Update the canonical location only.
 | GitHub Actions SHA pinning           | CONTRIBUTING.md § Security           |
 | Supply chain & app security          | `.claude/skills/security-audit`      |
 | Dependabot triage process            | `.claude/skills/dependabot-triage`   |
+| Release readiness (PR rebase/CI)     | `.claude/skills/release-readiness`   |
+| Release process (versioning/tags)    | `.claude/skills/release-review`      |


### PR DESCRIPTION
Add a release engineer agent (parallel to the security engineer) that runs
in two GitHub Actions workflows:

- release-readiness: daily check that rebases open PRs on main, resolves
  mechanical merge conflicts (lock file, generated files, formatting,
  adjacent independent edits), fixes trivial CI failures, and reports
  status — substantive conflicts requiring judgement are left to the
  PR author
- release-review: weekly assessment of main branch to cut new versions,
  bump package.json files, tag releases, and verify publish workflows

Move the detailed release procedure from CONTRIBUTING.md into the
release-review skill as the canonical source, keeping the tag prefix
table and version rules in CONTRIBUTING.md for reference.

https://claude.ai/code/session_01HEPoqEeAKA8SF6WDonxjyy