### PR TITLE
fix(ci): add codegen step to release agent workflows

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -29,6 +29,7 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npx fit-codegen --all
 
       - name: Check PR Readiness
         uses: ./.github/actions/claude

--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -29,6 +29,7 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npx fit-codegen --all
 
       - name: Review and Release
         uses: ./.github/actions/claude


### PR DESCRIPTION
## Summary

- Adds `npx fit-codegen --all` step to `release-review.yml` and `release-readiness.yml` workflows
- Both workflows run agents that execute `npm run check` (including `npm test`), but lacked the codegen step that `check-test.yml` uses to generate protobuf types
- Without this step, 40 tests fail every run due to missing `libraries/libtype/generated/types/types.js`, forcing the agent to waste tokens diagnosing and working around environment-specific failures

## Evidence

From release-review run [23736402180](https://github.com/forwardimpact/monorepo/actions/runs/23736402180):
- Agent ran `npm run check` → 40 test failures (1346 pass, 40 fail)
- Agent correctly diagnosed as missing generated protobuf types
- Agent spent 4+ tool calls investigating and working around the issue
- All failures were in packages not being released (libconfig, librpc, libtelemetry, etc.)

## Test plan

- [ ] Verify `release-review.yml` includes `npx fit-codegen --all` before the claude action step
- [ ] Verify `release-readiness.yml` includes the same step
- [ ] Confirm pattern matches `check-test.yml` line 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)