### PR TITLE
fix(product-backlog): add merge verification step

### DIFF
--- a/.claude/skills/product-backlog/SKILL.md
+++ b/.claude/skills/product-backlog/SKILL.md
@@ -151,6 +151,16 @@ gh pr comment <number> --body "Product backlog triage: all gates pass — type i
 gh pr merge <number> --squash --auto
 ```
 
+After merging, verify the PR state changed:
+
+```sh
+gh pr view <number> --json state --jq '.state'
+```
+
+The result should be `MERGED`. If the state is still `OPEN` (e.g. auto-merge was
+enabled but hasn't triggered yet), note this in the summary rather than
+reporting the PR as merged.
+
 ### Step 7: Report Summary
 
 After processing all PRs, produce a summary table:


### PR DESCRIPTION
## Summary

- Adds a post-merge verification step to the product-backlog skill (Step 6)
- After `gh pr merge --squash --auto`, the skill now instructs the agent to verify the PR state changed to `MERGED`
- If auto-merge was enabled but hasn't triggered yet, the agent reports the actual state rather than assuming success

**Root cause**: Trace analysis of product-backlog run [23749189609](https://github.com/forwardimpact/monorepo/actions/runs/23749189609) showed the agent received empty output from `gh pr merge --auto` but reported the PR as merged without verification. The `--auto` flag enables auto-merge which may not execute immediately.

## Test plan

- [ ] Verify SKILL.md renders correctly and the new verification step is clear
- [ ] Next product-backlog run should include a `gh pr view --json state` call after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)