### PR TITLE
spec(ci): add shared memory for CI agents via GitHub wiki

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -241,3 +241,26 @@ You perform **analysis and improvement only**. You do not:
 - Never speculate about root causes without trace evidence
 - Follow the repository's commit conventions (`type(scope): subject`)
 - Run `npm run check` before committing
+
+## Memory
+
+You have access to a shared memory directory that persists across runs and is
+shared with all CI agents. **Always write to memory at the end of your run.**
+
+Record:
+
+- **Actions taken** — What you did this run (traces analyzed, fixes applied,
+  specs written)
+- **Decisions and rationale** — Why you chose a particular action, especially
+  when alternatives existed
+- **Observations for teammates** — Patterns, recurring issues, or context that
+  other agents would benefit from knowing
+- **Blockers and deferred work** — Issues you could not resolve and why, so the
+  next run (or another agent) can pick them up
+
+Additionally record:
+
+- Which workflow run and trace you analyzed (workflow name, run ID, date)
+- Key findings and their categories (fix, spec, observation)
+- Patterns emerging across multiple coaching cycles
+- Trust audit results when analyzing product-backlog traces

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -81,3 +81,26 @@ You do not make code changes.
 - Never force-push to `main`
 - Always comment with rationale before merging or skipping a PR
 - Follow the repository's commit conventions (`type(scope): subject`)
+
+## Memory
+
+You have access to a shared memory directory that persists across runs and is
+shared with all CI agents. **Always write to memory at the end of your run.**
+
+Record:
+
+- **Actions taken** — What you did this run (PRs triaged, merged, skipped,
+  commented on)
+- **Decisions and rationale** — Why you chose a particular action, especially
+  when alternatives existed
+- **Observations for teammates** — Patterns, recurring issues, or context that
+  other agents would benefit from knowing
+- **Blockers and deferred work** — Issues you could not resolve and why, so the
+  next run (or another agent) can pick them up
+
+Additionally record:
+
+- PRs triaged with their types, authors, and outcomes
+- Contributor trust decisions — who was verified and the result
+- PR types that were skipped for human review
+- Spec PRs and their review-spec assessment results

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -91,3 +91,25 @@ not make code-level decisions.
 - Always push tags individually — never use `git push --tags`
 - Follow the tag prefix mapping and version rules from CONTRIBUTING.md
 - Release packages in dependency order when multiple packages change together
+
+## Memory
+
+You have access to a shared memory directory that persists across runs and is
+shared with all CI agents. **Always write to memory at the end of your run.**
+
+Record:
+
+- **Actions taken** — What you did this run (branches rebased, PRs fixed,
+  releases cut, main branch CI repairs)
+- **Decisions and rationale** — Why you chose a particular action, especially
+  when alternatives existed
+- **Observations for teammates** — Patterns, recurring issues, or context that
+  other agents would benefit from knowing
+- **Blockers and deferred work** — Issues you could not resolve and why, so the
+  next run (or another agent) can pick them up
+
+Additionally record:
+
+- Release versions cut and which packages were included
+- PRs that needed manual conflict resolution (so the improvement coach knows)
+- Main branch CI state — whether it was green or required repair

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -99,3 +99,25 @@ Never branch from a fix branch to create a spec branch or vice versa.
 - Always create branches from `main` — never from another audit branch
 - Always explain the rationale for closing a PR
 - Never skip spec PRs — if findings need specs, file them
+
+## Memory
+
+You have access to a shared memory directory that persists across runs and is
+shared with all CI agents. **Always write to memory at the end of your run.**
+
+Record:
+
+- **Actions taken** — What you did this run (PRs merged, fixes applied, specs
+  written, audits completed)
+- **Decisions and rationale** — Why you chose a particular action, especially
+  when alternatives existed
+- **Observations for teammates** — Patterns, recurring issues, or context that
+  other agents would benefit from knowing
+- **Blockers and deferred work** — Issues you could not resolve and why, so the
+  next run (or another agent) can pick them up
+
+Additionally record:
+
+- CVEs evaluated and their severity/status
+- Policy violations found and whether they were fixed or spec'd
+- Dependabot PRs processed and their outcomes (merged, fixed, closed)

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Artifact name for the trace
     required: false
     default: "claude-trace"
+  wiki:
+    description: Clone the repository wiki for shared agent memory
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -42,6 +46,42 @@ runs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Clone wiki for shared memory
+      id: clone-wiki
+      if: inputs.wiki == 'true'
+      shell: bash
+      run: |
+        WIKI_DIR="/tmp/wiki"
+        REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.wiki.git"
+
+        # Clone wiki (initialize if it doesn't exist yet)
+        if ! git clone "https://x-access-token:${GH_TOKEN}@${REPO_URL#https://}" "$WIKI_DIR" 2>/dev/null; then
+          mkdir -p "$WIKI_DIR"
+          git -C "$WIKI_DIR" init
+          echo "# Agent Memory" > "$WIKI_DIR/Home.md"
+          git -C "$WIKI_DIR" add .
+          git -C "$WIKI_DIR" commit -m "Initialize wiki for agent memory"
+        fi
+
+        echo "wiki-dir=$WIKI_DIR" >> "$GITHUB_OUTPUT"
+
+    - name: Configure shared memory directory
+      if: inputs.wiki == 'true'
+      shell: bash
+      run: |
+        WIKI_DIR="${{ steps.clone-wiki.outputs.wiki-dir }}"
+        SETTINGS_FILE=".claude/settings.json"
+        if [ -f "$SETTINGS_FILE" ]; then
+          node -e "
+            const fs = require('fs');
+            const s = JSON.parse(fs.readFileSync('$SETTINGS_FILE', 'utf8'));
+            s.autoMemoryDirectory = '$WIKI_DIR';
+            fs.writeFileSync('$SETTINGS_FILE', JSON.stringify(s, null, 2) + '\n');
+          "
+        else
+          echo '{"autoMemoryDirectory":"'"$WIKI_DIR"'"}' > "$SETTINGS_FILE"
+        fi
 
     - name: Run Claude Code
       id: run
@@ -86,3 +126,23 @@ runs:
       with:
         name: ${{ inputs.trace-name }}
         path: ${{ steps.run.outputs.trace-dir }}
+
+    - name: Push wiki changes
+      if: always() && inputs.wiki == 'true'
+      shell: bash
+      run: |
+        WIKI_DIR="${{ steps.clone-wiki.outputs.wiki-dir }}"
+        cd "$WIKI_DIR"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        # Stage all changes in the wiki
+        git add -A
+        if git diff --cached --quiet; then
+          echo "No wiki changes to push"
+          exit 0
+        fi
+
+        AGENT_NAME="${GITHUB_WORKFLOW// /-}"
+        git commit -m "memory($AGENT_NAME): update from run $GITHUB_RUN_NUMBER"
+        git push || echo "Wiki push failed (non-fatal)"

--- a/CONTINUOUS_IMPROVEMENT.md
+++ b/CONTINUOUS_IMPROVEMENT.md
@@ -226,6 +226,30 @@ prohibited.
 **Least privilege.** The security-audit workflow runs with `contents: read`
 only. Workflows that need to push use `contents: write` with a scoped token.
 
+## Shared Memory
+
+Agents share a persistent memory backed by the repository's **GitHub wiki**. The
+wiki is a separate git repository (`{repo}.wiki.git`) that the composite action
+clones before each run and pushes after.
+
+The composite action's `wiki` input (default `true`) controls this behaviour:
+
+1. **Before Claude runs** — clone the wiki to `/tmp/wiki` (or initialize it on
+   first use) and set `autoMemoryDirectory` in `.claude/settings.json` to point
+   there.
+2. **During the run** — Claude Code reads existing memory and writes new entries
+   via its auto-memory mechanism.
+3. **After Claude finishes** — commit and push any wiki changes. The push is
+   non-fatal so a failure does not break the workflow.
+
+Every agent is instructed to write to memory at the end of each run, recording
+actions taken, decisions, observations for teammates, and deferred work. This
+gives each subsequent run — by the same agent or a different one — context about
+what has already happened and what still needs attention.
+
+To disable wiki memory for a specific workflow, pass `wiki: "false"` to the
+composite action.
+
 ## Accountability
 
 The **improvement coach** is responsible for auditing the product manager's

--- a/specs/160-ci-agent-shared-memory/plan.md
+++ b/specs/160-ci-agent-shared-memory/plan.md
@@ -1,0 +1,136 @@
+# 160: Implementation Plan
+
+## Approach
+
+Modify the shared composite action to clone and push the GitHub wiki, configure
+Claude Code's `autoMemoryDirectory`, and update all agent profiles with
+memory-writing instructions. No workflow files change — they inherit the new
+`wiki: "true"` default automatically.
+
+## Modified Files
+
+### `.github/actions/claude/action.yml`
+
+Add a new input:
+
+```yaml
+wiki:
+  description: Clone the repository wiki for shared agent memory
+  required: false
+  default: "true"
+```
+
+Add three new steps around the existing "Run Claude Code" step:
+
+**Before Claude runs — Clone wiki:**
+
+```yaml
+- name: Clone wiki for shared memory
+  id: clone-wiki
+  if: inputs.wiki == 'true'
+  shell: bash
+  run: |
+    WIKI_DIR="/tmp/wiki"
+    REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.wiki.git"
+
+    if ! git clone "https://x-access-token:${GH_TOKEN}@${REPO_URL#https://}" "$WIKI_DIR" 2>/dev/null; then
+      mkdir -p "$WIKI_DIR"
+      git -C "$WIKI_DIR" init
+      echo "# Agent Memory" > "$WIKI_DIR/Home.md"
+      git -C "$WIKI_DIR" add .
+      git -C "$WIKI_DIR" commit -m "Initialize wiki for agent memory"
+    fi
+
+    echo "wiki-dir=$WIKI_DIR" >> "$GITHUB_OUTPUT"
+```
+
+**Before Claude runs — Configure settings:**
+
+```yaml
+- name: Configure shared memory directory
+  if: inputs.wiki == 'true'
+  shell: bash
+  run: |
+    WIKI_DIR="${{ steps.clone-wiki.outputs.wiki-dir }}"
+    SETTINGS_FILE=".claude/settings.json"
+    if [ -f "$SETTINGS_FILE" ]; then
+      node -e "
+        const fs = require('fs');
+        const s = JSON.parse(fs.readFileSync('$SETTINGS_FILE', 'utf8'));
+        s.autoMemoryDirectory = '$WIKI_DIR';
+        fs.writeFileSync('$SETTINGS_FILE', JSON.stringify(s, null, 2) + '\n');
+      "
+    else
+      echo '{"autoMemoryDirectory":"'"$WIKI_DIR"'"}' > "$SETTINGS_FILE"
+    fi
+```
+
+**After trace upload — Push wiki:**
+
+```yaml
+- name: Push wiki changes
+  if: always() && inputs.wiki == 'true'
+  shell: bash
+  run: |
+    WIKI_DIR="${{ steps.clone-wiki.outputs.wiki-dir }}"
+    cd "$WIKI_DIR"
+    git config user.name "github-actions[bot]"
+    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    git add -A
+    if git diff --cached --quiet; then
+      echo "No wiki changes to push"
+      exit 0
+    fi
+    AGENT_NAME="${GITHUB_WORKFLOW// /-}"
+    git commit -m "memory($AGENT_NAME): update from run $GITHUB_RUN_NUMBER"
+    git push || echo "Wiki push failed (non-fatal)"
+```
+
+### `.claude/agents/*.md` (all four agents)
+
+Add a `## Memory` section at the end of each agent profile with common
+instructions plus agent-specific guidance.
+
+**Common block (all agents):**
+
+```markdown
+## Memory
+
+You have access to a shared memory directory that persists across runs and is
+shared with all CI agents. **Always write to memory at the end of your run.**
+
+Record:
+- **Actions taken** — What you did this run (PRs merged, branches rebased,
+  releases cut, findings reported)
+- **Decisions and rationale** — Why you chose a particular action, especially
+  when alternatives existed
+- **Observations for teammates** — Patterns, recurring issues, or context that
+  other agents would benefit from knowing
+- **Blockers and deferred work** — Issues you could not resolve and why, so the
+  next run (or another agent) can pick them up
+```
+
+**Agent-specific additions:**
+
+- **release-engineer**: Release versions cut, PRs needing manual conflict
+  resolution, main branch CI state
+- **security-engineer**: CVEs evaluated, policy violations found, Dependabot PRs
+  processed and their outcomes
+- **improvement-coach**: Traces analyzed, key findings, patterns across coaching
+  cycles
+- **product-manager**: PRs triaged, contributor trust decisions, merge outcomes,
+  PR types skipped
+
+### `CONTINUOUS_IMPROVEMENT.md`
+
+Add a `## Shared Memory` section after `## Design Principles` describing the
+wiki-based memory architecture and how agents use it.
+
+## Verification
+
+1. Trigger any workflow via `workflow_dispatch` — verify wiki clone, memory
+   writes, and wiki push all succeed
+2. Run two workflows sequentially — verify the second agent sees memory from the
+   first
+3. Verify `wiki: "false"` skips all wiki steps
+4. Verify push failure is non-fatal (workflow still succeeds)

--- a/specs/160-ci-agent-shared-memory/spec.md
+++ b/specs/160-ci-agent-shared-memory/spec.md
@@ -1,0 +1,110 @@
+# 160: CI Agent Shared Memory via GitHub Wiki
+
+## Problem
+
+The CI agents (release-engineer, security-engineer, improvement-coach,
+product-manager) are stateless — each workflow run starts from scratch with no
+knowledge of what happened in previous runs or what teammate agents discovered.
+This limits their effectiveness: agents repeat investigations, miss patterns
+across runs, and cannot build on each other's findings.
+
+## Why
+
+- **Redundant work** — Agents re-investigate the same PRs, dependencies, and CI
+  failures that previous runs already handled.
+- **Lost institutional knowledge** — Patterns discovered during trace analysis,
+  security findings, and release decisions evaporate after each run.
+- **No team coordination** — The security engineer cannot tell the release
+  engineer about a problematic dependency; the improvement coach cannot leave
+  notes for future coaching cycles.
+- **GitHub wiki is the right medium** — It's a git repo (versioned, auditable),
+  lives outside the workspace (no contamination), requires no additional
+  infrastructure, and is already available on every GitHub repository.
+
+## What
+
+Three changes:
+
+1. **Enhanced composite action** (`.github/actions/claude/action.yml`) — Add a
+   `wiki` input parameter (boolean, default `true`). When enabled, clone the
+   repo's GitHub wiki before running Claude, configure `autoMemoryDirectory` in
+   a project-level settings override, and commit/push wiki changes after Claude
+   finishes.
+
+2. **Agent profile updates** (`.claude/agents/*.md`) — Add memory-writing
+   instructions to all four agent profiles so they actively record observations,
+   decisions, and status in memory files.
+
+3. **Documentation update** (`CONTINUOUS_IMPROVEMENT.md`) — Add a section
+   describing the shared memory architecture.
+
+## Scope
+
+### In scope
+
+- New `wiki` input on `.github/actions/claude/action.yml`
+- Wiki clone/push steps in the composite action
+- Settings override for `autoMemoryDirectory`
+- Memory-writing instructions in all 4 agent profiles
+- Documentation in `CONTINUOUS_IMPROVEMENT.md`
+
+### Out of scope
+
+- Changes to any workflow files (they inherit the new default automatically)
+- Changes to skills
+- Wiki page structure beyond what autoMemory creates
+- Custom memory tools or scripts
+
+## Design
+
+### How it works
+
+```
+Workflow run starts
+  │
+  ├─ Clone {repo}.wiki.git to /tmp/wiki
+  │    └─ Initialize if wiki doesn't exist yet
+  │
+  ├─ Merge autoMemoryDirectory into .claude/settings.json
+  │    └─ Points to /tmp/wiki
+  │
+  ├─ Run Claude Code (agent reads/writes memory via autoMemoryDirectory)
+  │
+  └─ Commit and push /tmp/wiki changes
+       └─ Non-fatal — push failure does not fail the workflow
+```
+
+All agents share one wiki. Each agent writes memory files that persist across
+runs and are visible to every other agent. Claude Code's `autoMemoryDirectory`
+setting tells it where to read and write these files automatically.
+
+### Wiki push permissions
+
+The wiki clone and push uses `GH_TOKEN` (the `CLAUDE_GH_TOKEN` secret) which
+already has `contents: write` scope on all workflows except `security-audit`.
+For `security-audit` (which has `contents: read`), the GH_TOKEN as a PAT should
+still work for wiki operations since the wiki is a separate repository. If not,
+the `wiki` parameter can be set to `false` for that workflow.
+
+### What agents record
+
+Each agent writes to memory at the end of every run:
+
+- **Actions taken** — What was done this run
+- **Decisions and rationale** — Why a particular action was chosen
+- **Observations for teammates** — Context other agents would benefit from
+- **Blockers and deferred work** — Issues that could not be resolved
+
+Plus agent-specific context: release versions cut, CVEs evaluated, traces
+analyzed, PRs triaged, and contributor trust decisions.
+
+## Files to modify
+
+| File                                  | Change                                       |
+| ------------------------------------- | -------------------------------------------- |
+| `.github/actions/claude/action.yml`   | Add `wiki` input, clone/configure/push steps |
+| `.claude/agents/release-engineer.md`  | Add Memory section                           |
+| `.claude/agents/security-engineer.md` | Add Memory section                           |
+| `.claude/agents/improvement-coach.md` | Add Memory section                           |
+| `.claude/agents/product-manager.md`   | Add Memory section                           |
+| `CONTINUOUS_IMPROVEMENT.md`           | Add Shared Memory section                    |


### PR DESCRIPTION
Give CI agents persistent, shared memory by cloning the repository's
GitHub wiki before each run and pushing changes after. This lets agents
remember what they and their teammates did across invocations.

- Add wiki input (default true) to the claude composite action
- Clone wiki to /tmp/wiki and configure autoMemoryDirectory in settings
- Push wiki changes after Claude finishes (non-fatal on failure)
- Add Memory section to all 4 agent profiles with recording instructions
- Document shared memory architecture in CONTINUOUS_IMPROVEMENT.md
- Add spec and plan in specs/160-ci-agent-shared-memory/

https://claude.ai/code/session_01Lgs7T58c9LxvyMRtJWm3xT