### PR TITLE
fix(eval): stream Claude output via fit-eval tee instead of post-processing

### DIFF
--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -109,9 +109,7 @@ runs:
             --max-turns "$MAX_TURNS" \
             --allowedTools "$TOOLS" \
             $AGENT_FLAG \
-            > "$TRACE_DIR/trace.ndjson"
-
-          npx fit-eval output --format=text < "$TRACE_DIR/trace.ndjson"
+            | npx fit-eval tee "$TRACE_DIR/trace.ndjson"
         else
           echo "$PROMPT" | claude --print \
             --model "$MODEL" \


### PR DESCRIPTION
Pipe Claude's stream-json output through `fit-eval tee` so text content
streams to stdout in real-time during the run, rather than capturing to a
file and processing after completion. The tee command saves the raw NDJSON
to the trace file simultaneously.

https://claude.ai/code/session_01GjfDQai9aAEceQSDNhYpjP