### PR TITLE
fix(ci): renumber spec 160 collision and fix wiki init git identity

### DIFF
--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -59,6 +59,8 @@ runs:
         if ! git clone "https://x-access-token:${GH_TOKEN}@${REPO_URL#https://}" "$WIKI_DIR" 2>/dev/null; then
           mkdir -p "$WIKI_DIR"
           git -C "$WIKI_DIR" init
+          git -C "$WIKI_DIR" config user.name "github-actions[bot]"
+          git -C "$WIKI_DIR" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           echo "# Agent Memory" > "$WIKI_DIR/Home.md"
           git -C "$WIKI_DIR" add .
           git -C "$WIKI_DIR" commit -m "Initialize wiki for agent memory"
@@ -119,7 +121,8 @@ runs:
         fi
 
     - name: Upload trace artifact
-      if: always() && inputs.trace == 'true'
+      if:
+        always() && inputs.trace == 'true' && steps.run.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ inputs.trace-name }}

--- a/specs/190-ci-agent-shared-memory/plan.md
+++ b/specs/190-ci-agent-shared-memory/plan.md
@@ -1,4 +1,4 @@
-# 160: Implementation Plan
+# 190: Implementation Plan
 
 ## Approach
 

--- a/specs/190-ci-agent-shared-memory/spec.md
+++ b/specs/190-ci-agent-shared-memory/spec.md
@@ -1,4 +1,4 @@
-# 160: CI Agent Shared Memory via GitHub Wiki
+# 190: CI Agent Shared Memory via GitHub Wiki
 
 ## Problem
 

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -34,3 +34,4 @@
 160	done
 170	done
 180	done
+190	done


### PR DESCRIPTION
Spec 160-ci-agent-shared-memory collided with 160-seo-llm-optimization.
Renumber the CI agent shared memory spec to 190 and update STATUS.

Fix the CI failure from run 23766576065: the wiki init fallback ran
`git commit` in /tmp/wiki without configuring user.name/email, causing
exit code 128 ("Author identity unknown"). Add git config for the
initialized wiki repo. Also guard the upload-artifact step so it skips
when trace-dir is empty (Claude never ran).

https://claude.ai/code/session_01Fbbn6gjA3vqZhzNLJ4fKRk