### PR TITLE
ci(test): run unit and e2e test jobs in parallel

### DIFF
--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -26,7 +26,6 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4


### PR DESCRIPTION
Remove `needs: test` dependency from the e2e job so both jobs start
immediately. All check-* workflows now run their jobs in parallel.

https://claude.ai/code/session_01TE9yK9xkThX7R5eooRsoJh