### PR TITLE
fix(ci): add remote origin to wiki fallback init so push succeeds

### DIFF
--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -55,10 +55,13 @@ runs:
         WIKI_DIR="/tmp/wiki"
         REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.wiki.git"
 
+        WIKI_REMOTE="https://x-access-token:${GH_TOKEN}@${REPO_URL#https://}"
+
         # Clone wiki (initialize if it doesn't exist yet)
-        if ! git clone "https://x-access-token:${GH_TOKEN}@${REPO_URL#https://}" "$WIKI_DIR" 2>/dev/null; then
+        if ! git clone "$WIKI_REMOTE" "$WIKI_DIR" 2>/dev/null; then
           mkdir -p "$WIKI_DIR"
           git -C "$WIKI_DIR" init
+          git -C "$WIKI_DIR" remote add origin "$WIKI_REMOTE"
           git -C "$WIKI_DIR" config user.name "github-actions[bot]"
           git -C "$WIKI_DIR" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           echo "# Agent Memory" > "$WIKI_DIR/Home.md"
@@ -137,13 +140,26 @@ runs:
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-        # Stage all changes in the wiki
+        # Stage and commit any uncommitted changes in the wiki
         git add -A
-        if git diff --cached --quiet; then
-          echo "No wiki changes to push"
+        if ! git diff --cached --quiet; then
+          AGENT_NAME="${GITHUB_WORKFLOW// /-}"
+          git commit -m "memory($AGENT_NAME): update from run $GITHUB_RUN_NUMBER"
+        fi
+
+        # Push all commits (including any the agent made during its run)
+        if ! git remote get-url origin >/dev/null 2>&1; then
+          echo "No wiki remote configured, skipping push"
           exit 0
         fi
 
-        AGENT_NAME="${GITHUB_WORKFLOW// /-}"
-        git commit -m "memory($AGENT_NAME): update from run $GITHUB_RUN_NUMBER"
-        git push || echo "Wiki push failed (non-fatal)"
+        # Check if there are commits to push (handles both cloned and init'd repos)
+        if git rev-parse --verify origin/master >/dev/null 2>&1; then
+          # Cloned repo: check for unpushed commits
+          if [ -z "$(git log origin/master..HEAD --oneline 2>/dev/null)" ]; then
+            echo "No wiki changes to push"
+            exit 0
+          fi
+        fi
+
+        git push -u origin HEAD:master || echo "Wiki push failed (non-fatal)"


### PR DESCRIPTION
When the wiki clone fails (e.g. wiki not yet initialized on GitHub),
the fallback creates a local repo with git init but never adds a remote.
This causes all subsequent wiki pushes to fail silently. Also fix the
push step to handle commits the agent makes during its run, not just
uncommitted changes.

https://claude.ai/code/session_017QbyGAVRvJwTQhuP6XTXjY