### PR TITLE
docs(spec): clean up plan 200, advance to planned

### DIFF
--- a/specs/200-github-app-auth-migration/plan.md
+++ b/specs/200-github-app-auth-migration/plan.md
@@ -7,8 +7,22 @@ short-lived installation tokens per workflow run. Use the official
 `actions/create-github-app-token` action (already permitted under the
 CONTRIBUTING.md policy — it is a first-party `actions/*` action).
 
-The migration has three phases: create the App, update the composite action, and
-update documentation.
+Token generation happens at the workflow level, not inside the composite action.
+The `actions/checkout` step runs before the composite action and needs the token
+to clone the repository (so pushes trigger downstream workflows). Generating the
+token once at the workflow level and passing it to both `actions/checkout` and
+the composite action via `GH_TOKEN` is simpler than splitting responsibility.
+
+The migration has three phases: create the App, update the workflows and
+composite action, and update documentation.
+
+## Prerequisites
+
+Before implementation begins:
+
+1. Look up the current latest stable release SHA for
+   `actions/create-github-app-token` (v1) and record it. All workflow files must
+   pin to this SHA per CONTRIBUTING.md § Security.
 
 ## Phase 1: Create the GitHub App
 
@@ -70,29 +84,21 @@ composite action.
 
 ### 2.1 Composite Action (`.github/actions/claude/action.yml`)
 
-Add a token-generation step at the beginning and update the git identity.
+The composite action receives the App token from the calling workflow via the
+`GH_TOKEN` environment variable (already used for wiki clone). No
+token-generation step is added to the composite action.
 
-**New inputs:**
+**New inputs** for git identity:
 
 ```yaml
 inputs:
+  app-slug:
+    description: GitHub App slug for git identity
+    required: false
+    default: forward-impact-ci
   app-id:
-    description: GitHub App ID for authentication
+    description: GitHub App ID for git identity email
     required: true
-  app-private-key:
-    description: GitHub App private key (PEM)
-    required: true
-```
-
-**New step** (before "Configure Git identity"):
-
-```yaml
-- name: Generate installation token
-  id: app-token
-  uses: actions/create-github-app-token@<SHA> # v1
-  with:
-    app-id: ${{ inputs.app-id }}
-    private-key: ${{ inputs.app-private-key }}
 ```
 
 **Updated step** — "Configure Git identity":
@@ -101,65 +107,22 @@ inputs:
 - name: Configure Git identity
   shell: bash
   env:
-    APP_SLUG: forward-impact-ci
+    APP_SLUG: ${{ inputs.app-slug }}
     APP_ID: ${{ inputs.app-id }}
   run: |
     git config user.name "${APP_SLUG}[bot]"
     git config user.email "${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 ```
 
-**Token propagation** — The generated token must replace `GH_TOKEN` everywhere
-it is used:
-
-1. **Wiki clone URL** (line 58): Change `${GH_TOKEN}` to use the generated token
-   from `${{ steps.app-token.outputs.token }}`. Since composite actions cannot
-   set environment variables for other steps, pass it as an input or expose it
-   as a step output.
-2. **Claude Code `GH_TOKEN` env var**: The composite action does not set this
-   directly — it is set by the calling workflow. The calling workflows will pass
-   the App token instead (see §2.2).
-
-**Expose the token as output:**
-
-```yaml
-outputs:
-  token:
-    description: Generated installation token for use in subsequent steps
-    value: ${{ steps.app-token.outputs.token }}
-```
-
-However, since the composite action both needs the token internally (wiki clone)
-and the calling workflow needs it for the `GH_TOKEN` env var, a cleaner approach
-is:
-
-- The composite action generates the token and uses it for wiki operations.
-- The composite action exposes it so the caller can reference it, OR the caller
-  generates its own token separately.
-
-**Recommended design**: Generate the token in the composite action. Use it
-internally for wiki and git operations. The calling workflow passes `app-id` and
-`app-private-key` as inputs, and the composite action handles everything — no
-`GH_TOKEN` env var needed from the workflow level.
-
-To accomplish this, the composite action should set `GH_TOKEN` itself:
-
-```yaml
-- name: Run Claude Code
-  shell: bash
-  env:
-    GH_TOKEN: ${{ steps.app-token.outputs.token }}
-    PROMPT: ${{ inputs.prompt }}
-    # ... rest unchanged
-```
-
-This keeps the token lifecycle entirely within the composite action.
+The `app-slug` input defaults to `forward-impact-ci` so the pre-built App works
+out of the box. Downstream installations with their own App override it.
 
 ### 2.2 Workflow Files
 
 Update all six agent workflows to replace `secrets.CLAUDE_GH_TOKEN` with the App
 credentials.
 
-**Before** (same pattern in all six):
+**Before** (same pattern in five of six workflows):
 
 ```yaml
 steps:
@@ -184,7 +147,7 @@ steps:
 steps:
   - name: Generate installation token
     id: app-token
-    uses: actions/create-github-app-token@<SHA> # v1
+    uses: actions/create-github-app-token@<resolved-sha> # v1
     with:
       app-id: ${{ secrets.CI_APP_ID }}
       private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
@@ -201,67 +164,38 @@ steps:
       GH_TOKEN: ${{ steps.app-token.outputs.token }}
       CLAUDE_CODE_USE_BEDROCK: "0"
     with:
+      app-id: ${{ secrets.CI_APP_ID }}
       prompt: "..."
 ```
 
-**Why generate the token in the workflow rather than the composite action?** The
-`actions/checkout` step runs before the composite action and needs the token to
-clone the repository (so pushes trigger downstream workflows). Generating the
-token at the workflow level and passing it through is simpler than splitting the
-composite action.
-
-This supersedes the "recommended design" in §2.1 — generate the token at the
-workflow level, pass it to both `actions/checkout` and the composite action via
-`GH_TOKEN`. The composite action's internal wiki operations already read
-`GH_TOKEN` from the environment, so no composite action input changes are needed
-for the token itself.
-
-**Composite action changes (revised):**
-
-- Update git identity to use App bot name/email (via new `app-id` and `app-slug`
-  inputs, or hardcoded if the App slug is stable).
-- Remove: no new token-generation step needed in the composite action.
-
-**Files to update:**
-
-| File                                      | Change                                   |
-| ----------------------------------------- | ---------------------------------------- |
-| `.github/workflows/dependabot-triage.yml` | Replace `CLAUDE_GH_TOKEN` with App token |
-| `.github/workflows/product-backlog.yml`   | Replace `CLAUDE_GH_TOKEN` with App token |
-| `.github/workflows/release-readiness.yml` | Replace `CLAUDE_GH_TOKEN` with App token |
-| `.github/workflows/release-review.yml`    | Replace `CLAUDE_GH_TOKEN` with App token |
-| `.github/workflows/improvement-coach.yml` | Replace `CLAUDE_GH_TOKEN` with App token |
-| `.github/workflows/security-audit.yml`    | Replace `CLAUDE_GH_TOKEN` with App token |
-| `.github/actions/claude/action.yml`       | Update git identity to App bot           |
-
-### 2.3 SHA Pinning
-
-Per CONTRIBUTING.md § Security, `actions/create-github-app-token` must be pinned
-to a full SHA hash with a version comment:
-
-```yaml
-uses: actions/create-github-app-token@<full-sha> # v1
-```
-
-Look up the current latest stable release SHA before implementing.
-
-### 2.4 Security Audit Workflow
+### 2.3 Security Audit Workflow (different pattern)
 
 The `security-audit` workflow currently uses `contents: read` and does not pass
 a token to `actions/checkout` (it uses the default `GITHUB_TOKEN`). It still
 needs `GH_TOKEN` for Claude Code to call the GitHub API.
 
-Two options:
+For this workflow: generate an App token for API access (`GH_TOKEN`), but keep
+`actions/checkout` using the default `GITHUB_TOKEN`. The workflow's
+`permissions: contents: read` block constrains the default token, and the App
+token is separately scoped for API calls only.
 
-- **Option A**: Generate an App token for API access, keep `actions/checkout`
-  using the default token. The workflow's `permissions: contents: read` block
-  still constrains the `GITHUB_TOKEN`, and the App token is separately scoped.
-- **Option B**: Generate the App token and use it everywhere, relying on the
-  App's own permission scoping.
+### 2.4 SHA Pinning
 
-**Recommended: Option A** — consistent with the other workflows (App token for
-`GH_TOKEN`), and the `actions/checkout` default token is sufficient for
-read-only clone.
+Per CONTRIBUTING.md § Security, `actions/create-github-app-token` must be pinned
+to a full SHA hash with a version comment. The SHA is resolved during the
+Prerequisites step and used consistently across all six workflow files.
+
+### 2.5 Files to Update
+
+| File                                      | Change                                                          |
+| ----------------------------------------- | --------------------------------------------------------------- |
+| `.github/workflows/dependabot-triage.yml` | Replace `CLAUDE_GH_TOKEN` with App token (standard pattern)     |
+| `.github/workflows/product-backlog.yml`   | Replace `CLAUDE_GH_TOKEN` with App token (standard pattern)     |
+| `.github/workflows/release-readiness.yml` | Replace `CLAUDE_GH_TOKEN` with App token (standard pattern)     |
+| `.github/workflows/release-review.yml`    | Replace `CLAUDE_GH_TOKEN` with App token (standard pattern)     |
+| `.github/workflows/improvement-coach.yml` | Replace `CLAUDE_GH_TOKEN` with App token (standard pattern)     |
+| `.github/workflows/security-audit.yml`    | App token for `GH_TOKEN` only; `actions/checkout` keeps default |
+| `.github/actions/claude/action.yml`       | Add `app-slug`/`app-id` inputs; update git identity to App bot  |
 
 ## Phase 3: Documentation
 
@@ -283,102 +217,52 @@ CONTRIBUTING.md.
 ### 3.3 Operations Documentation
 
 Update `website/docs/internals/operations/index.md` (or create a sub-page) with
-setup instructions for downstream installations:
+setup instructions for downstream installations covering two options:
 
-**Option 1 — Use the pre-built Forward Impact CI App (recommended):**
+**Option 1 — Forward Impact CI App (for repositories within the Forward Impact
+organization and trusted forks):**
 
-1. Go to `https://github.com/apps/forward-impact-ci` (public App page).
-2. Click **Install** and select your repository.
-3. Add two repository secrets:
-   - `CI_APP_ID`: shown on the App's settings page after installation.
-   - `CI_APP_PRIVATE_KEY`: generate a private key from the App's settings.
+The Forward Impact organization publishes a public GitHub App. Repositories
+within the org (or trusted forks where the org manages secrets centrally)
+install the App and use the org-managed `CI_APP_ID` and `CI_APP_PRIVATE_KEY`
+secrets. Private keys are per-App (not per-installation), so only the App owner
+can generate and distribute them.
 
-Wait — for the pre-built public App, downstream users install the same App but
-need their own private key. This does not work: private keys are per-App, not
-per-installation. The App owner (Forward Impact) holds the private key.
-
-**Corrected model for a shared public App:**
-
-For a **public** GitHub App that downstream installations can use:
-
-1. The downstream user installs the App on their repository (one-click from the
-   App's public page).
-2. The App owner (Forward Impact) provides the App ID publicly (it is not
-   secret).
-3. The **private key** is held by the App owner. Downstream users cannot
-   generate their own private key for someone else's App.
-
-This means a truly shared App requires the App owner to distribute the private
-key — which defeats the purpose. Instead, the correct pattern is:
-
-**Option 1 — Install the Forward Impact CI App (recommended for public forks):**
-
-The Forward Impact organization publishes a public GitHub App. Downstream
-repositories install it, and the Forward Impact team configures the app to
-generate tokens for installed repositories. The `CI_APP_ID` and
-`CI_APP_PRIVATE_KEY` secrets must be set by the Forward Impact team (or whoever
-owns the App). This works when the downstream repository is in the same
-organization or the App owner manages secrets for trusted installations.
-
-**Option 2 — Create your own GitHub App (recommended for independent
-installations):**
+**Option 2 — Create your own GitHub App (for independent installations):**
 
 Organizations that want full control create their own GitHub App following the
 permission table in §1.2, generate their own private key, and store `CI_APP_ID`
-and `CI_APP_PRIVATE_KEY` as repository secrets.
+and `CI_APP_PRIVATE_KEY` as repository secrets. They override the `app-slug`
+input in the composite action to match their App's slug.
 
-**Practical recommendation:** Document both options. The pre-built App is
-suitable for repositories within the Forward Impact organization and trusted
-forks where the org manages secrets centrally. Independent installations should
-create their own App.
-
-### 3.4 README / Setup Guide
-
-Add a section to the operations docs:
-
-```markdown
-## CI Agent Authentication
-
-The continuous improvement agents authenticate using a GitHub App installation
-token. This provides:
-
-- **No expiry management** — installation tokens are generated fresh each run
-- **Clear identity** — commits show `forward-impact-ci[bot]`, not a personal
-  account
-- **Least privilege** — permissions are declared on the App, not on a user
-
-### Setup
-
-1. [Install the Forward Impact CI App](https://github.com/apps/forward-impact-ci)
-   on your repository, OR create your own App with the permissions listed in the
-   spec.
-2. Store `CI_APP_ID` and `CI_APP_PRIVATE_KEY` as repository secrets.
-3. The workflows will automatically generate short-lived tokens per run.
-```
+The documentation should describe both options, explain the private key
+ownership model, and include the permission table for self-serve App creation.
 
 ## Ordering
 
-1. Create the GitHub App (manual, outside the codebase).
-2. Store `CI_APP_ID` and `CI_APP_PRIVATE_KEY` secrets (manual, GitHub UI).
-3. Update `.github/actions/claude/action.yml` — git identity only.
-4. Update all six workflow files — add token generation step, replace
-   `CLAUDE_GH_TOKEN` references.
-5. Update `CONTINUOUS_IMPROVEMENT.md`.
-6. Update operations documentation.
-7. Test: run each workflow via `workflow_dispatch` and verify:
+1. Resolve the `actions/create-github-app-token` SHA (prerequisite).
+2. Create the GitHub App (manual, outside the codebase).
+3. Store `CI_APP_ID` and `CI_APP_PRIVATE_KEY` secrets (manual, GitHub UI).
+4. Update `.github/actions/claude/action.yml` — add `app-slug`/`app-id` inputs,
+   update git identity.
+5. Update all six workflow files — add token generation step, replace
+   `CLAUDE_GH_TOKEN` references, pass `app-id` to composite action.
+6. Update `CONTINUOUS_IMPROVEMENT.md`.
+7. Update operations documentation.
+8. Test: run each workflow via `workflow_dispatch` and verify:
    - Workflow completes successfully.
    - Commits show App bot identity.
    - Wiki clone/push works.
    - PR operations (create, merge, comment) work.
-8. Remove the `CLAUDE_GH_TOKEN` secret from the repository (manual).
+9. Remove the `CLAUDE_GH_TOKEN` secret from the repository (manual).
 
-Steps 3-6 should be a single commit to avoid a state where some workflows use
+Steps 4-7 should be a single commit to avoid a state where some workflows use
 the old secret and others use the new one.
 
 ## Blast Radius
 
 - **Six workflow files** — mechanical find-and-replace of the secret reference.
-- **One composite action** — git identity change only.
+- **One composite action** — new inputs and git identity change.
 - **Two documentation files** — additive changes.
 - **No code changes** — no library, product, or test changes.
 - **Rollback** — revert the commit and re-add `CLAUDE_GH_TOKEN` secret.
@@ -403,8 +287,8 @@ the old secret and others use the new one.
    Impact org and trusted forks. Independent installations create their own App
    — same permissions, their own key.
 
-3. **Hardcode vs parameterize the App slug.** The bot identity (`{slug}[bot]`)
-   could be an input to the composite action or hardcoded. If hardcoded,
-   downstream installations with their own App would need to fork the composite
-   action. **Recommendation: make it an input with a default value** so the
-   composite action works for both the pre-built App and custom Apps.
+3. **App slug as input with default value.** The composite action accepts
+   `app-slug` as an input defaulting to `forward-impact-ci`. Downstream
+   installations with their own App override this value. This avoids requiring
+   forks of the composite action while keeping the default zero-configuration
+   for the Forward Impact org.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -35,5 +35,5 @@
 170	done
 180	done
 190	done
-200	draft
+200	planned
 210	draft


### PR DESCRIPTION
Remove self-contradicting token generation design (§2.1 vs §2.2),
stream-of-consciousness corrections in §3.3, and drafted documentation
content in §3.4. Commit to app-slug as input with default value.
Differentiate security-audit workflow in files table. Add explicit
SHA prerequisite.

https://claude.ai/code/session_01TuEvpsXjxVa66iQsfj9wyC