### PR TITLE
feat(ci): migrate agent workflows from PAT to GitHub App authentication

### DIFF
--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -33,6 +33,13 @@ inputs:
     description: Clone the repository wiki for shared agent memory
     required: false
     default: "true"
+  app-slug:
+    description: GitHub App slug for git identity
+    required: false
+    default: forward-impact-ci
+  app-id:
+    description: GitHub App ID for git identity email
+    required: true
 
 runs:
   using: composite
@@ -43,14 +50,20 @@ runs:
 
     - name: Configure Git identity
       shell: bash
+      env:
+        APP_SLUG: ${{ inputs.app-slug }}
+        APP_ID: ${{ inputs.app-id }}
       run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "${APP_SLUG}[bot]"
+        git config user.email "${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
     - name: Clone wiki for shared memory
       id: clone-wiki
       if: inputs.wiki == 'true'
       shell: bash
+      env:
+        APP_SLUG: ${{ inputs.app-slug }}
+        APP_ID: ${{ inputs.app-id }}
       run: |
         WIKI_DIR="/tmp/wiki"
         REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.wiki.git"
@@ -62,8 +75,8 @@ runs:
           mkdir -p "$WIKI_DIR"
           git -C "$WIKI_DIR" init
           git -C "$WIKI_DIR" remote add origin "$WIKI_REMOTE"
-          git -C "$WIKI_DIR" config user.name "github-actions[bot]"
-          git -C "$WIKI_DIR" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$WIKI_DIR" config user.name "${APP_SLUG}[bot]"
+          git -C "$WIKI_DIR" config user.email "${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           echo "# Agent Memory" > "$WIKI_DIR/Home.md"
           git -C "$WIKI_DIR" add .
           git -C "$WIKI_DIR" commit -m "Initialize wiki for agent memory"
@@ -134,11 +147,14 @@ runs:
     - name: Push wiki changes
       if: always() && inputs.wiki == 'true'
       shell: bash
+      env:
+        APP_SLUG: ${{ inputs.app-slug }}
+        APP_ID: ${{ inputs.app-id }}
       run: |
         WIKI_DIR="${{ steps.clone-wiki.outputs.wiki-dir }}"
         cd "$WIKI_DIR"
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "${APP_SLUG}[bot]"
+        git config user.email "${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
         # Stage and commit any uncommitted changes in the wiki
         git add -A

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -18,9 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Generate installation token
+        id: app-token
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.CLAUDE_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -33,9 +40,10 @@ jobs:
         uses: ./.github/actions/claude
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.CLAUDE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
+          app-id: ${{ secrets.CI_APP_ID }}
           prompt: "Review and triage open Dependabot pull requests."
           agent: "security-engineer"
           model: "opus"

--- a/.github/workflows/improvement-coach.yml
+++ b/.github/workflows/improvement-coach.yml
@@ -18,10 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Generate installation token
+        id: app-token
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLAUDE_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -34,9 +41,10 @@ jobs:
         uses: ./.github/actions/claude
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.CLAUDE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
+          app-id: ${{ secrets.CI_APP_ID }}
           prompt: >
             Pick one recent agent workflow run at random and deep-analyze its
             trace using the grounded-theory-analysis skill. Implement trivial

--- a/.github/workflows/product-backlog.yml
+++ b/.github/workflows/product-backlog.yml
@@ -18,10 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Generate installation token
+        id: app-token
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLAUDE_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -34,9 +41,10 @@ jobs:
         uses: ./.github/actions/claude
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.CLAUDE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
+          app-id: ${{ secrets.CI_APP_ID }}
           prompt: >
             Review all open pull requests for product alignment. Classify each
             by type, verify the author is a top contributor, check CI status,

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -18,10 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Generate installation token
+        id: app-token
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLAUDE_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -34,9 +41,10 @@ jobs:
         uses: ./.github/actions/claude
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.CLAUDE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
+          app-id: ${{ secrets.CI_APP_ID }}
           prompt: "Check all open pull requests for merge readiness."
           agent: "release-engineer"
           model: "opus"

--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -18,10 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Generate installation token
+        id: app-token
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.CLAUDE_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -34,9 +41,10 @@ jobs:
         uses: ./.github/actions/claude
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.CLAUDE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
+          app-id: ${{ secrets.CI_APP_ID }}
           prompt:
             "Review main branch for unreleased changes and cut new versions."
           agent: "release-engineer"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -18,6 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Generate installation token
+        id: app-token
+        uses: actions/create-github-app-token@67e27a7eb7db372a1c61a7f9bdab8699e9ee57f7 # v1
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -31,9 +38,10 @@ jobs:
         uses: ./.github/actions/claude
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ secrets.CLAUDE_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
+          app-id: ${{ secrets.CI_APP_ID }}
           prompt: "Perform a security audit of the repository."
           agent: "security-engineer"
           model: "opus"

--- a/CONTINUOUS_IMPROVEMENT.md
+++ b/CONTINUOUS_IMPROVEMENT.md
@@ -26,9 +26,11 @@ graph TD
 ```
 
 All workflows use a shared composite action (`.github/actions/claude/`) that
-installs Claude Code, configures a bot Git identity, runs a prompt against an
-agent profile in non-interactive mode, captures a full execution trace as
-NDJSON, and uploads it as a workflow artifact.
+installs Claude Code, configures the GitHub App's bot Git identity, runs a
+prompt against an agent profile in non-interactive mode, captures a full
+execution trace as NDJSON, and uploads it as a workflow artifact. Each workflow
+generates a short-lived installation token from the GitHub App before invoking
+the composite action (see § Authentication below).
 
 ## Agents
 
@@ -223,7 +225,8 @@ error messages, or token counts from traces. Speculation without evidence is
 prohibited.
 
 **Least privilege.** The security-audit workflow runs with `contents: read`
-only. Workflows that need to push use `contents: write` with a scoped token.
+only. Workflows that need to push use `contents: write` with a scoped
+installation token generated per run by the GitHub App.
 
 ## Shared Memory
 
@@ -248,6 +251,33 @@ what has already happened and what still needs attention.
 
 To disable wiki memory for a specific workflow, pass `wiki: "false"` to the
 composite action.
+
+## Authentication
+
+Agent workflows authenticate to GitHub using a **GitHub App** instead of a
+personal access token (PAT). Each workflow run generates a short-lived
+installation token via `actions/create-github-app-token`, scoped to the
+repository the App is installed on. This provides three benefits over PATs:
+
+1. **No token expiry management.** Installation tokens are generated on demand
+   and expire after one hour. There is no long-lived secret to rotate.
+2. **Distinct bot identity.** Commits and API calls appear as the App's bot
+   account (`forward-impact-ci[bot]`), not a personal GitHub user. This makes
+   the audit trail unambiguous — agent actions are clearly separated from human
+   actions.
+3. **One-click setup for downstream installations.** The Forward Impact CI App
+   is public. Organizations that install the monorepo can add the App to their
+   repository and store `CI_APP_ID` and `CI_APP_PRIVATE_KEY` as repository
+   secrets. Organizations that prefer full control can create their own GitHub
+   App with the same permissions and override the `app-slug` input in the
+   composite action.
+
+The token generation step runs at the workflow level before `actions/checkout`,
+so the checkout token triggers downstream workflows and the same token is passed
+to the composite action via the `GH_TOKEN` environment variable. The
+`security-audit` workflow generates an App token for API access but uses the
+default `GITHUB_TOKEN` for checkout, preserving its `contents: read` least
+privilege constraint.
 
 ## Accountability
 

--- a/website/docs/internals/operations/index.md
+++ b/website/docs/internals/operations/index.md
@@ -144,3 +144,50 @@ make config-reset             # Reset config files from examples
 ```
 
 See each product's skill file for full CLI reference.
+
+## CI Agent Authentication
+
+The continuous improvement system authenticates to GitHub using a **GitHub App**
+that generates short-lived installation tokens per workflow run. Two setup
+options are available:
+
+### Option 1: Forward Impact CI App (recommended)
+
+The Forward Impact organization publishes a public GitHub App. Repositories
+within the org (or trusted forks where the org manages secrets centrally)
+install the App and use the org-managed credentials.
+
+1. Install the **Forward Impact CI** App on your repository from its public
+   listing.
+2. Store the following as repository secrets:
+   - `CI_APP_ID` — the App's numeric ID (provided by the App owner)
+   - `CI_APP_PRIVATE_KEY` — the PEM-encoded private key (provided by the App
+     owner)
+3. Store `ANTHROPIC_API_KEY` as a repository secret.
+4. The agent workflows will generate installation tokens automatically.
+
+### Option 2: Create your own GitHub App
+
+Organizations that want full control create their own GitHub App.
+
+1. Create a GitHub App with these repository permissions:
+
+   | Permission        | Access     | Used by                                       |
+   | ----------------- | ---------- | --------------------------------------------- |
+   | **Contents**      | Read/Write | All agent workflows (push commits, read code) |
+   | **Pull requests** | Read/Write | Triage, backlog, release workflows            |
+   | **Issues**        | Read/Write | Improvement coach (open issues for findings)  |
+   | **Actions**       | Read       | Improvement coach (download trace artifacts)  |
+   | **Metadata**      | Read       | All (granted by default)                      |
+
+2. Disable webhooks (not needed — token-only usage).
+3. Install the App on your repository.
+4. Generate a private key and store as repository secrets:
+   - `CI_APP_ID` — your App's numeric ID
+   - `CI_APP_PRIVATE_KEY` — your App's PEM-encoded private key
+5. Override the `app-slug` input in the composite action to match your App's
+   slug. Each workflow passes `app-id` to the composite action; the `app-slug`
+   input defaults to `forward-impact-ci` and must be changed to your App's slug.
+
+Private keys are per-App, not per-installation. Only the App owner can generate
+and distribute them.


### PR DESCRIPTION
Replace CLAUDE_GH_TOKEN (PAT) with short-lived installation tokens
generated by the Forward Impact CI GitHub App. This eliminates token
expiry management, provides a distinct bot identity for agent commits,
and enables one-click setup for downstream installations.

- Add app-slug/app-id inputs to composite action
- Update git identity to use App bot account in all steps
- Add token generation step to all six agent workflows
- Update CONTINUOUS_IMPROVEMENT.md with Authentication section
- Add CI Agent Authentication setup guide to operations docs

Implements spec 200.

https://claude.ai/code/session_01RuYQ2faPpcrXhpJMsXZoCp