### PR TITLE
fix(deps): revert protobufjs 8.0.0 bump and clarify dependency policy

### DIFF
--- a/.claude/skills/dependabot-triage/SKILL.md
+++ b/.claude/skills/dependabot-triage/SKILL.md
@@ -58,6 +58,17 @@ reference the action — not just the one Dependabot found. Current usage:
 
 ## Process
 
+### Step 0: Read Memory for Triage History
+
+Before listing PRs, read all files in the memory directory. From previous
+`dependabot-triage-*.md` entries, extract:
+
+- PRs that were previously closed, merged, or deferred and their outcomes
+- Packages that repeatedly fail Check 8 (peer/transitive compatibility)
+
+Also check entries from other agents — the security engineer may have flagged
+dependency issues, or the improvement coach may have noted triage mistakes.
+
 ### Step 1: List Open Dependabot PRs
 
 ```sh
@@ -93,17 +104,24 @@ Determine the update type from the PR title and body:
 #### Check 8: Peer and Transitive Dependency Compatibility (npm major updates)
 
 For every npm major version bump, verify the updated package does not break
-co-installed packages. Run `npm ls <package>` on the PR branch and check for:
+co-installed packages. Run `bun pm ls` on the PR branch and check for:
 
 - **`invalid`** — a resolved version violates another package's declared range
   (peer or regular dependency). The major bump cannot land until those packages
   release compatible versions.
+- **Nested duplicates in `bun.lock`** — if the lockfile creates a nested entry
+  for the old major version under a co-dependent package (e.g.
+  `@grpc/proto-loader/protobufjs@7` alongside a top-level `protobufjs@8`), the
+  bump forces two major versions into the tree. This causes version splitting
+  (sometimes called "dependency indirection") and **fails this check**. Close
+  the PR until all co-dependent packages release compatible ranges.
 - **`deduped` across mismatched majors** — if the same package resolves to
   multiple major versions in the tree, the update may cause subtle runtime
   issues (e.g. type mismatches, duplicate registrations). Investigate before
   merging.
 
-If the tree is clean (single version, no `invalid` markers), the check passes.
+If the tree is clean (single version, no `invalid` markers, no nested
+duplicates), the check passes.
 
 ### Step 3: Check CI Status
 
@@ -204,10 +222,22 @@ After processing all PRs, produce a summary table:
 ```
 | PR  | Title                          | Action | Reason                     |
 | --- | ------------------------------ | ------ | -------------------------- |
-| #67 | bump protobufjs 7.5.4 to 8.0.0 | merge  | All policies pass, CI green |
+| #67 | bump protobufjs 7.5.4 to 8.0.0 | close  | Check 8: @grpc/proto-loader peers on ^7 |
 | #61 | bump upload-pages-artifact ...  | fix    | Missing SHA pins in ...    |
 | #58 | bump configure-pages ...        | close  | Introduces tag reference   |
 ```
 
 Include any PRs that were skipped (e.g. waiting for main to be fixed) with a
 note explaining why.
+
+### Memory: what to record for dependabot triage
+
+When writing your memory entry at the end of the run, include these
+triage-specific fields in addition to the standard agent memory fields:
+
+- **PR triage table** — Each PR processed with action taken (merged, closed,
+  fixed), which policy checks failed, and the reason for the decision
+- **Compatibility blockers** — Packages closed due to Check 8 (peer/transitive
+  incompatibility), noting which co-dependent packages need compatible releases
+- **Reverted merges** — Any PRs that were merged but later reverted, with the
+  root cause (e.g. lockfile duplication missed during triage)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,11 @@ Security policies apply to all contributors — human and agent.
   renderer)
 - Align version ranges for the same package across all workspaces
 - Verify peer and transitive dependency compatibility before merging major
-  version bumps — run `bun pm ls` and confirm no `invalid` markers
+  version bumps — run `bun pm ls` and confirm no `invalid` markers. Also inspect
+  `bun.lock` for **nested duplicates** (the same package resolved at two
+  different major versions, e.g. a top-level `protobufjs@8` alongside
+  `@grpc/proto-loader/protobufjs@7`). A major bump that forces co-installed
+  packages onto a separate version violates this policy — close the PR until all
+  dependents release compatible ranges
 - Run `npm audit --audit-level=high` after adding or updating dependencies (use
   `make audit-vulnerabilities` which generates a temporary lockfile)

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
       },
       "devDependencies": {
         "@forwardimpact/libharness": "^0.1.5",
-        "protobufjs": "^8.0.0",
+        "protobufjs": "^7.5.4",
         "protobufjs-cli": "^2.0.0",
       },
     },
@@ -347,7 +347,7 @@
         "@forwardimpact/libtelemetry": "^0.1.22",
         "@forwardimpact/libtype": "^0.1.63",
         "@forwardimpact/libutil": "^0.1.60",
-        "protobufjs": "^8.0.0",
+        "protobufjs": "^7.5.4",
         "yaml": "^2.8.3",
       },
       "devDependencies": {
@@ -1427,7 +1427,7 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
-    "protobufjs": ["protobufjs@8.0.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw=="],
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "protobufjs-cli": ["protobufjs-cli@2.0.0", "", { "dependencies": { "chalk": "^4.0.0", "escodegen": "^1.13.0", "espree": "^9.0.0", "estraverse": "^5.1.0", "glob": "^8.0.0", "jsdoc": "^4.0.0", "minimist": "^1.2.0", "semver": "^7.1.2", "tmp": "^0.2.1", "uglify-js": "^3.7.7" }, "peerDependencies": { "protobufjs": "^7.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-/QGByFXSLY9Was5Oq8yKn5lu1pMywGMHgE0fDR9b4nZFTvaWJonHiJxT3HHu2ZuOQAxd7ufYyQtW8Q1ZgW+gPg=="],
 
@@ -1614,8 +1614,6 @@
     "@forwardimpact/libskill/@forwardimpact/map": ["@forwardimpact/map@0.13.0", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "yaml": "^2.3.4" }, "bin": { "fit-map": "bin/fit-map.js" } }, "sha512-ucjZB4UXjkXCTU+abr1syfNw8ZK+Ak10hgBF3I7dp9fC0wxyNXrEmGLJl2pwGkaDW1mp01EOr/Bwm+tw1Dj0eQ=="],
 
     "@forwardimpact/pathway/@forwardimpact/map": ["@forwardimpact/map@0.14.0", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "yaml": "^2.3.4" }, "bin": { "fit-map": "bin/fit-map.js" } }, "sha512-+yZIzOG3FQfJxQ2sPRnJ07nCHYslpjPWL7ySWqWzOB942nle/vtamEXaf3kX6p9CK5M5q/f7LUflSfV6WkN9tw=="],
-
-    "@grpc/proto-loader/protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/libraries/libcodegen/package.json
+++ b/libraries/libcodegen/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@forwardimpact/libharness": "^0.1.5",
-    "protobufjs": "^8.0.0",
+    "protobufjs": "^7.5.4",
     "protobufjs-cli": "^2.0.0"
   },
   "publishConfig": {

--- a/libraries/libtool/package.json
+++ b/libraries/libtool/package.json
@@ -25,7 +25,7 @@
     "@forwardimpact/libtelemetry": "^0.1.22",
     "@forwardimpact/libtype": "^0.1.63",
     "@forwardimpact/libutil": "^0.1.60",
-    "protobufjs": "^8.0.0",
+    "protobufjs": "^7.5.4",
     "yaml": "^2.8.3"
   },
   "repository": {


### PR DESCRIPTION
PR #135 bumped protobufjs from 7.5.4 to 8.0.0, but @grpc/proto-loader
and protobufjs-cli peer on ^7.0.0, causing a nested duplicate in the
lockfile (two major versions of the same package). This violates the
dependency compatibility policy.

- Revert the protobufjs 8.0.0 merge commit
- Clarify CONTRIBUTING.md dependency policy to explicitly call out
  lockfile nested duplicates as a policy violation
- Add memory instructions to dependabot-triage skill (Step 0 and
  Memory recording section) following existing skill patterns
- Fix misleading example in triage report table
- Strengthen Check 8 guidance to inspect bun.lock for version splitting

https://claude.ai/code/session_01ULkxi4nsUBGUQkY1qApPed