### PR TITLE
chore(claude): broaden edit/write permissions to entire .claude folder

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "permissions": {
     "defaultMode": "acceptEdits",
-    "allow": ["Edit(.claude/memory/**)", "Write(.claude/memory/**)"]
+    "allow": ["Edit(.claude/**)", "Write(.claude/**)"]
   },
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
Previously only .claude/memory/** was allowed without prompting.
Widen to .claude/** so settings, skills, and other .claude files
can be edited without permission prompts.

https://claude.ai/code/session_01E4bxFiv8a1ovWbHeTA665o