### PR TITLE
feat(libeval): stream text output to stdout when writing NDJSON to file

### DIFF
--- a/libraries/libeval/index.js
+++ b/libraries/libeval/index.js
@@ -1,3 +1,4 @@
 export { TraceCollector, createTraceCollector } from "./src/trace-collector.js";
 export { AgentRunner, createAgentRunner } from "./src/agent-runner.js";
 export { Supervisor, createSupervisor } from "./src/supervisor.js";
+export { TeeWriter, createTeeWriter } from "./src/tee-writer.js";

--- a/libraries/libeval/src/commands/run.js
+++ b/libraries/libeval/src/commands/run.js
@@ -1,6 +1,7 @@
 import { readFileSync, createWriteStream } from "node:fs";
 import { resolve } from "node:path";
 import { createAgentRunner } from "../agent-runner.js";
+import { createTeeWriter } from "../tee-writer.js";
 
 /**
  * Parse a --key=value or --key value flag from args.
@@ -45,7 +46,13 @@ export async function runRunCommand(args) {
   ).split(",");
 
   const taskContent = readFileSync(task, "utf8");
-  const output = outputPath ? createWriteStream(outputPath) : process.stdout;
+
+  // When --output is specified, stream text to stdout while writing NDJSON to file.
+  // Otherwise, write NDJSON directly to stdout (backwards-compatible).
+  const fileStream = outputPath ? createWriteStream(outputPath) : null;
+  const output = fileStream
+    ? createTeeWriter({ fileStream, textStream: process.stdout, mode: "raw" })
+    : process.stdout;
 
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
   const runner = createAgentRunner({
@@ -59,8 +66,9 @@ export async function runRunCommand(args) {
 
   const result = await runner.run(taskContent);
 
-  if (outputPath && output !== process.stdout) {
+  if (fileStream) {
     await new Promise((r) => output.end(r));
+    await new Promise((r) => fileStream.end(r));
   }
 
   process.exit(result.success ? 0 : 1);

--- a/libraries/libeval/src/commands/supervise.js
+++ b/libraries/libeval/src/commands/supervise.js
@@ -2,6 +2,7 @@ import { readFileSync, createWriteStream, mkdtempSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createSupervisor } from "../supervisor.js";
+import { createTeeWriter } from "../tee-writer.js";
 
 /**
  * Parse a --key=value or --key value flag from args.
@@ -51,7 +52,17 @@ export async function runSuperviseCommand(args) {
   ).split(",");
 
   const taskContent = readFileSync(task, "utf8");
-  const output = outputPath ? createWriteStream(outputPath) : process.stdout;
+
+  // When --output is specified, stream text to stdout while writing NDJSON to file.
+  // Otherwise, write NDJSON directly to stdout (backwards-compatible).
+  const fileStream = outputPath ? createWriteStream(outputPath) : null;
+  const output = fileStream
+    ? createTeeWriter({
+        fileStream,
+        textStream: process.stdout,
+        mode: "supervised",
+      })
+    : process.stdout;
 
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
   const supervisor = createSupervisor({
@@ -66,8 +77,9 @@ export async function runSuperviseCommand(args) {
 
   const result = await supervisor.run(taskContent);
 
-  if (outputPath && output !== process.stdout) {
+  if (fileStream) {
     await new Promise((r) => output.end(r));
+    await new Promise((r) => fileStream.end(r));
   }
 
   process.exit(result.success ? 0 : 1);

--- a/libraries/libeval/src/tee-writer.js
+++ b/libraries/libeval/src/tee-writer.js
@@ -1,0 +1,157 @@
+/**
+ * TeeWriter — a Writable stream that writes raw NDJSON to a file while
+ * simultaneously streaming human-readable text to a separate stream (e.g.
+ * process.stdout).
+ *
+ * Supports two modes:
+ * - "raw" (default): expects standard stream-json events from AgentRunner
+ * - "supervised": expects tagged events {source, turn, event} from Supervisor
+ *
+ * Follows OO+DI: constructor injection, factory function, tests bypass factory.
+ */
+
+import { Writable } from "node:stream";
+import { TraceCollector } from "./trace-collector.js";
+
+export class TeeWriter extends Writable {
+  /**
+   * @param {object} deps
+   * @param {import("stream").Writable} deps.fileStream - Stream to write raw NDJSON to
+   * @param {import("stream").Writable} deps.textStream - Stream to write human-readable text to
+   * @param {"raw"|"supervised"} [deps.mode] - Event format: "raw" or "supervised" (default: "raw")
+   */
+  constructor({ fileStream, textStream, mode }) {
+    super();
+    if (!fileStream) throw new Error("fileStream is required");
+    if (!textStream) throw new Error("textStream is required");
+    this.fileStream = fileStream;
+    this.textStream = textStream;
+    this.mode = mode ?? "raw";
+    this.collector = new TraceCollector();
+    this.turnsEmitted = 0;
+    this.lastSource = null;
+    this.partial = "";
+  }
+
+  /**
+   * @param {Buffer|string} chunk
+   * @param {string} encoding
+   * @param {function} callback
+   */
+  _write(chunk, encoding, callback) {
+    const str = this.partial + chunk.toString();
+    const lines = str.split("\n");
+    this.partial = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      this.fileStream.write(line + "\n");
+      this.processLine(line);
+    }
+    callback();
+  }
+
+  /**
+   * @param {function} callback
+   */
+  _final(callback) {
+    if (this.partial.trim()) {
+      this.fileStream.write(this.partial + "\n");
+      this.processLine(this.partial);
+    }
+
+    if (this.mode === "raw" && this.collector.result) {
+      const text = this.collector.toText();
+      const idx = text.lastIndexOf("\n---");
+      if (idx !== -1) {
+        this.textStream.write(text.slice(idx) + "\n");
+      }
+    }
+
+    callback();
+  }
+
+  /**
+   * Process a single NDJSON line — feed to collector and flush text.
+   * @param {string} line
+   */
+  processLine(line) {
+    if (this.mode === "supervised") {
+      this.processSupervisedLine(line);
+    } else {
+      this.collector.addLine(line);
+      this.flushTurns();
+    }
+  }
+
+  /**
+   * Handle a tagged supervisor line: unwrap event, show source labels.
+   * @param {string} line
+   */
+  processSupervisedLine(line) {
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (parsed.source === "orchestrator" && parsed.type === "summary") {
+      const status = parsed.success ? "completed" : "incomplete";
+      this.textStream.write(
+        `\n--- Evaluation ${status} after ${parsed.turns} turns ---\n`,
+      );
+      return;
+    }
+
+    if (parsed.event) {
+      if (parsed.source && parsed.source !== this.lastSource) {
+        this.lastSource = parsed.source;
+        this.textStream.write(`\n[${parsed.source}]\n`);
+      }
+      this.collector.addLine(JSON.stringify(parsed.event));
+      this.flushTurns();
+    }
+  }
+
+  /**
+   * Emit text for any new turns accumulated by the collector.
+   */
+  flushTurns() {
+    const turns = this.collector.turns;
+    while (this.turnsEmitted < turns.length) {
+      const turn = turns[this.turnsEmitted++];
+      if (turn.role === "assistant") {
+        for (const block of turn.content) {
+          if (block.type === "text") {
+            this.textStream.write(block.text + "\n");
+          } else if (block.type === "tool_use") {
+            const input = summarizeInput(block.input);
+            this.textStream.write(`> Tool: ${block.name} ${input}\n`);
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Summarize tool input for text display, truncated to keep logs readable.
+ * @param {object} input - Tool input object
+ * @returns {string} Truncated summary
+ */
+function summarizeInput(input) {
+  if (!input || typeof input !== "object") return "";
+  const json = JSON.stringify(input);
+  if (json.length <= 200) return json;
+  return json.slice(0, 197) + "...";
+}
+
+/**
+ * Factory function — wires a TeeWriter with the given streams.
+ * @param {object} deps - Same as TeeWriter constructor
+ * @returns {TeeWriter}
+ */
+export function createTeeWriter(deps) {
+  return new TeeWriter(deps);
+}

--- a/libraries/libeval/test/tee-writer.test.js
+++ b/libraries/libeval/test/tee-writer.test.js
@@ -1,0 +1,328 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { PassThrough } from "node:stream";
+
+import { TeeWriter, createTeeWriter } from "@forwardimpact/libeval";
+
+/**
+ * Collect all data written to a PassThrough stream as a string.
+ * @param {PassThrough} stream
+ * @returns {string}
+ */
+function collect(stream) {
+  const data = stream.read();
+  return data ? data.toString() : "";
+}
+
+/**
+ * Write lines to a TeeWriter and wait for it to finish.
+ * @param {TeeWriter} writer
+ * @param {string[]} lines - JSON lines to write
+ */
+async function writeLines(writer, lines) {
+  for (const line of lines) {
+    writer.write(line + "\n");
+  }
+  await new Promise((resolve) => writer.end(resolve));
+}
+
+describe("TeeWriter", () => {
+  test("constructor throws on missing fileStream", () => {
+    assert.throws(
+      () => new TeeWriter({ textStream: new PassThrough() }),
+      /fileStream is required/,
+    );
+  });
+
+  test("constructor throws on missing textStream", () => {
+    assert.throws(
+      () => new TeeWriter({ fileStream: new PassThrough() }),
+      /textStream is required/,
+    );
+  });
+
+  test("writes NDJSON to fileStream and text to textStream in raw mode", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({ fileStream, textStream, mode: "raw" });
+
+    const events = [
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "s1",
+        model: "opus",
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Hello world" }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "Bash",
+              input: { command: "ls" },
+            },
+          ],
+          usage: { input_tokens: 20, output_tokens: 10 },
+        },
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        duration_ms: 5000,
+        num_turns: 2,
+        total_cost_usd: 0.05,
+        usage: { input_tokens: 30, output_tokens: 15 },
+      }),
+    ];
+
+    await writeLines(writer, events);
+
+    const fileData = collect(fileStream);
+    const textData = collect(textStream);
+
+    // File should contain all NDJSON lines
+    const fileLines = fileData.trim().split("\n");
+    assert.strictEqual(fileLines.length, 4);
+    assert.deepStrictEqual(JSON.parse(fileLines[0]).type, "system");
+    assert.deepStrictEqual(JSON.parse(fileLines[3]).type, "result");
+
+    // Text should contain human-readable output
+    assert.ok(textData.includes("Hello world"));
+    assert.ok(textData.includes("> Tool: Bash"));
+    assert.ok(textData.includes("--- Result: success"));
+  });
+
+  test("streams text incrementally as events arrive", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({ fileStream, textStream, mode: "raw" });
+
+    // Write first assistant message
+    writer.write(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "First message" }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      }) + "\n",
+    );
+
+    // Text should be available before stream ends
+    const firstText = collect(textStream);
+    assert.ok(firstText.includes("First message"));
+
+    writer.write(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Second message" }],
+          usage: { input_tokens: 20, output_tokens: 10 },
+        },
+      }) + "\n",
+    );
+
+    const secondText = collect(textStream);
+    assert.ok(secondText.includes("Second message"));
+
+    await new Promise((resolve) => writer.end(resolve));
+  });
+
+  test("supervised mode shows source labels and unwraps events", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({
+      fileStream,
+      textStream,
+      mode: "supervised",
+    });
+
+    const events = [
+      JSON.stringify({
+        source: "agent",
+        turn: 0,
+        event: {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Working on it" }],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          },
+        },
+      }),
+      JSON.stringify({
+        source: "supervisor",
+        turn: 1,
+        event: {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Looks good" }],
+            usage: { input_tokens: 20, output_tokens: 10 },
+          },
+        },
+      }),
+      JSON.stringify({
+        source: "orchestrator",
+        type: "summary",
+        success: true,
+        turns: 1,
+      }),
+    ];
+
+    await writeLines(writer, events);
+
+    const fileData = collect(fileStream);
+    const textData = collect(textStream);
+
+    // File should contain all raw tagged NDJSON
+    const fileLines = fileData.trim().split("\n");
+    assert.strictEqual(fileLines.length, 3);
+    assert.strictEqual(JSON.parse(fileLines[0]).source, "agent");
+
+    // Text should show source labels
+    assert.ok(textData.includes("[agent]"));
+    assert.ok(textData.includes("Working on it"));
+    assert.ok(textData.includes("[supervisor]"));
+    assert.ok(textData.includes("Looks good"));
+    assert.ok(textData.includes("Evaluation completed after 1 turns"));
+  });
+
+  test("supervised mode shows incomplete status on failure", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({
+      fileStream,
+      textStream,
+      mode: "supervised",
+    });
+
+    await writeLines(writer, [
+      JSON.stringify({
+        source: "orchestrator",
+        type: "summary",
+        success: false,
+        turns: 5,
+      }),
+    ]);
+
+    const textData = collect(textStream);
+    assert.ok(textData.includes("Evaluation incomplete after 5 turns"));
+  });
+
+  test("supervised mode only shows source label on change", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({
+      fileStream,
+      textStream,
+      mode: "supervised",
+    });
+
+    const events = [
+      JSON.stringify({
+        source: "agent",
+        turn: 0,
+        event: {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Step 1" }],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          },
+        },
+      }),
+      JSON.stringify({
+        source: "agent",
+        turn: 0,
+        event: {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Step 2" }],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          },
+        },
+      }),
+    ];
+
+    await writeLines(writer, events);
+
+    const textData = collect(textStream);
+    // [agent] label should appear only once
+    const agentLabels = textData.split("[agent]").length - 1;
+    assert.strictEqual(agentLabels, 1);
+  });
+
+  test("handles partial lines across chunks", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({ fileStream, textStream, mode: "raw" });
+
+    const fullLine = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Split message" }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    });
+
+    // Split the line across two chunks
+    const mid = Math.floor(fullLine.length / 2);
+    writer.write(fullLine.slice(0, mid));
+    writer.write(fullLine.slice(mid) + "\n");
+    await new Promise((resolve) => writer.end(resolve));
+
+    const textData = collect(textStream);
+    assert.ok(textData.includes("Split message"));
+  });
+
+  test("truncates long tool input", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({ fileStream, textStream, mode: "raw" });
+
+    const longInput = { command: "x".repeat(300) };
+    const event = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", id: "t1", name: "Bash", input: longInput },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    });
+
+    await writeLines(writer, [event]);
+
+    const textData = collect(textStream);
+    assert.ok(textData.includes("> Tool: Bash"));
+    assert.ok(textData.includes("..."));
+    // Truncated to ~200 chars
+    const toolLine = textData
+      .split("\n")
+      .find((l) => l.startsWith("> Tool:"));
+    assert.ok(toolLine.length < 250);
+  });
+
+  test("defaults to raw mode", () => {
+    const writer = new TeeWriter({
+      fileStream: new PassThrough(),
+      textStream: new PassThrough(),
+    });
+    assert.strictEqual(writer.mode, "raw");
+  });
+
+  test("createTeeWriter factory returns a TeeWriter instance", () => {
+    const writer = createTeeWriter({
+      fileStream: new PassThrough(),
+      textStream: new PassThrough(),
+    });
+    assert.ok(writer instanceof TeeWriter);
+  });
+});


### PR DESCRIPTION
When --output is specified, fit-eval run and fit-eval supervise now
stream human-readable text to stdout while writing full NDJSON to disk.
Without --output, behaviour is unchanged (NDJSON to stdout).

Adds TeeWriter — a Writable stream that splits output between an NDJSON
file stream and a text stream with incremental turn flushing. Supports
both raw mode (run) and supervised mode (supervise) with source labels.

https://claude.ai/code/session_0138foTzosPNAxbCmPs3wgwg