### PR TITLE
fix(libeval): match SDK result message format for success detection

### DIFF
--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -74,13 +74,13 @@ export class AgentRunner {
       if (message.type === "system" && message.subtype === "init") {
         this.sessionId = message.session_id;
       }
-      if ("result" in message) {
-        text = message.result;
-        stopReason = message.stop_reason;
+      if (message.type === "result") {
+        text = message.result ?? "";
+        stopReason = message.subtype;
       }
     }
 
-    const success = stopReason === "end_turn";
+    const success = stopReason === "success";
     return { success, text, sessionId: this.sessionId };
   }
 
@@ -101,13 +101,13 @@ export class AgentRunner {
       this.output.write(line + "\n");
       this.buffer.push(line);
 
-      if ("result" in message) {
-        text = message.result;
-        stopReason = message.stop_reason;
+      if (message.type === "result") {
+        text = message.result ?? "";
+        stopReason = message.subtype;
       }
     }
 
-    const success = stopReason === "end_turn";
+    const success = stopReason === "success";
     return { success, text };
   }
 

--- a/libraries/libeval/test/agent-runner.test.js
+++ b/libraries/libeval/test/agent-runner.test.js
@@ -88,7 +88,7 @@ describe("AgentRunner", () => {
     const messages = [
       { type: "system", subtype: "init", session_id: "sess-1" },
       { type: "assistant", content: "Working on it..." },
-      { result: "Done.", stop_reason: "end_turn" },
+      { type: "result", subtype: "success", result: "Done." },
     ];
 
     const output = new PassThrough();
@@ -113,7 +113,7 @@ describe("AgentRunner", () => {
   test("run() captures sessionId from init event", async () => {
     const messages = [
       { type: "system", subtype: "init", session_id: "my-session" },
-      { result: "OK", stop_reason: "end_turn" },
+      { type: "result", subtype: "success", result: "OK" },
     ];
 
     const output = new PassThrough();
@@ -130,7 +130,7 @@ describe("AgentRunner", () => {
   test("run() passes options to query", async () => {
     let captured = null;
     const query = mockQuery(
-      [{ result: "OK", stop_reason: "end_turn" }],
+      [{ type: "result", subtype: "success", result: "OK" }],
       (params) => {
         captured = params;
       },
@@ -158,8 +158,8 @@ describe("AgentRunner", () => {
     assert.strictEqual(captured.options.allowDangerouslySkipPermissions, true);
   });
 
-  test("run() returns success=false on non-end_turn stop_reason", async () => {
-    const messages = [{ result: "Stopped", stop_reason: "max_tokens" }];
+  test("run() returns success=false on non-success subtype", async () => {
+    const messages = [{ type: "result", subtype: "error", result: "Stopped" }];
 
     const output = new PassThrough();
     const runner = new AgentRunner({
@@ -178,7 +178,7 @@ describe("AgentRunner", () => {
 
     const initMessages = [
       { type: "system", subtype: "init", session_id: "sess-42" },
-      { result: "First done", stop_reason: "end_turn" },
+      { type: "result", subtype: "success", result: "First done" },
     ];
 
     let callCount = 0;
@@ -188,7 +188,7 @@ describe("AgentRunner", () => {
         for (const m of initMessages) yield m;
       } else {
         resumeCapture = params;
-        yield { result: "Resumed", stop_reason: "end_turn" };
+        yield { type: "result", subtype: "success", result: "Resumed" };
       }
     };
 
@@ -207,7 +207,7 @@ describe("AgentRunner", () => {
   test("drainOutput() returns buffered lines and clears buffer", async () => {
     const messages = [
       { type: "assistant", content: "Line 1" },
-      { result: "Line 2", stop_reason: "end_turn" },
+      { type: "result", subtype: "success", result: "Line 2" },
     ];
 
     const output = new PassThrough();


### PR DESCRIPTION
The Claude Agent SDK emits `{ type: "result", subtype: "success" }` for
completed sessions, not `{ stop_reason: "end_turn" }`. The AgentRunner
was checking for `stop_reason` which was always undefined on result
messages, causing `fit-eval run` to exit with code 1 even on success.

https://claude.ai/code/session_01NvfWmv9UM7UpLLK8hgG3S3