### PR TITLE
fix(libeval): drain buffered output when agent subprocess crashes

### DIFF
--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -55,33 +55,38 @@ export class AgentRunner {
   async run(task) {
     let text = "";
     let stopReason = null;
+    let error = null;
 
-    for await (const message of this.query({
-      prompt: task,
-      options: {
-        cwd: this.cwd,
-        allowedTools: this.allowedTools,
-        maxTurns: this.maxTurns,
-        model: this.model,
-        permissionMode: this.permissionMode,
-        allowDangerouslySkipPermissions: true,
-      },
-    })) {
-      const line = JSON.stringify(message);
-      this.output.write(line + "\n");
-      this.buffer.push(line);
+    try {
+      for await (const message of this.query({
+        prompt: task,
+        options: {
+          cwd: this.cwd,
+          allowedTools: this.allowedTools,
+          maxTurns: this.maxTurns,
+          model: this.model,
+          permissionMode: this.permissionMode,
+          allowDangerouslySkipPermissions: true,
+        },
+      })) {
+        const line = JSON.stringify(message);
+        this.output.write(line + "\n");
+        this.buffer.push(line);
 
-      if (message.type === "system" && message.subtype === "init") {
-        this.sessionId = message.session_id;
+        if (message.type === "system" && message.subtype === "init") {
+          this.sessionId = message.session_id;
+        }
+        if (message.type === "result") {
+          text = message.result ?? "";
+          stopReason = message.subtype;
+        }
       }
-      if (message.type === "result") {
-        text = message.result ?? "";
-        stopReason = message.subtype;
-      }
+    } catch (err) {
+      error = err;
     }
 
-    const success = stopReason === "success";
-    return { success, text, sessionId: this.sessionId };
+    const success = !error && stopReason === "success";
+    return { success, text, sessionId: this.sessionId, error };
   }
 
   /**
@@ -92,23 +97,28 @@ export class AgentRunner {
   async resume(prompt) {
     let text = "";
     let stopReason = null;
+    let error = null;
 
-    for await (const message of this.query({
-      prompt,
-      options: { resume: this.sessionId },
-    })) {
-      const line = JSON.stringify(message);
-      this.output.write(line + "\n");
-      this.buffer.push(line);
+    try {
+      for await (const message of this.query({
+        prompt,
+        options: { resume: this.sessionId },
+      })) {
+        const line = JSON.stringify(message);
+        this.output.write(line + "\n");
+        this.buffer.push(line);
 
-      if (message.type === "result") {
-        text = message.result ?? "";
-        stopReason = message.subtype;
+        if (message.type === "result") {
+          text = message.result ?? "";
+          stopReason = message.subtype;
+        }
       }
+    } catch (err) {
+      error = err;
     }
 
-    const success = stopReason === "success";
-    return { success, text };
+    const success = !error && stopReason === "success";
+    return { success, text, error };
   }
 
   /**

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -48,6 +48,11 @@ export class Supervisor {
     let agentResult = await this.agentRunner.run(task);
     this.emitTagged("agent", 0);
 
+    if (agentResult.error) {
+      this.emitSummary({ success: false, turns: 0 });
+      return { success: false, turns: 0 };
+    }
+
     for (let turn = 1; turn <= this.maxTurns; turn++) {
       // Supervisor observes the agent's output
       const supervisorPrompt =
@@ -62,6 +67,11 @@ export class Supervisor {
       }
       this.emitTagged("supervisor", turn);
 
+      if (supervisorResult.error) {
+        this.emitSummary({ success: false, turns: turn });
+        return { success: false, turns: turn };
+      }
+
       if (isDone(supervisorResult.text)) {
         this.emitSummary({ success: true, turns: turn });
         return { success: true, turns: turn };
@@ -70,6 +80,11 @@ export class Supervisor {
       // Supervisor's response becomes the agent's next input
       agentResult = await this.agentRunner.resume(supervisorResult.text);
       this.emitTagged("agent", turn);
+
+      if (agentResult.error) {
+        this.emitSummary({ success: false, turns: turn });
+        return { success: false, turns: turn };
+      }
     }
 
     this.emitSummary({ success: false, turns: this.maxTurns });

--- a/libraries/libeval/test/agent-runner.test.js
+++ b/libraries/libeval/test/agent-runner.test.js
@@ -229,6 +229,58 @@ describe("AgentRunner", () => {
     assert.strictEqual(secondDrain.length, 0);
   });
 
+  test("run() captures error when query throws and returns buffered output", async () => {
+    async function* failingQuery() {
+      yield { type: "system", subtype: "init", session_id: "sess-err" };
+      yield { type: "assistant", content: "Partial work" };
+      throw new Error("Claude Code process exited with code 1");
+    }
+
+    const output = new PassThrough();
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: () => failingQuery(),
+      output,
+    });
+
+    const result = await runner.run("Task");
+    assert.strictEqual(result.success, false);
+    assert.ok(result.error);
+    assert.match(result.error.message, /exited with code 1/);
+    assert.strictEqual(result.sessionId, "sess-err");
+
+    // Buffered output should contain the messages yielded before the error
+    const drained = runner.drainOutput();
+    assert.strictEqual(drained.length, 2);
+  });
+
+  test("resume() captures error when query throws", async () => {
+    const initMessages = [
+      { type: "system", subtype: "init", session_id: "sess-r" },
+      { type: "result", subtype: "success", result: "OK" },
+    ];
+
+    let callCount = 0;
+    const query = async function* () {
+      callCount++;
+      if (callCount === 1) {
+        for (const m of initMessages) yield m;
+      } else {
+        yield { type: "assistant", content: "Resuming..." };
+        throw new Error("Process crashed");
+      }
+    };
+
+    const output = new PassThrough();
+    const runner = new AgentRunner({ cwd: "/tmp", query, output });
+
+    await runner.run("Task");
+    const result = await runner.resume("Continue");
+    assert.strictEqual(result.success, false);
+    assert.ok(result.error);
+    assert.match(result.error.message, /Process crashed/);
+  });
+
   test("createAgentRunner factory returns an AgentRunner instance", () => {
     const runner = createAgentRunner({
       cwd: "/tmp",

--- a/libraries/libeval/test/supervisor.test.js
+++ b/libraries/libeval/test/supervisor.test.js
@@ -273,6 +273,54 @@ describe("Supervisor", () => {
     assert.strictEqual(tagged.event.source, "sdk-internal");
   });
 
+  test("drains agent output and emits summary when agent errors on turn 0", async () => {
+    const agentMessages = [[{ type: "assistant", content: "Partial work" }]];
+    const agentRunner = createMockRunner(
+      [{ text: "Partial work", success: false }],
+      agentMessages,
+    );
+
+    // Override run to simulate an error return
+    const origRun = agentRunner.run;
+    agentRunner.run = async (task) => {
+      const result = await origRun.call(agentRunner, task);
+      return { ...result, error: new Error("Process exited with code 1") };
+    };
+
+    const supervisorRunner = createMockRunner([]);
+
+    const output = new PassThrough();
+    const supervisor = new Supervisor({
+      agentRunner,
+      supervisorRunner,
+      output,
+      maxTurns: 10,
+    });
+
+    const result = await supervisor.run("Task");
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.turns, 0);
+
+    // Output should still contain the agent's buffered lines + summary
+    const data = output.read()?.toString() ?? "";
+    const lines = data
+      .trim()
+      .split("\n")
+      .filter((l) => l.length > 0);
+
+    assert.ok(lines.length >= 2, "Expected at least agent line + summary");
+
+    const agentLine = JSON.parse(lines[0]);
+    assert.strictEqual(agentLine.source, "agent");
+    assert.strictEqual(agentLine.turn, 0);
+
+    const summaryLine = JSON.parse(lines[lines.length - 1]);
+    assert.strictEqual(summaryLine.source, "orchestrator");
+    assert.strictEqual(summaryLine.success, false);
+    assert.strictEqual(summaryLine.turns, 0);
+  });
+
   test("createSupervisor factory returns a Supervisor instance", () => {
     const supervisor = createSupervisor({
       supervisorCwd: "/tmp/sup",


### PR DESCRIPTION
When the Claude Code subprocess exits with a non-zero code, the SDK
query iterator throws. Previously this propagated through AgentRunner
→ Supervisor → CLI, skipping emitTagged() entirely — so the trace
file stayed empty (0 bytes) and no text reached stdout.

Fix: AgentRunner.run()/resume() now catch iterator errors and return
them in the result instead of throwing. Supervisor.run() checks for
errors after each step and still drains buffered output via
emitTagged() before emitting a failure summary.

https://claude.ai/code/session_014jHC4iZ4324W7xV1naeCtk