### PR TITLE
fix(ci): increase agent max-turns to prevent premature exhaustion

### DIFF
--- a/.github/actions/fit-eval/action.yml
+++ b/.github/actions/fit-eval/action.yml
@@ -27,7 +27,7 @@ inputs:
   max-turns:
     description: Maximum turns
     required: false
-    default: "50"
+    default: "200"
   allowed-tools:
     description: Comma-separated list of allowed tools
     required: false

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -47,4 +47,4 @@ jobs:
           task: .github/tasks/dependabot-triage.md
           agent-profile: "security-engineer"
           model: "opus"
-          max-turns: "50"
+          max-turns: "200"

--- a/.github/workflows/guide-setup.yml
+++ b/.github/workflows/guide-setup.yml
@@ -56,5 +56,5 @@ jobs:
           agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
           supervisor-profile: "product-manager"
           model: "opus"
-          max-turns: "20"
+          max-turns: "50"
           allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,WebFetch,WebSearch"

--- a/.github/workflows/improvement-coach.yml
+++ b/.github/workflows/improvement-coach.yml
@@ -48,4 +48,4 @@ jobs:
           task: .github/tasks/improvement-coach.md
           agent-profile: "improvement-coach"
           model: "opus"
-          max-turns: "50"
+          max-turns: "200"

--- a/.github/workflows/product-backlog.yml
+++ b/.github/workflows/product-backlog.yml
@@ -48,4 +48,4 @@ jobs:
           task: .github/tasks/product-backlog.md
           agent-profile: "product-manager"
           model: "opus"
-          max-turns: "50"
+          max-turns: "200"

--- a/.github/workflows/product-feedback.yml
+++ b/.github/workflows/product-feedback.yml
@@ -48,4 +48,4 @@ jobs:
           task: .github/tasks/product-feedback.md
           agent-profile: "product-manager"
           model: "opus"
-          max-turns: "50"
+          max-turns: "200"

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -48,4 +48,4 @@ jobs:
           task: .github/tasks/release-readiness.md
           agent-profile: "release-engineer"
           model: "opus"
-          max-turns: "50"
+          max-turns: "200"

--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -48,4 +48,4 @@ jobs:
           task: .github/tasks/release-review.md
           agent-profile: "release-engineer"
           model: "opus"
-          max-turns: "50"
+          max-turns: "200"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -47,4 +47,4 @@ jobs:
           task: .github/tasks/security-audit.md
           agent-profile: "security-engineer"
           model: "opus"
-          max-turns: "50"
+          max-turns: "200"


### PR DESCRIPTION
Security audit (run 23858105830) hit error_max_turns after only 2m44s at
50 turns — not enough for even basic audits. Increase run-mode workflows
from 50 to 200 turns, supervise-mode from 20 to 50, and action default
from 50 to 200.

https://claude.ai/code/session_018nsYohVCEaR7BjsMDbD1Zt