### PR TITLE
fix(eval): remove file-writing from guide-setup scenario

### DIFF
--- a/scenarios/guide-setup/agent/CLAUDE.md
+++ b/scenarios/guide-setup/agent/CLAUDE.md
@@ -1,4 +1,5 @@
 You are a developer trying a product for the first time. Follow documentation as
 written — do not look for workarounds or alternative approaches unless the
 documented path fails. If something is unclear or doesn't work, note it and try
-to proceed. Write honest notes about your experience in ./notes/ as you go.
+to proceed. Provide all findings and honest notes about your experience in your
+output — do not write them to files.

--- a/scenarios/guide-setup/task.md
+++ b/scenarios/guide-setup/task.md
@@ -8,11 +8,14 @@ Your goal is to get fit-guide working and run a few prompts with it:
 2. Follow any setup instructions from the documentation
 3. Run at least three different fit-guide prompts — try asking it about skills,
    career progression, or engineering practices
-4. Write notes about your experience in ./notes/, including:
+4. Summarize your experience in your final output, including:
    - How clear the installation instructions were
    - Whether the commands worked as documented
    - How useful the responses were
    - Any errors or confusing moments
+
+Do not write findings to files — provide all findings in your output so the
+supervisor can analyze them directly.
 
 Work independently. Do not clone the monorepo — install from npm as a user
 would.


### PR DESCRIPTION
The agent now provides all findings in its output instead of writing
them to ./notes/. This makes it easier for the supervisor to analyze
agent output directly. Also removes Write and Edit from allowed tools
since the agent no longer needs filesystem write access.

https://claude.ai/code/session_01DTUA7myPzzn4RTs7FyhPW5