### PR TITLE
fix(guide): publish fit-rc so external users can start the service stack

### DIFF
--- a/libraries/librc/package.json
+++ b/libraries/librc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/librc",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Service manager for Forward Impact",
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
@@ -9,6 +9,10 @@
   "bin": {
     "fit-rc": "./bin/fit-rc.js"
   },
+  "files": [
+    "bin/",
+    "*.js"
+  ],
   "engines": {
     "bun": ">=1.2.0",
     "node": ">=18.0.0"

--- a/products/guide/bin/fit-guide.js
+++ b/products/guide/bin/fit-guide.js
@@ -85,7 +85,7 @@ services must be available:
 To get started:
 
   1. Run: npx fit-guide --init
-  2. Start the service stack and set SERVICE_SECRET
+  2. Start the service stack: npx fit-rc start
   3. Run: npx fit-guide
 
 Documentation: https://www.forwardimpact.team/guide
@@ -203,7 +203,7 @@ Error: ${err.message}
 Ensure all required services are running:
   agent, llm, memory, graph, vector, tool, trace, web
 
-For local development: just rc-start
+Start the service stack: npx fit-rc start
 Documentation: https://www.forwardimpact.team/guide`);
   process.exit(1);
 }

--- a/products/guide/package.json
+++ b/products/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forwardimpact/guide",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Conversational agent for engineering framework guidance — How do I find my bearing?",
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@forwardimpact/libcodegen": "^0.1.32",
+    "@forwardimpact/librc": "^0.1.16",
     "@forwardimpact/libconfig": "^0.1.58",
     "@forwardimpact/libsecret": "^0.1.7",
     "@forwardimpact/librepl": "^0.1.0",

--- a/website/docs/getting-started/engineers/index.md
+++ b/website/docs/getting-started/engineers/index.md
@@ -91,6 +91,17 @@ npx fit-guide --init
 The `fit-codegen` step generates gRPC service clients that Guide needs. Without
 it, imports fail with a missing module error.
 
+### Start the service stack
+
+Guide requires a running service stack. Start it before launching Guide:
+
+```sh
+npx fit-rc start
+```
+
+This supervises all required microservices (trace, vector, graph, llm, memory,
+tool, agent, web) in dependency order. Stop them with `npx fit-rc stop`.
+
 ### Usage
 
 ```sh

--- a/website/docs/internals/guide/index.md
+++ b/website/docs/internals/guide/index.md
@@ -89,7 +89,8 @@ dependency order:
 | 8     | agent   | Agent orchestration and handoffs         | 3008 |
 | 9     | web     | HTTP API and web interface               | 3001 |
 
-Start all services with `bunx fit-rc start` or `just rc-start`.
+Start all services with `npx fit-rc start` (external) or `just rc-start`
+(internal contributors).
 
 ---
 

--- a/website/docs/reference/cli/index.md
+++ b/website/docs/reference/cli/index.md
@@ -3,8 +3,8 @@ title: CLI Reference
 description: Commands, arguments, and options for all Forward Impact CLI tools.
 ---
 
-> **Availability:** `fit-pathway`, `fit-map`, and `fit-basecamp` are published
-> to npm and can be installed standalone. `fit-guide`, `fit-summit`, `fit-rc`,
+> **Availability:** `fit-pathway`, `fit-map`, `fit-basecamp`, `fit-guide`, and
+> `fit-rc` are published to npm and can be installed standalone. `fit-summit`,
 > `fit-doc`, and `fit-universe` are monorepo-only tools that require a full
 > checkout of the [monorepo](https://github.com/forwardimpact/monorepo).
 
@@ -273,6 +273,32 @@ npx fit-universe --cache=path        # Custom prose cache file
 | `--dry-run`      | Preview without writing files       |
 | `--story=<path>` | Path to custom story DSL file       |
 | `--cache=<path>` | Path to custom prose cache file     |
+
+---
+
+## fit-rc
+
+Service stack supervisor for Guide. Manages microservices in dependency order.
+
+```sh
+npx fit-rc start              # Start all services
+npx fit-rc stop               # Graceful shutdown
+npx fit-rc restart            # Restart all services
+npx fit-rc status             # Show service status
+npx fit-rc start <service>   # Start up to a specific service
+```
+
+| Command   | Description                             |
+| --------- | --------------------------------------- |
+| `start`   | Start services in dependency order      |
+| `stop`    | Graceful shutdown of all services       |
+| `restart` | Stop and restart all services           |
+| `status`  | Show running status of each service     |
+
+| Option          | Description       |
+| --------------- | ----------------- |
+| `-s`, `--silent` | Suppress output  |
+| `-h`, `--help`   | Show help message |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `@forwardimpact/librc` as a dependency of `@forwardimpact/guide` so `npx fit-rc start` works after `npm install @forwardimpact/guide`
- Add `files` field to librc's package.json for clean npm publishing
- Update `fit-guide` CLI error messages to reference `npx fit-rc start` instead of internal-only `just rc-start`
- Update CLI reference docs: move `fit-rc` from monorepo-only to published, add full `fit-rc` command docs
- Add "Start the service stack" step to the engineers getting-started guide
- Update Guide internals docs to show `npx fit-rc start` for external users

Bumps `@forwardimpact/librc` to 0.1.16 and `@forwardimpact/guide` to 0.1.12.

Closes #207

## Test plan

- [x] `bun run check` passes (1901 tests, 0 failures)
- [ ] After merge, tag `librc@v0.1.16` and `guide@v0.1.12` to trigger publish
- [ ] Verify `npm install @forwardimpact/guide` pulls in `fit-rc` binary
- [ ] Verify `npx fit-rc start` resolves correctly

https://claude.ai/code/session_012sN7EaUhhf42LVyjMip6tn