### PR TITLE
fix(guide): update JSDoc comment to use npx instead of bunx

### DIFF
--- a/products/guide/bin/fit-guide.js
+++ b/products/guide/bin/fit-guide.js
@@ -5,8 +5,8 @@
  * Conversational agent interface for the Guide knowledge platform.
  *
  * Usage:
- *   bunx fit-guide
- *   echo "Tell me about the company" | bunx fit-guide
+ *   npx fit-guide
+ *   echo "Tell me about the company" | npx fit-guide
  */
 
 import { resolve } from "path";


### PR DESCRIPTION
## Summary

- Fix stale `bunx` references in fit-guide.js JSDoc comment to use `npx`

Follow-up cleanup from #209.

https://claude.ai/code/session_012sN7EaUhhf42LVyjMip6tn