### PR TITLE
fix(libcodegen): add "type": "module" to generated package.json

### DIFF
--- a/libraries/libcodegen/bin/fit-codegen.js
+++ b/libraries/libcodegen/bin/fit-codegen.js
@@ -296,6 +296,16 @@ async function runCodegen(protoDirs, projectRoot, finder) {
 
   await generatedStorage.ensureBucket();
 
+  // Write package.json with "type": "module" so Node.js treats generated
+  // ES module files correctly and avoids MODULE_TYPELESS_PACKAGE_JSON warnings.
+  const generatedPkgPath = path.join(sourcePath, "package.json");
+  if (!fs.existsSync(generatedPkgPath)) {
+    fs.writeFileSync(
+      generatedPkgPath,
+      JSON.stringify({ type: "module" }, null, 2) + "\n",
+    );
+  }
+
   const codegens = createCodegen(
     protoDirs,
     projectRoot,


### PR DESCRIPTION
Generated exports.js files use ES module syntax but the generated
directory lacked a package.json with "type": "module", causing
Node.js MODULE_TYPELESS_PACKAGE_JSON warnings on every fit-guide run.

Fixes #201

https://claude.ai/code/session_01G7httGDm9ipGBMqDbxLUut