### PR TITLE
fix(guide): fix Guide getting-started onboarding flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,13 @@ Commit format: `type(scope): subject` — see CONTRIBUTING.md § Git Conventions
 
 Run `bun run check` before every commit — code **and** documentation.
 
+## LLM Environment
+
+If `LLM_TOKEN` is not set in `.env` it will **always** be set in the shell
+environment. Testers or contributors never need to generate or configure an LLM
+key — `libconfig` reads `LLM_TOKEN` and `LLM_BASE_URL` from the process
+environment, so testing with an LLM will always "just work".
+
 ## Structure
 
 Plain JS + JSDoc, YAML, no frameworks.

--- a/libraries/libsecret/index.js
+++ b/libraries/libsecret/index.js
@@ -86,8 +86,9 @@ export async function updateEnvFile(key, value, envPath = ".env") {
     lines.push(envLine);
   }
 
-  // Write back to file
-  await fs.writeFile(fullPath, lines.join("\n"));
+  // Write back to file — ensure trailing newline for POSIX compatibility
+  const output = lines.join("\n");
+  await fs.writeFile(fullPath, output.endsWith("\n") ? output : output + "\n");
 }
 
 /**

--- a/libraries/libsecret/test/libsecret.test.js
+++ b/libraries/libsecret/test/libsecret.test.js
@@ -231,6 +231,26 @@ describe("libsecret", () => {
       assert.ok(content.includes("SECOND_KEY=second-value"));
     });
 
+    test("output always ends with trailing newline", async () => {
+      await updateEnvFile("KEY_A", "value-a", envPath);
+      let content = await fs.readFile(envPath, "utf8");
+      assert.ok(content.endsWith("\n"), "new file should end with newline");
+
+      await updateEnvFile("KEY_B", "value-b", envPath);
+      content = await fs.readFile(envPath, "utf8");
+      assert.ok(
+        content.endsWith("\n"),
+        "file with appended key should end with newline",
+      );
+
+      await updateEnvFile("KEY_A", "updated", envPath);
+      content = await fs.readFile(envPath, "utf8");
+      assert.ok(
+        content.endsWith("\n"),
+        "file with updated key should end with newline",
+      );
+    });
+
     test("uses default .env path when not specified", async () => {
       // This test creates a file in the current directory, so we mock it carefully
       const defaultPath = path.join(tempDir, ".env");

--- a/products/guide/bin/fit-guide.js
+++ b/products/guide/bin/fit-guide.js
@@ -69,6 +69,7 @@ if (process.argv.includes("--init")) {
 
   // Assign unique ports so services don't all bind to the default 3000
   const serviceUrls = {
+    SERVICE_WEB_URL: "http://localhost:3001",
     SERVICE_AGENT_URL: "grpc://localhost:3002",
     SERVICE_MEMORY_URL: "grpc://localhost:3003",
     SERVICE_LLM_URL: "grpc://localhost:3004",
@@ -85,7 +86,7 @@ if (process.argv.includes("--init")) {
   console.log("SERVICE_SECRET was updated in .env");
   console.log("JWT_SECRET is set in .env");
   console.log("JWT_ANON_KEY was updated in .env");
-  console.log("Service URLs written to .env (ports 3002–3008).");
+  console.log("Service URLs written to .env (ports 3001–3008).");
 
   // Copy starter config into ./config/ (config.json, agents/, tools.yml)
   const starterDir = new URL("../starter", import.meta.url).pathname;
@@ -125,7 +126,7 @@ if (!process.env.SERVICE_SECRET) {
 Guide requires a running service stack to function. The following
 services must be available:
 
-  agent, llm, memory, graph, vector, tool, trace
+  agent, llm, memory, graph, vector, tool, trace, web
 
 To get started:
 

--- a/products/guide/package.json
+++ b/products/guide/package.json
@@ -50,7 +50,8 @@
     "@forwardimpact/svcmemory": "^0.1.87",
     "@forwardimpact/svctool": "^0.1.91",
     "@forwardimpact/svctrace": "^0.1.34",
-    "@forwardimpact/svcvector": "^0.1.111"
+    "@forwardimpact/svcvector": "^0.1.111",
+    "@forwardimpact/svcweb": "^0.1.5"
   },
   "publishConfig": {
     "access": "public"

--- a/products/guide/starter/config.json
+++ b/products/guide/starter/config.json
@@ -30,6 +30,10 @@
       {
         "name": "agent",
         "command": "node -e \"import('@forwardimpact/svcagent/server.js')\""
+      },
+      {
+        "name": "web",
+        "command": "node -e \"import('@forwardimpact/svcweb/server.js')\""
       }
     ]
   },

--- a/website/docs/getting-started/engineers/index.md
+++ b/website/docs/getting-started/engineers/index.md
@@ -110,18 +110,25 @@ npx fit-guide --init
 The `fit-codegen` step generates gRPC service clients that Guide needs. Without
 it, imports fail with a missing module error.
 
+The `--init` step generates:
+
+- `.env` — service secrets and port assignments
+- `config/config.json` — service configuration with agent, LLM, memory, and tool
+  settings
+- `config/agents/` — agent definitions (planner, researcher, editor)
+- `config/tools.yml` — tool descriptors for the agent pipeline
+
 ### Configure LLM credentials
 
-Guide needs access to an LLM provider. Add your credentials to the `.env` file
-created by `--init`:
+Guide needs access to an LLM provider. Open `.env` in your editor and append:
 
-```sh
-echo 'LLM_TOKEN=your-api-key' >> .env
-echo 'LLM_BASE_URL=https://api.anthropic.com' >> .env
+```
+LLM_TOKEN=your-api-key
+LLM_BASE_URL=https://api.anthropic.com
 ```
 
-Replace the values with your actual API key and provider endpoint. Without these
-variables, Guide fails at runtime with a `13 INTERNAL` gRPC error.
+Replace the values with your actual API key and provider endpoint. Guide
+validates these on startup and reports which variables are missing.
 
 ### Start the service stack
 
@@ -134,7 +141,7 @@ npx fit-rc start
 ```
 
 This supervises all required microservices (trace, vector, graph, llm, memory,
-tool, agent) in dependency order. Stop them with `npx fit-rc stop`.
+tool, agent, web) in dependency order. Stop them with `npx fit-rc stop`.
 
 ### Usage
 
@@ -178,10 +185,22 @@ background work. The CLI scheduler works on any platform.
 
 ## Troubleshooting
 
-### Guide: `13 INTERNAL: Cannot read properties of undefined`
+### Guide: configuration errors on startup
 
-The LLM credentials are missing or incorrect. Verify that `LLM_TOKEN` and
-`LLM_BASE_URL` are set in your `.env` file, then reload:
+Guide validates configuration before connecting. If you see errors about missing
+`service.agent.agent`, `service.agent.model`, `LLM_TOKEN`, or `LLM_BASE_URL`,
+check that:
+
+1. You ran `npx fit-guide --init` (creates `config/config.json` with the
+   `service` section)
+2. Your `.env` file contains `LLM_TOKEN` and `LLM_BASE_URL`
+3. You sourced the environment: `set -a && source .env && set +a`
+
+### Guide: `13 INTERNAL` gRPC error
+
+A `13 INTERNAL` error during a conversation usually means the LLM service cannot
+reach the provider. Verify that `LLM_TOKEN` and `LLM_BASE_URL` are correct in
+`.env`, then restart the services:
 
 ```sh
 set -a && source .env && set +a
@@ -207,11 +226,6 @@ cat data/logs/llm/current   # View the LLM service log (example)
 
 Each microservice writes to `data/logs/{service}/current`. Common causes are
 missing environment variables or port conflicts.
-
-### Guide: agent configuration not found
-
-Ensure `service.agent` is configured in `config/config.json`. Running
-`npx fit-guide --init` generates the default configuration.
 
 ---
 


### PR DESCRIPTION
- Fix updateEnvFile in libsecret to always write a trailing newline,
  preventing .env corruption when users append with `echo >>`
- Add web service to starter config, --init URLs, package.json dep,
  and all service list mentions in CLI and docs
- Remove EMBEDDING_BASE_URL from getting-started docs (TEI is optional)
- Document full --init output (config, agents, tools) in engineer docs
- Replace echo-based .env instructions with editor-based workflow
- Improve troubleshooting: separate config errors from runtime errors
- Add "LLM Environment" section to CLAUDE.md documenting that
  LLM_TOKEN is always in the shell environment for testers and
  contributors

https://claude.ai/code/session_01JTVnF4mxdjzw6p7BPwHFeN