### PR TITLE
fix(guide): move production imports from devDependencies to dependencies

### DIFF
--- a/libraries/libagent/package.json
+++ b/libraries/libagent/package.json
@@ -17,12 +17,12 @@
     "test": "bun run node --test test/*.test.js"
   },
   "dependencies": {
+    "@forwardimpact/libdoc": "^0.2.0",
     "@forwardimpact/libsecret": "^0.1.3",
     "@forwardimpact/libtelemetry": "^0.1.22",
     "@forwardimpact/libtype": "^0.1.63"
   },
   "devDependencies": {
-    "@forwardimpact/libdoc": "^0.2.0",
     "@forwardimpact/libharness": "^0.1.5"
   },
   "publishConfig": {

--- a/libraries/libresource/package.json
+++ b/libraries/libresource/package.json
@@ -29,13 +29,13 @@
     "@forwardimpact/libtelemetry": "^0.1.22",
     "@forwardimpact/libtype": "^0.1.63",
     "@forwardimpact/libutil": "^0.1.60",
-    "html-minifier-terser": "^7.2.0"
-  },
-  "devDependencies": {
+    "html-minifier-terser": "^7.2.0",
     "jsdom": "^29.0.1",
     "microdata-rdf-streaming-parser": "^3.0.0",
     "n3": "^2.0.3",
-    "rdf-canonize": "^5.0.0",
+    "rdf-canonize": "^5.0.0"
+  },
+  "devDependencies": {
     "@forwardimpact/libharness": "^0.1.5"
   },
   "publishConfig": {

--- a/website/docs/getting-started/engineers/index.md
+++ b/website/docs/getting-started/engineers/index.md
@@ -70,7 +70,7 @@ Generate a complete job definition by combining a discipline, level, and
 optional track:
 
 ```sh
-npx fit-pathway job software_engineering L3 --track=platform
+npx fit-pathway job software_engineering J040 --track=platform
 ```
 
 This produces a full view of the skills, behaviours, and expectations for that


### PR DESCRIPTION
libagent imports @forwardimpact/libdoc in processor/agent.js and
libresource imports jsdom, microdata-rdf-streaming-parser, n3, and
rdf-canonize in processor/resource.js and parser.js. These were listed
as devDependencies so external users hit ERR_MODULE_NOT_FOUND when
running fit-process-agents and fit-process-resources after npm install.

Also fix the getting-started docs job example to use J040 (a level that
exists in the starter data) instead of L3 which fails with the starter
framework.

https://claude.ai/code/session_012ZTJ3aidijYgoGPB1ayuM4