### PR TITLE
fix(libconfig): trim env values in #resolve

### DIFF
--- a/libraries/libconfig/config.js
+++ b/libraries/libconfig/config.js
@@ -218,6 +218,7 @@ export class Config {
 
     let value = this.#env(key);
     if (value) {
+      value = value.trim();
       if (transform) value = transform(value);
       this.#cache.set(key, value);
       return value;


### PR DESCRIPTION
## Summary

- Trim `process.env` values in `Config#resolve()` to handle accidental leading/trailing whitespace
- Fixes 401 Unauthorized from GitHub Models when `LLM_TOKEN` has a leading space (producing `Bearer  <token>` with double space in the Authorization header)
- `#resolve()` is the single gateway for all config lookups (tokens, URLs, secrets), so one trim covers every consumer

## Test plan

- [ ] Verify `libconfig.llmToken()` returns a trimmed value when `LLM_TOKEN` has leading whitespace
- [ ] Verify `createLlmApi` succeeds against GitHub Models org-scoped endpoint
- [ ] Verify existing libconfig tests pass

https://claude.ai/code/session_01TAiQU8nRhHXRThrGMmpDqw