### PR TITLE
chore: remove map validation from check command

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prestart": "bunx fit-pathway build",
     "start": "bunx serve public",
     "dev": "bunx fit-pathway dev",
-    "check": "bun run format & p1=$!; bun run lint & p2=$!; bun run test & p3=$!; bun run validate -- --json & p4=$!; wait $p1 && wait $p2 && wait $p3 && wait $p4",
+    "check": "bun run format & p1=$!; bun run lint & p2=$!; bun run test & p3=$!; wait $p1 && wait $p2 && wait $p3",
     "check:fix": "bun run format:fix && bun run lint:fix",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
Drop `bun run validate -- --json` from the `check` script so that
`bun run check` runs only format, lint, and test.

https://claude.ai/code/session_0197JMhWphvzgwHiKbLQmCJt