### PR TITLE
fix(skills): correct refactored CI skill inaccuracies

### DIFF
--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -9,6 +9,7 @@ model: opus
 skills:
   - product-backlog
   - product-feedback
+  - product-evaluation
   - spec
   - gh-cli
 ---
@@ -36,6 +37,10 @@ Determine which workflow to use from the task prompt:
 3. **User testing feedback** — Follow the `product-feedback` skill (Part 2).
    When skill access is limited (e.g. resumed session), use `gh issue create`
    directly.
+
+4. **Product evaluation** — When supervising a `fit-eval supervise` relay,
+   follow the `product-evaluation` skill. Brief the agent, observe the session,
+   capture feedback, and create issues via `product-feedback` Part 2.
 
 ## Constraints
 

--- a/.claude/skills/grounded-theory-analysis/scripts/trace-queries.sh
+++ b/.claude/skills/grounded-theory-analysis/scripts/trace-queries.sh
@@ -32,7 +32,9 @@ case "$CMD" in
     jq ".turns[-$N:]" "$FILE"
     ;;
   errors)
-    jq '.turns[] | select(.role == "tool_result" and .isError == true) | {index, content: .content[0:200]}' "$FILE"
+    # Stringify content first (it may be a string or an array of blocks),
+    # then truncate to 200 characters for readability.
+    jq '.turns[] | select(.role == "tool_result" and .isError == true) | {index, content: (.content | tostring | .[0:200])}' "$FILE"
     ;;
   tools)
     jq '[.turns[] | select(.role == "assistant") | .content[] | select(.type == "tool_use") | .name] | group_by(.) | map({tool: .[0], count: length}) | sort_by(-.count)' "$FILE"

--- a/.claude/skills/release-review/SKILL.md
+++ b/.claude/skills/release-review/SKILL.md
@@ -133,4 +133,6 @@ If a publish fails, investigate with `gh run view <run-id> --log-failed`.
 
 - **First release**: Skip packages with version `0.0.0` or `"private": true`.
 - **Failed publish**: Don't delete the tag. Fix, bump patch, re-tag.
-- **Dependency chain**: Release in order: map → libskill → pathway/summit.
+- **Dependency chain**: Release foundational packages before consumers — for
+  example, `map` and `libskill` must be released before `pathway` (which depends
+  on both). Check `package.json` dependencies before tagging.

--- a/.claude/skills/security-update/references/sha-inventory.md
+++ b/.claude/skills/security-update/references/sha-inventory.md
@@ -1,13 +1,40 @@
 # GitHub Actions SHA Inventory
 
 When evaluating SHA pinning (Policy Check 2), verify the PR updates **all**
-workflow files that reference the action.
+workflow files and composite actions that reference the action.
 
-| Action                          | Workflow files                                                                                                              |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `actions/checkout`              | check-quality.yml, check-test.yml, check-security.yml, publish-npm.yml, publish-macos.yml, publish-skills.yml, website.yaml |
-| `actions/setup-node`            | check-quality.yml, check-test.yml, check-security.yml, publish-npm.yml, website.yaml                                        |
-| `actions/configure-pages`       | website.yaml                                                                                                                |
-| `actions/upload-pages-artifact` | website.yaml                                                                                                                |
-| `actions/deploy-pages`          | website.yaml                                                                                                                |
-| `denoland/setup-deno`           | publish-macos.yml                                                                                                           |
+## Third-Party Actions
+
+| Action                            | Files                                                                                                                                                                                                                                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `actions/checkout`                | check-quality.yml, check-test.yml, check-security.yml, publish-npm.yml, publish-macos.yml, publish-skills.yml (×2), website.yaml, guide-setup.yml, improvement-coach.yml, product-backlog.yml, product-feedback.yml, release-readiness.yml, release-review.yml, security-audit.yml, security-update.yml |
+| `actions/create-github-app-token` | guide-setup.yml (×2), improvement-coach.yml, product-backlog.yml, product-feedback.yml, publish-skills.yml, release-readiness.yml, release-review.yml, security-audit.yml, security-update.yml                                                                                                          |
+| `actions/setup-node`              | check-security.yml, publish-npm.yml, website.yaml                                                                                                                                                                                                                                                       |
+| `actions/cache`                   | check-test.yml                                                                                                                                                                                                                                                                                          |
+| `actions/upload-artifact`         | .github/actions/fit-eval/action.yml (×3)                                                                                                                                                                                                                                                                |
+| `actions/configure-pages`         | website.yaml                                                                                                                                                                                                                                                                                            |
+| `actions/upload-pages-artifact`   | website.yaml                                                                                                                                                                                                                                                                                            |
+| `actions/deploy-pages`            | website.yaml                                                                                                                                                                                                                                                                                            |
+| `oven-sh/setup-bun`               | website.yaml, .github/actions/bootstrap/action.yml                                                                                                                                                                                                                                                      |
+
+## Composite Actions
+
+Composite actions in `.github/actions/` are consumed by most agent workflows via
+`uses: ./.github/actions/<name>` and inherit any third-party action references
+they contain. When updating a SHA used inside a composite action, no workflow
+file changes are needed — only the composite action's `action.yml`.
+
+| Composite action            | Third-party actions used       |
+| --------------------------- | ------------------------------ |
+| `.github/actions/bootstrap` | `oven-sh/setup-bun`            |
+| `.github/actions/fit-eval`  | `actions/upload-artifact` (×3) |
+
+## Verification
+
+Before merging a Dependabot SHA bump, run:
+
+```sh
+grep -rn "<action>@" .github/workflows/ .github/actions/
+```
+
+Confirm every match has been updated to the new SHA.


### PR DESCRIPTION
Tested the four CI agents (improvement-coach, security-specialist,
release-manager, product-manager) against their refactored skills and
fixed the issues found:

- product-manager: add missing product-evaluation skill to profile and
  document the evaluation supervision workflow used by guide-setup.yml
- security-update: rewrite sha-inventory.md to cover all 15 workflows
  and composite actions, add actions/create-github-app-token,
  oven-sh/setup-bun, actions/upload-artifact, actions/cache, and
  remove the stale denoland/setup-deno entry
- grounded-theory-analysis: fix trace-queries.sh errors command which
  sliced array elements instead of characters when content is a block
  array (now stringifies before truncation)
- release-review: replace stale 'pathway/summit' dependency-chain
  example with a generic rule (summit package does not exist)