### PR TITLE
chore: separate check and test commands

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -46,7 +46,7 @@ Systematic, evidence-driven. Blame the system, never the worker. Sign off:
 - Ground every finding in trace evidence — quote tool calls, errors, token
   counts
 - Trust audit results when analyzing product-backlog traces
-- Run `bun run check` before committing
+- Run `bun run check` and `bun run test` before committing
 - Read `improvement-coach.md` at start (plus other agents' summaries for
   cross-agent context); write daily log to `improvement-coach-YYYY-MM-DD.md` and
   update `improvement-coach.md` at end with actions taken, observations for

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -50,7 +50,7 @@ Determine which workflow to use from the task prompt:
 - Never make code changes on PR branches (release-manager scope) — only on your
   own `fix/` branches from issues
 - Features always get a spec, never a direct implementation
-- Run `bun run check` before every commit
+- Run `bun run check` and `bun run test` before every commit
 - Read `product-manager.md` at start (plus other agents' summaries for
   cross-agent context); write daily log to `product-manager-YYYY-MM-DD.md` and
   update `product-manager.md` at end with actions taken, observations for

--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -42,7 +42,7 @@ Determine which workflow to use from the task prompt:
 - Never release from a broken `main` — repair trivial failures first
 - Push tags individually — never `git push --tags`
 - Release in dependency order when multiple packages change together
-- Run `bun run check` before committing
+- Run `bun run check` and `bun run test` before committing
 - Read `release-manager.md` at start (plus other agents' summaries for
   cross-agent context); write daily log to `release-manager-YYYY-MM-DD.md` and
   update `release-manager.md` at end with actions taken, observations for

--- a/.claude/agents/security-specialist.md
+++ b/.claude/agents/security-specialist.md
@@ -42,7 +42,7 @@ Determine which workflow to use from the task prompt:
 - Never weaken existing security policies
 - Never change a SHA pin to a tag reference
 - Never skip spec PRs — if findings need specs, file them
-- Run `bun run check` before committing
+- Run `bun run check` and `bun run test` before committing
 - Read `security-specialist.md` at start (plus other agents' summaries for
   cross-agent context); write daily log to `security-specialist-YYYY-MM-DD.md`
   and update `security-specialist.md` at end with actions taken, observations

--- a/.claude/skills/implement-spec/SKILL.md
+++ b/.claude/skills/implement-spec/SKILL.md
@@ -94,7 +94,8 @@ For each task:
 
 After all tasks are complete:
 
-1. Run `bun run check` to verify formatting, lint, tests, and validation pass.
+1. Run `bun run check` to verify formatting and lint pass, then `bun run test`
+   to verify unit tests pass.
 2. Run any spec-specific verification commands mentioned in the plan.
 3. Review the full diff (`git diff` from the starting point) against the spec's
    success criteria. Confirm every criterion is met.

--- a/.claude/skills/product-feedback/SKILL.md
+++ b/.claude/skills/product-feedback/SKILL.md
@@ -84,7 +84,7 @@ Classify as **trivial fix/bug** (clear, reproducible, mechanical fix),
 
 #### Step 3: Handle Trivial Fixes
 
-Implement the fix, run `bun run check`, create a fix PR. See
+Implement the fix, run `bun run check` and `bun run test`, create a fix PR. See
 `references/templates.md` § Fix PRs for branch, commit, and PR body templates.
 Label the issue `triaged`.
 

--- a/.claude/skills/product-feedback/references/templates.md
+++ b/.claude/skills/product-feedback/references/templates.md
@@ -75,6 +75,7 @@ git checkout main && git pull origin main
 git checkout -b fix/issue-<number>-<short-description>
 # ... implement fix ...
 bun run check
+bun run test
 git add <changed-files>
 git commit -m "fix(<scope>): <description>
 
@@ -111,6 +112,7 @@ git checkout main && git pull origin main
 git checkout -b spec/issue-<number>-<short-description>
 # ... write spec using spec skill ...
 bun run check
+bun run test
 git add specs/<NNN>-<name>/spec.md specs/STATUS
 git commit -m "spec(<scope>): <description>
 

--- a/.claude/skills/security-update/SKILL.md
+++ b/.claude/skills/security-update/SKILL.md
@@ -86,7 +86,7 @@ to Dependabot branches):
 ```sh
 git fetch origin <dependabot-branch>
 git checkout -b fix/dependabot-<number> origin/<dependabot-branch>
-# Make fixes, run bun run check && just audit
+# Make fixes, run bun run check && bun run test && just audit
 git commit -m "fix(deps): <description for PR #number>"
 git push -u origin fix/dependabot-<number>
 gh pr create --title "chore(deps): <description> (fixed)" \

--- a/.github/prompts/commit-push.prompt.md
+++ b/.github/prompts/commit-push.prompt.md
@@ -9,7 +9,7 @@ Follow the conventions in `CLAUDE.md` (Git Workflow section).
 1. Run `git diff` to review all changes
 2. Group related changes into logical, atomic commits
 3. Separate feature/logic changes from formatting changes
-4. Run `bun run check` to validate changes
+4. Run `bun run check` and `bun run test` to validate changes
 5. Assess version bump level for affected packages:
    - Breaking changes → major
    - New features → minor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,8 @@ consult the [Getting Started guides](website/docs/getting-started/).
 
 Commit format: `type(scope): subject` — see CONTRIBUTING.md § Git Conventions.
 
-Run `bun run check` before every commit — code **and** documentation.
+Run `bun run check` and `bun run test` before every commit — code **and**
+documentation.
 
 ## LLM Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,12 @@ constraints.
 1. Create a branch from `main`
 2. Make your changes
 3. Auto-fix formatting and lint: `bun run check:fix` (applies to all file types)
-4. Verify all checks pass: `bun run check` (required for code **and** docs)
-5. Run security audit: `just audit`
-6. Commit: `git commit -m "type(scope): subject"`
-7. Push and open a pull request against `main`
+4. Verify formatting and lint pass: `bun run check` (required for code **and**
+   docs)
+5. Run unit tests: `bun run test`
+6. Run security audit: `just audit`
+7. Commit: `git commit -m "type(scope): subject"`
+8. Push and open a pull request against `main`
 
 **Always commit your work before finishing a task.**
 
@@ -90,9 +92,9 @@ The release manager agent handles version bumps, tagging, and publishing. See
 ## Quality Commands
 
 ```sh
-bun run check                 # Format, lint, test, validate — ALL file types (run before every commit)
+bun run check                 # Format and lint — ALL file types (run before every commit)
 bun run check:fix             # Auto-fix format and lint issues
-bun run test                  # Unit tests (bun run node --test)
+bun run test                  # Unit tests (run before every commit)
 bun run test:e2e              # Playwright E2E tests (requires generated data)
 bunx fit-map validate         # Validate data files
 bunx fit-map validate --shacl # Validate with SHACL syntax check

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prestart": "bunx fit-pathway build",
     "start": "bunx serve public",
     "dev": "bunx fit-pathway dev",
-    "check": "bun run format & p1=$!; bun run lint & p2=$!; bun run test & p3=$!; wait $p1 && wait $p2 && wait $p3",
+    "check": "bun run format && bun run lint",
     "check:fix": "bun run format:fix && bun run lint:fix",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/website/docs/getting-started/contributors/index.md
+++ b/website/docs/getting-started/contributors/index.md
@@ -49,14 +49,16 @@ just synthetic-no-prose   # Structural data only, no prose content
 
 ## Run checks
 
-Run the full quality suite before committing:
+Run formatting and linting, then unit tests, before committing:
 
 ```sh
 bun run check
+bun run test
 ```
 
-This runs formatting (Prettier), linting (ESLint), unit tests (`node --test`),
-and data validation (`fit-map validate`) in sequence.
+`bun run check` runs formatting (Prettier) and linting (ESLint) sequentially so
+failures are easy to spot. `bun run test` runs unit tests (`node --test`)
+separately so test output does not bury check failures.
 
 To auto-fix formatting and lint issues:
 
@@ -91,7 +93,7 @@ tests inject mocks directly.
 
 1. Create a branch from `main`
 2. Make your changes
-3. Run `bun run check`
+3. Run `bun run check` and `bun run test`
 4. Run `just audit` (npm audit + gitleaks secret scanning)
 5. Commit and push
 

--- a/website/docs/internals/pathway/index.md
+++ b/website/docs/internals/pathway/index.md
@@ -211,7 +211,7 @@ import { deriveReferenceLevel, deriveAgentSkills } from "@forwardimpact/libskill
 | ------------------- | ------------------------------- |
 | `bun start`         | Build and serve the static site |
 | `bun run dev`       | Live development server         |
-| `bun run check`     | Format, lint, test, validate    |
+| `bun run check`     | Format and lint                 |
 | `bun run check:fix` | Auto-fix formatting and linting |
 | `bun run test`      | Run unit tests                  |
 | `bun run test:e2e`  | Run Playwright E2E tests        |


### PR DESCRIPTION
Run formatting and linting sequentially in `bun run check` (no longer
runs unit tests). Tests now run separately via `bun run test` so check
failures are easy to spot at the tail of output and propagate as
expected. Update CLAUDE.md, CONTRIBUTING.md, and related docs to
instruct contributors to run both commands before committing.