### PR TITLE
fix(ci): scope guide-setup LLM token to the org

### DIFF
--- a/.github/workflows/guide-setup.yml
+++ b/.github/workflows/guide-setup.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           app-id: ${{ secrets.LLM_APP_ID }}
           private-key: ${{ secrets.LLM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
Without 'owner' set, actions/create-github-app-token mints a
repository-scoped installation token. GitHub Models permission only
applies to org-scoped tokens, so requests against
https://models.github.ai/orgs/forwardimpact returned 403 for every
model the evaluator tried. Pass github.repository_owner so the LLM
token is issued for the organization installation, which carries the
models:read permission.