### PR TITLE
docs: fix inaccuracies across documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,9 +137,9 @@ products/
   map/                 # fit-map — data product, validation
     schema/json/       #   JSON Schema
     schema/rdf/        #   RDF/SHACL
+    starter/           #   framework YAML (installs to data/pathway/)
   pathway/             # fit-pathway — web app, CLI, formatters
     src/formatters/    #   output formatters
-    starter/           #   framework YAML (installs to data/pathway/)
   basecamp/            # fit-basecamp — knowledge system, scheduler
     template/          #   KB template
   guide/               # fit-guide — LLM agent, artifact interpretation
@@ -151,7 +151,7 @@ libraries/
   libui/               # web UI framework, components, CSS
   libdoc/              # fit-doc — documentation build/serve
 services/
-  agent/ graph/ llm/ memory/ tool/ trace/ vector/ web/
+  agent/ graph/ llm/ memory/ pathway/ tool/ trace/ vector/ web/
 config/
   config.json          # service definitions, model settings, eval config
   tools.yml            # tool endpoint definitions
@@ -162,6 +162,9 @@ specs/
   {feature}/           # feature specifications and plans
 wiki/                  # GitHub wiki submodule — internal notes and shared agent memory
 ```
+
+Git tracks `*.example.*` templates in `config/` — the live files above are
+gitignored and created from examples during setup.
 
 Data-driven: entities defined in YAML, each external installation may have
 completely different framework data while using the same product code.
@@ -188,12 +191,13 @@ files in [.claude/skills/](.claude/skills/):
   libharness
 - **`libs-data-persistence`** — libstorage, libindex, libresource, libpolicy,
   libgraph, libvector
-- **`libs-llm-orchestration`** — libllm, libmemory, libprompt, libagent
-- **`libs-web-presentation`** — libui, libformat, libweb, libdoc, libtemplate
+- **`libs-llm-orchestration`** — libllm, libmemory, libprompt, libagent, libtool
+- **`libs-web-presentation`** — libui, libformat, libweb, libdoc, libtemplate,
+  librepl
 - **`libs-system-utilities`** — libutil, libsecret, libsupervise, librc,
-  libcodegen
+  libcodegen, libeval
 - **`libs-synthetic-data`** — libsyntheticgen, libsyntheticprose,
-  libsyntheticrender
+  libsyntheticrender, libuniverse
 
 `libskill` retains its own skill (pure-function design, exempt from OO+DI).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,6 @@ or feature changes. See
 [.claude/agents/release-engineer.md](.claude/agents/release-engineer.md) for the
 full scope constraints.
 
-The pre-commit hook auto-formats staged files and scans for secrets. If the hook
-reformats files, it re-stages them automatically — just re-run your commit.
-
 ## Git Conventions
 
 Format: `type(scope): subject`
@@ -105,7 +102,7 @@ change that requires design review before implementation (e.g.
 **Version rules** — pre-1.0 packages (`0.x.y`) bump patch for any change.
 Post-1.0 packages use semver: breaking=major, feat=minor, fix/refactor=patch.
 
-The release manager agent handles version bumps, tagging, and publishing. See
+The release engineer agent handles version bumps, tagging, and publishing. See
 the [gemba-release-review skill](.claude/skills/gemba-release-review) for the
 full release procedure.
 
@@ -138,7 +135,7 @@ Security policies apply to all contributors — human and agent.
 - **Vulnerability audit** — `npm audit --audit-level=high` runs in CI (via
   temporary lockfile generation) and gates publish workflows.
 - **CI secret scanning** — Gitleaks runs on every push and pull request via the
-  `audit` job in
+  `secret-scanning` job in
   [.github/workflows/check-security.yml](.github/workflows/check-security.yml).
 - **GitHub Actions** — All third-party actions are pinned to SHA hashes. Use
   `Dependabot` for updates. Never change a pin to a tag.

--- a/GEMBA.md
+++ b/GEMBA.md
@@ -123,20 +123,19 @@ than attempting the fix.
 
 ## Workflows
 
-Daily pipeline follows the PDSA cycle: **Plan** (04 UTC) → **Do** (05–07 UTC) →
-**Study** (08 UTC) → **Study → Act** (09–11 UTC). Times respect dependencies
-(plans before implementation, rebase before merge, merge before release) and
-same-agent workflows never overlap.
+Workflows span 04–11 UTC, loosely following a PDSA cycle. Times respect
+dependencies (plans before implementation, rebase before merge, merge before
+release) and same-agent workflows never overlap.
 
 | Workflow              | Phase          | Schedule                                | Agent             | What it does                                                                |
 | --------------------- | -------------- | --------------------------------------- | ----------------- | --------------------------------------------------------------------------- |
-| **plan-specs**        | Plan           | Daily 04:11 UTC                         | staff-engineer    | Pick up approved specs without plans and produce execution-ready plan.md    |
-| **implement-plans**   | Do             | Daily 05:07 UTC                         | staff-engineer    | Pick up approved plans (`status: planned`) and execute via implement-spec   |
-| **security-update**   | Do             | Mon & Thu 05:43 UTC                     | security-engineer | Apply security updates: triage Dependabot PRs, address audit findings       |
-| **release-readiness** | Do             | Daily 06:23 UTC                         | release-engineer  | Rebase open PRs on main, fix lint/format failures, repair main CI if broken |
-| **release-review**    | Do             | Tue, Thu, Sat 07:53 UTC                 | release-engineer  | Find unreleased changes, bump versions, tag, push, verify publish           |
+| **security-audit**    | Study          | Tue & Fri 04:07 UTC                     | security-engineer | Audit supply chain, dependencies, credentials, OWASP Top 10                 |
+| **security-update**   | Do             | Mon & Thu 04:43 UTC                     | security-engineer | Apply security updates: triage Dependabot PRs, address audit findings       |
 | **product-manager**   | Do, Study, Act | Daily 08:13 UTC + Mon/Wed/Fri 05:17 UTC | product-manager   | Classify and merge open PRs, then triage open issues into fixes and specs   |
-| **security-audit**    | Study          | Tue & Fri 08:37 UTC                     | security-engineer | Audit supply chain, dependencies, credentials, OWASP Top 10                 |
+| **release-readiness** | Do             | Daily 06:23 UTC                         | release-engineer  | Rebase open PRs on main, fix lint/format failures, repair main CI if broken |
+| **plan-specs**        | Plan           | Daily 07:11 UTC                         | staff-engineer    | Pick up approved specs without plans and produce execution-ready plan.md    |
+| **implement-plans**   | Do             | Daily 07:53 UTC                         | staff-engineer    | Pick up approved plans (`status: planned`) and execute via implement-spec   |
+| **release-review**    | Do             | Tue, Thu, Sat 09:37 UTC                 | release-engineer  | Find unreleased changes, bump versions, tag, push, verify publish           |
 | **improvement-coach** | Study → Act    | Wed & Sat 10:47 UTC                     | improvement-coach | Deep-analyze a single random agent trace, open fix PRs or write specs       |
 
 Off-minute schedules avoid API load spikes. All workflows support

--- a/website/basecamp/index.md
+++ b/website/basecamp/index.md
@@ -85,7 +85,7 @@ If your network requires a custom CA bundle, add an `env` block to
 npx fit-basecamp --init ~/Documents/Team   # Initialize knowledge base
 npx fit-basecamp --daemon                   # Start the scheduler
 npx fit-basecamp --status                   # Check what's happening
-npx fit-basecamp --run sync-mail            # Run a task now
+npx fit-basecamp --wake sync-mail           # Wake a specific agent now
 ```
 
 ### macOS Privacy & Security

--- a/website/docs/getting-started/contributors/index.md
+++ b/website/docs/getting-started/contributors/index.md
@@ -98,9 +98,9 @@ tests inject mocks directly.
 5. Commit and push
 
 Commit messages follow conventional format: `type(scope): subject`. Types
-include `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, and `perf`.
-Scope is the package name (e.g., `map`, `libskill`, `pathway`). Add `!` after
-scope for breaking changes.
+include `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, and `spec`. Scope is
+the package name (e.g., `map`, `libskill`, `pathway`). Add `!` after scope for
+breaking changes.
 
 ## Next steps
 

--- a/website/docs/getting-started/leadership/index.md
+++ b/website/docs/getting-started/leadership/index.md
@@ -75,9 +75,9 @@ Edit `data/pathway/levels.yaml` to define your level structure. Each level sets
 baseline expectations for skill proficiency and behaviour maturity.
 
 ```yaml
-- id: L1
-  professionalTitle: Junior Engineer
-  managementTitle: Junior Manager
+- id: J040
+  professionalTitle: Level I
+  managementTitle: Associate
   ordinalRank: 1
   baseSkillProficiencies:
     primary: foundational
@@ -85,9 +85,9 @@ baseline expectations for skill proficiency and behaviour maturity.
     broad: awareness
   baseBehaviourMaturity: emerging
 
-- id: L2
-  professionalTitle: Engineer
-  managementTitle: Manager
+- id: J060
+  professionalTitle: Level II
+  managementTitle: Senior Associate
   ordinalRank: 2
   baseSkillProficiencies:
     primary: working

--- a/website/docs/internals/operations/index.md
+++ b/website/docs/internals/operations/index.md
@@ -15,26 +15,18 @@ development tasks. For the PR workflow and contributing guidelines, see
 
 ## Environment Management
 
-Environment is configured via layered `.env` files, loaded by `scripts/env.sh`:
+Environment is configured via profile-based `.env` files, managed by
+`just env-setup`:
 
 ```sh
-# Load order (later files override earlier):
-.env                      # Base: API credentials, service secrets
-.env.{ENV}                # Network: local (localhost) or docker (container DNS)
-.env.storage.{STORAGE}    # Storage: local, minio (S3), or supabase
-.env.auth.{AUTH}           # Auth: none, gotrue, or supabase
+# Available profiles (complete, self-contained):
+.env.local.example            # Local dev: localhost, no auth, filesystem storage
+.env.docker-native.example    # Docker networking with MinIO storage
+.env.docker-supabase.example  # Docker networking with Supabase storage and auth
 ```
 
-Three variables control the environment stack:
-
-| Variable  | Values                       | Default |
-| --------- | ---------------------------- | ------- |
-| `ENV`     | `local`, `docker`            | `local` |
-| `STORAGE` | `local`, `minio`, `supabase` | `local` |
-| `AUTH`    | `none`, `gotrue`, `supabase` | `none`  |
-
-All `just` recipes automatically load environment from `.env`. Configure
-profiles via `just env-reset`:
+`just env-reset` copies a profile to `.env`. All `just` recipes automatically
+load `.env` via `set dotenv-load`. Configure profiles via `just env-reset`:
 
 ```sh
 just rc-start                              # local env, local storage, no auth

--- a/website/docs/internals/pathway/index.md
+++ b/website/docs/internals/pathway/index.md
@@ -45,7 +45,7 @@ products/pathway/src/
 
 ## Formatter Pattern
 
-Every entity has three formatter files:
+Formatters follow a three-file pattern (not all entities need every file):
 
 | File          | Purpose                                  | Imports   |
 | ------------- | ---------------------------------------- | --------- |
@@ -177,7 +177,7 @@ Agent output uses Mustache templates in `products/pathway/templates/`.
 Variables: `skillName`, `description`, `useWhen`, `stages` (with `focus`,
 `activities`, `ready` per stage).
 
-Template substitution is handled by `substituteTemplateVars()` in the agent
+Template substitution is handled by Mustache rendering in the agent formatter
 module.
 
 ---

--- a/website/landmark/index.md
+++ b/website/landmark/index.md
@@ -109,4 +109,4 @@ Landmark queries Map's central store:
 
 Landmark is currently in development. Product direction is specified in the
 Landmark and Map specs under `specs/080-landmark-product` and
-`specs/03-map-data-store`.
+`specs/050-map-data-product`.

--- a/website/pathway/index.md
+++ b/website/pathway/index.md
@@ -26,7 +26,7 @@ hero:
 
 - An interactive web app to explore roles, skills, and career paths
 - A CLI for generating job descriptions and agent profiles
-- VS Code Custom Agent profiles derived from your framework
+- Claude Code agent profiles derived from your framework
 - Agent skill files following the open Agent Skills Standard
 - A static site export for publishing your career framework
 - Interview question sets tailored to each role
@@ -65,7 +65,7 @@ The interactive browser gives you:
 
 ```sh
 npx fit-pathway dev                                       # Launch web app
-npx fit-pathway job software_engineering L3 --track=platform  # Job definition
+npx fit-pathway job software_engineering J060 --track=platform  # Job definition
 npx fit-pathway agent software_engineering --track=platform   # Agent profiles
 npx fit-pathway build --url=https://pathway.myorg.com         # Static site
 ```


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — fix structure tree (starter/ placement, missing service), add 4 missing libraries to skill groups, note config example templates
- **CONTRIBUTING.md** — remove false pre-commit hook claim, fix CI job name and agent name
- **GEMBA.md** — fix 5 incorrect workflow schedule times, reorder table chronologically
- **operations/index.md** — replace non-existent `scripts/env.sh` and layered env description with actual profile-based approach
- **leadership/index.md** — fix level IDs to match starter data (L1/L2 → J040/J060)
- **contributors/index.md** — fix commit types to match CONTRIBUTING.md
- **pathway/index.md** — fix level ID and agent profile type (VS Code → Claude Code)
- **basecamp/index.md** — fix CLI flag (`--run` → `--wake`)
- **landmark/index.md** — fix spec path reference
- **pathway internals** — soften formatter pattern claim, fix template function reference

## Test plan

- [ ] `bun run check` passes (formatting verified with Prettier before commit)
- [ ] All changes are documentation-only — no code changes
- [ ] Verify corrected cron times match `.github/workflows/*.yml`
- [ ] Verify level IDs match `products/map/starter/levels.yaml`

https://claude.ai/code/session_01RmPScPJ1H1Tz6KJA58s64y