### PR TITLE
fix(gemba): standardize wiki memory management across all agents and skills

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -48,7 +48,7 @@ Systematic, evidence-driven. Blame the system, never the worker. Sign off:
   check
 - Run `bun run check` and `bun run test` before committing
 - **Memory**: Before starting work, read `wiki/improvement-coach.md` and the
-  other three agent summaries for cross-agent context. Append this run as a new
+  other agent summaries for cross-agent context. Append this run as a new
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/improvement-coach-$(date +%G-W%V).md` — create the file if missing with
   an `# Improvement Coach — YYYY-Www` heading; one file per ISO week. Use `###`

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -55,7 +55,7 @@ Determine which workflow to use from the task prompt:
 - Features always get a spec, never a direct implementation
 - Run `bun run check` and `bun run test` before every commit
 - **Memory**: Before starting work, read `wiki/product-manager.md` and the other
-  three agent summaries for cross-agent context. Append this run as a new
+  agent summaries for cross-agent context. Append this run as a new
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/product-manager-$(date +%G-W%V).md` — create the file if missing with an
   `# Product Manager — YYYY-Www` heading; one file per ISO week. Use `###`

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -44,7 +44,7 @@ Determine which workflow to use from the task prompt:
 - Release in dependency order when multiple packages change together
 - Run `bun run check` and `bun run test` before committing
 - **Memory**: Before starting work, read `wiki/release-engineer.md` and the
-  other three agent summaries for cross-agent context. Append this run as a new
+  other agent summaries for cross-agent context. Append this run as a new
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/release-engineer-$(date +%G-W%V).md` — create the file if missing with
   an `# Release Engineer — YYYY-Www` heading; one file per ISO week. Use `###`

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -44,7 +44,7 @@ Determine which workflow to use from the task prompt:
 - Never skip spec PRs — if findings need specs, file them
 - Run `bun run check` and `bun run test` before committing
 - **Memory**: Before starting work, read `wiki/security-engineer.md` and the
-  other three agent summaries for cross-agent context. Append this run as a new
+  other agent summaries for cross-agent context. Append this run as a new
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/security-engineer-$(date +%G-W%V).md` — create the file if missing with
   an `# Security Engineer — YYYY-Www` heading; one file per ISO week. Use `###`

--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -20,6 +20,12 @@ changes methodically.
 
 ## Process
 
+### Step 0: Read Memory
+
+Read memory per the agent profile (your summary, the current week's log, and
+teammates' summaries). Extract specs previously implemented and any blockers
+from prior `staff-engineer` entries.
+
 Before starting: run the READ-DO checklist in CONTRIBUTING.md § Core Rules.
 Those rules apply to every implementation task — hold them in mind as you work
 through the steps below.
@@ -131,6 +137,17 @@ After all tasks are complete:
   using the spec's intent, codebase conventions, and CONTRIBUTING.md § Core
   Rules (Invariants and the READ-DO / DO-CONFIRM checklists). Do not ask for
   permission on routine decisions — only flag genuine ambiguity.
+
+## Memory: what to record
+
+Append to the current week's log (see agent profile for the file path):
+
+- **Spec implemented** — Spec number, name, and status transition (planned →
+  active → done)
+- **PR opened** — PR number and branch name
+- **Blockers encountered** — Plan deviations, codebase divergences, test
+  failures, and how they were resolved
+- **Deferred specs** — Specs skipped and why (not ready, missing plan, etc.)
 
 ## What NOT to Do
 

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -126,6 +126,14 @@ acting on it.
 
 ## Process
 
+### Step 0: Read Memory
+
+Read memory per the agent profile (your summary, the current week's log, and
+teammates' summaries). Extract specs previously planned and any deferred work
+from prior `staff-engineer` entries.
+
+### Steps
+
 1. **Find the spec.** A plan requires an approved spec in the same directory. If
    no spec exists or the spec has not yet been approved, stop — the spec skill
    must run first.
@@ -141,6 +149,15 @@ acting on it.
 6. **Update STATUS.** When both spec and plan are approved, advance the spec's
    status from `review` to `planned`. Do not advance while the plan is still
    being iterated on.
+
+## Memory: what to record
+
+Append to the current week's log (see agent profile for the file path):
+
+- **Specs planned** — Spec number, name, and status transition
+- **Plan decisions** — Key approach choices and why (so the implementer has
+  context)
+- **Deferred specs** — Specs skipped and why (not approved, missing info, etc.)
 
 ## What NOT to Do
 

--- a/.claude/skills/gemba-product-classify/SKILL.md
+++ b/.claude/skills/gemba-product-classify/SKILL.md
@@ -157,7 +157,7 @@ For each PR marked **mergeable** in the report:
    the failure in the run report and move on — do **not** retry without
    re-running Steps 1–6, since the gate state may have changed.
 
-## Memory: What to Record
+## Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.claude/skills/gemba-product-evaluation/SKILL.md
+++ b/.claude/skills/gemba-product-evaluation/SKILL.md
@@ -36,6 +36,12 @@ would after setting their own `LLM_TOKEN`.
 
 ## Process
 
+### Step 0: Read Memory
+
+Read memory per the agent profile (your summary, the current week's log, and
+teammates' summaries). Extract prior evaluation scenarios and recurring friction
+points from previous `product-manager` entries.
+
 ### Step 1: Brief the Agent
 
 Your first response becomes the agent's initial prompt. Include:

--- a/.claude/skills/gemba-product-triage/SKILL.md
+++ b/.claude/skills/gemba-product-triage/SKILL.md
@@ -101,7 +101,7 @@ The triage report is consumed by the calling agent, which then takes action:
 This skill stops at the report. Do not implement fixes or write specs from
 within gemba-product-triage — the phase boundary matters.
 
-## Memory: What to Record
+## Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.claude/skills/gemba-release-readiness/SKILL.md
+++ b/.claude/skills/gemba-release-readiness/SKILL.md
@@ -23,7 +23,7 @@ canonical query shapes used in the steps below.
 
 ## Process
 
-### Step 0: Read Memory for PR History
+### Step 0: Read Memory
 
 Read memory per the agent profile (your summary, the current week's log, and
 teammates' summaries). Extract the PR status table from prior `release-engineer`

--- a/.claude/skills/gemba-release-review/SKILL.md
+++ b/.claude/skills/gemba-release-review/SKILL.md
@@ -21,6 +21,14 @@ determine version bumps, and cut releases.
 See [`gemba-gh-cli`](../gemba-gh-cli/SKILL.md) for `gh` installation and the
 canonical query shapes used in the steps below.
 
+## Process
+
+### Step 0: Read Memory
+
+Read memory per the agent profile (your summary, the current week's log, and
+teammates' summaries). Extract previous release outcomes and any packages that
+had publish failures from prior `release-engineer` entries.
+
 ## Pre-Flight: Verify Main Branch CI
 
 <read_do_checklist>
@@ -137,6 +145,16 @@ If a publish fails, investigate with `gh run view <run-id> --log-failed`.
 | -------- | -------- | ------ | --------------- | ------- |
 | libskill | 4.0.3    | 4.0.4  | libskill@v4.0.4 | ✓       |
 ```
+
+### Memory: what to record
+
+Append to the current week's log (see agent profile for the file path):
+
+- **Packages assessed** — Which packages had unreleased changes
+- **Releases cut** — Package name, previous version, new version, tag, publish
+  status
+- **Publish failures** — Package and reason (so the next run can revisit)
+- **Main branch CI state** — Green or broken, and what was repaired
 
 ## Edge Cases
 

--- a/.claude/skills/gemba-security-update/SKILL.md
+++ b/.claude/skills/gemba-security-update/SKILL.md
@@ -125,7 +125,7 @@ gh pr close <number> --comment "Dependabot triage: closing because <reason>. Pol
 | #61 | bump upload-pages-artifact ...  | fix    | Missing SHA pins           |
 ```
 
-### Memory: What to Record
+### Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.claude/skills/gemba-walk/SKILL.md
+++ b/.claude/skills/gemba-walk/SKILL.md
@@ -27,9 +27,9 @@ If a specific workflow name, run ID, or URL is provided, use that run.
 
 Otherwise, select a run using memory-informed rotation:
 
-1. **Read memory** — Per the agent profile, read your summary, the current
-   week's log, and teammates' summaries. Extract workflow names and run IDs from
-   previous cycles.
+1. **Read memory** — Read memory per the agent profile (your summary, the
+   current week's log, and teammates' summaries). Extract workflow names and run
+   IDs from previous cycles.
 
 2. **Discover available runs**:
 
@@ -173,6 +173,20 @@ same fix-or-spec discipline:
 
 Every PR must branch directly from `main` — never from another fix or spec
 branch.
+
+### Memory: what to record
+
+Append to the current week's log (see agent profile for the file path):
+
+- **Trace analyzed** — Workflow name, run ID, date, conclusion, branch
+- **Actionable findings** — Each finding with severity, category (trivial fix /
+  improvement / observation), and action taken (PR number or spec name)
+- **Core category** — The central phenomenon and theoretical propositions
+- **Invariant audit results** — Each invariant checked with PASS/FAIL and quoted
+  evidence
+- **Saturation notes** — Patterns confirmed, refuted, or newly emerged compared
+  to prior cycles
+- **Observations for teammates** — Callouts for specific agents
 
 ## Analysis Principles
 

--- a/GEMBA.md
+++ b/GEMBA.md
@@ -268,6 +268,20 @@ acting, append that run's findings to the week's log, and update the summary at
 the end. The canonical memory instruction block lives in each agent profile;
 skills reference it without restating paths.
 
+**Skill responsibilities.** Every entry-point skill (the primary skill for a
+scheduled workflow) must include two memory elements:
+
+1. A **read step** — "Read memory per the agent profile (your summary, the
+   current week's log, and teammates' summaries)." followed by domain-specific
+   extraction (what to look for in prior entries).
+2. A **"Memory: what to record"** section — a bulleted list of the specific
+   fields to append to the weekly log.
+
+Sub-skills invoked within a workflow (e.g. `gemba-spec` called as the Act phase
+inside another workflow) do not need their own memory instructions — the
+entry-point skill's recording list and the agent profile's write protocol cover
+them. Utility skills with no PDSA phase (e.g. `gemba-gh-cli`) are also exempt.
+
 ## Authentication
 
 Workflows authenticate via a **GitHub App** (`forward-impact-ci`), not a PAT.


### PR DESCRIPTION
Every entry-point skill for a scheduled workflow now consistently includes
both a read step and a "Memory: what to record" section. Fixes several
inconsistencies that correlated with agents skipping memory operations:

- Remove hardcoded "other three" agent count from profiles (now "other"
  without a number, robust to adding/removing agents)
- Add missing memory write section to gemba-walk
- Add missing memory read step to gemba-product-evaluation
- Add memory read/write to gemba-release-review, gemba-plan, gemba-implement
  (all entry-point skills for scheduled workflows that lacked memory)
- Standardize heading case to "Memory: what to record" across all skills
- Standardize read step heading to "Step 0: Read Memory" across all skills
- Standardize read instruction wording to canonical phrasing
- Document entry-point vs sub-skill memory expectations in GEMBA.md

https://claude.ai/code/session_01WQpAavkmCoa3oqbSnU8Prm