### PR TITLE
spec(libcli): plan for CLI library (spec 360)

### DIFF
--- a/specs/360-cli-library/plan-a-01.md
+++ b/specs/360-cli-library/plan-a-01.md
@@ -1,0 +1,379 @@
+# 360 Part 01 — Create libcli library
+
+Create the `libraries/libcli/` package with all core classes, factory functions,
+and tests.
+
+## Files created
+
+| File                                    | Purpose                                         |
+| --------------------------------------- | ----------------------------------------------- |
+| `libraries/libcli/package.json`         | Package manifest                                |
+| `libraries/libcli/index.js`             | Public exports                                  |
+| `libraries/libcli/cli.js`               | Cli class + createCli factory                   |
+| `libraries/libcli/help.js`              | HelpRenderer class                              |
+| `libraries/libcli/summary.js`           | SummaryRenderer class                           |
+| `libraries/libcli/color.js`             | Color constants, supportsColor, colorize        |
+| `libraries/libcli/format.js`            | formatTable, formatHeader, and other formatting |
+| `libraries/libcli/test/cli.test.js`     | Cli class tests                                 |
+| `libraries/libcli/test/help.test.js`    | HelpRenderer tests                              |
+| `libraries/libcli/test/summary.test.js` | SummaryRenderer tests                           |
+| `libraries/libcli/test/color.test.js`   | Color utility tests                             |
+| `libraries/libcli/test/format.test.js`  | Formatting utility tests                        |
+
+## Steps
+
+### 1. Create package.json
+
+```json
+{
+  "name": "@forwardimpact/libcli",
+  "version": "0.1.0",
+  "description": "Shared CLI infrastructure for the Forward Impact monorepo",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "bun run node --test test/*.test.js"
+  },
+  "devDependencies": {
+    "@forwardimpact/libharness": "workspace:*"
+  }
+}
+```
+
+No runtime dependencies. libcli uses only `node:util` (for `parseArgs`).
+libharness is a devDependency for test mocking.
+
+Run `bun install` after creating this file to register the workspace package.
+
+### 2. Create color.js
+
+Migrate the generic color infrastructure from
+`products/pathway/src/lib/cli-output.js` (lines 9–44).
+
+**Key change:** `supportsColor` and `colorize` accept a `process` parameter
+instead of reading the global. This enables test injection.
+
+```js
+// ANSI color constants — same object as pathway's cli-output.js lines 9-23
+export const colors = { reset, bold, dim, italic, underline, red, green,
+  yellow, blue, magenta, cyan, white, gray };
+
+// Check if output supports colors.
+// @param {object} proc — process-like object with env and stdout
+export function supportsColor(proc = process) {
+  if (proc.env.NO_COLOR) return false;
+  if (proc.env.FORCE_COLOR) return true;
+  return proc.stdout?.isTTY ?? false;
+}
+
+// Wrap text with ANSI color if supported.
+export function colorize(text, color, proc = process) {
+  if (!supportsColor(proc)) return text;
+  return `${color}${text}${colors.reset}`;
+}
+```
+
+The `proc` parameter defaults to the global `process` for ergonomic use in
+production code while enabling test injection.
+
+### 3. Create format.js
+
+Migrate the generic formatting functions from pathway's `cli-output.js`. Each
+function gains a `proc` parameter (defaulting to `process`) for its internal
+`colorize` calls.
+
+Functions to migrate (pathway source lines → libcli):
+
+| Function                                     | Pathway lines | Notes                           |
+| -------------------------------------------- | ------------- | ------------------------------- |
+| `formatHeader(text, proc)`                   | 51–53         | Bold + cyan                     |
+| `formatSubheader(text, proc)`                | 60–62         | Bold                            |
+| `formatListItem(label, value, indent, proc)` | 71–75         | Bullet + label:value            |
+| `formatBullet(text, indent, proc)`           | 83–87         | Bullet only                     |
+| `formatTable(headers, rows, options, proc)`  | 97–126        | Aligned columns                 |
+| `formatError(message, proc)`                 | 214–216       | Red "Error: msg"                |
+| `formatSuccess(message, proc)`               | 223–225       | Green text                      |
+| `formatWarning(message, proc)`               | 235–237       | Yellow "Warning: msg"           |
+| `horizontalRule(width, proc)`                | 244–246       | Dim dashes                      |
+| `formatSection(title, content, proc)`        | 254–256       | Header + content                |
+| `indent(text, spaces)`                       | 264–270       | Indentation (no color, no proc) |
+
+All functions import `colorize` and `colors` from `./color.js`.
+
+### 4. Create help.js — HelpRenderer class
+
+The HelpRenderer renders a CLI definition into formatted help text.
+
+```js
+export class HelpRenderer {
+  #proc;
+
+  constructor({ process }) {
+    this.#proc = process;
+  }
+
+  render(definition, stream) {
+    // Build help text from definition, write to stream
+  }
+
+  renderJson(definition, stream) {
+    // Write JSON.stringify of definition to stream
+  }
+}
+```
+
+**`render()` output format:**
+
+```
+fit-pathway 1.2.0 — Career progression for engineering frameworks
+
+Usage: fit-pathway <command> [options]
+
+Commands:
+  discipline <id>             Show discipline details
+  capability <id>             Show capability details
+  job <discipline> [options]  Derive a job definition
+
+Options:
+  --level=<string>  Target level (default: mid)
+  --track=<string>  Apply track modifier
+  --json            Output as JSON
+  --help, -h        Show this help
+  --version         Show version
+
+Examples:
+  fit-pathway job backend --level=senior --track=lead
+  fit-pathway interview backend --level=mid --json
+```
+
+Implementation details:
+
+- **Header line:** `{name} {version} — {description}`. Version is omitted if not
+  provided. Description is omitted if not provided.
+- **Usage line:** If `definition.usage` is set, use it directly. Otherwise,
+  generate `{name} <command> [options]` when commands exist, or
+  `{name} [options]` when they don't.
+- **Commands section:** Only rendered if `definition.commands` is non-empty.
+  Each command on one line: 2-space indent, `{name} {args}` left-padded to the
+  widest command, then description. Compute column width from the longest
+  `name + args` string.
+- **Options section:** Each option on one line. Format: `--{name}=<{type}>` for
+  string options, `--{name}` for boolean options. Append `, -{short}` if short
+  alias exists. Left-pad to widest option string, then description.
+- **Examples section:** Only rendered if `definition.examples` is non-empty.
+  Each example on one line with 2-space indent.
+- **Color:** Section headers ("Commands:", "Options:", "Examples:") use
+  `formatSubheader`. Header line name uses `formatHeader`. Color is conditional
+  on `supportsColor(this.#proc)`.
+
+**`renderJson()` output:**
+
+Write the definition object as-is via `JSON.stringify(definition, null, 2)`.
+This gives agents a structured representation of all commands, options, and
+descriptions.
+
+### 5. Create summary.js — SummaryRenderer class
+
+```js
+export class SummaryRenderer {
+  #proc;
+
+  constructor({ process }) {
+    this.#proc = process;
+  }
+
+  render({ title, items }, stream) {
+    // Write title line, then indented items with aligned labels
+  }
+}
+```
+
+**Output format:**
+
+```
+Generated 38 files in ./generated/
+  definitions/  — Service definitions
+  proto/        — Proto source files
+  services/     — Service bases and clients
+  types/        — Protocol Buffer types
+```
+
+Implementation:
+
+- Write `title` followed by newline.
+- For each item in `items`: compute the max label width, pad each label, write
+  `  {label}  — {description}`.
+- If `items` is empty, just write the title.
+
+### 6. Create cli.js — Cli class + createCli factory
+
+```js
+import { parseArgs } from "node:util";
+import { HelpRenderer } from "./help.js";
+
+export class Cli {
+  #definition;
+  #proc;
+  #helpRenderer;
+
+  constructor(definition, { process, helpRenderer }) {
+    this.#definition = definition;
+    this.#proc = process;
+    this.#helpRenderer = helpRenderer;
+  }
+
+  get name() { return this.#definition.name; }
+
+  parse(argv) {
+    // Build parseArgs-compatible options from definition.options
+    const options = {};
+    for (const [name, opt] of Object.entries(this.#definition.options || {})) {
+      options[name] = { type: opt.type };
+      if (opt.short) options[name].short = opt.short;
+      if (opt.default !== undefined) options[name].default = opt.default;
+    }
+
+    const { values, positionals } = parseArgs({
+      options,
+      allowPositionals: true,
+      args: argv,
+    });
+
+    // Handle --help
+    if (values.help) {
+      if (values.json) {
+        this.#helpRenderer.renderJson(this.#definition, this.#proc.stdout);
+      } else {
+        this.#helpRenderer.render(this.#definition, this.#proc.stdout);
+      }
+      return null;
+    }
+
+    // Handle --version
+    if (values.version && this.#definition.version) {
+      this.#proc.stdout.write(this.#definition.version + "\n");
+      return null;
+    }
+
+    return { values, positionals };
+  }
+
+  error(message) {
+    this.#proc.stderr.write(`${this.#definition.name}: error: ${message}\n`);
+    this.#proc.exitCode = 1;
+  }
+
+  usageError(message) {
+    this.#proc.stderr.write(`${this.#definition.name}: error: ${message}\n`);
+    this.#proc.exitCode = 2;
+  }
+}
+
+export function createCli(definition) {
+  const helpRenderer = new HelpRenderer({ process });
+  return new Cli(definition, { process, helpRenderer });
+}
+```
+
+**Design decisions:**
+
+- `parse()` returns `null` when it handles the request (help/version), signaling
+  the caller to exit. This avoids libcli calling `process.exit()` directly,
+  which would make testing harder.
+- `error()` and `usageError()` set `exitCode` but don't call `process.exit()`.
+  The caller decides when to exit. This follows the pattern of setting exitCode
+  seen in fit-codegen (line 291: `process.exitCode = 1`).
+- The factory `createCli()` wires the real `process` and a real `HelpRenderer`.
+  Tests bypass the factory and inject mocks.
+- `allowPositionals: true` is always set — CLIs that don't want positionals can
+  validate themselves. This keeps the API simple.
+
+### 7. Create index.js
+
+```js
+export { Cli, createCli } from "./cli.js";
+export { HelpRenderer } from "./help.js";
+export { SummaryRenderer } from "./summary.js";
+export { colors, supportsColor, colorize } from "./color.js";
+export {
+  formatHeader, formatSubheader, formatListItem, formatBullet,
+  formatTable, formatError, formatSuccess, formatWarning,
+  horizontalRule, formatSection, indent,
+} from "./format.js";
+```
+
+### 8. Write tests
+
+#### test/color.test.js
+
+- `supportsColor` returns false when `proc.env.NO_COLOR` is set
+- `supportsColor` returns true when `proc.env.FORCE_COLOR` is set
+- `supportsColor` returns true when `proc.stdout.isTTY` is true
+- `supportsColor` returns false when `proc.stdout.isTTY` is false/undefined
+- `colorize` wraps text with ANSI codes when color is supported
+- `colorize` returns plain text when color is not supported
+
+Mock process object:
+
+```js
+const proc = { env: {}, stdout: { isTTY: true } };
+```
+
+#### test/format.test.js
+
+- `formatTable` aligns columns correctly
+- `formatTable` with compact option omits separator
+- `formatHeader` returns bold+cyan text when color supported, plain when not
+- `formatError` returns red "Error: msg" when color supported, plain when not
+- `indent` adds correct padding to all lines
+- `horizontalRule` returns correct-width dashed line
+
+#### test/help.test.js
+
+- `render` includes header line with name, version, description
+- `render` includes one-line-per-command with aligned descriptions
+- `render` includes options with type hints and descriptions
+- `render` includes examples section
+- `render` omits commands section when definition has no commands
+- `render` uses custom usage string when provided
+- `renderJson` produces valid JSON matching the definition
+
+Use a mock stream (`{ write(data) { this.output += data; } }`) to capture
+output.
+
+#### test/cli.test.js
+
+- `parse` returns values and positionals for normal input
+- `parse` returns null and writes help when `--help` is passed
+- `parse` returns null and writes JSON when `--help --json` is passed
+- `parse` returns null and writes version when `--version` is passed
+- `error` writes prefixed message to stderr and sets exitCode to 1
+- `usageError` writes prefixed message to stderr and sets exitCode to 2
+- `parse` throws on unknown flags (default parseArgs behavior)
+
+Mock process:
+
+```js
+const proc = {
+  env: {},
+  stdout: { write: spy(), isTTY: false },
+  stderr: { write: spy() },
+  exitCode: 0,
+};
+```
+
+#### test/summary.test.js
+
+- `render` writes title and aligned items
+- `render` writes only title when items is empty
+- Labels are right-padded to the longest label width
+
+### 9. Run verification
+
+```sh
+bun install
+bun run node --test libraries/libcli/test/*.test.js
+bun run check
+```
+
+All tests pass, lint and format clean.

--- a/specs/360-cli-library/plan-a-02.md
+++ b/specs/360-cli-library/plan-a-02.md
@@ -1,0 +1,428 @@
+# 360 Part 02 — Migrate product CLIs
+
+Migrate the four product CLIs to use libcli. These are the most complex CLIs and
+the most visible to external users.
+
+**Depends on:** Part 01 (libcli library must exist).
+
+## Files modified
+
+| File                                     | Change                                          |
+| ---------------------------------------- | ----------------------------------------------- |
+| `products/pathway/package.json`          | Add `@forwardimpact/libcli` dependency          |
+| `products/pathway/src/lib/cli-output.js` | Remove generic formatters, keep domain-specific |
+| `products/pathway/bin/fit-pathway.js`    | Rewrite to use Cli class                        |
+| `products/map/package.json`              | Add `@forwardimpact/libcli` dependency          |
+| `products/map/bin/fit-map.js`            | Rewrite to use Cli class                        |
+| `products/guide/package.json`            | Add `@forwardimpact/libcli` dependency          |
+| `products/guide/bin/fit-guide.js`        | Use Cli for initial parsing                     |
+| `products/basecamp/package.json`         | Add `@forwardimpact/libcli` dependency          |
+| `products/basecamp/src/basecamp.js`      | Rewrite CLI entry to use Cli class              |
+
+## Order
+
+1. Migrate pathway first (it's the source of the formatting code)
+2. Map, guide, basecamp in any order
+
+## Steps
+
+### 1. Migrate pathway
+
+#### 1a. Update `products/pathway/package.json`
+
+Add to `dependencies`:
+
+```json
+"@forwardimpact/libcli": "workspace:*"
+```
+
+#### 1b. Trim `products/pathway/src/lib/cli-output.js`
+
+Remove all generic functions that now live in libcli. Keep only the
+domain-specific formatters that pathway needs for its own output:
+
+**Remove** (now in libcli):
+
+- `colors` object (lines 9–23)
+- `supportsColor()` (lines 29–33)
+- `colorize()` (lines 41–44) — was not exported but was used internally
+- `formatHeader()` (lines 51–53)
+- `formatSubheader()` (lines 60–62)
+- `formatListItem()` (lines 71–75)
+- `formatBullet()` (lines 83–87)
+- `formatTable()` (lines 97–126)
+- `formatError()` (lines 214–216)
+- `formatSuccess()` (lines 223–225)
+- `formatWarning()` (lines 235–237)
+- `horizontalRule()` (lines 244–246)
+- `formatSection()` (lines 254–256)
+- `indent()` (lines 264–270)
+
+**Keep** (domain-specific, stays in pathway):
+
+- `formatSkillProficiency()` (lines 133–143)
+- `formatBehaviourMaturity()` (lines 150–161)
+- `formatModifier()` (lines 168–175)
+- `formatPercent()` (lines 182–193)
+- `formatChange()` (lines 200–207)
+
+**Update kept functions** to import `colorize` and `colors` from libcli:
+
+```js
+import { colorize, colors } from "@forwardimpact/libcli";
+```
+
+The kept functions currently call the local `colorize()` — they switch to the
+libcli import. Behavior is identical (the default `proc` parameter handles
+production use).
+
+**Update other pathway files** that import from `cli-output.js`. Search for
+imports of the removed functions across `products/pathway/src/` and update them
+to import from `@forwardimpact/libcli` instead. Common imports to redirect:
+
+- `formatTable` — used in command handlers for tabular output
+- `formatHeader`, `formatSubheader` — used in command handlers for section
+  titles
+- `formatError` — used in `bin/fit-pathway.js` (line 41) and command handlers
+- `formatSection`, `formatBullet`, `formatListItem` — used in command handlers
+- `horizontalRule`, `indent` — used in command handlers
+
+#### 1c. Rewrite `products/pathway/bin/fit-pathway.js`
+
+**Current state:** 440 lines with a 150-line `HELP_TEXT` const, custom
+`parseArgs()` function (lines 297–348), `BOOLEAN_FLAGS`/`VALUE_FLAGS` tables,
+and manual `--help`/`--version` handling.
+
+**Target state:** ~80 lines using the Cli class.
+
+Create a definition object capturing pathway's commands and options:
+
+```js
+import { createCli } from "@forwardimpact/libcli";
+
+const definition = {
+  name: "fit-pathway",
+  version: VERSION,
+  description: "Career progression for engineering frameworks",
+  commands: [
+    { name: "discipline", args: "[<id>]", description: "Show disciplines" },
+    { name: "level", args: "[<id>]", description: "Show levels" },
+    { name: "track", args: "[<id>]", description: "Show tracks" },
+    { name: "behaviour", args: "[<id>]", description: "Show behaviours" },
+    { name: "skill", args: "[<id>]", description: "Show skills" },
+    { name: "driver", args: "[<id>]", description: "Show drivers" },
+    { name: "stage", args: "[<id>]", description: "Show stages" },
+    { name: "tool", args: "[<name>]", description: "Show tools" },
+    { name: "job", args: "[<discipline> <level>]", description: "Generate job definition" },
+    { name: "interview", args: "<discipline> <level>", description: "Generate interview questions" },
+    { name: "progress", args: "<discipline> <level>", description: "Career progression analysis" },
+    { name: "questions", args: "[options]", description: "Browse interview questions" },
+    { name: "agent", args: "[<discipline>]", description: "Generate AI agent profile" },
+    { name: "dev", args: "[--port=PORT]", description: "Run live development server" },
+    { name: "build", args: "[--output=PATH]", description: "Generate static site" },
+    { name: "update", args: "[--url=URL]", description: "Update local installation" },
+  ],
+  options: {
+    list:       { type: "boolean", short: "l", description: "Output IDs only (for piping)" },
+    json:       { type: "boolean", description: "Output as JSON" },
+    data:       { type: "string", description: "Path to data directory" },
+    track:      { type: "string", description: "Track specialization" },
+    level:      { type: "string", description: "Target level" },
+    type:       { type: "string", description: "Interview type", default: "full" },
+    compare:    { type: "string", description: "Compare to level" },
+    format:     { type: "string", description: "Output format" },
+    output:     { type: "string", description: "Output path" },
+    stage:      { type: "string", description: "Lifecycle stage" },
+    checklist:  { type: "string", description: "Handoff checklist stage" },
+    maturity:   { type: "string", description: "Filter by behaviour maturity" },
+    skill:      { type: "string", description: "Filter by skill ID" },
+    behaviour:  { type: "string", description: "Filter by behaviour ID" },
+    capability: { type: "string", description: "Filter by capability" },
+    port:       { type: "string", description: "Dev server port" },
+    path:       { type: "string", description: "File path" },
+    url:        { type: "string", description: "URL for update" },
+    role:       { type: "string", description: "Role filter" },
+    stats:      { type: "boolean", description: "Show detailed statistics" },
+    "all-stages": { type: "boolean", description: "Show all stages" },
+    agent:      { type: "boolean", description: "Output as agent format" },
+    skills:     { type: "boolean", description: "Output skill IDs" },
+    tools:      { type: "boolean", description: "Output tool names" },
+    help:       { type: "boolean", short: "h", description: "Show this help" },
+    version:    { type: "boolean", short: "v", description: "Show version" },
+  },
+  examples: [
+    "fit-pathway discipline backend",
+    "fit-pathway job software_engineering J060 --track=platform",
+    "fit-pathway interview software_engineering J060 --json",
+    "fit-pathway agent software_engineering --track=platform",
+  ],
+};
+```
+
+**Replace the main() function:**
+
+```js
+async function main() {
+  const cli = createCli(definition);
+  const parsed = cli.parse(process.argv.slice(2));
+  if (!parsed) process.exit(0);
+
+  const { values, positionals } = parsed;
+  const [command, ...args] = positionals;
+
+  if (!command) {
+    cli.parse(["--help"]); // show help when no command given
+    process.exit(0);
+  }
+
+  // data directory resolution (keep existing Finder logic)
+  let dataDir;
+  if (values.data) {
+    dataDir = resolve(values.data);
+  } else {
+    const logger = createLogger("pathway");
+    const finder = new Finder(fs, logger, process);
+    try {
+      dataDir = join(finder.findData("data", homedir()), "pathway");
+    } catch {
+      cli.error("No data directory found. Use --data=<path> to specify location.");
+      process.exit(1);
+    }
+  }
+
+  // Special commands (dev, build, update)
+  if (command === "dev") { await runDevCommand({ dataDir, options: values }); return; }
+  if (command === "build") { await runBuildCommand({ dataDir, options: values }); process.exit(0); }
+  if (command === "update") { await runUpdateCommand({ dataDir, options: values }); process.exit(0); }
+
+  const handler = COMMANDS[command];
+  if (!handler) {
+    cli.usageError(`unknown command "${command}"`);
+    process.exit(2);
+  }
+
+  try {
+    const loader = createDataLoader();
+    const templateLoader = createTemplateLoader(TEMPLATE_DIR);
+    const data = await loader.loadAllData(dataDir);
+    validateAllData(data);
+    await handler({ data, args, options: values, dataDir, templateLoader, loader });
+  } catch (error) {
+    cli.error(error.message);
+    process.exit(1);
+  }
+}
+```
+
+**What's deleted:**
+
+- `HELP_TEXT` const (lines 86–234) — replaced by definition
+- `BOOLEAN_FLAGS`, `NEGATION_FLAGS`, `VALUE_FLAGS` objects (lines 237–274)
+- `parseValueFlag()` function (lines 282–290)
+- `parseArgs()` function (lines 297–348) — replaced by `cli.parse()`
+- `printHelp()` function (lines 353–355)
+
+**What's kept:**
+
+- `COMMANDS` dispatch table (lines 70–84)
+- Command handler imports (lines 45–59)
+- Data directory resolution logic
+- Special command handling (dev, build, update)
+
+**Compatibility note:** The current custom `parseArgs` accepts `--no-clean` as a
+negation flag. `node:util parseArgs` supports `--no-` prefixed negation for
+boolean flags natively. Add `clean: { type: "boolean", default: true }` to the
+options and it will work.
+
+### 2. Migrate map
+
+#### 2a. Update `products/map/package.json`
+
+Add `@forwardimpact/libcli` dependency.
+
+#### 2b. Rewrite `products/map/bin/fit-map.js`
+
+**Current state:** 448 lines with `showHelp()` function (line 235), inline
+`parseArgs` call (line 375), and `console.error` for error output.
+
+Create a definition object. Map has subcommands with sub-subcommands
+(`people validate`, `activity start`). Since libcli doesn't do nested subcommand
+routing, represent the top-level commands in the definition and keep the
+existing dispatcher functions:
+
+```js
+const definition = {
+  name: "fit-map",
+  version: VERSION,
+  description: "Data validation and management for Engineering Pathway",
+  commands: [
+    { name: "init", description: "Create ./data/pathway/ with starter framework data" },
+    { name: "validate", description: "Run validation (default: JSON schema)" },
+    { name: "generate-index", description: "Generate _index.yaml files" },
+    { name: "export", description: "Render base entities to HTML microdata" },
+    { name: "people", args: "<validate|push> <file>", description: "Validate or push people files" },
+    { name: "activity", args: "<start|stop|status|migrate|transform|verify>", description: "Manage activity stack" },
+    { name: "getdx", args: "sync", description: "Extract + transform GetDX snapshots" },
+  ],
+  options: {
+    data:       { type: "string", description: "Path to data directory" },
+    output:     { type: "string", description: "Output directory for export" },
+    url:        { type: "string", description: "Supabase URL" },
+    "base-url": { type: "string", description: "GetDX API base URL" },
+    json:       { type: "boolean", description: "Output as JSON" },
+    shacl:      { type: "boolean", description: "SHACL schema validation" },
+    help:       { type: "boolean", short: "h", description: "Show this help" },
+    version:    { type: "boolean", description: "Show version" },
+  },
+  examples: [
+    "fit-map init",
+    "fit-map validate",
+    "fit-map validate --shacl",
+    "fit-map people validate ./org/people.yaml",
+    "fit-map activity start",
+  ],
+};
+```
+
+Replace the `showHelp()` function and manual `--help` check with `cli.parse()`.
+Replace `console.error` in error paths with `cli.error()` and
+`cli.usageError()`. Keep the dispatcher functions (`dispatchPeople`,
+`dispatchActivity`, etc.) — these handle sub-subcommand routing which libcli
+doesn't own.
+
+### 3. Migrate guide
+
+#### 3a. Update `products/guide/package.json`
+
+Add `@forwardimpact/libcli` dependency.
+
+#### 3b. Update `products/guide/bin/fit-guide.js`
+
+**Current state:** Repl-based interactive CLI (279 lines). The `usage` variable
+(line 18) is a string passed to Repl configuration.
+
+Guide is a Repl-based CLI — the migration is minimal:
+
+- Add a definition object with `name`, `version`, `description`, and a `usage`
+  string
+- Use `createCli(definition)` to handle `--help` and `--version` before entering
+  the Repl session
+- The Repl session itself is unchanged
+- Replace `console.error()` in the catch block (line 269) with `cli.error()` or
+  `logger.exception()`
+
+```js
+const cli = createCli(definition);
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+// Existing Repl setup continues from here
+```
+
+### 4. Migrate basecamp
+
+#### 4a. Update `products/basecamp/package.json`
+
+Add `@forwardimpact/libcli` dependency.
+
+#### 4b. Rewrite `products/basecamp/src/basecamp.js`
+
+**Current state:** 348 lines with `showHelp()` function (line 281), manual
+`args[0]` command dispatch (lines 304–347), and `console.error` for errors.
+
+Create a definition object:
+
+```js
+const definition = {
+  name: "fit-basecamp",
+  version: VERSION,
+  description: "Schedule autonomous agents across knowledge bases",
+  commands: [
+    { name: "--daemon", description: "Run continuously (poll every 60s)" },
+    { name: "--wake", args: "<agent>", description: "Wake a specific agent immediately" },
+    { name: "--init", args: "<path>", description: "Initialize a new knowledge base" },
+    { name: "--update", args: "[path]", description: "Update KB with latest CLAUDE.md, agents and skills" },
+    { name: "--stop", description: "Gracefully stop daemon and all running agents" },
+    { name: "--validate", description: "Validate agent definitions exist" },
+    { name: "--status", description: "Show agent status" },
+  ],
+  options: {
+    daemon:   { type: "boolean", description: "Run as daemon" },
+    wake:     { type: "string", description: "Agent to wake" },
+    init:     { type: "string", description: "KB path to initialize" },
+    update:   { type: "string", description: "KB path to update" },
+    stop:     { type: "boolean", description: "Stop daemon" },
+    validate: { type: "boolean", description: "Validate definitions" },
+    status:   { type: "boolean", description: "Show agent status" },
+    help:     { type: "boolean", short: "h", description: "Show this help" },
+  },
+};
+```
+
+**Note:** Basecamp uses flags as commands (`--daemon`, `--wake <name>`, etc.)
+rather than positional subcommands. The `commands` array in the definition is
+**cosmetic only** — it populates the "Commands:" section of help output so users
+see the familiar flag-based interface. Actual dispatch goes through the
+`options` values (`values.daemon`, `values.wake`, etc.), not positional command
+routing. Do not attempt to match positionals against the commands array for
+basecamp.
+
+Replace `showHelp()` and the command dispatch block with:
+
+```js
+const cli = createCli(definition);
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+const { values } = parsed;
+if (values.daemon) { daemon(); }
+else if (values.wake) { /* wake logic */ }
+else if (values.init) { /* init logic */ }
+else if (values.update !== undefined) { /* update logic */ }
+else if (values.stop) { /* stop logic */ }
+else if (values.validate) { validate(); }
+else if (values.status) { showStatus(); }
+else { await scheduler.wakeDueAgents(); }
+```
+
+Replace `console.error` calls with `cli.error()` where the error should carry
+the CLI name prefix. Keep the custom `log()` function for daemon operational
+output — that's internal logging, not CLI error output.
+
+### 5. Add Logger where missing
+
+The spec requires every CLI to create a Logger. Check each product CLI:
+
+- **fit-pathway**: Already creates `createLogger("pathway")` (line 385) but only
+  for Finder. Keep as-is — Logger is already wired.
+- **fit-map**: Already creates `createLogger()` for Finder (line 37). Keep.
+- **fit-guide**: Already creates `createLogger("cli")` (line 150). Keep.
+- **fit-basecamp**: Has a custom `createLogger` (line 51) that writes to files.
+  This is intentional for daemon logging. Add a libtelemetry Logger for error
+  output alongside the existing file logger, or leave as-is since basecamp's
+  logging model is deliberately different (file-based).
+
+### 6. Verification
+
+For each product CLI:
+
+```sh
+bunx fit-pathway --help           # One-line-per-command format
+bunx fit-pathway --help --json    # JSON output
+bunx fit-pathway --version        # Version number
+bunx fit-pathway badcommand       # "fit-pathway: error: unknown command..."
+bunx fit-pathway job software_engineering J060  # Normal operation unchanged
+
+bunx fit-map --help
+bunx fit-map --help --json
+bunx fit-map validate             # Normal operation unchanged
+
+bunx fit-guide --help
+bunx fit-guide --help --json
+
+bunx fit-basecamp --help
+bunx fit-basecamp --help --json
+bunx fit-basecamp --status        # Normal operation unchanged
+```
+
+Run full test suite: `bun run check && bun run test`

--- a/specs/360-cli-library/plan-a-03.md
+++ b/specs/360-cli-library/plan-a-03.md
@@ -1,0 +1,400 @@
+# 360 Part 03 — Migrate library CLIs
+
+Migrate all 22 library CLIs to use libcli. Grouped by complexity from highest to
+lowest.
+
+**Depends on:** Part 01 (libcli library must exist).
+
+## Overview
+
+Library CLIs fall into four tiers of migration complexity:
+
+| Tier          | CLIs                                                                                                          | Migration scope                                                     |
+| ------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **Full**      | fit-codegen, fit-eval, fit-universe, fit-storage, fit-doc                                                     | Structured definition, help rewrite, error standardization          |
+| **Medium**    | fit-rc, fit-svscan, fit-logger                                                                                | Already use parseArgs + Logger; wire definition, standardize errors |
+| **Light**     | fit-query, fit-subjects, fit-search, fit-completion, fit-window, fit-tiktoken, fit-unary, fit-download-bundle | Minimal CLIs; add definition + help, standardize error output       |
+| **Processor** | fit-process-agents, fit-process-graphs, fit-process-resources, fit-process-tools, fit-process-vectors         | No user-facing interface; add Logger for errors, minimal help       |
+| **Repl**      | fit-visualize                                                                                                 | Repl-based; add initial --help parsing only                         |
+
+For every CLI: add `@forwardimpact/libcli` to the package's `dependencies` in
+`package.json`.
+
+## Tier 1: Full migration
+
+### fit-codegen (`libraries/libcodegen/bin/fit-codegen.js`)
+
+**Current:** 354 lines. `printUsage()` function (line 58), `parseFlags()` with
+`node:util parseArgs` (line 75), `printSummary()` function (line 205),
+`console.stderr.write` for errors (lines 345, 351).
+
+**Changes:**
+
+1. Create definition:
+
+   ```js
+   const definition = {
+     name: "fit-codegen",
+     version: VERSION,
+     description: "Generate protobuf types, service clients, and definitions",
+     options: {
+       all:        { type: "boolean", description: "Generate all code" },
+       type:       { type: "boolean", description: "Generate protobuf types only" },
+       service:    { type: "boolean", description: "Generate service bases only" },
+       client:     { type: "boolean", description: "Generate clients only" },
+       definition: { type: "boolean", description: "Generate service definitions only" },
+       help:       { type: "boolean", short: "h", description: "Show this help" },
+       version:    { type: "boolean", description: "Show version" },
+     },
+     examples: [
+       "npx fit-codegen --all",
+       "npx fit-codegen --type",
+       "npx fit-codegen --service",
+     ],
+   };
+   ```
+
+2. Replace `printUsage()` and `parseFlags()` with `cli.parse()`.
+
+3. Replace `printSummary()` with `SummaryRenderer`:
+
+   ```js
+   import { SummaryRenderer } from "@forwardimpact/libcli";
+   const summary = new SummaryRenderer({ process });
+   summary.render({
+     title: `Generated ${totalFiles} files in ./${relPath}/`,
+     items: dirs.map(dir => ({ label: `${dir.name}/`, description: dirLabels[dir.name] })),
+   }, process.stdout);
+   ```
+
+4. Replace `process.stderr.write("Error: ...")` with `cli.error()`.
+
+5. Wire Logger: already creates `new Logger("codegen")` (line 330). Use
+   `logger.exception()` in catch blocks instead of raw stderr writes.
+
+**Delete:** `printUsage()` (lines 58–69), `parseFlags()` (lines 75–113),
+`printSummary()` (lines 205–237).
+
+### fit-eval (`libraries/libeval/bin/fit-eval.js`)
+
+**Current:** 101 lines. `HELP_TEXT` const (lines 15–63), manual
+`process.argv.slice(2)` parsing (line 66), `console.error` for errors.
+
+**Changes:**
+
+1. Create definition with commands for `output`, `tee`, `run`, `supervise`.
+
+2. Replace `HELP_TEXT` and manual arg parsing with `cli.parse()`.
+
+3. The `run` and `supervise` commands accept many flags (`--task-file`,
+   `--model`, etc.) that are parsed inside the command handlers, not at
+   top-level. Keep these as-is — libcli parses the top-level command, each
+   handler parses its own flags internally.
+
+4. Replace `console.error` with `cli.error()` and `cli.usageError()`.
+
+5. Add Logger: `const logger = createLogger("eval");` and use
+   `logger.exception()` in the catch block.
+
+**Delete:** `HELP_TEXT` const (lines 15–63), manual `--help`/`--version`
+handling (lines 68–83).
+
+### fit-universe (`libraries/libuniverse/bin/fit-universe.js`)
+
+**Current:** 400 lines. `printHelp()` function (line 359), custom `parseArgs()`
+function (lines 343–357), `console.error` for errors.
+
+**Changes:**
+
+1. Create definition with options for `--generate`, `--no-prose`, `--strict`,
+   `--dry-run`, `--load`, `--only`, `--story`, `--cache`.
+
+2. Replace custom `parseArgs()` and `printHelp()` with `cli.parse()`.
+
+3. Replace `console.error` in the catch block with `cli.error()`.
+
+4. Logger already created: `createLogger("universe")` (line 310). Use
+   `logger.exception()` in the catch block.
+
+**Delete:** `parseArgs()` (lines 343–357), `printHelp()` (lines 359–395).
+
+### fit-storage (`libraries/libstorage/bin/fit-storage.js`)
+
+**Current:** 191 lines. `help()` function as a command (line 154), `parseArgs`
+from `node:util` (line 43), `console.error` for unknown commands.
+
+**Changes:**
+
+1. Create definition with commands: `create-bucket`, `wait`, `upload`,
+   `download`, `list`.
+
+2. Replace the `help` command and `values.help` check with `cli.parse()`.
+
+3. Replace `console.error("Unknown command: ...")` with `cli.usageError()`.
+
+4. Add Logger for errors.
+
+**Delete:** `help()` command function (lines 154–179).
+
+### fit-doc (`libraries/libdoc/bin/fit-doc.js`)
+
+**Current:** 143 lines. `USAGE` const (lines 14–34), `parseArgs` from
+`node:util` (line 4), `error()` function (line 39).
+
+**Changes:**
+
+1. Create definition with commands: `build` (implied default), `serve`.
+
+2. Replace `USAGE` and `error()` with `cli.parse()` and `cli.error()`.
+
+3. Add Logger for errors.
+
+**Delete:** `USAGE` const (lines 14–34), `error()` function (lines 39–43).
+
+## Tier 2: Medium migration
+
+### fit-rc (`libraries/librc/bin/fit-rc.js`)
+
+**Current:** 74 lines. `help()` function using `logger.info` (line 33),
+`parseArgs` (line 6), Logger with silent wrapper (lines 21–28).
+
+**Changes:**
+
+1. Create definition with commands: `start`, `stop`, `status`, `restart`.
+
+2. Replace `help()` function with `cli.parse()`.
+
+3. Replace `logger.error("main", "Unknown command", ...)` (line 69) with
+   `cli.usageError()`.
+
+4. Keep the silent Logger wrapper pattern — fit-rc's `--silent` flag suppresses
+   info/debug output. This aligns with the spec's `--silent`/`--quiet`
+   convention.
+
+**Delete:** `help()` function (lines 33–41), manual help check (lines 43–46).
+
+### fit-svscan (`libraries/libsupervise/bin/fit-svscan.js`)
+
+**Current:** 187 lines. No help text. `parseArgs` (line 10) for `--socket`,
+`--pid`, `--logdir`, `--timeout`. Logger for errors.
+
+**Changes:**
+
+1. Create definition with options for `socket`, `pid`, `logdir`, `timeout`.
+
+2. Replace the manual arg check (line 40) with `cli.parse()` + validation.
+
+3. Replace `logger.error("main", "Missing required arguments...")` (line 41)
+   with `cli.usageError()`.
+
+4. Logger already wired correctly.
+
+### fit-logger (`libraries/libsupervise/bin/fit-logger.js`)
+
+**Current:** 61 lines. Minimal. `parseArgs` (line 2) for `--dir`,
+`--maxFileSize`, `--maxFiles`. `console.error` for missing `--dir`.
+
+**Changes:**
+
+1. Create definition with required `--dir` option and optional size/count
+   limits.
+
+2. Replace manual error with `cli.usageError()`.
+
+3. Add Logger for errors.
+
+## Tier 3: Light migration
+
+These CLIs are 25–35 lines each. The migration is mechanical: add a definition,
+use `cli.parse()`, standardize error output.
+
+### fit-query (`libraries/libgraph/bin/fit-query.js`)
+
+**Current:** 31 lines. Inline usage string (line 12), manual `process.argv`
+parsing, `console.error`.
+
+**Changes:**
+
+```js
+const definition = {
+  name: "fit-query",
+  version: VERSION,
+  description: "Query the graph index with a triple pattern",
+  usage: "fit-query <subject> <predicate> <object>",
+  options: { help: { type: "boolean", short: "h", description: "Show this help" } },
+  examples: ['fit-query "?" rdf:type schema:Person'],
+};
+
+const cli = createCli(definition);
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+if (parsed.positionals.length !== 3) {
+  cli.usageError("expected 3 arguments: <subject> <predicate> <object>");
+  process.exit(2);
+}
+```
+
+Add Logger: `const logger = createLogger("query");` and use `logger.exception()`
+in the catch block.
+
+### fit-subjects (`libraries/libgraph/bin/fit-subjects.js`)
+
+Same pattern as fit-query. Add definition, use `cli.parse()`, standardize
+errors.
+
+### fit-search (`libraries/libvector/bin/fit-search.js`)
+
+Add definition, use `cli.parse()`, standardize errors.
+
+### fit-completion (`libraries/libllm/bin/fit-completion.js`)
+
+Add definition, use `cli.parse()`, standardize errors.
+
+### fit-window (`libraries/libmemory/bin/fit-window.js`)
+
+Add definition, use `cli.parse()`, standardize errors.
+
+### fit-tiktoken (`libraries/libutil/bin/fit-tiktoken.js`)
+
+**Current:** 33 lines. Reads from argv or stdin. Minimal inline error.
+
+Add definition with usage string. Use `cli.parse()`. Standardize error.
+
+### fit-unary (`libraries/librpc/bin/fit-unary.js`)
+
+**Current:** 33 lines. Manual argv parsing, `console.error` for errors.
+
+Add definition with usage `fit-unary <service> <method> [json]`. Use
+`cli.parse()`. Standardize errors.
+
+### fit-download-bundle (`libraries/libutil/bin/fit-download-bundle.js`)
+
+**Current:** 27 lines. No help, no args. `console.error` in catch.
+
+Add minimal definition. Use `cli.error()` in catch block. Logger already
+created.
+
+## Tier 4: Processor CLIs
+
+These CLIs have no user-facing help and take no arguments. They are batch
+processors run as part of internal pipelines.
+
+### Shared pattern
+
+For each processor CLI, the migration is:
+
+1. Add a minimal definition (name, version, description).
+2. Use `cli.parse()` to handle `--help` (adds discoverability).
+3. Ensure Logger is created and used for error output.
+4. Replace `console.error` in catch blocks with `logger.exception()`.
+
+### fit-process-agents (`libraries/libagent/bin/fit-process-agents.js`)
+
+**Current:** 28 lines. No error handling, no help. Logger created.
+
+Add `cli.parse()` for `--help` support. Add catch block with
+`logger.exception()`.
+
+### fit-process-graphs (`libraries/libgraph/bin/fit-process-graphs.js`)
+
+**Current:** 31 lines. Logger created. `logger.exception()` already in catch.
+
+Add `cli.parse()` for `--help`. Error handling already correct.
+
+### fit-process-resources (`libraries/libresource/bin/fit-process-resources.js`)
+
+Same pattern. Add `cli.parse()`. Ensure Logger and error handling.
+
+### fit-process-tools (`libraries/libtool/bin/fit-process-tools.js`)
+
+Same pattern.
+
+### fit-process-vectors (`libraries/libvector/bin/fit-process-vectors.js`)
+
+Same pattern.
+
+## Tier 5: Repl-based
+
+### fit-visualize (`libraries/libtelemetry/bin/fit-visualize.js`)
+
+**Current:** 90 lines. Repl-based interactive CLI with usage string in Repl
+config.
+
+Same approach as fit-guide: add definition, use `cli.parse()` for initial
+`--help`/`--version`, then enter Repl session unchanged.
+
+## Package.json updates
+
+Every library package that has a CLI needs `@forwardimpact/libcli` added to
+`dependencies`. The affected packages:
+
+| Package                               | CLIs                                        |
+| ------------------------------------- | ------------------------------------------- |
+| `libraries/libcodegen/package.json`   | fit-codegen                                 |
+| `libraries/libeval/package.json`      | fit-eval                                    |
+| `libraries/libuniverse/package.json`  | fit-universe                                |
+| `libraries/libstorage/package.json`   | fit-storage                                 |
+| `libraries/libdoc/package.json`       | fit-doc                                     |
+| `libraries/librc/package.json`        | fit-rc                                      |
+| `libraries/libsupervise/package.json` | fit-svscan, fit-logger                      |
+| `libraries/libgraph/package.json`     | fit-query, fit-subjects, fit-process-graphs |
+| `libraries/libvector/package.json`    | fit-search, fit-process-vectors             |
+| `libraries/libllm/package.json`       | fit-completion                              |
+| `libraries/libmemory/package.json`    | fit-window                                  |
+| `libraries/librpc/package.json`       | fit-unary                                   |
+| `libraries/libutil/package.json`      | fit-tiktoken, fit-download-bundle           |
+| `libraries/libagent/package.json`     | fit-process-agents                          |
+| `libraries/libresource/package.json`  | fit-process-resources                       |
+| `libraries/libtool/package.json`      | fit-process-tools                           |
+| `libraries/libtelemetry/package.json` | fit-visualize                               |
+
+All add: `"@forwardimpact/libcli": "workspace:*"` to `dependencies`.
+
+## Execution order
+
+No strict order between tiers — they are independent. Recommended:
+
+1. Tier 1 CLIs first (most impactful, validates the API)
+2. Tier 2 and 3 in any order
+3. Tier 4 and 5 last (least impactful)
+
+Within each tier, any order works.
+
+## Verification
+
+After all migrations:
+
+```sh
+bun install
+bun run check
+bun run test
+```
+
+Spot-check at least one CLI from each tier:
+
+```sh
+# Tier 1
+bunx fit-codegen --help
+bunx fit-codegen --help --json
+bunx fit-eval --help
+
+# Tier 2
+bunx fit-rc --help
+
+# Tier 3
+bunx fit-query --help
+
+# Tier 4
+bunx fit-process-agents --help
+
+# Tier 5
+bunx fit-visualize --help
+```
+
+Verify error format for at least one CLI:
+
+```sh
+bunx fit-codegen 2>&1  # Should show "fit-codegen: error: ..." or help
+bunx fit-rc badcmd     # Should show "fit-rc: error: unknown command..."
+```

--- a/specs/360-cli-library/plan-a-04.md
+++ b/specs/360-cli-library/plan-a-04.md
@@ -1,0 +1,231 @@
+# 360 Part 04 — Documentation
+
+Create the libcli internals documentation page and update cross-references.
+
+**Depends on:** Part 01 (libcli library must exist).
+
+## Files
+
+| File                                     | Change                                           |
+| ---------------------------------------- | ------------------------------------------------ |
+| `website/docs/internals/libcli/index.md` | **New** — CLI development internals page         |
+| `website/docs/internals/index.md`        | Add libcli card to the grid                      |
+| `CLAUDE.md`                              | Add libcli to Structure section and skill groups |
+
+## Steps
+
+### 1. Create `website/docs/internals/libcli/index.md`
+
+The spec (§ Internal documentation) prescribes the following sections. The page
+is the single reference for CLI development conventions.
+
+**Front matter:**
+
+```yaml
+---
+title: libcli — CLI Development
+description: Standard patterns for building CLI programs in the Forward Impact monorepo.
+layout: product
+---
+```
+
+**Sections:**
+
+#### Logger conventions
+
+Document the decision matrix from the spec (§ When to use libtelemetry Logger):
+
+| Output type           | Use Logger? | Why                                  |
+| --------------------- | ----------- | ------------------------------------ |
+| Progress updates      | Yes         | Structured attributes beat free text |
+| Errors and exceptions | Yes         | Preserves trace context              |
+| Help text             | No          | Rendered by libcli                   |
+| Pure data output      | No          | Primary result for piping            |
+| Version string        | No          | Single value, rendered by libcli     |
+
+Include the full table from the spec. Document:
+
+- How to create a Logger: `const logger = createLogger("domain")`
+- Domain naming: use the package name without `lib` prefix (e.g., `"codegen"`,
+  `"rc"`, `"pathway"`)
+- When to use each level: `debug` for internal tracing, `info` for operational
+  output, `error` for errors with context, `exception` for caught errors with
+  stack traces
+- How to structure attributes for agent parseability:
+  `logger.info("step", "Generated types", { files: "12" })`
+- The `--silent`/`--quiet` suppression pattern (from fit-rc)
+- RFC 5424 output format reference:
+  `{level} {timestamp} {domain} {appId} {procId} {msgId} [{attrs}] {message}`
+
+#### Help text
+
+Document:
+
+- How to declare commands and options as structured data (the definition object)
+- The one-line-per-command property and why it matters for agents
+- Human mode vs machine mode (`--help --json`)
+- How `cli.parse()` handles `--help` and `--version` automatically
+
+Include a minimal definition example.
+
+#### Error handling
+
+Document:
+
+- Standard error format: `cli-name: error: message`
+- Exit codes: 1 for runtime errors, 2 for usage errors
+- Why `cli.error()` and `cli.usageError()` exist
+- Why `logger.exception()` should be used in catch blocks for operational errors
+- No ANSI color on stderr
+
+#### Summary output
+
+Document:
+
+- `SummaryRenderer` usage for post-command output
+- The `{ title, items: [{ label, description }] }` data structure
+- The fit-codegen example as the reference pattern
+
+#### Argument parsing
+
+Document:
+
+- How definition options serve both parsing and help generation
+- `cli.parse()` wraps `node:util parseArgs`
+- `allowPositionals: true` is always set
+- How to validate positionals in the CLI entry point
+
+#### Composition with other libraries
+
+Document when to use each:
+
+- **libcli** — CLI chrome: help, errors, summaries, argument parsing, colors
+- **libformat** — Content rendering: markdown → HTML or ANSI terminal output
+- **librepl** — Interactive sessions: command loops, state, history
+- **libtelemetry** — Operational diagnostics: Logger, Tracer, Observer
+
+A CLI that renders markdown (fit-guide) uses libformat for content and libcli
+for chrome. A Repl-based CLI uses libcli for initial parsing and librepl for the
+session.
+
+#### Minimal CLI example
+
+A complete, runnable example showing the standard pattern:
+
+```js
+#!/usr/bin/env node
+
+import { createCli } from "@forwardimpact/libcli";
+import { createLogger } from "@forwardimpact/libtelemetry";
+
+const definition = {
+  name: "fit-example",
+  version: "0.1.0",
+  description: "Example CLI showing standard pattern",
+  usage: "fit-example <input>",
+  options: {
+    output: { type: "string", description: "Output path" },
+    json:   { type: "boolean", description: "Output as JSON" },
+    help:   { type: "boolean", short: "h", description: "Show this help" },
+    version: { type: "boolean", description: "Show version" },
+  },
+  examples: [
+    "fit-example data.yaml",
+    "fit-example data.yaml --json",
+  ],
+};
+
+const logger = createLogger("example");
+const cli = createCli(definition);
+
+async function main() {
+  const parsed = cli.parse(process.argv.slice(2));
+  if (!parsed) process.exit(0);
+
+  const { values, positionals } = parsed;
+  const [input] = positionals;
+
+  if (!input) {
+    cli.usageError("missing required argument <input>");
+    process.exit(2);
+  }
+
+  // ... do work, using logger for operational output
+  logger.info("main", "Processing complete", { file: input });
+}
+
+main().catch((error) => {
+  logger.exception("main", error);
+  cli.error(error.message);
+  process.exit(1);
+});
+```
+
+This example demonstrates: shebang, imports, definition as data, Logger
+creation, `cli.parse()`, positional validation, error handling, and the catch
+pattern.
+
+### 2. Update `website/docs/internals/index.md`
+
+Add a card to the grid, after the Codegen card (maintaining alphabetical-ish
+order by topic):
+
+```html
+<a href="/docs/internals/libcli/">
+
+### libcli
+
+CLI development patterns — help text, argument parsing, error handling, summary
+rendering, Logger conventions, and composition with other libraries.
+
+</a>
+```
+
+Insert between the existing "Codegen" card and the "Operations" card (or after
+the library cards, before Operations — match the existing grouping where product
+internals come first, then library internals, then operations).
+
+### 3. Update `CLAUDE.md`
+
+#### Structure section
+
+Add `libcli` to the libraries listing:
+
+```
+libraries/
+  libcli/              # CLI infrastructure, help, arg parsing, formatting
+  libskill/            # derivation logic, job/agent models
+  ...
+```
+
+#### Skill groups section
+
+Add libcli to the `libs-web-presentation` group (it provides CLI presentation
+utilities, analogous to libui for web and libformat for content):
+
+```
+- **`libs-web-presentation`** — libui, libformat, libweb, libdoc, libtemplate,
+  libcli, librepl
+```
+
+Alternatively, if libcli feels more like system infrastructure than
+presentation, add it to `libs-system-utilities`. The choice is a judgment call —
+libcli provides formatting and output (presentation-adjacent) but also argument
+parsing (utility-adjacent). Follow the existing grouping logic: libformat is in
+web-presentation and does terminal formatting, so libcli fits there too.
+
+## Verification
+
+```sh
+# Build docs locally
+bunx fit-doc build
+
+# Verify the new page renders
+bunx fit-doc serve
+# Browse to /docs/internals/libcli/
+
+# Verify the index card links correctly
+# Browse to /docs/internals/
+```
+
+Check that CLAUDE.md changes are consistent with the existing format.

--- a/specs/360-cli-library/plan-a.md
+++ b/specs/360-cli-library/plan-a.md
@@ -1,0 +1,248 @@
+# 360 — CLI Library: Plan
+
+## Strategy
+
+Introduce `libraries/libcli/` as a new library providing structured help
+rendering, argument parsing, error output, summary formatting, and color/TTY
+utilities. Then migrate all 26 CLIs to use it, eliminating per-CLI formatting
+code. Finally, add the internals documentation page.
+
+The library follows the monorepo's OO+DI pattern: classes accept collaborators
+through constructors, factory functions wire real implementations, tests inject
+mocks. No external dependencies — only Node.js built-ins and existing monorepo
+libraries (libtelemetry for Logger).
+
+### API design
+
+The core idea: **define a CLI's interface once as data, use it for both parsing
+and help rendering.** A definition object describes the CLI's name, version,
+description, commands, options, and examples. The `Cli` class consumes this
+definition to parse arguments and render help. Command dispatch stays in the CLI
+entry point — libcli is a thin library, not a framework.
+
+#### Definition structure
+
+```js
+const definition = {
+  name: "fit-pathway",
+  version: "1.2.0",
+  description: "Career progression for engineering frameworks",
+  commands: [
+    { name: "discipline", args: "<id>", description: "Show discipline details" },
+    { name: "job", args: "<discipline> [options]", description: "Derive a job definition" },
+  ],
+  options: {
+    level: { type: "string", description: "Target level (default: mid)" },
+    track: { type: "string", description: "Apply track modifier" },
+    json:  { type: "boolean", description: "Output as JSON" },
+    help:  { type: "boolean", short: "h", description: "Show this help" },
+    version: { type: "boolean", description: "Show version" },
+  },
+  examples: [
+    "fit-pathway job backend --level=senior --track=lead",
+    "fit-pathway interview backend --level=mid --json",
+  ],
+};
+```
+
+CLIs without subcommands omit `commands` and use a `usage` string instead:
+
+```js
+const definition = {
+  name: "fit-query",
+  version: "0.1.0",
+  description: "Query the graph index with a triple pattern",
+  usage: "fit-query <subject> <predicate> <object>",
+  options: {
+    help: { type: "boolean", short: "h", description: "Show this help" },
+  },
+  examples: ['fit-query "?" rdf:type schema:Person'],
+};
+```
+
+#### Cli class
+
+```js
+class Cli {
+  constructor(definition, { process, helpRenderer })
+
+  parse(argv)       // Returns { values, positionals } or null if --help/--version handled
+  error(message)    // Writes "name: error: message" to stderr, sets exitCode = 1
+  usageError(message) // Same but exitCode = 2
+}
+```
+
+`parse()` wraps `node:util parseArgs` using the definition's options, handles
+`--help` (with `--json` support) and `--version` internally, and returns parsed
+results or `null` when it handled the request itself. This eliminates the
+per-CLI boilerplate of checking for help/version flags.
+
+Typical entry point pattern after migration:
+
+```js
+const cli = createCli(definition);
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+const { values, positionals } = parsed;
+const [command, ...args] = positionals;
+const handler = COMMANDS[command];
+
+if (!handler) {
+  cli.usageError(`unknown command "${command}"`);
+  process.exit(2);
+}
+
+try {
+  await handler({ values, args });
+} catch (error) {
+  cli.error(error.message);
+  process.exit(1);
+}
+```
+
+#### HelpRenderer class
+
+```js
+class HelpRenderer {
+  constructor({ process })
+
+  render(definition, stream)     // Human-mode: formatted, optional color
+  renderJson(definition, stream) // Machine-mode: JSON structure
+}
+```
+
+Human-mode output follows the spec's format: header line
+(`name version — description`), usage, commands (one per line, aligned columns),
+options (one per line, aligned), examples. The one-line-per-command property
+makes `fit-name -h | grep keyword` return a complete, actionable line.
+
+Machine-mode (`--help --json`) outputs the definition as a JSON object
+describing all commands, options, and descriptions.
+
+#### SummaryRenderer class
+
+```js
+class SummaryRenderer {
+  constructor({ process })
+
+  render({ title, items })  // "title\n  label  — description\n..."
+}
+```
+
+Accepts a title string and an array of `{ label, description }` items. Pads
+labels for column alignment. This standardizes the pattern already used by
+fit-codegen's `printSummary()`.
+
+#### Color and formatting (migrated from pathway)
+
+Generic utilities move from `products/pathway/src/lib/cli-output.js` to libcli:
+
+- `colors` object (ANSI constants)
+- `supportsColor(process)` — checks `NO_COLOR`, `FORCE_COLOR`, TTY
+- `colorize(text, color, process)` — conditional ANSI wrapping
+- `formatTable(headers, rows, options)` — aligned columns with optional
+  separator
+- `formatHeader(text)`, `formatSubheader(text)` — bold/cyan text
+- `formatListItem(label, value, indent)`, `formatBullet(text, indent)`
+- `formatSection(title, content)`, `horizontalRule(width)`,
+  `indent(text, spaces)`
+- `formatError(message)`, `formatSuccess(message)`, `formatWarning(message)`
+
+Domain-specific formatters stay in pathway:
+
+- `formatSkillProficiency(level)` — imports `colorize`, `colors` from libcli
+- `formatBehaviourMaturity(maturity)` — same
+- `formatModifier(modifier)`, `formatPercent(value)`, `formatChange(change)` —
+  same
+
+The key change to `supportsColor`: accept a `process` parameter for testability,
+instead of reading `process` as a module global. Same for `colorize`.
+
+### Dependency direction
+
+```
+libcli ← (no monorepo dependencies; only node:util built-in)
+  ↑
+  ├── products/pathway (imports color primitives + Cli)
+  ├── products/map (imports Cli)
+  ├── products/guide (imports Cli for initial parsing)
+  ├── products/basecamp (imports Cli)
+  └── libraries/* (import Cli or just error())
+```
+
+libtelemetry is NOT a dependency of libcli. The spec is explicit: "libcli does
+not wrap, extend, or re-export Logger — CLIs import Logger from libtelemetry
+directly." libcli and libtelemetry are peers — both used by CLI entry points.
+
+## Parts
+
+| Part               | Scope                                                | Depends on | Files              |
+| ------------------ | ---------------------------------------------------- | ---------- | ------------------ |
+| [01](plan-a-01.md) | Create libcli library                                | —          | ~12 new            |
+| [02](plan-a-02.md) | Migrate product CLIs (pathway, map, guide, basecamp) | 01         | ~8 modified        |
+| [03](plan-a-03.md) | Migrate library CLIs (22 CLIs across 17 packages)    | 01         | ~22 modified       |
+| [04](plan-a-04.md) | Documentation (internals page, index update)         | 01         | ~2 new, 2 modified |
+
+Parts 02, 03, and 04 all depend on part 01 but are independent of each other.
+
+## Cross-cutting concerns
+
+### Testing
+
+Every libcli class gets unit tests using `node:test` and libharness mocks. Key
+test scenarios:
+
+- `Cli.parse()` returns correct values for valid input
+- `Cli.parse()` returns null and writes help when `--help` is passed
+- `Cli.parse()` returns null and writes JSON help when `--help --json` is passed
+- `Cli.parse()` returns null and writes version when `--version` is passed
+- `Cli.error()` writes prefixed message to stderr and sets exitCode = 1
+- `Cli.usageError()` sets exitCode = 2
+- `HelpRenderer.render()` produces one-line-per-command output
+- `HelpRenderer.renderJson()` produces valid JSON
+- `SummaryRenderer.render()` aligns labels
+- `supportsColor()` respects NO_COLOR, FORCE_COLOR, isTTY
+- `formatTable()` aligns columns
+
+Process is injected in constructors for testability — no reliance on global
+`process`.
+
+### Build and install
+
+After creating `libraries/libcli/`, run `bun install` to register the workspace
+package. Each migrated CLI's `package.json` gains `@forwardimpact/libcli` in
+`dependencies`.
+
+### Verification
+
+After each part, run:
+
+- `bun run check` — format and lint pass
+- `bun run test` — all unit tests pass
+- Manual smoke test: `bunx fit-<name> --help` produces new format,
+  `bunx fit-<name> --help --json` produces JSON, error format matches
+  `name: error: message`
+
+## Risks
+
+1. **pathway's 150-line HELP_TEXT** — The current help text has per-command
+   sections with detailed usage blocks. The structured definition can only
+   capture one-line-per-command summaries. Pathway may need per-command help
+   (e.g. `fit-pathway job --help`) in a future iteration, but the spec's scope
+   is the top-level help only. Per-command detailed help is out of scope.
+
+2. **basecamp uses `#!/usr/bin/env bun`** — Unlike other CLIs that use
+   `#!/usr/bin/env node`, basecamp uses bun directly. libcli's
+   `node:util parseArgs` works in both runtimes, so this is not a blocker, but
+   worth noting.
+
+3. **Processor CLIs have no user-facing interface** — The `fit-process-*` CLIs
+   (agents, graphs, resources, tools, vectors) have no help text, no arguments,
+   and no error handling beyond a catch block. Migration is minimal: add Logger
+   usage for error output and optionally wire `--help` for discoverability.
+   Don't over-engineer these.
+
+4. **Repl-based CLIs** — fit-guide and fit-visualize use librepl for interactive
+   sessions. libcli handles only the initial argument parsing and help; the Repl
+   session is unchanged. The spec explicitly scopes this out.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -51,4 +51,4 @@
 330	done
 340	done
 350	done
-360	review
+360	planned


### PR DESCRIPTION
## Summary

- Add implementation plan for spec 360 (CLI Library), decomposed into 4 independently executable parts
- Part 01: Create `libraries/libcli/` (Cli, HelpRenderer, SummaryRenderer, color/format utilities)
- Part 02: Migrate product CLIs (pathway, map, guide, basecamp)
- Part 03: Migrate 22 library CLIs across 17 packages
- Part 04: Documentation (internals page, CLAUDE.md updates)
- Advance spec 360 status from `review` to `planned`

## Test plan

- [ ] Plan files pass format check (`bun run check`)
- [ ] No code changes — plan-only PR, no runtime impact

https://claude.ai/code/session_015nJPkqP4C9cz4MxCZ6L4z3