### PR TITLE
chore(skills): add explicit trigger clauses to all gemba skill descriptions

### DIFF
--- a/.claude/skills/gemba-gh-cli/SKILL.md
+++ b/.claude/skills/gemba-gh-cli/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: gemba-gh-cli
-description: GitHub CLI usage for Gemba agents running in GitHub Actions. Covers sandbox installation, CI runner quirks, and the repeated gh query patterns Gemba skills use for PR triage, contributor lookup, trace downloads, and release operations. Generic gh reference included as appendix.
+description: >
+  GitHub CLI usage for Gemba agents running in GitHub Actions. Covers sandbox
+  installation, CI runner quirks, and the repeated gh query patterns Gemba
+  skills use for PR triage, contributor lookup, trace downloads, and release
+  operations. Use when running gh commands in CI, installing gh on a runner,
+  or looking up canonical query shapes for GitHub API calls.
 ---
 
 # GitHub CLI for Gemba workflows

--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -2,8 +2,9 @@
 name: gemba-implement
 description: >
   Implement a spec by studying its spec.md and plan, then executing the plan
-  step by step. Use when a spec and plan are approved and ready for
-  implementation.
+  step by step. Use when a spec has status `planned` and is ready for
+  execution, or the user says "implement spec", "execute plan", or "build
+  spec NNN".
 ---
 
 # Implement Spec

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -3,7 +3,9 @@ name: gemba-plan
 description: >
   Write and review implementation plans (HOW) for approved specs. Translate
   an approved spec.md into concrete steps, files, tests, and risks for a
-  trusted agent to execute. Advances status from review → planned.
+  trusted agent to execute. Advances status from review → planned. Use when
+  the user says "plan spec", "write plan", "review plan", or an approved spec
+  needs a concrete implementation strategy.
 ---
 
 # Write and Review Plans

--- a/.claude/skills/gemba-product-classify/SKILL.md
+++ b/.claude/skills/gemba-product-classify/SKILL.md
@@ -3,7 +3,8 @@ name: gemba-product-classify
 description: >
   Classify open pull requests for mergeability — verify contributor trust,
   parse PR type, check CI status, review spec quality on spec PRs, and merge
-  PRs that pass all gates.
+  PRs that pass all gates. Use when reviewing open PRs for product alignment,
+  deciding if a PR can be merged, or running scheduled PR classification.
 ---
 
 # Product PR Classification

--- a/.claude/skills/gemba-product-evaluation/SKILL.md
+++ b/.claude/skills/gemba-product-evaluation/SKILL.md
@@ -3,7 +3,9 @@ name: gemba-product-evaluation
 description: >
   Supervise a product evaluation session where an agent tries a product as a
   first-time external user. Guide the session, capture feedback, and create
-  GitHub issues for actionable findings.
+  GitHub issues for actionable findings. Use when running fit-eval supervise,
+  testing a product from the external user perspective, or conducting a
+  first-time user experience review.
 ---
 
 # Product Evaluation

--- a/.claude/skills/gemba-product-triage/SKILL.md
+++ b/.claude/skills/gemba-product-triage/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: gemba-product-triage
 description: >
-  Classify open GitHub issues by product alignment and decide what action
-  each needs — trivial fix, spec, or out-of-scope. Produce a triage report
-  for the agent to act on. Does not implement fixes or write specs itself.
+  Classify open GitHub issues by product alignment and decide what action each
+  needs — trivial fix, spec, or out-of-scope. Produce a triage report for the
+  agent to act on. Use when triaging issues, reviewing open issues for product
+  fit, or running scheduled issue classification.
 ---
 
 # Product Issue Triage

--- a/.claude/skills/gemba-release-readiness/SKILL.md
+++ b/.claude/skills/gemba-release-readiness/SKILL.md
@@ -2,8 +2,10 @@
 name: gemba-release-readiness
 description: >
   Check open pull requests for merge readiness. Rebase branches on main, fix
-  trivial CI failures (lint, format, lock file), and report status. Do not make
-  code-level decisions or approve PRs.
+  trivial CI failures (lint, format, lock file), and report status. Do not
+  make code-level decisions or approve PRs. Use when preparing PRs for merge,
+  running scheduled readiness checks, or fixing mechanical CI failures like
+  lint, format, or lock file drift.
 ---
 
 # Release Readiness

--- a/.claude/skills/gemba-release-review/SKILL.md
+++ b/.claude/skills/gemba-release-review/SKILL.md
@@ -3,7 +3,9 @@ name: gemba-release-review
 description: >
   Review the main branch for unreleased changes and cut new versions. Determine
   version bumps, update package.json files, tag releases, push tags, and verify
-  publish workflows. Canonical source for the release procedure.
+  publish workflows. Canonical source for the release procedure. Use when
+  cutting a release, checking for unreleased changes, or running the scheduled
+  weekly release cycle.
 ---
 
 # Release Review

--- a/.claude/skills/gemba-security-audit/SKILL.md
+++ b/.claude/skills/gemba-security-audit/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Perform a holistic security review of the monorepo. Assess GitHub Actions
   supply chain, dependency hygiene, credential leak controls, CI audit gates,
   and application-level vulnerabilities. Use when reviewing PRs for security
-  impact, auditing the repo posture, or investigating a reported vulnerability.
+  impact, auditing the repo security posture, investigating a reported
+  vulnerability, or checking for credential leaks and supply chain risks.
 ---
 
 # Security Audit

--- a/.claude/skills/gemba-security-update/SKILL.md
+++ b/.claude/skills/gemba-security-update/SKILL.md
@@ -3,8 +3,8 @@ name: gemba-security-update
 description: >
   Apply security updates to the repository. Triage open Dependabot PRs against
   repository policies, review npm audit findings, and action dependency
-  vulnerabilities. Merge PRs that pass all checks, fix minor issues on a new
-  branch, or close PRs that violate policy.
+  vulnerabilities. Use when processing Dependabot PRs, addressing npm audit
+  findings, remediating CVEs, or running scheduled security update sweeps.
 ---
 
 # Security Update

--- a/.claude/skills/gemba-spec/SKILL.md
+++ b/.claude/skills/gemba-spec/SKILL.md
@@ -3,8 +3,9 @@ name: gemba-spec
 description: >
   Write and review specifications (WHAT/WHY) for features, changes, and
   improvements. Manage spec status in specs/STATUS through draft → review.
-  Use when proposing changes, capturing findings as actionable specs, or
-  evaluating spec quality. Pair with the `gemba-plan` skill for the HOW side.
+  Use when the user says "write spec", "draft spec", "review spec", proposes
+  a new feature or change, or captures a finding as actionable work. Pair with
+  the `gemba-plan` skill for the HOW side.
 ---
 
 # Write and Review Specs

--- a/.claude/skills/gemba-walk/SKILL.md
+++ b/.claude/skills/gemba-walk/SKILL.md
@@ -3,7 +3,9 @@ name: gemba-walk
 description: >
   Walk the gemba of an agent workflow run. Select a trace, download it, observe
   the work as it actually happened, apply grounded theory analysis, and produce
-  a structured findings report. "Go see, ask why, show respect."
+  a structured findings report. Use when analyzing an agent workflow trace,
+  investigating a workflow failure, auditing trust boundaries, or running a
+  coaching cycle. "Go see, ask why, show respect."
 ---
 
 # Gemba Walk for Agent Workflows

--- a/GEMBA.md
+++ b/GEMBA.md
@@ -375,6 +375,41 @@ entirely instructional with no templates or scripts to extract — that's fine.
 The goal is not to hit a line count but to separate procedure from supporting
 material so the core instructions stay scannable.
 
+### Skill description triggers
+
+The `description` field in SKILL.md frontmatter is the primary activation
+mechanism — the model reads truncated descriptions (~250 chars) in the
+system-reminder to decide which skill to invoke. A description without trigger
+conditions is a skill that never fires at the right time.
+
+**Rules:**
+
+1. **Every description must include a "Use when" clause.** State the contexts
+   that should activate the skill — scheduled runs, specific user phrases,
+   prerequisite states.
+2. **Front-load triggers within 250 characters.** Descriptions are truncated in
+   the system-reminder preview. Keep the core purpose sentence short so "Use
+   when" appears before the cutoff.
+3. **Name specific user phrases.** Include the exact words a user or task would
+   say: "implement spec", "write plan", "cut a release". Generic summaries
+   ("handles PR operations") do not trigger reliably.
+4. **Replace implementation detail with trigger conditions.** The description
+   tells the model _when_ to activate, not _how_ the skill works. Swap
+   operational detail (merge/fix/close mechanics) for actionable contexts
+   (Dependabot PRs, npm audit findings, scheduled sweeps).
+5. **Include automated contexts.** Skills invoked by scheduled workflows should
+   name the schedule pattern: "running scheduled PR classification", "running
+   the weekly release cycle".
+
+**Common violations:**
+
+| Violation                                 | Symptom                                  |
+| ----------------------------------------- | ---------------------------------------- |
+| No "Use when" clause                      | Skill not activated when context matches |
+| "Use when" buried past 250 chars          | Trigger conditions truncated in preview  |
+| Generic capability summary only           | Model cannot distinguish similar skills  |
+| Implementation detail instead of triggers | Description consumed by HOW, not WHEN    |
+
 ### Shared patterns must be consistent
 
 Use the same wording for shared structural elements (memory instructions,


### PR DESCRIPTION
Every gemba skill now has a "Use when" clause in its frontmatter description,
ensuring the system-reminder preview surfaces actionable trigger conditions
rather than just capability summaries.

https://claude.ai/code/session_014GhvFDBeEJdu7bPTETJWXC