### PR TITLE
spec(libcli): plan for CLI library (spec 360)

### DIFF
--- a/.claude/skills/gemba-gh-cli/SKILL.md
+++ b/.claude/skills/gemba-gh-cli/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: gemba-gh-cli
-description: >
-  GitHub CLI usage for Gemba agents running in GitHub Actions. Covers sandbox
-  installation, CI runner quirks, and the repeated gh query patterns Gemba
-  skills use for PR triage, contributor lookup, trace downloads, and release
-  operations. Use when running gh commands in CI, installing gh on a runner,
-  or looking up canonical query shapes for GitHub API calls.
+description: GitHub CLI usage for Gemba agents running in GitHub Actions. Covers sandbox installation, CI runner quirks, and the repeated gh query patterns Gemba skills use for PR triage, contributor lookup, trace downloads, and release operations. Generic gh reference included as appendix.
 ---
 
 # GitHub CLI for Gemba workflows

--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -2,9 +2,8 @@
 name: gemba-implement
 description: >
   Implement a spec by studying its spec.md and plan, then executing the plan
-  step by step. Use when a spec has status `planned` and is ready for
-  execution, or the user says "implement spec", "execute plan", or "build
-  spec NNN".
+  step by step. Use when a spec and plan are approved and ready for
+  implementation.
 ---
 
 # Implement Spec

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -3,9 +3,7 @@ name: gemba-plan
 description: >
   Write and review implementation plans (HOW) for approved specs. Translate
   an approved spec.md into concrete steps, files, tests, and risks for a
-  trusted agent to execute. Advances status from review → planned. Use when
-  the user says "plan spec", "write plan", "review plan", or an approved spec
-  needs a concrete implementation strategy.
+  trusted agent to execute. Advances status from review → planned.
 ---
 
 # Write and Review Plans

--- a/.claude/skills/gemba-product-classify/SKILL.md
+++ b/.claude/skills/gemba-product-classify/SKILL.md
@@ -3,8 +3,7 @@ name: gemba-product-classify
 description: >
   Classify open pull requests for mergeability — verify contributor trust,
   parse PR type, check CI status, review spec quality on spec PRs, and merge
-  PRs that pass all gates. Use when reviewing open PRs for product alignment,
-  deciding if a PR can be merged, or running scheduled PR classification.
+  PRs that pass all gates.
 ---
 
 # Product PR Classification
@@ -36,7 +35,7 @@ All comment templates and the report format are in `references/templates.md`.
 
 ## Gate Checklist
 
-<do_confirm_checklist goal="Verify trust, type, CI, and spec quality">
+<do_confirm_checklist>
 
 - [ ] **Author is trusted** — CI app or top-20 lookup (Step 2). On failure, mark
       **blocked** and comment that only trusted authors merge.

--- a/.claude/skills/gemba-product-evaluation/SKILL.md
+++ b/.claude/skills/gemba-product-evaluation/SKILL.md
@@ -3,9 +3,7 @@ name: gemba-product-evaluation
 description: >
   Supervise a product evaluation session where an agent tries a product as a
   first-time external user. Guide the session, capture feedback, and create
-  GitHub issues for actionable findings. Use when running fit-eval supervise,
-  testing a product from the external user perspective, or conducting a
-  first-time user experience review.
+  GitHub issues for actionable findings.
 ---
 
 # Product Evaluation

--- a/.claude/skills/gemba-product-triage/SKILL.md
+++ b/.claude/skills/gemba-product-triage/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: gemba-product-triage
 description: >
-  Classify open GitHub issues by product alignment and decide what action each
-  needs — trivial fix, spec, or out-of-scope. Produce a triage report for the
-  agent to act on. Use when triaging issues, reviewing open issues for product
-  fit, or running scheduled issue classification.
+  Classify open GitHub issues by product alignment and decide what action
+  each needs — trivial fix, spec, or out-of-scope. Produce a triage report
+  for the agent to act on. Does not implement fixes or write specs itself.
 ---
 
 # Product Issue Triage

--- a/.claude/skills/gemba-release-readiness/SKILL.md
+++ b/.claude/skills/gemba-release-readiness/SKILL.md
@@ -2,10 +2,8 @@
 name: gemba-release-readiness
 description: >
   Check open pull requests for merge readiness. Rebase branches on main, fix
-  trivial CI failures (lint, format, lock file), and report status. Do not
-  make code-level decisions or approve PRs. Use when preparing PRs for merge,
-  running scheduled readiness checks, or fixing mechanical CI failures like
-  lint, format, or lock file drift.
+  trivial CI failures (lint, format, lock file), and report status. Do not make
+  code-level decisions or approve PRs.
 ---
 
 # Release Readiness

--- a/.claude/skills/gemba-release-review/SKILL.md
+++ b/.claude/skills/gemba-release-review/SKILL.md
@@ -3,9 +3,7 @@ name: gemba-release-review
 description: >
   Review the main branch for unreleased changes and cut new versions. Determine
   version bumps, update package.json files, tag releases, push tags, and verify
-  publish workflows. Canonical source for the release procedure. Use when
-  cutting a release, checking for unreleased changes, or running the scheduled
-  weekly release cycle.
+  publish workflows. Canonical source for the release procedure.
 ---
 
 # Release Review
@@ -33,7 +31,7 @@ had publish failures from prior `release-engineer` entries.
 
 ## Pre-Flight: Verify Main Branch CI
 
-<read_do_checklist goal="Verify main branch CI before releasing">
+<read_do_checklist>
 
 - [ ] Ran
       `gh run list --branch main --limit 5 --json name,conclusion,headBranch`.

--- a/.claude/skills/gemba-security-audit/SKILL.md
+++ b/.claude/skills/gemba-security-audit/SKILL.md
@@ -4,8 +4,7 @@ description: >
   Perform a holistic security review of the monorepo. Assess GitHub Actions
   supply chain, dependency hygiene, credential leak controls, CI audit gates,
   and application-level vulnerabilities. Use when reviewing PRs for security
-  impact, auditing the repo security posture, investigating a reported
-  vulnerability, or checking for credential leaks and supply chain risks.
+  impact, auditing the repo posture, or investigating a reported vulnerability.
 ---
 
 # Security Audit
@@ -77,7 +76,7 @@ Each run covers **one topic** in depth.
 
 ## 8. Audit Checklist
 
-<do_confirm_checklist goal="Confirm all audit areas reviewed">
+<do_confirm_checklist>
 
 - [ ] Ran `just audit` locally and reported findings.
 - [ ] Reviewed `.github/workflows/` for unpinned actions, missing permissions.

--- a/.claude/skills/gemba-security-update/SKILL.md
+++ b/.claude/skills/gemba-security-update/SKILL.md
@@ -3,8 +3,8 @@ name: gemba-security-update
 description: >
   Apply security updates to the repository. Triage open Dependabot PRs against
   repository policies, review npm audit findings, and action dependency
-  vulnerabilities. Use when processing Dependabot PRs, addressing npm audit
-  findings, remediating CVEs, or running scheduled security update sweeps.
+  vulnerabilities. Merge PRs that pass all checks, fix minor issues on a new
+  branch, or close PRs that violate policy.
 ---
 
 # Security Update
@@ -27,7 +27,7 @@ canonical query shapes used in the steps below.
 
 ## Policy Checklist
 
-<do_confirm_checklist goal="Verify dependency policy compliance">
+<do_confirm_checklist>
 
 - [ ] **All CI checks pass** (CONTRIBUTING.md § Before Submitting a PR). On
       failure: **fix** if caused by PR; if pre-existing on main, skip and

--- a/.claude/skills/gemba-spec/SKILL.md
+++ b/.claude/skills/gemba-spec/SKILL.md
@@ -3,9 +3,8 @@ name: gemba-spec
 description: >
   Write and review specifications (WHAT/WHY) for features, changes, and
   improvements. Manage spec status in specs/STATUS through draft → review.
-  Use when the user says "write spec", "draft spec", "review spec", proposes
-  a new feature or change, or captures a finding as actionable work. Pair with
-  the `gemba-plan` skill for the HOW side.
+  Use when proposing changes, capturing findings as actionable specs, or
+  evaluating spec quality. Pair with the `gemba-plan` skill for the HOW side.
 ---
 
 # Write and Review Specs

--- a/.claude/skills/gemba-walk/SKILL.md
+++ b/.claude/skills/gemba-walk/SKILL.md
@@ -3,9 +3,7 @@ name: gemba-walk
 description: >
   Walk the gemba of an agent workflow run. Select a trace, download it, observe
   the work as it actually happened, apply grounded theory analysis, and produce
-  a structured findings report. Use when analyzing an agent workflow trace,
-  investigating a workflow failure, auditing trust boundaries, or running a
-  coaching cycle. "Go see, ask why, show respect."
+  a structured findings report. "Go see, ask why, show respect."
 ---
 
 # Gemba Walk for Agent Workflows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,17 +117,11 @@ consult the [Getting Started guides](website/docs/getting-started/).
 `<read_do_checklist>` tags are entry gates — read each item, then do it.
 `<do_confirm_checklist>` tags are exit gates — do from memory, then confirm.
 Follow the protocol whenever you encounter these tags in the instruction stack.
-See [CHECKLISTS.md](CHECKLISTS.md) for the full approach.
 
-Discover all checklists relevant to your work:
-
-```sh
-rg '<read_do_checklist'     # entry gates — before starting
-rg '<do_confirm_checklist'  # exit gates — before committing
-```
-
-The [CONTRIBUTING.md](CONTRIBUTING.md#read-do) checklists apply to every task.
-Skills may define additional checklists for specific workflows.
+- **Before starting** — run
+  [CONTRIBUTING.md § READ-DO](CONTRIBUTING.md#read-do).
+- **Before committing** — run
+  [CONTRIBUTING.md § DO-CONFIRM](CONTRIBUTING.md#do-confirm).
 
 ## LLM Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ checks.
 Read every item before starting, and hold them while writing. Entry gate — don't
 start until all are internalized.
 
-<read_do_checklist goal="Internalize constraints before writing code">
+<read_do_checklist>
 
 - [ ] **Understand the task.** What is it actually asking? Which files will I
       touch, and which will I not?
@@ -55,7 +55,7 @@ start until all are internalized.
 Before committing, verify every item. Exit gate — don't proceed until all are
 confirmed.
 
-<do_confirm_checklist goal="Verify quality before committing">
+<do_confirm_checklist>
 
 - [ ] `bun run check` passes — format and lint, all file types.
 - [ ] `bun run test` passes — new logic has tests.

--- a/GEMBA.md
+++ b/GEMBA.md
@@ -395,52 +395,10 @@ skill, the gate checklist, the process steps, classification criteria, and
 memory instructions. If the agent needs it on every run to know _what to do
 next_, it belongs in the SKILL.md.
 
-**Checklists in skills** follow the conventions in
-[CHECKLISTS.md](CHECKLISTS.md): wrap in `<read_do_checklist>` or
-`<do_confirm_checklist>` tags with a `goal` attribute, place at the top of the
-skill (or at the relevant pause point), and keep to 5–9 killer items. The goal
-attribute must be short enough that the full opening tag fits on one line — this
-keeps `rg '<read_do_checklist'` results self-describing.
-
 **Guideline, not a hard rule.** Some skills (e.g. `spec` at 179 lines) are
 entirely instructional with no templates or scripts to extract — that's fine.
 The goal is not to hit a line count but to separate procedure from supporting
 material so the core instructions stay scannable.
-
-### Skill description triggers
-
-The `description` field in SKILL.md frontmatter is the primary activation
-mechanism — the model reads truncated descriptions (~250 chars) in the
-system-reminder to decide which skill to invoke. A description without trigger
-conditions is a skill that never fires at the right time.
-
-**Rules:**
-
-1. **Every description must include a "Use when" clause.** State the contexts
-   that should activate the skill — scheduled runs, specific user phrases,
-   prerequisite states.
-2. **Front-load triggers within 250 characters.** Descriptions are truncated in
-   the system-reminder preview. Keep the core purpose sentence short so "Use
-   when" appears before the cutoff.
-3. **Name specific user phrases.** Include the exact words a user or task would
-   say: "implement spec", "write plan", "cut a release". Generic summaries
-   ("handles PR operations") do not trigger reliably.
-4. **Replace implementation detail with trigger conditions.** The description
-   tells the model _when_ to activate, not _how_ the skill works. Swap
-   operational detail (merge/fix/close mechanics) for actionable contexts
-   (Dependabot PRs, npm audit findings, scheduled sweeps).
-5. **Include automated contexts.** Skills invoked by scheduled workflows should
-   name the schedule pattern: "running scheduled PR classification", "running
-   the weekly release cycle".
-
-**Common violations:**
-
-| Violation                                 | Symptom                                  |
-| ----------------------------------------- | ---------------------------------------- |
-| No "Use when" clause                      | Skill not activated when context matches |
-| "Use when" buried past 250 chars          | Trigger conditions truncated in preview  |
-| Generic capability summary only           | Model cannot distinguish similar skills  |
-| Implementation detail instead of triggers | Description consumed by HOW, not WHEN    |
 
 ### Shared patterns must be consistent
 

--- a/specs/360-cli-library/plan-a-01.md
+++ b/specs/360-cli-library/plan-a-01.md
@@ -29,19 +29,34 @@ and tests.
   "name": "@forwardimpact/libcli",
   "version": "0.1.0",
   "description": "Shared CLI infrastructure for the Forward Impact monorepo",
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",
   "main": "index.js",
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "test": "bun run node --test test/*.test.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "libraries/libcli"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
-    "@forwardimpact/libharness": "workspace:*"
+    "@forwardimpact/libharness": "^0.1.5"
   }
 }
 ```
 
-No runtime dependencies. libcli uses only `node:util` (for `parseArgs`).
-libharness is a devDependency for test mocking.
+Follows the standard library package.json pattern (cf. libformat). No runtime
+dependencies. libcli uses only `node:util` (for `parseArgs`). libharness is a
+devDependency for test mocking.
 
 Run `bun install` after creating this file to register the workspace package.
 
@@ -182,11 +197,14 @@ export class SummaryRenderer {
     this.#proc = process;
   }
 
-  render({ title, items }, stream) {
+  render({ title, items }, stream = this.#proc.stdout) {
     // Write title line, then indented items with aligned labels
   }
 }
 ```
+
+`stream` defaults to `this.#proc.stdout` when omitted, so callers can use
+`summary.render({ title, items })` without passing a stream explicitly.
 
 **Output format:**
 
@@ -287,6 +305,10 @@ export function createCli(definition) {
   Tests bypass the factory and inject mocks.
 - `allowPositionals: true` is always set — CLIs that don't want positionals can
   validate themselves. This keeps the API simple.
+- `parseArgs` always runs with `strict: true` (the default). Every CLI declares
+  every flag it accepts in the definition. CLIs that previously delegated flag
+  parsing to sub-command handlers (fit-eval) or to a Repl (fit-guide) are
+  restructured to declare all flags upfront. There is no `strict: false` mode.
 
 ### 7. Create index.js
 
@@ -349,7 +371,7 @@ output.
 - `parse` returns null and writes version when `--version` is passed
 - `error` writes prefixed message to stderr and sets exitCode to 1
 - `usageError` writes prefixed message to stderr and sets exitCode to 2
-- `parse` throws on unknown flags (default parseArgs behavior)
+- `parse` throws on unknown flags (strict parseArgs, always)
 
 Mock process:
 

--- a/specs/360-cli-library/plan-a-02.md
+++ b/specs/360-cli-library/plan-a-02.md
@@ -1,7 +1,9 @@
 # 360 Part 02 — Migrate product CLIs
 
-Migrate the four product CLIs to use libcli. These are the most complex CLIs and
-the most visible to external users.
+Migrate three product CLIs to use libcli. These are the most complex CLIs and
+the most visible to external users. Basecamp is handled separately in
+[part 05](plan-a-05.md) because it also requires a structural refactor from
+flag-based commands to positional subcommands.
 
 **Depends on:** Part 01 (libcli library must exist).
 
@@ -16,13 +18,11 @@ the most visible to external users.
 | `products/map/bin/fit-map.js`            | Rewrite to use Cli class                        |
 | `products/guide/package.json`            | Add `@forwardimpact/libcli` dependency          |
 | `products/guide/bin/fit-guide.js`        | Use Cli for initial parsing                     |
-| `products/basecamp/package.json`         | Add `@forwardimpact/libcli` dependency          |
-| `products/basecamp/src/basecamp.js`      | Rewrite CLI entry to use Cli class              |
 
 ## Order
 
 1. Migrate pathway first (it's the source of the formatting code)
-2. Map, guide, basecamp in any order
+2. Map, guide in any order
 
 ## Steps
 
@@ -76,16 +76,30 @@ The kept functions currently call the local `colorize()` — they switch to the
 libcli import. Behavior is identical (the default `proc` parameter handles
 production use).
 
-**Update other pathway files** that import from `cli-output.js`. Search for
-imports of the removed functions across `products/pathway/src/` and update them
-to import from `@forwardimpact/libcli` instead. Common imports to redirect:
+**Update other pathway files** that import from `cli-output.js`. The following
+13 files import generic formatters that move to libcli — redirect their imports
+to `@forwardimpact/libcli`:
 
-- `formatTable` — used in command handlers for tabular output
-- `formatHeader`, `formatSubheader` — used in command handlers for section
-  titles
-- `formatError` — used in `bin/fit-pathway.js` (line 41) and command handlers
-- `formatSection`, `formatBullet`, `formatListItem` — used in command handlers
-- `horizontalRule`, `indent` — used in command handlers
+| File                                           | Functions imported                                     |
+| ---------------------------------------------- | ------------------------------------------------------ |
+| `products/pathway/bin/fit-pathway.js`          | `formatError`                                          |
+| `products/pathway/src/commands/skill.js`       | `formatTable`, `formatError`                           |
+| `products/pathway/src/commands/track.js`       | `formatTable`                                          |
+| `products/pathway/src/commands/agent.js`       | `formatError`, `formatSuccess`                         |
+| `products/pathway/src/commands/behaviour.js`   | `formatTable`                                          |
+| `products/pathway/src/commands/level.js`       | `formatTable`                                          |
+| `products/pathway/src/commands/driver.js`      | `formatTable`, `formatHeader`, `formatSubheader`, `formatBullet` |
+| `products/pathway/src/commands/discipline.js`  | `formatTable`                                          |
+| `products/pathway/src/commands/job.js`         | `formatTable`                                          |
+| `products/pathway/src/commands/agent-io.js`    | `formatSuccess`                                        |
+| `products/pathway/src/commands/questions.js`   | `formatTable`                                          |
+| `products/pathway/src/commands/stage.js`       | `formatTable`, `formatHeader`, `formatSubheader`, `formatBullet` |
+| `products/pathway/src/commands/tool.js`        | `formatTable`, `formatHeader`, `formatSubheader`       |
+
+Each file switches from `import { fn } from "../lib/cli-output.js"` to
+`import { fn } from "@forwardimpact/libcli"`. Domain-specific formatters
+(`formatSkillProficiency`, etc.) continue to import from the local
+`cli-output.js`.
 
 #### 1c. Rewrite `products/pathway/bin/fit-pathway.js`
 
@@ -243,7 +257,15 @@ Add `@forwardimpact/libcli` dependency.
 #### 2b. Rewrite `products/map/bin/fit-map.js`
 
 **Current state:** 448 lines with `showHelp()` function (line 235), inline
-`parseArgs` call (line 375), and `console.error` for error output.
+`parseArgs` call (line 375), and `console.error` for error output. Has no
+`VERSION` constant — add one by reading `package.json` (same pattern as
+fit-pathway lines 66–68):
+
+```js
+const { version: VERSION } = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+```
 
 Create a definition object. Map has subcommands with sub-subcommands
 (`people validate`, `activity start`). Since libcli doesn't do nested subcommand
@@ -296,100 +318,78 @@ doesn't own.
 
 Add `@forwardimpact/libcli` dependency.
 
-#### 3b. Update `products/guide/bin/fit-guide.js`
+#### 3b. Rewrite `products/guide/bin/fit-guide.js`
 
-**Current state:** Repl-based interactive CLI (279 lines). The `usage` variable
-(line 18) is a string passed to Repl configuration.
+**Current state:** Repl-based interactive CLI (280 lines). The Repl's
+`commands` config (lines 231–261) handles `--version`, `--init`, `--data`, and
+`--streaming` as CLI flags parsed during `repl.start()`. These are CLI-time
+concerns, not interactive Repl commands.
 
-Guide is a Repl-based CLI — the migration is minimal:
-
-- Add a definition object with `name`, `version`, `description`, and a `usage`
-  string
-- Use `createCli(definition)` to handle `--help` and `--version` before entering
-  the Repl session
-- The Repl session itself is unchanged
-- Replace `console.error()` in the catch block (line 269) with `cli.error()` or
-  `logger.exception()`
+**The change:** Move all CLI flags out of the Repl and into a libcli definition.
+The CLI entry point handles them before starting the Repl. The Repl becomes
+purely interactive.
 
 ```js
-const cli = createCli(definition);
-const parsed = cli.parse(process.argv.slice(2));
-if (!parsed) process.exit(0);
+import { createCli } from "@forwardimpact/libcli";
 
-// Existing Repl setup continues from here
-```
-
-### 4. Migrate basecamp
-
-#### 4a. Update `products/basecamp/package.json`
-
-Add `@forwardimpact/libcli` dependency.
-
-#### 4b. Rewrite `products/basecamp/src/basecamp.js`
-
-**Current state:** 348 lines with `showHelp()` function (line 281), manual
-`args[0]` command dispatch (lines 304–347), and `console.error` for errors.
-
-Create a definition object:
-
-```js
 const definition = {
-  name: "fit-basecamp",
+  name: "fit-guide",
   version: VERSION,
-  description: "Schedule autonomous agents across knowledge bases",
-  commands: [
-    { name: "--daemon", description: "Run continuously (poll every 60s)" },
-    { name: "--wake", args: "<agent>", description: "Wake a specific agent immediately" },
-    { name: "--init", args: "<path>", description: "Initialize a new knowledge base" },
-    { name: "--update", args: "[path]", description: "Update KB with latest CLAUDE.md, agents and skills" },
-    { name: "--stop", description: "Gracefully stop daemon and all running agents" },
-    { name: "--validate", description: "Validate agent definitions exist" },
-    { name: "--status", description: "Show agent status" },
-  ],
+  description: "Conversational agent for the Guide knowledge platform",
   options: {
-    daemon:   { type: "boolean", description: "Run as daemon" },
-    wake:     { type: "string", description: "Agent to wake" },
-    init:     { type: "string", description: "KB path to initialize" },
-    update:   { type: "string", description: "KB path to update" },
-    stop:     { type: "boolean", description: "Stop daemon" },
-    validate: { type: "boolean", description: "Validate definitions" },
-    status:   { type: "boolean", description: "Show agent status" },
-    help:     { type: "boolean", short: "h", description: "Show this help" },
+    init:      { type: "boolean", description: "Generate secrets, .env, and config" },
+    data:      { type: "string",  description: "Path to framework data directory" },
+    streaming: { type: "boolean", description: "Use streaming agent endpoint" },
+    help:      { type: "boolean", short: "h", description: "Show this help" },
+    version:   { type: "boolean", description: "Show version" },
   },
+  examples: [
+    'echo "Tell me about the company" | npx fit-guide',
+    "npx fit-guide --init",
+  ],
 };
-```
 
-**Note:** Basecamp uses flags as commands (`--daemon`, `--wake <name>`, etc.)
-rather than positional subcommands. The `commands` array in the definition is
-**cosmetic only** — it populates the "Commands:" section of help output so users
-see the familiar flag-based interface. Actual dispatch goes through the
-`options` values (`values.daemon`, `values.wake`, etc.), not positional command
-routing. Do not attempt to match positionals against the commands array for
-basecamp.
-
-Replace `showHelp()` and the command dispatch block with:
-
-```js
 const cli = createCli(definition);
 const parsed = cli.parse(process.argv.slice(2));
 if (!parsed) process.exit(0);
 
 const { values } = parsed;
-if (values.daemon) { daemon(); }
-else if (values.wake) { /* wake logic */ }
-else if (values.init) { /* init logic */ }
-else if (values.update !== undefined) { /* update logic */ }
-else if (values.stop) { /* stop logic */ }
-else if (values.validate) { validate(); }
-else if (values.status) { showStatus(); }
-else { await scheduler.wakeDueAgents(); }
+
+// Handle one-shot CLI commands before entering Repl
+if (values.init) { await runInit(); process.exit(0); }
+if (values.data) dataDir = resolve(values.data);
+if (values.streaming) useStreaming = true;
+
+// Repl is now purely interactive — no CLI flag parsing
+const repl = new Repl({
+  prompt: "> ",
+  usage,
+  storage,
+  state: { resource_id: null },
+  commands: {},
+  setup: setupServices,
+  onLine: handlePrompt,
+});
+await repl.start();
 ```
 
-Replace `console.error` calls with `cli.error()` where the error should carry
-the CLI name prefix. Keep the custom `log()` function for daemon operational
-output — that's internal logging, not CLI error output.
+**What's deleted:**
 
-### 5. Add Logger where missing
+- The `commands` object passed to the Repl (lines 231–261) — `version`,
+  `init`, `data`, `streaming` entries all move to the libcli definition
+- The `showVersion()` function (lines 42–47) — `cli.parse()` handles
+  `--version` directly
+
+**What's kept:**
+
+- `runInit()` function (lines 53–123) — called by the CLI entry point
+- `setupServices()` function (lines 130–166) — called by Repl setup
+- `handlePrompt()` function (lines 176–219) — Repl onLine handler
+- All service wiring and imports
+
+Replace `console.error()` in the catch block (line 269) with `cli.error()`.
+
+### 4. Add Logger where missing
 
 The spec requires every CLI to create a Logger. Check each product CLI:
 
@@ -397,12 +397,7 @@ The spec requires every CLI to create a Logger. Check each product CLI:
   for Finder. Keep as-is — Logger is already wired.
 - **fit-map**: Already creates `createLogger()` for Finder (line 37). Keep.
 - **fit-guide**: Already creates `createLogger("cli")` (line 150). Keep.
-- **fit-basecamp**: Has a custom `createLogger` (line 51) that writes to files.
-  This is intentional for daemon logging. Add a libtelemetry Logger for error
-  output alongside the existing file logger, or leave as-is since basecamp's
-  logging model is deliberately different (file-based).
-
-### 6. Verification
+### 5. Verification
 
 For each product CLI:
 
@@ -419,10 +414,6 @@ bunx fit-map validate             # Normal operation unchanged
 
 bunx fit-guide --help
 bunx fit-guide --help --json
-
-bunx fit-basecamp --help
-bunx fit-basecamp --help --json
-bunx fit-basecamp --status        # Normal operation unchanged
 ```
 
 Run full test suite: `bun run check && bun run test`

--- a/specs/360-cli-library/plan-a-03.md
+++ b/specs/360-cli-library/plan-a-03.md
@@ -78,26 +78,109 @@ For every CLI: add `@forwardimpact/libcli` to the package's `dependencies` in
 ### fit-eval (`libraries/libeval/bin/fit-eval.js`)
 
 **Current:** 101 lines. `HELP_TEXT` const (lines 15–63), manual
-`process.argv.slice(2)` parsing (line 66), `console.error` for errors.
+`process.argv.slice(2)` parsing (line 66), `console.error` for errors. The
+`run` and `supervise` handlers each have a custom `parseFlag()` function that
+scans raw argv for `--key=value` patterns.
 
 **Changes:**
 
-1. Create definition with commands for `output`, `tee`, `run`, `supervise`.
+1. Declare **all** flags from all sub-commands in the top-level definition.
+   Handlers receive parsed `values` instead of raw argv. The custom
+   `parseFlag()` functions in `run.js` and `supervise.js` are deleted.
+
+   ```js
+   const definition = {
+     name: "fit-eval",
+     version: VERSION,
+     description: "Process Claude Code stream-json output",
+     commands: [
+       { name: "output", args: "[--format=FORMAT]", description: "Process trace and output formatted result" },
+       { name: "tee", args: "[output.ndjson]", description: "Stream text to stdout, optionally save raw NDJSON" },
+       { name: "run", args: "[options]", description: "Run a single agent via the Claude Agent SDK" },
+       { name: "supervise", args: "[options]", description: "Run a supervised agent-supervisor relay loop" },
+     ],
+     options: {
+       // Shared
+       format:  { type: "string", description: "Output format (json|text)" },
+       help:    { type: "boolean", short: "h", description: "Show this help" },
+       version: { type: "boolean", description: "Show version" },
+       // run + supervise
+       "task-file":    { type: "string", description: "Path to task file" },
+       "task-text":    { type: "string", description: "Inline task text" },
+       "task-amend":   { type: "string", description: "Additional text appended to task" },
+       model:          { type: "string", description: "Claude model (default: opus)" },
+       "max-turns":    { type: "string", description: "Max agentic turns (default: 50)" },
+       output:         { type: "string", description: "Write NDJSON trace to file" },
+       cwd:            { type: "string", description: "Working directory" },
+       "agent-profile":      { type: "string", description: "Agent profile name" },
+       "allowed-tools":      { type: "string", description: "Comma-separated tool list" },
+       // supervise-only
+       "supervisor-cwd":     { type: "string", description: "Supervisor working directory" },
+       "agent-cwd":          { type: "string", description: "Agent working directory" },
+       "supervisor-profile": { type: "string", description: "Supervisor profile name" },
+       "supervisor-allowed-tools": { type: "string", description: "Supervisor tool list" },
+     },
+     examples: [
+       "fit-eval output --format=text < trace.ndjson",
+       "fit-eval run --task-file=task.md --model=opus",
+       "fit-eval supervise --task-file=task.md --supervisor-cwd=.",
+     ],
+   };
+   ```
 
 2. Replace `HELP_TEXT` and manual arg parsing with `cli.parse()`.
 
-3. The `run` and `supervise` commands accept many flags (`--task-file`,
-   `--model`, etc.) that are parsed inside the command handlers, not at
-   top-level. Keep these as-is — libcli parses the top-level command, each
-   handler parses its own flags internally.
+3. Update handler signatures. Handlers receive `values` (parsed options object)
+   instead of raw `args`:
 
-4. Replace `console.error` with `cli.error()` and `cli.usageError()`.
+   ```js
+   const parsed = cli.parse(process.argv.slice(2));
+   if (!parsed) process.exit(0);
 
-5. Add Logger: `const logger = createLogger("eval");` and use
+   const { values, positionals } = parsed;
+   const [command, ...args] = positionals;
+   const handler = COMMANDS[command];
+
+   if (!handler) {
+     cli.usageError(`unknown command "${command}"`);
+     process.exit(2);
+   }
+
+   await handler(values, args);
+   ```
+
+4. Update `run.js` and `supervise.js`:
+
+   - Delete `parseFlag()` function (duplicated in both files)
+   - Delete `parseRunOptions()` / `parseSuperviseOptions()` functions
+   - Change handler signatures from `(args)` to `(values, args)`
+   - Read flags directly from `values` instead of scanning argv:
+     `values["task-file"]` instead of `parseFlag(args, "task-file")`
+   - Validation logic (`--task-file` and `--task-text` mutually exclusive,
+     one required) stays but reads from `values`
+
+5. Update `output.js`: Change signature to `(values, args)`, read
+   `values.format` instead of scanning args.
+
+6. Update `tee.js`: Change signature to `(values, args)`, read output path
+   from `args[0]` (already a positional).
+
+7. Replace `console.error` with `cli.error()` and `cli.usageError()`.
+
+8. Add Logger: `const logger = createLogger("eval");` and use
    `logger.exception()` in the catch block.
 
-**Delete:** `HELP_TEXT` const (lines 15–63), manual `--help`/`--version`
-handling (lines 68–83).
+**Delete:**
+
+- `HELP_TEXT` const (lines 15–63)
+- Manual `--help`/`--version` handling (lines 68–83)
+- `parseFlag()` in `run.js` (lines 12–19) and `supervise.js` (lines 13–20)
+- `parseRunOptions()` in `run.js` (lines 26–51)
+- `parseSuperviseOptions()` in `supervise.js` (lines 27–64)
+
+**Trade-off:** The `--help` output shows all flags in a flat list, including
+supervise-only flags like `--supervisor-cwd`. This is acceptable — per-command
+help is out of scope per the spec, and the flat list is still grep-friendly.
 
 ### fit-universe (`libraries/libuniverse/bin/fit-universe.js`)
 
@@ -321,8 +404,11 @@ Same pattern.
 **Current:** 90 lines. Repl-based interactive CLI with usage string in Repl
 config.
 
-Same approach as fit-guide: add definition, use `cli.parse()` for initial
-`--help`/`--version`, then enter Repl session unchanged.
+Same approach as fit-guide (part 02): declare all CLI flags in the libcli
+definition, handle them in the CLI entry point before starting the Repl. Move
+any CLI-time concerns out of the Repl's `commands` config. Use `cli.parse()`
+for `--help`/`--version` and any CLI flags, then start the Repl for the
+interactive session.
 
 ## Package.json updates
 
@@ -349,7 +435,9 @@ Every library package that has a CLI needs `@forwardimpact/libcli` added to
 | `libraries/libtool/package.json`      | fit-process-tools                           |
 | `libraries/libtelemetry/package.json` | fit-visualize                               |
 
-All add: `"@forwardimpact/libcli": "workspace:*"` to `dependencies`.
+Basecamp (`products/basecamp/package.json`) is handled in
+[part 05](plan-a-05.md). All packages above add:
+`"@forwardimpact/libcli": "workspace:*"` to `dependencies`.
 
 ## Execution order
 

--- a/specs/360-cli-library/plan-a-05.md
+++ b/specs/360-cli-library/plan-a-05.md
@@ -1,0 +1,234 @@
+# 360 Part 05 — Refactor Basecamp CLI
+
+Refactor fit-basecamp from flag-based commands (`--daemon`, `--wake`, `--init`)
+to positional subcommands (`daemon`, `wake`, `init`). This is a clean break —
+no backwards compatibility with the old flag syntax.
+
+**Depends on:** Part 01 (libcli library must exist).
+
+## Why a separate part
+
+Basecamp is the only CLI that uses flags as pseudo-commands. Every other CLI in
+the monorepo uses positional subcommands for dispatch. The current design:
+
+```
+fit-basecamp --daemon
+fit-basecamp --wake <agent>
+fit-basecamp --init <path>
+```
+
+This is confusing: `--daemon` appears under "Commands:" in help output, but
+it's syntactically an option. Agents and users parsing `--help` output see
+"Commands:" and expect positional arguments. The flag-as-command pattern also
+prevents basecamp from fitting cleanly into libcli's definition model, where
+`commands` are positional and `options` are flags.
+
+The new design:
+
+```
+fit-basecamp daemon
+fit-basecamp wake <agent>
+fit-basecamp init <path>
+```
+
+This aligns basecamp with every other CLI in the suite.
+
+## Files modified
+
+| File                                | Change                                        |
+| ----------------------------------- | --------------------------------------------- |
+| `products/basecamp/package.json`    | Add `@forwardimpact/libcli` dependency        |
+| `products/basecamp/src/basecamp.js` | Rewrite CLI entry: flags → positional commands |
+| `products/basecamp/test/basecamp-cli.test.js` | **New** — CLI dispatch tests         |
+
+## Steps
+
+### 1. Update `products/basecamp/package.json`
+
+Add to `dependencies`:
+
+```json
+"@forwardimpact/libcli": "workspace:*"
+```
+
+### 2. Rewrite `products/basecamp/src/basecamp.js`
+
+**Current state:** 348 lines. Flag-based dispatch at lines 304–347 using a
+`commands` object keyed by `--flag` strings. `showHelp()` function at line 281.
+Custom `createLogger` for file-based daemon logging at line 51.
+
+#### 2a. Create definition
+
+```js
+import { createCli } from "@forwardimpact/libcli";
+
+const definition = {
+  name: "fit-basecamp",
+  version: VERSION,
+  description: "Schedule autonomous agents across knowledge bases",
+  commands: [
+    { name: "daemon", description: "Run continuously (poll every 60s)" },
+    { name: "wake", args: "<agent>", description: "Wake a specific agent immediately" },
+    { name: "init", args: "<path>", description: "Initialize a new knowledge base" },
+    { name: "update", args: "[path]", description: "Update KB with latest CLAUDE.md, agents and skills" },
+    { name: "stop", description: "Gracefully stop daemon and all running agents" },
+    { name: "validate", description: "Validate agent definitions exist" },
+    { name: "status", description: "Show agent status" },
+  ],
+  options: {
+    help: { type: "boolean", short: "h", description: "Show this help" },
+    version: { type: "boolean", description: "Show version" },
+  },
+};
+```
+
+This is a clean command model — commands are positional, options are flags.
+No semantic confusion between "Commands:" and "Options:" in help output.
+
+#### 2b. Replace CLI entry point
+
+**Delete:**
+
+- `showHelp()` function (lines 281–300)
+- `requireArg()` function (lines 308–314)
+- `commands` dispatch object (lines 316–345)
+- The final dispatch line (line 347)
+
+**Replace with:**
+
+```js
+const cli = createCli(definition);
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+const { positionals } = parsed;
+const [command, ...args] = positionals;
+
+mkdirSync(BASECAMP_HOME, { recursive: true });
+
+const COMMANDS = {
+  daemon,
+  wake: async () => {
+    if (!args[0]) {
+      cli.usageError("missing required argument <agent>");
+      process.exit(2);
+    }
+    const config = loadConfig();
+    const state = stateManager.load();
+    const agent = config.agents[args[0]];
+    if (!agent) {
+      cli.error(
+        `agent "${args[0]}" not found. Available: ${Object.keys(config.agents).join(", ") || "(none)"}`,
+      );
+      process.exit(1);
+    }
+    await agentRunner.wake(args[0], agent, state);
+  },
+  init: () => {
+    if (!args[0]) {
+      cli.usageError("missing required argument <path>");
+      process.exit(2);
+    }
+    kbManager.init(args[0], requireTemplateDir());
+  },
+  update: () => runUpdate(args),
+  stop: async () => {
+    const stopped = await requestShutdown(SOCKET_PATH);
+    if (!stopped) process.exit(1);
+  },
+  validate,
+  status: showStatus,
+};
+
+const handler = COMMANDS[command];
+if (command && !handler) {
+  cli.usageError(`unknown command "${command}"`);
+  process.exit(2);
+}
+
+await (handler || (() => scheduler.wakeDueAgents()))();
+```
+
+#### 2c. Update `runUpdate()` to accept positional args
+
+The current `runUpdate(cliArgs)` reads `cliArgs[1]` (because `cliArgs[0]` was
+`--update`). After refactoring, `args` already has the flag stripped — change
+`runUpdate` to read `args[0]` directly:
+
+```js
+function runUpdate(args) {
+  if (args[0]) {
+    kbManager.update(args[0], requireTemplateDir());
+    return;
+  }
+  // ... rest unchanged (iterate configured KBs)
+}
+```
+
+Update the error message in `runUpdate` to use the new syntax:
+
+```js
+console.error(
+  "No knowledge bases configured and no path given.\n" +
+    "Usage: fit-basecamp update [path]",
+);
+```
+
+#### 2d. Replace `console.error` with `cli.error()`
+
+All `console.error` calls in the CLI dispatch paths become `cli.error()` for
+consistent prefixed error output. The custom file-based `log()` function stays
+unchanged — it's daemon operational logging, not CLI error output.
+
+#### 2e. Keep the `#!/usr/bin/env bun` shebang
+
+Basecamp uses bun directly (macOS app bundle, posix-spawn). This is intentional
+and unchanged.
+
+### 3. Write CLI dispatch tests
+
+Create `products/basecamp/test/basecamp-cli.test.js` with tests for the new
+command dispatch. Since basecamp's `main()` has side effects (file I/O, daemon
+loops), test the definition and argument parsing in isolation:
+
+- `cli.parse(["daemon"])` returns `{ positionals: ["daemon"] }`
+- `cli.parse(["wake", "my-agent"])` returns correct positionals
+- `cli.parse(["--help"])` returns null (help handled)
+- `cli.parse(["badcmd"])` returns `{ positionals: ["badcmd"] }` (dispatch
+  handles unknown command error)
+- `cli.parse([])` returns `{ positionals: [] }` (default: wake due agents)
+
+### 4. Verification
+
+```sh
+bun install
+bun run check
+bun run test
+
+# Smoke tests
+bunx fit-basecamp --help           # New positional command format
+bunx fit-basecamp --help --json    # JSON output
+bunx fit-basecamp --version        # Version number
+bunx fit-basecamp status           # Normal operation
+bunx fit-basecamp validate         # Normal operation
+bunx fit-basecamp badcmd           # "fit-basecamp: error: unknown command..."
+bunx fit-basecamp wake             # "fit-basecamp: error: missing required..."
+```
+
+### Command mapping reference
+
+Old → new syntax for all docs and skill updates (part 06):
+
+| Old (flag-based)               | New (positional)             |
+| ------------------------------ | ---------------------------- |
+| `fit-basecamp --daemon`        | `fit-basecamp daemon`        |
+| `fit-basecamp --wake <agent>`  | `fit-basecamp wake <agent>`  |
+| `fit-basecamp --init <path>`   | `fit-basecamp init <path>`   |
+| `fit-basecamp --update [path]` | `fit-basecamp update [path]` |
+| `fit-basecamp --stop`          | `fit-basecamp stop`          |
+| `fit-basecamp --validate`      | `fit-basecamp validate`      |
+| `fit-basecamp --status`        | `fit-basecamp status`        |
+| `fit-basecamp --help`          | `fit-basecamp --help`        |
+| `fit-basecamp`                 | `fit-basecamp`               |
+
+`--help` and the bare invocation (wake due agents) are unchanged.

--- a/specs/360-cli-library/plan-a-06.md
+++ b/specs/360-cli-library/plan-a-06.md
@@ -1,0 +1,145 @@
+# 360 Part 06 — Update documentation referencing CLI output
+
+Review and update all documentation files that show CLI command examples, sample
+output, or reference CLI syntax. After parts 02–05, help text, error formats,
+and basecamp's command syntax have all changed — docs must match reality.
+
+**Depends on:** Parts 02–05 (CLI migrations and basecamp refactor must be
+complete so the implementer can verify against actual output).
+
+## Scope
+
+Three categories of changes:
+
+1. **Basecamp syntax** — Every reference to `--daemon`, `--wake`, `--init`,
+   `--update`, `--stop`, `--validate`, `--status` as commands converts to
+   positional subcommands (`daemon`, `wake`, `init`, etc.). See the mapping
+   table in [plan-a-05.md § Command mapping reference](plan-a-05.md).
+
+2. **CLI help samples** — Any documentation showing help text output should
+   reflect the new libcli format (one-line-per-command, `name version —
+   description` header, aligned columns).
+
+3. **Error format samples** — Any documentation showing error messages should
+   use the new `cli-name: error: message` format.
+
+## Files to update
+
+### Tier 1: External-facing (users see these)
+
+| File | Changes needed |
+| ---- | -------------- |
+| `website/docs/reference/cli/index.md` | **Primary CLI reference.** Update basecamp section (lines 200–206) from flag syntax to positional. Verify all CLI command examples match new help output format. Update any option tables if flag names changed. |
+| `website/docs/getting-started/engineers/index.md` | Update basecamp commands (lines 200, 206, 212): `--init` → `init`, `--status` → `status`, `--daemon` → `daemon`. |
+| `website/docs/getting-started/leadership/index.md` | Check for any basecamp or CLI output samples. Update if present. |
+| `website/docs/guides/knowledge-systems/index.md` | Heavy basecamp usage (lines 17–18, 28, 115, 126–130). Convert all `--daemon`, `--init`, `--status` flags to positional subcommands. **Pre-existing error:** lines 18 and 129 reference `--task` which does not exist in the current CLI (should be `wake`). Fix to `fit-basecamp wake <id>`. |
+| `website/basecamp/index.md` | Quick start section (lines 85–86): `--init` → `init`, `--daemon` → `daemon`. |
+| `website/index.md` | Landing page (lines 190–191): `--init` → `init`, `--daemon` → `daemon`. |
+| `website/pathway/index.md` | Check command examples match new help format. |
+| `website/map/index.md` | Check command examples match new help format. |
+
+### Tier 2: Skill files (agents read these)
+
+| File | Changes needed |
+| ---- | -------------- |
+| `.claude/skills/fit-basecamp/SKILL.md` | Lines 74–78, 84–85, 117, 145, 150–151: all basecamp commands from flag to positional syntax. Update the architecture diagram line showing `fit-basecamp --daemon`. |
+| `.claude/skills/fit-guide/SKILL.md` | Check for any basecamp references in service setup examples. |
+| `.claude/skills/fit-map/SKILL.md` | Check CLI examples match new format. |
+| `.claude/skills/fit-pathway/SKILL.md` | Check CLI examples match new format. |
+| `.claude/skills/fit-universe/SKILL.md` | Check CLI examples match new format. |
+
+### Tier 3: Internal docs (contributors read these)
+
+| File | Changes needed |
+| ---- | -------------- |
+| `website/docs/internals/operations/index.md` | Lines 124–125: `--init` → `init`, `--daemon` → `daemon`. |
+| `website/docs/internals/basecamp/index.md` | Line 73: `fit-basecamp --daemon` → `fit-basecamp daemon` in architecture diagram. |
+| `website/docs/internals/pathway/index.md` | Check formatter documentation is consistent with libcli migration (formatters moved to libcli). |
+| `website/docs/internals/universe/index.md` | Check fit-universe command examples. |
+| `website/docs/internals/codegen/index.md` | Check fit-codegen command examples. |
+| `CLAUDE.md` | Updated in part 04 (structure + skill groups). Verify no stale CLI output samples remain. |
+
+### Tier 4: Specs (historical — update only if referenced as current)
+
+| File | Changes needed |
+| ---- | -------------- |
+| `specs/020-scheduling-agents/plan-a.md` | 5 references to old flag syntax. Historical spec. |
+| `specs/030-guide-infra/spec.v2.md` | Line 577: `--init` → `init`. Historical spec — update only if it's referenced as a current guide. |
+| `specs/170-docs-ia/plan-a.md` | Line 263: `--init` → `init`. Same consideration. |
+
+**Note:** Specs in tier 4 are historical documents. If they describe what was
+true at the time they were written, leave them as-is. Only update if they're
+referenced as current documentation (e.g., linked from an active guide).
+
+## Steps
+
+### 1. Basecamp syntax — mechanical find-and-replace
+
+For every file in tiers 1–3, apply the command mapping:
+
+| Search | Replace |
+| ------ | ------- |
+| `fit-basecamp --daemon` | `fit-basecamp daemon` |
+| `fit-basecamp --wake` | `fit-basecamp wake` |
+| `fit-basecamp --init` | `fit-basecamp init` |
+| `fit-basecamp --update` | `fit-basecamp update` |
+| `fit-basecamp --stop` | `fit-basecamp stop` |
+| `fit-basecamp --validate` | `fit-basecamp validate` |
+| `fit-basecamp --status` | `fit-basecamp status` |
+
+`--help` stays as `--help` (it's still a flag, not a command).
+
+Also update any surrounding descriptions that say "pass the `--daemon` flag" or
+similar — rewrite to "use the `daemon` command".
+
+### 2. CLI help output samples
+
+Run each migrated CLI with `--help` and compare the actual output against any
+documentation that shows help text. Key files to check:
+
+- `website/docs/reference/cli/index.md` — the primary CLI reference. Verify
+  every command listing matches the actual `--help` output.
+- Product overview pages (`website/pathway/index.md`, `website/map/index.md`,
+  `website/basecamp/index.md`) — verify quick-start examples.
+
+If a docs page shows a full help text block, replace it with the actual output
+from the migrated CLI. If it shows individual command examples, verify they
+match the new format.
+
+### 3. Error format samples
+
+Search for any documentation showing error message examples. Update to the new
+`cli-name: error: message` format. The spec's own examples (in `spec.md`) are
+the canonical reference — they should already be correct.
+
+### 4. Verify no stale references remain
+
+Run a final sweep:
+
+```sh
+# Should return zero results in non-spec docs after step 1
+grep -r 'fit-basecamp --daemon\|fit-basecamp --wake\|fit-basecamp --init' \
+  website/ .claude/skills/ --include='*.md' | grep -v specs/360
+
+# Check for any remaining raw console.error patterns in docs
+grep -r 'console\.error' website/ --include='*.md'
+```
+
+## Verification
+
+```sh
+bun run check  # format and lint pass
+
+# Build docs to verify no broken links
+bunx fit-doc build
+```
+
+Manually spot-check:
+
+- `website/docs/reference/cli/index.md` — basecamp section uses positional
+  subcommands
+- `website/docs/getting-started/engineers/index.md` — basecamp quick start uses
+  positional syntax
+- `.claude/skills/fit-basecamp/SKILL.md` — all commands use positional syntax
+- `website/docs/internals/operations/index.md` — internal commands use
+  positional syntax

--- a/specs/360-cli-library/plan-a.md
+++ b/specs/360-cli-library/plan-a.md
@@ -72,10 +72,25 @@ class Cli {
 }
 ```
 
-`parse()` wraps `node:util parseArgs` using the definition's options, handles
-`--help` (with `--json` support) and `--version` internally, and returns parsed
-results or `null` when it handled the request itself. This eliminates the
-per-CLI boilerplate of checking for help/version flags.
+`parse()` wraps `node:util parseArgs` (always `strict: true`) using the
+definition's options, handles `--help` (with `--json` support) and `--version`
+internally, and returns parsed results or `null` when it handled the request
+itself. This eliminates the per-CLI boilerplate of checking for help/version
+flags.
+
+**Every CLI declares every flag it accepts.** There is no `strict: false` mode,
+no `prescreen()`, no pass-through of unknown flags. CLIs that previously
+delegated flag parsing to sub-command handlers (fit-eval) or to a Repl
+(fit-guide, fit-visualize) are restructured:
+
+- **fit-eval**: All sub-command flags (`--task-file`, `--model`,
+  `--max-turns`, etc.) move into the top-level definition. Handlers receive
+  parsed `values` instead of raw argv. The custom `parseFlag()` function is
+  deleted. Unused flags for a given sub-command are harmlessly `undefined`.
+- **fit-guide, fit-visualize**: CLI flags (`--init`, `--data`, `--streaming`)
+  move out of the Repl's `commands` config and into the libcli definition. The
+  CLI entry point handles them before starting the Repl. The Repl becomes
+  purely interactive — no CLI flag parsing.
 
 Typical entry point pattern after migration:
 
@@ -126,13 +141,14 @@ describing all commands, options, and descriptions.
 class SummaryRenderer {
   constructor({ process })
 
-  render({ title, items })  // "title\n  label  — description\n..."
+  render({ title, items }, stream)  // "title\n  label  — description\n..."
 }
 ```
 
 Accepts a title string and an array of `{ label, description }` items. Pads
-labels for column alignment. This standardizes the pattern already used by
-fit-codegen's `printSummary()`.
+labels for column alignment. `stream` defaults to `this.#proc.stdout` when
+omitted. This standardizes the pattern already used by fit-codegen's
+`printSummary()`.
 
 #### Color and formatting (migrated from pathway)
 
@@ -177,14 +193,18 @@ directly." libcli and libtelemetry are peers — both used by CLI entry points.
 
 ## Parts
 
-| Part               | Scope                                                | Depends on | Files              |
-| ------------------ | ---------------------------------------------------- | ---------- | ------------------ |
-| [01](plan-a-01.md) | Create libcli library                                | —          | ~12 new            |
-| [02](plan-a-02.md) | Migrate product CLIs (pathway, map, guide, basecamp) | 01         | ~8 modified        |
-| [03](plan-a-03.md) | Migrate library CLIs (22 CLIs across 17 packages)    | 01         | ~22 modified       |
-| [04](plan-a-04.md) | Documentation (internals page, index update)         | 01         | ~2 new, 2 modified |
+| Part               | Scope                                                | Depends on | Files               |
+| ------------------ | ---------------------------------------------------- | ---------- | ------------------- |
+| [01](plan-a-01.md) | Create libcli library                                | —          | ~12 new             |
+| [02](plan-a-02.md) | Migrate product CLIs (pathway, map, guide)           | 01         | ~7 modified         |
+| [03](plan-a-03.md) | Migrate library CLIs (22 CLIs across 17 packages)    | 01         | ~22 modified        |
+| [04](plan-a-04.md) | Documentation (internals page, index update)         | 01         | ~2 new, 2 modified  |
+| [05](plan-a-05.md) | Refactor Basecamp CLI to positional subcommands      | 01         | ~3 modified, 1 new  |
+| [06](plan-a-06.md) | Update documentation referencing CLI output          | 02–05      | ~12 modified        |
 
-Parts 02, 03, and 04 all depend on part 01 but are independent of each other.
+Parts 02, 03, 04, and 05 all depend on part 01 but are independent of each
+other. Part 06 depends on parts 02–05 (it updates documentation to match the
+new CLI output formats, including basecamp's new positional subcommands).
 
 ## Cross-cutting concerns
 
@@ -197,6 +217,7 @@ test scenarios:
 - `Cli.parse()` returns null and writes help when `--help` is passed
 - `Cli.parse()` returns null and writes JSON help when `--help --json` is passed
 - `Cli.parse()` returns null and writes version when `--version` is passed
+- `Cli.parse()` throws on unknown flags (strict parseArgs, always)
 - `Cli.error()` writes prefixed message to stderr and sets exitCode = 1
 - `Cli.usageError()` sets exitCode = 2
 - `HelpRenderer.render()` produces one-line-per-command output
@@ -244,5 +265,19 @@ After each part, run:
    Don't over-engineer these.
 
 4. **Repl-based CLIs** — fit-guide and fit-visualize use librepl for interactive
-   sessions. libcli handles only the initial argument parsing and help; the Repl
-   session is unchanged. The spec explicitly scopes this out.
+   sessions. CLI flags (`--init`, `--data`, `--streaming`) move from the Repl's
+   `commands` config to the libcli definition and are handled by the CLI entry
+   point before starting the Repl. The Repl becomes purely interactive. The
+   Repl's `commands` object loses its CLI flag entries but retains any truly
+   interactive commands.
+
+5. **Basecamp flag-to-subcommand refactor** — Part 05 converts basecamp from
+   flag-based commands (`--daemon`, `--wake`, `--init`) to positional
+   subcommands (`daemon`, `wake`, `init`). This is a breaking change with no
+   backwards compatibility. All documentation and skill files referencing the
+   old flag syntax must be updated in part 06.
+
+6. **Documentation drift** — Part 06 updates all docs that show CLI output
+   samples or reference CLI syntax. If any file is missed, external users see
+   stale examples. The file list in part 06 was compiled by searching the full
+   repo; the implementer should re-verify with a grep before committing.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -52,4 +52,3 @@
 340	done
 350	done
 360	planned
-370	draft


### PR DESCRIPTION
## Summary

- Reviewed and revised the plan for spec 360 (CLI Library) across all 6 parts
- Added Part 05: Refactor Basecamp CLI from flag-based commands (`--daemon`, `--wake`) to positional subcommands (`daemon`, `wake`) — clean break, no backwards compatibility
- Added Part 06: Update all documentation (20+ files) referencing CLI output to match new formats
- Replaced broken `strict: false` approach with holistic redesign: single `parse()` method, every CLI declares every flag upfront
- fit-eval: sub-command flags move to top-level definition, custom `parseFlag()` deleted
- fit-guide/fit-visualize: CLI flags move out of Repl `commands` config, Repl becomes purely interactive
- Fixed package.json template, devDependencies version specifier, pathway importer list, map VERSION constant, and missing doc references

## Test plan

- [ ] Verify plan files render correctly and cross-references between parts are valid
- [ ] Confirm spec coverage: all 9 success criteria from spec.md are addressed
- [ ] Review fit-eval definition covers all flags from `run.js` and `supervise.js`
- [ ] Review fit-guide migration correctly separates CLI flags from Repl commands
- [ ] Verify part 06 file list covers all basecamp flag references (`grep -r 'fit-basecamp --' website/ .claude/skills/`)

https://claude.ai/code/session_01Ui5fALQMk6dRofhLBSpGSV