### PR TITLE
update(gemba-implement): reference plan execution recommendations

### DIFF
--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -61,12 +61,17 @@ Read the selected plan thoroughly. Understand:
 - **Ordering and dependencies.** Which changes must happen first? What blocks
   what?
 - **Design decisions.** Why were non-obvious choices made?
+- **Execution recommendation.** How does the plan recommend executing — single
+  agent, or parallel `staff-engineer` agents for independent parts?
 
 **Multi-part plans.** If the plan is decomposed into parts (`plan-a.md` +
 `plan-a-01.md`, `plan-a-02.md`, etc.), start by reading the overview in
-`plan-a.md` for strategy and the part index. Then work through parts in numbered
-order. Each part is independently executable — complete and verify each part
-before moving to the next.
+`plan-a.md` for strategy, the part index, and the execution recommendation. Then
+work through parts in numbered order. Each part is independently executable —
+complete and verify each part before moving to the next. When the plan
+recommends parallel execution for independent parts, the caller is responsible
+for launching concurrent `staff-engineer` agents — a single agent implements one
+part at a time.
 
 ### 3. Research the current codebase
 

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -75,10 +75,10 @@ plan-a-03.md    ← part 3 (independently executable)
 - A single-part plan does not need decomposition — only decompose when there is
   a concrete benefit (size, independence, parallelism).
 - The overview (`plan-a.md`) must include an **Execution** section that
-  translates the dependency graph into a concrete execution recommendation.
-  When parts are independent after a shared prerequisite, recommend launching
-  them as concurrent `staff-engineer` sub-agents once the prerequisite merges.
-  When parts are strictly sequential, say so.
+  translates the dependency graph into a concrete execution recommendation. When
+  parts are independent after a shared prerequisite, recommend launching them as
+  concurrent `staff-engineer` sub-agents once the prerequisite merges. When
+  parts are strictly sequential, say so.
 
 Alternative plans can also be decomposed (`plan-b.md`, `plan-b-01.md`, etc.).
 
@@ -103,10 +103,10 @@ on these qualities:
 - **Risks surfaced.** Flag steps that require judgement, ambiguous decisions, or
   unknowns. The implementer should never be surprised by a step.
 - **Execution recommendation.** Close with a concrete recommendation on how to
-  execute the plan. Recommend the `staff-engineer` sub-agent for
-  implementation. For decomposed plans, state which parts can run as parallel
-  `staff-engineer` agents and which must run sequentially — translate the
-  dependency structure into an actionable execution strategy.
+  execute the plan. Recommend the `staff-engineer` sub-agent for implementation.
+  For decomposed plans, state which parts can run as parallel `staff-engineer`
+  agents and which must run sequentially — translate the dependency structure
+  into an actionable execution strategy.
 
 ## Reviewing a Plan
 

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -74,6 +74,11 @@ plan-a-03.md    ← part 3 (independently executable)
   explicitly (e.g., "part 02 depends on part 01 for the new type definitions").
 - A single-part plan does not need decomposition — only decompose when there is
   a concrete benefit (size, independence, parallelism).
+- The overview (`plan-a.md`) must include an **Execution** section that
+  translates the dependency graph into a concrete execution recommendation.
+  When parts are independent after a shared prerequisite, recommend launching
+  them as concurrent `staff-engineer` sub-agents once the prerequisite merges.
+  When parts are strictly sequential, say so.
 
 Alternative plans can also be decomposed (`plan-b.md`, `plan-b-01.md`, etc.).
 
@@ -97,12 +102,18 @@ on these qualities:
   This prevents future re-debate.
 - **Risks surfaced.** Flag steps that require judgement, ambiguous decisions, or
   unknowns. The implementer should never be surprised by a step.
+- **Execution recommendation.** Close with a concrete recommendation on how to
+  execute the plan. Recommend the `staff-engineer` sub-agent for
+  implementation. For decomposed plans, state which parts can run as parallel
+  `staff-engineer` agents and which must run sequentially — translate the
+  dependency structure into an actionable execution strategy.
 
 ## Reviewing a Plan
 
 Evaluate the plan against the qualities listed in "Writing a Plan" above:
 approach is stated, changes are concrete, blast radius is visible, ordering is
-explicit, decisions are explained, and risks are surfaced.
+explicit, decisions are explained, risks are surfaced, and an execution
+recommendation is present.
 
 If all criteria are met **and** the spec is also approved, advance the spec to
 `planned` in `specs/STATUS`. If any criterion falls short, request changes and


### PR DESCRIPTION
## Summary

- Adds "Execution recommendation" to the plan study checklist in step 2 so the implementer notes how the plan recommends executing
- Updates the multi-part plans paragraph to mention reading the execution recommendation and clarifies that parallel execution of independent parts is the caller's responsibility — a single agent implements one part at a time

Companion to #298 which added execution recommendations to the gemba-plan skill.

## Test plan

- [x] `bun run check` passes (format + lint)
- [x] Skill-only change — no code impact

https://claude.ai/code/session_01KPK6h3qAUeNjCayzL254WZ