### PR TITLE
feat(gemba): add technical-writer agent

### DIFF
--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -1,0 +1,59 @@
+---
+name: technical-writer
+description: >
+  Repository technical writer. Reviews documentation for accuracy and
+  staleness, curates agent memory for cross-team collaboration, and ensures
+  the wiki remains a reliable coordination mechanism.
+model: opus
+skills:
+  - gemba-documentation
+  - gemba-wiki-curate
+  - gemba-spec
+---
+
+You are the technical writer. You keep documentation accurate, audience-pure,
+and current — and you keep the wiki reliable so agents can collaborate
+effectively.
+
+Each documentation review cycle focuses on **one topic**. Depth over breadth.
+
+## Voice
+
+Meticulous, constructive. Care about the reader's experience. Sign off:
+
+`— Technical Writer 📝`
+
+## Workflows
+
+Determine which workflow to use from the task prompt:
+
+1. **Documentation review** — Follow the `gemba-documentation` skill. Pick one
+   topic area, review it in depth, and act on findings:
+   - **Trivial fix** (typo, stale example, broken link) → batch into one
+     `fix/doc-review-YYYY-MM-DD` PR from `main`
+   - **Structural finding** (requires design) → write spec using `gemba-spec`
+     skill on its own `spec/docs-<name>` branch from `main`
+   - Every PR on an independent branch from `main` — never combine fixes and
+     specs, never branch from another review branch
+
+2. **Wiki curation** — Follow the `gemba-wiki-curate` skill. Verify agent
+   summaries, follow up on stale observations, update MEMORY.md, and clean
+   weekly logs.
+
+## Constraints
+
+- Incremental fixes only — structural changes get a spec
+- Never weaken documentation accuracy or audience separation
+- Never remove documentation without confirming the content is truly obsolete
+- Verify against source code before claiming a doc is wrong
+- Run `bunx fit-doc build --src=website --out=dist` before committing doc
+  changes
+- Run `bun run check` and `bun run test` before committing
+- **Memory**: Before starting work, read `wiki/technical-writer.md` and the
+  other agent summaries for cross-agent context. Append this run as a new
+  `## YYYY-MM-DD` section at the end of the current week's log
+  `wiki/technical-writer-$(date +%G-W%V).md` — create the file if missing with a
+  `# Technical Writer — YYYY-Www` heading; one file per ISO week. Use `###`
+  subheadings for the fields skills specify to record. At the end, update
+  `wiki/technical-writer.md` with actions taken, observations for teammates, and
+  open blockers.

--- a/.claude/skills/gemba-documentation/SKILL.md
+++ b/.claude/skills/gemba-documentation/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: gemba-documentation
+description: >
+  Write and review documentation in the website/ folder. Scheduled runs review
+  one topic in depth for accuracy, audience purity, and staleness. Interactive
+  runs write or update pages following documentation standards. Use when
+  writing, editing, auditing, or reviewing documentation, or running scheduled
+  documentation review.
+---
+
+# Documentation
+
+Write effective documentation and systematically review it for accuracy. Two
+modes of operation:
+
+- **Scheduled review** — Pick one topic, go deep, verify against source code.
+- **Interactive writing** — Write or update pages following the standards.
+
+Standards and conventions live in
+[`references/standards.md`](references/standards.md). Source-of-truth mappings
+live in [`references/source-of-truth.md`](references/source-of-truth.md). Read
+them before writing or reviewing.
+
+## 1. Scheduled Review
+
+Each run covers **one topic** in depth.
+
+### Topic areas
+
+| Topic                    | What to review                                                        |
+| ------------------------ | --------------------------------------------------------------------- |
+| `getting-started`        | `website/docs/getting-started/` — onboarding accuracy, CLI examples   |
+| `guides`                 | `website/docs/guides/` — task accuracy, audience purity, completeness |
+| `reference`              | `website/docs/reference/` — CLI synopsis, entity definitions, schema  |
+| `internals`              | `website/docs/internals/` — architecture accuracy, code path validity |
+| `product-pages`          | `website/{map,pathway,guide,basecamp,landmark,summit}/` — overviews   |
+| `root-docs`              | `CLAUDE.md`, `CONTRIBUTING.md`, `GEMBA.md`, `SECURITY.md`             |
+| `llms-txt-and-seo`       | `website/llms.txt`, `website/robots.txt`, sitemap completeness        |
+| `cross-page-consistency` | Terminology, proficiency scales, field names across all pages         |
+
+### Topic selection
+
+1. Read memory per the agent profile (your summary, the current week's log, and
+   teammates' summaries). Find last review dates per topic in the coverage map.
+2. Build coverage map — never-reviewed topics go first, then oldest.
+3. Revisit threshold — if all topics covered within last 6 runs, revisit oldest.
+4. Announce your pick and why before starting.
+5. Go deep — read every page in the topic area, not just spot-check.
+
+### Review process
+
+1. Read every page in the topic area.
+2. For each page, identify the source of truth (per
+   [`references/source-of-truth.md`](references/source-of-truth.md)).
+3. Read the actual source code/data and compare to documentation claims.
+4. Check audience purity — flag contributor content in user-facing pages (per
+   [`references/standards.md`](references/standards.md)).
+5. Run CLI examples shown in docs, verify output matches.
+6. Check YAML examples against JSON schemas in `products/map/schema/json/`.
+7. Verify all internal cross-links resolve.
+8. Run `bunx fit-doc build --src=website --out=dist` to confirm build.
+9. Check `git log --oneline -20 -- <paths>` for recent code changes that may
+   have invalidated docs.
+
+### Review checklist
+
+<do_confirm_checklist goal="Confirm documentation review is complete">
+
+- [ ] Every CLI example on the page was executed and output verified.
+- [ ] Every YAML example was checked against JSON schema.
+- [ ] Audience purity confirmed (no audience mixing).
+- [ ] Source of truth consulted and docs match current code.
+- [ ] All cross-links resolve.
+- [ ] `bunx fit-doc build` succeeds.
+- [ ] Terminology matches conventions in `references/standards.md`.
+
+</do_confirm_checklist>
+
+## 2. Interactive Writing
+
+### Writing a new page
+
+1. **Identify the audience.** Determine which user group the page serves — this
+   decides the section. See
+   [`references/standards.md`](references/standards.md).
+2. **Choose the section.** New to the product → Getting Started. Task to
+   accomplish → Guides. Looking something up → Reference. Understanding the code
+   → Internals.
+3. **Research the source of truth.** Read the actual code and data before
+   writing. Cross-reference
+   [`references/source-of-truth.md`](references/source-of-truth.md).
+4. **Write for the audience.** Strip content that belongs to a different
+   audience.
+5. **Verify accuracy.** Run CLI commands, check YAML against schemas, confirm
+   entity names against `data/pathway/`.
+6. **Add cross-links.** Guides → Reference for details. Getting Started → Guides
+   for next steps. Internals → Reference for the user-facing model.
+7. **Build and check.** Run `bunx fit-doc build --src=website --out=dist`.
+
+### Updating existing pages
+
+1. Read the page and its source of truth — check actual code, not just docs.
+2. Check audience purity — move contributor content to Internals if needed.
+3. Verify CLI examples. Run every command shown.
+4. Verify YAML examples against `products/map/schema/json/`.
+5. Check cross-links resolve.
+6. Build and check.
+
+## 3. Output
+
+Every review must produce both categories when applicable — incremental fixes on
+a `fix/` branch and specs for structural findings on `spec/` branches. Branch
+naming, commit conventions, and independence rules are defined in the agent
+profile.
+
+**Commit format:** `docs(website): {verb} {topic} documentation`
+
+Verbs: `add` for new pages, `update` for changes, `fix` for corrections.
+
+### Memory: what to record
+
+Append to the current week's log (see agent profile for the file path):
+
+- **Topic reviewed** — Which topic and why selected
+- **Coverage map** — Updated table of all topics with last review date
+- **Findings summary** — What found, severity, disposition
+  (fixed/spec'd/deferred)
+- **Deferred work** — Issues needing follow-up with enough context to resume
+- **Accuracy errors** — Specific docs that diverged from source code
+- **Observations for teammates** — Callouts for agents whose work affects docs

--- a/.claude/skills/gemba-documentation/references/source-of-truth.md
+++ b/.claude/skills/gemba-documentation/references/source-of-truth.md
@@ -1,0 +1,27 @@
+# Source of Truth
+
+When writing or reviewing documentation, verify claims against the canonical
+source. Never trust documentation alone — read the code.
+
+| Documentation topic   | Verify against                              |
+| --------------------- | ------------------------------------------- |
+| Skills and levels     | `data/pathway/capabilities/`                |
+| Behaviours            | `data/pathway/behaviours/`                  |
+| Disciplines           | `data/pathway/disciplines/`                 |
+| Tracks                | `data/pathway/tracks/`                      |
+| Levels                | `data/pathway/levels.yaml`                  |
+| Stages                | `data/pathway/stages.yaml`                  |
+| Drivers               | `data/pathway/drivers.yaml`                 |
+| Job derivation        | `libraries/libskill/src/job.js`             |
+| Agent derivation      | `libraries/libskill/src/agent.js`           |
+| Map validation        | `products/map/src/`                         |
+| Pathway CLI           | `products/pathway/bin/fit-pathway.js`       |
+| Basecamp CLI          | `products/basecamp/bin/fit-basecamp.js`     |
+| Landmark CLI          | `products/landmark/bin/fit-landmark.js`     |
+| Summit CLI            | `products/summit/bin/fit-summit.js`         |
+| Universe CLI          | `libraries/libuniverse/bin/fit-universe.js` |
+| Templates             | `products/pathway/templates/`               |
+| JSON Schema           | `products/map/schema/json/`                 |
+| RDF/SHACL Schema      | `products/map/schema/rdf/`                  |
+| LLM / SEO outputs     | `website/llms.txt`, `website/robots.txt`    |
+| Repo self-maintenance | `GEMBA.md`                                  |

--- a/.claude/skills/gemba-documentation/references/standards.md
+++ b/.claude/skills/gemba-documentation/references/standards.md
@@ -1,24 +1,4 @@
----
-name: write-docs
-description: >
-  Review and update documentation in the website/ folder. Use when writing,
-  editing, auditing, or reviewing documentation for accuracy, coherence,
-  or consistency.
----
-
-# Write Documentation
-
-Write effective, user-centric documentation for the `website/docs/` hierarchy.
-Documentation is organized by audience and task, not by product.
-
-## When to Use
-
-- Writing new documentation pages
-- Updating existing documentation after code changes
-- Auditing documentation for accuracy, gaps, or audience drift
-- Adding documentation for features that lack it
-- Reviewing documentation for cross-page coherence and consistency
-- Fixing terminology, formatting, or field name inaccuracies
+# Documentation Standards
 
 ## Information Architecture
 
@@ -58,8 +38,7 @@ website/docs/
 
 ## Audience Rules
 
-Every sentence belongs to exactly one audience. When writing or reviewing, apply
-these rules strictly:
+Every sentence belongs to exactly one audience. Apply these rules strictly:
 
 | Content type                                                  | Audience              | Section                 |
 | ------------------------------------------------------------- | --------------------- | ----------------------- |
@@ -119,7 +98,7 @@ these skills **must** use absolute URLs with the full domain:
 - [Guide](/docs/guides/authoring-frameworks/index.md)
 ```
 
-Internal skills (library groups, `write-docs`, etc.) may use repo-relative paths
+Internal skills (library groups, `gemba-*`, etc.) may use repo-relative paths
 since they only run inside the monorepo.
 
 ### Guides and Reference produce stable, agent-fetchable URLs
@@ -171,57 +150,6 @@ the single source of truth — do not guess from examples or convention.
 - Behaviour maturities: always lowercase with underscores (`role_modeling`)
 - Entity field names: always in backticks (`\`baseSkillProficiencies\``)
 
-## Process
-
-### Writing a new page
-
-1. **Identify the audience.** Determine which user group the page serves. This
-   decides which section it belongs to.
-2. **Choose the section.** Place the page in the correct tier:
-   - New to the product? → Getting Started
-   - Task to accomplish? → Guides
-   - Looking something up? → Reference
-   - Understanding the code? → Internals
-3. **Research the source of truth.** Read the actual code and data before
-   writing. Cross-reference the table below.
-4. **Write for the audience.** Strip out anything that belongs to a different
-   audience. A leadership user reading Authoring Frameworks should never see a
-   class name. A contributor reading Internals should never wade through
-   tutorials.
-5. **Verify accuracy.** Run CLI commands, check YAML against schemas, confirm
-   entity names against `data/pathway/`.
-6. **Add cross-links.** Link to related pages within the hierarchy. Guides link
-   to Reference for lookup details. Getting Started links to Guides for next
-   steps. Internals link to Reference for the user-facing model.
-7. **Build and check.** Run `bunx fit-doc build --src=website --out=dist` to
-   confirm the page renders and all links resolve.
-
-### Updating existing pages
-
-1. **Read the page and its source of truth.** Check the actual code and data
-   files — not just the documentation.
-2. **Check audience purity.** If contributor content has crept into a Guide or
-   Reference page, move it to the appropriate Internals page.
-3. **Verify CLI examples.** Run every CLI command shown. Use
-   `--data=data/pathway` for canonical output.
-4. **Verify YAML examples.** Check against schemas in
-   `products/map/schema/json/`.
-5. **Check cross-links.** Ensure all internal links resolve to pages that exist.
-6. **Build and check.** Run `bunx fit-doc build --src=website --out=dist`.
-
-### Auditing documentation
-
-1. **Check coverage.** Every product should have:
-   - At least one Guide (task-oriented user documentation)
-   - CLI entries in the Reference CLI page
-   - An Internals page (architecture for contributors)
-2. **Check accuracy.** For each page, examine the actual code it describes.
-   Cross-reference the source-of-truth table below.
-3. **Check freshness.** Review `git log --oneline -20` for recent changes that
-   may have invalidated documentation.
-4. **Check `llms.txt`.** Verify the Documentation section in `website/llms.txt`
-   reflects the current page inventory.
-
 ## Repository Documentation
 
 The documentation lives in two layers: repository-root files and the website.
@@ -236,7 +164,7 @@ The documentation lives in two layers: repository-root files and the website.
 
 **Website documentation** (`website/docs/`):
 
-The four-tier hierarchy described below. Contributor-facing reference material
+The four-tier hierarchy described above. Contributor-facing reference material
 (environment, services, tasks) lives at `docs/internals/operations/` — extracted
 from CONTRIBUTING.md to keep the workflow focused.
 
@@ -249,45 +177,9 @@ from CONTRIBUTING.md to keep the workflow focused.
 - `website/docs/internals/operations/` holds operational reference (environment,
   config, services, tasks) that supports CONTRIBUTING.md without cluttering it.
 
-## Source of Truth
-
-| Documentation topic   | Verify against                              |
-| --------------------- | ------------------------------------------- |
-| Skills and levels     | `data/pathway/capabilities/`                |
-| Behaviours            | `data/pathway/behaviours/`                  |
-| Disciplines           | `data/pathway/disciplines/`                 |
-| Tracks                | `data/pathway/tracks/`                      |
-| Levels                | `data/pathway/levels.yaml`                  |
-| Stages                | `data/pathway/stages.yaml`                  |
-| Drivers               | `data/pathway/drivers.yaml`                 |
-| Job derivation        | `libraries/libskill/src/job.js`             |
-| Agent derivation      | `libraries/libskill/src/agent.js`           |
-| Map validation        | `products/map/src/`                         |
-| Pathway CLI           | `products/pathway/bin/fit-pathway.js`       |
-| Basecamp CLI          | `products/basecamp/bin/fit-basecamp.js`     |
-| Landmark CLI          | `products/landmark/bin/fit-landmark.js`     |
-| Summit CLI            | `products/summit/bin/fit-summit.js`         |
-| Universe CLI          | `libraries/libuniverse/bin/fit-universe.js` |
-| Templates             | `products/pathway/templates/`               |
-| JSON Schema           | `products/map/schema/json/`                 |
-| RDF/SHACL Schema      | `products/map/schema/rdf/`                  |
-| LLM / SEO outputs     | `website/llms.txt`, `website/robots.txt`    |
-| Repo self-maintenance | `GEMBA.md`                                  |
-
 ## Layouts
 
 | Layout    | Use for                                                                             |
 | --------- | ----------------------------------------------------------------------------------- |
 | `product` | Section index pages (Getting Started, Guides, Reference, Internals) — grid of cards |
 | _(none)_  | Leaf pages — prose with table of contents                                           |
-
-## Commit
-
-After making updates, commit with:
-
-```
-docs(website): {verb} {topic} documentation
-```
-
-Use separate commits for distinct documentation areas. Verbs: `add` for new
-pages, `update` for changes to existing pages, `fix` for corrections.

--- a/.claude/skills/gemba-walk/references/invariants.md
+++ b/.claude/skills/gemba-walk/references/invariants.md
@@ -59,3 +59,18 @@ acceptance.
 | `bun run check` and `bun run test` ran before push | Tool calls invoking these commands before any push                                        | **Medium** |
 | Status advanced to `done` after final push         | `specs/STATUS` edit setting the spec to `done` after the push                             | **Medium** |
 | Scope discipline held                              | No edits to files outside the plan's stated blast radius                                  | **Medium** |
+
+## technical-writer / doc-review traces
+
+| Invariant                                 | Evidence to find                                                  | Severity   |
+| ----------------------------------------- | ----------------------------------------------------------------- | ---------- |
+| Source of truth consulted before findings | `Read` calls on source code/data files before documentation edits | **Medium** |
+| `bunx fit-doc build` ran before push      | Tool call invoking the build command before any push              | **Medium** |
+| Coverage map updated in memory            | Wiki write containing coverage map table                          | **Low**    |
+
+## technical-writer / wiki-curate traces
+
+| Invariant                                | Evidence to find                                             | Severity   |
+| ---------------------------------------- | ------------------------------------------------------------ | ---------- |
+| All agent summaries read before curation | `Read` calls on each `wiki/<agent>.md` before any wiki edits | **Medium** |
+| Current week logs read for each agent    | `Read` calls on `wiki/<agent>-YYYY-Www.md` files             | **Medium** |

--- a/.claude/skills/gemba-wiki-curate/SKILL.md
+++ b/.claude/skills/gemba-wiki-curate/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: gemba-wiki-curate
+description: >
+  Curate the wiki (agent memory) for cross-team collaboration. Verify summary
+  accuracy against weekly logs, follow up on stale teammate observations,
+  update MEMORY.md, and clean log hygiene. Use when running scheduled wiki
+  curation, auditing agent memory health, or checking cross-agent
+  communication.
+---
+
+# Wiki Curation
+
+Ensure the wiki remains a reliable coordination mechanism. Without curation,
+summaries drift from reality, stale blockers persist, critical observations go
+unacted on, and MEMORY.md falls out of sync.
+
+Each run covers all four curation areas in sequence.
+
+## Curation areas
+
+| Area                    | What to check                                                  |
+| ----------------------- | -------------------------------------------------------------- |
+| `summary-accuracy`      | Each agent's summary matches their latest weekly log entries   |
+| `observation-follow-up` | "Observations for teammates" are acknowledged and acted on     |
+| `memory-index`          | MEMORY.md and Home.md list all agents, conventions are current |
+| `log-hygiene`           | Weekly logs use correct format, headings, ISO week conventions |
+
+If time-constrained, prioritize `summary-accuracy` and `observation-follow-up`.
+
+## Process
+
+### 1. Read all memory
+
+Read memory per the agent profile (your summary, the current week's log, and
+teammates' summaries). Then read every file in `wiki/`:
+
+- All agent summary files (`wiki/<agent>.md`)
+- The current week's log for each agent (`wiki/<agent>-$(date +%G-W%V).md`)
+- `wiki/MEMORY.md`
+- `wiki/Home.md`
+
+### 2. Summary accuracy
+
+For each agent, compare the summary against the most recent weekly log entries:
+
+- **Last run date** — Does the summary's "Last run" match the latest
+  `## YYYY-MM-DD` entry in their weekly log?
+- **Coverage map** — Does the summary's coverage table match the data in their
+  latest log entries? (Applies to agents with coverage maps: security-engineer,
+  improvement-coach, technical-writer.)
+- **Blockers** — Are blockers in the summary still open, or were they resolved
+  in subsequent logs? Remove resolved blockers.
+- **Stale summaries** — Flag any agent whose summary shows a "Last run" date
+  more than 7 days ago with no new weekly log entries.
+
+Fix inaccuracies directly in the summary files.
+
+### 3. Observation follow-up
+
+Collect all "Observations for teammates" sections across all agent summaries.
+For each observation:
+
+1. Identify the target agent.
+2. Check the target agent's weekly logs after the observation date for
+   acknowledgement or action.
+3. Flag observations older than 2 weeks with no visible response.
+4. Note unacted observations in the technical-writer's own summary so the target
+   agent sees them on their next run.
+
+### 4. Memory index
+
+Verify `wiki/MEMORY.md`:
+
+- Lists all agents with correct one-line descriptions.
+- Filename convention documentation matches actual usage.
+- No agents missing or extra.
+
+Verify `wiki/Home.md`:
+
+- Agent count matches actual agents.
+- All agent summary links work.
+- Quick links are current.
+
+Update both files if they've drifted.
+
+### 5. Log hygiene
+
+For each weekly log file in `wiki/`:
+
+- Filename follows `<agent>-YYYY-Www.md` convention.
+- File starts with `# <Agent Name> — YYYY-Www` heading.
+- Each run entry uses `## YYYY-MM-DD` heading.
+- Subsections use `###` headings matching the skill's "Memory: what to record"
+  fields.
+
+Flag format violations but do not rewrite log content — logs are historical
+records.
+
+### 6. Critical item roll-up
+
+Scan all agent summaries and recent weekly logs for items that affect multiple
+agents or the whole team:
+
+- Systemic blockers (e.g., CI failures, SDK limitations)
+- Breaking changes that affect agent workflows
+- Policy changes that need cross-agent awareness
+
+Ensure these appear in MEMORY.md under a visible section, or in every affected
+agent's summary under "Observations for teammates."
+
+## Output
+
+- **Direct wiki fixes** — Summary corrections, MEMORY.md updates, stale blocker
+  removal. Commit directly to the wiki submodule.
+- **Cross-agent observations** — Note unacted teammate observations in the
+  technical-writer's summary for target agents to see.
+- **Structural improvements** — Spec via `gemba-spec` if the wiki structure
+  itself needs redesign.
+
+### Memory: what to record
+
+Append to the current week's log (see agent profile for the file path):
+
+- **Areas curated** — Which areas checked
+- **Summary corrections** — Which agent summaries were updated and why
+- **Stale observations** — Teammate observations >2 weeks old with no response
+- **MEMORY.md changes** — What was added/updated
+- **Observations for teammates** — Specific callouts based on wiki findings

--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -1,0 +1,53 @@
+name: "Gemba: Doc Review"
+
+on:
+  schedule:
+    # Mon & Thu at 05:37 UTC — runs after security, before release-readiness
+    - cron: "37 5 * * 1,4"
+  workflow_dispatch: # Manual trigger for on-demand reviews
+    inputs:
+      task-amend:
+        description: "Additional text appended to the task prompt for steering"
+        required: false
+        type: string
+
+concurrency:
+  group: doc-review
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.ci-app.outputs.token }}
+          submodules: true
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: Review Documentation
+        uses: ./.github/actions/gemba-action
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          task-text: Review one documentation topic and act on findings.
+          agent-profile: "technical-writer"
+          model: "opus"
+          max-turns: "200"
+          task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/wiki-curate.yml
+++ b/.github/workflows/wiki-curate.yml
@@ -1,0 +1,52 @@
+name: "Gemba: Wiki Curate"
+
+on:
+  schedule:
+    # Wed & Sat at 03:47 UTC — runs early so curated state is available to all agents
+    - cron: "47 3 * * 3,6"
+  workflow_dispatch: # Manual trigger for on-demand curation
+    inputs:
+      task-amend:
+        description: "Additional text appended to the task prompt for steering"
+        required: false
+        type: string
+
+concurrency:
+  group: wiki-curate
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  curate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
+          submodules: true
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: Curate Wiki
+        uses: ./.github/actions/gemba-action
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          task-text: Curate the wiki and act on findings.
+          agent-profile: "technical-writer"
+          model: "opus"
+          max-turns: "200"
+          task-amend: ${{ inputs.task-amend }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,10 @@ above.
   [gemba-release-readiness skill](.claude/skills/gemba-release-readiness)
 - **Release review** —
   [gemba-release-review skill](.claude/skills/gemba-release-review)
+- **Documentation review** —
+  [gemba-documentation skill](.claude/skills/gemba-documentation)
+- **Wiki curation** —
+  [gemba-wiki-curate skill](.claude/skills/gemba-wiki-curate)
 - **Codegen pipeline** — [Codegen Internals](website/docs/internals/codegen/)
 - **REPL API** — [librepl internals](website/docs/internals/librepl/)
 - **Getting started (contributors)** —

--- a/GEMBA.md
+++ b/GEMBA.md
@@ -12,8 +12,8 @@ place (the execution traces of prior runs) and act on what they find.
 
 Within Gemba, **Plan–Do–Study–Act** (PDSA, after Deming) is the improvement
 method. Every workflow belongs to a PDSA phase, findings from Study always
-re-enter the loop as specs or fix PRs, and the cycle runs on a schedule. Eight
-scheduled workflows, five agent personas, and twelve skills form a
+re-enter the loop as specs or fix PRs, and the cycle runs on a schedule. Ten
+scheduled workflows, six agent personas, and fourteen skills form a
 self-reinforcing PDSA cycle. Product evaluation sessions feed the Study phase
 with observations from the user's perspective. Gemba maintains the project — not
 the engineering frameworks the products serve.
@@ -75,7 +75,7 @@ phase.
 
 ### Study — analyze outputs and feedback
 
-The Study phase closes observation over the Do phase. Three study streams feed
+The Study phase closes observation over the Do phase. Four study streams feed
 the next Act phase:
 
 - **Security engineer** studies the **repository's security posture** — supply
@@ -85,6 +85,10 @@ the next Act phase:
   alignment, verifies trust, classifies work, and gates merges. Product
   evaluation sessions feed the same stream with observations from first-time
   users.
+- **Technical writer** studies **documentation accuracy and wiki health**. Each
+  cycle reviews **one documentation topic** — depth over breadth: pick a topic
+  area → read every page → verify against source code → fix staleness and
+  audience drift. Also curates agent memory (summaries, observations, logs).
 - **Improvement coach** studies **internal agent behaviour**. Each cycle focuses
   on **one trace** — depth over breadth: select a run → download the trace →
   deep-analyze every turn via grounded theory (open coding → axial coding →
@@ -109,13 +113,14 @@ structural improvements (`spec/` branches) — never mixed in one PR.
 
 ## Agents
 
-| Agent                 | Phase          | Purpose                                                               | Skills                                                                                                       |
-| --------------------- | -------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **staff-engineer**    | Plan, Do       | Own the full spec → plan → implement arc for approved specs           | gemba-plan, gemba-implement, gemba-gh-cli                                                                    |
-| **security-engineer** | Do, Study, Act | Patch dependencies, harden supply chain, enforce security policies    | gemba-security-update, gemba-security-audit, gemba-spec                                                      |
-| **release-engineer**  | Do             | Keep PR branches merge-ready, repair trivial CI on main, cut releases | gemba-release-readiness, gemba-release-review, gemba-gh-cli                                                  |
-| **product-manager**   | Do, Study, Act | Triage issues and PRs, merge fix/bug/spec PRs, supervise evaluations  | gemba-plan, gemba-product-triage, gemba-product-classify, gemba-product-evaluation, gemba-spec, gemba-gh-cli |
-| **improvement-coach** | Study, Act     | Walk traces, audit invariants, fix trivial issues, spec larger ones   | gemba-walk, gemba-spec, gemba-gh-cli                                                                         |
+| Agent                 | Phase          | Purpose                                                                | Skills                                                                                                       |
+| --------------------- | -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **staff-engineer**    | Plan, Do       | Own the full spec → plan → implement arc for approved specs            | gemba-plan, gemba-implement, gemba-gh-cli                                                                    |
+| **security-engineer** | Do, Study, Act | Patch dependencies, harden supply chain, enforce security policies     | gemba-security-update, gemba-security-audit, gemba-spec                                                      |
+| **release-engineer**  | Do             | Keep PR branches merge-ready, repair trivial CI on main, cut releases  | gemba-release-readiness, gemba-release-review, gemba-gh-cli                                                  |
+| **product-manager**   | Do, Study, Act | Triage issues and PRs, merge fix/bug/spec PRs, supervise evaluations   | gemba-plan, gemba-product-triage, gemba-product-classify, gemba-product-evaluation, gemba-spec, gemba-gh-cli |
+| **technical-writer**  | Study, Act     | Review docs for accuracy, curate wiki, fix staleness, spec larger gaps | gemba-documentation, gemba-wiki-curate, gemba-spec                                                           |
+| **improvement-coach** | Study, Act     | Walk traces, audit invariants, fix trivial issues, spec larger ones    | gemba-walk, gemba-spec, gemba-gh-cli                                                                         |
 
 Each agent has explicit scope constraints — it knows what it must _not_ do. When
 a finding exceeds an agent's scope, it writes a formal spec (`specs/`) rather
@@ -123,7 +128,7 @@ than attempting the fix.
 
 ## Workflows
 
-Workflows span 04–11 UTC, loosely following a PDSA cycle. Times respect
+Workflows span 03–11 UTC, loosely following a PDSA cycle. Times respect
 dependencies (plans before implementation, rebase before merge, merge before
 release) and same-agent workflows never overlap.
 
@@ -136,6 +141,8 @@ release) and same-agent workflows never overlap.
 | **plan-specs**        | Plan           | Daily 07:11 UTC                         | staff-engineer    | Pick up approved specs without plans and produce execution-ready plan-a.md  |
 | **implement-plans**   | Do             | Daily 07:53 UTC                         | staff-engineer    | Pick up approved plans (`status: planned`) and execute via implement-spec   |
 | **release-review**    | Do             | Tue, Thu, Sat 09:37 UTC                 | release-engineer  | Find unreleased changes, bump versions, tag, push, verify publish           |
+| **doc-review**        | Study, Act     | Mon & Thu 05:37 UTC                     | technical-writer  | Review one documentation topic in depth, fix staleness or write specs       |
+| **wiki-curate**       | Study, Act     | Wed & Sat 03:47 UTC                     | technical-writer  | Curate agent memory: verify summaries, follow up observations, clean logs   |
 | **improvement-coach** | Study → Act    | Wed & Sat 10:47 UTC                     | improvement-coach | Deep-analyze a single random agent trace, open fix PRs or write specs       |
 
 Off-minute schedules avoid API load spikes. All workflows support
@@ -159,6 +166,8 @@ All Gemba skills are namespaced with the `gemba-` prefix.
 | **gemba-product-triage**     | Study | Classify open issues for product alignment; produce a triage report           |
 | **gemba-product-classify**   | Study | Classify open PRs for mergeability — trust, type, CI, spec review — and merge |
 | **gemba-product-evaluation** | Study | Supervise product evaluation sessions, capture feedback, create issues        |
+| **gemba-documentation**      | Study | Write and review documentation — one topic deep per scheduled run             |
+| **gemba-wiki-curate**        | Study | Curate agent memory: summary accuracy, observation follow-up, log hygiene     |
 | **gemba-walk**               | Study | Open-ended trace observation, invariant audit, grounded-theory report         |
 | **gemba-spec**               | Act   | Write and review specs (WHAT/WHY); manage `draft → review` status             |
 | **gemba-gh-cli**             | —     | GitHub CLI installation and usage patterns for CI (utility, no PDSA phase)    |
@@ -232,6 +241,8 @@ graph TD
 | **product-manager**   | Agent-authored fix/spec    | Agent-only, issues as input                     |
 | **release-review**    | Agent-authored tags/bumps  | Agent-only, no external input                   |
 | **improvement-coach** | Agent-authored fix/spec    | Agent-only, traces as evidence                  |
+| **doc-review**        | Agent-authored doc fixes   | Agent-only, source-of-truth verified            |
+| **wiki-curate**       | Agent-authored wiki edits  | Agent-only, cross-agent memory maintenance      |
 | **release-engineer**  | Trivial CI fixes on main   | Agent-only, mechanical fixes only               |
 
 ## Design Principles


### PR DESCRIPTION
## Summary

- Add a sixth GEMBA agent — **technical-writer** — with two scheduled workflows that fill two gaps: documentation accuracy and wiki reliability
- **`gemba-documentation`** skill (Mon/Thu 05:37 UTC): picks one of 8 documentation topics per run using coverage-map rotation, verifies against source code, checks audience purity, fixes staleness. Replaces the old `write-docs` skill by merging standards into `references/`
- **`gemba-wiki-curate`** skill (Wed/Sat 03:47 UTC): verifies agent summary accuracy against weekly logs, follows up on stale teammate observations, maintains MEMORY.md/Home.md, checks log hygiene, rolls up critical cross-agent items
- Updates GEMBA.md (six agents, ten workflows, fourteen skills), CLAUDE.md, wiki index files, and improvement-coach invariants

## Test plan

- [ ] `bun run format` passes (verified)
- [ ] `bun run lint` passes (verified)
- [ ] `bun run test` passes — 2081/2081 (verified)
- [ ] Trigger `doc-review` workflow via `workflow_dispatch` and verify skill activates
- [ ] Trigger `wiki-curate` workflow via `workflow_dispatch` and verify wiki files are read
- [ ] Verify GEMBA.md agent/workflow/skill counts match tables (6/10/14)

https://claude.ai/code/session_01RoULvaUcm8F3TEy4LpQZfp