### PR TITLE
refactor(cli): route all CLI output through libcli format helpers

### DIFF
--- a/libraries/libdoc/bin/fit-doc.js
+++ b/libraries/libdoc/bin/fit-doc.js
@@ -8,7 +8,7 @@ import { marked } from "marked";
 import mustache from "mustache";
 import prettier from "prettier";
 
-import { createCli } from "@forwardimpact/libcli";
+import { createCli, formatBullet } from "@forwardimpact/libcli";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { DocsBuilder, DocsServer } from "../index.js";
 import { parseFrontMatter } from "../frontmatter.js";
@@ -101,7 +101,7 @@ async function runServe(builder, server, docsDir, distDir, options) {
   }
 
   server.serve(distDir, { port: options.port, hostname: "0.0.0.0" });
-  console.log("Press Ctrl+C to stop");
+  process.stdout.write(formatBullet("Press Ctrl+C to stop") + "\n");
 }
 
 async function main() {

--- a/libraries/libstorage/bin/fit-storage.js
+++ b/libraries/libstorage/bin/fit-storage.js
@@ -2,7 +2,12 @@
 
 import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
-import { createCli } from "@forwardimpact/libcli";
+import {
+  createCli,
+  formatHeader,
+  formatSuccess,
+  formatBullet,
+} from "@forwardimpact/libcli";
 import { createScriptConfig } from "@forwardimpact/libconfig";
 import { createStorage } from "@forwardimpact/libstorage";
 import { Logger } from "@forwardimpact/libtelemetry";
@@ -96,17 +101,22 @@ const commands = {
     // Use empty prefix for bucket-level operations
     const storage = createStorage("");
     const created = await storage.ensureBucket();
-    console.log(created ? "Bucket created" : "Bucket already exists");
+    process.stdout.write(
+      formatSuccess(created ? "Bucket created" : "Bucket already exists") +
+        "\n",
+    );
   },
 
   async wait() {
     await createScriptConfig("storage");
     const storage = createStorage("");
     const timeout = parseInt(values.timeout || "30000");
-    console.log(`Waiting for storage (timeout: ${timeout}ms)...`);
+    process.stdout.write(
+      formatHeader(`Waiting for storage (timeout: ${timeout}ms)`) + "\n",
+    );
     const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
     await waitFor(() => storage.isHealthy(), { timeout }, delay);
-    console.log("Storage is ready");
+    process.stdout.write(formatSuccess("Storage is ready") + "\n");
   },
 
   async upload() {
@@ -117,7 +127,9 @@ const commands = {
       : await discoverLocalPrefixes();
 
     if (prefixes.length === 0) {
-      console.log("No prefixes to upload (data/ directory empty or not found)");
+      process.stdout.write(
+        "No prefixes to upload (data/ directory empty or not found)\n",
+      );
       return;
     }
 
@@ -142,7 +154,7 @@ const commands = {
         prefix,
       });
     }
-    console.log("Upload completed");
+    process.stdout.write(formatSuccess("Upload completed") + "\n");
   },
 
   async download() {
@@ -153,7 +165,7 @@ const commands = {
       : await discoverRemotePrefixes();
 
     if (prefixes.length === 0) {
-      console.log("No prefixes found in remote storage");
+      process.stdout.write("No prefixes found in remote storage\n");
       return;
     }
 
@@ -169,7 +181,7 @@ const commands = {
 
       logger.info("download", `Downloaded ${keys.length} files`, { prefix });
     }
-    console.log("Download completed");
+    process.stdout.write(formatSuccess("Download completed") + "\n");
   },
 
   async list() {
@@ -179,14 +191,16 @@ const commands = {
       : await discoverRemotePrefixes();
 
     if (prefixes.length === 0) {
-      console.log("No prefixes found in remote storage");
+      process.stdout.write("No prefixes found in remote storage\n");
       return;
     }
 
     for (const prefix of prefixes) {
       const storage = createStorage(prefix);
       const keys = await storage.list();
-      keys.forEach((k) => console.log(`${prefix}/${k}`));
+      for (const k of keys) {
+        process.stdout.write(formatBullet(`${prefix}/${k}`, 0) + "\n");
+      }
     }
   },
 };

--- a/libraries/libuniverse/bin/fit-universe.js
+++ b/libraries/libuniverse/bin/fit-universe.js
@@ -10,7 +10,14 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { tmpdir } from "os";
 import { format } from "prettier";
-import { createCli } from "@forwardimpact/libcli";
+import {
+  createCli,
+  formatHeader,
+  formatSubheader,
+  formatSuccess,
+  formatError,
+  formatBullet,
+} from "@forwardimpact/libcli";
 import { createScriptConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { PromptLoader } from "@forwardimpact/libprompt";
@@ -132,7 +139,7 @@ async function writeOutputFiles(files, monorepoRoot) {
     await mkdir(dirname(fullPath), { recursive: true });
     await writeFile(fullPath, content);
   }
-  console.log(`${files.size} files written`);
+  process.stdout.write(formatSuccess(`${files.size} files written`) + "\n");
 }
 
 /**
@@ -191,10 +198,18 @@ async function loadRawToSupabase(rawDocuments) {
   const { loadToSupabase } = await import("../load.js");
   const supabase = createClient(url, key);
   const loadResult = await loadToSupabase(supabase, rawDocuments);
-  console.log(`${loadResult.loaded} raw documents loaded to Supabase Storage`);
+  process.stdout.write(
+    formatSuccess(
+      `${loadResult.loaded} raw documents loaded to Supabase Storage`,
+    ) + "\n",
+  );
   if (loadResult.errors.length > 0) {
-    console.error(`${loadResult.errors.length} errors:`);
-    for (const err of loadResult.errors) console.error(`  ${err}`);
+    process.stderr.write(
+      formatError(`${loadResult.errors.length} errors:`) + "\n",
+    );
+    for (const err of loadResult.errors) {
+      process.stderr.write(formatBullet(err, 1) + "\n");
+    }
   }
 }
 
@@ -209,8 +224,10 @@ async function writeRawLocally(rawDocuments, monorepoRoot) {
     await mkdir(dirname(fullPath), { recursive: true });
     await writeFile(fullPath, content);
   }
-  console.log(
-    `${rawDocuments.size} raw documents written to data/activity/raw/`,
+  process.stdout.write(
+    formatSuccess(
+      `${rawDocuments.size} raw documents written to data/activity/raw/`,
+    ) + "\n",
   );
 }
 
@@ -220,12 +237,24 @@ async function writeRawLocally(rawDocuments, monorepoRoot) {
  * @param {boolean} load
  */
 function printDryRun(result, load) {
-  console.log("\nFilesystem files:");
-  for (const [path] of result.files) console.log(`  ${path}`);
-  console.log(`\nRaw documents (${load ? "Supabase Storage" : "local"}):`);
-  for (const [path] of result.rawDocuments) console.log(`  raw/${path}`);
-  console.log(
-    `\n  ${result.files.size + result.rawDocuments.size} total (dry run)`,
+  process.stdout.write("\n" + formatHeader("Filesystem files") + "\n");
+  for (const [path] of result.files) {
+    process.stdout.write(formatBullet(path, 0) + "\n");
+  }
+  process.stdout.write(
+    "\n" +
+      formatHeader(`Raw documents (${load ? "Supabase Storage" : "local"})`) +
+      "\n",
+  );
+  for (const [path] of result.rawDocuments) {
+    process.stdout.write(formatBullet(`raw/${path}`, 0) + "\n");
+  }
+  process.stdout.write(
+    "\n" +
+      formatSubheader(
+        `${result.files.size + result.rawDocuments.size} total (dry run)`,
+      ) +
+      "\n",
   );
 }
 
@@ -234,23 +263,31 @@ function printDryRun(result, load) {
  * @param {object} result
  */
 function printReport(result) {
-  console.log("\nValidation:");
+  process.stdout.write("\n" + formatHeader("Validation") + "\n");
   for (const check of result.validation.checks) {
     const icon = check.passed ? "\u2713" : "\u2717";
-    console.log(`  ${icon} ${check.name}`);
+    process.stdout.write(formatBullet(`${icon} ${check.name}`, 0) + "\n");
   }
 
   const { hits, generated, misses } = result.stats.prose;
   const proseTotal = hits + generated + misses;
   if (proseTotal > 0) {
     const rate = Math.round((hits / proseTotal) * 100);
-    console.log(
-      `\nProse: ${hits} hits, ${generated} generated, ${misses} misses (${rate}% hit rate)`,
+    process.stdout.write(
+      "\n" +
+        formatSubheader(
+          `Prose: ${hits} hits, ${generated} generated, ${misses} misses (${rate}% hit rate)`,
+        ) +
+        "\n",
     );
   }
 
   if (!result.validation.passed) {
-    console.error(`\n${result.validation.failures} validation failures`);
+    process.stderr.write(
+      "\n" +
+        formatError(`${result.validation.failures} validation failures`) +
+        "\n",
+    );
     process.exit(1);
   }
 }

--- a/products/guide/bin/fit-guide.js
+++ b/products/guide/bin/fit-guide.js
@@ -16,7 +16,14 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
-import { createCli } from "@forwardimpact/libcli";
+import {
+  createCli,
+  SummaryRenderer,
+  formatHeader,
+  formatSuccess,
+  formatError,
+  formatBullet,
+} from "@forwardimpact/libcli";
 import { Repl } from "@forwardimpact/librepl";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -158,10 +165,17 @@ async function runInit() {
     await updateEnvFile(key, url);
   }
 
-  console.log("SERVICE_SECRET was updated in .env");
-  console.log("JWT_SECRET is set in .env");
-  console.log("JWT_ANON_KEY was updated in .env");
-  console.log("Service URLs written to .env (ports 3001–3008).");
+  const initSummary = new SummaryRenderer({ process });
+  initSummary.render({
+    title: formatHeader("Environment (.env)"),
+    items: [
+      { label: "SERVICE_SECRET", description: "updated" },
+      { label: "JWT_SECRET", description: "set" },
+      { label: "JWT_ANON_KEY", description: "updated" },
+      { label: "Service URLs", description: "ports 3001\u20133008" },
+    ],
+  });
+  process.stdout.write("\n");
 
   // Copy starter config into ./config/ (config.json, agents/, tools.yml)
   const starterDir = new URL("../starter", import.meta.url).pathname;
@@ -170,25 +184,32 @@ async function runInit() {
   try {
     await fs.access(starterDir);
   } catch {
-    console.error("Error: Starter data not found in package.");
-    console.error("This may indicate a corrupted package installation.");
+    process.stderr.write(
+      formatError("Starter data not found in package.") + "\n",
+    );
+    process.stderr.write(
+      "This may indicate a corrupted package installation.\n",
+    );
     process.exit(1);
   }
 
   try {
     await fs.access(configDir);
-    console.log("config/ already exists, skipping starter copy.");
+    process.stdout.write(
+      formatBullet("config/ already exists, skipping starter copy.", 0) + "\n",
+    );
   } catch {
     await fs.cp(starterDir, configDir, { recursive: true });
-    console.log(`config/ created with starter configuration.
-
-  config/
+    process.stdout.write(
+      formatSuccess("config/ created with starter configuration.") + "\n\n",
+    );
+    process.stdout.write(`  config/
   \u251C\u2500\u2500 config.json                  # Service configuration
   \u251C\u2500\u2500 agents/
   \u2502   \u251C\u2500\u2500 planner.agent.md         # Plans retrieval strategy
   \u2502   \u251C\u2500\u2500 researcher.agent.md      # Retrieves data
   \u2502   \u2514\u2500\u2500 editor.agent.md          # Synthesizes response
-  \u2514\u2500\u2500 tools.yml                    # Tool definitions`);
+  \u2514\u2500\u2500 tools.yml                    # Tool definitions\n`);
   }
 }
 
@@ -202,13 +223,19 @@ async function setupServices() {
   try {
     await fs.access(resolve("config", "config.json"));
   } catch {
-    console.log(`fit-guide — Conversational agent for the Guide knowledge platform
-
-Run npx fit-guide init to generate configuration, then
-npx fit-rc start to launch the service stack.
-
-Documentation: https://www.forwardimpact.team/guide
-Run npx fit-guide --help for CLI options.`);
+    process.stdout.write(
+      formatHeader(
+        "fit-guide \u2014 Conversational agent for the Guide knowledge platform",
+      ) + "\n\n",
+    );
+    process.stdout.write(
+      "Run npx fit-guide init to generate configuration, then\n",
+    );
+    process.stdout.write("npx fit-rc start to launch the service stack.\n\n");
+    process.stdout.write(
+      "Documentation: https://www.forwardimpact.team/guide\n",
+    );
+    process.stdout.write("Run npx fit-guide --help for CLI options.\n");
     process.exit(1);
   }
 
@@ -326,7 +353,6 @@ if (command === "status") {
   if (values.json) {
     process.stdout.write(JSON.stringify(result, null, 2) + "\n");
   } else {
-    const { SummaryRenderer } = await import("@forwardimpact/libcli");
     const summary = new SummaryRenderer({ process });
     printStatusSummary(summary, result);
   }

--- a/products/map/bin/fit-map.js
+++ b/products/map/bin/fit-map.js
@@ -14,7 +14,18 @@ import { readFileSync } from "fs";
 import { homedir } from "os";
 import { Finder } from "@forwardimpact/libutil";
 import { createLogger } from "@forwardimpact/libtelemetry";
-import { createCli } from "@forwardimpact/libcli";
+import {
+  createCli,
+  SummaryRenderer,
+  formatHeader,
+  formatSubheader,
+  formatSuccess,
+  formatError,
+  formatWarning,
+  formatBullet,
+} from "@forwardimpact/libcli";
+
+const summary = new SummaryRenderer({ process });
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -109,27 +120,31 @@ async function findDataDir(providedPath) {
 }
 
 /**
- * Format validation results for display
+ * Format validation results for display using libcli helpers.
+ * @param {{valid: boolean, errors: Array, warnings?: Array}} result
+ * @returns {string}
  */
 function formatValidationResults(result) {
   const lines = [];
 
   if (result.valid) {
-    lines.push("Validation passed\n");
+    lines.push(formatSuccess("Validation passed"));
   } else {
-    lines.push("Validation failed\n");
-    lines.push("\nErrors:");
+    lines.push(formatError("Validation failed"));
+    lines.push("");
+    lines.push(formatSubheader("Errors"));
     for (const error of result.errors) {
       const path = error.path ? ` (${error.path})` : "";
-      lines.push(`  - ${error.type}: ${error.message}${path}`);
+      lines.push(formatBullet(`${error.type}: ${error.message}${path}`, 0));
     }
   }
 
   if (result.warnings?.length > 0) {
-    lines.push("\nWarnings:");
+    lines.push("");
+    lines.push(formatSubheader("Warnings"));
     for (const warning of result.warnings) {
       const path = warning.path ? ` (${warning.path})` : "";
-      lines.push(`  - ${warning.type}: ${warning.message}${path}`);
+      lines.push(formatBullet(`${warning.type}: ${warning.message}${path}`, 0));
     }
   }
 
@@ -140,7 +155,7 @@ function formatValidationResults(result) {
  * Validate command
  */
 async function runValidate(dataDir) {
-  console.log(`Validating data in: ${dataDir}\n`);
+  process.stdout.write(formatHeader(`Validating data in: ${dataDir}`) + "\n\n");
 
   const { createDataLoader, createSchemaValidator } =
     await import("../src/index.js");
@@ -151,15 +166,25 @@ async function runValidate(dataDir) {
   const data = await loader.loadAllData(dataDir);
   const result = await validator.runFullValidation(dataDir, data);
 
-  console.log(formatValidationResults(result));
+  process.stdout.write(formatValidationResults(result) + "\n\n");
 
-  console.log("\nData Summary:");
-  console.log(`   Skills:      ${data.skills?.length || 0}`);
-  console.log(`   Behaviours:  ${data.behaviours?.length || 0}`);
-  console.log(`   Disciplines: ${data.disciplines?.length || 0}`);
-  console.log(`   Tracks:      ${data.tracks?.length || 0}`);
-  console.log(`   Levels:      ${data.levels?.length || 0}`);
-  console.log(`   Drivers:     ${data.drivers?.length || 0}`);
+  summary.render({
+    title: formatHeader("Data Summary"),
+    items: [
+      { label: "Skills", description: String(data.skills?.length || 0) },
+      {
+        label: "Behaviours",
+        description: String(data.behaviours?.length || 0),
+      },
+      {
+        label: "Disciplines",
+        description: String(data.disciplines?.length || 0),
+      },
+      { label: "Tracks", description: String(data.tracks?.length || 0) },
+      { label: "Levels", description: String(data.levels?.length || 0) },
+      { label: "Drivers", description: String(data.drivers?.length || 0) },
+    ],
+  });
 
   return result.valid ? 0 : 1;
 }
@@ -181,7 +206,9 @@ async function findOutputDir(providedPath) {
  * Export command — render every base entity to HTML microdata.
  */
 async function runExport(dataDir, outputDir) {
-  console.log(`Exporting framework to: ${outputDir}\n`);
+  process.stdout.write(
+    formatHeader(`Exporting framework to: ${outputDir}`) + "\n\n",
+  );
 
   const { createDataLoader, createExporter, createRenderer } =
     await import("../src/index.js");
@@ -199,16 +226,24 @@ async function runExport(dataDir, outputDir) {
     counts[type] = (counts[type] || 0) + 1;
   }
 
-  console.log("Export complete\n");
-  for (const [type, count] of Object.entries(counts).sort()) {
-    console.log(`   ${type.padEnd(12)} ${count}`);
-  }
-  console.log(`   ${"total".padEnd(12)} ${result.written.length}`);
+  process.stdout.write(formatSuccess("Export complete") + "\n\n");
+  summary.render({
+    title: formatSubheader("By type"),
+    items: [
+      ...Object.entries(counts)
+        .sort()
+        .map(([type, count]) => ({
+          label: type,
+          description: String(count),
+        })),
+      { label: "total", description: String(result.written.length) },
+    ],
+  });
 
   if (result.errors.length > 0) {
-    console.log("\nErrors:");
+    process.stderr.write("\n" + formatError("Errors:") + "\n");
     for (const err of result.errors) {
-      console.log(`   ${err.path}: ${err.error}`);
+      process.stderr.write(formatBullet(`${err.path}: ${err.error}`, 1) + "\n");
     }
     return 1;
   }
@@ -220,7 +255,9 @@ async function runExport(dataDir, outputDir) {
  * Generate index command
  */
 async function runGenerateIndex(dataDir) {
-  console.log(`Generating index files in: ${dataDir}\n`);
+  process.stdout.write(
+    formatHeader(`Generating index files in: ${dataDir}`) + "\n\n",
+  );
 
   const { createIndexGenerator } = await import("../src/index.js");
 
@@ -229,67 +266,17 @@ async function runGenerateIndex(dataDir) {
 
   for (const [dir, files] of Object.entries(results)) {
     if (files.error) {
-      console.log(`  ${dir}/_index.yaml: ${files.error}`);
+      process.stdout.write(
+        formatBullet(`${dir}/_index.yaml: ${files.error}`, 0) + "\n",
+      );
     } else {
-      console.log(`  ${dir}/_index.yaml (${files.length} files)`);
+      process.stdout.write(
+        formatBullet(`${dir}/_index.yaml (${files.length} files)`, 0) + "\n",
+      );
     }
   }
 
   return 0;
-}
-
-/**
- * SHACL validation command
- */
-async function runValidateShacl() {
-  console.log("Validating SHACL schema syntax...\n");
-
-  const rdfDir = join(__dirname, "../schema/rdf");
-
-  try {
-    const { default: N3 } = await import("n3");
-    const { readFile, readdir } = await import("fs/promises");
-
-    const files = await readdir(rdfDir);
-    const ttlFiles = files.filter((f) => f.endsWith(".ttl")).sort();
-
-    if (ttlFiles.length === 0) {
-      console.error("No .ttl files found in schema/rdf/\n");
-      return 1;
-    }
-
-    let totalQuads = 0;
-    const errors = [];
-
-    for (const file of ttlFiles) {
-      const filePath = join(rdfDir, file);
-      const turtleContent = await readFile(filePath, "utf-8");
-
-      try {
-        const parser = new N3.Parser({ format: "text/turtle" });
-        const quads = parser.parse(turtleContent);
-        totalQuads += quads.length;
-        console.log(`  ${file} (${quads.length} triples)`);
-      } catch (error) {
-        errors.push({ file, error: error.message });
-        console.log(`  ${file}: ${error.message}`);
-      }
-    }
-
-    console.log();
-    if (errors.length > 0) {
-      console.error(`SHACL syntax errors in ${errors.length} file(s)\n`);
-      return 1;
-    }
-
-    console.log(
-      `SHACL syntax valid (${ttlFiles.length} files, ${totalQuads} triples)\n`,
-    );
-    return 0;
-  } catch (error) {
-    console.error(`SHACL validation error: ${error.message}\n`);
-    return 1;
-  }
 }
 
 // ── Dispatchers ──────────────────────────────────────────────────────────────
@@ -321,10 +308,12 @@ async function dispatchPeople(subcommand, rest, values) {
       return people.push(filePath, supabase);
     }
     case "import": {
-      console.error(
-        "warning: `fit-map people import` is deprecated. Use " +
-          "`fit-map people validate` to validate locally or " +
-          "`fit-map people push` to push to the database.",
+      process.stderr.write(
+        formatWarning(
+          "`fit-map people import` is deprecated. Use " +
+            "`fit-map people validate` to validate locally or " +
+            "`fit-map people push` to push to the database.",
+        ) + "\n",
       );
       const filePath = rest[0];
       if (!filePath) {
@@ -407,6 +396,8 @@ async function main() {
       }
       case "validate": {
         if (values.shacl) {
+          const { runValidateShacl } =
+            await import("./lib/commands/validate-shacl.js");
           exitCode = await runValidateShacl();
         } else {
           const dataDir = await findDataDir(values.data);

--- a/products/map/bin/lib/commands/activity.js
+++ b/products/map/bin/lib/commands/activity.js
@@ -5,15 +5,28 @@ import { transformPeople } from "@forwardimpact/map/activity/transform/people";
 import { transformAllGetDX } from "@forwardimpact/map/activity/transform/getdx";
 import { transformAllGitHub } from "@forwardimpact/map/activity/transform/github";
 import { getOrganization } from "@forwardimpact/map/activity/queries/org";
+import {
+  formatHeader,
+  formatSubheader,
+  formatSuccess,
+  formatError,
+  formatBullet,
+  SummaryRenderer,
+} from "@forwardimpact/libcli";
+
+const summary = new SummaryRenderer({ process });
 
 export async function start() {
   await runSupabase(["start"]);
-  console.log(`
-Export these variables to use the activity layer:
-
-  export MAP_SUPABASE_URL=http://127.0.0.1:54321
-  export MAP_SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
-`);
+  process.stdout.write("\n");
+  process.stdout.write(
+    formatSubheader("Export these variables to use the activity layer:") +
+      "\n\n",
+  );
+  process.stdout.write("  export MAP_SUPABASE_URL=http://127.0.0.1:54321\n");
+  process.stdout.write(
+    "  export MAP_SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU\n\n",
+  );
   return 0;
 }
 
@@ -36,23 +49,28 @@ export async function transform(target, supabase) {
   switch (target) {
     case "people": {
       const r = await transformPeople(supabase);
-      report("people", { imported: r.imported, errors: r.errors });
+      report("people", { imported: r.imported, errors: r.errors.length });
       return r.errors.length === 0 ? 0 : 1;
     }
     case "getdx": {
       const r = await transformAllGetDX(supabase);
-      report("getdx", r);
+      report("getdx", summarizeCounts(r));
       return r.errors.length === 0 ? 0 : 1;
     }
     case "github": {
       const r = await transformAllGitHub(supabase);
-      report("github", r);
+      report("github", summarizeCounts(r));
       return r.errors.length === 0 ? 0 : 1;
     }
     case "all":
     case undefined: {
       const r = await transformAll(supabase);
-      report("all", r);
+      report("people", {
+        imported: r.people.imported,
+        errors: r.people.errors.length,
+      });
+      report("getdx", summarizeCounts(r.getdx));
+      report("github", summarizeCounts(r.github));
       const ok =
         r.people.errors.length === 0 &&
         r.getdx.errors.length === 0 &&
@@ -60,45 +78,58 @@ export async function transform(target, supabase) {
       return ok ? 0 : 1;
     }
     default:
-      console.error(`Unknown transform target: ${target}`);
+      process.stderr.write(
+        formatError(`Unknown transform target: ${target}`) + "\n",
+      );
       return 1;
   }
 }
 
 export async function verify(supabase) {
   const people = await getOrganization(supabase);
-  console.log(`  organization_people: ${people.length} rows`);
 
   const { count: snapshotCount, error: snapErr } = await supabase
     .from("getdx_snapshots")
     .select("*", { count: "exact", head: true });
   if (snapErr) throw new Error(`getdx_snapshots: ${snapErr.message}`);
-  console.log(`  getdx_snapshots:     ${snapshotCount ?? 0} rows`);
 
   const { count: eventCount, error: eventErr } = await supabase
     .from("github_events")
     .select("*", { count: "exact", head: true });
   if (eventErr) throw new Error(`github_events: ${eventErr.message}`);
-  console.log(`  github_events:       ${eventCount ?? 0} rows`);
+
+  summary.render({
+    title: formatHeader("Activity tables"),
+    items: [
+      { label: "organization_people", description: `${people.length} rows` },
+      { label: "getdx_snapshots", description: `${snapshotCount ?? 0} rows` },
+      { label: "github_events", description: `${eventCount ?? 0} rows` },
+    ],
+  });
 
   const hasPeople = people.length > 0;
   const hasDerived = (snapshotCount ?? 0) > 0 || (eventCount ?? 0) > 0;
 
   if (!hasPeople) {
-    console.error(
-      "\norganization_people is empty. Run `fit-map people push <file>`.",
+    process.stderr.write("\n");
+    process.stderr.write(
+      formatError(
+        "organization_people is empty. Run `fit-map people push <file>`.",
+      ) + "\n",
     );
     return 1;
   }
   if (!hasDerived) {
-    console.error(
-      "\nNo derived-table rows found. Run `fit-map getdx sync` or " +
-        "configure the github-webhook.",
+    process.stderr.write("\n");
+    process.stderr.write(
+      formatError(
+        "No derived-table rows found. Run `fit-map getdx sync` or configure the github-webhook.",
+      ) + "\n",
     );
     return 1;
   }
 
-  console.log("\nActivity layer verified");
+  process.stdout.write("\n" + formatSuccess("Activity layer verified") + "\n");
   return 0;
 }
 
@@ -127,7 +158,9 @@ export async function seed({ data, supabase }) {
     "text/yaml",
   );
   if (!stored.stored) {
-    console.error(`Failed to upload roster: ${stored.error}`);
+    process.stderr.write(
+      formatError(`Failed to upload roster: ${stored.error}`) + "\n",
+    );
     return 1;
   }
   report("Upload roster", { stored: 1 });
@@ -138,13 +171,18 @@ export async function seed({ data, supabase }) {
     stored: uploaded.count,
     errors: uploaded.errors.length,
   });
-  for (const err of uploaded.errors) console.error(`  ${err}`);
+  for (const err of uploaded.errors) {
+    process.stderr.write(formatBullet(err, 1) + "\n");
+  }
 
   // 3. Run all transforms
   const result = await transformAll(supabase);
-  report("Transform people", result.people);
-  report("Transform getdx", result.getdx);
-  report("Transform github", result.github);
+  report("Transform people", {
+    imported: result.people.imported,
+    errors: result.people.errors.length,
+  });
+  report("Transform getdx", summarizeCounts(result.getdx));
+  report("Transform github", summarizeCounts(result.github));
 
   // 4. Verify
   return verify(supabase);
@@ -194,6 +232,36 @@ async function uploadRawDir(supabase, rawDir) {
   return { count, errors };
 }
 
+/**
+ * Summarize a transform result into label/description pairs, dropping the
+ * errors array so numeric fields can be rendered individually.
+ * @param {object} counts
+ * @returns {object}
+ */
+function summarizeCounts(counts) {
+  const out = {};
+  for (const [key, value] of Object.entries(counts)) {
+    if (key === "errors") {
+      out.errors = Array.isArray(value) ? value.length : value;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Render a labeled transform report using the SummaryRenderer.
+ * @param {string} target
+ * @param {object} counts
+ */
 function report(target, counts) {
-  console.log(`Transform ${target}:`, JSON.stringify(counts, null, 2));
+  summary.render({
+    title: formatSubheader(target),
+    items: Object.entries(counts).map(([label, value]) => ({
+      label,
+      description: String(value),
+    })),
+  });
+  process.stdout.write("\n");
 }

--- a/products/map/bin/lib/commands/getdx.js
+++ b/products/map/bin/lib/commands/getdx.js
@@ -1,35 +1,51 @@
 import { extractGetDX } from "@forwardimpact/map/activity/extract/getdx";
 import { transformAllGetDX } from "@forwardimpact/map/activity/transform/getdx";
+import {
+  formatHeader,
+  formatBullet,
+  formatError,
+  formatSuccess,
+} from "@forwardimpact/libcli";
 
 export async function sync(supabase, { baseUrl } = {}) {
   const apiToken = process.env.GETDX_API_TOKEN;
   if (!apiToken) {
-    console.error(
-      "GETDX_API_TOKEN is not set. Export it before running getdx sync.",
+    process.stderr.write(
+      formatError(
+        "GETDX_API_TOKEN is not set. Export it before running getdx sync.",
+      ) + "\n",
     );
     return 1;
   }
 
-  console.log("Extracting GetDX snapshots...");
+  process.stdout.write(formatHeader("Extracting GetDX snapshots") + "\n");
   const extract = await extractGetDX(supabase, {
     apiToken,
     baseUrl: baseUrl ?? "https://api.getdx.com",
   });
-  console.log(`  Stored ${extract.files.length} raw files`);
+  process.stdout.write(
+    formatBullet(`Stored ${extract.files.length} raw files`, 0) + "\n",
+  );
   if (extract.errors.length > 0) {
-    console.error("Extract errors:");
-    for (const err of extract.errors) console.error(`  - ${err}`);
+    process.stderr.write(formatError("Extract errors:") + "\n");
+    for (const err of extract.errors) {
+      process.stderr.write(formatBullet(err, 1) + "\n");
+    }
     return 1;
   }
 
-  console.log("\nTransforming GetDX data...");
+  process.stdout.write("\n" + formatHeader("Transforming GetDX data") + "\n");
   const result = await transformAllGetDX(supabase);
-  console.log(
-    `Imported ${result.teams} teams, ${result.snapshots} snapshots, ${result.scores} scores`,
+  process.stdout.write(
+    formatSuccess(
+      `Imported ${result.teams} teams, ${result.snapshots} snapshots, ${result.scores} scores`,
+    ) + "\n",
   );
   if (result.errors.length > 0) {
-    console.error("Transform errors:");
-    for (const err of result.errors) console.error(`  - ${err}`);
+    process.stderr.write(formatError("Transform errors:") + "\n");
+    for (const err of result.errors) {
+      process.stderr.write(formatBullet(err, 1) + "\n");
+    }
     return 1;
   }
   return 0;

--- a/products/map/bin/lib/commands/init.js
+++ b/products/map/bin/lib/commands/init.js
@@ -7,6 +7,13 @@
 import { cp, access } from "fs/promises";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import {
+  formatError,
+  formatSuccess,
+  formatHeader,
+  formatBullet,
+  indent,
+} from "@forwardimpact/libcli";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const starterDir = join(__dirname, "..", "..", "..", "starter");
@@ -22,8 +29,8 @@ export async function runInit(targetPath) {
   // Check if data/pathway/ already exists
   try {
     await access(dataDir);
-    console.error("Error: ./data/pathway/ already exists.");
-    console.error("Remove it first or use a different directory.");
+    process.stderr.write(formatError("./data/pathway/ already exists.") + "\n");
+    process.stderr.write("Remove it first or use a different directory.\n");
     process.exit(1);
   } catch {
     // Directory doesn't exist, proceed
@@ -33,31 +40,43 @@ export async function runInit(targetPath) {
   try {
     await access(starterDir);
   } catch {
-    console.error("Error: Starter data not found in package.");
-    console.error("This may indicate a corrupted package installation.");
+    process.stderr.write(
+      formatError("Starter data not found in package.") + "\n",
+    );
+    process.stderr.write(
+      "This may indicate a corrupted package installation.\n",
+    );
     process.exit(1);
   }
 
   // Copy starter data
-  console.log("Creating ./data/pathway/ with starter data...\n");
+  process.stdout.write("Creating ./data/pathway/ with starter data...\n\n");
   await cp(starterDir, dataDir, { recursive: true });
 
-  console.log(`✅ Created ./data/pathway/ with starter data.
+  process.stdout.write(
+    formatSuccess("Created ./data/pathway/ with starter data.") + "\n\n",
+  );
 
-Next steps:
-  1. Edit data files to match your organization
-  2. npx fit-map validate
-  3. npx fit-pathway dev
+  process.stdout.write(formatHeader("Next steps") + "\n");
+  process.stdout.write(
+    formatBullet("Edit data files to match your organization", 0) + "\n",
+  );
+  process.stdout.write(formatBullet("npx fit-map validate", 0) + "\n");
+  process.stdout.write(formatBullet("npx fit-pathway dev", 0) + "\n\n");
 
-Data structure:
-  data/pathway/
-  ├── framework.yaml        # Framework metadata
-  ├── levels.yaml           # Career levels
-  ├── stages.yaml           # Lifecycle stages
-  ├── drivers.yaml          # Business drivers
-  ├── disciplines/          # Engineering disciplines
-  ├── capabilities/         # Capability areas with skills
-  ├── behaviours/           # Behavioural expectations
-  └── tracks/               # Track specializations
-`);
+  process.stdout.write(formatHeader("Data structure") + "\n");
+  process.stdout.write(
+    indent(
+      `data/pathway/
+\u251C\u2500\u2500 framework.yaml        # Framework metadata
+\u251C\u2500\u2500 levels.yaml           # Career levels
+\u251C\u2500\u2500 stages.yaml           # Lifecycle stages
+\u251C\u2500\u2500 drivers.yaml          # Business drivers
+\u251C\u2500\u2500 disciplines/          # Engineering disciplines
+\u251C\u2500\u2500 capabilities/         # Capability areas with skills
+\u251C\u2500\u2500 behaviours/           # Behavioural expectations
+\u2514\u2500\u2500 tracks/               # Track specializations`,
+      2,
+    ) + "\n",
+  );
 }

--- a/products/map/bin/lib/commands/people.js
+++ b/products/map/bin/lib/commands/people.js
@@ -5,45 +5,73 @@ import {
 } from "@forwardimpact/map/activity/validate/people";
 import { extractPeopleFile } from "@forwardimpact/map/activity/extract/people";
 import { transformPeople } from "@forwardimpact/map/activity/transform/people";
+import {
+  formatHeader,
+  formatSuccess,
+  formatError,
+  formatBullet,
+} from "@forwardimpact/libcli";
 
 export async function validate(filePath, dataDir) {
-  console.log(`Validating people file: ${filePath}\n`);
+  process.stdout.write(
+    formatHeader(`Validating people file: ${filePath}`) + "\n\n",
+  );
   const people = await loadPeopleFile(filePath);
-  console.log(`  Loaded ${people.length} people from file`);
+  process.stdout.write(
+    formatBullet(`Loaded ${people.length} people from file`, 0) + "\n",
+  );
 
   const { valid, errors } = await validatePeople(people, dataDir);
   if (errors.length > 0) {
-    console.log(`\nValidation errors:`);
+    process.stdout.write("\n" + formatHeader("Validation errors") + "\n");
     for (const err of errors) {
-      console.log(`  - Row ${err.row}: ${err.message}`);
+      process.stdout.write(
+        formatBullet(`Row ${err.row}: ${err.message}`, 0) + "\n",
+      );
     }
   }
 
-  console.log(`\n${valid.length} people validated`);
+  process.stdout.write(
+    "\n" + formatSuccess(`${valid.length} people validated`) + "\n",
+  );
   if (errors.length > 0) {
-    console.log(`${errors.length} rows with errors\n`);
+    process.stdout.write(
+      formatError(`${errors.length} rows with errors`) + "\n\n",
+    );
     return 1;
   }
   return 0;
 }
 
 export async function push(filePath, supabase) {
-  console.log(`Pushing people file: ${filePath}\n`);
+  process.stdout.write(
+    formatHeader(`Pushing people file: ${filePath}`) + "\n\n",
+  );
   const content = await readFile(filePath, "utf-8");
   const format = filePath.endsWith(".csv") ? "csv" : "yaml";
 
   const extractResult = await extractPeopleFile(supabase, content, format);
   if (!extractResult.stored) {
-    console.error(`Failed to store raw file: ${extractResult.error}`);
+    process.stderr.write(
+      formatError(`Failed to store raw file: ${extractResult.error}`) + "\n",
+    );
     return 1;
   }
-  console.log(`  Stored raw file: ${extractResult.path}`);
+  process.stdout.write(
+    formatBullet(`Stored raw file: ${extractResult.path}`, 0) + "\n",
+  );
 
   const result = await transformPeople(supabase);
-  console.log(`\nImported ${result.imported} people`);
+  process.stdout.write(
+    "\n" + formatSuccess(`Imported ${result.imported} people`) + "\n",
+  );
   if (result.errors.length > 0) {
-    console.error(`${result.errors.length} transform errors:`);
-    for (const err of result.errors) console.error(`  - ${err}`);
+    process.stderr.write(
+      formatError(`${result.errors.length} transform errors:`) + "\n",
+    );
+    for (const err of result.errors) {
+      process.stderr.write(formatBullet(err, 1) + "\n");
+    }
     return 1;
   }
   return 0;

--- a/products/map/bin/lib/commands/validate-shacl.js
+++ b/products/map/bin/lib/commands/validate-shacl.js
@@ -1,0 +1,83 @@
+/**
+ * SHACL validation command
+ *
+ * Parses every .ttl file under schema/rdf/ and reports syntax errors.
+ */
+
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import {
+  formatHeader,
+  formatSuccess,
+  formatError,
+  formatBullet,
+} from "@forwardimpact/libcli";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Validate SHACL/Turtle schemas in the package.
+ * @returns {Promise<number>} exit code
+ */
+export async function runValidateShacl() {
+  process.stdout.write(formatHeader("Validating SHACL schema syntax") + "\n\n");
+
+  const rdfDir = join(__dirname, "..", "..", "..", "schema", "rdf");
+
+  try {
+    const { default: N3 } = await import("n3");
+    const { readFile, readdir } = await import("fs/promises");
+
+    const files = await readdir(rdfDir);
+    const ttlFiles = files.filter((f) => f.endsWith(".ttl")).sort();
+
+    if (ttlFiles.length === 0) {
+      process.stderr.write(
+        formatError("No .ttl files found in schema/rdf/") + "\n",
+      );
+      return 1;
+    }
+
+    let totalQuads = 0;
+    const errors = [];
+
+    for (const file of ttlFiles) {
+      const filePath = join(rdfDir, file);
+      const turtleContent = await readFile(filePath, "utf-8");
+
+      try {
+        const parser = new N3.Parser({ format: "text/turtle" });
+        const quads = parser.parse(turtleContent);
+        totalQuads += quads.length;
+        process.stdout.write(
+          formatBullet(`${file} (${quads.length} triples)`, 0) + "\n",
+        );
+      } catch (error) {
+        errors.push({ file, error: error.message });
+        process.stdout.write(
+          formatBullet(`${file}: ${error.message}`, 0) + "\n",
+        );
+      }
+    }
+
+    process.stdout.write("\n");
+    if (errors.length > 0) {
+      process.stderr.write(
+        formatError(`SHACL syntax errors in ${errors.length} file(s)`) + "\n",
+      );
+      return 1;
+    }
+
+    process.stdout.write(
+      formatSuccess(
+        `SHACL syntax valid (${ttlFiles.length} files, ${totalQuads} triples)`,
+      ) + "\n",
+    );
+    return 0;
+  } catch (error) {
+    process.stderr.write(
+      formatError(`SHACL validation error: ${error.message}`) + "\n",
+    );
+    return 1;
+  }
+}

--- a/products/pathway/src/commands/agent-list.js
+++ b/products/pathway/src/commands/agent-list.js
@@ -1,0 +1,164 @@
+/**
+ * Agent listing and summary helpers
+ *
+ * Splits the listing / summary output out of agent.js so the command file
+ * stays focused on orchestration.
+ */
+
+import {
+  getDisciplineAbbreviation,
+  toKebabCase,
+} from "@forwardimpact/libskill/agent";
+import {
+  formatHeader,
+  formatSubheader,
+  formatBullet,
+  SummaryRenderer,
+} from "@forwardimpact/libcli";
+
+const summary = new SummaryRenderer({ process });
+
+/**
+ * Find valid agent combination pairs
+ * @param {Object} data - Pathway data
+ * @param {Object} agentData - Agent-specific data
+ * @returns {Array<{discipline: Object, track: Object, humanDiscipline: Object, humanTrack: Object}>}
+ */
+export function findValidCombinations(data, agentData) {
+  const pairs = [];
+  for (const discipline of agentData.disciplines) {
+    for (const track of agentData.tracks) {
+      const humanDiscipline = data.disciplines.find(
+        (d) => d.id === discipline.id,
+      );
+      const humanTrack = data.tracks.find((t) => t.id === track.id);
+      if (humanDiscipline && humanTrack) {
+        pairs.push({ discipline, track, humanDiscipline, humanTrack });
+      }
+    }
+  }
+  return pairs;
+}
+
+/**
+ * Show agent summary with stats
+ * @param {Object} data - Pathway data
+ * @param {Object} agentData - Agent-specific data
+ * @param {Array} skillsWithAgent - Skills with agent sections
+ */
+export function showAgentSummary(data, agentData, skillsWithAgent) {
+  const validCombinations = findValidCombinations(data, agentData).length;
+  const skillsWithAgentCount = skillsWithAgent.filter((s) => s.agent).length;
+
+  process.stdout.write("\n" + formatHeader("\u{1F916} Agent") + "\n\n");
+  summary.render({
+    title: formatSubheader("Coverage"),
+    items: [
+      {
+        label: "Disciplines",
+        description: `${agentData.disciplines.length}/${data.disciplines.length} with agent definitions`,
+      },
+      {
+        label: "Tracks",
+        description: `${agentData.tracks.length}/${data.tracks.length} with agent definitions`,
+      },
+      {
+        label: "Skills",
+        description: `${skillsWithAgentCount}/${skillsWithAgent.length} with agent sections`,
+      },
+      {
+        label: "Stages",
+        description: `${data.stages.length} available`,
+      },
+    ],
+  });
+  process.stdout.write(
+    "\n" + formatSubheader(`Valid combinations: ${validCombinations}`) + "\n\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway agent --list' for all combinations") +
+      "\n",
+  );
+  process.stdout.write(
+    formatBullet(
+      "Run 'npx fit-pathway agent <discipline> <track>' to generate files",
+    ) + "\n\n",
+  );
+}
+
+/**
+ * List available agent combinations — compact output for piping
+ * @param {Object} data - Pathway data
+ * @param {Object} agentData - Agent-specific data
+ */
+function listAgentCombinationsCompact(data, agentData) {
+  for (const {
+    discipline,
+    track,
+    humanDiscipline,
+    humanTrack,
+  } of findValidCombinations(data, agentData)) {
+    const abbrev = getDisciplineAbbreviation(discipline.id);
+    const agentName = `${abbrev}-${toKebabCase(track.id)}`;
+    const specName = humanDiscipline.specialization || humanDiscipline.id;
+    // Piped output — keep as plain console.log for stable format
+    console.log(
+      `${agentName} ${discipline.id} ${track.id}, ${specName} (${humanTrack.name})`,
+    );
+  }
+}
+
+/**
+ * List available agent combinations — verbose output (markdown)
+ * @param {Object} data - Pathway data
+ * @param {Object} agentData - Agent-specific data
+ */
+function listAgentCombinationsVerbose(data, agentData) {
+  // Markdown headings stay literal so downstream tools can parse them.
+  process.stdout.write("# 🤖 Available Agent Combinations\n\n");
+
+  const agentDisciplineIds = new Set(agentData.disciplines.map((d) => d.id));
+  const agentTrackIds = new Set(agentData.tracks.map((t) => t.id));
+
+  process.stdout.write("## Disciplines with agent definitions:\n\n");
+  for (const discipline of data.disciplines) {
+    const status = agentDisciplineIds.has(discipline.id) ? "✅" : "⬜";
+    process.stdout.write(
+      `  ${status} ${discipline.id} - ${discipline.specialization || discipline.name}\n`,
+    );
+  }
+
+  process.stdout.write("\n## Tracks with agent definitions:\n\n");
+  for (const track of data.tracks) {
+    const status = agentTrackIds.has(track.id) ? "✅" : "⬜";
+    process.stdout.write(`  ${status} ${track.id} - ${track.name}\n`);
+  }
+
+  process.stdout.write("\n## Valid combinations:\n\n");
+  for (const { discipline, track } of findValidCombinations(data, agentData)) {
+    process.stdout.write(
+      `  npx fit-pathway agent ${discipline.id} ${track.id}\n`,
+    );
+  }
+
+  process.stdout.write("\n## Available stages:\n\n");
+  for (const stage of data.stages) {
+    process.stdout.write(
+      `  --stage=${stage.id}: ${stage.description.split(" - ")[0]}\n`,
+    );
+  }
+}
+
+/**
+ * List available agent combinations
+ * @param {Object} data - Pathway data
+ * @param {Object} agentData - Agent-specific data
+ * @param {boolean} verbose - Show verbose output
+ */
+export function listAgentCombinations(data, agentData, verbose = false) {
+  if (verbose) {
+    listAgentCombinationsVerbose(data, agentData);
+  } else {
+    listAgentCombinationsCompact(data, agentData);
+  }
+}

--- a/products/pathway/src/commands/agent.js
+++ b/products/pathway/src/commands/agent.js
@@ -32,14 +32,18 @@ import {
   deriveReferenceLevel,
   deriveAgentSkills,
   generateSkillMarkdown,
-  getDisciplineAbbreviation,
-  toKebabCase,
   interpolateTeamInstructions,
 } from "@forwardimpact/libskill/agent";
 import { deriveToolkit } from "@forwardimpact/libskill/toolkit";
 import { formatAgentProfile } from "../formatters/agent/profile.js";
-import { formatError, formatSuccess } from "@forwardimpact/libcli";
+import {
+  formatError,
+  formatSuccess,
+  formatSubheader,
+  formatBullet,
+} from "@forwardimpact/libcli";
 import { toolkitToPlainList } from "../formatters/toolkit/markdown.js";
+import { showAgentSummary, listAgentCombinations } from "./agent-list.js";
 import {
   generateClaudeCodeSettings,
   writeProfile,
@@ -47,139 +51,9 @@ import {
   writeSkills,
 } from "./agent-io.js";
 
-/**
- * Show agent summary with stats
- * @param {Object} data - Pathway data
- * @param {Object} agentData - Agent-specific data
- * @param {Array} skillsWithAgent - Skills with agent sections
- */
-function showAgentSummary(data, agentData, skillsWithAgent) {
-  // Count valid combinations
-  let validCombinations = 0;
-  for (const discipline of agentData.disciplines) {
-    for (const track of agentData.tracks) {
-      const humanDiscipline = data.disciplines.find(
-        (d) => d.id === discipline.id,
-      );
-      const humanTrack = data.tracks.find((t) => t.id === track.id);
-      if (humanDiscipline && humanTrack) {
-        validCombinations++;
-      }
-    }
-  }
-
-  const skillsWithAgentCount = skillsWithAgent.filter((s) => s.agent).length;
-
-  console.log(`\n🤖 Agent\n`);
-  console.log(
-    `Disciplines: ${agentData.disciplines.length}/${data.disciplines.length} with agent definitions`,
-  );
-  console.log(
-    `Tracks:      ${agentData.tracks.length}/${data.tracks.length} with agent definitions`,
-  );
-  console.log(
-    `Skills:      ${skillsWithAgentCount}/${skillsWithAgent.length} with agent sections`,
-  );
-  console.log(`Stages:      ${data.stages.length} available`);
-  console.log(`\nValid combinations: ${validCombinations}`);
-  console.log(`\nRun 'npx fit-pathway agent --list' for all combinations`);
-  console.log(
-    `Run 'npx fit-pathway agent <discipline> <track>' to generate files\n`,
-  );
-}
-
-/**
- * Find valid agent combination pairs
- * @param {Object} data - Pathway data
- * @param {Object} agentData - Agent-specific data
- * @returns {Array<{discipline: Object, track: Object, humanDiscipline: Object, humanTrack: Object}>}
- */
-export function findValidCombinations(data, agentData) {
-  const pairs = [];
-  for (const discipline of agentData.disciplines) {
-    for (const track of agentData.tracks) {
-      const humanDiscipline = data.disciplines.find(
-        (d) => d.id === discipline.id,
-      );
-      const humanTrack = data.tracks.find((t) => t.id === track.id);
-      if (humanDiscipline && humanTrack) {
-        pairs.push({ discipline, track, humanDiscipline, humanTrack });
-      }
-    }
-  }
-  return pairs;
-}
-
-/**
- * List available agent combinations — compact output for piping
- * @param {Object} data - Pathway data
- * @param {Object} agentData - Agent-specific data
- */
-function listAgentCombinationsCompact(data, agentData) {
-  for (const {
-    discipline,
-    track,
-    humanDiscipline,
-    humanTrack,
-  } of findValidCombinations(data, agentData)) {
-    const abbrev = getDisciplineAbbreviation(discipline.id);
-    const agentName = `${abbrev}-${toKebabCase(track.id)}`;
-    const specName = humanDiscipline.specialization || humanDiscipline.id;
-    console.log(
-      `${agentName} ${discipline.id} ${track.id}, ${specName} (${humanTrack.name})`,
-    );
-  }
-}
-
-/**
- * List available agent combinations — verbose output
- * @param {Object} data - Pathway data
- * @param {Object} agentData - Agent-specific data
- */
-function listAgentCombinationsVerbose(data, agentData) {
-  console.log("# 🤖 Available Agent Combinations\n");
-
-  const agentDisciplineIds = new Set(agentData.disciplines.map((d) => d.id));
-  const agentTrackIds = new Set(agentData.tracks.map((t) => t.id));
-
-  console.log("## Disciplines with agent definitions:\n");
-  for (const discipline of data.disciplines) {
-    const status = agentDisciplineIds.has(discipline.id) ? "✅" : "⬜";
-    console.log(
-      `  ${status} ${discipline.id} - ${discipline.specialization || discipline.name}`,
-    );
-  }
-
-  console.log("\n## Tracks with agent definitions:\n");
-  for (const track of data.tracks) {
-    const status = agentTrackIds.has(track.id) ? "✅" : "⬜";
-    console.log(`  ${status} ${track.id} - ${track.name}`);
-  }
-
-  console.log("\n## Valid combinations:\n");
-  for (const { discipline, track } of findValidCombinations(data, agentData)) {
-    console.log(`  npx fit-pathway agent ${discipline.id} ${track.id}`);
-  }
-
-  console.log("\n## Available stages:\n");
-  for (const stage of data.stages) {
-    console.log(`  --stage=${stage.id}: ${stage.description.split(" - ")[0]}`);
-  }
-}
-
-/**
- * List available agent combinations (clean output for piping)
- * @param {Object} data - Pathway data
- * @param {Object} agentData - Agent-specific data
- * @param {boolean} verbose - Show verbose output
- */
-function listAgentCombinations(data, agentData, verbose = false) {
-  if (verbose) {
-    listAgentCombinationsVerbose(data, agentData);
-  } else {
-    listAgentCombinationsCompact(data, agentData);
-  }
-}
+// Re-export so downstream consumers (build-packs, tests) can import
+// findValidCombinations from './commands/agent.js' as before.
+export { findValidCombinations } from "./agent-list.js";
 
 /**
  * Resolve and validate human + agent entities for a discipline/track pair
@@ -194,15 +68,21 @@ function resolveAgentEntities(data, agentData, disciplineId, trackId) {
   const humanTrack = trackId ? data.tracks.find((t) => t.id === trackId) : null;
 
   if (!humanDiscipline) {
-    console.error(formatError(`Unknown discipline: ${disciplineId}`));
-    console.error("\nAvailable disciplines:");
-    for (const d of data.disciplines) console.error(`  - ${d.id}`);
+    process.stderr.write(
+      formatError(`Unknown discipline: ${disciplineId}`) + "\n",
+    );
+    process.stderr.write("\nAvailable disciplines:\n");
+    for (const d of data.disciplines) {
+      process.stderr.write(formatBullet(d.id, 1) + "\n");
+    }
     process.exit(1);
   }
   if (trackId && !humanTrack) {
-    console.error(formatError(`Unknown track: ${trackId}`));
-    console.error("\nAvailable tracks:");
-    for (const t of data.tracks) console.error(`  - ${t.id}`);
+    process.stderr.write(formatError(`Unknown track: ${trackId}`) + "\n");
+    process.stderr.write("\nAvailable tracks:\n");
+    for (const t of data.tracks) {
+      process.stderr.write(formatBullet(t.id, 1) + "\n");
+    }
     process.exit(1);
   }
 
@@ -214,17 +94,23 @@ function resolveAgentEntities(data, agentData, disciplineId, trackId) {
     : null;
 
   if (!agentDiscipline) {
-    console.error(
-      formatError(`No agent definition for discipline: ${disciplineId}`),
+    process.stderr.write(
+      formatError(`No agent definition for discipline: ${disciplineId}`) + "\n",
     );
-    console.error("\nAgent definitions exist for:");
-    for (const d of agentData.disciplines) console.error(`  - ${d.id}`);
+    process.stderr.write("\nAgent definitions exist for:\n");
+    for (const d of agentData.disciplines) {
+      process.stderr.write(formatBullet(d.id, 1) + "\n");
+    }
     process.exit(1);
   }
   if (trackId && !agentTrack) {
-    console.error(formatError(`No agent definition for track: ${trackId}`));
-    console.error("\nAgent definitions exist for:");
-    for (const t of agentData.tracks) console.error(`  - ${t.id}`);
+    process.stderr.write(
+      formatError(`No agent definition for track: ${trackId}`) + "\n",
+    );
+    process.stderr.write("\nAgent definitions exist for:\n");
+    for (const t of agentData.tracks) {
+      process.stderr.write(formatBullet(t.id, 1) + "\n");
+    }
     process.exit(1);
   }
 
@@ -242,9 +128,10 @@ function printTeamInstructions(agentTrack, humanDiscipline) {
     humanDiscipline,
   });
   if (teamInstructions) {
-    console.log("# Team Instructions (CLAUDE.md)\n");
-    console.log(teamInstructions.trim());
-    console.log("\n---\n");
+    // Markdown output — headings stay literal so downstream tools parse them
+    process.stdout.write("# Team Instructions (CLAUDE.md)\n\n");
+    process.stdout.write(teamInstructions.trim() + "\n");
+    process.stdout.write("\n---\n\n");
   }
 }
 
@@ -264,17 +151,21 @@ async function handleSingleStage({
 }) {
   const stage = data.stages.find((s) => s.id === options.stage);
   if (!stage) {
-    console.error(formatError(`Unknown stage: ${options.stage}`));
-    console.error("\nAvailable stages:");
-    for (const s of data.stages) console.error(`  - ${s.id}`);
+    process.stderr.write(formatError(`Unknown stage: ${options.stage}`) + "\n");
+    process.stderr.write("\nAvailable stages:\n");
+    for (const s of data.stages) {
+      process.stderr.write(formatBullet(s.id, 1) + "\n");
+    }
     process.exit(1);
   }
 
   const profile = generateStageAgentProfile({ ...stageParams, stage });
   const errors = validateAgentProfile(profile);
   if (errors.length > 0) {
-    console.error(formatError("Profile validation failed:"));
-    for (const err of errors) console.error(`  - ${err}`);
+    process.stderr.write(formatError("Profile validation failed:") + "\n");
+    for (const err of errors) {
+      process.stderr.write(formatBullet(err, 1) + "\n");
+    }
     process.exit(1);
   }
 
@@ -283,7 +174,7 @@ async function handleSingleStage({
 
   if (!options.output) {
     printTeamInstructions(agentTrack, humanDiscipline);
-    console.log(formatAgentProfile(profile, agentTemplate));
+    process.stdout.write(formatAgentProfile(profile, agentTemplate) + "\n");
     return;
   }
 
@@ -294,9 +185,9 @@ async function handleSingleStage({
   await writeTeamInstructions(teamInstructions, baseDir);
   await writeProfile(profile, baseDir, agentTemplate);
   await generateClaudeCodeSettings(baseDir, agentData.claudeCodeSettings);
-  console.log("");
-  console.log(
-    formatSuccess(`Generated stage agent: ${profile.frontmatter.name}`),
+  process.stdout.write("\n");
+  process.stdout.write(
+    formatSuccess(`Generated stage agent: ${profile.frontmatter.name}`) + "\n",
   );
 }
 
@@ -338,10 +229,13 @@ async function handleAllStages({
   for (const profile of profiles) {
     const errors = validateAgentProfile(profile);
     if (errors.length > 0) {
-      console.error(
-        formatError(`Profile ${profile.frontmatter.name} validation failed:`),
+      process.stderr.write(
+        formatError(`Profile ${profile.frontmatter.name} validation failed:`) +
+          "\n",
       );
-      for (const err of errors) console.error(`  - ${err}`);
+      for (const err of errors) {
+        process.stderr.write(formatBullet(err, 1) + "\n");
+      }
       process.exit(1);
     }
   }
@@ -349,10 +243,13 @@ async function handleAllStages({
   for (const skill of skillFiles) {
     const errors = validateAgentSkill(skill);
     if (errors.length > 0) {
-      console.error(
-        formatError(`Skill ${skill.frontmatter.name} validation failed:`),
+      process.stderr.write(
+        formatError(`Skill ${skill.frontmatter.name} validation failed:`) +
+          "\n",
       );
-      for (const err of errors) console.error(`  - ${err}`);
+      for (const err of errors) {
+        process.stderr.write(formatBullet(err, 1) + "\n");
+      }
       process.exit(1);
     }
   }
@@ -369,8 +266,8 @@ async function handleAllStages({
   if (!options.output) {
     printTeamInstructions(agentTrack, humanDiscipline);
     for (const profile of profiles) {
-      console.log(formatAgentProfile(profile, agentTemplate));
-      console.log("\n---\n");
+      process.stdout.write(formatAgentProfile(profile, agentTemplate) + "\n");
+      process.stdout.write("\n---\n\n");
     }
     return;
   }
@@ -386,12 +283,14 @@ async function handleAllStages({
   const fileCount = await writeSkills(skillFiles, baseDir, skillTemplates);
   await generateClaudeCodeSettings(baseDir, agentData.claudeCodeSettings);
 
-  console.log("");
-  console.log(formatSuccess(`Generated ${profiles.length} agents:`));
+  process.stdout.write("\n");
+  process.stdout.write(
+    formatSuccess(`Generated ${profiles.length} agents:`) + "\n",
+  );
   for (const profile of profiles) {
-    console.log(`  - ${profile.frontmatter.name}`);
+    process.stdout.write(formatBullet(profile.frontmatter.name, 1) + "\n");
   }
-  console.log(`  Skills: ${fileCount} files`);
+  process.stdout.write(formatSubheader(`Skills: ${fileCount} files`) + "\n");
 }
 
 /**
@@ -428,10 +327,10 @@ export async function runAgentCommand({
   const trackId = options.track;
 
   if (args.length > 1) {
-    console.error(
+    process.stderr.write(
       formatError(
         `Unexpected argument: ${args[1]}. Did you mean --track=${args[1]}?`,
-      ),
+      ) + "\n",
     );
     process.exit(1);
   }

--- a/products/pathway/src/commands/behaviour.js
+++ b/products/pathway/src/commands/behaviour.js
@@ -12,7 +12,12 @@
 
 import { createEntityCommand } from "./command-factory.js";
 import { behaviourToMarkdown } from "../formatters/behaviour/markdown.js";
-import { formatTable } from "@forwardimpact/libcli";
+import {
+  formatTable,
+  formatHeader,
+  formatSubheader,
+  formatBullet,
+} from "@forwardimpact/libcli";
 
 /**
  * Format behaviour list item for --list output
@@ -31,7 +36,7 @@ function formatListItem(behaviour) {
 function formatSummary(behaviours, data) {
   const { drivers } = data;
 
-  console.log(`\n🧠 Behaviours\n`);
+  process.stdout.write("\n" + formatHeader("\u{1F9E0} Behaviours") + "\n\n");
 
   // Summary table
   const rows = behaviours.map((b) => {
@@ -41,10 +46,17 @@ function formatSummary(behaviours, data) {
     return [b.id, b.name, linkedDrivers];
   });
 
-  console.log(formatTable(["ID", "Name", "Drivers"], rows));
-  console.log(`\nTotal: ${behaviours.length} behaviours`);
-  console.log(`\nRun 'npx fit-pathway behaviour --list' for IDs and names`);
-  console.log(`Run 'npx fit-pathway behaviour <id>' for details\n`);
+  process.stdout.write(formatTable(["ID", "Name", "Drivers"], rows) + "\n");
+  process.stdout.write(
+    "\n" + formatSubheader(`Total: ${behaviours.length} behaviours`) + "\n\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway behaviour --list' for IDs and names") +
+      "\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway behaviour <id>' for details") + "\n\n",
+  );
 }
 
 /**

--- a/products/pathway/src/commands/command-factory.js
+++ b/products/pathway/src/commands/command-factory.js
@@ -12,6 +12,12 @@
  */
 
 import { capitalize } from "../formatters/shared.js";
+import {
+  formatSuccess,
+  formatWarning,
+  formatError,
+  formatBullet,
+} from "@forwardimpact/libcli";
 
 /**
  * Create an entity command with standard behavior
@@ -88,8 +94,15 @@ export function createEntityCommand({
  */
 function handleValidate({ data, _entityName, pluralName, validate }) {
   if (!validate) {
-    console.log(`No specific validation for ${pluralName}.`);
-    console.log(`Run 'npx fit-pathway --validate' for full data validation.`);
+    process.stdout.write(
+      formatBullet(`No specific validation for ${pluralName}.`, 0) + "\n",
+    );
+    process.stdout.write(
+      formatBullet(
+        "Run 'npx fit-pathway --validate' for full data validation.",
+        0,
+      ) + "\n",
+    );
     return;
   }
 
@@ -97,21 +110,23 @@ function handleValidate({ data, _entityName, pluralName, validate }) {
   const { errors = [], warnings = [] } = result;
 
   if (errors.length === 0 && warnings.length === 0) {
-    console.log(`✅ ${capitalize(pluralName)} validation passed`);
+    process.stdout.write(
+      formatSuccess(`${capitalize(pluralName)} validation passed`) + "\n",
+    );
     return;
   }
 
   if (warnings.length > 0) {
-    console.log(`⚠️  Warnings:`);
+    process.stdout.write(formatWarning(`${warnings.length} warning(s)`) + "\n");
     for (const w of warnings) {
-      console.log(`  - ${w}`);
+      process.stdout.write(formatBullet(w, 1) + "\n");
     }
   }
 
   if (errors.length > 0) {
-    console.log(`❌ Errors:`);
+    process.stderr.write(formatError(`${errors.length} error(s)`) + "\n");
     for (const e of errors) {
-      console.log(`  - ${e}`);
+      process.stderr.write(formatBullet(e, 1) + "\n");
     }
     process.exit(1);
   }
@@ -134,15 +149,21 @@ function handleDetail({
   const entity = findEntity(data, id);
 
   if (!entity) {
-    console.error(`${capitalize(entityName)} not found: ${id}`);
-    console.error(`Available: ${data[pluralName].map((e) => e.id).join(", ")}`);
+    process.stderr.write(
+      formatError(`${capitalize(entityName)} not found: ${id}`) + "\n",
+    );
+    process.stderr.write(
+      `Available: ${data[pluralName].map((e) => e.id).join(", ")}\n`,
+    );
     process.exit(1);
   }
 
   const view = presentDetail(entity, data, options);
 
   if (!view) {
-    console.error(`Failed to present ${entityName}: ${id}`);
+    process.stderr.write(
+      formatError(`Failed to present ${entityName}: ${id}`) + "\n",
+    );
     process.exit(1);
   }
 
@@ -178,9 +199,11 @@ export function createCompositeCommand({
   return async function runCommand({ data, args, options }) {
     if (args.length < requiredArgs.length) {
       const argsList = requiredArgs.map((arg) => `<${arg}>`).join(" ");
-      console.error(`Usage: npx fit-pathway ${commandName} ${argsList}`);
+      process.stderr.write(
+        formatError(`Usage: npx fit-pathway ${commandName} ${argsList}`) + "\n",
+      );
       if (usageExample) {
-        console.error(`Example: ${usageExample}`);
+        process.stderr.write(`Example: ${usageExample}\n`);
       }
       process.exit(1);
     }
@@ -189,14 +212,16 @@ export function createCompositeCommand({
     const validationError = validateEntities(entities, data, options);
 
     if (validationError) {
-      console.error(validationError);
+      process.stderr.write(formatError(validationError) + "\n");
       process.exit(1);
     }
 
     const view = presenter(entities, data, options);
 
     if (!view) {
-      console.error(`Failed to generate ${commandName} output.`);
+      process.stderr.write(
+        formatError(`Failed to generate ${commandName} output.`) + "\n",
+      );
       process.exit(1);
     }
 

--- a/products/pathway/src/commands/discipline.js
+++ b/products/pathway/src/commands/discipline.js
@@ -12,7 +12,12 @@
 
 import { createEntityCommand } from "./command-factory.js";
 import { disciplineToMarkdown } from "../formatters/discipline/markdown.js";
-import { formatTable } from "@forwardimpact/libcli";
+import {
+  formatTable,
+  formatHeader,
+  formatSubheader,
+  formatBullet,
+} from "@forwardimpact/libcli";
 
 /**
  * Format discipline list item for --list output
@@ -32,7 +37,7 @@ function formatListItem(discipline) {
  * @param {Array} disciplines - Raw discipline entities
  */
 function formatSummary(disciplines) {
-  console.log(`\n📋 Disciplines\n`);
+  process.stdout.write("\n" + formatHeader("\u{1F4CB} Disciplines") + "\n\n");
 
   const rows = disciplines.map((d) => {
     const type = d.isProfessional ? "Professional" : "Management";
@@ -41,10 +46,19 @@ function formatSummary(disciplines) {
     return [d.id, d.specialization || d.id, type, trackStr];
   });
 
-  console.log(formatTable(["ID", "Specialization", "Type", "Tracks"], rows));
-  console.log(`\nTotal: ${disciplines.length} disciplines`);
-  console.log(`\nRun 'npx fit-pathway discipline --list' for IDs and names`);
-  console.log(`Run 'npx fit-pathway discipline <id>' for details\n`);
+  process.stdout.write(
+    formatTable(["ID", "Specialization", "Type", "Tracks"], rows) + "\n",
+  );
+  process.stdout.write(
+    "\n" + formatSubheader(`Total: ${disciplines.length} disciplines`) + "\n\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway discipline --list' for IDs and names") +
+      "\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway discipline <id>' for details") + "\n\n",
+  );
 }
 
 /**

--- a/products/pathway/src/commands/driver.js
+++ b/products/pathway/src/commands/driver.js
@@ -38,7 +38,7 @@ function formatSummary(drivers, data) {
   const { skills, behaviours, framework } = data;
   const emoji = framework ? getConceptEmoji(framework, "driver") : "🎯";
 
-  console.log(`\n${emoji} Drivers\n`);
+  process.stdout.write("\n" + formatHeader(`${emoji} Drivers`) + "\n\n");
 
   const rows = drivers.map((d) => {
     const contributingSkills = skills.filter((s) =>
@@ -50,10 +50,19 @@ function formatSummary(drivers, data) {
     return [d.id, d.name, contributingSkills, contributingBehaviours];
   });
 
-  console.log(formatTable(["ID", "Name", "Skills", "Behaviours"], rows));
-  console.log(`\nTotal: ${drivers.length} drivers`);
-  console.log(`\nRun 'npx fit-pathway driver --list' for IDs and names`);
-  console.log(`Run 'npx fit-pathway driver <id>' for details\n`);
+  process.stdout.write(
+    formatTable(["ID", "Name", "Skills", "Behaviours"], rows) + "\n",
+  );
+  process.stdout.write(
+    "\n" + formatSubheader(`Total: ${drivers.length} drivers`) + "\n\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway driver --list' for IDs and names") +
+      "\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway driver <id>' for details") + "\n\n",
+  );
 }
 
 /**
@@ -66,25 +75,25 @@ function formatDetail(viewAndContext, framework) {
   const view = prepareDriverDetail(driver, { skills, behaviours });
   const emoji = framework ? getConceptEmoji(framework, "driver") : "🎯";
 
-  console.log(formatHeader(`\n${emoji} ${view.name}\n`));
-  console.log(`${view.description}\n`);
+  process.stdout.write("\n" + formatHeader(`${emoji} ${view.name}`) + "\n\n");
+  process.stdout.write(view.description + "\n\n");
 
   // Contributing skills
   if (view.contributingSkills.length > 0) {
-    console.log(formatSubheader("Contributing Skills\n"));
+    process.stdout.write(formatSubheader("Contributing Skills") + "\n\n");
     for (const s of view.contributingSkills) {
-      console.log(formatBullet(s.name, 1));
+      process.stdout.write(formatBullet(s.name, 1) + "\n");
     }
-    console.log();
+    process.stdout.write("\n");
   }
 
   // Contributing behaviours
   if (view.contributingBehaviours.length > 0) {
-    console.log(formatSubheader("Contributing Behaviours\n"));
+    process.stdout.write(formatSubheader("Contributing Behaviours") + "\n\n");
     for (const b of view.contributingBehaviours) {
-      console.log(formatBullet(b.name, 1));
+      process.stdout.write(formatBullet(b.name, 1) + "\n");
     }
-    console.log();
+    process.stdout.write("\n");
   }
 }
 

--- a/products/pathway/src/commands/interview.js
+++ b/products/pathway/src/commands/interview.js
@@ -15,6 +15,7 @@ import {
   INTERVIEW_TYPES,
 } from "../formatters/interview/shared.js";
 import { interviewToMarkdown } from "../formatters/interview/markdown.js";
+import { formatError, horizontalRule } from "@forwardimpact/libcli";
 
 const VALID_TYPES = Object.keys(INTERVIEW_TYPES);
 
@@ -24,7 +25,9 @@ const VALID_TYPES = Object.keys(INTERVIEW_TYPES);
  * @param {Object} options - Options including framework
  */
 function formatInterview(view, options) {
-  console.log(interviewToMarkdown(view, { framework: options.framework }));
+  process.stdout.write(
+    interviewToMarkdown(view, { framework: options.framework }) + "\n",
+  );
 }
 
 /**
@@ -35,10 +38,10 @@ function formatInterview(view, options) {
 function formatAllInterviews(views, options) {
   for (let i = 0; i < views.length; i++) {
     if (i > 0) {
-      console.log("\n" + "─".repeat(80) + "\n");
+      process.stdout.write("\n" + horizontalRule(80) + "\n\n");
     }
-    console.log(
-      interviewToMarkdown(views[i], { framework: options.framework }),
+    process.stdout.write(
+      interviewToMarkdown(views[i], { framework: options.framework }) + "\n",
     );
   }
 }
@@ -50,8 +53,10 @@ export const runInterviewCommand = createCompositeCommand({
     const interviewType = options.type === "full" ? null : options.type;
 
     if (interviewType && !INTERVIEW_TYPES[interviewType]) {
-      console.error(`Unknown interview type: ${interviewType}`);
-      console.error(`Available types: ${VALID_TYPES.join(", ")}`);
+      process.stderr.write(
+        formatError(`Unknown interview type: ${interviewType}`) + "\n",
+      );
+      process.stderr.write(`Available types: ${VALID_TYPES.join(", ")}\n`);
       process.exit(1);
     }
 

--- a/products/pathway/src/commands/job.js
+++ b/products/pathway/src/commands/job.js
@@ -20,7 +20,13 @@ import {
   generateJobTitle,
   generateAllJobs,
 } from "@forwardimpact/libskill/derivation";
-import { formatTable } from "@forwardimpact/libcli";
+import {
+  formatTable,
+  formatHeader,
+  formatSubheader,
+  formatBullet,
+  formatError,
+} from "@forwardimpact/libcli";
 import {
   deriveChecklist,
   formatChecklistMarkdown,
@@ -66,7 +72,9 @@ function printJobList(filteredJobs) {
  */
 function printJobSummary(filteredJobs, options) {
   const trackLabel = options.track ? ` — ${options.track}` : "";
-  console.log(`\n💼 Jobs${trackLabel}\n`);
+  process.stdout.write(
+    "\n" + formatHeader(`\u{1F4BC} Jobs${trackLabel}`) + "\n\n",
+  );
 
   const byDiscipline = {};
   for (const job of filteredJobs) {
@@ -91,15 +99,24 @@ function printJobSummary(filteredJobs, options) {
     info.count,
     info.tracks.size > 0 ? [...info.tracks].join(", ") : "—",
   ]);
-  console.log(
-    formatTable(["ID", "Specialization", "Type", "Jobs", "Tracks"], rows),
+  process.stdout.write(
+    formatTable(["ID", "Specialization", "Type", "Jobs", "Tracks"], rows) +
+      "\n",
   );
-  console.log(`\nTotal: ${filteredJobs.length} valid job combinations`);
-  console.log(
-    `\nRun 'npx fit-pathway job --list' for all combinations with titles`,
+  process.stdout.write(
+    "\n" +
+      formatSubheader(`Total: ${filteredJobs.length} valid job combinations`) +
+      "\n\n",
   );
-  console.log(
-    `Run 'npx fit-pathway job <discipline> <level> [--track=<track>]' for details\n`,
+  process.stdout.write(
+    formatBullet(
+      "Run 'npx fit-pathway job --list' for all combinations with titles",
+    ) + "\n",
+  );
+  process.stdout.write(
+    formatBullet(
+      "Run 'npx fit-pathway job <discipline> <level> [--track=<track>]' for details",
+    ) + "\n\n",
   );
 }
 
@@ -112,22 +129,28 @@ function handleSingleArg(arg, data) {
   const isLevel = data.levels.some((g) => g.id === arg);
   const isTrack = data.tracks.some((t) => t.id === arg);
   if (isLevel) {
-    console.error(
-      `Missing discipline. Usage: npx fit-pathway job <discipline> ${arg} [--track=<track>]`,
+    process.stderr.write(
+      formatError(
+        `Missing discipline. Usage: npx fit-pathway job <discipline> ${arg} [--track=<track>]`,
+      ) + "\n",
     );
-    console.error(
-      `Disciplines: ${data.disciplines.map((d) => d.id).join(", ")}`,
+    process.stderr.write(
+      `Disciplines: ${data.disciplines.map((d) => d.id).join(", ")}\n`,
     );
   } else if (isTrack) {
-    console.error(`Track must be passed as a flag: --track=${arg}`);
-    console.error(
-      `Usage: npx fit-pathway job <discipline> <level> --track=${arg}`,
+    process.stderr.write(
+      formatError(`Track must be passed as a flag: --track=${arg}`) + "\n",
+    );
+    process.stderr.write(
+      `Usage: npx fit-pathway job <discipline> <level> --track=${arg}\n`,
     );
   } else {
-    console.error(
-      "Usage: npx fit-pathway job <discipline> <level> [--track=<track>]",
+    process.stderr.write(
+      formatError(
+        "Usage: npx fit-pathway job <discipline> <level> [--track=<track>]",
+      ) + "\n",
     );
-    console.error("       npx fit-pathway job --list");
+    process.stderr.write("       npx fit-pathway job --list\n");
   }
   process.exit(1);
 }
@@ -150,14 +173,18 @@ function resolveJobEntities(data, args, options) {
     const maybeLevel = data.levels.find((g) => g.id === args[0]);
     const maybeDiscipline = data.disciplines.find((d) => d.id === args[1]);
     if (maybeLevel && maybeDiscipline) {
-      console.error(`Arguments are in the wrong order. Try:`);
-      console.error(
-        `  npx fit-pathway job ${args[1]} ${args[0]}${options.track ? ` --track=${options.track}` : ""}`,
+      process.stderr.write(
+        formatError("Arguments are in the wrong order. Try:") + "\n",
+      );
+      process.stderr.write(
+        `  npx fit-pathway job ${args[1]} ${args[0]}${options.track ? ` --track=${options.track}` : ""}\n`,
       );
     } else {
-      console.error(`Discipline not found: ${args[0]}`);
-      console.error(
-        `Available: ${data.disciplines.map((d) => d.id).join(", ")}`,
+      process.stderr.write(
+        formatError(`Discipline not found: ${args[0]}`) + "\n",
+      );
+      process.stderr.write(
+        `Available: ${data.disciplines.map((d) => d.id).join(", ")}\n`,
       );
     }
     process.exit(1);
@@ -166,23 +193,33 @@ function resolveJobEntities(data, args, options) {
   if (!level) {
     const isTrack = data.tracks.some((t) => t.id === args[1]);
     if (isTrack) {
-      console.error(
-        `Track must be passed as a flag, not a positional argument:`,
+      process.stderr.write(
+        formatError(
+          "Track must be passed as a flag, not a positional argument:",
+        ) + "\n",
       );
-      console.error(
-        `  npx fit-pathway job ${args[0]} <level> --track=${args[1]}`,
+      process.stderr.write(
+        `  npx fit-pathway job ${args[0]} <level> --track=${args[1]}\n`,
       );
-      console.error(`Levels: ${data.levels.map((g) => g.id).join(", ")}`);
+      process.stderr.write(
+        `Levels: ${data.levels.map((g) => g.id).join(", ")}\n`,
+      );
     } else {
-      console.error(`Level not found: ${args[1]}`);
-      console.error(`Available: ${data.levels.map((g) => g.id).join(", ")}`);
+      process.stderr.write(formatError(`Level not found: ${args[1]}`) + "\n");
+      process.stderr.write(
+        `Available: ${data.levels.map((g) => g.id).join(", ")}\n`,
+      );
     }
     process.exit(1);
   }
 
   if (options.track && !track) {
-    console.error(`Track not found: ${options.track}`);
-    console.error(`Available: ${data.tracks.map((t) => t.id).join(", ")}`);
+    process.stderr.write(
+      formatError(`Track not found: ${options.track}`) + "\n",
+    );
+    process.stderr.write(
+      `Available: ${data.tracks.map((t) => t.id).join(", ")}\n`,
+    );
     process.exit(1);
   }
 
@@ -198,8 +235,8 @@ function resolveJobEntities(data, args, options) {
 function handleChecklist(view, data, stageId) {
   const validStages = data.stages.map((s) => s.id);
   if (!validStages.includes(stageId)) {
-    console.error(`Invalid stage: ${stageId}`);
-    console.error(`Available: ${validStages.join(", ")}`);
+    process.stderr.write(formatError(`Invalid stage: ${stageId}`) + "\n");
+    process.stderr.write(`Available: ${validStages.join(", ")}\n`);
     process.exit(1);
   }
 
@@ -211,21 +248,24 @@ function handleChecklist(view, data, stageId) {
   });
 
   if (readChecklist.length === 0 && confirmChecklist.length === 0) {
-    console.log(`\nNo checklist items for ${stageId} stage\n`);
+    process.stdout.write(
+      "\n" +
+        formatSubheader(`No checklist items for ${stageId} stage`) +
+        "\n\n",
+    );
     return;
   }
 
+  // Markdown output (#/##) is intentional — this is consumed as markdown.
   const stageLabel = stageId.charAt(0).toUpperCase() + stageId.slice(1);
-  console.log(`\n# ${view.title} — ${stageLabel} Stage Checklist\n`);
+  process.stdout.write(`\n# ${view.title} — ${stageLabel} Stage Checklist\n\n`);
   if (readChecklist.length > 0) {
-    console.log("## Read-Then-Do\n");
-    console.log(formatChecklistMarkdown(readChecklist));
-    console.log("");
+    process.stdout.write("## Read-Then-Do\n\n");
+    process.stdout.write(formatChecklistMarkdown(readChecklist) + "\n\n");
   }
   if (confirmChecklist.length > 0) {
-    console.log("## Do-Then-Confirm\n");
-    console.log(formatChecklistMarkdown(confirmChecklist));
-    console.log("");
+    process.stdout.write("## Do-Then-Confirm\n\n");
+    process.stdout.write(formatChecklistMarkdown(confirmChecklist) + "\n\n");
   }
 }
 
@@ -247,16 +287,22 @@ function validateTrackFilter(filteredJobs, data, options) {
   if (!options.track || filteredJobs.length > 0) return;
   const trackExists = data.tracks.some((t) => t.id === options.track);
   if (!trackExists) {
-    console.error(`Track not found: ${options.track}`);
-    console.error(`Available: ${data.tracks.map((t) => t.id).join(", ")}`);
+    process.stderr.write(
+      formatError(`Track not found: ${options.track}`) + "\n",
+    );
+    process.stderr.write(
+      `Available: ${data.tracks.map((t) => t.id).join(", ")}\n`,
+    );
   } else {
-    console.error(`No jobs found for track: ${options.track}`);
+    process.stderr.write(
+      formatError(`No jobs found for track: ${options.track}`) + "\n",
+    );
     const trackDisciplines = data.disciplines
       .filter((d) => d.validTracks && d.validTracks.includes(options.track))
       .map((d) => d.id);
     if (trackDisciplines.length > 0) {
-      console.error(
-        `Disciplines with this track: ${trackDisciplines.join(", ")}`,
+      process.stderr.write(
+        `Disciplines with this track: ${trackDisciplines.join(", ")}\n`,
       );
     }
   }
@@ -274,23 +320,23 @@ function reportInvalidCombination(discipline, level, track, data) {
   const combo = track
     ? `${discipline.id} × ${level.id} × ${track.id}`
     : `${discipline.id} × ${level.id}`;
-  console.error(`Invalid combination: ${combo}`);
+  process.stderr.write(formatError(`Invalid combination: ${combo}`) + "\n");
   if (track) {
     const validTracks = discipline.validTracks?.filter((t) => t !== null) || [];
     if (validTracks.length > 0) {
-      console.error(
-        `Valid tracks for ${discipline.id}: ${validTracks.join(", ")}`,
+      process.stderr.write(
+        `Valid tracks for ${discipline.id}: ${validTracks.join(", ")}\n`,
       );
     } else {
-      console.error(`${discipline.id} does not support tracks`);
+      process.stderr.write(`${discipline.id} does not support tracks\n`);
     }
   }
   if (discipline.minLevel) {
     const levelIndex = data.levels.findIndex((g) => g.id === level.id);
     const minIndex = data.levels.findIndex((g) => g.id === discipline.minLevel);
     if (levelIndex >= 0 && minIndex >= 0 && levelIndex < minIndex) {
-      console.error(
-        `${discipline.id} requires minimum level: ${discipline.minLevel}`,
+      process.stderr.write(
+        `${discipline.id} requires minimum level: ${discipline.minLevel}\n`,
       );
     }
   }

--- a/products/pathway/src/commands/level.js
+++ b/products/pathway/src/commands/level.js
@@ -12,7 +12,12 @@
 
 import { createEntityCommand } from "./command-factory.js";
 import { levelToMarkdown } from "../formatters/level/markdown.js";
-import { formatTable } from "@forwardimpact/libcli";
+import {
+  formatTable,
+  formatHeader,
+  formatSubheader,
+  formatBullet,
+} from "@forwardimpact/libcli";
 import { getConceptEmoji } from "@forwardimpact/map/levels";
 import { capitalize } from "../formatters/shared.js";
 
@@ -34,7 +39,7 @@ function formatSummary(levels, data) {
   const { framework } = data;
   const emoji = framework ? getConceptEmoji(framework, "level") : "📊";
 
-  console.log(`\n${emoji} Levels\n`);
+  process.stdout.write("\n" + formatHeader(`${emoji} Levels`) + "\n\n");
 
   const rows = levels.map((g) => [
     g.id,
@@ -44,7 +49,7 @@ function formatSummary(levels, data) {
     capitalize(g.baseSkillProficiencies?.primary || "-"),
   ]);
 
-  console.log(
+  process.stdout.write(
     formatTable(
       [
         "ID",
@@ -54,11 +59,18 @@ function formatSummary(levels, data) {
         "Primary Level",
       ],
       rows,
-    ),
+    ) + "\n",
   );
-  console.log(`\nTotal: ${levels.length} levels`);
-  console.log(`\nRun 'npx fit-pathway level --list' for IDs and titles`);
-  console.log(`Run 'npx fit-pathway level <id>' for details\n`);
+  process.stdout.write(
+    "\n" + formatSubheader(`Total: ${levels.length} levels`) + "\n\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway level --list' for IDs and titles") +
+      "\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway level <id>' for details") + "\n\n",
+  );
 }
 
 /**

--- a/products/pathway/src/commands/progress.js
+++ b/products/pathway/src/commands/progress.js
@@ -15,13 +15,14 @@ import {
   getDefaultTargetLevel,
 } from "../formatters/progress/shared.js";
 import { progressToMarkdown } from "../formatters/progress/markdown.js";
+import { formatError } from "@forwardimpact/libcli";
 
 /**
  * Format progress output
  * @param {Object} view - Presenter view
  */
 function formatProgress(view) {
-  console.log(progressToMarkdown(view));
+  process.stdout.write(progressToMarkdown(view) + "\n");
 }
 
 export const runProgressCommand = createCompositeCommand({
@@ -38,13 +39,17 @@ export const runProgressCommand = createCompositeCommand({
     if (options.compare) {
       targetLevel = data.levels.find((g) => g.id === options.compare);
       if (!targetLevel) {
-        console.error(`Target level not found: ${options.compare}`);
+        process.stderr.write(
+          formatError(`Target level not found: ${options.compare}`) + "\n",
+        );
         process.exit(1);
       }
     } else {
       targetLevel = getDefaultTargetLevel(level, data.levels);
       if (!targetLevel) {
-        console.error("No next level available for progression.");
+        process.stderr.write(
+          formatError("No next level available for progression.") + "\n",
+        );
         process.exit(1);
       }
     }

--- a/products/pathway/src/commands/questions.js
+++ b/products/pathway/src/commands/questions.js
@@ -17,7 +17,12 @@ import {
 import { questionsToMarkdown } from "../formatters/questions/markdown.js";
 import { questionsToYaml } from "../formatters/questions/yaml.js";
 import { questionsToJson } from "../formatters/questions/json.js";
-import { formatTable } from "@forwardimpact/libcli";
+import {
+  formatTable,
+  formatHeader,
+  formatSubheader,
+  formatBullet,
+} from "@forwardimpact/libcli";
 
 /**
  * Parse questions command options
@@ -46,7 +51,7 @@ function showQuestionsSummary(data) {
   const { skills, behaviours } = data;
   const questions = data.questions;
 
-  console.log(`\n❓ Questions\n`);
+  process.stdout.write("\n" + formatHeader("\u2753 Questions") + "\n\n");
 
   // Skill questions by level
   const skillProficiencies = [
@@ -70,8 +75,8 @@ function showQuestionsSummary(data) {
     return [level, count];
   });
 
-  console.log("Skill Questions:");
-  console.log(formatTable(["Level", "Count"], skillRows));
+  process.stdout.write(formatSubheader("Skill Questions") + "\n");
+  process.stdout.write(formatTable(["Level", "Count"], skillRows) + "\n");
 
   // Behaviour questions by maturity
   const maturities = [
@@ -94,13 +99,24 @@ function showQuestionsSummary(data) {
     return [maturity.replace(/_/g, " "), count];
   });
 
-  console.log("\nBehaviour Questions:");
-  console.log(formatTable(["Maturity", "Count"], behaviourRows));
+  process.stdout.write("\n" + formatSubheader("Behaviour Questions") + "\n");
+  process.stdout.write(
+    formatTable(["Maturity", "Count"], behaviourRows) + "\n",
+  );
 
-  console.log(`\nRun 'npx fit-pathway questions --list' for question IDs`);
-  console.log(`Run 'npx fit-pathway questions --stats' for detailed stats`);
-  console.log(
-    `Run 'npx fit-pathway questions --level=practitioner' to filter\n`,
+  process.stdout.write("\n");
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway questions --list' for question IDs") +
+      "\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway questions --stats' for detailed stats") +
+      "\n",
+  );
+  process.stdout.write(
+    formatBullet(
+      "Run 'npx fit-pathway questions --level=practitioner' to filter",
+    ) + "\n\n",
   );
 }
 

--- a/products/pathway/src/commands/skill.js
+++ b/products/pathway/src/commands/skill.js
@@ -15,7 +15,13 @@ import { createEntityCommand } from "./command-factory.js";
 import { skillToMarkdown } from "../formatters/skill/markdown.js";
 import { prepareSkillsList } from "../formatters/skill/shared.js";
 import { getConceptEmoji } from "@forwardimpact/map/levels";
-import { formatTable, formatError } from "@forwardimpact/libcli";
+import {
+  formatTable,
+  formatError,
+  formatHeader,
+  formatSubheader,
+  formatBullet,
+} from "@forwardimpact/libcli";
 import { generateSkillMarkdown } from "@forwardimpact/libskill/agent";
 import { formatAgentSkill } from "../formatters/agent/skill.js";
 
@@ -29,7 +35,7 @@ function formatSummary(skills, data) {
   const { groups, groupOrder } = prepareSkillsList(skills, capabilities);
   const emoji = framework ? getConceptEmoji(framework, "skill") : "📚";
 
-  console.log(`\n${emoji} Skills\n`);
+  process.stdout.write("\n" + formatHeader(`${emoji} Skills`) + "\n\n");
 
   // Summary table by capability
   const rows = groupOrder.map((capability) => {
@@ -38,10 +44,18 @@ function formatSummary(skills, data) {
     return [capability, count, withAgent];
   });
 
-  console.log(formatTable(["Capability", "Count", "Agent"], rows));
-  console.log(`\nTotal: ${skills.length} skills`);
-  console.log(`\nRun 'npx fit-pathway skill --list' for IDs`);
-  console.log(`Run 'npx fit-pathway skill <id>' for details\n`);
+  process.stdout.write(
+    formatTable(["Capability", "Count", "Agent"], rows) + "\n",
+  );
+  process.stdout.write(
+    "\n" + formatSubheader(`Total: ${skills.length} skills`) + "\n\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway skill --list' for IDs") + "\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway skill <id>' for details") + "\n\n",
+  );
 }
 
 /**
@@ -70,10 +84,12 @@ function formatDetail(viewAndContext, framework) {
  */
 async function formatAgentDetail(skill, stages, templateLoader, dataDir) {
   if (!skill.agent) {
-    console.error(formatError(`Skill '${skill.id}' has no agent section`));
-    console.error(`\nSkills with agent support:`);
-    console.error(
-      `  npx fit-pathway skill --list | xargs -I{} sh -c 'npx fit-pathway skill {} --json | jq -e .skill.agent > /dev/null && echo {}'`,
+    process.stderr.write(
+      formatError(`Skill '${skill.id}' has no agent section`) + "\n",
+    );
+    process.stderr.write("\nSkills with agent support:\n");
+    process.stderr.write(
+      `  npx fit-pathway skill --list | xargs -I{} sh -c 'npx fit-pathway skill {} --json | jq -e .skill.agent > /dev/null && echo {}'\n`,
     );
     process.exit(1);
   }
@@ -81,7 +97,7 @@ async function formatAgentDetail(skill, stages, templateLoader, dataDir) {
   const template = templateLoader.load("skill.template.md", dataDir);
   const skillMd = generateSkillMarkdown({ skillData: skill, stages });
   const output = formatAgentSkill(skillMd, template);
-  console.log(output);
+  process.stdout.write(output + "\n");
 }
 
 /**
@@ -131,8 +147,10 @@ export async function runSkillCommand({
     const skill = data.skills.find((s) => s.id === id);
 
     if (!skill) {
-      console.error(formatError(`Skill not found: ${id}`));
-      console.error(`Available: ${data.skills.map((s) => s.id).join(", ")}`);
+      process.stderr.write(formatError(`Skill not found: ${id}`) + "\n");
+      process.stderr.write(
+        `Available: ${data.skills.map((s) => s.id).join(", ")}\n`,
+      );
       process.exit(1);
     }
 

--- a/products/pathway/src/commands/stage.js
+++ b/products/pathway/src/commands/stage.js
@@ -19,6 +19,7 @@ import {
   formatHeader,
   formatSubheader,
   formatBullet,
+  formatWarning,
 } from "@forwardimpact/libcli";
 
 /**
@@ -36,13 +37,13 @@ function formatListItem(stage) {
  * @param {Object} _data - Full data context (unused)
  */
 function formatSummary(stages, _data) {
-  console.log("\n🔄 Stages\n");
+  process.stdout.write("\n" + formatHeader("\u{1F504} Stages") + "\n\n");
 
   // Show lifecycle flow
   const flow = stages
     .map((s) => `${getStageEmoji(stages, s.id)} ${s.name}`)
     .join(" → ");
-  console.log(`Lifecycle: ${flow}\n`);
+  process.stdout.write(formatSubheader(`Lifecycle: ${flow}`) + "\n\n");
 
   const rows = stages.map((s) => {
     const toolCount = s.tools?.length || 0;
@@ -50,10 +51,18 @@ function formatSummary(stages, _data) {
     return [s.id, s.name, s.mode, toolCount, handoffCount];
   });
 
-  console.log(formatTable(["ID", "Name", "Mode", "Tools", "Handoffs"], rows));
-  console.log(`\nTotal: ${stages.length} stages`);
-  console.log(`\nRun 'npx fit-pathway stage --list' for IDs and names`);
-  console.log(`Run 'npx fit-pathway stage <id>' for details\n`);
+  process.stdout.write(
+    formatTable(["ID", "Name", "Mode", "Tools", "Handoffs"], rows) + "\n",
+  );
+  process.stdout.write(
+    "\n" + formatSubheader(`Total: ${stages.length} stages`) + "\n\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway stage --list' for IDs and names") + "\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway stage <id>' for details") + "\n\n",
+  );
 }
 
 /**
@@ -66,51 +75,52 @@ function formatDetail(viewAndContext, _framework) {
   const view = prepareStageDetail(stage);
   const emoji = getStageEmoji(stages, stage.id);
 
-  console.log(formatHeader(`\n${emoji} ${view.name}\n`));
-  console.log(`${view.description}\n`);
+  process.stdout.write("\n" + formatHeader(`${emoji} ${view.name}`) + "\n\n");
+  process.stdout.write(view.description + "\n\n");
 
   // Read checklist
   if (view.readChecklist.length > 0) {
-    console.log(formatSubheader("Read-Then-Do Checklist\n"));
+    process.stdout.write(formatSubheader("Read-Then-Do Checklist") + "\n\n");
     for (const item of view.readChecklist) {
-      console.log(formatBullet(item, 1));
+      process.stdout.write(formatBullet(item, 1) + "\n");
     }
-    console.log();
+    process.stdout.write("\n");
   }
 
   // Confirm checklist
   if (view.confirmChecklist.length > 0) {
-    console.log(formatSubheader("Do-Then-Confirm Checklist\n"));
+    process.stdout.write(formatSubheader("Do-Then-Confirm Checklist") + "\n\n");
     for (const item of view.confirmChecklist) {
-      console.log(formatBullet(item, 1));
+      process.stdout.write(formatBullet(item, 1) + "\n");
     }
-    console.log();
+    process.stdout.write("\n");
   }
 
   // Constraints
   if (view.constraints.length > 0) {
-    console.log(formatSubheader("Constraints\n"));
+    process.stdout.write(formatSubheader("Constraints") + "\n\n");
     for (const item of view.constraints) {
-      console.log(formatBullet(`⚠️  ${item}`, 1));
+      process.stdout.write("  " + formatWarning(item) + "\n");
     }
-    console.log();
+    process.stdout.write("\n");
   }
 
   // Handoffs
   if (view.handoffs.length > 0) {
-    console.log(formatSubheader("Handoffs\n"));
+    process.stdout.write(formatSubheader("Handoffs") + "\n\n");
     for (const handoff of view.handoffs) {
       const targetStage = stages.find((s) => s.id === handoff.target);
       const targetEmoji = getStageEmoji(stages, handoff.target);
       const targetName = targetStage?.name || handoff.target;
-      console.log(
-        formatBullet(`${targetEmoji} ${handoff.label} → ${targetName}`, 1),
+      process.stdout.write(
+        formatBullet(`${targetEmoji} ${handoff.label} → ${targetName}`, 1) +
+          "\n",
       );
       if (handoff.prompt) {
-        console.log(`      "${handoff.prompt}"`);
+        process.stdout.write(`      "${handoff.prompt}"\n`);
       }
     }
-    console.log();
+    process.stdout.write("\n");
   }
 }
 

--- a/products/pathway/src/commands/tool.js
+++ b/products/pathway/src/commands/tool.js
@@ -15,6 +15,8 @@ import {
   formatTable,
   formatHeader,
   formatSubheader,
+  formatBullet,
+  formatError,
 } from "@forwardimpact/libcli";
 
 /**
@@ -50,8 +52,8 @@ export async function runToolCommand({ data, args, options }) {
   const tool = tools.find((t) => t.name.toLowerCase() === name.toLowerCase());
 
   if (!tool) {
-    console.error(`Tool not found: ${name}`);
-    console.error(`Available: ${tools.map((t) => t.name).join(", ")}`);
+    process.stderr.write(formatError(`Tool not found: ${name}`) + "\n");
+    process.stderr.write(`Available: ${tools.map((t) => t.name).join(", ")}\n`);
     process.exit(1);
   }
 
@@ -69,7 +71,7 @@ export async function runToolCommand({ data, args, options }) {
  * @param {number} totalCount - Total tool count
  */
 function formatSummary(tools, totalCount) {
-  console.log(`\n🔧 Tools\n`);
+  process.stdout.write("\n" + formatHeader("\u{1F527} Tools") + "\n\n");
 
   // Show tools sorted by usage count
   const sorted = [...tools].sort((a, b) => b.usages.length - a.usages.length);
@@ -83,15 +85,24 @@ function formatSummary(tools, totalCount) {
         : t.description,
     ]);
 
-  console.log(formatTable(["Tool", "Skills", "Description"], rows));
-  console.log(`\nTotal: ${totalCount} tools`);
-  if (sorted.length > 15) {
-    console.log(`(showing top 15 by usage)`);
-  }
-  console.log(
-    `\nRun 'npx fit-pathway tool --list' for all tool names and descriptions`,
+  process.stdout.write(
+    formatTable(["Tool", "Skills", "Description"], rows) + "\n",
   );
-  console.log(`Run 'npx fit-pathway tool <name>' for details\n`);
+  process.stdout.write(
+    "\n" + formatSubheader(`Total: ${totalCount} tools`) + "\n",
+  );
+  if (sorted.length > 15) {
+    process.stdout.write(formatBullet("(showing top 15 by usage)") + "\n");
+  }
+  process.stdout.write("\n");
+  process.stdout.write(
+    formatBullet(
+      "Run 'npx fit-pathway tool --list' for all tool names and descriptions",
+    ) + "\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway tool <name>' for details") + "\n\n",
+  );
 }
 
 /**
@@ -99,17 +110,16 @@ function formatSummary(tools, totalCount) {
  * @param {Object} tool - Aggregated tool with usages
  */
 function formatDetail(tool) {
-  console.log(formatHeader(`\n🔧 ${tool.name}\n`));
-  console.log(`${tool.description}\n`);
+  process.stdout.write("\n" + formatHeader(`\u{1F527} ${tool.name}`) + "\n\n");
+  process.stdout.write(tool.description + "\n\n");
 
   if (tool.url) {
-    console.log(`Documentation: ${tool.url}\n`);
+    process.stdout.write(`Documentation: ${tool.url}\n\n`);
   }
 
   if (tool.usages.length > 0) {
-    console.log(formatSubheader("Used in Skills\n"));
+    process.stdout.write(formatSubheader("Used in Skills") + "\n\n");
     const rows = tool.usages.map((u) => [u.skillName, u.useWhen]);
-    console.log(formatTable(["Skill", "Use When"], rows));
-    console.log();
+    process.stdout.write(formatTable(["Skill", "Use When"], rows) + "\n\n");
   }
 }

--- a/products/pathway/src/commands/track.js
+++ b/products/pathway/src/commands/track.js
@@ -13,7 +13,12 @@
 import { createEntityCommand } from "./command-factory.js";
 import { trackToMarkdown } from "../formatters/track/markdown.js";
 import { sortTracksByName } from "../formatters/track/shared.js";
-import { formatTable } from "@forwardimpact/libcli";
+import {
+  formatTable,
+  formatHeader,
+  formatSubheader,
+  formatBullet,
+} from "@forwardimpact/libcli";
 import { getConceptEmoji } from "@forwardimpact/map/levels";
 
 /**
@@ -34,7 +39,7 @@ function formatSummary(tracks, data) {
   const { framework, disciplines } = data;
   const emoji = framework ? getConceptEmoji(framework, "track") : "🛤️";
 
-  console.log(`\n${emoji} Tracks\n`);
+  process.stdout.write("\n" + formatHeader(`${emoji} Tracks`) + "\n\n");
 
   const rows = tracks.map((t) => {
     const modCount = Object.keys(t.skillModifiers || {}).length;
@@ -47,10 +52,18 @@ function formatSummary(tracks, data) {
     return [t.id, t.name, modCount, disciplineNames || "—"];
   });
 
-  console.log(formatTable(["ID", "Name", "Modifiers", "Disciplines"], rows));
-  console.log(`\nTotal: ${tracks.length} tracks`);
-  console.log(`\nRun 'npx fit-pathway track --list' for IDs and names`);
-  console.log(`Run 'npx fit-pathway track <id>' for details\n`);
+  process.stdout.write(
+    formatTable(["ID", "Name", "Modifiers", "Disciplines"], rows) + "\n",
+  );
+  process.stdout.write(
+    "\n" + formatSubheader(`Total: ${tracks.length} tracks`) + "\n\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway track --list' for IDs and names") + "\n",
+  );
+  process.stdout.write(
+    formatBullet("Run 'npx fit-pathway track <id>' for details") + "\n\n",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Audited every `bin/` script and pathway command module against the libcli public API. Replaced raw `console.log`/`console.error` calls with libcli helpers (`formatHeader`, `formatSubheader`, `formatSuccess`, `formatError`, `formatWarning`, `formatBullet`, `formatTable`, `horizontalRule`, `indent`, `SummaryRenderer`) so CLI output is consistent, colorized on TTY, and honors `NO_COLOR` / `FORCE_COLOR`.

### Updated bin scripts
- `products/map/bin/fit-map.js` + `lib/commands/{init,activity,people,getdx}.js`
- `products/map/bin/lib/commands/validate-shacl.js` (new; extracted to keep `fit-map.js` under the 400 logical-line cap)
- `products/guide/bin/fit-guide.js` (init now uses `SummaryRenderer`)
- `libraries/libstorage/bin/fit-storage.js`
- `libraries/libuniverse/bin/fit-universe.js`
- `libraries/libdoc/bin/fit-doc.js`

### Updated pathway command modules
- `command-factory.js` — `--validate` output via `formatSuccess`/`Warning`/`Error`, composite command errors via `formatError` to stderr
- Every entity command (`discipline`, `level`, `track`, `behaviour`, `skill`, `driver`, `stage`, `tool`, `job`, `interview`, `progress`, `questions`, `agent`) — summary headers via `formatHeader`, totals via `formatSubheader`, hint lines via `formatBullet`, errors routed to stderr via `formatError`
- `agent.js` — `showAgentSummary` uses `SummaryRenderer`; double-wrapped `console.error(formatError(...))` calls fixed
- `agent-list.js` (new) — extracted `showAgentSummary`, `listAgentCombinations`, and `findValidCombinations` to keep `agent.js` under the 400 logical-line cap; `findValidCombinations` is re-exported from `agent.js` so `build-packs.js` and tests can import it unchanged

### Intentionally left alone
- Piped outputs (`--list`, `--json`, `--skills`, `--tools`) — consumers parse these, so plain `console.log` is correct.
- Markdown-bearing output (`job --checklist`, `agent --list --verbose`, team instructions) — literal `#` / `##` headings are parsed downstream.
- Logger-only library bin scripts (libagent, libgraph, libresource, libtool, libvector, libsupervise, libutil/download-bundle, libtelemetry) — these emit telemetry, not user chrome.

## Test plan

- [x] `eslint .` clean
- [x] `prettier --check .` clean
- [x] 1839/1840 tests pass (1 pre-existing skip, 0 failures)
- [x] Smoke-tested every pathway entity command (`discipline`, `level`, `track`, `behaviour`, `skill`, `stage`, `tool`, `driver`, `questions`, `agent`, `job`) against `products/map/starter` — bold headers, dim bullets, aligned tables, `SummaryRenderer` lists all render correctly
- [x] Smoke-tested error paths (e.g. `discipline bogus` prints `Error: Discipline not found: bogus` to stderr with exit 1)
- [x] Smoke-tested `fit-map init`, `fit-map validate`, `fit-map validate --shacl`

https://claude.ai/code/session_016CuRrARZ8p1tZL2g5WAj4x