### PR TITLE
feat(skills): add gemba-ship and require sub-agent review in spec/plan/implement

### DIFF
--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -41,6 +41,8 @@ apply alongside the skill-specific ones below.
 - [ ] Spec-specific verification commands from the plan pass.
 - [ ] Full diff reviewed against the spec's success criteria — every criterion
       met.
+- [ ] Clean sub-agent review of the full diff completed (fresh context, no prior
+      bias) and every **blocker**, **high**, and **medium** finding addressed.
 - [ ] Spec status set to `done` in `specs/STATUS`.
 
 </do_confirm_checklist>
@@ -144,7 +146,21 @@ For each task:
 
 After all tasks are complete, run the DO-CONFIRM checklist above.
 
-Push all commits to the remote branch.
+### 8. Clean sub-agent review
+
+Before pushing, launch a fresh sub-agent (via the Task tool, no prior
+conversation context) and ask it to review the full diff
+(`git diff origin/main...HEAD`) against `spec.md`, the plan, and CONTRIBUTING.md
+§ Core Rules. Give the reviewer enough context to act independently — spec path,
+plan path, branch name — and instruct it to return findings grouped by severity:
+**blocker**, **high**, **medium**, **low**.
+
+Address every **blocker**, **high**, and **medium** finding before pushing.
+Low-severity findings are optional. If the reviewer raises blockers you disagree
+with, resolve the disagreement explicitly (fix the code, or record the rationale
+for dismissal in the commit message) — silent dismissal is not allowed.
+
+Push all commits to the remote branch only after the review is clean.
 
 ## Handling Problems
 

--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -152,11 +152,15 @@ Before pushing, launch a fresh sub-agent (via the `Agent` tool, no prior
 conversation context) and ask it to review the full diff
 (`git diff origin/main...HEAD`) against `spec.md`, the plan, and CONTRIBUTING.md
 § Core Rules. Give the reviewer enough context to act independently — spec path,
-plan path, branch name — and instruct it to return findings grouped by severity:
-**blocker**, **high**, **medium**, **low**.
+plan path, branch name.
+
+The reviewer must **return findings only** — tell it explicitly not to invoke
+the `gemba-implement` skill (or any other skill) and not to spawn its own
+sub-agents. This prevents recursion. Grade findings using the shared vocabulary
+in [`gemba-spec` § Review Severity](../gemba-spec/SKILL.md#review-severity).
 
 Address every **blocker**, **high**, and **medium** finding before pushing.
-Low-severity findings are optional. If the reviewer raises blockers you disagree
+**Low** findings are optional. If the reviewer raises blockers you disagree
 with, resolve the disagreement explicitly (fix the code, or record the rationale
 for dismissal in the commit message) — silent dismissal is not allowed.
 

--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -148,7 +148,7 @@ After all tasks are complete, run the DO-CONFIRM checklist above.
 
 ### 8. Clean sub-agent review
 
-Before pushing, launch a fresh sub-agent (via the Task tool, no prior
+Before pushing, launch a fresh sub-agent (via the `Agent` tool, no prior
 conversation context) and ask it to review the full diff
 (`git diff origin/main...HEAD`) against `spec.md`, the plan, and CONTRIBUTING.md
 § Core Rules. Give the reviewer enough context to act independently — spec path,

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -190,7 +190,7 @@ from prior `staff-engineer` entries.
    explicitly. If the plan is large, decompose it into parts (see § Large plan
    decomposition).
 5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
-   (via the Task tool, no prior conversation context) and ask it to review
+   (via the `Agent` tool, no prior conversation context) and ask it to review
    `plan-a.md` (and any `plan-a-NN.md` parts) against this skill's DO-CONFIRM
    checklist and the qualities in "Writing a Plan". Instruct it to return
    findings grouped by severity — **blocker**, **high**, **medium**, **low**.

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -47,6 +47,9 @@ no commitment to implement, and a plan has nothing to translate.
 - [ ] Non-obvious decisions explained.
 - [ ] Risks surfaced — no step should surprise the implementer.
 - [ ] Execution recommendation present (which agents, sequential vs parallel).
+- [ ] Clean sub-agent review of `plan-a.md` (and any parts) completed (fresh
+      context, no prior bias) and every **blocker**, **high**, and **medium**
+      finding addressed.
 
 </do_confirm_checklist>
 
@@ -186,8 +189,17 @@ from prior `staff-engineer` entries.
    concrete steps. Each step should be independently verifiable. Surface risks
    explicitly. If the plan is large, decompose it into parts (see § Large plan
    decomposition).
-5. **Present the plan.** Share it for feedback.
-6. **Update STATUS.** When both spec and plan are approved, advance the spec's
+5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
+   (via the Task tool, no prior conversation context) and ask it to review
+   `plan-a.md` (and any `plan-a-NN.md` parts) against this skill's DO-CONFIRM
+   checklist and the qualities in "Writing a Plan". Instruct it to return
+   findings grouped by severity — **blocker**, **high**, **medium**, **low**.
+   Address every blocker, high, and medium finding before moving on.
+   Low-severity findings are optional. If the reviewer raises blockers you
+   disagree with, resolve the disagreement explicitly (revise, or record the
+   rationale for dismissal) — silent dismissal is not allowed.
+6. **Present the plan.** Share it for feedback.
+7. **Update STATUS.** When both spec and plan are approved, advance the spec's
    status from `review` to `planned`. Do not advance while the plan is still
    being iterated on.
 

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -192,12 +192,15 @@ from prior `staff-engineer` entries.
 5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
    (via the `Agent` tool, no prior conversation context) and ask it to review
    `plan-a.md` (and any `plan-a-NN.md` parts) against this skill's DO-CONFIRM
-   checklist and the qualities in "Writing a Plan". Instruct it to return
-   findings grouped by severity — **blocker**, **high**, **medium**, **low**.
-   Address every blocker, high, and medium finding before moving on.
-   Low-severity findings are optional. If the reviewer raises blockers you
-   disagree with, resolve the disagreement explicitly (revise, or record the
-   rationale for dismissal) — silent dismissal is not allowed.
+   checklist and the qualities in "Writing a Plan". The reviewer must **return
+   findings only** — tell it explicitly not to invoke the `gemba-plan` skill or
+   any other skill, and not to spawn its own sub-agents. This prevents
+   recursion. Grade findings using the shared vocabulary in
+   [`gemba-spec` § Review Severity](../gemba-spec/SKILL.md#review-severity).
+   Address every **blocker**, **high**, and **medium** finding before moving on.
+   **Low** findings are optional. If the reviewer raises blockers you disagree
+   with, resolve the disagreement explicitly (revise, or record the rationale
+   for dismissal) — silent dismissal is not allowed.
 6. **Present the plan.** Share it for feedback.
 7. **Update STATUS.** When both spec and plan are approved, advance the spec's
    status from `review` to `planned`. Do not advance while the plan is still

--- a/.claude/skills/gemba-ship/SKILL.md
+++ b/.claude/skills/gemba-ship/SKILL.md
@@ -13,8 +13,8 @@ Take the current feature branch from "ready" to "merged" in one pass.
 ## When to Use
 
 - The current branch is a feature branch with committed work ready to land.
-- **Not applicable on `main`** — abort immediately if `git branch --show-current`
-  returns `main`.
+- **Not applicable on `main`** — abort immediately if
+  `git branch --show-current` returns `main`.
 
 ## Prerequisites
 
@@ -37,8 +37,8 @@ git fetch origin main
 git rebase origin/main
 ```
 
-Resolve conflicts in place, then `git add <files> && git rebase --continue`.
-If a conflict is substantive and cannot be resolved mechanically, abort with
+Resolve conflicts in place, then `git add <files> && git rebase --continue`. If
+a conflict is substantive and cannot be resolved mechanically, abort with
 `git rebase --abort` and stop.
 
 ### Step 3: Run Checks

--- a/.claude/skills/gemba-ship/SKILL.md
+++ b/.claude/skills/gemba-ship/SKILL.md
@@ -2,24 +2,41 @@
 name: gemba-ship
 description: >
   Ship the current feature branch: rebase on main, fix conflicts, run checks,
-  squash commits, create a PR, wait for checks, and merge. Use when a feature
-  branch is ready to land on main.
+  open (or reuse) a PR, wait for checks, and squash-merge into main. Use when
+  a feature branch is ready to land.
 ---
 
 # Ship Feature Branch
 
-Take the current feature branch from "ready" to "merged" in one pass.
+Take the current feature branch from "ready" to "merged" in one pass. Atomic
+commits are preserved on the branch and collapsed into a single commit on `main`
+by GitHub's squash merge — so bisect and review stay useful up to the moment of
+merge.
 
 ## When to Use
 
 - The current branch is a feature branch with committed work ready to land.
-- **Not applicable on `main`** — abort immediately if
-  `git branch --show-current` returns `main`.
+- **Not applicable on `main`** — the Step 1 guard aborts the workflow if the
+  current branch is `main`.
 
 ## Prerequisites
 
 See [`gemba-gh-cli`](../gemba-gh-cli/SKILL.md) for `gh` installation and the
 canonical `gh` query shapes used below.
+
+## Checklists
+
+<do_confirm_checklist goal="Confirm the branch is safe to merge into main">
+
+- [ ] Current branch is not `main`.
+- [ ] Rebased cleanly on `origin/main` (no unresolved conflicts).
+- [ ] `bun run check` and `bun run test` pass locally.
+- [ ] PR exists and its body follows the repo's Summary / Test plan template.
+- [ ] All PR checks reported green by `gh pr checks --watch`.
+- [ ] Merge uses `--squash` so the feature lands as a single conventional commit
+      on `main`.
+
+</do_confirm_checklist>
 
 ## Process
 
@@ -27,7 +44,10 @@ canonical `gh` query shapes used below.
 
 ```sh
 branch=$(git branch --show-current)
-[ "$branch" = "main" ] && { echo "refusing to ship from main"; exit 1; }
+if [ "$branch" = "main" ]; then
+  echo "refusing to ship from main" >&2
+  return 1 2>/dev/null || exit 1
+fi
 ```
 
 ### Step 2: Rebase on Main
@@ -51,21 +71,44 @@ bun run test         # unit tests
 
 Do not proceed until all checks pass.
 
-### Step 4: Squash Commits
+### Step 4: Push the Branch
 
 ```sh
-git reset --soft origin/main
-git commit -m "<type>(<scope>): <summary>"
 git push --force-with-lease -u origin "$branch"
 ```
 
-Use the conventional-commit style already in the repo history.
+Keep atomic commits intact — squashing happens at merge time, not here.
 
-### Step 5: Create PR
+### Step 5: Create or Reuse PR
+
+Probe for an existing open PR on this branch before creating one:
 
 ```sh
-gh pr create --base main --head "$branch" --fill
+pr_number=$(gh pr list --head "$branch" --state open \
+  --json number --jq '.[0].number')
 ```
+
+If `pr_number` is empty, create a new PR using the repo's house body template
+(see
+[`gemba-gh-cli/references/commands.md`](../gemba-gh-cli/references/commands.md)):
+
+```sh
+gh pr create --base main --head "$branch" \
+  --title "<type>(<scope>): <summary>" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- <what changed and why>
+
+## Test plan
+
+- [ ] `bun run check`
+- [ ] `bun run test`
+EOF
+)"
+```
+
+If a PR already exists, reuse it — do not open a duplicate.
 
 ### Step 6: Wait for Checks
 
@@ -73,10 +116,15 @@ gh pr create --base main --head "$branch" --fill
 gh pr checks "$branch" --watch
 ```
 
-If any check fails, stop and report — do not attempt code fixes here.
+If any check fails, stop and report — do not attempt code fixes from inside this
+skill. If no workflow runs against the branch at all, abort after a reasonable
+wait and investigate upstream rather than blocking forever.
 
-### Step 7: Merge
+### Step 7: Squash-Merge
 
 ```sh
-gh pr merge "$branch" --merge --delete-branch
+gh pr merge "$branch" --squash --delete-branch
 ```
+
+GitHub collapses the branch into a single conventional-style commit on `main`
+and deletes the remote branch.

--- a/.claude/skills/gemba-ship/SKILL.md
+++ b/.claude/skills/gemba-ship/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: gemba-ship
+description: >
+  Ship the current feature branch: rebase on main, fix conflicts, run checks,
+  squash commits, create a PR, wait for checks, and merge. Use when a feature
+  branch is ready to land on main.
+---
+
+# Ship Feature Branch
+
+Take the current feature branch from "ready" to "merged" in one pass.
+
+## When to Use
+
+- The current branch is a feature branch with committed work ready to land.
+- **Not applicable on `main`** — abort immediately if `git branch --show-current`
+  returns `main`.
+
+## Prerequisites
+
+See [`gemba-gh-cli`](../gemba-gh-cli/SKILL.md) for `gh` installation and the
+canonical `gh` query shapes used below.
+
+## Process
+
+### Step 1: Guard
+
+```sh
+branch=$(git branch --show-current)
+[ "$branch" = "main" ] && { echo "refusing to ship from main"; exit 1; }
+```
+
+### Step 2: Rebase on Main
+
+```sh
+git fetch origin main
+git rebase origin/main
+```
+
+Resolve conflicts in place, then `git add <files> && git rebase --continue`.
+If a conflict is substantive and cannot be resolved mechanically, abort with
+`git rebase --abort` and stop.
+
+### Step 3: Run Checks
+
+```sh
+bun run check:fix    # auto-fix format and lint
+bun run check        # verify
+bun run test         # unit tests
+```
+
+Do not proceed until all checks pass.
+
+### Step 4: Squash Commits
+
+```sh
+git reset --soft origin/main
+git commit -m "<type>(<scope>): <summary>"
+git push --force-with-lease -u origin "$branch"
+```
+
+Use the conventional-commit style already in the repo history.
+
+### Step 5: Create PR
+
+```sh
+gh pr create --base main --head "$branch" --fill
+```
+
+### Step 6: Wait for Checks
+
+```sh
+gh pr checks "$branch" --watch
+```
+
+If any check fails, stop and report — do not attempt code fixes here.
+
+### Step 7: Merge
+
+```sh
+gh pr merge "$branch" --merge --delete-branch
+```

--- a/.claude/skills/gemba-spec/SKILL.md
+++ b/.claude/skills/gemba-spec/SKILL.md
@@ -131,7 +131,7 @@ status clearly — the caller is responsible for acting on it.
    details — those go in the plan.
 4. **Update STATUS.** Add the spec to `specs/STATUS` with status `draft`.
 5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
-   (via the Task tool, no prior conversation context) and ask it to review
+   (via the `Agent` tool, no prior conversation context) and ask it to review
    `spec.md` against this skill's DO-CONFIRM checklist and the qualities in
    "Writing a Spec". Instruct it to return findings grouped by severity —
    **blocker**, **high**, **medium**, **low**. Address every blocker, high, and

--- a/.claude/skills/gemba-spec/SKILL.md
+++ b/.claude/skills/gemba-spec/SKILL.md
@@ -25,7 +25,7 @@ asked for. If they ask for a spec, write the spec and stop.
 
 ## Checklists
 
-<read_do_checklist goal="Ensure the WHAT/WHY boundary when writing a spec"
+<read_do_checklist goal="Ensure the WHAT/WHY boundary when writing a spec">
 
 - [ ] Only produce the deliverable asked for — if asked for a spec, stop after
       the spec. Do not also write a plan.
@@ -133,15 +133,33 @@ status clearly — the caller is responsible for acting on it.
 5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
    (via the `Agent` tool, no prior conversation context) and ask it to review
    `spec.md` against this skill's DO-CONFIRM checklist and the qualities in
-   "Writing a Spec". Instruct it to return findings grouped by severity —
-   **blocker**, **high**, **medium**, **low**. Address every blocker, high, and
-   medium finding before moving on. Low-severity findings are optional. If the
-   reviewer raises blockers you disagree with, resolve the disagreement
-   explicitly (revise, or record the rationale for dismissal) — silent dismissal
-   is not allowed.
+   "Writing a Spec". The reviewer must **return findings only** — tell it
+   explicitly not to invoke the `gemba-spec` skill or any other skill, and not
+   to spawn its own sub-agents. This prevents recursion. Instruct it to grade
+   each finding using the severity vocabulary in
+   [Review Severity](#review-severity) below. Address every **blocker**,
+   **high**, and **medium** finding before moving on. **Low** findings are
+   optional. If the reviewer raises blockers you disagree with, resolve the
+   disagreement explicitly (revise, or record the rationale for dismissal) —
+   silent dismissal is not allowed.
 6. **Present the spec.** Share it for feedback. Iterate until satisfied, then
    set status to `review` — signalling it is ready for formal evaluation. Stop
    here. The plan is the staff engineer's job.
+
+## Review Severity
+
+The clean sub-agent reviewer grades each finding using this vocabulary. It is
+shared with [`gemba-plan`](../gemba-plan/SKILL.md#review-severity) and
+[`gemba-implement`](../gemba-implement/SKILL.md#review-severity) so grading is
+consistent across the spec → plan → implement arc.
+
+- **Blocker** — The work is broken, dangerous, or materially wrong. Must fix
+  before advancing (approving the spec, advancing status, merging code).
+- **High** — A correctness or clarity problem that will cause rework, confusion,
+  or bugs downstream if shipped. Fix before advancing.
+- **Medium** — A real quality or consistency issue worth fixing now while the
+  context is fresh. Fix before advancing.
+- **Low** — Nit or preference. Optional; document if dismissed.
 
 ## What NOT to Do
 

--- a/.claude/skills/gemba-spec/SKILL.md
+++ b/.claude/skills/gemba-spec/SKILL.md
@@ -46,6 +46,8 @@ asked for. If they ask for a spec, write the spec and stop.
 - [ ] Success criteria are verifiable (a command, observable behaviour, or
       testable property).
 - [ ] No implementation details have leaked in (HOW belongs in the plan).
+- [ ] Clean sub-agent review of `spec.md` completed (fresh context, no prior
+      bias) and every **blocker**, **high**, and **medium** finding addressed.
 
 </do_confirm_checklist>
 
@@ -128,7 +130,16 @@ status clearly — the caller is responsible for acting on it.
 3. **Write the spec.** Focus on WHAT and WHY. Do not include implementation
    details — those go in the plan.
 4. **Update STATUS.** Add the spec to `specs/STATUS` with status `draft`.
-5. **Present the spec.** Share it for feedback. Iterate until satisfied, then
+5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
+   (via the Task tool, no prior conversation context) and ask it to review
+   `spec.md` against this skill's DO-CONFIRM checklist and the qualities in
+   "Writing a Spec". Instruct it to return findings grouped by severity —
+   **blocker**, **high**, **medium**, **low**. Address every blocker, high, and
+   medium finding before moving on. Low-severity findings are optional. If the
+   reviewer raises blockers you disagree with, resolve the disagreement
+   explicitly (revise, or record the rationale for dismissal) — silent dismissal
+   is not allowed.
+6. **Present the spec.** Share it for feedback. Iterate until satisfied, then
    set status to `review` — signalling it is ready for formal evaluation. Stop
    here. The plan is the staff engineer's job.
 

--- a/specs/390-consistent-package-layout/spec.md
+++ b/specs/390-consistent-package-layout/spec.md
@@ -8,34 +8,34 @@ having to read the tree.
 
 ### The tree looks different in every package
 
-The monorepo contains 47 packages (4 products, 9 services, 34 libraries).
-They were written at different times, by different authors, under different
-implicit conventions. Today there is no single layout an agent or contributor
-can rely on:
+The monorepo contains 47 packages (4 products, 9 services, 34 libraries). They
+were written at different times, by different authors, under different implicit
+conventions. Today there is no single layout an agent or contributor can rely
+on:
 
-- **Libraries** dump source files straight at the package root — `index.js`
-  sits next to `base.js`, `client.js`, `server.js`, `loader.js`, and so on.
+- **Libraries** dump source files straight at the package root — `index.js` sits
+  next to `base.js`, `client.js`, `server.js`, `loader.js`, and so on.
   `libskill` has 20 `.js` files at its root; `libtelemetry` has 7; `librpc`,
   `libsupervise`, `libui`, `libutil`, and `libstorage` all follow the same
   pattern. No library uses `src/` (with the sole exception of `libeval`, which
   has both a root `index.js` and a `src/commands/` tree).
-- **Products** are each laid out differently. `products/basecamp` has
-  `src/` + `macos/` + a per-package `justfile` at the root. `products/guide`
-  has no `src/` at all — it keeps a shared helper in `lib/status.js` at the
-  root. `products/map` sprawls across `src/`, `activity/`, `schema/`,
-  `supabase/`, `templates/`, `starter/`, plus a `bin/lib/commands/` tree.
-  Only `products/pathway` resembles the intended shape of `src/` + `bin/` +
-  `templates/` + `test/`. Each of these directories is reasonable in
-  isolation — the problem is not that they exist, but that they are not
-  documented as an allowed shape so new ones keep appearing.
+- **Products** are each laid out differently. `products/basecamp` has `src/` +
+  `macos/` + a per-package `justfile` at the root. `products/guide` has no
+  `src/` at all — it keeps a shared helper in `lib/status.js` at the root.
+  `products/map` sprawls across `src/`, `activity/`, `schema/`, `supabase/`,
+  `templates/`, `starter/`, plus a `bin/lib/commands/` tree. Only
+  `products/pathway` resembles the intended shape of `src/` + `bin/` +
+  `templates/` + `test/`. Each of these directories is reasonable in isolation —
+  the problem is not that they exist, but that they are not documented as an
+  allowed shape so new ones keep appearing.
 - **Services** are actually uniform — `index.js` and `server.js` at the root,
   plus `proto/` and `test/`. The one outlier is `services/pathway`, which has
   grown a lone `src/serialize.js`.
 
 Because each package is a little different, every task that touches a new
-package begins with "where does the code live here?" Agents reason in the
-wrong place, grep finds unexpected matches, and cross-package changes require
-studying each layout from scratch.
+package begins with "where does the code live here?" Agents reason in the wrong
+place, grep finds unexpected matches, and cross-package changes require studying
+each layout from scratch.
 
 ### CLI entry points are mixed with their implementation
 
@@ -55,50 +55,50 @@ bin/lib/
     people.js
 ```
 
-So the Map product keeps its CLI subcommand handlers and shared helpers
-beneath `bin/lib/`, while the Pathway product keeps identical-purpose code
-beneath `src/commands/`. Both are CLIs. Both solve the same problem. An agent
-reading one product cannot transfer what it learns to the other.
+So the Map product keeps its CLI subcommand handlers and shared helpers beneath
+`bin/lib/`, while the Pathway product keeps identical-purpose code beneath
+`src/commands/`. Both are CLIs. Both solve the same problem. An agent reading
+one product cannot transfer what it learns to the other.
 
 ### Domain folders at the root erode the contract
 
 Several packages have grown top-level domain folders that are not in any
 documented allowed-list:
 
-| Package             | Non-conforming root subdirs                                             |
-| ------------------- | ----------------------------------------------------------------------- |
-| `products/guide`    | `lib/` (as a root dir, not under `src/`)                                |
-| `products/map`      | `activity/`                                                             |
-| `libraries/libui`   | `components/`, `css/` (alongside 12 root-level `.js` files)             |
-| `libraries/libsyntheticgen`    | `dsl/`, `engine/`, `tools/`                                  |
-| `libraries/libsyntheticprose`  | `engine/`, `prompts/`                                        |
-| `libraries/libsyntheticrender` | `render/`                                                    |
-| `libraries/libharness`         | `fixture/`, `mock/`, `packages/`                             |
-| `libraries/libgraph`, `libmemory`, `libtelemetry`, `libvector` | `index/`          |
-| `libraries/libagent`, `libgraph`, `libresource`, `libtool`, `libvector` | `processor/` |
+| Package                                                                 | Non-conforming root subdirs                                 |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `products/guide`                                                        | `lib/` (as a root dir, not under `src/`)                    |
+| `products/map`                                                          | `activity/`                                                 |
+| `libraries/libui`                                                       | `components/`, `css/` (alongside 12 root-level `.js` files) |
+| `libraries/libsyntheticgen`                                             | `dsl/`, `engine/`, `tools/`                                 |
+| `libraries/libsyntheticprose`                                           | `engine/`, `prompts/`                                       |
+| `libraries/libsyntheticrender`                                          | `render/`                                                   |
+| `libraries/libharness`                                                  | `fixture/`, `mock/`, `packages/`                            |
+| `libraries/libgraph`, `libmemory`, `libtelemetry`, `libvector`          | `index/`                                                    |
+| `libraries/libagent`, `libgraph`, `libresource`, `libtool`, `libvector` | `processor/`                                                |
 
 Some of these are reasonable domain groupings, some are just code that leaked
-out of `src/` because `src/` never existed. Without an allowed-list contract
-at the package root, each new folder feels equally valid and the layout keeps
+out of `src/` because `src/` never existed. Without an allowed-list contract at
+the package root, each new folder feels equally valid and the layout keeps
 drifting.
 
 Separately, a few packages carry top-level directories that are not code but
 that do earn their place at the package root:
 
-- `products/map/schema/` — published JSON Schema and SHACL files consumers
-  read via subpath exports.
-- `products/map/supabase/` — the Supabase edge project (config, migrations,
-  and edge-function sources treated as one unit by `supabase` tooling).
+- `products/map/schema/` — published JSON Schema and SHACL files consumers read
+  via subpath exports.
+- `products/map/supabase/` — the Supabase edge project (config, migrations, and
+  edge-function sources treated as one unit by `supabase` tooling).
 - `products/basecamp/macos/` — the packaged macOS app bundle.
-- `products/basecamp/config/` — the only package with checked-in runtime
-  config today (`scheduler.json`).
-- `products/basecamp/pkg/` — the only package with build / packaging
-  artifacts today (`build.js` and `macos/` staging for the app bundle).
+- `products/basecamp/config/` — the only package with checked-in runtime config
+  today (`scheduler.json`).
+- `products/basecamp/pkg/` — the only package with build / packaging artifacts
+  today (`build.js` and `macos/` staging for the app bundle).
 - `test/` — directory used by 45 of the 47 packages for test files.
 
-None of these are code that leaked out of `src/`. The spec keeps them and
-adds them to the allowed-list rather than relocating them (see "Allowed root
-subdirs" below).
+None of these are code that leaked out of `src/`. The spec keeps them and adds
+them to the allowed-list rather than relocating them (see "Allowed root subdirs"
+below).
 
 ### Downstream consequences
 
@@ -148,29 +148,28 @@ on-disk shape:
   test/                   Test files
 ```
 
-Any further subdirectories under `src/` are free-form — a package may add
-domain subdirs (`commands/`, `formatters/`, `activity/`, `components/`, etc.)
-as its codebase requires.
+Any further subdirectories under `src/` are free-form — a package may add domain
+subdirs (`commands/`, `formatters/`, `activity/`, `components/`, etc.) as its
+codebase requires.
 
 **Rules:**
 
-1. **Source lives in `src/`.** No `.js`/`.ts` source files at the package
-   root. The package's public entry point is `src/index.js`. Non-source root
-   files (`package.json`, `README.md`, `.gitignore`, `justfile`, and similar
-   metadata) are unaffected.
+1. **Source lives in `src/`.** No `.js`/`.ts` source files at the package root.
+   The package's public entry point is `src/index.js`. Non-source root files
+   (`package.json`, `README.md`, `.gitignore`, `justfile`, and similar metadata)
+   are unaffected.
 
-2. **Services are the one exception.** A service has `index.js` and
-   `server.js` at the package root, because the runtime supervisor and the
-   service harness load those two files by fixed path. All other service
-   source files live under `src/`. Services do not have a `bin/` directory
-   and do not have `src/index.js` — the two fixed-path files are the only
-   entry points. `proto/` and `test/` stay at the service root like every
-   other package.
+2. **Services are the one exception.** A service has `index.js` and `server.js`
+   at the package root, because the runtime supervisor and the service harness
+   load those two files by fixed path. All other service source files live under
+   `src/`. Services do not have a `bin/` directory and do not have
+   `src/index.js` — the two fixed-path files are the only entry points. `proto/`
+   and `test/` stay at the service root like every other package.
 
 3. **Allowed root subdirs are `bin/`, `config/`, `macos/`, `pkg/`, `proto/`,
-   `schema/`, `src/`, `starter/`, `supabase/`, `templates/`, `test/`.** No
-   other directories may appear at the package root. Anything that does not
-   fit becomes a subdirectory of `src/`.
+   `schema/`, `src/`, `starter/`, `supabase/`, `templates/`, `test/`.** No other
+   directories may appear at the package root. Anything that does not fit
+   becomes a subdirectory of `src/`.
 
 4. **`bin/` contains only entry-point scripts.** One file per CLI binary
    declared in `package.json`. No subdirectories. No shared helpers. Entry
@@ -180,15 +179,15 @@ as its codebase requires.
    subcommand is the default. A package with only one command does not need a
    `commands/` directory.
 
-6. **Package-internal libraries live under `src/lib/`.** Use `src/lib/` when
-   a file is a general helper used across the package's other `src/` files. Do
-   not create `src/lib/` for a single file — put it where it is used.
+6. **Package-internal libraries live under `src/lib/`.** Use `src/lib/` when a
+   file is a general helper used across the package's other `src/` files. Do not
+   create `src/lib/` for a single file — put it where it is used.
 
 7. **Per-package `justfile` files are allowed.** A package may have its own
-   `justfile` at the root when it has meaningful package-local task targets
-   (for example `products/basecamp/justfile`). The top-level `justfile`
-   remains the primary entry point; per-package `justfile` files complement
-   it, they do not replace it.
+   `justfile` at the root when it has meaningful package-local task targets (for
+   example `products/basecamp/justfile`). The top-level `justfile` remains the
+   primary entry point; per-package `justfile` files complement it, they do not
+   replace it.
 
 ### Services — exact shape
 
@@ -212,91 +211,86 @@ While we are touching every package, also resolve these drifts:
 1. **Move generated code out of the package root.** Any `generated/` or
    equivalent code-generation output directory inside a package (for example
    `libraries/librpc/generated/`) moves to `src/generated/` or is regenerated
-   into `src/` by `fit-codegen`. Generated code is source code for the
-   package that contains it.
+   into `src/` by `fit-codegen`. Generated code is source code for the package
+   that contains it.
 
-2. **Fold `products/map/activity/` into `src/activity/`.** `activity/`
-   contains queries, validation, and the shared people parser — this is
-   source code that slipped out of `src/`. It moves wholesale, keeping the
-   internal directory shape.
+2. **Fold `products/map/activity/` into `src/activity/`.** `activity/` contains
+   queries, validation, and the shared people parser — this is source code that
+   slipped out of `src/`. It moves wholesale, keeping the internal directory
+   shape.
 
-3. **Move `products/guide/lib/` into `src/lib/`.** Add a `src/index.js` so
-   Guide matches every other package that is not a service.
+3. **Move `products/guide/lib/` into `src/lib/`.** Add a `src/index.js` so Guide
+   matches every other package that is not a service.
 
 4. **Remove `products/map/bin/lib/`.** `client.js`, `package-root.js`, and
    `supabase-cli.js` move to `src/lib/`. The `commands/` subtree moves to
-   `src/commands/`. `bin/fit-map.js` imports from `src/` like every other
-   binary in the monorepo.
+   `src/commands/`. `bin/fit-map.js` imports from `src/` like every other binary
+   in the monorepo.
 
 5. **Fix `libraries/libharness`.** libharness is the outlier in every library
-   audit — it has `index.js`, `fixture/`, `mock/`, and a stale `packages/`
-   tree at the root, plus an orphan zero-byte file at
+   audit — it has `index.js`, `fixture/`, `mock/`, and a stale `packages/` tree
+   at the root, plus an orphan zero-byte file at
    `packages/libharness/mock/config.js`. Bring it into line with every other
    library:
    - Create `src/` and move the current root `index.js` to `src/index.js`.
    - Move `fixture/` to `src/fixture/` and `mock/` to `src/mock/`.
-   - Delete the `packages/` tree. It contains a single zero-byte file with
-     no importers anywhere in the repo and is residue from an aborted
-     workspace experiment.
-   - Rename the package description to match reality — it now provides
-     shared test harness and mock infrastructure for the whole monorepo, not
-     only Guide.
-   - Update the `main`, `exports`, and `files` fields in `package.json` so
-     they point at the new `src/` paths, and update every call site across
-     the monorepo (services, libraries, tests) to import from the updated
-     subpaths.
+   - Delete the `packages/` tree. It contains a single zero-byte file with no
+     importers anywhere in the repo and is residue from an aborted workspace
+     experiment.
+   - Rename the package description to match reality — it now provides shared
+     test harness and mock infrastructure for the whole monorepo, not only
+     Guide.
+   - Update the `main`, `exports`, and `files` fields in `package.json` so they
+     point at the new `src/` paths, and update every call site across the
+     monorepo (services, libraries, tests) to import from the updated subpaths.
 
-6. **Fix `services/pathway/`.** The pathway service is the one outlier in
-   the services tier — it has already grown a lone `src/serialize.js`
-   alongside the usual `index.js` and `server.js`. Under the new rules that
-   is correct shape, but the service's `index.js` and `server.js` still
-   reference code at the service root rather than at `src/`. Make the
-   service match the services template exactly: root files load from
-   `./src/...` and any stray source file at the service root moves into
-   `src/`.
+6. **Fix `services/pathway/`.** The pathway service is the one outlier in the
+   services tier — it has already grown a lone `src/serialize.js` alongside the
+   usual `index.js` and `server.js`. Under the new rules that is correct shape,
+   but the service's `index.js` and `server.js` still reference code at the
+   service root rather than at `src/`. Make the service match the services
+   template exactly: root files load from `./src/...` and any stray source file
+   at the service root moves into `src/`.
 
 7. **Keep `products/pathway/src/formatters/` as the canonical home for
-   formatters.** Pathway already has `src/commands/` and `src/formatters/`.
-   Both are legitimate under the new rules. No change required, but document
-   `src/formatters/` as the canonical place for output formatters that
-   multiple commands share.
+   formatters.** Pathway already has `src/commands/` and `src/formatters/`. Both
+   are legitimate under the new rules. No change required, but document
+   `src/formatters/` as the canonical place for output formatters that multiple
+   commands share.
 
 8. **Reconsider domain subdirs inside libraries.** The `dsl/`, `engine/`,
    `processor/`, `index/`, `render/`, `prompts/`, `components/`, `css/`,
    `tools/` directories that currently live at library roots all move to
-   `src/<name>/` as-is. They keep their current name, just shift one level
-   down.
+   `src/<name>/` as-is. They keep their current name, just shift one level down.
 
 9. **Keep the exceptions called out in `CLAUDE.md` as exceptions.** `libskill`
    remains a pure-function library, `libui` remains a functional DOM library,
    `libsecret` remains stateless crypto, `libtype` remains generated code. The
-   layout rules apply to all four — `src/index.js`, no root-level sources —
-   but their _internal_ style (no classes, no OO+DI) is preserved. The OO+DI
-   exceptions in `CLAUDE.md § OO+DI Architecture` are about _what the code
-   looks like_, not _where it lives_.
+   layout rules apply to all four — `src/index.js`, no root-level sources — but
+   their _internal_ style (no classes, no OO+DI) is preserved. The OO+DI
+   exceptions in `CLAUDE.md § OO+DI Architecture` are about _what the code looks
+   like_, not _where it lives_.
 
 ### Package exports point directly at `src/`
 
-Published `package.json` `main`, `bin`, and `exports` fields point directly
-at files under `src/`. No root-level proxy file. No publish-time build step
-that flattens `src/`. `products/map` already ships this way and it works
-cleanly.
+Published `package.json` `main`, `bin`, and `exports` fields point directly at
+files under `src/`. No root-level proxy file. No publish-time build step that
+flattens `src/`. `products/map` already ships this way and it works cleanly.
 
 Why this over the alternatives:
 
-- **A publish-time flatten is a standing liability.** Every library's
-  publish step has to be kept in sync with its source layout; a
-  misconfigured flatten silently ships the wrong files; tests exercise the
-  source but users exercise the built artifact, so drift goes unnoticed
-  until a consumer breaks. The monorepo has no transpile steps today and
-  should not acquire one for this.
-- **A root-level `index.js` that re-exports from `src/` defeats the rule.**
-  If every library keeps a proxy at the root, the "no source at the root"
-  rule becomes cosmetic.
+- **A publish-time flatten is a standing liability.** Every library's publish
+  step has to be kept in sync with its source layout; a misconfigured flatten
+  silently ships the wrong files; tests exercise the source but users exercise
+  the built artifact, so drift goes unnoticed until a consumer breaks. The
+  monorepo has no transpile steps today and should not acquire one for this.
+- **A root-level `index.js` that re-exports from `src/` defeats the rule.** If
+  every library keeps a proxy at the root, the "no source at the root" rule
+  becomes cosmetic.
 - **The public import specifier does not change.** Consumers keep writing
-  `import { derive } from "@forwardimpact/libskill/derivation"`; the
-  `exports` map resolves that to `./src/derivation.js`. `/src/` never
-  appears in the consumer's import path.
+  `import { derive } from "@forwardimpact/libskill/derivation"`; the `exports`
+  map resolves that to `./src/derivation.js`. `/src/` never appears in the
+  consumer's import path.
 - **Deep-import paths stay 1:1 with on-disk paths.** An agent debugging a
   subpath import sees the same path in the consumer and on disk.
 
@@ -314,16 +308,16 @@ The shape looks like:
 }
 ```
 
-The only thing that breaks is code that reaches _around_ the `exports`
-map — imports that bypass the subpath alias and hit a file path directly.
-Success criterion #9 requires a grep to confirm there are none.
+The only thing that breaks is code that reaches _around_ the `exports` map —
+imports that bypass the subpath alias and hit a file path directly. Success
+criterion #9 requires a grep to confirm there are none.
 
 ### CLAUDE.md is the contract
 
 The standard layout is documented in a new section of `CLAUDE.md` (under
-`## Structure`). The section is the single canonical description of the
-expected package shape. No other document restates it; they reference this
-section. Future new packages copy the shape rather than invent one.
+`## Structure`). The section is the single canonical description of the expected
+package shape. No other document restates it; they reference this section.
+Future new packages copy the shape rather than invent one.
 
 ## Scope
 
@@ -331,30 +325,29 @@ section. Future new packages copy the shape rather than invent one.
 
 - Every package under `products/`, `services/`, and `libraries/`.
 - Every `package.json` `main`, `bin`, and `exports` field whose paths move —
-  rewritten to point directly at `src/` paths, with no root-level proxy
-  files and no build step.
-- Every import statement across the monorepo that references a moved file —
-  both internal workspace imports and deep subpath imports of
-  `@forwardimpact/*` packages.
+  rewritten to point directly at `src/` paths, with no root-level proxy files
+  and no build step.
+- Every import statement across the monorepo that references a moved file — both
+  internal workspace imports and deep subpath imports of `@forwardimpact/*`
+  packages.
 - Generated-code output directories that live inside packages.
 - The `libraries/libharness` restructure — `src/`, deletion of the stale
   `packages/` tree, updated description, and updated call sites.
-- `CLAUDE.md § Structure` — updated to describe the new layout and the
-  allowed root subdirs as a contract. Also reconciled with on-disk reality:
-  the current example tree lists `products/landmark/` and
-  `products/summit/`, which do not exist as packages yet.
+- `CLAUDE.md § Structure` — updated to describe the new layout and the allowed
+  root subdirs as a contract. Also reconciled with on-disk reality: the current
+  example tree lists `products/landmark/` and `products/summit/`, which do not
+  exist as packages yet.
 - Skill files under `.claude/skills/libs-*` and `.claude/skills/fit-*` that
-  describe library and product internals — updated to reference the new
-  paths.
+  describe library and product internals — updated to reference the new paths.
 - Product internals pages under `website/docs/internals/` that show file-tree
   diagrams — updated to reflect the new layout.
 
 ### Out of scope
 
-- Code behaviour changes. No function signatures, no new features, no bug
-  fixes that are not strictly required to make the move land. If a test fails
-  after the move, the fix is "adjust the import" or "adjust the path" — not
-  "rewrite the code".
+- Code behaviour changes. No function signatures, no new features, no bug fixes
+  that are not strictly required to make the move land. If a test fails after
+  the move, the fix is "adjust the import" or "adjust the path" — not "rewrite
+  the code".
 - OO+DI migration (spec 070 already landed). This spec does not change how
   classes are constructed, only where the files live.
 - The internal structure of `libskill`, `libui`, `libsecret`, or `libtype`
@@ -363,48 +356,48 @@ section. Future new packages copy the shape rather than invent one.
 - Service protocol or wire-format changes. `proto/` files stay where they are
   relative to the package root.
 - Wiki content under `wiki/` (it is a submodule and not a package).
-- `website/`, `data/`, `config/`, `specs/`, and other monorepo-root
-  directories. This spec only standardises the shape _inside_ each package.
+- `website/`, `data/`, `config/`, `specs/`, and other monorepo-root directories.
+  This spec only standardises the shape _inside_ each package.
 - Renaming or merging packages. Each existing package keeps its name and its
   boundary.
-- Versioning strategy. Whether the layout move is a major, minor, or patch
-  bump for each package is a release question, handled separately.
+- Versioning strategy. Whether the layout move is a major, minor, or patch bump
+  for each package is a release question, handled separately.
 
 ## Success criteria
 
-1. **Root-level source is zero in products and libraries.** For every
-   package under `products/` and `libraries/`,
-   `git ls-files '<pkg>/*.js' '<pkg>/*.ts'` returns nothing. No `.js` or
-   `.ts` source file sits at the package root in any product or library.
+1. **Root-level source is zero in products and libraries.** For every package
+   under `products/` and `libraries/`, `git ls-files '<pkg>/*.js' '<pkg>/*.ts'`
+   returns nothing. No `.js` or `.ts` source file sits at the package root in
+   any product or library.
 
 2. **Services have exactly two root source files.** For every service under
    `services/`, `git ls-files 'services/<name>/*.js'` returns exactly
    `services/<name>/index.js` and `services/<name>/server.js` — nothing else.
 
-3. **Allowed-list is enforced.** `just check` runs an allowed-root-subdirs
-   check that lists every directory at every package root under `products/`,
-   `services/`, and `libraries/`, and fails with a clear diff if any
-   directory is not one of `bin/`, `config/`, `macos/`, `pkg/`, `proto/`,
-   `schema/`, `src/`, `starter/`, `supabase/`, `templates/`, or `test/`.
-   The check runs in CI and must pass.
+3. **Allowed-list is enforced.** `just check` runs an allowed-root-subdirs check
+   that lists every directory at every package root under `products/`,
+   `services/`, and `libraries/`, and fails with a clear diff if any directory
+   is not one of `bin/`, `config/`, `macos/`, `pkg/`, `proto/`, `schema/`,
+   `src/`, `starter/`, `supabase/`, `templates/`, or `test/`. The check runs in
+   CI and must pass.
 
-4. **Every non-service package has `src/index.js`.** `ls src/index.js` in
-   every `products/*` and every `libraries/*` returns the file. No product
-   or library uses a root `index.js` any more.
+4. **Every non-service package has `src/index.js`.** `ls src/index.js` in every
+   `products/*` and every `libraries/*` returns the file. No product or library
+   uses a root `index.js` any more.
 
 5. **`bin/` is flat.** For every package with a `bin/` directory,
-   `find bin -mindepth 2` returns nothing. `bin/` contains only the
-   entry-point script files listed in the package's `bin` field.
+   `find bin -mindepth 2` returns nothing. `bin/` contains only the entry-point
+   script files listed in the package's `bin` field.
 
-6. **CLI subcommands are under `src/commands/`.** Every file that implements
-   a CLI subcommand lives in its package's `src/commands/` directory.
+6. **CLI subcommands are under `src/commands/`.** Every file that implements a
+   CLI subcommand lives in its package's `src/commands/` directory.
    Specifically, `products/map/bin/lib/commands/` no longer exists — its
    contents are under `products/map/src/commands/`.
 
-7. **Tests pass with no weakening.** `just check` passes on the branch, and
-   the diff between the pre-move and post-move test files contains only
-   import-path changes and file-move renames. No test is disabled, skipped,
-   or marked expected-failure as part of this move.
+7. **Tests pass with no weakening.** `just check` passes on the branch, and the
+   diff between the pre-move and post-move test files contains only import-path
+   changes and file-move renames. No test is disabled, skipped, or marked
+   expected-failure as part of this move.
 
 8. **`CLAUDE.md § Structure` describes the contract.** The section lists the
    allowed root subdirectories, documents the services exception and the
@@ -412,40 +405,38 @@ section. Future new packages copy the shape rather than invent one.
    longer references `products/landmark/` or `products/summit/` as existing
    packages.
 
-9. **Every published subpath export still resolves.** The set of public
-   subpath keys published in `exports` across all `@forwardimpact/*`
-   packages is the same after the move as before. Verifiable by enumerating
-   the pre-move keys (`rg '"\./' libraries/*/package.json products/*/package.json`)
-   and confirming the same set appears in the post-move package.json files,
-   and by a fresh-install smoke test in a clean directory that imports each
-   public subpath and asserts it resolves.
+9. **Every published subpath export still resolves.** The set of public subpath
+   keys published in `exports` across all `@forwardimpact/*` packages is the
+   same after the move as before. Verifiable by enumerating the pre-move keys
+   (`rg '"\./' libraries/*/package.json products/*/package.json`) and confirming
+   the same set appears in the post-move package.json files, and by a
+   fresh-install smoke test in a clean directory that imports each public
+   subpath and asserts it resolves.
 
-10. **libharness is restructured.** `libraries/libharness/packages/` no
-    longer exists. `libharness`'s `fixture/` and `mock/` are under `src/`,
-    along with a `src/index.js`. The package description in `package.json`
-    no longer says "for guide tests" — it describes the cross-monorepo
-    role.
+10. **libharness is restructured.** `libraries/libharness/packages/` no longer
+    exists. `libharness`'s `fixture/` and `mock/` are under `src/`, along with a
+    `src/index.js`. The package description in `package.json` no longer says
+    "for guide tests" — it describes the cross-monorepo role.
 
 ## Risks
 
 - **Published subpath exports are a large, silent blast radius.** Several
   packages (`@forwardimpact/map`, `@forwardimpact/libskill`,
-  `@forwardimpact/libharness`) publish many deep subpath exports that
-  reference specific on-disk files. Every export key has to keep resolving
-  after the move, and a missed key breaks downstream installations only
-  when a consumer happens to import that subpath — not at build time. The
-  `exports`-pointing-at-`src/` strategy contains this to the internal
-  paths, but the plan still needs an enumerated list of every published
-  key and a fresh-install smoke test (see success criterion #9) to catch
-  drift before cutting releases.
+  `@forwardimpact/libharness`) publish many deep subpath exports that reference
+  specific on-disk files. Every export key has to keep resolving after the move,
+  and a missed key breaks downstream installations only when a consumer happens
+  to import that subpath — not at build time. The `exports`-pointing-at-`src/`
+  strategy contains this to the internal paths, but the plan still needs an
+  enumerated list of every published key and a fresh-install smoke test (see
+  success criterion #9) to catch drift before cutting releases.
 
 - **One big diff touches everything.** This is a repo-wide rename. It will
   conflict with any in-flight branch that edits files inside the moved
-  directories. The change should land in a single commit, ideally during a
-  quiet window, with open branches rebased immediately afterwards.
+  directories. The change should land in a single commit, ideally during a quiet
+  window, with open branches rebased immediately afterwards.
 
-- **Codegen paths change.** `fit-codegen` currently writes generated code
-  into each package's root-level `generated/` tree. Moving generated code
-  into `src/generated/` means the codegen pipeline itself changes. If the
-  pipeline is not updated atomically with the layout move, the first
-  post-move `just codegen` run will put files back where they used to be.
+- **Codegen paths change.** `fit-codegen` currently writes generated code into
+  each package's root-level `generated/` tree. Moving generated code into
+  `src/generated/` means the codegen pipeline itself changes. If the pipeline is
+  not updated atomically with the layout move, the first post-move
+  `just codegen` run will put files back where they used to be.


### PR DESCRIPTION
## Summary

- New `gemba-ship` skill: short workflow to rebase, check, push, open (or
  reuse) a PR, watch CI, and squash-merge a feature branch into `main`.
  Atomic commits live on the branch; squashing happens at merge time via
  `gh pr merge --squash` so review/bisect stay useful up to the merge.
- `gemba-spec`, `gemba-plan`, `gemba-implement` now end with a clean
  sub-agent review (fresh context, `Agent` tool) and require all
  blocker/high/medium findings to be addressed. Each skill's DO-CONFIRM
  gains a matching exit-gate item.
- Severity grades (`blocker` / `high` / `medium` / `low`) are defined once
  in `gemba-spec § Review Severity` and referenced from the other two
  skills. The reviewer is explicitly told to return findings only — never
  to invoke the same skill or spawn its own sub-agents — to prevent
  recursion.
- Pre-existing housekeeping included in this branch:
  - Wiki submodule pointer bump from the SessionStart hook (commit
    `76b4869`).
  - Fix to a malformed `<read_do_checklist>` opening tag in
    `gemba-spec/SKILL.md` (was missing the closing `>`).

This branch was itself reviewed by a fresh sub-agent before the squash;
all blocker/high/medium findings were addressed in commit `89e61e1`.

## Test plan

- [x] `bun run check` (format + lint, all file types)
- [x] `bun run test` (full unit test suite)
- [x] Clean sub-agent review of full diff against spec/plan/Core Rules
- [x] Manual verification that `gemba-ship` references match
      `gemba-gh-cli` canonical query shapes