### PR TITLE
fix(map): detect npm-installed supabase CLI via npx fallback

### DIFF
--- a/.claude/skills/fit-map/SKILL.md
+++ b/.claude/skills/fit-map/SKILL.md
@@ -116,6 +116,13 @@ resolve). Both accept YAML or CSV with the same column names.
 
 ### Activity commands
 
+Activity commands require the Supabase CLI. Install via Homebrew
+(`brew install supabase/tap/supabase`) or npm (`npm install supabase`) —
+`fit-map` finds either and falls back to `npx supabase` for the npm-local
+install. See the
+[leadership getting-started guide](../../website/docs/getting-started/leadership/index.md#activity-install-the-supabase-cli)
+for details.
+
 ```sh
 npx fit-map activity start                  # Start the bundled local Supabase stack
 npx fit-map activity stop                   # Stop the local stack

--- a/products/map/bin/lib/commands/activity.js
+++ b/products/map/bin/lib/commands/activity.js
@@ -1,4 +1,4 @@
-import { runSupabase } from "../supabase-cli.js";
+import { createSupabaseCli } from "../supabase-cli.js";
 import { storeRaw } from "@forwardimpact/map/activity/storage";
 import { transformAll } from "@forwardimpact/map/activity/transform";
 import { transformPeople } from "@forwardimpact/map/activity/transform/people";
@@ -16,8 +16,10 @@ import {
 
 const summary = new SummaryRenderer({ process });
 
+const supabaseCli = createSupabaseCli();
+
 export async function start() {
-  await runSupabase(["start"]);
+  await supabaseCli.run(["start"]);
   process.stdout.write("\n");
   process.stdout.write(
     formatSubheader("Export these variables to use the activity layer:") +
@@ -31,17 +33,17 @@ export async function start() {
 }
 
 export async function stop() {
-  await runSupabase(["stop"]);
+  await supabaseCli.run(["stop"]);
   return 0;
 }
 
 export async function status() {
-  await runSupabase(["status"]);
+  await supabaseCli.run(["status"]);
   return 0;
 }
 
 export async function migrate() {
-  await runSupabase(["db", "reset"]);
+  await supabaseCli.run(["db", "reset"]);
   return 0;
 }
 

--- a/products/map/bin/lib/supabase-cli.js
+++ b/products/map/bin/lib/supabase-cli.js
@@ -1,41 +1,100 @@
 /**
- * Wraps the `supabase` CLI so fit-map can run it from the package root
- * without requiring the user to cd into node_modules. Detects a missing
- * binary and reports with a clear install link.
+ * Factory for the fit-map Supabase CLI wrapper.
+ *
+ * `createSupabaseCli()` returns an object with a single `run(args)` method
+ * that spawns the supabase CLI from the fit-map package root without
+ * requiring the user to `cd` into node_modules. It resolves the invocation
+ * the first time it is called and memoizes the result on instance state —
+ * there are no module-level singletons.
+ *
+ * Resolution order:
+ *   1. Bare `supabase` on PATH (Homebrew, system package, npm -g bin on PATH)
+ *   2. `npx --no-install -- supabase` (npm-local install, reached via npx
+ *      walking up from the fit-map package root to the consumer's node_modules)
  */
 
-import { spawn } from "child_process";
+import { spawn as realSpawn } from "child_process";
 import { getPackageRoot } from "./package-root.js";
 
 const SUPABASE_INSTALL_URL =
   "https://supabase.com/docs/guides/local-development";
 
-export async function detectSupabaseCli() {
+function probe(spawnFn, cwd, cmd, args) {
   return new Promise((resolve) => {
-    const child = spawn("supabase", ["--version"], { stdio: "ignore" });
+    const child = spawnFn(cmd, args, { cwd, stdio: "ignore" });
     child.on("error", () => resolve(false));
     child.on("exit", (code) => resolve(code === 0));
   });
 }
 
-export async function runSupabase(args, { cwd } = {}) {
-  const ok = await detectSupabaseCli();
-  if (!ok) {
-    throw new Error(
-      "The `supabase` CLI is not installed or not on your PATH. " +
-        `Install it from ${SUPABASE_INSTALL_URL} and retry.`,
-    );
+// Invariant: must never reject. Both failure modes — ENOENT and non-zero
+// exit — are converted to `false` inside `probe`, so the returned promise
+// always fulfils with either a descriptor or `null`. If this ever changes,
+// a rejected cached promise would re-throw for every subsequent caller.
+async function doResolve(spawnFn, cwd) {
+  if (await probe(spawnFn, cwd, "supabase", ["--version"])) {
+    return { cmd: "supabase", prefix: [] };
+  }
+  if (
+    await probe(spawnFn, cwd, "npx", [
+      "--no-install",
+      "--",
+      "supabase",
+      "--version",
+    ])
+  ) {
+    return { cmd: "npx", prefix: ["--no-install", "--", "supabase"] };
+  }
+  return null;
+}
+
+/**
+ * Create a Supabase CLI wrapper.
+ *
+ * @param {object} [opts]
+ * @param {typeof realSpawn} [opts.spawnFn] - Injected spawn for tests.
+ * @param {string} [opts.cwd] - Working directory for every spawn. Defaults
+ *   to the fit-map package root so npx walks up to the consumer's
+ *   `node_modules/.bin/supabase` on the npm-local install path.
+ * @returns {{
+ *   run: (args: string[]) => Promise<void>,
+ *   resolve: () => Promise<{cmd: string, prefix: string[]} | null>,
+ * }}
+ */
+export function createSupabaseCli({
+  spawnFn = realSpawn,
+  cwd = getPackageRoot(),
+} = {}) {
+  let resolvedPromise = null;
+
+  function resolve() {
+    if (!resolvedPromise) resolvedPromise = doResolve(spawnFn, cwd);
+    return resolvedPromise;
   }
 
-  return new Promise((resolve, reject) => {
-    const child = spawn("supabase", args, {
-      cwd: cwd ?? getPackageRoot(),
-      stdio: "inherit",
+  async function run(args) {
+    const desc = await resolve();
+    if (!desc) {
+      throw new Error(
+        "Could not find the `supabase` CLI. Install it via Homebrew " +
+          "(`brew install supabase/tap/supabase`) or npm " +
+          "(`npm install supabase` in this project, or `npm install -g supabase`), " +
+          `then retry. See ${SUPABASE_INSTALL_URL}.`,
+      );
+    }
+
+    return new Promise((res, rej) => {
+      const child = spawnFn(desc.cmd, [...desc.prefix, ...args], {
+        cwd,
+        stdio: "inherit",
+      });
+      child.on("error", rej);
+      child.on("exit", (code) => {
+        if (code === 0) res();
+        else rej(new Error(`supabase ${args.join(" ")} exited ${code}`));
+      });
     });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`supabase ${args.join(" ")} exited ${code}`));
-    });
-  });
+  }
+
+  return { run, resolve };
 }

--- a/products/map/test/supabase-cli.test.js
+++ b/products/map/test/supabase-cli.test.js
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for the Supabase CLI wrapper factory.
+ *
+ * Uses a manually-constructed fake spawn (matching the DI fake-client
+ * pattern in test/activity/storage.test.js) so we can drive the probe logic
+ * without a real `supabase` or `npx` binary on PATH.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { EventEmitter } from "node:events";
+
+import { createSupabaseCli } from "../bin/lib/supabase-cli.js";
+import { getPackageRoot } from "../bin/lib/package-root.js";
+
+/**
+ * Build a fake spawn function that returns scripted responses in order.
+ * @param {Array<{kind: "exit" | "error", code?: number}>} responses
+ */
+function createFakeSpawn(responses) {
+  let i = 0;
+  function spawnFn(cmd, args, options) {
+    spawnFn.calls.push({ cmd, args, options });
+    const ee = new EventEmitter();
+    const r = responses[i++] ?? { kind: "exit", code: 0 };
+    Promise.resolve().then(() => {
+      if (r.kind === "error") ee.emit("error", new Error("ENOENT"));
+      else ee.emit("exit", r.code ?? 0);
+    });
+    return ee;
+  }
+  spawnFn.calls = [];
+  return spawnFn;
+}
+
+describe("supabase-cli", () => {
+  test("bare supabase succeeds → resolves supabase descriptor", async () => {
+    const spawnFn = createFakeSpawn([{ kind: "exit", code: 0 }]);
+    const cli = createSupabaseCli({ spawnFn });
+    const desc = await cli.resolve();
+    assert.deepStrictEqual(desc, { cmd: "supabase", prefix: [] });
+    assert.strictEqual(spawnFn.calls.length, 1);
+    assert.strictEqual(spawnFn.calls[0].cmd, "supabase");
+    assert.deepStrictEqual(spawnFn.calls[0].args, ["--version"]);
+    assert.strictEqual(spawnFn.calls[0].options.cwd, getPackageRoot());
+    assert.strictEqual(spawnFn.calls[0].options.stdio, "ignore");
+  });
+
+  test("bare supabase errors (ENOENT), npx succeeds → npx descriptor", async () => {
+    const spawnFn = createFakeSpawn([
+      { kind: "error" },
+      { kind: "exit", code: 0 },
+    ]);
+    const cli = createSupabaseCli({ spawnFn });
+    const desc = await cli.resolve();
+    assert.deepStrictEqual(desc, {
+      cmd: "npx",
+      prefix: ["--no-install", "--", "supabase"],
+    });
+    assert.strictEqual(spawnFn.calls.length, 2);
+    assert.strictEqual(spawnFn.calls[1].cmd, "npx");
+    assert.deepStrictEqual(spawnFn.calls[1].args, [
+      "--no-install",
+      "--",
+      "supabase",
+      "--version",
+    ]);
+    assert.strictEqual(spawnFn.calls[1].options.cwd, getPackageRoot());
+  });
+
+  test("bare supabase exits non-zero, npx succeeds → npx descriptor", async () => {
+    const spawnFn = createFakeSpawn([
+      { kind: "exit", code: 1 },
+      { kind: "exit", code: 0 },
+    ]);
+    const cli = createSupabaseCli({ spawnFn });
+    const desc = await cli.resolve();
+    assert.deepStrictEqual(desc, {
+      cmd: "npx",
+      prefix: ["--no-install", "--", "supabase"],
+    });
+    assert.strictEqual(spawnFn.calls.length, 2);
+  });
+
+  test("both probes fail → run rejects with install instructions", async () => {
+    const spawnFn = createFakeSpawn([
+      { kind: "error" },
+      { kind: "exit", code: 1 },
+    ]);
+    const cli = createSupabaseCli({ spawnFn });
+    await assert.rejects(
+      () => cli.run(["start"]),
+      (err) => {
+        assert.ok(/brew install/.test(err.message), "mentions brew");
+        assert.ok(/npm install/.test(err.message), "mentions npm install");
+        assert.ok(/supabase\.com\/docs/.test(err.message), "includes docs URL");
+        return true;
+      },
+    );
+  });
+
+  test("resolve memoizes across calls on the same instance", async () => {
+    const spawnFn = createFakeSpawn([{ kind: "exit", code: 0 }]);
+    const cli = createSupabaseCli({ spawnFn });
+    const first = await cli.resolve();
+    const second = await cli.resolve();
+    assert.deepStrictEqual(first, second);
+    assert.strictEqual(spawnFn.calls.length, 1);
+  });
+
+  test("separate instances do not share cached descriptors", async () => {
+    const spawnFn = createFakeSpawn([
+      { kind: "exit", code: 0 },
+      { kind: "exit", code: 0 },
+    ]);
+    const a = createSupabaseCli({ spawnFn });
+    const b = createSupabaseCli({ spawnFn });
+    await a.resolve();
+    await b.resolve();
+    assert.strictEqual(spawnFn.calls.length, 2);
+  });
+
+  test("run invokes the resolved bare-supabase descriptor", async () => {
+    const spawnFn = createFakeSpawn([
+      { kind: "exit", code: 0 }, // bare supabase probe
+      { kind: "exit", code: 0 }, // actual db reset
+    ]);
+    const cli = createSupabaseCli({ spawnFn });
+    await cli.run(["db", "reset"]);
+    assert.strictEqual(spawnFn.calls.length, 2);
+
+    // Probe call
+    assert.strictEqual(spawnFn.calls[0].cmd, "supabase");
+    assert.deepStrictEqual(spawnFn.calls[0].args, ["--version"]);
+
+    // Execution call
+    const execCall = spawnFn.calls[1];
+    assert.strictEqual(execCall.cmd, "supabase");
+    assert.deepStrictEqual(execCall.args, ["db", "reset"]);
+    assert.strictEqual(execCall.options.cwd, getPackageRoot());
+    assert.strictEqual(execCall.options.stdio, "inherit");
+  });
+
+  test("run invokes the resolved npx descriptor", async () => {
+    const spawnFn = createFakeSpawn([
+      { kind: "error" }, // bare supabase probe
+      { kind: "exit", code: 0 }, // npx probe
+      { kind: "exit", code: 0 }, // actual db reset
+    ]);
+    const cli = createSupabaseCli({ spawnFn });
+    await cli.run(["db", "reset"]);
+    assert.strictEqual(spawnFn.calls.length, 3);
+
+    // Probe calls
+    assert.strictEqual(spawnFn.calls[0].cmd, "supabase");
+    assert.deepStrictEqual(spawnFn.calls[0].args, ["--version"]);
+    assert.strictEqual(spawnFn.calls[1].cmd, "npx");
+    assert.deepStrictEqual(spawnFn.calls[1].args, [
+      "--no-install",
+      "--",
+      "supabase",
+      "--version",
+    ]);
+
+    // Execution call
+    const execCall = spawnFn.calls[2];
+    assert.strictEqual(execCall.cmd, "npx");
+    assert.deepStrictEqual(execCall.args, [
+      "--no-install",
+      "--",
+      "supabase",
+      "db",
+      "reset",
+    ]);
+    assert.strictEqual(execCall.options.cwd, getPackageRoot());
+    assert.strictEqual(execCall.options.stdio, "inherit");
+  });
+
+  test("run rejects when the spawned command exits non-zero", async () => {
+    const spawnFn = createFakeSpawn([
+      { kind: "exit", code: 0 }, // bare supabase probe
+      { kind: "exit", code: 2 }, // actual db reset
+    ]);
+    const cli = createSupabaseCli({ spawnFn });
+    await assert.rejects(
+      () => cli.run(["db", "reset"]),
+      /supabase db reset exited 2/,
+    );
+  });
+});

--- a/specs/390-consistent-package-layout/spec.md
+++ b/specs/390-consistent-package-layout/spec.md
@@ -8,34 +8,34 @@ having to read the tree.
 
 ### The tree looks different in every package
 
-The monorepo contains 47 packages (4 products, 9 services, 34 libraries).
-They were written at different times, by different authors, under different
-implicit conventions. Today there is no single layout an agent or contributor
-can rely on:
+The monorepo contains 47 packages (4 products, 9 services, 34 libraries). They
+were written at different times, by different authors, under different implicit
+conventions. Today there is no single layout an agent or contributor can rely
+on:
 
-- **Libraries** dump source files straight at the package root — `index.js`
-  sits next to `base.js`, `client.js`, `server.js`, `loader.js`, and so on.
+- **Libraries** dump source files straight at the package root — `index.js` sits
+  next to `base.js`, `client.js`, `server.js`, `loader.js`, and so on.
   `libskill` has 20 `.js` files at its root; `libtelemetry` has 7; `librpc`,
   `libsupervise`, `libui`, `libutil`, and `libstorage` all follow the same
   pattern. No library uses `src/` (with the sole exception of `libeval`, which
   has both a root `index.js` and a `src/commands/` tree).
-- **Products** are each laid out differently. `products/basecamp` has
-  `src/` + `macos/` + a per-package `justfile` at the root. `products/guide`
-  has no `src/` at all — it keeps a shared helper in `lib/status.js` at the
-  root. `products/map` sprawls across `src/`, `activity/`, `schema/`,
-  `supabase/`, `templates/`, `starter/`, plus a `bin/lib/commands/` tree.
-  Only `products/pathway` resembles the intended shape of `src/` + `bin/` +
-  `templates/` + `test/`. Each of these directories is reasonable in
-  isolation — the problem is not that they exist, but that they are not
-  documented as an allowed shape so new ones keep appearing.
+- **Products** are each laid out differently. `products/basecamp` has `src/` +
+  `macos/` + a per-package `justfile` at the root. `products/guide` has no
+  `src/` at all — it keeps a shared helper in `lib/status.js` at the root.
+  `products/map` sprawls across `src/`, `activity/`, `schema/`, `supabase/`,
+  `templates/`, `starter/`, plus a `bin/lib/commands/` tree. Only
+  `products/pathway` resembles the intended shape of `src/` + `bin/` +
+  `templates/` + `test/`. Each of these directories is reasonable in isolation —
+  the problem is not that they exist, but that they are not documented as an
+  allowed shape so new ones keep appearing.
 - **Services** are actually uniform — `index.js` and `server.js` at the root,
   plus `proto/` and `test/`. The one outlier is `services/pathway`, which has
   grown a lone `src/serialize.js`.
 
 Because each package is a little different, every task that touches a new
-package begins with "where does the code live here?" Agents reason in the
-wrong place, grep finds unexpected matches, and cross-package changes require
-studying each layout from scratch.
+package begins with "where does the code live here?" Agents reason in the wrong
+place, grep finds unexpected matches, and cross-package changes require studying
+each layout from scratch.
 
 ### CLI entry points are mixed with their implementation
 
@@ -55,50 +55,50 @@ bin/lib/
     people.js
 ```
 
-So the Map product keeps its CLI subcommand handlers and shared helpers
-beneath `bin/lib/`, while the Pathway product keeps identical-purpose code
-beneath `src/commands/`. Both are CLIs. Both solve the same problem. An agent
-reading one product cannot transfer what it learns to the other.
+So the Map product keeps its CLI subcommand handlers and shared helpers beneath
+`bin/lib/`, while the Pathway product keeps identical-purpose code beneath
+`src/commands/`. Both are CLIs. Both solve the same problem. An agent reading
+one product cannot transfer what it learns to the other.
 
 ### Domain folders at the root erode the contract
 
 Several packages have grown top-level domain folders that are not in any
 documented allowed-list:
 
-| Package             | Non-conforming root subdirs                                             |
-| ------------------- | ----------------------------------------------------------------------- |
-| `products/guide`    | `lib/` (as a root dir, not under `src/`)                                |
-| `products/map`      | `activity/`                                                             |
-| `libraries/libui`   | `components/`, `css/` (alongside 12 root-level `.js` files)             |
-| `libraries/libsyntheticgen`    | `dsl/`, `engine/`, `tools/`                                  |
-| `libraries/libsyntheticprose`  | `engine/`, `prompts/`                                        |
-| `libraries/libsyntheticrender` | `render/`                                                    |
-| `libraries/libharness`         | `fixture/`, `mock/`, `packages/`                             |
-| `libraries/libgraph`, `libmemory`, `libtelemetry`, `libvector` | `index/`          |
-| `libraries/libagent`, `libgraph`, `libresource`, `libtool`, `libvector` | `processor/` |
+| Package                                                                 | Non-conforming root subdirs                                 |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `products/guide`                                                        | `lib/` (as a root dir, not under `src/`)                    |
+| `products/map`                                                          | `activity/`                                                 |
+| `libraries/libui`                                                       | `components/`, `css/` (alongside 12 root-level `.js` files) |
+| `libraries/libsyntheticgen`                                             | `dsl/`, `engine/`, `tools/`                                 |
+| `libraries/libsyntheticprose`                                           | `engine/`, `prompts/`                                       |
+| `libraries/libsyntheticrender`                                          | `render/`                                                   |
+| `libraries/libharness`                                                  | `fixture/`, `mock/`, `packages/`                            |
+| `libraries/libgraph`, `libmemory`, `libtelemetry`, `libvector`          | `index/`                                                    |
+| `libraries/libagent`, `libgraph`, `libresource`, `libtool`, `libvector` | `processor/`                                                |
 
 Some of these are reasonable domain groupings, some are just code that leaked
-out of `src/` because `src/` never existed. Without an allowed-list contract
-at the package root, each new folder feels equally valid and the layout keeps
+out of `src/` because `src/` never existed. Without an allowed-list contract at
+the package root, each new folder feels equally valid and the layout keeps
 drifting.
 
 Separately, a few packages carry top-level directories that are not code but
 that do earn their place at the package root:
 
-- `products/map/schema/` — published JSON Schema and SHACL files consumers
-  read via subpath exports.
-- `products/map/supabase/` — the Supabase edge project (config, migrations,
-  and edge-function sources treated as one unit by `supabase` tooling).
+- `products/map/schema/` — published JSON Schema and SHACL files consumers read
+  via subpath exports.
+- `products/map/supabase/` — the Supabase edge project (config, migrations, and
+  edge-function sources treated as one unit by `supabase` tooling).
 - `products/basecamp/macos/` — the packaged macOS app bundle.
-- `products/basecamp/config/` — the only package with checked-in runtime
-  config today (`scheduler.json`).
-- `products/basecamp/pkg/` — the only package with build / packaging
-  artifacts today (`build.js` and `macos/` staging for the app bundle).
+- `products/basecamp/config/` — the only package with checked-in runtime config
+  today (`scheduler.json`).
+- `products/basecamp/pkg/` — the only package with build / packaging artifacts
+  today (`build.js` and `macos/` staging for the app bundle).
 - `test/` — directory used by 45 of the 47 packages for test files.
 
-None of these are code that leaked out of `src/`. The spec keeps them and
-adds them to the allowed-list rather than relocating them (see "Allowed root
-subdirs" below).
+None of these are code that leaked out of `src/`. The spec keeps them and adds
+them to the allowed-list rather than relocating them (see "Allowed root subdirs"
+below).
 
 ### Downstream consequences
 
@@ -148,29 +148,28 @@ on-disk shape:
   test/                   Test files
 ```
 
-Any further subdirectories under `src/` are free-form — a package may add
-domain subdirs (`commands/`, `formatters/`, `activity/`, `components/`, etc.)
-as its codebase requires.
+Any further subdirectories under `src/` are free-form — a package may add domain
+subdirs (`commands/`, `formatters/`, `activity/`, `components/`, etc.) as its
+codebase requires.
 
 **Rules:**
 
-1. **Source lives in `src/`.** No `.js`/`.ts` source files at the package
-   root. The package's public entry point is `src/index.js`. Non-source root
-   files (`package.json`, `README.md`, `.gitignore`, `justfile`, and similar
-   metadata) are unaffected.
+1. **Source lives in `src/`.** No `.js`/`.ts` source files at the package root.
+   The package's public entry point is `src/index.js`. Non-source root files
+   (`package.json`, `README.md`, `.gitignore`, `justfile`, and similar metadata)
+   are unaffected.
 
-2. **Services are the one exception.** A service has `index.js` and
-   `server.js` at the package root, because the runtime supervisor and the
-   service harness load those two files by fixed path. All other service
-   source files live under `src/`. Services do not have a `bin/` directory
-   and do not have `src/index.js` — the two fixed-path files are the only
-   entry points. `proto/` and `test/` stay at the service root like every
-   other package.
+2. **Services are the one exception.** A service has `index.js` and `server.js`
+   at the package root, because the runtime supervisor and the service harness
+   load those two files by fixed path. All other service source files live under
+   `src/`. Services do not have a `bin/` directory and do not have
+   `src/index.js` — the two fixed-path files are the only entry points. `proto/`
+   and `test/` stay at the service root like every other package.
 
 3. **Allowed root subdirs are `bin/`, `config/`, `macos/`, `pkg/`, `proto/`,
-   `schema/`, `src/`, `starter/`, `supabase/`, `templates/`, `test/`.** No
-   other directories may appear at the package root. Anything that does not
-   fit becomes a subdirectory of `src/`.
+   `schema/`, `src/`, `starter/`, `supabase/`, `templates/`, `test/`.** No other
+   directories may appear at the package root. Anything that does not fit
+   becomes a subdirectory of `src/`.
 
 4. **`bin/` contains only entry-point scripts.** One file per CLI binary
    declared in `package.json`. No subdirectories. No shared helpers. Entry
@@ -180,15 +179,15 @@ as its codebase requires.
    subcommand is the default. A package with only one command does not need a
    `commands/` directory.
 
-6. **Package-internal libraries live under `src/lib/`.** Use `src/lib/` when
-   a file is a general helper used across the package's other `src/` files. Do
-   not create `src/lib/` for a single file — put it where it is used.
+6. **Package-internal libraries live under `src/lib/`.** Use `src/lib/` when a
+   file is a general helper used across the package's other `src/` files. Do not
+   create `src/lib/` for a single file — put it where it is used.
 
 7. **Per-package `justfile` files are allowed.** A package may have its own
-   `justfile` at the root when it has meaningful package-local task targets
-   (for example `products/basecamp/justfile`). The top-level `justfile`
-   remains the primary entry point; per-package `justfile` files complement
-   it, they do not replace it.
+   `justfile` at the root when it has meaningful package-local task targets (for
+   example `products/basecamp/justfile`). The top-level `justfile` remains the
+   primary entry point; per-package `justfile` files complement it, they do not
+   replace it.
 
 ### Services — exact shape
 
@@ -212,91 +211,86 @@ While we are touching every package, also resolve these drifts:
 1. **Move generated code out of the package root.** Any `generated/` or
    equivalent code-generation output directory inside a package (for example
    `libraries/librpc/generated/`) moves to `src/generated/` or is regenerated
-   into `src/` by `fit-codegen`. Generated code is source code for the
-   package that contains it.
+   into `src/` by `fit-codegen`. Generated code is source code for the package
+   that contains it.
 
-2. **Fold `products/map/activity/` into `src/activity/`.** `activity/`
-   contains queries, validation, and the shared people parser — this is
-   source code that slipped out of `src/`. It moves wholesale, keeping the
-   internal directory shape.
+2. **Fold `products/map/activity/` into `src/activity/`.** `activity/` contains
+   queries, validation, and the shared people parser — this is source code that
+   slipped out of `src/`. It moves wholesale, keeping the internal directory
+   shape.
 
-3. **Move `products/guide/lib/` into `src/lib/`.** Add a `src/index.js` so
-   Guide matches every other package that is not a service.
+3. **Move `products/guide/lib/` into `src/lib/`.** Add a `src/index.js` so Guide
+   matches every other package that is not a service.
 
 4. **Remove `products/map/bin/lib/`.** `client.js`, `package-root.js`, and
    `supabase-cli.js` move to `src/lib/`. The `commands/` subtree moves to
-   `src/commands/`. `bin/fit-map.js` imports from `src/` like every other
-   binary in the monorepo.
+   `src/commands/`. `bin/fit-map.js` imports from `src/` like every other binary
+   in the monorepo.
 
 5. **Fix `libraries/libharness`.** libharness is the outlier in every library
-   audit — it has `index.js`, `fixture/`, `mock/`, and a stale `packages/`
-   tree at the root, plus an orphan zero-byte file at
+   audit — it has `index.js`, `fixture/`, `mock/`, and a stale `packages/` tree
+   at the root, plus an orphan zero-byte file at
    `packages/libharness/mock/config.js`. Bring it into line with every other
    library:
    - Create `src/` and move the current root `index.js` to `src/index.js`.
    - Move `fixture/` to `src/fixture/` and `mock/` to `src/mock/`.
-   - Delete the `packages/` tree. It contains a single zero-byte file with
-     no importers anywhere in the repo and is residue from an aborted
-     workspace experiment.
-   - Rename the package description to match reality — it now provides
-     shared test harness and mock infrastructure for the whole monorepo, not
-     only Guide.
-   - Update the `main`, `exports`, and `files` fields in `package.json` so
-     they point at the new `src/` paths, and update every call site across
-     the monorepo (services, libraries, tests) to import from the updated
-     subpaths.
+   - Delete the `packages/` tree. It contains a single zero-byte file with no
+     importers anywhere in the repo and is residue from an aborted workspace
+     experiment.
+   - Rename the package description to match reality — it now provides shared
+     test harness and mock infrastructure for the whole monorepo, not only
+     Guide.
+   - Update the `main`, `exports`, and `files` fields in `package.json` so they
+     point at the new `src/` paths, and update every call site across the
+     monorepo (services, libraries, tests) to import from the updated subpaths.
 
-6. **Fix `services/pathway/`.** The pathway service is the one outlier in
-   the services tier — it has already grown a lone `src/serialize.js`
-   alongside the usual `index.js` and `server.js`. Under the new rules that
-   is correct shape, but the service's `index.js` and `server.js` still
-   reference code at the service root rather than at `src/`. Make the
-   service match the services template exactly: root files load from
-   `./src/...` and any stray source file at the service root moves into
-   `src/`.
+6. **Fix `services/pathway/`.** The pathway service is the one outlier in the
+   services tier — it has already grown a lone `src/serialize.js` alongside the
+   usual `index.js` and `server.js`. Under the new rules that is correct shape,
+   but the service's `index.js` and `server.js` still reference code at the
+   service root rather than at `src/`. Make the service match the services
+   template exactly: root files load from `./src/...` and any stray source file
+   at the service root moves into `src/`.
 
 7. **Keep `products/pathway/src/formatters/` as the canonical home for
-   formatters.** Pathway already has `src/commands/` and `src/formatters/`.
-   Both are legitimate under the new rules. No change required, but document
-   `src/formatters/` as the canonical place for output formatters that
-   multiple commands share.
+   formatters.** Pathway already has `src/commands/` and `src/formatters/`. Both
+   are legitimate under the new rules. No change required, but document
+   `src/formatters/` as the canonical place for output formatters that multiple
+   commands share.
 
 8. **Reconsider domain subdirs inside libraries.** The `dsl/`, `engine/`,
    `processor/`, `index/`, `render/`, `prompts/`, `components/`, `css/`,
    `tools/` directories that currently live at library roots all move to
-   `src/<name>/` as-is. They keep their current name, just shift one level
-   down.
+   `src/<name>/` as-is. They keep their current name, just shift one level down.
 
 9. **Keep the exceptions called out in `CLAUDE.md` as exceptions.** `libskill`
    remains a pure-function library, `libui` remains a functional DOM library,
    `libsecret` remains stateless crypto, `libtype` remains generated code. The
-   layout rules apply to all four — `src/index.js`, no root-level sources —
-   but their _internal_ style (no classes, no OO+DI) is preserved. The OO+DI
-   exceptions in `CLAUDE.md § OO+DI Architecture` are about _what the code
-   looks like_, not _where it lives_.
+   layout rules apply to all four — `src/index.js`, no root-level sources — but
+   their _internal_ style (no classes, no OO+DI) is preserved. The OO+DI
+   exceptions in `CLAUDE.md § OO+DI Architecture` are about _what the code looks
+   like_, not _where it lives_.
 
 ### Package exports point directly at `src/`
 
-Published `package.json` `main`, `bin`, and `exports` fields point directly
-at files under `src/`. No root-level proxy file. No publish-time build step
-that flattens `src/`. `products/map` already ships this way and it works
-cleanly.
+Published `package.json` `main`, `bin`, and `exports` fields point directly at
+files under `src/`. No root-level proxy file. No publish-time build step that
+flattens `src/`. `products/map` already ships this way and it works cleanly.
 
 Why this over the alternatives:
 
-- **A publish-time flatten is a standing liability.** Every library's
-  publish step has to be kept in sync with its source layout; a
-  misconfigured flatten silently ships the wrong files; tests exercise the
-  source but users exercise the built artifact, so drift goes unnoticed
-  until a consumer breaks. The monorepo has no transpile steps today and
-  should not acquire one for this.
-- **A root-level `index.js` that re-exports from `src/` defeats the rule.**
-  If every library keeps a proxy at the root, the "no source at the root"
-  rule becomes cosmetic.
+- **A publish-time flatten is a standing liability.** Every library's publish
+  step has to be kept in sync with its source layout; a misconfigured flatten
+  silently ships the wrong files; tests exercise the source but users exercise
+  the built artifact, so drift goes unnoticed until a consumer breaks. The
+  monorepo has no transpile steps today and should not acquire one for this.
+- **A root-level `index.js` that re-exports from `src/` defeats the rule.** If
+  every library keeps a proxy at the root, the "no source at the root" rule
+  becomes cosmetic.
 - **The public import specifier does not change.** Consumers keep writing
-  `import { derive } from "@forwardimpact/libskill/derivation"`; the
-  `exports` map resolves that to `./src/derivation.js`. `/src/` never
-  appears in the consumer's import path.
+  `import { derive } from "@forwardimpact/libskill/derivation"`; the `exports`
+  map resolves that to `./src/derivation.js`. `/src/` never appears in the
+  consumer's import path.
 - **Deep-import paths stay 1:1 with on-disk paths.** An agent debugging a
   subpath import sees the same path in the consumer and on disk.
 
@@ -314,16 +308,16 @@ The shape looks like:
 }
 ```
 
-The only thing that breaks is code that reaches _around_ the `exports`
-map — imports that bypass the subpath alias and hit a file path directly.
-Success criterion #9 requires a grep to confirm there are none.
+The only thing that breaks is code that reaches _around_ the `exports` map —
+imports that bypass the subpath alias and hit a file path directly. Success
+criterion #9 requires a grep to confirm there are none.
 
 ### CLAUDE.md is the contract
 
 The standard layout is documented in a new section of `CLAUDE.md` (under
-`## Structure`). The section is the single canonical description of the
-expected package shape. No other document restates it; they reference this
-section. Future new packages copy the shape rather than invent one.
+`## Structure`). The section is the single canonical description of the expected
+package shape. No other document restates it; they reference this section.
+Future new packages copy the shape rather than invent one.
 
 ## Scope
 
@@ -331,30 +325,29 @@ section. Future new packages copy the shape rather than invent one.
 
 - Every package under `products/`, `services/`, and `libraries/`.
 - Every `package.json` `main`, `bin`, and `exports` field whose paths move —
-  rewritten to point directly at `src/` paths, with no root-level proxy
-  files and no build step.
-- Every import statement across the monorepo that references a moved file —
-  both internal workspace imports and deep subpath imports of
-  `@forwardimpact/*` packages.
+  rewritten to point directly at `src/` paths, with no root-level proxy files
+  and no build step.
+- Every import statement across the monorepo that references a moved file — both
+  internal workspace imports and deep subpath imports of `@forwardimpact/*`
+  packages.
 - Generated-code output directories that live inside packages.
 - The `libraries/libharness` restructure — `src/`, deletion of the stale
   `packages/` tree, updated description, and updated call sites.
-- `CLAUDE.md § Structure` — updated to describe the new layout and the
-  allowed root subdirs as a contract. Also reconciled with on-disk reality:
-  the current example tree lists `products/landmark/` and
-  `products/summit/`, which do not exist as packages yet.
+- `CLAUDE.md § Structure` — updated to describe the new layout and the allowed
+  root subdirs as a contract. Also reconciled with on-disk reality: the current
+  example tree lists `products/landmark/` and `products/summit/`, which do not
+  exist as packages yet.
 - Skill files under `.claude/skills/libs-*` and `.claude/skills/fit-*` that
-  describe library and product internals — updated to reference the new
-  paths.
+  describe library and product internals — updated to reference the new paths.
 - Product internals pages under `website/docs/internals/` that show file-tree
   diagrams — updated to reflect the new layout.
 
 ### Out of scope
 
-- Code behaviour changes. No function signatures, no new features, no bug
-  fixes that are not strictly required to make the move land. If a test fails
-  after the move, the fix is "adjust the import" or "adjust the path" — not
-  "rewrite the code".
+- Code behaviour changes. No function signatures, no new features, no bug fixes
+  that are not strictly required to make the move land. If a test fails after
+  the move, the fix is "adjust the import" or "adjust the path" — not "rewrite
+  the code".
 - OO+DI migration (spec 070 already landed). This spec does not change how
   classes are constructed, only where the files live.
 - The internal structure of `libskill`, `libui`, `libsecret`, or `libtype`
@@ -363,48 +356,48 @@ section. Future new packages copy the shape rather than invent one.
 - Service protocol or wire-format changes. `proto/` files stay where they are
   relative to the package root.
 - Wiki content under `wiki/` (it is a submodule and not a package).
-- `website/`, `data/`, `config/`, `specs/`, and other monorepo-root
-  directories. This spec only standardises the shape _inside_ each package.
+- `website/`, `data/`, `config/`, `specs/`, and other monorepo-root directories.
+  This spec only standardises the shape _inside_ each package.
 - Renaming or merging packages. Each existing package keeps its name and its
   boundary.
-- Versioning strategy. Whether the layout move is a major, minor, or patch
-  bump for each package is a release question, handled separately.
+- Versioning strategy. Whether the layout move is a major, minor, or patch bump
+  for each package is a release question, handled separately.
 
 ## Success criteria
 
-1. **Root-level source is zero in products and libraries.** For every
-   package under `products/` and `libraries/`,
-   `git ls-files '<pkg>/*.js' '<pkg>/*.ts'` returns nothing. No `.js` or
-   `.ts` source file sits at the package root in any product or library.
+1. **Root-level source is zero in products and libraries.** For every package
+   under `products/` and `libraries/`, `git ls-files '<pkg>/*.js' '<pkg>/*.ts'`
+   returns nothing. No `.js` or `.ts` source file sits at the package root in
+   any product or library.
 
 2. **Services have exactly two root source files.** For every service under
    `services/`, `git ls-files 'services/<name>/*.js'` returns exactly
    `services/<name>/index.js` and `services/<name>/server.js` — nothing else.
 
-3. **Allowed-list is enforced.** `just check` runs an allowed-root-subdirs
-   check that lists every directory at every package root under `products/`,
-   `services/`, and `libraries/`, and fails with a clear diff if any
-   directory is not one of `bin/`, `config/`, `macos/`, `pkg/`, `proto/`,
-   `schema/`, `src/`, `starter/`, `supabase/`, `templates/`, or `test/`.
-   The check runs in CI and must pass.
+3. **Allowed-list is enforced.** `just check` runs an allowed-root-subdirs check
+   that lists every directory at every package root under `products/`,
+   `services/`, and `libraries/`, and fails with a clear diff if any directory
+   is not one of `bin/`, `config/`, `macos/`, `pkg/`, `proto/`, `schema/`,
+   `src/`, `starter/`, `supabase/`, `templates/`, or `test/`. The check runs in
+   CI and must pass.
 
-4. **Every non-service package has `src/index.js`.** `ls src/index.js` in
-   every `products/*` and every `libraries/*` returns the file. No product
-   or library uses a root `index.js` any more.
+4. **Every non-service package has `src/index.js`.** `ls src/index.js` in every
+   `products/*` and every `libraries/*` returns the file. No product or library
+   uses a root `index.js` any more.
 
 5. **`bin/` is flat.** For every package with a `bin/` directory,
-   `find bin -mindepth 2` returns nothing. `bin/` contains only the
-   entry-point script files listed in the package's `bin` field.
+   `find bin -mindepth 2` returns nothing. `bin/` contains only the entry-point
+   script files listed in the package's `bin` field.
 
-6. **CLI subcommands are under `src/commands/`.** Every file that implements
-   a CLI subcommand lives in its package's `src/commands/` directory.
+6. **CLI subcommands are under `src/commands/`.** Every file that implements a
+   CLI subcommand lives in its package's `src/commands/` directory.
    Specifically, `products/map/bin/lib/commands/` no longer exists — its
    contents are under `products/map/src/commands/`.
 
-7. **Tests pass with no weakening.** `just check` passes on the branch, and
-   the diff between the pre-move and post-move test files contains only
-   import-path changes and file-move renames. No test is disabled, skipped,
-   or marked expected-failure as part of this move.
+7. **Tests pass with no weakening.** `just check` passes on the branch, and the
+   diff between the pre-move and post-move test files contains only import-path
+   changes and file-move renames. No test is disabled, skipped, or marked
+   expected-failure as part of this move.
 
 8. **`CLAUDE.md § Structure` describes the contract.** The section lists the
    allowed root subdirectories, documents the services exception and the
@@ -412,40 +405,38 @@ section. Future new packages copy the shape rather than invent one.
    longer references `products/landmark/` or `products/summit/` as existing
    packages.
 
-9. **Every published subpath export still resolves.** The set of public
-   subpath keys published in `exports` across all `@forwardimpact/*`
-   packages is the same after the move as before. Verifiable by enumerating
-   the pre-move keys (`rg '"\./' libraries/*/package.json products/*/package.json`)
-   and confirming the same set appears in the post-move package.json files,
-   and by a fresh-install smoke test in a clean directory that imports each
-   public subpath and asserts it resolves.
+9. **Every published subpath export still resolves.** The set of public subpath
+   keys published in `exports` across all `@forwardimpact/*` packages is the
+   same after the move as before. Verifiable by enumerating the pre-move keys
+   (`rg '"\./' libraries/*/package.json products/*/package.json`) and confirming
+   the same set appears in the post-move package.json files, and by a
+   fresh-install smoke test in a clean directory that imports each public
+   subpath and asserts it resolves.
 
-10. **libharness is restructured.** `libraries/libharness/packages/` no
-    longer exists. `libharness`'s `fixture/` and `mock/` are under `src/`,
-    along with a `src/index.js`. The package description in `package.json`
-    no longer says "for guide tests" — it describes the cross-monorepo
-    role.
+10. **libharness is restructured.** `libraries/libharness/packages/` no longer
+    exists. `libharness`'s `fixture/` and `mock/` are under `src/`, along with a
+    `src/index.js`. The package description in `package.json` no longer says
+    "for guide tests" — it describes the cross-monorepo role.
 
 ## Risks
 
 - **Published subpath exports are a large, silent blast radius.** Several
   packages (`@forwardimpact/map`, `@forwardimpact/libskill`,
-  `@forwardimpact/libharness`) publish many deep subpath exports that
-  reference specific on-disk files. Every export key has to keep resolving
-  after the move, and a missed key breaks downstream installations only
-  when a consumer happens to import that subpath — not at build time. The
-  `exports`-pointing-at-`src/` strategy contains this to the internal
-  paths, but the plan still needs an enumerated list of every published
-  key and a fresh-install smoke test (see success criterion #9) to catch
-  drift before cutting releases.
+  `@forwardimpact/libharness`) publish many deep subpath exports that reference
+  specific on-disk files. Every export key has to keep resolving after the move,
+  and a missed key breaks downstream installations only when a consumer happens
+  to import that subpath — not at build time. The `exports`-pointing-at-`src/`
+  strategy contains this to the internal paths, but the plan still needs an
+  enumerated list of every published key and a fresh-install smoke test (see
+  success criterion #9) to catch drift before cutting releases.
 
 - **One big diff touches everything.** This is a repo-wide rename. It will
   conflict with any in-flight branch that edits files inside the moved
-  directories. The change should land in a single commit, ideally during a
-  quiet window, with open branches rebased immediately afterwards.
+  directories. The change should land in a single commit, ideally during a quiet
+  window, with open branches rebased immediately afterwards.
 
-- **Codegen paths change.** `fit-codegen` currently writes generated code
-  into each package's root-level `generated/` tree. Moving generated code
-  into `src/generated/` means the codegen pipeline itself changes. If the
-  pipeline is not updated atomically with the layout move, the first
-  post-move `just codegen` run will put files back where they used to be.
+- **Codegen paths change.** `fit-codegen` currently writes generated code into
+  each package's root-level `generated/` tree. Moving generated code into
+  `src/generated/` means the codegen pipeline itself changes. If the pipeline is
+  not updated atomically with the layout move, the first post-move
+  `just codegen` run will put files back where they used to be.

--- a/website/docs/getting-started/leadership/index.md
+++ b/website/docs/getting-started/leadership/index.md
@@ -149,20 +149,29 @@ After each change, re-validate with `npx fit-map validate`.
 
 The activity layer runs on Supabase. You need the Supabase CLI to start a local
 instance and to deploy migrations and edge functions to a hosted project.
-`fit-map` wraps the CLI for every activity workflow, but it still needs the
-`supabase` binary on your `PATH`.
+`fit-map` wraps the CLI for every activity workflow and will find it whether you
+install it via Homebrew or as an npm package.
 
 ```sh
-# macOS
+# macOS via Homebrew (recommended if you have brew)
 brew install supabase/tap/supabase
+
+# Anywhere, as a project dependency
+npm install supabase
 
 # Linux / Windows — see https://supabase.com/docs/guides/local-development
 ```
+
+`fit-map` prefers a `supabase` binary on your `PATH` and falls back to
+`npx supabase` (resolving from your project's `node_modules`) if one is not
+found, so the npm-local install works without any PATH setup.
 
 Verify the install:
 
 ```sh
 supabase --version
+# or, for a project-local install:
+npx supabase --version
 ```
 
 ### Activity: start the database


### PR DESCRIPTION
## Summary

Resolves #305.

`fit-map activity {start,stop,status,migrate}` spawned bare `supabase` directly, which only worked when the binary was on `PATH`. Users who installed the supabase npm package — locally with `npm install supabase`, or globally on a system whose npm global bin isn't on `PATH` — got a misleading "not installed or not on PATH" error even though the CLI was reachable via `npx supabase`.

This PR introduces `createSupabaseCli({ spawnFn, cwd })`, a factory in `products/map/bin/lib/supabase-cli.js` that returns `{ run, resolve }`. The first call probes bare `supabase --version` and falls back to `npx --no-install -- supabase --version`, memoizing the winning descriptor on instance state — no module-level singleton, in line with the OO+DI invariant in CONTRIBUTING.md. Both probes and the actual execution use `cwd: getPackageRoot()` so npx walks up from `node_modules/@forwardimpact/map/` to find a sibling `node_modules/.bin/supabase` in the consumer's project. The error message names both install options when neither probe succeeds.

`activity.js` now instantiates the factory once at module load and routes the four activity commands through `supabaseCli.run(...)`. The leadership getting-started guide lists `npm install supabase` as a first-class install option and explains the npx fallback. The fit-map skill cross-links the install section above its activity commands.

## Changes

- **`products/map/bin/lib/supabase-cli.js`** — rewritten as a `createSupabaseCli` factory. Closure-state memoization, no module-level singletons, no `detectSupabaseCli` shim.
- **`products/map/bin/lib/commands/activity.js`** — instantiates `createSupabaseCli()` once at module load; the four activity commands call `supabaseCli.run(...)`.
- **`products/map/test/supabase-cli.test.js`** — new file, 9 tests covering bare success, ENOENT-then-npx, non-zero-then-npx, both-fail error message, instance memoization, instance isolation, bare execution path, npx execution path (with probe-call assertions), and non-zero exit propagation.
- **`website/docs/getting-started/leadership/index.md`** — install section adds `npm install supabase` as a first-class option and documents the `npx supabase` fallback.
- **`.claude/skills/fit-map/SKILL.md`** — install cross-link above the activity commands block.

## Test plan

- [x] `bun test` in `products/map`: 136/136 pass (9 new)
- [x] `bun run check` (prettier + eslint, repo-wide): clean *(spec 390 prettier warning is pre-existing on main)*
- [x] `node -e "import('./bin/lib/commands/activity.js')"` smoke test: factory wires cleanly at module load
- [x] Manual brew path: `bunx fit-map activity status` invokes bare `supabase`
- [ ] Manual project-local npm install: requires throwaway project — covered by test 8 (`run invokes the resolved npx descriptor`)
- [ ] Manual scrubbed-PATH error message: covered by test 4 (`both probes fail → run rejects with install instructions`)

## Notes

- Rebased onto `main` (HEAD `c7cc737`). One conflict in `activity.js:start()` between the libcli formatter refactor (#312) and the factory wiring — resolved by keeping both improvements (`supabaseCli.run(["start"])` + `formatSubheader` for the export message).
- Squashed two commits into one. Original feedback came from a `staff-engineer` review of an earlier draft that flagged a module-level singleton and a back-compat shim with no callers — both fixed in this version.
- Windows `spawn("npx")` quirk (`.cmd` shim needs `shell: true`) not addressed here — pre-existing issue with the bare `spawn("supabase")` call too. Out of scope; flag as a follow-up if a Windows user files an issue.

https://claude.ai/code/session_01Vp5u9YyEXee5Vq665Utogz