### PR TITLE
refactor(skills): extract gemba-review for recursion-safe self-review

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -8,6 +8,7 @@ model: opus
 skills:
   - gemba-walk
   - gemba-spec
+  - gemba-review
   - gemba-gh-cli
 ---
 

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -12,6 +12,7 @@ skills:
   - gemba-product-evaluation
   - gemba-spec
   - gemba-plan
+  - gemba-review
   - gemba-gh-cli
 ---
 

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -9,6 +9,7 @@ skills:
   - gemba-security-update
   - gemba-security-audit
   - gemba-spec
+  - gemba-review
 ---
 
 You are the security engineer. You keep the codebase secure — dependencies

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -8,6 +8,7 @@ model: opus
 skills:
   - gemba-plan
   - gemba-implement
+  - gemba-review
   - gemba-gh-cli
 ---
 

--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -9,6 +9,7 @@ skills:
   - gemba-documentation
   - gemba-wiki-curate
   - gemba-spec
+  - gemba-review
 ---
 
 You are the technical writer. You keep documentation accurate, audience-pure,

--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -41,8 +41,10 @@ apply alongside the skill-specific ones below.
 - [ ] Spec-specific verification commands from the plan pass.
 - [ ] Full diff reviewed against the spec's success criteria — every criterion
       met.
-- [ ] Clean sub-agent review of the full diff completed (fresh context, no prior
-      bias) and every **blocker**, **high**, and **medium** finding addressed.
+- [ ] Clean sub-agent review of the full diff via
+      [`gemba-review`](../gemba-review/SKILL.md) completed (fresh context, no
+      prior bias) and every **blocker**, **high**, and **medium** finding
+      addressed.
 - [ ] Spec status set to `done` in `specs/STATUS`.
 
 </do_confirm_checklist>
@@ -149,15 +151,17 @@ After all tasks are complete, run the DO-CONFIRM checklist above.
 ### 8. Clean sub-agent review
 
 Before pushing, launch a fresh sub-agent (via the `Agent` tool, no prior
-conversation context) and ask it to review the full diff
-(`git diff origin/main...HEAD`) against `spec.md`, the plan, and CONTRIBUTING.md
-§ Core Rules. Give the reviewer enough context to act independently — spec path,
-plan path, branch name.
+conversation context) and instruct it to load the
+[`gemba-review`](../gemba-review/SKILL.md) skill and grade the full diff
+(`git diff origin/main...HEAD`). Give the reviewer enough context to act
+independently — spec path, plan path, branch name.
 
-The reviewer must **return findings only** — tell it explicitly not to invoke
-the `gemba-implement` skill (or any other skill) and not to spawn its own
-sub-agents. This prevents recursion. Grade findings using the shared vocabulary
-in [`gemba-spec` § Review Severity](../gemba-spec/SKILL.md#review-severity).
+`gemba-review` owns the severity vocabulary and the implementation-diff
+criteria; it never spawns sub-agents, so the review loop bottoms out
+structurally — see
+[GEMBA.md § Recursion-safe self-review](../../../GEMBA.md#recursion-safe-self-review).
+Tell the reviewer explicitly **not** to invoke `gemba-implement` itself —
+defense in depth on top of the structural fix.
 
 Address every **blocker**, **high**, and **medium** finding before pushing.
 **Low** findings are optional. If the reviewer raises blockers you disagree

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -47,9 +47,10 @@ no commitment to implement, and a plan has nothing to translate.
 - [ ] Non-obvious decisions explained.
 - [ ] Risks surfaced — no step should surprise the implementer.
 - [ ] Execution recommendation present (which agents, sequential vs parallel).
-- [ ] Clean sub-agent review of `plan-a.md` (and any parts) completed (fresh
-      context, no prior bias) and every **blocker**, **high**, and **medium**
-      finding addressed.
+- [ ] Clean sub-agent review of `plan-a.md` (and any parts) via
+      [`gemba-review`](../gemba-review/SKILL.md) completed (fresh context, no
+      prior bias) and every **blocker**, **high**, and **medium** finding
+      addressed.
 
 </do_confirm_checklist>
 
@@ -190,17 +191,18 @@ from prior `staff-engineer` entries.
    explicitly. If the plan is large, decompose it into parts (see § Large plan
    decomposition).
 5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
-   (via the `Agent` tool, no prior conversation context) and ask it to review
-   `plan-a.md` (and any `plan-a-NN.md` parts) against this skill's DO-CONFIRM
-   checklist and the qualities in "Writing a Plan". The reviewer must **return
-   findings only** — tell it explicitly not to invoke the `gemba-plan` skill or
-   any other skill, and not to spawn its own sub-agents. This prevents
-   recursion. Grade findings using the shared vocabulary in
-   [`gemba-spec` § Review Severity](../gemba-spec/SKILL.md#review-severity).
-   Address every **blocker**, **high**, and **medium** finding before moving on.
-   **Low** findings are optional. If the reviewer raises blockers you disagree
-   with, resolve the disagreement explicitly (revise, or record the rationale
-   for dismissal) — silent dismissal is not allowed.
+   (via the `Agent` tool, no prior conversation context) and instruct it to load
+   the [`gemba-review`](../gemba-review/SKILL.md) skill and grade `plan-a.md`
+   (and any `plan-a-NN.md` parts). `gemba-review` owns the severity vocabulary
+   and the plan criteria; it never spawns sub-agents, so the review loop bottoms
+   out structurally — see
+   [GEMBA.md § Recursion-safe self-review](../../../GEMBA.md#recursion-safe-self-review).
+   Tell the reviewer explicitly **not** to invoke `gemba-plan` itself — defense
+   in depth on top of the structural fix. Address every **blocker**, **high**,
+   and **medium** finding before moving on. **Low** findings are optional. If
+   the reviewer raises blockers you disagree with, resolve the disagreement
+   explicitly (revise, or record the rationale for dismissal) — silent dismissal
+   is not allowed.
 6. **Present the plan.** Share it for feedback.
 7. **Update STATUS.** When both spec and plan are approved, advance the spec's
    status from `review` to `planned`. Do not advance while the plan is still

--- a/.claude/skills/gemba-review/SKILL.md
+++ b/.claude/skills/gemba-review/SKILL.md
@@ -51,7 +51,9 @@ finding before advancing. **Low** findings are optional.
 
 1. **Identify the artifact type.** The caller tells you whether the input is a
    `spec.md`, a `plan-a.md` (plus any decomposed parts), or a code diff
-   (`git diff origin/main...HEAD`). If unclear, ask the caller — do not guess.
+   (`git diff origin/main...HEAD`). You are spawned cold with no back-channel to
+   the caller — if the artifact type or path is genuinely ambiguous, return a
+   single **Blocker** finding asking for clarification and stop. Do not guess.
 
 2. **Read the artifact and directly relevant context.** For a plan, read the
    spec it targets. For a diff, read the spec, the plan, and CONTRIBUTING.md §
@@ -104,10 +106,14 @@ and CONTRIBUTING.md § Core Rules. Look for:
 - Diff implements every spec success criterion
 - No scope creep (refactors, features, cleanup beyond the plan)
 - Atomic, conventional-style commits on the branch
-- `bun run check` and `bun run test` pass on HEAD
 - Plan deviations noted in commit messages where present
 - No security regressions (input validation at boundaries, secrets, dangerous
   shell)
+
+You may run `bun run check` and `bun run test` yourself to verify the head
+commit, or trust the caller's assertion that they pass — the caller's Step 7
+already requires green checks before delegating to you. Treat any test or lint
+failure you observe as at minimum a **High** finding.
 
 ## Output Format
 

--- a/.claude/skills/gemba-review/SKILL.md
+++ b/.claude/skills/gemba-review/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: gemba-review
+description: >
+  Grade a single artifact (spec, plan, or implementation diff) against quality
+  criteria and return findings by severity. Use when another skill spawns a
+  fresh sub-agent for an independent review of its work. This skill never
+  spawns sub-agents — it produces findings only — which structurally prevents
+  the spec/plan/implement review loop from recursing.
+---
+
+# Review
+
+Independent grading skill for artifacts produced by `gemba-spec`, `gemba-plan`,
+and `gemba-implement`. Returns severity-graded findings; takes no action. Never
+spawns sub-agents.
+
+## When to Use
+
+- A `gemba-spec`, `gemba-plan`, or `gemba-implement` workflow has reached its
+  clean sub-agent review step and you have been spawned with no prior context to
+  grade the artifact.
+- Any time another agent needs an independent quality grade on a spec, plan, or
+  diff without changing it.
+
+## Invariant: never spawn
+
+This skill's Process has **no step that launches a sub-agent**. That is the
+property that prevents the spec / plan / implement review loop from recursing —
+if you find yourself wanting to make an `Agent` tool call from inside this
+skill, stop and return findings instead. See
+[GEMBA.md § Recursion-safe self-review](../../../GEMBA.md#recursion-safe-self-review)
+for the full design rationale.
+
+## Severity Vocabulary
+
+This is the canonical definition of review severity for the spec → plan →
+implement arc. Grade every finding using exactly one level:
+
+- **Blocker** — The work is broken, dangerous, or materially wrong. Must fix
+  before advancing (approving the spec, advancing status, merging code).
+- **High** — A correctness or clarity problem that will cause rework, confusion,
+  or bugs downstream if shipped. Fix before advancing.
+- **Medium** — A real quality or consistency issue worth fixing now while the
+  context is fresh. Fix before advancing.
+- **Low** — Nit or preference. Optional; document if dismissed.
+
+The caller is required to address every **blocker**, **high**, and **medium**
+finding before advancing. **Low** findings are optional.
+
+## Process
+
+1. **Identify the artifact type.** The caller tells you whether the input is a
+   `spec.md`, a `plan-a.md` (plus any decomposed parts), or a code diff
+   (`git diff origin/main...HEAD`). If unclear, ask the caller — do not guess.
+
+2. **Read the artifact and directly relevant context.** For a plan, read the
+   spec it targets. For a diff, read the spec, the plan, and CONTRIBUTING.md §
+   Core Rules. Read once, fully, before grading.
+
+3. **Grade against the artifact-specific criteria** in the section below. For
+   each gap or risk, write one finding with:
+   - File path and line number (or commit hash)
+   - The criterion violated, in one short phrase
+   - Severity per the vocabulary above
+   - One-sentence explanation
+
+4. **Return findings only.** Do not modify the artifact, do not open PRs, do not
+   invoke other skills, do not spawn sub-agents. Group findings by severity and
+   report.
+
+## Artifact Criteria
+
+### spec.md
+
+Match the qualities in
+[`gemba-spec` § Writing a Spec](../gemba-spec/SKILL.md#writing-a-spec-what-and-why)
+and that skill's DO-CONFIRM checklist. Look for:
+
+- Problem stated first with concrete evidence (errors, metrics, examples)
+- Specific scope (files, APIs, entities) with explicit exclusions
+- Verifiable success criteria
+- No implementation details (HOW belongs in the plan)
+
+### plan-a.md (and parts)
+
+Match the qualities in
+[`gemba-plan` § Writing a Plan](../gemba-plan/SKILL.md#writing-a-plan-how) and
+that skill's DO-CONFIRM checklist. Look for:
+
+- Approach and rationale stated before details
+- Concrete changes (file paths, function names, before/after)
+- Visible blast radius (created / modified / deleted files)
+- Explicit ordering with stated dependencies
+- Non-obvious decisions explained
+- Risks surfaced
+- Execution recommendation present
+
+### Implementation diff
+
+Match
+[`gemba-implement` § Final verification](../gemba-implement/SKILL.md#7-final-verification)
+and CONTRIBUTING.md § Core Rules. Look for:
+
+- Diff implements every spec success criterion
+- No scope creep (refactors, features, cleanup beyond the plan)
+- Atomic, conventional-style commits on the branch
+- `bun run check` and `bun run test` pass on HEAD
+- Plan deviations noted in commit messages where present
+- No security regressions (input validation at boundaries, secrets, dangerous
+  shell)
+
+## Output Format
+
+Return findings grouped by severity exactly in this shape:
+
+```text
+### Blocker
+- <file:line> — <criterion> — <one-sentence reason>
+- ...
+(or "none")
+
+### High
+- ...
+
+### Medium
+- ...
+
+### Low
+- ...
+```
+
+Be honest and specific. Do not invent findings to look thorough. Do not
+rubber-stamp.
+
+## What NOT to Do
+
+- **Do not spawn sub-agents.** This skill must remain a leaf in the call graph;
+  spawning would re-introduce the recursion this skill exists to prevent.
+- **Do not modify the artifact.** Reviewers grade; they do not edit.
+- **Do not open PRs, comments, or commits.** Findings are returned to the
+  caller, who decides what to act on.
+- **Do not invoke `gemba-spec`, `gemba-plan`, or `gemba-implement`.** Their
+  Process steps would spawn another reviewer and loop.

--- a/.claude/skills/gemba-spec/SKILL.md
+++ b/.claude/skills/gemba-spec/SKILL.md
@@ -46,8 +46,9 @@ asked for. If they ask for a spec, write the spec and stop.
 - [ ] Success criteria are verifiable (a command, observable behaviour, or
       testable property).
 - [ ] No implementation details have leaked in (HOW belongs in the plan).
-- [ ] Clean sub-agent review of `spec.md` completed (fresh context, no prior
-      bias) and every **blocker**, **high**, and **medium** finding addressed.
+- [ ] Clean sub-agent review via [`gemba-review`](../gemba-review/SKILL.md)
+      completed (fresh context, no prior bias) and every **blocker**, **high**,
+      and **medium** finding addressed.
 
 </do_confirm_checklist>
 
@@ -131,35 +132,20 @@ status clearly — the caller is responsible for acting on it.
    details — those go in the plan.
 4. **Update STATUS.** Add the spec to `specs/STATUS` with status `draft`.
 5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
-   (via the `Agent` tool, no prior conversation context) and ask it to review
-   `spec.md` against this skill's DO-CONFIRM checklist and the qualities in
-   "Writing a Spec". The reviewer must **return findings only** — tell it
-   explicitly not to invoke the `gemba-spec` skill or any other skill, and not
-   to spawn its own sub-agents. This prevents recursion. Instruct it to grade
-   each finding using the severity vocabulary in
-   [Review Severity](#review-severity) below. Address every **blocker**,
-   **high**, and **medium** finding before moving on. **Low** findings are
-   optional. If the reviewer raises blockers you disagree with, resolve the
-   disagreement explicitly (revise, or record the rationale for dismissal) —
-   silent dismissal is not allowed.
+   (via the `Agent` tool, no prior conversation context) and instruct it to load
+   the [`gemba-review`](../gemba-review/SKILL.md) skill and grade `spec.md`.
+   `gemba-review` owns the severity vocabulary and the spec criteria; it never
+   spawns sub-agents, so the review loop bottoms out structurally — see
+   [GEMBA.md § Recursion-safe self-review](../../../GEMBA.md#recursion-safe-self-review).
+   Tell the reviewer explicitly **not** to invoke `gemba-spec` itself — defense
+   in depth on top of the structural fix. Address every **blocker**, **high**,
+   and **medium** finding before moving on. **Low** findings are optional. If
+   the reviewer raises blockers you disagree with, resolve the disagreement
+   explicitly (revise, or record the rationale for dismissal) — silent dismissal
+   is not allowed.
 6. **Present the spec.** Share it for feedback. Iterate until satisfied, then
    set status to `review` — signalling it is ready for formal evaluation. Stop
    here. The plan is the staff engineer's job.
-
-## Review Severity
-
-The clean sub-agent reviewer grades each finding using this vocabulary. It is
-shared with [`gemba-plan`](../gemba-plan/SKILL.md#review-severity) and
-[`gemba-implement`](../gemba-implement/SKILL.md#review-severity) so grading is
-consistent across the spec → plan → implement arc.
-
-- **Blocker** — The work is broken, dangerous, or materially wrong. Must fix
-  before advancing (approving the spec, advancing status, merging code).
-- **High** — A correctness or clarity problem that will cause rework, confusion,
-  or bugs downstream if shipped. Fix before advancing.
-- **Medium** — A real quality or consistency issue worth fixing now while the
-  context is fresh. Fix before advancing.
-- **Low** — Nit or preference. Optional; document if dismissed.
 
 ## What NOT to Do
 

--- a/GEMBA.md
+++ b/GEMBA.md
@@ -170,9 +170,9 @@ All Gemba skills are namespaced with the `gemba-` prefix.
 | **gemba-wiki-curate**        | Study | Curate agent memory: summary accuracy, observation follow-up, log hygiene     |
 | **gemba-walk**               | Study | Open-ended trace observation, invariant audit, grounded-theory report         |
 | **gemba-spec**               | Act   | Write and review specs (WHAT/WHY); manage `draft → review` status             |
-| **gemba-ship**               | —     | Rebase, check, push, open/reuse PR, watch CI, squash-merge a feature branch   |
-| **gemba-review**             | —     | Grade a spec, plan, or diff against criteria — leaf skill, never spawns       |
 | **gemba-gh-cli**             | —     | GitHub CLI installation and usage patterns for CI (utility, no PDSA phase)    |
+| **gemba-review**             | —     | Grade a spec, plan, or diff against criteria — leaf skill, never spawns       |
+| **gemba-ship**               | —     | Rebase, check, push, open/reuse PR, watch CI, squash-merge a feature branch   |
 
 ## Trust Boundary
 
@@ -293,7 +293,8 @@ scheduled workflow) must include two memory elements:
 Sub-skills invoked within a workflow (e.g. `gemba-spec` called as the Act phase
 inside another workflow) do not need their own memory instructions — the
 entry-point skill's recording list and the agent profile's write protocol cover
-them. Utility skills with no PDSA phase (e.g. `gemba-gh-cli`) are also exempt.
+them. Utility skills with no PDSA phase (`gemba-gh-cli`, `gemba-ship`,
+`gemba-review`) are also exempt.
 
 ## Authentication
 

--- a/GEMBA.md
+++ b/GEMBA.md
@@ -13,7 +13,7 @@ place (the execution traces of prior runs) and act on what they find.
 Within Gemba, **Plan–Do–Study–Act** (PDSA, after Deming) is the improvement
 method. Every workflow belongs to a PDSA phase, findings from Study always
 re-enter the loop as specs or fix PRs, and the cycle runs on a schedule. Ten
-scheduled workflows, six agent personas, and fourteen skills form a
+scheduled workflows, six agent personas, and sixteen skills form a
 self-reinforcing PDSA cycle. Product evaluation sessions feed the Study phase
 with observations from the user's perspective. Gemba maintains the project — not
 the engineering frameworks the products serve.
@@ -113,14 +113,14 @@ structural improvements (`spec/` branches) — never mixed in one PR.
 
 ## Agents
 
-| Agent                 | Phase          | Purpose                                                                | Skills                                                                                                       |
-| --------------------- | -------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **staff-engineer**    | Plan, Do       | Own the full spec → plan → implement arc for approved specs            | gemba-plan, gemba-implement, gemba-gh-cli                                                                    |
-| **security-engineer** | Do, Study, Act | Patch dependencies, harden supply chain, enforce security policies     | gemba-security-update, gemba-security-audit, gemba-spec                                                      |
-| **release-engineer**  | Do             | Keep PR branches merge-ready, repair trivial CI on main, cut releases  | gemba-release-readiness, gemba-release-review, gemba-gh-cli                                                  |
-| **product-manager**   | Do, Study, Act | Triage issues and PRs, merge fix/bug/spec PRs, supervise evaluations   | gemba-plan, gemba-product-triage, gemba-product-classify, gemba-product-evaluation, gemba-spec, gemba-gh-cli |
-| **technical-writer**  | Study, Act     | Review docs for accuracy, curate wiki, fix staleness, spec larger gaps | gemba-documentation, gemba-wiki-curate, gemba-spec                                                           |
-| **improvement-coach** | Study, Act     | Walk traces, audit invariants, fix trivial issues, spec larger ones    | gemba-walk, gemba-spec, gemba-gh-cli                                                                         |
+| Agent                 | Phase          | Purpose                                                                | Skills                                                                                                                     |
+| --------------------- | -------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **staff-engineer**    | Plan, Do       | Own the full spec → plan → implement arc for approved specs            | gemba-plan, gemba-implement, gemba-review, gemba-gh-cli                                                                    |
+| **security-engineer** | Do, Study, Act | Patch dependencies, harden supply chain, enforce security policies     | gemba-security-update, gemba-security-audit, gemba-spec, gemba-review                                                      |
+| **release-engineer**  | Do             | Keep PR branches merge-ready, repair trivial CI on main, cut releases  | gemba-release-readiness, gemba-release-review, gemba-gh-cli                                                                |
+| **product-manager**   | Do, Study, Act | Triage issues and PRs, merge fix/bug/spec PRs, supervise evaluations   | gemba-plan, gemba-product-triage, gemba-product-classify, gemba-product-evaluation, gemba-spec, gemba-review, gemba-gh-cli |
+| **technical-writer**  | Study, Act     | Review docs for accuracy, curate wiki, fix staleness, spec larger gaps | gemba-documentation, gemba-wiki-curate, gemba-spec, gemba-review                                                           |
+| **improvement-coach** | Study, Act     | Walk traces, audit invariants, fix trivial issues, spec larger ones    | gemba-walk, gemba-spec, gemba-review, gemba-gh-cli                                                                         |
 
 Each agent has explicit scope constraints — it knows what it must _not_ do. When
 a finding exceeds an agent's scope, it writes a formal spec (`specs/`) rather
@@ -170,6 +170,8 @@ All Gemba skills are namespaced with the `gemba-` prefix.
 | **gemba-wiki-curate**        | Study | Curate agent memory: summary accuracy, observation follow-up, log hygiene     |
 | **gemba-walk**               | Study | Open-ended trace observation, invariant audit, grounded-theory report         |
 | **gemba-spec**               | Act   | Write and review specs (WHAT/WHY); manage `draft → review` status             |
+| **gemba-ship**               | —     | Rebase, check, push, open/reuse PR, watch CI, squash-merge a feature branch   |
+| **gemba-review**             | —     | Grade a spec, plan, or diff against criteria — leaf skill, never spawns       |
 | **gemba-gh-cli**             | —     | GitHub CLI installation and usage patterns for CI (utility, no PDSA phase)    |
 
 ## Trust Boundary
@@ -405,6 +407,38 @@ material so the core instructions stay scannable.
 Use the same wording for shared structural elements (memory instructions,
 prerequisites format, section headings) across all agents and skills.
 Inconsistent wording correlated with agents skipping steps in trace analysis.
+
+### Recursion-safe self-review
+
+Skills that require an independent review of their own output (e.g.
+`gemba-spec`, `gemba-plan`, `gemba-implement`) must spawn a fresh sub-agent —
+otherwise the reviewer shares context with the author and grades aren't
+independent. The naive design — "spawn a sub-agent and ask it to review using
+this same skill" — is **structurally vulnerable to recursion**: the sub-agent
+matches the skill's "When to Use" triggers, runs the full Process, and reaches
+its own review step, which spawns another sub-agent, which… and so on.
+
+The fix is to **delegate the review to a separate, leaf skill** (`gemba-review`)
+whose Process never spawns sub-agents. The call graph then bottoms out
+structurally:
+
+```text
+gemba-spec.Step5 → spawn sub-agent → gemba-review.Process → return findings
+                                                            ↑
+                                                      no spawn step here
+```
+
+Even if a buggy prompt match causes the sub-agent to mis-load `gemba-spec`
+instead of `gemba-review`, defense-in-depth applies: the parent skill's review
+step explicitly tells the sub-agent **"do not invoke this skill"**. The
+structural fix prevents recursion in the happy path; the prompt instruction
+catches it in the edge case.
+
+**Rule for new skills.** A skill that calls another skill via a sub-agent must
+target a skill whose Process has no further sub-agent spawn step. If you find
+yourself wanting to recursively self-review, factor the review into a separate
+leaf skill instead. `gemba-review` is the canonical example — copy its shape
+when you need a new self-review loop.
 
 ### resume() must propagate session state
 


### PR DESCRIPTION
## Summary

- New leaf skill `gemba-review` that grades a spec, plan, or implementation
  diff against quality criteria and returns severity-graded findings —
  **never spawns sub-agents**, so the spec / plan / implement self-review
  loop bottoms out structurally instead of relying on prompt instructions
  alone.
- `gemba-spec`, `gemba-plan`, `gemba-implement` now delegate their clean
  sub-agent review step to `gemba-review` instead of restating review prose
  inline. Severity definitions live only in `gemba-review` (single source
  of truth).
- `gemba-review` added to the skill lists of `staff-engineer`,
  `security-engineer`, `product-manager`, `technical-writer`, and
  `improvement-coach`. `release-engineer` is unchanged — it doesn't use
  spec/plan/implement.
- `GEMBA.md`: skill count → sixteen, new `gemba-review` and `gemba-ship`
  rows in the skills table, agent skills column updated, and a new
  **Recursion-safe self-review** subsection in Authoring Best Practices
  documenting the design rule.
- Four low-severity nits from the clean sub-agent review of this branch
  applied (folded into a follow-up commit): the impossible "ask the caller"
  instruction, the unverifiable check/test bullet, the stale utility-skill
  example in Shared Memory, and utility-row ordering in the skills table.

This branch was itself reviewed via the new `gemba-review` skill in a
fresh sub-agent — 0 blockers, 0 high, 0 medium. The four low findings the
reviewer raised are addressed in commit `abfce52`.

## Test plan

- [x] `bun run check` (format + lint, all file types)
- [x] `bun run test` (full unit test suite)
- [x] Clean sub-agent review of full diff via `gemba-review` (the new
      skill reviewing its own introduction — the canonical test that the
      structural recursion fix actually works)
- [x] Manual verification that all relative links resolve and the
      `#recursion-safe-self-review` GitHub anchor matches the heading slug