### PR TITLE
plan(390): consistent package layout

### DIFF
--- a/specs/390-consistent-package-layout/plan-a-01.md
+++ b/specs/390-consistent-package-layout/plan-a-01.md
@@ -1,0 +1,223 @@
+# Plan A — Part 01: Allowed-root-subdirs check infrastructure
+
+Introduce the layout contract as an executable check, running in **permissive
+mode** for the duration of the migration (Parts 02–07) and switched to
+**strict mode** by Part 08. This part adds no enforcement against existing
+drift yet — it only makes the drift visible.
+
+## Scope
+
+Add a new `bun run layout` script that walks every package under `products/`,
+`services/`, and `libraries/`, lists each root subdirectory, and reports any
+directory not on the allowed list. In permissive mode it prints the drift and
+exits 0; in strict mode it exits non-zero.
+
+This part also wires the new script into `bun run check` and the CI quality
+workflow, so subsequent parts can see their progress with a single command.
+
+## Files created
+
+- `scripts/check-package-layout.js` — the check implementation (≈80 lines).
+
+## Files modified
+
+- `package.json` — add `layout` script; add `layout` to the `check` pipeline:
+  ```jsonc
+  "scripts": {
+    "check": "bun run format && bun run lint && bun run layout",
+    "check:fix": "bun run format:fix && bun run lint:fix",
+    "layout": "node scripts/check-package-layout.js",
+    // ...
+  }
+  ```
+- `.github/workflows/check-quality.yml` — add a third job `layout`:
+  ```yaml
+  layout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/bootstrap
+      - run: bun run layout
+  ```
+- `justfile` — add a `layout` recipe under `## ── Quality ──` for convenience:
+  ```make
+  # Check package layout against allowed-subdirs contract
+  layout:
+      bun run layout
+  ```
+
+## Check implementation
+
+`scripts/check-package-layout.js` walks `products/*`, `services/*`, and
+`libraries/*` and inspects each package directory. It takes an optional
+`--strict` flag (default: permissive).
+
+```js
+#!/usr/bin/env node
+// Check every package under products/, services/, libraries/ for conformance
+// to the allowed-root-subdirs contract (spec 390).
+
+import { readdirSync, statSync, existsSync } from "node:fs";
+import { join, basename } from "node:path";
+
+const ALLOWED_SUBDIRS = new Set([
+  "bin",
+  "config",
+  "macos",
+  "pkg",
+  "proto",
+  "schema",
+  "src",
+  "starter",
+  "supabase",
+  "templates",
+  "test",
+]);
+
+// Dirs the working tree may contain but that are gitignored / out of scope.
+const IGNORED_SUBDIRS = new Set(["node_modules"]);
+
+const TIERS = ["products", "services", "libraries"];
+const strict = process.argv.includes("--strict");
+
+const violations = [];
+const rootSourceFiles = [];
+
+for (const tier of TIERS) {
+  for (const pkgName of readdirSync(tier)) {
+    const pkgDir = join(tier, pkgName);
+    if (!statSync(pkgDir).isDirectory()) continue;
+
+    for (const entry of readdirSync(pkgDir)) {
+      const entryPath = join(pkgDir, entry);
+      const stat = statSync(entryPath);
+
+      if (stat.isDirectory()) {
+        if (IGNORED_SUBDIRS.has(entry)) continue;
+        if (!ALLOWED_SUBDIRS.has(entry)) {
+          violations.push({ pkg: pkgDir, subdir: entry });
+        }
+        continue;
+      }
+
+      // Root-level source files.
+      if (entry.endsWith(".js") || entry.endsWith(".ts")) {
+        // Services are allowed exactly two: index.js and server.js.
+        if (tier === "services") {
+          if (entry !== "index.js" && entry !== "server.js") {
+            rootSourceFiles.push({ pkg: pkgDir, file: entry });
+          }
+        } else {
+          rootSourceFiles.push({ pkg: pkgDir, file: entry });
+        }
+      }
+    }
+  }
+}
+
+if (violations.length || rootSourceFiles.length) {
+  console.error("Package layout drift detected (spec 390):\n");
+
+  if (violations.length) {
+    console.error("  Non-allowed root subdirectories:");
+    for (const v of violations) {
+      console.error(`    ${v.pkg}/${v.subdir}/`);
+    }
+    console.error(
+      "\n  Allowed: " + [...ALLOWED_SUBDIRS].sort().join(", ") + "\n",
+    );
+  }
+
+  if (rootSourceFiles.length) {
+    console.error("  Root-level source files (move into src/):");
+    for (const f of rootSourceFiles) {
+      console.error(`    ${f.pkg}/${f.file}`);
+    }
+    console.error(
+      "\n  Services may keep only index.js and server.js at the root.\n",
+    );
+  }
+
+  if (strict) {
+    process.exit(1);
+  }
+  console.error("  (Permissive mode — not failing. Pass --strict to fail.)");
+}
+```
+
+**Key design choices:**
+
+- Uses `readdirSync` on the working tree (not `git ls-files`) because the
+  check runs _before_ the working tree is committed and needs to see in-flight
+  changes. `node_modules/` is explicitly skipped so `libskill/node_modules/`
+  (created by Bun for workspace deps) does not trip the check.
+- Permissive is the default so every intermediate commit in Parts 02–07 still
+  passes CI. Strict mode is enabled in Part 08.
+- Report is grouped by violation type for easy scanning — non-allowed subdirs
+  first, then root source files.
+- Output is plaintext (not JSON) because it runs in CI logs and in terminal.
+  Adding JSON output later is easy; do not add it speculatively.
+
+## Ordering
+
+1. Write `scripts/check-package-layout.js`.
+2. Add the `layout` script to `package.json`, wire it into `check`.
+3. Add `layout` recipe to `justfile`.
+4. Add the `layout` job to `check-quality.yml`.
+5. Run `bun run layout` locally — **expect it to report drift** (that is the
+   whole point of permissive mode). Verify the report lists all the
+   non-conforming packages the spec calls out (`libui`, `libskill`,
+   `libsyntheticgen`, `libharness`, `products/guide`, `products/map`, etc.).
+6. Run `bun run check` — should pass (permissive mode exits 0 on drift).
+7. Commit as `refactor(layout): add package layout contract check (permissive)`.
+8. Push.
+
+## Verification
+
+- `bun run layout` prints the drift report and exits 0.
+- `bun run layout --strict` prints the drift report and exits 1.
+- `bun run check` exits 0.
+- `bun run test` exits 0.
+- Drift report includes at minimum: `products/guide/lib`, `products/map/activity`,
+  `libraries/libharness/packages`, `libraries/libharness/fixture`,
+  `libraries/libharness/mock`, `libraries/libskill/policies`,
+  `libraries/libsyntheticgen/dsl`, `libraries/libsyntheticgen/engine`,
+  `libraries/libsyntheticgen/tools`, `libraries/libsyntheticprose/engine`,
+  `libraries/libsyntheticprose/prompts`, `libraries/libsyntheticrender/render`,
+  `libraries/libui/components`, `libraries/libui/css`, and root `.js` files in
+  every library that has them.
+
+## Risks
+
+- **False positives from `.ts` files.** Today no package uses `.ts` source at
+  the root, but the check forbids them. That matches the spec's rule #1. No
+  change required; flagged for the implementer so an unrelated `.ts` file
+  introduction is caught quickly.
+- **Permissive drift is invisible to CI.** The new `layout` job prints to
+  stderr but exits 0 during the migration. A reviewer skimming the CI status
+  page will not notice ongoing drift. Mitigation: Part 08 flips strict mode
+  on. Between Part 01 and Part 08, drift is visible locally via
+  `bun run layout` but not enforced in PRs — acceptable for the two-hour
+  planning-to-landing window of this branch.
+- **Running `node scripts/check-package-layout.js` from a subdirectory
+  breaks.** The script uses relative paths (`products/`, `libraries/`,
+  `services/`). Wire it exclusively via `bun run layout` from the monorepo
+  root. Do not invoke directly.
+
+## Deliverable commit
+
+```
+refactor(layout): add package layout contract check (permissive)
+
+Introduces bun run layout, powered by scripts/check-package-layout.js,
+which reports any package root subdir outside the allowed contract from
+spec 390 and any root-level source file. Permissive by default — the
+check prints drift but exits 0 until every package conforms and strict
+mode is enabled in part 08.
+
+Wires layout into bun run check and the check-quality CI workflow.
+
+Part 01 of 08 for spec 390.
+```
+
+— Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a-01.md
+++ b/specs/390-consistent-package-layout/plan-a-01.md
@@ -1,9 +1,9 @@
 # Plan A — Part 01: Allowed-root-subdirs check infrastructure
 
 Introduce the layout contract as an executable check, running in **permissive
-mode** for the duration of the migration (Parts 02–07) and switched to
-**strict mode** by Part 08. This part adds no enforcement against existing
-drift yet — it only makes the drift visible.
+mode** for the duration of the migration (Parts 02–07) and switched to **strict
+mode** by Part 08. This part adds no enforcement against existing drift yet — it
+only makes the drift visible.
 
 ## Scope
 
@@ -147,8 +147,8 @@ if (violations.length || rootSourceFiles.length) {
 
 **Key design choices:**
 
-- Uses `readdirSync` on the working tree (not `git ls-files`) because the
-  check runs _before_ the working tree is committed and needs to see in-flight
+- Uses `readdirSync` on the working tree (not `git ls-files`) because the check
+  runs _before_ the working tree is committed and needs to see in-flight
   changes. `node_modules/` is explicitly skipped so `libskill/node_modules/`
   (created by Bun for workspace deps) does not trip the check.
 - Permissive is the default so every intermediate commit in Parts 02–07 still
@@ -178,14 +178,14 @@ if (violations.length || rootSourceFiles.length) {
 - `bun run layout --strict` prints the drift report and exits 1.
 - `bun run check` exits 0.
 - `bun run test` exits 0.
-- Drift report includes at minimum: `products/guide/lib`, `products/map/activity`,
-  `libraries/libharness/packages`, `libraries/libharness/fixture`,
-  `libraries/libharness/mock`, `libraries/libskill/policies`,
-  `libraries/libsyntheticgen/dsl`, `libraries/libsyntheticgen/engine`,
-  `libraries/libsyntheticgen/tools`, `libraries/libsyntheticprose/engine`,
-  `libraries/libsyntheticprose/prompts`, `libraries/libsyntheticrender/render`,
-  `libraries/libui/components`, `libraries/libui/css`, and root `.js` files in
-  every library that has them.
+- Drift report includes at minimum: `products/guide/lib`,
+  `products/map/activity`, `libraries/libharness/packages`,
+  `libraries/libharness/fixture`, `libraries/libharness/mock`,
+  `libraries/libskill/policies`, `libraries/libsyntheticgen/dsl`,
+  `libraries/libsyntheticgen/engine`, `libraries/libsyntheticgen/tools`,
+  `libraries/libsyntheticprose/engine`, `libraries/libsyntheticprose/prompts`,
+  `libraries/libsyntheticrender/render`, `libraries/libui/components`,
+  `libraries/libui/css`, and root `.js` files in every library that has them.
 
 ## Risks
 
@@ -193,16 +193,16 @@ if (violations.length || rootSourceFiles.length) {
   the root, but the check forbids them. That matches the spec's rule #1. No
   change required; flagged for the implementer so an unrelated `.ts` file
   introduction is caught quickly.
-- **Permissive drift is invisible to CI.** The new `layout` job prints to
-  stderr but exits 0 during the migration. A reviewer skimming the CI status
-  page will not notice ongoing drift. Mitigation: Part 08 flips strict mode
-  on. Between Part 01 and Part 08, drift is visible locally via
-  `bun run layout` but not enforced in PRs — acceptable for the two-hour
-  planning-to-landing window of this branch.
-- **Running `node scripts/check-package-layout.js` from a subdirectory
-  breaks.** The script uses relative paths (`products/`, `libraries/`,
-  `services/`). Wire it exclusively via `bun run layout` from the monorepo
-  root. Do not invoke directly.
+- **Permissive drift is invisible to CI.** The new `layout` job prints to stderr
+  but exits 0 during the migration. A reviewer skimming the CI status page will
+  not notice ongoing drift. Mitigation: Part 08 flips strict mode on. Between
+  Part 01 and Part 08, drift is visible locally via `bun run layout` but not
+  enforced in PRs — acceptable for the two-hour planning-to-landing window of
+  this branch.
+- **Running `node scripts/check-package-layout.js` from a subdirectory breaks.**
+  The script uses relative paths (`products/`, `libraries/`, `services/`). Wire
+  it exclusively via `bun run layout` from the monorepo root. Do not invoke
+  directly.
 
 ## Deliverable commit
 

--- a/specs/390-consistent-package-layout/plan-a-02.md
+++ b/specs/390-consistent-package-layout/plan-a-02.md
@@ -154,6 +154,11 @@ and `libtype/src/generated` symlink into it.
 
 ## Ordering
 
+All steps below land in a **single atomic commit**. Do not commit
+intermediate states — an intermediate commit leaves the tree in a state
+where codegen writes symlinks to paths whose `src/` parent may or may not
+exist.
+
 1. Read `libraries/libutil/finder.js` lines 108–167 to confirm the exact
    shape of `findGeneratedPath` and `createPackageSymlinks`.
 2. Change `findGeneratedPath` line 117 from `"generated"` →
@@ -161,24 +166,33 @@ and `libtype/src/generated` symlink into it.
 3. Add the target-parent `mkdir -p` in `createSymlink` before the
    `fsAsync.symlink(...)` call on line 143.
 4. Move `librpc` root sources to `src/` (7 files: auth.js, base.js,
-   client.js, health.js, index.js, interceptor.js, server.js).
+   client.js, health.js, index.js, interceptor.js, server.js). Use
+   `git mv` so history is preserved.
 5. Move `libtype` root source to `src/` (1 file: index.js).
 6. Remove both old symlinks explicitly:
    `rm libraries/librpc/generated libraries/libtype/generated`.
-7. Run `just codegen` — recreates symlinks at the new `src/generated`
+7. Update `librpc` and `libtype` `package.json` files (`main`, `files`).
+8. Run `just codegen` — recreates symlinks at the new `src/generated`
    paths. Verify both symlinks now point at the monorepo-root
-   `generated/` directory.
-8. Update `librpc` and `libtype` `package.json` files (`main`, `files`).
-9. Verify internal imports still resolve — should be a no-op because the
-   symlinks moved with the importing files.
-10. Run `bun run check` and `bun run test`.
-11. Verify the monorepo-root `generated/` directory is unchanged (still
+   `generated/` directory (still absolute). If `just codegen` fails at
+   this point, **roll back the finder.js edit**, investigate, and do not
+   proceed. Do not commit a partial state.
+9. Run `bun run node --test libraries/librpc/test/*.test.js` and
+   `bun run node --test libraries/libtype/test/*.test.js`.
+10. Run `bun run check` and `bun run test` (full suite).
+11. Run `npm pack --workspace=@forwardimpact/librpc --dry-run` and
+    `npm pack --workspace=@forwardimpact/libtype --dry-run`. Confirm the
+    tarball contents include `src/*.js` and do not include the
+    `src/generated/` symlink. If either tarball's file list differs from
+    the pre-move baseline in unexpected ways, investigate before
+    committing.
+12. Verify the monorepo-root `generated/` directory is unchanged (still
     contains `types/`, `services/`, `definitions/`, `proto/`,
     `bundle.tar.gz`, `package.json`).
-12. Verify the symlinks resolve: `ls libraries/librpc/src/generated/services/`
-    should list the service subdirs;
-    `ls libraries/libtype/src/generated/types/` should list `types.js`.
-13. Commit.
+13. Verify the new symlinks resolve:
+    `ls libraries/librpc/src/generated/services/` and
+    `ls libraries/libtype/src/generated/types/`.
+14. Commit all changes as one atomic commit.
 
 ## Verification
 
@@ -201,12 +215,13 @@ and `libtype/src/generated` symlink into it.
    the root `generated/` directory, and then codegen must regenerate it.
    Codegen is idempotent but takes ~1 minute to run.
 
-2. **Symlink path is relative vs absolute.** The current implementation of
-   `createPackageSymlinks` uses either relative or absolute symlink targets.
-   Read the code to find out which before editing. A relative symlink must
-   reference `../../../generated` (from `libraries/librpc/src/generated`);
-   an absolute symlink references the full monorepo root. Preserve whichever
-   convention is currently in use.
+2. **Symlink path is absolute.** Verified on disk:
+   `libraries/librpc/generated → /home/user/monorepo/generated` — an
+   absolute path. `createSymlink()` passes `sourcePath` (the resolved
+   `generatedPath` argument to `createPackageSymlinks`) straight through
+   `fsAsync.symlink`. Absolute is fine inside a single working tree and
+   survives `just codegen` runs. The migration preserves this convention —
+   the target directory moves, the source target stays absolute.
 
 3. **Stale symlinks left behind.** If the old `libraries/librpc/generated`
    and `libraries/libtype/generated` symlinks are not removed before
@@ -222,27 +237,55 @@ and `libtype/src/generated` symlink into it.
    would break the upward search because there is no monorepo-root
    `src/generated` — the `src/` directories only exist inside packages.
 
-5. **`files` field in `package.json` for librpc and libtype.** Symlinks are
-   not typically published in npm tarballs — `npm pack` may either follow
-   them (including the target files) or skip them (leaving the consumer's
-   install broken). Today this works because the symlink target is
-   co-located inside the same package tree once codegen runs.
+5. **The published npm tarballs never contain the generated tree —
+   confirmed, and this is fine.** `npm pack --workspace=@forwardimpact/librpc
+   --dry-run` against `main` (version 0.1.88) produces a 13-file tarball
+   containing `auth.js`, `base.js`, `bin/fit-unary.js`, `client.js`,
+   `health.js`, `index.js`, `interceptor.js`, `package.json`, `server.js`,
+   and four test files. The `generated/` symlink is silently dropped by
+   `npm pack` (npm excludes dangling/absolute symlinks). No `files` field
+   exists in `librpc` or `libtype` today, so npm uses its default include
+   list.
 
-   Check with `npm pack --dry-run` in `librpc` and `libtype` post-move.
-   The `files` field should include:
+   External consumers of `@forwardimpact/librpc` install the package and
+   then run `npx fit-codegen --all` as documented in the distribution
+   model (`CLAUDE.md § Distribution Model`). fit-codegen writes the
+   generated tree into the consumer's own project root and creates
+   symlinks at `node_modules/@forwardimpact/{librpc,libtype}/generated`
+   pointing at the consumer's generated directory.
+
+   **Post-move behaviour:** after Part 02 the tarball contents become
+   `src/auth.js`, `src/base.js`, `src/client.js`, `src/health.js`,
+   `src/index.js`, `src/interceptor.js`, `src/server.js`, plus
+   `bin/fit-unary.js`, `package.json`, and `test/*.test.js`. The symlink
+   is still silently dropped. When the consumer runs `npx fit-codegen`,
+   the new `findGeneratedPath` creates the symlink at
+   `node_modules/@forwardimpact/librpc/src/generated` — which requires
+   `node_modules/@forwardimpact/librpc/src/` to exist, which it does
+   because the published tarball contains `src/*.js` files. The `mkdir -p`
+   guard added to `createSymlink()` in Part 02 ensures this works even
+   on packages that end up without a `src/` directory in the tarball.
+
+   **Contributor-local behaviour** (`just codegen` in the monorepo): the
+   symlink is created at `libraries/librpc/src/generated` pointing at
+   `/home/user/monorepo/generated` (absolute path). Running tests loads
+   through the symlink and still works.
+
+   Fresh-install smoke test (Part 08) must include at least one
+   `librpc`/`libtype` import to catch any regression.
+
+6. **Both `librpc` and `libtype` lack a `files` field.** This is the
+   reason the smoke-tested pack works: npm defaults include everything
+   not explicitly gitignored. Part 02 introduces a `files` field for
+   cleanliness:
    ```jsonc
    "files": ["src/**/*.js", "bin/**/*.js", "README.md"]
    ```
-
-   If `npm pack` does not include the generated tree, either:
-   - List `src/generated/**` explicitly in `files` (may not follow the
-     symlink either), OR
-   - Run codegen during publish and inline the generated files as real
-     files before publishing (requires a prepublish step — out of scope
-     for this spec).
-
-   The fresh-install smoke test in Part 08 catches this at the end of the
-   migration. If it fails, escalate and add a targeted fix.
+   `src/generated/**` is **not** listed — the generated files are never
+   checked into the tarball; they are regenerated client-side. If
+   `npm pack --dry-run` post-Part-02 shows a different file set than the
+   pre-move baseline (minus the moved paths), investigate before
+   committing.
 
 ## Deliverable commit
 

--- a/specs/390-consistent-package-layout/plan-a-02.md
+++ b/specs/390-consistent-package-layout/plan-a-02.md
@@ -1,0 +1,265 @@
+# Plan A — Part 02: Codegen pipeline → `src/generated/`
+
+Move the per-package codegen symlinks so that every package that consumes
+generated code imports it via `src/generated/` instead of a root-level
+`generated/`. The monorepo-root `generated/` directory — the real codegen
+output target — is **unchanged**. Only the symlinks into it from `librpc`
+and `libtype` move.
+
+## Scope
+
+- **libstorage is not touched.** The "generated" storage bucket continues
+  to resolve to the monorepo-root `generated/` directory via
+  `libstorage/index.js#_createLocalStorage` (lines 111–146, `switch (prefix)`
+  at lines 114–123 maps `"generated"` → `"generated"`). This is correct and
+  load-bearing: `Finder.findUpward` searches upward for the relative path
+  literal, and the monorepo has exactly one `generated/` directory at the
+  root. Changing this mapping would break the upward search.
+- Update `libraries/libutil/finder.js#findGeneratedPath` so the per-package
+  symlink targets `<packagePath>/src/generated` instead of
+  `<packagePath>/generated`. This is a one-line change at line 117.
+- Ensure `<packagePath>/src/` exists before the symlink is created — add a
+  `mkdir -p` in `createPackageSymlinks` (or in `createSymlink` near line 128,
+  wrapping the `targetPath`'s parent directory).
+- Create `libraries/librpc/src/` and `libraries/libtype/src/` (the two
+  packages that own the symlinks) and move every root-level source file into
+  `src/` using the cross-cutting recipe in `plan-a.md`.
+- The internal imports inside the moved files are **unchanged** because the
+  symlink moves with the importing files:
+  - `libraries/librpc/base.js` → `libraries/librpc/src/base.js`, import
+    `./generated/definitions/exports.js` still resolves via the new
+    symlink at `libraries/librpc/src/generated`.
+  - `libraries/librpc/index.js` → `libraries/librpc/src/index.js`, import
+    `./generated/services/exports.js` — same.
+  - `libraries/libtype/index.js` → `libraries/libtype/src/index.js`, import
+    `./generated/types/types.js` — same.
+- Update `librpc` and `libtype` `package.json` fields (`main`, `files`) to
+  point at `src/`.
+- Re-run `just codegen` so the symlinks are recreated at their new targets.
+
+## Rationale
+
+`libraries/librpc/generated` and `libraries/libtype/generated` are
+**symlinks** into the monorepo-root `generated/` directory. The symlinks are
+created by `libutil/finder.js#createPackageSymlinks` (line 156), which
+hardcodes the package list `["libtype", "librpc"]` and uses
+`findGeneratedPath(projectRoot, packageName)` (line 115) to compute the
+target: currently `join(packagePath, "generated")`.
+
+Moving the **symlink target** — not the monorepo-root directory — into each
+consumer's `src/` satisfies the "no generated/ at the package root" rule
+while keeping the single codegen output tree at the monorepo root.
+
+The internal imports that reach into `./generated/...` do **not** change
+because they are relative to the importing file: when both the file and the
+symlink move together into `src/`, `./generated/...` still resolves.
+
+## Files modified
+
+### libutil
+
+- `libraries/libutil/finder.js` — single-line change at line 117 in
+  `findGeneratedPath(projectRoot, packageName)`:
+  ```js
+  // Before:
+  return path.join(packagePath, "generated");
+
+  // After:
+  return path.join(packagePath, "src", "generated");
+  ```
+  `createSymlink()` (lines 126–148) already removes any pre-existing target
+  (symlink or directory) before creating the new one, so it cleans up the
+  old `libraries/<pkg>/generated` location automatically the first time it
+  runs against the new target path.
+
+- Additionally, `createSymlink()` needs to ensure the target's **parent**
+  directory exists. Today it does `mkdir -p` on the source, not the target.
+  Add a `mkdir -p` for the target parent (`libraries/<pkg>/src/`) before
+  the `fsAsync.symlink(sourcePath, targetPath)` call on line 143:
+  ```js
+  await fsAsync.mkdir(path.dirname(targetPath), { recursive: true });
+  await fsAsync.symlink(sourcePath, targetPath, "dir");
+  ```
+  Without this, the first codegen run after the move fails with ENOENT
+  because `libraries/librpc/src/` does not yet exist when the symlink is
+  being created.
+
+### Cleanup: remove pre-existing symlinks at old locations
+
+`createSymlink()` removes pre-existing targets at the **new** location, but
+it does not know about the **old** location. After the rewrite, the
+previous symlinks at `libraries/librpc/generated` and
+`libraries/libtype/generated` are still on disk (as lingering artifacts
+from before the edit).
+
+Delete them explicitly as part of Part 02:
+```sh
+rm libraries/librpc/generated
+rm libraries/libtype/generated
+```
+
+Commit the removal in the same commit as the code change so the branch is
+clean.
+
+### librpc
+
+Apply the cross-cutting move recipe from `plan-a.md`:
+
+1. `mkdir -p libraries/librpc/src`
+2. `git mv libraries/librpc/auth.js libraries/librpc/src/auth.js`
+3. Same for `base.js`, `client.js`, `health.js`, `index.js`, `interceptor.js`,
+   `server.js` (total 7 root `.js` files per the inventory).
+4. Remove the existing dead symlink: `rm libraries/librpc/generated`.
+5. Run `just codegen` — this recreates the symlink at
+   `libraries/librpc/src/generated` pointing into the root `generated/`.
+6. Update `libraries/librpc/package.json`:
+   ```jsonc
+   {
+     "main": "./src/index.js",
+     "bin": { "fit-unary": "./bin/fit-unary.js" },
+     "files": ["src/**/*.js", "bin/**/*.js", "README.md"]
+   }
+   ```
+   No `exports` field is added — librpc does not currently publish subpath
+   exports and this spec does not introduce new ones.
+7. Confirm internal imports work unchanged — `./generated/services/exports.js`
+   resolves because both files are now in `src/` and the symlink is at
+   `src/generated`.
+8. Run `bun run node --test libraries/librpc/test/*.test.js`.
+
+### libtype
+
+Same recipe, simpler because libtype has exactly one root source file:
+
+1. `mkdir -p libraries/libtype/src`
+2. `git mv libraries/libtype/index.js libraries/libtype/src/index.js`
+3. `rm libraries/libtype/generated`.
+4. `just codegen` — recreates `libraries/libtype/src/generated`.
+5. Update `libraries/libtype/package.json`:
+   ```jsonc
+   {
+     "main": "./src/index.js",
+     "files": ["src/**/*.js", "README.md"]
+   }
+   ```
+6. Internal import `./generated/types/types.js` still resolves through the
+   new symlink.
+7. Run `bun run node --test libraries/libtype/test/*.test.js`.
+
+### Root generated/ — unchanged
+
+The monorepo-root `generated/` directory is **not** moved. It is outside any
+package and is the real codegen output target. Both `librpc/src/generated`
+and `libtype/src/generated` symlink into it.
+
+## Ordering
+
+1. Read `libraries/libutil/finder.js` lines 108–167 to confirm the exact
+   shape of `findGeneratedPath` and `createPackageSymlinks`.
+2. Change `findGeneratedPath` line 117 from `"generated"` →
+   `path.join("src", "generated")`.
+3. Add the target-parent `mkdir -p` in `createSymlink` before the
+   `fsAsync.symlink(...)` call on line 143.
+4. Move `librpc` root sources to `src/` (7 files: auth.js, base.js,
+   client.js, health.js, index.js, interceptor.js, server.js).
+5. Move `libtype` root source to `src/` (1 file: index.js).
+6. Remove both old symlinks explicitly:
+   `rm libraries/librpc/generated libraries/libtype/generated`.
+7. Run `just codegen` — recreates symlinks at the new `src/generated`
+   paths. Verify both symlinks now point at the monorepo-root
+   `generated/` directory.
+8. Update `librpc` and `libtype` `package.json` files (`main`, `files`).
+9. Verify internal imports still resolve — should be a no-op because the
+   symlinks moved with the importing files.
+10. Run `bun run check` and `bun run test`.
+11. Verify the monorepo-root `generated/` directory is unchanged (still
+    contains `types/`, `services/`, `definitions/`, `proto/`,
+    `bundle.tar.gz`, `package.json`).
+12. Verify the symlinks resolve: `ls libraries/librpc/src/generated/services/`
+    should list the service subdirs;
+    `ls libraries/libtype/src/generated/types/` should list `types.js`.
+13. Commit.
+
+## Verification
+
+- `just codegen` succeeds and writes the same output as before.
+- `libraries/librpc/src/generated` is a symlink to the root `generated/`.
+- `libraries/libtype/src/generated` is a symlink to the root `generated/`.
+- `bun run node --test libraries/librpc/test/*.test.js` passes.
+- `bun run node --test libraries/libtype/test/*.test.js` passes.
+- Every service under `services/*` still imports from `@forwardimpact/librpc`
+  successfully — `bun run test` at repo root passes.
+- No root-level `.js` files remain in `libraries/librpc/` or
+  `libraries/libtype/`.
+- `bun run layout` (permissive) no longer lists `librpc/generated` or
+  `libtype/generated` as drift (the symlinks are now under `src/`).
+
+## Risks
+
+1. **`just codegen` is destructive if the root `generated/` is cleaned
+   first.** Do not run `just data-reset` before this part — it will delete
+   the root `generated/` directory, and then codegen must regenerate it.
+   Codegen is idempotent but takes ~1 minute to run.
+
+2. **Symlink path is relative vs absolute.** The current implementation of
+   `createPackageSymlinks` uses either relative or absolute symlink targets.
+   Read the code to find out which before editing. A relative symlink must
+   reference `../../../generated` (from `libraries/librpc/src/generated`);
+   an absolute symlink references the full monorepo root. Preserve whichever
+   convention is currently in use.
+
+3. **Stale symlinks left behind.** If the old `libraries/librpc/generated`
+   and `libraries/libtype/generated` symlinks are not removed before
+   recreating them, `git status` will show them as tracked files pointing at
+   stale targets. Delete them explicitly in step 7 above.
+
+4. **The `Finder.findUpward` search in libstorage is load-bearing.** The
+   `"generated"` storage bucket maps through a switch case at
+   `libstorage/index.js` line 116 that sets `relative = "generated"`.
+   `Finder.findUpward(cwd, "generated")` then searches upward for a
+   directory ending in `generated/`, finding the monorepo root's
+   `generated/`. **Do not change this case.** Changing it to `src/generated`
+   would break the upward search because there is no monorepo-root
+   `src/generated` — the `src/` directories only exist inside packages.
+
+5. **`files` field in `package.json` for librpc and libtype.** Symlinks are
+   not typically published in npm tarballs — `npm pack` may either follow
+   them (including the target files) or skip them (leaving the consumer's
+   install broken). Today this works because the symlink target is
+   co-located inside the same package tree once codegen runs.
+
+   Check with `npm pack --dry-run` in `librpc` and `libtype` post-move.
+   The `files` field should include:
+   ```jsonc
+   "files": ["src/**/*.js", "bin/**/*.js", "README.md"]
+   ```
+
+   If `npm pack` does not include the generated tree, either:
+   - List `src/generated/**` explicitly in `files` (may not follow the
+     symlink either), OR
+   - Run codegen during publish and inline the generated files as real
+     files before publishing (requires a prepublish step — out of scope
+     for this spec).
+
+   The fresh-install smoke test in Part 08 catches this at the end of the
+   migration. If it fails, escalate and add a targeted fix.
+
+## Deliverable commit
+
+```
+refactor(layout): move codegen symlinks under src/ (part 02/08)
+
+Updates findGeneratedPath in libutil/finder.js so fit-codegen creates
+per-package symlinks at libraries/<pkg>/src/generated pointing at the
+(unchanged) monorepo-root generated/ directory. libstorage's bucket
+resolution is untouched — the monorepo-root generated/ directory is
+still the single codegen output target.
+
+Moves librpc (7 files) and libtype (1 file) root sources into src/.
+Both packages' internal ./generated/... imports resolve unchanged
+because the symlinks move with the importing files.
+
+Part 02 of 08 for spec 390.
+```
+
+— Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a-02.md
+++ b/specs/390-consistent-package-layout/plan-a-02.md
@@ -2,57 +2,57 @@
 
 Move the per-package codegen symlinks so that every package that consumes
 generated code imports it via `src/generated/` instead of a root-level
-`generated/`. The monorepo-root `generated/` directory — the real codegen
-output target — is **unchanged**. Only the symlinks into it from `librpc`
-and `libtype` move.
+`generated/`. The monorepo-root `generated/` directory — the real codegen output
+target — is **unchanged**. Only the symlinks into it from `librpc` and `libtype`
+move.
 
 ## Scope
 
-- **libstorage is not touched.** The "generated" storage bucket continues
-  to resolve to the monorepo-root `generated/` directory via
-  `libstorage/index.js#_createLocalStorage` (lines 111–146, `switch (prefix)`
-  at lines 114–123 maps `"generated"` → `"generated"`). This is correct and
+- **libstorage is not touched.** The "generated" storage bucket continues to
+  resolve to the monorepo-root `generated/` directory via
+  `libstorage/index.js#_createLocalStorage` (lines 111–146, `switch (prefix)` at
+  lines 114–123 maps `"generated"` → `"generated"`). This is correct and
   load-bearing: `Finder.findUpward` searches upward for the relative path
-  literal, and the monorepo has exactly one `generated/` directory at the
-  root. Changing this mapping would break the upward search.
+  literal, and the monorepo has exactly one `generated/` directory at the root.
+  Changing this mapping would break the upward search.
 - Update `libraries/libutil/finder.js#findGeneratedPath` so the per-package
   symlink targets `<packagePath>/src/generated` instead of
   `<packagePath>/generated`. This is a one-line change at line 117.
 - Ensure `<packagePath>/src/` exists before the symlink is created — add a
   `mkdir -p` in `createPackageSymlinks` (or in `createSymlink` near line 128,
   wrapping the `targetPath`'s parent directory).
-- Create `libraries/librpc/src/` and `libraries/libtype/src/` (the two
-  packages that own the symlinks) and move every root-level source file into
-  `src/` using the cross-cutting recipe in `plan-a.md`.
+- Create `libraries/librpc/src/` and `libraries/libtype/src/` (the two packages
+  that own the symlinks) and move every root-level source file into `src/` using
+  the cross-cutting recipe in `plan-a.md`.
 - The internal imports inside the moved files are **unchanged** because the
   symlink moves with the importing files:
   - `libraries/librpc/base.js` → `libraries/librpc/src/base.js`, import
-    `./generated/definitions/exports.js` still resolves via the new
-    symlink at `libraries/librpc/src/generated`.
+    `./generated/definitions/exports.js` still resolves via the new symlink at
+    `libraries/librpc/src/generated`.
   - `libraries/librpc/index.js` → `libraries/librpc/src/index.js`, import
     `./generated/services/exports.js` — same.
   - `libraries/libtype/index.js` → `libraries/libtype/src/index.js`, import
     `./generated/types/types.js` — same.
-- Update `librpc` and `libtype` `package.json` fields (`main`, `files`) to
-  point at `src/`.
+- Update `librpc` and `libtype` `package.json` fields (`main`, `files`) to point
+  at `src/`.
 - Re-run `just codegen` so the symlinks are recreated at their new targets.
 
 ## Rationale
 
-`libraries/librpc/generated` and `libraries/libtype/generated` are
-**symlinks** into the monorepo-root `generated/` directory. The symlinks are
-created by `libutil/finder.js#createPackageSymlinks` (line 156), which
-hardcodes the package list `["libtype", "librpc"]` and uses
-`findGeneratedPath(projectRoot, packageName)` (line 115) to compute the
-target: currently `join(packagePath, "generated")`.
+`libraries/librpc/generated` and `libraries/libtype/generated` are **symlinks**
+into the monorepo-root `generated/` directory. The symlinks are created by
+`libutil/finder.js#createPackageSymlinks` (line 156), which hardcodes the
+package list `["libtype", "librpc"]` and uses
+`findGeneratedPath(projectRoot, packageName)` (line 115) to compute the target:
+currently `join(packagePath, "generated")`.
 
 Moving the **symlink target** — not the monorepo-root directory — into each
-consumer's `src/` satisfies the "no generated/ at the package root" rule
-while keeping the single codegen output tree at the monorepo root.
+consumer's `src/` satisfies the "no generated/ at the package root" rule while
+keeping the single codegen output tree at the monorepo root.
 
-The internal imports that reach into `./generated/...` do **not** change
-because they are relative to the importing file: when both the file and the
-symlink move together into `src/`, `./generated/...` still resolves.
+The internal imports that reach into `./generated/...` do **not** change because
+they are relative to the importing file: when both the file and the symlink move
+together into `src/`, `./generated/...` still resolves.
 
 ## Files modified
 
@@ -60,6 +60,7 @@ symlink move together into `src/`, `./generated/...` still resolves.
 
 - `libraries/libutil/finder.js` — single-line change at line 117 in
   `findGeneratedPath(projectRoot, packageName)`:
+
   ```js
   // Before:
   return path.join(packagePath, "generated");
@@ -67,39 +68,38 @@ symlink move together into `src/`, `./generated/...` still resolves.
   // After:
   return path.join(packagePath, "src", "generated");
   ```
+
   `createSymlink()` (lines 126–148) already removes any pre-existing target
-  (symlink or directory) before creating the new one, so it cleans up the
-  old `libraries/<pkg>/generated` location automatically the first time it
-  runs against the new target path.
+  (symlink or directory) before creating the new one, so it cleans up the old
+  `libraries/<pkg>/generated` location automatically the first time it runs
+  against the new target path.
 
 - Additionally, `createSymlink()` needs to ensure the target's **parent**
-  directory exists. Today it does `mkdir -p` on the source, not the target.
-  Add a `mkdir -p` for the target parent (`libraries/<pkg>/src/`) before
-  the `fsAsync.symlink(sourcePath, targetPath)` call on line 143:
+  directory exists. Today it does `mkdir -p` on the source, not the target. Add
+  a `mkdir -p` for the target parent (`libraries/<pkg>/src/`) before the
+  `fsAsync.symlink(sourcePath, targetPath)` call on line 143:
   ```js
   await fsAsync.mkdir(path.dirname(targetPath), { recursive: true });
   await fsAsync.symlink(sourcePath, targetPath, "dir");
   ```
-  Without this, the first codegen run after the move fails with ENOENT
-  because `libraries/librpc/src/` does not yet exist when the symlink is
-  being created.
+  Without this, the first codegen run after the move fails with ENOENT because
+  `libraries/librpc/src/` does not yet exist when the symlink is being created.
 
 ### Cleanup: remove pre-existing symlinks at old locations
 
-`createSymlink()` removes pre-existing targets at the **new** location, but
-it does not know about the **old** location. After the rewrite, the
-previous symlinks at `libraries/librpc/generated` and
-`libraries/libtype/generated` are still on disk (as lingering artifacts
-from before the edit).
+`createSymlink()` removes pre-existing targets at the **new** location, but it
+does not know about the **old** location. After the rewrite, the previous
+symlinks at `libraries/librpc/generated` and `libraries/libtype/generated` are
+still on disk (as lingering artifacts from before the edit).
 
 Delete them explicitly as part of Part 02:
+
 ```sh
 rm libraries/librpc/generated
 rm libraries/libtype/generated
 ```
 
-Commit the removal in the same commit as the code change so the branch is
-clean.
+Commit the removal in the same commit as the code change so the branch is clean.
 
 ### librpc
 
@@ -142,53 +142,51 @@ Same recipe, simpler because libtype has exactly one root source file:
      "files": ["src/**/*.js", "README.md"]
    }
    ```
-6. Internal import `./generated/types/types.js` still resolves through the
-   new symlink.
+6. Internal import `./generated/types/types.js` still resolves through the new
+   symlink.
 7. Run `bun run node --test libraries/libtype/test/*.test.js`.
 
 ### Root generated/ — unchanged
 
 The monorepo-root `generated/` directory is **not** moved. It is outside any
-package and is the real codegen output target. Both `librpc/src/generated`
-and `libtype/src/generated` symlink into it.
+package and is the real codegen output target. Both `librpc/src/generated` and
+`libtype/src/generated` symlink into it.
 
 ## Ordering
 
-All steps below land in a **single atomic commit**. Do not commit
-intermediate states — an intermediate commit leaves the tree in a state
-where codegen writes symlinks to paths whose `src/` parent may or may not
-exist.
+All steps below land in a **single atomic commit**. Do not commit intermediate
+states — an intermediate commit leaves the tree in a state where codegen writes
+symlinks to paths whose `src/` parent may or may not exist.
 
-1. Read `libraries/libutil/finder.js` lines 108–167 to confirm the exact
-   shape of `findGeneratedPath` and `createPackageSymlinks`.
+1. Read `libraries/libutil/finder.js` lines 108–167 to confirm the exact shape
+   of `findGeneratedPath` and `createPackageSymlinks`.
 2. Change `findGeneratedPath` line 117 from `"generated"` →
    `path.join("src", "generated")`.
 3. Add the target-parent `mkdir -p` in `createSymlink` before the
    `fsAsync.symlink(...)` call on line 143.
-4. Move `librpc` root sources to `src/` (7 files: auth.js, base.js,
-   client.js, health.js, index.js, interceptor.js, server.js). Use
-   `git mv` so history is preserved.
+4. Move `librpc` root sources to `src/` (7 files: auth.js, base.js, client.js,
+   health.js, index.js, interceptor.js, server.js). Use `git mv` so history is
+   preserved.
 5. Move `libtype` root source to `src/` (1 file: index.js).
 6. Remove both old symlinks explicitly:
    `rm libraries/librpc/generated libraries/libtype/generated`.
 7. Update `librpc` and `libtype` `package.json` files (`main`, `files`).
-8. Run `just codegen` — recreates symlinks at the new `src/generated`
-   paths. Verify both symlinks now point at the monorepo-root
-   `generated/` directory (still absolute). If `just codegen` fails at
-   this point, **roll back the finder.js edit**, investigate, and do not
-   proceed. Do not commit a partial state.
+8. Run `just codegen` — recreates symlinks at the new `src/generated` paths.
+   Verify both symlinks now point at the monorepo-root `generated/` directory
+   (still absolute). If `just codegen` fails at this point, **roll back the
+   finder.js edit**, investigate, and do not proceed. Do not commit a partial
+   state.
 9. Run `bun run node --test libraries/librpc/test/*.test.js` and
    `bun run node --test libraries/libtype/test/*.test.js`.
 10. Run `bun run check` and `bun run test` (full suite).
 11. Run `npm pack --workspace=@forwardimpact/librpc --dry-run` and
-    `npm pack --workspace=@forwardimpact/libtype --dry-run`. Confirm the
-    tarball contents include `src/*.js` and do not include the
-    `src/generated/` symlink. If either tarball's file list differs from
-    the pre-move baseline in unexpected ways, investigate before
-    committing.
-12. Verify the monorepo-root `generated/` directory is unchanged (still
-    contains `types/`, `services/`, `definitions/`, `proto/`,
-    `bundle.tar.gz`, `package.json`).
+    `npm pack --workspace=@forwardimpact/libtype --dry-run`. Confirm the tarball
+    contents include `src/*.js` and do not include the `src/generated/` symlink.
+    If either tarball's file list differs from the pre-move baseline in
+    unexpected ways, investigate before committing.
+12. Verify the monorepo-root `generated/` directory is unchanged (still contains
+    `types/`, `services/`, `definitions/`, `proto/`, `bundle.tar.gz`,
+    `package.json`).
 13. Verify the new symlinks resolve:
     `ls libraries/librpc/src/generated/services/` and
     `ls libraries/libtype/src/generated/types/`.
@@ -210,82 +208,79 @@ exist.
 
 ## Risks
 
-1. **`just codegen` is destructive if the root `generated/` is cleaned
-   first.** Do not run `just data-reset` before this part — it will delete
-   the root `generated/` directory, and then codegen must regenerate it.
-   Codegen is idempotent but takes ~1 minute to run.
+1. **`just codegen` is destructive if the root `generated/` is cleaned first.**
+   Do not run `just data-reset` before this part — it will delete the root
+   `generated/` directory, and then codegen must regenerate it. Codegen is
+   idempotent but takes ~1 minute to run.
 
 2. **Symlink path is absolute.** Verified on disk:
-   `libraries/librpc/generated → /home/user/monorepo/generated` — an
-   absolute path. `createSymlink()` passes `sourcePath` (the resolved
-   `generatedPath` argument to `createPackageSymlinks`) straight through
-   `fsAsync.symlink`. Absolute is fine inside a single working tree and
-   survives `just codegen` runs. The migration preserves this convention —
-   the target directory moves, the source target stays absolute.
+   `libraries/librpc/generated → /home/user/monorepo/generated` — an absolute
+   path. `createSymlink()` passes `sourcePath` (the resolved `generatedPath`
+   argument to `createPackageSymlinks`) straight through `fsAsync.symlink`.
+   Absolute is fine inside a single working tree and survives `just codegen`
+   runs. The migration preserves this convention — the target directory moves,
+   the source target stays absolute.
 
-3. **Stale symlinks left behind.** If the old `libraries/librpc/generated`
-   and `libraries/libtype/generated` symlinks are not removed before
-   recreating them, `git status` will show them as tracked files pointing at
-   stale targets. Delete them explicitly in step 7 above.
+3. **Stale symlinks left behind.** If the old `libraries/librpc/generated` and
+   `libraries/libtype/generated` symlinks are not removed before recreating
+   them, `git status` will show them as tracked files pointing at stale targets.
+   Delete them explicitly in step 7 above.
 
 4. **The `Finder.findUpward` search in libstorage is load-bearing.** The
    `"generated"` storage bucket maps through a switch case at
    `libstorage/index.js` line 116 that sets `relative = "generated"`.
-   `Finder.findUpward(cwd, "generated")` then searches upward for a
-   directory ending in `generated/`, finding the monorepo root's
-   `generated/`. **Do not change this case.** Changing it to `src/generated`
-   would break the upward search because there is no monorepo-root
-   `src/generated` — the `src/` directories only exist inside packages.
+   `Finder.findUpward(cwd, "generated")` then searches upward for a directory
+   ending in `generated/`, finding the monorepo root's `generated/`. **Do not
+   change this case.** Changing it to `src/generated` would break the upward
+   search because there is no monorepo-root `src/generated` — the `src/`
+   directories only exist inside packages.
 
-5. **The published npm tarballs never contain the generated tree —
-   confirmed, and this is fine.** `npm pack --workspace=@forwardimpact/librpc
-   --dry-run` against `main` (version 0.1.88) produces a 13-file tarball
-   containing `auth.js`, `base.js`, `bin/fit-unary.js`, `client.js`,
-   `health.js`, `index.js`, `interceptor.js`, `package.json`, `server.js`,
-   and four test files. The `generated/` symlink is silently dropped by
-   `npm pack` (npm excludes dangling/absolute symlinks). No `files` field
-   exists in `librpc` or `libtype` today, so npm uses its default include
-   list.
+5. **The published npm tarballs never contain the generated tree — confirmed,
+   and this is fine.** `npm pack --workspace=@forwardimpact/librpc --dry-run`
+   against `main` (version 0.1.88) produces a 13-file tarball containing
+   `auth.js`, `base.js`, `bin/fit-unary.js`, `client.js`, `health.js`,
+   `index.js`, `interceptor.js`, `package.json`, `server.js`, and four test
+   files. The `generated/` symlink is silently dropped by `npm pack` (npm
+   excludes dangling/absolute symlinks). No `files` field exists in `librpc` or
+   `libtype` today, so npm uses its default include list.
 
-   External consumers of `@forwardimpact/librpc` install the package and
-   then run `npx fit-codegen --all` as documented in the distribution
-   model (`CLAUDE.md § Distribution Model`). fit-codegen writes the
-   generated tree into the consumer's own project root and creates
-   symlinks at `node_modules/@forwardimpact/{librpc,libtype}/generated`
-   pointing at the consumer's generated directory.
+   External consumers of `@forwardimpact/librpc` install the package and then
+   run `npx fit-codegen --all` as documented in the distribution model
+   (`CLAUDE.md § Distribution Model`). fit-codegen writes the generated tree
+   into the consumer's own project root and creates symlinks at
+   `node_modules/@forwardimpact/{librpc,libtype}/generated` pointing at the
+   consumer's generated directory.
 
    **Post-move behaviour:** after Part 02 the tarball contents become
    `src/auth.js`, `src/base.js`, `src/client.js`, `src/health.js`,
    `src/index.js`, `src/interceptor.js`, `src/server.js`, plus
-   `bin/fit-unary.js`, `package.json`, and `test/*.test.js`. The symlink
-   is still silently dropped. When the consumer runs `npx fit-codegen`,
-   the new `findGeneratedPath` creates the symlink at
+   `bin/fit-unary.js`, `package.json`, and `test/*.test.js`. The symlink is
+   still silently dropped. When the consumer runs `npx fit-codegen`, the new
+   `findGeneratedPath` creates the symlink at
    `node_modules/@forwardimpact/librpc/src/generated` — which requires
-   `node_modules/@forwardimpact/librpc/src/` to exist, which it does
-   because the published tarball contains `src/*.js` files. The `mkdir -p`
-   guard added to `createSymlink()` in Part 02 ensures this works even
-   on packages that end up without a `src/` directory in the tarball.
+   `node_modules/@forwardimpact/librpc/src/` to exist, which it does because the
+   published tarball contains `src/*.js` files. The `mkdir -p` guard added to
+   `createSymlink()` in Part 02 ensures this works even on packages that end up
+   without a `src/` directory in the tarball.
 
-   **Contributor-local behaviour** (`just codegen` in the monorepo): the
-   symlink is created at `libraries/librpc/src/generated` pointing at
-   `/home/user/monorepo/generated` (absolute path). Running tests loads
-   through the symlink and still works.
+   **Contributor-local behaviour** (`just codegen` in the monorepo): the symlink
+   is created at `libraries/librpc/src/generated` pointing at
+   `/home/user/monorepo/generated` (absolute path). Running tests loads through
+   the symlink and still works.
 
    Fresh-install smoke test (Part 08) must include at least one
    `librpc`/`libtype` import to catch any regression.
 
-6. **Both `librpc` and `libtype` lack a `files` field.** This is the
-   reason the smoke-tested pack works: npm defaults include everything
-   not explicitly gitignored. Part 02 introduces a `files` field for
-   cleanliness:
+6. **Both `librpc` and `libtype` lack a `files` field.** This is the reason the
+   smoke-tested pack works: npm defaults include everything not explicitly
+   gitignored. Part 02 introduces a `files` field for cleanliness:
    ```jsonc
    "files": ["src/**/*.js", "bin/**/*.js", "README.md"]
    ```
-   `src/generated/**` is **not** listed — the generated files are never
-   checked into the tarball; they are regenerated client-side. If
-   `npm pack --dry-run` post-Part-02 shows a different file set than the
-   pre-move baseline (minus the moved paths), investigate before
-   committing.
+   `src/generated/**` is **not** listed — the generated files are never checked
+   into the tarball; they are regenerated client-side. If `npm pack --dry-run`
+   post-Part-02 shows a different file set than the pre-move baseline (minus the
+   moved paths), investigate before committing.
 
 ## Deliverable commit
 

--- a/specs/390-consistent-package-layout/plan-a-03.md
+++ b/specs/390-consistent-package-layout/plan-a-03.md
@@ -1,15 +1,28 @@
-# Plan A — Part 03: Services
+# Plan A — Part 03: Services (verification only)
 
-Bring every service into conformance with the services template: **exactly
-two** root-level source files (`index.js` and `server.js`), a `test/`
-directory, and (optionally) `proto/` and `src/`. Nothing else.
+Verify that every service already conforms to the services template —
+**exactly two** root-level source files (`index.js` and `server.js`), a
+`test/` directory, and (optionally) `proto/` and `src/`. Nothing else.
 
 ## Scope
 
-Only `services/pathway` has real work — the spec's sole service outlier. The
-other eight services already conform. This part also documents the services
-exception explicitly (the CLAUDE.md contract update itself happens in Part
-08, but the behaviour is already in place after Part 03).
+**Verification only. No file changes.** The spec describes services as a
+uniform tier with `services/pathway` as the "one outlier" whose
+`index.js` and `server.js` "still reference code at the service root
+rather than at `src/`." Re-verified against the actual codebase:
+
+- `services/pathway/index.js` line 20 imports **`./src/serialize.js`** —
+  already correctly pointing at `src/`. No root-level imports remain.
+- `services/pathway/server.js` line 10 imports `./index.js`, which is
+  the services-exception root file. This is correct per spec rule 2.
+- No stray source files exist at `services/pathway/` root besides
+  `index.js` and `server.js`.
+
+The spec inherited a stale observation — somebody already fixed pathway
+before the spec landed. Part 03 is therefore a verification-only step
+that **makes no file changes**, but it remains in the plan as an
+explicit gate: Part 01's permissive layout check must report zero drift
+for all nine services before Part 04 begins.
 
 ## Current state (from research)
 
@@ -31,83 +44,53 @@ check does not flag it.
 
 ## Files modified
 
-### services/pathway
+None. This part is verification-only.
 
-The spec states:
+If verification surfaces drift (a stray `.js` file at a service root, an
+import from `./<file>.js` where `<file>` is no longer at the root, etc.),
+fix it in Part 03 using the cross-cutting recipe in `plan-a.md` and
+document the surprise in the commit message. Expected state on a clean
+main is zero drift.
 
-> The pathway service is the one outlier in the services tier — it has
-> already grown a lone `src/serialize.js` alongside the usual `index.js` and
-> `server.js`. Under the new rules that is correct shape, but the service's
-> `index.js` and `server.js` still reference code at the service root rather
-> than at `src/`. Make the service match the services template exactly: root
-> files load from `./src/...` and any stray source file at the service root
-> moves into `src/`.
+### Optional documentation touch-up
 
-**Step 1: inspect.** Read these files to confirm current state:
+If `services/pathway/package.json` is missing `src/**` from its `files`
+field, add it now — it is published today without a `files` field (npm
+defaults). This is a belt-and-braces cleanup, not a correctness issue.
+Skip if no `files` field exists at all.
 
-- `services/pathway/index.js`
-- `services/pathway/server.js`
-- `services/pathway/src/serialize.js`
+### Other services — verify only
 
-Look specifically for:
-
-- Any import in `index.js` or `server.js` that reaches into the service root
-  for helpers (e.g., `import { foo } from "./helpers.js"` where
-  `helpers.js` sits at the service root — which would be a stray root source
-  file).
-- Any direct import of `./serialize.js` in `index.js` — this would be the
-  import path that needs to become `./src/serialize.js`.
-
-**Step 2: move any stray root source files into `src/`.** The inventory
-shows `index.js` and `server.js` only at the root, but the spec hints at
-"any stray source file at the service root moves into `src/`". Read the
-directory again at execution time; if extra files exist, move them.
-
-**Step 3: fix imports.** In `index.js` and `server.js`, rewrite any import
-that currently points at `./<file>.js` (service root) to `./src/<file>.js`.
-The two fixed-path files themselves stay at the root.
-
-**Step 4: update `services/pathway/package.json`:** add `src/` to `files` if
-not already present. The `main` field stays as `"./index.js"` because
-`index.js` is at the service root (services exception).
-
-**Step 5: run `bun run node --test services/pathway/test/*.test.js`.**
-
-### services/web — no action, but verify
-
-Confirm `services/web` has no root source files besides `index.js` and
-`server.js`. The spec's rule applies to every service; web has no `proto/`
-which is allowed.
-
-### Other services — no action
-
-`services/agent`, `graph`, `llm`, `memory`, `tool`, `trace`, `vector` already
-conform. Touch them only if the layout check reports drift — otherwise leave
-them alone.
+- `services/web` — verify: no root `.js` files besides `index.js` and
+  `server.js`; no `proto/` (HTTP-only service, allowed).
+- `services/{agent,graph,llm,memory,tool,trace,vector}` — verify: exactly
+  two root `.js` files + `proto/` + `test/`.
 
 ## Ordering
 
-1. Read the three `services/pathway/` files to confirm import targets.
-2. Read each other service directory to confirm conformance (use
-   `bun run layout` as a quick audit).
-3. Fix `services/pathway/index.js` and `server.js` imports.
-4. If any stray source file exists at a service root, move it to `src/`.
-5. Run `bun run node --test services/pathway/test/*.test.js`.
-6. Run `bun run layout` — services should no longer report any drift.
-7. Run `bun run check` and `bun run test`.
-8. Commit.
+1. Run `bun run layout` — expect zero drift under `services/*`.
+2. Spot-read `services/pathway/index.js` (line 20) and `server.js`
+   (line 10) to confirm they already import from `./src/serialize.js`
+   and `./index.js` respectively.
+3. Spot-read one other service (e.g., `services/graph/`) to confirm the
+   two-file root pattern.
+4. Run `bun run check` and `bun run test`.
+5. Commit only if any optional cleanup was applied; otherwise this part
+   is a no-op gate and the plan advances to Part 04.
 
 ## Verification
 
-- `services/pathway/index.js` and `server.js` import all non-trivial helpers
-  from `./src/...`.
 - `bun run layout` reports zero drift under `services/*`.
-- `bun run node --test services/pathway/test/*.test.js` passes.
+- `services/pathway/index.js` already imports `./src/serialize.js`
+  (confirmed on main at line 20).
+- `services/pathway/server.js` already imports `./index.js` (confirmed on
+  main at line 10) — correct per the services exception.
 - All service tests at repo root pass: `bun run test`.
-- `fit-rc start pathway` (spot check) launches the service without error —
-  the `node --watch services/pathway/server.js` command in
-  `config/config.example.json` still resolves because `server.js` is still
-  at the service root. **No config change is needed.**
+- `fit-rc start pathway` (spot check, if services are running locally)
+  launches without error — the `node --watch services/pathway/server.js`
+  command in `config/config.example.json` still resolves because
+  `server.js` is still at the service root. **No config change is
+  needed.**
 
 ## Risks
 
@@ -129,15 +112,23 @@ them alone.
 
 ## Deliverable commit
 
+Part 03 is verification-only on a clean main. It usually produces **no
+commit** — the plan advances to Part 04 directly after the layout check
+passes for `services/*`.
+
+If optional cleanup is applied (e.g., adding `files` to
+`services/pathway/package.json`), use:
+
 ```
-refactor(layout): fix services/pathway imports to src/ (part 03/08)
+refactor(layout): verify services tier conformance (part 03/08)
 
-services/pathway has the correct shape (index.js, server.js at root +
-src/ for other source files) but the root files still import from ./
-instead of ./src/. This rewrites those imports and brings pathway into
-full conformance with the services template.
+Verification step — all nine services already conform to the services
+template (two root files, proto/, test/). services/pathway was the
+spec's listed outlier but has already been fixed on main: index.js at
+line 20 imports ./src/serialize.js and server.js at line 10 imports
+./index.js (services exception).
 
-All other services already conform — no other changes.
+Optional: add src/** to services/pathway/package.json files field.
 
 Part 03 of 08 for spec 390.
 ```

--- a/specs/390-consistent-package-layout/plan-a-03.md
+++ b/specs/390-consistent-package-layout/plan-a-03.md
@@ -1,0 +1,145 @@
+# Plan A — Part 03: Services
+
+Bring every service into conformance with the services template: **exactly
+two** root-level source files (`index.js` and `server.js`), a `test/`
+directory, and (optionally) `proto/` and `src/`. Nothing else.
+
+## Scope
+
+Only `services/pathway` has real work — the spec's sole service outlier. The
+other eight services already conform. This part also documents the services
+exception explicitly (the CLAUDE.md contract update itself happens in Part
+08, but the behaviour is already in place after Part 03).
+
+## Current state (from research)
+
+| Service           | Root files                      | Root subdirs             | Notes |
+| ----------------- | ------------------------------- | ------------------------ | ----- |
+| services/agent    | index.js, server.js             | proto, test              | ✅ conforms |
+| services/graph    | index.js, server.js             | proto, test              | ✅ conforms |
+| services/llm      | index.js, server.js             | proto, test              | ✅ conforms |
+| services/memory   | index.js, server.js             | proto, test              | ✅ conforms |
+| services/pathway  | index.js, server.js             | proto, **src**, test     | ⚠️ needs pathway fix |
+| services/tool     | index.js, server.js             | proto, test              | ✅ conforms |
+| services/trace    | index.js, server.js             | proto, test              | ✅ conforms |
+| services/vector   | index.js, server.js             | proto, test              | ✅ conforms |
+| services/web      | index.js, server.js             | test                     | ✅ conforms (no proto by design) |
+
+`services/web` has no `proto/` — it is an HTTP-only service. This is allowed
+by the spec (proto/ is optional); no action required, noted so the Part 01
+check does not flag it.
+
+## Files modified
+
+### services/pathway
+
+The spec states:
+
+> The pathway service is the one outlier in the services tier — it has
+> already grown a lone `src/serialize.js` alongside the usual `index.js` and
+> `server.js`. Under the new rules that is correct shape, but the service's
+> `index.js` and `server.js` still reference code at the service root rather
+> than at `src/`. Make the service match the services template exactly: root
+> files load from `./src/...` and any stray source file at the service root
+> moves into `src/`.
+
+**Step 1: inspect.** Read these files to confirm current state:
+
+- `services/pathway/index.js`
+- `services/pathway/server.js`
+- `services/pathway/src/serialize.js`
+
+Look specifically for:
+
+- Any import in `index.js` or `server.js` that reaches into the service root
+  for helpers (e.g., `import { foo } from "./helpers.js"` where
+  `helpers.js` sits at the service root — which would be a stray root source
+  file).
+- Any direct import of `./serialize.js` in `index.js` — this would be the
+  import path that needs to become `./src/serialize.js`.
+
+**Step 2: move any stray root source files into `src/`.** The inventory
+shows `index.js` and `server.js` only at the root, but the spec hints at
+"any stray source file at the service root moves into `src/`". Read the
+directory again at execution time; if extra files exist, move them.
+
+**Step 3: fix imports.** In `index.js` and `server.js`, rewrite any import
+that currently points at `./<file>.js` (service root) to `./src/<file>.js`.
+The two fixed-path files themselves stay at the root.
+
+**Step 4: update `services/pathway/package.json`:** add `src/` to `files` if
+not already present. The `main` field stays as `"./index.js"` because
+`index.js` is at the service root (services exception).
+
+**Step 5: run `bun run node --test services/pathway/test/*.test.js`.**
+
+### services/web — no action, but verify
+
+Confirm `services/web` has no root source files besides `index.js` and
+`server.js`. The spec's rule applies to every service; web has no `proto/`
+which is allowed.
+
+### Other services — no action
+
+`services/agent`, `graph`, `llm`, `memory`, `tool`, `trace`, `vector` already
+conform. Touch them only if the layout check reports drift — otherwise leave
+them alone.
+
+## Ordering
+
+1. Read the three `services/pathway/` files to confirm import targets.
+2. Read each other service directory to confirm conformance (use
+   `bun run layout` as a quick audit).
+3. Fix `services/pathway/index.js` and `server.js` imports.
+4. If any stray source file exists at a service root, move it to `src/`.
+5. Run `bun run node --test services/pathway/test/*.test.js`.
+6. Run `bun run layout` — services should no longer report any drift.
+7. Run `bun run check` and `bun run test`.
+8. Commit.
+
+## Verification
+
+- `services/pathway/index.js` and `server.js` import all non-trivial helpers
+  from `./src/...`.
+- `bun run layout` reports zero drift under `services/*`.
+- `bun run node --test services/pathway/test/*.test.js` passes.
+- All service tests at repo root pass: `bun run test`.
+- `fit-rc start pathway` (spot check) launches the service without error —
+  the `node --watch services/pathway/server.js` command in
+  `config/config.example.json` still resolves because `server.js` is still
+  at the service root. **No config change is needed.**
+
+## Risks
+
+1. **The service supervisor uses a fixed path.** `config/config.example.json`
+   hardcodes `node --watch services/pathway/server.js` (and the same for
+   every other service). Keep `server.js` at the service root exactly as it
+   is — the services exception exists precisely because of this hardcoded
+   path. Part 03 must not introduce any rewrite of `config.json`.
+
+2. **`index.js` and `server.js` are both entry points.** Do not collapse them
+   into one file or rename them. `index.js` exports the service class (used
+   by the harness); `server.js` is the process entry point (used by the
+   supervisor). Both paths are load-bearing.
+
+3. **`services/pathway/src/` existing today is the correct shape, not an
+   outlier.** Do not "clean up" by moving `src/serialize.js` back to the
+   root. The spec explicitly preserves `src/` for services that need it —
+   `src/` is allowed in the services template.
+
+## Deliverable commit
+
+```
+refactor(layout): fix services/pathway imports to src/ (part 03/08)
+
+services/pathway has the correct shape (index.js, server.js at root +
+src/ for other source files) but the root files still import from ./
+instead of ./src/. This rewrites those imports and brings pathway into
+full conformance with the services template.
+
+All other services already conform — no other changes.
+
+Part 03 of 08 for spec 390.
+```
+
+— Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a-03.md
+++ b/specs/390-consistent-package-layout/plan-a-03.md
@@ -1,120 +1,118 @@
 # Plan A — Part 03: Services (verification only)
 
-Verify that every service already conforms to the services template —
-**exactly two** root-level source files (`index.js` and `server.js`), a
-`test/` directory, and (optionally) `proto/` and `src/`. Nothing else.
+Verify that every service already conforms to the services template — **exactly
+two** root-level source files (`index.js` and `server.js`), a `test/` directory,
+and (optionally) `proto/` and `src/`. Nothing else.
 
 ## Scope
 
-**Verification only. No file changes.** The spec describes services as a
-uniform tier with `services/pathway` as the "one outlier" whose
-`index.js` and `server.js` "still reference code at the service root
-rather than at `src/`." Re-verified against the actual codebase:
+**Verification only. No file changes.** The spec describes services as a uniform
+tier with `services/pathway` as the "one outlier" whose `index.js` and
+`server.js` "still reference code at the service root rather than at `src/`."
+Re-verified against the actual codebase:
 
-- `services/pathway/index.js` line 20 imports **`./src/serialize.js`** —
-  already correctly pointing at `src/`. No root-level imports remain.
-- `services/pathway/server.js` line 10 imports `./index.js`, which is
-  the services-exception root file. This is correct per spec rule 2.
-- No stray source files exist at `services/pathway/` root besides
-  `index.js` and `server.js`.
+- `services/pathway/index.js` line 20 imports **`./src/serialize.js`** — already
+  correctly pointing at `src/`. No root-level imports remain.
+- `services/pathway/server.js` line 10 imports `./index.js`, which is the
+  services-exception root file. This is correct per spec rule 2.
+- No stray source files exist at `services/pathway/` root besides `index.js` and
+  `server.js`.
 
-The spec inherited a stale observation — somebody already fixed pathway
-before the spec landed. Part 03 is therefore a verification-only step
-that **makes no file changes**, but it remains in the plan as an
-explicit gate: Part 01's permissive layout check must report zero drift
-for all nine services before Part 04 begins.
+The spec inherited a stale observation — somebody already fixed pathway before
+the spec landed. Part 03 is therefore a verification-only step that **makes no
+file changes**, but it remains in the plan as an explicit gate: Part 01's
+permissive layout check must report zero drift for all nine services before Part
+04 begins.
 
 ## Current state (from research)
 
-| Service           | Root files                      | Root subdirs             | Notes |
-| ----------------- | ------------------------------- | ------------------------ | ----- |
-| services/agent    | index.js, server.js             | proto, test              | ✅ conforms |
-| services/graph    | index.js, server.js             | proto, test              | ✅ conforms |
-| services/llm      | index.js, server.js             | proto, test              | ✅ conforms |
-| services/memory   | index.js, server.js             | proto, test              | ✅ conforms |
-| services/pathway  | index.js, server.js             | proto, **src**, test     | ⚠️ needs pathway fix |
-| services/tool     | index.js, server.js             | proto, test              | ✅ conforms |
-| services/trace    | index.js, server.js             | proto, test              | ✅ conforms |
-| services/vector   | index.js, server.js             | proto, test              | ✅ conforms |
-| services/web      | index.js, server.js             | test                     | ✅ conforms (no proto by design) |
+| Service          | Root files          | Root subdirs         | Notes                            |
+| ---------------- | ------------------- | -------------------- | -------------------------------- |
+| services/agent   | index.js, server.js | proto, test          | ✅ conforms                      |
+| services/graph   | index.js, server.js | proto, test          | ✅ conforms                      |
+| services/llm     | index.js, server.js | proto, test          | ✅ conforms                      |
+| services/memory  | index.js, server.js | proto, test          | ✅ conforms                      |
+| services/pathway | index.js, server.js | proto, **src**, test | ⚠️ needs pathway fix             |
+| services/tool    | index.js, server.js | proto, test          | ✅ conforms                      |
+| services/trace   | index.js, server.js | proto, test          | ✅ conforms                      |
+| services/vector  | index.js, server.js | proto, test          | ✅ conforms                      |
+| services/web     | index.js, server.js | test                 | ✅ conforms (no proto by design) |
 
-`services/web` has no `proto/` — it is an HTTP-only service. This is allowed
-by the spec (proto/ is optional); no action required, noted so the Part 01
-check does not flag it.
+`services/web` has no `proto/` — it is an HTTP-only service. This is allowed by
+the spec (proto/ is optional); no action required, noted so the Part 01 check
+does not flag it.
 
 ## Files modified
 
 None. This part is verification-only.
 
-If verification surfaces drift (a stray `.js` file at a service root, an
-import from `./<file>.js` where `<file>` is no longer at the root, etc.),
-fix it in Part 03 using the cross-cutting recipe in `plan-a.md` and
-document the surprise in the commit message. Expected state on a clean
-main is zero drift.
+If verification surfaces drift (a stray `.js` file at a service root, an import
+from `./<file>.js` where `<file>` is no longer at the root, etc.), fix it in
+Part 03 using the cross-cutting recipe in `plan-a.md` and document the surprise
+in the commit message. Expected state on a clean main is zero drift.
 
 ### Optional documentation touch-up
 
-If `services/pathway/package.json` is missing `src/**` from its `files`
-field, add it now — it is published today without a `files` field (npm
-defaults). This is a belt-and-braces cleanup, not a correctness issue.
-Skip if no `files` field exists at all.
+If `services/pathway/package.json` is missing `src/**` from its `files` field,
+add it now — it is published today without a `files` field (npm defaults). This
+is a belt-and-braces cleanup, not a correctness issue. Skip if no `files` field
+exists at all.
 
 ### Other services — verify only
 
 - `services/web` — verify: no root `.js` files besides `index.js` and
   `server.js`; no `proto/` (HTTP-only service, allowed).
-- `services/{agent,graph,llm,memory,tool,trace,vector}` — verify: exactly
-  two root `.js` files + `proto/` + `test/`.
+- `services/{agent,graph,llm,memory,tool,trace,vector}` — verify: exactly two
+  root `.js` files + `proto/` + `test/`.
 
 ## Ordering
 
 1. Run `bun run layout` — expect zero drift under `services/*`.
-2. Spot-read `services/pathway/index.js` (line 20) and `server.js`
-   (line 10) to confirm they already import from `./src/serialize.js`
-   and `./index.js` respectively.
-3. Spot-read one other service (e.g., `services/graph/`) to confirm the
-   two-file root pattern.
+2. Spot-read `services/pathway/index.js` (line 20) and `server.js` (line 10) to
+   confirm they already import from `./src/serialize.js` and `./index.js`
+   respectively.
+3. Spot-read one other service (e.g., `services/graph/`) to confirm the two-file
+   root pattern.
 4. Run `bun run check` and `bun run test`.
-5. Commit only if any optional cleanup was applied; otherwise this part
-   is a no-op gate and the plan advances to Part 04.
+5. Commit only if any optional cleanup was applied; otherwise this part is a
+   no-op gate and the plan advances to Part 04.
 
 ## Verification
 
 - `bun run layout` reports zero drift under `services/*`.
-- `services/pathway/index.js` already imports `./src/serialize.js`
-  (confirmed on main at line 20).
-- `services/pathway/server.js` already imports `./index.js` (confirmed on
-  main at line 10) — correct per the services exception.
+- `services/pathway/index.js` already imports `./src/serialize.js` (confirmed on
+  main at line 20).
+- `services/pathway/server.js` already imports `./index.js` (confirmed on main
+  at line 10) — correct per the services exception.
 - All service tests at repo root pass: `bun run test`.
-- `fit-rc start pathway` (spot check, if services are running locally)
-  launches without error — the `node --watch services/pathway/server.js`
-  command in `config/config.example.json` still resolves because
-  `server.js` is still at the service root. **No config change is
-  needed.**
+- `fit-rc start pathway` (spot check, if services are running locally) launches
+  without error — the `node --watch services/pathway/server.js` command in
+  `config/config.example.json` still resolves because `server.js` is still at
+  the service root. **No config change is needed.**
 
 ## Risks
 
 1. **The service supervisor uses a fixed path.** `config/config.example.json`
-   hardcodes `node --watch services/pathway/server.js` (and the same for
-   every other service). Keep `server.js` at the service root exactly as it
-   is — the services exception exists precisely because of this hardcoded
-   path. Part 03 must not introduce any rewrite of `config.json`.
+   hardcodes `node --watch services/pathway/server.js` (and the same for every
+   other service). Keep `server.js` at the service root exactly as it is — the
+   services exception exists precisely because of this hardcoded path. Part 03
+   must not introduce any rewrite of `config.json`.
 
 2. **`index.js` and `server.js` are both entry points.** Do not collapse them
-   into one file or rename them. `index.js` exports the service class (used
-   by the harness); `server.js` is the process entry point (used by the
+   into one file or rename them. `index.js` exports the service class (used by
+   the harness); `server.js` is the process entry point (used by the
    supervisor). Both paths are load-bearing.
 
 3. **`services/pathway/src/` existing today is the correct shape, not an
-   outlier.** Do not "clean up" by moving `src/serialize.js` back to the
-   root. The spec explicitly preserves `src/` for services that need it —
-   `src/` is allowed in the services template.
+   outlier.** Do not "clean up" by moving `src/serialize.js` back to the root.
+   The spec explicitly preserves `src/` for services that need it — `src/` is
+   allowed in the services template.
 
 ## Deliverable commit
 
-Part 03 is verification-only on a clean main. It usually produces **no
-commit** — the plan advances to Part 04 directly after the layout check
-passes for `services/*`.
+Part 03 is verification-only on a clean main. It usually produces **no commit**
+— the plan advances to Part 04 directly after the layout check passes for
+`services/*`.
 
 If optional cleanup is applied (e.g., adding `files` to
 `services/pathway/package.json`), use:

--- a/specs/390-consistent-package-layout/plan-a-04.md
+++ b/specs/390-consistent-package-layout/plan-a-04.md
@@ -24,9 +24,12 @@ All six items from spec 390's "Fix `libraries/libharness`" section:
 libraries/libharness/
 ├── index.js              ← root source, moves to src/index.js
 ├── fixture/
-│   └── index.js          ← moves to src/fixture/index.js
+│   ├── assertions.js     ← all 4 files move to src/fixture/
+│   ├── index.js
+│   ├── pathway.js
+│   └── services.js
 ├── mock/
-│   ├── index.js          ← moves to src/mock/index.js
+│   ├── index.js          ← all 13 files move to src/mock/
 │   ├── clients.js
 │   ├── config.js
 │   ├── data.js
@@ -77,7 +80,10 @@ libraries/libharness/
 ├── src/
 │   ├── index.js
 │   ├── fixture/
-│   │   └── index.js
+│   │   ├── assertions.js
+│   │   ├── index.js
+│   │   ├── pathway.js
+│   │   └── services.js
 │   └── mock/
 │       ├── index.js
 │       ├── clients.js

--- a/specs/390-consistent-package-layout/plan-a-04.md
+++ b/specs/390-consistent-package-layout/plan-a-04.md
@@ -1,0 +1,237 @@
+# Plan A — Part 04: libharness full restructure
+
+`libharness` is the outlier in every library audit. This part fixes it end to
+end: move sources into `src/`, delete the stale `packages/` tree, update the
+package description to reflect its actual cross-monorepo role, and verify
+every call site across ~23 test files still resolves.
+
+## Scope
+
+All six items from spec 390's "Fix `libraries/libharness`" section:
+
+1. Create `src/` and move root `index.js` to `src/index.js`.
+2. Move `fixture/` → `src/fixture/` and `mock/` → `src/mock/`.
+3. Delete the stale `packages/` tree (contains a single zero-byte
+   `packages/libharness/mock/config.js`).
+4. Update `package.json` description.
+5. Update `main`, `exports`, `files` fields.
+6. Verify every call site across the monorepo still resolves — import
+   specifiers are unchanged because the `exports` map absorbs the move.
+
+## Current state
+
+```
+libraries/libharness/
+├── index.js              ← root source, moves to src/index.js
+├── fixture/
+│   └── index.js          ← moves to src/fixture/index.js
+├── mock/
+│   ├── index.js          ← moves to src/mock/index.js
+│   ├── clients.js
+│   ├── config.js
+│   ├── data.js
+│   ├── fs.js
+│   ├── grpc.js
+│   ├── http.js
+│   ├── logger.js
+│   ├── observer.js
+│   ├── resource-index.js
+│   ├── service-callbacks.js
+│   ├── services.js
+│   └── storage.js
+├── packages/             ← STALE — delete entirely
+│   └── libharness/
+│       └── mock/
+│           └── config.js (zero bytes, no importers, residue from a workspace experiment)
+├── test/
+└── package.json
+```
+
+Current `package.json`:
+
+```jsonc
+{
+  "name": "@forwardimpact/libharness",
+  "version": "0.1.12",
+  "description": "Test harness and mock infrastructure for guide tests",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./mock": "./mock/index.js",
+    "./fixture": "./fixture/index.js"
+  },
+  "files": [
+    "index.js",
+    "mock/**/*.js",
+    "fixture/**/*.js",
+    "README.md"
+  ],
+  // ...
+}
+```
+
+## Target state
+
+```
+libraries/libharness/
+├── src/
+│   ├── index.js
+│   ├── fixture/
+│   │   └── index.js
+│   └── mock/
+│       ├── index.js
+│       ├── clients.js
+│       ├── config.js
+│       ├── data.js
+│       ├── fs.js
+│       ├── grpc.js
+│       ├── http.js
+│       ├── logger.js
+│       ├── observer.js
+│       ├── resource-index.js
+│       ├── service-callbacks.js
+│       ├── services.js
+│       └── storage.js
+├── test/
+└── package.json
+```
+
+Target `package.json`:
+
+```jsonc
+{
+  "name": "@forwardimpact/libharness",
+  "version": "0.1.12",
+  "description": "Shared test harness and mock infrastructure for the Forward Impact monorepo",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./mock": "./src/mock/index.js",
+    "./fixture": "./src/fixture/index.js"
+  },
+  "files": [
+    "src/**/*.js",
+    "README.md"
+  ],
+  // ...
+}
+```
+
+**Subpath export keys (`.`, `./mock`, `./fixture`) are unchanged** — only the
+right-hand targets move. Every current call site continues to resolve.
+
+## Files modified
+
+- `libraries/libharness/package.json` — description, main, exports, files.
+- `libraries/libharness/index.js` → `libraries/libharness/src/index.js` (via `git mv`).
+- `libraries/libharness/fixture/index.js` → `libraries/libharness/src/fixture/index.js`.
+- `libraries/libharness/mock/*` → `libraries/libharness/src/mock/*`.
+
+## Files deleted
+
+- `libraries/libharness/packages/` — entire tree, including
+  `packages/libharness/mock/config.js` (zero bytes, no importers).
+
+## Files NOT modified
+
+**No call sites.** Every call site uses one of the three public subpath
+specifiers:
+
+- `@forwardimpact/libharness`
+- `@forwardimpact/libharness/mock`
+- `@forwardimpact/libharness/fixture`
+
+The exports map catches all three; their targets change under the hood but
+the specifiers remain valid. The research sweep identified ~23 test files
+across services (`services/{agent,graph,llm,memory,pathway,tool,trace,vector,web}/test/`)
+and libraries (`libraries/{librpc,libutil,libvector,libindex}/test/`). None
+need changes.
+
+## Ordering
+
+1. Read `libraries/libharness/index.js` to confirm its imports (it
+   re-exports from `./fixture/index.js` and `./mock/index.js` — these become
+   `./fixture/index.js` and `./mock/index.js` inside `src/`, still
+   resolving).
+2. Read `libraries/libharness/mock/index.js` to confirm its internal imports
+   are relative (`./clients.js`, etc.) — these resolve unchanged after the
+   move because the whole directory moves together.
+3. `mkdir -p libraries/libharness/src`
+4. `git mv libraries/libharness/index.js libraries/libharness/src/index.js`
+5. `git mv libraries/libharness/fixture libraries/libharness/src/fixture`
+6. `git mv libraries/libharness/mock libraries/libharness/src/mock`
+7. `git rm -r libraries/libharness/packages`
+8. Edit `libraries/libharness/package.json`:
+   - `description` → "Shared test harness and mock infrastructure for the Forward Impact monorepo"
+   - `main` → `"./src/index.js"`
+   - `exports["."]` → `"./src/index.js"`
+   - `exports["./mock"]` → `"./src/mock/index.js"`
+   - `exports["./fixture"]` → `"./src/fixture/index.js"`
+   - `files` → `["src/**/*.js", "README.md"]`
+9. Run `bun run node --test libraries/libharness/test/*.test.js` (if tests
+   exist in libharness itself — per the inventory there is a `test/` dir).
+10. Run `bun run test` at repo root to verify every call site still
+    resolves.
+11. Run `bun run layout` — libharness should no longer report any drift.
+12. Commit.
+
+## Verification
+
+- `libraries/libharness/packages/` does not exist (`git ls-files libraries/libharness/packages` returns nothing).
+- `libraries/libharness/src/index.js`, `src/fixture/index.js`,
+  `src/mock/index.js` all exist.
+- No root-level `.js` files in `libraries/libharness/`.
+- `libraries/libharness/package.json` description no longer mentions "guide".
+- Every file in `test/` across services and libraries that imports
+  `@forwardimpact/libharness` or `@forwardimpact/libharness/mock` still
+  passes its test.
+- `bun run test` passes.
+- `bun run layout` shows libharness conformant.
+
+## Risks
+
+1. **The zero-byte `packages/libharness/mock/config.js` has no importers,
+   per the spec.** Verify once more with
+   `rg 'packages/libharness' .` before deleting. A single hit would reset
+   the plan — investigate and escalate before proceeding.
+
+2. **Internal relative imports inside `mock/`.** Files like
+   `mock/clients.js` and `mock/index.js` likely import from each other via
+   `./clients.js`. These paths are preserved when the whole `mock/`
+   directory moves into `src/mock/`. No edits needed, but run
+   `bun run node --test libraries/libharness/test/*.test.js` to catch any
+   miss.
+
+3. **The description change is a published metadata change.** External npm
+   consumers see the new description on the next release. That is the
+   intended outcome of spec 390 success criterion #10.
+
+4. **`libharness/README.md` may reference the old layout.** If a README
+   exists, read it and update any file paths it shows. Grep for
+   `./index.js` and `./mock/` in the README.
+
+5. **Stale symlinks or untracked files in `packages/`.** `git rm -r` only
+   removes tracked files; untracked residue needs a separate
+   `rm -rf libraries/libharness/packages` before the commit. Use
+   `git status` to confirm the directory is gone from both the tree and the
+   index before committing.
+
+## Deliverable commit
+
+```
+refactor(layout): restructure libharness under src/ (part 04/08)
+
+- move root index.js to src/index.js
+- move fixture/ to src/fixture/
+- move mock/ (13 files) to src/mock/
+- delete the stale packages/ tree (zero-byte config.js, no importers)
+- update main, exports, files, description in package.json
+- description now reflects cross-monorepo role, not "for guide tests"
+
+Every call site across the monorepo continues to resolve because the
+exports map keys (., ./mock, ./fixture) are unchanged.
+
+Part 04 of 08 for spec 390.
+```
+
+— Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a-04.md
+++ b/specs/390-consistent-package-layout/plan-a-04.md
@@ -2,8 +2,8 @@
 
 `libharness` is the outlier in every library audit. This part fixes it end to
 end: move sources into `src/`, delete the stale `packages/` tree, update the
-package description to reflect its actual cross-monorepo role, and verify
-every call site across ~23 test files still resolves.
+package description to reflect its actual cross-monorepo role, and verify every
+call site across ~23 test files still resolves.
 
 ## Scope
 
@@ -15,8 +15,8 @@ All six items from spec 390's "Fix `libraries/libharness`" section:
    `packages/libharness/mock/config.js`).
 4. Update `package.json` description.
 5. Update `main`, `exports`, `files` fields.
-6. Verify every call site across the monorepo still resolves — import
-   specifiers are unchanged because the `exports` map absorbs the move.
+6. Verify every call site across the monorepo still resolves — import specifiers
+   are unchanged because the `exports` map absorbs the move.
 
 ## Current state
 
@@ -129,8 +129,10 @@ right-hand targets move. Every current call site continues to resolve.
 ## Files modified
 
 - `libraries/libharness/package.json` — description, main, exports, files.
-- `libraries/libharness/index.js` → `libraries/libharness/src/index.js` (via `git mv`).
-- `libraries/libharness/fixture/index.js` → `libraries/libharness/src/fixture/index.js`.
+- `libraries/libharness/index.js` → `libraries/libharness/src/index.js` (via
+  `git mv`).
+- `libraries/libharness/fixture/index.js` →
+  `libraries/libharness/src/fixture/index.js`.
 - `libraries/libharness/mock/*` → `libraries/libharness/src/mock/*`.
 
 ## Files deleted
@@ -147,80 +149,80 @@ specifiers:
 - `@forwardimpact/libharness/mock`
 - `@forwardimpact/libharness/fixture`
 
-The exports map catches all three; their targets change under the hood but
-the specifiers remain valid. The research sweep identified ~23 test files
-across services (`services/{agent,graph,llm,memory,pathway,tool,trace,vector,web}/test/`)
-and libraries (`libraries/{librpc,libutil,libvector,libindex}/test/`). None
-need changes.
+The exports map catches all three; their targets change under the hood but the
+specifiers remain valid. The research sweep identified ~23 test files across
+services
+(`services/{agent,graph,llm,memory,pathway,tool,trace,vector,web}/test/`) and
+libraries (`libraries/{librpc,libutil,libvector,libindex}/test/`). None need
+changes.
 
 ## Ordering
 
-1. Read `libraries/libharness/index.js` to confirm its imports (it
-   re-exports from `./fixture/index.js` and `./mock/index.js` — these become
-   `./fixture/index.js` and `./mock/index.js` inside `src/`, still
-   resolving).
-2. Read `libraries/libharness/mock/index.js` to confirm its internal imports
-   are relative (`./clients.js`, etc.) — these resolve unchanged after the
-   move because the whole directory moves together.
+1. Read `libraries/libharness/index.js` to confirm its imports (it re-exports
+   from `./fixture/index.js` and `./mock/index.js` — these become
+   `./fixture/index.js` and `./mock/index.js` inside `src/`, still resolving).
+2. Read `libraries/libharness/mock/index.js` to confirm its internal imports are
+   relative (`./clients.js`, etc.) — these resolve unchanged after the move
+   because the whole directory moves together.
 3. `mkdir -p libraries/libharness/src`
 4. `git mv libraries/libharness/index.js libraries/libharness/src/index.js`
 5. `git mv libraries/libharness/fixture libraries/libharness/src/fixture`
 6. `git mv libraries/libharness/mock libraries/libharness/src/mock`
 7. `git rm -r libraries/libharness/packages`
 8. Edit `libraries/libharness/package.json`:
-   - `description` → "Shared test harness and mock infrastructure for the Forward Impact monorepo"
+   - `description` → "Shared test harness and mock infrastructure for the
+     Forward Impact monorepo"
    - `main` → `"./src/index.js"`
    - `exports["."]` → `"./src/index.js"`
    - `exports["./mock"]` → `"./src/mock/index.js"`
    - `exports["./fixture"]` → `"./src/fixture/index.js"`
    - `files` → `["src/**/*.js", "README.md"]`
-9. Run `bun run node --test libraries/libharness/test/*.test.js` (if tests
-   exist in libharness itself — per the inventory there is a `test/` dir).
-10. Run `bun run test` at repo root to verify every call site still
-    resolves.
+9. Run `bun run node --test libraries/libharness/test/*.test.js` (if tests exist
+   in libharness itself — per the inventory there is a `test/` dir).
+10. Run `bun run test` at repo root to verify every call site still resolves.
 11. Run `bun run layout` — libharness should no longer report any drift.
 12. Commit.
 
 ## Verification
 
-- `libraries/libharness/packages/` does not exist (`git ls-files libraries/libharness/packages` returns nothing).
+- `libraries/libharness/packages/` does not exist
+  (`git ls-files libraries/libharness/packages` returns nothing).
 - `libraries/libharness/src/index.js`, `src/fixture/index.js`,
   `src/mock/index.js` all exist.
 - No root-level `.js` files in `libraries/libharness/`.
 - `libraries/libharness/package.json` description no longer mentions "guide".
 - Every file in `test/` across services and libraries that imports
-  `@forwardimpact/libharness` or `@forwardimpact/libharness/mock` still
-  passes its test.
+  `@forwardimpact/libharness` or `@forwardimpact/libharness/mock` still passes
+  its test.
 - `bun run test` passes.
 - `bun run layout` shows libharness conformant.
 
 ## Risks
 
-1. **The zero-byte `packages/libharness/mock/config.js` has no importers,
-   per the spec.** Verify once more with
-   `rg 'packages/libharness' .` before deleting. A single hit would reset
-   the plan — investigate and escalate before proceeding.
+1. **The zero-byte `packages/libharness/mock/config.js` has no importers, per
+   the spec.** Verify once more with `rg 'packages/libharness' .` before
+   deleting. A single hit would reset the plan — investigate and escalate before
+   proceeding.
 
-2. **Internal relative imports inside `mock/`.** Files like
-   `mock/clients.js` and `mock/index.js` likely import from each other via
-   `./clients.js`. These paths are preserved when the whole `mock/`
-   directory moves into `src/mock/`. No edits needed, but run
-   `bun run node --test libraries/libharness/test/*.test.js` to catch any
-   miss.
+2. **Internal relative imports inside `mock/`.** Files like `mock/clients.js`
+   and `mock/index.js` likely import from each other via `./clients.js`. These
+   paths are preserved when the whole `mock/` directory moves into `src/mock/`.
+   No edits needed, but run
+   `bun run node --test libraries/libharness/test/*.test.js` to catch any miss.
 
 3. **The description change is a published metadata change.** External npm
-   consumers see the new description on the next release. That is the
-   intended outcome of spec 390 success criterion #10.
+   consumers see the new description on the next release. That is the intended
+   outcome of spec 390 success criterion #10.
 
-4. **`libharness/README.md` may reference the old layout.** If a README
-   exists, read it and update any file paths it shows. Grep for
-   `./index.js` and `./mock/` in the README.
+4. **`libharness/README.md` may reference the old layout.** If a README exists,
+   read it and update any file paths it shows. Grep for `./index.js` and
+   `./mock/` in the README.
 
 5. **Stale symlinks or untracked files in `packages/`.** `git rm -r` only
    removes tracked files; untracked residue needs a separate
-   `rm -rf libraries/libharness/packages` before the commit. Use
-   `git status` to confirm the directory is gone from both the tree and the
-   index before committing.
+   `rm -rf libraries/libharness/packages` before the commit. Use `git status` to
+   confirm the directory is gone from both the tree and the index before
+   committing.
 
 ## Deliverable commit
 

--- a/specs/390-consistent-package-layout/plan-a-05.md
+++ b/specs/390-consistent-package-layout/plan-a-05.md
@@ -1,0 +1,414 @@
+# Plan A — Part 05: Products
+
+Bring all four products into conformance:
+
+- **map** — flatten `bin/lib/`, fold `activity/` into `src/activity/`,
+  rewrite the 25-key `exports` map.
+- **guide** — create `src/` and `src/index.js`, move `lib/status.js` to
+  `src/lib/status.js`.
+- **basecamp** — rename `template/` → `templates/`, update references.
+- **pathway** — already conforms, verify only.
+
+Products is the largest single part in the migration. It lands on its own
+commit to keep the diff reviewable.
+
+## Scope
+
+Four packages under `products/`. Each is handled as its own mini-migration
+below. The whole part ships as one commit.
+
+## products/map
+
+### Current state
+
+```
+products/map/
+├── activity/
+│   ├── parse-people.js
+│   ├── queries/
+│   └── validate/
+├── bin/
+│   ├── fit-map.js
+│   └── lib/
+│       ├── client.js
+│       ├── package-root.js
+│       ├── supabase-cli.js
+│       └── commands/
+│           ├── activity.js
+│           ├── getdx.js
+│           ├── init.js
+│           ├── people.js
+│           └── validate-shacl.js
+├── schema/
+├── src/
+│   ├── index.js
+│   ├── iri.js
+│   ├── loader.js
+│   ├── renderer.js
+│   ├── exporter.js
+│   ├── validation.js
+│   ├── schema-validation.js
+│   ├── index-generator.js
+│   └── levels.js
+├── starter/
+├── supabase/
+├── templates/
+├── test/
+└── package.json
+```
+
+### Non-conformance
+
+- `activity/` is a non-allowed root subdir (contains source code).
+- `bin/lib/` violates rule 4 ("bin/ contains only entry-point scripts").
+- The spec also flags that exports reach _into_ `supabase/functions/_shared/`
+  — we keep those pointing at `supabase/` because `supabase/` is on the
+  allowed list. No change.
+
+### Target state
+
+```
+products/map/
+├── bin/
+│   └── fit-map.js          ← thin entry point only
+├── schema/
+├── src/
+│   ├── index.js
+│   ├── iri.js
+│   ├── loader.js
+│   ├── renderer.js
+│   ├── exporter.js
+│   ├── validation.js
+│   ├── schema-validation.js
+│   ├── index-generator.js
+│   ├── levels.js
+│   ├── lib/
+│   │   ├── client.js
+│   │   ├── package-root.js
+│   │   └── supabase-cli.js
+│   ├── commands/
+│   │   ├── activity.js
+│   │   ├── getdx.js
+│   │   ├── init.js
+│   │   ├── people.js
+│   │   └── validate-shacl.js
+│   └── activity/
+│       ├── parse-people.js
+│       ├── queries/
+│       └── validate/
+├── starter/
+├── supabase/
+├── templates/
+├── test/
+└── package.json
+```
+
+### Steps
+
+1. `git mv products/map/activity products/map/src/activity`
+2. `mkdir -p products/map/src/lib products/map/src/commands`
+3. `git mv products/map/bin/lib/client.js products/map/src/lib/client.js`
+4. `git mv products/map/bin/lib/package-root.js products/map/src/lib/package-root.js`
+5. `git mv products/map/bin/lib/supabase-cli.js products/map/src/lib/supabase-cli.js`
+6. `git mv products/map/bin/lib/commands/*.js products/map/src/commands/`
+7. `rmdir products/map/bin/lib/commands products/map/bin/lib` (must be
+   empty after step 6).
+8. **Rewrite `products/map/bin/fit-map.js` imports.** Any import like
+   `./lib/client.js` becomes `../src/lib/client.js`; any
+   `./lib/commands/activity.js` becomes `../src/commands/activity.js`.
+9. **Rewrite internal imports inside the moved files.** Commands currently
+   import from `../package-root.js`, `../client.js` etc. — those relative
+   paths are preserved because the whole tree moves together (command files
+   that used `../client.js` from `bin/lib/commands/` still use `../client.js`
+   from `src/commands/` — same relative relationship because `client.js`
+   also moves to `src/lib/` one level up… wait — **this is not
+   preserved.** Original: `bin/lib/commands/activity.js` → `../client.js`
+   resolves to `bin/lib/client.js`. New: `src/commands/activity.js` →
+   `../client.js` resolves to `src/client.js`, which does not exist. The
+   correct new path is `../lib/client.js`. **Fix every internal import by
+   hand** — grep for `../` inside the moved files and re-target.
+10. Update `products/map/package.json` exports — rewrite every
+    `"./activity/..."` value from `"./activity/..."` to `"./src/activity/..."`.
+    For example:
+    ```jsonc
+    "./activity/queries/org": "./src/activity/queries/org.js",
+    "./activity/parse-people": "./src/activity/parse-people.js",
+    "./activity/validate/people": "./src/activity/validate/people.js",
+    ```
+    The `"./activity/storage"`, `"./activity/extract/*"`, and
+    `"./activity/transform/*"` keys already point at
+    `./supabase/functions/_shared/activity/...` — leave those targets
+    unchanged because `supabase/` is on the allowed list and the source
+    lives inside the supabase edge-function tree by design.
+11. `products/map/package.json` — `files` field gets `src/**/*.js` (should
+    already have it) and the removal of any stale `activity/` entry.
+12. Run `bunx fit-map validate` (the package's CLI smoke test) to confirm
+    the binary still launches.
+13. Run `bun run node --test products/map/test/*.test.js`.
+14. Verify the 25 subpath exports: grep every `"./"` key in map's
+    `package.json` and for each, confirm the target file exists with
+    `test -f`. This is the per-package version of success criterion #9.
+
+### products/map imports recap
+
+**External imports of `@forwardimpact/map/...`** (pathway, libskill, etc.)
+do not change — they use the subpath keys, which do not change.
+
+**Internal imports inside the moved `bin/lib/`**:
+
+- `bin/fit-map.js` imports from `./lib/...` — rewrite to `../src/lib/...`
+  or `../src/commands/...`.
+- `bin/lib/commands/*.js` imports from `../client.js`, `../package-root.js`,
+  `../supabase-cli.js` — after the move these become `../lib/client.js`,
+  `../lib/package-root.js`, `../lib/supabase-cli.js` (because the commands
+  move into `src/commands/` but client.js etc. move into `src/lib/` — one
+  extra directory hop).
+- `bin/lib/commands/*.js` imports from the moved `activity/` tree — the
+  relative paths need auditing. Read each command file before editing.
+
+Use `bun run test` after every rewrite to catch misses.
+
+## products/guide
+
+### Current state
+
+```
+products/guide/
+├── bin/
+│   └── fit-guide.js
+├── lib/
+│   └── status.js       ← non-conforming root subdir (source code)
+├── proto/
+├── starter/
+├── test/
+└── package.json
+```
+
+No `src/`. No `main`. No `exports`.
+
+### Target state
+
+```
+products/guide/
+├── bin/
+│   └── fit-guide.js
+├── proto/
+├── src/
+│   ├── index.js        ← new, thin re-export of lib/status.js
+│   └── lib/
+│       └── status.js
+├── starter/
+├── test/
+└── package.json
+```
+
+### Steps
+
+1. `mkdir -p products/guide/src/lib`
+2. `git mv products/guide/lib/status.js products/guide/src/lib/status.js`
+3. `rmdir products/guide/lib` (must be empty after step 2).
+4. **Create `products/guide/src/index.js`** — the spec requires every
+   non-service package to have `src/index.js`. Contents:
+   ```js
+   // Public entry point for @forwardimpact/guide.
+   // Re-exports the thin helpers the CLI wires together at launch.
+   export * from "./lib/status.js";
+   ```
+   This is a new file. Keep it minimal — only re-export what is currently
+   imported elsewhere from the guide package (likely nothing outside of
+   `bin/fit-guide.js`).
+5. **Rewrite `bin/fit-guide.js` imports.** Any `../lib/status.js` becomes
+   `../src/lib/status.js`. Use `rg 'status' products/guide/bin/` to find
+   the call site.
+6. **Rewrite any imports from `@forwardimpact/guide/lib/status.js`** —
+   research shows this is imported from `libraries/librpc/generated/...`
+   under the current layout (reference from research agent output). Confirm
+   with `rg '@forwardimpact/guide' .` and update any consumers. If the only
+   consumer is librpc itself, the fix is to add a subpath export to guide's
+   `package.json`.
+7. Update `products/guide/package.json`:
+   ```jsonc
+   {
+     "main": "./src/index.js",
+     "bin": { "fit-guide": "./bin/fit-guide.js" },
+     "exports": {
+       ".": "./src/index.js"
+     },
+     "files": ["src/**/*.js", "bin/**/*.js", "proto/**", "starter/**", "README.md"]
+   }
+   ```
+8. Run `bun run node --test products/guide/test/*.test.js`.
+9. Spot-check `bunx fit-guide --help`.
+
+## products/basecamp
+
+### Current state
+
+```
+products/basecamp/
+├── config/
+│   └── scheduler.json
+├── justfile
+├── macos/
+├── package.json
+├── pkg/
+├── src/
+│   ├── agent-runner.js
+│   ├── basecamp.js
+│   ├── kb-manager.js
+│   ├── posix-spawn.js
+│   ├── scheduler.js
+│   ├── socket-server.js
+│   └── state-manager.js
+├── template/           ← singular — non-allowed root subdir
+│   ├── CLAUDE.md
+│   ├── USER.md
+│   └── knowledge/
+└── test/
+```
+
+Basecamp already has `src/`. The only non-conformance is `template/`
+(singular) vs the allowed `templates/` (plural).
+
+### Target state
+
+Rename `template/` → `templates/` and update every reference.
+
+### Steps
+
+1. `git mv products/basecamp/template products/basecamp/templates`
+2. Grep for `template/` references inside basecamp:
+   ```
+   rg 'template/' products/basecamp/ -l
+   ```
+3. Update every hit. Typical call sites:
+   - `products/basecamp/src/kb-manager.js` — likely reads the template
+     directory at runtime (e.g., `fs.readFileSync(join(__dirname, "../template/CLAUDE.md"))`).
+   - `products/basecamp/src/basecamp.js` — may reference template layout.
+   - `products/basecamp/bin/...` — any CLI entry point.
+4. Update `products/basecamp/package.json` `files` field if it references
+   `template/**` — change to `templates/**`.
+5. Grep the entire monorepo for `basecamp/template/` (external references):
+   ```
+   rg 'basecamp/template' .
+   ```
+6. Run `bun run node --test products/basecamp/test/*.test.js`.
+7. Spot-check `bunx fit-basecamp --help` (or the relevant CLI if one is
+   defined — basecamp's `main` is `./src/basecamp.js`).
+
+### Decision flag
+
+The spec does not explicitly authorize this rename. Two alternatives:
+
+- **(Chosen)** Rename `template/` → `templates/`. Basecamp's single KB
+  template becomes `templates/default/` conceptually (but the plan does not
+  nest — it is a flat move). The `templates/` plural name matches the
+  allowed list and pathway's existing `templates/` directory.
+- **(Alternative)** Add `template/` to the allowed list in Part 01 and
+  leave basecamp alone. This is less churn but introduces a singular form
+  alongside the plural.
+
+The plan chooses rename because it preserves the allowed-list as a short,
+memorable set. Flag to the spec author if this decision is wrong.
+
+## products/pathway
+
+### Current state
+
+Already conforms: `bin/`, `src/`, `templates/`, `test/`.
+
+### Steps
+
+1. Read `products/pathway/package.json` to confirm exports point at `src/`.
+   (Per the inventory: `"./formatters": "./src/formatters/index.js"` and
+   `"./commands": "./src/commands/index.js"` — both already correct.)
+2. No changes.
+3. Running `bun run layout` reports pathway as conformant.
+
+## Ordering
+
+1. map: move activity/ and bin/lib/ into src/; rewrite imports; rewrite
+   exports; verify.
+2. guide: move lib/status.js into src/lib/; create src/index.js; add main,
+   exports; verify.
+3. basecamp: rename template/ → templates/; update references; verify.
+4. pathway: no changes; verify with `bun run layout`.
+5. Run `bun run check` and `bun run test`.
+6. Commit.
+
+## Verification
+
+- `bun run layout` reports zero drift under `products/*`.
+- `git ls-files 'products/*/*.js'` returns nothing (no root source files).
+- `git ls-files 'products/map/bin/lib/**'` returns nothing.
+- `products/guide/src/index.js` exists.
+- `products/basecamp/template/` does not exist; `templates/` does.
+- `bunx fit-map validate` succeeds.
+- `bunx fit-guide --help` succeeds.
+- `bunx fit-basecamp --help` (or equivalent) succeeds.
+- `bunx fit-pathway --help` succeeds.
+- `bun run test` passes.
+- Every `"./"` key in every product's `package.json` resolves to a file
+  that exists on disk (per-package smoke check for #9).
+
+## Risks
+
+1. **products/map has 25 subpath exports.** The activity/ ones move from
+   `./activity/...` to `./src/activity/...`; the `./activity/storage` and
+   `./activity/{extract,transform}/*` keys point at `./supabase/functions/_shared/...`
+   and must stay untouched. Reading the spec's import list confirms which
+   is which. Mis-targeting any key silently breaks downstream at import
+   time.
+
+2. **The `bin/lib/commands/` rewrite has multi-level relative paths.**
+   Commands like `bin/lib/commands/activity.js` likely import from
+   `../client.js` (reaching `bin/lib/client.js`). After the move, the
+   command is at `src/commands/activity.js` and client.js is at
+   `src/lib/client.js` — the relative path becomes `../lib/client.js`. Get
+   every one right. Do not batch with `sed` — read and edit each file.
+
+3. **`products/map/bin/fit-map.js` loads commands by name.** Read it
+   carefully: if it does something like `import(`./lib/commands/${cmd}.js`)`
+   the dynamic string has to change too. Grep for `commands/` inside the
+   binary.
+
+4. **basecamp KB template rename is load-bearing.** The runtime code that
+   reads `template/CLAUDE.md` during `fit-basecamp init` is the user-facing
+   feature that copies the template to a consumer's knowledge directory. If
+   a reference is missed, `fit-basecamp init` silently copies zero files.
+   Grep for both the literal string `"template/"` and the path fragment
+   `template` inside JS files. The `config/scheduler.json` file may also
+   reference the template path.
+
+5. **products/pathway is "untouched" but Part 01's check still runs
+   against it.** Verify no new drift has been introduced since the
+   inventory was taken.
+
+6. **`src/index.js` for guide.** Making guide's `src/index.js` a re-export
+   of `status.js` is enough for the layout contract but may not match how
+   the guide package currently exposes anything publicly. Today guide has
+   no `main` and no `exports` — it is not imported as a library by any
+   consumer, only launched as a CLI. The new `src/index.js` is essentially
+   a placeholder. Do not add real logic to it; adding logic would be out of
+   scope for this spec.
+
+## Deliverable commit
+
+```
+refactor(layout): flatten product layouts to the contract (part 05/08)
+
+- products/map: move bin/lib/ into src/{lib,commands}/, fold activity/
+  into src/activity/, rewrite the 25-key exports map, rewrite
+  internal imports in bin/fit-map.js and the moved commands
+- products/guide: create src/, move lib/status.js to src/lib/, add
+  src/index.js and main/exports/files
+- products/basecamp: rename template/ to templates/, update runtime
+  references (kb-manager + any config references)
+- products/pathway: no change (already conforms)
+
+Every public subpath export key is preserved; only targets move.
+
+Part 05 of 08 for spec 390.
+```
+
+— Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a-05.md
+++ b/specs/390-consistent-package-layout/plan-a-05.md
@@ -3,7 +3,7 @@
 Bring all four products into conformance:
 
 - **map** — flatten `bin/lib/`, fold `activity/` into `src/activity/`,
-  rewrite the 25-key `exports` map.
+  rewrite the 25-key `exports` map (1 root `"."` + 24 subpaths).
 - **guide** — create `src/` and `src/index.js`, move `lib/status.js` to
   `src/lib/status.js`.
 - **basecamp** — rename `template/` → `templates/`, update references.
@@ -145,9 +145,10 @@ products/map/
 12. Run `bunx fit-map validate` (the package's CLI smoke test) to confirm
     the binary still launches.
 13. Run `bun run node --test products/map/test/*.test.js`.
-14. Verify the 25 subpath exports: grep every `"./"` key in map's
-    `package.json` and for each, confirm the target file exists with
-    `test -f`. This is the per-package version of success criterion #9.
+14. Verify all 25 exports (1 root `"."` + 24 subpaths): grep every
+    `"./"` and `"."` key in map's `package.json` and for each, confirm
+    the target file exists with `test -f`. This is the per-package
+    version of success criterion #9.
 
 ### products/map imports recap
 
@@ -220,12 +221,11 @@ products/guide/
 5. **Rewrite `bin/fit-guide.js` imports.** Any `../lib/status.js` becomes
    `../src/lib/status.js`. Use `rg 'status' products/guide/bin/` to find
    the call site.
-6. **Rewrite any imports from `@forwardimpact/guide/lib/status.js`** —
-   research shows this is imported from `libraries/librpc/generated/...`
-   under the current layout (reference from research agent output). Confirm
-   with `rg '@forwardimpact/guide' .` and update any consumers. If the only
-   consumer is librpc itself, the fix is to add a subpath export to guide's
-   `package.json`.
+6. **Verify no external consumer exists.** Run
+   `rg '@forwardimpact/guide' .`. Today the only consumer is
+   `products/guide/bin/fit-guide.js` itself, which uses a relative
+   import (`../lib/status.js`), not the package name. If any external
+   consumer appears in the grep, investigate before proceeding.
 7. Update `products/guide/package.json`:
    ```jsonc
    {
@@ -250,29 +250,38 @@ products/basecamp/
 │   └── scheduler.json
 ├── justfile
 ├── macos/
-├── package.json
+├── package.json           ← main = "src/basecamp.js"; bin = "./src/basecamp.js"
 ├── pkg/
 ├── src/
 │   ├── agent-runner.js
-│   ├── basecamp.js
+│   ├── basecamp.js        ← #!/usr/bin/env bun — CLI + library main
 │   ├── kb-manager.js
 │   ├── posix-spawn.js
 │   ├── scheduler.js
 │   ├── socket-server.js
 │   └── state-manager.js
-├── template/           ← singular — non-allowed root subdir
+├── template/              ← singular — non-allowed root subdir
 │   ├── CLAUDE.md
 │   ├── USER.md
 │   └── knowledge/
 └── test/
 ```
 
-Basecamp already has `src/`. The only non-conformance is `template/`
-(singular) vs the allowed `templates/` (plural).
+**Two non-conformances:**
+
+1. `template/` (singular) vs the allowed `templates/` (plural).
+2. `package.json`'s `bin.fit-basecamp` points at `./src/basecamp.js`.
+   Spec rule 4 says "`bin/` contains only entry-point scripts. One file
+   per CLI binary declared in `package.json`." Basecamp has no `bin/`
+   directory at all — its CLI entry lives inside `src/`. Under the new
+   contract, every declared binary must live at `bin/<name>.js`.
 
 ### Target state
 
-Rename `template/` → `templates/` and update every reference.
+- Rename `template/` → `templates/` and update every reference.
+- Create `bin/fit-basecamp.js` as a thin shim that runs
+  `src/basecamp.js`. Update `package.json` `bin` to point at the new
+  thin shim. Keep `src/basecamp.js` as the library entry (`main`).
 
 ### Steps
 
@@ -283,18 +292,52 @@ Rename `template/` → `templates/` and update every reference.
    ```
 3. Update every hit. Typical call sites:
    - `products/basecamp/src/kb-manager.js` — likely reads the template
-     directory at runtime (e.g., `fs.readFileSync(join(__dirname, "../template/CLAUDE.md"))`).
+     directory at runtime.
    - `products/basecamp/src/basecamp.js` — may reference template layout.
-   - `products/basecamp/bin/...` — any CLI entry point.
-4. Update `products/basecamp/package.json` `files` field if it references
-   `template/**` — change to `templates/**`.
-5. Grep the entire monorepo for `basecamp/template/` (external references):
+4. Update `products/basecamp/package.json` `files` field to replace
+   `template/` (if present) with `templates/`.
+5. Grep the entire monorepo for `basecamp/template/` (external
+   references):
    ```
    rg 'basecamp/template' .
    ```
-6. Run `bun run node --test products/basecamp/test/*.test.js`.
-7. Spot-check `bunx fit-basecamp --help` (or the relevant CLI if one is
-   defined — basecamp's `main` is `./src/basecamp.js`).
+6. **Create `products/basecamp/bin/fit-basecamp.js`** as a thin CLI
+   shim. Preserve the current shebang (`#!/usr/bin/env bun`) because
+   `src/basecamp.js` uses it — swapping to node is out of scope for
+   this spec. Contents:
+   ```js
+   #!/usr/bin/env bun
+   // Thin entry point — delegates to src/basecamp.js.
+   import "../src/basecamp.js";
+   ```
+   Make it executable: `chmod +x products/basecamp/bin/fit-basecamp.js`.
+7. **Update `products/basecamp/package.json`**:
+   ```jsonc
+   {
+     "main": "./src/basecamp.js",
+     "bin": { "fit-basecamp": "./bin/fit-basecamp.js" }
+   }
+   ```
+   Do **not** remove the shebang from `src/basecamp.js`. When
+   `src/basecamp.js` is executed as a library entry it runs a CLI
+   dispatcher at the bottom of the file — leaving that in place means
+   the thin shim just re-imports the module and the side-effect runs.
+   If the module does not run CLI-on-import today, split it: move the
+   CLI dispatcher into `bin/fit-basecamp.js` and keep the exports in
+   `src/basecamp.js`. Read the file first to decide which approach fits.
+8. **Update the scripts in `package.json`** that currently reference
+   `src/basecamp.js` as a runtime target:
+   ```jsonc
+   "scripts": {
+     "start": "bun ./bin/fit-basecamp.js",
+     "status": "bun ./bin/fit-basecamp.js status",
+     "build": "bun pkg/build.js"
+   }
+   ```
+   (Read the current scripts first — they may reference
+   `src/basecamp.js` directly. Rewrite to point at `bin/fit-basecamp.js`.)
+9. Run `bun run node --test products/basecamp/test/*.test.js`.
+10. Spot-check `bunx fit-basecamp --help` from the monorepo root.
 
 ### Decision flag
 
@@ -315,15 +358,52 @@ memorable set. Flag to the spec author if this decision is wrong.
 
 ### Current state
 
-Already conforms: `bin/`, `src/`, `templates/`, `test/`.
+Directory shape is conformant: `bin/`, `src/`, `templates/`, `test/`.
+**But two gaps block success criterion #4:**
+
+1. `products/pathway/src/index.js` **does not exist**. The src/ tree
+   has `main.js`, `handout-main.js`, `slide-main.js`, `types.js`, and
+   several subdirectories (`commands/`, `components/`, `css/`,
+   `formatters/`, `pages/`, `slides/`, `lib/`), but no `index.js`.
+2. `products/pathway/package.json` has **no `main` field** and **no
+   `"."` entry in `exports`** — only `./formatters` and `./commands`.
+
+Success criterion #4 requires every non-service package to have
+`src/index.js`. Part 05 fixes both gaps.
 
 ### Steps
 
-1. Read `products/pathway/package.json` to confirm exports point at `src/`.
-   (Per the inventory: `"./formatters": "./src/formatters/index.js"` and
-   `"./commands": "./src/commands/index.js"` — both already correct.)
-2. No changes.
-3. Running `bun run layout` reports pathway as conformant.
+1. **Create `products/pathway/src/index.js`.** Make it a thin re-export
+   of the types module (which is the closest thing to a public library
+   entry pathway has today):
+   ```js
+   // Public entry point for @forwardimpact/pathway.
+   // The primary consumption mode is the CLI (fit-pathway) — this
+   // re-export exists so the package conforms to the repo-wide layout
+   // contract (spec 390) and so consumers who import
+   // @forwardimpact/pathway directly receive the shared type
+   // definitions.
+   export * from "./types.js";
+   ```
+   Keep it minimal. Do not move runtime logic — that is out of scope.
+2. **Update `products/pathway/package.json`** to add `main` and a `"."`
+   exports entry:
+   ```jsonc
+   {
+     "main": "./src/index.js",
+     "exports": {
+       ".": "./src/index.js",
+       "./formatters": "./src/formatters/index.js",
+       "./commands": "./src/commands/index.js"
+     }
+   }
+   ```
+   The `./formatters` and `./commands` entries stay exactly as today.
+3. Run `bun run node --test products/pathway/test/*.test.js`.
+4. Spot-check `bunx fit-pathway --help`.
+5. Verify with `bun run layout` — pathway now reports fully
+   conformant (root subdirs already allowed; `src/index.js` now
+   exists).
 
 ## Ordering
 
@@ -342,23 +422,33 @@ Already conforms: `bin/`, `src/`, `templates/`, `test/`.
 - `git ls-files 'products/*/*.js'` returns nothing (no root source files).
 - `git ls-files 'products/map/bin/lib/**'` returns nothing.
 - `products/guide/src/index.js` exists.
+- `products/pathway/src/index.js` exists.
+- `products/basecamp/bin/fit-basecamp.js` exists and is executable.
 - `products/basecamp/template/` does not exist; `templates/` does.
+- `products/basecamp/package.json` `bin.fit-basecamp` is
+  `./bin/fit-basecamp.js` (not `./src/basecamp.js`).
+- `products/pathway/package.json` has `main: "./src/index.js"` and
+  `exports["."]` present.
 - `bunx fit-map validate` succeeds.
 - `bunx fit-guide --help` succeeds.
 - `bunx fit-basecamp --help` (or equivalent) succeeds.
 - `bunx fit-pathway --help` succeeds.
 - `bun run test` passes.
-- Every `"./"` key in every product's `package.json` resolves to a file
-  that exists on disk (per-package smoke check for #9).
+- Every `"."` and `"./"` key in every product's `package.json` resolves
+  to a file that exists on disk (per-package smoke check for #9).
 
 ## Risks
 
-1. **products/map has 25 subpath exports.** The activity/ ones move from
-   `./activity/...` to `./src/activity/...`; the `./activity/storage` and
-   `./activity/{extract,transform}/*` keys point at `./supabase/functions/_shared/...`
-   and must stay untouched. Reading the spec's import list confirms which
-   is which. Mis-targeting any key silently breaks downstream at import
-   time.
+1. **products/map has 25 total exports keys** — 1 root (`"."`) + 24
+   subpaths. The activity/ ones that reference package-local source
+   (`./activity/queries/*`, `./activity/parse-people`,
+   `./activity/validate/people`) move from `./activity/...` to
+   `./src/activity/...`; the `./activity/storage` and
+   `./activity/{extract,transform}/*` keys point at
+   `./supabase/functions/_shared/...` and **must stay untouched**
+   because their source lives inside the supabase edge-function tree by
+   design and `supabase/` is on the allowed root-subdirs list.
+   Mis-targeting any key silently breaks downstream at import time.
 
 2. **The `bin/lib/commands/` rewrite has multi-level relative paths.**
    Commands like `bin/lib/commands/activity.js` likely import from
@@ -398,13 +488,16 @@ Already conforms: `bin/`, `src/`, `templates/`, `test/`.
 refactor(layout): flatten product layouts to the contract (part 05/08)
 
 - products/map: move bin/lib/ into src/{lib,commands}/, fold activity/
-  into src/activity/, rewrite the 25-key exports map, rewrite
-  internal imports in bin/fit-map.js and the moved commands
+  into src/activity/, rewrite the 24 subpath exports (map ships 25
+  keys total: "." + 24 subpaths), rewrite internal imports in
+  bin/fit-map.js and the moved commands
 - products/guide: create src/, move lib/status.js to src/lib/, add
   src/index.js and main/exports/files
 - products/basecamp: rename template/ to templates/, update runtime
-  references (kb-manager + any config references)
-- products/pathway: no change (already conforms)
+  references (kb-manager + package.json scripts), create
+  bin/fit-basecamp.js thin shim, update bin field to point there
+- products/pathway: create src/index.js, add main and exports["."]
+  (otherwise already conformant)
 
 Every public subpath export key is preserved; only targets move.
 

--- a/specs/390-consistent-package-layout/plan-a-05.md
+++ b/specs/390-consistent-package-layout/plan-a-05.md
@@ -2,15 +2,15 @@
 
 Bring all four products into conformance:
 
-- **map** — flatten `bin/lib/`, fold `activity/` into `src/activity/`,
-  rewrite the 25-key `exports` map (1 root `"."` + 24 subpaths).
+- **map** — flatten `bin/lib/`, fold `activity/` into `src/activity/`, rewrite
+  the 25-key `exports` map (1 root `"."` + 24 subpaths).
 - **guide** — create `src/` and `src/index.js`, move `lib/status.js` to
   `src/lib/status.js`.
 - **basecamp** — rename `template/` → `templates/`, update references.
 - **pathway** — already conforms, verify only.
 
-Products is the largest single part in the migration. It lands on its own
-commit to keep the diff reviewable.
+Products is the largest single part in the migration. It lands on its own commit
+to keep the diff reviewable.
 
 ## Scope
 
@@ -61,9 +61,9 @@ products/map/
 
 - `activity/` is a non-allowed root subdir (contains source code).
 - `bin/lib/` violates rule 4 ("bin/ contains only entry-point scripts").
-- The spec also flags that exports reach _into_ `supabase/functions/_shared/`
-  — we keep those pointing at `supabase/` because `supabase/` is on the
-  allowed list. No change.
+- The spec also flags that exports reach _into_ `supabase/functions/_shared/` —
+  we keep those pointing at `supabase/` because `supabase/` is on the allowed
+  list. No change.
 
 ### Target state
 
@@ -111,22 +111,22 @@ products/map/
 4. `git mv products/map/bin/lib/package-root.js products/map/src/lib/package-root.js`
 5. `git mv products/map/bin/lib/supabase-cli.js products/map/src/lib/supabase-cli.js`
 6. `git mv products/map/bin/lib/commands/*.js products/map/src/commands/`
-7. `rmdir products/map/bin/lib/commands products/map/bin/lib` (must be
-   empty after step 6).
+7. `rmdir products/map/bin/lib/commands products/map/bin/lib` (must be empty
+   after step 6).
 8. **Rewrite `products/map/bin/fit-map.js` imports.** Any import like
    `./lib/client.js` becomes `../src/lib/client.js`; any
    `./lib/commands/activity.js` becomes `../src/commands/activity.js`.
 9. **Rewrite internal imports inside the moved files.** Commands currently
-   import from `../package-root.js`, `../client.js` etc. — those relative
-   paths are preserved because the whole tree moves together (command files
-   that used `../client.js` from `bin/lib/commands/` still use `../client.js`
-   from `src/commands/` — same relative relationship because `client.js`
-   also moves to `src/lib/` one level up… wait — **this is not
-   preserved.** Original: `bin/lib/commands/activity.js` → `../client.js`
-   resolves to `bin/lib/client.js`. New: `src/commands/activity.js` →
-   `../client.js` resolves to `src/client.js`, which does not exist. The
-   correct new path is `../lib/client.js`. **Fix every internal import by
-   hand** — grep for `../` inside the moved files and re-target.
+   import from `../package-root.js`, `../client.js` etc. — those relative paths
+   are preserved because the whole tree moves together (command files that used
+   `../client.js` from `bin/lib/commands/` still use `../client.js` from
+   `src/commands/` — same relative relationship because `client.js` also moves
+   to `src/lib/` one level up… wait — **this is not preserved.** Original:
+   `bin/lib/commands/activity.js` → `../client.js` resolves to
+   `bin/lib/client.js`. New: `src/commands/activity.js` → `../client.js`
+   resolves to `src/client.js`, which does not exist. The correct new path is
+   `../lib/client.js`. **Fix every internal import by hand** — grep for `../`
+   inside the moved files and re-target.
 10. Update `products/map/package.json` exports — rewrite every
     `"./activity/..."` value from `"./activity/..."` to `"./src/activity/..."`.
     For example:
@@ -137,35 +137,35 @@ products/map/
     ```
     The `"./activity/storage"`, `"./activity/extract/*"`, and
     `"./activity/transform/*"` keys already point at
-    `./supabase/functions/_shared/activity/...` — leave those targets
-    unchanged because `supabase/` is on the allowed list and the source
-    lives inside the supabase edge-function tree by design.
+    `./supabase/functions/_shared/activity/...` — leave those targets unchanged
+    because `supabase/` is on the allowed list and the source lives inside the
+    supabase edge-function tree by design.
 11. `products/map/package.json` — `files` field gets `src/**/*.js` (should
     already have it) and the removal of any stale `activity/` entry.
-12. Run `bunx fit-map validate` (the package's CLI smoke test) to confirm
-    the binary still launches.
+12. Run `bunx fit-map validate` (the package's CLI smoke test) to confirm the
+    binary still launches.
 13. Run `bun run node --test products/map/test/*.test.js`.
-14. Verify all 25 exports (1 root `"."` + 24 subpaths): grep every
-    `"./"` and `"."` key in map's `package.json` and for each, confirm
-    the target file exists with `test -f`. This is the per-package
-    version of success criterion #9.
+14. Verify all 25 exports (1 root `"."` + 24 subpaths): grep every `"./"` and
+    `"."` key in map's `package.json` and for each, confirm the target file
+    exists with `test -f`. This is the per-package version of success criterion
+    #9.
 
 ### products/map imports recap
 
-**External imports of `@forwardimpact/map/...`** (pathway, libskill, etc.)
-do not change — they use the subpath keys, which do not change.
+**External imports of `@forwardimpact/map/...`** (pathway, libskill, etc.) do
+not change — they use the subpath keys, which do not change.
 
 **Internal imports inside the moved `bin/lib/`**:
 
-- `bin/fit-map.js` imports from `./lib/...` — rewrite to `../src/lib/...`
-  or `../src/commands/...`.
+- `bin/fit-map.js` imports from `./lib/...` — rewrite to `../src/lib/...` or
+  `../src/commands/...`.
 - `bin/lib/commands/*.js` imports from `../client.js`, `../package-root.js`,
   `../supabase-cli.js` — after the move these become `../lib/client.js`,
-  `../lib/package-root.js`, `../lib/supabase-cli.js` (because the commands
-  move into `src/commands/` but client.js etc. move into `src/lib/` — one
-  extra directory hop).
-- `bin/lib/commands/*.js` imports from the moved `activity/` tree — the
-  relative paths need auditing. Read each command file before editing.
+  `../lib/package-root.js`, `../lib/supabase-cli.js` (because the commands move
+  into `src/commands/` but client.js etc. move into `src/lib/` — one extra
+  directory hop).
+- `bin/lib/commands/*.js` imports from the moved `activity/` tree — the relative
+  paths need auditing. Read each command file before editing.
 
 Use `bun run test` after every rewrite to catch misses.
 
@@ -219,13 +219,12 @@ products/guide/
    imported elsewhere from the guide package (likely nothing outside of
    `bin/fit-guide.js`).
 5. **Rewrite `bin/fit-guide.js` imports.** Any `../lib/status.js` becomes
-   `../src/lib/status.js`. Use `rg 'status' products/guide/bin/` to find
-   the call site.
-6. **Verify no external consumer exists.** Run
-   `rg '@forwardimpact/guide' .`. Today the only consumer is
-   `products/guide/bin/fit-guide.js` itself, which uses a relative
-   import (`../lib/status.js`), not the package name. If any external
-   consumer appears in the grep, investigate before proceeding.
+   `../src/lib/status.js`. Use `rg 'status' products/guide/bin/` to find the
+   call site.
+6. **Verify no external consumer exists.** Run `rg '@forwardimpact/guide' .`.
+   Today the only consumer is `products/guide/bin/fit-guide.js` itself, which
+   uses a relative import (`../lib/status.js`), not the package name. If any
+   external consumer appears in the grep, investigate before proceeding.
 7. Update `products/guide/package.json`:
    ```jsonc
    {
@@ -270,18 +269,18 @@ products/basecamp/
 **Two non-conformances:**
 
 1. `template/` (singular) vs the allowed `templates/` (plural).
-2. `package.json`'s `bin.fit-basecamp` points at `./src/basecamp.js`.
-   Spec rule 4 says "`bin/` contains only entry-point scripts. One file
-   per CLI binary declared in `package.json`." Basecamp has no `bin/`
-   directory at all — its CLI entry lives inside `src/`. Under the new
-   contract, every declared binary must live at `bin/<name>.js`.
+2. `package.json`'s `bin.fit-basecamp` points at `./src/basecamp.js`. Spec rule
+   4 says "`bin/` contains only entry-point scripts. One file per CLI binary
+   declared in `package.json`." Basecamp has no `bin/` directory at all — its
+   CLI entry lives inside `src/`. Under the new contract, every declared binary
+   must live at `bin/<name>.js`.
 
 ### Target state
 
 - Rename `template/` → `templates/` and update every reference.
-- Create `bin/fit-basecamp.js` as a thin shim that runs
-  `src/basecamp.js`. Update `package.json` `bin` to point at the new
-  thin shim. Keep `src/basecamp.js` as the library entry (`main`).
+- Create `bin/fit-basecamp.js` as a thin shim that runs `src/basecamp.js`.
+  Update `package.json` `bin` to point at the new thin shim. Keep
+  `src/basecamp.js` as the library entry (`main`).
 
 ### Steps
 
@@ -291,20 +290,18 @@ products/basecamp/
    rg 'template/' products/basecamp/ -l
    ```
 3. Update every hit. Typical call sites:
-   - `products/basecamp/src/kb-manager.js` — likely reads the template
-     directory at runtime.
+   - `products/basecamp/src/kb-manager.js` — likely reads the template directory
+     at runtime.
    - `products/basecamp/src/basecamp.js` — may reference template layout.
-4. Update `products/basecamp/package.json` `files` field to replace
-   `template/` (if present) with `templates/`.
-5. Grep the entire monorepo for `basecamp/template/` (external
-   references):
+4. Update `products/basecamp/package.json` `files` field to replace `template/`
+   (if present) with `templates/`.
+5. Grep the entire monorepo for `basecamp/template/` (external references):
    ```
    rg 'basecamp/template' .
    ```
-6. **Create `products/basecamp/bin/fit-basecamp.js`** as a thin CLI
-   shim. Preserve the current shebang (`#!/usr/bin/env bun`) because
-   `src/basecamp.js` uses it — swapping to node is out of scope for
-   this spec. Contents:
+6. **Create `products/basecamp/bin/fit-basecamp.js`** as a thin CLI shim.
+   Preserve the current shebang (`#!/usr/bin/env bun`) because `src/basecamp.js`
+   uses it — swapping to node is out of scope for this spec. Contents:
    ```js
    #!/usr/bin/env bun
    // Thin entry point — delegates to src/basecamp.js.
@@ -318,13 +315,13 @@ products/basecamp/
      "bin": { "fit-basecamp": "./bin/fit-basecamp.js" }
    }
    ```
-   Do **not** remove the shebang from `src/basecamp.js`. When
-   `src/basecamp.js` is executed as a library entry it runs a CLI
-   dispatcher at the bottom of the file — leaving that in place means
-   the thin shim just re-imports the module and the side-effect runs.
-   If the module does not run CLI-on-import today, split it: move the
-   CLI dispatcher into `bin/fit-basecamp.js` and keep the exports in
-   `src/basecamp.js`. Read the file first to decide which approach fits.
+   Do **not** remove the shebang from `src/basecamp.js`. When `src/basecamp.js`
+   is executed as a library entry it runs a CLI dispatcher at the bottom of the
+   file — leaving that in place means the thin shim just re-imports the module
+   and the side-effect runs. If the module does not run CLI-on-import today,
+   split it: move the CLI dispatcher into `bin/fit-basecamp.js` and keep the
+   exports in `src/basecamp.js`. Read the file first to decide which approach
+   fits.
 8. **Update the scripts in `package.json`** that currently reference
    `src/basecamp.js` as a runtime target:
    ```jsonc
@@ -334,8 +331,8 @@ products/basecamp/
      "build": "bun pkg/build.js"
    }
    ```
-   (Read the current scripts first — they may reference
-   `src/basecamp.js` directly. Rewrite to point at `bin/fit-basecamp.js`.)
+   (Read the current scripts first — they may reference `src/basecamp.js`
+   directly. Rewrite to point at `bin/fit-basecamp.js`.)
 9. Run `bun run node --test products/basecamp/test/*.test.js`.
 10. Spot-check `bunx fit-basecamp --help` from the monorepo root.
 
@@ -343,13 +340,13 @@ products/basecamp/
 
 The spec does not explicitly authorize this rename. Two alternatives:
 
-- **(Chosen)** Rename `template/` → `templates/`. Basecamp's single KB
-  template becomes `templates/default/` conceptually (but the plan does not
-  nest — it is a flat move). The `templates/` plural name matches the
-  allowed list and pathway's existing `templates/` directory.
-- **(Alternative)** Add `template/` to the allowed list in Part 01 and
-  leave basecamp alone. This is less churn but introduces a singular form
-  alongside the plural.
+- **(Chosen)** Rename `template/` → `templates/`. Basecamp's single KB template
+  becomes `templates/default/` conceptually (but the plan does not nest — it is
+  a flat move). The `templates/` plural name matches the allowed list and
+  pathway's existing `templates/` directory.
+- **(Alternative)** Add `template/` to the allowed list in Part 01 and leave
+  basecamp alone. This is less churn but introduces a singular form alongside
+  the plural.
 
 The plan chooses rename because it preserves the allowed-list as a short,
 memorable set. Flag to the spec author if this decision is wrong.
@@ -358,24 +355,24 @@ memorable set. Flag to the spec author if this decision is wrong.
 
 ### Current state
 
-Directory shape is conformant: `bin/`, `src/`, `templates/`, `test/`.
-**But two gaps block success criterion #4:**
+Directory shape is conformant: `bin/`, `src/`, `templates/`, `test/`. **But two
+gaps block success criterion #4:**
 
-1. `products/pathway/src/index.js` **does not exist**. The src/ tree
-   has `main.js`, `handout-main.js`, `slide-main.js`, `types.js`, and
-   several subdirectories (`commands/`, `components/`, `css/`,
-   `formatters/`, `pages/`, `slides/`, `lib/`), but no `index.js`.
-2. `products/pathway/package.json` has **no `main` field** and **no
-   `"."` entry in `exports`** — only `./formatters` and `./commands`.
+1. `products/pathway/src/index.js` **does not exist**. The src/ tree has
+   `main.js`, `handout-main.js`, `slide-main.js`, `types.js`, and several
+   subdirectories (`commands/`, `components/`, `css/`, `formatters/`, `pages/`,
+   `slides/`, `lib/`), but no `index.js`.
+2. `products/pathway/package.json` has **no `main` field** and **no `"."` entry
+   in `exports`** — only `./formatters` and `./commands`.
 
-Success criterion #4 requires every non-service package to have
-`src/index.js`. Part 05 fixes both gaps.
+Success criterion #4 requires every non-service package to have `src/index.js`.
+Part 05 fixes both gaps.
 
 ### Steps
 
-1. **Create `products/pathway/src/index.js`.** Make it a thin re-export
-   of the types module (which is the closest thing to a public library
-   entry pathway has today):
+1. **Create `products/pathway/src/index.js`.** Make it a thin re-export of the
+   types module (which is the closest thing to a public library entry pathway
+   has today):
    ```js
    // Public entry point for @forwardimpact/pathway.
    // The primary consumption mode is the CLI (fit-pathway) — this
@@ -386,8 +383,8 @@ Success criterion #4 requires every non-service package to have
    export * from "./types.js";
    ```
    Keep it minimal. Do not move runtime logic — that is out of scope.
-2. **Update `products/pathway/package.json`** to add `main` and a `"."`
-   exports entry:
+2. **Update `products/pathway/package.json`** to add `main` and a `"."` exports
+   entry:
    ```jsonc
    {
      "main": "./src/index.js",
@@ -401,14 +398,13 @@ Success criterion #4 requires every non-service package to have
    The `./formatters` and `./commands` entries stay exactly as today.
 3. Run `bun run node --test products/pathway/test/*.test.js`.
 4. Spot-check `bunx fit-pathway --help`.
-5. Verify with `bun run layout` — pathway now reports fully
-   conformant (root subdirs already allowed; `src/index.js` now
-   exists).
+5. Verify with `bun run layout` — pathway now reports fully conformant (root
+   subdirs already allowed; `src/index.js` now exists).
 
 ## Ordering
 
-1. map: move activity/ and bin/lib/ into src/; rewrite imports; rewrite
-   exports; verify.
+1. map: move activity/ and bin/lib/ into src/; rewrite imports; rewrite exports;
+   verify.
 2. guide: move lib/status.js into src/lib/; create src/index.js; add main,
    exports; verify.
 3. basecamp: rename template/ → templates/; update references; verify.
@@ -425,8 +421,8 @@ Success criterion #4 requires every non-service package to have
 - `products/pathway/src/index.js` exists.
 - `products/basecamp/bin/fit-basecamp.js` exists and is executable.
 - `products/basecamp/template/` does not exist; `templates/` does.
-- `products/basecamp/package.json` `bin.fit-basecamp` is
-  `./bin/fit-basecamp.js` (not `./src/basecamp.js`).
+- `products/basecamp/package.json` `bin.fit-basecamp` is `./bin/fit-basecamp.js`
+  (not `./src/basecamp.js`).
 - `products/pathway/package.json` has `main: "./src/index.js"` and
   `exports["."]` present.
 - `bunx fit-map validate` succeeds.
@@ -434,53 +430,49 @@ Success criterion #4 requires every non-service package to have
 - `bunx fit-basecamp --help` (or equivalent) succeeds.
 - `bunx fit-pathway --help` succeeds.
 - `bun run test` passes.
-- Every `"."` and `"./"` key in every product's `package.json` resolves
-  to a file that exists on disk (per-package smoke check for #9).
+- Every `"."` and `"./"` key in every product's `package.json` resolves to a
+  file that exists on disk (per-package smoke check for #9).
 
 ## Risks
 
-1. **products/map has 25 total exports keys** — 1 root (`"."`) + 24
-   subpaths. The activity/ ones that reference package-local source
+1. **products/map has 25 total exports keys** — 1 root (`"."`) + 24 subpaths.
+   The activity/ ones that reference package-local source
    (`./activity/queries/*`, `./activity/parse-people`,
    `./activity/validate/people`) move from `./activity/...` to
    `./src/activity/...`; the `./activity/storage` and
    `./activity/{extract,transform}/*` keys point at
-   `./supabase/functions/_shared/...` and **must stay untouched**
-   because their source lives inside the supabase edge-function tree by
-   design and `supabase/` is on the allowed root-subdirs list.
-   Mis-targeting any key silently breaks downstream at import time.
+   `./supabase/functions/_shared/...` and **must stay untouched** because their
+   source lives inside the supabase edge-function tree by design and `supabase/`
+   is on the allowed root-subdirs list. Mis-targeting any key silently breaks
+   downstream at import time.
 
-2. **The `bin/lib/commands/` rewrite has multi-level relative paths.**
-   Commands like `bin/lib/commands/activity.js` likely import from
-   `../client.js` (reaching `bin/lib/client.js`). After the move, the
-   command is at `src/commands/activity.js` and client.js is at
-   `src/lib/client.js` — the relative path becomes `../lib/client.js`. Get
-   every one right. Do not batch with `sed` — read and edit each file.
+2. **The `bin/lib/commands/` rewrite has multi-level relative paths.** Commands
+   like `bin/lib/commands/activity.js` likely import from `../client.js`
+   (reaching `bin/lib/client.js`). After the move, the command is at
+   `src/commands/activity.js` and client.js is at `src/lib/client.js` — the
+   relative path becomes `../lib/client.js`. Get every one right. Do not batch
+   with `sed` — read and edit each file.
 
-3. **`products/map/bin/fit-map.js` loads commands by name.** Read it
-   carefully: if it does something like `import(`./lib/commands/${cmd}.js`)`
-   the dynamic string has to change too. Grep for `commands/` inside the
-   binary.
+3. **`products/map/bin/fit-map.js` loads commands by name.** Read it carefully:
+   if it does something like `import(`./lib/commands/${cmd}.js`)` the dynamic
+   string has to change too. Grep for `commands/` inside the binary.
 
-4. **basecamp KB template rename is load-bearing.** The runtime code that
-   reads `template/CLAUDE.md` during `fit-basecamp init` is the user-facing
-   feature that copies the template to a consumer's knowledge directory. If
-   a reference is missed, `fit-basecamp init` silently copies zero files.
-   Grep for both the literal string `"template/"` and the path fragment
-   `template` inside JS files. The `config/scheduler.json` file may also
-   reference the template path.
+4. **basecamp KB template rename is load-bearing.** The runtime code that reads
+   `template/CLAUDE.md` during `fit-basecamp init` is the user-facing feature
+   that copies the template to a consumer's knowledge directory. If a reference
+   is missed, `fit-basecamp init` silently copies zero files. Grep for both the
+   literal string `"template/"` and the path fragment `template` inside JS
+   files. The `config/scheduler.json` file may also reference the template path.
 
-5. **products/pathway is "untouched" but Part 01's check still runs
-   against it.** Verify no new drift has been introduced since the
-   inventory was taken.
+5. **products/pathway is "untouched" but Part 01's check still runs against
+   it.** Verify no new drift has been introduced since the inventory was taken.
 
-6. **`src/index.js` for guide.** Making guide's `src/index.js` a re-export
-   of `status.js` is enough for the layout contract but may not match how
-   the guide package currently exposes anything publicly. Today guide has
-   no `main` and no `exports` — it is not imported as a library by any
-   consumer, only launched as a CLI. The new `src/index.js` is essentially
-   a placeholder. Do not add real logic to it; adding logic would be out of
-   scope for this spec.
+6. **`src/index.js` for guide.** Making guide's `src/index.js` a re-export of
+   `status.js` is enough for the layout contract but may not match how the guide
+   package currently exposes anything publicly. Today guide has no `main` and no
+   `exports` — it is not imported as a library by any consumer, only launched as
+   a CLI. The new `src/index.js` is essentially a placeholder. Do not add real
+   logic to it; adding logic would be out of scope for this spec.
 
 ## Deliverable commit
 

--- a/specs/390-consistent-package-layout/plan-a-06.md
+++ b/specs/390-consistent-package-layout/plan-a-06.md
@@ -1,0 +1,583 @@
+# Plan A — Part 06: Libraries tier A (published subpath exports)
+
+Migrate the 14 libraries that publish one or more subpath exports. These
+carry the highest blast radius because a missed key in the `exports` rewrite
+breaks downstream consumers silently at import time. Part 06 is split from
+Part 07 because the per-library diff is bigger and a reviewer benefits from
+seeing these first as a standalone commit.
+
+## Libraries in tier A
+
+| Library | Root source files | Non-conforming root subdirs | Subpath keys |
+| --- | ---:| --- | ---:|
+| libdoc | builder.js, frontmatter.js, index.js, server.js | — | 4 |
+| libgraph | index.js, serializer.js | index/, processor/ | 3 |
+| libmemory | index.js, models.js | index/ | 2 |
+| libprompt | index.js, loader.js | — | 2 |
+| libresource | index.js, parser.js, sanitizer.js, skolemizer.js | processor/ | 4 |
+| libskill | 20 `.js` files | policies/ | 13 |
+| libsyntheticgen | index.js, vocabulary.js | dsl/, engine/, tools/ | 11 |
+| libsyntheticprose | index.js | engine/, prompts/ | 3 |
+| libsyntheticrender | 5 `.js` files | render/, templates/ | 8 |
+| libtelemetry | 7 `.js` files | index/ | 4 |
+| libtemplate | index.js, loader.js | — | 2 |
+| libtool | index.js, schema.js | processor/ | 2 |
+| libui | 12 `.js` files | components/, css/ | 15 |
+| libuniverse | index.js, load.js, pipeline.js | — | 3 |
+| libvector | index.js | index/, processor/ | 3 |
+
+(libharness tier-A candidate was handled in Part 04.)
+
+**Total: 15 libraries, 79 subpath keys.** Every key's right-hand target is
+rewritten from `./foo.js` → `./src/foo.js` or `./<dir>/x.js` → `./src/<dir>/x.js`.
+
+## Approach
+
+For each library, apply the cross-cutting move recipe from `plan-a.md`:
+
+1. `mkdir -p <pkg>/src`
+2. `git mv <pkg>/*.js <pkg>/src/`
+3. `git mv <pkg>/<domain-dir>/ <pkg>/src/<domain-dir>/` for each
+   non-conforming root subdir.
+4. Update `package.json` — rewrite `main`, every `exports` target, and
+   `files`.
+5. Rewrite test relative imports (`../foo.js` → `../src/foo.js`).
+6. Rewrite bin entry-point imports (`../foo.js` → `../src/foo.js`) if a
+   `bin/` directory exists.
+7. `bun run node --test <pkg>/test/*.test.js` per library.
+
+Internal relative imports _within_ the moved tree are preserved: files that
+move together keep the same relative relationships.
+
+## Per-library specifics
+
+This section is not a line-by-line rewrite — the implementer runs the
+cross-cutting recipe and consults the per-library notes below for gotchas
+and the pre-move subpath key list (so post-move verification has a
+checklist).
+
+### libdoc (4 keys)
+
+Current exports:
+```jsonc
+{
+  ".": "./index.js",
+  "./builder": "./builder.js",
+  "./server": "./server.js",
+  "./frontmatter": "./frontmatter.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./builder": "./src/builder.js",
+  "./server": "./src/server.js",
+  "./frontmatter": "./src/frontmatter.js"
+}
+```
+
+4 files to move (`builder.js`, `frontmatter.js`, `index.js`, `server.js`) +
+`bin/fit-doc.js` stays. Templates directory stays (allowed).
+
+### libgraph (3 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./index/graph.js": "./index/graph.js",
+  "./processor/graph.js": "./processor/graph.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./index/graph.js": "./src/index/graph.js",
+  "./processor/graph.js": "./src/processor/graph.js"
+}
+```
+
+The keys include the `.js` suffix — preserve exactly. 2 root `.js` files
+(`index.js`, `serializer.js`) + `index/` subdir + `processor/` subdir all
+move into `src/`. `bin/` stays.
+
+### libmemory (2 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./index/memory.js": "./index/memory.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./index/memory.js": "./src/index/memory.js"
+}
+```
+
+2 root files + `index/` subdir + `bin/fit-window.js` (stays).
+
+### libprompt (2 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./loader": "./loader.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./loader": "./src/loader.js"
+}
+```
+
+2 root files. No subdirs to move.
+
+### libresource (4 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./processor/resource.js": "./processor/resource.js",
+  "./parser.js": "./parser.js",
+  "./skolemizer.js": "./skolemizer.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./processor/resource.js": "./src/processor/resource.js",
+  "./parser.js": "./src/parser.js",
+  "./skolemizer.js": "./src/skolemizer.js"
+}
+```
+
+4 root files (`index.js`, `parser.js`, `sanitizer.js`, `skolemizer.js`) +
+`processor/` subdir. `sanitizer.js` is not currently exported but still
+moves to `src/` (rule 1: no source at the package root).
+
+### libskill (13 keys) — biggest
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./derivation": "./derivation.js",
+  "./modifiers": "./modifiers.js",
+  "./agent": "./agent.js",
+  "./interview": "./interview.js",
+  "./job": "./job.js",
+  "./job-cache": "./job-cache.js",
+  "./checklist": "./checklist.js",
+  "./matching": "./matching.js",
+  "./profile": "./profile.js",
+  "./progression": "./progression.js",
+  "./policies": "./policies/index.js",
+  "./toolkit": "./toolkit.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./derivation": "./src/derivation.js",
+  "./modifiers": "./src/modifiers.js",
+  "./agent": "./src/agent.js",
+  "./interview": "./src/interview.js",
+  "./job": "./src/job.js",
+  "./job-cache": "./src/job-cache.js",
+  "./checklist": "./src/checklist.js",
+  "./matching": "./src/matching.js",
+  "./profile": "./src/profile.js",
+  "./progression": "./src/progression.js",
+  "./policies": "./src/policies/index.js",
+  "./toolkit": "./src/toolkit.js"
+}
+```
+
+**20 root source files to move** (`agent-stage.js`, `agent-validation.js`,
+`agent.js`, `checklist.js`, `derivation-responsibilities.js`,
+`derivation-validation.js`, `derivation.js`, `index.js`,
+`interview-helpers.js`, `interview-selection.js`, `interview-specialized.js`,
+`interview.js`, `job-cache.js`, `job.js`, `matching-development.js`,
+`matching.js`, `modifiers.js`, `profile.js`, `progression.js`, `toolkit.js`).
+Plus `policies/` subdir (not in the spec's non-conforming table but exists
+and must move). `node_modules/` is gitignored and stays.
+
+libskill is a pure-function library (exempt from OO+DI per `CLAUDE.md`).
+The move preserves that — no internal style changes. Only files shift.
+
+**Consumer blast radius:** 63 subpath imports across 37 files. Not a single
+file edit is required because the specifiers are absorbed by the exports
+map. Verify with `bun run test` after the move.
+
+### libsyntheticgen (11 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./dsl": "./dsl/index.js",
+  "./engine": "./engine/tier0.js",
+  "./engine/entities": "./engine/entities.js",
+  "./engine/activity": "./engine/activity.js",
+  "./vocabulary": "./vocabulary.js",
+  "./vocabulary.js": "./vocabulary.js",
+  "./rng": "./engine/rng.js",
+  "./tools/faker": "./tools/faker.js",
+  "./tools/synthea": "./tools/synthea.js",
+  "./tools/sdv": "./tools/sdv.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./dsl": "./src/dsl/index.js",
+  "./engine": "./src/engine/tier0.js",
+  "./engine/entities": "./src/engine/entities.js",
+  "./engine/activity": "./src/engine/activity.js",
+  "./vocabulary": "./src/vocabulary.js",
+  "./vocabulary.js": "./src/vocabulary.js",
+  "./rng": "./src/engine/rng.js",
+  "./tools/faker": "./src/tools/faker.js",
+  "./tools/synthea": "./src/tools/synthea.js",
+  "./tools/sdv": "./src/tools/sdv.js"
+}
+```
+
+2 root files (`index.js`, `vocabulary.js`) + `dsl/` + `engine/` + `tools/`.
+Note: `./vocabulary` and `./vocabulary.js` are two distinct keys pointing at
+the same target today — preserve both, same pattern.
+
+### libsyntheticprose (3 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./prose": "./engine/prose.js",
+  "./pathway": "./engine/pathway.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./prose": "./src/engine/prose.js",
+  "./pathway": "./src/engine/pathway.js"
+}
+```
+
+1 root file (`index.js`) + `engine/` + `prompts/`.
+
+### libsyntheticrender (8 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./render/html": "./render/html.js",
+  "./render/pathway": "./render/pathway.js",
+  "./render/raw": "./render/raw.js",
+  "./render/markdown": "./render/markdown.js",
+  "./render/dataset-renderers": "./render/dataset-renderers.js",
+  "./validate": "./validate.js",
+  "./format": "./format.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./render/html": "./src/render/html.js",
+  "./render/pathway": "./src/render/pathway.js",
+  "./render/raw": "./src/render/raw.js",
+  "./render/markdown": "./src/render/markdown.js",
+  "./render/dataset-renderers": "./src/render/dataset-renderers.js",
+  "./validate": "./src/validate.js",
+  "./format": "./src/format.js"
+}
+```
+
+5 root files + `render/` subdir. **`templates/` stays at the root** — it is
+on the allowed list. Do not move it into `src/templates/`.
+
+### libtelemetry (4 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./tracer.js": "./tracer.js",
+  "./visualizer.js": "./visualizer.js",
+  "./index/trace.js": "./index/trace.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./tracer.js": "./src/tracer.js",
+  "./visualizer.js": "./src/visualizer.js",
+  "./index/trace.js": "./src/index/trace.js"
+}
+```
+
+7 root files + `index/` subdir. `bin/fit-visualize.js` stays.
+
+### libtemplate (2 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./loader": "./loader.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./loader": "./src/loader.js"
+}
+```
+
+2 root files, no subdirs.
+
+### libtool (2 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./processor/tool.js": "./processor/tool.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./processor/tool.js": "./src/processor/tool.js"
+}
+```
+
+2 root files + `processor/`. `bin/fit-process-tools.js` stays.
+
+### libui (15 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./render": "./render.js",
+  "./reactive": "./reactive.js",
+  "./state": "./state.js",
+  "./errors": "./errors.js",
+  "./error-boundary": "./error-boundary.js",
+  "./router-core": "./router-core.js",
+  "./router-pages": "./router-pages.js",
+  "./router-slides": "./router-slides.js",
+  "./yaml-loader": "./yaml-loader.js",
+  "./markdown": "./markdown.js",
+  "./utils": "./utils.js",
+  "./components": "./components/index.js",
+  "./components/*": "./components/*.js",
+  "./css/*": "./css/*"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./render": "./src/render.js",
+  "./reactive": "./src/reactive.js",
+  "./state": "./src/state.js",
+  "./errors": "./src/errors.js",
+  "./error-boundary": "./src/error-boundary.js",
+  "./router-core": "./src/router-core.js",
+  "./router-pages": "./src/router-pages.js",
+  "./router-slides": "./src/router-slides.js",
+  "./yaml-loader": "./src/yaml-loader.js",
+  "./markdown": "./src/markdown.js",
+  "./utils": "./src/utils.js",
+  "./components": "./src/components/index.js",
+  "./components/*": "./src/components/*.js",
+  "./css/*": "./src/css/*"
+}
+```
+
+12 root files + `components/` subdir + `css/` subdir. The `./css/*`
+wildcard pattern is important — it exposes raw `.css` files, not JS — the
+rewrite preserves the wildcard and its suffix. libui is a functional DOM
+library (exempt from OO+DI); the move preserves that.
+
+### libuniverse (3 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./pipeline": "./pipeline.js",
+  "./load": "./load.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./pipeline": "./src/pipeline.js",
+  "./load": "./src/load.js"
+}
+```
+
+3 root files. `bin/fit-universe.js` stays.
+
+### libvector (3 keys)
+
+Current:
+```jsonc
+{
+  ".": "./index.js",
+  "./index/vector.js": "./index/vector.js",
+  "./processor/vector.js": "./processor/vector.js"
+}
+```
+
+Post-move:
+```jsonc
+{
+  ".": "./src/index.js",
+  "./index/vector.js": "./src/index/vector.js",
+  "./processor/vector.js": "./src/processor/vector.js"
+}
+```
+
+1 root file + `index/` subdir + `processor/` subdir. `bin/` stays.
+
+## Ordering
+
+Sequence the per-library moves in alphabetical order for a predictable
+commit trail. After each library:
+
+1. Update `package.json` (`main`, `exports`, `files`).
+2. Move files with `git mv`.
+3. Run `bun run node --test <pkg>/test/*.test.js` at the package level.
+4. If any test fails because of a stale relative import, fix it and re-run.
+5. Do not advance to the next library until tests pass.
+
+After all 15 libraries:
+
+6. `bun run check`
+7. `bun run test` (full suite)
+8. `bun run layout` — every tier-A library should now show as conformant.
+9. Commit the whole tier-A batch.
+
+## Verification
+
+- `git ls-files 'libraries/libdoc/*.js' 'libraries/libgraph/*.js' ... 'libraries/libvector/*.js'`
+  returns nothing (no root sources across all 15 tier-A libraries).
+- Every `src/index.js` in each tier-A library exists.
+- Every subpath key in every tier-A `package.json` has a target that
+  exists on disk. Spot-check by running a small script:
+  ```js
+  for each package.json in tier-A:
+    for each ["./foo", "./src/foo.js"] in exports:
+      assert statSync("libraries/<pkg>/src/foo.js").isFile()
+  ```
+  (The actual implementation uses the same walker logic as
+  `scripts/check-package-layout.js`.)
+- `bun run test` passes, 0 regressions vs. the main-branch baseline.
+- `bun run layout` reports zero drift in `libraries/{libdoc,libgraph,…}` —
+  every tier-A library.
+- Total pre-move subpath key count matches post-move count: 79.
+
+## Risks
+
+1. **`libskill` is the largest single move — 20 root files + 1 subdir +
+   13 exports.** Pair it with an extra verification pass: after moving
+   libskill, run the pathway and libskill tests explicitly before moving on.
+   If they fail, the likely cause is a missed relative import inside a test
+   file, not an exports misconfiguration.
+
+2. **`libui/components/*` and `libui/css/*` wildcards.** Wildcard export
+   patterns are quirky — the `*` is replaced character-by-character in
+   Node's resolver. Preserve the full pattern:
+   - `./components/*` → `./src/components/*.js` (keep the `.js`)
+   - `./css/*` → `./src/css/*` (no suffix — resolves to whatever the
+     consumer imports, including `.css`)
+   Test by `grep -r '@forwardimpact/libui/components/' products/pathway/` to
+   find an existing consumer and verify its import still resolves.
+
+3. **`libsyntheticgen` has dual keys for vocabulary (`./vocabulary` and
+   `./vocabulary.js`).** Both point at the same target. Preserve both —
+   removing one breaks a consumer that depends on the `.js` form. The spec
+   does not ask for consolidation.
+
+4. **`libresource/sanitizer.js` has no export key.** Moving it into `src/`
+   is still required (rule 1). It remains unexported; no exports edit is
+   needed for sanitizer.
+
+5. **`libpolicy` is not in tier A.** Even though libskill exports
+   `./policies`, the target lives inside libskill's own `policies/`
+   subdirectory, not the `libpolicy` library. Do not confuse them.
+
+6. **Test relative imports.** Every library's `test/*.test.js` files import
+   from the package under test. Grep for `../` imports in each test file
+   and rewrite to `../src/`. This is the single most likely cause of
+   post-move test failures. A sample audit command per package:
+   ```
+   rg '^import .* from ["'\''](\.\./[^s])' libraries/<pkg>/test/
+   ```
+   (The `[^s]` excludes `../src/...` which is already correct.)
+
+7. **Per-library commit vs. tier commit.** The plan lands the tier as one
+   commit. If a single library fails mid-sequence, pause, resolve, and
+   continue rather than committing per library — the branch diff should
+   remain reviewable. If a library fails in a way that requires more than
+   a mechanical fix, commit completed libraries first and open a discussion
+   before proceeding.
+
+## Deliverable commit
+
+```
+refactor(layout): migrate 15 libraries (tier A) into src/ (part 06/08)
+
+Moves every tier-A library into a src/ subtree and rewrites every
+subpath exports target from "./foo" to "./src/foo". Subpath keys are
+preserved — consumer import specifiers are unchanged.
+
+Libraries: libdoc, libgraph, libmemory, libprompt, libresource,
+libskill, libsyntheticgen, libsyntheticprose, libsyntheticrender,
+libtelemetry, libtemplate, libtool, libui, libuniverse, libvector.
+
+libharness was handled in part 04.
+
+Part 06 of 08 for spec 390.
+```
+
+— Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a-06.md
+++ b/specs/390-consistent-package-layout/plan-a-06.md
@@ -1,35 +1,36 @@
 # Plan A — Part 06: Libraries tier A (published subpath exports)
 
-Migrate the 14 libraries that publish one or more subpath exports. These
-carry the highest blast radius because a missed key in the `exports` rewrite
-breaks downstream consumers silently at import time. Part 06 is split from
-Part 07 because the per-library diff is bigger and a reviewer benefits from
-seeing these first as a standalone commit.
+Migrate the 14 libraries that publish one or more subpath exports. These carry
+the highest blast radius because a missed key in the `exports` rewrite breaks
+downstream consumers silently at import time. Part 06 is split from Part 07
+because the per-library diff is bigger and a reviewer benefits from seeing these
+first as a standalone commit.
 
 ## Libraries in tier A
 
-| Library | Root source files | Non-conforming root subdirs | Subpath keys |
-| --- | ---:| --- | ---:|
-| libdoc | builder.js, frontmatter.js, index.js, server.js | — | 4 |
-| libgraph | index.js, serializer.js | index/, processor/ | 3 |
-| libmemory | index.js, models.js | index/ | 2 |
-| libprompt | index.js, loader.js | — | 2 |
-| libresource | index.js, parser.js, sanitizer.js, skolemizer.js | processor/ | 4 |
-| libskill | 20 `.js` files | policies/ | 13 |
-| libsyntheticgen | index.js, vocabulary.js | dsl/, engine/, tools/ | 11 |
-| libsyntheticprose | index.js | engine/, prompts/ | 3 |
-| libsyntheticrender | 5 `.js` files | render/, templates/ | 8 |
-| libtelemetry | 7 `.js` files | index/ | 4 |
-| libtemplate | index.js, loader.js | — | 2 |
-| libtool | index.js, schema.js | processor/ | 2 |
-| libui | 12 `.js` files | components/, css/ | 15 |
-| libuniverse | index.js, load.js, pipeline.js | — | 3 |
-| libvector | index.js | index/, processor/ | 3 |
+| Library            |                                Root source files | Non-conforming root subdirs | Subpath keys |
+| ------------------ | -----------------------------------------------: | --------------------------- | -----------: |
+| libdoc             |  builder.js, frontmatter.js, index.js, server.js | —                           |            4 |
+| libgraph           |                          index.js, serializer.js | index/, processor/          |            3 |
+| libmemory          |                              index.js, models.js | index/                      |            2 |
+| libprompt          |                              index.js, loader.js | —                           |            2 |
+| libresource        | index.js, parser.js, sanitizer.js, skolemizer.js | processor/                  |            4 |
+| libskill           |                                   20 `.js` files | policies/                   |           13 |
+| libsyntheticgen    |                          index.js, vocabulary.js | dsl/, engine/, tools/       |           11 |
+| libsyntheticprose  |                                         index.js | engine/, prompts/           |            3 |
+| libsyntheticrender |                                    5 `.js` files | render/, templates/         |            8 |
+| libtelemetry       |                                    7 `.js` files | index/                      |            4 |
+| libtemplate        |                              index.js, loader.js | —                           |            2 |
+| libtool            |                              index.js, schema.js | processor/                  |            2 |
+| libui              |                                   12 `.js` files | components/, css/           |           15 |
+| libuniverse        |                   index.js, load.js, pipeline.js | —                           |            3 |
+| libvector          |                                         index.js | index/, processor/          |            3 |
 
 (libharness tier-A candidate was handled in Part 04.)
 
 **Total: 15 libraries, 79 subpath keys.** Every key's right-hand target is
-rewritten from `./foo.js` → `./src/foo.js` or `./<dir>/x.js` → `./src/<dir>/x.js`.
+rewritten from `./foo.js` → `./src/foo.js` or `./<dir>/x.js` →
+`./src/<dir>/x.js`.
 
 ## Approach
 
@@ -37,28 +38,27 @@ For each library, apply the cross-cutting move recipe from `plan-a.md`:
 
 1. `mkdir -p <pkg>/src`
 2. `git mv <pkg>/*.js <pkg>/src/`
-3. `git mv <pkg>/<domain-dir>/ <pkg>/src/<domain-dir>/` for each
-   non-conforming root subdir.
-4. Update `package.json` — rewrite `main`, every `exports` target, and
-   `files`.
+3. `git mv <pkg>/<domain-dir>/ <pkg>/src/<domain-dir>/` for each non-conforming
+   root subdir.
+4. Update `package.json` — rewrite `main`, every `exports` target, and `files`.
 5. Rewrite test relative imports (`../foo.js` → `../src/foo.js`).
-6. Rewrite bin entry-point imports (`../foo.js` → `../src/foo.js`) if a
-   `bin/` directory exists.
+6. Rewrite bin entry-point imports (`../foo.js` → `../src/foo.js`) if a `bin/`
+   directory exists.
 7. `bun run node --test <pkg>/test/*.test.js` per library.
 
-Internal relative imports _within_ the moved tree are preserved: files that
-move together keep the same relative relationships.
+Internal relative imports _within_ the moved tree are preserved: files that move
+together keep the same relative relationships.
 
 ## Per-library specifics
 
 This section is not a line-by-line rewrite — the implementer runs the
-cross-cutting recipe and consults the per-library notes below for gotchas
-and the pre-move subpath key list (so post-move verification has a
-checklist).
+cross-cutting recipe and consults the per-library notes below for gotchas and
+the pre-move subpath key list (so post-move verification has a checklist).
 
 ### libdoc (4 keys)
 
 Current exports:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -69,6 +69,7 @@ Current exports:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -84,6 +85,7 @@ Post-move:
 ### libgraph (3 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -93,6 +95,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -102,12 +105,13 @@ Post-move:
 ```
 
 The keys include the `.js` suffix — preserve exactly. 2 root `.js` files
-(`index.js`, `serializer.js`) + `index/` subdir + `processor/` subdir all
-move into `src/`. `bin/` stays.
+(`index.js`, `serializer.js`) + `index/` subdir + `processor/` subdir all move
+into `src/`. `bin/` stays.
 
 ### libmemory (2 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -116,6 +120,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -128,6 +133,7 @@ Post-move:
 ### libprompt (2 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -136,6 +142,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -148,6 +155,7 @@ Post-move:
 ### libresource (4 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -158,6 +166,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -168,12 +177,13 @@ Post-move:
 ```
 
 4 root files (`index.js`, `parser.js`, `sanitizer.js`, `skolemizer.js`) +
-`processor/` subdir. `sanitizer.js` is not currently exported but still
-moves to `src/` (rule 1: no source at the package root).
+`processor/` subdir. `sanitizer.js` is not currently exported but still moves to
+`src/` (rule 1: no source at the package root).
 
 ### libskill (13 keys) — biggest
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -193,6 +203,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -213,23 +224,24 @@ Post-move:
 
 **20 root source files to move** (`agent-stage.js`, `agent-validation.js`,
 `agent.js`, `checklist.js`, `derivation-responsibilities.js`,
-`derivation-validation.js`, `derivation.js`, `index.js`,
-`interview-helpers.js`, `interview-selection.js`, `interview-specialized.js`,
-`interview.js`, `job-cache.js`, `job.js`, `matching-development.js`,
-`matching.js`, `modifiers.js`, `profile.js`, `progression.js`, `toolkit.js`).
-Plus `policies/` subdir (not in the spec's non-conforming table but exists
-and must move). `node_modules/` is gitignored and stays.
+`derivation-validation.js`, `derivation.js`, `index.js`, `interview-helpers.js`,
+`interview-selection.js`, `interview-specialized.js`, `interview.js`,
+`job-cache.js`, `job.js`, `matching-development.js`, `matching.js`,
+`modifiers.js`, `profile.js`, `progression.js`, `toolkit.js`). Plus `policies/`
+subdir (not in the spec's non-conforming table but exists and must move).
+`node_modules/` is gitignored and stays.
 
-libskill is a pure-function library (exempt from OO+DI per `CLAUDE.md`).
-The move preserves that — no internal style changes. Only files shift.
+libskill is a pure-function library (exempt from OO+DI per `CLAUDE.md`). The
+move preserves that — no internal style changes. Only files shift.
 
-**Consumer blast radius:** 63 subpath imports across 37 files. Not a single
-file edit is required because the specifiers are absorbed by the exports
-map. Verify with `bun run test` after the move.
+**Consumer blast radius:** 63 subpath imports across 37 files. Not a single file
+edit is required because the specifiers are absorbed by the exports map. Verify
+with `bun run test` after the move.
 
 ### libsyntheticgen (11 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -247,6 +259,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -264,12 +277,13 @@ Post-move:
 ```
 
 2 root files (`index.js`, `vocabulary.js`) + `dsl/` + `engine/` + `tools/`.
-Note: `./vocabulary` and `./vocabulary.js` are two distinct keys pointing at
-the same target today — preserve both, same pattern.
+Note: `./vocabulary` and `./vocabulary.js` are two distinct keys pointing at the
+same target today — preserve both, same pattern.
 
 ### libsyntheticprose (3 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -279,6 +293,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -292,6 +307,7 @@ Post-move:
 ### libsyntheticrender (8 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -306,6 +322,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -319,12 +336,13 @@ Post-move:
 }
 ```
 
-5 root files + `render/` subdir. **`templates/` stays at the root** — it is
-on the allowed list. Do not move it into `src/templates/`.
+5 root files + `render/` subdir. **`templates/` stays at the root** — it is on
+the allowed list. Do not move it into `src/templates/`.
 
 ### libtelemetry (4 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -335,6 +353,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -349,6 +368,7 @@ Post-move:
 ### libtemplate (2 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -357,6 +377,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -369,6 +390,7 @@ Post-move:
 ### libtool (2 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -377,6 +399,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -389,6 +412,7 @@ Post-move:
 ### libui (15 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -410,6 +434,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -430,14 +455,15 @@ Post-move:
 }
 ```
 
-12 root files + `components/` subdir + `css/` subdir. The `./css/*`
-wildcard pattern is important — it exposes raw `.css` files, not JS — the
-rewrite preserves the wildcard and its suffix. libui is a functional DOM
-library (exempt from OO+DI); the move preserves that.
+12 root files + `components/` subdir + `css/` subdir. The `./css/*` wildcard
+pattern is important — it exposes raw `.css` files, not JS — the rewrite
+preserves the wildcard and its suffix. libui is a functional DOM library (exempt
+from OO+DI); the move preserves that.
 
 ### libuniverse (3 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -447,6 +473,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -460,6 +487,7 @@ Post-move:
 ### libvector (3 keys)
 
 Current:
+
 ```jsonc
 {
   ".": "./index.js",
@@ -469,6 +497,7 @@ Current:
 ```
 
 Post-move:
+
 ```jsonc
 {
   ".": "./src/index.js",
@@ -481,8 +510,8 @@ Post-move:
 
 ## Ordering
 
-Sequence the per-library moves in alphabetical order for a predictable
-commit trail. After each library:
+Sequence the per-library moves in alphabetical order for a predictable commit
+trail. After each library:
 
 1. Update `package.json` (`main`, `exports`, `files`).
 2. Move files with `git mv`.
@@ -502,8 +531,8 @@ After all 15 libraries:
 - `git ls-files 'libraries/libdoc/*.js' 'libraries/libgraph/*.js' ... 'libraries/libvector/*.js'`
   returns nothing (no root sources across all 15 tier-A libraries).
 - Every `src/index.js` in each tier-A library exists.
-- Every subpath key in every tier-A `package.json` has a target that
-  exists on disk. Spot-check by running a small script:
+- Every subpath key in every tier-A `package.json` has a target that exists on
+  disk. Spot-check by running a small script:
   ```js
   for each package.json in tier-A:
     for each ["./foo", "./src/foo.js"] in exports:
@@ -512,55 +541,57 @@ After all 15 libraries:
   (The actual implementation uses the same walker logic as
   `scripts/check-package-layout.js`.)
 - `bun run test` passes, 0 regressions vs. the main-branch baseline.
-- `bun run layout` reports zero drift in `libraries/{libdoc,libgraph,…}` —
-  every tier-A library.
+- `bun run layout` reports zero drift in `libraries/{libdoc,libgraph,…}` — every
+  tier-A library.
 - Total pre-move subpath key count matches post-move count: 79.
 
 ## Risks
 
-1. **`libskill` is the largest single move — 20 root files + 1 subdir +
-   13 exports.** Pair it with an extra verification pass: after moving
-   libskill, run the pathway and libskill tests explicitly before moving on.
-   If they fail, the likely cause is a missed relative import inside a test
-   file, not an exports misconfiguration.
+1. **`libskill` is the largest single move — 20 root files + 1 subdir + 13
+   exports.** Pair it with an extra verification pass: after moving libskill,
+   run the pathway and libskill tests explicitly before moving on. If they fail,
+   the likely cause is a missed relative import inside a test file, not an
+   exports misconfiguration.
 
 2. **`libui/components/*` and `libui/css/*` wildcards.** Wildcard export
-   patterns are quirky — the `*` is replaced character-by-character in
-   Node's resolver. Preserve the full pattern:
+   patterns are quirky — the `*` is replaced character-by-character in Node's
+   resolver. Preserve the full pattern:
    - `./components/*` → `./src/components/*.js` (keep the `.js`)
-   - `./css/*` → `./src/css/*` (no suffix — resolves to whatever the
-     consumer imports, including `.css`)
-   Test by `grep -r '@forwardimpact/libui/components/' products/pathway/` to
-   find an existing consumer and verify its import still resolves.
+   - `./css/*` → `./src/css/*` (no suffix — resolves to whatever the consumer
+     imports, including `.css`) Test by
+     `grep -r '@forwardimpact/libui/components/' products/pathway/` to find an
+     existing consumer and verify its import still resolves.
 
 3. **`libsyntheticgen` has dual keys for vocabulary (`./vocabulary` and
-   `./vocabulary.js`).** Both point at the same target. Preserve both —
-   removing one breaks a consumer that depends on the `.js` form. The spec
-   does not ask for consolidation.
+   `./vocabulary.js`).** Both point at the same target. Preserve both — removing
+   one breaks a consumer that depends on the `.js` form. The spec does not ask
+   for consolidation.
 
-4. **`libresource/sanitizer.js` has no export key.** Moving it into `src/`
-   is still required (rule 1). It remains unexported; no exports edit is
-   needed for sanitizer.
+4. **`libresource/sanitizer.js` has no export key.** Moving it into `src/` is
+   still required (rule 1). It remains unexported; no exports edit is needed for
+   sanitizer.
 
-5. **`libpolicy` is not in tier A.** Even though libskill exports
-   `./policies`, the target lives inside libskill's own `policies/`
-   subdirectory, not the `libpolicy` library. Do not confuse them.
+5. **`libpolicy` is not in tier A.** Even though libskill exports `./policies`,
+   the target lives inside libskill's own `policies/` subdirectory, not the
+   `libpolicy` library. Do not confuse them.
 
-6. **Test relative imports.** Every library's `test/*.test.js` files import
-   from the package under test. Grep for `../` imports in each test file
-   and rewrite to `../src/`. This is the single most likely cause of
-   post-move test failures. A sample audit command per package:
+6. **Test relative imports.** Every library's `test/*.test.js` files import from
+   the package under test. Grep for `../` imports in each test file and rewrite
+   to `../src/`. This is the single most likely cause of post-move test
+   failures. A sample audit command per package:
+
    ```
    rg '^import .* from ["'\''](\.\./[^s])' libraries/<pkg>/test/
    ```
+
    (The `[^s]` excludes `../src/...` which is already correct.)
 
 7. **Per-library commit vs. tier commit.** The plan lands the tier as one
-   commit. If a single library fails mid-sequence, pause, resolve, and
-   continue rather than committing per library — the branch diff should
-   remain reviewable. If a library fails in a way that requires more than
-   a mechanical fix, commit completed libraries first and open a discussion
-   before proceeding.
+   commit. If a single library fails mid-sequence, pause, resolve, and continue
+   rather than committing per library — the branch diff should remain
+   reviewable. If a library fails in a way that requires more than a mechanical
+   fix, commit completed libraries first and open a discussion before
+   proceeding.
 
 ## Deliverable commit
 

--- a/specs/390-consistent-package-layout/plan-a-07.md
+++ b/specs/390-consistent-package-layout/plan-a-07.md
@@ -34,58 +34,97 @@ package root is properly walled off.
 
 ## Approach
 
-Apply the cross-cutting move recipe for each library. Because there are no
-subpath exports, the `package.json` edit is minimal:
+Apply the cross-cutting move recipe for each library. **The exact
+`package.json` shape depends on whether the library publishes a `bin/`
+directory** — see the two cases below.
+
+### Case A: tier-B library with no `bin/`
+
+Libraries: libcli, libconfig, libformat, libindex, libpolicy, librepl,
+libsecret, libweb.
+
+```jsonc
+{
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "files": ["src/**/*.js", "README.md"]
+}
+```
+
+### Case B: tier-B library with `bin/`
+
+Libraries: libagent, libcodegen, libeval, libllm, librc, libstorage,
+libsupervise, libutil.
+
+The library's `bin/<entry>.js` files must remain resolvable via
+`require.resolve("@forwardimpact/libfoo/bin/<entry>.js")`. An explicit
+`exports` field that only maps `"."` locks down every other subpath and
+breaks those resolvers. Therefore every tier-B library with a `bin/`
+directory gets every bin entry mirrored into the exports map as a
+subpath key:
 
 ```jsonc
 {
   "main": "./src/index.js",
   "bin": { /* unchanged */ },
   "exports": {
-    ".": "./src/index.js"
+    ".": "./src/index.js",
+    "./bin/<entry-1>.js": "./bin/<entry-1>.js",
+    "./bin/<entry-2>.js": "./bin/<entry-2>.js"
   },
   "files": ["src/**/*.js", "bin/**/*.js", "README.md"]
 }
 ```
 
-**Key decision — add an `exports` field even where none exists today.** A
-bare `main` field without an `exports` field means Node resolves any
-subpath freely by falling back to on-disk file lookup, which means
-consumers could bypass the contract. The spec's rules (especially rule 1:
-"no source at the root") are weakened if subpath bypass is allowed.
-Therefore every tier-B library gets an explicit `exports` field that maps
-only `"."`. Subsequent subpath access throws, catching any accidental deep
-import at runtime.
+**Confirmed call site:** `libraries/librc/manager.js` line 12 runs
+`require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")`. A
+monorepo-wide grep (`rg '@forwardimpact/\w+/bin/' --type js`) confirms
+this is the **only** cross-package reference into a `bin/` directory
+today. libsupervise therefore MUST keep
+`"./bin/fit-svscan.js": "./bin/fit-svscan.js"` in its exports map and —
+as a symmetry choice — also maps `./bin/fit-logger.js`.
 
-**Exception:** if an existing consumer already depends on a tier-B
-library's deep import, the import must be rewritten to either use the
-library's default export (if the needed symbol is exported from
-`index.js`) or a new subpath key must be added. Part 07 runs a discovery
-grep before the rewrite to find such consumers.
+Every other tier-B library with a `bin/` gets the bin subpath keys
+added anyway. This is zero-cost (no extra files) and future-proofs
+against new `require.resolve` calls landing from librc-style service
+managers.
 
 ## Pre-move discovery
 
-Before any tier-B library is migrated, run:
+Before any tier-B library is migrated, run two separate greps:
+
+**1. Static imports into tier-B libraries by subpath:**
 
 ```
-rg '@forwardimpact/(libagent|libcli|libcodegen|libconfig|libeval|libformat|libindex|libllm|libpolicy|librc|librepl|libsecret|libstorage|libsupervise|libutil|libweb)/[^"'\'']+' --type js
+rg '@forwardimpact/(libagent|libcli|libcodegen|libconfig|libeval|libformat|libindex|libllm|libpolicy|librc|librepl|libsecret|libstorage|libsupervise|libutil|libweb)/[^"'\''`]+' --type js -g '!libraries/*/src/**' -g '!libraries/*/test/**'
 ```
 
-Report every hit. Each hit is a call site that reaches into the library by
-subpath without being listed in the current exports map. For each hit,
-decide:
+The `-g` excludes are important: a library's own internal relative
+imports don't count as cross-package subpath access. Report every hit.
 
-- **Re-export from index.js.** Preferred — add the needed symbol to the
+**2. `require.resolve` calls into any `@forwardimpact/*` package:**
+
+```
+rg 'require\.resolve\(["'\''`]@forwardimpact' --type js
+```
+
+These are trickier because they bypass static analysis. The known hit
+is `librc/manager.js:12` into libsupervise's bin — documented above.
+Any new hit needs the same treatment: add a subpath export key.
+
+For each hit from either grep, decide:
+
+- **Re-export from index.js** (preferred). Add the needed symbol to the
   library's `src/index.js`. Consumer's import specifier changes from
   `@forwardimpact/libfoo/bar` → `@forwardimpact/libfoo`.
-- **Add a new subpath export.** Only if the symbol is large enough to
-  warrant a separate entry point. Add `"./bar": "./src/bar.js"` to the
-  library's exports and leave the consumer alone.
+- **Add a new subpath export**. Only if the symbol is large enough to
+  warrant a separate entry point.
 
 Document every decision inline in the commit message. The research phase
-already flagged four cross-package references (all in comments or
-`require.resolve` calls using package names, not subpaths) so this sweep
-is expected to be quiet.
+confirmed this sweep is expected to be quiet (only the librc/libsupervise
+`require.resolve` hit is known).
 
 ## Per-library specifics
 
@@ -102,11 +141,14 @@ factory — make sure `src/cli.js` still re-exports correctly after moving.
 ### libcodegen
 
 5 root files + `templates/` (allowed, stays) + `bin/fit-codegen.js`
-(stays). Note: libcodegen itself was modified in Part 02; verify that
-Part 02's changes to `fit-codegen.js` still work after the root sources
-move to `src/`. The edits in Part 02 modified `bin/fit-codegen.js` which
-stays at `bin/`, so its imports of `../base.js`, `../services.js`, etc.
-need to be updated to `../src/base.js`, `../src/services.js`, etc.
+(stays). **libcodegen has no `test/` directory** — skip the per-library
+test step for libcodegen; the full-suite `bun run test` at repo root
+exercises it indirectly. Note: libcodegen itself was NOT modified in
+Part 02 — Part 02 only edited `libutil/finder.js`. libcodegen's
+`fit-codegen.js` CLI entry point stays at `bin/fit-codegen.js` and its
+imports of `../base.js`, `../services.js`, etc. need to be rewritten to
+`../src/base.js`, `../src/services.js`, etc. when the root sources
+move.
 
 ### libconfig
 
@@ -138,10 +180,14 @@ complete the migration.
 
 ### librc
 
-2 root files + `bin/fit-rc.js`. **Careful:** `librc/manager.js` currently
-includes `require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")`
-— this resolves through the libsupervise package and is unaffected by the
-move (bin/ stays at the libsupervise root).
+2 root files + `bin/fit-rc.js`. **Careful:** `librc/manager.js` line 12
+runs `require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")`.
+After Part 07 adds an explicit `exports` field to libsupervise, this
+resolve would break unless libsupervise's exports map includes
+`"./bin/fit-svscan.js"`. Part 07's "Case B" template handles this — see
+§ libsupervise below. librc itself needs no special handling beyond
+the standard case B (its own `bin/fit-rc.js` gets mirrored into its
+own exports map).
 
 ### librepl
 
@@ -162,15 +208,39 @@ preserved.
 
 ### libsupervise
 
-6 root files + `bin/{fit-logger.js,fit-svscan.js}`. `require.resolve`
-from librc (above) keeps working because `bin/` stays at the root.
+6 root files + `bin/{fit-logger.js,fit-svscan.js}`. **Case B library
+with a known cross-package `require.resolve` consumer.** The
+`package.json` exports map MUST include both bin subpaths:
+
+```jsonc
+{
+  "main": "./src/index.js",
+  "bin": {
+    "fit-logger": "./bin/fit-logger.js",
+    "fit-svscan": "./bin/fit-svscan.js"
+  },
+  "exports": {
+    ".": "./src/index.js",
+    "./bin/fit-logger.js": "./bin/fit-logger.js",
+    "./bin/fit-svscan.js": "./bin/fit-svscan.js"
+  },
+  "files": ["src/**/*.js", "bin/**/*.js", "README.md"]
+}
+```
+
+Without the `./bin/fit-svscan.js` subpath key, `require.resolve` from
+`librc/manager.js:12` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. This is a
+**runtime breakage**, not a build-time one — the fit-rc CLI would fail
+the first time it tries to start a supervised service. Add both bin
+subpaths regardless of current consumer count.
 
 ### libutil
 
 9 root files + `bin/{fit-download-bundle.js,fit-tiktoken.js}`. **Part 02
-already edited `libutil/finder.js`** to change `createPackageSymlinks()`.
+already edited `libutil/finder.js`#findGeneratedPath** (line 117).
 After Part 07 moves `finder.js` into `src/finder.js`, the edit travels
-with it. The `bin/` entries stay.
+with the file via `git mv` and no re-edit is needed. The `bin/` entries
+stay and get mirrored into the exports map per case B.
 
 ### libweb
 
@@ -209,14 +279,19 @@ with it. The `bin/` entries stay.
 
 ## Risks
 
-1. **Adding an explicit `exports` field can break deep imports that used
-   to work.** The pre-move discovery grep catches these. If a consumer is
-   found that depends on a deep import, either:
-   - Add a new subpath key to the library's exports (preferred when the
-     internal file is a coherent module boundary), or
-   - Rewrite the consumer to import the symbol from the library's default
-     export (preferred when the deep path was incidental).
-   Do not leave the deep import broken.
+1. **Adding an explicit `exports` field can break deep imports and
+   `require.resolve` calls that used to work.** Today libsupervise
+   (and every other tier-B library) has no `exports` field, so Node
+   resolves any subpath freely. Adding
+   `{ ".": "./src/index.js" }` without the bin entries locks subpath
+   access and breaks `librc/manager.js:12`'s
+   `require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")`
+   with `ERR_PACKAGE_PATH_NOT_EXPORTED` — at runtime, not build time.
+   This is a **load-bearing fit-rc path**: without it, services cannot
+   start. Mitigation: every tier-B library with a `bin/` directory
+   follows Case B (bin subpaths mirrored into the exports map) — see
+   § Approach. Running the pre-move discovery grep is the second line
+   of defence.
 
 2. **`libcli` is used by 22 CLIs across the monorepo** (per the staff
    engineer's Apr 10 log). All use the default export. No subpath deep

--- a/specs/390-consistent-package-layout/plan-a-07.md
+++ b/specs/390-consistent-package-layout/plan-a-07.md
@@ -1,0 +1,274 @@
+# Plan A — Part 07: Libraries tier B (no subpath exports)
+
+Migrate the remaining 18 libraries — those that publish only a default
+export (or no explicit `exports` field) and therefore have no subpath
+targets to rewrite. Lower blast radius than tier A.
+
+## Libraries in tier B
+
+| Library | Root source files | Non-conforming root subdirs | Exports |
+| --- | ---:| --- | ---:|
+| libagent | hands.js, index.js, mind.js | processor/ | — |
+| libcli | cli.js, color.js, format.js, help.js, index.js, summary.js | — | — |
+| libcodegen | base.js, definitions.js, index.js, services.js, types.js | — | — |
+| libconfig | config.js, index.js | — | — |
+| libeval | index.js (plus existing src/) | — | — |
+| libformat | index.js | — | — |
+| libindex | base.js, buffered.js, index.js | — | — |
+| libllm | hallucination.js, index.js, models.js | — | — |
+| libpolicy | index.js | — | — |
+| librc | index.js, manager.js | — | — |
+| librepl | index.js | — | — |
+| libsecret | index.js | — | — |
+| libstorage | index.js, local.js, s3.js, supabase.js | — | — |
+| libsupervise | index.js, logger.js, longrun.js, oneshot.js, state.js, tree.js | — | — |
+| libutil | downloader.js, extractor.js, finder.js, http.js, index.js, processor.js, retry.js, tokenizer.js, wait.js | — | — |
+| libweb | auth.js, cors.js, index.js, validation.js | — | — |
+
+(librpc and libtype handled in Part 02. libharness handled in Part 04.)
+
+**Total: 16 libraries** (after excluding librpc, libtype, libharness which
+are in earlier parts). Each gets a minimal `exports` field added when one
+does not already exist — at a minimum `{ ".": "./src/index.js" }` — so the
+package root is properly walled off.
+
+## Approach
+
+Apply the cross-cutting move recipe for each library. Because there are no
+subpath exports, the `package.json` edit is minimal:
+
+```jsonc
+{
+  "main": "./src/index.js",
+  "bin": { /* unchanged */ },
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "files": ["src/**/*.js", "bin/**/*.js", "README.md"]
+}
+```
+
+**Key decision — add an `exports` field even where none exists today.** A
+bare `main` field without an `exports` field means Node resolves any
+subpath freely by falling back to on-disk file lookup, which means
+consumers could bypass the contract. The spec's rules (especially rule 1:
+"no source at the root") are weakened if subpath bypass is allowed.
+Therefore every tier-B library gets an explicit `exports` field that maps
+only `"."`. Subsequent subpath access throws, catching any accidental deep
+import at runtime.
+
+**Exception:** if an existing consumer already depends on a tier-B
+library's deep import, the import must be rewritten to either use the
+library's default export (if the needed symbol is exported from
+`index.js`) or a new subpath key must be added. Part 07 runs a discovery
+grep before the rewrite to find such consumers.
+
+## Pre-move discovery
+
+Before any tier-B library is migrated, run:
+
+```
+rg '@forwardimpact/(libagent|libcli|libcodegen|libconfig|libeval|libformat|libindex|libllm|libpolicy|librc|librepl|libsecret|libstorage|libsupervise|libutil|libweb)/[^"'\'']+' --type js
+```
+
+Report every hit. Each hit is a call site that reaches into the library by
+subpath without being listed in the current exports map. For each hit,
+decide:
+
+- **Re-export from index.js.** Preferred — add the needed symbol to the
+  library's `src/index.js`. Consumer's import specifier changes from
+  `@forwardimpact/libfoo/bar` → `@forwardimpact/libfoo`.
+- **Add a new subpath export.** Only if the symbol is large enough to
+  warrant a separate entry point. Add `"./bar": "./src/bar.js"` to the
+  library's exports and leave the consumer alone.
+
+Document every decision inline in the commit message. The research phase
+already flagged four cross-package references (all in comments or
+`require.resolve` calls using package names, not subpaths) so this sweep
+is expected to be quiet.
+
+## Per-library specifics
+
+### libagent
+
+3 root files + `processor/` subdir + `bin/fit-process-agents.js`.
+`processor/` moves to `src/processor/`.
+
+### libcli
+
+6 root files, no subdirs. The file `cli.js` is the core `createCli()`
+factory — make sure `src/cli.js` still re-exports correctly after moving.
+
+### libcodegen
+
+5 root files + `templates/` (allowed, stays) + `bin/fit-codegen.js`
+(stays). Note: libcodegen itself was modified in Part 02; verify that
+Part 02's changes to `fit-codegen.js` still work after the root sources
+move to `src/`. The edits in Part 02 modified `bin/fit-codegen.js` which
+stays at `bin/`, so its imports of `../base.js`, `../services.js`, etc.
+need to be updated to `../src/base.js`, `../src/services.js`, etc.
+
+### libconfig
+
+2 root files, no subdirs. Unremarkable.
+
+### libeval
+
+**Already half-migrated.** Existing `src/commands/` tree stays. Root
+`index.js` moves to `src/index.js`. The existing `src/` structure
+(`src/commands/run.js`, `src/commands/supervise.js`, etc.) is unchanged.
+`bin/fit-eval.js` already imports from `../src/...` in places; audit and
+complete the migration.
+
+### libformat
+
+1 root file. Unremarkable.
+
+### libindex
+
+3 root files, no subdirs. Unremarkable.
+
+### libllm
+
+3 root files + `bin/fit-completion.js`. Unremarkable.
+
+### libpolicy
+
+1 root file. Unremarkable.
+
+### librc
+
+2 root files + `bin/fit-rc.js`. **Careful:** `librc/manager.js` currently
+includes `require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")`
+— this resolves through the libsupervise package and is unaffected by the
+move (bin/ stays at the libsupervise root).
+
+### librepl
+
+1 root file. Unremarkable.
+
+### libsecret
+
+1 root file. Stateless crypto (exempt from OO+DI); internal style
+preserved.
+
+### libstorage
+
+4 root files + `bin/fit-storage.js`. libstorage is not touched by Part 02
+— the `"generated"` bucket mapping in `libstorage/index.js` stays as is
+(monorepo-root `generated/` is the load-bearing target for
+`Finder.findUpward`). Part 07 only moves `index.js`, `local.js`, `s3.js`,
+`supabase.js` into `src/` and updates `package.json`.
+
+### libsupervise
+
+6 root files + `bin/{fit-logger.js,fit-svscan.js}`. `require.resolve`
+from librc (above) keeps working because `bin/` stays at the root.
+
+### libutil
+
+9 root files + `bin/{fit-download-bundle.js,fit-tiktoken.js}`. **Part 02
+already edited `libutil/finder.js`** to change `createPackageSymlinks()`.
+After Part 07 moves `finder.js` into `src/finder.js`, the edit travels
+with it. The `bin/` entries stay.
+
+### libweb
+
+4 root files, no subdirs. Unremarkable.
+
+## Ordering
+
+1. Run the pre-move discovery grep. Resolve every surprise consumer
+   before touching any file.
+2. Alphabetically, for each tier-B library:
+   a. Move root sources into `src/`.
+   b. Move any allowed non-conforming subdirs into `src/<name>/` (none in
+      tier B except libagent's `processor/`).
+   c. Add or update `main`, `exports`, `files` in `package.json`.
+   d. Rewrite `bin/fit-<name>.js` imports (`../foo.js` → `../src/foo.js`).
+   e. Rewrite `test/*.test.js` imports.
+   f. Run `bun run node --test <pkg>/test/*.test.js`.
+3. After all 16 libraries:
+4. `bun run check`
+5. `bun run test`
+6. `bun run layout` — every library should be conformant (only the Part 08
+   strict-mode enable remains).
+7. Commit.
+
+## Verification
+
+- `git ls-files 'libraries/libagent/*.js' 'libraries/libcli/*.js' ... 'libraries/libweb/*.js'`
+  returns nothing (no root sources across any tier-B library).
+- Every tier-B library has `src/index.js`.
+- Every tier-B library has an `exports` field with at least `"."` mapped
+  to `./src/index.js`.
+- `bun run layout` shows zero drift across `libraries/*`.
+- `bun run test` passes.
+- Success criterion #1 is mechanically satisfied:
+  `git ls-files 'libraries/*/*.js' 'libraries/*/*.ts'` returns nothing.
+
+## Risks
+
+1. **Adding an explicit `exports` field can break deep imports that used
+   to work.** The pre-move discovery grep catches these. If a consumer is
+   found that depends on a deep import, either:
+   - Add a new subpath key to the library's exports (preferred when the
+     internal file is a coherent module boundary), or
+   - Rewrite the consumer to import the symbol from the library's default
+     export (preferred when the deep path was incidental).
+   Do not leave the deep import broken.
+
+2. **`libcli` is used by 22 CLIs across the monorepo** (per the staff
+   engineer's Apr 10 log). All use the default export. No subpath deep
+   imports are known. Still, run the discovery grep for libcli
+   specifically as a sanity check.
+
+3. **`libeval` is half-migrated** — existing `src/commands/` tree means
+   some tests may already use `../src/` imports while others use `../`.
+   Audit both patterns. Finishing libeval means bringing all root source
+   files into the existing `src/` tree.
+
+4. **`libcodegen` has the `fit-codegen` CLI** — the staff engineer's Apr
+   10 log shows libcli migration already touched `fit-codegen.js`, which
+   calls into the package's own root-level `services.js` and `types.js`.
+   After Part 07 moves those into `src/`, the bin file imports need
+   rewriting. Read `bin/fit-codegen.js` carefully before the move — it has
+   several imports from the package root.
+
+5. **`libstorage` and `libutil` were edited in Part 02.** The Part 02
+   edits are on files at the package root (`libstorage/index.js` and
+   `libutil/finder.js`). When Part 07 moves those files into `src/`, the
+   Part 02 edits come with them. No re-edit is needed, but verify the
+   resulting `src/index.js` and `src/finder.js` still have the Part 02
+   changes. Diff against the main branch baseline if in doubt.
+
+6. **Transitive missing dependencies.** The staff engineer's Apr 10 log
+   notes: "libvector (fit-search imports libconfig, libllm, libstorage
+   which are not in libvector's package.json) and libmemory (fit-window
+   imports libconfig, librpc)". These are pre-existing issues, not
+   introduced by this spec, and remain pre-existing after the migration.
+   Do not fix them as part of Part 07 — that is scope creep. Note them in
+   the commit message as "preserved pre-existing transitive issues".
+
+## Deliverable commit
+
+```
+refactor(layout): migrate 16 libraries (tier B) into src/ (part 07/08)
+
+Moves every tier-B library (no published subpath exports) into a src/
+subtree. Adds an explicit { ".": "./src/index.js" } exports field to
+every library that lacked one, closing the deep-import bypass.
+
+Libraries: libagent, libcli, libcodegen, libconfig, libeval, libformat,
+libindex, libllm, libpolicy, librc, librepl, libsecret, libstorage,
+libsupervise, libutil, libweb.
+
+librpc, libtype handled in part 02; libharness in part 04.
+
+Pre-existing transitive dep issues in libvector (fit-search) and
+libmemory (fit-window) are preserved — out of scope for 390.
+
+Part 07 of 08 for spec 390.
+```
+
+— Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a-07.md
+++ b/specs/390-consistent-package-layout/plan-a-07.md
@@ -1,42 +1,42 @@
 # Plan A — Part 07: Libraries tier B (no subpath exports)
 
-Migrate the remaining 18 libraries — those that publish only a default
-export (or no explicit `exports` field) and therefore have no subpath
-targets to rewrite. Lower blast radius than tier A.
+Migrate the remaining 18 libraries — those that publish only a default export
+(or no explicit `exports` field) and therefore have no subpath targets to
+rewrite. Lower blast radius than tier A.
 
 ## Libraries in tier B
 
-| Library | Root source files | Non-conforming root subdirs | Exports |
-| --- | ---:| --- | ---:|
-| libagent | hands.js, index.js, mind.js | processor/ | — |
-| libcli | cli.js, color.js, format.js, help.js, index.js, summary.js | — | — |
-| libcodegen | base.js, definitions.js, index.js, services.js, types.js | — | — |
-| libconfig | config.js, index.js | — | — |
-| libeval | index.js (plus existing src/) | — | — |
-| libformat | index.js | — | — |
-| libindex | base.js, buffered.js, index.js | — | — |
-| libllm | hallucination.js, index.js, models.js | — | — |
-| libpolicy | index.js | — | — |
-| librc | index.js, manager.js | — | — |
-| librepl | index.js | — | — |
-| libsecret | index.js | — | — |
-| libstorage | index.js, local.js, s3.js, supabase.js | — | — |
-| libsupervise | index.js, logger.js, longrun.js, oneshot.js, state.js, tree.js | — | — |
-| libutil | downloader.js, extractor.js, finder.js, http.js, index.js, processor.js, retry.js, tokenizer.js, wait.js | — | — |
-| libweb | auth.js, cors.js, index.js, validation.js | — | — |
+| Library      |                                                                                        Root source files | Non-conforming root subdirs | Exports |
+| ------------ | -------------------------------------------------------------------------------------------------------: | --------------------------- | ------: |
+| libagent     |                                                                              hands.js, index.js, mind.js | processor/                  |       — |
+| libcli       |                                               cli.js, color.js, format.js, help.js, index.js, summary.js | —                           |       — |
+| libcodegen   |                                                 base.js, definitions.js, index.js, services.js, types.js | —                           |       — |
+| libconfig    |                                                                                      config.js, index.js | —                           |       — |
+| libeval      |                                                                            index.js (plus existing src/) | —                           |       — |
+| libformat    |                                                                                                 index.js | —                           |       — |
+| libindex     |                                                                           base.js, buffered.js, index.js | —                           |       — |
+| libllm       |                                                                    hallucination.js, index.js, models.js | —                           |       — |
+| libpolicy    |                                                                                                 index.js | —                           |       — |
+| librc        |                                                                                     index.js, manager.js | —                           |       — |
+| librepl      |                                                                                                 index.js | —                           |       — |
+| libsecret    |                                                                                                 index.js | —                           |       — |
+| libstorage   |                                                                   index.js, local.js, s3.js, supabase.js | —                           |       — |
+| libsupervise |                                           index.js, logger.js, longrun.js, oneshot.js, state.js, tree.js | —                           |       — |
+| libutil      | downloader.js, extractor.js, finder.js, http.js, index.js, processor.js, retry.js, tokenizer.js, wait.js | —                           |       — |
+| libweb       |                                                                auth.js, cors.js, index.js, validation.js | —                           |       — |
 
 (librpc and libtype handled in Part 02. libharness handled in Part 04.)
 
-**Total: 16 libraries** (after excluding librpc, libtype, libharness which
-are in earlier parts). Each gets a minimal `exports` field added when one
-does not already exist — at a minimum `{ ".": "./src/index.js" }` — so the
-package root is properly walled off.
+**Total: 16 libraries** (after excluding librpc, libtype, libharness which are
+in earlier parts). Each gets a minimal `exports` field added when one does not
+already exist — at a minimum `{ ".": "./src/index.js" }` — so the package root
+is properly walled off.
 
 ## Approach
 
-Apply the cross-cutting move recipe for each library. **The exact
-`package.json` shape depends on whether the library publishes a `bin/`
-directory** — see the two cases below.
+Apply the cross-cutting move recipe for each library. **The exact `package.json`
+shape depends on whether the library publishes a `bin/` directory** — see the
+two cases below.
 
 ### Case A: tier-B library with no `bin/`
 
@@ -59,11 +59,10 @@ Libraries: libagent, libcodegen, libeval, libllm, librc, libstorage,
 libsupervise, libutil.
 
 The library's `bin/<entry>.js` files must remain resolvable via
-`require.resolve("@forwardimpact/libfoo/bin/<entry>.js")`. An explicit
-`exports` field that only maps `"."` locks down every other subpath and
-breaks those resolvers. Therefore every tier-B library with a `bin/`
-directory gets every bin entry mirrored into the exports map as a
-subpath key:
+`require.resolve("@forwardimpact/libfoo/bin/<entry>.js")`. An explicit `exports`
+field that only maps `"."` locks down every other subpath and breaks those
+resolvers. Therefore every tier-B library with a `bin/` directory gets every bin
+entry mirrored into the exports map as a subpath key:
 
 ```jsonc
 {
@@ -80,16 +79,14 @@ subpath key:
 
 **Confirmed call site:** `libraries/librc/manager.js` line 12 runs
 `require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")`. A
-monorepo-wide grep (`rg '@forwardimpact/\w+/bin/' --type js`) confirms
-this is the **only** cross-package reference into a `bin/` directory
-today. libsupervise therefore MUST keep
-`"./bin/fit-svscan.js": "./bin/fit-svscan.js"` in its exports map and —
-as a symmetry choice — also maps `./bin/fit-logger.js`.
+monorepo-wide grep (`rg '@forwardimpact/\w+/bin/' --type js`) confirms this is
+the **only** cross-package reference into a `bin/` directory today. libsupervise
+therefore MUST keep `"./bin/fit-svscan.js": "./bin/fit-svscan.js"` in its
+exports map and — as a symmetry choice — also maps `./bin/fit-logger.js`.
 
-Every other tier-B library with a `bin/` gets the bin subpath keys
-added anyway. This is zero-cost (no extra files) and future-proofs
-against new `require.resolve` calls landing from librc-style service
-managers.
+Every other tier-B library with a `bin/` gets the bin subpath keys added anyway.
+This is zero-cost (no extra files) and future-proofs against new
+`require.resolve` calls landing from librc-style service managers.
 
 ## Pre-move discovery
 
@@ -101,8 +98,8 @@ Before any tier-B library is migrated, run two separate greps:
 rg '@forwardimpact/(libagent|libcli|libcodegen|libconfig|libeval|libformat|libindex|libllm|libpolicy|librc|librepl|libsecret|libstorage|libsupervise|libutil|libweb)/[^"'\''`]+' --type js -g '!libraries/*/src/**' -g '!libraries/*/test/**'
 ```
 
-The `-g` excludes are important: a library's own internal relative
-imports don't count as cross-package subpath access. Report every hit.
+The `-g` excludes are important: a library's own internal relative imports don't
+count as cross-package subpath access. Report every hit.
 
 **2. `require.resolve` calls into any `@forwardimpact/*` package:**
 
@@ -110,17 +107,17 @@ imports don't count as cross-package subpath access. Report every hit.
 rg 'require\.resolve\(["'\''`]@forwardimpact' --type js
 ```
 
-These are trickier because they bypass static analysis. The known hit
-is `librc/manager.js:12` into libsupervise's bin — documented above.
-Any new hit needs the same treatment: add a subpath export key.
+These are trickier because they bypass static analysis. The known hit is
+`librc/manager.js:12` into libsupervise's bin — documented above. Any new hit
+needs the same treatment: add a subpath export key.
 
 For each hit from either grep, decide:
 
 - **Re-export from index.js** (preferred). Add the needed symbol to the
   library's `src/index.js`. Consumer's import specifier changes from
   `@forwardimpact/libfoo/bar` → `@forwardimpact/libfoo`.
-- **Add a new subpath export**. Only if the symbol is large enough to
-  warrant a separate entry point.
+- **Add a new subpath export**. Only if the symbol is large enough to warrant a
+  separate entry point.
 
 Document every decision inline in the commit message. The research phase
 confirmed this sweep is expected to be quiet (only the librc/libsupervise
@@ -130,25 +127,24 @@ confirmed this sweep is expected to be quiet (only the librc/libsupervise
 
 ### libagent
 
-3 root files + `processor/` subdir + `bin/fit-process-agents.js`.
-`processor/` moves to `src/processor/`.
+3 root files + `processor/` subdir + `bin/fit-process-agents.js`. `processor/`
+moves to `src/processor/`.
 
 ### libcli
 
-6 root files, no subdirs. The file `cli.js` is the core `createCli()`
-factory — make sure `src/cli.js` still re-exports correctly after moving.
+6 root files, no subdirs. The file `cli.js` is the core `createCli()` factory —
+make sure `src/cli.js` still re-exports correctly after moving.
 
 ### libcodegen
 
-5 root files + `templates/` (allowed, stays) + `bin/fit-codegen.js`
-(stays). **libcodegen has no `test/` directory** — skip the per-library
-test step for libcodegen; the full-suite `bun run test` at repo root
-exercises it indirectly. Note: libcodegen itself was NOT modified in
-Part 02 — Part 02 only edited `libutil/finder.js`. libcodegen's
-`fit-codegen.js` CLI entry point stays at `bin/fit-codegen.js` and its
-imports of `../base.js`, `../services.js`, etc. need to be rewritten to
-`../src/base.js`, `../src/services.js`, etc. when the root sources
-move.
+5 root files + `templates/` (allowed, stays) + `bin/fit-codegen.js` (stays).
+**libcodegen has no `test/` directory** — skip the per-library test step for
+libcodegen; the full-suite `bun run test` at repo root exercises it indirectly.
+Note: libcodegen itself was NOT modified in Part 02 — Part 02 only edited
+`libutil/finder.js`. libcodegen's `fit-codegen.js` CLI entry point stays at
+`bin/fit-codegen.js` and its imports of `../base.js`, `../services.js`, etc.
+need to be rewritten to `../src/base.js`, `../src/services.js`, etc. when the
+root sources move.
 
 ### libconfig
 
@@ -156,11 +152,10 @@ move.
 
 ### libeval
 
-**Already half-migrated.** Existing `src/commands/` tree stays. Root
-`index.js` moves to `src/index.js`. The existing `src/` structure
-(`src/commands/run.js`, `src/commands/supervise.js`, etc.) is unchanged.
-`bin/fit-eval.js` already imports from `../src/...` in places; audit and
-complete the migration.
+**Already half-migrated.** Existing `src/commands/` tree stays. Root `index.js`
+moves to `src/index.js`. The existing `src/` structure (`src/commands/run.js`,
+`src/commands/supervise.js`, etc.) is unchanged. `bin/fit-eval.js` already
+imports from `../src/...` in places; audit and complete the migration.
 
 ### libformat
 
@@ -180,14 +175,13 @@ complete the migration.
 
 ### librc
 
-2 root files + `bin/fit-rc.js`. **Careful:** `librc/manager.js` line 12
-runs `require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")`.
-After Part 07 adds an explicit `exports` field to libsupervise, this
-resolve would break unless libsupervise's exports map includes
-`"./bin/fit-svscan.js"`. Part 07's "Case B" template handles this — see
-§ libsupervise below. librc itself needs no special handling beyond
-the standard case B (its own `bin/fit-rc.js` gets mirrored into its
-own exports map).
+2 root files + `bin/fit-rc.js`. **Careful:** `librc/manager.js` line 12 runs
+`require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")`. After Part
+07 adds an explicit `exports` field to libsupervise, this resolve would break
+unless libsupervise's exports map includes `"./bin/fit-svscan.js"`. Part 07's
+"Case B" template handles this — see § libsupervise below. librc itself needs no
+special handling beyond the standard case B (its own `bin/fit-rc.js` gets
+mirrored into its own exports map).
 
 ### librepl
 
@@ -195,22 +189,21 @@ own exports map).
 
 ### libsecret
 
-1 root file. Stateless crypto (exempt from OO+DI); internal style
-preserved.
+1 root file. Stateless crypto (exempt from OO+DI); internal style preserved.
 
 ### libstorage
 
-4 root files + `bin/fit-storage.js`. libstorage is not touched by Part 02
-— the `"generated"` bucket mapping in `libstorage/index.js` stays as is
-(monorepo-root `generated/` is the load-bearing target for
-`Finder.findUpward`). Part 07 only moves `index.js`, `local.js`, `s3.js`,
-`supabase.js` into `src/` and updates `package.json`.
+4 root files + `bin/fit-storage.js`. libstorage is not touched by Part 02 — the
+`"generated"` bucket mapping in `libstorage/index.js` stays as is (monorepo-root
+`generated/` is the load-bearing target for `Finder.findUpward`). Part 07 only
+moves `index.js`, `local.js`, `s3.js`, `supabase.js` into `src/` and updates
+`package.json`.
 
 ### libsupervise
 
-6 root files + `bin/{fit-logger.js,fit-svscan.js}`. **Case B library
-with a known cross-package `require.resolve` consumer.** The
-`package.json` exports map MUST include both bin subpaths:
+6 root files + `bin/{fit-logger.js,fit-svscan.js}`. **Case B library with a
+known cross-package `require.resolve` consumer.** The `package.json` exports map
+MUST include both bin subpaths:
 
 ```jsonc
 {
@@ -230,17 +223,17 @@ with a known cross-package `require.resolve` consumer.** The
 
 Without the `./bin/fit-svscan.js` subpath key, `require.resolve` from
 `librc/manager.js:12` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. This is a
-**runtime breakage**, not a build-time one — the fit-rc CLI would fail
-the first time it tries to start a supervised service. Add both bin
-subpaths regardless of current consumer count.
+**runtime breakage**, not a build-time one — the fit-rc CLI would fail the first
+time it tries to start a supervised service. Add both bin subpaths regardless of
+current consumer count.
 
 ### libutil
 
-9 root files + `bin/{fit-download-bundle.js,fit-tiktoken.js}`. **Part 02
-already edited `libutil/finder.js`#findGeneratedPath** (line 117).
-After Part 07 moves `finder.js` into `src/finder.js`, the edit travels
-with the file via `git mv` and no re-edit is needed. The `bin/` entries
-stay and get mirrored into the exports map per case B.
+9 root files + `bin/{fit-download-bundle.js,fit-tiktoken.js}`. **Part 02 already
+edited `libutil/finder.js`#findGeneratedPath** (line 117). After Part 07 moves
+`finder.js` into `src/finder.js`, the edit travels with the file via `git mv`
+and no re-edit is needed. The `bin/` entries stay and get mirrored into the
+exports map per case B.
 
 ### libweb
 
@@ -248,16 +241,14 @@ stay and get mirrored into the exports map per case B.
 
 ## Ordering
 
-1. Run the pre-move discovery grep. Resolve every surprise consumer
-   before touching any file.
-2. Alphabetically, for each tier-B library:
-   a. Move root sources into `src/`.
-   b. Move any allowed non-conforming subdirs into `src/<name>/` (none in
-      tier B except libagent's `processor/`).
-   c. Add or update `main`, `exports`, `files` in `package.json`.
-   d. Rewrite `bin/fit-<name>.js` imports (`../foo.js` → `../src/foo.js`).
-   e. Rewrite `test/*.test.js` imports.
-   f. Run `bun run node --test <pkg>/test/*.test.js`.
+1. Run the pre-move discovery grep. Resolve every surprise consumer before
+   touching any file.
+2. Alphabetically, for each tier-B library: a. Move root sources into `src/`. b.
+   Move any allowed non-conforming subdirs into `src/<name>/` (none in tier B
+   except libagent's `processor/`). c. Add or update `main`, `exports`, `files`
+   in `package.json`. d. Rewrite `bin/fit-<name>.js` imports (`../foo.js` →
+   `../src/foo.js`). e. Rewrite `test/*.test.js` imports. f. Run
+   `bun run node --test <pkg>/test/*.test.js`.
 3. After all 16 libraries:
 4. `bun run check`
 5. `bun run test`
@@ -270,8 +261,8 @@ stay and get mirrored into the exports map per case B.
 - `git ls-files 'libraries/libagent/*.js' 'libraries/libcli/*.js' ... 'libraries/libweb/*.js'`
   returns nothing (no root sources across any tier-B library).
 - Every tier-B library has `src/index.js`.
-- Every tier-B library has an `exports` field with at least `"."` mapped
-  to `./src/index.js`.
+- Every tier-B library has an `exports` field with at least `"."` mapped to
+  `./src/index.js`.
 - `bun run layout` shows zero drift across `libraries/*`.
 - `bun run test` passes.
 - Success criterion #1 is mechanically satisfied:
@@ -280,50 +271,47 @@ stay and get mirrored into the exports map per case B.
 ## Risks
 
 1. **Adding an explicit `exports` field can break deep imports and
-   `require.resolve` calls that used to work.** Today libsupervise
-   (and every other tier-B library) has no `exports` field, so Node
-   resolves any subpath freely. Adding
-   `{ ".": "./src/index.js" }` without the bin entries locks subpath
-   access and breaks `librc/manager.js:12`'s
-   `require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")`
-   with `ERR_PACKAGE_PATH_NOT_EXPORTED` — at runtime, not build time.
-   This is a **load-bearing fit-rc path**: without it, services cannot
-   start. Mitigation: every tier-B library with a `bin/` directory
-   follows Case B (bin subpaths mirrored into the exports map) — see
-   § Approach. Running the pre-move discovery grep is the second line
-   of defence.
+   `require.resolve` calls that used to work.** Today libsupervise (and every
+   other tier-B library) has no `exports` field, so Node resolves any subpath
+   freely. Adding `{ ".": "./src/index.js" }` without the bin entries locks
+   subpath access and breaks `librc/manager.js:12`'s
+   `require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")` with
+   `ERR_PACKAGE_PATH_NOT_EXPORTED` — at runtime, not build time. This is a
+   **load-bearing fit-rc path**: without it, services cannot start. Mitigation:
+   every tier-B library with a `bin/` directory follows Case B (bin subpaths
+   mirrored into the exports map) — see § Approach. Running the pre-move
+   discovery grep is the second line of defence.
 
-2. **`libcli` is used by 22 CLIs across the monorepo** (per the staff
-   engineer's Apr 10 log). All use the default export. No subpath deep
-   imports are known. Still, run the discovery grep for libcli
-   specifically as a sanity check.
+2. **`libcli` is used by 22 CLIs across the monorepo** (per the staff engineer's
+   Apr 10 log). All use the default export. No subpath deep imports are known.
+   Still, run the discovery grep for libcli specifically as a sanity check.
 
-3. **`libeval` is half-migrated** — existing `src/commands/` tree means
-   some tests may already use `../src/` imports while others use `../`.
-   Audit both patterns. Finishing libeval means bringing all root source
-   files into the existing `src/` tree.
+3. **`libeval` is half-migrated** — existing `src/commands/` tree means some
+   tests may already use `../src/` imports while others use `../`. Audit both
+   patterns. Finishing libeval means bringing all root source files into the
+   existing `src/` tree.
 
-4. **`libcodegen` has the `fit-codegen` CLI** — the staff engineer's Apr
-   10 log shows libcli migration already touched `fit-codegen.js`, which
-   calls into the package's own root-level `services.js` and `types.js`.
-   After Part 07 moves those into `src/`, the bin file imports need
-   rewriting. Read `bin/fit-codegen.js` carefully before the move — it has
-   several imports from the package root.
+4. **`libcodegen` has the `fit-codegen` CLI** — the staff engineer's Apr 10 log
+   shows libcli migration already touched `fit-codegen.js`, which calls into the
+   package's own root-level `services.js` and `types.js`. After Part 07 moves
+   those into `src/`, the bin file imports need rewriting. Read
+   `bin/fit-codegen.js` carefully before the move — it has several imports from
+   the package root.
 
-5. **`libstorage` and `libutil` were edited in Part 02.** The Part 02
-   edits are on files at the package root (`libstorage/index.js` and
-   `libutil/finder.js`). When Part 07 moves those files into `src/`, the
-   Part 02 edits come with them. No re-edit is needed, but verify the
-   resulting `src/index.js` and `src/finder.js` still have the Part 02
-   changes. Diff against the main branch baseline if in doubt.
+5. **`libstorage` and `libutil` were edited in Part 02.** The Part 02 edits are
+   on files at the package root (`libstorage/index.js` and `libutil/finder.js`).
+   When Part 07 moves those files into `src/`, the Part 02 edits come with them.
+   No re-edit is needed, but verify the resulting `src/index.js` and
+   `src/finder.js` still have the Part 02 changes. Diff against the main branch
+   baseline if in doubt.
 
-6. **Transitive missing dependencies.** The staff engineer's Apr 10 log
-   notes: "libvector (fit-search imports libconfig, libllm, libstorage
-   which are not in libvector's package.json) and libmemory (fit-window
-   imports libconfig, librpc)". These are pre-existing issues, not
-   introduced by this spec, and remain pre-existing after the migration.
-   Do not fix them as part of Part 07 — that is scope creep. Note them in
-   the commit message as "preserved pre-existing transitive issues".
+6. **Transitive missing dependencies.** The staff engineer's Apr 10 log notes:
+   "libvector (fit-search imports libconfig, libllm, libstorage which are not in
+   libvector's package.json) and libmemory (fit-window imports libconfig,
+   librpc)". These are pre-existing issues, not introduced by this spec, and
+   remain pre-existing after the migration. Do not fix them as part of Part 07 —
+   that is scope creep. Note them in the commit message as "preserved
+   pre-existing transitive issues".
 
 ## Deliverable commit
 

--- a/specs/390-consistent-package-layout/plan-a-08.md
+++ b/specs/390-consistent-package-layout/plan-a-08.md
@@ -1,0 +1,408 @@
+# Plan A — Part 08: Enforce, document, smoke test
+
+Final part. Flip the allowed-subdirs check to strict mode, rewrite
+`CLAUDE.md § Structure` to describe the contract, update the internals docs
+and library/product skill files, and run a fresh-install smoke test that
+proves every published subpath export still resolves.
+
+## Scope
+
+This part has two stages. Stage 1 is **code and configuration** (run as
+staff-engineer): flip strict mode, run the smoke test, verify CI. Stage 2
+is **prose** (handed off to the technical-writer sub-agent): rewrite
+`CLAUDE.md § Structure`, update internals pages, update library skill files.
+
+The handoff boundary is explicit: after Stage 1 commits cleanly and the
+layout check is enforcing strict mode, the staff-engineer launches a
+`technical-writer` sub-agent with the prose task and waits for it to
+return a commit. The staff-engineer then runs a final `bun run check` and
+`bun run test`, pushes, and advances `specs/STATUS` from `active` → `done`.
+
+## Stage 1: Enforce + smoke test
+
+### Flip strict mode
+
+Edit `scripts/check-package-layout.js` from Part 01 so strict mode is the
+default:
+
+```diff
+-const strict = process.argv.includes("--strict");
++const strict = !process.argv.includes("--no-strict");
+```
+
+Equivalently, set `strict = true` unconditionally and remove the
+permissive fall-through. The explicit `--no-strict` escape hatch is kept
+for ad-hoc debugging.
+
+The script now fails fast on any drift. After Parts 02–07 there should be
+zero drift, so this change is a no-op for exit behaviour on a clean
+branch.
+
+### Fresh-install smoke test
+
+The spec's success criterion #9 requires proving every published subpath
+export key still resolves. The Part 01 check confirms directory layout; the
+smoke test confirms **resolution**.
+
+Create `scripts/check-exports-resolve.js`:
+
+```js
+#!/usr/bin/env node
+// Prove that every published subpath export across every @forwardimpact
+// package resolves to a file on disk. Used by spec 390 success criterion #9.
+
+import { readFileSync, existsSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { glob } from "node:fs/promises";
+
+const manifests = await Array.fromAsync(
+  glob(["libraries/*/package.json", "products/*/package.json", "services/*/package.json"]),
+);
+
+let failures = 0;
+let total = 0;
+
+for (const manifestPath of manifests) {
+  const pkgRoot = dirname(manifestPath);
+  const pkg = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (!pkg.exports) continue;
+
+  const walk = (exports) => {
+    if (typeof exports === "string") return [exports];
+    return Object.values(exports).flatMap(walk);
+  };
+
+  const targets = walk(pkg.exports);
+  for (const target of targets) {
+    // Skip wildcard patterns — they are resolved per-consumer and can't be
+    // checked without a concrete consumer path.
+    if (target.includes("*")) continue;
+    total += 1;
+    const resolved = join(pkgRoot, target);
+    if (!existsSync(resolved) || !statSync(resolved).isFile()) {
+      console.error(`MISSING: ${pkg.name} → ${target}  (${resolved})`);
+      failures += 1;
+    }
+  }
+
+  // Also verify `main` resolves.
+  if (pkg.main) {
+    total += 1;
+    const resolved = join(pkgRoot, pkg.main);
+    if (!existsSync(resolved) || !statSync(resolved).isFile()) {
+      console.error(`MISSING main: ${pkg.name} → ${pkg.main}  (${resolved})`);
+      failures += 1;
+    }
+  }
+
+  // And every bin entry.
+  if (pkg.bin) {
+    for (const [name, target] of Object.entries(pkg.bin)) {
+      total += 1;
+      const resolved = join(pkgRoot, target);
+      if (!existsSync(resolved) || !statSync(resolved).isFile()) {
+        console.error(`MISSING bin[${name}]: ${pkg.name} → ${target}  (${resolved})`);
+        failures += 1;
+      }
+    }
+  }
+}
+
+console.log(`Checked ${total} resolution targets across ${manifests.length} packages.`);
+if (failures) {
+  console.error(`${failures} missing.`);
+  process.exit(1);
+}
+console.log("All exports resolve.");
+```
+
+Wire it into `package.json`:
+
+```jsonc
+"scripts": {
+  "check": "bun run format && bun run lint && bun run layout && bun run check:exports",
+  "check:exports": "node scripts/check-exports-resolve.js"
+}
+```
+
+Add it to the CI quality workflow as a fourth job.
+
+### Pre-move vs post-move key parity
+
+Before the branch started, snapshot the set of published subpath keys from
+`main`:
+
+```sh
+git checkout main -- .
+node -e '
+  const { readFileSync } = require("node:fs");
+  const { globSync } = require("node:fs");
+  const keys = [];
+  for (const p of require("glob").sync(["libraries/*/package.json", "products/*/package.json", "services/*/package.json"])) {
+    const m = JSON.parse(readFileSync(p, "utf8"));
+    if (!m.exports) continue;
+    const walk = (e, prefix = "") => {
+      if (typeof e === "string") { keys.push(`${m.name}${prefix}`); return; }
+      for (const [k, v] of Object.entries(e)) walk(v, prefix + k.replace(/^\./, ""));
+    };
+    walk(m.exports);
+  }
+  keys.sort();
+  console.log(keys.join("\n"));
+' > /tmp/pre-move-keys.txt
+git checkout feat/390-consistent-package-layout -- .
+# Same script:
+... > /tmp/post-move-keys.txt
+diff /tmp/pre-move-keys.txt /tmp/post-move-keys.txt
+```
+
+**Expected output: empty diff.** Any difference is a missed key and must
+be fixed before the part is complete. The exact script is captured in
+Part 08 as a one-off verification — do not add it to CI.
+
+### Ordering (Stage 1)
+
+1. Flip strict mode in `scripts/check-package-layout.js`.
+2. Add `scripts/check-exports-resolve.js`.
+3. Wire both into `package.json` and `.github/workflows/check-quality.yml`.
+4. Run `bun run check` locally. Must pass end-to-end.
+5. Snapshot pre-move vs post-move key parity. Must match.
+6. Run `bun run test`. Must pass.
+7. Commit Stage 1.
+8. Launch the Stage 2 sub-agent.
+
+## Stage 2: Prose
+
+Handed off to a **`technical-writer` sub-agent** via the `Agent` tool. The
+sub-agent does not invoke any skill. Tell it explicitly: no skills, no
+nested sub-agents.
+
+### CLAUDE.md § Structure rewrite
+
+The current section (lines 143–175) shows a sample tree with
+`landmark/` and `summit/` as products — neither exists as a package. It
+does not describe the allowed-root-subdirs contract.
+
+Target state: rewrite the section so it is **the** canonical description
+of the per-package layout. New subsections:
+
+1. **Monorepo structure** — one-screen tree showing top-level folders
+   (`products/`, `services/`, `libraries/`, `config/`, `data/`, `specs/`,
+   `wiki/`, `website/`). Remove `landmark/` and `summit/` from the tree
+   comment. They can be mentioned in the products list but not shown as
+   directories.
+
+2. **Per-package layout** — the canonical tree for a non-service package,
+   the canonical tree for a service, and the allowed-root-subdirs list as
+   a bullet:
+
+   > Every package under `products/`, `services/`, and `libraries/`
+   > follows this layout. Any directory at the package root must be one
+   > of: `bin/`, `config/`, `macos/`, `pkg/`, `proto/`, `schema/`,
+   > `src/`, `starter/`, `supabase/`, `templates/`, `test/`. Anything
+   > else fails `bun run layout`.
+
+3. **Services exception** — the two-file root (`index.js`, `server.js`),
+   loaded by fixed path from `config/config.example.json` service commands,
+   is called out explicitly.
+
+4. **Per-package `justfile`** — allowed-list paragraph confirming that a
+   package may add its own `justfile` without replacing the top-level one
+   (per rule 7 of the spec).
+
+5. **Enforcement** — link to `scripts/check-package-layout.js` and
+   `bun run layout` / `bun run check:exports`.
+
+Keep the section concise — under 80 lines. Put the long-form rationale
+in an internals page if needed, not CLAUDE.md.
+
+### Internals doc updates
+
+These pages currently have file-tree diagrams that show the old layout.
+Each needs a pass:
+
+- `website/docs/internals/map/index.md`
+- `website/docs/internals/pathway/index.md`
+- `website/docs/internals/basecamp/index.md`
+- `website/docs/internals/guide/index.md`
+- `website/docs/internals/codegen/index.md` — codegen now writes to
+  `src/generated/`, mention the per-package symlink behaviour in one
+  paragraph.
+
+The technical-writer sub-agent runs a targeted grep for any tree diagram
+or file-path reference that shows the pre-move layout:
+
+```
+rg -n 'libraries/[a-z]+/[a-z-]+\.js' website/docs/internals/
+rg -n 'products/[a-z]+/[a-z-]+\.js' website/docs/internals/
+rg -n '`[a-z-]+\.js`' website/docs/internals/
+```
+
+Then fixes each hit. Do not over-expand the scope — only touch the lines
+that reference on-disk paths.
+
+### Library skill updates
+
+Every skill file under `.claude/skills/libs-*` lists the libraries it
+covers and points at specific files. After the move, those files live
+under `src/`. Skills to audit:
+
+- `.claude/skills/libs-service-infrastructure/SKILL.md`
+- `.claude/skills/libs-data-persistence/SKILL.md`
+- `.claude/skills/libs-llm-orchestration/SKILL.md`
+- `.claude/skills/libs-web-presentation/SKILL.md`
+- `.claude/skills/libs-system-utilities/SKILL.md`
+- `.claude/skills/libs-synthetic-data/SKILL.md`
+- `.claude/skills/libskill/SKILL.md` (libskill has its own skill)
+
+And the product skills:
+
+- `.claude/skills/fit-map/SKILL.md`
+- `.claude/skills/fit-pathway/SKILL.md`
+- `.claude/skills/fit-basecamp/SKILL.md`
+- `.claude/skills/fit-guide/SKILL.md`
+- `.claude/skills/fit-universe/SKILL.md`
+
+The technical-writer updates every file-path reference from the root to
+`src/`. Grep for `.js`  patterns inside each skill file and verify each
+matches a file that exists post-move. Rewrite the path if not.
+
+Do not touch published skill _copy_ beyond file paths — that is
+documentation policy for the wider skills review, not for this spec.
+
+### gemba-walk / other skill invariants
+
+The staff engineer's Apr 10 memory notes:
+
+> gemba-walk has invariants for both of my workflows (plan-specs and
+> implement-plans) in .claude/skills/gemba-walk/references/invariants.md
+
+Check `invariants.md` for file-path references. Update any that have
+moved.
+
+### Ordering (Stage 2)
+
+1. Technical-writer rewrites `CLAUDE.md § Structure`.
+2. Technical-writer updates each internals page.
+3. Technical-writer updates each library and product skill file.
+4. Technical-writer commits with:
+   ```
+   docs(layout): update structure contract and internals pages (part 08/08)
+
+   Rewrites CLAUDE.md § Structure to describe the allowed-root-subdirs
+   contract, removes stale landmark/ and summit/ references, and updates
+   every internals page and skill file that referenced the pre-move
+   layout.
+
+   Part 08 of 08 for spec 390.
+   ```
+5. Technical-writer returns control.
+6. Staff-engineer runs `bun run check` and `bun run test` one last time.
+7. Staff-engineer updates `specs/STATUS`: `390 done`.
+8. Staff-engineer commits the STATUS update as
+   `chore(specs): advance 390 to done`.
+9. Push.
+
+## Stage 2 sub-agent prompt (exact briefing)
+
+Below is the briefing the staff-engineer uses when launching the
+technical-writer sub-agent. It is self-contained and explicit about the
+no-skills constraint. Adapt the exact prompt text at execution time but
+keep these points intact:
+
+> Spec 390 (consistent package layout) has landed as Parts 01–07 of its
+> plan. Every package now lives under `src/`; the root-level `generated/`
+> output is symlinked as `libraries/{librpc,libtype}/src/generated`;
+> `libharness` is fully restructured. Your job is the documentation pass
+> that completes Part 08.
+>
+> Update these surfaces so they reflect the new layout:
+>
+> 1. `CLAUDE.md § Structure` (lines ~143–175) — rewrite per
+>    `specs/390-consistent-package-layout/plan-a-08.md § Stage 2`.
+> 2. Internals pages under `website/docs/internals/{map,pathway,basecamp,guide,codegen}/index.md`.
+> 3. Library skills under `.claude/skills/libs-*/SKILL.md` and the
+>    `libskill/SKILL.md` exception.
+> 4. Product skills under `.claude/skills/fit-*/SKILL.md`.
+> 5. `.claude/skills/gemba-walk/references/invariants.md` if it references
+>    moved file paths.
+>
+> Scope constraints: do not touch prose beyond file paths unless the
+> surrounding prose has become misleading as a result of the move.
+> Do not invoke any skill. Do not spawn sub-agents. Use Grep, Read, Edit,
+> and Write directly. Commit with the message in plan-a-08.md § Stage 2.
+> Return control when the commit is in place.
+
+## Verification
+
+- `bun run check` passes (strict layout check included).
+- `bun run check:exports` passes (every subpath target resolves).
+- Pre-move vs post-move subpath key diff is empty.
+- `bun run test` passes, no regressions.
+- `specs/STATUS` shows `390 done`.
+- `CLAUDE.md § Structure` no longer mentions `landmark/` or `summit/` as
+  directories.
+- Fresh-install smoke test: run `npm pack` for a couple of published
+  libraries (libskill, libharness, map) and verify the tarball contents
+  include `src/**` and no legacy root-level `.js` files.
+
+## Risks
+
+1. **The fresh-install smoke test is only as good as its coverage.**
+   `check-exports-resolve.js` skips wildcard patterns (`./components/*`,
+   `./css/*`). For libui, a wildcard miss is possible. Mitigation: pick
+   one concrete wildcard consumer (e.g., `pathway` importing
+   `@forwardimpact/libui/components/card`) and assert it resolves in the
+   smoke test. A single-line hardcoded assertion is acceptable.
+
+2. **Strict mode may surface drift the prior parts missed.** If Part 08
+   flips the switch and `bun run layout` fails, stop — do not commit.
+   Back-fill the missed package in Part 06 or Part 07 as a fixup commit
+   and re-run.
+
+3. **The technical-writer sub-agent may edit copy beyond file paths.**
+   Scope creep risk. The briefing is explicit, but review the technical
+   writer's commit before pushing and revert any prose edits that go
+   beyond updating file paths.
+
+4. **`specs/STATUS` advancement must wait until everything is clean.**
+   The spec lifecycle is `planned → active → done`. When Part 01 starts,
+   the status goes to `active`; when Part 08 finishes and pushes, the
+   status advances to `done`. Do not advance to `done` while the
+   technical-writer commit is still pending.
+
+## Deliverable commits (stages)
+
+**Stage 1:**
+
+```
+refactor(layout): enforce strict mode and smoke-test exports (part 08/08 stage 1)
+
+- flip scripts/check-package-layout.js to strict mode by default
+- add scripts/check-exports-resolve.js and wire into bun run check
+- add check-exports job to check-quality CI workflow
+- verify pre-move vs post-move subpath key parity (empty diff)
+
+Part 08 stage 1 for spec 390.
+```
+
+**Stage 2** (technical-writer sub-agent):
+
+```
+docs(layout): update structure contract and internals pages (part 08/08 stage 2)
+
+Rewrites CLAUDE.md § Structure to describe the allowed-root-subdirs
+contract, removes stale landmark/ and summit/ references, and updates
+every internals page and skill file that referenced the pre-move
+layout.
+
+Part 08 stage 2 for spec 390.
+```
+
+**Status advancement** (staff-engineer):
+
+```
+chore(specs): advance 390 to done
+```
+
+— Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a-08.md
+++ b/specs/390-consistent-package-layout/plan-a-08.md
@@ -1,22 +1,22 @@
 # Plan A — Part 08: Enforce, document, smoke test
 
 Final part. Flip the allowed-subdirs check to strict mode, rewrite
-`CLAUDE.md § Structure` to describe the contract, update the internals docs
-and library/product skill files, and run a fresh-install smoke test that
-proves every published subpath export still resolves.
+`CLAUDE.md § Structure` to describe the contract, update the internals docs and
+library/product skill files, and run a fresh-install smoke test that proves
+every published subpath export still resolves.
 
 ## Scope
 
 This part has two stages. Stage 1 is **code and configuration** (run as
-staff-engineer): flip strict mode, run the smoke test, verify CI. Stage 2
-is **prose** (handed off to the technical-writer sub-agent): rewrite
+staff-engineer): flip strict mode, run the smoke test, verify CI. Stage 2 is
+**prose** (handed off to the technical-writer sub-agent): rewrite
 `CLAUDE.md § Structure`, update internals pages, update library skill files.
 
-The handoff boundary is explicit: after Stage 1 commits cleanly and the
-layout check is enforcing strict mode, the staff-engineer launches a
-`technical-writer` sub-agent with the prose task and waits for it to
-return a commit. The staff-engineer then runs a final `bun run check` and
-`bun run test`, pushes, and advances `specs/STATUS` from `active` → `done`.
+The handoff boundary is explicit: after Stage 1 commits cleanly and the layout
+check is enforcing strict mode, the staff-engineer launches a `technical-writer`
+sub-agent with the prose task and waits for it to return a commit. The
+staff-engineer then runs a final `bun run check` and `bun run test`, pushes, and
+advances `specs/STATUS` from `active` → `done`.
 
 ## Stage 1: Enforce + smoke test
 
@@ -30,19 +30,18 @@ default:
 +const strict = !process.argv.includes("--no-strict");
 ```
 
-Equivalently, set `strict = true` unconditionally and remove the
-permissive fall-through. The explicit `--no-strict` escape hatch is kept
-for ad-hoc debugging.
+Equivalently, set `strict = true` unconditionally and remove the permissive
+fall-through. The explicit `--no-strict` escape hatch is kept for ad-hoc
+debugging.
 
-The script now fails fast on any drift. After Parts 02–07 there should be
-zero drift, so this change is a no-op for exit behaviour on a clean
-branch.
+The script now fails fast on any drift. After Parts 02–07 there should be zero
+drift, so this change is a no-op for exit behaviour on a clean branch.
 
 ### Fresh-install smoke test
 
-The spec's success criterion #9 requires proving every published subpath
-export key still resolves. The Part 01 check confirms directory layout; the
-smoke test confirms **resolution**.
+The spec's success criterion #9 requires proving every published subpath export
+key still resolves. The Part 01 check confirms directory layout; the smoke test
+confirms **resolution**.
 
 Create `scripts/check-exports-resolve.js`:
 
@@ -156,9 +155,9 @@ git checkout feat/390-consistent-package-layout -- .
 diff /tmp/pre-move-keys.txt /tmp/post-move-keys.txt
 ```
 
-**Expected output: empty diff.** Any difference is a missed key and must
-be fixed before the part is complete. The exact script is captured in
-Part 08 as a one-off verification — do not add it to CI.
+**Expected output: empty diff.** Any difference is a missed key and must be
+fixed before the part is complete. The exact script is captured in Part 08 as a
+one-off verification — do not add it to CI.
 
 ### Ordering (Stage 1)
 
@@ -174,63 +173,59 @@ Part 08 as a one-off verification — do not add it to CI.
 ## Stage 2: Prose
 
 Handed off to a **`technical-writer` sub-agent** via the `Agent` tool. The
-sub-agent does not invoke any skill. Tell it explicitly: no skills, no
-nested sub-agents.
+sub-agent does not invoke any skill. Tell it explicitly: no skills, no nested
+sub-agents.
 
 ### CLAUDE.md § Structure rewrite
 
-The current section (lines 143–175) shows a sample tree with
-`landmark/` and `summit/` as products — neither exists as a package. It
-does not describe the allowed-root-subdirs contract.
+The current section (lines 143–175) shows a sample tree with `landmark/` and
+`summit/` as products — neither exists as a package. It does not describe the
+allowed-root-subdirs contract.
 
-Target state: rewrite the section so it is **the** canonical description
-of the per-package layout. New subsections:
+Target state: rewrite the section so it is **the** canonical description of the
+per-package layout. New subsections:
 
 1. **Monorepo structure** — one-screen tree showing top-level folders
    (`products/`, `services/`, `libraries/`, `config/`, `data/`, `specs/`,
-   `wiki/`, `website/`). Remove `landmark/` and `summit/` from the tree
-   comment. They can be mentioned in the products list but not shown as
-   directories.
+   `wiki/`, `website/`). Remove `landmark/` and `summit/` from the tree comment.
+   They can be mentioned in the products list but not shown as directories.
 
-2. **Per-package layout** — the canonical tree for a non-service package,
-   the canonical tree for a service, and the allowed-root-subdirs list as
-   a bullet:
+2. **Per-package layout** — the canonical tree for a non-service package, the
+   canonical tree for a service, and the allowed-root-subdirs list as a bullet:
 
-   > Every package under `products/`, `services/`, and `libraries/`
-   > follows this layout. Any directory at the package root must be one
-   > of: `bin/`, `config/`, `macos/`, `pkg/`, `proto/`, `schema/`,
-   > `src/`, `starter/`, `supabase/`, `templates/`, `test/`. Anything
-   > else fails `bun run layout`.
+   > Every package under `products/`, `services/`, and `libraries/` follows this
+   > layout. Any directory at the package root must be one of: `bin/`,
+   > `config/`, `macos/`, `pkg/`, `proto/`, `schema/`, `src/`, `starter/`,
+   > `supabase/`, `templates/`, `test/`. Anything else fails `bun run layout`.
 
-3. **Services exception** — the two-file root (`index.js`, `server.js`),
-   loaded by fixed path from `config/config.example.json` service commands,
-   is called out explicitly.
+3. **Services exception** — the two-file root (`index.js`, `server.js`), loaded
+   by fixed path from `config/config.example.json` service commands, is called
+   out explicitly.
 
-4. **Per-package `justfile`** — allowed-list paragraph confirming that a
-   package may add its own `justfile` without replacing the top-level one
-   (per rule 7 of the spec).
+4. **Per-package `justfile`** — allowed-list paragraph confirming that a package
+   may add its own `justfile` without replacing the top-level one (per rule 7 of
+   the spec).
 
 5. **Enforcement** — link to `scripts/check-package-layout.js` and
    `bun run layout` / `bun run check:exports`.
 
-Keep the section concise — under 80 lines. Put the long-form rationale
-in an internals page if needed, not CLAUDE.md.
+Keep the section concise — under 80 lines. Put the long-form rationale in an
+internals page if needed, not CLAUDE.md.
 
 ### Internals doc updates
 
-These pages currently have file-tree diagrams that show the old layout.
-Each needs a pass:
+These pages currently have file-tree diagrams that show the old layout. Each
+needs a pass:
 
 - `website/docs/internals/map/index.md`
 - `website/docs/internals/pathway/index.md`
 - `website/docs/internals/basecamp/index.md`
 - `website/docs/internals/guide/index.md`
 - `website/docs/internals/codegen/index.md` — codegen now writes to
-  `src/generated/`, mention the per-package symlink behaviour in one
-  paragraph.
+  `src/generated/`, mention the per-package symlink behaviour in one paragraph.
 
-The technical-writer sub-agent runs a targeted grep for any tree diagram
-or file-path reference that shows the pre-move layout:
+The technical-writer sub-agent runs a targeted grep for any tree diagram or
+file-path reference that shows the pre-move layout:
 
 ```
 rg -n 'libraries/[a-z]+/[a-z-]+\.js' website/docs/internals/
@@ -238,14 +233,14 @@ rg -n 'products/[a-z]+/[a-z-]+\.js' website/docs/internals/
 rg -n '`[a-z-]+\.js`' website/docs/internals/
 ```
 
-Then fixes each hit. Do not over-expand the scope — only touch the lines
-that reference on-disk paths.
+Then fixes each hit. Do not over-expand the scope — only touch the lines that
+reference on-disk paths.
 
 ### Library skill updates
 
-Every skill file under `.claude/skills/libs-*` lists the libraries it
-covers and points at specific files. After the move, those files live
-under `src/`. Skills to audit:
+Every skill file under `.claude/skills/libs-*` lists the libraries it covers and
+points at specific files. After the move, those files live under `src/`. Skills
+to audit:
 
 - `.claude/skills/libs-service-infrastructure/SKILL.md`
 - `.claude/skills/libs-data-persistence/SKILL.md`
@@ -263,12 +258,12 @@ And the product skills:
 - `.claude/skills/fit-guide/SKILL.md`
 - `.claude/skills/fit-universe/SKILL.md`
 
-The technical-writer updates every file-path reference from the root to
-`src/`. Grep for `.js`  patterns inside each skill file and verify each
-matches a file that exists post-move. Rewrite the path if not.
+The technical-writer updates every file-path reference from the root to `src/`.
+Grep for `.js` patterns inside each skill file and verify each matches a file
+that exists post-move. Rewrite the path if not.
 
-Do not touch published skill _copy_ beyond file paths — that is
-documentation policy for the wider skills review, not for this spec.
+Do not touch published skill _copy_ beyond file paths — that is documentation
+policy for the wider skills review, not for this spec.
 
 ### gemba-walk / other skill invariants
 
@@ -277,8 +272,7 @@ The staff engineer's Apr 10 memory notes:
 > gemba-walk has invariants for both of my workflows (plan-specs and
 > implement-plans) in .claude/skills/gemba-walk/references/invariants.md
 
-Check `invariants.md` for file-path references. Update any that have
-moved.
+Check `invariants.md` for file-path references. Update any that have moved.
 
 ### Ordering (Stage 2)
 
@@ -286,6 +280,7 @@ moved.
 2. Technical-writer updates each internals page.
 3. Technical-writer updates each library and product skill file.
 4. Technical-writer commits with:
+
    ```
    docs(layout): update structure contract and internals pages (part 08/08)
 
@@ -296,6 +291,7 @@ moved.
 
    Part 08 of 08 for spec 390.
    ```
+
 5. Technical-writer returns control.
 6. Staff-engineer runs `bun run check` and `bun run test` one last time.
 7. Staff-engineer updates `specs/STATUS`: `390 done`.
@@ -307,31 +303,31 @@ moved.
 
 Below is the briefing the staff-engineer uses when launching the
 technical-writer sub-agent. It is self-contained and explicit about the
-no-skills constraint. Adapt the exact prompt text at execution time but
-keep these points intact:
+no-skills constraint. Adapt the exact prompt text at execution time but keep
+these points intact:
 
-> Spec 390 (consistent package layout) has landed as Parts 01–07 of its
-> plan. Every package now lives under `src/`; the root-level `generated/`
-> output is symlinked as `libraries/{librpc,libtype}/src/generated`;
-> `libharness` is fully restructured. Your job is the documentation pass
-> that completes Part 08.
+> Spec 390 (consistent package layout) has landed as Parts 01–07 of its plan.
+> Every package now lives under `src/`; the root-level `generated/` output is
+> symlinked as `libraries/{librpc,libtype}/src/generated`; `libharness` is fully
+> restructured. Your job is the documentation pass that completes Part 08.
 >
 > Update these surfaces so they reflect the new layout:
 >
 > 1. `CLAUDE.md § Structure` (lines ~143–175) — rewrite per
 >    `specs/390-consistent-package-layout/plan-a-08.md § Stage 2`.
-> 2. Internals pages under `website/docs/internals/{map,pathway,basecamp,guide,codegen}/index.md`.
+> 2. Internals pages under
+>    `website/docs/internals/{map,pathway,basecamp,guide,codegen}/index.md`.
 > 3. Library skills under `.claude/skills/libs-*/SKILL.md` and the
 >    `libskill/SKILL.md` exception.
 > 4. Product skills under `.claude/skills/fit-*/SKILL.md`.
-> 5. `.claude/skills/gemba-walk/references/invariants.md` if it references
->    moved file paths.
+> 5. `.claude/skills/gemba-walk/references/invariants.md` if it references moved
+>    file paths.
 >
-> Scope constraints: do not touch prose beyond file paths unless the
-> surrounding prose has become misleading as a result of the move.
-> Do not invoke any skill. Do not spawn sub-agents. Use Grep, Read, Edit,
-> and Write directly. Commit with the message in plan-a-08.md § Stage 2.
-> Return control when the commit is in place.
+> Scope constraints: do not touch prose beyond file paths unless the surrounding
+> prose has become misleading as a result of the move. Do not invoke any skill.
+> Do not spawn sub-agents. Use Grep, Read, Edit, and Write directly. Commit with
+> the message in plan-a-08.md § Stage 2. Return control when the commit is in
+> place.
 
 ## Verification
 
@@ -342,34 +338,32 @@ keep these points intact:
 - `specs/STATUS` shows `390 done`.
 - `CLAUDE.md § Structure` no longer mentions `landmark/` or `summit/` as
   directories.
-- Fresh-install smoke test: run `npm pack` for a couple of published
-  libraries (libskill, libharness, map) and verify the tarball contents
-  include `src/**` and no legacy root-level `.js` files.
+- Fresh-install smoke test: run `npm pack` for a couple of published libraries
+  (libskill, libharness, map) and verify the tarball contents include `src/**`
+  and no legacy root-level `.js` files.
 
 ## Risks
 
 1. **The fresh-install smoke test is only as good as its coverage.**
    `check-exports-resolve.js` skips wildcard patterns (`./components/*`,
-   `./css/*`). For libui, a wildcard miss is possible. Mitigation: pick
-   one concrete wildcard consumer (e.g., `pathway` importing
-   `@forwardimpact/libui/components/card`) and assert it resolves in the
-   smoke test. A single-line hardcoded assertion is acceptable.
+   `./css/*`). For libui, a wildcard miss is possible. Mitigation: pick one
+   concrete wildcard consumer (e.g., `pathway` importing
+   `@forwardimpact/libui/components/card`) and assert it resolves in the smoke
+   test. A single-line hardcoded assertion is acceptable.
 
-2. **Strict mode may surface drift the prior parts missed.** If Part 08
-   flips the switch and `bun run layout` fails, stop — do not commit.
-   Back-fill the missed package in Part 06 or Part 07 as a fixup commit
-   and re-run.
+2. **Strict mode may surface drift the prior parts missed.** If Part 08 flips
+   the switch and `bun run layout` fails, stop — do not commit. Back-fill the
+   missed package in Part 06 or Part 07 as a fixup commit and re-run.
 
-3. **The technical-writer sub-agent may edit copy beyond file paths.**
-   Scope creep risk. The briefing is explicit, but review the technical
-   writer's commit before pushing and revert any prose edits that go
-   beyond updating file paths.
+3. **The technical-writer sub-agent may edit copy beyond file paths.** Scope
+   creep risk. The briefing is explicit, but review the technical writer's
+   commit before pushing and revert any prose edits that go beyond updating file
+   paths.
 
-4. **`specs/STATUS` advancement must wait until everything is clean.**
-   The spec lifecycle is `planned → active → done`. When Part 01 starts,
-   the status goes to `active`; when Part 08 finishes and pushes, the
-   status advances to `done`. Do not advance to `done` while the
-   technical-writer commit is still pending.
+4. **`specs/STATUS` advancement must wait until everything is clean.** The spec
+   lifecycle is `planned → active → done`. When Part 01 starts, the status goes
+   to `active`; when Part 08 finishes and pushes, the status advances to `done`.
+   Do not advance to `done` while the technical-writer commit is still pending.
 
 ## Deliverable commits (stages)
 

--- a/specs/390-consistent-package-layout/plan-a.md
+++ b/specs/390-consistent-package-layout/plan-a.md
@@ -1,0 +1,307 @@
+# Plan A — Consistent Package Layout
+
+Implementation plan for [spec 390](spec.md). Translates the spec's "every
+package uses the same on-disk shape" mandate into concrete, ordered changes
+across all 47 packages (4 products, 9 services, 34 libraries).
+
+## Approach
+
+This is a repo-wide rename. It touches every package, every published
+`package.json`, the codegen pipeline, and several doc surfaces. It lands on a
+single feature branch as a stack of verified commits and merges atomically —
+the spec's "one big diff" guidance is respected at merge time, not authoring
+time.
+
+The plan decomposes the work into **eight sequential parts** along
+infrastructure seams. Each part is independently verifiable but all parts are
+executed in order on the same branch. The branch is merged as one commit.
+
+**Guiding principles:**
+
+1. **The `exports` map absorbs the move.** Package-external import specifiers
+   (`@forwardimpact/foo/bar`) do not change. Only `package.json` targets move.
+   Consumer code edits are required only when a test or internal file uses a
+   relative path that crosses the new `src/` boundary.
+
+2. **No build step, no proxy files.** Published `main`, `bin`, and `exports`
+   point directly at `src/`. The spec explicitly rejects publish-time flatten
+   and root-level `index.js` proxies.
+
+3. **Contract before enforcement.** The allowed-root-subdirs check is
+   introduced first (Part 01) and toggled to strict enforcement last (Part 08)
+   once every package conforms. A permissive/`--dry-run` mode during the
+   migration lets the implementer see remaining drift at every step.
+
+4. **Test relative imports are the main call-site churn.** `test/foo.test.js`
+   files that import `../bar.js` need to become `../src/bar.js` after the
+   source file moves. External call sites remain unchanged because the
+   `exports` map handles the remap.
+
+5. **Services are the one exception.** `services/<name>/index.js` and
+   `services/<name>/server.js` stay at the service root — they are loaded by
+   fixed path from `config/config.example.json` (and service commands in the
+   live `config.json`). Only `services/pathway` has any real work (the spec's
+   stray `src/serialize.js` is already in the right place but the root files
+   do not yet import from `src/`).
+
+6. **Codegen output moves atomically with its consumers.** The monorepo-root
+   `generated/` directory is the real output target and does **not** move —
+   libstorage's `"generated"` bucket still resolves to it. What moves is
+   the **symlinks**: `libraries/librpc/generated` and `libraries/libtype/generated`
+   become `libraries/librpc/src/generated` and `libraries/libtype/src/generated`.
+   The symlinks are recreated by `fit-codegen` via
+   `libutil/finder.js#findGeneratedPath` (one-line change, line 117). The
+   internal `./generated/...` imports inside the moved `librpc` and
+   `libtype` sources resolve unchanged because the symlink moves with the
+   importing file. Part 02 does the finder change, the librpc/libtype file
+   moves, and the codegen re-run as one commit.
+
+## Part index
+
+Execute parts sequentially on branch `feat/390-consistent-package-layout`. Each
+part has its own plan file with scope, file list, ordering, and verification
+steps.
+
+| # | File | Scope | Agent |
+| --- | --- | --- | --- |
+| 01 | [plan-a-01.md](plan-a-01.md) | Allowed-root-subdirs check infrastructure (permissive mode) | staff-engineer |
+| 02 | [plan-a-02.md](plan-a-02.md) | Codegen pipeline: move `generated/` → `src/generated/` | staff-engineer |
+| 03 | [plan-a-03.md](plan-a-03.md) | Services: fix `services/pathway/`, document the services exception | staff-engineer |
+| 04 | [plan-a-04.md](plan-a-04.md) | `libharness` full restructure + stale `packages/` deletion | staff-engineer |
+| 05 | [plan-a-05.md](plan-a-05.md) | Products: map, guide, basecamp, pathway | staff-engineer |
+| 06 | [plan-a-06.md](plan-a-06.md) | Libraries tier A (published subpath exports, higher blast radius) | staff-engineer |
+| 07 | [plan-a-07.md](plan-a-07.md) | Libraries tier B (no subpath exports, lower blast radius) | staff-engineer |
+| 08 | [plan-a-08.md](plan-a-08.md) | Enable strict enforcement, rewrite `CLAUDE.md § Structure`, update skills and internals docs, publish smoke test | staff-engineer + technical-writer |
+
+## Part dependency graph
+
+```
+  01 (check infra, permissive)
+    │
+    ▼
+  02 (codegen: libstorage + symlinks + librpc/libtype imports)
+    │
+    ▼
+  03 (services/pathway)
+    │
+    ▼
+  04 (libharness)
+    │
+    ▼
+  05 (products) ──┐
+                  ├──► 06 and 07 (libraries, could parallelise in principle
+  06 (libs tier A)│        but run sequentially because they all touch
+                  │        package.json and we want one authoritative diff)
+  07 (libs tier B)┘
+    │
+    ▼
+  08 (strict enforcement + docs + smoke test)
+```
+
+## Execution
+
+Run every part sequentially on a single `feat/390-consistent-package-layout`
+branch cut from `main`. Each part ends with `bun run check` and `bun run test`
+passing — if either fails the part is not complete. Commit per part using the
+commit message convention `refactor(layout): <one-line summary>` and push
+after each commit so the branch reflects incremental progress.
+
+Route every part to **`staff-engineer`**. Part 08 has a documentation
+component that is large enough to hand off; the handoff is a final step
+_inside_ Part 08 that launches the `technical-writer` subagent for the prose
+updates and then resumes in `staff-engineer` for the smoke test and STATUS
+update. See Part 08 for the exact handoff boundary.
+
+Do **not** parallelise parts. Every part modifies `package.json` files, which
+means parallel branches would conflict on every merge. Sequential is cheaper
+than the merge-conflict tax.
+
+## Cross-cutting conventions
+
+These conventions apply inside every part — restated here so each part can
+assume them without repetition.
+
+### File move recipe (per package)
+
+For a non-service package that today has root-level `.js` sources:
+
+```
+1. mkdir -p <pkg>/src
+2. git mv <pkg>/*.js <pkg>/src/        # only root source, not test/
+3. git mv <pkg>/<domain-dir>/ <pkg>/src/<domain-dir>/   # for each non-allowed root subdir
+4. Update package.json:
+     main       → ./src/index.js         (or remove if redundant with exports)
+     bin.*      → unchanged (bin stays at root)
+     exports    → all "./foo" values rewritten to "./src/foo" and
+                  all "./<dir>/x.js" rewritten to "./src/<dir>/x.js"
+     files      → ["src/**/*.js", "bin/**/*.js"] (plus README.md, etc.)
+5. Update test/*.test.js relative imports:
+     "../foo.js"  →  "../src/foo.js"
+     "../<dir>/x" →  "../src/<dir>/x"
+6. Update bin/<entry>.js imports that reach into the package:
+     "../foo.js"  →  "../src/foo.js"
+7. Run `bun run node --test test/*.test.js` at the package root to verify.
+```
+
+Internal imports _within_ `src/` (e.g., `./helper.js` → `./helper.js`) are
+unchanged — the files move together, relative paths are preserved.
+
+### package.json invariants
+
+After the move, every published package conforms to this shape:
+
+```jsonc
+{
+  "main": "./src/index.js",          // omitted if exports["."] is set
+  "bin": { "fit-<name>": "./bin/fit-<name>.js" }, // only if the package has a CLI
+  "exports": {
+    ".": "./src/index.js",
+    "./foo": "./src/foo.js"
+    // ... per subpath
+  },
+  "files": ["src/**/*.js", "bin/**/*.js", "README.md"]
+}
+```
+
+For services, the shape stays:
+
+```jsonc
+{
+  "main": "./index.js",
+  "files": ["index.js", "server.js", "proto/**", "src/**/*.js", "README.md"]
+}
+```
+
+### Git history preservation
+
+Use `git mv` (not `cp` + `rm`) for every file move so `git log --follow` keeps
+working. Do not batch-move across packages in a single commit — one commit per
+part keeps the diff reviewable.
+
+### Verification per part
+
+Every part ends with:
+
+1. `bun run check` — format and lint clean
+2. `bun run test` — all tests pass, no skipped/disabled tests
+3. `bun run layout` — new allowed-root-subdirs check (introduced in Part 01)
+   must pass against the packages touched by this part, even in permissive
+   mode where remaining drift is allowed
+4. Spot-check one `--help` invocation of any CLI the part touched
+5. Commit and push
+
+## Known plan decisions and risks
+
+These choices were made during planning. Flag them to the reviewer before
+execution if any are wrong.
+
+1. **`products/basecamp/template/` → `products/basecamp/templates/`.** The
+   spec's allowed-list uses the plural `templates/` (as `products/pathway/`
+   already does). Basecamp's `template/` (singular, a single KB template
+   project) is not on the allowed list. The plan renames it to the plural
+   form in Part 05. **If the spec author wants to keep the singular name, the
+   allowed-list in Part 01 and the CLAUDE.md update in Part 08 must add
+   `template/` instead and this rename drops out.**
+
+2. **`libraries/libskill/policies/` → `libraries/libskill/src/policies/`.**
+   The spec's non-conforming-root-subdirs table does not list `policies/`, but
+   the inventory shows `libraries/libskill/policies/` exists and is exported
+   via `./policies`. Under the general rule ("any further subdirectories
+   under `src/` are free-form"), `policies/` moves into `src/` with the rest
+   of libskill. This is consistent with the spec's intent but not explicit.
+
+3. **`services/web` has no `proto/` directory.** All other services have
+   `proto/`. Web is the odd one because it is an HTTP-only service. This
+   remains the case after the move — `proto/` is optional per the allowed-list.
+   No action required; flagged so the check in Part 01 does not trip.
+
+4. **Root `generated/` directory stays at the monorepo root.** It is not a
+   package. The spec's item "move generated code out of the package root"
+   refers to generated code _inside a package_. The root `generated/` is
+   outside any package and is the real codegen output target. What moves is
+   the **symlinks** that point into it from `librpc` and `libtype`, not the
+   root directory itself.
+
+5. **Symlinks live under `src/generated/` inside each consumer.** After Part
+   02, `libraries/librpc/src/generated` and `libraries/libtype/src/generated`
+   are symlinks to `../../../../generated`. The relative imports become
+   `./generated/services/exports.js` (from `src/index.js`) which resolves
+   through the symlink to the real generated output. This preserves the "no
+   root-level source in libraries" rule while keeping the single generated
+   output tree.
+
+6. **Published subpath export keys are frozen.** The set of public keys (the
+   left-hand side of the `exports` map) is identical before and after the
+   move. Only right-hand side targets change. This makes success criterion #9
+   mechanically verifiable: diff the sorted set of keys from every
+   `package.json` pre-move against post-move and require zero diff.
+
+7. **`just check` is actually `bun run check`.** The current root `justfile`
+   has no `check` recipe — the spec references `just check` but the
+   implementation target is `bun run check` in `package.json`. Part 01 adds
+   `bun run layout` as a new script and wires it into `bun run check`
+   (`"check": "bun run format && bun run lint && bun run layout"`). CI workflow
+   `check-quality.yml` gets a new job that runs `bun run layout`.
+
+8. **Single-commit atomicity is at merge, not commit.** The spec says the
+   change should land in a single commit "during a quiet window." The plan
+   produces one commit per part on the branch and relies on squash-merge at
+   PR time for the atomic history entry. If the release-engineer prefers
+   rebase-merge, Part 08 can conclude with an interactive rebase to squash
+   the eight part commits into one before the PR is marked ready.
+
+## Risks
+
+1. **Published subpath silent blast radius.** The `@forwardimpact/map`
+   package has 25 subpath export keys (including the `activity/*` set); any
+   missed key in the rewrite breaks downstream installations only when a
+   consumer happens to import that subpath. Mitigation: Part 08 runs a
+   fresh-install smoke test in a clean directory that imports every published
+   subpath key and asserts it resolves. The test is generated from the live
+   `exports` map, so it self-updates when new keys land.
+
+2. **Merge conflicts with in-flight branches.** Any open PR that edits files
+   under `libraries/*` or `products/*` will conflict hard against this
+   branch. Mitigation: coordinate a quiet window with product-manager and
+   release-engineer before landing the final squash, and rebase other open
+   branches immediately after.
+
+3. **Codegen drift if Part 02 is interrupted.** If Part 02 commits the
+   libstorage bucket-prefix change but not the symlink update, the next
+   `just codegen` run writes to `src/generated/` while `librpc` still imports
+   from the old symlink target. Mitigation: Part 02 is atomic — the libstorage
+   change, the symlink update, the two import rewrites in `librpc`/`libtype`,
+   and a `just codegen && bun run test` verification all land in one commit.
+
+4. **Test relative imports missed by the initial rewrite.** Some tests import
+   from `../../<dir>/file.js` instead of `../<file>.js` — easy to miss with a
+   simple search-and-replace. Mitigation: the per-part verification step runs
+   `bun run node --test test/*.test.js` at the package root, which surfaces
+   any unresolved relative import immediately. Any missed import is fixed
+   before moving to the next package.
+
+5. **`libeval` already has `src/` AND a root `index.js`.** It is half-migrated.
+   Part 07 finishes the job: the root `index.js` moves into `src/index.js` and
+   the existing `src/commands/` tree is unchanged.
+
+6. **`libskill/node_modules/` appears as a root subdir.** Bun installs
+   workspace deps there; it is gitignored and does not affect the layout
+   check (the check operates on `git ls-files`, not on the working tree).
+   Confirmed by `git check-ignore`.
+
+## References
+
+- Spec: [spec.md](spec.md)
+- Current `CLAUDE.md § Structure`: lines 143–175 — out of date (references
+  `landmark/`, `summit/` which do not exist as packages).
+- Codegen storage bucket (unchanged by this plan):
+  `libraries/libstorage/index.js` lines 114–123 (`case "generated"`)
+- Codegen symlink target (changed by Part 02):
+  `libraries/libutil/finder.js#findGeneratedPath` line 115–118;
+  `#createPackageSymlinks` line 156–166
+- Service command paths:
+  `config/config.example.json` lines 20, 24, 28, 32, 36, 40, 44, 48, 52
+- Subpath export inventory: 112 keys across 25 libraries + 2 products
+- libharness call sites: ~23 test files across services and libraries
+
+— Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a.md
+++ b/specs/390-consistent-package-layout/plan-a.md
@@ -253,12 +253,14 @@ execution if any are wrong.
 ## Risks
 
 1. **Published subpath silent blast radius.** The `@forwardimpact/map`
-   package has 25 subpath export keys (including the `activity/*` set); any
-   missed key in the rewrite breaks downstream installations only when a
-   consumer happens to import that subpath. Mitigation: Part 08 runs a
-   fresh-install smoke test in a clean directory that imports every published
-   subpath key and asserts it resolves. The test is generated from the live
-   `exports` map, so it self-updates when new keys land.
+   package ships 25 export keys (the `"."` root + 24 subpaths, including
+   the `activity/*` set). libskill ships 13. libui ships 15. Across all
+   packages there are ≈112 export keys total. Any missed key in the
+   rewrite breaks downstream installations only when a consumer happens
+   to import that subpath — not at build time. Mitigation: Part 08 runs
+   a fresh-install smoke test in a clean directory that imports every
+   published subpath key and asserts it resolves. The test is generated
+   from the live `exports` map, so it self-updates when new keys land.
 
 2. **Merge conflicts with in-flight branches.** Any open PR that edits files
    under `libraries/*` or `products/*` will conflict hard against this
@@ -285,9 +287,12 @@ execution if any are wrong.
    the existing `src/commands/` tree is unchanged.
 
 6. **`libskill/node_modules/` appears as a root subdir.** Bun installs
-   workspace deps there; it is gitignored and does not affect the layout
-   check (the check operates on `git ls-files`, not on the working tree).
-   Confirmed by `git check-ignore`.
+   workspace deps there; it is gitignored. The Part 01 layout check
+   walks the working tree (`readdirSync`), not `git ls-files`, but
+   explicitly skips `node_modules/` in its allow-list (see
+   `IGNORED_SUBDIRS` in `scripts/check-package-layout.js`). Confirmed
+   by `git check-ignore libraries/libskill/node_modules` — returns the
+   path, so it is gitignored.
 
 ## References
 
@@ -302,6 +307,7 @@ execution if any are wrong.
 - Service command paths:
   `config/config.example.json` lines 20, 24, 28, 32, 36, 40, 44, 48, 52
 - Subpath export inventory: 112 keys across 25 libraries + 2 products
+  (map alone contributes 25 keys: 1 root `"."` + 24 subpaths)
 - libharness call sites: ~23 test files across services and libraries
 
 — Staff Engineer 🛠️

--- a/specs/390-consistent-package-layout/plan-a.md
+++ b/specs/390-consistent-package-layout/plan-a.md
@@ -8,9 +8,8 @@ across all 47 packages (4 products, 9 services, 34 libraries).
 
 This is a repo-wide rename. It touches every package, every published
 `package.json`, the codegen pipeline, and several doc surfaces. It lands on a
-single feature branch as a stack of verified commits and merges atomically —
-the spec's "one big diff" guidance is respected at merge time, not authoring
-time.
+single feature branch as a stack of verified commits and merges atomically — the
+spec's "one big diff" guidance is respected at merge time, not authoring time.
 
 The plan decomposes the work into **eight sequential parts** along
 infrastructure seams. Each part is independently verifiable but all parts are
@@ -27,32 +26,32 @@ executed in order on the same branch. The branch is merged as one commit.
    point directly at `src/`. The spec explicitly rejects publish-time flatten
    and root-level `index.js` proxies.
 
-3. **Contract before enforcement.** The allowed-root-subdirs check is
-   introduced first (Part 01) and toggled to strict enforcement last (Part 08)
-   once every package conforms. A permissive/`--dry-run` mode during the
-   migration lets the implementer see remaining drift at every step.
+3. **Contract before enforcement.** The allowed-root-subdirs check is introduced
+   first (Part 01) and toggled to strict enforcement last (Part 08) once every
+   package conforms. A permissive/`--dry-run` mode during the migration lets the
+   implementer see remaining drift at every step.
 
 4. **Test relative imports are the main call-site churn.** `test/foo.test.js`
-   files that import `../bar.js` need to become `../src/bar.js` after the
-   source file moves. External call sites remain unchanged because the
-   `exports` map handles the remap.
+   files that import `../bar.js` need to become `../src/bar.js` after the source
+   file moves. External call sites remain unchanged because the `exports` map
+   handles the remap.
 
 5. **Services are the one exception.** `services/<name>/index.js` and
    `services/<name>/server.js` stay at the service root — they are loaded by
    fixed path from `config/config.example.json` (and service commands in the
    live `config.json`). Only `services/pathway` has any real work (the spec's
-   stray `src/serialize.js` is already in the right place but the root files
-   do not yet import from `src/`).
+   stray `src/serialize.js` is already in the right place but the root files do
+   not yet import from `src/`).
 
 6. **Codegen output moves atomically with its consumers.** The monorepo-root
    `generated/` directory is the real output target and does **not** move —
-   libstorage's `"generated"` bucket still resolves to it. What moves is
-   the **symlinks**: `libraries/librpc/generated` and `libraries/libtype/generated`
-   become `libraries/librpc/src/generated` and `libraries/libtype/src/generated`.
-   The symlinks are recreated by `fit-codegen` via
-   `libutil/finder.js#findGeneratedPath` (one-line change, line 117). The
-   internal `./generated/...` imports inside the moved `librpc` and
-   `libtype` sources resolve unchanged because the symlink moves with the
+   libstorage's `"generated"` bucket still resolves to it. What moves is the
+   **symlinks**: `libraries/librpc/generated` and `libraries/libtype/generated`
+   become `libraries/librpc/src/generated` and
+   `libraries/libtype/src/generated`. The symlinks are recreated by
+   `fit-codegen` via `libutil/finder.js#findGeneratedPath` (one-line change,
+   line 117). The internal `./generated/...` imports inside the moved `librpc`
+   and `libtype` sources resolve unchanged because the symlink moves with the
    importing file. Part 02 does the finder change, the librpc/libtype file
    moves, and the codegen re-run as one commit.
 
@@ -62,16 +61,16 @@ Execute parts sequentially on branch `feat/390-consistent-package-layout`. Each
 part has its own plan file with scope, file list, ordering, and verification
 steps.
 
-| # | File | Scope | Agent |
-| --- | --- | --- | --- |
-| 01 | [plan-a-01.md](plan-a-01.md) | Allowed-root-subdirs check infrastructure (permissive mode) | staff-engineer |
-| 02 | [plan-a-02.md](plan-a-02.md) | Codegen pipeline: move `generated/` → `src/generated/` | staff-engineer |
-| 03 | [plan-a-03.md](plan-a-03.md) | Services: fix `services/pathway/`, document the services exception | staff-engineer |
-| 04 | [plan-a-04.md](plan-a-04.md) | `libharness` full restructure + stale `packages/` deletion | staff-engineer |
-| 05 | [plan-a-05.md](plan-a-05.md) | Products: map, guide, basecamp, pathway | staff-engineer |
-| 06 | [plan-a-06.md](plan-a-06.md) | Libraries tier A (published subpath exports, higher blast radius) | staff-engineer |
-| 07 | [plan-a-07.md](plan-a-07.md) | Libraries tier B (no subpath exports, lower blast radius) | staff-engineer |
-| 08 | [plan-a-08.md](plan-a-08.md) | Enable strict enforcement, rewrite `CLAUDE.md § Structure`, update skills and internals docs, publish smoke test | staff-engineer + technical-writer |
+| #   | File                         | Scope                                                                                                            | Agent                             |
+| --- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| 01  | [plan-a-01.md](plan-a-01.md) | Allowed-root-subdirs check infrastructure (permissive mode)                                                      | staff-engineer                    |
+| 02  | [plan-a-02.md](plan-a-02.md) | Codegen pipeline: move `generated/` → `src/generated/`                                                           | staff-engineer                    |
+| 03  | [plan-a-03.md](plan-a-03.md) | Services: fix `services/pathway/`, document the services exception                                               | staff-engineer                    |
+| 04  | [plan-a-04.md](plan-a-04.md) | `libharness` full restructure + stale `packages/` deletion                                                       | staff-engineer                    |
+| 05  | [plan-a-05.md](plan-a-05.md) | Products: map, guide, basecamp, pathway                                                                          | staff-engineer                    |
+| 06  | [plan-a-06.md](plan-a-06.md) | Libraries tier A (published subpath exports, higher blast radius)                                                | staff-engineer                    |
+| 07  | [plan-a-07.md](plan-a-07.md) | Libraries tier B (no subpath exports, lower blast radius)                                                        | staff-engineer                    |
+| 08  | [plan-a-08.md](plan-a-08.md) | Enable strict enforcement, rewrite `CLAUDE.md § Structure`, update skills and internals docs, publish smoke test | staff-engineer + technical-writer |
 
 ## Part dependency graph
 
@@ -103,14 +102,14 @@ steps.
 Run every part sequentially on a single `feat/390-consistent-package-layout`
 branch cut from `main`. Each part ends with `bun run check` and `bun run test`
 passing — if either fails the part is not complete. Commit per part using the
-commit message convention `refactor(layout): <one-line summary>` and push
-after each commit so the branch reflects incremental progress.
+commit message convention `refactor(layout): <one-line summary>` and push after
+each commit so the branch reflects incremental progress.
 
-Route every part to **`staff-engineer`**. Part 08 has a documentation
-component that is large enough to hand off; the handoff is a final step
-_inside_ Part 08 that launches the `technical-writer` subagent for the prose
-updates and then resumes in `staff-engineer` for the smoke test and STATUS
-update. See Part 08 for the exact handoff boundary.
+Route every part to **`staff-engineer`**. Part 08 has a documentation component
+that is large enough to hand off; the handoff is a final step _inside_ Part 08
+that launches the `technical-writer` subagent for the prose updates and then
+resumes in `staff-engineer` for the smoke test and STATUS update. See Part 08
+for the exact handoff boundary.
 
 Do **not** parallelise parts. Every part modifies `package.json` files, which
 means parallel branches would conflict on every merge. Sequential is cheaper
@@ -185,8 +184,8 @@ Every part ends with:
 1. `bun run check` — format and lint clean
 2. `bun run test` — all tests pass, no skipped/disabled tests
 3. `bun run layout` — new allowed-root-subdirs check (introduced in Part 01)
-   must pass against the packages touched by this part, even in permissive
-   mode where remaining drift is allowed
+   must pass against the packages touched by this part, even in permissive mode
+   where remaining drift is allowed
 4. Spot-check one `--help` invocation of any CLI the part touched
 5. Commit and push
 
@@ -198,73 +197,73 @@ execution if any are wrong.
 1. **`products/basecamp/template/` → `products/basecamp/templates/`.** The
    spec's allowed-list uses the plural `templates/` (as `products/pathway/`
    already does). Basecamp's `template/` (singular, a single KB template
-   project) is not on the allowed list. The plan renames it to the plural
-   form in Part 05. **If the spec author wants to keep the singular name, the
+   project) is not on the allowed list. The plan renames it to the plural form
+   in Part 05. **If the spec author wants to keep the singular name, the
    allowed-list in Part 01 and the CLAUDE.md update in Part 08 must add
    `template/` instead and this rename drops out.**
 
-2. **`libraries/libskill/policies/` → `libraries/libskill/src/policies/`.**
-   The spec's non-conforming-root-subdirs table does not list `policies/`, but
-   the inventory shows `libraries/libskill/policies/` exists and is exported
-   via `./policies`. Under the general rule ("any further subdirectories
-   under `src/` are free-form"), `policies/` moves into `src/` with the rest
-   of libskill. This is consistent with the spec's intent but not explicit.
+2. **`libraries/libskill/policies/` → `libraries/libskill/src/policies/`.** The
+   spec's non-conforming-root-subdirs table does not list `policies/`, but the
+   inventory shows `libraries/libskill/policies/` exists and is exported via
+   `./policies`. Under the general rule ("any further subdirectories under
+   `src/` are free-form"), `policies/` moves into `src/` with the rest of
+   libskill. This is consistent with the spec's intent but not explicit.
 
 3. **`services/web` has no `proto/` directory.** All other services have
-   `proto/`. Web is the odd one because it is an HTTP-only service. This
-   remains the case after the move — `proto/` is optional per the allowed-list.
-   No action required; flagged so the check in Part 01 does not trip.
+   `proto/`. Web is the odd one because it is an HTTP-only service. This remains
+   the case after the move — `proto/` is optional per the allowed-list. No
+   action required; flagged so the check in Part 01 does not trip.
 
 4. **Root `generated/` directory stays at the monorepo root.** It is not a
-   package. The spec's item "move generated code out of the package root"
-   refers to generated code _inside a package_. The root `generated/` is
-   outside any package and is the real codegen output target. What moves is
-   the **symlinks** that point into it from `librpc` and `libtype`, not the
-   root directory itself.
+   package. The spec's item "move generated code out of the package root" refers
+   to generated code _inside a package_. The root `generated/` is outside any
+   package and is the real codegen output target. What moves is the **symlinks**
+   that point into it from `librpc` and `libtype`, not the root directory
+   itself.
 
-5. **Symlinks live under `src/generated/` inside each consumer.** After Part
-   02, `libraries/librpc/src/generated` and `libraries/libtype/src/generated`
-   are symlinks to `../../../../generated`. The relative imports become
+5. **Symlinks live under `src/generated/` inside each consumer.** After Part 02,
+   `libraries/librpc/src/generated` and `libraries/libtype/src/generated` are
+   symlinks to `../../../../generated`. The relative imports become
    `./generated/services/exports.js` (from `src/index.js`) which resolves
    through the symlink to the real generated output. This preserves the "no
    root-level source in libraries" rule while keeping the single generated
    output tree.
 
 6. **Published subpath export keys are frozen.** The set of public keys (the
-   left-hand side of the `exports` map) is identical before and after the
-   move. Only right-hand side targets change. This makes success criterion #9
+   left-hand side of the `exports` map) is identical before and after the move.
+   Only right-hand side targets change. This makes success criterion #9
    mechanically verifiable: diff the sorted set of keys from every
    `package.json` pre-move against post-move and require zero diff.
 
-7. **`just check` is actually `bun run check`.** The current root `justfile`
-   has no `check` recipe — the spec references `just check` but the
-   implementation target is `bun run check` in `package.json`. Part 01 adds
-   `bun run layout` as a new script and wires it into `bun run check`
+7. **`just check` is actually `bun run check`.** The current root `justfile` has
+   no `check` recipe — the spec references `just check` but the implementation
+   target is `bun run check` in `package.json`. Part 01 adds `bun run layout` as
+   a new script and wires it into `bun run check`
    (`"check": "bun run format && bun run lint && bun run layout"`). CI workflow
    `check-quality.yml` gets a new job that runs `bun run layout`.
 
-8. **Single-commit atomicity is at merge, not commit.** The spec says the
-   change should land in a single commit "during a quiet window." The plan
-   produces one commit per part on the branch and relies on squash-merge at
-   PR time for the atomic history entry. If the release-engineer prefers
-   rebase-merge, Part 08 can conclude with an interactive rebase to squash
-   the eight part commits into one before the PR is marked ready.
+8. **Single-commit atomicity is at merge, not commit.** The spec says the change
+   should land in a single commit "during a quiet window." The plan produces one
+   commit per part on the branch and relies on squash-merge at PR time for the
+   atomic history entry. If the release-engineer prefers rebase-merge, Part 08
+   can conclude with an interactive rebase to squash the eight part commits into
+   one before the PR is marked ready.
 
 ## Risks
 
-1. **Published subpath silent blast radius.** The `@forwardimpact/map`
-   package ships 25 export keys (the `"."` root + 24 subpaths, including
-   the `activity/*` set). libskill ships 13. libui ships 15. Across all
-   packages there are ≈112 export keys total. Any missed key in the
-   rewrite breaks downstream installations only when a consumer happens
-   to import that subpath — not at build time. Mitigation: Part 08 runs
-   a fresh-install smoke test in a clean directory that imports every
-   published subpath key and asserts it resolves. The test is generated
-   from the live `exports` map, so it self-updates when new keys land.
+1. **Published subpath silent blast radius.** The `@forwardimpact/map` package
+   ships 25 export keys (the `"."` root + 24 subpaths, including the
+   `activity/*` set). libskill ships 13. libui ships 15. Across all packages
+   there are ≈112 export keys total. Any missed key in the rewrite breaks
+   downstream installations only when a consumer happens to import that subpath
+   — not at build time. Mitigation: Part 08 runs a fresh-install smoke test in a
+   clean directory that imports every published subpath key and asserts it
+   resolves. The test is generated from the live `exports` map, so it
+   self-updates when new keys land.
 
 2. **Merge conflicts with in-flight branches.** Any open PR that edits files
-   under `libraries/*` or `products/*` will conflict hard against this
-   branch. Mitigation: coordinate a quiet window with product-manager and
+   under `libraries/*` or `products/*` will conflict hard against this branch.
+   Mitigation: coordinate a quiet window with product-manager and
    release-engineer before landing the final squash, and rebase other open
    branches immediately after.
 
@@ -278,20 +277,19 @@ execution if any are wrong.
 4. **Test relative imports missed by the initial rewrite.** Some tests import
    from `../../<dir>/file.js` instead of `../<file>.js` — easy to miss with a
    simple search-and-replace. Mitigation: the per-part verification step runs
-   `bun run node --test test/*.test.js` at the package root, which surfaces
-   any unresolved relative import immediately. Any missed import is fixed
-   before moving to the next package.
+   `bun run node --test test/*.test.js` at the package root, which surfaces any
+   unresolved relative import immediately. Any missed import is fixed before
+   moving to the next package.
 
 5. **`libeval` already has `src/` AND a root `index.js`.** It is half-migrated.
    Part 07 finishes the job: the root `index.js` moves into `src/index.js` and
    the existing `src/commands/` tree is unchanged.
 
-6. **`libskill/node_modules/` appears as a root subdir.** Bun installs
-   workspace deps there; it is gitignored. The Part 01 layout check
-   walks the working tree (`readdirSync`), not `git ls-files`, but
-   explicitly skips `node_modules/` in its allow-list (see
-   `IGNORED_SUBDIRS` in `scripts/check-package-layout.js`). Confirmed
-   by `git check-ignore libraries/libskill/node_modules` — returns the
+6. **`libskill/node_modules/` appears as a root subdir.** Bun installs workspace
+   deps there; it is gitignored. The Part 01 layout check walks the working tree
+   (`readdirSync`), not `git ls-files`, but explicitly skips `node_modules/` in
+   its allow-list (see `IGNORED_SUBDIRS` in `scripts/check-package-layout.js`).
+   Confirmed by `git check-ignore libraries/libskill/node_modules` — returns the
    path, so it is gitignored.
 
 ## References
@@ -304,10 +302,10 @@ execution if any are wrong.
 - Codegen symlink target (changed by Part 02):
   `libraries/libutil/finder.js#findGeneratedPath` line 115–118;
   `#createPackageSymlinks` line 156–166
-- Service command paths:
-  `config/config.example.json` lines 20, 24, 28, 32, 36, 40, 44, 48, 52
-- Subpath export inventory: 112 keys across 25 libraries + 2 products
-  (map alone contributes 25 keys: 1 root `"."` + 24 subpaths)
+- Service command paths: `config/config.example.json` lines 20, 24, 28, 32, 36,
+  40, 44, 48, 52
+- Subpath export inventory: 112 keys across 25 libraries + 2 products (map alone
+  contributes 25 keys: 1 root `"."` + 24 subpaths)
 - libharness call sites: ~23 test files across services and libraries
 
 — Staff Engineer 🛠️

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -54,4 +54,4 @@
 360	done
 370	planned
 380	done
-390	review
+390	planned


### PR DESCRIPTION
## Summary

- Translates [spec 390](../blob/main/specs/390-consistent-package-layout/spec.md) (consistent package layout across the monorepo) into an 8-part execution plan on a single feature branch.
- Decomposes into `plan-a.md` + `plan-a-01.md` through `plan-a-08.md` (~3100 lines total) covering: check infrastructure, codegen pipeline, services, libharness, products, 15 tier-A libraries, 16 tier-B libraries, and the enforcement/docs/smoke-test close.
- Advances `specs/STATUS` from `390 review` → `390 planned`.
- No code changes — this PR ships the plan files, a STATUS advancement, and a wiki submodule memory update only. The implementation arc starts once this lands.

## Plan highlights

- **Contract before enforcement.** Part 01 adds `bun run layout` in permissive mode; Part 08 flips it to strict after every package conforms.
- **Codegen pipeline is a one-line change.** `libutil/finder.js#findGeneratedPath` line 117 retargets the per-package symlinks from `<pkg>/generated` → `<pkg>/src/generated`. The monorepo-root `generated/` directory is unchanged — libstorage stays untouched so `Finder.findUpward` keeps resolving.
- **Symlinks are never published.** `npm pack --dry-run` confirmed that librpc's current tarball has 13 files and drops the `generated/` symlink silently. Consumers run `npx fit-codegen` post-install; the migration preserves this model.
- **Services are verification-only.** The spec's claim about `services/pathway` referencing root-level files is stale — `index.js` line 20 already imports `./src/serialize.js` on main.
- **Tier-B library `bin/` entries are mirrored into the exports map.** Locking down `libsupervise` to `{ ".": "./src/index.js" }` alone would break `librc/manager.js:12`'s `require.resolve("@forwardimpact/libsupervise/bin/fit-svscan.js")` at runtime. Case B of Part 07 addresses this.
- **Clean sub-agent review completed.** Fresh-context reviewer flagged 1 blocker + 3 high + 6 medium + 3 low findings; all blocker/high/medium addressed in the `ccbfc68` follow-up commit.
- **Part 08 Stage 2 is handed off to the technical-writer sub-agent** for the `CLAUDE.md § Structure` rewrite, internals doc updates, and skill file path refreshes.

## Test plan

- [x] `bun run check` — passes (format + lint + permissive layout check)
- [x] `bun run test` — 2159/2160 pass (1 pre-existing skip, 0 failures)
- [x] Clean sub-agent review (gemba-plan DO-CONFIRM)
- [ ] Execution happens on a follow-up `feat/390-consistent-package-layout` branch via the `plan-specs` → `implement-plans` workflow
