### PR TITLE
chore(scripts): ignore `generated/` in package layout check

### DIFF
--- a/scripts/check-package-layout.js
+++ b/scripts/check-package-layout.js
@@ -20,7 +20,10 @@ const ALLOWED_SUBDIRS = new Set([
 ]);
 
 // Dirs the working tree may contain but that are gitignored / out of scope.
-const IGNORED_SUBDIRS = new Set(["node_modules"]);
+// `generated` is created by `fit-codegen` (it symlinks the root ./generated/
+// dir into libraries/libtype and libraries/librpc); it's gitignored, so the
+// layout check should ignore it too.
+const IGNORED_SUBDIRS = new Set(["node_modules", "generated"]);
 
 const TIERS = ["products", "services", "libraries"];
 const strict = !process.argv.includes("--no-strict");


### PR DESCRIPTION
## Summary

Add `generated` to `IGNORED_SUBDIRS` in `scripts/check-package-layout.js` so the layout check doesn't trip on `fit-codegen` symlinks.

`Finder.createPackageSymlinks` (in `libraries/libutil/src/finder.js`) symlinks the root `./generated/` directory into `libraries/libtype` and `libraries/librpc` whenever codegen runs. Spec 390 (#322) moved the symlink target from `<package>/generated` to `<package>/src/generated`, which keeps it out of the layout check's view on a clean tree — but worktrees that ran codegen before #322 landed still have stale `<package>/generated` symlinks at the root level. `check-package-layout.js` calls `statSync` (not `lstat`), so it follows the symlink and reports `generated` as a non-allowlisted subdir.

Both `node_modules` and `generated` are gitignored and out of scope for the spec 390 contract. Adding `generated` to the existing `IGNORED_SUBDIRS` set makes the check robust against either symlink location.

This is a defensive guard, not a fix for a bug on current `main` — a freshly-cloned tree only places the symlinks under `src/`, so today's CI doesn't trip on it. The change protects local environments with stale pre-#322 symlinks and prevents future regressions if codegen ever generates at the package root again.

## Test plan

- [x] `bun run check` (format, lint, layout, check:exports)
- [x] `bun run test` — 2159 pass, 0 fail, 1 skipped
- [x] Verified `bun run layout` still passes against both layouts (clean post-spec-390 tree, and a tree with stale `libraries/{librpc,libtype}/generated` root symlinks)