### PR TITLE
fix(libskill): re-export getSkillTypeForDiscipline from ./derivation.js

### DIFF
--- a/libraries/libskill/src/index.js
+++ b/libraries/libskill/src/index.js
@@ -23,6 +23,7 @@ export {
   generateJobId,
   deriveJob,
   getDisciplineSkillIds,
+  getSkillTypeForDiscipline,
   generateAllJobs,
 } from "./derivation.js";
 
@@ -43,7 +44,6 @@ export { buildJobKey, createJobCache } from "./job-cache.js";
 export {
   isCapability,
   getSkillsByCapability,
-  getSkillTypeForDiscipline,
   buildCapabilityToSkillsMap,
   expandModifiersToSkills,
   extractCapabilityModifiers,

--- a/libraries/libskill/test/index-root-exports.test.js
+++ b/libraries/libskill/test/index-root-exports.test.js
@@ -1,0 +1,88 @@
+/**
+ * Regression test for the root package import.
+ *
+ * The root `src/index.js` re-exports a curated surface from several
+ * submodules. Re-exporting a name from the wrong submodule produces an
+ * ESM `SyntaxError: export 'X' not found in './module.js'` at link time —
+ * which no existing test catches because every other test imports
+ * directly from its submodule under test. This test imports the root,
+ * which exercises the full re-export graph and fails loudly if any
+ * re-export is misrouted.
+ *
+ * History: `getSkillTypeForDiscipline` was re-exported from `./modifiers.js`
+ * but defined in `./derivation.js`, silently breaking the root import.
+ * The bug was only discovered when a new consumer (outside the monorepo's
+ * own import conventions) tried to import from the package root.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import * as libskill from "@forwardimpact/libskill";
+
+test("root import resolves without ESM link errors", () => {
+  // If any re-export in src/index.js points at the wrong submodule,
+  // the import above throws at module-graph link time and this test
+  // never even runs. Arrival here already means the root links cleanly.
+  assert.ok(libskill, "root import returned a module namespace");
+});
+
+test("every documented export is callable from the root", () => {
+  // Keep this list aligned with src/index.js. Any function that the
+  // root re-exports should appear here so misrouted re-exports break
+  // immediately.
+  const expected = [
+    // Core derivation
+    "deriveSkillMatrix",
+    "deriveBehaviourProfile",
+    "generateJobTitle",
+    "generateJobId",
+    "deriveJob",
+    "getDisciplineSkillIds",
+    "getSkillTypeForDiscipline",
+    "generateAllJobs",
+    "isValidJobCombination",
+    "deriveResponsibilities",
+    // Job operations
+    "prepareJobDetail",
+    "prepareJobSummary",
+    "prepareJobBuilderPreview",
+    // Job caching
+    "buildJobKey",
+    "createJobCache",
+    // Modifiers
+    "isCapability",
+    "getSkillsByCapability",
+    "buildCapabilityToSkillsMap",
+    "expandModifiersToSkills",
+    "extractCapabilityModifiers",
+    "extractSkillModifiers",
+    "resolveSkillModifier",
+    // Matching
+    "calculateJobMatch",
+    "findMatchingJobs",
+    "estimateBestFitLevel",
+    "findRealisticMatches",
+    // Development path
+    "deriveDevelopmentPath",
+    "findNextStepJob",
+    "analyzeCandidate",
+    // Progression
+    "analyzeProgression",
+    "analyzeLevelProgression",
+    "analyzeTrackComparison",
+    "getValidTracksForComparison",
+    "getNextLevel",
+    "getPreviousLevel",
+    "analyzeCustomProgression",
+    "getValidLevelTrackCombinations",
+  ];
+
+  for (const name of expected) {
+    assert.equal(
+      typeof libskill[name],
+      "function",
+      `libskill.${name} should be a function at the root`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

The root `@forwardimpact/libskill` import is broken under strict ESM linking. `src/index.js` tries to re-export `getSkillTypeForDiscipline` from `./modifiers.js`, but the function is defined in `./derivation.js`. Importing from the package root throws at module-graph link time:

```
SyntaxError: export 'getSkillTypeForDiscipline' not found in './modifiers.js'
```

### Why CI didn't catch it

Every libskill consumer in the monorepo imports via subpath exports — Pathway uses `@forwardimpact/libskill/derivation`, `/agent`, `/job`, etc. (see `products/pathway/src/formatters/skill/shared.js:11` and ~30 other call sites). libskill's own test suite imports the submodule under test directly (e.g. `test/modifiers.test.js:4` imports from `../src/modifiers.js`), never from the root. The failing re-export path has been unexercised since the spec 390 layout refactor (#322).

The bug surfaced during manual testing of an external import pattern for a new product: a plan that wrote `import { deriveSkillMatrix } from "@forwardimpact/libskill"` failed immediately.

### Fix

One-line change in `libraries/libskill/src/index.js`: move `getSkillTypeForDiscipline` into the derivation re-export block.

### Regression test

`libraries/libskill/test/index-root-exports.test.js` imports from the package root and asserts every documented export resolves. Any future misrouted re-export fails this test at ESM link time — the same failure mode that let the original bug slip through.

**Verified via negative control.** Temporarily reverted the fix in the working tree, ran the new test: it failed with the exact original `SyntaxError`. Restored the fix, ran the full suite: **2161 pass, 0 fail** (2159 previous + 2 new).

## Test plan

- [x] `bun test libraries/libskill/test/index-root-exports.test.js` → 2 pass
- [x] `bun run test` → 2161/2162 pass (1 pre-existing skip, 0 fail)
- [x] `bun run format` → clean
- [x] `bun run lint` → clean
- [x] `bun run check:exports` → all 210 targets across 47 packages resolve
- [x] Negative control: reverting the one-line fix reproduces the exact original error in the new regression test
- [x] `bun -e 'import("@forwardimpact/libskill").then(m => console.log(typeof m.deriveSkillMatrix))'` → `function` (was `FAIL` on main)

## Notes

- No `package.json` version bump — leaving version management to the release-engineer workflow.
- No changes to any consumer — Pathway's existing subpath imports continue to work unchanged; this fix strictly restores a broken alternative import path.
- `bun run layout` fails on pre-existing gitignored `libraries/librpc/generated/` and `libraries/libtype/generated/` directories produced by codegen. Confirmed by stashing my changes and re-running against clean `main` — same failure. Unrelated to this PR; worth a follow-up to add `generated` to `IGNORED_SUBDIRS` in `scripts/check-package-layout.js`.

https://claude.ai/code/session_01418DLMU1fUwHDKxjeyrRZS