### PR TITLE
docs(summit): expand leadership guide and add summit-setup scenario

### DIFF
--- a/.github/workflows/summit-setup.yml
+++ b/.github/workflows/summit-setup.yml
@@ -1,0 +1,83 @@
+name: "Gemba: Summit Setup"
+
+on:
+  workflow_dispatch: # Manual trigger for on-demand evaluation
+    inputs:
+      task-amend:
+        description: "Additional text appended to the task prompt for steering"
+        required: false
+        type: string
+
+concurrency:
+  group: summit-setup
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - name: Generate LLM token
+        id: llm-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.LLM_APP_ID }}
+          private-key: ${{ secrets.LLM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.ci-app.outputs.token }}
+          submodules: true
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: Prepare agent workspace
+        id: agent-workspace
+        shell: bash
+        run: |
+          agent_dir=$(mktemp -d)
+
+          # Generate all synthetic data using cached prose — this produces
+          # data/pathway/ (framework) and data/activity/raw/activity/summit.yaml
+          # (roster).
+          bunx fit-universe
+
+          mkdir -p "$agent_dir/data"
+          cp -r data/pathway "$agent_dir/data/pathway"
+          cp data/activity/raw/activity/summit.yaml "$agent_dir/summit.yaml"
+
+          cp scenarios/summit-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
+          echo "dir=$agent_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate Summit Setup
+        uses: ./.github/actions/gemba-action
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LLM_TOKEN: ${{ steps.llm-app.outputs.token }}
+          LLM_BASE_URL: https://models.github.ai/orgs/forwardimpact
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          mode: "supervise"
+          task-file: scenarios/summit-setup/task.md
+          supervisor-cwd: "."
+          agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
+          supervisor-profile: "product-manager"
+          model: "opus"
+          max-turns: "200"
+          allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,WebFetch,WebSearch"
+          supervisor-allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,Skill,TodoWrite"
+          task-amend: ${{ inputs.task-amend }}

--- a/scenarios/summit-setup/agent/CLAUDE.md
+++ b/scenarios/summit-setup/agent/CLAUDE.md
@@ -1,0 +1,5 @@
+You are a developer trying a product for the first time. Follow documentation as
+written — do not look for workarounds or alternative approaches unless the
+documented path fails. If something is unclear or doesn't work, note it and try
+to proceed. Provide all findings and honest notes about your experience in your
+output — do not write them to files.

--- a/scenarios/summit-setup/task.md
+++ b/scenarios/summit-setup/task.md
@@ -1,0 +1,35 @@
+Introduce yourself to the agent and give them the following task:
+
+Try the Forward Impact Summit product for the first time. Start at
+www.forwardimpact.team, find the Summit product page, and follow the
+instructions to install and set up fit-summit.
+
+The workspace is already prepared: synthetic framework data (`data/pathway/`)
+and a synthetic roster (`summit.yaml` at the workspace root) have been
+generated. Summit is fully local — no Supabase, no GetDX, no LLM calls needed
+for the core views.
+
+Exercise the product:
+
+1. Install the @forwardimpact/summit package from npm
+2. Run `npx fit-summit validate --roster ./summit.yaml` against the generated
+   framework data
+3. Run `npx fit-summit roster --roster ./summit.yaml` to see the team layout
+4. Run `npx fit-summit coverage <team> --roster ./summit.yaml` for at least one
+   team from the roster
+5. Run `npx fit-summit risks <team> --roster ./summit.yaml` for the same team
+6. Run at least one `npx fit-summit what-if <team> --roster ./summit.yaml`
+   scenario (for example
+   `--add "{ discipline: software_engineering, level: J060 }"`)
+7. Summarize their experience in their final output, including:
+   - How clear the setup instructions were
+   - Whether the commands worked as documented
+   - Whether the coverage, risks, and what-if views were understandable
+   - Any errors or confusing moments
+
+The agent should not write findings to files — all findings should be in their
+output. They should work independently and install from npm as a user would, not
+clone the monorepo.
+
+Use the `product-evaluation` skill to supervise the session and capture
+feedback.

--- a/website/docs/getting-started/leadership/index.md
+++ b/website/docs/getting-started/leadership/index.md
@@ -596,8 +596,10 @@ are allocation-weighted project teams that can either reference existing
 reporting-team members by `email` (inheriting their job profile) or declare new
 members inline. Allocation is a fraction between 0 and 1.
 
-If your roster lives somewhere else or has a different name, pass it explicitly
-with `--roster ./path/to/summit.yaml`. All the commands below accept the flag.
+Summit does not auto-discover a roster — pass `--roster ./path/to/summit.yaml`
+explicitly to every command. All the commands below accept the flag. (If you've
+set up Map's activity layer, you can omit `--roster` and Summit will read the
+team from the `organization_people` table instead.)
 
 ### Validate the roster
 
@@ -650,9 +652,10 @@ npx fit-summit risks platform --roster ./summit.yaml
 Summit reports three kinds of risk. **Single points of failure** are skills
 where exactly one person holds working+ proficiency — losing them leaves the
 team unable to execute. **Critical gaps** are skills the discipline or track
-expects but nobody on the team practices. **Concentration risks** are clusters
-where three or more people overlap on the same (level, capability) bucket — a
-structural imbalance that suggests room for cross-training.
+expects but nobody on the team holds at working level or above. **Concentration
+risks** are clusters where three or more people overlap on the same (level,
+capability, proficiency) bucket — a structural imbalance that suggests room for
+cross-training.
 
 ### Run what-if scenarios
 
@@ -740,9 +743,10 @@ Set `--lookback-months` (default 12) to control the practice window.
 Summit has a built-in privacy model. The `--audience` flag adjusts what
 individual-level detail is shown:
 
-- `engineer` — team gaps and growth directions without peer names
-- `manager` — full individual specificity for direct reports (the default)
-- `director` — aggregated team views with individual names removed
+- `manager` (the default) and `engineer` — individual holders are visible by
+  name; appropriate for 1:1s and for engineers reviewing their own team
+- `director` — holder names are stripped; only aggregated counts remain,
+  appropriate for cross-team planning artifacts
 
 Use `--audience director` when sharing a view across teams or publishing a
 planning artifact beyond the team manager.

--- a/website/docs/getting-started/leadership/index.md
+++ b/website/docs/getting-started/leadership/index.md
@@ -532,14 +532,111 @@ npx fit-landmark health --manager platform_manager
 
 Summit treats a team as a system, not a collection of individuals. It aggregates
 skill matrices into capability coverage, structural risks, and what-if staffing
-scenarios.
+scenarios. Core Summit is fully local and deterministic — it reads your Map
+framework data plus a team roster, and runs instantly with no network calls.
+
+Two optional flags unlock the activity layer: `--evidenced` compares derived
+coverage against practice patterns from evidence rows, and `--outcomes` weights
+growth recommendations by GetDX driver scores. Without those flags Summit needs
+nothing beyond framework data and a roster.
+
+### Create a roster
+
+Summit reads team composition from a `summit.yaml` file (or, if you've set up
+Map's activity layer, from the `organization_people` table directly). A roster
+file is the fastest way to try Summit — every discipline, level, and track it
+references must exist in your Map framework data.
+
+Save this as `summit.yaml` next to your `data/pathway/` directory:
+
+```yaml
+teams:
+  platform:
+    - name: Alice
+      email: alice@example.com
+      job:
+        discipline: software_engineering
+        level: J060
+        track: platform
+    - name: Bob
+      email: bob@example.com
+      job:
+        discipline: software_engineering
+        level: J040
+
+  delivery:
+    - name: Carol
+      email: carol@example.com
+      job:
+        discipline: software_engineering
+        level: J060
+    - name: Dan
+      email: dan@example.com
+      job:
+        discipline: software_engineering
+        level: J040
+        track: forward_deployed
+
+projects:
+  migration-q2:
+    - email: alice@example.com
+      allocation: 0.6
+    - email: carol@example.com
+      allocation: 0.4
+    - name: External Consultant
+      job:
+        discipline: software_engineering
+        level: J060
+        track: platform
+      allocation: 1.0
+```
+
+`teams:` are reporting teams — the people who roll up to a manager. `projects:`
+are allocation-weighted project teams that can either reference existing
+reporting-team members by `email` (inheriting their job profile) or declare new
+members inline. Allocation is a fraction between 0 and 1.
+
+If your roster lives somewhere else or has a different name, pass it explicitly
+with `--roster ./path/to/summit.yaml`. All the commands below accept the flag.
+
+### Validate the roster
+
+Before running analysis, check that every discipline, level, and track your
+roster references actually exists in your framework:
+
+```sh
+npx fit-summit validate --roster ./summit.yaml
+```
+
+A successful run prints the total member count across all teams. Any validation
+errors point at the offending row so you can fix the YAML before aggregating.
+
+### Show the roster
+
+Dump what Summit sees — useful for confirming the right file is being picked up
+and for sharing the team layout with a collaborator:
+
+```sh
+npx fit-summit roster --roster ./summit.yaml
+```
 
 ### View capability coverage
 
 See your team's collective proficiency across all skills:
 
 ```sh
-npx fit-summit coverage platform
+npx fit-summit coverage platform --roster ./summit.yaml
+```
+
+The report groups skills by capability and shows, for each skill, the headcount
+depth at `working+` proficiency. A blank bar signals a gap — nobody on the team
+holds the skill at the working level or above.
+
+Project teams carry allocation weights, so coverage reports effective depth
+instead of raw headcount:
+
+```sh
+npx fit-summit coverage --project migration-q2 --roster ./summit.yaml
 ```
 
 ### Identify structural risks
@@ -547,15 +644,111 @@ npx fit-summit coverage platform
 Find single points of failure, critical gaps, and concentration risks:
 
 ```sh
-npx fit-summit risks platform
+npx fit-summit risks platform --roster ./summit.yaml
 ```
+
+Summit reports three kinds of risk. **Single points of failure** are skills
+where exactly one person holds working+ proficiency — losing them leaves the
+team unable to execute. **Critical gaps** are skills the discipline or track
+expects but nobody on the team practices. **Concentration risks** are clusters
+where three or more people overlap on the same (level, capability) bucket — a
+structural imbalance that suggests room for cross-training.
 
 ### Run what-if scenarios
 
-Simulate roster changes and see their impact before making a decision:
+Simulate roster changes and see their impact before making a decision. Summit
+supports four kinds of mutation — `--add`, `--remove`, `--move`, and `--promote`
+— and reports which capabilities and risks change as a result:
 
 ```sh
-npx fit-summit what-if platform --add "{ discipline: se, level: L3, track: platform }"
+# Hypothetical new hire
+npx fit-summit what-if platform --roster ./summit.yaml \
+  --add "{ discipline: software_engineering, level: J060, track: platform }"
+
+# Departure
+npx fit-summit what-if platform --roster ./summit.yaml \
+  --remove bob@example.com
+
+# Internal move
+npx fit-summit what-if platform --roster ./summit.yaml \
+  --move carol@example.com --to delivery
+
+# Promotion
+npx fit-summit what-if platform --roster ./summit.yaml \
+  --promote bob@example.com
+```
+
+Add `--focus <capability>` to filter the diff to a single capability when you
+want to see the impact of a change on one area of the team.
+
+### Align growth with team needs
+
+Growth opportunities highlight where individual development would have the most
+leverage for the team as a whole:
+
+```sh
+npx fit-summit growth platform --roster ./summit.yaml
+```
+
+Add `--outcomes` to weight recommendations by GetDX driver scores (requires
+Map's activity layer):
+
+```sh
+npx fit-summit growth platform --roster ./summit.yaml --outcomes
+```
+
+### Compare two teams
+
+Diff two teams' coverage and risks side by side — useful when considering a
+structural reorganization or understanding why two similarly-sized teams feel
+different:
+
+```sh
+npx fit-summit compare platform delivery --roster ./summit.yaml
+```
+
+### Track trajectory over time
+
+Summit can reconstruct the history of your roster from git — if `summit.yaml` is
+checked into a repository, `trajectory` walks the git log to rebuild the roster
+at each quarter boundary and charts how capability has evolved:
+
+```sh
+npx fit-summit trajectory platform --roster ./summit.yaml --quarters 4
+```
+
+This turns "is the team getting stronger?" from a felt sense into a structural
+answer.
+
+### Combine with the activity layer
+
+When Map's activity layer is populated (see the Map section above), Summit can
+overlay evidence of practiced capability onto its structural view. The
+`--evidenced` flag reads practice patterns from `activity.evidence` and compares
+them to what the roster predicts — flagging skills the framework says the team
+should have that aren't showing up in real work:
+
+```sh
+npx fit-summit coverage platform --roster ./summit.yaml --evidenced
+npx fit-summit risks platform --roster ./summit.yaml --evidenced
+```
+
+Set `--lookback-months` (default 12) to control the practice window.
+
+### Match the audience to the conversation
+
+Summit has a built-in privacy model. The `--audience` flag adjusts what
+individual-level detail is shown:
+
+- `engineer` — team gaps and growth directions without peer names
+- `manager` — full individual specificity for direct reports (the default)
+- `director` — aggregated team views with individual names removed
+
+Use `--audience director` when sharing a view across teams or publishing a
+planning artifact beyond the team manager.
+
+```sh
+npx fit-summit coverage platform --roster ./summit.yaml --audience director
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Expand the Summit section of the leadership getting started guide from three
  one-liners into an end-to-end walkthrough: create a roster, validate, show
  roster, coverage (teams + projects), risks (with all three risk types
  described), what-if (all four mutation types), growth, compare, trajectory,
  `--evidenced`/`--outcomes` activity-layer integration, and the `--audience`
  privacy model.
- Add a `summit-setup` supervised-agent scenario alongside `guide-setup` and
  `map-setup`: a workflow_dispatch GitHub workflow, a product-evaluation task
  prompt, and a first-time-user agent profile. The workflow runs
  `bunx fit-universe` to generate a synthetic framework and roster, stages them
  into a mktemp workspace, and invokes `gemba-action` in `supervise` mode
  against the `product-manager` supervisor profile. Summit is fully local, so
  no Supabase bring-up is required (unlike `map-setup`).
- Apply gemba-review follow-ups: correct the concentration-risk bucket to
  `(level, capability, proficiency)`, fix the critical-gap wording from
  "practices" to "holds at working level or above", clarify that Summit does
  not auto-discover a roster file, and realign the `--audience` description
  with the actual implementation (only `director` strips holder names).

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2219 pass, 1 skipped, 0 fail)
- [x] Validated the workspace layout end-to-end by running the exact `cp`
      sequence locally and exercising `fit-summit validate`, `roster`,
      `coverage <team>`, and `what-if <team> --add ...` against the staged
      directory.

Note: the `summit-setup` workflow installs `@forwardimpact/summit` from npm.
The package is not yet published (same pre-existing state as
`@forwardimpact/landmark`), so the scenario will be runnable once Summit cuts
its first release. Until then the workflow is `workflow_dispatch` only and
will not auto-run.