### PR TITLE
plan(400): library skill discovery — 4-part plan

### DIFF
--- a/specs/400-library-skill-discovery/plan-a-01.md
+++ b/specs/400-library-skill-discovery/plan-a-01.md
@@ -1,0 +1,191 @@
+# Plan A Part 01 — Rename skill directories and update CLAUDE.md
+
+Part 1 of 4 of [plan-a](plan-a.md) for [spec 400](spec.md).
+
+Renames five `.claude/skills/libs-*` directories so the filesystem reflects
+the six task-named groups from spec 400 Move 1, and updates
+`CLAUDE.md § Skill Groups` to match. **This part does not touch any SKILL.md
+content** — file bodies are rewritten in Part 02.
+
+## Scope
+
+- Rename five skill directories via `git mv`.
+- Update `CLAUDE.md § Skill Groups` with the new group names, membership, and
+  the orphan libraries added in spec 400 Move 1.
+- Leave SKILL.md file contents unchanged — Part 02 owns frontmatter and body
+  rewrites.
+- Leave `libs-synthetic-data/` and `libskill/` directories in place — only
+  their CLAUDE.md § Skill Groups entries change (to add `libuniverse`).
+
+## Files touched
+
+### Renamed directories (five)
+
+| From                                            | To                                      |
+| ----------------------------------------------- | --------------------------------------- |
+| `.claude/skills/libs-service-infrastructure/`   | `.claude/skills/libs-grpc-services/`    |
+| `.claude/skills/libs-data-persistence/`         | `.claude/skills/libs-storage/`          |
+| `.claude/skills/libs-llm-orchestration/`        | `.claude/skills/libs-llm-and-agents/`   |
+| `.claude/skills/libs-web-presentation/`         | `.claude/skills/libs-content/`          |
+| `.claude/skills/libs-system-utilities/`         | `.claude/skills/libs-cli-and-tooling/`  |
+
+Each rename moves exactly one file: `SKILL.md`.
+
+Unchanged: `.claude/skills/libs-synthetic-data/`,
+`.claude/skills/libskill/`.
+
+### Modified file (one)
+
+- `CLAUDE.md` — rewrite § Skill Groups (lines 259–276).
+
+## Ordering
+
+1. **Rename the five directories.** One `git mv` per directory:
+
+   ```sh
+   git mv .claude/skills/libs-service-infrastructure .claude/skills/libs-grpc-services
+   git mv .claude/skills/libs-data-persistence       .claude/skills/libs-storage
+   git mv .claude/skills/libs-llm-orchestration      .claude/skills/libs-llm-and-agents
+   git mv .claude/skills/libs-web-presentation       .claude/skills/libs-content
+   git mv .claude/skills/libs-system-utilities       .claude/skills/libs-cli-and-tooling
+   ```
+
+2. **Update `CLAUDE.md § Skill Groups`.** Replace lines 259–276 with the new
+   section (see § CLAUDE.md rewrite below). Preserve the existing heading
+   (`## Skill Groups`), the intro sentence, and the closing `libskill` note.
+
+3. **Verify.** Run `ls .claude/skills/libs-*` and spot-check that exactly six
+   directories exist with the new names. Run `grep -n 'libs-' CLAUDE.md` and
+   confirm only the new names appear. Grep for the five old names
+   repo-wide (see § Verification) and confirm there are no remaining
+   references outside the Part 01 diff.
+
+## CLAUDE.md rewrite
+
+Replace the existing § Skill Groups block (`CLAUDE.md:259–276`) with the
+following. The intro sentence and the `libskill` closing note are unchanged;
+only the bulleted list changes.
+
+```markdown
+## Skill Groups
+
+Library skills are organized into capability groups with corresponding skill
+files in [.claude/skills/](.claude/skills/):
+
+- **`libs-grpc-services`** — librpc, libconfig, libtelemetry, libtype,
+  libharness
+- **`libs-storage`** — libstorage, libindex, libresource, libpolicy, libgraph,
+  libvector
+- **`libs-llm-and-agents`** — libllm, libmemory, libprompt, libagent, libtool
+- **`libs-content`** — libui, libformat, libweb, libdoc, libtemplate
+- **`libs-cli-and-tooling`** — libcli, librepl, libutil, libsecret, libsupervise,
+  librc, libcodegen, libeval
+- **`libs-synthetic-data`** — libsyntheticgen, libsyntheticprose,
+  libsyntheticrender, libuniverse
+
+`libskill` retains its own skill (pure-function design, exempt from OO+DI).
+```
+
+**Diff points to flag:**
+
+- Group names all change except `libs-synthetic-data`.
+- `libtool` moves from `libs-llm-and-agents` (already listed in the old block
+  under `libs-llm-orchestration`).
+- `libcli`, `librepl` move from `libs-web-presentation` (already listed in the
+  old block) into `libs-cli-and-tooling`.
+- `libeval` was already listed under `libs-system-utilities`; it stays but in
+  the renamed group `libs-cli-and-tooling`.
+- `libuniverse` is added to the `libs-synthetic-data` line (was absent from
+  CLAUDE.md previously, despite being in `libraries/`).
+
+## Verification
+
+Run at the package root after the renames and the CLAUDE.md edit:
+
+1. **Filesystem shape check.**
+
+   ```sh
+   ls -1d .claude/skills/libs-* .claude/skills/libskill
+   ```
+
+   Expected output (exactly seven entries, new names only):
+
+   ```
+   .claude/skills/libs-cli-and-tooling
+   .claude/skills/libs-content
+   .claude/skills/libs-grpc-services
+   .claude/skills/libs-llm-and-agents
+   .claude/skills/libs-storage
+   .claude/skills/libs-synthetic-data
+   .claude/skills/libskill
+   ```
+
+2. **No dangling references to old names anywhere in the repo.**
+
+   ```sh
+   rg -n 'libs-service-infrastructure|libs-data-persistence|libs-llm-orchestration|libs-web-presentation|libs-system-utilities'
+   ```
+
+   Expected: zero hits. If any hit is inside `.claude/skills/libs-*/SKILL.md`
+   body text (e.g., the old group name mentioned inside the file), leave it
+   for Part 02 — Part 02 rewrites those sections and will catch them. Any hit
+   outside that tree is a Part 01 blocker and must be fixed before committing.
+
+3. **CLAUDE.md structure check.**
+
+   ```sh
+   grep -n '^- \*\*`libs-' CLAUDE.md
+   ```
+
+   Expected: six lines with the six new group names, in the order listed in
+   the CLAUDE.md rewrite block above.
+
+4. **`bun run check` passes.** No format/lint/layout/exports drift.
+
+5. **Git history survives the rename.**
+
+   ```sh
+   git log --follow -- .claude/skills/libs-grpc-services/SKILL.md | head -5
+   ```
+
+   Expected: commits predating the rename (from when the file lived at
+   `libs-service-infrastructure/SKILL.md`). Repeat for the other four renamed
+   directories. If `--follow` fails, `git mv` was not used — revert and redo.
+
+## Risks
+
+1. **`git mv` into a directory vs into a file.** Using
+   `git mv old new` where `new` already exists moves `old` **into** `new`.
+   The destinations in the rename table do not exist yet, so this is safe,
+   but check with `ls .claude/skills/libs-grpc-services 2>/dev/null` before
+   running `git mv` if there's any doubt.
+
+2. **Leftover references in website docs.** `website/docs/internals/` may
+   reference skill group names in prose. Step 2 of Verification catches this;
+   if anything hits, update the prose in the same commit so the rename is
+   atomic.
+
+3. **Commit message noise.** `git mv` of a directory with one file produces a
+   clean rename diff, but if the working tree has any untracked file inside
+   the old directory, `git mv` will fail. Ensure the tree is clean
+   (`git status` shows only the Part 01 changes) before running the moves.
+
+## Commit
+
+One commit for all five renames plus the CLAUDE.md update:
+
+```
+docs(skills): rename libs-* groups to task-named (spec 400 part 1/4)
+
+- libs-service-infrastructure → libs-grpc-services
+- libs-data-persistence       → libs-storage
+- libs-llm-orchestration      → libs-llm-and-agents
+- libs-web-presentation       → libs-content
+- libs-system-utilities       → libs-cli-and-tooling
+
+Update CLAUDE.md § Skill Groups to match the six task-named groups and add
+libuniverse to libs-synthetic-data membership. SKILL.md content rewrites
+follow in part 2.
+```
+
+— Staff Engineer 🛠️

--- a/specs/400-library-skill-discovery/plan-a-01.md
+++ b/specs/400-library-skill-discovery/plan-a-01.md
@@ -2,8 +2,8 @@
 
 Part 1 of 4 of [plan-a](plan-a.md) for [spec 400](spec.md).
 
-Renames five `.claude/skills/libs-*` directories so the filesystem reflects
-the six task-named groups from spec 400 Move 1, and updates
+Renames five `.claude/skills/libs-*` directories so the filesystem reflects the
+six task-named groups from spec 400 Move 1, and updates
 `CLAUDE.md § Skill Groups` to match. **This part does not touch any SKILL.md
 content** — file bodies are rewritten in Part 02.
 
@@ -14,25 +14,24 @@ content** — file bodies are rewritten in Part 02.
   the orphan libraries added in spec 400 Move 1.
 - Leave SKILL.md file contents unchanged — Part 02 owns frontmatter and body
   rewrites.
-- Leave `libs-synthetic-data/` and `libskill/` directories in place — only
-  their CLAUDE.md § Skill Groups entries change (to add `libuniverse`).
+- Leave `libs-synthetic-data/` and `libskill/` directories in place — only their
+  CLAUDE.md § Skill Groups entries change (to add `libuniverse`).
 
 ## Files touched
 
 ### Renamed directories (five)
 
-| From                                            | To                                      |
-| ----------------------------------------------- | --------------------------------------- |
-| `.claude/skills/libs-service-infrastructure/`   | `.claude/skills/libs-grpc-services/`    |
-| `.claude/skills/libs-data-persistence/`         | `.claude/skills/libs-storage/`          |
-| `.claude/skills/libs-llm-orchestration/`        | `.claude/skills/libs-llm-and-agents/`   |
-| `.claude/skills/libs-web-presentation/`         | `.claude/skills/libs-content/`          |
-| `.claude/skills/libs-system-utilities/`         | `.claude/skills/libs-cli-and-tooling/`  |
+| From                                          | To                                     |
+| --------------------------------------------- | -------------------------------------- |
+| `.claude/skills/libs-service-infrastructure/` | `.claude/skills/libs-grpc-services/`   |
+| `.claude/skills/libs-data-persistence/`       | `.claude/skills/libs-storage/`         |
+| `.claude/skills/libs-llm-orchestration/`      | `.claude/skills/libs-llm-and-agents/`  |
+| `.claude/skills/libs-web-presentation/`       | `.claude/skills/libs-content/`         |
+| `.claude/skills/libs-system-utilities/`       | `.claude/skills/libs-cli-and-tooling/` |
 
 Each rename moves exactly one file: `SKILL.md`.
 
-Unchanged: `.claude/skills/libs-synthetic-data/`,
-`.claude/skills/libskill/`.
+Unchanged: `.claude/skills/libs-synthetic-data/`, `.claude/skills/libskill/`.
 
 ### Modified file (one)
 
@@ -56,9 +55,9 @@ Unchanged: `.claude/skills/libs-synthetic-data/`,
 
 3. **Verify.** Run `ls .claude/skills/libs-*` and spot-check that exactly six
    directories exist with the new names. Run `grep -n 'libs-' CLAUDE.md` and
-   confirm only the new names appear. Grep for the five old names
-   repo-wide (see § Verification) and confirm there are no remaining
-   references outside the Part 01 diff.
+   confirm only the new names appear. Grep for the five old names repo-wide (see
+   § Verification) and confirm there are no remaining references outside the
+   Part 01 diff.
 
 ## CLAUDE.md rewrite
 
@@ -120,16 +119,23 @@ Run at the package root after the renames and the CLAUDE.md edit:
    .claude/skills/libskill
    ```
 
-2. **No dangling references to old names anywhere in the repo.**
+2. **No dangling references to old names in live surfaces.** Scope the grep to
+   files that Part 01 is responsible for keeping current. Historic specs and
+   plans under `specs/` correctly reference the group names that existed at
+   their time of writing — **do not rewrite history**.
 
    ```sh
-   rg -n 'libs-service-infrastructure|libs-data-persistence|libs-llm-orchestration|libs-web-presentation|libs-system-utilities'
+   rg -n 'libs-service-infrastructure|libs-data-persistence|libs-llm-orchestration|libs-web-presentation|libs-system-utilities' \
+      CLAUDE.md CONTRIBUTING.md .claude/ website/docs/internals/ .github/ scripts/
    ```
 
    Expected: zero hits. If any hit is inside `.claude/skills/libs-*/SKILL.md`
-   body text (e.g., the old group name mentioned inside the file), leave it
-   for Part 02 — Part 02 rewrites those sections and will catch them. Any hit
-   outside that tree is a Part 01 blocker and must be fixed before committing.
+   body text (e.g., the old group name mentioned inside a file), leave it for
+   Part 02 — Part 02 rewrites those sections and will catch them. Any hit in
+   `CLAUDE.md`, `CONTRIBUTING.md`, the website internals, GitHub workflows, or
+   `scripts/` is a Part 01 blocker and must be fixed before committing. Hits
+   inside `specs/` are expected historical artifacts and are explicitly out of
+   scope.
 
 3. **CLAUDE.md structure check.**
 
@@ -137,8 +143,8 @@ Run at the package root after the renames and the CLAUDE.md edit:
    grep -n '^- \*\*`libs-' CLAUDE.md
    ```
 
-   Expected: six lines with the six new group names, in the order listed in
-   the CLAUDE.md rewrite block above.
+   Expected: six lines with the six new group names, in the order listed in the
+   CLAUDE.md rewrite block above.
 
 4. **`bun run check` passes.** No format/lint/layout/exports drift.
 
@@ -154,21 +160,20 @@ Run at the package root after the renames and the CLAUDE.md edit:
 
 ## Risks
 
-1. **`git mv` into a directory vs into a file.** Using
-   `git mv old new` where `new` already exists moves `old` **into** `new`.
-   The destinations in the rename table do not exist yet, so this is safe,
-   but check with `ls .claude/skills/libs-grpc-services 2>/dev/null` before
-   running `git mv` if there's any doubt.
+1. **`git mv` into a directory vs into a file.** Using `git mv old new` where
+   `new` already exists moves `old` **into** `new`. The destinations in the
+   rename table do not exist yet, so this is safe, but check with
+   `ls .claude/skills/libs-grpc-services 2>/dev/null` before running `git mv` if
+   there's any doubt.
 
 2. **Leftover references in website docs.** `website/docs/internals/` may
-   reference skill group names in prose. Step 2 of Verification catches this;
-   if anything hits, update the prose in the same commit so the rename is
-   atomic.
+   reference skill group names in prose. Step 2 of Verification catches this; if
+   anything hits, update the prose in the same commit so the rename is atomic.
 
 3. **Commit message noise.** `git mv` of a directory with one file produces a
-   clean rename diff, but if the working tree has any untracked file inside
-   the old directory, `git mv` will fail. Ensure the tree is clean
-   (`git status` shows only the Part 01 changes) before running the moves.
+   clean rename diff, but if the working tree has any untracked file inside the
+   old directory, `git mv` will fail. Ensure the tree is clean (`git status`
+   shows only the Part 01 changes) before running the moves.
 
 ## Commit
 

--- a/specs/400-library-skill-discovery/plan-a-02.md
+++ b/specs/400-library-skill-discovery/plan-a-02.md
@@ -1,0 +1,350 @@
+# Plan A Part 02 — Rewrite SKILL.md content (descriptions, tables, orphans)
+
+Part 2 of 4 of [plan-a](plan-a.md) for [spec 400](spec.md). Depends on Part 01.
+
+Rewrites the frontmatter descriptions, inner `Libraries` tables, and any body
+text referencing the old group names across all six `libs-*/SKILL.md` files
+plus `libskill/SKILL.md`. This is the largest part of the plan and the one
+that produces the signal the skill router sees at load time.
+
+## Scope
+
+- Rewrite frontmatter `description` in every `libs-*/SKILL.md` and
+  `libskill/SKILL.md` in capability-verb vocabulary, opening with "Use when".
+- Rename the inner table columns from `Main API` / `Purpose` to
+  `Capabilities` / `Key Exports` across all six `libs-*` files.
+- Add one row per orphan: `libtool` (in `libs-llm-and-agents`), `libcli`,
+  `librepl`, `libeval` (in `libs-cli-and-tooling`), `libuniverse` (in
+  `libs-synthetic-data`). `libs-cli-and-tooling` also gains `libutil`,
+  `libsecret`, `libsupervise`, `librc`, `libcodegen` rows inherited from the
+  old `libs-system-utilities` table but with the new column headers and
+  verified `Key Exports`.
+- Populate every `Key Exports` cell by reading the library's actual public
+  export surface (`libraries/<libname>/src/index.js` plus any subpath targets
+  declared in `libraries/<libname>/package.json`'s `exports` map).
+- Update body section intros ("When to Use", "Decision Guide", "Composition
+  Recipes", "DI Wiring") where they reference the old group name or need to
+  cover a newly added library.
+- **Do not rewrite Decision Guide or Composition Recipes beyond adjustments
+  required by the reorganisation.** Spec 130 already corrected these.
+
+## Files touched
+
+Seven files, all rewrites (no creates, no deletes):
+
+1. `.claude/skills/libs-grpc-services/SKILL.md`
+2. `.claude/skills/libs-storage/SKILL.md`
+3. `.claude/skills/libs-llm-and-agents/SKILL.md`
+4. `.claude/skills/libs-content/SKILL.md`
+5. `.claude/skills/libs-cli-and-tooling/SKILL.md`
+6. `.claude/skills/libs-synthetic-data/SKILL.md`
+7. `.claude/skills/libskill/SKILL.md`
+
+## Ordering
+
+Rewrite files one at a time in the order listed above. After each file, run
+`bun run check` to confirm format/lint pass. Commit all seven files together
+at the end of the part — the branch does not need to be checkable at any
+intermediate point.
+
+For each file, the rewrite recipe is:
+
+1. **Read the current file end-to-end.**
+2. **Inventory the library's actual exports.** For each library row you will
+   write, open `libraries/<libname>/src/index.js` plus every file referenced
+   in `libraries/<libname>/package.json`'s `exports` map. Collect every name
+   that appears as `export function X`, `export class X`, `export const X`,
+   `export { X }`, `export { X } from …`, or `export default`. De-dupe. This
+   is the source of truth for the `Key Exports` column.
+3. **Draft the `Key Exports` cells.** Select a representative subset per row:
+   the primary class(es) and factory function(s) plus the highest-value
+   helpers. Do not list every export — the spec forbids the reverse check
+   precisely because internal helpers shouldn't pollute the discovery
+   surface. Aim for 3–6 names per row. Every name must resolve under Part
+   04's script.
+4. **Draft the `Capabilities` cells.** Verb-led phrases the way an agent
+   phrases a task: "retry a flaky fetch", "supervise a daemon", "render
+   markdown to terminal". Avoid library names.
+5. **Rewrite the frontmatter `description`.** Gather every `Capabilities`
+   phrase from step 4 across all rows in the table. Merge into one "Use when
+   …" paragraph, under ~100 words. Every row's capabilities must appear in
+   the description (the router only sees the frontmatter).
+6. **Update body intros.** Replace any reference to the old group name. Spot
+   the "When to Use" list, the Decision Guide heading introductions, and any
+   "# <Group Title>" H1 (e.g., "# Web Presentation" → "# Content"). Leave
+   recipe code blocks unchanged unless a library was added to the group
+   (then add one recipe or DI block for the new library).
+7. **Spot-verify the frontmatter.** Word count should be under ~120 (the
+   ~100 target plus a 20-word buffer; anything over is flagged to the
+   reviewer, not auto-blocked). Description must open with "Use when".
+
+### Per-file rewrites
+
+#### 1. `libs-grpc-services/SKILL.md`
+
+- **Group title H1:** keep as "Service Infrastructure" or rename to "gRPC
+  Services" for consistency with the new directory name. **Decision:** rename
+  to "gRPC Services and Service Infrastructure". Naming the directory and the
+  H1 with compatible words helps readers who grep for "service".
+- **Members (5):** librpc, libconfig, libtelemetry, libtype, libharness.
+  Unchanged from old `libs-service-infrastructure`.
+- **`Key Exports` source-of-truth check (read at execution time):**
+
+  | Library      | Entry file(s)                                                                                  |
+  | ------------ | ---------------------------------------------------------------------------------------------- |
+  | librpc       | `libraries/librpc/src/index.js`                                                                |
+  | libconfig    | `libraries/libconfig/src/index.js`                                                             |
+  | libtelemetry | `libraries/libtelemetry/src/index.js` + `./tracer.js` + `./visualizer.js` + `./index/trace.js` |
+  | libtype      | `libraries/libtype/src/index.js` (re-exports from `./generated/types/types.js`)                |
+  | libharness   | `libraries/libharness/src/index.js` (re-exports from `./fixture/index.js`, `./mock/index.js`)  |
+
+  Known divergence from the current (stale) `Main API` column: librpc
+  exports `Server`/`Client`/`createClient` (not `RpcServer`/`RpcClient`/
+  `createClientFactory`). libconfig exports `createServiceConfig`/
+  `createExtensionConfig`/`createScriptConfig` (not `serviceConfig`/…).
+  libtelemetry's root index does **not** export `Tracer` — it lives at
+  `./tracer.js`; if the Key Exports cell lists `Tracer`, the Part 04 check
+  must be able to resolve it via the subpath export.
+- **Body changes:** keep Decision Guide, Composition Recipes, DI Wiring
+  unchanged content-wise; update any stray "service-infrastructure" text to
+  the new group name. Update Recipe 1 code comments if they reference
+  `RpcServer` (rename to `Server`) — Part 02 is the natural place to fix
+  this stale reference from spec 130's pass.
+
+#### 2. `libs-storage/SKILL.md`
+
+- **H1:** "Data Persistence" → "Storage".
+- **Members (6):** libstorage, libindex, libresource, libpolicy, libgraph,
+  libvector. Unchanged.
+- **`Key Exports`:** read entry files under `libraries/{libstorage,libindex,
+  libresource,libpolicy,libgraph,libvector}/src/index.js` (plus any subpath
+  exports declared in each `package.json`).
+  - libstorage: `createStorage`, `parseJsonl`, `serializeJsonl`
+  - libindex: `Index`, `BufferedIndex` (check current exports)
+  - libresource: `ResourceIndex`, `createResourceIndex`, `toResourceId`
+  - libpolicy: `PolicyIndex`, `createPolicyIndex`
+  - libgraph: `GraphIndex`, `createGraphIndex`, `PREFIXES`
+  - libvector: `VectorIndex`, `VectorProcessor` (verify — spec 130 flagged
+    this as potentially missing)
+- **Body changes:** smallest of the six. Change H1 and update any "data
+  persistence" prose, but the Decision Guide and Recipes already use the
+  correct names after spec 130.
+
+#### 3. `libs-llm-and-agents/SKILL.md`
+
+- **H1:** "LLM Orchestration" → "LLM and Agents".
+- **Members (5):** libllm, libmemory, libprompt, libagent, **libtool**.
+  `libtool` is new to this table.
+- **`Key Exports`:**
+  - libllm: `LlmApi`
+  - libmemory: verify current exports (`WindowBuilder`, `createWindow`,
+    `MemoryIndex`?)
+  - libprompt: `PromptLoader`, `createPromptLoader`
+  - libagent: `AgentMind`, `AgentAction` (verify)
+  - libtool: `ToolProcessor`, `mapFieldToSchema`, `generateSchemaFromProtobuf`,
+    `buildToolDescription` (from `libraries/libtool/src/index.js` — confirmed
+    at planning time)
+- **Body changes:** add a `libtool` row to the table; add one Decision Guide
+  bullet ("libtool vs libagent — `ToolProcessor` for binding a protobuf tool
+  service into an LLM-callable tool; `AgentMind` for running the
+  conversation"); add one DI Wiring code block showing `ToolProcessor`
+  construction.
+
+#### 4. `libs-content/SKILL.md`
+
+- **H1:** "Web Presentation" → "Content".
+- **Members (5):** libui, libformat, libweb, libdoc, libtemplate. `libcli`
+  and `librepl` move **out** to `libs-cli-and-tooling`.
+- **`Key Exports`:** existing rows stay, minus libcli and librepl.
+- **Body changes:** remove libcli and librepl from any Decision Guide /
+  Composition Recipes / DI Wiring content that currently references them.
+  (Grep inside the file before removing; if libcli/librepl appear only in
+  the table, only the table row removal is needed.)
+- **libdoc build outputs section** (currently at `libs-web-presentation/
+  SKILL.md` lines 144–167): preserve verbatim.
+
+#### 5. `libs-cli-and-tooling/SKILL.md`
+
+- **H1:** "System Utilities" → "CLI and Tooling".
+- **Members (8):** **libcli**, **librepl**, libutil, libsecret, libsupervise,
+  librc, libcodegen, **libeval**. This is the biggest membership change —
+  three libraries inherited from `libs-system-utilities` plus libcli, librepl
+  (moved in) plus libeval (already in the old table).
+- **`Key Exports`:**
+  - libcli: `Cli`, `createCli`, `HelpRenderer`, `SummaryRenderer`,
+    `formatTable`, `colorize` (subset — libcli exports 17+ names)
+  - librepl: `Repl`
+  - libutil: `generateHash`, `generateUUID`, `countTokens`, `createTokenizer`,
+    `createBundleDownloader`, `Retry`, `createRetry`, `waitFor`,
+    `parseJsonBody`, `updateEnvFile`, `Finder`, `BundleDownloader`,
+    `TarExtractor` — pick a representative 4–6.
+  - libsecret: `generateSecret`, `generateBase64Secret`, `generateJWT`,
+    `readEnvFile`, `getOrGenerateSecret`, `updateEnvFile`, `generateHash`,
+    `generateUUID`
+  - libsupervise: `SupervisionTree`, `createSupervisionTree`, `LongrunProcess`,
+    `OneshotProcess`, `LogWriter`, `ProcessState`
+  - librc: `ServiceManager`, `sendCommand`, `waitForSocket`
+  - libcodegen: `CodegenBase`, `CodegenTypes`, `CodegenServices`,
+    `CodegenDefinitions`
+  - libeval: `TraceCollector`, `createTraceCollector`, `AgentRunner`,
+    `createAgentRunner`, `Supervisor`, `createSupervisor`, `TeeWriter`,
+    `createTeeWriter`
+- **Body changes:**
+  - Decision Guide gains entries for libcli (CLI entry point vs REPL),
+    librepl (vs inline readline), libeval (trace processing, agent running,
+    supervisor loop). Remove libraries that moved **out** (libtool — moved
+    to `libs-llm-and-agents`; nothing else moves out).
+  - Composition Recipes: keep the two existing recipes (supervise a service,
+    generate secrets, generate code from proto) and add one recipe each for
+    libcli (create a CLI entry point using `Cli` + `HelpRenderer`), librepl
+    (start a REPL with `Repl`), libeval (run an agent with `AgentRunner`).
+  - DI Wiring: add blocks for libcli, librepl, libeval.
+  - Cross-reference line to `libs-grpc-services` for the `libtelemetry.Logger`
+    guidance ("for CLI logging, see libtelemetry in libs-grpc-services") —
+    one sentence, no duplication.
+  - Remove the libtool DI Wiring block if one exists (libtool was never in
+    the old `libs-system-utilities`, but double-check nothing references it).
+- **This is the highest-risk file.** It has the most rows, the longest
+  description (8 libraries' verbs packed into ~100 words), and gains the
+  most new content. Review the frontmatter description last, after the
+  inner table is final, and count words.
+
+#### 6. `libs-synthetic-data/SKILL.md`
+
+- **H1:** "Synthetic Data Libraries" — unchanged.
+- **Members (4):** libsyntheticgen, libsyntheticprose, libsyntheticrender,
+  **libuniverse**. libuniverse is new to the table (currently referenced in
+  the body but not listed in the three-row `Libraries` table).
+- **`Key Exports`:**
+  - libsyntheticgen: `DslParser`, `createDslParser`, `EntityGenerator`,
+    `createEntityGenerator`, `createSeededRNG`, `collectProseKeys`,
+    `PROFICIENCY_LEVELS`, `MATURITY_LEVELS`, `STAGE_NAMES`
+  - libsyntheticprose: `ProseEngine`, `PathwayGenerator`, `createProseEngine`,
+    `loadSchemas`
+  - libsyntheticrender: `Renderer`, `createRenderer`, `ContentValidator`,
+    `ContentFormatter`, `validateCrossContent`, `formatContent`,
+    `generateDrugs`, `generatePlatforms`, `assignLinks`, `validateLinks`
+  - libuniverse: `Pipeline`, `loadToSupabase` (plus the re-exports from the
+    other three libraries — do **not** list re-exports in libuniverse's row,
+    since they belong to their originating libraries)
+- **Body changes:** add libuniverse row; the body Decision Guide already
+  explains the `libsyntheticgen vs libuniverse` distinction (see line 38 of
+  the current file), keep as-is; preserve the GetDX API References section,
+  Verification section, and everything else below the Libraries table.
+
+#### 7. `libskill/SKILL.md`
+
+- **Frontmatter `description` rewrite.** Current description opens "Work with
+  the @forwardimpact/libskill package" — the anti-pattern. Rewrite as "Use
+  when deriving a job from Discipline × Level × Track, generating an agent
+  profile, resolving skill modifiers, producing stage transition checklists,
+  selecting interview questions by role, analysing career progression
+  between levels, or matching candidates to jobs." (draft; adjust wording to
+  stay under ~100 words and cover every function in
+  `libraries/libskill/src/*.js`).
+- **Body:** no changes. libskill is pure functions and the existing body is
+  accurate after spec 130's pass; no inner `Libraries` table to restructure.
+
+## Verification
+
+Run at the package root after all seven files are rewritten, before committing:
+
+1. **Grammar and structure check.**
+
+   ```sh
+   for f in .claude/skills/libs-*/SKILL.md .claude/skills/libskill/SKILL.md; do
+     echo "=== $f ==="
+     head -10 "$f"
+   done
+   ```
+
+   Expected: every frontmatter `description` opens with "Use when".
+
+2. **Column header check.**
+
+   ```sh
+   grep -n '^| Library' .claude/skills/libs-*/SKILL.md
+   ```
+
+   Expected: six lines, each reading `| Library | Capabilities | Key Exports |`.
+   Zero hits with `Main API` or `Purpose`.
+
+3. **Membership check.**
+
+   Visually confirm against the truth table in `plan-a.md § New six-group
+   truth table` that each file's `Libraries` table rows exactly match the
+   expected members.
+
+4. **Word-count check on descriptions.**
+
+   ```sh
+   for f in .claude/skills/libs-*/SKILL.md; do
+     name=$(basename "$(dirname "$f")")
+     desc=$(awk '/^description: >/,/^---$/' "$f" | sed '1d;$d' | tr '\n' ' ')
+     words=$(echo "$desc" | wc -w)
+     echo "$name: $words words"
+   done
+   ```
+
+   Expected: six lines, each under ~120 words. Over 120 is a flag for the
+   reviewer, not an auto-block.
+
+5. **`bun run check` passes** (prettier reformats markdown tables, eslint
+   is no-op on markdown). Format changes are expected; commit the
+   reformatted output.
+
+6. **`bun run test` passes** — unchanged, but running it confirms nothing in
+   the SKILL.md rewrite affected any test.
+
+7. **Part 04's `check:skill-exports`** is not yet wired in at this point.
+   The Part 02 output is the canonical input that Part 04 validates against;
+   any `Key Exports` name that doesn't resolve when Part 04 lands is a Part
+   02 bug to be fixed before Part 04 commits.
+
+## Risks
+
+1. **Description word cap vs coverage.** Already flagged in the plan
+   overview; main source of implementer judgement. Mitigation: review the
+   `libs-cli-and-tooling` description last, after all capabilities are
+   locked in.
+
+2. **Stale names in existing tables.** The current `Main API` columns in
+   some files contain names that do not match the actual exports (e.g.,
+   `RpcServer` vs `Server` in librpc). **Do not copy stale names forward.**
+   Read the live entry file every time.
+
+3. **Reserved future extensibility.** If a library grows a new public export
+   after Part 02 lands but before Part 04's check is running in CI, the
+   advertised `Key Exports` cell is still valid (the check is
+   strict-positive) but the Capabilities column drifts. This is acceptable;
+   spec 130 and future spec are the continual correction mechanism.
+
+4. **libsyntheticrender has many domain-specific helpers**
+   (`generateDrugs`, `generatePlatforms`) that don't read like "synthetic
+   data" verbs. Include them in Key Exports if they are public but keep
+   Capabilities language at the level of "generate synthetic entities" — the
+   specific names are in Key Exports, the router signal is in Capabilities
+   and the frontmatter description.
+
+5. **Recipe code in Composition Recipes may reference symbols that were
+   renamed (e.g., `RpcServer`).** Fix as part of Part 02 — this is the last
+   chance to catch spec 130 drift before Part 04 locks the contract.
+
+## Commit
+
+One commit for all seven files:
+
+```
+docs(skills): rewrite libs-* descriptions and tables (spec 400 part 2/4)
+
+- Every libs-* SKILL.md frontmatter description now opens with "Use when"
+  and lists capability verbs covering every public library export in the
+  group.
+- Inner Libraries tables use Capabilities / Key Exports columns.
+- Add libtool to libs-llm-and-agents; libcli, librepl, libeval to
+  libs-cli-and-tooling; libuniverse to libs-synthetic-data.
+- Rewrite libskill frontmatter description from "Work with the package"
+  to capability-verb form.
+```
+
+— Staff Engineer 🛠️

--- a/specs/400-library-skill-discovery/plan-a-02.md
+++ b/specs/400-library-skill-discovery/plan-a-02.md
@@ -3,22 +3,22 @@
 Part 2 of 4 of [plan-a](plan-a.md) for [spec 400](spec.md). Depends on Part 01.
 
 Rewrites the frontmatter descriptions, inner `Libraries` tables, and any body
-text referencing the old group names across all six `libs-*/SKILL.md` files
-plus `libskill/SKILL.md`. This is the largest part of the plan and the one
-that produces the signal the skill router sees at load time.
+text referencing the old group names across all six `libs-*/SKILL.md` files plus
+`libskill/SKILL.md`. This is the largest part of the plan and the one that
+produces the signal the skill router sees at load time.
 
 ## Scope
 
 - Rewrite frontmatter `description` in every `libs-*/SKILL.md` and
   `libskill/SKILL.md` in capability-verb vocabulary, opening with "Use when".
-- Rename the inner table columns from `Main API` / `Purpose` to
-  `Capabilities` / `Key Exports` across all six `libs-*` files.
+- Rename the inner table columns from `Main API` / `Purpose` to `Capabilities` /
+  `Key Exports` across all six `libs-*` files.
 - Add one row per orphan: `libtool` (in `libs-llm-and-agents`), `libcli`,
   `librepl`, `libeval` (in `libs-cli-and-tooling`), `libuniverse` (in
   `libs-synthetic-data`). `libs-cli-and-tooling` also gains `libutil`,
-  `libsecret`, `libsupervise`, `librc`, `libcodegen` rows inherited from the
-  old `libs-system-utilities` table but with the new column headers and
-  verified `Key Exports`.
+  `libsecret`, `libsupervise`, `librc`, `libcodegen` rows inherited from the old
+  `libs-system-utilities` table but with the new column headers and verified
+  `Key Exports`.
 - Populate every `Key Exports` cell by reading the library's actual public
   export surface (`libraries/<libname>/src/index.js` plus any subpath targets
   declared in `libraries/<libname>/package.json`'s `exports` map).
@@ -43,49 +43,48 @@ Seven files, all rewrites (no creates, no deletes):
 ## Ordering
 
 Rewrite files one at a time in the order listed above. After each file, run
-`bun run check` to confirm format/lint pass. Commit all seven files together
-at the end of the part — the branch does not need to be checkable at any
+`bun run check` to confirm format/lint pass. Commit all seven files together at
+the end of the part — the branch does not need to be checkable at any
 intermediate point.
 
 For each file, the rewrite recipe is:
 
 1. **Read the current file end-to-end.**
 2. **Inventory the library's actual exports.** For each library row you will
-   write, open `libraries/<libname>/src/index.js` plus every file referenced
-   in `libraries/<libname>/package.json`'s `exports` map. Collect every name
-   that appears as `export function X`, `export class X`, `export const X`,
-   `export { X }`, `export { X } from …`, or `export default`. De-dupe. This
-   is the source of truth for the `Key Exports` column.
+   write, open `libraries/<libname>/src/index.js` plus every file referenced in
+   `libraries/<libname>/package.json`'s `exports` map. Collect every name that
+   appears as `export function X`, `export class X`, `export const X`,
+   `export { X }`, `export { X } from …`, or `export default`. De-dupe. This is
+   the source of truth for the `Key Exports` column.
 3. **Draft the `Key Exports` cells.** Select a representative subset per row:
-   the primary class(es) and factory function(s) plus the highest-value
-   helpers. Do not list every export — the spec forbids the reverse check
-   precisely because internal helpers shouldn't pollute the discovery
-   surface. Aim for 3–6 names per row. Every name must resolve under Part
-   04's script.
-4. **Draft the `Capabilities` cells.** Verb-led phrases the way an agent
-   phrases a task: "retry a flaky fetch", "supervise a daemon", "render
-   markdown to terminal". Avoid library names.
-5. **Rewrite the frontmatter `description`.** Gather every `Capabilities`
-   phrase from step 4 across all rows in the table. Merge into one "Use when
-   …" paragraph, under ~100 words. Every row's capabilities must appear in
-   the description (the router only sees the frontmatter).
-6. **Update body intros.** Replace any reference to the old group name. Spot
-   the "When to Use" list, the Decision Guide heading introductions, and any
-   "# <Group Title>" H1 (e.g., "# Web Presentation" → "# Content"). Leave
-   recipe code blocks unchanged unless a library was added to the group
-   (then add one recipe or DI block for the new library).
-7. **Spot-verify the frontmatter.** Word count should be under ~120 (the
-   ~100 target plus a 20-word buffer; anything over is flagged to the
-   reviewer, not auto-blocked). Description must open with "Use when".
+   the primary class(es) and factory function(s) plus the highest-value helpers.
+   Do not list every export — the spec forbids the reverse check precisely
+   because internal helpers shouldn't pollute the discovery surface. Aim for 3–6
+   names per row. Every name must resolve under Part 04's script.
+4. **Draft the `Capabilities` cells.** Verb-led phrases the way an agent phrases
+   a task: "retry a flaky fetch", "supervise a daemon", "render markdown to
+   terminal". Avoid library names.
+5. **Rewrite the frontmatter `description`.** Gather every `Capabilities` phrase
+   from step 4 across all rows in the table. Merge into one "Use when …"
+   paragraph, under ~100 words. Every row's capabilities must appear in the
+   description (the router only sees the frontmatter).
+6. **Update body intros.** Replace any reference to the old group name. Spot the
+   "When to Use" list, the Decision Guide heading introductions, and any "#
+   <Group Title>" H1 (e.g., "# Web Presentation" → "# Content"). Leave recipe
+   code blocks unchanged unless a library was added to the group (then add one
+   recipe or DI block for the new library).
+7. **Spot-verify the frontmatter.** Word count should be under ~120 (the ~100
+   target plus a 20-word buffer; anything over is flagged to the reviewer, not
+   auto-blocked). Description must open with "Use when".
 
 ### Per-file rewrites
 
 #### 1. `libs-grpc-services/SKILL.md`
 
 - **Group title H1:** keep as "Service Infrastructure" or rename to "gRPC
-  Services" for consistency with the new directory name. **Decision:** rename
-  to "gRPC Services and Service Infrastructure". Naming the directory and the
-  H1 with compatible words helps readers who grep for "service".
+  Services" for consistency with the new directory name. **Decision:** rename to
+  "gRPC Services and Service Infrastructure". Naming the directory and the H1
+  with compatible words helps readers who grep for "service".
 - **Members (5):** librpc, libconfig, libtelemetry, libtype, libharness.
   Unchanged from old `libs-service-infrastructure`.
 - **`Key Exports` source-of-truth check (read at execution time):**
@@ -98,37 +97,38 @@ For each file, the rewrite recipe is:
   | libtype      | `libraries/libtype/src/index.js` (re-exports from `./generated/types/types.js`)                |
   | libharness   | `libraries/libharness/src/index.js` (re-exports from `./fixture/index.js`, `./mock/index.js`)  |
 
-  Known divergence from the current (stale) `Main API` column: librpc
-  exports `Server`/`Client`/`createClient` (not `RpcServer`/`RpcClient`/
+  Known divergence from the current (stale) `Main API` column: librpc exports
+  `Server`/`Client`/`createClient` (not `RpcServer`/`RpcClient`/
   `createClientFactory`). libconfig exports `createServiceConfig`/
   `createExtensionConfig`/`createScriptConfig` (not `serviceConfig`/…).
   libtelemetry's root index does **not** export `Tracer` — it lives at
-  `./tracer.js`; if the Key Exports cell lists `Tracer`, the Part 04 check
-  must be able to resolve it via the subpath export.
+  `./tracer.js`; if the Key Exports cell lists `Tracer`, the Part 04 check must
+  be able to resolve it via the subpath export.
+
 - **Body changes:** keep Decision Guide, Composition Recipes, DI Wiring
-  unchanged content-wise; update any stray "service-infrastructure" text to
-  the new group name. Update Recipe 1 code comments if they reference
-  `RpcServer` (rename to `Server`) — Part 02 is the natural place to fix
-  this stale reference from spec 130's pass.
+  unchanged content-wise; update any stray "service-infrastructure" text to the
+  new group name. Update Recipe 1 code comments if they reference `RpcServer`
+  (rename to `Server`) — Part 02 is the natural place to fix this stale
+  reference from spec 130's pass.
 
 #### 2. `libs-storage/SKILL.md`
 
 - **H1:** "Data Persistence" → "Storage".
 - **Members (6):** libstorage, libindex, libresource, libpolicy, libgraph,
   libvector. Unchanged.
-- **`Key Exports`:** read entry files under `libraries/{libstorage,libindex,
-  libresource,libpolicy,libgraph,libvector}/src/index.js` (plus any subpath
-  exports declared in each `package.json`).
+- **`Key Exports`:** read entry files under
+  `libraries/{libstorage,libindex, libresource,libpolicy,libgraph,libvector}/src/index.js`
+  (plus any subpath exports declared in each `package.json`).
   - libstorage: `createStorage`, `parseJsonl`, `serializeJsonl`
   - libindex: `Index`, `BufferedIndex` (check current exports)
   - libresource: `ResourceIndex`, `createResourceIndex`, `toResourceId`
   - libpolicy: `PolicyIndex`, `createPolicyIndex`
   - libgraph: `GraphIndex`, `createGraphIndex`, `PREFIXES`
-  - libvector: `VectorIndex`, `VectorProcessor` (verify — spec 130 flagged
-    this as potentially missing)
+  - libvector: `VectorIndex`, `VectorProcessor` (verify — spec 130 flagged this
+    as potentially missing)
 - **Body changes:** smallest of the six. Change H1 and update any "data
-  persistence" prose, but the Decision Guide and Recipes already use the
-  correct names after spec 130.
+  persistence" prose, but the Decision Guide and Recipes already use the correct
+  names after spec 130.
 
 #### 3. `libs-llm-and-agents/SKILL.md`
 
@@ -142,34 +142,45 @@ For each file, the rewrite recipe is:
   - libprompt: `PromptLoader`, `createPromptLoader`
   - libagent: `AgentMind`, `AgentAction` (verify)
   - libtool: `ToolProcessor`, `mapFieldToSchema`, `generateSchemaFromProtobuf`,
-    `buildToolDescription` (from `libraries/libtool/src/index.js` — confirmed
-    at planning time)
+    `buildToolDescription` (from `libraries/libtool/src/index.js` — confirmed at
+    planning time)
 - **Body changes:** add a `libtool` row to the table; add one Decision Guide
   bullet ("libtool vs libagent — `ToolProcessor` for binding a protobuf tool
-  service into an LLM-callable tool; `AgentMind` for running the
-  conversation"); add one DI Wiring code block showing `ToolProcessor`
-  construction.
+  service into an LLM-callable tool; `AgentMind` for running the conversation");
+  add one DI Wiring code block showing `ToolProcessor` construction.
 
 #### 4. `libs-content/SKILL.md`
 
 - **H1:** "Web Presentation" → "Content".
-- **Members (5):** libui, libformat, libweb, libdoc, libtemplate. `libcli`
-  and `librepl` move **out** to `libs-cli-and-tooling`.
-- **`Key Exports`:** existing rows stay, minus libcli and librepl.
-- **Body changes:** remove libcli and librepl from any Decision Guide /
-  Composition Recipes / DI Wiring content that currently references them.
-  (Grep inside the file before removing; if libcli/librepl appear only in
-  the table, only the table row removal is needed.)
-- **libdoc build outputs section** (currently at `libs-web-presentation/
-  SKILL.md` lines 144–167): preserve verbatim.
+- **Members (5):** libui, libformat, libweb, libdoc, libtemplate. libcli and
+  librepl are **not** present in the current `libs-web-presentation/SKILL.md`
+  `Libraries` table — CLAUDE.md lists them under the old `libs-web-presentation`
+  group but they never got a row (spec 400 §2 "Five libraries are missing or
+  incomplete"). No table-row removal is needed; the existing five rows (libui,
+  libformat, libweb, libdoc, libtemplate) get new column headers and their
+  `Key Exports` cells re-verified.
+- **`Key Exports`:** read each entry file; the spec 130 pass already put
+  plausible names into `Main API` but they must be re-verified against the
+  actual `src/index.js` of each library.
+- **Body changes:** grep the file for any prose reference to `libcli` or
+  `librepl` (`rg -n 'libcli|librepl' .claude/skills/libs-content/SKILL.md`) and
+  remove or redirect those references to `libs-cli-and-tooling`. Expected: zero
+  hits, because libcli/librepl were never integrated into the body either — but
+  verify at execution time.
+- **libdoc build outputs section** (currently at
+  `libs-web-presentation/ SKILL.md` lines 144–167 before Part 01's rename):
+  preserve verbatim.
 
 #### 5. `libs-cli-and-tooling/SKILL.md`
 
 - **H1:** "System Utilities" → "CLI and Tooling".
 - **Members (8):** **libcli**, **librepl**, libutil, libsecret, libsupervise,
-  librc, libcodegen, **libeval**. This is the biggest membership change —
-  three libraries inherited from `libs-system-utilities` plus libcli, librepl
-  (moved in) plus libeval (already in the old table).
+  librc, libcodegen, **libeval**. This is the biggest membership change — five
+  libraries inherited from the old `libs-system-utilities` table (libutil,
+  libsecret, libsupervise, librc, libcodegen) plus three new rows added from
+  scratch: libcli (moved from the old `libs-web-presentation` group in CLAUDE.md
+  but never in that table), librepl (same), and libeval (listed in CLAUDE.md
+  under `libs-system-utilities` but absent from the table per spec 400 §2).
 - **`Key Exports`:**
   - libcli: `Cli`, `createCli`, `HelpRenderer`, `SummaryRenderer`,
     `formatTable`, `colorize` (subset — libcli exports 17+ names)
@@ -190,31 +201,31 @@ For each file, the rewrite recipe is:
     `createAgentRunner`, `Supervisor`, `createSupervisor`, `TeeWriter`,
     `createTeeWriter`
 - **Body changes:**
-  - Decision Guide gains entries for libcli (CLI entry point vs REPL),
-    librepl (vs inline readline), libeval (trace processing, agent running,
-    supervisor loop). Remove libraries that moved **out** (libtool — moved
-    to `libs-llm-and-agents`; nothing else moves out).
+  - Decision Guide gains entries for libcli (CLI entry point vs REPL), librepl
+    (vs inline readline), libeval (trace processing, agent running, supervisor
+    loop). Remove libraries that moved **out** (libtool — moved to
+    `libs-llm-and-agents`; nothing else moves out).
   - Composition Recipes: keep the two existing recipes (supervise a service,
     generate secrets, generate code from proto) and add one recipe each for
     libcli (create a CLI entry point using `Cli` + `HelpRenderer`), librepl
     (start a REPL with `Repl`), libeval (run an agent with `AgentRunner`).
   - DI Wiring: add blocks for libcli, librepl, libeval.
   - Cross-reference line to `libs-grpc-services` for the `libtelemetry.Logger`
-    guidance ("for CLI logging, see libtelemetry in libs-grpc-services") —
-    one sentence, no duplication.
-  - Remove the libtool DI Wiring block if one exists (libtool was never in
-    the old `libs-system-utilities`, but double-check nothing references it).
+    guidance ("for CLI logging, see libtelemetry in libs-grpc-services") — one
+    sentence, no duplication.
+  - Remove the libtool DI Wiring block if one exists (libtool was never in the
+    old `libs-system-utilities`, but double-check nothing references it).
 - **This is the highest-risk file.** It has the most rows, the longest
-  description (8 libraries' verbs packed into ~100 words), and gains the
-  most new content. Review the frontmatter description last, after the
-  inner table is final, and count words.
+  description (8 libraries' verbs packed into ~100 words), and gains the most
+  new content. Review the frontmatter description last, after the inner table is
+  final, and count words.
 
 #### 6. `libs-synthetic-data/SKILL.md`
 
 - **H1:** "Synthetic Data Libraries" — unchanged.
 - **Members (4):** libsyntheticgen, libsyntheticprose, libsyntheticrender,
-  **libuniverse**. libuniverse is new to the table (currently referenced in
-  the body but not listed in the three-row `Libraries` table).
+  **libuniverse**. libuniverse is new to the table (currently referenced in the
+  body but not listed in the three-row `Libraries` table).
 - **`Key Exports`:**
   - libsyntheticgen: `DslParser`, `createDslParser`, `EntityGenerator`,
     `createEntityGenerator`, `createSeededRNG`, `collectProseKeys`,
@@ -228,20 +239,19 @@ For each file, the rewrite recipe is:
     other three libraries — do **not** list re-exports in libuniverse's row,
     since they belong to their originating libraries)
 - **Body changes:** add libuniverse row; the body Decision Guide already
-  explains the `libsyntheticgen vs libuniverse` distinction (see line 38 of
-  the current file), keep as-is; preserve the GetDX API References section,
+  explains the `libsyntheticgen vs libuniverse` distinction (see line 38 of the
+  current file), keep as-is; preserve the GetDX API References section,
   Verification section, and everything else below the Libraries table.
 
 #### 7. `libskill/SKILL.md`
 
 - **Frontmatter `description` rewrite.** Current description opens "Work with
-  the @forwardimpact/libskill package" — the anti-pattern. Rewrite as "Use
-  when deriving a job from Discipline × Level × Track, generating an agent
-  profile, resolving skill modifiers, producing stage transition checklists,
-  selecting interview questions by role, analysing career progression
-  between levels, or matching candidates to jobs." (draft; adjust wording to
-  stay under ~100 words and cover every function in
-  `libraries/libskill/src/*.js`).
+  the @forwardimpact/libskill package" — the anti-pattern. Rewrite as "Use when
+  deriving a job from Discipline × Level × Track, generating an agent profile,
+  resolving skill modifiers, producing stage transition checklists, selecting
+  interview questions by role, analysing career progression between levels, or
+  matching candidates to jobs." (draft; adjust wording to stay under ~100 words
+  and cover every function in `libraries/libskill/src/*.js`).
 - **Body:** no changes. libskill is pure functions and the existing body is
   accurate after spec 130's pass; no inner `Libraries` table to restructure.
 
@@ -271,9 +281,9 @@ Run at the package root after all seven files are rewritten, before committing:
 
 3. **Membership check.**
 
-   Visually confirm against the truth table in `plan-a.md § New six-group
-   truth table` that each file's `Libraries` table rows exactly match the
-   expected members.
+   Visually confirm against the truth table in
+   `plan-a.md § New six-group truth table` that each file's `Libraries` table
+   rows exactly match the expected members.
 
 4. **Word-count check on descriptions.**
 
@@ -289,46 +299,51 @@ Run at the package root after all seven files are rewritten, before committing:
    Expected: six lines, each under ~120 words. Over 120 is a flag for the
    reviewer, not an auto-block.
 
-5. **`bun run check` passes** (prettier reformats markdown tables, eslint
-   is no-op on markdown). Format changes are expected; commit the
-   reformatted output.
+5. **`bun run check` passes** (prettier reformats markdown tables, eslint is
+   no-op on markdown). Format changes are expected; commit the reformatted
+   output.
 
-6. **`bun run test` passes** — unchanged, but running it confirms nothing in
-   the SKILL.md rewrite affected any test.
+6. **`bun run test` passes** — unchanged, but running it confirms nothing in the
+   SKILL.md rewrite affected any test.
 
-7. **Part 04's `check:skill-exports`** is not yet wired in at this point.
-   The Part 02 output is the canonical input that Part 04 validates against;
-   any `Key Exports` name that doesn't resolve when Part 04 lands is a Part
-   02 bug to be fixed before Part 04 commits.
+7. **Manual `Key Exports` verification.** Part 04's `check:skill-exports` script
+   does not exist yet at Part 02 commit time. Verify every `Key Exports` cell by
+   reading the corresponding library's `src/index.js` and any subpath export
+   targets in its `package.json` at the moment the row is written. Do not copy
+   names from the old `Main API` column — spec 130's pass left some stale. When
+   Part 04 lands, the script must pass on Part 02's output on first run; any
+   failure is diagnosed as either a Part 04 parser bug (fix in the Part 04
+   commit) or a Part 02 row error (fix in a follow-up commit, or as an amendment
+   inside the Part 04 commit if still on the same branch pre-push).
 
 ## Risks
 
-1. **Description word cap vs coverage.** Already flagged in the plan
-   overview; main source of implementer judgement. Mitigation: review the
-   `libs-cli-and-tooling` description last, after all capabilities are
-   locked in.
+1. **Description word cap vs coverage.** Already flagged in the plan overview;
+   main source of implementer judgement. Mitigation: review the
+   `libs-cli-and-tooling` description last, after all capabilities are locked
+   in.
 
-2. **Stale names in existing tables.** The current `Main API` columns in
-   some files contain names that do not match the actual exports (e.g.,
-   `RpcServer` vs `Server` in librpc). **Do not copy stale names forward.**
-   Read the live entry file every time.
+2. **Stale names in existing tables.** The current `Main API` columns in some
+   files contain names that do not match the actual exports (e.g., `RpcServer`
+   vs `Server` in librpc). **Do not copy stale names forward.** Read the live
+   entry file every time.
 
 3. **Reserved future extensibility.** If a library grows a new public export
    after Part 02 lands but before Part 04's check is running in CI, the
-   advertised `Key Exports` cell is still valid (the check is
-   strict-positive) but the Capabilities column drifts. This is acceptable;
-   spec 130 and future spec are the continual correction mechanism.
+   advertised `Key Exports` cell is still valid (the check is strict-positive)
+   but the Capabilities column drifts. This is acceptable; spec 130 and future
+   spec are the continual correction mechanism.
 
-4. **libsyntheticrender has many domain-specific helpers**
-   (`generateDrugs`, `generatePlatforms`) that don't read like "synthetic
-   data" verbs. Include them in Key Exports if they are public but keep
-   Capabilities language at the level of "generate synthetic entities" — the
-   specific names are in Key Exports, the router signal is in Capabilities
-   and the frontmatter description.
+4. **libsyntheticrender has many domain-specific helpers** (`generateDrugs`,
+   `generatePlatforms`) that don't read like "synthetic data" verbs. Include
+   them in Key Exports if they are public but keep Capabilities language at the
+   level of "generate synthetic entities" — the specific names are in Key
+   Exports, the router signal is in Capabilities and the frontmatter
+   description.
 
-5. **Recipe code in Composition Recipes may reference symbols that were
-   renamed (e.g., `RpcServer`).** Fix as part of Part 02 — this is the last
-   chance to catch spec 130 drift before Part 04 locks the contract.
+5. **Recipe code in Composition Recipes may reference symbols that were renamed
+   (e.g., `RpcServer`).** Fix as part of Part 02 — this is the last chance to
+   catch spec 130 drift before Part 04 locks the contract.
 
 ## Commit
 

--- a/specs/400-library-skill-discovery/plan-a-03.md
+++ b/specs/400-library-skill-discovery/plan-a-03.md
@@ -12,34 +12,40 @@ Parts 01, 02, and 04 — can run in parallel with any of them.
 - Add a READ-DO checklist item to `CONTRIBUTING.md` that makes library search
   mandatory before writing a helper.
 - Update `gemba-plan` SKILL.md to require every `plan-a.md` to enumerate the
-  `@forwardimpact/lib*` packages and exports it uses (or explicitly state
-  that none are used).
+  `@forwardimpact/lib*` packages and exports it uses (or explicitly state that
+  none are used).
 - Add the six `libs-*` skills to `staff-engineer.md`'s `skills:` field so the
   library catalog is pre-loaded when the agent starts work.
 - Do **not** modify any other agent profile. Spec 400's success criterion 5
-  permits the plan to identify additional code-writing agents; this plan's
-  risk #6 in `plan-a.md` explains why only staff-engineer is in scope.
+  permits the plan to identify additional code-writing agents; this plan's risk
+  #6 in `plan-a.md` explains why only staff-engineer is in scope.
 
 ## Files touched
 
 Three files, all edits (no creates, no deletes):
 
 1. `CONTRIBUTING.md` — add one item to the `<read_do_checklist>` block.
-2. `.claude/skills/gemba-plan/SKILL.md` — add a "Libraries Used" requirement
-   to the plan structure guidance and to the DO-CONFIRM checklist.
+2. `.claude/skills/gemba-plan/SKILL.md` — add a "Libraries Used" requirement to
+   the plan structure guidance and to the DO-CONFIRM checklist.
 3. `.claude/agents/staff-engineer.md` — append six `libs-*` entries to the
    `skills:` list in frontmatter.
 
 ## Ordering
 
-Files are independent of each other. Edit in the order listed; one commit
-for all three.
+Files are independent of each other. Edit in the order listed; one commit for
+all three.
 
 ### 1. `CONTRIBUTING.md`
 
-Insert a new item into the `<read_do_checklist>` block at `CONTRIBUTING.md`
-lines 33–51. Place it after "Read the code" (line 39) and before "Simple
-over easy" (line 40), because library search is a read-before-write step.
+Insert a new item into the `<read_do_checklist>` block in `CONTRIBUTING.md`
+(currently lines 33–51 but anchor by bullet content, not line number, to survive
+any unrelated edit). Place it **between the 3rd bullet ("Read the code") and the
+4th bullet ("Simple over easy")** of the READ-DO checklist. After insertion the
+checklist has seven bullets in this order: Understand the task, Smallest plan,
+Read the code, **Search shared libraries first**, Simple over easy, No defensive
+code, Clean breaks. The placement is deliberate — library search is a
+read-before-write step, so it follows "Read the code" and precedes "Simple over
+easy".
 
 **New item (exact text, subject to wording review):**
 
@@ -52,18 +58,18 @@ over easy" (line 40), because library search is a read-before-write step.
 ```
 
 **Observable after edit:** `grep 'Search shared libraries' CONTRIBUTING.md`
-returns one hit inside the READ-DO block. The READ-DO checklist gains one
-item (seven items total, up from six).
+returns one hit inside the READ-DO block. The READ-DO checklist gains one item
+(seven items total, up from six).
 
 ### 2. `gemba-plan/SKILL.md`
 
 Two edits:
 
-**Edit 2a — add to "Writing a Plan (HOW)" guidance** (lines 117–144). Insert
-a new bullet between the existing "Decisions explained" and "Risks surfaced"
-bullets (or append at the end of the list — placement is reviewer
-preference; the default is to append so the order follows the natural
-workflow of "what to write last").
+**Edit 2a — add to "Writing a Plan (HOW)" guidance** (lines 117–144). Insert a
+new bullet between the existing "Decisions explained" and "Risks surfaced"
+bullets (or append at the end of the list — placement is reviewer preference;
+the default is to append so the order follows the natural workflow of "what to
+write last").
 
 New bullet (exact text, subject to wording review):
 
@@ -78,9 +84,9 @@ New bullet (exact text, subject to wording review):
   cheap.
 ```
 
-**Edit 2b — add to DO-CONFIRM checklist** (lines 41–55). Insert a new item
-just after "Risks surfaced" (line 48) and before "Execution recommendation
-present" (line 49):
+**Edit 2b — add to DO-CONFIRM checklist** (lines 41–55). Insert a new item just
+after "Risks surfaced" (line 48) and before "Execution recommendation present"
+(line 49):
 
 ```markdown
 - [ ] Libraries-used section present. Every shared library the
@@ -89,9 +95,9 @@ present" (line 49):
       used.
 ```
 
-**Observable after edit:** `gemba-plan` SKILL.md contains both the new
-writing guidance bullet and the DO-CONFIRM checklist item. The DO-CONFIRM
-block gains one item.
+**Observable after edit:** `gemba-plan` SKILL.md contains both the new writing
+guidance bullet and the DO-CONFIRM checklist item. The DO-CONFIRM block gains
+one item.
 
 ### 3. `.claude/agents/staff-engineer.md`
 
@@ -124,15 +130,15 @@ skills:
   - libskill
 ```
 
-**Observable after edit:** `.claude/agents/staff-engineer.md`'s `skills:`
-field contains all six `libs-*` entries plus `libskill`. These match the
-renamed directories after Part 01.
+**Observable after edit:** `.claude/agents/staff-engineer.md`'s `skills:` field
+contains all six `libs-*` entries plus `libskill`. These match the renamed
+directories after Part 01.
 
 **Dependency note:** This edit depends on Part 01 having renamed the
 directories. If Part 03 runs in parallel with Parts 01/02, the
-`staff-engineer.md` edit must be ordered **after** Part 01's commit or
-pulled into a separate commit sequenced after it. The simplest way is to
-run Part 03 sequentially after Part 01 lands on the branch.
+`staff-engineer.md` edit must be ordered **after** Part 01's commit or pulled
+into a separate commit sequenced after it. The simplest way is to run Part 03
+sequentially after Part 01 lands on the branch.
 
 ## Verification
 
@@ -178,40 +184,38 @@ Run at the package root after all three edits:
    grep -l 'libs-' .claude/agents/
    ```
 
-   Expected: `.claude/agents/staff-engineer.md` only. Any other hit is a
-   bug — Part 03 should not touch other agents.
+   Expected: `.claude/agents/staff-engineer.md` only. Any other hit is a bug —
+   Part 03 should not touch other agents.
 
 ## Risks
 
 1. **Checklist ordering in `CONTRIBUTING.md`.** Inserting a new item in the
-   middle of a well-established checklist is a documentation-stability
-   concern. The placement after "Read the code" and before "Simple over
-   easy" is deliberate: you can't reuse code you haven't read, and library
-   search is a form of reading. If the reviewer prefers the end of the
-   list, move it — the observable criterion is presence, not position.
+   middle of a well-established checklist is a documentation-stability concern.
+   The placement after "Read the code" and before "Simple over easy" is
+   deliberate: you can't reuse code you haven't read, and library search is a
+   form of reading. If the reviewer prefers the end of the list, move it — the
+   observable criterion is presence, not position.
 
-2. **"Libraries used" section in gemba-plan adds friction for trivial
-   plans.** Some plans (e.g., a typo fix) use no libraries and the "state
-   it explicitly" rule adds one boilerplate line to every such plan. This
-   is a deliberate cost: absence is a visible signal. If reviewer pushback
-   is strong, alternative is to scope the requirement to plans with >1
-   implementation step — but that creates a harder-to-enforce edge case.
-   Keep the universal rule.
+2. **"Libraries used" section in gemba-plan adds friction for trivial plans.**
+   Some plans (e.g., a typo fix) use no libraries and the "state it explicitly"
+   rule adds one boilerplate line to every such plan. This is a deliberate cost:
+   absence is a visible signal. If reviewer pushback is strong, alternative is
+   to scope the requirement to plans with >1 implementation step — but that
+   creates a harder-to-enforce edge case. Keep the universal rule.
 
-3. **staff-engineer pre-loads seven new skill files.** Skills have a cost
-   at agent startup (router scan and frontmatter load). Seven additional
-   skills (six `libs-*` + `libskill`) is a measurable but not problematic
-   overhead — existing agents load 3–5 skills and these files are small
-   (~150 lines each, ~50 KB total). No mitigation needed.
+3. **staff-engineer pre-loads seven new skill files.** Skills have a cost at
+   agent startup (router scan and frontmatter load). Seven additional skills
+   (six `libs-*` + `libskill`) is a measurable but not problematic overhead —
+   existing agents load 3–5 skills and these files are small (~150 lines each,
+   ~50 KB total). No mitigation needed.
 
 4. **Other code-writing agents may still miss libraries.** `product-manager`
-   writes fixes for trivial issues and has `gemba-plan` in its skills list
-   but not the `libs-*` skills. The spec's success criterion 5 says "staff
-   engineer and any other code-writing agent profile identified during
-   planning." The plan identifies only `staff-engineer` as the primary
-   implementation agent; if the reviewer thinks product-manager's fix
-   workflow also needs library discovery, expand the edit to its profile
-   too. Flag to reviewer.
+   writes fixes for trivial issues and has `gemba-plan` in its skills list but
+   not the `libs-*` skills. The spec's success criterion 5 says "staff engineer
+   and any other code-writing agent profile identified during planning." The
+   plan identifies only `staff-engineer` as the primary implementation agent; if
+   the reviewer thinks product-manager's fix workflow also needs library
+   discovery, expand the edit to its profile too. Flag to reviewer.
 
 ## Commit
 

--- a/specs/400-library-skill-discovery/plan-a-03.md
+++ b/specs/400-library-skill-discovery/plan-a-03.md
@@ -1,0 +1,229 @@
+# Plan A Part 03 — Discovery protocol
+
+Part 3 of 4 of [plan-a](plan-a.md) for [spec 400](spec.md).
+
+Adds library discovery as an explicit requirement in three places: the
+contributor workflow (`CONTRIBUTING.md` READ-DO), the planning skill
+(`gemba-plan` SKILL.md), and the staff-engineer agent profile. Independent of
+Parts 01, 02, and 04 — can run in parallel with any of them.
+
+## Scope
+
+- Add a READ-DO checklist item to `CONTRIBUTING.md` that makes library search
+  mandatory before writing a helper.
+- Update `gemba-plan` SKILL.md to require every `plan-a.md` to enumerate the
+  `@forwardimpact/lib*` packages and exports it uses (or explicitly state
+  that none are used).
+- Add the six `libs-*` skills to `staff-engineer.md`'s `skills:` field so the
+  library catalog is pre-loaded when the agent starts work.
+- Do **not** modify any other agent profile. Spec 400's success criterion 5
+  permits the plan to identify additional code-writing agents; this plan's
+  risk #6 in `plan-a.md` explains why only staff-engineer is in scope.
+
+## Files touched
+
+Three files, all edits (no creates, no deletes):
+
+1. `CONTRIBUTING.md` — add one item to the `<read_do_checklist>` block.
+2. `.claude/skills/gemba-plan/SKILL.md` — add a "Libraries Used" requirement
+   to the plan structure guidance and to the DO-CONFIRM checklist.
+3. `.claude/agents/staff-engineer.md` — append six `libs-*` entries to the
+   `skills:` list in frontmatter.
+
+## Ordering
+
+Files are independent of each other. Edit in the order listed; one commit
+for all three.
+
+### 1. `CONTRIBUTING.md`
+
+Insert a new item into the `<read_do_checklist>` block at `CONTRIBUTING.md`
+lines 33–51. Place it after "Read the code" (line 39) and before "Simple
+over easy" (line 40), because library search is a read-before-write step.
+
+**New item (exact text, subject to wording review):**
+
+```markdown
+- [ ] **Search shared libraries first.** Before writing a helper, utility,
+      retry wrapper, argument parser, or any other generic capability,
+      search `libraries/` and the `libs-*` skill group that covers the task.
+      If a shared library already provides the capability, use it. If not,
+      note that in the commit or plan so future contributors don't re-search.
+```
+
+**Observable after edit:** `grep 'Search shared libraries' CONTRIBUTING.md`
+returns one hit inside the READ-DO block. The READ-DO checklist gains one
+item (seven items total, up from six).
+
+### 2. `gemba-plan/SKILL.md`
+
+Two edits:
+
+**Edit 2a — add to "Writing a Plan (HOW)" guidance** (lines 117–144). Insert
+a new bullet between the existing "Decisions explained" and "Risks surfaced"
+bullets (or append at the end of the list — placement is reviewer
+preference; the default is to append so the order follows the natural
+workflow of "what to write last").
+
+New bullet (exact text, subject to wording review):
+
+```markdown
+- **Libraries used.** Every plan must include a "Libraries used" section
+  listing the `@forwardimpact/lib*` packages the implementation will
+  consume, with the specific exports it will call (e.g., `libutil.Retry`,
+  `libcli.Cli`, `libtelemetry.createLogger`). If the plan uses no shared
+  libraries, state that explicitly — absence is a visible signal, not a
+  default. This catches "write a helper" steps that could be replaced by an
+  existing library before implementation starts, when substitution is
+  cheap.
+```
+
+**Edit 2b — add to DO-CONFIRM checklist** (lines 41–55). Insert a new item
+just after "Risks surfaced" (line 48) and before "Execution recommendation
+present" (line 49):
+
+```markdown
+- [ ] Libraries-used section present. Every shared library the
+      implementation will consume is listed by package and by specific
+      exports, or the section explicitly states no shared libraries are
+      used.
+```
+
+**Observable after edit:** `gemba-plan` SKILL.md contains both the new
+writing guidance bullet and the DO-CONFIRM checklist item. The DO-CONFIRM
+block gains one item.
+
+### 3. `.claude/agents/staff-engineer.md`
+
+Extend the `skills:` list in frontmatter (currently lines 8–13):
+
+**Before:**
+
+```yaml
+skills:
+  - gemba-plan
+  - gemba-implement
+  - gemba-review
+  - gemba-gh-cli
+```
+
+**After:**
+
+```yaml
+skills:
+  - gemba-plan
+  - gemba-implement
+  - gemba-review
+  - gemba-gh-cli
+  - libs-grpc-services
+  - libs-storage
+  - libs-llm-and-agents
+  - libs-content
+  - libs-cli-and-tooling
+  - libs-synthetic-data
+  - libskill
+```
+
+**Observable after edit:** `.claude/agents/staff-engineer.md`'s `skills:`
+field contains all six `libs-*` entries plus `libskill`. These match the
+renamed directories after Part 01.
+
+**Dependency note:** This edit depends on Part 01 having renamed the
+directories. If Part 03 runs in parallel with Parts 01/02, the
+`staff-engineer.md` edit must be ordered **after** Part 01's commit or
+pulled into a separate commit sequenced after it. The simplest way is to
+run Part 03 sequentially after Part 01 lands on the branch.
+
+## Verification
+
+Run at the package root after all three edits:
+
+1. **READ-DO item count.**
+
+   ```sh
+   awk '/<read_do_checklist/,/<\/read_do_checklist/' CONTRIBUTING.md | grep -c '^- \[ \]'
+   ```
+
+   Expected: `7` (was 6).
+
+2. **gemba-plan DO-CONFIRM item count.**
+
+   ```sh
+   awk '/<do_confirm_checklist/,/<\/do_confirm_checklist/' .claude/skills/gemba-plan/SKILL.md | grep -c '^- \[ \]'
+   ```
+
+   Expected: one more than the current count (currently 8, so 9 after).
+
+3. **gemba-plan "Libraries used" guidance present.**
+
+   ```sh
+   grep -n 'Libraries used' .claude/skills/gemba-plan/SKILL.md
+   ```
+
+   Expected: two hits (one in Writing a Plan, one in DO-CONFIRM).
+
+4. **staff-engineer skills list.**
+
+   ```sh
+   awk '/^skills:/,/^---/' .claude/agents/staff-engineer.md | grep -c 'libs-'
+   ```
+
+   Expected: `6` (six `libs-*` entries). Plus one `libskill` entry.
+
+5. **`bun run check` passes.**
+
+6. **No drift in other agent profiles.**
+
+   ```sh
+   grep -l 'libs-' .claude/agents/
+   ```
+
+   Expected: `.claude/agents/staff-engineer.md` only. Any other hit is a
+   bug — Part 03 should not touch other agents.
+
+## Risks
+
+1. **Checklist ordering in `CONTRIBUTING.md`.** Inserting a new item in the
+   middle of a well-established checklist is a documentation-stability
+   concern. The placement after "Read the code" and before "Simple over
+   easy" is deliberate: you can't reuse code you haven't read, and library
+   search is a form of reading. If the reviewer prefers the end of the
+   list, move it — the observable criterion is presence, not position.
+
+2. **"Libraries used" section in gemba-plan adds friction for trivial
+   plans.** Some plans (e.g., a typo fix) use no libraries and the "state
+   it explicitly" rule adds one boilerplate line to every such plan. This
+   is a deliberate cost: absence is a visible signal. If reviewer pushback
+   is strong, alternative is to scope the requirement to plans with >1
+   implementation step — but that creates a harder-to-enforce edge case.
+   Keep the universal rule.
+
+3. **staff-engineer pre-loads seven new skill files.** Skills have a cost
+   at agent startup (router scan and frontmatter load). Seven additional
+   skills (six `libs-*` + `libskill`) is a measurable but not problematic
+   overhead — existing agents load 3–5 skills and these files are small
+   (~150 lines each, ~50 KB total). No mitigation needed.
+
+4. **Other code-writing agents may still miss libraries.** `product-manager`
+   writes fixes for trivial issues and has `gemba-plan` in its skills list
+   but not the `libs-*` skills. The spec's success criterion 5 says "staff
+   engineer and any other code-writing agent profile identified during
+   planning." The plan identifies only `staff-engineer` as the primary
+   implementation agent; if the reviewer thinks product-manager's fix
+   workflow also needs library discovery, expand the edit to its profile
+   too. Flag to reviewer.
+
+## Commit
+
+One commit:
+
+```
+docs(protocol): require library discovery in contributor workflow (spec 400 part 3/4)
+
+- CONTRIBUTING.md READ-DO: add "search shared libraries first" checklist item
+- gemba-plan SKILL.md: plans must enumerate @forwardimpact/lib* usage
+- staff-engineer agent profile: pre-load libs-* skills so the library
+  catalog is in context at task start
+```
+
+— Staff Engineer 🛠️

--- a/specs/400-library-skill-discovery/plan-a-04.md
+++ b/specs/400-library-skill-discovery/plan-a-04.md
@@ -13,56 +13,53 @@ must exist; unadvertised library exports are fine.
 
 - Create `scripts/check-skill-exports.js` (new file).
 - Add `check:skill-exports` to `package.json` scripts.
-- Wire `check:skill-exports` into `bun run check`.
-- Update `.github/workflows/check-quality.yml` (or whichever workflow runs
-  `bun run check` in CI) only if it doesn't already invoke `bun run check`
-  wholesale — most likely no workflow change is needed because the script is
-  chained behind `bun run check`.
-- Deliberately out of scope: reverse direction check ("every public export
-  must be advertised"), cross-library duplication check, any language server
+- Wire `check:skill-exports` into `bun run check` so local checks fail on drift.
+- **Add a `check-skill-exports` job to `.github/workflows/check-quality.yml`**
+  mirroring the existing `check-exports` job. This is required, not optional —
+  the current workflow runs `bun run check:exports` as a standalone job
+  (`.github/workflows/check-quality.yml:33–39`) and does **not** invoke
+  `bun run check` wholesale, so chaining the new script behind `bun run check`
+  only affects local runs. Without the workflow edit, spec 400 success criterion
+  6 ("verifiable … in the `check-quality` CI workflow") cannot be met.
+- Deliberately out of scope: reverse direction check ("every public export must
+  be advertised"), cross-library duplication check, any language server
   integration.
 
 ## Files touched
 
-Two files, one new:
+Three files, one new:
 
 1. `scripts/check-skill-exports.js` (new) — ~150 lines.
 2. `package.json` (edit) — add one script entry, extend the `check` chain.
-
-Optional third file:
-
-3. `.github/workflows/check-quality.yml` — only if the current workflow
-   invokes `bun run check:exports` directly instead of `bun run check`.
-   At planning time the CI config was not exhaustively audited; the
-   implementer verifies during execution.
+3. `.github/workflows/check-quality.yml` (edit) — add one new job,
+   `check-skill-exports`, mirroring the existing `check-exports` job at lines
+   33–39.
 
 ## Ordering
 
 1. **Draft the script.** See § Script design below.
 2. **Wire into `package.json`.** Add
-   `"check:skill-exports": "node scripts/check-skill-exports.js"` to
-   `scripts`, and extend the `check` chain from
+   `"check:skill-exports": "node scripts/check-skill-exports.js"` to `scripts`,
+   and extend the `check` chain from
    `"bun run format && bun run lint && bun run layout && bun run check:exports"`
    to
    `"bun run format && bun run lint && bun run layout && bun run check:exports && bun run check:skill-exports"`.
-3. **Run locally.** Expected result: all rows resolve, the script prints
+3. **Add the CI job.** Edit `.github/workflows/check-quality.yml` to add a new
+   job `check-skill-exports` mirroring the existing `check-exports` job. See §
+   Workflow edit below for the exact diff.
+4. **Run locally.** Expected result: all rows resolve, the script prints
    `All libs-* Key Exports resolve.` and exits 0.
-4. **Verify drift detection.** Manually rename one exported symbol in a
-   library (e.g., rename `Cli` to `TempCli` in
-   `libraries/libcli/src/cli.js` and remove it from `src/index.js`) and
-   re-run the script. Expected: exit code 1, error message names the
-   SKILL.md file and the missing export. Revert the rename before
-   committing.
-5. **Check CI workflow.** `grep -n 'check:exports\|bun run check' .github/workflows/*.yml`
-   — confirm the workflow runs `bun run check` (which now chains
-   `check:skill-exports`) rather than `bun run check:exports` directly.
-   Edit the workflow if the latter.
+5. **Verify drift detection.** Manually rename one exported symbol in a library
+   (e.g., rename `Cli` to `TempCli` in `libraries/libcli/src/cli.js` and remove
+   it from `src/index.js`) and re-run the script. Expected: exit code 1, error
+   message names the SKILL.md file and the missing export. Revert the rename
+   before committing.
 6. **Commit.**
 
 ## Script design
 
-The script lives at `scripts/check-skill-exports.js` and follows the
-structure of the existing `scripts/check-exports-resolve.js` (spec 390).
+The script lives at `scripts/check-skill-exports.js` and follows the structure
+of the existing `scripts/check-exports-resolve.js` (spec 390).
 
 ### Algorithm
 
@@ -90,25 +87,24 @@ structure of the existing `scripts/check-exports-resolve.js` (spec 390).
         value is not a .js file (e.g., "./css/*": "./src/css/*" is not a
         module, skip).
      c. For each target file, parse it as ES module source to collect
-        export names. Three cases:
-          - `export function X(…)`      → add "X"
-          - `export async function X(…)` → add "X"
-          - `export class X { … }`       → add "X"
-          - `export const X = …`         → add "X" (and any other
-                                             destructured `let`/`const`)
-          - `export { X, Y, Z }`         → add each
-          - `export { X, Y } from "…"`   → add each (re-exports count as
-                                             the importing file's public
-                                             surface)
-          - `export * from "…"`          → recursively collect exports
-                                             from the referenced file
-          - `export default …`           → add "default" (rarely used in
-                                             Key Exports, but support it)
+        export names. Read the whole file as a string and apply the
+        regex set in § Parsing constraints. Cases handled:
+          - `export function X(…)` / `export async function X(…)` → add "X"
+          - `export class X { … }`                                 → add "X"
+          - `export const X = …` (also let, var)                   → add "X"
+          - `export { X, Y, Z }` (possibly multi-line)             → add each
+          - `export { X, Y } from "…"` (possibly multi-line)       → add each
+                                                                     and recurse
+                                                                     into "…"
+          - `export * from "…"`                                    → recurse into "…"
+          - `export default …`                                     → add "default"
         Use a regex-based scan, not a full parser — the library sources
         are all ES module syntax and the regex set is small. The
         existing `check-exports-resolve.js` is pure regex-free (it only
         resolves file paths) so this is a new parsing responsibility;
-        keep it tight and inline.
+        keep it tight and inline. Multi-line blocks and package-name
+        re-exports are handled; see § Parsing constraints and
+        § Recursive resolution for the concrete rules.
 
      d. De-dupe the collected names into a Set.
 
@@ -127,46 +123,68 @@ structure of the existing `scripts/check-exports-resolve.js` (spec 390).
 
 ### Parsing constraints
 
-- **Markdown table parsing.** The `libs-*/SKILL.md` files all use GFM
-  pipe tables. Header is one row starting with `|`, the next row is the
-  separator `| --- |`, data rows follow until a blank line or a non-pipe
-  line. The parser must handle leading/trailing pipes and pad columns
-  robustly. Do **not** import a third-party markdown parser — the pattern
-  is regular enough to parse inline in ~30 lines.
-- **ES module export scan.** Use these regexes against the file
-  contents:
-  - `^export\s+(async\s+)?function\s+(\w+)` → capture group 2
-  - `^export\s+class\s+(\w+)` → capture group 1
-  - `^export\s+(const|let|var)\s+(\w+)` → capture group 2
-  - `^export\s+\{([^}]+)\}` → split group 1 by `,`, trim, strip any `as X`
-    alias (the aliased name is what's public)
-  - `^export\s+\*\s+from\s+["']([^"']+)["']` → recurse into the referenced
-    file (resolve relative to the current file)
-  - `^export\s+default` → add the literal `"default"`
+- **Markdown table parsing.** The `libs-*/SKILL.md` files all use GFM pipe
+  tables. Header is one row starting with `|`, the next row is the separator
+  `| --- |`, data rows follow until a blank line or a non-pipe line. The parser
+  must handle leading/trailing pipes and pad columns robustly. Do **not** import
+  a third-party markdown parser — the pattern is regular enough to parse inline
+  in ~30 lines.
+- **ES module export scan.** Read each target file as a single string and run
+  these regexes over the full contents (not line-by-line), because
+  `export { … }` and `export { … } from` blocks span multiple lines in real
+  libraries (e.g., `libraries/libuniverse/src/index.js:1–27` has three 6–10 line
+  blocks).
+  - Functions: `/export\s+(?:async\s+)?function\s+(\w+)/g` → group 1
+  - Classes: `/export\s+class\s+(\w+)/g` → group 1
+  - Variables: `/export\s+(?:const|let|var)\s+(\w+)/g` → group 1
+  - Named export blocks:
+    `/export\s+\{([\s\S]*?)\}(?:\s*from\s+["']([^"']+)["'])?/g` → parse group 1
+    as a comma-separated list; for each entry, strip whitespace and newlines,
+    handle `X as Y` (add the aliased name `Y`, which is what's publicly
+    visible), add to the collected set. If group 2 is present (re-export form),
+    also enqueue group 2's resolved file for recursive scanning — see §
+    Recursive resolution below.
+  - Wildcard re-exports: `/export\s+\*\s+from\s+["']([^"']+)["']/g` → enqueue
+    the referenced file for recursive scanning.
+  - Default: `/export\s+default\b/` → add the literal `"default"`.
 
-  Scan line-by-line with `m` flag. Do not attempt to handle
+  The `[\s\S]*?` class is deliberate — `.` does not cross newlines by default,
+  and `[\s\S]` does. Use the `g` flag with no `m` anchor so blocks matching
+  across newlines work. Do not attempt to handle
   `import { X }; export { X as Y }` chained across statements — none of the
   current libraries use that pattern. If one appears, add a regex for it.
 
-- **Circular re-exports.** libuniverse re-exports from libsyntheticgen,
-  libsyntheticprose, libsyntheticrender. The scan must follow
-  `export * from "@forwardimpact/libX"` **inside a library's source** by
-  resolving the package name to `libraries/libX/src/index.js` and continuing
-  the scan. Guard against infinite recursion with a visited set keyed by
-  absolute path.
+- **Recursive resolution of re-exports.** The scanner must resolve the source
+  path inside `export { … } from "…"` and `export * from "…"` in two cases:
+  1. **Relative path** (e.g., `./generated/types/types.js`, as in
+     `libraries/libtype/src/index.js`): resolve relative to the current file's
+     directory and recurse.
+  2. **Package specifier** (e.g., `@forwardimpact/libsyntheticgen`, as in
+     `libraries/libuniverse/src/index.js`): map the package name to
+     `libraries/<libname>/src/index.js` by stripping the `@forwardimpact/`
+     prefix. Recurse into that file's export scan. This is the only
+     package-specifier form the scanner must handle; no other registries or
+     aliases are used in `libraries/`.
 
-- **Backticks in Key Exports cells.** The SKILL.md tables may write
-  exports as `` `Cli` `` to render as inline code. Strip backticks before
-  matching.
+  Both cases share a visited set keyed by absolute file path to guard against
+  cycles.
+
+- **Circular re-exports.** libuniverse re-exports from libsyntheticgen,
+  libsyntheticprose, libsyntheticrender via `@forwardimpact/libX` package
+  specifiers (see `libraries/libuniverse/src/index.js:1–27`). The recursive
+  resolution above handles this; the visited set prevents infinite loops if any
+  library re-exports back into libuniverse (none do today).
+
+- **Backticks in Key Exports cells.** The SKILL.md tables may write exports as
+  `` `Cli` `` to render as inline code. Strip backticks before matching.
 
 ### CLI ergonomics
 
 - `node scripts/check-skill-exports.js` — default, runs the check.
-- `node scripts/check-skill-exports.js --verbose` — prints the resolved
-  export set for each library, useful for debugging. Optional flag; the
-  implementer may skip it if complexity isn't worth it.
-- Exit code: 0 on success, 1 on any failure. Matches
-  `check-exports-resolve.js`.
+- `node scripts/check-skill-exports.js --verbose` — prints the resolved export
+  set for each library, useful for debugging. Optional flag; the implementer may
+  skip it if complexity isn't worth it.
+- Exit code: 0 on success, 1 on any failure. Matches `check-exports-resolve.js`.
 
 ### Example error output
 
@@ -195,6 +213,32 @@ Checked 6 libs-* skill files, 33 library rows, 142 key exports.
    "lint": "eslint .",
 ```
 
+## Workflow edit
+
+`.github/workflows/check-quality.yml` runs the existing checks as separate jobs:
+`lint`, `format`, `layout`, `check-exports`. The new check needs a matching job.
+Append after the existing `check-exports` block:
+
+```diff
+   check-exports:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+       - uses: ./.github/actions/bootstrap
+       - run: bun run check:exports
++
++  check-skill-exports:
++    runs-on: ubuntu-latest
++    steps:
++      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
++      - uses: ./.github/actions/bootstrap
++      - run: bun run check:skill-exports
+```
+
+The new job uses the same bootstrap action and runs the new `package.json`
+script. Pin the checkout action to the exact SHA already used by the file. Do
+not introduce a new checkout version.
+
 ## Verification
 
 Run at the package root:
@@ -210,16 +254,16 @@ Run at the package root:
 2. **Script catches a synthetic drift.**
 
    Introduce a deliberate misspelling in
-   `.claude/skills/libs-cli-and-tooling/SKILL.md` — change `Cli` to
-   `CliXYZ` in one Key Exports cell — and re-run:
+   `.claude/skills/libs-cli-and-tooling/SKILL.md` — change `Cli` to `CliXYZ` in
+   one Key Exports cell — and re-run:
 
    ```sh
    node scripts/check-skill-exports.js; echo "exit=$?"
    ```
 
    Expected: exit 1, error message identifies
-   `libs-cli-and-tooling/SKILL.md: libcli.CliXYZ is not a public export`.
-   Revert the edit before continuing.
+   `libs-cli-and-tooling/SKILL.md: libcli.CliXYZ is not a public export`. Revert
+   the edit before continuing.
 
 3. **`bun run check` chains the new script.**
 
@@ -227,74 +271,68 @@ Run at the package root:
    bun run check
    ```
 
-   Expected: runs format, lint, layout, check:exports, check:skill-exports
-   in that order, and exits 0. Intentionally break one Key Exports cell to
-   confirm the chain halts; revert.
+   Expected: runs format, lint, layout, check:exports, check:skill-exports in
+   that order, and exits 0. Intentionally break one Key Exports cell to confirm
+   the chain halts; revert.
 
 4. **CI workflow sanity.**
 
    ```sh
-   rg -n 'bun run check' .github/workflows/
+   rg -n 'check-skill-exports|check:skill-exports' .github/workflows/
    ```
 
-   Confirm at least one workflow calls `bun run check` (not just
-   `bun run check:exports`) so the new step runs in CI. If not, edit the
-   workflow to call `bun run check` and commit the workflow change in the
-   same Part 04 commit.
+   Expected: at least one hit showing the new `check-skill-exports` job and its
+   `run:` line. If missing, the workflow edit from § Workflow edit was not
+   applied — fix before committing.
 
 5. **No false positives from libtelemetry subpath exports.** `libtelemetry`
-   publishes `./tracer.js` as a subpath. Any Key Exports row listing
-   `Tracer` (defined in `libraries/libtelemetry/src/tracer.js`) must
-   resolve under the script. Confirm by running the check on the final
-   Part 02 output.
+   publishes `./tracer.js` as a subpath. Any Key Exports row listing `Tracer`
+   (defined in `libraries/libtelemetry/src/tracer.js`) must resolve under the
+   script. Confirm by running the check on the final Part 02 output.
 
 6. **No false positives from libuniverse re-exports.**
    `libraries/libuniverse/src/index.js` contains
-   `export { DslParser, … } from "@forwardimpact/libsyntheticgen"`. If Part
-   02 lists `DslParser` under the libuniverse row (it shouldn't — the plan
-   says leave re-exports out of libuniverse's row), the check still resolves
-   because re-exports count as the importing file's public surface. The
-   check should pass either way; the stylistic decision is Part 02's.
+   `export { DslParser, … } from "@forwardimpact/libsyntheticgen"`. If Part 02
+   lists `DslParser` under the libuniverse row (it shouldn't — the plan says
+   leave re-exports out of libuniverse's row), the check still resolves because
+   re-exports count as the importing file's public surface. The check should
+   pass either way; the stylistic decision is Part 02's.
 
 ## Risks
 
 1. **Regex-based ES module parsing is fragile.** A library using
-   `export {\n  foo,\n  bar,\n} from "./x.js"` across multiple lines may
-   break a line-by-line regex. Mitigation: the script reads each file as
-   a whole string and runs the export-block regex with the `m` flag and
-   multiline-friendly bracket matching. If any library uses unusual
-   export syntax, the check fails loudly on that library — easy to
-   diagnose.
+   `export {\n  foo,\n  bar,\n} from "./x.js"` across multiple lines may break a
+   line-by-line regex. Mitigation: the script reads each file as a whole string
+   and runs the export-block regex with the `m` flag and multiline-friendly
+   bracket matching. If any library uses unusual export syntax, the check fails
+   loudly on that library — easy to diagnose.
 
 2. **`export * from` cycles.** libuniverse re-exports from three other
-   libraries. If one of those re-exports back (they don't today), the
-   scan would infinite-loop. Mitigation: visited-set guard keyed by
-   absolute file path.
+   libraries. If one of those re-exports back (they don't today), the scan would
+   infinite-loop. Mitigation: visited-set guard keyed by absolute file path.
 
 3. **Subpath wildcards.** libui has `"./components/*": "./src/components/*.js"`.
    The script must **skip** wildcard subpaths when collecting target files —
-   they are consumer-specific and can't be enumerated without a concrete
-   import path. This matches the behaviour of
-   `scripts/check-exports-resolve.js:46–48` which also skips wildcards.
+   they are consumer-specific and can't be enumerated without a concrete import
+   path. This matches the behaviour of `scripts/check-exports-resolve.js:46–48`
+   which also skips wildcards.
 
-4. **`./css/*` non-JS subpaths.** libui also has
-   `"./css/*": "./src/css/*"` pointing at CSS files. The script must skip
-   any subpath target whose file extension is not `.js`/`.mjs`. Matches
-   consumer expectation: you don't "export" a symbol from a CSS file.
+4. **`./css/*` non-JS subpaths.** libui also has `"./css/*": "./src/css/*"`
+   pointing at CSS files. The script must skip any subpath target whose file
+   extension is not `.js`/`.mjs`. Matches consumer expectation: you don't
+   "export" a symbol from a CSS file.
 
-5. **libtype re-exports from generated code.** `libtype/src/index.js`
-   does `export * from "./generated/types/types.js"`. The generated file
-   is ~thousands of lines. Parsing it is slow but not unacceptable
-   (~100ms). If the check becomes a CI bottleneck, add a cache keyed by
-   file mtime. Not worth doing in Part 04 unless measurement shows a
-   problem.
+5. **libtype re-exports from generated code.** `libtype/src/index.js` does
+   `export * from "./generated/types/types.js"`. The generated file is
+   ~thousands of lines. Parsing it is slow but not unacceptable (~100ms). If the
+   check becomes a CI bottleneck, add a cache keyed by file mtime. Not worth
+   doing in Part 04 unless measurement shows a problem.
 
-6. **New failure mode in CI.** After Part 04 merges, any library refactor
-   that removes a public export without updating the corresponding
-   `libs-*/SKILL.md` row fails CI. This is intentional and is the success
-   criterion. Document in the script's error output how to fix:
-   "Update the Key Exports cell in <SKILL.md> to match, or restore the
-   export."
+6. **New failure mode in CI.** After Part 04 merges, any library refactor that
+   removes a public export without updating the corresponding `libs-*/SKILL.md`
+   row fails CI. This is intentional and is the success criterion. Document in
+   the script's error output how to fix: "Update the Key Exports cell in
+   <SKILL.md> to match, or restore the export."
 
 ## Commit
 
@@ -305,8 +343,9 @@ feat(ci): add check:skill-exports script (spec 400 part 4/4)
 
 New script scripts/check-skill-exports.js asserts every name in a
 `Key Exports` cell of a libs-*/SKILL.md resolves to a public export of
-the corresponding library package. Wired into `bun run check` so
-drift fails locally and in the check-quality CI workflow.
+the corresponding library package. Wired into `bun run check` for
+local runs, and added as a new `check-skill-exports` job in
+.github/workflows/check-quality.yml so drift fails in CI too.
 
 Structurally equivalent to scripts/check-exports-resolve.js (spec 390):
 strict-positive resolution only (the reverse direction is intentionally

--- a/specs/400-library-skill-discovery/plan-a-04.md
+++ b/specs/400-library-skill-discovery/plan-a-04.md
@@ -1,0 +1,316 @@
+# Plan A Part 04 — CI guard against `Key Exports` drift
+
+Part 4 of 4 of [plan-a](plan-a.md) for [spec 400](spec.md). Depends on Part 02.
+
+Adds a new script, `scripts/check-skill-exports.js`, that enforces the core
+invariant from spec 400 Move 4: **every name in a `Key Exports` cell of any
+`libs-*/SKILL.md` must resolve to a public export of the corresponding
+library.** The script runs as part of `bun run check` and the `check-quality`
+GitHub Actions workflow. The check is strict-positive only: advertised names
+must exist; unadvertised library exports are fine.
+
+## Scope
+
+- Create `scripts/check-skill-exports.js` (new file).
+- Add `check:skill-exports` to `package.json` scripts.
+- Wire `check:skill-exports` into `bun run check`.
+- Update `.github/workflows/check-quality.yml` (or whichever workflow runs
+  `bun run check` in CI) only if it doesn't already invoke `bun run check`
+  wholesale — most likely no workflow change is needed because the script is
+  chained behind `bun run check`.
+- Deliberately out of scope: reverse direction check ("every public export
+  must be advertised"), cross-library duplication check, any language server
+  integration.
+
+## Files touched
+
+Two files, one new:
+
+1. `scripts/check-skill-exports.js` (new) — ~150 lines.
+2. `package.json` (edit) — add one script entry, extend the `check` chain.
+
+Optional third file:
+
+3. `.github/workflows/check-quality.yml` — only if the current workflow
+   invokes `bun run check:exports` directly instead of `bun run check`.
+   At planning time the CI config was not exhaustively audited; the
+   implementer verifies during execution.
+
+## Ordering
+
+1. **Draft the script.** See § Script design below.
+2. **Wire into `package.json`.** Add
+   `"check:skill-exports": "node scripts/check-skill-exports.js"` to
+   `scripts`, and extend the `check` chain from
+   `"bun run format && bun run lint && bun run layout && bun run check:exports"`
+   to
+   `"bun run format && bun run lint && bun run layout && bun run check:exports && bun run check:skill-exports"`.
+3. **Run locally.** Expected result: all rows resolve, the script prints
+   `All libs-* Key Exports resolve.` and exits 0.
+4. **Verify drift detection.** Manually rename one exported symbol in a
+   library (e.g., rename `Cli` to `TempCli` in
+   `libraries/libcli/src/cli.js` and remove it from `src/index.js`) and
+   re-run the script. Expected: exit code 1, error message names the
+   SKILL.md file and the missing export. Revert the rename before
+   committing.
+5. **Check CI workflow.** `grep -n 'check:exports\|bun run check' .github/workflows/*.yml`
+   — confirm the workflow runs `bun run check` (which now chains
+   `check:skill-exports`) rather than `bun run check:exports` directly.
+   Edit the workflow if the latter.
+6. **Commit.**
+
+## Script design
+
+The script lives at `scripts/check-skill-exports.js` and follows the
+structure of the existing `scripts/check-exports-resolve.js` (spec 390).
+
+### Algorithm
+
+```
+1. Enumerate SKILL.md files:
+     .claude/skills/libs-*/SKILL.md  (glob)
+
+2. For each SKILL.md:
+     a. Read the file.
+     b. Locate the `## Libraries` table (first markdown table after an H2
+        heading "Libraries" — tolerate H2 "Libraries" or "## Libraries").
+     c. Parse the header row. Require exact headers:
+          | Library | Capabilities | Key Exports |
+        Fail with a clear error if the headers differ.
+     d. Parse each data row. For each row:
+          - library name  (column 1, stripped)
+          - key exports   (column 3, split by comma, names trimmed,
+                           backticks stripped)
+
+3. For each (library, keyExports) pair:
+     a. Load libraries/<library>/package.json.
+     b. Collect every target file referenced by the package's `main`,
+        `bin`, and `exports` map. Walk nested exports objects; skip
+        wildcard patterns (e.g., "./components/*"); skip subpaths whose
+        value is not a .js file (e.g., "./css/*": "./src/css/*" is not a
+        module, skip).
+     c. For each target file, parse it as ES module source to collect
+        export names. Three cases:
+          - `export function X(…)`      → add "X"
+          - `export async function X(…)` → add "X"
+          - `export class X { … }`       → add "X"
+          - `export const X = …`         → add "X" (and any other
+                                             destructured `let`/`const`)
+          - `export { X, Y, Z }`         → add each
+          - `export { X, Y } from "…"`   → add each (re-exports count as
+                                             the importing file's public
+                                             surface)
+          - `export * from "…"`          → recursively collect exports
+                                             from the referenced file
+          - `export default …`           → add "default" (rarely used in
+                                             Key Exports, but support it)
+        Use a regex-based scan, not a full parser — the library sources
+        are all ES module syntax and the regex set is small. The
+        existing `check-exports-resolve.js` is pure regex-free (it only
+        resolves file paths) so this is a new parsing responsibility;
+        keep it tight and inline.
+
+     d. De-dupe the collected names into a Set.
+
+     e. For each key-export name in the SKILL.md row, assert it is in
+        the Set. If not, print:
+          `.claude/skills/<skill>/SKILL.md: <library>.<name> is not a
+           public export`
+        and increment failure count.
+
+4. If failures > 0:
+     print summary and exit 1.
+   Else:
+     print `Checked N libs-* skill files, M library rows, K key exports.
+            All resolve.` and exit 0.
+```
+
+### Parsing constraints
+
+- **Markdown table parsing.** The `libs-*/SKILL.md` files all use GFM
+  pipe tables. Header is one row starting with `|`, the next row is the
+  separator `| --- |`, data rows follow until a blank line or a non-pipe
+  line. The parser must handle leading/trailing pipes and pad columns
+  robustly. Do **not** import a third-party markdown parser — the pattern
+  is regular enough to parse inline in ~30 lines.
+- **ES module export scan.** Use these regexes against the file
+  contents:
+  - `^export\s+(async\s+)?function\s+(\w+)` → capture group 2
+  - `^export\s+class\s+(\w+)` → capture group 1
+  - `^export\s+(const|let|var)\s+(\w+)` → capture group 2
+  - `^export\s+\{([^}]+)\}` → split group 1 by `,`, trim, strip any `as X`
+    alias (the aliased name is what's public)
+  - `^export\s+\*\s+from\s+["']([^"']+)["']` → recurse into the referenced
+    file (resolve relative to the current file)
+  - `^export\s+default` → add the literal `"default"`
+
+  Scan line-by-line with `m` flag. Do not attempt to handle
+  `import { X }; export { X as Y }` chained across statements — none of the
+  current libraries use that pattern. If one appears, add a regex for it.
+
+- **Circular re-exports.** libuniverse re-exports from libsyntheticgen,
+  libsyntheticprose, libsyntheticrender. The scan must follow
+  `export * from "@forwardimpact/libX"` **inside a library's source** by
+  resolving the package name to `libraries/libX/src/index.js` and continuing
+  the scan. Guard against infinite recursion with a visited set keyed by
+  absolute path.
+
+- **Backticks in Key Exports cells.** The SKILL.md tables may write
+  exports as `` `Cli` `` to render as inline code. Strip backticks before
+  matching.
+
+### CLI ergonomics
+
+- `node scripts/check-skill-exports.js` — default, runs the check.
+- `node scripts/check-skill-exports.js --verbose` — prints the resolved
+  export set for each library, useful for debugging. Optional flag; the
+  implementer may skip it if complexity isn't worth it.
+- Exit code: 0 on success, 1 on any failure. Matches
+  `check-exports-resolve.js`.
+
+### Example error output
+
+```
+.claude/skills/libs-grpc-services/SKILL.md: librpc.RpcServer is not a public export
+  available exports: Server, Client, createClient, createTracer, createGrpc,
+                     createAuth, Rpc, Interceptor, HmacAuth, healthDefinition,
+                     createHealthHandlers, ServingStatus
+Checked 6 libs-* skill files, 33 library rows, 142 key exports.
+3 missing.
+```
+
+## package.json changes
+
+```diff
+ "scripts": {
+   "prestart": "bunx fit-pathway build",
+   "start": "bunx serve public",
+   "dev": "bunx fit-pathway dev",
+-  "check": "bun run format && bun run lint && bun run layout && bun run check:exports",
++  "check": "bun run format && bun run lint && bun run layout && bun run check:exports && bun run check:skill-exports",
+   "check:fix": "bun run format:fix && bun run lint:fix",
+   "layout": "node scripts/check-package-layout.js",
+   "check:exports": "node scripts/check-exports-resolve.js",
++  "check:skill-exports": "node scripts/check-skill-exports.js",
+   "lint": "eslint .",
+```
+
+## Verification
+
+Run at the package root:
+
+1. **Script runs clean on the Part 02 output.**
+
+   ```sh
+   node scripts/check-skill-exports.js
+   ```
+
+   Expected: exit 0, summary line prints the total counts and "All resolve."
+
+2. **Script catches a synthetic drift.**
+
+   Introduce a deliberate misspelling in
+   `.claude/skills/libs-cli-and-tooling/SKILL.md` — change `Cli` to
+   `CliXYZ` in one Key Exports cell — and re-run:
+
+   ```sh
+   node scripts/check-skill-exports.js; echo "exit=$?"
+   ```
+
+   Expected: exit 1, error message identifies
+   `libs-cli-and-tooling/SKILL.md: libcli.CliXYZ is not a public export`.
+   Revert the edit before continuing.
+
+3. **`bun run check` chains the new script.**
+
+   ```sh
+   bun run check
+   ```
+
+   Expected: runs format, lint, layout, check:exports, check:skill-exports
+   in that order, and exits 0. Intentionally break one Key Exports cell to
+   confirm the chain halts; revert.
+
+4. **CI workflow sanity.**
+
+   ```sh
+   rg -n 'bun run check' .github/workflows/
+   ```
+
+   Confirm at least one workflow calls `bun run check` (not just
+   `bun run check:exports`) so the new step runs in CI. If not, edit the
+   workflow to call `bun run check` and commit the workflow change in the
+   same Part 04 commit.
+
+5. **No false positives from libtelemetry subpath exports.** `libtelemetry`
+   publishes `./tracer.js` as a subpath. Any Key Exports row listing
+   `Tracer` (defined in `libraries/libtelemetry/src/tracer.js`) must
+   resolve under the script. Confirm by running the check on the final
+   Part 02 output.
+
+6. **No false positives from libuniverse re-exports.**
+   `libraries/libuniverse/src/index.js` contains
+   `export { DslParser, … } from "@forwardimpact/libsyntheticgen"`. If Part
+   02 lists `DslParser` under the libuniverse row (it shouldn't — the plan
+   says leave re-exports out of libuniverse's row), the check still resolves
+   because re-exports count as the importing file's public surface. The
+   check should pass either way; the stylistic decision is Part 02's.
+
+## Risks
+
+1. **Regex-based ES module parsing is fragile.** A library using
+   `export {\n  foo,\n  bar,\n} from "./x.js"` across multiple lines may
+   break a line-by-line regex. Mitigation: the script reads each file as
+   a whole string and runs the export-block regex with the `m` flag and
+   multiline-friendly bracket matching. If any library uses unusual
+   export syntax, the check fails loudly on that library — easy to
+   diagnose.
+
+2. **`export * from` cycles.** libuniverse re-exports from three other
+   libraries. If one of those re-exports back (they don't today), the
+   scan would infinite-loop. Mitigation: visited-set guard keyed by
+   absolute file path.
+
+3. **Subpath wildcards.** libui has `"./components/*": "./src/components/*.js"`.
+   The script must **skip** wildcard subpaths when collecting target files —
+   they are consumer-specific and can't be enumerated without a concrete
+   import path. This matches the behaviour of
+   `scripts/check-exports-resolve.js:46–48` which also skips wildcards.
+
+4. **`./css/*` non-JS subpaths.** libui also has
+   `"./css/*": "./src/css/*"` pointing at CSS files. The script must skip
+   any subpath target whose file extension is not `.js`/`.mjs`. Matches
+   consumer expectation: you don't "export" a symbol from a CSS file.
+
+5. **libtype re-exports from generated code.** `libtype/src/index.js`
+   does `export * from "./generated/types/types.js"`. The generated file
+   is ~thousands of lines. Parsing it is slow but not unacceptable
+   (~100ms). If the check becomes a CI bottleneck, add a cache keyed by
+   file mtime. Not worth doing in Part 04 unless measurement shows a
+   problem.
+
+6. **New failure mode in CI.** After Part 04 merges, any library refactor
+   that removes a public export without updating the corresponding
+   `libs-*/SKILL.md` row fails CI. This is intentional and is the success
+   criterion. Document in the script's error output how to fix:
+   "Update the Key Exports cell in <SKILL.md> to match, or restore the
+   export."
+
+## Commit
+
+One commit:
+
+```
+feat(ci): add check:skill-exports script (spec 400 part 4/4)
+
+New script scripts/check-skill-exports.js asserts every name in a
+`Key Exports` cell of a libs-*/SKILL.md resolves to a public export of
+the corresponding library package. Wired into `bun run check` so
+drift fails locally and in the check-quality CI workflow.
+
+Structurally equivalent to scripts/check-exports-resolve.js (spec 390):
+strict-positive resolution only (the reverse direction is intentionally
+not checked).
+```
+
+— Staff Engineer 🛠️

--- a/specs/400-library-skill-discovery/plan-a.md
+++ b/specs/400-library-skill-discovery/plan-a.md
@@ -1,0 +1,314 @@
+# Plan A — Library Skill Discovery
+
+Implementation plan for [spec 400](spec.md). Translates the spec's five moves
+(reorganise groups, rewrite descriptions/tables, discovery protocol, CI guard,
+record rejected alternatives) into concrete, ordered changes across the seven
+`libs-*`/`libskill` skill files, `CLAUDE.md`, `CONTRIBUTING.md`, the
+`gemba-plan` skill, the staff-engineer agent profile, and one new script.
+
+## Approach
+
+This is a documentation and tooling change. No code inside `libraries/*/src/`
+moves. The shape of the work is:
+
+1. **Move the walls** — rename five `.claude/skills/libs-*` directories so the
+   six groups match spec 400's Move 1 table, and update `CLAUDE.md § Skill
+   Groups` to match.
+2. **Repaint the signs** — rewrite every `libs-*` SKILL.md frontmatter
+   description in capability verbs, switch the inner `Libraries` tables from
+   `Main API` / `Purpose` to `Capabilities` / `Key Exports`, and add the five
+   missing library rows.
+3. **Post the protocol** — add library-discovery steps to CONTRIBUTING.md's
+   READ-DO, to the gemba-plan skill, and to agent profiles that write code.
+4. **Install the alarm** — add a `check:skill-exports` script that proves every
+   name in a `Key Exports` cell resolves to a real public export and fail
+   `bun run check` when it doesn't.
+
+The work decomposes into **four parts** on the feature branch
+`claude/spec-400-planning-a4Okz` (already checked out). Parts 01, 02, and 04
+are strictly sequential on the `libs-*` surface. Part 03 (discovery protocol)
+is independent of 01/02/04 and can run in parallel with Part 02 if executed by
+a second agent.
+
+**Guiding principles:**
+
+1. **Directory rename before content rewrite.** Renaming a skill directory
+   (`git mv`) while simultaneously rewriting its SKILL.md is a single diff but
+   reviewers struggle to tell "what moved" from "what changed." Part 01 does
+   pure renames plus the CLAUDE.md anchor update; Part 02 rewrites the
+   contents. `git log --follow` keeps history intact either way.
+2. **Keep existing body sections (Decision Guide, Composition Recipes, DI
+   Wiring) unless the reorganisation forced a change.** Spec 130 already
+   corrected their contents. Part 02's rewrite is surgical: frontmatter, the
+   `Libraries` table, and body section titles/intros that referenced the old
+   group name.
+3. **Capability tables are the CI contract.** The `Capabilities` / `Key Exports`
+   column rename is load-bearing — Part 04's check resolves names against the
+   `Key Exports` column specifically. Column titles and table placement must be
+   consistent across all seven files so the parser has a single contract.
+4. **Description rewrites must cover every library's public surface, not just
+   the headline.** If `libutil` exposes `Retry`, `waitFor`, and `parseJsonBody`
+   but the description only mentions hashing and tokens, an agent searching
+   "retry with backoff" will miss it. Capability coverage is the success
+   criterion for Move 2, not word count.
+5. **CI guard is strict-positive, not reverse.** The check asserts "everything
+   advertised in `Key Exports` must resolve"; it does **not** assert "every
+   library export must appear in `Key Exports`." Internal helpers stay hidden.
+   This matches the spec's explicit guidance under Move 4.
+
+## Part index
+
+Execute parts on the existing `claude/spec-400-planning-a4Okz` branch. Each
+part has its own plan file with scope, file list, ordering, and verification
+steps.
+
+| #   | File                         | Scope                                                                                                   | Agent          |
+| --- | ---------------------------- | ------------------------------------------------------------------------------------------------------- | -------------- |
+| 01  | [plan-a-01.md](plan-a-01.md) | Rename five `libs-*` skill directories; update `CLAUDE.md § Skill Groups`                              | staff-engineer |
+| 02  | [plan-a-02.md](plan-a-02.md) | Rewrite frontmatter descriptions; switch inner tables to `Capabilities` / `Key Exports`; add orphan rows | staff-engineer |
+| 03  | [plan-a-03.md](plan-a-03.md) | Discovery protocol: `CONTRIBUTING.md` READ-DO, `gemba-plan` SKILL.md, `staff-engineer.md` skills list    | staff-engineer |
+| 04  | [plan-a-04.md](plan-a-04.md) | `scripts/check-skill-exports.js` + wire into `bun run check` and `check-quality` CI                     | staff-engineer |
+
+## Part dependency graph
+
+```
+  01 (directory renames + CLAUDE.md)
+    │
+    ▼
+  02 (SKILL.md content rewrites)               03 (discovery protocol)
+    │                                              │
+    ▼                                              │
+  04 (check:skill-exports script)                  │
+    │                                              │
+    └──────────────► final verification ◄──────────┘
+```
+
+Part 03 is the only part that does not touch `libs-*` files. If the
+implementer has parallel capacity, launch 03 as a concurrent sub-agent after
+01 merges locally. Otherwise run 01 → 02 → 03 → 04 sequentially. Either order
+is correct; the dependency arrow from 03 to "final verification" is satisfied
+by running `bun run check` and `bun run test` once at the end.
+
+## Execution
+
+Run every part on the existing `claude/spec-400-planning-a4Okz` branch. Each
+part ends with `bun run check` and `bun run test` passing. Commit per part
+using the convention `docs(skills): <summary>` for Parts 01–03 and
+`feat(ci): add skill-exports check` for Part 04. Push after each commit.
+
+Route every part to **`staff-engineer`**. Parts 01, 02, and 04 are pure
+infrastructure/doc work inside `.claude/skills/`, `CLAUDE.md`, and `scripts/`.
+Part 03 also lives in doc-adjacent files (`CONTRIBUTING.md`, `gemba-plan`
+skill, `staff-engineer.md` agent profile) and is still staff-engineer scope —
+no `website/` or wiki changes, so no technical-writer handoff.
+
+## Cross-cutting conventions
+
+These conventions apply inside every part — restated here so each part can
+assume them without repetition.
+
+### New six-group truth table
+
+Parts 01 and 02 both depend on this table. Spec 400 Move 1 is the
+authoritative source; reproduced here for in-plan reference.
+
+| New group             | Old group                   | Members (count)                                                                                        |
+| --------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------ |
+| libs-grpc-services    | libs-service-infrastructure | librpc, libconfig, libtelemetry, libtype, libharness (5)                                               |
+| libs-storage          | libs-data-persistence       | libstorage, libindex, libresource, libpolicy, libgraph, libvector (6)                                  |
+| libs-llm-and-agents   | libs-llm-orchestration      | libllm, libmemory, libprompt, libagent, **libtool** (5)                                                |
+| libs-content          | libs-web-presentation       | libui, libformat, libweb, libdoc, libtemplate (5)                                                      |
+| libs-cli-and-tooling  | libs-system-utilities       | **libcli**, **librepl**, libutil, libsecret, libsupervise, librc, libcodegen, **libeval** (8)          |
+| libs-synthetic-data   | libs-synthetic-data         | libsyntheticgen, libsyntheticprose, libsyntheticrender, **libuniverse** (4)                            |
+
+Standalone: `libskill` stays in `.claude/skills/libskill/`.
+
+Bold entries are either moved from another group or added from the spec's
+"orphan" list.
+
+### Inner-table column contract
+
+Every `libs-*/SKILL.md` `## Libraries` table must use exactly these headers in
+this order:
+
+```
+| Library | Capabilities | Key Exports |
+```
+
+`Capabilities` is a verb-led phrase listing what you use the library for
+("retry a flaky fetch," "supervise a daemon"). `Key Exports` is a
+comma-separated list of public symbols that resolve to a real export in the
+library package — the CI guard in Part 04 parses this column by exact match.
+
+`Key Exports` cells may not be empty. A library with nothing worth
+advertising is a signal the library shouldn't be listed at all — but every
+library in `libraries/` must appear somewhere, so in practice every cell has
+content.
+
+### Frontmatter description contract
+
+Every `libs-*/SKILL.md` frontmatter `description` must:
+
+- **Open with "Use when"** so the agent's task verb is the first lexical match
+  at router load.
+- **List verbs, not library names.** Descriptions describe the tasks the group
+  performs; naming a library in the first sentence is the anti-pattern spec 400
+  is trying to retire.
+- **Cover every public capability of every library in the group** — if a
+  capability is in the inner table's `Capabilities` column, it must also be
+  reachable from the frontmatter's verb list. The router only sees the
+  frontmatter.
+- **Stay under ~100 words** so the router can skim it cheaply.
+
+`libskill`'s description is rewritten to the same shape even though it stays
+standalone: "Use when deriving a job from Discipline × Level × Track, …" — not
+"Work with the libskill package."
+
+### Git history preservation
+
+Use `git mv` for every directory rename in Part 01. Do not `rm -rf` and re-add
+— `git log --follow` on SKILL.md should track through the rename.
+
+## Known plan decisions and risks
+
+Flag these to the reviewer before execution.
+
+1. **`libs-cli-and-tooling` is intentionally 8 libraries.** The spec explicitly
+   rejects splitting it. Part 02's description for this group has to cover more
+   verbs than any other — expect the description to push toward the ~100-word
+   cap. If any single capability is omitted, the router will miss it. Part 02's
+   verification step explicitly spot-reads this description last because it is
+   the most demanding.
+
+2. **`libskill` frontmatter description rewrite is a spec requirement even
+   though it isn't in a `libs-*` group.** Spec 400 Move 1 rationale says
+   libskill's description is rewritten "as domain logic for jobs, skills,
+   agents, career progression." Success criterion 2 says "every `libs-*`
+   SKILL.md" but the Move 1 table explicitly covers libskill. The plan treats
+   libskill's rewrite as in-scope; if the reviewer reads success criterion 2
+   narrowly, flag it and drop libskill's frontmatter from Part 02.
+
+3. **The CI check walks `Key Exports` across the union of all public subpath
+   exports, not just `./src/index.js`.** Libraries like `libui` (15 subpaths),
+   `libdoc` (4), `libuniverse` (3), `libtemplate` (2) publish symbols via
+   subpath export maps in `package.json`. The Part 04 script resolves names by
+   reading each value in the `exports` map, parsing the referenced `.js` file,
+   and collecting `export`/`export from` declarations. A name in `Key Exports`
+   matches if it appears in any of those files. This mirrors the existing
+   `check-exports-resolve.js` pattern (spec 390) which also walks the
+   `exports` map.
+
+4. **The existing `Libraries` tables in the six files already contain stale
+   names.** Example: `libs-service-infrastructure` lists `RpcServer`,
+   `RpcClient`, `createClientFactory` but librpc actually exports `Server`,
+   `Client`, `createClient`, `createTracer`, `createGrpc`, `createAuth`,
+   `Rpc`, `Interceptor`, `HmacAuth`, `healthDefinition`, `createHealthHandlers`,
+   `ServingStatus` (no `RpcServer`/`RpcClient`). `libs-llm-orchestration`
+   lists `WindowBuilder`, `createWindow` but libmemory currently exports —
+   Part 02 verifies via Part 04's script while writing the tables, so every
+   new row is correct-by-construction. **Do not assume the existing
+   `Main API` column is correct.** Read `libraries/<libname>/src/index.js`
+   (and any subpath exports) directly when drafting each `Key Exports` cell.
+
+5. **Description rewrites must cover orphan capabilities.** `libtool` moves
+   into `libs-llm-and-agents`; its verbs ("dispatch a tool call," "generate a
+   tool schema from protobuf," "describe a tool to an LLM") must appear in
+   that group's description. Same pattern for `libcli`, `librepl`, `libeval`,
+   `libuniverse` in their target groups. A capability absent from the
+   frontmatter is invisible to the router even if it's in the inner table.
+
+6. **Agent profile change is minimal.** Only `staff-engineer.md` needs new
+   `skills:` entries in Part 03. The other five agents
+   (`improvement-coach`, `product-manager`, `release-engineer`,
+   `security-engineer`, `technical-writer`) write some code but not
+   library-consuming implementation code. `staff-engineer` owns the "writes
+   implementation code" workflow and is the only profile where pre-loading
+   the `libs-*` catalog changes router behaviour at task time. Flag to
+   reviewer if they want a broader rollout.
+
+7. **`CLAUDE.md § Skill Groups` list ordering is preserved.** The spec's Move
+   1 table uses a specific order (grpc → storage → llm → content → cli →
+   synthetic). Part 01 writes the new section in that order so the file reads
+   the same top-to-bottom.
+
+8. **Existing `libs-synthetic-data` table only needs a `libuniverse` row added
+   and column rename.** The group name does not change and membership grows
+   by one. This is the smallest single-file change in Part 02.
+
+## Risks
+
+1. **Frontmatter description length vs coverage.** The spec caps descriptions
+   at ~100 words so the router can skim them. Covering 8 libraries'
+   capabilities for `libs-cli-and-tooling` inside that cap is tight. Mitigation:
+   Part 02's verification step counts words in each description and flags any
+   over 120 for manual review; the implementer can elide redundant verbs
+   ("hash" + "generate hash" → "hash") to fit.
+
+2. **`Key Exports` drift between planning and implementation.** Any library
+   refactor that merges while this plan is in flight can re-introduce a stale
+   name. Mitigation: Part 04 lands the check; Part 02 rebases on top of the
+   check before final commit so drift fails loudly. Order matters — Part 02
+   before Part 04 is correct because Part 04 needs rows to validate against.
+   See dependency graph above.
+
+3. **CI check cold-start false positives.** The script has to parse every
+   `libs-*/SKILL.md` and every library's `src/` export surface; a naive
+   implementation that only reads `src/index.js` will miss subpath exports
+   (e.g., `libui/render`, `libtelemetry/tracer.js`). Mitigation: Part 04's
+   plan mandates parsing the full `package.json` `exports` map per library
+   and de-duping exported names across subpaths before matching. First run
+   on the final Part 02 output must return zero failures; any failure is a
+   bug in either Part 02's table or Part 04's script.
+
+4. **Symbol name collisions between libraries.** Two libraries can export the
+   same name (e.g., `generateHash` appears in both `libutil` and `libsecret`).
+   The CI check resolves names per-row (which library is this row about?), so
+   there is no collision at match time, but the `Capabilities` column must
+   disambiguate if both libs are in the same group so the reader knows which
+   one to reach for. `libutil` and `libsecret` are in the same
+   `libs-cli-and-tooling` group — Part 02's Decision Guide carries the
+   existing "libutil.generateHash vs libsecret.generateSecret vs
+   libsecret.hashValues" call-out (currently in `libs-system-utilities`) into
+   the new file.
+
+5. **Skill router behaviour change on rename.** Renaming a skill directory
+   can break any external reference to the old name (e.g., docs that say "see
+   the libs-system-utilities skill"). Mitigation: grep the monorepo for the
+   five old names before committing Part 01 and update any hits. Expected
+   hits: `CLAUDE.md § Skill Groups` (Part 01 rewrites), `CLAUDE.md § Skill
+   Groups` cross-references elsewhere in CLAUDE.md (none found as of drafting
+   but grep at execution time), and `.claude/skills/*/SKILL.md` body text in
+   the moved files themselves (Part 02 catches these because it rewrites each
+   file's "When to Use" and body intro).
+
+6. **Spec 130's Decision Guide text references old group membership.** Any
+   "X vs Y" comparison in a Decision Guide may span a group boundary after
+   Part 01 (e.g., `libtelemetry.Logger` advice that currently lives in
+   `libs-service-infrastructure` is still relevant to CLI authors using
+   `libs-cli-and-tooling`). Mitigation: Part 02's per-file checklist includes
+   "re-read the Decision Guide and update any stale cross-references"; the
+   logger guidance stays with `libtelemetry` in its own group
+   (`libs-grpc-services`) but a one-line cross-reference from
+   `libs-cli-and-tooling` points readers to it.
+
+## References
+
+- Spec: [spec.md](spec.md)
+- Spec 130 (prior pass on the same files, fixed body content): spec 130 —
+  library skill tables
+- Spec 390 (introduced `check:exports`, the pattern Part 04 reuses):
+  `scripts/check-exports-resolve.js`, `package.json` `"check"` script
+- Current `CLAUDE.md § Skill Groups`: lines 259–276
+- Current `CONTRIBUTING.md § READ-DO`: lines 33–51
+- Current `gemba-plan` SKILL.md: `.claude/skills/gemba-plan/SKILL.md`
+- Current `staff-engineer.md` agent profile:
+  `.claude/agents/staff-engineer.md` lines 8–13
+- Current `libs-*` SKILL.md files: `.claude/skills/libs-{data-persistence,
+  llm-orchestration, service-infrastructure, synthetic-data, system-utilities,
+  web-presentation}/SKILL.md` and `.claude/skills/libskill/SKILL.md`
+- Existing export-resolution script (pattern for Part 04):
+  `scripts/check-exports-resolve.js` (91 lines)
+- Orphan library source entry points (Part 02 reads for `Key Exports`):
+  `libraries/{libtool,libcli,librepl,libeval,libuniverse}/src/index.js`
+
+— Staff Engineer 🛠️

--- a/specs/400-library-skill-discovery/plan-a.md
+++ b/specs/400-library-skill-discovery/plan-a.md
@@ -12,8 +12,8 @@ This is a documentation and tooling change. No code inside `libraries/*/src/`
 moves. The shape of the work is:
 
 1. **Move the walls** — rename five `.claude/skills/libs-*` directories so the
-   six groups match spec 400's Move 1 table, and update `CLAUDE.md § Skill
-   Groups` to match.
+   six groups match spec 400's Move 1 table, and update
+   `CLAUDE.md § Skill Groups` to match.
 2. **Repaint the signs** — rewrite every `libs-*` SKILL.md frontmatter
    description in capability verbs, switch the inner `Libraries` tables from
    `Main API` / `Purpose` to `Capabilities` / `Key Exports`, and add the five
@@ -25,18 +25,18 @@ moves. The shape of the work is:
    `bun run check` when it doesn't.
 
 The work decomposes into **four parts** on the feature branch
-`claude/spec-400-planning-a4Okz` (already checked out). Parts 01, 02, and 04
-are strictly sequential on the `libs-*` surface. Part 03 (discovery protocol)
-is independent of 01/02/04 and can run in parallel with Part 02 if executed by
-a second agent.
+`claude/spec-400-planning-a4Okz` (already checked out). Parts 01, 02, and 04 are
+strictly sequential on the `libs-*` surface. Part 03 (discovery protocol) is
+independent of 01/02/04 and can run in parallel with Part 02 if executed by a
+second agent.
 
 **Guiding principles:**
 
 1. **Directory rename before content rewrite.** Renaming a skill directory
    (`git mv`) while simultaneously rewriting its SKILL.md is a single diff but
    reviewers struggle to tell "what moved" from "what changed." Part 01 does
-   pure renames plus the CLAUDE.md anchor update; Part 02 rewrites the
-   contents. `git log --follow` keeps history intact either way.
+   pure renames plus the CLAUDE.md anchor update; Part 02 rewrites the contents.
+   `git log --follow` keeps history intact either way.
 2. **Keep existing body sections (Decision Guide, Composition Recipes, DI
    Wiring) unless the reorganisation forced a change.** Spec 130 already
    corrected their contents. Part 02's rewrite is surgical: frontmatter, the
@@ -58,16 +58,15 @@ a second agent.
 
 ## Part index
 
-Execute parts on the existing `claude/spec-400-planning-a4Okz` branch. Each
-part has its own plan file with scope, file list, ordering, and verification
-steps.
+Execute parts on the existing `claude/spec-400-planning-a4Okz` branch. Each part
+has its own plan file with scope, file list, ordering, and verification steps.
 
-| #   | File                         | Scope                                                                                                   | Agent          |
-| --- | ---------------------------- | ------------------------------------------------------------------------------------------------------- | -------------- |
-| 01  | [plan-a-01.md](plan-a-01.md) | Rename five `libs-*` skill directories; update `CLAUDE.md § Skill Groups`                              | staff-engineer |
+| #   | File                         | Scope                                                                                                    | Agent          |
+| --- | ---------------------------- | -------------------------------------------------------------------------------------------------------- | -------------- |
+| 01  | [plan-a-01.md](plan-a-01.md) | Rename five `libs-*` skill directories; update `CLAUDE.md § Skill Groups`                                | staff-engineer |
 | 02  | [plan-a-02.md](plan-a-02.md) | Rewrite frontmatter descriptions; switch inner tables to `Capabilities` / `Key Exports`; add orphan rows | staff-engineer |
 | 03  | [plan-a-03.md](plan-a-03.md) | Discovery protocol: `CONTRIBUTING.md` READ-DO, `gemba-plan` SKILL.md, `staff-engineer.md` skills list    | staff-engineer |
-| 04  | [plan-a-04.md](plan-a-04.md) | `scripts/check-skill-exports.js` + wire into `bun run check` and `check-quality` CI                     | staff-engineer |
+| 04  | [plan-a-04.md](plan-a-04.md) | `scripts/check-skill-exports.js` + wire into `bun run check` and `check-quality` CI                      | staff-engineer |
 
 ## Part dependency graph
 
@@ -83,24 +82,24 @@ steps.
     └──────────────► final verification ◄──────────┘
 ```
 
-Part 03 is the only part that does not touch `libs-*` files. If the
-implementer has parallel capacity, launch 03 as a concurrent sub-agent after
-01 merges locally. Otherwise run 01 → 02 → 03 → 04 sequentially. Either order
-is correct; the dependency arrow from 03 to "final verification" is satisfied
-by running `bun run check` and `bun run test` once at the end.
+Part 03 is the only part that does not touch `libs-*` files. If the implementer
+has parallel capacity, launch 03 as a concurrent sub-agent after 01 merges
+locally. Otherwise run 01 → 02 → 03 → 04 sequentially. Either order is correct;
+the dependency arrow from 03 to "final verification" is satisfied by running
+`bun run check` and `bun run test` once at the end.
 
 ## Execution
 
 Run every part on the existing `claude/spec-400-planning-a4Okz` branch. Each
-part ends with `bun run check` and `bun run test` passing. Commit per part
-using the convention `docs(skills): <summary>` for Parts 01–03 and
+part ends with `bun run check` and `bun run test` passing. Commit per part using
+the convention `docs(skills): <summary>` for Parts 01–03 and
 `feat(ci): add skill-exports check` for Part 04. Push after each commit.
 
 Route every part to **`staff-engineer`**. Parts 01, 02, and 04 are pure
 infrastructure/doc work inside `.claude/skills/`, `CLAUDE.md`, and `scripts/`.
-Part 03 also lives in doc-adjacent files (`CONTRIBUTING.md`, `gemba-plan`
-skill, `staff-engineer.md` agent profile) and is still staff-engineer scope —
-no `website/` or wiki changes, so no technical-writer handoff.
+Part 03 also lives in doc-adjacent files (`CONTRIBUTING.md`, `gemba-plan` skill,
+`staff-engineer.md` agent profile) and is still staff-engineer scope — no
+`website/` or wiki changes, so no technical-writer handoff.
 
 ## Cross-cutting conventions
 
@@ -109,17 +108,17 @@ assume them without repetition.
 
 ### New six-group truth table
 
-Parts 01 and 02 both depend on this table. Spec 400 Move 1 is the
-authoritative source; reproduced here for in-plan reference.
+Parts 01 and 02 both depend on this table. Spec 400 Move 1 is the authoritative
+source; reproduced here for in-plan reference.
 
-| New group             | Old group                   | Members (count)                                                                                        |
-| --------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------ |
-| libs-grpc-services    | libs-service-infrastructure | librpc, libconfig, libtelemetry, libtype, libharness (5)                                               |
-| libs-storage          | libs-data-persistence       | libstorage, libindex, libresource, libpolicy, libgraph, libvector (6)                                  |
-| libs-llm-and-agents   | libs-llm-orchestration      | libllm, libmemory, libprompt, libagent, **libtool** (5)                                                |
-| libs-content          | libs-web-presentation       | libui, libformat, libweb, libdoc, libtemplate (5)                                                      |
-| libs-cli-and-tooling  | libs-system-utilities       | **libcli**, **librepl**, libutil, libsecret, libsupervise, librc, libcodegen, **libeval** (8)          |
-| libs-synthetic-data   | libs-synthetic-data         | libsyntheticgen, libsyntheticprose, libsyntheticrender, **libuniverse** (4)                            |
+| New group            | Old group                   | Members (count)                                                                               |
+| -------------------- | --------------------------- | --------------------------------------------------------------------------------------------- |
+| libs-grpc-services   | libs-service-infrastructure | librpc, libconfig, libtelemetry, libtype, libharness (5)                                      |
+| libs-storage         | libs-data-persistence       | libstorage, libindex, libresource, libpolicy, libgraph, libvector (6)                         |
+| libs-llm-and-agents  | libs-llm-orchestration      | libllm, libmemory, libprompt, libagent, **libtool** (5)                                       |
+| libs-content         | libs-web-presentation       | libui, libformat, libweb, libdoc, libtemplate (5)                                             |
+| libs-cli-and-tooling | libs-system-utilities       | **libcli**, **librepl**, libutil, libsecret, libsupervise, librc, libcodegen, **libeval** (8) |
+| libs-synthetic-data  | libs-synthetic-data         | libsyntheticgen, libsyntheticprose, libsyntheticrender, **libuniverse** (4)                   |
 
 Standalone: `libskill` stays in `.claude/skills/libskill/`.
 
@@ -135,15 +134,14 @@ this order:
 | Library | Capabilities | Key Exports |
 ```
 
-`Capabilities` is a verb-led phrase listing what you use the library for
-("retry a flaky fetch," "supervise a daemon"). `Key Exports` is a
-comma-separated list of public symbols that resolve to a real export in the
-library package — the CI guard in Part 04 parses this column by exact match.
+`Capabilities` is a verb-led phrase listing what you use the library for ("retry
+a flaky fetch," "supervise a daemon"). `Key Exports` is a comma-separated list
+of public symbols that resolve to a real export in the library package — the CI
+guard in Part 04 parses this column by exact match.
 
-`Key Exports` cells may not be empty. A library with nothing worth
-advertising is a signal the library shouldn't be listed at all — but every
-library in `libraries/` must appear somewhere, so in practice every cell has
-content.
+`Key Exports` cells may not be empty. A library with nothing worth advertising
+is a signal the library shouldn't be listed at all — but every library in
+`libraries/` must appear somewhere, so in practice every cell has content.
 
 ### Frontmatter description contract
 
@@ -166,8 +164,8 @@ standalone: "Use when deriving a job from Discipline × Level × Track, …" —
 
 ### Git history preservation
 
-Use `git mv` for every directory rename in Part 01. Do not `rm -rf` and re-add
-— `git log --follow` on SKILL.md should track through the rename.
+Use `git mv` for every directory rename in Part 01. Do not `rm -rf` and re-add —
+`git log --follow` on SKILL.md should track through the rename.
 
 ## Known plan decisions and risks
 
@@ -195,95 +193,98 @@ Flag these to the reviewer before execution.
    reading each value in the `exports` map, parsing the referenced `.js` file,
    and collecting `export`/`export from` declarations. A name in `Key Exports`
    matches if it appears in any of those files. This mirrors the existing
-   `check-exports-resolve.js` pattern (spec 390) which also walks the
-   `exports` map.
+   `check-exports-resolve.js` pattern (spec 390) which also walks the `exports`
+   map.
 
 4. **The existing `Libraries` tables in the six files already contain stale
    names.** Example: `libs-service-infrastructure` lists `RpcServer`,
    `RpcClient`, `createClientFactory` but librpc actually exports `Server`,
-   `Client`, `createClient`, `createTracer`, `createGrpc`, `createAuth`,
-   `Rpc`, `Interceptor`, `HmacAuth`, `healthDefinition`, `createHealthHandlers`,
-   `ServingStatus` (no `RpcServer`/`RpcClient`). `libs-llm-orchestration`
-   lists `WindowBuilder`, `createWindow` but libmemory currently exports —
-   Part 02 verifies via Part 04's script while writing the tables, so every
-   new row is correct-by-construction. **Do not assume the existing
-   `Main API` column is correct.** Read `libraries/<libname>/src/index.js`
-   (and any subpath exports) directly when drafting each `Key Exports` cell.
+   `Client`, `createClient`, `createTracer`, `createGrpc`, `createAuth`, `Rpc`,
+   `Interceptor`, `HmacAuth`, `healthDefinition`, `createHealthHandlers`,
+   `ServingStatus` (no `RpcServer`/`RpcClient`). `libs-llm-orchestration` lists
+   `WindowBuilder`, `createWindow` but libmemory currently exports — Part 02
+   verifies via Part 04's script while writing the tables, so every new row is
+   correct-by-construction. **Do not assume the existing `Main API` column is
+   correct.** Read `libraries/<libname>/src/index.js` (and any subpath exports)
+   directly when drafting each `Key Exports` cell.
 
-5. **Description rewrites must cover orphan capabilities.** `libtool` moves
-   into `libs-llm-and-agents`; its verbs ("dispatch a tool call," "generate a
-   tool schema from protobuf," "describe a tool to an LLM") must appear in
-   that group's description. Same pattern for `libcli`, `librepl`, `libeval`,
+5. **Description rewrites must cover orphan capabilities.** `libtool` moves into
+   `libs-llm-and-agents`; its verbs ("dispatch a tool call," "generate a tool
+   schema from protobuf," "describe a tool to an LLM") must appear in that
+   group's description. Same pattern for `libcli`, `librepl`, `libeval`,
    `libuniverse` in their target groups. A capability absent from the
    frontmatter is invisible to the router even if it's in the inner table.
 
 6. **Agent profile change is minimal.** Only `staff-engineer.md` needs new
-   `skills:` entries in Part 03. The other five agents
-   (`improvement-coach`, `product-manager`, `release-engineer`,
-   `security-engineer`, `technical-writer`) write some code but not
-   library-consuming implementation code. `staff-engineer` owns the "writes
-   implementation code" workflow and is the only profile where pre-loading
-   the `libs-*` catalog changes router behaviour at task time. Flag to
-   reviewer if they want a broader rollout.
+   `skills:` entries in Part 03. The other five agents (`improvement-coach`,
+   `product-manager`, `release-engineer`, `security-engineer`,
+   `technical-writer`) write some code but not library-consuming implementation
+   code. `staff-engineer` owns the "writes implementation code" workflow and is
+   the only profile where pre-loading the `libs-*` catalog changes router
+   behaviour at task time. Flag to reviewer if they want a broader rollout.
 
-7. **`CLAUDE.md § Skill Groups` list ordering is preserved.** The spec's Move
-   1 table uses a specific order (grpc → storage → llm → content → cli →
+7. **`CLAUDE.md § Skill Groups` list ordering is preserved.** The spec's Move 1
+   table uses a specific order (grpc → storage → llm → content → cli →
    synthetic). Part 01 writes the new section in that order so the file reads
    the same top-to-bottom.
 
 8. **Existing `libs-synthetic-data` table only needs a `libuniverse` row added
-   and column rename.** The group name does not change and membership grows
-   by one. This is the smallest single-file change in Part 02.
+   and column rename.** The group name does not change and membership grows by
+   one. This is the smallest single-file change in Part 02.
 
 ## Risks
 
-1. **Frontmatter description length vs coverage.** The spec caps descriptions
-   at ~100 words so the router can skim them. Covering 8 libraries'
-   capabilities for `libs-cli-and-tooling` inside that cap is tight. Mitigation:
-   Part 02's verification step counts words in each description and flags any
-   over 120 for manual review; the implementer can elide redundant verbs
-   ("hash" + "generate hash" → "hash") to fit.
+1. **Frontmatter description length vs coverage.** The spec caps descriptions at
+   ~100 words so the router can skim them. Covering 8 libraries' capabilities
+   for `libs-cli-and-tooling` inside that cap is tight. Mitigation: Part 02's
+   verification step counts words in each description and flags any over 120 for
+   manual review; the implementer can elide redundant verbs ("hash" + "generate
+   hash" → "hash") to fit.
 
 2. **`Key Exports` drift between planning and implementation.** Any library
    refactor that merges while this plan is in flight can re-introduce a stale
-   name. Mitigation: Part 04 lands the check; Part 02 rebases on top of the
-   check before final commit so drift fails loudly. Order matters — Part 02
-   before Part 04 is correct because Part 04 needs rows to validate against.
-   See dependency graph above.
+   name. Mitigation: strict ordering — **Part 02 commits first with every
+   `Key Exports` cell verified by the implementer reading each library's live
+   `src/index.js` and its subpath exports manually** (not by running the Part 04
+   script, which does not exist yet). Part 04 lands afterwards and **must pass
+   on Part 02's output on first run** — any failure is fixed as a Part 04 bug
+   (parser/resolution issue) or a Part 02 bug (row edited to a non-existent
+   export) and the fix lands in the appropriate part's commit. Once Part 04 is
+   in place, any future library refactor that drops an advertised export fails
+   `bun run check` and the CI job, catching drift at the source.
 
 3. **CI check cold-start false positives.** The script has to parse every
    `libs-*/SKILL.md` and every library's `src/` export surface; a naive
    implementation that only reads `src/index.js` will miss subpath exports
-   (e.g., `libui/render`, `libtelemetry/tracer.js`). Mitigation: Part 04's
-   plan mandates parsing the full `package.json` `exports` map per library
-   and de-duping exported names across subpaths before matching. First run
-   on the final Part 02 output must return zero failures; any failure is a
-   bug in either Part 02's table or Part 04's script.
+   (e.g., `libui/render`, `libtelemetry/tracer.js`). Mitigation: Part 04's plan
+   mandates parsing the full `package.json` `exports` map per library and
+   de-duping exported names across subpaths before matching. First run on the
+   final Part 02 output must return zero failures; any failure is a bug in
+   either Part 02's table or Part 04's script.
 
 4. **Symbol name collisions between libraries.** Two libraries can export the
    same name (e.g., `generateHash` appears in both `libutil` and `libsecret`).
    The CI check resolves names per-row (which library is this row about?), so
    there is no collision at match time, but the `Capabilities` column must
-   disambiguate if both libs are in the same group so the reader knows which
-   one to reach for. `libutil` and `libsecret` are in the same
-   `libs-cli-and-tooling` group — Part 02's Decision Guide carries the
-   existing "libutil.generateHash vs libsecret.generateSecret vs
-   libsecret.hashValues" call-out (currently in `libs-system-utilities`) into
-   the new file.
+   disambiguate if both libs are in the same group so the reader knows which one
+   to reach for. `libutil` and `libsecret` are in the same
+   `libs-cli-and-tooling` group — Part 02's Decision Guide carries the existing
+   "libutil.generateHash vs libsecret.generateSecret vs libsecret.hashValues"
+   call-out (currently in `libs-system-utilities`) into the new file.
 
-5. **Skill router behaviour change on rename.** Renaming a skill directory
-   can break any external reference to the old name (e.g., docs that say "see
-   the libs-system-utilities skill"). Mitigation: grep the monorepo for the
-   five old names before committing Part 01 and update any hits. Expected
-   hits: `CLAUDE.md § Skill Groups` (Part 01 rewrites), `CLAUDE.md § Skill
-   Groups` cross-references elsewhere in CLAUDE.md (none found as of drafting
-   but grep at execution time), and `.claude/skills/*/SKILL.md` body text in
-   the moved files themselves (Part 02 catches these because it rewrites each
-   file's "When to Use" and body intro).
+5. **Skill router behaviour change on rename.** Renaming a skill directory can
+   break any external reference to the old name (e.g., docs that say "see the
+   libs-system-utilities skill"). Mitigation: grep the monorepo for the five old
+   names before committing Part 01 and update any hits. Expected hits:
+   `CLAUDE.md § Skill Groups` (Part 01 rewrites), `CLAUDE.md § Skill Groups`
+   cross-references elsewhere in CLAUDE.md (none found as of drafting but grep
+   at execution time), and `.claude/skills/*/SKILL.md` body text in the moved
+   files themselves (Part 02 catches these because it rewrites each file's "When
+   to Use" and body intro).
 
-6. **Spec 130's Decision Guide text references old group membership.** Any
-   "X vs Y" comparison in a Decision Guide may span a group boundary after
-   Part 01 (e.g., `libtelemetry.Logger` advice that currently lives in
+6. **Spec 130's Decision Guide text references old group membership.** Any "X vs
+   Y" comparison in a Decision Guide may span a group boundary after Part 01
+   (e.g., `libtelemetry.Logger` advice that currently lives in
    `libs-service-infrastructure` is still relevant to CLI authors using
    `libs-cli-and-tooling`). Mitigation: Part 02's per-file checklist includes
    "re-read the Decision Guide and update any stale cross-references"; the
@@ -301,11 +302,11 @@ Flag these to the reviewer before execution.
 - Current `CLAUDE.md § Skill Groups`: lines 259–276
 - Current `CONTRIBUTING.md § READ-DO`: lines 33–51
 - Current `gemba-plan` SKILL.md: `.claude/skills/gemba-plan/SKILL.md`
-- Current `staff-engineer.md` agent profile:
-  `.claude/agents/staff-engineer.md` lines 8–13
-- Current `libs-*` SKILL.md files: `.claude/skills/libs-{data-persistence,
-  llm-orchestration, service-infrastructure, synthetic-data, system-utilities,
-  web-presentation}/SKILL.md` and `.claude/skills/libskill/SKILL.md`
+- Current `staff-engineer.md` agent profile: `.claude/agents/staff-engineer.md`
+  lines 8–13
+- Current `libs-*` SKILL.md files:
+  `.claude/skills/libs-{data-persistence, llm-orchestration, service-infrastructure, synthetic-data, system-utilities, web-presentation}/SKILL.md`
+  and `.claude/skills/libskill/SKILL.md`
 - Existing export-resolution script (pattern for Part 04):
   `scripts/check-exports-resolve.js` (91 lines)
 - Orphan library source entry points (Part 02 reads for `Key Exports`):

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -55,4 +55,4 @@
 370	planned
 380	done
 390	done
-400	review
+400	planned


### PR DESCRIPTION
## Summary

- Adds `plan-a.md` + `plan-a-01.md` through `plan-a-04.md` for spec 400 (Library Skill Discovery).
- Advances `specs/STATUS` for spec 400 from `review` → `planned`.
- No code changes outside `specs/400-library-skill-discovery/` and `specs/STATUS`.

## Plan shape

Four independently-executable parts on the same branch:

| # | File | Scope |
| --- | --- | --- |
| 01 | `plan-a-01.md` | `git mv` five `libs-*` skill directories to task-named groups; update `CLAUDE.md § Skill Groups` |
| 02 | `plan-a-02.md` | Rewrite all 7 SKILL.md files — frontmatter descriptions in "Use when" capability verbs; inner tables switched to `Capabilities` / `Key Exports`; orphan rows added (`libtool`, `libcli`, `librepl`, `libeval`, `libuniverse`) |
| 03 | `plan-a-03.md` | Discovery protocol: READ-DO checklist item in `CONTRIBUTING.md`; "Libraries used" section required by `gemba-plan`; six `libs-*` skills pre-loaded in `staff-engineer.md` |
| 04 | `plan-a-04.md` | New `scripts/check-skill-exports.js` + wire into `bun run check` **and** new `check-skill-exports` job in `.github/workflows/check-quality.yml` |

Parts 01 → 02 → 04 are sequential on the `libs-*` surface. Part 03 is independent and can run in parallel.

## Review

Clean sub-agent review via `gemba-review` returned 2 High + 5 Medium findings — all addressed before status advance:

- **High**: Part 04 CI workflow edit promoted from optional to required (the existing workflow runs `check:exports` as a standalone job, not `bun run check` wholesale).
- **High**: Part 01 grep scoped to live surfaces; historic `specs/` references preserved.
- **Medium**: Part 04 ES module scanner uses `[\s\S]*?` for multi-line `export { … } from` blocks, with explicit recursive resolution for `@forwardimpact/libX` package specifiers.
- **Medium**: Part 02 `libs-content` section reworded — libcli/librepl were never in the old table (the orphan problem spec 400 fixes).
- **Medium**: Part 02 `libs-cli-and-tooling` split into 5 inherited + 3 new-from-scratch rows (libeval was listed in CLAUDE.md but absent from the old table).
- **Medium**: Part 03 CONTRIBUTING.md anchor uses bullet ordinals, not line numbers.
- **Medium**: Part 02/04 ordering clarified — Part 02 commits first with hand-verified `Key Exports`; Part 04 must pass on first run.

## Test plan

- [x] `bun run format` clean
- [x] `bun run lint` clean
- [x] `bun run check:exports` clean
- [x] `bun run test` — 2221 passing, 0 failing
- [ ] `bun run layout` — pre-existing environmental issue (`libraries/librpc/generated/` and `libraries/libtype/generated/` are gitignored symlinks created by the session-start codegen hook; CI passes because it runs against a fresh checkout without codegen output). Unrelated to this PR.

https://claude.ai/code/session_01LAQU8EwZBgCXvfMwENYk3x