### PR TITLE
plan(080): Landmark product implementation plan

### DIFF
--- a/specs/080-landmark-product/plan-a-01.md
+++ b/specs/080-landmark-product/plan-a-01.md
@@ -72,8 +72,8 @@ products/landmark/
 - `justfile` — if other products have per-product `just` targets (e.g.
   `just pathway ...`), add an equivalent `landmark` recipe delegating to
   `bunx fit-landmark`. If no per-product recipes exist, skip this change.
-- `specs/STATUS` — do **not** change in this part; status changes are a
-  reviewer action, not an implementation step.
+- `specs/STATUS` — do **not** change in this part; status changes are a reviewer
+  action, not an implementation step.
 
 ## Implementation details
 
@@ -128,8 +128,8 @@ later parts will extend this list.
 }
 ```
 
-Do not add `@forwardimpact/summit` yet — that dependency is owned by Part 03.
-Do not add `yaml` — Landmark loads framework data through Map's loader, which
+Do not add `@forwardimpact/summit` yet — that dependency is owned by Part 03. Do
+not add `yaml` — Landmark loads framework data through Map's loader, which
 already owns YAML parsing.
 
 ### `products/landmark/bin/fit-landmark.js`
@@ -149,14 +149,13 @@ const COMMANDS = {
 ```
 
 The `createCli` definition lists the full spec-080 command set from the
-beginning (so `fit-landmark --help` prints the correct usage even though
-Parts 02–05 are not yet implemented). Unimplemented commands in Part 01
-dispatch to a shared `runNotYetImplementedCommand` stub that prints
-"`<command>` lands in spec 080 Part <NN>" and exits with code **64**
-(`EX_USAGE`-adjacent — clearly distinct from libcli's code 2 "usage error"
-so shell automation can tell "unknown command" apart from "command not yet
-implemented"). This keeps `fit-landmark --help` honest and gives downstream
-parts a fixed insertion point.
+beginning (so `fit-landmark --help` prints the correct usage even though Parts
+02–05 are not yet implemented). Unimplemented commands in Part 01 dispatch to a
+shared `runNotYetImplementedCommand` stub that prints "`<command>` lands in spec
+080 Part <NN>" and exits with code **64** (`EX_USAGE`-adjacent — clearly
+distinct from libcli's code 2 "usage error" so shell automation can tell
+"unknown command" apart from "command not yet implemented"). This keeps
+`fit-landmark --help` honest and gives downstream parts a fixed insertion point.
 
 Global options (shared with Summit's pattern):
 
@@ -177,10 +176,10 @@ options: {
 }
 ```
 
-`main()` resolves `dataDir` via `resolveDataDir(values)` (from `src/lib/cli.js`),
-loads Map data via `loadMapData(dataDir)`, creates a Supabase client lazily
-inside commands that need it, and dispatches to the handler with the shape
-described in plan-a § Cross-part conventions.
+`main()` resolves `dataDir` via `resolveDataDir(values)` (from
+`src/lib/cli.js`), loads Map data via `loadMapData(dataDir)`, creates a Supabase
+client lazily inside commands that need it, and dispatches to the handler with
+the shape described in plan-a § Cross-part conventions.
 
 Error handling: wrap the handler in try/catch. On `SupabaseUnavailableError`,
 print the message, exit code 3. On any other error, print via
@@ -197,20 +196,19 @@ Rationale: duplicating Summit's helper avoids cross-product coupling from a
 shared library change while both products' needs are still evolving. A future
 refactor can extract this into `libmap-cli` if a third consumer appears.
 
-**Data directory subpath:** Summit's `resolveDataDir` hard-codes the
-`"pathway"` subdirectory under the contributor data finder root (`join(finder
-.findData("data", homedir()), "pathway")`). This is intentional — Pathway,
-Summit, and Landmark all read the same Map data directory, which lives under
-`data/pathway/` for historical reasons. Landmark copies the literal
+**Data directory subpath:** Summit's `resolveDataDir` hard-codes the `"pathway"`
+subdirectory under the contributor data finder root
+(`join(finder .findData("data", homedir()), "pathway")`). This is intentional —
+Pathway, Summit, and Landmark all read the same Map data directory, which lives
+under `data/pathway/` for historical reasons. Landmark copies the literal
 `"pathway"` verbatim; do not rename.
 
 ### `products/landmark/src/lib/supabase.js`
 
 Copy Summit's `src/lib/supabase.js`, renaming the factory to
-`createLandmarkClient` and the error class to `SupabaseUnavailableError`
-(reuse the name; scoping is via `code: "LANDMARK_SUPABASE_UNAVAILABLE"`).
-Environment contract is identical: `MAP_SUPABASE_URL` and
-`MAP_SUPABASE_SERVICE_ROLE_KEY`.
+`createLandmarkClient` and the error class to `SupabaseUnavailableError` (reuse
+the name; scoping is via `code: "LANDMARK_SUPABASE_UNAVAILABLE"`). Environment
+contract is identical: `MAP_SUPABASE_URL` and `MAP_SUPABASE_SERVICE_ROLE_KEY`.
 
 ### `products/landmark/src/lib/context.js`
 
@@ -225,16 +223,16 @@ export async function buildContext({ dataDir, options, needsSupabase }) {
 }
 ```
 
-Commands declare `needsSupabase` via a flag on the handler module (see below)
-so the dispatcher can open a client only when necessary. `marker` declares
+Commands declare `needsSupabase` via a flag on the handler module (see below) so
+the dispatcher can open a client only when necessary. `marker` declares
 `needsSupabase: false`; everything else declares `true`.
 
 ### `products/landmark/src/lib/empty-state.js`
 
 Central registry of the spec's empty-state messages (spec § Empty States and
-Error Behavior). Export a `describeEmptyState(kind, context)` function and
-named constants for each row in the spec table. Tests assert each kind maps
-to the expected message.
+Error Behavior). Export a `describeEmptyState(kind, context)` function and named
+constants for each row in the spec table. Tests assert each kind maps to the
+expected message.
 
 ```js
 export const EMPTY_STATES = {
@@ -273,26 +271,28 @@ export async function runOrgCommand({ args, options, mapData, supabase, format }
 ```
 
 `showOrganization` calls `getOrganization(supabase)` from
-`@forwardimpact/map/activity/queries/org` and returns `{ view: people, meta: {
-format } }`. The `org team` path calls `getTeam(supabase, managerEmail)`; if the
-result is empty, set `meta.emptyState = EMPTY_STATES.MANAGER_NOT_FOUND(email)`.
+`@forwardimpact/map/activity/queries/org` and returns
+`{ view: people, meta: { format } }`. The `org team` path calls
+`getTeam(supabase, managerEmail)`; if the result is empty, set
+`meta.emptyState = EMPTY_STATES.MANAGER_NOT_FOUND(email)`.
 
 ### Command: `snapshot` — `products/landmark/src/commands/snapshot.js`
 
 Dispatches `list`, `show`, `trend`, `compare`:
 
 - `list` → `listSnapshots(supabase)`. Empty → `EMPTY_STATES.NO_SNAPSHOTS`.
-- `show` → requires `--snapshot <id>`. Calls `getSnapshotScores(supabase, id,
-  { managerEmail: options.manager })`. Empty → `EMPTY_STATES.NO_SNAPSHOTS` or
-  `MANAGER_NOT_FOUND`.
-- `trend` → requires `--item <id>`. Calls `getItemTrend(supabase, itemId,
-  { managerEmail })`. Empty → `EMPTY_STATES.NO_SNAPSHOTS`.
+- `show` → requires `--snapshot <id>`. Calls
+  `getSnapshotScores(supabase, id, { managerEmail: options.manager })`. Empty →
+  `EMPTY_STATES.NO_SNAPSHOTS` or `MANAGER_NOT_FOUND`.
+- `trend` → requires `--item <id>`. Calls
+  `getItemTrend(supabase, itemId, { managerEmail })`. Empty →
+  `EMPTY_STATES.NO_SNAPSHOTS`.
 - `compare` → requires `--snapshot <id>`. Calls **`getSnapshotComparison`**
   directly from `@forwardimpact/map/activity/queries/snapshots` — the module
   already exports it as its own function (internal implementation may wrap
-  `getSnapshotScores`, but Landmark must depend on the public contract).
-  Columns in text/markdown formatters use `vs_prev`, `vs_org`, `vs_50th`,
-  `vs_75th`, `vs_90th`.
+  `getSnapshotScores`, but Landmark must depend on the public contract). Columns
+  in text/markdown formatters use `vs_prev`, `vs_org`, `vs_50th`, `vs_75th`,
+  `vs_90th`.
 
 Cross-reference unknown `item_id` values against `mapData.drivers` to collect
 warnings: any score row whose `item_id` has no matching driver adds a warning
@@ -324,10 +324,10 @@ already exposes). Skills come from `createDataLoader().loadAllData()` which
 preserves the `markers` field per research.
 
 Explicitly calls out that no capability in the starter data currently defines
-markers. Part 02 will add them, at which point `fit-landmark marker
-task_completion` will produce real output. Until Part 02 merges, this command
-always returns the "No markers defined" empty state — and the test asserts
-exactly that path.
+markers. Part 02 will add them, at which point
+`fit-landmark marker task_completion` will produce real output. Until Part 02
+merges, this command always returns the "No markers defined" empty state — and
+the test asserts exactly that path.
 
 ### Formatters
 
@@ -350,13 +350,16 @@ wrapper around libcli formatting helpers already used by Summit.
 Every test runs against in-memory fixtures. No network, no actual Supabase.
 
 - `test/cli-command.test.js` — parses arg strings, confirms each declared
-  command routes to the correct handler, confirms `--format` defaults to
-  `text`, confirms unknown commands exit with code 2.
-- `test/org.test.js` — stub `supabase` with a controlled `from('organization_people').select()` path. Verify `getOrganization` is called, verify `org team --manager` filters, verify empty manager returns the correct empty state.
-- `test/snapshot.test.js` — four cases: `list`, `show`, `trend`, `compare`.
-  Mock the snapshot query module by passing an injected query object into the
-  command handler rather than going through `createLandmarkClient`. Tests
-  exercise the `item_id`↔driver warning path explicitly.
+  command routes to the correct handler, confirms `--format` defaults to `text`,
+  confirms unknown commands exit with code 2.
+- `test/org.test.js` — stub `supabase` with a controlled
+  `from('organization_people').select()` path. Verify `getOrganization` is
+  called, verify `org team --manager` filters, verify empty manager returns the
+  correct empty state.
+- `test/snapshot.test.js` — four cases: `list`, `show`, `trend`, `compare`. Mock
+  the snapshot query module by passing an injected query object into the command
+  handler rather than going through `createLandmarkClient`. Tests exercise the
+  `item_id`↔driver warning path explicitly.
 - `test/marker.test.js` — uses a hand-built `mapData` fixture with one skill
   that has markers and one that doesn't. Covers `--level` filtering and the
   empty-state path.
@@ -365,35 +368,34 @@ Every test runs against in-memory fixtures. No network, no actual Supabase.
   empty-state table.
 
 Mocking pattern for commands: command handlers accept an optional `queries`
-parameter (default: module imports from `@forwardimpact/map/activity/...`)
-that tests override to inject stubs. This keeps `createLandmarkClient`
-untouched by tests while still exercising the handler end-to-end.
+parameter (default: module imports from `@forwardimpact/map/activity/...`) that
+tests override to inject stubs. This keeps `createLandmarkClient` untouched by
+tests while still exercising the handler end-to-end.
 
 ## Verification
 
 After all files are written and tests pass locally:
 
-1. `cd products/landmark && bun install` — confirms workspace graph is
-   correct.
-2. `bun run layout` at the repo root — asserts Landmark's `src/`-rooted
-   package layout passes `scripts/check-package-layout.js`.
-3. `bun run check:exports` at the repo root — asserts every published
-   `main`, `bin`, `exports` target resolves to a real file
-   (`scripts/check-exports-resolve.js`). This catches invented exports
-   entries before they reach CI.
+1. `cd products/landmark && bun install` — confirms workspace graph is correct.
+2. `bun run layout` at the repo root — asserts Landmark's `src/`-rooted package
+   layout passes `scripts/check-package-layout.js`.
+3. `bun run check:exports` at the repo root — asserts every published `main`,
+   `bin`, `exports` target resolves to a real file
+   (`scripts/check-exports-resolve.js`). This catches invented exports entries
+   before they reach CI.
 4. `bun run check` at the repo root — full lint/format/layout/exports.
 5. `bun test products/landmark/test` — runs Part 01 tests in isolation.
-6. Smoke test: `bunx fit-landmark --help` prints the full command set with
-   Part 01 commands implemented and Parts 02–05 listed (dispatching to the
-   "not yet implemented" stub, exit code 64).
-7. `bunx fit-landmark marker task_completion` against the starter data
-   returns the "No markers defined" empty state, proving the command hits the
+6. Smoke test: `bunx fit-landmark --help` prints the full command set with Part
+   01 commands implemented and Parts 02–05 listed (dispatching to the "not yet
+   implemented" stub, exit code 64).
+7. `bunx fit-landmark marker task_completion` against the starter data returns
+   the "No markers defined" empty state, proving the command hits the
    spec-documented empty path.
-8. With a running `just activity` Supabase, `bunx fit-landmark org show`
-   returns the seeded `organization_people` rows.
+8. With a running `just activity` Supabase, `bunx fit-landmark org show` returns
+   the seeded `organization_people` rows.
 
 ## Deliverable
 
-A merged PR that leaves `main` with a working `fit-landmark` CLI exposing
-`org`, `snapshot`, and `marker` commands. No changes to Map, Summit, or any
-other product. No status change to `specs/STATUS`.
+A merged PR that leaves `main` with a working `fit-landmark` CLI exposing `org`,
+`snapshot`, and `marker` commands. No changes to Map, Summit, or any other
+product. No status change to `specs/STATUS`.

--- a/specs/080-landmark-product/plan-a-01.md
+++ b/specs/080-landmark-product/plan-a-01.md
@@ -110,9 +110,7 @@ later parts will extend this list.
   },
   "files": ["bin/", "src/"],
   "exports": {
-    ".": "./src/index.js",
-    "./formatters": "./src/formatters/index.js",
-    "./commands": "./src/commands/index.js"
+    ".": "./src/index.js"
   },
   "dependencies": {
     "@forwardimpact/libcli": "^0.1.0",
@@ -154,9 +152,11 @@ The `createCli` definition lists the full spec-080 command set from the
 beginning (so `fit-landmark --help` prints the correct usage even though
 Parts 02–05 are not yet implemented). Unimplemented commands in Part 01
 dispatch to a shared `runNotYetImplementedCommand` stub that prints
-"`<command>` lands in spec 080 Part <NN>" and exits with code 2. This keeps
-`fit-landmark --help` honest and gives downstream parts a fixed insertion
-point.
+"`<command>` lands in spec 080 Part <NN>" and exits with code **64**
+(`EX_USAGE`-adjacent — clearly distinct from libcli's code 2 "usage error"
+so shell automation can tell "unknown command" apart from "command not yet
+implemented"). This keeps `fit-landmark --help` honest and gives downstream
+parts a fixed insertion point.
 
 Global options (shared with Summit's pattern):
 
@@ -196,6 +196,13 @@ sync going forward; if either diverges, the divergence must be justified.
 Rationale: duplicating Summit's helper avoids cross-product coupling from a
 shared library change while both products' needs are still evolving. A future
 refactor can extract this into `libmap-cli` if a third consumer appears.
+
+**Data directory subpath:** Summit's `resolveDataDir` hard-codes the
+`"pathway"` subdirectory under the contributor data finder root (`join(finder
+.findData("data", homedir()), "pathway")`). This is intentional — Pathway,
+Summit, and Landmark all read the same Map data directory, which lives under
+`data/pathway/` for historical reasons. Landmark copies the literal
+`"pathway"` verbatim; do not rename.
 
 ### `products/landmark/src/lib/supabase.js`
 
@@ -280,10 +287,12 @@ Dispatches `list`, `show`, `trend`, `compare`:
   `MANAGER_NOT_FOUND`.
 - `trend` → requires `--item <id>`. Calls `getItemTrend(supabase, itemId,
   { managerEmail })`. Empty → `EMPTY_STATES.NO_SNAPSHOTS`.
-- `compare` → requires `--snapshot <id>`. Calls `getSnapshotComparison(...)`;
-  note spec says this reuses `getSnapshotScores`, so the command simply calls
-  that. Columns shown in text/markdown formatters use `vs_prev`, `vs_org`,
-  `vs_50th`, `vs_75th`, `vs_90th`.
+- `compare` → requires `--snapshot <id>`. Calls **`getSnapshotComparison`**
+  directly from `@forwardimpact/map/activity/queries/snapshots` — the module
+  already exports it as its own function (internal implementation may wrap
+  `getSnapshotScores`, but Landmark must depend on the public contract).
+  Columns in text/markdown formatters use `vs_prev`, `vs_org`, `vs_50th`,
+  `vs_75th`, `vs_90th`.
 
 Cross-reference unknown `item_id` values against `mapData.drivers` to collect
 warnings: any score row whose `item_id` has no matching driver adds a warning
@@ -366,17 +375,21 @@ After all files are written and tests pass locally:
 
 1. `cd products/landmark && bun install` — confirms workspace graph is
    correct.
-2. `bun run check` at the repo root — runs lint, format, layout
-   (`scripts/check-package-layout.js` asserts `src/`-rooted layout), and
-   exports check.
-3. `bun test products/landmark/test` — runs Part 01 tests in isolation.
-4. Smoke test: `bunx fit-landmark --help` prints the full command set with
+2. `bun run layout` at the repo root — asserts Landmark's `src/`-rooted
+   package layout passes `scripts/check-package-layout.js`.
+3. `bun run check:exports` at the repo root — asserts every published
+   `main`, `bin`, `exports` target resolves to a real file
+   (`scripts/check-exports-resolve.js`). This catches invented exports
+   entries before they reach CI.
+4. `bun run check` at the repo root — full lint/format/layout/exports.
+5. `bun test products/landmark/test` — runs Part 01 tests in isolation.
+6. Smoke test: `bunx fit-landmark --help` prints the full command set with
    Part 01 commands implemented and Parts 02–05 listed (dispatching to the
-   "not yet implemented" stub).
-5. `bunx fit-landmark marker task_completion` against the starter data
+   "not yet implemented" stub, exit code 64).
+7. `bunx fit-landmark marker task_completion` against the starter data
    returns the "No markers defined" empty state, proving the command hits the
    spec-documented empty path.
-6. With a running `just activity` Supabase, `bunx fit-landmark org show`
+8. With a running `just activity` Supabase, `bunx fit-landmark org show`
    returns the seeded `organization_people` rows.
 
 ## Deliverable

--- a/specs/080-landmark-product/plan-a-01.md
+++ b/specs/080-landmark-product/plan-a-01.md
@@ -1,0 +1,386 @@
+# Plan A · Part 01 — Scaffolding and foundational views
+
+Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md).
+
+This part creates the `@forwardimpact/landmark` package, wires the
+`fit-landmark` CLI through libcli, and ships three commands whose data sources
+already exist in Map: `org`, `snapshot`, and `marker`.
+
+No other part of the plan depends on anything except Part 01 being merged, so
+this is the strict foundation.
+
+## Scope
+
+**In scope**
+
+- Create `products/landmark/` with the standard per-package layout (spec 390).
+- Declare dependencies and add Landmark to the monorepo workspace.
+- Implement the CLI bootstrap (`bin/fit-landmark.js`), shared helpers
+  (`src/lib/*`), and formatter infrastructure (`src/formatters/*`).
+- Implement commands: `org show`, `org team`, `snapshot list`, `snapshot show`,
+  `snapshot trend`, `snapshot compare`, `marker`.
+- Implement the standard empty-state system shared by all future commands.
+- Tests for each command using `node:test` and stub clients.
+- `bun run check` clean.
+
+**Out of scope**
+
+- Evidence-based views (Part 02).
+- Health view (Part 03).
+- Voice, initiative commands (Parts 04, 05).
+- Documentation updates (Part 06).
+- Changes to Map, Summit, or any existing product source.
+- Adding markers to starter data (Part 02).
+
+## Files
+
+### Created
+
+```
+products/landmark/
+  package.json
+  bin/
+    fit-landmark.js
+  src/
+    index.js
+    lib/
+      cli.js
+      supabase.js
+      context.js
+      empty-state.js
+    commands/
+      org.js
+      snapshot.js
+      marker.js
+    formatters/
+      index.js
+      shared.js
+      org.js
+      snapshot.js
+      marker.js
+  test/
+    cli-command.test.js
+    org.test.js
+    snapshot.test.js
+    marker.test.js
+    empty-state.test.js
+```
+
+### Modified
+
+- `package.json` (monorepo root) — add `"products/landmark"` to `workspaces`.
+- `justfile` — if other products have per-product `just` targets (e.g.
+  `just pathway ...`), add an equivalent `landmark` recipe delegating to
+  `bunx fit-landmark`. If no per-product recipes exist, skip this change.
+- `specs/STATUS` — do **not** change in this part; status changes are a
+  reviewer action, not an implementation step.
+
+## Implementation details
+
+### `products/landmark/package.json`
+
+Mirror Summit's shape. Declare only the dependencies this part actually needs;
+later parts will extend this list.
+
+```json
+{
+  "name": "@forwardimpact/landmark",
+  "version": "0.1.0",
+  "description": "Analysis and recommendation layer on top of Map activity data.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/forwardimpact/monorepo",
+    "directory": "products/landmark"
+  },
+  "homepage": "https://www.forwardimpact.team/landmark",
+  "keywords": [
+    "engineering",
+    "analytics",
+    "framework",
+    "skills",
+    "team",
+    "getdx",
+    "github"
+  ],
+  "type": "module",
+  "main": "./src/index.js",
+  "bin": {
+    "fit-landmark": "./bin/fit-landmark.js"
+  },
+  "files": ["bin/", "src/"],
+  "exports": {
+    ".": "./src/index.js",
+    "./formatters": "./src/formatters/index.js",
+    "./commands": "./src/commands/index.js"
+  },
+  "dependencies": {
+    "@forwardimpact/libcli": "^0.1.0",
+    "@forwardimpact/libtelemetry": "^0.1.33",
+    "@forwardimpact/libutil": "^0.1.72",
+    "@forwardimpact/libskill": "^4.1.7",
+    "@forwardimpact/map": "^0.15.18",
+    "@supabase/supabase-js": "^2.103.0"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=18.0.0"
+  },
+  "publishConfig": { "access": "public" }
+}
+```
+
+Do not add `@forwardimpact/summit` yet — that dependency is owned by Part 03.
+Do not add `yaml` — Landmark loads framework data through Map's loader, which
+already owns YAML parsing.
+
+### `products/landmark/bin/fit-landmark.js`
+
+Follow Summit's bin pattern verbatim where possible. Node-compatible shebang
+(`#!/usr/bin/env node`), version read from `package.json`, dispatcher using
+`libcli.createCli`.
+
+Command set for Part 01:
+
+```js
+const COMMANDS = {
+  org: runOrgCommand,
+  snapshot: runSnapshotCommand,
+  marker: runMarkerCommand,
+};
+```
+
+The `createCli` definition lists the full spec-080 command set from the
+beginning (so `fit-landmark --help` prints the correct usage even though
+Parts 02–05 are not yet implemented). Unimplemented commands in Part 01
+dispatch to a shared `runNotYetImplementedCommand` stub that prints
+"`<command>` lands in spec 080 Part <NN>" and exits with code 2. This keeps
+`fit-landmark --help` honest and gives downstream parts a fixed insertion
+point.
+
+Global options (shared with Summit's pattern):
+
+```js
+options: {
+  data: { type: "string", description: "Path to Map data directory" },
+  format: { type: "string", default: "text", description: "Output format (text|json|markdown)" },
+  manager: { type: "string", description: "Filter by manager email" },
+  email: { type: "string", description: "Filter by person email" },
+  skill: { type: "string", description: "Filter by skill id" },
+  level: { type: "string", description: "Target or filter level" },
+  target: { type: "string", description: "Readiness target level" },
+  snapshot: { type: "string", description: "Snapshot id" },
+  item: { type: "string", description: "Driver/item id for trend" },
+  id: { type: "string", description: "Entity id (initiative, etc.)" },
+  help: { type: "boolean", short: "h", description: "Show help" },
+  version: { type: "boolean", short: "v", description: "Show version" },
+}
+```
+
+`main()` resolves `dataDir` via `resolveDataDir(values)` (from `src/lib/cli.js`),
+loads Map data via `loadMapData(dataDir)`, creates a Supabase client lazily
+inside commands that need it, and dispatches to the handler with the shape
+described in plan-a § Cross-part conventions.
+
+Error handling: wrap the handler in try/catch. On `SupabaseUnavailableError`,
+print the message, exit code 3. On any other error, print via
+`cli.error(err.message)`, exit code 1.
+
+### `products/landmark/src/lib/cli.js`
+
+Copy Summit's `src/lib/cli.js` (`resolveDataDir`, `loadMapData`,
+`resolveFormat`, `Format` constant) verbatim, changing only the logger name
+(`"landmark"`) and the error-message prefix. The two files should be kept in
+sync going forward; if either diverges, the divergence must be justified.
+
+Rationale: duplicating Summit's helper avoids cross-product coupling from a
+shared library change while both products' needs are still evolving. A future
+refactor can extract this into `libmap-cli` if a third consumer appears.
+
+### `products/landmark/src/lib/supabase.js`
+
+Copy Summit's `src/lib/supabase.js`, renaming the factory to
+`createLandmarkClient` and the error class to `SupabaseUnavailableError`
+(reuse the name; scoping is via `code: "LANDMARK_SUPABASE_UNAVAILABLE"`).
+Environment contract is identical: `MAP_SUPABASE_URL` and
+`MAP_SUPABASE_SERVICE_ROLE_KEY`.
+
+### `products/landmark/src/lib/context.js`
+
+Builds the command context. Signature:
+
+```js
+export async function buildContext({ dataDir, options, needsSupabase }) {
+  const mapData = await loadMapData(dataDir);
+  const supabase = needsSupabase ? createLandmarkClient() : null;
+  const format = resolveFormat(options);
+  return { mapData, supabase, format, options };
+}
+```
+
+Commands declare `needsSupabase` via a flag on the handler module (see below)
+so the dispatcher can open a client only when necessary. `marker` declares
+`needsSupabase: false`; everything else declares `true`.
+
+### `products/landmark/src/lib/empty-state.js`
+
+Central registry of the spec's empty-state messages (spec § Empty States and
+Error Behavior). Export a `describeEmptyState(kind, context)` function and
+named constants for each row in the spec table. Tests assert each kind maps
+to the expected message.
+
+```js
+export const EMPTY_STATES = {
+  NO_EVIDENCE: "No evidence data available. Guide has not yet interpreted artifacts for this scope.",
+  NO_MARKERS_FOR_SKILL: (skill) => `No markers defined for ${skill}. Add markers to the capability YAML.`,
+  NO_MARKERS_AT_TARGET: "No markers defined at target level — cannot generate checklist.",
+  NO_SNAPSHOTS: "No GetDX snapshot data available. Run `fit-map getdx sync` (or `fit-map activity seed` for synthetic data) to ingest.",
+  NO_COMMENTS: "Snapshot comments not available. The getdx_snapshot_comments table has not been created.",
+  NO_INITIATIVES: "Initiative data not available. The getdx_initiatives table has not been created.",
+  PERSON_NOT_FOUND: (email) => `No person found with email ${email} in organization_people.`,
+  MANAGER_NOT_FOUND: (email) => `No team found for manager ${email}.`,
+  NO_HIGHER_LEVEL: (id) => `No higher level defined in levels.yaml. Current level (${id}) is the highest.`,
+};
+```
+
+Parts 02–05 add their own entries without modifying existing ones.
+
+### Command: `org` — `products/landmark/src/commands/org.js`
+
+Subcommand dispatch inside the module:
+
+```js
+export const needsSupabase = true;
+
+export async function runOrgCommand({ args, options, mapData, supabase, format }) {
+  const [sub] = args;
+  switch (sub) {
+    case "show":
+      return showOrganization({ supabase, format });
+    case "team":
+      return showTeam({ supabase, managerEmail: options.manager, format });
+    default:
+      throw new UsageError("org: expected `show` or `team` subcommand");
+  }
+}
+```
+
+`showOrganization` calls `getOrganization(supabase)` from
+`@forwardimpact/map/activity/queries/org` and returns `{ view: people, meta: {
+format } }`. The `org team` path calls `getTeam(supabase, managerEmail)`; if the
+result is empty, set `meta.emptyState = EMPTY_STATES.MANAGER_NOT_FOUND(email)`.
+
+### Command: `snapshot` — `products/landmark/src/commands/snapshot.js`
+
+Dispatches `list`, `show`, `trend`, `compare`:
+
+- `list` → `listSnapshots(supabase)`. Empty → `EMPTY_STATES.NO_SNAPSHOTS`.
+- `show` → requires `--snapshot <id>`. Calls `getSnapshotScores(supabase, id,
+  { managerEmail: options.manager })`. Empty → `EMPTY_STATES.NO_SNAPSHOTS` or
+  `MANAGER_NOT_FOUND`.
+- `trend` → requires `--item <id>`. Calls `getItemTrend(supabase, itemId,
+  { managerEmail })`. Empty → `EMPTY_STATES.NO_SNAPSHOTS`.
+- `compare` → requires `--snapshot <id>`. Calls `getSnapshotComparison(...)`;
+  note spec says this reuses `getSnapshotScores`, so the command simply calls
+  that. Columns shown in text/markdown formatters use `vs_prev`, `vs_org`,
+  `vs_50th`, `vs_75th`, `vs_90th`.
+
+Cross-reference unknown `item_id` values against `mapData.drivers` to collect
+warnings: any score row whose `item_id` has no matching driver adds a warning
+message to `meta.warnings`. Part 03's `health` command relies on this mapping
+being solid; exercising it here ensures regressions surface early.
+
+### Command: `marker` — `products/landmark/src/commands/marker.js`
+
+```js
+export const needsSupabase = false;
+
+export async function runMarkerCommand({ args, options, mapData, format }) {
+  const [skillId] = args;
+  if (!skillId) throw new UsageError("marker: skill id is required");
+  const skill = findSkill(mapData, skillId);
+  if (!skill) return { view: null, meta: { format, emptyState: `Skill not found: ${skillId}` } };
+  const markers = skill.markers ?? null;
+  if (!markers || Object.keys(markers).length === 0) {
+    return { view: null, meta: { format, emptyState: EMPTY_STATES.NO_MARKERS_FOR_SKILL(skillId) } };
+  }
+  const levelFilter = options.level ?? null;
+  const filtered = levelFilter ? { [levelFilter]: markers[levelFilter] ?? [] } : markers;
+  return { view: { skill: skill.id, name: skill.name, markers: filtered }, meta: { format } };
+}
+```
+
+`findSkill` walks `mapData.skills` (or the capabilities-to-skills map Map
+already exposes). Skills come from `createDataLoader().loadAllData()` which
+preserves the `markers` field per research.
+
+Explicitly calls out that no capability in the starter data currently defines
+markers. Part 02 will add them, at which point `fit-landmark marker
+task_completion` will produce real output. Until Part 02 merges, this command
+always returns the "No markers defined" empty state — and the test asserts
+exactly that path.
+
+### Formatters
+
+`src/formatters/index.js` re-exports one formatter per command and a
+`formatResult(result)` dispatcher that picks the formatter by command name and
+by `meta.format`. Each formatter module exports:
+
+- `toText(view, meta)` — returns a string for the `text` format.
+- `toJson(view, meta)` — returns a JSON string (always includes `meta`).
+- `toMarkdown(view, meta)` — returns a markdown string.
+
+Empty-state rule: if `meta.emptyState` is set, every format prints only the
+empty-state message (JSON includes it as `{ emptyState: "...", view: null }`).
+
+`src/formatters/shared.js` hosts `formatTable`, `formatKeyValue`, and a thin
+wrapper around libcli formatting helpers already used by Summit.
+
+## Tests
+
+Every test runs against in-memory fixtures. No network, no actual Supabase.
+
+- `test/cli-command.test.js` — parses arg strings, confirms each declared
+  command routes to the correct handler, confirms `--format` defaults to
+  `text`, confirms unknown commands exit with code 2.
+- `test/org.test.js` — stub `supabase` with a controlled `from('organization_people').select()` path. Verify `getOrganization` is called, verify `org team --manager` filters, verify empty manager returns the correct empty state.
+- `test/snapshot.test.js` — four cases: `list`, `show`, `trend`, `compare`.
+  Mock the snapshot query module by passing an injected query object into the
+  command handler rather than going through `createLandmarkClient`. Tests
+  exercise the `item_id`↔driver warning path explicitly.
+- `test/marker.test.js` — uses a hand-built `mapData` fixture with one skill
+  that has markers and one that doesn't. Covers `--level` filtering and the
+  empty-state path.
+- `test/empty-state.test.js` — every entry in `EMPTY_STATES` is reachable from
+  at least one command path. This is a regression test against the spec's
+  empty-state table.
+
+Mocking pattern for commands: command handlers accept an optional `queries`
+parameter (default: module imports from `@forwardimpact/map/activity/...`)
+that tests override to inject stubs. This keeps `createLandmarkClient`
+untouched by tests while still exercising the handler end-to-end.
+
+## Verification
+
+After all files are written and tests pass locally:
+
+1. `cd products/landmark && bun install` — confirms workspace graph is
+   correct.
+2. `bun run check` at the repo root — runs lint, format, layout
+   (`scripts/check-package-layout.js` asserts `src/`-rooted layout), and
+   exports check.
+3. `bun test products/landmark/test` — runs Part 01 tests in isolation.
+4. Smoke test: `bunx fit-landmark --help` prints the full command set with
+   Part 01 commands implemented and Parts 02–05 listed (dispatching to the
+   "not yet implemented" stub).
+5. `bunx fit-landmark marker task_completion` against the starter data
+   returns the "No markers defined" empty state, proving the command hits the
+   spec-documented empty path.
+6. With a running `just activity` Supabase, `bunx fit-landmark org show`
+   returns the seeded `organization_people` rows.
+
+## Deliverable
+
+A merged PR that leaves `main` with a working `fit-landmark` CLI exposing
+`org`, `snapshot`, and `marker` commands. No changes to Map, Summit, or any
+other product. No status change to `specs/STATUS`.

--- a/specs/080-landmark-product/plan-a-02.md
+++ b/specs/080-landmark-product/plan-a-02.md
@@ -4,16 +4,16 @@ Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
 [Part 01](./plan-a-01.md) being merged.
 
 This part adds marker definitions to the starter capabilities so the
-evidence-based views have criteria to evaluate against, then ships the
-Landmark commands that read from Map's existing `evidence` query module:
-`evidence`, `readiness`, `timeline`, `coverage`, `practiced`.
+evidence-based views have criteria to evaluate against, then ships the Landmark
+commands that read from Map's existing `evidence` query module: `evidence`,
+`readiness`, `timeline`, `coverage`, `practiced`.
 
 ## Scope
 
 **In scope**
 
-- Author `markers:` sections on `task_completion`, `planning`, and at least
-  one skill inside `reliability.yaml`.
+- Author `markers:` sections on `task_completion`, `planning`, and at least one
+  skill inside `reliability.yaml`.
 - Add a shared `evidenceHelpers.js` module in Landmark's `src/lib/` for join
   logic reused by multiple commands.
 - Implement commands: `evidence`, `readiness`, `timeline`, `coverage`,
@@ -22,18 +22,17 @@ Landmark commands that read from Map's existing `evidence` query module:
   resolve required skills at a target level for a given discipline+track.
 - Empty-state handling for every command per spec § Empty States.
 - Tests for each command using `node:test`.
-- Update Part 01's `marker` command test to confirm it now produces real
-  output for seeded skills (the test that previously asserted the empty path
-  now asserts real output — both paths are kept, exercised via different
-  fixtures).
+- Update Part 01's `marker` command test to confirm it now produces real output
+  for seeded skills (the test that previously asserted the empty path now
+  asserts real output — both paths are kept, exercised via different fixtures).
 
 **Out of scope**
 
 - Health view (Part 03).
 - Voice/initiative commands (Parts 04/05).
 - Changes to `drivers.yaml` (Part 03 owns that).
-- Marker authoring beyond the two starter capabilities (installations extend
-  on their own).
+- Marker authoring beyond the two starter capabilities (installations extend on
+  their own).
 
 ## Files
 
@@ -73,22 +72,22 @@ products/landmark/test/
 - `products/map/starter/capabilities/reliability.yaml` — add `markers` to at
   least one skill (pick `incident_response` if defined, otherwise the first
   skill).
-- `products/landmark/bin/fit-landmark.js` — replace "not yet implemented"
-  stubs for `evidence`, `readiness`, `timeline`, `coverage`, `practiced` with
-  the real handler imports and dispatch entries in `COMMANDS`.
+- `products/landmark/bin/fit-landmark.js` — replace "not yet implemented" stubs
+  for `evidence`, `readiness`, `timeline`, `coverage`, `practiced` with the real
+  handler imports and dispatch entries in `COMMANDS`.
 - `products/landmark/src/formatters/index.js` — register the new formatters.
 - `products/map/test/` — extend any test that loads starter capabilities to
-  accept the new `markers` field, or confirm existing tests still pass
-  without change (Map's loader test just snapshot-compares the loaded shape;
-  update the snapshot if necessary).
+  accept the new `markers` field, or confirm existing tests still pass without
+  change (Map's loader test just snapshot-compares the loaded shape; update the
+  snapshot if necessary).
 
 ## Implementation details
 
 ### Starter marker authoring
 
 Authoring rule (from spec § Markers): each marker entry is a proficiency key
-(`awareness` | `foundational` | `working` | `practitioner` | `expert`) with
-an object containing `human:` and/or `agent:` string arrays. Validated by
+(`awareness` | `foundational` | `working` | `practitioner` | `expert`) with an
+object containing `human:` and/or `agent:` string arrays. Validated by
 `products/map/src/validation/skill.js#validateSkillMarkers`.
 
 **Proficiency coverage rule.** Starter levels map to libskill-derived
@@ -99,15 +98,15 @@ proficiencies via each level's `baseSkillProficiencies` (see
 - `J060`: primary=`working`, secondary=`foundational`, broad=`awareness`
 
 For an engineer at `J040` targeting `J060`, the readiness checklist needs
-markers at **every proficiency `J060` requires** for the skills in their
-matrix: `working` (primary), `foundational` (secondary), `awareness` (broad).
-Therefore this part authors markers at **`awareness`, `foundational`, and
-`working`** — all three tiers the starter levels can request. Practitioner
-and expert are out of scope (no starter level requires them).
+markers at **every proficiency `J060` requires** for the skills in their matrix:
+`working` (primary), `foundational` (secondary), `awareness` (broad). Therefore
+this part authors markers at **`awareness`, `foundational`, and `working`** —
+all three tiers the starter levels can request. Practitioner and expert are out
+of scope (no starter level requires them).
 
 Authoring fewer than all three proficiencies leaves the happy-path readiness
-test firing the `NO_MARKERS_AT_TARGET` empty state for broad/secondary
-skills, which defeats the point of Part 02.
+test firing the `NO_MARKERS_AT_TARGET` empty state for broad/secondary skills,
+which defeats the point of Part 02.
 
 Example authored content for `task_completion` in `delivery.yaml`:
 
@@ -165,7 +164,8 @@ export function buildMarkerChecklist(markers, evidenceRows) { ... }
 export function computeCoverageRatio(artifacts, evidenceRows) { ... }
 ```
 
-All functions are pure; each has its own unit test in `evidence-helpers.test.js`.
+All functions are pure; each has its own unit test in
+`evidence-helpers.test.js`.
 
 ### Command: `evidence`
 
@@ -174,8 +174,9 @@ Signature: `fit-landmark evidence [--skill <id>] [--email <email>]`.
 Handler calls `getEvidence(supabase, { skillId, email })` from
 `@forwardimpact/map/activity/queries/evidence`. Groups results by skill via
 `groupEvidenceBySkill`. Always includes a coverage line: uses
-`getUnscoredArtifacts` + `getArtifacts` counts to render `Evidence covers
-X/Y artifacts` (spec § Evidence coverage metrics). Empty → `NO_EVIDENCE`.
+`getUnscoredArtifacts` + `getArtifacts` counts to render
+`Evidence covers X/Y artifacts` (spec § Evidence coverage metrics). Empty →
+`NO_EVIDENCE`.
 
 ### Command: `readiness`
 
@@ -186,56 +187,56 @@ Steps:
 1. `getPerson(supabase, options.email)`. If null → `PERSON_NOT_FOUND`.
 2. Resolve `currentLevel` as the level object (not id) by looking up
    `person.level` in `mapData.levels` where `level.id === person.level`.
-3. Resolve `targetLevel` as a level object. If `options.target` is set,
-   look it up the same way; else call
-   `getNextLevel({ level: currentLevel, levels: mapData.levels })`
-   (libskill's real signature — destructured, not positional). If null →
+3. Resolve `targetLevel` as a level object. If `options.target` is set, look it
+   up the same way; else call
+   `getNextLevel({ level: currentLevel, levels: mapData.levels })` (libskill's
+   real signature — destructured, not positional). If null →
    `NO_HIGHER_LEVEL(currentLevel.id)`.
-4. Resolve the person's `discipline` and `track` objects from `mapData`
-   (same id-lookup pattern as the level).
-5. Derive the expected skill matrix at the target level using libskill's
-   real signature:
+4. Resolve the person's `discipline` and `track` objects from `mapData` (same
+   id-lookup pattern as the level).
+5. Derive the expected skill matrix at the target level using libskill's real
+   signature:
    `deriveSkillMatrix({ discipline, level: targetLevel, track, skills: mapData.skills })`.
-   The return is an array of `{ skillId, skillName, proficiency, ... }`
-   entries where `proficiency` is the libskill-resolved required
-   proficiency for each skill at the target level (one of
+   The return is an array of `{ skillId, skillName, proficiency, ... }` entries
+   where `proficiency` is the libskill-resolved required proficiency for each
+   skill at the target level (one of
    `awareness|foundational|working|practitioner|expert`).
 6. For each matrix entry, load the skill from `mapData.skills`, find its
    `markers[entry.proficiency]`, and collect the list of required markers.
-   Skills without markers at their required proficiency are **skipped with
-   a per-skill note** (`{ skillId, skipped: "no markers at <proficiency>" }`)
-   — not a command-wide failure.
+   Skills without markers at their required proficiency are **skipped with a
+   per-skill note** (`{ skillId, skipped: "no markers at <proficiency>" }`) —
+   not a command-wide failure.
 7. If **every** matrix skill is skipped (no markers defined anywhere at the
-   required proficiencies) → `NO_MARKERS_AT_TARGET`. Otherwise continue
-   with the non-skipped set.
+   required proficiencies) → `NO_MARKERS_AT_TARGET`. Otherwise continue with the
+   non-skipped set.
 8. Load evidence rows for the person: `getEvidence(supabase, { email })`,
    filtered to `matched: true`.
 9. Build the checklist via `buildMarkerChecklist`. Summary line:
-   `"<evidenced>/<total> markers evidenced. Missing: ..."`. Include a
-   separate footer line listing any skipped skills so the user can act.
+   `"<evidenced>/<total> markers evidenced. Missing: ..."`. Include a separate
+   footer line listing any skipped skills so the user can act.
 
-The `readiness` formatter renders `[x]` / `[ ]` checkboxes with artifact ids
-in text/markdown; JSON returns the raw checklist array plus the skipped-skill
-list.
+The `readiness` formatter renders `[x]` / `[ ]` checkboxes with artifact ids in
+text/markdown; JSON returns the raw checklist array plus the skipped-skill list.
 
 Starter-limitation tests (three cases):
 
-1. Person at `J060` (highest starter level) — handler returns
-   `NO_HIGHER_LEVEL` empty state.
-2. Person at `J040` targeting `J060` with fully-authored markers at
-   `awareness`, `foundational`, and `working` — handler returns a real
-   checklist with zero skipped skills.
+1. Person at `J060` (highest starter level) — handler returns `NO_HIGHER_LEVEL`
+   empty state.
+2. Person at `J040` targeting `J060` with fully-authored markers at `awareness`,
+   `foundational`, and `working` — handler returns a real checklist with zero
+   skipped skills.
 3. Fixture where one skill's required proficiency has no markers — handler
-   returns a real checklist for the remaining skills and lists the skipped
-   skill in the footer. No `NO_MARKERS_AT_TARGET` empty state in this case.
+   returns a real checklist for the remaining skills and lists the skipped skill
+   in the footer. No `NO_MARKERS_AT_TARGET` empty state in this case.
 
 ### Command: `timeline`
 
 Signature: `fit-landmark timeline --email <email> [--skill <id>]`.
 
 Calls `getEvidence(supabase, { email, skillId })`. Passes the result through
-`highestLevelPerSkillPerQuarter`. Output rows are `(quarter, skillId,
-highestLevel)`. No markers needed — this view is purely temporal aggregation.
+`highestLevelPerSkillPerQuarter`. Output rows are
+`(quarter, skillId, highestLevel)`. No markers needed — this view is purely
+temporal aggregation.
 
 Empty → `NO_EVIDENCE`.
 
@@ -246,8 +247,8 @@ Signature: `fit-landmark coverage --email <email>`.
 Calls `getPerson`, then `getArtifacts(supabase, { email })` and
 `getUnscoredArtifacts(supabase, { email })`. Computes the coverage ratio via
 `computeCoverageRatio`. The view groups uncovered artifacts by `artifact_type`
-so the user sees which artifact categories have been interpreted and which
-have not.
+so the user sees which artifact categories have been interpreted and which have
+not.
 
 Empty (no artifacts at all) → `"No artifacts found for ${email}."` (a new
 empty-state constant `NO_ARTIFACTS_FOR_PERSON` added to
@@ -268,9 +269,9 @@ Shows evidenced depth alongside derived depth for a manager's team. Steps:
    which returns `[{ skill_id, matched, unmatched, total }, ...]`.
 4. For each skill, render `derived_depth` alongside `evidenced_depth`.
    Divergence highlight rule: if `derived_depth` is non-null and
-   `evidenced_depth` is zero, flag as "on paper only". If `evidenced_depth`
-   is non-zero for a skill not in the derived matrix, flag as "evidenced
-   beyond role".
+   `evidenced_depth` is zero, flag as "on paper only". If `evidenced_depth` is
+   non-zero for a skill not in the derived matrix, flag as "evidenced beyond
+   role".
 
 Empty (no evidence rows for any team member) → `NO_EVIDENCE`.
 
@@ -297,8 +298,8 @@ const COMMANDS = {
 };
 ```
 
-`health`, `voice`, and `initiative` entries remain routed to the stub
-handler from Part 01 — Parts 03/04/05 replace them.
+`health`, `voice`, and `initiative` entries remain routed to the stub handler
+from Part 01 — Parts 03/04/05 replace them.
 
 ## Tests
 
@@ -311,8 +312,8 @@ handler from Part 01 — Parts 03/04/05 replace them.
      object signature.
   2. J060 person — `NO_HIGHER_LEVEL` empty state.
   3. Mixed-marker fixture where one required skill has no markers at its
-     required proficiency — checklist for the remaining skills, skipped
-     skill listed in footer, no empty state.
+     required proficiency — checklist for the remaining skills, skipped skill
+     listed in footer, no empty state.
   4. Fully-unmarked fixture (no skills have any markers at required
      proficiencies) — `NO_MARKERS_AT_TARGET` empty state.
 - `timeline.test.js` — fixture with evidence across 3 quarters, two skills.
@@ -325,12 +326,12 @@ handler from Part 01 — Parts 03/04/05 replace them.
   divergence flags.
 - `evidence-helpers.test.js` — pure unit tests for every exported function.
 - Update `marker.test.js` from Part 01: add a new case using a synthetic
-  `mapData` fixture where `task_completion` has authored markers, asserting
-  the formatted output matches spec § Marker reference view. Part 01's
-  original "no markers defined" test case stays — it uses a different
-  synthetic fixture with an empty `markers` field. The two cases coexist
-  because neither depends on real starter data; they share the command
-  handler but inject distinct in-memory fixtures.
+  `mapData` fixture where `task_completion` has authored markers, asserting the
+  formatted output matches spec § Marker reference view. Part 01's original "no
+  markers defined" test case stays — it uses a different synthetic fixture with
+  an empty `markers` field. The two cases coexist because neither depends on
+  real starter data; they share the command handler but inject distinct
+  in-memory fixtures.
 
 ## Verification
 
@@ -338,10 +339,10 @@ handler from Part 01 — Parts 03/04/05 replace them.
    `markers` fields pass schema validation.
 2. `bun test products/landmark/test` — all command tests green, including the
    updated `marker.test.js`.
-3. `bun test products/map/test` — Map's loader and validation tests still
-   green with the expanded starter content.
-4. `bun run layout && bun run check:exports && bun run check` — layout,
-   exports, lint/format all green.
+3. `bun test products/map/test` — Map's loader and validation tests still green
+   with the expanded starter content.
+4. `bun run layout && bun run check:exports && bun run check` — layout, exports,
+   lint/format all green.
 5. Smoke test against `fit-map activity seed`:
    - `bunx fit-landmark readiness --email engineer-1@example.com` produces a
      checklist.
@@ -353,5 +354,5 @@ handler from Part 01 — Parts 03/04/05 replace them.
 ## Deliverable
 
 A merged PR that enables every evidence-based view declared in spec § Product
-Behavior (except `health`). Starter data now demonstrates markers. `fit-map
-validate` stays green.
+Behavior (except `health`). Starter data now demonstrates markers.
+`fit-map validate` stays green.

--- a/specs/080-landmark-product/plan-a-02.md
+++ b/specs/080-landmark-product/plan-a-02.md
@@ -91,10 +91,23 @@ Authoring rule (from spec § Markers): each marker entry is a proficiency key
 an object containing `human:` and/or `agent:` string arrays. Validated by
 `products/map/src/validation/skill.js#validateSkillMarkers`.
 
-Author only `foundational` and `working` markers in this part — the starter's
-two levels (`J040`, `J060`) only exercise those proficiencies, and adding
-more would inflate the scope without adding coverage. Installations extend
-with higher proficiencies as needed.
+**Proficiency coverage rule.** Starter levels map to libskill-derived
+proficiencies via each level's `baseSkillProficiencies` (see
+`products/map/starter/levels.yaml`):
+
+- `J040`: primary=`foundational`, secondary=`awareness`, broad=`awareness`
+- `J060`: primary=`working`, secondary=`foundational`, broad=`awareness`
+
+For an engineer at `J040` targeting `J060`, the readiness checklist needs
+markers at **every proficiency `J060` requires** for the skills in their
+matrix: `working` (primary), `foundational` (secondary), `awareness` (broad).
+Therefore this part authors markers at **`awareness`, `foundational`, and
+`working`** — all three tiers the starter levels can request. Practitioner
+and expert are out of scope (no starter level requires them).
+
+Authoring fewer than all three proficiencies leaves the happy-path readiness
+test firing the `NO_MARKERS_AT_TARGET` empty state for broad/secondary
+skills, which defeats the point of Part 02.
 
 Example authored content for `task_completion` in `delivery.yaml`:
 
@@ -103,6 +116,11 @@ Example authored content for `task_completion` in `delivery.yaml`:
   name: Task Completion
   # ... existing content ...
   markers:
+    awareness:
+      human:
+        - Closed an assigned task by following a documented runbook
+      agent:
+        - Completed a task by applying an existing pattern from the codebase
     foundational:
       human:
         - Delivered a small feature end-to-end with minimal rework
@@ -166,27 +184,50 @@ Signature: `fit-landmark readiness --email <email> [--target <level>]`.
 Steps:
 
 1. `getPerson(supabase, options.email)`. If null → `PERSON_NOT_FOUND`.
-2. Resolve target level. If `options.target` is set, use it directly.
-   Otherwise call `getNextLevel(mapData.levels, person.level)`. If no next
-   level exists → `NO_HIGHER_LEVEL(person.level)`.
-3. Derive the expected skill matrix at the target level for the person's
-   discipline/track using `deriveSkillMatrix` from `libskill`. (Confirm the
-   exact function name in Part 01 research; the agent reported
-   `deriveSkillMatrix` as the canonical export.)
-4. For each skill in the matrix, load its markers at the target level from
-   `mapData.skills`. If no markers are defined for any required skill →
-   `NO_MARKERS_AT_TARGET` (do not silently skip).
-5. Load evidence rows for the person: `getEvidence(supabase, { email })`,
+2. Resolve `currentLevel` as the level object (not id) by looking up
+   `person.level` in `mapData.levels` where `level.id === person.level`.
+3. Resolve `targetLevel` as a level object. If `options.target` is set,
+   look it up the same way; else call
+   `getNextLevel({ level: currentLevel, levels: mapData.levels })`
+   (libskill's real signature — destructured, not positional). If null →
+   `NO_HIGHER_LEVEL(currentLevel.id)`.
+4. Resolve the person's `discipline` and `track` objects from `mapData`
+   (same id-lookup pattern as the level).
+5. Derive the expected skill matrix at the target level using libskill's
+   real signature:
+   `deriveSkillMatrix({ discipline, level: targetLevel, track, skills: mapData.skills })`.
+   The return is an array of `{ skillId, skillName, proficiency, ... }`
+   entries where `proficiency` is the libskill-resolved required
+   proficiency for each skill at the target level (one of
+   `awareness|foundational|working|practitioner|expert`).
+6. For each matrix entry, load the skill from `mapData.skills`, find its
+   `markers[entry.proficiency]`, and collect the list of required markers.
+   Skills without markers at their required proficiency are **skipped with
+   a per-skill note** (`{ skillId, skipped: "no markers at <proficiency>" }`)
+   — not a command-wide failure.
+7. If **every** matrix skill is skipped (no markers defined anywhere at the
+   required proficiencies) → `NO_MARKERS_AT_TARGET`. Otherwise continue
+   with the non-skipped set.
+8. Load evidence rows for the person: `getEvidence(supabase, { email })`,
    filtered to `matched: true`.
-6. Build the checklist via `buildMarkerChecklist`. Summary line:
-   `"<evidenced>/<total> markers evidenced. Missing: ..."`.
+9. Build the checklist via `buildMarkerChecklist`. Summary line:
+   `"<evidenced>/<total> markers evidenced. Missing: ..."`. Include a
+   separate footer line listing any skipped skills so the user can act.
 
 The `readiness` formatter renders `[x]` / `[ ]` checkboxes with artifact ids
-in text/markdown; JSON returns the raw checklist array.
+in text/markdown; JSON returns the raw checklist array plus the skipped-skill
+list.
 
-Starter-limitation test: fixture with a person at level `J060` (the highest
-in starter data) — handler returns the `NO_HIGHER_LEVEL` empty state. Second
-fixture with a person at `J040` returns a real checklist.
+Starter-limitation tests (three cases):
+
+1. Person at `J060` (highest starter level) — handler returns
+   `NO_HIGHER_LEVEL` empty state.
+2. Person at `J040` targeting `J060` with fully-authored markers at
+   `awareness`, `foundational`, and `working` — handler returns a real
+   checklist with zero skipped skills.
+3. Fixture where one skill's required proficiency has no markers — handler
+   returns a real checklist for the remaining skills and lists the skipped
+   skill in the footer. No `NO_MARKERS_AT_TARGET` empty state in this case.
 
 ### Command: `timeline`
 
@@ -264,10 +305,16 @@ handler from Part 01 — Parts 03/04/05 replace them.
 - `evidence.test.js` — fixtures: one person with 3 evidence rows across 2
   skills, one person with none. Covers `--skill` filter, `--email` filter, and
   the empty-state path. Also asserts the coverage line is always present.
-- `readiness.test.js` — three cases: J040 person with partial evidence
-  (checklist with mix of `[x]` / `[ ]`), J060 person (`NO_HIGHER_LEVEL`
-  empty state), person with required skills that have no markers at the
-  target level (`NO_MARKERS_AT_TARGET`).
+- `readiness.test.js` — four cases:
+  1. J040 person with partial evidence — checklist with mix of `[x]` / `[ ]`,
+     zero skipped, verifies `getNextLevel` is called with the destructured
+     object signature.
+  2. J060 person — `NO_HIGHER_LEVEL` empty state.
+  3. Mixed-marker fixture where one required skill has no markers at its
+     required proficiency — checklist for the remaining skills, skipped
+     skill listed in footer, no empty state.
+  4. Fully-unmarked fixture (no skills have any markers at required
+     proficiencies) — `NO_MARKERS_AT_TARGET` empty state.
 - `timeline.test.js` — fixture with evidence across 3 quarters, two skills.
   Verifies highest-level-per-(quarter, skill) aggregation and the `--skill`
   filter.
@@ -277,9 +324,13 @@ handler from Part 01 — Parts 03/04/05 replace them.
   derived-depth aggregation and the "on paper only" / "evidenced beyond role"
   divergence flags.
 - `evidence-helpers.test.js` — pure unit tests for every exported function.
-- Update `marker.test.js` from Part 01: add a new case that uses a fixture
-  where `task_completion` has markers, asserting the formatted output now
-  matches spec § Marker reference view.
+- Update `marker.test.js` from Part 01: add a new case using a synthetic
+  `mapData` fixture where `task_completion` has authored markers, asserting
+  the formatted output matches spec § Marker reference view. Part 01's
+  original "no markers defined" test case stays — it uses a different
+  synthetic fixture with an empty `markers` field. The two cases coexist
+  because neither depends on real starter data; they share the command
+  handler but inject distinct in-memory fixtures.
 
 ## Verification
 
@@ -289,7 +340,8 @@ handler from Part 01 — Parts 03/04/05 replace them.
    updated `marker.test.js`.
 3. `bun test products/map/test` — Map's loader and validation tests still
    green with the expanded starter content.
-4. `bun run check` — lint, format, layout, exports check.
+4. `bun run layout && bun run check:exports && bun run check` — layout,
+   exports, lint/format all green.
 5. Smoke test against `fit-map activity seed`:
    - `bunx fit-landmark readiness --email engineer-1@example.com` produces a
      checklist.

--- a/specs/080-landmark-product/plan-a-02.md
+++ b/specs/080-landmark-product/plan-a-02.md
@@ -1,0 +1,305 @@
+# Plan A · Part 02 — Evidence-based views + starter markers
+
+Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
+[Part 01](./plan-a-01.md) being merged.
+
+This part adds marker definitions to the starter capabilities so the
+evidence-based views have criteria to evaluate against, then ships the
+Landmark commands that read from Map's existing `evidence` query module:
+`evidence`, `readiness`, `timeline`, `coverage`, `practiced`.
+
+## Scope
+
+**In scope**
+
+- Author `markers:` sections on `task_completion`, `planning`, and at least
+  one skill inside `reliability.yaml`.
+- Add a shared `evidenceHelpers.js` module in Landmark's `src/lib/` for join
+  logic reused by multiple commands.
+- Implement commands: `evidence`, `readiness`, `timeline`, `coverage`,
+  `practiced`.
+- Wire `readiness` to `libskill`'s `getNextLevel` and `deriveSkillMatrix` to
+  resolve required skills at a target level for a given discipline+track.
+- Empty-state handling for every command per spec § Empty States.
+- Tests for each command using `node:test`.
+- Update Part 01's `marker` command test to confirm it now produces real
+  output for seeded skills (the test that previously asserted the empty path
+  now asserts real output — both paths are kept, exercised via different
+  fixtures).
+
+**Out of scope**
+
+- Health view (Part 03).
+- Voice/initiative commands (Parts 04/05).
+- Changes to `drivers.yaml` (Part 03 owns that).
+- Marker authoring beyond the two starter capabilities (installations extend
+  on their own).
+
+## Files
+
+### Created
+
+```
+products/landmark/src/lib/
+  evidence-helpers.js
+
+products/landmark/src/commands/
+  evidence.js
+  readiness.js
+  timeline.js
+  coverage.js
+  practiced.js
+
+products/landmark/src/formatters/
+  evidence.js
+  readiness.js
+  timeline.js
+  coverage.js
+  practiced.js
+
+products/landmark/test/
+  evidence.test.js
+  readiness.test.js
+  timeline.test.js
+  coverage.test.js
+  practiced.test.js
+  evidence-helpers.test.js
+```
+
+### Modified
+
+- `products/map/starter/capabilities/delivery.yaml` — add `markers` to
+  `task_completion` and `planning`.
+- `products/map/starter/capabilities/reliability.yaml` — add `markers` to at
+  least one skill (pick `incident_response` if defined, otherwise the first
+  skill).
+- `products/landmark/bin/fit-landmark.js` — replace "not yet implemented"
+  stubs for `evidence`, `readiness`, `timeline`, `coverage`, `practiced` with
+  the real handler imports and dispatch entries in `COMMANDS`.
+- `products/landmark/src/formatters/index.js` — register the new formatters.
+- `products/map/test/` — extend any test that loads starter capabilities to
+  accept the new `markers` field, or confirm existing tests still pass
+  without change (Map's loader test just snapshot-compares the loaded shape;
+  update the snapshot if necessary).
+
+## Implementation details
+
+### Starter marker authoring
+
+Authoring rule (from spec § Markers): each marker entry is a proficiency key
+(`awareness` | `foundational` | `working` | `practitioner` | `expert`) with
+an object containing `human:` and/or `agent:` string arrays. Validated by
+`products/map/src/validation/skill.js#validateSkillMarkers`.
+
+Author only `foundational` and `working` markers in this part — the starter's
+two levels (`J040`, `J060`) only exercise those proficiencies, and adding
+more would inflate the scope without adding coverage. Installations extend
+with higher proficiencies as needed.
+
+Example authored content for `task_completion` in `delivery.yaml`:
+
+```yaml
+- id: task_completion
+  name: Task Completion
+  # ... existing content ...
+  markers:
+    foundational:
+      human:
+        - Delivered a small feature end-to-end with minimal rework
+        - Estimated and completed a defined task within the committed timeframe
+      agent:
+        - Completed a single-file change that passes CI on the first attempt
+    working:
+      human:
+        - Delivered a feature end-to-end with no revision to the initial design
+        - Independently resolved a production issue within SLA
+      agent:
+        - Completed a multi-file change that passes CI without human rework
+        - Resolved an ambiguous bug report with evidence from logs and tests
+```
+
+Mirror for `planning` and for one skill in `reliability.yaml`. Keep language
+consistent with the existing `proficiencyDescriptions` on each skill.
+
+Run `bunx fit-map validate` after editing to confirm the new content passes
+schema validation. This is the single canonical validation entry point.
+
+### `evidence-helpers.js`
+
+Shared logic reused across commands. Export:
+
+```js
+// Groups raw evidence rows by skillId → { matched, unmatched, markers[] }.
+export function groupEvidenceBySkill(evidenceRows) { ... }
+
+// Groups evidence rows by ISO quarter (YYYY-Q{1..4}) derived from created_at.
+export function groupEvidenceByQuarter(evidenceRows) { ... }
+
+// Picks the highest matched level per (quarter, skill) using
+// SKILL_PROFICIENCY_ORDER from @forwardimpact/map/levels.
+export function highestLevelPerSkillPerQuarter(evidenceRows) { ... }
+
+// Given markers at a target level and evidence rows, returns a checklist
+// array: [{ marker, evidenced: boolean, artifactId?, rationale? }, ...].
+export function buildMarkerChecklist(markers, evidenceRows) { ... }
+
+// Computes coverage ratio: (artifacts with ≥1 evidence row) / (total artifacts).
+export function computeCoverageRatio(artifacts, evidenceRows) { ... }
+```
+
+All functions are pure; each has its own unit test in `evidence-helpers.test.js`.
+
+### Command: `evidence`
+
+Signature: `fit-landmark evidence [--skill <id>] [--email <email>]`.
+
+Handler calls `getEvidence(supabase, { skillId, email })` from
+`@forwardimpact/map/activity/queries/evidence`. Groups results by skill via
+`groupEvidenceBySkill`. Always includes a coverage line: uses
+`getUnscoredArtifacts` + `getArtifacts` counts to render `Evidence covers
+X/Y artifacts` (spec § Evidence coverage metrics). Empty → `NO_EVIDENCE`.
+
+### Command: `readiness`
+
+Signature: `fit-landmark readiness --email <email> [--target <level>]`.
+
+Steps:
+
+1. `getPerson(supabase, options.email)`. If null → `PERSON_NOT_FOUND`.
+2. Resolve target level. If `options.target` is set, use it directly.
+   Otherwise call `getNextLevel(mapData.levels, person.level)`. If no next
+   level exists → `NO_HIGHER_LEVEL(person.level)`.
+3. Derive the expected skill matrix at the target level for the person's
+   discipline/track using `deriveSkillMatrix` from `libskill`. (Confirm the
+   exact function name in Part 01 research; the agent reported
+   `deriveSkillMatrix` as the canonical export.)
+4. For each skill in the matrix, load its markers at the target level from
+   `mapData.skills`. If no markers are defined for any required skill →
+   `NO_MARKERS_AT_TARGET` (do not silently skip).
+5. Load evidence rows for the person: `getEvidence(supabase, { email })`,
+   filtered to `matched: true`.
+6. Build the checklist via `buildMarkerChecklist`. Summary line:
+   `"<evidenced>/<total> markers evidenced. Missing: ..."`.
+
+The `readiness` formatter renders `[x]` / `[ ]` checkboxes with artifact ids
+in text/markdown; JSON returns the raw checklist array.
+
+Starter-limitation test: fixture with a person at level `J060` (the highest
+in starter data) — handler returns the `NO_HIGHER_LEVEL` empty state. Second
+fixture with a person at `J040` returns a real checklist.
+
+### Command: `timeline`
+
+Signature: `fit-landmark timeline --email <email> [--skill <id>]`.
+
+Calls `getEvidence(supabase, { email, skillId })`. Passes the result through
+`highestLevelPerSkillPerQuarter`. Output rows are `(quarter, skillId,
+highestLevel)`. No markers needed — this view is purely temporal aggregation.
+
+Empty → `NO_EVIDENCE`.
+
+### Command: `coverage`
+
+Signature: `fit-landmark coverage --email <email>`.
+
+Calls `getPerson`, then `getArtifacts(supabase, { email })` and
+`getUnscoredArtifacts(supabase, { email })`. Computes the coverage ratio via
+`computeCoverageRatio`. The view groups uncovered artifacts by `artifact_type`
+so the user sees which artifact categories have been interpreted and which
+have not.
+
+Empty (no artifacts at all) → `"No artifacts found for ${email}."` (a new
+empty-state constant `NO_ARTIFACTS_FOR_PERSON` added to
+`src/lib/empty-state.js`).
+
+### Command: `practiced`
+
+Signature: `fit-landmark practiced --manager <email>`.
+
+Shows evidenced depth alongside derived depth for a manager's team. Steps:
+
+1. `getTeam(supabase, options.manager)`. If empty → `MANAGER_NOT_FOUND`.
+2. For each team member, derive their expected skill matrix via
+   `deriveSkillMatrix(mapData, { discipline, level, track })`. Aggregate the
+   derived depths across the team per skill (using the highest required
+   proficiency wins, matching Summit's convention).
+3. Fetch evidenced depth via `getPracticePatterns(supabase, { managerEmail })`
+   which returns `[{ skill_id, matched, unmatched, total }, ...]`.
+4. For each skill, render `derived_depth` alongside `evidenced_depth`.
+   Divergence highlight rule: if `derived_depth` is non-null and
+   `evidenced_depth` is zero, flag as "on paper only". If `evidenced_depth`
+   is non-zero for a skill not in the derived matrix, flag as "evidenced
+   beyond role".
+
+Empty (no evidence rows for any team member) → `NO_EVIDENCE`.
+
+### Bin dispatch update
+
+In `bin/fit-landmark.js`:
+
+```js
+import { runEvidenceCommand } from "../src/commands/evidence.js";
+import { runReadinessCommand } from "../src/commands/readiness.js";
+import { runTimelineCommand } from "../src/commands/timeline.js";
+import { runCoverageCommand } from "../src/commands/coverage.js";
+import { runPracticedCommand } from "../src/commands/practiced.js";
+
+const COMMANDS = {
+  org: runOrgCommand,
+  snapshot: runSnapshotCommand,
+  marker: runMarkerCommand,
+  evidence: runEvidenceCommand,
+  readiness: runReadinessCommand,
+  timeline: runTimelineCommand,
+  coverage: runCoverageCommand,
+  practiced: runPracticedCommand,
+};
+```
+
+`health`, `voice`, and `initiative` entries remain routed to the stub
+handler from Part 01 — Parts 03/04/05 replace them.
+
+## Tests
+
+- `evidence.test.js` — fixtures: one person with 3 evidence rows across 2
+  skills, one person with none. Covers `--skill` filter, `--email` filter, and
+  the empty-state path. Also asserts the coverage line is always present.
+- `readiness.test.js` — three cases: J040 person with partial evidence
+  (checklist with mix of `[x]` / `[ ]`), J060 person (`NO_HIGHER_LEVEL`
+  empty state), person with required skills that have no markers at the
+  target level (`NO_MARKERS_AT_TARGET`).
+- `timeline.test.js` — fixture with evidence across 3 quarters, two skills.
+  Verifies highest-level-per-(quarter, skill) aggregation and the `--skill`
+  filter.
+- `coverage.test.js` — person with mix of scored and unscored artifacts.
+  Verifies ratio and category grouping.
+- `practiced.test.js` — team of 3 with differing job profiles. Verifies
+  derived-depth aggregation and the "on paper only" / "evidenced beyond role"
+  divergence flags.
+- `evidence-helpers.test.js` — pure unit tests for every exported function.
+- Update `marker.test.js` from Part 01: add a new case that uses a fixture
+  where `task_completion` has markers, asserting the formatted output now
+  matches spec § Marker reference view.
+
+## Verification
+
+1. `bunx fit-map validate` with the updated starter data — confirms the new
+   `markers` fields pass schema validation.
+2. `bun test products/landmark/test` — all command tests green, including the
+   updated `marker.test.js`.
+3. `bun test products/map/test` — Map's loader and validation tests still
+   green with the expanded starter content.
+4. `bun run check` — lint, format, layout, exports check.
+5. Smoke test against `fit-map activity seed`:
+   - `bunx fit-landmark readiness --email engineer-1@example.com` produces a
+     checklist.
+   - `bunx fit-landmark coverage --email engineer-1@example.com` produces a
+     ratio.
+   - `bunx fit-landmark practiced --manager manager-1@example.com` produces a
+     derived-vs-evidenced table.
+
+## Deliverable
+
+A merged PR that enables every evidence-based view declared in spec § Product
+Behavior (except `health`). Starter data now demonstrates markers. `fit-map
+validate` stays green.

--- a/specs/080-landmark-product/plan-a-03.md
+++ b/specs/080-landmark-product/plan-a-03.md
@@ -3,15 +3,15 @@
 Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
 [Part 02](./plan-a-02.md) being merged.
 
-This part expands the starter `drivers.yaml` to demonstrate multi-driver
-views and ships the `health` command. Health joins snapshot scores,
-contributing-skill evidence counts, and (when available) Summit growth
-recommendations rendered inline.
+This part expands the starter `drivers.yaml` to demonstrate multi-driver views
+and ships the `health` command. Health joins snapshot scores, contributing-skill
+evidence counts, and (when available) Summit growth recommendations rendered
+inline.
 
 Summit exists in the repo (spec 090 is `done`) and already exports
-`computeGrowthAlignment` from the package root, so this part consumes it as
-a hard dependency while keeping the graceful-degrade path exercised in tests
-via a controlled wrapper.
+`computeGrowthAlignment` from the package root, so this part consumes it as a
+hard dependency while keeping the graceful-degrade path exercised in tests via a
+controlled wrapper.
 
 ## Scope
 
@@ -22,23 +22,23 @@ via a controlled wrapper.
   match skills already defined in the starter).
 - Add `@forwardimpact/summit` to Landmark's `dependencies`.
 - Implement the `health` command.
-- Wire a wrapper (`src/lib/summit.js`) that imports `computeGrowthAlignment`
-  and exposes a synchronous feature-detection boolean plus an async
-  `computeGrowth({ team, mapData, evidence, driverScores })` function that
-  tests can stub.
-- Extend the `item_id`↔driver validation introduced in Part 01 with a
-  formatter surface: warnings are rendered under the health view output.
-- Tests: health command with Summit present, health command with Summit
-  stubbed absent (graceful-degrade path).
+- Wire a wrapper (`src/lib/summit.js`) that imports `computeGrowthAlignment` and
+  exposes a synchronous feature-detection boolean plus an async
+  `computeGrowth({ team, mapData, evidence, driverScores })` function that tests
+  can stub.
+- Extend the `item_id`↔driver validation introduced in Part 01 with a formatter
+  surface: warnings are rendered under the health view output.
+- Tests: health command with Summit present, health command with Summit stubbed
+  absent (graceful-degrade path).
 
 **Out of scope**
 
-- Voice command (Part 04). Health's comment section renders whatever
-  `voice` data is passed in; Part 04 adds the fetch. Part 03 leaves the
-  comment section empty with a note "comments surface once Part 04 lands" —
-  the render path is ready, the data source is not.
-- Initiative tracking in health (Part 05 extends health to include
-  initiatives once the table exists).
+- Voice command (Part 04). Health's comment section renders whatever `voice`
+  data is passed in; Part 04 adds the fetch. Part 03 leaves the comment section
+  empty with a note "comments surface once Part 04 lands" — the render path is
+  ready, the data source is not.
+- Initiative tracking in health (Part 05 extends health to include initiatives
+  once the table exists).
 - Changes to Summit.
 
 ## Files
@@ -62,12 +62,11 @@ products/landmark/test/
 
 ### Modified
 
-- `products/map/starter/drivers.yaml` — add `reliability` and
-  `cognitive_load` drivers.
-- `products/landmark/package.json` — add `"@forwardimpact/summit": "^0.1.0"`
-  to `dependencies` (the actual version pin matches whatever Summit is
-  currently publishing; use the workspace convention of the caret of the
-  current minor).
+- `products/map/starter/drivers.yaml` — add `reliability` and `cognitive_load`
+  drivers.
+- `products/landmark/package.json` — add `"@forwardimpact/summit": "^0.1.0"` to
+  `dependencies` (the actual version pin matches whatever Summit is currently
+  publishing; use the workspace convention of the caret of the current minor).
 - `products/landmark/bin/fit-landmark.js` — replace `health` stub with real
   handler import and dispatch.
 - `products/landmark/src/formatters/index.js` — register health formatter.
@@ -78,9 +77,9 @@ products/landmark/test/
 ### `drivers.yaml` expansion
 
 Starter authoring must not break the existing `quality` driver. Add entries
-after the current one; do not reorder. Pick contributing skills from the
-set already present in the starter (`task_completion`, `planning`, plus any
-skills added in `reliability.yaml` if Part 02 added them).
+after the current one; do not reorder. Pick contributing skills from the set
+already present in the starter (`task_completion`, `planning`, plus any skills
+added in `reliability.yaml` if Part 02 added them).
 
 Exact content to add (adjust skill ids to match whatever Part 02 authored):
 
@@ -102,48 +101,48 @@ Exact content to add (adjust skill ids to match whatever Part 02 authored):
     - systems_thinking
 ```
 
-**Behaviours in health view — scope decision.** The existing `quality`
-driver already declares `contributingBehaviours: [systems_thinking]`. The
-spec's § Health view output example shows only contributing **skills** and
-their evidence counts, not behaviours. Behaviour evidence does not flow
-through the evidence pipeline the same way (behaviours are maturity
-profiles, not artifact-interpreted markers).
+**Behaviours in health view — scope decision.** The existing `quality` driver
+already declares `contributingBehaviours: [systems_thinking]`. The spec's §
+Health view output example shows only contributing **skills** and their evidence
+counts, not behaviours. Behaviour evidence does not flow through the evidence
+pipeline the same way (behaviours are maturity profiles, not
+artifact-interpreted markers).
 
-**Decision:** Part 03 preserves the `contributingBehaviours` field on all
-three drivers (consistency with `quality`), but the `health` command
-**does not render behaviours**. This matches the spec's mock-up exactly.
-Behaviour rendering is explicitly **out of scope** for spec 080 and should
-be tracked as a follow-up if a user asks for it. The spec's § Out of scope
-does not list this, so note it in Part 06's internals documentation.
+**Decision:** Part 03 preserves the `contributingBehaviours` field on all three
+drivers (consistency with `quality`), but the `health` command **does not render
+behaviours**. This matches the spec's mock-up exactly. Behaviour rendering is
+explicitly **out of scope** for spec 080 and should be tracked as a follow-up if
+a user asks for it. The spec's § Out of scope does not list this, so note it in
+Part 06's internals documentation.
 
-Rationale for preserving the field: dropping `contributingBehaviours` from
-the new drivers would create schema-level asymmetry with `quality` and
-suggest behaviours are irrelevant to those drivers, which is not the
-claim — Landmark just doesn't render them in this version.
+Rationale for preserving the field: dropping `contributingBehaviours` from the
+new drivers would create schema-level asymmetry with `quality` and suggest
+behaviours are irrelevant to those drivers, which is not the claim — Landmark
+just doesn't render them in this version.
 
 Validate with `bunx fit-map validate`. Confirm the new drivers load via
-`createDataLoader().loadAllData(dataDir)` in a unit test — Map's loader test
-may already assert the count; update the expected count.
+`createDataLoader().loadAllData(dataDir)` in a unit test — Map's loader test may
+already assert the count; update the expected count.
 
 Note: real GetDX installations will match `driver.id` to
-`getdx_snapshot_team_scores.item_id` values. The starter drivers use short
-ids that are unlikely to collide with a real GetDX scorecard, which is
-intentional: starter drivers are demonstrative, not production.
+`getdx_snapshot_team_scores.item_id` values. The starter drivers use short ids
+that are unlikely to collide with a real GetDX scorecard, which is intentional:
+starter drivers are demonstrative, not production.
 
 ### `src/lib/summit.js`
 
 Wrapper around Summit's growth export. Summit's `computeGrowthAlignment` is
 **synchronous** (`export function computeGrowthAlignment(...)` in
 `products/summit/src/aggregation/growth.js`). The wrapper exists purely for
-**optionality** (dynamic `import()` so Landmark degrades gracefully if
-Summit is absent from node_modules) and for **test injection**. It is not
-an async-bridging shim.
+**optionality** (dynamic `import()` so Landmark degrades gracefully if Summit is
+absent from node_modules) and for **test injection**. It is not an
+async-bridging shim.
 
 Summit also exports `GrowthContractError` — raised when the caller's framework
-data violates Summit's contract (e.g., a skill without a valid proficiency
-at the target level). This is a **data problem**, not a "Summit unavailable"
-problem, and must surface differently: as a warning on the health view, not
-as silent degradation.
+data violates Summit's contract (e.g., a skill without a valid proficiency at
+the target level). This is a **data problem**, not a "Summit unavailable"
+problem, and must surface differently: as a warning on the health view, not as
+silent degradation.
 
 ```js
 let cachedFn = null;
@@ -206,11 +205,10 @@ Decisions:
 
 - `loadSummit` is cached because `import()` is async and repeated dispatch
   inside the health view would otherwise re-resolve the module.
-- The test hook `__setSummitForTests` is the documented seam and is used
-  only by `summit.test.js` and `health.test.js`. No production code calls
-  it.
-- `GrowthContractError` becomes a **warning** on the health view rather
-  than a silent skip, so framework authoring bugs are visible to the user.
+- The test hook `__setSummitForTests` is the documented seam and is used only by
+  `summit.test.js` and `health.test.js`. No production code calls it.
+- `GrowthContractError` becomes a **warning** on the health view rather than a
+  silent skip, so framework authoring bugs are visible to the user.
 
 ### Command: `health`
 
@@ -224,36 +222,35 @@ Steps:
 2. `listSnapshots(supabase)` — pick the most recent (first row, spec says
    ordered DESC). No snapshots → `NO_SNAPSHOTS`.
 3. `getSnapshotScores(supabase, latest.snapshot_id, { managerEmail })`.
-4. Load Map drivers. Join scores to drivers by `item_id === driver.id`.
-   Collect unknown-item warnings in `meta.warnings`.
+4. Load Map drivers. Join scores to drivers by `item_id === driver.id`. Collect
+   unknown-item warnings in `meta.warnings`.
 5. For each matched driver, gather contributing skills from the driver
-   definition, then fetch evidence counts per skill via `getEvidence(supabase,
-   { skillId, managerEmail? })`. The query does not natively support
-   managerEmail filtering on evidence; when `--manager` is set, filter
-   client-side by intersecting artifact emails against the team roster.
-   (Encapsulate this filter in `evidence-helpers.js#filterEvidenceByTeam`
-   added here, with its own unit test.)
-6. Build the growth-recommendation bundle: team roster (from step 1), map
-   data, evidence grouped by skillId via
-   `evidence-helpers.js#groupEvidenceBySkill`, and driverScores as a Map
-   from `driver.id` to `{ score, vs_prev, vs_org, vs_50th, vs_75th, vs_90th }`.
-   Call `computeGrowth(...)`. If `available: false`, render without
-   recommendation lines; if `available: true`, render each recommendation
-   inline under its driver section matching the spec's output (§ Health
-   view, lines 410–440).
-7. Comment section: reserved for Part 04. The handler reserves a
-   `comments: []` field inside each driver view entry and the formatter
-   renders `(engineer voice requires Part 04 — getdx_snapshot_comments
-   table)` when the array is empty. Part 04 populates the field; the
-   formatter handles both paths.
-8. Initiatives section: reserved for Part 05. Each driver view entry
-   reserves an `initiatives: []` field; the formatter renders
-   `(no active initiatives)` when empty. Part 05 populates the field.
+   definition, then fetch evidence counts per skill via
+   `getEvidence(supabase, { skillId, managerEmail? })`. The query does not
+   natively support managerEmail filtering on evidence; when `--manager` is set,
+   filter client-side by intersecting artifact emails against the team roster.
+   (Encapsulate this filter in `evidence-helpers.js#filterEvidenceByTeam` added
+   here, with its own unit test.)
+6. Build the growth-recommendation bundle: team roster (from step 1), map data,
+   evidence grouped by skillId via `evidence-helpers.js#groupEvidenceBySkill`,
+   and driverScores as a Map from `driver.id` to
+   `{ score, vs_prev, vs_org, vs_50th, vs_75th, vs_90th }`. Call
+   `computeGrowth(...)`. If `available: false`, render without recommendation
+   lines; if `available: true`, render each recommendation inline under its
+   driver section matching the spec's output (§ Health view, lines 410–440).
+7. Comment section: reserved for Part 04. The handler reserves a `comments: []`
+   field inside each driver view entry and the formatter renders
+   `(engineer voice requires Part 04 — getdx_snapshot_comments table)` when the
+   array is empty. Part 04 populates the field; the formatter handles both
+   paths.
+8. Initiatives section: reserved for Part 05. Each driver view entry reserves an
+   `initiatives: []` field; the formatter renders `(no active initiatives)` when
+   empty. Part 05 populates the field.
 9. Return `{ view: { drivers: [...] }, meta: { format, warnings } }`.
 
-**Anchor-comment contract for Parts 04 and 05.** Part 03 **must** place
-two explicit anchor comments inside `src/commands/health.js` at the
-fetch-assembly stage:
+**Anchor-comment contract for Parts 04 and 05.** Part 03 **must** place two
+explicit anchor comments inside `src/commands/health.js` at the fetch-assembly
+stage:
 
 ```js
 // <comments section> — Part 04 adds getSnapshotComments fetch here
@@ -268,10 +265,9 @@ per-driver render stage:
 // <initiatives section> — Part 05 renders per-driver initiatives here
 ```
 
-Parts 04 and 05 edit only the code between their own anchors. This
-contract makes the parallel execution window risk-free: a merge conflict
-between Parts 04 and 05 indicates a contract violation, not a merge
-problem to resolve.
+Parts 04 and 05 edit only the code between their own anchors. This contract
+makes the parallel execution window risk-free: a merge conflict between Parts 04
+and 05 indicates a contract violation, not a merge problem to resolve.
 
 ### Formatter
 
@@ -289,30 +285,29 @@ Platform team — health view
       (Summit growth alignment: high impact)
 ```
 
-Text formatter uses the arrow glyph in the spec (`⮕`). Markdown formatter
-uses plain `>` blockquotes. JSON formatter emits the full structured view
-untouched.
+Text formatter uses the arrow glyph in the spec (`⮕`). Markdown formatter uses
+plain `>` blockquotes. JSON formatter emits the full structured view untouched.
 
 ## Tests
 
 - `health.test.js`:
   - **With Summit present.** Fixture: team of 3, snapshot with scores for
-    `quality`, evidence rows for `task_completion`. Asserts the formatted
-    text output contains the driver header line, the evidence counts, and
-    the recommendation line. Asserts `meta.warnings` is empty.
+    `quality`, evidence rows for `task_completion`. Asserts the formatted text
+    output contains the driver header line, the evidence counts, and the
+    recommendation line. Asserts `meta.warnings` is empty.
   - **With Summit absent.** Uses `__setSummitForTests(null)`. Asserts the
     recommendation line is omitted and the rest of the output is identical.
-  - **Unknown item_id.** Fixture includes a score with `item_id: "sci_fi"`
-    that has no driver. Asserts warning is collected and the unknown item
-    does not render.
+  - **Unknown item_id.** Fixture includes a score with `item_id: "sci_fi"` that
+    has no driver. Asserts warning is collected and the unknown item does not
+    render.
   - **No snapshots.** Empty snapshot list → `NO_SNAPSHOTS` empty state.
-  - **Manager not found.** `--manager unknown@example.com` → 
+  - **Manager not found.** `--manager unknown@example.com` →
     `MANAGER_NOT_FOUND`.
 - `summit.test.js`:
   - `loadSummit` caches results across calls.
   - `__setSummitForTests(null)` → `computeGrowth` returns `available: false`.
-  - `__setSummitForTests(() => { throw new Error("boom"); })` →
-    `computeGrowth` returns `available: false` with `error` populated.
+  - `__setSummitForTests(() => { throw new Error("boom"); })` → `computeGrowth`
+    returns `available: false` with `error` populated.
 
 ## Verification
 
@@ -320,34 +315,32 @@ untouched.
 2. `bun test products/landmark/test` — new tests green. Part 02 tests still
    green (no regressions from Part 02 helpers reused in Part 03).
 3. `bun test products/map/test` — starter-count assertions updated; green.
-4. `bun run layout && bun run check:exports && bun run check` — layout,
-   exports, lint/format all green.
-5. Grep asserts the two `<comments section>` and `<initiatives section>`
-   anchors exist in both `src/commands/health.js` and
-   `src/formatters/health.js`, so Parts 04/05 have hook points to edit.
-5. Smoke test against `fit-map activity seed`:
+4. `bun run layout && bun run check:exports && bun run check` — layout, exports,
+   lint/format all green.
+5. Grep asserts the two `<comments section>` and `<initiatives section>` anchors
+   exist in both `src/commands/health.js` and `src/formatters/health.js`, so
+   Parts 04/05 have hook points to edit.
+6. Smoke test against `fit-map activity seed`:
    - `bunx fit-landmark health --manager manager-1@example.com` prints a
-     multi-driver health view including at least one Summit recommendation
-     line.
-   - `bunx fit-landmark health` (no manager) prints an organization-wide
-     view.
+     multi-driver health view including at least one Summit recommendation line.
+   - `bunx fit-landmark health` (no manager) prints an organization-wide view.
 
 ## Risks and open questions
 
-- **Driver ids vs GetDX item ids in real installations.** The warning
-  surface this part adds makes silent mismatches visible, but does not
-  resolve them. Document the join contract clearly in Part 06's internals
-  page so installations know to align their GetDX scorecard item ids with
+- **Driver ids vs GetDX item ids in real installations.** The warning surface
+  this part adds makes silent mismatches visible, but does not resolve them.
+  Document the join contract clearly in Part 06's internals page so
+  installations know to align their GetDX scorecard item ids with
   `drivers.yaml`.
-- **Summit's growth signature might narrow in future.** Pinned minor
-  version in `package.json` limits blast radius; CI catches breakage.
-- **`filterEvidenceByTeam` assumes team roster fits in memory.** Acceptable
-  for realistic team sizes (dozens to hundreds); document the assumption
-  inline and revisit if ever needed.
+- **Summit's growth signature might narrow in future.** Pinned minor version in
+  `package.json` limits blast radius; CI catches breakage.
+- **`filterEvidenceByTeam` assumes team roster fits in memory.** Acceptable for
+  realistic team sizes (dozens to hundreds); document the assumption inline and
+  revisit if ever needed.
 
 ## Deliverable
 
-A merged PR that ships a working `fit-landmark health` command demonstrating
-the full spec § Health view output (minus the comment section, which Part 04
+A merged PR that ships a working `fit-landmark health` command demonstrating the
+full spec § Health view output (minus the comment section, which Part 04
 completes). Starter drivers now include `reliability` and `cognitive_load`
 alongside `quality`.

--- a/specs/080-landmark-product/plan-a-03.md
+++ b/specs/080-landmark-product/plan-a-03.md
@@ -1,0 +1,266 @@
+# Plan A · Part 03 — Health view + drivers expansion
+
+Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
+[Part 02](./plan-a-02.md) being merged.
+
+This part expands the starter `drivers.yaml` to demonstrate multi-driver
+views and ships the `health` command. Health joins snapshot scores,
+contributing-skill evidence counts, and (when available) Summit growth
+recommendations rendered inline.
+
+Summit exists in the repo (spec 090 is `done`) and already exports
+`computeGrowthAlignment` from the package root, so this part consumes it as
+a hard dependency while keeping the graceful-degrade path exercised in tests
+via a controlled wrapper.
+
+## Scope
+
+**In scope**
+
+- Add two additional drivers to `products/map/starter/drivers.yaml`:
+  `reliability` and `cognitive_load` (names and contributing skills picked to
+  match skills already defined in the starter).
+- Add `@forwardimpact/summit` to Landmark's `dependencies`.
+- Implement the `health` command.
+- Wire a wrapper (`src/lib/summit.js`) that imports `computeGrowthAlignment`
+  and exposes a synchronous feature-detection boolean plus an async
+  `computeGrowth({ team, mapData, evidence, driverScores })` function that
+  tests can stub.
+- Extend the `item_id`↔driver validation introduced in Part 01 with a
+  formatter surface: warnings are rendered under the health view output.
+- Tests: health command with Summit present, health command with Summit
+  stubbed absent (graceful-degrade path).
+
+**Out of scope**
+
+- Voice command (Part 04). Health's comment section renders whatever
+  `voice` data is passed in; Part 04 adds the fetch. Part 03 leaves the
+  comment section empty with a note "comments surface once Part 04 lands" —
+  the render path is ready, the data source is not.
+- Initiative tracking in health (Part 05 extends health to include
+  initiatives once the table exists).
+- Changes to Summit.
+
+## Files
+
+### Created
+
+```
+products/landmark/src/lib/
+  summit.js
+
+products/landmark/src/commands/
+  health.js
+
+products/landmark/src/formatters/
+  health.js
+
+products/landmark/test/
+  health.test.js
+  summit.test.js
+```
+
+### Modified
+
+- `products/map/starter/drivers.yaml` — add `reliability` and
+  `cognitive_load` drivers.
+- `products/landmark/package.json` — add `"@forwardimpact/summit": "^0.1.0"`
+  to `dependencies` (the actual version pin matches whatever Summit is
+  currently publishing; use the workspace convention of the caret of the
+  current minor).
+- `products/landmark/bin/fit-landmark.js` — replace `health` stub with real
+  handler import and dispatch.
+- `products/landmark/src/formatters/index.js` — register health formatter.
+- Root `package.json` — no change (workspace entry already added in Part 01).
+
+## Implementation details
+
+### `drivers.yaml` expansion
+
+Starter authoring must not break the existing `quality` driver. Add entries
+after the current one; do not reorder. Pick contributing skills from the
+set already present in the starter (`task_completion`, `planning`, plus any
+skills added in `reliability.yaml` if Part 02 added them).
+
+Exact content to add (adjust skill ids to match whatever Part 02 authored):
+
+```yaml
+- id: reliability
+  name: Reliability
+  description: Keep systems dependable and recover quickly from disruption.
+  contributingSkills:
+    - incident_response   # or whatever skill Part 02 added markers to
+  contributingBehaviours: []
+
+- id: cognitive_load
+  name: Cognitive Load
+  description: Keep day-to-day engineering tractable by managing complexity.
+  contributingSkills:
+    - planning
+  contributingBehaviours: []
+```
+
+Validate with `bunx fit-map validate`. Confirm the new drivers load via
+`createDataLoader().loadAllData(dataDir)` in a unit test — Map's loader test
+may already assert the count; update the expected count.
+
+Note: real GetDX installations will match `driver.id` to
+`getdx_snapshot_team_scores.item_id` values. The starter drivers use short
+ids that are unlikely to collide with a real GetDX scorecard, which is
+intentional: starter drivers are demonstrative, not production.
+
+### `src/lib/summit.js`
+
+Wrapper around Summit's growth export. Exposes an injectable surface so
+tests can exercise both the "Summit installed" and "Summit missing" paths.
+
+```js
+let cached = null;
+let cacheSet = false;
+
+export async function loadSummit() {
+  if (cacheSet) return cached;
+  try {
+    const mod = await import("@forwardimpact/summit");
+    cached = mod?.computeGrowthAlignment ?? null;
+  } catch {
+    cached = null;
+  }
+  cacheSet = true;
+  return cached;
+}
+
+// Test helper — reset cache and optionally inject a stub.
+export function __setSummitForTests(fn) {
+  cached = fn;
+  cacheSet = true;
+}
+
+export async function computeGrowth(params) {
+  const fn = await loadSummit();
+  if (!fn) return { available: false, recommendations: [] };
+  try {
+    return { available: true, recommendations: fn(params) };
+  } catch (err) {
+    return {
+      available: false,
+      recommendations: [],
+      error: `Summit growth computation failed: ${err.message}`,
+    };
+  }
+}
+```
+
+Decision: `loadSummit` is cached because `import()` is async and repeated
+dispatch inside the health view would otherwise re-resolve the module. The
+test hook `__setSummitForTests` is the documented seam and is used only by
+`summit.test.js` and `health.test.js`. No production code calls it.
+
+### Command: `health`
+
+Signature: `fit-landmark health [--manager <email>]`.
+
+Steps:
+
+1. `getTeam(supabase, options.manager)` if `--manager` is set, else
+   `getOrganization(supabase)`. No results → `MANAGER_NOT_FOUND` or
+   `EMPTY_STATES.NO_ORGANIZATION` (add a new constant for the latter).
+2. `listSnapshots(supabase)` — pick the most recent (first row, spec says
+   ordered DESC). No snapshots → `NO_SNAPSHOTS`.
+3. `getSnapshotScores(supabase, latest.snapshot_id, { managerEmail })`.
+4. Load Map drivers. Join scores to drivers by `item_id === driver.id`.
+   Collect unknown-item warnings in `meta.warnings`.
+5. For each matched driver, gather contributing skills from the driver
+   definition, then fetch evidence counts per skill via `getEvidence(supabase,
+   { skillId, managerEmail? })`. The query does not natively support
+   managerEmail filtering on evidence; when `--manager` is set, filter
+   client-side by intersecting artifact emails against the team roster.
+   (Encapsulate this filter in `evidence-helpers.js#filterEvidenceByTeam`
+   added here, with its own unit test.)
+6. Build the growth-recommendation bundle: team roster (from step 1), map
+   data, evidence grouped by skillId via
+   `evidence-helpers.js#groupEvidenceBySkill`, and driverScores as a Map
+   from `driver.id` to `{ score, vs_prev, vs_org, vs_50th, vs_75th, vs_90th }`.
+   Call `computeGrowth(...)`. If `available: false`, render without
+   recommendation lines; if `available: true`, render each recommendation
+   inline under its driver section matching the spec's output (§ Health
+   view, lines 410–440).
+7. Comment section: reserved for Part 04. Render a placeholder `"(engineer
+   voice requires Part 04 — getdx_snapshot_comments table)"` when Part 04
+   has not landed. Part 04 will replace the placeholder with the real fetch.
+8. Return `{ view: { drivers: [...] }, meta: { format, warnings } }`.
+
+### Formatter
+
+`health.js` formatter renders the spec's exact shape:
+
+```
+Platform team — health view
+
+  Driver: quality (42nd percentile, vs_org: -10)
+    Contributing skills: task_completion, planning
+    Evidence: 3 artifacts for task_completion, 0 for planning
+    GetDX comments: (comments surface once Part 04 lands)
+
+    ⮕ Recommendation: Dan (Level I) or Carol (Level II) could develop planning.
+      (Summit growth alignment: high impact)
+```
+
+Text formatter uses the arrow glyph in the spec (`⮕`). Markdown formatter
+uses plain `>` blockquotes. JSON formatter emits the full structured view
+untouched.
+
+## Tests
+
+- `health.test.js`:
+  - **With Summit present.** Fixture: team of 3, snapshot with scores for
+    `quality`, evidence rows for `task_completion`. Asserts the formatted
+    text output contains the driver header line, the evidence counts, and
+    the recommendation line. Asserts `meta.warnings` is empty.
+  - **With Summit absent.** Uses `__setSummitForTests(null)`. Asserts the
+    recommendation line is omitted and the rest of the output is identical.
+  - **Unknown item_id.** Fixture includes a score with `item_id: "sci_fi"`
+    that has no driver. Asserts warning is collected and the unknown item
+    does not render.
+  - **No snapshots.** Empty snapshot list → `NO_SNAPSHOTS` empty state.
+  - **Manager not found.** `--manager unknown@example.com` → 
+    `MANAGER_NOT_FOUND`.
+- `summit.test.js`:
+  - `loadSummit` caches results across calls.
+  - `__setSummitForTests(null)` → `computeGrowth` returns `available: false`.
+  - `__setSummitForTests(() => { throw new Error("boom"); })` →
+    `computeGrowth` returns `available: false` with `error` populated.
+
+## Verification
+
+1. `bunx fit-map validate` — updated `drivers.yaml` passes.
+2. `bun test products/landmark/test` — new tests green. Part 02 tests still
+   green (no regressions from Part 02 helpers reused in Part 03).
+3. `bun test products/map/test` — starter-count assertions updated; green.
+4. `bun run check` — lint, format, layout, exports.
+5. Smoke test against `fit-map activity seed`:
+   - `bunx fit-landmark health --manager manager-1@example.com` prints a
+     multi-driver health view including at least one Summit recommendation
+     line.
+   - `bunx fit-landmark health` (no manager) prints an organization-wide
+     view.
+
+## Risks and open questions
+
+- **Driver ids vs GetDX item ids in real installations.** The warning
+  surface this part adds makes silent mismatches visible, but does not
+  resolve them. Document the join contract clearly in Part 06's internals
+  page so installations know to align their GetDX scorecard item ids with
+  `drivers.yaml`.
+- **Summit's growth signature might narrow in future.** Pinned minor
+  version in `package.json` limits blast radius; CI catches breakage.
+- **`filterEvidenceByTeam` assumes team roster fits in memory.** Acceptable
+  for realistic team sizes (dozens to hundreds); document the assumption
+  inline and revisit if ever needed.
+
+## Deliverable
+
+A merged PR that ships a working `fit-landmark health` command demonstrating
+the full spec § Health view output (minus the comment section, which Part 04
+completes). Starter drivers now include `reliability` and `cognitive_load`
+alongside `quality`.

--- a/specs/080-landmark-product/plan-a-03.md
+++ b/specs/080-landmark-product/plan-a-03.md
@@ -90,15 +90,36 @@ Exact content to add (adjust skill ids to match whatever Part 02 authored):
   description: Keep systems dependable and recover quickly from disruption.
   contributingSkills:
     - incident_response   # or whatever skill Part 02 added markers to
-  contributingBehaviours: []
+  contributingBehaviours:
+    - systems_thinking
 
 - id: cognitive_load
   name: Cognitive Load
   description: Keep day-to-day engineering tractable by managing complexity.
   contributingSkills:
     - planning
-  contributingBehaviours: []
+  contributingBehaviours:
+    - systems_thinking
 ```
+
+**Behaviours in health view — scope decision.** The existing `quality`
+driver already declares `contributingBehaviours: [systems_thinking]`. The
+spec's § Health view output example shows only contributing **skills** and
+their evidence counts, not behaviours. Behaviour evidence does not flow
+through the evidence pipeline the same way (behaviours are maturity
+profiles, not artifact-interpreted markers).
+
+**Decision:** Part 03 preserves the `contributingBehaviours` field on all
+three drivers (consistency with `quality`), but the `health` command
+**does not render behaviours**. This matches the spec's mock-up exactly.
+Behaviour rendering is explicitly **out of scope** for spec 080 and should
+be tracked as a follow-up if a user asks for it. The spec's § Out of scope
+does not list this, so note it in Part 06's internals documentation.
+
+Rationale for preserving the field: dropping `contributingBehaviours` from
+the new drivers would create schema-level asymmetry with `quality` and
+suggest behaviours are irrelevant to those drivers, which is not the
+claim — Landmark just doesn't render them in this version.
 
 Validate with `bunx fit-map validate`. Confirm the new drivers load via
 `createDataLoader().loadAllData(dataDir)` in a unit test — Map's loader test
@@ -111,50 +132,85 @@ intentional: starter drivers are demonstrative, not production.
 
 ### `src/lib/summit.js`
 
-Wrapper around Summit's growth export. Exposes an injectable surface so
-tests can exercise both the "Summit installed" and "Summit missing" paths.
+Wrapper around Summit's growth export. Summit's `computeGrowthAlignment` is
+**synchronous** (`export function computeGrowthAlignment(...)` in
+`products/summit/src/aggregation/growth.js`). The wrapper exists purely for
+**optionality** (dynamic `import()` so Landmark degrades gracefully if
+Summit is absent from node_modules) and for **test injection**. It is not
+an async-bridging shim.
+
+Summit also exports `GrowthContractError` — raised when the caller's framework
+data violates Summit's contract (e.g., a skill without a valid proficiency
+at the target level). This is a **data problem**, not a "Summit unavailable"
+problem, and must surface differently: as a warning on the health view, not
+as silent degradation.
 
 ```js
-let cached = null;
+let cachedFn = null;
+let cachedErrorClass = null;
 let cacheSet = false;
 
 export async function loadSummit() {
-  if (cacheSet) return cached;
+  if (cacheSet) return { fn: cachedFn, GrowthContractError: cachedErrorClass };
   try {
     const mod = await import("@forwardimpact/summit");
-    cached = mod?.computeGrowthAlignment ?? null;
+    cachedFn = mod?.computeGrowthAlignment ?? null;
+    cachedErrorClass = mod?.GrowthContractError ?? null;
   } catch {
-    cached = null;
+    cachedFn = null;
+    cachedErrorClass = null;
   }
   cacheSet = true;
-  return cached;
+  return { fn: cachedFn, GrowthContractError: cachedErrorClass };
 }
 
 // Test helper — reset cache and optionally inject a stub.
-export function __setSummitForTests(fn) {
-  cached = fn;
+export function __setSummitForTests({ fn, GrowthContractError } = {}) {
+  cachedFn = fn ?? null;
+  cachedErrorClass = GrowthContractError ?? null;
   cacheSet = true;
 }
 
 export async function computeGrowth(params) {
-  const fn = await loadSummit();
-  if (!fn) return { available: false, recommendations: [] };
+  const { fn, GrowthContractError } = await loadSummit();
+  if (!fn) {
+    // Summit module is absent — graceful degrade, no warning.
+    return { available: false, recommendations: [], warnings: [] };
+  }
   try {
-    return { available: true, recommendations: fn(params) };
+    // fn is synchronous; no await needed, but await tolerates non-promises.
+    const recommendations = fn(params);
+    return { available: true, recommendations, warnings: [] };
   } catch (err) {
+    // Distinguish contract violations from unexpected failures.
+    if (GrowthContractError && err instanceof GrowthContractError) {
+      return {
+        available: true,
+        recommendations: [],
+        warnings: [
+          `Summit growth alignment skipped: ${err.message} (code: ${err.code ?? "unknown"})`,
+        ],
+      };
+    }
+    // Unknown failure — surface as warning, do not crash the health view.
     return {
-      available: false,
+      available: true,
       recommendations: [],
-      error: `Summit growth computation failed: ${err.message}`,
+      warnings: [`Summit growth computation failed: ${err.message}`],
     };
   }
 }
 ```
 
-Decision: `loadSummit` is cached because `import()` is async and repeated
-dispatch inside the health view would otherwise re-resolve the module. The
-test hook `__setSummitForTests` is the documented seam and is used only by
-`summit.test.js` and `health.test.js`. No production code calls it.
+Decisions:
+
+- `loadSummit` is cached because `import()` is async and repeated dispatch
+  inside the health view would otherwise re-resolve the module.
+- The test hook `__setSummitForTests` is the documented seam and is used
+  only by `summit.test.js` and `health.test.js`. No production code calls
+  it.
+- `GrowthContractError` becomes a **warning** on the health view rather
+  than a silent skip, so framework authoring bugs are visible to the user.
 
 ### Command: `health`
 
@@ -185,10 +241,37 @@ Steps:
    recommendation lines; if `available: true`, render each recommendation
    inline under its driver section matching the spec's output (§ Health
    view, lines 410–440).
-7. Comment section: reserved for Part 04. Render a placeholder `"(engineer
-   voice requires Part 04 — getdx_snapshot_comments table)"` when Part 04
-   has not landed. Part 04 will replace the placeholder with the real fetch.
-8. Return `{ view: { drivers: [...] }, meta: { format, warnings } }`.
+7. Comment section: reserved for Part 04. The handler reserves a
+   `comments: []` field inside each driver view entry and the formatter
+   renders `(engineer voice requires Part 04 — getdx_snapshot_comments
+   table)` when the array is empty. Part 04 populates the field; the
+   formatter handles both paths.
+8. Initiatives section: reserved for Part 05. Each driver view entry
+   reserves an `initiatives: []` field; the formatter renders
+   `(no active initiatives)` when empty. Part 05 populates the field.
+9. Return `{ view: { drivers: [...] }, meta: { format, warnings } }`.
+
+**Anchor-comment contract for Parts 04 and 05.** Part 03 **must** place
+two explicit anchor comments inside `src/commands/health.js` at the
+fetch-assembly stage:
+
+```js
+// <comments section> — Part 04 adds getSnapshotComments fetch here
+// <initiatives section> — Part 05 adds listInitiatives fetch here
+```
+
+and two corresponding anchors inside `src/formatters/health.js` at the
+per-driver render stage:
+
+```js
+// <comments section> — Part 04 renders per-driver comments here
+// <initiatives section> — Part 05 renders per-driver initiatives here
+```
+
+Parts 04 and 05 edit only the code between their own anchors. This
+contract makes the parallel execution window risk-free: a merge conflict
+between Parts 04 and 05 indicates a contract violation, not a merge
+problem to resolve.
 
 ### Formatter
 
@@ -237,7 +320,11 @@ untouched.
 2. `bun test products/landmark/test` — new tests green. Part 02 tests still
    green (no regressions from Part 02 helpers reused in Part 03).
 3. `bun test products/map/test` — starter-count assertions updated; green.
-4. `bun run check` — lint, format, layout, exports.
+4. `bun run layout && bun run check:exports && bun run check` — layout,
+   exports, lint/format all green.
+5. Grep asserts the two `<comments section>` and `<initiatives section>`
+   anchors exist in both `src/commands/health.js` and
+   `src/formatters/health.js`, so Parts 04/05 have hook points to edit.
 5. Smoke test against `fit-map activity seed`:
    - `bunx fit-landmark health --manager manager-1@example.com` prints a
      multi-driver health view including at least one Summit recommendation

--- a/specs/080-landmark-product/plan-a-04.md
+++ b/specs/080-landmark-product/plan-a-04.md
@@ -1,16 +1,15 @@
 # Plan A · Part 04 — Snapshot comments pipeline + voice command
 
 Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
-[Part 03](./plan-a-03.md) being merged (health.js + formatters/health.js
-must exist with the `<comments section>` anchor pre-placed).
+[Part 03](./plan-a-03.md) being merged (health.js + formatters/health.js must
+exist with the `<comments section>` anchor pre-placed).
 
-This part adds the `activity.getdx_snapshot_comments` table, extends Map's
-GetDX extract/transform pipeline to populate it, exports a new query module
-from Map, and ships the `fit-landmark voice` command. It also extends Part
-03's `health` command with comment fetching, editing **only** the code
-between the `// <comments section>` anchors pre-placed in Part 03. Part 05
-runs in parallel with this part and edits the disjoint
-`// <initiatives section>` anchors.
+This part adds the `activity.getdx_snapshot_comments` table, extends Map's GetDX
+extract/transform pipeline to populate it, exports a new query module from Map,
+and ships the `fit-landmark voice` command. It also extends Part 03's `health`
+command with comment fetching, editing **only** the code between the
+`// <comments section>` anchors pre-placed in Part 03. Part 05 runs in parallel
+with this part and edits the disjoint `// <initiatives section>` anchors.
 
 Touches **both** Map and Landmark — this is intentional: the feature is only
 verifiable end-to-end when migration + extract + transform + query + CLI all
@@ -22,29 +21,27 @@ land together.
 
 - New migration creating `activity.getdx_snapshot_comments` with the columns
   spec § Data Contracts enumerates.
-- Extend
-  `products/map/supabase/functions/_shared/activity/extract/getdx.js` to
-  call `snapshots.comments.list` for each snapshot in the current extract
-  loop.
-- Extend `.../transform/getdx.js` with `transformSnapshotComments` and wire
-  it into `transformAllGetDX`.
-- New query module `products/map/src/activity/queries/comments.js`
-  exporting `getSnapshotComments`, with matching subpath entry in
+- Extend `products/map/supabase/functions/_shared/activity/extract/getdx.js` to
+  call `snapshots.comments.list` for each snapshot in the current extract loop.
+- Extend `.../transform/getdx.js` with `transformSnapshotComments` and wire it
+  into `transformAllGetDX`.
+- New query module `products/map/src/activity/queries/comments.js` exporting
+  `getSnapshotComments`, with matching subpath entry in
   `products/map/package.json`.
 - Landmark: `voice` command with `--manager` and `--email` modes.
 - Landmark: update `src/commands/health.js` to fetch comments for each
   driver-aligned contributor and render them inline, replacing Part 03's
   placeholder.
-- Tests for the new extract path, transform, query, Landmark voice command,
-  and the updated health command.
+- Tests for the new extract path, transform, query, Landmark voice command, and
+  the updated health command.
 
 **Out of scope**
 
 - Initiatives pipeline (Part 05).
-- Theme analysis beyond a simple frequency bucket — the spec mock-ups show
-  theme counts, which this part implements by grouping on
-  case-insensitive keyword matches of a short stop-listed noun-phrase set.
-  Anything more sophisticated is deferred.
+- Theme analysis beyond a simple frequency bucket — the spec mock-ups show theme
+  counts, which this part implements by grouping on case-insensitive keyword
+  matches of a short stop-listed noun-phrase set. Anything more sophisticated is
+  deferred.
 
 ## Files
 
@@ -74,34 +71,34 @@ products/landmark/test/
 ### Modified
 
 - `products/map/supabase/functions/_shared/activity/extract/getdx.js` — add
-  `extractSnapshotComments` helper and invoke it once per snapshot inside
-  the existing loop.
-- `products/map/supabase/functions/_shared/activity/transform/getdx.js` —
-  add `transformSnapshotComments` and call it from `transformAllGetDX`;
-  update the return shape to include `comments: number`.
+  `extractSnapshotComments` helper and invoke it once per snapshot inside the
+  existing loop.
+- `products/map/supabase/functions/_shared/activity/transform/getdx.js` — add
+  `transformSnapshotComments` and call it from `transformAllGetDX`; update the
+  return shape to include `comments: number`.
 - `products/map/package.json` — add
   `"./activity/queries/comments": "./src/activity/queries/comments.js"` to
   `exports`.
-- `products/map/test/activity/transform-getdx.test.js` — extend to cover
-  the new counts field or leave untouched if existing assertions don't
-  pin the shape; add new test file for the comments path.
+- `products/map/test/activity/transform-getdx.test.js` — extend to cover the new
+  counts field or leave untouched if existing assertions don't pin the shape;
+  add new test file for the comments path.
 - `products/landmark/bin/fit-landmark.js` — wire `runVoiceCommand` into
   `COMMANDS`.
-- `products/landmark/src/commands/health.js` — replace the
-  "comments surface once Part 04 lands" placeholder with the real fetch.
-- `products/landmark/src/formatters/health.js` — render the fetched
-  comments per driver.
-- `products/landmark/test/health.test.js` — add an assertion that
-  comments render when present.
+- `products/landmark/src/commands/health.js` — replace the "comments surface
+  once Part 04 lands" placeholder with the real fetch.
+- `products/landmark/src/formatters/health.js` — render the fetched comments per
+  driver.
+- `products/landmark/test/health.test.js` — add an assertion that comments
+  render when present.
 
 ## Implementation details
 
 ### Migration
 
-Name: `<next-sequence>_getdx_snapshot_comments.sql`. Look at existing
-files under `products/map/supabase/migrations/` for the numbering
-convention (the current activity schema is `20250101000000_activity_schema.sql`
-— follow whatever date prefix pattern newer migrations use).
+Name: `<next-sequence>_getdx_snapshot_comments.sql`. Look at existing files
+under `products/map/supabase/migrations/` for the numbering convention (the
+current activity schema is `20250101000000_activity_schema.sql` — follow
+whatever date prefix pattern newer migrations use).
 
 Schema:
 
@@ -127,22 +124,22 @@ create index if not exists idx_getdx_snapshot_comments_team
 
 Decisions:
 
-- `comment_id` uses whatever stable id GetDX returns per comment; if GetDX
-  does not provide a stable id, fall back to `${snapshot_id}::${email}::${timestamp}`
+- `comment_id` uses whatever stable id GetDX returns per comment; if GetDX does
+  not provide a stable id, fall back to `${snapshot_id}::${email}::${timestamp}`
   concatenation computed at transform time. Extract stores the raw response
   verbatim; transform handles id synthesis.
-- `email` is nullable because anonymous responses are possible; the
-  Landmark `--email` filter ignores null rows.
-- `team_id` is derived at transform time by looking up the respondent's
-  current team in `getdx_teams` (via manager-email join).
+- `email` is nullable because anonymous responses are possible; the Landmark
+  `--email` filter ignores null rows.
+- `team_id` is derived at transform time by looking up the respondent's current
+  team in `getdx_teams` (via manager-email join).
 - `inserted_at` mirrors existing activity tables' idempotency column.
 
 ### Extract extension
 
 Inside the existing loop that iterates `snapshots.list`, after fetching
-`snapshots.info`, call `/snapshots.comments.list?snapshot_id=<id>` and
-store the response to `getdx/snapshots-comments/<snapshot_id>.json`. Handle
-rate limiting with the existing retry helper if present.
+`snapshots.info`, call `/snapshots.comments.list?snapshot_id=<id>` and store the
+response to `getdx/snapshots-comments/<snapshot_id>.json`. Handle rate limiting
+with the existing retry helper if present.
 
 ```js
 async function extractSnapshotComments(supabase, config, snapshotId) {
@@ -159,9 +156,9 @@ async function extractSnapshotComments(supabase, config, snapshotId) {
 }
 ```
 
-(Use the existing `storeDocument` helper Map already uses for raw
-responses.) Accumulate errors into the extract's `errors` array; do not
-fail the whole extract on a single comment fetch.
+(Use the existing `storeDocument` helper Map already uses for raw responses.)
+Accumulate errors into the extract's `errors` array; do not fail the whole
+extract on a single comment fetch.
 
 ### Transform
 
@@ -173,11 +170,11 @@ Add `transformSnapshotComments(supabase)` to `.../transform/getdx.js`:
    - `comment_id` from the raw payload if present, else
      `${snapshotId}::${email ?? "anon"}::${timestamp}`.
    - `email`, `text`, `timestamp` from the payload.
-   - `team_id` by looking up `organization_people(email)` → manager_email,
-     then `getdx_teams` where `manager_email` matches. If no match, leave
-     `team_id` null.
-4. Upsert into `activity.getdx_snapshot_comments` with `on conflict
-   (comment_id) do update`.
+   - `team_id` by looking up `organization_people(email)` → manager_email, then
+     `getdx_teams` where `manager_email` matches. If no match, leave `team_id`
+     null.
+4. Upsert into `activity.getdx_snapshot_comments` with
+   `on conflict (comment_id) do update`.
 5. Return `{ comments: <count>, errors: [...] }`.
 
 Wire into `transformAllGetDX`:
@@ -226,9 +223,9 @@ export async function getSnapshotComments(supabase, options = {}) {
 }
 ```
 
-Decision: the manager-to-team resolution happens inside the query for
-ergonomic reasons (one helper, one semantic). If profiling later shows this
-is hot, the resolution can move into a cached lookup.
+Decision: the manager-to-team resolution happens inside the query for ergonomic
+reasons (one helper, one semantic). If profiling later shows this is hot, the
+resolution can move into a cached lookup.
 
 Add the exports entry:
 
@@ -258,43 +255,42 @@ export async function runVoiceCommand({ options, supabase, mapData, format }) {
 ```
 
 `runEmailVoice` fetches `getSnapshotComments(supabase, { email })`, sorts by
-snapshot `scheduled_for` DESC, limits to the last 4 snapshots. Pulls
-evidence counts via `getEvidence(supabase, { email })` and joins them into
-a "Context from evidence" section matching spec § Engineer voice.
+snapshot `scheduled_for` DESC, limits to the last 4 snapshots. Pulls evidence
+counts via `getEvidence(supabase, { email })` and joins them into a "Context
+from evidence" section matching spec § Engineer voice.
 
 `runManagerVoice` fetches comments for the manager's team via
-`{ managerEmail }`. Groups by a lightweight theme bucket (simple
-substring-match against a small curated list: `estimation`, `incident`,
-`planning`, `handoff`, `onboarding`, `deploy`, `runbook`). Returns top N
-themes with comment counts and representative snippets. Also fetches driver
-scores from the latest snapshot and surfaces the "aligned with health
-signals" footer when a theme aligns with a poorly-scoring driver.
+`{ managerEmail }`. Groups by a lightweight theme bucket (simple substring-match
+against a small curated list: `estimation`, `incident`, `planning`, `handoff`,
+`onboarding`, `deploy`, `runbook`). Returns top N themes with comment counts and
+representative snippets. Also fetches driver scores from the latest snapshot and
+surfaces the "aligned with health signals" footer when a theme aligns with a
+poorly-scoring driver.
 
-Theme bucketing is intentionally crude. Anything smarter is an LLM call,
-which spec § Out of Scope forbids.
+Theme bucketing is intentionally crude. Anything smarter is an LLM call, which
+spec § Out of Scope forbids.
 
-Empty paths use **one** constant, `NO_COMMENTS`, which Part 01 already
-placed in `src/lib/empty-state.js`. The voice command differentiates the
-two empty cases by appending a context hint to the message:
+Empty paths use **one** constant, `NO_COMMENTS`, which Part 01 already placed in
+`src/lib/empty-state.js`. The voice command differentiates the two empty cases
+by appending a context hint to the message:
 
-- Comments table missing (catch `42P01` error) → return `NO_COMMENTS` with
-  no hint. Message: "Snapshot comments not available. The
-  getdx_snapshot_comments table has not been created."
-- Table exists but no comments match the filter → return `NO_COMMENTS` with
-  a `hint` field in the meta: `"No comments in scope — try broadening the
-  --manager or --email filter."`. Formatters append the hint on a second
-  line.
+- Comments table missing (catch `42P01` error) → return `NO_COMMENTS` with no
+  hint. Message: "Snapshot comments not available. The getdx_snapshot_comments
+  table has not been created."
+- Table exists but no comments match the filter → return `NO_COMMENTS` with a
+  `hint` field in the meta:
+  `"No comments in scope — try broadening the --manager or --email filter."`.
+  Formatters append the hint on a second line.
 
-Do **not** add a `NO_COMMENTS_FOR_SCOPE` constant. The spec's empty-state
-table (§ Empty States) has exactly one `NO_COMMENTS` row, and introducing a
-second constant would diverge from the spec contract.
+Do **not** add a `NO_COMMENTS_FOR_SCOPE` constant. The spec's empty-state table
+(§ Empty States) has exactly one `NO_COMMENTS` row, and introducing a second
+constant would diverge from the spec contract.
 
 ### Health view integration
 
 Edit **only** between the `// <comments section>` anchors Part 03 placed in
-`src/commands/health.js` and `src/formatters/health.js`. Do not touch any
-other region of these files; Part 05 owns the `<initiatives section>`
-region.
+`src/commands/health.js` and `src/formatters/health.js`. Do not touch any other
+region of these files; Part 05 owns the `<initiatives section>` region.
 
 Replace the placeholder between the anchors in `src/commands/health.js`:
 
@@ -316,69 +312,66 @@ try {
 }
 ```
 
-Attach `comments` to each driver in the view by the same theme-bucket
-match used by voice (so "estimation" comments appear under `quality`).
-Formatter renders up to 2 comment snippets per driver.
+Attach `comments` to each driver in the view by the same theme-bucket match used
+by voice (so "estimation" comments appear under `quality`). Formatter renders up
+to 2 comment snippets per driver.
 
-Add `isRelationNotFoundError(err)` to `src/lib/supabase.js` — matches
-Postgres error code `42P01` from the underlying client.
+Add `isRelationNotFoundError(err)` to `src/lib/supabase.js` — matches Postgres
+error code `42P01` from the underlying client.
 
 ## Tests
 
-- `products/map/test/activity/transform-getdx-comments.test.js` — feeds
-  mocked `getdx/snapshots-comments/<id>.json` documents into
-  `transformSnapshotComments` and asserts the upsert payload. Covers
-  id-fallback path, null-email path, team lookup via manager join.
-- `products/map/test/activity/query-comments.test.js` — stubs Supabase
-  query builder, verifies filter chaining for each option.
+- `products/map/test/activity/transform-getdx-comments.test.js` — feeds mocked
+  `getdx/snapshots-comments/<id>.json` documents into
+  `transformSnapshotComments` and asserts the upsert payload. Covers id-fallback
+  path, null-email path, team lookup via manager join.
+- `products/map/test/activity/query-comments.test.js` — stubs Supabase query
+  builder, verifies filter chaining for each option.
 - `products/landmark/test/voice.test.js`:
   - `--email` path with comments across 4 snapshots.
   - `--manager` path with themed comments.
   - `--email` with no comments → `NO_COMMENTS` with scope hint appended.
-  - `--manager` with table missing → `NO_COMMENTS` without hint (simulate
-    via stub throwing a 42P01 error).
+  - `--manager` with table missing → `NO_COMMENTS` without hint (simulate via
+    stub throwing a 42P01 error).
   - Missing both flags → `UsageError`.
 - `products/landmark/test/health.test.js` — extend with an assertion that
-  comments render under driver sections when the stub returns them, and
-  that the missing-table path records a warning without failing the
-  command.
+  comments render under driver sections when the stub returns them, and that the
+  missing-table path records a warning without failing the command.
 
 ## Verification
 
 1. `just migrate` (or the repo's local migration runner) against a fresh
    Supabase — migration applies cleanly.
-2. `fit-map getdx sync` against a real (or stubbed) GetDX endpoint — new
-   extract path stores `snapshots-comments` documents.
-3. `fit-map activity transform` — new transform step populates the table
-   and the count appears in the CLI's output.
+2. `fit-map getdx sync` against a real (or stubbed) GetDX endpoint — new extract
+   path stores `snapshots-comments` documents.
+3. `fit-map activity transform` — new transform step populates the table and the
+   count appears in the CLI's output.
 4. `bun test products/map/test/activity` — new and existing tests green.
-5. `bun test products/landmark/test` — new and existing tests green,
-   including the updated `health.test.js`.
-6. `bun run layout && bun run check:exports && bun run check` — layout,
-   exports (confirms the new `./activity/queries/comments` subpath is
-   wired), and full lint/format all green.
-7. Smoke test: `bunx fit-landmark voice --manager alice@example.com`
-   returns themed comments; `bunx fit-landmark voice --email
-   dan@example.com` returns the per-snapshot timeline with the evidence
-   context footer.
+5. `bun test products/landmark/test` — new and existing tests green, including
+   the updated `health.test.js`.
+6. `bun run layout && bun run check:exports && bun run check` — layout, exports
+   (confirms the new `./activity/queries/comments` subpath is wired), and full
+   lint/format all green.
+7. Smoke test: `bunx fit-landmark voice --manager alice@example.com` returns
+   themed comments; `bunx fit-landmark voice --email dan@example.com` returns
+   the per-snapshot timeline with the evidence context footer.
 
 ## Risks
 
-- **GetDX comments API shape is not fully documented here.** The extract
-  stores whatever the endpoint returns; the transform is the only layer
-  that parses the shape. If the real shape diverges from what this part
-  assumes, adjust only the transform — the rest of the pipeline stays put.
-- **`isRelationNotFoundError` error-code matching is client-version
-  dependent.** The helper is a single place to patch if `@supabase/supabase-js`
-  changes its error shape.
-- **Theme bucketing is fragile.** This is deliberate — a richer
-  classifier would require LLM calls which the spec forbids. Keep the theme
-  keyword list small and obvious; users can read the full list via
-  `fit-landmark voice --email` if the manager view's grouping is
-  unsatisfactory.
+- **GetDX comments API shape is not fully documented here.** The extract stores
+  whatever the endpoint returns; the transform is the only layer that parses the
+  shape. If the real shape diverges from what this part assumes, adjust only the
+  transform — the rest of the pipeline stays put.
+- **`isRelationNotFoundError` error-code matching is client-version dependent.**
+  The helper is a single place to patch if `@supabase/supabase-js` changes its
+  error shape.
+- **Theme bucketing is fragile.** This is deliberate — a richer classifier would
+  require LLM calls which the spec forbids. Keep the theme keyword list small
+  and obvious; users can read the full list via `fit-landmark voice --email` if
+  the manager view's grouping is unsatisfactory.
 
 ## Deliverable
 
-A merged PR that ships `fit-landmark voice` and completes the `health`
-command's engineer-voice section. The `getdx_snapshot_comments` table exists
-end-to-end: extract, transform, query, CLI.
+A merged PR that ships `fit-landmark voice` and completes the `health` command's
+engineer-voice section. The `getdx_snapshot_comments` table exists end-to-end:
+extract, transform, query, CLI.

--- a/specs/080-landmark-product/plan-a-04.md
+++ b/specs/080-landmark-product/plan-a-04.md
@@ -1,12 +1,16 @@
 # Plan A · Part 04 — Snapshot comments pipeline + voice command
 
 Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
-[Part 01](./plan-a-01.md). Independent of Parts 02, 03, 05.
+[Part 03](./plan-a-03.md) being merged (health.js + formatters/health.js
+must exist with the `<comments section>` anchor pre-placed).
 
 This part adds the `activity.getdx_snapshot_comments` table, extends Map's
 GetDX extract/transform pipeline to populate it, exports a new query module
-from Map, and ships the `fit-landmark voice` command. It also replaces the
-Part 03 placeholder inside the `health` command with a real comment fetch.
+from Map, and ships the `fit-landmark voice` command. It also extends Part
+03's `health` command with comment fetching, editing **only** the code
+between the `// <comments section>` anchors pre-placed in Part 03. Part 05
+runs in parallel with this part and edits the disjoint
+`// <initiatives section>` anchors.
 
 Touches **both** Map and Landmark — this is intentional: the feature is only
 verifiable end-to-end when migration + extract + transform + query + CLI all
@@ -269,19 +273,30 @@ signals" footer when a theme aligns with a poorly-scoring driver.
 Theme bucketing is intentionally crude. Anything smarter is an LLM call,
 which spec § Out of Scope forbids.
 
-Empty paths:
+Empty paths use **one** constant, `NO_COMMENTS`, which Part 01 already
+placed in `src/lib/empty-state.js`. The voice command differentiates the
+two empty cases by appending a context hint to the message:
 
-- Comments table does not exist yet (query throws a "relation not found"
-  error) → catch and return `NO_COMMENTS` empty state. This handles the
-  case where the migration has not been applied locally.
-- No comments matching filter → `NO_COMMENTS` empty state with a specific
-  message: "No snapshot comments found for scope."
+- Comments table missing (catch `42P01` error) → return `NO_COMMENTS` with
+  no hint. Message: "Snapshot comments not available. The
+  getdx_snapshot_comments table has not been created."
+- Table exists but no comments match the filter → return `NO_COMMENTS` with
+  a `hint` field in the meta: `"No comments in scope — try broadening the
+  --manager or --email filter."`. Formatters append the hint on a second
+  line.
 
-Add `NO_COMMENTS_FOR_SCOPE` to `src/lib/empty-state.js`.
+Do **not** add a `NO_COMMENTS_FOR_SCOPE` constant. The spec's empty-state
+table (§ Empty States) has exactly one `NO_COMMENTS` row, and introducing a
+second constant would diverge from the spec contract.
 
 ### Health view integration
 
-Replace the Part 03 placeholder in `src/commands/health.js`:
+Edit **only** between the `// <comments section>` anchors Part 03 placed in
+`src/commands/health.js` and `src/formatters/health.js`. Do not touch any
+other region of these files; Part 05 owns the `<initiatives section>`
+region.
+
+Replace the placeholder between the anchors in `src/commands/health.js`:
 
 ```js
 // Fetch comments once per health render; filter per driver downstream.
@@ -319,9 +334,9 @@ Postgres error code `42P01` from the underlying client.
 - `products/landmark/test/voice.test.js`:
   - `--email` path with comments across 4 snapshots.
   - `--manager` path with themed comments.
-  - `--email` with no comments → `NO_COMMENTS_FOR_SCOPE`.
-  - `--manager` with table missing → `NO_COMMENTS` (simulate via stub
-    throwing a 42P01 error).
+  - `--email` with no comments → `NO_COMMENTS` with scope hint appended.
+  - `--manager` with table missing → `NO_COMMENTS` without hint (simulate
+    via stub throwing a 42P01 error).
   - Missing both flags → `UsageError`.
 - `products/landmark/test/health.test.js` — extend with an assertion that
   comments render under driver sections when the stub returns them, and
@@ -339,8 +354,9 @@ Postgres error code `42P01` from the underlying client.
 4. `bun test products/map/test/activity` — new and existing tests green.
 5. `bun test products/landmark/test` — new and existing tests green,
    including the updated `health.test.js`.
-6. `bun run check` — lint, format, layout, exports (confirms the new
-   subpath export is wired).
+6. `bun run layout && bun run check:exports && bun run check` — layout,
+   exports (confirms the new `./activity/queries/comments` subpath is
+   wired), and full lint/format all green.
 7. Smoke test: `bunx fit-landmark voice --manager alice@example.com`
    returns themed comments; `bunx fit-landmark voice --email
    dan@example.com` returns the per-snapshot timeline with the evidence

--- a/specs/080-landmark-product/plan-a-04.md
+++ b/specs/080-landmark-product/plan-a-04.md
@@ -1,0 +1,368 @@
+# Plan A · Part 04 — Snapshot comments pipeline + voice command
+
+Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
+[Part 01](./plan-a-01.md). Independent of Parts 02, 03, 05.
+
+This part adds the `activity.getdx_snapshot_comments` table, extends Map's
+GetDX extract/transform pipeline to populate it, exports a new query module
+from Map, and ships the `fit-landmark voice` command. It also replaces the
+Part 03 placeholder inside the `health` command with a real comment fetch.
+
+Touches **both** Map and Landmark — this is intentional: the feature is only
+verifiable end-to-end when migration + extract + transform + query + CLI all
+land together.
+
+## Scope
+
+**In scope**
+
+- New migration creating `activity.getdx_snapshot_comments` with the columns
+  spec § Data Contracts enumerates.
+- Extend
+  `products/map/supabase/functions/_shared/activity/extract/getdx.js` to
+  call `snapshots.comments.list` for each snapshot in the current extract
+  loop.
+- Extend `.../transform/getdx.js` with `transformSnapshotComments` and wire
+  it into `transformAllGetDX`.
+- New query module `products/map/src/activity/queries/comments.js`
+  exporting `getSnapshotComments`, with matching subpath entry in
+  `products/map/package.json`.
+- Landmark: `voice` command with `--manager` and `--email` modes.
+- Landmark: update `src/commands/health.js` to fetch comments for each
+  driver-aligned contributor and render them inline, replacing Part 03's
+  placeholder.
+- Tests for the new extract path, transform, query, Landmark voice command,
+  and the updated health command.
+
+**Out of scope**
+
+- Initiatives pipeline (Part 05).
+- Theme analysis beyond a simple frequency bucket — the spec mock-ups show
+  theme counts, which this part implements by grouping on
+  case-insensitive keyword matches of a short stop-listed noun-phrase set.
+  Anything more sophisticated is deferred.
+
+## Files
+
+### Created
+
+```
+products/map/supabase/migrations/
+  <next-sequence>_getdx_snapshot_comments.sql
+
+products/map/src/activity/queries/
+  comments.js
+
+products/map/test/activity/
+  transform-getdx-comments.test.js
+  query-comments.test.js
+
+products/landmark/src/commands/
+  voice.js
+
+products/landmark/src/formatters/
+  voice.js
+
+products/landmark/test/
+  voice.test.js
+```
+
+### Modified
+
+- `products/map/supabase/functions/_shared/activity/extract/getdx.js` — add
+  `extractSnapshotComments` helper and invoke it once per snapshot inside
+  the existing loop.
+- `products/map/supabase/functions/_shared/activity/transform/getdx.js` —
+  add `transformSnapshotComments` and call it from `transformAllGetDX`;
+  update the return shape to include `comments: number`.
+- `products/map/package.json` — add
+  `"./activity/queries/comments": "./src/activity/queries/comments.js"` to
+  `exports`.
+- `products/map/test/activity/transform-getdx.test.js` — extend to cover
+  the new counts field or leave untouched if existing assertions don't
+  pin the shape; add new test file for the comments path.
+- `products/landmark/bin/fit-landmark.js` — wire `runVoiceCommand` into
+  `COMMANDS`.
+- `products/landmark/src/commands/health.js` — replace the
+  "comments surface once Part 04 lands" placeholder with the real fetch.
+- `products/landmark/src/formatters/health.js` — render the fetched
+  comments per driver.
+- `products/landmark/test/health.test.js` — add an assertion that
+  comments render when present.
+
+## Implementation details
+
+### Migration
+
+Name: `<next-sequence>_getdx_snapshot_comments.sql`. Look at existing
+files under `products/map/supabase/migrations/` for the numbering
+convention (the current activity schema is `20250101000000_activity_schema.sql`
+— follow whatever date prefix pattern newer migrations use).
+
+Schema:
+
+```sql
+create table if not exists activity.getdx_snapshot_comments (
+  comment_id text primary key,
+  snapshot_id text not null references activity.getdx_snapshots(snapshot_id) on delete cascade,
+  email text references activity.organization_people(email) on delete set null,
+  team_id text references activity.getdx_teams(getdx_team_id) on delete set null,
+  text text not null,
+  timestamp timestamptz not null,
+  raw jsonb,
+  inserted_at timestamptz not null default now()
+);
+
+create index if not exists idx_getdx_snapshot_comments_snapshot
+  on activity.getdx_snapshot_comments(snapshot_id);
+create index if not exists idx_getdx_snapshot_comments_email
+  on activity.getdx_snapshot_comments(email);
+create index if not exists idx_getdx_snapshot_comments_team
+  on activity.getdx_snapshot_comments(team_id);
+```
+
+Decisions:
+
+- `comment_id` uses whatever stable id GetDX returns per comment; if GetDX
+  does not provide a stable id, fall back to `${snapshot_id}::${email}::${timestamp}`
+  concatenation computed at transform time. Extract stores the raw response
+  verbatim; transform handles id synthesis.
+- `email` is nullable because anonymous responses are possible; the
+  Landmark `--email` filter ignores null rows.
+- `team_id` is derived at transform time by looking up the respondent's
+  current team in `getdx_teams` (via manager-email join).
+- `inserted_at` mirrors existing activity tables' idempotency column.
+
+### Extract extension
+
+Inside the existing loop that iterates `snapshots.list`, after fetching
+`snapshots.info`, call `/snapshots.comments.list?snapshot_id=<id>` and
+store the response to `getdx/snapshots-comments/<snapshot_id>.json`. Handle
+rate limiting with the existing retry helper if present.
+
+```js
+async function extractSnapshotComments(supabase, config, snapshotId) {
+  const url = `${config.baseUrl}/snapshots.comments.list?snapshot_id=${encodeURIComponent(snapshotId)}`;
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${config.apiToken}` },
+  });
+  if (!response.ok) {
+    return { error: `snapshots.comments.list ${snapshotId} → HTTP ${response.status}` };
+  }
+  const payload = await response.json();
+  await storeDocument(supabase, `getdx/snapshots-comments/${snapshotId}.json`, payload);
+  return { ok: true };
+}
+```
+
+(Use the existing `storeDocument` helper Map already uses for raw
+responses.) Accumulate errors into the extract's `errors` array; do not
+fail the whole extract on a single comment fetch.
+
+### Transform
+
+Add `transformSnapshotComments(supabase)` to `.../transform/getdx.js`:
+
+1. List all documents under `getdx/snapshots-comments/`.
+2. For each document, parse the array of comments.
+3. For each comment, derive:
+   - `comment_id` from the raw payload if present, else
+     `${snapshotId}::${email ?? "anon"}::${timestamp}`.
+   - `email`, `text`, `timestamp` from the payload.
+   - `team_id` by looking up `organization_people(email)` → manager_email,
+     then `getdx_teams` where `manager_email` matches. If no match, leave
+     `team_id` null.
+4. Upsert into `activity.getdx_snapshot_comments` with `on conflict
+   (comment_id) do update`.
+5. Return `{ comments: <count>, errors: [...] }`.
+
+Wire into `transformAllGetDX`:
+
+```js
+const commentsResult = await transformSnapshotComments(supabase);
+return {
+  teams,
+  snapshots,
+  scores,
+  comments: commentsResult.comments,
+  errors: [...teams.errors, ..., ...commentsResult.errors],
+};
+```
+
+### Query module
+
+`products/map/src/activity/queries/comments.js`:
+
+```js
+export async function getSnapshotComments(supabase, options = {}) {
+  let query = supabase
+    .from("getdx_snapshot_comments")
+    .select("*, getdx_snapshots(scheduled_for)")
+    .order("timestamp", { ascending: false });
+  if (options.snapshotId) query = query.eq("snapshot_id", options.snapshotId);
+  if (options.email) query = query.eq("email", options.email);
+  if (options.managerEmail) {
+    // Filter via getdx_teams where manager_email matches.
+    // First look up the team id, then filter.
+    const { data: teams } = await supabase
+      .from("getdx_teams")
+      .select("getdx_team_id")
+      .eq("manager_email", options.managerEmail);
+    const teamIds = (teams ?? []).map((t) => t.getdx_team_id);
+    if (teamIds.length === 0) return [];
+    query = query.in("team_id", teamIds);
+  }
+  if (options.driverId) {
+    // Optional future filter — unused in Part 04, reserved for Part 03's
+    // per-driver comment pulling when GetDX exposes driver-tagged comments.
+  }
+  const { data, error } = await query;
+  if (error) throw error;
+  return data ?? [];
+}
+```
+
+Decision: the manager-to-team resolution happens inside the query for
+ergonomic reasons (one helper, one semantic). If profiling later shows this
+is hot, the resolution can move into a cached lookup.
+
+Add the exports entry:
+
+```json
+"./activity/queries/comments": "./src/activity/queries/comments.js"
+```
+
+### Landmark: `voice` command
+
+Signature:
+
+```
+fit-landmark voice --manager <email>
+fit-landmark voice --email <email>
+```
+
+Handler:
+
+```js
+export const needsSupabase = true;
+
+export async function runVoiceCommand({ options, supabase, mapData, format }) {
+  if (options.email) return runEmailVoice({ email: options.email, supabase, mapData, format });
+  if (options.manager) return runManagerVoice({ managerEmail: options.manager, supabase, mapData, format });
+  throw new UsageError("voice: one of --email or --manager is required");
+}
+```
+
+`runEmailVoice` fetches `getSnapshotComments(supabase, { email })`, sorts by
+snapshot `scheduled_for` DESC, limits to the last 4 snapshots. Pulls
+evidence counts via `getEvidence(supabase, { email })` and joins them into
+a "Context from evidence" section matching spec § Engineer voice.
+
+`runManagerVoice` fetches comments for the manager's team via
+`{ managerEmail }`. Groups by a lightweight theme bucket (simple
+substring-match against a small curated list: `estimation`, `incident`,
+`planning`, `handoff`, `onboarding`, `deploy`, `runbook`). Returns top N
+themes with comment counts and representative snippets. Also fetches driver
+scores from the latest snapshot and surfaces the "aligned with health
+signals" footer when a theme aligns with a poorly-scoring driver.
+
+Theme bucketing is intentionally crude. Anything smarter is an LLM call,
+which spec § Out of Scope forbids.
+
+Empty paths:
+
+- Comments table does not exist yet (query throws a "relation not found"
+  error) → catch and return `NO_COMMENTS` empty state. This handles the
+  case where the migration has not been applied locally.
+- No comments matching filter → `NO_COMMENTS` empty state with a specific
+  message: "No snapshot comments found for scope."
+
+Add `NO_COMMENTS_FOR_SCOPE` to `src/lib/empty-state.js`.
+
+### Health view integration
+
+Replace the Part 03 placeholder in `src/commands/health.js`:
+
+```js
+// Fetch comments once per health render; filter per driver downstream.
+let comments = [];
+try {
+  comments = await getSnapshotComments(supabase, {
+    snapshotId: latestSnapshot.snapshot_id,
+    managerEmail: options.manager,
+  });
+} catch (err) {
+  if (isRelationNotFoundError(err)) {
+    comments = [];
+    meta.warnings.push("Snapshot comments unavailable — table not present.");
+  } else {
+    throw err;
+  }
+}
+```
+
+Attach `comments` to each driver in the view by the same theme-bucket
+match used by voice (so "estimation" comments appear under `quality`).
+Formatter renders up to 2 comment snippets per driver.
+
+Add `isRelationNotFoundError(err)` to `src/lib/supabase.js` — matches
+Postgres error code `42P01` from the underlying client.
+
+## Tests
+
+- `products/map/test/activity/transform-getdx-comments.test.js` — feeds
+  mocked `getdx/snapshots-comments/<id>.json` documents into
+  `transformSnapshotComments` and asserts the upsert payload. Covers
+  id-fallback path, null-email path, team lookup via manager join.
+- `products/map/test/activity/query-comments.test.js` — stubs Supabase
+  query builder, verifies filter chaining for each option.
+- `products/landmark/test/voice.test.js`:
+  - `--email` path with comments across 4 snapshots.
+  - `--manager` path with themed comments.
+  - `--email` with no comments → `NO_COMMENTS_FOR_SCOPE`.
+  - `--manager` with table missing → `NO_COMMENTS` (simulate via stub
+    throwing a 42P01 error).
+  - Missing both flags → `UsageError`.
+- `products/landmark/test/health.test.js` — extend with an assertion that
+  comments render under driver sections when the stub returns them, and
+  that the missing-table path records a warning without failing the
+  command.
+
+## Verification
+
+1. `just migrate` (or the repo's local migration runner) against a fresh
+   Supabase — migration applies cleanly.
+2. `fit-map getdx sync` against a real (or stubbed) GetDX endpoint — new
+   extract path stores `snapshots-comments` documents.
+3. `fit-map activity transform` — new transform step populates the table
+   and the count appears in the CLI's output.
+4. `bun test products/map/test/activity` — new and existing tests green.
+5. `bun test products/landmark/test` — new and existing tests green,
+   including the updated `health.test.js`.
+6. `bun run check` — lint, format, layout, exports (confirms the new
+   subpath export is wired).
+7. Smoke test: `bunx fit-landmark voice --manager alice@example.com`
+   returns themed comments; `bunx fit-landmark voice --email
+   dan@example.com` returns the per-snapshot timeline with the evidence
+   context footer.
+
+## Risks
+
+- **GetDX comments API shape is not fully documented here.** The extract
+  stores whatever the endpoint returns; the transform is the only layer
+  that parses the shape. If the real shape diverges from what this part
+  assumes, adjust only the transform — the rest of the pipeline stays put.
+- **`isRelationNotFoundError` error-code matching is client-version
+  dependent.** The helper is a single place to patch if `@supabase/supabase-js`
+  changes its error shape.
+- **Theme bucketing is fragile.** This is deliberate — a richer
+  classifier would require LLM calls which the spec forbids. Keep the theme
+  keyword list small and obvious; users can read the full list via
+  `fit-landmark voice --email` if the manager view's grouping is
+  unsatisfactory.
+
+## Deliverable
+
+A merged PR that ships `fit-landmark voice` and completes the `health`
+command's engineer-voice section. The `getdx_snapshot_comments` table exists
+end-to-end: extract, transform, query, CLI.

--- a/specs/080-landmark-product/plan-a-05.md
+++ b/specs/080-landmark-product/plan-a-05.md
@@ -1,33 +1,32 @@
 # Plan A · Part 05 — Initiatives pipeline + initiative commands
 
 Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
-[Part 03](./plan-a-03.md) being merged (extends `health.js` via the
-pre-placed `<initiatives section>` anchors). Runs in parallel with Part 04,
-which edits the disjoint `<comments section>` anchors.
+[Part 03](./plan-a-03.md) being merged (extends `health.js` via the pre-placed
+`<initiatives section>` anchors). Runs in parallel with Part 04, which edits the
+disjoint `<comments section>` anchors.
 
 This part adds the `activity.getdx_initiatives` table, extends Map's GetDX
 extract/transform pipeline to populate it from the GetDX Initiatives API,
 exports a new query module, ships `fit-landmark initiative list|show|impact`,
-and extends Part 03's health view with an active-initiatives section per
-driver (spec § Initiative tracking explicitly requires this — it is **not**
-polish).
+and extends Part 03's health view with an active-initiatives section per driver
+(spec § Initiative tracking explicitly requires this — it is **not** polish).
 
 Structurally similar to Part 04 but for the initiatives table. The impact
 command is the novel piece: it joins initiative completion dates against
-`getdx_snapshot_team_scores` across before/after snapshots to compute
-percentile deltas. The cross-snapshot join lives in Landmark, not Map —
-see § Design decision below.
+`getdx_snapshot_team_scores` across before/after snapshots to compute percentile
+deltas. The cross-snapshot join lives in Landmark, not Map — see § Design
+decision below.
 
 ## Scope
 
 **In scope**
 
-- New migration creating `activity.getdx_initiatives` with the columns spec
-  § Data Contracts enumerates.
+- New migration creating `activity.getdx_initiatives` with the columns spec §
+  Data Contracts enumerates.
 - Extend Map's GetDX extract with an Initiatives API fetch.
 - Add `transformInitiatives` and wire into `transformAllGetDX`.
-- New query module `products/map/src/activity/queries/initiatives.js`
-  exporting `listInitiatives`, `getInitiative`, and `getInitiativeImpact`.
+- New query module `products/map/src/activity/queries/initiatives.js` exporting
+  `listInitiatives`, `getInitiative`, and `getInitiativeImpact`.
 - Subpath export entry in `products/map/package.json`.
 - Landmark: `initiative list`, `initiative show`, `initiative impact`
   subcommands on a single `initiative` command file.
@@ -43,9 +42,9 @@ see § Design decision below.
 The cross-snapshot join logic (pick the snapshot before an initiative's
 `completed_at`, pick the one after, compute the delta) is **analytical
 computation**, not a raw query. Map's existing query modules in
-`products/map/src/activity/queries/` are thin `SELECT` wrappers — none of
-them implement multi-row analysis. Putting the join there would break that
-convention and force Landmark's domain logic into Map's surface area.
+`products/map/src/activity/queries/` are thin `SELECT` wrappers — none of them
+implement multi-row analysis. Putting the join there would break that convention
+and force Landmark's domain logic into Map's surface area.
 
 Instead:
 
@@ -53,12 +52,12 @@ Instead:
   existing `listSnapshots` and `getSnapshotScores`.
 - Landmark owns the analytical join in a new helper:
   `products/landmark/src/lib/initiative-helpers.js`, exporting
-  `computeInitiativeImpact({ completed, snapshots, scoresBySnapshot })`
-  as a pure function operating on already-fetched rows. The function is
-  unit-testable with in-memory fixtures; no Supabase contact.
-- `runImpact` in `src/commands/initiative.js` performs the fetches
-  (completed initiatives, all snapshots, scores per relevant snapshot) and
-  passes the result arrays into `computeInitiativeImpact`.
+  `computeInitiativeImpact({ completed, snapshots, scoresBySnapshot })` as a
+  pure function operating on already-fetched rows. The function is unit-testable
+  with in-memory fixtures; no Supabase contact.
+- `runImpact` in `src/commands/initiative.js` performs the fetches (completed
+  initiatives, all snapshots, scores per relevant snapshot) and passes the
+  result arrays into `computeInitiativeImpact`.
 
 ## Files
 
@@ -92,24 +91,23 @@ products/landmark/test/
 ### Modified
 
 - `products/map/supabase/functions/_shared/activity/extract/getdx.js` — add
-  `extractInitiatives` helper and call it once per extract (not per
-  snapshot, since initiatives are org-scoped in GetDX).
-- `products/map/supabase/functions/_shared/activity/transform/getdx.js` —
-  add `transformInitiatives` and call it from `transformAllGetDX`; update
-  the return shape to include `initiatives: number`.
+  `extractInitiatives` helper and call it once per extract (not per snapshot,
+  since initiatives are org-scoped in GetDX).
+- `products/map/supabase/functions/_shared/activity/transform/getdx.js` — add
+  `transformInitiatives` and call it from `transformAllGetDX`; update the return
+  shape to include `initiatives: number`.
 - `products/map/package.json` — add
   `"./activity/queries/initiatives": "./src/activity/queries/initiatives.js"`.
 - `products/landmark/bin/fit-landmark.js` — wire `runInitiativeCommand`.
-- `products/landmark/src/formatters/index.js` — register initiative
-  formatter.
+- `products/landmark/src/formatters/index.js` — register initiative formatter.
 - `products/landmark/src/commands/health.js` — add initiatives fetch **only
-  between the `<initiatives section>` anchors** placed by Part 03. Do not
-  touch the `<comments section>` region (that is Part 04's territory).
+  between the `<initiatives section>` anchors** placed by Part 03. Do not touch
+  the `<comments section>` region (that is Part 04's territory).
 - `products/landmark/src/formatters/health.js` — render per-driver active
   initiatives between the matching `<initiatives section>` anchors.
 - `products/landmark/test/health.test.js` — extend with assertions that
-  initiatives render per driver when present, and that missing initiatives
-  table records a warning without failing the command.
+  initiatives render per driver when present, and that missing initiatives table
+  records a warning without failing the command.
 
 ## Implementation details
 
@@ -147,14 +145,14 @@ Notes:
 
 - `completed_at` is added beyond the spec's enumeration because the impact
   computation needs it as the join key. `due_date` is the scheduled date;
-  `completed_at` is derived from GetDX's status transition. If GetDX does
-  not expose a completion timestamp, fall back to the first snapshot where
+  `completed_at` is derived from GetDX's status transition. If GetDX does not
+  expose a completion timestamp, fall back to the first snapshot where
   `completion_pct` reaches 100 (computed at transform time).
 - `tags` stored as JSONB for flexibility.
-- `scorecard_id` is the join key to `getdx_snapshot_team_scores.item_id`
-  — spec says initiatives target drivers through scorecard items, so
-  `scorecard_id === driver.id` for linked initiatives. Unlinked
-  initiatives (no scorecard) leave this null.
+- `scorecard_id` is the join key to `getdx_snapshot_team_scores.item_id` — spec
+  says initiatives target drivers through scorecard items, so
+  `scorecard_id === driver.id` for linked initiatives. Unlinked initiatives (no
+  scorecard) leave this null.
 
 ### Extract
 
@@ -180,13 +178,13 @@ async function extractInitiatives(supabase, config) {
 }
 ```
 
-Accumulate errors into the extract's return value; do not fail the whole
-extract on an initiatives fetch error.
+Accumulate errors into the extract's return value; do not fail the whole extract
+on an initiatives fetch error.
 
 **Risk:** the spec does not pin the exact GetDX Initiatives API path. The
-implementer should cross-reference GetDX docs at implementation time. If
-the path is wrong, only this function needs patching — the rest of the
-pipeline treats the payload as opaque JSON.
+implementer should cross-reference GetDX docs at implementation time. If the
+path is wrong, only this function needs patching — the rest of the pipeline
+treats the payload as opaque JSON.
 
 ### Transform
 
@@ -206,9 +204,8 @@ pipeline treats the payload as opaque JSON.
    - `completed_at` from the payload if present, else computed as
      `passed_checks === total_checks && total_checks > 0 ? now() : null`.
    - `raw` = the entire payload entry.
-4. Upsert on `id` with a **completion-preserving merge**: if the row
-   already exists and the old `completed_at` is non-null, keep the old
-   value. Use:
+4. Upsert on `id` with a **completion-preserving merge**: if the row already
+   exists and the old `completed_at` is non-null, keep the old value. Use:
 
    ```sql
    on conflict (id) do update set
@@ -227,17 +224,18 @@ pipeline treats the payload as opaque JSON.
      inserted_at = now()
    ```
 
-   This makes the transform idempotent: replaying the same extract cannot
-   shift `completed_at` forward, so the before/after snapshot selection in
-   impact computation stays deterministic.
+   This makes the transform idempotent: replaying the same extract cannot shift
+   `completed_at` forward, so the before/after snapshot selection in impact
+   computation stays deterministic.
+
 5. Return `{ initiatives: <count>, errors: [...] }`.
 
 ### Query module (thin SELECT wrappers only)
 
-Map's query module exports **two** functions —
-`listInitiatives` and `getInitiative` — that stay in line with the existing
-Map query convention (thin `SELECT` wrappers, no cross-row analysis). The
-impact computation lives in Landmark (see § Design decision above).
+Map's query module exports **two** functions — `listInitiatives` and
+`getInitiative` — that stay in line with the existing Map query convention (thin
+`SELECT` wrappers, no cross-row analysis). The impact computation lives in
+Landmark (see § Design decision above).
 
 ```js
 export async function listInitiatives(supabase, options = {}) {
@@ -329,9 +327,9 @@ export function computeInitiativeImpact({ completed, snapshots, scoresBySnapshot
 1. `listInitiatives(supabase, { ...filter, status: "completed" })`
 2. `listSnapshots(supabase)`
 3. For each unique `(snapshot_id, scorecard_id)` pair referenced by the
-   completed initiatives, `getSnapshotScores(supabase, snapshot_id, {
-   managerEmail })` once and index the result by `item_id` into
-   `scoresBySnapshot`.
+   completed initiatives,
+   `getSnapshotScores(supabase, snapshot_id, { managerEmail })` once and index
+   the result by `item_id` into `scoresBySnapshot`.
 4. Call `computeInitiativeImpact({ completed, snapshots, scoresBySnapshot })`.
 
 ### Landmark: `initiative` command
@@ -352,31 +350,31 @@ export async function runInitiativeCommand({ args, options, supabase, mapData, f
 }
 ```
 
-- `list` → `listInitiatives(supabase, { managerEmail: options.manager })`.
-  Empty → `NO_INITIATIVES`. Table-missing error → same empty state.
+- `list` → `listInitiatives(supabase, { managerEmail: options.manager })`. Empty
+  → `NO_INITIATIVES`. Table-missing error → same empty state.
 - `show` → requires `--id`. `getInitiative(supabase, options.id)`. Null →
   `"No initiative found with id ${id}."` empty state.
 - `impact` → orchestrates fetches (see § Landmark helper) and calls
-  `computeInitiativeImpact`. Renders per the spec's mocked output
-  (§ Initiative impact, lines 510–541). Initiatives with null
-  `scorecard_id` render the "no driver linked" note.
+  `computeInitiativeImpact`. Renders per the spec's mocked output (§ Initiative
+  impact, lines 510–541). Initiatives with null `scorecard_id` render the "no
+  driver linked" note.
 
 Catch `42P01` errors on the initiatives query and return `NO_INITIATIVES`,
 matching Part 04's pattern for `NO_COMMENTS`.
 
 ### Formatter
 
-`initiative.js` formatter renders the spec § Initiative impact output
-exactly: initiative name, target driver id, before/after percentile, delta,
-and any engineer voice quote (deferred — engineer voice is Part 04's
-concern; initiatives formatter only renders voice if the view object has a
-`voice` field, which Part 06 polish can add later).
+`initiative.js` formatter renders the spec § Initiative impact output exactly:
+initiative name, target driver id, before/after percentile, delta, and any
+engineer voice quote (deferred — engineer voice is Part 04's concern;
+initiatives formatter only renders voice if the view object has a `voice` field,
+which Part 06 polish can add later).
 
 ### Health view integration — active initiatives per driver
 
-Edit **only** between the `// <initiatives section>` anchors Part 03
-placed in `src/commands/health.js` and `src/formatters/health.js`. Do not
-touch the `<comments section>` region (Part 04's territory).
+Edit **only** between the `// <initiatives section>` anchors Part 03 placed in
+`src/commands/health.js` and `src/formatters/health.js`. Do not touch the
+`<comments section>` region (Part 04's territory).
 
 In `src/commands/health.js`, between the `<initiatives section>` anchors:
 
@@ -405,21 +403,21 @@ for (const driver of view.drivers) {
 // </initiatives section>
 ```
 
-`isRelationNotFoundError` was added to `src/lib/supabase.js` by Part 04; if
-this part lands before Part 04 (tie-break), add it here instead. Parts 04
-and 05 must coordinate: whichever lands first adds the helper, the second
-asserts it already exists.
+`isRelationNotFoundError` was added to `src/lib/supabase.js` by Part 04; if this
+part lands before Part 04 (tie-break), add it here instead. Parts 04 and 05 must
+coordinate: whichever lands first adds the helper, the second asserts it already
+exists.
 
-In `src/formatters/health.js`, between the matching anchors, render up to
-3 active initiatives per driver as one line each (name + completion_pct).
+In `src/formatters/health.js`, between the matching anchors, render up to 3
+active initiatives per driver as one line each (name + completion_pct).
 
 ## Tests
 
 - `transform-getdx-initiatives.test.js` — feeds mocked
-  `getdx/initiatives-list/<ts>.json` into `transformInitiatives`, asserts
-  upsert payload, including `completed_at` fallback logic.
-- `query-initiatives.test.js` — stubs Supabase query builder, verifies
-  filter chaining for `listInitiatives`, `getInitiative`, and especially
+  `getdx/initiatives-list/<ts>.json` into `transformInitiatives`, asserts upsert
+  payload, including `completed_at` fallback logic.
+- `query-initiatives.test.js` — stubs Supabase query builder, verifies filter
+  chaining for `listInitiatives`, `getInitiative`, and especially
   `getInitiativeImpact` (before/after snapshot selection, delta calculation,
   handling of unlinked initiatives).
 - `initiative.test.js`:
@@ -430,14 +428,14 @@ In `src/formatters/health.js`, between the matching anchors, render up to
     in-progress initiative (skipped in impact view).
   - `NO_INITIATIVES` empty state for the three subcommands.
 - `initiative-helpers.test.js`:
-  - Happy path: completed initiative between two snapshots produces a
-    non-null delta.
+  - Happy path: completed initiative between two snapshots produces a non-null
+    delta.
   - Edge: no snapshots before completion → null before/after.
   - Edge: no snapshots after completion → null after/delta.
   - Edge: `scorecard_id` null → null delta.
   - Edge: score missing in one of the snapshots → null delta.
-  - Idempotency: identical input yields identical output regardless of
-    snapshot array input order (the helper sorts internally).
+  - Idempotency: identical input yields identical output regardless of snapshot
+    array input order (the helper sorts internally).
 - `health.test.js` — extended with:
   - Active initiatives render per driver when the fetch returns rows.
   - Missing initiatives table records the warning, does not fail.
@@ -448,37 +446,37 @@ In `src/formatters/health.js`, between the matching anchors, render up to
 2. `fit-map getdx sync` — new extract stores initiatives document.
 3. `fit-map activity transform` — new transform step populates the table.
 4. `bun test products/map/test/activity` — new tests green.
-5. `bun test products/landmark/test` — new tests green (including the
-   extended `health.test.js`).
-6. `bun run layout && bun run check:exports && bun run check` — layout,
-   exports (confirms `./activity/queries/initiatives` subpath is wired),
-   and lint/format all green.
-7. Grep confirms only `<initiatives section>` anchors were edited in
-   `health.js` and `formatters/health.js` — the `<comments section>`
-   region remains untouched. Any edit outside the initiatives anchors is
-   a contract violation and must be reverted.
-7. Smoke tests:
+5. `bun test products/landmark/test` — new tests green (including the extended
+   `health.test.js`).
+6. `bun run layout && bun run check:exports && bun run check` — layout, exports
+   (confirms `./activity/queries/initiatives` subpath is wired), and lint/format
+   all green.
+7. Grep confirms only `<initiatives section>` anchors were edited in `health.js`
+   and `formatters/health.js` — the `<comments section>` region remains
+   untouched. Any edit outside the initiatives anchors is a contract violation
+   and must be reverted.
+8. Smoke tests:
    - `bunx fit-landmark initiative list --manager alice@example.com`
    - `bunx fit-landmark initiative show --id <id>`
    - `bunx fit-landmark initiative impact --manager alice@example.com`
 
 ## Risks
 
-- **GetDX Initiatives API shape is the primary unknown.** Same mitigation
-  as Part 04: the extract stores raw payload; the transform is the only
-  layer that parses. Patch the transform if the shape differs.
+- **GetDX Initiatives API shape is the primary unknown.** Same mitigation as
+  Part 04: the extract stores raw payload; the transform is the only layer that
+  parses. Patch the transform if the shape differs.
 - **Before/after snapshot selection is sensitive to `completed_at` fidelity.**
-  If GetDX does not supply a completion timestamp, the fallback (first
-  snapshot at 100%) is imperfect — it may delay the "before" marker by up
-  to one quarter. Document this limitation in the formatter output when the
-  fallback path is used.
-- **`scorecard_id === driver.id` join assumes parity.** Real installations
-  may need an explicit mapping layer. This part does not build one; Part 06
+  If GetDX does not supply a completion timestamp, the fallback (first snapshot
+  at 100%) is imperfect — it may delay the "before" marker by up to one quarter.
+  Document this limitation in the formatter output when the fallback path is
+  used.
+- **`scorecard_id === driver.id` join assumes parity.** Real installations may
+  need an explicit mapping layer. This part does not build one; Part 06
   documents the assumption.
 
 ## Deliverable
 
 A merged PR that ships `fit-landmark initiative list|show|impact` and the
-supporting Map pipeline. Spec § Initiative tracking and § Initiative impact
-are fully implemented except for the optional health-view integration,
-which is tracked as a Part 06 polish item.
+supporting Map pipeline. Spec § Initiative tracking and § Initiative impact are
+fully implemented except for the optional health-view integration, which is
+tracked as a Part 06 polish item.

--- a/specs/080-landmark-product/plan-a-05.md
+++ b/specs/080-landmark-product/plan-a-05.md
@@ -1,16 +1,22 @@
 # Plan A · Part 05 — Initiatives pipeline + initiative commands
 
 Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
-[Part 01](./plan-a-01.md). Independent of Parts 02, 03, 04.
+[Part 03](./plan-a-03.md) being merged (extends `health.js` via the
+pre-placed `<initiatives section>` anchors). Runs in parallel with Part 04,
+which edits the disjoint `<comments section>` anchors.
 
 This part adds the `activity.getdx_initiatives` table, extends Map's GetDX
 extract/transform pipeline to populate it from the GetDX Initiatives API,
-exports a new query module, and ships `fit-landmark initiative list|show|impact`.
+exports a new query module, ships `fit-landmark initiative list|show|impact`,
+and extends Part 03's health view with an active-initiatives section per
+driver (spec § Initiative tracking explicitly requires this — it is **not**
+polish).
 
-Structurally identical to Part 04 but for the initiatives table. The impact
+Structurally similar to Part 04 but for the initiatives table. The impact
 command is the novel piece: it joins initiative completion dates against
 `getdx_snapshot_team_scores` across before/after snapshots to compute
-percentile deltas.
+percentile deltas. The cross-snapshot join lives in Landmark, not Map —
+see § Design decision below.
 
 ## Scope
 
@@ -29,13 +35,30 @@ percentile deltas.
 
 **Out of scope**
 
-- Extending the health view to show active initiatives inline — the spec
-  mentions this (§ Initiative tracking) but it's a small additive formatter
-  change that can follow in Part 06 as a polish, or in a separate small PR.
-  Keeping it out of this part reduces the diff size and keeps the initiative
-  command self-contained.
 - Any write path to initiatives (Landmark is read-only).
 - Driver linking UI changes beyond what the schema requires.
+
+### Design decision — impact join lives in Landmark, not Map
+
+The cross-snapshot join logic (pick the snapshot before an initiative's
+`completed_at`, pick the one after, compute the delta) is **analytical
+computation**, not a raw query. Map's existing query modules in
+`products/map/src/activity/queries/` are thin `SELECT` wrappers — none of
+them implement multi-row analysis. Putting the join there would break that
+convention and force Landmark's domain logic into Map's surface area.
+
+Instead:
+
+- Map exports raw queries only: `listInitiatives`, `getInitiative`, plus the
+  existing `listSnapshots` and `getSnapshotScores`.
+- Landmark owns the analytical join in a new helper:
+  `products/landmark/src/lib/initiative-helpers.js`, exporting
+  `computeInitiativeImpact({ completed, snapshots, scoresBySnapshot })`
+  as a pure function operating on already-fetched rows. The function is
+  unit-testable with in-memory fixtures; no Supabase contact.
+- `runImpact` in `src/commands/initiative.js` performs the fetches
+  (completed initiatives, all snapshots, scores per relevant snapshot) and
+  passes the result arrays into `computeInitiativeImpact`.
 
 ## Files
 
@@ -52,6 +75,9 @@ products/map/test/activity/
   transform-getdx-initiatives.test.js
   query-initiatives.test.js
 
+products/landmark/src/lib/
+  initiative-helpers.js
+
 products/landmark/src/commands/
   initiative.js
 
@@ -60,6 +86,7 @@ products/landmark/src/formatters/
 
 products/landmark/test/
   initiative.test.js
+  initiative-helpers.test.js
 ```
 
 ### Modified
@@ -75,6 +102,14 @@ products/landmark/test/
 - `products/landmark/bin/fit-landmark.js` — wire `runInitiativeCommand`.
 - `products/landmark/src/formatters/index.js` — register initiative
   formatter.
+- `products/landmark/src/commands/health.js` — add initiatives fetch **only
+  between the `<initiatives section>` anchors** placed by Part 03. Do not
+  touch the `<comments section>` region (that is Part 04's territory).
+- `products/landmark/src/formatters/health.js` — render per-driver active
+  initiatives between the matching `<initiatives section>` anchors.
+- `products/landmark/test/health.test.js` — extend with assertions that
+  initiatives render per driver when present, and that missing initiatives
+  table records a warning without failing the command.
 
 ## Implementation details
 
@@ -171,10 +206,38 @@ pipeline treats the payload as opaque JSON.
    - `completed_at` from the payload if present, else computed as
      `passed_checks === total_checks && total_checks > 0 ? now() : null`.
    - `raw` = the entire payload entry.
-4. Upsert on `id`.
+4. Upsert on `id` with a **completion-preserving merge**: if the row
+   already exists and the old `completed_at` is non-null, keep the old
+   value. Use:
+
+   ```sql
+   on conflict (id) do update set
+     name = excluded.name,
+     description = excluded.description,
+     scorecard_id = excluded.scorecard_id,
+     owner_email = excluded.owner_email,
+     due_date = excluded.due_date,
+     priority = excluded.priority,
+     passed_checks = excluded.passed_checks,
+     total_checks = excluded.total_checks,
+     completion_pct = excluded.completion_pct,
+     tags = excluded.tags,
+     completed_at = coalesce(getdx_initiatives.completed_at, excluded.completed_at),
+     raw = excluded.raw,
+     inserted_at = now()
+   ```
+
+   This makes the transform idempotent: replaying the same extract cannot
+   shift `completed_at` forward, so the before/after snapshot selection in
+   impact computation stays deterministic.
 5. Return `{ initiatives: <count>, errors: [...] }`.
 
-### Query module
+### Query module (thin SELECT wrappers only)
+
+Map's query module exports **two** functions —
+`listInitiatives` and `getInitiative` — that stay in line with the existing
+Map query convention (thin `SELECT` wrappers, no cross-row analysis). The
+impact computation lives in Landmark (see § Design decision above).
 
 ```js
 export async function listInitiatives(supabase, options = {}) {
@@ -210,49 +273,66 @@ export async function getInitiative(supabase, id) {
   return data;
 }
 
-// Core impact computation: for each initiative, find the snapshot
-// immediately before completion and the snapshot immediately after, then
-// return the score delta on the linked scorecard driver.
-export async function getInitiativeImpact(supabase, options = {}) {
-  const completed = await listInitiatives(supabase, {
-    ...options,
-    status: "completed",
-  });
-  const snapshots = await listSnapshots(supabase);
-  // For each completed initiative, find the latest snapshot with
-  // scheduled_for <= completed_at (= "before") and the earliest snapshot
-  // with scheduled_for > completed_at (= "after").
+```
+
+### Landmark helper: `initiative-helpers.js`
+
+Pure function operating on already-fetched rows. No Supabase inside.
+
+```js
+/**
+ * @param {object} params
+ * @param {Array<object>} params.completed - Completed initiatives.
+ * @param {Array<object>} params.snapshots - All snapshots (ordered DESC).
+ * @param {Map<string, Map<string, number>>} params.scoresBySnapshot -
+ *   snapshotId → (scorecardId → score).
+ * @returns {Array<{initiative, before, after, delta}>}
+ */
+export function computeInitiativeImpact({ completed, snapshots, scoresBySnapshot }) {
+  const sorted = [...snapshots].sort((a, b) =>
+    a.scheduled_for.localeCompare(b.scheduled_for),
+  );
   const results = [];
   for (const init of completed) {
-    const before = [...snapshots]
-      .filter((s) => s.scheduled_for <= init.completed_at)
-      .sort((a, b) => b.scheduled_for.localeCompare(a.scheduled_for))[0];
-    const after = snapshots
-      .filter((s) => s.scheduled_for > init.completed_at)
-      .sort((a, b) => a.scheduled_for.localeCompare(b.scheduled_for))[0];
-    if (!before || !after || !init.scorecard_id) {
+    if (!init.scorecard_id || !init.completed_at) {
       results.push({ initiative: init, before: null, after: null, delta: null });
       continue;
     }
-    const beforeScore = await getScoreForItem(supabase, before.snapshot_id, init.scorecard_id);
-    const afterScore = await getScoreForItem(supabase, after.snapshot_id, init.scorecard_id);
+    // Latest snapshot before completion.
+    let before = null;
+    for (const s of sorted) {
+      if (s.scheduled_for <= init.completed_at) before = s;
+      else break;
+    }
+    // Earliest snapshot after completion.
+    const after = sorted.find((s) => s.scheduled_for > init.completed_at) ?? null;
+    if (!before || !after) {
+      results.push({ initiative: init, before: null, after: null, delta: null });
+      continue;
+    }
+    const beforeScore = scoresBySnapshot.get(before.snapshot_id)?.get(init.scorecard_id) ?? null;
+    const afterScore = scoresBySnapshot.get(after.snapshot_id)?.get(init.scorecard_id) ?? null;
     results.push({
       initiative: init,
       before: beforeScore,
       after: afterScore,
-      delta: beforeScore && afterScore ? afterScore - beforeScore : null,
+      delta:
+        beforeScore != null && afterScore != null ? afterScore - beforeScore : null,
     });
   }
   return results;
 }
 ```
 
-`getScoreForItem` is a small private helper inside the same module that
-queries `getdx_snapshot_team_scores`. It accepts an optional `managerEmail`
-to scope to a team when needed.
+`runImpact` in the initiative command is responsible for fetching:
 
-Note: `listSnapshots` comes from `@forwardimpact/map/activity/queries/snapshots`
-— keep the cross-module import.
+1. `listInitiatives(supabase, { ...filter, status: "completed" })`
+2. `listSnapshots(supabase)`
+3. For each unique `(snapshot_id, scorecard_id)` pair referenced by the
+   completed initiatives, `getSnapshotScores(supabase, snapshot_id, {
+   managerEmail })` once and index the result by `item_id` into
+   `scoresBySnapshot`.
+4. Call `computeInitiativeImpact({ completed, snapshots, scoresBySnapshot })`.
 
 ### Landmark: `initiative` command
 
@@ -276,9 +356,10 @@ export async function runInitiativeCommand({ args, options, supabase, mapData, f
   Empty → `NO_INITIATIVES`. Table-missing error → same empty state.
 - `show` → requires `--id`. `getInitiative(supabase, options.id)`. Null →
   `"No initiative found with id ${id}."` empty state.
-- `impact` → `getInitiativeImpact(supabase, { managerEmail: options.manager })`.
-  Renders per the spec's mocked output (§ Initiative impact, lines 510–541).
-  Initiatives with null `scorecard_id` render the "no driver linked" note.
+- `impact` → orchestrates fetches (see § Landmark helper) and calls
+  `computeInitiativeImpact`. Renders per the spec's mocked output
+  (§ Initiative impact, lines 510–541). Initiatives with null
+  `scorecard_id` render the "no driver linked" note.
 
 Catch `42P01` errors on the initiatives query and return `NO_INITIATIVES`,
 matching Part 04's pattern for `NO_COMMENTS`.
@@ -290,6 +371,47 @@ exactly: initiative name, target driver id, before/after percentile, delta,
 and any engineer voice quote (deferred — engineer voice is Part 04's
 concern; initiatives formatter only renders voice if the view object has a
 `voice` field, which Part 06 polish can add later).
+
+### Health view integration — active initiatives per driver
+
+Edit **only** between the `// <initiatives section>` anchors Part 03
+placed in `src/commands/health.js` and `src/formatters/health.js`. Do not
+touch the `<comments section>` region (Part 04's territory).
+
+In `src/commands/health.js`, between the `<initiatives section>` anchors:
+
+```js
+// <initiatives section> — Part 05
+let activeInitiatives = [];
+try {
+  activeInitiatives = await listInitiatives(supabase, {
+    managerEmail: options.manager,
+    status: "active",
+  });
+} catch (err) {
+  if (isRelationNotFoundError(err)) {
+    activeInitiatives = [];
+    meta.warnings.push("Active initiatives unavailable — table not present.");
+  } else {
+    throw err;
+  }
+}
+// Attach to each driver by scorecard_id match.
+for (const driver of view.drivers) {
+  driver.initiatives = activeInitiatives.filter(
+    (i) => i.scorecard_id === driver.id,
+  );
+}
+// </initiatives section>
+```
+
+`isRelationNotFoundError` was added to `src/lib/supabase.js` by Part 04; if
+this part lands before Part 04 (tie-break), add it here instead. Parts 04
+and 05 must coordinate: whichever lands first adds the helper, the second
+asserts it already exists.
+
+In `src/formatters/health.js`, between the matching anchors, render up to
+3 active initiatives per driver as one line each (name + completion_pct).
 
 ## Tests
 
@@ -307,6 +429,18 @@ concern; initiatives formatter only renders voice if the view object has a
     delta), a completed initiative without alignment (null delta), and an
     in-progress initiative (skipped in impact view).
   - `NO_INITIATIVES` empty state for the three subcommands.
+- `initiative-helpers.test.js`:
+  - Happy path: completed initiative between two snapshots produces a
+    non-null delta.
+  - Edge: no snapshots before completion → null before/after.
+  - Edge: no snapshots after completion → null after/delta.
+  - Edge: `scorecard_id` null → null delta.
+  - Edge: score missing in one of the snapshots → null delta.
+  - Idempotency: identical input yields identical output regardless of
+    snapshot array input order (the helper sorts internally).
+- `health.test.js` — extended with:
+  - Active initiatives render per driver when the fetch returns rows.
+  - Missing initiatives table records the warning, does not fail.
 
 ## Verification
 
@@ -314,8 +448,15 @@ concern; initiatives formatter only renders voice if the view object has a
 2. `fit-map getdx sync` — new extract stores initiatives document.
 3. `fit-map activity transform` — new transform step populates the table.
 4. `bun test products/map/test/activity` — new tests green.
-5. `bun test products/landmark/test` — new tests green.
-6. `bun run check` — lint, format, layout, exports.
+5. `bun test products/landmark/test` — new tests green (including the
+   extended `health.test.js`).
+6. `bun run layout && bun run check:exports && bun run check` — layout,
+   exports (confirms `./activity/queries/initiatives` subpath is wired),
+   and lint/format all green.
+7. Grep confirms only `<initiatives section>` anchors were edited in
+   `health.js` and `formatters/health.js` — the `<comments section>`
+   region remains untouched. Any edit outside the initiatives anchors is
+   a contract violation and must be reverted.
 7. Smoke tests:
    - `bunx fit-landmark initiative list --manager alice@example.com`
    - `bunx fit-landmark initiative show --id <id>`

--- a/specs/080-landmark-product/plan-a-05.md
+++ b/specs/080-landmark-product/plan-a-05.md
@@ -1,0 +1,343 @@
+# Plan A · Part 05 — Initiatives pipeline + initiative commands
+
+Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
+[Part 01](./plan-a-01.md). Independent of Parts 02, 03, 04.
+
+This part adds the `activity.getdx_initiatives` table, extends Map's GetDX
+extract/transform pipeline to populate it from the GetDX Initiatives API,
+exports a new query module, and ships `fit-landmark initiative list|show|impact`.
+
+Structurally identical to Part 04 but for the initiatives table. The impact
+command is the novel piece: it joins initiative completion dates against
+`getdx_snapshot_team_scores` across before/after snapshots to compute
+percentile deltas.
+
+## Scope
+
+**In scope**
+
+- New migration creating `activity.getdx_initiatives` with the columns spec
+  § Data Contracts enumerates.
+- Extend Map's GetDX extract with an Initiatives API fetch.
+- Add `transformInitiatives` and wire into `transformAllGetDX`.
+- New query module `products/map/src/activity/queries/initiatives.js`
+  exporting `listInitiatives`, `getInitiative`, and `getInitiativeImpact`.
+- Subpath export entry in `products/map/package.json`.
+- Landmark: `initiative list`, `initiative show`, `initiative impact`
+  subcommands on a single `initiative` command file.
+- Tests for extract, transform, query, and the three Landmark subcommands.
+
+**Out of scope**
+
+- Extending the health view to show active initiatives inline — the spec
+  mentions this (§ Initiative tracking) but it's a small additive formatter
+  change that can follow in Part 06 as a polish, or in a separate small PR.
+  Keeping it out of this part reduces the diff size and keeps the initiative
+  command self-contained.
+- Any write path to initiatives (Landmark is read-only).
+- Driver linking UI changes beyond what the schema requires.
+
+## Files
+
+### Created
+
+```
+products/map/supabase/migrations/
+  <next-sequence>_getdx_initiatives.sql
+
+products/map/src/activity/queries/
+  initiatives.js
+
+products/map/test/activity/
+  transform-getdx-initiatives.test.js
+  query-initiatives.test.js
+
+products/landmark/src/commands/
+  initiative.js
+
+products/landmark/src/formatters/
+  initiative.js
+
+products/landmark/test/
+  initiative.test.js
+```
+
+### Modified
+
+- `products/map/supabase/functions/_shared/activity/extract/getdx.js` — add
+  `extractInitiatives` helper and call it once per extract (not per
+  snapshot, since initiatives are org-scoped in GetDX).
+- `products/map/supabase/functions/_shared/activity/transform/getdx.js` —
+  add `transformInitiatives` and call it from `transformAllGetDX`; update
+  the return shape to include `initiatives: number`.
+- `products/map/package.json` — add
+  `"./activity/queries/initiatives": "./src/activity/queries/initiatives.js"`.
+- `products/landmark/bin/fit-landmark.js` — wire `runInitiativeCommand`.
+- `products/landmark/src/formatters/index.js` — register initiative
+  formatter.
+
+## Implementation details
+
+### Migration
+
+Schema follows spec § Data Contracts:
+
+```sql
+create table if not exists activity.getdx_initiatives (
+  id text primary key,
+  name text not null,
+  description text,
+  scorecard_id text,
+  owner_email text references activity.organization_people(email) on delete set null,
+  due_date date,
+  priority text,
+  passed_checks integer,
+  total_checks integer,
+  completion_pct numeric,
+  tags jsonb,
+  completed_at timestamptz,
+  raw jsonb,
+  inserted_at timestamptz not null default now()
+);
+
+create index if not exists idx_getdx_initiatives_owner
+  on activity.getdx_initiatives(owner_email);
+create index if not exists idx_getdx_initiatives_completed_at
+  on activity.getdx_initiatives(completed_at);
+create index if not exists idx_getdx_initiatives_scorecard
+  on activity.getdx_initiatives(scorecard_id);
+```
+
+Notes:
+
+- `completed_at` is added beyond the spec's enumeration because the impact
+  computation needs it as the join key. `due_date` is the scheduled date;
+  `completed_at` is derived from GetDX's status transition. If GetDX does
+  not expose a completion timestamp, fall back to the first snapshot where
+  `completion_pct` reaches 100 (computed at transform time).
+- `tags` stored as JSONB for flexibility.
+- `scorecard_id` is the join key to `getdx_snapshot_team_scores.item_id`
+  — spec says initiatives target drivers through scorecard items, so
+  `scorecard_id === driver.id` for linked initiatives. Unlinked
+  initiatives (no scorecard) leave this null.
+
+### Extract
+
+```js
+async function extractInitiatives(supabase, config) {
+  // GetDX Initiatives API endpoint — confirm exact path during
+  // implementation. Store the raw response under
+  // getdx/initiatives-list/<timestamp>.json for idempotent replay.
+  const url = `${config.baseUrl}/initiatives.list`;
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${config.apiToken}` },
+  });
+  if (!response.ok) {
+    return { error: `initiatives.list → HTTP ${response.status}` };
+  }
+  const payload = await response.json();
+  await storeDocument(
+    supabase,
+    `getdx/initiatives-list/${Date.now()}.json`,
+    payload,
+  );
+  return { ok: true };
+}
+```
+
+Accumulate errors into the extract's return value; do not fail the whole
+extract on an initiatives fetch error.
+
+**Risk:** the spec does not pin the exact GetDX Initiatives API path. The
+implementer should cross-reference GetDX docs at implementation time. If
+the path is wrong, only this function needs patching — the rest of the
+pipeline treats the payload as opaque JSON.
+
+### Transform
+
+`transformInitiatives(supabase)`:
+
+1. List documents under `getdx/initiatives-list/`.
+2. Parse the most recent document (initiatives are state-of-the-world, not
+   event-sourced — always prefer the latest extract).
+3. For each initiative in the array, build an upsert row:
+   - `id`, `name`, `description` from the payload.
+   - `scorecard_id` from the payload's scorecard field.
+   - `owner_email` from the payload's owner field.
+   - `due_date`, `priority` from the payload.
+   - `passed_checks`, `total_checks`, `completion_pct` from the payload's
+     aggregate fields.
+   - `tags` as JSONB.
+   - `completed_at` from the payload if present, else computed as
+     `passed_checks === total_checks && total_checks > 0 ? now() : null`.
+   - `raw` = the entire payload entry.
+4. Upsert on `id`.
+5. Return `{ initiatives: <count>, errors: [...] }`.
+
+### Query module
+
+```js
+export async function listInitiatives(supabase, options = {}) {
+  let query = supabase
+    .from("getdx_initiatives")
+    .select("*")
+    .order("due_date", { ascending: true });
+  if (options.ownerEmail) query = query.eq("owner_email", options.ownerEmail);
+  if (options.managerEmail) {
+    // Team roster → list of emails → filter by owner_email IN (...)
+    const { data: team } = await supabase
+      .from("organization_people")
+      .select("email")
+      .eq("manager_email", options.managerEmail);
+    const emails = (team ?? []).map((t) => t.email);
+    if (emails.length === 0) return [];
+    query = query.in("owner_email", emails);
+  }
+  if (options.status === "active") query = query.is("completed_at", null);
+  if (options.status === "completed") query = query.not("completed_at", "is", null);
+  const { data, error } = await query;
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function getInitiative(supabase, id) {
+  const { data, error } = await supabase
+    .from("getdx_initiatives")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+// Core impact computation: for each initiative, find the snapshot
+// immediately before completion and the snapshot immediately after, then
+// return the score delta on the linked scorecard driver.
+export async function getInitiativeImpact(supabase, options = {}) {
+  const completed = await listInitiatives(supabase, {
+    ...options,
+    status: "completed",
+  });
+  const snapshots = await listSnapshots(supabase);
+  // For each completed initiative, find the latest snapshot with
+  // scheduled_for <= completed_at (= "before") and the earliest snapshot
+  // with scheduled_for > completed_at (= "after").
+  const results = [];
+  for (const init of completed) {
+    const before = [...snapshots]
+      .filter((s) => s.scheduled_for <= init.completed_at)
+      .sort((a, b) => b.scheduled_for.localeCompare(a.scheduled_for))[0];
+    const after = snapshots
+      .filter((s) => s.scheduled_for > init.completed_at)
+      .sort((a, b) => a.scheduled_for.localeCompare(b.scheduled_for))[0];
+    if (!before || !after || !init.scorecard_id) {
+      results.push({ initiative: init, before: null, after: null, delta: null });
+      continue;
+    }
+    const beforeScore = await getScoreForItem(supabase, before.snapshot_id, init.scorecard_id);
+    const afterScore = await getScoreForItem(supabase, after.snapshot_id, init.scorecard_id);
+    results.push({
+      initiative: init,
+      before: beforeScore,
+      after: afterScore,
+      delta: beforeScore && afterScore ? afterScore - beforeScore : null,
+    });
+  }
+  return results;
+}
+```
+
+`getScoreForItem` is a small private helper inside the same module that
+queries `getdx_snapshot_team_scores`. It accepts an optional `managerEmail`
+to scope to a team when needed.
+
+Note: `listSnapshots` comes from `@forwardimpact/map/activity/queries/snapshots`
+— keep the cross-module import.
+
+### Landmark: `initiative` command
+
+One file dispatches three subcommands:
+
+```js
+export const needsSupabase = true;
+
+export async function runInitiativeCommand({ args, options, supabase, mapData, format }) {
+  const [sub] = args;
+  switch (sub) {
+    case "list":   return runList({ options, supabase, format });
+    case "show":   return runShow({ options, supabase, format });
+    case "impact": return runImpact({ options, supabase, mapData, format });
+    default:       throw new UsageError("initiative: expected `list`, `show`, or `impact`");
+  }
+}
+```
+
+- `list` → `listInitiatives(supabase, { managerEmail: options.manager })`.
+  Empty → `NO_INITIATIVES`. Table-missing error → same empty state.
+- `show` → requires `--id`. `getInitiative(supabase, options.id)`. Null →
+  `"No initiative found with id ${id}."` empty state.
+- `impact` → `getInitiativeImpact(supabase, { managerEmail: options.manager })`.
+  Renders per the spec's mocked output (§ Initiative impact, lines 510–541).
+  Initiatives with null `scorecard_id` render the "no driver linked" note.
+
+Catch `42P01` errors on the initiatives query and return `NO_INITIATIVES`,
+matching Part 04's pattern for `NO_COMMENTS`.
+
+### Formatter
+
+`initiative.js` formatter renders the spec § Initiative impact output
+exactly: initiative name, target driver id, before/after percentile, delta,
+and any engineer voice quote (deferred — engineer voice is Part 04's
+concern; initiatives formatter only renders voice if the view object has a
+`voice` field, which Part 06 polish can add later).
+
+## Tests
+
+- `transform-getdx-initiatives.test.js` — feeds mocked
+  `getdx/initiatives-list/<ts>.json` into `transformInitiatives`, asserts
+  upsert payload, including `completed_at` fallback logic.
+- `query-initiatives.test.js` — stubs Supabase query builder, verifies
+  filter chaining for `listInitiatives`, `getInitiative`, and especially
+  `getInitiativeImpact` (before/after snapshot selection, delta calculation,
+  handling of unlinked initiatives).
+- `initiative.test.js`:
+  - `list` with and without `--manager`.
+  - `show` with valid and invalid `--id`.
+  - `impact` with a completed initiative that has scorecard alignment (real
+    delta), a completed initiative without alignment (null delta), and an
+    in-progress initiative (skipped in impact view).
+  - `NO_INITIATIVES` empty state for the three subcommands.
+
+## Verification
+
+1. `just migrate` — migration applies cleanly.
+2. `fit-map getdx sync` — new extract stores initiatives document.
+3. `fit-map activity transform` — new transform step populates the table.
+4. `bun test products/map/test/activity` — new tests green.
+5. `bun test products/landmark/test` — new tests green.
+6. `bun run check` — lint, format, layout, exports.
+7. Smoke tests:
+   - `bunx fit-landmark initiative list --manager alice@example.com`
+   - `bunx fit-landmark initiative show --id <id>`
+   - `bunx fit-landmark initiative impact --manager alice@example.com`
+
+## Risks
+
+- **GetDX Initiatives API shape is the primary unknown.** Same mitigation
+  as Part 04: the extract stores raw payload; the transform is the only
+  layer that parses. Patch the transform if the shape differs.
+- **Before/after snapshot selection is sensitive to `completed_at` fidelity.**
+  If GetDX does not supply a completion timestamp, the fallback (first
+  snapshot at 100%) is imperfect — it may delay the "before" marker by up
+  to one quarter. Document this limitation in the formatter output when the
+  fallback path is used.
+- **`scorecard_id === driver.id` join assumes parity.** Real installations
+  may need an explicit mapping layer. This part does not build one; Part 06
+  documents the assumption.
+
+## Deliverable
+
+A merged PR that ships `fit-landmark initiative list|show|impact` and the
+supporting Map pipeline. Spec § Initiative tracking and § Initiative impact
+are fully implemented except for the optional health-view integration,
+which is tracked as a Part 06 polish item.

--- a/specs/080-landmark-product/plan-a-06.md
+++ b/specs/080-landmark-product/plan-a-06.md
@@ -4,13 +4,13 @@ Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
 Parts 01–05 being merged (needs the final command surface to document
 accurately).
 
-This part is the documentation and polish pass. It covers the website,
-internal architecture docs, the published Claude skill for external users,
-root-level doc updates, and the optional polish item deferred from Part 05
-(surfacing active initiatives inside the health view).
+This part is the documentation and polish pass. It covers the website, internal
+architecture docs, the published Claude skill for external users, root-level doc
+updates, and the optional polish item deferred from Part 05 (surfacing active
+initiatives inside the health view).
 
-**Route to `technical-writer`** — no code changes beyond optional polish
-items listed at the end.
+**Route to `technical-writer`** — no code changes beyond optional polish items
+listed at the end.
 
 ## Scope
 
@@ -18,21 +18,20 @@ items listed at the end.
 
 - Flesh out `website/landmark/index.md` with content describing the final
   command surface and the audience model.
-- Create `website/docs/internals/landmark/index.md` covering architecture,
-  join contracts, and the Summit import pattern.
-- Create `.claude/skills/fit-landmark/SKILL.md` — the published skill that
-  helps external users understand how Landmark _works_ (not how it is
-  implemented).
-- Update `CLAUDE.md` if the Landmark entry needs adjustment (the current
-  entry is a placeholder — replace with the canonical product summary
-  linking to the new overview and internals pages).
+- Create `website/docs/internals/landmark/index.md` covering architecture, join
+  contracts, and the Summit import pattern.
+- Create `.claude/skills/fit-landmark/SKILL.md` — the published skill that helps
+  external users understand how Landmark _works_ (not how it is implemented).
+- Update `CLAUDE.md` if the Landmark entry needs adjustment (the current entry
+  is a placeholder — replace with the canonical product summary linking to the
+  new overview and internals pages).
 - Add Landmark to `website/docs/getting-started/` content where relevant
   (install, first run, authoring markers).
 - Author the "Landmark quickstart" guide referenced in spec § Starter Data
   Philosophy at `website/docs/guides/landmark-quickstart/index.md`.
-- Update `specs/STATUS` to advance `080` from `draft` to `done` once all
-  code parts and this docs part merge. (This step is a reviewer action,
-  not an implementation step — documented here for continuity.)
+- Update `specs/STATUS` to advance `080` from `draft` to `done` once all code
+  parts and this docs part merge. (This step is a reviewer action, not an
+  implementation step — documented here for continuity.)
 
 **Out of scope**
 
@@ -57,20 +56,18 @@ website/docs/guides/landmark-quickstart/
 
 ### Modified
 
-- `website/landmark/index.md` — replace the stub content with the full
-  overview derived from the spec. Keep the YAML front matter (layout:
-  product, hero config) and rewrite the body.
-- `CLAUDE.md` — confirm the Landmark entry under `## Products` matches the
-  final product surface and links to the new overview and internals pages.
-  Adjust wording only where the current placeholder text is inaccurate.
-- `website/docs/getting-started/engineers/` — add a short section that
-  explains `fit-landmark evidence`, `readiness`, and `timeline` for
-  individual use.
+- `website/landmark/index.md` — replace the stub content with the full overview
+  derived from the spec. Keep the YAML front matter (layout: product, hero
+  config) and rewrite the body.
+- `CLAUDE.md` — confirm the Landmark entry under `## Products` matches the final
+  product surface and links to the new overview and internals pages. Adjust
+  wording only where the current placeholder text is inaccurate.
+- `website/docs/getting-started/engineers/` — add a short section that explains
+  `fit-landmark evidence`, `readiness`, and `timeline` for individual use.
 - `website/docs/getting-started/leadership/` — add a short section on
-  `fit-landmark health` and `voice`, with a note about authoring drivers
-  and markers before expecting rich output.
-- `specs/STATUS` — advance spec 080 to `done` (reviewer step, performed
-  last).
+  `fit-landmark health` and `voice`, with a note about authoring drivers and
+  markers before expecting rich output.
+- `specs/STATUS` — advance spec 080 to `done` (reviewer step, performed last).
 
 ## Implementation details
 
@@ -79,40 +76,40 @@ website/docs/guides/landmark-quickstart/
 Replace the stub body with content covering:
 
 - What Landmark is (1 paragraph, lifted from spec § Why).
-- The audience model table (from spec § Audience Model — copy verbatim, it
-  is already reader-facing).
-- The final command list by group (organization, snapshot, evidence,
-  health, voice, initiative). Short description per command.
+- The audience model table (from spec § Audience Model — copy verbatim, it is
+  already reader-facing).
+- The final command list by group (organization, snapshot, evidence, health,
+  voice, initiative). Short description per command.
 - The "works without Summit / richer with Summit" framing for health.
-- Prereqs: GetDX account, Map with activity schema migrated, framework data
-  with drivers and markers authored.
+- Prereqs: GetDX account, Map with activity schema migrated, framework data with
+  drivers and markers authored.
 - CTAs: link to the quickstart guide and the authoring guide.
 
-Use `npm` and `npx` exclusively in any command snippets in this file — it
-is an external-facing page (per CLAUDE.md's documentation rule).
+Use `npm` and `npx` exclusively in any command snippets in this file — it is an
+external-facing page (per CLAUDE.md's documentation rule).
 
 ### `website/docs/internals/landmark/index.md`
 
 New page covering:
 
 - Package layout (spec 390) and how it mirrors Summit.
-- Data contracts with Map: which queries Landmark consumes, and the
-  subpath import paths.
+- Data contracts with Map: which queries Landmark consumes, and the subpath
+  import paths.
 - The Summit import pattern (`src/lib/summit.js`) and the graceful-degrade
   rationale, including the `GrowthContractError` warning path.
 - The `item_id ↔ driver.id` (and `scorecard_id ↔ driver.id` for initiatives)
-  join contract — call this out as the single most important framework
-  authoring constraint.
+  join contract — call this out as the single most important framework authoring
+  constraint.
 - The comment and initiative pipelines (ELT flow).
 - Testing strategy: stub query pattern, fixture conventions, anchor-comment
   contract for cross-part edits to `health.js` and `formatters/health.js`.
 - Audience model enforcement — which commands apply which privacy rules.
 - **Behaviour rendering — explicit non-goal.** Drivers may declare
-  `contributingBehaviours`, but Landmark does not render behaviour evidence
-  in the health view for spec 080. Rationale: behaviours are maturity
-  profiles (derived from discipline + level + track), not artifact-level
-  markers, and the spec's § Health view mock-up shows skills only. Track as
-  a follow-up if a user asks.
+  `contributingBehaviours`, but Landmark does not render behaviour evidence in
+  the health view for spec 080. Rationale: behaviours are maturity profiles
+  (derived from discipline + level + track), not artifact-level markers, and the
+  spec's § Health view mock-up shows skills only. Track as a follow-up if a user
+  asks.
 
 This page uses internal contributor conventions — `bun`, `bunx`, `just` —
 because it lives under `website/docs/internals/`.
@@ -156,8 +153,8 @@ readiness, timeline, coverage, practiced, health, voice, initiative>
  - "Did the initiative we ran actually help?" → initiative impact>
 ```
 
-Keep the skill short and external-user-friendly. It should answer "what
-does Landmark _do_?", not "how was Landmark built?".
+Keep the skill short and external-user-friendly. It should answer "what does
+Landmark _do_?", not "how was Landmark built?".
 
 ### `website/docs/guides/landmark-quickstart/index.md`
 
@@ -166,9 +163,10 @@ Walk an external user from zero to a useful `health` view:
 1. Install: `npm install -g @forwardimpact/landmark`.
 2. Install Map and generate codegen: `npx fit-codegen --all`.
 3. Run Map's activity schema migration: `npx fit-map activity migrate`.
-4. Configure GetDX credentials (`MAP_SUPABASE_URL`, `MAP_SUPABASE_SERVICE_ROLE_KEY`).
-5. Sync GetDX data: `npx fit-map getdx sync` then `npx fit-map activity
-   transform`.
+4. Configure GetDX credentials (`MAP_SUPABASE_URL`,
+   `MAP_SUPABASE_SERVICE_ROLE_KEY`).
+5. Sync GetDX data: `npx fit-map getdx sync` then
+   `npx fit-map activity transform`.
 6. Author drivers and markers (link to the authoring guide).
 7. Run `npx fit-landmark health --manager alice@example.com`.
 
@@ -176,12 +174,12 @@ Keep the guide to one page. Link out for deeper topics.
 
 ### `CLAUDE.md` adjustments
 
-Read the existing Landmark entry in `## Products` and confirm it matches
-the final command surface. The current placeholder says "No LLM calls" and
-describes analysis plus GetDX/GitHub integration — this is still accurate.
-Update only the link targets to point at the new overview and internals
-pages. Do not restate content that already lives in the spec or on the
-website (CLAUDE.md's rule: reference, don't restate).
+Read the existing Landmark entry in `## Products` and confirm it matches the
+final command surface. The current placeholder says "No LLM calls" and describes
+analysis plus GetDX/GitHub integration — this is still accurate. Update only the
+link targets to point at the new overview and internals pages. Do not restate
+content that already lives in the spec or on the website (CLAUDE.md's rule:
+reference, don't restate).
 
 ### STATUS advancement
 
@@ -191,49 +189,46 @@ After all merges land, update `specs/STATUS`:
 080 done
 ```
 
-This is the reviewer action. Do not change it until Parts 01–06 are all
-merged and the spec-level DO-CONFIRM checklist (§ Verification below) is
-complete.
+This is the reviewer action. Do not change it until Parts 01–06 are all merged
+and the spec-level DO-CONFIRM checklist (§ Verification below) is complete.
 
 ## Optional polish (can split into separate small PRs)
 
-These small additive changes close the spec's last cosmetic gaps. Each can
-be landed standalone or bundled into this part. Unlike earlier plan
-revisions, the **"health shows active initiatives"** feature is no longer
-optional — it lives in Part 05 because spec § Initiative tracking
-mandates it.
+These small additive changes close the spec's last cosmetic gaps. Each can be
+landed standalone or bundled into this part. Unlike earlier plan revisions, the
+**"health shows active initiatives"** feature is no longer optional — it lives
+in Part 05 because spec § Initiative tracking mandates it.
 
 - **Initiative impact shows engineer voice.** Extend
-  `src/commands/initiative.js` `runImpact` to fetch two representative
-  comments for the "after" snapshot in the affected driver and render them
-  under the impact line (matching the spec's mock-up). Small diff; routed
-  to `staff-engineer` as a Part 06 sub-task.
+  `src/commands/initiative.js` `runImpact` to fetch two representative comments
+  for the "after" snapshot in the affected driver and render them under the
+  impact line (matching the spec's mock-up). Small diff; routed to
+  `staff-engineer` as a Part 06 sub-task.
 - **`fit-landmark --help` examples.** Expand the `examples:` array in
   `bin/fit-landmark.js` with one realistic invocation per command group.
 
-Each polish item has a corresponding test addition in the relevant
-`.test.js` file. Route these two items to `staff-engineer` separately from
-the main documentation pass, since they are code not docs. Part 06's
-primary routing is `technical-writer` for everything else in this file.
+Each polish item has a corresponding test addition in the relevant `.test.js`
+file. Route these two items to `staff-engineer` separately from the main
+documentation pass, since they are code not docs. Part 06's primary routing is
+`technical-writer` for everything else in this file.
 
 ## Verification
 
 1. `bun run check` — lint, format, layout, exports across the whole repo.
 2. `bunx fit-map validate` — still green.
 3. `bun test` repo-wide — green.
-4. Manual website preview (`bun run site:dev` or equivalent) — new pages
-   render, links resolve.
+4. Manual website preview (`bun run site:dev` or equivalent) — new pages render,
+   links resolve.
 5. `fit-landmark --help` — command list matches spec § CLI.
 6. External user simulation: in a fresh directory with only
    `@forwardimpact/landmark`, `@forwardimpact/map`, and `@forwardimpact/summit`
-   installed from npm, run through the quickstart guide. Any step that
-   fails in that clean context is a documentation bug.
+   installed from npm, run through the quickstart guide. Any step that fails in
+   that clean context is a documentation bug.
 7. Spec-level DO-CONFIRM: re-read spec § Scope and tick off every in-scope
-   bullet against an actual command. Anything missing blocks the status
-   advance.
+   bullet against an actual command. Anything missing blocks the status advance.
 
 ## Deliverable
 
 A merged PR that completes spec 080's documentation surface. `specs/STATUS`
-advances to `080 done`. Published skill lives under `.claude/skills/` and
-syncs to `forwardimpact/skills` on the next push to `main`.
+advances to `080 done`. Published skill lives under `.claude/skills/` and syncs
+to `forwardimpact/skills` on the next push to `main`.

--- a/specs/080-landmark-product/plan-a-06.md
+++ b/specs/080-landmark-product/plan-a-06.md
@@ -99,12 +99,20 @@ New page covering:
 - Data contracts with Map: which queries Landmark consumes, and the
   subpath import paths.
 - The Summit import pattern (`src/lib/summit.js`) and the graceful-degrade
-  rationale.
-- The `item_id ↔ driver.id` join contract — call this out as the single
-  most important framework authoring constraint.
+  rationale, including the `GrowthContractError` warning path.
+- The `item_id ↔ driver.id` (and `scorecard_id ↔ driver.id` for initiatives)
+  join contract — call this out as the single most important framework
+  authoring constraint.
 - The comment and initiative pipelines (ELT flow).
-- Testing strategy: stub query pattern, fixture conventions.
+- Testing strategy: stub query pattern, fixture conventions, anchor-comment
+  contract for cross-part edits to `health.js` and `formatters/health.js`.
 - Audience model enforcement — which commands apply which privacy rules.
+- **Behaviour rendering — explicit non-goal.** Drivers may declare
+  `contributingBehaviours`, but Landmark does not render behaviour evidence
+  in the health view for spec 080. Rationale: behaviours are maturity
+  profiles (derived from discipline + level + track), not artifact-level
+  markers, and the spec's § Health view mock-up shows skills only. Track as
+  a follow-up if a user asks.
 
 This page uses internal contributor conventions — `bun`, `bunx`, `just` —
 because it lives under `website/docs/internals/`.
@@ -189,24 +197,24 @@ complete.
 
 ## Optional polish (can split into separate small PRs)
 
-These are small additive changes that did not justify their own part file
-but close the spec's last gaps. Each can be landed standalone or bundled
-into this part:
+These small additive changes close the spec's last cosmetic gaps. Each can
+be landed standalone or bundled into this part. Unlike earlier plan
+revisions, the **"health shows active initiatives"** feature is no longer
+optional — it lives in Part 05 because spec § Initiative tracking
+mandates it.
 
-- **Health view shows active initiatives.** Extend
-  `src/commands/health.js` to also fetch `listInitiatives(supabase, {
-  managerEmail, status: "active" })` and render a one-line-per-initiative
-  block under each driver. Conditional on the initiatives table existing
-  (catch `42P01` → render without).
 - **Initiative impact shows engineer voice.** Extend
   `src/commands/initiative.js` `runImpact` to fetch two representative
   comments for the "after" snapshot in the affected driver and render them
-  under the impact line (matching the spec's mock-up).
+  under the impact line (matching the spec's mock-up). Small diff; routed
+  to `staff-engineer` as a Part 06 sub-task.
 - **`fit-landmark --help` examples.** Expand the `examples:` array in
   `bin/fit-landmark.js` with one realistic invocation per command group.
 
 Each polish item has a corresponding test addition in the relevant
-`.test.js` file.
+`.test.js` file. Route these two items to `staff-engineer` separately from
+the main documentation pass, since they are code not docs. Part 06's
+primary routing is `technical-writer` for everything else in this file.
 
 ## Verification
 

--- a/specs/080-landmark-product/plan-a-06.md
+++ b/specs/080-landmark-product/plan-a-06.md
@@ -1,0 +1,231 @@
+# Plan A · Part 06 — Documentation, published skill, and starter template
+
+Parent plan: [plan-a.md](./plan-a.md). Spec: [spec.md](./spec.md). Depends on
+Parts 01–05 being merged (needs the final command surface to document
+accurately).
+
+This part is the documentation and polish pass. It covers the website,
+internal architecture docs, the published Claude skill for external users,
+root-level doc updates, and the optional polish item deferred from Part 05
+(surfacing active initiatives inside the health view).
+
+**Route to `technical-writer`** — no code changes beyond optional polish
+items listed at the end.
+
+## Scope
+
+**In scope**
+
+- Flesh out `website/landmark/index.md` with content describing the final
+  command surface and the audience model.
+- Create `website/docs/internals/landmark/index.md` covering architecture,
+  join contracts, and the Summit import pattern.
+- Create `.claude/skills/fit-landmark/SKILL.md` — the published skill that
+  helps external users understand how Landmark _works_ (not how it is
+  implemented).
+- Update `CLAUDE.md` if the Landmark entry needs adjustment (the current
+  entry is a placeholder — replace with the canonical product summary
+  linking to the new overview and internals pages).
+- Add Landmark to `website/docs/getting-started/` content where relevant
+  (install, first run, authoring markers).
+- Author the "Landmark quickstart" guide referenced in spec § Starter Data
+  Philosophy at `website/docs/guides/landmark-quickstart/index.md`.
+- Update `specs/STATUS` to advance `080` from `draft` to `done` once all
+  code parts and this docs part merge. (This step is a reviewer action,
+  not an implementation step — documented here for continuity.)
+
+**Out of scope**
+
+- Any new command surface.
+- Any change to the generated website build pipeline.
+- Marketing copy beyond what the spec already defines.
+
+## Files
+
+### Created
+
+```
+website/docs/internals/landmark/
+  index.md
+
+website/docs/guides/landmark-quickstart/
+  index.md
+
+.claude/skills/fit-landmark/
+  SKILL.md
+```
+
+### Modified
+
+- `website/landmark/index.md` — replace the stub content with the full
+  overview derived from the spec. Keep the YAML front matter (layout:
+  product, hero config) and rewrite the body.
+- `CLAUDE.md` — confirm the Landmark entry under `## Products` matches the
+  final product surface and links to the new overview and internals pages.
+  Adjust wording only where the current placeholder text is inaccurate.
+- `website/docs/getting-started/engineers/` — add a short section that
+  explains `fit-landmark evidence`, `readiness`, and `timeline` for
+  individual use.
+- `website/docs/getting-started/leadership/` — add a short section on
+  `fit-landmark health` and `voice`, with a note about authoring drivers
+  and markers before expecting rich output.
+- `specs/STATUS` — advance spec 080 to `done` (reviewer step, performed
+  last).
+
+## Implementation details
+
+### `website/landmark/index.md` rewrite
+
+Replace the stub body with content covering:
+
+- What Landmark is (1 paragraph, lifted from spec § Why).
+- The audience model table (from spec § Audience Model — copy verbatim, it
+  is already reader-facing).
+- The final command list by group (organization, snapshot, evidence,
+  health, voice, initiative). Short description per command.
+- The "works without Summit / richer with Summit" framing for health.
+- Prereqs: GetDX account, Map with activity schema migrated, framework data
+  with drivers and markers authored.
+- CTAs: link to the quickstart guide and the authoring guide.
+
+Use `npm` and `npx` exclusively in any command snippets in this file — it
+is an external-facing page (per CLAUDE.md's documentation rule).
+
+### `website/docs/internals/landmark/index.md`
+
+New page covering:
+
+- Package layout (spec 390) and how it mirrors Summit.
+- Data contracts with Map: which queries Landmark consumes, and the
+  subpath import paths.
+- The Summit import pattern (`src/lib/summit.js`) and the graceful-degrade
+  rationale.
+- The `item_id ↔ driver.id` join contract — call this out as the single
+  most important framework authoring constraint.
+- The comment and initiative pipelines (ELT flow).
+- Testing strategy: stub query pattern, fixture conventions.
+- Audience model enforcement — which commands apply which privacy rules.
+
+This page uses internal contributor conventions — `bun`, `bunx`, `just` —
+because it lives under `website/docs/internals/`.
+
+### `.claude/skills/fit-landmark/SKILL.md`
+
+Published skill, follows the pattern of other `fit-*` skills under
+`.claude/skills/`. Structure:
+
+```markdown
+---
+name: fit-landmark
+description: >
+  Work with the @forwardimpact/landmark product. Use when analyzing
+  engineering-system signals, exploring GetDX snapshot trends, reading
+  marker evidence, checking promotion readiness, viewing team health
+  with growth recommendations, or surfacing engineer voice.
+---
+
+# Landmark
+
+<overview paragraph>
+
+## When to Use
+<bulleted list>
+
+## Commands
+<short description per command — org, snapshot, evidence, marker,
+readiness, timeline, coverage, practiced, health, voice, initiative>
+
+## Audience Model
+<reference to the per-view privacy rules>
+
+## Prereqs
+<GetDX, Map activity schema, authored markers/drivers>
+
+## Common Workflows
+<- "What should this engineer be evidenced at?" → readiness
+ - "How is this team doing?" → health
+ - "What are engineers blocked on?" → voice
+ - "Did the initiative we ran actually help?" → initiative impact>
+```
+
+Keep the skill short and external-user-friendly. It should answer "what
+does Landmark _do_?", not "how was Landmark built?".
+
+### `website/docs/guides/landmark-quickstart/index.md`
+
+Walk an external user from zero to a useful `health` view:
+
+1. Install: `npm install -g @forwardimpact/landmark`.
+2. Install Map and generate codegen: `npx fit-codegen --all`.
+3. Run Map's activity schema migration: `npx fit-map activity migrate`.
+4. Configure GetDX credentials (`MAP_SUPABASE_URL`, `MAP_SUPABASE_SERVICE_ROLE_KEY`).
+5. Sync GetDX data: `npx fit-map getdx sync` then `npx fit-map activity
+   transform`.
+6. Author drivers and markers (link to the authoring guide).
+7. Run `npx fit-landmark health --manager alice@example.com`.
+
+Keep the guide to one page. Link out for deeper topics.
+
+### `CLAUDE.md` adjustments
+
+Read the existing Landmark entry in `## Products` and confirm it matches
+the final command surface. The current placeholder says "No LLM calls" and
+describes analysis plus GetDX/GitHub integration — this is still accurate.
+Update only the link targets to point at the new overview and internals
+pages. Do not restate content that already lives in the spec or on the
+website (CLAUDE.md's rule: reference, don't restate).
+
+### STATUS advancement
+
+After all merges land, update `specs/STATUS`:
+
+```
+080 done
+```
+
+This is the reviewer action. Do not change it until Parts 01–06 are all
+merged and the spec-level DO-CONFIRM checklist (§ Verification below) is
+complete.
+
+## Optional polish (can split into separate small PRs)
+
+These are small additive changes that did not justify their own part file
+but close the spec's last gaps. Each can be landed standalone or bundled
+into this part:
+
+- **Health view shows active initiatives.** Extend
+  `src/commands/health.js` to also fetch `listInitiatives(supabase, {
+  managerEmail, status: "active" })` and render a one-line-per-initiative
+  block under each driver. Conditional on the initiatives table existing
+  (catch `42P01` → render without).
+- **Initiative impact shows engineer voice.** Extend
+  `src/commands/initiative.js` `runImpact` to fetch two representative
+  comments for the "after" snapshot in the affected driver and render them
+  under the impact line (matching the spec's mock-up).
+- **`fit-landmark --help` examples.** Expand the `examples:` array in
+  `bin/fit-landmark.js` with one realistic invocation per command group.
+
+Each polish item has a corresponding test addition in the relevant
+`.test.js` file.
+
+## Verification
+
+1. `bun run check` — lint, format, layout, exports across the whole repo.
+2. `bunx fit-map validate` — still green.
+3. `bun test` repo-wide — green.
+4. Manual website preview (`bun run site:dev` or equivalent) — new pages
+   render, links resolve.
+5. `fit-landmark --help` — command list matches spec § CLI.
+6. External user simulation: in a fresh directory with only
+   `@forwardimpact/landmark`, `@forwardimpact/map`, and `@forwardimpact/summit`
+   installed from npm, run through the quickstart guide. Any step that
+   fails in that clean context is a documentation bug.
+7. Spec-level DO-CONFIRM: re-read spec § Scope and tick off every in-scope
+   bullet against an actual command. Anything missing blocks the status
+   advance.
+
+## Deliverable
+
+A merged PR that completes spec 080's documentation surface. `specs/STATUS`
+advances to `080 done`. Published skill lives under `.claude/skills/` and
+syncs to `forwardimpact/skills` on the next push to `main`.

--- a/specs/080-landmark-product/plan-a.md
+++ b/specs/080-landmark-product/plan-a.md
@@ -20,9 +20,9 @@ already:
 The strategy is therefore: **scaffold Landmark as a near-twin of Summit**,
 reusing its CLI bootstrap pattern, Supabase factory, `resolveFormat` helper,
 formatter layout, and test harness. Anything that already works in Summit gets
-copied, not rediscovered. Divergence from Summit happens only where the
-products actually differ (Landmark's per-view audience model, its Map activity
-queries, its evidence-based views).
+copied, not rediscovered. Divergence from Summit happens only where the products
+actually differ (Landmark's per-view audience model, its Map activity queries,
+its evidence-based views).
 
 ### Key architectural decisions
 
@@ -32,39 +32,39 @@ queries, its evidence-based views).
    Shared helpers (`resolveDataDir`, `loadMapData`, `resolveFormat`,
    `createLandmarkClient`) live in `src/lib/`.
 
-2. **Summit is a declared dependency with optional runtime.** Spec 090 is
-   `done` and `@forwardimpact/summit` already exports `computeGrowthAlignment`
-   from the package root (synchronous function). Landmark lists Summit in its
-   `dependencies` so contributors and default npm installs always have it.
-   The spec still specifies a graceful-degrade path when Summit is missing,
-   so Landmark loads Summit through a dynamic `import()` wrapper and falls
-   back to a no-recommendations view if the module is absent. This resolves
-   the tension between "hard dep in the manifest" and "optional at runtime":
-   the manifest is truthful, the wrapper makes the spec's empty-state
-   enforceable in tests, and real users always get recommendations.
+2. **Summit is a declared dependency with optional runtime.** Spec 090 is `done`
+   and `@forwardimpact/summit` already exports `computeGrowthAlignment` from the
+   package root (synchronous function). Landmark lists Summit in its
+   `dependencies` so contributors and default npm installs always have it. The
+   spec still specifies a graceful-degrade path when Summit is missing, so
+   Landmark loads Summit through a dynamic `import()` wrapper and falls back to
+   a no-recommendations view if the module is absent. This resolves the tension
+   between "hard dep in the manifest" and "optional at runtime": the manifest is
+   truthful, the wrapper makes the spec's empty-state enforceable in tests, and
+   real users always get recommendations.
 
 3. **Supabase client is created lazily per command.** Commands that need
    activity data call `createLandmarkClient()` from `src/lib/supabase.js` (a
    thin clone of Summit's factory). Commands that only need framework data
    (`marker`) do not open a client at all.
 
-4. **Audience flags are per-command, not global.** Spec's audience model maps
-   to `--email` (engineer scope), `--manager` (manager/director scope). The
-   privacy rule (director aggregation vs manager specificity) is encoded per
-   command. No global `--audience` flag — command options are sufficient.
+4. **Audience flags are per-command, not global.** Spec's audience model maps to
+   `--email` (engineer scope), `--manager` (manager/director scope). The privacy
+   rule (director aggregation vs manager specificity) is encoded per command. No
+   global `--audience` flag — command options are sufficient.
 
 5. **Empty states are data, not exceptions.** Every command produces a
-   well-formed result object with a `meta.emptyState` string when a data
-   source is missing. Formatters render the empty-state message verbatim; JSON
-   output always includes the field. This keeps the "explain in terms the user
-   can act on" rule (spec line 571) enforceable in tests.
+   well-formed result object with a `meta.emptyState` string when a data source
+   is missing. Formatters render the empty-state message verbatim; JSON output
+   always includes the field. This keeps the "explain in terms the user can act
+   on" rule (spec line 571) enforceable in tests.
 
 6. **Markers are authored in starter data as part of this plan.** Part 02 adds
    marker definitions to `delivery.yaml` and `reliability.yaml`. Part 03 adds
-   additional drivers (`reliability`, `cognitive_load`) to `drivers.yaml` so
-   the starter demonstrates multi-driver `health` views. These changes are
-   scoped to the starter template and are independent from external
-   installations, which must still author their own markers and drivers.
+   additional drivers (`reliability`, `cognitive_load`) to `drivers.yaml` so the
+   starter demonstrates multi-driver `health` views. These changes are scoped to
+   the starter template and are independent from external installations, which
+   must still author their own markers and drivers.
 
 7. **New Map tables (`getdx_snapshot_comments`, `getdx_initiatives`) are
    authored here**, inside Parts 04 and 05. Those parts touch
@@ -94,19 +94,19 @@ True DAG:
   Parts 03 and 04 reuse.
 - **Part 03** depends on Part 02 (evidence helpers) and creates
   `src/commands/health.js`. Both Parts 04 and 05 later mutate this file.
-- **Part 04** depends on Part 03. It adds the comments pipeline, ships
-  `voice`, and adds a **comments section** to `health.js` and
-  `formatters/health.js` via a clearly-named hook point (`// <comments
-  section>` comment anchor) documented in Part 03.
+- **Part 04** depends on Part 03. It adds the comments pipeline, ships `voice`,
+  and adds a **comments section** to `health.js` and `formatters/health.js` via
+  a clearly-named hook point (`// <comments section>` comment anchor) documented
+  in Part 03.
 - **Part 05** depends on Part 03. It adds the initiatives pipeline, ships
   `initiative list|show|impact`, and adds an **initiatives section** to
-  `health.js` and `formatters/health.js` via a separate hook point (`//
-  <initiatives section>`). Part 05 is required (not polish) because spec
-  § Initiative tracking mandates the health-view integration.
+  `health.js` and `formatters/health.js` via a separate hook point
+  (`// <initiatives section>`). Part 05 is required (not polish) because spec §
+  Initiative tracking mandates the health-view integration.
 - **Parts 04 and 05 can run in parallel** after Part 03 lands, because they
   touch disjoint sections of the same files. Part 03 pre-places the two
-  hook-point comments so the two sequential edits are non-overlapping.
-  Part 06 waits for both.
+  hook-point comments so the two sequential edits are non-overlapping. Part 06
+  waits for both.
 - **Part 06** depends on Parts 01–05. Documentation only.
 
 ### Blast radius
@@ -127,35 +127,35 @@ True DAG:
 - `justfile` — add `landmark` target wrappers if present for other products
 - No changes to Map or existing products in Part 01.
 
-Parts 02–05 each list their own created/modified files in their part file.
-Part 06 touches `website/`, `.claude/skills/`, and root docs.
+Parts 02–05 each list their own created/modified files in their part file. Part
+06 touches `website/`, `.claude/skills/`, and root docs.
 
 ### Risks
 
-| Risk                                                                                                                        | Mitigation                                                                                                                                                                                                                 |
-| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `getdx_snapshot_team_scores.item_id` ↔ `drivers.yaml` id is an implicit contract                                            | Part 03 adds a validation step: when `health` runs, it cross-references the set of `item_id` values against loaded drivers and surfaces unknown items as a warning rather than silently dropping them.                    |
-| Starter data has only 2 levels (`J040`, `J060`), so `readiness` at Level II produces "no higher level defined"              | Spec already anticipates this (§ Promotion readiness). Part 02's test covers both paths: Level I → Level II checklist, Level II → empty-state.                                                                             |
-| `getEvidence({email})` joins via `github_artifacts.email` — confirms the join chain but assumes artifact rows exist         | Part 02 covers the empty-evidence case (no artifacts yet) by rendering the standard "No evidence data available" empty state. Test fixture uses an org_people row with no artifacts to prove the path.                    |
-| Summit's `computeGrowthAlignment` signature could change                                                                    | Part 03 pins a compatible `@forwardimpact/summit` minor version in `products/landmark/package.json` and asserts the expected output shape in a unit test. A breaking change in Summit will be caught by CI.               |
-| GetDX Initiatives API shape is unknown in advance (no existing code to copy)                                                | Part 05 defines the Initiatives API integration against a stub extract that stores raw responses. The migration + query can be written against the stub. Wiring the real endpoint is a one-line change once verified.    |
-| Adding markers to starter capabilities is a breaking change for downstream installations that have their own marker schema | Starter markers are additive — existing capabilities keep their `proficiencyDescriptions` and simply gain a `markers` field. Since nobody currently defines markers, this cannot conflict with external installations.   |
-| New Supabase migrations require coordinating with `just migrate`                                                            | Parts 04 and 05 use the Map migration conventions (single `.sql` file under `products/map/supabase/migrations/NNNN_*.sql`) and note the `just migrate` run step in their verification sections.                           |
-| Dynamic `import("@forwardimpact/summit")` in Part 03 needs a test path that simulates "Summit missing"                      | Part 03's test uses `mock.module` or a controlled wrapper function (`loadSummit()`) injected into the command handler so that unit tests can pass `() => null` to exercise the graceful path without touching node_modules. |
+| Risk                                                                                                                       | Mitigation                                                                                                                                                                                                                  |
+| -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getdx_snapshot_team_scores.item_id` ↔ `drivers.yaml` id is an implicit contract                                           | Part 03 adds a validation step: when `health` runs, it cross-references the set of `item_id` values against loaded drivers and surfaces unknown items as a warning rather than silently dropping them.                      |
+| Starter data has only 2 levels (`J040`, `J060`), so `readiness` at Level II produces "no higher level defined"             | Spec already anticipates this (§ Promotion readiness). Part 02's test covers both paths: Level I → Level II checklist, Level II → empty-state.                                                                              |
+| `getEvidence({email})` joins via `github_artifacts.email` — confirms the join chain but assumes artifact rows exist        | Part 02 covers the empty-evidence case (no artifacts yet) by rendering the standard "No evidence data available" empty state. Test fixture uses an org_people row with no artifacts to prove the path.                      |
+| Summit's `computeGrowthAlignment` signature could change                                                                   | Part 03 pins a compatible `@forwardimpact/summit` minor version in `products/landmark/package.json` and asserts the expected output shape in a unit test. A breaking change in Summit will be caught by CI.                 |
+| GetDX Initiatives API shape is unknown in advance (no existing code to copy)                                               | Part 05 defines the Initiatives API integration against a stub extract that stores raw responses. The migration + query can be written against the stub. Wiring the real endpoint is a one-line change once verified.       |
+| Adding markers to starter capabilities is a breaking change for downstream installations that have their own marker schema | Starter markers are additive — existing capabilities keep their `proficiencyDescriptions` and simply gain a `markers` field. Since nobody currently defines markers, this cannot conflict with external installations.      |
+| New Supabase migrations require coordinating with `just migrate`                                                           | Parts 04 and 05 use the Map migration conventions (single `.sql` file under `products/map/supabase/migrations/NNNN_*.sql`) and note the `just migrate` run step in their verification sections.                             |
+| Dynamic `import("@forwardimpact/summit")` in Part 03 needs a test path that simulates "Summit missing"                     | Part 03's test uses `mock.module` or a controlled wrapper function (`loadSummit()`) injected into the command handler so that unit tests can pass `() => null` to exercise the graceful path without touching node_modules. |
 
 ### Execution
 
 Route every part to **`staff-engineer`** except Part 06, which goes to
 **`technical-writer`**. Plan execution is:
 
-1. **Part 01** runs first in isolation (staff-engineer). Merge before
-   starting any other part.
+1. **Part 01** runs first in isolation (staff-engineer). Merge before starting
+   any other part.
 2. **Part 02** runs after Part 01 merges (staff-engineer). Its
    `evidence-helpers.js` is reused by Parts 03 and 04 so it must land first.
 3. **Part 03** runs after Part 02 merges (staff-engineer). Part 03 creates
    `src/commands/health.js` and pre-places two anchor comments
-   (`// <comments section>`, `// <initiatives section>`) so Parts 04 and 05
-   can edit disjoint regions of the file without merge conflicts.
+   (`// <comments section>`, `// <initiatives section>`) so Parts 04 and 05 can
+   edit disjoint regions of the file without merge conflicts.
 4. **Parts 04 and 05 run in parallel** (two concurrent staff-engineer
    sub-agents) after Part 03 merges. They touch disjoint sections of
    `health.js`/`formatters/health.js`, disjoint query modules in Map, and
@@ -174,40 +174,39 @@ All parts follow these shared conventions so they compose cleanly:
   formatters at `products/landmark/src/formatters/<name>.js`. One file per
   top-level command (`org`, `snapshot`, `evidence`, `health`, etc.). Subcommands
   (`snapshot list` vs `snapshot show`) dispatch inside the command file.
-- **Command handler signature:** `async function run<Name>Command({ data, args,
-  options, supabase, mapData })`, matching Summit's shape. `supabase` is
-  `null` when the command did not open a client. `mapData` is the result of
-  `loadMapData(dataDir)`.
+- **Command handler signature:**
+  `async function run<Name>Command({ data, args, options, supabase, mapData })`,
+  matching Summit's shape. `supabase` is `null` when the command did not open a
+  client. `mapData` is the result of `loadMapData(dataDir)`.
 - **Return shape:** every handler returns `{ view, meta }` where `view` is the
   command-specific data object and `meta` is `{ format, emptyState, warnings }`.
   The dispatcher in `bin/fit-landmark.js` passes this to the appropriate
   formatter.
 - **Tests:** Node's built-in `node:test` and `node:assert`, mirroring Pathway
-  and Summit. Test files at `products/landmark/test/<name>.test.js`. Use
-  fixture objects for Map data and a stub Supabase client that returns seeded
-  results; no real network calls.
-- **Lint & format:** run `bun run check` inside `products/landmark/` after
-  each part.
+  and Summit. Test files at `products/landmark/test/<name>.test.js`. Use fixture
+  objects for Map data and a stub Supabase client that returns seeded results;
+  no real network calls.
+- **Lint & format:** run `bun run check` inside `products/landmark/` after each
+  part.
 
 ## Part Index
 
-1. **[Part 01 — Scaffolding + foundational views](./plan-a-01.md)** — Create
-   the `@forwardimpact/landmark` package, wire `fit-landmark` through libcli,
-   ship `org`, `snapshot`, and `marker` commands that depend only on
-   already-existing Map infrastructure.
-2. **[Part 02 — Evidence-based views + starter markers](./plan-a-02.md)** —
-   Add marker definitions to starter `delivery.yaml` and `reliability.yaml`,
-   ship `evidence`, `readiness`, `timeline`, `coverage`, and `practiced`
-   commands reading Map's existing evidence query module.
+1. **[Part 01 — Scaffolding + foundational views](./plan-a-01.md)** — Create the
+   `@forwardimpact/landmark` package, wire `fit-landmark` through libcli, ship
+   `org`, `snapshot`, and `marker` commands that depend only on already-existing
+   Map infrastructure.
+2. **[Part 02 — Evidence-based views + starter markers](./plan-a-02.md)** — Add
+   marker definitions to starter `delivery.yaml` and `reliability.yaml`, ship
+   `evidence`, `readiness`, `timeline`, `coverage`, and `practiced` commands
+   reading Map's existing evidence query module.
 3. **[Part 03 — Health view + drivers expansion](./plan-a-03.md)** — Expand
    `drivers.yaml` to demonstrate multi-driver views, ship the `health` command
    joining snapshot scores, evidence counts, and Summit growth recommendations
    inline.
 4. **[Part 04 — Snapshot comments pipeline + voice](./plan-a-04.md)** — Add
-   `activity.getdx_snapshot_comments` migration, extend Map's GetDX extract
-   with `snapshots.comments.list`, add the transform step and the new query
-   module, ship `fit-landmark voice` with both `--manager` and `--email`
-   modes.
+   `activity.getdx_snapshot_comments` migration, extend Map's GetDX extract with
+   `snapshots.comments.list`, add the transform step and the new query module,
+   ship `fit-landmark voice` with both `--manager` and `--email` modes.
 5. **[Part 05 — Initiatives pipeline + initiative commands](./plan-a-05.md)** —
    Add `activity.getdx_initiatives` migration, extend Map's GetDX extract with
    Initiatives API, add the transform step and new query module, ship

--- a/specs/080-landmark-product/plan-a.md
+++ b/specs/080-landmark-product/plan-a.md
@@ -1,0 +1,206 @@
+# Plan A — Landmark Product
+
+Implementation plan for [spec.md](./spec.md) (spec 080).
+
+## Approach
+
+Landmark is a read-only CLI analysis layer over Map's activity schema. It has
+one very close sibling in the repo — **Summit** (`products/summit/`) — which
+already:
+
+- Uses the same `libcli` + `--format text|json|markdown` conventions Landmark
+  needs.
+- Imports Map's pure loader (`createDataLoader`) and activity queries under the
+  same subpath aliases Landmark will consume.
+- Ships a Supabase client factory (`src/lib/supabase.js`) that mirrors Map's
+  env-var contract and handles graceful unavailability.
+- Exports `computeGrowthAlignment` — the function Landmark's `health` view
+  imports directly.
+
+The strategy is therefore: **scaffold Landmark as a near-twin of Summit**,
+reusing its CLI bootstrap pattern, Supabase factory, `resolveFormat` helper,
+formatter layout, and test harness. Anything that already works in Summit gets
+copied, not rediscovered. Divergence from Summit happens only where the
+products actually differ (Landmark's per-view audience model, its Map activity
+queries, its evidence-based views).
+
+### Key architectural decisions
+
+1. **Mirror Summit's package layout.** `products/landmark/{bin,src,test}` with
+   `src/{commands,formatters,lib}`. Commands live under `src/commands/<name>.js`
+   and are dispatched from `bin/fit-landmark.js` through `libcli.createCli`.
+   Shared helpers (`resolveDataDir`, `loadMapData`, `resolveFormat`,
+   `createLandmarkClient`) live in `src/lib/`.
+
+2. **Summit is a hard dependency, not optional.** Spec 090 is `done` and
+   `@forwardimpact/summit` already exports `computeGrowthAlignment` from the
+   package root. Landmark lists Summit in its `dependencies` and imports it
+   directly. The spec's "Summit not installed" empty-state remains relevant
+   only for hypothetical external users who strip Summit from their install —
+   handled via a dynamic `import()` guarded by a try/catch in the health
+   command, with the catch path rendering the graceful-degraded output.
+
+3. **Supabase client is created lazily per command.** Commands that need
+   activity data call `createLandmarkClient()` from `src/lib/supabase.js` (a
+   thin clone of Summit's factory). Commands that only need framework data
+   (`marker`) do not open a client at all.
+
+4. **Audience flags are per-command, not global.** Spec's audience model maps
+   to `--email` (engineer scope), `--manager` (manager/director scope). The
+   privacy rule (director aggregation vs manager specificity) is encoded per
+   command. No global `--audience` flag — command options are sufficient.
+
+5. **Empty states are data, not exceptions.** Every command produces a
+   well-formed result object with a `meta.emptyState` string when a data
+   source is missing. Formatters render the empty-state message verbatim; JSON
+   output always includes the field. This keeps the "explain in terms the user
+   can act on" rule (spec line 571) enforceable in tests.
+
+6. **Markers are authored in starter data as part of this plan.** Part 02 adds
+   marker definitions to `delivery.yaml` and `reliability.yaml`. Part 03 adds
+   additional drivers (`reliability`, `cognitive_load`) to `drivers.yaml` so
+   the starter demonstrates multi-driver `health` views. These changes are
+   scoped to the starter template and are independent from external
+   installations, which must still author their own markers and drivers.
+
+7. **New Map tables (`getdx_snapshot_comments`, `getdx_initiatives`) are
+   authored here**, inside Parts 04 and 05. Those parts touch
+   `products/map/supabase/` to extend the extract/transform pipeline, add
+   migrations, export new query modules, and wire them through
+   `products/map/package.json`. Landmark consumes the new queries in the same
+   part to keep each feature end-to-end verifiable.
+
+### Dependency graph
+
+```
+┌──────────────────────────────┐
+│ Part 01 — Scaffolding +      │   foundation
+│  org, snapshot, marker       │
+└──────┬───────────────────────┘
+       │
+       ├──→ Part 02 — Evidence views + starter markers
+       │        (evidence, readiness, timeline, coverage, practiced)
+       │
+       ├──→ Part 03 — Health view + drivers expansion
+       │        (depends on Part 02 for evidence query wiring)
+       │
+       ├──→ Part 04 — Map snapshot comments + voice
+       │        (independent of Parts 02/03 on the Map side; the voice
+       │         command reuses Part 01's CLI plumbing only)
+       │
+       ├──→ Part 05 — Map initiatives + initiative commands
+       │        (independent of Part 04)
+       │
+       └──→ Part 06 — Documentation + published skill
+                (depends on Parts 01-05 being merged)
+```
+
+Parts 02 and 03 are strictly sequential (Part 03's `health` view reuses
+evidence query helpers written in Part 02). Parts 04 and 05 are independent
+of each other and of Parts 02/03 — they can run in parallel after Part 01
+lands. Part 06 is the last step.
+
+### Blast radius
+
+**Created (Part 01 baseline):**
+
+- `products/landmark/package.json`
+- `products/landmark/bin/fit-landmark.js`
+- `products/landmark/src/index.js`
+- `products/landmark/src/lib/{cli,supabase,context,empty-state}.js`
+- `products/landmark/src/commands/{org,snapshot,marker}.js`
+- `products/landmark/src/formatters/{index,org,snapshot,marker,shared}.js`
+- `products/landmark/test/*.test.js`
+
+**Modified (Part 01):**
+
+- `package.json` (root) — add `products/landmark` to workspaces array
+- `justfile` — add `landmark` target wrappers if present for other products
+- No changes to Map or existing products in Part 01.
+
+Parts 02–05 each list their own created/modified files in their part file.
+Part 06 touches `website/`, `.claude/skills/`, and root docs.
+
+### Risks
+
+| Risk                                                                                                                        | Mitigation                                                                                                                                                                                                                 |
+| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getdx_snapshot_team_scores.item_id` ↔ `drivers.yaml` id is an implicit contract                                            | Part 03 adds a validation step: when `health` runs, it cross-references the set of `item_id` values against loaded drivers and surfaces unknown items as a warning rather than silently dropping them.                    |
+| Starter data has only 2 levels (`J040`, `J060`), so `readiness` at Level II produces "no higher level defined"              | Spec already anticipates this (§ Promotion readiness). Part 02's test covers both paths: Level I → Level II checklist, Level II → empty-state.                                                                             |
+| `getEvidence({email})` joins via `github_artifacts.email` — confirms the join chain but assumes artifact rows exist         | Part 02 covers the empty-evidence case (no artifacts yet) by rendering the standard "No evidence data available" empty state. Test fixture uses an org_people row with no artifacts to prove the path.                    |
+| Summit's `computeGrowthAlignment` signature could change                                                                    | Part 03 pins a compatible `@forwardimpact/summit` minor version in `products/landmark/package.json` and asserts the expected output shape in a unit test. A breaking change in Summit will be caught by CI.               |
+| GetDX Initiatives API shape is unknown in advance (no existing code to copy)                                                | Part 05 defines the Initiatives API integration against a stub extract that stores raw responses. The migration + query can be written against the stub. Wiring the real endpoint is a one-line change once verified.    |
+| Adding markers to starter capabilities is a breaking change for downstream installations that have their own marker schema | Starter markers are additive — existing capabilities keep their `proficiencyDescriptions` and simply gain a `markers` field. Since nobody currently defines markers, this cannot conflict with external installations.   |
+| New Supabase migrations require coordinating with `just migrate`                                                            | Parts 04 and 05 use the Map migration conventions (single `.sql` file under `products/map/supabase/migrations/NNNN_*.sql`) and note the `just migrate` run step in their verification sections.                           |
+| Dynamic `import("@forwardimpact/summit")` in Part 03 needs a test path that simulates "Summit missing"                      | Part 03's test uses `mock.module` or a controlled wrapper function (`loadSummit()`) injected into the command handler so that unit tests can pass `() => null` to exercise the graceful path without touching node_modules. |
+
+### Execution
+
+Route every part to **`staff-engineer`** except Part 06, which goes to
+**`technical-writer`**. Plan execution is:
+
+1. **Part 01** runs first in isolation. It creates the package and lands
+   nothing else. Merge before starting any other part.
+2. After Part 01 merges, launch **Parts 02, 04, and 05 in parallel** as three
+   concurrent staff-engineer sub-agents. They touch disjoint files (Part 02
+   only inside `products/landmark/` + starter markers; Parts 04/05 touch Map's
+   Supabase layer and the Landmark command files they own).
+3. **Part 03** waits for Part 02 to merge (it reuses Part 02's evidence
+   helper). Launch after Part 02 lands.
+4. **Part 06** runs after all code parts are merged — it needs the final
+   command surface to write accurate documentation.
+
+Each part includes its own verification steps (tests, CI, smoke test). Do not
+chain parts past a failing verification.
+
+### Cross-part conventions
+
+All parts follow these shared conventions so they compose cleanly:
+
+- **File naming:** commands at `products/landmark/src/commands/<name>.js`,
+  formatters at `products/landmark/src/formatters/<name>.js`. One file per
+  top-level command (`org`, `snapshot`, `evidence`, `health`, etc.). Subcommands
+  (`snapshot list` vs `snapshot show`) dispatch inside the command file.
+- **Command handler signature:** `async function run<Name>Command({ data, args,
+  options, supabase, mapData })`, matching Summit's shape. `supabase` is
+  `null` when the command did not open a client. `mapData` is the result of
+  `loadMapData(dataDir)`.
+- **Return shape:** every handler returns `{ view, meta }` where `view` is the
+  command-specific data object and `meta` is `{ format, emptyState, warnings }`.
+  The dispatcher in `bin/fit-landmark.js` passes this to the appropriate
+  formatter.
+- **Tests:** Node's built-in `node:test` and `node:assert`, mirroring Pathway
+  and Summit. Test files at `products/landmark/test/<name>.test.js`. Use
+  fixture objects for Map data and a stub Supabase client that returns seeded
+  results; no real network calls.
+- **Lint & format:** run `bun run check` inside `products/landmark/` after
+  each part.
+
+## Part Index
+
+1. **[Part 01 — Scaffolding + foundational views](./plan-a-01.md)** — Create
+   the `@forwardimpact/landmark` package, wire `fit-landmark` through libcli,
+   ship `org`, `snapshot`, and `marker` commands that depend only on
+   already-existing Map infrastructure.
+2. **[Part 02 — Evidence-based views + starter markers](./plan-a-02.md)** —
+   Add marker definitions to starter `delivery.yaml` and `reliability.yaml`,
+   ship `evidence`, `readiness`, `timeline`, `coverage`, and `practiced`
+   commands reading Map's existing evidence query module.
+3. **[Part 03 — Health view + drivers expansion](./plan-a-03.md)** — Expand
+   `drivers.yaml` to demonstrate multi-driver views, ship the `health` command
+   joining snapshot scores, evidence counts, and Summit growth recommendations
+   inline.
+4. **[Part 04 — Snapshot comments pipeline + voice](./plan-a-04.md)** — Add
+   `activity.getdx_snapshot_comments` migration, extend Map's GetDX extract
+   with `snapshots.comments.list`, add the transform step and the new query
+   module, ship `fit-landmark voice` with both `--manager` and `--email`
+   modes.
+5. **[Part 05 — Initiatives pipeline + initiative commands](./plan-a-05.md)** —
+   Add `activity.getdx_initiatives` migration, extend Map's GetDX extract with
+   Initiatives API, add the transform step and new query module, ship
+   `fit-landmark initiative list|show|impact`, including the before/after
+   snapshot score delta computation.
+6. **[Part 06 — Documentation, skill, and starter template](./plan-a-06.md)** —
+   Update `website/landmark/index.md`, add `website/docs/internals/landmark/`,
+   ship `.claude/skills/fit-landmark/SKILL.md` (published skill for external
+   users), update `CLAUDE.md` if needed, and refresh the spec 080 STATUS entry.

--- a/specs/080-landmark-product/plan-a.md
+++ b/specs/080-landmark-product/plan-a.md
@@ -32,13 +32,16 @@ queries, its evidence-based views).
    Shared helpers (`resolveDataDir`, `loadMapData`, `resolveFormat`,
    `createLandmarkClient`) live in `src/lib/`.
 
-2. **Summit is a hard dependency, not optional.** Spec 090 is `done` and
-   `@forwardimpact/summit` already exports `computeGrowthAlignment` from the
-   package root. Landmark lists Summit in its `dependencies` and imports it
-   directly. The spec's "Summit not installed" empty-state remains relevant
-   only for hypothetical external users who strip Summit from their install —
-   handled via a dynamic `import()` guarded by a try/catch in the health
-   command, with the catch path rendering the graceful-degraded output.
+2. **Summit is a declared dependency with optional runtime.** Spec 090 is
+   `done` and `@forwardimpact/summit` already exports `computeGrowthAlignment`
+   from the package root (synchronous function). Landmark lists Summit in its
+   `dependencies` so contributors and default npm installs always have it.
+   The spec still specifies a graceful-degrade path when Summit is missing,
+   so Landmark loads Summit through a dynamic `import()` wrapper and falls
+   back to a no-recommendations view if the module is absent. This resolves
+   the tension between "hard dep in the manifest" and "optional at runtime":
+   the manifest is truthful, the wrapper makes the spec's empty-state
+   enforceable in tests, and real users always get recommendations.
 
 3. **Supabase client is created lazily per command.** Commands that need
    activity data call `createLandmarkClient()` from `src/lib/supabase.js` (a
@@ -73,32 +76,38 @@ queries, its evidence-based views).
 ### Dependency graph
 
 ```
-┌──────────────────────────────┐
-│ Part 01 — Scaffolding +      │   foundation
-│  org, snapshot, marker       │
-└──────┬───────────────────────┘
-       │
-       ├──→ Part 02 — Evidence views + starter markers
-       │        (evidence, readiness, timeline, coverage, practiced)
-       │
-       ├──→ Part 03 — Health view + drivers expansion
-       │        (depends on Part 02 for evidence query wiring)
-       │
-       ├──→ Part 04 — Map snapshot comments + voice
-       │        (independent of Parts 02/03 on the Map side; the voice
-       │         command reuses Part 01's CLI plumbing only)
-       │
-       ├──→ Part 05 — Map initiatives + initiative commands
-       │        (independent of Part 04)
-       │
-       └──→ Part 06 — Documentation + published skill
-                (depends on Parts 01-05 being merged)
+Part 01 ─────────────┬──→ Part 02 ──→ Part 03 ──┬──→ Part 04 ──┐
+(scaffolding)        │   (evidence    (health)  │   (comments  │
+                     │    helpers)              │    + voice)  │
+                     │                          │              ├──→ Part 06
+                     └──→ Part 05 ──────────────┘              │    (docs)
+                         (initiatives)                         │
+                                                               │
+                         Part 05 also joins  ─────────────────┘
+                         before Part 06
 ```
 
-Parts 02 and 03 are strictly sequential (Part 03's `health` view reuses
-evidence query helpers written in Part 02). Parts 04 and 05 are independent
-of each other and of Parts 02/03 — they can run in parallel after Part 01
-lands. Part 06 is the last step.
+True DAG:
+
+- **Part 01** is the strict prerequisite for everything.
+- **Part 02** depends on Part 01. It introduces `evidence-helpers.js` which
+  Parts 03 and 04 reuse.
+- **Part 03** depends on Part 02 (evidence helpers) and creates
+  `src/commands/health.js`. Both Parts 04 and 05 later mutate this file.
+- **Part 04** depends on Part 03. It adds the comments pipeline, ships
+  `voice`, and adds a **comments section** to `health.js` and
+  `formatters/health.js` via a clearly-named hook point (`// <comments
+  section>` comment anchor) documented in Part 03.
+- **Part 05** depends on Part 03. It adds the initiatives pipeline, ships
+  `initiative list|show|impact`, and adds an **initiatives section** to
+  `health.js` and `formatters/health.js` via a separate hook point (`//
+  <initiatives section>`). Part 05 is required (not polish) because spec
+  § Initiative tracking mandates the health-view integration.
+- **Parts 04 and 05 can run in parallel** after Part 03 lands, because they
+  touch disjoint sections of the same files. Part 03 pre-places the two
+  hook-point comments so the two sequential edits are non-overlapping.
+  Part 06 waits for both.
+- **Part 06** depends on Parts 01–05. Documentation only.
 
 ### Blast radius
 
@@ -139,16 +148,20 @@ Part 06 touches `website/`, `.claude/skills/`, and root docs.
 Route every part to **`staff-engineer`** except Part 06, which goes to
 **`technical-writer`**. Plan execution is:
 
-1. **Part 01** runs first in isolation. It creates the package and lands
-   nothing else. Merge before starting any other part.
-2. After Part 01 merges, launch **Parts 02, 04, and 05 in parallel** as three
-   concurrent staff-engineer sub-agents. They touch disjoint files (Part 02
-   only inside `products/landmark/` + starter markers; Parts 04/05 touch Map's
-   Supabase layer and the Landmark command files they own).
-3. **Part 03** waits for Part 02 to merge (it reuses Part 02's evidence
-   helper). Launch after Part 02 lands.
-4. **Part 06** runs after all code parts are merged — it needs the final
-   command surface to write accurate documentation.
+1. **Part 01** runs first in isolation (staff-engineer). Merge before
+   starting any other part.
+2. **Part 02** runs after Part 01 merges (staff-engineer). Its
+   `evidence-helpers.js` is reused by Parts 03 and 04 so it must land first.
+3. **Part 03** runs after Part 02 merges (staff-engineer). Part 03 creates
+   `src/commands/health.js` and pre-places two anchor comments
+   (`// <comments section>`, `// <initiatives section>`) so Parts 04 and 05
+   can edit disjoint regions of the file without merge conflicts.
+4. **Parts 04 and 05 run in parallel** (two concurrent staff-engineer
+   sub-agents) after Part 03 merges. They touch disjoint sections of
+   `health.js`/`formatters/health.js`, disjoint query modules in Map, and
+   disjoint command files. The anchor-comment contract is mandatory.
+5. **Part 06** runs after Parts 04 and 05 both merge (technical-writer). It
+   needs the final command surface to write accurate documentation.
 
 Each part includes its own verification steps (tests, CI, smoke test). Do not
 chain parts past a failing verification.


### PR DESCRIPTION
## Summary

- Implementation plan for spec 080 (Landmark — analysis and recommendation engine on top of Map's activity schema). Decomposed into 6 independently-executable parts: scaffolding + foundational views, evidence-based views + starter markers, health view + drivers expansion, snapshot comments pipeline + voice command, initiatives pipeline + initiative commands, and documentation.
- Plan reviewed by a fresh gemba-review sub-agent; all 6 high and 12 medium findings addressed (wrong libskill signatures, dependency-graph ordering error, invented exports entry, incomplete marker proficiency coverage, initiative-impact join placement, completed_at idempotency, and more).
- Introduces an anchor-comment contract on health.js so Parts 04 and 05 can edit disjoint sections in parallel after Part 03 lands.

## Test plan

- [ ] Plan files pass prettier formatting (`bun run check:fix` applied)
- [ ] No code changes — spec-only PR, all files under `specs/080-landmark-product/`
- [ ] Cross-referenced libskill signatures (`getNextLevel`, `deriveSkillMatrix`) against actual codebase
- [ ] Cross-referenced Map activity query signatures and exports map against actual codebase
- [ ] Confirmed Summit `computeGrowthAlignment` exists and is synchronous

https://claude.ai/code/session_01CC49L3BDUk5vpC1qsSdv3h