### PR TITLE
fix(skills): require verification of sub-agent review findings

### DIFF
--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -163,10 +163,13 @@ structurally — see
 Tell the reviewer explicitly **not** to invoke `gemba-implement` itself —
 defense in depth on top of the structural fix.
 
-Address every **blocker**, **high**, and **medium** finding before pushing.
-**Low** findings are optional. If the reviewer raises blockers you disagree
-with, resolve the disagreement explicitly (fix the code, or record the rationale
-for dismissal in the commit message) — silent dismissal is not allowed.
+**Verify** every finding against the actual artifact before acting on it —
+sub-agent reviewers lack prior conversation context and can misread intent or
+flag false positives. After verification, address every confirmed **blocker**,
+**high**, and **medium** finding before pushing. **Low** findings are optional.
+If the reviewer raises blockers you disagree with, resolve the disagreement
+explicitly (fix the code, or record the rationale for dismissal in the commit
+message) — silent dismissal is not allowed.
 
 Push all commits to the remote branch only after the review is clean.
 

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -198,11 +198,14 @@ from prior `staff-engineer` entries.
    out structurally — see
    [GEMBA.md § Recursion-safe self-review](../../../GEMBA.md#recursion-safe-self-review).
    Tell the reviewer explicitly **not** to invoke `gemba-plan` itself — defense
-   in depth on top of the structural fix. Address every **blocker**, **high**,
-   and **medium** finding before moving on. **Low** findings are optional. If
-   the reviewer raises blockers you disagree with, resolve the disagreement
-   explicitly (revise, or record the rationale for dismissal) — silent dismissal
-   is not allowed.
+   in depth on top of the structural fix. **Verify** every finding against the
+   actual artifact before acting on it — sub-agent reviewers lack prior
+   conversation context and can misread intent or flag false positives. After
+   verification, address every confirmed **blocker**, **high**, and **medium**
+   finding before moving on. **Low** findings are optional. If the reviewer
+   raises blockers you disagree with, resolve the disagreement explicitly
+   (revise, or record the rationale for dismissal) — silent dismissal is not
+   allowed.
 6. **Present the plan.** Share it for feedback.
 7. **Update STATUS.** When both spec and plan are approved, advance the spec's
    status from `review` to `planned`. Do not advance while the plan is still

--- a/.claude/skills/gemba-review/SKILL.md
+++ b/.claude/skills/gemba-review/SKILL.md
@@ -44,8 +44,12 @@ implement arc. Grade every finding using exactly one level:
   context is fresh. Fix before advancing.
 - **Low** — Nit or preference. Optional; document if dismissed.
 
-The caller is required to address every **blocker**, **high**, and **medium**
-finding before advancing. **Low** findings are optional.
+The caller is required to **verify** every finding against the actual artifact
+before acting on it — sub-agent reviewers operate without prior conversation
+context and can misread intent, miss surrounding code, or flag false positives.
+After verification, the caller must address every confirmed **blocker**,
+**high**, and **medium** finding before advancing. **Low** findings are
+optional.
 
 ## Process
 

--- a/.claude/skills/gemba-spec/SKILL.md
+++ b/.claude/skills/gemba-spec/SKILL.md
@@ -138,11 +138,14 @@ status clearly — the caller is responsible for acting on it.
    spawns sub-agents, so the review loop bottoms out structurally — see
    [GEMBA.md § Recursion-safe self-review](../../../GEMBA.md#recursion-safe-self-review).
    Tell the reviewer explicitly **not** to invoke `gemba-spec` itself — defense
-   in depth on top of the structural fix. Address every **blocker**, **high**,
-   and **medium** finding before moving on. **Low** findings are optional. If
-   the reviewer raises blockers you disagree with, resolve the disagreement
-   explicitly (revise, or record the rationale for dismissal) — silent dismissal
-   is not allowed.
+   in depth on top of the structural fix. **Verify** every finding against the
+   actual artifact before acting on it — sub-agent reviewers lack prior
+   conversation context and can misread intent or flag false positives. After
+   verification, address every confirmed **blocker**, **high**, and **medium**
+   finding before moving on. **Low** findings are optional. If the reviewer
+   raises blockers you disagree with, resolve the disagreement explicitly
+   (revise, or record the rationale for dismissal) — silent dismissal is not
+   allowed.
 6. **Present the spec.** Share it for feedback. Iterate until satisfied, then
    set status to `review` — signalling it is ready for formal evaluation. Stop
    here. The plan is the staff engineer's job.


### PR DESCRIPTION
## Summary

- Sub-agent reviewers operate without prior conversation context and can misread intent, miss surrounding code, or flag false positives. Updated gemba-review's severity vocabulary section and all three calling skills (gemba-spec, gemba-plan, gemba-implement) to require callers to **verify** findings against the actual artifact before addressing them.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2221 pass, 0 fail)

https://claude.ai/code/session_01Tix7kEpgrKRPAcu2r45DKK