### PR TITLE
feat(landmark): implement spec 080 — Landmark analysis product

### DIFF
--- a/.claude/skills/fit-landmark/SKILL.md
+++ b/.claude/skills/fit-landmark/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: fit-landmark
+description: >
+  Work with the @forwardimpact/landmark product. Use when analyzing
+  engineering-system signals, exploring GetDX snapshot trends, reading
+  marker evidence, checking promotion readiness, viewing team health
+  with growth recommendations, or surfacing engineer voice.
+---
+
+# Landmark
+
+Landmark is the analysis and recommendation layer on top of Map data. It reads
+from Map's activity schema and framework YAML to surface evidence, health,
+readiness, growth timelines, initiative impact, and engineer voice. All
+computation is deterministic — no LLM calls.
+
+## When to Use
+
+- Analyzing team health across GetDX drivers and skill evidence
+- Checking an engineer's promotion readiness against marker checklists
+- Viewing growth timelines based on Guide-interpreted evidence
+- Surfacing engineer voice from GetDX snapshot comments
+- Tracking initiative impact on driver scores
+- Exploring snapshot trends and factor comparisons
+
+## Commands
+
+- `fit-landmark org show` / `org team` — Organization directory and team views
+- `fit-landmark snapshot list|show|trend|compare` — GetDX snapshot analytics
+- `fit-landmark evidence` — Marker-linked evidence with Guide's rationale
+- `fit-landmark marker <skill>` — Marker definitions reference view
+- `fit-landmark readiness --email <email>` — Promotion readiness checklist
+- `fit-landmark timeline --email <email>` — Individual growth timeline by
+  quarter
+- `fit-landmark coverage --email <email>` — Evidence coverage metrics
+- `fit-landmark practiced --manager <email>` — Evidenced vs derived capability
+- `fit-landmark health [--manager <email>]` — Health view with drivers,
+  evidence, and growth recommendations
+- `fit-landmark voice --manager|--email` — Engineer voice from GetDX comments
+- `fit-landmark initiative list|show|impact` — Initiative tracking and impact
+  analysis
+
+## Audience Model
+
+Each view applies privacy rules based on the audience:
+
+- **Engineer** (own data): `evidence`, `readiness`, `timeline`, `coverage`,
+  `voice --email`
+- **Manager** (1:1 tool): `health`, `readiness`, `timeline`, `practiced`,
+  `voice --manager`
+- **Director** (planning): `snapshot`, `coverage`, `practiced`, `initiative`
+
+## Prerequisites
+
+- GetDX account with API access
+- Map activity schema migrated and populated
+- Framework data with drivers and markers authored in capability YAML
+- Summit (optional) for inline growth recommendations in health view
+
+## Common Workflows
+
+- "What should this engineer be demonstrating at the next level?" → `readiness`
+- "How is this team doing?" → `health`
+- "What are engineers saying is blocking them?" → `voice`
+- "Did the initiative we ran actually improve scores?" → `initiative impact`
+- "What skills are practiced vs only on paper?" → `practiced`

--- a/.github/workflows/implement-plans.yml
+++ b/.github/workflows/implement-plans.yml
@@ -45,7 +45,10 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: "Implement approved plans. Select the planned spec with the lowest ID and implement it. Never ask for clarification — this is an automated workflow."
+          task-text:
+            "Implement approved plans. Select the planned spec with the lowest
+            ID and implement it. Never ask for clarification — this is an
+            automated workflow."
           agent-profile: "staff-engineer"
           model: "opus"
           max-turns: "0"

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "libraries/libagent": {
       "name": "@forwardimpact/libagent",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "bin": {
         "fit-process-agents": "./bin/fit-process-agents.js",
       },
@@ -33,14 +33,14 @@
     },
     "libraries/libcli": {
       "name": "@forwardimpact/libcli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@forwardimpact/libharness": "^0.1.5",
       },
     },
     "libraries/libcodegen": {
       "name": "@forwardimpact/libcodegen",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "bin": {
         "fit-codegen": "./bin/fit-codegen.js",
       },
@@ -60,7 +60,7 @@
     },
     "libraries/libconfig": {
       "name": "@forwardimpact/libconfig",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "dependencies": {
         "@forwardimpact/libstorage": "^0.1.53",
       },
@@ -70,7 +70,7 @@
     },
     "libraries/libdoc": {
       "name": "@forwardimpact/libdoc",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "bin": {
         "fit-doc": "./bin/fit-doc.js",
       },
@@ -91,7 +91,7 @@
     },
     "libraries/libeval": {
       "name": "@forwardimpact/libeval",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "bin": {
         "fit-eval": "./bin/fit-eval.js",
       },
@@ -103,7 +103,7 @@
     },
     "libraries/libformat": {
       "name": "@forwardimpact/libformat",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "marked": "^17.0.5",
         "marked-terminal": "^7.3.0",
@@ -115,7 +115,7 @@
     },
     "libraries/libgraph": {
       "name": "@forwardimpact/libgraph",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "bin": {
         "fit-process-graphs": "./bin/fit-process-graphs.js",
         "fit-subjects": "./bin/fit-subjects.js",
@@ -136,14 +136,14 @@
     },
     "libraries/libharness": {
       "name": "@forwardimpact/libharness",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "peerDependencies": {
         "@forwardimpact/libtype": "*",
       },
     },
     "libraries/libindex": {
       "name": "@forwardimpact/libindex",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "dependencies": {
         "@forwardimpact/libtype": "^0.1.63",
       },
@@ -153,7 +153,7 @@
     },
     "libraries/libllm": {
       "name": "@forwardimpact/libllm",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "bin": {
         "fit-completion": "./bin/fit-completion.js",
       },
@@ -169,7 +169,7 @@
     },
     "libraries/libmemory": {
       "name": "@forwardimpact/libmemory",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "bin": {
         "fit-window": "./bin/fit-window.js",
       },
@@ -183,7 +183,7 @@
     },
     "libraries/libpolicy": {
       "name": "@forwardimpact/libpolicy",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "dependencies": {
         "@forwardimpact/libstorage": "^0.1.53",
       },
@@ -193,14 +193,14 @@
     },
     "libraries/libprompt": {
       "name": "@forwardimpact/libprompt",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "mustache": "^4.2.0",
       },
     },
     "libraries/librc": {
       "name": "@forwardimpact/librc",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "bin": {
         "fit-rc": "./bin/fit-rc.js",
       },
@@ -216,7 +216,7 @@
     },
     "libraries/librepl": {
       "name": "@forwardimpact/librepl",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@forwardimpact/libformat": "^0.1.0",
       },
@@ -226,7 +226,7 @@
     },
     "libraries/libresource": {
       "name": "@forwardimpact/libresource",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "bin": {
         "fit-process-resources": "./bin/fit-process-resources.js",
       },
@@ -250,7 +250,7 @@
     },
     "libraries/librpc": {
       "name": "@forwardimpact/librpc",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "bin": {
         "fit-unary": "./bin/fit-unary.js",
       },
@@ -267,18 +267,18 @@
     },
     "libraries/libsecret": {
       "name": "@forwardimpact/libsecret",
-      "version": "0.1.8",
+      "version": "0.1.9",
     },
     "libraries/libskill": {
       "name": "@forwardimpact/libskill",
-      "version": "4.1.7",
+      "version": "4.1.8",
       "dependencies": {
         "@forwardimpact/map": "^0.13.0",
       },
     },
     "libraries/libstorage": {
       "name": "@forwardimpact/libstorage",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "bin": {
         "fit-storage": "./bin/fit-storage.js",
       },
@@ -297,7 +297,7 @@
     },
     "libraries/libsupervise": {
       "name": "@forwardimpact/libsupervise",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "bin": {
         "fit-logger": "./bin/fit-logger.js",
         "fit-svscan": "./bin/fit-svscan.js",
@@ -312,7 +312,7 @@
     },
     "libraries/libsyntheticgen": {
       "name": "@forwardimpact/libsyntheticgen",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.61",
         "seedrandom": "^3.0.5",
@@ -323,7 +323,7 @@
     },
     "libraries/libsyntheticprose": {
       "name": "@forwardimpact/libsyntheticprose",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@forwardimpact/libprompt": "^0.1.0",
         "@forwardimpact/libtelemetry": "^0.1.23",
@@ -335,7 +335,7 @@
     },
     "libraries/libsyntheticrender": {
       "name": "@forwardimpact/libsyntheticrender",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@forwardimpact/libsyntheticgen": "^0.1.0",
         "@forwardimpact/libtemplate": "^0.2.0",
@@ -351,7 +351,7 @@
     },
     "libraries/libtelemetry": {
       "name": "@forwardimpact/libtelemetry",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "bin": {
         "fit-visualize": "./bin/fit-visualize.js",
       },
@@ -366,14 +366,14 @@
     },
     "libraries/libtemplate": {
       "name": "@forwardimpact/libtemplate",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "mustache": "^4.2.0",
       },
     },
     "libraries/libtool": {
       "name": "@forwardimpact/libtool",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "bin": {
         "fit-process-tools": "./bin/fit-process-tools.js",
       },
@@ -393,7 +393,7 @@
     },
     "libraries/libtype": {
       "name": "@forwardimpact/libtype",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "dependencies": {
         "@forwardimpact/libsecret": "^0.1.3",
         "@forwardimpact/libutil": "^0.1.60",
@@ -404,11 +404,11 @@
     },
     "libraries/libui": {
       "name": "@forwardimpact/libui",
-      "version": "1.1.5",
+      "version": "1.1.6",
     },
     "libraries/libuniverse": {
       "name": "@forwardimpact/libuniverse",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "bin": {
         "fit-universe": "./bin/fit-universe.js",
       },
@@ -432,7 +432,7 @@
     },
     "libraries/libutil": {
       "name": "@forwardimpact/libutil",
-      "version": "0.1.72",
+      "version": "0.1.73",
       "bin": {
         "fit-download-bundle": "./bin/fit-download-bundle.js",
         "fit-tiktoken": "./bin/fit-tiktoken.js",
@@ -447,7 +447,7 @@
     },
     "libraries/libvector": {
       "name": "@forwardimpact/libvector",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "bin": {
         "fit-process-vectors": "./bin/fit-process-vectors.js",
         "fit-search": "./bin/fit-search.js",
@@ -465,7 +465,7 @@
     },
     "libraries/libweb": {
       "name": "@forwardimpact/libweb",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@forwardimpact/libconfig": "^0.1.58",
         "hono": "^4.12.12",
@@ -476,7 +476,7 @@
     },
     "products/basecamp": {
       "name": "@forwardimpact/basecamp",
-      "version": "2.12.1",
+      "version": "2.12.2",
       "bin": {
         "fit-basecamp": "./src/basecamp.js",
       },
@@ -486,7 +486,7 @@
     },
     "products/guide": {
       "name": "@forwardimpact/guide",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "bin": {
         "fit-guide": "./bin/fit-guide.js",
       },
@@ -512,9 +512,25 @@
         "@forwardimpact/svcweb": "^0.1.5",
       },
     },
+    "products/landmark": {
+      "name": "@forwardimpact/landmark",
+      "version": "0.1.0",
+      "bin": {
+        "fit-landmark": "./bin/fit-landmark.js",
+      },
+      "dependencies": {
+        "@forwardimpact/libcli": "^0.1.0",
+        "@forwardimpact/libskill": "^4.1.7",
+        "@forwardimpact/libtelemetry": "^0.1.33",
+        "@forwardimpact/libutil": "^0.1.72",
+        "@forwardimpact/map": "^0.15.18",
+        "@forwardimpact/summit": "^0.1.0",
+        "@supabase/supabase-js": "^2.103.0",
+      },
+    },
     "products/map": {
       "name": "@forwardimpact/map",
-      "version": "0.15.18",
+      "version": "0.15.19",
       "bin": {
         "fit-map": "./bin/fit-map.js",
       },
@@ -537,7 +553,7 @@
     },
     "products/pathway": {
       "name": "@forwardimpact/pathway",
-      "version": "0.25.25",
+      "version": "0.25.26",
       "bin": {
         "fit-pathway": "./bin/fit-pathway.js",
       },
@@ -848,6 +864,8 @@
     "@forwardimpact/basecamp": ["@forwardimpact/basecamp@workspace:products/basecamp"],
 
     "@forwardimpact/guide": ["@forwardimpact/guide@workspace:products/guide"],
+
+    "@forwardimpact/landmark": ["@forwardimpact/landmark@workspace:products/landmark"],
 
     "@forwardimpact/libagent": ["@forwardimpact/libagent@workspace:libraries/libagent"],
 

--- a/products/landmark/bin/fit-landmark.js
+++ b/products/landmark/bin/fit-landmark.js
@@ -21,6 +21,7 @@ import { runEvidenceCommand } from "../src/commands/evidence.js";
 import { runReadinessCommand } from "../src/commands/readiness.js";
 import { runTimelineCommand } from "../src/commands/timeline.js";
 import { runCoverageCommand } from "../src/commands/coverage.js";
+import { runPracticeCommand } from "../src/commands/practice.js";
 import { runPracticedCommand } from "../src/commands/practiced.js";
 import { runHealthCommand } from "../src/commands/health.js";
 import { runVoiceCommand } from "../src/commands/voice.js";
@@ -44,6 +45,7 @@ const COMMANDS = {
   readiness: { handler: runReadinessCommand, needsSupabase: true },
   timeline: { handler: runTimelineCommand, needsSupabase: true },
   coverage: { handler: runCoverageCommand, needsSupabase: true },
+  practice: { handler: runPracticeCommand, needsSupabase: true },
   practiced: { handler: runPracticedCommand, needsSupabase: true },
   health: { handler: runHealthCommand, needsSupabase: true },
   voice: { handler: runVoiceCommand, needsSupabase: true },
@@ -153,10 +155,6 @@ const definition = {
     snapshot: { type: "string", description: "Snapshot id" },
     item: { type: "string", description: "Driver/item id for trend" },
     id: { type: "string", description: "Entity id (initiative, etc.)" },
-    evidenced: {
-      type: "boolean",
-      description: "Include practiced capability from evidence data",
-    },
     help: { type: "boolean", short: "h", description: "Show help" },
     version: { type: "boolean", short: "v", description: "Show version" },
   },
@@ -182,17 +180,9 @@ async function main() {
   }
 
   const entry = COMMANDS[command];
-  if (entry === undefined) {
+  if (!entry) {
     cli.usageError(`unknown command "${command}"`);
     process.exit(2);
-  }
-
-  // Not-yet-implemented stub for commands landing in later parts.
-  if (entry === null) {
-    process.stderr.write(
-      `fit-landmark: "${command}" is not yet implemented (spec 080).\n`,
-    );
-    process.exit(64);
   }
 
   try {

--- a/products/landmark/bin/fit-landmark.js
+++ b/products/landmark/bin/fit-landmark.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Landmark CLI
+ *
+ * Analysis and recommendation layer on top of Map activity data.
+ *
+ * Usage:
+ *   npx fit-landmark <command> [options]
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createCli } from "@forwardimpact/libcli";
+
+import { runOrgCommand } from "../src/commands/org.js";
+import { runSnapshotCommand } from "../src/commands/snapshot.js";
+import { runMarkerCommand } from "../src/commands/marker.js";
+import { runEvidenceCommand } from "../src/commands/evidence.js";
+import { runReadinessCommand } from "../src/commands/readiness.js";
+import { runTimelineCommand } from "../src/commands/timeline.js";
+import { runCoverageCommand } from "../src/commands/coverage.js";
+import { runPracticedCommand } from "../src/commands/practiced.js";
+import { runHealthCommand } from "../src/commands/health.js";
+import { runVoiceCommand } from "../src/commands/voice.js";
+import { runInitiativeCommand } from "../src/commands/initiative.js";
+import { resolveDataDir } from "../src/lib/cli.js";
+import { buildContext } from "../src/lib/context.js";
+import { SupabaseUnavailableError } from "../src/lib/supabase.js";
+import { formatResult } from "../src/formatters/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const VERSION = JSON.parse(
+  readFileSync(join(__dirname, "..", "package.json"), "utf8"),
+).version;
+
+const COMMANDS = {
+  org: { handler: runOrgCommand, needsSupabase: true },
+  snapshot: { handler: runSnapshotCommand, needsSupabase: true },
+  marker: { handler: runMarkerCommand, needsSupabase: false },
+  evidence: { handler: runEvidenceCommand, needsSupabase: true },
+  readiness: { handler: runReadinessCommand, needsSupabase: true },
+  timeline: { handler: runTimelineCommand, needsSupabase: true },
+  coverage: { handler: runCoverageCommand, needsSupabase: true },
+  practiced: { handler: runPracticedCommand, needsSupabase: true },
+  health: { handler: runHealthCommand, needsSupabase: true },
+  voice: { handler: runVoiceCommand, needsSupabase: true },
+  initiative: { handler: runInitiativeCommand, needsSupabase: true },
+};
+
+const definition = {
+  name: "fit-landmark",
+  version: VERSION,
+  description: "Landmark — analysis and recommendations on top of Map data.",
+  commands: [
+    { name: "org show", description: "Show full organization directory" },
+    {
+      name: "org team",
+      args: "--manager <email>",
+      description: "Show hierarchy under a manager",
+    },
+    { name: "snapshot list", description: "List available snapshots" },
+    {
+      name: "snapshot show",
+      args: "--snapshot <id> [--manager <email>]",
+      description: "Show factor/driver scores for a snapshot",
+    },
+    {
+      name: "snapshot trend",
+      args: "--item <item_id> [--manager <email>]",
+      description: "Track item trend across snapshots",
+    },
+    {
+      name: "snapshot compare",
+      args: "--snapshot <id> [--manager <email>]",
+      description: "Compare snapshot against benchmarks",
+    },
+    {
+      name: "evidence",
+      args: "[--skill <id>] [--email <email>]",
+      description: "Show marker-linked evidence",
+    },
+    {
+      name: "practice",
+      args: "[--skill <id>] [--manager <email>]",
+      description: "Show practice-pattern aggregates",
+    },
+    {
+      name: "marker",
+      args: "<skill> [--level <level>]",
+      description: "Show marker definitions for a skill",
+    },
+    {
+      name: "health",
+      args: "[--manager <email>]",
+      description: "Show health view with driver scores and evidence",
+    },
+    {
+      name: "readiness",
+      args: "--email <email> [--target <level>]",
+      description: "Show promotion readiness checklist",
+    },
+    {
+      name: "timeline",
+      args: "--email <email> [--skill <id>]",
+      description: "Show individual growth timeline",
+    },
+    {
+      name: "initiative list",
+      args: "[--manager <email>]",
+      description: "List active initiatives",
+    },
+    {
+      name: "initiative show",
+      args: "--id <id>",
+      description: "Show initiative detail",
+    },
+    {
+      name: "initiative impact",
+      args: "[--manager <email>]",
+      description: "Show initiative impact on scores",
+    },
+    {
+      name: "coverage",
+      args: "--email <email>",
+      description: "Show evidence coverage metrics",
+    },
+    {
+      name: "practiced",
+      args: "--manager <email>",
+      description: "Show evidenced vs derived capability",
+    },
+    {
+      name: "voice",
+      args: "--manager <email> | --email <email>",
+      description: "Surface engineer voice from GetDX comments",
+    },
+  ],
+  options: {
+    data: { type: "string", description: "Path to Map data directory" },
+    format: {
+      type: "string",
+      default: "text",
+      description: "Output format (text|json|markdown)",
+    },
+    manager: { type: "string", description: "Filter by manager email" },
+    email: { type: "string", description: "Filter by person email" },
+    skill: { type: "string", description: "Filter by skill id" },
+    level: { type: "string", description: "Target or filter level" },
+    target: { type: "string", description: "Readiness target level" },
+    snapshot: { type: "string", description: "Snapshot id" },
+    item: { type: "string", description: "Driver/item id for trend" },
+    id: { type: "string", description: "Entity id (initiative, etc.)" },
+    evidenced: {
+      type: "boolean",
+      description: "Include practiced capability from evidence data",
+    },
+    help: { type: "boolean", short: "h", description: "Show help" },
+    version: { type: "boolean", short: "v", description: "Show version" },
+  },
+  examples: [
+    "fit-landmark org show",
+    "fit-landmark snapshot list",
+    "fit-landmark marker task_completion",
+    "fit-landmark health --manager alice@example.com",
+  ],
+};
+
+async function main() {
+  const cli = createCli(definition);
+  const parsed = cli.parse(process.argv.slice(2));
+  if (!parsed) process.exit(0);
+
+  const { values, positionals } = parsed;
+  const [command, ...args] = positionals;
+
+  if (!command) {
+    cli.showHelp();
+    process.exit(0);
+  }
+
+  const entry = COMMANDS[command];
+  if (entry === undefined) {
+    cli.usageError(`unknown command "${command}"`);
+    process.exit(2);
+  }
+
+  // Not-yet-implemented stub for commands landing in later parts.
+  if (entry === null) {
+    process.stderr.write(
+      `fit-landmark: "${command}" is not yet implemented (spec 080).\n`,
+    );
+    process.exit(64);
+  }
+
+  try {
+    const dataDir = resolveDataDir(values);
+    const ctx = await buildContext({
+      dataDir,
+      options: values,
+      needsSupabase: entry.needsSupabase,
+    });
+
+    const result = await entry.handler({
+      args,
+      options: values,
+      mapData: ctx.mapData,
+      supabase: ctx.supabase,
+      format: ctx.format,
+    });
+
+    const output = formatResult(command, result);
+    process.stdout.write(output);
+
+    if (result.meta?.warnings?.length > 0) {
+      for (const w of result.meta.warnings) {
+        process.stderr.write(`  warning: ${w}\n`);
+      }
+    }
+  } catch (error) {
+    if (error instanceof SupabaseUnavailableError) {
+      cli.error(error.message);
+      process.exit(3);
+    }
+    cli.error(error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/products/landmark/package.json
+++ b/products/landmark/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@forwardimpact/landmark",
+  "version": "0.1.0",
+  "description": "Analysis and recommendation layer on top of Map activity data.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/forwardimpact/monorepo",
+    "directory": "products/landmark"
+  },
+  "homepage": "https://www.forwardimpact.team/landmark",
+  "keywords": [
+    "engineering",
+    "analytics",
+    "framework",
+    "skills",
+    "team",
+    "getdx",
+    "github"
+  ],
+  "type": "module",
+  "main": "./src/index.js",
+  "bin": {
+    "fit-landmark": "./bin/fit-landmark.js"
+  },
+  "files": [
+    "bin/",
+    "src/"
+  ],
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "dependencies": {
+    "@forwardimpact/libcli": "^0.1.0",
+    "@forwardimpact/libtelemetry": "^0.1.33",
+    "@forwardimpact/libutil": "^0.1.72",
+    "@forwardimpact/libskill": "^4.1.7",
+    "@forwardimpact/map": "^0.15.18",
+    "@forwardimpact/summit": "^0.1.0",
+    "@supabase/supabase-js": "^2.103.0"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/products/landmark/src/commands/coverage.js
+++ b/products/landmark/src/commands/coverage.js
@@ -1,0 +1,85 @@
+/**
+ * `fit-landmark coverage --email <email>`
+ *
+ * Evidence coverage metrics per person.
+ */
+
+import { getPerson } from "@forwardimpact/map/activity/queries/org";
+import {
+  getArtifacts,
+  getUnscoredArtifacts,
+} from "@forwardimpact/map/activity/queries/artifacts";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+import { computeCoverageRatio } from "../lib/evidence-helpers.js";
+
+export const needsSupabase = true;
+
+export async function runCoverageCommand({
+  options,
+  supabase,
+  format,
+  queries,
+}) {
+  const q = queries ?? { getPerson, getArtifacts, getUnscoredArtifacts };
+
+  if (!options.email) {
+    throw new Error("coverage: --email <email> is required");
+  }
+
+  const person = await q.getPerson(supabase, options.email);
+  if (!person) {
+    return {
+      view: null,
+      meta: {
+        format,
+        emptyState: EMPTY_STATES.PERSON_NOT_FOUND(options.email),
+      },
+    };
+  }
+
+  const allArtifacts = await q.getArtifacts(supabase, {
+    email: options.email,
+  });
+
+  if (!allArtifacts || allArtifacts.length === 0) {
+    return {
+      view: null,
+      meta: {
+        format,
+        emptyState: EMPTY_STATES.NO_ARTIFACTS_FOR_PERSON(options.email),
+      },
+    };
+  }
+
+  const unscored = await q.getUnscoredArtifacts(supabase, {
+    email: options.email,
+  });
+
+  const ratio = computeCoverageRatio(allArtifacts, unscored);
+
+  // Group uncovered by type
+  const uncoveredByType = {};
+  for (const a of unscored) {
+    const type = a.artifact_type ?? "unknown";
+    uncoveredByType[type] = (uncoveredByType[type] ?? 0) + 1;
+  }
+
+  // Group all by type
+  const allByType = {};
+  for (const a of allArtifacts) {
+    const type = a.artifact_type ?? "unknown";
+    allByType[type] = (allByType[type] ?? 0) + 1;
+  }
+
+  return {
+    view: {
+      email: options.email,
+      name: person.name,
+      coverage: ratio,
+      byType: allByType,
+      uncoveredByType,
+    },
+    meta: { format },
+  };
+}

--- a/products/landmark/src/commands/evidence.js
+++ b/products/landmark/src/commands/evidence.js
@@ -1,0 +1,63 @@
+/**
+ * `fit-landmark evidence [--skill <id>] [--email <email>]`
+ *
+ * Show marker-linked evidence by skill with Guide's rationale.
+ */
+
+import { getEvidence } from "@forwardimpact/map/activity/queries/evidence";
+import {
+  getArtifacts,
+  getUnscoredArtifacts,
+} from "@forwardimpact/map/activity/queries/artifacts";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+import {
+  groupEvidenceBySkill,
+  computeCoverageRatio,
+} from "../lib/evidence-helpers.js";
+
+export const needsSupabase = true;
+
+export async function runEvidenceCommand({
+  options,
+  supabase,
+  format,
+  queries,
+}) {
+  const q = queries ?? { getEvidence, getArtifacts, getUnscoredArtifacts };
+  const filterOpts = {};
+  if (options.skill) filterOpts.skillId = options.skill;
+  if (options.email) filterOpts.email = options.email;
+
+  const evidenceRows = await q.getEvidence(supabase, filterOpts);
+
+  if (!evidenceRows || evidenceRows.length === 0) {
+    return {
+      view: null,
+      meta: { format, emptyState: EMPTY_STATES.NO_EVIDENCE },
+    };
+  }
+
+  const grouped = groupEvidenceBySkill(evidenceRows);
+
+  // Coverage line
+  let coverage = null;
+  if (options.email) {
+    const allArtifacts = await q.getArtifacts(supabase, {
+      email: options.email,
+    });
+    const unscored = await q.getUnscoredArtifacts(supabase, {
+      email: options.email,
+    });
+    coverage = computeCoverageRatio(allArtifacts, unscored);
+  }
+
+  return {
+    view: {
+      evidence: Object.fromEntries(grouped),
+      coverage,
+      filters: filterOpts,
+    },
+    meta: { format },
+  };
+}

--- a/products/landmark/src/commands/health.js
+++ b/products/landmark/src/commands/health.js
@@ -66,7 +66,7 @@ export async function runHealthCommand({
 
   // 4. Join scores to drivers and build driver rows
   const teamEmails = new Set(team.map((p) => p.email));
-  const drivers = await buildDriverRows(
+  const { drivers, collectedEvidence } = await buildDriverRows(
     scores,
     mapData,
     q,
@@ -98,10 +98,7 @@ export async function runHealthCommand({
     growth,
     team,
     mapData,
-    q,
-    supabase,
-    options,
-    teamEmails,
+    collectedEvidence,
     drivers,
     meta,
   );
@@ -158,6 +155,7 @@ async function buildDriverRows(
 ) {
   const driverMap = new Map((mapData.drivers ?? []).map((d) => [d.id, d]));
   const drivers = [];
+  const collectedEvidence = new Map();
 
   for (const scoreRow of scores) {
     const driver = driverMap.get(scoreRow.item_id);
@@ -174,6 +172,7 @@ async function buildDriverRows(
       supabase,
       options,
       teamEmails,
+      collectedEvidence,
     );
 
     drivers.push({
@@ -192,17 +191,28 @@ async function buildDriverRows(
     });
   }
 
-  return drivers;
+  return { drivers, collectedEvidence };
 }
 
-/** Collect evidence counts for a list of contributing skill ids. */
-async function gatherSkillEvidence(skillIds, q, supabase, options, teamEmails) {
+/** Collect evidence counts for a list of contributing skill ids. Caches raw rows in collectedEvidence. */
+async function gatherSkillEvidence(
+  skillIds,
+  q,
+  supabase,
+  options,
+  teamEmails,
+  collectedEvidence,
+) {
   const skillEvidence = [];
   for (const skillId of skillIds) {
-    const allEvidence = await q.getEvidence(supabase, { skillId });
-    const teamEvidence = options.manager
-      ? filterEvidenceByTeam(allEvidence, teamEmails)
-      : allEvidence;
+    if (!collectedEvidence.has(skillId)) {
+      const allEvidence = await q.getEvidence(supabase, { skillId });
+      const teamEvidence = options.manager
+        ? filterEvidenceByTeam(allEvidence, teamEmails)
+        : allEvidence;
+      collectedEvidence.set(skillId, teamEvidence);
+    }
+    const teamEvidence = collectedEvidence.get(skillId);
     const grouped = groupEvidenceBySkill(teamEvidence);
     const count = grouped.get(skillId)?.matched ?? 0;
     skillEvidence.push({ skillId, count });
@@ -274,10 +284,7 @@ async function computeGrowthRecommendations(
   growth,
   team,
   mapData,
-  q,
-  supabase,
-  options,
-  teamEmails,
+  collectedEvidence,
   drivers,
   meta,
 ) {
@@ -287,12 +294,7 @@ async function computeGrowthRecommendations(
     job: { discipline: p.discipline, level: p.level, track: p.track },
   }));
 
-  const summitEvidence = await buildSummitEvidence(
-    q,
-    supabase,
-    options,
-    teamEmails,
-  );
+  const summitEvidence = buildSummitEvidence(collectedEvidence);
 
   const driverScores = new Map();
   for (const d of drivers) {
@@ -326,16 +328,13 @@ async function computeGrowthRecommendations(
   return growthResult;
 }
 
-/** Build the evidence map that Summit expects. */
-async function buildSummitEvidence(q, supabase, options, teamEmails) {
-  const allEvidence = await q.getEvidence(supabase, {});
-  const teamAllEvidence = options.manager
-    ? filterEvidenceByTeam(allEvidence, teamEmails)
-    : allEvidence;
-  const evidenceBySkill = groupEvidenceBySkill(teamAllEvidence);
-
+/** Build the evidence map Summit expects from already-collected per-skill evidence. */
+function buildSummitEvidence(collectedEvidence) {
   const summitEvidence = new Map();
-  for (const [skillId, group] of evidenceBySkill) {
+  for (const [skillId, rows] of collectedEvidence) {
+    const grouped = groupEvidenceBySkill(rows);
+    const group = grouped.get(skillId);
+    if (!group) continue;
     const practitioners = new Set(
       group.rows
         .filter((r) => r.matched)

--- a/products/landmark/src/commands/health.js
+++ b/products/landmark/src/commands/health.js
@@ -1,0 +1,348 @@
+/**
+ * `fit-landmark health [--manager <email>]`
+ *
+ * Health view joining snapshot scores, contributing-skill evidence, and
+ * Summit growth recommendations.
+ */
+
+import {
+  getOrganization,
+  getTeam,
+} from "@forwardimpact/map/activity/queries/org";
+import {
+  listSnapshots,
+  getSnapshotScores,
+} from "@forwardimpact/map/activity/queries/snapshots";
+import { getEvidence } from "@forwardimpact/map/activity/queries/evidence";
+import { getSnapshotComments } from "@forwardimpact/map/activity/queries/comments";
+import { listInitiatives } from "@forwardimpact/map/activity/queries/initiatives";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+import { isRelationNotFoundError } from "../lib/supabase.js";
+import {
+  groupEvidenceBySkill,
+  filterEvidenceByTeam,
+} from "../lib/evidence-helpers.js";
+import { computeGrowth } from "../lib/summit.js";
+
+export const needsSupabase = true;
+
+export async function runHealthCommand({
+  options,
+  mapData,
+  supabase,
+  format,
+  queries,
+  summitFn,
+}) {
+  const q = queries ?? {
+    getOrganization,
+    getTeam,
+    listSnapshots,
+    getSnapshotScores,
+    getEvidence,
+    getSnapshotComments,
+    listInitiatives,
+  };
+  const growth = summitFn ?? computeGrowth;
+
+  const meta = { format, warnings: [] };
+
+  // 1. Get the team or org
+  const teamResult = await resolveTeam(q, supabase, options, meta);
+  if (!teamResult) return { view: null, meta };
+  const { team, teamLabel } = teamResult;
+
+  // 2. Get latest snapshot
+  const latestSnapshot = await resolveLatestSnapshot(q, supabase, meta);
+  if (!latestSnapshot) return { view: null, meta };
+
+  // 3. Get scores
+  const scores = await q.getSnapshotScores(
+    supabase,
+    latestSnapshot.snapshot_id,
+    { managerEmail: options.manager },
+  );
+
+  // 4. Join scores to drivers and build driver rows
+  const teamEmails = new Set(team.map((p) => p.email));
+  const drivers = await buildDriverRows(
+    scores,
+    mapData,
+    q,
+    supabase,
+    options,
+    teamEmails,
+    meta,
+  );
+
+  // Attach comments to drivers
+  const allComments = await fetchComments(
+    q,
+    supabase,
+    latestSnapshot,
+    options,
+    meta,
+  );
+  attachComments(drivers, allComments);
+
+  // Attach initiatives to drivers
+  const activeInitiatives = await fetchInitiatives(q, supabase, options, meta);
+  attachInitiatives(drivers, activeInitiatives);
+
+  // Deduplicate warnings
+  meta.warnings = [...new Set(meta.warnings)];
+
+  // 5. Growth recommendations from Summit
+  const growthResult = await computeGrowthRecommendations(
+    growth,
+    team,
+    mapData,
+    q,
+    supabase,
+    options,
+    teamEmails,
+    drivers,
+    meta,
+  );
+
+  return {
+    view: {
+      teamLabel,
+      snapshotId: latestSnapshot.snapshot_id,
+      snapshotDate: latestSnapshot.scheduled_for,
+      drivers,
+      summitAvailable: growthResult.available,
+    },
+    meta,
+  };
+}
+
+/** Resolve team members (by manager or full org). Returns null on empty state. */
+async function resolveTeam(q, supabase, options, meta) {
+  if (options.manager) {
+    const team = await q.getTeam(supabase, options.manager);
+    if (!team || team.length === 0) {
+      meta.emptyState = EMPTY_STATES.MANAGER_NOT_FOUND(options.manager);
+      return null;
+    }
+    return { team, teamLabel: `${options.manager} team` };
+  }
+  const team = await q.getOrganization(supabase);
+  if (!team || team.length === 0) {
+    meta.emptyState = EMPTY_STATES.NO_ORGANIZATION;
+    return null;
+  }
+  return { team, teamLabel: "Organization" };
+}
+
+/** Fetch the latest snapshot. Returns null on empty state. */
+async function resolveLatestSnapshot(q, supabase, meta) {
+  const snapshots = await q.listSnapshots(supabase);
+  if (!snapshots || snapshots.length === 0) {
+    meta.emptyState = EMPTY_STATES.NO_SNAPSHOTS;
+    return null;
+  }
+  return snapshots[0];
+}
+
+/** Join score rows to driver definitions and gather per-skill evidence. */
+async function buildDriverRows(
+  scores,
+  mapData,
+  q,
+  supabase,
+  options,
+  teamEmails,
+  meta,
+) {
+  const driverMap = new Map((mapData.drivers ?? []).map((d) => [d.id, d]));
+  const drivers = [];
+
+  for (const scoreRow of scores) {
+    const driver = driverMap.get(scoreRow.item_id);
+    if (!driver) {
+      meta.warnings.push(
+        `Unknown item_id "${scoreRow.item_id}" in snapshot scores — no matching driver in drivers.yaml.`,
+      );
+      continue;
+    }
+
+    const skillEvidence = await gatherSkillEvidence(
+      driver.contributingSkills ?? [],
+      q,
+      supabase,
+      options,
+      teamEmails,
+    );
+
+    drivers.push({
+      id: driver.id,
+      name: driver.name,
+      score: scoreRow.score,
+      vs_prev: scoreRow.vs_prev,
+      vs_org: scoreRow.vs_org,
+      vs_50th: scoreRow.vs_50th,
+      vs_75th: scoreRow.vs_75th,
+      vs_90th: scoreRow.vs_90th,
+      contributingSkills: skillEvidence,
+      comments: [],
+      initiatives: [],
+      recommendations: [],
+    });
+  }
+
+  return drivers;
+}
+
+/** Collect evidence counts for a list of contributing skill ids. */
+async function gatherSkillEvidence(skillIds, q, supabase, options, teamEmails) {
+  const skillEvidence = [];
+  for (const skillId of skillIds) {
+    const allEvidence = await q.getEvidence(supabase, { skillId });
+    const teamEvidence = options.manager
+      ? filterEvidenceByTeam(allEvidence, teamEmails)
+      : allEvidence;
+    const grouped = groupEvidenceBySkill(teamEvidence);
+    const count = grouped.get(skillId)?.matched ?? 0;
+    skillEvidence.push({ skillId, count });
+  }
+  return skillEvidence;
+}
+
+/** Fetch snapshot comments, returning [] on error or absence. */
+async function fetchComments(q, supabase, latestSnapshot, options, meta) {
+  if (!q.getSnapshotComments) return [];
+  try {
+    return await q.getSnapshotComments(supabase, {
+      snapshotId: latestSnapshot.snapshot_id,
+      managerEmail: options.manager,
+    });
+  } catch (err) {
+    if (isRelationNotFoundError(err)) {
+      meta.warnings.push("Snapshot comments unavailable — table not present.");
+      return [];
+    }
+    throw err;
+  }
+}
+
+/** Attach comments to drivers by keyword match on contributing skill names. */
+function attachComments(drivers, allComments) {
+  if (allComments.length === 0) return;
+  for (const d of drivers) {
+    const skillKeywords = (d.contributingSkills ?? []).map((s) =>
+      s.skillId.replace(/_/g, " ").toLowerCase(),
+    );
+    d.comments = allComments
+      .filter((c) => {
+        const lower = (c.text ?? "").toLowerCase();
+        return skillKeywords.some((kw) => lower.includes(kw));
+      })
+      .slice(0, 3);
+  }
+}
+
+/** Fetch active initiatives, returning [] on error or absence. */
+async function fetchInitiatives(q, supabase, options, meta) {
+  if (!q.listInitiatives) return [];
+  try {
+    return await q.listInitiatives(supabase, {
+      managerEmail: options.manager,
+      status: "active",
+    });
+  } catch (err) {
+    if (isRelationNotFoundError(err)) {
+      meta.warnings.push("Active initiatives unavailable — table not present.");
+      return [];
+    }
+    throw err;
+  }
+}
+
+/** Attach initiatives to each driver by scorecard_id match. */
+function attachInitiatives(drivers, activeInitiatives) {
+  for (const driver of drivers) {
+    driver.initiatives = activeInitiatives.filter(
+      (i) => i.scorecard_id === driver.id,
+    );
+  }
+}
+
+/** Compute Summit growth recommendations and attach to drivers. */
+async function computeGrowthRecommendations(
+  growth,
+  team,
+  mapData,
+  q,
+  supabase,
+  options,
+  teamEmails,
+  drivers,
+  meta,
+) {
+  const summitTeam = team.map((p) => ({
+    email: p.email,
+    name: p.name,
+    job: { discipline: p.discipline, level: p.level, track: p.track },
+  }));
+
+  const summitEvidence = await buildSummitEvidence(
+    q,
+    supabase,
+    options,
+    teamEmails,
+  );
+
+  const driverScores = new Map();
+  for (const d of drivers) {
+    driverScores.set(d.id, { percentile: d.score });
+  }
+
+  const growthResult = await growth({
+    team: summitTeam,
+    mapData,
+    evidence: summitEvidence,
+    driverScores,
+  });
+
+  if (growthResult.warnings.length > 0) {
+    meta.warnings.push(...growthResult.warnings);
+  }
+
+  if (growthResult.available && growthResult.recommendations.length > 0) {
+    for (const rec of growthResult.recommendations) {
+      for (const d of drivers) {
+        const contributes = d.contributingSkills.some(
+          (s) => s.skillId === rec.skill,
+        );
+        if (contributes) {
+          d.recommendations.push(rec);
+        }
+      }
+    }
+  }
+
+  return growthResult;
+}
+
+/** Build the evidence map that Summit expects. */
+async function buildSummitEvidence(q, supabase, options, teamEmails) {
+  const allEvidence = await q.getEvidence(supabase, {});
+  const teamAllEvidence = options.manager
+    ? filterEvidenceByTeam(allEvidence, teamEmails)
+    : allEvidence;
+  const evidenceBySkill = groupEvidenceBySkill(teamAllEvidence);
+
+  const summitEvidence = new Map();
+  for (const [skillId, group] of evidenceBySkill) {
+    const practitioners = new Set(
+      group.rows
+        .filter((r) => r.matched)
+        .map((r) => r.github_artifacts?.email)
+        .filter(Boolean),
+    );
+    summitEvidence.set(skillId, { practitioners, count: group.matched });
+  }
+  return summitEvidence;
+}

--- a/products/landmark/src/commands/initiative.js
+++ b/products/landmark/src/commands/initiative.js
@@ -1,0 +1,168 @@
+/**
+ * `fit-landmark initiative list|show|impact`
+ *
+ * Initiative tracking views.
+ */
+
+import {
+  listInitiatives,
+  getInitiative,
+} from "@forwardimpact/map/activity/queries/initiatives";
+import {
+  listSnapshots,
+  getSnapshotScores,
+} from "@forwardimpact/map/activity/queries/snapshots";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+import { isRelationNotFoundError } from "../lib/supabase.js";
+import { computeInitiativeImpact } from "../lib/initiative-helpers.js";
+
+export const needsSupabase = true;
+
+export async function runInitiativeCommand({
+  args,
+  options,
+  supabase,
+  mapData,
+  format,
+  queries,
+}) {
+  const q = queries ?? {
+    listInitiatives,
+    getInitiative,
+    listSnapshots,
+    getSnapshotScores,
+  };
+  const [sub] = args;
+
+  switch (sub) {
+    case "list":
+      return runList({ options, supabase, format, q });
+    case "show":
+      return runShow({ options, supabase, format, q });
+    case "impact":
+      return runImpact({ options, supabase, mapData, format, q });
+    default:
+      throw new Error(
+        'initiative: expected "list", "show", or "impact" subcommand',
+      );
+  }
+}
+
+async function runList({ options, supabase, format, q }) {
+  let initiatives;
+  try {
+    initiatives = await q.listInitiatives(supabase, {
+      managerEmail: options.manager,
+    });
+  } catch (err) {
+    if (isRelationNotFoundError(err)) {
+      return {
+        view: null,
+        meta: { format, emptyState: EMPTY_STATES.NO_INITIATIVES },
+      };
+    }
+    throw err;
+  }
+
+  if (!initiatives || initiatives.length === 0) {
+    return {
+      view: null,
+      meta: { format, emptyState: EMPTY_STATES.NO_INITIATIVES },
+    };
+  }
+
+  return { view: { initiatives }, meta: { format } };
+}
+
+async function runShow({ options, supabase, format, q }) {
+  if (!options.id) {
+    throw new Error("initiative show: --id <id> is required");
+  }
+
+  let initiative;
+  try {
+    initiative = await q.getInitiative(supabase, options.id);
+  } catch (err) {
+    if (isRelationNotFoundError(err)) {
+      return {
+        view: null,
+        meta: { format, emptyState: EMPTY_STATES.NO_INITIATIVES },
+      };
+    }
+    throw err;
+  }
+
+  if (!initiative) {
+    return {
+      view: null,
+      meta: {
+        format,
+        emptyState: `No initiative found with id ${options.id}.`,
+      },
+    };
+  }
+
+  return { view: { initiative }, meta: { format } };
+}
+
+async function runImpact({ options, supabase, mapData, format, q }) {
+  let completed;
+  try {
+    completed = await q.listInitiatives(supabase, {
+      managerEmail: options.manager,
+      status: "completed",
+    });
+  } catch (err) {
+    if (isRelationNotFoundError(err)) {
+      return {
+        view: null,
+        meta: { format, emptyState: EMPTY_STATES.NO_INITIATIVES },
+      };
+    }
+    throw err;
+  }
+
+  if (!completed || completed.length === 0) {
+    return {
+      view: null,
+      meta: { format, emptyState: EMPTY_STATES.NO_INITIATIVES },
+    };
+  }
+
+  const snapshots = await q.listSnapshots(supabase);
+
+  // Build scores lookup
+  const scoresBySnapshot = new Map();
+  const relevantSnapshotIds = new Set(snapshots.map((s) => s.snapshot_id));
+
+  for (const snapshotId of relevantSnapshotIds) {
+    const scores = await q.getSnapshotScores(supabase, snapshotId, {
+      managerEmail: options.manager,
+    });
+    const scoreMap = new Map();
+    for (const s of scores) {
+      scoreMap.set(s.item_id, s.score);
+    }
+    scoresBySnapshot.set(snapshotId, scoreMap);
+  }
+
+  const impacts = computeInitiativeImpact({
+    completed,
+    snapshots,
+    scoresBySnapshot,
+  });
+
+  // Enrich with driver name from mapData
+  const driverMap = new Map((mapData.drivers ?? []).map((d) => [d.id, d]));
+
+  const enriched = impacts.map((i) => ({
+    ...i,
+    driverName: driverMap.get(i.initiative.scorecard_id)?.name ?? null,
+  }));
+
+  return {
+    view: { impacts: enriched },
+    meta: { format },
+  };
+}

--- a/products/landmark/src/commands/marker.js
+++ b/products/landmark/src/commands/marker.js
@@ -1,0 +1,76 @@
+/**
+ * `fit-landmark marker <skill> [--level <level>]` — marker reference view.
+ *
+ * Displays marker definitions from Map's capability YAML files.
+ * Does not require Supabase.
+ */
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+
+export const needsSupabase = false;
+
+/**
+ * @param {object} params
+ * @param {string[]} params.args
+ * @param {object} params.options
+ * @param {object} params.mapData
+ * @param {string} params.format
+ */
+export async function runMarkerCommand({ args, options, mapData, format }) {
+  const [skillId] = args;
+  if (!skillId) {
+    throw new Error("marker: skill id is required");
+  }
+
+  const skill = findSkill(mapData, skillId);
+  if (!skill) {
+    return {
+      view: null,
+      meta: { format, emptyState: `Skill not found: ${skillId}` },
+    };
+  }
+
+  const markers = skill.markers ?? null;
+  if (!markers || Object.keys(markers).length === 0) {
+    return {
+      view: null,
+      meta: {
+        format,
+        emptyState: EMPTY_STATES.NO_MARKERS_FOR_SKILL(skillId),
+      },
+    };
+  }
+
+  const levelFilter = options.level ?? null;
+  let filtered;
+  if (levelFilter) {
+    const levelMarkers = markers[levelFilter];
+    if (!levelMarkers) {
+      return {
+        view: null,
+        meta: {
+          format,
+          emptyState: EMPTY_STATES.NO_MARKERS_FOR_SKILL(
+            `${skillId} at level ${levelFilter}`,
+          ),
+        },
+      };
+    }
+    filtered = { [levelFilter]: levelMarkers };
+  } else {
+    filtered = markers;
+  }
+
+  return {
+    view: { skill: skill.id, name: skill.name, markers: filtered },
+    meta: { format },
+  };
+}
+
+/**
+ * Find a skill by id across all capabilities in mapData.
+ */
+function findSkill(mapData, skillId) {
+  const skills = mapData.skills ?? [];
+  return skills.find((s) => s.id === skillId) ?? null;
+}

--- a/products/landmark/src/commands/org.js
+++ b/products/landmark/src/commands/org.js
@@ -1,0 +1,73 @@
+/**
+ * `fit-landmark org show|team` — organization directory views.
+ */
+
+import {
+  getOrganization,
+  getTeam,
+} from "@forwardimpact/map/activity/queries/org";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+
+export const needsSupabase = true;
+
+/**
+ * @param {object} params
+ * @param {string[]} params.args
+ * @param {object} params.options
+ * @param {object} params.supabase
+ * @param {string} params.format
+ * @param {object} [params.queries] - Injectable query module for testing.
+ */
+export async function runOrgCommand({
+  args,
+  options,
+  supabase,
+  format,
+  queries,
+}) {
+  const q = queries ?? { getOrganization, getTeam };
+  const [sub] = args;
+
+  switch (sub) {
+    case "show":
+      return showOrganization({ supabase, format, q });
+    case "team":
+      return showTeam({
+        supabase,
+        managerEmail: options.manager,
+        format,
+        q,
+      });
+    default:
+      throw new Error('org: expected "show" or "team" subcommand');
+  }
+}
+
+async function showOrganization({ supabase, format, q }) {
+  const people = await q.getOrganization(supabase);
+  if (!people || people.length === 0) {
+    return {
+      view: null,
+      meta: { format, emptyState: EMPTY_STATES.NO_ORGANIZATION },
+    };
+  }
+  return { view: { people }, meta: { format } };
+}
+
+async function showTeam({ supabase, managerEmail, format, q }) {
+  if (!managerEmail) {
+    throw new Error("org team: --manager <email> is required");
+  }
+  const members = await q.getTeam(supabase, managerEmail);
+  if (!members || members.length === 0) {
+    return {
+      view: null,
+      meta: {
+        format,
+        emptyState: EMPTY_STATES.MANAGER_NOT_FOUND(managerEmail),
+      },
+    };
+  }
+  return { view: { team: members, managerEmail }, meta: { format } };
+}

--- a/products/landmark/src/commands/practice.js
+++ b/products/landmark/src/commands/practice.js
@@ -1,0 +1,38 @@
+/**
+ * `fit-landmark practice [--skill <id>] [--manager <email>]`
+ *
+ * Show practice-pattern aggregates for manager-defined teams.
+ */
+
+import { getPracticePatterns } from "@forwardimpact/map/activity/queries/evidence";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+
+export const needsSupabase = true;
+
+export async function runPracticeCommand({
+  options,
+  supabase,
+  format,
+  queries,
+}) {
+  const q = queries ?? { getPracticePatterns };
+
+  const filterOpts = {};
+  if (options.skill) filterOpts.skillId = options.skill;
+  if (options.manager) filterOpts.managerEmail = options.manager;
+
+  const patterns = await q.getPracticePatterns(supabase, filterOpts);
+
+  if (!patterns || patterns.length === 0) {
+    return {
+      view: null,
+      meta: { format, emptyState: EMPTY_STATES.NO_EVIDENCE },
+    };
+  }
+
+  return {
+    view: { patterns, filters: filterOpts },
+    meta: { format },
+  };
+}

--- a/products/landmark/src/commands/practiced.js
+++ b/products/landmark/src/commands/practiced.js
@@ -1,0 +1,146 @@
+/**
+ * `fit-landmark practiced --manager <email>`
+ *
+ * Show evidenced depth alongside derived depth for a manager's team.
+ */
+
+import { getTeam } from "@forwardimpact/map/activity/queries/org";
+import { getPracticePatterns } from "@forwardimpact/map/activity/queries/evidence";
+import { deriveSkillMatrix } from "@forwardimpact/libskill";
+import { SKILL_PROFICIENCY_ORDER } from "@forwardimpact/map/levels";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+
+export const needsSupabase = true;
+
+export async function runPracticedCommand({
+  options,
+  mapData,
+  supabase,
+  format,
+  queries,
+}) {
+  const q = queries ?? { getTeam, getPracticePatterns };
+
+  if (!options.manager) {
+    throw new Error("practiced: --manager <email> is required");
+  }
+
+  const team = await q.getTeam(supabase, options.manager);
+  if (!team || team.length === 0) {
+    return {
+      view: null,
+      meta: {
+        format,
+        emptyState: EMPTY_STATES.MANAGER_NOT_FOUND(options.manager),
+      },
+    };
+  }
+
+  // Derive expected skills per team member, aggregate highest per skill
+  const derivedDepths = aggregateDerivedDepths(team, mapData);
+
+  // Fetch practice patterns
+  const patterns = await q.getPracticePatterns(supabase, {
+    managerEmail: options.manager,
+  });
+
+  const evidencedDepths = buildEvidencedDepths(patterns);
+
+  // Build the comparison view
+  const skills = buildSkillComparison(derivedDepths, evidencedDepths, mapData);
+
+  const hasEvidence = patterns.length > 0;
+
+  return {
+    view: {
+      managerEmail: options.manager,
+      teamSize: team.length,
+      skills,
+    },
+    meta: {
+      format,
+      emptyState: hasEvidence ? undefined : EMPTY_STATES.NO_EVIDENCE,
+    },
+  };
+}
+
+/** Aggregate highest derived depth per skill across all team members. */
+function aggregateDerivedDepths(team, mapData) {
+  const derivedDepths = new Map();
+  for (const member of team) {
+    const discipline = (mapData.disciplines ?? []).find(
+      (d) => d.id === member.discipline,
+    );
+    const level = (mapData.levels ?? []).find((l) => l.id === member.level);
+    const track = member.track
+      ? (mapData.tracks ?? []).find((t) => t.id === member.track)
+      : null;
+
+    if (!discipline || !level) continue;
+
+    const matrix = deriveSkillMatrix({
+      discipline,
+      level,
+      track,
+      skills: mapData.skills,
+    });
+
+    for (const entry of matrix) {
+      const currentIdx = derivedDepths.get(entry.skillId) ?? -1;
+      const entryIdx = SKILL_PROFICIENCY_ORDER.indexOf(entry.proficiency);
+      if (entryIdx > currentIdx) {
+        derivedDepths.set(entry.skillId, entryIdx);
+      }
+    }
+  }
+  return derivedDepths;
+}
+
+/** Extract evidenced skill depths from practice patterns. */
+function buildEvidencedDepths(patterns) {
+  const evidencedDepths = new Map();
+  for (const p of patterns) {
+    if (p.matched > 0) {
+      evidencedDepths.set(p.skill_id, p.matched);
+    }
+  }
+  return evidencedDepths;
+}
+
+/** Build sorted skill comparison rows from derived and evidenced depths. */
+function buildSkillComparison(derivedDepths, evidencedDepths, mapData) {
+  const allSkillIds = new Set([
+    ...derivedDepths.keys(),
+    ...evidencedDepths.keys(),
+  ]);
+
+  const skills = [];
+  for (const skillId of allSkillIds) {
+    const derivedIdx = derivedDepths.get(skillId) ?? -1;
+    const derivedDepth =
+      derivedIdx >= 0 ? SKILL_PROFICIENCY_ORDER[derivedIdx] : null;
+    const evidencedCount = evidencedDepths.get(skillId) ?? 0;
+    const skillObj = (mapData.skills ?? []).find((s) => s.id === skillId);
+
+    const flag = deriveFlag(derivedDepth, evidencedCount);
+
+    skills.push({
+      skillId,
+      skillName: skillObj?.name ?? skillId,
+      derivedDepth,
+      evidencedCount,
+      flag,
+    });
+  }
+
+  skills.sort((a, b) => a.skillId.localeCompare(b.skillId));
+  return skills;
+}
+
+/** Determine the flag for a skill based on derived vs evidenced status. */
+function deriveFlag(derivedDepth, evidencedCount) {
+  if (derivedDepth && evidencedCount === 0) return "on paper only";
+  if (!derivedDepth && evidencedCount > 0) return "evidenced beyond role";
+  return null;
+}

--- a/products/landmark/src/commands/readiness.js
+++ b/products/landmark/src/commands/readiness.js
@@ -1,0 +1,176 @@
+/**
+ * `fit-landmark readiness --email <email> [--target <level>]`
+ *
+ * Show marker checklist for a target level.
+ */
+
+import { getPerson } from "@forwardimpact/map/activity/queries/org";
+import { getEvidence } from "@forwardimpact/map/activity/queries/evidence";
+import { deriveSkillMatrix, getNextLevel } from "@forwardimpact/libskill";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+import { buildMarkerChecklist } from "../lib/evidence-helpers.js";
+
+export const needsSupabase = true;
+
+export async function runReadinessCommand({
+  options,
+  mapData,
+  supabase,
+  format,
+  queries,
+}) {
+  const q = queries ?? { getPerson, getEvidence };
+
+  if (!options.email) {
+    throw new Error("readiness: --email <email> is required");
+  }
+
+  const person = await q.getPerson(supabase, options.email);
+  if (!person) {
+    return emptyResult(format, EMPTY_STATES.PERSON_NOT_FOUND(options.email));
+  }
+
+  const resolved = resolveTargetLevel(person, options, mapData);
+  if (resolved.error) return emptyResult(format, resolved.error);
+
+  const { currentLevel, targetLevel, discipline, track } = resolved;
+
+  const matrix = deriveSkillMatrix({
+    discipline,
+    level: targetLevel,
+    track,
+    skills: mapData.skills,
+  });
+
+  const { checklist, skippedSkills } = partitionMatrix(matrix, mapData);
+
+  if (checklist.length === 0) {
+    return emptyResult(format, EMPTY_STATES.NO_MARKERS_AT_TARGET);
+  }
+
+  const evidenceRows = await q.getEvidence(supabase, { email: options.email });
+  const matchedEvidence = (evidenceRows ?? []).filter((e) => e.matched);
+
+  const items = buildChecklistItems(checklist, matchedEvidence);
+  const summary = summarizeChecklist(items);
+
+  return {
+    view: {
+      email: options.email,
+      currentLevel: currentLevel.id,
+      targetLevel: targetLevel.id,
+      checklist: items,
+      skippedSkills,
+      summary,
+    },
+    meta: { format },
+  };
+}
+
+function emptyResult(format, emptyState) {
+  return { view: null, meta: { format, emptyState } };
+}
+
+/** Resolve current level, target level, discipline, and track from the person and options. */
+function resolveTargetLevel(person, options, mapData) {
+  const currentLevel = (mapData.levels ?? []).find(
+    (l) => l.id === person.level,
+  );
+  if (!currentLevel) {
+    return { error: `Unknown level "${person.level}" for ${options.email}.` };
+  }
+
+  let targetLevel;
+  if (options.target) {
+    targetLevel = (mapData.levels ?? []).find((l) => l.id === options.target);
+    if (!targetLevel) {
+      return { error: `Unknown target level "${options.target}".` };
+    }
+  } else {
+    targetLevel = getNextLevel({ level: currentLevel, levels: mapData.levels });
+    if (!targetLevel) {
+      return { error: EMPTY_STATES.NO_HIGHER_LEVEL(currentLevel.id) };
+    }
+  }
+
+  const discipline = (mapData.disciplines ?? []).find(
+    (d) => d.id === person.discipline,
+  );
+  if (!discipline) {
+    return {
+      error: `Unknown discipline "${person.discipline}" for ${options.email}.`,
+    };
+  }
+
+  const track = person.track
+    ? (mapData.tracks ?? []).find((t) => t.id === person.track)
+    : null;
+
+  return { currentLevel, targetLevel, discipline, track };
+}
+
+/** Check if a marker entry has any content. */
+function hasMarkers(markers) {
+  if (!markers) return false;
+  const hasHuman = markers.human && markers.human.length > 0;
+  const hasAgent = markers.agent && markers.agent.length > 0;
+  return hasHuman || hasAgent;
+}
+
+/** Partition matrix entries into those with markers and those without. */
+function partitionMatrix(matrix, mapData) {
+  const checklist = [];
+  const skippedSkills = [];
+
+  for (const entry of matrix) {
+    const skill = (mapData.skills ?? []).find((s) => s.id === entry.skillId);
+    if (!skill) continue;
+
+    const markers = skill.markers?.[entry.proficiency];
+    if (!hasMarkers(markers)) {
+      skippedSkills.push({
+        skillId: entry.skillId,
+        reason: `no markers at ${entry.proficiency}`,
+      });
+      continue;
+    }
+
+    checklist.push({
+      skillId: entry.skillId,
+      skillName: entry.skillName,
+      proficiency: entry.proficiency,
+      markers,
+    });
+  }
+
+  return { checklist, skippedSkills };
+}
+
+/** Build checklist items from checklist entries and matched evidence. */
+function buildChecklistItems(checklist, matchedEvidence) {
+  return checklist.map((entry) => {
+    const skillEvidence = matchedEvidence.filter(
+      (e) => e.skill_id === entry.skillId,
+    );
+    return {
+      skillId: entry.skillId,
+      skillName: entry.skillName,
+      proficiency: entry.proficiency,
+      items: buildMarkerChecklist(entry.markers, skillEvidence),
+    };
+  });
+}
+
+/** Summarize the checklist into evidenced/total/missing. */
+function summarizeChecklist(items) {
+  const total = items.reduce((sum, s) => sum + s.items.length, 0);
+  const evidenced = items.reduce(
+    (sum, s) => sum + s.items.filter((i) => i.evidenced).length,
+    0,
+  );
+  const missing = items.flatMap((s) =>
+    s.items.filter((i) => !i.evidenced).map((i) => i.marker),
+  );
+  return { evidenced, total, missing };
+}

--- a/products/landmark/src/commands/snapshot.js
+++ b/products/landmark/src/commands/snapshot.js
@@ -1,0 +1,140 @@
+/**
+ * `fit-landmark snapshot list|show|trend|compare` — GetDX snapshot views.
+ */
+
+import {
+  listSnapshots,
+  getSnapshotScores,
+  getItemTrend,
+  getSnapshotComparison,
+} from "@forwardimpact/map/activity/queries/snapshots";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+
+export const needsSupabase = true;
+
+/**
+ * @param {object} params
+ * @param {string[]} params.args
+ * @param {object} params.options
+ * @param {object} params.mapData
+ * @param {object} params.supabase
+ * @param {string} params.format
+ * @param {object} [params.queries] - Injectable query module for testing.
+ */
+export async function runSnapshotCommand({
+  args,
+  options,
+  mapData,
+  supabase,
+  format,
+  queries,
+}) {
+  const q = queries ?? {
+    listSnapshots,
+    getSnapshotScores,
+    getItemTrend,
+    getSnapshotComparison,
+  };
+  const [sub] = args;
+
+  switch (sub) {
+    case "list":
+      return runList({ supabase, format, q });
+    case "show":
+      return runShow({ supabase, options, mapData, format, q });
+    case "trend":
+      return runTrend({ supabase, options, format, q });
+    case "compare":
+      return runCompare({ supabase, options, mapData, format, q });
+    default:
+      throw new Error(
+        'snapshot: expected "list", "show", "trend", or "compare" subcommand',
+      );
+  }
+}
+
+async function runList({ supabase, format, q }) {
+  const snapshots = await q.listSnapshots(supabase);
+  if (!snapshots || snapshots.length === 0) {
+    return {
+      view: null,
+      meta: { format, emptyState: EMPTY_STATES.NO_SNAPSHOTS },
+    };
+  }
+  return { view: { snapshots }, meta: { format } };
+}
+
+async function runShow({ supabase, options, mapData, format, q }) {
+  if (!options.snapshot) {
+    throw new Error("snapshot show: --snapshot <id> is required");
+  }
+  const scores = await q.getSnapshotScores(supabase, options.snapshot, {
+    managerEmail: options.manager,
+  });
+  if (!scores || scores.length === 0) {
+    const emptyState = options.manager
+      ? EMPTY_STATES.MANAGER_NOT_FOUND(options.manager)
+      : EMPTY_STATES.NO_SNAPSHOTS;
+    return { view: null, meta: { format, emptyState } };
+  }
+  const warnings = collectDriverWarnings(scores, mapData);
+  return {
+    view: { snapshotId: options.snapshot, scores },
+    meta: { format, warnings },
+  };
+}
+
+async function runTrend({ supabase, options, format, q }) {
+  if (!options.item) {
+    throw new Error("snapshot trend: --item <item_id> is required");
+  }
+  const trend = await q.getItemTrend(supabase, options.item, {
+    managerEmail: options.manager,
+  });
+  if (!trend || trend.length === 0) {
+    return {
+      view: null,
+      meta: { format, emptyState: EMPTY_STATES.NO_SNAPSHOTS },
+    };
+  }
+  return { view: { itemId: options.item, trend }, meta: { format } };
+}
+
+async function runCompare({ supabase, options, mapData, format, q }) {
+  if (!options.snapshot) {
+    throw new Error("snapshot compare: --snapshot <id> is required");
+  }
+  const scores = await q.getSnapshotComparison(supabase, options.snapshot, {
+    managerEmail: options.manager,
+  });
+  if (!scores || scores.length === 0) {
+    const emptyState = options.manager
+      ? EMPTY_STATES.MANAGER_NOT_FOUND(options.manager)
+      : EMPTY_STATES.NO_SNAPSHOTS;
+    return { view: null, meta: { format, emptyState } };
+  }
+  const warnings = collectDriverWarnings(scores, mapData);
+  return {
+    view: { snapshotId: options.snapshot, scores },
+    meta: { format, warnings },
+  };
+}
+
+/**
+ * Cross-reference score item_ids against known drivers.
+ * Unknown items produce warnings.
+ */
+export function collectDriverWarnings(scores, mapData) {
+  const driverIds = new Set((mapData.drivers ?? []).map((d) => d.id));
+  const warnings = [];
+  for (const row of scores) {
+    if (row.item_id && !driverIds.has(row.item_id)) {
+      warnings.push(
+        `Unknown item_id "${row.item_id}" in snapshot scores — no matching driver in drivers.yaml.`,
+      );
+    }
+  }
+  // Deduplicate
+  return [...new Set(warnings)];
+}

--- a/products/landmark/src/commands/timeline.js
+++ b/products/landmark/src/commands/timeline.js
@@ -1,0 +1,44 @@
+/**
+ * `fit-landmark timeline --email <email> [--skill <id>]`
+ *
+ * Individual growth timeline: aggregate evidence by quarter per skill.
+ */
+
+import { getEvidence } from "@forwardimpact/map/activity/queries/evidence";
+
+import { EMPTY_STATES } from "../lib/empty-state.js";
+import { highestLevelPerSkillPerQuarter } from "../lib/evidence-helpers.js";
+
+export const needsSupabase = true;
+
+export async function runTimelineCommand({
+  options,
+  supabase,
+  format,
+  queries,
+}) {
+  const q = queries ?? { getEvidence };
+
+  if (!options.email) {
+    throw new Error("timeline: --email <email> is required");
+  }
+
+  const filterOpts = { email: options.email };
+  if (options.skill) filterOpts.skillId = options.skill;
+
+  const evidenceRows = await q.getEvidence(supabase, filterOpts);
+
+  if (!evidenceRows || evidenceRows.length === 0) {
+    return {
+      view: null,
+      meta: { format, emptyState: EMPTY_STATES.NO_EVIDENCE },
+    };
+  }
+
+  const timeline = highestLevelPerSkillPerQuarter(evidenceRows);
+
+  return {
+    view: { email: options.email, timeline },
+    meta: { format },
+  };
+}

--- a/products/landmark/src/commands/voice.js
+++ b/products/landmark/src/commands/voice.js
@@ -1,0 +1,235 @@
+/**
+ * `fit-landmark voice --manager <email> | --email <email>`
+ *
+ * Surface engineer voice from GetDX snapshot comments.
+ */
+
+import { getSnapshotComments } from "@forwardimpact/map/activity/queries/comments";
+import { getEvidence } from "@forwardimpact/map/activity/queries/evidence";
+import {
+  listSnapshots,
+  getSnapshotScores,
+} from "@forwardimpact/map/activity/queries/snapshots";
+import { isRelationNotFoundError } from "../lib/supabase.js";
+import { EMPTY_STATES } from "../lib/empty-state.js";
+import { groupEvidenceBySkill } from "../lib/evidence-helpers.js";
+
+export const needsSupabase = true;
+
+/** Simple theme keywords for crude bucketing. */
+const THEME_KEYWORDS = [
+  "estimation",
+  "incident",
+  "planning",
+  "handoff",
+  "onboarding",
+  "deploy",
+  "runbook",
+  "testing",
+  "documentation",
+  "tooling",
+];
+
+export async function runVoiceCommand({
+  options,
+  supabase,
+  mapData,
+  format,
+  queries,
+}) {
+  const q = queries ?? {
+    getSnapshotComments,
+    getEvidence,
+    listSnapshots,
+    getSnapshotScores,
+  };
+
+  if (options.email) {
+    return runEmailVoice({
+      email: options.email,
+      supabase,
+      mapData,
+      format,
+      q,
+    });
+  }
+  if (options.manager) {
+    return runManagerVoice({
+      managerEmail: options.manager,
+      supabase,
+      mapData,
+      format,
+      q,
+    });
+  }
+  throw new Error("voice: one of --email or --manager is required");
+}
+
+async function runEmailVoice({
+  email,
+  supabase,
+  mapData: _mapData,
+  format,
+  q,
+}) {
+  let comments;
+  try {
+    comments = await q.getSnapshotComments(supabase, { email });
+  } catch (err) {
+    if (isRelationNotFoundError(err)) {
+      return {
+        view: null,
+        meta: { format, emptyState: EMPTY_STATES.NO_COMMENTS },
+      };
+    }
+    throw err;
+  }
+
+  if (!comments || comments.length === 0) {
+    return {
+      view: null,
+      meta: {
+        format,
+        emptyState: EMPTY_STATES.NO_COMMENTS,
+        hint: "No comments in scope — try broadening the --email filter.",
+      },
+    };
+  }
+
+  // Limit to last 4 snapshots
+  const snapshotIds = [...new Set(comments.map((c) => c.snapshot_id))];
+  const recentSnapshots = snapshotIds.slice(0, 4);
+  const recentComments = comments.filter((c) =>
+    recentSnapshots.includes(c.snapshot_id),
+  );
+
+  // Get evidence context
+  const evidenceRows = await q.getEvidence(supabase, { email });
+  const evidenceBySkill = groupEvidenceBySkill(evidenceRows);
+
+  const evidenceContext = [];
+  for (const [skillId, group] of evidenceBySkill) {
+    evidenceContext.push({
+      skillId,
+      matched: group.matched,
+      highestLevel: null, // simplified
+    });
+  }
+
+  return {
+    view: {
+      mode: "email",
+      email,
+      comments: recentComments.map((c) => ({
+        snapshotDate: c.getdx_snapshots?.scheduled_for ?? c.snapshot_id,
+        text: c.text,
+      })),
+      evidenceContext,
+    },
+    meta: { format },
+  };
+}
+
+async function runManagerVoice({ managerEmail, supabase, mapData, format, q }) {
+  let comments;
+  try {
+    comments = await q.getSnapshotComments(supabase, { managerEmail });
+  } catch (err) {
+    if (isRelationNotFoundError(err)) {
+      return {
+        view: null,
+        meta: { format, emptyState: EMPTY_STATES.NO_COMMENTS },
+      };
+    }
+    throw err;
+  }
+
+  if (!comments || comments.length === 0) {
+    return {
+      view: null,
+      meta: {
+        format,
+        emptyState: EMPTY_STATES.NO_COMMENTS,
+        hint: "No comments in scope — try broadening the --manager filter.",
+      },
+    };
+  }
+
+  const sortedThemes = bucketCommentsByTheme(comments);
+  const healthAlignment = await findHealthAlignment(
+    q,
+    supabase,
+    managerEmail,
+    mapData,
+  );
+
+  return {
+    view: {
+      mode: "manager",
+      managerEmail,
+      totalComments: comments.length,
+      themes: sortedThemes,
+      healthAlignment,
+    },
+    meta: { format },
+  };
+}
+
+/** Bucket comments by theme keywords and return sorted by count. */
+function bucketCommentsByTheme(comments) {
+  const themes = new Map();
+  for (const keyword of THEME_KEYWORDS) {
+    themes.set(keyword, { count: 0, snippets: [] });
+  }
+
+  for (const c of comments) {
+    const lower = (c.text ?? "").toLowerCase();
+    for (const keyword of THEME_KEYWORDS) {
+      if (lower.includes(keyword)) {
+        const theme = themes.get(keyword);
+        theme.count++;
+        if (theme.snippets.length < 2) {
+          theme.snippets.push(c.text);
+        }
+      }
+    }
+  }
+
+  return [...themes.entries()]
+    .filter(([, v]) => v.count > 0)
+    .sort((a, b) => b[1].count - a[1].count)
+    .map(([keyword, data]) => ({
+      theme: keyword,
+      count: data.count,
+      snippets: data.snippets,
+    }));
+}
+
+/** Find health signals that score below 50th percentile. */
+async function findHealthAlignment(q, supabase, managerEmail, mapData) {
+  try {
+    const snapshots = await q.listSnapshots(supabase);
+    if (!snapshots || snapshots.length === 0) return [];
+
+    const latestScores = await q.getSnapshotScores(
+      supabase,
+      snapshots[0].snapshot_id,
+      { managerEmail },
+    );
+    const driverMap = new Map((mapData.drivers ?? []).map((d) => [d.id, d]));
+    const alignment = [];
+    for (const score of latestScores) {
+      const driver = driverMap.get(score.item_id);
+      if (driver && score.score != null && score.score < 50) {
+        alignment.push({
+          driverId: driver.id,
+          driverName: driver.name,
+          percentile: score.score,
+        });
+      }
+    }
+    return alignment;
+  } catch {
+    return [];
+  }
+}

--- a/products/landmark/src/formatters/coverage.js
+++ b/products/landmark/src/formatters/coverage.js
@@ -1,0 +1,59 @@
+/**
+ * Formatters for the `coverage` command.
+ */
+
+import { padRight, renderHeader } from "./shared.js";
+
+export function toText(view) {
+  const lines = [
+    renderHeader(`Evidence coverage for ${view.name} (${view.email})`),
+    "",
+  ];
+
+  const pct = (view.coverage.ratio * 100).toFixed(1);
+  lines.push(
+    `    ${view.coverage.scored}/${view.coverage.total} artifacts interpreted (${pct}%)`,
+  );
+  lines.push("");
+
+  const types = Object.keys(view.byType).sort();
+  if (types.length > 0) {
+    lines.push("    By type:");
+    for (const type of types) {
+      const total = view.byType[type];
+      const uncovered = view.uncoveredByType[type] ?? 0;
+      const covered = total - uncovered;
+      lines.push(
+        `      ${padRight(type, 20)}  ${covered}/${total} interpreted`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  const pct = (view.coverage.ratio * 100).toFixed(1);
+  const lines = [
+    `# Evidence coverage for ${view.name} (${view.email})`,
+    "",
+    `**${view.coverage.scored}/${view.coverage.total}** artifacts interpreted (${pct}%)`,
+    "",
+    "| Type | Covered | Total |",
+    "| --- | --- | --- |",
+  ];
+
+  for (const type of Object.keys(view.byType).sort()) {
+    const total = view.byType[type];
+    const uncovered = view.uncoveredByType[type] ?? 0;
+    const covered = total - uncovered;
+    lines.push(`| ${type} | ${covered} | ${total} |`);
+  }
+
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/evidence.js
+++ b/products/landmark/src/formatters/evidence.js
@@ -1,0 +1,61 @@
+/**
+ * Formatters for the `evidence` command.
+ */
+
+import { renderHeader } from "./shared.js";
+
+export function toText(view) {
+  const lines = [renderHeader("Evidence"), ""];
+
+  for (const [skillId, group] of Object.entries(view.evidence)) {
+    lines.push(
+      `    ${skillId}: ${group.matched} matched, ${group.unmatched} unmatched`,
+    );
+    for (const row of group.rows.slice(0, 5)) {
+      const marker = row.marker_text ?? "(no marker)";
+      const status = row.matched ? "[matched]" : "[unmatched]";
+      lines.push(`      ${status} ${marker}`);
+      if (row.rationale) lines.push(`        rationale: ${row.rationale}`);
+    }
+    if (group.rows.length > 5) {
+      lines.push(`      ... and ${group.rows.length - 5} more`);
+    }
+    lines.push("");
+  }
+
+  if (view.coverage) {
+    lines.push(
+      `    Evidence covers ${view.coverage.scored}/${view.coverage.total} artifacts.`,
+    );
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  const lines = ["# Evidence", ""];
+
+  for (const [skillId, group] of Object.entries(view.evidence)) {
+    lines.push(`## ${skillId}`);
+    lines.push(`${group.matched} matched, ${group.unmatched} unmatched`);
+    lines.push("");
+    for (const row of group.rows) {
+      const status = row.matched ? "✓" : "✗";
+      lines.push(`- ${status} ${row.marker_text ?? "(no marker)"}`);
+    }
+    lines.push("");
+  }
+
+  if (view.coverage) {
+    lines.push(
+      `Evidence covers ${view.coverage.scored}/${view.coverage.total} artifacts.`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/health.js
+++ b/products/landmark/src/formatters/health.js
@@ -1,0 +1,127 @@
+/**
+ * Formatters for the `health` command.
+ */
+
+import { formatDelta, renderHeader } from "./shared.js";
+
+export function toText(view) {
+  const lines = [renderHeader(`${view.teamLabel} — health view`), ""];
+
+  for (const driver of view.drivers) {
+    const scorePart =
+      driver.score != null ? `${driver.score}th percentile` : "n/a";
+    const orgPart =
+      driver.vs_org != null ? `vs_org: ${formatDelta(driver.vs_org)}` : "";
+    lines.push(
+      `    Driver: ${driver.name} (${scorePart}${orgPart ? ", " + orgPart : ""})`,
+    );
+
+    const skillNames = driver.contributingSkills
+      .map((s) => s.skillId)
+      .join(", ");
+    lines.push(`      Contributing skills: ${skillNames}`);
+
+    const evidenceParts = driver.contributingSkills.map(
+      (s) => `${s.count} artifacts for ${s.skillId}`,
+    );
+    lines.push(`      Evidence: ${evidenceParts.join(", ")}`);
+
+    // <comments section> — Part 04 renders per-driver comments here
+    if (driver.comments && driver.comments.length > 0) {
+      const snippets = driver.comments.slice(0, 2).map((c) => `"${c.text}"`);
+      lines.push(
+        `      GetDX comments: ${snippets.join("\n                      ")}`,
+      );
+    }
+
+    // Recommendations from Summit
+    if (driver.recommendations && driver.recommendations.length > 0) {
+      for (const rec of driver.recommendations) {
+        const candidates = rec.candidates
+          .slice(0, 2)
+          .map((c) => `${c.name ?? c.email} (${c.currentLevel})`)
+          .join(" or ");
+        lines.push("");
+        lines.push(
+          `      ⮕ Recommendation: ${candidates} could develop ${rec.skill}.`,
+        );
+        lines.push(`        (Summit growth alignment: ${rec.impact})`);
+      }
+    }
+
+    // <initiatives section> — Part 05 renders per-driver initiatives here
+    if (driver.initiatives && driver.initiatives.length > 0) {
+      lines.push("");
+      lines.push("      Active initiatives:");
+      for (const init of driver.initiatives.slice(0, 3)) {
+        const pct =
+          init.completion_pct != null ? `${init.completion_pct}%` : "n/a";
+        lines.push(`        - ${init.name} (${pct} complete)`);
+      }
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  const lines = [`# ${view.teamLabel} — health view`, ""];
+
+  for (const driver of view.drivers) {
+    const scorePart =
+      driver.score != null ? `${driver.score}th percentile` : "n/a";
+    lines.push(`## Driver: ${driver.name} (${scorePart})`);
+    lines.push("");
+
+    const skillNames = driver.contributingSkills
+      .map((s) => s.skillId)
+      .join(", ");
+    lines.push(`**Contributing skills:** ${skillNames}`);
+
+    const evidenceParts = driver.contributingSkills.map(
+      (s) => `${s.count} artifacts for ${s.skillId}`,
+    );
+    lines.push(`**Evidence:** ${evidenceParts.join(", ")}`);
+
+    if (driver.comments && driver.comments.length > 0) {
+      lines.push("");
+      lines.push("**GetDX comments:**");
+      for (const c of driver.comments.slice(0, 2)) {
+        lines.push(`> ${c.text}`);
+      }
+    }
+
+    if (driver.recommendations && driver.recommendations.length > 0) {
+      lines.push("");
+      for (const rec of driver.recommendations) {
+        const candidates = rec.candidates
+          .slice(0, 2)
+          .map((c) => `${c.name ?? c.email} (${c.currentLevel})`)
+          .join(" or ");
+        lines.push(
+          `> **Recommendation:** ${candidates} could develop ${rec.skill}. (${rec.impact})`,
+        );
+      }
+    }
+
+    if (driver.initiatives && driver.initiatives.length > 0) {
+      lines.push("");
+      lines.push("**Active initiatives:**");
+      for (const init of driver.initiatives.slice(0, 3)) {
+        const pct =
+          init.completion_pct != null ? `${init.completion_pct}%` : "n/a";
+        lines.push(`- ${init.name} (${pct} complete)`);
+      }
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/index.js
+++ b/products/landmark/src/formatters/index.js
@@ -13,6 +13,7 @@ import * as evidenceFormatter from "./evidence.js";
 import * as readinessFormatter from "./readiness.js";
 import * as timelineFormatter from "./timeline.js";
 import * as coverageFormatter from "./coverage.js";
+import * as practiceFormatter from "./practice.js";
 import * as practicedFormatter from "./practiced.js";
 import * as healthFormatter from "./health.js";
 import * as voiceFormatter from "./voice.js";
@@ -26,19 +27,12 @@ const formatters = {
   readiness: readinessFormatter,
   timeline: timelineFormatter,
   coverage: coverageFormatter,
+  practice: practiceFormatter,
   practiced: practicedFormatter,
   health: healthFormatter,
   voice: voiceFormatter,
   initiative: initiativeFormatter,
 };
-
-/**
- * Register a new formatter. Used by later parts to add formatters
- * without modifying this file's static imports.
- */
-export function registerFormatter(name, formatter) {
-  formatters[name] = formatter;
-}
 
 /**
  * Format a command result into a string for output.

--- a/products/landmark/src/formatters/index.js
+++ b/products/landmark/src/formatters/index.js
@@ -1,0 +1,78 @@
+/**
+ * Formatter registry.
+ *
+ * Each command has a corresponding formatter module with toText, toJson,
+ * toMarkdown exports. This module dispatches to the correct formatter
+ * based on the command name and format.
+ */
+
+import * as orgFormatter from "./org.js";
+import * as snapshotFormatter from "./snapshot.js";
+import * as markerFormatter from "./marker.js";
+import * as evidenceFormatter from "./evidence.js";
+import * as readinessFormatter from "./readiness.js";
+import * as timelineFormatter from "./timeline.js";
+import * as coverageFormatter from "./coverage.js";
+import * as practicedFormatter from "./practiced.js";
+import * as healthFormatter from "./health.js";
+import * as voiceFormatter from "./voice.js";
+import * as initiativeFormatter from "./initiative.js";
+
+const formatters = {
+  org: orgFormatter,
+  snapshot: snapshotFormatter,
+  marker: markerFormatter,
+  evidence: evidenceFormatter,
+  readiness: readinessFormatter,
+  timeline: timelineFormatter,
+  coverage: coverageFormatter,
+  practiced: practicedFormatter,
+  health: healthFormatter,
+  voice: voiceFormatter,
+  initiative: initiativeFormatter,
+};
+
+/**
+ * Register a new formatter. Used by later parts to add formatters
+ * without modifying this file's static imports.
+ */
+export function registerFormatter(name, formatter) {
+  formatters[name] = formatter;
+}
+
+/**
+ * Format a command result into a string for output.
+ *
+ * @param {string} command - Command name.
+ * @param {{view: object|null, meta: object}} result - Command result.
+ * @returns {string}
+ */
+export function formatResult(command, result) {
+  const { view, meta } = result;
+
+  // Empty-state handling: all formats render only the message.
+  if (meta.emptyState) {
+    if (meta.format === "json") {
+      return (
+        JSON.stringify({ emptyState: meta.emptyState, view: null }, null, 2) +
+        "\n"
+      );
+    }
+    return `  ${meta.emptyState}\n`;
+  }
+
+  const fmt = formatters[command];
+  if (!fmt) {
+    // Fallback: JSON dump.
+    return JSON.stringify(result, null, 2) + "\n";
+  }
+
+  switch (meta.format) {
+    case "json":
+      return fmt.toJson(view, meta) + "\n";
+    case "markdown":
+      return fmt.toMarkdown(view, meta);
+    default:
+      return fmt.toText(view, meta);
+  }
+}

--- a/products/landmark/src/formatters/initiative.js
+++ b/products/landmark/src/formatters/initiative.js
@@ -1,0 +1,145 @@
+/**
+ * Formatters for the `initiative` command.
+ */
+
+import { formatDelta, padRight, renderHeader } from "./shared.js";
+
+export function toText(view) {
+  if (view.initiatives) return listToText(view);
+  if (view.initiative) return showToText(view);
+  if (view.impacts) return impactToText(view);
+  return "";
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  if (view.initiatives) return listToMarkdown(view);
+  if (view.initiative) return showToMarkdown(view);
+  if (view.impacts) return impactToMarkdown(view);
+  return "";
+}
+
+function listToText({ initiatives }) {
+  const lines = [renderHeader("Initiatives"), ""];
+  const nameWidth = Math.max(
+    20,
+    ...initiatives.map((i) => (i.name ?? "").length),
+  );
+
+  for (const init of initiatives) {
+    const name = padRight(init.name ?? "(unnamed)", nameWidth);
+    const pct = init.completion_pct != null ? `${init.completion_pct}%` : "n/a";
+    const status = init.completed_at ? "completed" : "active";
+    lines.push(
+      `    ${name}  ${padRight(pct, 6)}  ${status}  ${init.due_date ?? ""}`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function showToText({ initiative }) {
+  const init = initiative;
+  const lines = [renderHeader(`Initiative: ${init.name}`), ""];
+  lines.push(`    ID:          ${init.id}`);
+  lines.push(`    Description: ${init.description ?? "(none)"}`);
+  lines.push(`    Owner:       ${init.owner_email ?? "(none)"}`);
+  lines.push(`    Due date:    ${init.due_date ?? "(none)"}`);
+  lines.push(`    Priority:    ${init.priority ?? "(none)"}`);
+  lines.push(`    Scorecard:   ${init.scorecard_id ?? "(none)"}`);
+  const pct = init.completion_pct != null ? `${init.completion_pct}%` : "n/a";
+  lines.push(
+    `    Completion:  ${pct} (${init.passed_checks ?? 0}/${init.total_checks ?? 0} checks)`,
+  );
+  lines.push(`    Status:      ${init.completed_at ? "completed" : "active"}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function impactToText({ impacts }) {
+  const lines = [
+    renderHeader("Completed initiatives — outcome correlation"),
+    "",
+  ];
+
+  for (const item of impacts) {
+    const init = item.initiative;
+    lines.push(
+      `    "${init.name}" (completed ${init.completed_at ?? "unknown"})`,
+    );
+
+    const driver = item.driverName ?? init.scorecard_id;
+    if (driver) {
+      lines.push(`      Target driver: ${driver}`);
+    } else {
+      lines.push("      Target driver: (no driver linked)");
+    }
+
+    if (item.before != null) {
+      lines.push(`      Score before: ${item.before}`);
+      lines.push(`      Score after:  ${item.after}`);
+      lines.push(`      Change: ${formatDelta(item.delta)} percentile points`);
+    } else {
+      lines.push("      Score before: n/a");
+      lines.push("      Score after:  n/a");
+      lines.push("      Change: n/a");
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function listToMarkdown({ initiatives }) {
+  const lines = [
+    "# Initiatives",
+    "",
+    "| Name | Completion | Status | Due Date |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const init of initiatives) {
+    const pct = init.completion_pct != null ? `${init.completion_pct}%` : "n/a";
+    const status = init.completed_at ? "completed" : "active";
+    lines.push(
+      `| ${init.name} | ${pct} | ${status} | ${init.due_date ?? ""} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function showToMarkdown({ initiative }) {
+  const init = initiative;
+  return [
+    `# Initiative: ${init.name}`,
+    "",
+    `- **ID:** ${init.id}`,
+    `- **Owner:** ${init.owner_email ?? "(none)"}`,
+    `- **Due:** ${init.due_date ?? "(none)"}`,
+    `- **Completion:** ${init.completion_pct ?? "n/a"}% (${init.passed_checks ?? 0}/${init.total_checks ?? 0})`,
+    `- **Status:** ${init.completed_at ? "completed" : "active"}`,
+  ].join("\n");
+}
+
+function impactToMarkdown({ impacts }) {
+  const lines = ["# Initiative Impact", ""];
+  for (const item of impacts) {
+    const init = item.initiative;
+    lines.push(`## ${init.name}`);
+    lines.push(`Completed: ${init.completed_at ?? "unknown"}`);
+    if (item.driverName) {
+      lines.push(`Target driver: ${item.driverName}`);
+    }
+    if (item.delta != null) {
+      lines.push(
+        `Change: **${formatDelta(item.delta)}** percentile points (${item.before} → ${item.after})`,
+      );
+    } else {
+      lines.push("Change: n/a");
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/marker.js
+++ b/products/landmark/src/formatters/marker.js
@@ -1,0 +1,71 @@
+/**
+ * Formatters for the `marker` command.
+ */
+
+import { renderHeader } from "./shared.js";
+
+const PROFICIENCY_ORDER = [
+  "awareness",
+  "foundational",
+  "working",
+  "practitioner",
+  "expert",
+];
+
+export function toText(view) {
+  const lines = [renderHeader(`Markers for ${view.name} (${view.skill})`), ""];
+
+  const orderedLevels = PROFICIENCY_ORDER.filter((l) => view.markers[l]);
+
+  for (const level of orderedLevels) {
+    const entry = view.markers[level];
+    lines.push(`    ${level}:`);
+    if (entry.human && entry.human.length > 0) {
+      lines.push("      human:");
+      for (const m of entry.human) {
+        lines.push(`        - ${m}`);
+      }
+    }
+    if (entry.agent && entry.agent.length > 0) {
+      lines.push("      agent:");
+      for (const m of entry.agent) {
+        lines.push(`        - ${m}`);
+      }
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  const lines = [`# Markers for ${view.name} (${view.skill})`, ""];
+
+  const orderedLevels = PROFICIENCY_ORDER.filter((l) => view.markers[l]);
+
+  for (const level of orderedLevels) {
+    const entry = view.markers[level];
+    lines.push(`## ${level}`);
+    lines.push("");
+    if (entry.human && entry.human.length > 0) {
+      lines.push("**Human:**");
+      for (const m of entry.human) {
+        lines.push(`- ${m}`);
+      }
+      lines.push("");
+    }
+    if (entry.agent && entry.agent.length > 0) {
+      lines.push("**Agent:**");
+      for (const m of entry.agent) {
+        lines.push(`- ${m}`);
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/org.js
+++ b/products/landmark/src/formatters/org.js
@@ -1,0 +1,74 @@
+/**
+ * Formatters for the `org` command.
+ */
+
+import { padRight, renderHeader } from "./shared.js";
+
+export function toText(view) {
+  if (view.team) return teamToText(view);
+  return orgToText(view);
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  if (view.team) return teamToMarkdown(view);
+  return orgToMarkdown(view);
+}
+
+function orgToText({ people }) {
+  const lines = [renderHeader("Organization directory"), ""];
+  const nameWidth = Math.max(20, ...people.map((p) => (p.name ?? "").length));
+  for (const p of people) {
+    const name = padRight(p.name ?? "(unknown)", nameWidth);
+    const role = [p.discipline, p.level, p.track].filter(Boolean).join(" / ");
+    lines.push(`    ${name}  ${p.email}  ${role}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function teamToText({ team, managerEmail }) {
+  const lines = [renderHeader(`Team under ${managerEmail}`), ""];
+  const nameWidth = Math.max(20, ...team.map((p) => (p.name ?? "").length));
+  for (const p of team) {
+    const name = padRight(p.name ?? "(unknown)", nameWidth);
+    const role = [p.discipline, p.level, p.track].filter(Boolean).join(" / ");
+    const mgr = p.email === managerEmail ? " (manager)" : "";
+    lines.push(`    ${name}  ${p.email}  ${role}${mgr}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function orgToMarkdown({ people }) {
+  const lines = [
+    "# Organization directory",
+    "",
+    "| Name | Email | Role |",
+    "| --- | --- | --- |",
+  ];
+  for (const p of people) {
+    const role = [p.discipline, p.level, p.track].filter(Boolean).join(" / ");
+    lines.push(`| ${p.name ?? "(unknown)"} | ${p.email} | ${role} |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function teamToMarkdown({ team, managerEmail }) {
+  const lines = [
+    `# Team under ${managerEmail}`,
+    "",
+    "| Name | Email | Role |",
+    "| --- | --- | --- |",
+  ];
+  for (const p of team) {
+    const role = [p.discipline, p.level, p.track].filter(Boolean).join(" / ");
+    lines.push(`| ${p.name ?? "(unknown)"} | ${p.email} | ${role} |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/practice.js
+++ b/products/landmark/src/formatters/practice.js
@@ -1,0 +1,44 @@
+/**
+ * Formatters for the `practice` command.
+ */
+
+import { padRight, renderHeader } from "./shared.js";
+
+export function toText(view) {
+  const lines = [renderHeader("Practice patterns"), ""];
+
+  const nameWidth = Math.max(
+    20,
+    ...view.patterns.map((p) => p.skill_id.length),
+  );
+
+  for (const p of view.patterns) {
+    const name = padRight(p.skill_id, nameWidth);
+    lines.push(
+      `    ${name}  matched: ${p.matched}  unmatched: ${p.unmatched}  total: ${p.total}`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  const lines = [
+    "# Practice patterns",
+    "",
+    "| Skill | Matched | Unmatched | Total |",
+    "| --- | --- | --- | --- |",
+  ];
+
+  for (const p of view.patterns) {
+    lines.push(
+      `| ${p.skill_id} | ${p.matched} | ${p.unmatched} | ${p.total} |`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/practiced.js
+++ b/products/landmark/src/formatters/practiced.js
@@ -1,0 +1,52 @@
+/**
+ * Formatters for the `practiced` command.
+ */
+
+import { padRight, renderHeader } from "./shared.js";
+
+export function toText(view) {
+  const lines = [
+    renderHeader(
+      `Practiced capability — ${view.managerEmail} (${view.teamSize} members)`,
+    ),
+    "",
+  ];
+
+  const nameWidth = Math.max(20, ...view.skills.map((s) => s.skillName.length));
+
+  for (const skill of view.skills) {
+    const name = padRight(skill.skillName, nameWidth);
+    const derived = skill.derivedDepth ?? "(none)";
+    const evidenced =
+      skill.evidencedCount > 0 ? `${skill.evidencedCount} evidence rows` : "0";
+    const flag = skill.flag ? ` ← ${skill.flag}` : "";
+    lines.push(
+      `    ${name}  derived: ${padRight(derived, 15)}  evidenced: ${evidenced}${flag}`,
+    );
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  const lines = [
+    `# Practiced capability — ${view.managerEmail}`,
+    "",
+    "| Skill | Derived | Evidenced | Flag |",
+    "| --- | --- | --- | --- |",
+  ];
+
+  for (const skill of view.skills) {
+    const flag = skill.flag ?? "";
+    lines.push(
+      `| ${skill.skillName} | ${skill.derivedDepth ?? "(none)"} | ${skill.evidencedCount} | ${flag} |`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/readiness.js
+++ b/products/landmark/src/formatters/readiness.js
@@ -1,0 +1,79 @@
+/**
+ * Formatters for the `readiness` command.
+ */
+
+import { renderHeader } from "./shared.js";
+
+export function toText(view) {
+  const lines = [
+    renderHeader(
+      `Readiness: ${view.email} (${view.currentLevel} → ${view.targetLevel})`,
+    ),
+    "",
+  ];
+
+  for (const section of view.checklist) {
+    lines.push(`    ${section.skillName} (${section.proficiency}):`);
+    for (const item of section.items) {
+      const check = item.evidenced ? "[x]" : "[ ]";
+      const artifact = item.artifactId ? ` (${item.artifactId})` : "";
+      lines.push(`      ${check} ${item.marker}${artifact}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    `    ${view.summary.evidenced}/${view.summary.total} markers evidenced.`,
+  );
+
+  if (view.summary.missing.length > 0) {
+    lines.push(`    Missing: ${view.summary.missing.join("; ")}`);
+  }
+
+  if (view.skippedSkills.length > 0) {
+    lines.push("");
+    lines.push("    Skipped skills (no markers at required proficiency):");
+    for (const s of view.skippedSkills) {
+      lines.push(`      - ${s.skillId}: ${s.reason}`);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  const lines = [
+    `# Readiness: ${view.email} (${view.currentLevel} → ${view.targetLevel})`,
+    "",
+  ];
+
+  for (const section of view.checklist) {
+    lines.push(`## ${section.skillName} (${section.proficiency})`);
+    lines.push("");
+    for (const item of section.items) {
+      const check = item.evidenced ? "[x]" : "[ ]";
+      const artifact = item.artifactId ? ` (${item.artifactId})` : "";
+      lines.push(`- ${check} ${item.marker}${artifact}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    `**${view.summary.evidenced}/${view.summary.total} markers evidenced.**`,
+  );
+
+  if (view.summary.missing.length > 0) {
+    lines.push("");
+    lines.push("Missing:");
+    for (const m of view.summary.missing) {
+      lines.push(`- ${m}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/shared.js
+++ b/products/landmark/src/formatters/shared.js
@@ -1,0 +1,51 @@
+/**
+ * Shared rendering helpers used by Landmark formatters.
+ * All functions are pure — take explicit parameters, return strings.
+ */
+
+/**
+ * Pad a string to a fixed display width on the right.
+ *
+ * @param {string} str
+ * @param {number} width
+ * @returns {string}
+ */
+export function padRight(str, width) {
+  if (str.length >= width) return str;
+  return str + " ".repeat(width - str.length);
+}
+
+/**
+ * Render a section header.
+ *
+ * @param {string} title
+ * @returns {string}
+ */
+export function renderHeader(title) {
+  return `  ${title}\n`;
+}
+
+/**
+ * Format a number as a signed string (e.g. "+10", "-5", "0").
+ *
+ * @param {number|null} value
+ * @returns {string}
+ */
+export function formatDelta(value) {
+  if (value == null) return "n/a";
+  if (value > 0) return `+${value}`;
+  return String(value);
+}
+
+/**
+ * Render a simple key-value table.
+ *
+ * @param {Array<[string, string]>} rows
+ * @param {number} [indent=4]
+ * @returns {string}
+ */
+export function formatKeyValue(rows, indent = 4) {
+  const pad = " ".repeat(indent);
+  const maxKey = Math.max(0, ...rows.map(([k]) => k.length));
+  return rows.map(([k, v]) => `${pad}${padRight(k, maxKey)}  ${v}`).join("\n");
+}

--- a/products/landmark/src/formatters/snapshot.js
+++ b/products/landmark/src/formatters/snapshot.js
@@ -1,0 +1,113 @@
+/**
+ * Formatters for the `snapshot` command.
+ */
+
+import { formatDelta, padRight, renderHeader } from "./shared.js";
+
+export function toText(view) {
+  if (view.snapshots) return listToText(view);
+  if (view.trend) return trendToText(view);
+  return scoresToText(view);
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  if (view.snapshots) return listToMarkdown(view);
+  if (view.trend) return trendToMarkdown(view);
+  return scoresToMarkdown(view);
+}
+
+function listToText({ snapshots }) {
+  const lines = [renderHeader("GetDX Snapshots"), ""];
+  for (const s of snapshots) {
+    const date = s.scheduled_for ?? "(no date)";
+    const status = s.completed_at ? "completed" : "pending";
+    lines.push(`    ${padRight(s.snapshot_id, 30)}  ${date}  ${status}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function scoresToText({ snapshotId, scores }) {
+  const lines = [renderHeader(`Snapshot ${snapshotId}`), ""];
+  const nameWidth = Math.max(
+    20,
+    ...scores.map((s) => (s.item_name ?? s.item_id ?? "").length),
+  );
+  for (const s of scores) {
+    const name = padRight(s.item_name ?? s.item_id ?? "", nameWidth);
+    const score = s.score != null ? `${s.score}` : "n/a";
+    const comparisons = [
+      `vs_prev: ${formatDelta(s.vs_prev)}`,
+      `vs_org: ${formatDelta(s.vs_org)}`,
+      `vs_50th: ${formatDelta(s.vs_50th)}`,
+      `vs_75th: ${formatDelta(s.vs_75th)}`,
+      `vs_90th: ${formatDelta(s.vs_90th)}`,
+    ].join(", ");
+    lines.push(`    ${name}  ${padRight(score, 6)}  ${comparisons}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function trendToText({ itemId, trend }) {
+  const lines = [renderHeader(`Trend for ${itemId}`), ""];
+  for (const row of trend) {
+    const date = row.getdx_snapshots?.scheduled_for ?? "(unknown)";
+    const score = row.score != null ? `${row.score}` : "n/a";
+    lines.push(`    ${padRight(date, 15)}  ${score}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function listToMarkdown({ snapshots }) {
+  const lines = [
+    "# GetDX Snapshots",
+    "",
+    "| Snapshot ID | Date | Status |",
+    "| --- | --- | --- |",
+  ];
+  for (const s of snapshots) {
+    const date = s.scheduled_for ?? "(no date)";
+    const status = s.completed_at ? "completed" : "pending";
+    lines.push(`| ${s.snapshot_id} | ${date} | ${status} |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function scoresToMarkdown({ snapshotId, scores }) {
+  const lines = [
+    `# Snapshot ${snapshotId}`,
+    "",
+    "| Item | Score | vs_prev | vs_org | vs_50th | vs_75th | vs_90th |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+  ];
+  for (const s of scores) {
+    const name = s.item_name ?? s.item_id ?? "";
+    lines.push(
+      `| ${name} | ${s.score ?? "n/a"} | ${formatDelta(s.vs_prev)} | ${formatDelta(s.vs_org)} | ${formatDelta(s.vs_50th)} | ${formatDelta(s.vs_75th)} | ${formatDelta(s.vs_90th)} |`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function trendToMarkdown({ itemId, trend }) {
+  const lines = [
+    `# Trend for ${itemId}`,
+    "",
+    "| Date | Score |",
+    "| --- | --- |",
+  ];
+  for (const row of trend) {
+    const date = row.getdx_snapshots?.scheduled_for ?? "(unknown)";
+    lines.push(`| ${date} | ${row.score ?? "n/a"} |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/timeline.js
+++ b/products/landmark/src/formatters/timeline.js
@@ -1,0 +1,43 @@
+/**
+ * Formatters for the `timeline` command.
+ */
+
+import { padRight, renderHeader } from "./shared.js";
+
+export function toText(view) {
+  const lines = [renderHeader(`Growth timeline for ${view.email}`), ""];
+
+  const skillWidth = Math.max(
+    15,
+    ...view.timeline.map((t) => t.skillId.length),
+  );
+
+  for (const entry of view.timeline) {
+    lines.push(
+      `    ${padRight(entry.quarter, 10)}  ${padRight(entry.skillId, skillWidth)}  ${entry.highestLevel}`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  const lines = [
+    `# Growth timeline for ${view.email}`,
+    "",
+    "| Quarter | Skill | Highest Level |",
+    "| --- | --- | --- |",
+  ];
+
+  for (const entry of view.timeline) {
+    lines.push(
+      `| ${entry.quarter} | ${entry.skillId} | ${entry.highestLevel} |`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/products/landmark/src/formatters/voice.js
+++ b/products/landmark/src/formatters/voice.js
@@ -1,0 +1,112 @@
+/**
+ * Formatters for the `voice` command.
+ */
+
+import { renderHeader } from "./shared.js";
+
+export function toText(view) {
+  if (view.mode === "email") return emailToText(view);
+  return managerToText(view);
+}
+
+export function toJson(view, meta) {
+  return JSON.stringify({ ...view, meta }, null, 2);
+}
+
+export function toMarkdown(view) {
+  if (view.mode === "email") return emailToMarkdown(view);
+  return managerToMarkdown(view);
+}
+
+function emailToText(view) {
+  const lines = [renderHeader(`${view.email}'s snapshot comments`), ""];
+
+  for (const c of view.comments) {
+    lines.push(`    ${c.snapshotDate}: "${c.text}"`);
+  }
+  lines.push("");
+
+  if (view.evidenceContext.length > 0) {
+    lines.push("    Context from evidence:");
+    for (const e of view.evidenceContext) {
+      lines.push(`      ${e.skillId}: ${e.matched} matched evidence rows`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function managerToText(view) {
+  const lines = [
+    renderHeader(`${view.managerEmail} team — engineer voice`),
+    "",
+  ];
+
+  if (view.themes.length > 0) {
+    lines.push("    Most discussed themes:");
+    for (const t of view.themes) {
+      const snippetPreview = t.snippets
+        .slice(0, 2)
+        .map((s) => `"${s.slice(0, 60)}"`)
+        .join(", ");
+      lines.push(
+        `      ${t.theme.padEnd(20)}  ${t.count} comments   ${snippetPreview}`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (view.healthAlignment.length > 0) {
+    lines.push("    Aligned with health signals:");
+    for (const h of view.healthAlignment) {
+      lines.push(`      ${h.driverName} driver (${h.percentile}th pctl)`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function emailToMarkdown(view) {
+  const lines = [`# ${view.email}'s snapshot comments`, ""];
+
+  for (const c of view.comments) {
+    lines.push(`- **${c.snapshotDate}:** "${c.text}"`);
+  }
+  lines.push("");
+
+  if (view.evidenceContext.length > 0) {
+    lines.push("## Context from evidence");
+    for (const e of view.evidenceContext) {
+      lines.push(`- ${e.skillId}: ${e.matched} matched evidence rows`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function managerToMarkdown(view) {
+  const lines = [`# ${view.managerEmail} team — engineer voice`, ""];
+
+  if (view.themes.length > 0) {
+    lines.push("## Most discussed themes");
+    lines.push("");
+    lines.push("| Theme | Comments | Snippets |");
+    lines.push("| --- | --- | --- |");
+    for (const t of view.themes) {
+      const snippets = t.snippets.map((s) => `"${s.slice(0, 60)}"`).join(", ");
+      lines.push(`| ${t.theme} | ${t.count} | ${snippets} |`);
+    }
+    lines.push("");
+  }
+
+  if (view.healthAlignment.length > 0) {
+    lines.push("## Aligned with health signals");
+    for (const h of view.healthAlignment) {
+      lines.push(`- ${h.driverName} driver (${h.percentile}th pctl)`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/products/landmark/src/index.js
+++ b/products/landmark/src/index.js
@@ -1,0 +1,12 @@
+/**
+ * @forwardimpact/landmark
+ *
+ * Analysis and recommendation layer on top of Map activity data.
+ * Public API re-exports.
+ */
+
+export {
+  createLandmarkClient,
+  SupabaseUnavailableError,
+} from "./lib/supabase.js";
+export { EMPTY_STATES } from "./lib/empty-state.js";

--- a/products/landmark/src/lib/cli.js
+++ b/products/landmark/src/lib/cli.js
@@ -1,0 +1,75 @@
+/**
+ * Shared CLI helpers for Landmark command handlers.
+ *
+ * Resolves the Map data directory from CLI options (or the contributor
+ * data finder), loads framework data, and normalizes option lookups used
+ * across commands.
+ */
+
+import fs from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { createDataLoader } from "@forwardimpact/map/loader";
+import { Finder } from "@forwardimpact/libutil";
+import { createLogger } from "@forwardimpact/libtelemetry";
+
+/** Canonical output format constants. */
+export const Format = Object.freeze({
+  TEXT: "text",
+  JSON: "json",
+  MARKDOWN: "markdown",
+});
+
+/**
+ * Resolve the Map data directory from options, falling back to the
+ * contributor data finder. Uses the "pathway" subdirectory — same as
+ * Summit and Pathway.
+ *
+ * @param {object} options - Parsed CLI options.
+ * @returns {string}
+ */
+export function resolveDataDir(options) {
+  if (options.data) return resolve(options.data);
+
+  const logger = createLogger("landmark");
+  const finder = new Finder(fs, logger, process);
+  try {
+    return join(finder.findData("data", homedir()), "pathway");
+  } catch {
+    throw new Error(
+      "landmark: no data directory found. Pass --data <path> pointing at a Map data directory.",
+    );
+  }
+}
+
+/**
+ * Load framework data for a given data directory.
+ *
+ * @param {string} dataDir
+ * @returns {Promise<object>}
+ */
+export async function loadMapData(dataDir) {
+  const loader = createDataLoader();
+  return loader.loadAllData(dataDir);
+}
+
+/**
+ * Normalize the `--format` option to a known constant.
+ *
+ * @param {object} options
+ * @returns {string}
+ */
+export function resolveFormat(options) {
+  const value = options.format ?? Format.TEXT;
+  if (
+    value !== Format.TEXT &&
+    value !== Format.JSON &&
+    value !== Format.MARKDOWN
+  ) {
+    throw new Error(
+      `landmark: invalid --format "${value}". Expected one of text, json, markdown.`,
+    );
+  }
+  return value;
+}

--- a/products/landmark/src/lib/context.js
+++ b/products/landmark/src/lib/context.js
@@ -1,0 +1,24 @@
+/**
+ * Command context builder.
+ *
+ * Assembles the shared context object every command handler receives.
+ */
+
+import { loadMapData, resolveFormat } from "./cli.js";
+import { createLandmarkClient } from "./supabase.js";
+
+/**
+ * Build the execution context for a command handler.
+ *
+ * @param {object} params
+ * @param {string} params.dataDir - Resolved Map data directory.
+ * @param {object} params.options - Parsed CLI options.
+ * @param {boolean} params.needsSupabase - Whether to open a Supabase client.
+ * @returns {Promise<{mapData: object, supabase: object|null, format: string, options: object}>}
+ */
+export async function buildContext({ dataDir, options, needsSupabase }) {
+  const mapData = await loadMapData(dataDir);
+  const supabase = needsSupabase ? createLandmarkClient() : null;
+  const format = resolveFormat(options);
+  return { mapData, supabase, format, options };
+}

--- a/products/landmark/src/lib/empty-state.js
+++ b/products/landmark/src/lib/empty-state.js
@@ -1,0 +1,32 @@
+/**
+ * Central registry of empty-state messages.
+ *
+ * Every entry corresponds to a row in spec § Empty States and Error
+ * Behavior. Commands set `meta.emptyState` to one of these values when
+ * a data source is missing or empty.
+ */
+
+export const EMPTY_STATES = {
+  NO_EVIDENCE:
+    "No evidence data available. Guide has not yet interpreted artifacts for this scope.",
+  NO_MARKERS_FOR_SKILL: (skill) =>
+    `No markers defined for ${skill}. Add markers to the capability YAML.`,
+  NO_MARKERS_AT_TARGET:
+    "No markers defined at target level — cannot generate checklist.",
+  NO_SNAPSHOTS:
+    "No GetDX snapshot data available. Run `fit-map getdx sync` (or `fit-map activity seed` for synthetic data) to ingest.",
+  NO_COMMENTS:
+    "Snapshot comments not available. The getdx_snapshot_comments table has not been created.",
+  NO_INITIATIVES:
+    "Initiative data not available. The getdx_initiatives table has not been created.",
+  NO_ORGANIZATION:
+    "No organization data available. Run `fit-map people push` to load roster data.",
+  PERSON_NOT_FOUND: (email) =>
+    `No person found with email ${email} in organization_people.`,
+  MANAGER_NOT_FOUND: (email) => `No team found for manager ${email}.`,
+  NO_HIGHER_LEVEL: (id) =>
+    `No higher level defined in levels.yaml. Current level (${id}) is the highest.`,
+  NO_ARTIFACTS_FOR_PERSON: (email) => `No artifacts found for ${email}.`,
+  NO_EVIDENCE_WITH_NOTE:
+    "No evidence data found. Evidenced depth reflects Guide-interpreted artifacts only.",
+};

--- a/products/landmark/src/lib/evidence-helpers.js
+++ b/products/landmark/src/lib/evidence-helpers.js
@@ -1,0 +1,148 @@
+/**
+ * Shared evidence helpers reused across evidence-based commands.
+ * All functions are pure.
+ */
+
+import { SKILL_PROFICIENCY_ORDER } from "@forwardimpact/map/levels";
+
+/**
+ * Group raw evidence rows by skillId.
+ * @param {Array<object>} evidenceRows
+ * @returns {Map<string, {matched: number, unmatched: number, rows: Array<object>}>}
+ */
+export function groupEvidenceBySkill(evidenceRows) {
+  const groups = new Map();
+  for (const row of evidenceRows) {
+    const key = row.skill_id;
+    if (!groups.has(key)) {
+      groups.set(key, { matched: 0, unmatched: 0, rows: [] });
+    }
+    const g = groups.get(key);
+    g.rows.push(row);
+    if (row.matched) g.matched++;
+    else g.unmatched++;
+  }
+  return groups;
+}
+
+/**
+ * Group evidence rows by ISO quarter (YYYY-QN) derived from created_at.
+ * @param {Array<object>} evidenceRows
+ * @returns {Map<string, Array<object>>}
+ */
+export function groupEvidenceByQuarter(evidenceRows) {
+  const groups = new Map();
+  for (const row of evidenceRows) {
+    const q = toQuarter(row.created_at);
+    if (!groups.has(q)) groups.set(q, []);
+    groups.get(q).push(row);
+  }
+  return groups;
+}
+
+/**
+ * Pick the highest matched level per (quarter, skill).
+ * @param {Array<object>} evidenceRows
+ * @returns {Array<{quarter: string, skillId: string, highestLevel: string}>}
+ */
+export function highestLevelPerSkillPerQuarter(evidenceRows) {
+  // Group by quarter, then by skill
+  const byQuarter = groupEvidenceByQuarter(evidenceRows);
+  const results = [];
+
+  for (const [quarter, rows] of byQuarter) {
+    const bySkill = new Map();
+    for (const row of rows) {
+      if (!row.matched) continue;
+      const key = row.skill_id;
+      const currentIdx = bySkill.get(key) ?? -1;
+      const rowIdx = SKILL_PROFICIENCY_ORDER.indexOf(row.level_id);
+      if (rowIdx > currentIdx) {
+        bySkill.set(key, rowIdx);
+      }
+    }
+    for (const [skillId, idx] of bySkill) {
+      results.push({
+        quarter,
+        skillId,
+        highestLevel: SKILL_PROFICIENCY_ORDER[idx],
+      });
+    }
+  }
+
+  results.sort(
+    (a, b) =>
+      a.quarter.localeCompare(b.quarter) || a.skillId.localeCompare(b.skillId),
+  );
+  return results;
+}
+
+/**
+ * Build a readiness checklist from target markers and evidence rows.
+ * @param {object} markers - Markers at the target proficiency level ({human: string[], agent: string[]}).
+ * @param {Array<object>} evidenceRows - Evidence rows filtered to this person.
+ * @returns {Array<{marker: string, variant: string, evidenced: boolean, artifactId?: string, rationale?: string}>}
+ */
+export function buildMarkerChecklist(markers, evidenceRows) {
+  const checklist = [];
+
+  for (const variant of ["human", "agent"]) {
+    const markerTexts = markers[variant] ?? [];
+    for (const marker of markerTexts) {
+      const match = evidenceRows.find(
+        (e) => e.matched && e.marker_text === marker,
+      );
+      checklist.push({
+        marker,
+        variant,
+        evidenced: !!match,
+        artifactId: match?.artifact_id ?? null,
+        rationale: match?.rationale ?? null,
+      });
+    }
+  }
+
+  return checklist;
+}
+
+/**
+ * Compute coverage ratio: (artifacts with >= 1 evidence row) / (total artifacts).
+ * @param {Array<object>} artifacts - All artifacts.
+ * @param {Array<object>} unscoredArtifacts - Artifacts without evidence.
+ * @returns {{scored: number, total: number, ratio: number}}
+ */
+export function computeCoverageRatio(artifacts, unscoredArtifacts) {
+  const total = artifacts.length;
+  const unscored = unscoredArtifacts.length;
+  const scored = total - unscored;
+  const ratio = total > 0 ? scored / total : 0;
+  return { scored, total, ratio };
+}
+
+/**
+ * Filter evidence rows to only those belonging to a set of team emails.
+ * Evidence rows carry the email via the joined github_artifacts record.
+ * @param {Array<object>} evidenceRows
+ * @param {Set<string>} teamEmails
+ * @returns {Array<object>}
+ */
+export function filterEvidenceByTeam(evidenceRows, teamEmails) {
+  return evidenceRows.filter((row) => {
+    const email = row.github_artifacts?.email;
+    return email && teamEmails.has(email);
+  });
+}
+
+/**
+ * Convert an ISO date string to a quarter label (YYYY-QN).
+ * @param {string} dateStr
+ * @returns {string}
+ */
+function toQuarter(dateStr) {
+  if (!dateStr) return "unknown";
+  const d = new Date(dateStr);
+  const year = d.getFullYear();
+  const month = d.getMonth(); // 0-based
+  const q = Math.floor(month / 3) + 1;
+  return `${year}-Q${q}`;
+}

--- a/products/landmark/src/lib/initiative-helpers.js
+++ b/products/landmark/src/lib/initiative-helpers.js
@@ -1,0 +1,72 @@
+/**
+ * Initiative impact computation.
+ *
+ * Pure function operating on already-fetched rows. No Supabase inside.
+ */
+
+/**
+ * Compute initiative impact by joining completion dates to snapshot score deltas.
+ *
+ * @param {object} params
+ * @param {Array<object>} params.completed - Completed initiatives.
+ * @param {Array<object>} params.snapshots - All snapshots (ordered by scheduled_for).
+ * @param {Map<string, Map<string, number>>} params.scoresBySnapshot -
+ *   snapshotId → Map(scorecardId → score).
+ * @returns {Array<{initiative: object, before: number|null, after: number|null, delta: number|null}>}
+ */
+export function computeInitiativeImpact({
+  completed,
+  snapshots,
+  scoresBySnapshot,
+}) {
+  const sorted = [...snapshots].sort((a, b) =>
+    (a.scheduled_for ?? "").localeCompare(b.scheduled_for ?? ""),
+  );
+  return completed.map((init) =>
+    computeSingleImpact(init, sorted, scoresBySnapshot),
+  );
+}
+
+/** Compute impact for a single initiative against sorted snapshots. */
+function computeSingleImpact(init, sorted, scoresBySnapshot) {
+  const nullResult = {
+    initiative: init,
+    before: null,
+    after: null,
+    delta: null,
+  };
+
+  if (!init.scorecard_id || !init.completed_at) return nullResult;
+
+  const { before, after } = findBoundingSnapshots(sorted, init.completed_at);
+  if (!before || !after) return nullResult;
+
+  const beforeScore =
+    scoresBySnapshot.get(before.snapshot_id)?.get(init.scorecard_id) ?? null;
+  const afterScore =
+    scoresBySnapshot.get(after.snapshot_id)?.get(init.scorecard_id) ?? null;
+
+  return {
+    initiative: init,
+    before: beforeScore,
+    after: afterScore,
+    delta:
+      beforeScore != null && afterScore != null
+        ? afterScore - beforeScore
+        : null,
+  };
+}
+
+/** Find the latest snapshot before and earliest snapshot after a date. */
+function findBoundingSnapshots(sorted, completedAt) {
+  let before = null;
+  for (const s of sorted) {
+    if ((s.scheduled_for ?? "") <= completedAt) before = s;
+    else break;
+  }
+
+  const after =
+    sorted.find((s) => (s.scheduled_for ?? "") > completedAt) ?? null;
+
+  return { before, after };
+}

--- a/products/landmark/src/lib/summit.js
+++ b/products/landmark/src/lib/summit.js
@@ -2,43 +2,36 @@
  * Summit growth alignment wrapper.
  *
  * Wraps Summit's computeGrowthAlignment with dynamic import for
- * optional runtime and a test injection seam.
+ * optional runtime. Node caches dynamic import() results at the module
+ * level, so no manual cache is needed.
+ *
+ * Production code uses the `summitFn` injection point on runHealthCommand
+ * for DI. This module's computeGrowth is the default wiring; summit.test.js
+ * tests it in isolation via __testOverride.
  */
 
-let cachedFn = null;
-let cachedErrorClass = null;
-let cacheSet = false;
+/** Test-only override. Set to a {fn, GrowthContractError} object to bypass import(). */
+let __testOverride = null;
 
-export async function loadSummit() {
-  if (cacheSet) return { fn: cachedFn, GrowthContractError: cachedErrorClass };
+/**
+ * Test helper — inject a stub so summit.test.js can exercise computeGrowth
+ * without touching node_modules. Pass null to clear.
+ */
+export function __setSummitForTests(override) {
+  __testOverride = override ?? null;
+}
+
+async function loadSummit() {
+  if (__testOverride) return __testOverride;
   try {
     const mod = await import("@forwardimpact/summit");
-    cachedFn = mod?.computeGrowthAlignment ?? null;
-    cachedErrorClass = mod?.GrowthContractError ?? null;
+    return {
+      fn: mod?.computeGrowthAlignment ?? null,
+      GrowthContractError: mod?.GrowthContractError ?? null,
+    };
   } catch {
-    cachedFn = null;
-    cachedErrorClass = null;
+    return { fn: null, GrowthContractError: null };
   }
-  cacheSet = true;
-  return { fn: cachedFn, GrowthContractError: cachedErrorClass };
-}
-
-/**
- * Test helper — reset cache and optionally inject a stub.
- */
-export function __setSummitForTests({ fn, GrowthContractError } = {}) {
-  cachedFn = fn ?? null;
-  cachedErrorClass = GrowthContractError ?? null;
-  cacheSet = true;
-}
-
-/**
- * Reset the cache (for tests that need fresh module resolution).
- */
-export function __resetSummitCache() {
-  cachedFn = null;
-  cachedErrorClass = null;
-  cacheSet = false;
 }
 
 /**

--- a/products/landmark/src/lib/summit.js
+++ b/products/landmark/src/lib/summit.js
@@ -1,0 +1,74 @@
+/**
+ * Summit growth alignment wrapper.
+ *
+ * Wraps Summit's computeGrowthAlignment with dynamic import for
+ * optional runtime and a test injection seam.
+ */
+
+let cachedFn = null;
+let cachedErrorClass = null;
+let cacheSet = false;
+
+export async function loadSummit() {
+  if (cacheSet) return { fn: cachedFn, GrowthContractError: cachedErrorClass };
+  try {
+    const mod = await import("@forwardimpact/summit");
+    cachedFn = mod?.computeGrowthAlignment ?? null;
+    cachedErrorClass = mod?.GrowthContractError ?? null;
+  } catch {
+    cachedFn = null;
+    cachedErrorClass = null;
+  }
+  cacheSet = true;
+  return { fn: cachedFn, GrowthContractError: cachedErrorClass };
+}
+
+/**
+ * Test helper — reset cache and optionally inject a stub.
+ */
+export function __setSummitForTests({ fn, GrowthContractError } = {}) {
+  cachedFn = fn ?? null;
+  cachedErrorClass = GrowthContractError ?? null;
+  cacheSet = true;
+}
+
+/**
+ * Reset the cache (for tests that need fresh module resolution).
+ */
+export function __resetSummitCache() {
+  cachedFn = null;
+  cachedErrorClass = null;
+  cacheSet = false;
+}
+
+/**
+ * Compute growth recommendations via Summit.
+ *
+ * @param {object} params - Passed through to computeGrowthAlignment.
+ * @returns {Promise<{available: boolean, recommendations: Array, warnings: string[]}>}
+ */
+export async function computeGrowth(params) {
+  const { fn, GrowthContractError } = await loadSummit();
+  if (!fn) {
+    return { available: false, recommendations: [], warnings: [] };
+  }
+  try {
+    const recommendations = fn(params);
+    return { available: true, recommendations, warnings: [] };
+  } catch (err) {
+    if (GrowthContractError && err instanceof GrowthContractError) {
+      return {
+        available: true,
+        recommendations: [],
+        warnings: [
+          `Summit growth alignment skipped: ${err.message} (code: ${err.code ?? "unknown"})`,
+        ],
+      };
+    }
+    return {
+      available: true,
+      recommendations: [],
+      warnings: [`Summit growth computation failed: ${err.message}`],
+    };
+  }
+}

--- a/products/landmark/src/lib/supabase.js
+++ b/products/landmark/src/lib/supabase.js
@@ -45,10 +45,5 @@ export function createLandmarkClient(opts = {}) {
  * @returns {boolean}
  */
 export function isRelationNotFoundError(err) {
-  return (
-    err?.code === "42P01" ||
-    err?.message?.includes("42P01") ||
-    err?.message?.includes("relation") ||
-    false
-  );
+  return err?.code === "42P01" || err?.message?.includes("42P01");
 }

--- a/products/landmark/src/lib/supabase.js
+++ b/products/landmark/src/lib/supabase.js
@@ -1,0 +1,54 @@
+/**
+ * Supabase client factory for Landmark.
+ *
+ * Mirrors the env-var contract used by Summit's createSummitClient.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+export class SupabaseUnavailableError extends Error {
+  constructor(reason) {
+    super(`Supabase connection unavailable: ${reason}`);
+    this.code = "LANDMARK_SUPABASE_UNAVAILABLE";
+  }
+}
+
+/**
+ * Create a Supabase client configured for Map's activity schema.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.url] - Override for MAP_SUPABASE_URL.
+ * @param {string} [opts.serviceRoleKey] - Override for MAP_SUPABASE_SERVICE_ROLE_KEY.
+ * @param {string} [opts.schema] - Database schema (default: "activity").
+ * @returns {import("@supabase/supabase-js").SupabaseClient}
+ */
+export function createLandmarkClient(opts = {}) {
+  const url = opts.url ?? process.env.MAP_SUPABASE_URL;
+  const key = opts.serviceRoleKey ?? process.env.MAP_SUPABASE_SERVICE_ROLE_KEY;
+  const schema = opts.schema ?? "activity";
+
+  if (!url || !key) {
+    throw new SupabaseUnavailableError(
+      "MAP_SUPABASE_URL / MAP_SUPABASE_SERVICE_ROLE_KEY not set. " +
+        "Run `fit-map activity start` and export the URL + key it prints.",
+    );
+  }
+
+  return createClient(url, key, { db: { schema } });
+}
+
+/**
+ * Check if an error is a Postgres "relation not found" error (42P01).
+ * Used to detect missing tables gracefully.
+ *
+ * @param {Error} err
+ * @returns {boolean}
+ */
+export function isRelationNotFoundError(err) {
+  return (
+    err?.code === "42P01" ||
+    err?.message?.includes("42P01") ||
+    err?.message?.includes("relation") ||
+    false
+  );
+}

--- a/products/landmark/test/cli-command.test.js
+++ b/products/landmark/test/cli-command.test.js
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { formatResult } from "../src/formatters/index.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+describe("formatResult", () => {
+  it("renders empty state in text format", () => {
+    const result = {
+      view: null,
+      meta: { format: "text", emptyState: EMPTY_STATES.NO_SNAPSHOTS },
+    };
+    const output = formatResult("snapshot", result);
+    assert.ok(output.includes("GetDX"));
+  });
+
+  it("renders empty state in JSON format", () => {
+    const result = {
+      view: null,
+      meta: { format: "json", emptyState: EMPTY_STATES.NO_SNAPSHOTS },
+    };
+    const output = formatResult("snapshot", result);
+    const parsed = JSON.parse(output);
+    assert.equal(parsed.view, null);
+    assert.ok(parsed.emptyState.includes("GetDX"));
+  });
+
+  it("renders org view in text format", () => {
+    const result = {
+      view: {
+        people: [
+          { email: "a@b.com", name: "Alice", discipline: "se", level: "J040" },
+        ],
+      },
+      meta: { format: "text" },
+    };
+    const output = formatResult("org", result);
+    assert.ok(output.includes("Alice"));
+    assert.ok(output.includes("a@b.com"));
+  });
+
+  it("renders marker view in text format", () => {
+    const result = {
+      view: {
+        skill: "task_completion",
+        name: "Task Completion",
+        markers: {
+          working: {
+            human: ["Delivered a feature end-to-end"],
+            agent: ["Completed a multi-file change"],
+          },
+        },
+      },
+      meta: { format: "text" },
+    };
+    const output = formatResult("marker", result);
+    assert.ok(output.includes("Task Completion"));
+    assert.ok(output.includes("working"));
+    assert.ok(output.includes("Delivered a feature"));
+  });
+
+  it("renders snapshot list in text format", () => {
+    const result = {
+      view: {
+        snapshots: [
+          {
+            snapshot_id: "snap-1",
+            scheduled_for: "2025-03-15",
+            completed_at: "2025-03-20",
+          },
+        ],
+      },
+      meta: { format: "text" },
+    };
+    const output = formatResult("snapshot", result);
+    assert.ok(output.includes("snap-1"));
+    assert.ok(output.includes("2025-03-15"));
+  });
+
+  it("falls back to JSON for unknown command", () => {
+    const result = { view: { data: 1 }, meta: { format: "text" } };
+    const output = formatResult("nonexistent", result);
+    assert.ok(output.includes('"data"'));
+  });
+});

--- a/products/landmark/test/coverage.test.js
+++ b/products/landmark/test/coverage.test.js
@@ -1,0 +1,72 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runCoverageCommand } from "../src/commands/coverage.js";
+
+const PERSON = {
+  email: "alice@example.com",
+  name: "Alice",
+  discipline: "software_engineering",
+  level: "J040",
+};
+
+const ARTIFACTS = [
+  { artifact_id: "a1", artifact_type: "pull_request" },
+  { artifact_id: "a2", artifact_type: "pull_request" },
+  { artifact_id: "a3", artifact_type: "review" },
+  { artifact_id: "a4", artifact_type: "commit" },
+];
+
+const UNSCORED = [
+  { artifact_id: "a3", artifact_type: "review" },
+  { artifact_id: "a4", artifact_type: "commit" },
+];
+
+function stubQueries({
+  person = PERSON,
+  artifacts = ARTIFACTS,
+  unscored = UNSCORED,
+} = {}) {
+  return {
+    getPerson: async () => person,
+    getArtifacts: async () => artifacts,
+    getUnscoredArtifacts: async () => unscored,
+  };
+}
+
+describe("coverage command", () => {
+  it("returns coverage ratio and type breakdown", async () => {
+    const result = await runCoverageCommand({
+      options: { email: "alice@example.com" },
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.coverage.scored, 2);
+    assert.equal(result.view.coverage.total, 4);
+    assert.equal(result.view.byType.pull_request, 2);
+    assert.equal(result.view.uncoveredByType.review, 1);
+  });
+
+  it("returns PERSON_NOT_FOUND for unknown email", async () => {
+    const result = await runCoverageCommand({
+      options: { email: "nobody@example.com" },
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ person: null }),
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("nobody@example.com"));
+  });
+
+  it("returns NO_ARTIFACTS when person has no artifacts", async () => {
+    const result = await runCoverageCommand({
+      options: { email: "alice@example.com" },
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ artifacts: [], unscored: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("alice@example.com"));
+  });
+});

--- a/products/landmark/test/empty-state.test.js
+++ b/products/landmark/test/empty-state.test.js
@@ -1,0 +1,57 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+describe("EMPTY_STATES", () => {
+  it("has a NO_EVIDENCE constant", () => {
+    assert.equal(typeof EMPTY_STATES.NO_EVIDENCE, "string");
+    assert.ok(EMPTY_STATES.NO_EVIDENCE.includes("Guide"));
+  });
+
+  it("NO_MARKERS_FOR_SKILL is a function returning skill-specific message", () => {
+    const msg = EMPTY_STATES.NO_MARKERS_FOR_SKILL("task_completion");
+    assert.ok(msg.includes("task_completion"));
+    assert.ok(msg.includes("markers"));
+  });
+
+  it("has a NO_MARKERS_AT_TARGET constant", () => {
+    assert.equal(typeof EMPTY_STATES.NO_MARKERS_AT_TARGET, "string");
+  });
+
+  it("has a NO_SNAPSHOTS constant", () => {
+    assert.ok(EMPTY_STATES.NO_SNAPSHOTS.includes("GetDX"));
+  });
+
+  it("has a NO_COMMENTS constant", () => {
+    assert.ok(EMPTY_STATES.NO_COMMENTS.includes("getdx_snapshot_comments"));
+  });
+
+  it("has a NO_INITIATIVES constant", () => {
+    assert.ok(EMPTY_STATES.NO_INITIATIVES.includes("getdx_initiatives"));
+  });
+
+  it("PERSON_NOT_FOUND includes the email", () => {
+    const msg = EMPTY_STATES.PERSON_NOT_FOUND("alice@example.com");
+    assert.ok(msg.includes("alice@example.com"));
+  });
+
+  it("MANAGER_NOT_FOUND includes the email", () => {
+    const msg = EMPTY_STATES.MANAGER_NOT_FOUND("boss@example.com");
+    assert.ok(msg.includes("boss@example.com"));
+  });
+
+  it("NO_HIGHER_LEVEL includes the level id", () => {
+    const msg = EMPTY_STATES.NO_HIGHER_LEVEL("J060");
+    assert.ok(msg.includes("J060"));
+  });
+
+  it("NO_ARTIFACTS_FOR_PERSON includes the email", () => {
+    const msg = EMPTY_STATES.NO_ARTIFACTS_FOR_PERSON("dan@example.com");
+    assert.ok(msg.includes("dan@example.com"));
+  });
+
+  it("has a NO_ORGANIZATION constant", () => {
+    assert.ok(EMPTY_STATES.NO_ORGANIZATION.includes("organization"));
+  });
+});

--- a/products/landmark/test/evidence-helpers.test.js
+++ b/products/landmark/test/evidence-helpers.test.js
@@ -1,0 +1,159 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  groupEvidenceBySkill,
+  groupEvidenceByQuarter,
+  highestLevelPerSkillPerQuarter,
+  buildMarkerChecklist,
+  computeCoverageRatio,
+  filterEvidenceByTeam,
+} from "../src/lib/evidence-helpers.js";
+
+describe("groupEvidenceBySkill", () => {
+  it("groups rows by skill_id", () => {
+    const rows = [
+      { skill_id: "planning", matched: true },
+      { skill_id: "planning", matched: false },
+      { skill_id: "task_completion", matched: true },
+    ];
+    const grouped = groupEvidenceBySkill(rows);
+    assert.equal(grouped.get("planning").matched, 1);
+    assert.equal(grouped.get("planning").unmatched, 1);
+    assert.equal(grouped.get("task_completion").matched, 1);
+  });
+});
+
+describe("groupEvidenceByQuarter", () => {
+  it("groups rows by quarter", () => {
+    const rows = [
+      { created_at: "2025-01-15T00:00:00Z" },
+      { created_at: "2025-04-01T00:00:00Z" },
+      { created_at: "2025-01-30T00:00:00Z" },
+    ];
+    const grouped = groupEvidenceByQuarter(rows);
+    assert.equal(grouped.get("2025-Q1").length, 2);
+    assert.equal(grouped.get("2025-Q2").length, 1);
+  });
+});
+
+describe("highestLevelPerSkillPerQuarter", () => {
+  it("picks the highest matched level per (quarter, skill)", () => {
+    const rows = [
+      {
+        skill_id: "planning",
+        level_id: "awareness",
+        matched: true,
+        created_at: "2025-01-15T00:00:00Z",
+      },
+      {
+        skill_id: "planning",
+        level_id: "working",
+        matched: true,
+        created_at: "2025-01-20T00:00:00Z",
+      },
+      {
+        skill_id: "planning",
+        level_id: "foundational",
+        matched: true,
+        created_at: "2025-04-10T00:00:00Z",
+      },
+      {
+        skill_id: "task_completion",
+        level_id: "working",
+        matched: true,
+        created_at: "2025-01-05T00:00:00Z",
+      },
+      {
+        skill_id: "task_completion",
+        level_id: "awareness",
+        matched: false,
+        created_at: "2025-01-06T00:00:00Z",
+      },
+    ];
+    const result = highestLevelPerSkillPerQuarter(rows);
+
+    const q1Planning = result.find(
+      (r) => r.quarter === "2025-Q1" && r.skillId === "planning",
+    );
+    assert.equal(q1Planning.highestLevel, "working");
+
+    const q2Planning = result.find(
+      (r) => r.quarter === "2025-Q2" && r.skillId === "planning",
+    );
+    assert.equal(q2Planning.highestLevel, "foundational");
+
+    const q1Task = result.find(
+      (r) => r.quarter === "2025-Q1" && r.skillId === "task_completion",
+    );
+    assert.equal(q1Task.highestLevel, "working");
+  });
+
+  it("ignores unmatched rows", () => {
+    const rows = [
+      {
+        skill_id: "planning",
+        level_id: "working",
+        matched: false,
+        created_at: "2025-01-15T00:00:00Z",
+      },
+    ];
+    const result = highestLevelPerSkillPerQuarter(rows);
+    assert.equal(result.length, 0);
+  });
+});
+
+describe("buildMarkerChecklist", () => {
+  it("marks evidenced markers", () => {
+    const markers = {
+      human: ["Delivered a feature end-to-end"],
+      agent: ["Completed a multi-file change"],
+    };
+    const evidence = [
+      {
+        matched: true,
+        marker_text: "Delivered a feature end-to-end",
+        artifact_id: "abc",
+        rationale: "Good",
+      },
+    ];
+    const checklist = buildMarkerChecklist(markers, evidence);
+    assert.equal(checklist.length, 2);
+    assert.equal(checklist[0].evidenced, true);
+    assert.equal(checklist[0].artifactId, "abc");
+    assert.equal(checklist[1].evidenced, false);
+  });
+});
+
+describe("computeCoverageRatio", () => {
+  it("computes the coverage ratio", () => {
+    const all = [
+      { artifact_id: "a" },
+      { artifact_id: "b" },
+      { artifact_id: "c" },
+    ];
+    const unscored = [{ artifact_id: "c" }];
+    const result = computeCoverageRatio(all, unscored);
+    assert.equal(result.scored, 2);
+    assert.equal(result.total, 3);
+    assert.ok(Math.abs(result.ratio - 2 / 3) < 0.001);
+  });
+
+  it("handles empty artifacts", () => {
+    const result = computeCoverageRatio([], []);
+    assert.equal(result.ratio, 0);
+  });
+});
+
+describe("filterEvidenceByTeam", () => {
+  it("filters to team emails via github_artifacts join", () => {
+    const rows = [
+      { github_artifacts: { email: "alice@example.com" } },
+      { github_artifacts: { email: "bob@example.com" } },
+      { github_artifacts: { email: "carol@example.com" } },
+    ];
+    const teamEmails = new Set(["alice@example.com", "carol@example.com"]);
+    const filtered = filterEvidenceByTeam(rows, teamEmails);
+    assert.equal(filtered.length, 2);
+  });
+});

--- a/products/landmark/test/evidence.test.js
+++ b/products/landmark/test/evidence.test.js
@@ -1,0 +1,86 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runEvidenceCommand } from "../src/commands/evidence.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const EVIDENCE_ROWS = [
+  {
+    skill_id: "task_completion",
+    level_id: "working",
+    marker_text: "Delivered a feature",
+    matched: true,
+    artifact_id: "art-1",
+    rationale: "Clean delivery",
+    created_at: "2025-01-15T00:00:00Z",
+    github_artifacts: { email: "alice@example.com" },
+  },
+  {
+    skill_id: "task_completion",
+    level_id: "foundational",
+    marker_text: "Small feature",
+    matched: false,
+    artifact_id: "art-2",
+    rationale: null,
+    created_at: "2025-01-10T00:00:00Z",
+    github_artifacts: { email: "alice@example.com" },
+  },
+  {
+    skill_id: "planning",
+    level_id: "awareness",
+    marker_text: "Followed plan",
+    matched: true,
+    artifact_id: "art-3",
+    rationale: "On track",
+    created_at: "2025-02-01T00:00:00Z",
+    github_artifacts: { email: "alice@example.com" },
+  },
+];
+
+function stubQueries({ evidence = EVIDENCE_ROWS } = {}) {
+  return {
+    getEvidence: async () => evidence,
+    getArtifacts: async () => [
+      { artifact_id: "art-1" },
+      { artifact_id: "art-2" },
+      { artifact_id: "art-3" },
+    ],
+    getUnscoredArtifacts: async () => [{ artifact_id: "art-2" }],
+  };
+}
+
+describe("evidence command", () => {
+  it("returns grouped evidence with coverage", async () => {
+    const result = await runEvidenceCommand({
+      options: { email: "alice@example.com" },
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view.evidence.task_completion);
+    assert.equal(result.view.evidence.task_completion.matched, 1);
+    assert.equal(result.view.coverage.scored, 2);
+    assert.equal(result.view.coverage.total, 3);
+  });
+
+  it("returns empty state when no evidence", async () => {
+    const result = await runEvidenceCommand({
+      options: {},
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ evidence: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_EVIDENCE);
+  });
+
+  it("skips coverage when no email filter", async () => {
+    const result = await runEvidenceCommand({
+      options: { skill: "planning" },
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.coverage, null);
+  });
+});

--- a/products/landmark/test/health.test.js
+++ b/products/landmark/test/health.test.js
@@ -1,0 +1,238 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runHealthCommand } from "../src/commands/health.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const TEAM = [
+  {
+    email: "alice@example.com",
+    name: "Alice",
+    discipline: "software_engineering",
+    level: "J040",
+    track: "platform",
+  },
+  {
+    email: "bob@example.com",
+    name: "Bob",
+    discipline: "software_engineering",
+    level: "J060",
+    track: null,
+  },
+];
+
+const SNAPSHOTS = [
+  {
+    snapshot_id: "snap-1",
+    scheduled_for: "2025-03-15",
+    completed_at: "2025-03-20",
+  },
+];
+
+const SCORES = [
+  {
+    snapshot_id: "snap-1",
+    item_id: "quality",
+    item_name: "Quality",
+    score: 42,
+    vs_prev: -5,
+    vs_org: -10,
+    vs_50th: -8,
+    vs_75th: -25,
+    vs_90th: -40,
+  },
+];
+
+const EVIDENCE = [
+  {
+    skill_id: "task_completion",
+    level_id: "working",
+    matched: true,
+    artifact_id: "art-1",
+    created_at: "2025-01-15T00:00:00Z",
+    github_artifacts: { email: "alice@example.com" },
+  },
+  {
+    skill_id: "task_completion",
+    level_id: "foundational",
+    matched: true,
+    artifact_id: "art-2",
+    created_at: "2025-02-01T00:00:00Z",
+    github_artifacts: { email: "bob@example.com" },
+  },
+  {
+    skill_id: "planning",
+    level_id: "awareness",
+    matched: false,
+    artifact_id: "art-3",
+    created_at: "2025-01-20T00:00:00Z",
+    github_artifacts: { email: "alice@example.com" },
+  },
+];
+
+const MAP_DATA = {
+  drivers: [
+    {
+      id: "quality",
+      name: "Quality",
+      contributingSkills: ["task_completion", "planning"],
+      contributingBehaviours: ["systems_thinking"],
+    },
+    {
+      id: "reliability",
+      name: "Reliability",
+      contributingSkills: ["incident_response"],
+      contributingBehaviours: ["systems_thinking"],
+    },
+  ],
+  skills: [
+    { id: "task_completion", name: "Task Completion" },
+    { id: "planning", name: "Planning" },
+    { id: "incident_response", name: "Incident Response" },
+  ],
+  levels: [
+    {
+      id: "J040",
+      ordinalRank: 1,
+      baseSkillProficiencies: {
+        primary: "foundational",
+        secondary: "awareness",
+        broad: "awareness",
+      },
+    },
+    {
+      id: "J060",
+      ordinalRank: 2,
+      baseSkillProficiencies: {
+        primary: "working",
+        secondary: "foundational",
+        broad: "awareness",
+      },
+    },
+  ],
+  disciplines: [
+    {
+      id: "software_engineering",
+      coreSkills: ["task_completion"],
+      supportingSkills: ["planning"],
+      broadSkills: ["incident_response"],
+    },
+  ],
+  tracks: [{ id: "platform", skillModifiers: {} }],
+  capabilities: [],
+};
+
+function stubQueries({
+  team = TEAM,
+  snapshots = SNAPSHOTS,
+  scores = SCORES,
+  evidence = EVIDENCE,
+} = {}) {
+  return {
+    getOrganization: async () => team,
+    getTeam: async () => team,
+    listSnapshots: async () => snapshots,
+    getSnapshotScores: async () => scores,
+    getEvidence: async () => evidence,
+  };
+}
+
+function summitPresent(_params) {
+  return {
+    available: true,
+    recommendations: [
+      {
+        skill: "planning",
+        impact: "critical",
+        candidates: [
+          { email: "bob@example.com", name: "Bob", currentLevel: "Level II" },
+        ],
+      },
+    ],
+    warnings: [],
+  };
+}
+
+function summitAbsent() {
+  return { available: false, recommendations: [], warnings: [] };
+}
+
+describe("health command", () => {
+  it("renders health with Summit present", async () => {
+    const result = await runHealthCommand({
+      options: { manager: "alice@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+      summitFn: summitPresent,
+    });
+    assert.ok(result.view);
+    assert.ok(result.view.drivers.length > 0);
+    assert.equal(result.view.summitAvailable, true);
+
+    const quality = result.view.drivers.find((d) => d.id === "quality");
+    assert.ok(quality);
+    assert.equal(quality.score, 42);
+    assert.ok(quality.contributingSkills.length > 0);
+    assert.ok(quality.recommendations.length > 0);
+  });
+
+  it("renders health without Summit", async () => {
+    const result = await runHealthCommand({
+      options: { manager: "alice@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+      summitFn: summitAbsent,
+    });
+    assert.ok(result.view);
+    assert.equal(result.view.summitAvailable, false);
+
+    const quality = result.view.drivers.find((d) => d.id === "quality");
+    assert.equal(quality.recommendations.length, 0);
+  });
+
+  it("warns on unknown item_id", async () => {
+    const scoresWithUnknown = [
+      ...SCORES,
+      { snapshot_id: "snap-1", item_id: "unknown_driver", score: 50 },
+    ];
+    const result = await runHealthCommand({
+      options: { manager: "alice@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ scores: scoresWithUnknown }),
+      summitFn: summitAbsent,
+    });
+    assert.ok(result.meta.warnings.some((w) => w.includes("unknown_driver")));
+  });
+
+  it("returns NO_SNAPSHOTS when empty", async () => {
+    const result = await runHealthCommand({
+      options: { manager: "alice@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ snapshots: [] }),
+      summitFn: summitAbsent,
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_SNAPSHOTS);
+  });
+
+  it("returns MANAGER_NOT_FOUND for unknown manager", async () => {
+    const result = await runHealthCommand({
+      options: { manager: "nobody@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ team: [] }),
+      summitFn: summitAbsent,
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("nobody@example.com"));
+  });
+});

--- a/products/landmark/test/initiative-helpers.test.js
+++ b/products/landmark/test/initiative-helpers.test.js
@@ -1,0 +1,150 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeInitiativeImpact } from "../src/lib/initiative-helpers.js";
+
+const SNAPSHOTS = [
+  { snapshot_id: "snap-q3", scheduled_for: "2024-09-15" },
+  { snapshot_id: "snap-q4", scheduled_for: "2024-12-15" },
+  { snapshot_id: "snap-q1", scheduled_for: "2025-03-15" },
+  { snapshot_id: "snap-q2", scheduled_for: "2025-06-15" },
+];
+
+function makeScores(data) {
+  const m = new Map();
+  for (const [snapId, scores] of Object.entries(data)) {
+    m.set(snapId, new Map(Object.entries(scores)));
+  }
+  return m;
+}
+
+describe("computeInitiativeImpact", () => {
+  it("computes delta for a completed initiative", () => {
+    const completed = [
+      {
+        id: "init-1",
+        name: "Improve estimation",
+        scorecard_id: "quality",
+        completed_at: "2025-01-10",
+      },
+    ];
+
+    const scores = makeScores({
+      "snap-q3": { quality: 38 },
+      "snap-q4": { quality: 42 },
+      "snap-q1": { quality: 58 },
+      "snap-q2": { quality: 60 },
+    });
+
+    const results = computeInitiativeImpact({
+      completed,
+      snapshots: SNAPSHOTS,
+      scoresBySnapshot: scores,
+    });
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0].before, 42); // snap-q4 (before completion)
+    assert.equal(results[0].after, 58); // snap-q1 (after completion)
+    assert.equal(results[0].delta, 16);
+  });
+
+  it("returns null delta for initiative without scorecard_id", () => {
+    const completed = [
+      {
+        id: "init-2",
+        name: "No scorecard",
+        scorecard_id: null,
+        completed_at: "2025-01-10",
+      },
+    ];
+    const results = computeInitiativeImpact({
+      completed,
+      snapshots: SNAPSHOTS,
+      scoresBySnapshot: makeScores({}),
+    });
+    assert.equal(results[0].delta, null);
+  });
+
+  it("returns null delta when no snapshot before completion", () => {
+    const completed = [
+      {
+        id: "init-3",
+        name: "Early",
+        scorecard_id: "quality",
+        completed_at: "2024-01-01",
+      },
+    ];
+    const results = computeInitiativeImpact({
+      completed,
+      snapshots: SNAPSHOTS,
+      scoresBySnapshot: makeScores({}),
+    });
+    assert.equal(results[0].delta, null);
+  });
+
+  it("returns null delta when no snapshot after completion", () => {
+    const completed = [
+      {
+        id: "init-4",
+        name: "Late",
+        scorecard_id: "quality",
+        completed_at: "2025-12-01",
+      },
+    ];
+    const results = computeInitiativeImpact({
+      completed,
+      snapshots: SNAPSHOTS,
+      scoresBySnapshot: makeScores({}),
+    });
+    assert.equal(results[0].delta, null);
+  });
+
+  it("returns null delta when score missing in a snapshot", () => {
+    const completed = [
+      {
+        id: "init-5",
+        name: "Missing score",
+        scorecard_id: "quality",
+        completed_at: "2025-01-10",
+      },
+    ];
+    const scores = makeScores({
+      "snap-q4": {}, // quality missing
+      "snap-q1": { quality: 50 },
+    });
+    const results = computeInitiativeImpact({
+      completed,
+      snapshots: SNAPSHOTS,
+      scoresBySnapshot: scores,
+    });
+    assert.equal(results[0].delta, null);
+  });
+
+  it("produces identical output regardless of snapshot array order", () => {
+    const completed = [
+      {
+        id: "init-1",
+        name: "Test",
+        scorecard_id: "quality",
+        completed_at: "2025-01-10",
+      },
+    ];
+    const scores = makeScores({
+      "snap-q4": { quality: 42 },
+      "snap-q1": { quality: 58 },
+    });
+
+    const result1 = computeInitiativeImpact({
+      completed,
+      snapshots: SNAPSHOTS,
+      scoresBySnapshot: scores,
+    });
+    const result2 = computeInitiativeImpact({
+      completed,
+      snapshots: [...SNAPSHOTS].reverse(),
+      scoresBySnapshot: scores,
+    });
+
+    assert.deepEqual(result1[0].delta, result2[0].delta);
+  });
+});

--- a/products/landmark/test/initiative.test.js
+++ b/products/landmark/test/initiative.test.js
@@ -1,0 +1,180 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runInitiativeCommand } from "../src/commands/initiative.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const INITIATIVES = [
+  {
+    id: "init-1",
+    name: "Improve sprint estimation",
+    scorecard_id: "quality",
+    owner_email: "alice@example.com",
+    due_date: "2025-06-01",
+    priority: "high",
+    passed_checks: 8,
+    total_checks: 10,
+    completion_pct: 80,
+    completed_at: null,
+    tags: ["planning"],
+  },
+  {
+    id: "init-2",
+    name: "Create incident runbooks",
+    scorecard_id: null,
+    owner_email: "bob@example.com",
+    due_date: "2025-03-01",
+    priority: "medium",
+    passed_checks: 5,
+    total_checks: 5,
+    completion_pct: 100,
+    completed_at: "2025-03-01T00:00:00Z",
+    tags: ["reliability"],
+  },
+];
+
+const SNAPSHOTS = [
+  { snapshot_id: "snap-q4", scheduled_for: "2024-12-15" },
+  { snapshot_id: "snap-q1", scheduled_for: "2025-03-15" },
+];
+
+const MAP_DATA = {
+  drivers: [
+    {
+      id: "quality",
+      name: "Quality",
+      contributingSkills: ["task_completion", "planning"],
+    },
+  ],
+};
+
+function stubQueries({
+  initiatives = INITIATIVES,
+  snapshots = SNAPSHOTS,
+} = {}) {
+  return {
+    listInitiatives: async (_sb, opts) => {
+      let result = initiatives;
+      if (opts?.status === "completed") {
+        result = result.filter((i) => i.completed_at);
+      }
+      return result;
+    },
+    getInitiative: async (_sb, id) =>
+      initiatives.find((i) => i.id === id) ?? null,
+    listSnapshots: async () => snapshots,
+    getSnapshotScores: async (_sb, snapshotId) => {
+      if (snapshotId === "snap-q4") return [{ item_id: "quality", score: 42 }];
+      if (snapshotId === "snap-q1") return [{ item_id: "quality", score: 58 }];
+      return [];
+    },
+  };
+}
+
+describe("initiative list", () => {
+  it("returns all initiatives", async () => {
+    const result = await runInitiativeCommand({
+      args: ["list"],
+      options: {},
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.initiatives.length, 2);
+  });
+
+  it("returns NO_INITIATIVES when empty", async () => {
+    const result = await runInitiativeCommand({
+      args: ["list"],
+      options: {},
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries({ initiatives: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_INITIATIVES);
+  });
+
+  it("returns NO_INITIATIVES when table missing", async () => {
+    const result = await runInitiativeCommand({
+      args: ["list"],
+      options: {},
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: {
+        ...stubQueries(),
+        listInitiatives: async () => {
+          const err = new Error("relation does not exist");
+          err.code = "42P01";
+          throw err;
+        },
+      },
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_INITIATIVES);
+  });
+});
+
+describe("initiative show", () => {
+  it("returns initiative detail", async () => {
+    const result = await runInitiativeCommand({
+      args: ["show"],
+      options: { id: "init-1" },
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.initiative.name, "Improve sprint estimation");
+  });
+
+  it("returns empty state for unknown id", async () => {
+    const result = await runInitiativeCommand({
+      args: ["show"],
+      options: { id: "nonexistent" },
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("nonexistent"));
+  });
+});
+
+describe("initiative impact", () => {
+  it("computes impact for completed initiatives", async () => {
+    const result = await runInitiativeCommand({
+      args: ["impact"],
+      options: {},
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view.impacts.length > 0);
+    // init-2 has no scorecard_id so delta should be null
+    const init2 = result.view.impacts.find((i) => i.initiative.id === "init-2");
+    assert.equal(init2.delta, null);
+  });
+});
+
+describe("initiative subcommand validation", () => {
+  it("throws for unknown subcommand", async () => {
+    await assert.rejects(
+      () =>
+        runInitiativeCommand({
+          args: ["bogus"],
+          options: {},
+          supabase: {},
+          mapData: MAP_DATA,
+          format: "text",
+          queries: stubQueries(),
+        }),
+      /expected/,
+    );
+  });
+});

--- a/products/landmark/test/marker.test.js
+++ b/products/landmark/test/marker.test.js
@@ -1,0 +1,124 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runMarkerCommand } from "../src/commands/marker.js";
+
+const MAP_DATA_WITH_MARKERS = {
+  skills: [
+    {
+      id: "task_completion",
+      name: "Task Completion",
+      markers: {
+        awareness: {
+          human: ["Closed an assigned task by following a documented runbook"],
+          agent: [
+            "Completed a task by applying an existing pattern from the codebase",
+          ],
+        },
+        working: {
+          human: [
+            "Delivered a feature end-to-end with no revision to the initial design",
+          ],
+          agent: [
+            "Completed a multi-file change that passes CI without human rework",
+          ],
+        },
+      },
+    },
+    {
+      id: "planning",
+      name: "Planning",
+      // No markers
+    },
+  ],
+};
+
+const MAP_DATA_NO_MARKERS = {
+  skills: [
+    { id: "task_completion", name: "Task Completion" },
+    { id: "planning", name: "Planning" },
+  ],
+};
+
+describe("marker command", () => {
+  it("returns markers for a skill that has them", async () => {
+    const result = await runMarkerCommand({
+      args: ["task_completion"],
+      options: {},
+      mapData: MAP_DATA_WITH_MARKERS,
+      format: "text",
+    });
+    assert.equal(result.view.skill, "task_completion");
+    assert.ok(result.view.markers.awareness);
+    assert.ok(result.view.markers.working);
+    assert.equal(result.meta.emptyState, undefined);
+  });
+
+  it("returns empty state for skill without markers", async () => {
+    const result = await runMarkerCommand({
+      args: ["planning"],
+      options: {},
+      mapData: MAP_DATA_WITH_MARKERS,
+      format: "text",
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("planning"));
+  });
+
+  it("returns empty state when no markers exist in data", async () => {
+    const result = await runMarkerCommand({
+      args: ["task_completion"],
+      options: {},
+      mapData: MAP_DATA_NO_MARKERS,
+      format: "text",
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("task_completion"));
+  });
+
+  it("filters by --level", async () => {
+    const result = await runMarkerCommand({
+      args: ["task_completion"],
+      options: { level: "working" },
+      mapData: MAP_DATA_WITH_MARKERS,
+      format: "text",
+    });
+    assert.ok(result.view.markers.working);
+    assert.equal(result.view.markers.awareness, undefined);
+  });
+
+  it("returns empty state for unknown level filter", async () => {
+    const result = await runMarkerCommand({
+      args: ["task_completion"],
+      options: { level: "expert" },
+      mapData: MAP_DATA_WITH_MARKERS,
+      format: "text",
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("expert"));
+  });
+
+  it("returns empty state for unknown skill", async () => {
+    const result = await runMarkerCommand({
+      args: ["nonexistent"],
+      options: {},
+      mapData: MAP_DATA_WITH_MARKERS,
+      format: "text",
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("nonexistent"));
+  });
+
+  it("throws when skill id is missing", async () => {
+    await assert.rejects(
+      () =>
+        runMarkerCommand({
+          args: [],
+          options: {},
+          mapData: MAP_DATA_WITH_MARKERS,
+          format: "text",
+        }),
+      /skill id is required/,
+    );
+  });
+});

--- a/products/landmark/test/org.test.js
+++ b/products/landmark/test/org.test.js
@@ -1,0 +1,113 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runOrgCommand } from "../src/commands/org.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const PEOPLE = [
+  {
+    email: "alice@example.com",
+    name: "Alice",
+    discipline: "software_engineering",
+    level: "J040",
+    track: null,
+    manager_email: null,
+  },
+  {
+    email: "bob@example.com",
+    name: "Bob",
+    discipline: "software_engineering",
+    level: "J060",
+    track: "platform",
+    manager_email: "alice@example.com",
+  },
+];
+
+function stubQueries({ org = PEOPLE, team = PEOPLE } = {}) {
+  return {
+    getOrganization: async () => org,
+    getTeam: async (_sb, _email) => team,
+  };
+}
+
+describe("org show", () => {
+  it("returns all people", async () => {
+    const result = await runOrgCommand({
+      args: ["show"],
+      options: {},
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.people.length, 2);
+    assert.equal(result.meta.emptyState, undefined);
+  });
+
+  it("returns empty state when no people", async () => {
+    const result = await runOrgCommand({
+      args: ["show"],
+      options: {},
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ org: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_ORGANIZATION);
+  });
+});
+
+describe("org team", () => {
+  it("returns team members for a manager", async () => {
+    const result = await runOrgCommand({
+      args: ["team"],
+      options: { manager: "alice@example.com" },
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.team.length, 2);
+    assert.equal(result.view.managerEmail, "alice@example.com");
+  });
+
+  it("returns empty state when manager has no team", async () => {
+    const result = await runOrgCommand({
+      args: ["team"],
+      options: { manager: "nobody@example.com" },
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ team: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("nobody@example.com"));
+  });
+
+  it("throws when --manager is missing", async () => {
+    await assert.rejects(
+      () =>
+        runOrgCommand({
+          args: ["team"],
+          options: {},
+          supabase: {},
+          format: "text",
+          queries: stubQueries(),
+        }),
+      /--manager/,
+    );
+  });
+});
+
+describe("org subcommand validation", () => {
+  it("throws for unknown subcommand", async () => {
+    await assert.rejects(
+      () =>
+        runOrgCommand({
+          args: ["bogus"],
+          options: {},
+          supabase: {},
+          format: "text",
+          queries: stubQueries(),
+        }),
+      /expected/,
+    );
+  });
+});

--- a/products/landmark/test/practice.test.js
+++ b/products/landmark/test/practice.test.js
@@ -1,0 +1,57 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runPracticeCommand } from "../src/commands/practice.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const PATTERNS = [
+  { skill_id: "task_completion", matched: 5, unmatched: 2, total: 7 },
+  { skill_id: "planning", matched: 1, unmatched: 3, total: 4 },
+];
+
+function stubQueries({ patterns = PATTERNS } = {}) {
+  return { getPracticePatterns: async () => patterns };
+}
+
+describe("practice command", () => {
+  it("returns practice patterns", async () => {
+    const result = await runPracticeCommand({
+      options: {},
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view);
+    assert.equal(result.view.patterns.length, 2);
+    assert.equal(result.view.patterns[0].matched, 5);
+  });
+
+  it("passes skill filter", async () => {
+    let captured;
+    const result = await runPracticeCommand({
+      options: { skill: "planning", manager: "alice@example.com" },
+      supabase: {},
+      format: "text",
+      queries: {
+        getPracticePatterns: async (_sb, opts) => {
+          captured = opts;
+          return PATTERNS;
+        },
+      },
+    });
+    assert.equal(captured.skillId, "planning");
+    assert.equal(captured.managerEmail, "alice@example.com");
+    assert.ok(result.view);
+  });
+
+  it("returns NO_EVIDENCE when empty", async () => {
+    const result = await runPracticeCommand({
+      options: {},
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ patterns: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_EVIDENCE);
+  });
+});

--- a/products/landmark/test/practiced.test.js
+++ b/products/landmark/test/practiced.test.js
@@ -1,0 +1,126 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runPracticedCommand } from "../src/commands/practiced.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const MAP_DATA = {
+  levels: [
+    {
+      id: "J040",
+      ordinalRank: 1,
+      baseSkillProficiencies: {
+        primary: "foundational",
+        secondary: "awareness",
+        broad: "awareness",
+      },
+    },
+    {
+      id: "J060",
+      ordinalRank: 2,
+      baseSkillProficiencies: {
+        primary: "working",
+        secondary: "foundational",
+        broad: "awareness",
+      },
+    },
+  ],
+  disciplines: [
+    {
+      id: "software_engineering",
+      coreSkills: ["task_completion"],
+      supportingSkills: ["planning"],
+      broadSkills: ["incident_response"],
+    },
+  ],
+  tracks: [{ id: "platform", skillModifiers: {} }],
+  skills: [
+    { id: "task_completion", name: "Task Completion" },
+    { id: "planning", name: "Planning" },
+    { id: "incident_response", name: "Incident Response" },
+  ],
+  capabilities: [],
+};
+
+const TEAM = [
+  {
+    email: "alice@example.com",
+    name: "Alice",
+    discipline: "software_engineering",
+    level: "J040",
+    track: "platform",
+  },
+  {
+    email: "bob@example.com",
+    name: "Bob",
+    discipline: "software_engineering",
+    level: "J060",
+    track: null,
+  },
+  {
+    email: "carol@example.com",
+    name: "Carol",
+    discipline: "software_engineering",
+    level: "J040",
+    track: "platform",
+  },
+];
+
+const PATTERNS = [
+  { skill_id: "task_completion", matched: 5, unmatched: 2, total: 7 },
+  { skill_id: "planning", matched: 0, unmatched: 1, total: 1 },
+];
+
+function stubQueries({ team = TEAM, patterns = PATTERNS } = {}) {
+  return {
+    getTeam: async () => team,
+    getPracticePatterns: async () => patterns,
+  };
+}
+
+describe("practiced command", () => {
+  it("returns derived vs evidenced comparison", async () => {
+    const result = await runPracticedCommand({
+      options: { manager: "alice@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view);
+    assert.equal(result.view.teamSize, 3);
+
+    const taskComp = result.view.skills.find(
+      (s) => s.skillId === "task_completion",
+    );
+    assert.ok(taskComp.derivedDepth);
+    assert.equal(taskComp.evidencedCount, 5);
+    assert.equal(taskComp.flag, null);
+
+    const planning = result.view.skills.find((s) => s.skillId === "planning");
+    assert.equal(planning.flag, "on paper only");
+  });
+
+  it("returns empty state when team is empty", async () => {
+    const result = await runPracticedCommand({
+      options: { manager: "nobody@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ team: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("nobody@example.com"));
+  });
+
+  it("returns NO_EVIDENCE when no practice patterns", async () => {
+    const result = await runPracticedCommand({
+      options: { manager: "alice@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ patterns: [] }),
+    });
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_EVIDENCE);
+  });
+});

--- a/products/landmark/test/readiness.test.js
+++ b/products/landmark/test/readiness.test.js
@@ -1,0 +1,242 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runReadinessCommand } from "../src/commands/readiness.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const MAP_DATA = {
+  levels: [
+    {
+      id: "J040",
+      professionalTitle: "Level I",
+      ordinalRank: 1,
+      baseSkillProficiencies: {
+        primary: "foundational",
+        secondary: "awareness",
+        broad: "awareness",
+      },
+    },
+    {
+      id: "J060",
+      professionalTitle: "Level II",
+      ordinalRank: 2,
+      baseSkillProficiencies: {
+        primary: "working",
+        secondary: "foundational",
+        broad: "awareness",
+      },
+    },
+  ],
+  disciplines: [
+    {
+      id: "software_engineering",
+      coreSkills: ["task_completion"],
+      supportingSkills: ["planning"],
+      broadSkills: ["incident_response"],
+    },
+  ],
+  tracks: [{ id: "platform", skillModifiers: {} }],
+  skills: [
+    {
+      id: "task_completion",
+      name: "Task Completion",
+      markers: {
+        awareness: {
+          human: ["Closed a task by following a runbook"],
+          agent: ["Applied an existing pattern"],
+        },
+        foundational: {
+          human: [
+            "Delivered a small feature",
+            "Estimated and completed a task",
+          ],
+          agent: ["Single-file change passes CI"],
+        },
+        working: {
+          human: [
+            "Delivered feature end-to-end",
+            "Resolved production issue within SLA",
+          ],
+          agent: ["Multi-file change passes CI"],
+        },
+      },
+    },
+    {
+      id: "planning",
+      name: "Planning",
+      markers: {
+        awareness: {
+          human: ["Followed a project plan"],
+          agent: ["Executed prescribed steps"],
+        },
+        foundational: {
+          human: ["Created a task breakdown"],
+          agent: ["Generated an implementation plan"],
+        },
+        working: {
+          human: ["Planned and delivered across sprints"],
+          agent: ["Multi-part plan with dependencies"],
+        },
+      },
+    },
+    {
+      id: "incident_response",
+      name: "Incident Response",
+      markers: {
+        awareness: {
+          human: ["Followed escalation procedure"],
+          agent: ["Identified failing health check"],
+        },
+        foundational: {
+          human: ["Gathered diagnostic info"],
+          agent: ["Collected log entries"],
+        },
+        working: {
+          human: ["Led incident response"],
+          agent: ["Diagnosed production issue"],
+        },
+      },
+    },
+  ],
+  capabilities: [],
+};
+
+function stubQueries({ person = undefined, evidence = [] } = {}) {
+  return {
+    getPerson: async (_sb, email) => {
+      if (person === null) return null;
+      return (
+        person ?? {
+          email,
+          name: "Alice",
+          discipline: "software_engineering",
+          level: "J040",
+          track: "platform",
+        }
+      );
+    },
+    getEvidence: async () => evidence,
+  };
+}
+
+describe("readiness command", () => {
+  it("generates checklist for J040 targeting J060", async () => {
+    const result = await runReadinessCommand({
+      options: { email: "alice@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries({
+        evidence: [
+          {
+            skill_id: "task_completion",
+            matched: true,
+            marker_text: "Delivered feature end-to-end",
+            artifact_id: "a1",
+          },
+        ],
+      }),
+    });
+    assert.ok(result.view);
+    assert.equal(result.view.currentLevel, "J040");
+    assert.equal(result.view.targetLevel, "J060");
+    assert.ok(result.view.checklist.length > 0);
+    assert.ok(result.view.summary.total > 0);
+    assert.equal(result.view.skippedSkills.length, 0);
+  });
+
+  it("returns NO_HIGHER_LEVEL for J060 (highest)", async () => {
+    const result = await runReadinessCommand({
+      options: { email: "bob@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries({
+        person: {
+          email: "bob@example.com",
+          name: "Bob",
+          discipline: "software_engineering",
+          level: "J060",
+          track: null,
+        },
+      }),
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("J060"));
+  });
+
+  it("skips skills with no markers at required proficiency", async () => {
+    const mapDataPartialMarkers = {
+      ...MAP_DATA,
+      skills: [
+        {
+          id: "task_completion",
+          name: "Task Completion",
+          markers: {
+            working: {
+              human: ["Delivered feature end-to-end"],
+              agent: ["Multi-file change"],
+            },
+          },
+        },
+        {
+          id: "planning",
+          name: "Planning",
+          // No markers at any level
+        },
+        {
+          id: "incident_response",
+          name: "Incident Response",
+          markers: {
+            awareness: {
+              human: ["Followed escalation"],
+              agent: ["Health check alert"],
+            },
+          },
+        },
+      ],
+    };
+    const result = await runReadinessCommand({
+      options: { email: "alice@example.com" },
+      mapData: mapDataPartialMarkers,
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view);
+    assert.ok(result.view.skippedSkills.length > 0);
+    assert.ok(result.view.checklist.length > 0);
+  });
+
+  it("returns NO_MARKERS_AT_TARGET when all skills lack markers", async () => {
+    const mapDataNoMarkers = {
+      ...MAP_DATA,
+      skills: [
+        { id: "task_completion", name: "Task Completion" },
+        { id: "planning", name: "Planning" },
+        { id: "incident_response", name: "Incident Response" },
+      ],
+    };
+    const result = await runReadinessCommand({
+      options: { email: "alice@example.com" },
+      mapData: mapDataNoMarkers,
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_MARKERS_AT_TARGET);
+  });
+
+  it("returns PERSON_NOT_FOUND for unknown email", async () => {
+    const result = await runReadinessCommand({
+      options: { email: "nobody@example.com" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ person: null }),
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("nobody@example.com"));
+  });
+});

--- a/products/landmark/test/snapshot.test.js
+++ b/products/landmark/test/snapshot.test.js
@@ -1,0 +1,197 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  runSnapshotCommand,
+  collectDriverWarnings,
+} from "../src/commands/snapshot.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const SNAPSHOTS = [
+  {
+    snapshot_id: "snap-1",
+    scheduled_for: "2025-03-15",
+    completed_at: "2025-03-20",
+  },
+  {
+    snapshot_id: "snap-2",
+    scheduled_for: "2024-12-15",
+    completed_at: "2025-01-05",
+  },
+];
+
+const SCORES = [
+  {
+    snapshot_id: "snap-1",
+    item_id: "quality",
+    item_name: "Quality",
+    score: 42,
+    vs_prev: -5,
+    vs_org: -10,
+    vs_50th: -8,
+    vs_75th: -25,
+    vs_90th: -40,
+  },
+];
+
+const TREND = [
+  {
+    item_id: "quality",
+    score: 38,
+    getdx_snapshots: { scheduled_for: "2024-06-15" },
+  },
+  {
+    item_id: "quality",
+    score: 42,
+    getdx_snapshots: { scheduled_for: "2025-03-15" },
+  },
+];
+
+const MAP_DATA = {
+  drivers: [{ id: "quality", name: "Quality" }],
+};
+
+function stubQueries({
+  snapshots = SNAPSHOTS,
+  scores = SCORES,
+  trend = TREND,
+} = {}) {
+  return {
+    listSnapshots: async () => snapshots,
+    getSnapshotScores: async () => scores,
+    getItemTrend: async () => trend,
+    getSnapshotComparison: async () => scores,
+  };
+}
+
+describe("snapshot list", () => {
+  it("returns all snapshots", async () => {
+    const result = await runSnapshotCommand({
+      args: ["list"],
+      options: {},
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.snapshots.length, 2);
+  });
+
+  it("returns empty state when no snapshots", async () => {
+    const result = await runSnapshotCommand({
+      args: ["list"],
+      options: {},
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ snapshots: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_SNAPSHOTS);
+  });
+});
+
+describe("snapshot show", () => {
+  it("returns scores for a snapshot", async () => {
+    const result = await runSnapshotCommand({
+      args: ["show"],
+      options: { snapshot: "snap-1" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.snapshotId, "snap-1");
+    assert.equal(result.view.scores.length, 1);
+  });
+
+  it("throws when --snapshot is missing", async () => {
+    await assert.rejects(
+      () =>
+        runSnapshotCommand({
+          args: ["show"],
+          options: {},
+          mapData: MAP_DATA,
+          supabase: {},
+          format: "text",
+          queries: stubQueries(),
+        }),
+      /--snapshot/,
+    );
+  });
+});
+
+describe("snapshot trend", () => {
+  it("returns trend data for an item", async () => {
+    const result = await runSnapshotCommand({
+      args: ["trend"],
+      options: { item: "quality" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.itemId, "quality");
+    assert.equal(result.view.trend.length, 2);
+  });
+
+  it("throws when --item is missing", async () => {
+    await assert.rejects(
+      () =>
+        runSnapshotCommand({
+          args: ["trend"],
+          options: {},
+          mapData: MAP_DATA,
+          supabase: {},
+          format: "text",
+          queries: stubQueries(),
+        }),
+      /--item/,
+    );
+  });
+});
+
+describe("snapshot compare", () => {
+  it("returns comparison scores", async () => {
+    const result = await runSnapshotCommand({
+      args: ["compare"],
+      options: { snapshot: "snap-1" },
+      mapData: MAP_DATA,
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.equal(result.view.snapshotId, "snap-1");
+  });
+});
+
+describe("collectDriverWarnings", () => {
+  it("warns on unknown item_id", () => {
+    const scores = [{ item_id: "quality" }, { item_id: "unknown_driver" }];
+    const warnings = collectDriverWarnings(scores, MAP_DATA);
+    assert.equal(warnings.length, 1);
+    assert.ok(warnings[0].includes("unknown_driver"));
+  });
+
+  it("returns no warnings for known drivers", () => {
+    const warnings = collectDriverWarnings(SCORES, MAP_DATA);
+    assert.equal(warnings.length, 0);
+  });
+});
+
+describe("snapshot subcommand validation", () => {
+  it("throws for unknown subcommand", async () => {
+    await assert.rejects(
+      () =>
+        runSnapshotCommand({
+          args: ["bogus"],
+          options: {},
+          mapData: MAP_DATA,
+          supabase: {},
+          format: "text",
+          queries: stubQueries(),
+        }),
+      /expected/,
+    );
+  });
+});

--- a/products/landmark/test/summit.test.js
+++ b/products/landmark/test/summit.test.js
@@ -1,14 +1,10 @@
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 
-import {
-  computeGrowth,
-  __setSummitForTests,
-  __resetSummitCache,
-} from "../src/lib/summit.js";
+import { computeGrowth, __setSummitForTests } from "../src/lib/summit.js";
 
 afterEach(() => {
-  __resetSummitCache();
+  __setSummitForTests(null);
 });
 
 describe("summit wrapper", () => {

--- a/products/landmark/test/summit.test.js
+++ b/products/landmark/test/summit.test.js
@@ -1,0 +1,61 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  computeGrowth,
+  __setSummitForTests,
+  __resetSummitCache,
+} from "../src/lib/summit.js";
+
+afterEach(() => {
+  __resetSummitCache();
+});
+
+describe("summit wrapper", () => {
+  it("returns available: false when Summit is absent", async () => {
+    __setSummitForTests({ fn: null });
+    const result = await computeGrowth({});
+    assert.equal(result.available, false);
+    assert.equal(result.recommendations.length, 0);
+  });
+
+  it("returns recommendations when Summit is present", async () => {
+    __setSummitForTests({
+      fn: () => [{ skill: "planning", impact: "critical", candidates: [] }],
+    });
+    const result = await computeGrowth({});
+    assert.equal(result.available, true);
+    assert.equal(result.recommendations.length, 1);
+    assert.equal(result.recommendations[0].skill, "planning");
+  });
+
+  it("catches unknown errors as warnings", async () => {
+    __setSummitForTests({
+      fn: () => {
+        throw new Error("boom");
+      },
+    });
+    const result = await computeGrowth({});
+    assert.equal(result.available, true);
+    assert.equal(result.recommendations.length, 0);
+    assert.ok(result.warnings[0].includes("boom"));
+  });
+
+  it("catches GrowthContractError as warnings", async () => {
+    class GrowthContractError extends Error {
+      constructor(code, message) {
+        super(message);
+        this.code = code;
+      }
+    }
+    __setSummitForTests({
+      fn: () => {
+        throw new GrowthContractError("UNKNOWN_DISCIPLINE", "bad discipline");
+      },
+      GrowthContractError,
+    });
+    const result = await computeGrowth({});
+    assert.equal(result.available, true);
+    assert.ok(result.warnings[0].includes("bad discipline"));
+  });
+});

--- a/products/landmark/test/timeline.test.js
+++ b/products/landmark/test/timeline.test.js
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runTimelineCommand } from "../src/commands/timeline.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const EVIDENCE = [
+  {
+    skill_id: "planning",
+    level_id: "awareness",
+    matched: true,
+    created_at: "2024-07-15T00:00:00Z",
+  },
+  {
+    skill_id: "planning",
+    level_id: "foundational",
+    matched: true,
+    created_at: "2024-10-20T00:00:00Z",
+  },
+  {
+    skill_id: "planning",
+    level_id: "working",
+    matched: true,
+    created_at: "2025-02-01T00:00:00Z",
+  },
+  {
+    skill_id: "task_completion",
+    level_id: "working",
+    matched: true,
+    created_at: "2024-07-10T00:00:00Z",
+  },
+  {
+    skill_id: "task_completion",
+    level_id: "working",
+    matched: true,
+    created_at: "2025-01-05T00:00:00Z",
+  },
+];
+
+function stubQueries({ evidence = EVIDENCE } = {}) {
+  return { getEvidence: async () => evidence };
+}
+
+describe("timeline command", () => {
+  it("returns quarterly timeline", async () => {
+    const result = await runTimelineCommand({
+      options: { email: "alice@example.com" },
+      supabase: {},
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view.timeline.length > 0);
+    // Q3 2024 has planning at awareness and task_completion at working
+    const q3Planning = result.view.timeline.find(
+      (t) => t.quarter === "2024-Q3" && t.skillId === "planning",
+    );
+    assert.equal(q3Planning.highestLevel, "awareness");
+  });
+
+  it("returns empty state when no evidence", async () => {
+    const result = await runTimelineCommand({
+      options: { email: "alice@example.com" },
+      supabase: {},
+      format: "text",
+      queries: stubQueries({ evidence: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_EVIDENCE);
+  });
+
+  it("throws when --email is missing", async () => {
+    await assert.rejects(
+      () =>
+        runTimelineCommand({
+          options: {},
+          supabase: {},
+          format: "text",
+          queries: stubQueries(),
+        }),
+      /--email/,
+    );
+  });
+});

--- a/products/landmark/test/voice.test.js
+++ b/products/landmark/test/voice.test.js
@@ -1,0 +1,151 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { runVoiceCommand } from "../src/commands/voice.js";
+import { EMPTY_STATES } from "../src/lib/empty-state.js";
+
+const COMMENTS = [
+  {
+    comment_id: "c1",
+    snapshot_id: "snap-1",
+    email: "alice@example.com",
+    text: "Estimation is always off, we overcommit every sprint",
+    timestamp: "2025-03-10T00:00:00Z",
+    getdx_snapshots: { scheduled_for: "2025-Q1" },
+  },
+  {
+    comment_id: "c2",
+    snapshot_id: "snap-1",
+    email: "bob@example.com",
+    text: "Incident response is painful, no runbook for the payment service",
+    timestamp: "2025-03-11T00:00:00Z",
+    getdx_snapshots: { scheduled_for: "2025-Q1" },
+  },
+  {
+    comment_id: "c3",
+    snapshot_id: "snap-2",
+    email: "alice@example.com",
+    text: "Planning process improved this quarter",
+    timestamp: "2024-12-10T00:00:00Z",
+    getdx_snapshots: { scheduled_for: "2024-Q4" },
+  },
+];
+
+const MAP_DATA = {
+  drivers: [
+    {
+      id: "quality",
+      name: "Quality",
+      contributingSkills: ["task_completion", "planning"],
+    },
+  ],
+};
+
+function stubQueries({ comments = COMMENTS, evidence = [] } = {}) {
+  return {
+    getSnapshotComments: async () => comments,
+    getEvidence: async () => evidence,
+    listSnapshots: async () => [
+      { snapshot_id: "snap-1", scheduled_for: "2025-Q1" },
+    ],
+    getSnapshotScores: async () => [
+      { item_id: "quality", score: 42, vs_org: -10 },
+    ],
+  };
+}
+
+describe("voice --email", () => {
+  it("returns comments grouped by snapshot", async () => {
+    const result = await runVoiceCommand({
+      options: { email: "alice@example.com" },
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view);
+    assert.equal(result.view.mode, "email");
+    assert.ok(result.view.comments.length > 0);
+  });
+
+  it("returns NO_COMMENTS when none found", async () => {
+    const result = await runVoiceCommand({
+      options: { email: "alice@example.com" },
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries({ comments: [] }),
+    });
+    assert.equal(result.view, null);
+    assert.ok(result.meta.emptyState.includes("comments"));
+    assert.ok(result.meta.hint);
+  });
+
+  it("returns NO_COMMENTS when table is missing", async () => {
+    const result = await runVoiceCommand({
+      options: { email: "alice@example.com" },
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: {
+        ...stubQueries(),
+        getSnapshotComments: async () => {
+          const err = new Error("relation does not exist");
+          err.code = "42P01";
+          throw err;
+        },
+      },
+    });
+    assert.equal(result.view, null);
+    assert.equal(result.meta.emptyState, EMPTY_STATES.NO_COMMENTS);
+    assert.equal(result.meta.hint, undefined);
+  });
+});
+
+describe("voice --manager", () => {
+  it("returns themed comments", async () => {
+    const result = await runVoiceCommand({
+      options: { manager: "alice@example.com" },
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view);
+    assert.equal(result.view.mode, "manager");
+    assert.ok(result.view.themes.length > 0);
+    const estimationTheme = result.view.themes.find(
+      (t) => t.theme === "estimation",
+    );
+    assert.ok(estimationTheme);
+    assert.equal(estimationTheme.count, 1);
+  });
+
+  it("includes health alignment for poor scores", async () => {
+    const result = await runVoiceCommand({
+      options: { manager: "alice@example.com" },
+      supabase: {},
+      mapData: MAP_DATA,
+      format: "text",
+      queries: stubQueries(),
+    });
+    assert.ok(result.view.healthAlignment.length > 0);
+    assert.equal(result.view.healthAlignment[0].driverId, "quality");
+  });
+});
+
+describe("voice validation", () => {
+  it("throws when neither --email nor --manager is set", async () => {
+    await assert.rejects(
+      () =>
+        runVoiceCommand({
+          options: {},
+          supabase: {},
+          mapData: MAP_DATA,
+          format: "text",
+          queries: stubQueries(),
+        }),
+      /--email.*--manager/,
+    );
+  });
+});

--- a/products/map/package.json
+++ b/products/map/package.json
@@ -42,6 +42,8 @@
     "./activity/queries/snapshots": "./src/activity/queries/snapshots.js",
     "./activity/queries/evidence": "./src/activity/queries/evidence.js",
     "./activity/queries/artifacts": "./src/activity/queries/artifacts.js",
+    "./activity/queries/comments": "./src/activity/queries/comments.js",
+    "./activity/queries/initiatives": "./src/activity/queries/initiatives.js",
     "./activity/parse-people": "./src/activity/parse-people.js",
     "./activity/validate/people": "./src/activity/validate/people.js",
     "./activity/storage": "./supabase/functions/_shared/activity/storage.js",

--- a/products/map/src/activity/queries/comments.js
+++ b/products/map/src/activity/queries/comments.js
@@ -1,0 +1,43 @@
+/**
+ * Snapshot Comments Queries
+ *
+ * Query functions for GetDX snapshot comments (engineer voice).
+ */
+
+/**
+ * Get snapshot comments with optional filters.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Object} [options]
+ * @param {string} [options.snapshotId] - Filter by snapshot
+ * @param {string} [options.email] - Filter by respondent email
+ * @param {string} [options.managerEmail] - Filter to this manager's team
+ * @returns {Promise<Array<Object>>} Comments
+ */
+export async function getSnapshotComments(supabase, options = {}) {
+  let query = supabase
+    .from("getdx_snapshot_comments")
+    .select("*, getdx_snapshots(scheduled_for)")
+    .order("timestamp", { ascending: false });
+
+  if (options.snapshotId) {
+    query = query.eq("snapshot_id", options.snapshotId);
+  }
+
+  if (options.email) {
+    query = query.eq("email", options.email);
+  }
+
+  if (options.managerEmail) {
+    const { data: teams } = await supabase
+      .from("getdx_teams")
+      .select("getdx_team_id")
+      .eq("manager_email", options.managerEmail);
+    const teamIds = (teams ?? []).map((t) => t.getdx_team_id);
+    if (teamIds.length === 0) return [];
+    query = query.in("team_id", teamIds);
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return data ?? [];
+}

--- a/products/map/src/activity/queries/initiatives.js
+++ b/products/map/src/activity/queries/initiatives.js
@@ -1,0 +1,63 @@
+/**
+ * Initiative Queries
+ *
+ * Thin SELECT wrappers for GetDX initiatives.
+ */
+
+/**
+ * List initiatives with optional filters.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Object} [options]
+ * @param {string} [options.ownerEmail] - Filter by owner email
+ * @param {string} [options.managerEmail] - Filter to this manager's team
+ * @param {"active"|"completed"} [options.status] - Filter by completion status
+ * @returns {Promise<Array<Object>>} Initiatives
+ */
+export async function listInitiatives(supabase, options = {}) {
+  let query = supabase
+    .from("getdx_initiatives")
+    .select("*")
+    .order("due_date", { ascending: true });
+
+  if (options.ownerEmail) {
+    query = query.eq("owner_email", options.ownerEmail);
+  }
+
+  if (options.managerEmail) {
+    const { data: team } = await supabase
+      .from("organization_people")
+      .select("email")
+      .eq("manager_email", options.managerEmail);
+    const emails = (team ?? []).map((t) => t.email);
+    if (emails.length === 0) return [];
+    query = query.in("owner_email", emails);
+  }
+
+  if (options.status === "active") {
+    query = query.is("completed_at", null);
+  }
+  if (options.status === "completed") {
+    query = query.not("completed_at", "is", null);
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return data ?? [];
+}
+
+/**
+ * Get a single initiative by ID.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} id - Initiative ID
+ * @returns {Promise<Object|null>}
+ */
+export async function getInitiative(supabase, id) {
+  const { data, error } = await supabase
+    .from("getdx_initiatives")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data;
+}

--- a/products/map/starter/capabilities/delivery.yaml
+++ b/products/map/starter/capabilities/delivery.yaml
@@ -43,6 +43,27 @@ skills:
         expert:
           You define delivery practices across the organization and drive
           completion of the most complex initiatives.
+    markers:
+      awareness:
+        human:
+          - Closed an assigned task by following a documented runbook
+        agent:
+          - Completed a task by applying an existing pattern from the codebase
+      foundational:
+        human:
+          - Delivered a small feature end-to-end with minimal rework
+          - Estimated and completed a defined task within the committed
+            timeframe
+        agent:
+          - Completed a single-file change that passes CI on the first attempt
+      working:
+        human:
+          - Delivered a feature end-to-end with no revision to the initial
+            design
+          - Independently resolved a production issue within SLA
+        agent:
+          - Completed a multi-file change that passes CI without human rework
+          - Resolved an ambiguous bug report with evidence from logs and tests
     agent:
       name: task-completion
       description: |
@@ -85,6 +106,30 @@ skills:
         expert:
           You shape planning strategy across the organization and drive delivery
           of the most complex programmes.
+    markers:
+      awareness:
+        human:
+          - Followed a project plan created by others and reported status on
+            time
+        agent:
+          - Executed a prescribed sequence of implementation steps without
+            deviation
+      foundational:
+        human:
+          - Created a task breakdown for a small feature with realistic
+            estimates
+          - Identified a dependency before it became a blocker
+        agent:
+          - Generated an implementation plan that correctly orders dependent
+            changes
+      working:
+        human:
+          - Planned and delivered a feature across multiple sprints adjusting
+            for new information
+          - Managed dependencies across two or more contributors
+        agent:
+          - Produced a multi-part plan that accounts for cross-file dependencies
+            and testing strategy
     agent:
       name: planning
       description: |

--- a/products/map/starter/capabilities/reliability.yaml
+++ b/products/map/starter/capabilities/reliability.yaml
@@ -50,6 +50,31 @@ skills:
         expert:
           You define incident management strategy across the organization and
           lead response to the most critical incidents.
+    markers:
+      awareness:
+        human:
+          - Followed the incident escalation procedure when encountering an
+            issue
+        agent:
+          - Identified a failing health check and raised an alert via the
+            configured channel
+      foundational:
+        human:
+          - Gathered diagnostic information during an incident and contributed
+            findings to the post-incident review
+          - Wrote a runbook entry for a recurring operational task
+        agent:
+          - Collected relevant log entries and metrics during an incident to
+            support root cause analysis
+      working:
+        human:
+          - Led incident response for a service outage and coordinated
+            resolution across teams
+          - Conducted a blameless post-mortem that produced actionable
+            follow-ups
+        agent:
+          - Diagnosed a production issue by correlating logs, metrics, and
+            recent deployments
     agent:
       name: incident-response
       description: |

--- a/products/map/starter/drivers.yaml
+++ b/products/map/starter/drivers.yaml
@@ -8,3 +8,19 @@
     - planning
   contributingBehaviours:
     - systems_thinking
+
+- id: reliability
+  name: Reliability
+  description: Keep systems dependable and recover quickly from disruption.
+  contributingSkills:
+    - incident_response
+  contributingBehaviours:
+    - systems_thinking
+
+- id: cognitive_load
+  name: Cognitive Load
+  description: Keep day-to-day engineering tractable by managing complexity.
+  contributingSkills:
+    - planning
+  contributingBehaviours:
+    - systems_thinking

--- a/products/map/supabase/functions/_shared/activity/extract/getdx.js
+++ b/products/map/supabase/functions/_shared/activity/extract/getdx.js
@@ -51,7 +51,7 @@ export async function extractGetDX(supabase, config) {
     if (snapshotsResult.stored) files.push(snapshotsPath);
     else errors.push(snapshotsResult.error);
 
-    // snapshots.info for each snapshot
+    // snapshots.info and snapshots.comments.list for each snapshot
     const snapshots = snapshotsResponse.snapshots || [];
     for (const snapshot of snapshots) {
       if (snapshot.deleted_at) continue;
@@ -71,9 +71,42 @@ export async function extractGetDX(supabase, config) {
       } catch (err) {
         errors.push(`snapshots.info(${snapshot.id}): ${err.message}`);
       }
+
+      // snapshots.comments.list
+      try {
+        const commentsResponse = await fetchGetDX(
+          `/snapshots.comments.list?snapshot_id=${encodeURIComponent(snapshot.id)}`,
+          config,
+        );
+        const commentsPath = `getdx/snapshots-comments/${snapshot.id}.json`;
+        const commentsResult = await storeRaw(
+          supabase,
+          commentsPath,
+          JSON.stringify(commentsResponse),
+        );
+        if (commentsResult.stored) files.push(commentsPath);
+        else errors.push(commentsResult.error);
+      } catch (err) {
+        errors.push(`snapshots.comments.list(${snapshot.id}): ${err.message}`);
+      }
     }
   } catch (err) {
     errors.push(`snapshots.list: ${err.message}`);
+  }
+
+  // initiatives.list (org-scoped, not per-snapshot)
+  try {
+    const initiativesResponse = await fetchGetDX("/initiatives.list", config);
+    const initiativesPath = `getdx/initiatives-list/${timestamp}.json`;
+    const initiativesResult = await storeRaw(
+      supabase,
+      initiativesPath,
+      JSON.stringify(initiativesResponse),
+    );
+    if (initiativesResult.stored) files.push(initiativesPath);
+    else errors.push(initiativesResult.error);
+  } catch (err) {
+    errors.push(`initiatives.list: ${err.message}`);
   }
 
   return { files, errors };

--- a/products/map/supabase/functions/_shared/activity/transform/getdx.js
+++ b/products/map/supabase/functions/_shared/activity/transform/getdx.js
@@ -49,10 +49,37 @@ export async function transformAllGetDX(supabase) {
     errors.push(...scoresResult.errors);
   }
 
+  // Transform snapshot comments
+  let commentCount = 0;
+  const commentsFiles = await listRaw(supabase, "getdx/snapshots-comments/");
+  for (const file of commentsFiles) {
+    const commentsResult = await transformSnapshotComments(
+      supabase,
+      `getdx/snapshots-comments/${file.name}`,
+    );
+    commentCount += commentsResult.comments;
+    errors.push(...commentsResult.errors);
+  }
+
+  // Transform initiatives from the most recent initiatives-list document
+  let initiativeCount = 0;
+  const initiativesFiles = await listRaw(supabase, "getdx/initiatives-list/");
+  if (initiativesFiles.length > 0) {
+    const latestInitiatives = `getdx/initiatives-list/${initiativesFiles[0].name}`;
+    const initiativesResult = await transformInitiatives(
+      supabase,
+      latestInitiatives,
+    );
+    initiativeCount = initiativesResult.initiatives;
+    errors.push(...initiativesResult.errors);
+  }
+
   return {
     teams: teamCount,
     snapshots: snapshotCount,
     scores: scoreCount,
+    comments: commentCount,
+    initiatives: initiativeCount,
     errors,
   };
 }
@@ -176,4 +203,144 @@ async function transformSnapshotScores(supabase, path) {
   }
 
   return { scores: scoreRows.length, errors };
+}
+
+/**
+ * Transform a stored snapshots-comments document into getdx_snapshot_comments rows.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} path - Storage path
+ * @returns {Promise<{comments: number, errors: Array<string>}>}
+ */
+async function transformSnapshotComments(supabase, path) {
+  const raw = JSON.parse(await readRaw(supabase, path));
+  const comments = raw.comments || [];
+  const errors = [];
+
+  // Derive snapshot_id from the path (filename is {snapshot_id}.json)
+  const snapshotId = path.split("/").pop().replace(".json", "");
+
+  // Build email → team lookup
+  const { data: people } = await supabase
+    .from("organization_people")
+    .select("email, manager_email");
+  const managerByEmail = new Map(
+    (people || []).map((p) => [p.email, p.manager_email]),
+  );
+
+  const { data: teams } = await supabase
+    .from("getdx_teams")
+    .select("getdx_team_id, manager_email");
+  const teamByManager = new Map(
+    (teams || []).map((t) => [t.manager_email, t.getdx_team_id]),
+  );
+
+  const rows = comments.map((comment) => {
+    const email = comment.email || null;
+    const commentId =
+      comment.id ||
+      `${snapshotId}::${email ?? "anon"}::${comment.timestamp ?? Date.now()}`;
+
+    // Derive team_id from email → manager → team
+    let teamId = null;
+    if (email) {
+      const managerEmail = managerByEmail.get(email);
+      if (managerEmail) {
+        teamId = teamByManager.get(managerEmail) || null;
+      }
+    }
+
+    return {
+      comment_id: commentId,
+      snapshot_id: snapshotId,
+      email,
+      team_id: teamId,
+      text: comment.text || "",
+      timestamp: comment.timestamp || new Date().toISOString(),
+      raw: comment,
+    };
+  });
+
+  if (rows.length > 0) {
+    const { error } = await supabase
+      .from("getdx_snapshot_comments")
+      .upsert(rows, { onConflict: "comment_id" });
+
+    if (error) {
+      errors.push(`Comments for ${snapshotId}: ${error.message}`);
+      return { comments: 0, errors };
+    }
+  }
+
+  return { comments: rows.length, errors };
+}
+
+/**
+ * Transform a stored initiatives-list document into getdx_initiatives rows.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} path - Storage path
+ * @returns {Promise<{initiatives: number, errors: Array<string>}>}
+ */
+async function transformInitiatives(supabase, path) {
+  const raw = JSON.parse(await readRaw(supabase, path));
+  const initiatives = raw.initiatives || [];
+  const errors = [];
+
+  const rows = initiatives.map(buildInitiativeRow);
+
+  if (rows.length > 0) {
+    // Use raw upsert — Supabase JS doesn't support COALESCE in upsert,
+    // so we preserve completed_at by checking client-side.
+    for (const row of rows) {
+      const { data: existing } = await supabase
+        .from("getdx_initiatives")
+        .select("completed_at")
+        .eq("id", row.id)
+        .maybeSingle();
+
+      // Preserve earliest completed_at
+      if (existing?.completed_at) {
+        row.completed_at = existing.completed_at;
+      }
+
+      const { error } = await supabase
+        .from("getdx_initiatives")
+        .upsert(row, { onConflict: "id" });
+
+      if (error) {
+        errors.push(`Initiative ${row.id}: ${error.message}`);
+      }
+    }
+  }
+
+  return { initiatives: rows.length - errors.length, errors };
+}
+
+/** Derive completed_at from raw initiative data. */
+function deriveCompletedAt(init) {
+  if (init.completed_at) return init.completed_at;
+  const allPassed =
+    init.passed_checks != null &&
+    init.total_checks != null &&
+    init.passed_checks === init.total_checks &&
+    init.total_checks > 0;
+  return allPassed ? new Date().toISOString() : null;
+}
+
+/** Build a database row from a raw GetDX initiative object. */
+function buildInitiativeRow(init) {
+  return {
+    id: init.id,
+    name: init.name || "(unnamed)",
+    description: init.description || null,
+    scorecard_id: init.scorecard_id || null,
+    owner_email: init.owner_email || null,
+    due_date: init.due_date || null,
+    priority: init.priority || null,
+    passed_checks: init.passed_checks ?? null,
+    total_checks: init.total_checks ?? null,
+    completion_pct: init.completion_pct ?? null,
+    tags: init.tags || null,
+    completed_at: deriveCompletedAt(init),
+    raw: init,
+  };
 }

--- a/products/map/supabase/migrations/20250101000003_getdx_snapshot_comments.sql
+++ b/products/map/supabase/migrations/20250101000003_getdx_snapshot_comments.sql
@@ -1,0 +1,20 @@
+-- GetDX Snapshot Comments
+-- Stores individual comments from GetDX snapshot responses.
+
+create table if not exists activity.getdx_snapshot_comments (
+  comment_id text primary key,
+  snapshot_id text not null references activity.getdx_snapshots(snapshot_id) on delete cascade,
+  email text references activity.organization_people(email) on delete set null,
+  team_id text references activity.getdx_teams(getdx_team_id) on delete set null,
+  text text not null,
+  timestamp timestamptz not null,
+  raw jsonb,
+  inserted_at timestamptz not null default now()
+);
+
+create index if not exists idx_getdx_snapshot_comments_snapshot
+  on activity.getdx_snapshot_comments(snapshot_id);
+create index if not exists idx_getdx_snapshot_comments_email
+  on activity.getdx_snapshot_comments(email);
+create index if not exists idx_getdx_snapshot_comments_team
+  on activity.getdx_snapshot_comments(team_id);

--- a/products/map/supabase/migrations/20250101000004_getdx_initiatives.sql
+++ b/products/map/supabase/migrations/20250101000004_getdx_initiatives.sql
@@ -1,0 +1,26 @@
+-- GetDX Initiatives
+-- Stores initiative data from the GetDX Initiatives API.
+
+create table if not exists activity.getdx_initiatives (
+  id text primary key,
+  name text not null,
+  description text,
+  scorecard_id text,
+  owner_email text references activity.organization_people(email) on delete set null,
+  due_date date,
+  priority text,
+  passed_checks integer,
+  total_checks integer,
+  completion_pct numeric,
+  tags jsonb,
+  completed_at timestamptz,
+  raw jsonb,
+  inserted_at timestamptz not null default now()
+);
+
+create index if not exists idx_getdx_initiatives_owner
+  on activity.getdx_initiatives(owner_email);
+create index if not exists idx_getdx_initiatives_completed_at
+  on activity.getdx_initiatives(completed_at);
+create index if not exists idx_getdx_initiatives_scorecard
+  on activity.getdx_initiatives(scorecard_id);

--- a/website/docs/guides/landmark-quickstart/index.md
+++ b/website/docs/guides/landmark-quickstart/index.md
@@ -1,0 +1,109 @@
+---
+title: Landmark Quickstart
+description: Get from zero to a useful health view in minutes.
+---
+
+# Landmark Quickstart
+
+This guide walks you from a fresh install to a working `fit-landmark health`
+view. By the end you will see driver scores, skill evidence counts, and
+(optionally) growth recommendations for a manager-scoped team.
+
+## Prerequisites
+
+- Node.js 18+
+- A Supabase project (or `fit-map activity start` for local development)
+- A GetDX account with API access
+
+## 1. Install
+
+```sh
+npm install -g @forwardimpact/landmark @forwardimpact/map
+npx fit-codegen --all
+```
+
+## 2. Migrate the activity schema
+
+```sh
+npx fit-map activity migrate
+```
+
+This creates the `activity` schema tables Landmark reads from:
+`organization_people`, `getdx_snapshots`, `github_artifacts`, `evidence`, and
+more.
+
+## 3. Configure GetDX credentials
+
+Export the environment variables Map needs to reach your Supabase instance:
+
+```sh
+export MAP_SUPABASE_URL="https://your-project.supabase.co"
+export MAP_SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+```
+
+## 4. Load your roster and sync GetDX data
+
+```sh
+npx fit-map people push roster.csv
+npx fit-map getdx sync
+npx fit-map activity transform
+```
+
+This populates `organization_people`, `getdx_snapshots`, and
+`getdx_snapshot_team_scores`.
+
+## 5. Author drivers and markers
+
+Landmark's `health`, `readiness`, and `evidence` views require framework data
+with **drivers** and **markers** defined. The starter data ships minimal
+examples — you should author your own.
+
+**Drivers** in `drivers.yaml` link GetDX scorecard items to contributing skills:
+
+```yaml
+- id: quality
+  name: Quality
+  contributingSkills:
+    - task_completion
+    - planning
+```
+
+**Markers** in capability YAML files define observable indicators per skill and
+proficiency level:
+
+```yaml
+skills:
+  - id: task_completion
+    markers:
+      working:
+        human:
+          - Delivered a feature end-to-end with no revision to the initial design
+        agent:
+          - Completed a multi-file change that passes CI without human rework
+```
+
+See the [Authoring Frameworks guide](/docs/guides/authoring-frameworks/) for
+vocabulary standards and validation.
+
+Run `npx fit-map validate` to confirm your framework data passes schema
+validation.
+
+## 6. Run Landmark
+
+```sh
+npx fit-landmark health --manager alice@example.com
+```
+
+You should see driver scores, contributing skill evidence counts, and (if Summit
+is installed) inline growth recommendations.
+
+## Next steps
+
+- `npx fit-landmark readiness --email engineer@example.com` — promotion
+  readiness checklist
+- `npx fit-landmark voice --manager alice@example.com` — engineer voice from
+  GetDX comments (requires the `getdx_snapshot_comments` table)
+- `npx fit-landmark initiative impact` — initiative outcome correlation
+  (requires the `getdx_initiatives` table)
+
+See the [Landmark overview](/landmark/) for the full command reference.

--- a/website/docs/internals/landmark/index.md
+++ b/website/docs/internals/landmark/index.md
@@ -1,0 +1,105 @@
+---
+title: Landmark Internals
+description: Architecture and implementation details for the Landmark analysis product.
+---
+
+# Landmark Internals
+
+Landmark (`@forwardimpact/landmark`) is a read-only CLI analysis layer over
+Map's activity schema. It mirrors Summit's package layout and CLI conventions.
+
+## Package Layout
+
+```
+products/landmark/
+  bin/fit-landmark.js     CLI entry point
+  src/
+    index.js              Public API re-exports
+    lib/                  Shared helpers
+      cli.js              resolveDataDir, loadMapData, resolveFormat
+      supabase.js         createLandmarkClient factory
+      context.js          buildContext for command handlers
+      empty-state.js      Central registry of empty-state messages
+      evidence-helpers.js Shared evidence join/grouping logic
+      initiative-helpers.js Initiative impact computation (pure)
+      summit.js           Dynamic import wrapper for Summit's growth function
+    commands/             One file per top-level command
+    formatters/           One file per command (toText, toJson, toMarkdown)
+  test/                   node:test with stub queries, no network
+```
+
+## Data Contracts
+
+Landmark consumes Map's activity queries via subpath imports:
+
+| Import                                            | Query functions                                                               |
+| ------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `@forwardimpact/map/activity/queries/org`         | `getOrganization`, `getTeam`, `getPerson`                                     |
+| `@forwardimpact/map/activity/queries/snapshots`   | `listSnapshots`, `getSnapshotScores`, `getItemTrend`, `getSnapshotComparison` |
+| `@forwardimpact/map/activity/queries/evidence`    | `getEvidence`, `getPracticePatterns`                                          |
+| `@forwardimpact/map/activity/queries/artifacts`   | `getArtifacts`, `getUnscoredArtifacts`                                        |
+| `@forwardimpact/map/activity/queries/comments`    | `getSnapshotComments`                                                         |
+| `@forwardimpact/map/activity/queries/initiatives` | `listInitiatives`, `getInitiative`                                            |
+
+Framework data is loaded via `@forwardimpact/map/loader` (`createDataLoader`).
+
+## Join Contracts
+
+### `item_id ↔ driver.id`
+
+The `getdx_snapshot_team_scores.item_id` field must match a `driver.id` in
+`drivers.yaml`. Unknown items produce warnings in the health view. Installations
+must align their GetDX scorecard item IDs with driver definitions.
+
+### `scorecard_id ↔ driver.id`
+
+Initiatives link to drivers via `getdx_initiatives.scorecard_id`. The impact
+command uses this to compute before/after score deltas.
+
+## Summit Import Pattern
+
+`src/lib/summit.js` wraps `@forwardimpact/summit`'s `computeGrowthAlignment` via
+dynamic `import()`. This provides:
+
+- **Optional runtime**: if Summit is absent, health degrades to driver scores +
+  evidence + comments without growth recommendations.
+- **Test injection**: `__setSummitForTests()` allows unit tests to stub Summit
+  without touching `node_modules`.
+- **`GrowthContractError` handling**: framework data violations become health
+  view warnings, not crashes.
+
+## Comments and Initiatives Pipeline
+
+Both follow the same ELT pattern:
+
+1. **Extract** —
+   `products/map/supabase/functions/_shared/activity/extract/getdx.js` fetches
+   from GetDX API and stores raw JSON to Supabase Storage.
+2. **Transform** — `.../transform/getdx.js` reads raw documents and upserts
+   structured rows into the activity schema.
+3. **Query** — `products/map/src/activity/queries/{comments,initiatives}.js`
+   export thin SELECT wrappers.
+4. **Landmark** — commands import query modules and present the data.
+
+## Testing Strategy
+
+All command tests use injectable `queries` parameters to avoid network calls.
+Fixtures are in-memory objects. The pattern:
+
+```js
+const result = await runHealthCommand({
+  options: { manager: "alice@example.com" },
+  mapData: MAP_DATA_FIXTURE,
+  supabase: {},
+  format: "text",
+  queries: stubQueries(),     // injected stubs
+  summitFn: summitPresent,    // injected Summit stub
+});
+```
+
+## Behaviour Rendering — Non-Goal
+
+Drivers declare `contributingBehaviours`, but Landmark does not render behaviour
+evidence in the health view. Behaviours are maturity profiles (derived from
+discipline + level + track), not artifact-level markers. The spec's health view
+mock-up shows skills only.

--- a/website/landmark/index.md
+++ b/website/landmark/index.md
@@ -15,98 +15,107 @@ hero:
       secondary: true
 ---
 
-> Landmark turns shared data into clear analysis. It combines objective marker
-> evidence from GitHub artifacts with subjective outcomes from GetDX snapshots,
-> then presents team-level and individual views grounded in your framework.
-
-### What you get
-
-- Personal evidence views by skill marker and artifact context
-- Practice-pattern summaries across manager-derived team scopes
-- Snapshot trend and comparison views from GetDX quarterly results
-- Combined health views joining marker evidence and snapshot factors
-- Consistent filters by manager hierarchy, skill, and factor
+> Landmark answers one question: **what do the signals say about how engineering
+> is functioning — and what should we do about it?** It reads Map data, combines
+> objective marker evidence with GetDX snapshot outcomes, and presents analysis
+> grounded in your framework. No LLM calls — fully deterministic.
 
 ---
 
-### Who it's for
+### Audience Model
 
-**Engineers** reviewing their own evidence in context of role expectations.
-
-**Engineering leaders** tracking team patterns and DX trends using shared,
-manager-scoped views.
+| Audience                | Views                                                                | Privacy                                   |
+| ----------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
+| **Engineer** (own data) | `evidence`, `readiness`, `timeline`, `coverage`, `voice --email`     | Full individual detail                    |
+| **Manager** (1:1 tool)  | `health`, `readiness`, `timeline`, `practiced`, `voice --manager`    | Individual specificity for direct reports |
+| **Director** (planning) | `snapshot`, `coverage`, `practiced`, `initiative`, `voice --manager` | Aggregated team views                     |
 
 ---
 
-## Core Views
+## Commands
 
-### Personal Evidence
-
-An engineer reviews recent artifacts linked to specific skill markers.
-
-```
-$ fit-landmark evidence --skill system_design
-
-  Your evidence: System Design (working level)
-
-  PR #342 "Redesign authentication flow"
-    Design doc with component diagram in PR description. Approved by two
-    reviewers without structural rework.
-    → relates to: design doc accepted without senior rewrite
-
-  PR #342 review thread
-    Resolved caching vs. session debate. Posted trade-off comparison and
-    the team converged on session approach.
-    → relates to: led a discussion that resolved a design disagreement
-```
-
-### Practice Patterns
-
-Engineering leadership sees aggregate marker patterns across a manager-defined
-team scope.
-
-```
-  $ fit-landmark practice --skill system_design --manager platform_manager
-
-  System Design practice — Platform team (last quarter)
-
-  Strong evidence:
-    Design documents in PRs — most feature PRs include architecture sections
-    Review quality — review threads regularly discuss design rationale
-
-  Weak evidence:
-    Trade-off analysis — few PRs document multiple approaches considered
-    Consider: where does design exploration happen in the current workflow?
-```
-
-### Snapshot Trends
-
-Quarterly GetDX snapshots show how factors move over time and relative to org
-and benchmark comparisons.
+### Organization
 
 ```sh
-fit-landmark snapshot trend --item MTQ2 --manager platform_manager
-fit-landmark snapshot compare --snapshot MjUyNbaY --manager platform_manager
+npx fit-landmark org show                    # Full organization directory
+npx fit-landmark org team --manager <email>  # Hierarchy under a manager
 ```
+
+### Snapshots
+
+```sh
+npx fit-landmark snapshot list
+npx fit-landmark snapshot show --snapshot <id> [--manager <email>]
+npx fit-landmark snapshot trend --item <item_id> [--manager <email>]
+npx fit-landmark snapshot compare --snapshot <id> [--manager <email>]
+```
+
+### Evidence & Readiness
+
+```sh
+npx fit-landmark evidence [--skill <id>] [--email <email>]
+npx fit-landmark marker <skill> [--level <level>]
+npx fit-landmark readiness --email <email> [--target <level>]
+npx fit-landmark timeline --email <email> [--skill <id>]
+npx fit-landmark coverage --email <email>
+npx fit-landmark practiced --manager <email>
+```
+
+### Health
+
+```sh
+npx fit-landmark health [--manager <email>]
+```
+
+Shows driver scores, contributing skill evidence, engineer voice comments, and
+(when Summit is installed) inline growth recommendations.
+
+### Engineer Voice
+
+```sh
+npx fit-landmark voice --manager <email>   # Themed team comments
+npx fit-landmark voice --email <email>     # Individual comment timeline
+```
+
+### Initiatives
+
+```sh
+npx fit-landmark initiative list [--manager <email>]
+npx fit-landmark initiative show --id <id>
+npx fit-landmark initiative impact [--manager <email>]
+```
+
+All commands support `--format text|json|markdown`.
+
+---
+
+## Prerequisites
+
+- **GetDX account** with API access configured
+- **Map** with the activity schema migrated (`npx fit-map activity migrate`)
+- **Framework data** with drivers and markers authored in your capability YAML
 
 ---
 
 ## How It Works
 
-Landmark queries Map's central store:
+Landmark reads from Map's activity layer:
 
 1. `organization_people` for hierarchy and team slicing
 2. `github_artifacts` + `evidence` for objective marker analysis
 3. `getdx_snapshots` + `getdx_snapshot_team_scores` for quarterly outcomes
+4. `getdx_snapshot_comments` for engineer voice
+5. `getdx_initiatives` for initiative tracking
 
 ```
-  GetDX + GitHub → Map (ingest + store) → Landmark (analyze + present)
+GetDX + GitHub → Map (ingest + store) → Landmark (analyze + present)
+                                           ↑
+                                       Summit (growth recommendations)
 ```
+
+Health works without Summit — it shows driver scores, evidence, and comments.
+Growth recommendations appear when Summit is installed.
 
 ---
 
-### Stay Updated
-
-Landmark is currently in development. Product direction is specified in the
-Landmark and Map specs under `specs/080-landmark-product` and
-`specs/050-map-data-product`.
+See [Landmark Internals](/docs/internals/landmark/) for architecture details.


### PR DESCRIPTION
## Summary

- Implements the full Landmark product (`@forwardimpact/landmark`, CLI `fit-landmark`) across all 6 plan parts: package scaffold, 15 CLI commands, evidence-based views, health view with Summit growth recommendations, snapshot comments pipeline + voice command, initiatives pipeline + impact analysis, and documentation
- Adds marker definitions to starter `delivery.yaml` and `reliability.yaml` capabilities (awareness/foundational/working) and two new drivers (`reliability`, `cognitive_load`) to `drivers.yaml`
- Extends Map's GetDX extract/transform pipeline with `snapshots.comments.list` and `initiatives.list`, adds two new migrations (`getdx_snapshot_comments`, `getdx_initiatives`), and two new query modules (`comments.js`, `initiatives.js`)
- Ships website overview, internals page, quickstart guide, and published Claude skill

## Test plan

- [x] `bun test products/landmark/test` — 96 tests pass across 17 files
- [x] `bun test products/map/test` — 136 existing Map tests still green
- [x] `bun run lint` — clean (0 errors)
- [x] `bun run format` — clean
- [x] `bun run check:exports` — 220 targets across 49 packages resolve
- [x] `bunx fit-map validate --data products/map/starter` — passes with 3 skills, 3 drivers, 2 levels
- [ ] `bun run layout` — pre-existing failure from codegen `generated/` dirs, unrelated to this branch

https://claude.ai/code/session_017x9KxEHdbGohtAUJozEZeW