### PR TITLE
fix(gemba): widen gemba-implement trigger phrases

### DIFF
--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -18,10 +18,9 @@ changes methodically.
 
 - A spec and plan exist with STATUS `planned` (has passed review)
 - The user says "implement spec NNN", "implement the plan for spec NNN",
-  "execute the plan for NNN", "build spec NNN", or "start implementation of
-  NNN"
-- Resuming a partially completed implementation ("continue spec NNN",
-  "finish implementing NNN")
+  "execute the plan for NNN", "build spec NNN", or "start implementation of NNN"
+- Resuming a partially completed implementation ("continue spec NNN", "finish
+  implementing NNN")
 
 ## Checklists
 

--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -3,7 +3,9 @@ name: gemba-implement
 description: >
   Implement a spec by studying its spec.md and plan, then executing the plan
   step by step. Use when a spec and plan are approved and ready for
-  implementation.
+  implementation. Triggers: "implement spec NNN", "implement the plan for
+  spec NNN", "execute plan NNN", "build spec NNN", "start implementation of
+  NNN".
 ---
 
 # Implement Spec
@@ -15,8 +17,11 @@ changes methodically.
 ## When to Use
 
 - A spec and plan exist with STATUS `planned` (has passed review)
-- The user says "implement spec NNN" or "execute the plan for NNN"
-- Resuming a partially completed implementation
+- The user says "implement spec NNN", "implement the plan for spec NNN",
+  "execute the plan for NNN", "build spec NNN", or "start implementation of
+  NNN"
+- Resuming a partially completed implementation ("continue spec NNN",
+  "finish implementing NNN")
 
 ## Checklists
 


### PR DESCRIPTION
## Summary

- Adds explicit trigger phrases to the gemba-implement frontmatter `description` so the skill matches natural phrasings like "implement the plan for spec NNN"
- Expands the "When to Use" section with broader phrase variants and resume examples ("continue spec NNN", "finish implementing NNN")

## Test plan

- [ ] `bun run check` (format + lint pass)
- [ ] `bun run test` (2317 pass, 0 fail)
- [ ] Verify the skill now appears in the skill list with the updated description containing trigger phrases

https://claude.ai/code/session_01LFBaAoPxXQSsfbN5y1JAsv