### PR TITLE
docs(landmark): expand getting-started docs and add landmark-setup workflow

### DIFF
--- a/.github/workflows/landmark-setup.yml
+++ b/.github/workflows/landmark-setup.yml
@@ -1,0 +1,87 @@
+name: "Gemba: Landmark Setup"
+
+on:
+  workflow_dispatch: # Manual trigger for on-demand evaluation
+    inputs:
+      task-amend:
+        description: "Additional text appended to the task prompt for steering"
+        required: false
+        type: string
+
+concurrency:
+  group: landmark-setup
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - name: Generate LLM token
+        id: llm-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.LLM_APP_ID }}
+          private-key: ${{ secrets.LLM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.ci-app.outputs.token }}
+          submodules: true
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: Prepare agent workspace
+        id: agent-workspace
+        shell: bash
+        run: |
+          agent_dir=$(mktemp -d)
+
+          # Generate all synthetic data using cached prose — this produces
+          # data/pathway/ (framework) and data/activity/ (roster, raw documents
+          # including GetDX snapshots, GitHub webhooks, evidence, and comments).
+          bunx fit-universe
+
+          mkdir -p "$agent_dir/data"
+          cp -r data/pathway "$agent_dir/data/pathway"
+          cp -r data/activity "$agent_dir/data/activity"
+
+          # Install the Supabase CLI so the agent has it on PATH
+          # npm global install is blocked by supabase's postinstall script
+          bun install -g supabase
+
+          cp scenarios/landmark-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
+          echo "dir=$agent_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate Landmark Setup
+        uses: ./.github/actions/gemba-action
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LLM_TOKEN: ${{ steps.llm-app.outputs.token }}
+          LLM_BASE_URL: https://models.github.ai/orgs/forwardimpact
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          mode: "supervise"
+          task-file: scenarios/landmark-setup/task.md
+          supervisor-cwd: "."
+          agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
+          supervisor-profile: "product-manager"
+          model: "opus"
+          max-turns: "200"
+          allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,WebFetch,WebSearch"
+          supervisor-allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,Skill,TodoWrite"
+          task-amend: ${{ inputs.task-amend }}

--- a/scenarios/landmark-setup/agent/CLAUDE.md
+++ b/scenarios/landmark-setup/agent/CLAUDE.md
@@ -1,0 +1,5 @@
+You are a developer trying a product for the first time. Follow documentation as
+written — do not look for workarounds or alternative approaches unless the
+documented path fails. If something is unclear or doesn't work, note it and try
+to proceed. Provide all findings and honest notes about your experience in your
+output — do not write them to files.

--- a/scenarios/landmark-setup/task.md
+++ b/scenarios/landmark-setup/task.md
@@ -1,0 +1,37 @@
+Introduce yourself to the agent and give them the following task:
+
+Try the Forward Impact Landmark product for the first time. Start at
+www.forwardimpact.team, find the Landmark product page, and follow the
+instructions to install and set up fit-landmark.
+
+The workspace is already prepared: synthetic framework data (`data/pathway/`)
+and activity data (`data/activity/`) have been generated, and the Supabase CLI
+is installed globally.
+
+Exercise the product:
+
+1. Install the @forwardimpact/landmark and @forwardimpact/map packages from npm
+2. Start the local Supabase stack with `npx fit-map activity start`
+3. Seed the activity database with `npx fit-map activity seed`
+4. Run `npx fit-landmark org show` to see the organization directory
+5. Run `npx fit-landmark health --manager <email>` using a manager email from
+   the org output
+6. Run `npx fit-landmark snapshot list` to see available snapshots
+7. Run `npx fit-landmark evidence --email <email>` for an individual from the
+   org
+8. Run `npx fit-landmark readiness --email <email>` for the same individual
+9. Run `npx fit-landmark voice --manager <email>` to see engineer voice comments
+10. Summarize their experience in their final output, including:
+    - Whether the Supabase stack started and data seeded successfully
+    - How clear the setup instructions were
+    - Whether the commands worked as documented
+    - Whether the health, evidence, readiness, and voice views were
+      understandable
+    - Any errors or confusing moments
+
+The agent should not write findings to files — all findings should be in their
+output. They should work independently and install from npm as a user would, not
+clone the monorepo.
+
+Use the `product-evaluation` skill to supervise the session and capture
+feedback.

--- a/website/docs/getting-started/engineers/index.md
+++ b/website/docs/getting-started/engineers/index.md
@@ -193,19 +193,16 @@ expectations, and markers — not generic career advice.
 
 ## Landmark
 
-Landmark gives you visibility into your own practice evidence and growth data.
-It reads from Map's activity layer — the same database that stores GitHub
-artifact evidence and GetDX snapshots — to show what your engineering record
-looks like against your framework's markers.
-
 Landmark requires Map's activity layer (Supabase). If your organization has
 already set this up, Landmark works immediately. If not, see the
 [Landmark quickstart](/docs/guides/landmark-quickstart/) or the
 [leadership getting-started](/docs/getting-started/leadership/) for activity
-layer setup.
+layer setup. One command works without Supabase: `marker` reads directly from
+your framework YAML.
 
-One command works without Supabase: `marker` reads directly from your framework
-YAML.
+With the activity layer in place, Landmark gives you visibility into your own
+practice evidence and growth data — showing what your engineering record looks
+like against your framework's markers.
 
 ### Browse marker definitions
 

--- a/website/docs/getting-started/engineers/index.md
+++ b/website/docs/getting-started/engineers/index.md
@@ -1,11 +1,12 @@
 ---
 title: "Getting Started: Engineers"
-description: "Browse career paths with Pathway, get AI guidance with Guide, and set up your knowledge base with Basecamp."
+description: "Browse career paths with Pathway, get AI guidance with Guide, check your evidence with Landmark, and set up your knowledge base with Basecamp."
 ---
 
 Get up and running with the Forward Impact CLI tools. This guide covers browsing
 your career framework, generating AI agent teams, getting framework-aware
-guidance, and managing your personal knowledge base.
+guidance, checking your evidence and growth data, and managing your personal
+knowledge base.
 
 ## Prerequisites
 
@@ -15,13 +16,14 @@ guidance, and managing your personal knowledge base.
 ## Install
 
 ```sh
-npm install @forwardimpact/pathway @forwardimpact/guide @forwardimpact/basecamp
+npm install @forwardimpact/pathway @forwardimpact/guide @forwardimpact/landmark @forwardimpact/basecamp
 ```
 
-This gives you three CLI tools:
+This gives you four CLI tools:
 
 - `fit-pathway` — browse job definitions and generate agent teams
 - `fit-guide` — AI agent that understands your engineering framework
+- `fit-landmark` — check your evidence, readiness, and growth timeline
 - `fit-basecamp` — personal knowledge base with scheduled AI tasks
 
 ---
@@ -189,6 +191,94 @@ expectations, and markers — not generic career advice.
 
 ---
 
+## Landmark
+
+Landmark gives you visibility into your own practice evidence and growth data.
+It reads from Map's activity layer — the same database that stores GitHub
+artifact evidence and GetDX snapshots — to show what your engineering record
+looks like against your framework's markers.
+
+Landmark requires Map's activity layer (Supabase). If your organization has
+already set this up, Landmark works immediately. If not, see the
+[Landmark quickstart](/docs/guides/landmark-quickstart/) or the
+[leadership getting-started](/docs/getting-started/leadership/) for activity
+layer setup.
+
+One command works without Supabase: `marker` reads directly from your framework
+YAML.
+
+### Browse marker definitions
+
+Look up the observable indicators defined for any skill — useful for
+understanding what evidence is expected at each proficiency level:
+
+```sh
+npx fit-landmark marker task_completion
+npx fit-landmark marker task_completion --level working
+```
+
+### Check your evidence
+
+See which markers have evidence linked to your work:
+
+```sh
+npx fit-landmark evidence --email you@example.com
+npx fit-landmark evidence --skill system_design --email you@example.com
+```
+
+Each row shows the artifact, the marker it matched, and Guide's rationale.
+Filter by `--skill` to focus on a specific area.
+
+### View your skill coverage
+
+See how complete your evidence record is across all expected skills:
+
+```sh
+npx fit-landmark coverage --email you@example.com
+```
+
+Coverage shows evidenced artifacts versus total expected markers — a quick gauge
+of where your record is strong and where it has gaps.
+
+### Check promotion readiness
+
+See which next-level markers you have already evidenced and which are still
+outstanding:
+
+```sh
+npx fit-landmark readiness --email you@example.com
+npx fit-landmark readiness --email you@example.com --target J060
+```
+
+Without `--target`, readiness checks against the next level above your current
+level. With `--target`, you can check against any specific level — useful for
+planning a multi-level trajectory.
+
+### Track your growth timeline
+
+See how your evidence has accumulated over time, aggregated by quarter:
+
+```sh
+npx fit-landmark timeline --email you@example.com
+npx fit-landmark timeline --email you@example.com --skill system_design
+```
+
+Timelines help you see whether growth is accelerating, stalling, or concentrated
+in one area. Add `--skill` to focus on a specific capability.
+
+### Read your voice comments
+
+See your own GetDX snapshot comments in a timeline view alongside evidence
+context:
+
+```sh
+npx fit-landmark voice --email you@example.com
+```
+
+All Landmark commands support `--format text|json|markdown`.
+
+---
+
 ## Basecamp
 
 Basecamp is your personal operations center. It syncs email and calendar, builds
@@ -280,6 +370,8 @@ missing environment variables or port conflicts.
   agents
 - [Finding your bearing](/docs/guides/finding-your-bearing/) — Guide usage and
   configuration
+- [Landmark quickstart](/docs/guides/landmark-quickstart/) — step-by-step guide
+  from install to a working health view
 - [Knowledge systems](/docs/guides/knowledge-systems/) — deep dive into Basecamp
   features
 - [Career paths](/docs/guides/career-paths/) — understand progression and skill

--- a/website/docs/getting-started/leadership/index.md
+++ b/website/docs/getting-started/leadership/index.md
@@ -497,11 +497,14 @@ npx fit-pathway question software_engineering L3
 Landmark is the analysis layer for engineering-system signals. It reads Map's
 activity layer — organization roster, GitHub artifact evidence, GetDX snapshot
 outcomes, and engineer voice comments — to produce deterministic analysis views.
-No LLM calls.
+All computation runs locally with no LLM calls.
 
 Unlike Summit (which runs fully locally from a roster file), Landmark requires
 Map's activity layer (Supabase). If you set up the activity layer in the Map
-section above, Landmark is ready to go. To explore with synthetic data first:
+section above, Landmark is ready to go. To explore with synthetic data first
+(see
+[Trying the activity layer with synthetic data](#trying-the-activity-layer-with-synthetic-data)
+in the Map section):
 
 ```sh
 npx fit-map activity start
@@ -671,8 +674,14 @@ See how organizational initiatives correlate with driver score changes:
 
 ```sh
 npx fit-landmark initiative list --manager alice@example.com
-npx fit-landmark initiative show --id initiative-123
 npx fit-landmark initiative impact --manager alice@example.com
+```
+
+`initiative list` shows active initiatives with their IDs. To drill into a
+specific initiative, pass the ID from the list output:
+
+```sh
+npx fit-landmark initiative show --id <id>
 ```
 
 `initiative impact` joins initiative completion dates to snapshot score deltas,

--- a/website/docs/getting-started/leadership/index.md
+++ b/website/docs/getting-started/leadership/index.md
@@ -494,37 +494,195 @@ npx fit-pathway question software_engineering L3
 
 ## Landmark
 
-Landmark is the analysis layer for engineering-system signals. It reads Map data
-to show practice patterns, snapshot trends, and combined health views for
-manager-defined teams.
+Landmark is the analysis layer for engineering-system signals. It reads Map's
+activity layer — organization roster, GitHub artifact evidence, GetDX snapshot
+outcomes, and engineer voice comments — to produce deterministic analysis views.
+No LLM calls.
+
+Unlike Summit (which runs fully locally from a roster file), Landmark requires
+Map's activity layer (Supabase). If you set up the activity layer in the Map
+section above, Landmark is ready to go. To explore with synthetic data first:
+
+```sh
+npx fit-map activity start
+npx fit-map activity seed
+```
+
+### View the organization
+
+See who is in the organization and how teams are structured:
+
+```sh
+npx fit-landmark org show
+npx fit-landmark org team --manager alice@example.com
+```
+
+`org show` prints the full organization directory — names, roles, and reporting
+lines. `org team` walks the hierarchy under a specific manager, which is the
+scope most other commands operate on.
+
+### Browse marker definitions
+
+Look up the observable indicators defined for any skill in your framework:
+
+```sh
+npx fit-landmark marker task_completion
+npx fit-landmark marker task_completion --level working
+```
+
+This is a reference view — it reads directly from your framework YAML and does
+not require Supabase. Use it to review what markers exist before checking
+evidence against them.
 
 ### View practice patterns
 
-See aggregate marker patterns across a team scope:
+See aggregate marker evidence across a team scope:
 
 ```sh
-npx fit-landmark practice --skill system_design --manager platform_manager
+npx fit-landmark practice --manager alice@example.com
+npx fit-landmark practice --skill system_design --manager alice@example.com
 ```
 
-This shows where your team has strong evidence of skill practice and where
-evidence is weak — helping you identify coaching opportunities.
+Practice patterns show where your team has strong evidence of skill practice and
+where evidence is thin — helping you identify coaching opportunities before they
+become gaps.
+
+### Browse evidence
+
+Drill into the evidence rows linked to framework markers:
+
+```sh
+npx fit-landmark evidence --email bob@example.com
+npx fit-landmark evidence --skill system_design --email bob@example.com
+```
+
+Each row shows the artifact, the marker it was matched to, the skill and
+proficiency level, and Guide's rationale for the match. Filter by `--skill` to
+focus on a specific area or omit it to see everything.
 
 ### Track snapshot trends
 
-Compare GetDX snapshot scores over time:
+GetDX snapshots capture quarterly survey results. Landmark reads them from the
+activity layer:
 
 ```sh
-npx fit-landmark snapshot trend --item MTQ2 --manager platform_manager
-npx fit-landmark snapshot compare --snapshot MjUyNbaY --manager platform_manager
+npx fit-landmark snapshot list
+npx fit-landmark snapshot show --snapshot MjUyNbaY
+npx fit-landmark snapshot show --snapshot MjUyNbaY --manager alice@example.com
 ```
+
+`snapshot list` shows available snapshots. `snapshot show` displays factor and
+driver scores — add `--manager` to scope to a single team.
+
+Track a specific driver or factor over time:
+
+```sh
+npx fit-landmark snapshot trend --item MTQ2 --manager alice@example.com
+```
+
+Compare a snapshot against organizational benchmarks:
+
+```sh
+npx fit-landmark snapshot compare --snapshot MjUyNbaY --manager alice@example.com
+```
+
+### Check promotion readiness
+
+See which next-level markers an engineer has already evidenced and which are
+still outstanding — a checklist for promotion conversations:
+
+```sh
+npx fit-landmark readiness --email bob@example.com
+npx fit-landmark readiness --email bob@example.com --target J060
+```
+
+Without `--target`, readiness uses the next level above the engineer's current
+level. With `--target`, you can check against any specific level.
+
+### View individual timelines
+
+Track how an engineer's evidence has accumulated over time, aggregated by
+quarter:
+
+```sh
+npx fit-landmark timeline --email bob@example.com
+npx fit-landmark timeline --email bob@example.com --skill system_design
+```
+
+Timelines help you see whether growth is accelerating, stalling, or concentrated
+in one area. Add `--skill` to focus on a specific capability.
+
+### View evidence coverage
+
+See how complete an individual's evidence coverage is across their expected
+skills:
+
+```sh
+npx fit-landmark coverage --email bob@example.com
+```
+
+Coverage shows evidenced artifacts versus total expected markers — a quick gauge
+of how well the evidence record reflects what the engineer actually does.
+
+### Compare evidenced vs derived capability
+
+See where real practice diverges from what the framework predicts:
+
+```sh
+npx fit-landmark practiced --manager alice@example.com
+```
+
+This compares the capability the team should have (based on their job profiles)
+against what marker evidence actually shows. Skills with high derived capability
+but low evidence may indicate either a data gap or a coaching opportunity.
 
 ### View team health
 
-Combine marker evidence and snapshot factors into a single health view:
+The health view is Landmark's centerpiece — it joins driver scores, contributing
+skill evidence, engineer voice comments, and (when Summit is installed) growth
+recommendations into a single picture:
 
 ```sh
-npx fit-landmark health --manager platform_manager
+npx fit-landmark health --manager alice@example.com
 ```
+
+For each driver Landmark shows the GetDX score with percentile comparisons, the
+skills that contribute to that driver, the evidence count for each skill, any
+engineer comments related to the driver, and growth recommendations from Summit.
+
+### Surface engineer voice
+
+Landmark surfaces GetDX snapshot comments so you can hear what engineers are
+saying:
+
+```sh
+npx fit-landmark voice --manager alice@example.com
+npx fit-landmark voice --email bob@example.com
+```
+
+In manager mode, comments are bucketed by theme (estimation, incident, planning,
+etc.) and aligned to low-scoring drivers — showing where engineer sentiment
+matches the data. In individual mode, comments appear as a timeline alongside
+evidence context.
+
+### Track initiatives
+
+See how organizational initiatives correlate with driver score changes:
+
+```sh
+npx fit-landmark initiative list --manager alice@example.com
+npx fit-landmark initiative show --id initiative-123
+npx fit-landmark initiative impact --manager alice@example.com
+```
+
+`initiative impact` joins initiative completion dates to snapshot score deltas,
+showing whether a completed initiative moved the needle on its target drivers.
+
+### Output formats
+
+All Landmark commands support `--format text|json|markdown`. The default is
+`text` (formatted for the terminal). Use `json` for programmatic consumption or
+`markdown` for sharing in documents and pull requests.
 
 ---
 
@@ -762,6 +920,8 @@ npx fit-summit coverage platform --roster ./summit.yaml --audience director
 - [Authoring frameworks](/docs/guides/authoring-frameworks/) — full guide to
   defining all entity types: levels, disciplines, tracks, capabilities, skills,
   behaviours, stages, and drivers
+- [Landmark quickstart](/docs/guides/landmark-quickstart/) — step-by-step guide
+  from install to a working health view
 - [Team capability](/docs/guides/team-capability/) — deep dive into Summit
   coverage, risks, and scenario planning
 - [YAML schema reference](/docs/reference/yaml-schema/) — complete file format

--- a/website/docs/guides/index.md
+++ b/website/docs/guides/index.md
@@ -43,6 +43,15 @@ knowledge base structure.
 
 </a>
 
+<a href="/docs/guides/landmark-quickstart/">
+
+### Landmark Quickstart
+
+Get from zero to a useful health view in minutes — install Landmark, migrate the
+activity schema, and run your first health analysis.
+
+</a>
+
 <a href="/docs/guides/team-capability/">
 
 ### Team Capability


### PR DESCRIPTION
## Summary

- Link the orphaned landmark-quickstart guide in the guides index grid
- Expand the Landmark section in leadership getting-started from ~30 lines to ~200 lines covering all commands with examples
- Add a new Landmark section to engineers getting-started for engineer-audience views (evidence, readiness, timeline, coverage, voice, marker)
- Create `landmark-setup.yml` Gemba evaluation workflow following the map-setup pattern (Supabase workspace + synthetic data)
- Create scenario files (`scenarios/landmark-setup/task.md` + `agent/CLAUDE.md`)

## Test plan

- [x] `bun run check` — pre-existing layout drift only (generated dirs from codegen bootstrap, same on main)
- [x] `bun run test` — 2317 pass, 0 fail
- [x] `prettier --check` passes on all modified files
- [x] All internal doc links reference existing pages
- [x] CLI command names verified against `products/landmark/bin/fit-landmark.js`