### PR TITLE
fix(gemba): improve instruction layering across all Gemba skills

### DIFF
--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -28,7 +28,7 @@ Warm, encouraging, organized. Appreciate every contribution. Sign off:
 
 ## Workflows
 
-Determine which workflow to use from the task prompt:
+Run each applicable workflow based on the task prompt:
 
 1. **PR triage** — Follow the `gemba-product-classify` skill to classify open
    PRs and merge those that pass all gates. For `spec` PRs, also apply the

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -44,16 +44,8 @@ Determine which workflow to use from the task prompt:
 - Planning and implementation only — never write specs (security-engineer,
   product-manager, and improvement-coach scope) and never cut releases
   (release-engineer scope)
-- One plan per spec — never bundle multiple specs into a single plan
-- Decompose into steps you (or another trusted agent) can execute mechanically —
-  if a step requires judgement or ambiguous decisions, flag it in the plan as a
-  risk
-- Never advance a spec from `draft` to `planned` without a finished plan
-- When implementing, follow the plan — do not refactor adjacent code, add
-  features the spec didn't request, or "clean up" files you happen to touch.
-  Scope discipline prevents scope creep.
-- When the plan and current codebase have diverged, adapt to the codebase and
-  note the deviation in the commit message — do not blindly replay a stale plan
+- Scope discipline: follow the plan, do not refactor adjacent code or add
+  unrequested features — the skills' checklists verify this at each step
 - Run `bun run check` and `bun run test` before committing
 - **Memory**: Before starting work, read `wiki/staff-engineer.md` and the other
   agent summaries for cross-agent context. Append this run as a new

--- a/.claude/skills/gemba-documentation/SKILL.md
+++ b/.claude/skills/gemba-documentation/SKILL.md
@@ -48,7 +48,7 @@ modes of operation:
 
 </do_confirm_checklist>
 
-## 1. Scheduled Review
+## Scheduled Review
 
 Each run covers **one topic** in depth.
 
@@ -96,7 +96,7 @@ teammates' summaries). Find last review dates per topic in the coverage map.
 
 Run the DO-CONFIRM checklist at the top of this skill.
 
-## 2. Interactive Writing
+## Interactive Writing
 
 ### Writing a new page
 

--- a/.claude/skills/gemba-documentation/SKILL.md
+++ b/.claude/skills/gemba-documentation/SKILL.md
@@ -16,6 +16,12 @@ modes of operation:
 - **Scheduled review** — Pick one topic, go deep, verify against source code.
 - **Interactive writing** — Write or update pages following the standards.
 
+## When to Use
+
+- Scheduled documentation review (one topic per run)
+- Writing or updating pages in `website/`
+- Auditing documentation accuracy against source code
+
 ## Checklists
 
 <read_do_checklist goal="Load documentation standards before starting">
@@ -59,14 +65,17 @@ Each run covers **one topic** in depth.
 | `llms-txt-and-seo`       | `website/llms.txt`, `website/robots.txt`, sitemap completeness        |
 | `cross-page-consistency` | Terminology, proficiency scales, field names across all pages         |
 
+### Step 0: Read Memory
+
+Read memory per the agent profile (your summary, the current week's log, and
+teammates' summaries). Find last review dates per topic in the coverage map.
+
 ### Topic selection
 
-1. Read memory per the agent profile (your summary, the current week's log, and
-   teammates' summaries). Find last review dates per topic in the coverage map.
-2. Build coverage map — never-reviewed topics go first, then oldest.
-3. Revisit threshold — if all topics covered within last 6 runs, revisit oldest.
-4. Announce your pick and why before starting.
-5. Go deep — read every page in the topic area, not just spot-check.
+1. Build coverage map — never-reviewed topics go first, then oldest.
+2. Revisit threshold — if all topics covered within last 6 runs, revisit oldest.
+3. Announce your pick and why before starting.
+4. Go deep — read every page in the topic area, not just spot-check.
 
 ### Review process
 
@@ -117,7 +126,7 @@ Run the DO-CONFIRM checklist at the top of this skill.
 5. Check cross-links resolve.
 6. Build and check.
 
-## 3. Output
+## Output
 
 Every review must produce both categories when applicable — incremental fixes on
 a `fix/` branch and specs for structural findings on `spec/` branches. Branch
@@ -139,7 +148,7 @@ Each branch gets its own PR. Fix and spec branches are independent — push and 
 each one separately. Wiki submodule changes follow the wiki curation skill's
 publishing instructions.
 
-### Memory: what to record
+## Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.claude/skills/gemba-gh-cli/SKILL.md
+++ b/.claude/skills/gemba-gh-cli/SKILL.md
@@ -9,7 +9,7 @@ Canonical `gh` usage for Gemba agents. By the time a skill invokes `gh`, the
 workflow has already provisioned `GH_TOKEN` — the agent's concern is using `gh`
 consistently, not authenticating it.
 
-## When to use
+## When to Use
 
 - You are a Gemba skill running inside a scheduled GitHub Actions workflow and
   need to read from or write to GitHub.

--- a/.claude/skills/gemba-implement/SKILL.md
+++ b/.claude/skills/gemba-implement/SKILL.md
@@ -154,26 +154,13 @@ After all tasks are complete, run the DO-CONFIRM checklist above.
 
 ### 8. Clean sub-agent review
 
-Before pushing, launch a fresh sub-agent (via the `Agent` tool, no prior
-conversation context) and instruct it to load the
-[`gemba-review`](../gemba-review/SKILL.md) skill and grade the full diff
-(`git diff origin/main...HEAD`). Give the reviewer enough context to act
-independently — spec path, plan path, branch name.
-
-`gemba-review` owns the severity vocabulary and the implementation-diff
-criteria; it never spawns sub-agents, so the review loop bottoms out
-structurally — see
-[GEMBA.md § Recursion-safe self-review](../../../GEMBA.md#recursion-safe-self-review).
-Tell the reviewer explicitly **not** to invoke `gemba-implement` itself —
-defense in depth on top of the structural fix.
-
-**Verify** every finding against the actual artifact before acting on it —
-sub-agent reviewers lack prior conversation context and can misread intent or
-flag false positives. After verification, address every confirmed **blocker**,
-**high**, and **medium** finding before pushing. **Low** findings are optional.
-If the reviewer raises blockers you disagree with, resolve the disagreement
-explicitly (fix the code, or record the rationale for dismissal in the commit
-message) — silent dismissal is not allowed.
+Follow the
+[`gemba-review` caller protocol](../gemba-review/references/caller-protocol.md)
+to launch a fresh sub-agent that grades the full diff
+(`git diff origin/main...HEAD`). Provide spec path, plan path, and branch name
+so the reviewer can act independently. Tell the reviewer not to invoke
+`gemba-implement`. Verify findings, address all confirmed blocker/high/medium
+issues before pushing.
 
 Push all commits to the remote branch only after the review is clean.
 

--- a/.claude/skills/gemba-plan/SKILL.md
+++ b/.claude/skills/gemba-plan/SKILL.md
@@ -190,22 +190,11 @@ from prior `staff-engineer` entries.
    concrete steps. Each step should be independently verifiable. Surface risks
    explicitly. If the plan is large, decompose it into parts (see § Large plan
    decomposition).
-5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
-   (via the `Agent` tool, no prior conversation context) and instruct it to load
-   the [`gemba-review`](../gemba-review/SKILL.md) skill and grade `plan-a.md`
-   (and any `plan-a-NN.md` parts). `gemba-review` owns the severity vocabulary
-   and the plan criteria; it never spawns sub-agents, so the review loop bottoms
-   out structurally — see
-   [GEMBA.md § Recursion-safe self-review](../../../GEMBA.md#recursion-safe-self-review).
-   Tell the reviewer explicitly **not** to invoke `gemba-plan` itself — defense
-   in depth on top of the structural fix. **Verify** every finding against the
-   actual artifact before acting on it — sub-agent reviewers lack prior
-   conversation context and can misread intent or flag false positives. After
-   verification, address every confirmed **blocker**, **high**, and **medium**
-   finding before moving on. **Low** findings are optional. If the reviewer
-   raises blockers you disagree with, resolve the disagreement explicitly
-   (revise, or record the rationale for dismissal) — silent dismissal is not
-   allowed.
+5. **Clean sub-agent review.** Follow the
+   [`gemba-review` caller protocol](../gemba-review/references/caller-protocol.md)
+   to launch a fresh sub-agent that grades `plan-a.md` (and any `plan-a-NN.md`
+   parts). Tell the reviewer not to invoke `gemba-plan`. Verify findings,
+   address all confirmed blocker/high/medium issues before advancing.
 6. **Present the plan.** Share it for feedback.
 7. **Update STATUS.** When both spec and plan are approved, advance the spec's
    status from `review` to `planned`. Do not advance while the plan is still

--- a/.claude/skills/gemba-product-classify/SKILL.md
+++ b/.claude/skills/gemba-product-classify/SKILL.md
@@ -33,22 +33,20 @@ trust lookup, which the `gemba-walk` invariant audit verifies against.
 
 All comment templates and the report format are in `references/templates.md`.
 
-## Gate Checklist
+## Checklists
 
 <do_confirm_checklist goal="Verify all gates pass before merging a PR">
 
-- [ ] **Author is trusted** — CI app or top-7 lookup (Step 2). On failure, mark
-      **blocked** and comment that only trusted authors merge.
-- [ ] **PR type is `fix`, `bug`, or `spec`** — parse title prefix (Step 3). On
-      failure, mark **blocked** and comment that the PR type is outside scope.
-- [ ] **All CI checks pass** — `gh pr checks` (Step 4). On failure, mark
-      **blocked** and comment with the failing checks.
-- [ ] **Spec quality approved** (spec PRs only) — apply `gemba-spec` review
-      (Step 5). On failure, mark **blocked** and comment with review findings.
+- [ ] Author is trusted — CI app identity or top-7 contributor lookup ran.
+- [ ] PR type is `fix`, `bug`, or `spec` — parsed from title prefix.
+- [ ] All CI checks pass.
+- [ ] Spec quality approved (spec PRs only) via `gemba-spec` review.
 
 </do_confirm_checklist>
 
-A PR that passes all four gates is merged in Step 7.
+A PR that fails any gate is marked **blocked** with the reason (see Steps 2–5
+for failure-handling details). A PR that passes all four gates is merged in
+Step 7.
 
 ## Process
 

--- a/.claude/skills/gemba-release-readiness/SKILL.md
+++ b/.claude/skills/gemba-release-readiness/SKILL.md
@@ -18,8 +18,7 @@ branches, fix mechanical CI failures, and report status on each PR.
 
 ## Checklists
 
-<do_confirm_checklist goal="Confirm readiness pass is complete before
-reporting">
+<do_confirm_checklist goal="Confirm readiness pass is complete">
 
 - [ ] Every open PR assessed — none skipped except Dependabot.
 - [ ] Behind and stale PRs rebased on `origin/main`.

--- a/.claude/skills/gemba-release-readiness/SKILL.md
+++ b/.claude/skills/gemba-release-readiness/SKILL.md
@@ -16,6 +16,19 @@ branches, fix mechanical CI failures, and report status on each PR.
 - Scheduled daily to keep PRs up-to-date with `main`
 - Before a release review to ensure PRs can be merged cleanly
 
+## Checklists
+
+<do_confirm_checklist goal="Confirm readiness pass is complete before
+reporting">
+
+- [ ] Every open PR assessed — none skipped except Dependabot.
+- [ ] Behind and stale PRs rebased on `origin/main`.
+- [ ] Trivial CI failures fixed with `bun run check:fix` — not code changes.
+- [ ] Substantive conflicts aborted and commented for the author.
+- [ ] PR status table produced with consecutive-stuck counts.
+
+</do_confirm_checklist>
+
 ## Prerequisites
 
 See [`gemba-gh-cli`](../gemba-gh-cli/SKILL.md) for `gh` installation and the
@@ -120,7 +133,7 @@ Comment on each PR:
 
 **Flag PRs stuck across 3+ consecutive runs** — these need human attention.
 
-### Memory: what to record
+## Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.claude/skills/gemba-release-review/SKILL.md
+++ b/.claude/skills/gemba-release-review/SKILL.md
@@ -69,7 +69,7 @@ git add <fixed-files> && git commit -m "chore: fix formatting on main"
 git push origin main
 ```
 
-### Step 2: Tag Prefix Mapping
+### Tag Prefix Mapping
 
 | Directory          | Tag prefix | Example tag         |
 | ------------------ | ---------- | ------------------- |
@@ -83,7 +83,7 @@ git push origin main
 - **Post-1.0**: breaking (`!` suffix) → **major**; `feat` → **minor**; else →
   **patch**
 
-### Step 3: Enumerate Changed Packages
+### Step 2: Enumerate Changed Packages
 
 ```sh
 latest=$(git tag --sort=-creatordate --list "${prefix}@v*" | head -1)
@@ -96,12 +96,12 @@ fi
 
 Skip packages with no unreleased commits.
 
-### Step 4: Determine Version Bumps
+### Step 3: Determine Version Bumps
 
 Read current version from `package.json` and scan commit log since last tag.
 Apply version rules above.
 
-### Step 5: Bump, Sync, Verify
+### Step 4: Bump, Sync, Verify
 
 ```sh
 cd <package-directory>
@@ -121,7 +121,7 @@ bun install
 bun run check:fix && bun run check
 ```
 
-### Step 6: Commit and Tag
+### Step 5: Commit and Tag
 
 ```sh
 git add <package>/package.json package-lock.json
@@ -131,7 +131,7 @@ git tag <prefix>@v<version>
 
 For multiple packages: commit all bumps, then tag each.
 
-### Step 7: Push and Verify
+### Step 6: Push and Verify
 
 Push commit first, then each tag individually:
 
@@ -148,7 +148,7 @@ gh run list --limit 10 --json name,conclusion,headBranch,event
 
 If a publish fails, investigate with `gh run view <run-id> --log-failed`.
 
-### Step 8: Summary
+### Step 7: Summary
 
 ```
 | Package  | Previous | New    | Tag             | Publish |

--- a/.claude/skills/gemba-release-review/SKILL.md
+++ b/.claude/skills/gemba-release-review/SKILL.md
@@ -21,15 +21,7 @@ determine version bumps, and cut releases.
 See [`gemba-gh-cli`](../gemba-gh-cli/SKILL.md) for `gh` installation and the
 canonical query shapes used in the steps below.
 
-## Process
-
-### Step 0: Read Memory
-
-Read memory per the agent profile (your summary, the current week's log, and
-teammates' summaries). Extract previous release outcomes and any packages that
-had publish failures from prior `release-engineer` entries.
-
-## Pre-Flight: Verify Main Branch CI
+## Checklists
 
 <read_do_checklist goal="Confirm CI is green before cutting releases">
 
@@ -43,7 +35,27 @@ had publish failures from prior `release-engineer` entries.
 
 </read_do_checklist>
 
-Worked examples:
+<do_confirm_checklist goal="Verify releases were cut correctly before pushing">
+
+- [ ] Each changed package assessed for version bump type.
+- [ ] `bun run check` passes after all version bumps.
+- [ ] Each tag follows `{prefix}@v{version}` convention.
+- [ ] Tags pushed individually — never `git push --tags`.
+- [ ] Publish workflows verified as triggered for each tag.
+
+</do_confirm_checklist>
+
+## Process
+
+### Step 0: Read Memory
+
+Read memory per the agent profile (your summary, the current week's log, and
+teammates' summaries). Extract previous release outcomes and any packages that
+had publish failures from prior `release-engineer` entries.
+
+### Step 1: Pre-Flight — Verify Main Branch CI
+
+Run the READ-DO checklist above before proceeding. Worked examples:
 
 ```sh
 gh run list --branch main --limit 5 --json name,conclusion,headBranch
@@ -57,7 +69,7 @@ git add <fixed-files> && git commit -m "chore: fix formatting on main"
 git push origin main
 ```
 
-## Tag Prefix Mapping
+### Step 2: Tag Prefix Mapping
 
 | Directory          | Tag prefix | Example tag         |
 | ------------------ | ---------- | ------------------- |
@@ -65,15 +77,13 @@ git push origin main
 | `products/pathway` | `pathway`  | `pathway@v0.25.0`   |
 | `services/agent`   | `svcagent` | `svcagent@v0.1.110` |
 
-## Version Rules
+### Version Rules
 
 - **Pre-1.0** (`0.x.y`): bump **patch** for any change
 - **Post-1.0**: breaking (`!` suffix) → **major**; `feat` → **minor**; else →
   **patch**
 
-## Process
-
-### Step 1: Enumerate Changed Packages
+### Step 3: Enumerate Changed Packages
 
 ```sh
 latest=$(git tag --sort=-creatordate --list "${prefix}@v*" | head -1)
@@ -86,12 +96,12 @@ fi
 
 Skip packages with no unreleased commits.
 
-### Step 2: Determine Version Bumps
+### Step 4: Determine Version Bumps
 
 Read current version from `package.json` and scan commit log since last tag.
 Apply version rules above.
 
-### Step 3: Bump, Sync, Verify
+### Step 5: Bump, Sync, Verify
 
 ```sh
 cd <package-directory>
@@ -111,7 +121,7 @@ bun install
 bun run check:fix && bun run check
 ```
 
-### Step 4: Commit and Tag
+### Step 6: Commit and Tag
 
 ```sh
 git add <package>/package.json package-lock.json
@@ -121,7 +131,7 @@ git tag <prefix>@v<version>
 
 For multiple packages: commit all bumps, then tag each.
 
-### Step 5: Push and Verify
+### Step 7: Push and Verify
 
 Push commit first, then each tag individually:
 
@@ -138,7 +148,7 @@ gh run list --limit 10 --json name,conclusion,headBranch,event
 
 If a publish fails, investigate with `gh run view <run-id> --log-failed`.
 
-### Step 6: Summary
+### Step 8: Summary
 
 ```
 | Package  | Previous | New    | Tag             | Publish |
@@ -146,7 +156,7 @@ If a publish fails, investigate with `gh run view <run-id> --log-failed`.
 | libskill | 4.0.3    | 4.0.4  | libskill@v4.0.4 | ✓       |
 ```
 
-### Memory: what to record
+## Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.claude/skills/gemba-review/references/caller-protocol.md
+++ b/.claude/skills/gemba-review/references/caller-protocol.md
@@ -1,0 +1,35 @@
+# Sub-Agent Review Protocol
+
+Shared protocol for callers of `gemba-review`. Used by `gemba-spec` (Step 5),
+`gemba-plan` (Step 5), and `gemba-implement` (Step 8).
+
+## How to invoke
+
+1. **Launch a fresh sub-agent** via the `Agent` tool with no prior conversation
+   context. Instruct it to load the [`gemba-review`](../SKILL.md) skill and
+   grade the artifact (spec, plan, or diff).
+
+2. **Tell the reviewer not to invoke the parent skill** (e.g., "do not invoke
+   `gemba-spec`") — defense in depth on top of the structural recursion fix.
+
+3. **Provide enough context** for the reviewer to act independently — artifact
+   path, spec path (for plans and diffs), plan path (for diffs), and branch name
+   (for diffs).
+
+## Why this is safe
+
+`gemba-review` never spawns sub-agents — that is the structural property that
+prevents the spec / plan / implement review loop from recursing. See
+[GEMBA.md § Recursion-safe self-review](../../../../GEMBA.md#recursion-safe-self-review).
+
+## How to handle findings
+
+- **Verify** every finding against the actual artifact before acting on it.
+  Sub-agent reviewers operate without prior conversation context and can misread
+  intent, miss surrounding code, or flag false positives.
+- After verification, address every confirmed **blocker**, **high**, and
+  **medium** finding before advancing (approving, pushing, or merging).
+- **Low** findings are optional. Document if dismissed.
+- If the reviewer raises blockers you disagree with, resolve the disagreement
+  explicitly — revise the artifact, or record the rationale for dismissal.
+  Silent dismissal is not allowed.

--- a/.claude/skills/gemba-security-audit/SKILL.md
+++ b/.claude/skills/gemba-security-audit/SKILL.md
@@ -9,21 +9,44 @@ description: >
 
 # Security Audit
 
-## 1. Supply Chain — GitHub Actions
+## When to Use
+
+- Scheduled audit of the monorepo's security posture (one topic per run)
+- Reviewing a PR for security impact
+- Investigating a reported vulnerability
+
+## Checklists
+
+<do_confirm_checklist goal="Confirm audit topic was thoroughly checked">
+
+- [ ] Ran `just audit` locally and reported findings.
+- [ ] Reviewed all files relevant to the selected topic (not just grep).
+- [ ] Findings grounded in specific file paths and line numbers.
+- [ ] Each finding categorized: trivial fix, structural (spec), or observation.
+- [ ] Coverage map updated with today's date for the audited topic.
+
+</do_confirm_checklist>
+
+## Audit Areas
+
+Reference material for each topic. The focused audit strategy (§ 7) selects one
+area per run and goes deep.
+
+### 1. Supply Chain — GitHub Actions
 
 - All third-party actions pinned to full SHA with version comment (`# v4`).
 - Only first-party (`actions/*`) or official org actions permitted.
 - All workflows must declare explicit `permissions` with least privilege.
 - Dependabot configured to propose updates to action SHAs.
 
-## 2. Supply Chain — npm Dependencies
+### 2. Supply Chain — npm Dependencies
 
 Dependency policy in CONTRIBUTING.md § Dependency Policy. Additionally verify:
 
 - Publish workflows gate on `npm audit` results
 - No packages with known CVEs remain unpatched
 
-## 3. Credential & Secret Leak Prevention
+### 3. Credential & Secret Leak Prevention
 
 Rules in CONTRIBUTING.md § Security. Additionally verify:
 
@@ -31,28 +54,35 @@ Rules in CONTRIBUTING.md § Security. Additionally verify:
 - `.gitleaks.toml` allowlist exists for known false positives
 - Secrets in workflows use `secrets.*` — no hardcoded values
 
-## 4. Static Analysis
+### 4. Static Analysis
 
 Verify no security rules disabled in `eslint.config.js` without inline
 justification.
 
-## 5. Application Security (OWASP Top 10)
+### 5. Application Security (OWASP Top 10)
 
 Check for: injection (shell, SQL, template), broken auth, sensitive data
 exposure, security misconfiguration (CORS, headers), vulnerable components
 (`npm audit`), insufficient logging, SSRF, insecure deserialization (untrusted
 YAML/JSON without schema validation).
 
-## 6. CI/CD Security
+### 6. CI/CD Security
 
 Verify publish workflows block on audit failures and CI/local workflows run the
 same checks.
 
-## 7. Focused Audit Strategy
+## Process
+
+### Step 0: Read Memory
+
+Read memory per the agent profile (your summary, the current week's log, and
+teammates' summaries). Find last audit dates per topic in the coverage map.
+
+### Step 1: Select Topic
 
 Each run covers **one topic** in depth.
 
-### Topic areas
+#### Topic areas
 
 | Topic                        | What to audit                                               |
 | ---------------------------- | ----------------------------------------------------------- |
@@ -65,38 +95,27 @@ Each run covers **one topic** in depth.
 | `app-security-products`      | OWASP Top 10 in `products/` code                            |
 | `cicd-pipeline`              | Workflow integrity, publish gates, audit gates              |
 
-### Topic selection
+#### Topic selection
 
-1. Read memory per the agent profile (your summary, the current week's log, and
-   teammates' summaries). Find last audit dates per topic in the coverage map.
-2. Build coverage map — never-audited topics go first, then oldest.
-3. Revisit threshold — if all topics covered within last 4 runs, revisit oldest.
-4. Announce your pick and why before starting.
-5. Go deep — read every relevant file, not just grep for patterns.
+1. Build coverage map — never-audited topics go first, then oldest.
+2. Revisit threshold — if all topics covered within last 4 runs, revisit oldest.
+3. Announce your pick and why before starting.
+4. Go deep — read every relevant file, not just grep for patterns.
 
-## 8. Audit Checklist
+### Step 2: Audit the Topic
 
-<do_confirm_checklist goal="Confirm all audit areas were checked">
+Go deep on the selected topic using the audit area reference above. Read every
+relevant file — do not rely on grep alone. Ground findings in specific file
+paths and line numbers.
 
-- [ ] Ran `just audit` locally and reported findings.
-- [ ] Reviewed `.github/workflows/` for unpinned actions, missing permissions.
-- [ ] Reviewed `package.json` files for unnecessary or duplicate dependencies.
-- [ ] Reviewed `.gitignore` and `.gitleaks.toml` for coverage gaps.
-- [ ] Reviewed `eslint.config.js` for disabled security rules.
-- [ ] Grepped for vulnerability patterns: `eval(`, `child_process.exec(`,
-      `innerHTML`, `new Function(`, unsanitized template literals in SQL/shell
-      contexts.
-
-</do_confirm_checklist>
-
-## 9. Output
+### Step 3: Act on Findings
 
 Every audit must produce both categories when applicable — incremental fixes on
 a `fix/` branch and specs for structural findings on `spec/` branches. Branch
 naming, commit conventions, and independence rules are defined in the agent
 profile.
 
-### Memory: what to record
+## Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.claude/skills/gemba-security-audit/SKILL.md
+++ b/.claude/skills/gemba-security-audit/SKILL.md
@@ -20,8 +20,8 @@ description: >
 <do_confirm_checklist goal="Confirm audit topic was thoroughly checked">
 
 - [ ] Ran `just audit` locally and reported findings.
-- [ ] Reviewed all files relevant to the selected topic (not just grep).
-- [ ] Findings grounded in specific file paths and line numbers.
+- [ ] Read every file in the topic's audit scope — not just grep results.
+- [ ] Each finding cites a specific file path and line number.
 - [ ] Each finding categorized: trivial fix, structural (spec), or observation.
 - [ ] Coverage map updated with today's date for the audited topic.
 
@@ -29,8 +29,8 @@ description: >
 
 ## Audit Areas
 
-Reference material for each topic. The focused audit strategy (§ 7) selects one
-area per run and goes deep.
+Reference material for each topic. The process selects one area per run and goes
+deep.
 
 ### 1. Supply Chain — GitHub Actions
 

--- a/.claude/skills/gemba-security-update/SKILL.md
+++ b/.claude/skills/gemba-security-update/SKILL.md
@@ -25,32 +25,36 @@ security policies.
 See [`gemba-gh-cli`](../gemba-gh-cli/SKILL.md) for `gh` installation and the
 canonical query shapes used in the steps below.
 
-## Policy Checklist
+## Checklists
 
 <do_confirm_checklist goal="Verify dependency PR meets repo policies">
 
-- [ ] **All CI checks pass** (CONTRIBUTING.md § Before Submitting a PR). On
-      failure: **fix** if caused by PR; if pre-existing on main, skip and
-      recommend rebase.
-- [ ] **Actions pinned to SHA with version comment** (CONTRIBUTING.md §
-      Security; gemba-security-audit § 1). On failure: **fix** — update all
-      workflow files to the new SHA.
-- [ ] **No duplicate dependencies** (CONTRIBUTING.md § Dependency Policy). On
-      failure: **close** with explanation.
-- [ ] **Version ranges aligned across workspaces** (CONTRIBUTING.md § Dependency
-      Policy). On failure: **fix** — align all workspace ranges.
-- [ ] **`npm audit` clean (`--audit-level=high`)** (CONTRIBUTING.md § Dependency
-      Policy). On failure: **close** if update introduces vulnerability; skip if
-      pre-existing.
-- [ ] **No unnecessary dependencies** (CONTRIBUTING.md § Dependency Policy). On
-      failure: **close** with explanation.
-- [ ] **First-party or official org actions only** (gemba-security-audit § 1).
-      On failure: **close** with explanation.
-- [ ] **Peer and transitive dependency compatibility** (CONTRIBUTING.md §
-      Dependency Policy). On failure: **close** until co-dependent packages
-      release compatible versions.
+- [ ] All CI checks pass.
+- [ ] Actions pinned to SHA with version comment.
+- [ ] No duplicate dependencies.
+- [ ] Version ranges aligned across workspaces.
+- [ ] `npm audit` clean (`--audit-level=high`).
+- [ ] No unnecessary dependencies.
+- [ ] First-party or official org actions only.
+- [ ] Peer and transitive dependency compatibility verified.
 
 </do_confirm_checklist>
+
+### Policy failure dispositions
+
+When a check fails, the disposition depends on the check. The table below maps
+each check to its policy source and failure action — merge, fix, close, or skip.
+
+| Check                    | Policy source                       | Failure action                                                |
+| ------------------------ | ----------------------------------- | ------------------------------------------------------------- |
+| CI checks                | CONTRIBUTING.md § Before Submitting | **fix** if PR-caused; **skip** if pre-existing on main        |
+| SHA-pinned actions       | CONTRIBUTING.md § Security          | **fix** — update all workflow files to the new SHA            |
+| No duplicate deps        | CONTRIBUTING.md § Dependency Policy | **close** with explanation                                    |
+| Aligned version ranges   | CONTRIBUTING.md § Dependency Policy | **fix** — align all workspace ranges                          |
+| Clean npm audit          | CONTRIBUTING.md § Dependency Policy | **close** if update introduces vuln; **skip** if pre-exist    |
+| No unnecessary deps      | CONTRIBUTING.md § Dependency Policy | **close** with explanation                                    |
+| First-party actions only | gemba-security-audit § 1            | **close** with explanation                                    |
+| Peer/transitive compat   | CONTRIBUTING.md § Dependency Policy | **close** until co-dependent packages release compat versions |
 
 When evaluating the SHA-pinning check, verify the PR updates **all** workflow
 files referencing the action. See `references/sha-inventory.md` for the full
@@ -125,7 +129,7 @@ gh pr close <number> --comment "Dependabot triage: closing because <reason>. Pol
 | #61 | bump upload-pages-artifact ...  | fix    | Missing SHA pins           |
 ```
 
-### Memory: what to record
+## Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.claude/skills/gemba-security-update/SKILL.md
+++ b/.claude/skills/gemba-security-update/SKILL.md
@@ -51,7 +51,7 @@ each check to its policy source and failure action — merge, fix, close, or ski
 | SHA-pinned actions       | CONTRIBUTING.md § Security          | **fix** — update all workflow files to the new SHA            |
 | No duplicate deps        | CONTRIBUTING.md § Dependency Policy | **close** with explanation                                    |
 | Aligned version ranges   | CONTRIBUTING.md § Dependency Policy | **fix** — align all workspace ranges                          |
-| Clean npm audit          | CONTRIBUTING.md § Dependency Policy | **close** if update introduces vuln; **skip** if pre-exist    |
+| Clean npm audit          | CONTRIBUTING.md § Dependency Policy | **close** if new vuln; **skip** if pre-existing               |
 | No unnecessary deps      | CONTRIBUTING.md § Dependency Policy | **close** with explanation                                    |
 | First-party actions only | gemba-security-audit § 1            | **close** with explanation                                    |
 | Peer/transitive compat   | CONTRIBUTING.md § Dependency Policy | **close** until co-dependent packages release compat versions |

--- a/.claude/skills/gemba-spec/SKILL.md
+++ b/.claude/skills/gemba-spec/SKILL.md
@@ -131,21 +131,11 @@ status clearly — the caller is responsible for acting on it.
 3. **Write the spec.** Focus on WHAT and WHY. Do not include implementation
    details — those go in the plan.
 4. **Update STATUS.** Add the spec to `specs/STATUS` with status `draft`.
-5. **Clean sub-agent review.** Before advancing status, launch a fresh sub-agent
-   (via the `Agent` tool, no prior conversation context) and instruct it to load
-   the [`gemba-review`](../gemba-review/SKILL.md) skill and grade `spec.md`.
-   `gemba-review` owns the severity vocabulary and the spec criteria; it never
-   spawns sub-agents, so the review loop bottoms out structurally — see
-   [GEMBA.md § Recursion-safe self-review](../../../GEMBA.md#recursion-safe-self-review).
-   Tell the reviewer explicitly **not** to invoke `gemba-spec` itself — defense
-   in depth on top of the structural fix. **Verify** every finding against the
-   actual artifact before acting on it — sub-agent reviewers lack prior
-   conversation context and can misread intent or flag false positives. After
-   verification, address every confirmed **blocker**, **high**, and **medium**
-   finding before moving on. **Low** findings are optional. If the reviewer
-   raises blockers you disagree with, resolve the disagreement explicitly
-   (revise, or record the rationale for dismissal) — silent dismissal is not
-   allowed.
+5. **Clean sub-agent review.** Follow the
+   [`gemba-review` caller protocol](../gemba-review/references/caller-protocol.md)
+   to launch a fresh sub-agent that grades `spec.md`. Tell the reviewer not to
+   invoke `gemba-spec`. Verify findings, address all confirmed
+   blocker/high/medium issues before advancing.
 6. **Present the spec.** Share it for feedback. Iterate until satisfied, then
    set status to `review` — signalling it is ready for formal evaluation. Stop
    here. The plan is the staff engineer's job.

--- a/.claude/skills/gemba-walk/SKILL.md
+++ b/.claude/skills/gemba-walk/SKILL.md
@@ -47,17 +47,18 @@ breadth.
 
 ## Process
 
+### Step 0: Read Memory
+
+Read memory per the agent profile (your summary, the current week's log, and
+teammates' summaries). Extract workflow names and run IDs from previous cycles.
+
 ### 1. Select a Run
 
 If a specific workflow name, run ID, or URL is provided, use that run.
 
 Otherwise, select a run using memory-informed rotation:
 
-1. **Read memory** — Read memory per the agent profile (your summary, the
-   current week's log, and teammates' summaries). Extract workflow names and run
-   IDs from previous cycles.
-
-2. **Discover available runs**:
+1. **Discover available runs**:
 
    ```sh
    bash .claude/skills/gemba-walk/scripts/find-runs.sh [lookback]
@@ -67,11 +68,11 @@ Otherwise, select a run using memory-informed rotation:
    only. Returns JSON sorted newest-first with `workflow`, `run_id`, `status`,
    `conclusion`, `created_at`, `branch`, and `url` fields.
 
-3. **Avoid duplicates** — Skip run IDs already analyzed (per memory).
+2. **Avoid duplicates** — Skip run IDs already analyzed (per memory).
 
-4. **Rotate across agents** — Prefer the least-recently analyzed workflow.
+3. **Rotate across agents** — Prefer the least-recently analyzed workflow.
 
-5. **Prefer failures** — Among eligible runs, prefer non-success conclusions.
+4. **Prefer failures** — Among eligible runs, prefer non-success conclusions.
 
 Announce which run you selected and why before proceeding.
 

--- a/.claude/skills/gemba-walk/SKILL.md
+++ b/.claude/skills/gemba-walk/SKILL.md
@@ -202,7 +202,7 @@ same fix-or-spec discipline:
 Every PR must branch directly from `main` — never from another fix or spec
 branch.
 
-### Memory: what to record
+## Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.claude/skills/gemba-wiki-curate/SKILL.md
+++ b/.claude/skills/gemba-wiki-curate/SKILL.md
@@ -16,6 +16,12 @@ unacted on, and MEMORY.md falls out of sync.
 
 Each run covers all four curation areas in sequence.
 
+## When to Use
+
+- Scheduled wiki curation run
+- Auditing agent memory health
+- Checking cross-agent communication
+
 ## Curation areas
 
 | Area                    | What to check                                                  |
@@ -29,7 +35,7 @@ If time-constrained, prioritize `summary-accuracy` and `observation-follow-up`.
 
 ## Process
 
-### 1. Read all memory
+### Step 0: Read Memory
 
 Read memory per the agent profile (your summary, the current week's log, and
 teammates' summaries). Then read every file in `wiki/`:
@@ -39,7 +45,7 @@ teammates' summaries). Then read every file in `wiki/`:
 - `wiki/MEMORY.md`
 - `wiki/Home.md`
 
-### 2. Summary accuracy
+### Step 1: Summary accuracy
 
 For each agent, compare the summary against the most recent weekly log entries:
 
@@ -55,7 +61,7 @@ For each agent, compare the summary against the most recent weekly log entries:
 
 Fix inaccuracies directly in the summary files.
 
-### 3. Observation follow-up
+### Step 2: Observation follow-up
 
 Collect all "Observations for teammates" sections across all agent summaries.
 For each observation:
@@ -67,7 +73,7 @@ For each observation:
 4. Note unacted observations in the technical-writer's own summary so the target
    agent sees them on their next run.
 
-### 4. Memory index
+### Step 3: Memory index
 
 Verify `wiki/MEMORY.md`:
 
@@ -83,7 +89,7 @@ Verify `wiki/Home.md`:
 
 Update both files if they've drifted.
 
-### 5. Log hygiene
+### Step 4: Log hygiene
 
 For each weekly log file in `wiki/`:
 
@@ -96,7 +102,7 @@ For each weekly log file in `wiki/`:
 Flag format violations but do not rewrite log content — logs are historical
 records.
 
-### 6. Critical item roll-up
+### Step 5: Critical item roll-up
 
 Scan all agent summaries and recent weekly logs for items that affect multiple
 agents or the whole team:
@@ -130,7 +136,7 @@ If the curation also produced monorepo fixes (e.g., stale spec STATUS, doc
 corrections), branch from `main` as `fix/wiki-curate-YYYY-MM-DD`, commit, push,
 and open a PR — same discipline as doc-review fixes.
 
-### Memory: what to record
+## Memory: what to record
 
 Append to the current week's log (see agent profile for the file path):
 

--- a/.github/workflows/implement-plans.yml
+++ b/.github/workflows/implement-plans.yml
@@ -47,8 +47,7 @@ jobs:
           app-id: ${{ secrets.CI_APP_ID }}
           task-text:
             "Implement approved plans. Select the planned spec with the lowest
-            ID and implement it. Never ask for clarification — this is an
-            automated workflow."
+            ID and implement it."
           agent-profile: "staff-engineer"
           model: "opus"
           max-turns: "0"


### PR DESCRIPTION
## Summary

- Structural review of all 16 Gemba skills, 6 agent profiles, and 10 workflow tasks against GEMBA.md and CHECKLISTS.md authoring best practices
- Fixed 12 violations across instruction layers 2-5 (tasks, profiles, skills, checklists), then addressed 7 additional findings from independent sub-agent review

### Checklists (layer 5)
- Add missing DO-CONFIRM to `gemba-release-readiness` and `gemba-release-review`
- Move `gemba-security-audit` checklist from bottom to top per placement rule
- Strip instructional content from checklist items in `product-classify`, `security-update`, `security-audit` — move failure-handling to procedure tables
- Standardize section heading to `## Checklists` across all skills

### Skills (layer 4)
- Standardize `## Memory: what to record` heading level and `### Step 0: Read Memory` placement across all entry-point skills
- Add `## When to Use` to `documentation`, `wiki-curate`, `security-audit`
- Extract duplicated sub-agent review protocol to `gemba-review/references/caller-protocol.md`
- Fix stale cross-references, numbered heading inconsistencies, and reference-data-as-steps in `release-review`

### Profiles (layer 3) and Tasks (layer 2)
- Trim `staff-engineer` constraints that duplicate skill checklists
- Clarify `product-manager` workflow routing
- Remove constraint from `implement-plans` task that belongs in skill layer

## Test plan

- [x] `bun run format` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (2317/2317)
- [x] Independent sub-agent review against GEMBA.md and CHECKLISTS.md — all high/medium findings addressed

https://claude.ai/code/session_01PwingZV78JiQ2xfAZ7Mr97