### PR TITLE
feat(gemba-walk): add instruction-layer attribution step

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -26,7 +26,10 @@ Systematic, evidence-driven. Blame the system, never the worker. Sign off:
 ## Workflow
 
 1. **Walk the gemba** — Use the `gemba-walk` skill to observe a single trace,
-   audit named invariants, and produce findings via grounded theory.
+   audit named invariants, and produce findings via grounded theory. The walk
+   includes instruction-layer attribution — mapping findings to the 5-layer
+   model (GEMBA.md § Instruction layering) to bias action toward system
+   instruction improvements.
 
 2. **Act on findings** — For each finding (gemba or audit):
    - **Trivial fix** (mechanical, obvious, low risk) → branch from `main` as
@@ -45,6 +48,8 @@ Systematic, evidence-driven. Blame the system, never the worker. Sign off:
 - Mechanical fixes only — anything beyond gets a spec
 - Ground every finding in trace evidence — quote tool calls, errors, token
   counts
+- Prefer fixing the highest instruction layer where the defect originates —
+  downstream fixes are palliative
 - Trust the invariant audit results — they are the structured accountability
   check
 - Run `bun run check` and `bun run test` before committing

--- a/.claude/skills/gemba-walk/SKILL.md
+++ b/.claude/skills/gemba-walk/SKILL.md
@@ -11,7 +11,11 @@ description: >
 Go to where the work happens — the execution trace of a CI agent workflow run —
 and observe it firsthand. Select one run, download its trace, study every turn
 via grounded theory, categorize findings, and act on what you find. Depth over
-breadth.
+breadth. This skill operates within the Gemba system defined in
+[GEMBA.md](../../../GEMBA.md), whose five-layer instruction model (§ Instruction
+layering) and checklist design principles
+([CHECKLISTS.md](../../../CHECKLISTS.md)) govern how findings translate into
+system improvements.
 
 ## When to Use
 
@@ -41,6 +45,7 @@ breadth.
 - [ ] Memos written during coding (not retroactively).
 - [ ] Categories built with all five paradigm elements filled.
 - [ ] Core category identified — integrates the most categories.
+- [ ] Categories attributed to instruction layers where evidence supports it.
 - [ ] Named invariants from `references/invariants.md` audited with PASS/FAIL.
 
 </do_confirm_checklist>
@@ -55,26 +60,9 @@ teammates' summaries). Extract workflow names and run IDs from previous cycles.
 ### 1. Select a Run
 
 If a specific workflow name, run ID, or URL is provided, use that run.
-
-Otherwise, select a run using memory-informed rotation:
-
-1. **Discover available runs**:
-
-   ```sh
-   bash .claude/skills/gemba-walk/scripts/find-runs.sh [lookback]
-   ```
-
-   Default lookback is `7d`. Use `14d` for broader window, `24h` for recent
-   only. Returns JSON sorted newest-first with `workflow`, `run_id`, `status`,
-   `conclusion`, `created_at`, `branch`, and `url` fields.
-
-2. **Avoid duplicates** — Skip run IDs already analyzed (per memory).
-
-3. **Rotate across agents** — Prefer the least-recently analyzed workflow.
-
-4. **Prefer failures** — Among eligible runs, prefer non-success conclusions.
-
-Announce which run you selected and why before proceeding.
+Otherwise, select a run using memory-informed rotation — see
+[`references/run-selection.md`](references/run-selection.md) for the selection
+algorithm. Announce which run you selected and why before proceeding.
 
 ### 2. Download and Process the Trace
 
@@ -97,16 +85,9 @@ gh run download <run-id> --name agent-trace --dir /tmp/trace-<run-id>
 bunx fit-eval output --format=json < /tmp/trace-<run-id>/trace.ndjson > /tmp/trace-<run-id>/structured.json
 ```
 
-If no trace artifacts exist, pick a different run and note why.
-
-For large traces, use the extraction helpers in `scripts/trace-queries.sh`
-(`overview`, `count`, `batch N M`, `tail N`, `errors`, `tools`):
-
-```sh
-bash .claude/skills/gemba-walk/scripts/trace-queries.sh structured.json overview
-bash .claude/skills/gemba-walk/scripts/trace-queries.sh structured.json batch 0 20
-bash .claude/skills/gemba-walk/scripts/trace-queries.sh structured.json errors
-```
+If no trace artifacts exist, pick a different run and note why. For large
+traces, use `scripts/trace-queries.sh` (`overview`, `count`, `batch N M`,
+`tail N`, `errors`, `tools`).
 
 ### 3. Observe the Work (Open Coding + Memos)
 
@@ -158,7 +139,34 @@ it), and **actionable** (implies a concrete change).
 
 See `references/examples.md` for worked axial and selective coding examples.
 
-### 5. Categorize Findings
+### 5. Attribute to Instruction Layers
+
+For each category and proposition, ask: which instruction layer (if any) is the
+root cause? See [GEMBA.md § Instruction layering](../../../GEMBA.md) for the
+full model. Quick-reference key:
+
+`L1 system prompt / L2 task / L3 profile / L4 skill / L5 checklist`
+
+| Layer               | Typical fix shape                               |
+| ------------------- | ----------------------------------------------- |
+| L1 (system prompt)  | Infrastructure fix (relay code, supervisor.js)  |
+| L2 (workflow task)  | Trivial fix (reword task text in workflow YAML) |
+| L3 (agent profile)  | Trivial fix or improvement (edit profile .md)   |
+| L4 (skill)          | Improvement or trivial fix depending on scope   |
+| L5 (checklist)      | Trivial fix (add or edit checklist item)        |
+| None (infra/config) | Depends on scope                                |
+
+Not every finding maps to an instruction layer — infrastructure, SDK, and
+external service failures are valid non-layer findings. Attribute only when the
+evidence supports it. Prefer the highest layer where the defect originates — a
+symptom in L4 (skill execution) may have a root cause in L2 (task text).
+
+See `references/examples.md` for a worked attribution example.
+
+### 6. Categorize Findings
+
+Use the instruction-layer attribution from Step 5 to inform the action column —
+the typical fix shape biases the trivial-fix vs improvement judgment.
 
 | Category        | Criteria                                        | Action         |
 | --------------- | ----------------------------------------------- | -------------- |
@@ -166,7 +174,7 @@ See `references/examples.md` for worked axial and selective coding examples.
 | **Improvement** | Pattern requires design, touches multiple files | Write spec     |
 | **Observation** | Not actionable yet, or needs more data          | Note in report |
 
-### 6. Audit Named Invariants
+### 7. Audit Named Invariants
 
 In addition to open-ended observation, verify the trace against the named
 per-agent invariants listed in
@@ -180,7 +188,7 @@ on `product-manager` traces — must result in a fix PR or spec just like any
 other gemba finding. Silent acceptance of a high-severity failure is itself a
 process failure.
 
-### 7. Report and Act
+### 8. Report and Act
 
 Run the DO-CONFIRM checklist above before producing the report.
 
@@ -213,6 +221,8 @@ Append to the current week's log (see agent profile for the file path):
 - **Core category** — The central phenomenon and theoretical propositions
 - **Invariant audit results** — Each invariant checked with PASS/FAIL and quoted
   evidence
+- **Instruction-layer attributions** — Which layers were implicated and what fix
+  shapes resulted
 - **Saturation notes** — Patterns confirmed, refuted, or newly emerged compared
   to prior cycles
 - **Observations for teammates** — Callouts for specific agents
@@ -229,3 +239,8 @@ principles add practical guidance:
 - **Count what matters.** Token usage, retry counts, wasted turns, cost.
 - **Compare to intent.** Read the skill docs, compare to actual execution.
 - **Maintain traceability.** Proposition → category → code → turn number.
+- **Trace findings back to instruction layers.** When a failure's root cause is
+  an instruction defect, name the layer. Attributed findings lead to layer
+  fixes; unattributed findings lead to vague improvements.
+- **Prefer upstream layers.** A symptom in L4 (skill execution) may have a root
+  cause in L2 (task text). Fix the highest layer where the defect originates.

--- a/.claude/skills/gemba-walk/references/examples.md
+++ b/.claude/skills/gemba-walk/references/examples.md
@@ -80,6 +80,34 @@ Each proposition must be:
 - **Actionable** — implies a concrete change to skills, workflows, or
   infrastructure
 
+## Instruction-Layer Attribution Example
+
+After selective coding, map each category to an instruction layer:
+
+```
+Category: TASK_AMBIGUITY_PARALYSIS
+  Layer: L2 (workflow task)
+  Evidence: Turn 24 — agent cites singular "an" from task text
+    "Implement an approved plan" as reason for asking instead of acting.
+  Fix shape: Trivial fix — reword task to include selection criteria
+    ("implement the highest-priority planned spec").
+
+Category: STALE_STATUS_FILE
+  Layer: None (data integrity)
+  Evidence: specs/STATUS shows "planned" for spec 370 but implementation
+    is already on main.
+  Fix shape: Trivial fix — update STATUS file.
+
+Category: EFFECTIVE_RESEARCH_DELEGATION
+  Layer: None (positive finding)
+  No attribution — this is a working pattern, not a defect.
+```
+
+Not every category maps to a layer. Positive findings and infrastructure issues
+may have no instruction-layer attribution. The discipline is to check
+systematically — ask "could an instruction-layer change have prevented this?"
+for every category, then attribute only when the answer is yes with evidence.
+
 ## Cross-trace patterns
 
 Gemba walks are single-trace by design — depth over breadth. When returning to

--- a/.claude/skills/gemba-walk/references/report-template.md
+++ b/.claude/skills/gemba-walk/references/report-template.md
@@ -66,17 +66,31 @@ the core. Reference the categories it connects.>
 2. <Testable statement...>
 3. <Testable statement...>
 
+### Instruction-Layer Attribution
+
+<For each category with an instruction-layer root cause, map it to the
+layer and state the evidence. Not every category maps to a layer — only
+attribute when the evidence supports it. See GEMBA.md § Instruction layering
+for the five-layer model.>
+
+| Category | Layer              | Evidence                        | Fix Shape    |
+| -------- | ------------------ | ------------------------------- | ------------ |
+| TASK_... | L2 (workflow task) | Turn NN: agent cites singular   | Trivial fix  |
+| CRED_... | L4 (skill)         | No diagnostic step in skill doc | Improvement  |
+| BUDGET.. | None (infra)       | Hardcoded maxTurns in JS        | Trivial fix  |
+
 ### Actionable Findings
 
 <Translate propositions into concrete actions. Each finding traces back
-to a proposition, which traces to categories, which trace to codes, which
-trace to specific turns. This traceability chain is the report's integrity.>
+to a proposition, which traces to categories and layers, which trace to
+codes, which trace to specific turns. This traceability chain is the
+report's integrity.>
 
-| # | Proposition | Category | Finding                           | Action            |
-| - | ----------- | -------- | --------------------------------- | ----------------- |
-| 1 | P1          | CRED_... | Agent lacks credential diagnostic | Spec: skill update |
-| 2 | P3          | WASTE_.. | 3 identical retries, no backoff   | Fix: add retry cap |
-| 3 | —           | —        | High token usage in triage phase  | Observe            |
+| # | Proposition | Category | Layer | Finding                           | Action            |
+| - | ----------- | -------- | ----- | --------------------------------- | ----------------- |
+| 1 | P1          | CRED_... | L4    | Agent lacks credential diagnostic | Spec: skill update |
+| 2 | P3          | WASTE_.. | —     | 3 identical retries, no backoff   | Fix: add retry cap |
+| 3 | —           | —        | —     | High token usage in triage phase  | Observe            |
 
 ### Saturation Notes
 

--- a/.claude/skills/gemba-walk/references/run-selection.md
+++ b/.claude/skills/gemba-walk/references/run-selection.md
@@ -1,0 +1,20 @@
+# Run Selection Algorithm
+
+When no specific workflow name, run ID, or URL is provided, select a run using
+memory-informed rotation:
+
+1. **Discover available runs**:
+
+   ```sh
+   bash .claude/skills/gemba-walk/scripts/find-runs.sh [lookback]
+   ```
+
+   Default lookback is `7d`. Use `14d` for broader window, `24h` for recent
+   only. Returns JSON sorted newest-first with `workflow`, `run_id`, `status`,
+   `conclusion`, `created_at`, `branch`, and `url` fields.
+
+2. **Avoid duplicates** — Skip run IDs already analyzed (per memory).
+
+3. **Rotate across agents** — Prefer the least-recently analyzed workflow.
+
+4. **Prefer failures** — Among eligible runs, prefer non-success conclusions.


### PR DESCRIPTION
## Summary\n\n- Add Step 5 (Attribute to Instruction Layers) to the gemba-walk skill, mapping each grounded-theory category to the 5-layer instruction model (L1 system prompt / L2 task / L3 profile / L4 skill / L5 checklist) with typical fix shapes\n- Update report template with attribution section and Layer column in findings table\n- Add worked attribution example using real W15 implement-plans trace data\n- Orient improvement-coach profile toward instruction-layer improvements\n- Extract run-selection algorithm to references/run-selection.md for line recovery\n\n## Test plan\n\n- [x] `bun run check` (format + lint pass; layout error is pre-existing)\n- [x] `bun run test` (2317 pass, 0 fail)\n- [x] Step numbering consistent (0-8)\n- [x] DO-CONFIRM checklist has 7 items