### PR TITLE
fix: sync environment with origin/main on session start

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# ── Sync with origin/main ────────────────────────────────────────
+git fetch origin main
+
+current_branch=$(git branch --show-current)
+
+if [ "$current_branch" = "main" ]; then
+  git merge --ff-only origin/main
+else
+  # Update local main ref without checkout
+  git branch -f main origin/main
+  # Rebase feature branch onto updated main; reset to main on conflict
+  git rebase main || {
+    git rebase --abort
+    git reset --hard main
+  }
+fi
+
+# ── Install tooling ──────────────────────────────────────────────
 if ! command -v just &>/dev/null; then
   bun install -g rust-just
 fi


### PR DESCRIPTION
The SessionStart hook (scripts/bootstrap.sh) never fetched from origin,
so each new session started with a stale snapshot of main. Add git fetch
and rebase logic before installing dependencies. If rebase conflicts
(severely stale environment), fall back to resetting the branch to main.

https://claude.ai/code/session_01TQ3sbJcvFyKMoZjo2xbzNg