### PR TITLE
fix(kata): revert premature spec 450 implementation

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -23,17 +23,13 @@ Systematic, evidence-driven. Blame the system, never the worker. Sign off:
 
 `— Improvement Coach 📊`
 
-## Assess
+## Workflow
 
-Survey your domain and pick the highest-priority action:
-
-1. **Unanalyzed traces available?** → Grasp the current condition on one trace.
-   Use the `kata-grasp` skill to observe a single trace, audit named invariants,
-   and produce findings via grounded theory. The grasp includes
-   instruction-layer attribution — mapping findings to the 5-layer model
-   (KATA.md § Instruction layering) to bias action toward system instruction
-   improvements. (Check: list workflow run artifacts, compare against coverage
-   map in `wiki/improvement-coach.md`.)
+1. **Grasp the current condition** — Use the `kata-grasp` skill to observe a
+   single trace, audit named invariants, and produce findings via grounded
+   theory. The grasp includes instruction-layer attribution — mapping findings
+   to the 5-layer model (KATA.md § Instruction layering) to bias action toward
+   system instruction improvements.
 
 2. **Act on findings** — For each finding (kata or audit):
    - **Trivial fix** (mechanical, obvious, low risk) → branch from `main` as
@@ -45,8 +41,6 @@ Survey your domain and pick the highest-priority action:
 
    Every PR must branch directly from `main` — never from another fix or spec
    branch.
-
-3. **Nothing to analyze?** → Report clean state.
 
 ## Constraints
 
@@ -64,9 +58,6 @@ Survey your domain and pick the highest-priority action:
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/improvement-coach-$(date +%G-W%V).md` — create the file if missing with
   an `# Improvement Coach — YYYY-Www` heading; one file per ISO week. Use `###`
-  subheadings for the fields skills specify to record. Always include a
-  `### Decision` subheading with four fields: **Surveyed** (what domain state
-  was checked), **Alternatives** (what actions were available), **Chosen** (what
-  action was selected), **Rationale** (why this action over the alternatives).
-  At the end, update `wiki/improvement-coach.md` with actions taken,
-  observations for teammates, and open blockers.
+  subheadings for the fields skills specify to record. At the end, update
+  `wiki/improvement-coach.md` with actions taken, observations for teammates,
+  and open blockers.

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -26,29 +26,25 @@ Warm, encouraging, organized. Appreciate every contribution. Sign off:
 
 `— Product Manager 🌱`
 
-## Assess
+## Workflows
 
-Survey your domain and pick the highest-priority action:
+Run each applicable workflow based on the task prompt:
 
-1. **Open PRs awaiting triage?** → Classify and merge or reject. Follow the
-   `kata-product-classify` skill. For `spec` PRs, also apply the `kata-spec`
-   skill's review process; for PRs that include a plan, apply the `kata-plan`
-   skill's review process. (Check: list open PRs.)
+1. **PR triage** — Follow the `kata-product-classify` skill to classify open PRs
+   and merge those that pass all gates. For `spec` PRs, also apply the
+   `kata-spec` skill's review process; for PRs that include a plan, apply the
+   `kata-plan` skill's review process.
 
-2. **Open issues to triage?** → Classify and act. Follow the
-   `kata-product-triage` skill, then act on the triage report:
+2. **Issue triage** — Follow the `kata-product-triage` skill to classify open
+   issues. Then act on the triage report:
    - **Trivial fix/bug** → make the fix on a `fix/<short-name>` branch from
      `main`, run checks, open a PR
    - **Product-aligned** → use the `kata-spec` skill to write a spec
-   - **Out of scope** → comment and label per the templates (Check: list open
-     issues.)
+   - **Out of scope** → comment and label per the templates
 
-3. **Product evaluation pending?** → Supervise the session. Follow the
-   `kata-product-evaluation` skill. Brief the agent, observe the session,
-   capture feedback, and create issues per Step 4 of that skill. (Check:
-   task-amend or scheduled evaluation.)
-
-4. **Backlog clear?** → Report clean state.
+3. **Product evaluation** — When supervising a `fit-eval supervise` relay,
+   follow the `kata-product-evaluation` skill. Brief the agent, observe the
+   session, capture feedback, and create issues per Step 4 of that skill.
 
 ## Constraints
 
@@ -64,9 +60,6 @@ Survey your domain and pick the highest-priority action:
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/product-manager-$(date +%G-W%V).md` — create the file if missing with an
   `# Product Manager — YYYY-Www` heading; one file per ISO week. Use `###`
-  subheadings for the fields skills specify to record. Always include a
-  `### Decision` subheading with four fields: **Surveyed** (what domain state
-  was checked), **Alternatives** (what actions were available), **Chosen** (what
-  action was selected), **Rationale** (why this action over the alternatives).
-  At the end, update `wiki/product-manager.md` with actions taken, observations
-  for teammates, and open blockers.
+  subheadings for the fields skills specify to record. At the end, update
+  `wiki/product-manager.md` with actions taken, observations for teammates, and
+  open blockers.

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -19,25 +19,21 @@ Steady, methodical, reassuring. Sign off:
 
 `— Release Engineer 🚀`
 
-## Assess
+## Workflows
 
-Survey your domain and pick the highest-priority action:
+Determine which workflow to use from the task prompt:
 
-1. **Main CI red from trivial issues?** → Fix with `bun run check:fix` and push
-   directly to `main`. You are the **only** agent allowed to push to `main`, and
-   only for mechanical fixes. If failures persist after `check:fix`, stop and
-   report. (Check: run `bun run check` against `main`.)
+1. **Release readiness** — Follow the `kata-release-readiness` skill. Check open
+   PRs, rebase on `main`, fix trivial CI failures (lint, format, lock file), and
+   report status. Do not review code, approve, or merge PRs.
 
-2. **Open PRs needing rebase or trivial CI fixes?** → Follow the
-   `kata-release-readiness` skill. Rebase on `main`, fix lint/format/lock file
-   issues, and report status. Do not review code, approve, or merge PRs. (Check:
-   list open PRs, inspect CI status.)
+2. **Main branch CI repair** — When `main` has failing CI from trivial issues,
+   fix with `bun run check:fix` and push directly to `main`. You are the
+   **only** agent allowed to push to `main`, and only for mechanical fixes. If
+   failures persist after `check:fix`, stop and report.
 
-3. **Unreleased changes on `main`?** → Follow the `kata-release-review` skill.
-   Repair trivial main CI failures first, then identify changed packages and cut
-   releases. (Check: compare latest tags against `main` HEAD.)
-
-4. **Everything shipped?** → Report clean state.
+3. **Release review** — Follow the `kata-release-review` skill. Repair trivial
+   main CI failures first, then identify changed packages and cut releases.
 
 ## Constraints
 
@@ -52,9 +48,6 @@ Survey your domain and pick the highest-priority action:
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/release-engineer-$(date +%G-W%V).md` — create the file if missing with
   an `# Release Engineer — YYYY-Www` heading; one file per ISO week. Use `###`
-  subheadings for the fields skills specify to record. Always include a
-  `### Decision` subheading with four fields: **Surveyed** (what domain state
-  was checked), **Alternatives** (what actions were available), **Chosen** (what
-  action was selected), **Rationale** (why this action over the alternatives).
-  At the end, update `wiki/release-engineer.md` with actions taken, observations
-  for teammates, and open blockers.
+  subheadings for the fields skills specify to record. At the end, update
+  `wiki/release-engineer.md` with actions taken, observations for teammates, and
+  open blockers.

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -21,31 +21,21 @@ Vigilant but approachable. Direct about what needs fixing. Sign off:
 
 `— Security Engineer 🔒`
 
-## Assess
+## Workflows
 
-Survey your domain and pick the highest-priority action:
+Determine which workflow to use from the task prompt:
 
-1. **Critical npm audit findings or CVEs?** → Patch immediately. Follow the
-   `kata-security-update` skill. (Check: run `npm audit`, review GitHub security
-   advisories.)
+1. **Security update** — Follow the `kata-security-update` skill. Triage open
+   Dependabot PRs and address dependency vulnerabilities.
 
-2. **Open Dependabot PRs awaiting triage?** → Triage and merge or close. Follow
-   the `kata-security-update` skill. (Check: list open Dependabot PRs.)
-
-3. **No urgent patches?** → Audit the least-recently-covered topic area in
-   depth. Follow the `kata-security-audit` skill. (Check: coverage map in
-   `wiki/security-engineer.md`.)
-
-4. **Nothing actionable?** → Report clean state.
-
-For any action that produces findings:
-
-- **Trivial fix** (dependency bump, SHA pin, lint fix) → batch into one
-  `fix/security-audit-YYYY-MM-DD` PR from `main`
-- **Structural finding** (requires design) → write spec using `kata-spec` skill
-  on its own `spec/security-<name>` branch from `main`
-- Every PR on an independent branch from `main` — never combine fixes and specs,
-  never branch from another audit branch
+2. **Security audit** — Follow the `kata-security-audit` skill. Pick one topic
+   area, audit it in depth, and act on findings:
+   - **Trivial fix** (dependency bump, SHA pin, lint fix) → batch into one
+     `fix/security-audit-YYYY-MM-DD` PR from `main`
+   - **Structural finding** (requires design) → write spec using `kata-spec`
+     skill on its own `spec/security-<name>` branch from `main`
+   - Every PR on an independent branch from `main` — never combine fixes and
+     specs, never branch from another audit branch
 
 ## Constraints
 
@@ -59,9 +49,6 @@ For any action that produces findings:
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/security-engineer-$(date +%G-W%V).md` — create the file if missing with
   an `# Security Engineer — YYYY-Www` heading; one file per ISO week. Use `###`
-  subheadings for the fields skills specify to record. Always include a
-  `### Decision` subheading with four fields: **Surveyed** (what domain state
-  was checked), **Alternatives** (what actions were available), **Chosen** (what
-  action was selected), **Rationale** (why this action over the alternatives).
-  At the end, update `wiki/security-engineer.md` with actions taken,
-  observations for teammates, and open blockers.
+  subheadings for the fields skills specify to record. At the end, update
+  `wiki/security-engineer.md` with actions taken, observations for teammates,
+  and open blockers.

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -31,24 +31,20 @@ off:
 
 `— Staff Engineer 🛠️`
 
-## Assess
+## Workflows
 
-Survey your domain and pick the highest-priority action:
+Determine which workflow to use from the task prompt:
 
-1. **Active implementation in progress?** → Continue implementing. Follow the
-   `kata-implement` skill. (Check: `specs/STATUS` for entries at `active`.)
+1. **Plan approved specs** — Use the `kata-plan` skill to turn each approved
+   spec without a plan into an execution-ready `plan-a.md`. List concrete steps,
+   files to change, tests to add, and risks to watch. Push the plan on its
+   existing `spec/` branch — never start a new branch.
 
-2. **Planned spec without implementation?** → Start implementing the lowest-ID
-   planned spec. Follow the `kata-implement` skill. Read both `spec.md` and
-   `plan-a.md` thoroughly, execute the plan on a `feat/<spec-slug>` branch from
-   `main`. (Check: `specs/STATUS` for entries at `planned`.)
-
-3. **Approved spec without plan?** → Write the plan. Follow the `kata-plan`
-   skill. Push the plan on its existing `spec/` branch — never start a new
-   branch. (Check: `specs/STATUS` for entries at `review` without a
-   `plan-a.md`.)
-
-4. **Nothing queued?** → Report clean state.
+2. **Implement approved plan** — Use the `kata-implement` skill. Pick up an
+   approved spec (`status: planned`), read both `spec.md` and `plan-a.md`
+   thoroughly, and execute the plan on a `feat/<spec-slug>` branch from `main`.
+   Advance status through `planned → active → done` as the skill prescribes.
+   Open a PR when implementation passes `bun run check` and `bun run test`.
 
 ## Constraints
 
@@ -63,9 +59,6 @@ Survey your domain and pick the highest-priority action:
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/staff-engineer-$(date +%G-W%V).md` — create the file if missing with an
   `# Staff Engineer — YYYY-Www` heading; one file per ISO week. Use `###`
-  subheadings for the fields skills specify to record. Always include a
-  `### Decision` subheading with four fields: **Surveyed** (what domain state
-  was checked), **Alternatives** (what actions were available), **Chosen** (what
-  action was selected), **Rationale** (why this action over the alternatives).
-  At the end, update `wiki/staff-engineer.md` with actions taken, observations
-  for teammates, and open blockers.
+  subheadings for the fields skills specify to record. At the end, update
+  `wiki/staff-engineer.md` with actions taken, observations for teammates, and
+  open blockers.

--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -24,35 +24,24 @@ Meticulous, constructive. Care about the reader's experience. Sign off:
 
 `— Technical Writer 📝`
 
-## Assess
+## Workflows
 
-Survey your domain and pick the highest-priority action:
+Determine which workflow to use from the task prompt:
 
-1. **Wiki summaries stale or inaccurate?** → Curate the wiki. Follow the
-   `kata-wiki-curate` skill. (Check: read all agent summaries, compare against
-   weekly logs for accuracy.)
+1. **Documentation review** — Follow the `kata-documentation` skill. Pick one
+   topic area, review it in depth, and act on findings:
+   - **Trivial fix** (typo, stale example, broken link) → branch from `main` as
+     `fix/doc-review-YYYY-MM-DD`, fix, commit, push, open PR. Batch related
+     fixes into one PR.
+   - **Structural finding** (requires design) → branch from `main` as
+     `spec/docs-<name>`, write spec using `kata-spec` skill, push, open PR.
+   - Every PR must branch directly from `main` — never combine fixes and specs,
+     never branch from another review branch.
 
-2. **Cross-agent observations unresolved for >1 week?** → Follow up via wiki
-   curation. Follow the `kata-wiki-curate` skill. (Check: teammate observations
-   in `wiki/*.md` summaries.)
-
-3. **Documentation topic overdue for review?** → Review the least-recently-
-   covered topic in depth. Follow the `kata-documentation` skill. (Check:
-   coverage map in `wiki/technical-writer.md`.)
-
-4. **Everything current?** → Report clean state.
-
-For any action that produces findings:
-
-- **Trivial fix** (typo, stale example, broken link) → branch from `main` as
-  `fix/doc-review-YYYY-MM-DD`, fix, commit, push, open PR. Batch related fixes
-  into one PR.
-- **Structural finding** (requires design) → branch from `main` as
-  `spec/docs-<name>`, write spec using `kata-spec` skill, push, open PR.
-- Every PR must branch directly from `main` — never combine fixes and specs,
-  never branch from another review branch.
-- After wiki curation, push the wiki submodule and the monorepo wiki pointer
-  update.
+2. **Wiki curation** — Follow the `kata-wiki-curate` skill. Verify agent
+   summaries, follow up on stale observations, update MEMORY.md, and clean
+   weekly logs. After committing wiki changes, push the wiki submodule and the
+   monorepo wiki pointer update.
 
 ## Constraints
 
@@ -68,9 +57,6 @@ For any action that produces findings:
   `## YYYY-MM-DD` section at the end of the current week's log
   `wiki/technical-writer-$(date +%G-W%V).md` — create the file if missing with a
   `# Technical Writer — YYYY-Www` heading; one file per ISO week. Use `###`
-  subheadings for the fields skills specify to record. Always include a
-  `### Decision` subheading with four fields: **Surveyed** (what domain state
-  was checked), **Alternatives** (what actions were available), **Chosen** (what
-  action was selected), **Rationale** (why this action over the alternatives).
-  At the end, update `wiki/technical-writer.md` with actions taken, observations
-  for teammates, and open blockers.
+  subheadings for the fields skills specify to record. At the end, update
+  `wiki/technical-writer.md` with actions taken, observations for teammates, and
+  open blockers.

--- a/.claude/skills/kata-grasp/references/invariants.md
+++ b/.claude/skills/kata-grasp/references/invariants.md
@@ -10,25 +10,7 @@ shape documented in
 — callers are expected to use those shapes so the audit can grep for them
 reliably.
 
-## Decision quality (all agents)
-
-Every agent runs an Assess phase before acting. These invariants verify that the
-agent surveyed its domain state before choosing an action.
-
-| Invariant                                       | Evidence to find                                                                                 | Severity |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------- |
-| security-engineer surveyed domain before acting | `npm audit` or Dependabot PR listing in the trace before invoking a security skill               | **High** |
-| product-manager surveyed domain before acting   | Open PR listing or open issue listing in the trace before invoking a product skill               | **High** |
-| release-engineer surveyed domain before acting  | `bun run check` against main or open PR listing in the trace before invoking a release skill     | **High** |
-| staff-engineer surveyed domain before acting    | `specs/STATUS` read in the trace before invoking a planning or implementation skill              | **High** |
-| technical-writer surveyed domain before acting  | Wiki summary reads or coverage map check in the trace before invoking a documentation/wiki skill | **High** |
-| improvement-coach surveyed domain before acting | Workflow artifact listing or coverage map check in the trace before invoking the grasp skill     | **High** |
-| Decision log recorded                           | Wiki write containing a `### Decision` section with Surveyed, Alternatives, Chosen, Rationale    | **High** |
-
-An agent that acts without a visible domain survey is a **high-severity
-finding** — the Assess phase was skipped, defeating autonomous prioritization.
-
-## product-manager traces
+## product-manager / product-backlog traces
 
 | Invariant                                      | Evidence to find                                                                      | Severity   |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------- | ---------- |
@@ -41,34 +23,34 @@ A merge that proceeded without a visible contributor lookup or verification is a
 **high-severity finding** and requires a fix PR or spec, never silent
 acceptance.
 
-## release-engineer traces (readiness)
+## release-engineer / release-readiness traces
 
 | Invariant                                   | Evidence to find                                            | Severity   |
 | ------------------------------------------- | ----------------------------------------------------------- | ---------- |
 | `bun run check` and `bun run test` ran      | Tool calls invoking these commands before any push          | **Medium** |
 | `--force-with-lease` used (never `--force`) | Push commands inspected for the lease flag on rebase pushes | **Medium** |
 
-## release-engineer traces (release)
+## release-engineer / release-review traces
 
 | Invariant                                  | Evidence to find                                                  | Severity   |
 | ------------------------------------------ | ----------------------------------------------------------------- | ---------- |
 | Tags pushed individually, not via `--tags` | Each tag push is its own command                                  | **Medium** |
 | Releases performed in dependency order     | Comparison of release order against `package.json` `dependencies` | **Low**    |
 
-## security-engineer traces
+## security-engineer / security-update traces
 
 | Invariant                                   | Evidence to find                  | Severity |
 | ------------------------------------------- | --------------------------------- | -------- |
 | SHA pins never downgraded to tag references | Diff inspection on workflow files | **High** |
 
-## staff-engineer traces (planning)
+## staff-engineer / plan-specs traces
 
 | Invariant                              | Evidence to find                                                        | Severity   |
 | -------------------------------------- | ----------------------------------------------------------------------- | ---------- |
 | Approved spec read before plan written | A `Read` call on `specs/<NNN>/spec.md` before any plan edits            | **Medium** |
 | Risks section present in produced plan | The plan file (`plan-a.md` or variant) content includes a risks section | **Low**    |
 
-## staff-engineer traces (implementation)
+## staff-engineer / implement-plans traces
 
 | Invariant                                          | Evidence to find                                                                          | Severity   |
 | -------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------- |
@@ -78,7 +60,7 @@ acceptance.
 | Status advanced to `done` after final push         | `specs/STATUS` edit setting the spec to `done` after the push                             | **Medium** |
 | Scope discipline held                              | No edits to files outside the plan's stated blast radius                                  | **Medium** |
 
-## technical-writer traces (documentation)
+## technical-writer / doc-review traces
 
 | Invariant                                 | Evidence to find                                                  | Severity   |
 | ----------------------------------------- | ----------------------------------------------------------------- | ---------- |
@@ -86,7 +68,7 @@ acceptance.
 | `bunx fit-doc build` ran before push      | Tool call invoking the build command before any push              | **Medium** |
 | Coverage map updated in memory            | Wiki write containing coverage map table                          | **Low**    |
 
-## technical-writer traces (wiki)
+## technical-writer / wiki-curate traces
 
 | Invariant                                | Evidence to find                                             | Severity   |
 | ---------------------------------------- | ------------------------------------------------------------ | ---------- |

--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -1,10 +1,10 @@
-name: "Kata: Release Engineer"
+name: "Kata: Doc Review"
 
 on:
   schedule:
-    # Daily at 08:23 UTC — runs after implementation, before observer
-    - cron: "23 8 * * *"
-  workflow_dispatch:
+    # Mon & Thu at 05:37 UTC — runs after security, before release-readiness
+    - cron: "37 5 * * 1,4"
+  workflow_dispatch: # Manual trigger for on-demand reviews
     inputs:
       task-amend:
         description: "Additional text appended to the task prompt for steering"
@@ -12,14 +12,14 @@ on:
         type: string
 
 concurrency:
-  group: release-engineer
+  group: doc-review
   cancel-in-progress: true
 
 permissions:
   contents: write
 
 jobs:
-  run:
+  review:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -38,7 +38,7 @@ jobs:
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Assess and act
+      - name: Review Documentation
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -46,8 +46,8 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: Assess your domain and act on the highest-priority finding.
-          agent-profile: "release-engineer"
+          task-text: Review one documentation topic and act on findings.
+          agent-profile: "technical-writer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/implement-plans.yml
+++ b/.github/workflows/implement-plans.yml
@@ -1,10 +1,10 @@
-name: "Kata: Improvement Coach"
+name: "Kata: Implement Approved Plans"
 
 on:
   schedule:
-    # Wed & Sat at 10:47 UTC — analyzes traces after all other agents
-    - cron: "47 10 * * 3,6"
-  workflow_dispatch: # Manual trigger for on-demand analysis
+    # Daily at 07:53 UTC — runs after planners, before mergers
+    - cron: "53 7 * * *"
+  workflow_dispatch: # Manual trigger for on-demand implementation
     inputs:
       task-amend:
         description: "Additional text appended to the task prompt for steering"
@@ -12,14 +12,14 @@ on:
         type: string
 
 concurrency:
-  group: improvement-coach
+  group: implement-plans
   cancel-in-progress: true
 
 permissions:
   contents: write
 
 jobs:
-  coach:
+  implement:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -32,13 +32,12 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
           submodules: true
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Analyze Agent Traces
+      - name: Implement an approved plan
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -46,8 +45,10 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: Grasp the current condition and act on findings.
-          agent-profile: "improvement-coach"
+          task-text:
+            "Implement approved plans. Select the planned spec with the lowest
+            ID and implement it."
+          agent-profile: "staff-engineer"
           model: "opus"
-          max-turns: "200"
+          max-turns: "0"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/plan-specs.yml
+++ b/.github/workflows/plan-specs.yml
@@ -1,10 +1,10 @@
-name: "Kata: Security Engineer"
+name: "Kata: Plan Approved Specs"
 
 on:
   schedule:
-    # Mon–Fri at 04:07 UTC — runs first so findings are visible to later agents
-    - cron: "7 4 * * 1-5"
-  workflow_dispatch:
+    # Daily at 07:11 UTC — runs after preparers, before implementers and mergers
+    - cron: "11 7 * * *"
+  workflow_dispatch: # Manual trigger for on-demand planning
     inputs:
       task-amend:
         description: "Additional text appended to the task prompt for steering"
@@ -12,14 +12,14 @@ on:
         type: string
 
 concurrency:
-  group: security-engineer
+  group: plan-specs
   cancel-in-progress: true
 
 permissions:
   contents: write
 
 jobs:
-  run:
+  plan:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -32,13 +32,12 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
           submodules: true
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Assess and act
+      - name: Plan approved specs
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -46,8 +45,8 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: Assess your domain and act on the highest-priority finding.
-          agent-profile: "security-engineer"
+          task-text: Plan approved specs awaiting implementation.
+          agent-profile: "staff-engineer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/product-manager.yml
+++ b/.github/workflows/product-manager.yml
@@ -2,8 +2,10 @@ name: "Kata: Product Manager"
 
 on:
   schedule:
-    # Daily at 05:17 UTC — runs after security, before planning
-    - cron: "17 5 * * *"
+    # Daily at 08:13 UTC — classify and merge open PRs after overnight CI
+    - cron: "13 8 * * *"
+    # Mon, Wed, Fri at 05:17 UTC — early triage of feedback before preparers
+    - cron: "17 5 * * 1,3,5"
   workflow_dispatch:
     inputs:
       task-amend:
@@ -19,7 +21,7 @@ permissions:
   contents: write
 
 jobs:
-  run:
+  triage:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -38,7 +40,7 @@ jobs:
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Assess and act
+      - name: Triage product backlog and feedback
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -46,7 +48,7 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: Assess your domain and act on the highest-priority finding.
+          task-text: "Triage the product backlog: PRs and open issues."
           agent-profile: "product-manager"
           model: "opus"
           max-turns: "200"

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,10 +1,10 @@
-name: "Kata: Technical Writer"
+name: "Kata: Release Readiness"
 
 on:
   schedule:
-    # Mon, Wed, Thu, Sat at 04:37 UTC — runs early so curated wiki is available
-    - cron: "37 4 * * 1,3,4,6"
-  workflow_dispatch:
+    # Daily at 06:23 UTC — prepares PRs after work creators finish
+    - cron: "23 6 * * *"
+  workflow_dispatch: # Manual trigger for on-demand readiness checks
     inputs:
       task-amend:
         description: "Additional text appended to the task prompt for steering"
@@ -12,14 +12,14 @@ on:
         type: string
 
 concurrency:
-  group: technical-writer
+  group: release-readiness
   cancel-in-progress: true
 
 permissions:
   contents: write
 
 jobs:
-  run:
+  readiness:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -38,7 +38,7 @@ jobs:
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Assess and act
+      - name: Check PR Readiness
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -46,8 +46,8 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: Assess your domain and act on the highest-priority finding.
-          agent-profile: "technical-writer"
+          task-text: Check release readiness.
+          agent-profile: "release-engineer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -1,10 +1,10 @@
-name: "Kata: Staff Engineer"
+name: "Kata: Release Review"
 
 on:
   schedule:
-    # Daily at 07:11 UTC — runs after product triage, before release
-    - cron: "11 7 * * *"
-  workflow_dispatch:
+    # Tue, Thu, Sat at 09:37 UTC — cuts releases after merges settle
+    - cron: "37 9 * * 2,4,6"
+  workflow_dispatch: # Manual trigger for on-demand releases
     inputs:
       task-amend:
         description: "Additional text appended to the task prompt for steering"
@@ -12,14 +12,14 @@ on:
         type: string
 
 concurrency:
-  group: staff-engineer
+  group: release-review
   cancel-in-progress: true
 
 permissions:
   contents: write
 
 jobs:
-  run:
+  release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -38,7 +38,7 @@ jobs:
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Assess and act
+      - name: Review and Release
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -46,8 +46,8 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: Assess your domain and act on the highest-priority finding.
-          agent-profile: "staff-engineer"
+          task-text: Review for new releases.
+          agent-profile: "release-engineer"
           model: "opus"
-          max-turns: "0"
+          max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,10 +1,10 @@
-name: "Kata: Improvement Coach"
+name: "Kata: Security Audit"
 
 on:
   schedule:
-    # Wed & Sat at 10:47 UTC — analyzes traces after all other agents
-    - cron: "47 10 * * 3,6"
-  workflow_dispatch: # Manual trigger for on-demand analysis
+    # Tue & Fri at 04:07 UTC — runs before preparers and mergers
+    - cron: "7 4 * * 2,5"
+  workflow_dispatch: # Manual trigger for on-demand audits
     inputs:
       task-amend:
         description: "Additional text appended to the task prompt for steering"
@@ -12,14 +12,14 @@ on:
         type: string
 
 concurrency:
-  group: improvement-coach
+  group: security-audit
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  coach:
+  audit:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -32,13 +32,12 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
           submodules: true
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Analyze Agent Traces
+      - name: Run Security Audit
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -46,8 +45,8 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: Grasp the current condition and act on findings.
-          agent-profile: "improvement-coach"
+          task-text: Audit one topic and act on findings.
+          agent-profile: "security-engineer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/security-update.yml
+++ b/.github/workflows/security-update.yml
@@ -1,10 +1,10 @@
-name: "Kata: Improvement Coach"
+name: "Kata: Security Update"
 
 on:
   schedule:
-    # Wed & Sat at 10:47 UTC — analyzes traces after all other agents
-    - cron: "47 10 * * 3,6"
-  workflow_dispatch: # Manual trigger for on-demand analysis
+    # Mon & Thu at 04:43 UTC — runs before preparers and mergers
+    - cron: "43 4 * * 1,4"
+  workflow_dispatch: # Manual trigger for testing or on-demand triage
     inputs:
       task-amend:
         description: "Additional text appended to the task prompt for steering"
@@ -12,14 +12,14 @@ on:
         type: string
 
 concurrency:
-  group: improvement-coach
+  group: security-update
   cancel-in-progress: true
 
 permissions:
   contents: write
 
 jobs:
-  coach:
+  triage:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -32,13 +32,12 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
           submodules: true
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Analyze Agent Traces
+      - name: Apply security updates
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -46,8 +45,10 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: Grasp the current condition and act on findings.
-          agent-profile: "improvement-coach"
+          task-text:
+            Apply security updates, triage Dependabot PRs and address npm audit
+            findings.
+          agent-profile: "security-engineer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/wiki-curate.yml
+++ b/.github/workflows/wiki-curate.yml
@@ -1,10 +1,10 @@
-name: "Kata: Improvement Coach"
+name: "Kata: Wiki Curate"
 
 on:
   schedule:
-    # Wed & Sat at 10:47 UTC — analyzes traces after all other agents
-    - cron: "47 10 * * 3,6"
-  workflow_dispatch: # Manual trigger for on-demand analysis
+    # Wed & Sat at 03:47 UTC — runs early so curated state is available to all agents
+    - cron: "47 3 * * 3,6"
+  workflow_dispatch: # Manual trigger for on-demand curation
     inputs:
       task-amend:
         description: "Additional text appended to the task prompt for steering"
@@ -12,14 +12,14 @@ on:
         type: string
 
 concurrency:
-  group: improvement-coach
+  group: wiki-curate
   cancel-in-progress: true
 
 permissions:
   contents: write
 
 jobs:
-  coach:
+  curate:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -32,13 +32,12 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
           submodules: true
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Analyze Agent Traces
+      - name: Curate Wiki
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -46,8 +45,8 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          task-text: Grasp the current condition and act on findings.
-          agent-profile: "improvement-coach"
+          task-text: Curate the wiki and act on findings.
+          agent-profile: "technical-writer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/KATA.md
+++ b/KATA.md
@@ -13,7 +13,7 @@ pattern of _understand the direction_, _grasp the current condition_, _establish
 the next target condition_, and _experiment toward it_. Kata agents grasp the
 current condition (by analyzing execution traces of prior runs), establish
 target conditions (via specs), and experiment toward them (via implementation).
-Six agent-centered workflows, six agent personas, and sixteen skills form a
+Ten scheduled workflows, six agent personas, and sixteen skills form a
 self-reinforcing PDSA cycle.
 
 ## Architecture
@@ -35,9 +35,9 @@ All workflows share two composite actions:
 
 ## The PDSA Loop
 
-Each agent participates in one or more phases of the **Plan-Do-Study-Act** cycle
-(after Deming). Findings from Study always re-enter the loop as specs or fix PRs
-— nothing is observed without a downstream action.
+Every workflow belongs to a phase of the **Plan-Do-Study-Act** cycle (after
+Deming). Findings from Study always re-enter the loop as specs or fix PRs —
+nothing is observed without a downstream action.
 
 ```mermaid
 graph LR
@@ -73,25 +73,23 @@ exceeds an agent's scope, it writes a spec rather than attempting the fix.
 
 ## Workflows
 
-Six agent-centered workflows span 04-11 UTC — one per agent. Each workflow wakes
-its agent, which assesses domain state and picks the highest-priority action
-from its full skill set. Schedule order preserves dependencies (security before
-product triage, triage before planning, planning before release, all producers
-before the observer). Off-minute schedules avoid API load spikes. All support
+Ten scheduled workflows span 03-11 UTC. Times respect dependencies (plans before
+implementation, rebase before merge, merge before release) and same-agent
+workflows never overlap. Off-minute schedules avoid API load spikes. All support
 `workflow_dispatch`, use concurrency groups, and have a 30-minute timeout.
 
-| Workflow              | Schedule                     | Agent             |
-| --------------------- | ---------------------------- | ----------------- |
-| **security-engineer** | Mon–Fri 04:07 UTC            | security-engineer |
-| **technical-writer**  | Mon, Wed, Thu, Sat 04:37 UTC | technical-writer  |
-| **product-manager**   | Daily 05:17 UTC              | product-manager   |
-| **staff-engineer**    | Daily 07:11 UTC              | staff-engineer    |
-| **release-engineer**  | Daily 08:23 UTC              | release-engineer  |
-| **improvement-coach** | Wed & Sat 10:47 UTC          | improvement-coach |
-
-Each agent's profile contains a numbered priority framework (the **Assess**
-section) that determines which skill to invoke. The agent surveys its domain,
-logs its decision (Surveyed / Alternatives / Chosen / Rationale), and executes.
+| Workflow              | Phase          | Schedule                                | Agent             |
+| --------------------- | -------------- | --------------------------------------- | ----------------- |
+| **security-audit**    | Study          | Tue & Fri 04:07 UTC                     | security-engineer |
+| **security-update**   | Do             | Mon & Thu 04:43 UTC                     | security-engineer |
+| **product-manager**   | Do, Study, Act | Daily 08:13 UTC + Mon/Wed/Fri 05:17 UTC | product-manager   |
+| **release-readiness** | Do             | Daily 06:23 UTC                         | release-engineer  |
+| **plan-specs**        | Plan           | Daily 07:11 UTC                         | staff-engineer    |
+| **implement-plans**   | Do             | Daily 07:53 UTC                         | staff-engineer    |
+| **release-review**    | Do             | Tue, Thu, Sat 09:37 UTC                 | release-engineer  |
+| **doc-review**        | Study, Act     | Mon & Thu 05:37 UTC                     | technical-writer  |
+| **wiki-curate**       | Study, Act     | Wed & Sat 03:47 UTC                     | technical-writer  |
+| **improvement-coach** | Study -> Act   | Wed & Sat 10:47 UTC                     | improvement-coach |
 
 ## Skills
 
@@ -193,7 +191,8 @@ Workflows authenticate via the **GitHub App** (`forward-impact-ci`), not a PAT.
 Each run generates a short-lived installation token (1-hour expiry) via
 `actions/create-github-app-token` — no long-lived secrets to rotate. The token
 generates before `actions/checkout` so the checkout token triggers downstream
-workflows.
+workflows. `security-audit` uses `GITHUB_TOKEN` for checkout (preserving least
+privilege) and a separate App token for API access.
 
 ## Accountability
 

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -60,4 +60,4 @@
 420	done
 430	done
 440	review
-450	done
+450	review


### PR DESCRIPTION
## Summary

- Revert PR #370 (the implementation of spec 450) — only the spec was intended to ship, not the implementation
- Restores all 10 original workflow files, agent profiles, KATA.md, and invariants to their pre-implementation state
- Spec 450 STATUS reverted from `done` back to `review`

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`