### PR TITLE
docs(specs): spec and design 470 — reframe kata-grasp as kata-trace

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -11,11 +11,13 @@ if [ "$current_branch" = "main" ]; then
 else
   # Update local main ref without checkout
   git branch -f main origin/main
-  # Rebase feature branch onto updated main; reset to main on conflict
-  git rebase main || {
-    git rebase --abort
-    git reset --hard main
-  }
+  # Don't rebase feature branches automatically — rebasing is a deliberate
+  # action the user should request. Just report how far behind main we are.
+  ahead_behind=$(git rev-list --left-right --count main..."$current_branch" 2>/dev/null || echo "0 0")
+  behind=$(echo "$ahead_behind" | awk '{print $1}')
+  if [ "$behind" -gt 0 ]; then
+    echo "Branch '$current_branch' is $behind commit(s) behind main. Rebase when ready."
+  fi
 fi
 
 # ── Install tooling ──────────────────────────────────────────────

--- a/specs/470-reframe-kata-grasp-as-kata-trace/design.md
+++ b/specs/470-reframe-kata-grasp-as-kata-trace/design.md
@@ -1,0 +1,160 @@
+# Design 470 — Reframe kata-grasp as kata-trace
+
+## Overview
+
+A skill rename with reframed description text. Three components change: the
+skill itself (directory, frontmatter, title, opening paragraph), the
+improvement-coach agent profile (skill list and all routing/jargon references),
+and 7 other external files that reference the skill by name. No interfaces, data
+flow, or architecture change — the design's value is in the naming and
+description decisions.
+
+## Component 1: Skill Identity
+
+### Directory
+
+`.claude/skills/kata-grasp/` becomes `.claude/skills/kata-trace/`. All contents
+move as-is — `SKILL.md`, `references/`, `scripts/`.
+
+### Frontmatter
+
+```yaml
+---
+name: kata-trace
+description: >
+  Go and see the work agents did by analyzing their execution traces. Select a
+  workflow run, download its trace artifact, observe every turn via grounded
+  theory, and produce a structured findings report with instruction-layer
+  attribution.
+---
+```
+
+**Decision: lead with "Go and see" vs. "Download and analyze" vs. keep "Grasp
+the current condition."** "Go and see the work agents did" was chosen because:
+
+- It is concrete and action-oriented — the agent knows to look at actual work.
+- "by analyzing their execution traces" immediately names the object and method.
+- It echoes the gemba ("go and see") philosophy without reintroducing the
+  retired `gemba-*` naming convention (spec 340 consolidated those into
+  `kata-*`).
+- Rejected: "Grasp the current condition" — pattern-matched to general
+  assessment by the LLM in run 24418764670.
+- Rejected: "Download and analyze" as lead — technically correct but misses the
+  intent (observation of actual work, not just data processing).
+
+**Decision: name `kata-trace` vs. `kata-analyze-trace` vs. `kata-study`.**
+`kata-trace` was chosen because:
+
+- It is short and parallel to other kata skill names (`kata-spec`, `kata-plan`,
+  `kata-ship`, `kata-review`).
+- "trace" names the primary object, and the skill's only purpose is to operate
+  on traces.
+- Rejected: `kata-analyze-trace` — too verbose, breaks naming pattern.
+- Rejected: `kata-study` — still abstract; "study" could mean studying code,
+  docs, or specs, not specifically traces.
+
+### Title and Opening Paragraph
+
+```markdown
+# Agent Trace Analysis
+
+Go and see the work agents did by analyzing their execution traces. Select one
+workflow run, download its trace, study every turn via grounded theory, categorize
+findings, and act on what you find. Depth over breadth. This skill operates
+within the Kata system defined in [KATA.md](../../../KATA.md), whose five-layer
+instruction model (§ Instruction layering) and checklist design principles
+([CHECKLISTS.md](../../../CHECKLISTS.md)) govern how findings translate into
+system improvements.
+```
+
+The Toyota Kata connection ("step 2 of the improvement kata") moves out of the
+frontmatter description and can remain as context later in the document — but
+not in the title or first sentence that drives skill routing.
+
+## Component 2: Agent Profile Routing
+
+`improvement-coach.md` has four change sites — all must be updated to eliminate
+the "grasp" jargon that the spec identifies as the root cause:
+
+1. **Skills frontmatter** (line 9): `- kata-grasp` becomes `- kata-trace`.
+   Mechanical rename — controls which skill the agent can invoke.
+
+2. **Opening directive** (line 15): "Grasp the current condition of agent
+   workflow runs" becomes "Go and see the work done by agent workflow runs."
+   Deliberate reword — this is the agent's identity statement and must match the
+   reframed skill language.
+
+3. **Assess item 1** (lines 30-31): "Grasp the current condition (`kata-grasp`)"
+   becomes "Go and see the work agents did by analyzing their traces
+   (`kata-trace`)." Deliberate reword — this is the primary routing instruction.
+
+4. **Assess item 2** (line 33): "Unaddressed findings from prior grasps?"
+   becomes "Unaddressed findings from prior trace analyses?" Deliberate reword —
+   removes the last "grasp" jargon from the profile.
+
+**Decision: rewrite all four sites vs. just swap the skill name in the
+frontmatter.** All four sites change because the spec identified that "Grasp the
+current condition (`kata-grasp`)" reinforced the abstract interpretation.
+Swapping only the frontmatter reference while keeping "Grasp" in the routing
+text and identity statement would leave the same jargon anchor. The new phrasing
+uses "go and see" and "trace analysis" consistently.
+
+## Component 3: Cross-References
+
+Seven remaining external files contain `kata-grasp` references
+(`improvement- coach.md` is fully handled by Component 2). Most are mechanical
+find-and-replace of `kata-grasp` with `kata-trace`, with two exceptions in
+`KATA.md`:
+
+```mermaid
+graph LR
+    SK["kata-trace/SKILL.md<br/>(Component 1)"]
+    IC["improvement-coach.md<br/>(Component 2: 4 sites)"]
+
+    subgraph "Mechanical rename — kata-grasp → kata-trace"
+        PC["kata-product-classify<br/>SKILL.md (4 refs)"]
+        GH["kata-gh-cli<br/>SKILL.md (4 refs)"]
+        GHR["kata-gh-cli<br/>commands.md (1 ref)"]
+        S1["specs/450<br/>spec.md (1 ref)"]
+        S2["specs/450<br/>plan-a.md (3 refs)"]
+        WK["wiki<br/>staff-engineer.md (1 ref)"]
+    end
+
+    subgraph "Deliberate rewrite"
+        K["KATA.md (3 refs)"]
+    end
+
+    subgraph "Internal — move with directory"
+        INV["references/invariants.md"]
+        RS["references/run-selection.md"]
+    end
+
+    IC --> SK
+    SK --> K
+    SK --> PC
+    SK --> GH
+```
+
+**Exception 1: `KATA.md` line 117.** The skill table entry currently reads
+`kata-grasp — grasp the current condition via trace observation and grounded theory`.
+This becomes
+`kata-trace — go and see the work agents did via trace analysis and grounded theory`.
+Not a pure find-and-replace — the description clause also changes.
+
+**Exception 2: `KATA.md` lines 197-201.** The accountability section references
+`kata-grasp` by name and its directory path for `invariants.md`. Both the name
+and the path update to `kata-trace`.
+
+All other cross-reference files are pure `kata-grasp` → `kata-trace` string
+replacement with no surrounding text changes needed.
+
+## What Does NOT Change
+
+- Grounded theory methodology (open/axial/selective coding, memos, paradigm
+  model)
+- Invariant definitions and audit procedure
+- Scripts (`find-runs.sh`, `trace-queries.sh`)
+- Reference content (`invariants.md`, `examples.md`, `report-template.md`,
+  `run-selection.md`)
+- Checklists (read-do and do-confirm)
+- Any other agent profile or workflow

--- a/specs/470-reframe-kata-grasp-as-kata-trace/spec.md
+++ b/specs/470-reframe-kata-grasp-as-kata-trace/spec.md
@@ -1,0 +1,129 @@
+# Spec 470 — Reframe kata-grasp as kata-trace
+
+## Problem
+
+The improvement coach's primary function is downloading agent execution traces
+and analyzing them via grounded theory. On run 24418764670 (2026-04-14), the
+improvement coach **bypassed kata-grasp entirely** and instead performed a
+surface-level domain assessment — auditing open PRs, issues, tests, and specs —
+which is product-manager behavior, not coaching behavior.
+
+The trace shows the agent spawned general-purpose subagents for repo health
+checks (seq 6, 23, 33), attempted PR classification (seq 125, 128), and fixed a
+spec quality defect (seq 340+). It never invoked the Skill tool for kata-grasp,
+never downloaded a trace artifact, and never performed grounded theory analysis.
+The entire 10-minute session produced useful work (spec 460 fix), but none of it
+was the improvement coach's assigned function.
+
+### Root cause: name and description use abstract jargon
+
+The skill name `kata-grasp` and its description — "Grasp the current condition
+of an agent workflow run" — use Toyota Kata vocabulary. "Grasp the current
+condition" is meaningful to someone steeped in the improvement kata framework,
+but to an LLM selecting among available skills, it reads as a generic directive
+to understand the repo's state. The agent did exactly that: it "grasped the
+current condition" by surveying PRs, tests, and specs — a literal interpretation
+that misses the skill's actual function.
+
+Compare how the skill description appears in the system-reminder skill list:
+
+> `kata-grasp: Grasp the current condition of an agent workflow run. Select a trace, download it, observe the work as it actually happened, apply grounded theory analysis, and produce a structured findings report — step 2 of the improvement kata.`
+
+The first sentence is abstract ("grasp the current condition"). The concrete
+actions (select trace, download, observe, apply grounded theory) are buried in
+the second sentence. Skill routing is dominated by the name and opening clause —
+by the time the description reaches "download it," the agent has already
+pattern-matched "grasp current condition" to "assess repo state."
+
+### Evidence this is a recurring risk
+
+The improvement coach's Assess section routes to kata-grasp with the phrase
+"Grasp the current condition (`kata-grasp`)." This couples the routing
+instruction to the same abstract jargon as the skill name. When the agent
+reinterprets "grasp" as general assessment, the routing instruction reinforces
+the misinterpretation rather than correcting it.
+
+Prior runs successfully invoked kata-grasp — W15 analyzed runs 24120743042
+(guide-setup), 24278652769 (implement-plans), and 24290929444 (summit-setup).
+However, the W15 runs benefited from explicit user direction or fresh wiki
+context naming specific trace IDs. The April 14 run had no such anchoring — the
+agent was left to route on name and description alone, and it failed.
+
+## Proposal
+
+Rename `kata-grasp` to `kata-trace` and rewrite its description to lead with
+concrete, unambiguous language about what the skill does: go and see the work
+agents did by analyzing their execution traces.
+
+### What changes
+
+1. **Skill directory**: `.claude/skills/kata-grasp/` becomes
+   `.claude/skills/kata-trace/`
+
+2. **Skill frontmatter**: Name changes from `kata-grasp` to `kata-trace`.
+   Description changes from "Grasp the current condition of an agent workflow
+   run..." to language that leads with "Go and see the work agents did by
+   analyzing their execution traces."
+
+3. **SKILL.md title and opening**: Replace "Grasping the Current Condition" with
+   a title that names the actual activity (trace analysis). The Toyota Kata
+   framing can remain as context but should not be the lead.
+
+4. **Agent profile** (`improvement-coach.md`): Update skill list reference and
+   Assess routing text. Replace "Grasp the current condition (`kata-grasp`)"
+   with "Go and see the work agents did by analyzing their traces
+   (`kata-trace`)."
+
+5. **Cross-references**: Update all files that reference `kata-grasp`:
+   - `KATA.md` — skill table entry and accountability section
+   - `kata-product-classify/SKILL.md` — invariant audit references
+   - `kata-gh-cli/SKILL.md` — canonical query patterns section
+   - `kata-gh-cli/references/commands.md` — invariant audit reference
+   - `specs/450-agent-centered-workflows/` — spec and plan references
+   - `wiki/staff-engineer.md` — reference to kata-grasp analysis
+   - Internal references within the skill's own `references/` directory
+
+### What does NOT change
+
+- **Grounded theory methodology**: The analysis process (open coding, axial
+  coding, selective coding, memos, paradigm model) is unchanged. This spec
+  renames and reframes — it does not alter the analytical method.
+- **Invariant audit function**: The named per-agent invariants and their
+  evidence requirements remain identical.
+- **Scripts and references**: `scripts/find-runs.sh`,
+  `scripts/trace-queries.sh`, `references/invariants.md`,
+  `references/examples.md`, `references/report-template.md`,
+  `references/run-selection.md` — content unchanged, only moved under the new
+  directory name.
+- **Checklist content**: Both the read-do and do-confirm checklists remain
+  as-is.
+
+## Scope
+
+### Included
+
+- Rename skill directory from `kata-grasp` to `kata-trace`
+- Rewrite skill name, description, title, and opening paragraph
+- Update improvement-coach agent profile routing text
+- Update all cross-references across the repository (8 external files reference
+  `kata-grasp` outside the skill's own directory)
+
+### Excluded
+
+- Changes to grounded theory methodology or analysis process
+- Changes to invariant definitions or audit procedure
+- Changes to the improvement-coach agent profile beyond skill routing
+- Changes to other agent profiles or workflows
+- Adding new functionality to the skill
+
+## Success Criteria
+
+1. `rg kata-grasp` returns zero matches across the repository — all references
+   updated to `kata-trace`.
+2. The skill description in the system-reminder skill list leads with "Go and
+   see" language (not Toyota Kata jargon) when viewed by an agent.
+3. The improvement-coach Assess section routes to trace analysis using "go and
+   see the work agents did" language with an explicit `kata-trace` reference.
+4. `bun run check` and `bun run test` pass — no broken references or imports.
+5. All existing `kata-grasp` reference files (`references/`, `scripts/`) are
+   present under `kata-trace/` with unchanged content.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -64,3 +64,4 @@
 440	plan	implemented
 450	plan	implemented
 460	spec	approved
+470	design	draft

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -64,4 +64,4 @@
 440	plan	implemented
 450	plan	implemented
 460	spec	approved
-470	design	draft
+470	design	approved


### PR DESCRIPTION
## Summary

- **Spec 470**: Rename `kata-grasp` to `kata-trace` with "go and see the work agents did" language — the improvement coach bypassed trace analysis on run 24418764670 because the abstract Toyota Kata name caused it to assess repo state instead
- **Design 470**: Three components — skill identity (new name/frontmatter/title), agent profile routing (all four change sites in improvement-coach.md), and cross-references across 7 external files
- **Bootstrap fix**: Stop auto-rebasing feature branches on session start — the old behavior destroyed branch state on conflict by resetting to main

## Test plan

- [x] `bun run check` passes
- [x] `bun run test` passes (2339/2339)
- [ ] CI checks green