### PR TITLE
fix(bootstrap): unshallow clone and safely rebase on session start

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 # ── Sync with origin/main ────────────────────────────────────────
+# Shallow clones lack enough history for rebase to find a merge base.
+# Unshallow first so rebase works reliably.
+if [ -f .git/shallow ]; then
+  git fetch --unshallow origin
+fi
+
 git fetch origin main
 
 current_branch=$(git branch --show-current)
@@ -11,12 +17,12 @@ if [ "$current_branch" = "main" ]; then
 else
   # Update local main ref without checkout
   git branch -f main origin/main
-  # Don't rebase feature branches automatically — rebasing is a deliberate
-  # action the user should request. Just report how far behind main we are.
-  ahead_behind=$(git rev-list --left-right --count main..."$current_branch" 2>/dev/null || echo "0 0")
-  behind=$(echo "$ahead_behind" | awk '{print $1}')
-  if [ "$behind" -gt 0 ]; then
-    echo "Branch '$current_branch' is $behind commit(s) behind main. Rebase when ready."
+  # Rebase feature branch onto main; on conflict abort and warn (never reset)
+  if git rebase main 2>/dev/null; then
+    echo "Rebased '$current_branch' onto main."
+  else
+    git rebase --abort
+    echo "Branch '$current_branch' has conflicts with main. Rebase manually when ready."
   fi
 fi
 


### PR DESCRIPTION
## Summary

- The Claude Code web environment uses shallow clones, so feature branches often lack a common ancestor with main — causing rebase to always fail on session start
- The previous fix (`ea79de3`) auto-rebased but fell back to `git reset --hard main` on conflict, which destroyed unpushed feature branch work — so it was removed in `1d6707d`
- This restores auto-rebase with two fixes: (1) unshallow the clone first so a merge base always exists, (2) on conflict abort cleanly and warn — never reset

## Test plan

- [ ] `bun run check` — passes (format + lint clean)
- [ ] `bun run test` — 63 pre-existing failures unrelated to this change (all in library tests; bootstrap.sh is a shell script not covered by the test suite)
- [ ] Manual: start a new Claude Code web session on a feature branch behind main — should unshallow then rebase cleanly
- [ ] Manual: start a session on a branch with real conflicts — should abort rebase and print warning, leaving branch untouched