### PR TITLE
plan(460): Kata Coaching System

### DIFF
--- a/specs/460-daily-team-meeting/plan-a-01.md
+++ b/specs/460-daily-team-meeting/plan-a-01.md
@@ -1,0 +1,137 @@
+# Plan 460-A Part 01 — kata-metrics Utility Skill
+
+## Scope
+
+Create the metrics infrastructure utility skill. Three new files, no
+modifications.
+
+## Files
+
+| Action | Path                                                       |
+| ------ | ---------------------------------------------------------- |
+| Create | `.claude/skills/kata-metrics/SKILL.md`                     |
+| Create | `.claude/skills/kata-metrics/references/csv-schema.md`     |
+| Create | `.claude/skills/kata-metrics/references/control-charts.md` |
+
+## Steps
+
+### 1. Create SKILL.md
+
+Create `.claude/skills/kata-metrics/SKILL.md` with:
+
+**Frontmatter:**
+
+```yaml
+---
+name: kata-metrics
+description: >
+  Time-series data recording protocol for Kata agents. Defines CSV schema,
+  storage conventions, and metric design guidance. Utility skill — no agent
+  routes to it directly; entry-point skills reference it for recording.
+---
+```
+
+**Content (~80 lines):**
+
+- `# Metrics Recording Protocol` heading
+- Brief introduction: utility skill like kata-gh-cli — defines the protocol that
+  entry-point skills follow when recording time-series data at the end of each
+  run.
+- `## When to Use` — You are an entry-point kata skill recording measurements
+  after completing primary work. Reference this protocol for format, storage,
+  and design guidance.
+- `## Recording Protocol` — Step-by-step:
+  1. Choose which metrics to record based on what you observed during this run
+     (informed by your skill's `references/metrics.md`).
+  2. For each metric, append one CSV row to
+     `wiki/metrics/{agent}/{domain}/{YYYY}.csv`. Create the directory and header
+     row if the file does not exist.
+  3. Commit metrics files as part of the wiki push at the end of the run.
+- `## Metric Design Guidance` — Brief section:
+  - Prefer counts and durations over ratios (ratios hide volume).
+  - Prefer direct measurements over derived values.
+  - Keep metric names stable across runs (snake_case, descriptive).
+  - One metric per measurement — do not pack multiple values into one row.
+- `## Storage` — `wiki/metrics/{agent}/{domain}/{YYYY}.csv`. Agent matches
+  profile name. Domain matches skill domain slug (e.g., `audit`, `triage`,
+  `release-readiness`). Partitioned by year. First line of each new file is the
+  header row.
+- `## CSV Format` — Brief pointer: see `references/csv-schema.md` for field
+  definitions, types, and appending rules.
+- `## Process Behavior Charts` — Brief pointer: see
+  `references/control-charts.md` for XmR chart guidance.
+
+### 2. Create csv-schema.md
+
+Create `.claude/skills/kata-metrics/references/csv-schema.md` with:
+
+**Content (~60 lines):**
+
+- `# CSV Schema` heading
+- Long format, one row per data point. Six fields:
+
+  | Field  | Type          | Required | Example                          |
+  | ------ | ------------- | -------- | -------------------------------- |
+  | date   | ISO 8601 date | yes      | `2026-04-14`                     |
+  | metric | string        | yes      | `open_vulnerabilities`           |
+  | value  | number        | yes      | `3`                              |
+  | unit   | string        | yes      | `count`, `days`, `minutes`       |
+  | run    | string        | yes      | GitHub Actions run URL           |
+  | note   | string        | no       | Anomaly annotation (empty if ok) |
+
+- **Header row:** `date,metric,value,unit,run,note` — written as the first line
+  when creating a new file.
+- **Appending rules:**
+  - Always append — never rewrite or sort existing rows.
+  - One row per metric per run. If recording three metrics, append three rows.
+  - Empty `note` field: leave empty (not null, not "none"), resulting in a
+    trailing comma.
+  - Quote fields containing commas using double quotes.
+- **Example:**
+  ```csv
+  date,metric,value,unit,run,note
+  2026-04-14,open_vulnerabilities,3,count,https://github.com/forwardimpact/monorepo/actions/runs/12345,
+  2026-04-14,days_since_topic_audit,7,days,https://github.com/forwardimpact/monorepo/actions/runs/12345,
+  2026-04-15,open_vulnerabilities,2,count,https://github.com/forwardimpact/monorepo/actions/runs/12400,resolved CVE-2026-1234
+  ```
+
+### 3. Create control-charts.md
+
+Create `.claude/skills/kata-metrics/references/control-charts.md` with:
+
+**Content (~80 lines):**
+
+- `# Process Behavior Charts (XmR)` heading
+- Brief introduction: XmR (individuals and moving range) charts are the standard
+  tool for distinguishing stable processes from those reacting to special
+  causes. They use the data itself to compute natural process limits — no
+  external targets needed.
+- `## Construction`:
+  1. **X chart (individuals):** Plot each measurement value in time order.
+     Compute the average (X̄) as the central line.
+  2. **mR chart (moving range):** Compute the absolute difference between
+     consecutive measurements. Compute the average moving range (m̄R).
+  3. **Natural Process Limits (NPL):** Upper NPL = X̄ + 2.66 × m̄R. Lower NPL = X̄
+     − 2.66 × m̄R (or 0 if negative for counts).
+  4. **Plot.** X chart with X̄ and NPLs. mR chart with m̄R and Upper Range Limit
+     (URL = 3.27 × m̄R).
+- `## Reading the chart`:
+  - **Within limits, no patterns** → stable/predictable process. Variation is
+    routine. Do not react to individual points.
+  - **Point outside NPL** → signal (special cause). Investigate what changed.
+  - **Run of 8+ on same side of central line** → signal. Process has shifted.
+  - **Trend of 6+ consecutive increases or decreases** → signal.
+- `## Guidance for agents`:
+  - Build charts mentally or in markdown tables when reviewing metrics during
+    storyboard meetings.
+  - Minimum 10-15 data points before computing meaningful limits.
+  - When a signal appears, annotate the CSV `note` field with what you discover.
+  - Do not set targets based on NPLs — they describe what the process _does_,
+    not what it _should_ do. Target conditions come from the storyboard.
+
+## Verification
+
+1. `bun run check` passes (prettier formatting).
+2. All three files exist at the specified paths.
+3. SKILL.md is under 100 lines (well within the ~200 line budget).
+4. csv-schema.md and control-charts.md are self-contained references.

--- a/specs/460-daily-team-meeting/plan-a-02.md
+++ b/specs/460-daily-team-meeting/plan-a-02.md
@@ -1,0 +1,229 @@
+# Plan 460-A Part 02 — kata-storyboard Entry-Point Skill
+
+## Scope
+
+Create the coaching protocol entry-point skill. Three new files, no
+modifications. Note: the spec lists `references/storyboard-template.md` as the
+only reference file. This plan adds `references/coaching-protocol.md` to keep
+SKILL.md under the ~200 line budget — the five-question protocol details are
+substantial enough to warrant extraction into a reference file, following the
+KATA.md § Skill structure pattern.
+
+## Files
+
+| Action | Path                                                               |
+| ------ | ------------------------------------------------------------------ |
+| Create | `.claude/skills/kata-storyboard/SKILL.md`                          |
+| Create | `.claude/skills/kata-storyboard/references/storyboard-template.md` |
+| Create | `.claude/skills/kata-storyboard/references/coaching-protocol.md`   |
+
+## Steps
+
+### 1. Create SKILL.md
+
+Create `.claude/skills/kata-storyboard/SKILL.md` with:
+
+**Frontmatter:**
+
+```yaml
+---
+name: kata-storyboard
+description: >
+  Toyota Kata coaching protocol for team storyboard meetings and 1-on-1
+  coaching sessions. The improvement coach facilitates; domain agents
+  participate. Same five coaching kata questions in both contexts.
+---
+```
+
+**Content (~150 lines):**
+
+- `# Kata Storyboard` heading
+- Brief introduction: entry-point skill used by the improvement coach in two
+  contexts — team storyboard meetings (5 domain agents) and 1-on-1 coaching
+  sessions (1 domain agent analyzing its own trace). Both use the same five
+  coaching kata questions.
+- `## When to Use` — Your Assess section routed you to a coaching context: team
+  storyboard meeting or 1-on-1 coaching session.
+
+- `## Checklists`
+
+  `<read_do_checklist goal="Prepare for the coaching session">`:
+  - Read the current month's storyboard (`wiki/storyboard-YYYY-MNN.md`). If none
+    exists, this is a planning meeting.
+  - Identify which metrics CSVs to review from `wiki/metrics/`.
+  - For 1-on-1: identify the agent's most recent trace for analysis.
+
+  `<do_confirm_checklist goal="Verify coaching session quality">`:
+  - All five coaching kata questions were addressed.
+  - Current condition updated with numbers from metrics CSVs (not narrative).
+  - For team meetings: storyboard file updated and committed.
+  - For 1-on-1: agent's findings written to its own memory.
+  - Experiment expected outcome recorded _before_ the experiment runs.
+
+- `## Storyboard Artifact` — Brief description: monthly file at
+  `wiki/storyboard-YYYY-MNN.md` with five sections (Challenge, Target Condition,
+  Current Condition, Obstacles, Experiments). Full template at
+  `references/storyboard-template.md`.
+
+- `## Meeting Modes`
+
+  Three modes, all using the five coaching kata questions:
+
+  **Planning meeting** — first meeting of the month or no storyboard exists.
+  Create the storyboard. Lead the team through: establishing/confirming the
+  Challenge, setting the Target Condition (measurable, by month end), measuring
+  the Current Condition from metrics CSVs, identifying initial Obstacles, and
+  planning the first Experiment.
+
+  **Review meeting** — all other team meetings. Walk through the five questions
+  (see `references/coaching-protocol.md`), update Current Condition with fresh
+  metrics, record experiment outcomes (actual vs. expected), update Obstacles,
+  and plan the next experiment.
+
+  **1-on-1 coaching** — coach facilitates, one domain agent participates. The
+  agent runs `kata-trace` on its own recent trace during the session. The five
+  questions guide the agent's reflection: what were you trying to achieve? What
+  actually happened (measured)? What obstacles did you encounter? What will you
+  try next? When will you know?
+
+- `## Process`
+  1. **Read the storyboard.** Load `wiki/storyboard-YYYY-MNN.md`. If it does not
+     exist, this is a planning meeting — create it from
+     `references/storyboard-template.md`.
+  2. **Gather metrics.** Read relevant CSVs from `wiki/metrics/` for each
+     participating agent's domain.
+  3. **Run the five questions.** Follow `references/coaching-protocol.md` for
+     the appropriate mode.
+  4. **Update the storyboard.** Write updated Current Condition, Obstacles, and
+     Experiments sections back to the storyboard file.
+  5. **Commit.** Commit storyboard changes as part of the wiki push.
+
+- `## Memory: what to record`
+
+  Append to the current week's log (see agent profile for the file path):
+  - **Meeting type** — Planning, review, or 1-on-1 (with which agent)
+  - **Current condition** — Key numbers from metrics CSVs reviewed
+  - **Obstacle addressed** — Which obstacle was the focus
+  - **Experiment status** — Outcome of prior experiment, next experiment planned
+  - **Metrics** — Record relevant measurements to
+    `wiki/metrics/{agent}/{domain}/` per the `kata-metrics` protocol
+
+### 2. Create storyboard-template.md
+
+Create `.claude/skills/kata-storyboard/references/storyboard-template.md` with:
+
+**Content (~50 lines):**
+
+```markdown
+# Storyboard — YYYY Month
+
+## Challenge
+
+_The long-term direction that gives meaning to target conditions and
+experiments. Changes rarely — only when strategic direction shifts._
+
+> [Write the challenge here. One or two sentences describing the team's
+> long-term direction.]
+
+## Target Condition
+
+_The measurable state the team aims to reach by the end of this month. Not a
+task list — a description of how the system will behave differently, expressed
+in terms verifiable with data from metrics CSVs._
+
+> [Write the target condition here. Include specific metrics and thresholds.]
+
+**Due:** YYYY-MM-DD (end of month)
+
+## Current Condition
+
+_The measured state as of the last storyboard review. Updated daily using data
+from wiki/metrics/. Always numbers, not narratives._
+
+| Agent | Domain | Key metric | Value | Trend |
+| ----- | ------ | ---------- | ----- | ----- |
+|       |        |            |       |       |
+
+**Last updated:** YYYY-MM-DD
+
+## Obstacles
+
+_What stands between the current condition and the target condition. Discovered
+through experiments, not predicted upfront._
+
+- **Current obstacle →** [describe]
+- [other known obstacles]
+
+## Experiments
+
+_PDSA cycles run against the current obstacle. Record expected outcome before
+running, actual outcome after._
+
+### Experiment N
+
+- **Obstacle:** [which obstacle this addresses]
+- **What:** [description of the experiment]
+- **Expected outcome:** [what you predict will happen — record before running]
+- **Actual outcome:** [what actually happened — record after running]
+- **What did we learn?** [gap between expected and actual]
+- **Next step:** [continue, pivot, or new experiment]
+```
+
+### 3. Create coaching-protocol.md
+
+Create `.claude/skills/kata-storyboard/references/coaching-protocol.md` with:
+
+**Content (~70 lines):**
+
+- `# The Five Coaching Kata Questions` heading
+- Introduction: these questions structure every coaching interaction — team
+  meetings and 1-on-1 sessions. The coach asks, the learner(s) reflect.
+
+- **Question 1: What is the target condition?**
+  - Facilitator reads the target condition from the storyboard.
+  - Grounds the conversation in where the team is headed.
+  - If the target condition is unclear or expired, update it (planning mode).
+
+- **Question 2: What is the actual condition now?**
+  - Each agent (or the single agent in 1-on-1) reports measured data from their
+    domain's metrics CSVs.
+  - The facilitator updates the Current Condition section with fresh numbers.
+  - Use counts and durations — not narratives like "improving" or "stable."
+  - Reference specific CSV files: `wiki/metrics/{agent}/{domain}/{YYYY}.csv`.
+
+- **Question 3: What obstacles are preventing us from reaching the target
+  condition?**
+  - Agents identify obstacles from their domain based on the gap between current
+    and target condition.
+  - Obstacles are discovered through data and experiments, not hypothesized
+    upfront.
+  - The facilitator updates the Obstacles list and marks which obstacle the team
+    is currently addressing.
+
+- **Question 4: What is the next step? What do you expect?**
+  - For the obstacle currently being addressed, agents propose their next
+    experiment.
+  - The expected outcome is recorded _before_ the experiment runs.
+  - Experiments should be small and testable within one or two daily cycles.
+
+- **Question 5: When can we see what we learned from that step?**
+  - Establish when the experiment's results will be visible.
+  - Typically: next meeting, end of week, or after a specific workflow run.
+  - This creates the feedback loop — the next meeting opens by reviewing what
+    was learned.
+
+- `## 1-on-1 Coaching Adaptation`
+  - The same five questions apply but scoped to the individual agent's trace.
+  - Q1: What were you trying to achieve in this run?
+  - Q2: What actually happened? (agent runs `kata-trace` on its own trace)
+  - Q3: What obstacles prevented better outcomes?
+  - Q4: What will you do differently next run?
+  - Q5: When will you see the effect? (next scheduled run)
+
+## Verification
+
+1. `bun run check` passes (prettier formatting).
+2. All three files exist at the specified paths.
+3. SKILL.md is under 160 lines.
+4. Template is self-contained with placeholder markers.
+5. Protocol reference covers all five questions for both team and 1-on-1 modes.

--- a/specs/460-daily-team-meeting/plan-a-02.md
+++ b/specs/460-daily-team-meeting/plan-a-02.md
@@ -105,8 +105,11 @@ description: >
   - **Current condition** — Key numbers from metrics CSVs reviewed
   - **Obstacle addressed** — Which obstacle was the focus
   - **Experiment status** — Outcome of prior experiment, next experiment planned
-  - **Metrics** — Record relevant measurements to
-    `wiki/metrics/{agent}/{domain}/` per the `kata-metrics` protocol
+  - **Metrics** — Record coaching-specific measurements (e.g.,
+    `meetings_facilitated`, `experiments_active`) to
+    `wiki/metrics/improvement-coach/coaching/` per the `kata-metrics` protocol.
+    The coach records coaching activity metrics, not domain metrics — domain
+    agents record their own domain metrics via their own entry-point skills.
 
 ### 2. Create storyboard-template.md
 

--- a/specs/460-daily-team-meeting/plan-a-03.md
+++ b/specs/460-daily-team-meeting/plan-a-03.md
@@ -138,11 +138,11 @@ sources):
 
 **kata-trace** (`references/metrics.md`):
 
-| Metric              | Unit  | Description                                 | Data source     |
-| ------------------- | ----- | ------------------------------------------- | --------------- |
-| traces_analyzed     | count | Workflow traces analyzed this run           | Run actions     |
-| findings_per_trace  | count | Actionable findings from the analyzed trace | Analysis        |
-| invariant_pass_rate | count | Invariants that passed out of total checked | Invariant audit |
+| Metric             | Unit  | Description                                 | Data source     |
+| ------------------ | ----- | ------------------------------------------- | --------------- |
+| traces_analyzed    | count | Workflow traces analyzed this run           | Run actions     |
+| findings_per_trace | count | Actionable findings from the analyzed trace | Analysis        |
+| invariants_passed  | count | Invariants that passed this run             | Invariant audit |
 
 **kata-spec** (`references/metrics.md`):
 

--- a/specs/460-daily-team-meeting/plan-a-03.md
+++ b/specs/460-daily-team-meeting/plan-a-03.md
@@ -1,0 +1,244 @@
+# Plan 460-A Part 03 — Skill Integration (14 Entry-Point Skills)
+
+## Scope
+
+Add `references/metrics.md` and a metrics recording bullet to all 14 entry-point
+kata skills. 14 new files created, 14 existing files modified.
+
+## Files
+
+| Action | Path                                                           |
+| ------ | -------------------------------------------------------------- |
+| Create | `.claude/skills/kata-security-audit/references/metrics.md`     |
+| Create | `.claude/skills/kata-security-update/references/metrics.md`    |
+| Create | `.claude/skills/kata-release-readiness/references/metrics.md`  |
+| Create | `.claude/skills/kata-release-review/references/metrics.md`     |
+| Create | `.claude/skills/kata-product-triage/references/metrics.md`     |
+| Create | `.claude/skills/kata-product-classify/references/metrics.md`   |
+| Create | `.claude/skills/kata-product-evaluation/references/metrics.md` |
+| Create | `.claude/skills/kata-documentation/references/metrics.md`      |
+| Create | `.claude/skills/kata-wiki-curate/references/metrics.md`        |
+| Create | `.claude/skills/kata-trace/references/metrics.md`              |
+| Create | `.claude/skills/kata-spec/references/metrics.md`               |
+| Create | `.claude/skills/kata-design/references/metrics.md`             |
+| Create | `.claude/skills/kata-plan/references/metrics.md`               |
+| Create | `.claude/skills/kata-implement/references/metrics.md`          |
+| Modify | `.claude/skills/kata-security-audit/SKILL.md`                  |
+| Modify | `.claude/skills/kata-security-update/SKILL.md`                 |
+| Modify | `.claude/skills/kata-release-readiness/SKILL.md`               |
+| Modify | `.claude/skills/kata-release-review/SKILL.md`                  |
+| Modify | `.claude/skills/kata-product-triage/SKILL.md`                  |
+| Modify | `.claude/skills/kata-product-classify/SKILL.md`                |
+| Modify | `.claude/skills/kata-product-evaluation/SKILL.md`              |
+| Modify | `.claude/skills/kata-documentation/SKILL.md`                   |
+| Modify | `.claude/skills/kata-wiki-curate/SKILL.md`                     |
+| Modify | `.claude/skills/kata-trace/SKILL.md`                           |
+| Modify | `.claude/skills/kata-spec/SKILL.md`                            |
+| Modify | `.claude/skills/kata-design/SKILL.md`                          |
+| Modify | `.claude/skills/kata-plan/SKILL.md`                            |
+| Modify | `.claude/skills/kata-implement/SKILL.md`                       |
+
+## Steps
+
+### 1. Create 14 metrics.md reference files
+
+Each `references/metrics.md` follows the same structure (~20 lines each):
+
+```markdown
+# Metrics — {Skill Domain}
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric | Unit | Description | Data source |
+| ------ | ---- | ----------- | ----------- |
+| ...    | ...  | ...         | ...         |
+```
+
+Create the `references/` directory for skills that lack one (9 of 14). Skills
+that already have a `references/` directory (kata-security-update,
+kata-product-triage, kata-product-classify, kata-documentation, kata-trace)
+already have the directory — just add `metrics.md`.
+
+**Metric suggestions per skill** (from the spec's table, fleshed out with data
+sources):
+
+**kata-security-audit** (`references/metrics.md`):
+
+| Metric                 | Unit  | Description                                   | Data source          |
+| ---------------------- | ----- | --------------------------------------------- | -------------------- |
+| open_vulnerabilities   | count | Unresolved vulnerabilities at run end         | npm audit, gh alerts |
+| days_since_topic_audit | days  | Days since this audit topic was last reviewed | Coverage map in wiki |
+| findings_count         | count | New findings identified this run              | Audit report         |
+
+**kata-security-update** (`references/metrics.md`):
+
+| Metric                | Unit  | Description                               | Data source       |
+| --------------------- | ----- | ----------------------------------------- | ----------------- |
+| dependabot_pr_backlog | count | Open Dependabot PRs at run end            | gh pr list        |
+| time_to_resolve       | days  | Days oldest open Dependabot PR has waited | gh pr list        |
+| prs_merged            | count | PRs successfully merged this run          | Run actions taken |
+
+**kata-release-readiness** (`references/metrics.md`):
+
+| Metric                  | Unit  | Description                              | Data source |
+| ----------------------- | ----- | ---------------------------------------- | ----------- |
+| prs_waiting             | count | PRs awaiting rebase or CI fix at run end | gh pr list  |
+| consecutive_stuck_count | count | PRs stuck across multiple runs           | Wiki log    |
+| rebase_failures         | count | Rebases that failed this run             | Run actions |
+
+**kata-release-review** (`references/metrics.md`):
+
+| Metric             | Unit  | Description                              | Data source     |
+| ------------------ | ----- | ---------------------------------------- | --------------- |
+| unreleased_changes | count | Commits on main since last release       | git log         |
+| days_since_release | days  | Days since most recent release tag       | gh release list |
+| publish_failures   | count | Publish workflow failures since last run | gh run list     |
+
+**kata-product-triage** (`references/metrics.md`):
+
+| Metric                | Unit  | Description                        | Data source   |
+| --------------------- | ----- | ---------------------------------- | ------------- |
+| open_issues           | count | Open issues at run end             | gh issue list |
+| issues_triaged        | count | Issues triaged this run            | Run actions   |
+| spec_conversion_count | count | Issues converted to specs this run | Run actions   |
+
+**kata-product-classify** (`references/metrics.md`):
+
+| Metric           | Unit  | Description                         | Data source    |
+| ---------------- | ----- | ----------------------------------- | -------------- |
+| open_prs         | count | Open PRs at run end                 | gh pr list     |
+| prs_merged       | count | PRs merged this run                 | Run actions    |
+| blocked_pr_count | count | PRs blocked by CI or trust failures | Classification |
+
+**kata-product-evaluation** (`references/metrics.md`):
+
+| Metric                | Unit  | Description                              | Data source   |
+| --------------------- | ----- | ---------------------------------------- | ------------- |
+| friction_points_found | count | User friction points identified this run | Evaluation    |
+| tasks_completed       | count | Evaluation tasks completed               | Evaluation    |
+| issues_created        | count | GitHub issues created from findings      | gh issue list |
+
+**kata-documentation** (`references/metrics.md`):
+
+| Metric            | Unit  | Description                             | Data source  |
+| ----------------- | ----- | --------------------------------------- | ------------ |
+| pages_reviewed    | count | Documentation pages reviewed this run   | Run actions  |
+| accuracy_errors   | count | Factual errors found                    | Review       |
+| days_since_review | days  | Days since this topic was last reviewed | Coverage map |
+
+**kata-wiki-curate** (`references/metrics.md`):
+
+| Metric              | Unit  | Description                             | Data source |
+| ------------------- | ----- | --------------------------------------- | ----------- |
+| stale_observations  | count | Teammate observations older than 7 days | Wiki scan   |
+| summary_corrections | count | Summary inaccuracies corrected this run | Run actions |
+| log_hygiene_issues  | count | Weekly log format issues found          | Wiki scan   |
+
+**kata-trace** (`references/metrics.md`):
+
+| Metric              | Unit  | Description                                 | Data source     |
+| ------------------- | ----- | ------------------------------------------- | --------------- |
+| traces_analyzed     | count | Workflow traces analyzed this run           | Run actions     |
+| findings_per_trace  | count | Actionable findings from the analyzed trace | Analysis        |
+| invariant_pass_rate | count | Invariants that passed out of total checked | Invariant audit |
+
+**kata-spec** (`references/metrics.md`):
+
+| Metric           | Unit  | Description                           | Data source  |
+| ---------------- | ----- | ------------------------------------- | ------------ |
+| specs_in_backlog | count | Specs at `spec draft` in STATUS       | specs/STATUS |
+| days_in_draft    | days  | Days the oldest draft spec has waited | Git log      |
+
+**kata-design** (`references/metrics.md`):
+
+| Metric             | Unit  | Description                              | Data source  |
+| ------------------ | ----- | ---------------------------------------- | ------------ |
+| designs_in_backlog | count | Specs at `spec approved` awaiting design | specs/STATUS |
+| days_in_draft      | days  | Days the oldest design draft has waited  | Git log      |
+
+**kata-plan** (`references/metrics.md`):
+
+| Metric           | Unit  | Description                              | Data source  |
+| ---------------- | ----- | ---------------------------------------- | ------------ |
+| plans_in_backlog | count | Specs at `design approved` awaiting plan | specs/STATUS |
+| days_in_draft    | days  | Days the oldest plan draft has waited    | Git log      |
+
+**kata-implement** (`references/metrics.md`):
+
+| Metric               | Unit  | Description                       | Data source |
+| -------------------- | ----- | --------------------------------- | ----------- |
+| steps_completed      | count | Plan steps completed this run     | Run actions |
+| blockers_encountered | count | Plan deviations or blockers hit   | Run actions |
+| plan_deviation_count | count | Steps that diverged from the plan | Run actions |
+
+### 2. Add metrics recording bullet to 13 existing Memory sections
+
+For the 13 skills that already have `## Memory: what to record`, add one bullet
+at the end of the existing bullet list. Use identical wording across all 13:
+
+```markdown
+- **Metrics** — Record relevant measurements to
+  `wiki/metrics/{agent}/{domain}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol
+```
+
+**Exact insertion points** (add after the last existing bullet, before the next
+`##` heading or end of file):
+
+| Skill                   | Insert after line containing                            |
+| ----------------------- | ------------------------------------------------------- |
+| kata-security-audit     | `- Policy violations found and whether fixed or spec'd` |
+| kata-security-update    | `- **Reverted merges**`                                 |
+| kata-release-readiness  | `- **Releases cut**`                                    |
+| kata-release-review     | `- **Main branch CI state**`                            |
+| kata-product-triage     | `- **Hand-offs**`                                       |
+| kata-product-classify   | `- **Merge failures**`                                  |
+| kata-product-evaluation | `- **Issues created/updated**`                          |
+| kata-documentation      | `- **Observations for teammates**`                      |
+| kata-wiki-curate        | `- **Observations for teammates**`                      |
+| kata-trace              | `- **Observations for teammates**`                      |
+| kata-design             | `- **Deferred specs**`                                  |
+| kata-plan               | `- **Deferred specs**`                                  |
+| kata-implement          | `- **Deferred specs**`                                  |
+
+**Important:** Verify the exact last bullet text by reading each file before
+editing. The table above is based on current codebase state — confirm before
+applying. If the expected last bullet is not found (file was modified between
+plan writing and implementation), locate the `## Memory: what to record` section
+and append the metrics bullet as the last item in that section's bullet list.
+
+### 3. Add Memory section to kata-spec
+
+`kata-spec` is the only entry-point skill without a "Memory: what to record"
+section. Add a new section before the existing `## What NOT to Do` heading:
+
+```markdown
+## Memory: what to record
+
+Append to the current week's log (see agent profile for the file path):
+
+- **Specs written** — Spec number, name, and status
+- **Review results** — Specs reviewed and disposition (approved/changes needed)
+- **Deferred work** — Findings not yet captured as specs
+- **Metrics** — Record relevant measurements to
+  `wiki/metrics/{agent}/{domain}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol
+```
+
+Insert this before:
+
+```markdown
+## What NOT to Do
+```
+
+at line 126 of the current `kata-spec/SKILL.md`.
+
+## Verification
+
+1. `bun run check` passes.
+2. All 14 `references/metrics.md` files exist with 3–5 metrics each.
+3. All 14 `SKILL.md` files have a `## Memory: what to record` section containing
+   the metrics bullet with identical wording.
+4. No other changes to any SKILL.md content (only the metrics bullet addition).

--- a/specs/460-daily-team-meeting/plan-a-04.md
+++ b/specs/460-daily-team-meeting/plan-a-04.md
@@ -1,0 +1,566 @@
+# Plan 460-A Part 04 — Profiles, Workflows, Documentation
+
+## Scope
+
+Restructure the improvement coach profile, add Assess step 0 and `kata-trace` to
+five domain profiles, extend `kata-action` for facilitate mode, create two new
+workflows, and update KATA.md and wiki/MEMORY.md.
+
+## Files
+
+| Action | Path                                           |
+| ------ | ---------------------------------------------- |
+| Modify | `.claude/agents/improvement-coach.md`          |
+| Modify | `.claude/agents/security-engineer.md`          |
+| Modify | `.claude/agents/technical-writer.md`           |
+| Modify | `.claude/agents/product-manager.md`            |
+| Modify | `.claude/agents/staff-engineer.md`             |
+| Modify | `.claude/agents/release-engineer.md`           |
+| Modify | `.github/actions/kata-action/action.yml`       |
+| Modify | `libraries/libeval/src/commands/facilitate.js` |
+| Create | `.github/workflows/daily-meeting.yml`          |
+| Create | `.github/workflows/coaching-session.yml`       |
+| Modify | `KATA.md`                                      |
+| Modify | `wiki/MEMORY.md`                               |
+
+## Steps
+
+### 1. Restructure improvement-coach.md
+
+**Before (frontmatter skills):**
+
+```yaml
+skills:
+  - kata-trace
+  - kata-spec
+  - kata-review
+  - kata-gh-cli
+```
+
+**After (frontmatter skills):**
+
+```yaml
+skills:
+  - kata-storyboard
+  - kata-metrics
+  - kata-spec
+  - kata-review
+  - kata-gh-cli
+```
+
+**Before (description):**
+
+```
+Continuous improvement coach. Deep-analyzes a single trace from an agent
+workflow run, identifies process failures and improvement opportunities,
+and either fixes them directly or writes specs for larger changes.
+```
+
+**After (description):**
+
+```
+Continuous improvement coach. Facilitates team storyboard meetings and
+1-on-1 coaching sessions using the Toyota Kata five-question protocol.
+Writes specs for structural improvements found through coaching.
+```
+
+**Before (body intro):**
+
+```
+You are the improvement coach. Go and see the work done by agent workflow runs,
+identify process failures, and drive improvements into the codebase.
+
+Each cycle focuses on **one trace**. Depth over breadth.
+```
+
+**After (body intro):**
+
+```
+You are the improvement coach. Facilitate storyboard meetings and 1-on-1
+coaching sessions using the Toyota Kata five-question protocol. Help domain
+agents grasp their current condition, identify obstacles, and design
+experiments.
+
+Each coaching context focuses on measured conditions. Numbers over narratives.
+```
+
+**Before (Assess section):**
+
+```
+1. **Recent workflow traces not yet analyzed?** ...
+2. **Unaddressed findings from prior trace analyses?** ...
+3. **Nothing actionable?** ...
+```
+
+**After (Assess section):**
+
+```
+Survey domain state, then choose the highest-priority action:
+
+1. **Agent due for 1-on-1 coaching?** — Facilitate a coaching session
+   (`kata-storyboard`; check: select the domain agent whose last coaching session
+   is oldest or who has the most unanalyzed traces; trigger the coaching-session
+   workflow with the agent name)
+2. **Unaddressed findings from prior coaching sessions?** — Act on findings
+   (check: previous findings in `wiki/improvement-coach.md`; trivial fix —
+   `fix/coach-<name>` branch from `main`, improvement — spec via `kata-spec` on
+   `spec/<name>` branch from `main`)
+3. **Nothing actionable?** — Report clean state
+
+Note: team storyboard meetings are handled by the daily-meeting workflow
+(03:00 UTC), not by this agent's scheduled run. This agent's run focuses on
+1-on-1 coaching and acting on prior findings.
+
+After choosing, follow the selected skill's full procedure. Every PR must branch
+directly from `main`.
+```
+
+**Constraints section:** Keep existing content. Add one bullet:
+
+```
+- Coaching only — you ask the five questions, you do not analyze traces yourself.
+  Domain agents run `kata-trace` during 1-on-1 coaching sessions.
+```
+
+### 2. Add Assess step 0 and kata-trace to five domain profiles
+
+For each of the five domain profiles, make two changes:
+
+**a) Add `kata-trace` to the frontmatter skills list.**
+
+Insert `kata-trace` at the end of the existing skills list (before any `libs-*`
+skills if present). For each profile:
+
+| Profile           | Insert after                   |
+| ----------------- | ------------------------------ |
+| security-engineer | `kata-review`                  |
+| technical-writer  | `kata-review`                  |
+| product-manager   | `kata-gh-cli`                  |
+| staff-engineer    | `kata-gh-cli` (before libs-\*) |
+| release-engineer  | `kata-gh-cli`                  |
+
+**b) Add Assess step 0 before the existing numbered list.**
+
+Insert the following text after the "Survey domain state, then choose the
+highest-priority action:" line, before the existing step 1:
+
+```markdown
+0. **Read the storyboard.** Check `wiki/storyboard-YYYY-MNN.md` for this month.
+   If it exists, review the target condition and current obstacle. Weight
+   priority assessment toward actions that advance the target condition. If no
+   storyboard exists, proceed with your standard priority framework. Urgency
+   always overrides storyboard alignment.
+```
+
+The existing steps (1, 2, 3, ...) remain numbered as-is — step 0 precedes them.
+
+### 3. Relax facilitate minimum agents validation
+
+Modify `libraries/libeval/src/commands/facilitate.js` line 52:
+
+**Before:**
+
+```js
+if (agentConfigs.length < 2)
+  throw new Error("--agents must specify at least two agents");
+```
+
+**After:**
+
+```js
+if (agentConfigs.length < 1)
+  throw new Error("--agents must specify at least one agent");
+```
+
+This allows 1-on-1 coaching sessions (1 agent + facilitator). The facilitator is
+always a separate session from agents, so 1 agent is a valid configuration.
+
+### 4. Extend kata-action for facilitate mode
+
+Modify `.github/actions/kata-action/action.yml`:
+
+**a) Update mode input description (line 12):**
+
+Before: `Execution mode — "run" (single agent) or "supervise"`
+
+After: `Execution mode — "run", "supervise", or "facilitate"`
+
+**b) Add two new inputs after `agent-profile` (after line 49):**
+
+```yaml
+  facilitator-profile:
+    description:
+      Facilitator profile name (passed as --facilitator-profile, facilitate mode
+      only)
+    required: false
+  agents:
+    description:
+      Comma-separated agent configs for facilitate mode (format
+      "name1:role=x,name2:role=y")
+    required: false
+```
+
+**c) Add facilitate branch in the "Run fit-eval" step (after the supervise
+branch, before the `else` for run mode).**
+
+The shell script currently has:
+
+```bash
+if [ "$MODE" = "supervise" ]; then
+  ...
+else
+  ...
+fi
+```
+
+Change to:
+
+```bash
+if [ "$MODE" = "supervise" ]; then
+  ...
+elif [ "$MODE" = "facilitate" ]; then
+  if [ -n "$FACILITATOR_PROFILE" ]; then
+    args+=("--facilitator-profile=$FACILITATOR_PROFILE")
+  fi
+
+  if [ "$MAX_TURNS" != "0" ]; then
+    args+=("--max-turns=$MAX_TURNS")
+  fi
+
+  bunx fit-eval facilitate \
+    --facilitator-cwd="." \
+    --agents="$AGENTS" \
+    --model="$MODEL" \
+    "${args[@]}"
+
+  # Note: facilitate mode does not accept --allowed-tools at the CLI level.
+  # Tool permissions are controlled per-agent via the agent config string
+  # (e.g., "name:allowedTools=Bash,Read"). The default allowed tools from
+  # AgentRunner apply when not specified per-agent.
+else
+  ...
+fi
+```
+
+Add new env vars to the step's `env:` block:
+
+```yaml
+FACILITATOR_PROFILE: ${{ inputs.facilitator-profile }}
+AGENTS: ${{ inputs.agents }}
+```
+
+**d) Update trace split step.**
+
+The current split step (line 168-181) only handles supervise mode. Add a
+parallel step for facilitate mode that extracts per-participant traces:
+
+```yaml
+- name: Split facilitated trace
+  if:
+    always() && inputs.trace == 'true' && inputs.mode == 'facilitate' &&
+    steps.setup.outputs.trace-dir != ''
+  shell: bash
+  env:
+    TRACE_DIR: ${{ steps.setup.outputs.trace-dir }}
+  run: |
+    # Extract facilitator events
+    jq -c 'select(.source == "facilitator") | .event' "$TRACE_DIR/trace.ndjson" \
+      > "$TRACE_DIR/facilitator-trace.ndjson"
+    # Extract per-agent traces (one file per unique source that is not facilitator)
+    # This enables each domain agent to analyze its own trace via kata-trace
+    for agent in $(jq -r 'select(.source != "facilitator") | .source' "$TRACE_DIR/trace.ndjson" | sort -u); do
+      jq -c "select(.source == \"$agent\") | .event" "$TRACE_DIR/trace.ndjson" \
+        > "$TRACE_DIR/${agent}-trace.ndjson"
+    done
+    # Also produce a combined agent trace for the agent-trace artifact
+    jq -c 'select(.source != "facilitator") | .event' "$TRACE_DIR/trace.ndjson" \
+      > "$TRACE_DIR/agent-trace.ndjson"
+```
+
+**e) Update artifact upload conditions.**
+
+The existing "Upload agent trace" step (line 183-191) uses a conditional path
+expression. Update the condition to also handle facilitate mode. The existing
+path expression already resolves correctly for facilitate mode because it checks
+`supervise` first and falls through to the raw trace for `run`. Simplify by
+adding facilitate alongside supervise:
+
+```yaml
+path: |
+  ${{ (inputs.mode == 'supervise' || inputs.mode == 'facilitate') && format('{0}/agent-trace.ndjson', steps.setup.outputs.trace-dir) || format('{0}/trace.ndjson', steps.setup.outputs.trace-dir) }}
+```
+
+Add a "Upload facilitator trace" step (parallel to "Upload supervisor trace"):
+
+```yaml
+- name: Upload facilitator trace
+  if:
+    always() && inputs.trace == 'true' && inputs.mode == 'facilitate' &&
+    steps.setup.outputs.trace-dir != ''
+  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+  with:
+    name: facilitator-trace
+    path: ${{ steps.setup.outputs.trace-dir }}/facilitator-trace.ndjson
+```
+
+Also update the existing "Upload combined trace" step condition to include
+facilitate mode:
+
+```yaml
+if:
+  always() && inputs.trace == 'true' && (inputs.mode == 'supervise' ||
+  inputs.mode == 'facilitate') && steps.setup.outputs.trace-dir != ''
+```
+
+### 5. Create daily-meeting.yml
+
+Create `.github/workflows/daily-meeting.yml`. Note: facilitate mode workflows
+use `facilitator-profile` instead of `agent-profile`. The `agent-profile` input
+is only used in `run` and `supervise` modes. This is correct — facilitate mode
+identifies participants via the `agents` config string, not the `agent-profile`
+input.
+
+```yaml
+name: "Kata: Daily Meeting"
+
+on:
+  schedule:
+    # Daily at 03:00 UTC — before all individual agent workflows
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      task-amend:
+        description: "Additional text appended to the task prompt for steering"
+        required: false
+        type: string
+
+concurrency:
+  group: daily-meeting
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  kata:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.ci-app.outputs.token }}
+          submodules: true
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: Team Storyboard Meeting
+        uses: ./.github/actions/kata-action
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          mode: "facilitate"
+          task-text: >-
+            Facilitate the team storyboard meeting. Walk through the five
+            coaching kata questions with all participants. Update the storyboard
+            with fresh metrics and experiment progress.
+          facilitator-profile: "improvement-coach"
+          agents: "security-engineer:role=security-engineer,technical-writer:role=technical-writer,product-manager:role=product-manager,staff-engineer:role=staff-engineer,release-engineer:role=release-engineer"
+          model: "opus"
+          max-turns: "200"
+          task-amend: ${{ inputs.task-amend }}
+```
+
+### 6. Create coaching-session.yml
+
+Create `.github/workflows/coaching-session.yml`:
+
+```yaml
+name: "Kata: Coaching Session"
+
+on:
+  workflow_dispatch:
+    inputs:
+      agent:
+        description: "Agent name to coach (e.g., security-engineer)"
+        required: true
+        type: string
+      task-amend:
+        description: "Additional text appended to the task prompt for steering"
+        required: false
+        type: string
+
+concurrency:
+  group: coaching-session
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  kata:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.ci-app.outputs.token }}
+          submodules: true
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: 1-on-1 Coaching Session
+        uses: ./.github/actions/kata-action
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          mode: "facilitate"
+          task-text: >-
+            Facilitate a 1-on-1 coaching session with the participant agent.
+            Guide them through the five coaching kata questions. Have them
+            analyze their own most recent trace using kata-trace. Help them
+            identify obstacles and design their next experiment.
+          facilitator-profile: "improvement-coach"
+          agents: "${{ inputs.agent }}:role=${{ inputs.agent }}"
+          model: "opus"
+          max-turns: "200"
+          task-amend: ${{ inputs.task-amend }}
+```
+
+### 7. Update KATA.md
+
+**a) Update the Workflows section introduction (line 76–80).**
+
+Before:
+
+```
+Six scheduled workflows span 04-11 UTC, one per agent. Times respect ordering
+constraints ...
+```
+
+After:
+
+```
+Eight workflows: six individual agent runs spanning 04–11 UTC, one daily team
+meeting at 03:00 UTC, and one on-demand coaching session. Times respect ordering
+constraints (team meeting before individual runs, security before product,
+product before planning, planning before release, all producers before the
+improvement coach). ...
+```
+
+**b) Add rows to the Workflows table (line 83–90).**
+
+Insert two new rows at the top of the table (before security-engineer), since
+the daily meeting runs at 03:00 UTC (earliest):
+
+```markdown
+| **daily-meeting**     | Daily 03:00 UTC     | improvement-coach (facilitates 5 agents) |
+| **coaching-session**  | `workflow_dispatch`  | improvement-coach (facilitates 1 agent)  |
+```
+
+**c) Add a Metrics section after the Shared Memory section (after line 185).**
+
+```markdown
+## Metrics
+
+Agents record time-series data to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`
+after each run. The `kata-metrics` skill defines the CSV schema (six fields:
+date, metric, value, unit, run, note), storage convention, and metric design
+guidance. Each entry-point skill carries a `references/metrics.md` suggesting
+domain-specific metrics.
+
+Metrics serve the coaching cycle: the team storyboard meeting (see Workflows
+table) uses metric data to answer "what is the actual condition now?" with
+numbers rather than narratives. Process behavior charts (XmR) built from the
+time series distinguish stable processes from those reacting to special causes.
+```
+
+**d) Update Accountability section (line 196–201).**
+
+The existing text says "The improvement coach verifies named per-agent
+invariants against the actual trace on every trace analysis cycle." This is now
+inaccurate — domain agents run kata-trace on their own traces during 1-on-1
+coaching sessions. Rewrite the first sentence and add the new framing:
+
+**Before:**
+
+```
+Cross-agent accountability runs through the `kata-trace` skill's invariant
+audit. The improvement coach verifies named per-agent invariants against the
+actual trace on every trace analysis cycle — ...
+```
+
+**After:**
+
+```
+Cross-agent accountability runs through the `kata-trace` skill's invariant
+audit. Domain agents verify their own per-agent invariants against their own
+traces during 1-on-1 coaching sessions facilitated by the improvement coach —
+e.g., that the product manager ran a contributor lookup before marking any
+non-CI-app PR mergeable. ...
+```
+
+### 8. Update wiki/MEMORY.md
+
+Add two new entries to document the storyboard and metrics conventions.
+
+**a) Add Storyboard section after "Skill State Files" (after line 40):**
+
+```markdown
+## Storyboard
+
+Monthly storyboard artifact maintained by the improvement coach during team
+meetings:
+
+- `storyboard-YYYY-MNN.md` — where NN is the zero-padded month. Created during
+  the first meeting of each month. Updated daily during storyboard review
+  meetings. Contains: Challenge, Target Condition, Current Condition,
+  Obstacles, Experiments.
+```
+
+**b) Add Metrics section after the new Storyboard section:**
+
+```markdown
+## Metrics
+
+Time-series data recorded by agents after each run:
+
+- `metrics/{agent}/{domain}/{YYYY}.csv` — one CSV file per agent per domain
+  per year. Long format, one row per data point. Fields: date, metric, value,
+  unit, run, note. See `kata-metrics` skill for the full protocol.
+```
+
+## Verification
+
+1. `bun run check` passes.
+2. All six agent profiles have correct skill lists and Assess sections.
+3. The improvement coach no longer lists `kata-trace`; all five domain profiles
+   list it.
+4. kata-action supports `facilitate` mode with `facilitator-profile` and
+   `agents` inputs.
+5. Both new workflows exist and follow the established pattern (token
+   generation, checkout, bootstrap, kata-action).
+6. KATA.md workflows table includes all eight workflows.
+7. KATA.md has a Metrics section.
+8. wiki/MEMORY.md documents storyboard and metrics conventions.

--- a/specs/460-daily-team-meeting/plan-a-04.md
+++ b/specs/460-daily-team-meeting/plan-a-04.md
@@ -266,12 +266,16 @@ parallel step for facilitate mode that extracts per-participant traces:
     # Extract facilitator events
     jq -c 'select(.source == "facilitator") | .event' "$TRACE_DIR/trace.ndjson" \
       > "$TRACE_DIR/facilitator-trace.ndjson"
-    # Extract per-agent traces (one file per unique source that is not facilitator)
-    # This enables each domain agent to analyze its own trace via kata-trace
-    for agent in $(jq -r 'select(.source != "facilitator") | .source' "$TRACE_DIR/trace.ndjson" | sort -u); do
-      jq -c "select(.source == \"$agent\") | .event" "$TRACE_DIR/trace.ndjson" \
-        > "$TRACE_DIR/${agent}-trace.ndjson"
-    done
+    # Extract per-agent traces using jq --arg to avoid shell injection.
+    # Agent names come from trace .source fields which originate from
+    # workflow_dispatch input — sanitize by filtering to alphanumeric + hyphen.
+    jq -r 'select(.source != "facilitator") | .source' "$TRACE_DIR/trace.ndjson" \
+      | sort -u \
+      | grep -E '^[a-z][a-z0-9-]*$' \
+      | while IFS= read -r agent; do
+          jq -c --arg src "$agent" 'select(.source == $src) | .event' \
+            "$TRACE_DIR/trace.ndjson" > "$TRACE_DIR/${agent}-trace.ndjson"
+        done
     # Also produce a combined agent trace for the agent-trace artifact
     jq -c 'select(.source != "facilitator") | .event' "$TRACE_DIR/trace.ndjson" \
       > "$TRACE_DIR/agent-trace.ndjson"
@@ -301,6 +305,24 @@ Add a "Upload facilitator trace" step (parallel to "Upload supervisor trace"):
   with:
     name: facilitator-trace
     path: ${{ steps.setup.outputs.trace-dir }}/facilitator-trace.ndjson
+```
+
+Add an "Upload per-agent traces" step so domain agents can access their own
+trace during 1-on-1 coaching sessions:
+
+```yaml
+- name: Upload per-agent traces
+  if:
+    always() && inputs.trace == 'true' && inputs.mode == 'facilitate' &&
+    steps.setup.outputs.trace-dir != ''
+  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+  with:
+    name: per-agent-traces
+    path: |
+      ${{ steps.setup.outputs.trace-dir }}/*-trace.ndjson
+      !${{ steps.setup.outputs.trace-dir }}/facilitator-trace.ndjson
+      !${{ steps.setup.outputs.trace-dir }}/agent-trace.ndjson
+      !${{ steps.setup.outputs.trace-dir }}/trace.ndjson
 ```
 
 Also update the existing "Upload combined trace" step condition to include

--- a/specs/460-daily-team-meeting/plan-a.md
+++ b/specs/460-daily-team-meeting/plan-a.md
@@ -1,0 +1,112 @@
+# Plan 460-A — Kata Coaching System
+
+## Approach
+
+The spec introduces four interdependent additions: metrics infrastructure,
+coaching protocol, coach/learner role realignment, and holistic skill
+integration. The design decomposes these into six components. This plan
+sequences them into four independently-committable parts that respect
+dependencies while maximizing parallelism.
+
+**Sequencing rationale:** Metrics infrastructure (Part 01) must land first — the
+storyboard skill reads metrics CSVs, and skill integration adds metric recording
+steps referencing the kata-metrics protocol. Once Part 01 exists, Parts 02–04
+are independent of each other: the storyboard skill (Part 02) references
+kata-metrics but does not depend on the skill integration edits; the skill
+integration (Part 03) adds metrics.md references and memory bullets to 14
+skills; and the infrastructure changes (Part 04) wire workflows, profiles, and
+documentation.
+
+```
+Part 01: kata-metrics skill (utility)
+   ↓
+Part 02: kata-storyboard skill (coaching protocol)  ─┐
+Part 03: Skill integration (14 entry-point skills)   ├── independent after 01
+Part 04: Profiles, workflows, documentation          ─┘
+```
+
+Part 04 depends on Parts 02 and 03 conceptually (it wires the storyboard and
+metrics into profiles/workflows/docs), so it should run last. Parts 02 and 03
+can run concurrently after Part 01.
+
+## Cross-cutting concerns
+
+- **One code change.** This spec is almost entirely instructional content (.md,
+  .yml). The sole exception: `fit-eval facilitate` currently enforces `--agents`
+  must have at least 2 entries (`facilitate.js:52`), but the coaching-session
+  workflow needs 1-on-1 mode (1 agent + facilitator). Part 04 relaxes this
+  validation to `>= 1`. All other changes are skill files, agent profiles,
+  workflow YAML, and documentation. `bun run check` and `bun run test` must
+  pass.
+- **Formatting.** All markdown files must pass `bun run check` (prettier). Run
+  check before committing each part.
+- **SKILL.md line budget.** Per KATA.md § Skill structure, aim for ~200 lines or
+  fewer per SKILL.md. Supporting material goes into `references/`.
+- **Consistent wording.** Per KATA.md § Shared patterns, use identical phrasing
+  for the metrics recording bullet across all 14 skills.
+
+## Part index
+
+| Part | Summary                                      | Files | Depends on |
+| ---- | -------------------------------------------- | ----- | ---------- |
+| 01   | kata-metrics utility skill                   | 3     | —          |
+| 02   | kata-storyboard entry-point skill            | 3     | 01         |
+| 03   | Skill integration (14 metrics.md + 14 edits) | 28    | 01         |
+| 04   | Profiles, workflows, documentation           | 12    | 01, 02, 03 |
+
+## Libraries used
+
+No shared `@forwardimpact/lib*` packages are consumed. This spec is purely
+instructional content (skills, profiles, workflows, documentation).
+
+## Risks
+
+1. **kata-action facilitate mode gap.** The composite action currently supports
+   only `run` and `supervise` modes. Part 04 adds `facilitate` mode: two new
+   inputs, a new shell branch, a new trace split step, modified artifact upload
+   conditions, and two new upload steps — five coordinated changes to a shared
+   composite action used by all agent workflows. **Mitigation:** The facilitate
+   branch is additive — the `run` and `supervise` branches are untouched.
+   Existing workflows pass `mode: "run"` or omit mode (default `"run"`), so they
+   never enter the new branch. Any YAML syntax error would still break the
+   action file for all consumers, so validate YAML before committing.
+
+2. **fit-eval facilitate minimum agents.** `fit-eval facilitate` enforces
+   `--agents` must have at least 2 entries (`facilitate.js:52`). The
+   coaching-session workflow passes only 1 agent. Part 04 includes a one-line
+   code change to relax this validation to `>= 1`. Risk is low — the facilitator
+   is always a separate session from the agents, so 1 agent + 1 facilitator is a
+   valid configuration.
+
+3. **Facilitate trace splitting.** The current trace split step handles
+   `supervise` mode only (2 participants: agent + supervisor). Facilitate mode
+   has N+1 participants. Part 04 splits traces per participant name (not just
+   facilitator vs. all-agents) so each domain agent can analyze its own trace
+   during 1-on-1 coaching. **Mitigation:** fit-eval writes a unified NDJSON
+   trace with `.source` fields per participant. The split step uses `jq` to
+   extract per-source traces, following the same pattern as the supervise split.
+
+4. **14-skill blast radius.** Part 03 edits all 14 entry-point SKILL.md files. A
+   typo in the shared metrics bullet would propagate to all 14. **Mitigation:**
+   Use identical wording from a template, and run `bun run check` after all
+   edits.
+
+5. **Storyboard skill length.** The coaching protocol (five questions × two
+   modes + 1-on-1 coaching) may exceed the ~200 line SKILL.md budget.
+   **Mitigation:** Move the storyboard template and detailed protocol into
+   `references/` — SKILL.md holds only the routing logic and checklists.
+
+## Execution
+
+- **Part 01** → `staff-engineer` (sequential prerequisite)
+- **Parts 02 + 03** → two `staff-engineer` sub-agents in parallel after Part 01
+  merges
+- **Part 04** → `staff-engineer` after Parts 02 + 03 complete
+
+All four parts are instructional content (skills, profiles, workflows, docs).
+`staff-engineer` owns all parts because: KATA.md and wiki/MEMORY.md are
+operational infrastructure docs (not user-facing website/ content), and all
+skill/profile/workflow changes require understanding the kata architecture.
+`technical-writer` owns `website/` pages and wiki curation — neither applies
+here. The KATA.md and MEMORY.md changes are small additive sections describing
+new infrastructure, not documentation rewrites.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -63,6 +63,6 @@
 430	plan	implemented
 440	plan	implemented
 450	plan	implemented
-460	design	approved
+460	plan	draft
 470	plan	implemented
 480	spec	draft

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -63,6 +63,6 @@
 430	plan	implemented
 440	plan	implemented
 450	plan	implemented
-460	plan	draft
+460	plan	approved
 470	plan	implemented
 480	spec	draft


### PR DESCRIPTION
## Summary

- 4-part execution plan for spec 460 (Kata Coaching System): kata-metrics utility skill, kata-storyboard coaching protocol, 14-skill metrics integration, and profiles/workflows/documentation updates
- Two rounds of clean kata-review sub-agent review with all blocker, high, and medium findings addressed (shell injection in trace split, per-agent artifact uploads, fit-eval min-agents validation, coach Assess routing)
- Advances spec 460 from `design approved` to `plan approved`

## Test plan

- [x] `bun run check`
- [x] `bun run test`