### PR TITLE
feat(kata): implement Kata Coaching System (spec 460)

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -1,21 +1,24 @@
 ---
 name: improvement-coach
 description: >
-  Continuous improvement coach. Deep-analyzes a single trace from an agent
-  workflow run, identifies process failures and improvement opportunities,
-  and either fixes them directly or writes specs for larger changes.
+  Continuous improvement coach. Facilitates team storyboard meetings and
+  1-on-1 coaching sessions using the Toyota Kata five-question protocol.
+  Writes specs for structural improvements found through coaching.
 model: opus
 skills:
-  - kata-trace
+  - kata-storyboard
+  - kata-metrics
   - kata-spec
   - kata-review
   - kata-gh-cli
 ---
 
-You are the improvement coach. Go and see the work done by agent workflow runs,
-identify process failures, and drive improvements into the codebase.
+You are the improvement coach. Facilitate storyboard meetings and 1-on-1
+coaching sessions using the Toyota Kata five-question protocol. Help domain
+agents grasp their current condition, identify obstacles, and design
+experiments.
 
-Each cycle focuses on **one trace**. Depth over breadth.
+Each coaching context focuses on measured conditions. Numbers over narratives.
 
 ## Voice
 
@@ -27,14 +30,19 @@ Systematic, evidence-driven. Blame the system, never the worker. Sign off:
 
 Survey domain state, then choose the highest-priority action:
 
-1. **Recent workflow traces not yet analyzed?** -- Go and see the work agents
-   did by analyzing their traces (`kata-trace`; check: completed workflow runs
-   since last analysis, using the run selection algorithm)
-2. **Unaddressed findings from prior trace analyses?** -- Act on findings
-   (check: previous findings in `wiki/improvement-coach.md`; trivial fix --
-   `fix/coach-<name>` branch from `main`, improvement -- spec via `kata-spec` on
+1. **Agent due for 1-on-1 coaching?** — Facilitate a coaching session
+   (`kata-storyboard`; check: select the domain agent whose last coaching
+   session is oldest or who has the most unanalyzed traces; trigger the
+   coaching-session workflow with the agent name)
+2. **Unaddressed findings from prior coaching sessions?** — Act on findings
+   (check: previous findings in `wiki/improvement-coach.md`; trivial fix —
+   `fix/coach-<name>` branch from `main`, improvement — spec via `kata-spec` on
    `spec/<name>` branch from `main`)
-3. **Nothing actionable?** -- Report clean state
+3. **Nothing actionable?** — Report clean state
+
+Note: team storyboard meetings are handled by the daily-meeting workflow (03:00
+UTC), not by this agent's scheduled run. This agent's run focuses on 1-on-1
+coaching and acting on prior findings.
 
 After choosing, follow the selected skill's full procedure. Every PR must branch
 directly from `main`.
@@ -49,6 +57,8 @@ directly from `main`.
   downstream fixes are palliative
 - Trust the invariant audit results — they are the structured accountability
   check
+- Coaching only — you ask the five questions, you do not analyze traces
+  yourself. Domain agents run `kata-trace` during 1-on-1 coaching sessions.
 - Run `bun run check` and `bun run test` before committing
 - **Memory**: Before starting work, read `wiki/improvement-coach.md` and the
   other agent summaries for cross-agent context. Append this run as a new

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -14,6 +14,7 @@ skills:
   - kata-plan
   - kata-review
   - kata-gh-cli
+  - kata-trace
 ---
 
 You are the product manager. You review open pull requests for product
@@ -30,6 +31,11 @@ Warm, encouraging, organized. Appreciate every contribution. Sign off:
 
 Survey domain state, then choose the highest-priority action:
 
+0. **Read the storyboard.** Check `wiki/storyboard-YYYY-MNN.md` for this month.
+   If it exists, review the target condition and current obstacle. Weight
+   priority assessment toward actions that advance the target condition. If no
+   storyboard exists, proceed with your standard priority framework. Urgency
+   always overrides storyboard alignment.
 1. **Open PRs awaiting triage?** -- Classify and merge qualifying PRs
    (`kata-product-classify`; check: open PRs, contributor trust, CI status; for
    spec PRs also apply `kata-spec` review, for plan PRs also apply `kata-plan`

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -8,6 +8,7 @@ skills:
   - kata-release-readiness
   - kata-release-review
   - kata-gh-cli
+  - kata-trace
 ---
 
 You are the release engineer. You keep pull request branches merge-ready and
@@ -23,6 +24,11 @@ Steady, methodical, reassuring. Sign off:
 
 Survey domain state, then choose the highest-priority action:
 
+0. **Read the storyboard.** Check `wiki/storyboard-YYYY-MNN.md` for this month.
+   If it exists, review the target condition and current obstacle. Weight
+   priority assessment toward actions that advance the target condition. If no
+   storyboard exists, proceed with your standard priority framework. Urgency
+   always overrides storyboard alignment.
 1. **Main branch CI failing from trivial issues?** -- Repair CI directly (push
    `bun run check:fix` to `main`; you are the **only** agent allowed to push to
    `main`, and only for mechanical fixes -- if failures persist after

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -10,6 +10,7 @@ skills:
   - kata-security-audit
   - kata-spec
   - kata-review
+  - kata-trace
 ---
 
 You are the security engineer. You keep the codebase secure — dependencies
@@ -25,6 +26,11 @@ Vigilant but approachable. Direct about what needs fixing. Sign off:
 
 Survey domain state, then choose the highest-priority action:
 
+0. **Read the storyboard.** Check `wiki/storyboard-YYYY-MNN.md` for this month.
+   If it exists, review the target condition and current obstacle. Weight
+   priority assessment toward actions that advance the target condition. If no
+   storyboard exists, proceed with your standard priority framework. Urgency
+   always overrides storyboard alignment.
 1. **Critical vulnerabilities?** -- Patch immediately (`kata-security-update`;
    check: `npm audit`, GitHub security advisories)
 2. **Open Dependabot PRs?** -- Triage and merge or close

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -11,6 +11,7 @@ skills:
   - kata-implement
   - kata-review
   - kata-gh-cli
+  - kata-trace
   - libs-grpc-services
   - libs-storage
   - libs-llm-and-agents
@@ -37,6 +38,11 @@ off:
 
 Survey domain state, then choose the highest-priority action:
 
+0. **Read the storyboard.** Check `wiki/storyboard-YYYY-MNN.md` for this month.
+   If it exists, review the target condition and current obstacle. Weight
+   priority assessment toward actions that advance the target condition. If no
+   storyboard exists, proceed with your standard priority framework. Urgency
+   always overrides storyboard alignment.
 1. **Approved specs without designs?** -- Write an architectural design
    (`kata-design`; check: `specs/STATUS` for specs at `spec approved` without a
    `design.md`; push the design on the existing `spec/` branch -- never start a

--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -10,6 +10,7 @@ skills:
   - kata-wiki-curate
   - kata-spec
   - kata-review
+  - kata-trace
 ---
 
 You are the technical writer. You keep documentation accurate, audience-pure,
@@ -28,6 +29,11 @@ Meticulous, constructive. Care about the reader's experience. Sign off:
 
 Survey domain state, then choose the highest-priority action:
 
+0. **Read the storyboard.** Check `wiki/storyboard-YYYY-MNN.md` for this month.
+   If it exists, review the target condition and current obstacle. Weight
+   priority assessment toward actions that advance the target condition. If no
+   storyboard exists, proceed with your standard priority framework. Urgency
+   always overrides storyboard alignment.
 1. **Stale or inaccurate cross-agent observations?** -- Curate the wiki
    (`kata-wiki-curate`; check: agent summaries for unacknowledged observations,
    stale data, or log hygiene issues)

--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -155,6 +155,8 @@ Append to the current week's log (see agent profile for the file path):
 - **Design decisions** — Key architectural choices and why (so the planner has
   context)
 - **Deferred specs** — Specs skipped and why (not approved, missing info, etc.)
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol
 
 ## What NOT to Do
 

--- a/.claude/skills/kata-design/references/metrics.md
+++ b/.claude/skills/kata-design/references/metrics.md
@@ -1,0 +1,10 @@
+# Metrics — Design
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric             | Unit  | Description                              | Data source  |
+| ------------------ | ----- | ---------------------------------------- | ------------ |
+| designs_in_backlog | count | Specs at `spec approved` awaiting design | specs/STATUS |
+| days_in_draft      | days  | Days the oldest design draft has waited  | Git log      |

--- a/.claude/skills/kata-documentation/SKILL.md
+++ b/.claude/skills/kata-documentation/SKILL.md
@@ -159,3 +159,5 @@ Append to the current week's log (see agent profile for the file path):
 - **Deferred work** — Issues needing follow-up with enough context to resume
 - **Accuracy errors** — Specific docs that diverged from source code
 - **Observations for teammates** — Callouts for agents whose work affects docs
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol

--- a/.claude/skills/kata-documentation/references/metrics.md
+++ b/.claude/skills/kata-documentation/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Documentation
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric            | Unit  | Description                             | Data source  |
+| ----------------- | ----- | --------------------------------------- | ------------ |
+| pages_reviewed    | count | Documentation pages reviewed this run   | Run actions  |
+| accuracy_errors   | count | Factual errors found                    | Review       |
+| days_since_review | days  | Days since this topic was last reviewed | Coverage map |

--- a/.claude/skills/kata-implement/SKILL.md
+++ b/.claude/skills/kata-implement/SKILL.md
@@ -183,6 +183,8 @@ Append to the current week's log (see agent profile for the file path):
 - **Blockers encountered** — Plan deviations, codebase divergences, test
   failures, and how they were resolved
 - **Deferred specs** — Specs skipped and why (not ready, missing plan, etc.)
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol
 
 ## What NOT to Do
 

--- a/.claude/skills/kata-implement/references/metrics.md
+++ b/.claude/skills/kata-implement/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Implementation
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric               | Unit  | Description                       | Data source |
+| -------------------- | ----- | --------------------------------- | ----------- |
+| steps_completed      | count | Plan steps completed this run     | Run actions |
+| blockers_encountered | count | Plan deviations or blockers hit   | Run actions |
+| plan_deviation_count | count | Steps that diverged from the plan | Run actions |

--- a/.claude/skills/kata-metrics/SKILL.md
+++ b/.claude/skills/kata-metrics/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: kata-metrics
+description: >
+  Time-series data recording protocol for Kata agents. Defines CSV schema,
+  storage conventions, and metric design guidance. Utility skill — no agent
+  routes to it directly; entry-point skills reference it for recording.
+---
+
+# Metrics Recording Protocol
+
+Utility skill like `kata-gh-cli` — defines the protocol that entry-point skills
+follow when recording time-series data at the end of each run.
+
+## When to Use
+
+You are an entry-point kata skill recording measurements after completing
+primary work. Reference this protocol for format, storage, and design guidance.
+
+## Recording Protocol
+
+1. Choose which metrics to record based on what you observed during this run
+   (informed by your skill's `references/metrics.md`).
+2. For each metric, append one CSV row to
+   `wiki/metrics/{agent}/{domain}/{YYYY}.csv`. Create the directory and header
+   row if the file does not exist.
+3. Commit metrics files as part of the wiki push at the end of the run.
+
+## Metric Design Guidance
+
+- Prefer counts and durations over ratios (ratios hide volume).
+- Prefer direct measurements over derived values.
+- Keep metric names stable across runs (snake_case, descriptive).
+- One metric per measurement — do not pack multiple values into one row.
+
+## Storage
+
+```
+wiki/metrics/{agent}/{domain}/{YYYY}.csv
+```
+
+Agent matches profile name. Domain matches skill domain slug (e.g., `audit`,
+`triage`, `release-readiness`). Partitioned by year. First line of each new file
+is the header row.
+
+## CSV Format
+
+See [`references/csv-schema.md`](references/csv-schema.md) for field
+definitions, types, and appending rules.
+
+## Process Behavior Charts
+
+See [`references/control-charts.md`](references/control-charts.md) for XmR chart
+construction, natural process limits, and signal detection.

--- a/.claude/skills/kata-metrics/references/control-charts.md
+++ b/.claude/skills/kata-metrics/references/control-charts.md
@@ -1,0 +1,33 @@
+# Process Behavior Charts (XmR)
+
+XmR (individuals and moving range) charts are the standard tool for
+distinguishing stable processes from those reacting to special causes. They use
+the data itself to compute natural process limits — no external targets needed.
+
+## Construction
+
+1. **X chart (individuals):** Plot each measurement value in time order. Compute
+   the average (X-bar) as the central line.
+2. **mR chart (moving range):** Compute the absolute difference between
+   consecutive measurements. Compute the average moving range (mR-bar).
+3. **Natural Process Limits (NPL):** Upper NPL = X-bar + 2.66 x mR-bar. Lower
+   NPL = X-bar - 2.66 x mR-bar (or 0 if negative for counts).
+4. **Plot.** X chart with X-bar and NPLs. mR chart with mR-bar and Upper Range
+   Limit (URL = 3.27 x mR-bar).
+
+## Reading the Chart
+
+- **Within limits, no patterns** — stable/predictable process. Variation is
+  routine. Do not react to individual points.
+- **Point outside NPL** — signal (special cause). Investigate what changed.
+- **Run of 8+ on same side of central line** — signal. Process has shifted.
+- **Trend of 6+ consecutive increases or decreases** — signal.
+
+## Guidance for Agents
+
+- Build charts mentally or in markdown tables when reviewing metrics during
+  storyboard meetings.
+- Minimum 10-15 data points before computing meaningful limits.
+- When a signal appears, annotate the CSV `note` field with what you discover.
+- Do not set targets based on NPLs — they describe what the process _does_, not
+  what it _should_ do. Target conditions come from the storyboard.

--- a/.claude/skills/kata-metrics/references/csv-schema.md
+++ b/.claude/skills/kata-metrics/references/csv-schema.md
@@ -1,0 +1,37 @@
+# CSV Schema
+
+Long format, one row per data point. Six fields:
+
+| Field  | Type          | Required | Example                          |
+| ------ | ------------- | -------- | -------------------------------- |
+| date   | ISO 8601 date | yes      | `2026-04-14`                     |
+| metric | string        | yes      | `open_vulnerabilities`           |
+| value  | number        | yes      | `3`                              |
+| unit   | string        | yes      | `count`, `days`, `minutes`       |
+| run    | string        | yes      | GitHub Actions run URL           |
+| note   | string        | no       | Anomaly annotation (empty if ok) |
+
+## Header Row
+
+```
+date,metric,value,unit,run,note
+```
+
+Written as the first line when creating a new file.
+
+## Appending Rules
+
+- Always append — never rewrite or sort existing rows.
+- One row per metric per run. If recording three metrics, append three rows.
+- Empty `note` field: leave empty (not null, not "none"), resulting in a
+  trailing comma.
+- Quote fields containing commas using double quotes.
+
+## Example
+
+```csv
+date,metric,value,unit,run,note
+2026-04-14,open_vulnerabilities,3,count,https://github.com/forwardimpact/monorepo/actions/runs/12345,
+2026-04-14,days_since_topic_audit,7,days,https://github.com/forwardimpact/monorepo/actions/runs/12345,
+2026-04-15,open_vulnerabilities,2,count,https://github.com/forwardimpact/monorepo/actions/runs/12400,resolved CVE-2026-1234
+```

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -206,6 +206,8 @@ Append to the current week's log (see agent profile for the file path):
 - **Plan decisions** — Key approach choices and why (so the implementer has
   context)
 - **Deferred specs** — Specs skipped and why (not approved, missing info, etc.)
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol
 
 ## What NOT to Do
 

--- a/.claude/skills/kata-plan/references/metrics.md
+++ b/.claude/skills/kata-plan/references/metrics.md
@@ -1,0 +1,10 @@
+# Metrics — Planning
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric           | Unit  | Description                              | Data source  |
+| ---------------- | ----- | ---------------------------------------- | ------------ |
+| plans_in_backlog | count | Specs at `design approved` awaiting plan | specs/STATUS |
+| days_in_draft    | days  | Days the oldest plan draft has waited    | Git log      |

--- a/.claude/skills/kata-product-classify/SKILL.md
+++ b/.claude/skills/kata-product-classify/SKILL.md
@@ -166,3 +166,5 @@ Append to the current week's log (see agent profile for the file path):
 - **Spec review results** — Spec PRs and their assessment
 - **PRs merged this run** — number, title, and final state
 - **Merge failures** — number and the reason (so the next run can revisit)
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol

--- a/.claude/skills/kata-product-classify/references/metrics.md
+++ b/.claude/skills/kata-product-classify/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Product Classify
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric           | Unit  | Description                         | Data source    |
+| ---------------- | ----- | ----------------------------------- | -------------- |
+| open_prs         | count | Open PRs at run end                 | gh pr list     |
+| prs_merged       | count | PRs merged this run                 | Run actions    |
+| blocked_pr_count | count | PRs blocked by CI or trust failures | Classification |

--- a/.claude/skills/kata-product-evaluation/SKILL.md
+++ b/.claude/skills/kata-product-evaluation/SKILL.md
@@ -142,3 +142,5 @@ Append to the current week's log (see agent profile for the file path):
 - **Completion status** — Whether the agent completed all tasks
 - **Key friction points** — Where the agent struggled most
 - **Issues created or updated** — Issue numbers and their categories
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol

--- a/.claude/skills/kata-product-evaluation/references/metrics.md
+++ b/.claude/skills/kata-product-evaluation/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Product Evaluation
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric                | Unit  | Description                              | Data source   |
+| --------------------- | ----- | ---------------------------------------- | ------------- |
+| friction_points_found | count | User friction points identified this run | Evaluation    |
+| tasks_completed       | count | Evaluation tasks completed               | Evaluation    |
+| issues_created        | count | GitHub issues created from findings      | gh issue list |

--- a/.claude/skills/kata-product-triage/SKILL.md
+++ b/.claude/skills/kata-product-triage/SKILL.md
@@ -120,3 +120,5 @@ Append to the current week's log (see agent profile for the file path):
 - **Issue triage table** — Each issue with category, action, and rationale
 - **Recurring themes** — Patterns across issues, with frequency and alignment
 - **Hand-offs** — Which follow-up skills were invoked for which issues
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol

--- a/.claude/skills/kata-product-triage/references/metrics.md
+++ b/.claude/skills/kata-product-triage/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Product Triage
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric                | Unit  | Description                        | Data source   |
+| --------------------- | ----- | ---------------------------------- | ------------- |
+| open_issues           | count | Open issues at run end             | gh issue list |
+| issues_triaged        | count | Issues triaged this run            | Run actions   |
+| spec_conversion_count | count | Issues converted to specs this run | Run actions   |

--- a/.claude/skills/kata-release-readiness/SKILL.md
+++ b/.claude/skills/kata-release-readiness/SKILL.md
@@ -139,3 +139,5 @@ Append to the current week's log (see agent profile for the file path):
 - **PR status table** — Each PR with state and consecutive-stuck count
 - **Main branch CI state** — Green or broken, and what was wrong
 - **Releases cut** — Version numbers and packages (if any)
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol

--- a/.claude/skills/kata-release-readiness/references/metrics.md
+++ b/.claude/skills/kata-release-readiness/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Release Readiness
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric                  | Unit  | Description                              | Data source |
+| ----------------------- | ----- | ---------------------------------------- | ----------- |
+| prs_waiting             | count | PRs awaiting rebase or CI fix at run end | gh pr list  |
+| consecutive_stuck_count | count | PRs stuck across multiple runs           | Wiki log    |
+| rebase_failures         | count | Rebases that failed this run             | Run actions |

--- a/.claude/skills/kata-release-review/SKILL.md
+++ b/.claude/skills/kata-release-review/SKILL.md
@@ -165,6 +165,8 @@ Append to the current week's log (see agent profile for the file path):
   status
 - **Publish failures** — Package and reason (so the next run can revisit)
 - **Main branch CI state** — Green or broken, and what was repaired
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol
 
 ## Edge Cases
 

--- a/.claude/skills/kata-release-review/references/metrics.md
+++ b/.claude/skills/kata-release-review/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Release Review
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric             | Unit  | Description                              | Data source     |
+| ------------------ | ----- | ---------------------------------------- | --------------- |
+| unreleased_changes | count | Commits on main since last release       | git log         |
+| days_since_release | days  | Days since most recent release tag       | gh release list |
+| publish_failures   | count | Publish workflow failures since last run | gh run list     |

--- a/.claude/skills/kata-security-audit/SKILL.md
+++ b/.claude/skills/kata-security-audit/SKILL.md
@@ -126,3 +126,5 @@ Append to the current week's log (see agent profile for the file path):
 - **Deferred work** — Issues needing follow-up with enough context to resume
 - CVEs evaluated and their status
 - Policy violations found and whether fixed or spec'd
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol

--- a/.claude/skills/kata-security-audit/references/metrics.md
+++ b/.claude/skills/kata-security-audit/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Security Audit
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric                 | Unit  | Description                                   | Data source          |
+| ---------------------- | ----- | --------------------------------------------- | -------------------- |
+| open_vulnerabilities   | count | Unresolved vulnerabilities at run end         | npm audit, gh alerts |
+| days_since_topic_audit | days  | Days since this audit topic was last reviewed | Coverage map in wiki |
+| findings_count         | count | New findings identified this run              | Audit report         |

--- a/.claude/skills/kata-security-update/SKILL.md
+++ b/.claude/skills/kata-security-update/SKILL.md
@@ -136,3 +136,5 @@ Append to the current week's log (see agent profile for the file path):
 - **PR triage table** — Each PR with action, failed checks, and reason
 - **Compatibility blockers** — Packages closed due to Check 8
 - **Reverted merges** — PRs merged then reverted, with root cause
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol

--- a/.claude/skills/kata-security-update/references/metrics.md
+++ b/.claude/skills/kata-security-update/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Security Update
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric                | Unit  | Description                               | Data source       |
+| --------------------- | ----- | ----------------------------------------- | ----------------- |
+| dependabot_pr_backlog | count | Open Dependabot PRs at run end            | gh pr list        |
+| time_to_resolve       | days  | Days oldest open Dependabot PR has waited | gh pr list        |
+| prs_merged            | count | PRs successfully merged this run          | Run actions taken |

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -123,6 +123,16 @@ commit changes, report your decision so the caller can act on it.
    spec stays at `spec draft` until a human approves it. Stop here — the plan is
    the staff engineer's job.
 
+## Memory: what to record
+
+Append to the current week's log (see agent profile for the file path):
+
+- **Specs written** — Spec number, name, and status
+- **Review results** — Specs reviewed and disposition (approved/changes needed)
+- **Deferred work** — Findings not yet captured as specs
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol
+
 ## What NOT to Do
 
 The READ-DO checklist covers the core boundaries (spec only, no implementation

--- a/.claude/skills/kata-spec/references/metrics.md
+++ b/.claude/skills/kata-spec/references/metrics.md
@@ -1,0 +1,10 @@
+# Metrics — Specification
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric           | Unit  | Description                           | Data source  |
+| ---------------- | ----- | ------------------------------------- | ------------ |
+| specs_in_backlog | count | Specs at `spec draft` in STATUS       | specs/STATUS |
+| days_in_draft    | days  | Days the oldest draft spec has waited | Git log      |

--- a/.claude/skills/kata-storyboard/SKILL.md
+++ b/.claude/skills/kata-storyboard/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: kata-storyboard
+description: >
+  Toyota Kata coaching protocol for team storyboard meetings and 1-on-1
+  coaching sessions. The improvement coach facilitates; domain agents
+  participate. Same five coaching kata questions in both contexts.
+---
+
+# Kata Storyboard
+
+Entry-point skill used by the improvement coach in two contexts — team
+storyboard meetings (5 domain agents) and 1-on-1 coaching sessions (1 domain
+agent analyzing its own trace). Both use the same five coaching kata questions.
+
+## When to Use
+
+Your Assess section routed you to a coaching context: team storyboard meeting or
+1-on-1 coaching session.
+
+## Checklists
+
+<read_do_checklist goal="Prepare for the coaching session">
+
+- [ ] Read the current month's storyboard (`wiki/storyboard-YYYY-MNN.md`). If
+      none exists, this is a planning meeting.
+- [ ] Identify which metrics CSVs to review from `wiki/metrics/`.
+- [ ] For 1-on-1: identify the agent's most recent trace for analysis.
+
+</read_do_checklist>
+
+<do_confirm_checklist goal="Verify coaching session quality">
+
+- [ ] All five coaching kata questions were addressed.
+- [ ] Current condition updated with numbers from metrics CSVs (not narrative).
+- [ ] For team meetings: storyboard file updated and committed.
+- [ ] For 1-on-1: agent's findings written to its own memory.
+- [ ] Experiment expected outcome recorded _before_ the experiment runs.
+
+</do_confirm_checklist>
+
+## Storyboard Artifact
+
+Monthly file at `wiki/storyboard-YYYY-MNN.md` (e.g., `storyboard-2026-M04.md`)
+with five sections: Challenge, Target Condition, Current Condition, Obstacles,
+Experiments. Full template at
+[`references/storyboard-template.md`](references/storyboard-template.md).
+
+## Meeting Modes
+
+Three modes, all using the five coaching kata questions:
+
+**Planning meeting** — first meeting of the month or no storyboard exists.
+Create the storyboard. Lead the team through: establishing/confirming the
+Challenge, setting the Target Condition (measurable, by month end), measuring
+the Current Condition from metrics CSVs, identifying initial Obstacles, and
+planning the first Experiment.
+
+**Review meeting** — all other team meetings. Walk through the five questions
+(see [`references/coaching-protocol.md`](references/coaching-protocol.md)),
+update Current Condition with fresh metrics, record experiment outcomes (actual
+vs. expected), update Obstacles, and plan the next experiment.
+
+**1-on-1 coaching** — coach facilitates, one domain agent participates. The
+agent runs `kata-trace` on its own recent trace during the session. The five
+questions guide the agent's reflection: what were you trying to achieve? What
+actually happened (measured)? What obstacles did you encounter? What will you
+try next? When will you know?
+
+## Process
+
+1. **Read the storyboard.** Load `wiki/storyboard-YYYY-MNN.md`. If it does not
+   exist, this is a planning meeting — create it from
+   [`references/storyboard-template.md`](references/storyboard-template.md).
+2. **Gather metrics.** Read relevant CSVs from `wiki/metrics/` for each
+   participating agent's domain.
+3. **Run the five questions.** Follow
+   [`references/coaching-protocol.md`](references/coaching-protocol.md) for the
+   appropriate mode.
+4. **Update the storyboard.** Write updated Current Condition, Obstacles, and
+   Experiments sections back to the storyboard file.
+5. **Commit.** Commit storyboard changes as part of the wiki push.
+
+## Memory: what to record
+
+Append to the current week's log (see agent profile for the file path):
+
+- **Meeting type** — Planning, review, or 1-on-1 (with which agent)
+- **Current condition** — Key numbers from metrics CSVs reviewed
+- **Obstacle addressed** — Which obstacle was the focus
+- **Experiment status** — Outcome of prior experiment, next experiment planned
+- **Metrics** — Record coaching-specific measurements (e.g.,
+  `meetings_facilitated`, `experiments_active`) to
+  `wiki/metrics/improvement-coach/coaching/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. The coach records
+  coaching activity metrics, not domain metrics — domain agents record their own
+  domain metrics via their own entry-point skills.

--- a/.claude/skills/kata-storyboard/references/coaching-protocol.md
+++ b/.claude/skills/kata-storyboard/references/coaching-protocol.md
@@ -1,0 +1,51 @@
+# The Five Coaching Kata Questions
+
+These questions structure every coaching interaction — team meetings and 1-on-1
+sessions. The coach asks, the learner(s) reflect.
+
+## Question 1: What is the target condition?
+
+- Facilitator reads the target condition from the storyboard.
+- Grounds the conversation in where the team is headed.
+- If the target condition is unclear or expired, update it (planning mode).
+
+## Question 2: What is the actual condition now?
+
+- Each agent (or the single agent in 1-on-1) reports measured data from their
+  domain's metrics CSVs.
+- The facilitator updates the Current Condition section with fresh numbers.
+- Use counts and durations — not narratives like "improving" or "stable."
+- Reference specific CSV files: `wiki/metrics/{agent}/{domain}/{YYYY}.csv`.
+
+## Question 3: What obstacles are preventing us from reaching the target condition?
+
+- Agents identify obstacles from their domain based on the gap between current
+  and target condition.
+- Obstacles are discovered through data and experiments, not hypothesized
+  upfront.
+- The facilitator updates the Obstacles list and marks which obstacle the team
+  is currently addressing.
+
+## Question 4: What is the next step? What do you expect?
+
+- For the obstacle currently being addressed, agents propose their next
+  experiment.
+- The expected outcome is recorded _before_ the experiment runs.
+- Experiments should be small and testable within one or two daily cycles.
+
+## Question 5: When can we see what we learned from that step?
+
+- Establish when the experiment's results will be visible.
+- Typically: next meeting, end of week, or after a specific workflow run.
+- This creates the feedback loop — the next meeting opens by reviewing what was
+  learned.
+
+## 1-on-1 Coaching Adaptation
+
+The same five questions apply but scoped to the individual agent's trace:
+
+- Q1: What were you trying to achieve in this run?
+- Q2: What actually happened? (agent runs `kata-trace` on its own trace)
+- Q3: What obstacles prevented better outcomes?
+- Q4: What will you do differently next run?
+- Q5: When will you see the effect? (next scheduled run)

--- a/.claude/skills/kata-storyboard/references/storyboard-template.md
+++ b/.claude/skills/kata-storyboard/references/storyboard-template.md
@@ -1,0 +1,52 @@
+# Storyboard — YYYY Month
+
+## Challenge
+
+_The long-term direction that gives meaning to target conditions and
+experiments. Changes rarely — only when strategic direction shifts._
+
+> [Write the challenge here. One or two sentences describing the team's >
+> long-term direction.]
+
+## Target Condition
+
+_The measurable state the team aims to reach by the end of this month. Not a
+task list — a description of how the system will behave differently, expressed
+in terms verifiable with data from metrics CSVs._
+
+> [Write the target condition here. Include specific metrics and thresholds.]
+
+**Due:** YYYY-MM-DD (end of month)
+
+## Current Condition
+
+_The measured state as of the last storyboard review. Updated daily using data
+from wiki/metrics/. Always numbers, not narratives._
+
+| Agent | Domain | Key metric | Value | Trend |
+| ----- | ------ | ---------- | ----- | ----- |
+|       |        |            |       |       |
+
+**Last updated:** YYYY-MM-DD
+
+## Obstacles
+
+_What stands between the current condition and the target condition. Discovered
+through experiments, not predicted upfront._
+
+- **Current obstacle -->** [describe]
+- [other known obstacles]
+
+## Experiments
+
+_PDSA cycles run against the current obstacle. Record expected outcome before
+running, actual outcome after._
+
+### Experiment N
+
+- **Obstacle:** [which obstacle this addresses]
+- **What:** [description of the experiment]
+- **Expected outcome:** [what you predict will happen — record before running]
+- **Actual outcome:** [what actually happened — record after running]
+- **What did we learn?** [gap between expected and actual]
+- **Next step:** [continue, pivot, or new experiment]

--- a/.claude/skills/kata-storyboard/references/storyboard-template.md
+++ b/.claude/skills/kata-storyboard/references/storyboard-template.md
@@ -5,8 +5,7 @@
 _The long-term direction that gives meaning to target conditions and
 experiments. Changes rarely — only when strategic direction shifts._
 
-> [Write the challenge here. One or two sentences describing the team's > > >
-> long-term direction.]
+> [Write the challenge here.]
 
 ## Target Condition
 

--- a/.claude/skills/kata-storyboard/references/storyboard-template.md
+++ b/.claude/skills/kata-storyboard/references/storyboard-template.md
@@ -5,7 +5,7 @@
 _The long-term direction that gives meaning to target conditions and
 experiments. Changes rarely — only when strategic direction shifts._
 
-> [Write the challenge here. One or two sentences describing the team's >
+> [Write the challenge here. One or two sentences describing the team's > > >
 > long-term direction.]
 
 ## Target Condition

--- a/.claude/skills/kata-trace/SKILL.md
+++ b/.claude/skills/kata-trace/SKILL.md
@@ -226,6 +226,8 @@ Append to the current week's log (see agent profile for the file path):
 - **Saturation notes** — Patterns confirmed, refuted, or newly emerged compared
   to prior cycles
 - **Observations for teammates** — Callouts for specific agents
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol
 
 ## Analysis Principles
 

--- a/.claude/skills/kata-trace/references/metrics.md
+++ b/.claude/skills/kata-trace/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Trace Analysis
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric             | Unit  | Description                                 | Data source     |
+| ------------------ | ----- | ------------------------------------------- | --------------- |
+| traces_analyzed    | count | Workflow traces analyzed this run           | Run actions     |
+| findings_per_trace | count | Actionable findings from the analyzed trace | Analysis        |
+| invariants_passed  | count | Invariants that passed this run             | Invariant audit |

--- a/.claude/skills/kata-wiki-curate/SKILL.md
+++ b/.claude/skills/kata-wiki-curate/SKILL.md
@@ -145,3 +145,5 @@ Append to the current week's log (see agent profile for the file path):
 - **Stale observations** — Teammate observations >2 weeks old with no response
 - **MEMORY.md changes** — What was added/updated
 - **Observations for teammates** — Specific callouts based on wiki findings
+- **Metrics** — Record relevant measurements to `wiki/metrics/{agent}/{domain}/`
+  per the [`kata-metrics`](../kata-metrics/SKILL.md) protocol

--- a/.claude/skills/kata-wiki-curate/references/metrics.md
+++ b/.claude/skills/kata-wiki-curate/references/metrics.md
@@ -1,0 +1,11 @@
+# Metrics — Wiki Curation
+
+Suggested metrics for this domain. These are starting points — discover which
+metrics are most useful through practice. Record per the
+[`kata-metrics`](../../kata-metrics/SKILL.md) protocol.
+
+| Metric              | Unit  | Description                             | Data source |
+| ------------------- | ----- | --------------------------------------- | ----------- |
+| stale_observations  | count | Teammate observations older than 7 days | Wiki scan   |
+| summary_corrections | count | Summary inaccuracies corrected this run | Run actions |
+| log_hygiene_issues  | count | Weekly log format issues found          | Wiki scan   |

--- a/.github/actions/kata-action/action.yml
+++ b/.github/actions/kata-action/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Inline task text (mutually exclusive with task-file)
     required: false
   mode:
-    description: Execution mode — "run" (single agent) or "supervise"
+    description: Execution mode — "run", "supervise", or "facilitate"
     required: false
     default: "run"
   cwd:
@@ -47,6 +47,16 @@ inputs:
     required: false
   agent-profile:
     description: Agent profile name (passed as --agent to Claude CLI)
+    required: false
+  facilitator-profile:
+    description:
+      Facilitator profile name (passed as --facilitator-profile, facilitate mode
+      only)
+    required: false
+  agents:
+    description:
+      Comma-separated agent configs for facilitate mode (format
+      "name1:role=x,name2:role=y")
     required: false
   task-amend:
     description: Additional text appended to the task prompt for steering
@@ -98,6 +108,8 @@ runs:
         SUPERVISOR_TOOLS: ${{ inputs.supervisor-allowed-tools }}
         SUPERVISOR_PROFILE: ${{ inputs.supervisor-profile }}
         AGENT_PROFILE: ${{ inputs.agent-profile }}
+        FACILITATOR_PROFILE: ${{ inputs.facilitator-profile }}
+        AGENTS: ${{ inputs.agents }}
         TASK_AMEND: ${{ inputs.task-amend }}
         TRACE_ENABLED: ${{ inputs.trace }}
         TRACE_DIR: ${{ steps.setup.outputs.trace-dir }}
@@ -149,6 +161,20 @@ runs:
             --model="$MODEL" \
             --allowed-tools="$TOOLS" \
             "${args[@]}"
+        elif [ "$MODE" = "facilitate" ]; then
+          if [ -n "$FACILITATOR_PROFILE" ]; then
+            args+=("--facilitator-profile=$FACILITATOR_PROFILE")
+          fi
+
+          if [ "$MAX_TURNS" != "0" ]; then
+            args+=("--max-turns=$MAX_TURNS")
+          fi
+
+          bunx fit-eval facilitate \
+            --facilitator-cwd="." \
+            --agents="$AGENTS" \
+            --model="$MODEL" \
+            "${args[@]}"
         else
           if [ -n "$AGENT_PROFILE" ]; then
             args+=("--agent-profile=$AGENT_PROFILE")
@@ -180,6 +206,31 @@ runs:
         jq -c 'select(.source == "supervisor") | .event' "$TRACE_DIR/trace.ndjson" \
           > "$TRACE_DIR/supervisor-trace.ndjson"
 
+    - name: Split facilitated trace
+      if:
+        always() && inputs.trace == 'true' && inputs.mode == 'facilitate' &&
+        steps.setup.outputs.trace-dir != ''
+      shell: bash
+      env:
+        TRACE_DIR: ${{ steps.setup.outputs.trace-dir }}
+      run: |
+        # Extract facilitator events
+        jq -c 'select(.source == "facilitator") | .event' "$TRACE_DIR/trace.ndjson" \
+          > "$TRACE_DIR/facilitator-trace.ndjson"
+        # Extract per-agent traces using jq --arg to avoid shell injection.
+        # Agent names come from trace .source fields which originate from
+        # workflow_dispatch input — sanitize by filtering to alphanumeric + hyphen.
+        jq -r 'select(.source != "facilitator") | .source' "$TRACE_DIR/trace.ndjson" \
+          | sort -u \
+          | grep -E '^[a-z][a-z0-9-]*$' \
+          | while IFS= read -r agent; do
+              jq -c --arg src "$agent" 'select(.source == $src) | .event' \
+                "$TRACE_DIR/trace.ndjson" > "$TRACE_DIR/${agent}-trace.ndjson"
+            done
+        # Also produce a combined agent trace for the agent-trace artifact
+        jq -c 'select(.source != "facilitator") | .event' "$TRACE_DIR/trace.ndjson" \
+          > "$TRACE_DIR/agent-trace.ndjson"
+
     - name: Upload agent trace
       if:
         always() && inputs.trace == 'true' && steps.setup.outputs.trace-dir !=
@@ -188,7 +239,7 @@ runs:
       with:
         name: agent-trace
         path: |
-          ${{ inputs.mode == 'supervise' && format('{0}/agent-trace.ndjson', steps.setup.outputs.trace-dir) || format('{0}/trace.ndjson', steps.setup.outputs.trace-dir) }}
+          ${{ (inputs.mode == 'supervise' || inputs.mode == 'facilitate') && format('{0}/agent-trace.ndjson', steps.setup.outputs.trace-dir) || format('{0}/trace.ndjson', steps.setup.outputs.trace-dir) }}
 
     - name: Upload supervisor trace
       if:
@@ -199,10 +250,32 @@ runs:
         name: supervisor-trace
         path: ${{ steps.setup.outputs.trace-dir }}/supervisor-trace.ndjson
 
+    - name: Upload facilitator trace
+      if:
+        always() && inputs.trace == 'true' && inputs.mode == 'facilitate' &&
+        steps.setup.outputs.trace-dir != ''
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: facilitator-trace
+        path: ${{ steps.setup.outputs.trace-dir }}/facilitator-trace.ndjson
+
+    - name: Upload per-agent traces
+      if:
+        always() && inputs.trace == 'true' && inputs.mode == 'facilitate' &&
+        steps.setup.outputs.trace-dir != ''
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: per-agent-traces
+        path: |
+          ${{ steps.setup.outputs.trace-dir }}/*-trace.ndjson
+          !${{ steps.setup.outputs.trace-dir }}/facilitator-trace.ndjson
+          !${{ steps.setup.outputs.trace-dir }}/agent-trace.ndjson
+          !${{ steps.setup.outputs.trace-dir }}/trace.ndjson
+
     - name: Upload combined trace
       if:
-        always() && inputs.trace == 'true' && inputs.mode == 'supervise' &&
-        steps.setup.outputs.trace-dir != ''
+        always() && inputs.trace == 'true' && (inputs.mode == 'supervise' ||
+        inputs.mode == 'facilitate') && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: combined-trace

--- a/.github/workflows/coaching-session.yml
+++ b/.github/workflows/coaching-session.yml
@@ -1,0 +1,60 @@
+name: "Kata: Coaching Session"
+
+on:
+  workflow_dispatch:
+    inputs:
+      agent:
+        description: "Agent name to coach (e.g., security-engineer)"
+        required: true
+        type: string
+      task-amend:
+        description: "Additional text appended to the task prompt for steering"
+        required: false
+        type: string
+
+concurrency:
+  group: coaching-session
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  kata:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.ci-app.outputs.token }}
+          submodules: true
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: 1-on-1 Coaching Session
+        uses: ./.github/actions/kata-action
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          mode: "facilitate"
+          task-text: >-
+            Facilitate a 1-on-1 coaching session with the participant agent.
+            Guide them through the five coaching kata questions. Have them
+            analyze their own most recent trace using kata-trace. Help them
+            identify obstacles and design their next experiment.
+          facilitator-profile: "improvement-coach"
+          agents: "${{ inputs.agent }}:role=${{ inputs.agent }}"
+          model: "opus"
+          max-turns: "200"
+          task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/daily-meeting.yml
+++ b/.github/workflows/daily-meeting.yml
@@ -1,0 +1,58 @@
+name: "Kata: Daily Meeting"
+
+on:
+  schedule:
+    # Daily at 03:00 UTC — before all individual agent workflows
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      task-amend:
+        description: "Additional text appended to the task prompt for steering"
+        required: false
+        type: string
+
+concurrency:
+  group: daily-meeting
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  kata:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.ci-app.outputs.token }}
+          submodules: true
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: Team Storyboard Meeting
+        uses: ./.github/actions/kata-action
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          mode: "facilitate"
+          task-text: >-
+            Facilitate the team storyboard meeting. Walk through the five
+            coaching kata questions with all participants. Update the storyboard
+            with fresh metrics and experiment progress.
+          facilitator-profile: "improvement-coach"
+          agents: "security-engineer:role=security-engineer,technical-writer:role=technical-writer,product-manager:role=product-manager,staff-engineer:role=staff-engineer,release-engineer:role=release-engineer"
+          model: "opus"
+          max-turns: "200"
+          task-amend: ${{ inputs.task-amend }}

--- a/KATA.md
+++ b/KATA.md
@@ -13,8 +13,9 @@ pattern of _understand the direction_, _grasp the current condition_, _establish
 the next target condition_, and _experiment toward it_. Kata agents grasp the
 current condition (by analyzing execution traces of prior runs), establish
 target conditions (via specs), and experiment toward them (via implementation).
-Six scheduled workflows — one per agent — six agent personas, and seventeen
-skills form a self-reinforcing PDSA cycle.
+Eight workflows — six individual agent runs, one daily team meeting, and one
+on-demand coaching session — six agent personas, and nineteen skills form a
+self-reinforcing PDSA cycle.
 
 ## Architecture
 
@@ -73,21 +74,25 @@ exceeds an agent's scope, it writes a spec rather than attempting the fix.
 
 ## Workflows
 
-Six scheduled workflows span 04-11 UTC, one per agent. Times respect ordering
-constraints (security before product, product before planning, planning before
-release, all producers before the improvement coach). Off-minute schedules avoid
-API load spikes. All support `workflow_dispatch`, use concurrency groups, and
-have a 30-minute timeout. Each workflow sends the same generic task prompt; the
-agent's Assess section determines the actual action.
+Eight workflows: six individual agent runs spanning 04-11 UTC, one daily team
+meeting at 03:00 UTC, and one on-demand coaching session. Times respect ordering
+constraints (team meeting before individual runs, security before product,
+product before planning, planning before release, all producers before the
+improvement coach). Off-minute schedules avoid API load spikes. All support
+`workflow_dispatch`, use concurrency groups, and have a 30-minute timeout. Each
+workflow sends the same generic task prompt; the agent's Assess section
+determines the actual action.
 
-| Workflow              | Schedule            | Agent             |
-| --------------------- | ------------------- | ----------------- |
-| **security-engineer** | Daily 04:07 UTC     | security-engineer |
-| **technical-writer**  | Daily 05:37 UTC     | technical-writer  |
-| **product-manager**   | Daily 06:23 UTC     | product-manager   |
-| **staff-engineer**    | Daily 07:11 UTC     | staff-engineer    |
-| **release-engineer**  | Daily 08:43 UTC     | release-engineer  |
-| **improvement-coach** | Wed & Sat 10:47 UTC | improvement-coach |
+| Workflow              | Schedule            | Agent                                    |
+| --------------------- | ------------------- | ---------------------------------------- |
+| **daily-meeting**     | Daily 03:00 UTC     | improvement-coach (facilitates 5 agents) |
+| **coaching-session**  | `workflow_dispatch` | improvement-coach (facilitates 1 agent)  |
+| **security-engineer** | Daily 04:07 UTC     | security-engineer                        |
+| **technical-writer**  | Daily 05:37 UTC     | technical-writer                         |
+| **product-manager**   | Daily 06:23 UTC     | product-manager                          |
+| **staff-engineer**    | Daily 07:11 UTC     | staff-engineer                           |
+| **release-engineer**  | Daily 08:43 UTC     | release-engineer                         |
+| **improvement-coach** | Wed & Sat 10:47 UTC | improvement-coach                        |
 
 ## Skills
 
@@ -184,6 +189,19 @@ appends findings to the log, and updates the summary at the end. Entry-point
 skills must include a read step and a "Memory: what to record" section.
 Sub-skills and utility skills are exempt.
 
+## Metrics
+
+Agents record time-series data to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`
+after each run. The `kata-metrics` skill defines the CSV schema (six fields:
+date, metric, value, unit, run, note), storage convention, and metric design
+guidance. Each entry-point skill carries a `references/metrics.md` suggesting
+domain-specific metrics.
+
+Metrics serve the coaching cycle: the team storyboard meeting (see Workflows
+table) uses metric data to answer "what is the actual condition now?" with
+numbers rather than narratives. Process behavior charts (XmR) built from the
+time series distinguish stable processes from those reacting to special causes.
+
 ## Authentication
 
 Workflows authenticate via the **GitHub App** (`forward-impact-ci`), not a PAT.
@@ -195,11 +213,12 @@ workflows.
 ## Accountability
 
 Cross-agent accountability runs through the `kata-trace` skill's invariant
-audit. The improvement coach verifies named per-agent invariants against the
-actual trace on every trace analysis cycle — e.g., that the product manager ran
-a contributor lookup before marking any non-CI-app PR mergeable. The canonical
-invariant list lives in `.claude/skills/kata-trace/references/invariants.md`.
-High-severity audit failures must result in a fix PR or spec.
+audit. Domain agents verify their own per-agent invariants against their own
+traces during 1-on-1 coaching sessions facilitated by the improvement coach —
+e.g., that the product manager ran a contributor lookup before marking any
+non-CI-app PR mergeable. The canonical invariant list lives in
+`.claude/skills/kata-trace/references/invariants.md`. High-severity audit
+failures must result in a fix PR or spec.
 
 ## Authoring Best Practices
 

--- a/libraries/libeval/src/commands/facilitate.js
+++ b/libraries/libeval/src/commands/facilitate.js
@@ -49,8 +49,8 @@ function parseFacilitateOptions(values) {
   if (!agentsRaw) throw new Error("--agents is required");
 
   const agentConfigs = parseAgentConfigs(agentsRaw);
-  if (agentConfigs.length < 2)
-    throw new Error("--agents must specify at least two agents");
+  if (agentConfigs.length < 1)
+    throw new Error("--agents must specify at least one agent");
 
   const maxTurnsRaw = values["max-turns"] ?? "20";
 

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -63,6 +63,6 @@
 430	plan	implemented
 440	plan	implemented
 450	plan	implemented
-460	plan	approved
+460	plan	implemented
 470	plan	implemented
 480	spec	draft


### PR DESCRIPTION
## Summary

- Add kata-metrics utility skill (CSV schema, storage conventions, XmR chart guidance) and kata-storyboard entry-point skill (five-question coaching protocol, storyboard template, meeting modes)
- Add `references/metrics.md` with domain-specific metric suggestions and a metrics recording bullet in "Memory: what to record" to all 14 entry-point kata skills
- Restructure improvement-coach profile to facilitate via kata-storyboard/kata-metrics (no longer runs kata-trace); add Assess step 0 (storyboard reading) and kata-trace to all 5 domain agent profiles
- Extend kata-action with facilitate mode support (inputs, shell branch, trace splitting, artifact uploads); relax facilitate minimum agents to 1 for 1-on-1 coaching
- Create daily-meeting workflow (03:00 UTC, 5 domain agents) and coaching-session workflow (on-demand, 1 agent)
- Update KATA.md (workflows table, metrics section, accountability reframing) and wiki/MEMORY.md (storyboard and metrics conventions)

## Test plan

- [x] `bun run check` passes (format + lint)
- [x] `bun run test` passes (2339/2339, 0 failures)
- [x] All 14 success criteria from spec verified by clean sub-agent review
- [x] Security review of kata-action shell script (variable quoting, jq --arg, agent name sanitization)
- [x] SHA pins on new workflow actions match existing workflows