### PR TITLE
spec(490): storyboard skill lacks facilitation instructions

### DIFF
--- a/specs/490-storyboard-facilitation-gap/spec.md
+++ b/specs/490-storyboard-facilitation-gap/spec.md
@@ -1,0 +1,167 @@
+# Spec 490 — Storyboard Skill Lacks Facilitation Instructions
+
+## Problem
+
+The daily meeting workflow (run 24439250411, 2026-04-15) ran the improvement
+coach as facilitator with five domain agents configured as participants. The
+coach had all five orchestration tools available (RollCall, Share, Tell,
+Redirect, Conclude) and the FACILITATOR_SYSTEM_PROMPT explicitly instructed
+their use. Despite this, the coach made zero orchestration tool calls across 55
+turns and 634 seconds. It read every agent's wiki summary directly, gathered
+metrics via `gh` commands itself, wrote the storyboard alone, and committed —
+never waking a single participant. The five agent sessions recorded zero events.
+
+The root cause is an instruction layering conflict. The
+FACILITATOR_SYSTEM_PROMPT describes orchestration tool semantics (appended to
+the system prompt alongside layer 1 relay mechanics), but the `kata-storyboard`
+skill (layer 4) defines a self-sufficient solo procedure that never references
+those tools. See
+[KATA.md § Instruction layering](../../KATA.md#instruction-layering) for the
+five-layer model.
+
+### The storyboard skill reads as a solo research procedure
+
+The Process section in `kata-storyboard/SKILL.md` lists five steps:
+
+1. Read the storyboard (self-action)
+2. Gather metrics (self-action)
+3. Run the five questions (ambiguous — points to
+   `references/coaching-protocol.md`)
+4. Update the storyboard (self-action)
+5. Commit (self-action)
+
+Four of five steps are actions the facilitator performs alone. Step 3 defers to
+the coaching protocol reference, which says "each agent reports measured data"
+and "agents identify obstacles" — but in passive voice, never specifying the
+mechanism. The facilitator can satisfy these descriptions by reading agent wiki
+files, which is exactly what it did.
+
+Neither the skill nor the coaching protocol reference mentions the orchestration
+tools — RollCall, Tell, Share, Redirect, or Conclude — by name. The word "Tell"
+does not appear. The word "Share" does not appear. "RollCall" and "Conclude" do
+not appear. The facilitation mechanism is entirely absent from the domain
+instructions.
+
+### The system prompt is drowned out by the skill
+
+The FACILITATOR_SYSTEM_PROMPT (appended to the system prompt in
+`facilitator.js:20-25`) correctly says:
+
+> "Use Tell to assign work to individual agents. Use Share to broadcast to all.
+> Use RollCall to see who is available. Use Conclude with a summary when the
+> task is done."
+
+But this is relay-mechanics-layer instruction — it describes what the tools do,
+not when or why to use them in a storyboard meeting context. The
+`kata-storyboard` skill is far more detailed, contextually specific, and loaded
+later in the prompt. When the agent loaded the skill (turn 0 via
+`Skill("kata-storyboard")`), it followed the skill's self-sufficient procedure
+and never circled back to the system prompt's tool guidance.
+
+This follows a known pattern from trace analysis: when a more detailed skill
+procedure exists, agents follow it over generic system-level guidance. The
+instruction layering rule in KATA.md is clear — "skills define steps" — and the
+storyboard skill's steps are all solo actions.
+
+### Agents use lazy start — they need Tell to wake up
+
+The `Facilitator` class in `facilitator.js:162-167` uses lazy agent startup:
+agents block on `messageBus.waitForMessages()` until the facilitator sends them
+a message via Tell or Share. Since the coach never called Tell or Share, the
+five participant agents never started. The orchestration infrastructure worked
+exactly as designed — the instructions failed to trigger it.
+
+### Evidence from the trace
+
+The facilitator trace (`facilitator-trace.ndjson`, 130 events, 55 turns) shows:
+
+- **Turn 0:** Loaded `kata-storyboard` skill via `Skill()` tool
+- **Turns 1-10:** Read storyboard template, coaching protocol, wiki summaries
+  for all five agents — all via direct file reads (Read tool), not via Tell
+- **Turns 11-15:** Read weekly logs for all agents — direct file reads
+- **Turns 16-30:** Ran `gh run list`, `gh api`, counted outcomes, read
+  specs/STATUS, ran `bun run test` — all solo research
+- **Turns 31-38:** Wrote storyboard, weekly log, updated summary, ran checks,
+  committed, pushed
+- **Turn 39:** Verified do-confirm checklist, produced meeting summary
+
+Zero RollCall. Zero Tell. Zero Share. Zero Conclude. The combined trace
+confirms: 130 facilitator events, 1 orchestrator `session_start` event, zero
+agent events.
+
+## Proposal
+
+Close the instruction gap by making the `kata-storyboard` skill explicitly
+orchestration-aware. The facilitation mechanism — how the coach uses Tell,
+Share, RollCall, and Conclude to run the meeting through participant agents —
+must be part of the skill's domain procedure, not left to generic system-level
+tool descriptions.
+
+### Add facilitation steps to the storyboard process
+
+The skill's Process section must require the facilitator to communicate with
+participant agents via the orchestration tools (RollCall, Tell, Share, Redirect,
+Conclude) rather than reading agent wiki files directly. Domain data comes from
+agents reporting it in response to the coach's questions, not from the coach
+extracting it via file reads.
+
+The coach still owns the storyboard artifact (reading, writing, committing) and
+the session lifecycle (opening with RollCall, closing with Conclude). The exact
+interleaving of tool calls with coaching steps is a design concern — the
+requirement is that every coaching question reaches participants through
+orchestration tools and every participant response flows back through the
+message bus.
+
+### Update the coaching protocol reference
+
+`references/coaching-protocol.md` currently uses passive voice: "each agent
+reports," "agents identify obstacles." Rewrite with explicit facilitation
+mechanics: which tool the coach uses to pose each question, how agents respond,
+and how the coach collects and integrates responses before moving to the next
+question.
+
+### Preserve instruction layering
+
+Per KATA.md's authoring guidance: "skills define steps." The facilitation
+mechanism is a step-level concern — it belongs in the skill, not in the system
+prompt. The FACILITATOR_SYSTEM_PROMPT remains as-is (it correctly describes tool
+semantics at the relay layer). The skill gains the domain-specific procedure for
+when and why to use those tools in a storyboard meeting.
+
+## Scope
+
+### Affected
+
+- `.claude/skills/kata-storyboard/SKILL.md` — add orchestration-aware process
+  steps, add context detection (facilitated vs. solo), update checklists
+- `.claude/skills/kata-storyboard/references/coaching-protocol.md` — rewrite
+  with explicit facilitation mechanics per question
+
+### Excluded
+
+- `libraries/libeval/src/facilitator.js` — orchestration infrastructure works
+  correctly; the bug is in instructions, not code
+- `libraries/libeval/src/orchestration-toolkit.js` — tools work correctly
+- `.github/workflows/daily-meeting.yml` — workflow configuration is correct
+- `.github/workflows/coaching-session.yml` — workflow configuration is correct
+- `.claude/agents/improvement-coach.md` — agent profile routing is correct
+- `FACILITATOR_SYSTEM_PROMPT` — relay-layer description is correct
+- Domain agent profiles — they receive correct facilitated agent system prompts
+
+## Dependencies
+
+- **Spec 440** (`plan implemented`) — orchestration tools and facilitate mode
+- **Spec 460** (`plan implemented`) — kata-storyboard skill and daily-meeting
+  workflow (the artifacts this spec modifies)
+
+## Success Criteria
+
+1. The `kata-storyboard` Process section requires the facilitator to use
+   orchestration tools (RollCall, Tell, Share, Redirect, Conclude) to
+   communicate with participant agents rather than reading their wiki files
+   directly.
+2. `references/coaching-protocol.md` specifies the facilitation mechanism for
+   each of the five questions — which tool the coach uses to pose the question
+   and how agents respond.
+3. The read-do and do-confirm checklists include orchestration-specific items.
+4. `bun run check` and `bun run test` pass with no regressions.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -66,4 +66,4 @@
 460	plan	implemented
 470	plan	implemented
 480	spec	draft
-490	spec	draft
+490	spec	approved

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -66,3 +66,4 @@
 460	plan	implemented
 470	plan	implemented
 480	spec	draft
+490	spec	draft


### PR DESCRIPTION
## Summary

- The kata-storyboard skill's Process section is a self-sufficient solo procedure that never mentions orchestration tools (RollCall, Tell, Share, Redirect, Conclude) by name
- Trace from daily-meeting run 24439250411 confirms: the improvement-coach ran all 55 turns solo, zero orchestration tool calls, zero participant agent turns
- Root cause is an instruction layering conflict — the FACILITATOR_SYSTEM_PROMPT describes tool semantics but the more detailed skill procedure dominates agent behavior

## Test plan

- [ ] Verify `bun run check` passes
- [ ] Verify `bun run test` passes
- [ ] Review spec for WHAT/WHY clarity — no implementation details

🤖 Generated with [Claude Code](https://claude.com/claude-code)