### PR TITLE
fix(kata): give storyboard meeting participants repo access

### DIFF
--- a/.claude/skills/kata-metrics/SKILL.md
+++ b/.claude/skills/kata-metrics/SKILL.md
@@ -49,5 +49,5 @@ definitions, types, and appending rules.
 
 ## XmR Analysis
 
-See [`references/xmr.md`](references/xmr.md) for chart construction, JSON
-report format, signal rules, and interpretation guidance.
+See [`references/xmr.md`](references/xmr.md) for chart construction, JSON report
+format, signal rules, and interpretation guidance.

--- a/.claude/skills/kata-metrics/scripts/xmr.mjs
+++ b/.claude/skills/kata-metrics/scripts/xmr.mjs
@@ -90,6 +90,7 @@ function streaks(dates, series, test, makeSignal) {
   return signals;
 }
 
+// eslint-disable-next-line complexity -- inherent to 4 XMR rules
 function detectSignals(dates, values, mrs, stats) {
   const { xBar, unpl, lnpl, url } = stats;
   const signals = [];

--- a/.claude/skills/kata-storyboard/references/coaching-protocol.md
+++ b/.claude/skills/kata-storyboard/references/coaching-protocol.md
@@ -31,10 +31,12 @@ Agents hear the same direction and can orient before the coach asks Q2.
 
 ### Facilitation
 
-The coach poses Q2 to each agent individually via **Tell**. Each agent responds
-by broadcasting their domain metrics via **Share** — all participants see every
-response, enabling cross-domain awareness. The coach collects all responses
-before moving to Q3.
+The coach poses Q2 to each agent individually via **Tell**. Include the
+facilitator's working directory path in each Tell message so agents can locate
+the repository checkout for direct measurement (e.g., `specs/STATUS`,
+`wiki/<agent>.md`). Each agent responds by broadcasting their domain metrics via
+**Share** — all participants see every response, enabling cross-domain
+awareness. The coach collects all responses before moving to Q3.
 
 ## Question 3: What obstacles are preventing us from reaching the target condition?
 

--- a/.github/workflows/daily-meeting.yml
+++ b/.github/workflows/daily-meeting.yml
@@ -51,7 +51,7 @@ jobs:
             coaching kata questions with all participants. Update the storyboard
             with fresh metrics and experiment progress.
           facilitator-profile: "improvement-coach"
-          agents: "security-engineer:role=security-engineer,technical-writer:role=technical-writer,product-manager:role=product-manager,staff-engineer:role=staff-engineer,release-engineer:role=release-engineer"
+          agents: "security-engineer:role=security-engineer:cwd=.,technical-writer:role=technical-writer:cwd=.,product-manager:role=product-manager:cwd=.,staff-engineer:role=staff-engineer:cwd=.,release-engineer:role=release-engineer:cwd=."
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}


### PR DESCRIPTION
## Summary

- Add `cwd=.` to all 5 agent configs in `daily-meeting.yml` so participant
  agents start in the repo checkout instead of empty temp directories
- Update coaching protocol Q2 facilitation guidance to include the working
  directory path in Tell messages as a safety net

**Root cause:** `parseAgentConfigs()` in `facilitate.js` defaults to
`mkdtempSync()` when no `cwd` is specified. All 5 agents spawned in
`/tmp/fit-eval-{name}-*` with no files. Agents wasted 90+ turns running
`ls`, `git status`, `find` in empty dirs before two agents explicitly
asked the facilitator for the repo path.

**Traced from:** Run [24449733970](https://github.com/forwardimpact/monorepo/actions/runs/24449733970)
(2026-04-15 daily meeting). Core category: PARTICIPANT_ISOLATION.

## Test plan

- [ ] Next daily-meeting run: verify agents start in the repo checkout
      (no "working directory is empty" messages in trace)
- [ ] Confirm `parseAgentConfigs` correctly resolves `cwd=.` to the
      checkout directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)