### PR TITLE
fix(kata): inject agent identity into facilitated session system prompt

### DIFF
--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -475,7 +475,11 @@ export function createFacilitator({
       systemPrompt: {
         type: "preset",
         preset: "claude_code",
-        append: FACILITATED_AGENT_SYSTEM_PROMPT,
+        append:
+          `You are "${config.name}" (role: ${config.role}). ` +
+          FACILITATED_AGENT_SYSTEM_PROMPT +
+          " Report only on your own domain — do not duplicate " +
+          "other participants' areas.",
       },
     });
 

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -479,7 +479,10 @@ export function createFacilitator({
           `You are "${config.name}" (role: ${config.role}). ` +
           FACILITATED_AGENT_SYSTEM_PROMPT +
           " Report only on your own domain — do not duplicate " +
-          "other participants' areas.",
+          "other participants' areas. " +
+          "The facilitator's messages contain measured data — use it " +
+          "as your starting point rather than re-gathering the same " +
+          "information.",
       },
     });
 


### PR DESCRIPTION
## Summary

- Interpolates `config.name` and `config.role` into `FACILITATED_AGENT_SYSTEM_PROMPT` so each agent knows its identity in facilitated meetings
- Adds domain-boundary instruction ("report only on your own domain") to prevent role mirroring
- Adds "use facilitator data" instruction to reduce redundant data gathering (~17 duplicate tool calls per meeting)

## Trace Evidence

- Run [24461540859](https://github.com/forwardimpact/monorepo/actions/runs/24461540859): 5/5 agents adopted "Staff Engineer" identity (UNIVERSAL_ROLE_ADOPTION)
- Run [24464669481](https://github.com/forwardimpact/monorepo/actions/runs/24464669481): confirmed saturation — same 5/5 pattern, plus REDUNDANT_DATA_GATHERING (all agents re-ran facilitator's commands)

## Change

Two commits in `libraries/libeval/src/facilitator.js:476-485`:
1. Prepend agent identity (`You are "<name>" (role: <role>)`)
2. Append domain boundary + data reuse instructions

## Test plan

- [x] `bun test libraries/libeval/test/` — 115 pass, 0 fail
- [x] Lint clean
- [x] Format clean (our file passes; pre-existing `index.mjs` failure on main)
- [ ] Next daily-meeting run should show domain-diverse reports and reduced redundant tool calls


🤖 Generated with [Claude Code](https://claude.com/claude-code)