### PR TITLE
feat(500): agent identity via profile loading, not prompt injection

### DIFF
--- a/.github/actions/kata-action/action.yml
+++ b/.github/actions/kata-action/action.yml
@@ -21,8 +21,9 @@ inputs:
     required: false
     default: "."
   agent-cwd:
-    description: Agent working directory (for "supervise" mode)
+    description: Agent working directory (for supervise and facilitate modes)
     required: false
+    default: "."
   model:
     description: Claude model to use
     required: false
@@ -53,10 +54,8 @@ inputs:
       Facilitator profile name (passed as --facilitator-profile, facilitate mode
       only)
     required: false
-  agents:
-    description:
-      Comma-separated agent configs for facilitate mode (format
-      "name1:role=x,name2:role=y")
+  agent-profiles:
+    description: Comma-separated agent profile names for facilitate mode
     required: false
   task-amend:
     description: Additional text appended to the task prompt for steering
@@ -109,7 +108,7 @@ runs:
         SUPERVISOR_PROFILE: ${{ inputs.supervisor-profile }}
         AGENT_PROFILE: ${{ inputs.agent-profile }}
         FACILITATOR_PROFILE: ${{ inputs.facilitator-profile }}
-        AGENTS: ${{ inputs.agents }}
+        AGENT_PROFILES: ${{ inputs.agent-profiles }}
         TASK_AMEND: ${{ inputs.task-amend }}
         TRACE_ENABLED: ${{ inputs.trace }}
         TRACE_DIR: ${{ steps.setup.outputs.trace-dir }}
@@ -172,7 +171,8 @@ runs:
 
           bunx fit-eval facilitate \
             --facilitator-cwd="." \
-            --agents="$AGENTS" \
+            --agent-profiles="$AGENT_PROFILES" \
+            --agent-cwd="$AGENT_CWD" \
             --model="$MODEL" \
             "${args[@]}"
         else

--- a/.github/actions/post-run/index.mjs
+++ b/.github/actions/post-run/index.mjs
@@ -1,2 +1,5 @@
 import { appendFileSync } from "fs";
-appendFileSync(process.env.GITHUB_STATE, `command=${process.env.INPUT_COMMAND}\n`);
+appendFileSync(
+  process.env.GITHUB_STATE,
+  `command=${process.env.INPUT_COMMAND}\n`,
+);

--- a/.github/workflows/coaching-session.yml
+++ b/.github/workflows/coaching-session.yml
@@ -53,7 +53,7 @@ jobs:
             analyze their own most recent trace using kata-trace. Help them
             identify obstacles and design their next experiment.
           facilitator-profile: "improvement-coach"
-          agents: "${{ inputs.agent }}:role=${{ inputs.agent }}"
+          agent-profiles: "${{ inputs.agent }}"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/daily-meeting.yml
+++ b/.github/workflows/daily-meeting.yml
@@ -51,7 +51,7 @@ jobs:
             coaching kata questions with all participants. Update the storyboard
             with fresh metrics and experiment progress.
           facilitator-profile: "improvement-coach"
-          agents: "security-engineer:role=security-engineer:cwd=.,technical-writer:role=technical-writer:cwd=.,product-manager:role=product-manager:cwd=.,staff-engineer:role=staff-engineer:cwd=.,release-engineer:role=release-engineer:cwd=."
+          agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/libraries/libeval/bin/fit-eval.js
+++ b/libraries/libeval/bin/fit-eval.js
@@ -117,10 +117,13 @@ const definition = {
           type: "string",
           description: "Facilitator profile name",
         },
-        agents: {
+        "agent-profiles": {
           type: "string",
-          description:
-            "Agent configs: name1:cwd=/tmp/a:role=explorer,name2:cwd=/tmp/b:role=tester",
+          description: "Comma-separated agent profile names",
+        },
+        "agent-cwd": {
+          type: "string",
+          description: "Agent working directory (default: .)",
         },
       },
     },
@@ -135,7 +138,7 @@ const definition = {
     "fit-eval output --format=text < trace.ndjson",
     "fit-eval run --task-file=task.md --model=opus",
     "fit-eval supervise --task-file=task.md --supervisor-cwd=.",
-    'fit-eval facilitate --task-file=task.md --agents "explorer:cwd=/tmp/a,tester:cwd=/tmp/b"',
+    'fit-eval facilitate --task-file=task.md --agent-profiles "security-engineer,technical-writer"',
   ],
 };
 

--- a/libraries/libeval/src/commands/facilitate.js
+++ b/libraries/libeval/src/commands/facilitate.js
@@ -37,8 +37,6 @@ function parseFacilitateOptions(values) {
   if (!profilesRaw) throw new Error("--agent-profiles is required");
   const agentCwd = resolve(values["agent-cwd"] ?? ".");
   const agentConfigs = parseAgentProfiles(profilesRaw, agentCwd);
-  if (agentConfigs.length < 1)
-    throw new Error("--agent-profiles must specify at least one profile");
 
   const maxTurnsRaw = values["max-turns"] ?? "20";
 

--- a/libraries/libeval/src/commands/facilitate.js
+++ b/libraries/libeval/src/commands/facilitate.js
@@ -1,30 +1,18 @@
-import { readFileSync, createWriteStream, mkdtempSync } from "node:fs";
-import { resolve, join } from "node:path";
-import { tmpdir } from "node:os";
+import { readFileSync, createWriteStream } from "node:fs";
+import { resolve } from "node:path";
 import { createFacilitator } from "../facilitator.js";
 import { createTeeWriter } from "../tee-writer.js";
 
 /**
- * Parse agent config string into structured configs.
- * Format: "name1:key=val:key=val,name2:key=val"
- * @param {string} raw
- * @returns {Array<{name: string, role: string, cwd: string, maxTurns?: number}>}
+ * Parse comma-separated agent profile names into structured configs.
+ * @param {string} raw - Comma-separated profile names
+ * @param {string} cwd - Shared working directory for all agents
+ * @returns {Array<{name: string, role: string, cwd: string, agentProfile: string}>}
  */
-function parseAgentConfigs(raw) {
-  return raw.split(",").map((spec) => {
-    const parts = spec.split(":");
-    const name = parts[0];
-    const config = { name, role: name };
-    for (let i = 1; i < parts.length; i++) {
-      const [key, val] = parts[i].split("=");
-      if (key === "cwd") config.cwd = resolve(val);
-      else if (key === "role") config.role = val;
-      else if (key === "maxTurns") config.maxTurns = parseInt(val, 10);
-    }
-    if (!config.cwd) {
-      config.cwd = mkdtempSync(join(tmpdir(), `fit-eval-${name}-`));
-    }
-    return config;
+function parseAgentProfiles(raw, cwd) {
+  return raw.split(",").map((entry) => {
+    const name = entry.trim();
+    return { name, role: name, cwd, agentProfile: name };
   });
 }
 
@@ -45,12 +33,12 @@ function parseFacilitateOptions(values) {
   let taskContent = taskFile ? readFileSync(taskFile, "utf8") : taskText;
   if (taskAmend) taskContent += `\n\n${taskAmend}`;
 
-  const agentsRaw = values.agents;
-  if (!agentsRaw) throw new Error("--agents is required");
-
-  const agentConfigs = parseAgentConfigs(agentsRaw);
+  const profilesRaw = values["agent-profiles"];
+  if (!profilesRaw) throw new Error("--agent-profiles is required");
+  const agentCwd = resolve(values["agent-cwd"] ?? ".");
+  const agentConfigs = parseAgentProfiles(profilesRaw, agentCwd);
   if (agentConfigs.length < 1)
-    throw new Error("--agents must specify at least one agent");
+    throw new Error("--agent-profiles must specify at least one profile");
 
   const maxTurnsRaw = values["max-turns"] ?? "20";
 

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -475,14 +475,7 @@ export function createFacilitator({
       systemPrompt: {
         type: "preset",
         preset: "claude_code",
-        append:
-          `You are "${config.name}" (role: ${config.role}). ` +
-          FACILITATED_AGENT_SYSTEM_PROMPT +
-          " Report only on your own domain — do not duplicate " +
-          "other participants' areas. " +
-          "The facilitator's messages contain measured data — use it " +
-          "as your starting point rather than re-gathering the same " +
-          "information.",
+        append: FACILITATED_AGENT_SYSTEM_PROMPT,
       },
     });
 

--- a/specs/500-facilitated-agent-identity/design.md
+++ b/specs/500-facilitated-agent-identity/design.md
@@ -1,0 +1,120 @@
+# Design 500 — Facilitated Agent Identity via Profile Loading
+
+## Context
+
+Spec 500 identified that facilitated agents collapse to a single identity
+because they receive an anonymous system prompt. The root cause is simpler than
+the spec's prompt-injection fix suggests: agents are spawned in temp directories
+where `.claude/agents/` does not exist, so the Claude Agent SDK never loads
+their profile. The profiles already contain name, description, model, and skill
+assignments — everything needed for identity and domain focus.
+
+This design addresses identity and domain focus by making profiles load
+correctly. It does not add defensive prompt instructions — if the profile loads,
+the agent knows who it is.
+
+## Components
+
+Three components change. No new components are introduced.
+
+### 1. `fit-eval facilitate` CLI option
+
+**Current:** `--agents` accepts a colon-delimited config string
+(`name:role=x:cwd=y`) parsed by `parseAgentConfigs()`. `--agent-profile` exists
+on `run` and `supervise` commands but not on `facilitate`.
+
+**Changed:** Replace `--agents` with `--agent-profiles` (comma-separated list of
+profile names). Add `--agent-cwd` (single directory, shared by all agents).
+
+```
+# Before
+fit-eval facilitate --agents "sec:role=sec:cwd=.,tw:role=tw:cwd=."
+
+# After
+fit-eval facilitate --agent-profiles "security-engineer,technical-writer,..." \
+                    --agent-cwd "."
+```
+
+Agent name and role derive from the profile name — no separate `role` or `name`
+parsing. `cwd` is a single value for all agents, not per-agent.
+
+**Rejected alternative — keep `--agents` and add `agentProfile` parsing.** The
+`name:key=val` format exists because agents previously needed per-agent cwd and
+role overrides. With profiles supplying identity and a shared cwd, the parsing
+complexity is unnecessary.
+
+### 2. `parseAgentConfigs()` in facilitate.js
+
+**Current:** Parses `name:key=val:key=val,...` into config objects. Creates temp
+directories when cwd is absent. Never sets `agentProfile`.
+
+**Changed:** Replace with a function that splits the comma-separated profile
+list and pairs each with the shared cwd. Each config gets
+`{ name: profileName, role: profileName, cwd: agentCwd, agentProfile: profileName }`.
+
+**Rejected alternative — retain per-agent cwd.** No current or planned use case
+requires agents in different directories. A single `--agent-cwd` eliminates the
+temp-directory default that caused the original bug.
+
+### 3. `FACILITATED_AGENT_SYSTEM_PROMPT` append in facilitator.js
+
+**Current (post-4f18e5f):** Prepends `You are "${config.name}" (role: ...)` and
+appends domain-focus and data-reuse instructions to every agent's system prompt.
+
+**Changed:** Remove the identity prefix and domain-focus instruction. The
+profile provides identity and domain context. Retain only the base
+`FACILITATED_AGENT_SYSTEM_PROMPT` constant (orchestration tool descriptions)
+which agents need regardless of identity.
+
+**Rejected alternative — keep the identity prefix as defense-in-depth.**
+Duplicating identity across profile and prompt creates two sources of truth. If
+they diverge (e.g. profile renamed but prompt not updated), the agent receives
+contradictory identity signals. A single authoritative source — the profile —
+is both simpler and correct by construction.
+
+## Data Flow
+
+```mermaid
+graph LR
+  W[Workflow YAML] -->|--agent-profiles, --agent-cwd| CLI[fit-eval facilitate]
+  CLI -->|profile list + cwd| F[createFacilitator]
+  F -->|per agent: agentProfile, cwd| R[createAgentRunner]
+  R -->|extraArgs.agent + cwd| SDK[Claude Agent SDK]
+  SDK -->|reads .claude/agents/name.md| P[Agent Profile]
+  P -->|identity, skills| SYS[System Prompt]
+  PROMPT[FACILITATED_AGENT_SYSTEM_PROMPT] -->|orchestration tools| SYS
+```
+
+Each agent runner receives the profile name via `agentProfile` and the monorepo
+as `cwd`. The SDK resolves `.claude/agents/{name}.md` relative to cwd, loading
+the full profile with identity, description, and skills. The system prompt
+append contributes only orchestration tool descriptions — identity comes
+entirely from the profile.
+
+## Workflow Interface
+
+Workflow callers (`kata-action`, `daily-meeting.yml`, `coaching-session.yml`)
+replace the `agents` input with two inputs: `agent-profiles` (comma-separated
+profile names) and `agent-cwd` (single directory, defaults to `.`). The
+`kata-action` facilitate branch passes these as `--agent-profiles` and
+`--agent-cwd` to `fit-eval facilitate`.
+
+## Scope Boundary
+
+This design addresses spec 500 success criteria 1 (identity) and 2 (domain
+focus) through profile loading. It does not address criterion 3 (data reuse of
+facilitator broadcasts). Data reuse is a facilitation protocol concern — it
+governs how the facilitator's broadcast content is consumed, not whether agents
+know their identity. Solving identity first lets us observe whether diverse,
+domain-aware agents naturally reduce redundant data gathering before adding
+protocol-level instructions. Criterion 3 will be evaluated separately after
+this change lands and its trace impact is measured.
+
+## Success Criteria Mapping
+
+| Spec criterion | Addressed | Mechanism |
+|---|---|---|
+| 1. System prompt contains name/role | Yes | Profile loaded by SDK provides full identity |
+| 2. Domain-specific reporting | Yes | Profile skills list defines domain |
+| 3. Reuse facilitator data | No | Deferred — independent protocol concern |
+| 4. `bun run check` passes | Yes | Verified at implementation |

--- a/specs/500-facilitated-agent-identity/design.md
+++ b/specs/500-facilitated-agent-identity/design.md
@@ -69,8 +69,8 @@ which agents need regardless of identity.
 **Rejected alternative — keep the identity prefix as defense-in-depth.**
 Duplicating identity across profile and prompt creates two sources of truth. If
 they diverge (e.g. profile renamed but prompt not updated), the agent receives
-contradictory identity signals. A single authoritative source — the profile —
-is both simpler and correct by construction.
+contradictory identity signals. A single authoritative source — the profile — is
+both simpler and correct by construction.
 
 ## Data Flow
 
@@ -107,14 +107,14 @@ facilitator broadcasts). Data reuse is a facilitation protocol concern — it
 governs how the facilitator's broadcast content is consumed, not whether agents
 know their identity. Solving identity first lets us observe whether diverse,
 domain-aware agents naturally reduce redundant data gathering before adding
-protocol-level instructions. Criterion 3 will be evaluated separately after
-this change lands and its trace impact is measured.
+protocol-level instructions. Criterion 3 will be evaluated separately after this
+change lands and its trace impact is measured.
 
 ## Success Criteria Mapping
 
-| Spec criterion | Addressed | Mechanism |
-|---|---|---|
-| 1. System prompt contains name/role | Yes | Profile loaded by SDK provides full identity |
-| 2. Domain-specific reporting | Yes | Profile skills list defines domain |
-| 3. Reuse facilitator data | No | Deferred — independent protocol concern |
-| 4. `bun run check` passes | Yes | Verified at implementation |
+| Spec criterion                      | Addressed | Mechanism                                    |
+| ----------------------------------- | --------- | -------------------------------------------- |
+| 1. System prompt contains name/role | Yes       | Profile loaded by SDK provides full identity |
+| 2. Domain-specific reporting        | Yes       | Profile skills list defines domain           |
+| 3. Reuse facilitator data           | No        | Deferred — independent protocol concern      |
+| 4. `bun run check` passes           | Yes       | Verified at implementation                   |

--- a/specs/500-facilitated-agent-identity/plan-a.md
+++ b/specs/500-facilitated-agent-identity/plan-a.md
@@ -140,8 +140,8 @@ agent-profiles:
   required: false
 ```
 
-3. Update the existing `agent-cwd` input (lines 23-25) — broaden the
-   description and add a default:
+3. Update the existing `agent-cwd` input (lines 23-25) — broaden the description
+   and add a default:
 
 ```yaml
 # Before
@@ -156,8 +156,8 @@ agent-cwd:
   default: "."
 ```
 
-Env block — remove the `AGENTS` line (line 112) and add `AGENT_PROFILES`.
-Leave the existing `AGENT_CWD` line (line 104) unchanged:
+Env block — remove the `AGENTS` line (line 112) and add `AGENT_PROFILES`. Leave
+the existing `AGENT_CWD` line (line 104) unchanged:
 
 ```yaml
 # Remove
@@ -219,14 +219,14 @@ option changes.
 
 ## Blast radius
 
-| File | Action |
-|---|---|
-| `libraries/libeval/bin/fit-eval.js` | Modified — option definition + example |
-| `libraries/libeval/src/commands/facilitate.js` | Modified — replace parser, update imports |
-| `libraries/libeval/src/facilitator.js` | Modified — simplify system prompt append |
-| `.github/actions/kata-action/action.yml` | Modified — inputs + env + facilitate branch |
-| `.github/workflows/daily-meeting.yml` | Modified — replace `agents` with `agent-profiles` |
-| `.github/workflows/coaching-session.yml` | Modified — replace `agents` with `agent-profiles` |
+| File                                           | Action                                            |
+| ---------------------------------------------- | ------------------------------------------------- |
+| `libraries/libeval/bin/fit-eval.js`            | Modified — option definition + example            |
+| `libraries/libeval/src/commands/facilitate.js` | Modified — replace parser, update imports         |
+| `libraries/libeval/src/facilitator.js`         | Modified — simplify system prompt append          |
+| `.github/actions/kata-action/action.yml`       | Modified — inputs + env + facilitate branch       |
+| `.github/workflows/daily-meeting.yml`          | Modified — replace `agents` with `agent-profiles` |
+| `.github/workflows/coaching-session.yml`       | Modified — replace `agents` with `agent-profiles` |
 
 No files created. No files deleted.
 

--- a/specs/500-facilitated-agent-identity/plan-a.md
+++ b/specs/500-facilitated-agent-identity/plan-a.md
@@ -1,0 +1,249 @@
+# Plan 500-A — Facilitated Agent Identity via Profile Loading
+
+## Approach
+
+Replace the `--agents` colon-delimited config string with `--agent-profiles`
+(comma-separated profile names) and `--agent-cwd` (single shared directory).
+This makes the Claude Agent SDK load `.claude/agents/{name}.md` for each
+facilitated agent, giving it full identity and domain context. Then strip the
+defensive identity/domain/data-reuse prompt injection from `facilitator.js`,
+leaving only the orchestration tool descriptions.
+
+Six files change, one function is replaced, no files are created or deleted.
+
+## Ordering
+
+Steps 1 and 2 are tightly coupled (CLI definition → parser). Step 3 (prompt
+cleanup) is independent. Step 4 (workflows) depends on step 1 (new option
+names). Step 5 (verification) depends on all prior steps.
+
+## Steps
+
+### Step 1. Replace `--agents` with `--agent-profiles` and `--agent-cwd` in CLI definition
+
+**File:** `libraries/libeval/bin/fit-eval.js` (lines 120-124, 138)
+
+Replace the `agents` option in the `facilitate` command definition:
+
+```js
+// Before
+agents: {
+  type: "string",
+  description:
+    "Agent configs: name1:cwd=/tmp/a:role=explorer,name2:cwd=/tmp/b:role=tester",
+},
+
+// After
+"agent-profiles": {
+  type: "string",
+  description: "Comma-separated agent profile names",
+},
+"agent-cwd": {
+  type: "string",
+  description: "Agent working directory (default: .)",
+},
+```
+
+Update the example (line 138):
+
+```js
+// Before
+'fit-eval facilitate --task-file=task.md --agents "explorer:cwd=/tmp/a,tester:cwd=/tmp/b"'
+
+// After
+'fit-eval facilitate --task-file=task.md --agent-profiles "security-engineer,technical-writer"'
+```
+
+### Step 2. Replace `parseAgentConfigs()` and update `parseFacilitateOptions()`
+
+**File:** `libraries/libeval/src/commands/facilitate.js`
+
+Remove the `parseAgentConfigs()` function (lines 7-29) and the `mkdtempSync`,
+`join`, `tmpdir` imports it uses. Replace with:
+
+```js
+function parseAgentProfiles(raw, cwd) {
+  return raw.split(",").map((entry) => {
+    const name = entry.trim();
+    return { name, role: name, cwd, agentProfile: name };
+  });
+}
+```
+
+In `parseFacilitateOptions()`, replace:
+
+```js
+// Before
+const agentsRaw = values.agents;
+if (!agentsRaw) throw new Error("--agents is required");
+const agentConfigs = parseAgentConfigs(agentsRaw);
+if (agentConfigs.length < 1)
+  throw new Error("--agents must specify at least one agent");
+
+// After
+const profilesRaw = values["agent-profiles"];
+if (!profilesRaw) throw new Error("--agent-profiles is required");
+const agentCwd = resolve(values["agent-cwd"] ?? ".");
+const agentConfigs = parseAgentProfiles(profilesRaw, agentCwd);
+if (agentConfigs.length < 1)
+  throw new Error("--agent-profiles must specify at least one profile");
+```
+
+The `resolve` import already exists. Remove the now-unused `mkdtempSync` from
+`"node:fs"`, `join` from `"node:path"`, and the `tmpdir` import from
+`"node:os"`.
+
+### Step 3. Strip identity/domain/data-reuse append from system prompt
+
+**File:** `libraries/libeval/src/facilitator.js` (lines 475-486)
+
+Replace the system prompt assembly in the `createAgentRunner` call:
+
+```js
+// Before
+systemPrompt: {
+  type: "preset",
+  preset: "claude_code",
+  append:
+    `You are "${config.name}" (role: ${config.role}). ` +
+    FACILITATED_AGENT_SYSTEM_PROMPT +
+    " Report only on your own domain — do not duplicate " +
+    "other participants' areas. " +
+    "The facilitator's messages contain measured data — use it " +
+    "as your starting point rather than re-gathering the same " +
+    "information.",
+},
+
+// After
+systemPrompt: {
+  type: "preset",
+  preset: "claude_code",
+  append: FACILITATED_AGENT_SYSTEM_PROMPT,
+},
+```
+
+### Step 4. Update workflow callers
+
+Three files change.
+
+**File:** `.github/actions/kata-action/action.yml`
+
+Inputs section — the `agent-cwd` input already exists (line 23) for supervise
+mode but has no default and a supervise-only description. Three changes:
+
+1. Remove the `agents` input (lines 56-60).
+2. Add `agent-profiles` input in its place:
+
+```yaml
+agent-profiles:
+  description: Comma-separated agent profile names for facilitate mode
+  required: false
+```
+
+3. Update the existing `agent-cwd` input (lines 23-25) — broaden the
+   description and add a default:
+
+```yaml
+# Before
+agent-cwd:
+  description: Agent working directory (for "supervise" mode)
+  required: false
+
+# After
+agent-cwd:
+  description: Agent working directory (for supervise and facilitate modes)
+  required: false
+  default: "."
+```
+
+Env block — remove the `AGENTS` line (line 112) and add `AGENT_PROFILES`.
+Leave the existing `AGENT_CWD` line (line 104) unchanged:
+
+```yaml
+# Remove
+AGENTS: ${{ inputs.agents }}
+
+# Add
+AGENT_PROFILES: ${{ inputs.agent-profiles }}
+```
+
+Facilitate branch (lines 173-177) — pass new options:
+
+```bash
+# Before
+bunx fit-eval facilitate \
+  --facilitator-cwd="." \
+  --agents="$AGENTS" \
+  --model="$MODEL" \
+  "${args[@]}"
+
+# After
+bunx fit-eval facilitate \
+  --facilitator-cwd="." \
+  --agent-profiles="$AGENT_PROFILES" \
+  --agent-cwd="$AGENT_CWD" \
+  --model="$MODEL" \
+  "${args[@]}"
+```
+
+**File:** `.github/workflows/daily-meeting.yml` (line 54)
+
+```yaml
+# Before
+agents: "security-engineer:role=security-engineer:cwd=.,..."
+
+# After
+agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
+```
+
+The `agent-cwd` input is not needed — the action default (`.`) is correct.
+
+**File:** `.github/workflows/coaching-session.yml` (line 56)
+
+```yaml
+# Before
+agents: "${{ inputs.agent }}:role=${{ inputs.agent }}"
+
+# After
+agent-profiles: "${{ inputs.agent }}"
+```
+
+The `agent-cwd` input is not needed — the action default (`.`) is correct.
+
+### Step 5. Verify
+
+Run `bun run check` to confirm no regressions. The existing facilitator tests
+(`facilitator.test.js`, `facilitator-messaging.test.js`) construct `Facilitator`
+directly with mock runners — they bypass CLI parsing and are unaffected by the
+option changes.
+
+## Blast radius
+
+| File | Action |
+|---|---|
+| `libraries/libeval/bin/fit-eval.js` | Modified — option definition + example |
+| `libraries/libeval/src/commands/facilitate.js` | Modified — replace parser, update imports |
+| `libraries/libeval/src/facilitator.js` | Modified — simplify system prompt append |
+| `.github/actions/kata-action/action.yml` | Modified — inputs + env + facilitate branch |
+| `.github/workflows/daily-meeting.yml` | Modified — replace `agents` with `agent-profiles` |
+| `.github/workflows/coaching-session.yml` | Modified — replace `agents` with `agent-profiles` |
+
+No files created. No files deleted.
+
+## Libraries used
+
+No shared `@forwardimpact/lib*` libraries are consumed by this change. The
+modifications use only Node.js built-ins (`node:fs`, `node:path`) and the
+existing `createFacilitator` and `createAgentRunner` internal imports.
+
+## Risks
+
+- **Profile name must match `.claude/agents/{name}.md` exactly.** If a workflow
+  passes a name that doesn't match a profile file, the SDK will not load a
+  profile. This is the existing behaviour for `run` and `supervise` modes —
+  facilitate simply adopts the same convention.
+
+## Execution
+
+Single agent: `staff-engineer`. All steps are sequential and small. No
+decomposition needed.

--- a/specs/500-facilitated-agent-identity/spec.md
+++ b/specs/500-facilitated-agent-identity/spec.md
@@ -7,9 +7,9 @@ main, branch `fix/coach-agent-identity`). This spec documents the rationale
 retroactively. Line references describe pre-fix state unless noted otherwise.
 
 Participant agents in facilitated daily meetings had no identity. The
-`FACILITATED_AGENT_SYSTEM_PROMPT` in `facilitator.js` was a static string —
-"You are one of several agents" — that never named the agent or its role. When
-five domain agents (staff-engineer, security-engineer, technical-writer,
+`FACILITATED_AGENT_SYSTEM_PROMPT` in `facilitator.js` was a static string — "You
+are one of several agents" — that never named the agent or its role. When five
+domain agents (staff-engineer, security-engineer, technical-writer,
 release-engineer, product-manager) received the same anonymous prompt and the
 same facilitator broadcast about technical topics (specs, CI, quality gates),
 they converged on whichever role best matched the shared context.
@@ -17,11 +17,11 @@ they converged on whichever role best matched the shared context.
 In three consecutive daily-meeting traces on 2026-04-15, this convergence
 worsened:
 
-| Trace (run ID)  | Role confusion rate | Manifestation                                |
-| --------------- | ------------------- | -------------------------------------------- |
-| 24459264601     | 1/5 (PM only)       | PM adopted facilitator voice, 0 domain Shares |
-| 24461540859     | 5/5                 | All agents titled "Staff Engineer — Current Condition" |
-| 24464669481     | 5/5                 | All agents titled "Staff Engineer perspective" |
+| Trace (run ID) | Role confusion rate | Manifestation                                          |
+| -------------- | ------------------- | ------------------------------------------------------ |
+| 24459264601    | 1/5 (PM only)       | PM adopted facilitator voice, 0 domain Shares          |
+| 24461540859    | 5/5                 | All agents titled "Staff Engineer — Current Condition" |
+| 24464669481    | 5/5                 | All agents titled "Staff Engineer perspective"         |
 
 The PM in the first trace was not uniquely vulnerable — it was the canary. By
 the third trace every agent self-identified as "Staff Engineer" and produced
@@ -47,18 +47,18 @@ observed problems:
 
 1. **Redundant data gathering.** When all agents believe they are the same role,
    they query the same data sources. In run 24464669481, `cat specs/STATUS` was
-   run 5 times, `gh issue list` 4 times, `gh run list` 4 times, and `bun run
-   check` 4 times — approximately 17 redundant tool calls producing identical
-   results. In run 24459264601, key files were read 6-9 times across agents (97
-   total Read calls). Agents also re-gather data the facilitator already
-   broadcast in Q1 because the prompt doesn't instruct them to use it.
+   run 5 times, `gh issue list` 4 times, `gh run list` 4 times, and
+   `bun run check` 4 times — approximately 17 redundant tool calls producing
+   identical results. In run 24459264601, key files were read 6-9 times across
+   agents (97 total Read calls). Agents also re-gather data the facilitator
+   already broadcast in Q1 because the prompt doesn't instruct them to use it.
 
 2. **Solo completion of Q2-Q5 (observed correlation).** The facilitator yields
-   correctly after Q1 (per commit 330e702), but after receiving five identical Q1
-   responses, it completed Q2-Q5 as a monologue in all three traces. Whether this
-   is caused by identity collapse or an independent facilitation-protocol issue is
-   not yet determined — diverse Q1 responses may provide sufficient incentive for
-   collaborative Q2-Q5, but this remains to be verified.
+   correctly after Q1 (per commit 330e702), but after receiving five identical
+   Q1 responses, it completed Q2-Q5 as a monologue in all three traces. Whether
+   this is caused by identity collapse or an independent facilitation-protocol
+   issue is not yet determined — diverse Q1 responses may provide sufficient
+   incentive for collaborative Q2-Q5, but this remains to be verified.
 
 3. **Redundant corrections.** When agents do catch stale data, the correction
    comes N times instead of once. In run 24461540859, four agents independently
@@ -83,15 +83,16 @@ than re-gathering it.
 
 The system prompt appended to each agent must include the agent's name and role.
 The `config.name` and `config.role` fields are already available at agent
-construction time — they must be interpolated into the prompt so each agent knows
-who it is without an identity-discovery loop.
+construction time — they must be interpolated into the prompt so each agent
+knows who it is without an identity-discovery loop.
 
 ### Domain focus
 
-The prompt must instruct each agent to report on its own domain and not duplicate
-other participants' areas. When a security-engineer receives this instruction
-alongside its identity, it should analyze supply chain and dependency security
-rather than mirroring the staff-engineer's specs pipeline analysis.
+The prompt must instruct each agent to report on its own domain and not
+duplicate other participants' areas. When a security-engineer receives this
+instruction alongside its identity, it should analyze supply chain and
+dependency security rather than mirroring the staff-engineer's specs pipeline
+analysis.
 
 ### Data reuse
 
@@ -137,8 +138,8 @@ not re-verify it.
    stated in the agent config.
 2. Each facilitated agent's system prompt instructs domain-specific reporting
    (not generic analysis).
-3. Each facilitated agent's system prompt instructs reuse of facilitator-provided
-   data.
+3. Each facilitated agent's system prompt instructs reuse of
+   facilitator-provided data.
 4. `bun run check` passes with no regressions.
 
 Runtime validation (role confusion rate, redundant tool call count, domain

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -67,4 +67,4 @@
 470	plan	implemented
 480	spec	draft
 490	plan	implemented
-500	design	draft
+500	plan	draft

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -67,4 +67,4 @@
 470	plan	implemented
 480	spec	draft
 490	plan	implemented
-500	plan	draft
+500	plan	implemented

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -67,4 +67,4 @@
 470	plan	implemented
 480	spec	draft
 490	plan	implemented
-500	spec	draft
+500	design	draft


### PR DESCRIPTION
## Summary

- Replace `--agents` colon-delimited config with `--agent-profiles` (comma-separated profile names) + `--agent-cwd` (shared directory) on `fit-eval facilitate`
- The Claude Agent SDK now loads `.claude/agents/{name}.md` for each facilitated agent, providing full identity and domain context via the profile
- Strip defensive identity/domain/data-reuse system prompt injection from `facilitator.js`, keeping only orchestration tool descriptions
- Update `kata-action`, `daily-meeting`, and `coaching-session` workflows

## Test plan

- [x] `bun run check` — passes (only pre-existing `post-run/index.mjs` format issue)
- [x] `bun run test` — 2339 pass, 0 fail
- [x] Clean sub-agent review of full diff — PASS, no actionable findings