### PR TITLE
fix(libeval): pass mcpServers on session resume

### DIFF
--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -108,6 +108,7 @@ export class AgentRunner {
           permissionMode: this.permissionMode,
           allowDangerouslySkipPermissions: true,
           abortController,
+          ...(this.mcpServers && { mcpServers: this.mcpServers }),
         },
       });
       return await this.#consumeQuery(iterator);

--- a/libraries/libeval/test/agent-runner.test.js
+++ b/libraries/libeval/test/agent-runner.test.js
@@ -207,6 +207,44 @@ describe("AgentRunner", () => {
     assert.strictEqual(result.text, "Resumed");
   });
 
+  test("resume() passes mcpServers when configured", async () => {
+    let resumeCapture = null;
+
+    const initMessages = [
+      { type: "system", subtype: "init", session_id: "sess-mcp" },
+      { type: "result", subtype: "success", result: "First done" },
+    ];
+
+    let callCount = 0;
+    const query = async function* (params) {
+      callCount++;
+      if (callCount === 1) {
+        for (const m of initMessages) yield m;
+      } else {
+        resumeCapture = params;
+        yield { type: "result", subtype: "success", result: "Resumed" };
+      }
+    };
+
+    const mcpServers = { orchestration: { command: "test-server" } };
+    const output = new PassThrough();
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query,
+      output,
+      mcpServers,
+    });
+
+    await runner.run("Initial task");
+    await runner.resume("Follow up");
+
+    assert.deepStrictEqual(
+      resumeCapture.options.mcpServers,
+      mcpServers,
+      "mcpServers must be passed on resume",
+    );
+  });
+
   test("drainOutput() returns buffered lines and clears buffer", async () => {
     const messages = [
       { type: "assistant", content: "Line 1" },


### PR DESCRIPTION
## Summary

- `AgentRunner.resume()` did not pass `mcpServers` to the SDK query, so MCP servers (including the orchestration toolkit) were lost on every resume boundary — the initial `run()` passed them correctly, but `resume()` only sent `sessionId` and `permissionMode`.
- This caused the facilitator to lose orchestration tools (RollCall, Share, Tell, Conclude) whenever it was resumed after an agent responded. Trace for daily-meeting run 24473022098 shows `mcp_servers: [{name: "orchestration", status: "connected"}]` on the initial init event (seq 4) but `mcp_servers: []` on every resume (seq 184, seq 398) — same `session_id` throughout.
- Downstream effect: coach had no way to pose Q2–Q5 via Tell/Share, so it fell back to solo mode and answered the remaining coaching kata questions from pre-gathered data instead of posing them to participants.
- Fix adds the same `mcpServers` spread to `resume()` that `run()` already has. New test verifies `mcpServers` is present in the resume query options.

## Test plan

- [x] `bun run check`
- [x] `bun test libraries/libeval/test/` (116 pass, 0 fail)
- [ ] Next facilitated daily-meeting run shows `mcp_servers: [{orchestration, connected}]` on all resume init events, not just the initial one
- [ ] Coach poses Q2–Q5 to participants via Tell in the next meeting

https://claude.ai/code/session_01Cf1xihMJghgZWYXkdmpDdR