### PR TITLE
fix(ci): authenticate wiki checkout and surface push errors

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -1,6 +1,14 @@
 name: Bootstrap
 description: Set up Bun, install just, and run just install
 
+inputs:
+  token:
+    description:
+      GitHub token with write access to the wiki. When provided, the wiki is
+      checked out into ./wiki and pushed back during post-run cleanup.
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -15,11 +23,20 @@ runs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+    - name: Checkout wiki
+      if: inputs.token != ''
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        repository: ${{ github.repository }}.wiki
+        path: wiki
+        token: ${{ inputs.token }}
+
     - name: Bootstrap
       shell: bash
       run: ./scripts/bootstrap.sh
 
     - name: Push wiki changes
+      if: inputs.token != ''
       uses: ./.github/actions/post-run
       with:
         command: just wiki-push

--- a/.github/workflows/coaching-session.yml
+++ b/.github/workflows/coaching-session.yml
@@ -37,6 +37,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: 1-on-1 Coaching Session
         uses: ./.github/actions/kata-action

--- a/.github/workflows/daily-meeting.yml
+++ b/.github/workflows/daily-meeting.yml
@@ -36,6 +36,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Team Storyboard Meeting
         uses: ./.github/actions/kata-action

--- a/.github/workflows/guide-setup.yml
+++ b/.github/workflows/guide-setup.yml
@@ -41,6 +41,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Prepare agent workspace
         id: agent-workspace

--- a/.github/workflows/landmark-setup.yml
+++ b/.github/workflows/landmark-setup.yml
@@ -41,6 +41,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Prepare agent workspace
         id: agent-workspace

--- a/.github/workflows/map-setup.yml
+++ b/.github/workflows/map-setup.yml
@@ -41,6 +41,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Prepare agent workspace
         id: agent-workspace

--- a/.github/workflows/product-manager.yml
+++ b/.github/workflows/product-manager.yml
@@ -36,6 +36,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Assess and Act
         uses: ./.github/actions/kata-action

--- a/.github/workflows/release-engineer.yml
+++ b/.github/workflows/release-engineer.yml
@@ -36,6 +36,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Assess and Act
         uses: ./.github/actions/kata-action

--- a/.github/workflows/security-engineer.yml
+++ b/.github/workflows/security-engineer.yml
@@ -36,6 +36,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Assess and Act
         uses: ./.github/actions/kata-action

--- a/.github/workflows/staff-engineer.yml
+++ b/.github/workflows/staff-engineer.yml
@@ -36,6 +36,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Assess and Act
         uses: ./.github/actions/kata-action

--- a/.github/workflows/summit-setup.yml
+++ b/.github/workflows/summit-setup.yml
@@ -41,6 +41,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Prepare agent workspace
         id: agent-workspace

--- a/.github/workflows/technical-writer.yml
+++ b/.github/workflows/technical-writer.yml
@@ -36,6 +36,8 @@ jobs:
           token: ${{ steps.ci-app.outputs.token }}
 
       - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
 
       - name: Assess and Act
         uses: ./.github/actions/kata-action

--- a/scripts/wiki-sync.sh
+++ b/scripts/wiki-sync.sh
@@ -9,11 +9,16 @@ WIKI_DIR="wiki"
 WIKI_URL="https://github.com/forwardimpact/monorepo.wiki.git"
 
 # ── Init: clone if missing ──
-if ! [ -d "$WIKI_DIR/.git" ]; then
-    git clone "$WIKI_URL" "$WIKI_DIR" 2>/dev/null || {
+# CI workflows pre-checkout the wiki with an authenticated token; skip the
+# clone when the wiki directory is already a git repo (handles both a
+# plain .git dir and a gitdir pointer file from an earlier submodule
+# checkout). For local dev without network, anonymous clone failure is
+# non-fatal — bootstrap continues without a wiki.
+if ! git -C "$WIKI_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    if ! git clone "$WIKI_URL" "$WIKI_DIR"; then
         echo "wiki-sync: could not clone wiki, skipping" >&2
         exit 0
-    }
+    fi
 fi
 
 cd "$WIKI_DIR"
@@ -23,14 +28,14 @@ git config user.name  "$(cd .. && git config user.name)"
 git config user.email "$(cd .. && git config user.email)"
 
 # ── Fetch latest ──
-git fetch origin master 2>/dev/null || exit 0
+git fetch origin master
 
 # ── Pull mode: rebase onto remote ──
 if [ "$MODE" = "pull" ]; then
-    git rebase origin/master 2>/dev/null || {
-        git rebase --abort 2>/dev/null || true
+    if ! git rebase origin/master; then
+        git rebase --abort || true
         git reset --hard origin/master
-    }
+    fi
     exit 0
 fi
 
@@ -41,10 +46,8 @@ if git diff --cached --quiet; then
 fi
 git commit -m "wiki: update from session"
 
-if ! git rebase origin/master 2>/dev/null; then
-    git rebase --abort 2>/dev/null || true
-    git merge origin/master -X ours --no-edit 2>/dev/null || {
-        git merge --abort 2>/dev/null || true
-    }
+if ! git rebase origin/master; then
+    git rebase --abort || true
+    git merge origin/master -X ours --no-edit
 fi
-git push origin master 2>/dev/null || true
+git push origin master


### PR DESCRIPTION
## Summary

- Pre-checkout the wiki in the bootstrap composite action using the caller's GitHub App installation token so `git push` to the wiki authenticates via `http.extraheader` (mirroring how `actions/checkout` wires auth for the main repo).
- Pass `token: ${{ steps.ci-app.outputs.token }}` to bootstrap from every kata workflow (11 files). Leave quality/test/publish workflows untouched — they don't need wiki write.
- Drop `2>/dev/null || true` throughout `scripts/wiki-sync.sh` so fetch/rebase/merge/push failures fail loudly instead of silently. Harden the clone guard to detect both a `.git/` directory and a gitdir pointer file.

Fixes the `AUTH_BOUNDARY` pattern the improvement-coach has been flagging for weeks: wiki memory updates from daily-meeting and other kata workflows were silently dropped because the wiki was cloned anonymously and every push returned 403 with the error piped to `/dev/null`.

## Test plan

- [x] `bun run check` passes locally
- [x] `bun run test` passes locally (2340/2341, 1 skipped)
- [x] `bash scripts/wiki-sync.sh pull` works with the existing gitdir pointer
- [x] `bash scripts/wiki-sync.sh push` no-ops cleanly when there are no changes
- [ ] CI Quality / Security / Test workflows pass on PR
- [ ] Next scheduled daily-meeting run successfully persists wiki updates (verify after merge)

https://claude.ai/code/session_011R5pLXpFrs1ZtBMq7Fg3k5