### PR TITLE
refactor(kata): schedule agents across three shifts on Paris time

### DIFF
--- a/.claude/skills/kata-storyboard/SKILL.md
+++ b/.claude/skills/kata-storyboard/SKILL.md
@@ -17,8 +17,8 @@ Protocol. Both use the same five coaching kata questions.
 ## When to Use
 
 **Facilitator**: Entry-point skill for the improvement coach's two facilitation
-contexts — team storyboard meetings (daily-meeting workflow) and 1-on-1 coaching
-sessions (coaching-session workflow).
+contexts — team storyboard meetings (kata-storyboard workflow) and 1-on-1
+coaching sessions (kata-coaching workflow).
 
 **Participant**: Loaded automatically when you join a storyboard meeting. Follow
 the Participant Protocol when the coach poses questions via orchestration tools.
@@ -127,9 +127,8 @@ try next? When will you know?
 7. **Evaluate coaching need (team meetings only).** Review the session's
    findings. If a participant would benefit from a 1-on-1 coaching session —
    persistent obstacles, unanalyzed traces, or stalled experiments — trigger
-   `coaching-session.yml` via
-   `gh workflow run coaching-session.yml -f agent=<name>`. Skip this step in
-   1-on-1 sessions.
+   `kata-coaching.yml` via `gh workflow run kata-coaching.yml -f agent=<name>`.
+   Skip this step in 1-on-1 sessions.
 8. **Commit.** Commit storyboard changes as part of the wiki push.
 9. **Conclude (facilitated mode only).** Call Conclude with a session summary
    covering: meeting type, key metrics reviewed, obstacles addressed,

--- a/.claude/skills/kata-trace/SKILL.md
+++ b/.claude/skills/kata-trace/SKILL.md
@@ -62,8 +62,9 @@ list recent runs and select using memory-informed rotation — see
 you selected and why.
 
 ```sh
-bunx fit-trace runs kata                   # list recent kata workflow runs
-bunx fit-trace runs kata --lookback 14d    # wider lookback window
+bunx fit-trace runs                        # list recent agent workflow runs (default)
+bunx fit-trace runs agent --lookback 14d   # wider lookback window
+bunx fit-trace runs kata                   # filter by a different workflow name substring
 ```
 
 ### 2. Download and Process the Trace

--- a/.github/workflows/agent-product-manager.yml
+++ b/.github/workflows/agent-product-manager.yml
@@ -2,8 +2,8 @@ name: "Agent: Product Manager"
 
 on:
   schedule:
-    # Triage first in each shift, before planning. Paris (CEST) times below.
-    - cron: "11 3 * * *" # Night shift — 05:11 Paris, finishes before 07:00
+    # Triage first in each shift so staff has fresh backlog. Paris (CEST) times below.
+    - cron: "23 1 * * *" # Night shift — 03:23 Paris, finishes before 07:00
     - cron: "17 10 * * *" # Day shift   — 12:17 Paris, finishes before 15:00
     - cron: "17 18 * * *" # Swing shift — 20:17 Paris, finishes before 23:00
   workflow_dispatch:

--- a/.github/workflows/agent-product-manager.yml
+++ b/.github/workflows/agent-product-manager.yml
@@ -1,9 +1,11 @@
-name: "Kata: Product Manager"
+name: "Agent: Product Manager"
 
 on:
   schedule:
-    # Daily at 06:23 UTC — triage after security, before planning
-    - cron: "23 6 * * *"
+    # Triage first in each shift, before planning. Paris (CEST) times below.
+    - cron: "11 3 * * *" # Night shift — 05:11 Paris, finishes before 07:00
+    - cron: "17 10 * * *" # Day shift   — 12:17 Paris, finishes before 15:00
+    - cron: "17 18 * * *" # Swing shift — 20:17 Paris, finishes before 23:00
   workflow_dispatch:
     inputs:
       task-amend:
@@ -12,7 +14,7 @@ on:
         type: string
 
 concurrency:
-  group: product-manager
+  group: agent-product-manager
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/agent-release-engineer.yml
+++ b/.github/workflows/agent-release-engineer.yml
@@ -1,9 +1,11 @@
-name: "Kata: Security Engineer"
+name: "Agent: Release Engineer"
 
 on:
   schedule:
-    # Daily at 04:07 UTC — first agent in the cycle
-    - cron: "7 4 * * *"
+    # Release last in each shift, after implementation. Paris (CEST) times below.
+    - cron: "23 4 * * *" # Night shift — 06:23 Paris, finishes before 07:00
+    - cron: "23 12 * * *" # Day shift   — 14:23 Paris, finishes before 15:00
+    - cron: "23 20 * * *" # Swing shift — 22:23 Paris, finishes before 23:00
   workflow_dispatch:
     inputs:
       task-amend:
@@ -12,7 +14,7 @@ on:
         type: string
 
 concurrency:
-  group: security-engineer
+  group: agent-release-engineer
   cancel-in-progress: true
 
 permissions:
@@ -50,7 +52,7 @@ jobs:
           task-text: >-
             Assess the current state of your domain and act on the
             highest-priority finding.
-          agent-profile: "security-engineer"
+          agent-profile: "release-engineer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-security-engineer.yml
+++ b/.github/workflows/agent-security-engineer.yml
@@ -1,19 +1,18 @@
-name: "Kata: Coaching Session"
+name: "Agent: Security Engineer"
 
 on:
+  schedule:
+    # Night shift — once daily. 01:37 UTC = 03:37 Paris (CEST) → finishes before 07:00 Paris.
+    - cron: "37 1 * * *"
   workflow_dispatch:
     inputs:
-      agent:
-        description: "Agent name to coach (e.g., security-engineer)"
-        required: true
-        type: string
       task-amend:
         description: "Additional text appended to the task prompt for steering"
         required: false
         type: string
 
 concurrency:
-  group: coaching-session
+  group: agent-security-engineer
   cancel-in-progress: true
 
 permissions:
@@ -40,7 +39,7 @@ jobs:
         with:
           token: ${{ steps.ci-app.outputs.token }}
 
-      - name: 1-on-1 Coaching Session
+      - name: Assess and Act
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -48,14 +47,10 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          mode: "facilitate"
           task-text: >-
-            Facilitate a 1-on-1 coaching session with the participant agent.
-            Guide them through the five coaching kata questions. Have them
-            analyze their own most recent trace using kata-trace. Help them
-            identify obstacles and design their next experiment.
-          facilitator-profile: "improvement-coach"
-          agent-profiles: "${{ inputs.agent }}"
+            Assess the current state of your domain and act on the
+            highest-priority finding.
+          agent-profile: "security-engineer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-security-engineer.yml
+++ b/.github/workflows/agent-security-engineer.yml
@@ -2,8 +2,9 @@ name: "Agent: Security Engineer"
 
 on:
   schedule:
-    # Night shift — once daily. 01:37 UTC = 03:37 Paris (CEST) → finishes before 07:00 Paris.
-    - cron: "37 1 * * *"
+    # Night shift only — review staff's new code after implementation.
+    # 02:53 UTC = 04:53 Paris (CEST) → finishes before 07:00 Paris.
+    - cron: "53 2 * * *"
   workflow_dispatch:
     inputs:
       task-amend:

--- a/.github/workflows/agent-staff-engineer.yml
+++ b/.github/workflows/agent-staff-engineer.yml
@@ -3,7 +3,7 @@ name: "Agent: Staff Engineer"
 on:
   schedule:
     # Plan and implement after triage in each shift. Paris (CEST) times below.
-    - cron: "53 3 * * *" # Night shift — 05:53 Paris, finishes before 07:00
+    - cron: "11 2 * * *" # Night shift — 04:11 Paris, finishes before 07:00
     - cron: "11 11 * * *" # Day shift   — 13:11 Paris, finishes before 15:00
     - cron: "11 19 * * *" # Swing shift — 21:11 Paris, finishes before 23:00
   workflow_dispatch:

--- a/.github/workflows/agent-staff-engineer.yml
+++ b/.github/workflows/agent-staff-engineer.yml
@@ -1,9 +1,11 @@
-name: "Kata: Daily Meeting"
+name: "Agent: Staff Engineer"
 
 on:
   schedule:
-    # Daily at 03:00 UTC — before all individual agent workflows
-    - cron: "0 3 * * *"
+    # Plan and implement after triage in each shift. Paris (CEST) times below.
+    - cron: "53 3 * * *" # Night shift — 05:53 Paris, finishes before 07:00
+    - cron: "11 11 * * *" # Day shift   — 13:11 Paris, finishes before 15:00
+    - cron: "11 19 * * *" # Swing shift — 21:11 Paris, finishes before 23:00
   workflow_dispatch:
     inputs:
       task-amend:
@@ -12,7 +14,7 @@ on:
         type: string
 
 concurrency:
-  group: daily-meeting
+  group: agent-staff-engineer
   cancel-in-progress: true
 
 permissions:
@@ -39,7 +41,7 @@ jobs:
         with:
           token: ${{ steps.ci-app.outputs.token }}
 
-      - name: Team Storyboard Meeting
+      - name: Assess and Act
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -47,11 +49,10 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
-          mode: "facilitate"
           task-text: >-
-            Facilitate the team storyboard meeting.
-          facilitator-profile: "improvement-coach"
-          agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
+            Assess the current state of your domain and act on the
+            highest-priority finding.
+          agent-profile: "staff-engineer"
           model: "opus"
-          max-turns: "200"
+          max-turns: "0"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-technical-writer.yml
+++ b/.github/workflows/agent-technical-writer.yml
@@ -1,9 +1,9 @@
-name: "Kata: Staff Engineer"
+name: "Agent: Technical Writer"
 
 on:
   schedule:
-    # Daily at 07:11 UTC — plan and implement after triage
-    - cron: "11 7 * * *"
+    # Night shift — once daily. 02:23 UTC = 04:23 Paris (CEST) → finishes before 07:00 Paris.
+    - cron: "23 2 * * *"
   workflow_dispatch:
     inputs:
       task-amend:
@@ -12,7 +12,7 @@ on:
         type: string
 
 concurrency:
-  group: staff-engineer
+  group: agent-technical-writer
   cancel-in-progress: true
 
 permissions:
@@ -50,7 +50,7 @@ jobs:
           task-text: >-
             Assess the current state of your domain and act on the
             highest-priority finding.
-          agent-profile: "staff-engineer"
+          agent-profile: "technical-writer"
           model: "opus"
-          max-turns: "0"
+          max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-technical-writer.yml
+++ b/.github/workflows/agent-technical-writer.yml
@@ -2,8 +2,9 @@ name: "Agent: Technical Writer"
 
 on:
   schedule:
-    # Night shift — once daily. 02:23 UTC = 04:23 Paris (CEST) → finishes before 07:00 Paris.
-    - cron: "23 2 * * *"
+    # Night shift only — review docs against staff's new code.
+    # 03:37 UTC = 05:37 Paris (CEST) → finishes before 07:00 Paris.
+    - cron: "37 3 * * *"
   workflow_dispatch:
     inputs:
       task-amend:

--- a/.github/workflows/interview-guide-setup.yml
+++ b/.github/workflows/interview-guide-setup.yml
@@ -1,4 +1,4 @@
-name: "Kata: Map Setup"
+name: "Interview: Guide Setup"
 
 on:
   workflow_dispatch: # Manual trigger for on-demand evaluation
@@ -9,7 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: map-setup
+  group: interview-guide-setup
   cancel-in-progress: true
 
 permissions:
@@ -49,22 +49,10 @@ jobs:
         shell: bash
         run: |
           agent_dir=$(mktemp -d)
-
-          # Generate all synthetic data using cached prose
-          bunx fit-terrain
-
-          mkdir -p "$agent_dir/data"
-          cp -r data/pathway "$agent_dir/data/pathway"
-          cp -r data/activity "$agent_dir/data/activity"
-
-          # Install the Supabase CLI so the agent has it on PATH
-          # npm global install is blocked by supabase's postinstall script
-          bun install -g supabase
-
-          cp scenarios/map-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
+          cp scenarios/guide-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
           echo "dir=$agent_dir" >> "$GITHUB_OUTPUT"
 
-      - name: Evaluate Map Setup
+      - name: Evaluate Guide Setup
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -75,7 +63,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "supervise"
-          task-file: scenarios/map-setup/task.md
+          task-file: scenarios/guide-setup/task.md
           supervisor-cwd: "."
           agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
           supervisor-profile: "product-manager"

--- a/.github/workflows/interview-landmark-setup.yml
+++ b/.github/workflows/interview-landmark-setup.yml
@@ -1,4 +1,4 @@
-name: "Kata: Summit Setup"
+name: "Interview: Landmark Setup"
 
 on:
   workflow_dispatch: # Manual trigger for on-demand evaluation
@@ -9,7 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: summit-setup
+  group: interview-landmark-setup
   cancel-in-progress: true
 
 permissions:
@@ -51,18 +51,22 @@ jobs:
           agent_dir=$(mktemp -d)
 
           # Generate all synthetic data using cached prose — this produces
-          # data/pathway/ (framework) and data/activity/raw/activity/summit.yaml
-          # (roster).
+          # data/pathway/ (framework) and data/activity/ (roster, raw documents
+          # including GetDX snapshots, GitHub webhooks, evidence, and comments).
           bunx fit-terrain
 
           mkdir -p "$agent_dir/data"
           cp -r data/pathway "$agent_dir/data/pathway"
-          cp data/activity/raw/activity/summit.yaml "$agent_dir/summit.yaml"
+          cp -r data/activity "$agent_dir/data/activity"
 
-          cp scenarios/summit-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
+          # Install the Supabase CLI so the agent has it on PATH
+          # npm global install is blocked by supabase's postinstall script
+          bun install -g supabase
+
+          cp scenarios/landmark-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
           echo "dir=$agent_dir" >> "$GITHUB_OUTPUT"
 
-      - name: Evaluate Summit Setup
+      - name: Evaluate Landmark Setup
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -73,7 +77,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "supervise"
-          task-file: scenarios/summit-setup/task.md
+          task-file: scenarios/landmark-setup/task.md
           supervisor-cwd: "."
           agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
           supervisor-profile: "product-manager"

--- a/.github/workflows/interview-map-setup.yml
+++ b/.github/workflows/interview-map-setup.yml
@@ -1,4 +1,4 @@
-name: "Kata: Landmark Setup"
+name: "Interview: Map Setup"
 
 on:
   workflow_dispatch: # Manual trigger for on-demand evaluation
@@ -9,7 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: landmark-setup
+  group: interview-map-setup
   cancel-in-progress: true
 
 permissions:
@@ -50,9 +50,7 @@ jobs:
         run: |
           agent_dir=$(mktemp -d)
 
-          # Generate all synthetic data using cached prose — this produces
-          # data/pathway/ (framework) and data/activity/ (roster, raw documents
-          # including GetDX snapshots, GitHub webhooks, evidence, and comments).
+          # Generate all synthetic data using cached prose
           bunx fit-terrain
 
           mkdir -p "$agent_dir/data"
@@ -63,10 +61,10 @@ jobs:
           # npm global install is blocked by supabase's postinstall script
           bun install -g supabase
 
-          cp scenarios/landmark-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
+          cp scenarios/map-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
           echo "dir=$agent_dir" >> "$GITHUB_OUTPUT"
 
-      - name: Evaluate Landmark Setup
+      - name: Evaluate Map Setup
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -77,7 +75,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "supervise"
-          task-file: scenarios/landmark-setup/task.md
+          task-file: scenarios/map-setup/task.md
           supervisor-cwd: "."
           agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
           supervisor-profile: "product-manager"

--- a/.github/workflows/interview-summit-setup.yml
+++ b/.github/workflows/interview-summit-setup.yml
@@ -1,4 +1,4 @@
-name: "Kata: Guide Setup"
+name: "Interview: Summit Setup"
 
 on:
   workflow_dispatch: # Manual trigger for on-demand evaluation
@@ -9,7 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: guide-setup
+  group: interview-summit-setup
   cancel-in-progress: true
 
 permissions:
@@ -49,10 +49,20 @@ jobs:
         shell: bash
         run: |
           agent_dir=$(mktemp -d)
-          cp scenarios/guide-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
+
+          # Generate all synthetic data using cached prose — this produces
+          # data/pathway/ (framework) and data/activity/raw/activity/summit.yaml
+          # (roster).
+          bunx fit-terrain
+
+          mkdir -p "$agent_dir/data"
+          cp -r data/pathway "$agent_dir/data/pathway"
+          cp data/activity/raw/activity/summit.yaml "$agent_dir/summit.yaml"
+
+          cp scenarios/summit-setup/agent/CLAUDE.md "$agent_dir/CLAUDE.md"
           echo "dir=$agent_dir" >> "$GITHUB_OUTPUT"
 
-      - name: Evaluate Guide Setup
+      - name: Evaluate Summit Setup
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -63,7 +73,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "supervise"
-          task-file: scenarios/guide-setup/task.md
+          task-file: scenarios/summit-setup/task.md
           supervisor-cwd: "."
           agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
           supervisor-profile: "product-manager"

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -1,18 +1,19 @@
-name: "Kata: Technical Writer"
+name: "Kata: Coaching"
 
 on:
-  schedule:
-    # Daily at 05:37 UTC — curate and review before producers
-    - cron: "37 5 * * *"
   workflow_dispatch:
     inputs:
+      agent:
+        description: "Agent name to coach (e.g., security-engineer)"
+        required: true
+        type: string
       task-amend:
         description: "Additional text appended to the task prompt for steering"
         required: false
         type: string
 
 concurrency:
-  group: technical-writer
+  group: kata-coaching
   cancel-in-progress: true
 
 permissions:
@@ -39,7 +40,7 @@ jobs:
         with:
           token: ${{ steps.ci-app.outputs.token }}
 
-      - name: Assess and Act
+      - name: 1-on-1 Coaching Session
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -47,10 +48,14 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
+          mode: "facilitate"
           task-text: >-
-            Assess the current state of your domain and act on the
-            highest-priority finding.
-          agent-profile: "technical-writer"
+            Facilitate a 1-on-1 coaching session with the participant agent.
+            Guide them through the five coaching kata questions. Have them
+            analyze their own most recent trace using kata-trace. Help them
+            identify obstacles and design their next experiment.
+          facilitator-profile: "improvement-coach"
+          agent-profiles: "${{ inputs.agent }}"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -1,9 +1,9 @@
-name: "Kata: Release Engineer"
+name: "Kata: Storyboard"
 
 on:
   schedule:
-    # Daily at 08:43 UTC — release after implementation
-    - cron: "43 8 * * *"
+    # Daily at 06:00 UTC = 08:00 Paris (CEST), after night shift finishes.
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       task-amend:
@@ -12,7 +12,7 @@ on:
         type: string
 
 concurrency:
-  group: release-engineer
+  group: kata-storyboard
   cancel-in-progress: true
 
 permissions:
@@ -39,7 +39,7 @@ jobs:
         with:
           token: ${{ steps.ci-app.outputs.token }}
 
-      - name: Assess and Act
+      - name: Team Storyboard Meeting
         uses: ./.github/actions/kata-action
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -47,10 +47,11 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           app-id: ${{ secrets.CI_APP_ID }}
+          mode: "facilitate"
           task-text: >-
-            Assess the current state of your domain and act on the
-            highest-priority finding.
-          agent-profile: "release-engineer"
+            Facilitate the team storyboard meeting.
+          facilitator-profile: "improvement-coach"
+          agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
           model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/KATA.md
+++ b/KATA.md
@@ -77,12 +77,15 @@ exceeds an agent's scope, it writes a spec rather than attempting the fix.
 Seven workflows run on a three-shift rhythm aligned to Europe/Paris time: a
 **night shift** finishes by 07:00, the **storyboard** runs at 08:00, a **day
 shift** finishes by 15:00, and a **swing shift** finishes by 23:00. Within each
-shift agents run in PDSA order (triage → plan/implement → release). Security and
-technical-writer run once daily on the night shift — dependency churn and
-documentation drift do not need intra-day cadence. Product-manager, staff-
-engineer, and release-engineer run every shift so triage, planning, and release
-throughput stay steady. Cron schedules are authored in UTC; Paris times below
-use CEST (UTC+2), the tighter summer constraint. All support
+shift agents form a producer → reviewer → shipper chain: product-manager triages
+and merges incoming work so staff-engineer has a fresh backlog, staff
+implements, and release-engineer ships. On the night shift — the full cycle
+before the morning storyboard — security-engineer and technical-writer slot in
+between staff and release so they can review the code staff just produced before
+it ships. Day and swing shifts skip the review pair; dependency churn and
+documentation drift do not need intra-day cadence, and CVE-driven work can run
+on demand via `workflow_dispatch`. Cron schedules are authored in UTC; Paris
+times below use CEST (UTC+2), the tighter summer constraint. All support
 `workflow_dispatch`, use concurrency groups, and have a 30-minute timeout.
 Individual agent workflows send a generic task prompt; the agent's Assess
 section determines the actual action. The storyboard and coaching session send
@@ -92,10 +95,10 @@ specific task prompts to the improvement coach as facilitator.
 | --------------------------- | ------------------------------------- | ---------------------------------------- |
 | **kata-storyboard**         | Daily 08:00                           | improvement-coach (facilitates 5 agents) |
 | **kata-coaching**           | `workflow_dispatch`                   | improvement-coach (facilitates 1 agent)  |
-| **agent-security-engineer** | Night 03:37                           | security-engineer                        |
-| **agent-technical-writer**  | Night 04:23                           | technical-writer                         |
-| **agent-product-manager**   | Night 05:11 · Day 12:17 · Swing 20:17 | product-manager                          |
-| **agent-staff-engineer**    | Night 05:53 · Day 13:11 · Swing 21:11 | staff-engineer                           |
+| **agent-product-manager**   | Night 03:23 · Day 12:17 · Swing 20:17 | product-manager                          |
+| **agent-staff-engineer**    | Night 04:11 · Day 13:11 · Swing 21:11 | staff-engineer                           |
+| **agent-security-engineer** | Night 04:53                           | security-engineer                        |
+| **agent-technical-writer**  | Night 05:37                           | technical-writer                         |
 | **agent-release-engineer**  | Night 06:23 · Day 14:23 · Swing 22:23 | release-engineer                         |
 
 ## Skills

--- a/KATA.md
+++ b/KATA.md
@@ -13,9 +13,9 @@ pattern of _understand the direction_, _grasp the current condition_, _establish
 the next target condition_, and _experiment toward it_. Kata agents grasp the
 current condition (by analyzing execution traces of prior runs), establish
 target conditions (via specs), and experiment toward them (via implementation).
-Seven workflows — five individual agent runs, one daily team meeting, and one
-on-demand coaching session — six agent personas, and eighteen skills form a
-self-reinforcing PDSA cycle.
+Seven workflows — five individual agent runs scheduled across three shifts, one
+daily team storyboard, and one on-demand coaching session — six agent personas,
+and eighteen skills form a self-reinforcing PDSA cycle.
 
 ## Architecture
 
@@ -74,25 +74,29 @@ exceeds an agent's scope, it writes a spec rather than attempting the fix.
 
 ## Workflows
 
-Seven workflows: five individual agent runs spanning 04–09 UTC, one daily team
-meeting at 03:00 UTC, and one on-demand coaching session. Times respect ordering
-constraints (team meeting before individual runs, security before product,
-product before planning, planning before release). Off-minute schedules avoid
-API load spikes. All support `workflow_dispatch`, use concurrency groups, and
-have a 30-minute timeout. Individual agent workflows send a generic task prompt;
-the agent's Assess section determines the actual action. The daily meeting and
-coaching session send specific task prompts to the improvement coach as
-facilitator.
+Seven workflows run on a three-shift rhythm aligned to Europe/Paris time: a
+**night shift** finishes by 07:00, the **storyboard** runs at 08:00, a **day
+shift** finishes by 15:00, and a **swing shift** finishes by 23:00. Within each
+shift agents run in PDSA order (triage → plan/implement → release). Security and
+technical-writer run once daily on the night shift — dependency churn and
+documentation drift do not need intra-day cadence. Product-manager, staff-
+engineer, and release-engineer run every shift so triage, planning, and release
+throughput stay steady. Cron schedules are authored in UTC; Paris times below
+use CEST (UTC+2), the tighter summer constraint. All support
+`workflow_dispatch`, use concurrency groups, and have a 30-minute timeout.
+Individual agent workflows send a generic task prompt; the agent's Assess
+section determines the actual action. The storyboard and coaching session send
+specific task prompts to the improvement coach as facilitator.
 
-| Workflow              | Schedule            | Agent                                    |
-| --------------------- | ------------------- | ---------------------------------------- |
-| **daily-meeting**     | Daily 03:00 UTC     | improvement-coach (facilitates 5 agents) |
-| **coaching-session**  | `workflow_dispatch` | improvement-coach (facilitates 1 agent)  |
-| **security-engineer** | Daily 04:07 UTC     | security-engineer                        |
-| **technical-writer**  | Daily 05:37 UTC     | technical-writer                         |
-| **product-manager**   | Daily 06:23 UTC     | product-manager                          |
-| **staff-engineer**    | Daily 07:11 UTC     | staff-engineer                           |
-| **release-engineer**  | Daily 08:43 UTC     | release-engineer                         |
+| Workflow                    | Schedule (Paris, CEST)                | Agent                                    |
+| --------------------------- | ------------------------------------- | ---------------------------------------- |
+| **kata-storyboard**         | Daily 08:00                           | improvement-coach (facilitates 5 agents) |
+| **kata-coaching**           | `workflow_dispatch`                   | improvement-coach (facilitates 1 agent)  |
+| **agent-security-engineer** | Night 03:37                           | security-engineer                        |
+| **agent-technical-writer**  | Night 04:23                           | technical-writer                         |
+| **agent-product-manager**   | Night 05:11 · Day 12:17 · Swing 20:17 | product-manager                          |
+| **agent-staff-engineer**    | Night 05:53 · Day 13:11 · Swing 21:11 | staff-engineer                           |
+| **agent-release-engineer**  | Night 06:23 · Day 14:23 · Swing 22:23 | release-engineer                         |
 
 ## Skills
 

--- a/libraries/libeval/bin/fit-trace.js
+++ b/libraries/libeval/bin/fit-trace.js
@@ -33,7 +33,7 @@ const definition = {
     {
       name: "runs",
       args: "[pattern]",
-      description: "List recent workflow runs (default pattern: kata)",
+      description: "List recent workflow runs (default pattern: agent)",
       options: {
         lookback: {
           type: "string",

--- a/libraries/libeval/src/commands/trace.js
+++ b/libraries/libeval/src/commands/trace.js
@@ -13,7 +13,7 @@ import { createTraceGitHub } from "../trace-github.js";
  */
 export async function runRunsCommand(values, args) {
   const gh = await createTraceGitHub({ repo: values.repo });
-  const pattern = args[0] ?? "kata";
+  const pattern = args[0] ?? "agent";
   const lookback = values.lookback ?? "7d";
   const runs = await gh.listRuns({ pattern, lookback });
   writeJSON(runs);

--- a/libraries/libeval/src/trace-github.js
+++ b/libraries/libeval/src/trace-github.js
@@ -27,13 +27,13 @@ export class TraceGitHub {
    * List recent workflow runs, optionally filtered by name pattern.
    *
    * @param {object} [opts]
-   * @param {string} [opts.pattern] - Case-insensitive substring to match workflow name (default: "kata")
+   * @param {string} [opts.pattern] - Case-insensitive substring to match workflow name (default: "agent")
    * @param {number} [opts.limit=50] - Max runs to return from GitHub API
    * @param {string} [opts.lookback="7d"] - How far back to search (e.g. "7d", "24h", "2w")
    * @returns {Promise<object[]>} Array of {workflow, runId, status, conclusion, createdAt, branch, url}
    */
   async listRuns(opts = {}) {
-    const { pattern = "kata", limit = 50, lookback = "7d" } = opts;
+    const { pattern = "agent", limit = 50, lookback = "7d" } = opts;
     const cutoff = parseLookback(lookback);
 
     const params = new URLSearchParams({


### PR DESCRIPTION
## Summary

- Reschedule the five agent workflows across three shifts aligned to Europe/Paris: night (finish by 07:00), storyboard at 08:00, day (finish by 15:00), swing (finish by 23:00).
- Within each shift agents run as a producer → reviewer → shipper chain: product-manager triages so staff has a fresh backlog, staff implements, and release-engineer ships. Night shift inserts security-engineer + technical-writer between staff and release so they review the code staff just produced before it ships; day and swing skip the review pair (once-daily cadence for dependency churn and doc drift, CVE-driven work available via `workflow_dispatch`).
- Rename workflows by purpose: `agent-*.yml` ("Agent: *") for scheduled agent runs, `kata-storyboard.yml` / `kata-coaching.yml` ("Kata: *") for the coach routines, `interview-*.yml` ("Interview: *") for on-demand product evaluations.
- `fit-trace runs [pattern]` now defaults the workflow-name filter to `"agent"` (was `"kata"`) so trace analysis finds agent runs by default; the positional argument remains optional and accepts any substring.
- Update KATA.md, kata-trace, and kata-storyboard skills to match.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2404/2405 pass, 1 skipped)
