### PR TITLE
fix(libeval): pass agent profile via SDK top-level option

### DIFF
--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -82,7 +82,7 @@ export class AgentRunner {
             disallowedTools: this.disallowedTools,
           }),
           ...(this.systemPrompt && { systemPrompt: this.systemPrompt }),
-          ...(this.agentProfile && { extraArgs: { agent: this.agentProfile } }),
+          ...(this.agentProfile && { agent: this.agentProfile }),
           ...(this.mcpServers && { mcpServers: this.mcpServers }),
         },
       });


### PR DESCRIPTION
Scheduled agent workflows (security-engineer, technical-writer,
staff-engineer) stopped adopting their .claude/agents/ profile after
dependabot bumped @anthropic-ai/claude-agent-sdk from 0.2.98 to 0.2.112
in #404. Traces showed the main thread responding "I don't have a
specific agent role assigned" despite --agent <name> reaching the CLI.

Switch from extraArgs: { agent } to the SDK's top-level agent option,
which the SDK docs describe as equivalent to --agent. The top-level path
performs agent validation and setup that extraArgs bypasses in 0.2.112.

Investigation: issue analyzing runs 24549060597 and 24550014866.
Companion feedback on trace tooling: #408.

https://claude.ai/code/session_01196RuGADyEPw9F3R2cZjaG