### PR TITLE
chore(agents): pin kata agents to Opus 4.6

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -3,7 +3,7 @@ name: improvement-coach
 description: >
   Continuous improvement coach. Facilitates team storyboard meetings and
   1-on-1 coaching sessions using the Toyota Kata five-question protocol.
-model: opus
+model: claude-opus-4-6
 skills:
   - kata-storyboard
   - kata-metrics

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -5,7 +5,7 @@ description: >
   verifies contributor trust, and merges fix, bug, and spec PRs that pass all
   quality and security gates. Triages open issues — implements trivial fixes
   and writes specs for product-aligned requests.
-model: opus
+model: claude-opus-4-6
 skills:
   - kata-product-pr
   - kata-product-issue

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -3,7 +3,7 @@ name: release-engineer
 description: >
   Repository release engineer. Keeps pull request branches merge-ready, cuts
   releases from main, and verifies publish workflows.
-model: opus
+model: claude-opus-4-6
 skills:
   - kata-release-readiness
   - kata-release-review

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -4,7 +4,7 @@ description: >
   Repository security engineer. Applies security updates, triages Dependabot
   pull requests, audits supply chain and application security, and enforces
   dependency and CI policies.
-model: opus
+model: claude-opus-4-6
 skills:
   - kata-security-update
   - kata-security-audit

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -4,7 +4,7 @@ description: >
   Repository staff engineer. Owns the full spec → design → plan → implement arc
   for approved specs: turns spec.md into an architectural design, then an
   execution-ready plan, then executes the plan step by step.
-model: opus
+model: claude-opus-4-6
 skills:
   - kata-design
   - kata-plan

--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -4,7 +4,7 @@ description: >
   Repository technical writer. Reviews documentation for accuracy and
   staleness, curates agent memory for cross-team collaboration, and ensures
   the wiki remains a reliable coordination mechanism.
-model: opus
+model: claude-opus-4-6
 skills:
   - kata-documentation
   - kata-wiki-curate


### PR DESCRIPTION
## Summary

- The bare `model: opus` alias now resolves to Opus 4.7. Kata agent workflows are tuned for Opus 4.6 behavior, so pin the six kata agents (`improvement-coach`, `product-manager`, `release-engineer`, `security-engineer`, `staff-engineer`, `technical-writer`) to `claude-opus-4-6` explicitly to avoid drift from the auto-updated alias.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2408 pass, 0 fail)

https://claude.ai/code/session_01SLfE95jtXHijaAhuVoDPSG