### PR TITLE
chore(agents,workflows): pin kata agents to Opus 4.6 at the workflow layer

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -3,7 +3,6 @@ name: improvement-coach
 description: >
   Continuous improvement coach. Facilitates team storyboard meetings and
   1-on-1 coaching sessions using the Toyota Kata five-question protocol.
-model: claude-opus-4-6
 skills:
   - kata-storyboard
   - kata-metrics

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -5,7 +5,6 @@ description: >
   verifies contributor trust, and merges fix, bug, and spec PRs that pass all
   quality and security gates. Triages open issues — implements trivial fixes
   and writes specs for product-aligned requests.
-model: claude-opus-4-6
 skills:
   - kata-product-pr
   - kata-product-issue

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -3,7 +3,6 @@ name: release-engineer
 description: >
   Repository release engineer. Keeps pull request branches merge-ready, cuts
   releases from main, and verifies publish workflows.
-model: claude-opus-4-6
 skills:
   - kata-release-readiness
   - kata-release-review

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -4,7 +4,6 @@ description: >
   Repository security engineer. Applies security updates, triages Dependabot
   pull requests, audits supply chain and application security, and enforces
   dependency and CI policies.
-model: claude-opus-4-6
 skills:
   - kata-security-update
   - kata-security-audit

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -4,7 +4,6 @@ description: >
   Repository staff engineer. Owns the full spec → design → plan → implement arc
   for approved specs: turns spec.md into an architectural design, then an
   execution-ready plan, then executes the plan step by step.
-model: claude-opus-4-6
 skills:
   - kata-design
   - kata-plan

--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -4,7 +4,6 @@ description: >
   Repository technical writer. Reviews documentation for accuracy and
   staleness, curates agent memory for cross-team collaboration, and ensures
   the wiki remains a reliable coordination mechanism.
-model: claude-opus-4-6
 skills:
   - kata-documentation
   - kata-wiki-curate

--- a/.github/workflows/agent-product-manager.yml
+++ b/.github/workflows/agent-product-manager.yml
@@ -53,6 +53,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "product-manager"
-          model: "opus"
+          model: "claude-opus-4-6"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-release-engineer.yml
+++ b/.github/workflows/agent-release-engineer.yml
@@ -53,6 +53,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "release-engineer"
-          model: "opus"
+          model: "claude-opus-4-6"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-security-engineer.yml
+++ b/.github/workflows/agent-security-engineer.yml
@@ -52,6 +52,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "security-engineer"
-          model: "opus"
+          model: "claude-opus-4-6"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-staff-engineer.yml
+++ b/.github/workflows/agent-staff-engineer.yml
@@ -53,6 +53,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "staff-engineer"
-          model: "opus"
+          model: "claude-opus-4-6"
           max-turns: "0"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-technical-writer.yml
+++ b/.github/workflows/agent-technical-writer.yml
@@ -52,6 +52,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "technical-writer"
-          model: "opus"
+          model: "claude-opus-4-6"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -56,6 +56,6 @@ jobs:
             identify obstacles and design their next experiment.
           facilitator-profile: "improvement-coach"
           agent-profiles: "${{ inputs.agent }}"
-          model: "opus"
+          model: "claude-opus-4-6"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -52,6 +52,6 @@ jobs:
             Facilitate the team storyboard meeting.
           facilitator-profile: "improvement-coach"
           agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
-          model: "opus"
+          model: "claude-opus-4-6"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}


### PR DESCRIPTION
## Summary

- Pin `--model=claude-opus-4-6` directly in the 5 kata agent workflows plus `kata-coaching` and `kata-storyboard`, replacing the `"opus"` alias that was resolving to Opus 4.7.
- Remove the now-dead `model:` frontmatter from all six kata agent profiles. The Claude Code CLI only applies profile model when `--model` is absent (`!userSpecifiedModel` gate in `cli.js`), so the frontmatter value was silently ignored whenever a workflow ran.

## Why

In run [24582757426](https://github.com/forwardimpact/monorepo/actions/runs/24582757426) the `Agent: Technical Writer` workflow triaged issue #408, signed a comment `— Product Manager 🌱`, and wrote a "Run 9" entry into `wiki/product-manager-2026-W16.md`. Trace analysis showed the workflow was passing `agent-profile: "technical-writer"` and `model: "opus"`, but the session ran on Opus 4.7 and adopted a product-manager identity end-to-end. The `opus` alias was defeating #410's frontmatter pin; Opus 4.7 follows agent profiles less reliably than 4.6.

`fit-eval` already threads `--model` end-to-end (`commands/run.js` → `agent-runner.js` → SDK `options.model`), so no code changes were needed — this is a configuration-only PR.

`interview-*.yml` workflows still use `"opus"` — different use case (product evaluation), not in scope.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2408 pass, 1 skipped)
- [ ] Next scheduled kata agent run lands on `claude-opus-4-6` (visible in trace `system/init` `model` field)
- [ ] Agent identity holds — no cross-agent memory writes in the next week's traces