### PR TITLE
refactor(libeval)!: load GitHub token via Config at CLI entry

### DIFF
--- a/libraries/libeval/bin/fit-eval.js
+++ b/libraries/libeval/bin/fit-eval.js
@@ -2,7 +2,6 @@
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
-import { createScriptConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
 import { runOutputCommand } from "../src/commands/output.js";
@@ -173,8 +172,7 @@ async function main() {
     process.exit(2);
   }
 
-  const config = await createScriptConfig("eval");
-  await handler(values, args, { config });
+  await handler(values, args);
 }
 
 main().catch((error) => {

--- a/libraries/libeval/bin/fit-eval.js
+++ b/libraries/libeval/bin/fit-eval.js
@@ -2,6 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
+import { createScriptConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
 import { runOutputCommand } from "../src/commands/output.js";
@@ -172,7 +173,8 @@ async function main() {
     process.exit(2);
   }
 
-  await handler(values, args);
+  const config = await createScriptConfig("eval");
+  await handler(values, args, { config });
 }
 
 main().catch((error) => {

--- a/libraries/libeval/bin/fit-trace.js
+++ b/libraries/libeval/bin/fit-trace.js
@@ -2,6 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
+import { createScriptConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
 import {
@@ -188,7 +189,8 @@ async function main() {
     process.exit(2);
   }
 
-  await handler(values, args);
+  const config = await createScriptConfig("eval");
+  await handler(values, args, { config });
 }
 
 main().catch((error) => {

--- a/libraries/libeval/src/commands/trace.js
+++ b/libraries/libeval/src/commands/trace.js
@@ -10,9 +10,13 @@ import { createTraceGitHub } from "../trace-github.js";
  * List recent workflow runs matching a pattern.
  * @param {object} values - Parsed option values
  * @param {string[]} args - [pattern?]
+ * @param {{config: import("@forwardimpact/libconfig").Config}} ctx
  */
-export async function runRunsCommand(values, args) {
-  const gh = await createTraceGitHub({ repo: values.repo });
+export async function runRunsCommand(values, args, ctx) {
+  const gh = await createTraceGitHub({
+    token: ctx.config.ghToken(),
+    repo: values.repo,
+  });
   const pattern = args[0] ?? "agent";
   const lookback = values.lookback ?? "7d";
   const runs = await gh.listRuns({ pattern, lookback });
@@ -23,9 +27,13 @@ export async function runRunsCommand(values, args) {
  * Download a trace artifact and auto-convert to structured JSON.
  * @param {object} values - Parsed option values
  * @param {string[]} args - [run-id]
+ * @param {{config: import("@forwardimpact/libconfig").Config}} ctx
  */
-export async function runDownloadCommand(values, args) {
-  const gh = await createTraceGitHub({ repo: values.repo });
+export async function runDownloadCommand(values, args, ctx) {
+  const gh = await createTraceGitHub({
+    token: ctx.config.ghToken(),
+    repo: values.repo,
+  });
   const result = await gh.downloadTrace(args[0], {
     dir: values.dir,
     name: values.artifact,

--- a/libraries/libeval/src/trace-github.js
+++ b/libraries/libeval/src/trace-github.js
@@ -186,21 +186,21 @@ export function parseGitRemote(remote) {
 }
 
 /**
- * Create a TraceGitHub instance using libconfig for the token and
- * git remote for the repo.
+ * Create a TraceGitHub instance. The caller is responsible for resolving
+ * the GitHub token — typically via `Config.ghToken()` — so credential
+ * loading stays at the CLI entry point.
  *
- * @param {object} [opts]
+ * @param {object} opts
+ * @param {string} opts.token - GitHub token (e.g. from `Config.ghToken()`)
  * @param {string} [opts.repo] - "owner/repo" override (default: detect from git remote)
  * @returns {Promise<TraceGitHub>}
  */
-export async function createTraceGitHub(opts = {}) {
-  const { createScriptConfig } = await import("@forwardimpact/libconfig");
-  const config = await createScriptConfig("eval");
-  const token = config.ghToken();
+export async function createTraceGitHub(opts) {
+  const { token, repo: repoOverride } = opts;
 
   let owner, repo;
-  if (opts.repo) {
-    ({ owner, repo } = parseGitRemote(opts.repo));
+  if (repoOverride) {
+    ({ owner, repo } = parseGitRemote(repoOverride));
   } else {
     const { execSync } = await import("node:child_process");
     const remote = execSync("git remote get-url origin", {

--- a/libraries/libeval/src/trace-github.js
+++ b/libraries/libeval/src/trace-github.js
@@ -190,13 +190,22 @@ export function parseGitRemote(remote) {
  * the GitHub token — typically via `Config.ghToken()` — so credential
  * loading stays at the CLI entry point.
  *
+ * Breaking change from the prior signature: `token` is now a required
+ * caller input. Construct a `Config` via `@forwardimpact/libconfig` and
+ * pass `config.ghToken()`.
+ *
  * @param {object} opts
  * @param {string} opts.token - GitHub token (e.g. from `Config.ghToken()`)
  * @param {string} [opts.repo] - "owner/repo" override (default: detect from git remote)
  * @returns {Promise<TraceGitHub>}
  */
-export async function createTraceGitHub(opts) {
+export async function createTraceGitHub(opts = {}) {
   const { token, repo: repoOverride } = opts;
+  if (!token) {
+    throw new Error(
+      "createTraceGitHub: token is required (pass Config.ghToken())",
+    );
+  }
 
   let owner, repo;
   if (repoOverride) {

--- a/libraries/libeval/test/trace-github.test.js
+++ b/libraries/libeval/test/trace-github.test.js
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert";
 
-import { parseGitRemote } from "@forwardimpact/libeval";
+import { createTraceGitHub, parseGitRemote } from "@forwardimpact/libeval";
 
 describe("parseGitRemote", () => {
   test("parses SSH remote", () => {
@@ -44,5 +44,31 @@ describe("parseGitRemote", () => {
     const result = parseGitRemote("git@github.com:acme/widgets.git");
     assert.strictEqual(result.owner, "acme");
     assert.strictEqual(result.repo, "widgets");
+  });
+});
+
+describe("createTraceGitHub", () => {
+  test("throws a clear error when called with no arguments", async () => {
+    await assert.rejects(
+      () => createTraceGitHub(),
+      /token is required.*Config\.ghToken/,
+    );
+  });
+
+  test("throws a clear error when token is missing", async () => {
+    await assert.rejects(
+      () => createTraceGitHub({ repo: "owner/repo" }),
+      /token is required.*Config\.ghToken/,
+    );
+  });
+
+  test("returns a TraceGitHub with the provided token and parsed repo", async () => {
+    const gh = await createTraceGitHub({
+      token: "ghp_fake",
+      repo: "forwardimpact/monorepo",
+    });
+    assert.strictEqual(gh.token, "ghp_fake");
+    assert.strictEqual(gh.owner, "forwardimpact");
+    assert.strictEqual(gh.repo, "monorepo");
   });
 });


### PR DESCRIPTION
## Summary

- Hoist GitHub-token loading out of `createTraceGitHub` into the `fit-trace` CLI entry point, which constructs a `Config` via `@forwardimpact/libconfig` and passes `config.ghToken()` to the two handlers that need it (`runs`, `download`).
- `createTraceGitHub({ repo })` → `createTraceGitHub({ token, repo })` — credential resolution is now the caller's responsibility and visible at the CLI boundary rather than hidden behind a dynamic `libconfig` import.
- Explicit token guard + restored `opts = {}` default so a no-arg call returns `"createTraceGitHub: token is required (pass Config.ghToken())"` instead of a destructuring `TypeError`.
- New `createTraceGitHub` test coverage (no-arg error, missing-token error, happy path).

## Breaking change

`createTraceGitHub` now requires `opts.token`. External callers must construct a `Config` and pass `config.ghToken()`:

```js
import { createScriptConfig } from "@forwardimpact/libconfig";
import { createTraceGitHub } from "@forwardimpact/libeval";

const config = await createScriptConfig("eval");
const gh = await createTraceGitHub({ token: config.ghToken(), repo });
```

## Test plan

- [x] `bun run check` (format + lint + check-instructions)
- [x] `bun run test` (2411 pass, 1 skipped; 3 new `createTraceGitHub` tests)
- [x] `fit-eval --help` renders; `fit-trace --help` renders
- [x] Smoke test: `GITHUB_TOKEN=test fit-trace runs --repo=...` returns `401 Unauthorized` — token flows through the new path

https://claude.ai/code/session_016XKs3Fazi1u3p6ozxD78TU