### PR TITLE
feat(specs): approved plan for agent profile main-thread binding (530)

### DIFF
--- a/specs/530-agent-profile-main-thread-binding/design.md
+++ b/specs/530-agent-profile-main-thread-binding/design.md
@@ -5,22 +5,22 @@
 libeval owns main-thread profile binding. A new pure function,
 `composeProfilePrompt`, reads `.claude/agents/<name>.md` and returns an SDK
 `systemPrompt` value. Every command (`run`, `supervise`, `facilitate`) calls
-this function at startup for each main thread it creates, then passes the
-result into `AgentRunner` via the existing `systemPrompt` input.
-`AgentRunner` loses its `agentProfile` field and no longer sets the SDK's
-`options.agent`. The SDK's top-level `agent` option and its `--agent` CLI
-mirror are removed from libeval's source — they remain a subagent-registration
-concern for Claude Code itself, not a main-thread input we control.
+this function at startup for each main thread it creates, then passes the result
+into `AgentRunner` via the existing `systemPrompt` input. `AgentRunner` loses
+its `agentProfile` field and no longer sets the SDK's `options.agent`. The SDK's
+top-level `agent` option and its `--agent` CLI mirror are removed from libeval's
+source — they remain a subagent-registration concern for Claude Code itself, not
+a main-thread input we control.
 
 ### Components
 
-| Component | Role | Where it lives conceptually |
-| --- | --- | --- |
-| `composeProfilePrompt(name, { profilesDir })` | Pure: load + merge profile file into `{ type: "preset", preset: "claude_code", append: string }` | New module inside libeval (`src/profile-prompt.js`) |
-| `AgentRunner` | Continues to own the single SDK `query({ options })` call; drops the `agentProfile` constructor dep and the `options.agent` spread; accepts a pre-composed `systemPrompt` from callers | `libraries/libeval/src/agent-runner.js` |
-| `run` command | Loads the profile via `composeProfilePrompt` and passes the resulting `systemPrompt` to `AgentRunner`; stops forwarding `--agent` | `src/commands/run.js` |
-| `Supervisor` factory | Same load-and-pass pattern for both agent and supervisor runners; `AGENT_SYSTEM_PROMPT` becomes a trailer merged into the profile's `append`, not a replacement | `src/supervisor.js` |
-| `Facilitator` factory | Same pattern per agent config and for the facilitator runner; `FACILITATED_AGENT_SYSTEM_PROMPT` / `FACILITATOR_SYSTEM_PROMPT` become trailers | `src/facilitator.js` |
+| Component                                     | Role                                                                                                                                                                                   | Where it lives conceptually                         |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `composeProfilePrompt(name, { profilesDir })` | Pure: load + merge profile file into `{ type: "preset", preset: "claude_code", append: string }`                                                                                       | New module inside libeval (`src/profile-prompt.js`) |
+| `AgentRunner`                                 | Continues to own the single SDK `query({ options })` call; drops the `agentProfile` constructor dep and the `options.agent` spread; accepts a pre-composed `systemPrompt` from callers | `libraries/libeval/src/agent-runner.js`             |
+| `run` command                                 | Loads the profile via `composeProfilePrompt` and passes the resulting `systemPrompt` to `AgentRunner`; stops forwarding `--agent`                                                      | `src/commands/run.js`                               |
+| `Supervisor` factory                          | Same load-and-pass pattern for both agent and supervisor runners; `AGENT_SYSTEM_PROMPT` becomes a trailer merged into the profile's `append`, not a replacement                        | `src/supervisor.js`                                 |
+| `Facilitator` factory                         | Same pattern per agent config and for the facilitator runner; `FACILITATED_AGENT_SYSTEM_PROMPT` / `FACILITATOR_SYSTEM_PROMPT` become trailers                                          | `src/facilitator.js`                                |
 
 ### Interface — `composeProfilePrompt`
 
@@ -31,22 +31,22 @@ composeProfilePrompt(
 ): { type: "preset", preset: "claude_code", append: string }
 ```
 
-- Reads `${profilesDir}/${name}.md`. A missing or unreadable file propagates
-  the underlying `ENOENT` / permission error unchanged — that is the spec's
-  first safety net.
-- Returns the SDK-shaped `systemPrompt` with `append` equal to the profile
-  body plus, when provided, a blank line and `trailer`. Orchestration modes
-  pass their existing boilerplate (`AGENT_SYSTEM_PROMPT`,
-  `FACILITATED_AGENT_SYSTEM_PROMPT`, `FACILITATOR_SYSTEM_PROMPT`) as
-  `trailer` so today's working behaviour is preserved.
+- Reads `${profilesDir}/${name}.md`. A missing or unreadable file propagates the
+  underlying `ENOENT` / permission error unchanged — that is the spec's first
+  safety net.
+- Returns the SDK-shaped `systemPrompt` with `append` equal to the profile body
+  plus, when provided, a blank line and `trailer`. Orchestration modes pass
+  their existing boilerplate (`AGENT_SYSTEM_PROMPT`,
+  `FACILITATED_AGENT_SYSTEM_PROMPT`, `FACILITATOR_SYSTEM_PROMPT`) as `trailer`
+  so today's working behaviour is preserved.
 - `name` is the only identity the caller knows. The function never guesses,
   never falls back to a default profile, and never silently returns a prompt
   with empty `append`.
-- When a caller has no profile name to supply (e.g. `fit-eval run`
-  invoked without `--agent-profile`), it does not call the function at all
-  and passes `systemPrompt: undefined` to `AgentRunner`. That keeps ad-hoc
-  CLI usage working while guaranteeing that whenever a profile name _is_
-  supplied, its content reaches the system prompt.
+- When a caller has no profile name to supply (e.g. `fit-eval run` invoked
+  without `--agent-profile`), it does not call the function at all and passes
+  `systemPrompt: undefined` to `AgentRunner`. That keeps ad-hoc CLI usage
+  working while guaranteeing that whenever a profile name _is_ supplied, its
+  content reaches the system prompt.
 
 ## Data flow
 
@@ -61,8 +61,8 @@ flowchart TD
   SDK --> MainThread["Main-thread system prompt<br/>carries profile content"]
 ```
 
-Every main thread — solo agent, supervised agent, supervisor, facilitated
-agent, facilitator — enters the SDK through the same two-step sequence:
+Every main thread — solo agent, supervised agent, supervisor, facilitated agent,
+facilitator — enters the SDK through the same two-step sequence:
 `composeProfilePrompt` → `AgentRunner` with `systemPrompt` set. There is no
 other path.
 
@@ -70,11 +70,11 @@ other path.
 
 The full file contents after YAML frontmatter — the human-readable body — are
 what carries voice markers, scope constraints, and skill routing. The
-frontmatter itself (name, description, skills list) is stripped because the
-body already expresses those contracts in natural language and the skills
-list duplicates registrations the SDK discovers via `settingSources:
-["project"]`. `composeProfilePrompt` parses and discards the frontmatter
-fence, appends only the body, then appends the optional mode trailer.
+frontmatter itself (name, description, skills list) is stripped because the body
+already expresses those contracts in natural language and the skills list
+duplicates registrations the SDK discovers via `settingSources: ["project"]`.
+`composeProfilePrompt` parses and discards the frontmatter fence, appends only
+the body, then appends the optional mode trailer.
 
 ### Decision — append the profile body, not the whole file
 
@@ -83,9 +83,9 @@ fence, appends only the body, then appends the optional mode trailer.
 
 **Rejected — append the entire raw file including frontmatter.** Cheaper to
 implement but it leaks a YAML block into the model's system prompt that was
-never written for the model to read, and it re-asserts a `skills:` list the
-SDK already loads from the filesystem when `settingSources: ["project"]` is
-set — inviting contradiction if the two drift.
+never written for the model to read, and it re-asserts a `skills:` list the SDK
+already loads from the filesystem when `settingSources: ["project"]` is set —
+inviting contradiction if the two drift.
 
 **Rejected — replace the `claude_code` preset with the profile as a custom
 string prompt.** Gives cleaner separation but forfeits Claude Code's default
@@ -98,13 +98,13 @@ works today; do not regress.
 ### Decision — loader in libeval, one module, pure function
 
 **Chosen:** `composeProfilePrompt` is a pure function in
-`libraries/libeval/src/profile-prompt.js`. Each command calls it once at
-startup and passes the result into its runner factory.
+`libraries/libeval/src/profile-prompt.js`. Each command calls it once at startup
+and passes the result into its runner factory.
 
 **Rejected — load inside `AgentRunner`.** Would couple the runner to the
-filesystem and to a specific profile directory layout, making the
-long-standing test pattern of injecting a mock `query` awkward (tests would
-now need to stub `fs` too).
+filesystem and to a specific profile directory layout, making the long-standing
+test pattern of injecting a mock `query` awkward (tests would now need to stub
+`fs` too).
 
 **Rejected — load inside each command's options parser.** Scatters the
 profile-shaping logic across `run.js`, `supervise.js`, and `facilitate.js`.
@@ -115,45 +115,45 @@ Three copies drift; one module does not.
 ### Decision — `AgentRunner` takes a pre-composed `systemPrompt`, not a profile name
 
 **Chosen:** Drop the `agentProfile` constructor field from `AgentRunner`.
-Callers construct `systemPrompt` via `composeProfilePrompt` and pass it in.
-The runner loses its only filesystem concern; the orchestration factories
-each call `composeProfilePrompt` once per runner they create, passing the
-mode-specific trailer.
+Callers construct `systemPrompt` via `composeProfilePrompt` and pass it in. The
+runner loses its only filesystem concern; the orchestration factories each call
+`composeProfilePrompt` once per runner they create, passing the mode-specific
+trailer.
 
 **Rejected — have `AgentRunner` accept `profileName` and call the loader
 internally.** Convenient for callers but re-introduces the same two failure
-modes in three places: either every mode needs its own trailer parameter
-plumbed through `AgentRunner`'s constructor, or the runner grows a
-mode-awareness switch. Neither is the runner's job.
+modes in three places: either every mode needs its own trailer parameter plumbed
+through `AgentRunner`'s constructor, or the runner grows a mode-awareness
+switch. Neither is the runner's job.
 
-**Rejected — leave solo mode wiring `options.agent` and only touch the
-solo-mode path.** The spec explicitly forbids this: libeval must stop using
-`options.agent` as a binding mechanism everywhere, so that if a future SDK
-makes the option attach profile content, we do not end up double-stacking
-the profile in supervised and facilitated modes.
+**Rejected — leave solo mode wiring `options.agent` and only touch the solo-mode
+path.** The spec explicitly forbids this: libeval must stop using
+`options.agent` as a binding mechanism everywhere, so that if a future SDK makes
+the option attach profile content, we do not end up double-stacking the profile
+in supervised and facilitated modes.
 
 ## Safety nets (restated, not re-designed)
 
 - **Unreadable profile file.** The `fs.readFileSync` inside
-  `composeProfilePrompt` throws; the command exits non-zero with the
-  underlying error. No bespoke validation layer is added.
+  `composeProfilePrompt` throws; the command exits non-zero with the underlying
+  error. No bespoke validation layer is added.
 - **Bound-but-wrong content.** A main thread carrying an empty or mismatched
-  profile drifts across domain boundaries in the first few turns.
-  `kata-trace`'s grounded-theory analysis already detects this from trace
-  artifacts; no dedicated trace event is introduced.
+  profile drifts across domain boundaries in the first few turns. `kata-trace`'s
+  grounded-theory analysis already detects this from trace artifacts; no
+  dedicated trace event is introduced.
 
 ## Removed surface area
 
 - `AgentRunner.agentProfile` and the `options.agent` spread in its `run()` /
   `resume()` calls.
 - Internal routing of every profile-name CLI flag (`--agent-profile`,
-  `--agent-profiles`, `--supervisor-profile`, `--facilitator-profile`) into
-  SDK `options.agent`. The flags keep their names at the CLI boundary but
-  inside libeval they now feed `composeProfilePrompt` and nothing else —
-  satisfying success criterion #2 (no call site in libeval's source
-  references the SDK's top-level `agent` option or `--agent` CLI flag).
-- `AGENT_SYSTEM_PROMPT` etc. stay exported — they become trailer strings
-  passed into `composeProfilePrompt`, not standalone `append` values.
+  `--agent-profiles`, `--supervisor-profile`, `--facilitator-profile`) into SDK
+  `options.agent`. The flags keep their names at the CLI boundary but inside
+  libeval they now feed `composeProfilePrompt` and nothing else — satisfying
+  success criterion #2 (no call site in libeval's source references the SDK's
+  top-level `agent` option or `--agent` CLI flag).
+- `AGENT_SYSTEM_PROMPT` etc. stay exported — they become trailer strings passed
+  into `composeProfilePrompt`, not standalone `append` values.
 
 ## Out of scope (per spec)
 

--- a/specs/530-agent-profile-main-thread-binding/design.md
+++ b/specs/530-agent-profile-main-thread-binding/design.md
@@ -4,9 +4,11 @@
 
 libeval owns main-thread profile binding. A new pure function,
 `composeProfilePrompt`, reads `.claude/agents/<name>.md` and returns an SDK
-`systemPrompt` value. All three execution modes route through
-`AgentRunner`, and `AgentRunner` becomes the single place that knows how to
-attach a profile. The SDK's top-level `agent` option and its `--agent` CLI
+`systemPrompt` value. Every command (`run`, `supervise`, `facilitate`) calls
+this function at startup for each main thread it creates, then passes the
+result into `AgentRunner` via the existing `systemPrompt` input.
+`AgentRunner` loses its `agentProfile` field and no longer sets the SDK's
+`options.agent`. The SDK's top-level `agent` option and its `--agent` CLI
 mirror are removed from libeval's source — they remain a subagent-registration
 concern for Claude Code itself, not a main-thread input we control.
 
@@ -15,7 +17,7 @@ concern for Claude Code itself, not a main-thread input we control.
 | Component | Role | Where it lives conceptually |
 | --- | --- | --- |
 | `composeProfilePrompt(name, { profilesDir })` | Pure: load + merge profile file into `{ type: "preset", preset: "claude_code", append: string }` | New module inside libeval (`src/profile-prompt.js`) |
-| `AgentRunner` | Continues to own the single SDK `query({ options })` call; gains a `profileName` input, drops `agentProfile`/`options.agent` | `libraries/libeval/src/agent-runner.js` |
+| `AgentRunner` | Continues to own the single SDK `query({ options })` call; drops the `agentProfile` constructor dep and the `options.agent` spread; accepts a pre-composed `systemPrompt` from callers | `libraries/libeval/src/agent-runner.js` |
 | `run` command | Loads the profile via `composeProfilePrompt` and passes the resulting `systemPrompt` to `AgentRunner`; stops forwarding `--agent` | `src/commands/run.js` |
 | `Supervisor` factory | Same load-and-pass pattern for both agent and supervisor runners; `AGENT_SYSTEM_PROMPT` becomes a trailer merged into the profile's `append`, not a replacement | `src/supervisor.js` |
 | `Facilitator` factory | Same pattern per agent config and for the facilitator runner; `FACILITATED_AGENT_SYSTEM_PROMPT` / `FACILITATOR_SYSTEM_PROMPT` become trailers | `src/facilitator.js` |
@@ -40,6 +42,11 @@ composeProfilePrompt(
 - `name` is the only identity the caller knows. The function never guesses,
   never falls back to a default profile, and never silently returns a prompt
   with empty `append`.
+- When a caller has no profile name to supply (e.g. `fit-eval run`
+  invoked without `--agent-profile`), it does not call the function at all
+  and passes `systemPrompt: undefined` to `AgentRunner`. That keeps ad-hoc
+  CLI usage working while guaranteeing that whenever a profile name _is_
+  supplied, its content reaches the system prompt.
 
 ## Data flow
 
@@ -139,9 +146,12 @@ the profile in supervised and facilitated modes.
 
 - `AgentRunner.agentProfile` and the `options.agent` spread in its `run()` /
   `resume()` calls.
-- `--agent-profile` and `--facilitator-profile` CLI flags' pass-through to
-  `options.agent`. The flags may keep their names at the CLI boundary, but
-  in libeval's source they now feed `composeProfilePrompt` and nothing else.
+- Internal routing of every profile-name CLI flag (`--agent-profile`,
+  `--agent-profiles`, `--supervisor-profile`, `--facilitator-profile`) into
+  SDK `options.agent`. The flags keep their names at the CLI boundary but
+  inside libeval they now feed `composeProfilePrompt` and nothing else —
+  satisfying success criterion #2 (no call site in libeval's source
+  references the SDK's top-level `agent` option or `--agent` CLI flag).
 - `AGENT_SYSTEM_PROMPT` etc. stay exported — they become trailer strings
   passed into `composeProfilePrompt`, not standalone `append` values.
 

--- a/specs/530-agent-profile-main-thread-binding/design.md
+++ b/specs/530-agent-profile-main-thread-binding/design.md
@@ -1,0 +1,154 @@
+# Design 530 — Agent Profile Main-Thread Binding
+
+## Architectural summary
+
+libeval owns main-thread profile binding. A new pure function,
+`composeProfilePrompt`, reads `.claude/agents/<name>.md` and returns an SDK
+`systemPrompt` value. All three execution modes route through
+`AgentRunner`, and `AgentRunner` becomes the single place that knows how to
+attach a profile. The SDK's top-level `agent` option and its `--agent` CLI
+mirror are removed from libeval's source — they remain a subagent-registration
+concern for Claude Code itself, not a main-thread input we control.
+
+### Components
+
+| Component | Role | Where it lives conceptually |
+| --- | --- | --- |
+| `composeProfilePrompt(name, { profilesDir })` | Pure: load + merge profile file into `{ type: "preset", preset: "claude_code", append: string }` | New module inside libeval (`src/profile-prompt.js`) |
+| `AgentRunner` | Continues to own the single SDK `query({ options })` call; gains a `profileName` input, drops `agentProfile`/`options.agent` | `libraries/libeval/src/agent-runner.js` |
+| `run` command | Loads the profile via `composeProfilePrompt` and passes the resulting `systemPrompt` to `AgentRunner`; stops forwarding `--agent` | `src/commands/run.js` |
+| `Supervisor` factory | Same load-and-pass pattern for both agent and supervisor runners; `AGENT_SYSTEM_PROMPT` becomes a trailer merged into the profile's `append`, not a replacement | `src/supervisor.js` |
+| `Facilitator` factory | Same pattern per agent config and for the facilitator runner; `FACILITATED_AGENT_SYSTEM_PROMPT` / `FACILITATOR_SYSTEM_PROMPT` become trailers | `src/facilitator.js` |
+
+### Interface — `composeProfilePrompt`
+
+```
+composeProfilePrompt(
+  name: string,
+  opts: { profilesDir: string, trailer?: string }
+): { type: "preset", preset: "claude_code", append: string }
+```
+
+- Reads `${profilesDir}/${name}.md`. A missing or unreadable file propagates
+  the underlying `ENOENT` / permission error unchanged — that is the spec's
+  first safety net.
+- Returns the SDK-shaped `systemPrompt` with `append` equal to the profile
+  body plus, when provided, a blank line and `trailer`. Orchestration modes
+  pass their existing boilerplate (`AGENT_SYSTEM_PROMPT`,
+  `FACILITATED_AGENT_SYSTEM_PROMPT`, `FACILITATOR_SYSTEM_PROMPT`) as
+  `trailer` so today's working behaviour is preserved.
+- `name` is the only identity the caller knows. The function never guesses,
+  never falls back to a default profile, and never silently returns a prompt
+  with empty `append`.
+
+## Data flow
+
+```mermaid
+flowchart TD
+  CLI["fit-eval run / supervise / facilitate"] --> Cmd["command parseOptions<br/>(profile name: string)"]
+  Cmd --> Compose["composeProfilePrompt(name)"]
+  Profile[".claude/agents/&lt;name&gt;.md<br/>(frontmatter + body)"] --> Compose
+  Compose --> Prompt["{ type: 'preset',<br/>preset: 'claude_code',<br/>append: body [+ trailer] }"]
+  Prompt --> Runner["AgentRunner.run(task)"]
+  Runner --> SDK["@anthropic-ai/claude-agent-sdk<br/>query({ options.systemPrompt })"]
+  SDK --> MainThread["Main-thread system prompt<br/>carries profile content"]
+```
+
+Every main thread — solo agent, supervised agent, supervisor, facilitated
+agent, facilitator — enters the SDK through the same two-step sequence:
+`composeProfilePrompt` → `AgentRunner` with `systemPrompt` set. There is no
+other path.
+
+## What lands in the system prompt
+
+The full file contents after YAML frontmatter — the human-readable body — are
+what carries voice markers, scope constraints, and skill routing. The
+frontmatter itself (name, description, skills list) is stripped because the
+body already expresses those contracts in natural language and the skills
+list duplicates registrations the SDK discovers via `settingSources:
+["project"]`. `composeProfilePrompt` parses and discards the frontmatter
+fence, appends only the body, then appends the optional mode trailer.
+
+### Decision — append the profile body, not the whole file
+
+**Chosen:** Strip the frontmatter, append the markdown body via
+`systemPrompt.append` on top of the `claude_code` preset.
+
+**Rejected — append the entire raw file including frontmatter.** Cheaper to
+implement but it leaks a YAML block into the model's system prompt that was
+never written for the model to read, and it re-asserts a `skills:` list the
+SDK already loads from the filesystem when `settingSources: ["project"]` is
+set — inviting contradiction if the two drift.
+
+**Rejected — replace the `claude_code` preset with the profile as a custom
+string prompt.** Gives cleaner separation but forfeits Claude Code's default
+tool-use scaffolding that every successful run in the Evidence table depended
+on. The facilitated-mode baseline proves preset-plus-append is the shape that
+works today; do not regress.
+
+## Where profile loading lives
+
+### Decision — loader in libeval, one module, pure function
+
+**Chosen:** `composeProfilePrompt` is a pure function in
+`libraries/libeval/src/profile-prompt.js`. Each command calls it once at
+startup and passes the result into its runner factory.
+
+**Rejected — load inside `AgentRunner`.** Would couple the runner to the
+filesystem and to a specific profile directory layout, making the
+long-standing test pattern of injecting a mock `query` awkward (tests would
+now need to stub `fs` too).
+
+**Rejected — load inside each command's options parser.** Scatters the
+profile-shaping logic across `run.js`, `supervise.js`, and `facilitate.js`.
+Three copies drift; one module does not.
+
+## How the three modes converge
+
+### Decision — `AgentRunner` takes a pre-composed `systemPrompt`, not a profile name
+
+**Chosen:** Drop the `agentProfile` constructor field from `AgentRunner`.
+Callers construct `systemPrompt` via `composeProfilePrompt` and pass it in.
+The runner loses its only filesystem concern; the orchestration factories
+each call `composeProfilePrompt` once per runner they create, passing the
+mode-specific trailer.
+
+**Rejected — have `AgentRunner` accept `profileName` and call the loader
+internally.** Convenient for callers but re-introduces the same two failure
+modes in three places: either every mode needs its own trailer parameter
+plumbed through `AgentRunner`'s constructor, or the runner grows a
+mode-awareness switch. Neither is the runner's job.
+
+**Rejected — leave solo mode wiring `options.agent` and only touch the
+solo-mode path.** The spec explicitly forbids this: libeval must stop using
+`options.agent` as a binding mechanism everywhere, so that if a future SDK
+makes the option attach profile content, we do not end up double-stacking
+the profile in supervised and facilitated modes.
+
+## Safety nets (restated, not re-designed)
+
+- **Unreadable profile file.** The `fs.readFileSync` inside
+  `composeProfilePrompt` throws; the command exits non-zero with the
+  underlying error. No bespoke validation layer is added.
+- **Bound-but-wrong content.** A main thread carrying an empty or mismatched
+  profile drifts across domain boundaries in the first few turns.
+  `kata-trace`'s grounded-theory analysis already detects this from trace
+  artifacts; no dedicated trace event is introduced.
+
+## Removed surface area
+
+- `AgentRunner.agentProfile` and the `options.agent` spread in its `run()` /
+  `resume()` calls.
+- `--agent-profile` and `--facilitator-profile` CLI flags' pass-through to
+  `options.agent`. The flags may keep their names at the CLI boundary, but
+  in libeval's source they now feed `composeProfilePrompt` and nothing else.
+- `AGENT_SYSTEM_PROMPT` etc. stay exported — they become trailer strings
+  passed into `composeProfilePrompt`, not standalone `append` values.
+
+## Out of scope (per spec)
+
+Profile file contents, subagent registration via `Task`/`Agent`, future SDK
+behaviour of `options.agent`, dedicated startup validation, dedicated trace
+events, task-prompt rewording.
+
+— Staff Engineer 🛠️

--- a/specs/530-agent-profile-main-thread-binding/plan-a.md
+++ b/specs/530-agent-profile-main-thread-binding/plan-a.md
@@ -1,0 +1,287 @@
+# Plan 530 — Agent Profile Main-Thread Binding
+
+## Approach
+
+Introduce a pure `composeProfilePrompt` module inside libeval, then thread it
+through the three command call sites (`run`, `supervise`, `facilitate`) and the
+two orchestration factories (`supervisor.js`, `facilitator.js`). `AgentRunner`
+loses its `agentProfile` field and the SDK `options.agent` spread. The CLI
+flags keep their surface at the boundary but internally feed
+`composeProfilePrompt` — nothing else. Mode-specific trailers
+(`AGENT_SYSTEM_PROMPT`, `FACILITATED_AGENT_SYSTEM_PROMPT`,
+`FACILITATOR_SYSTEM_PROMPT`, `SUPERVISOR_SYSTEM_PROMPT`) move from the
+`append` slot into the composer's `trailer` option so today's working
+behaviour in facilitated/supervised modes is preserved bit-for-bit.
+
+## Ordered Steps
+
+### Step 1 — New module `src/profile-prompt.js` + unit tests
+
+**Create** `/home/user/monorepo/libraries/libeval/src/profile-prompt.js`
+exporting one function:
+
+```
+composeProfilePrompt(name, { profilesDir, trailer })
+  → { type: "preset", preset: "claude_code", append: string }
+```
+
+Behaviour:
+
+- Reads `${profilesDir}/${name}.md` with `readFileSync(path, "utf8")`. Missing
+  file propagates `ENOENT` unchanged (first safety net).
+- Strips YAML frontmatter. Recognise the fence pattern: file begins with
+  `---\n`, a second `\n---\n` terminates it. If the file lacks frontmatter,
+  the entire body is used.
+- `append` = body (trimmed of leading/trailing whitespace) + `"\n\n"` +
+  `trailer` when trailer is a non-empty string; otherwise just the body.
+- No fallback, no default profile, no catch-around-read.
+
+**Export** from `/home/user/monorepo/libraries/libeval/src/index.js` alongside
+`createAgentRunner` so callers outside libeval could depend on it (consistency
+with existing public surface).
+
+**Create** `/home/user/monorepo/libraries/libeval/test/profile-prompt.test.js`.
+Fixtures live alongside in `test/fixtures/profile-prompt/` — one with
+frontmatter, one without. Tests:
+
+- Returns the `{ type: "preset", preset: "claude_code", append }` shape.
+- Strips frontmatter (the `append` does not contain `---` or YAML keys from
+  the fence).
+- Concatenates trailer with blank-line separator when provided; no trailing
+  whitespace mismatch when omitted.
+- Throws `ENOENT` for a missing profile file.
+- **Spec SC#1 coverage (loop test):** `readdirSync(".claude/agents")`, filter
+  `*.md`, for each file assert
+  `composeProfilePrompt(basename, { profilesDir: ".claude/agents" }).append`
+  contains a non-trivial substring of the real profile body (e.g. first 40
+  chars of the file past frontmatter). This walks every live profile and
+  fails the build if any profile stops being loadable.
+
+### Step 2 — `AgentRunner` cleanup (`src/agent-runner.js`)
+
+Depends on: nothing (structural).
+
+- Remove `agentProfile: deps.agentProfile ?? null` from `applyDefaults`.
+- Remove the `@param {string} [deps.agentProfile]` JSDoc line.
+- In `run()`, remove the line
+  `...(this.agentProfile && { agent: this.agentProfile }),`.
+- `resume()` never set `agent`; no change there.
+
+After this, `AgentRunner` has no filesystem or profile concerns. The only way
+profile content enters the SDK is via the caller-provided `systemPrompt`.
+
+### Step 3 — Wire `commands/run.js` through the composer
+
+Depends on: Step 1.
+
+Before (line 79–90):
+
+```
+const { query } = await import("@anthropic-ai/claude-agent-sdk");
+const runner = createAgentRunner({
+  cwd, query, output: devNull, model, maxTurns, allowedTools,
+  onLine, settingSources: ["project"],
+  agentProfile,
+});
+```
+
+After:
+
+```
+import { composeProfilePrompt } from "../profile-prompt.js";
+...
+const systemPrompt = agentProfile
+  ? composeProfilePrompt(agentProfile, { profilesDir: resolve(cwd, ".claude/agents") })
+  : undefined;
+const { query } = await import("@anthropic-ai/claude-agent-sdk");
+const runner = createAgentRunner({
+  cwd, query, output: devNull, model, maxTurns, allowedTools,
+  onLine, settingSources: ["project"],
+  systemPrompt,
+});
+```
+
+The `agentProfile` local stays (read from `--agent-profile`); it feeds the
+composer and nothing else. `parseRunOptions` is unchanged.
+
+### Step 4 — Wire `supervisor.js` through the composer
+
+Depends on: Step 1, Step 2.
+
+At the supervisor factory (~L390–443):
+
+- Remove `agentProfile` and `supervisorProfile` from the `createAgentRunner`
+  argument objects.
+- Replace the agent runner's `systemPrompt: { type: "preset", preset:
+  "claude_code", append: AGENT_SYSTEM_PROMPT }` with
+  ```
+  systemPrompt: agentProfile
+    ? composeProfilePrompt(agentProfile, { profilesDir, trailer: AGENT_SYSTEM_PROMPT })
+    : { type: "preset", preset: "claude_code", append: AGENT_SYSTEM_PROMPT },
+  ```
+- Same shape for the supervisor runner using `supervisorProfile` and
+  `SUPERVISOR_SYSTEM_PROMPT` as trailer.
+- Add `profilesDir` to the factory's dep signature with default
+  `resolve(agentCwd, ".claude/agents")`; accept an override from callers for
+  test injection symmetry.
+- Import `composeProfilePrompt` from `./profile-prompt.js`.
+
+The `AGENT_SYSTEM_PROMPT` / `SUPERVISOR_SYSTEM_PROMPT` exports stay — they
+are consumed here as trailers, not as standalone `append` values. The JSDoc
+on `createSupervisor`'s `agentProfile` / `supervisorProfile` params is
+updated to say "resolved into the main-thread system prompt via
+`composeProfilePrompt`" rather than "passed to Claude as `--agent`".
+
+### Step 5 — Wire `facilitator.js` through the composer
+
+Depends on: Step 1, Step 2.
+
+At the facilitator factory (~L440–500):
+
+- For each agent runner in the `agents.map(...)` block: remove
+  `agentProfile: config.agentProfile`; replace the static `systemPrompt`
+  with `composeProfilePrompt(config.agentProfile, { profilesDir, trailer:
+  FACILITATED_AGENT_SYSTEM_PROMPT })` when `config.agentProfile` is set,
+  otherwise keep today's plain-trailer shape.
+- Facilitator runner: same replacement with `facilitatorProfile` and
+  `FACILITATOR_SYSTEM_PROMPT` as trailer.
+- Accept a `profilesDir` dep with the same default pattern as Step 4.
+
+### Step 6 — CLI flag audit (`bin/fit-eval.js`, `commands/*.js`)
+
+Depends on: Steps 3–5.
+
+Verify — and document in the commit message — that:
+
+- `bin/fit-eval.js` still exposes `--agent-profile`, `--supervisor-profile`,
+  `--facilitator-profile`, `--agent-profiles` (unchanged — that is the CLI
+  boundary per the design).
+- No command file passes `options.agent` or the SDK's top-level `agent`
+  option into `createAgentRunner`. The `agentProfile` locals in `run.js`,
+  `supervise.js`, and `facilitate.js` feed only `composeProfilePrompt`.
+- `commands/supervise.js` `opts.agentProfile` and `opts.supervisorProfile`
+  feed the supervisor factory's new signature unchanged at the CLI layer.
+
+No code change expected in this step beyond whatever minor rewiring Steps
+3–5 already required in the command files; this step is a grep-and-read
+confirmation.
+
+### Step 7 — Grep verification for Spec SC#2
+
+Depends on: Steps 2–6.
+
+Run these greps and confirm zero matches inside `libraries/libeval/src/`
+and `libraries/libeval/bin/`:
+
+```
+rg -n "\bagent:\s*[A-Za-z]" libraries/libeval/src libraries/libeval/bin
+rg -n "agentProfile" libraries/libeval/src libraries/libeval/bin
+rg -n "\"--agent\"" libraries/libeval/src libraries/libeval/bin
+```
+
+Tests and fixtures may still reference the old shape when stubbing
+historical SDK options — those matches are acceptable. Record the greps in
+the final commit body so the reviewer can replay them.
+
+## Files touched
+
+- **Created:** `libraries/libeval/src/profile-prompt.js`,
+  `libraries/libeval/test/profile-prompt.test.js`,
+  `libraries/libeval/test/fixtures/profile-prompt/*`.
+- **Modified:** `libraries/libeval/src/agent-runner.js`,
+  `libraries/libeval/src/commands/run.js`,
+  `libraries/libeval/src/commands/supervise.js` (signature pass-through only),
+  `libraries/libeval/src/commands/facilitate.js` (signature pass-through only),
+  `libraries/libeval/src/supervisor.js`,
+  `libraries/libeval/src/facilitator.js`,
+  `libraries/libeval/src/index.js` (export).
+- **Deleted:** none.
+
+## Test additions
+
+- `test/profile-prompt.test.js` — unit tests for the composer, including the
+  SC#1 loop over `.claude/agents/*.md`.
+- Existing tests that stub `AgentRunner` with `agentProfile` (likely in
+  `test/agent-runner.test.js`, `test/supervisor-*.test.js`,
+  `test/facilitator*.test.js`, `test/mock-runner.js`) must be updated to stop
+  passing `agentProfile` and either pass a precomposed `systemPrompt` or
+  leave `systemPrompt` unset. Inventory these at implementation time with
+  `rg agentProfile libraries/libeval/test/`.
+
+## Libraries used
+
+None. `composeProfilePrompt` uses only `node:fs` (`readFileSync`) and
+`node:path` (`join`). No `@forwardimpact/lib*` package is consumed. This is
+intentional — the composer stays a ~30-line pure function so tests can
+exercise it without DI scaffolding.
+
+## Risks
+
+- **SDK preset-composition semantics.** The design asserts that
+  `{ type: "preset", preset: "claude_code", append: body + trailer }`
+  composes profile + mode-boilerplate correctly at runtime. This holds in
+  today's facilitated and supervised runs (Evidence table, spec.md) but is
+  not directly unit-testable without a live SDK call. SC#3 is the
+  end-to-end verifier — first night-shift run after merge either emits
+  voice markers or does not.
+- **Test stubs for `AgentRunner`.** Existing tests pass `agentProfile` into
+  the constructor. They will keep passing silently because
+  `applyDefaults` previously accepted the field, but after Step 2 any test
+  that asserts `options.agent` was forwarded into the SDK query will fail.
+  Step 2 includes an inventory pass to update them.
+- **Non-main-thread uses of `options.agent`.** Subagent dispatch via the
+  `Task`/`Agent` tool is out of scope (spec § Excluded), but a stray
+  `options.agent` inside supervisor/facilitator code paths that is _not_
+  main-thread-binding-related would also be removed by Step 2. The greps
+  in Step 7 flag any such leak for conscious decision at implementation
+  time.
+- **Profile directory location.** The composer takes `profilesDir` as an
+  input and defaults to `<cwd>/.claude/agents` at each call site. A run
+  whose `cwd` is not the monorepo root (test harness, custom invocation)
+  will receive an `ENOENT` — surfaced exactly as the spec's first safety
+  net requires.
+
+## Execution recommendation
+
+Single `staff-engineer` run on branch `feat/530-agent-profile-main-thread-binding`.
+Do not decompose. The change is tightly coupled (one module + five wiring
+sites + test updates) and the whole diff must land together so greps pass.
+Steps 1 and 2 are independent; Steps 3–5 depend on both; Steps 6–7 are the
+tail audit. Implementer runs `bun run check` and `bun run test` after each
+wiring step and once at the end.
+
+SC#3 (voice-marker appearance in scheduled runs) is end-to-end and observed
+after the fix lands in `main`. Note it in the implementation PR body as a
+post-merge verification step against the next night-shift traces; do not
+block PR merge on it.
+
+## Self-review
+
+Ran the DO-CONFIRM checklist:
+
+- [x] Approach and rationale stated up front.
+- [x] Changes concrete — file paths, function names, before/after snippets.
+- [x] Blast radius visible — "Files touched" lists created/modified/deleted.
+- [x] Ordering explicit with stated dependencies on each step.
+- [x] Non-obvious decisions explained (trailer semantics, no libs, why
+      single-agent).
+- [x] Risks surfaced — SDK composition, test stubs, stray `options.agent`,
+      profileDir location.
+- [x] Libraries-used section present — states "None" explicitly with
+      rationale.
+- [x] Execution recommendation present — single agent, no decomposition,
+      SC#3 deferred.
+
+**Self-caught findings:**
+
+- None material. One caveat: the test in Step 1 for SC#1 asserts the
+  presence of a body substring, not a voice marker. Voice markers (the
+  em-dash-plus-emoji trailers in each profile) live in the body and would
+  be a tighter assertion, but the profile files do not share a common
+  marker shape, so per-profile substrings are the durable choice. The
+  alternative — a per-profile hardcoded list of expected markers —
+  duplicates knowledge already in the `.md` files and would drift. Flag
+  this trade-off to the implementer; they may tighten the assertion if a
+  stable per-profile signature emerges.
+
+— Staff Engineer 🛠️

--- a/specs/530-agent-profile-main-thread-binding/plan-a.md
+++ b/specs/530-agent-profile-main-thread-binding/plan-a.md
@@ -50,12 +50,16 @@ frontmatter, one without. Tests:
 - Concatenates trailer with blank-line separator when provided; no trailing
   whitespace mismatch when omitted.
 - Throws `ENOENT` for a missing profile file.
-- **Spec SC#1 coverage (loop test):** `readdirSync(".claude/agents")`, filter
-  `*.md`, for each file assert
-  `composeProfilePrompt(basename, { profilesDir: ".claude/agents" }).append`
-  contains a non-trivial substring of the real profile body (e.g. first 40
-  chars of the file past frontmatter). This walks every live profile and
-  fails the build if any profile stops being loadable.
+- **Spec SC#1 coverage (loop test):** Resolve the profiles directory via
+  `fileURLToPath(new URL("../../../.claude/agents", import.meta.url))` so
+  the path is anchored to the test file's location and independent of
+  `bun test` cwd. `readdirSync` that dir, filter `.md` files (no
+  subdirectory filtering needed — `.claude/agents/references/` is a
+  directory and will not match). For each file assert
+  `composeProfilePrompt(basename, { profilesDir }).append` contains a
+  non-trivial substring of the real profile body (e.g. first 40 chars of
+  the file past frontmatter). This walks every live profile and fails the
+  build if any profile stops being loadable.
 
 ### Step 2 — `AgentRunner` cleanup (`src/agent-runner.js`)
 
@@ -106,9 +110,10 @@ composer and nothing else. `parseRunOptions` is unchanged.
 
 ### Step 4 — Wire `supervisor.js` through the composer
 
-Depends on: Step 1, Step 2.
+Depends on: Step 1.
 
-At the supervisor factory (~L390–443):
+At the two `systemPrompt:` blocks inside `createSupervisor` (one for the
+agent runner, one for the supervisor runner — currently at L406 and L437):
 
 - Remove `agentProfile` and `supervisorProfile` from the `createAgentRunner`
   argument objects.
@@ -134,9 +139,11 @@ updated to say "resolved into the main-thread system prompt via
 
 ### Step 5 — Wire `facilitator.js` through the composer
 
-Depends on: Step 1, Step 2.
+Depends on: Step 1.
 
-At the facilitator factory (~L440–500):
+At the two `systemPrompt:` blocks inside `createFacilitator` — the per-agent
+runner inside `agents.map(...)` (currently at L475) and the facilitator
+runner itself (currently at L495):
 
 - For each agent runner in the `agents.map(...)` block: remove
   `agentProfile: config.agentProfile`; replace the static `systemPrompt`
@@ -151,37 +158,50 @@ At the facilitator factory (~L440–500):
 
 Depends on: Steps 3–5.
 
-Verify — and document in the commit message — that:
+Audit-only step — no code change expected. Verify — and record the
+findings in the commit message — that:
 
 - `bin/fit-eval.js` still exposes `--agent-profile`, `--supervisor-profile`,
   `--facilitator-profile`, `--agent-profiles` (unchanged — that is the CLI
   boundary per the design).
 - No command file passes `options.agent` or the SDK's top-level `agent`
   option into `createAgentRunner`. The `agentProfile` locals in `run.js`,
-  `supervise.js`, and `facilitate.js` feed only `composeProfilePrompt`.
-- `commands/supervise.js` `opts.agentProfile` and `opts.supervisorProfile`
-  feed the supervisor factory's new signature unchanged at the CLI layer.
+  `supervise.js`, and `facilitate.js` feed only `composeProfilePrompt` or
+  the factory signatures updated in Steps 4 and 5.
+- Factory signatures in `supervisor.js` and `facilitator.js` default
+  `profilesDir` to `<cwd>/.claude/agents`, so command files pass nothing
+  new across the boundary.
 
-No code change expected in this step beyond whatever minor rewiring Steps
-3–5 already required in the command files; this step is a grep-and-read
-confirmation.
+If the audit uncovers a path the plan missed, surface it as a deviation
+note on the implementation PR rather than editing silently.
 
 ### Step 7 — Grep verification for Spec SC#2
 
 Depends on: Steps 2–6.
 
-Run these greps and confirm zero matches inside `libraries/libeval/src/`
-and `libraries/libeval/bin/`:
+Spec SC#2 targets the SDK binding surface, not the `agentProfile`
+identifier used as a local or CLI argument name (which is fine to keep —
+it feeds `composeProfilePrompt` and nothing else). The greps below must
+return zero matches inside `libraries/libeval/src/` and
+`libraries/libeval/bin/`:
 
 ```
-rg -n "\bagent:\s*[A-Za-z]" libraries/libeval/src libraries/libeval/bin
-rg -n "agentProfile" libraries/libeval/src libraries/libeval/bin
-rg -n "\"--agent\"" libraries/libeval/src libraries/libeval/bin
+# SDK query option shape: object literal key "agent:" followed by an
+# identifier (captures both `agent: agentProfile` and
+# `agent: this.agentProfile`).
+rg -n "[{,]\s*agent:\s*[A-Za-z_.]" libraries/libeval/src libraries/libeval/bin
+
+# Old extraArgs shape, in case any path still forwards the flag.
+rg -n "extraArgs.*agent" libraries/libeval/src libraries/libeval/bin
+
+# Literal --agent flag pass-through.
+rg -n '"--agent"' libraries/libeval/src libraries/libeval/bin
 ```
 
-Tests and fixtures may still reference the old shape when stubbing
-historical SDK options — those matches are acceptable. Record the greps in
-the final commit body so the reviewer can replay them.
+The `agentProfile` name itself remains (as a variable holding the profile
+name to hand to `composeProfilePrompt`) and is not searched for. Tests and
+fixtures are out of scope for these greps. Record the exact commands in
+the commit body so the reviewer can replay them.
 
 ## Files touched
 
@@ -190,23 +210,24 @@ the final commit body so the reviewer can replay them.
   `libraries/libeval/test/fixtures/profile-prompt/*`.
 - **Modified:** `libraries/libeval/src/agent-runner.js`,
   `libraries/libeval/src/commands/run.js`,
-  `libraries/libeval/src/commands/supervise.js` (signature pass-through only),
-  `libraries/libeval/src/commands/facilitate.js` (signature pass-through only),
   `libraries/libeval/src/supervisor.js`,
   `libraries/libeval/src/facilitator.js`,
   `libraries/libeval/src/index.js` (export).
 - **Deleted:** none.
+- **Not modified:** `libraries/libeval/src/commands/supervise.js` and
+  `libraries/libeval/src/commands/facilitate.js` are inspected in Step 6
+  but do not need edits given the `profilesDir` default in the factory
+  signatures.
 
 ## Test additions
 
 - `test/profile-prompt.test.js` — unit tests for the composer, including the
   SC#1 loop over `.claude/agents/*.md`.
-- Existing tests that stub `AgentRunner` with `agentProfile` (likely in
-  `test/agent-runner.test.js`, `test/supervisor-*.test.js`,
-  `test/facilitator*.test.js`, `test/mock-runner.js`) must be updated to stop
-  passing `agentProfile` and either pass a precomposed `systemPrompt` or
-  leave `systemPrompt` unset. Inventory these at implementation time with
-  `rg agentProfile libraries/libeval/test/`.
+- A grep at plan-writing time (`rg -n agentProfile libraries/libeval/test/`)
+  returns zero matches today, so **no existing test files need updates**.
+  The implementer should re-run that grep after Step 2 to confirm the
+  assumption still holds; if any test has gained an `agentProfile` stub in
+  the meantime, update it to stop passing the field.
 
 ## Libraries used
 
@@ -224,11 +245,12 @@ exercise it without DI scaffolding.
   not directly unit-testable without a live SDK call. SC#3 is the
   end-to-end verifier — first night-shift run after merge either emits
   voice markers or does not.
-- **Test stubs for `AgentRunner`.** Existing tests pass `agentProfile` into
-  the constructor. They will keep passing silently because
-  `applyDefaults` previously accepted the field, but after Step 2 any test
-  that asserts `options.agent` was forwarded into the SDK query will fail.
-  Step 2 includes an inventory pass to update them.
+- **Test stubs for `AgentRunner` (verified absent).** A grep at
+  plan-writing time showed zero test files reference `agentProfile`, so
+  there is nothing to retrofit. Risk retained as a re-verification
+  checkpoint: if a test gained an `agentProfile` stub between plan writing
+  and implementation, the `applyDefaults` removal in Step 2 will make that
+  test silently pass without binding and it must be updated.
 - **Non-main-thread uses of `options.agent`.** Subagent dispatch via the
   `Task`/`Agent` tool is out of scope (spec § Excluded), but a stray
   `options.agent` inside supervisor/facilitator code paths that is _not_
@@ -245,10 +267,12 @@ exercise it without DI scaffolding.
 
 Single `staff-engineer` run on branch `feat/530-agent-profile-main-thread-binding`.
 Do not decompose. The change is tightly coupled (one module + five wiring
-sites + test updates) and the whole diff must land together so greps pass.
-Steps 1 and 2 are independent; Steps 3–5 depend on both; Steps 6–7 are the
-tail audit. Implementer runs `bun run check` and `bun run test` after each
-wiring step and once at the end.
+sites + the test file) and the whole diff must land together so the Step 7
+greps pass. Steps 1 and 2 are independent prerequisites; Steps 3, 4, and 5
+each depend on Step 1 only and may be completed in any order; Step 6 is an
+audit that depends on Steps 3–5; Step 7 is the final grep check.
+Implementer runs `bun run check` and `bun run test` after each wiring step
+and once at the end.
 
 SC#3 (voice-marker appearance in scheduled runs) is end-to-end and observed
 after the fix lands in `main`. Note it in the implementation PR body as a

--- a/specs/530-agent-profile-main-thread-binding/plan-a.md
+++ b/specs/530-agent-profile-main-thread-binding/plan-a.md
@@ -5,13 +5,13 @@
 Introduce a pure `composeProfilePrompt` module inside libeval, then thread it
 through the three command call sites (`run`, `supervise`, `facilitate`) and the
 two orchestration factories (`supervisor.js`, `facilitator.js`). `AgentRunner`
-loses its `agentProfile` field and the SDK `options.agent` spread. The CLI
-flags keep their surface at the boundary but internally feed
-`composeProfilePrompt` — nothing else. Mode-specific trailers
-(`AGENT_SYSTEM_PROMPT`, `FACILITATED_AGENT_SYSTEM_PROMPT`,
-`FACILITATOR_SYSTEM_PROMPT`, `SUPERVISOR_SYSTEM_PROMPT`) move from the
-`append` slot into the composer's `trailer` option so today's working
-behaviour in facilitated/supervised modes is preserved bit-for-bit.
+loses its `agentProfile` field and the SDK `options.agent` spread. The CLI flags
+keep their surface at the boundary but internally feed `composeProfilePrompt` —
+nothing else. Mode-specific trailers (`AGENT_SYSTEM_PROMPT`,
+`FACILITATED_AGENT_SYSTEM_PROMPT`, `FACILITATOR_SYSTEM_PROMPT`,
+`SUPERVISOR_SYSTEM_PROMPT`) move from the `append` slot into the composer's
+`trailer` option so today's working behaviour in facilitated/supervised modes is
+preserved bit-for-bit.
 
 ## Ordered Steps
 
@@ -28,39 +28,37 @@ composeProfilePrompt(name, { profilesDir, trailer })
 Behaviour:
 
 - Reads `join(profilesDir, `${name}.md`)` with `readFileSync(path, "utf8")`
-  using `node:path`'s `join`. Missing file propagates `ENOENT` unchanged
-  (first safety net).
+  using `node:path`'s `join`. Missing file propagates `ENOENT` unchanged (first
+  safety net).
 - Strips YAML frontmatter. Recognise the fence pattern: file begins with
-  `---\n`, a second `\n---\n` terminates it. If the file lacks frontmatter,
-  the entire body is used.
+  `---\n`, a second `\n---\n` terminates it. If the file lacks frontmatter, the
+  entire body is used.
 - `append` = body (trimmed of leading/trailing whitespace) + `"\n\n"` +
   `trailer` when trailer is a non-empty string; otherwise just the body.
 - No fallback, no default profile, no catch-around-read.
 
-**Export** from `/home/user/monorepo/libraries/libeval/src/index.js` by
-adding `export { composeProfilePrompt } from "./profile-prompt.js";`
-alongside the existing `createAgentRunner` re-export. No other index.js
-lines change.
+**Export** from `/home/user/monorepo/libraries/libeval/src/index.js` by adding
+`export { composeProfilePrompt } from "./profile-prompt.js";` alongside the
+existing `createAgentRunner` re-export. No other index.js lines change.
 
 **Create** `/home/user/monorepo/libraries/libeval/test/profile-prompt.test.js`.
 Fixtures live alongside in `test/fixtures/profile-prompt/` — one with
 frontmatter, one without. Tests:
 
 - Returns the `{ type: "preset", preset: "claude_code", append }` shape.
-- Strips frontmatter (the `append` does not contain `---` or YAML keys from
-  the fence).
+- Strips frontmatter (the `append` does not contain `---` or YAML keys from the
+  fence).
 - Concatenates trailer with blank-line separator when provided; no trailing
   whitespace mismatch when omitted.
 - Throws `ENOENT` for a missing profile file.
 - **Spec SC#1 coverage (loop test):** Resolve the profiles directory via
-  `fileURLToPath(new URL("../../../.claude/agents", import.meta.url))` so
-  the path is anchored to the test file's location and independent of
-  `bun test` cwd. `readdirSync` that dir, filter `.md` files (no
-  subdirectory filtering needed — `.claude/agents/references/` is a
-  directory and will not match). For each file assert
-  `composeProfilePrompt(basename, { profilesDir }).append` contains a
-  non-trivial substring of the real profile body (e.g. first 40 chars of
-  the file past frontmatter). This walks every live profile and fails the
+  `fileURLToPath(new URL("../../../.claude/agents", import.meta.url))` so the
+  path is anchored to the test file's location and independent of `bun test`
+  cwd. `readdirSync` that dir, filter `.md` files (no subdirectory filtering
+  needed — `.claude/agents/references/` is a directory and will not match). For
+  each file assert `composeProfilePrompt(basename, { profilesDir }).append`
+  contains a non-trivial substring of the real profile body (e.g. first 40 chars
+  of the file past frontmatter). This walks every live profile and fails the
   build if any profile stops being loadable.
 
 ### Step 2 — `AgentRunner` cleanup (`src/agent-runner.js`)
@@ -114,13 +112,14 @@ composer and nothing else. `parseRunOptions` is unchanged.
 
 Depends on: Step 1.
 
-At the two `systemPrompt:` blocks inside `createSupervisor` (one for the
-agent runner, one for the supervisor runner — currently at L406 and L437):
+At the two `systemPrompt:` blocks inside `createSupervisor` (one for the agent
+runner, one for the supervisor runner — currently at L406 and L437):
 
 - Remove `agentProfile` and `supervisorProfile` from the `createAgentRunner`
   argument objects.
-- Replace the agent runner's `systemPrompt: { type: "preset", preset:
-  "claude_code", append: AGENT_SYSTEM_PROMPT }` with
+- Replace the agent runner's
+  `systemPrompt: { type: "preset", preset: "claude_code", append: AGENT_SYSTEM_PROMPT }`
+  with
   ```
   systemPrompt: agentProfile
     ? composeProfilePrompt(agentProfile, { profilesDir, trailer: AGENT_SYSTEM_PROMPT })
@@ -129,71 +128,68 @@ agent runner, one for the supervisor runner — currently at L406 and L437):
 - Same shape for the supervisor runner using `supervisorProfile` and
   `SUPERVISOR_SYSTEM_PROMPT` as trailer.
 - Add `profilesDir` to the factory's dep signature with default
-  `resolve(supervisorCwd, ".claude/agents")`; accept an override from
-  callers for test injection symmetry. **Resolution rule:** `profilesDir`
-  is a single value for the whole session, resolved from the
-  orchestrator's cwd (the supervisor's cwd here), not from the agent
-  runner's cwd — profiles are project-level content and must not follow an
-  agent into a sandbox or worktree.
+  `resolve(supervisorCwd, ".claude/agents")`; accept an override from callers
+  for test injection symmetry. **Resolution rule:** `profilesDir` is a single
+  value for the whole session, resolved from the orchestrator's cwd (the
+  supervisor's cwd here), not from the agent runner's cwd — profiles are
+  project-level content and must not follow an agent into a sandbox or worktree.
 - Import `composeProfilePrompt` from `./profile-prompt.js`.
 
-The `AGENT_SYSTEM_PROMPT` / `SUPERVISOR_SYSTEM_PROMPT` exports stay — they
-are consumed here as trailers, not as standalone `append` values. The JSDoc
-on `createSupervisor`'s `agentProfile` / `supervisorProfile` params is
-updated to say "resolved into the main-thread system prompt via
-`composeProfilePrompt`" rather than "passed to Claude as `--agent`".
+The `AGENT_SYSTEM_PROMPT` / `SUPERVISOR_SYSTEM_PROMPT` exports stay — they are
+consumed here as trailers, not as standalone `append` values. The JSDoc on
+`createSupervisor`'s `agentProfile` / `supervisorProfile` params is updated to
+say "resolved into the main-thread system prompt via `composeProfilePrompt`"
+rather than "passed to Claude as `--agent`".
 
 ### Step 5 — Wire `facilitator.js` through the composer
 
 Depends on: Step 1.
 
 At the two `systemPrompt:` blocks inside `createFacilitator` — the per-agent
-runner inside `agents.map(...)` (currently at L475) and the facilitator
-runner itself (currently at L495):
+runner inside `agents.map(...)` (currently at L475) and the facilitator runner
+itself (currently at L495):
 
 - For each agent runner in the `agents.map(...)` block: remove
-  `agentProfile: config.agentProfile`; replace the static `systemPrompt`
-  with `composeProfilePrompt(config.agentProfile, { profilesDir, trailer:
-  FACILITATED_AGENT_SYSTEM_PROMPT })` when `config.agentProfile` is set,
-  otherwise keep today's plain-trailer shape.
+  `agentProfile: config.agentProfile`; replace the static `systemPrompt` with
+  `composeProfilePrompt(config.agentProfile, { profilesDir, trailer: FACILITATED_AGENT_SYSTEM_PROMPT })`
+  when `config.agentProfile` is set, otherwise keep today's plain-trailer shape.
 - Facilitator runner: same replacement with `facilitatorProfile` and
   `FACILITATOR_SYSTEM_PROMPT` as trailer.
 - Add `profilesDir` to the factory's dep signature with default
-  `resolve(facilitatorCwd, ".claude/agents")`. Same resolution rule as
-  Step 4: `profilesDir` is a single value for the whole session, resolved
-  from `facilitatorCwd`, not from each agent's `config.cwd` (which may
-  point to per-agent sandboxes).
+  `resolve(facilitatorCwd, ".claude/agents")`. Same resolution rule as Step 4:
+  `profilesDir` is a single value for the whole session, resolved from
+  `facilitatorCwd`, not from each agent's `config.cwd` (which may point to
+  per-agent sandboxes).
 
 ### Step 6 — CLI flag audit (`bin/fit-eval.js`, `commands/*.js`)
 
 Depends on: Steps 3–5.
 
-Audit-only step — no code change expected. Verify — and record the
-findings in the commit message — that:
+Audit-only step — no code change expected. Verify — and record the findings in
+the commit message — that:
 
 - `bin/fit-eval.js` still exposes `--agent-profile`, `--supervisor-profile`,
   `--facilitator-profile`, `--agent-profiles` (unchanged — that is the CLI
   boundary per the design).
-- No command file passes `options.agent` or the SDK's top-level `agent`
-  option into `createAgentRunner`. The `agentProfile` locals in `run.js`,
-  `supervise.js`, and `facilitate.js` feed only `composeProfilePrompt` or
-  the factory signatures updated in Steps 4 and 5.
+- No command file passes `options.agent` or the SDK's top-level `agent` option
+  into `createAgentRunner`. The `agentProfile` locals in `run.js`,
+  `supervise.js`, and `facilitate.js` feed only `composeProfilePrompt` or the
+  factory signatures updated in Steps 4 and 5.
 - Factory signatures in `supervisor.js` and `facilitator.js` default
-  `profilesDir` to `<cwd>/.claude/agents`, so command files pass nothing
-  new across the boundary.
+  `profilesDir` to `<cwd>/.claude/agents`, so command files pass nothing new
+  across the boundary.
 
-If the audit uncovers a path the plan missed, surface it as a deviation
-note on the implementation PR rather than editing silently.
+If the audit uncovers a path the plan missed, surface it as a deviation note on
+the implementation PR rather than editing silently.
 
 ### Step 7 — Grep verification for Spec SC#2
 
 Depends on: Steps 2–6.
 
-Spec SC#2 targets the SDK binding surface, not the `agentProfile`
-identifier used as a local or CLI argument name (which is fine to keep —
-it feeds `composeProfilePrompt` and nothing else). The greps below must
-return zero matches inside `libraries/libeval/src/` and
-`libraries/libeval/bin/`:
+Spec SC#2 targets the SDK binding surface, not the `agentProfile` identifier
+used as a local or CLI argument name (which is fine to keep — it feeds
+`composeProfilePrompt` and nothing else). The greps below must return zero
+matches inside `libraries/libeval/src/` and `libraries/libeval/bin/`:
 
 ```
 # SDK query option shape: the "agent:" key bound to an identifier,
@@ -210,14 +206,14 @@ rg -n "extraArgs.*agent" libraries/libeval/src libraries/libeval/bin
 rg -n '"--agent"' libraries/libeval/src libraries/libeval/bin
 ```
 
-Then open every file under `libraries/libeval/src` and search visually for
-any `agent:` key in an options object the implementer did not expect —
-regex coverage is a floor, not a ceiling.
+Then open every file under `libraries/libeval/src` and search visually for any
+`agent:` key in an options object the implementer did not expect — regex
+coverage is a floor, not a ceiling.
 
-The `agentProfile` name itself remains (as a variable holding the profile
-name to hand to `composeProfilePrompt`) and is not searched for. Tests and
-fixtures are out of scope for these greps. Record the exact commands in
-the commit body so the reviewer can replay them.
+The `agentProfile` name itself remains (as a variable holding the profile name
+to hand to `composeProfilePrompt`) and is not searched for. Tests and fixtures
+are out of scope for these greps. Record the exact commands in the commit body
+so the reviewer can replay them.
 
 ## Files touched
 
@@ -226,74 +222,69 @@ the commit body so the reviewer can replay them.
   `libraries/libeval/test/fixtures/profile-prompt/*`.
 - **Modified:** `libraries/libeval/src/agent-runner.js`,
   `libraries/libeval/src/commands/run.js`,
-  `libraries/libeval/src/supervisor.js`,
-  `libraries/libeval/src/facilitator.js`,
+  `libraries/libeval/src/supervisor.js`, `libraries/libeval/src/facilitator.js`,
   `libraries/libeval/src/index.js` (export).
 - **Deleted:** none.
 - **Not modified:** `libraries/libeval/src/commands/supervise.js` and
-  `libraries/libeval/src/commands/facilitate.js` are inspected in Step 6
-  but do not need edits given the `profilesDir` default in the factory
-  signatures.
+  `libraries/libeval/src/commands/facilitate.js` are inspected in Step 6 but do
+  not need edits given the `profilesDir` default in the factory signatures.
 
 ## Test additions
 
 - `test/profile-prompt.test.js` — unit tests for the composer, including the
   SC#1 loop over `.claude/agents/*.md`.
 - A grep at plan-writing time (`rg -n agentProfile libraries/libeval/test/`)
-  returns zero matches today, so **no existing test files need updates**.
-  The implementer should re-run that grep after Step 2 to confirm the
-  assumption still holds; if any test has gained an `agentProfile` stub in
-  the meantime, update it to stop passing the field.
+  returns zero matches today, so **no existing test files need updates**. The
+  implementer should re-run that grep after Step 2 to confirm the assumption
+  still holds; if any test has gained an `agentProfile` stub in the meantime,
+  update it to stop passing the field.
 
 ## Libraries used
 
 None. `composeProfilePrompt` uses only `node:fs` (`readFileSync`) and
 `node:path` (`join`). No `@forwardimpact/lib*` package is consumed. This is
-intentional — the composer stays a ~30-line pure function so tests can
-exercise it without DI scaffolding.
+intentional — the composer stays a ~30-line pure function so tests can exercise
+it without DI scaffolding.
 
 ## Risks
 
 - **SDK preset-composition semantics.** The design asserts that
-  `{ type: "preset", preset: "claude_code", append: body + trailer }`
-  composes profile + mode-boilerplate correctly at runtime. This holds in
-  today's facilitated and supervised runs (Evidence table, spec.md) but is
-  not directly unit-testable without a live SDK call. SC#3 is the
-  end-to-end verifier — first night-shift run after merge either emits
-  voice markers or does not.
-- **Test stubs for `AgentRunner` (verified absent).** A grep at
-  plan-writing time showed zero test files reference `agentProfile`, so
-  there is nothing to retrofit. Risk retained as a re-verification
-  checkpoint: if a test gained an `agentProfile` stub between plan writing
-  and implementation, the `applyDefaults` removal in Step 2 will make that
-  test silently pass without binding and it must be updated.
+  `{ type: "preset", preset: "claude_code", append: body + trailer }` composes
+  profile + mode-boilerplate correctly at runtime. This holds in today's
+  facilitated and supervised runs (Evidence table, spec.md) but is not directly
+  unit-testable without a live SDK call. SC#3 is the end-to-end verifier — first
+  night-shift run after merge either emits voice markers or does not.
+- **Test stubs for `AgentRunner` (verified absent).** A grep at plan-writing
+  time showed zero test files reference `agentProfile`, so there is nothing to
+  retrofit. Risk retained as a re-verification checkpoint: if a test gained an
+  `agentProfile` stub between plan writing and implementation, the
+  `applyDefaults` removal in Step 2 will make that test silently pass without
+  binding and it must be updated.
 - **Non-main-thread uses of `options.agent`.** Subagent dispatch via the
   `Task`/`Agent` tool is out of scope (spec § Excluded), but a stray
   `options.agent` inside supervisor/facilitator code paths that is _not_
-  main-thread-binding-related would also be removed by Step 2. The greps
-  in Step 7 flag any such leak for conscious decision at implementation
-  time.
-- **Profile directory location.** The composer takes `profilesDir` as an
-  input and defaults to `<cwd>/.claude/agents` at each call site. A run
-  whose `cwd` is not the monorepo root (test harness, custom invocation)
-  will receive an `ENOENT` — surfaced exactly as the spec's first safety
-  net requires.
+  main-thread-binding-related would also be removed by Step 2. The greps in Step
+  7 flag any such leak for conscious decision at implementation time.
+- **Profile directory location.** The composer takes `profilesDir` as an input
+  and defaults to `<cwd>/.claude/agents` at each call site. A run whose `cwd` is
+  not the monorepo root (test harness, custom invocation) will receive an
+  `ENOENT` — surfaced exactly as the spec's first safety net requires.
 
 ## Execution recommendation
 
-Single `staff-engineer` run on branch `feat/530-agent-profile-main-thread-binding`.
-Do not decompose. The change is tightly coupled (one module + five wiring
-sites + the test file) and the whole diff must land together so the Step 7
-greps pass. Steps 1 and 2 are independent prerequisites; Steps 3, 4, and 5
-each depend on Step 1 only and may be completed in any order; Step 6 is an
-audit that depends on Steps 3–5; Step 7 is the final grep check.
-Implementer runs `bun run check` and `bun run test` after each wiring step
-and once at the end.
+Single `staff-engineer` run on branch
+`feat/530-agent-profile-main-thread-binding`. Do not decompose. The change is
+tightly coupled (one module + five wiring sites + the test file) and the whole
+diff must land together so the Step 7 greps pass. Steps 1 and 2 are independent
+prerequisites; Steps 3, 4, and 5 each depend on Step 1 only and may be completed
+in any order; Step 6 is an audit that depends on Steps 3–5; Step 7 is the final
+grep check. Implementer runs `bun run check` and `bun run test` after each
+wiring step and once at the end.
 
 SC#3 (voice-marker appearance in scheduled runs) is end-to-end and observed
 after the fix lands in `main`. Note it in the implementation PR body as a
-post-merge verification step against the next night-shift traces; do not
-block PR merge on it.
+post-merge verification step against the next night-shift traces; do not block
+PR merge on it.
 
 ## Self-review
 
@@ -307,21 +298,19 @@ Ran the DO-CONFIRM checklist:
       single-agent).
 - [x] Risks surfaced — SDK composition, test stubs, stray `options.agent`,
       profileDir location.
-- [x] Libraries-used section present — states "None" explicitly with
-      rationale.
-- [x] Execution recommendation present — single agent, no decomposition,
-      SC#3 deferred.
+- [x] Libraries-used section present — states "None" explicitly with rationale.
+- [x] Execution recommendation present — single agent, no decomposition, SC#3
+      deferred.
 
 **Self-caught findings:**
 
-- None material. One caveat: the test in Step 1 for SC#1 asserts the
-  presence of a body substring, not a voice marker. Voice markers (the
-  em-dash-plus-emoji trailers in each profile) live in the body and would
-  be a tighter assertion, but the profile files do not share a common
-  marker shape, so per-profile substrings are the durable choice. The
-  alternative — a per-profile hardcoded list of expected markers —
-  duplicates knowledge already in the `.md` files and would drift. Flag
-  this trade-off to the implementer; they may tighten the assertion if a
-  stable per-profile signature emerges.
+- None material. One caveat: the test in Step 1 for SC#1 asserts the presence of
+  a body substring, not a voice marker. Voice markers (the em-dash-plus-emoji
+  trailers in each profile) live in the body and would be a tighter assertion,
+  but the profile files do not share a common marker shape, so per-profile
+  substrings are the durable choice. The alternative — a per-profile hardcoded
+  list of expected markers — duplicates knowledge already in the `.md` files and
+  would drift. Flag this trade-off to the implementer; they may tighten the
+  assertion if a stable per-profile signature emerges.
 
 — Staff Engineer 🛠️

--- a/specs/530-agent-profile-main-thread-binding/plan-a.md
+++ b/specs/530-agent-profile-main-thread-binding/plan-a.md
@@ -27,8 +27,9 @@ composeProfilePrompt(name, { profilesDir, trailer })
 
 Behaviour:
 
-- Reads `${profilesDir}/${name}.md` with `readFileSync(path, "utf8")`. Missing
-  file propagates `ENOENT` unchanged (first safety net).
+- Reads `join(profilesDir, `${name}.md`)` with `readFileSync(path, "utf8")`
+  using `node:path`'s `join`. Missing file propagates `ENOENT` unchanged
+  (first safety net).
 - Strips YAML frontmatter. Recognise the fence pattern: file begins with
   `---\n`, a second `\n---\n` terminates it. If the file lacks frontmatter,
   the entire body is used.
@@ -36,9 +37,10 @@ Behaviour:
   `trailer` when trailer is a non-empty string; otherwise just the body.
 - No fallback, no default profile, no catch-around-read.
 
-**Export** from `/home/user/monorepo/libraries/libeval/src/index.js` alongside
-`createAgentRunner` so callers outside libeval could depend on it (consistency
-with existing public surface).
+**Export** from `/home/user/monorepo/libraries/libeval/src/index.js` by
+adding `export { composeProfilePrompt } from "./profile-prompt.js";`
+alongside the existing `createAgentRunner` re-export. No other index.js
+lines change.
 
 **Create** `/home/user/monorepo/libraries/libeval/test/profile-prompt.test.js`.
 Fixtures live alongside in `test/fixtures/profile-prompt/` — one with
@@ -127,8 +129,12 @@ agent runner, one for the supervisor runner — currently at L406 and L437):
 - Same shape for the supervisor runner using `supervisorProfile` and
   `SUPERVISOR_SYSTEM_PROMPT` as trailer.
 - Add `profilesDir` to the factory's dep signature with default
-  `resolve(agentCwd, ".claude/agents")`; accept an override from callers for
-  test injection symmetry.
+  `resolve(supervisorCwd, ".claude/agents")`; accept an override from
+  callers for test injection symmetry. **Resolution rule:** `profilesDir`
+  is a single value for the whole session, resolved from the
+  orchestrator's cwd (the supervisor's cwd here), not from the agent
+  runner's cwd — profiles are project-level content and must not follow an
+  agent into a sandbox or worktree.
 - Import `composeProfilePrompt` from `./profile-prompt.js`.
 
 The `AGENT_SYSTEM_PROMPT` / `SUPERVISOR_SYSTEM_PROMPT` exports stay — they
@@ -152,7 +158,11 @@ runner itself (currently at L495):
   otherwise keep today's plain-trailer shape.
 - Facilitator runner: same replacement with `facilitatorProfile` and
   `FACILITATOR_SYSTEM_PROMPT` as trailer.
-- Accept a `profilesDir` dep with the same default pattern as Step 4.
+- Add `profilesDir` to the factory's dep signature with default
+  `resolve(facilitatorCwd, ".claude/agents")`. Same resolution rule as
+  Step 4: `profilesDir` is a single value for the whole session, resolved
+  from `facilitatorCwd`, not from each agent's `config.cwd` (which may
+  point to per-agent sandboxes).
 
 ### Step 6 — CLI flag audit (`bin/fit-eval.js`, `commands/*.js`)
 
@@ -186,10 +196,12 @@ return zero matches inside `libraries/libeval/src/` and
 `libraries/libeval/bin/`:
 
 ```
-# SDK query option shape: object literal key "agent:" followed by an
-# identifier (captures both `agent: agentProfile` and
-# `agent: this.agentProfile`).
-rg -n "[{,]\s*agent:\s*[A-Za-z_.]" libraries/libeval/src libraries/libeval/bin
+# SDK query option shape: the "agent:" key bound to an identifier,
+# matching across lines so a multi-line object literal cannot hide a
+# regression. Captures `agent: agentProfile`, `agent: this.agentProfile`,
+# and multi-line `{\n  agent: foo\n}` variants.
+rg -Un --multiline --pcre2 "(?:^|[{,])\s*\n?\s*agent:\s*[A-Za-z_.]" \
+  libraries/libeval/src libraries/libeval/bin
 
 # Old extraArgs shape, in case any path still forwards the flag.
 rg -n "extraArgs.*agent" libraries/libeval/src libraries/libeval/bin
@@ -197,6 +209,10 @@ rg -n "extraArgs.*agent" libraries/libeval/src libraries/libeval/bin
 # Literal --agent flag pass-through.
 rg -n '"--agent"' libraries/libeval/src libraries/libeval/bin
 ```
+
+Then open every file under `libraries/libeval/src` and search visually for
+any `agent:` key in an options object the implementer did not expect —
+regex coverage is a floor, not a ceiling.
 
 The `agentProfile` name itself remains (as a variable holding the profile
 name to hand to `composeProfilePrompt`) and is not searched for. Tests and

--- a/specs/530-agent-profile-main-thread-binding/spec.md
+++ b/specs/530-agent-profile-main-thread-binding/spec.md
@@ -6,8 +6,12 @@ Scheduled Kata agents are not adopting their `.claude/agents/<name>.md` profile
 as the main-thread system prompt. The main thread runs as a generic
 Claude Code session that happens to know `<name>` is a registered subagent. PR
 [#409] (2026-04-17) switched libeval from `extraArgs: { agent }` to the SDK's
-top-level `agent` option expecting this to bind the profile; traces from five
-runs spanning four agents on the next night shift show it did not.
+top-level `options.agent` expecting this to bind the profile; traces from
+five runs spanning four agents on the next night shift show it did not.
+The `options.agent` route is the wrong integration point for libeval's
+needs — evidence in this spec establishes it as unreliable for main-thread
+binding across SDK 0.2.98–0.2.112, and libeval should stop depending on it
+even if a future SDK version makes it work.
 
 [#409]: https://github.com/forwardimpact/monorepo/pull/409
 
@@ -61,14 +65,18 @@ All profiles registered as subagents; none bound as the main-thread agent.
 The per-turn `agent_type` field described in `sdk.d.ts` as "Present … on the
 main thread of a session started with --agent" never appears.
 
-**SDK expectation mismatch.** `@anthropic-ai/claude-agent-sdk@0.2.112`
-documents the top-level `agent` option as: "The agent must be defined either
-in the `agents` option or in settings." libeval passes `agent: "<name>"` but
-does not pass `agents: { "<name>": { prompt, description, … } }`. The
-`settings` fallback path reads subagent definitions from
-`.claude/agents/*.md`, but the observed behaviour shows those definitions are
-applied to the _subagent registry_ (for the `Task`/`Agent` tool), not to the
-_main-thread system prompt_.
+**The `options.agent` contract is underspecified for this use case.**
+`@anthropic-ai/claude-agent-sdk@0.2.112` documents the top-level `agent`
+option as: "The agent must be defined either in the `agents` option or in
+settings." libeval passes `agent: "<name>"` but does not pass
+`agents: { "<name>": { prompt, description, … } }`. The `settings` fallback
+path reads subagent definitions from `.claude/agents/*.md`, but the
+observed behaviour shows those definitions are applied to the _subagent
+registry_ (for the `Task`/`Agent` tool), not to the _main-thread system
+prompt_. The option has also shifted behaviour across SDK versions —
+PR [#409] was itself a response to a behaviour change between 0.2.98 and
+0.2.112. Treat `options.agent` as unreliable infrastructure for
+main-thread binding regardless of SDK version.
 
 **All five runs completed successfully at the API level** — the bug is
 silent. No validation error, no warning. The only visible signal is
@@ -98,11 +106,14 @@ prompt at session start, not through a tool call.
 
 **The difference is at session start, not at task time.** Facilitated and
 supervised modes compose the profile into the main-thread system prompt
-before the first turn; solo mode does not. The `agent` option alone — the
+before the first turn; solo mode does not. `options.agent` alone — the
 approach PR [#409] reached for — is not what distinguishes a working run
 from a broken one in this SDK version; some additional session-start
 composition, already present in the facilitated and supervised call sites,
-is. Solo mode is the single outlier among the three execution modes.
+is. Solo mode is the single outlier among the three execution modes. The
+working modes' correctness does _not_ depend on `options.agent` being
+respected by the SDK, which is why their binding holds even when the option
+is silently ignored.
 
 ### Impact
 
@@ -134,14 +145,27 @@ binding must be verifiable from the trace without reading behaviour across
 many turns, and a missing profile must surface as a loud startup failure
 rather than a silent fallback to a generic main thread.
 
-### Binding must be explicit
+### libeval owns the binding; `options.agent` is not part of it
 
-Passing a profile name alone is not enough — the invariant behind this spec
-is that whatever the runtime needs to attach profile content to the main
-thread, libeval must supply it. The current solo-mode path has been
-observed to produce an unbound main thread while reporting success.
-Facilitated and supervised modes already bind correctly and stand as the
-baseline; solo mode must meet the same guarantee.
+libeval must attach profile content to the main thread at its own layer,
+using inputs it controls directly. Passing the profile's name via
+`options.agent` (or the equivalent CLI flag) has been observed to silently
+not bind across SDK 0.2.98–0.2.112 and must be treated as unreliable for
+this purpose regardless of SDK version. Two consequences follow:
+
+1. Solo-mode runs today produce an unbound main thread while reporting
+   success. That cannot continue.
+2. If a future SDK version makes `options.agent` reliably attach profile
+   content, libeval's own binding path would _duplicate_ that work —
+   potentially stacking two copies of the same profile in the system prompt,
+   or producing conflicting tool/model restrictions. libeval must not rely
+   on the option, and must not set the option alongside its own binding, to
+   avoid either failure mode.
+
+Facilitated and supervised modes already bind correctly without depending
+on `options.agent`; they stand as the baseline. Solo mode must meet the
+same guarantee and must reach it through the same layer-appropriate
+mechanism — libeval's own.
 
 ### Missing profile must fail loudly
 
@@ -170,9 +194,12 @@ against which solo mode's fix is verified.
 
 ### Affected
 
-- **libeval main-thread profile loading** — the path that currently passes
-  `agent: <name>` to the SDK, across all execution modes (run, supervise,
-  facilitate).
+- **libeval main-thread profile loading** — all three execution modes (run,
+  supervise, facilitate) across their respective main threads.
+- **Use of `options.agent` inside libeval** — libeval must stop passing the
+  SDK's top-level `agent` option (and the equivalent `--agent` CLI flag)
+  for main-thread binding. Whatever libeval does to attach profile content
+  stands alone and does not coexist with that option.
 - **`fit-eval` CLI startup** — must reject an unresolvable profile before
   starting the query.
 - **Trace schema** — whichever signal identifies the bound main-thread agent
@@ -187,10 +214,13 @@ against which solo mode's fix is verified.
   as written. This spec changes how they are loaded, not what they say.
 - **Subagent registration.** The existing mechanism for making `Explore`,
   `Plan`, `improvement-coach`, etc. available via the `Task`/`Agent` tool
-  continues to work as today.
-- **SDK upstream fixes.** If investigation shows the SDK itself has a bug,
-  the upstream fix is out of scope — this spec delivers a workaround in
-  libeval that holds regardless of SDK behaviour.
+  continues to work as today. The Task/Agent tool's use of agent names is a
+  separate concern from main-thread binding.
+- **Future SDK behaviour of `options.agent`.** Whether a later SDK version
+  makes the option reliable for main-thread binding does not affect this
+  spec; libeval's binding does not use that option, and the correctness of
+  libeval's binding must not depend on the option being ignored, respected,
+  or changed.
 - **Task prompt rewording.** The task text "Assess the current state of
   your domain and act on the highest-priority finding" stays generic. The
   profile is what binds "your domain" to a specific meaning, and fixing the
@@ -201,8 +231,10 @@ against which solo mode's fix is verified.
 
 ## Dependencies
 
-None blocking. [#409] merged a related libeval change; the evidence in this
-spec shows it was necessary but not sufficient.
+None blocking. [#409] merged a prior libeval change that routed through
+`options.agent`; the evidence in this spec shows that integration point is
+unreliable and the spec's direction is to move off it rather than refine
+it.
 
 ## Success Criteria
 
@@ -226,3 +258,7 @@ spec shows it was necessary but not sufficient.
    such that a reader can confirm, from the artifact, that the profile's
    content is what drove the first turn. This is an artifact property, not
    dependent on whether any particular run chose to emit a voice marker.
+6. A repository-wide grep for the SDK option that previously carried the
+   profile name (top-level `agent` in SDK query options, `--agent` CLI flag)
+   returns no call sites inside libeval's source. Test fixtures and
+   historical documentation may still reference it.

--- a/specs/530-agent-profile-main-thread-binding/spec.md
+++ b/specs/530-agent-profile-main-thread-binding/spec.md
@@ -1,0 +1,194 @@
+# Spec 530 — Agent Profile Main-Thread Binding
+
+## Problem
+
+Scheduled Kata agents are not adopting their `.claude/agents/<name>.md` profile
+as the main-thread system prompt. The main thread runs as a generic
+Claude Code session that happens to know `<name>` is a registered subagent. PR
+[#409] (2026-04-17) switched libeval from `extraArgs: { agent }` to the SDK's
+top-level `agent` option expecting this to bind the profile; traces from five
+runs spanning four agents on the next night shift show it did not.
+
+[#409]: https://github.com/forwardimpact/monorepo/pull/409
+
+### Evidence
+
+Five consecutive workflow runs ran after [#409] merged at `2026-04-17T17:46Z`.
+Each started on a commit containing the fix. None adopted its profile.
+
+| Workflow | Run ID | Start UTC | Own profile read? | Other profiles read? | Behaviour exhibited |
+| --- | --- | --- | --- | --- | --- |
+| Technical Writer | [24587425816] | 21:26 | no | none | Implemented summit/coverage code fix (#414) |
+| Release Engineer | [24586709478] | 21:06 | no | none | Ran product-manager PR gate, merged #413 |
+| Product Manager | [24596510543] | 04:05 | no | improvement-coach.md | Ran product-manager PR gate (in-domain by coincidence) |
+| Staff Engineer | [24597071264] | 04:39 | no | improvement-coach.md, **product-manager.md** | Ran product-manager PR gate on #414 |
+| Security Engineer | [24597390612] | 04:58 | no | **product-manager.md** | Ran product-manager PR gate on #414 |
+
+[24587425816]: https://github.com/forwardimpact/monorepo/actions/runs/24587425816
+[24586709478]: https://github.com/forwardimpact/monorepo/actions/runs/24586709478
+[24596510543]: https://github.com/forwardimpact/monorepo/actions/runs/24596510543
+[24597071264]: https://github.com/forwardimpact/monorepo/actions/runs/24597071264
+[24597390612]: https://github.com/forwardimpact/monorepo/actions/runs/24597390612
+
+**Shared opening phrase.** Every one of the five main-thread agents opens with
+near-identical framing — "The user is asking me to assess the current state of
+my domain and act on the highest-priority finding. This looks like an
+autonomous loop prompt/request/task." The security engineer adds "Let me
+figure out what domain I'm in." That framing is generic Claude Code responding
+to a task, not a profile introducing itself.
+
+**Voice markers absent.** `technical-writer.md` instructs the agent to sign
+output with `— Technical Writer 📝`. The technical-writer run emitted no
+signature. None of the other profiles' voice markers appear either.
+
+**Drift converges on product-manager behaviour.** Three of four non-PM runs
+produced Product PR Gate reports on PR #414 — the most actionable visible
+work. When the profile is absent, the agent reads `KATA.md` for orientation,
+sees the seven-agent landscape, picks the most visible queue (open PRs), and
+acts as whichever profile that queue belongs to. The Security Engineer run
+even read `.claude/agents/product-manager.md` to execute the gate correctly.
+
+**Init event does not mark a main-thread agent.** The SDK's `system.init`
+event from run 24587425816 contains:
+
+```
+agents: ['Explore', 'general-purpose', 'improvement-coach', 'Plan',
+         'product-manager', 'release-engineer', 'security-engineer',
+         'staff-engineer', 'statusline-setup', 'technical-writer']
+```
+
+All profiles registered as subagents; none bound as the main-thread agent.
+The per-turn `agent_type` field described in `sdk.d.ts` as "Present … on the
+main thread of a session started with --agent" never appears.
+
+**SDK expectation mismatch.** `@anthropic-ai/claude-agent-sdk@0.2.112`
+documents the top-level `agent` option as: "The agent must be defined either
+in the `agents` option or in settings." libeval passes `agent: "<name>"` but
+does not pass `agents: { "<name>": { prompt, description, … } }`. The
+`settings` fallback path reads subagent definitions from
+`.claude/agents/*.md`, but the observed behaviour shows those definitions are
+applied to the _subagent registry_ (for the `Task`/`Agent` tool), not to the
+_main-thread system prompt_.
+
+**All five runs completed successfully at the API level** — the bug is
+silent. No validation error, no warning. The only visible signal is
+behavioural drift across many turns.
+
+### Impact
+
+- **Persona-enforced scope constraints are not in force.** Each profile
+  defines scope boundaries ("never weaken documentation accuracy", "trust
+  boundary: product-manager is sole external merge point", etc.). When the
+  profile is not loaded, those boundaries are absent.
+- **Skill routing fails.** Profiles list 5–8 skills each; the main thread
+  instead sees the union of all skills and picks whichever matches the
+  self-chosen task.
+- **Voice and signatures are absent.** Downstream PR comments and wiki
+  writes cannot be attributed to the right agent by voice — breaks
+  cross-agent audit trails.
+- **Invariant audits produce false FAILs.** `kata-trace`'s per-agent
+  invariants (`references/invariants.md`) assume the profile drove the run;
+  when the profile was absent, every invariant that refers to persona-scoped
+  behaviour fails against a main thread that never tried to satisfy them.
+- **Cost inflation.** Generic triage runs dispatch multiple Explore
+  sub-agents to re-derive what the profile would have narrowed to "read own
+  summary + current week log". Run 24587425816 spent 816K cache-read tokens
+  and six Agent sub-agents on broad repo triage.
+
+## Proposal
+
+Bind the designated agent profile as the main-thread system prompt on every
+scheduled agent run. The profile must drive the first token of the main
+thread, the binding must be verifiable from the trace without reading
+behaviour across many turns, and a missing profile must surface as a loud
+startup failure rather than a silent fallback to a generic main thread.
+
+### Binding must be explicit
+
+Passing a profile name alone is not enough — the invariant behind this spec
+is that whatever the runtime needs to attach profile content to the main
+thread, libeval must supply it. The current behaviour (naming the profile
+and expecting the SDK's settings layer to resolve it) has been observed to
+produce an unbound main thread while reporting success.
+
+### Missing profile must fail loudly
+
+When a profile name does not resolve to profile content, the run must fail
+before any API call with an error that names the missing profile. Silent
+fallback to a generic main thread is the failure mode this spec closes.
+
+### Binding must be observable in the trace
+
+The trace emitted for each run must contain a signal that identifies the
+main-thread agent. `kata-trace` must be able to verify the binding from the
+trace artifact alone, without inferring it from behaviour. Whether that
+signal is one the runtime emits natively or one libeval emits itself is a
+design choice.
+
+### Binding must hold across execution modes
+
+All three libeval execution modes — single-agent runs, supervised runs, and
+facilitated multi-agent sessions — must bind their respective main-thread
+profiles with the same guarantees. In supervised and facilitated modes, each
+independent main thread must bind its own profile independently.
+
+## Scope
+
+### Affected
+
+- **libeval main-thread profile loading** — the path that currently passes
+  `agent: <name>` to the SDK, across all execution modes (run, supervise,
+  facilitate).
+- **`fit-eval` CLI startup** — must reject an unresolvable profile before
+  starting the query.
+- **Trace schema** — whichever signal identifies the bound main-thread agent
+  must be documented alongside the existing event types so `kata-trace` can
+  audit it.
+- **`kata-trace` invariant audit** — gains a universal "main-thread agent
+  bound" invariant applied to every scheduled agent trace.
+
+### Excluded
+
+- **Agent profile content.** The `.md` files under `.claude/agents/` stay
+  as written. This spec changes how they are loaded, not what they say.
+- **Subagent registration.** The existing mechanism for making `Explore`,
+  `Plan`, `improvement-coach`, etc. available via the `Task`/`Agent` tool
+  continues to work as today.
+- **SDK upstream fixes.** If investigation shows the SDK itself has a bug,
+  the upstream fix is out of scope — this spec delivers a workaround in
+  libeval that holds regardless of SDK behaviour.
+- **Task prompt rewording.** The task text "Assess the current state of
+  your domain and act on the highest-priority finding" stays generic. The
+  profile is what binds "your domain" to a specific meaning, and fixing the
+  binding is this spec's job. A follow-up spec may later add defence-in-depth
+  prefixes to task text, but only after the binding fix is verified.
+- **Storyboard / coaching task prompts.** Those are specific enough to be
+  self-identifying today.
+
+## Dependencies
+
+None blocking. [#409] merged a related libeval change; the evidence in this
+spec shows it was necessary but not sufficient.
+
+## Success Criteria
+
+1. For every scheduled agent workflow
+   (`agent-technical-writer`, `agent-security-engineer`, `agent-staff-engineer`,
+   `agent-release-engineer`, `agent-product-manager`), the captured trace
+   contains an event that identifies the main-thread agent by its profile
+   name. The signal must be discoverable by a documented `kata-trace` query.
+2. For each of those runs, the main thread's first `Read` targets
+   `wiki/<agent>.md` before any other wiki or agent-profile read. This
+   property is checkable by scanning the trace for the first `Read`
+   tool call.
+3. Running `fit-eval` with a non-existent agent profile exits non-zero with
+   an error message naming the missing profile, before any API call.
+4. `kata-trace`'s invariant audit includes a "main-thread agent bound"
+   invariant. Audits of the five evidence runs listed above mark it FAIL;
+   audits of the next scheduled run of each workflow after the fix lands
+   mark it PASS.
+5. The main-thread profile system prompt is detectable in the trace —
+   either via a dedicated event or via an echoed system-prompt payload —
+   such that a reader can confirm, from the artifact, that the profile's
+   content is what drove the first turn. This is an artifact property, not
+   dependent on whether any particular run chose to emit a voice marker.

--- a/specs/530-agent-profile-main-thread-binding/spec.md
+++ b/specs/530-agent-profile-main-thread-binding/spec.md
@@ -140,10 +140,14 @@ is silently ignored.
 
 Bind the designated agent profile as the main-thread system prompt on every
 scheduled agent run — including solo-mode runs, which today silently skip
-this step. The profile must drive the first token of the main thread, the
-binding must be verifiable from the trace without reading behaviour across
-many turns, and a missing profile must surface as a loud startup failure
-rather than a silent fallback to a generic main thread.
+this step. The profile must drive the first token of the main thread, and
+silent fallback to a generic main thread when the profile is unreachable
+is not an acceptable outcome. Two pre-existing safety nets already cover
+the remaining failure surfaces and need no augmentation: an unreadable
+profile file surfaces as the file-read's own error and halts the run, and
+a main thread that binds the wrong or empty content drifts across domain
+boundaries within the first few turns — which `kata-trace` already detects
+through grounded-theory analysis of trace artifacts.
 
 ### libeval owns the binding; `options.agent` is not part of it
 
@@ -167,20 +171,6 @@ on `options.agent`; they stand as the baseline. Solo mode must meet the
 same guarantee and must reach it through the same layer-appropriate
 mechanism — libeval's own.
 
-### Missing profile must fail loudly
-
-When a profile name does not resolve to profile content, the run must fail
-before any API call with an error that names the missing profile. Silent
-fallback to a generic main thread is the failure mode this spec closes.
-
-### Binding must be observable in the trace
-
-The trace emitted for each run must contain a signal that identifies the
-main-thread agent. `kata-trace` must be able to verify the binding from the
-trace artifact alone, without inferring it from behaviour. Whether that
-signal is one the runtime emits natively or one libeval emits itself is a
-design choice.
-
 ### Binding must hold across execution modes
 
 All three libeval execution modes — single-agent runs, supervised runs, and
@@ -200,13 +190,6 @@ against which solo mode's fix is verified.
   SDK's top-level `agent` option (and the equivalent `--agent` CLI flag)
   for main-thread binding. Whatever libeval does to attach profile content
   stands alone and does not coexist with that option.
-- **`fit-eval` CLI startup** — must reject an unresolvable profile before
-  starting the query.
-- **Trace schema** — whichever signal identifies the bound main-thread agent
-  must be documented alongside the existing event types so `kata-trace` can
-  audit it.
-- **`kata-trace` invariant audit** — gains a universal "main-thread agent
-  bound" invariant applied to every scheduled agent trace.
 
 ### Excluded
 
@@ -221,6 +204,12 @@ against which solo mode's fix is verified.
   spec; libeval's binding does not use that option, and the correctness of
   libeval's binding must not depend on the option being ignored, respected,
   or changed.
+- **Dedicated binding instrumentation.** Startup validation that refuses
+  unresolvable profile names with bespoke error messages, and dedicated
+  trace events that announce which profile is bound, are both out of scope.
+  The spec does not add that layer because the two existing safety nets
+  described in the Proposal already cover unreadable-profile and
+  drift-from-wrong-content failure modes.
 - **Task prompt rewording.** The task text "Assess the current state of
   your domain and act on the highest-priority finding" stays generic. The
   profile is what binds "your domain" to a specific meaning, and fixing the
@@ -238,27 +227,20 @@ it.
 
 ## Success Criteria
 
-1. For every scheduled agent workflow
-   (`agent-technical-writer`, `agent-security-engineer`, `agent-staff-engineer`,
-   `agent-release-engineer`, `agent-product-manager`), the captured trace
-   contains an event that identifies the main-thread agent by its profile
-   name. The signal must be discoverable by a documented `kata-trace` query.
-2. For each of those runs, the main thread's first `Read` targets
-   `wiki/<agent>.md` before any other wiki or agent-profile read. This
-   property is checkable by scanning the trace for the first `Read`
-   tool call.
-3. Running `fit-eval` with a non-existent agent profile exits non-zero with
-   an error message naming the missing profile, before any API call.
-4. `kata-trace`'s invariant audit includes a "main-thread agent bound"
-   invariant. Audits of the five evidence runs listed above mark it FAIL;
-   audits of the next scheduled run of each workflow after the fix lands
-   mark it PASS.
-5. The main-thread profile system prompt is detectable in the trace —
-   either via a dedicated event or via an echoed system-prompt payload —
-   such that a reader can confirm, from the artifact, that the profile's
-   content is what drove the first turn. This is an artifact property, not
-   dependent on whether any particular run chose to emit a voice marker.
-6. A repository-wide grep for the SDK option that previously carried the
+1. A libeval test verifies that for each profile defined under
+   `.claude/agents/`, the SDK call libeval constructs carries the profile's
+   content in its system prompt. The test passes; `bun run test` is the
+   command.
+2. A repository-wide grep for the SDK option that previously carried the
    profile name (top-level `agent` in SDK query options, `--agent` CLI flag)
    returns no call sites inside libeval's source. Test fixtures and
    historical documentation may still reference it.
+3. On the next scheduled run of each agent workflow
+   (`agent-technical-writer`, `agent-security-engineer`, `agent-staff-engineer`,
+   `agent-release-engineer`, `agent-product-manager`) after the fix lands,
+   the trace contains the profile's voice marker
+   (`— Technical Writer 📝`, `— Security Engineer 🔒`, etc.) in at least
+   one text block. The markers are authored only in `.claude/agents/<name>.md`;
+   their appearance confirms profile content reached the main thread and
+   is a signal the fix survived the scheduled-run integration path, not
+   only the libeval test harness.

--- a/specs/530-agent-profile-main-thread-binding/spec.md
+++ b/specs/530-agent-profile-main-thread-binding/spec.md
@@ -74,6 +74,36 @@ _main-thread system prompt_.
 silent. No validation error, no warning. The only visible signal is
 behavioural drift across many turns.
 
+### Contrast — facilitated mode works
+
+The daily storyboard meeting uses libeval's `facilitate` execution mode,
+which wires its agents with a different SDK option shape. Run
+[24554487708] (2026-04-17 07:58, 10 hours _before_ PR #409 merged) shows
+perfect persona adoption across all five facilitated agents:
+
+[24554487708]: https://github.com/forwardimpact/monorepo/actions/runs/24554487708
+
+| Signal | Solo runs (5 sampled) | Facilitated run (5 agents) |
+| --- | --- | --- |
+| Read own `wiki/<agent>.md` before first domain action | 0 / 5 | **5 / 5** |
+| First tool call in-domain | 0 / 5 | **5 / 5** |
+| Emitted profile voice marker (🌱 🔒 🚀 📝 📊) | 0 / 5 | **5 / 5** |
+| Drift to other profile | 4 / 5 (all to product-manager) | 0 / 5 |
+
+Voice markers like `— Technical Writer 📝` are authored only in
+`.claude/agents/<name>.md`. No facilitated agent _Read_ its own profile file
+during the run, yet every one of them emitted the correct marker. The
+profile content therefore reaches facilitated agents through the system
+prompt at session start, not through a tool call.
+
+**The difference is at session start, not at task time.** Facilitated and
+supervised modes compose the profile into the main-thread system prompt
+before the first turn; solo mode does not. The `agent` option alone — the
+approach PR [#409] reached for — is not what distinguishes a working run
+from a broken one in this SDK version; some additional session-start
+composition, already present in the facilitated and supervised call sites,
+is. Solo mode is the single outlier among the three execution modes.
+
 ### Impact
 
 - **Persona-enforced scope constraints are not in force.** Each profile
@@ -98,18 +128,20 @@ behavioural drift across many turns.
 ## Proposal
 
 Bind the designated agent profile as the main-thread system prompt on every
-scheduled agent run. The profile must drive the first token of the main
-thread, the binding must be verifiable from the trace without reading
-behaviour across many turns, and a missing profile must surface as a loud
-startup failure rather than a silent fallback to a generic main thread.
+scheduled agent run — including solo-mode runs, which today silently skip
+this step. The profile must drive the first token of the main thread, the
+binding must be verifiable from the trace without reading behaviour across
+many turns, and a missing profile must surface as a loud startup failure
+rather than a silent fallback to a generic main thread.
 
 ### Binding must be explicit
 
 Passing a profile name alone is not enough — the invariant behind this spec
 is that whatever the runtime needs to attach profile content to the main
-thread, libeval must supply it. The current behaviour (naming the profile
-and expecting the SDK's settings layer to resolve it) has been observed to
-produce an unbound main thread while reporting success.
+thread, libeval must supply it. The current solo-mode path has been
+observed to produce an unbound main thread while reporting success.
+Facilitated and supervised modes already bind correctly and stand as the
+baseline; solo mode must meet the same guarantee.
 
 ### Missing profile must fail loudly
 
@@ -130,7 +162,9 @@ design choice.
 All three libeval execution modes — single-agent runs, supervised runs, and
 facilitated multi-agent sessions — must bind their respective main-thread
 profiles with the same guarantees. In supervised and facilitated modes, each
-independent main thread must bind its own profile independently.
+independent main thread must bind its own profile independently. The
+existing behaviour of supervised and facilitated modes is the baseline
+against which solo mode's fix is verified.
 
 ## Scope
 

--- a/specs/530-agent-profile-main-thread-binding/spec.md
+++ b/specs/530-agent-profile-main-thread-binding/spec.md
@@ -3,15 +3,15 @@
 ## Problem
 
 Scheduled Kata agents are not adopting their `.claude/agents/<name>.md` profile
-as the main-thread system prompt. The main thread runs as a generic
-Claude Code session that happens to know `<name>` is a registered subagent. PR
-[#409] (2026-04-17) switched libeval from `extraArgs: { agent }` to the SDK's
-top-level `options.agent` expecting this to bind the profile; traces from
-five runs spanning four agents on the next night shift show it did not.
-The `options.agent` route is the wrong integration point for libeval's
-needs — evidence in this spec establishes it as unreliable for main-thread
-binding across SDK 0.2.98–0.2.112, and libeval should stop depending on it
-even if a future SDK version makes it work.
+as the main-thread system prompt. The main thread runs as a generic Claude Code
+session that happens to know `<name>` is a registered subagent. PR [#409]
+(2026-04-17) switched libeval from `extraArgs: { agent }` to the SDK's top-level
+`options.agent` expecting this to bind the profile; traces from five runs
+spanning four agents on the next night shift show it did not. The
+`options.agent` route is the wrong integration point for libeval's needs —
+evidence in this spec establishes it as unreliable for main-thread binding
+across SDK 0.2.98–0.2.112, and libeval should stop depending on it even if a
+future SDK version makes it work.
 
 [#409]: https://github.com/forwardimpact/monorepo/pull/409
 
@@ -20,40 +20,45 @@ even if a future SDK version makes it work.
 Five consecutive workflow runs ran after [#409] merged at `2026-04-17T17:46Z`.
 Each started on a commit containing the fix. None adopted its profile.
 
-| Workflow | Run ID | Start UTC | Own profile read? | Other profiles read? | Behaviour exhibited |
-| --- | --- | --- | --- | --- | --- |
-| Technical Writer | [24587425816] | 21:26 | no | none | Implemented summit/coverage code fix (#414) |
-| Release Engineer | [24586709478] | 21:06 | no | none | Ran product-manager PR gate, merged #413 |
-| Product Manager | [24596510543] | 04:05 | no | improvement-coach.md | Ran product-manager PR gate (in-domain by coincidence) |
-| Staff Engineer | [24597071264] | 04:39 | no | improvement-coach.md, **product-manager.md** | Ran product-manager PR gate on #414 |
-| Security Engineer | [24597390612] | 04:58 | no | **product-manager.md** | Ran product-manager PR gate on #414 |
+| Workflow          | Run ID        | Start UTC | Own profile read? | Other profiles read?                         | Behaviour exhibited                                    |
+| ----------------- | ------------- | --------- | ----------------- | -------------------------------------------- | ------------------------------------------------------ |
+| Technical Writer  | [24587425816] | 21:26     | no                | none                                         | Implemented summit/coverage code fix (#414)            |
+| Release Engineer  | [24586709478] | 21:06     | no                | none                                         | Ran product-manager PR gate, merged #413               |
+| Product Manager   | [24596510543] | 04:05     | no                | improvement-coach.md                         | Ran product-manager PR gate (in-domain by coincidence) |
+| Staff Engineer    | [24597071264] | 04:39     | no                | improvement-coach.md, **product-manager.md** | Ran product-manager PR gate on #414                    |
+| Security Engineer | [24597390612] | 04:58     | no                | **product-manager.md**                       | Ran product-manager PR gate on #414                    |
 
-[24587425816]: https://github.com/forwardimpact/monorepo/actions/runs/24587425816
-[24586709478]: https://github.com/forwardimpact/monorepo/actions/runs/24586709478
-[24596510543]: https://github.com/forwardimpact/monorepo/actions/runs/24596510543
-[24597071264]: https://github.com/forwardimpact/monorepo/actions/runs/24597071264
-[24597390612]: https://github.com/forwardimpact/monorepo/actions/runs/24597390612
+[24587425816]:
+  https://github.com/forwardimpact/monorepo/actions/runs/24587425816
+[24586709478]:
+  https://github.com/forwardimpact/monorepo/actions/runs/24586709478
+[24596510543]:
+  https://github.com/forwardimpact/monorepo/actions/runs/24596510543
+[24597071264]:
+  https://github.com/forwardimpact/monorepo/actions/runs/24597071264
+[24597390612]:
+  https://github.com/forwardimpact/monorepo/actions/runs/24597390612
 
 **Shared opening phrase.** Every one of the five main-thread agents opens with
 near-identical framing — "The user is asking me to assess the current state of
-my domain and act on the highest-priority finding. This looks like an
-autonomous loop prompt/request/task." The security engineer adds "Let me
-figure out what domain I'm in." That framing is generic Claude Code responding
-to a task, not a profile introducing itself.
+my domain and act on the highest-priority finding. This looks like an autonomous
+loop prompt/request/task." The security engineer adds "Let me figure out what
+domain I'm in." That framing is generic Claude Code responding to a task, not a
+profile introducing itself.
 
 **Voice markers absent.** `technical-writer.md` instructs the agent to sign
 output with `— Technical Writer 📝`. The technical-writer run emitted no
 signature. None of the other profiles' voice markers appear either.
 
 **Drift converges on product-manager behaviour.** Three of four non-PM runs
-produced Product PR Gate reports on PR #414 — the most actionable visible
-work. When the profile is absent, the agent reads `KATA.md` for orientation,
-sees the seven-agent landscape, picks the most visible queue (open PRs), and
-acts as whichever profile that queue belongs to. The Security Engineer run
-even read `.claude/agents/product-manager.md` to execute the gate correctly.
+produced Product PR Gate reports on PR #414 — the most actionable visible work.
+When the profile is absent, the agent reads `KATA.md` for orientation, sees the
+seven-agent landscape, picks the most visible queue (open PRs), and acts as
+whichever profile that queue belongs to. The Security Engineer run even read
+`.claude/agents/product-manager.md` to execute the gate correctly.
 
-**Init event does not mark a main-thread agent.** The SDK's `system.init`
-event from run 24587425816 contains:
+**Init event does not mark a main-thread agent.** The SDK's `system.init` event
+from run 24587425816 contains:
 
 ```
 agents: ['Explore', 'general-purpose', 'improvement-coach', 'Plan',
@@ -61,124 +66,123 @@ agents: ['Explore', 'general-purpose', 'improvement-coach', 'Plan',
          'staff-engineer', 'statusline-setup', 'technical-writer']
 ```
 
-All profiles registered as subagents; none bound as the main-thread agent.
-The per-turn `agent_type` field described in `sdk.d.ts` as "Present … on the
-main thread of a session started with --agent" never appears.
+All profiles registered as subagents; none bound as the main-thread agent. The
+per-turn `agent_type` field described in `sdk.d.ts` as "Present … on the main
+thread of a session started with --agent" never appears.
 
 **The `options.agent` contract is underspecified for this use case.**
-`@anthropic-ai/claude-agent-sdk@0.2.112` documents the top-level `agent`
-option as: "The agent must be defined either in the `agents` option or in
-settings." libeval passes `agent: "<name>"` but does not pass
-`agents: { "<name>": { prompt, description, … } }`. The `settings` fallback
-path reads subagent definitions from `.claude/agents/*.md`, but the
-observed behaviour shows those definitions are applied to the _subagent
-registry_ (for the `Task`/`Agent` tool), not to the _main-thread system
-prompt_. The option has also shifted behaviour across SDK versions —
-PR [#409] was itself a response to a behaviour change between 0.2.98 and
-0.2.112. Treat `options.agent` as unreliable infrastructure for
-main-thread binding regardless of SDK version.
+`@anthropic-ai/claude-agent-sdk@0.2.112` documents the top-level `agent` option
+as: "The agent must be defined either in the `agents` option or in settings."
+libeval passes `agent: "<name>"` but does not pass
+`agents: { "<name>": { prompt, description, … } }`. The `settings` fallback path
+reads subagent definitions from `.claude/agents/*.md`, but the observed
+behaviour shows those definitions are applied to the _subagent registry_ (for
+the `Task`/`Agent` tool), not to the _main-thread system prompt_. The option has
+also shifted behaviour across SDK versions — PR [#409] was itself a response to
+a behaviour change between 0.2.98 and 0.2.112. Treat `options.agent` as
+unreliable infrastructure for main-thread binding regardless of SDK version.
 
-**All five runs completed successfully at the API level** — the bug is
-silent. No validation error, no warning. The only visible signal is
-behavioural drift across many turns.
+**All five runs completed successfully at the API level** — the bug is silent.
+No validation error, no warning. The only visible signal is behavioural drift
+across many turns.
 
 ### Contrast — facilitated mode works
 
-The daily storyboard meeting uses libeval's `facilitate` execution mode,
-which wires its agents with a different SDK option shape. Run
-[24554487708] (2026-04-17 07:58, 10 hours _before_ PR #409 merged) shows
-perfect persona adoption across all five facilitated agents:
+The daily storyboard meeting uses libeval's `facilitate` execution mode, which
+wires its agents with a different SDK option shape. Run [24554487708]
+(2026-04-17 07:58, 10 hours _before_ PR #409 merged) shows perfect persona
+adoption across all five facilitated agents:
 
-[24554487708]: https://github.com/forwardimpact/monorepo/actions/runs/24554487708
+[24554487708]:
+  https://github.com/forwardimpact/monorepo/actions/runs/24554487708
 
-| Signal | Solo runs (5 sampled) | Facilitated run (5 agents) |
-| --- | --- | --- |
-| Read own `wiki/<agent>.md` before first domain action | 0 / 5 | **5 / 5** |
-| First tool call in-domain | 0 / 5 | **5 / 5** |
-| Emitted profile voice marker (🌱 🔒 🚀 📝 📊) | 0 / 5 | **5 / 5** |
-| Drift to other profile | 4 / 5 (all to product-manager) | 0 / 5 |
+| Signal                                                | Solo runs (5 sampled)          | Facilitated run (5 agents) |
+| ----------------------------------------------------- | ------------------------------ | -------------------------- |
+| Read own `wiki/<agent>.md` before first domain action | 0 / 5                          | **5 / 5**                  |
+| First tool call in-domain                             | 0 / 5                          | **5 / 5**                  |
+| Emitted profile voice marker (🌱 🔒 🚀 📝 📊)         | 0 / 5                          | **5 / 5**                  |
+| Drift to other profile                                | 4 / 5 (all to product-manager) | 0 / 5                      |
 
 Voice markers like `— Technical Writer 📝` are authored only in
 `.claude/agents/<name>.md`. No facilitated agent _Read_ its own profile file
-during the run, yet every one of them emitted the correct marker. The
-profile content therefore reaches facilitated agents through the system
-prompt at session start, not through a tool call.
+during the run, yet every one of them emitted the correct marker. The profile
+content therefore reaches facilitated agents through the system prompt at
+session start, not through a tool call.
 
 **The difference is at session start, not at task time.** Facilitated and
-supervised modes compose the profile into the main-thread system prompt
-before the first turn; solo mode does not. `options.agent` alone — the
-approach PR [#409] reached for — is not what distinguishes a working run
-from a broken one in this SDK version; some additional session-start
-composition, already present in the facilitated and supervised call sites,
-is. Solo mode is the single outlier among the three execution modes. The
-working modes' correctness does _not_ depend on `options.agent` being
-respected by the SDK, which is why their binding holds even when the option
-is silently ignored.
+supervised modes compose the profile into the main-thread system prompt before
+the first turn; solo mode does not. `options.agent` alone — the approach PR
+[#409] reached for — is not what distinguishes a working run from a broken one
+in this SDK version; some additional session-start composition, already present
+in the facilitated and supervised call sites, is. Solo mode is the single
+outlier among the three execution modes. The working modes' correctness does
+_not_ depend on `options.agent` being respected by the SDK, which is why their
+binding holds even when the option is silently ignored.
 
 ### Impact
 
-- **Persona-enforced scope constraints are not in force.** Each profile
-  defines scope boundaries ("never weaken documentation accuracy", "trust
-  boundary: product-manager is sole external merge point", etc.). When the
-  profile is not loaded, those boundaries are absent.
+- **Persona-enforced scope constraints are not in force.** Each profile defines
+  scope boundaries ("never weaken documentation accuracy", "trust boundary:
+  product-manager is sole external merge point", etc.). When the profile is not
+  loaded, those boundaries are absent.
 - **Skill routing fails.** Profiles list 5–8 skills each; the main thread
   instead sees the union of all skills and picks whichever matches the
   self-chosen task.
-- **Voice and signatures are absent.** Downstream PR comments and wiki
-  writes cannot be attributed to the right agent by voice — breaks
-  cross-agent audit trails.
-- **Invariant audits produce false FAILs.** `kata-trace`'s per-agent
-  invariants (`references/invariants.md`) assume the profile drove the run;
-  when the profile was absent, every invariant that refers to persona-scoped
-  behaviour fails against a main thread that never tried to satisfy them.
-- **Cost inflation.** Generic triage runs dispatch multiple Explore
-  sub-agents to re-derive what the profile would have narrowed to "read own
-  summary + current week log". Run 24587425816 spent 816K cache-read tokens
-  and six Agent sub-agents on broad repo triage.
+- **Voice and signatures are absent.** Downstream PR comments and wiki writes
+  cannot be attributed to the right agent by voice — breaks cross-agent audit
+  trails.
+- **Invariant audits produce false FAILs.** `kata-trace`'s per-agent invariants
+  (`references/invariants.md`) assume the profile drove the run; when the
+  profile was absent, every invariant that refers to persona-scoped behaviour
+  fails against a main thread that never tried to satisfy them.
+- **Cost inflation.** Generic triage runs dispatch multiple Explore sub-agents
+  to re-derive what the profile would have narrowed to "read own summary +
+  current week log". Run 24587425816 spent 816K cache-read tokens and six Agent
+  sub-agents on broad repo triage.
 
 ## Proposal
 
 Bind the designated agent profile as the main-thread system prompt on every
-scheduled agent run — including solo-mode runs, which today silently skip
-this step. The profile must drive the first token of the main thread, and
-silent fallback to a generic main thread when the profile is unreachable
-is not an acceptable outcome. Two pre-existing safety nets already cover
-the remaining failure surfaces and need no augmentation: an unreadable
-profile file surfaces as the file-read's own error and halts the run, and
-a main thread that binds the wrong or empty content drifts across domain
-boundaries within the first few turns — which `kata-trace` already detects
-through grounded-theory analysis of trace artifacts.
+scheduled agent run — including solo-mode runs, which today silently skip this
+step. The profile must drive the first token of the main thread, and silent
+fallback to a generic main thread when the profile is unreachable is not an
+acceptable outcome. Two pre-existing safety nets already cover the remaining
+failure surfaces and need no augmentation: an unreadable profile file surfaces
+as the file-read's own error and halts the run, and a main thread that binds the
+wrong or empty content drifts across domain boundaries within the first few
+turns — which `kata-trace` already detects through grounded-theory analysis of
+trace artifacts.
 
 ### libeval owns the binding; `options.agent` is not part of it
 
-libeval must attach profile content to the main thread at its own layer,
-using inputs it controls directly. Passing the profile's name via
-`options.agent` (or the equivalent CLI flag) has been observed to silently
-not bind across SDK 0.2.98–0.2.112 and must be treated as unreliable for
-this purpose regardless of SDK version. Two consequences follow:
+libeval must attach profile content to the main thread at its own layer, using
+inputs it controls directly. Passing the profile's name via `options.agent` (or
+the equivalent CLI flag) has been observed to silently not bind across SDK
+0.2.98–0.2.112 and must be treated as unreliable for this purpose regardless of
+SDK version. Two consequences follow:
 
-1. Solo-mode runs today produce an unbound main thread while reporting
-   success. That cannot continue.
+1. Solo-mode runs today produce an unbound main thread while reporting success.
+   That cannot continue.
 2. If a future SDK version makes `options.agent` reliably attach profile
-   content, libeval's own binding path would _duplicate_ that work —
-   potentially stacking two copies of the same profile in the system prompt,
-   or producing conflicting tool/model restrictions. libeval must not rely
-   on the option, and must not set the option alongside its own binding, to
-   avoid either failure mode.
+   content, libeval's own binding path would _duplicate_ that work — potentially
+   stacking two copies of the same profile in the system prompt, or producing
+   conflicting tool/model restrictions. libeval must not rely on the option, and
+   must not set the option alongside its own binding, to avoid either failure
+   mode.
 
-Facilitated and supervised modes already bind correctly without depending
-on `options.agent`; they stand as the baseline. Solo mode must meet the
-same guarantee and must reach it through the same layer-appropriate
-mechanism — libeval's own.
+Facilitated and supervised modes already bind correctly without depending on
+`options.agent`; they stand as the baseline. Solo mode must meet the same
+guarantee and must reach it through the same layer-appropriate mechanism —
+libeval's own.
 
 ### Binding must hold across execution modes
 
 All three libeval execution modes — single-agent runs, supervised runs, and
 facilitated multi-agent sessions — must bind their respective main-thread
 profiles with the same guarantees. In supervised and facilitated modes, each
-independent main thread must bind its own profile independently. The
-existing behaviour of supervised and facilitated modes is the baseline
-against which solo mode's fix is verified.
+independent main thread must bind its own profile independently. The existing
+behaviour of supervised and facilitated modes is the baseline against which solo
+mode's fix is verified.
 
 ## Scope
 
@@ -187,34 +191,33 @@ against which solo mode's fix is verified.
 - **libeval main-thread profile loading** — all three execution modes (run,
   supervise, facilitate) across their respective main threads.
 - **Use of `options.agent` inside libeval** — libeval must stop passing the
-  SDK's top-level `agent` option (and the equivalent `--agent` CLI flag)
-  for main-thread binding. Whatever libeval does to attach profile content
-  stands alone and does not coexist with that option.
+  SDK's top-level `agent` option (and the equivalent `--agent` CLI flag) for
+  main-thread binding. Whatever libeval does to attach profile content stands
+  alone and does not coexist with that option.
 
 ### Excluded
 
-- **Agent profile content.** The `.md` files under `.claude/agents/` stay
-  as written. This spec changes how they are loaded, not what they say.
+- **Agent profile content.** The `.md` files under `.claude/agents/` stay as
+  written. This spec changes how they are loaded, not what they say.
 - **Subagent registration.** The existing mechanism for making `Explore`,
   `Plan`, `improvement-coach`, etc. available via the `Task`/`Agent` tool
   continues to work as today. The Task/Agent tool's use of agent names is a
   separate concern from main-thread binding.
-- **Future SDK behaviour of `options.agent`.** Whether a later SDK version
-  makes the option reliable for main-thread binding does not affect this
-  spec; libeval's binding does not use that option, and the correctness of
-  libeval's binding must not depend on the option being ignored, respected,
-  or changed.
+- **Future SDK behaviour of `options.agent`.** Whether a later SDK version makes
+  the option reliable for main-thread binding does not affect this spec;
+  libeval's binding does not use that option, and the correctness of libeval's
+  binding must not depend on the option being ignored, respected, or changed.
 - **Dedicated binding instrumentation.** Startup validation that refuses
-  unresolvable profile names with bespoke error messages, and dedicated
-  trace events that announce which profile is bound, are both out of scope.
-  The spec does not add that layer because the two existing safety nets
-  described in the Proposal already cover unreadable-profile and
-  drift-from-wrong-content failure modes.
-- **Task prompt rewording.** The task text "Assess the current state of
-  your domain and act on the highest-priority finding" stays generic. The
-  profile is what binds "your domain" to a specific meaning, and fixing the
-  binding is this spec's job. A follow-up spec may later add defence-in-depth
-  prefixes to task text, but only after the binding fix is verified.
+  unresolvable profile names with bespoke error messages, and dedicated trace
+  events that announce which profile is bound, are both out of scope. The spec
+  does not add that layer because the two existing safety nets described in the
+  Proposal already cover unreadable-profile and drift-from-wrong-content failure
+  modes.
+- **Task prompt rewording.** The task text "Assess the current state of your
+  domain and act on the highest-priority finding" stays generic. The profile is
+  what binds "your domain" to a specific meaning, and fixing the binding is this
+  spec's job. A follow-up spec may later add defence-in-depth prefixes to task
+  text, but only after the binding fix is verified.
 - **Storyboard / coaching task prompts.** Those are specific enough to be
   self-identifying today.
 
@@ -222,25 +225,22 @@ against which solo mode's fix is verified.
 
 None blocking. [#409] merged a prior libeval change that routed through
 `options.agent`; the evidence in this spec shows that integration point is
-unreliable and the spec's direction is to move off it rather than refine
-it.
+unreliable and the spec's direction is to move off it rather than refine it.
 
 ## Success Criteria
 
 1. A libeval test verifies that for each profile defined under
    `.claude/agents/`, the SDK call libeval constructs carries the profile's
-   content in its system prompt. The test passes; `bun run test` is the
-   command.
-2. A repository-wide grep for the SDK option that previously carried the
-   profile name (top-level `agent` in SDK query options, `--agent` CLI flag)
-   returns no call sites inside libeval's source. Test fixtures and
-   historical documentation may still reference it.
-3. On the next scheduled run of each agent workflow
-   (`agent-technical-writer`, `agent-security-engineer`, `agent-staff-engineer`,
-   `agent-release-engineer`, `agent-product-manager`) after the fix lands,
-   the trace contains the profile's voice marker
-   (`— Technical Writer 📝`, `— Security Engineer 🔒`, etc.) in at least
-   one text block. The markers are authored only in `.claude/agents/<name>.md`;
-   their appearance confirms profile content reached the main thread and
-   is a signal the fix survived the scheduled-run integration path, not
-   only the libeval test harness.
+   content in its system prompt. The test passes; `bun run test` is the command.
+2. A repository-wide grep for the SDK option that previously carried the profile
+   name (top-level `agent` in SDK query options, `--agent` CLI flag) returns no
+   call sites inside libeval's source. Test fixtures and historical
+   documentation may still reference it.
+3. On the next scheduled run of each agent workflow (`agent-technical-writer`,
+   `agent-security-engineer`, `agent-staff-engineer`, `agent-release-engineer`,
+   `agent-product-manager`) after the fix lands, the trace contains the
+   profile's voice marker (`— Technical Writer 📝`, `— Security Engineer 🔒`,
+   etc.) in at least one text block. The markers are authored only in
+   `.claude/agents/<name>.md`; their appearance confirms profile content reached
+   the main thread and is a signal the fix survived the scheduled-run
+   integration path, not only the libeval test harness.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -70,4 +70,4 @@
 500	plan	implemented
 510	design	draft
 520	plan	implemented
-530	spec	draft
+530	design	draft

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -70,4 +70,4 @@
 500	plan	implemented
 510	design	draft
 520	plan	implemented
-530	plan	draft
+530	plan	approved

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -70,4 +70,4 @@
 500	plan	implemented
 510	design	draft
 520	plan	implemented
-530	design	draft
+530	design	approved

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -70,4 +70,4 @@
 500	plan	implemented
 510	design	draft
 520	plan	implemented
-530	design	approved
+530	plan	draft

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -70,3 +70,4 @@
 500	plan	implemented
 510	design	draft
 520	plan	implemented
+530	spec	draft


### PR DESCRIPTION
## Summary

- Spec 530 — documents that scheduled Kata agents' `.claude/agents/<name>.md` profiles are not binding to the main-thread system prompt in solo mode (facilitated and supervised modes work correctly). Root cause is an underspecified SDK `options.agent` contract; libeval will stop depending on it.
- Design 530 — pure `composeProfilePrompt(name, { profilesDir, trailer })` module in libeval; three command call sites and two orchestration factories converge on the same pattern. AgentRunner drops the `agentProfile` field.
- Plan 530 — seven-step implementation plan (one new module + AgentRunner cleanup + three wiring sites + CLI audit + grep verification), single-agent execution, no decomposition.

STATUS advances: `530 spec approved`, `530 design approved`, `530 plan approved`.

## Test plan

- [x] `bun run check`
- [x] `bun run test` — 2411 pass / 0 fail / 1 skipped

https://claude.ai/code/session_013dfKmt4NSZhVeBX7htcnFS