### PR TITLE
feat(kata): parallelise kata-review with a reviewer panel

### DIFF
--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -58,10 +58,10 @@ spec's scope is too broad and should be narrowed.
       and data structures but not file-level changes, execution ordering, or
       implementation steps (those belong in the plan).
 - [ ] Under 200 lines total.
-- [ ] Clean sub-agent review of `design.md` via
+- [ ] Clean sub-agent review panel of `design.md` via
       [`kata-review`](../kata-review/SKILL.md) completed (fresh context, no
-      prior bias) and every **blocker**, **high**, and **medium** finding
-      addressed.
+      prior bias, panel size per caller protocol) and every **blocker**,
+      **high**, and **medium** finding addressed.
 
 </do_confirm_checklist>
 
@@ -138,11 +138,12 @@ from prior `staff-engineer` entries.
 4. **Write the design.** Create `design.md` in the spec directory. Focus on
    direction, decisions, and diagrams. Stay under 200 lines. Each architectural
    choice should name a rejected alternative.
-5. **Clean sub-agent review.** Follow the
+5. **Clean sub-agent review panel.** Follow the
    [`kata-review` caller protocol](../kata-review/references/caller-protocol.md)
-   to launch a fresh sub-agent that grades `design.md`. Tell the reviewer not to
-   invoke `kata-design`. Verify findings, address all confirmed
-   blocker/high/medium issues before advancing.
+   to launch a parallel panel of fresh sub-agents that each grade `design.md`.
+   Tell each reviewer not to invoke `kata-design`. Merge panel findings per the
+   protocol, verify, and address all confirmed blocker/high/medium issues before
+   advancing.
 6. **Present the design.** Share it for feedback. Iterate until satisfied. The
    design stays at `design draft` until a human approves it.
 7. **Update STATUS.** Set the spec to `design draft` in `specs/STATUS`.

--- a/.claude/skills/kata-implement/SKILL.md
+++ b/.claude/skills/kata-implement/SKILL.md
@@ -45,10 +45,10 @@ apply alongside the skill-specific ones below.
 - [ ] Spec-specific verification commands from the plan pass.
 - [ ] Full diff reviewed against the spec's success criteria — every criterion
       met.
-- [ ] Clean sub-agent review of the full diff via
+- [ ] Clean sub-agent review panel of the full diff via
       [`kata-review`](../kata-review/SKILL.md) completed (fresh context, no
-      prior bias) and every **blocker**, **high**, and **medium** finding
-      addressed.
+      prior bias, panel size per caller protocol) and every **blocker**,
+      **high**, and **medium** finding addressed.
 - [ ] Spec status set to `plan implemented` in `specs/STATUS`.
 
 </do_confirm_checklist>
@@ -148,17 +148,17 @@ For each task:
 
 After all tasks are complete, run the DO-CONFIRM checklist above.
 
-### 7. Clean sub-agent review
+### 7. Clean sub-agent review panel
 
 Follow the
 [`kata-review` caller protocol](../kata-review/references/caller-protocol.md) to
-launch a fresh sub-agent that grades the full diff
-(`git diff origin/main...HEAD`). Provide spec path, plan path, and branch name
-so the reviewer can act independently. Tell the reviewer not to invoke
-`kata-implement`. Verify findings, address all confirmed blocker/high/medium
-issues before pushing.
+launch a parallel panel of fresh sub-agents that each grade the full diff
+(`git diff origin/main...HEAD`). Provide each reviewer with spec path, plan
+path, and branch name so they can act independently. Tell each reviewer not to
+invoke `kata-implement`. Merge panel findings per the protocol, verify, and
+address all confirmed blocker/high/medium issues before pushing.
 
-Push all commits to the remote branch only after the review is clean.
+Push all commits to the remote branch only after the panel review is clean.
 
 ## Handling Problems
 

--- a/.claude/skills/kata-implement/SKILL.md
+++ b/.claude/skills/kata-implement/SKILL.md
@@ -153,10 +153,10 @@ After all tasks are complete, run the DO-CONFIRM checklist above.
 Follow the
 [`kata-review` caller protocol](../kata-review/references/caller-protocol.md) to
 launch a parallel panel of fresh sub-agents that each grade the full diff
-(`git diff origin/main...HEAD`). Provide each reviewer with spec path, plan
-path, and branch name so they can act independently. Tell each reviewer not to
-invoke `kata-implement`. Merge panel findings per the protocol, verify, and
-address all confirmed blocker/high/medium issues before pushing.
+(`git diff origin/main...HEAD`). Provide each reviewer with spec path, design
+path, plan path, and branch name so they can act independently. Tell each
+reviewer not to invoke `kata-implement`. Merge panel findings per the protocol,
+verify, and address all confirmed blocker/high/medium issues before pushing.
 
 Push all commits to the remote branch only after the panel review is clean.
 

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -51,10 +51,10 @@ there is no architectural direction to translate into implementation steps.
       will consume is listed by package and by specific exports, or the section
       explicitly states no shared libraries are used.
 - [ ] Execution recommendation present (which agents, sequential vs parallel).
-- [ ] Clean sub-agent review of `plan-a.md` (and any parts) via
+- [ ] Clean sub-agent review panel of `plan-a.md` (and any parts) via
       [`kata-review`](../kata-review/SKILL.md) completed (fresh context, no
-      prior bias) and every **blocker**, **high**, and **medium** finding
-      addressed.
+      prior bias, panel size per caller protocol) and every **blocker**,
+      **high**, and **medium** finding addressed.
 
 </do_confirm_checklist>
 
@@ -162,11 +162,12 @@ from prior `staff-engineer` entries.
    concrete steps. Each step should be independently verifiable. Surface risks
    explicitly. If the plan is large, decompose it into parts (see § Large plan
    decomposition).
-5. **Clean sub-agent review.** Follow the
+5. **Clean sub-agent review panel.** Follow the
    [`kata-review` caller protocol](../kata-review/references/caller-protocol.md)
-   to launch a fresh sub-agent that grades `plan-a.md` (and any `plan-a-NN.md`
-   parts). Tell the reviewer not to invoke `kata-plan`. Verify findings, address
-   all confirmed blocker/high/medium issues before advancing.
+   to launch a parallel panel of fresh sub-agents that each grade `plan-a.md`
+   (and any `plan-a-NN.md` parts). Tell each reviewer not to invoke `kata-plan`.
+   Merge panel findings per the protocol, verify, and address all confirmed
+   blocker/high/medium issues before advancing.
 6. **Present the plan.** Share it for feedback.
 7. **Update STATUS.** Set the spec to `plan draft` in `specs/STATUS`. The plan
    stays at `plan draft` until a human approves it.

--- a/.claude/skills/kata-review/references/caller-protocol.md
+++ b/.claude/skills/kata-review/references/caller-protocol.md
@@ -29,8 +29,9 @@ an implicit second pass at the next phase.
 ## How to invoke
 
 1. **Launch N fresh sub-agents in parallel** via a single message with N `Agent`
-   tool calls — parallelism is required; sequential calls waste wall-clock time
-   and tempt context leakage. Each sub-agent:
+   tool calls. Parallelism is required for two reasons: wall-clock time, and so
+   the caller cannot (accidentally or otherwise) cross-feed one reviewer's
+   output into another's prompt. Each sub-agent:
    - Starts cold with no prior conversation context.
    - Loads the [`kata-review`](../SKILL.md) skill.
    - Receives the **identical** prompt: artifact type, artifact path, spec path
@@ -47,31 +48,47 @@ an implicit second pass at the next phase.
 
 ## How to merge findings
 
-`kata-review` emits findings in a structured format:
-`<file:line> — <criterion> — <one-sentence reason>`.
+`kata-review` emits findings grouped under `### Blocker` / `### High` /
+`### Medium` / `### Low` headers, with each row shaped
+`<file:line> — <criterion> — <one-sentence reason>` (or `<commit-hash>` in place
+of `file:line` when a reviewer cites a commit).
 
-1. **Group by `(file:line, criterion)` key.** Findings that match on both fields
-   are duplicates regardless of severity phrasing or reason wording.
+1. **Group semantically, not by string equality.** Two findings are the same
+   when they cite the same `file:line` (or commit hash, or nearby lines in the
+   same hunk) _and_ raise the same underlying concern. The `<criterion>` phrase
+   is free-form; merge findings that describe the same defect in different
+   words. When in doubt, merge — a combined finding is easier to verify than two
+   near-duplicates.
 
 2. **Record the vote count** per unique finding (how many of N reviewers flagged
-   it).
+   it) and the severity each flagging reviewer assigned (read from the
+   `### <Level>` section header the finding appeared under in that reviewer's
+   report).
 
-3. **Pick severity by consensus, not by max.** Take the median severity across
-   reviewers who flagged the finding — a Blocker flagged once and a Low flagged
-   four times is a Low/Medium concern, not a Blocker.
+3. **Pick severity by mode, tie-breaking high.** Use the most common severity
+   among the reviewers who flagged the finding. If two severities tie, pick the
+   higher one to stay cautious. A Blocker flagged by 1 of 5 with four silent
+   reviewers is a Blocker at vote 1 — the vote count, not the severity, reflects
+   how many reviewers saw it.
 
-4. **Partition the merged list** into three buckets:
-   - **Consensus (≥⌈N/2⌉ votes)** — treat as the panel's verdict. Verify and
-     address all confirmed blocker/high/medium findings before advancing.
-   - **Minority (between singleton and consensus)** — verify with extra care; a
-     2-of-5 finding on an implement diff is often a real edge case only some
-     reviewers spotted.
+4. **Partition the merged list** by vote count:
+   - **Consensus (≥⌈N/2⌉ votes)** — the panel's verdict. Verify and address
+     every confirmed blocker/high/medium finding in the same turn, without
+     pausing; see `How to handle findings` below.
+   - **Minority (>1 and <⌈N/2⌉ votes)** — for N=5 this is the 2-vote band; for
+     N=3 panels this bucket is empty and findings are either Consensus or
+     Singleton. Verify with extra care — a 2-of-5 finding is often a real edge
+     case only some reviewers spotted.
    - **Singleton (1 vote)** — likely false positive, but not dismissed silently.
      Verify each; address or record the rationale for dismissal.
 
-5. **Scope-creep guard.** If reviewers flag issues outside the artifact's stated
-   scope, dismiss by default with a one-line note — scope is set by the spec,
-   not the review panel.
+5. **Scope-creep guard.** Dismiss by default any finding that raises a concern
+   outside the artifact's declared scope (spec scope for design/plan, plan scope
+   for diffs). For a spec review there is no prior scope document — use the
+   user's stated intent instead. This guard does **not** override kata-review's
+   own scope-creep criterion for diffs ("the diff refactors or adds unrelated
+   changes"); consensus findings of that kind remain Consensus and must be
+   addressed.
 
 ## Why this is safe
 
@@ -84,9 +101,15 @@ not change this invariant; each reviewer is still a leaf. See
 
 - **Verify** every unique finding against the actual artifact before acting on
   it. The caller is accountable, not the panel.
-- After verification, address every confirmed **blocker**, **high**, and
-  **medium** finding before advancing (approving, pushing, or merging).
+- **Proceed without pausing.** After verification, address every confirmed
+  consensus **blocker**, **high**, and **medium** finding in the same turn — do
+  not stop to ask the user for permission to fix them. Acting on the panel's
+  verdict is part of this Process step, not a separate approval gate. Fix the
+  artifact, re-run the panel if the fix is substantial, then advance.
 - **Low** findings are optional. Document if dismissed.
-- If reviewers raise blockers you disagree with — including consensus blockers —
-  resolve the disagreement explicitly: revise the artifact, or record the
-  rationale for dismissal. Silent dismissal is not allowed.
+- **False positives.** If you verify a finding and judge it a false positive,
+  record a one-line rationale in the commit message or artifact and continue.
+  Silent dismissal is not allowed.
+- **Disagreement with a consensus blocker.** Revise the artifact to address the
+  underlying concern, or record a rationale — in the same turn, without
+  stopping.

--- a/.claude/skills/kata-review/references/caller-protocol.md
+++ b/.claude/skills/kata-review/references/caller-protocol.md
@@ -1,35 +1,92 @@
 # Sub-Agent Review Protocol
 
-Shared protocol for callers of `kata-review`. Used by `kata-spec` (Step 5),
-`kata-design` (Step 5), `kata-plan` (Step 5), and `kata-implement` (Step 8).
+Shared protocol for callers of `kata-review`. Used by:
+
+- `kata-spec` Step 5, `kata-design` Step 5, `kata-plan` Step 5 — panel of 3
+- `kata-implement` Step 7 — panel of 5
+
+## Why a panel
+
+Sub-agent reviewers spawn cold and can misread intent, miss surrounding code, or
+flag false positives. Independent reviewers produce uncorrelated errors: a
+finding flagged by ≥⌈N/2⌉ reviewers is high-signal; a singleton is likely noise
+but must still be verified. Odd N enables majority voting.
+
+## Panel size
+
+| Caller           | Artifact                    | Reviewers |
+| ---------------- | --------------------------- | --------- |
+| `kata-spec`      | `spec.md`                   | 3         |
+| `kata-design`    | `design.md`                 | 3         |
+| `kata-plan`      | `plan-a.md` (+ parts)       | 3         |
+| `kata-implement` | diff (`origin/main...HEAD`) | 5         |
+
+Implementation diffs get 5 because the artifact is larger, the step is
+irreversible (code lands on `main`), and the surface area for subtle bugs and
+security regressions is largest. Spec/design/plan artifacts are bounded and have
+an implicit second pass at the next phase.
 
 ## How to invoke
 
-1. **Launch a fresh sub-agent** via the `Agent` tool with no prior conversation
-   context. Instruct it to load the [`kata-review`](../SKILL.md) skill and grade
-   the artifact (spec, plan, or diff).
+1. **Launch N fresh sub-agents in parallel** via a single message with N `Agent`
+   tool calls — parallelism is required; sequential calls waste wall-clock time
+   and tempt context leakage. Each sub-agent:
+   - Starts cold with no prior conversation context.
+   - Loads the [`kata-review`](../SKILL.md) skill.
+   - Receives the **identical** prompt: artifact type, artifact path, spec path
+     (for design/plan/diff), design path (for plan/diff), plan path (for diff),
+     and branch name (for diff).
+   - Is told not to invoke the parent skill (e.g., "do not invoke `kata-spec`")
+     — defense in depth on top of the structural recursion fix.
 
-2. **Tell the reviewer not to invoke the parent skill** (e.g., "do not invoke
-   `kata-spec`") — defense in depth on top of the structural recursion fix.
+2. **Do not share a scratchpad or cross-feed reviewer output.** Correlated
+   errors collapse the ensemble back to one reviewer's signal.
 
-3. **Provide enough context** for the reviewer to act independently — artifact
-   path, spec path (for plans and diffs), plan path (for diffs), and branch name
-   (for diffs).
+3. **Collect all N findings reports** before merging. A missing report is not a
+   pass — re-spawn that reviewer.
+
+## How to merge findings
+
+`kata-review` emits findings in a structured format:
+`<file:line> — <criterion> — <one-sentence reason>`.
+
+1. **Group by `(file:line, criterion)` key.** Findings that match on both fields
+   are duplicates regardless of severity phrasing or reason wording.
+
+2. **Record the vote count** per unique finding (how many of N reviewers flagged
+   it).
+
+3. **Pick severity by consensus, not by max.** Take the median severity across
+   reviewers who flagged the finding — a Blocker flagged once and a Low flagged
+   four times is a Low/Medium concern, not a Blocker.
+
+4. **Partition the merged list** into three buckets:
+   - **Consensus (≥⌈N/2⌉ votes)** — treat as the panel's verdict. Verify and
+     address all confirmed blocker/high/medium findings before advancing.
+   - **Minority (between singleton and consensus)** — verify with extra care; a
+     2-of-5 finding on an implement diff is often a real edge case only some
+     reviewers spotted.
+   - **Singleton (1 vote)** — likely false positive, but not dismissed silently.
+     Verify each; address or record the rationale for dismissal.
+
+5. **Scope-creep guard.** If reviewers flag issues outside the artifact's stated
+   scope, dismiss by default with a one-line note — scope is set by the spec,
+   not the review panel.
 
 ## Why this is safe
 
 `kata-review` never spawns sub-agents — that is the structural property that
-prevents the spec / plan / implement review loop from recursing. See
+prevents the spec / plan / implement review loop from recursing. Panel size does
+not change this invariant; each reviewer is still a leaf. See
 [KATA.md § Recursion-safe self-review](../../../../KATA.md#recursion-safe-self-review).
 
 ## How to handle findings
 
-- **Verify** every finding against the actual artifact before acting on it.
-  Sub-agent reviewers operate without prior conversation context and can misread
-  intent, miss surrounding code, or flag false positives.
+- **Verify** every unique finding against the actual artifact before acting on
+  it. The caller is accountable, not the panel.
 - After verification, address every confirmed **blocker**, **high**, and
   **medium** finding before advancing (approving, pushing, or merging).
 - **Low** findings are optional. Document if dismissed.
-- If the reviewer raises blockers you disagree with, resolve the disagreement
-  explicitly — revise the artifact, or record the rationale for dismissal.
-  Silent dismissal is not allowed.
+- If reviewers raise blockers you disagree with — including consensus blockers —
+  resolve the disagreement explicitly: revise the artifact, or record the
+  rationale for dismissal. Silent dismissal is not allowed.

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -48,9 +48,10 @@ asked for. If they ask for a spec, write the spec and stop.
 - [ ] Success criteria are verifiable (a command, observable behaviour, or
       testable property).
 - [ ] No implementation details have leaked in (HOW belongs in the plan).
-- [ ] Clean sub-agent review panel via [`kata-review`](../kata-review/SKILL.md)
-      completed (fresh context, no prior bias, panel size per caller protocol)
-      and every **blocker**, **high**, and **medium** finding addressed.
+- [ ] Clean sub-agent review panel of `spec.md` via
+      [`kata-review`](../kata-review/SKILL.md) completed (fresh context, no
+      prior bias, panel size per caller protocol) and every **blocker**,
+      **high**, and **medium** finding addressed.
 
 </do_confirm_checklist>
 

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -48,9 +48,9 @@ asked for. If they ask for a spec, write the spec and stop.
 - [ ] Success criteria are verifiable (a command, observable behaviour, or
       testable property).
 - [ ] No implementation details have leaked in (HOW belongs in the plan).
-- [ ] Clean sub-agent review via [`kata-review`](../kata-review/SKILL.md)
-      completed (fresh context, no prior bias) and every **blocker**, **high**,
-      and **medium** finding addressed.
+- [ ] Clean sub-agent review panel via [`kata-review`](../kata-review/SKILL.md)
+      completed (fresh context, no prior bias, panel size per caller protocol)
+      and every **blocker**, **high**, and **medium** finding addressed.
 
 </do_confirm_checklist>
 
@@ -114,11 +114,12 @@ commit changes, report your decision so the caller can act on it.
 3. **Write the spec.** Focus on WHAT and WHY. Do not include implementation
    details — those go in the plan.
 4. **Update STATUS.** Add the spec to `specs/STATUS` with `spec draft`.
-5. **Clean sub-agent review.** Follow the
+5. **Clean sub-agent review panel.** Follow the
    [`kata-review` caller protocol](../kata-review/references/caller-protocol.md)
-   to launch a fresh sub-agent that grades `spec.md`. Tell the reviewer not to
-   invoke `kata-spec`. Verify findings, address all confirmed
-   blocker/high/medium issues before advancing.
+   to launch a parallel panel of fresh sub-agents that each grade `spec.md`.
+   Tell each reviewer not to invoke `kata-spec`. Merge panel findings per the
+   protocol, verify, and address all confirmed blocker/high/medium issues before
+   advancing.
 6. **Present the spec.** Share it for feedback. Iterate until satisfied. The
    spec stays at `spec draft` until a human approves it. Stop here — the plan is
    the staff engineer's job.

--- a/KATA.md
+++ b/KATA.md
@@ -330,10 +330,9 @@ Skills requiring independent review of their output must spawn a fresh sub-agent
 targeting a **leaf skill** (`kata-review`) whose process never spawns further
 sub-agents. This prevents infinite recursion. Defense-in-depth: the parent's
 review step also tells the sub-agent "do not invoke this skill." Callers spawn a
-**panel** of such leaf reviewers in parallel (3 for spec/design/plan, 5 for
-implement diffs) and merge findings by `(file:line, criterion)` with majority
-vote — panel size does not change the leaf invariant. See the `kata-review`
-caller protocol.
+**panel** of such leaf reviewers in parallel and merge findings by majority
+vote; panel size does not change the leaf invariant. See the `kata-review`
+caller protocol for panel sizes and merge algorithm.
 
 ### Shared patterns
 

--- a/KATA.md
+++ b/KATA.md
@@ -329,7 +329,11 @@ selection, and authoring guidance.
 Skills requiring independent review of their output must spawn a fresh sub-agent
 targeting a **leaf skill** (`kata-review`) whose process never spawns further
 sub-agents. This prevents infinite recursion. Defense-in-depth: the parent's
-review step also tells the sub-agent "do not invoke this skill."
+review step also tells the sub-agent "do not invoke this skill." Callers spawn a
+**panel** of such leaf reviewers in parallel (3 for spec/design/plan, 5 for
+implement diffs) and merge findings by `(file:line, criterion)` with majority
+vote — panel size does not change the leaf invariant. See the `kata-review`
+caller protocol.
 
 ### Shared patterns
 


### PR DESCRIPTION
## Summary

- Turn each single-reviewer `kata-review` invocation in `kata-spec`, `kata-design`, `kata-plan`, and `kata-implement` into a **panel of independent reviewers** — 3 for spec/design/plan, 5 for implement diffs. Odd panel sizes enable majority voting; each reviewer is still a `kata-review` leaf so the recursion-safety invariant is preserved.
- Extend `.claude/skills/kata-review/references/caller-protocol.md` with: parallel spawning rules, semantic `(file:line, criterion)` deduplication, mode-severity merging (tie-break high), and a three-bucket partition (Consensus / Minority / Singleton) with the N=3 Minority-empty case documented.
- Add a "Proceed without pausing" rule: callers verify and address consensus Blocker/High/Medium findings in the same turn, not behind a human approval gate.
- Update the Process step and DO-CONFIRM item in all four caller skills with identical shared wording ("Clean sub-agent review panel"). Trim `KATA.md § Recursion-safe self-review` to point at the caller protocol without duplicating its policy.
- Follow-up commit tightens the merge algorithm after a 5-reviewer panel reviewed the initial commit and returned consensus Medium findings: N=3 degeneracy documented, mode rule replaces ambiguous median rule with a worked example that actually matches the rule, scope-creep guard no longer cancels kata-review's own scope-creep criterion for diffs, kata-implement Step 7 now passes design path, and kata-spec DO-CONFIRM aligns to shared "of `<artifact>`" wording.

## Test plan

- [x] `bun run check` — format, lint, instruction-length
- [x] `bun run test` — 2411 pass, 0 fail
- [x] SKILL.md line counts all ≤ 192 (kata-spec 146, kata-design 174, kata-plan 186, kata-implement 190, kata-review 170)
- [x] `kata-review/SKILL.md` unchanged — leaf invariant preserved
- [x] Shared-wording check: "Clean sub-agent review panel" identical across 4 callers modulo per-artifact nouns
- [x] Dogfooded: this branch was itself reviewed by a panel of 5 cold `kata-review` sub-agents; consensus Medium findings were addressed in the follow-up commit

https://claude.ai/code/session_014fuMAMkdZyKjkaMZYxDUwE