### PR TITLE
feat(libeval): bind agent profile to main-thread system prompt (530)

### DIFF
--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -21,7 +21,6 @@ function applyDefaults(deps) {
     onBatch: deps.onBatch ?? null,
     batchSize: deps.batchSize ?? 3,
     settingSources: deps.settingSources ?? [],
-    agentProfile: deps.agentProfile ?? null,
     systemPrompt: deps.systemPrompt ?? null,
     disallowedTools: deps.disallowedTools ?? [],
     mcpServers: deps.mcpServers ?? null,
@@ -42,7 +41,6 @@ export class AgentRunner {
    * @param {function} [deps.onBatch] - Async callback invoked with a batch of NDJSON lines at flush boundaries: every `batchSize` assistant text blocks, the terminal `result` message, and — on iterator crash/abort — once more in a final flush carrying any lines that never reached a boundary. Receives `(lines, { abort })` where calling `abort()` stops the in-flight SDK session via the AbortController. Optional; assignable at runtime so the Supervisor can swap it per turn.
    * @param {number} [deps.batchSize] - Assistant text-block messages to accumulate before firing onBatch. Tool-only assistant messages ride along without counting. Default 3: the supervisor reviews the agent every three text turns instead of every turn. The terminal `result` always flushes regardless of count.
    * @param {string[]} [deps.settingSources] - SDK setting sources (e.g. ['project'] to load CLAUDE.md)
-   * @param {string} [deps.agentProfile] - Agent profile name to pass as --agent to the Claude CLI
    * @param {string|object} [deps.systemPrompt] - SDK system prompt (string replaces default; {type:'preset', preset:'claude_code', append} appends)
    * @param {string[]} [deps.disallowedTools] - Tools to explicitly remove from the model's context
    * @param {Record<string, object>} [deps.mcpServers] - MCP server configs to pass to the SDK query
@@ -82,7 +80,6 @@ export class AgentRunner {
             disallowedTools: this.disallowedTools,
           }),
           ...(this.systemPrompt && { systemPrompt: this.systemPrompt }),
-          ...(this.agentProfile && { agent: this.agentProfile }),
           ...(this.mcpServers && { mcpServers: this.mcpServers }),
         },
       });

--- a/libraries/libeval/src/commands/run.js
+++ b/libraries/libeval/src/commands/run.js
@@ -2,6 +2,7 @@ import { readFileSync, createWriteStream } from "node:fs";
 import { Writable } from "node:stream";
 import { resolve } from "node:path";
 import { createAgentRunner } from "../agent-runner.js";
+import { composeProfilePrompt } from "../profile-prompt.js";
 import { createTeeWriter } from "../tee-writer.js";
 import { SequenceCounter } from "../sequence-counter.js";
 
@@ -76,6 +77,12 @@ export async function runRunCommand(values, _args) {
     );
   };
 
+  const systemPrompt = agentProfile
+    ? composeProfilePrompt(agentProfile, {
+        profilesDir: resolve(cwd, ".claude/agents"),
+      })
+    : undefined;
+
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
   const runner = createAgentRunner({
     cwd,
@@ -86,7 +93,7 @@ export async function runRunCommand(values, _args) {
     allowedTools,
     onLine,
     settingSources: ["project"],
-    agentProfile,
+    systemPrompt,
   });
 
   const result = await runner.run(taskContent);

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -7,7 +7,9 @@
  */
 
 import { Writable } from "node:stream";
+import { resolve } from "node:path";
 import { createAgentRunner } from "./agent-runner.js";
+import { composeProfilePrompt } from "./profile-prompt.js";
 import { SequenceCounter } from "./sequence-counter.js";
 import { createMessageBus } from "./message-bus.js";
 import {
@@ -415,7 +417,8 @@ const devNull = new Writable({
  * @param {import("stream").Writable} deps.output
  * @param {string} [deps.model]
  * @param {number} [deps.maxTurns]
- * @param {string} [deps.facilitatorProfile]
+ * @param {string} [deps.facilitatorProfile] - Facilitator profile name; resolved into the main-thread system prompt via `composeProfilePrompt`.
+ * @param {string} [deps.profilesDir] - Directory containing `<name>.md` profile files. Defaults to `<facilitatorCwd>/.claude/agents`. Resolved once from the facilitator's cwd so profiles travel with the project, not with per-agent sandboxes.
  * @returns {Facilitator}
  */
 export function createFacilitator({
@@ -426,7 +429,17 @@ export function createFacilitator({
   model,
   maxTurns,
   facilitatorProfile,
+  profilesDir,
 }) {
+  const resolvedProfilesDir =
+    profilesDir ?? resolve(facilitatorCwd, ".claude/agents");
+  const systemPromptFor = (profile, trailer) =>
+    profile
+      ? composeProfilePrompt(profile, {
+          profilesDir: resolvedProfilesDir,
+          trailer,
+        })
+      : { type: "preset", preset: "claude_code", append: trailer };
   const ctx = createOrchestrationContext();
   const messageBus = createMessageBus({
     participants: ["facilitator", ...agentConfigs.map((a) => a.name)],
@@ -471,12 +484,10 @@ export function createFacilitator({
       onLine: (line) => facilitator.emitLine(config.name, line),
       mcpServers: { orchestration: agentServer },
       settingSources: ["project"],
-      agentProfile: config.agentProfile,
-      systemPrompt: {
-        type: "preset",
-        preset: "claude_code",
-        append: FACILITATED_AGENT_SYSTEM_PROMPT,
-      },
+      systemPrompt: systemPromptFor(
+        config.agentProfile,
+        FACILITATED_AGENT_SYSTEM_PROMPT,
+      ),
     });
 
     return { name: config.name, role: config.role, runner };
@@ -491,12 +502,10 @@ export function createFacilitator({
     onLine: (line) => facilitator.emitLine("facilitator", line),
     mcpServers: { orchestration: facilitatorServer },
     settingSources: ["project"],
-    agentProfile: facilitatorProfile,
-    systemPrompt: {
-      type: "preset",
-      preset: "claude_code",
-      append: FACILITATOR_SYSTEM_PROMPT,
-    },
+    systemPrompt: systemPromptFor(
+      facilitatorProfile,
+      FACILITATOR_SYSTEM_PROMPT,
+    ),
   });
 
   facilitator = new Facilitator({

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -433,13 +433,15 @@ export function createFacilitator({
 }) {
   const resolvedProfilesDir =
     profilesDir ?? resolve(facilitatorCwd, ".claude/agents");
-  const systemPromptFor = (profile, trailer) =>
-    profile
+  const systemPromptFor = (profile, trailer) => {
+    if (!trailer) throw new Error("trailer is required");
+    return profile
       ? composeProfilePrompt(profile, {
           profilesDir: resolvedProfilesDir,
           trailer,
         })
       : { type: "preset", preset: "claude_code", append: trailer };
+  };
   const ctx = createOrchestrationContext();
   const messageBus = createMessageBus({
     participants: ["facilitator", ...agentConfigs.map((a) => a.name)],

--- a/libraries/libeval/src/index.js
+++ b/libraries/libeval/src/index.js
@@ -6,6 +6,7 @@ export {
   parseGitRemote,
 } from "./trace-github.js";
 export { AgentRunner, createAgentRunner } from "./agent-runner.js";
+export { composeProfilePrompt } from "./profile-prompt.js";
 export {
   Supervisor,
   createSupervisor,

--- a/libraries/libeval/src/profile-prompt.js
+++ b/libraries/libeval/src/profile-prompt.js
@@ -1,0 +1,41 @@
+/**
+ * Compose an SDK `systemPrompt` value from a `.claude/agents/<name>.md` file.
+ *
+ * Pure function. Reads the profile file, strips YAML frontmatter, and returns
+ * the SDK-shaped `{ type: "preset", preset: "claude_code", append }` object
+ * with the profile body — plus an optional mode-specific trailer — in the
+ * `append` slot. Callers in libeval pass the result straight into an
+ * `AgentRunner`'s `systemPrompt` input so the profile reaches the main-thread
+ * system prompt without going through the SDK's top-level `agent` option.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * @param {string} name - Profile basename (no `.md` suffix)
+ * @param {object} opts
+ * @param {string} opts.profilesDir - Directory containing `<name>.md`
+ * @param {string} [opts.trailer] - Optional mode-specific trailer appended after a blank line
+ * @returns {{type: "preset", preset: "claude_code", append: string}}
+ */
+export function composeProfilePrompt(name, { profilesDir, trailer }) {
+  const path = join(profilesDir, `${name}.md`);
+  const raw = readFileSync(path, "utf8");
+  const body = stripFrontmatter(raw).trim();
+  const append = trailer && trailer.length > 0 ? `${body}\n\n${trailer}` : body;
+  return { type: "preset", preset: "claude_code", append };
+}
+
+/**
+ * Strip a leading YAML frontmatter fence (`---\n…\n---\n`) from a markdown
+ * string. Returns the input unchanged when no frontmatter is present.
+ * @param {string} raw
+ * @returns {string}
+ */
+function stripFrontmatter(raw) {
+  if (!raw.startsWith("---\n")) return raw;
+  const end = raw.indexOf("\n---\n", 4);
+  if (end === -1) return raw;
+  return raw.slice(end + 5);
+}

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -378,13 +378,15 @@ export function createSupervisor({
 }) {
   const resolvedProfilesDir =
     profilesDir ?? resolve(supervisorCwd, ".claude/agents");
-  const systemPromptFor = (profile, trailer) =>
-    profile
+  const systemPromptFor = (profile, trailer) => {
+    if (!trailer) throw new Error("trailer is required");
+    return profile
       ? composeProfilePrompt(profile, {
           profilesDir: resolvedProfilesDir,
           trailer,
         })
       : { type: "preset", preset: "claude_code", append: trailer };
+  };
   let supervisor;
   let supervisorRunner;
 

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -11,7 +11,9 @@
  */
 
 import { Writable } from "node:stream";
+import { resolve } from "node:path";
 import { createAgentRunner } from "./agent-runner.js";
+import { composeProfilePrompt } from "./profile-prompt.js";
 import { TraceCollector } from "./trace-collector.js";
 import { SequenceCounter } from "./sequence-counter.js";
 import {
@@ -355,8 +357,9 @@ const devNull = new Writable({
  * @param {string[]} [deps.allowedTools]
  * @param {string[]} [deps.supervisorAllowedTools]
  * @param {string[]} [deps.supervisorDisallowedTools]
- * @param {string} [deps.supervisorProfile]
- * @param {string} [deps.agentProfile]
+ * @param {string} [deps.supervisorProfile] - Supervisor profile name; resolved into the main-thread system prompt via `composeProfilePrompt`.
+ * @param {string} [deps.agentProfile] - Agent profile name; resolved into the main-thread system prompt via `composeProfilePrompt`.
+ * @param {string} [deps.profilesDir] - Directory containing `<name>.md` profile files. Defaults to `<supervisorCwd>/.claude/agents`. Resolved once from the orchestrator's cwd so profiles travel with the project, not with a per-agent sandbox.
  * @returns {Supervisor}
  */
 export function createSupervisor({
@@ -371,7 +374,17 @@ export function createSupervisor({
   supervisorAllowedTools,
   supervisorProfile,
   agentProfile,
+  profilesDir,
 }) {
+  const resolvedProfilesDir =
+    profilesDir ?? resolve(supervisorCwd, ".claude/agents");
+  const systemPromptFor = (profile, trailer) =>
+    profile
+      ? composeProfilePrompt(profile, {
+          profilesDir: resolvedProfilesDir,
+          trailer,
+        })
+      : { type: "preset", preset: "claude_code", append: trailer };
   let supervisor;
   let supervisorRunner;
 
@@ -402,12 +415,7 @@ export function createSupervisor({
     allowedTools,
     onLine,
     settingSources: ["project"],
-    agentProfile,
-    systemPrompt: {
-      type: "preset",
-      preset: "claude_code",
-      append: AGENT_SYSTEM_PROMPT,
-    },
+    systemPrompt: systemPromptFor(agentProfile, AGENT_SYSTEM_PROMPT),
     mcpServers: { orchestration: agentServer },
   });
 
@@ -433,12 +441,7 @@ export function createSupervisor({
     disallowedTools,
     onLine,
     settingSources: ["project"],
-    agentProfile: supervisorProfile,
-    systemPrompt: {
-      type: "preset",
-      preset: "claude_code",
-      append: SUPERVISOR_SYSTEM_PROMPT,
-    },
+    systemPrompt: systemPromptFor(supervisorProfile, SUPERVISOR_SYSTEM_PROMPT),
     mcpServers: { orchestration: supervisorServer },
   });
 

--- a/libraries/libeval/test/fixtures/profile-prompt/no-frontmatter.md
+++ b/libraries/libeval/test/fixtures/profile-prompt/no-frontmatter.md
@@ -1,0 +1,3 @@
+You are the frontmatter-less fixture agent. Your job is to exercise the
+composer's fallback path when a profile file has no YAML fence at all — the
+entire body should land in the SDK `systemPrompt.append` unchanged.

--- a/libraries/libeval/test/fixtures/profile-prompt/with-frontmatter.md
+++ b/libraries/libeval/test/fixtures/profile-prompt/with-frontmatter.md
@@ -1,0 +1,13 @@
+---
+name: with-frontmatter
+description: A fixture profile that carries a YAML frontmatter fence.
+skills:
+  - kata-spec
+  - kata-review
+---
+
+You are the fixture agent. You exist so `composeProfilePrompt` tests can verify
+that the YAML frontmatter is stripped and the markdown body is what lands in the
+SDK's `systemPrompt.append`.
+
+— Fixture 🧪

--- a/libraries/libeval/test/profile-prompt.test.js
+++ b/libraries/libeval/test/profile-prompt.test.js
@@ -1,0 +1,120 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { composeProfilePrompt } from "@forwardimpact/libeval";
+
+const FIXTURES = fileURLToPath(
+  new URL("./fixtures/profile-prompt", import.meta.url),
+);
+const LIVE_PROFILES = fileURLToPath(
+  new URL("../../../.claude/agents", import.meta.url),
+);
+
+describe("composeProfilePrompt", () => {
+  test("returns preset-shaped object", () => {
+    const result = composeProfilePrompt("with-frontmatter", {
+      profilesDir: FIXTURES,
+    });
+    assert.strictEqual(result.type, "preset");
+    assert.strictEqual(result.preset, "claude_code");
+    assert.strictEqual(typeof result.append, "string");
+  });
+
+  test("strips YAML frontmatter", () => {
+    const result = composeProfilePrompt("with-frontmatter", {
+      profilesDir: FIXTURES,
+    });
+    assert.ok(
+      !result.append.includes("---"),
+      "append should not contain the frontmatter fence",
+    );
+    assert.ok(
+      !result.append.includes("description:"),
+      "append should not leak YAML keys",
+    );
+    assert.ok(
+      !result.append.includes("skills:"),
+      "append should not leak the skills list",
+    );
+    assert.ok(
+      result.append.startsWith("You are the fixture agent."),
+      "append should start with the body content",
+    );
+  });
+
+  test("uses entire body when frontmatter is absent", () => {
+    const result = composeProfilePrompt("no-frontmatter", {
+      profilesDir: FIXTURES,
+    });
+    assert.ok(result.append.startsWith("You are the frontmatter-less"));
+  });
+
+  test("concatenates trailer with blank-line separator", () => {
+    const result = composeProfilePrompt("with-frontmatter", {
+      profilesDir: FIXTURES,
+      trailer: "TRAILER_TEXT",
+    });
+    assert.ok(result.append.endsWith("\n\nTRAILER_TEXT"));
+    assert.ok(result.append.includes("You are the fixture agent."));
+  });
+
+  test("omits trailer cleanly when not provided", () => {
+    const result = composeProfilePrompt("with-frontmatter", {
+      profilesDir: FIXTURES,
+    });
+    assert.ok(
+      !result.append.endsWith("\n\n"),
+      "append should not have trailing blank lines when no trailer",
+    );
+  });
+
+  test("treats empty trailer as omitted", () => {
+    const result = composeProfilePrompt("with-frontmatter", {
+      profilesDir: FIXTURES,
+      trailer: "",
+    });
+    assert.ok(!result.append.endsWith("\n\n"));
+  });
+
+  test("throws ENOENT for missing profile", () => {
+    assert.throws(
+      () => composeProfilePrompt("does-not-exist", { profilesDir: FIXTURES }),
+      /ENOENT/,
+    );
+  });
+
+  test("every live .claude/agents profile is loadable (SC#1)", () => {
+    const entries = readdirSync(LIVE_PROFILES, { withFileTypes: true });
+    const profileFiles = entries
+      .filter((e) => e.isFile() && e.name.endsWith(".md"))
+      .map((e) => e.name);
+
+    assert.ok(
+      profileFiles.length > 0,
+      "expected at least one live profile under .claude/agents",
+    );
+
+    for (const fileName of profileFiles) {
+      const name = fileName.slice(0, -".md".length);
+      const result = composeProfilePrompt(name, {
+        profilesDir: LIVE_PROFILES,
+      });
+
+      const raw = readFileSync(`${LIVE_PROFILES}/${fileName}`, "utf8");
+      const bodyStart = raw.indexOf("\n---\n");
+      const body = bodyStart === -1 ? raw : raw.slice(bodyStart + 5);
+      const probe = body.trim().slice(0, 40);
+
+      assert.ok(
+        probe.length > 0,
+        `expected ${fileName} to have non-empty body`,
+      );
+      assert.ok(
+        result.append.includes(probe),
+        `expected composed prompt for ${name} to include body substring "${probe}"`,
+      );
+    }
+  });
+});

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -70,4 +70,4 @@
 500	plan	implemented
 510	design	draft
 520	plan	implemented
-530	plan	approved
+530	plan	implemented


### PR DESCRIPTION
## Summary

- Adds `composeProfilePrompt` — pure loader that reads `.claude/agents/<name>.md`, strips YAML frontmatter, and returns the SDK `{ type: "preset", preset: "claude_code", append }` shape with the profile body and an optional mode-specific trailer in `append`.
- Drops `AgentRunner.agentProfile` and the SDK `options.agent` spread. libeval no longer relies on the SDK's top-level `agent` option for main-thread binding (PR #409 showed it was silently ignored across SDK 0.2.98–0.2.112). CLI flags (`--agent-profile`, `--agent-profiles`, `--supervisor-profile`, `--facilitator-profile`) stay at the boundary and feed the composer exclusively.
- `run`, `supervise`, and `facilitate` each call `composeProfilePrompt` at startup for every main thread they create. `AGENT_SYSTEM_PROMPT`, `SUPERVISOR_SYSTEM_PROMPT`, `FACILITATED_AGENT_SYSTEM_PROMPT`, and `FACILITATOR_SYSTEM_PROMPT` become composer trailers, preserving facilitated/supervised behaviour bit-for-bit.
- `systemPromptFor` helper in supervisor.js and facilitator.js guards against an undefined trailer (addresses the review panel's consensus medium).

Implements spec [530](https://github.com/forwardimpact/monorepo/tree/main/specs/530-agent-profile-main-thread-binding).

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2419 pass / 1 pre-existing skip)
- [x] New `test/profile-prompt.test.js` covers shape, frontmatter strip, trailer, `ENOENT`, plus SC#1 loop over every live `.claude/agents/*.md`
- [x] SC#2 greps — no SDK-binding `agent:` references in `libraries/libeval/src` or `libraries/libeval/bin`:
  - `rg -Un --multiline --pcre2 "(?:^|[{,])\s*\n?\s*agent:\s*[A-Za-z_.]" libraries/libeval/src libraries/libeval/bin`
  - `rg -n "extraArgs.*agent" libraries/libeval/src libraries/libeval/bin`
  - `rg -n '"--agent"' libraries/libeval/src libraries/libeval/bin`
- [ ] SC#3 — voice markers (`— Technical Writer 📝`, `— Security Engineer 🔒`, etc.) appear in the next scheduled run of each agent workflow. Verified post-merge against the next night-shift traces.

https://claude.ai/code/session_015M9qdeowp3XGDEHu3BFGcb