### PR TITLE
feat(libeval): simplify mcp__*__* tool names in tee-writer logs

### DIFF
--- a/libraries/libeval/src/render/tool-hints.js
+++ b/libraries/libeval/src/render/tool-hints.js
@@ -77,8 +77,24 @@ const HINT_HANDLERS = {
 };
 
 /**
+ * Strip the `mcp__<server>__` prefix from MCP-namespaced tool names so logs
+ * show the bare method (e.g. `mcp__orchestration__Tell` → `Tell`). Non-MCP
+ * names and malformed inputs pass through unchanged.
+ * @param {string} name
+ * @returns {string}
+ */
+export function simplifyToolName(name) {
+  if (!name) return "";
+  if (!name.startsWith("mcp__")) return name;
+  const parts = name.split("__");
+  if (parts.length < 3) return name;
+  return parts.slice(2).join("__");
+}
+
+/**
  * MCP-prefixed tool names (e.g. `mcp__orchestration__Tell`) take a different
- * handler path: strip the prefix, then optionally decorate with `to/from`.
+ * handler path. The method name itself is surfaced via `simplifyToolName`,
+ * so this only adds the `to/from` decorators for orchestration calls.
  * Returns null if the name does not match any MCP prefix.
  * @param {string} name
  * @param {object} input
@@ -86,14 +102,13 @@ const HINT_HANDLERS = {
  */
 function hintForMcp(name, input) {
   if (name.startsWith("mcp__orchestration__")) {
-    const method = name.slice("mcp__orchestration__".length);
-    const parts = [method];
+    const parts = [];
     if (input.to) parts.push(`to ${sanitize(input.to)}`);
     if (input.from) parts.push(`from ${sanitize(input.from)}`);
     return truncate(parts.join(" "));
   }
-  if (name.startsWith("mcp__github__")) {
-    return name.slice("mcp__github__".length);
+  if (name.startsWith("mcp__")) {
+    return "";
   }
   return null;
 }

--- a/libraries/libeval/src/tee-writer.js
+++ b/libraries/libeval/src/tee-writer.js
@@ -22,7 +22,11 @@ import {
   renderToolCallLine,
   renderToolResultLine,
 } from "./render/line-renderer.js";
-import { hintForCall, previewForResult } from "./render/tool-hints.js";
+import {
+  hintForCall,
+  previewForResult,
+  simplifyToolName,
+} from "./render/tool-hints.js";
 import { isSuppressedOrchestratorEvent } from "./render/orchestrator-filter.js";
 
 export class TeeWriter extends Writable {
@@ -144,7 +148,7 @@ export class TeeWriter extends Writable {
             this.textStream.write(
               renderToolCallLine({
                 source: turn.source,
-                toolName: block.name,
+                toolName: simplifyToolName(block.name),
                 hint: hintForCall(block.name, block.input),
                 withPrefix,
               }),

--- a/libraries/libeval/src/trace-collector.js
+++ b/libraries/libeval/src/trace-collector.js
@@ -14,7 +14,11 @@ import {
   renderToolCallLine,
   renderToolResultLine,
 } from "./render/line-renderer.js";
-import { hintForCall, previewForResult } from "./render/tool-hints.js";
+import {
+  hintForCall,
+  previewForResult,
+  simplifyToolName,
+} from "./render/tool-hints.js";
 import { isSuppressedOrchestratorEvent } from "./render/orchestrator-filter.js";
 
 export class TraceCollector {
@@ -252,7 +256,7 @@ export class TraceCollector {
             out.push(
               renderToolCallLine({
                 source: turn.source,
-                toolName: block.name,
+                toolName: simplifyToolName(block.name),
                 hint: hintForCall(block.name, block.input),
                 withPrefix,
               }),

--- a/libraries/libeval/test/tee-writer.test.js
+++ b/libraries/libeval/test/tee-writer.test.js
@@ -456,6 +456,37 @@ describe("TeeWriter", () => {
     assert.ok(!toolLine.includes('"'));
   });
 
+  test("simplifies mcp__*__* tool names in the text stream", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({ fileStream, textStream, mode: "raw" });
+
+    const event = JSON.stringify({
+      source: "orchestrator",
+      seq: 0,
+      event: {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "mcp__orchestration__Tell",
+              input: { to: "staff-engineer", message: "go" },
+            },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      },
+    });
+
+    await writeLines(writer, [event]);
+
+    const plain = stripAnsi(collect(textStream));
+    assert.ok(plain.includes("Tell: to staff-engineer"));
+    assert.ok(!plain.includes("mcp__orchestration__Tell"));
+  });
+
   test("defaults to raw mode", () => {
     const writer = new TeeWriter({
       fileStream: new PassThrough(),

--- a/libraries/libeval/test/tee-writer.test.js
+++ b/libraries/libeval/test/tee-writer.test.js
@@ -456,37 +456,6 @@ describe("TeeWriter", () => {
     assert.ok(!toolLine.includes('"'));
   });
 
-  test("simplifies mcp__*__* tool names in the text stream", async () => {
-    const fileStream = new PassThrough();
-    const textStream = new PassThrough();
-    const writer = new TeeWriter({ fileStream, textStream, mode: "raw" });
-
-    const event = JSON.stringify({
-      source: "orchestrator",
-      seq: 0,
-      event: {
-        type: "assistant",
-        message: {
-          content: [
-            {
-              type: "tool_use",
-              id: "t1",
-              name: "mcp__orchestration__Tell",
-              input: { to: "staff-engineer", message: "go" },
-            },
-          ],
-          usage: { input_tokens: 1, output_tokens: 1 },
-        },
-      },
-    });
-
-    await writeLines(writer, [event]);
-
-    const plain = stripAnsi(collect(textStream));
-    assert.ok(plain.includes("Tell: to staff-engineer"));
-    assert.ok(!plain.includes("mcp__orchestration__Tell"));
-  });
-
   test("defaults to raw mode", () => {
     const writer = new TeeWriter({
       fileStream: new PassThrough(),

--- a/libraries/libeval/test/tool-hints.test.js
+++ b/libraries/libeval/test/tool-hints.test.js
@@ -1,7 +1,11 @@
 import { describe, test } from "node:test";
 import assert from "node:assert";
 
-import { hintForCall, previewForResult } from "../src/render/tool-hints.js";
+import {
+  hintForCall,
+  previewForResult,
+  simplifyToolName,
+} from "../src/render/tool-hints.js";
 
 /**
  * Assert a hint contains no `{`, `}`, or `"` characters — success criterion #2.
@@ -140,29 +144,29 @@ describe("hintForCall", () => {
     assert.strictEqual(hint, "summarise the diff");
   });
 
-  test("mcp__orchestration__RollCall — renders method name", () => {
+  test("mcp__orchestration__RollCall — no decorators, empty hint", () => {
     const hint = hintForCall("mcp__orchestration__RollCall", {});
-    assert.strictEqual(hint, "RollCall");
+    assert.strictEqual(hint, "");
   });
 
-  test("mcp__orchestration__Tell — renders method + to", () => {
+  test("mcp__orchestration__Tell — renders to decorator only", () => {
     const hint = hintForCall("mcp__orchestration__Tell", {
       to: "staff-engineer",
       message: "go",
     });
-    assert.strictEqual(hint, "Tell to staff-engineer");
+    assert.strictEqual(hint, "to staff-engineer");
   });
 
-  test("mcp__orchestration__Share — renders method name", () => {
+  test("mcp__orchestration__Share — no decorators, empty hint", () => {
     const hint = hintForCall("mcp__orchestration__Share", {
       message: 'Say "hello"',
     });
-    assert.strictEqual(hint, "Share");
+    assert.strictEqual(hint, "");
   });
 
-  test("mcp__github__list_branches — renders method name", () => {
+  test("mcp__github__list_branches — no decorators, empty hint", () => {
     const hint = hintForCall("mcp__github__list_branches", { owner: "foo" });
-    assert.strictEqual(hint, "list_branches");
+    assert.strictEqual(hint, "");
   });
 
   test("unknown tool — returns empty string", () => {
@@ -186,6 +190,33 @@ describe("hintForCall", () => {
     for (const [name, input] of cases) {
       assertNoJsonPunctuation(hintForCall(name, input));
     }
+  });
+});
+
+describe("simplifyToolName", () => {
+  test("strips mcp__orchestration__ prefix", () => {
+    assert.strictEqual(simplifyToolName("mcp__orchestration__Tell"), "Tell");
+  });
+
+  test("strips mcp__github__ prefix", () => {
+    assert.strictEqual(
+      simplifyToolName("mcp__github__list_branches"),
+      "list_branches",
+    );
+  });
+
+  test("preserves method with embedded __", () => {
+    assert.strictEqual(simplifyToolName("mcp__server__foo__bar"), "foo__bar");
+  });
+
+  test("non-mcp names pass through unchanged", () => {
+    assert.strictEqual(simplifyToolName("Bash"), "Bash");
+    assert.strictEqual(simplifyToolName("TodoWrite"), "TodoWrite");
+  });
+
+  test("empty and malformed names return safely", () => {
+    assert.strictEqual(simplifyToolName(""), "");
+    assert.strictEqual(simplifyToolName("mcp__only"), "mcp__only");
   });
 });
 


### PR DESCRIPTION
## Summary

- Log output now shows bare method names (e.g. `Tell` instead of `mcp__orchestration__Tell`) via a new `simplifyToolName` helper applied in both `TeeWriter` and `TraceCollector.toText()`.
- `hintForMcp` no longer duplicates the method name in the hint — it only carries `to`/`from` decorators for orchestration calls.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (217 libeval tests pass)