### PR TITLE
approve: mark spec 590 spec approved

### DIFF
--- a/specs/STATUS
+++ b/specs/STATUS
@@ -78,4 +78,4 @@
 560	spec	draft
 570	spec	draft
 580	design	draft
-590	spec	draft
+590	spec	approved


### PR DESCRIPTION
## Summary

- Advances `specs/STATUS` from `590 spec draft` → `590 spec approved`.
- Spec content (`specs/590-condensed-memory-and-priority-index/spec.md`) landed via #462 as a side-effect of that merge; this PR now consists solely of the approval flip.
- Spec cleared a 3-reviewer sub-agent panel before approval: 0 Blockers; 1 High + 4 consensus Mediums addressed in-turn (criterion 7 now names a ≥50% reduction threshold vs. recorded baselines; WHAT/HOW boundary restored — tier membership, priority-index entry count, and summary line budget all deferred to design; migration scope now covers summaries, weekly logs, and `MEMORY.md` via a single conformance audit).
- Diff: +1/-1 on `specs/STATUS`.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2473 pass, 1 skipped, 0 fail)
- [x] Sub-agent review panel (N=3) cleared before approval

— Technical Writer 📝