### PR TITLE
fix(libeval): honor maxTurns=0 as unlimited in AgentRunner

### DIFF
--- a/.github/workflows/agent-staff-engineer.yml
+++ b/.github/workflows/agent-staff-engineer.yml
@@ -54,5 +54,5 @@ jobs:
             highest-priority finding.
           agent-profile: "staff-engineer"
           model: "claude-opus-4-6"
-          max-turns: "0"
+          max-turns: "300"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-staff-engineer.yml
+++ b/.github/workflows/agent-staff-engineer.yml
@@ -54,5 +54,5 @@ jobs:
             highest-priority finding.
           agent-profile: "staff-engineer"
           model: "claude-opus-4-6"
-          max-turns: "300"
+          max-turns: "0"
           task-amend: ${{ inputs.task-amend }}

--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -38,7 +38,7 @@ export class AgentRunner {
    * @param {function} deps.query - SDK query function (injected for testing)
    * @param {import("stream").Writable} deps.output - Stream to emit NDJSON to
    * @param {string} [deps.model] - Claude model identifier
-   * @param {number} [deps.maxTurns] - Maximum agentic turns
+   * @param {number} [deps.maxTurns] - Maximum agentic turns; 0 means unlimited
    * @param {string[]} [deps.allowedTools] - Tools the agent may use
    * @param {function} [deps.onLine] - Callback invoked with each NDJSON line as it's produced
    * @param {function} [deps.onBatch] - Async callback invoked with a batch of NDJSON lines at flush boundaries: every `batchSize` assistant text blocks, the terminal `result` message, and — on iterator crash/abort — once more in a final flush carrying any lines that never reached a boundary. Receives `(lines, { abort })` where calling `abort()` stops the in-flight SDK session via the AbortController. Optional; assignable at runtime so the Supervisor can swap it per turn.
@@ -73,7 +73,8 @@ export class AgentRunner {
         options: {
           cwd: this.cwd,
           allowedTools: this.allowedTools,
-          ...(this.maxTurns > 0 && { maxTurns: this.maxTurns }),
+          maxTurns:
+            this.maxTurns === 0 ? Number.MAX_SAFE_INTEGER : this.maxTurns,
           model: this.model,
           permissionMode: PERMISSION_MODE,
           allowDangerouslySkipPermissions: true,

--- a/libraries/libeval/test/agent-runner.test.js
+++ b/libraries/libeval/test/agent-runner.test.js
@@ -159,6 +159,28 @@ describe("AgentRunner", () => {
     assert.deepStrictEqual(captured.options.settingSources, ["project"]);
   });
 
+  test("run() forwards maxTurns=0 as MAX_SAFE_INTEGER (unlimited)", async () => {
+    let captured = null;
+    const query = mockQuery(
+      [{ type: "result", subtype: "success", result: "OK" }],
+      (params) => {
+        captured = params;
+      },
+    );
+
+    const output = new PassThrough();
+    const runner = new AgentRunner({
+      cwd: "/work",
+      query,
+      output,
+      maxTurns: 0,
+    });
+
+    await runner.run("Task");
+
+    assert.strictEqual(captured.options.maxTurns, Number.MAX_SAFE_INTEGER);
+  });
+
   test("run() returns success=false on non-success subtype", async () => {
     const messages = [{ type: "result", subtype: "error", result: "Stopped" }];
 


### PR DESCRIPTION
## Summary

- `AgentRunner` was spreading `maxTurns` into the SDK query only when `> 0`, so callers that passed `0` meaning "unlimited" (the convention already used by `Supervisor`, see `libraries/libeval/src/supervisor.js:95`) silently fell back to the SDK's ~50-turn default.
- This capped `Agent: Staff Engineer` runs at turn 51. Three of the last five runs ended in `error_max_turns` (runs `24612539194`, `24665765111`, `24754625530`) — one was truncated mid-`kata-design` for spec 550.
- Fix: always forward `maxTurns` to the SDK and map `0 → Number.MAX_SAFE_INTEGER` so the SDK is still bounded but effectively never hits the cap.
- No workflow change needed — `agent-staff-engineer.yml` already sets `max-turns: "0"`, which now does what it was intended to do.
- Added a unit test pinning the `maxTurns=0 → MAX_SAFE_INTEGER` behavior.

## Test plan

- [x] `bun run check`
- [x] `bun run test` — 2337/2338 pass (1 pre-existing skip), 217/217 in libeval

— Staff Engineer 🛠️