### PR TITLE
feat(libeval): detect repo slug for fit-trace --repo default

### DIFF
--- a/libraries/libeval/bin/fit-trace.js
+++ b/libraries/libeval/bin/fit-trace.js
@@ -42,7 +42,8 @@ const definition = {
         },
         repo: {
           type: "string",
-          description: "GitHub repo override (default: git remote)",
+          description:
+            "GitHub repo override (default: $GITHUB_REPOSITORY or 'origin' git remote)",
         },
       },
     },
@@ -55,7 +56,8 @@ const definition = {
         artifact: { type: "string", description: "Artifact name override" },
         repo: {
           type: "string",
-          description: "GitHub repo override (default: git remote)",
+          description:
+            "GitHub repo override (default: $GITHUB_REPOSITORY or 'origin' git remote)",
         },
       },
     },

--- a/libraries/libeval/src/index.js
+++ b/libraries/libeval/src/index.js
@@ -3,6 +3,7 @@ export { TraceQuery, createTraceQuery } from "./trace-query.js";
 export {
   TraceGitHub,
   createTraceGitHub,
+  detectRepoSlug,
   parseGitRemote,
 } from "./trace-github.js";
 export { AgentRunner, createAgentRunner } from "./agent-runner.js";

--- a/libraries/libeval/src/trace-github.js
+++ b/libraries/libeval/src/trace-github.js
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { createWriteStream } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
@@ -116,7 +117,6 @@ export class TraceGitHub {
     // Stream to disk then extract.
     await pipeline(Readable.fromWeb(response.body), createWriteStream(zipPath));
 
-    const { execSync } = await import("node:child_process");
     execSync(
       `unzip -o -q ${JSON.stringify(zipPath)} -d ${JSON.stringify(dir)}`,
     );
@@ -182,7 +182,49 @@ export function parseGitRemote(remote) {
   const simple = remote.match(/^([^/:@]+)\/([^/]+)$/);
   if (simple) return { owner: simple[1], repo: simple[2] };
 
+  // Generic URL fallback: any remote whose path ends in /owner/repo(.git)?
+  // Covers GitHub Enterprise, proxied git URLs, and mirrors.
+  const generic = remote.match(/[/:]([^/:@?#]+)\/([^/:@?#]+?)(?:\.git)?\/?$/);
+  if (generic) return { owner: generic[1], repo: generic[2] };
+
   throw new Error(`Cannot parse GitHub remote: ${remote}`);
+}
+
+/**
+ * Detect the current GitHub repository slug as `{owner, repo}`.
+ *
+ * Resolution order:
+ *   1. `GITHUB_REPOSITORY` env var (set automatically by GitHub Actions).
+ *   2. `git remote get-url origin` in the current working directory.
+ *
+ * @returns {{owner: string, repo: string}}
+ * @throws {Error} with a clear message if neither source yields a parseable slug.
+ */
+export function detectRepoSlug() {
+  const env = process.env.GITHUB_REPOSITORY;
+  if (env && env.trim()) {
+    return parseGitRemote(env.trim());
+  }
+
+  let remote;
+  try {
+    remote = execSync("git remote get-url origin", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    throw new Error(
+      "Cannot detect repository: set --repo <owner/repo>, export GITHUB_REPOSITORY, or run inside a git checkout with an 'origin' remote.",
+    );
+  }
+
+  if (!remote) {
+    throw new Error(
+      "Cannot detect repository: 'git remote get-url origin' returned an empty value. Pass --repo <owner/repo> or set GITHUB_REPOSITORY.",
+    );
+  }
+
+  return parseGitRemote(remote);
 }
 
 /**
@@ -207,16 +249,9 @@ export async function createTraceGitHub(opts = {}) {
     );
   }
 
-  let owner, repo;
-  if (repoOverride) {
-    ({ owner, repo } = parseGitRemote(repoOverride));
-  } else {
-    const { execSync } = await import("node:child_process");
-    const remote = execSync("git remote get-url origin", {
-      encoding: "utf8",
-    }).trim();
-    ({ owner, repo } = parseGitRemote(remote));
-  }
+  const { owner, repo } = repoOverride
+    ? parseGitRemote(repoOverride)
+    : detectRepoSlug();
 
   return new TraceGitHub({ token, owner, repo });
 }

--- a/libraries/libeval/test/trace-github.test.js
+++ b/libraries/libeval/test/trace-github.test.js
@@ -1,7 +1,11 @@
 import { describe, test } from "node:test";
 import assert from "node:assert";
 
-import { createTraceGitHub, parseGitRemote } from "@forwardimpact/libeval";
+import {
+  createTraceGitHub,
+  detectRepoSlug,
+  parseGitRemote,
+} from "@forwardimpact/libeval";
 
 describe("parseGitRemote", () => {
   test("parses SSH remote", () => {
@@ -44,6 +48,51 @@ describe("parseGitRemote", () => {
     const result = parseGitRemote("git@github.com:acme/widgets.git");
     assert.strictEqual(result.owner, "acme");
     assert.strictEqual(result.repo, "widgets");
+  });
+});
+
+describe("detectRepoSlug", () => {
+  function withEnv(vars, fn) {
+    const saved = {};
+    for (const key of Object.keys(vars)) {
+      saved[key] = process.env[key];
+      if (vars[key] === undefined) delete process.env[key];
+      else process.env[key] = vars[key];
+    }
+    try {
+      return fn();
+    } finally {
+      for (const key of Object.keys(saved)) {
+        if (saved[key] === undefined) delete process.env[key];
+        else process.env[key] = saved[key];
+      }
+    }
+  }
+
+  test("reads GITHUB_REPOSITORY when set", () => {
+    const result = withEnv(
+      { GITHUB_REPOSITORY: "forwardimpact/monorepo" },
+      () => detectRepoSlug(),
+    );
+    assert.strictEqual(result.owner, "forwardimpact");
+    assert.strictEqual(result.repo, "monorepo");
+  });
+
+  test("ignores blank GITHUB_REPOSITORY and falls back to git remote", () => {
+    const result = withEnv({ GITHUB_REPOSITORY: "   " }, () =>
+      detectRepoSlug(),
+    );
+    assert.ok(result.owner);
+    assert.ok(result.repo);
+  });
+
+  test("falls back to git remote when GITHUB_REPOSITORY is unset", () => {
+    const result = withEnv({ GITHUB_REPOSITORY: undefined }, () =>
+      detectRepoSlug(),
+    );
+    // We're running inside this monorepo, so origin should resolve.
+    assert.ok(result.owner);
+    assert.ok(result.repo);
   });
 });
 


### PR DESCRIPTION
## Summary

- Extract `detectRepoSlug()` in `libraries/libeval/src/trace-github.js` — reads `GITHUB_REPOSITORY` (set by GitHub Actions), falls back to `git remote get-url origin`, throws a clear error if neither resolves.
- Wire `createTraceGitHub()` through the new helper and export it from the libeval package.
- Generalize `parseGitRemote()` with a URL-path fallback so GitHub Enterprise / proxied remotes also parse.
- Update `fit-trace` `--repo` help: `(default: $GITHUB_REPOSITORY or 'origin' git remote)`.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (220 pass, 0 fail)
- [x] `fit-trace runs --help` shows the updated default description