### PR TITLE
fix(claude): scope allow rules to skills and agents subdirs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,12 @@
   },
   "permissions": {
     "defaultMode": "acceptEdits",
-    "allow": ["Edit(.claude/**)", "Write(.claude/**)", "Bash(sed:*.claude/**)"]
+    "allow": [
+      "Edit(.claude/skills/**)",
+      "Edit(.claude/agents/**)",
+      "Write(.claude/skills/**)",
+      "Write(.claude/agents/**)"
+    ]
   },
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
## Summary

- Kata-trace of [run 24756152077](https://github.com/forwardimpact/monorepo/actions/runs/24756152077/job/72429696271) shows PR #467's broad `Edit(.claude/**)` / `Write(.claude/**)` allow rules still get denied when scheduled agents write under `.claude/skills/**`, despite `bypassPermissions` mode and `defaultMode: acceptEdits`.
- Per the [Claude Code permission docs](https://code.claude.com/docs/en/permissions), `bypassPermissions` hardcodes an ask-style prompt for writes under `.claude` (alongside `.git`, `.vscode`, `.idea`, `.husky`) to prevent self-modification, with a narrow path-based exemption for `.claude/commands`, `.claude/agents`, and `.claude/skills`. Rule precedence is `deny → ask → allow`, so the broad `.claude/**` allow rule was shadowed by the hardcoded ask guard.
- Narrow the allow list to `.claude/skills/**` and `.claude/agents/**` — the directories scheduled agents actually need to write. These match the documented exemption and deliberately do not cover `.claude/settings.json`, preserving the guard against self-modification.
- Drop `Bash(sed:*.claude/**)`: per docs, `:*` is only recognised at end of pattern, so the rule never matched. Edit/Write alone is enough — agents fell back to sed only because Edit was denied.
- Unblocks #441 without a staging mechanism.

## Test plan

- [x] `bun run check`
- [x] `bun run test`
- [ ] Next scheduled agent run successfully edits a file under `.claude/skills/**`