### PR TITLE
docs(kata): require push + PR as universal exit gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,9 @@ Exit gate — verify every item before committing.
 - [ ] My diff only contains changes the task required — no unrequested
       refactors, no scope creep.
 - [ ] Commit format: `type(scope): subject` (see § Git Conventions).
-- [ ] If the run produced commits on a `fix/` or `spec/` branch: branch pushed
-      (`git push -u origin <branch>`) and PR URL captured in output. Exception:
-      release engineer's direct-to-`main` CI fixes.
+- [ ] If the run produced commits: branch pushed with `git push -u origin` and
+      PR URL captured in output. Exception: release engineer's direct-to-`main`
+      CI fixes.
 
 </do_confirm_checklist>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,13 +62,16 @@ Entry gate — read every item before starting.
 
 Exit gate — verify every item before committing.
 
-<do_confirm_checklist goal="Verify quality before committing">
+<do_confirm_checklist goal="Verify quality and publish before finishing">
 
 - [ ] `bun run check` passes — format and lint, all file types.
 - [ ] `bun run test` passes — new logic has tests.
 - [ ] My diff only contains changes the task required — no unrequested
       refactors, no scope creep.
 - [ ] Commit format: `type(scope): subject` (see § Git Conventions).
+- [ ] If the run produced commits on a `fix/` or `spec/` branch: branch pushed
+      (`git push -u origin <branch>`) and PR URL captured in output. Exception:
+      release engineer's direct-to-`main` CI fixes.
 
 </do_confirm_checklist>
 
@@ -144,7 +147,9 @@ path from `config/config.example.json`), plus `proto/`, `src/`, `test/`, and
 
 All changes go through pull requests — never push directly to `main`.
 
-**Always commit your work before finishing a task.**
+**Always commit, push, and open a PR before finishing a task.** A local commit
+on a scheduled-run ephemeral runner is lost work — the PR URL is the only valid
+"done" signal. Commit alone is not finishing.
 
 **Exception:** The release engineer may push trivial CI fixes (formatting, lint,
 lock file drift) directly to `main` — limited to what `bun run check:fix` can

--- a/KATA.md
+++ b/KATA.md
@@ -53,10 +53,11 @@ graph LR
 - **Study** — Analyze outputs from Do. Four streams: security posture audits,
   external feedback triage, documentation review (one topic deep per cycle), and
   trace analysis (one trace deep per cycle via grounded theory).
-- **Act** — Convert findings into action. Trivial findings become fix PRs
-  directly; structural findings become new `spec.md` documents entering the
-  backlog. Fix PRs (`fix/` branches) and specs (`spec/` branches) are never
-  mixed.
+- **Act** — Convert findings into action. Trivial findings become **pushed fix
+  PRs** directly; structural findings become new `spec.md` documents on **pushed
+  spec branches** entering the backlog. A local commit is not a PR — the URL is
+  the only valid completion signal. Fix PRs (`fix/` branches) and specs (`spec/`
+  branches) are never mixed.
 
 ## Agents
 
@@ -171,7 +172,9 @@ through the autonomous pipeline — specs merge only the document, not code.
 
 Agents share persistent memory via the **GitHub wiki** at `wiki/`. Cloned on
 demand and synced by `just wiki-pull` (on `SessionStart`) and `just wiki-push`
-(on `Stop`).
+(on `Stop`). The wiki is a separate checkout, not a git submodule — `wiki/` is
+gitignored in the main repo. Wiki commits are published only by the `Stop` hook;
+never `git add wiki` into a main-repo commit.
 
 Each agent maintains two file types:
 
@@ -349,6 +352,16 @@ Entry-point skills embed domain-specific checklists; universal checklists live
 in CONTRIBUTING.md. See [CHECKLISTS.md](CHECKLISTS.md) for design rules, type
 selection, and authoring guidance.
 
+### Publishing as a gate
+
+Autonomous agents default to human-loop handoff phrasing ("ready for PR when
+you'd like me to push") when no exit criterion requires external state change —
+they finish at the last locally-verifiable action. Any skill whose output is
+code (`fix/` or `spec/` branches) must rely on the universal DO-CONFIRM's push +
+PR item as its publishing gate; publishing steps described only in L6 procedural
+prose correlate with agents stopping after local commit on ephemeral runners,
+losing the work.
+
 ### Recursion-safe self-review
 
 Skills requiring independent review of their output must spawn a fresh sub-agent
@@ -363,7 +376,9 @@ caller protocol for panel sizes and merge algorithm.
 
 Use identical wording for shared structural elements (memory instructions,
 prerequisites, section headings) across all agents and skills. Inconsistent
-wording correlated with agents skipping steps in trace analysis.
+wording correlated with agents skipping steps in trace analysis. Act-phase
+skills (those producing `fix/` or `spec/` branches) defer to the universal
+DO-CONFIRM for publishing — no skill restates the push + PR gate.
 
 ### SDK caveat
 


### PR DESCRIPTION
## Summary

Autonomous agents were stopping at local commit with human-loop handoff phrasing ("ready for PR when you'd like me to push") because neither the universal DO-CONFIRM nor the Act definition named publishing as an exit criterion — only L6 procedural prose described it, and agents finish at the last item on the checklist. Grounded in trace run [24755944348](https://github.com/forwardimpact/monorepo/actions/runs/24755944348) (agent-technical-writer, 2026-04-22), where three real doc fixes were committed on a `fix/` branch on an ephemeral runner and then lost when the agent announced readiness instead of pushing.

- **CONTRIBUTING.md DO-CONFIRM** (L3 universal exit gate) — add push + PR URL item with release-engineer direct-to-`main` carve-out. Vocabulary-agnostic: "if the run produced commits," not kata-specific branch prefixes.
- **CONTRIBUTING.md Pull Request Workflow** — strengthen "always commit" to "always commit, push, and open a PR" — name the ephemeral-runner loss risk.
- **KATA.md Act** — trivial findings become "pushed fix PRs"; local commit is not a PR.
- **KATA.md Shared Memory** — clarify wiki is a separate checkout, not a git submodule; never `git add wiki` into a main-repo commit.
- **KATA.md Publishing as a gate** (new authoring subsection) — capture the trace-analysis lesson.
- **KATA.md Shared patterns** — act-phase skills defer to the universal DO-CONFIRM for publishing; no skill restates the gate.

## Test plan

- [x] `bun run check` passes
- [x] `bun run test` passes (2340/2341, 1 skipped)
- [x] `scripts/check-instructions.mjs` passes — all instruction-length limits respected

— Technical Writer 📝