### PR TITLE
feat(justfile): split install into install-bun and install-gh

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,10 +15,17 @@ wiki-pull:
 wiki-push:
     bash scripts/wiki-sync.sh push
 
-# Install dependencies and generate code
-install: wiki-pull
+# Install dependencies and tooling
+install: wiki-pull install-bun install-gh
+
+# Install bun dependencies and generate code
+install-bun:
     bun install --frozen-lockfile
     bunx --workspace=@forwardimpact/libcodegen fit-codegen --all
+
+# Install the GitHub CLI (gh)
+install-gh:
+    bash scripts/install-gh.sh
 
 # Bootstrap from scratch
 quickstart: env-setup synthetic data-init codegen process-fast _quickstart-seed

--- a/scripts/install-gh.sh
+++ b/scripts/install-gh.sh
@@ -1,18 +1,30 @@
 #!/usr/bin/env bash
-# Install the GitHub CLI (gh) from the official tarball.
+# Install the GitHub CLI (gh).
 # Usage: install-gh.sh [version]
 #
-# The tarball method is preferred over apt-get because sandboxed environments
-# often fail GPG key verification.
+# Tries brew first, then falls back to the official tarball. The tarball
+# method is preferred over apt-get because sandboxed environments often
+# fail GPG key verification.
 
 set -euo pipefail
 
 VERSION="${1:-2.63.2}"
-ARCH=$(dpkg --print-architecture 2>/dev/null || echo "amd64")
 
-wget -q "https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.tar.gz" \
-  -O /tmp/gh.tar.gz
-tar -xzf /tmp/gh.tar.gz -C /tmp
+if command -v gh &>/dev/null; then
+  echo "gh already installed: $(gh --version | head -1)"
+  exit 0
+fi
+
+if command -v brew &>/dev/null; then
+  brew install gh
+  echo "Installed gh via brew: $(gh --version | head -1)"
+  exit 0
+fi
+
+ARCH=$(dpkg --print-architecture 2>/dev/null || echo "amd64")
+URL="https://github.com/cli/cli/releases/download/v${VERSION}/gh_${VERSION}_linux_${ARCH}.tar.gz"
+
+wget -qO- "$URL" | tar -xz -C /tmp
 cp "/tmp/gh_${VERSION}_linux_${ARCH}/bin/gh" /usr/local/bin/gh
 
 echo "Installed gh $(gh --version | head -1)"


### PR DESCRIPTION
## Summary

- Make `just install` an entry point that dispatches to `install-bun` (bun deps + codegen) and `install-gh` (GitHub CLI).
- New `just install-gh` target runs `scripts/install-gh.sh`.
- `install-gh.sh` now skips if `gh` is already installed, prefers `brew install gh`, and falls back to a single `wget -qO- | tar -xz -C /tmp` pipe (replacing the previous two-step download-then-extract).

## Test plan

- [x] `just --list` shows `install`, `install-bun`, `install-gh`
- [x] `bun run check`
- [x] `bun run test`
- [x] `bash -n scripts/install-gh.sh`
