### PR TITLE
fix(guide): remove residual agent processing (closes #477)

### DIFF
--- a/libraries/libharness/src/mock/resource-index.js
+++ b/libraries/libharness/src/mock/resource-index.js
@@ -34,31 +34,16 @@ export function createMockResourceIndex(options = {}) {
     /**
      * Sets up default test resources
      * @param {object} setupOptions - Setup options
-     * @param {string[]} [setupOptions.tools] - Tool names for agent
+     * @param {string[]} [setupOptions.tools] - Tool names to seed
      * @param {string} [setupOptions.conversationId] - Conversation ID
-     * @param {string} [setupOptions.agentId] - Agent ID
      */
     setupDefaults(setupOptions = {}) {
-      const {
-        tools = [],
-        conversationId = "test-conversation",
-        agentId = "test-agent",
-      } = setupOptions;
+      const { tools = [], conversationId = "test-conversation" } = setupOptions;
 
       resources.set(
         conversationId,
         common.Conversation.fromObject({
           id: { name: conversationId },
-          agent_id: `common.Agent.${agentId}`,
-        }),
-      );
-
-      resources.set(
-        `common.Agent.${agentId}`,
-        common.Agent.fromObject({
-          id: { name: agentId, tokens: 50 },
-          tools,
-          content: "You are a test agent.",
         }),
       );
 
@@ -102,7 +87,7 @@ export function createMockResourceIndex(options = {}) {
     },
   };
 
-  if (options.tools || options.conversationId || options.agentId) {
+  if (options.tools || options.conversationId) {
     index.setupDefaults(options);
   }
 

--- a/libraries/libtelemetry/src/attributes.js
+++ b/libraries/libtelemetry/src/attributes.js
@@ -19,10 +19,6 @@ export const TELEMETRY_ATTRIBUTES_MAP = [
   { key: "tools", type: "count" },
   { key: "tool_call_id", type: "string" },
 
-  // Agent/handoff identification
-  { key: "agent_id", type: "string" },
-  { key: "label", type: "string" },
-
   // Query
   { key: "input", type: "first" },
   { key: "subject", type: "string" },

--- a/libraries/libtype/src/index.js
+++ b/libraries/libtype/src/index.js
@@ -13,11 +13,8 @@ export { metadata } from "./generated/types/metadata.js";
 const {
   common = {},
   resource = {},
-  agent = {},
-  llm = {},
   vector = {},
   graph = {},
-  memory = {},
   tool = {},
   trace = {},
 } = types;
@@ -76,7 +73,6 @@ function withIdentifier(parent, subjects) {
   }
 }
 
-common.Agent.prototype.withIdentifier = withIdentifier;
 common.Conversation.prototype.withIdentifier = withIdentifier;
 common.Message.prototype.withIdentifier = withIdentifier;
 tool.ToolFunction.prototype.withIdentifier = withIdentifier;
@@ -137,19 +133,6 @@ common.Conversation.fromObject = function (object) {
 };
 
 /**
- * Monkey-patches for common.Agent
- */
-const AgentCtor = common.Agent;
-const AgentfromObject = AgentCtor.fromObject;
-
-// Monkey-patch Agent.fromObject to apply identifier
-common.Agent.fromObject = function (object) {
-  const typed = AgentfromObject(object);
-  typed.withIdentifier();
-  return typed;
-};
-
-/**
  * Monkey-patches for tool.ToolFunction
  */
 const ToolFunctionCtor = tool.ToolFunction;
@@ -190,11 +173,8 @@ export {
   // Export all namespaces with any applied patches
   common,
   resource,
-  agent,
-  llm,
   vector,
   graph,
-  memory,
   tool,
   trace,
 };

--- a/libraries/libvector/src/processor/vector.js
+++ b/libraries/libvector/src/processor/vector.js
@@ -36,12 +36,11 @@ export class VectorProcessor extends ProcessorBase {
     // 1. Get all resource identifiers
     const identifiers = await this.#resourceIndex.findAll();
 
-    // 2. Filter out conversations, their child resources, tool functions, and agents
+    // 2. Filter out conversations, their child resources, and tool functions
     const filteredIdentifiers = identifiers.filter(
       (id) =>
         !String(id).startsWith("common.Conversation") &&
-        !String(id).startsWith("tool.ToolFunction") &&
-        !String(id).startsWith("common.Agent"),
+        !String(id).startsWith("tool.ToolFunction"),
     );
 
     // 3. Load the full resources using the identifiers

--- a/products/guide/proto/common.proto
+++ b/products/guide/proto/common.proto
@@ -36,7 +36,6 @@ message Embeddings {
 
 message Conversation {
   resource.Identifier id = 1;
-  optional string agent_id = 2;
 }
 
 message Message {
@@ -45,20 +44,4 @@ message Message {
   string content = 3;
   repeated tool.ToolCall tool_calls = 4;
   optional string tool_call_id = 5;
-}
-
-message Handoff {
-  string label = 1;
-  string agent = 2;
-  string prompt = 3;
-}
-
-message Agent {
-  resource.Identifier id = 1;
-  string name = 2;
-  string description = 3;
-  bool infer = 4;
-  repeated string tools = 5;
-  repeated Handoff handoffs = 6;
-  string content = 7;
 }


### PR DESCRIPTION
## Summary

Spec 580 retired Guide's bespoke agent harness, but the `Agent` / `Handoff`
proto messages, the `Conversation.agent_id` field, libtype monkey-patches,
libvector/libharness filters, and telemetry attributes for `common.Agent`
were left behind. With no processor populating these resources, lookups
still tried to resolve them and failed with
`Agent not found: common.Agent.planner` (issue #477).

This change removes the remaining surfaces so the pipeline has nothing
to resolve:

- `products/guide/proto/common.proto` — dropped `Agent`, `Handoff`,
  and `Conversation.agent_id`
- `libraries/libtype/src/index.js` — removed `common.Agent` monkey-patches
  and unused `agent` / `llm` / `memory` namespace imports
- `libraries/libvector/src/processor/vector.js` — dropped obsolete
  `common.Agent` filter
- `libraries/libharness/src/mock/resource-index.js` — removed dead
  `common.Agent` setup from `setupDefaults`
- `libraries/libtelemetry/src/attributes.js` — dropped `agent_id` and
  handoff `label` span attributes

## Test plan

- [x] `just codegen` regenerates types without `Agent` / `Handoff` / `agent_id`
- [x] `bun run check`
- [x] `bun run test` — 2340 pass, 1 skipped, 0 fail
- [x] `products/guide/test/parity/zero-residue.sh` passes

https://claude.ai/code/session_01NFpojKFY3f27tkiYkcaknQ