### PR TITLE
docs(specs): spec 600 native binary distribution via Homebrew

### DIFF
--- a/specs/600-native-binary-distribution/design.md
+++ b/specs/600-native-binary-distribution/design.md
@@ -28,10 +28,10 @@ ES module — it becomes the `bun build --compile` entry unchanged. The
 `#!/usr/bin/env node` shebang is a no-op in a compiled binary and the npm path
 keeps using it, so no source rewrite is needed.
 
-**Recipe shape.** One **parameterized recipe** `build-binary CLI TARGET` drives
-`bun build --compile --minify --sourcemap=none --target=bun-<TARGET>`. A
-top-level `build-binaries` recipe fans out over the seven CLIs for the default
-target (`darwin-arm64`).
+**Recipe shape.** One **parameterized recipe** `build-binary CLI TARGET` invokes
+bun's compile bundler for a CLI × target triple. A top-level `build-binaries`
+recipe fans out over the seven CLIs for the default target (`darwin-arm64`).
+Exact flag set is a plan concern.
 
 | Field          | Value                                                     |
 | -------------- | --------------------------------------------------------- |
@@ -84,8 +84,8 @@ keeping one trigger shape means one `git tag` launches both channels.
 **Artifact naming.** `fit-<cli>-<version>-<os>-<arch>` (e.g.
 `fit-pathway-0.25.32-darwin-arm64`). Version in the filename keeps old release
 assets immutable and gives casks a stable, versioned URL. A matching `.sha256`
-sidecar is uploaded alongside each binary via
-`shasum -a 256 <file> > <file>.sha256`.
+sidecar is uploaded alongside each binary so casks can pin the hash without a
+separate manifest file.
 
 **Interaction with `publish-npm.yml`.** Two independent workflows on the same
 trigger; both read `products/<cli>/package.json` for the version, so npm and
@@ -116,10 +116,11 @@ install prebuilt artifacts. Our binaries ship prebuilt from CI, and casks unlock
 | `livecheck`  | GitHub Releases API, `<cli>@v*` tag series                                |
 | `zap`        | no-op — CLIs are stateless; user data in `data/*` is theirs               |
 
-**Update automation — chosen: PR via PAT.** The `tap-pr` job clones
-`forwardimpact/homebrew-tap`, updates `version` and `sha256` in the relevant
-`Casks/fit-<cli>.rb`, and opens a PR `chore: bump fit-<cli> to <version>`. Repo
-secret `HOMEBREW_TAP_PAT` scopes to the tap repo only.
+**Update automation — chosen: PR via PAT.** The `tap-pr` job proposes a cask
+update against `forwardimpact/homebrew-tap` via a pull request that carries the
+new `version` and `sha256`. Authentication is a repo secret
+`HOMEBREW_TAP_PAT` scoped to the tap repo only. PR title, body, and commit
+message shape are plan concerns.
 
 **Rejected — `homebrew-releaser` action.** Opinionated about formula shape, less
 flexible for per-cask `arch` gating, and hides the diff from review.
@@ -156,25 +157,37 @@ expansion, not a redesign.
 
 ## Component 6 — Version sync (single source of truth)
 
-The **git tag** `<cli>@v<version>` is the single source of truth. Flow:
+The **git tag** `<cli>@v<version>` is the single source of truth for both
+channels. `publish-npm.yml` and `publish-brew.yml` resolve the version from the
+same `products/<cli>/package.json` at the tagged commit; since both read the
+same file in the same commit, npm and brew cannot carry different version
+numbers for a given tag. The two channels can lag only in publication timing —
+npm publishes directly, while brew publication waits on the tap PR being merged
+by a human. No cross-workflow state is shared; the invariant is enforced by the
+common tag + common file.
 
-1. Developer runs release-please (or `git tag cli@vX.Y.Z`).
-2. Tag push fires both `publish-npm.yml` and `publish-brew.yml`.
-3. `publish-npm.yml` reads `products/<cli>/package.json` and publishes to npm.
-4. `publish-brew.yml` reads the same `package.json`, builds binaries, uploads
-   release assets, and opens the tap PR using that version.
-5. Merging the tap PR makes `brew upgrade` available.
+**Rejected — a release manifest file.** Adds a second source of truth that can
+drift from `package.json`; the tag already serialises the version.
 
-Both workflows read the same file in the same commit — versions cannot diverge,
-only timing (tap PR awaits human merge).
+## Component 7 — Per-product documentation
+
+Spec SC6 requires every affected product's Overview page to document the brew
+install flow. Each `website/<product>/index.md` gains an **Install** section (or
+extends the existing one) with two blocks: npm (unchanged) and brew (the
+`brew tap` + `brew install` invocation and the Gatekeeper-warning caveat).
+Docs live in the monorepo and ship through the existing website workflow — no
+new publishing surface.
+
+**Rejected — a single shared install page.** Per-product pages are the entry
+points external users land on; cross-linking to a shared page doubles the click
+count on the first-install path.
 
 ## Open questions for plan phase
 
-- **Exact justfile syntax** for the `build-binaries` fan-out over the CLI list.
-- **Exact workflow YAML**, including bun-install cache keys across matrix jobs.
-- **Tap repo bootstrap**: `forwardimpact/homebrew-tap` creation,
-  `HOMEBREW_TAP_PAT` provisioning, seeding initial cask files.
-- **Gatekeeper UX copy** on per-product Overview pages — exact
-  `xattr -d com.apple.quarantine` guidance (signing is deferred per spec).
-- **Release-notes template** — whether `publish-brew.yml` appends a brew install
-  snippet to the `gh release` body.
+- **Tap repo bootstrap.** Whether `forwardimpact/homebrew-tap` is created fresh,
+  seeded with empty casks the first release populates, or seeded with a manual
+  initial cask. Bootstrapping only happens once, but it changes which CI steps
+  are idempotent vs. first-run-only.
+- **Gatekeeper UX copy baseline.** Signing is deferred per spec; the design
+  commits to a caveat block on Overview pages, but the exact wording and where
+  it sits relative to the install command is a plan concern.

--- a/specs/600-native-binary-distribution/design.md
+++ b/specs/600-native-binary-distribution/design.md
@@ -33,19 +33,26 @@ bun's compile bundler for a CLI × target triple. A top-level `build-binaries`
 recipe fans out over the seven CLIs for the default target (`darwin-arm64`).
 Exact flag set is a plan concern.
 
-| Field          | Value                                                     |
-| -------------- | --------------------------------------------------------- |
-| Target triple  | `bun-darwin-arm64` (acceptance); `bun-darwin-x64` Phase 2 |
-| Output path    | `dist/binaries/<cli>-<os>-<arch>`                         |
-| Size ceiling   | 150 MB per binary (bun runtime ~60 MB + app code/deps)    |
-| Startup budget | `--help` in < 500 ms cold on an M-series mac              |
+| Field          | Value                                                            |
+| -------------- | ---------------------------------------------------------------- |
+| Target triple  | `bun-darwin-arm64` (acceptance); `bun-darwin-x64` Phase 2        |
+| Output path    | `dist/binaries/<cli>-<os>-<arch>`                                |
+| Size ceiling   | 150 MB per binary (bun runtime ~60 MB + app code/deps), CI-gated |
+| Startup budget | `--help` in < 500 ms cold on an M-series mac, CI-gated           |
+
+"Phase 2" throughout this design is a placeholder for a follow-up spec that
+promotes `bun-darwin-x64` from pre-reserved (target name wired in the recipe,
+no CI job) to acceptance (built, released, tapped). No Phase 2 work lands here.
 
 **Rejected — one recipe per CLI.** Seven near-identical recipes duplicate the
 flag set; a parameterized recipe keeps flags in one place.
 
 **Rejected — `pkg`/`nexe` bundlers.** Bun already produces single-file
-executables and is our primary runtime; a second toolchain adds surface for no
-gain.
+executables and is our primary runtime; a second toolchain adds a parallel
+dependency graph without a smaller or faster output than `bun build --compile`.
+
+**Rejected — no budgets.** Without size/startup ceilings, bundled deps drift
+silently; a cheap CI check at the build step catches regressions before release.
 
 **Codegen as build prerequisite.** `build-binary` depends on `codegen` (the
 existing `just codegen` recipe that runs `fit-codegen --all`). Generated gRPC
@@ -122,9 +129,8 @@ new `version` and `sha256`. Authentication is a repo secret
 `HOMEBREW_TAP_PAT` scoped to the tap repo only. PR title, body, and commit
 message shape are plan concerns.
 
-**Rejected — `homebrew-releaser` action.** Opinionated about formula shape, less
-flexible for per-cask `arch` gating, and hides the diff from review.
-
+**Rejected — `homebrew-releaser` action.** Opinionated about formula shape,
+inflexible for per-cask `arch` gating, and hides the diff from review.
 **Rejected — manual updates.** Guarantees drift between npm and brew versions.
 
 ## Component 4 — fit-guide codegen story

--- a/specs/600-native-binary-distribution/design.md
+++ b/specs/600-native-binary-distribution/design.md
@@ -1,0 +1,180 @@
+# Design 600 — Native Binary Distribution via Homebrew
+
+See [`spec.md`](./spec.md) for WHAT/WHY. This document captures WHICH components
+exist and WHERE they interact.
+
+## Architecture
+
+```mermaid
+graph LR
+  MR[monorepo<br/>justfile] -->|bun build --compile| BIN[dist/binaries/<br/>fit-*-darwin-arm64]
+  Tag[release tag<br/>cli@vX.Y.Z] -->|triggers| WF[publish-brew.yml]
+  WF -->|build on macos-14| BIN
+  WF -->|gh release upload| REL[GitHub Release assets]
+  WF -->|PR via PAT| TAP[forwardimpact/<br/>homebrew-tap]
+  User[macOS arm64 user] -->|brew install| TAP
+  TAP -->|cask url| REL
+```
+
+Three cooperating surfaces: a **local build pipeline** (justfile + bun) used by
+contributors and CI, a **release workflow** that uploads artifacts and opens a
+cask-update PR, and a **separate tap repository** users tap. The existing npm
+path is untouched.
+
+## Component 1 — Native binary build (justfile)
+
+**Entry point.** Each CLI's existing `bin/fit-<name>.js` is already a runnable
+ES module — it becomes the `bun build --compile` entry unchanged. The
+`#!/usr/bin/env node` shebang is a no-op in a compiled binary and the npm path
+keeps using it, so no source rewrite is needed.
+
+**Recipe shape.** One **parameterized recipe** `build-binary CLI TARGET` drives
+`bun build --compile --minify --sourcemap=none --target=bun-<TARGET>`. A
+top-level `build-binaries` recipe fans out over the seven CLIs for the default
+target (`darwin-arm64`).
+
+| Field          | Value                                                     |
+| -------------- | --------------------------------------------------------- |
+| Target triple  | `bun-darwin-arm64` (acceptance); `bun-darwin-x64` Phase 2 |
+| Output path    | `dist/binaries/<cli>-<os>-<arch>`                         |
+| Size ceiling   | 150 MB per binary (bun runtime ~60 MB + app code/deps)    |
+| Startup budget | `--help` in < 500 ms cold on an M-series mac              |
+
+**Rejected — one recipe per CLI.** Seven near-identical recipes duplicate the
+flag set; a parameterized recipe keeps flags in one place.
+
+**Rejected — `pkg`/`nexe` bundlers.** Bun already produces single-file
+executables and is our primary runtime; a second toolchain adds surface for no
+gain.
+
+**Codegen as build prerequisite.** `build-binary` depends on `codegen` (the
+existing `just codegen` recipe that runs `fit-codegen --all`). Generated gRPC
+clients and types land in `generated/` before `bun build --compile`; bun's
+bundler follows the import graph and embeds them into the executable. Generated
+code is baked into every binary — brew users never run codegen.
+
+**Rejected — lazy codegen at first run.** Requires either embedding protoc (~20
+MB + ABI risk) or requiring it on `PATH` (violates zero-dependency promise).
+
+## Component 2 — GitHub Actions release workflow
+
+New workflow: `.github/workflows/publish-brew.yml`.
+
+**Trigger.** Tag push matching `*@v*` — the same pattern `publish-npm.yml` uses.
+A single tag fires both workflows in parallel.
+
+**Job matrix.**
+
+| Job              | Runner          | Per CLI | Output                                  |
+| ---------------- | --------------- | ------- | --------------------------------------- |
+| `build`          | `macos-14`      | matrix  | `fit-<cli>-…-darwin-arm64` + sha256     |
+| `release-assets` | `macos-14`      | once    | `gh release upload` for all             |
+| `tap-pr`         | `ubuntu-latest` | once    | PR against `forwardimpact/homebrew-tap` |
+
+`macos-14` is GitHub's arm64 runner — native build, no cross-compile risk.
+Matrix dimension is **CLI only** (seven parallel jobs); target stays single
+until Phase 2.
+
+**Rejected — monolithic build job.** Seven sequential builds add ~5–7 minutes;
+matrix parallelism keeps release feedback under 3 minutes.
+
+**Rejected — `release`-event trigger.** Tag push is how npm already fires;
+keeping one trigger shape means one `git tag` launches both channels.
+
+**Artifact naming.** `fit-<cli>-<version>-<os>-<arch>` (e.g.
+`fit-pathway-0.25.32-darwin-arm64`). Version in the filename keeps old release
+assets immutable and gives casks a stable, versioned URL. A matching `.sha256`
+sidecar is uploaded alongside each binary via
+`shasum -a 256 <file> > <file>.sha256`.
+
+**Interaction with `publish-npm.yml`.** Two independent workflows on the same
+trigger; both read `products/<cli>/package.json` for the version, so npm and
+brew cannot diverge.
+
+## Component 3 — Homebrew tap and casks
+
+**Tap repository.** Separate repo `forwardimpact/homebrew-tap`. Users run
+`brew tap forwardimpact/tap` then `brew install forwardimpact/tap/fit-pathway`.
+
+**Rejected — tap directory inside this monorepo.** Brew only taps repos, not
+subdirectories; users would need a brittle custom tap URL. A separate repo also
+lets casks be updated without a monorepo PR cycle.
+
+**Cask vs formula.** Casks, not formulae. Formulae compile from source; casks
+install prebuilt artifacts. Our binaries ship prebuilt from CI, and casks unlock
+`depends_on arch:` gating.
+
+**Cask shape.** One cask per CLI at `Casks/fit-<cli>.rb`:
+
+| Field        | Value                                                                     |
+| ------------ | ------------------------------------------------------------------------- |
+| `version`    | npm package version (e.g. `"0.25.32"`)                                    |
+| `sha256`     | sha256 of the arm64 binary                                                |
+| `url`        | `…/releases/download/<cli>@v#{version}/fit-<cli>-#{version}-darwin-arm64` |
+| `binary`     | artifact, renamed to `fit-<cli>` on install                               |
+| `depends_on` | `arch: :arm64` — blocks install on non-arm64                              |
+| `livecheck`  | GitHub Releases API, `<cli>@v*` tag series                                |
+| `zap`        | no-op — CLIs are stateless; user data in `data/*` is theirs               |
+
+**Update automation — chosen: PR via PAT.** The `tap-pr` job clones
+`forwardimpact/homebrew-tap`, updates `version` and `sha256` in the relevant
+`Casks/fit-<cli>.rb`, and opens a PR `chore: bump fit-<cli> to <version>`. Repo
+secret `HOMEBREW_TAP_PAT` scopes to the tap repo only.
+
+**Rejected — `homebrew-releaser` action.** Opinionated about formula shape, less
+flexible for per-cask `arch` gating, and hides the diff from review.
+
+**Rejected — manual updates.** Guarantees drift between npm and brew versions.
+
+## Component 4 — fit-guide codegen story
+
+The spec leaves the choice open. **This design chooses option (b): the
+`fit-guide` binary ships its generated gRPC artifacts baked in** (via Component
+1's codegen prerequisite). Bun's compile bundler already embeds `generated/`
+imports, so this option adds zero new moving parts.
+
+`fit-codegen` is still built as a standalone binary (spec requires all seven),
+but brew users of `fit-guide` never need to invoke it.
+
+**Rejected — option (a) exclusive (fit-guide invokes fit-codegen at first
+run).** Requires embedding protoc or finding it on `PATH` — violates the
+zero-dependency install promise.
+
+## Component 5 — Non-arm64 macOS behaviour
+
+Casks use `depends_on arch: :arm64`. Homebrew's built-in arch check produces a
+standard "Cask depends on hardware: ARM64" error on Intel macs and Linuxbrew —
+no bespoke stub needed. Docs add one line: "Intel macOS and Linux users continue
+via npm."
+
+**Rejected — custom-stub cask with bespoke error.** Brew's native check is
+already clear and discoverable; a stub is code for identical UX.
+
+x64 macOS is not in this spec — reserved for Phase 2. The `bun-darwin-x64`
+target is pre-reserved in the parameterized recipe so Phase 2 is a matrix
+expansion, not a redesign.
+
+## Component 6 — Version sync (single source of truth)
+
+The **git tag** `<cli>@v<version>` is the single source of truth. Flow:
+
+1. Developer runs release-please (or `git tag cli@vX.Y.Z`).
+2. Tag push fires both `publish-npm.yml` and `publish-brew.yml`.
+3. `publish-npm.yml` reads `products/<cli>/package.json` and publishes to npm.
+4. `publish-brew.yml` reads the same `package.json`, builds binaries, uploads
+   release assets, and opens the tap PR using that version.
+5. Merging the tap PR makes `brew upgrade` available.
+
+Both workflows read the same file in the same commit — versions cannot diverge,
+only timing (tap PR awaits human merge).
+
+## Open questions for plan phase
+
+- **Exact justfile syntax** for the `build-binaries` fan-out over the CLI list.
+- **Exact workflow YAML**, including bun-install cache keys across matrix jobs.
+- **Tap repo bootstrap**: `forwardimpact/homebrew-tap` creation,
+  `HOMEBREW_TAP_PAT` provisioning, seeding initial cask files.
+- **Gatekeeper UX copy** on per-product Overview pages — exact
+  `xattr -d com.apple.quarantine` guidance (signing is deferred per spec).
+- **Release-notes template** — whether `publish-brew.yml` appends a brew install
+  snippet to the `gh release` body.

--- a/specs/600-native-binary-distribution/design.md
+++ b/specs/600-native-binary-distribution/design.md
@@ -41,8 +41,8 @@ Exact flag set is a plan concern.
 | Startup budget | `--help` in < 500 ms cold on an M-series mac, CI-gated           |
 
 "Phase 2" throughout this design is a placeholder for a follow-up spec that
-promotes `bun-darwin-x64` from pre-reserved (target name wired in the recipe,
-no CI job) to acceptance (built, released, tapped). No Phase 2 work lands here.
+promotes `bun-darwin-x64` from pre-reserved (target name wired in the recipe, no
+CI job) to acceptance (built, released, tapped). No Phase 2 work lands here.
 
 **Rejected — one recipe per CLI.** Seven near-identical recipes duplicate the
 flag set; a parameterized recipe keeps flags in one place.
@@ -125,9 +125,9 @@ install prebuilt artifacts. Our binaries ship prebuilt from CI, and casks unlock
 
 **Update automation — chosen: PR via PAT.** The `tap-pr` job proposes a cask
 update against `forwardimpact/homebrew-tap` via a pull request that carries the
-new `version` and `sha256`. Authentication is a repo secret
-`HOMEBREW_TAP_PAT` scoped to the tap repo only. PR title, body, and commit
-message shape are plan concerns.
+new `version` and `sha256`. Authentication is a repo secret `HOMEBREW_TAP_PAT`
+scoped to the tap repo only. PR title, body, and commit message shape are plan
+concerns.
 
 **Rejected — `homebrew-releaser` action.** Opinionated about formula shape,
 inflexible for per-cask `arch` gating, and hides the diff from review.
@@ -180,9 +180,9 @@ drift from `package.json`; the tag already serialises the version.
 Spec SC6 requires every affected product's Overview page to document the brew
 install flow. Each `website/<product>/index.md` gains an **Install** section (or
 extends the existing one) with two blocks: npm (unchanged) and brew (the
-`brew tap` + `brew install` invocation and the Gatekeeper-warning caveat).
-Docs live in the monorepo and ship through the existing website workflow — no
-new publishing surface.
+`brew tap` + `brew install` invocation and the Gatekeeper-warning caveat). Docs
+live in the monorepo and ship through the existing website workflow — no new
+publishing surface.
 
 **Rejected — a single shared install page.** Per-product pages are the entry
 points external users land on; cross-linking to a shared page doubles the click

--- a/specs/600-native-binary-distribution/spec.md
+++ b/specs/600-native-binary-distribution/spec.md
@@ -48,20 +48,20 @@ on macOS additionally get a zero-Node option via Homebrew.
 Three new capabilities:
 
 1. **Native binary build targets.** Each `fit-*` CLI has a single documented
-   build entry point that produces a fully-bundled standalone native executable —
-   no Node, no Bun, no runtime dependency on user-side tooling. The executables
-   cover all seven current CLIs (`fit-map`, `fit-pathway`, `fit-basecamp`,
-   `fit-guide`, `fit-landmark`, `fit-summit`, `fit-codegen`). The build toolchain
-   and entry-point naming are design decisions.
+   build entry point that produces a fully-bundled standalone native executable
+   — no Node, no Bun, no runtime dependency on user-side tooling. The
+   executables cover all seven current CLIs (`fit-map`, `fit-pathway`,
+   `fit-basecamp`, `fit-guide`, `fit-landmark`, `fit-summit`, `fit-codegen`).
+   The build toolchain and entry-point naming are design decisions.
 2. **Release-workflow artifact publishing.** Release automation, triggered on
    release tag, builds the binaries and attaches them to the GitHub release as
    downloadable assets, one per CLI per target triple. The CI platform and
    workflow layout are design decisions.
 3. **Homebrew tap distribution.** A Homebrew tap exposes one installable package
    per CLI. Each package installs its matching GitHub release artifact and
-   places the binary on the user's `PATH`. Tap location, packaging format
-   (cask vs. formula), and release-sync mechanism are design decisions (see
-   Open Questions).
+   places the binary on the user's `PATH`. Tap location, packaging format (cask
+   vs. formula), and release-sync mechanism are design decisions (see Open
+   Questions).
 
 The intent is deliberately narrow: preserve every existing install path,
 behaviour, and CLI surface unchanged, and add one new way to get the same
@@ -118,22 +118,23 @@ executables onto a macOS machine without installing Node.
 3. A Homebrew tap contains one installable package per CLI. Each package
    references the GitHub release artifact for the CLI and target triple.
 4. On a clean macOS arm64 machine with Homebrew installed but no Node and no
-   Bun, running `brew install <tap>/fit-<cli>` for each of the seven CLIs
-   leaves each corresponding `fit-<cli>` command on `PATH` answering `--help`.
-   The concrete tap path is fixed by design.
+   Bun, running `brew install <tap>/fit-<cli>` for each of the seven CLIs leaves
+   each corresponding `fit-<cli>` command on `PATH` answering `--help`. The
+   concrete tap path is fixed by design.
 5. After installing `fit-guide` exclusively via brew — no npm, no post-install
-   command — the user can run `fit-guide --help` and every user-visible
-   command documented in the [Guide Overview](../../website/guide/index.md) with
-   no additional install step. No `fit-codegen` invocation, `npm install`, or
+   command — the user can run `fit-guide --help` and every user-visible command
+   documented in the [Guide Overview](../../website/guide/index.md) with no
+   additional install step. No `fit-codegen` invocation, `npm install`, or
    toolchain step is required from the user between `brew install` and first
    successful command.
-6. Every per-product Overview page linked from [`CLAUDE.md` § Products](../../CLAUDE.md)
-   for a CLI in scope carries a "Install" section (or equivalent) that
-   documents the brew install command alongside the existing npm flow.
+6. Every per-product Overview page linked from
+   [`CLAUDE.md` § Products](../../CLAUDE.md) for a CLI in scope carries a
+   "Install" section (or equivalent) that documents the brew install command
+   alongside the existing npm flow.
 7. The existing npm distribution is unchanged: for each of the seven CLIs,
-   `npm install` followed by `npx fit-<cli> --help` succeeds on a reference
-   Node LTS environment after the release that ships the brew channel. No
-   `bin` script, `package.json` `bin` entry, or shebang has changed.
+   `npm install` followed by `npx fit-<cli> --help` succeeds on a reference Node
+   LTS environment after the release that ships the brew channel. No `bin`
+   script, `package.json` `bin` entry, or shebang has changed.
 
 ## Open questions
 
@@ -149,15 +150,15 @@ Each item below is a decision the design must make; none block the spec.
 - **Tap repository location.** A separate Forward Impact tap repo published to
   from this monorepo, vs. a tap subdirectory inside the monorepo that a release
   job syncs outward. Affects release automation and tap discoverability.
-- **Version sync between npm and brew.** How a release tag that publishes to
-  npm also updates package hashes and version strings in the tap — one
-  workflow, two workflows, or a follow-up job. Design must state the mechanism
-  so a single release does not leave the two channels on different versions.
-- **Non-arm64 macOS and Linux behaviour.** Whether `brew install` on a
-  non-arm64 macOS machine or on Linuxbrew fails fast with a clear message,
-  falls back to advising the npm path, or ships an Intel/Linux build. The spec
-  requires arm64-only at acceptance; the failure mode on other architectures is
-  a design decision.
+- **Version sync between npm and brew.** How a release tag that publishes to npm
+  also updates package hashes and version strings in the tap — one workflow, two
+  workflows, or a follow-up job. Design must state the mechanism so a single
+  release does not leave the two channels on different versions.
+- **Non-arm64 macOS and Linux behaviour.** Whether `brew install` on a non-arm64
+  macOS machine or on Linuxbrew fails fast with a clear message, falls back to
+  advising the npm path, or ships an Intel/Linux build. The spec requires
+  arm64-only at acceptance; the failure mode on other architectures is a design
+  decision.
 - **`fit-guide` codegen mechanism.** The spec requires zero second-step install
   for `fit-guide`; the design chooses between bundling generated artifacts into
   the binary, having `fit-guide` invoke a bundled `fit-codegen` transparently,

--- a/specs/600-native-binary-distribution/spec.md
+++ b/specs/600-native-binary-distribution/spec.md
@@ -95,11 +95,10 @@ executables onto a macOS machine without installing Node.
   raw tarballs, or none of the above is out of scope. Linux users continue via
   the existing npm channel for now.
 - **Code signing and notarization.** Unsigned binaries will trigger Gatekeeper
-  warnings on macOS and need a user-side bypass (right-click open, or
-  `xattr -d com.apple.quarantine`). The security and UX implications are real
-  but resolving them — Developer ID certificate, notarization pipeline, hardened
-  runtime, stapling — is deferred to a follow-up spec. This spec must not claim
-  signing as complete.
+  warnings on macOS that the user must acknowledge before first run. The
+  security and UX implications are real but resolving them — Developer ID
+  certificate, notarization pipeline, hardened runtime, stapling — is deferred
+  to a follow-up spec. This spec must not claim signing as complete.
 - **Replacing or modifying the existing npm channel.** `npm install` /
   `npx fit-*` continues to work identically. No CLI is removed from npm, no
   shebang is rewritten, and no existing user workflow changes.
@@ -131,6 +130,10 @@ executables onto a macOS machine without installing Node.
 6. Every per-product Overview page linked from [`CLAUDE.md` § Products](../../CLAUDE.md)
    for a CLI in scope carries a "Install" section (or equivalent) that
    documents the brew install command alongside the existing npm flow.
+7. The existing npm distribution is unchanged: for each of the seven CLIs,
+   `npm install` followed by `npx fit-<cli> --help` succeeds on a reference
+   Node LTS environment after the release that ships the brew channel. No
+   `bin` script, `package.json` `bin` entry, or shebang has changed.
 
 ## Open questions
 
@@ -146,10 +149,10 @@ Each item below is a decision the design must make; none block the spec.
 - **Tap repository location.** A separate Forward Impact tap repo published to
   from this monorepo, vs. a tap subdirectory inside the monorepo that a release
   job syncs outward. Affects release automation and tap discoverability.
-- **Version sync between npm and brew.** How a release tag that publishes to npm
-  also updates cask SHAs and version strings in the tap — one workflow, two
-  workflows, or a follow-up job. Design must state the mechanism so a single
-  release does not leave the two channels on different versions.
+- **Version sync between npm and brew.** How a release tag that publishes to
+  npm also updates package hashes and version strings in the tap — one
+  workflow, two workflows, or a follow-up job. Design must state the mechanism
+  so a single release does not leave the two channels on different versions.
 - **Non-arm64 macOS and Linux behaviour.** Whether `brew install` on a
   non-arm64 macOS machine or on Linuxbrew fails fast with a clear message,
   falls back to advising the npm path, or ships an Intel/Linux build. The spec

--- a/specs/600-native-binary-distribution/spec.md
+++ b/specs/600-native-binary-distribution/spec.md
@@ -22,43 +22,43 @@ The same is true for `fit-map`, `fit-basecamp`, `fit-guide`, `fit-landmark`,
 1. **Adoption friction on fresh machines.** A new developer evaluating Forward
    Impact on a clean macOS laptop must first install a Node toolchain (nvm,
    Homebrew, Volta, or a vendor installer) before they can run `npx fit-map`.
-   Leadership and engineers doing a first-look evaluation pay a setup tax
-   before seeing any product value.
-2. **Version coupling to the user's Node.** Our CLIs run under whatever Node
-   the user happens to have on `PATH`. Breakages caused by old LTS versions,
-   ESM/CJS interop drift, or site-installed shims surface as Forward Impact
-   bugs even when the cause is the host Node.
+   Leadership and engineers doing a first-look evaluation pay a setup tax before
+   seeing any product value.
+2. **Version coupling to the user's Node.** Our CLIs run under whatever Node the
+   user happens to have on `PATH`. Breakages caused by old LTS versions, ESM/CJS
+   interop drift, or site-installed shims surface as Forward Impact bugs even
+   when the cause is the host Node.
 3. **A second post-install step for Guide.** `fit-guide` additionally requires
-   `npx fit-codegen --all` after install because its gRPC clients are
-   generated, installation-specific, and never bundled in the npm package
-   (see [Codegen Internals](../../website/docs/internals/codegen/index.md)).
-   The smoothest possible install is "install one thing, run it"; today's
-   Guide path needs two.
+   `npx fit-codegen --all` after install because its gRPC clients are generated,
+   installation-specific, and never bundled in the npm package (see
+   [Codegen Internals](../../website/docs/internals/codegen/index.md)). The
+   smoothest possible install is "install one thing, run it"; today's Guide path
+   needs two.
 
 We want a zero-Node install path for macOS developers that installs a single
-bundled executable, runs immediately, and does not drag the user's Node
-version into our support surface.
+bundled executable, runs immediately, and does not drag the user's Node version
+into our support surface.
 
 ## Proposal
 
 Add a **second distribution channel**, alongside (not replacing) the existing
-npm channel. External users keep `npm install` / `npx fit-*` as today; new
-users on macOS additionally get a zero-Node option via Homebrew.
+npm channel. External users keep `npm install` / `npx fit-*` as today; new users
+on macOS additionally get a zero-Node option via Homebrew.
 
 Three new capabilities:
 
-1. **Native binary build targets.** Each `fit-*` CLI has a justfile recipe
-   that produces a fully-bundled standalone native executable — no Node, no
-   Bun, no runtime dependency on user-side tooling. The executables cover all
-   seven current CLIs (`fit-map`, `fit-pathway`, `fit-basecamp`, `fit-guide`,
+1. **Native binary build targets.** Each `fit-*` CLI has a justfile recipe that
+   produces a fully-bundled standalone native executable — no Node, no Bun, no
+   runtime dependency on user-side tooling. The executables cover all seven
+   current CLIs (`fit-map`, `fit-pathway`, `fit-basecamp`, `fit-guide`,
    `fit-landmark`, `fit-summit`, `fit-codegen`).
 2. **Release-workflow artifact publishing.** A GitHub Actions workflow,
-   triggered on release tag, builds the binaries and attaches them to the
-   GitHub release as downloadable assets, one per CLI per target triple.
-3. **Homebrew tap with cask formulae.** A Homebrew tap exposes a cask per
-   CLI. Each cask installs its matching GitHub release artifact and places
-   the binary on the user's `PATH`. The tap's location and release-sync
-   mechanism are design decisions (see Open Questions).
+   triggered on release tag, builds the binaries and attaches them to the GitHub
+   release as downloadable assets, one per CLI per target triple.
+3. **Homebrew tap with cask formulae.** A Homebrew tap exposes a cask per CLI.
+   Each cask installs its matching GitHub release artifact and places the binary
+   on the user's `PATH`. The tap's location and release-sync mechanism are
+   design decisions (see Open Questions).
 
 The intent is deliberately narrow: preserve every existing install path,
 behaviour, and CLI surface unchanged, and add one new way to get the same
@@ -71,32 +71,32 @@ executables onto a macOS machine without installing Node.
 - All seven `fit-*` CLIs listed above, each buildable as a standalone native
   binary.
 - macOS arm64 as the primary and required target at acceptance.
-- A GitHub Actions release workflow that builds the binaries on release tag
-  and attaches them to the GitHub release.
+- A GitHub Actions release workflow that builds the binaries on release tag and
+  attaches them to the GitHub release.
 - Homebrew cask formulae — one per CLI — in a Forward Impact tap.
-- Documentation of the brew install flow on the website overview pages for
-  each affected product (the per-product Overview pages linked from
+- Documentation of the brew install flow on the website overview pages for each
+  affected product (the per-product Overview pages linked from
   [`CLAUDE.md` § Products](../../CLAUDE.md)).
 - A stated story for the `fit-guide` codegen dependency so a brew-installed
-  `fit-guide` is usable without the user reaching back into npm. The story
-  picks one of: (a) `fit-codegen` itself is a standalone native binary the
-  user can invoke, (b) brew-installed `fit-guide` ships the generated
-  artifacts it needs, or (c) another approach documented in design. The
-  selection is a WHAT; the HOW is a design decision.
+  `fit-guide` is usable without the user reaching back into npm. The story picks
+  one of: (a) `fit-codegen` itself is a standalone native binary the user can
+  invoke, (b) brew-installed `fit-guide` ships the generated artifacts it needs,
+  or (c) another approach documented in design. The selection is a WHAT; the HOW
+  is a design decision.
 
 ### Excluded (explicit non-goals)
 
-- **Windows support.** Not in this spec. A separate spec can revisit after
-  the macOS path is proven.
-- **Linux distribution.** Whether Linux users get Linuxbrew, apt/dnf
-  packaging, raw tarballs, or none of the above is out of scope. Linux users
-  continue via the existing npm channel for now.
+- **Windows support.** Not in this spec. A separate spec can revisit after the
+  macOS path is proven.
+- **Linux distribution.** Whether Linux users get Linuxbrew, apt/dnf packaging,
+  raw tarballs, or none of the above is out of scope. Linux users continue via
+  the existing npm channel for now.
 - **Code signing and notarization.** Unsigned binaries will trigger Gatekeeper
   warnings on macOS and need a user-side bypass (right-click open, or
-  `xattr -d com.apple.quarantine`). The security and UX implications are
-  real but resolving them — Developer ID certificate, notarization pipeline,
-  hardened runtime, stapling — is deferred to a follow-up spec. This spec
-  must not claim signing as complete.
+  `xattr -d com.apple.quarantine`). The security and UX implications are real
+  but resolving them — Developer ID certificate, notarization pipeline, hardened
+  runtime, stapling — is deferred to a follow-up spec. This spec must not claim
+  signing as complete.
 - **Replacing or modifying the existing npm channel.** `npm install` /
   `npx fit-*` continues to work identically. No CLI is removed from npm, no
   shebang is rewritten, and no existing user workflow changes.
@@ -105,30 +105,30 @@ executables onto a macOS machine without installing Node.
 
 ## Success Criteria
 
-1. A single justfile entry point (working name `just build-binaries`) produces
-   a standalone macOS arm64 native binary for each of the seven `fit-*` CLIs.
-   Each binary runs its `--help` successfully on a macOS arm64 machine that
-   has neither `node` nor `bun` on `PATH`. Each binary sits within a size
-   ceiling agreed in design (low tens to low hundreds of MB is expected for
+1. A single justfile entry point (working name `just build-binaries`) produces a
+   standalone macOS arm64 native binary for each of the seven `fit-*` CLIs. Each
+   binary runs its `--help` successfully on a macOS arm64 machine that has
+   neither `node` nor `bun` on `PATH`. Each binary sits within a size ceiling
+   agreed in design (low tens to low hundreds of MB is expected for
    fully-bundled runtimes; the exact ceiling is a design decision).
-2. A GitHub Actions workflow, triggered by a release tag, builds the full
-   binary set and attaches the binaries to the GitHub release as downloadable
-   assets, with a deterministic asset-name scheme that identifies the CLI and
-   target triple.
-3. A Homebrew tap (working name `forwardimpact/homebrew-tap`) contains one
-   cask formula per CLI. Each formula references the GitHub release artifact
-   for the CLI and target triple.
+2. A GitHub Actions workflow, triggered by a release tag, builds the full binary
+   set and attaches the binaries to the GitHub release as downloadable assets,
+   with a deterministic asset-name scheme that identifies the CLI and target
+   triple.
+3. A Homebrew tap (working name `forwardimpact/homebrew-tap`) contains one cask
+   formula per CLI. Each formula references the GitHub release artifact for the
+   CLI and target triple.
 4. On a clean macOS arm64 machine with Homebrew installed but no Node and no
    Bun, `brew install forwardimpact/tap/fit-pathway` results in a working
    `fit-pathway` command on `PATH` that answers `fit-pathway --help`.
    **Stretch:** the equivalent command works for every one of the seven CLIs.
 5. `fit-guide` installed exclusively via brew — no npm, no post-install `npx`
    step required from the user — is able to complete whatever codegen or
-   artifact setup it needs and answer a framework question. The spec commits
-   to one of the three options listed under Scope § Included; the
-   implementation follows the chosen option.
-6. The per-product Overview pages on the website describe the brew install
-   flow for each affected product alongside the existing npm flow.
+   artifact setup it needs and answer a framework question. The spec commits to
+   one of the three options listed under Scope § Included; the implementation
+   follows the chosen option.
+6. The per-product Overview pages on the website describe the brew install flow
+   for each affected product alongside the existing npm flow.
 
 ## Open questions
 
@@ -137,24 +137,23 @@ Each item below is a decision the design must make; none block the spec.
 - **Cross-compile strategy.** Build natively on macOS arm64 runners only
   (single-arch matrix), or matrix across multiple runner architectures for
   future-proofing. Affects workflow cost and cross-compile risk.
-- **Signing and notarization timing.** Defer entirely to a follow-up spec
-  (this spec's current stance) vs. land a minimal signed-but-unnotarized path
-  now. Design must document the user-visible Gatekeeper experience under
-  whichever option is chosen.
+- **Signing and notarization timing.** Defer entirely to a follow-up spec (this
+  spec's current stance) vs. land a minimal signed-but-unnotarized path now.
+  Design must document the user-visible Gatekeeper experience under whichever
+  option is chosen.
 - **Tap repository location.** A separate `forwardimpact/homebrew-tap` repo
-  published to from this monorepo, vs. a tap subdirectory inside the
-  monorepo that a release job syncs outward. Affects release automation and
-  tap discoverability.
-- **Version sync between npm and brew.** How a release tag that publishes to
-  npm also updates cask SHAs and version strings in the tap — one workflow,
-  two workflows, or a follow-up job. Design must state the mechanism so a
-  single release does not leave the two channels on different versions.
-- **Non-arm64 macOS behaviour.** Whether `brew install forwardimpact/tap/...`
-  on a non-arm64 machine fails fast with a clear message, falls back to
-  advising the npm path, or ships an Intel build. The spec requires
-  arm64-only at acceptance; the failure mode on other architectures is a
-  design decision.
+  published to from this monorepo, vs. a tap subdirectory inside the monorepo
+  that a release job syncs outward. Affects release automation and tap
+  discoverability.
+- **Version sync between npm and brew.** How a release tag that publishes to npm
+  also updates cask SHAs and version strings in the tap — one workflow, two
+  workflows, or a follow-up job. Design must state the mechanism so a single
+  release does not leave the two channels on different versions.
+- **Non-arm64 macOS behaviour.** Whether `brew install forwardimpact/tap/...` on
+  a non-arm64 machine fails fast with a clear message, falls back to advising
+  the npm path, or ships an Intel build. The spec requires arm64-only at
+  acceptance; the failure mode on other architectures is a design decision.
 - **`fit-codegen` runtime behaviour.** If `fit-codegen` becomes a standalone
   binary that `fit-guide` can invoke, whether it ships its proto and template
-  inputs bundled inside the executable or fetches them over the network at
-  first run. Affects offline usability and artifact size.
+  inputs bundled inside the executable or fetches them over the network at first
+  run. Affects offline usability and artifact size.

--- a/specs/600-native-binary-distribution/spec.md
+++ b/specs/600-native-binary-distribution/spec.md
@@ -47,18 +47,21 @@ on macOS additionally get a zero-Node option via Homebrew.
 
 Three new capabilities:
 
-1. **Native binary build targets.** Each `fit-*` CLI has a justfile recipe that
-   produces a fully-bundled standalone native executable — no Node, no Bun, no
-   runtime dependency on user-side tooling. The executables cover all seven
-   current CLIs (`fit-map`, `fit-pathway`, `fit-basecamp`, `fit-guide`,
-   `fit-landmark`, `fit-summit`, `fit-codegen`).
-2. **Release-workflow artifact publishing.** A GitHub Actions workflow,
-   triggered on release tag, builds the binaries and attaches them to the GitHub
-   release as downloadable assets, one per CLI per target triple.
-3. **Homebrew tap with cask formulae.** A Homebrew tap exposes a cask per CLI.
-   Each cask installs its matching GitHub release artifact and places the binary
-   on the user's `PATH`. The tap's location and release-sync mechanism are
-   design decisions (see Open Questions).
+1. **Native binary build targets.** Each `fit-*` CLI has a single documented
+   build entry point that produces a fully-bundled standalone native executable —
+   no Node, no Bun, no runtime dependency on user-side tooling. The executables
+   cover all seven current CLIs (`fit-map`, `fit-pathway`, `fit-basecamp`,
+   `fit-guide`, `fit-landmark`, `fit-summit`, `fit-codegen`). The build toolchain
+   and entry-point naming are design decisions.
+2. **Release-workflow artifact publishing.** Release automation, triggered on
+   release tag, builds the binaries and attaches them to the GitHub release as
+   downloadable assets, one per CLI per target triple. The CI platform and
+   workflow layout are design decisions.
+3. **Homebrew tap distribution.** A Homebrew tap exposes one installable package
+   per CLI. Each package installs its matching GitHub release artifact and
+   places the binary on the user's `PATH`. Tap location, packaging format
+   (cask vs. formula), and release-sync mechanism are design decisions (see
+   Open Questions).
 
 The intent is deliberately narrow: preserve every existing install path,
 behaviour, and CLI surface unchanged, and add one new way to get the same
@@ -71,18 +74,18 @@ executables onto a macOS machine without installing Node.
 - All seven `fit-*` CLIs listed above, each buildable as a standalone native
   binary.
 - macOS arm64 as the primary and required target at acceptance.
-- A GitHub Actions release workflow that builds the binaries on release tag and
+- A release automation workflow that builds the binaries on release tag and
   attaches them to the GitHub release.
-- Homebrew cask formulae — one per CLI — in a Forward Impact tap.
-- Documentation of the brew install flow on the website overview pages for each
-  affected product (the per-product Overview pages linked from
-  [`CLAUDE.md` § Products](../../CLAUDE.md)).
-- A stated story for the `fit-guide` codegen dependency so a brew-installed
-  `fit-guide` is usable without the user reaching back into npm. The story picks
-  one of: (a) `fit-codegen` itself is a standalone native binary the user can
-  invoke, (b) brew-installed `fit-guide` ships the generated artifacts it needs,
-  or (c) another approach documented in design. The selection is a WHAT; the HOW
-  is a design decision.
+- A Homebrew tap with one installable package per CLI.
+- Documentation of the brew install flow on the per-product Overview pages
+  linked from [`CLAUDE.md` § Products](../../CLAUDE.md) for every affected
+  product.
+- A zero-second-step install for `fit-guide`. A brew-installed `fit-guide` must
+  be usable immediately after install with no additional command from the user —
+  no `npm install`, no `npx fit-codegen`, no PATH-dependent toolchain step. The
+  mechanism (whether generated artifacts ship inside the binary, whether
+  `fit-codegen` is invoked transparently, or another approach) is a design
+  decision.
 
 ### Excluded (explicit non-goals)
 
@@ -105,30 +108,29 @@ executables onto a macOS machine without installing Node.
 
 ## Success Criteria
 
-1. A single justfile entry point (working name `just build-binaries`) produces a
-   standalone macOS arm64 native binary for each of the seven `fit-*` CLIs. Each
-   binary runs its `--help` successfully on a macOS arm64 machine that has
-   neither `node` nor `bun` on `PATH`. Each binary sits within a size ceiling
-   agreed in design (low tens to low hundreds of MB is expected for
-   fully-bundled runtimes; the exact ceiling is a design decision).
-2. A GitHub Actions workflow, triggered by a release tag, builds the full binary
-   set and attaches the binaries to the GitHub release as downloadable assets,
-   with a deterministic asset-name scheme that identifies the CLI and target
-   triple.
-3. A Homebrew tap (working name `forwardimpact/homebrew-tap`) contains one cask
-   formula per CLI. Each formula references the GitHub release artifact for the
-   CLI and target triple.
+1. A single documented build entry point produces a standalone macOS arm64
+   native binary for each of the seven `fit-*` CLIs. Each binary runs its
+   `--help` successfully on a macOS arm64 machine that has neither `node` nor
+   `bun` on `PATH`.
+2. A release-automation workflow, triggered by a release tag, builds the full
+   binary set and attaches the binaries to the GitHub release as downloadable
+   assets, with a deterministic asset-name scheme that identifies the CLI and
+   target triple.
+3. A Homebrew tap contains one installable package per CLI. Each package
+   references the GitHub release artifact for the CLI and target triple.
 4. On a clean macOS arm64 machine with Homebrew installed but no Node and no
-   Bun, `brew install forwardimpact/tap/fit-pathway` results in a working
-   `fit-pathway` command on `PATH` that answers `fit-pathway --help`.
-   **Stretch:** the equivalent command works for every one of the seven CLIs.
-5. `fit-guide` installed exclusively via brew — no npm, no post-install `npx`
-   step required from the user — is able to complete whatever codegen or
-   artifact setup it needs and answer a framework question. The spec commits to
-   one of the three options listed under Scope § Included; the implementation
-   follows the chosen option.
-6. The per-product Overview pages on the website describe the brew install flow
-   for each affected product alongside the existing npm flow.
+   Bun, running `brew install <tap>/fit-<cli>` for each of the seven CLIs
+   leaves each corresponding `fit-<cli>` command on `PATH` answering `--help`.
+   The concrete tap path is fixed by design.
+5. After installing `fit-guide` exclusively via brew — no npm, no post-install
+   command — the user can run `fit-guide --help` and every user-visible
+   command documented in the [Guide Overview](../../website/guide/index.md) with
+   no additional install step. No `fit-codegen` invocation, `npm install`, or
+   toolchain step is required from the user between `brew install` and first
+   successful command.
+6. Every per-product Overview page linked from [`CLAUDE.md` § Products](../../CLAUDE.md)
+   for a CLI in scope carries a "Install" section (or equivalent) that
+   documents the brew install command alongside the existing npm flow.
 
 ## Open questions
 
@@ -141,19 +143,19 @@ Each item below is a decision the design must make; none block the spec.
   spec's current stance) vs. land a minimal signed-but-unnotarized path now.
   Design must document the user-visible Gatekeeper experience under whichever
   option is chosen.
-- **Tap repository location.** A separate `forwardimpact/homebrew-tap` repo
-  published to from this monorepo, vs. a tap subdirectory inside the monorepo
-  that a release job syncs outward. Affects release automation and tap
-  discoverability.
+- **Tap repository location.** A separate Forward Impact tap repo published to
+  from this monorepo, vs. a tap subdirectory inside the monorepo that a release
+  job syncs outward. Affects release automation and tap discoverability.
 - **Version sync between npm and brew.** How a release tag that publishes to npm
   also updates cask SHAs and version strings in the tap — one workflow, two
   workflows, or a follow-up job. Design must state the mechanism so a single
   release does not leave the two channels on different versions.
-- **Non-arm64 macOS behaviour.** Whether `brew install forwardimpact/tap/...` on
-  a non-arm64 machine fails fast with a clear message, falls back to advising
-  the npm path, or ships an Intel build. The spec requires arm64-only at
-  acceptance; the failure mode on other architectures is a design decision.
-- **`fit-codegen` runtime behaviour.** If `fit-codegen` becomes a standalone
-  binary that `fit-guide` can invoke, whether it ships its proto and template
-  inputs bundled inside the executable or fetches them over the network at first
-  run. Affects offline usability and artifact size.
+- **Non-arm64 macOS and Linux behaviour.** Whether `brew install` on a
+  non-arm64 macOS machine or on Linuxbrew fails fast with a clear message,
+  falls back to advising the npm path, or ships an Intel/Linux build. The spec
+  requires arm64-only at acceptance; the failure mode on other architectures is
+  a design decision.
+- **`fit-guide` codegen mechanism.** The spec requires zero second-step install
+  for `fit-guide`; the design chooses between bundling generated artifacts into
+  the binary, having `fit-guide` invoke a bundled `fit-codegen` transparently,
+  or another approach. Affects offline usability and artifact size.

--- a/specs/600-native-binary-distribution/spec.md
+++ b/specs/600-native-binary-distribution/spec.md
@@ -1,0 +1,160 @@
+# Spec 600 — Native Binary Distribution via Homebrew
+
+## Problem
+
+External users of Forward Impact products must install Node.js before they can
+run any `fit-*` CLI. Today's distribution model states this as policy:
+
+> External users — Node.js + npm, run `npx fit-*`.
+>
+> — [`CLAUDE.md` § Distribution Model](../../CLAUDE.md)
+
+Every published CLI carries a Node shebang that makes this coupling concrete —
+for example, `products/pathway/bin/fit-pathway.js` begins:
+
+```
+#!/usr/bin/env node
+```
+
+The same is true for `fit-map`, `fit-basecamp`, `fit-guide`, `fit-landmark`,
+`fit-summit`, and `fit-codegen`. In practice this produces three costs:
+
+1. **Adoption friction on fresh machines.** A new developer evaluating Forward
+   Impact on a clean macOS laptop must first install a Node toolchain (nvm,
+   Homebrew, Volta, or a vendor installer) before they can run `npx fit-map`.
+   Leadership and engineers doing a first-look evaluation pay a setup tax
+   before seeing any product value.
+2. **Version coupling to the user's Node.** Our CLIs run under whatever Node
+   the user happens to have on `PATH`. Breakages caused by old LTS versions,
+   ESM/CJS interop drift, or site-installed shims surface as Forward Impact
+   bugs even when the cause is the host Node.
+3. **A second post-install step for Guide.** `fit-guide` additionally requires
+   `npx fit-codegen --all` after install because its gRPC clients are
+   generated, installation-specific, and never bundled in the npm package
+   (see [Codegen Internals](../../website/docs/internals/codegen/index.md)).
+   The smoothest possible install is "install one thing, run it"; today's
+   Guide path needs two.
+
+We want a zero-Node install path for macOS developers that installs a single
+bundled executable, runs immediately, and does not drag the user's Node
+version into our support surface.
+
+## Proposal
+
+Add a **second distribution channel**, alongside (not replacing) the existing
+npm channel. External users keep `npm install` / `npx fit-*` as today; new
+users on macOS additionally get a zero-Node option via Homebrew.
+
+Three new capabilities:
+
+1. **Native binary build targets.** Each `fit-*` CLI has a justfile recipe
+   that produces a fully-bundled standalone native executable — no Node, no
+   Bun, no runtime dependency on user-side tooling. The executables cover all
+   seven current CLIs (`fit-map`, `fit-pathway`, `fit-basecamp`, `fit-guide`,
+   `fit-landmark`, `fit-summit`, `fit-codegen`).
+2. **Release-workflow artifact publishing.** A GitHub Actions workflow,
+   triggered on release tag, builds the binaries and attaches them to the
+   GitHub release as downloadable assets, one per CLI per target triple.
+3. **Homebrew tap with cask formulae.** A Homebrew tap exposes a cask per
+   CLI. Each cask installs its matching GitHub release artifact and places
+   the binary on the user's `PATH`. The tap's location and release-sync
+   mechanism are design decisions (see Open Questions).
+
+The intent is deliberately narrow: preserve every existing install path,
+behaviour, and CLI surface unchanged, and add one new way to get the same
+executables onto a macOS machine without installing Node.
+
+## Scope
+
+### Included
+
+- All seven `fit-*` CLIs listed above, each buildable as a standalone native
+  binary.
+- macOS arm64 as the primary and required target at acceptance.
+- A GitHub Actions release workflow that builds the binaries on release tag
+  and attaches them to the GitHub release.
+- Homebrew cask formulae — one per CLI — in a Forward Impact tap.
+- Documentation of the brew install flow on the website overview pages for
+  each affected product (the per-product Overview pages linked from
+  [`CLAUDE.md` § Products](../../CLAUDE.md)).
+- A stated story for the `fit-guide` codegen dependency so a brew-installed
+  `fit-guide` is usable without the user reaching back into npm. The story
+  picks one of: (a) `fit-codegen` itself is a standalone native binary the
+  user can invoke, (b) brew-installed `fit-guide` ships the generated
+  artifacts it needs, or (c) another approach documented in design. The
+  selection is a WHAT; the HOW is a design decision.
+
+### Excluded (explicit non-goals)
+
+- **Windows support.** Not in this spec. A separate spec can revisit after
+  the macOS path is proven.
+- **Linux distribution.** Whether Linux users get Linuxbrew, apt/dnf
+  packaging, raw tarballs, or none of the above is out of scope. Linux users
+  continue via the existing npm channel for now.
+- **Code signing and notarization.** Unsigned binaries will trigger Gatekeeper
+  warnings on macOS and need a user-side bypass (right-click open, or
+  `xattr -d com.apple.quarantine`). The security and UX implications are
+  real but resolving them — Developer ID certificate, notarization pipeline,
+  hardened runtime, stapling — is deferred to a follow-up spec. This spec
+  must not claim signing as complete.
+- **Replacing or modifying the existing npm channel.** `npm install` /
+  `npx fit-*` continues to work identically. No CLI is removed from npm, no
+  shebang is rewritten, and no existing user workflow changes.
+- **Auto-update mechanism inside the binaries.** Users upgrade via
+  `brew upgrade`; in-process self-update is not in scope.
+
+## Success Criteria
+
+1. A single justfile entry point (working name `just build-binaries`) produces
+   a standalone macOS arm64 native binary for each of the seven `fit-*` CLIs.
+   Each binary runs its `--help` successfully on a macOS arm64 machine that
+   has neither `node` nor `bun` on `PATH`. Each binary sits within a size
+   ceiling agreed in design (low tens to low hundreds of MB is expected for
+   fully-bundled runtimes; the exact ceiling is a design decision).
+2. A GitHub Actions workflow, triggered by a release tag, builds the full
+   binary set and attaches the binaries to the GitHub release as downloadable
+   assets, with a deterministic asset-name scheme that identifies the CLI and
+   target triple.
+3. A Homebrew tap (working name `forwardimpact/homebrew-tap`) contains one
+   cask formula per CLI. Each formula references the GitHub release artifact
+   for the CLI and target triple.
+4. On a clean macOS arm64 machine with Homebrew installed but no Node and no
+   Bun, `brew install forwardimpact/tap/fit-pathway` results in a working
+   `fit-pathway` command on `PATH` that answers `fit-pathway --help`.
+   **Stretch:** the equivalent command works for every one of the seven CLIs.
+5. `fit-guide` installed exclusively via brew — no npm, no post-install `npx`
+   step required from the user — is able to complete whatever codegen or
+   artifact setup it needs and answer a framework question. The spec commits
+   to one of the three options listed under Scope § Included; the
+   implementation follows the chosen option.
+6. The per-product Overview pages on the website describe the brew install
+   flow for each affected product alongside the existing npm flow.
+
+## Open questions
+
+Each item below is a decision the design must make; none block the spec.
+
+- **Cross-compile strategy.** Build natively on macOS arm64 runners only
+  (single-arch matrix), or matrix across multiple runner architectures for
+  future-proofing. Affects workflow cost and cross-compile risk.
+- **Signing and notarization timing.** Defer entirely to a follow-up spec
+  (this spec's current stance) vs. land a minimal signed-but-unnotarized path
+  now. Design must document the user-visible Gatekeeper experience under
+  whichever option is chosen.
+- **Tap repository location.** A separate `forwardimpact/homebrew-tap` repo
+  published to from this monorepo, vs. a tap subdirectory inside the
+  monorepo that a release job syncs outward. Affects release automation and
+  tap discoverability.
+- **Version sync between npm and brew.** How a release tag that publishes to
+  npm also updates cask SHAs and version strings in the tap — one workflow,
+  two workflows, or a follow-up job. Design must state the mechanism so a
+  single release does not leave the two channels on different versions.
+- **Non-arm64 macOS behaviour.** Whether `brew install forwardimpact/tap/...`
+  on a non-arm64 machine fails fast with a clear message, falls back to
+  advising the npm path, or ships an Intel build. The spec requires
+  arm64-only at acceptance; the failure mode on other architectures is a
+  design decision.
+- **`fit-codegen` runtime behaviour.** If `fit-codegen` becomes a standalone
+  binary that `fit-guide` can invoke, whether it ships its proto and template
+  inputs bundled inside the executable or fetches them over the network at
+  first run. Affects offline usability and artifact size.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -79,4 +79,4 @@
 570	design	approved
 580	plan	implemented
 590	design	approved
-600	design	draft
+600	design	approved

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -79,4 +79,4 @@
 570	design	approved
 580	plan	implemented
 590	design	approved
-600	spec	draft
+600	design	draft

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -79,3 +79,4 @@
 570	design	approved
 580	plan	implemented
 590	design	approved
+600	spec	draft


### PR DESCRIPTION
## Summary

- New spec 600 proposing a second distribution channel for the seven `fit-*` CLIs alongside npm: fully-bundled native binaries installable via Homebrew, targeting macOS arm64.
- Companion design that commits to `bun build --compile` on `macos-14` runners, a separate `forwardimpact/homebrew-tap` repo updated via PR-via-PAT, and baking generated gRPC artifacts into the `fit-guide` binary so brew users never run codegen.
- `specs/STATUS` row for 600 advances to `design approved`.

Artifacts were graded by a 10-reviewer panel (5 × spec, 5 × design); every consensus blocker/high/medium finding and the worth-addressing minorities/singletons were resolved on the branch before this PR opened. Spec is 164 lines; design is 199 lines (under the kata-design 200-line Blocker threshold).

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2343 pass / 1 skip / 0 fail)
