### PR TITLE
docs(specs): plan spec 590 condensed memory and priority index

### DIFF
--- a/specs/590-condensed-memory-and-priority-index/plan-a-01.md
+++ b/specs/590-condensed-memory-and-priority-index/plan-a-01.md
@@ -1,0 +1,209 @@
+# Plan 590-A Part 01 — Protocol, MEMORY.md Shape, Curate Skill
+
+**Agent:** staff-engineer **Branch:** `spec/590-part-01-protocol` from `main`
+**Depends on:** none (first part) **PR type:** `docs` (agent infrastructure — no
+runtime code changes)
+
+## Goal
+
+Establish the three contracts (tiered memory load, summary contract, weekly log
+contract), reshape `wiki/MEMORY.md` to hold the cross-cutting priority index,
+and update `kata-wiki-curate/SKILL.md` so its Step 5 output target matches the
+new shape. All three changes land in one PR because the design requires protocol
+changes and the MEMORY.md shape to arrive together.
+
+Summary files are _not_ migrated in this part. They become non-conforming at
+merge — that is expected and is the measurable gap closed by parts 02 and 03.
+
+## Files
+
+| Action  | Path                                           | Notes                                                           |
+| ------- | ---------------------------------------------- | --------------------------------------------------------------- |
+| Rewrite | `.claude/agents/references/memory-protocol.md` | Tiered load + summary contract + weekly log contract            |
+| Rewrite | `wiki/MEMORY.md`                               | Adds `## Cross-Cutting Priorities` section with empty-state row |
+| Modify  | `.claude/skills/kata-wiki-curate/SKILL.md`     | Step 5 output target; Step 1 extended with contract check       |
+
+No other files.
+
+## Step 1 — Rewrite `memory-protocol.md`
+
+Replace the entire file with the structure below. The current file is 39 lines;
+the new one will be ~90 lines because it absorbs the summary contract and the
+weekly log contract (which previously had no canonical home).
+
+Current structure: a single `## Memory` H2 with three H3 subsections
+(`### Before starting work`, `### During each run`, `### After each run`). The
+new structure promotes the content of the latter two H3s to top-level H2s
+(content preserved verbatim; only heading depth changes) and replaces the first
+H3 with the new `## Memory Tiers` section.
+
+Section order:
+
+1. `# Shared Agent Protocol` (H1, unchanged)
+2. `## Memory Tiers` — new; replaces today's `### Before starting work` H3.
+   - **Tier 1 (always):** three files — `wiki/{agent}.md`, `wiki/MEMORY.md`,
+     `wiki/storyboard-YYYY-MNN.md` (if exists).
+   - **Tier 2 (opt-in):** teammate summaries, weekly logs. State conditions:
+     teammate summary read only when coordinating with that agent or
+     investigating a priority-index item that names them; weekly log read only
+     when the skill is `kata-wiki-curate`, `kata-trace`, `kata-storyboard`, or
+     when explicitly investigating a historical decision.
+   - Include the mermaid diagram verbatim from `design.md` (the block currently
+     between lines 37–46 of design.md at the time of writing; copy the fenced
+     block by content, not by line number).
+3. `## During Each Run` — content promoted from today's `### During each run` H3
+   (keep the `### Decision` table and the weekly log path rule verbatim; only
+   the heading level changes H3 → H2).
+4. `## After Each Run` — content promoted from today's `### After each run` H3
+   (three-item list: actions, observations, blockers; only the heading level
+   changes H3 → H2).
+5. `## Summary Contract` — new section.
+   - **Permitted sections (in order):** H1 `# {Agent Title} — Summary`,
+     `**Last run**:` line, agent-specific state section(s) using H2,
+     `## Open Blockers`, `## Observations for Teammates`.
+   - **Excluded content:** historical audit data, storyboard commitments, policy
+     clarifications, metrics tables. Each exclusion names the correct home
+     (weekly log, storyboard file, `CONTRIBUTING.md`/skill docs, CSV under
+     `wiki/metrics/`).
+   - **Line budget:** 80 lines, checked mechanically by `wc -l`.
+   - **Rationale note** (one paragraph, no alternatives rehash): summaries are
+     state, not history. The line budget forces the discipline.
+6. `## Weekly Log Contract` — new section.
+   - Append-only audit records; no edits to past entries except format fixes.
+   - Tier 2 — not in the default startup load.
+   - Named readers: `kata-wiki-curate` (always), `kata-storyboard` (for
+     experiment verification), and agents explicitly investigating past
+     decisions.
+   - Format unchanged: `## YYYY-MM-DD` / `### {Subsection}` structure.
+   - No line budget.
+7. `## Cross-Cutting Priority Index` — new section.
+   - States that `wiki/MEMORY.md` is the canonical location for cross-cutting
+     items that affect multiple agents.
+   - States the schema (fields: Item / Agents / Owner / Status / Added), maximum
+     10 active entries, and the explicit empty-state row.
+   - Names `kata-wiki-curate` as the authoritative writer. Any agent may propose
+     an entry mid-run; the curator is the one verifier.
+
+The `### Decision` table preserves today's wording verbatim — any rewording is
+out of scope for this spec.
+
+### Acceptance
+
+- `wc -l .claude/agents/references/memory-protocol.md` returns a number ≤ 100
+  (target ~90; the 10-line headroom covers formatter rewraps, not new content).
+- File has H2 headings exactly: `## Memory Tiers`, `## During Each Run`,
+  `## After Each Run`, `## Summary Contract`, `## Weekly Log Contract`,
+  `## Cross-Cutting Priority Index`.
+- `bunx fit-map validate` passes (file is not read by fit-map but the monorepo
+  as a whole must still validate — smoke test only).
+
+## Step 2 — Rewrite `wiki/MEMORY.md`
+
+Current file is 20 lines of static navigation. New file adds a priority section
+above the navigation. Keep the existing agent-summary links (they are still
+useful for Tier 2 opt-in lookup) but demote them beneath the priorities.
+
+Structure (in order):
+
+1. `# Memory Index` (H1, unchanged).
+2. `## Cross-Cutting Priorities` — new section. Introduces the table with a
+   one-sentence description. Then a markdown table with columns **Item**,
+   **Agents**, **Owner**, **Status**, **Added**. Empty-state row: a single row
+   reading `| *None* | — | — | — | — |` so agents can tell "no items" apart from
+   "not tracked yet." Cap: 10 active rows.
+3. `## Storyboard` — unchanged link to the current month's storyboard file.
+4. `## Agent Summaries` — unchanged list (note: Tier 2, opt-in).
+5. `## Cross-Agent` — unchanged link to `downstream-skill.md`.
+
+The priority table is seeded with the empty-state row only. Part 03
+(technical-writer) populates the real cross-cutting items during migration.
+
+### Acceptance
+
+- File has the `## Cross-Cutting Priorities` section directly below the H1.
+- Table header is `| Item | Agents | Owner | Status | Added |` with left-aligned
+  separator (`| --- | --- | --- | --- | --- |`).
+- Empty-state row present.
+- `wc -l wiki/MEMORY.md` returns ≤ 40.
+
+## Step 3 — Modify `kata-wiki-curate/SKILL.md`
+
+Three localized edits. Do not rewrite the whole file.
+
+**Edit 3a — Step 0 wording (lines 38–46).** The line "Read memory per the agent
+profile (your summary, the current week's log, and teammates' summaries)" is
+currently misaligned with the new tiered protocol (teammate summaries are Tier 2
+for every skill except this one). Replace the parenthetical with: "(your
+summary, the current week's log, and — because this skill is a named Tier 2
+reader — all teammate summaries, all current-week logs, `wiki/MEMORY.md`, and
+`wiki/Home.md`)." This states the curator's authority explicitly.
+
+**Edit 3b — Step 1 adds contract enforcement.** After the existing four bullets
+under "Summary accuracy", add a fifth bullet (phrased so the forward reference
+is explicit and self-disabling if part 02 is reverted):
+
+> - **Contract conformance** — When `just wiki-audit` is available (added by
+>   spec 590 part 02), run it and fix any summary failures directly in the
+>   summary file. The curator is the only agent that rewrites summaries; other
+>   agents propose edits via observations.
+
+The forward reference is intentional: part 01 lands first, part 02 creates the
+command. Between the two merges, the bullet reads as a conditional instruction
+("when available"), not as a broken promise. The first curator invocation under
+the new protocol is part 03, by which time part 02 has landed.
+
+**Edit 3c — Step 5 output target (lines 105–116).** Rewrite Step 5 to state:
+
+- The scan logic is unchanged (systemic blockers, breaking changes, policy
+  changes).
+- The **required destination** is `wiki/MEMORY.md`'s
+  `## Cross-Cutting Priorities` table. Add an entry with the schema (Item /
+  Agents / Owner / Status / Added).
+- Mirroring into an affected agent's `Observations for Teammates` is
+  **conditional** — only when the agent needs context beyond what the index
+  entry conveys. State this explicitly.
+- Resolved items: remove within one curation cycle.
+
+### Acceptance
+
+- Step 0 contains the new parenthetical stating "Tier 2 reader."
+- Step 1 contains the new "Contract conformance" bullet referencing
+  `just wiki-audit`.
+- Step 5 heading unchanged; body contains the phrases "required destination",
+  "`wiki/MEMORY.md`", and "conditional" in that order.
+- No other edits to the file.
+
+## Step 4 — Smoke checks
+
+Run from the repo root:
+
+```bash
+bunx fit-map validate
+bun run format
+bun run lint
+```
+
+Commit only if all three pass.
+
+## Blast Radius
+
+- 3 files modified.
+- No runtime code, no tests, no CI workflow, no public API.
+- Documentation linters (`bun run format` / Prettier) apply.
+
+## Commit + PR
+
+- One commit, conventional commit message:
+  `docs(protocol): condense agent memory and add cross-cutting priority index`
+- PR body links to `specs/590-condensed-memory-and-priority-index/spec.md`,
+  `design.md`, and `plan-a-01.md`.
+- Sign PR body with `— Staff Engineer 🛠️`.
+
+## Risks specific to this part
+
+- **Misalignment between protocol text and kata-wiki-curate Step 0.** Mitigated
+  by editing both files in the same PR and by the review panel.
+- **Agents miss the new Tier 1/2 split at runtime.** The protocol is declarative
+  and agents read it at session start; no runtime change is required. The
+  structural pressure to read teammate summaries drops in part 03 when the
+  priority index is populated — not in this part.

--- a/specs/590-condensed-memory-and-priority-index/plan-a-02.md
+++ b/specs/590-condensed-memory-and-priority-index/plan-a-02.md
@@ -1,0 +1,196 @@
+# Plan 590-A Part 02 — Conformance Command
+
+**Agent:** staff-engineer **Branch:** `spec/590-part-02-audit` from `main`
+**Depends on:** part 01 merged to `main` **PR type:** `docs` (no runtime code —
+audit script lives under `scripts/`)
+
+## Goal
+
+Add a mechanical conformance command named in the spec (success criterion 6):
+`just wiki-audit`. It reports per-file pass/fail against the summary contract,
+weekly log contract, and priority index schema that part 01 established. It is
+the measurable definition of "done" for the content migration in part 03.
+
+## Files
+
+| Action | Path                    | Notes                                                         |
+| ------ | ----------------------- | ------------------------------------------------------------- |
+| Create | `scripts/wiki-audit.sh` | POSIX shell script — no Bun/Node dependency                   |
+| Modify | `justfile`              | Add `wiki-audit` recipe directly after `wiki-push` (line ~16) |
+
+`kata-wiki-curate/SKILL.md` is not touched by this part — the forward reference
+added in part 01 resolves once this part lands. No verification step needed
+beyond running `just wiki-audit` from the curate skill's new bullet, which part
+03 will exercise.
+
+## Step 1 — Write `scripts/wiki-audit.sh`
+
+A Bash script (not POSIX — uses `shopt` for glob safety). Match the style of the
+existing `scripts/wiki-sync.sh`. Shebang `#!/usr/bin/env bash` followed by
+`set -euo pipefail` and `shopt -s nullglob`. No arguments; exits non-zero if any
+check fails. Prints a one-line verdict plus per-failure detail.
+
+**Summary-file identification.** A file is an "agent summary" if it matches
+_all_ of the following: lives directly under `wiki/` (not in a subdirectory),
+ends in `.md`, does not match the weekly-log pattern (`*-YYYY-Www.md`), is not
+`MEMORY.md`, `Home.md`, or `storyboard-*.md`, **and** its first non-blank line
+matches `^# .* — Summary$`. Files in `wiki/` that fail the "— Summary" H1 probe
+(today: `downstream-skill.md`) are not audited against the summary contract.
+This keeps the audit tight without hard-coding a file list.
+
+Declare the permitted H2 set at the top of the script as a bash array so the
+intent is singular and greppable:
+
+```bash
+permitted_summary_h2s=(
+  "Open Blockers"
+  "Observations for Teammates"
+)
+# Any H2 whose text is NOT in this list is considered an agent-specific
+# state section — permitted but must appear before "Open Blockers".
+```
+
+Checks performed in order (each is a separate function; first-to-fail continues
+so the operator sees all failures, not just the first):
+
+### 1a. Summary contract — line budget
+
+For each agent summary file (per the identification rule above):
+
+- `wc -l "$file"` must be ≤ 80.
+- Fail message: `FAIL budget: $file has $lines lines (limit 80)`.
+
+### 1b. Summary contract — permitted sections and order
+
+For each agent summary file:
+
+- First non-blank line must match `^# [A-Z].* — Summary$`.
+- File must contain a line starting with `**Last run**:`.
+- Enumerate H2s in document order via `grep -n '^## '`. Verify:
+  - If both `## Open Blockers` and `## Observations for Teammates` are present,
+    `## Open Blockers` must appear first.
+  - If any H2 not in `permitted_summary_h2s` (a state H2) appears after
+    `## Open Blockers`, that is out of order.
+- Fail message: `FAIL sections: $file missing $section` or
+  `FAIL sections: $file sections out of order ($detail)`.
+
+### 1c. Summary contract — excluded content (informational)
+
+Warn (do not fail) if an H2 heading in a summary file matches any of these
+extended regex patterns. Use `grep -E -n '^## ...' "$file"`:
+
+```bash
+excluded_h2_patterns=(
+  '^## Previously Tracked'
+  '^## Evaluation History'
+  '^## Recently Closed'
+  '^## Storyboard Commitments'
+  '^## W[0-9]+ Day'
+  '^## .*Outcomes \(20'
+)
+```
+
+Warn message:
+`WARN excluded: $file:$line contains $match (belongs in weekly log)`.
+
+**Why warn and not fail:** 1a already fails any over-budget summary, and
+over-budget summaries are almost always over-budget _because_ of excluded
+content. Hard-failing on patterns would double-report the same underlying
+violation and make the audit output noisier without changing the pass/fail
+outcome. The warnings exist as a migration aid for part 03 (pointing the
+technical-writer at the specific lines to trim) and for the curator's recurring
+Step 1 check.
+
+### 1d. Weekly log contract — filename and heading
+
+For each file matching `wiki/*-[0-9][0-9][0-9][0-9]-W[0-9][0-9].md`:
+
+- Filename matches `^wiki/[a-z-]+-20[0-9][0-9]-W[0-9][0-9]\.md$`.
+- First non-blank line matches `^# .* — 20[0-9][0-9]-W[0-9][0-9]$`.
+- Fail message: `FAIL weekly-log: $file $reason`.
+
+### 1e. Priority index schema
+
+For `wiki/MEMORY.md`:
+
+- Must contain the exact H2 `## Cross-Cutting Priorities`.
+- Under it, must contain the exact header row
+  `| Item | Agents | Owner | Status | Added |`.
+- Must contain at least one data row (empty-state row
+  `| *None* | — | — | — | — |` counts).
+- Active (status=`active`) rows must not exceed 10.
+- Fail message: `FAIL memory: $reason`.
+
+### 1f. Aggregate verdict
+
+- If any FAIL line printed: `RESULT: fail (N checks failed)` then `exit 1`.
+- Else: `RESULT: pass` then `exit 0`.
+
+Warnings are always included in output regardless of verdict.
+
+### Acceptance
+
+- `bash scripts/wiki-audit.sh` runs in under 1 second on the current wiki.
+- `echo $?` is non-zero because current wiki is non-conforming (summaries too
+  long). This is expected and proves the audit detects real violations.
+- The script does not need `bunx` / `npm` / `bun` — only `bash`, `wc`, `grep`,
+  `awk`, `sed`.
+
+## Step 2 — Add `wiki-audit` justfile recipe
+
+Insert directly after the `wiki-push` recipe (currently lines 14–16). New
+recipe:
+
+```just
+# Audit agent memory against the wiki contract
+wiki-audit:
+    bash scripts/wiki-audit.sh
+```
+
+Two lines added, no other changes to `justfile`. Verify `just --list` shows the
+new recipe.
+
+## Step 3 — Smoke checks
+
+```bash
+just wiki-audit   # expected: non-zero exit, prints specific failures
+bun run format
+bun run lint
+```
+
+Verify that the `bun run format` check passes for any markdown the script
+touches (it touches none) and that `bun run lint` does not regress.
+
+## Blast Radius
+
+- 1 new file (`scripts/wiki-audit.sh`).
+- 1 existing file modified by 2 lines (`justfile`).
+- No changes to TypeScript/JavaScript code, no test files, no CI.
+
+## Commit + PR
+
+- One commit: `docs(scripts): add wiki-audit conformance command for spec 590`
+- Mark executable (`chmod +x scripts/wiki-audit.sh`) before commit.
+- PR body references plan-a-02.md and links to part 01's PR.
+
+## Risks specific to this part
+
+- **False negatives (checks miss a violation type).** Mitigated by keeping the
+  audit narrow: it checks the contract, not prose quality. Additional checks can
+  be added in a later iteration without changing the contract.
+- **False positives (valid summary fails a heuristic).** Most likely in 1b
+  (section order). If an agent's legitimate state needs a section name outside
+  the permitted list, the permitted list is what must change, not the skip list.
+  The audit script must not silently tolerate unknown H2s — unknown H2s warn so
+  part 03 can surface a budget-or-contract decision to a human.
+- **`set -euo pipefail` + glob expansion with no matches.** Use
+  `shopt -s nullglob` or the POSIX-safe loop pattern (`for f in $(find ...)`) to
+  avoid the "no matches" trap. Document the chosen idiom at the top of the file.
+
+## Non-goals
+
+- No CI integration. `just wiki-audit` is a local command for the
+  technical-writer's curate workflow. A Stop-hook or GitHub Actions job is out
+  of scope for this spec (spec 590 § Scope → Excluded: enforcement mechanism is
+  a design decision; the design chose "curation step", not "CI gate").
+- No auto-fix. The script only detects.

--- a/specs/590-condensed-memory-and-priority-index/plan-a-03.md
+++ b/specs/590-condensed-memory-and-priority-index/plan-a-03.md
@@ -1,0 +1,256 @@
+# Plan 590-A Part 03 — Wiki Cleanup Under New Protocol
+
+**Agent:** technical-writer **Depends on:** parts 01 and 02 merged to `main`
+**Branches (two):**
+
+1. **Wiki branch** — commits go directly to the `wiki/` submodule on `master`
+   (no GitHub PR is opened for the wiki repo). Follow the `kata-wiki-curate`
+   skill's "Publishing changes" section —
+   `cd wiki && git push origin HEAD:master`, or let the `Stop` hook run
+   `just wiki-push`. Carries: the summary migrations, MEMORY.md priority-index
+   seeding, weekly log hygiene fixes, and the metrics CSV row from Step 5.
+2. **Monorepo branch** — `fix/spec-590-status-plan-implemented` from `main`.
+   One-line edit to `specs/STATUS` (the `590 plan approved` row becomes
+   `590 plan implemented`). Standard docs-type PR via
+   `mcp__github__create_pull_request`, merged through the usual PM gate. This is
+   the only monorepo change in part 03.
+
+Keeping the two changes on two branches matches the design's wiki/monorepo split
+and mirrors the pattern used by `kata-wiki-curate`'s "Publishing changes"
+guidance.
+
+## Goal
+
+Migrate the existing wiki content to conform to the protocol established in
+part 01. At the end of this part, `just wiki-audit` (from part 02) returns a
+clean zero-failure verdict. This is the final step of spec 590.
+
+This part is intentionally routed to the **technical-writer agent** because wiki
+curation — deciding what counts as state vs. history, which cross-cutting items
+belong in the index, how to preserve meaning while trimming lines — is
+technical-writer scope. The staff-engineer must not perform this migration; the
+agent skilled at prose is the right executor.
+
+## Step 0 — Preconditions
+
+Confirm before starting:
+
+- `git show main:specs/STATUS` shows spec 590 at exactly `plan approved`. Parts
+  01 and 02 do **not** advance STATUS (per plan-a.md § Execution); STATUS stays
+  at `plan approved` from human approval through the end of part 02. Step 6 of
+  this part is what advances it to `plan implemented`. If the row reads anything
+  else, stop — either the plan has not been approved yet, or a prior part
+  mistakenly advanced it.
+- `git show main:.claude/agents/references/memory-protocol.md` contains the
+  `## Summary Contract`, `## Weekly Log Contract`, and
+  `## Cross-Cutting Priority Index` sections (part 01 landed).
+- `git show main:scripts/wiki-audit.sh` exists (part 02 landed).
+- `just wiki-audit` runs from the repo root and currently prints failures for at
+  least product-manager, improvement-coach, and security-engineer summary files.
+
+If any precondition fails, stop and surface the gap.
+
+## Step 1 — Populate `wiki/MEMORY.md` priority index
+
+Run `kata-wiki-curate` Step 5's new logic (per part 01): scan all agent
+summaries and recent weekly logs for cross-cutting items. For each item, write a
+row to the `## Cross-Cutting Priorities` table with the schema **Item / Agents /
+Owner / Status / Added**.
+
+Expected seed entries (from the spec's evidence section, verified against
+current wiki state on the branch). Agent slugs only — no `PM`/`TW`/`RE`
+abbreviations; the audit in part 02 expects slugs and the acceptance criterion
+below enforces this:
+
+| Candidate                                               | Affected agents                                     | Owner            | Status | Notes                                                                |
+| ------------------------------------------------------- | --------------------------------------------------- | ---------------- | ------ | -------------------------------------------------------------------- |
+| Spec 590 migration in flight                            | all                                                 | technical-writer | active | Remove when this part merges                                         |
+| Spec 420 documentation debt (46+ accuracy errors)       | technical-writer, staff-engineer, product-manager   | technical-writer | active | Names the largest outstanding doc item                               |
+| Formatting regressions on main (direct-to-main merges)  | all                                                 | release-engineer | active | Referenced by improvement-coach, release-engineer, security-engineer |
+| Harness-level `.claude/skills/` write protection (#441) | staff-engineer, security-engineer, technical-writer | human            | active | Blocks agent self-maintenance                                        |
+
+Do not invent entries. If a candidate is already resolved in the current wiki
+state, do not add it. If more than 10 active entries are identified, defer the
+lowest-severity ones to agent-to-agent `Observations for Teammates` sections —
+the cap is a forcing function for importance, not a silent truncation.
+
+Remove the empty-state row once at least one real entry is written.
+
+### Acceptance
+
+- `wiki/MEMORY.md` priority table has between 1 and 10 active rows.
+- Every affected agent is named by its slug (e.g., `technical-writer`, not
+  "TW").
+- `just wiki-audit` no longer prints the `FAIL memory` line.
+
+## Step 2 — Migrate each summary file
+
+For each `wiki/<agent>.md`, bring it under the 80-line budget and into contract
+conformance. Work in this order (largest first, so budget pressure is resolved
+before section-order fixes):
+
+| File                        | Current lines | Target | Primary action                                      |
+| --------------------------- | ------------: | ------ | --------------------------------------------------- |
+| `wiki/security-engineer.md` |           164 | ≤ 80   | Move W17 Day-by-day Outcomes sections to weekly log |
+| `wiki/improvement-coach.md` |           137 | ≤ 80   | Compact `## Recurring Patterns` (11 bullets)        |
+| `wiki/product-manager.md`   |           130 | ≤ 80   | Delete `## Previously Tracked PRs` (32-row table)   |
+| `wiki/technical-writer.md`  |            86 | ≤ 80   | Trim `## Resolved Since Last Summary` (move to log) |
+| `wiki/staff-engineer.md`    |            72 | ≤ 80   | Already within budget — verify section order only   |
+| `wiki/release-engineer.md`  |            64 | ≤ 80   | Already within budget — verify section order only   |
+
+**Migration rules (apply uniformly):**
+
+- **Historical audit data → weekly log.** "Previously Tracked PRs", "W{N} Day X
+  Outcomes", "Recently Closed", "Evaluation History", "Resolved Since Last
+  Summary" — move the content to the agent's current weekly log under a
+  `## YYYY-MM-DD` section marked `### Migrated from summary on 2026-04-23`. Do
+  not delete content without first appending it to the log. Git history alone is
+  not the archival mechanism (the design permits deletion but only where the
+  content already exists in logs).
+- **Storyboard commitments → storyboard file.** If a summary has a
+  `## Storyboard Commitments` section, delete it from the summary; verify the
+  same information is in `wiki/storyboard-2026-M04.md` (it almost certainly is,
+  because the storyboard is authoritative).
+- **Metrics tables → CSV.** If a summary has a `## Metrics` section with more
+  than a reference to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`, replace the
+  section body with a one-line pointer: "Recording {list} to
+  `wiki/metrics/{agent}/{domain}/2026.csv`."
+- **Permitted sections only.** After migration, the summary's H2s must be a
+  subset of: any agent-specific state section(s), `## Open Blockers`,
+  `## Observations for Teammates`. H1 and `**Last run**:` line stay.
+- **Active content only.** "Open Blockers" lists currently blocking items.
+  Delete anything marked resolved, ~~struck-through~~, or historical.
+- **Observations trimmed.** If an item in `## Observations for Teammates`
+  crosses ≥3 agents, promote it to the priority index (Step 1) instead of
+  repeating it in multiple summaries.
+
+### Acceptance per file
+
+- `wc -l wiki/<agent>.md` ≤ 80.
+- No excluded-content warnings from `just wiki-audit`.
+- Every removed historical item has been appended to the agent's current weekly
+  log.
+
+## Step 3 — Weekly log hygiene
+
+Run `kata-wiki-curate` Step 4 (log hygiene) against every `wiki/*-20??-W??.md`.
+The audit script covers filename and top heading; the human-level check is:
+
+- Each run entry uses `## YYYY-MM-DD` heading.
+- Subsections use `###` headings consistent with each skill's "Memory: what to
+  record" list.
+- No edits to past entries (migration additions in Step 2 are flagged as
+  `### Migrated from summary on 2026-04-23` — that is an append, not an edit to
+  prior content).
+
+### Acceptance
+
+- `just wiki-audit` no longer prints any `FAIL weekly-log` lines.
+
+## Step 4 — Final audit
+
+From the repo root:
+
+```bash
+just wiki-audit
+```
+
+Expected output: `RESULT: pass`. No FAIL lines.
+
+Warnings are allowed (they are informational by design) but the technical-writer
+must note each warning in the curation log for the next curation cycle to
+consider.
+
+Also run:
+
+```bash
+bunx fit-map validate   # spec 590 success criterion 8
+just wiki-push          # publishes the migrated wiki
+```
+
+## Step 5 — Record baseline + measurement for future kata-trace
+
+Spec 590 success criterion 7 requires a follow-up kata-trace analysis that
+compares post-change numbers against the baseline (25 wiki reads before first
+action; turn 60 first non-read action). This part does **not** run that analysis
+— the next scheduled technical-writer non-curate run produces the numbers. What
+this part does:
+
+- Append a row to `wiki/metrics/technical-writer/coverage/2026.csv` recording
+  `wiki_lines_total` (post-migration `wc -l wiki/*.md | tail -1`) and
+  `summary_files_conforming` (count of `wiki/<agent>.md` files where
+  `wc -l ≤ 80`). Create the CSV and header row if missing.
+- Note in the technical-writer's summary under `## Observations for Teammates`:
+  "Spec 590 migration complete — next non-curate TW run's kata-trace should show
+  ≤12 wiki reads pre-first-action and first-non-read-action ≤ turn 30 (both 50%
+  of baseline)."
+
+The actual kata-trace comparison is a later improvement-coach / technical-writer
+joint action; it is not in scope for this part.
+
+### Acceptance
+
+- `wiki/metrics/technical-writer/coverage/2026.csv` has the new row.
+- The observation is present in `wiki/technical-writer.md` and the summary still
+  fits the 80-line budget.
+
+## Step 6 — Publish and close
+
+Wiki publish (on the wiki submodule):
+
+- `just wiki-push` (or let the `Stop` hook do it).
+- Append the usual curation entry to the current week's technical-writer weekly
+  log — i.e. `wiki/technical-writer-$(date +%G-W%V).md`, which today resolves to
+  `wiki/technical-writer-2026-W17.md`. Do not hand-pick the week; use the
+  ISO-week-of-run. Entry fields:
+  - **Areas curated** — all four plus priority-index-seed
+  - **Summary corrections** — all 6 agents
+  - **MEMORY.md changes** — priority index seeded with N rows
+  - **Migration notes** — per-agent line counts before → after
+  - **Observations for teammates** — the kata-trace measurement prompt
+
+STATUS advance (on the monorepo `fix/spec-590-status-plan-implemented` branch
+declared in the header):
+
+- Edit `specs/STATUS`: change the row `590\tplan\tapproved` to
+  `590\tplan\timplemented` (tabs preserved; the file uses tab separators).
+  Confirm the vocabulary matches the header comments of `specs/STATUS` which
+  enumerate the lifecycle phases.
+- `bun run format` to normalize any trailing whitespace.
+- Commit message: `docs(specs): advance spec 590 to plan implemented`.
+- Open PR via `mcp__github__create_pull_request`, signed
+  `— Technical Writer 📝`. Normal docs-type PM gate applies.
+
+## Blast Radius
+
+- **Wiki submodule:** every `wiki/<agent>.md`, `wiki/MEMORY.md`, and the
+  current-week technical-writer log. Metrics CSV created/appended in
+  `wiki/metrics/technical-writer/coverage/2026.csv`. No other wiki files
+  touched.
+- **Monorepo:** one-line edit to `specs/STATUS`. No `.claude/` changes. No
+  source code. No test or CI changes.
+
+## Risks specific to this part
+
+- **Summary budget too tight for security-engineer.** The SE summary at 164
+  lines is the hardest to compress to 80. If genuine state (compatibility
+  blockers, coverage map, watchlist, observations) cannot fit, the
+  technical-writer surfaces a budget-revision question rather than stripping
+  load-bearing content. Escalation path: raise as an observation in the priority
+  index with owner=technical-writer, status=active. Do not pre-commit to a
+  larger budget; the design picked 80 deliberately.
+- **Content loss during history → weekly log move.** Mitigated by appending
+  first, deleting second, within the same commit.
+- **Priority index bloats past 10.** Technical-writer applies judgement: the cap
+  is the forcing function. The four seed candidates named in Step 1 are the
+  expected starting set; real migration may find fewer.
+- **Wiki push / Stop hook interaction.** The existing Stop hook runs
+  `just wiki-push`; migration commits to the wiki repo must not stage monorepo
+  paths. Standard wiki-curate discipline applies.
+
+## Non-goals
+
+- Storyboard redesign (explicitly excluded by spec 590 scope).
+- Per-agent skill-specific memory field changes (excluded by spec 590 scope).
+- Wiki archival directory creation (design chose deletion-after-log-append over
+  an archive tree).

--- a/specs/590-condensed-memory-and-priority-index/plan-a.md
+++ b/specs/590-condensed-memory-and-priority-index/plan-a.md
@@ -1,0 +1,107 @@
+# Plan 590-A — Condensed Agent Memory and Cross-Cutting Priority Index
+
+## Approach
+
+Land the protocol, the MEMORY.md shape, and the kata-wiki-curate update in one
+infrastructure PR so the contracts and the file shape they describe arrive
+together (design constraint). Then add a canonical conformance command so
+progress is pass/fail-measurable. Finally, the technical-writer agent performs
+the content migration of the wiki to conform, using the new protocol as its
+working contract.
+
+This order keeps the design's invariant ("protocol must not reference contracts
+or a MEMORY.md shape that does not yet exist") intact while keeping each part
+small enough to review and revert independently.
+
+Three parts. Parts 01 and 02 are staff-engineer work; part 03 is
+technical-writer work and is the last step in the plan, per the approved
+direction.
+
+## Part Index
+
+| Part                         | Agent            | Summary                                                                                    |
+| ---------------------------- | ---------------- | ------------------------------------------------------------------------------------------ |
+| [plan-a-01.md](plan-a-01.md) | staff-engineer   | Rewrite `memory-protocol.md`, reshape `wiki/MEMORY.md`, update `kata-wiki-curate/SKILL.md` |
+| [plan-a-02.md](plan-a-02.md) | staff-engineer   | Add `scripts/wiki-audit.sh` + `just wiki-audit` conformance command                        |
+| [plan-a-03.md](plan-a-03.md) | technical-writer | Migrate wiki content (summaries, MEMORY.md priorities, log hygiene) to conform             |
+
+## Dependencies
+
+- Part 01 → Part 02: audit script encodes the contracts defined in part 01.
+- Part 02 → Part 03: migration success is measured by part 02's audit command.
+- Part 03 is strictly last: the wiki cannot pass conformance until the protocol
+  and the audit command exist.
+
+No parallelism — this is a strictly sequential plan.
+
+## Libraries Used
+
+No `@forwardimpact/lib*` packages are consumed by this plan. All work is
+markdown edits, a POSIX shell script, and a justfile recipe. The conformance
+script uses standard Unix tools (`wc`, `grep`, `awk`) — no new runtime
+dependency.
+
+## Execution
+
+Each part is an independent branch off `main` and an independent PR. Each PR
+requires the normal human review/merge gate — nothing about decomposition waives
+that.
+
+1. **Part 01** — staff-engineer. Infrastructure PR on
+   `spec/590-part-01-protocol`. Lands protocol, MEMORY.md shape, and
+   kata-wiki-curate update together. After merge to main, MEMORY.md carries an
+   empty-state "None" row in the priorities section; agent summaries are still
+   non-conforming (expected).
+2. **Part 02** — staff-engineer. Follow-up PR on `spec/590-part-02-audit`
+   branched from `main` after part 01 merges. Adds the audit script and just
+   recipe. On main immediately after part 02, `just wiki-audit` reports the
+   current non-conformance count so migration progress is visible.
+3. **Part 03** — technical-writer. Final work on `fix/wiki-migrate-spec-590`,
+   branched from `main` after part 02 merges. Migrates summaries to meet the
+   line budget and section contract, seeds the priority index with currently
+   active cross-cutting items, verifies log hygiene. Ends with `just wiki-audit`
+   returning a clean (zero-failure) result — this is the success criterion for
+   the whole spec.
+
+STATUS transitions: parts 01 and 02 do **not** advance `specs/STATUS`. STATUS
+stays at `plan approved` throughout parts 01 and 02 and only advances to
+`plan implemented` as the final action of part 03 (see plan-a-03 Step 6).
+
+## Risks
+
+- **Protocol drift from skills that restate it.** The design says contracts live
+  only in `memory-protocol.md`; skills reference them. A future skill change
+  could re-introduce a restatement. Mitigated by part 01's kata-wiki-curate edit
+  showing the reference-only pattern.
+- **MEMORY.md priority index goes stale.** Resolved items linger. Mitigated by
+  part 01 naming the curator as the authoritative writer — the curator runs on
+  schedule and is responsible for removing resolved items within one curation
+  cycle. The audit does not check staleness; that is a process discipline, not a
+  mechanical check.
+- **Line budget too tight for some agents.** Current state on this branch,
+  verified by `wc -l`: PM 130, IC 137, SE 164, TW 86, RE 64, Staff 72. (The
+  design cites "PM 163, IC 137, SE 103" — those numbers had aged by the time
+  this plan was written; the plan uses the current `wc -l` values and supersedes
+  the design's figures for planning purposes.) Budget is 80. If a post-migration
+  summary cannot fit legitimate state under 80 lines, part 03 must surface it
+  for budget revision rather than silently stripping state. Failure mode
+  documented in part 03.
+- **Wiki content migration is destructive** (deletes historical tables). Part 03
+  must verify the relevant history is captured in weekly logs or git before
+  deletion. Mitigation: the technical-writer agent follows its standard wiki
+  curation discipline and is the right agent for content judgement calls.
+
+## Success Criteria (from spec 590, verified post-part-03)
+
+- `wiki/MEMORY.md` exposes cross-cutting items (criterion 1)
+- `memory-protocol.md` defines the tiered load (criterion 2)
+- `kata-wiki-curate` Step 5 targets MEMORY.md (criterion 3)
+- Summary contract lives canonically in `memory-protocol.md` (criterion 4)
+- Weekly log contract lives canonically in `memory-protocol.md` (criterion 5)
+- `just wiki-audit` passes over the migrated wiki (criterion 6)
+- Follow-up kata-trace measurements (criterion 7) — recorded by the technical
+  writer to `wiki/metrics/technical-writer/` after the first post-migration run.
+  Not a blocker for this plan; it is verification that lands in a later
+  kata-trace analysis session.
+- `bunx fit-map validate` and wiki push/curate workflows continue to succeed
+  (criterion 8) — verified at the end of each part.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -78,5 +78,5 @@
 560	plan	draft
 570	plan	approved
 580	plan	implemented
-590	design	approved
+590	plan	draft
 600	design	approved

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -78,5 +78,5 @@
 560	plan	draft
 570	plan	approved
 580	plan	implemented
-590	plan	draft
+590	plan	approved
 600	design	approved


### PR DESCRIPTION
## Summary

- 3-part plan for spec 590 (condensed agent memory + cross-cutting priority index). Parts 01–02 are staff-engineer infrastructure (rewrite `memory-protocol.md`, reshape `wiki/MEMORY.md`, update `kata-wiki-curate`; then add `scripts/wiki-audit.sh` + `just wiki-audit`). Part 03 routes to the technical-writer — the final step migrates the existing wiki to conform to the new protocol.
- Plan decomposed to honor the design's "protocol + MEMORY.md shape must land together" constraint while keeping parts small enough to review independently.
- `specs/STATUS` advances 590 `design approved` → `plan approved`.

## Test plan

- [x] `bun run check` (format + lint + instructions)
- [x] `bun run test` (2360 pass, 1 skip, 0 fail)
- [x] Clean 3-agent kata-review panel; all consensus blocker/high/medium findings addressed, singletons triaged with explicit rationale

— Staff Engineer 🛠️

---
_Generated by [Claude Code](https://claude.ai/code/session_011iF7zSsQfiQwNeZ2mvGGv5)_