### PR TITLE
fix(kata-action): stop stripping --max-turns=0 from fit-eval invocations

### DIFF
--- a/.github/actions/kata-action/action.yml
+++ b/.github/actions/kata-action/action.yml
@@ -141,9 +141,13 @@ runs:
           args+=("--output=$TRACE_DIR/trace.ndjson")
         fi
 
-        if [ "$MODE" = "supervise" ]; then
-          agent_cwd="${AGENT_CWD:-$(mktemp -d)}"
+        # Mode-invariant flags. --max-turns is always forwarded; the CLI
+        # treats "0" as unlimited, while omitting the flag silently falls
+        # back to the SDK's ~50-turn cap.
+        args+=("--max-turns=$MAX_TURNS")
+        args+=("--model=$MODEL")
 
+        if [ "$MODE" = "supervise" ]; then
           if [ -n "$SUPERVISOR_PROFILE" ]; then
             args+=("--supervisor-profile=$SUPERVISOR_PROFILE")
           fi
@@ -154,14 +158,9 @@ runs:
             args+=("--agent-profile=$AGENT_PROFILE")
           fi
 
-          if [ "$MAX_TURNS" != "0" ]; then
-            args+=("--max-turns=$MAX_TURNS")
-          fi
-
           bunx fit-eval supervise \
             --supervisor-cwd="$SUPERVISOR_CWD" \
-            --agent-cwd="$agent_cwd" \
-            --model="$MODEL" \
+            --agent-cwd="$AGENT_CWD" \
             --allowed-tools="$TOOLS" \
             "${args[@]}"
         elif [ "$MODE" = "facilitate" ]; then
@@ -169,28 +168,18 @@ runs:
             args+=("--facilitator-profile=$FACILITATOR_PROFILE")
           fi
 
-          if [ "$MAX_TURNS" != "0" ]; then
-            args+=("--max-turns=$MAX_TURNS")
-          fi
-
           bunx fit-eval facilitate \
             --facilitator-cwd="." \
             --agent-profiles="$AGENT_PROFILES" \
             --agent-cwd="$AGENT_CWD" \
-            --model="$MODEL" \
             "${args[@]}"
         else
           if [ -n "$AGENT_PROFILE" ]; then
             args+=("--agent-profile=$AGENT_PROFILE")
           fi
 
-          if [ "$MAX_TURNS" != "0" ]; then
-            args+=("--max-turns=$MAX_TURNS")
-          fi
-
           bunx fit-eval run \
             --cwd="$CWD" \
-            --model="$MODEL" \
             --allowed-tools="$TOOLS" \
             "${args[@]}"
         fi


### PR DESCRIPTION
## Summary

- `Agent: Staff Engineer` kept ending with `error_max_turns | Turns: 51` (e.g. [run 24817983741](https://github.com/forwardimpact/monorepo/actions/runs/24817983741/job/72636284599)) despite d60ce46, because three guards in `.github/actions/kata-action/action.yml` stripped `--max-turns` from the CLI invocation whenever the workflow passed `max-turns: "0"`. `fit-eval run` then fell back to its own `"50"` default (`libraries/libeval/src/commands/run.js:22`), which bypassed the `0 → MAX_SAFE_INTEGER` mapping in `AgentRunner` (`libraries/libeval/src/agent-runner.js:76-77`).
- Drop the three `if [ "$MAX_TURNS" != "0" ]` guards so `--max-turns=$MAX_TURNS` is always forwarded. The CLI already parses `"0"` as `0` (`run.js:31`, `supervise.js:33-36`, `facilitate.js:48`).
- Hoist `--max-turns` and `--model` into the shared `args` prelude (assembled once, not three times) and drop the unreachable `agent_cwd="${AGENT_CWD:-$(mktemp -d)}"` fallback — the action input defaults `agent-cwd` to `"."` so `$AGENT_CWD` is never empty, and `supervise.js:29-31` already `mkdtempSync`es when `--agent-cwd` is absent.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2360/2361, 1 skipped)
- [x] `bash -n` of the new shell block
- [ ] Observe the next scheduled `Agent: Staff Engineer` run ends with `Result: success` instead of `error_max_turns`

https://claude.ai/code/session_01QM9sFMWCSWwQo35kdNrMjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QM9sFMWCSWwQo35kdNrMjp)_