### PR TITLE
feat(libconfig): accept GH_TOKEN as fallback in Config.ghToken()

### DIFF
--- a/libraries/libconfig/src/config.js
+++ b/libraries/libconfig/src/config.js
@@ -20,6 +20,7 @@ export class Config {
   // so shell-exported credentials still work; .env is the fallback.
   static #CREDENTIAL_KEYS = new Set([
     "ANTHROPIC_API_KEY",
+    "GH_TOKEN",
     "GITHUB_TOKEN",
     "LLM_TOKEN",
     "MCP_TOKEN",
@@ -112,9 +113,14 @@ export class Config {
     Object.assign(this, data);
   }
 
-  /** @returns {string} GitHub token */
+  /** @returns {string} GitHub token (GITHUB_TOKEN, or GH_TOKEN as fallback) */
   ghToken() {
-    return this.#resolve("GITHUB_TOKEN");
+    if (this.#cache.has("GITHUB_TOKEN")) return this.#cache.get("GITHUB_TOKEN");
+    const value = this.#env("GITHUB_TOKEN") ?? this.#env("GH_TOKEN");
+    if (!value) throw new Error("GITHUB_TOKEN not found in environment");
+    const trimmed = value.trim();
+    this.#cache.set("GITHUB_TOKEN", trimmed);
+    return trimmed;
   }
 
   /** @returns {Promise<string>} LLM API token (async for caller compatibility) */

--- a/libraries/libconfig/test/libconfig-env-file.test.js
+++ b/libraries/libconfig/test/libconfig-env-file.test.js
@@ -68,13 +68,7 @@ describe("libconfig - .env file loading", () => {
     writeEnvFile("GH_TOKEN=gh-cli-value\n");
 
     const proc = createProcess();
-    const config = await createConfig(
-      "test",
-      "svc",
-      {},
-      proc,
-      mockStorageFn,
-    );
+    const config = await createConfig("test", "svc", {}, proc, mockStorageFn);
 
     assert.strictEqual(config.ghToken(), "gh-cli-value");
     assert.strictEqual(proc.env.GH_TOKEN, undefined);

--- a/libraries/libconfig/test/libconfig-env-file.test.js
+++ b/libraries/libconfig/test/libconfig-env-file.test.js
@@ -64,6 +64,22 @@ describe("libconfig - .env file loading", () => {
     assert.strictEqual(config.ghToken(), "env-value");
   });
 
+  test("GH_TOKEN from .env file is treated as a credential", async () => {
+    writeEnvFile("GH_TOKEN=gh-cli-value\n");
+
+    const proc = createProcess();
+    const config = await createConfig(
+      "test",
+      "svc",
+      {},
+      proc,
+      mockStorageFn,
+    );
+
+    assert.strictEqual(config.ghToken(), "gh-cli-value");
+    assert.strictEqual(proc.env.GH_TOKEN, undefined);
+  });
+
   test("loads non-allowed keys into process.env", async () => {
     writeEnvFile(
       "SERVICE_SECRET=my-secret\nSERVICE_MCP_URL=http://localhost:3005\nGITHUB_TOKEN=allowed\n",

--- a/libraries/libconfig/test/libconfig-getters.test.js
+++ b/libraries/libconfig/test/libconfig-getters.test.js
@@ -118,6 +118,38 @@ describe("libconfig - Config getters", () => {
     assert.strictEqual(config.ghToken(), "gh-token-xyz");
   });
 
+  test("ghToken falls back to GH_TOKEN when GITHUB_TOKEN is unset", async () => {
+    const mockProcess = {
+      cwd: mock.fn(() => "/test/dir"),
+      env: { GH_TOKEN: "gh-cli-token" },
+    };
+
+    const config = await createConfig(
+      "test",
+      "myservice",
+      {},
+      mockProcess,
+      mockStorageFn,
+    );
+    assert.strictEqual(config.ghToken(), "gh-cli-token");
+  });
+
+  test("ghToken prefers GITHUB_TOKEN when both are set", async () => {
+    const mockProcess = {
+      cwd: mock.fn(() => "/test/dir"),
+      env: { GITHUB_TOKEN: "github-token", GH_TOKEN: "gh-token" },
+    };
+
+    const config = await createConfig(
+      "test",
+      "myservice",
+      {},
+      mockProcess,
+      mockStorageFn,
+    );
+    assert.strictEqual(config.ghToken(), "github-token");
+  });
+
   test("llmToken throws when not set in environment", async () => {
     const mockProcess = {
       cwd: mock.fn(() => "/test/dir"),


### PR DESCRIPTION
## Summary

- `Config.ghToken()` now returns `GITHUB_TOKEN` when set and falls back to `GH_TOKEN` (the variable used by the `gh` CLI) when it isn't. Error message unchanged when neither is present.
- `GH_TOKEN` added to the credential keys set, so `.env` values are held in the private override map instead of leaking onto `process.env`.
- Tests cover GH_TOKEN fallback, GITHUB_TOKEN precedence, and `.env` credential isolation.

## Test plan

- [x] `bun run check`
- [x] `bun run test`

https://claude.ai/code/session_01SV3rNQbSf2vRsKkXWKm4gv