### PR TITLE
docs(specs): 620 rewrite scope to primitive redesign

### DIFF
--- a/specs/620-facilitated-tell-share-response-protocol/design.md
+++ b/specs/620-facilitated-tell-share-response-protocol/design.md
@@ -1,193 +1,193 @@
-# Design 620 — Facilitated Tell→Share Response Protocol
+# Design 620 — Request–Response Primitives for libeval Orchestration
 
 ## Problem (restated)
 
-Facilitated participants lack any instruction that a `Tell` requires a `Share`
-response. The facilitator side is enforced (`FACILITATOR_SYSTEM_PROMPT`,
-`facilitator.js:30-33`); the participant side survives only because
-team-storyboard Q2 `Tell`s end with "then Share". 1-on-1 coaching has no such
-template and stalls after Q1. Fix: state the rule at each layer the participant
-reads, deliver the Participant Protocol into the 1-on-1 context, and catalogue
-an invariant so the silent hang surfaces in audits.
+The Tell→Share stall is a symptom of messaging primitives that encode no
+request-response obligation. Four-layer prose defence-in-depth was the prior
+fix; it is brittle and survives only as long as every layer keeps restating the
+rule. Reshape the primitives so the contract is structural, not taught, and
+collapse the prose layers.
 
 ## Components
 
-Six change sites spanning four of the eight instruction layers defined in
-[KATA.md § Instruction layering](../../KATA.md#instruction-layering). Layer
-numbers below refer to that model — L1 = libeval system prompt + relay
-mechanics, L4 = workflow task, L6 = skill procedure (`SKILL.md`), L7 = skill
-references (`references/*.md`).
+Changes span the runtime (L1), one renamed skill (L6/L7), one workflow (L4), and
+one reference (L7). Layer numbers per
+[KATA.md § Instruction layering](../../KATA.md#instruction-layering).
 
-| Layer              | Component                                                                      | Role                                                      |
-| ------------------ | ------------------------------------------------------------------------------ | --------------------------------------------------------- |
-| L1 (system prompt) | `FACILITATED_AGENT_SYSTEM_PROMPT`                                              | Mode-universal base rule                                  |
-| L1 (tool server)   | `createFacilitatedAgentToolServer`                                             | Tool-catalog reinforcement                                |
-| L6                 | `kata-storyboard/SKILL.md` § Participant Protocol                              | Mode-agnostic step list                                   |
-| L7                 | `kata-storyboard/references/coaching-protocol.md` § 1-on-1 Coaching Adaptation | Invokes Participant Protocol; carries skill-load preamble |
-| L4                 | `.github/workflows/kata-coaching.yml`                                          | Minimal task-text, skill-delivery input                   |
-| L7                 | `kata-trace/references/invariants.md`                                          | Facilitated-mode completeness invariant                   |
+| Layer | Component                                                                               | Role                                                   |
+| ----- | --------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| L1    | `OrchestrationToolkit` — tool-server factories, handler factories, `ctx.pendingAsks`    | Tool surface, pending-ask state, violation emission    |
+| L1    | `Facilitator` / `Supervisor` — `#runAgent` turn-complete guard, system prompts, msg bus | Runtime enforcement; descriptive system-prompt framing |
+| L6    | `kata-session/SKILL.md` (renamed from `kata-storyboard`)                                | Mode-agnostic five-question procedure + Ask/Answer     |
+| L7    | `kata-session/references/{team-storyboard,one-on-one}.md`                               | Mode-specific overlays                                 |
+| L4    | `.github/workflows/kata-coaching.yml` `task-text`                                       | Single-sentence skill dispatch                         |
+| L7    | `kata-trace/references/invariants.md`                                                   | Two `protocol_violation` invariants (facil. + superv.) |
 
 ## Architecture
 
-### Defence-in-depth rule placement
+### New primitive vocabulary
 
-```mermaid
-flowchart TD
-    A[Participant receives first Tell] --> B[L1 system prompt: Tell→Share rule]
-    B --> C[L1 Tell/Share tool-catalog: response semantics]
-    C --> D[L6 Participant Protocol step 1: Share before turn ends]
-    D --> E{Share called?}
-    E -->|Yes| F[Facilitator resumed via messageBus]
-    E -->|No| G[Invariant: facilitated-mode completeness FAIL]
-```
+Both modes share one vocabulary. Asymmetric cardinality (1:1 vs 1:N) is handled
+by the `to` parameter, not by distinct tools.
 
-The rule is stated once per layer, progressively more specific. Per
-[KATA.md § Instruction layering](../../KATA.md#instruction-layering), L1 is
-descriptive (tool semantics) and L6 is procedural (steps): L1 names the
-Tell→Share response semantic, L6 requires the call.
+| Tool                     | Side                            | Semantics                                                                                           |
+| ------------------------ | ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `Ask(to?, question)`     | facilitator, supervisor         | Register pending-ask keyed by addressee; asker's turn ends; facilitator omits `to` → broadcast ask. |
+| `Answer(message)`        | participant, supervised agent   | Resolve the pending-ask owed to the caller; delivers reply to the asker's queue.                    |
+| `Announce(message)`      | both sides, both modes          | No-reply broadcast. Legitimate use of today's `Share`; never creates a pending-ask.                 |
+| `Redirect(message, to?)` | facilitator, supervisor         | Unchanged: hard interrupt with replacement instructions.                                            |
+| `Conclude(summary)`      | facilitator, supervisor         | Unchanged: close session.                                                                           |
+| `RollCall()`             | facilitator, supervisor, agents | Unchanged: list participants.                                                                       |
 
-**Rejected: single layer only.** If the participant misses that layer (skill not
-loaded, prompt truncation, SDK update), the rule vanishes. Defence in depth
-costs four short edits.
+`Tell`, `Share`, and the participant-side blocking `Ask` tool are removed — no
+aliases. `ctx.pendingAsks: Map<addressee, {askId, askerName, question}>` lives
+in the context built by `createOrchestrationContext()`.
 
-**Rejected: stronger enforcement in `facilitator.js`** (auto-inject a
-Share-reminder when an agent's turn ends without Share). Infrastructure that
-repairs a protocol violation masks it from trace audits, where spec 620 Success
-Criterion 3 needs it to be visible.
+**Rejected: keep `Tell`/`Share`, add `Ask`/`Answer` alongside.** Two
+vocabularies re-introduce the "is this Tell a question or an announcement?"
+ambiguity. **Rejected: distinct name for participant→facilitator Ask.**
+Unnecessary asymmetry — the from/to arguments already distinguish roles.
 
-### L1: participant system-prompt rule
+### Pending-ask registry and turn-complete guard
 
-`FACILITATED_AGENT_SYSTEM_PROMPT` gains one sentence stating the Tell→Share
-response semantic, symmetric in shape to the facilitator's existing rule at
-`facilitator.js:30-33`. Final wording belongs in the plan; the architectural
-commitment is (a) a single sentence, (b) appended to the constant, (c)
-describing the contract without new imperatives beyond the minimum needed to
-teach it.
-
-### L1: agent-side Tool-catalog descriptions
-
-`createFacilitatedAgentToolServer` `Share` description gains an addendum naming
-the "respond to a facilitator Tell" use of the tool. Agent-side `Tell`
-description is left unchanged.
-
-**Rejected: describe response via `Tell` back to the facilitator.** Works
-mechanically but loses cross-domain visibility (spec 490).
-
-**Rejected: mirror the addendum on agent-side `Tell`.** Participants in current
-workflows do not Tell each other; adding the rule there both increases surface
-without protocol benefit and risks suggesting agent-to-agent Tell as a response
-pattern, which is not the contract.
-
-### L6: universal Participant Protocol
-
-`kata-storyboard/SKILL.md` § Participant Protocol gains a universal step for the
-Tell→Share response rule ahead of its mode-specific steps (CSV recording,
-metrics sharing). Whether the universal step is prepended with renumbering or
-appears as an unnumbered preamble is a plan-level choice; the architectural
-commitment is that the rule appears once in the Protocol, in mode-agnostic form,
-before any mode-specific content.
-
-**Rejected: duplicate the rule in both the Team and 1-on-1 adaptations.**
-Divergence risk; the rule is mode-agnostic by construction.
-
-### L7: 1-on-1 Coaching Adaptation invokes the Participant Protocol
-
-`references/coaching-protocol.md` § 1-on-1 Coaching Adaptation gains a preamble
-that explicitly invokes the Participant Protocol in `SKILL.md` — making the
-universal Tell→Share step apply by reference rather than by inheritance. The
-existing question table follows as the mode-specific overlay. Preamble wording
-is a plan concern.
-
-### L4: coaching workflow task-text
-
-`.github/workflows/kata-coaching.yml` `task-text` is reduced to the same shape
-as `kata-storyboard.yml`: a single sentence that dispatches to the skill and
-names no participant-side work. The Q1-content prescription and the `kata-trace`
-assignment leave the workflow; `kata-trace` is reached under Q2 via the skill's
-existing `coaching-protocol.md` § Q2 guidance once the round-trip protocol
-works. Final wording is a plan choice.
-
-### Participant-Protocol delivery to 1-on-1 participants
-
-**Chosen: the 1-on-1 Coaching Adaptation section of `coaching-protocol.md`
-carries the skill-load preamble.** The section already guides the coach through
-the five questions in 1-on-1 mode (the coach reads it at Step 4 of the existing
-Facilitator Process). Adding a preamble there — "before Q1, instruct the
-participant to load `kata-storyboard` and follow its Participant Protocol" —
-puts the skill-load directive into the coach's first `Tell` to the participant
-without changing the Facilitator Process step list in `SKILL.md`. Spec SC 6
-(Facilitator Process unchanged) is preserved because the only modification to
-`SKILL.md` stays within the Participant Protocol section, as SC 6 explicitly
-permits.
+The orchestrator's agent loop (`#runAgent` in `facilitator.js`, equivalent loop
+in `supervisor.js`) becomes the enforcement site. Before emitting
+`lifecycle:turn_complete`, it consults `ctx.pendingAsks`.
 
 ```mermaid
 sequenceDiagram
-    participant C as Coach
+    participant F as Facilitator
+    participant R as #runAgent
     participant P as Participant
-    Note over C: Reads coaching-protocol.md 1-on-1 Adaptation preamble
-    C->>P: Tell — "load kata-storyboard, follow Participant Protocol, then Q1"
-    P->>P: Skill("kata-storyboard") — Participant Protocol now in context
-    P->>C: Share — Q1 response (per Protocol step 1)
-    loop Q2..Q5
-        C->>P: Tell Qn
-        P->>C: Share Qn response
-    end
-    C-->>P: Conclude
+    participant T as Trace
+
+    F->>R: Ask(to=P, question)
+    Note over R: ctx.pendingAsks.set(P, ask)
+    R->>P: deliver as user turn
+    P->>P: produce text, no Answer
+    Note over R: turn ends; pendingAsks.has(P)?
+    R->>P: synthetic reminder (once)
+    P->>P: still no Answer
+    R->>T: emit protocol_violation
+    Note over R: allow turn_complete
+    R-->>F: null Answer via messageBus
 ```
 
-**Rejected: add an opening step to the Facilitator Process in `SKILL.md`.** Spec
-SC 6 constrains the Facilitator Process to be unchanged; adding a new step would
-expand scope beyond what the spec allows.
+If the participant calls `Answer(message)` at any point, the handler clears the
+entry, routes the message to the asker via `messageBus`, and the runtime
+short-circuits the reminder/violation path.
 
-**Rejected: workflow `task-text` carries the protocol.** Couples protocol
-content to workflow config; every edit to the Protocol forces a workflow change,
-and the facilitate command only delivers `task-text` to the facilitator, not to
-participants.
+**Rejected: block `turn_complete` forever** (same deadlock, moved from prompt to
+runtime). **Rejected: zero retries** (wastes a turn the LLM would have recovered
+with a nudge). **Rejected: unbounded retries** (silent budget burn). One
+reminder + one trace event is the bounded cost/signal balance.
 
-**Rejected: agent-profile addendum.** Would bleed into every non-facilitated
-invocation of each domain agent, confusing solo runs.
+### Supervisor parity
 
-**Rejected: direct `Skill("kata-storyboard")` at participant session start via a
-facilitator.js change.** Requires infrastructure to inject a skill load into the
-participant's initial prompt, preferring infrastructure over an
-instruction-layer fix.
+Supervision gets the same vocabulary. Today the supervisor has `Redirect` +
+`Conclude` only; supervised agents have a blocking `Ask`. The new shape:
 
-### Facilitated-mode completeness invariant
+- **Supervisor:** `Ask`, `Announce`, `Redirect`, `Conclude`, `RollCall`.
+- **Supervised agent:** `Ask`, `Answer`, `Announce`, `RollCall`.
 
-A new `## Facilitator traces` table in `kata-trace/references/invariants.md`
-with two rows (spec SC 3). The evidence interface each row requires, at the
-architectural level:
+Either side can ask; either side must answer. The supervised-agent's historic
+blocking `Ask` (agent waits mid-tool-call for supervisor's text) becomes a
+regular `Ask` that registers pending on the supervisor. The supervisor's
+implicit text-relay reply becomes an explicit `Answer` call. This removes the
+special-case blocking path in `agent-runner.js`; all replies flow through the
+same `Answer` → `messageBus` route.
 
-| Invariant                                         | Evidence signature                                                                               | Severity |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------- |
-| Every addressed participant responded via `Share` | Set of distinct `Tell.to` values ⊆ set of distinct `Share` source values over the combined trace | **High** |
-| Session closed with exactly one `Conclude`        | Count of `Conclude` tool calls from the facilitator source equals 1                              | **High** |
+**Rejected: leave supervision untouched.** Two vocabularies across libeval is
+worse than one. The runtime cost of parity is small (same handlers, different
+wiring); the skill-authoring cost of two vocabularies is large (every future
+skill must learn both).
 
-Both signatures are computable from combined-trace tool-call records already
-produced by `facilitator.js`'s trace splitter — no new trace instrumentation.
-The concrete `fit-trace` query shape belongs in the plan (or inline in the
-invariant entry itself, the pattern the other tables in that file already
-follow).
+### System-prompt framing
 
-**Rejected: agent-typed invariant** (under `improvement-coach traces`). The
-contract is facilitated-mode, not coach-specific — any future facilitator
-benefits from the same audit.
+All four prompts (`FACILITATOR_`, `FACILITATED_AGENT_`, `SUPERVISOR_`,
+`AGENT_SYSTEM_PROMPT`) become descriptive, not enforcing. They name
+`Ask`/`Answer`/`Announce` in one sentence each and set the conversational frame
+("you are in a coaching session" / "a supervisor watches your work"). Every
+"then Share", "stop making tool calls", and "do not proceed until" phrase is
+removed — the runtime holds the contract now.
+
+**Rejected: keep enforcement phrases as belt-and-suspenders.** Creates
+contradiction risk when runtime and prompt disagree, and preserves the pattern
+the spec set out to dismantle.
+
+### Participant Protocol delivery
+
+Chosen: `FACILITATED_AGENT_SYSTEM_PROMPT` carries the Participant Protocol as a
+short descriptive summary (two or three sentences), plus a pointer to
+`kata-session` for detail. `systemPrompt` is set on the runner at construction
+time (`facilitator.js:489-492`), so every participant receives it before any Ask
+arrives — no bootstrap ordering problem, no coach-Tell circularity.
+
+**Rejected:** coach's first `Ask` (circular — bootstraps with the very protocol
+being bootstrapped); workflow `task-text` (reaches the facilitator only);
+agent-profile addendum (bleeds into solo runs); synthetic bootstrap user message
+(pollutes the trace with orchestrator-authored user turns). `systemPrompt`
+append is trace-clean by construction.
+
+### Skill restructure: `kata-storyboard` → `kata-session`
+
+Directory rename with content redistribution:
+
+```text
+kata-session/
+  SKILL.md                          mode-agnostic: five questions + Ask/Answer
+  references/team-storyboard.md     storyboard artifact, XmR, CSV, planning
+  references/one-on-one.md          participant-trace overlay
+  references/storyboard-template.md unchanged
+  references/metrics.md             unchanged
+```
+
+Front-matter `name: kata-session`. KATA.md skills table, agent profiles,
+workflows, and website internals update in lockstep.
+
+**Rejected: keep the name, add a mode-agnostic section.** Compounds the
+instruction-layer kludge this spec dismantles.
+
+### Coaching workflow task-text
+
+`kata-coaching.yml` `task-text` becomes one sentence that dispatches to
+`kata-session` with the target agent name. No Q1 prescription, no `kata-trace`
+front-load, no participant-side work. Unchanged rationale from prior draft; spec
+SC 8.
+
+### Protocol-violation invariants
+
+`kata-trace/references/invariants.md` gains two entries under a new
+`## Orchestrator traces` table, one per mode:
+
+| Mode        | Evidence signature                                                                  |
+| ----------- | ----------------------------------------------------------------------------------- |
+| Facilitated | Count of `protocol_violation` events in combined trace == 0; `Conclude` count == 1. |
+| Supervised  | Count of `protocol_violation` events in combined trace == 0; `Conclude` count == 1. |
+
+Both reduce to the same evidence function over distinct trace shapes; the
+invariant catalogue writes it once and parameterises on trace source.
+
+**Rejected: infer violations from tool-call set differences.** No longer
+necessary — the runtime emits structured events that are a direct match.
 
 ## Key Decisions
 
-| Decision                    | Chosen                                                        | Rejected                                                                             | Why                                                    |
-| --------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------ |
-| Rule placement              | Defence in depth across L1 system prompt + L1 tools + L6 + L7 | Single layer                                                                         | Survives skill-load gaps and SDK updates               |
-| Enforcement site            | Instruction layers                                            | Auto-inject in `facilitator.js`                                                      | Keeps violation visible to invariant audit (SC 3)      |
-| Participant Protocol shape  | Universal rule before mode-specific steps                     | Duplicate per mode                                                                   | No divergence; single source of truth                  |
-| Response tool               | `Share`                                                       | `Tell` back to facilitator                                                           | Cross-domain visibility (spec 490)                     |
-| Protocol delivery to 1-on-1 | Preamble in `coaching-protocol.md` § 1-on-1 Adaptation        | Opening step in Facilitator Process; `task-text`; profile addendum; infra skill-load | Stays within spec SC 6 (Facilitator Process unchanged) |
-| `task-text` shape           | Single sentence                                               | Keep prescription                                                                    | Matches `kata-storyboard.yml`; spec SC 4               |
-| Invariant scope             | Facilitated-mode (any facilitator)                            | Coach-specific                                                                       | Generalises to future facilitators                     |
+| Decision                      | Chosen                                                                     | Rejected                                                      | Why                                              |
+| ----------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------ |
+| Primitive set                 | `Ask` / `Answer` / `Announce` (+ Redirect/Conclude/RollCall), shared modes | Keep `Tell`/`Share`; add alongside; mode-specific names       | One vocabulary; contract encoded structurally    |
+| Enforcement site              | `#runAgent` turn-complete guard + `protocol_violation` event               | Prose in four layers; auto-repair that masks violation        | Structural contract; violation remains loud      |
+| Retry policy                  | One synthetic reminder, then advance + trace event                         | Unbounded retry; no retry; block forever                      | Bounded cost, non-deadlocking, audible           |
+| Supervision parity            | Same vocabulary as facilitation                                            | Leave supervision's `Redirect`+`Conclude`+blocking-Ask        | Single vocabulary across libeval                 |
+| System-prompt posture         | Descriptive framing only                                                   | Keep "then Share" / "do not proceed" as belt-and-suspenders   | No contradiction risk; runtime owns the contract |
+| Participant-Protocol delivery | `FACILITATED_AGENT_SYSTEM_PROMPT` append                                   | Coach first-Ask; task-text; profile; synthetic user bootstrap | Non-circular, trace-clean, bleeds into nothing   |
+| Skill name                    | `kata-session`                                                             | `kata-storyboard` retained                                    | Name matches the skill's actual scope            |
+| Invariant source              | `protocol_violation` events from runtime                                   | Set-difference inference over Ask/Answer calls                | Direct signal vs. inferred                       |
 
 ## Out of Scope
 
-Per spec 620: facilitator-side system prompt and tool descriptions, the
-`Facilitator` class orchestration logic, `kata-storyboard.yml` workflow,
-behavioural recovery (retry/timeout shortening), and any redesign of
-facilitated-agent identity. This design makes no changes to those surfaces.
+Per spec 620: facilitated-agent identity (spec 500), the pure-facilitator
+posture itself (spec 490 — this spec refines its vocabulary, does not revert
+it), behavioural recovery beyond the bounded single retry, `agent-runner.js`
+per-turn mechanics, trace-format changes beyond the new `protocol_violation`
+event type, and any new workflows or agent personas.

--- a/specs/620-facilitated-tell-share-response-protocol/spec.md
+++ b/specs/620-facilitated-tell-share-response-protocol/spec.md
@@ -1,4 +1,4 @@
-# Spec 620 — Facilitated Tell→Share Response Protocol for 1-on-1 Coaching
+# Spec 620 — Request–Response Primitives for libeval Orchestration
 
 ## Problem
 
@@ -185,178 +185,269 @@ SDK's success flag reports a green run.
 
 ## Proposal
 
-Make the Tell→Share response protocol a first-class, mandatory contract in
-facilitated mode — stated once at the lowest applicable layer, reinforced once
-at the skill layer, and testable via an invariant. Remove the workflow task-text
-that over-directs Q1 so the coaching procedure matches the skill.
+The Tell→Share stall is a symptom, not a root cause. `Tell` and `Share` are
+one-way messaging primitives that encode no request-response obligation; the
+participant has no structural reason to reply. A four-layer defence-in-depth
+that restates the rule in prose every time a facilitator sends a question is
+evidence of the primitive, not the instructions, being wrong. Any future
+facilitator, model update, or prompt edit re-introduces the same deadlock.
 
-### A symmetric participant protocol rule
+Fix the primitives. Reify the request-response contract in the libeval tool
+surface on both facilitated and supervised sides, enforce it at the runtime, and
+collapse the four prose layers into two short descriptive ones framed by the new
+vocabulary.
 
-The facilitator's system prompt already enforces a round-trip expectation on its
-own side (`facilitator.js:30-33`). The participant side must gain the symmetric
-rule: when the facilitator sends a `Tell`, the participant's turn is not
-complete until the participant has called `Share` with its response. This rule
-is generic to facilitated mode — not specific to storyboards or to coaching —
-and therefore belongs at the lowest instruction layer that is universal to all
-facilitated agents. Which exact layer carries the rule (tool description,
-facilitated-agent system prompt, skill Participant Protocol, or several in
-combination) is a design decision.
+### Request–response primitive pair
 
-### Universal Participant Protocol in `kata-storyboard`
+Replace the current messaging primitives with a pair that encodes the contract:
 
-The `kata-storyboard` skill's Participant Protocol must apply to both team
-storyboard and 1-on-1 coaching contexts. The protocol must state the Tell→Share
-response rule in a form that is not conditional on the meeting mode. The "1-on-1
-Coaching Adaptation" section must explicitly invoke the Participant Protocol
-rather than implying its inheritance.
+- **`Ask(to?, question)`** — the authoritative speech act. Sending an `Ask`
+  registers a pending-ask record in the orchestration context keyed by the
+  addressee. The asker's turn ends after the call (same as today's `Tell`).
+- **`Answer(message)`** — the symmetric reply. Resolves the pending-ask from the
+  asker's counterpart. On the participant side this replaces `Share`-as-
+  response; on the supervisor/facilitator side this replaces the implicit text
+  relay.
+- **`Announce(message)`** — no-reply broadcast (the legitimate use of today's
+  `Share`). Clearly distinguished from `Ask`.
+- `Redirect`, `Conclude`, `RollCall` are unchanged in semantics but renamed or
+  retained consistently across both modes.
 
-Participants in 1-on-1 coaching must load the `kata-storyboard` skill (today
-they do not) so that the Participant Protocol is in their context. The mechanism
-— whether the facilitator's opening `Tell` instructs the participant to load the
-skill, whether the workflow task injects the skill directly into the agent
-session, or whether the coach includes the protocol verbatim in its first `Tell`
-— is a design decision.
+The vocabulary is shared between supervision and facilitation. Supervision is
+1:1 with a single pending-ask slot; facilitation is 1:N with one slot per
+addressed participant.
+
+### Runtime enforcement of the contract
+
+`Facilitator` and `Supervisor` track `ctx.pendingAsks` — a map keyed by
+addressee, value holding the ask id and question. The agent outer loop
+(`#runAgent` in `facilitator.js`, the equivalent loop in `supervisor.js`) must
+not emit `lifecycle:turn_complete` while the agent has an outstanding ask.
+
+When an agent ends a turn with a pending ask:
+
+1. Inject a bounded synthetic reminder and resume the agent once.
+2. If the ask is still pending after the resume, emit a `protocol_violation`
+   event on the trace and permit turn completion so the session can advance (the
+   facilitator sees a null response and may Redirect or Conclude).
+
+Keeping the session live and keeping the violation visible are orthogonal — both
+are required. The silent deadlock is structurally impossible, and the violation
+is a first-class trace fact rather than an inference.
+
+### Session-bootstrap delivery of the Participant Protocol
+
+The Participant Protocol reaches 1-on-1 participants via the participant's
+initial system prompt, which the facilitator controls via
+`createFacilitatedAgentToolServer` / the runner's `systemPrompt`. Candidate
+surfaces — a short Participant-Protocol summary appended to
+`FACILITATED_AGENT_SYSTEM_PROMPT`, an initial bootstrap user message synthesised
+by `#runAgent` before the first `Ask` is delivered, or a direct skill-load
+directive — are enumerated without ranking; which surface is chosen is a design
+decision. Delivery via the coach's first `Ask` is rejected: it uses the very
+protocol that's being bootstrapped.
+
+### Skill restructure: `kata-storyboard` → `kata-session`
+
+The current skill name ties a generic coaching protocol to a single artifact
+(the monthly storyboard) used in only one of the two meeting modes. Rename the
+skill to `kata-session` with a mode-agnostic procedure and two mode-specific
+references:
+
+- `SKILL.md` — the five kata questions, the Ask/Answer turn-taking contract,
+  Conclude.
+- `references/team-storyboard.md` — storyboard artifact, XmR, CSV metrics,
+  planning vs. review branch (content migrated from today's Facilitator Process
+  steps and team-scoped pieces of `coaching-protocol.md`).
+- `references/one-on-one.md` — participant-trace overlay (content migrated from
+  today's "1-on-1 Coaching Adaptation" section).
+
+All references to `kata-storyboard` across the repo (KATA.md, agent profiles,
+workflows, prior spec designs that are live history) update to `kata-session`.
 
 ### Reduced task-text for `kata-coaching.yml`
 
-The coaching workflow's `task-text` must not prescribe Q1 content or dictate
-tool usage on the participant's behalf. It should match the shape of the
-storyboard workflow's task-text (one sentence, skill-dispatch only). The
-trace-analysis step belongs inside Q2 as the skill already describes it
-(`coaching-protocol.md:62-68`), not as a Q1 work assignment.
+Unchanged in rationale from the prior draft of this spec: one sentence, skill
+dispatch only, no Q1 prescription and no participant-side work assignment.
+Matches the shape of `kata-storyboard.yml`.
 
-### Invariant that makes the hang loud
+### Structured protocol-violation invariants
 
-The kata-trace invariant catalogue must carry a named facilitated-mode
-completeness invariant. The WHAT: a facilitated-mode run is incomplete when an
-addressed participant never `Share`s or when `Conclude` is not called exactly
-once. The WHY: the Agent SDK's `result: success` flag does not reflect coaching
-completion, so monitoring that trusts it silently misses the failure mode
-documented above.
+The kata-trace invariant catalogue gains two named entries whose evidence is the
+count of `protocol_violation` trace events in a combined trace, plus the
+`Conclude` cardinality check. One entry per mode (facilitated, supervised); the
+evidence function is shared.
 
 ## Scope
 
 ### Included
 
-- `libraries/libeval/src/facilitator.js` — `FACILITATED_AGENT_SYSTEM_PROMPT`.
-  Whether the Tell→Share rule lives here, elsewhere, or in several places is a
-  design decision.
-- `libraries/libeval/src/orchestration-toolkit.js` — agent-side `Share` and
-  `Tell` tool descriptions (`createFacilitatedAgentToolServer`). Facilitator-
-  side descriptions are unchanged.
-- `.claude/skills/kata-storyboard/SKILL.md` — Participant Protocol
-  universalisation and 1-on-1 Coaching Adaptation section.
-- `.claude/skills/kata-storyboard/references/coaching-protocol.md` — if the
-  Tell→Share rule is restated here for coach consumption, it must remain
-  consistent with the Participant Protocol wording.
-- `.github/workflows/kata-coaching.yml` — `task-text` input.
-- `.claude/skills/kata-trace/references/invariants.md` — new invariant for
-  facilitated-mode completeness.
-- The repository artifact through which participants in 1-on-1 coaching obtain
-  the `kata-storyboard` Participant Protocol in their context. Candidate
-  surfaces, enumerated without ranking: the `kata-coaching.yml` workflow
-  `task-text`, a new participant-profile addendum in `.claude/agents/`, the
-  facilitator's opening-`Tell` template inside the skill, or a direct
-  `Skill("kata-storyboard")` load from the participant's session. Which surface
+- `libraries/libeval/src/orchestration-toolkit.js` — full rewrite of the four
+  tool-server factories (`createSupervisorToolServer`,
+  `createSupervisedAgentToolServer`, `createFacilitatorToolServer`,
+  `createFacilitatedAgentToolServer`) to expose `Ask` / `Answer` / `Announce` in
+  place of `Tell` / `Share` and the participant-side blocking `Ask`. Handler
+  factories (`createAskHandler`, `createAnswerHandler`, `createAnnounceHandler`)
+  and the orchestration context now track `pendingAsks`.
+- `libraries/libeval/src/facilitator.js` — `Facilitator` class gains the
+  pending-ask registry, the `#runAgent` turn-complete guard with bounded
+  resume-once behaviour, and emits `protocol_violation` trace events.
+  `FACILITATOR_SYSTEM_PROMPT` and `FACILITATED_AGENT_SYSTEM_PROMPT` are
+  rewritten to match the new vocabulary and to name the Ask/Answer contract
+  descriptively.
+- `libraries/libeval/src/supervisor.js` — parallel changes for supervision mode:
+  pending-ask registry, turn-complete guard, updated `SUPERVISOR_SYSTEM_PROMPT`
+  and `AGENT_SYSTEM_PROMPT`.
+- `libraries/libeval/src/message-bus.js` — `tell` / `share` methods renamed or
+  augmented so the bus speaks the new vocabulary; message tag shape (`[direct]`
+  / `[shared]`) is a design decision.
+- `libraries/libeval/src/index.js` — exports.
+- `libraries/libeval/test/**` — new and updated tests for `Ask` / `Answer` /
+  `Announce`, pending-ask tracking, turn-complete guard, and
+  `protocol_violation` emission. Affected: `orchestration-toolkit.test.js`,
+  `facilitator.test.js`, `facilitator-messaging.test.js`,
+  `supervisor-*.test.js`, `message-bus.test.js`.
+- `.claude/skills/kata-storyboard/` — renamed to `.claude/skills/kata-session/`
+  with `SKILL.md` holding the mode-agnostic procedure, and
+  `references/team-storyboard.md` + `references/one-on-one.md` carrying the
+  mode-specific overlays. Existing `references/coaching-protocol.md`,
+  `references/metrics.md`, and `references/storyboard-template.md` are
+  redistributed into the new structure.
+- `.github/workflows/kata-coaching.yml` — `task-text` reduced to single-sentence
+  skill dispatch.
+- `.github/workflows/kata-storyboard.yml` — any skill-name references updated;
+  workflow behaviour otherwise unchanged.
+- `.claude/agents/*.md` — agent profiles referencing `kata-storyboard`
+  (improvement-coach, staff-engineer, security-engineer, release-engineer,
+  technical-writer, product-manager) update to `kata-session`.
+- `.claude/agents/references/memory-protocol.md` — skill name reference update.
+- `KATA.md` — Skills table entry updated to `kata-session`.
+- `.claude/skills/kata-trace/references/invariants.md` — two new entries:
+  facilitated-mode and supervised-mode protocol-violation invariants (counts of
+  `protocol_violation` trace events plus `Conclude` cardinality).
+- The participant-side Participant-Protocol delivery surface, chosen from:
+  `FACILITATED_AGENT_SYSTEM_PROMPT` append, a bootstrap user message synthesised
+  by `#runAgent` before the first Ask arrives, or workflow input. Which surface
   is chosen is a design decision.
 
 ### Excluded
 
-- **Facilitator-side system prompt and tool descriptions.** The facilitator's
-  "stop making tool calls and wait for responses" instruction
-  (`facilitator.js:30-33`) is correct as written; its side of the contract is
-  already enforced. This spec only adds the symmetric participant-side rule.
-- **The `Facilitator` class orchestration logic.** Loop mechanics,
-  `#facilitatorLoop`, `#runAgent`, and the `messageBus` are correct given a
-  participant that honours the protocol. No behavioural change is required
-  there.
-- **The `kata-storyboard.yml` workflow.** Team storyboards work today; no change
-  to their workflow is in scope.
-- **Spec 490** (already `plan implemented`). That spec established the coach as
-  a pure facilitator and added orchestration-awareness to the skill on the
-  facilitator side. This spec is the complementary participant-side fix it did
-  not cover.
-- **A general redesign of facilitated-mode agent identity.** Spec 500
-  (facilitated-agent identity) stays in scope for identity; this spec only adds
-  a single protocol rule.
-- **Automatic retry / timeout shortening on stalled coaching runs.** The
-  completeness invariant in Success Criterion 3 makes the hang loud; behavioural
-  recovery (shorter timeout, retry, redirect) is a separate concern.
+- **Facilitated-agent identity (spec 500 scope).** The participant's persona,
+  voice, and scope constraints stay as-is. Only its tool surface and system-
+  prompt framing change.
+- **Facilitator-as-pure-orchestrator posture (spec 490 scope).** That spec
+  established the coach as a pure facilitator with orchestration-tool-only
+  interaction. This spec refines the vocabulary of those tools; it does not
+  revert the posture. Prompt text introduced by spec 490 is rewritten to the new
+  vocabulary, not removed.
+- **Behavioural recovery strategies.** Shorter timeouts, automatic retry on
+  protocol_violation, or re-dispatching a stalled coaching session are out of
+  scope. The runtime's one bounded resume-once is the only recovery action;
+  further escalation is a separate spec.
+- **`agent-runner.js` core loop.** Per-turn mechanics of the individual agent
+  runner are unchanged. The orchestrator (Facilitator / Supervisor) reads ctx at
+  existing checkpoints; no new callbacks into the runner are introduced.
+- **Trace format changes beyond the new `protocol_violation` event type.**
+  Existing tool-call records, message tags, and orchestrator events keep their
+  shapes.
+- **New facilitated workflows or agents.** No new workflow, no new agent
+  persona. Scope is limited to the two existing facilitated workflows
+  (`kata-storyboard.yml`, `kata-coaching.yml`) and the supervised mode consumed
+  by `fit-eval supervise`.
 
 ## Dependencies
 
-- **Spec 460** (`plan implemented`) — `kata-storyboard` skill exists.
-- **Spec 490** (`plan implemented`) — facilitator-side orchestration awareness.
-  This spec is the participant-side counterpart.
-- **Spec 500** (`plan implemented`) — facilitated-agent identity, which
-  determines how participants receive their initial instruction surface.
+- **Spec 460** (`plan implemented`) — `kata-storyboard` skill exists and is
+  renamed by this spec.
+- **Spec 490** (`plan implemented`) — facilitator-as-pure-orchestrator posture.
+  This spec refines the vocabulary that spec 490 introduced; the posture itself
+  is preserved.
+- **Spec 500** (`plan implemented`) — facilitated-agent identity. Unchanged; the
+  Participant Protocol delivery surface this spec selects sits alongside the
+  identity surface, not inside it.
 
 ## Success Criteria
 
 The spec is done when these **artifact properties** hold. Each criterion is a
-property of a file in the repository after the change, checkable without
-scheduling a workflow run. A validation run against `kata-coaching.yml` (see the
-Validation note at the end of this section) is the one-time confirmation that
-the artifact properties produce the intended runtime behaviour — it is not
-itself a success criterion.
+property of a file or a testable runtime behaviour, checkable without scheduling
+a workflow run. The validation note at the end confirms that the artifact
+properties compose into the intended runtime behaviour; it is not a criterion.
 
-1. **Participant-side protocol rule exists in the instruction surface a
-   facilitated participant is guaranteed to read before acting.** The rule
-   states that a `Tell` from the facilitator requires a `Share` response before
-   the participant's turn is complete, symmetric to the facilitator's existing
-   "do not proceed until you have received responses" rule in
-   `libraries/libeval/src/facilitator.js` `FACILITATOR_SYSTEM_PROMPT`. Checkable
-   by reading the chosen surface(s) once the design is settled.
+1. **The new primitive vocabulary is the only tool surface.**
+   `orchestration-toolkit.js` exposes `Ask`, `Answer`, `Announce`, `Redirect`,
+   `Conclude`, `RollCall` across both facilitator and supervisor tool servers
+   and their counterparts on the participant / agent side. `Tell`, `Share`, and
+   the participant-side blocking `Ask` (as a distinct tool) are removed — no
+   aliases, no compatibility shims. Checkable by reading the file.
 
-2. **`kata-storyboard` Participant Protocol applies to both meeting types.**
-   `.claude/skills/kata-storyboard/SKILL.md` § Participant Protocol contains the
-   Tell→Share response rule in mode-agnostic form, and the 1-on-1 adaptation in
-   `references/coaching-protocol.md` § 1-on-1 Coaching Adaptation explicitly
-   invokes the Participant Protocol. Checkable by reading the two files.
+2. **Pending-ask tracking is structural, not inferred.** The orchestration
+   context exposes a `pendingAsks` map populated by the `Ask` handler and
+   cleared by the `Answer` handler. Tests in
+   `libraries/libeval/test/orchestration-toolkit.test.js` assert the map's
+   transitions. Checkable by reading the tests and running them.
 
-3. **Facilitated-mode completeness invariant is catalogued.** A named invariant
-   exists in `.claude/skills/kata-trace/references/invariants.md` whose WHAT and
-   evidence queries together detect a facilitated run in which an addressed
-   participant has zero `Share` calls or in which `Conclude` was not called
-   exactly once. Checkable by reading the invariant entry and running its own
-   documented evidence query against the baseline artifacts listed in the entry.
+3. **Runtime refuses silent turn-completion while an ask is pending.** The
+   `#runAgent` loop in `facilitator.js` (and the equivalent in `supervisor.js`)
+   injects exactly one synthetic reminder on first detection of a pending ask at
+   turn-end, then on a second detection emits a `protocol_violation` trace event
+   and permits the turn to complete so the session can advance. Covered by a
+   test that drives an agent which ignores the first `Ask`, observes the
+   synthetic reminder, ignores again, and verifies the `protocol_violation`
+   event appears exactly once and the session does not deadlock.
 
-4. **Coaching workflow task-text does not prescribe Q1 content.**
-   `.github/workflows/kata-coaching.yml` `task-text` does not dictate which
-   question to ask first, does not specify which tools the participant should
-   use, and does not assign participant-side work. Checkable by reading the
-   workflow file; the shape matches `.github/workflows/kata-storyboard.yml` in
-   its delegation to the skill.
+4. **System prompts match the new vocabulary and are descriptive, not
+   enforcing.** `FACILITATOR_SYSTEM_PROMPT`, `FACILITATED_AGENT_SYSTEM_PROMPT`,
+   `SUPERVISOR_SYSTEM_PROMPT`, and `AGENT_SYSTEM_PROMPT` name the `Ask` /
+   `Answer` / `Announce` primitives. No prompt contains "then Share", "respond
+   via Share", "stop making tool calls", or equivalent enforcing phrases —
+   runtime enforcement replaces them. Checkable by reading `facilitator.js` and
+   `supervisor.js`.
 
-5. **Participants in 1-on-1 coaching are delivered the Participant Protocol.**
-   The repository artifact responsible for participant context in 1-on-1 mode —
-   whichever surface the design selects (workflow input, facilitator opening
-   template, agent profile, or direct skill load) — contains or references the
-   `kata-storyboard` Participant Protocol such that a participant reading its
-   initial instruction surface has the Tell→Share rule in scope. Checkable by
-   reading that one file; no live trace needed.
+5. **`kata-session` skill replaces `kata-storyboard` with a mode-agnostic
+   procedure.** The directory `.claude/skills/kata-session/` exists with
+   `SKILL.md` (mode-agnostic: five questions, Ask/Answer contract, Conclude),
+   `references/team-storyboard.md` (storyboard overlay), and
+   `references/one-on-one.md` (participant-trace overlay).
+   `.claude/skills/kata-storyboard/` does not exist. Checkable by `ls` and by
+   reading the SKILL.md front-matter name field.
 
-6. **The team-storyboard workflow artifacts are unchanged in shape.**
-   `.github/workflows/kata-storyboard.yml` and the facilitator-side
-   `FACILITATOR_SYSTEM_PROMPT`, Facilitator tool-server descriptions, and
-   Facilitator Process steps in `kata-storyboard/SKILL.md` are unchanged except
-   where this spec explicitly touches them (Participant Protocol and 1-on-1
-   Coaching Adaptation). Checkable by diff of the workflow, `facilitator.js`,
-   and the Facilitator Process section.
+6. **All repo references to the old name are updated.** No file under
+   `.claude/`, `.github/`, `KATA.md`, or `website/docs/` contains the string
+   `kata-storyboard` except in historical spec/design artifacts under `specs/`
+   that document prior work. Checkable by `grep -rn kata-storyboard`.
 
-7. **Existing facilitated-mode tests pass.** `bun run check` and `bun run test`
-   pass with no regressions. Tests under
-   `libraries/libeval/test/orchestration-toolkit.test.js` and any test that
-   exercises `FACILITATED_AGENT_SYSTEM_PROMPT` or the agent-side `Share`/`Tell`
-   tool descriptions still pass; new tests cover any new behaviour the design
-   introduces.
+7. **Participant Protocol is delivered via a session-bootstrap surface, not via
+   the coach's first `Ask`.** Whichever surface the design selects (system
+   prompt append, bootstrap user message, or workflow input), a participant in a
+   1-on-1 session has the Participant Protocol in its context before the first
+   `Ask` from the facilitator is delivered. Checkable by reading the selected
+   surface and by a test that asserts the surface is loaded into the
+   participant's runner before `messageBus.waitForMessages` returns.
 
-**Validation note (not a criterion).** Once the seven criteria above hold,
+8. **Coaching workflow task-text is a single-sentence skill dispatch.**
+   `.github/workflows/kata-coaching.yml` `task-text` does not prescribe Q1
+   content, does not name tools the participant should use, and does not assign
+   participant-side work. Shape matches `kata-storyboard.yml`. Checkable by
+   reading the workflow.
+
+9. **Protocol-violation invariants are catalogued for both modes.**
+   `.claude/skills/kata-trace/references/invariants.md` contains one entry per
+   mode (facilitated, supervised). Each entry's evidence query counts
+   `protocol_violation` events in the combined trace and asserts `Conclude`
+   cardinality equals 1 on success. Checkable by reading the entries and running
+   their documented queries against the baseline artifacts.
+
+10. **Test suite passes with new coverage.** `bun run check` and `bun run test`
+    pass. New tests cover: `Ask` registers pending, `Answer` clears pending,
+    `Announce` does not, the turn-complete guard in both modes, the
+    `protocol_violation` event shape, and the `messageBus`/tool-server rename
+    migration.
+
+**Validation note (not a criterion).** Once the ten criteria above hold,
 schedule one `kata-coaching.yml` run against the staff-engineer (same agent as
-the two failing runs `24850558182` and `24844117144`) and one
-`kata-storyboard.yml` run, download both combined traces, and confirm: (a) the
-new invariant in criterion 3 reports no violation on either, and (b) the
-coaching run contains at least one `Share` from the participant and exactly one
-`Conclude`. This is a one-time check that the artifact properties compose into
-the intended runtime behaviour. Persistent monitoring is handled by criterion
-3's invariant, not by repeated manual runs.
+the two failing runs `24850558182` and `24844117144`), one `kata-storyboard.yml`
+run, and one supervised run of an arbitrary agent. Download all three combined
+traces and confirm: (a) the new invariants in criterion 9 report no violations
+on any of the three, (b) the coaching run contains at least one `Answer` from
+the participant and exactly one `Conclude`, and (c) no run exhibits silent
+deadlock. Persistent monitoring is the invariants, not manual runs.


### PR DESCRIPTION
## Summary

- Reframes spec 620 from a four-layer instruction-layer patch to a first-principles reshape of the libeval orchestration primitives. The Tell→Share stall is a symptom of messaging primitives that encode no request-response obligation; fix the primitives, not the prose.
- Replaces `Tell` / `Share` with `Ask` / `Answer` / `Announce` across both facilitated and supervised modes. Contract moves into the runtime: `ctx.pendingAsks` registry, `#runAgent` turn-complete guard with bounded single-reminder retry, and a structured `protocol_violation` trace event.
- Renames `kata-storyboard` → `kata-session` with a mode-agnostic `SKILL.md` plus `references/team-storyboard.md` and `references/one-on-one.md`. Participant Protocol is delivered via `FACILITATED_AGENT_SYSTEM_PROMPT` append, not via the coach's first Tell.

## Test plan

- [ ] `kata-review` panel against `spec.md` — confirm scope and success criteria are internally consistent after the primitive redesign.
- [ ] `kata-review` panel against `design.md` — confirm components/architecture cover each spec success criterion, decisions name rejected alternatives, and the file stays ≤ 200 lines.
- [ ] Once design is approved: `kata-plan` translates it into `plan-a.md` covering libeval primitive rename, runtime guard, skill rename, workflow and repo-wide reference updates.

https://claude.ai/code/session_01Q87dopCz9S2LKKsvWd359J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q87dopCz9S2LKKsvWd359J)_