### PR TITLE
Prefer GH_TOKEN over GITHUB_TOKEN; authenticate wiki-sync

### DIFF
--- a/libraries/libconfig/src/config.js
+++ b/libraries/libconfig/src/config.js
@@ -113,9 +113,9 @@ export class Config {
     Object.assign(this, data);
   }
 
-  /** @returns {string} GitHub token (GITHUB_TOKEN, or GH_TOKEN as fallback) */
+  /** @returns {string} GitHub token (GH_TOKEN, or GITHUB_TOKEN as fallback) */
   ghToken() {
-    return this.#resolve(["GITHUB_TOKEN", "GH_TOKEN"]);
+    return this.#resolve(["GH_TOKEN", "GITHUB_TOKEN"]);
   }
 
   /** @returns {Promise<string>} LLM API token (async for caller compatibility) */

--- a/libraries/libconfig/test/libconfig-env-file.test.js
+++ b/libraries/libconfig/test/libconfig-env-file.test.js
@@ -164,7 +164,7 @@ describe("libconfig - .env file loading", () => {
     );
 
     assert.throws(() => config.ghToken(), {
-      message: "GITHUB_TOKEN not found in environment",
+      message: "GH_TOKEN not found in environment",
     });
   });
 
@@ -216,7 +216,7 @@ describe("libconfig - .env file loading", () => {
 
     // After reset, .env overrides are cleared and no process env either
     assert.throws(() => config.ghToken(), {
-      message: "GITHUB_TOKEN not found in environment",
+      message: "GH_TOKEN not found in environment",
     });
   });
 

--- a/libraries/libconfig/test/libconfig-getters.test.js
+++ b/libraries/libconfig/test/libconfig-getters.test.js
@@ -98,27 +98,11 @@ describe("libconfig - Config getters", () => {
       mockStorageFn,
     );
     assert.throws(() => config.ghToken(), {
-      message: "GITHUB_TOKEN not found in environment",
+      message: "GH_TOKEN not found in environment",
     });
   });
 
   test("ghToken returns from environment", async () => {
-    const mockProcess = {
-      cwd: spy(() => "/test/dir"),
-      env: { GITHUB_TOKEN: "gh-token-xyz" },
-    };
-
-    const config = await createConfig(
-      "test",
-      "myservice",
-      {},
-      mockProcess,
-      mockStorageFn,
-    );
-    assert.strictEqual(config.ghToken(), "gh-token-xyz");
-  });
-
-  test("ghToken falls back to GH_TOKEN when GITHUB_TOKEN is unset", async () => {
     const mockProcess = {
       cwd: spy(() => "/test/dir"),
       env: { GH_TOKEN: "gh-cli-token" },
@@ -134,7 +118,23 @@ describe("libconfig - Config getters", () => {
     assert.strictEqual(config.ghToken(), "gh-cli-token");
   });
 
-  test("ghToken prefers GITHUB_TOKEN when both are set", async () => {
+  test("ghToken falls back to GITHUB_TOKEN when GH_TOKEN is unset", async () => {
+    const mockProcess = {
+      cwd: spy(() => "/test/dir"),
+      env: { GITHUB_TOKEN: "actions-token" },
+    };
+
+    const config = await createConfig(
+      "test",
+      "myservice",
+      {},
+      mockProcess,
+      mockStorageFn,
+    );
+    assert.strictEqual(config.ghToken(), "actions-token");
+  });
+
+  test("ghToken prefers GH_TOKEN when both are set", async () => {
     const mockProcess = {
       cwd: spy(() => "/test/dir"),
       env: { GITHUB_TOKEN: "github-token", GH_TOKEN: "gh-token" },
@@ -147,7 +147,7 @@ describe("libconfig - Config getters", () => {
       mockProcess,
       mockStorageFn,
     );
-    assert.strictEqual(config.ghToken(), "github-token");
+    assert.strictEqual(config.ghToken(), "gh-token");
   });
 
   test("llmToken throws when not set in environment", async () => {

--- a/scripts/wiki-sync.sh
+++ b/scripts/wiki-sync.sh
@@ -8,6 +8,21 @@ MODE="${1:-pull}"
 WIKI_DIR="wiki"
 WIKI_URL="https://github.com/forwardimpact/monorepo.wiki.git"
 
+# The wiki remote is a raw https://github.com/... URL and bypasses the local
+# git proxy that serves the main repo. Without credentials, git prompts for a
+# username and fails in non-TTY environments (CI, agent sessions). When
+# GITHUB_TOKEN is present, wire it in via an inline credential helper so
+# clone/fetch/push authenticate without writing the token into .git/config.
+auth_git() {
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        git -c credential.helper= \
+            -c 'credential.helper=!f() { echo username=x-access-token; echo password=$GITHUB_TOKEN; }; f' \
+            "$@"
+    else
+        git "$@"
+    fi
+}
+
 # ── Init: clone if missing ──
 # CI workflows pre-checkout the wiki with an authenticated token; skip the
 # clone when the wiki directory is already a git repo (handles both a
@@ -15,7 +30,7 @@ WIKI_URL="https://github.com/forwardimpact/monorepo.wiki.git"
 # checkout). For local dev without network, anonymous clone failure is
 # non-fatal — bootstrap continues without a wiki.
 if ! git -C "$WIKI_DIR" rev-parse --git-dir >/dev/null 2>&1; then
-    if ! git clone "$WIKI_URL" "$WIKI_DIR"; then
+    if ! auth_git clone "$WIKI_URL" "$WIKI_DIR"; then
         echo "wiki-sync: could not clone wiki, skipping" >&2
         exit 0
     fi
@@ -28,7 +43,7 @@ git config user.name  "$(cd .. && git config user.name)"
 git config user.email "$(cd .. && git config user.email)"
 
 # ── Fetch latest ──
-git fetch origin master
+auth_git fetch origin master
 
 # ── Pull mode: rebase onto remote ──
 if [ "$MODE" = "pull" ]; then
@@ -51,4 +66,4 @@ if ! git rebase origin/master; then
     git rebase --abort || true
     git merge origin/master -X ours --no-edit
 fi
-git push origin master
+auth_git push origin master

--- a/scripts/wiki-sync.sh
+++ b/scripts/wiki-sync.sh
@@ -10,13 +10,15 @@ WIKI_URL="https://github.com/forwardimpact/monorepo.wiki.git"
 
 # The wiki remote is a raw https://github.com/... URL and bypasses the local
 # git proxy that serves the main repo. Without credentials, git prompts for a
-# username and fails in non-TTY environments (CI, agent sessions). When
-# GITHUB_TOKEN is present, wire it in via an inline credential helper so
-# clone/fetch/push authenticate without writing the token into .git/config.
+# username and fails in non-TTY environments (CI, agent sessions). When a
+# token is present (GITHUB_TOKEN from Actions, GH_TOKEN from gh CLI), wire it
+# in via an inline credential helper so clone/fetch/push authenticate without
+# writing the token into .git/config. The helper expands the vars in the
+# subshell git spawns, so whichever one is set at invocation time wins.
 auth_git() {
-    if [ -n "${GITHUB_TOKEN:-}" ]; then
+    if [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${GH_TOKEN:-}" ]; then
         git -c credential.helper= \
-            -c 'credential.helper=!f() { echo username=x-access-token; echo password=$GITHUB_TOKEN; }; f' \
+            -c 'credential.helper=!f() { echo username=x-access-token; echo "password=${GH_TOKEN:-$GITHUB_TOKEN}"; }; f' \
             "$@"
     else
         git "$@"


### PR DESCRIPTION
## Summary

- **`scripts/wiki-sync.sh`** — The wiki remote is a raw `https://github.com/...` URL and bypasses the local git proxy the main repo uses. Without credentials, git prompts for a username and fails in non-TTY environments (CI, agent sessions). Added an `auth_git` wrapper that injects a token via an inline `credential.helper` for clone/fetch/push. Accepts both `GH_TOKEN` and `GITHUB_TOKEN`; the token never lands in `.git/config` (the helper expands the vars in the subshell git spawns).
- **`libconfig` `Config.ghToken()`** — Swapped resolution order from `[GITHUB_TOKEN, GH_TOKEN]` to `[GH_TOKEN, GITHUB_TOKEN]`. First-principles rationale: explicit beats ambient. `GITHUB_TOKEN` is auto-injected by the Actions runner with a narrow default scope; `GH_TOKEN` is typically set deliberately to override it (e.g., a PAT with broader scope for wiki pushes). When both are present the user's chosen token should win — same precedence `gh` CLI uses.
- Error message now reads `GH_TOKEN not found in environment` since it derives from `keys[0]`. Updated three test assertions.

## Test plan

- [x] `bun test` in `libraries/libconfig` — 52/52 pass
- [x] Verified credential helper with all four token states (GITHUB_TOKEN only, GH_TOKEN only, both, neither)
- [x] Codebase survey: zero direct `process.env.GITHUB_TOKEN`/`GH_TOKEN` reads in JS/TS — all consumers route through `config.ghToken()`, so the libconfig swap reaches them transparently
- [ ] CI green on this branch

---
_Generated by [Claude Code](https://claude.ai/code/session_019Sd1eK9WwjGX2mYieutUZM)_