### PR TITLE
specs(620): keep libeval generic; harmonise amend surfaces; design approved

### DIFF
--- a/specs/620-facilitated-tell-share-response-protocol/design.md
+++ b/specs/620-facilitated-tell-share-response-protocol/design.md
@@ -117,17 +117,33 @@ the spec set out to dismantle.
 
 ### Participant Protocol delivery
 
-Chosen: `FACILITATED_AGENT_SYSTEM_PROMPT` carries the Participant Protocol as a
-short descriptive summary (two or three sentences), plus a pointer to
-`kata-session` for detail. `systemPrompt` is set on the runner at construction
-time (`facilitator.js:489-492`), so every participant receives it before any Ask
-arrives — no bootstrap ordering problem, no coach-Tell circularity.
+Libeval is a generic library; its system prompts must not name or assume any
+specific skill. `FACILITATED_AGENT_SYSTEM_PROMPT` describes only the
+`Ask`/`Answer`/`Announce` contract in generic language — no "Participant
+Protocol" as a proper noun, no `kata-session` pointer, no coaching, storyboard,
+CSV, or XmR vocabulary. The prompt steers strongly toward the request-response
+pattern but stays domain-agnostic.
 
-**Rejected:** coach's first `Ask` (circular — bootstraps with the very protocol
-being bootstrapped); workflow `task-text` (reaches the facilitator only);
-agent-profile addendum (bleeds into solo runs); synthetic bootstrap user message
-(pollutes the trace with orchestrator-authored user turns). `systemPrompt`
-append is trace-clean by construction.
+Chosen: the coaching-specific participant framing travels via the workflow
+`task-text` → facilitator → a new libeval pass-through field. Libeval's
+participant config gains a `sessionBootstrap: string?` field; libeval
+concatenates it after `FACILITATED_AGENT_SYSTEM_PROMPT` at the
+`systemPromptFor` call site (`facilitator.js:489-492`). `kata-coaching.yml`
+`task-text` carries the coaching framing (mode, target, protocol pointer) that
+primes the facilitator, and `kata-session/SKILL.md` Facilitator Process tells
+the coach how to derive a participant-side summary from
+`references/one-on-one.md` or `references/team-storyboard.md` and pass it as
+`sessionBootstrap`. Trace-clean (no synthetic user turn), non-circular
+(delivered before any `Ask`), no bleed into solo runs.
+
+**Rejected:** append the Participant Protocol — or a pointer to `kata-session`
+— to `FACILITATED_AGENT_SYSTEM_PROMPT` (couples a generic library to a
+specific skill; regresses libeval's domain-agnostic posture); coach's first
+`Ask` (circular — bootstraps with the very protocol being bootstrapped);
+agent-profile addendum (bleeds into solo runs); synthetic bootstrap user
+message (pollutes the trace with orchestrator-authored user turns). The
+pass-through field keeps libeval generic while giving the consumer full
+authority over participant framing.
 
 ### Skill restructure: `kata-storyboard` → `kata-session`
 
@@ -150,10 +166,17 @@ instruction-layer kludge this spec dismantles.
 
 ### Coaching workflow task-text
 
-`kata-coaching.yml` `task-text` becomes one sentence that dispatches to
-`kata-session` with the target agent name. No Q1 prescription, no `kata-trace`
-front-load, no participant-side work. Unchanged rationale from prior draft; spec
-SC 8.
+`kata-coaching.yml` `task-text` primes the facilitator with the coaching
+framing that libeval's generic prompts deliberately omit: mode (1-on-1),
+target participant, pointer to `kata-session`, and the participant-side
+summary the coach should pass through as `sessionBootstrap`. It must not
+prescribe participant-side work (the original `kata-trace` front-load that
+caused run `24850558182` to burn its turn budget), must not prescribe Q1
+content (the skill supplies wording), and must not carry enforcement phrasing
+("stop making tool calls", "then Share") — the runtime owns the contract.
+Because libeval is now generic, domain framing is expected to live here; the
+task-text is not reduced to a single sentence, and its shape no longer needs
+to match `kata-storyboard.yml`. Spec SC 8.
 
 ### Protocol-violation invariants
 
@@ -179,8 +202,8 @@ necessary — the runtime emits structured events that are a direct match.
 | Enforcement site              | `#runAgent` turn-complete guard + `protocol_violation` event               | Prose in four layers; auto-repair that masks violation        | Structural contract; violation remains loud      |
 | Retry policy                  | One synthetic reminder, then advance + trace event                         | Unbounded retry; no retry; block forever                      | Bounded cost, non-deadlocking, audible           |
 | Supervision parity            | Same vocabulary as facilitation                                            | Leave supervision's `Redirect`+`Conclude`+blocking-Ask        | Single vocabulary across libeval                 |
-| System-prompt posture         | Descriptive framing only                                                   | Keep "then Share" / "do not proceed" as belt-and-suspenders   | No contradiction risk; runtime owns the contract |
-| Participant-Protocol delivery | `FACILITATED_AGENT_SYSTEM_PROMPT` append                                   | Coach first-Ask; task-text; profile; synthetic user bootstrap | Non-circular, trace-clean, bleeds into nothing   |
+| System-prompt posture         | Descriptive framing only; generic language; no skill names or domain vocabulary | Keep "then Share" / "do not proceed" as belt-and-suspenders; name `kata-session` in libeval prompt | No contradiction risk; runtime owns the contract; libeval stays generic |
+| Participant-Protocol delivery | Workflow `task-text` → facilitator → libeval `sessionBootstrap` pass-through | Append to libeval prompt (couples library to skill); coach first-Ask; agent-profile; synthetic user bootstrap | libeval stays generic; non-circular, trace-clean, no solo-run bleed |
 | Skill name                    | `kata-session`                                                             | `kata-storyboard` retained                                    | Name matches the skill's actual scope            |
 | Invariant source              | `protocol_violation` events from runtime                                   | Set-difference inference over Ask/Answer calls                | Direct signal vs. inferred                       |
 

--- a/specs/620-facilitated-tell-share-response-protocol/design.md
+++ b/specs/620-facilitated-tell-share-response-protocol/design.md
@@ -8,14 +8,14 @@ Changes span the runtime (L1), one renamed skill (L6/L7), one workflow (L4), and
 one reference (L7). Layer numbers per
 [KATA.md § Instruction layering](../../KATA.md#instruction-layering).
 
-| Layer | Component                                                                               | Role                                                   |
-| ----- | --------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| L1    | `OrchestrationToolkit` — tool-server factories, handler factories, `pendingAsks` context state | Tool surface, pending-ask state, violation emission |
+| Layer | Component                                                                                                                                                        | Role                                                                                    |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| L1    | `OrchestrationToolkit` — tool-server factories, handler factories, `pendingAsks` context state                                                                   | Tool surface, pending-ask state, violation emission                                     |
 | L1    | `Facilitator` / `Supervisor` — agent loop with turn-complete guard; domain-agnostic system prompts; `systemPromptAmend` / `taskAmend` pass-throughs; message bus | Runtime enforcement; generic system-prompt framing; consumer-controlled append surfaces |
-| L6    | `kata-session/SKILL.md` (renamed from `kata-storyboard`)                                | Mode-agnostic five-question procedure + Ask/Answer     |
-| L7    | `kata-session/references/{team-storyboard,one-on-one}.md`                               | Mode-specific overlays                                 |
-| L4    | `.github/workflows/kata-coaching.yml` `task-text`                                       | Coaching framing into the facilitator                  |
-| L7    | `kata-trace/references/invariants.md`                                                   | Two `protocol_violation` invariants (facil. + superv.) |
+| L6    | `kata-session/SKILL.md` (renamed from `kata-storyboard`)                                                                                                         | Mode-agnostic five-question procedure + Ask/Answer                                      |
+| L7    | `kata-session/references/{team-storyboard,one-on-one}.md`                                                                                                        | Mode-specific overlays                                                                  |
+| L4    | `.github/workflows/kata-coaching.yml` `task-text`                                                                                                                | Coaching framing into the facilitator                                                   |
+| L7    | `kata-trace/references/invariants.md`                                                                                                                            | Two `protocol_violation` invariants (facil. + superv.)                                  |
 
 ## Architecture
 
@@ -44,8 +44,8 @@ Unnecessary asymmetry — the from/to arguments already distinguish roles.
 
 ### Pending-ask registry and turn-complete guard
 
-The orchestrator's agent loop (in both `Facilitator` and `Supervisor`) is
-the enforcement site: before emitting `lifecycle:turn_complete`, it consults
+The orchestrator's agent loop (in both `Facilitator` and `Supervisor`) is the
+enforcement site: before emitting `lifecycle:turn_complete`, it consults
 `ctx.pendingAsks`.
 
 ```mermaid
@@ -67,9 +67,9 @@ sequenceDiagram
     R-->>F: null Answer via messageBus
 ```
 
-If the participant calls `Answer(message)`, the handler clears the entry,
-routes the message to the asker via `messageBus`, and the runtime
-short-circuits the reminder/violation path.
+If the participant calls `Answer(message)`, the handler clears the entry, routes
+the message to the asker via `messageBus`, and the runtime short-circuits the
+reminder/violation path.
 
 **Rejected:** block `turn_complete` forever (same deadlock); zero retries
 (wastes a recoverable turn); unbounded retries (silent budget burn). One
@@ -84,11 +84,11 @@ Supervision adopts the same vocabulary. The new tool surface:
 
 Either side can ask; either side must answer. The supervised-agent's historic
 blocking `Ask` (which waited mid-tool-call for the supervisor's text) is
-replaced at the toolkit layer by a non-blocking `Ask` that registers
-pending on the supervisor; the supervisor's implicit text-relay reply
-becomes an explicit `Answer`. Per-turn mechanics of `agent-runner.js` are
-unchanged (spec § Excluded); replacement happens in the tool-server
-factories and the orchestrator loop.
+replaced at the toolkit layer by a non-blocking `Ask` that registers pending on
+the supervisor; the supervisor's implicit text-relay reply becomes an explicit
+`Answer`. Per-turn mechanics of `agent-runner.js` are unchanged (spec §
+Excluded); replacement happens in the tool-server factories and the orchestrator
+loop.
 
 **Rejected: leave supervision untouched.** Two vocabularies across libeval is
 worse than one. Skill-authoring cost of two vocabularies is large.
@@ -110,25 +110,25 @@ the spec set out to dismantle.
 
 Libeval's four system prompts stay domain-agnostic (see § System-prompt
 framing). Coaching-specific participant framing travels
-`task-text → facilitator → libeval pass-through` to each participant's
-system prompt:
+`task-text → facilitator → libeval pass-through` to each participant's system
+prompt:
 
 - **`systemPromptAmend: string?`** on the `Facilitator` participant config —
   opaque addendum concatenated after `FACILITATED_AGENT_SYSTEM_PROMPT` before
   any `Ask` is delivered.
-- **`taskAmend: string?`** on the `Facilitator`, `Supervisor`, and
-  `AgentRunner` configs — promotes libeval's existing CLI-only
-  `--task-amend` concatenation to a public config field; the CLI flag drives
-  it. Same shape across all three orchestrators.
+- **`taskAmend: string?`** on the `Facilitator`, `Supervisor`, and `AgentRunner`
+  configs — promotes libeval's existing CLI-only `--task-amend` concatenation to
+  a public config field; the CLI flag drives it. Same shape across all three
+  orchestrators.
 
-`taskAmend` (task-content level) and `systemPromptAmend` (system-prompt
-level) form one naming family of consumer-controlled append surfaces.
+`taskAmend` (task-content level) and `systemPromptAmend` (system-prompt level)
+form one naming family of consumer-controlled append surfaces.
 
 **Rejected:** append the coaching protocol (or a `kata-session` pointer)
-directly to `FACILITATED_AGENT_SYSTEM_PROMPT` (couples a generic library to
-a specific skill); coach's first `Ask` (circular); agent-profile addendum
-(bleeds into solo runs); synthetic bootstrap user message (pollutes the
-trace); bespoke name unrelated to `taskAmend` (misses the harmonisation).
+directly to `FACILITATED_AGENT_SYSTEM_PROMPT` (couples a generic library to a
+specific skill); coach's first `Ask` (circular); agent-profile addendum (bleeds
+into solo runs); synthetic bootstrap user message (pollutes the trace); bespoke
+name unrelated to `taskAmend` (misses the harmonisation).
 
 ### Skill restructure: `kata-storyboard` → `kata-session`
 
@@ -151,8 +151,8 @@ instruction-layer kludge this spec dismantles.
 
 ### Coaching workflow task-text
 
-`kata-coaching.yml` `task-text` is the source of the coaching framing
-libeval's generic prompts omit. Shape: mode, target participant, pointer to
+`kata-coaching.yml` `task-text` is the source of the coaching framing libeval's
+generic prompts omit. Shape: mode, target participant, pointer to
 `kata-session`, and the participant-side summary to pass through as
 `systemPromptAmend`. Spec § Rewritten task-text and SC 7/SC 8 own the
 constraints on what it may and may not contain.
@@ -175,13 +175,13 @@ necessary — the runtime emits structured events that are a direct match.
 
 ## Key Decisions
 
-| Decision             | Chosen                                                                    | Rejected                                                | Why                                                       |
-| -------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
-| Primitive set        | `Ask` / `Answer` / `Announce` + Redirect/Conclude/RollCall, shared modes  | Keep `Tell`/`Share`; add alongside; mode-specific names | One vocabulary; contract encoded structurally             |
-| Enforcement site     | Orchestrator turn-complete guard + `protocol_violation` event             | Prose in four prompt layers; auto-repair                | Structural contract; violation stays loud                 |
-| Retry policy         | One synthetic reminder, then advance + trace event                        | Unbounded retry; no retry; block forever                | Bounded, non-deadlocking, audible                         |
-| Supervision parity   | Same vocabulary as facilitation                                           | Leave supervision's `Redirect`+`Conclude`+blocking-Ask  | One vocabulary across libeval                             |
-| Prompt posture       | Descriptive only; generic language; no skill names or domain vocabulary   | Enforcement phrases; name `kata-session` in libeval     | Runtime owns the contract; libeval stays generic          |
-| Participant framing  | `task-text` → facilitator → libeval `systemPromptAmend` + `taskAmend`     | Append to libeval prompt; first-`Ask`; profile; bootstrap user msg | Library stays generic; one naming family for both amends |
-| Skill name           | `kata-session`                                                            | `kata-storyboard` retained                              | Name matches the skill's actual scope                     |
-| Invariant source     | `protocol_violation` events from runtime                                  | Set-difference inference over Ask/Answer calls          | Direct signal vs. inferred                                |
+| Decision            | Chosen                                                                   | Rejected                                                           | Why                                                      |
+| ------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------ | -------------------------------------------------------- |
+| Primitive set       | `Ask` / `Answer` / `Announce` + Redirect/Conclude/RollCall, shared modes | Keep `Tell`/`Share`; add alongside; mode-specific names            | One vocabulary; contract encoded structurally            |
+| Enforcement site    | Orchestrator turn-complete guard + `protocol_violation` event            | Prose in four prompt layers; auto-repair                           | Structural contract; violation stays loud                |
+| Retry policy        | One synthetic reminder, then advance + trace event                       | Unbounded retry; no retry; block forever                           | Bounded, non-deadlocking, audible                        |
+| Supervision parity  | Same vocabulary as facilitation                                          | Leave supervision's `Redirect`+`Conclude`+blocking-Ask             | One vocabulary across libeval                            |
+| Prompt posture      | Descriptive only; generic language; no skill names or domain vocabulary  | Enforcement phrases; name `kata-session` in libeval                | Runtime owns the contract; libeval stays generic         |
+| Participant framing | `task-text` → facilitator → libeval `systemPromptAmend` + `taskAmend`    | Append to libeval prompt; first-`Ask`; profile; bootstrap user msg | Library stays generic; one naming family for both amends |
+| Skill name          | `kata-session`                                                           | `kata-storyboard` retained                                         | Name matches the skill's actual scope                    |
+| Invariant source    | `protocol_violation` events from runtime                                 | Set-difference inference over Ask/Answer calls                     | Direct signal vs. inferred                               |

--- a/specs/620-facilitated-tell-share-response-protocol/design.md
+++ b/specs/620-facilitated-tell-share-response-protocol/design.md
@@ -126,22 +126,37 @@ pattern but stays domain-agnostic.
 
 Chosen: the coaching-specific participant framing travels via the workflow
 `task-text` → facilitator → a new libeval pass-through field. Libeval's
-participant config gains a `sessionBootstrap: string?` field; libeval
+participant config gains a `systemPromptAmend: string?` field; libeval
 concatenates it after `FACILITATED_AGENT_SYSTEM_PROMPT` at the
 `systemPromptFor` call site (`facilitator.js:489-492`). `kata-coaching.yml`
-`task-text` carries the coaching framing (mode, target, protocol pointer) that
-primes the facilitator, and `kata-session/SKILL.md` Facilitator Process tells
-the coach how to derive a participant-side summary from
+`task-text` carries the coaching framing (mode, target, protocol pointer)
+that primes the facilitator, and `kata-session/SKILL.md` Facilitator Process
+tells the coach how to derive a participant-side summary from
 `references/one-on-one.md` or `references/team-storyboard.md` and pass it as
-`sessionBootstrap`. Trace-clean (no synthetic user turn), non-circular
+`systemPromptAmend`. Trace-clean (no synthetic user turn), non-circular
 (delivered before any `Ask`), no bleed into solo runs.
+
+Name chosen to pair with libeval's existing task-content append surface.
+Today `fit-eval run|supervise|facilitate --task-amend <text>` concatenates
+text onto the invoked agent's task content (see
+`libraries/libeval/src/commands/{run,supervise,facilitate}.js`) — a
+CLI-only mechanism that the CLI applies before calling
+`createFacilitator`/`createSupervisor`. This spec promotes that concatenation
+into libeval's programmatic config as a public `taskAmend: string?` field,
+and introduces the parallel `systemPromptAmend: string?` for system-prompt
+append. The two fields form one naming family operating at two prompt
+levels: `taskAmend` (user/task-content level) and `systemPromptAmend`
+(system-prompt level). CLI flags (`--task-amend`, and optionally a future
+`--system-prompt-amend`) become thin mappings onto these config fields.
 
 **Rejected:** append the Participant Protocol — or a pointer to `kata-session`
 — to `FACILITATED_AGENT_SYSTEM_PROMPT` (couples a generic library to a
 specific skill; regresses libeval's domain-agnostic posture); coach's first
 `Ask` (circular — bootstraps with the very protocol being bootstrapped);
 agent-profile addendum (bleeds into solo runs); synthetic bootstrap user
-message (pollutes the trace with orchestrator-authored user turns). The
+message (pollutes the trace with orchestrator-authored user turns);
+bespoke name unrelated to `taskAmend` (misses the chance to harmonise the
+two consumer-controlled append surfaces into one naming family). The
 pass-through field keeps libeval generic while giving the consumer full
 authority over participant framing.
 
@@ -169,7 +184,7 @@ instruction-layer kludge this spec dismantles.
 `kata-coaching.yml` `task-text` primes the facilitator with the coaching
 framing that libeval's generic prompts deliberately omit: mode (1-on-1),
 target participant, pointer to `kata-session`, and the participant-side
-summary the coach should pass through as `sessionBootstrap`. It must not
+summary the coach should pass through as `systemPromptAmend`. It must not
 prescribe participant-side work (the original `kata-trace` front-load that
 caused run `24850558182` to burn its turn budget), must not prescribe Q1
 content (the skill supplies wording), and must not carry enforcement phrasing
@@ -203,7 +218,7 @@ necessary — the runtime emits structured events that are a direct match.
 | Retry policy                  | One synthetic reminder, then advance + trace event                         | Unbounded retry; no retry; block forever                      | Bounded cost, non-deadlocking, audible           |
 | Supervision parity            | Same vocabulary as facilitation                                            | Leave supervision's `Redirect`+`Conclude`+blocking-Ask        | Single vocabulary across libeval                 |
 | System-prompt posture         | Descriptive framing only; generic language; no skill names or domain vocabulary | Keep "then Share" / "do not proceed" as belt-and-suspenders; name `kata-session` in libeval prompt | No contradiction risk; runtime owns the contract; libeval stays generic |
-| Participant-Protocol delivery | Workflow `task-text` → facilitator → libeval `sessionBootstrap` pass-through | Append to libeval prompt (couples library to skill); coach first-Ask; agent-profile; synthetic user bootstrap | libeval stays generic; non-circular, trace-clean, no solo-run bleed |
+| Participant-Protocol delivery | Workflow `task-text` → facilitator → libeval `systemPromptAmend` pass-through (paired with promoted `taskAmend` config) | Append to libeval prompt (couples library to skill); coach first-Ask; agent-profile; synthetic user bootstrap; bespoke name unrelated to `taskAmend` | libeval stays generic; non-circular, trace-clean, no solo-run bleed; one naming family for both append surfaces |
 | Skill name                    | `kata-session`                                                             | `kata-storyboard` retained                                    | Name matches the skill's actual scope            |
 | Invariant source              | `protocol_violation` events from runtime                                   | Set-difference inference over Ask/Answer calls                | Direct signal vs. inferred                       |
 

--- a/specs/620-facilitated-tell-share-response-protocol/design.md
+++ b/specs/620-facilitated-tell-share-response-protocol/design.md
@@ -1,12 +1,6 @@
 # Design 620 — Request–Response Primitives for libeval Orchestration
 
-## Problem (restated)
-
-The Tell→Share stall is a symptom of messaging primitives that encode no
-request-response obligation. Four-layer prose defence-in-depth was the prior
-fix; it is brittle and survives only as long as every layer keeps restating the
-rule. Reshape the primitives so the contract is structural, not taught, and
-collapse the prose layers.
+Spec: [`spec.md`](./spec.md).
 
 ## Components
 
@@ -16,11 +10,11 @@ one reference (L7). Layer numbers per
 
 | Layer | Component                                                                               | Role                                                   |
 | ----- | --------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| L1    | `OrchestrationToolkit` — tool-server factories, handler factories, `ctx.pendingAsks`    | Tool surface, pending-ask state, violation emission    |
-| L1    | `Facilitator` / `Supervisor` — `#runAgent` turn-complete guard, system prompts, msg bus | Runtime enforcement; descriptive system-prompt framing |
+| L1    | `OrchestrationToolkit` — tool-server factories, handler factories, `pendingAsks` context state | Tool surface, pending-ask state, violation emission |
+| L1    | `Facilitator` / `Supervisor` — agent loop with turn-complete guard; domain-agnostic system prompts; `systemPromptAmend` / `taskAmend` pass-throughs; message bus | Runtime enforcement; generic system-prompt framing; consumer-controlled append surfaces |
 | L6    | `kata-session/SKILL.md` (renamed from `kata-storyboard`)                                | Mode-agnostic five-question procedure + Ask/Answer     |
 | L7    | `kata-session/references/{team-storyboard,one-on-one}.md`                               | Mode-specific overlays                                 |
-| L4    | `.github/workflows/kata-coaching.yml` `task-text`                                       | Single-sentence skill dispatch                         |
+| L4    | `.github/workflows/kata-coaching.yml` `task-text`                                       | Coaching framing into the facilitator                  |
 | L7    | `kata-trace/references/invariants.md`                                                   | Two `protocol_violation` invariants (facil. + superv.) |
 
 ## Architecture
@@ -50,19 +44,19 @@ Unnecessary asymmetry — the from/to arguments already distinguish roles.
 
 ### Pending-ask registry and turn-complete guard
 
-The orchestrator's agent loop (`#runAgent` in `facilitator.js`, equivalent loop
-in `supervisor.js`) becomes the enforcement site. Before emitting
-`lifecycle:turn_complete`, it consults `ctx.pendingAsks`.
+The orchestrator's agent loop (in both `Facilitator` and `Supervisor`) is
+the enforcement site: before emitting `lifecycle:turn_complete`, it consults
+`ctx.pendingAsks`.
 
 ```mermaid
 sequenceDiagram
     participant F as Facilitator
-    participant R as #runAgent
+    participant R as agent loop
     participant P as Participant
     participant T as Trace
 
     F->>R: Ask(to=P, question)
-    Note over R: ctx.pendingAsks.set(P, ask)
+    Note over R: pendingAsks.set(P, ask)
     R->>P: deliver as user turn
     P->>P: produce text, no Answer
     Note over R: turn ends; pendingAsks.has(P)?
@@ -73,34 +67,31 @@ sequenceDiagram
     R-->>F: null Answer via messageBus
 ```
 
-If the participant calls `Answer(message)` at any point, the handler clears the
-entry, routes the message to the asker via `messageBus`, and the runtime
+If the participant calls `Answer(message)`, the handler clears the entry,
+routes the message to the asker via `messageBus`, and the runtime
 short-circuits the reminder/violation path.
 
-**Rejected: block `turn_complete` forever** (same deadlock, moved from prompt to
-runtime). **Rejected: zero retries** (wastes a turn the LLM would have recovered
-with a nudge). **Rejected: unbounded retries** (silent budget burn). One
+**Rejected:** block `turn_complete` forever (same deadlock); zero retries
+(wastes a recoverable turn); unbounded retries (silent budget burn). One
 reminder + one trace event is the bounded cost/signal balance.
 
 ### Supervisor parity
 
-Supervision gets the same vocabulary. Today the supervisor has `Redirect` +
-`Conclude` only; supervised agents have a blocking `Ask`. The new shape:
+Supervision adopts the same vocabulary. The new tool surface:
 
 - **Supervisor:** `Ask`, `Announce`, `Redirect`, `Conclude`, `RollCall`.
 - **Supervised agent:** `Ask`, `Answer`, `Announce`, `RollCall`.
 
 Either side can ask; either side must answer. The supervised-agent's historic
-blocking `Ask` (agent waits mid-tool-call for supervisor's text) becomes a
-regular `Ask` that registers pending on the supervisor. The supervisor's
-implicit text-relay reply becomes an explicit `Answer` call. This removes the
-special-case blocking path in `agent-runner.js`; all replies flow through the
-same `Answer` → `messageBus` route.
+blocking `Ask` (which waited mid-tool-call for the supervisor's text) is
+replaced at the toolkit layer by a non-blocking `Ask` that registers
+pending on the supervisor; the supervisor's implicit text-relay reply
+becomes an explicit `Answer`. Per-turn mechanics of `agent-runner.js` are
+unchanged (spec § Excluded); replacement happens in the tool-server
+factories and the orchestrator loop.
 
 **Rejected: leave supervision untouched.** Two vocabularies across libeval is
-worse than one. The runtime cost of parity is small (same handlers, different
-wiring); the skill-authoring cost of two vocabularies is large (every future
-skill must learn both).
+worse than one. Skill-authoring cost of two vocabularies is large.
 
 ### System-prompt framing
 
@@ -117,48 +108,27 @@ the spec set out to dismantle.
 
 ### Participant Protocol delivery
 
-Libeval is a generic library; its system prompts must not name or assume any
-specific skill. `FACILITATED_AGENT_SYSTEM_PROMPT` describes only the
-`Ask`/`Answer`/`Announce` contract in generic language — no "Participant
-Protocol" as a proper noun, no `kata-session` pointer, no coaching, storyboard,
-CSV, or XmR vocabulary. The prompt steers strongly toward the request-response
-pattern but stays domain-agnostic.
+Libeval's four system prompts stay domain-agnostic (see § System-prompt
+framing). Coaching-specific participant framing travels
+`task-text → facilitator → libeval pass-through` to each participant's
+system prompt:
 
-Chosen: the coaching-specific participant framing travels via the workflow
-`task-text` → facilitator → a new libeval pass-through field. Libeval's
-participant config gains a `systemPromptAmend: string?` field; libeval
-concatenates it after `FACILITATED_AGENT_SYSTEM_PROMPT` at the
-`systemPromptFor` call site (`facilitator.js:489-492`). `kata-coaching.yml`
-`task-text` carries the coaching framing (mode, target, protocol pointer)
-that primes the facilitator, and `kata-session/SKILL.md` Facilitator Process
-tells the coach how to derive a participant-side summary from
-`references/one-on-one.md` or `references/team-storyboard.md` and pass it as
-`systemPromptAmend`. Trace-clean (no synthetic user turn), non-circular
-(delivered before any `Ask`), no bleed into solo runs.
+- **`systemPromptAmend: string?`** on the `Facilitator` participant config —
+  opaque addendum concatenated after `FACILITATED_AGENT_SYSTEM_PROMPT` before
+  any `Ask` is delivered.
+- **`taskAmend: string?`** on the `Facilitator`, `Supervisor`, and
+  `AgentRunner` configs — promotes libeval's existing CLI-only
+  `--task-amend` concatenation to a public config field; the CLI flag drives
+  it. Same shape across all three orchestrators.
 
-Name chosen to pair with libeval's existing task-content append surface.
-Today `fit-eval run|supervise|facilitate --task-amend <text>` concatenates
-text onto the invoked agent's task content (see
-`libraries/libeval/src/commands/{run,supervise,facilitate}.js`) — a
-CLI-only mechanism that the CLI applies before calling
-`createFacilitator`/`createSupervisor`. This spec promotes that concatenation
-into libeval's programmatic config as a public `taskAmend: string?` field,
-and introduces the parallel `systemPromptAmend: string?` for system-prompt
-append. The two fields form one naming family operating at two prompt
-levels: `taskAmend` (user/task-content level) and `systemPromptAmend`
-(system-prompt level). CLI flags (`--task-amend`, and optionally a future
-`--system-prompt-amend`) become thin mappings onto these config fields.
+`taskAmend` (task-content level) and `systemPromptAmend` (system-prompt
+level) form one naming family of consumer-controlled append surfaces.
 
-**Rejected:** append the Participant Protocol — or a pointer to `kata-session`
-— to `FACILITATED_AGENT_SYSTEM_PROMPT` (couples a generic library to a
-specific skill; regresses libeval's domain-agnostic posture); coach's first
-`Ask` (circular — bootstraps with the very protocol being bootstrapped);
-agent-profile addendum (bleeds into solo runs); synthetic bootstrap user
-message (pollutes the trace with orchestrator-authored user turns);
-bespoke name unrelated to `taskAmend` (misses the chance to harmonise the
-two consumer-controlled append surfaces into one naming family). The
-pass-through field keeps libeval generic while giving the consumer full
-authority over participant framing.
+**Rejected:** append the coaching protocol (or a `kata-session` pointer)
+directly to `FACILITATED_AGENT_SYSTEM_PROMPT` (couples a generic library to
+a specific skill); coach's first `Ask` (circular); agent-profile addendum
+(bleeds into solo runs); synthetic bootstrap user message (pollutes the
+trace); bespoke name unrelated to `taskAmend` (misses the harmonisation).
 
 ### Skill restructure: `kata-storyboard` → `kata-session`
 
@@ -181,17 +151,11 @@ instruction-layer kludge this spec dismantles.
 
 ### Coaching workflow task-text
 
-`kata-coaching.yml` `task-text` primes the facilitator with the coaching
-framing that libeval's generic prompts deliberately omit: mode (1-on-1),
-target participant, pointer to `kata-session`, and the participant-side
-summary the coach should pass through as `systemPromptAmend`. It must not
-prescribe participant-side work (the original `kata-trace` front-load that
-caused run `24850558182` to burn its turn budget), must not prescribe Q1
-content (the skill supplies wording), and must not carry enforcement phrasing
-("stop making tool calls", "then Share") — the runtime owns the contract.
-Because libeval is now generic, domain framing is expected to live here; the
-task-text is not reduced to a single sentence, and its shape no longer needs
-to match `kata-storyboard.yml`. Spec SC 8.
+`kata-coaching.yml` `task-text` is the source of the coaching framing
+libeval's generic prompts omit. Shape: mode, target participant, pointer to
+`kata-session`, and the participant-side summary to pass through as
+`systemPromptAmend`. Spec § Rewritten task-text and SC 7/SC 8 own the
+constraints on what it may and may not contain.
 
 ### Protocol-violation invariants
 
@@ -211,21 +175,13 @@ necessary — the runtime emits structured events that are a direct match.
 
 ## Key Decisions
 
-| Decision                      | Chosen                                                                     | Rejected                                                      | Why                                              |
-| ----------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------ |
-| Primitive set                 | `Ask` / `Answer` / `Announce` (+ Redirect/Conclude/RollCall), shared modes | Keep `Tell`/`Share`; add alongside; mode-specific names       | One vocabulary; contract encoded structurally    |
-| Enforcement site              | `#runAgent` turn-complete guard + `protocol_violation` event               | Prose in four layers; auto-repair that masks violation        | Structural contract; violation remains loud      |
-| Retry policy                  | One synthetic reminder, then advance + trace event                         | Unbounded retry; no retry; block forever                      | Bounded cost, non-deadlocking, audible           |
-| Supervision parity            | Same vocabulary as facilitation                                            | Leave supervision's `Redirect`+`Conclude`+blocking-Ask        | Single vocabulary across libeval                 |
-| System-prompt posture         | Descriptive framing only; generic language; no skill names or domain vocabulary | Keep "then Share" / "do not proceed" as belt-and-suspenders; name `kata-session` in libeval prompt | No contradiction risk; runtime owns the contract; libeval stays generic |
-| Participant-Protocol delivery | Workflow `task-text` → facilitator → libeval `systemPromptAmend` pass-through (paired with promoted `taskAmend` config) | Append to libeval prompt (couples library to skill); coach first-Ask; agent-profile; synthetic user bootstrap; bespoke name unrelated to `taskAmend` | libeval stays generic; non-circular, trace-clean, no solo-run bleed; one naming family for both append surfaces |
-| Skill name                    | `kata-session`                                                             | `kata-storyboard` retained                                    | Name matches the skill's actual scope            |
-| Invariant source              | `protocol_violation` events from runtime                                   | Set-difference inference over Ask/Answer calls                | Direct signal vs. inferred                       |
-
-## Out of Scope
-
-Per spec 620: facilitated-agent identity (spec 500), the pure-facilitator
-posture itself (spec 490 — this spec refines its vocabulary, does not revert
-it), behavioural recovery beyond the bounded single retry, `agent-runner.js`
-per-turn mechanics, trace-format changes beyond the new `protocol_violation`
-event type, and any new workflows or agent personas.
+| Decision             | Chosen                                                                    | Rejected                                                | Why                                                       |
+| -------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------- |
+| Primitive set        | `Ask` / `Answer` / `Announce` + Redirect/Conclude/RollCall, shared modes  | Keep `Tell`/`Share`; add alongside; mode-specific names | One vocabulary; contract encoded structurally             |
+| Enforcement site     | Orchestrator turn-complete guard + `protocol_violation` event             | Prose in four prompt layers; auto-repair                | Structural contract; violation stays loud                 |
+| Retry policy         | One synthetic reminder, then advance + trace event                        | Unbounded retry; no retry; block forever                | Bounded, non-deadlocking, audible                         |
+| Supervision parity   | Same vocabulary as facilitation                                           | Leave supervision's `Redirect`+`Conclude`+blocking-Ask  | One vocabulary across libeval                             |
+| Prompt posture       | Descriptive only; generic language; no skill names or domain vocabulary   | Enforcement phrases; name `kata-session` in libeval     | Runtime owns the contract; libeval stays generic          |
+| Participant framing  | `task-text` → facilitator → libeval `systemPromptAmend` + `taskAmend`     | Append to libeval prompt; first-`Ask`; profile; bootstrap user msg | Library stays generic; one naming family for both amends |
+| Skill name           | `kata-session`                                                            | `kata-storyboard` retained                              | Name matches the skill's actual scope                     |
+| Invariant source     | `protocol_violation` events from runtime                                  | Set-difference inference over Ask/Answer calls          | Direct signal vs. inferred                                |

--- a/specs/620-facilitated-tell-share-response-protocol/spec.md
+++ b/specs/620-facilitated-tell-share-response-protocol/spec.md
@@ -296,10 +296,16 @@ evidence function is shared.
   rewritten to match the new vocabulary and to name the Ask/Answer contract
   descriptively in generic, domain-agnostic language — no kata references, no
   skill names, no domain vocabulary. The `Facilitator` participant config
-  gains an optional `sessionBootstrap: string?` field; when provided,
+  gains an optional `systemPromptAmend: string?` field; when provided,
   libeval concatenates it after `FACILITATED_AGENT_SYSTEM_PROMPT` at the
   `systemPromptFor` call site so consumers can supply participant framing
-  without libeval knowing its content.
+  without libeval knowing its content. The existing CLI-only `--task-amend`
+  concatenation in `libraries/libeval/src/commands/{run,supervise,facilitate}.js`
+  is promoted to a public config field (`taskAmend: string?`) on the
+  `Facilitator`, `Supervisor`, and `AgentRunner` configs; the CLI flag
+  becomes a thin mapping onto the config field. `taskAmend` (task-content
+  level) and `systemPromptAmend` (system-prompt level) form one naming
+  family of consumer-controlled append surfaces.
 - `libraries/libeval/src/supervisor.js` — parallel changes for supervision mode:
   pending-ask registry, turn-complete guard, updated `SUPERVISOR_SYSTEM_PROMPT`
   and `AGENT_SYSTEM_PROMPT`.
@@ -319,11 +325,11 @@ evidence function is shared.
   `references/metrics.md`, and `references/storyboard-template.md` are
   redistributed into the new structure. `SKILL.md` Facilitator Process gains
   a step describing how the coach derives a participant-side summary from the
-  relevant overlay and passes it as `sessionBootstrap` to libeval's
+  relevant overlay and passes it as `systemPromptAmend` to libeval's
   `Facilitator` participant config.
 - `.github/workflows/kata-coaching.yml` — `task-text` rewritten to carry the
   coaching framing (mode, target participant, pointer to `kata-session`,
-  participant-side summary to be passed through as `sessionBootstrap`). Does
+  participant-side summary to be passed through as `systemPromptAmend`). Does
   not prescribe Q1 content, does not assign participant-side work, does not
   carry enforcement phrasing. Not reduced to a single sentence; shape need
   not match `kata-storyboard.yml`.
@@ -338,12 +344,13 @@ evidence function is shared.
   facilitated-mode and supervised-mode protocol-violation invariants (counts of
   `protocol_violation` trace events plus `Conclude` cardinality).
 - The participant-side coaching-framing delivery surface: libeval exposes a
-  generic `sessionBootstrap: string?` pass-through on the `Facilitator`
-  participant config (libeval stays domain-agnostic); the coaching framing
-  originates in `kata-coaching.yml` `task-text` and is propagated to
-  participants by the facilitator agent, which derives participant-side
-  content from the `kata-session` skill and passes it through libeval's
-  pass-through field.
+  generic `systemPromptAmend: string?` pass-through on the `Facilitator`
+  participant config, paired with the promoted `taskAmend: string?` config
+  field that harmonises with the existing `--task-amend` CLI flag (libeval
+  stays domain-agnostic). The coaching framing originates in
+  `kata-coaching.yml` `task-text` and is propagated to participants by the
+  facilitator agent, which derives participant-side content from the
+  `kata-session` skill and passes it through libeval's pass-through field.
 
 ### Excluded
 
@@ -379,7 +386,7 @@ evidence function is shared.
   is preserved.
 - **Spec 500** (`plan implemented`) — facilitated-agent identity. Unchanged;
   the participant-side coaching-framing surface this spec selects
-  (libeval's generic `sessionBootstrap` pass-through populated by the
+  (libeval's generic `systemPromptAmend` pass-through populated by the
   facilitator) sits alongside the identity surface, not inside it.
 
 ## Success Criteria
@@ -441,27 +448,35 @@ properties compose into the intended runtime behaviour; it is not a criterion.
 
 7. **Participant-side coaching framing is delivered via a consumer-controlled
    pass-through, not via libeval's system prompt or the coach's first `Ask`.**
-   Libeval's `Facilitator` participant config exposes a `sessionBootstrap:
+   Libeval's `Facilitator` participant config exposes a `systemPromptAmend:
    string?` field; when provided, libeval concatenates it after
    `FACILITATED_AGENT_SYSTEM_PROMPT` at construction time so every participant
-   receives it before `messageBus.waitForMessages` returns. The coaching
-   framing itself (mode, target, pointer to `kata-session`, participant-side
-   summary) originates in `.github/workflows/kata-coaching.yml` `task-text`
-   and is propagated to participants by the facilitator as derived from the
-   `kata-session` skill. Libeval knows nothing about the string's content.
-   Checkable by (a) a libeval test asserting a provided `sessionBootstrap`
-   appears in the participant runner's system prompt before
-   `messageBus.waitForMessages` returns and an omitted one leaves the prompt
-   purely generic, (b) `kata-session/SKILL.md` containing a Facilitator
-   Process step that constructs and passes the bootstrap, and (c)
-   `kata-coaching.yml` `task-text` priming that step.
+   receives it before `messageBus.waitForMessages` returns. The field is
+   named to harmonise with the existing `--task-amend` CLI flag, which this
+   spec promotes into a public `taskAmend: string?` config field on the
+   `Facilitator`, `Supervisor`, and `AgentRunner` configs (the CLI flag
+   becomes a thin mapping onto it). `taskAmend` (task-content level) and
+   `systemPromptAmend` (system-prompt level) form one naming family of
+   consumer-controlled append surfaces. The coaching framing itself (mode,
+   target, pointer to `kata-session`, participant-side summary) originates
+   in `.github/workflows/kata-coaching.yml` `task-text` and is propagated to
+   participants by the facilitator as derived from the `kata-session` skill.
+   Libeval knows nothing about either string's content. Checkable by (a) a
+   libeval test asserting a provided `systemPromptAmend` appears in the
+   participant runner's system prompt before `messageBus.waitForMessages`
+   returns and an omitted one leaves the prompt purely generic, (b) a
+   libeval test asserting the promoted `taskAmend` config field produces the
+   same concatenation semantics that the CLI flag produced previously,
+   (c) `kata-session/SKILL.md` containing a Facilitator Process step that
+   constructs and passes `systemPromptAmend`, and (d) `kata-coaching.yml`
+   `task-text` priming that step.
 
 8. **Coaching workflow task-text primes the facilitator without prescribing
    participant work.** `.github/workflows/kata-coaching.yml` `task-text`
    carries the coaching framing that libeval's generic prompts deliberately
    omit: mode (1-on-1), target participant, pointer to `kata-session`, and
    the participant-side summary the coach should pass through as
-   `sessionBootstrap`. It must not prescribe Q1 content (the skill supplies
+   `systemPromptAmend`. It must not prescribe Q1 content (the skill supplies
    wording), must not assign participant-side work (no "have them analyze
    their trace using kata-trace"), must not name tools the participant should
    use, and must not carry enforcement phrasing ("stop making tool calls",

--- a/specs/620-facilitated-tell-share-response-protocol/spec.md
+++ b/specs/620-facilitated-tell-share-response-protocol/spec.md
@@ -210,8 +210,8 @@ Replace the current messaging primitives with a pair that encodes the contract:
   relay.
 - **`Announce(message)`** — no-reply broadcast (the legitimate use of today's
   `Share`). Clearly distinguished from `Ask`.
-- `Redirect`, `Conclude`, `RollCall` retain their current names and semantics
-  in both modes.
+- `Redirect`, `Conclude`, `RollCall` retain their current names and semantics in
+  both modes.
 
 The vocabulary is shared between supervision and facilitation. Supervision is
 1:1 with a single pending-ask slot; facilitation is 1:N with one slot per
@@ -221,19 +221,18 @@ addressed participant.
 
 The orchestrator (facilitator or supervisor) tracks outstanding asks per
 addressee and refuses to finalise an agent's turn while that agent has an
-unanswered ask. Recovery is bounded: exactly one nudge to answer, and if the
-ask is still outstanding after that, the orchestrator emits a
-`protocol_violation` trace event and allows the turn to complete so the
-session can advance (the facilitator sees a null response and may Redirect
-or Conclude).
+unanswered ask. Recovery is bounded: exactly one nudge to answer, and if the ask
+is still outstanding after that, the orchestrator emits a `protocol_violation`
+trace event and allows the turn to complete so the session can advance (the
+facilitator sees a null response and may Redirect or Conclude).
 
-Keeping the session live and keeping the violation visible are orthogonal —
-both are required. Silent deadlock becomes structurally impossible, and the
-violation becomes a first-class trace fact rather than an inference. The
-specific data structures, call sites, and nudge mechanism are design
-decisions; see design.md.
+Keeping the session live and keeping the violation visible are orthogonal — both
+are required. Silent deadlock becomes structurally impossible, and the violation
+becomes a first-class trace fact rather than an inference. The specific data
+structures, call sites, and nudge mechanism are design decisions; see design.md.
 
 ### Participant-side coaching framing reaches participants via a generic,
+
 consumer-controlled pass-through
 
 Libeval stays domain-agnostic: its system prompts describe only the
@@ -241,10 +240,10 @@ Ask/Answer/Announce contract in generic language and name no specific skill,
 kata concept, or domain vocabulary. Coaching framing (mode, target, protocol
 pointer, participant-side summary) travels from the workflow into the
 facilitator's context, and the facilitator propagates it to each participant
-through a generic pass-through field on libeval's participant config.
-Delivery via the coach's first `Ask` is rejected: it uses the very protocol
-that's being bootstrapped. The specific field name, concatenation order,
-and CLI-to-config mapping are design decisions; see design.md.
+through a generic pass-through field on libeval's participant config. Delivery
+via the coach's first `Ask` is rejected: it uses the very protocol that's being
+bootstrapped. The specific field name, concatenation order, and CLI-to-config
+mapping are design decisions; see design.md.
 
 ### Skill restructure: `kata-storyboard` → `kata-session`
 
@@ -267,13 +266,13 @@ workflows, prior spec designs that are live history) update to `kata-session`.
 ### Rewritten task-text for `kata-coaching.yml`
 
 The coaching workflow's `task-text` primes the facilitator with the coaching
-framing libeval's generic prompts deliberately omit — mode, target
-participant, pointer to `kata-session`, and the participant-side summary the
-coach will propagate. It must not prescribe Q1 content, must not assign
-participant-side work, must not name participant tools, and must not carry
-enforcement phrasing. Because libeval is now generic, domain framing is
-expected to live here; the task-text is not reduced to a single sentence and
-its shape need not match `kata-storyboard.yml`.
+framing libeval's generic prompts deliberately omit — mode, target participant,
+pointer to `kata-session`, and the participant-side summary the coach will
+propagate. It must not prescribe Q1 content, must not assign participant-side
+work, must not name participant tools, and must not carry enforcement phrasing.
+Because libeval is now generic, domain framing is expected to live here; the
+task-text is not reduced to a single sentence and its shape need not match
+`kata-storyboard.yml`.
 
 ### Structured protocol-violation invariants
 
@@ -286,52 +285,49 @@ evidence function is shared.
 
 ### Included
 
-- `libraries/libeval/src/orchestration-toolkit.js` — the tool surface for
-  both facilitator and supervisor modes switches to `Ask` / `Answer` /
-  `Announce`. `Tell`, `Share`, and the participant-side blocking `Ask`
-  are removed with no aliases or compatibility shims.
+- `libraries/libeval/src/orchestration-toolkit.js` — the tool surface for both
+  facilitator and supervisor modes switches to `Ask` / `Answer` / `Announce`.
+  `Tell`, `Share`, and the participant-side blocking `Ask` are removed with no
+  aliases or compatibility shims.
 - `libraries/libeval/src/facilitator.js` and
-  `libraries/libeval/src/supervisor.js` — both orchestrators gain
-  pending-ask tracking and a turn-complete guard with bounded single
-  recovery and `protocol_violation` trace emission (observable properties
-  asserted by SC 2 and SC 3). `FACILITATOR_SYSTEM_PROMPT`,
-  `FACILITATED_AGENT_SYSTEM_PROMPT`, `SUPERVISOR_SYSTEM_PROMPT`, and
-  `AGENT_SYSTEM_PROMPT` are rewritten to match the new vocabulary in
-  generic, domain-agnostic language — no skill names, no kata concepts, no
-  domain vocabulary. The `Facilitator` participant config exposes a
-  generic `systemPromptAmend: string?` pass-through so consumers can
+  `libraries/libeval/src/supervisor.js` — both orchestrators gain pending-ask
+  tracking and a turn-complete guard with bounded single recovery and
+  `protocol_violation` trace emission (observable properties asserted by SC 2
+  and SC 3). `FACILITATOR_SYSTEM_PROMPT`, `FACILITATED_AGENT_SYSTEM_PROMPT`,
+  `SUPERVISOR_SYSTEM_PROMPT`, and `AGENT_SYSTEM_PROMPT` are rewritten to match
+  the new vocabulary in generic, domain-agnostic language — no skill names, no
+  kata concepts, no domain vocabulary. The `Facilitator` participant config
+  exposes a generic `systemPromptAmend: string?` pass-through so consumers can
   supply participant framing; libeval treats its content as opaque. The
   `taskAmend` concatenation currently performed by
-  `libraries/libeval/src/commands/*` is exposed in the same shape as a
-  public config field on `Facilitator`, `Supervisor`, and `AgentRunner`,
-  with the CLI flag driving that field. `taskAmend` (task-content level)
-  and `systemPromptAmend` (system-prompt level) share one naming family.
+  `libraries/libeval/src/commands/*` is exposed in the same shape as a public
+  config field on `Facilitator`, `Supervisor`, and `AgentRunner`, with the CLI
+  flag driving that field. `taskAmend` (task-content level) and
+  `systemPromptAmend` (system-prompt level) share one naming family.
 - `libraries/libeval/src/message-bus.js` — bus API updated to the new
-  vocabulary; existing `tell` / `share` methods are removed in favour of
-  `ask` / `answer` / `announce` counterparts. Message-tag shape is a
-  design decision.
-- `libraries/libeval/src/index.js` — public exports reflect the new
-  vocabulary and the new config fields.
-- `libraries/libeval/test/**` — test coverage updated and extended for the
-  new primitives, pending-ask transitions, turn-complete guard,
-  `protocol_violation` event emission, and the `taskAmend` /
-  `systemPromptAmend` pass-throughs. File-level test decomposition is a
-  plan decision.
+  vocabulary; existing `tell` / `share` methods are removed in favour of `ask` /
+  `answer` / `announce` counterparts. Message-tag shape is a design decision.
+- `libraries/libeval/src/index.js` — public exports reflect the new vocabulary
+  and the new config fields.
+- `libraries/libeval/test/**` — test coverage updated and extended for the new
+  primitives, pending-ask transitions, turn-complete guard, `protocol_violation`
+  event emission, and the `taskAmend` / `systemPromptAmend` pass-throughs.
+  File-level test decomposition is a plan decision.
 - `.claude/skills/kata-storyboard/` — renamed to `.claude/skills/kata-session/`
   with `SKILL.md` holding the mode-agnostic procedure, and
   `references/team-storyboard.md` + `references/one-on-one.md` carrying the
   mode-specific overlays. Existing `references/coaching-protocol.md`,
   `references/metrics.md`, and `references/storyboard-template.md` are
-  redistributed into the new structure. `SKILL.md` Facilitator Process gains
-  a step describing how the coach derives a participant-side summary from the
+  redistributed into the new structure. `SKILL.md` Facilitator Process gains a
+  step describing how the coach derives a participant-side summary from the
   relevant overlay and passes it as `systemPromptAmend` to libeval's
   `Facilitator` participant config.
 - `.github/workflows/kata-coaching.yml` — `task-text` rewritten to carry the
   coaching framing (mode, target participant, pointer to `kata-session`,
   participant-side summary to be passed through as `systemPromptAmend`). Does
   not prescribe Q1 content, does not assign participant-side work, does not
-  carry enforcement phrasing. Not reduced to a single sentence; shape need
-  not match `kata-storyboard.yml`.
+  carry enforcement phrasing. Not reduced to a single sentence; shape need not
+  match `kata-storyboard.yml`.
 - `.github/workflows/kata-storyboard.yml` — any skill-name references updated;
   workflow behaviour otherwise unchanged.
 - `.claude/agents/*.md` — agent profiles referencing `kata-storyboard`
@@ -375,10 +371,10 @@ evidence function is shared.
 - **Spec 490** (`plan implemented`) — facilitator-as-pure-orchestrator posture.
   This spec refines the vocabulary that spec 490 introduced; the posture itself
   is preserved.
-- **Spec 500** (`plan implemented`) — facilitated-agent identity. Unchanged;
-  the participant-side coaching-framing surface this spec selects
-  (libeval's generic `systemPromptAmend` pass-through populated by the
-  facilitator) sits alongside the identity surface, not inside it.
+- **Spec 500** (`plan implemented`) — facilitated-agent identity. Unchanged; the
+  participant-side coaching-framing surface this spec selects (libeval's generic
+  `systemPromptAmend` pass-through populated by the facilitator) sits alongside
+  the identity surface, not inside it.
 
 ## Success Criteria
 
@@ -400,26 +396,25 @@ properties compose into the intended runtime behaviour; it is not a criterion.
    `libraries/libeval/test/orchestration-toolkit.test.js` assert the map's
    transitions. Checkable by reading the tests and running them.
 
-3. **Runtime refuses silent turn-completion while an ask is pending.** In
-   both facilitated and supervised modes, the orchestrator's agent loop
-   injects exactly one synthetic reminder on first detection of a pending
-   ask at turn-end, then on a second detection emits a `protocol_violation`
-   trace event and permits the turn to complete so the session can advance.
-   Covered by a test that drives an agent which ignores the first `Ask`,
-   observes the synthetic reminder, ignores again, and verifies the
-   `protocol_violation` event appears exactly once and the session does
-   not deadlock.
+3. **Runtime refuses silent turn-completion while an ask is pending.** In both
+   facilitated and supervised modes, the orchestrator's agent loop injects
+   exactly one synthetic reminder on first detection of a pending ask at
+   turn-end, then on a second detection emits a `protocol_violation` trace event
+   and permits the turn to complete so the session can advance. Covered by a
+   test that drives an agent which ignores the first `Ask`, observes the
+   synthetic reminder, ignores again, and verifies the `protocol_violation`
+   event appears exactly once and the session does not deadlock.
 
-4. **System prompts match the new vocabulary, are descriptive not enforcing,
-   and stay domain-agnostic.** `FACILITATOR_SYSTEM_PROMPT`,
+4. **System prompts match the new vocabulary, are descriptive not enforcing, and
+   stay domain-agnostic.** `FACILITATOR_SYSTEM_PROMPT`,
    `FACILITATED_AGENT_SYSTEM_PROMPT`, `SUPERVISOR_SYSTEM_PROMPT`, and
    `AGENT_SYSTEM_PROMPT` name the `Ask` / `Answer` / `Announce` primitives in
    generic language. No prompt contains enforcing phrases (e.g. "then Share",
-   "respond via Share", "stop making tool calls") — runtime enforcement
-   replaces them. No prompt names a specific skill, a coaching/storyboard
-   domain concept, or artifact vocabulary; libeval is a generic library and
-   its prompts must stay domain-agnostic. Checkable by reading the four
-   prompt constants in `facilitator.js` and `supervisor.js`.
+   "respond via Share", "stop making tool calls") — runtime enforcement replaces
+   them. No prompt names a specific skill, a coaching/storyboard domain concept,
+   or artifact vocabulary; libeval is a generic library and its prompts must
+   stay domain-agnostic. Checkable by reading the four prompt constants in
+   `facilitator.js` and `supervisor.js`.
 
 5. **`kata-session` skill replaces `kata-storyboard` with a mode-agnostic
    procedure.** The directory `.claude/skills/kata-session/` exists with
@@ -435,33 +430,32 @@ properties compose into the intended runtime behaviour; it is not a criterion.
    that document prior work. Checkable by `grep -rn kata-storyboard`.
 
 7. **Participant-side coaching framing is delivered via a consumer-controlled
-   pass-through, not via libeval's system prompt or the coach's first
-   `Ask`.** Libeval exposes two public, consumer-controlled append surfaces
-   in a single naming family: one at task-content level (the existing
-   `--task-amend` promoted from CLI-only to the programmatic config) and one
-   at system-prompt level (new). Both accept opaque strings; libeval never
-   inspects their content. The coaching framing itself (mode, target,
-   pointer to `kata-session`, participant-side summary) originates in
+   pass-through, not via libeval's system prompt or the coach's first `Ask`.**
+   Libeval exposes two public, consumer-controlled append surfaces in a single
+   naming family: one at task-content level (the existing `--task-amend`
+   promoted from CLI-only to the programmatic config) and one at system-prompt
+   level (new). Both accept opaque strings; libeval never inspects their
+   content. The coaching framing itself (mode, target, pointer to
+   `kata-session`, participant-side summary) originates in
    `.github/workflows/kata-coaching.yml` `task-text` and is propagated to
    participants by the facilitator as derived from the `kata-session` skill.
-   Checkable by (a) a libeval test asserting that a provided
-   system-prompt-level addendum reaches the participant's system prompt
-   before the first `Ask` is delivered, and that the absence of one leaves
-   the prompt purely generic; (b) a libeval test asserting that the promoted
-   task-content-level config field produces the same concatenation semantics
-   that the CLI flag produced previously; (c) `kata-session/SKILL.md`
-   containing a Facilitator Process step that constructs and passes the
-   participant-side summary; and (d) `kata-coaching.yml` `task-text`
-   priming that step. Specific field names are a design decision.
+   Checkable by (a) a libeval test asserting that a provided system-prompt-level
+   addendum reaches the participant's system prompt before the first `Ask` is
+   delivered, and that the absence of one leaves the prompt purely generic; (b)
+   a libeval test asserting that the promoted task-content-level config field
+   produces the same concatenation semantics that the CLI flag produced
+   previously; (c) `kata-session/SKILL.md` containing a Facilitator Process step
+   that constructs and passes the participant-side summary; and (d)
+   `kata-coaching.yml` `task-text` priming that step. Specific field names are a
+   design decision.
 
-8. **Coaching workflow task-text does not over-direct the facilitator or
-   assign participant work.** `.github/workflows/kata-coaching.yml`
-   `task-text` does not prescribe Q1 content, does not assign
-   participant-side work (no "have them analyze their trace using
-   kata-trace"), does not name tools the participant should use, and does
-   not carry enforcement phrasing ("stop making tool calls", "then Share").
-   Checkable by reading the workflow. (SC 7 covers the positive content the
-   task-text carries.)
+8. **Coaching workflow task-text does not over-direct the facilitator or assign
+   participant work.** `.github/workflows/kata-coaching.yml` `task-text` does
+   not prescribe Q1 content, does not assign participant-side work (no "have
+   them analyze their trace using kata-trace"), does not name tools the
+   participant should use, and does not carry enforcement phrasing ("stop making
+   tool calls", "then Share"). Checkable by reading the workflow. (SC 7 covers
+   the positive content the task-text carries.)
 
 9. **Protocol-violation invariants are catalogued for both modes.**
    `.claude/skills/kata-trace/references/invariants.md` contains one entry per

--- a/specs/620-facilitated-tell-share-response-protocol/spec.md
+++ b/specs/620-facilitated-tell-share-response-protocol/spec.md
@@ -210,8 +210,8 @@ Replace the current messaging primitives with a pair that encodes the contract:
   relay.
 - **`Announce(message)`** — no-reply broadcast (the legitimate use of today's
   `Share`). Clearly distinguished from `Ask`.
-- `Redirect`, `Conclude`, `RollCall` are unchanged in semantics but renamed or
-  retained consistently across both modes.
+- `Redirect`, `Conclude`, `RollCall` retain their current names and semantics
+  in both modes.
 
 The vocabulary is shared between supervision and facilitation. Supervision is
 1:1 with a single pending-ask slot; facilitation is 1:N with one slot per
@@ -219,33 +219,32 @@ addressed participant.
 
 ### Runtime enforcement of the contract
 
-`Facilitator` and `Supervisor` track `ctx.pendingAsks` — a map keyed by
-addressee, value holding the ask id and question. The agent outer loop
-(`#runAgent` in `facilitator.js`, the equivalent loop in `supervisor.js`) must
-not emit `lifecycle:turn_complete` while the agent has an outstanding ask.
+The orchestrator (facilitator or supervisor) tracks outstanding asks per
+addressee and refuses to finalise an agent's turn while that agent has an
+unanswered ask. Recovery is bounded: exactly one nudge to answer, and if the
+ask is still outstanding after that, the orchestrator emits a
+`protocol_violation` trace event and allows the turn to complete so the
+session can advance (the facilitator sees a null response and may Redirect
+or Conclude).
 
-When an agent ends a turn with a pending ask:
+Keeping the session live and keeping the violation visible are orthogonal —
+both are required. Silent deadlock becomes structurally impossible, and the
+violation becomes a first-class trace fact rather than an inference. The
+specific data structures, call sites, and nudge mechanism are design
+decisions; see design.md.
 
-1. Inject a bounded synthetic reminder and resume the agent once.
-2. If the ask is still pending after the resume, emit a `protocol_violation`
-   event on the trace and permit turn completion so the session can advance (the
-   facilitator sees a null response and may Redirect or Conclude).
+### Participant-side coaching framing reaches participants via a generic,
+consumer-controlled pass-through
 
-Keeping the session live and keeping the violation visible are orthogonal — both
-are required. The silent deadlock is structurally impossible, and the violation
-is a first-class trace fact rather than an inference.
-
-### Session-bootstrap delivery of the Participant Protocol
-
-The Participant Protocol reaches 1-on-1 participants via the participant's
-initial system prompt, which the facilitator controls via
-`createFacilitatedAgentToolServer` / the runner's `systemPrompt`. Candidate
-surfaces — a short Participant-Protocol summary appended to
-`FACILITATED_AGENT_SYSTEM_PROMPT`, an initial bootstrap user message synthesised
-by `#runAgent` before the first `Ask` is delivered, or a direct skill-load
-directive — are enumerated without ranking; which surface is chosen is a design
-decision. Delivery via the coach's first `Ask` is rejected: it uses the very
-protocol that's being bootstrapped.
+Libeval stays domain-agnostic: its system prompts describe only the
+Ask/Answer/Announce contract in generic language and name no specific skill,
+kata concept, or domain vocabulary. Coaching framing (mode, target, protocol
+pointer, participant-side summary) travels from the workflow into the
+facilitator's context, and the facilitator propagates it to each participant
+through a generic pass-through field on libeval's participant config.
+Delivery via the coach's first `Ask` is rejected: it uses the very protocol
+that's being bootstrapped. The specific field name, concatenation order,
+and CLI-to-config mapping are design decisions; see design.md.
 
 ### Skill restructure: `kata-storyboard` → `kata-session`
 
@@ -265,11 +264,16 @@ references:
 All references to `kata-storyboard` across the repo (KATA.md, agent profiles,
 workflows, prior spec designs that are live history) update to `kata-session`.
 
-### Reduced task-text for `kata-coaching.yml`
+### Rewritten task-text for `kata-coaching.yml`
 
-Unchanged in rationale from the prior draft of this spec: one sentence, skill
-dispatch only, no Q1 prescription and no participant-side work assignment.
-Matches the shape of `kata-storyboard.yml`.
+The coaching workflow's `task-text` primes the facilitator with the coaching
+framing libeval's generic prompts deliberately omit — mode, target
+participant, pointer to `kata-session`, and the participant-side summary the
+coach will propagate. It must not prescribe Q1 content, must not assign
+participant-side work, must not name participant tools, and must not carry
+enforcement phrasing. Because libeval is now generic, domain framing is
+expected to live here; the task-text is not reduced to a single sentence and
+its shape need not match `kata-storyboard.yml`.
 
 ### Structured protocol-violation invariants
 
@@ -282,42 +286,37 @@ evidence function is shared.
 
 ### Included
 
-- `libraries/libeval/src/orchestration-toolkit.js` — full rewrite of the four
-  tool-server factories (`createSupervisorToolServer`,
-  `createSupervisedAgentToolServer`, `createFacilitatorToolServer`,
-  `createFacilitatedAgentToolServer`) to expose `Ask` / `Answer` / `Announce` in
-  place of `Tell` / `Share` and the participant-side blocking `Ask`. Handler
-  factories (`createAskHandler`, `createAnswerHandler`, `createAnnounceHandler`)
-  and the orchestration context now track `pendingAsks`.
-- `libraries/libeval/src/facilitator.js` — `Facilitator` class gains the
-  pending-ask registry, the `#runAgent` turn-complete guard with bounded
-  resume-once behaviour, and emits `protocol_violation` trace events.
-  `FACILITATOR_SYSTEM_PROMPT` and `FACILITATED_AGENT_SYSTEM_PROMPT` are
-  rewritten to match the new vocabulary and to name the Ask/Answer contract
-  descriptively in generic, domain-agnostic language — no kata references, no
-  skill names, no domain vocabulary. The `Facilitator` participant config
-  gains an optional `systemPromptAmend: string?` field; when provided,
-  libeval concatenates it after `FACILITATED_AGENT_SYSTEM_PROMPT` at the
-  `systemPromptFor` call site so consumers can supply participant framing
-  without libeval knowing its content. The existing CLI-only `--task-amend`
-  concatenation in `libraries/libeval/src/commands/{run,supervise,facilitate}.js`
-  is promoted to a public config field (`taskAmend: string?`) on the
-  `Facilitator`, `Supervisor`, and `AgentRunner` configs; the CLI flag
-  becomes a thin mapping onto the config field. `taskAmend` (task-content
-  level) and `systemPromptAmend` (system-prompt level) form one naming
-  family of consumer-controlled append surfaces.
-- `libraries/libeval/src/supervisor.js` — parallel changes for supervision mode:
-  pending-ask registry, turn-complete guard, updated `SUPERVISOR_SYSTEM_PROMPT`
-  and `AGENT_SYSTEM_PROMPT`.
-- `libraries/libeval/src/message-bus.js` — `tell` / `share` methods renamed or
-  augmented so the bus speaks the new vocabulary; message tag shape (`[direct]`
-  / `[shared]`) is a design decision.
-- `libraries/libeval/src/index.js` — exports.
-- `libraries/libeval/test/**` — new and updated tests for `Ask` / `Answer` /
-  `Announce`, pending-ask tracking, turn-complete guard, and
-  `protocol_violation` emission. Affected: `orchestration-toolkit.test.js`,
-  `facilitator.test.js`, `facilitator-messaging.test.js`,
-  `supervisor-*.test.js`, `message-bus.test.js`.
+- `libraries/libeval/src/orchestration-toolkit.js` — the tool surface for
+  both facilitator and supervisor modes switches to `Ask` / `Answer` /
+  `Announce`. `Tell`, `Share`, and the participant-side blocking `Ask`
+  are removed with no aliases or compatibility shims.
+- `libraries/libeval/src/facilitator.js` and
+  `libraries/libeval/src/supervisor.js` — both orchestrators gain
+  pending-ask tracking and a turn-complete guard with bounded single
+  recovery and `protocol_violation` trace emission (observable properties
+  asserted by SC 2 and SC 3). `FACILITATOR_SYSTEM_PROMPT`,
+  `FACILITATED_AGENT_SYSTEM_PROMPT`, `SUPERVISOR_SYSTEM_PROMPT`, and
+  `AGENT_SYSTEM_PROMPT` are rewritten to match the new vocabulary in
+  generic, domain-agnostic language — no skill names, no kata concepts, no
+  domain vocabulary. The `Facilitator` participant config exposes a
+  generic `systemPromptAmend: string?` pass-through so consumers can
+  supply participant framing; libeval treats its content as opaque. The
+  `taskAmend` concatenation currently performed by
+  `libraries/libeval/src/commands/*` is exposed in the same shape as a
+  public config field on `Facilitator`, `Supervisor`, and `AgentRunner`,
+  with the CLI flag driving that field. `taskAmend` (task-content level)
+  and `systemPromptAmend` (system-prompt level) share one naming family.
+- `libraries/libeval/src/message-bus.js` — bus API updated to the new
+  vocabulary; existing `tell` / `share` methods are removed in favour of
+  `ask` / `answer` / `announce` counterparts. Message-tag shape is a
+  design decision.
+- `libraries/libeval/src/index.js` — public exports reflect the new
+  vocabulary and the new config fields.
+- `libraries/libeval/test/**` — test coverage updated and extended for the
+  new primitives, pending-ask transitions, turn-complete guard,
+  `protocol_violation` event emission, and the `taskAmend` /
+  `systemPromptAmend` pass-throughs. File-level test decomposition is a
+  plan decision.
 - `.claude/skills/kata-storyboard/` — renamed to `.claude/skills/kata-session/`
   with `SKILL.md` holding the mode-agnostic procedure, and
   `references/team-storyboard.md` + `references/one-on-one.md` carrying the
@@ -343,14 +342,6 @@ evidence function is shared.
 - `.claude/skills/kata-trace/references/invariants.md` — two new entries:
   facilitated-mode and supervised-mode protocol-violation invariants (counts of
   `protocol_violation` trace events plus `Conclude` cardinality).
-- The participant-side coaching-framing delivery surface: libeval exposes a
-  generic `systemPromptAmend: string?` pass-through on the `Facilitator`
-  participant config, paired with the promoted `taskAmend: string?` config
-  field that harmonises with the existing `--task-amend` CLI flag (libeval
-  stays domain-agnostic). The coaching framing originates in
-  `kata-coaching.yml` `task-text` and is propagated to participants by the
-  facilitator agent, which derives participant-side content from the
-  `kata-session` skill and passes it through libeval's pass-through field.
 
 ### Excluded
 
@@ -409,29 +400,26 @@ properties compose into the intended runtime behaviour; it is not a criterion.
    `libraries/libeval/test/orchestration-toolkit.test.js` assert the map's
    transitions. Checkable by reading the tests and running them.
 
-3. **Runtime refuses silent turn-completion while an ask is pending.** The
-   `#runAgent` loop in `facilitator.js` (and the equivalent in `supervisor.js`)
-   injects exactly one synthetic reminder on first detection of a pending ask at
-   turn-end, then on a second detection emits a `protocol_violation` trace event
-   and permits the turn to complete so the session can advance. Covered by a
-   test that drives an agent which ignores the first `Ask`, observes the
-   synthetic reminder, ignores again, and verifies the `protocol_violation`
-   event appears exactly once and the session does not deadlock.
+3. **Runtime refuses silent turn-completion while an ask is pending.** In
+   both facilitated and supervised modes, the orchestrator's agent loop
+   injects exactly one synthetic reminder on first detection of a pending
+   ask at turn-end, then on a second detection emits a `protocol_violation`
+   trace event and permits the turn to complete so the session can advance.
+   Covered by a test that drives an agent which ignores the first `Ask`,
+   observes the synthetic reminder, ignores again, and verifies the
+   `protocol_violation` event appears exactly once and the session does
+   not deadlock.
 
 4. **System prompts match the new vocabulary, are descriptive not enforcing,
    and stay domain-agnostic.** `FACILITATOR_SYSTEM_PROMPT`,
    `FACILITATED_AGENT_SYSTEM_PROMPT`, `SUPERVISOR_SYSTEM_PROMPT`, and
    `AGENT_SYSTEM_PROMPT` name the `Ask` / `Answer` / `Announce` primitives in
-   generic language. No prompt contains "then Share", "respond via Share",
-   "stop making tool calls", or equivalent enforcing phrases — runtime
-   enforcement replaces them. No prompt names a specific skill
-   (`kata-session`, `kata-storyboard`, any `kata-*`), a domain concept
-   ("Participant Protocol" as a proper noun, "five questions", "coaching",
-   "storyboard"), or artifact vocabulary ("CSV", "XmR"). Libeval is a generic
-   library and its prompts must stay domain-agnostic. Checkable by reading
-   `facilitator.js` and `supervisor.js`, and by
-   `grep -nE 'kata-|Participant Protocol|five questions|coaching|storyboard|CSV|XmR' libraries/libeval/src/`
-   returning no hits.
+   generic language. No prompt contains enforcing phrases (e.g. "then Share",
+   "respond via Share", "stop making tool calls") — runtime enforcement
+   replaces them. No prompt names a specific skill, a coaching/storyboard
+   domain concept, or artifact vocabulary; libeval is a generic library and
+   its prompts must stay domain-agnostic. Checkable by reading the four
+   prompt constants in `facilitator.js` and `supervisor.js`.
 
 5. **`kata-session` skill replaces `kata-storyboard` with a mode-agnostic
    procedure.** The directory `.claude/skills/kata-session/` exists with
@@ -447,43 +435,33 @@ properties compose into the intended runtime behaviour; it is not a criterion.
    that document prior work. Checkable by `grep -rn kata-storyboard`.
 
 7. **Participant-side coaching framing is delivered via a consumer-controlled
-   pass-through, not via libeval's system prompt or the coach's first `Ask`.**
-   Libeval's `Facilitator` participant config exposes a `systemPromptAmend:
-   string?` field; when provided, libeval concatenates it after
-   `FACILITATED_AGENT_SYSTEM_PROMPT` at construction time so every participant
-   receives it before `messageBus.waitForMessages` returns. The field is
-   named to harmonise with the existing `--task-amend` CLI flag, which this
-   spec promotes into a public `taskAmend: string?` config field on the
-   `Facilitator`, `Supervisor`, and `AgentRunner` configs (the CLI flag
-   becomes a thin mapping onto it). `taskAmend` (task-content level) and
-   `systemPromptAmend` (system-prompt level) form one naming family of
-   consumer-controlled append surfaces. The coaching framing itself (mode,
-   target, pointer to `kata-session`, participant-side summary) originates
-   in `.github/workflows/kata-coaching.yml` `task-text` and is propagated to
+   pass-through, not via libeval's system prompt or the coach's first
+   `Ask`.** Libeval exposes two public, consumer-controlled append surfaces
+   in a single naming family: one at task-content level (the existing
+   `--task-amend` promoted from CLI-only to the programmatic config) and one
+   at system-prompt level (new). Both accept opaque strings; libeval never
+   inspects their content. The coaching framing itself (mode, target,
+   pointer to `kata-session`, participant-side summary) originates in
+   `.github/workflows/kata-coaching.yml` `task-text` and is propagated to
    participants by the facilitator as derived from the `kata-session` skill.
-   Libeval knows nothing about either string's content. Checkable by (a) a
-   libeval test asserting a provided `systemPromptAmend` appears in the
-   participant runner's system prompt before `messageBus.waitForMessages`
-   returns and an omitted one leaves the prompt purely generic, (b) a
-   libeval test asserting the promoted `taskAmend` config field produces the
-   same concatenation semantics that the CLI flag produced previously,
-   (c) `kata-session/SKILL.md` containing a Facilitator Process step that
-   constructs and passes `systemPromptAmend`, and (d) `kata-coaching.yml`
-   `task-text` priming that step.
+   Checkable by (a) a libeval test asserting that a provided
+   system-prompt-level addendum reaches the participant's system prompt
+   before the first `Ask` is delivered, and that the absence of one leaves
+   the prompt purely generic; (b) a libeval test asserting that the promoted
+   task-content-level config field produces the same concatenation semantics
+   that the CLI flag produced previously; (c) `kata-session/SKILL.md`
+   containing a Facilitator Process step that constructs and passes the
+   participant-side summary; and (d) `kata-coaching.yml` `task-text`
+   priming that step. Specific field names are a design decision.
 
-8. **Coaching workflow task-text primes the facilitator without prescribing
-   participant work.** `.github/workflows/kata-coaching.yml` `task-text`
-   carries the coaching framing that libeval's generic prompts deliberately
-   omit: mode (1-on-1), target participant, pointer to `kata-session`, and
-   the participant-side summary the coach should pass through as
-   `systemPromptAmend`. It must not prescribe Q1 content (the skill supplies
-   wording), must not assign participant-side work (no "have them analyze
-   their trace using kata-trace"), must not name tools the participant should
-   use, and must not carry enforcement phrasing ("stop making tool calls",
-   "then Share"). The shape does not need to match `kata-storyboard.yml` —
-   the coaching workflow's task-text is expected to be longer because libeval
-   is now generic and domain framing lives here. Checkable by reading the
-   workflow.
+8. **Coaching workflow task-text does not over-direct the facilitator or
+   assign participant work.** `.github/workflows/kata-coaching.yml`
+   `task-text` does not prescribe Q1 content, does not assign
+   participant-side work (no "have them analyze their trace using
+   kata-trace"), does not name tools the participant should use, and does
+   not carry enforcement phrasing ("stop making tool calls", "then Share").
+   Checkable by reading the workflow. (SC 7 covers the positive content the
+   task-text carries.)
 
 9. **Protocol-violation invariants are catalogued for both modes.**
    `.claude/skills/kata-trace/references/invariants.md` contains one entry per

--- a/specs/620-facilitated-tell-share-response-protocol/spec.md
+++ b/specs/620-facilitated-tell-share-response-protocol/spec.md
@@ -294,7 +294,12 @@ evidence function is shared.
   resume-once behaviour, and emits `protocol_violation` trace events.
   `FACILITATOR_SYSTEM_PROMPT` and `FACILITATED_AGENT_SYSTEM_PROMPT` are
   rewritten to match the new vocabulary and to name the Ask/Answer contract
-  descriptively.
+  descriptively in generic, domain-agnostic language — no kata references, no
+  skill names, no domain vocabulary. The `Facilitator` participant config
+  gains an optional `sessionBootstrap: string?` field; when provided,
+  libeval concatenates it after `FACILITATED_AGENT_SYSTEM_PROMPT` at the
+  `systemPromptFor` call site so consumers can supply participant framing
+  without libeval knowing its content.
 - `libraries/libeval/src/supervisor.js` — parallel changes for supervision mode:
   pending-ask registry, turn-complete guard, updated `SUPERVISOR_SYSTEM_PROMPT`
   and `AGENT_SYSTEM_PROMPT`.
@@ -312,9 +317,16 @@ evidence function is shared.
   `references/team-storyboard.md` + `references/one-on-one.md` carrying the
   mode-specific overlays. Existing `references/coaching-protocol.md`,
   `references/metrics.md`, and `references/storyboard-template.md` are
-  redistributed into the new structure.
-- `.github/workflows/kata-coaching.yml` — `task-text` reduced to single-sentence
-  skill dispatch.
+  redistributed into the new structure. `SKILL.md` Facilitator Process gains
+  a step describing how the coach derives a participant-side summary from the
+  relevant overlay and passes it as `sessionBootstrap` to libeval's
+  `Facilitator` participant config.
+- `.github/workflows/kata-coaching.yml` — `task-text` rewritten to carry the
+  coaching framing (mode, target participant, pointer to `kata-session`,
+  participant-side summary to be passed through as `sessionBootstrap`). Does
+  not prescribe Q1 content, does not assign participant-side work, does not
+  carry enforcement phrasing. Not reduced to a single sentence; shape need
+  not match `kata-storyboard.yml`.
 - `.github/workflows/kata-storyboard.yml` — any skill-name references updated;
   workflow behaviour otherwise unchanged.
 - `.claude/agents/*.md` — agent profiles referencing `kata-storyboard`
@@ -325,10 +337,13 @@ evidence function is shared.
 - `.claude/skills/kata-trace/references/invariants.md` — two new entries:
   facilitated-mode and supervised-mode protocol-violation invariants (counts of
   `protocol_violation` trace events plus `Conclude` cardinality).
-- The participant-side Participant-Protocol delivery surface, chosen from:
-  `FACILITATED_AGENT_SYSTEM_PROMPT` append, a bootstrap user message synthesised
-  by `#runAgent` before the first Ask arrives, or workflow input. Which surface
-  is chosen is a design decision.
+- The participant-side coaching-framing delivery surface: libeval exposes a
+  generic `sessionBootstrap: string?` pass-through on the `Facilitator`
+  participant config (libeval stays domain-agnostic); the coaching framing
+  originates in `kata-coaching.yml` `task-text` and is propagated to
+  participants by the facilitator agent, which derives participant-side
+  content from the `kata-session` skill and passes it through libeval's
+  pass-through field.
 
 ### Excluded
 
@@ -362,9 +377,10 @@ evidence function is shared.
 - **Spec 490** (`plan implemented`) — facilitator-as-pure-orchestrator posture.
   This spec refines the vocabulary that spec 490 introduced; the posture itself
   is preserved.
-- **Spec 500** (`plan implemented`) — facilitated-agent identity. Unchanged; the
-  Participant Protocol delivery surface this spec selects sits alongside the
-  identity surface, not inside it.
+- **Spec 500** (`plan implemented`) — facilitated-agent identity. Unchanged;
+  the participant-side coaching-framing surface this spec selects
+  (libeval's generic `sessionBootstrap` pass-through populated by the
+  facilitator) sits alongside the identity surface, not inside it.
 
 ## Success Criteria
 
@@ -395,13 +411,20 @@ properties compose into the intended runtime behaviour; it is not a criterion.
    synthetic reminder, ignores again, and verifies the `protocol_violation`
    event appears exactly once and the session does not deadlock.
 
-4. **System prompts match the new vocabulary and are descriptive, not
-   enforcing.** `FACILITATOR_SYSTEM_PROMPT`, `FACILITATED_AGENT_SYSTEM_PROMPT`,
-   `SUPERVISOR_SYSTEM_PROMPT`, and `AGENT_SYSTEM_PROMPT` name the `Ask` /
-   `Answer` / `Announce` primitives. No prompt contains "then Share", "respond
-   via Share", "stop making tool calls", or equivalent enforcing phrases —
-   runtime enforcement replaces them. Checkable by reading `facilitator.js` and
-   `supervisor.js`.
+4. **System prompts match the new vocabulary, are descriptive not enforcing,
+   and stay domain-agnostic.** `FACILITATOR_SYSTEM_PROMPT`,
+   `FACILITATED_AGENT_SYSTEM_PROMPT`, `SUPERVISOR_SYSTEM_PROMPT`, and
+   `AGENT_SYSTEM_PROMPT` name the `Ask` / `Answer` / `Announce` primitives in
+   generic language. No prompt contains "then Share", "respond via Share",
+   "stop making tool calls", or equivalent enforcing phrases — runtime
+   enforcement replaces them. No prompt names a specific skill
+   (`kata-session`, `kata-storyboard`, any `kata-*`), a domain concept
+   ("Participant Protocol" as a proper noun, "five questions", "coaching",
+   "storyboard"), or artifact vocabulary ("CSV", "XmR"). Libeval is a generic
+   library and its prompts must stay domain-agnostic. Checkable by reading
+   `facilitator.js` and `supervisor.js`, and by
+   `grep -nE 'kata-|Participant Protocol|five questions|coaching|storyboard|CSV|XmR' libraries/libeval/src/`
+   returning no hits.
 
 5. **`kata-session` skill replaces `kata-storyboard` with a mode-agnostic
    procedure.** The directory `.claude/skills/kata-session/` exists with
@@ -416,19 +439,36 @@ properties compose into the intended runtime behaviour; it is not a criterion.
    `kata-storyboard` except in historical spec/design artifacts under `specs/`
    that document prior work. Checkable by `grep -rn kata-storyboard`.
 
-7. **Participant Protocol is delivered via a session-bootstrap surface, not via
-   the coach's first `Ask`.** Whichever surface the design selects (system
-   prompt append, bootstrap user message, or workflow input), a participant in a
-   1-on-1 session has the Participant Protocol in its context before the first
-   `Ask` from the facilitator is delivered. Checkable by reading the selected
-   surface and by a test that asserts the surface is loaded into the
-   participant's runner before `messageBus.waitForMessages` returns.
+7. **Participant-side coaching framing is delivered via a consumer-controlled
+   pass-through, not via libeval's system prompt or the coach's first `Ask`.**
+   Libeval's `Facilitator` participant config exposes a `sessionBootstrap:
+   string?` field; when provided, libeval concatenates it after
+   `FACILITATED_AGENT_SYSTEM_PROMPT` at construction time so every participant
+   receives it before `messageBus.waitForMessages` returns. The coaching
+   framing itself (mode, target, pointer to `kata-session`, participant-side
+   summary) originates in `.github/workflows/kata-coaching.yml` `task-text`
+   and is propagated to participants by the facilitator as derived from the
+   `kata-session` skill. Libeval knows nothing about the string's content.
+   Checkable by (a) a libeval test asserting a provided `sessionBootstrap`
+   appears in the participant runner's system prompt before
+   `messageBus.waitForMessages` returns and an omitted one leaves the prompt
+   purely generic, (b) `kata-session/SKILL.md` containing a Facilitator
+   Process step that constructs and passes the bootstrap, and (c)
+   `kata-coaching.yml` `task-text` priming that step.
 
-8. **Coaching workflow task-text is a single-sentence skill dispatch.**
-   `.github/workflows/kata-coaching.yml` `task-text` does not prescribe Q1
-   content, does not name tools the participant should use, and does not assign
-   participant-side work. Shape matches `kata-storyboard.yml`. Checkable by
-   reading the workflow.
+8. **Coaching workflow task-text primes the facilitator without prescribing
+   participant work.** `.github/workflows/kata-coaching.yml` `task-text`
+   carries the coaching framing that libeval's generic prompts deliberately
+   omit: mode (1-on-1), target participant, pointer to `kata-session`, and
+   the participant-side summary the coach should pass through as
+   `sessionBootstrap`. It must not prescribe Q1 content (the skill supplies
+   wording), must not assign participant-side work (no "have them analyze
+   their trace using kata-trace"), must not name tools the participant should
+   use, and must not carry enforcement phrasing ("stop making tool calls",
+   "then Share"). The shape does not need to match `kata-storyboard.yml` —
+   the coaching workflow's task-text is expected to be longer because libeval
+   is now generic and domain framing lives here. Checkable by reading the
+   workflow.
 
 9. **Protocol-violation invariants are catalogued for both modes.**
    `.claude/skills/kata-trace/references/invariants.md` contains one entry per

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -81,7 +81,7 @@
 590	plan	implemented
 600	plan	draft
 610	plan	implemented
-620	design	draft
+620	design	approved
 630	spec	draft
 640	plan	implemented
 650	plan	implemented


### PR DESCRIPTION
## Summary

Revise spec 620 (Request–Response Primitives for libeval Orchestration) so libeval's four system prompts stay domain-agnostic (no kata skill names, no coaching vocabulary), harmonise the new participant-framing append surface with libeval's existing `--task-amend` CLI flag, and address consensus findings from a three-reviewer `kata-review` panel on both spec.md and design.md. Design is marked approved.

## What changed

**libeval stays a generic library** — its prompts describe only the `Ask`/`Answer`/`Announce` contract. Coaching-specific participant framing travels `workflow task-text → facilitator → libeval pass-through`. Libeval never inspects the addendum's content.

**Two append surfaces, one naming family:**
- `systemPromptAmend: string?` (new) — participant system-prompt append on the `Facilitator` participant config.
- `taskAmend: string?` — libeval's existing CLI-only `--task-amend` concatenation promoted to a public config field on `Facilitator`, `Supervisor`, and `AgentRunner`.

**Design.md rewrite** to pass `kata-review`: 231 → 187 lines (under the 200-line Blocker), dropped duplicated sections (§ "Problem (restated)", § "Out of Scope"), compressed § "Participant Protocol delivery" and § "Coaching workflow task-text", fixed § "Supervisor parity" scope contradiction with spec § Excluded (`agent-runner.js` untouched), removed exact file:line citations and private-method names from prose.

**Spec.md revision** to tighten WHAT/WHY: resolved three revision-artifact contradictions (task-text "one sentence" vs. "longer"; delivery surface "candidates without ranking" vs. committed; `Redirect`/`Conclude`/`RollCall` "renamed or retained"); removed HOW-level detail from Scope and Success Criteria (handler-factory names, `#runAgent`, "thin mapping", grep command in SC 4); consolidated duplicated delivery-surface bullet.

**`specs/STATUS`**: 620 design marked `approved`.

## Test plan

- [x] `grep -nE 'sessionBootstrap|#runAgent|facilitator.js:489' specs/620-facilitated-tell-share-response-protocol/*.md` returns only one Problem-evidence citation
- [x] `wc -l` on design.md ≤ 200 (currently 187)
- [x] spec.md and design.md reviewed by three independent `kata-review` sub-agents each; consensus findings addressed
- [ ] Downstream planning phase verifies the `systemPromptAmend` + `taskAmend` shape satisfies the coaching-workflow Participant Protocol delivery (spec 620 plan phase)

https://claude.ai/code/session_01VUdMFKE3yaXPrRRXLSZgH4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUdMFKE3yaXPrRRXLSZgH4)_