### PR TITLE
docs(specs): 600 approve plan — macOS .app bundle distribution + TCC

### DIFF
--- a/specs/600-native-binary-distribution/design.md
+++ b/specs/600-native-binary-distribution/design.md
@@ -19,180 +19,168 @@ graph LR
   TAP -->|download| REL
 ```
 
-Four cooperating surfaces: a **local build pipeline** (monorepo justfile +
-bun), a **shared bundle assembler** in `libraries/libmacos/` that every
-release artifact flows through, a **release workflow** that zips and
-uploads bundles then opens cask-update PRs, and a **separate tap
-repository** users install from. The existing npm path is untouched.
+Four cooperating surfaces: a **local build pipeline** (monorepo justfile + bun),
+a **shared bundle assembler** in `libraries/libmacos/` that every release
+artifact flows through, a **release workflow** that zips and uploads bundles
+then opens cask-update PRs, and a **separate tap repository** users install
+from. The existing npm path is untouched.
 
 ## Component 1 — Native binary build
 
-`bun build --compile` runs per target to produce Mach-Os in
-`dist/binaries/`. Outputs are **intermediate**, not release artifacts —
-they flow into Component 8 (bundle assembly). The build fans out across
-three input categories: product CLIs (one Mach-O per product), gRPC
-services under `services/` (one Mach-O per service), and library CLIs
-under `libraries/*` with a `bin` field (one Mach-O per CLI). The
-architectural invariant is that generated gRPC code (`generated/`) is
-baked into each binary at compile time so brew users never run codegen.
-Recipe shape, target-triple flags, and codegen chaining are plan
-concerns.
+`bun build --compile` runs per target to produce Mach-Os in `dist/binaries/`.
+Outputs are **intermediate**, not release artifacts — they flow into Component 8
+(bundle assembly). The build fans out across three input categories: product
+CLIs (one Mach-O per product), gRPC services under `services/` (one Mach-O per
+service), and library CLIs under `libraries/*` with a `bin` field (one Mach-O
+per CLI). The architectural invariant is that generated gRPC code (`generated/`)
+is baked into each binary at compile time so brew users never run codegen.
+Recipe shape, target-triple flags, and codegen chaining are plan concerns.
 
-**Rejected — `pkg`/`nexe` bundlers.** Bun is already our primary runtime
-and produces single-file executables; a second toolchain adds a parallel
-dependency graph without shrinking or speeding up the output.
+**Rejected — `pkg`/`nexe` bundlers.** Bun is already our primary runtime and
+produces single-file executables; a second toolchain adds a parallel dependency
+graph without shrinking or speeding up the output.
 
-**Rejected — lazy codegen at first run.** Requires either embedding
-protoc (~20 MB + ABI risk) or finding it on `PATH` — violates the
-zero-dependency install promise.
+**Rejected — lazy codegen at first run.** Requires either embedding protoc (~20
+MB + ABI risk) or finding it on `PATH` — violates the zero-dependency install
+promise.
 
 ## Component 2 — GitHub Actions release workflow
 
 A new workflow triggered on release tags builds the single bundle the tag
-targets, codesigns and zips the `.app`, uploads it as a GitHub Release
-asset, and opens a cask-update PR against the tap repository. The tag
-pattern matches `publish-npm.yml` (`*@v*`) so one tag fires both channels
-in parallel. The build runs on Apple's native arm64 macOS runner — no
-cross-compile risk.
+targets, codesigns and zips the `.app`, uploads it as a GitHub Release asset,
+and opens a cask-update PR against the tap repository. The tag pattern matches
+`publish-npm.yml` (`*@v*`) so one tag fires both channels in parallel. The build
+runs on Apple's native arm64 macOS runner — no cross-compile risk.
 
-Authentication for the tap-PR step is a monorepo secret
-(`HOMEBREW_TAP_PAT`) scoped to the tap repo only. Tag-to-bundle mapping
-(`<product>@v*`, `services@v*`, `utilities@v*`), runner label, workflow
-filename, artifact-naming scheme, job layout, and `.sha256` sidecar
-shape are plan concerns.
+Authentication for the tap-PR step is a monorepo secret (`HOMEBREW_TAP_PAT`)
+scoped to the tap repo only. Tag-to-bundle mapping (`<product>@v*`,
+`services@v*`, `utilities@v*`), runner label, workflow filename, artifact-naming
+scheme, job layout, and `.sha256` sidecar shape are plan concerns.
 
-**Rejected — `homebrew-releaser` action.** Opinionated about formula
-shape, inflexible for per-cask `arch` gating, and hides the diff from
-review.
+**Rejected — `homebrew-releaser` action.** Opinionated about formula shape,
+inflexible for per-cask `arch` gating, and hides the diff from review.
 
 ## Component 3 — Homebrew tap and casks
 
-A separate repository `forwardimpact/homebrew-tap` hosts one cask per
-bundle: six product casks plus `fit-services` and `fit-utilities` for
-the two shared bundles. Each product cask declares a cask-level
-dependency on both shared casks, so a single
-`brew install --cask forwardimpact/tap/fit-<product>` delivers the full
-runtime. Each cask installs its `.app` bundle into `/Applications/` and
-symlinks every `fit-*` Mach-O from the bundle's `Contents/MacOS/` onto
-the user's `PATH`. Specific stanza values, Homebrew-prefix-dependent
-symlink directories, livecheck strategy, and update automation are plan
-concerns.
+A separate repository `forwardimpact/homebrew-tap` hosts one cask per bundle:
+six product casks plus `fit-services` and `fit-utilities` for the two shared
+bundles. Each product cask declares a cask-level dependency on both shared
+casks, so a single `brew install --cask forwardimpact/tap/fit-<product>`
+delivers the full runtime. Each cask installs its `.app` bundle into
+`/Applications/` and symlinks every `fit-*` Mach-O from the bundle's
+`Contents/MacOS/` onto the user's `PATH`. Specific stanza values,
+Homebrew-prefix-dependent symlink directories, livecheck strategy, and update
+automation are plan concerns.
 
 **Rejected — tap directory inside this monorepo.** Brew taps repos, not
-subdirectories; users would need a brittle custom URL, and casks would
-ride the monorepo PR cycle instead of updating independently.
+subdirectories; users would need a brittle custom URL, and casks would ride the
+monorepo PR cycle instead of updating independently.
 
-**Rejected — casks as formulae.** Formulae compile from source; our
-bundles ship prebuilt, so casks are the right shape.
+**Rejected — casks as formulae.** Formulae compile from source; our bundles ship
+prebuilt, so casks are the right shape.
 
 ## Component 4 — fit-guide codegen story
 
-The spec leaves the mechanism open. **This design chooses option (b):
-the `fit-guide` bundle ships its generated gRPC artifacts baked in**,
-via Component 1's compile-time codegen prerequisite. Bun's bundler embeds
-imports from `generated/` automatically, so this adds no new moving
-parts.
+The spec leaves the mechanism open. **This design chooses option (b): the
+`fit-guide` bundle ships its generated gRPC artifacts baked in**, via Component
+1's compile-time codegen prerequisite. Bun's bundler embeds imports from
+`generated/` automatically, so this adds no new moving parts.
 
-**Rejected — option (a): fit-guide invokes fit-codegen at first run.**
-Requires embedding protoc or finding it on `PATH` — violates the
-zero-dependency install promise.
+**Rejected — option (a): fit-guide invokes fit-codegen at first run.** Requires
+embedding protoc or finding it on `PATH` — violates the zero-dependency install
+promise.
 
 ## Component 5 — Non-arm64 macOS behaviour
 
-Casks gate on `depends_on arch: :arm64`. Homebrew's built-in arch check
-produces a standard error on Intel macs and Linuxbrew — no bespoke stub.
-Docs add one line: "Intel macOS and Linux users continue via npm."
+Casks gate on `depends_on arch: :arm64`. Homebrew's built-in arch check produces
+a standard error on Intel macs and Linuxbrew — no bespoke stub. Docs add one
+line: "Intel macOS and Linux users continue via npm."
 
-**Rejected — custom-stub cask with bespoke error.** Brew's native check
-is already clear and discoverable; a stub would be code for identical UX.
+**Rejected — custom-stub cask with bespoke error.** Brew's native check is
+already clear and discoverable; a stub would be code for identical UX.
 
 ## Component 6 — Version sync
 
-The git tag `<name>@v<version>` is the single source of truth for both
-channels. Both release workflows resolve the version from the same
-`package.json` at the tagged commit, so npm and brew cannot carry
-different versions for a given tag.
+The git tag `<name>@v<version>` is the single source of truth for both channels.
+Both release workflows resolve the version from the same `package.json` at the
+tagged commit, so npm and brew cannot carry different versions for a given tag.
 
-**Rejected — a release manifest file.** Adds a second source of truth
-that can drift; the tag already serialises the version.
+**Rejected — a release manifest file.** Adds a second source of truth that can
+drift; the tag already serialises the version.
 
 ## Component 7 — Per-product documentation
 
-Spec SC6 requires every affected product's Overview page to document the
-brew install flow. Each gains an **Install** section with two blocks: npm
-(unchanged) and brew. Docs ship through the existing website workflow —
-no new publishing surface.
+Spec SC6 requires every affected product's Overview page to document the brew
+install flow. Each gains an **Install** section with two blocks: npm (unchanged)
+and brew. Docs ship through the existing website workflow — no new publishing
+surface.
 
-**Rejected — a single shared install page.** Per-product pages are the
-external landing surface; cross-linking to a shared page doubles the
-first-install click count.
+**Rejected — a single shared install page.** Per-product pages are the external
+landing surface; cross-linking to a shared page doubles the first-install click
+count.
 
 ## Component 8 — macOS `.app` bundle assembly
 
-Every release artifact is a `.app` bundle. Bundles are the unit of
-release — Mach-Os are intermediate. Each bundle follows the standard
-macOS shape (`Contents/{Info.plist, MacOS/…, Resources/…}`) and is ad-hoc
-codesigned with Hardened Runtime enabled and a stable,
-content-hash-independent identifier so TCC grants survive rebuilds.
+Every release artifact is a `.app` bundle. Bundles are the unit of release —
+Mach-Os are intermediate. Each bundle follows the standard macOS shape
+(`Contents/{Info.plist, MacOS/…, Resources/…}`) and is ad-hoc codesigned with
+Hardened Runtime enabled and a stable, content-hash-independent identifier so
+TCC grants survive rebuilds.
 
 Three bundle categories:
 
-- **Per-product bundles** (six total). Each holds the product's
-  bun-compiled CLI as its primary executable; basecamp additionally
-  holds its Swift launcher.
-- **Shared services bundle.** Holds every Mach-O compiled from
-  `services/*`; each is independently exposed via the shared cask's
-  PATH symlinks.
-- **Shared utilities bundle.** Same shape for library CLIs with a `bin`
-  field.
+- **Per-product bundles** (six total). Each holds the product's bun-compiled CLI
+  as its primary executable; basecamp additionally holds its Swift launcher.
+- **Shared services bundle.** Holds every Mach-O compiled from `services/*`;
+  each is independently exposed via the shared cask's PATH symlinks.
+- **Shared utilities bundle.** Same shape for library CLIs with a `bin` field.
 
-The signing identity is ad-hoc (no Developer ID); the follow-up
-Developer-ID spec swaps the identity without disturbing any other
-metadata. Specific bundle-identifier strings, entitlement keys, and the
-exact codesign invocation are plan concerns.
+The signing identity is ad-hoc (no Developer ID); the follow-up Developer-ID
+spec swaps the identity without disturbing any other metadata. Specific
+bundle-identifier strings, entitlement keys, and the exact codesign invocation
+are plan concerns.
 
-**Rejected — bare Mach-Os with `__TEXT,__info_plist` embedding.** An
-earlier iteration proposed splicing `Info.plist` into the Mach-O section
-table. It needed an Xcode-CLI-tools spike, was fragile against bun
-runtime changes, and left no clean PATH symlink story. Bundles eliminate
-the problem — `Info.plist` lives on disk.
+**Rejected — bare Mach-Os with `__TEXT,__info_plist` embedding.** An earlier
+iteration proposed splicing `Info.plist` into the Mach-O section table. It
+needed an Xcode-CLI-tools spike, was fragile against bun runtime changes, and
+left no clean PATH symlink story. Bundles eliminate the problem — `Info.plist`
+lives on disk.
 
-**Rejected — one `.app` per library CLI / service.** Would produce ~25
-bundles from `libraries/` and `services/`, each needing its own
-Info.plist, entitlements, codesign pass, and cask. Two shared bundles
-cut the signing surface from ~31 to 8 without losing TCC granularity
-(none of the library CLIs or services request TCC resources today).
+**Rejected — one `.app` per library CLI / service.** Would produce ~25 bundles
+from `libraries/` and `services/`, each needing its own Info.plist,
+entitlements, codesign pass, and cask. Two shared bundles cut the signing
+surface from ~31 to 8 without losing TCC granularity (none of the library CLIs
+or services request TCC resources today).
 
-**Rejected — skip hardening under ad-hoc signing.** The follow-up
-Developer-ID spec would have to re-add every metadata piece and force a
-cdhash change across every previously-installed user, wiping TCC grants.
+**Rejected — skip hardening under ad-hoc signing.** The follow-up Developer-ID
+spec would have to re-add every metadata piece and force a cdhash change across
+every previously-installed user, wiping TCC grants.
 
 ## Component 9 — Shared `libraries/libmacos`
 
-A new Darwin-only library owning every piece of macOS-specific surface
-shared across bundles: the `posix-spawn` / responsibility-disclaim FFI
-wrapper (lifted from `products/basecamp/`), the parameterized
-bundle-assembly script every bundle flows through, the `codesign`
-wrapper it invokes, and the default entitlements and `Info.plist`
-templates. One library means one canonical place to change
-bundle-assembly shape as signing policy evolves.
+A new Darwin-only library owning every piece of macOS-specific surface shared
+across bundles: the `posix-spawn` / responsibility-disclaim FFI wrapper (lifted
+from `products/basecamp/`), the parameterized bundle-assembly script every
+bundle flows through, the `codesign` wrapper it invokes, and the default
+entitlements and `Info.plist` templates. One library means one canonical place
+to change bundle-assembly shape as signing policy evolves.
 
 `libmacos` does **not** own basecamp's Swift launcher (product-specific),
-basecamp's `.pkg` installer flow (orthogonal channel), or Developer-ID
-signing (follow-up spec).
+basecamp's `.pkg` installer flow (orthogonal channel), or Developer-ID signing
+(follow-up spec).
 
-**Rejected — put this in `libcli` or `libbuild`.** Those are
-cross-platform; importing a macOS-only FFI would bleed Darwin code into
-every CLI's import graph.
+**Rejected — put this in `libcli` or `libbuild`.** Those are cross-platform;
+importing a macOS-only FFI would bleed Darwin code into every CLI's import
+graph.
 
-**Rejected — leave the assembler in basecamp and copy per bundle.** Eight
-copies of a ~70-line script guarantee drift.
+**Rejected — leave the assembler in basecamp and copy per bundle.** Eight copies
+of a ~70-line script guarantee drift.
 
 ## Open questions for plan phase
 
-- **Tap repo bootstrap.** Whether the tap repo starts empty, with
-  placeholder casks, or with a manually-written initial cask. Affects
-  idempotency of the release workflow's first run.
-- **Gatekeeper UX copy.** Signing is deferred; the exact caveat wording
-  on Overview pages and its placement relative to the install command is
-  a plan concern.
+- **Tap repo bootstrap.** Whether the tap repo starts empty, with placeholder
+  casks, or with a manually-written initial cask. Affects idempotency of the
+  release workflow's first run.
+- **Gatekeeper UX copy.** Signing is deferred; the exact caveat wording on
+  Overview pages and its placement relative to the install command is a plan
+  concern.

--- a/specs/600-native-binary-distribution/design.md
+++ b/specs/600-native-binary-distribution/design.md
@@ -7,355 +7,192 @@ exist and WHERE they interact.
 
 ```mermaid
 graph LR
-  MR[monorepo<br/>justfile] -->|bun build --compile| BIN[dist/binaries/<br/>Mach-Os<br/>per product, service,<br/>library CLI]
-  BIN -->|build-app.sh × 6| APPS[dist/apps/<br/>fit-*.app × 6]
-  BIN -->|build-app.sh| SVC[dist/apps/<br/>FIT Services.app]
-  BIN -->|build-app.sh| UTIL[dist/apps/<br/>FIT Utilities.app]
-  LIB[libraries/libmacos<br/>build-app.sh,<br/>templates, FFI] -.->|shared recipe| MR
-  Tag[release tag<br/>cli@vX.Y.Z] -->|triggers| WF[publish-brew.yml]
-  WF -->|build on macos-14| APPS
-  WF -->|gh release upload| REL[GitHub Release<br/>*.app.zip assets]
-  WF -->|PR via PAT| TAP[forwardimpact/<br/>homebrew-tap]
+  MR[monorepo justfile] -->|bun build --compile| MO[dist/binaries<br/>Mach-Os]
+  MO --> ASM[build-app.sh<br/>bundle assembler]
+  ASM --> APPS[dist/apps<br/>eight .app bundles]
+  LIB[libraries/libmacos] -.->|assembler + FFI| ASM
+  Tag[release tag] -->|triggers| WF[release workflow]
+  WF -->|build + codesign| APPS
+  WF -->|upload .app.zip| REL[GitHub Release]
+  WF -->|cask-update PR| TAP[homebrew-tap]
   User[macOS arm64 user] -->|brew install| TAP
-  TAP -->|cask url| REL
+  TAP -->|download| REL
 ```
 
-Four cooperating surfaces: a **local build pipeline** (justfile + bun +
-`libmacos/scripts/build-app.sh`) used by contributors and CI, a **bundle
-assembler** in `libraries/libmacos/` that every release artifact flows
-through, a **release workflow** that uploads `.app.zip` artifacts and opens
-cask-update PRs, and a **separate tap repository** with eight casks users
-tap. The existing npm path is untouched.
+Four cooperating surfaces: a **local build pipeline** (monorepo justfile +
+bun), a **shared bundle assembler** in `libraries/libmacos/` that every
+release artifact flows through, a **release workflow** that zips and
+uploads bundles then opens cask-update PRs, and a **separate tap
+repository** users install from. The existing npm path is untouched.
 
-## Component 1 — Native binary build (justfile)
+## Component 1 — Native binary build
 
-**Entry point.** Each CLI's existing `bin/fit-<name>.js` is already a runnable
-ES module — it becomes the `bun build --compile` entry unchanged. The
-`#!/usr/bin/env node` shebang is a no-op in a compiled binary and the npm path
-keeps using it, so no source rewrite is needed.
+`bun build --compile` runs per target to produce Mach-Os in
+`dist/binaries/`. Outputs are **intermediate**, not release artifacts —
+they flow into Component 8 (bundle assembly). The build fans out across
+three input categories: product CLIs (one Mach-O per product), gRPC
+services under `services/` (one Mach-O per service), and library CLIs
+under `libraries/*` with a `bin` field (one Mach-O per CLI). The
+architectural invariant is that generated gRPC code (`generated/`) is
+baked into each binary at compile time so brew users never run codegen.
+Recipe shape, target-triple flags, and codegen chaining are plan
+concerns.
 
-**Recipe shape.** One **parameterized recipe** `build-binary CLI TARGET` invokes
-bun's compile bundler for a CLI × target triple. A top-level `build-binaries`
-recipe fans out over the seven CLIs for the default target (`darwin-arm64`).
-Exact flag set is a plan concern.
+**Rejected — `pkg`/`nexe` bundlers.** Bun is already our primary runtime
+and produces single-file executables; a second toolchain adds a parallel
+dependency graph without shrinking or speeding up the output.
 
-| Field          | Value                                                            |
-| -------------- | ---------------------------------------------------------------- |
-| Target triple  | `bun-darwin-arm64` (acceptance); `bun-darwin-x64` Phase 2        |
-| Output path    | `dist/binaries/<cli>-<os>-<arch>`                                |
-| Size ceiling   | 150 MB per binary (bun runtime ~60 MB + app code/deps), CI-gated |
-| Startup budget | `--help` in < 500 ms cold on an M-series mac, CI-gated           |
-
-"Phase 2" throughout this design is a placeholder for a follow-up spec that
-promotes `bun-darwin-x64` from pre-reserved (target name wired in the recipe, no
-CI job) to acceptance (built, released, tapped). No Phase 2 work lands here.
-
-**Compilation is intermediate; bundles are the release artifact.**
-`build-binary` runs `bun build --compile` to produce Mach-Os in
-`dist/binaries/`. Those Mach-Os are **inputs** to Component 8 (bundle
-assembly) and are never themselves release artifacts. The final `.app`
-bundles at `dist/apps/` are what Component 2's release workflow uploads.
-
-**Three fan-out targets.** `build-binaries` fans out into three recipes:
-
-- `build-product-binaries` — six Mach-Os, one per product (basecamp, guide,
-  landmark, map, pathway, summit).
-- `build-service-binaries` — five Mach-Os from `services/*` (graph, mcp,
-  pathway, trace, vector), each named `fit-service-<name>`.
-- `build-utility-binaries` — ~20 Mach-Os from `libraries/*` that declare a
-  `bin` field (`fit-codegen`, `fit-terrain`, `fit-eval`, `fit-doc`, `fit-rc`,
-  `fit-xmr`, `fit-storage`, `fit-logger`, `fit-svscan`, `fit-trace`,
-  `fit-visualize`, `fit-query`, `fit-subjects`, `fit-process-graphs`,
-  `fit-process-resources`, `fit-process-vectors`, `fit-search`, `fit-unary`,
-  `fit-tiktoken`, `fit-download-bundle`).
-
-**Rejected — one recipe per CLI.** Seven near-identical recipes duplicate the
-flag set; a parameterized recipe keeps flags in one place.
-
-**Rejected — `pkg`/`nexe` bundlers.** Bun already produces single-file
-executables and is our primary runtime; a second toolchain adds a parallel
-dependency graph without a smaller or faster output than `bun build --compile`.
-
-**Rejected — no budgets.** Without size/startup ceilings, bundled deps drift
-silently; a cheap CI check at the build step catches regressions before release.
-
-**Codegen as build prerequisite.** `build-binary` depends on `codegen` (the
-existing `just codegen` recipe that runs `fit-codegen --all`). Generated gRPC
-clients and types land in `generated/` before `bun build --compile`; bun's
-bundler follows the import graph and embeds them into the executable. Generated
-code is baked into every binary — brew users never run codegen.
-
-**Rejected — lazy codegen at first run.** Requires either embedding protoc (~20
-MB + ABI risk) or requiring it on `PATH` (violates zero-dependency promise).
+**Rejected — lazy codegen at first run.** Requires either embedding
+protoc (~20 MB + ABI risk) or finding it on `PATH` — violates the
+zero-dependency install promise.
 
 ## Component 2 — GitHub Actions release workflow
 
-New workflow: `.github/workflows/publish-brew.yml`.
+A new workflow triggered on release tags builds the single bundle the tag
+targets, codesigns and zips the `.app`, uploads it as a GitHub Release
+asset, and opens a cask-update PR against the tap repository. The tag
+pattern matches `publish-npm.yml` (`*@v*`) so one tag fires both channels
+in parallel. The build runs on Apple's native arm64 macOS runner — no
+cross-compile risk.
 
-**Trigger.** Tag push matching `*@v*` — the same pattern `publish-npm.yml` uses.
-A single tag fires both workflows in parallel.
+Authentication for the tap-PR step is a monorepo secret
+(`HOMEBREW_TAP_PAT`) scoped to the tap repo only. Tag-to-bundle mapping
+(`<product>@v*`, `services@v*`, `utilities@v*`), runner label, workflow
+filename, artifact-naming scheme, job layout, and `.sha256` sidecar
+shape are plan concerns.
 
-**Job matrix.**
-
-| Job              | Runner          | Per CLI | Output                                  |
-| ---------------- | --------------- | ------- | --------------------------------------- |
-| `build`          | `macos-14`      | matrix  | `fit-<cli>-…-darwin-arm64` + sha256     |
-| `release-assets` | `macos-14`      | once    | `gh release upload` for all             |
-| `tap-pr`         | `ubuntu-latest` | once    | PR against `forwardimpact/homebrew-tap` |
-
-`macos-14` is GitHub's arm64 runner — native build, no cross-compile risk.
-Matrix dimension is **CLI only** (seven parallel jobs); target stays single
-until Phase 2.
-
-**Rejected — monolithic build job.** Seven sequential builds add ~5–7 minutes;
-matrix parallelism keeps release feedback under 3 minutes.
-
-**Rejected — `release`-event trigger.** Tag push is how npm already fires;
-keeping one trigger shape means one `git tag` launches both channels.
-
-**Artifact naming.** `fit-<cli>-<version>-<os>-<arch>` (e.g.
-`fit-pathway-0.25.32-darwin-arm64`). Version in the filename keeps old release
-assets immutable and gives casks a stable, versioned URL. A matching `.sha256`
-sidecar is uploaded alongside each binary so casks can pin the hash without a
-separate manifest file.
-
-**Interaction with `publish-npm.yml`.** Two independent workflows on the same
-trigger; both read `products/<cli>/package.json` for the version, so npm and
-brew cannot diverge.
+**Rejected — `homebrew-releaser` action.** Opinionated about formula
+shape, inflexible for per-cask `arch` gating, and hides the diff from
+review.
 
 ## Component 3 — Homebrew tap and casks
 
-**Tap repository.** Separate repo `forwardimpact/homebrew-tap`. Users run
-`brew tap forwardimpact/tap` then
-`brew install --cask forwardimpact/tap/fit-pathway`.
-
-**Rejected — tap directory inside this monorepo.** Brew only taps repos, not
-subdirectories; users would need a brittle custom tap URL. A separate repo also
-lets casks be updated without a monorepo PR cycle.
-
-**Cask vs formula.** Casks, not formulae. Formulae compile from source; casks
-install prebuilt artifacts. Our bundles ship prebuilt from CI, casks unlock
-`depends_on arch:` gating, and the cask `app` stanza installs `.app` bundles
-to `/Applications/` out of the box.
-
-**Tap layout — eight casks.** Six product casks plus two shared-bundle casks:
-
-- `fit-basecamp.rb`, `fit-guide.rb`, `fit-landmark.rb`, `fit-map.rb`,
-  `fit-pathway.rb`, `fit-summit.rb` — per-product casks.
-- `fit-services.rb` — installs `FIT Services.app` (gRPC servers).
-- `fit-utilities.rb` — installs `FIT Utilities.app` (library CLIs, including
-  `fit-codegen`, `fit-terrain`, `fit-eval`, etc.).
-
-Each product cask declares `depends_on cask: ["forwardimpact/tap/fit-services",
-"forwardimpact/tap/fit-utilities"]`, so a single `brew install --cask
-forwardimpact/tap/fit-<product>` pulls in the full runtime. Users who only want
-the library CLIs install `fit-utilities` directly.
-
-**Cask shape.** One cask per bundle:
-
-| Field        | Value                                                                                                                                                                                          |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`    | npm package version (e.g. `"0.25.32"`)                                                                                                                                                         |
-| `sha256`     | sha256 of the arm64 `.app.zip`                                                                                                                                                                 |
-| `url`        | `…/releases/download/<bundle>@v#{version}/<Bundle>.app-#{version}-darwin-arm64.zip`                                                                                                            |
-| `app`        | `"<Bundle>.app"` — installs into `/Applications/Forward Impact/`                                                                                                                              |
-| `binary`     | `"#{appdir}/Forward Impact/<Bundle>.app/Contents/MacOS/fit-<cli>"` — one `binary` line per CLI exposed by the bundle; for `fit-services` and `fit-utilities`, one line per Mach-O in `MacOS/` |
-| `depends_on` | `arch: :arm64` + for product casks, `cask: ["forwardimpact/tap/fit-services", "forwardimpact/tap/fit-utilities"]`                                                                             |
-| `livecheck`  | GitHub Releases API, `<bundle>@v*` tag series                                                                                                                                                  |
-| `uninstall`  | `quit "com.forwardimpact.<bundle>"` for GUI bundles; (none) for headless                                                                                                                       |
-| `zap`        | `trash: ~/Library/Preferences/com.forwardimpact.<bundle>.plist` + any bundle-specific caches                                                                                                   |
-
-**Update automation — chosen: PR via PAT.** The `tap-pr` job proposes a cask
-update against `forwardimpact/homebrew-tap` via a pull request that carries the
-new `version` and `sha256`. Authentication is a repo secret `HOMEBREW_TAP_PAT`
-scoped to the tap repo only. PR title, body, and commit message shape are plan
+A separate repository `forwardimpact/homebrew-tap` hosts one cask per
+bundle: six product casks plus `fit-services` and `fit-utilities` for
+the two shared bundles. Each product cask declares a cask-level
+dependency on both shared casks, so a single
+`brew install --cask forwardimpact/tap/fit-<product>` delivers the full
+runtime. Each cask installs its `.app` bundle into `/Applications/` and
+symlinks every `fit-*` Mach-O from the bundle's `Contents/MacOS/` onto
+the user's `PATH`. Specific stanza values, Homebrew-prefix-dependent
+symlink directories, livecheck strategy, and update automation are plan
 concerns.
 
-**Rejected — `homebrew-releaser` action.** Opinionated about formula shape,
-inflexible for per-cask `arch` gating, and hides the diff from review.
-**Rejected — manual updates.** Guarantees drift between npm and brew versions.
+**Rejected — tap directory inside this monorepo.** Brew taps repos, not
+subdirectories; users would need a brittle custom URL, and casks would
+ride the monorepo PR cycle instead of updating independently.
+
+**Rejected — casks as formulae.** Formulae compile from source; our
+bundles ship prebuilt, so casks are the right shape.
 
 ## Component 4 — fit-guide codegen story
 
-The spec leaves the choice open. **This design chooses option (b): the
-`fit-guide` binary ships its generated gRPC artifacts baked in** (via Component
-1's codegen prerequisite). Bun's compile bundler already embeds `generated/`
-imports, so this option adds zero new moving parts.
+The spec leaves the mechanism open. **This design chooses option (b):
+the `fit-guide` bundle ships its generated gRPC artifacts baked in**,
+via Component 1's compile-time codegen prerequisite. Bun's bundler embeds
+imports from `generated/` automatically, so this adds no new moving
+parts.
 
-`fit-codegen` is still built as a standalone binary (spec requires all seven),
-but brew users of `fit-guide` never need to invoke it.
-
-**Rejected — option (a) exclusive (fit-guide invokes fit-codegen at first
-run).** Requires embedding protoc or finding it on `PATH` — violates the
+**Rejected — option (a): fit-guide invokes fit-codegen at first run.**
+Requires embedding protoc or finding it on `PATH` — violates the
 zero-dependency install promise.
 
 ## Component 5 — Non-arm64 macOS behaviour
 
-Casks use `depends_on arch: :arm64`. Homebrew's built-in arch check produces a
-standard "Cask depends on hardware: ARM64" error on Intel macs and Linuxbrew —
-no bespoke stub needed. Docs add one line: "Intel macOS and Linux users continue
-via npm."
+Casks gate on `depends_on arch: :arm64`. Homebrew's built-in arch check
+produces a standard error on Intel macs and Linuxbrew — no bespoke stub.
+Docs add one line: "Intel macOS and Linux users continue via npm."
 
-**Rejected — custom-stub cask with bespoke error.** Brew's native check is
-already clear and discoverable; a stub is code for identical UX.
+**Rejected — custom-stub cask with bespoke error.** Brew's native check
+is already clear and discoverable; a stub would be code for identical UX.
 
-x64 macOS is not in this spec — reserved for Phase 2. The `bun-darwin-x64`
-target is pre-reserved in the parameterized recipe so Phase 2 is a matrix
-expansion, not a redesign.
+## Component 6 — Version sync
 
-## Component 6 — Version sync (single source of truth)
+The git tag `<name>@v<version>` is the single source of truth for both
+channels. Both release workflows resolve the version from the same
+`package.json` at the tagged commit, so npm and brew cannot carry
+different versions for a given tag.
 
-The **git tag** `<cli>@v<version>` is the single source of truth for both
-channels. `publish-npm.yml` and `publish-brew.yml` resolve the version from the
-same `products/<cli>/package.json` at the tagged commit; since both read the
-same file in the same commit, npm and brew cannot carry different version
-numbers for a given tag. The two channels can lag only in publication timing —
-npm publishes directly, while brew publication waits on the tap PR being merged
-by a human. No cross-workflow state is shared; the invariant is enforced by the
-common tag + common file.
-
-**Rejected — a release manifest file.** Adds a second source of truth that can
-drift from `package.json`; the tag already serialises the version.
+**Rejected — a release manifest file.** Adds a second source of truth
+that can drift; the tag already serialises the version.
 
 ## Component 7 — Per-product documentation
 
-Spec SC6 requires every affected product's Overview page to document the brew
-install flow. Each `website/<product>/index.md` gains an **Install** section (or
-extends the existing one) with two blocks: npm (unchanged) and brew (the
-`brew tap` + `brew install` invocation and the Gatekeeper-warning caveat). Docs
-live in the monorepo and ship through the existing website workflow — no new
-publishing surface.
+Spec SC6 requires every affected product's Overview page to document the
+brew install flow. Each gains an **Install** section with two blocks: npm
+(unchanged) and brew. Docs ship through the existing website workflow —
+no new publishing surface.
 
-**Rejected — a single shared install page.** Per-product pages are the entry
-points external users land on; cross-linking to a shared page doubles the click
-count on the first-install path.
+**Rejected — a single shared install page.** Per-product pages are the
+external landing surface; cross-linking to a shared page doubles the
+first-install click count.
 
 ## Component 8 — macOS `.app` bundle assembly
 
-Every release artifact is a `.app` bundle. Bundle assembly is a single script
-— `libraries/libmacos/scripts/build-app.sh` (see Component 9) — invoked
-eight times per release set (six product bundles, `FIT Services.app`,
-`FIT Utilities.app`).
+Every release artifact is a `.app` bundle. Bundles are the unit of
+release — Mach-Os are intermediate. Each bundle follows the standard
+macOS shape (`Contents/{Info.plist, MacOS/…, Resources/…}`) and is ad-hoc
+codesigned with Hardened Runtime enabled and a stable,
+content-hash-independent identifier so TCC grants survive rebuilds.
 
-**Bundle layout.** Each bundle follows the standard macOS shape:
+Three bundle categories:
 
-```
-<Bundle>.app/
-  Contents/
-    Info.plist                          # from libmacos template, per-bundle substitutions
-    MacOS/
-      <primary-executable>              # CFBundleExecutable
-      <additional Mach-Os for shared bundles>
-    Resources/
-      <per-bundle resources, e.g. icons, templates>
-    _CodeSignature/                     # produced by codesign
-```
+- **Per-product bundles** (six total). Each holds the product's
+  bun-compiled CLI as its primary executable; basecamp additionally
+  holds its Swift launcher.
+- **Shared services bundle.** Holds every Mach-O compiled from
+  `services/*`; each is independently exposed via the shared cask's
+  PATH symlinks.
+- **Shared utilities bundle.** Same shape for library CLIs with a `bin`
+  field.
 
-Per-bundle specifics:
-
-| Bundle              | `CFBundleIdentifier`           | `CFBundleExecutable` | Extras in `MacOS/`                                |
-| ------------------- | ------------------------------ | -------------------- | ------------------------------------------------- |
-| `fit-basecamp.app`  | `com.forwardimpact.basecamp`   | `Basecamp` (Swift)   | `fit-basecamp` (bun scheduler)                    |
-| `fit-guide.app`     | `com.forwardimpact.guide`      | `fit-guide`          | —                                                 |
-| `fit-landmark.app`  | `com.forwardimpact.landmark`   | `fit-landmark`       | —                                                 |
-| `fit-map.app`       | `com.forwardimpact.map`        | `fit-map`            | —                                                 |
-| `fit-pathway.app`   | `com.forwardimpact.pathway`    | `fit-pathway`        | —                                                 |
-| `fit-summit.app`    | `com.forwardimpact.summit`     | `fit-summit`         | —                                                 |
-| `FIT Services.app`  | `com.forwardimpact.services`   | `fit-service-graph`  | `fit-service-{mcp,pathway,trace,vector}`          |
-| `FIT Utilities.app` | `com.forwardimpact.utilities`  | `fit-codegen`        | 19 other `fit-*` library CLIs                     |
-
-`FIT Services.app` and `FIT Utilities.app` are bundles-as-container:
-`CFBundleExecutable` names a single "primary" Mach-O to satisfy the bundle
-shape, but every Mach-O in `Contents/MacOS/` is independently exposed via
-its cask's `binary` stanza (Component 3).
-
-**Hardening.** After assembly, each bundle is ad-hoc codesigned:
-
-```
-codesign --force --sign - \
-  --entitlements <bundle-entitlements>.plist \
-  --options runtime \
-  --identifier com.forwardimpact.<name> \
-  --deep \
-  dist/apps/<Bundle>.app
-```
-
-`--identifier` fixes the designated requirement, so TCC grants keyed on
-the bundle ID survive rebuilds. `--options runtime` enables Hardened
-Runtime so the JIT entitlement applies and the later Developer ID spec is
-a pure identity swap. `--deep` recursively signs every Mach-O under
-`Contents/MacOS/`, giving `FIT Services.app` and `FIT Utilities.app` a
-single codesign pass over their multi-executable contents.
+The signing identity is ad-hoc (no Developer ID); the follow-up
+Developer-ID spec swaps the identity without disturbing any other
+metadata. Specific bundle-identifier strings, entitlement keys, and the
+exact codesign invocation are plan concerns.
 
 **Rejected — bare Mach-Os with `__TEXT,__info_plist` embedding.** An
-earlier iteration of this design proposed splicing `Info.plist` into the
-Mach-O section table. That required an Xcode-CLI-tools spike, was fragile
-against future bun runtime changes, and left Homebrew without a clean
-PATH symlink story. Bundles eliminate the whole problem — `Info.plist`
-lives on disk at `Contents/Info.plist`.
+earlier iteration proposed splicing `Info.plist` into the Mach-O section
+table. It needed an Xcode-CLI-tools spike, was fragile against bun
+runtime changes, and left no clean PATH symlink story. Bundles eliminate
+the problem — `Info.plist` lives on disk.
 
-**Rejected — one `.app` per library CLI.** Would produce ~20 `fit-*.app`
-bundles from `libraries/` plus five from `services/`. Each would need
-its own Info.plist, entitlements, codesign pass, and Homebrew cask;
-coarsening into two shared bundles cuts signing surface from 31 to 8
-without losing TCC granularity (none of the library CLIs or services
-request TCC resources today).
+**Rejected — one `.app` per library CLI / service.** Would produce ~25
+bundles from `libraries/` and `services/`, each needing its own
+Info.plist, entitlements, codesign pass, and cask. Two shared bundles
+cut the signing surface from ~31 to 8 without losing TCC granularity
+(none of the library CLIs or services request TCC resources today).
 
 **Rejected — skip hardening under ad-hoc signing.** The follow-up
-Developer ID spec would have to re-add every metadata piece and force a
+Developer-ID spec would have to re-add every metadata piece and force a
 cdhash change across every previously-installed user, wiping TCC grants.
-Landing hardening now is near-free and forward-compatible.
 
 ## Component 9 — Shared `libraries/libmacos`
 
-New library: `libraries/libmacos/`. Owns every piece of macOS-specific
-surface shared across bundles.
+A new Darwin-only library owning every piece of macOS-specific surface
+shared across bundles: the `posix-spawn` / responsibility-disclaim FFI
+wrapper (lifted from `products/basecamp/`), the parameterized
+bundle-assembly script every bundle flows through, the `codesign`
+wrapper it invokes, and the default entitlements and `Info.plist`
+templates. One library means one canonical place to change
+bundle-assembly shape as signing policy evolves.
 
-| Module                             | Contents                                                                                                                          |
-| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `src/posix-spawn.js`               | Bun FFI wrapper around `posix_spawn` + `responsibility_spawnattrs_setdisclaim`. Lifted verbatim from `products/basecamp/src/posix-spawn.js`. |
-| `src/tcc-responsibility.js`        | Higher-level helper: spawn a child, disclaim TCC responsibility, return a Promise for exit code. Wraps `posix-spawn.js`.          |
-| `scripts/build-app.sh`             | **Bundle assembler.** Generalized from `products/basecamp/pkg/macos/build-app.sh`. Parameterized on bundle name, identifier, executable list, entitlements path, resource list, version. |
-| `scripts/sign-app.sh`              | Ad-hoc `codesign --force --sign - --options runtime --deep --identifier <id> --entitlements <path>` wrapper. Invoked by `build-app.sh` as its final stage. |
-| `templates/entitlements.plist`     | Default entitlements (JIT + disable-library-validation only).                                                                     |
-| `templates/entitlements-gui.plist` | Extended template for GUI bundles that need Calendar/Contacts/Network access; seeded from basecamp's current `Basecamp.entitlements`. |
-| `templates/Info.plist.hbs`         | `Info.plist` template with `{{bundleId}}`, `{{bundleName}}`, `{{executable}}`, `{{version}}`, `{{minOS}}`, `{{lsuiElement}}` placeholders. |
+`libmacos` does **not** own basecamp's Swift launcher (product-specific),
+basecamp's `.pkg` installer flow (orthogonal channel), or Developer-ID
+signing (follow-up spec).
 
-**Adoption.** Basecamp is the first consumer. Its current
-`src/posix-spawn.js` becomes `import { spawn } from "libmacos/spawn"`.
-Its `pkg/macos/build-app.sh` is deleted; basecamp's justfile `build-app`
-recipe calls `libmacos/scripts/build-app.sh` with basecamp-specific
-arguments (Swift launcher as `CFBundleExecutable`, `fit-basecamp` as a
-secondary Mach-O in `Contents/MacOS/`, `Basecamp.entitlements` as the
-entitlements path, `LSUIElement=true`). The other five products,
-`FIT Services.app`, and `FIT Utilities.app` call the same script with
-their own arguments.
+**Rejected — put this in `libcli` or `libbuild`.** Those are
+cross-platform; importing a macOS-only FFI would bleed Darwin code into
+every CLI's import graph.
 
-**Scope boundary.** `libmacos` does **not** own:
-
-- Swift launcher source — basecamp's Swift target stays with basecamp.
-- `.pkg` installer flow — basecamp's `build-pkg.sh` stays with basecamp
-  for as long as the `.pkg` channel remains; spec 600's distribution
-  channel is Homebrew.
-- Developer ID signing / notarization — follow-up spec.
-
-**Rejected — put this in `libcli` or `libbuild`.** `libcli` is
-cross-platform, and consuming a macOS-only FFI would bleed Darwin code
-into every CLI's import graph. A dedicated `libmacos` library makes the
-boundary obvious and lets `libmacos/package.json` declare
-`"os": ["darwin"]`.
-
-**Rejected — leave `build-app.sh` in basecamp and have each bundle copy
-it.** Eight copies of a 70-line assembler script guarantee drift. Lifting
-into libmacos is the natural home given `posix-spawn.js` and the
-templates already want to live there.
+**Rejected — leave the assembler in basecamp and copy per bundle.** Eight
+copies of a ~70-line script guarantee drift.
 
 ## Open questions for plan phase
 
-- **Tap repo bootstrap.** Whether `forwardimpact/homebrew-tap` is created fresh,
-  seeded with empty casks the first release populates, or seeded with a manual
-  initial cask. Bootstrapping only happens once, but it changes which CI steps
-  are idempotent vs. first-run-only.
-- **Gatekeeper UX copy baseline.** Signing is deferred per spec; the design
-  commits to a caveat block on Overview pages, but the exact wording and where
-  it sits relative to the install command is a plan concern.
+- **Tap repo bootstrap.** Whether the tap repo starts empty, with
+  placeholder casks, or with a manually-written initial cask. Affects
+  idempotency of the release workflow's first run.
+- **Gatekeeper UX copy.** Signing is deferred; the exact caveat wording
+  on Overview pages and its placement relative to the install command is
+  a plan concern.

--- a/specs/600-native-binary-distribution/design.md
+++ b/specs/600-native-binary-distribution/design.md
@@ -7,19 +7,25 @@ exist and WHERE they interact.
 
 ```mermaid
 graph LR
-  MR[monorepo<br/>justfile] -->|bun build --compile| BIN[dist/binaries/<br/>fit-*-darwin-arm64]
+  MR[monorepo<br/>justfile] -->|bun build --compile| BIN[dist/binaries/<br/>Mach-Os<br/>per product, service,<br/>library CLI]
+  BIN -->|build-app.sh × 6| APPS[dist/apps/<br/>fit-*.app × 6]
+  BIN -->|build-app.sh| SVC[dist/apps/<br/>FIT Services.app]
+  BIN -->|build-app.sh| UTIL[dist/apps/<br/>FIT Utilities.app]
+  LIB[libraries/libmacos<br/>build-app.sh,<br/>templates, FFI] -.->|shared recipe| MR
   Tag[release tag<br/>cli@vX.Y.Z] -->|triggers| WF[publish-brew.yml]
-  WF -->|build on macos-14| BIN
-  WF -->|gh release upload| REL[GitHub Release assets]
+  WF -->|build on macos-14| APPS
+  WF -->|gh release upload| REL[GitHub Release<br/>*.app.zip assets]
   WF -->|PR via PAT| TAP[forwardimpact/<br/>homebrew-tap]
   User[macOS arm64 user] -->|brew install| TAP
   TAP -->|cask url| REL
 ```
 
-Three cooperating surfaces: a **local build pipeline** (justfile + bun) used by
-contributors and CI, a **release workflow** that uploads artifacts and opens a
-cask-update PR, and a **separate tap repository** users tap. The existing npm
-path is untouched.
+Four cooperating surfaces: a **local build pipeline** (justfile + bun +
+`libmacos/scripts/build-app.sh`) used by contributors and CI, a **bundle
+assembler** in `libraries/libmacos/` that every release artifact flows
+through, a **release workflow** that uploads `.app.zip` artifacts and opens
+cask-update PRs, and a **separate tap repository** with eight casks users
+tap. The existing npm path is untouched.
 
 ## Component 1 — Native binary build (justfile)
 
@@ -43,6 +49,25 @@ Exact flag set is a plan concern.
 "Phase 2" throughout this design is a placeholder for a follow-up spec that
 promotes `bun-darwin-x64` from pre-reserved (target name wired in the recipe, no
 CI job) to acceptance (built, released, tapped). No Phase 2 work lands here.
+
+**Compilation is intermediate; bundles are the release artifact.**
+`build-binary` runs `bun build --compile` to produce Mach-Os in
+`dist/binaries/`. Those Mach-Os are **inputs** to Component 8 (bundle
+assembly) and are never themselves release artifacts. The final `.app`
+bundles at `dist/apps/` are what Component 2's release workflow uploads.
+
+**Three fan-out targets.** `build-binaries` fans out into three recipes:
+
+- `build-product-binaries` — six Mach-Os, one per product (basecamp, guide,
+  landmark, map, pathway, summit).
+- `build-service-binaries` — five Mach-Os from `services/*` (graph, mcp,
+  pathway, trace, vector), each named `fit-service-<name>`.
+- `build-utility-binaries` — ~20 Mach-Os from `libraries/*` that declare a
+  `bin` field (`fit-codegen`, `fit-terrain`, `fit-eval`, `fit-doc`, `fit-rc`,
+  `fit-xmr`, `fit-storage`, `fit-logger`, `fit-svscan`, `fit-trace`,
+  `fit-visualize`, `fit-query`, `fit-subjects`, `fit-process-graphs`,
+  `fit-process-resources`, `fit-process-vectors`, `fit-search`, `fit-unary`,
+  `fit-tiktoken`, `fit-download-bundle`).
 
 **Rejected — one recipe per CLI.** Seven near-identical recipes duplicate the
 flag set; a parameterized recipe keeps flags in one place.
@@ -101,27 +126,44 @@ brew cannot diverge.
 ## Component 3 — Homebrew tap and casks
 
 **Tap repository.** Separate repo `forwardimpact/homebrew-tap`. Users run
-`brew tap forwardimpact/tap` then `brew install forwardimpact/tap/fit-pathway`.
+`brew tap forwardimpact/tap` then
+`brew install --cask forwardimpact/tap/fit-pathway`.
 
 **Rejected — tap directory inside this monorepo.** Brew only taps repos, not
 subdirectories; users would need a brittle custom tap URL. A separate repo also
 lets casks be updated without a monorepo PR cycle.
 
 **Cask vs formula.** Casks, not formulae. Formulae compile from source; casks
-install prebuilt artifacts. Our binaries ship prebuilt from CI, and casks unlock
-`depends_on arch:` gating.
+install prebuilt artifacts. Our bundles ship prebuilt from CI, casks unlock
+`depends_on arch:` gating, and the cask `app` stanza installs `.app` bundles
+to `/Applications/` out of the box.
 
-**Cask shape.** One cask per CLI at `Casks/fit-<cli>.rb`:
+**Tap layout — eight casks.** Six product casks plus two shared-bundle casks:
 
-| Field        | Value                                                                     |
-| ------------ | ------------------------------------------------------------------------- |
-| `version`    | npm package version (e.g. `"0.25.32"`)                                    |
-| `sha256`     | sha256 of the arm64 binary                                                |
-| `url`        | `…/releases/download/<cli>@v#{version}/fit-<cli>-#{version}-darwin-arm64` |
-| `binary`     | artifact, renamed to `fit-<cli>` on install                               |
-| `depends_on` | `arch: :arm64` — blocks install on non-arm64                              |
-| `livecheck`  | GitHub Releases API, `<cli>@v*` tag series                                |
-| `zap`        | no-op — CLIs are stateless; user data in `data/*` is theirs               |
+- `fit-basecamp.rb`, `fit-guide.rb`, `fit-landmark.rb`, `fit-map.rb`,
+  `fit-pathway.rb`, `fit-summit.rb` — per-product casks.
+- `fit-services.rb` — installs `FIT Services.app` (gRPC servers).
+- `fit-utilities.rb` — installs `FIT Utilities.app` (library CLIs, including
+  `fit-codegen`, `fit-terrain`, `fit-eval`, etc.).
+
+Each product cask declares `depends_on cask: ["forwardimpact/tap/fit-services",
+"forwardimpact/tap/fit-utilities"]`, so a single `brew install --cask
+forwardimpact/tap/fit-<product>` pulls in the full runtime. Users who only want
+the library CLIs install `fit-utilities` directly.
+
+**Cask shape.** One cask per bundle:
+
+| Field        | Value                                                                                                                                                                                          |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`    | npm package version (e.g. `"0.25.32"`)                                                                                                                                                         |
+| `sha256`     | sha256 of the arm64 `.app.zip`                                                                                                                                                                 |
+| `url`        | `…/releases/download/<bundle>@v#{version}/<Bundle>.app-#{version}-darwin-arm64.zip`                                                                                                            |
+| `app`        | `"<Bundle>.app"` — installs into `/Applications/Forward Impact/`                                                                                                                              |
+| `binary`     | `"#{appdir}/Forward Impact/<Bundle>.app/Contents/MacOS/fit-<cli>"` — one `binary` line per CLI exposed by the bundle; for `fit-services` and `fit-utilities`, one line per Mach-O in `MacOS/` |
+| `depends_on` | `arch: :arm64` + for product casks, `cask: ["forwardimpact/tap/fit-services", "forwardimpact/tap/fit-utilities"]`                                                                             |
+| `livecheck`  | GitHub Releases API, `<bundle>@v*` tag series                                                                                                                                                  |
+| `uninstall`  | `quit "com.forwardimpact.<bundle>"` for GUI bundles; (none) for headless                                                                                                                       |
+| `zap`        | `trash: ~/Library/Preferences/com.forwardimpact.<bundle>.plist` + any bundle-specific caches                                                                                                   |
 
 **Update automation — chosen: PR via PAT.** The `tap-pr` job proposes a cask
 update against `forwardimpact/homebrew-tap` via a pull request that carries the
@@ -187,6 +229,126 @@ publishing surface.
 **Rejected — a single shared install page.** Per-product pages are the entry
 points external users land on; cross-linking to a shared page doubles the click
 count on the first-install path.
+
+## Component 8 — macOS `.app` bundle assembly
+
+Every release artifact is a `.app` bundle. Bundle assembly is a single script
+— `libraries/libmacos/scripts/build-app.sh` (see Component 9) — invoked
+eight times per release set (six product bundles, `FIT Services.app`,
+`FIT Utilities.app`).
+
+**Bundle layout.** Each bundle follows the standard macOS shape:
+
+```
+<Bundle>.app/
+  Contents/
+    Info.plist                          # from libmacos template, per-bundle substitutions
+    MacOS/
+      <primary-executable>              # CFBundleExecutable
+      <additional Mach-Os for shared bundles>
+    Resources/
+      <per-bundle resources, e.g. icons, templates>
+    _CodeSignature/                     # produced by codesign
+```
+
+Per-bundle specifics:
+
+| Bundle              | `CFBundleIdentifier`           | `CFBundleExecutable` | Extras in `MacOS/`                                |
+| ------------------- | ------------------------------ | -------------------- | ------------------------------------------------- |
+| `fit-basecamp.app`  | `com.forwardimpact.basecamp`   | `Basecamp` (Swift)   | `fit-basecamp` (bun scheduler)                    |
+| `fit-guide.app`     | `com.forwardimpact.guide`      | `fit-guide`          | —                                                 |
+| `fit-landmark.app`  | `com.forwardimpact.landmark`   | `fit-landmark`       | —                                                 |
+| `fit-map.app`       | `com.forwardimpact.map`        | `fit-map`            | —                                                 |
+| `fit-pathway.app`   | `com.forwardimpact.pathway`    | `fit-pathway`        | —                                                 |
+| `fit-summit.app`    | `com.forwardimpact.summit`     | `fit-summit`         | —                                                 |
+| `FIT Services.app`  | `com.forwardimpact.services`   | `fit-service-graph`  | `fit-service-{mcp,pathway,trace,vector}`          |
+| `FIT Utilities.app` | `com.forwardimpact.utilities`  | `fit-codegen`        | 19 other `fit-*` library CLIs                     |
+
+`FIT Services.app` and `FIT Utilities.app` are bundles-as-container:
+`CFBundleExecutable` names a single "primary" Mach-O to satisfy the bundle
+shape, but every Mach-O in `Contents/MacOS/` is independently exposed via
+its cask's `binary` stanza (Component 3).
+
+**Hardening.** After assembly, each bundle is ad-hoc codesigned:
+
+```
+codesign --force --sign - \
+  --entitlements <bundle-entitlements>.plist \
+  --options runtime \
+  --identifier com.forwardimpact.<name> \
+  --deep \
+  dist/apps/<Bundle>.app
+```
+
+`--identifier` fixes the designated requirement, so TCC grants keyed on
+the bundle ID survive rebuilds. `--options runtime` enables Hardened
+Runtime so the JIT entitlement applies and the later Developer ID spec is
+a pure identity swap. `--deep` recursively signs every Mach-O under
+`Contents/MacOS/`, giving `FIT Services.app` and `FIT Utilities.app` a
+single codesign pass over their multi-executable contents.
+
+**Rejected — bare Mach-Os with `__TEXT,__info_plist` embedding.** An
+earlier iteration of this design proposed splicing `Info.plist` into the
+Mach-O section table. That required an Xcode-CLI-tools spike, was fragile
+against future bun runtime changes, and left Homebrew without a clean
+PATH symlink story. Bundles eliminate the whole problem — `Info.plist`
+lives on disk at `Contents/Info.plist`.
+
+**Rejected — one `.app` per library CLI.** Would produce ~20 `fit-*.app`
+bundles from `libraries/` plus five from `services/`. Each would need
+its own Info.plist, entitlements, codesign pass, and Homebrew cask;
+coarsening into two shared bundles cuts signing surface from 31 to 8
+without losing TCC granularity (none of the library CLIs or services
+request TCC resources today).
+
+**Rejected — skip hardening under ad-hoc signing.** The follow-up
+Developer ID spec would have to re-add every metadata piece and force a
+cdhash change across every previously-installed user, wiping TCC grants.
+Landing hardening now is near-free and forward-compatible.
+
+## Component 9 — Shared `libraries/libmacos`
+
+New library: `libraries/libmacos/`. Owns every piece of macOS-specific
+surface shared across bundles.
+
+| Module                             | Contents                                                                                                                          |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `src/posix-spawn.js`               | Bun FFI wrapper around `posix_spawn` + `responsibility_spawnattrs_setdisclaim`. Lifted verbatim from `products/basecamp/src/posix-spawn.js`. |
+| `src/tcc-responsibility.js`        | Higher-level helper: spawn a child, disclaim TCC responsibility, return a Promise for exit code. Wraps `posix-spawn.js`.          |
+| `scripts/build-app.sh`             | **Bundle assembler.** Generalized from `products/basecamp/pkg/macos/build-app.sh`. Parameterized on bundle name, identifier, executable list, entitlements path, resource list, version. |
+| `scripts/sign-app.sh`              | Ad-hoc `codesign --force --sign - --options runtime --deep --identifier <id> --entitlements <path>` wrapper. Invoked by `build-app.sh` as its final stage. |
+| `templates/entitlements.plist`     | Default entitlements (JIT + disable-library-validation only).                                                                     |
+| `templates/entitlements-gui.plist` | Extended template for GUI bundles that need Calendar/Contacts/Network access; seeded from basecamp's current `Basecamp.entitlements`. |
+| `templates/Info.plist.hbs`         | `Info.plist` template with `{{bundleId}}`, `{{bundleName}}`, `{{executable}}`, `{{version}}`, `{{minOS}}`, `{{lsuiElement}}` placeholders. |
+
+**Adoption.** Basecamp is the first consumer. Its current
+`src/posix-spawn.js` becomes `import { spawn } from "libmacos/spawn"`.
+Its `pkg/macos/build-app.sh` is deleted; basecamp's justfile `build-app`
+recipe calls `libmacos/scripts/build-app.sh` with basecamp-specific
+arguments (Swift launcher as `CFBundleExecutable`, `fit-basecamp` as a
+secondary Mach-O in `Contents/MacOS/`, `Basecamp.entitlements` as the
+entitlements path, `LSUIElement=true`). The other five products,
+`FIT Services.app`, and `FIT Utilities.app` call the same script with
+their own arguments.
+
+**Scope boundary.** `libmacos` does **not** own:
+
+- Swift launcher source — basecamp's Swift target stays with basecamp.
+- `.pkg` installer flow — basecamp's `build-pkg.sh` stays with basecamp
+  for as long as the `.pkg` channel remains; spec 600's distribution
+  channel is Homebrew.
+- Developer ID signing / notarization — follow-up spec.
+
+**Rejected — put this in `libcli` or `libbuild`.** `libcli` is
+cross-platform, and consuming a macOS-only FFI would bleed Darwin code
+into every CLI's import graph. A dedicated `libmacos` library makes the
+boundary obvious and lets `libmacos/package.json` declare
+`"os": ["darwin"]`.
+
+**Rejected — leave `build-app.sh` in basecamp and have each bundle copy
+it.** Eight copies of a 70-line assembler script guarantee drift. Lifting
+into libmacos is the natural home given `posix-spawn.js` and the
+templates already want to live there.
 
 ## Open questions for plan phase
 

--- a/specs/600-native-binary-distribution/plan-a.md
+++ b/specs/600-native-binary-distribution/plan-a.md
@@ -68,6 +68,13 @@ migrate basecamp to consume it. This step blocks Step 1b onward.
   with basecamp-specific arguments (Swift launcher as `CFBundleExecutable`,
   `fit-basecamp` as a secondary Mach-O, `Basecamp.entitlements` as
   entitlements path, `LSUIElement=true`).
+- Preserve basecamp's existing `.pkg` flow: `pkg/macos/build-pkg.sh`
+  currently depends on `dist/Basecamp.app` being produced by the
+  now-retired `build-app.sh`. The rewired `build-app` recipe must
+  produce a bundle at the same path (`dist/Basecamp.app`) so
+  `build-pkg.sh` keeps working unchanged. If the shared
+  `libmacos/scripts/build-app.sh` output path differs, add a thin
+  basecamp-local recipe that copies / symlinks to the legacy path.
 
 ### Files
 
@@ -110,24 +117,31 @@ Replaces the original Step 1. Drive every bundle through
 
 ### Recipe: `build-binary`
 
+`NAME` is the full binary name (e.g. `fit-pathway`, `fit-service-graph`,
+`fit-codegen`). The recipe resolves the entry file by scanning every
+`package.json` under `products/`, `services/`, and `libraries/` for a
+`bin` field whose key matches `NAME`, and uses the path that field points
+at as the bun-compile entry. This replaces heuristic-based path guessing
+(like "`libraries/lib<NAME>/bin/fit-<NAME>.js`"), which fails for the many
+library CLIs whose library name doesn't match the CLI name (e.g. `fit-trace`
+lives in `libeval`, `fit-process-graphs` in `libgraph`, `fit-visualize` in
+`libtelemetry`).
+
 ```just
-# Build a standalone native Mach-O for a product, service, or library CLI
+# Build a standalone native Mach-O. NAME is a full bin name like fit-codegen.
 build-binary NAME TARGET="bun-darwin-arm64":
     #!/usr/bin/env bash
     set -euo pipefail
-    # Resolve entry point — products, then services, then libraries
-    ENTRY="products/{{NAME}}/bin/fit-{{NAME}}.js"
-    OUT_NAME="fit-{{NAME}}"
-    if [ ! -f "$ENTRY" ]; then
-      ENTRY="services/{{NAME}}/server.js"
-      OUT_NAME="fit-service-{{NAME}}"
-    fi
-    if [ ! -f "$ENTRY" ]; then
-      ENTRY="libraries/lib{{NAME}}/bin/fit-{{NAME}}.js"
-      OUT_NAME="fit-{{NAME}}"
-    fi
-    if [ ! -f "$ENTRY" ]; then
-      echo "Error: no entry point found for {{NAME}}" >&2
+    ENTRY=""
+    for PKG in products/*/package.json services/*/package.json libraries/*/package.json; do
+      REL=$(jq -r --arg n "{{NAME}}" '.bin[$n] // empty' "$PKG" 2>/dev/null)
+      if [ -n "$REL" ]; then
+        ENTRY="$(dirname "$PKG")/$REL"
+        break
+      fi
+    done
+    if [ -z "$ENTRY" ] || [ ! -f "$ENTRY" ]; then
+      echo "Error: no package.json declares bin[{{NAME}}] with an existing entry" >&2
       exit 1
     fi
     mkdir -p dist/binaries
@@ -135,102 +149,91 @@ build-binary NAME TARGET="bun-darwin-arm64":
       --target "{{TARGET}}" \
       --no-compile-autoload-dotenv \
       --no-compile-autoload-bunfig \
-      --outfile "dist/binaries/${OUT_NAME}-{{TARGET}}" \
+      --outfile "dist/binaries/{{NAME}}-{{TARGET}}" \
       "$ENTRY"
-    # Size gate (design: 150 MB ceiling)
-    SIZE=$(stat -f%z "dist/binaries/${OUT_NAME}-{{TARGET}}" 2>/dev/null \
-        || stat -c%s "dist/binaries/${OUT_NAME}-{{TARGET}}")
-    MAX=$((150 * 1024 * 1024))
-    if [ "$SIZE" -gt "$MAX" ]; then
-      echo "Error: ${OUT_NAME} binary is $(( SIZE / 1024 / 1024 )) MB (ceiling: 150 MB)" >&2
-      exit 1
-    fi
-    echo "${OUT_NAME}: $(( SIZE / 1024 / 1024 )) MB"
 ```
 
 **Flags explained:**
 
-- `--target` — sets the output platform triple; defaults to `bun-darwin-arm64`
-  per the design. Phase 2 passes `bun-darwin-x64`.
+- `--target` — sets the output platform triple; defaults to `bun-darwin-arm64`.
 - `--no-compile-autoload-dotenv` / `--no-compile-autoload-bunfig` — CLIs must
   not read `.env` or `bunfig.toml` from the user's working directory; they have
   their own config mechanisms (`fit-rc`, `config.json`).
 - `--outfile dist/binaries/<name>-<target>` — deterministic output path. `dist/`
-  is already in `.gitignore` (line 57). The local filename uses bun's target
-  triple (`bun-darwin-arm64`) because that's what `--target` requires. The
-  bundle-assembly step (`build-app-*` below) reads from this path.
+  is already in `.gitignore`. The bundle-assembly step (`build-app-*` below)
+  reads from this path.
 
-**Entry point resolution:** Six product CLIs live under
-`products/<name>/bin/fit-<name>.js`. Five gRPC services live under
-`services/<name>/server.js` and compile to `fit-service-<name>`. Library CLIs
-live under `libraries/lib<name>/bin/fit-<name>.js` (`fit-codegen`,
-`fit-terrain`, `fit-eval`, etc.). The recipe checks products, then services,
-then libraries, and fails with a clear error if none match.
+**Prerequisite for services.** Today `services/<name>/package.json` has no
+`bin` field — each service runs via `bun server.js`. Step 1b adds
+`"bin": { "fit-service-<name>": "./server.js" }` to each of the five service
+packages so the same `build-binary` recipe drives them uniformly.
 
-**Codegen dependency (design divergence).** The design says `build-binary`
-depends on `codegen`. This plan breaks that dependency on the individual recipe
-to avoid re-running codegen seven times in the CI matrix. Instead, `codegen`
-runs once before the matrix: the CI workflow runs it via `bootstrap` →
-`just install` → `install-bun` → `fit-codegen --all`, and the `build-binaries`
-fan-out recipe depends on `codegen` for local use. Risk: a contributor running
-`just build-binary guide` without codegen gets a broken binary. This is
-acceptable — the fan-out recipe is the documented entry point, not the per-CLI
-recipe.
-
-**Size gate.** The recipe checks the binary against the design's 150 MB ceiling
-and fails if exceeded. Uses `stat -f%z` (macOS) with `stat -c%s` (Linux)
-fallback.
+**Codegen.** `build-binary` does not depend on `codegen` as an individual
+recipe — the `build-binaries` fan-out below depends on `codegen` for local
+use, and CI's bootstrap action runs `fit-codegen --all` before the bundle
+job. A contributor running `just build-binary fit-guide` on a tree without
+generated code gets a broken binary; the fan-out is the documented entry
+point.
 
 ### Recipe: `build-binaries`
 
+Each fan-out below uses the real binary names declared in each
+package.json's `bin` field — no aliasing or rename machinery. Service
+binaries get the `fit-service-` prefix so they don't collide with any
+product or library CLI.
+
 ```just
-# Build all Mach-Os for the default target — products, services, library CLIs
+# Build all Mach-Os for the default target
 build-binaries: codegen build-product-binaries build-service-binaries build-utility-binaries
 
 build-product-binaries:
-    just build-binary basecamp
-    just build-binary guide
-    just build-binary landmark
-    just build-binary map
-    just build-binary pathway
-    just build-binary summit
+    just build-binary fit-basecamp
+    just build-binary fit-guide
+    just build-binary fit-landmark
+    just build-binary fit-map
+    just build-binary fit-pathway
+    just build-binary fit-summit
 
 build-service-binaries:
-    just build-binary graph
-    just build-binary mcp
-    just build-binary pathway-service  # services/pathway renamed target to avoid collision
-    just build-binary trace
-    just build-binary vector
+    just build-binary fit-service-graph
+    just build-binary fit-service-mcp
+    just build-binary fit-service-pathway
+    just build-binary fit-service-trace
+    just build-binary fit-service-vector
 
 build-utility-binaries:
-    just build-binary codegen
-    just build-binary terrain
-    just build-binary eval
-    just build-binary doc
-    just build-binary rc
-    just build-binary xmr
-    just build-binary storage
-    just build-binary logger
-    just build-binary svscan
-    just build-binary trace-util  # libeval's fit-trace, disambiguated
-    just build-binary visualize
-    just build-binary query
-    just build-binary subjects
-    just build-binary process-graphs
-    just build-binary process-resources
-    just build-binary process-vectors
-    just build-binary search
-    just build-binary unary
-    just build-binary tiktoken
-    just build-binary download-bundle
+    # Enumerated from `libraries/*/package.json` bin fields at Step 1a time.
+    # Every addition or removal here MUST be mirrored in the `binary` stanza
+    # list of Casks/fit-utilities.rb (Step 3) — the two lists are the single
+    # source of truth for "what ends up on PATH via fit-utilities".
+    just build-binary fit-codegen
+    just build-binary fit-terrain
+    just build-binary fit-eval
+    just build-binary fit-doc
+    just build-binary fit-rc
+    just build-binary fit-xmr
+    just build-binary fit-storage
+    just build-binary fit-logger
+    just build-binary fit-svscan
+    just build-binary fit-trace
+    just build-binary fit-visualize
+    just build-binary fit-query
+    just build-binary fit-subjects
+    just build-binary fit-process-graphs
+    just build-binary fit-process-resources
+    just build-binary fit-process-vectors
+    just build-binary fit-search
+    just build-binary fit-unary
+    just build-binary fit-tiktoken
+    just build-binary fit-download-bundle
 ```
 
 Sequential execution is intentional — parallel `bun build --compile` can
-exhaust memory on CI runners (each embeds the ~60 MB bun runtime). `codegen`
-runs first to ensure generated gRPC code is current. The exact list of
-services and library CLIs, and any target-name disambiguation, is resolved
-during Step 1a/1b implementation from `services/*/package.json` and
-`libraries/*/package.json` `bin` fields.
+exhaust memory on CI runners (each embeds the ~60 MB bun runtime).
+`codegen` runs first so generated gRPC code is current. The canonical
+utility list above must be verified against
+`libraries/*/package.json` during Step 1a implementation and updated if
+any library's `bin` set has changed since this plan was written.
 
 ### Recipes: `build-app-*`
 
@@ -357,7 +360,7 @@ codesign -d --entitlements - dist/apps/fit-pathway.app
 codesign --verify --deep --strict dist/apps/fit-pathway.app
 # Expect: exit 0
 ./dist/apps/fit-pathway.app/Contents/MacOS/fit-pathway --help
-# Expect: pathway help output, exit 0 in < 500 ms
+# Expect: pathway help output, exit 0
 
 # Build every bundle
 just build-apps
@@ -365,9 +368,12 @@ ls dist/apps/
 # Expect: fit-basecamp.app, fit-guide.app, fit-landmark.app, fit-map.app,
 #         fit-pathway.app, fit-summit.app, FIT Services.app, FIT Utilities.app
 
-# cdhash stability check (CI gate)
+# cdhash stability check (CI gate): rebuild from the same tree twice and
+# compare the signed cdhash. No stash — the tree is unchanged between
+# invocations; the build must be deterministic on its own.
 BASELINE=$(codesign -dvvv dist/apps/fit-pathway.app 2>&1 | grep CDHash)
-git stash && just build-app-product pathway && git stash pop
+rm -rf dist/apps/fit-pathway.app dist/binaries/fit-pathway-bun-darwin-arm64
+just build-app-product pathway
 AFTER=$(codesign -dvvv dist/apps/fit-pathway.app 2>&1 | grep CDHash)
 [ "$BASELINE" = "$AFTER" ] || { echo "cdhash drift"; exit 1; }
 ```
@@ -721,7 +727,7 @@ and declares `depends_on cask:` on the two shared-bundle casks:
 ```ruby
 cask "fit-pathway" do
   version "0.0.0"
-  sha256 :no_check
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
 
   url "https://github.com/forwardimpact/monorepo/releases/download/pathway@v#{version}/fit-pathway-#{version}-darwin-arm64.zip"
   name "Forward Impact Pathway"
@@ -756,7 +762,7 @@ bundles and enumerate every Mach-O inside `Contents/MacOS/` as a separate
 ```ruby
 cask "fit-utilities" do
   version "0.0.0"
-  sha256 :no_check
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
 
   url "https://github.com/forwardimpact/monorepo/releases/download/utilities@v#{version}/fit-utilities-#{version}-darwin-arm64.zip"
   name "Forward Impact Utilities"
@@ -805,9 +811,11 @@ end
 gRPC servers (`fit-service-{graph,mcp,pathway,trace,vector}`).
 
 Each product cask gets a tailored `desc` matching the product tagline from
-its Overview page. The `sha256 :no_check` placeholder is safe — no release
+its Overview page. The all-zero `sha256` placeholder is safe — no release
 asset exists at `v0.0.0`, so `brew install` would fail with a download
-error, not an integrity bypass.
+error, not an integrity bypass. The placeholder's quoted-string form
+matches the shape Step 2's `sed -i` cask-update edits on first release,
+so the initial `version` / `sha256` bump is mechanical.
 
 ### README.md content
 
@@ -832,9 +840,9 @@ brew info forwardimpact/tap/fit-pathway
 
 ## Step 4 — Product overview documentation
 
-Add a brew install section to each of the seven product Overview pages and to
-the codegen internals page. Each page gets a "Getting Started" section update
-showing both npm and brew paths.
+Add a brew install section to each of the six product Overview pages and to
+the codegen internals page. Each page gets a "Getting Started" section
+update showing both npm and brew paths.
 
 ### Pattern
 
@@ -954,17 +962,25 @@ Installing any product cask (e.g. `fit-guide`) also installs
   are modified by this plan. Existing `publish-npm.yml` and CI quality checks
   exercise the npm path — no new verification needed.
 
+### Agent & parallelism
+
+**Agent:** technical-writer.
+**Parallelism:** Can start once the tap path (`forwardimpact/tap`) and
+cask names (e.g. `fit-pathway`, `fit-utilities`) are fixed by Step 3.
+Runs in parallel with Steps 1b–2; does not block any tag push.
+
 ## Risks
 
 1. **Binary size.** Each binary embeds the bun runtime (~60 MB) plus bundled
-   dependencies. The 150 MB ceiling from the design is enforced by the
-   `build-binary` recipe's size gate. If a CLI exceeds it, the build fails
-   immediately.
+   dependencies. Neither spec nor design pins an acceptance ceiling; size is
+   treated as observable, not gated. If a bundle grows enough to affect
+   Homebrew download times or cask-upgrade reliability, revisit in a
+   follow-up and propose a ceiling there.
 2. **Symlink resolution.** The `generated/` symlink in `librpc/src/generated` →
    `<repo>/generated/` must be resolved by bun's bundler at compile time.
    Confirmed working by basecamp's `build-scheduler` recipe
-   (`products/basecamp/justfile:35`). Detectable in Step 1 verification if it
-   ever regresses.
+   (`products/basecamp/justfile:35`). Detectable in Step 1b verification if
+   it ever regresses.
 3. **Tag collision.** `publish-brew.yml` and `publish-npm.yml` both fire on
    `*@v*`. They're independent, but if `publish-brew.yml` fails, the npm release
    ships without a brew release. Mitigation: the tap PR is the human gate — a
@@ -979,10 +995,10 @@ Installing any product cask (e.g. `fit-guide`) also installs
 6. **Gatekeeper friction.** Unsigned binaries require manual approval on first
    run. Mitigation: every Overview page carries the caveat with step-by-step
    instructions. Signing is explicitly deferred per spec.
-7. **Startup budget.** The design specifies a 500 ms cold-start budget for
-   `--help`. The CI smoke test runs `--help` but does not time it (timing on
-   shared CI runners is unreliable). Startup budget enforcement is deferred to
-   manual acceptance testing on dedicated hardware.
+7. **Cold-start performance.** Neither spec nor design pins a `--help`
+   startup budget. CI smoke-tests `--help` for correctness; any regression
+   large enough to affect interactive feel is expected to surface in
+   manual acceptance testing on dedicated hardware before release.
 8. **SC5 acceptance.** The CI smoke test runs `--help` only. Full SC5 coverage
    (every user-visible Guide command works without codegen) requires manual
    acceptance testing on a clean macOS machine with no Node/Bun on PATH. The

--- a/specs/600-native-binary-distribution/plan-a.md
+++ b/specs/600-native-binary-distribution/plan-a.md
@@ -5,13 +5,16 @@ WHICH/WHERE. This plan captures HOW to implement and WHEN to sequence changes.
 
 ## Approach
 
-The implementation has four steps: build recipes, release workflow, tap
-repository, and documentation. Steps 1 and 2 are strictly sequential (the
-workflow uses the recipes). Step 3 (tap repo) can run in parallel with steps 1–2
-since it creates an external repo with placeholder casks. Step 4 (docs) can run
-in parallel with step 3. However, the tap repo and `HOMEBREW_TAP_PAT` secret
-must both exist before the first real release tag is pushed — otherwise the
-`tap-pr` job fails.
+The implementation has six steps: libmacos extraction (1a), bundle build
+recipes (1b), release workflow (2), basecamp TCC verification (2b), tap
+repository (3), and documentation (4). Step 1a lands first and blocks all
+other bundle-assembly work. Steps 1b and 2 are strictly sequential. Step 3
+(tap repo) can run in parallel with steps 1–2 since it creates an external
+repo with placeholder casks. Step 4 (docs) can run in parallel with step 3.
+Step 2b (manual TCC verification) runs before the first `basecamp@v*` tag
+is pushed through the new workflow. The tap repo and `HOMEBREW_TAP_PAT`
+secret must both exist before the first real release tag is pushed —
+otherwise the `tap-pr` job fails.
 
 The fit-guide codegen story resolves automatically: `just codegen` runs before
 `bun build --compile`, so generated gRPC clients are bundled into every binary
@@ -21,31 +24,110 @@ via bun's import-graph traversal. No special handling needed — the existing
 `products/basecamp/justfile:35`).
 
 **Naming convention (deliberate design divergence).** The design specifies
-output path `dist/binaries/<cli>-<os>-<arch>`. This plan uses
-`dist/binaries/fit-<cli>-bun-darwin-arm64` as the local build output — the
-`bun-` prefix is bun's target triple convention and is required by the
-`--target` flag. The `release-assets` job renames to the design's asset naming
-scheme (`fit-<cli>-<version>-darwin-arm64`) at upload time.
+output path `dist/binaries/<cli>-<os>-<arch>` for Mach-Os and `dist/apps/` for
+`.app` bundles. This plan uses `dist/binaries/fit-<cli>-bun-darwin-arm64` as
+the local Mach-O output — the `bun-` prefix is bun's target triple convention
+and is required by the `--target` flag. Bundle assembly then reads from
+`dist/binaries/` and writes `dist/apps/<Bundle>.app`. The `release-assets`
+job zips each `.app` and uploads as
+`<Bundle>.app-<version>-darwin-arm64.zip`.
 
-## Step 1 — Build recipes in justfile
+## Step 1a — Extract `libraries/libmacos`
 
-Add a parameterized recipe `build-binary` and a fan-out recipe `build-binaries`
-to the root justfile.
+Create the shared macOS library every bundle-assembly step depends on, and
+migrate basecamp to consume it. This step blocks Step 1b onward.
+
+### Actions
+
+- Create `libraries/libmacos/` with `package.json`, `src/`, `templates/`,
+  `scripts/`. Declare `"os": ["darwin"]` so Linux CI skips it cleanly.
+- Move `products/basecamp/src/posix-spawn.js` →
+  `libraries/libmacos/src/posix-spawn.js`. Rewrite basecamp's imports
+  (`products/basecamp/src/agent-runner.js` and any other caller). Add
+  `libraries/libmacos/src/tcc-responsibility.js` — a thin wrapper that
+  spawns a child, disclaims TCC responsibility, and returns an
+  exit-code Promise.
+- Generalize `products/basecamp/pkg/macos/build-app.sh` into
+  `libraries/libmacos/scripts/build-app.sh` accepting:
+  `--bundle-name`, `--bundle-id`, `--primary-exec`, `--extra-exec`
+  (repeatable), `--info-plist`, `--entitlements`, `--resource`
+  (repeatable), `--version`, `--out-dir`. Output path
+  `<out-dir>/<bundle-name>.app`.
+- Extract the codesign call into `libraries/libmacos/scripts/sign-app.sh`
+  and have `build-app.sh` invoke it as its final stage.
+- Commit default templates:
+  - `templates/entitlements.plist` — JIT +
+    `com.apple.security.cs.disable-library-validation` only.
+  - `templates/entitlements-gui.plist` — seeded from basecamp's current
+    `Basecamp.entitlements` (Calendar, Contacts, Network).
+  - `templates/Info.plist.hbs` — template with `{{bundleId}}`,
+    `{{bundleName}}`, `{{executable}}`, `{{version}}`, `{{minOS}}`,
+    `{{lsuiElement}}` placeholders.
+- Delete `products/basecamp/pkg/macos/build-app.sh`. Update basecamp's
+  justfile `build-app` recipe to call `libraries/libmacos/scripts/build-app.sh`
+  with basecamp-specific arguments (Swift launcher as `CFBundleExecutable`,
+  `fit-basecamp` as a secondary Mach-O, `Basecamp.entitlements` as
+  entitlements path, `LSUIElement=true`).
+
+### Files
+
+| File                                                  | Action                                               |
+| ----------------------------------------------------- | ---------------------------------------------------- |
+| `libraries/libmacos/package.json`                     | Created — `"os": ["darwin"]`                         |
+| `libraries/libmacos/src/posix-spawn.js`               | Created — moved from `products/basecamp/src/`        |
+| `libraries/libmacos/src/tcc-responsibility.js`        | Created                                              |
+| `libraries/libmacos/scripts/build-app.sh`             | Created — generalized from basecamp's `build-app.sh` |
+| `libraries/libmacos/scripts/sign-app.sh`              | Created                                              |
+| `libraries/libmacos/templates/entitlements.plist`     | Created                                              |
+| `libraries/libmacos/templates/entitlements-gui.plist` | Created — seeded from `Basecamp.entitlements`        |
+| `libraries/libmacos/templates/Info.plist.hbs`         | Created                                              |
+| `products/basecamp/src/posix-spawn.js`                | Deleted — moved to libmacos                          |
+| `products/basecamp/src/agent-runner.js`               | Modified — import from `libmacos`                    |
+| `products/basecamp/pkg/macos/build-app.sh`            | Deleted — superseded by `libmacos/scripts/build-app.sh` |
+| `products/basecamp/justfile`                          | Modified — `build-app` recipe calls `libmacos/scripts/build-app.sh` |
+
+### Verification
+
+```sh
+cd products/basecamp
+just build-app
+# Expect: dist/Basecamp.app produced with Swift launcher as CFBundleExecutable
+#         and fit-basecamp in Contents/MacOS/; codesign -dvvv passes
+bun test
+# Expect: basecamp's existing test suite passes, including agent-runner paths
+#         that exercise posix-spawn via libmacos
+```
+
+### Agent & parallelism
+
+**Agent:** staff-engineer.
+**Parallelism:** First step. Blocks Step 1b, Step 2, Step 2b.
+
+## Step 1b — Bundle recipes in root justfile
+
+Replaces the original Step 1. Drive every bundle through
+`libmacos/scripts/build-app.sh` from root-level justfile recipes.
 
 ### Recipe: `build-binary`
 
 ```just
-# Build a standalone native binary for a CLI
-build-binary CLI TARGET="bun-darwin-arm64":
+# Build a standalone native Mach-O for a product, service, or library CLI
+build-binary NAME TARGET="bun-darwin-arm64":
     #!/usr/bin/env bash
     set -euo pipefail
-    # Resolve entry point — products first, then libraries
-    ENTRY="products/{{CLI}}/bin/fit-{{CLI}}.js"
+    # Resolve entry point — products, then services, then libraries
+    ENTRY="products/{{NAME}}/bin/fit-{{NAME}}.js"
+    OUT_NAME="fit-{{NAME}}"
     if [ ! -f "$ENTRY" ]; then
-      ENTRY="libraries/lib{{CLI}}/bin/fit-{{CLI}}.js"
+      ENTRY="services/{{NAME}}/server.js"
+      OUT_NAME="fit-service-{{NAME}}"
     fi
     if [ ! -f "$ENTRY" ]; then
-      echo "Error: no entry point found for fit-{{CLI}}" >&2
+      ENTRY="libraries/lib{{NAME}}/bin/fit-{{NAME}}.js"
+      OUT_NAME="fit-{{NAME}}"
+    fi
+    if [ ! -f "$ENTRY" ]; then
+      echo "Error: no entry point found for {{NAME}}" >&2
       exit 1
     fi
     mkdir -p dist/binaries
@@ -53,17 +135,17 @@ build-binary CLI TARGET="bun-darwin-arm64":
       --target "{{TARGET}}" \
       --no-compile-autoload-dotenv \
       --no-compile-autoload-bunfig \
-      --outfile "dist/binaries/fit-{{CLI}}-{{TARGET}}" \
+      --outfile "dist/binaries/${OUT_NAME}-{{TARGET}}" \
       "$ENTRY"
     # Size gate (design: 150 MB ceiling)
-    SIZE=$(stat -f%z "dist/binaries/fit-{{CLI}}-{{TARGET}}" 2>/dev/null \
-        || stat -c%s "dist/binaries/fit-{{CLI}}-{{TARGET}}")
+    SIZE=$(stat -f%z "dist/binaries/${OUT_NAME}-{{TARGET}}" 2>/dev/null \
+        || stat -c%s "dist/binaries/${OUT_NAME}-{{TARGET}}")
     MAX=$((150 * 1024 * 1024))
     if [ "$SIZE" -gt "$MAX" ]; then
-      echo "Error: fit-{{CLI}} binary is $(( SIZE / 1024 / 1024 )) MB (ceiling: 150 MB)" >&2
+      echo "Error: ${OUT_NAME} binary is $(( SIZE / 1024 / 1024 )) MB (ceiling: 150 MB)" >&2
       exit 1
     fi
-    echo "fit-{{CLI}}: $(( SIZE / 1024 / 1024 )) MB"
+    echo "${OUT_NAME}: $(( SIZE / 1024 / 1024 )) MB"
 ```
 
 **Flags explained:**
@@ -73,15 +155,17 @@ build-binary CLI TARGET="bun-darwin-arm64":
 - `--no-compile-autoload-dotenv` / `--no-compile-autoload-bunfig` — CLIs must
   not read `.env` or `bunfig.toml` from the user's working directory; they have
   their own config mechanisms (`fit-rc`, `config.json`).
-- `--outfile dist/binaries/fit-<cli>-<target>` — deterministic output path.
-  `dist/` is already in `.gitignore` (line 57). The local filename uses bun's
-  target triple (`bun-darwin-arm64`) because that's what `--target` requires.
-  The `release-assets` job renames to the design's versioned scheme at upload.
+- `--outfile dist/binaries/<name>-<target>` — deterministic output path. `dist/`
+  is already in `.gitignore` (line 57). The local filename uses bun's target
+  triple (`bun-darwin-arm64`) because that's what `--target` requires. The
+  bundle-assembly step (`build-app-*` below) reads from this path.
 
-**Entry point resolution:** Six CLIs live under `products/<cli>/bin/`, but
-`fit-codegen` lives under `libraries/libcodegen/bin/`. The recipe checks
-`products/` first, falls back to `libraries/lib<cli>/`, and fails with a clear
-error if neither exists. This covers the seven CLIs without a lookup table.
+**Entry point resolution:** Six product CLIs live under
+`products/<name>/bin/fit-<name>.js`. Five gRPC services live under
+`services/<name>/server.js` and compile to `fit-service-<name>`. Library CLIs
+live under `libraries/lib<name>/bin/fit-<name>.js` (`fit-codegen`,
+`fit-terrain`, `fit-eval`, etc.). The recipe checks products, then services,
+then libraries, and fails with a clear error if none match.
 
 **Codegen dependency (design divergence).** The design says `build-binary`
 depends on `codegen`. This plan breaks that dependency on the individual recipe
@@ -100,42 +184,192 @@ fallback.
 ### Recipe: `build-binaries`
 
 ```just
-# Build all CLI binaries for the default target
-build-binaries: codegen
-    just build-binary map
-    just build-binary pathway
+# Build all Mach-Os for the default target — products, services, library CLIs
+build-binaries: codegen build-product-binaries build-service-binaries build-utility-binaries
+
+build-product-binaries:
     just build-binary basecamp
     just build-binary guide
     just build-binary landmark
+    just build-binary map
+    just build-binary pathway
     just build-binary summit
+
+build-service-binaries:
+    just build-binary graph
+    just build-binary mcp
+    just build-binary pathway-service  # services/pathway renamed target to avoid collision
+    just build-binary trace
+    just build-binary vector
+
+build-utility-binaries:
     just build-binary codegen
+    just build-binary terrain
+    just build-binary eval
+    just build-binary doc
+    just build-binary rc
+    just build-binary xmr
+    just build-binary storage
+    just build-binary logger
+    just build-binary svscan
+    just build-binary trace-util  # libeval's fit-trace, disambiguated
+    just build-binary visualize
+    just build-binary query
+    just build-binary subjects
+    just build-binary process-graphs
+    just build-binary process-resources
+    just build-binary process-vectors
+    just build-binary search
+    just build-binary unary
+    just build-binary tiktoken
+    just build-binary download-bundle
 ```
 
-This depends on `codegen` to ensure generated code is current. Sequential
-execution is intentional — parallel `bun build --compile` can exhaust memory on
-CI runners (each embeds the ~60 MB bun runtime). This recipe is for local
-contributor use; CI uses the workflow's single-CLI build per tag.
+Sequential execution is intentional — parallel `bun build --compile` can
+exhaust memory on CI runners (each embeds the ~60 MB bun runtime). `codegen`
+runs first to ensure generated gRPC code is current. The exact list of
+services and library CLIs, and any target-name disambiguation, is resolved
+during Step 1a/1b implementation from `services/*/package.json` and
+`libraries/*/package.json` `bin` fields.
+
+### Recipes: `build-app-*`
+
+After Mach-Os are built, bundle them via `libmacos/scripts/build-app.sh`:
+
+```just
+# Assemble a per-product .app bundle
+build-app-product NAME:
+    bash libraries/libmacos/scripts/build-app.sh \
+      --bundle-name "fit-{{NAME}}" \
+      --bundle-id "com.forwardimpact.{{NAME}}" \
+      --primary-exec "dist/binaries/fit-{{NAME}}-bun-darwin-arm64" \
+      --info-plist "products/{{NAME}}/macos/Info.plist" \
+      --entitlements "products/{{NAME}}/macos/entitlements.plist" \
+      --version "$(jq -r .version products/{{NAME}}/package.json)" \
+      --out-dir dist/apps
+
+# Assemble FIT Services.app
+build-app-services:
+    bash libraries/libmacos/scripts/build-app.sh \
+      --bundle-name "FIT Services" \
+      --bundle-id "com.forwardimpact.services" \
+      --primary-exec "dist/binaries/fit-service-graph-bun-darwin-arm64" \
+      --extra-exec "dist/binaries/fit-service-mcp-bun-darwin-arm64" \
+      --extra-exec "dist/binaries/fit-service-pathway-bun-darwin-arm64" \
+      --extra-exec "dist/binaries/fit-service-trace-bun-darwin-arm64" \
+      --extra-exec "dist/binaries/fit-service-vector-bun-darwin-arm64" \
+      --info-plist "services/macos/Info.plist" \
+      --entitlements "services/macos/entitlements.plist" \
+      --version "$(jq -r .version package.json)" \
+      --out-dir dist/apps
+
+# Assemble FIT Utilities.app
+build-app-utilities:
+    bash libraries/libmacos/scripts/build-app.sh \
+      --bundle-name "FIT Utilities" \
+      --bundle-id "com.forwardimpact.utilities" \
+      --primary-exec "dist/binaries/fit-codegen-bun-darwin-arm64" \
+      --extra-exec "dist/binaries/fit-terrain-bun-darwin-arm64" \
+      # … remaining library-CLI Mach-Os as --extra-exec
+      --info-plist "libraries/macos/Info.plist" \
+      --entitlements "libraries/macos/entitlements.plist" \
+      --version "$(jq -r .version package.json)" \
+      --out-dir dist/apps
+
+# Fan-out: build every Mach-O, then every bundle
+build-apps: build-binaries
+    just build-app-product basecamp
+    just build-app-product guide
+    just build-app-product landmark
+    just build-app-product map
+    just build-app-product pathway
+    just build-app-product summit
+    just build-app-services
+    just build-app-utilities
+```
+
+### Per-bundle metadata files
+
+Create `Info.plist` and `entitlements.plist` alongside each bundle's source
+tree:
+
+- `products/<name>/macos/Info.plist` for the five non-basecamp products —
+  render `libmacos/templates/Info.plist.hbs` with
+  `bundleId=com.forwardimpact.<name>`, `executable=fit-<name>`,
+  `minOS=13.0`, no `NS*UsageDescription` entries. Basecamp already has
+  `products/basecamp/macos/Info.plist` — leave it alone.
+- `products/<name>/macos/entitlements.plist` for the five non-basecamp
+  products — copy `libmacos/templates/entitlements.plist` (JIT +
+  disable-library-validation). Basecamp continues to reference
+  `products/basecamp/macos/Basecamp.entitlements`.
+- `services/macos/Info.plist` and `services/macos/entitlements.plist` —
+  metadata for `FIT Services.app`. Identifier `com.forwardimpact.services`,
+  `CFBundleExecutable=fit-service-graph`.
+- `libraries/macos/Info.plist` and `libraries/macos/entitlements.plist` —
+  metadata for `FIT Utilities.app`. Identifier
+  `com.forwardimpact.utilities`, `CFBundleExecutable=fit-codegen`.
+
+### Service compile targets
+
+Each `services/<name>/package.json` needs a `bin` entry or the equivalent
+so `build-binary <name>` finds an entry point that compiles to
+`fit-service-<name>`. Add per-service `bin` fields during Step 1b
+implementation.
 
 ### Recipe placement
 
-Add both recipes under a new `# ── Binaries` section after the existing
-`# ── CLI` section. This groups binary builds near the CLIs they compile.
+Add the binary and bundle recipes under a new `# ── Bundles` section after
+the existing `# ── CLI` section of the root justfile.
 
 ### Files
 
-| File       | Action                                                     |
-| ---------- | ---------------------------------------------------------- |
-| `justfile` | Modified — add `build-binary` and `build-binaries` recipes |
+| File                                              | Action                                         |
+| ------------------------------------------------- | ---------------------------------------------- |
+| `justfile`                                        | Modified — add binary and bundle recipes       |
+| `products/guide/macos/Info.plist`                 | Created                                        |
+| `products/guide/macos/entitlements.plist`         | Created                                        |
+| `products/landmark/macos/Info.plist`              | Created                                        |
+| `products/landmark/macos/entitlements.plist`      | Created                                        |
+| `products/map/macos/Info.plist`                   | Created                                        |
+| `products/map/macos/entitlements.plist`           | Created                                        |
+| `products/pathway/macos/Info.plist`               | Created                                        |
+| `products/pathway/macos/entitlements.plist`       | Created                                        |
+| `products/summit/macos/Info.plist`                | Created                                        |
+| `products/summit/macos/entitlements.plist`        | Created                                        |
+| `services/macos/Info.plist`                       | Created                                        |
+| `services/macos/entitlements.plist`               | Created                                        |
+| `libraries/macos/Info.plist`                      | Created                                        |
+| `libraries/macos/entitlements.plist`              | Created                                        |
+| `services/*/package.json`                         | Modified — add `bin` fields for compile target |
 
 ### Verification
 
 ```sh
 just codegen
-just build-binary pathway
-./dist/binaries/fit-pathway-bun-darwin-arm64 --help
-# Expect: pathway help output, exit 0
-# On CI (Linux): binary is macOS-only — verify file exists and is Mach-O
-file dist/binaries/fit-pathway-bun-darwin-arm64
+just build-app-product pathway
+# Expect: dist/apps/fit-pathway.app exists
+codesign -dvvv dist/apps/fit-pathway.app
+# Expect: Identifier=com.forwardimpact.pathway, Signature=adhoc, non-empty cdhash
+plutil -p dist/apps/fit-pathway.app/Contents/Info.plist
+# Expect: CFBundleIdentifier=com.forwardimpact.pathway, CFBundleShortVersionString=<version>
+codesign -d --entitlements - dist/apps/fit-pathway.app
+# Expect: entitlements plist with com.apple.security.cs.allow-jit
+codesign --verify --deep --strict dist/apps/fit-pathway.app
+# Expect: exit 0
+./dist/apps/fit-pathway.app/Contents/MacOS/fit-pathway --help
+# Expect: pathway help output, exit 0 in < 500 ms
+
+# Build every bundle
+just build-apps
+ls dist/apps/
+# Expect: fit-basecamp.app, fit-guide.app, fit-landmark.app, fit-map.app,
+#         fit-pathway.app, fit-summit.app, FIT Services.app, FIT Utilities.app
+
+# cdhash stability check (CI gate)
+BASELINE=$(codesign -dvvv dist/apps/fit-pathway.app 2>&1 | grep CDHash)
+git stash && just build-app-product pathway && git stash pop
+AFTER=$(codesign -dvvv dist/apps/fit-pathway.app 2>&1 | grep CDHash)
+[ "$BASELINE" = "$AFTER" ] || { echo "cdhash drift"; exit 1; }
 ```
 
 ## Step 2 — Release workflow
@@ -144,11 +378,17 @@ Create `.github/workflows/publish-brew.yml` triggered by release tags.
 
 ### Key design decisions
 
-**Single-CLI build per tag.** The workflow extracts the CLI name from the tag
-(e.g. `pathway` from `pathway@v0.25.32`) and builds only that CLI. This matches
-`publish-npm.yml`'s per-CLI tag semantics — a tag releases one CLI, not all
-seven. Building all seven would pollute the release with unrelated assets and
-waste expensive macOS runner minutes.
+**Single-bundle build per tag.** The workflow extracts the bundle name from
+the tag and builds only that bundle. Tag shapes:
+
+- `<product>@v*` (e.g. `pathway@v0.25.32`) — builds `fit-<product>.app` via
+  `just build-app-product <product>`.
+- `services@v*` — builds `FIT Services.app` via `just build-app-services`.
+- `utilities@v*` — builds `FIT Utilities.app` via `just build-app-utilities`.
+
+This matches `publish-npm.yml`'s per-package tag semantics — a tag releases
+one artifact, not the full set. Building everything per tag would pollute
+each release with unrelated assets and waste expensive macOS runner minutes.
 
 **Codegen chain.** The bootstrap action runs `./scripts/bootstrap.sh` which
 calls `just install` → `install-bun` → `fit-codegen --all`. This ensures
@@ -157,7 +397,7 @@ after bootstrap as a defensive measure against bootstrap refactors.
 
 **Release creation.** `publish-npm.yml` does not create GitHub Releases;
 `publish-macos.yml` creates one only for `basecamp@v*`. This workflow must
-create the release if it does not exist, then upload the binary.
+create the release if it does not exist, then upload the zipped bundle.
 
 ### Workflow structure
 
@@ -177,36 +417,59 @@ jobs:
     steps:
       - uses: actions/checkout@<pinned-sha>  # v6
 
-      - name: Extract CLI and version from tag
+      - name: Extract bundle and version from tag
         id: meta
         run: |
-          CLI_NAME="${GITHUB_REF_NAME%%@v*}"
+          NAME="${GITHUB_REF_NAME%%@v*}"
           VERSION="${GITHUB_REF_NAME#*@v}"
-          echo "cli=${CLI_NAME}" >> $GITHUB_OUTPUT
+          case "$NAME" in
+            services)   KIND=services;   BUNDLE="FIT Services.app";         CASK=fit-services   ;;
+            utilities)  KIND=utilities;  BUNDLE="FIT Utilities.app";        CASK=fit-utilities  ;;
+            *)          KIND=product;    BUNDLE="fit-${NAME}.app";          CASK=fit-${NAME}    ;;
+          esac
+          echo "name=${NAME}"       >> $GITHUB_OUTPUT
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "kind=${KIND}"       >> $GITHUB_OUTPUT
+          echo "bundle=${BUNDLE}"   >> $GITHUB_OUTPUT
+          echo "cask=${CASK}"       >> $GITHUB_OUTPUT
 
       - uses: ./.github/actions/bootstrap
 
       - name: Ensure codegen is current
         run: just codegen
 
-      - name: Build binary
-        run: just build-binary ${{ steps.meta.outputs.cli }}
+      - name: Build bundle
+        run: |
+          case "${{ steps.meta.outputs.kind }}" in
+            services)   just build-app-services   ;;
+            utilities)  just build-app-utilities  ;;
+            product)    just build-app-product ${{ steps.meta.outputs.name }} ;;
+          esac
 
       - name: Smoke test
         run: |
-          BINARY="dist/binaries/fit-${{ steps.meta.outputs.cli }}-bun-darwin-arm64"
-          ./"$BINARY" --help
+          BUNDLE="dist/apps/${{ steps.meta.outputs.bundle }}"
+          codesign --verify --deep --strict "$BUNDLE"
+          # For product bundles, run the matching CLI's --help.
+          # Shared bundles expose multiple CLIs; exercise the primary exec only.
+          case "${{ steps.meta.outputs.kind }}" in
+            product)    "$BUNDLE/Contents/MacOS/fit-${{ steps.meta.outputs.name }}" --help ;;
+            services)   "$BUNDLE/Contents/MacOS/fit-service-graph" --help                  ;;
+            utilities)  "$BUNDLE/Contents/MacOS/fit-codegen" --help                        ;;
+          esac
 
-      - name: Generate sha256
+      - name: Zip bundle and hash
         id: hash
         run: |
-          CLI="${{ steps.meta.outputs.cli }}"
           VERSION="${{ steps.meta.outputs.version }}"
-          BINARY="dist/binaries/fit-${CLI}-bun-darwin-arm64"
-          ASSET="fit-${CLI}-${VERSION}-darwin-arm64"
-          shasum -a 256 "$BINARY" | awk '{print $1}' > "dist/binaries/${ASSET}.sha256"
-          echo "sha256=$(cat "dist/binaries/${ASSET}.sha256")" >> $GITHUB_OUTPUT
+          CASK="${{ steps.meta.outputs.cask }}"
+          BUNDLE="dist/apps/${{ steps.meta.outputs.bundle }}"
+          ASSET="${CASK}-${VERSION}-darwin-arm64.zip"
+          # Use `ditto` to preserve codesign metadata through zip.
+          ditto -c -k --sequesterRsrc --keepParent "$BUNDLE" "dist/apps/${ASSET}"
+          shasum -a 256 "dist/apps/${ASSET}" | awk '{print $1}' > "dist/apps/${ASSET}.sha256"
+          echo "asset=${ASSET}" >> $GITHUB_OUTPUT
+          echo "sha256=$(cat "dist/apps/${ASSET}.sha256")" >> $GITHUB_OUTPUT
 
       - name: Create or reuse GitHub Release
         env:
@@ -221,38 +484,41 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${GITHUB_REF_NAME}"
-          CLI="${{ steps.meta.outputs.cli }}"
-          VERSION="${{ steps.meta.outputs.version }}"
-          BINARY="dist/binaries/fit-${CLI}-bun-darwin-arm64"
-          ASSET="fit-${CLI}-${VERSION}-darwin-arm64"
+          ASSET="${{ steps.hash.outputs.asset }}"
           gh release upload "$TAG" \
-            "${BINARY}#${ASSET}" \
-            "dist/binaries/${ASSET}.sha256" \
+            "dist/apps/${ASSET}" \
+            "dist/apps/${ASSET}.sha256" \
             --clobber
 
   tap-pr:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Extract CLI and version from tag
+      - name: Extract bundle and version from tag
         id: meta
         run: |
-          CLI_NAME="${GITHUB_REF_NAME%%@v*}"
+          NAME="${GITHUB_REF_NAME%%@v*}"
           VERSION="${GITHUB_REF_NAME#*@v}"
-          echo "cli=${CLI_NAME}" >> $GITHUB_OUTPUT
+          case "$NAME" in
+            services)   KIND=services;   CASK=fit-services   ;;
+            utilities)  KIND=utilities;  CASK=fit-utilities  ;;
+            *)          KIND=product;    CASK=fit-${NAME}    ;;
+          esac
+          echo "name=${NAME}"       >> $GITHUB_OUTPUT
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "kind=${KIND}"       >> $GITHUB_OUTPUT
+          echo "cask=${CASK}"       >> $GITHUB_OUTPUT
 
       - name: Download sha256 from release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${GITHUB_REF_NAME}"
-          CLI="${{ steps.meta.outputs.cli }}"
+          CASK="${{ steps.meta.outputs.cask }}"
           VERSION="${{ steps.meta.outputs.version }}"
-          gh release download "$TAG" \
-            --pattern "fit-${CLI}-${VERSION}-darwin-arm64.sha256" \
-            --dir .
-          echo "sha256=$(cat fit-${CLI}-${VERSION}-darwin-arm64.sha256)" >> $GITHUB_OUTPUT
+          ASSET="${CASK}-${VERSION}-darwin-arm64.zip"
+          gh release download "$TAG" --pattern "${ASSET}.sha256" --dir .
+          echo "sha256=$(cat "${ASSET}.sha256")" >> $GITHUB_OUTPUT
         id: hash
 
       - name: Checkout tap repo
@@ -270,51 +536,36 @@ jobs:
 
       - name: Update cask
         env:
-          CLI_NAME: ${{ steps.meta.outputs.cli }}
+          CASK:    ${{ steps.meta.outputs.cask }}
+          NAME:    ${{ steps.meta.outputs.name }}
           VERSION: ${{ steps.meta.outputs.version }}
-          SHA256: ${{ steps.hash.outputs.sha256 }}
+          SHA256:  ${{ steps.hash.outputs.sha256 }}
         run: |
-          CASK_FILE="tap/Casks/fit-${CLI_NAME}.rb"
-          sed \
-            -e "s|__VERSION__|${VERSION}|g" \
-            -e "s|__SHA256__|${SHA256}|g" \
-            -e "s|__CLI__|${CLI_NAME}|g" \
-            > "$CASK_FILE" << 'TEMPLATE'
-          cask "fit-__CLI__" do
-            version "__VERSION__"
-            sha256 "__SHA256__"
-
-            url "https://github.com/forwardimpact/monorepo/releases/download/__CLI__@v#{version}/fit-__CLI__-#{version}-darwin-arm64"
-            name "fit-__CLI__"
-            desc "Forward Impact __CLI__ CLI"
-            homepage "https://www.forwardimpact.team/__CLI__/"
-
-            depends_on arch: :arm64
-
-            binary "fit-__CLI__-#{version}-darwin-arm64", target: "fit-__CLI__"
-
-            livecheck do
-              url "https://github.com/forwardimpact/monorepo/releases?q=__CLI__@v"
-              strategy :github_releases
-              regex(/^__CLI__@v(\d+(?:\.\d+)+)$/i)
-            end
-          end
-          TEMPLATE
+          # Only the version and sha256 are updated per release; the rest of
+          # the cask body lives in the tap repo (see Step 3) and is not
+          # regenerated from this workflow. This avoids clobbering per-cask
+          # differences (e.g. the shared fit-services / fit-utilities casks'
+          # multi-binary stanza lists, and product casks' depends_on graph).
+          CASK_FILE="tap/Casks/${CASK}.rb"
+          sed -i \
+            -e "s|^  version \".*\"|  version \"${VERSION}\"|" \
+            -e "s|^  sha256 \".*\"|  sha256 \"${SHA256}\"|" \
+            "$CASK_FILE"
 
       - name: Open PR
         working-directory: tap
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
         run: |
-          CLI="${{ steps.meta.outputs.cli }}"
+          CASK="${{ steps.meta.outputs.cask }}"
           VERSION="${{ steps.meta.outputs.version }}"
-          BRANCH="update/fit-${CLI}-${VERSION}"
+          BRANCH="update/${CASK}-${VERSION}"
           git checkout -b "$BRANCH"
-          git add "Casks/fit-${CLI}.rb"
-          git commit -m "Update fit-${CLI} to ${VERSION}"
+          git add "Casks/${CASK}.rb"
+          git commit -m "Update ${CASK} to ${VERSION}"
           git push origin "$BRANCH"
           gh pr create \
-            --title "Update fit-${CLI} to ${VERSION}" \
+            --title "Update ${CASK} to ${VERSION}" \
             --body "Automated cask update from monorepo release ${GITHUB_REF_NAME}." \
             --base main
 ```
@@ -332,14 +583,18 @@ jobs:
   and opens a cask-update PR. Runs on cheap Linux since it only does git + gh
   operations.
 
-### Cask template approach
+### Cask update approach
 
-The cask is generated using a quoted heredoc (`<< 'TEMPLATE'`) piped through
-`sed`. The quoted delimiter prevents shell expansion of `#{version}` (Ruby
-interpolation that must survive literally). Shell variables (`VERSION`,
-`SHA256`, `CLI_NAME`) are injected via sed placeholders (`__VERSION__`,
-`__SHA256__`, `__CLI__`). This avoids the fragile mixing of shell `${}` and Ruby
-`#{}` expansion.
+The workflow updates only `version` and `sha256` lines in place via `sed
+-i`. It does **not** regenerate the full cask body. Rationale: the eight
+casks (six product + `fit-services` + `fit-utilities`) differ from each
+other in ways the release workflow shouldn't re-derive every tag — product
+casks declare a `depends_on cask:` list pointing at the shared-bundle
+casks, and the two shared casks enumerate many `binary` stanza lines (one
+per Mach-O they expose). Those structural pieces live in the tap repo
+(seeded by Step 3) and are edited there by humans when the bundle contents
+change. The release workflow's responsibility is narrow: bump the version
+string and hash when a new `.app.zip` ships.
 
 ### Livecheck strategy
 
@@ -384,12 +639,56 @@ scope and rotation cadence.
 ### Verification
 
 - Push a test tag (e.g. `pathway@v0.0.0-test.1`) and verify:
-  1. Single binary built for `pathway` only
-  2. Release created with versioned asset name
-  3. `--help` smoke test passes in CI log
-  4. Tap PR opens with correct cask content (version, sha256, no leading
-     whitespace, `#{version}` Ruby interpolation intact)
-- Delete test tag and release after verification.
+  1. Single bundle (`fit-pathway.app`) built, no other bundles touched.
+  2. Release created with asset name `fit-pathway-0.0.0-test.1-darwin-arm64.zip`.
+  3. `codesign --verify --deep --strict` passes in CI log.
+  4. `--help` smoke test exits 0.
+  5. Tap PR opens and updates only `version` and `sha256` lines in
+     `Casks/fit-pathway.rb`; `depends_on cask:`, `binary`, and
+     `livecheck` stanzas are preserved unchanged.
+- Repeat with `services@v0.0.0-test.1` and `utilities@v0.0.0-test.1` to
+  cover the shared-bundle paths.
+- Delete test tags and releases after verification.
+
+## Step 2b — Verify basecamp's TCC responsibility chain
+
+Before shipping any real `basecamp@v*` tag through the new workflow,
+confirm the shared `libmacos/scripts/build-app.sh` produces a
+`fit-basecamp.app` bundle that still inherits Calendar and Contacts
+grants from macOS TCC.
+
+### Actions
+
+- Build `fit-basecamp.app` via `just build-app-product basecamp`.
+- On a macOS 14+ machine that has already granted Basecamp Calendar and
+  Contacts access via a previous `.pkg` install: fully uninstall the
+  `.pkg`-installed Basecamp, install the newly-built `.app` via the
+  local Homebrew cask from a clone of the tap
+  (`brew install --cask ./Casks/fit-basecamp.rb`). Launch the app,
+  trigger a calendar sync via the scheduler, verify no TCC prompt
+  appears and the sync succeeds.
+- Repeat after bumping basecamp's patch version in `package.json` and
+  rebuilding + reinstalling: no re-prompt is expected because the
+  bundle identifier is stable.
+
+### Verification
+
+```sh
+# While the sync is running, tail the TCC log to confirm the responsible
+# process resolves to the bundle, not to Terminal or the PATH symlink:
+log stream --predicate 'subsystem == "com.apple.tcc"'
+# Expect to see responsible-process lookups resolve to
+# com.forwardimpact.basecamp
+```
+
+Record the test outcome in the implementation PR's description.
+
+### Agent & parallelism
+
+**Agent:** staff-engineer + human tester.
+**Parallelism:** Runs before the first `basecamp@v*` tag is pushed
+through the new workflow. Blocks that tag; does not block Step 3 or
+Step 4.
 
 ## Step 3 — Bootstrap Homebrew tap repository
 
@@ -402,47 +701,113 @@ structure. This step can run in parallel with steps 1–2.
 forwardimpact/homebrew-tap/
 ├── README.md
 ├── Casks/
-│   ├── fit-map.rb
-│   ├── fit-pathway.rb
-│   ├── fit-basecamp.rb
+│   ├── fit-basecamp.rb      # product casks — each depends_on the two shared casks
 │   ├── fit-guide.rb
 │   ├── fit-landmark.rb
+│   ├── fit-map.rb
+│   ├── fit-pathway.rb
 │   ├── fit-summit.rb
-│   └── fit-codegen.rb
+│   ├── fit-services.rb      # shared bundle — FIT Services.app
+│   └── fit-utilities.rb     # shared bundle — FIT Utilities.app
 └── .github/
     └── dependabot.yml
 ```
 
-### Initial cask content
+### Initial cask content — product cask template
 
-Each cask is a placeholder that the first release will overwrite:
+Each product cask installs a `.app` bundle, symlinks its CLI onto PATH,
+and declares `depends_on cask:` on the two shared-bundle casks:
 
 ```ruby
 cask "fit-pathway" do
   version "0.0.0"
   sha256 :no_check
 
-  url "https://github.com/forwardimpact/monorepo/releases/download/pathway@v#{version}/fit-pathway-#{version}-darwin-arm64"
-  name "fit-pathway"
+  url "https://github.com/forwardimpact/monorepo/releases/download/pathway@v#{version}/fit-pathway-#{version}-darwin-arm64.zip"
+  name "Forward Impact Pathway"
   desc "Forward Impact Pathway CLI — navigate engineering skills and careers"
   homepage "https://www.forwardimpact.team/pathway/"
 
   depends_on arch: :arm64
+  depends_on cask: [
+    "forwardimpact/tap/fit-services",
+    "forwardimpact/tap/fit-utilities",
+  ]
 
-  binary "fit-pathway-#{version}-darwin-arm64", target: "fit-pathway"
+  app "fit-pathway.app", target: "Forward Impact/fit-pathway.app"
+  binary "#{appdir}/Forward Impact/fit-pathway.app/Contents/MacOS/fit-pathway"
 
   livecheck do
     url "https://github.com/forwardimpact/monorepo/releases?q=pathway@v"
     strategy :github_releases
     regex(/^pathway@v(\d+(?:\.\d+)+)$/i)
   end
+
+  zap trash: "~/Library/Preferences/com.forwardimpact.pathway.plist"
 end
 ```
 
-Each CLI gets a tailored `desc` matching its product tagline from the Overview
-page. The `sha256 :no_check` placeholder is safe — no release asset exists at
-`v0.0.0`, so `brew install` would fail with a download error, not an integrity
-bypass.
+### Initial cask content — shared bundle cask template
+
+`fit-services.rb` and `fit-utilities.rb` install their respective shared
+bundles and enumerate every Mach-O inside `Contents/MacOS/` as a separate
+`binary` stanza so all exposed CLIs land on PATH:
+
+```ruby
+cask "fit-utilities" do
+  version "0.0.0"
+  sha256 :no_check
+
+  url "https://github.com/forwardimpact/monorepo/releases/download/utilities@v#{version}/fit-utilities-#{version}-darwin-arm64.zip"
+  name "Forward Impact Utilities"
+  desc "Forward Impact library CLIs — fit-codegen, fit-terrain, fit-eval, and more"
+  homepage "https://www.forwardimpact.team/"
+
+  depends_on arch: :arm64
+
+  app "FIT Utilities.app", target: "Forward Impact/FIT Utilities.app"
+
+  # One binary stanza per Mach-O the bundle exposes. Keeping this list
+  # explicit (rather than globbing in the cask) makes the PATH surface
+  # reviewable in code review when the utility set changes.
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-codegen"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-terrain"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-eval"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-doc"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-rc"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-xmr"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-storage"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-logger"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-svscan"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-trace"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-visualize"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-query"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-subjects"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-process-graphs"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-process-resources"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-process-vectors"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-search"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-unary"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-tiktoken"
+  binary "#{appdir}/Forward Impact/FIT Utilities.app/Contents/MacOS/fit-download-bundle"
+
+  livecheck do
+    url "https://github.com/forwardimpact/monorepo/releases?q=utilities@v"
+    strategy :github_releases
+    regex(/^utilities@v(\d+(?:\.\d+)+)$/i)
+  end
+
+  zap trash: "~/Library/Preferences/com.forwardimpact.utilities.plist"
+end
+```
+
+`fit-services.rb` follows the same shape with five `binary` stanzas for the
+gRPC servers (`fit-service-{graph,mcp,pathway,trace,vector}`).
+
+Each product cask gets a tailored `desc` matching the product tagline from
+its Overview page. The `sha256 :no_check` placeholder is safe — no release
+asset exists at `v0.0.0`, so `brew install` would fail with a download
+error, not an integrity bypass.
 
 ### README.md content
 
@@ -504,14 +869,23 @@ npx fit-pathway dev
 
 ```sh
 brew tap forwardimpact/tap
-brew install forwardimpact/tap/fit-pathway
+brew install --cask forwardimpact/tap/fit-pathway
 fit-pathway dev
 ```
 
-> **Unsigned binary.** This binary is not yet code-signed or notarized. macOS
-> will show a Gatekeeper warning on first run. To allow it: open **System
-> Settings → Privacy & Security**, scroll to the "fit-pathway was blocked"
-> message, and click **Open Anyway**. A follow-up release will add signing.
+Installing any product cask automatically pulls in the shared
+`fit-services` and `fit-utilities` casks via `depends_on`. The
+`fit-pathway.app` bundle lands in `/Applications/Forward Impact/` and
+the `fit-pathway` CLI is symlinked onto `PATH`.
+
+> **Unsigned bundle.** This bundle is ad-hoc signed but not yet Developer
+> ID signed or notarized. macOS will show a Gatekeeper warning on first
+> launch for each newly-installed bundle (the product bundle plus the
+> two shared bundles). To allow them: open **System Settings → Privacy
+> & Security → Open Anyway**. Once approved, TCC permission grants and
+> Gatekeeper approvals persist across `brew upgrade` — you won't be
+> re-prompted. A follow-up release will add Developer ID signing to
+> skip the Gatekeeper step entirely.
 
 ````
 
@@ -525,31 +899,37 @@ codegen → init). The brew section omits the codegen step:
 
 ```sh
 brew tap forwardimpact/tap
-brew install forwardimpact/tap/fit-guide
+brew install --cask forwardimpact/tap/fit-guide
 fit-guide init
 ````
 
 Generated gRPC clients are bundled into the brew binary — no `fit-codegen` step
-needed.
+needed. The gRPC service bundles (graph, mcp, pathway, trace, vector)
+install via the `fit-services` shared cask pulled in by `depends_on`.
 
 ````
 
-### fit-codegen
+### fit-codegen and other library CLIs
 
 `fit-codegen` is a library, not a product — it has no Overview page under
-`website/`. Its brew availability is documented in the
+`website/`. It is installed alongside every other library CLI by the
+`fit-utilities` shared cask. Its brew availability is documented in the
 [Codegen Internals](../../website/docs/internals/codegen/index.md) page:
 
 ```md
 ### Install via Homebrew (macOS arm64)
 
-External users on macOS can also install fit-codegen directly:
+External users on macOS can install fit-codegen standalone via the
+shared Utilities bundle:
 
 ```sh
 brew tap forwardimpact/tap
-brew install forwardimpact/tap/fit-codegen
+brew install --cask forwardimpact/tap/fit-utilities
 fit-codegen --all
 ````
+
+Installing any product cask (e.g. `fit-guide`) also installs
+`fit-utilities` automatically via `depends_on`.
 
 ```
 
@@ -607,37 +987,79 @@ fit-codegen --all
    (every user-visible Guide command works without codegen) requires manual
    acceptance testing on a clean macOS machine with no Node/Bun on PATH. The
    implementer should document the acceptance test results.
+9. **Bundle cdhash stability depends on deterministic builds.** Bun's
+   `--compile` is not guaranteed deterministic across bun versions (embedded
+   runtime may shift), and `codesign --deep` signs in directory-order. A
+   rotating cdhash wipes TCC grants on `brew upgrade`. Mitigated by pinning
+   the bun version in CI and adding a check that rebuilds twice and diffs the
+   bundle cdhash; a mismatch fails the release.
+10. **Moving `posix-spawn.js` and `build-app.sh` could break basecamp.**
+    Both files currently live in `products/basecamp/` and Step 1a relocates
+    them to `libraries/libmacos/`. Mitigated by Step 1a running basecamp's
+    full test suite plus Step 2b's manual TCC verification on hardware
+    before any `basecamp@v*` tag is pushed through the new workflow.
+11. **Symlink-from-Terminal TCC responsibility.** PATH symlinks into
+    `.app` bundles make Terminal the TCC-responsible process when a CLI
+    is invoked interactively. No current non-basecamp CLI requests TCC
+    resources, so this is latent; if a future product needs TCC from a
+    Terminal invocation it must ship its own self-disclaim logic using
+    `libraries/libmacos/src/posix-spawn.js`.
 
 ## Libraries used
 
-No new shared `@forwardimpact/lib*` libraries are consumed by this plan.
+**New library introduced by this plan:**
+
+- `@forwardimpact/libmacos` — owns `posix-spawn.js`, `tcc-responsibility.js`,
+  `build-app.sh`, `sign-app.sh`, and the Info.plist / entitlements templates.
+  Darwin-only (`"os": ["darwin"]`). Created in Step 1a; consumed by every
+  bundle-assembly recipe.
 
 Existing libraries consumed transitively (via the CLIs being compiled):
-- `@forwardimpact/librpc` — gRPC clients (guide)
+
+- `@forwardimpact/librpc` — gRPC clients (guide, services/*)
 - `@forwardimpact/libcodegen` — code generation (fit-codegen itself)
 - All other `@forwardimpact/lib*` packages in each CLI's dependency tree are
   bundled by `bun build --compile` — no new dependencies introduced.
 
 Build toolchain: `bun >= 1.3.11` (pinned in `.github/actions/bootstrap`),
-`just` (installed by `scripts/bootstrap.sh`), `gh`.
+`just` (installed by `scripts/bootstrap.sh`), `gh`, `ditto` (macOS native),
+`codesign` (Xcode command-line tools).
 
 ## Execution
 
-**Agent:** `staff-engineer` for steps 1–3 (justfile, workflow, tap
-bootstrap), `technical-writer` for step 4 (documentation).
+**Agent:** `staff-engineer` for Steps 1a, 1b, 2, 3 (libmacos, justfile,
+workflow, tap bootstrap); `staff-engineer + human tester` for Step 2b
+(hardware TCC verification); `technical-writer` for Step 4 (documentation).
 
-**Parallelism:** Step 3 (tap bootstrap) can run in parallel with steps 1–2.
-Step 4 can start once the tap path (`forwardimpact/tap`) is known (it is — from
-the design). Steps 1 → 2 are strictly sequential.
+**Parallelism:**
 
-**PR boundaries:** Steps 1–2 in one monorepo PR (justfile + workflow). Step 3
-is a manual external repo creation. Step 4 in a second monorepo PR (docs only).
+- Step 1a is first and blocks everything bundle-related.
+- Step 1b → Step 2 are strictly sequential after Step 1a (the workflow
+  invokes the recipes).
+- Step 3 (tap bootstrap) can run in parallel with Steps 1a–2 since it
+  creates an external repo with placeholder casks.
+- Step 4 (docs) can start once the tap path (`forwardimpact/tap`) is
+  known (it is — from the design).
+- Step 2b runs on hardware before the first `basecamp@v*` tag is pushed
+  through the new workflow. Blocks that tag only.
 
-**Ordering constraint:** The tap repo (step 3) and `HOMEBREW_TAP_PAT` secret
-must exist before the first release tag triggers the workflow. Coordinate with
-the release engineer.
+**PR boundaries:**
 
-**Recommended:** Staff engineer implements steps 1–2 and opens the PR, creates
-the tap repo (step 3) in parallel, then signals technical writer to start step
-4. If a single agent executes all four, run steps 1 → 2 → 3 → 4 sequentially.
+- Step 1a (libmacos extraction + basecamp migration) in its own monorepo
+  PR — this is a refactor that should land and bake before the bundle
+  pipeline lights up on top of it.
+- Steps 1b–2 in a second monorepo PR (justfile recipes + workflow).
+- Step 3 is a manual external repo creation.
+- Step 4 in a third monorepo PR (docs only).
+
+**Ordering constraint:** The tap repo (Step 3) and `HOMEBREW_TAP_PAT`
+secret must both exist before the first release tag triggers the
+workflow. Step 2b must pass before the first `basecamp@v*` tag.
+Coordinate with the release engineer.
+
+**Recommended:** Staff engineer implements Step 1a and opens the first
+PR, then Steps 1b–2 in the second PR, then creates the tap repo (Step
+3) manually. Technical writer starts Step 4 once the tap path is
+confirmed. Step 2b runs on hardware immediately before the first
+basecamp release.
 ```

--- a/specs/600-native-binary-distribution/plan-a.md
+++ b/specs/600-native-binary-distribution/plan-a.md
@@ -5,16 +5,15 @@ WHICH/WHERE. This plan captures HOW to implement and WHEN to sequence changes.
 
 ## Approach
 
-The implementation has six steps: libmacos extraction (1a), bundle build
-recipes (1b), release workflow (2), basecamp TCC verification (2b), tap
-repository (3), and documentation (4). Step 1a lands first and blocks all
-other bundle-assembly work. Steps 1b and 2 are strictly sequential. Step 3
-(tap repo) can run in parallel with steps 1–2 since it creates an external
-repo with placeholder casks. Step 4 (docs) can run in parallel with step 3.
-Step 2b (manual TCC verification) runs before the first `basecamp@v*` tag
-is pushed through the new workflow. The tap repo and `HOMEBREW_TAP_PAT`
-secret must both exist before the first real release tag is pushed —
-otherwise the `tap-pr` job fails.
+The implementation has six steps: libmacos extraction (1a), bundle build recipes
+(1b), release workflow (2), basecamp TCC verification (2b), tap repository (3),
+and documentation (4). Step 1a lands first and blocks all other bundle-assembly
+work. Steps 1b and 2 are strictly sequential. Step 3 (tap repo) can run in
+parallel with steps 1–2 since it creates an external repo with placeholder
+casks. Step 4 (docs) can run in parallel with step 3. Step 2b (manual TCC
+verification) runs before the first `basecamp@v*` tag is pushed through the new
+workflow. The tap repo and `HOMEBREW_TAP_PAT` secret must both exist before the
+first real release tag is pushed — otherwise the `tap-pr` job fails.
 
 The fit-guide codegen story resolves automatically: `just codegen` runs before
 `bun build --compile`, so generated gRPC clients are bundled into every binary
@@ -25,12 +24,11 @@ via bun's import-graph traversal. No special handling needed — the existing
 
 **Naming convention (deliberate design divergence).** The design specifies
 output path `dist/binaries/<cli>-<os>-<arch>` for Mach-Os and `dist/apps/` for
-`.app` bundles. This plan uses `dist/binaries/fit-<cli>-bun-darwin-arm64` as
-the local Mach-O output — the `bun-` prefix is bun's target triple convention
-and is required by the `--target` flag. Bundle assembly then reads from
-`dist/binaries/` and writes `dist/apps/<Bundle>.app`. The `release-assets`
-job zips each `.app` and uploads as
-`<Bundle>.app-<version>-darwin-arm64.zip`.
+`.app` bundles. This plan uses `dist/binaries/fit-<cli>-bun-darwin-arm64` as the
+local Mach-O output — the `bun-` prefix is bun's target triple convention and is
+required by the `--target` flag. Bundle assembly then reads from
+`dist/binaries/` and writes `dist/apps/<Bundle>.app`. The `release-assets` job
+zips each `.app` and uploads as `<Bundle>.app-<version>-darwin-arm64.zip`.
 
 ## Step 1a — Extract `libraries/libmacos`
 
@@ -44,53 +42,50 @@ migrate basecamp to consume it. This step blocks Step 1b onward.
 - Move `products/basecamp/src/posix-spawn.js` →
   `libraries/libmacos/src/posix-spawn.js`. Rewrite basecamp's imports
   (`products/basecamp/src/agent-runner.js` and any other caller). Add
-  `libraries/libmacos/src/tcc-responsibility.js` — a thin wrapper that
-  spawns a child, disclaims TCC responsibility, and returns an
-  exit-code Promise.
+  `libraries/libmacos/src/tcc-responsibility.js` — a thin wrapper that spawns a
+  child, disclaims TCC responsibility, and returns an exit-code Promise.
 - Generalize `products/basecamp/pkg/macos/build-app.sh` into
-  `libraries/libmacos/scripts/build-app.sh` accepting:
-  `--bundle-name`, `--bundle-id`, `--primary-exec`, `--extra-exec`
-  (repeatable), `--info-plist`, `--entitlements`, `--resource`
-  (repeatable), `--version`, `--out-dir`. Output path
-  `<out-dir>/<bundle-name>.app`.
-- Extract the codesign call into `libraries/libmacos/scripts/sign-app.sh`
-  and have `build-app.sh` invoke it as its final stage.
+  `libraries/libmacos/scripts/build-app.sh` accepting: `--bundle-name`,
+  `--bundle-id`, `--primary-exec`, `--extra-exec` (repeatable), `--info-plist`,
+  `--entitlements`, `--resource` (repeatable), `--version`, `--out-dir`. Output
+  path `<out-dir>/<bundle-name>.app`.
+- Extract the codesign call into `libraries/libmacos/scripts/sign-app.sh` and
+  have `build-app.sh` invoke it as its final stage.
 - Commit default templates:
   - `templates/entitlements.plist` — JIT +
     `com.apple.security.cs.disable-library-validation` only.
   - `templates/entitlements-gui.plist` — seeded from basecamp's current
     `Basecamp.entitlements` (Calendar, Contacts, Network).
-  - `templates/Info.plist.hbs` — template with `{{bundleId}}`,
-    `{{bundleName}}`, `{{executable}}`, `{{version}}`, `{{minOS}}`,
-    `{{lsuiElement}}` placeholders.
-- Delete `products/basecamp/pkg/macos/build-app.sh`. Update basecamp's
-  justfile `build-app` recipe to call `libraries/libmacos/scripts/build-app.sh`
-  with basecamp-specific arguments (Swift launcher as `CFBundleExecutable`,
-  `fit-basecamp` as a secondary Mach-O, `Basecamp.entitlements` as
-  entitlements path, `LSUIElement=true`).
-- Preserve basecamp's existing `.pkg` flow: `pkg/macos/build-pkg.sh`
-  currently depends on `dist/Basecamp.app` being produced by the
-  now-retired `build-app.sh`. The rewired `build-app` recipe must
-  produce a bundle at the same path (`dist/Basecamp.app`) so
-  `build-pkg.sh` keeps working unchanged. If the shared
-  `libmacos/scripts/build-app.sh` output path differs, add a thin
+  - `templates/Info.plist.hbs` — template with `{{bundleId}}`, `{{bundleName}}`,
+    `{{executable}}`, `{{version}}`, `{{minOS}}`, `{{lsuiElement}}`
+    placeholders.
+- Delete `products/basecamp/pkg/macos/build-app.sh`. Update basecamp's justfile
+  `build-app` recipe to call `libraries/libmacos/scripts/build-app.sh` with
+  basecamp-specific arguments (Swift launcher as `CFBundleExecutable`,
+  `fit-basecamp` as a secondary Mach-O, `Basecamp.entitlements` as entitlements
+  path, `LSUIElement=true`).
+- Preserve basecamp's existing `.pkg` flow: `pkg/macos/build-pkg.sh` currently
+  depends on `dist/Basecamp.app` being produced by the now-retired
+  `build-app.sh`. The rewired `build-app` recipe must produce a bundle at the
+  same path (`dist/Basecamp.app`) so `build-pkg.sh` keeps working unchanged. If
+  the shared `libmacos/scripts/build-app.sh` output path differs, add a thin
   basecamp-local recipe that copies / symlinks to the legacy path.
 
 ### Files
 
-| File                                                  | Action                                               |
-| ----------------------------------------------------- | ---------------------------------------------------- |
-| `libraries/libmacos/package.json`                     | Created — `"os": ["darwin"]`                         |
-| `libraries/libmacos/src/posix-spawn.js`               | Created — moved from `products/basecamp/src/`        |
-| `libraries/libmacos/src/tcc-responsibility.js`        | Created                                              |
-| `libraries/libmacos/scripts/build-app.sh`             | Created — generalized from basecamp's `build-app.sh` |
-| `libraries/libmacos/scripts/sign-app.sh`              | Created                                              |
-| `libraries/libmacos/templates/entitlements.plist`     | Created                                              |
-| `libraries/libmacos/templates/entitlements-gui.plist` | Created — seeded from `Basecamp.entitlements`        |
-| `libraries/libmacos/templates/Info.plist.hbs`         | Created                                              |
-| `products/basecamp/src/posix-spawn.js`                | Deleted — moved to libmacos                          |
-| `products/basecamp/src/agent-runner.js`               | Modified — import from `libmacos`                    |
-| `products/basecamp/pkg/macos/build-app.sh`            | Deleted — superseded by `libmacos/scripts/build-app.sh` |
+| File                                                  | Action                                                              |
+| ----------------------------------------------------- | ------------------------------------------------------------------- |
+| `libraries/libmacos/package.json`                     | Created — `"os": ["darwin"]`                                        |
+| `libraries/libmacos/src/posix-spawn.js`               | Created — moved from `products/basecamp/src/`                       |
+| `libraries/libmacos/src/tcc-responsibility.js`        | Created                                                             |
+| `libraries/libmacos/scripts/build-app.sh`             | Created — generalized from basecamp's `build-app.sh`                |
+| `libraries/libmacos/scripts/sign-app.sh`              | Created                                                             |
+| `libraries/libmacos/templates/entitlements.plist`     | Created                                                             |
+| `libraries/libmacos/templates/entitlements-gui.plist` | Created — seeded from `Basecamp.entitlements`                       |
+| `libraries/libmacos/templates/Info.plist.hbs`         | Created                                                             |
+| `products/basecamp/src/posix-spawn.js`                | Deleted — moved to libmacos                                         |
+| `products/basecamp/src/agent-runner.js`               | Modified — import from `libmacos`                                   |
+| `products/basecamp/pkg/macos/build-app.sh`            | Deleted — superseded by `libmacos/scripts/build-app.sh`             |
 | `products/basecamp/justfile`                          | Modified — `build-app` recipe calls `libmacos/scripts/build-app.sh` |
 
 ### Verification
@@ -107,8 +102,8 @@ bun test
 
 ### Agent & parallelism
 
-**Agent:** staff-engineer.
-**Parallelism:** First step. Blocks Step 1b, Step 2, Step 2b.
+**Agent:** staff-engineer. **Parallelism:** First step. Blocks Step 1b, Step 2,
+Step 2b.
 
 ## Step 1b — Bundle recipes in root justfile
 
@@ -119,12 +114,12 @@ Replaces the original Step 1. Drive every bundle through
 
 `NAME` is the full binary name (e.g. `fit-pathway`, `fit-service-graph`,
 `fit-codegen`). The recipe resolves the entry file by scanning every
-`package.json` under `products/`, `services/`, and `libraries/` for a
-`bin` field whose key matches `NAME`, and uses the path that field points
-at as the bun-compile entry. This replaces heuristic-based path guessing
-(like "`libraries/lib<NAME>/bin/fit-<NAME>.js`"), which fails for the many
-library CLIs whose library name doesn't match the CLI name (e.g. `fit-trace`
-lives in `libeval`, `fit-process-graphs` in `libgraph`, `fit-visualize` in
+`package.json` under `products/`, `services/`, and `libraries/` for a `bin`
+field whose key matches `NAME`, and uses the path that field points at as the
+bun-compile entry. This replaces heuristic-based path guessing (like
+"`libraries/lib<NAME>/bin/fit-<NAME>.js`"), which fails for the many library
+CLIs whose library name doesn't match the CLI name (e.g. `fit-trace` lives in
+`libeval`, `fit-process-graphs` in `libgraph`, `fit-visualize` in
 `libtelemetry`).
 
 ```just
@@ -163,24 +158,22 @@ build-binary NAME TARGET="bun-darwin-arm64":
   is already in `.gitignore`. The bundle-assembly step (`build-app-*` below)
   reads from this path.
 
-**Prerequisite for services.** Today `services/<name>/package.json` has no
-`bin` field — each service runs via `bun server.js`. Step 1b adds
+**Prerequisite for services.** Today `services/<name>/package.json` has no `bin`
+field — each service runs via `bun server.js`. Step 1b adds
 `"bin": { "fit-service-<name>": "./server.js" }` to each of the five service
 packages so the same `build-binary` recipe drives them uniformly.
 
-**Codegen.** `build-binary` does not depend on `codegen` as an individual
-recipe — the `build-binaries` fan-out below depends on `codegen` for local
-use, and CI's bootstrap action runs `fit-codegen --all` before the bundle
-job. A contributor running `just build-binary fit-guide` on a tree without
-generated code gets a broken binary; the fan-out is the documented entry
-point.
+**Codegen.** `build-binary` does not depend on `codegen` as an individual recipe
+— the `build-binaries` fan-out below depends on `codegen` for local use, and
+CI's bootstrap action runs `fit-codegen --all` before the bundle job. A
+contributor running `just build-binary fit-guide` on a tree without generated
+code gets a broken binary; the fan-out is the documented entry point.
 
 ### Recipe: `build-binaries`
 
-Each fan-out below uses the real binary names declared in each
-package.json's `bin` field — no aliasing or rename machinery. Service
-binaries get the `fit-service-` prefix so they don't collide with any
-product or library CLI.
+Each fan-out below uses the real binary names declared in each package.json's
+`bin` field — no aliasing or rename machinery. Service binaries get the
+`fit-service-` prefix so they don't collide with any product or library CLI.
 
 ```just
 # Build all Mach-Os for the default target
@@ -228,12 +221,11 @@ build-utility-binaries:
     just build-binary fit-download-bundle
 ```
 
-Sequential execution is intentional — parallel `bun build --compile` can
-exhaust memory on CI runners (each embeds the ~60 MB bun runtime).
-`codegen` runs first so generated gRPC code is current. The canonical
-utility list above must be verified against
-`libraries/*/package.json` during Step 1a implementation and updated if
-any library's `bin` set has changed since this plan was written.
+Sequential execution is intentional — parallel `bun build --compile` can exhaust
+memory on CI runners (each embeds the ~60 MB bun runtime). `codegen` runs first
+so generated gRPC code is current. The canonical utility list above must be
+verified against `libraries/*/package.json` during Step 1a implementation and
+updated if any library's `bin` set has changed since this plan was written.
 
 ### Recipes: `build-app-*`
 
@@ -296,54 +288,53 @@ build-apps: build-binaries
 Create `Info.plist` and `entitlements.plist` alongside each bundle's source
 tree:
 
-- `products/<name>/macos/Info.plist` for the five non-basecamp products —
-  render `libmacos/templates/Info.plist.hbs` with
-  `bundleId=com.forwardimpact.<name>`, `executable=fit-<name>`,
-  `minOS=13.0`, no `NS*UsageDescription` entries. Basecamp already has
-  `products/basecamp/macos/Info.plist` — leave it alone.
-- `products/<name>/macos/entitlements.plist` for the five non-basecamp
-  products — copy `libmacos/templates/entitlements.plist` (JIT +
+- `products/<name>/macos/Info.plist` for the five non-basecamp products — render
+  `libmacos/templates/Info.plist.hbs` with `bundleId=com.forwardimpact.<name>`,
+  `executable=fit-<name>`, `minOS=13.0`, no `NS*UsageDescription` entries.
+  Basecamp already has `products/basecamp/macos/Info.plist` — leave it alone.
+- `products/<name>/macos/entitlements.plist` for the five non-basecamp products
+  — copy `libmacos/templates/entitlements.plist` (JIT +
   disable-library-validation). Basecamp continues to reference
   `products/basecamp/macos/Basecamp.entitlements`.
-- `services/macos/Info.plist` and `services/macos/entitlements.plist` —
-  metadata for `FIT Services.app`. Identifier `com.forwardimpact.services`,
+- `services/macos/Info.plist` and `services/macos/entitlements.plist` — metadata
+  for `FIT Services.app`. Identifier `com.forwardimpact.services`,
   `CFBundleExecutable=fit-service-graph`.
 - `libraries/macos/Info.plist` and `libraries/macos/entitlements.plist` —
-  metadata for `FIT Utilities.app`. Identifier
-  `com.forwardimpact.utilities`, `CFBundleExecutable=fit-codegen`.
+  metadata for `FIT Utilities.app`. Identifier `com.forwardimpact.utilities`,
+  `CFBundleExecutable=fit-codegen`.
 
 ### Service compile targets
 
-Each `services/<name>/package.json` needs a `bin` entry or the equivalent
-so `build-binary <name>` finds an entry point that compiles to
+Each `services/<name>/package.json` needs a `bin` entry or the equivalent so
+`build-binary <name>` finds an entry point that compiles to
 `fit-service-<name>`. Add per-service `bin` fields during Step 1b
 implementation.
 
 ### Recipe placement
 
-Add the binary and bundle recipes under a new `# ── Bundles` section after
-the existing `# ── CLI` section of the root justfile.
+Add the binary and bundle recipes under a new `# ── Bundles` section after the
+existing `# ── CLI` section of the root justfile.
 
 ### Files
 
-| File                                              | Action                                         |
-| ------------------------------------------------- | ---------------------------------------------- |
-| `justfile`                                        | Modified — add binary and bundle recipes       |
-| `products/guide/macos/Info.plist`                 | Created                                        |
-| `products/guide/macos/entitlements.plist`         | Created                                        |
-| `products/landmark/macos/Info.plist`              | Created                                        |
-| `products/landmark/macos/entitlements.plist`      | Created                                        |
-| `products/map/macos/Info.plist`                   | Created                                        |
-| `products/map/macos/entitlements.plist`           | Created                                        |
-| `products/pathway/macos/Info.plist`               | Created                                        |
-| `products/pathway/macos/entitlements.plist`       | Created                                        |
-| `products/summit/macos/Info.plist`                | Created                                        |
-| `products/summit/macos/entitlements.plist`        | Created                                        |
-| `services/macos/Info.plist`                       | Created                                        |
-| `services/macos/entitlements.plist`               | Created                                        |
-| `libraries/macos/Info.plist`                      | Created                                        |
-| `libraries/macos/entitlements.plist`              | Created                                        |
-| `services/*/package.json`                         | Modified — add `bin` fields for compile target |
+| File                                         | Action                                         |
+| -------------------------------------------- | ---------------------------------------------- |
+| `justfile`                                   | Modified — add binary and bundle recipes       |
+| `products/guide/macos/Info.plist`            | Created                                        |
+| `products/guide/macos/entitlements.plist`    | Created                                        |
+| `products/landmark/macos/Info.plist`         | Created                                        |
+| `products/landmark/macos/entitlements.plist` | Created                                        |
+| `products/map/macos/Info.plist`              | Created                                        |
+| `products/map/macos/entitlements.plist`      | Created                                        |
+| `products/pathway/macos/Info.plist`          | Created                                        |
+| `products/pathway/macos/entitlements.plist`  | Created                                        |
+| `products/summit/macos/Info.plist`           | Created                                        |
+| `products/summit/macos/entitlements.plist`   | Created                                        |
+| `services/macos/Info.plist`                  | Created                                        |
+| `services/macos/entitlements.plist`          | Created                                        |
+| `libraries/macos/Info.plist`                 | Created                                        |
+| `libraries/macos/entitlements.plist`         | Created                                        |
+| `services/*/package.json`                    | Modified — add `bin` fields for compile target |
 
 ### Verification
 
@@ -384,17 +375,17 @@ Create `.github/workflows/publish-brew.yml` triggered by release tags.
 
 ### Key design decisions
 
-**Single-bundle build per tag.** The workflow extracts the bundle name from
-the tag and builds only that bundle. Tag shapes:
+**Single-bundle build per tag.** The workflow extracts the bundle name from the
+tag and builds only that bundle. Tag shapes:
 
 - `<product>@v*` (e.g. `pathway@v0.25.32`) — builds `fit-<product>.app` via
   `just build-app-product <product>`.
 - `services@v*` — builds `FIT Services.app` via `just build-app-services`.
 - `utilities@v*` — builds `FIT Utilities.app` via `just build-app-utilities`.
 
-This matches `publish-npm.yml`'s per-package tag semantics — a tag releases
-one artifact, not the full set. Building everything per tag would pollute
-each release with unrelated assets and waste expensive macOS runner minutes.
+This matches `publish-npm.yml`'s per-package tag semantics — a tag releases one
+artifact, not the full set. Building everything per tag would pollute each
+release with unrelated assets and waste expensive macOS runner minutes.
 
 **Codegen chain.** The bootstrap action runs `./scripts/bootstrap.sh` which
 calls `just install` → `install-bun` → `fit-codegen --all`. This ensures
@@ -591,16 +582,15 @@ jobs:
 
 ### Cask update approach
 
-The workflow updates only `version` and `sha256` lines in place via `sed
--i`. It does **not** regenerate the full cask body. Rationale: the eight
-casks (six product + `fit-services` + `fit-utilities`) differ from each
-other in ways the release workflow shouldn't re-derive every tag — product
-casks declare a `depends_on cask:` list pointing at the shared-bundle
-casks, and the two shared casks enumerate many `binary` stanza lines (one
-per Mach-O they expose). Those structural pieces live in the tap repo
-(seeded by Step 3) and are edited there by humans when the bundle contents
-change. The release workflow's responsibility is narrow: bump the version
-string and hash when a new `.app.zip` ships.
+The workflow updates only `version` and `sha256` lines in place via `sed -i`. It
+does **not** regenerate the full cask body. Rationale: the eight casks (six
+product + `fit-services` + `fit-utilities`) differ from each other in ways the
+release workflow shouldn't re-derive every tag — product casks declare a
+`depends_on cask:` list pointing at the shared-bundle casks, and the two shared
+casks enumerate many `binary` stanza lines (one per Mach-O they expose). Those
+structural pieces live in the tap repo (seeded by Step 3) and are edited there
+by humans when the bundle contents change. The release workflow's responsibility
+is narrow: bump the version string and hash when a new `.app.zip` ships.
 
 ### Livecheck strategy
 
@@ -646,36 +636,35 @@ scope and rotation cadence.
 
 - Push a test tag (e.g. `pathway@v0.0.0-test.1`) and verify:
   1. Single bundle (`fit-pathway.app`) built, no other bundles touched.
-  2. Release created with asset name `fit-pathway-0.0.0-test.1-darwin-arm64.zip`.
+  2. Release created with asset name
+     `fit-pathway-0.0.0-test.1-darwin-arm64.zip`.
   3. `codesign --verify --deep --strict` passes in CI log.
   4. `--help` smoke test exits 0.
   5. Tap PR opens and updates only `version` and `sha256` lines in
-     `Casks/fit-pathway.rb`; `depends_on cask:`, `binary`, and
-     `livecheck` stanzas are preserved unchanged.
-- Repeat with `services@v0.0.0-test.1` and `utilities@v0.0.0-test.1` to
-  cover the shared-bundle paths.
+     `Casks/fit-pathway.rb`; `depends_on cask:`, `binary`, and `livecheck`
+     stanzas are preserved unchanged.
+- Repeat with `services@v0.0.0-test.1` and `utilities@v0.0.0-test.1` to cover
+  the shared-bundle paths.
 - Delete test tags and releases after verification.
 
 ## Step 2b — Verify basecamp's TCC responsibility chain
 
-Before shipping any real `basecamp@v*` tag through the new workflow,
-confirm the shared `libmacos/scripts/build-app.sh` produces a
-`fit-basecamp.app` bundle that still inherits Calendar and Contacts
-grants from macOS TCC.
+Before shipping any real `basecamp@v*` tag through the new workflow, confirm the
+shared `libmacos/scripts/build-app.sh` produces a `fit-basecamp.app` bundle that
+still inherits Calendar and Contacts grants from macOS TCC.
 
 ### Actions
 
 - Build `fit-basecamp.app` via `just build-app-product basecamp`.
-- On a macOS 14+ machine that has already granted Basecamp Calendar and
-  Contacts access via a previous `.pkg` install: fully uninstall the
-  `.pkg`-installed Basecamp, install the newly-built `.app` via the
-  local Homebrew cask from a clone of the tap
-  (`brew install --cask ./Casks/fit-basecamp.rb`). Launch the app,
-  trigger a calendar sync via the scheduler, verify no TCC prompt
-  appears and the sync succeeds.
+- On a macOS 14+ machine that has already granted Basecamp Calendar and Contacts
+  access via a previous `.pkg` install: fully uninstall the `.pkg`-installed
+  Basecamp, install the newly-built `.app` via the local Homebrew cask from a
+  clone of the tap (`brew install --cask ./Casks/fit-basecamp.rb`). Launch the
+  app, trigger a calendar sync via the scheduler, verify no TCC prompt appears
+  and the sync succeeds.
 - Repeat after bumping basecamp's patch version in `package.json` and
-  rebuilding + reinstalling: no re-prompt is expected because the
-  bundle identifier is stable.
+  rebuilding + reinstalling: no re-prompt is expected because the bundle
+  identifier is stable.
 
 ### Verification
 
@@ -691,10 +680,9 @@ Record the test outcome in the implementation PR's description.
 
 ### Agent & parallelism
 
-**Agent:** staff-engineer + human tester.
-**Parallelism:** Runs before the first `basecamp@v*` tag is pushed
-through the new workflow. Blocks that tag; does not block Step 3 or
-Step 4.
+**Agent:** staff-engineer + human tester. **Parallelism:** Runs before the first
+`basecamp@v*` tag is pushed through the new workflow. Blocks that tag; does not
+block Step 3 or Step 4.
 
 ## Step 3 — Bootstrap Homebrew tap repository
 
@@ -721,8 +709,8 @@ forwardimpact/homebrew-tap/
 
 ### Initial cask content — product cask template
 
-Each product cask installs a `.app` bundle, symlinks its CLI onto PATH,
-and declares `depends_on cask:` on the two shared-bundle casks:
+Each product cask installs a `.app` bundle, symlinks its CLI onto PATH, and
+declares `depends_on cask:` on the two shared-bundle casks:
 
 ```ruby
 cask "fit-pathway" do
@@ -755,9 +743,9 @@ end
 
 ### Initial cask content — shared bundle cask template
 
-`fit-services.rb` and `fit-utilities.rb` install their respective shared
-bundles and enumerate every Mach-O inside `Contents/MacOS/` as a separate
-`binary` stanza so all exposed CLIs land on PATH:
+`fit-services.rb` and `fit-utilities.rb` install their respective shared bundles
+and enumerate every Mach-O inside `Contents/MacOS/` as a separate `binary`
+stanza so all exposed CLIs land on PATH:
 
 ```ruby
 cask "fit-utilities" do
@@ -807,15 +795,15 @@ cask "fit-utilities" do
 end
 ```
 
-`fit-services.rb` follows the same shape with five `binary` stanzas for the
-gRPC servers (`fit-service-{graph,mcp,pathway,trace,vector}`).
+`fit-services.rb` follows the same shape with five `binary` stanzas for the gRPC
+servers (`fit-service-{graph,mcp,pathway,trace,vector}`).
 
-Each product cask gets a tailored `desc` matching the product tagline from
-its Overview page. The all-zero `sha256` placeholder is safe — no release
-asset exists at `v0.0.0`, so `brew install` would fail with a download
-error, not an integrity bypass. The placeholder's quoted-string form
-matches the shape Step 2's `sed -i` cask-update edits on first release,
-so the initial `version` / `sha256` bump is mechanical.
+Each product cask gets a tailored `desc` matching the product tagline from its
+Overview page. The all-zero `sha256` placeholder is safe — no release asset
+exists at `v0.0.0`, so `brew install` would fail with a download error, not an
+integrity bypass. The placeholder's quoted-string form matches the shape Step
+2's `sed -i` cask-update edits on first release, so the initial `version` /
+`sha256` bump is mechanical.
 
 ### README.md content
 
@@ -840,9 +828,9 @@ brew info forwardimpact/tap/fit-pathway
 
 ## Step 4 — Product overview documentation
 
-Add a brew install section to each of the six product Overview pages and to
-the codegen internals page. Each page gets a "Getting Started" section
-update showing both npm and brew paths.
+Add a brew install section to each of the six product Overview pages and to the
+codegen internals page. Each page gets a "Getting Started" section update
+showing both npm and brew paths.
 
 ### Pattern
 
@@ -881,19 +869,18 @@ brew install --cask forwardimpact/tap/fit-pathway
 fit-pathway dev
 ```
 
-Installing any product cask automatically pulls in the shared
-`fit-services` and `fit-utilities` casks via `depends_on`. The
-`fit-pathway.app` bundle lands in `/Applications/Forward Impact/` and
-the `fit-pathway` CLI is symlinked onto `PATH`.
+Installing any product cask automatically pulls in the shared `fit-services` and
+`fit-utilities` casks via `depends_on`. The `fit-pathway.app` bundle lands in
+`/Applications/Forward Impact/` and the `fit-pathway` CLI is symlinked onto
+`PATH`.
 
-> **Unsigned bundle.** This bundle is ad-hoc signed but not yet Developer
-> ID signed or notarized. macOS will show a Gatekeeper warning on first
-> launch for each newly-installed bundle (the product bundle plus the
-> two shared bundles). To allow them: open **System Settings → Privacy
-> & Security → Open Anyway**. Once approved, TCC permission grants and
-> Gatekeeper approvals persist across `brew upgrade` — you won't be
-> re-prompted. A follow-up release will add Developer ID signing to
-> skip the Gatekeeper step entirely.
+> **Unsigned bundle.** This bundle is ad-hoc signed but not yet Developer ID
+> signed or notarized. macOS will show a Gatekeeper warning on first launch for
+> each newly-installed bundle (the product bundle plus the two shared bundles).
+> To allow them: open **System Settings → Privacy & Security → Open Anyway**.
+> Once approved, TCC permission grants and Gatekeeper approvals persist across
+> `brew upgrade` — you won't be re-prompted. A follow-up release will add
+> Developer ID signing to skip the Gatekeeper step entirely.
 
 ````
 
@@ -912,8 +899,8 @@ fit-guide init
 ````
 
 Generated gRPC clients are bundled into the brew binary — no `fit-codegen` step
-needed. The gRPC service bundles (graph, mcp, pathway, trace, vector)
-install via the `fit-services` shared cask pulled in by `depends_on`.
+needed. The gRPC service bundles (graph, mcp, pathway, trace, vector) install
+via the `fit-services` shared cask pulled in by `depends_on`.
 
 ````
 
@@ -936,8 +923,8 @@ brew install --cask forwardimpact/tap/fit-utilities
 fit-codegen --all
 ````
 
-Installing any product cask (e.g. `fit-guide`) also installs
-`fit-utilities` automatically via `depends_on`.
+Installing any product cask (e.g. `fit-guide`) also installs `fit-utilities`
+automatically via `depends_on`.
 
 ```
 

--- a/specs/600-native-binary-distribution/spec.md
+++ b/specs/600-native-binary-distribution/spec.md
@@ -47,35 +47,34 @@ on macOS additionally get a zero-Node option via Homebrew.
 
 Four new capabilities:
 
-1. **macOS `.app` bundle build targets.** Every compiled artifact ships as a
-   real macOS `.app` bundle, not a bare Mach-O. Three categories of bundle are
-   produced: (a) one per-product bundle for each of the six products
-   (`fit-basecamp.app`, `fit-guide.app`, `fit-landmark.app`, `fit-map.app`,
-   `fit-pathway.app`, `fit-summit.app`), (b) a shared `FIT Services.app`
-   containing the gRPC servers from `services/`, (c) a shared `FIT Utilities.app`
-   containing the library CLIs from `libraries/*` that have a `bin` field
-   (including `fit-codegen`, `fit-terrain`, `fit-eval`, and the rest). Each
-   bundle carries its own `Contents/Info.plist`, `entitlements.plist`, and
-   ad-hoc code signature with a stable `CFBundleIdentifier`. No Node, no Bun,
-   no runtime dependency on user-side tooling.
+1. **macOS `.app` bundle build targets.** Every compiled artifact ships as
+   a real macOS `.app` bundle, not a bare Mach-O. Three categories of bundle
+   are produced: (a) one per-product bundle for each of the six products,
+   (b) a shared bundle containing every gRPC server under `services/`,
+   (c) a shared bundle containing every library CLI under `libraries/*`
+   that has a `bin` field. Each bundle carries its own `Info.plist`,
+   entitlements, and ad-hoc code signature. The exact bundle names,
+   identifiers, and the enumeration of library CLIs that go into the
+   shared bundles are design decisions. No Node, no Bun, no runtime
+   dependency on user-side tooling.
 2. **Release-workflow artifact publishing.** Release automation, triggered on
    release tag, builds the bundles and attaches them to the GitHub release as
    downloadable assets, one `.app.zip` per bundle per target triple. The CI
    platform and workflow layout are design decisions.
-3. **Homebrew tap distribution.** A Homebrew tap exposes eight cask packages:
-   one per product bundle plus `fit-services` and `fit-utilities` for the two
-   shared bundles. Each product cask `depends_on` the two shared-bundle casks,
-   and every cask's `binary` stanza symlinks the `fit-*` Mach-Os out of
-   `Contents/MacOS/` onto the user's `PATH`.
-4. **macOS TCC compatibility.** Each bundle carries a stable
-   `CFBundleIdentifier`-based designated requirement across rebuilds, declares
-   the entitlements bun's JavaScriptCore JIT needs
-   (`com.apple.security.cs.allow-jit`,
-   `com.apple.security.cs.disable-library-validation`), and exposes any
-   `NS*UsageDescription` strings via `Contents/Info.plist` for TCC-gated
-   resources the bundle's executables access. Adding Developer ID signing +
-   notarization in a follow-up spec is a drop-in **replacement of the signing
-   identity**, not a rebuild of the metadata layer.
+3. **Homebrew tap distribution.** A Homebrew tap exposes one cask per
+   bundle: a product cask for each of the six products plus one cask for
+   each shared bundle. Installing a product cask transitively installs the
+   two shared-bundle casks, and every `fit-*` CLI the bundles surface ends
+   up on the user's `PATH`. Tap location, cask names, and the specific
+   Homebrew stanzas used are design decisions.
+4. **macOS TCC compatibility.** Each bundle carries a stable, content-hash-
+   independent designated requirement across rebuilds, is ad-hoc signed
+   with Hardened Runtime enabled, and declares the entitlements bun's
+   JavaScriptCore JIT needs. Bundles whose executables access TCC-gated
+   resources (Calendar, Contacts, etc.) also carry the usage-description
+   strings macOS requires before prompting. Adding Developer ID signing
+   and notarization in a follow-up spec is a drop-in **replacement of the
+   signing identity**, not a rebuild of the metadata layer.
 
 The intent is deliberately narrow: preserve every existing install path,
 behaviour, and CLI surface unchanged, and add one new way to get the same
@@ -85,12 +84,16 @@ executables onto a macOS machine without installing Node.
 
 ### Included
 
-- All seven `fit-*` CLIs listed above, each buildable as a standalone native
-  binary.
+- Every `fit-*` CLI listed in the Problem section plus every gRPC service
+  under `services/` and every library CLI under `libraries/*` with a `bin`
+  field is reachable through the new channel — either as the primary
+  executable of a per-product bundle, or as a named Mach-O inside one of
+  the two shared bundles.
 - macOS arm64 as the primary and required target at acceptance.
-- A release automation workflow that builds the binaries on release tag and
+- A release automation workflow that builds the bundles on release tag and
   attaches them to the GitHub release.
-- A Homebrew tap with one installable package per CLI.
+- A Homebrew tap with one cask per bundle (six product casks plus the two
+  shared-bundle casks).
 - Documentation of the brew install flow on the per-product Overview pages
   linked from [`CLAUDE.md` § Products](../../CLAUDE.md) for every affected
   product.
@@ -121,13 +124,18 @@ executables onto a macOS machine without installing Node.
   with the minimal JIT entitlement set and no usage-description strings.
   Adding new TCC-gated resources to any CLI is a per-bundle change, not a
   spec-600 concern.
-- **Symlink-from-Terminal TCC responsibility.** When a user invokes a CLI
-  via its PATH symlink (`/usr/local/bin/fit-<cli>` → the `.app` bundle's
-  `Contents/MacOS/fit-<cli>`), Terminal becomes the TCC-responsible process
-  rather than the bundle. This only matters for CLIs that request
-  TCC-gated resources and is out of scope; `fit-basecamp`'s scheduler is
-  invoked by `fit-basecamp.app`, not from Terminal, so its TCC grants
-  attach to the bundle correctly.
+- **Fixing Terminal-inherited TCC responsibility for PATH symlinks.**
+  Capability #3 requires that every CLI still be invokable from Terminal
+  through the cask's `binary` symlink; that is in scope and must work.
+  What is **out** of scope is changing which process macOS considers
+  TCC-responsible in that case: when the CLI launches via the symlink,
+  Terminal (not the bundle) is the responsible process, which only
+  matters for CLIs that actively request TCC-gated resources like
+  Calendar or Contacts. No non-basecamp CLI does so today, and
+  `fit-basecamp`'s scheduler is launched by the `fit-basecamp.app`
+  bundle rather than from Terminal, so its TCC grants already attach
+  to the bundle correctly. Adding a self-disclaim helper for a future
+  Terminal-invoked TCC-gated CLI is deferred.
 - **Replacing or modifying the existing npm channel.** `npm install` /
   `npx fit-*` continues to work identically. No CLI is removed from npm, no
   shebang is rewritten, and no existing user workflow changes.
@@ -137,19 +145,23 @@ executables onto a macOS machine without installing Node.
 ## Success Criteria
 
 1. A single documented build entry point produces a standalone macOS arm64
-   native binary for each of the seven `fit-*` CLIs. Each binary runs its
-   `--help` successfully on a macOS arm64 machine that has neither `node` nor
-   `bun` on `PATH`.
-2. A release-automation workflow, triggered by a release tag, builds the full
-   binary set and attaches the binaries to the GitHub release as downloadable
-   assets, with a deterministic asset-name scheme that identifies the CLI and
-   target triple.
-3. A Homebrew tap contains one installable package per CLI. Each package
-   references the GitHub release artifact for the CLI and target triple.
-4. On a clean macOS arm64 machine with Homebrew installed but no Node and no
-   Bun, running `brew install <tap>/fit-<cli>` for each of the seven CLIs leaves
-   each corresponding `fit-<cli>` command on `PATH` answering `--help`. The
-   concrete tap path is fixed by design.
+   release artifact for each of the eight bundles in scope (six per-product
+   plus the two shared bundles). Every `fit-*` CLI surfaced by those
+   bundles runs its `--help` successfully on a macOS arm64 machine that
+   has neither `node` nor `bun` on `PATH`.
+2. A release-automation workflow, triggered by a release tag, builds the
+   artifact for that tag and attaches it to the GitHub release as a
+   downloadable asset, with a deterministic asset-name scheme that
+   identifies the bundle and target triple.
+3. A Homebrew tap contains one cask per bundle. Each cask references the
+   GitHub release artifact for that bundle and target triple, and product
+   casks declare a dependency on the two shared-bundle casks so installing
+   a product cask delivers the full runtime.
+4. On a clean macOS arm64 machine with Homebrew installed but no Node and
+   no Bun, running the brew install command published on each affected
+   product's Overview page leaves every `fit-*` CLI surfaced by the
+   bundles on the user's `PATH`, each answering `--help`. The concrete tap
+   path and cask names are fixed by design.
 5. After installing `fit-guide` exclusively via brew — no npm, no post-install
    command — the user can run `fit-guide --help` and every user-visible command
    documented in the [Guide Overview](../../website/guide/index.md) with no
@@ -164,31 +176,32 @@ executables onto a macOS machine without installing Node.
    `npm install` followed by `npx fit-<cli> --help` succeeds on a reference Node
    LTS environment after the release that ships the brew channel. No `bin`
    script, `package.json` `bin` entry, or shebang has changed.
-8. **Stable bundle identity.** Rebuilding any bundle from the same source tree
-   and re-installing via `brew upgrade` on a machine that previously granted a
-   TCC permission keeps the grant — the user is not re-prompted. Verified by:
-   `codesign -dvvv <Bundle>.app` shows
-   `Identifier=com.forwardimpact.<bundle>`, and the bundle's signed cdhash is
-   stable across clean rebuilds of the same commit.
-9. **Entitlements and Info.plist present on every bundle.** For each of the
-   eight bundles (six product bundles, `FIT Services.app`, `FIT Utilities.app`),
-   `Contents/Info.plist` contains `CFBundleIdentifier =
-   com.forwardimpact.<bundle>` and `CFBundleShortVersionString` matching the
-   release tag; `codesign -d --entitlements - <Bundle>.app` prints an
-   entitlements plist containing `com.apple.security.cs.allow-jit`.
-10. **`fit-basecamp` TCC responsibility chain intact.** The `fit-basecamp.app`
-    bundle built through the shared bundle-assembly recipe still inherits TCC
-    grants when launched, and its scheduler still disclaims responsibility
-    when spawning `claude`. Verified by: Basecamp's existing Calendar and
-    Contacts integration continues to work after migrating to the shared
-    recipe.
-11. **Homebrew cask install adds CLIs to PATH.** After
-    `brew install --cask forwardimpact/tap/fit-<product>` for any product,
-    both `/Applications/Forward Impact/fit-<product>.app` and
-    `/usr/local/bin/fit-<product>` exist, and the CLI answers `--help`
-    successfully. The product cask's `depends_on` pulls in the
-    `fit-services` and `fit-utilities` casks automatically, leaving the
-    shared-bundle CLIs (e.g. `fit-codegen`, `fit-terrain`) on PATH as well.
+8. **Stable bundle identity.** Rebuilding any bundle from the same source
+   tree and re-installing via `brew upgrade` on a machine that previously
+   granted it a TCC permission keeps the grant — the user is not
+   re-prompted. The bundle's designated-requirement identity is stable
+   across rebuilds of the same commit.
+9. **Entitlements and Info.plist present on every bundle.** Every bundle
+   carries a `Contents/Info.plist` declaring a bundle identifier and a
+   version string matching the release tag, and is ad-hoc signed with an
+   entitlements set that unlocks bun's JavaScriptCore JIT under Hardened
+   Runtime. The exact identifier scheme, entitlement keys, and
+   verification commands are design decisions.
+10. **`fit-basecamp` TCC responsibility chain intact.** Basecamp's existing
+    Calendar and Contacts integration continues to work after migrating to
+    the shared bundle-assembly recipe, and its scheduler still disclaims
+    TCC responsibility when spawning `claude`. Verified by a manual
+    hardware test on macOS 14+ that launches the rebuilt bundle, triggers
+    a calendar sync, and observes no TCC prompt plus a
+    responsible-process lookup that resolves to the basecamp bundle
+    (specific `log stream` predicate is a plan decision).
+11. **Homebrew cask install surfaces every CLI on `PATH`.** After the
+    documented `brew install` command for any product cask runs on a
+    clean macOS arm64 machine, every `fit-*` CLI surfaced by that product
+    and by the two shared bundles that `depends_on` pulls in is on the
+    user's `PATH` and answers `--help`. The specific `/Applications/…`
+    install location and the PATH-symlink directory are Homebrew-prefix
+    dependent and are design decisions, not acceptance literals.
 
 ## Open questions
 

--- a/specs/600-native-binary-distribution/spec.md
+++ b/specs/600-native-binary-distribution/spec.md
@@ -45,23 +45,37 @@ Add a **second distribution channel**, alongside (not replacing) the existing
 npm channel. External users keep `npm install` / `npx fit-*` as today; new users
 on macOS additionally get a zero-Node option via Homebrew.
 
-Three new capabilities:
+Four new capabilities:
 
-1. **Native binary build targets.** Each `fit-*` CLI has a single documented
-   build entry point that produces a fully-bundled standalone native executable
-   — no Node, no Bun, no runtime dependency on user-side tooling. The
-   executables cover all seven current CLIs (`fit-map`, `fit-pathway`,
-   `fit-basecamp`, `fit-guide`, `fit-landmark`, `fit-summit`, `fit-codegen`).
-   The build toolchain and entry-point naming are design decisions.
+1. **macOS `.app` bundle build targets.** Every compiled artifact ships as a
+   real macOS `.app` bundle, not a bare Mach-O. Three categories of bundle are
+   produced: (a) one per-product bundle for each of the six products
+   (`fit-basecamp.app`, `fit-guide.app`, `fit-landmark.app`, `fit-map.app`,
+   `fit-pathway.app`, `fit-summit.app`), (b) a shared `FIT Services.app`
+   containing the gRPC servers from `services/`, (c) a shared `FIT Utilities.app`
+   containing the library CLIs from `libraries/*` that have a `bin` field
+   (including `fit-codegen`, `fit-terrain`, `fit-eval`, and the rest). Each
+   bundle carries its own `Contents/Info.plist`, `entitlements.plist`, and
+   ad-hoc code signature with a stable `CFBundleIdentifier`. No Node, no Bun,
+   no runtime dependency on user-side tooling.
 2. **Release-workflow artifact publishing.** Release automation, triggered on
-   release tag, builds the binaries and attaches them to the GitHub release as
-   downloadable assets, one per CLI per target triple. The CI platform and
-   workflow layout are design decisions.
-3. **Homebrew tap distribution.** A Homebrew tap exposes one installable package
-   per CLI. Each package installs its matching GitHub release artifact and
-   places the binary on the user's `PATH`. Tap location, packaging format (cask
-   vs. formula), and release-sync mechanism are design decisions (see Open
-   Questions).
+   release tag, builds the bundles and attaches them to the GitHub release as
+   downloadable assets, one `.app.zip` per bundle per target triple. The CI
+   platform and workflow layout are design decisions.
+3. **Homebrew tap distribution.** A Homebrew tap exposes eight cask packages:
+   one per product bundle plus `fit-services` and `fit-utilities` for the two
+   shared bundles. Each product cask `depends_on` the two shared-bundle casks,
+   and every cask's `binary` stanza symlinks the `fit-*` Mach-Os out of
+   `Contents/MacOS/` onto the user's `PATH`.
+4. **macOS TCC compatibility.** Each bundle carries a stable
+   `CFBundleIdentifier`-based designated requirement across rebuilds, declares
+   the entitlements bun's JavaScriptCore JIT needs
+   (`com.apple.security.cs.allow-jit`,
+   `com.apple.security.cs.disable-library-validation`), and exposes any
+   `NS*UsageDescription` strings via `Contents/Info.plist` for TCC-gated
+   resources the bundle's executables access. Adding Developer ID signing +
+   notarization in a follow-up spec is a drop-in **replacement of the signing
+   identity**, not a rebuild of the metadata layer.
 
 The intent is deliberately narrow: preserve every existing install path,
 behaviour, and CLI surface unchanged, and add one new way to get the same
@@ -94,11 +108,26 @@ executables onto a macOS machine without installing Node.
 - **Linux distribution.** Whether Linux users get Linuxbrew, apt/dnf packaging,
   raw tarballs, or none of the above is out of scope. Linux users continue via
   the existing npm channel for now.
-- **Code signing and notarization.** Unsigned binaries will trigger Gatekeeper
-  warnings on macOS that the user must acknowledge before first run. The
-  security and UX implications are real but resolving them — Developer ID
-  certificate, notarization pipeline, hardened runtime, stapling — is deferred
-  to a follow-up spec. This spec must not claim signing as complete.
+- **Apple Developer ID signing and notarization.** Obtaining a paid Developer
+  ID certificate, running `notarytool submit`, stapling, and the
+  Gatekeeper-clean first-run experience are deferred to a follow-up spec.
+  This spec lands **ad-hoc** signing (`codesign --sign -`) on every bundle
+  with correct entitlements and `Contents/Info.plist`, so the follow-up is a
+  signing-identity swap only. Unsigned-by-Apple bundles still trigger
+  Gatekeeper warnings on first run, which the user must acknowledge. This
+  spec must not claim Developer ID signing as complete.
+- **TCC prompts for resources no current CLI accesses.** Only `fit-basecamp`
+  requests Calendar, Contacts, and Downloads today. The other bundles ship
+  with the minimal JIT entitlement set and no usage-description strings.
+  Adding new TCC-gated resources to any CLI is a per-bundle change, not a
+  spec-600 concern.
+- **Symlink-from-Terminal TCC responsibility.** When a user invokes a CLI
+  via its PATH symlink (`/usr/local/bin/fit-<cli>` → the `.app` bundle's
+  `Contents/MacOS/fit-<cli>`), Terminal becomes the TCC-responsible process
+  rather than the bundle. This only matters for CLIs that request
+  TCC-gated resources and is out of scope; `fit-basecamp`'s scheduler is
+  invoked by `fit-basecamp.app`, not from Terminal, so its TCC grants
+  attach to the bundle correctly.
 - **Replacing or modifying the existing npm channel.** `npm install` /
   `npx fit-*` continues to work identically. No CLI is removed from npm, no
   shebang is rewritten, and no existing user workflow changes.
@@ -135,6 +164,31 @@ executables onto a macOS machine without installing Node.
    `npm install` followed by `npx fit-<cli> --help` succeeds on a reference Node
    LTS environment after the release that ships the brew channel. No `bin`
    script, `package.json` `bin` entry, or shebang has changed.
+8. **Stable bundle identity.** Rebuilding any bundle from the same source tree
+   and re-installing via `brew upgrade` on a machine that previously granted a
+   TCC permission keeps the grant — the user is not re-prompted. Verified by:
+   `codesign -dvvv <Bundle>.app` shows
+   `Identifier=com.forwardimpact.<bundle>`, and the bundle's signed cdhash is
+   stable across clean rebuilds of the same commit.
+9. **Entitlements and Info.plist present on every bundle.** For each of the
+   eight bundles (six product bundles, `FIT Services.app`, `FIT Utilities.app`),
+   `Contents/Info.plist` contains `CFBundleIdentifier =
+   com.forwardimpact.<bundle>` and `CFBundleShortVersionString` matching the
+   release tag; `codesign -d --entitlements - <Bundle>.app` prints an
+   entitlements plist containing `com.apple.security.cs.allow-jit`.
+10. **`fit-basecamp` TCC responsibility chain intact.** The `fit-basecamp.app`
+    bundle built through the shared bundle-assembly recipe still inherits TCC
+    grants when launched, and its scheduler still disclaims responsibility
+    when spawning `claude`. Verified by: Basecamp's existing Calendar and
+    Contacts integration continues to work after migrating to the shared
+    recipe.
+11. **Homebrew cask install adds CLIs to PATH.** After
+    `brew install --cask forwardimpact/tap/fit-<product>` for any product,
+    both `/Applications/Forward Impact/fit-<product>.app` and
+    `/usr/local/bin/fit-<product>` exist, and the CLI answers `--help`
+    successfully. The product cask's `depends_on` pulls in the
+    `fit-services` and `fit-utilities` casks automatically, leaving the
+    shared-bundle CLIs (e.g. `fit-codegen`, `fit-terrain`) on PATH as well.
 
 ## Open questions
 

--- a/specs/600-native-binary-distribution/spec.md
+++ b/specs/600-native-binary-distribution/spec.md
@@ -47,34 +47,33 @@ on macOS additionally get a zero-Node option via Homebrew.
 
 Four new capabilities:
 
-1. **macOS `.app` bundle build targets.** Every compiled artifact ships as
-   a real macOS `.app` bundle, not a bare Mach-O. Three categories of bundle
-   are produced: (a) one per-product bundle for each of the six products,
-   (b) a shared bundle containing every gRPC server under `services/`,
-   (c) a shared bundle containing every library CLI under `libraries/*`
-   that has a `bin` field. Each bundle carries its own `Info.plist`,
-   entitlements, and ad-hoc code signature. The exact bundle names,
-   identifiers, and the enumeration of library CLIs that go into the
-   shared bundles are design decisions. No Node, no Bun, no runtime
-   dependency on user-side tooling.
+1. **macOS `.app` bundle build targets.** Every compiled artifact ships as a
+   real macOS `.app` bundle, not a bare Mach-O. Three categories of bundle are
+   produced: (a) one per-product bundle for each of the six products, (b) a
+   shared bundle containing every gRPC server under `services/`, (c) a shared
+   bundle containing every library CLI under `libraries/*` that has a `bin`
+   field. Each bundle carries its own `Info.plist`, entitlements, and ad-hoc
+   code signature. The exact bundle names, identifiers, and the enumeration of
+   library CLIs that go into the shared bundles are design decisions. No Node,
+   no Bun, no runtime dependency on user-side tooling.
 2. **Release-workflow artifact publishing.** Release automation, triggered on
    release tag, builds the bundles and attaches them to the GitHub release as
    downloadable assets, one `.app.zip` per bundle per target triple. The CI
    platform and workflow layout are design decisions.
-3. **Homebrew tap distribution.** A Homebrew tap exposes one cask per
-   bundle: a product cask for each of the six products plus one cask for
-   each shared bundle. Installing a product cask transitively installs the
-   two shared-bundle casks, and every `fit-*` CLI the bundles surface ends
-   up on the user's `PATH`. Tap location, cask names, and the specific
-   Homebrew stanzas used are design decisions.
+3. **Homebrew tap distribution.** A Homebrew tap exposes one cask per bundle: a
+   product cask for each of the six products plus one cask for each shared
+   bundle. Installing a product cask transitively installs the two shared-bundle
+   casks, and every `fit-*` CLI the bundles surface ends up on the user's
+   `PATH`. Tap location, cask names, and the specific Homebrew stanzas used are
+   design decisions.
 4. **macOS TCC compatibility.** Each bundle carries a stable, content-hash-
-   independent designated requirement across rebuilds, is ad-hoc signed
-   with Hardened Runtime enabled, and declares the entitlements bun's
-   JavaScriptCore JIT needs. Bundles whose executables access TCC-gated
-   resources (Calendar, Contacts, etc.) also carry the usage-description
-   strings macOS requires before prompting. Adding Developer ID signing
-   and notarization in a follow-up spec is a drop-in **replacement of the
-   signing identity**, not a rebuild of the metadata layer.
+   independent designated requirement across rebuilds, is ad-hoc signed with
+   Hardened Runtime enabled, and declares the entitlements bun's JavaScriptCore
+   JIT needs. Bundles whose executables access TCC-gated resources (Calendar,
+   Contacts, etc.) also carry the usage-description strings macOS requires
+   before prompting. Adding Developer ID signing and notarization in a follow-up
+   spec is a drop-in **replacement of the signing identity**, not a rebuild of
+   the metadata layer.
 
 The intent is deliberately narrow: preserve every existing install path,
 behaviour, and CLI surface unchanged, and add one new way to get the same
@@ -84,11 +83,10 @@ executables onto a macOS machine without installing Node.
 
 ### Included
 
-- Every `fit-*` CLI listed in the Problem section plus every gRPC service
-  under `services/` and every library CLI under `libraries/*` with a `bin`
-  field is reachable through the new channel — either as the primary
-  executable of a per-product bundle, or as a named Mach-O inside one of
-  the two shared bundles.
+- Every `fit-*` CLI listed in the Problem section plus every gRPC service under
+  `services/` and every library CLI under `libraries/*` with a `bin` field is
+  reachable through the new channel — either as the primary executable of a
+  per-product bundle, or as a named Mach-O inside one of the two shared bundles.
 - macOS arm64 as the primary and required target at acceptance.
 - A release automation workflow that builds the bundles on release tag and
   attaches them to the GitHub release.
@@ -111,31 +109,29 @@ executables onto a macOS machine without installing Node.
 - **Linux distribution.** Whether Linux users get Linuxbrew, apt/dnf packaging,
   raw tarballs, or none of the above is out of scope. Linux users continue via
   the existing npm channel for now.
-- **Apple Developer ID signing and notarization.** Obtaining a paid Developer
-  ID certificate, running `notarytool submit`, stapling, and the
-  Gatekeeper-clean first-run experience are deferred to a follow-up spec.
-  This spec lands **ad-hoc** signing (`codesign --sign -`) on every bundle
-  with correct entitlements and `Contents/Info.plist`, so the follow-up is a
-  signing-identity swap only. Unsigned-by-Apple bundles still trigger
-  Gatekeeper warnings on first run, which the user must acknowledge. This
-  spec must not claim Developer ID signing as complete.
+- **Apple Developer ID signing and notarization.** Obtaining a paid Developer ID
+  certificate, running `notarytool submit`, stapling, and the Gatekeeper-clean
+  first-run experience are deferred to a follow-up spec. This spec lands
+  **ad-hoc** signing (`codesign --sign -`) on every bundle with correct
+  entitlements and `Contents/Info.plist`, so the follow-up is a signing-identity
+  swap only. Unsigned-by-Apple bundles still trigger Gatekeeper warnings on
+  first run, which the user must acknowledge. This spec must not claim Developer
+  ID signing as complete.
 - **TCC prompts for resources no current CLI accesses.** Only `fit-basecamp`
-  requests Calendar, Contacts, and Downloads today. The other bundles ship
-  with the minimal JIT entitlement set and no usage-description strings.
-  Adding new TCC-gated resources to any CLI is a per-bundle change, not a
-  spec-600 concern.
-- **Fixing Terminal-inherited TCC responsibility for PATH symlinks.**
-  Capability #3 requires that every CLI still be invokable from Terminal
-  through the cask's `binary` symlink; that is in scope and must work.
-  What is **out** of scope is changing which process macOS considers
-  TCC-responsible in that case: when the CLI launches via the symlink,
-  Terminal (not the bundle) is the responsible process, which only
-  matters for CLIs that actively request TCC-gated resources like
-  Calendar or Contacts. No non-basecamp CLI does so today, and
-  `fit-basecamp`'s scheduler is launched by the `fit-basecamp.app`
-  bundle rather than from Terminal, so its TCC grants already attach
-  to the bundle correctly. Adding a self-disclaim helper for a future
-  Terminal-invoked TCC-gated CLI is deferred.
+  requests Calendar, Contacts, and Downloads today. The other bundles ship with
+  the minimal JIT entitlement set and no usage-description strings. Adding new
+  TCC-gated resources to any CLI is a per-bundle change, not a spec-600 concern.
+- **Fixing Terminal-inherited TCC responsibility for PATH symlinks.** Capability
+  #3 requires that every CLI still be invokable from Terminal through the cask's
+  `binary` symlink; that is in scope and must work. What is **out** of scope is
+  changing which process macOS considers TCC-responsible in that case: when the
+  CLI launches via the symlink, Terminal (not the bundle) is the responsible
+  process, which only matters for CLIs that actively request TCC-gated resources
+  like Calendar or Contacts. No non-basecamp CLI does so today, and
+  `fit-basecamp`'s scheduler is launched by the `fit-basecamp.app` bundle rather
+  than from Terminal, so its TCC grants already attach to the bundle correctly.
+  Adding a self-disclaim helper for a future Terminal-invoked TCC-gated CLI is
+  deferred.
 - **Replacing or modifying the existing npm channel.** `npm install` /
   `npx fit-*` continues to work identically. No CLI is removed from npm, no
   shebang is rewritten, and no existing user workflow changes.
@@ -145,23 +141,23 @@ executables onto a macOS machine without installing Node.
 ## Success Criteria
 
 1. A single documented build entry point produces a standalone macOS arm64
-   release artifact for each of the eight bundles in scope (six per-product
-   plus the two shared bundles). Every `fit-*` CLI surfaced by those
-   bundles runs its `--help` successfully on a macOS arm64 machine that
-   has neither `node` nor `bun` on `PATH`.
+   release artifact for each of the eight bundles in scope (six per-product plus
+   the two shared bundles). Every `fit-*` CLI surfaced by those bundles runs its
+   `--help` successfully on a macOS arm64 machine that has neither `node` nor
+   `bun` on `PATH`.
 2. A release-automation workflow, triggered by a release tag, builds the
-   artifact for that tag and attaches it to the GitHub release as a
-   downloadable asset, with a deterministic asset-name scheme that
-   identifies the bundle and target triple.
-3. A Homebrew tap contains one cask per bundle. Each cask references the
-   GitHub release artifact for that bundle and target triple, and product
-   casks declare a dependency on the two shared-bundle casks so installing
-   a product cask delivers the full runtime.
-4. On a clean macOS arm64 machine with Homebrew installed but no Node and
-   no Bun, running the brew install command published on each affected
-   product's Overview page leaves every `fit-*` CLI surfaced by the
-   bundles on the user's `PATH`, each answering `--help`. The concrete tap
-   path and cask names are fixed by design.
+   artifact for that tag and attaches it to the GitHub release as a downloadable
+   asset, with a deterministic asset-name scheme that identifies the bundle and
+   target triple.
+3. A Homebrew tap contains one cask per bundle. Each cask references the GitHub
+   release artifact for that bundle and target triple, and product casks declare
+   a dependency on the two shared-bundle casks so installing a product cask
+   delivers the full runtime.
+4. On a clean macOS arm64 machine with Homebrew installed but no Node and no
+   Bun, running the brew install command published on each affected product's
+   Overview page leaves every `fit-*` CLI surfaced by the bundles on the user's
+   `PATH`, each answering `--help`. The concrete tap path and cask names are
+   fixed by design.
 5. After installing `fit-guide` exclusively via brew — no npm, no post-install
    command — the user can run `fit-guide --help` and every user-visible command
    documented in the [Guide Overview](../../website/guide/index.md) with no
@@ -176,32 +172,29 @@ executables onto a macOS machine without installing Node.
    `npm install` followed by `npx fit-<cli> --help` succeeds on a reference Node
    LTS environment after the release that ships the brew channel. No `bin`
    script, `package.json` `bin` entry, or shebang has changed.
-8. **Stable bundle identity.** Rebuilding any bundle from the same source
-   tree and re-installing via `brew upgrade` on a machine that previously
-   granted it a TCC permission keeps the grant — the user is not
-   re-prompted. The bundle's designated-requirement identity is stable
-   across rebuilds of the same commit.
-9. **Entitlements and Info.plist present on every bundle.** Every bundle
-   carries a `Contents/Info.plist` declaring a bundle identifier and a
-   version string matching the release tag, and is ad-hoc signed with an
-   entitlements set that unlocks bun's JavaScriptCore JIT under Hardened
-   Runtime. The exact identifier scheme, entitlement keys, and
-   verification commands are design decisions.
+8. **Stable bundle identity.** Rebuilding any bundle from the same source tree
+   and re-installing via `brew upgrade` on a machine that previously granted it
+   a TCC permission keeps the grant — the user is not re-prompted. The bundle's
+   designated-requirement identity is stable across rebuilds of the same commit.
+9. **Entitlements and Info.plist present on every bundle.** Every bundle carries
+   a `Contents/Info.plist` declaring a bundle identifier and a version string
+   matching the release tag, and is ad-hoc signed with an entitlements set that
+   unlocks bun's JavaScriptCore JIT under Hardened Runtime. The exact identifier
+   scheme, entitlement keys, and verification commands are design decisions.
 10. **`fit-basecamp` TCC responsibility chain intact.** Basecamp's existing
-    Calendar and Contacts integration continues to work after migrating to
-    the shared bundle-assembly recipe, and its scheduler still disclaims
-    TCC responsibility when spawning `claude`. Verified by a manual
-    hardware test on macOS 14+ that launches the rebuilt bundle, triggers
-    a calendar sync, and observes no TCC prompt plus a
-    responsible-process lookup that resolves to the basecamp bundle
-    (specific `log stream` predicate is a plan decision).
-11. **Homebrew cask install surfaces every CLI on `PATH`.** After the
-    documented `brew install` command for any product cask runs on a
-    clean macOS arm64 machine, every `fit-*` CLI surfaced by that product
-    and by the two shared bundles that `depends_on` pulls in is on the
-    user's `PATH` and answers `--help`. The specific `/Applications/…`
-    install location and the PATH-symlink directory are Homebrew-prefix
-    dependent and are design decisions, not acceptance literals.
+    Calendar and Contacts integration continues to work after migrating to the
+    shared bundle-assembly recipe, and its scheduler still disclaims TCC
+    responsibility when spawning `claude`. Verified by a manual hardware test on
+    macOS 14+ that launches the rebuilt bundle, triggers a calendar sync, and
+    observes no TCC prompt plus a responsible-process lookup that resolves to
+    the basecamp bundle (specific `log stream` predicate is a plan decision).
+11. **Homebrew cask install surfaces every CLI on `PATH`.** After the documented
+    `brew install` command for any product cask runs on a clean macOS arm64
+    machine, every `fit-*` CLI surfaced by that product and by the two shared
+    bundles that `depends_on` pulls in is on the user's `PATH` and answers
+    `--help`. The specific `/Applications/…` install location and the
+    PATH-symlink directory are Homebrew-prefix dependent and are design
+    decisions, not acceptance literals.
 
 ## Open questions
 

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -79,7 +79,7 @@
 570	plan	implemented
 580	plan	implemented
 590	plan	implemented
-600	plan	draft
+600	plan	approved
 610	plan	implemented
 620	design	approved
 630	spec	draft


### PR DESCRIPTION
## Summary

- Rewrites spec 600 around **macOS `.app` bundle distribution** instead of
  bare Mach-Os. Eight bundles total: six per-product (`fit-basecamp.app`,
  `fit-guide.app`, `fit-landmark.app`, `fit-map.app`, `fit-pathway.app`,
  `fit-summit.app`) plus `FIT Services.app` (gRPC servers from `services/`)
  and `FIT Utilities.app` (library CLIs from `libraries/*` with a `bin`
  field, including `fit-codegen`, `fit-terrain`, `fit-eval`, …).
- Adds TCC compatibility as an explicit capability (stable designated
  requirement, Hardened Runtime + JIT entitlement, usage-description
  strings) and narrows the signing exclusion to Developer ID +
  notarization only. This dissolves the Mach-O `__TEXT,__info_plist`
  embedding spike the previous plan required — `Contents/Info.plist`
  lives on disk.
- Generalizes Basecamp's `pkg/macos/build-app.sh` into a new
  `libraries/libmacos/` library that owns the shared bundle assembler,
  codesign wrapper, entitlements + `Info.plist` templates, and the
  `posix-spawn` FFI wrapper that basecamp uses for TCC responsibility
  disclaiming.
- Homebrew distribution: one cask per bundle; product casks
  `depends_on` the two shared-bundle casks so a single
  `brew install --cask forwardimpact/tap/fit-<product>` delivers the
  full runtime.
- Three kata-review panels (three reviewers each, one per document)
  ran on every document; all consensus findings were addressed,
  including cutting `design.md` from 361 → 186 lines under the
  kata-review ceiling, fixing `build-binary` entry-point resolution to
  scan `package.json` `bin` fields (the prior `libraries/lib<NAME>/`
  heuristic failed for most library CLIs), and fixing the cask-update
  `sed -i` vs `sha256 :no_check` mismatch.
- Marks spec 600 `plan approved` in `specs/STATUS`.

Branch history preserves the review iteration for reviewers:

- `515e5897` — initial architectural rewrite
- `c291fe3b` — kata-review consensus fixes
- `d61e4752` — STATUS approval
- `949ed0f5` — `bun run check:fix` prettier formatting

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2405 pass, 0 fail)
- [ ] CI pipeline on this branch

---
_Generated by [Claude Code](https://claude.ai/code/session_01576vox32vrttJQDUsaRvvo)_