### PR TITLE
refactor(kata-ship): streamline pace and skip redundant checks

### DIFF
--- a/.claude/skills/kata-ship/SKILL.md
+++ b/.claude/skills/kata-ship/SKILL.md
@@ -62,6 +62,11 @@ handles the `specs/STATUS` update before the mechanical ship process begins.
 
 ## Process
 
+Run the steps back-to-back as a pipeline. Short status updates are fine, but
+don't narrate or pause between every step — stop only on a real blocker
+(conflicts, failing checks, unexpected state). Batch independent commands in a
+single turn where possible (e.g. guard + fetch, probe PR + push).
+
 ### Step 1: Guard
 
 ```sh
@@ -112,6 +117,10 @@ a conflict is substantive and cannot be resolved mechanically, abort with
 `git rebase --abort` and stop.
 
 ### Step 4: Run Checks
+
+If `bun run check` and `bun run test` already passed in this session on the
+same commits that just rebased cleanly (no new files, no conflict resolutions),
+trust that result and skip ahead to Step 5. Otherwise:
 
 ```sh
 bun run check:fix    # auto-fix format and lint

--- a/.claude/skills/kata-ship/SKILL.md
+++ b/.claude/skills/kata-ship/SKILL.md
@@ -62,8 +62,8 @@ handles the `specs/STATUS` update before the mechanical ship process begins.
 
 ## Process
 
-Run steps back-to-back; pause only on real blockers (conflicts, failing
-checks, unexpected state). Batch independent commands where possible.
+Run steps back-to-back; pause only on real blockers (conflicts, failing checks,
+unexpected state). Batch independent commands where possible.
 
 ### Step 1: Guard
 
@@ -116,8 +116,8 @@ a conflict is substantive and cannot be resolved mechanically, abort with
 
 ### Step 4: Run Checks
 
-Skip if `check` and `test` already passed this session and the rebase was
-clean. Otherwise:
+Skip if `check` and `test` already passed this session and the rebase was clean.
+Otherwise:
 
 ```sh
 bun run check:fix    # auto-fix format and lint

--- a/.claude/skills/kata-ship/SKILL.md
+++ b/.claude/skills/kata-ship/SKILL.md
@@ -62,10 +62,8 @@ handles the `specs/STATUS` update before the mechanical ship process begins.
 
 ## Process
 
-Run the steps back-to-back as a pipeline. Short status updates are fine, but
-don't narrate or pause between every step — stop only on a real blocker
-(conflicts, failing checks, unexpected state). Batch independent commands in a
-single turn where possible (e.g. guard + fetch, probe PR + push).
+Run steps back-to-back; pause only on real blockers (conflicts, failing
+checks, unexpected state). Batch independent commands where possible.
 
 ### Step 1: Guard
 
@@ -118,9 +116,8 @@ a conflict is substantive and cannot be resolved mechanically, abort with
 
 ### Step 4: Run Checks
 
-If `bun run check` and `bun run test` already passed in this session on the
-same commits that just rebased cleanly (no new files, no conflict resolutions),
-trust that result and skip ahead to Step 5. Otherwise:
+Skip if `check` and `test` already passed this session and the rebase was
+clean. Otherwise:
 
 ```sh
 bun run check:fix    # auto-fix format and lint


### PR DESCRIPTION
## Summary

- Add a short "Process" preamble telling the agent to run steps back-to-back and pause only on real blockers, so ship runs don't stall after every step.
- Let Step 4 skip `check`/`test` when they already passed in the same session and the rebase was clean, instead of re-running unconditionally.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwsZBjDUhwJN6WxNwtuFmq)_