### PR TITLE
perf(e2e): double workers and cache synthetic + pathway build in CI

### DIFF
--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -43,11 +43,17 @@ jobs:
             data/knowledge
             data/activity
             data/personal
-          key: synthetic-${{ hashFiles('data/synthetic/**', 'products/map/schema/json/**', 'bun.lock') }}
+          key:
+            synthetic-${{ hashFiles('data/synthetic/**',
+            'products/map/schema/json/**', 'bun.lock') }}
       - if: steps.synthetic-cache.outputs.cache-hit != 'true'
         run: just synthetic
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: public
-          key: pathway-build-${{ hashFiles('data/synthetic/**', 'products/map/schema/json/**', 'products/pathway/src/**', 'products/map/starter/**', 'libraries/**/src/**', 'libraries/**/package.json', 'bun.lock') }}
+          key:
+            pathway-build-${{ hashFiles('data/synthetic/**',
+            'products/map/schema/json/**', 'products/pathway/src/**',
+            'products/map/starter/**', 'libraries/**/src/**',
+            'libraries/**/package.json', 'bun.lock') }}
       - run: bun run test:e2e

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -35,5 +35,19 @@ jobs:
       - name: Install Playwright OS dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: bunx playwright install-deps chromium
-      - run: just synthetic
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: synthetic-cache
+        with:
+          path: |
+            data/pathway
+            data/knowledge
+            data/activity
+            data/personal
+          key: synthetic-${{ hashFiles('data/synthetic/**', 'products/map/schema/json/**', 'bun.lock') }}
+      - if: steps.synthetic-cache.outputs.cache-hit != 'true'
+        run: just synthetic
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: public
+          key: pathway-build-${{ hashFiles('data/synthetic/**', 'products/map/schema/json/**', 'products/pathway/src/**', 'products/map/starter/**', 'libraries/**/src/**', 'libraries/**/package.json', 'bun.lock') }}
       - run: bun run test:e2e

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,14 +3,14 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests",
   testMatch: "*.spec.js",
-  timeout: 30000,
+  timeout: 15000,
   expect: {
     timeout: 5000,
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? "50%" : undefined,
+  workers: process.env.CI ? "100%" : undefined,
   reporter: "list",
   use: {
     baseURL: "http://localhost:3000/",


### PR DESCRIPTION
## Summary

- `playwright.config.js`: `workers: "50%"` → `"100%"` (2 workers on the 2-core runner; ~halves parallel execution time with `fullyParallel: true`) and `timeout: 30000` → `15000` (faster fail on hangs; ample headroom for the 4 current tests).
- `.github/workflows/check-test.yml`: cache `data/{pathway,knowledge,activity,personal}` keyed on `data/synthetic/**` + schemas + `bun.lock` so `just synthetic` is skipped on cache hits; cache `public/` keyed on the same inputs plus pathway/map/library sources so `bun start`'s `prestart` rebuild is a no-op on hits.

On cache miss: same behavior as before (full regeneration + rebuild). On cache hit: both stages are skipped and the test run goes straight from Playwright install to the tests themselves.

## Test plan

- [x] `bun run check`
- [x] `bun run test`
- [ ] CI cold cache: first run regenerates and passes
- [ ] CI warm cache: rerun hits both caches, `just synthetic` is skipped, e2e passes
- [ ] Playwright log shows "Running N tests using 2 workers" (was 1)


---
_Generated by [Claude Code](https://claude.ai/code/session_01A4PhL6mFcjAgBrcSa4ttWf)_