### PR TITLE
plan(620): request-response primitives for libeval orchestration

### DIFF
--- a/specs/620-facilitated-tell-share-response-protocol/plan-a-01.md
+++ b/specs/620-facilitated-tell-share-response-protocol/plan-a-01.md
@@ -1,0 +1,667 @@
+# Plan 620a, Part 01 — libeval Runtime
+
+Spec: [`spec.md`](./spec.md). Design: [`design.md`](./design.md). Overview:
+[`plan-a.md`](./plan-a.md).
+
+## Scope
+
+This part owns every code and test change inside `libraries/libeval/`. No
+skill, workflow, or invariant-catalogue changes — those live in Parts 02
+and 03.
+
+## Approach
+
+Land the contract at the runtime in a single coherent unit. The tool surface,
+the pending-ask registry, the turn-complete guard, the prompt rewrites, and
+the `systemPromptAmend` / `taskAmend` config family are mutually
+dependent — a PR that lands only a subset leaves the library in an
+internally-inconsistent state (old prompts pointing at removed tools, new
+tools without enforcement). One PR, one review cycle.
+
+Removal of `Tell` / `Share` / blocking-`Ask` is atomic with the addition of
+`Ask` / `Answer` / `Announce`. The spec forbids aliases; grep confirms no
+external consumer imports the old names (`createFacilitator`,
+`createSupervisor`, `createAgentRunner` are called nowhere outside libeval
+itself).
+
+## Libraries used
+
+Consumes no `@forwardimpact/lib*` packages — this part implements one. The
+existing libeval dependencies (`@anthropic-ai/claude-agent-sdk`, `zod`,
+`@forwardimpact/libharness` for test helpers) stay as-is.
+
+## Blast radius
+
+**Modified** (13 files):
+
+- `libraries/libeval/src/orchestration-toolkit.js`
+- `libraries/libeval/src/facilitator.js`
+- `libraries/libeval/src/supervisor.js`
+- `libraries/libeval/src/message-bus.js`
+- `libraries/libeval/src/agent-runner.js` (one new optional field:
+  `taskAmend`; no behavioral change)
+- `libraries/libeval/src/index.js`
+- `libraries/libeval/src/commands/facilitate.js`
+- `libraries/libeval/src/commands/supervise.js`
+- `libraries/libeval/src/commands/run.js`
+- `libraries/libeval/src/render/orchestrator-filter.js` (leave
+  `protocol_violation` un-suppressed; assert via test)
+- `libraries/libeval/test/orchestration-toolkit.test.js`
+- `libraries/libeval/test/facilitator.test.js`
+- `libraries/libeval/test/supervisor-run.test.js`,
+  `supervisor-intervention.test.js`, `supervisor-output.test.js`,
+  `supervisor-batching.test.js`
+- `libraries/libeval/test/message-bus.test.js`
+
+**Created** (1 file): `libraries/libeval/test/pending-ask.test.js` — focused
+coverage of the pending-ask registry and the turn-complete guard across both
+modes.
+
+**Deleted** (0 files). No aliases, no shims, but no existing file becomes
+empty.
+
+## Step-by-step
+
+Each step is independently verifiable. Order matters — the tool surface
+(step 1) is the foundation; the pending-ask registry (step 2) is where
+subsequent steps hang their assertions; steps 3 and 4 consume the registry.
+
+### Step 1 — New tool surface in `orchestration-toolkit.js`
+
+Rewrite the handler factories and per-role MCP server factories around the
+three-primitive vocabulary.
+
+**`createOrchestrationContext()`** — extend the returned object:
+
+```js
+return {
+  concluded: false,
+  summary: null,
+  redirect: null,
+  participants: [],
+  messageBus: null,
+  // Map<addresseeName, {askId, askerName, question, reminded}>
+  // Always keyed by an addressee name. Broadcast asks write one entry
+  // per named participant (one per pair), so every pending entry has a
+  // concrete addressee and the match rule is uniform.
+  pendingAsks: new Map(),
+  askIdCounter: 0,
+};
+```
+
+**Canonical addressee names.** The facilitator mode uses participant names
+from `ctx.participants` (e.g., `"staff-engineer"`) and the literal
+`"facilitator"` for the facilitator itself. The supervise mode uses the
+fixed pair `"supervisor"` / `"agent"`. Every `from` argument passed into
+handler factories matches the caller's canonical name — so the key the
+registry uses is always the `to` value on the asker's side and the
+`from` value on the answerer's side.
+
+**New handlers (replace `Ask`/`Tell`/`Share` trio):**
+
+- `createAskHandler(ctx, { from, defaultTo })` — `from` is the asker's
+  canonical name; `defaultTo` is a string or `undefined`. On a call with
+  argument `to`, use `to`; otherwise use `defaultTo`; otherwise, when
+  neither is present (only valid for the facilitator whose tool signature
+  accepts an optional `to`), iterate `ctx.participants` and write one
+  pending entry per non-asker participant. For each entry:
+  - `askId = ++ctx.askIdCounter` — one id per asker→addressee pair (so a
+    broadcast ask creates N distinct ids, one per pending entry).
+  - `ctx.pendingAsks.set(addressee, { askId, askerName: from, question,
+    reminded: false })`.
+  - `messageBus.ask(from, addressee, question, askId)` — direct queue.
+  Returns `{ content: [{ type: "text", text: "Ask delivered." }] }`. The
+  asker's turn ends after the call (same as today's Tell — no blocking).
+
+- `createAnswerHandler(ctx, { from })` — `from` is the answerer's
+  canonical name. Looks up `ctx.pendingAsks.get(from)` — this is the
+  entry the answerer owes, because broadcast asks wrote one entry keyed
+  by each addressee. Clears that entry, then publishes via
+  `messageBus.answer(from, entry.askerName, message, entry.askId)`, and
+  returns `"Answer delivered."`. If no pending entry matches, the
+  handler returns `{ isError: true, content: [{ type: "text", text: "No
+  pending ask to answer." }] }` — surfacing misuse as a tool-call error
+  instead of silently routing the text.
+
+- `createAnnounceHandler(ctx, { from })` — publishes via
+  `messageBus.announce(from, message)` without touching `pendingAsks`.
+
+Retain existing: `createConcludeHandler`, `createRedirectHandler`,
+`createRollCallHandler`. Delete: `createTellHandler`, `createShareHandler`,
+and the old two-arg `createAskHandler(ctx, { onAsk })`.
+
+**Per-role server factories** (note `from` / `defaultTo` bindings; these
+are the wiring points for the canonical names above):
+
+- `createFacilitatorToolServer(ctx)` — tools:
+  `Ask({ question, to })` wired with
+  `createAskHandler(ctx, { from: "facilitator", defaultTo: undefined })`
+  and schema `{ question: z.string(), to: z.string().optional() }`.
+  `Announce({ message })` wired with
+  `createAnnounceHandler(ctx, { from: "facilitator" })`. `Conclude`,
+  `Redirect`, `RollCall` unchanged.
+- `createFacilitatedAgentToolServer(ctx, { from })` — tools:
+  `Ask({ question, to })` wired with
+  `createAskHandler(ctx, { from, defaultTo: "facilitator" })` so a
+  participant omitting `to` asks the facilitator; explicit `to` asks a
+  named peer. `Answer({ message })` wired with
+  `createAnswerHandler(ctx, { from })`. `Announce({ message })` wired
+  with `createAnnounceHandler(ctx, { from })`. `RollCall` unchanged.
+- `createSupervisorToolServer(ctx)` — tools: `Ask({ question })` wired
+  with `createAskHandler(ctx, { from: "supervisor", defaultTo: "agent" })`
+  (supervise mode has one addressee); `Announce`, `Conclude`, `Redirect`,
+  `RollCall` unchanged.
+- `createSupervisedAgentToolServer(ctx)` — tools: `Ask({ question })`
+  wired with `createAskHandler(ctx, { from: "agent", defaultTo:
+  "supervisor" })`; `Answer({ message })` wired with
+  `createAnswerHandler(ctx, { from: "agent" })`; `Announce`, `RollCall`
+  unchanged. The signature loses its current `{ onAsk }` parameter —
+  supervise mode's Ask now routes through the bus, not through a
+  promise-based blocking callback.
+
+**Tool descriptions** stay one-line and generic. No enforcement verbs;
+describe the tool's effect, not the addressee's obligation:
+
+- `Ask`: `"Send a question to a participant. The reply arrives via
+  Answer."`
+- `Answer`: `"Reply to an ask addressed to you."`
+- `Announce`: `"Broadcast a message with no reply expected."`
+
+Exports: `index.js` currently re-exports only context factory + server
+factories (not individual handlers). Step 1 adds no new handler exports —
+the new handlers are consumed internally by the server factories. Leave
+`index.js` alone at this step; Step 5 covers any index.js churn (in
+practice, none — the server-factory names are unchanged).
+
+**Verify:** `bun run check` on `orchestration-toolkit.js` compiles. The
+seven steps land atomically in one PR — the intermediate state
+between Step 1 (toolkit) and Steps 3–4 (orchestrator rewiring) does not
+compile (`facilitator.js` still imports the removed `createTellHandler`
+until Step 3 rewrites it). Each step is an independently-verifiable
+logical unit within the diff, not a standalone commit.
+
+### Step 2 — MessageBus vocabulary migration
+
+Rewrite `message-bus.js` around the new methods. The existing queues/waiter
+data structures carry over; only the public API and the message shape
+change.
+
+**New methods** on `MessageBus`:
+
+- `ask(from, to, text, askId)` — direct message to one recipient (or
+  broadcast if `to === "@broadcast"`, delivering an identical entry to
+  every participant except the sender). Queued entry shape:
+  `{ from, text, kind: "ask", askId, direct: boolean }`.
+- `answer(from, to, text, askId)` — direct reply. Queued entry shape:
+  `{ from, text, kind: "answer", askId, direct: true }`.
+- `announce(from, text)` — broadcast to all except sender. Queued entry
+  shape: `{ from, text, kind: "announce", direct: false }`.
+- `synthetic(to, text)` — internal, orchestrator-only. Queued entry
+  shape: `{ from: "@orchestrator", text, kind: "synthetic", direct: true }`.
+  Used by the turn-complete guard (Step 3) to inject the single reminder.
+
+**Removed:** `share()`, `tell()`. No aliases.
+
+**Unchanged:** `drain()`, `waitForMessages()`, `#assertParticipant()`,
+`#resolveWaiter()`, the `createMessageBus` factory.
+
+Consumers that read from the queue (facilitator and supervisor, see Step 5)
+learn to switch on `kind` when formatting messages for the LLM. The
+formatter gains one line:
+
+```js
+const tag =
+  m.kind === "ask"      ? "[ask]"      :
+  m.kind === "answer"   ? "[answer]"   :
+  m.kind === "synthetic"? "[system]"   :
+  m.direct              ? "[direct]"   : "[shared]";
+return `${tag} ${m.from}: ${m.text}`;
+```
+
+**Verify:** `message-bus.test.js` is rewritten in Step 6 to cover the new
+methods; Steps 3–5 consume them.
+
+### Step 3 — Pending-ask registry + turn-complete guard in `Facilitator`
+
+Modify `libraries/libeval/src/facilitator.js` to track outstanding asks and
+enforce the reply obligation at agent-turn boundaries.
+
+**Prompt rewrites.** Replace the two exported prompt constants with
+descriptive, domain-agnostic text. No skill names, no domain vocabulary, no
+enforcement phrasing:
+
+```js
+export const FACILITATOR_SYSTEM_PROMPT =
+  "You coordinate multiple participants. " +
+  "Ask sends a question to a participant; omit the addressee to broadcast. " +
+  "Announce sends a message with no reply obligation. " +
+  "Redirect interrupts a participant with replacement instructions. " +
+  "RollCall lists participants. " +
+  "Conclude ends the session with a summary.";
+
+export const FACILITATED_AGENT_SYSTEM_PROMPT =
+  "You participate in a coordinated session. " +
+  "Answer replies to an ask addressed to you. " +
+  "Ask sends a question to another participant. " +
+  "Announce broadcasts a message. " +
+  "RollCall lists participants.";
+```
+
+Each prompt sentence describes a tool's effect. No sentence names a
+deadline, an ordering, or an obligation — the runtime holds the
+contract. Absent-phrase audit: neither prompt contains "before",
+"stop", "respond via", "then Answer", "must Answer", or any domain
+vocabulary; Step 6 asserts this mechanically.
+
+**Registry wiring.** In the `#runAgent` loop, after each
+`agent.runner.run(...)` or `agent.runner.resume(...)` returns, call the
+shared helper `checkPendingAsk({ ctx, messageBus, addresseeName:
+agent.name, mode: "facilitated", emitViolation })` (see below) and act on
+its return value:
+
+- `"advance"` — enqueue `lifecycle:turn_complete` as today.
+- `"recheck"` — a synthetic reminder has been queued; resume the agent
+  once more and call the helper again when that resume returns.
+
+The helper's body:
+
+1. Read `ctx.pendingAsks.get(addresseeName)`. If absent, return
+   `"advance"`.
+2. If `entry.reminded === false`: set `entry.reminded = true`, call
+   `messageBus.synthetic(addresseeName, <reminder text>)` where the
+   reminder text is the locked string `"You have an unanswered ask from
+   <entry.askerName>. Reply via Answer."` — return `"recheck"`.
+3. Otherwise (`reminded === true`): call
+   `emitViolation({ type: "protocol_violation", agent: addresseeName,
+   askId: entry.askId, mode })`, then inject a typed synthetic answer
+   into the asker's queue so the asker resumes instead of waiting:
+   `messageBus.answer("@orchestrator", entry.askerName, "[no answer:
+   " + addresseeName + " did not reply to ask " + entry.askId + "]",
+   entry.askId)`. Clear the entry (`ctx.pendingAsks.delete(
+   addresseeName)`) and return `"advance"`. The synthetic answer text is
+   a plain string that satisfies the message-bus shape (`text: string`);
+   the facilitator's LLM can read it as a null-reply signal without the
+   literal `null` issue.
+
+**Broadcast asks.** Facilitator `Ask` with no `to` writes one pending
+entry per non-asker participant (Step 1's handler). Each entry is
+independent; the helper evaluates each addressee separately on that
+agent's turn boundary. A broadcast ask therefore emits up to N
+`protocol_violation` events (one per non-answering participant) over the
+lifetime of the session — the invariant catalogue (Part 03) asserts
+count == 0 on success, which is correct regardless of broadcast
+cardinality. The facilitator's `#facilitatorLoop` already handles
+multiple `answer` events arriving at its queue via the existing
+`"messages"` case drain; no new event case is required.
+
+**Remove obsolete wiring.** The current facilitator has an `"ask"` event
+case in `#handleEvent` (`facilitator.js:240-266`) that resolves a
+promise passed from `createFacilitatedAgentToolServer`'s `onAsk`
+callback (`facilitator.js:462-477`). Both go away: the `"ask"` case in
+`#handleEvent` is deleted, the `onAsk` parameter to
+`createFacilitatedAgentToolServer` is removed (Step 1 already dropped it
+from the factory), and `createFacilitator` no longer constructs
+`resolve`/`promise` pairs per participant. The `eventQueue` loses the
+`"ask"` event type entirely; only `"messages"` and `"lifecycle"` remain.
+
+**Event exposure.** `protocol_violation` is emitted via the existing
+`emitOrchestratorEvent` path. It is **not** added to
+`render/orchestrator-filter.js` suppressed set — the event must reach
+both the NDJSON artifact and the human-readable `toText()` stream so
+auditors and live readers both see it.
+
+**Shared helper location.** The registry check is identical in
+facilitate and supervise mode; it lives as a free function
+`checkPendingAsk({ ctx, messageBus, addresseeName, mode, emitViolation })`
+exported from `orchestration-toolkit.js`. Both `Facilitator.#runAgent`
+(Step 3) and `Supervisor.#runAgentTurn` / `#endOfTurnReview` (Step 4)
+import and call it. Return type: `"advance" | "recheck"`.
+
+**Verify:** `facilitator.test.js` rewrite in Step 6 and the new
+`pending-ask.test.js` exercise the registry and the guard end-to-end.
+
+### Step 4 — Pending-ask registry + turn-complete guard in `Supervisor`
+
+`libraries/libeval/src/supervisor.js` gets the same enforcement mechanism,
+adapted to supervision's 1:1 shape.
+
+**Prompt rewrites.** Same policy as Step 3 — descriptive, generic, no
+enforcement phrases:
+
+```js
+export const SUPERVISOR_SYSTEM_PROMPT =
+  "You supervise one agent. " +
+  "Ask the agent a question when you need a reply. " +
+  "Announce to send a message with no reply obligation. " +
+  "Redirect interrupts the agent with replacement instructions. " +
+  "Conclude ends the session with a summary.";
+
+export const AGENT_SYSTEM_PROMPT =
+  "A supervisor watches your work. " +
+  "Answer replies to an ask addressed to you. " +
+  "Ask sends a question to the supervisor. " +
+  "Announce sends a message with no reply expected.";
+```
+
+**Registry wiring.** Supervise mode uses the two fixed canonical names
+from Step 1: `"supervisor"` and `"agent"`. Two enforcement sites, both
+calling the shared `checkPendingAsk` helper (Step 3) with
+`mode: "supervised"`:
+
+1. **Agent side (supervisor→agent ask).** Inside `#runAgentTurn`, after
+   each `agentResult` returns without a redirect/conclude, call
+   `checkPendingAsk({ ctx, messageBus, addresseeName: "agent", mode:
+   "supervised", emitViolation })`. `"advance"` → fall through to
+   `#endOfTurnReview` as today. `"recheck"` → the helper queued a
+   synthetic reminder; resume the agent once more by looping back with
+   the drained synthetic message as the relay text.
+
+2. **Supervisor side (agent→supervisor ask).** Inside
+   `#endOfTurnReview`, immediately before resuming the supervisor, call
+   `checkPendingAsk({ ctx, messageBus, addresseeName: "supervisor",
+   mode: "supervised", emitViolation })`. `"advance"` → resume the
+   supervisor as today. `"recheck"` → the helper queued a synthetic
+   reminder on the supervisor's queue; resume the supervisor with the
+   reminder drained into the resume prompt.
+
+The supervisor's `emitViolation` binds to its existing
+`emitOrchestratorEvent` method (so the `protocol_violation` event
+inherits the same source tagging as other orchestrator events). The
+`pendingAsks` map is keyed by the two canonical strings — no
+`ctx.participants` lookup is required on the supervisor side.
+
+**Ask-relay plumbing.** Today's supervisor factory wires the supervised
+agent's `Ask` tool through an `onAsk` callback
+(`supervisor.js:396-407`) that calls `supervisorRunner.resume(...)` and
+returns the supervisor's text synchronously. That entire callback path
+is removed. Replacement flow, end-to-end:
+
+- Agent calls `Ask(question)` → Step 1's new `createAskHandler` wired
+  with `{ from: "agent", defaultTo: "supervisor" }` writes a pending
+  entry keyed by `"supervisor"` and publishes via
+  `messageBus.ask("agent", "supervisor", question, askId)`. Agent's turn
+  ends.
+- `#endOfTurnReview` drains `messageBus` for the `"supervisor"` queue
+  before resuming the supervisor; the agent transcript concatenation
+  gains a `[ask] agent: ...` block from the drained ask (Step 2's
+  formatter) and the registry-check prefix from `checkPendingAsk` (if
+  the supervisor ignores the ask).
+- Supervisor calls `Answer(message)` → clears the pending entry,
+  publishes `messageBus.answer("supervisor", "agent", message,
+  askId)` → the agent receives the answer on its next resume.
+
+Compared to the old synchronous shape, this converts the blocking
+mid-tool-call relay into a turn-boundary relay, aligning supervise mode
+with facilitate mode and removing the `onAsk` promise plumbing from
+both factories and from `createSupervisor`.
+
+**Per-turn mechanics of `agent-runner.js` stay unchanged** per the
+spec's Excluded section. The registry/guard hooks sit in the
+orchestrator wrapper, not inside the runner's iterator consumer. The
+only change inside `agent-runner.js` itself is the addition of a
+`taskAmend` config field (Step 5) — a plain constructor/defaults
+extension with no effect on loop mechanics or ctx checkpoints.
+
+**Verify:** `supervisor-run.test.js`, `supervisor-output.test.js`,
+`supervisor-intervention.test.js`, and the new `pending-ask.test.js`
+exercise both enforcement sites. Mid-turn intervention via `#midTurnReview`
+and the `onBatch` path remain unchanged — the registry only affects
+turn-complete transitions.
+
+### Step 5 — Call-site cleanup + config additions
+
+With the toolkit (Step 1), bus (Step 2), and orchestrators (Steps 3–4)
+migrated, clean the remaining call sites.
+
+**`Facilitator` / `Supervisor` / `AgentRunner` config surface.** Add
+optional fields:
+
+- `systemPromptAmend: string?` — on `Facilitator` participant config only
+  (each entry in `agentConfigs`). Appended verbatim after
+  `FACILITATED_AGENT_SYSTEM_PROMPT` with a blank line. Factory-level
+  concatenation in `createFacilitator`:
+
+  ```js
+  const trailer = config.systemPromptAmend
+    ? `${FACILITATED_AGENT_SYSTEM_PROMPT}\n\n${config.systemPromptAmend}`
+    : FACILITATED_AGENT_SYSTEM_PROMPT;
+  ```
+
+  Pass `trailer` to `systemPromptFor(config.agentProfile, trailer)`.
+
+- `taskAmend: string?` — on `Facilitator`, `Supervisor`, and `AgentRunner`
+  constructor/factory configs. Replaces the CLI-side concatenation
+  currently performed in `commands/{facilitate,supervise,run}.js`. Each
+  orchestrator appends it to the task string just before delivery: the
+  run-side logic is `task + (this.taskAmend ? "\n\n" + this.taskAmend :
+  "")` — appended, preserving today's observable concatenation order so
+  SC 7 (b) holds. Applies to:
+  - `Facilitator.run(task)` — before `this.facilitatorRunner.run(task)`.
+  - `Supervisor.run(task)` — before
+    `this.supervisorRunner.run(task)`.
+  - `AgentRunner.run(task)` — before the `query({ prompt: task, ... })`
+    call.
+
+  `AgentRunner`'s `applyDefaults(deps)` function (`agent-runner.js:16-32`)
+  gains one line: `taskAmend: deps.taskAmend ?? null`. No behavioral
+  change to the per-turn loop; loop mechanics stay unchanged per spec §
+  Excluded. Opaque string. No interpretation.
+
+**CLI layer cleanup.** Remove the `taskAmend` concatenation from
+`commands/facilitate.js`, `commands/supervise.js`, `commands/run.js`; the
+CLI now forwards `--task-amend` value into the respective
+factory/constructor's `taskAmend` option. Option parsing stays the same;
+only the point of concatenation moves.
+
+**Index exports.** `libraries/libeval/src/index.js` currently re-exports
+`createOrchestrationContext`, `createSupervisorToolServer`,
+`createSupervisedAgentToolServer`, `createFacilitatorToolServer`,
+`createFacilitatedAgentToolServer` (server factories only — no handler
+factories are exported today). After this step, the same set of names
+still exports — `createSupervisedAgentToolServer` has lost its `onAsk`
+parameter (Step 1) but the export name is unchanged. No additions, no
+deletions to `index.js`.
+
+**Participants list shape.** Unchanged. `ctx.participants` still
+`[{name, role}, ...]`.
+
+**Final grep — tool names.** Run a pair of greps in
+`libraries/libeval/src/` plus `libraries/libeval/test/`:
+
+```bash
+# No Zod schema or handler uses the removed tool names.
+grep -RnE '"Tell"|"Share"' libraries/libeval/src libraries/libeval/test
+# No Zod `tool("Tell"` or `tool("Share"` constructs.
+grep -Rn 'tool("Tell\|tool("Share' libraries/libeval/src
+```
+
+Both must return zero matches. Comments mentioning "shared" or "Tell me"
+are unaffected — the greps target the double-quoted tool-name literals
+the SDK recognises.
+
+**Verify:** `bun run check` across the package compiles; `bun run format`
+leaves the tree clean.
+
+### Step 6 — Test coverage
+
+Rewrite and extend tests in one coherent pass so CI runs once against the
+full surface.
+
+**`test/orchestration-toolkit.test.js`** — rewrite the handler suite:
+
+- `Ask` handler with explicit `to` registers one `ctx.pendingAsks` entry
+  keyed by that addressee, publishes to the bus via `ask()`, returns
+  ack.
+- `Ask` handler with facilitator's `defaultTo: undefined` and no `to`
+  argument registers one entry per non-asker participant (broadcast
+  semantics); verify `ctx.pendingAsks.size === participants.length - 1`.
+- `Ask` handler with participant's `defaultTo: "facilitator"` and no
+  `to` argument registers exactly one entry keyed by `"facilitator"`.
+- `Answer` handler clears the matching pending entry (keyed by the
+  answerer's `from`) and publishes to the bus via `answer()`.
+- `Answer` handler returns `isError: true` when no pending ask matches
+  `from`.
+- `Announce` handler publishes via `announce()` and does **not** touch
+  `pendingAsks`.
+- `RollCall`, `Redirect`, `Conclude` — existing tests stay; rename only
+  where they pass input shaped for removed tools.
+- Four server-factory tests (`create*ToolServer returns sdk-type server`)
+  continue to pass after the rename — update expected tool-name lists to
+  `["Ask", "Announce", "Conclude", "Redirect", "RollCall"]` for
+  facilitator/supervisor and `["Ask", "Answer", "Announce", "RollCall"]`
+  for the two participant-side servers.
+
+**`test/message-bus.test.js`** — rewrite around `ask` / `answer` /
+`announce` / `synthetic`. One case per method covering delivery,
+broadcast-except-sender semantics, and queue drain. Existing
+`waitForMessages` + `createMessageBus` tests stay.
+
+**`test/facilitator.test.js`** — update existing scenarios:
+
+- Rename helper builders (`tellMsg` → `askMsg`, `shareMsg` → `announceMsg`,
+  add `answerMsg`).
+- Rename toolDispatcher keys.
+- Update message-format assertions to expect `[ask]` / `[answer]` /
+  `[announce]` prefixes.
+- Adjust "lazy start" / "fail-fast" / "turn 0 Conclude" test bodies to use
+  `Ask`/`Answer`/`Announce` wording — behavior asserted is unchanged.
+
+**`test/supervisor-output.test.js`** — update the four prompt-constant
+assertions:
+
+- Positive: `SUPERVISOR_SYSTEM_PROMPT` and `AGENT_SYSTEM_PROMPT` each
+  include the tool names `"Ask"`, `"Answer"`, `"Announce"`.
+- Negative (SC 4, enforcement-free): neither prompt includes
+  `"EVALUATION_COMPLETE"`, `"EVALUATION_INTERVENTION"`, `"then Answer"`,
+  `"then Share"`, `"respond via"`, `"stop making tool calls"`, `"must "`,
+  or `"before your turn"`.
+- Negative (SC 4, domain-agnostic): neither prompt includes `"kata-"`,
+  `"storyboard"`, `"coaching"`, `"Toyota"`, or `"meeting"`.
+
+Add a parallel suite in `test/facilitator.test.js` (new top-level
+`describe` block) running the same positive + negative assertions
+against `FACILITATOR_SYSTEM_PROMPT` and `FACILITATED_AGENT_SYSTEM_PROMPT`
+so all four prompts are covered.
+
+**`test/supervisor-run.test.js`, `supervisor-intervention.test.js`,
+`supervisor-batching.test.js`** — mechanical renames (`Tell`→`Ask`,
+`Share`→`Announce`, `Ask`→`Answer` on the reply side). Drop every
+reference to the `onAsk` callback — both supervisor-side and agent-side
+constructors no longer accept it.
+
+**`test/pending-ask.test.js` (new)** — focused coverage of the registry
+and guard. At minimum:
+
+- **SC 2 — registry transitions.** `Ask` handler sets a pending entry;
+  `Answer` handler clears it; `Announce` handler leaves `pendingAsks`
+  untouched.
+- **Facilitated, happy path.** `Ask` registers, agent `Answer` clears,
+  no `protocol_violation` event on the wire.
+- **Facilitated, one reminder.** `Ask` registers, agent ignores once,
+  helper queues synthetic reminder, agent answers → no
+  `protocol_violation`.
+- **SC 3 — facilitated violation.** `Ask` registers, agent ignores
+  twice, `protocol_violation` event appears **exactly once**, the
+  facilitator receives the synthetic `"[no answer: … ]"` string on its
+  queue, and the session advances to the next event without
+  deadlocking.
+- **Supervised mode.** Same three cases keyed on the
+  `"supervisor"`/`"agent"` pair, covering both enforcement sites (§
+  Step 4): supervisor→agent and agent→supervisor asks.
+- **Broadcast facilitator `Ask`.** Three participants, one ignores.
+  `protocol_violation` is emitted only for the ignoring participant;
+  the other two answers clear their entries; the facilitator's queue
+  receives two `answer` messages plus one synthetic no-answer.
+- **SC 7 (a) — `systemPromptAmend` delivery.** Construct a `Facilitator`
+  with one participant whose config includes `systemPromptAmend:
+  "<TEST_MARKER>"`. Inspect
+  `facilitator.agents[0].runner.systemPrompt` — the `append` field must
+  end with the marker string, and the literal
+  `FACILITATED_AGENT_SYSTEM_PROMPT` must appear before it. Repeat with
+  `systemPromptAmend` absent and assert the `append` field equals
+  `FACILITATED_AGENT_SYSTEM_PROMPT` verbatim — the "absence leaves the
+  prompt purely generic" clause.
+- **SC 7 (b) — `taskAmend` delivery.** Construct a `Facilitator`,
+  `Supervisor`, and `AgentRunner` with `taskAmend: "<TEST_APPEND>"`.
+  Stub the underlying SDK `query` to capture the first `prompt`
+  argument. Assert the captured prompt equals `<task> + "\n\n" +
+  "<TEST_APPEND>"` for each orchestrator — preserving the concatenation
+  shape `commands/{facilitate,supervise,run}.js` produced previously.
+- **`orchestrator-filter`.** `protocol_violation` is **not** in the
+  suppressed set (direct import of `isSuppressedOrchestratorEvent` with
+  `{type: "protocol_violation"}` returns `false`).
+
+**`test/mock-runner.js`** — no structural edits; scripted
+`toolDispatcher` entries in individual test files switch their keys
+from `Tell`/`Share` to `Ask`/`Answer`/`Announce`, but
+`mock-runner.js` itself remains agnostic to tool names (verified by
+reading its source). Drop `mock-runner.js` from the "Modified" list in
+§ Blast radius.
+
+**Verify:** `bun run test` passes the full libeval suite. The
+`pending-ask.test.js` file drives SC 2, SC 3, and the SC 10 clause about
+`protocol_violation` event shape.
+
+### Step 7 — Final `bun run check` + self-review
+
+Before pushing:
+
+- `bun run check` — type-and-lint clean across the package.
+- `bun run test` — all suites green, including the new `pending-ask`
+  suite.
+- Step 6's prompt-content tests are the machine-checked SC 4 gate. As a
+  human double-check, print each of the four prompt constants from
+  `facilitator.js` / `supervisor.js` and eyeball the text — inspecting
+  the string values, not the identifier names, so the audit catches
+  anything the tests miss.
+- `grep -RnE '"Tell"|"Share"' libraries/libeval/src libraries/libeval/test`
+  returns zero matches. The quoted tool-name literals are the only
+  Tell/Share usage that matters; unquoted words ("Shared state" in a
+  comment) are fine.
+- `grep -Rn 'tool("Tell\|tool("Share' libraries/libeval/src` returns
+  zero matches — the Zod `tool(...)` constructors for the removed
+  primitives are gone.
+
+## Risks
+
+- **Broadcast ask semantics.** A facilitator `Ask` with no `to` creates N
+  pending entries. Design-decision trade-off: if any one participant fails
+  to `Answer`, the facilitator still receives one `protocol_violation`
+  per failing participant. That is the intent (each participant's
+  obligation is independent), but generates more `protocol_violation`
+  events than the single-participant case — invariant queries in Part 03
+  compare counts against expectations per participant, not a flat count.
+  The invariant design accommodates this by asserting count == 0 on
+  success, not a specific cardinality on violation.
+- **Synthetic reminder pollution.** Each unanswered ask costs one extra
+  resume cycle and one extra line in the trace. Acceptable — the whole
+  point is that agents who would otherwise silently fail now visibly
+  recover on the first retry. The trace reader can grep `kind:
+  "synthetic"` to separate these from content messages.
+- **Ask handler `isError`.** Returning `isError: true` from an `Answer`
+  handler when no pending ask exists is a design choice to make misuse
+  loud. A future test that calls `Answer` without a prior `Ask` will see
+  the error surface back to the LLM, which may then retry. This is
+  preferable to silently routing the text as an announcement.
+
+## Verification
+
+- SC 1: `grep -l "Tell\|Share" libraries/libeval/src/` returns no tool
+  names (only comments/identifiers).
+- SC 2: `pending-ask.test.js` covers transition from set → clear.
+- SC 3: `pending-ask.test.js` covers reminder-once, then
+  `protocol_violation` emission, then session advance.
+- SC 4: prompt content assertions in `supervisor-output.test.js` and a
+  parallel suite in `facilitator.test.js` (added in Step 6) verify the
+  vocabulary + absence of enforcement/domain terms.
+- SC 10: `bun run check && bun run test` green.
+
+Out of scope for this part (belong to Parts 02 and 03): SC 5 (kata-session
+directory), SC 6 (repo grep), SC 7 beyond the libeval test of the
+`systemPromptAmend` delivery mechanism, SC 8 (workflow task-text), SC 9
+(invariant entries).
+
+## Agent routing
+
+`staff-engineer`. Runtime, library code, tests. Follows the full
+`kata-implement` checklist, including DO-CONFIRM's push + PR gate.

--- a/specs/620-facilitated-tell-share-response-protocol/plan-a-01.md
+++ b/specs/620-facilitated-tell-share-response-protocol/plan-a-01.md
@@ -5,18 +5,17 @@ Spec: [`spec.md`](./spec.md). Design: [`design.md`](./design.md). Overview:
 
 ## Scope
 
-This part owns every code and test change inside `libraries/libeval/`. No
-skill, workflow, or invariant-catalogue changes — those live in Parts 02
-and 03.
+This part owns every code and test change inside `libraries/libeval/`. No skill,
+workflow, or invariant-catalogue changes — those live in Parts 02 and 03.
 
 ## Approach
 
 Land the contract at the runtime in a single coherent unit. The tool surface,
-the pending-ask registry, the turn-complete guard, the prompt rewrites, and
-the `systemPromptAmend` / `taskAmend` config family are mutually
-dependent — a PR that lands only a subset leaves the library in an
-internally-inconsistent state (old prompts pointing at removed tools, new
-tools without enforcement). One PR, one review cycle.
+the pending-ask registry, the turn-complete guard, the prompt rewrites, and the
+`systemPromptAmend` / `taskAmend` config family are mutually dependent — a PR
+that lands only a subset leaves the library in an internally-inconsistent state
+(old prompts pointing at removed tools, new tools without enforcement). One PR,
+one review cycle.
 
 Removal of `Tell` / `Share` / blocking-`Ask` is atomic with the addition of
 `Ask` / `Answer` / `Announce`. The spec forbids aliases; grep confirms no
@@ -38,8 +37,8 @@ existing libeval dependencies (`@anthropic-ai/claude-agent-sdk`, `zod`,
 - `libraries/libeval/src/facilitator.js`
 - `libraries/libeval/src/supervisor.js`
 - `libraries/libeval/src/message-bus.js`
-- `libraries/libeval/src/agent-runner.js` (one new optional field:
-  `taskAmend`; no behavioral change)
+- `libraries/libeval/src/agent-runner.js` (one new optional field: `taskAmend`;
+  no behavioral change)
 - `libraries/libeval/src/index.js`
 - `libraries/libeval/src/commands/facilitate.js`
 - `libraries/libeval/src/commands/supervise.js`
@@ -57,14 +56,13 @@ existing libeval dependencies (`@anthropic-ai/claude-agent-sdk`, `zod`,
 coverage of the pending-ask registry and the turn-complete guard across both
 modes.
 
-**Deleted** (0 files). No aliases, no shims, but no existing file becomes
-empty.
+**Deleted** (0 files). No aliases, no shims, but no existing file becomes empty.
 
 ## Step-by-step
 
-Each step is independently verifiable. Order matters — the tool surface
-(step 1) is the foundation; the pending-ask registry (step 2) is where
-subsequent steps hang their assertions; steps 3 and 4 consume the registry.
+Each step is independently verifiable. Order matters — the tool surface (step 1)
+is the foundation; the pending-ask registry (step 2) is where subsequent steps
+hang their assertions; steps 3 and 4 consume the registry.
 
 ### Step 1 — New tool surface in `orchestration-toolkit.js`
 
@@ -89,116 +87,110 @@ return {
 };
 ```
 
-**Canonical addressee names.** The facilitator mode uses participant names
-from `ctx.participants` (e.g., `"staff-engineer"`) and the literal
-`"facilitator"` for the facilitator itself. The supervise mode uses the
-fixed pair `"supervisor"` / `"agent"`. Every `from` argument passed into
-handler factories matches the caller's canonical name — so the key the
-registry uses is always the `to` value on the asker's side and the
-`from` value on the answerer's side.
+**Canonical addressee names.** The facilitator mode uses participant names from
+`ctx.participants` (e.g., `"staff-engineer"`) and the literal `"facilitator"`
+for the facilitator itself. The supervise mode uses the fixed pair
+`"supervisor"` / `"agent"`. Every `from` argument passed into handler factories
+matches the caller's canonical name — so the key the registry uses is always the
+`to` value on the asker's side and the `from` value on the answerer's side.
 
 **New handlers (replace `Ask`/`Tell`/`Share` trio):**
 
-- `createAskHandler(ctx, { from, defaultTo })` — `from` is the asker's
-  canonical name; `defaultTo` is a string or `undefined`. On a call with
-  argument `to`, use `to`; otherwise use `defaultTo`; otherwise, when
-  neither is present (only valid for the facilitator whose tool signature
-  accepts an optional `to`), iterate `ctx.participants` and write one
-  pending entry per non-asker participant. For each entry:
+- `createAskHandler(ctx, { from, defaultTo })` — `from` is the asker's canonical
+  name; `defaultTo` is a string or `undefined`. On a call with argument `to`,
+  use `to`; otherwise use `defaultTo`; otherwise, when neither is present (only
+  valid for the facilitator whose tool signature accepts an optional `to`),
+  iterate `ctx.participants` and write one pending entry per non-asker
+  participant. For each entry:
   - `askId = ++ctx.askIdCounter` — one id per asker→addressee pair (so a
     broadcast ask creates N distinct ids, one per pending entry).
-  - `ctx.pendingAsks.set(addressee, { askId, askerName: from, question,
-    reminded: false })`.
-  - `messageBus.ask(from, addressee, question, askId)` — direct queue.
-  Returns `{ content: [{ type: "text", text: "Ask delivered." }] }`. The
-  asker's turn ends after the call (same as today's Tell — no blocking).
+  - `ctx.pendingAsks.set(addressee, { askId, askerName: from, question, reminded: false })`.
+  - `messageBus.ask(from, addressee, question, askId)` — direct queue. Returns
+    `{ content: [{ type: "text", text: "Ask delivered." }] }`. The asker's turn
+    ends after the call (same as today's Tell — no blocking).
 
-- `createAnswerHandler(ctx, { from })` — `from` is the answerer's
-  canonical name. Looks up `ctx.pendingAsks.get(from)` — this is the
-  entry the answerer owes, because broadcast asks wrote one entry keyed
-  by each addressee. Clears that entry, then publishes via
-  `messageBus.answer(from, entry.askerName, message, entry.askId)`, and
-  returns `"Answer delivered."`. If no pending entry matches, the
-  handler returns `{ isError: true, content: [{ type: "text", text: "No
-  pending ask to answer." }] }` — surfacing misuse as a tool-call error
-  instead of silently routing the text.
+- `createAnswerHandler(ctx, { from })` — `from` is the answerer's canonical
+  name. Looks up `ctx.pendingAsks.get(from)` — this is the entry the answerer
+  owes, because broadcast asks wrote one entry keyed by each addressee. Clears
+  that entry, then publishes via
+  `messageBus.answer(from, entry.askerName, message, entry.askId)`, and returns
+  `"Answer delivered."`. If no pending entry matches, the handler returns
+  `{ isError: true, content: [{ type: "text", text: "No pending ask to answer." }] }`
+  — surfacing misuse as a tool-call error instead of silently routing the text.
 
 - `createAnnounceHandler(ctx, { from })` — publishes via
   `messageBus.announce(from, message)` without touching `pendingAsks`.
 
 Retain existing: `createConcludeHandler`, `createRedirectHandler`,
-`createRollCallHandler`. Delete: `createTellHandler`, `createShareHandler`,
-and the old two-arg `createAskHandler(ctx, { onAsk })`.
+`createRollCallHandler`. Delete: `createTellHandler`, `createShareHandler`, and
+the old two-arg `createAskHandler(ctx, { onAsk })`.
 
-**Per-role server factories** (note `from` / `defaultTo` bindings; these
-are the wiring points for the canonical names above):
+**Per-role server factories** (note `from` / `defaultTo` bindings; these are the
+wiring points for the canonical names above):
 
-- `createFacilitatorToolServer(ctx)` — tools:
-  `Ask({ question, to })` wired with
-  `createAskHandler(ctx, { from: "facilitator", defaultTo: undefined })`
-  and schema `{ question: z.string(), to: z.string().optional() }`.
+- `createFacilitatorToolServer(ctx)` — tools: `Ask({ question, to })` wired with
+  `createAskHandler(ctx, { from: "facilitator", defaultTo: undefined })` and
+  schema `{ question: z.string(), to: z.string().optional() }`.
   `Announce({ message })` wired with
-  `createAnnounceHandler(ctx, { from: "facilitator" })`. `Conclude`,
-  `Redirect`, `RollCall` unchanged.
+  `createAnnounceHandler(ctx, { from: "facilitator" })`. `Conclude`, `Redirect`,
+  `RollCall` unchanged.
 - `createFacilitatedAgentToolServer(ctx, { from })` — tools:
   `Ask({ question, to })` wired with
-  `createAskHandler(ctx, { from, defaultTo: "facilitator" })` so a
-  participant omitting `to` asks the facilitator; explicit `to` asks a
-  named peer. `Answer({ message })` wired with
-  `createAnswerHandler(ctx, { from })`. `Announce({ message })` wired
-  with `createAnnounceHandler(ctx, { from })`. `RollCall` unchanged.
-- `createSupervisorToolServer(ctx)` — tools: `Ask({ question })` wired
-  with `createAskHandler(ctx, { from: "supervisor", defaultTo: "agent" })`
-  (supervise mode has one addressee); `Announce`, `Conclude`, `Redirect`,
+  `createAskHandler(ctx, { from, defaultTo: "facilitator" })` so a participant
+  omitting `to` asks the facilitator; explicit `to` asks a named peer.
+  `Answer({ message })` wired with `createAnswerHandler(ctx, { from })`.
+  `Announce({ message })` wired with `createAnnounceHandler(ctx, { from })`.
   `RollCall` unchanged.
-- `createSupervisedAgentToolServer(ctx)` — tools: `Ask({ question })`
-  wired with `createAskHandler(ctx, { from: "agent", defaultTo:
-  "supervisor" })`; `Answer({ message })` wired with
+- `createSupervisorToolServer(ctx)` — tools: `Ask({ question })` wired with
+  `createAskHandler(ctx, { from: "supervisor", defaultTo: "agent" })` (supervise
+  mode has one addressee); `Announce`, `Conclude`, `Redirect`, `RollCall`
+  unchanged.
+- `createSupervisedAgentToolServer(ctx)` — tools: `Ask({ question })` wired with
+  `createAskHandler(ctx, { from: "agent", defaultTo: "supervisor" })`;
+  `Answer({ message })` wired with
   `createAnswerHandler(ctx, { from: "agent" })`; `Announce`, `RollCall`
-  unchanged. The signature loses its current `{ onAsk }` parameter —
-  supervise mode's Ask now routes through the bus, not through a
-  promise-based blocking callback.
+  unchanged. The signature loses its current `{ onAsk }` parameter — supervise
+  mode's Ask now routes through the bus, not through a promise-based blocking
+  callback.
 
-**Tool descriptions** stay one-line and generic. No enforcement verbs;
-describe the tool's effect, not the addressee's obligation:
+**Tool descriptions** stay one-line and generic. No enforcement verbs; describe
+the tool's effect, not the addressee's obligation:
 
-- `Ask`: `"Send a question to a participant. The reply arrives via
-  Answer."`
+- `Ask`: `"Send a question to a participant. The reply arrives via Answer."`
 - `Answer`: `"Reply to an ask addressed to you."`
 - `Announce`: `"Broadcast a message with no reply expected."`
 
-Exports: `index.js` currently re-exports only context factory + server
-factories (not individual handlers). Step 1 adds no new handler exports —
-the new handlers are consumed internally by the server factories. Leave
-`index.js` alone at this step; Step 5 covers any index.js churn (in
-practice, none — the server-factory names are unchanged).
+Exports: `index.js` currently re-exports only context factory + server factories
+(not individual handlers). Step 1 adds no new handler exports — the new handlers
+are consumed internally by the server factories. Leave `index.js` alone at this
+step; Step 5 covers any index.js churn (in practice, none — the server-factory
+names are unchanged).
 
-**Verify:** `bun run check` on `orchestration-toolkit.js` compiles. The
-seven steps land atomically in one PR — the intermediate state
-between Step 1 (toolkit) and Steps 3–4 (orchestrator rewiring) does not
-compile (`facilitator.js` still imports the removed `createTellHandler`
-until Step 3 rewrites it). Each step is an independently-verifiable
-logical unit within the diff, not a standalone commit.
+**Verify:** `bun run check` on `orchestration-toolkit.js` compiles. The seven
+steps land atomically in one PR — the intermediate state between Step 1
+(toolkit) and Steps 3–4 (orchestrator rewiring) does not compile
+(`facilitator.js` still imports the removed `createTellHandler` until Step 3
+rewrites it). Each step is an independently-verifiable logical unit within the
+diff, not a standalone commit.
 
 ### Step 2 — MessageBus vocabulary migration
 
-Rewrite `message-bus.js` around the new methods. The existing queues/waiter
-data structures carry over; only the public API and the message shape
-change.
+Rewrite `message-bus.js` around the new methods. The existing queues/waiter data
+structures carry over; only the public API and the message shape change.
 
 **New methods** on `MessageBus`:
 
-- `ask(from, to, text, askId)` — direct message to one recipient (or
-  broadcast if `to === "@broadcast"`, delivering an identical entry to
-  every participant except the sender). Queued entry shape:
+- `ask(from, to, text, askId)` — direct message to one recipient (or broadcast
+  if `to === "@broadcast"`, delivering an identical entry to every participant
+  except the sender). Queued entry shape:
   `{ from, text, kind: "ask", askId, direct: boolean }`.
 - `answer(from, to, text, askId)` — direct reply. Queued entry shape:
   `{ from, text, kind: "answer", askId, direct: true }`.
-- `announce(from, text)` — broadcast to all except sender. Queued entry
-  shape: `{ from, text, kind: "announce", direct: false }`.
-- `synthetic(to, text)` — internal, orchestrator-only. Queued entry
-  shape: `{ from: "@orchestrator", text, kind: "synthetic", direct: true }`.
-  Used by the turn-complete guard (Step 3) to inject the single reminder.
+- `announce(from, text)` — broadcast to all except sender. Queued entry shape:
+  `{ from, text, kind: "announce", direct: false }`.
+- `synthetic(to, text)` — internal, orchestrator-only. Queued entry shape:
+  `{ from: "@orchestrator", text, kind: "synthetic", direct: true }`. Used by
+  the turn-complete guard (Step 3) to inject the single reminder.
 
 **Removed:** `share()`, `tell()`. No aliases.
 
@@ -206,8 +198,8 @@ change.
 `#resolveWaiter()`, the `createMessageBus` factory.
 
 Consumers that read from the queue (facilitator and supervisor, see Step 5)
-learn to switch on `kind` when formatting messages for the LLM. The
-formatter gains one line:
+learn to switch on `kind` when formatting messages for the LLM. The formatter
+gains one line:
 
 ```js
 const tag =
@@ -226,9 +218,9 @@ methods; Steps 3–5 consume them.
 Modify `libraries/libeval/src/facilitator.js` to track outstanding asks and
 enforce the reply obligation at agent-turn boundaries.
 
-**Prompt rewrites.** Replace the two exported prompt constants with
-descriptive, domain-agnostic text. No skill names, no domain vocabulary, no
-enforcement phrasing:
+**Prompt rewrites.** Replace the two exported prompt constants with descriptive,
+domain-agnostic text. No skill names, no domain vocabulary, no enforcement
+phrasing:
 
 ```js
 export const FACILITATOR_SYSTEM_PROMPT =
@@ -247,75 +239,69 @@ export const FACILITATED_AGENT_SYSTEM_PROMPT =
   "RollCall lists participants.";
 ```
 
-Each prompt sentence describes a tool's effect. No sentence names a
-deadline, an ordering, or an obligation — the runtime holds the
-contract. Absent-phrase audit: neither prompt contains "before",
-"stop", "respond via", "then Answer", "must Answer", or any domain
-vocabulary; Step 6 asserts this mechanically.
+Each prompt sentence describes a tool's effect. No sentence names a deadline, an
+ordering, or an obligation — the runtime holds the contract. Absent-phrase
+audit: neither prompt contains "before", "stop", "respond via", "then Answer",
+"must Answer", or any domain vocabulary; Step 6 asserts this mechanically.
 
-**Registry wiring.** In the `#runAgent` loop, after each
-`agent.runner.run(...)` or `agent.runner.resume(...)` returns, call the
-shared helper `checkPendingAsk({ ctx, messageBus, addresseeName:
-agent.name, mode: "facilitated", emitViolation })` (see below) and act on
-its return value:
+**Registry wiring.** In the `#runAgent` loop, after each `agent.runner.run(...)`
+or `agent.runner.resume(...)` returns, call the shared helper
+`checkPendingAsk({ ctx, messageBus, addresseeName: agent.name, mode: "facilitated", emitViolation })`
+(see below) and act on its return value:
 
 - `"advance"` — enqueue `lifecycle:turn_complete` as today.
-- `"recheck"` — a synthetic reminder has been queued; resume the agent
-  once more and call the helper again when that resume returns.
+- `"recheck"` — a synthetic reminder has been queued; resume the agent once more
+  and call the helper again when that resume returns.
 
 The helper's body:
 
-1. Read `ctx.pendingAsks.get(addresseeName)`. If absent, return
-   `"advance"`.
+1. Read `ctx.pendingAsks.get(addresseeName)`. If absent, return `"advance"`.
 2. If `entry.reminded === false`: set `entry.reminded = true`, call
-   `messageBus.synthetic(addresseeName, <reminder text>)` where the
-   reminder text is the locked string `"You have an unanswered ask from
-   <entry.askerName>. Reply via Answer."` — return `"recheck"`.
+   `messageBus.synthetic(addresseeName, <reminder text>)` where the reminder
+   text is the locked string
+   `"You have an unanswered ask from <entry.askerName>. Reply via Answer."` —
+   return `"recheck"`.
 3. Otherwise (`reminded === true`): call
-   `emitViolation({ type: "protocol_violation", agent: addresseeName,
-   askId: entry.askId, mode })`, then inject a typed synthetic answer
-   into the asker's queue so the asker resumes instead of waiting:
-   `messageBus.answer("@orchestrator", entry.askerName, "[no answer:
-   " + addresseeName + " did not reply to ask " + entry.askId + "]",
-   entry.askId)`. Clear the entry (`ctx.pendingAsks.delete(
-   addresseeName)`) and return `"advance"`. The synthetic answer text is
-   a plain string that satisfies the message-bus shape (`text: string`);
-   the facilitator's LLM can read it as a null-reply signal without the
-   literal `null` issue.
+   `emitViolation({ type: "protocol_violation", agent: addresseeName, askId: entry.askId, mode })`,
+   then inject a typed synthetic answer into the asker's queue so the asker
+   resumes instead of waiting:
+   `messageBus.answer("@orchestrator", entry.askerName, "[no answer: " + addresseeName + " did not reply to ask " + entry.askId + "]", entry.askId)`.
+   Clear the entry (`ctx.pendingAsks.delete( addresseeName)`) and return
+   `"advance"`. The synthetic answer text is a plain string that satisfies the
+   message-bus shape (`text: string`); the facilitator's LLM can read it as a
+   null-reply signal without the literal `null` issue.
 
-**Broadcast asks.** Facilitator `Ask` with no `to` writes one pending
-entry per non-asker participant (Step 1's handler). Each entry is
-independent; the helper evaluates each addressee separately on that
-agent's turn boundary. A broadcast ask therefore emits up to N
-`protocol_violation` events (one per non-answering participant) over the
-lifetime of the session — the invariant catalogue (Part 03) asserts
-count == 0 on success, which is correct regardless of broadcast
-cardinality. The facilitator's `#facilitatorLoop` already handles
-multiple `answer` events arriving at its queue via the existing
-`"messages"` case drain; no new event case is required.
+**Broadcast asks.** Facilitator `Ask` with no `to` writes one pending entry per
+non-asker participant (Step 1's handler). Each entry is independent; the helper
+evaluates each addressee separately on that agent's turn boundary. A broadcast
+ask therefore emits up to N `protocol_violation` events (one per non-answering
+participant) over the lifetime of the session — the invariant catalogue
+(Part 03) asserts count == 0 on success, which is correct regardless of
+broadcast cardinality. The facilitator's `#facilitatorLoop` already handles
+multiple `answer` events arriving at its queue via the existing `"messages"`
+case drain; no new event case is required.
 
-**Remove obsolete wiring.** The current facilitator has an `"ask"` event
-case in `#handleEvent` (`facilitator.js:240-266`) that resolves a
-promise passed from `createFacilitatedAgentToolServer`'s `onAsk`
-callback (`facilitator.js:462-477`). Both go away: the `"ask"` case in
-`#handleEvent` is deleted, the `onAsk` parameter to
-`createFacilitatedAgentToolServer` is removed (Step 1 already dropped it
-from the factory), and `createFacilitator` no longer constructs
-`resolve`/`promise` pairs per participant. The `eventQueue` loses the
+**Remove obsolete wiring.** The current facilitator has an `"ask"` event case in
+`#handleEvent` (`facilitator.js:240-266`) that resolves a promise passed from
+`createFacilitatedAgentToolServer`'s `onAsk` callback
+(`facilitator.js:462-477`). Both go away: the `"ask"` case in `#handleEvent` is
+deleted, the `onAsk` parameter to `createFacilitatedAgentToolServer` is removed
+(Step 1 already dropped it from the factory), and `createFacilitator` no longer
+constructs `resolve`/`promise` pairs per participant. The `eventQueue` loses the
 `"ask"` event type entirely; only `"messages"` and `"lifecycle"` remain.
 
 **Event exposure.** `protocol_violation` is emitted via the existing
 `emitOrchestratorEvent` path. It is **not** added to
-`render/orchestrator-filter.js` suppressed set — the event must reach
-both the NDJSON artifact and the human-readable `toText()` stream so
-auditors and live readers both see it.
+`render/orchestrator-filter.js` suppressed set — the event must reach both the
+NDJSON artifact and the human-readable `toText()` stream so auditors and live
+readers both see it.
 
-**Shared helper location.** The registry check is identical in
-facilitate and supervise mode; it lives as a free function
+**Shared helper location.** The registry check is identical in facilitate and
+supervise mode; it lives as a free function
 `checkPendingAsk({ ctx, messageBus, addresseeName, mode, emitViolation })`
-exported from `orchestration-toolkit.js`. Both `Facilitator.#runAgent`
-(Step 3) and `Supervisor.#runAgentTurn` / `#endOfTurnReview` (Step 4)
-import and call it. Return type: `"advance" | "recheck"`.
+exported from `orchestration-toolkit.js`. Both `Facilitator.#runAgent` (Step 3)
+and `Supervisor.#runAgentTurn` / `#endOfTurnReview` (Step 4) import and call it.
+Return type: `"advance" | "recheck"`.
 
 **Verify:** `facilitator.test.js` rewrite in Step 6 and the new
 `pending-ask.test.js` exercise the registry and the guard end-to-end.
@@ -343,81 +329,75 @@ export const AGENT_SYSTEM_PROMPT =
   "Announce sends a message with no reply expected.";
 ```
 
-**Registry wiring.** Supervise mode uses the two fixed canonical names
-from Step 1: `"supervisor"` and `"agent"`. Two enforcement sites, both
-calling the shared `checkPendingAsk` helper (Step 3) with
-`mode: "supervised"`:
+**Registry wiring.** Supervise mode uses the two fixed canonical names from Step
+1: `"supervisor"` and `"agent"`. Two enforcement sites, both calling the shared
+`checkPendingAsk` helper (Step 3) with `mode: "supervised"`:
 
-1. **Agent side (supervisor→agent ask).** Inside `#runAgentTurn`, after
-   each `agentResult` returns without a redirect/conclude, call
-   `checkPendingAsk({ ctx, messageBus, addresseeName: "agent", mode:
-   "supervised", emitViolation })`. `"advance"` → fall through to
-   `#endOfTurnReview` as today. `"recheck"` → the helper queued a
-   synthetic reminder; resume the agent once more by looping back with
-   the drained synthetic message as the relay text.
+1. **Agent side (supervisor→agent ask).** Inside `#runAgentTurn`, after each
+   `agentResult` returns without a redirect/conclude, call
+   `checkPendingAsk({ ctx, messageBus, addresseeName: "agent", mode: "supervised", emitViolation })`.
+   `"advance"` → fall through to `#endOfTurnReview` as today. `"recheck"` → the
+   helper queued a synthetic reminder; resume the agent once more by looping
+   back with the drained synthetic message as the relay text.
 
-2. **Supervisor side (agent→supervisor ask).** Inside
-   `#endOfTurnReview`, immediately before resuming the supervisor, call
-   `checkPendingAsk({ ctx, messageBus, addresseeName: "supervisor",
-   mode: "supervised", emitViolation })`. `"advance"` → resume the
-   supervisor as today. `"recheck"` → the helper queued a synthetic
-   reminder on the supervisor's queue; resume the supervisor with the
-   reminder drained into the resume prompt.
+2. **Supervisor side (agent→supervisor ask).** Inside `#endOfTurnReview`,
+   immediately before resuming the supervisor, call
+   `checkPendingAsk({ ctx, messageBus, addresseeName: "supervisor", mode: "supervised", emitViolation })`.
+   `"advance"` → resume the supervisor as today. `"recheck"` → the helper queued
+   a synthetic reminder on the supervisor's queue; resume the supervisor with
+   the reminder drained into the resume prompt.
 
-The supervisor's `emitViolation` binds to its existing
-`emitOrchestratorEvent` method (so the `protocol_violation` event
-inherits the same source tagging as other orchestrator events). The
-`pendingAsks` map is keyed by the two canonical strings — no
-`ctx.participants` lookup is required on the supervisor side.
+The supervisor's `emitViolation` binds to its existing `emitOrchestratorEvent`
+method (so the `protocol_violation` event inherits the same source tagging as
+other orchestrator events). The `pendingAsks` map is keyed by the two canonical
+strings — no `ctx.participants` lookup is required on the supervisor side.
 
-**Ask-relay plumbing.** Today's supervisor factory wires the supervised
-agent's `Ask` tool through an `onAsk` callback
-(`supervisor.js:396-407`) that calls `supervisorRunner.resume(...)` and
-returns the supervisor's text synchronously. That entire callback path
-is removed. Replacement flow, end-to-end:
+**Ask-relay plumbing.** Today's supervisor factory wires the supervised agent's
+`Ask` tool through an `onAsk` callback (`supervisor.js:396-407`) that calls
+`supervisorRunner.resume(...)` and returns the supervisor's text synchronously.
+That entire callback path is removed. Replacement flow, end-to-end:
 
-- Agent calls `Ask(question)` → Step 1's new `createAskHandler` wired
-  with `{ from: "agent", defaultTo: "supervisor" }` writes a pending
-  entry keyed by `"supervisor"` and publishes via
-  `messageBus.ask("agent", "supervisor", question, askId)`. Agent's turn
-  ends.
-- `#endOfTurnReview` drains `messageBus` for the `"supervisor"` queue
-  before resuming the supervisor; the agent transcript concatenation
-  gains a `[ask] agent: ...` block from the drained ask (Step 2's
-  formatter) and the registry-check prefix from `checkPendingAsk` (if
-  the supervisor ignores the ask).
-- Supervisor calls `Answer(message)` → clears the pending entry,
-  publishes `messageBus.answer("supervisor", "agent", message,
-  askId)` → the agent receives the answer on its next resume.
+- Agent calls `Ask(question)` → Step 1's new `createAskHandler` wired with
+  `{ from: "agent", defaultTo: "supervisor" }` writes a pending entry keyed by
+  `"supervisor"` and publishes via
+  `messageBus.ask("agent", "supervisor", question, askId)`. Agent's turn ends.
+- `#endOfTurnReview` drains `messageBus` for the `"supervisor"` queue before
+  resuming the supervisor; the agent transcript concatenation gains a
+  `[ask] agent: ...` block from the drained ask (Step 2's formatter) and the
+  registry-check prefix from `checkPendingAsk` (if the supervisor ignores the
+  ask).
+- Supervisor calls `Answer(message)` → clears the pending entry, publishes
+  `messageBus.answer("supervisor", "agent", message, askId)` → the agent
+  receives the answer on its next resume.
 
-Compared to the old synchronous shape, this converts the blocking
-mid-tool-call relay into a turn-boundary relay, aligning supervise mode
-with facilitate mode and removing the `onAsk` promise plumbing from
-both factories and from `createSupervisor`.
+Compared to the old synchronous shape, this converts the blocking mid-tool-call
+relay into a turn-boundary relay, aligning supervise mode with facilitate mode
+and removing the `onAsk` promise plumbing from both factories and from
+`createSupervisor`.
 
-**Per-turn mechanics of `agent-runner.js` stay unchanged** per the
-spec's Excluded section. The registry/guard hooks sit in the
-orchestrator wrapper, not inside the runner's iterator consumer. The
-only change inside `agent-runner.js` itself is the addition of a
-`taskAmend` config field (Step 5) — a plain constructor/defaults
-extension with no effect on loop mechanics or ctx checkpoints.
+**Per-turn mechanics of `agent-runner.js` stay unchanged** per the spec's
+Excluded section. The registry/guard hooks sit in the orchestrator wrapper, not
+inside the runner's iterator consumer. The only change inside `agent-runner.js`
+itself is the addition of a `taskAmend` config field (Step 5) — a plain
+constructor/defaults extension with no effect on loop mechanics or ctx
+checkpoints.
 
 **Verify:** `supervisor-run.test.js`, `supervisor-output.test.js`,
-`supervisor-intervention.test.js`, and the new `pending-ask.test.js`
-exercise both enforcement sites. Mid-turn intervention via `#midTurnReview`
-and the `onBatch` path remain unchanged — the registry only affects
-turn-complete transitions.
+`supervisor-intervention.test.js`, and the new `pending-ask.test.js` exercise
+both enforcement sites. Mid-turn intervention via `#midTurnReview` and the
+`onBatch` path remain unchanged — the registry only affects turn-complete
+transitions.
 
 ### Step 5 — Call-site cleanup + config additions
 
-With the toolkit (Step 1), bus (Step 2), and orchestrators (Steps 3–4)
-migrated, clean the remaining call sites.
+With the toolkit (Step 1), bus (Step 2), and orchestrators (Steps 3–4) migrated,
+clean the remaining call sites.
 
-**`Facilitator` / `Supervisor` / `AgentRunner` config surface.** Add
-optional fields:
+**`Facilitator` / `Supervisor` / `AgentRunner` config surface.** Add optional
+fields:
 
-- `systemPromptAmend: string?` — on `Facilitator` participant config only
-  (each entry in `agentConfigs`). Appended verbatim after
+- `systemPromptAmend: string?` — on `Facilitator` participant config only (each
+  entry in `agentConfigs`). Appended verbatim after
   `FACILITATED_AGENT_SYSTEM_PROMPT` with a blank line. Factory-level
   concatenation in `createFacilitator`:
 
@@ -430,43 +410,40 @@ optional fields:
   Pass `trailer` to `systemPromptFor(config.agentProfile, trailer)`.
 
 - `taskAmend: string?` — on `Facilitator`, `Supervisor`, and `AgentRunner`
-  constructor/factory configs. Replaces the CLI-side concatenation
-  currently performed in `commands/{facilitate,supervise,run}.js`. Each
-  orchestrator appends it to the task string just before delivery: the
-  run-side logic is `task + (this.taskAmend ? "\n\n" + this.taskAmend :
-  "")` — appended, preserving today's observable concatenation order so
-  SC 7 (b) holds. Applies to:
+  constructor/factory configs. Replaces the CLI-side concatenation currently
+  performed in `commands/{facilitate,supervise,run}.js`. Each orchestrator
+  appends it to the task string just before delivery: the run-side logic is
+  `task + (this.taskAmend ? "\n\n" + this.taskAmend : "")` — appended,
+  preserving today's observable concatenation order so SC 7 (b) holds. Applies
+  to:
   - `Facilitator.run(task)` — before `this.facilitatorRunner.run(task)`.
-  - `Supervisor.run(task)` — before
-    `this.supervisorRunner.run(task)`.
-  - `AgentRunner.run(task)` — before the `query({ prompt: task, ... })`
-    call.
+  - `Supervisor.run(task)` — before `this.supervisorRunner.run(task)`.
+  - `AgentRunner.run(task)` — before the `query({ prompt: task, ... })` call.
 
-  `AgentRunner`'s `applyDefaults(deps)` function (`agent-runner.js:16-32`)
-  gains one line: `taskAmend: deps.taskAmend ?? null`. No behavioral
-  change to the per-turn loop; loop mechanics stay unchanged per spec §
-  Excluded. Opaque string. No interpretation.
+  `AgentRunner`'s `applyDefaults(deps)` function (`agent-runner.js:16-32`) gains
+  one line: `taskAmend: deps.taskAmend ?? null`. No behavioral change to the
+  per-turn loop; loop mechanics stay unchanged per spec § Excluded. Opaque
+  string. No interpretation.
 
 **CLI layer cleanup.** Remove the `taskAmend` concatenation from
-`commands/facilitate.js`, `commands/supervise.js`, `commands/run.js`; the
-CLI now forwards `--task-amend` value into the respective
-factory/constructor's `taskAmend` option. Option parsing stays the same;
-only the point of concatenation moves.
+`commands/facilitate.js`, `commands/supervise.js`, `commands/run.js`; the CLI
+now forwards `--task-amend` value into the respective factory/constructor's
+`taskAmend` option. Option parsing stays the same; only the point of
+concatenation moves.
 
 **Index exports.** `libraries/libeval/src/index.js` currently re-exports
 `createOrchestrationContext`, `createSupervisorToolServer`,
 `createSupervisedAgentToolServer`, `createFacilitatorToolServer`,
-`createFacilitatedAgentToolServer` (server factories only — no handler
-factories are exported today). After this step, the same set of names
-still exports — `createSupervisedAgentToolServer` has lost its `onAsk`
-parameter (Step 1) but the export name is unchanged. No additions, no
-deletions to `index.js`.
+`createFacilitatedAgentToolServer` (server factories only — no handler factories
+are exported today). After this step, the same set of names still exports —
+`createSupervisedAgentToolServer` has lost its `onAsk` parameter (Step 1) but
+the export name is unchanged. No additions, no deletions to `index.js`.
 
 **Participants list shape.** Unchanged. `ctx.participants` still
 `[{name, role}, ...]`.
 
-**Final grep — tool names.** Run a pair of greps in
-`libraries/libeval/src/` plus `libraries/libeval/test/`:
+**Final grep — tool names.** Run a pair of greps in `libraries/libeval/src/`
+plus `libraries/libeval/test/`:
 
 ```bash
 # No Zod schema or handler uses the removed tool names.
@@ -475,128 +452,120 @@ grep -RnE '"Tell"|"Share"' libraries/libeval/src libraries/libeval/test
 grep -Rn 'tool("Tell\|tool("Share' libraries/libeval/src
 ```
 
-Both must return zero matches. Comments mentioning "shared" or "Tell me"
-are unaffected — the greps target the double-quoted tool-name literals
-the SDK recognises.
+Both must return zero matches. Comments mentioning "shared" or "Tell me" are
+unaffected — the greps target the double-quoted tool-name literals the SDK
+recognises.
 
-**Verify:** `bun run check` across the package compiles; `bun run format`
-leaves the tree clean.
+**Verify:** `bun run check` across the package compiles; `bun run format` leaves
+the tree clean.
 
 ### Step 6 — Test coverage
 
-Rewrite and extend tests in one coherent pass so CI runs once against the
-full surface.
+Rewrite and extend tests in one coherent pass so CI runs once against the full
+surface.
 
 **`test/orchestration-toolkit.test.js`** — rewrite the handler suite:
 
-- `Ask` handler with explicit `to` registers one `ctx.pendingAsks` entry
-  keyed by that addressee, publishes to the bus via `ask()`, returns
-  ack.
-- `Ask` handler with facilitator's `defaultTo: undefined` and no `to`
-  argument registers one entry per non-asker participant (broadcast
-  semantics); verify `ctx.pendingAsks.size === participants.length - 1`.
-- `Ask` handler with participant's `defaultTo: "facilitator"` and no
-  `to` argument registers exactly one entry keyed by `"facilitator"`.
-- `Answer` handler clears the matching pending entry (keyed by the
-  answerer's `from`) and publishes to the bus via `answer()`.
-- `Answer` handler returns `isError: true` when no pending ask matches
-  `from`.
+- `Ask` handler with explicit `to` registers one `ctx.pendingAsks` entry keyed
+  by that addressee, publishes to the bus via `ask()`, returns ack.
+- `Ask` handler with facilitator's `defaultTo: undefined` and no `to` argument
+  registers one entry per non-asker participant (broadcast semantics); verify
+  `ctx.pendingAsks.size === participants.length - 1`.
+- `Ask` handler with participant's `defaultTo: "facilitator"` and no `to`
+  argument registers exactly one entry keyed by `"facilitator"`.
+- `Answer` handler clears the matching pending entry (keyed by the answerer's
+  `from`) and publishes to the bus via `answer()`.
+- `Answer` handler returns `isError: true` when no pending ask matches `from`.
 - `Announce` handler publishes via `announce()` and does **not** touch
   `pendingAsks`.
-- `RollCall`, `Redirect`, `Conclude` — existing tests stay; rename only
-  where they pass input shaped for removed tools.
+- `RollCall`, `Redirect`, `Conclude` — existing tests stay; rename only where
+  they pass input shaped for removed tools.
 - Four server-factory tests (`create*ToolServer returns sdk-type server`)
   continue to pass after the rename — update expected tool-name lists to
   `["Ask", "Announce", "Conclude", "Redirect", "RollCall"]` for
-  facilitator/supervisor and `["Ask", "Answer", "Announce", "RollCall"]`
-  for the two participant-side servers.
+  facilitator/supervisor and `["Ask", "Answer", "Announce", "RollCall"]` for the
+  two participant-side servers.
 
-**`test/message-bus.test.js`** — rewrite around `ask` / `answer` /
-`announce` / `synthetic`. One case per method covering delivery,
-broadcast-except-sender semantics, and queue drain. Existing
-`waitForMessages` + `createMessageBus` tests stay.
+**`test/message-bus.test.js`** — rewrite around `ask` / `answer` / `announce` /
+`synthetic`. One case per method covering delivery, broadcast-except-sender
+semantics, and queue drain. Existing `waitForMessages` + `createMessageBus`
+tests stay.
 
 **`test/facilitator.test.js`** — update existing scenarios:
 
-- Rename helper builders (`tellMsg` → `askMsg`, `shareMsg` → `announceMsg`,
-  add `answerMsg`).
+- Rename helper builders (`tellMsg` → `askMsg`, `shareMsg` → `announceMsg`, add
+  `answerMsg`).
 - Rename toolDispatcher keys.
-- Update message-format assertions to expect `[ask]` / `[answer]` /
-  `[announce]` prefixes.
+- Update message-format assertions to expect `[ask]` / `[answer]` / `[announce]`
+  prefixes.
 - Adjust "lazy start" / "fail-fast" / "turn 0 Conclude" test bodies to use
   `Ask`/`Answer`/`Announce` wording — behavior asserted is unchanged.
 
 **`test/supervisor-output.test.js`** — update the four prompt-constant
 assertions:
 
-- Positive: `SUPERVISOR_SYSTEM_PROMPT` and `AGENT_SYSTEM_PROMPT` each
-  include the tool names `"Ask"`, `"Answer"`, `"Announce"`.
+- Positive: `SUPERVISOR_SYSTEM_PROMPT` and `AGENT_SYSTEM_PROMPT` each include
+  the tool names `"Ask"`, `"Answer"`, `"Announce"`.
 - Negative (SC 4, enforcement-free): neither prompt includes
   `"EVALUATION_COMPLETE"`, `"EVALUATION_INTERVENTION"`, `"then Answer"`,
-  `"then Share"`, `"respond via"`, `"stop making tool calls"`, `"must "`,
-  or `"before your turn"`.
+  `"then Share"`, `"respond via"`, `"stop making tool calls"`, `"must "`, or
+  `"before your turn"`.
 - Negative (SC 4, domain-agnostic): neither prompt includes `"kata-"`,
   `"storyboard"`, `"coaching"`, `"Toyota"`, or `"meeting"`.
 
-Add a parallel suite in `test/facilitator.test.js` (new top-level
-`describe` block) running the same positive + negative assertions
-against `FACILITATOR_SYSTEM_PROMPT` and `FACILITATED_AGENT_SYSTEM_PROMPT`
-so all four prompts are covered.
+Add a parallel suite in `test/facilitator.test.js` (new top-level `describe`
+block) running the same positive + negative assertions against
+`FACILITATOR_SYSTEM_PROMPT` and `FACILITATED_AGENT_SYSTEM_PROMPT` so all four
+prompts are covered.
 
 **`test/supervisor-run.test.js`, `supervisor-intervention.test.js`,
 `supervisor-batching.test.js`** — mechanical renames (`Tell`→`Ask`,
-`Share`→`Announce`, `Ask`→`Answer` on the reply side). Drop every
-reference to the `onAsk` callback — both supervisor-side and agent-side
-constructors no longer accept it.
+`Share`→`Announce`, `Ask`→`Answer` on the reply side). Drop every reference to
+the `onAsk` callback — both supervisor-side and agent-side constructors no
+longer accept it.
 
-**`test/pending-ask.test.js` (new)** — focused coverage of the registry
-and guard. At minimum:
+**`test/pending-ask.test.js` (new)** — focused coverage of the registry and
+guard. At minimum:
 
-- **SC 2 — registry transitions.** `Ask` handler sets a pending entry;
-  `Answer` handler clears it; `Announce` handler leaves `pendingAsks`
-  untouched.
-- **Facilitated, happy path.** `Ask` registers, agent `Answer` clears,
-  no `protocol_violation` event on the wire.
-- **Facilitated, one reminder.** `Ask` registers, agent ignores once,
-  helper queues synthetic reminder, agent answers → no
-  `protocol_violation`.
-- **SC 3 — facilitated violation.** `Ask` registers, agent ignores
-  twice, `protocol_violation` event appears **exactly once**, the
-  facilitator receives the synthetic `"[no answer: … ]"` string on its
-  queue, and the session advances to the next event without
-  deadlocking.
-- **Supervised mode.** Same three cases keyed on the
-  `"supervisor"`/`"agent"` pair, covering both enforcement sites (§
-  Step 4): supervisor→agent and agent→supervisor asks.
+- **SC 2 — registry transitions.** `Ask` handler sets a pending entry; `Answer`
+  handler clears it; `Announce` handler leaves `pendingAsks` untouched.
+- **Facilitated, happy path.** `Ask` registers, agent `Answer` clears, no
+  `protocol_violation` event on the wire.
+- **Facilitated, one reminder.** `Ask` registers, agent ignores once, helper
+  queues synthetic reminder, agent answers → no `protocol_violation`.
+- **SC 3 — facilitated violation.** `Ask` registers, agent ignores twice,
+  `protocol_violation` event appears **exactly once**, the facilitator receives
+  the synthetic `"[no answer: … ]"` string on its queue, and the session
+  advances to the next event without deadlocking.
+- **Supervised mode.** Same three cases keyed on the `"supervisor"`/`"agent"`
+  pair, covering both enforcement sites (§ Step 4): supervisor→agent and
+  agent→supervisor asks.
 - **Broadcast facilitator `Ask`.** Three participants, one ignores.
-  `protocol_violation` is emitted only for the ignoring participant;
-  the other two answers clear their entries; the facilitator's queue
-  receives two `answer` messages plus one synthetic no-answer.
-- **SC 7 (a) — `systemPromptAmend` delivery.** Construct a `Facilitator`
-  with one participant whose config includes `systemPromptAmend:
-  "<TEST_MARKER>"`. Inspect
-  `facilitator.agents[0].runner.systemPrompt` — the `append` field must
-  end with the marker string, and the literal
-  `FACILITATED_AGENT_SYSTEM_PROMPT` must appear before it. Repeat with
-  `systemPromptAmend` absent and assert the `append` field equals
-  `FACILITATED_AGENT_SYSTEM_PROMPT` verbatim — the "absence leaves the
-  prompt purely generic" clause.
-- **SC 7 (b) — `taskAmend` delivery.** Construct a `Facilitator`,
-  `Supervisor`, and `AgentRunner` with `taskAmend: "<TEST_APPEND>"`.
-  Stub the underlying SDK `query` to capture the first `prompt`
-  argument. Assert the captured prompt equals `<task> + "\n\n" +
-  "<TEST_APPEND>"` for each orchestrator — preserving the concatenation
-  shape `commands/{facilitate,supervise,run}.js` produced previously.
-- **`orchestrator-filter`.** `protocol_violation` is **not** in the
-  suppressed set (direct import of `isSuppressedOrchestratorEvent` with
+  `protocol_violation` is emitted only for the ignoring participant; the other
+  two answers clear their entries; the facilitator's queue receives two `answer`
+  messages plus one synthetic no-answer.
+- **SC 7 (a) — `systemPromptAmend` delivery.** Construct a `Facilitator` with
+  one participant whose config includes `systemPromptAmend: "<TEST_MARKER>"`.
+  Inspect `facilitator.agents[0].runner.systemPrompt` — the `append` field must
+  end with the marker string, and the literal `FACILITATED_AGENT_SYSTEM_PROMPT`
+  must appear before it. Repeat with `systemPromptAmend` absent and assert the
+  `append` field equals `FACILITATED_AGENT_SYSTEM_PROMPT` verbatim — the
+  "absence leaves the prompt purely generic" clause.
+- **SC 7 (b) — `taskAmend` delivery.** Construct a `Facilitator`, `Supervisor`,
+  and `AgentRunner` with `taskAmend: "<TEST_APPEND>"`. Stub the underlying SDK
+  `query` to capture the first `prompt` argument. Assert the captured prompt
+  equals `<task> + "\n\n" + "<TEST_APPEND>"` for each orchestrator — preserving
+  the concatenation shape `commands/{facilitate,supervise,run}.js` produced
+  previously.
+- **`orchestrator-filter`.** `protocol_violation` is **not** in the suppressed
+  set (direct import of `isSuppressedOrchestratorEvent` with
   `{type: "protocol_violation"}` returns `false`).
 
-**`test/mock-runner.js`** — no structural edits; scripted
-`toolDispatcher` entries in individual test files switch their keys
-from `Tell`/`Share` to `Ask`/`Answer`/`Announce`, but
-`mock-runner.js` itself remains agnostic to tool names (verified by
-reading its source). Drop `mock-runner.js` from the "Modified" list in
-§ Blast radius.
+**`test/mock-runner.js`** — no structural edits; scripted `toolDispatcher`
+entries in individual test files switch their keys from `Tell`/`Share` to
+`Ask`/`Answer`/`Announce`, but `mock-runner.js` itself remains agnostic to tool
+names (verified by reading its source). Drop `mock-runner.js` from the
+"Modified" list in § Blast radius.
 
 **Verify:** `bun run test` passes the full libeval suite. The
 `pending-ask.test.js` file drives SC 2, SC 3, and the SC 10 clause about
@@ -607,53 +576,50 @@ reading its source). Drop `mock-runner.js` from the "Modified" list in
 Before pushing:
 
 - `bun run check` — type-and-lint clean across the package.
-- `bun run test` — all suites green, including the new `pending-ask`
-  suite.
-- Step 6's prompt-content tests are the machine-checked SC 4 gate. As a
-  human double-check, print each of the four prompt constants from
-  `facilitator.js` / `supervisor.js` and eyeball the text — inspecting
-  the string values, not the identifier names, so the audit catches
-  anything the tests miss.
+- `bun run test` — all suites green, including the new `pending-ask` suite.
+- Step 6's prompt-content tests are the machine-checked SC 4 gate. As a human
+  double-check, print each of the four prompt constants from `facilitator.js` /
+  `supervisor.js` and eyeball the text — inspecting the string values, not the
+  identifier names, so the audit catches anything the tests miss.
 - `grep -RnE '"Tell"|"Share"' libraries/libeval/src libraries/libeval/test`
-  returns zero matches. The quoted tool-name literals are the only
-  Tell/Share usage that matters; unquoted words ("Shared state" in a
-  comment) are fine.
-- `grep -Rn 'tool("Tell\|tool("Share' libraries/libeval/src` returns
-  zero matches — the Zod `tool(...)` constructors for the removed
-  primitives are gone.
+  returns zero matches. The quoted tool-name literals are the only Tell/Share
+  usage that matters; unquoted words ("Shared state" in a comment) are fine.
+- `grep -Rn 'tool("Tell\|tool("Share' libraries/libeval/src` returns zero
+  matches — the Zod `tool(...)` constructors for the removed primitives are
+  gone.
 
 ## Risks
 
 - **Broadcast ask semantics.** A facilitator `Ask` with no `to` creates N
-  pending entries. Design-decision trade-off: if any one participant fails
-  to `Answer`, the facilitator still receives one `protocol_violation`
-  per failing participant. That is the intent (each participant's
-  obligation is independent), but generates more `protocol_violation`
-  events than the single-participant case — invariant queries in Part 03
-  compare counts against expectations per participant, not a flat count.
-  The invariant design accommodates this by asserting count == 0 on
-  success, not a specific cardinality on violation.
-- **Synthetic reminder pollution.** Each unanswered ask costs one extra
-  resume cycle and one extra line in the trace. Acceptable — the whole
-  point is that agents who would otherwise silently fail now visibly
-  recover on the first retry. The trace reader can grep `kind:
-  "synthetic"` to separate these from content messages.
-- **Ask handler `isError`.** Returning `isError: true` from an `Answer`
-  handler when no pending ask exists is a design choice to make misuse
-  loud. A future test that calls `Answer` without a prior `Ask` will see
-  the error surface back to the LLM, which may then retry. This is
-  preferable to silently routing the text as an announcement.
+  pending entries. Design-decision trade-off: if any one participant fails to
+  `Answer`, the facilitator still receives one `protocol_violation` per failing
+  participant. That is the intent (each participant's obligation is
+  independent), but generates more `protocol_violation` events than the
+  single-participant case — invariant queries in Part 03 compare counts against
+  expectations per participant, not a flat count. The invariant design
+  accommodates this by asserting count == 0 on success, not a specific
+  cardinality on violation.
+- **Synthetic reminder pollution.** Each unanswered ask costs one extra resume
+  cycle and one extra line in the trace. Acceptable — the whole point is that
+  agents who would otherwise silently fail now visibly recover on the first
+  retry. The trace reader can grep `kind: "synthetic"` to separate these from
+  content messages.
+- **Ask handler `isError`.** Returning `isError: true` from an `Answer` handler
+  when no pending ask exists is a design choice to make misuse loud. A future
+  test that calls `Answer` without a prior `Ask` will see the error surface back
+  to the LLM, which may then retry. This is preferable to silently routing the
+  text as an announcement.
 
 ## Verification
 
-- SC 1: `grep -l "Tell\|Share" libraries/libeval/src/` returns no tool
-  names (only comments/identifiers).
+- SC 1: `grep -l "Tell\|Share" libraries/libeval/src/` returns no tool names
+  (only comments/identifiers).
 - SC 2: `pending-ask.test.js` covers transition from set → clear.
-- SC 3: `pending-ask.test.js` covers reminder-once, then
-  `protocol_violation` emission, then session advance.
-- SC 4: prompt content assertions in `supervisor-output.test.js` and a
-  parallel suite in `facilitator.test.js` (added in Step 6) verify the
-  vocabulary + absence of enforcement/domain terms.
+- SC 3: `pending-ask.test.js` covers reminder-once, then `protocol_violation`
+  emission, then session advance.
+- SC 4: prompt content assertions in `supervisor-output.test.js` and a parallel
+  suite in `facilitator.test.js` (added in Step 6) verify the vocabulary +
+  absence of enforcement/domain terms.
 - SC 10: `bun run check && bun run test` green.
 
 Out of scope for this part (belong to Parts 02 and 03): SC 5 (kata-session

--- a/specs/620-facilitated-tell-share-response-protocol/plan-a-02.md
+++ b/specs/620-facilitated-tell-share-response-protocol/plan-a-02.md
@@ -1,0 +1,442 @@
+# Plan 620a, Part 02 — Skill rename `kata-storyboard` → `kata-session`
+
+Spec: [`spec.md`](./spec.md). Design: [`design.md`](./design.md). Overview:
+[`plan-a.md`](./plan-a.md).
+
+## Scope
+
+Directory rename, content redistribution into mode overlays, and
+mechanical update of every repository reference to the old name. No code
+changes — markdown and YAML only.
+
+## Approach
+
+Rename in place with `git mv` so history follows. Split the existing
+`SKILL.md` into a mode-agnostic core and two mode overlays: team
+storyboard (retains the artifact + XmR content) and 1-on-1 (adopts the
+participant-trace adaptation currently buried in `coaching-protocol.md`).
+`references/coaching-protocol.md` is redistributed; the two surviving
+references (`metrics.md`, `storyboard-template.md`) stay under
+`references/` unchanged.
+
+Every skill-name reference outside the skill that names
+`kata-storyboard` becomes `kata-session`. Agent-profile `skills:`
+lists, KATA.md Skills table row, KATA.md memory prose reference,
+memory-protocol's named-reader list — all mechanical substitutions
+verified by a final `grep -rn kata-storyboard`.
+
+### SC 6 reconciliation
+
+SC 6 reads: "No file under `.claude/`, `.github/`, `KATA.md`, or
+`website/docs/` contains the string `kata-storyboard` except in
+historical spec/design artifacts under `specs/`." Two identifiers
+survive the rename because they name **the workflow file**, not the
+skill:
+
+- `.github/workflows/kata-storyboard.yml` — filename. Spec § Included
+  says the workflow file is edited for "any skill-name references
+  updated; workflow behaviour otherwise unchanged." Renaming the
+  workflow file is a behavioural change (GitHub Actions keys runs by
+  file path) and is therefore outside spec scope. The concurrency group
+  literal `kata-storyboard` (line 15) names the workflow, not the
+  skill, and stays.
+- `KATA.md` Workflows table row (line 97) — the left column header is
+  "Workflow" and the value **kata-storyboard** refers to the
+  `kata-storyboard.yml` workflow file. Same reasoning.
+
+The reconciliation is **the spec's own words** — SC 6 targets
+skill-name references; these two identifiers are workflow-name
+identifiers. The final grep at Step 10 enumerates the expected survivors
+by file and line so a reviewer can confirm the exemption at a glance
+rather than relying on prose inference.
+
+If a reviewer disagrees with this interpretation, the fallback is to
+rename the workflow file (`git mv`
+`.github/workflows/kata-storyboard.yml` → `kata-session-team.yml`),
+update the concurrency group, and update KATA.md's Workflows row.
+That expansion is out of this plan's scope and would require spec
+revision — Part 02 does not execute it.
+
+## Libraries used
+
+None. This part touches only markdown and YAML.
+
+## Blast radius
+
+**Renamed** (1 directory):
+
+- `.claude/skills/kata-storyboard/` → `.claude/skills/kata-session/`
+  (`git mv`, preserves history on every file inside)
+
+**Modified** (inside the renamed skill, 3 files):
+
+- `kata-session/SKILL.md` — mode-agnostic core; adopts the new Ask/Answer
+  vocabulary; adds a Facilitator Process step about `systemPromptAmend`.
+- `kata-session/references/coaching-protocol.md` — deleted after its
+  content is redistributed (see Created below).
+- `kata-session/references/metrics.md` — unchanged content; moves by
+  virtue of the directory rename.
+- `kata-session/references/storyboard-template.md` — unchanged content;
+  moves by virtue of the directory rename.
+
+**Created** (2 files):
+
+- `kata-session/references/team-storyboard.md` — storyboard artifact
+  description, XmR guidance, CSV recording, planning vs. review mode
+  (content migrated from today's SKILL.md "Storyboard Artifact" + "Meeting
+  Modes" planning/review + coaching-protocol.md team-scoped content).
+- `kata-session/references/one-on-one.md` — participant-trace overlay
+  (content migrated from today's coaching-protocol.md § 1-on-1 Coaching
+  Adaptation + SKILL.md "Meeting Modes" 1-on-1 sub-section).
+
+**Deleted** (1 file):
+
+- `kata-session/references/coaching-protocol.md` — content redistributed
+  into `team-storyboard.md` and `one-on-one.md`.
+
+**Modified** (outside the skill, 10 files):
+
+- `.claude/agents/improvement-coach.md` — `skills:` list entry.
+- `.claude/agents/product-manager.md` — `skills:` list entry.
+- `.claude/agents/release-engineer.md` — `skills:` list entry.
+- `.claude/agents/security-engineer.md` — `skills:` list entry.
+- `.claude/agents/staff-engineer.md` — `skills:` list entry.
+- `.claude/agents/technical-writer.md` — `skills:` list entry.
+- `.claude/agents/references/memory-protocol.md` — two references to
+  `kata-storyboard` in the Tier 2 named-readers list.
+- `KATA.md` — Workflow row (`kata-storyboard` workflow keeps its workflow
+  name but the skill reference in the last paragraph of § Metrics
+  updates), Skills table row (`kata-storyboard` → `kata-session` with
+  purpose-line rewording to reflect mode-agnostic scope), any prose
+  reference.
+- `.github/workflows/kata-storyboard.yml` — `concurrency.group:
+  kata-storyboard` stays (workflow filename keeps its semantic scope; the
+  rename is skill-internal, not workflow-internal). The workflow file is
+  touched only if prose references the skill name directly, which a
+  `grep` verifies. Expected: zero edits; verified, not assumed.
+- `.github/workflows/kata-coaching.yml` — same consideration; the
+  workflow-level skill reference (if any) is updated. Content-level
+  rewrite of this workflow's `task-text` is Part 03's scope, not Part 02.
+
+**Untouched** (explicit non-scope):
+
+- Historical spec artifacts under `specs/` that mention `kata-storyboard`
+  (spec 460, etc.) — SC 6 explicitly exempts `specs/`.
+- Wiki files under `wiki/` — agent memory is append-only audit record;
+  historical mentions stay.
+
+## Step-by-step
+
+### Step 1 — Rename the directory
+
+```bash
+git mv .claude/skills/kata-storyboard .claude/skills/kata-session
+```
+
+This single move migrates `SKILL.md`, `references/coaching-protocol.md`,
+`references/metrics.md`, and `references/storyboard-template.md` in one
+commit with preserved history.
+
+**Verify:** `ls .claude/skills/kata-session/` lists the four files;
+`.claude/skills/kata-storyboard/` is gone; `git log --follow
+.claude/skills/kata-session/SKILL.md` shows the original history.
+
+### Step 2 — Rewrite `kata-session/SKILL.md`
+
+Transform the renamed SKILL.md from storyboard-centric to mode-agnostic.
+
+**Front-matter** — change `name: kata-storyboard` to `name: kata-session`.
+Description rewrite:
+
+```yaml
+name: kata-session
+description: >
+  Toyota Kata coaching protocol for facilitated sessions. Used by the
+  improvement coach (facilitator) and by domain agents who participate
+  via libeval's Ask/Answer/Announce tools. Same five coaching kata
+  questions across team storyboard meetings and 1-on-1 coaching
+  sessions; mode-specific guidance lives in references/team-storyboard.md
+  and references/one-on-one.md.
+```
+
+Note: the skill is not "auto-loaded" on every participant. Libeval stays
+domain-agnostic (SC 4). The facilitator reads this skill from its own
+agent profile's `skills:` list; participants that need the five-question
+structure in context receive it via the participant-side summary passed
+through `systemPromptAmend` (see Facilitator Process below).
+
+**Body structure** (target ~150 lines, well under the 192-line L6 budget):
+
+1. `# Kata Session` heading.
+2. Short preamble explaining the skill is loaded by both facilitator and
+   participants across two modes, with a pointer to mode overlays.
+3. `## When to Use` — two bullets: facilitator use (team storyboard or
+   1-on-1), participant use (auto-loaded when coach calls `Ask`).
+4. `## Checklists` — the existing `<read_do_checklist>` and two
+   `<do_confirm_checklist>` blocks, updated to reference `Ask` / `Answer`
+   instead of `Tell` / `Share`. The facilitator's do-confirm loses the
+   "every coaching question reached participants via Tell or Share" line
+   and gains "every Ask received an Answer or surfaced a
+   `protocol_violation` trace event" — the runtime, not the coach,
+   enforces the relay; the coach confirms it happened.
+5. `## The Five Kata Questions` — concise listing (preserved from
+   `coaching-protocol.md`), framed as mode-agnostic prose. Each question
+   gets one paragraph. Mode-specific wording (e.g., Q2 wording for 1-on-1
+   vs. team) moves to the overlays.
+6. `## Meeting Modes` — one short section with two pointers:
+   > For team storyboard meetings, see
+   > [`references/team-storyboard.md`](references/team-storyboard.md).
+   > For 1-on-1 coaching sessions, see
+   > [`references/one-on-one.md`](references/one-on-one.md).
+7. `## Facilitator Process` — the existing steps (Detect mode, Read the
+   storyboard/select participant overlay, Run XmR, Ask the five
+   questions, Update artifacts, Record metrics, Evaluate coaching need,
+   Commit, Conclude) reworded around Ask/Answer and made mode-agnostic.
+   **New step** between "Read the storyboard/overlay" and "Run XmR":
+
+   > **Propagate participant framing.** Derive a short
+   > participant-side summary from the mode overlay (team-storyboard.md
+   > or one-on-one.md) — one paragraph that names the mode and the
+   > Ask/Answer contract. Pass it as `systemPromptAmend` on each
+   > participant's libeval config. libeval treats the string as opaque
+   > and appends it to each participant's system prompt before the first
+   > `Ask`.
+
+   This step is what SC 7 (c) checks for. The implementer writes the
+   step such that a grep for `systemPromptAmend` finds it.
+8. `## Participant Protocol` — five steps, generic Ask/Answer wording.
+   Q2 recording, CSV append, Announce vs. Answer discrimination
+   (participants Answer the coach; they Announce if they have team-wide
+   context to share unsolicited).
+9. `## Memory: what to record` — unchanged in substance; rewrite to
+   reference "session" rather than "meeting" where the phrasing was
+   team-scoped.
+
+**Remove** from SKILL.md: the ## Storyboard Artifact section (moves to
+team-storyboard.md), the expanded Meeting Modes prose (moves to
+overlays), any direct mention of `wiki/storyboard-YYYY-MNN.md` (overlay
+owns it).
+
+**Verify:** `wc -l .claude/skills/kata-session/SKILL.md` ≤ 192. Content
+mentions `Ask` / `Answer` / `Announce`; does not mention `Tell` /
+`Share`. Front-matter `name: kata-session`.
+
+### Step 3 — Create `references/team-storyboard.md`
+
+Write the storyboard overlay. Content is migrated from today's
+`SKILL.md` (Storyboard Artifact section + Meeting Modes planning/review
+sub-sections) and `coaching-protocol.md` (team-scoped wording of Q1–Q5,
+XmR sparkline direction, storyboard CSV conventions).
+
+**Target shape** (≤ 128 lines per L7 budget):
+
+1. `# Team Storyboard Overlay` — one-paragraph preamble: when this
+   overlay applies (facilitator running `kata-storyboard.yml`;
+   participants joining a team meeting).
+2. `## Artifact` — `wiki/storyboard-YYYY-MNN.md` structure, the five
+   sections (Challenge, Target, Current, Obstacles, Experiments),
+   pointer to `storyboard-template.md`. Use the same-directory relative
+   link `[storyboard-template.md](storyboard-template.md)` — both files
+   live under `kata-session/references/`, so no `../` traversal is
+   needed. Update any cross-reference from SKILL.md that previously
+   linked to `references/storyboard-template.md` to point at this
+   overlay instead (SKILL.md's rewrite in Step 2 already removes the
+   direct link; the overlay inherits the obligation).
+3. `## Planning vs. Review` — two short paragraphs: first meeting of the
+   month creates the storyboard; subsequent meetings update Current
+   Condition, record experiment outcomes, and plan the next experiment.
+4. `## Question Wording (Team)` — the storyboard-flavoured wording for
+   Q1–Q5, moved verbatim from `coaching-protocol.md` (team paragraphs
+   only; the 1-on-1 adaptation moves to `one-on-one.md`).
+5. `## Metrics` — reference to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`
+   + pointer to `metrics.md` for suggested coaching-side metrics;
+   authoritative XmR protocol reference to
+   `../../kata-metrics/references/xmr.md`.
+6. `## Participant-side summary` — a one-paragraph template the
+   facilitator uses verbatim when populating `systemPromptAmend`:
+
+   > "You are joining a team storyboard meeting. The coach will Ask you
+   > five questions via the orchestration `Ask` tool. Reply to each
+   > with `Answer`. Before answering Q2, record your domain metrics to
+   > `wiki/metrics/{agent}/{domain}/{YYYY}.csv`; your Answer references
+   > the CSV row."
+
+**Verify:** `wc -l .claude/skills/kata-session/references/team-storyboard.md`
+≤ 128. Mentions `Ask` / `Answer`; does not mention `Tell` / `Share`.
+
+### Step 4 — Create `references/one-on-one.md`
+
+Write the 1-on-1 coaching overlay. Content migrated from
+`coaching-protocol.md § 1-on-1 Coaching Adaptation` plus the 1-on-1
+paragraph in today's Meeting Modes.
+
+**Target shape** (≤ 128 lines):
+
+1. `# 1-on-1 Coaching Overlay` — preamble: applies to
+   `kata-coaching.yml` runs; one facilitator, one participant.
+2. `## Session Shape` — participant analyzes its own most recent trace
+   via `kata-trace`; the five questions scope to that trace.
+3. `## Question Wording (1-on-1)` — the five reworded questions from
+   `coaching-protocol.md`:
+
+   - Q1: What were you trying to achieve in this run?
+   - Q2: What actually happened? (participant runs `kata-trace`)
+   - Q3: What obstacles prevented better outcomes?
+   - Q4: What will you do differently next run?
+   - Q5: When will you see the effect?
+
+4. `## Participant-side summary` — template the facilitator passes as
+   `systemPromptAmend`:
+
+   > "You are in a 1-on-1 coaching session. The coach will Ask you five
+   > questions via the orchestration `Ask` tool. Reply to each with
+   > `Answer`. Under Q2, run `kata-trace` on your most recent workflow
+   > trace and include the numeric findings in your Answer."
+
+5. `## Trace access` — a short note that the participant uses
+   `kata-trace` against its own agent's trace artifact; the facilitator
+   does not pre-load the trace content into the participant's context.
+
+**Verify:** `wc -l .claude/skills/kata-session/references/one-on-one.md`
+≤ 128.
+
+### Step 5 — Delete `references/coaching-protocol.md`
+
+With its content redistributed into `team-storyboard.md` and
+`one-on-one.md`:
+
+```bash
+git rm .claude/skills/kata-session/references/coaching-protocol.md
+```
+
+**Verify:** `ls .claude/skills/kata-session/references/` lists exactly:
+`metrics.md`, `one-on-one.md`, `storyboard-template.md`,
+`team-storyboard.md`. Four files.
+
+### Step 6 — Update agent profiles
+
+Six agent profiles reference `kata-storyboard` in their `skills:` lists.
+Line numbers drift; anchor the replacement on the exact string instead:
+
+```bash
+grep -l "  - kata-storyboard" .claude/agents/*.md
+```
+
+The six expected files are `improvement-coach.md`,
+`product-manager.md`, `release-engineer.md`, `security-engineer.md`,
+`staff-engineer.md`, `technical-writer.md`. For each, replace the
+single line `  - kata-storyboard` with `  - kata-session`. No other
+edits to these profiles.
+
+**Verify:** `grep -rn "kata-storyboard" .claude/agents/` returns zero
+matches. `grep -rn "kata-session" .claude/agents/` returns six matches
+(one per profile).
+
+### Step 7 — Update `memory-protocol.md`
+
+`.claude/agents/references/memory-protocol.md` names `kata-storyboard` in
+two places:
+
+- Line 24: Tier 2 trigger condition
+- Line 85: Named-readers list
+
+Replace both with `kata-session`. No other edits.
+
+**Verify:** `grep -n "kata-storyboard" .claude/agents/references/memory-protocol.md`
+returns zero matches. `grep -n "kata-session" .claude/agents/references/memory-protocol.md`
+returns two matches.
+
+### Step 8 — Update `KATA.md`
+
+Three references:
+
+- Line 97 (Workflows table): the row reads
+  `| **kata-storyboard** | Daily 08:00 | improvement-coach (facilitates 5
+  agents) |`. This row names the **workflow** `kata-storyboard.yml`, not
+  the skill, and stays as-is — the workflow file is not renamed. Verify
+  by reading the row header: the left column is "Workflow". No edit.
+- Line 129 (Skills table): `| kata-storyboard | Utility | Toyota Kata
+  coaching protocol for meetings |` becomes `| kata-session | Utility |
+  Toyota Kata coaching protocol for facilitated sessions |`.
+- Line 204 (Shared Memory prose): `All agents — both facilitator and
+  participants — load kata-storyboard and kata-metrics.` becomes
+  `... load kata-session and kata-metrics.`
+
+**Verify:** `grep -n "kata-storyboard" KATA.md` returns only the
+Workflows table row (line 97), which names the workflow file correctly.
+`grep -n "kata-session" KATA.md` returns two new matches.
+`scripts/check-instructions.mjs` still passes CLAUDE.md ≤ 192-line
+budget — KATA.md has no line-count gate, but net change is zero lines.
+
+### Step 9 — Verify workflow files untouched
+
+Run `grep -n "kata-storyboard" .github/workflows/kata-storyboard.yml
+.github/workflows/kata-coaching.yml`. Expected: the only match is the
+`concurrency.group: kata-storyboard` literal in
+`kata-storyboard.yml` (a runtime-level concurrency key that names the
+workflow file, not the skill). The coaching workflow's prose-level
+framing is Part 03's scope. No edits in Part 02.
+
+**Verify:** `grep -n "kata-storyboard"
+.github/workflows/kata-storyboard.yml` returns one match (concurrency
+group). `grep -n "kata-storyboard" .github/workflows/kata-coaching.yml`
+returns zero matches.
+
+### Step 10 — Final repo-wide grep
+
+The catchall SC 6 check:
+
+```bash
+grep -rn "kata-storyboard" \
+  .claude/ .github/ KATA.md CLAUDE.md CONTRIBUTING.md website/docs/
+```
+
+Expected: exactly one match — `concurrency.group: kata-storyboard` in
+`.github/workflows/kata-storyboard.yml` (Step 9). Everything else is
+`kata-session`.
+
+If the grep surfaces any other match, fix it before pushing.
+
+**Verify:** match count equals 1 and the single match points at the
+workflow-file concurrency group.
+
+## Risks
+
+- **Skill-name drift in wiki.** The wiki has accumulated weekly-log
+  entries that mention `kata-storyboard` as a past event. These are
+  audit history, not active references, but a future agent reading old
+  logs may copy the name forward. Acceptable — the memory-protocol
+  named-reader list (Step 7) is what triggers fresh reads; no agent
+  rediscovers the skill from historical log text.
+- **Concurrency-group rename risk.** Changing
+  `concurrency.group: kata-storyboard` to `kata-session` in
+  `kata-storyboard.yml` would break the workflow's own concurrency
+  semantics for any currently-running instance. Plan does **not** rename
+  the concurrency group — Step 9 makes this explicit and Step 10's
+  single allowed grep match defends it.
+- **Review panel on split content.** The participant-side summary
+  templates in `team-storyboard.md` and `one-on-one.md` are consumed
+  opaquely by libeval. A reviewer may suggest domain-specific tuning of
+  the summary text; keep the templates short and declarative so
+  `kata-coaching.yml`'s task-text (Part 03) can reference the
+  team-storyboard or one-on-one summary by file path without tight
+  coupling to line content.
+
+## Verification
+
+- SC 5: `ls .claude/skills/kata-session/` shows `SKILL.md` and
+  `references/{team-storyboard,one-on-one}.md` (plus `metrics.md`,
+  `storyboard-template.md`); `.claude/skills/kata-storyboard/` does not
+  exist; `SKILL.md` front-matter names `kata-session`.
+- SC 6: Step 10 grep match count is exactly 1 (the workflow's own
+  concurrency-group literal).
+- SC 7 (c): Step 2 adds the `systemPromptAmend`-propagation step to
+  SKILL.md's Facilitator Process; Steps 3 + 4 provide the summary
+  templates.
+
+## Agent routing
+
+`staff-engineer`. Skill procedure is agent-behavior content, not
+website documentation. The rename + content redistribution is
+mechanical enough that a single staff-engineer pass covers it; TW is not
+required.

--- a/specs/620-facilitated-tell-share-response-protocol/plan-a-02.md
+++ b/specs/620-facilitated-tell-share-response-protocol/plan-a-02.md
@@ -5,56 +5,50 @@ Spec: [`spec.md`](./spec.md). Design: [`design.md`](./design.md). Overview:
 
 ## Scope
 
-Directory rename, content redistribution into mode overlays, and
-mechanical update of every repository reference to the old name. No code
-changes — markdown and YAML only.
+Directory rename, content redistribution into mode overlays, and mechanical
+update of every repository reference to the old name. No code changes — markdown
+and YAML only.
 
 ## Approach
 
-Rename in place with `git mv` so history follows. Split the existing
-`SKILL.md` into a mode-agnostic core and two mode overlays: team
-storyboard (retains the artifact + XmR content) and 1-on-1 (adopts the
-participant-trace adaptation currently buried in `coaching-protocol.md`).
-`references/coaching-protocol.md` is redistributed; the two surviving
-references (`metrics.md`, `storyboard-template.md`) stay under
-`references/` unchanged.
+Rename in place with `git mv` so history follows. Split the existing `SKILL.md`
+into a mode-agnostic core and two mode overlays: team storyboard (retains the
+artifact + XmR content) and 1-on-1 (adopts the participant-trace adaptation
+currently buried in `coaching-protocol.md`). `references/coaching-protocol.md`
+is redistributed; the two surviving references (`metrics.md`,
+`storyboard-template.md`) stay under `references/` unchanged.
 
-Every skill-name reference outside the skill that names
-`kata-storyboard` becomes `kata-session`. Agent-profile `skills:`
-lists, KATA.md Skills table row, KATA.md memory prose reference,
-memory-protocol's named-reader list — all mechanical substitutions
-verified by a final `grep -rn kata-storyboard`.
+Every skill-name reference outside the skill that names `kata-storyboard`
+becomes `kata-session`. Agent-profile `skills:` lists, KATA.md Skills table row,
+KATA.md memory prose reference, memory-protocol's named-reader list — all
+mechanical substitutions verified by a final `grep -rn kata-storyboard`.
 
 ### SC 6 reconciliation
 
-SC 6 reads: "No file under `.claude/`, `.github/`, `KATA.md`, or
-`website/docs/` contains the string `kata-storyboard` except in
-historical spec/design artifacts under `specs/`." Two identifiers
-survive the rename because they name **the workflow file**, not the
-skill:
+SC 6 reads: "No file under `.claude/`, `.github/`, `KATA.md`, or `website/docs/`
+contains the string `kata-storyboard` except in historical spec/design artifacts
+under `specs/`." Two identifiers survive the rename because they name **the
+workflow file**, not the skill:
 
-- `.github/workflows/kata-storyboard.yml` — filename. Spec § Included
-  says the workflow file is edited for "any skill-name references
-  updated; workflow behaviour otherwise unchanged." Renaming the
-  workflow file is a behavioural change (GitHub Actions keys runs by
-  file path) and is therefore outside spec scope. The concurrency group
-  literal `kata-storyboard` (line 15) names the workflow, not the
-  skill, and stays.
-- `KATA.md` Workflows table row (line 97) — the left column header is
-  "Workflow" and the value **kata-storyboard** refers to the
-  `kata-storyboard.yml` workflow file. Same reasoning.
+- `.github/workflows/kata-storyboard.yml` — filename. Spec § Included says the
+  workflow file is edited for "any skill-name references updated; workflow
+  behaviour otherwise unchanged." Renaming the workflow file is a behavioural
+  change (GitHub Actions keys runs by file path) and is therefore outside spec
+  scope. The concurrency group literal `kata-storyboard` (line 15) names the
+  workflow, not the skill, and stays.
+- `KATA.md` Workflows table row (line 97) — the left column header is "Workflow"
+  and the value **kata-storyboard** refers to the `kata-storyboard.yml` workflow
+  file. Same reasoning.
 
-The reconciliation is **the spec's own words** — SC 6 targets
-skill-name references; these two identifiers are workflow-name
-identifiers. The final grep at Step 10 enumerates the expected survivors
-by file and line so a reviewer can confirm the exemption at a glance
-rather than relying on prose inference.
+The reconciliation is **the spec's own words** — SC 6 targets skill-name
+references; these two identifiers are workflow-name identifiers. The final grep
+at Step 10 enumerates the expected survivors by file and line so a reviewer can
+confirm the exemption at a glance rather than relying on prose inference.
 
-If a reviewer disagrees with this interpretation, the fallback is to
-rename the workflow file (`git mv`
-`.github/workflows/kata-storyboard.yml` → `kata-session-team.yml`),
-update the concurrency group, and update KATA.md's Workflows row.
-That expansion is out of this plan's scope and would require spec
+If a reviewer disagrees with this interpretation, the fallback is to rename the
+workflow file (`git mv` `.github/workflows/kata-storyboard.yml` →
+`kata-session-team.yml`), update the concurrency group, and update KATA.md's
+Workflows row. That expansion is out of this plan's scope and would require spec
 revision — Part 02 does not execute it.
 
 ## Libraries used
@@ -65,34 +59,34 @@ None. This part touches only markdown and YAML.
 
 **Renamed** (1 directory):
 
-- `.claude/skills/kata-storyboard/` → `.claude/skills/kata-session/`
-  (`git mv`, preserves history on every file inside)
+- `.claude/skills/kata-storyboard/` → `.claude/skills/kata-session/` (`git mv`,
+  preserves history on every file inside)
 
 **Modified** (inside the renamed skill, 3 files):
 
 - `kata-session/SKILL.md` — mode-agnostic core; adopts the new Ask/Answer
   vocabulary; adds a Facilitator Process step about `systemPromptAmend`.
-- `kata-session/references/coaching-protocol.md` — deleted after its
-  content is redistributed (see Created below).
-- `kata-session/references/metrics.md` — unchanged content; moves by
+- `kata-session/references/coaching-protocol.md` — deleted after its content is
+  redistributed (see Created below).
+- `kata-session/references/metrics.md` — unchanged content; moves by virtue of
+  the directory rename.
+- `kata-session/references/storyboard-template.md` — unchanged content; moves by
   virtue of the directory rename.
-- `kata-session/references/storyboard-template.md` — unchanged content;
-  moves by virtue of the directory rename.
 
 **Created** (2 files):
 
 - `kata-session/references/team-storyboard.md` — storyboard artifact
-  description, XmR guidance, CSV recording, planning vs. review mode
-  (content migrated from today's SKILL.md "Storyboard Artifact" + "Meeting
-  Modes" planning/review + coaching-protocol.md team-scoped content).
-- `kata-session/references/one-on-one.md` — participant-trace overlay
-  (content migrated from today's coaching-protocol.md § 1-on-1 Coaching
-  Adaptation + SKILL.md "Meeting Modes" 1-on-1 sub-section).
+  description, XmR guidance, CSV recording, planning vs. review mode (content
+  migrated from today's SKILL.md "Storyboard Artifact" + "Meeting Modes"
+  planning/review + coaching-protocol.md team-scoped content).
+- `kata-session/references/one-on-one.md` — participant-trace overlay (content
+  migrated from today's coaching-protocol.md § 1-on-1 Coaching Adaptation +
+  SKILL.md "Meeting Modes" 1-on-1 sub-section).
 
 **Deleted** (1 file):
 
-- `kata-session/references/coaching-protocol.md` — content redistributed
-  into `team-storyboard.md` and `one-on-one.md`.
+- `kata-session/references/coaching-protocol.md` — content redistributed into
+  `team-storyboard.md` and `one-on-one.md`.
 
 **Modified** (outside the skill, 10 files):
 
@@ -104,24 +98,23 @@ None. This part touches only markdown and YAML.
 - `.claude/agents/technical-writer.md` — `skills:` list entry.
 - `.claude/agents/references/memory-protocol.md` — two references to
   `kata-storyboard` in the Tier 2 named-readers list.
-- `KATA.md` — Workflow row (`kata-storyboard` workflow keeps its workflow
-  name but the skill reference in the last paragraph of § Metrics
-  updates), Skills table row (`kata-storyboard` → `kata-session` with
-  purpose-line rewording to reflect mode-agnostic scope), any prose
-  reference.
-- `.github/workflows/kata-storyboard.yml` — `concurrency.group:
-  kata-storyboard` stays (workflow filename keeps its semantic scope; the
-  rename is skill-internal, not workflow-internal). The workflow file is
-  touched only if prose references the skill name directly, which a
-  `grep` verifies. Expected: zero edits; verified, not assumed.
-- `.github/workflows/kata-coaching.yml` — same consideration; the
-  workflow-level skill reference (if any) is updated. Content-level
-  rewrite of this workflow's `task-text` is Part 03's scope, not Part 02.
+- `KATA.md` — Workflow row (`kata-storyboard` workflow keeps its workflow name
+  but the skill reference in the last paragraph of § Metrics updates), Skills
+  table row (`kata-storyboard` → `kata-session` with purpose-line rewording to
+  reflect mode-agnostic scope), any prose reference.
+- `.github/workflows/kata-storyboard.yml` — `concurrency.group: kata-storyboard`
+  stays (workflow filename keeps its semantic scope; the rename is
+  skill-internal, not workflow-internal). The workflow file is touched only if
+  prose references the skill name directly, which a `grep` verifies. Expected:
+  zero edits; verified, not assumed.
+- `.github/workflows/kata-coaching.yml` — same consideration; the workflow-level
+  skill reference (if any) is updated. Content-level rewrite of this workflow's
+  `task-text` is Part 03's scope, not Part 02.
 
 **Untouched** (explicit non-scope):
 
-- Historical spec artifacts under `specs/` that mention `kata-storyboard`
-  (spec 460, etc.) — SC 6 explicitly exempts `specs/`.
+- Historical spec artifacts under `specs/` that mention `kata-storyboard` (spec
+  460, etc.) — SC 6 explicitly exempts `specs/`.
 - Wiki files under `wiki/` — agent memory is append-only audit record;
   historical mentions stay.
 
@@ -134,12 +127,13 @@ git mv .claude/skills/kata-storyboard .claude/skills/kata-session
 ```
 
 This single move migrates `SKILL.md`, `references/coaching-protocol.md`,
-`references/metrics.md`, and `references/storyboard-template.md` in one
-commit with preserved history.
+`references/metrics.md`, and `references/storyboard-template.md` in one commit
+with preserved history.
 
 **Verify:** `ls .claude/skills/kata-session/` lists the four files;
-`.claude/skills/kata-storyboard/` is gone; `git log --follow
-.claude/skills/kata-session/SKILL.md` shows the original history.
+`.claude/skills/kata-storyboard/` is gone;
+`git log --follow .claude/skills/kata-session/SKILL.md` shows the original
+history.
 
 ### Step 2 — Rewrite `kata-session/SKILL.md`
 
@@ -160,106 +154,103 @@ description: >
 ```
 
 Note: the skill is not "auto-loaded" on every participant. Libeval stays
-domain-agnostic (SC 4). The facilitator reads this skill from its own
-agent profile's `skills:` list; participants that need the five-question
-structure in context receive it via the participant-side summary passed
-through `systemPromptAmend` (see Facilitator Process below).
+domain-agnostic (SC 4). The facilitator reads this skill from its own agent
+profile's `skills:` list; participants that need the five-question structure in
+context receive it via the participant-side summary passed through
+`systemPromptAmend` (see Facilitator Process below).
 
 **Body structure** (target ~150 lines, well under the 192-line L6 budget):
 
 1. `# Kata Session` heading.
 2. Short preamble explaining the skill is loaded by both facilitator and
    participants across two modes, with a pointer to mode overlays.
-3. `## When to Use` — two bullets: facilitator use (team storyboard or
-   1-on-1), participant use (auto-loaded when coach calls `Ask`).
+3. `## When to Use` — two bullets: facilitator use (team storyboard or 1-on-1),
+   participant use (auto-loaded when coach calls `Ask`).
 4. `## Checklists` — the existing `<read_do_checklist>` and two
    `<do_confirm_checklist>` blocks, updated to reference `Ask` / `Answer`
-   instead of `Tell` / `Share`. The facilitator's do-confirm loses the
-   "every coaching question reached participants via Tell or Share" line
-   and gains "every Ask received an Answer or surfaced a
-   `protocol_violation` trace event" — the runtime, not the coach,
-   enforces the relay; the coach confirms it happened.
+   instead of `Tell` / `Share`. The facilitator's do-confirm loses the "every
+   coaching question reached participants via Tell or Share" line and gains
+   "every Ask received an Answer or surfaced a `protocol_violation` trace event"
+   — the runtime, not the coach, enforces the relay; the coach confirms it
+   happened.
 5. `## The Five Kata Questions` — concise listing (preserved from
-   `coaching-protocol.md`), framed as mode-agnostic prose. Each question
-   gets one paragraph. Mode-specific wording (e.g., Q2 wording for 1-on-1
-   vs. team) moves to the overlays.
+   `coaching-protocol.md`), framed as mode-agnostic prose. Each question gets
+   one paragraph. Mode-specific wording (e.g., Q2 wording for 1-on-1 vs. team)
+   moves to the overlays.
 6. `## Meeting Modes` — one short section with two pointers:
    > For team storyboard meetings, see
-   > [`references/team-storyboard.md`](references/team-storyboard.md).
-   > For 1-on-1 coaching sessions, see
+   > [`references/team-storyboard.md`](references/team-storyboard.md). For
+   > 1-on-1 coaching sessions, see
    > [`references/one-on-one.md`](references/one-on-one.md).
 7. `## Facilitator Process` — the existing steps (Detect mode, Read the
-   storyboard/select participant overlay, Run XmR, Ask the five
-   questions, Update artifacts, Record metrics, Evaluate coaching need,
-   Commit, Conclude) reworded around Ask/Answer and made mode-agnostic.
-   **New step** between "Read the storyboard/overlay" and "Run XmR":
+   storyboard/select participant overlay, Run XmR, Ask the five questions,
+   Update artifacts, Record metrics, Evaluate coaching need, Commit, Conclude)
+   reworded around Ask/Answer and made mode-agnostic. **New step** between "Read
+   the storyboard/overlay" and "Run XmR":
 
-   > **Propagate participant framing.** Derive a short
-   > participant-side summary from the mode overlay (team-storyboard.md
-   > or one-on-one.md) — one paragraph that names the mode and the
-   > Ask/Answer contract. Pass it as `systemPromptAmend` on each
-   > participant's libeval config. libeval treats the string as opaque
-   > and appends it to each participant's system prompt before the first
-   > `Ask`.
+   > **Propagate participant framing.** Derive a short participant-side summary
+   > from the mode overlay (team-storyboard.md or one-on-one.md) — one paragraph
+   > that names the mode and the Ask/Answer contract. Pass it as
+   > `systemPromptAmend` on each participant's libeval config. libeval treats
+   > the string as opaque and appends it to each participant's system prompt
+   > before the first `Ask`.
 
-   This step is what SC 7 (c) checks for. The implementer writes the
-   step such that a grep for `systemPromptAmend` finds it.
-8. `## Participant Protocol` — five steps, generic Ask/Answer wording.
-   Q2 recording, CSV append, Announce vs. Answer discrimination
-   (participants Answer the coach; they Announce if they have team-wide
-   context to share unsolicited).
-9. `## Memory: what to record` — unchanged in substance; rewrite to
-   reference "session" rather than "meeting" where the phrasing was
-   team-scoped.
+   This step is what SC 7 (c) checks for. The implementer writes the step such
+   that a grep for `systemPromptAmend` finds it.
+
+8. `## Participant Protocol` — five steps, generic Ask/Answer wording. Q2
+   recording, CSV append, Announce vs. Answer discrimination (participants
+   Answer the coach; they Announce if they have team-wide context to share
+   unsolicited).
+9. `## Memory: what to record` — unchanged in substance; rewrite to reference
+   "session" rather than "meeting" where the phrasing was team-scoped.
 
 **Remove** from SKILL.md: the ## Storyboard Artifact section (moves to
-team-storyboard.md), the expanded Meeting Modes prose (moves to
-overlays), any direct mention of `wiki/storyboard-YYYY-MNN.md` (overlay
-owns it).
+team-storyboard.md), the expanded Meeting Modes prose (moves to overlays), any
+direct mention of `wiki/storyboard-YYYY-MNN.md` (overlay owns it).
 
-**Verify:** `wc -l .claude/skills/kata-session/SKILL.md` ≤ 192. Content
-mentions `Ask` / `Answer` / `Announce`; does not mention `Tell` /
-`Share`. Front-matter `name: kata-session`.
+**Verify:** `wc -l .claude/skills/kata-session/SKILL.md` ≤ 192. Content mentions
+`Ask` / `Answer` / `Announce`; does not mention `Tell` / `Share`. Front-matter
+`name: kata-session`.
 
 ### Step 3 — Create `references/team-storyboard.md`
 
-Write the storyboard overlay. Content is migrated from today's
-`SKILL.md` (Storyboard Artifact section + Meeting Modes planning/review
-sub-sections) and `coaching-protocol.md` (team-scoped wording of Q1–Q5,
-XmR sparkline direction, storyboard CSV conventions).
+Write the storyboard overlay. Content is migrated from today's `SKILL.md`
+(Storyboard Artifact section + Meeting Modes planning/review sub-sections) and
+`coaching-protocol.md` (team-scoped wording of Q1–Q5, XmR sparkline direction,
+storyboard CSV conventions).
 
 **Target shape** (≤ 128 lines per L7 budget):
 
-1. `# Team Storyboard Overlay` — one-paragraph preamble: when this
-   overlay applies (facilitator running `kata-storyboard.yml`;
-   participants joining a team meeting).
-2. `## Artifact` — `wiki/storyboard-YYYY-MNN.md` structure, the five
-   sections (Challenge, Target, Current, Obstacles, Experiments),
-   pointer to `storyboard-template.md`. Use the same-directory relative
-   link `[storyboard-template.md](storyboard-template.md)` — both files
-   live under `kata-session/references/`, so no `../` traversal is
-   needed. Update any cross-reference from SKILL.md that previously
-   linked to `references/storyboard-template.md` to point at this
-   overlay instead (SKILL.md's rewrite in Step 2 already removes the
-   direct link; the overlay inherits the obligation).
-3. `## Planning vs. Review` — two short paragraphs: first meeting of the
-   month creates the storyboard; subsequent meetings update Current
-   Condition, record experiment outcomes, and plan the next experiment.
-4. `## Question Wording (Team)` — the storyboard-flavoured wording for
-   Q1–Q5, moved verbatim from `coaching-protocol.md` (team paragraphs
-   only; the 1-on-1 adaptation moves to `one-on-one.md`).
+1. `# Team Storyboard Overlay` — one-paragraph preamble: when this overlay
+   applies (facilitator running `kata-storyboard.yml`; participants joining a
+   team meeting).
+2. `## Artifact` — `wiki/storyboard-YYYY-MNN.md` structure, the five sections
+   (Challenge, Target, Current, Obstacles, Experiments), pointer to
+   `storyboard-template.md`. Use the same-directory relative link
+   `[storyboard-template.md](storyboard-template.md)` — both files live under
+   `kata-session/references/`, so no `../` traversal is needed. Update any
+   cross-reference from SKILL.md that previously linked to
+   `references/storyboard-template.md` to point at this overlay instead
+   (SKILL.md's rewrite in Step 2 already removes the direct link; the overlay
+   inherits the obligation).
+3. `## Planning vs. Review` — two short paragraphs: first meeting of the month
+   creates the storyboard; subsequent meetings update Current Condition, record
+   experiment outcomes, and plan the next experiment.
+4. `## Question Wording (Team)` — the storyboard-flavoured wording for Q1–Q5,
+   moved verbatim from `coaching-protocol.md` (team paragraphs only; the 1-on-1
+   adaptation moves to `one-on-one.md`).
 5. `## Metrics` — reference to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`
-   + pointer to `metrics.md` for suggested coaching-side metrics;
-   authoritative XmR protocol reference to
-   `../../kata-metrics/references/xmr.md`.
-6. `## Participant-side summary` — a one-paragraph template the
-   facilitator uses verbatim when populating `systemPromptAmend`:
+   - pointer to `metrics.md` for suggested coaching-side metrics; authoritative
+     XmR protocol reference to `../../kata-metrics/references/xmr.md`.
+6. `## Participant-side summary` — a one-paragraph template the facilitator uses
+   verbatim when populating `systemPromptAmend`:
 
-   > "You are joining a team storyboard meeting. The coach will Ask you
-   > five questions via the orchestration `Ask` tool. Reply to each
-   > with `Answer`. Before answering Q2, record your domain metrics to
-   > `wiki/metrics/{agent}/{domain}/{YYYY}.csv`; your Answer references
-   > the CSV row."
+   > "You are joining a team storyboard meeting. The coach will Ask you five
+   > questions via the orchestration `Ask` tool. Reply to each with `Answer`.
+   > Before answering Q2, record your domain metrics to
+   > `wiki/metrics/{agent}/{domain}/{YYYY}.csv`; your Answer references the CSV
+   > row."
 
 **Verify:** `wc -l .claude/skills/kata-session/references/team-storyboard.md`
 ≤ 128. Mentions `Ask` / `Answer`; does not mention `Tell` / `Share`.
@@ -267,18 +258,17 @@ XmR sparkline direction, storyboard CSV conventions).
 ### Step 4 — Create `references/one-on-one.md`
 
 Write the 1-on-1 coaching overlay. Content migrated from
-`coaching-protocol.md § 1-on-1 Coaching Adaptation` plus the 1-on-1
-paragraph in today's Meeting Modes.
+`coaching-protocol.md § 1-on-1 Coaching Adaptation` plus the 1-on-1 paragraph in
+today's Meeting Modes.
 
 **Target shape** (≤ 128 lines):
 
-1. `# 1-on-1 Coaching Overlay` — preamble: applies to
-   `kata-coaching.yml` runs; one facilitator, one participant.
-2. `## Session Shape` — participant analyzes its own most recent trace
-   via `kata-trace`; the five questions scope to that trace.
+1. `# 1-on-1 Coaching Overlay` — preamble: applies to `kata-coaching.yml` runs;
+   one facilitator, one participant.
+2. `## Session Shape` — participant analyzes its own most recent trace via
+   `kata-trace`; the five questions scope to that trace.
 3. `## Question Wording (1-on-1)` — the five reworded questions from
    `coaching-protocol.md`:
-
    - Q1: What were you trying to achieve in this run?
    - Q2: What actually happened? (participant runs `kata-trace`)
    - Q3: What obstacles prevented better outcomes?
@@ -289,98 +279,97 @@ paragraph in today's Meeting Modes.
    `systemPromptAmend`:
 
    > "You are in a 1-on-1 coaching session. The coach will Ask you five
-   > questions via the orchestration `Ask` tool. Reply to each with
-   > `Answer`. Under Q2, run `kata-trace` on your most recent workflow
-   > trace and include the numeric findings in your Answer."
+   > questions via the orchestration `Ask` tool. Reply to each with `Answer`.
+   > Under Q2, run `kata-trace` on your most recent workflow trace and include
+   > the numeric findings in your Answer."
 
-5. `## Trace access` — a short note that the participant uses
-   `kata-trace` against its own agent's trace artifact; the facilitator
-   does not pre-load the trace content into the participant's context.
+5. `## Trace access` — a short note that the participant uses `kata-trace`
+   against its own agent's trace artifact; the facilitator does not pre-load the
+   trace content into the participant's context.
 
-**Verify:** `wc -l .claude/skills/kata-session/references/one-on-one.md`
-≤ 128.
+**Verify:** `wc -l .claude/skills/kata-session/references/one-on-one.md` ≤ 128.
 
 ### Step 5 — Delete `references/coaching-protocol.md`
 
-With its content redistributed into `team-storyboard.md` and
-`one-on-one.md`:
+With its content redistributed into `team-storyboard.md` and `one-on-one.md`:
 
 ```bash
 git rm .claude/skills/kata-session/references/coaching-protocol.md
 ```
 
 **Verify:** `ls .claude/skills/kata-session/references/` lists exactly:
-`metrics.md`, `one-on-one.md`, `storyboard-template.md`,
-`team-storyboard.md`. Four files.
+`metrics.md`, `one-on-one.md`, `storyboard-template.md`, `team-storyboard.md`.
+Four files.
 
 ### Step 6 — Update agent profiles
 
-Six agent profiles reference `kata-storyboard` in their `skills:` lists.
-Line numbers drift; anchor the replacement on the exact string instead:
+Six agent profiles reference `kata-storyboard` in their `skills:` lists. Line
+numbers drift; anchor the replacement on the exact string instead:
 
 ```bash
 grep -l "  - kata-storyboard" .claude/agents/*.md
 ```
 
-The six expected files are `improvement-coach.md`,
-`product-manager.md`, `release-engineer.md`, `security-engineer.md`,
-`staff-engineer.md`, `technical-writer.md`. For each, replace the
-single line `  - kata-storyboard` with `  - kata-session`. No other
-edits to these profiles.
+The six expected files are `improvement-coach.md`, `product-manager.md`,
+`release-engineer.md`, `security-engineer.md`, `staff-engineer.md`,
+`technical-writer.md`. For each, replace the single line `  - kata-storyboard`
+with `  - kata-session`. No other edits to these profiles.
 
-**Verify:** `grep -rn "kata-storyboard" .claude/agents/` returns zero
-matches. `grep -rn "kata-session" .claude/agents/` returns six matches
-(one per profile).
+**Verify:** `grep -rn "kata-storyboard" .claude/agents/` returns zero matches.
+`grep -rn "kata-session" .claude/agents/` returns six matches (one per profile).
 
 ### Step 7 — Update `memory-protocol.md`
 
-`.claude/agents/references/memory-protocol.md` names `kata-storyboard` in
-two places:
+`.claude/agents/references/memory-protocol.md` names `kata-storyboard` in two
+places:
 
 - Line 24: Tier 2 trigger condition
 - Line 85: Named-readers list
 
 Replace both with `kata-session`. No other edits.
 
-**Verify:** `grep -n "kata-storyboard" .claude/agents/references/memory-protocol.md`
-returns zero matches. `grep -n "kata-session" .claude/agents/references/memory-protocol.md`
-returns two matches.
+**Verify:**
+`grep -n "kata-storyboard" .claude/agents/references/memory-protocol.md` returns
+zero matches.
+`grep -n "kata-session" .claude/agents/references/memory-protocol.md` returns
+two matches.
 
 ### Step 8 — Update `KATA.md`
 
 Three references:
 
 - Line 97 (Workflows table): the row reads
-  `| **kata-storyboard** | Daily 08:00 | improvement-coach (facilitates 5
-  agents) |`. This row names the **workflow** `kata-storyboard.yml`, not
-  the skill, and stays as-is — the workflow file is not renamed. Verify
-  by reading the row header: the left column is "Workflow". No edit.
-- Line 129 (Skills table): `| kata-storyboard | Utility | Toyota Kata
-  coaching protocol for meetings |` becomes `| kata-session | Utility |
-  Toyota Kata coaching protocol for facilitated sessions |`.
-- Line 204 (Shared Memory prose): `All agents — both facilitator and
-  participants — load kata-storyboard and kata-metrics.` becomes
-  `... load kata-session and kata-metrics.`
+  `| **kata-storyboard** | Daily 08:00 | improvement-coach (facilitates 5 agents) |`.
+  This row names the **workflow** `kata-storyboard.yml`, not the skill, and
+  stays as-is — the workflow file is not renamed. Verify by reading the row
+  header: the left column is "Workflow". No edit.
+- Line 129 (Skills table):
+  `| kata-storyboard | Utility | Toyota Kata coaching protocol for meetings |`
+  becomes
+  `| kata-session | Utility | Toyota Kata coaching protocol for facilitated sessions |`.
+- Line 204 (Shared Memory prose):
+  `All agents — both facilitator and participants — load kata-storyboard and kata-metrics.`
+  becomes `... load kata-session and kata-metrics.`
 
-**Verify:** `grep -n "kata-storyboard" KATA.md` returns only the
-Workflows table row (line 97), which names the workflow file correctly.
+**Verify:** `grep -n "kata-storyboard" KATA.md` returns only the Workflows table
+row (line 97), which names the workflow file correctly.
 `grep -n "kata-session" KATA.md` returns two new matches.
-`scripts/check-instructions.mjs` still passes CLAUDE.md ≤ 192-line
-budget — KATA.md has no line-count gate, but net change is zero lines.
+`scripts/check-instructions.mjs` still passes CLAUDE.md ≤ 192-line budget —
+KATA.md has no line-count gate, but net change is zero lines.
 
 ### Step 9 — Verify workflow files untouched
 
-Run `grep -n "kata-storyboard" .github/workflows/kata-storyboard.yml
-.github/workflows/kata-coaching.yml`. Expected: the only match is the
-`concurrency.group: kata-storyboard` literal in
-`kata-storyboard.yml` (a runtime-level concurrency key that names the
-workflow file, not the skill). The coaching workflow's prose-level
-framing is Part 03's scope. No edits in Part 02.
+Run
+`grep -n "kata-storyboard" .github/workflows/kata-storyboard.yml .github/workflows/kata-coaching.yml`.
+Expected: the only match is the `concurrency.group: kata-storyboard` literal in
+`kata-storyboard.yml` (a runtime-level concurrency key that names the workflow
+file, not the skill). The coaching workflow's prose-level framing is Part 03's
+scope. No edits in Part 02.
 
-**Verify:** `grep -n "kata-storyboard"
-.github/workflows/kata-storyboard.yml` returns one match (concurrency
-group). `grep -n "kata-storyboard" .github/workflows/kata-coaching.yml`
-returns zero matches.
+**Verify:** `grep -n "kata-storyboard" .github/workflows/kata-storyboard.yml`
+returns one match (concurrency group).
+`grep -n "kata-storyboard" .github/workflows/kata-coaching.yml` returns zero
+matches.
 
 ### Step 10 — Final repo-wide grep
 
@@ -402,41 +391,37 @@ workflow-file concurrency group.
 
 ## Risks
 
-- **Skill-name drift in wiki.** The wiki has accumulated weekly-log
-  entries that mention `kata-storyboard` as a past event. These are
-  audit history, not active references, but a future agent reading old
-  logs may copy the name forward. Acceptable — the memory-protocol
-  named-reader list (Step 7) is what triggers fresh reads; no agent
-  rediscovers the skill from historical log text.
+- **Skill-name drift in wiki.** The wiki has accumulated weekly-log entries that
+  mention `kata-storyboard` as a past event. These are audit history, not active
+  references, but a future agent reading old logs may copy the name forward.
+  Acceptable — the memory-protocol named-reader list (Step 7) is what triggers
+  fresh reads; no agent rediscovers the skill from historical log text.
 - **Concurrency-group rename risk.** Changing
   `concurrency.group: kata-storyboard` to `kata-session` in
-  `kata-storyboard.yml` would break the workflow's own concurrency
-  semantics for any currently-running instance. Plan does **not** rename
-  the concurrency group — Step 9 makes this explicit and Step 10's
-  single allowed grep match defends it.
-- **Review panel on split content.** The participant-side summary
-  templates in `team-storyboard.md` and `one-on-one.md` are consumed
-  opaquely by libeval. A reviewer may suggest domain-specific tuning of
-  the summary text; keep the templates short and declarative so
-  `kata-coaching.yml`'s task-text (Part 03) can reference the
-  team-storyboard or one-on-one summary by file path without tight
-  coupling to line content.
+  `kata-storyboard.yml` would break the workflow's own concurrency semantics for
+  any currently-running instance. Plan does **not** rename the concurrency group
+  — Step 9 makes this explicit and Step 10's single allowed grep match defends
+  it.
+- **Review panel on split content.** The participant-side summary templates in
+  `team-storyboard.md` and `one-on-one.md` are consumed opaquely by libeval. A
+  reviewer may suggest domain-specific tuning of the summary text; keep the
+  templates short and declarative so `kata-coaching.yml`'s task-text (Part 03)
+  can reference the team-storyboard or one-on-one summary by file path without
+  tight coupling to line content.
 
 ## Verification
 
 - SC 5: `ls .claude/skills/kata-session/` shows `SKILL.md` and
   `references/{team-storyboard,one-on-one}.md` (plus `metrics.md`,
-  `storyboard-template.md`); `.claude/skills/kata-storyboard/` does not
-  exist; `SKILL.md` front-matter names `kata-session`.
+  `storyboard-template.md`); `.claude/skills/kata-storyboard/` does not exist;
+  `SKILL.md` front-matter names `kata-session`.
 - SC 6: Step 10 grep match count is exactly 1 (the workflow's own
   concurrency-group literal).
-- SC 7 (c): Step 2 adds the `systemPromptAmend`-propagation step to
-  SKILL.md's Facilitator Process; Steps 3 + 4 provide the summary
-  templates.
+- SC 7 (c): Step 2 adds the `systemPromptAmend`-propagation step to SKILL.md's
+  Facilitator Process; Steps 3 + 4 provide the summary templates.
 
 ## Agent routing
 
-`staff-engineer`. Skill procedure is agent-behavior content, not
-website documentation. The rename + content redistribution is
-mechanical enough that a single staff-engineer pass covers it; TW is not
-required.
+`staff-engineer`. Skill procedure is agent-behavior content, not website
+documentation. The rename + content redistribution is mechanical enough that a
+single staff-engineer pass covers it; TW is not required.

--- a/specs/620-facilitated-tell-share-response-protocol/plan-a-03.md
+++ b/specs/620-facilitated-tell-share-response-protocol/plan-a-03.md
@@ -7,8 +7,8 @@ Spec: [`spec.md`](./spec.md). Design: [`design.md`](./design.md). Overview:
 
 Two small surfaces:
 
-1. Rewrite `.github/workflows/kata-coaching.yml`'s `task-text` to carry
-   the coaching framing libeval's generic prompts deliberately omit.
+1. Rewrite `.github/workflows/kata-coaching.yml`'s `task-text` to carry the
+   coaching framing libeval's generic prompts deliberately omit.
 2. Add two `protocol_violation` entries to
    `.claude/skills/kata-trace/references/invariants.md` — one per mode.
 
@@ -16,18 +16,17 @@ No code changes. No skill changes (Part 02 owns those).
 
 ## Approach
 
-The coaching framing lives here because libeval stays generic (SC 4) and
-the skill name lives in Part 02. This part depends on Part 01 (runtime
-must accept `systemPromptAmend` and emit `protocol_violation`) and on
-Part 02 (the skill name `kata-session` and the one-on-one overlay must
-exist for the task-text to reference them).
+The coaching framing lives here because libeval stays generic (SC 4) and the
+skill name lives in Part 02. This part depends on Part 01 (runtime must accept
+`systemPromptAmend` and emit `protocol_violation`) and on Part 02 (the skill
+name `kata-session` and the one-on-one overlay must exist for the task-text to
+reference them).
 
-The invariants reuse the existing kata-trace catalogue shape. The
-evidence function — "count `protocol_violation` events in the combined
-trace; assert `Conclude` cardinality equals 1 on success" — is written
-once as prose in the invariant entry and applies to both modes
-(facilitated and supervised) with the only difference being which trace
-artifact is consulted.
+The invariants reuse the existing kata-trace catalogue shape. The evidence
+function — "count `protocol_violation` events in the combined trace; assert
+`Conclude` cardinality equals 1 on success" — is written once as prose in the
+invariant entry and applies to both modes (facilitated and supervised) with the
+only difference being which trace artifact is consulted.
 
 ## Libraries used
 
@@ -37,12 +36,11 @@ None. This part touches one workflow YAML and one reference markdown.
 
 **Modified** (2 files):
 
-- `.github/workflows/kata-coaching.yml` — `task-text` replaced (lines
-  52–56 in the current file, within the `with:` block of the
-  `1-on-1 Coaching Session` step).
+- `.github/workflows/kata-coaching.yml` — `task-text` replaced (lines 52–56 in
+  the current file, within the `with:` block of the `1-on-1 Coaching Session`
+  step).
 - `.claude/skills/kata-trace/references/invariants.md` — append a new
-  `## Orchestrator traces` section at the end, containing one row per
-  mode.
+  `## Orchestrator traces` section at the end, containing one row per mode.
 
 **Created / Deleted**: none.
 
@@ -52,30 +50,28 @@ None. This part touches one workflow YAML and one reference markdown.
 
 The current task-text (lines 52–56):
 
-> "Facilitate a 1-on-1 coaching session with the participant agent.
-> Guide them through the five coaching kata questions. Have them
-> analyze their own most recent trace using kata-trace. Help them
-> identify obstacles and design their next experiment."
+> "Facilitate a 1-on-1 coaching session with the participant agent. Guide them
+> through the five coaching kata questions. Have them analyze their own most
+> recent trace using kata-trace. Help them identify obstacles and design their
+> next experiment."
 
 Replace with a block that:
 
 - Names the mode.
-- Names the target participant (via `${{ inputs.agent }}`, same as
-  today — but referenced as "target participant" not "participant
-  agent").
-- Points to `kata-session` by name, and to its one-on-one overlay
-  specifically.
-- Instructs the coach to derive the participant-side summary from the
-  overlay and pass it to libeval via `systemPromptAmend`.
+- Names the target participant (via `${{ inputs.agent }}`, same as today — but
+  referenced as "target participant" not "participant agent").
+- Points to `kata-session` by name, and to its one-on-one overlay specifically.
+- Instructs the coach to derive the participant-side summary from the overlay
+  and pass it to libeval via `systemPromptAmend`.
 - Does **not** prescribe Q1 content (SC 8).
-- Does **not** assign participant-side work (SC 8: no "have them
-  analyze their trace using kata-trace").
+- Does **not** assign participant-side work (SC 8: no "have them analyze their
+  trace using kata-trace").
 - Does **not** name participant tools (SC 8).
-- Does **not** carry enforcement phrasing (SC 8: no "then Answer", no
-  "stop making tool calls", no "respond via Answer").
+- Does **not** carry enforcement phrasing (SC 8: no "then Answer", no "stop
+  making tool calls", no "respond via Answer").
 
-Proposed replacement (YAML folded-block style to match the current
-file; adjust whitespace per file formatting):
+Proposed replacement (YAML folded-block style to match the current file; adjust
+whitespace per file formatting):
 
 ```yaml
 task-text: >-
@@ -99,28 +95,26 @@ Key properties verified by reading the YAML:
 - Names the target participant via `${{ inputs.agent }}`. ✓
 - Points to `kata-session` by skill name and to the overlay by path. ✓
 - Instructs the coach to derive + pass the summary. ✓
-- Does not prescribe Q1 content; does not assign participant work;
-  does not name participant tools; does not carry enforcement
-  phrasing. ✓
+- Does not prescribe Q1 content; does not assign participant work; does not name
+  participant tools; does not carry enforcement phrasing. ✓
 
-Shape is not reduced to a single sentence (spec § Rewritten task-text
-explicitly allows this) and does not need to match `kata-storyboard.yml`.
+Shape is not reduced to a single sentence (spec § Rewritten task-text explicitly
+allows this) and does not need to match `kata-storyboard.yml`.
 
-**Do not edit** the `task-amend` input, concurrency group, timeout, or
-any other workflow key. The rewrite is confined to the `task-text` value.
+**Do not edit** the `task-amend` input, concurrency group, timeout, or any other
+workflow key. The rewrite is confined to the `task-text` value.
 
-**Verify** — precise greps targeting SC 8's clauses directly rather
-than broad alternations:
+**Verify** — precise greps targeting SC 8's clauses directly rather than broad
+alternations:
 
-- **No participant-tool naming** (SC 8: "does not name tools the
-  participant should use"):
+- **No participant-tool naming** (SC 8: "does not name tools the participant
+  should use"):
   ```bash
   grep -nE 'kata-trace|kata-metrics|kata-implement|Bash|Read|Grep|Glob'
   .github/workflows/kata-coaching.yml
   ```
   Zero matches in the `task-text:` block.
-- **No enforcement phrasing** (SC 8: "stop making tool calls", "then
-  Share"):
+- **No enforcement phrasing** (SC 8: "stop making tool calls", "then Share"):
   ```bash
   grep -nE 'then Answer|then Share|respond via|stop making|must Answer|before your turn'
   .github/workflows/kata-coaching.yml
@@ -141,12 +135,11 @@ than broad alternations:
 
 ### Step 2 — Add `protocol_violation` invariants
 
-Append a new section to
-`.claude/skills/kata-trace/references/invariants.md` after the
-"Cross-cutting invariants" section (currently the last section). The
-invariants file is a layer-7 reference with no line budget beyond the
-128-line L7 guideline — current file is ~78 lines; the addition brings
-it to ~105 lines, within budget.
+Append a new section to `.claude/skills/kata-trace/references/invariants.md`
+after the "Cross-cutting invariants" section (currently the last section). The
+invariants file is a layer-7 reference with no line budget beyond the 128-line
+L7 guideline — current file is ~78 lines; the addition brings it to ~105 lines,
+within budget.
 
 Append:
 
@@ -193,49 +186,45 @@ double-conclude bug (more than one).
 - `wc -l .claude/skills/kata-trace/references/invariants.md` ≤ 128.
 - `grep -n "protocol_violation" .claude/skills/kata-trace/references/invariants.md`
   returns at least two matches (one per entry).
-- Query V and Query C parse and return integers. Dry-run against the
-  combined trace captured by the kata-storyboard workflow run following
-  Part 03's merge (artifact retention on successful scheduled runs
-  keeps the artifact available for at least the 90-day default). Do not
-  reference a specific historical run id in the reference file.
+- Query V and Query C parse and return integers. Dry-run against the combined
+  trace captured by the kata-storyboard workflow run following Part 03's merge
+  (artifact retention on successful scheduled runs keeps the artifact available
+  for at least the 90-day default). Do not reference a specific historical run
+  id in the reference file.
 
 ## Risks
 
 - **jq query fragility.** The invariant queries depend on
-  `combined-trace.ndjson` being the canonical name kata-action uploads
-  (see `.github/actions/kata-action/action.yml` § Upload combined
-  trace). If a future spec renames that artifact, both invariants
-  break. Mitigation: the evidence prose names the combined trace by
-  shape ("combined trace produced by `fit-eval facilitate`") so the
-  intent survives a name change and the query text can be rewritten
-  mechanically.
-- **Summary-success coupling.** The current facilitator emits a
-  `summary` event with `success: true` when `ctx.concluded`. The
-  invariant's "success == true" branch is redundant with "Conclude
-  cardinality == 1" — if the session concluded, success is true; if
-  it didn't, there is no single `Conclude`. Kept together because the
-  two signals are independent at emission: a run that concluded but
-  emitted a protocol_violation is still a violation, and the invariant
-  correctly flags it.
-- **Cross-mode copy-paste drift.** Two near-identical invariant rows
-  invite a future editor to update one and forget the other. The
-  preamble explicitly calls out shared evidence so reviewers grep for
-  both entries together.
+  `combined-trace.ndjson` being the canonical name kata-action uploads (see
+  `.github/actions/kata-action/action.yml` § Upload combined trace). If a future
+  spec renames that artifact, both invariants break. Mitigation: the evidence
+  prose names the combined trace by shape ("combined trace produced by
+  `fit-eval facilitate`") so the intent survives a name change and the query
+  text can be rewritten mechanically.
+- **Summary-success coupling.** The current facilitator emits a `summary` event
+  with `success: true` when `ctx.concluded`. The invariant's "success == true"
+  branch is redundant with "Conclude cardinality == 1" — if the session
+  concluded, success is true; if it didn't, there is no single `Conclude`. Kept
+  together because the two signals are independent at emission: a run that
+  concluded but emitted a protocol_violation is still a violation, and the
+  invariant correctly flags it.
+- **Cross-mode copy-paste drift.** Two near-identical invariant rows invite a
+  future editor to update one and forget the other. The preamble explicitly
+  calls out shared evidence so reviewers grep for both entries together.
 
 ## Verification
 
-- SC 8: `kata-coaching.yml` `task-text` properties asserted by the
-  greps in Step 1.
-- SC 9: invariant entries present; `jq` queries run against real
-  artifacts.
+- SC 8: `kata-coaching.yml` `task-text` properties asserted by the greps in
+  Step 1.
+- SC 9: invariant entries present; `jq` queries run against real artifacts.
 
-Full-plan validation (per the spec's validation note — one kata-coaching
-run, one kata-storyboard run, one supervise run) is the implementer's
-responsibility after all three parts are on `main`. It is not a Part 03
-step because it requires Parts 01 + 02 + 03 to all be merged first.
+Full-plan validation (per the spec's validation note — one kata-coaching run,
+one kata-storyboard run, one supervise run) is the implementer's responsibility
+after all three parts are on `main`. It is not a Part 03 step because it
+requires Parts 01 + 02 + 03 to all be merged first.
 
 ## Agent routing
 
 `staff-engineer`. Workflow YAML and invariant catalogue sit close to
-orchestration behavior, not to end-user documentation. TW is not
-required — this is skill/agent infrastructure.
+orchestration behavior, not to end-user documentation. TW is not required — this
+is skill/agent infrastructure.

--- a/specs/620-facilitated-tell-share-response-protocol/plan-a-03.md
+++ b/specs/620-facilitated-tell-share-response-protocol/plan-a-03.md
@@ -1,0 +1,241 @@
+# Plan 620a, Part 03 — Coaching workflow + `protocol_violation` invariants
+
+Spec: [`spec.md`](./spec.md). Design: [`design.md`](./design.md). Overview:
+[`plan-a.md`](./plan-a.md).
+
+## Scope
+
+Two small surfaces:
+
+1. Rewrite `.github/workflows/kata-coaching.yml`'s `task-text` to carry
+   the coaching framing libeval's generic prompts deliberately omit.
+2. Add two `protocol_violation` entries to
+   `.claude/skills/kata-trace/references/invariants.md` — one per mode.
+
+No code changes. No skill changes (Part 02 owns those).
+
+## Approach
+
+The coaching framing lives here because libeval stays generic (SC 4) and
+the skill name lives in Part 02. This part depends on Part 01 (runtime
+must accept `systemPromptAmend` and emit `protocol_violation`) and on
+Part 02 (the skill name `kata-session` and the one-on-one overlay must
+exist for the task-text to reference them).
+
+The invariants reuse the existing kata-trace catalogue shape. The
+evidence function — "count `protocol_violation` events in the combined
+trace; assert `Conclude` cardinality equals 1 on success" — is written
+once as prose in the invariant entry and applies to both modes
+(facilitated and supervised) with the only difference being which trace
+artifact is consulted.
+
+## Libraries used
+
+None. This part touches one workflow YAML and one reference markdown.
+
+## Blast radius
+
+**Modified** (2 files):
+
+- `.github/workflows/kata-coaching.yml` — `task-text` replaced (lines
+  52–56 in the current file, within the `with:` block of the
+  `1-on-1 Coaching Session` step).
+- `.claude/skills/kata-trace/references/invariants.md` — append a new
+  `## Orchestrator traces` section at the end, containing one row per
+  mode.
+
+**Created / Deleted**: none.
+
+## Step-by-step
+
+### Step 1 — Rewrite `kata-coaching.yml` task-text
+
+The current task-text (lines 52–56):
+
+> "Facilitate a 1-on-1 coaching session with the participant agent.
+> Guide them through the five coaching kata questions. Have them
+> analyze their own most recent trace using kata-trace. Help them
+> identify obstacles and design their next experiment."
+
+Replace with a block that:
+
+- Names the mode.
+- Names the target participant (via `${{ inputs.agent }}`, same as
+  today — but referenced as "target participant" not "participant
+  agent").
+- Points to `kata-session` by name, and to its one-on-one overlay
+  specifically.
+- Instructs the coach to derive the participant-side summary from the
+  overlay and pass it to libeval via `systemPromptAmend`.
+- Does **not** prescribe Q1 content (SC 8).
+- Does **not** assign participant-side work (SC 8: no "have them
+  analyze their trace using kata-trace").
+- Does **not** name participant tools (SC 8).
+- Does **not** carry enforcement phrasing (SC 8: no "then Answer", no
+  "stop making tool calls", no "respond via Answer").
+
+Proposed replacement (YAML folded-block style to match the current
+file; adjust whitespace per file formatting):
+
+```yaml
+task-text: >-
+  Facilitate a 1-on-1 coaching session in kata-session mode with
+  participant "${{ inputs.agent }}".
+
+  Load the kata-session skill. Its one-on-one overlay
+  (.claude/skills/kata-session/references/one-on-one.md) describes the
+  session shape, the five-question wording for 1-on-1 mode, and a
+  participant-side summary template.
+
+  Before the first Ask, derive the participant-side summary from the
+  one-on-one overlay and pass it to libeval as systemPromptAmend on the
+  participant config. libeval delivers it into the participant's system
+  prompt before any Ask is sent.
+```
+
+Key properties verified by reading the YAML:
+
+- Names the mode ("kata-session", "1-on-1"). ✓
+- Names the target participant via `${{ inputs.agent }}`. ✓
+- Points to `kata-session` by skill name and to the overlay by path. ✓
+- Instructs the coach to derive + pass the summary. ✓
+- Does not prescribe Q1 content; does not assign participant work;
+  does not name participant tools; does not carry enforcement
+  phrasing. ✓
+
+Shape is not reduced to a single sentence (spec § Rewritten task-text
+explicitly allows this) and does not need to match `kata-storyboard.yml`.
+
+**Do not edit** the `task-amend` input, concurrency group, timeout, or
+any other workflow key. The rewrite is confined to the `task-text` value.
+
+**Verify** — precise greps targeting SC 8's clauses directly rather
+than broad alternations:
+
+- **No participant-tool naming** (SC 8: "does not name tools the
+  participant should use"):
+  ```bash
+  grep -nE 'kata-trace|kata-metrics|kata-implement|Bash|Read|Grep|Glob'
+  .github/workflows/kata-coaching.yml
+  ```
+  Zero matches in the `task-text:` block.
+- **No enforcement phrasing** (SC 8: "stop making tool calls", "then
+  Share"):
+  ```bash
+  grep -nE 'then Answer|then Share|respond via|stop making|must Answer|before your turn'
+  .github/workflows/kata-coaching.yml
+  ```
+  Zero matches.
+- **No Q1 content prescription / no participant-work assignment**:
+  ```bash
+  grep -nE 'Q1|first question|analyze.*trace|have (them|the participant)'
+  .github/workflows/kata-coaching.yml
+  ```
+  Zero matches.
+- **Positive: task-text primes the propagation step** (SC 7 (d)):
+  ```bash
+  grep -nE 'kata-session|systemPromptAmend|one-on-one'
+  .github/workflows/kata-coaching.yml
+  ```
+  At least one match per token inside the `task-text:` block.
+
+### Step 2 — Add `protocol_violation` invariants
+
+Append a new section to
+`.claude/skills/kata-trace/references/invariants.md` after the
+"Cross-cutting invariants" section (currently the last section). The
+invariants file is a layer-7 reference with no line budget beyond the
+128-line L7 guideline — current file is ~78 lines; the addition brings
+it to ~105 lines, within budget.
+
+Append:
+
+```markdown
+## Orchestrator traces
+
+Applicable to combined traces produced by `fit-eval facilitate` and
+`fit-eval supervise`. Both invariants use the same two evidence
+queries — the only axis of difference is which trace the queries run
+against.
+
+**Query V — protocol_violation cardinality.** Count `protocol_violation`
+events emitted by the orchestrator:
+
+    jq -c 'select(.source == "orchestrator" and .event.type == "protocol_violation")' \
+        combined-trace.ndjson | wc -l
+
+Must return `0` on a healthy run.
+
+**Query C — Conclude cardinality.** Count `Conclude` tool calls emitted
+by the facilitator / supervisor (the orchestrator's `tool_use` blocks
+name the tool explicitly):
+
+    jq -c 'select(.event.type == "assistant") | .event.message.content[]? |
+           select(.type == "tool_use" and .name == "Conclude")' \
+        combined-trace.ndjson | wc -l
+
+Must return `1` on a healthy run.
+
+| Invariant                                         | Evidence to find                       | Severity |
+| ------------------------------------------------- | -------------------------------------- | -------- |
+| Facilitated-mode request-response contract held   | Query V == 0 AND Query C == 1 against the combined trace of a `fit-eval facilitate` run | **High** |
+| Supervised-mode request-response contract held    | Query V == 0 AND Query C == 1 against the combined trace of a `fit-eval supervise` run  | **High** |
+
+A run with one or more `protocol_violation` events is a high-severity
+finding: the runtime observed an agent ignoring its reply obligation
+across the single allowed reminder. A Conclude count other than 1
+indicates either a silent-deadlock exit (zero Concludes) or a
+double-conclude bug (more than one).
+```
+
+**Verify:**
+
+- `wc -l .claude/skills/kata-trace/references/invariants.md` ≤ 128.
+- `grep -n "protocol_violation" .claude/skills/kata-trace/references/invariants.md`
+  returns at least two matches (one per entry).
+- Query V and Query C parse and return integers. Dry-run against the
+  combined trace captured by the kata-storyboard workflow run following
+  Part 03's merge (artifact retention on successful scheduled runs
+  keeps the artifact available for at least the 90-day default). Do not
+  reference a specific historical run id in the reference file.
+
+## Risks
+
+- **jq query fragility.** The invariant queries depend on
+  `combined-trace.ndjson` being the canonical name kata-action uploads
+  (see `.github/actions/kata-action/action.yml` § Upload combined
+  trace). If a future spec renames that artifact, both invariants
+  break. Mitigation: the evidence prose names the combined trace by
+  shape ("combined trace produced by `fit-eval facilitate`") so the
+  intent survives a name change and the query text can be rewritten
+  mechanically.
+- **Summary-success coupling.** The current facilitator emits a
+  `summary` event with `success: true` when `ctx.concluded`. The
+  invariant's "success == true" branch is redundant with "Conclude
+  cardinality == 1" — if the session concluded, success is true; if
+  it didn't, there is no single `Conclude`. Kept together because the
+  two signals are independent at emission: a run that concluded but
+  emitted a protocol_violation is still a violation, and the invariant
+  correctly flags it.
+- **Cross-mode copy-paste drift.** Two near-identical invariant rows
+  invite a future editor to update one and forget the other. The
+  preamble explicitly calls out shared evidence so reviewers grep for
+  both entries together.
+
+## Verification
+
+- SC 8: `kata-coaching.yml` `task-text` properties asserted by the
+  greps in Step 1.
+- SC 9: invariant entries present; `jq` queries run against real
+  artifacts.
+
+Full-plan validation (per the spec's validation note — one kata-coaching
+run, one kata-storyboard run, one supervise run) is the implementer's
+responsibility after all three parts are on `main`. It is not a Part 03
+step because it requires Parts 01 + 02 + 03 to all be merged first.
+
+## Agent routing
+
+`staff-engineer`. Workflow YAML and invariant catalogue sit close to
+orchestration behavior, not to end-user documentation. TW is not
+required — this is skill/agent infrastructure.

--- a/specs/620-facilitated-tell-share-response-protocol/plan-a.md
+++ b/specs/620-facilitated-tell-share-response-protocol/plan-a.md
@@ -6,40 +6,40 @@ Spec: [`spec.md`](./spec.md). Design: [`design.md`](./design.md).
 
 The spec replaces a three-tool, prose-enforced messaging surface
 (`Tell`/`Share`/blocking `Ask`) with a symmetric three-tool contract
-(`Ask`/`Answer`/`Announce`) whose request–response obligation is enforced at
-the libeval runtime. Three surfaces change in lockstep: the library code and
-its tests, the domain-facing skill that coaches use to facilitate meetings,
-and the coaching workflow + invariant catalogue that exercise and audit the
-new contract.
+(`Ask`/`Answer`/`Announce`) whose request–response obligation is enforced at the
+libeval runtime. Three surfaces change in lockstep: the library code and its
+tests, the domain-facing skill that coaches use to facilitate meetings, and the
+coaching workflow + invariant catalogue that exercise and audit the new
+contract.
 
 The changes group naturally into three independently-executable parts:
 
 - **Part 01 — libeval runtime.** The contract itself: new tools, pending-ask
   registry, turn-complete guard, `protocol_violation` event, prompt rewrites,
-  `systemPromptAmend` / `taskAmend` config family, test coverage.
-  Self-contained — no skill or workflow depends on the intermediate state.
-- **Part 02 — kata-session skill + repo references.** Directory rename,
-  content redistribution into mode overlays, mechanical replacement of
-  `kata-storyboard` → `kata-session` across agent profiles, KATA.md, the
-  storyboard workflow, memory-protocol, and website internals.
+  `systemPromptAmend` / `taskAmend` config family, test coverage. Self-contained
+  — no skill or workflow depends on the intermediate state.
+- **Part 02 — kata-session skill + repo references.** Directory rename, content
+  redistribution into mode overlays, mechanical replacement of `kata-storyboard`
+  → `kata-session` across agent profiles, KATA.md, the storyboard workflow,
+  memory-protocol, and website internals.
 - **Part 03 — coaching workflow + kata-trace invariants.** Rewrite
   `kata-coaching.yml` task-text to carry the coaching framing (mode, target,
   `kata-session` pointer, participant-side summary) and add the two
   `protocol_violation` invariant entries.
 
-Part 01 is the prerequisite for both 02 and 03: the skill's Facilitator
-Process references the new `systemPromptAmend` surface; the workflow's
-task-text instructs the coach to use that surface; the invariants reference
-the `protocol_violation` event type emitted by the new runtime. Parts 02 and
-03 touch disjoint files and share no build-time coupling, so they can run
+Part 01 is the prerequisite for both 02 and 03: the skill's Facilitator Process
+references the new `systemPromptAmend` surface; the workflow's task-text
+instructs the coach to use that surface; the invariants reference the
+`protocol_violation` event type emitted by the new runtime. Parts 02 and 03
+touch disjoint files and share no build-time coupling, so they can run
 concurrently once Part 01 has merged.
 
 ## Part index
 
-| Part | File                           | Scope                                                              | Depends on |
-| ---- | ------------------------------ | ------------------------------------------------------------------ | ---------- |
-| 01   | [`plan-a-01.md`](./plan-a-01.md) | libeval tool surface, pending-ask runtime, prompts, config, tests | —          |
-| 02   | [`plan-a-02.md`](./plan-a-02.md) | Rename `kata-storyboard` → `kata-session`; update all references  | Part 01    |
+| Part | File                             | Scope                                                               | Depends on |
+| ---- | -------------------------------- | ------------------------------------------------------------------- | ---------- |
+| 01   | [`plan-a-01.md`](./plan-a-01.md) | libeval tool surface, pending-ask runtime, prompts, config, tests   | —          |
+| 02   | [`plan-a-02.md`](./plan-a-02.md) | Rename `kata-storyboard` → `kata-session`; update all references    | Part 01    |
 | 03   | [`plan-a-03.md`](./plan-a-03.md) | `kata-coaching.yml` task-text + two `protocol_violation` invariants | Part 01    |
 
 ## Cross-cutting decisions
@@ -50,23 +50,23 @@ concurrently once Part 01 has merged.
   Same family, different scopes. Locked in Part 01 and consumed verbatim by
   Parts 02 and 03.
 - **Event shape.** `protocol_violation` trace event is emitted from the
-  orchestrator with `{type: "protocol_violation", agent: <name>, askId:
-  <id>, mode: "facilitated"|"supervised"}`. Shape defined in Part 01 so Part
-  03's invariant queries can grep for it.
+  orchestrator with
+  `{type: "protocol_violation", agent: <name>, askId: <id>, mode: "facilitated"|"supervised"}`.
+  Shape defined in Part 01 so Part 03's invariant queries can grep for it.
 - **Skill name.** `kata-session` is the locked name. Part 01 does not name
   skills (library stays generic). Part 02 creates the directory. Part 03's
   task-text references the name.
-- **No backwards-compat shims.** Spec forbids aliases. Removal of
-  `Tell` / `Share` / blocking-`Ask` is atomic in Part 01 — callers that
-  imported these names stop compiling. All internal callers live in libeval
-  itself (verified via `grep -rn` across the repo); no external downstream
-  consumers exist. Part 01 carries all runtime-side call-site updates.
+- **No backwards-compat shims.** Spec forbids aliases. Removal of `Tell` /
+  `Share` / blocking-`Ask` is atomic in Part 01 — callers that imported these
+  names stop compiling. All internal callers live in libeval itself (verified
+  via `grep -rn` across the repo); no external downstream consumers exist. Part
+  01 carries all runtime-side call-site updates.
 
 ## Libraries used
 
 This plan implements libeval itself. No consumption of other
-`@forwardimpact/lib*` packages. Part 02 and Part 03 touch only markdown and
-YAML — no library code.
+`@forwardimpact/lib*` packages. Part 02 and Part 03 touch only markdown and YAML
+— no library code.
 
 ## Risks
 
@@ -75,8 +75,8 @@ YAML — no library code.
   mix-and-match suite that passes locally but flags at `bun run test` on CI.
   Mitigation: the Part 01 DO-CONFIRM runs `bun run check` + `bun run test`
   before push; plan lists every test file by name.
-- **Skill rename misses.** A single missed `kata-storyboard` reference in
-  an agent profile leaves an agent looking for a skill that no longer exists,
+- **Skill rename misses.** A single missed `kata-storyboard` reference in an
+  agent profile leaves an agent looking for a skill that no longer exists,
   silently degrading behavior. Mitigation: Part 02 concludes with an explicit
   `grep -rn kata-storyboard` verification step covering the paths SC 6 names.
 - **Violation event suppression regression.** The existing
@@ -91,22 +91,20 @@ YAML — no library code.
 
 ## Execution
 
-- **Part 01** runs first and alone. Route to `staff-engineer` —
-  runtime/library code and tests. Must land on `main` before Parts 02 and 03
-  open.
+- **Part 01** runs first and alone. Route to `staff-engineer` — runtime/library
+  code and tests. Must land on `main` before Parts 02 and 03 open.
 - **Parts 02 and 03** run concurrently after Part 01 merges. Both route to
-  `staff-engineer` — Part 02 edits agent profiles + skill markdown + YAML;
-  Part 03 edits one workflow YAML + one reference markdown. Touches no code,
-  but close to the agent/orchestration surface — skill scope, not
-  technical-writer scope. Launch them in a single message with two `Agent`
-  tool calls.
+  `staff-engineer` — Part 02 edits agent profiles + skill markdown + YAML; Part
+  03 edits one workflow YAML + one reference markdown. Touches no code, but
+  close to the agent/orchestration surface — skill scope, not technical-writer
+  scope. Launch them in a single message with two `Agent` tool calls.
 
 Validation per the spec's validation note (one kata-coaching run, one
-kata-storyboard run, one supervise run; confirm invariants, `Answer`
-presence, and single `Conclude`) is gated on all three parts being on
-`main`. Ownership: the implementer of Part 03 — once Part 03 merges,
-they dispatch `kata-coaching.yml` manually (`gh workflow run
-kata-coaching.yml -f agent=<name>`), wait for the next scheduled
-`kata-storyboard.yml` (daily 06:00 UTC), and run a local `fit-eval
-supervise` against an arbitrary agent. Invariant queries from Part 03
+kata-storyboard run, one supervise run; confirm invariants, `Answer` presence,
+and single `Conclude`) is gated on all three parts being on `main`. Ownership:
+the implementer of Part 03 — once Part 03 merges, they dispatch
+`kata-coaching.yml` manually
+(`gh workflow run kata-coaching.yml -f agent=<name>`), wait for the next
+scheduled `kata-storyboard.yml` (daily 06:00 UTC), and run a local
+`fit-eval supervise` against an arbitrary agent. Invariant queries from Part 03
 then evaluate against the combined-trace artifacts.

--- a/specs/620-facilitated-tell-share-response-protocol/plan-a.md
+++ b/specs/620-facilitated-tell-share-response-protocol/plan-a.md
@@ -1,0 +1,112 @@
+# Plan 620a — Request–Response Primitives for libeval Orchestration
+
+Spec: [`spec.md`](./spec.md). Design: [`design.md`](./design.md).
+
+## Approach
+
+The spec replaces a three-tool, prose-enforced messaging surface
+(`Tell`/`Share`/blocking `Ask`) with a symmetric three-tool contract
+(`Ask`/`Answer`/`Announce`) whose request–response obligation is enforced at
+the libeval runtime. Three surfaces change in lockstep: the library code and
+its tests, the domain-facing skill that coaches use to facilitate meetings,
+and the coaching workflow + invariant catalogue that exercise and audit the
+new contract.
+
+The changes group naturally into three independently-executable parts:
+
+- **Part 01 — libeval runtime.** The contract itself: new tools, pending-ask
+  registry, turn-complete guard, `protocol_violation` event, prompt rewrites,
+  `systemPromptAmend` / `taskAmend` config family, test coverage.
+  Self-contained — no skill or workflow depends on the intermediate state.
+- **Part 02 — kata-session skill + repo references.** Directory rename,
+  content redistribution into mode overlays, mechanical replacement of
+  `kata-storyboard` → `kata-session` across agent profiles, KATA.md, the
+  storyboard workflow, memory-protocol, and website internals.
+- **Part 03 — coaching workflow + kata-trace invariants.** Rewrite
+  `kata-coaching.yml` task-text to carry the coaching framing (mode, target,
+  `kata-session` pointer, participant-side summary) and add the two
+  `protocol_violation` invariant entries.
+
+Part 01 is the prerequisite for both 02 and 03: the skill's Facilitator
+Process references the new `systemPromptAmend` surface; the workflow's
+task-text instructs the coach to use that surface; the invariants reference
+the `protocol_violation` event type emitted by the new runtime. Parts 02 and
+03 touch disjoint files and share no build-time coupling, so they can run
+concurrently once Part 01 has merged.
+
+## Part index
+
+| Part | File                           | Scope                                                              | Depends on |
+| ---- | ------------------------------ | ------------------------------------------------------------------ | ---------- |
+| 01   | [`plan-a-01.md`](./plan-a-01.md) | libeval tool surface, pending-ask runtime, prompts, config, tests | —          |
+| 02   | [`plan-a-02.md`](./plan-a-02.md) | Rename `kata-storyboard` → `kata-session`; update all references  | Part 01    |
+| 03   | [`plan-a-03.md`](./plan-a-03.md) | `kata-coaching.yml` task-text + two `protocol_violation` invariants | Part 01    |
+
+## Cross-cutting decisions
+
+- **Field names.** `systemPromptAmend` (system-prompt-level, new, Facilitator
+  participant config only) and `taskAmend` (task-content-level, promoted from
+  CLI-only to public config on `Facilitator` / `Supervisor` / `AgentRunner`).
+  Same family, different scopes. Locked in Part 01 and consumed verbatim by
+  Parts 02 and 03.
+- **Event shape.** `protocol_violation` trace event is emitted from the
+  orchestrator with `{type: "protocol_violation", agent: <name>, askId:
+  <id>, mode: "facilitated"|"supervised"}`. Shape defined in Part 01 so Part
+  03's invariant queries can grep for it.
+- **Skill name.** `kata-session` is the locked name. Part 01 does not name
+  skills (library stays generic). Part 02 creates the directory. Part 03's
+  task-text references the name.
+- **No backwards-compat shims.** Spec forbids aliases. Removal of
+  `Tell` / `Share` / blocking-`Ask` is atomic in Part 01 — callers that
+  imported these names stop compiling. All internal callers live in libeval
+  itself (verified via `grep -rn` across the repo); no external downstream
+  consumers exist. Part 01 carries all runtime-side call-site updates.
+
+## Libraries used
+
+This plan implements libeval itself. No consumption of other
+`@forwardimpact/lib*` packages. Part 02 and Part 03 touch only markdown and
+YAML — no library code.
+
+## Risks
+
+- **Test suite drift.** Part 01 rewrites nine orchestration-toolkit tests and
+  touches five facilitator/supervisor tests. A partial update leaves a
+  mix-and-match suite that passes locally but flags at `bun run test` on CI.
+  Mitigation: the Part 01 DO-CONFIRM runs `bun run check` + `bun run test`
+  before push; plan lists every test file by name.
+- **Skill rename misses.** A single missed `kata-storyboard` reference in
+  an agent profile leaves an agent looking for a skill that no longer exists,
+  silently degrading behavior. Mitigation: Part 02 concludes with an explicit
+  `grep -rn kata-storyboard` verification step covering the paths SC 6 names.
+- **Violation event suppression regression.** The existing
+  `orchestrator-filter.js` suppresses lifecycle events from the human text
+  stream. Adding `protocol_violation` to that set would hide the new signal.
+  Mitigation: Part 01 explicitly leaves `protocol_violation` **out** of the
+  suppressed set and asserts via test.
+- **Workflow cadence.** `kata-coaching.yml` runs on `workflow_dispatch` only,
+  and `kata-storyboard.yml` runs daily at 06:00 UTC. The daily cron provides
+  automatic validation of Part 02's skill rename within 24 hours of merge;
+  coaching-side validation requires a manual dispatch after Part 03 merges.
+
+## Execution
+
+- **Part 01** runs first and alone. Route to `staff-engineer` —
+  runtime/library code and tests. Must land on `main` before Parts 02 and 03
+  open.
+- **Parts 02 and 03** run concurrently after Part 01 merges. Both route to
+  `staff-engineer` — Part 02 edits agent profiles + skill markdown + YAML;
+  Part 03 edits one workflow YAML + one reference markdown. Touches no code,
+  but close to the agent/orchestration surface — skill scope, not
+  technical-writer scope. Launch them in a single message with two `Agent`
+  tool calls.
+
+Validation per the spec's validation note (one kata-coaching run, one
+kata-storyboard run, one supervise run; confirm invariants, `Answer`
+presence, and single `Conclude`) is gated on all three parts being on
+`main`. Ownership: the implementer of Part 03 — once Part 03 merges,
+they dispatch `kata-coaching.yml` manually (`gh workflow run
+kata-coaching.yml -f agent=<name>`), wait for the next scheduled
+`kata-storyboard.yml` (daily 06:00 UTC), and run a local `fit-eval
+supervise` against an arbitrary agent. Invariant queries from Part 03
+then evaluate against the combined-trace artifacts.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -81,7 +81,7 @@
 590	plan	implemented
 600	plan	approved
 610	plan	implemented
-620	plan	draft
+620	plan	approved
 630	spec	draft
 640	plan	implemented
 650	plan	implemented

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -81,7 +81,7 @@
 590	plan	implemented
 600	plan	approved
 610	plan	implemented
-620	design	approved
+620	plan	draft
 630	spec	draft
 640	plan	implemented
 650	plan	implemented


### PR DESCRIPTION
## Summary

- Decomposed 3-part plan for spec 620 (Tell/Share → Ask/Answer/Announce with runtime enforcement).
  - **Part 01** (`plan-a-01.md`) — libeval runtime: new tool surface, `pendingAsks` registry, turn-complete guard with one synthetic reminder + `protocol_violation` event, domain-agnostic prompts, `systemPromptAmend`/`taskAmend` config family, test coverage.
  - **Part 02** (`plan-a-02.md`) — rename `kata-storyboard` → `kata-session` with content redistribution into `team-storyboard.md` and `one-on-one.md` overlays.
  - **Part 03** (`plan-a-03.md`) — rewrite `kata-coaching.yml` task-text + two `protocol_violation` invariants in kata-trace.
- Execution: Part 01 first; Parts 02 and 03 concurrent after Part 01 lands.
- Review panel: 3/3. Ten consensus blocker/high/medium findings addressed (keying unification, typed synthetic-answer text, canonical addressee names, `Conclude`-cardinality jq query, `onAsk` wiring removal, `index.js` export accuracy, prompt phrasing, precise verification greps, table-cell query hygiene, `AgentRunner.taskAmend` plumbing).
- STATUS: 620 design approved → plan approved.

## Test plan

- [x] `bun run check`
- [x] `bun run test`

— Staff Engineer 🛠️

https://claude.ai/code/session_013FCgkJV71oC5o6L2HJqaHi

---
_Generated by [Claude Code](https://claude.ai/code/session_013FCgkJV71oC5o6L2HJqaHi)_