### PR TITLE
chore(skills): trim prose in kata-{spec,design,plan,review}

### DIFF
--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -20,11 +20,6 @@ the plan translates those into file-level changes and execution ordering.
 **A design requires an existing approved spec.** Without an approved spec there
 is no commitment to implement, and a design has nothing to shape.
 
-**200-line limit.** A design document must not exceed 200 lines of markdown text
-or Mermaid diagrams. This constraint is the point — it forces the author to
-communicate direction, not detail. If a design genuinely needs more space, the
-spec's scope is too broad and should be narrowed.
-
 ## When to Use
 
 - Turning an approved spec (`spec approved` in STATUS) into an architectural
@@ -73,39 +68,31 @@ spec's scope is too broad and should be narrowed.
 
 ## Naming Convention
 
-The design is always **`design.md`**. There are no variants and no decomposition
-— a design that cannot fit in 200 lines signals that the spec should be
-narrowed, not that the design should be split.
+The design is always **`design.md`**. No variants, no decomposition — if a
+design cannot fit in 200 lines, narrow the spec instead.
 
 ## Writing a Design (WHICH + WHERE)
 
 The design answers: which components exist, where they interact, and what
 interfaces connect them — and why this architecture over alternatives.
 
-Structure and format are up to you — match the complexity of the change. The
-DO-CONFIRM checklist verifies these qualities; the guidance below explains what
-each one means in practice:
+- **Architecture, not execution.** Name components, interfaces, data flow. Do
+  not specify file-level changes or execution ordering — those belong in the
+  plan.
+- **Decisions with trade-offs.** Each architectural choice names at least one
+  rejected alternative and why.
+- **One home per decision.** If a decision has a `## Key Decisions` table row,
+  do not also write a `Rejected:` paragraph under its section. Table or prose,
+  not both.
+- **Visual when possible.** Mermaid diagrams for component relationships, data
+  flow, state machines, sequence diagrams.
+- **Scope-faithful.** Stay within the spec's scope. If scope should change,
+  return the spec to draft rather than expanding silently.
 
-- **Architecture over execution.** Name components, classes, interfaces, data
-  structures, and their interactions. Do not specify file-level changes,
-  execution ordering, or implementation steps — those belong in the plan. The
-  boundary: a design names _what exists and how it connects_; a plan names
-  _which files change and in what order_.
-- **Decisions with trade-offs.** Each architectural choice should name at least
-  one rejected alternative and why it was rejected. This is the primary review
-  leverage point — a reviewer can redirect a decision here at low cost, versus
-  after a full plan is written.
-- **Visual when possible.** Use Mermaid diagrams for component relationships,
-  data flow, state machines, and sequence diagrams. A diagram that replaces two
-  paragraphs of prose is always a win.
-- **Scope-faithful.** Stay within the spec's declared scope. If the design
-  reveals that the scope should change, return the spec to draft rather than
-  expanding silently.
-- **Plan-enabling.** After reading the design, a planner should know which
-  components to build, what interfaces they expose, and how data flows between
-  them — without ambiguity. The planner's job is to translate those into
-  file-level changes and execution ordering, not to make architectural
-  decisions.
+**Form follows content.** Prefer tables for lists with shared structure
+(components, decisions). Prefer bullets for flat facts. Use prose only for the
+narrative thread between them. If a paragraph could be a row, make it a row. Do
+not restate what the artifact already shows.
 
 ## Status
 
@@ -134,24 +121,17 @@ from prior `staff-engineer` entries.
 
 ### Steps
 
-1. **Find the spec.** A design requires `spec approved` in `specs/STATUS`. If
-   the spec is still at `spec draft` or missing, stop — it must be approved
-   first.
-2. **Study the spec.** Read `spec.md` end to end. You should be able to restate
-   the problem, scope, and success criteria without referring back.
-3. **Research the codebase.** Read the code areas the spec targets. Understand
-   current architecture, patterns, and constraints that will shape the design.
-4. **Write the design.** Create `design.md` in the spec directory. Focus on
-   direction, decisions, and diagrams. Stay under 200 lines. Each architectural
-   choice should name a rejected alternative.
+1. **Find the spec.** Requires `spec approved` in `specs/STATUS`; otherwise
+   stop.
+2. **Study the spec.** Read `spec.md` end to end.
+3. **Research the codebase.** Read the code areas the spec targets.
+4. **Write the design.** Stay under 200 lines. Each architectural choice names a
+   rejected alternative.
 5. **Clean sub-agent review panel.** Follow the
-   [`kata-review` caller protocol](../kata-review/references/caller-protocol.md)
-   to launch a parallel panel of fresh sub-agents that each grade `design.md`.
-   Tell each reviewer not to invoke `kata-design`. Merge panel findings per the
-   protocol, verify, and address all confirmed blocker/high/medium issues before
-   advancing.
-6. **Present the design.** Share it for feedback. Iterate until satisfied. The
-   design stays at `design draft` until a human approves it.
+   [`kata-review` caller protocol](../kata-review/references/caller-protocol.md).
+   Tell each reviewer not to invoke `kata-design`. Address every confirmed
+   blocker/high/medium finding before advancing.
+6. **Present the design.** Iterate until satisfied.
 7. **Update STATUS.** Set the spec to `design draft` in `specs/STATUS`.
 
 ## Memory: what to record
@@ -166,15 +146,3 @@ Append to the current week's log (see agent profile for the file path):
   `wiki/metrics/{agent}/{domain}/` per the
   [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.
-
-## What NOT to Do
-
-The READ-DO checklist covers the core boundaries (no spec writing, no plan
-writing, one design per spec). Additionally:
-
-- **Do not write a design whose spec is not yet approved.** The spec must show
-  `spec approved` in STATUS before designing begins.
-- **Do not exceed 200 lines.** If the design needs more, narrow the spec.
-- **Do not include file-level execution detail.** File changes, execution
-  ordering, and implementation steps belong in the plan. Naming components,
-  interfaces, and data structures is expected — that is the design's job.

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -45,15 +45,13 @@ there is no architectural direction to translate into implementation steps.
 
 <do_confirm_checklist goal="Verify plan quality before recommending approval">
 
-- [ ] Approach and rationale stated before details.
+- [ ] One-paragraph approach. More rationale than that belongs in the design.
 - [ ] Changes are concrete — exact file paths, functions, before/after.
 - [ ] Blast radius visible — created, modified, and deleted files clear.
 - [ ] Ordering explicit with stated dependencies.
-- [ ] Non-obvious decisions explained.
-- [ ] Risks surfaced — no step should surprise the implementer.
-- [ ] Libraries-used section present. Every shared library the implementation
-      will consume is listed by package and by specific exports, or the section
-      explicitly states no shared libraries are used.
+- [ ] No per-step rationale paragraphs.
+- [ ] Risks list only items the implementer cannot see from the plan itself.
+- [ ] Libraries used is one line (packages + exports, or `none`).
 - [ ] Execution recommendation present (which agents, sequential vs parallel).
 - [ ] Clean sub-agent review panel of `plan-a.md` (and any parts) via
       [`kata-review`](../kata-review/SKILL.md) completed (fresh context, no
@@ -102,38 +100,43 @@ plan-a-03.md    ← part 3 (independently executable)
 
 **Rules for decomposition:**
 
-- `plan-a.md` contains the overall approach, rationale, cross-cutting concerns,
-  and a numbered index linking to each part with a one-line summary.
-- Each part (`plan-a-NN.md`) is independently executable — it has its own scope,
-  file list, ordering, and verification steps. The implementer can complete and
-  commit each part without needing the others to be finished.
-- Parts are numbered in execution order. State inter-part dependencies
-  explicitly (e.g., "part 02 depends on part 01 for the new type definitions").
-- A single-part plan does not need decomposition — only decompose when there is
-  a concrete benefit (size, independence, parallelism).
-- The overview (`plan-a.md`) must include an **Execution** section that
-  translates the dependency graph into a concrete execution recommendation. When
-  parts are independent after a shared prerequisite, recommend launching them as
-  concurrent sub-agents once the prerequisite merges. When parts are strictly
-  sequential, say so. Route each part to the agent whose skills match the work:
-  `staff-engineer` for code and infrastructure, `technical-writer` for
-  documentation (`website/`, wiki, CLAUDE.md, CONTRIBUTING.md). A single plan
-  may use both agents for different parts.
+- `plan-a.md` holds the approach, cross-cutting concerns, and a numbered index
+  with a one-line summary per part.
+- Each `plan-a-NN.md` is independently executable (its own scope, files,
+  ordering, verification) and numbered in execution order. State inter-part
+  dependencies explicitly.
+- Decompose only when there is concrete benefit (size, independence,
+  parallelism).
+- `plan-a.md` includes an **Execution** section: which parts run in parallel vs
+  sequentially, and which agent each part routes to (`staff-engineer` for code,
+  `technical-writer` for docs). A plan may use both.
 
 Alternative plans can also be decomposed (`plan-b.md`, `plan-b-01.md`, etc.).
 
 ## Writing a Plan (HOW + WHEN)
 
-The plan translates an approved spec into concrete implementation steps.
-Structure and format are up to you — match the complexity of the change. The
-DO-CONFIRM checklist verifies the qualities; key guidance on two items:
+The plan translates an approved design into concrete implementation steps.
 
-- **Libraries used.** List every `@forwardimpact/lib*` package the
-  implementation will consume with specific exports. If none, state that
-  explicitly — absence is a signal, not a default.
+- **No re-introduction.** A plan's job is to let a trusted agent execute without
+  re-reading the spec or design. Reference them by link; do not restate them.
+  The "Approach" section is one paragraph — if more rationale is needed, the
+  decisions belong in the design.
+- **Per-step shape.** Each step is a heading plus: one sentence of intent; a
+  file list (created / modified / deleted); the concrete change (code block,
+  table, or bullet list); one line of verification. No per-step rationale
+  paragraphs — decisions live in the Approach paragraph or the design.
+- **Libraries used.** One line: `Libraries used: libfoo (a, b), libbar (c).` or
+  `Libraries used: none.` No section heading, no paragraph.
+- **Risks.** List risks the implementer cannot see from reading the plan. If the
+  mitigation is "do the plan correctly", it is not a risk.
 - **Execution recommendation.** Route parts to matching agents —
   `staff-engineer` for code, `technical-writer` for docs. For decomposed plans,
   state which parts can run in parallel vs sequentially.
+
+**Form follows content.** Prefer tables for lists with shared structure (files,
+steps, parts). Prefer bullets for flat facts. Use prose only for the narrative
+thread between them. If a paragraph could be a row, make it a row. Do not
+restate what the artifact already shows.
 
 ## Reviewing a Plan
 
@@ -154,27 +157,18 @@ from prior `staff-engineer` entries.
 
 ### Steps
 
-1. **Find the spec.** A plan requires `design approved` in `specs/STATUS`. If
-   the spec is still at `spec draft`, `spec approved`, or `design draft`, stop —
-   the design must be approved first.
-2. **Study the spec and design.** Read `spec.md` and `design.md` end to end. You
-   should be able to restate the problem, scope, success criteria, and
-   architectural direction without referring back.
-3. **Research the codebase.** Read the files the plan will target. Verify
-   current state matches what the spec assumes.
-4. **Write the plan.** Create `plan-a.md`. Translate the approved spec into
-   concrete steps. Each step should be independently verifiable. Surface risks
-   explicitly. If the plan is large, decompose it into parts (see § Large plan
-   decomposition).
+1. **Find the spec.** Requires `design approved` in `specs/STATUS`; otherwise
+   stop.
+2. **Study the spec and design.** Read both end to end.
+3. **Research the codebase.** Read the files the plan will target.
+4. **Write the plan.** Create `plan-a.md`. Each step independently verifiable.
+   Decompose into parts if large (see § Large plan decomposition).
 5. **Clean sub-agent review panel.** Follow the
-   [`kata-review` caller protocol](../kata-review/references/caller-protocol.md)
-   to launch a parallel panel of fresh sub-agents that each grade `plan-a.md`
-   (and any `plan-a-NN.md` parts). Tell each reviewer not to invoke `kata-plan`.
-   Merge panel findings per the protocol, verify, and address all confirmed
-   blocker/high/medium issues before advancing.
-6. **Present the plan.** Share it for feedback.
-7. **Update STATUS.** Set the spec to `plan draft` in `specs/STATUS`. The plan
-   stays at `plan draft` until a human approves it.
+   [`kata-review` caller protocol](../kata-review/references/caller-protocol.md).
+   Tell each reviewer not to invoke `kata-plan`. Address every confirmed
+   blocker/high/medium finding before advancing.
+6. **Present the plan.** Iterate until satisfied.
+7. **Update STATUS.** Set the spec to `plan draft` in `specs/STATUS`.
 
 ## Memory: what to record
 

--- a/.claude/skills/kata-review/SKILL.md
+++ b/.claude/skills/kata-review/SKILL.md
@@ -78,45 +78,21 @@ optional.
 
 ## Artifact Criteria
 
+Grade each artifact against its skill's DO-CONFIRM checklist. The deltas below
+are review-specific additions on top of the checklist.
+
 ### spec.md
 
-Match the qualities in
-[`kata-spec` § Writing a Spec](../kata-spec/SKILL.md#writing-a-spec-what-and-why)
-and that skill's DO-CONFIRM checklist. Look for:
-
-- Problem stated first with concrete evidence (errors, metrics, examples)
-- Specific scope (files, APIs, entities) with explicit exclusions
-- Verifiable success criteria
-- No implementation details (HOW/WHEN belongs in the plan, WHICH/WHERE in the
-  design)
+Skill: [`kata-spec`](../kata-spec/SKILL.md). No review-specific deltas.
 
 ### design.md
 
-Match the qualities in
-[`kata-design` § Writing a Design](../kata-design/SKILL.md#writing-a-design-which--where)
-and that skill's DO-CONFIRM checklist. Look for:
-
-- Components, interfaces, and data flow stated before detail
-- Key decisions name a rejected alternative and why
-- Mermaid diagrams used where they clarify structure
-- Stays within spec scope — no scope expansion
-- Stays at the architectural level — names components, classes, interfaces, and
-  data structures but not file-level changes, execution ordering, or steps
-- Under 200 lines total (violation is a **Blocker**)
+Skill: [`kata-design`](../kata-design/SKILL.md). Delta: **over 200 lines is a
+Blocker.**
 
 ### plan-a.md (and parts)
 
-Match the qualities in
-[`kata-plan` § Writing a Plan](../kata-plan/SKILL.md#writing-a-plan-how--when)
-and that skill's DO-CONFIRM checklist. Look for:
-
-- Approach and rationale stated before details
-- Concrete changes (file paths, function names, before/after)
-- Visible blast radius (created / modified / deleted files)
-- Explicit ordering with stated dependencies
-- Non-obvious decisions explained
-- Risks surfaced
-- Execution recommendation present
+Skill: [`kata-plan`](../kata-plan/SKILL.md). No review-specific deltas.
 
 ### Implementation diff
 
@@ -156,7 +132,9 @@ Return findings grouped by severity exactly in this shape:
 - ...
 ```
 
-Be honest and specific. Do not invent findings to look thorough. Do not
+Each finding is one line: `file:line — criterion — one-sentence reason`. No
+preamble, no summary, no conclusion. The severity headers are the only prose. Be
+honest and specific. Do not invent findings to look thorough. Do not
 rubber-stamp.
 
 ## What NOT to Do

--- a/.claude/skills/kata-review/references/caller-protocol.md
+++ b/.claude/skills/kata-review/references/caller-protocol.md
@@ -7,10 +7,9 @@ Shared protocol for callers of `kata-review`. Used by:
 
 ## Why a panel
 
-Sub-agent reviewers spawn cold and can misread intent, miss surrounding code, or
-flag false positives. Independent reviewers produce uncorrelated errors: a
-finding flagged by ≥⌈N/2⌉ reviewers is high-signal; a singleton is likely noise
-but must still be verified. Odd N enables majority voting.
+Cold sub-agents produce uncorrelated errors. A finding flagged by ≥⌈N/2⌉
+reviewers is high-signal; singletons get verified but often prove noise. Odd N
+enables majority voting.
 
 ## Panel size
 
@@ -48,47 +47,25 @@ an implicit second pass at the next phase.
 
 ## How to merge findings
 
-`kata-review` emits findings grouped under `### Blocker` / `### High` /
-`### Medium` / `### Low` headers, with each row shaped
-`<file:line> — <criterion> — <one-sentence reason>` (or `<commit-hash>` in place
-of `file:line` when a reviewer cites a commit).
+Findings arrive under `### Blocker` / `### High` / `### Medium` / `### Low`,
+each row shaped `<file:line> — <criterion> — <one-sentence reason>` (or a commit
+hash in place of `file:line` for diffs).
 
-1. **Group semantically, not by string equality.** Two findings are the same
-   when they cite the same `file:line` (or commit hash, or nearby lines in the
-   same hunk) _and_ raise the same underlying concern. The `<criterion>` phrase
-   is free-form; merge findings that describe the same defect in different
-   words. When in doubt, merge — a combined finding is easier to verify than two
-   near-duplicates.
-
-2. **Record the vote count** per unique finding (how many of N reviewers flagged
-   it) and the severity each flagging reviewer assigned (read from the
-   `### <Level>` section header the finding appeared under in that reviewer's
-   report).
-
-3. **Pick severity by mode, tie-breaking high.** Use the most common severity
-   among the reviewers who flagged the finding. If two severities tie, pick the
-   higher one to stay cautious. A Blocker flagged by 1 of 5 with four silent
-   reviewers is a Blocker at vote 1 — the vote count, not the severity, reflects
-   how many reviewers saw it.
-
-4. **Partition the merged list** by vote count:
-   - **Consensus (≥⌈N/2⌉ votes)** — the panel's verdict. Verify and address
-     every confirmed blocker/high/medium finding in the same turn, without
-     pausing; see `How to handle findings` below.
-   - **Minority (>1 and <⌈N/2⌉ votes)** — for N=5 this is the 2-vote band; for
-     N=3 panels this bucket is empty and findings are either Consensus or
-     Singleton. Verify with extra care — a 2-of-5 finding is often a real edge
-     case only some reviewers spotted.
-   - **Singleton (1 vote)** — likely false positive, but not dismissed silently.
-     Verify each; address or record the rationale for dismissal.
-
-5. **Scope-creep guard.** Dismiss by default any finding that raises a concern
-   outside the artifact's declared scope (spec scope for design/plan, plan scope
-   for diffs). For a spec review there is no prior scope document — use the
-   user's stated intent instead. This guard does **not** override kata-review's
-   own scope-creep criterion for diffs ("the diff refactors or adds unrelated
-   changes"); consensus findings of that kind remain Consensus and must be
-   addressed.
+1. **Group semantically.** Merge findings citing the same `file:line` (or nearby
+   lines in the same hunk) that raise the same concern, even if worded
+   differently. When in doubt, merge.
+2. **Record vote count and each flagging reviewer's severity.**
+3. **Pick severity by mode; tie-break high.** Vote count reflects reach;
+   severity reflects seriousness.
+4. **Partition by vote count:**
+   - **Consensus (≥⌈N/2⌉):** verify and address all confirmed blocker/high/
+     medium findings in the same turn.
+   - **Minority (>1, <⌈N/2⌉):** empty for N=3. For N=5, verify with extra care.
+   - **Singleton (1):** verify each; address or record dismissal rationale.
+5. **Scope-creep guard.** Dismiss findings raising concerns outside the
+   artifact's declared scope (spec scope for design/plan, plan scope for diffs;
+   user intent for specs). Exception: consensus "scope-creep in the diff"
+   findings stand.
 
 ## Why this is safe
 

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -70,23 +70,18 @@ Number directories sequentially. Use the next available number.
 
 The spec answers two questions: what are we changing, and why does it matter?
 
-Structure and format are up to you — adapt to whatever best serves the content.
-Focus on these qualities:
+- **Problem first.** Evidence before proposal — errors, metrics, examples.
+- **Specific scope.** Name affected files, APIs, entities; state what is
+  excluded.
+- **Verifiable success.** Each criterion is a claim plus the command or path
+  that verifies it. One sentence each. No rationale, no alternatives considered.
+- **No HOW.** Name what each component does, not which mechanism implements it.
+  Tool selection and sequencing belong in the design and plan.
 
-- **Problem first.** The reader should feel the pain or see the opportunity
-  before encountering any proposal. Back it up with evidence — errors, metrics,
-  audit findings, examples of current behaviour.
-- **Specific scope.** Name the files, APIs, entities, or behaviours affected.
-  Make clear what is and is not included. Vague specs produce vague work.
-- **Verifiable success.** Define what "done" looks like in terms someone can
-  check at implementation time — a file that exists, a property of the code, a
-  command that succeeds. Avoid criteria that describe ongoing runtime behaviour
-  observable only across multiple runs; reframe those as properties of the
-  artifacts that produce the behaviour.
-- **No HOW.** If you find yourself describing implementation steps, stop and
-  save it for the plan. Name what each phase or component does, not which
-  mechanism implements it — tool selection and sequencing belong in the design
-  and plan. The spec should remain stable as implementation details change.
+**Form follows content.** Prefer tables for lists with shared structure (files,
+criteria, alternatives). Prefer bullets for flat facts. Use prose only for the
+narrative thread between them. If a paragraph could be a row, make it a row. Do
+not restate what the artifact already shows.
 
 ## Status
 
@@ -106,24 +101,17 @@ commit changes, report your decision so the caller can act on it.
 
 ## Process
 
-1. **Clarify first.** Ask the user (or upstream finding source) questions before
-   writing anything. Understand the motivation, desired scope, constraints, and
-   what success looks like. A brief conversation up front prevents major
-   rewrites later.
-2. **Research.** Read relevant code, data files, and existing specs. Understand
-   the current state before proposing changes.
-3. **Write the spec.** Focus on WHAT and WHY. Do not include implementation
-   details — those go in the plan.
+1. **Clarify first.** Ask about motivation, scope, constraints, and success
+   before writing.
+2. **Research.** Read relevant code, data, and existing specs.
+3. **Write the spec.** WHAT and WHY only.
 4. **Update STATUS.** Add the spec to `specs/STATUS` with `spec draft`.
 5. **Clean sub-agent review panel.** Follow the
-   [`kata-review` caller protocol](../kata-review/references/caller-protocol.md)
-   to launch a parallel panel of fresh sub-agents that each grade `spec.md`.
-   Tell each reviewer not to invoke `kata-spec`. Merge panel findings per the
-   protocol, verify, and address all confirmed blocker/high/medium issues before
-   advancing.
-6. **Present the spec.** Share it for feedback. Iterate until satisfied. The
-   spec stays at `spec draft` until a human approves it. Stop here — the plan is
-   the staff engineer's job.
+   [`kata-review` caller protocol](../kata-review/references/caller-protocol.md).
+   Tell each reviewer not to invoke `kata-spec`. Address every confirmed
+   blocker/high/medium finding before advancing.
+6. **Present the spec.** Iterate until satisfied. Stop at `spec draft` — the
+   plan is the staff engineer's job.
 
 ## Memory: what to record
 
@@ -136,11 +124,3 @@ Append to the current week's log (see agent profile for the file path):
   `wiki/metrics/{agent}/{domain}/` per the
   [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.
-
-## What NOT to Do
-
-The READ-DO checklist covers the core boundaries (spec only, no implementation
-details, evaluate don't rewrite). Additionally:
-
-- **Do not approve without reading.** Every criterion must be checked against
-  the actual content.


### PR DESCRIPTION
## Summary

- Adds normative brevity rules to `kata-spec`, `kata-design`, `kata-plan`, and `kata-review` to reduce downstream artifact bloat (e.g. plan 620-01 at 633 lines).
- Introduces a shared "form follows content" rule across all four skills: if a paragraph could be a table row, make it a row.
- Key new rules: success criteria are one sentence + verifier (`kata-spec`); "one home per decision" — table or prose, not both (`kata-design`); per-step shape enforced with no rationale paragraphs (`kata-plan`); review findings must be one line each (`kata-review`).
- Removes duplicated sections: "What NOT to Do" blocks that restated READ-DO, the 200-line rule repeated in four places in `kata-design`, and duplicated artifact-criteria sections in `kata-review`.
- Net skill shrinkage: 801 → 694 lines (−13%). Primary goal is downstream reduction in new specs/designs/plans.

## Test plan

- [x] `bun run check`
- [x] `bun run test`
- [x] `bun run format:fix` (clean)


---
_Generated by [Claude Code](https://claude.ai/code/session_014SUhdcRx8cRC6ijWRk7T1G)_