### PR TITLE
refactor(kata-session): simplify workflows and align with layering rules

### DIFF
--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -29,8 +29,8 @@ contexts — team storyboard meetings (`kata-storyboard.yml` workflow) and 1-on-
 coaching sessions (`kata-coaching.yml` workflow).
 
 **Participant**: You do not load this skill directly. The coach briefs you
-in-session via `Redirect` before the first question; answer each `Ask` with
-`Answer`.
+inside the first `Ask` — the Q1 question body is preceded by a short framing
+sentence. Answer each `Ask` with `Answer`.
 
 ## Checklists
 
@@ -109,10 +109,12 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    coaching runs, load [`references/one-on-one.md`](references/one-on-one.md).
    The overlay owns the mode-specific artifact surface, the question wording,
    and the participant briefing template.
-3. **Brief each participant.** Before the first `Ask`, send each participant a
-   `Redirect` carrying the briefing from the overlay — one sentence that names
-   the mode, points at `Answer` as the reply tool, and mentions any setup step
-   (e.g. running `kata-trace` before Q2 in 1-on-1 mode).
+3. **Brief each participant inside the first `Ask`.** Prepend the overlay's
+   briefing sentence to the Q1 question body, so each participant's first
+   message is "briefing + Q1" in a single `Ask`. Their `Answer` to Q1 closes the
+   first request-response round and confirms they have the framing. `Redirect`
+   is for interrupting an in-flight participant mid-session, not for opening
+   framing.
 4. **Run XmR analysis.** For every CSV in `wiki/metrics/`, run:
    `bunx fit-xmr analyze wiki/metrics/{agent}/{domain}/{YYYY}.csv --format json`.
    Use `status`, `signals`, and `x_bar` from the JSON output when reporting the
@@ -141,8 +143,8 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
 
 ## Participant Protocol
 
-Participants receive the mode briefing from the coach's opening `Redirect`, not
-by loading this skill directly. The generic pattern below applies in both modes.
+Participants receive the mode briefing inside the coach's first `Ask`, not by
+loading this skill directly. The generic pattern below applies in both modes.
 
 1. **Prepare for Q2.** When the coach poses Q2 via `Ask`, gather your domain's
    current measured state. Use live data (`gh`, `bun`, repo files) — not memory

--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -28,9 +28,9 @@ Two mode overlays describe the mode-specific artifact surface:
 contexts — team storyboard meetings (`kata-storyboard.yml` workflow) and 1-on-1
 coaching sessions (`kata-coaching.yml` workflow).
 
-**Participant**: You do not load this skill directly. The coach briefs you at
-session open — in team mode via an `Announce` before the first `Ask` round, in
-1-on-1 mode inside the Q1 `Ask` body. Answer each `Ask` with `Answer`.
+**Participant**: Answer each `Ask` with `Answer`. The coach's session-open
+briefing is sufficient for most runs; load this skill only if you need the full
+Participant Protocol below.
 
 ## Checklists
 
@@ -109,24 +109,19 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    coaching runs, load [`references/one-on-one.md`](references/one-on-one.md).
    The overlay owns the mode-specific artifact surface, the question wording,
    and the participant briefing template.
-3. **Brief participants.** Deliver the overlay's briefing before Q1. In team
-   mode, send it via a single `Announce` at session open — one broadcast covers
-   all participants and avoids repeating the same framing in every Q1 `Ask`. In
-   1-on-1 mode, prepend it to the Q1 question body, since there is only one
-   participant and folding the briefing into Q1's `Ask` closes the first
-   request-response round on the first beat. `Redirect` is for interrupting an
-   in-flight participant mid-session, not for opening framing.
+3. **Brief participants.** Deliver the overlay's briefing template before Q1.
+   Team mode: broadcast once via `Announce` at session open. 1-on-1 mode:
+   prepend it to the Q1 `Ask` body.
 4. **Run XmR analysis.** For every CSV in `wiki/metrics/`, run:
    `bunx fit-xmr analyze wiki/metrics/{agent}/{domain}/{YYYY}.csv --format json`.
    Use `status`, `signals`, and `x_bar` from the JSON output when reporting the
    Condition. If a metric returns `insufficient_data`, note it. In facilitated
    mode, include XmR summaries in the Q2 `Ask` to each agent.
-5. **Run the five questions.** Follow the overlay's wording. In facilitated mode
-   use `Ask` to pose each question and collect `Answer` replies before
-   advancing. Use `Announce` for team-wide context that applies to every
-   participant (session framing at open, between-question transitions, shared
-   status) — anything that would otherwise be duplicated into each `Ask`. In
-   solo mode, read metrics and wiki files directly.
+5. **Run the five questions.** Follow the overlay's wording. In facilitated
+   mode, pose each question via `Ask` and collect `Answer` replies before
+   advancing. Use `Announce` for between-question transitions or any status that
+   would otherwise repeat into every `Ask`. In solo mode, read metrics and wiki
+   files directly.
 6. **Update artifacts.** Write back whatever the overlay prescribes — for team
    mode, the storyboard file; for 1-on-1, the participant's memory.
 7. **Record coaching metrics.** Append coaching activity metrics (e.g.,
@@ -146,9 +141,8 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
 
 ## Participant Protocol
 
-Participants receive the mode briefing from the coach at session open — via
-`Announce` in team mode, or inside the Q1 `Ask` body in 1-on-1 mode — not by
-loading this skill directly. The generic pattern below applies in both modes.
+The generic pattern below applies in both modes. It expands the session-open
+briefing participants receive from the coach.
 
 1. **Prepare for Q2.** When the coach poses Q2 via `Ask`, gather your domain's
    current measured state. Use live data (`gh`, `bun`, repo files) — not memory

--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -28,9 +28,9 @@ Two mode overlays describe the mode-specific artifact surface:
 contexts — team storyboard meetings (`kata-storyboard.yml` workflow) and 1-on-1
 coaching sessions (`kata-coaching.yml` workflow).
 
-**Participant**: You do not load this skill directly. The coach briefs you
-inside the first `Ask` — the Q1 question body is preceded by a short framing
-sentence. Answer each `Ask` with `Answer`.
+**Participant**: You do not load this skill directly. The coach briefs you at
+session open — in team mode via an `Announce` before the first `Ask` round, in
+1-on-1 mode inside the Q1 `Ask` body. Answer each `Ask` with `Answer`.
 
 ## Checklists
 
@@ -109,12 +109,13 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    coaching runs, load [`references/one-on-one.md`](references/one-on-one.md).
    The overlay owns the mode-specific artifact surface, the question wording,
    and the participant briefing template.
-3. **Brief each participant inside the first `Ask`.** Prepend the overlay's
-   briefing sentence to the Q1 question body, so each participant's first
-   message is "briefing + Q1" in a single `Ask`. Their `Answer` to Q1 closes the
-   first request-response round and confirms they have the framing. `Redirect`
-   is for interrupting an in-flight participant mid-session, not for opening
-   framing.
+3. **Brief participants.** Deliver the overlay's briefing before Q1. In team
+   mode, send it via a single `Announce` at session open — one broadcast covers
+   all participants and avoids repeating the same framing in every Q1 `Ask`. In
+   1-on-1 mode, prepend it to the Q1 question body, since there is only one
+   participant and folding the briefing into Q1's `Ask` closes the first
+   request-response round on the first beat. `Redirect` is for interrupting an
+   in-flight participant mid-session, not for opening framing.
 4. **Run XmR analysis.** For every CSV in `wiki/metrics/`, run:
    `bunx fit-xmr analyze wiki/metrics/{agent}/{domain}/{YYYY}.csv --format json`.
    Use `status`, `signals`, and `x_bar` from the JSON output when reporting the
@@ -122,8 +123,10 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    mode, include XmR summaries in the Q2 `Ask` to each agent.
 5. **Run the five questions.** Follow the overlay's wording. In facilitated mode
    use `Ask` to pose each question and collect `Answer` replies before
-   advancing. Use `Announce` for team-wide context. In solo mode, read metrics
-   and wiki files directly.
+   advancing. Use `Announce` for team-wide context that applies to every
+   participant (session framing at open, between-question transitions, shared
+   status) — anything that would otherwise be duplicated into each `Ask`. In
+   solo mode, read metrics and wiki files directly.
 6. **Update artifacts.** Write back whatever the overlay prescribes — for team
    mode, the storyboard file; for 1-on-1, the participant's memory.
 7. **Record coaching metrics.** Append coaching activity metrics (e.g.,
@@ -143,7 +146,8 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
 
 ## Participant Protocol
 
-Participants receive the mode briefing inside the coach's first `Ask`, not by
+Participants receive the mode briefing from the coach at session open — via
+`Announce` in team mode, or inside the Q1 `Ask` body in 1-on-1 mode — not by
 loading this skill directly. The generic pattern below applies in both modes.
 
 1. **Prepare for Q2.** When the coach poses Q2 via `Ask`, gather your domain's

--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -2,8 +2,8 @@
 name: kata-session
 description: >
   Toyota Kata coaching protocol for facilitated sessions. Used by the
-  improvement coach (facilitator) and by domain agents who participate via
-  libeval's Ask/Answer/Announce tools. Same five coaching kata questions
+  improvement coach (facilitator) and by domain agents who participate via the
+  Ask/Answer/Announce orchestration tools. Same five coaching kata questions
   across team storyboard meetings and 1-on-1 coaching sessions; mode-specific
   guidance lives in references/team-storyboard.md and references/one-on-one.md.
 ---
@@ -28,9 +28,9 @@ Two mode overlays describe the mode-specific artifact surface:
 contexts — team storyboard meetings (`kata-storyboard.yml` workflow) and 1-on-1
 coaching sessions (`kata-coaching.yml` workflow).
 
-**Participant**: The coach passes a participant-side summary through libeval's
-`systemPromptAmend` before the first `Ask`. You do not load this skill in
-participant runs; respond to each Ask with Answer per the summary you receive.
+**Participant**: You do not load this skill directly. The coach briefs you
+in-session via `Redirect` before the first question; answer each `Ask` with
+`Answer`.
 
 ## Checklists
 
@@ -53,9 +53,7 @@ participant runs; respond to each Ask with Answer per the summary you receive.
 <do_confirm_checklist goal="Verify coaching session quality">
 
 - [ ] All five coaching kata questions were addressed.
-- [ ] Every `Ask` received an `Answer`, or surfaced a `protocol_violation` trace
-      event. The runtime — not the coach — enforces the relay; the coach
-      confirms it happened.
+- [ ] Every `Ask` received an `Answer`.
 - [ ] Current condition updated with numbers from metrics CSVs (not narrative),
       including XmR `status` and signal descriptions for each metric with
       sufficient data. Metrics with `insufficient_data` are noted.
@@ -106,17 +104,15 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    use orchestration tools (`Ask`, `Answer`, `Announce`, `Conclude`, `Redirect`)
    for all participant interaction. If the call fails with tool-not-found, you
    are in solo mode — use direct file reads.
-2. **Select the overlay.** For `kata-storyboard.yml` runs, load
-   [`references/team-storyboard.md`](references/team-storyboard.md). For
-   `kata-coaching.yml` runs, load
-   [`references/one-on-one.md`](references/one-on-one.md). The overlay owns the
-   mode-specific artifact surface, the question wording, and the
-   participant-side summary template.
-3. **Propagate participant framing.** Derive a short participant-side summary
-   from the overlay (one paragraph that names the mode and the Ask/Answer
-   contract) and pass it to libeval as `systemPromptAmend` on each participant's
-   config. libeval treats the string as opaque and appends it to each
-   participant's system prompt before the first `Ask`.
+2. **Select the overlay.** For team storyboard runs, load
+   [`references/team-storyboard.md`](references/team-storyboard.md). For 1-on-1
+   coaching runs, load [`references/one-on-one.md`](references/one-on-one.md).
+   The overlay owns the mode-specific artifact surface, the question wording,
+   and the participant briefing template.
+3. **Brief each participant.** Before the first `Ask`, send each participant a
+   `Redirect` carrying the briefing from the overlay — one sentence that names
+   the mode, points at `Answer` as the reply tool, and mentions any setup step
+   (e.g. running `kata-trace` before Q2 in 1-on-1 mode).
 4. **Run XmR analysis.** For every CSV in `wiki/metrics/`, run:
    `bunx fit-xmr analyze wiki/metrics/{agent}/{domain}/{YYYY}.csv --format json`.
    Use `status`, `signals`, and `x_bar` from the JSON output when reporting the
@@ -145,8 +141,8 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
 
 ## Participant Protocol
 
-Participants receive the mode summary via `systemPromptAmend`, not by loading
-this skill directly. The generic pattern below applies in both modes.
+Participants receive the mode briefing from the coach's opening `Redirect`, not
+by loading this skill directly. The generic pattern below applies in both modes.
 
 1. **Prepare for Q2.** When the coach poses Q2 via `Ask`, gather your domain's
    current measured state. Use live data (`gh`, `bun`, repo files) — not memory

--- a/.claude/skills/kata-session/references/one-on-one.md
+++ b/.claude/skills/kata-session/references/one-on-one.md
@@ -1,8 +1,7 @@
 # 1-on-1 Coaching Overlay
 
 Applies to `kata-coaching.yml` runs: the improvement coach facilitates a 1-on-1
-session with one domain agent. The participant does not load this skill directly
-— the coach briefs them inside the first `Ask`.
+session with one domain agent.
 
 ## Session Shape
 
@@ -29,9 +28,7 @@ The participant runs `kata-trace` against its own agent's trace artifact. The
 coach does not pre-load the trace content into the participant's context; the
 participant fetches it under Q2.
 
-## Participant briefing
-
-Prepend this to the Q1 question body when you make the first `Ask`:
+## Participant briefing template
 
 > "You are in a 1-on-1 coaching session. I will Ask you five questions; reply to
 > each with Answer. Under Q2, run `kata-trace` on your most recent workflow

--- a/.claude/skills/kata-session/references/one-on-one.md
+++ b/.claude/skills/kata-session/references/one-on-one.md
@@ -1,15 +1,15 @@
 # 1-on-1 Coaching Overlay
 
 Applies to `kata-coaching.yml` runs: the improvement coach facilitates a 1-on-1
-session with one domain agent. The participant's framing arrives via libeval's
-`systemPromptAmend`; the participant does not load this skill directly.
+session with one domain agent. The participant does not load this skill directly
+— the coach briefs them via `Redirect` before the first `Ask`.
 
 ## Session Shape
 
 The participant reflects on its most recent workflow trace. Under Q2 the
 participant runs `kata-trace` on that trace; the five questions scope to the
-trace's run-level findings. One facilitator, one participant, turn-taking
-structure enforced by the libeval runtime's Ask/Answer contract.
+trace's run-level findings. One facilitator, one participant, turn-taking via
+`Ask` / `Answer`.
 
 ## Question Wording (1-on-1)
 
@@ -29,14 +29,13 @@ The participant runs `kata-trace` against its own agent's trace artifact. The
 coach does not pre-load the trace content into the participant's context; the
 participant fetches it under Q2.
 
-## Participant-side summary (`systemPromptAmend`)
+## Participant briefing
 
-Use this template verbatim when populating the participant config:
+Send this via `Redirect` to the participant before the first `Ask`:
 
-> "You are in a 1-on-1 coaching session. The coach will Ask you five questions
-> via the orchestration `Ask` tool. Reply to each with `Answer`. Under Q2, run
-> `kata-trace` on your most recent workflow trace and include the numeric
-> findings in your Answer."
+> "You are in a 1-on-1 coaching session. I will Ask you five questions; reply to
+> each with Answer. Under Q2, run `kata-trace` on your most recent workflow
+> trace and include the numeric findings in your Answer."
 
 ## Memory
 

--- a/.claude/skills/kata-session/references/one-on-one.md
+++ b/.claude/skills/kata-session/references/one-on-one.md
@@ -2,7 +2,7 @@
 
 Applies to `kata-coaching.yml` runs: the improvement coach facilitates a 1-on-1
 session with one domain agent. The participant does not load this skill directly
-— the coach briefs them via `Redirect` before the first `Ask`.
+— the coach briefs them inside the first `Ask`.
 
 ## Session Shape
 
@@ -31,7 +31,7 @@ participant fetches it under Q2.
 
 ## Participant briefing
 
-Send this via `Redirect` to the participant before the first `Ask`:
+Prepend this to the Q1 question body when you make the first `Ask`:
 
 > "You are in a 1-on-1 coaching session. I will Ask you five questions; reply to
 > each with Answer. Under Q2, run `kata-trace` on your most recent workflow

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -1,9 +1,8 @@
 # Team Storyboard Overlay
 
 Applies to `kata-storyboard.yml` runs: the improvement coach facilitates a
-monthly team storyboard meeting with multiple participants. Each participant
-receives the participant-side summary through libeval's `systemPromptAmend`
-before the first `Ask`.
+monthly team storyboard meeting with multiple participants. Each participant is
+briefed by the coach via `Redirect` before the first `Ask`.
 
 ## Artifact
 
@@ -59,12 +58,11 @@ For each CSV-backed metric in the Current Condition table, generate a sparkline
 with `bunx fit-xmr spark <csv> --metric <name>` and write it to the Spark
 column.
 
-## Participant-side summary (`systemPromptAmend`)
+## Participant briefing
 
-Use this template verbatim when populating the participant config:
+Send this via `Redirect` to each participant before the first `Ask`:
 
-> "You are joining a team storyboard meeting. The coach will Ask you five
-> questions via the orchestration `Ask` tool. Reply to each with `Answer`.
-> Before answering Q2, record your domain metrics to
+> "You are joining a team storyboard meeting. I will Ask you five questions;
+> reply to each with Answer. Before answering Q2, record your domain metrics to
 > `wiki/metrics/{your-agent}/{domain}/{YYYY}.csv`; your Answer references the
 > CSV row."

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -1,8 +1,7 @@
 # Team Storyboard Overlay
 
 Applies to `kata-storyboard.yml` runs: the improvement coach facilitates a
-monthly team storyboard meeting with multiple participants. Each participant is
-briefed by the coach inside the first `Ask`.
+monthly team storyboard meeting with multiple participants.
 
 ## Artifact
 
@@ -58,11 +57,7 @@ For each CSV-backed metric in the Current Condition table, generate a sparkline
 with `bunx fit-xmr spark <csv> --metric <name>` and write it to the Spark
 column.
 
-## Participant briefing
-
-Broadcast this once via `Announce` at session open, before the first Q1 `Ask`
-round. One broadcast reaches every participant, so Q1 Asks carry only the
-question:
+## Participant briefing template
 
 > "You are joining a team storyboard meeting. I will Ask you five questions;
 > reply to each with Answer. Before answering Q2, record your domain metrics to

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -60,8 +60,9 @@ column.
 
 ## Participant briefing
 
-Prepend this to the Q1 question body when you make the first `Ask` to each
-participant:
+Broadcast this once via `Announce` at session open, before the first Q1 `Ask`
+round. One broadcast reaches every participant, so Q1 Asks carry only the
+question:
 
 > "You are joining a team storyboard meeting. I will Ask you five questions;
 > reply to each with Answer. Before answering Q2, record your domain metrics to

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -2,7 +2,7 @@
 
 Applies to `kata-storyboard.yml` runs: the improvement coach facilitates a
 monthly team storyboard meeting with multiple participants. Each participant is
-briefed by the coach via `Redirect` before the first `Ask`.
+briefed by the coach inside the first `Ask`.
 
 ## Artifact
 
@@ -60,7 +60,8 @@ column.
 
 ## Participant briefing
 
-Send this via `Redirect` to each participant before the first `Ask`:
+Prepend this to the Q1 question body when you make the first `Ask` to each
+participant:
 
 > "You are joining a team storyboard meeting. I will Ask you five questions;
 > reply to each with Answer. Before answering Q2, record your domain metrics to

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -50,16 +50,7 @@ jobs:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "facilitate"
           task-text: >-
-            Facilitate a 1-on-1 coaching session in kata-session mode with
-            target participant "${{ inputs.agent }}". Load the kata-session
-            skill. Its one-on-one overlay
-            (.claude/skills/kata-session/references/one-on-one.md) describes the
-            session shape, the five-question wording for 1-on-1 mode, and a
-            participant-side summary template. Before the first Ask, derive the
-            participant-side summary from the one-on-one overlay and pass it to
-            libeval as systemPromptAmend on the participant config. libeval
-            delivers it into the participant's system prompt before any Ask is
-            sent.
+            One-on-one Kata coaching session with "${{ inputs.agent }}".
           facilitator-profile: "improvement-coach"
           agent-profiles: "${{ inputs.agent }}"
           model: "claude-opus-4-6"

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -50,7 +50,8 @@ jobs:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "facilitate"
           task-text: >-
-            One-on-one Kata coaching session with "${{ inputs.agent }}".
+            Facilitate a one-on-one Kata coaching session with "${{ inputs.agent
+            }}".
           facilitator-profile: "improvement-coach"
           agent-profiles: "${{ inputs.agent }}"
           model: "claude-opus-4-6"

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -49,7 +49,7 @@ jobs:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "facilitate"
           task-text: >-
-            Team Kata storyboard session.
+            Facilitate a team Kata storyboard session.
           facilitator-profile: "improvement-coach"
           agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
           model: "claude-opus-4-6"

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -49,7 +49,7 @@ jobs:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "facilitate"
           task-text: >-
-            Facilitate the team storyboard meeting.
+            Team Kata storyboard session.
           facilitator-profile: "improvement-coach"
           agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
           model: "claude-opus-4-6"


### PR DESCRIPTION
## Summary

Post-spec-620 cleanup of the kata-coaching and kata-storyboard workflows and
the kata-session skill, driven by trace analysis of runs
[24867602412](https://github.com/forwardimpact/monorepo/actions/runs/24867602412)
and
[24876326433](https://github.com/forwardimpact/monorepo/actions/runs/24876326433).

- **Workflow task-text collapsed** — both `kata-coaching.yml` and
  `kata-storyboard.yml` now carry a single-sentence instruction
  ("Facilitate a one-on-one Kata coaching session with …", "Facilitate a team
  Kata storyboard session.") that names the skill implicitly via keyword
  matching. The coaching workflow previously drove the coach to spend ~100
  turns of a 200-turn budget hunting for a runtime `systemPromptAmend`
  mechanism that does not exist.
- **Dropped runtime `systemPromptAmend` leakage** from SKILL.md and overlays —
  the field is a libeval startup-time config, not a runtime handle. Removed
  all references and reframed participant briefing in terms of orchestration
  tools the coach actually has.
- **Chose the right tool for each session beat** — the coach now briefs
  participants inside the first `Ask` (1-on-1) or via a single `Announce` at
  session open (team). `Redirect` (which aborts the target's runner in
  `facilitator.js:267`) is reserved for mid-session course correction. Step 5
  guidance for `Announce` sharpened to "anything that would otherwise be
  duplicated into each `Ask`".
- **Layering cleanup against `KATA.md`** — removed defensive tool-semantic
  restatements from L6 (Step 3), eliminated duplication between Step 3 and
  Step 5, converted overlay "Participant briefing" sections to pure
  declarative templates (L7), and corrected the misleading "You do not load
  this skill directly" participant note (agent profiles do list
  `kata-session`).

SKILL.md: 179 → 174 lines. Overlays trimmed. No behavioural changes to
libeval or the facilitator; all edits are instruction-layer.

## Test plan

- [x] `bun run check`
- [x] `bun run test`
- [ ] A scheduled `kata-storyboard.yml` run completes with 5 Asks, 5 Answers,
      1 Conclude, and a single session-open `Announce` carrying the briefing.
- [ ] A manual `kata-coaching.yml` run completes with briefing inside the
      first `Ask` and without the coach hunting for `systemPromptAmend`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcUMyuUGxumaqfRCrxKdnc)_