### PR TITLE
fix(libeval): remove Redirect from facilitator, use model alias

### DIFF
--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -101,9 +101,9 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
 ## Facilitator Process
 
 1. **Detect mode.** Call RollCall. If it succeeds, you are in facilitated mode —
-   use orchestration tools (`Ask`, `Answer`, `Announce`, `Conclude`, `Redirect`)
-   for all participant interaction. If the call fails with tool-not-found, you
-   are in solo mode — use direct file reads.
+   use orchestration tools (`Ask`, `Answer`, `Announce`, `Conclude`) for all
+   participant interaction. If the call fails with tool-not-found, you are in
+   solo mode — use direct file reads.
 2. **Select the overlay.** For team storyboard runs, load
    [`references/team-storyboard.md`](references/team-storyboard.md). For 1-on-1
    coaching runs, load [`references/one-on-one.md`](references/one-on-one.md).

--- a/.github/workflows/agent-product-manager.yml
+++ b/.github/workflows/agent-product-manager.yml
@@ -53,6 +53,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "product-manager"
-          model: "claude-opus-4-6"
+          model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-release-engineer.yml
+++ b/.github/workflows/agent-release-engineer.yml
@@ -53,6 +53,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "release-engineer"
-          model: "claude-opus-4-6"
+          model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-security-engineer.yml
+++ b/.github/workflows/agent-security-engineer.yml
@@ -52,6 +52,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "security-engineer"
-          model: "claude-opus-4-6"
+          model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-staff-engineer.yml
+++ b/.github/workflows/agent-staff-engineer.yml
@@ -53,6 +53,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "staff-engineer"
-          model: "claude-opus-4-6"
+          model: "opus"
           max-turns: "0"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-technical-writer.yml
+++ b/.github/workflows/agent-technical-writer.yml
@@ -52,6 +52,6 @@ jobs:
             Assess the current state of your domain and act on the
             highest-priority finding.
           agent-profile: "technical-writer"
-          model: "claude-opus-4-6"
+          model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -54,6 +54,6 @@ jobs:
             }}".
           facilitator-profile: "improvement-coach"
           agent-profiles: "${{ inputs.agent }}"
-          model: "claude-opus-4-6"
+          model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -52,6 +52,6 @@ jobs:
             Facilitate a team Kata storyboard session.
           facilitator-profile: "improvement-coach"
           agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
-          model: "claude-opus-4-6"
+          model: "opus"
           max-turns: "200"
           task-amend: ${{ inputs.task-amend }}

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -286,16 +286,6 @@ export class Facilitator {
       if (target) {
         target.runner.currentAbortController?.abort();
       }
-      // Create a pending Ask so the redirected agent can Answer.
-      // Without this, a Redirect after a consumed Ask leaves the agent
-      // unable to respond — Answer returns "No pending ask to answer."
-      const askId = ++this.ctx.askIdCounter;
-      this.ctx.pendingAsks.set(redirect.to, {
-        askId,
-        askerName: "facilitator",
-        question: redirect.message,
-        reminded: false,
-      });
       this.messageBus.direct("facilitator", redirect.to, redirect.message);
     }
   }

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -286,6 +286,16 @@ export class Facilitator {
       if (target) {
         target.runner.currentAbortController?.abort();
       }
+      // Create a pending Ask so the redirected agent can Answer.
+      // Without this, a Redirect after a consumed Ask leaves the agent
+      // unable to respond — Answer returns "No pending ask to answer."
+      const askId = ++this.ctx.askIdCounter;
+      this.ctx.pendingAsks.set(redirect.to, {
+        askId,
+        askerName: "facilitator",
+        question: redirect.message,
+        reminded: false,
+      });
       this.messageBus.direct("facilitator", redirect.to, redirect.message);
     }
   }

--- a/libraries/libeval/src/orchestration-toolkit.js
+++ b/libraries/libeval/src/orchestration-toolkit.js
@@ -275,7 +275,14 @@ export function createSupervisedAgentToolServer(ctx) {
 }
 
 /**
- * Facilitator tools: Ask + Announce + Conclude + Redirect + RollCall.
+ * Facilitator tools: Ask + Announce + Conclude + RollCall.
+ *
+ * Redirect is intentionally omitted. In facilitated mode the facilitator
+ * can re-Ask a participant to course-correct — Ask overwrites the pending
+ * slot, giving the agent a proper round-trip path. Redirect (abort +
+ * direct message) belongs in supervised mode where a single agent is
+ * steered by a supervisor.
+ *
  * @param {object} ctx - Orchestration context
  * @returns {object} MCP server config (type: "sdk")
  */
@@ -300,12 +307,6 @@ export function createFacilitatorToolServer(ctx) {
         "End the session with a summary.",
         { summary: z.string() },
         createConcludeHandler(ctx),
-      ),
-      tool(
-        "Redirect",
-        "Interrupt a participant with replacement instructions. Use to='all' for all participants or a specific name.",
-        { message: z.string(), to: z.string().optional() },
-        createRedirectHandler(ctx),
       ),
       tool(
         "RollCall",

--- a/libraries/libeval/test/facilitator-redirect.test.js
+++ b/libraries/libeval/test/facilitator-redirect.test.js
@@ -6,7 +6,6 @@ import { Facilitator } from "@forwardimpact/libeval";
 import {
   createOrchestrationContext,
   createConcludeHandler,
-  createRedirectHandler,
   createAskHandler,
   createAnswerHandler,
 } from "../src/orchestration-toolkit.js";
@@ -19,8 +18,6 @@ const askMsg = (to, question) =>
   createToolUseMsg("Ask", { to, question }, { id: `ask-${to}` });
 const answerMsg = (message) =>
   createToolUseMsg("Answer", { message }, { id: "answer-1" });
-const redirectMsg = (to, message) =>
-  createToolUseMsg("Redirect", { to, message }, { id: "redirect-1" });
 
 function seedCtx(participants) {
   const ctx = createOrchestrationContext();
@@ -30,30 +27,28 @@ function seedCtx(participants) {
   return { ctx, messageBus };
 }
 
-describe("Facilitator - redirect creates pending ask", () => {
-  test("agent can Answer after being redirected", async () => {
+describe("Facilitator - re-Ask recovery", () => {
+  test("re-Ask overwrites consumed slot so agent can Answer", async () => {
     const { ctx, messageBus } = seedCtx(["facilitator", "agent-1"]);
     const concludeHandler = createConcludeHandler(ctx);
     const askHandler = createAskHandler(ctx, {
       from: "facilitator",
       defaultTo: undefined,
     });
-    const redirectHandler = createRedirectHandler(ctx);
 
-    // Turn 0: Ask agent-1
-    // Turn 1 (after premature answer): Redirect agent-1
+    // Turn 0: Ask agent-1 "What is 2+2?"
+    // Turn 1 (after premature answer): Ask agent-1 again
     // Turn 2 (after correct answer): Conclude
     const facilitatorRunner = createMockRunner(
-      [{ text: "Asking" }, { text: "Redirecting" }, { text: "Done" }],
+      [{ text: "Asking" }, { text: "Re-asking" }, { text: "Done" }],
       [
         [askMsg("agent-1", "What is 2+2?")],
-        [redirectMsg("agent-1", "Actually, what is 3+3?")],
+        [askMsg("agent-1", "Please answer: what is 2+2?")],
         [concludeMsg("Complete")],
       ],
       {
         toolDispatcher: {
           Ask: (input) => askHandler(input),
-          Redirect: (input) => redirectHandler(input),
           Conclude: (input) => concludeHandler(input),
         },
       },
@@ -61,10 +56,10 @@ describe("Facilitator - redirect creates pending ask", () => {
 
     const agent1AnswerHandler = createAnswerHandler(ctx, { from: "agent-1" });
     // Run 0: premature answer consuming the Ask slot
-    // Resume (after redirect): correct answer — should succeed
+    // Resume (after re-Ask): correct answer — should succeed
     const agent1Runner = createMockRunner(
-      [{ text: "Ready" }, { text: "Six" }],
-      [[answerMsg("Ready")], [answerMsg("6")]],
+      [{ text: "Ready" }, { text: "Four" }],
+      [[answerMsg("Ready")], [answerMsg("4")]],
       { toolDispatcher: { Answer: (i) => agent1AnswerHandler(i) } },
     );
 
@@ -78,12 +73,12 @@ describe("Facilitator - redirect creates pending ask", () => {
       ctx,
     });
 
-    const result = await facilitator.run("Test redirect creates ask");
+    const result = await facilitator.run("Test re-Ask recovery");
 
     assert.strictEqual(result.success, true);
     assert.ok(
       !ctx.pendingAsks.has("agent-1"),
-      "pending ask should be cleared after agent answered the redirect",
+      "pending ask should be cleared after agent answered the re-Ask",
     );
   });
 });

--- a/libraries/libeval/test/facilitator-redirect.test.js
+++ b/libraries/libeval/test/facilitator-redirect.test.js
@@ -1,0 +1,89 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { PassThrough } from "node:stream";
+
+import { Facilitator } from "@forwardimpact/libeval";
+import {
+  createOrchestrationContext,
+  createConcludeHandler,
+  createRedirectHandler,
+  createAskHandler,
+  createAnswerHandler,
+} from "../src/orchestration-toolkit.js";
+import { MessageBus } from "../src/message-bus.js";
+import { createMockRunner } from "./mock-runner.js";
+import { createToolUseMsg } from "@forwardimpact/libharness";
+
+const concludeMsg = (summary) => createToolUseMsg("Conclude", { summary });
+const askMsg = (to, question) =>
+  createToolUseMsg("Ask", { to, question }, { id: `ask-${to}` });
+const answerMsg = (message) =>
+  createToolUseMsg("Answer", { message }, { id: "answer-1" });
+const redirectMsg = (to, message) =>
+  createToolUseMsg("Redirect", { to, message }, { id: "redirect-1" });
+
+function seedCtx(participants) {
+  const ctx = createOrchestrationContext();
+  const messageBus = new MessageBus({ participants });
+  ctx.messageBus = messageBus;
+  ctx.participants = participants.map((name) => ({ name, role: name }));
+  return { ctx, messageBus };
+}
+
+describe("Facilitator - redirect creates pending ask", () => {
+  test("agent can Answer after being redirected", async () => {
+    const { ctx, messageBus } = seedCtx(["facilitator", "agent-1"]);
+    const concludeHandler = createConcludeHandler(ctx);
+    const askHandler = createAskHandler(ctx, {
+      from: "facilitator",
+      defaultTo: undefined,
+    });
+    const redirectHandler = createRedirectHandler(ctx);
+
+    // Turn 0: Ask agent-1
+    // Turn 1 (after premature answer): Redirect agent-1
+    // Turn 2 (after correct answer): Conclude
+    const facilitatorRunner = createMockRunner(
+      [{ text: "Asking" }, { text: "Redirecting" }, { text: "Done" }],
+      [
+        [askMsg("agent-1", "What is 2+2?")],
+        [redirectMsg("agent-1", "Actually, what is 3+3?")],
+        [concludeMsg("Complete")],
+      ],
+      {
+        toolDispatcher: {
+          Ask: (input) => askHandler(input),
+          Redirect: (input) => redirectHandler(input),
+          Conclude: (input) => concludeHandler(input),
+        },
+      },
+    );
+
+    const agent1AnswerHandler = createAnswerHandler(ctx, { from: "agent-1" });
+    // Run 0: premature answer consuming the Ask slot
+    // Resume (after redirect): correct answer — should succeed
+    const agent1Runner = createMockRunner(
+      [{ text: "Ready" }, { text: "Six" }],
+      [[answerMsg("Ready")], [answerMsg("6")]],
+      { toolDispatcher: { Answer: (i) => agent1AnswerHandler(i) } },
+    );
+
+    const output = new PassThrough();
+    const facilitator = new Facilitator({
+      facilitatorRunner,
+      agents: [{ name: "agent-1", role: "worker", runner: agent1Runner }],
+      messageBus,
+      output,
+      maxTurns: 10,
+      ctx,
+    });
+
+    const result = await facilitator.run("Test redirect creates ask");
+
+    assert.strictEqual(result.success, true);
+    assert.ok(
+      !ctx.pendingAsks.has("agent-1"),
+      "pending ask should be cleared after agent answered the redirect",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Trace analysis of storyboard run [24880491053](https://github.com/forwardimpact/monorepo/actions/runs/24880491053) revealed two infrastructure issues that caused the session to end at Q2 without reaching Q3-Q5:

- **Model mismatch**: All 7 workflows used the full model ID `"claude-opus-4-6"` which SDK 0.2.112 did not resolve, falling back to Sonnet (200K context). This caused 11 context compactions in 159s — 5 on the facilitator alone — until it lost its protocol position. Changed to the short alias `"opus"` which the SDK resolves correctly.
- **Redirect protocol gap**: The facilitator used `Redirect` to catch up a slow participant, but Redirect only sends a `direct()` message — no Ask slot is created. The agent could not `Answer`. Redirect belongs in supervised mode (one agent steered by a supervisor); in facilitated mode the facilitator should re-`Ask` instead, which overwrites the pending slot and gives the agent a proper round-trip path. Removed `Redirect` from `createFacilitatorToolServer`.

## Test plan

- [x] New test in `facilitator-redirect.test.js` — re-Ask overwrites consumed slot so agent can Answer
- [x] `bun run check` passes (format + lint + instructions)
- [x] `bun run test` passes (2442 tests across 215 files)
- [ ] Next storyboard run shows correct model in init event (not `claude-sonnet-4-6`)
- [ ] Next storyboard run completes all 5 kata questions with `Conclude` called

🤖 Generated with [Claude Code](https://claude.com/claude-code)