### PR TITLE
fix(libeval): pass model on resume to prevent compaction reset

### DIFF
--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -110,6 +110,7 @@ export class AgentRunner {
         prompt,
         options: {
           resume: this.sessionId,
+          model: this.model,
           permissionMode: PERMISSION_MODE,
           allowDangerouslySkipPermissions: true,
           abortController,

--- a/libraries/libeval/test/agent-runner.test.js
+++ b/libraries/libeval/test/agent-runner.test.js
@@ -208,6 +208,7 @@ describe("AgentRunner", () => {
     const result = await runner.resume("Follow up");
 
     assert.strictEqual(resumeCapture.options.resume, "sess-42");
+    assert.strictEqual(resumeCapture.options.model, "opus");
     assert.strictEqual(resumeCapture.prompt, "Follow up");
     assert.strictEqual(result.success, true);
     assert.strictEqual(result.text, "Resumed");


### PR DESCRIPTION
## Summary

`AgentRunner.resume()` did not forward the `model` option to the SDK's `query()` call. Sessions started correctly on Opus (via `run()`), but every `resume()` — triggered by new orchestration messages or context compaction — fell back to the API plan default (Sonnet 4.6).

Trace evidence from run [24891456898](https://github.com/forwardimpact/monorepo/actions/runs/24891456898):
- 6 init events on `claude-opus-4-7` (one per agent at session start)
- 89 init events on `claude-sonnet-4-6` (every compaction/resume)

One-line fix: add `model: this.model` to `resume()` options.

## Test plan

- [x] Existing `resume()` test extended with model assertion
- [x] `bun run check` passes
- [x] `bun run test` passes (2442 tests)
- [ ] Next storyboard run shows Opus in ALL init events (not just the first 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)