### PR TITLE
spec(660): skill multiple references — spec + design

### DIFF
--- a/specs/660-skill-multiple-references/design.md
+++ b/specs/660-skill-multiple-references/design.md
@@ -1,0 +1,200 @@
+# Design 660: Skill Multiple References
+
+## Problem Restated
+
+Replace `skill.implementationReference` (string → single
+`references/REFERENCE.md`) with `skill.references` (array of
+`{name, title, body}` → one file per entry under `references/`). The change
+propagates through the sites enumerated in spec § Affected entities. The
+design's job is to settle the _shape_ of the data at each hop and _where_ the
+per-entry loop, directory-ownership contract, and deprecation rejection live —
+so the plan can execute without rediscovering the mechanics.
+
+## Data Flow
+
+```mermaid
+flowchart LR
+    YAML[capabilities/*.yaml<br/>skill.references] --> V[map/validation/skill.js]
+    V -->|validateSkillReferences<br/>+ validateSkillDeprecatedFields| L[map/loader.js]
+    L -->|skill.references: Array| R[libskill/agent.js<br/>render model]
+    L --> SV[pathway/formatters/skill/shared.js<br/>SkillDetailView.references]
+    R --> AF[formatAgentSkill → SKILL.md]
+    R --> RF[formatReference per entry]
+    RF --> H[writeSkillReferences helper<br/>wipe → write N files]
+    H --> W1[commands/agent-io.js]
+    H --> W2[commands/build-packs.js]
+    H --> W3[pages/agent-builder-download.js<br/>addSkillsToZip]
+    SV --> MD[skill/markdown.js]
+    SV --> DOM[skill/dom.js<br/>buildSkillFiles]
+```
+
+The array stays an array at every hop. No layer flattens it, rekeys it, or
+splits `{name, title, body}` into parallel fields.
+
+## Components
+
+### 1. Validation — `products/map/src/validation/skill.js`
+
+| Change                                           | Mechanism                                                                                                                                                                                                                                                         |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Validate `skill.references`                      | New `validateSkillReferences(skill, path)` enforcing all nine rules from spec § Validation rules (authoritative): array type, regex `^[a-z0-9][a-z0-9_-]*$` with length 1–64, case-insensitive uniqueness, `title` non-empty string, `body` non-whitespace string |
+| Reject top-level `skill.implementationReference` | New `validateSkillDeprecatedFields(skill, path)` — a skill-level sibling of the existing agent-level `validateSkillAgentDeprecatedFields()`. Emits `INVALID_FIELD` whose message names `skill.references` as the replacement                                      |
+| Update legacy `agent.reference` hint             | Retarget the hint text in the existing `validateSkillAgentDeprecatedFields` deprecation list to `skill.references`                                                                                                                                                |
+| Remove `<scaffolding_steps>` check               | Delete the conditional in `validateSkillOptionalStringFields`                                                                                                                                                                                                     |
+
+`validateSkillReferences` and `validateSkillDeprecatedFields` both run and both
+append to the error array — a YAML that contains `implementationReference` _and_
+an invalid `references` entry reports both errors. Neither short-circuits the
+other. This matches how the existing validators already accumulate errors.
+
+### 2. Loader — `products/map/src/loader.js`
+
+`skill.references` flows through the destructuring block alongside
+`toolReferences` and `instructions`. Shape on the normalized skill record:
+
+```
+skill.references: Array<{ name: string, title: string, body: string }> | undefined
+```
+
+Absent and empty-array inputs both yield `undefined` on the record — the writer
+treats them identically (§ 6).
+
+### 3. Render model — `libraries/libskill/src/agent.js`
+
+`generateSkillMarkdown()` replaces the single `implementationReference: string`
+field with `references: Array` passed through verbatim. Rendering lives in the
+Pathway layer per the existing libskill/Pathway layering (libskill owns the
+model shape, Pathway owns output formatting). All five Pathway callers of
+`generateSkillMarkdown` — `commands/agent.js`, `commands/build-packs.js`,
+`commands/skill.js`, `pages/agent-builder-preview.js`, `pages/skill.js` —
+consume the new shape; no external callers exist.
+
+### 4. Agent SKILL.md template + formatter — `products/pathway/src/formatters/agent/skill.js` and `templates/skill.template.md`
+
+The `{{#hasReference}}` block in `skill.template.md` currently hard-codes a
+pointer to `references/REFERENCE.md`. With N titled references, no single
+pointer is correct, and the spec makes reference discovery author-driven via
+`skill.instructions`. **Decision: remove the block.** Authors who want to
+mention references in SKILL.md do so through the `instructions` field, which
+lands in the `{{#hasInstructions}}` region.
+
+Consequently `prepareAgentSkillData` drops `implementationReference`,
+`hasReference`, and `trimmedReference`. `formatReference` changes signature:
+
+```
+formatReference(entry, template) → string
+```
+
+Takes one `{name, title, body}` entry plus the reference template; returns the
+file body. Filename resolution (`{name}.md`) moves to the writer. Rejected
+alternative: `formatReferences(skill, template) → Array<{filename,content}>` —
+bundles directory layout with rendering, making the formatter aware of output
+path conventions. Kept rendering pure instead.
+
+### 5. Reference template — `products/pathway/templates/skill-reference.template.md`
+
+```
+# {{{title}}}
+
+{{{body}}}
+```
+
+Triple-brace ensures verbatim output — no HTML escaping, no whitespace collapse.
+`body` is rejected as invalid before rendering (see § 1 — whitespace-only `body`
+fails validation), so the template never has to handle empty input. Rendered
+once per entry. The old `# {{{title}}} — Reference` suffix is dropped: each
+entry now carries its own title, and the suffix is incompatible with titles like
+"CLI Usage" or "Metrics Schema".
+
+### 6. Writer helper — new function in `products/pathway/src/commands/agent-io.js`
+
+New `writeSkillReferences(skillDir, references, template)` lives in
+`agent-io.js` (the canonical file-writing module for skills) and is imported by
+`commands/build-packs.js` and `pages/agent-builder-download.js`. Chosen over a
+standalone module: the helper is a peer of `writeSkills`; extracting it to its
+own file would add an import hop without changing the ownership.
+
+Ownership contract (spec § Output shape, criterion 6): the helper treats
+`<skillDir>/references/` as generator-owned. Every invocation:
+
+1. Remove `<skillDir>/references/` recursively if it exists.
+2. If `references.length > 0`, create the directory and write `{entry.name}.md`
+   for each entry using `formatReference(entry, template)`.
+
+Wipe runs on _every_ call, including when `references` is empty/`undefined` —
+otherwise stale files from a prior run violate criterion 4. Filesystem errors
+propagate to the caller and abort generation for the current skill; the helper
+does not retry. Wipe-then-write chosen over diff-apply: simplest path to
+"contents exactly match YAML", and the one-skill-per-call scope removes any
+cross-skill race concern.
+
+The zip-generation branch (`addSkillsToZip` in
+`pages/agent-builder-download.js`) cannot use the helper as-is (it writes to a
+`JSZip` instance, not the filesystem). It gets its own per-entry loop with the
+same rendering but zip-based output — no wipe needed since the zip is built
+fresh. The shared piece is `formatReference(entry, template)`; the file layout
+differs.
+
+### 7. Non-agent view-model & formatters — `products/pathway/src/formatters/skill/`
+
+`shared.js` — `SkillDetailView.implementationReference: string|null` becomes
+`references: Array<{name, title, body}>` (empty array when absent).
+
+`markdown.js` — the single `## Implementation Patterns` section becomes a loop
+emitting `## {title}` / `{body}` per entry. Two entries sharing a title produce
+two identical `##` headings; acceptable, since `title` is human-written and
+uniqueness is only required on `name`.
+
+`dom.js` — `buildSkillFiles` replaces its single `references/REFERENCE.md` push
+with a loop pushing `references/{name}.md` per entry. The gate condition in
+`createSkillFilesSection` that decides whether to render the "Agent Skill Files"
+block switches from checking the old string field to checking
+`view.references.length > 0`.
+
+### 8. Starter framework — `products/map/starter/capabilities/`
+
+Success criterion 5 requires at least one starter skill to declare a
+`references:` array with two or more entries. The design commits the feature to
+the `incident_response` skill (the spec's running example) in
+`reliability.yaml`: two entries of form `{name, title, body}`. The precise
+content is plan/implementation work; the architectural commitment is that
+starter data exercises the multi-file path end-to-end.
+
+### 9. Authoring documentation — `website/docs/guides/`
+
+Two documentation files reference the removed field (spec § Affected entities
+lines 189–193): `authoring-frameworks/index.md` (teaches the field with a YAML
+example) and `agent-teams/index.md` (generator-mapping table row). These are
+content rewrites, not architectural changes — the plan updates them to describe
+`references` and the `references/{name}.md` output. The design decision is only
+that they stay _content_ work and no new doc mechanism (e.g. autogeneration from
+schema) is introduced.
+
+### 10. Pathway YAML loader — `products/pathway/src/lib/yaml-loader.js`
+
+Mirrors the Map loader field swap (§ 2). Same destructuring and same
+undefined-collapse semantics.
+
+## Key Decisions
+
+| Decision                            | Chosen                                                                 | Rejected alternative                                              | Why                                                                                                                                                             |
+| ----------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Where the per-entry loop lives      | Writer layer (shared helper + per-caller zip loop)                     | Formatter returns `Array<{filename,content}>`                     | Keeps rendering pure — strings only; directory/zip layout is a writer concern                                                                                   |
+| Directory ownership enforcement     | Wipe-then-write, every call                                            | Diff-apply (compare expected vs actual, delete extras, write new) | Simplest path to "exactly matches YAML"; acceptable filesystem churn for a build step                                                                           |
+| SKILL.md `hasReference` pointer     | Remove the block entirely                                              | Replace with an auto-generated list of references                 | Spec makes discovery author-driven; any auto-list would duplicate what `skill.instructions` can already express and conflict with the "no auto-index" exclusion |
+| Deprecated-field rejection location | New skill-level function                                               | Extend `validateSkillAgentDeprecatedFields`                       | `implementationReference` sits at skill top level, not under `agent.*`; shoehorning two nesting levels into one function conflates paths                        |
+| `formatReference` signature         | `(entry, template) → string`                                           | `(skill, template) → Array`                                       | Filename is a writer concern; formatter shouldn't know output lives at `{name}.md`                                                                              |
+| Helper module home                  | `commands/agent-io.js` (peer of `writeSkills`)                         | Standalone `commands/skill-references.js`                         | No new ownership introduced; adds an import hop for no gain                                                                                                     |
+| Reference template line             | `# {{{title}}}`                                                        | Keep `— Reference` suffix                                         | Per-entry titles now carry the heading's meaning                                                                                                                |
+| Error accumulation                  | Both `validateSkillReferences` and `validateSkillDeprecatedFields` run | Short-circuit on `implementationReference` presence               | Matches existing validator behavior; user sees all issues in one pass                                                                                           |
+
+## Scope Boundary
+
+- **In scope:** Every file listed in spec § Affected entities (lines 170–196),
+  including the starter skill and the two documentation files. Two new functions
+  (`validateSkillReferences`, `validateSkillDeprecatedFields`) and one new
+  helper (`writeSkillReferences`); all other changes modify existing functions
+  in place.
+- **Out of scope:** Automatic `SKILL.md` index injection, per-reference
+  `useWhen`, alternative output formats, runtime reference discovery — all
+  deferred by the spec.

--- a/specs/660-skill-multiple-references/spec.md
+++ b/specs/660-skill-multiple-references/spec.md
@@ -1,0 +1,264 @@
+# 660 — Skill Multiple References
+
+The Map schema currently lets a skill attach a single reference document via
+`skill.implementationReference` (a string), which renders into
+`.claude/skills/{skill}/references/REFERENCE.md`. Complex skills routinely need
+more than one reference file to support progressive disclosure, but the single
+fixed slot forces authors to either combine unrelated topics into one file, push
+content into `SKILL.md`, or drop it. Replace the single string with an array of
+named reference objects so one skill can produce any number of reference files.
+
+## Why
+
+### The single-file shape caps progressive disclosure
+
+A published skill is read lazily: agents load `SKILL.md`, then fetch reference
+files only when a task needs detail. The pattern only works when references can
+be named and scoped so the agent knows which one to open. Today the Map schema
+supports exactly one reference per skill, wired to a fixed filename:
+
+```yaml
+skills:
+  - id: incident_response
+    name: Incident Response
+    agent: { ... }
+    implementationReference: |
+      # Markdown body rendered verbatim into references/REFERENCE.md
+```
+
+Shipped skills under `.claude/skills/` already demonstrate the ceiling.
+`fit-pathway/references/` contains `cli.md` and `workflows.md`;
+`kata-spec/references/metrics.md` sits alongside other hand-authored files
+across `kata-*` skills. Those files exist because contributors bypassed the
+generator and wrote them by hand. That divergence is the symptom: the Map →
+Pathway generator cannot express what published skills actually need.
+
+### One slot forces authors into bad trade-offs
+
+When a skill only gets one reference slot, authors choose between:
+
+1. Stuffing multiple topics into one `REFERENCE.md` — defeats progressive
+   disclosure; agents pay tokens for context they do not need.
+2. Moving the material into `SKILL.md` — bloats the always-loaded core.
+3. Dropping the material entirely — ships a less useful skill.
+
+None of these preserve the "load what you need" property that makes reference
+files valuable in the first place.
+
+### The current pipeline is one-to-one by construction
+
+Every layer assumes exactly one reference per skill, so lifting the cap is a
+schema change that cascades through each:
+
+| Layer              | Location                                                 | Current behaviour                                                 |
+| ------------------ | -------------------------------------------------------- | ----------------------------------------------------------------- |
+| Schema             | `products/map/src/validation/skill.js`                   | Validates `implementationReference` as an optional string         |
+| Loader             | `products/map/src/loader.js`                             | Destructures the single field into the skill record               |
+| Render             | `libraries/libskill/src/agent.js`                        | Carries one `implementationReference` field into the model        |
+| Agent formatter    | `products/pathway/src/formatters/agent/skill.js`         | `formatReference(skill, template)` returns one string             |
+| Skill view-model   | `products/pathway/src/formatters/skill/shared.js`        | `implementationReference` property on the view-model type         |
+| Skill markdown     | `products/pathway/src/formatters/skill/markdown.js`      | Emits the single field into the markdown output                   |
+| Skill DOM          | `products/pathway/src/formatters/skill/dom.js`           | Emits the single field into the HTML preview                      |
+| Template           | `products/pathway/templates/skill-reference.template.md` | `# {title} — Reference` followed by `{implementationReference}`   |
+| Writer             | `products/pathway/src/commands/agent-io.js`              | Writes hard-coded `references/REFERENCE.md`                       |
+| Build              | `products/pathway/src/commands/build-packs.js`           | Same hard-coded path in the pack build loop                       |
+| Web view           | `products/pathway/src/pages/agent-builder-preview.js`    | Reads the single field into preview output                        |
+| Web view           | `products/pathway/src/pages/agent-builder-download.js`   | Reads the single field into downloaded zip                        |
+| YAML load          | `products/pathway/src/lib/yaml-loader.js`                | Mirrors Map's single-field shape                                  |
+| Deprecated hint    | `products/map/src/validation/skill.js`                   | Maps legacy `reference` → `implementationReference`               |
+| Authoring guide    | `website/docs/guides/authoring-frameworks/index.md`      | Teaches `implementationReference` and shows YAML example          |
+| Generator mapping  | `website/docs/guides/agent-teams/index.md`               | Table row mapping `implementationReference` to `REFERENCE.md`     |
+
+### The `<scaffolding_steps>` rule is obsolete
+
+The current validator rejects `<scaffolding_steps>` tags in
+`implementationReference` because an earlier migration asked authors to move
+install commands into `installScript`. That migration is complete; no shipped
+skill still contains the tag. The rule carries no ongoing value and is removed
+rather than re-homed onto the new field.
+
+## What
+
+### 1. Replace `implementationReference` with `references`
+
+The Map skill schema drops `skill.implementationReference` (string) and adds
+`skill.references` (optional array). Each entry is an object with three required
+fields:
+
+| Field   | Type   | Purpose                                                       |
+| ------- | ------ | ------------------------------------------------------------- |
+| `name`  | string | Filename stem — becomes `references/{name}.md` on disk        |
+| `title` | string | Document title — rendered as `# {title}` at the top of file   |
+| `body`  | string | Reference content (markdown body, rendered verbatim below the title with no trimming or normalization) |
+
+Example YAML:
+
+```yaml
+skills:
+  - id: incident_response
+    name: Incident Response
+    agent: { ... }
+    references:
+      - name: runbooks
+        title: Incident Runbooks
+        body: |
+          Step-by-step procedures for the top five incident classes...
+      - name: postmortem-template
+        title: Postmortem Template
+        body: |
+          Fields expected in every postmortem...
+```
+
+A skill with no `references` (field absent, `null`, or empty array) emits no
+`references/` directory. A skill with N entries emits N files in `references/`.
+The filename `REFERENCE.md` is no longer produced by the generator.
+
+The `references/` directory is owned by the generator. When regenerating a
+skill, any pre-existing `references/*.md` files — including hand-authored ones
+— are overwritten or removed so the directory contents exactly match the
+current YAML. Skill authors who need ongoing hand-authored content must express
+it as a `references:` entry.
+
+### 2. Validation rules
+
+| Rule                                  | Applies to                 | Failure mode                                                                    |
+| ------------------------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `references` is optional              | `skill`                    | Absent, `null`, or empty array are all valid and produce no files               |
+| If present, must be an array          | `skill.references`         | `INVALID_VALUE` at `{path}.references`                                          |
+| `name` present and a string           | each entry                 | `MISSING_REQUIRED` / `INVALID_VALUE` at `{path}.references[i].name`             |
+| `name` matches `^[a-z0-9][a-z0-9_-]*$` with length 1–64 | each entry | `INVALID_VALUE` at `{path}.references[i].name` — covers `/`, `..`, `.`, null byte, uppercase, spaces, unicode, emoji, and length overflow in a single rule |
+| `name` unique within the skill, compared case-insensitively | `skill.references` | `INVALID_VALUE` at `{path}.references[i].name` on duplicate or case-only collision (e.g. `foo` and `Foo`) — prevents filesystem collisions on case-insensitive filesystems |
+| `title` present and a non-empty string | each entry                | `MISSING_REQUIRED` / `INVALID_VALUE` at `{path}.references[i].title`            |
+| `body` present and a non-empty string | each entry                 | `MISSING_REQUIRED` / `INVALID_VALUE` at `{path}.references[i].body` (whitespace-only is treated as empty) |
+| `implementationReference` is rejected  | `skill`                   | `INVALID_FIELD` at `{path}.implementationReference` with a message pointing to `references`. This rule is required — the friendly error message must fire for any skill that still uses the removed field. |
+
+Two adjacent changes to the existing deprecated-field machinery in
+`products/map/src/validation/skill.js`, independent of the rule above:
+
+- The `<scaffolding_steps>` check on `implementationReference` is deleted, not
+  re-homed onto `body`.
+- The existing deprecated-field entry for legacy `reference` currently reads
+  "Use `skill.implementationReference` instead." Its hint text is updated to
+  point at `skill.references`. The entry itself stays — removing it would
+  drop the helpful error for any framework still using the older legacy
+  name.
+
+### 3. Output shape
+
+For each entry in `skill.references`, the generator writes
+`<skillDir>/references/{name}.md` with contents:
+
+```
+# {title}
+
+{body}
+```
+
+`body` is written verbatim after the `# {title}` line and one blank line — no
+trimming, no collapsing of trailing newlines. Authors control the exact tail of
+each file.
+
+No index file is synthesized. Reference discovery is author-driven: agents
+find references by following pointers the author writes in `SKILL.md`
+(via `skill.instructions` or `agent.focus`). Automatic index generation is
+out of scope (see § Excluded).
+
+## Scope
+
+### Affected entities
+
+- `skill.implementationReference` — deleted from the Map schema
+- `skill.references` — new array field on every skill entity
+- Validation rules in `products/map/src/validation/skill.js`, including the
+  deprecated-field hint that currently maps legacy `reference` →
+  `implementationReference`
+- Loader in `products/map/src/loader.js`
+- Render model in `libraries/libskill/src/agent.js`
+- Pathway agent formatter `products/pathway/src/formatters/agent/skill.js`
+- Pathway skill view-model and non-agent formatters:
+  `products/pathway/src/formatters/skill/shared.js` (owns the view-model
+  property), `products/pathway/src/formatters/skill/markdown.js`, and
+  `products/pathway/src/formatters/skill/dom.js`
+- Pathway template `products/pathway/templates/skill-reference.template.md`
+- File-writing loops in `products/pathway/src/commands/agent-io.js` and
+  `products/pathway/src/commands/build-packs.js`
+- Web preview/download in
+  `products/pathway/src/pages/agent-builder-preview.js` and
+  `products/pathway/src/pages/agent-builder-download.js`
+- Pathway YAML loader `products/pathway/src/lib/yaml-loader.js`
+- Authoring documentation:
+  `website/docs/guides/authoring-frameworks/index.md` (teaches the field and
+  shows a YAML example) and `website/docs/guides/agent-teams/index.md` (the
+  generator-mapping table that names `implementationReference` and
+  `REFERENCE.md`)
+- Starter framework YAML under `products/map/starter/` — at least one starter
+  skill gains a `references:` array so the feature is exercised in-tree
+- Generated `<skillDir>/references/*.md` outputs
+
+### Excluded
+
+- `skill.toolReferences` — unrelated field; not renamed or restructured
+- `skill.instructions`, `skill.installScript`, and `skill.agent.*` — untouched
+- `SKILL.md` template and front matter shape — unchanged. The generator does
+  not auto-inject a "References" section into `SKILL.md`; authors point agents
+  at references through the existing `skill.instructions` and `agent.focus`
+  content they already write
+- Per-reference metadata beyond `{ name, title, body }` (e.g. `useWhen`, tags) —
+  can be added later if demand is demonstrated
+- Auto-generated discovery index (e.g. `references/INDEX.md`) — authors may add
+  one as a regular entry; the generator does not synthesize one
+- Runtime reference discovery/loading by agents — this spec concerns authoring
+  and generation, not consumption
+- Preserving hand-authored files under a generated skill's `references/`
+  directory — the generator owns the directory and overwrites it
+- Backward-compatibility shim for `implementationReference` — deliberately not
+  provided; this is a clean break
+
+## Success criteria
+
+1. A Map YAML file with a `references:` array of N entries validates, and
+   `bunx fit-pathway` generation produces a `<skillDir>/references/` directory
+   whose contents are exactly `{names}.md` for each entry's `name` in YAML
+   order, with no extra files. Each file begins with `# {title}` followed by a
+   blank line and the entry's `body` written verbatim.
+
+2. A Map YAML file containing `implementationReference` fails `bunx fit-map
+   validate` with an `INVALID_FIELD` error at `…implementationReference`
+   whose message names `references`. No `REFERENCE.md` is generated for such
+   inputs.
+
+3. Each of the following fails validation with the specified error code and
+   path:
+   - invalid `name` (`/`, `..`, `.`, empty string, null byte, uppercase,
+     whitespace, unicode, emoji, or length > 64) → `INVALID_VALUE` at
+     `…references[i].name`;
+   - duplicate `name` values within one skill, including case-only collisions
+     (`foo` vs `Foo`) → `INVALID_VALUE` at `…references[i].name`;
+   - missing or non-string `title` → `MISSING_REQUIRED` / `INVALID_VALUE` at
+     `…references[i].title`;
+   - missing, non-string, or whitespace-only `body` → `MISSING_REQUIRED` /
+     `INVALID_VALUE` at `…references[i].body`.
+
+4. A skill with no `references` field, a `null` value, or an empty array
+   produces no `<skillDir>/references/` directory.
+
+5. At least one starter skill under `products/map/starter/` declares a
+   `references:` array with two or more entries, and `bunx fit-map validate`
+   on `products/map/starter/` passes. Running the generator over the starter
+   data produces the corresponding multi-file `references/` directory in the
+   generated skill, demonstrating the feature end-to-end.
+
+6. Regenerating an existing skill whose `<skillDir>/references/` directory
+   contains stale or hand-authored files produces a `references/` directory
+   whose contents match the YAML exactly (stale files are removed or
+   overwritten).
+
+7. The identifier `implementationReference` and the string
+   `<scaffolding_steps>` do not appear under `products/map/src/`,
+   `products/pathway/src/`, `products/pathway/templates/`,
+   `libraries/libskill/src/`, or `website/docs/guides/` after the change,
+   except for:
+   - the single validation rule in `products/map/src/validation/skill.js` that
+     rejects the removed field (criterion 2), and
+   - test fixtures that include `implementationReference` as rejected input
+     for criterion 2.

--- a/specs/660-skill-multiple-references/spec.md
+++ b/specs/660-skill-multiple-references/spec.md
@@ -50,24 +50,24 @@ files valuable in the first place.
 Every layer assumes exactly one reference per skill, so lifting the cap is a
 schema change that cascades through each:
 
-| Layer              | Location                                                 | Current behaviour                                                 |
-| ------------------ | -------------------------------------------------------- | ----------------------------------------------------------------- |
-| Schema             | `products/map/src/validation/skill.js`                   | Validates `implementationReference` as an optional string         |
-| Loader             | `products/map/src/loader.js`                             | Destructures the single field into the skill record               |
-| Render             | `libraries/libskill/src/agent.js`                        | Carries one `implementationReference` field into the model        |
-| Agent formatter    | `products/pathway/src/formatters/agent/skill.js`         | `formatReference(skill, template)` returns one string             |
-| Skill view-model   | `products/pathway/src/formatters/skill/shared.js`        | `implementationReference` property on the view-model type         |
-| Skill markdown     | `products/pathway/src/formatters/skill/markdown.js`      | Emits the single field into the markdown output                   |
-| Skill DOM          | `products/pathway/src/formatters/skill/dom.js`           | Emits the single field into the HTML preview                      |
-| Template           | `products/pathway/templates/skill-reference.template.md` | `# {title} — Reference` followed by `{implementationReference}`   |
-| Writer             | `products/pathway/src/commands/agent-io.js`              | Writes hard-coded `references/REFERENCE.md`                       |
-| Build              | `products/pathway/src/commands/build-packs.js`           | Same hard-coded path in the pack build loop                       |
-| Web view           | `products/pathway/src/pages/agent-builder-preview.js`    | Reads the single field into preview output                        |
-| Web view           | `products/pathway/src/pages/agent-builder-download.js`   | Reads the single field into downloaded zip                        |
-| YAML load          | `products/pathway/src/lib/yaml-loader.js`                | Mirrors Map's single-field shape                                  |
-| Deprecated hint    | `products/map/src/validation/skill.js`                   | Maps legacy `reference` → `implementationReference`               |
-| Authoring guide    | `website/docs/guides/authoring-frameworks/index.md`      | Teaches `implementationReference` and shows YAML example          |
-| Generator mapping  | `website/docs/guides/agent-teams/index.md`               | Table row mapping `implementationReference` to `REFERENCE.md`     |
+| Layer             | Location                                                 | Current behaviour                                               |
+| ----------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
+| Schema            | `products/map/src/validation/skill.js`                   | Validates `implementationReference` as an optional string       |
+| Loader            | `products/map/src/loader.js`                             | Destructures the single field into the skill record             |
+| Render            | `libraries/libskill/src/agent.js`                        | Carries one `implementationReference` field into the model      |
+| Agent formatter   | `products/pathway/src/formatters/agent/skill.js`         | `formatReference(skill, template)` returns one string           |
+| Skill view-model  | `products/pathway/src/formatters/skill/shared.js`        | `implementationReference` property on the view-model type       |
+| Skill markdown    | `products/pathway/src/formatters/skill/markdown.js`      | Emits the single field into the markdown output                 |
+| Skill DOM         | `products/pathway/src/formatters/skill/dom.js`           | Emits the single field into the HTML preview                    |
+| Template          | `products/pathway/templates/skill-reference.template.md` | `# {title} — Reference` followed by `{implementationReference}` |
+| Writer            | `products/pathway/src/commands/agent-io.js`              | Writes hard-coded `references/REFERENCE.md`                     |
+| Build             | `products/pathway/src/commands/build-packs.js`           | Same hard-coded path in the pack build loop                     |
+| Web view          | `products/pathway/src/pages/agent-builder-preview.js`    | Reads the single field into preview output                      |
+| Web view          | `products/pathway/src/pages/agent-builder-download.js`   | Reads the single field into downloaded zip                      |
+| YAML load         | `products/pathway/src/lib/yaml-loader.js`                | Mirrors Map's single-field shape                                |
+| Deprecated hint   | `products/map/src/validation/skill.js`                   | Maps legacy `reference` → `implementationReference`             |
+| Authoring guide   | `website/docs/guides/authoring-frameworks/index.md`      | Teaches `implementationReference` and shows YAML example        |
+| Generator mapping | `website/docs/guides/agent-teams/index.md`               | Table row mapping `implementationReference` to `REFERENCE.md`   |
 
 ### The `<scaffolding_steps>` rule is obsolete
 
@@ -85,10 +85,10 @@ The Map skill schema drops `skill.implementationReference` (string) and adds
 `skill.references` (optional array). Each entry is an object with three required
 fields:
 
-| Field   | Type   | Purpose                                                       |
-| ------- | ------ | ------------------------------------------------------------- |
-| `name`  | string | Filename stem — becomes `references/{name}.md` on disk        |
-| `title` | string | Document title — rendered as `# {title}` at the top of file   |
+| Field   | Type   | Purpose                                                                                                |
+| ------- | ------ | ------------------------------------------------------------------------------------------------------ |
+| `name`  | string | Filename stem — becomes `references/{name}.md` on disk                                                 |
+| `title` | string | Document title — rendered as `# {title}` at the top of file                                            |
 | `body`  | string | Reference content (markdown body, rendered verbatim below the title with no trimming or normalization) |
 
 Example YAML:
@@ -114,23 +114,23 @@ A skill with no `references` (field absent, `null`, or empty array) emits no
 The filename `REFERENCE.md` is no longer produced by the generator.
 
 The `references/` directory is owned by the generator. When regenerating a
-skill, any pre-existing `references/*.md` files — including hand-authored ones
-— are overwritten or removed so the directory contents exactly match the
-current YAML. Skill authors who need ongoing hand-authored content must express
-it as a `references:` entry.
+skill, any pre-existing `references/*.md` files — including hand-authored ones —
+are overwritten or removed so the directory contents exactly match the current
+YAML. Skill authors who need ongoing hand-authored content must express it as a
+`references:` entry.
 
 ### 2. Validation rules
 
-| Rule                                  | Applies to                 | Failure mode                                                                    |
-| ------------------------------------- | -------------------------- | ------------------------------------------------------------------------------- |
-| `references` is optional              | `skill`                    | Absent, `null`, or empty array are all valid and produce no files               |
-| If present, must be an array          | `skill.references`         | `INVALID_VALUE` at `{path}.references`                                          |
-| `name` present and a string           | each entry                 | `MISSING_REQUIRED` / `INVALID_VALUE` at `{path}.references[i].name`             |
-| `name` matches `^[a-z0-9][a-z0-9_-]*$` with length 1–64 | each entry | `INVALID_VALUE` at `{path}.references[i].name` — covers `/`, `..`, `.`, null byte, uppercase, spaces, unicode, emoji, and length overflow in a single rule |
-| `name` unique within the skill, compared case-insensitively | `skill.references` | `INVALID_VALUE` at `{path}.references[i].name` on duplicate or case-only collision (e.g. `foo` and `Foo`) — prevents filesystem collisions on case-insensitive filesystems |
-| `title` present and a non-empty string | each entry                | `MISSING_REQUIRED` / `INVALID_VALUE` at `{path}.references[i].title`            |
-| `body` present and a non-empty string | each entry                 | `MISSING_REQUIRED` / `INVALID_VALUE` at `{path}.references[i].body` (whitespace-only is treated as empty) |
-| `implementationReference` is rejected  | `skill`                   | `INVALID_FIELD` at `{path}.implementationReference` with a message pointing to `references`. This rule is required — the friendly error message must fire for any skill that still uses the removed field. |
+| Rule                                                        | Applies to         | Failure mode                                                                                                                                                                                               |
+| ----------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `references` is optional                                    | `skill`            | Absent, `null`, or empty array are all valid and produce no files                                                                                                                                          |
+| If present, must be an array                                | `skill.references` | `INVALID_VALUE` at `{path}.references`                                                                                                                                                                     |
+| `name` present and a string                                 | each entry         | `MISSING_REQUIRED` / `INVALID_VALUE` at `{path}.references[i].name`                                                                                                                                        |
+| `name` matches `^[a-z0-9][a-z0-9_-]*$` with length 1–64     | each entry         | `INVALID_VALUE` at `{path}.references[i].name` — covers `/`, `..`, `.`, null byte, uppercase, spaces, unicode, emoji, and length overflow in a single rule                                                 |
+| `name` unique within the skill, compared case-insensitively | `skill.references` | `INVALID_VALUE` at `{path}.references[i].name` on duplicate or case-only collision (e.g. `foo` and `Foo`) — prevents filesystem collisions on case-insensitive filesystems                                 |
+| `title` present and a non-empty string                      | each entry         | `MISSING_REQUIRED` / `INVALID_VALUE` at `{path}.references[i].title`                                                                                                                                       |
+| `body` present and a non-empty string                       | each entry         | `MISSING_REQUIRED` / `INVALID_VALUE` at `{path}.references[i].body` (whitespace-only is treated as empty)                                                                                                  |
+| `implementationReference` is rejected                       | `skill`            | `INVALID_FIELD` at `{path}.implementationReference` with a message pointing to `references`. This rule is required — the friendly error message must fire for any skill that still uses the removed field. |
 
 Two adjacent changes to the existing deprecated-field machinery in
 `products/map/src/validation/skill.js`, independent of the rule above:
@@ -139,9 +139,8 @@ Two adjacent changes to the existing deprecated-field machinery in
   re-homed onto `body`.
 - The existing deprecated-field entry for legacy `reference` currently reads
   "Use `skill.implementationReference` instead." Its hint text is updated to
-  point at `skill.references`. The entry itself stays — removing it would
-  drop the helpful error for any framework still using the older legacy
-  name.
+  point at `skill.references`. The entry itself stays — removing it would drop
+  the helpful error for any framework still using the older legacy name.
 
 ### 3. Output shape
 
@@ -158,10 +157,10 @@ For each entry in `skill.references`, the generator writes
 trimming, no collapsing of trailing newlines. Authors control the exact tail of
 each file.
 
-No index file is synthesized. Reference discovery is author-driven: agents
-find references by following pointers the author writes in `SKILL.md`
-(via `skill.instructions` or `agent.focus`). Automatic index generation is
-out of scope (see § Excluded).
+No index file is synthesized. Reference discovery is author-driven: agents find
+references by following pointers the author writes in `SKILL.md` (via
+`skill.instructions` or `agent.focus`). Automatic index generation is out of
+scope (see § Excluded).
 
 ## Scope
 
@@ -182,15 +181,13 @@ out of scope (see § Excluded).
 - Pathway template `products/pathway/templates/skill-reference.template.md`
 - File-writing loops in `products/pathway/src/commands/agent-io.js` and
   `products/pathway/src/commands/build-packs.js`
-- Web preview/download in
-  `products/pathway/src/pages/agent-builder-preview.js` and
-  `products/pathway/src/pages/agent-builder-download.js`
+- Web preview/download in `products/pathway/src/pages/agent-builder-preview.js`
+  and `products/pathway/src/pages/agent-builder-download.js`
 - Pathway YAML loader `products/pathway/src/lib/yaml-loader.js`
-- Authoring documentation:
-  `website/docs/guides/authoring-frameworks/index.md` (teaches the field and
-  shows a YAML example) and `website/docs/guides/agent-teams/index.md` (the
-  generator-mapping table that names `implementationReference` and
-  `REFERENCE.md`)
+- Authoring documentation: `website/docs/guides/authoring-frameworks/index.md`
+  (teaches the field and shows a YAML example) and
+  `website/docs/guides/agent-teams/index.md` (the generator-mapping table that
+  names `implementationReference` and `REFERENCE.md`)
 - Starter framework YAML under `products/map/starter/` — at least one starter
   skill gains a `references:` array so the feature is exercised in-tree
 - Generated `<skillDir>/references/*.md` outputs
@@ -199,10 +196,10 @@ out of scope (see § Excluded).
 
 - `skill.toolReferences` — unrelated field; not renamed or restructured
 - `skill.instructions`, `skill.installScript`, and `skill.agent.*` — untouched
-- `SKILL.md` template and front matter shape — unchanged. The generator does
-  not auto-inject a "References" section into `SKILL.md`; authors point agents
-  at references through the existing `skill.instructions` and `agent.focus`
-  content they already write
+- `SKILL.md` template and front matter shape — unchanged. The generator does not
+  auto-inject a "References" section into `SKILL.md`; authors point agents at
+  references through the existing `skill.instructions` and `agent.focus` content
+  they already write
 - Per-reference metadata beyond `{ name, title, body }` (e.g. `useWhen`, tags) —
   can be added later if demand is demonstrated
 - Auto-generated discovery index (e.g. `references/INDEX.md`) — authors may add
@@ -222,10 +219,10 @@ out of scope (see § Excluded).
    order, with no extra files. Each file begins with `# {title}` followed by a
    blank line and the entry's `body` written verbatim.
 
-2. A Map YAML file containing `implementationReference` fails `bunx fit-map
-   validate` with an `INVALID_FIELD` error at `…implementationReference`
-   whose message names `references`. No `REFERENCE.md` is generated for such
-   inputs.
+2. A Map YAML file containing `implementationReference` fails
+   `bunx fit-map validate` with an `INVALID_FIELD` error at
+   `…implementationReference` whose message names `references`. No
+   `REFERENCE.md` is generated for such inputs.
 
 3. Each of the following fails validation with the specified error code and
    path:
@@ -243,9 +240,9 @@ out of scope (see § Excluded).
    produces no `<skillDir>/references/` directory.
 
 5. At least one starter skill under `products/map/starter/` declares a
-   `references:` array with two or more entries, and `bunx fit-map validate`
-   on `products/map/starter/` passes. Running the generator over the starter
-   data produces the corresponding multi-file `references/` directory in the
+   `references:` array with two or more entries, and `bunx fit-map validate` on
+   `products/map/starter/` passes. Running the generator over the starter data
+   produces the corresponding multi-file `references/` directory in the
    generated skill, demonstrating the feature end-to-end.
 
 6. Regenerating an existing skill whose `<skillDir>/references/` directory
@@ -253,12 +250,11 @@ out of scope (see § Excluded).
    whose contents match the YAML exactly (stale files are removed or
    overwritten).
 
-7. The identifier `implementationReference` and the string
-   `<scaffolding_steps>` do not appear under `products/map/src/`,
-   `products/pathway/src/`, `products/pathway/templates/`,
-   `libraries/libskill/src/`, or `website/docs/guides/` after the change,
-   except for:
+7. The identifier `implementationReference` and the string `<scaffolding_steps>`
+   do not appear under `products/map/src/`, `products/pathway/src/`,
+   `products/pathway/templates/`, `libraries/libskill/src/`, or
+   `website/docs/guides/` after the change, except for:
    - the single validation rule in `products/map/src/validation/skill.js` that
      rejects the removed field (criterion 2), and
-   - test fixtures that include `implementationReference` as rejected input
-     for criterion 2.
+   - test fixtures that include `implementationReference` as rejected input for
+     criterion 2.

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -85,4 +85,4 @@
 630	spec	draft
 640	plan	implemented
 650	plan	implemented
-660	design	draft
+660	design	approved

--- a/specs/STATUS
+++ b/specs/STATUS
@@ -85,4 +85,4 @@
 630	spec	draft
 640	plan	implemented
 650	plan	implemented
-660	spec	draft
+660	design	draft


### PR DESCRIPTION
## Summary

- Spec 660 — replace `skill.implementationReference` (single string → `references/REFERENCE.md`) with `skill.references` (array of `{name, title, body}` → one file per entry under `references/`). Clean break, no backward compatibility.
- Design 660 — settles the data shape at every pipeline hop, commits `writeSkillReferences` to `agent-io.js` with a wipe-then-write ownership contract, splits validation across two new functions, removes the obsolete `{{#hasReference}}` block from the agent SKILL.md template, and covers the download zip loop, starter YAML, and docs.
- STATUS advanced to `660 design approved` — ready for `kata-plan`.

No code changes — spec + design only.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2443 pass)


---
_Generated by [Claude Code](https://claude.ai/code/session_01STg8dxiNUHPRMdzdLsTHr1)_