### PR TITLE
ci: facilitated agent workflow for new PR comments

### DIFF
--- a/.github/workflows/agent-pr-comment.yml
+++ b/.github/workflows/agent-pr-comment.yml
@@ -59,15 +59,20 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         with:
           app-id: ${{ secrets.CI_APP_ID }}
+          mode: "facilitate"
           task-text: >-
             A new comment was posted on PR #${{ github.event.issue.number || github.event.pull_request.number }}
             by @${{ github.event.comment.user.login || github.event.review.user.login }}
             (user type: ${{ github.event.comment.user.type || github.event.review.user.type }};
             event: ${{ github.event_name }}).
             Comment URL: ${{ github.event.comment.html_url || github.event.review.html_url }}.
-            Assess the comment and act on it, but only if the author is a trusted
-            contributor and not a bot. If the author is a bot or not trusted,
-            stop immediately without taking any action.
-          agent-profile: "product-manager"
+            As facilitator, first verify the comment author is a trusted
+            contributor and not a bot — if not, stop immediately without
+            engaging any participant. Otherwise decide which participant agent
+            is most appropriate to handle the comment based on its content and
+            their domain, then ask that single agent to assess the comment and
+            act on it.
+          facilitator-profile: "product-manager"
+          agent-profiles: "release-engineer,security-engineer,staff-engineer,technical-writer"
           model: "claude-opus-4-7[1m]"
           max-turns: "200"

--- a/.github/workflows/agent-pr-comment.yml
+++ b/.github/workflows/agent-pr-comment.yml
@@ -9,7 +9,10 @@ on:
     types: [submitted]
 
 concurrency:
-  group: agent-pr-comment-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.event.review.id }}
+  group:
+    agent-pr-comment-${{ github.event.issue.number ||
+    github.event.pull_request.number }}-${{ github.event.comment.id ||
+    github.event.review.id }}
   cancel-in-progress: false
 
 permissions:
@@ -21,9 +24,9 @@ jobs:
   kata:
     # Only run for PR-related comments (issue_comment fires for issues too) and skip bots.
     if: >-
-      github.event.sender.type != 'Bot' &&
-      (
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request
+      != null) ||
         github.event_name == 'pull_request_review_comment' ||
         github.event_name == 'pull_request_review'
       )
@@ -52,26 +55,33 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
-          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-          COMMENT_AUTHOR: ${{ github.event.comment.user.login || github.event.review.user.login }}
-          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type || github.event.review.user.type }}
-          COMMENT_URL: ${{ github.event.comment.html_url || github.event.review.html_url }}
+          PR_NUMBER:
+            ${{ github.event.issue.number || github.event.pull_request.number }}
+          COMMENT_AUTHOR:
+            ${{ github.event.comment.user.login ||
+            github.event.review.user.login }}
+          COMMENT_AUTHOR_TYPE:
+            ${{ github.event.comment.user.type || github.event.review.user.type
+            }}
+          COMMENT_URL:
+            ${{ github.event.comment.html_url || github.event.review.html_url }}
           EVENT_NAME: ${{ github.event_name }}
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "facilitate"
           task-text: >-
-            A new comment was posted on PR #${{ github.event.issue.number || github.event.pull_request.number }}
-            by @${{ github.event.comment.user.login || github.event.review.user.login }}
-            (user type: ${{ github.event.comment.user.type || github.event.review.user.type }};
-            event: ${{ github.event_name }}).
-            Comment URL: ${{ github.event.comment.html_url || github.event.review.html_url }}.
-            As facilitator, first verify the comment author is a trusted
-            contributor and not a bot — if not, stop immediately without
-            engaging any participant. Otherwise decide which participant agent
-            is most appropriate to handle the comment based on its content and
-            their domain, then ask that single agent to assess the comment and
-            act on it.
+            A new comment was posted on PR #${{ github.event.issue.number ||
+            github.event.pull_request.number }} by @${{
+            github.event.comment.user.login || github.event.review.user.login }}
+            (user type: ${{ github.event.comment.user.type ||
+            github.event.review.user.type }}; event: ${{ github.event_name }}).
+            Comment URL: ${{ github.event.comment.html_url ||
+            github.event.review.html_url }}. As facilitator, first verify the
+            comment author is a trusted contributor and not a bot — if not, stop
+            immediately without engaging any participant. Otherwise decide which
+            participant agent is most appropriate to handle the comment based on
+            its content and their domain, then ask that single agent to assess
+            the comment and act on it.
           facilitator-profile: "product-manager"
           agent-profiles: "release-engineer,security-engineer,staff-engineer,technical-writer"
           model: "claude-opus-4-7[1m]"

--- a/.github/workflows/agent-pr-comment.yml
+++ b/.github/workflows/agent-pr-comment.yml
@@ -1,0 +1,73 @@
+name: "Agent: PR Comment"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: agent-pr-comment-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.event.review.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  kata:
+    # Only run for PR-related comments (issue_comment fires for issues too) and skip bots.
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      (
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
+        github.event_name == 'pull_request_review_comment' ||
+        github.event_name == 'pull_request_review'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.ci-app.outputs.token }}
+
+      - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
+
+      - name: Assess and Act on Comment
+        uses: ./.github/actions/kata-action
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login || github.event.review.user.login }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type || github.event.review.user.type }}
+          COMMENT_URL: ${{ github.event.comment.html_url || github.event.review.html_url }}
+          EVENT_NAME: ${{ github.event_name }}
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          task-text: >-
+            A new comment was posted on PR #${{ github.event.issue.number || github.event.pull_request.number }}
+            by @${{ github.event.comment.user.login || github.event.review.user.login }}
+            (user type: ${{ github.event.comment.user.type || github.event.review.user.type }};
+            event: ${{ github.event_name }}).
+            Comment URL: ${{ github.event.comment.html_url || github.event.review.html_url }}.
+            Assess the comment and act on it, but only if the author is a trusted
+            contributor and not a bot. If the author is a bot or not trusted,
+            stop immediately without taking any action.
+          agent-profile: "product-manager"
+          model: "claude-opus-4-7[1m]"
+          max-turns: "200"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/agent-pr-comment.yml`, triggered on `issue_comment` (PRs only), `pull_request_review_comment`, and `pull_request_review`.
- Run a facilitated session via `./.github/actions/kata-action`: `product-manager` is the facilitator and routes the comment to the most appropriate participant (`release-engineer`, `security-engineer`, `staff-engineer`, `technical-writer`).
- Job-level `if:` skips bot senders and non-PR `issue_comment` events; the facilitator additionally verifies trusted-contributor status before delegating.

## Test plan

- [x] `bun run check`
- [x] `bun run test`
- [ ] Workflow runs successfully on a new PR comment after merge.

https://claude.ai/code/session_01E8GQm9xSJUjjrc7AcwM5wq

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8GQm9xSJUjjrc7AcwM5wq)_