### PR TITLE
ci: stop Prettier from folding GitHub Actions expressions

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -3,9 +3,7 @@ description: Set up Bun, install just, and run just install
 
 inputs:
   token:
-    description:
-      GitHub token with write access to the wiki. When provided, the wiki is
-      checked out into ./wiki and pushed back during post-run cleanup.
+    description: GitHub token with write access to the wiki. When provided, the wiki is checked out into ./wiki and pushed back during post-run cleanup.
     required: false
     default: ""
 

--- a/.github/actions/kata-action/action.yml
+++ b/.github/actions/kata-action/action.yml
@@ -37,22 +37,16 @@ inputs:
     required: false
     default: "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"
   supervisor-allowed-tools:
-    description:
-      Comma-separated list of allowed tools for the supervisor (supervise mode
-      only)
+    description: Comma-separated list of allowed tools for the supervisor (supervise mode only)
     required: false
   supervisor-profile:
-    description:
-      Supervisor agent profile name (passed as --agent to Claude CLI, supervise
-      mode only)
+    description: Supervisor agent profile name (passed as --agent to Claude CLI, supervise mode only)
     required: false
   agent-profile:
     description: Agent profile name (passed as --agent to Claude CLI)
     required: false
   facilitator-profile:
-    description:
-      Facilitator profile name (passed as --facilitator-profile, facilitate mode
-      only)
+    description: Facilitator profile name (passed as --facilitator-profile, facilitate mode only)
     required: false
   agent-profiles:
     description: Comma-separated agent profile names for facilitate mode
@@ -185,9 +179,7 @@ runs:
         fi
 
     - name: Split supervised trace
-      if:
-        always() && inputs.trace == 'true' && inputs.mode == 'supervise' &&
-        steps.setup.outputs.trace-dir != ''
+      if: always() && inputs.trace == 'true' && inputs.mode == 'supervise' && steps.setup.outputs.trace-dir != ''
       shell: bash
       env:
         TRACE_DIR: ${{ steps.setup.outputs.trace-dir }}
@@ -200,9 +192,7 @@ runs:
           > "$TRACE_DIR/supervisor-trace.ndjson"
 
     - name: Split facilitated trace
-      if:
-        always() && inputs.trace == 'true' && inputs.mode == 'facilitate' &&
-        steps.setup.outputs.trace-dir != ''
+      if: always() && inputs.trace == 'true' && inputs.mode == 'facilitate' && steps.setup.outputs.trace-dir != ''
       shell: bash
       env:
         TRACE_DIR: ${{ steps.setup.outputs.trace-dir }}
@@ -225,9 +215,7 @@ runs:
           > "$TRACE_DIR/agent-trace.ndjson"
 
     - name: Upload agent trace
-      if:
-        always() && inputs.trace == 'true' && steps.setup.outputs.trace-dir !=
-        ''
+      if: always() && inputs.trace == 'true' && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: agent-trace
@@ -235,27 +223,21 @@ runs:
           ${{ (inputs.mode == 'supervise' || inputs.mode == 'facilitate') && format('{0}/agent-trace.ndjson', steps.setup.outputs.trace-dir) || format('{0}/trace.ndjson', steps.setup.outputs.trace-dir) }}
 
     - name: Upload supervisor trace
-      if:
-        always() && inputs.trace == 'true' && inputs.mode == 'supervise' &&
-        steps.setup.outputs.trace-dir != ''
+      if: always() && inputs.trace == 'true' && inputs.mode == 'supervise' && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: supervisor-trace
         path: ${{ steps.setup.outputs.trace-dir }}/supervisor-trace.ndjson
 
     - name: Upload facilitator trace
-      if:
-        always() && inputs.trace == 'true' && inputs.mode == 'facilitate' &&
-        steps.setup.outputs.trace-dir != ''
+      if: always() && inputs.trace == 'true' && inputs.mode == 'facilitate' && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: facilitator-trace
         path: ${{ steps.setup.outputs.trace-dir }}/facilitator-trace.ndjson
 
     - name: Upload per-agent traces
-      if:
-        always() && inputs.trace == 'true' && inputs.mode == 'facilitate' &&
-        steps.setup.outputs.trace-dir != ''
+      if: always() && inputs.trace == 'true' && inputs.mode == 'facilitate' && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: per-agent-traces
@@ -266,9 +248,7 @@ runs:
           !${{ steps.setup.outputs.trace-dir }}/trace.ndjson
 
     - name: Upload combined trace
-      if:
-        always() && inputs.trace == 'true' && (inputs.mode == 'supervise' ||
-        inputs.mode == 'facilitate') && steps.setup.outputs.trace-dir != ''
+      if: always() && inputs.trace == 'true' && (inputs.mode == 'supervise' || inputs.mode == 'facilitate') && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: combined-trace

--- a/.github/workflows/agent-pr-comment.yml
+++ b/.github/workflows/agent-pr-comment.yml
@@ -7,12 +7,15 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "PR number to act on (manual trigger for verification)"
+        required: true
+        type: string
 
 concurrency:
-  group:
-    agent-pr-comment-${{ github.event.issue.number ||
-    github.event.pull_request.number }}-${{ github.event.comment.id ||
-    github.event.review.id }}
+  group: agent-pr-comment-${{ github.event.issue.number || github.event.pull_request.number || inputs.pr-number }}-${{ github.event.comment.id || github.event.review.id || github.run_id }}
   cancel-in-progress: false
 
 permissions:
@@ -23,13 +26,7 @@ permissions:
 jobs:
   kata:
     # Only run for PR-related comments (issue_comment fires for issues too) and skip bots.
-    if: >-
-      github.event.sender.type != 'Bot' && (
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request
-      != null) ||
-        github.event_name == 'pull_request_review_comment' ||
-        github.event_name == 'pull_request_review'
-      )
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && ((github.event_name == 'issue_comment' && github.event.issue.pull_request != null) || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -55,33 +52,15 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
-          PR_NUMBER:
-            ${{ github.event.issue.number || github.event.pull_request.number }}
-          COMMENT_AUTHOR:
-            ${{ github.event.comment.user.login ||
-            github.event.review.user.login }}
-          COMMENT_AUTHOR_TYPE:
-            ${{ github.event.comment.user.type || github.event.review.user.type
-            }}
-          COMMENT_URL:
-            ${{ github.event.comment.html_url || github.event.review.html_url }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || inputs.pr-number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login || github.event.review.user.login || github.actor }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type || github.event.review.user.type || 'User' }}
+          COMMENT_URL: ${{ github.event.comment.html_url || github.event.review.html_url || '' }}
           EVENT_NAME: ${{ github.event_name }}
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "facilitate"
-          task-text: >-
-            A new comment was posted on PR #${{ github.event.issue.number ||
-            github.event.pull_request.number }} by @${{
-            github.event.comment.user.login || github.event.review.user.login }}
-            (user type: ${{ github.event.comment.user.type ||
-            github.event.review.user.type }}; event: ${{ github.event_name }}).
-            Comment URL: ${{ github.event.comment.html_url ||
-            github.event.review.html_url }}. As facilitator, first verify the
-            comment author is a trusted contributor and not a bot — if not, stop
-            immediately without engaging any participant. Otherwise decide which
-            participant agent is most appropriate to handle the comment based on
-            its content and their domain, then ask that single agent to assess
-            the comment and act on it.
+          task-text: "A new comment was posted on PR #${{ env.PR_NUMBER }} by @${{ env.COMMENT_AUTHOR }} (user type: ${{ env.COMMENT_AUTHOR_TYPE }}; event: ${{ env.EVENT_NAME }}). Comment URL: ${{ env.COMMENT_URL }}. As facilitator, first verify the comment author is a trusted contributor and not a bot — if not, stop immediately without engaging any participant. Otherwise decide which participant agent is most appropriate to handle the comment based on its content and their domain, then ask that single agent to assess the comment and act on it."
           facilitator-profile: "product-manager"
           agent-profiles: "release-engineer,security-engineer,staff-engineer,technical-writer"
           model: "claude-opus-4-7[1m]"

--- a/.github/workflows/agent-product-manager.yml
+++ b/.github/workflows/agent-product-manager.yml
@@ -50,8 +50,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           task-text: >-
-            Assess the current state of your domain and act on the
-            highest-priority finding.
+            Assess the current state of your domain and act on the highest-priority finding.
           agent-profile: "product-manager"
           model: "claude-opus-4-7[1m]"
           max-turns: "200"

--- a/.github/workflows/agent-release-engineer.yml
+++ b/.github/workflows/agent-release-engineer.yml
@@ -50,8 +50,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           task-text: >-
-            Assess the current state of your domain and act on the
-            highest-priority finding.
+            Assess the current state of your domain and act on the highest-priority finding.
           agent-profile: "release-engineer"
           model: "claude-opus-4-7[1m]"
           max-turns: "200"

--- a/.github/workflows/agent-security-engineer.yml
+++ b/.github/workflows/agent-security-engineer.yml
@@ -49,8 +49,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           task-text: >-
-            Assess the current state of your domain and act on the
-            highest-priority finding.
+            Assess the current state of your domain and act on the highest-priority finding.
           agent-profile: "security-engineer"
           model: "claude-opus-4-7[1m]"
           max-turns: "200"

--- a/.github/workflows/agent-staff-engineer.yml
+++ b/.github/workflows/agent-staff-engineer.yml
@@ -50,8 +50,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           task-text: >-
-            Assess the current state of your domain and act on the
-            highest-priority finding.
+            Assess the current state of your domain and act on the highest-priority finding.
           agent-profile: "staff-engineer"
           model: "claude-opus-4-7[1m]"
           max-turns: "0"

--- a/.github/workflows/agent-technical-writer.yml
+++ b/.github/workflows/agent-technical-writer.yml
@@ -49,8 +49,7 @@ jobs:
         with:
           app-id: ${{ secrets.CI_APP_ID }}
           task-text: >-
-            Assess the current state of your domain and act on the
-            highest-priority finding.
+            Assess the current state of your domain and act on the highest-priority finding.
           agent-profile: "technical-writer"
           model: "claude-opus-4-7[1m]"
           max-turns: "200"

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -43,17 +43,11 @@ jobs:
             data/knowledge
             data/activity
             data/personal
-          key:
-            synthetic-${{ hashFiles('data/synthetic/**',
-            'products/map/schema/json/**', 'bun.lock') }}
+          key: synthetic-${{ hashFiles('data/synthetic/**', 'products/map/schema/json/**', 'bun.lock') }}
       - if: steps.synthetic-cache.outputs.cache-hit != 'true'
         run: just synthetic
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: public
-          key:
-            pathway-build-${{ hashFiles('data/synthetic/**',
-            'products/map/schema/json/**', 'products/pathway/src/**',
-            'products/map/starter/**', 'libraries/**/src/**',
-            'libraries/**/package.json', 'bun.lock') }}
+          key: pathway-build-${{ hashFiles('data/synthetic/**', 'products/map/schema/json/**', 'products/pathway/src/**', 'products/map/starter/**', 'libraries/**/src/**', 'libraries/**/package.json', 'bun.lock') }}
       - run: bun run test:e2e

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -50,8 +50,7 @@ jobs:
           app-id: ${{ secrets.CI_APP_ID }}
           mode: "facilitate"
           task-text: >-
-            Facilitate a one-on-one Kata coaching session with "${{ inputs.agent
-            }}".
+            Facilitate a one-on-one Kata coaching session with "${{ inputs.agent }}".
           facilitator-profile: "improvement-coach"
           agent-profiles: "${{ inputs.agent }}"
           model: "claude-opus-4-7[1m]"

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,12 @@
       "options": {
         "embeddedLanguageFormatting": "off"
       }
+    },
+    {
+      "files": [".github/**/*.yml", ".github/**/*.yaml"],
+      "options": {
+        "printWidth": 999
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Prettier (default `printWidth: 80`) was wrapping long YAML scalars in `.github/**/*.yml` into folded multi-line strings with embedded newlines. The `Agent: PR Comment` workflow's `if:` and `concurrency.group:` ended up as multi-line `>-` scalars, and GitHub Actions silently failed to materialize a workflow run from `pull_request_review_comment` and `pull_request_review` events on PR #528 — 0 lifetime runs despite real events firing.

- Add a `printWidth: 999` Prettier override for `.github/**/*.{yml,yaml}` so expressions stay on a single line.
- Re-flatten `agent-pr-comment.yml`. Add `workflow_dispatch` with a `pr-number` input so the workflow can be triggered manually for verification.
- Re-run Prettier across `.github/`, which collapsed the same fold pattern in 8 other workflow/action files (notably several `if:` blocks in `kata-action/action.yml` and the cache keys in `check-test.yml`).

## Test plan

- [x] `bun run check`
- [x] `bun run test`
- [ ] After merge: `gh workflow run "Agent: PR Comment" -f pr-number=528` triggers the workflow.
- [ ] After merge: a fresh review comment on an open PR triggers the workflow.

https://claude.ai/code/session_01EAGxLXofp2BLCTEpJi7ABQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAGxLXofp2BLCTEpJi7ABQ)_