### PR TITLE
ci(agent-pr-comment): drop ${{ }} wrapping from if:

### DIFF
--- a/.github/workflows/agent-pr-comment.yml
+++ b/.github/workflows/agent-pr-comment.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   kata:
     # Only run for PR-related comments (issue_comment fires for issues too) and skip bots.
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && ((github.event_name == 'issue_comment' && github.event.issue.pull_request != null) || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review')) }}
+    if: github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && ((github.event_name == 'issue_comment' && github.event.issue.pull_request != null) || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary

Test #1 for the comment-event trigger investigation. After PR #543 collapsed the multi-line `>-` scalars, comment events still didn't trigger the workflow (only `workflow_dispatch` did). Drop the `${{ }}` wrapping on `jobs.kata.if:` — in `if:` contexts GitHub evaluates the bare expression natively, and wrapping can in some edge cases produce a literal `"true"`/`"false"` string that always evaluates falsy.

## Test plan

- [x] `bun run check`
- [ ] After merge: post a fresh review comment on PR #528 and verify a `pull_request_review_comment` run appears in the workflow's run list.

https://claude.ai/code/session_01EAGxLXofp2BLCTEpJi7ABQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAGxLXofp2BLCTEpJi7ABQ)_