### PR TITLE
docs(kata): tighten KATA.md from 386 to 327 lines

### DIFF
--- a/KATA.md
+++ b/KATA.md
@@ -6,15 +6,12 @@
 >
 > — Mike Rother, _Toyota Kata_
 
-Kata is the Forward Impact repo self-maintenance system: autonomous agents
-running on GitHub Actions that keep the codebase secure, release-ready, and
-steadily improving. The name comes from Toyota Kata — the improvement kata
-pattern of _understand the direction_, _grasp the current condition_, _establish
-the next target condition_, and _experiment toward it_. Kata agents grasp the
-current condition (by analyzing execution traces of prior runs), establish
-target conditions (via specs), and experiment toward them (via implementation).
-Seven workflows — five individual agent runs scheduled across three shifts, one
-daily team storyboard, and one on-demand coaching session — six agent personas,
+Kata is the Forward Impact repo self-maintenance system: autonomous agents on
+GitHub Actions that keep the codebase secure, release-ready, and steadily
+improving. The name follows Toyota Kata — agents grasp the current condition
+(via prior-run traces), establish target conditions (via specs), and experiment
+toward them (via implementation). Seven workflows (five agent runs across three
+shifts, a daily storyboard, an on-demand coaching session), six agent personas,
 and eighteen skills form a self-reinforcing PDSA cycle.
 
 ## Architecture
@@ -24,21 +21,17 @@ graph LR
     W["Workflows<br/>.github/workflows/"] --> A["Agents<br/>.claude/agents/"] --> S["Skills<br/>.claude/skills/"]
 ```
 
-**Workflows** define schedule, trigger, and permissions. **Agents** define
-persona, scope constraints, and skill composition. **Skills** define procedures,
-checklists, and domain knowledge.
-
-All workflows share two composite actions:
-
-- `bootstrap/` — sets up Bun and installs dependencies.
-- `kata-action/` — runs a task against an agent profile via `fit-eval`, captures
-  the execution trace as NDJSON, and uploads it as an artifact.
+**Workflows** define schedule, trigger, permissions; **Agents** define persona,
+scope, skill composition; **Skills** define procedures, checklists, domain
+knowledge. Two composite actions are shared by all workflows: `bootstrap/`
+(Bun + dependencies) and `kata-action/` (runs a task against an agent profile
+via `fit-eval`, capturing the execution trace as NDJSON artifact).
 
 ## The PDSA Loop
 
 Every workflow belongs to a phase of the **Plan-Do-Study-Act** cycle (after
 Deming). Findings from Study always re-enter the loop as specs or fix PRs —
-nothing is observed without a downstream action.
+nothing is observed without downstream action.
 
 ```mermaid
 graph LR
@@ -46,23 +39,20 @@ graph LR
 ```
 
 - **Plan** — Turn approved `spec.md` (WHAT/WHY) into `design.md` (WHICH/WHERE)
-  and then `plan-a.md` (HOW/WHEN) with steps, files, sequencing, and risks.
-- **Do** — Execute plans via implementation PRs. Run scheduled workflows that
-  harden, release, and maintain the codebase. Every run captures a full
-  execution trace.
-- **Study** — Analyze outputs from Do. Four streams: security posture audits,
-  external feedback triage, documentation review (one topic deep per cycle), and
-  trace analysis (one trace deep per cycle via grounded theory).
-- **Act** — Convert findings into action. Trivial findings become **pushed fix
-  PRs** directly; structural findings become new `spec.md` documents on **pushed
-  spec branches** entering the backlog. A local commit is not a PR — the URL is
-  the only valid completion signal. Fix PRs (`fix/` branches) and specs (`spec/`
-  branches) are never mixed.
+  then `plan-a.md` (HOW/WHEN) with steps, files, sequencing, risks.
+- **Do** — Execute plans via implementation PRs; run scheduled workflows that
+  harden, release, and maintain. Every run captures a trace.
+- **Study** — Analyze Do outputs across four streams: security audits, external
+  feedback triage, one-topic-deep doc review, one-trace-deep grounded theory.
+- **Act** — Trivial findings become **pushed fix PRs**; structural findings
+  become `spec.md` documents on **pushed spec branches**. A local commit is not
+  a PR — the URL is the only valid completion signal. `fix/` and `spec/`
+  branches never mix.
 
 ## Agents
 
-Six agent personas, each with explicit scope constraints — when a finding
-exceeds an agent's scope, it writes a spec rather than attempting the fix.
+Six personas with explicit scope constraints — when a finding exceeds scope, the
+agent writes a spec rather than attempting the fix.
 
 | Agent                 | Phase          | Purpose                                                                 |
 | --------------------- | -------------- | ----------------------------------------------------------------------- |
@@ -75,22 +65,18 @@ exceeds an agent's scope, it writes a spec rather than attempting the fix.
 
 ## Workflows
 
-Seven workflows run on a three-shift rhythm aligned to Europe/Paris time: a
-**night shift** finishes by 07:00, the **storyboard** runs at 08:00, a **day
-shift** finishes by 15:00, and a **swing shift** finishes by 23:00. Within each
-shift agents form a producer → reviewer → shipper chain: product-manager triages
-and merges incoming work so staff-engineer has a fresh backlog, staff
-implements, and release-engineer ships. On the night shift — the full cycle
-before the morning storyboard — security-engineer and technical-writer slot in
-between staff and release so they can review the code staff just produced before
-it ships. Day and swing shifts skip the review pair; dependency churn and
-documentation drift do not need intra-day cadence, and CVE-driven work can run
-on demand via `workflow_dispatch`. Cron schedules are authored in UTC; Paris
-times below use CEST (UTC+2), the tighter summer constraint. All support
-`workflow_dispatch`, use concurrency groups, and have a 30-minute timeout.
-Individual agent workflows send a generic task prompt; the agent's Assess
-section determines the actual action. The storyboard and coaching session send
-specific task prompts to the improvement coach as facilitator.
+Seven workflows run on a three-shift Europe/Paris rhythm: **night** by 07:00,
+**storyboard** at 08:00, **day** by 15:00, **swing** by 23:00. Each shift forms
+a producer → reviewer → shipper chain: product-manager triages and merges so
+staff has a fresh backlog, staff implements, release ships. The night shift —
+the full cycle before the morning storyboard — slots security-engineer and
+technical-writer between staff and release to review code before it ships; day
+and swing skip the review pair (dependency churn and doc drift need no intra-day
+cadence; CVE-driven work runs on demand). Crons are authored in UTC; Paris times
+below use CEST (UTC+2), the tighter summer bound. All workflows support
+`workflow_dispatch`, use concurrency groups, and time out at 30 minutes. Agent
+workflows send a generic prompt; the agent's Assess section picks the action.
+Storyboard and coaching send specific prompts to the improvement coach.
 
 | Workflow                    | Schedule (Paris, CEST)                | Agent                                    |
 | --------------------------- | ------------------------------------- | ---------------------------------------- |
@@ -104,8 +90,8 @@ specific task prompts to the improvement coach as facilitator.
 
 ## Skills
 
-All Kata skills use the `kata-` prefix. Each owns exactly one PDSA phase (or
-none for utilities). Reading an agent's skill list reveals its phase coverage.
+All Kata skills use the `kata-` prefix and own exactly one PDSA phase (or none
+for utilities). An agent's skill list reveals its phase coverage.
 
 | Skill                     | Phase   | Purpose                                       |
 | ------------------------- | ------- | --------------------------------------------- |
@@ -130,7 +116,7 @@ none for utilities). Reading an agent's skill list reveals its phase coverage.
 
 ## Trust Boundary
 
-The product manager is the sole external merge point. All other merge paths
+The product manager is the sole external merge point; all other merge paths
 operate on trusted sources (our agents, Dependabot).
 
 ```mermaid
@@ -151,9 +137,9 @@ graph TD
 | `spec`           | Specification document only     | Trusted agents, never the contributor |
 | Everything else  | Nothing — requires human review | N/A                                   |
 
-Top-7 contributors pass the trust gate. CI app PRs (`forward-impact-ci`) are
-trusted by identity. Even a compromised top contributor cannot inject code
-through the autonomous pipeline — specs merge only the document, not code.
+Top-7 contributors pass the trust gate; `forward-impact-ci` PRs are trusted by
+identity. A compromised top contributor cannot inject code via this pipeline —
+specs merge only the document, not code.
 
 ## Design Principles
 
@@ -161,68 +147,58 @@ through the autonomous pipeline — specs merge only the document, not code.
 - **Fix-or-spec discipline.** Mechanical fixes and structural improvements never
   share a PR.
 - **Explicit scope constraints.** Each agent knows what it must _not_ do.
-- **Trace-driven observability.** Every workflow captures a trace. The
-  improvement coach must quote specific evidence — no speculation.
-- **Least privilege.** Read-only workflows use `contents: read`. Write workflows
+- **Trace-driven observability.** Every workflow captures a trace; the
+  improvement coach quotes specific evidence — no speculation.
+- **Least privilege.** Read-only workflows use `contents: read`; write workflows
   use scoped per-run installation tokens.
 - **Main branch CI repair.** See CONTRIBUTING.md for the release engineer's
   direct-to-`main` exception.
 
 ## Shared Memory
 
-Agents share persistent memory via the **GitHub wiki** at `wiki/`. Cloned on
+Agents share persistent memory via the **GitHub wiki** at `wiki/`, cloned on
 demand and synced by `just wiki-pull` (on `SessionStart`) and `just wiki-push`
-(on `Stop`). The wiki is a separate checkout, not a git submodule — `wiki/` is
-gitignored in the main repo. Wiki commits are published only by the `Stop` hook;
-never `git add wiki` into a main-repo commit.
+(on `Stop`). The wiki is a separate checkout, not a submodule — `wiki/` is
+gitignored, and only the `Stop` hook publishes wiki commits; never
+`git add wiki` into a main-repo commit.
 
-Each agent maintains two file types:
-
-- **Summary** (`<agent>.md`) — latest state: coverage, backlog, blockers,
-  teammate observations.
-- **Weekly log** (`<agent>-<YYYY>-W<VV>.md`) — one file per agent per week,
-  keyed by ISO week-year.
-
-Every scheduled run reads the summary and current week's log before acting,
-appends findings to the log, and updates the summary at the end. Entry-point
-skills must include a read step and a "Memory: what to record" section.
-Sub-skills and utility skills are exempt.
+Each agent maintains a **summary** (`<agent>.md`) — latest state, backlog,
+blockers, teammate observations — and a **weekly log**
+(`<agent>-<YYYY>-W<VV>.md`), one file per agent per ISO week. Every scheduled
+run reads both before acting, appends findings to the log, and updates the
+summary at the end. Entry-point skills must include a read step and a "Memory:
+what to record" section; sub-skills and utility skills are exempt.
 
 ## Metrics
 
 Agents record time-series data to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`
 after each run. The `kata-metrics` skill defines the CSV schema (six fields:
-date, metric, value, unit, run, note), storage convention, and metric design
-guidance. Each entry-point skill carries a `references/metrics.md` suggesting
+date, metric, value, unit, run, note), storage convention, and metric design;
+each entry-point skill carries a `references/metrics.md` suggesting
 domain-specific metrics.
 
-Metrics serve the coaching cycle: the team storyboard meeting (see Workflows
-table) uses metric data to answer "what is the actual condition now?" with
-numbers rather than narratives. Process behavior charts (XmR) built from the
-time series distinguish stable processes from those reacting to special causes.
-
-All agents — both facilitator and participants — load `kata-session` and
-`kata-metrics`. During storyboard meetings, each participant records its own
-domain metrics to CSV before sharing them with the team, ensuring measurements
-persist as structured data rather than only as narrative in the storyboard
-markdown.
+Metrics drive the coaching cycle: the storyboard meeting answers "what is the
+actual condition now?" with numbers, not narratives, and XmR process behavior
+charts distinguish stable processes from special-cause reactions. All agents —
+facilitator and participants — load `kata-session` and `kata-metrics`. Each
+participant records metrics to CSV before sharing in storyboard, so measurements
+persist as structured data rather than prose.
 
 ## Authentication
 
 Workflows authenticate via the **GitHub App** (`forward-impact-ci`), not a PAT.
-Each run generates a short-lived installation token (1-hour expiry) via
+Each run generates a 1-hour installation token via
 `actions/create-github-app-token` — no long-lived secrets to rotate. The token
-generates before `actions/checkout` so the checkout token triggers downstream
-workflows.
+must generate before `actions/checkout` so checkout-token writes trigger
+downstream workflows.
 
 ## Accountability
 
-Cross-agent accountability runs through the `kata-trace` skill's invariant
-audit. Domain agents verify their own per-agent invariants against their own
-traces during 1-on-1 coaching sessions facilitated by the improvement coach —
-e.g., that the product manager ran a contributor lookup before marking any
-non-CI-app PR mergeable. The canonical invariant list lives in
-`.claude/skills/kata-trace/references/invariants.md`. High-severity audit
+Cross-agent accountability runs through `kata-trace`'s invariant audit. During
+1-on-1 coaching sessions, domain agents verify per-agent invariants against
+their own traces — e.g., the product manager ran a contributor lookup before
+marking any non-CI-app PR mergeable. The canonical invariant list lives in
+`.claude/skills/kata-trace/references/invariants.md`; high-severity audit
 failures must result in a fix PR or spec.
 
 ## Authoring Best Practices
@@ -231,71 +207,55 @@ Lessons from trace analysis of agent workflow runs.
 
 ### Instruction layering
 
-Agent instructions span eight layers, each owning a distinct concern. Layers
-ascend from most general (every agent, every run) to most specific (one step,
-one pause point):
+Agent instructions span eight layers, ascending from most general (every agent,
+every run) to most specific (one step, one pause point):
 
-1. **libeval system prompt** — relay mechanics. How turns, tool calls, and
-   completion signalling work. Loaded once per session by the runner.
-2. **CLAUDE.md** — project identity. Goal, users, products, distribution model,
-   documentation map. Auto-loaded every run via `settingSources: ["project"]`.
-3. **CONTRIBUTING.md** — contribution standards. Invariants, technical rules,
-   quality gates, git conventions, security. Referenced by layer 2 and read on
-   demand.
-4. **workflow task** — this run. Which product, scenario, success criteria.
-   Passed in by the workflow YAML.
-5. **agent profile** — who you are. Persona, voice, skill routing, scope
-   constraints. Auto-loaded every run.
-6. **skill procedure (SKILL.md)** — how to do it. Decision-making, sequencing,
-   and rationale that teaches the agent what to do and why. Auto-loaded per
-   skill.
-7. **skill references (references/)** — data the procedure consults. Templates,
-   worked examples, invariant tables, metric definitions, lookup data. Read on
-   demand when SKILL.md points to them.
-8. **checklists** — did you do it. Binary verification at natural pause points,
-   with no explanation of how. Embedded in SKILL.md (domain-specific) or
-   CONTRIBUTING.md (universal).
+1. **libeval system prompt** — relay mechanics: turns, tool calls, completion
+   signalling. Loaded once per session.
+2. **CLAUDE.md** — project identity: goal, users, products, distribution, doc
+   map. Auto-loaded via `settingSources: ["project"]`.
+3. **CONTRIBUTING.md** — contribution standards: invariants, technical rules,
+   quality gates, git, security. Referenced by L2; read on demand.
+4. **workflow task** — this run: product, scenario, success criteria. Passed in
+   by workflow YAML.
+5. **agent profile** — persona, voice, skill routing, scope constraints.
+   Auto-loaded every run.
+6. **skill procedure (SKILL.md)** — decision-making, sequencing, rationale.
+   Auto-loaded per skill.
+7. **skill references (references/)** — data the procedure consults: templates,
+   worked examples, invariant tables, lookup data. Read on demand.
+8. **checklists** — binary verification at pause points, no explanation. In
+   SKILL.md (domain) or CONTRIBUTING.md (universal).
 
-Layers 6, 7, and 8 all live inside a skill but serve fundamentally different
-concerns. Layer 6 is _procedural_ — it teaches, explains, and guides decisions.
-Layer 7 is _declarative_ — it supplies the data a procedure consults, without
-prescribing steps. Layer 8 is _verificational_ — each item is a binary assertion
-that a prior step was completed. Layer 7 earns its own slot because a defect in
-a template, example, or data table is a different class of problem from a defect
-in the procedure that consults it — trace attribution must distinguish "wrong
-procedure" from "stale data" from "missing verification". Similarly,
-CONTRIBUTING.md spans layers: its invariants and rules are layer 3 content,
-while its universal READ-DO and DO-CONFIRM checklists are layer 8 content.
+L6/L7/L8 share a skill folder but serve different concerns: L6 is _procedural_,
+L7 is _declarative_, L8 is _verificational_. L7 earns its own slot because a
+defective template is a different class of problem from a defective procedure —
+trace attribution must separate "wrong procedure" from "stale data" from
+"missing verification". CONTRIBUTING.md likewise spans layers: invariants are
+L3; its universal READ-DO and DO-CONFIRM checklists are L8.
 
 Rules:
 
-- No layer restates another's content. When two layers mention the same tool,
-  use voice to separate them: layer 1 describes what a tool is ("ToolX sends a
-  message to ThingY"), layer 6 directs when to use it ("Use ToolX to deliver the
-  quarterly finance report to ThingY").
-- Agents follow the most specific layer. A skill procedure that provides
-  complete steps makes system-level tool descriptions invisible — tools not
-  named in the procedure will not be used regardless of what layer 1 says.
-- CLAUDE.md orients — what the project is, who it serves, where to find things.
-  It never contains technical rules or step-by-step procedures.
-- CONTRIBUTING.md governs — how contributions must behave. All technical
-  invariants, quality commands, and policies live here. Domain-specific
-  procedures belong in skills.
-- Tasks name skills — they don't copy steps. Shared procedures belong in skills;
-  per-run details belong in tasks.
-- Profiles define boundaries; skill procedures define steps; references supply
-  data; checklists verify steps.
-- A reference file is declarative, not procedural. It supplies templates,
-  examples, or data tables that the procedure consults. If a reference starts
-  prescribing steps, that content belongs in SKILL.md.
-- A checklist item must never teach how to do something — that belongs in the
-  skill procedure above it. If a checklist item needs explanation, the procedure
-  is incomplete.
+- No layer restates another. When two layers mention the same tool, separate by
+  voice: L1 describes ("ToolX sends a message to ThingY"), L6 directs ("Use
+  ToolX to deliver the report to ThingY").
+- Agents follow the most specific layer — a complete skill procedure makes
+  system-level tool descriptions invisible.
+- CLAUDE.md orients (what, who, where); CONTRIBUTING.md governs (invariants,
+  quality commands, policies); domain procedures live in skills.
+- Tasks name skills; they don't copy steps. Shared procedures in skills; per-run
+  details in tasks.
+- Profiles define boundaries; procedures define steps; references supply data;
+  checklists verify steps.
+- A reference is declarative, not procedural — prescribing steps belongs in
+  SKILL.md.
+- A checklist item must never teach. If an item needs explanation, the procedure
+  above it is incomplete.
 
 ### Instruction length
 
-Auto-loaded layers consume context on every run. Keep them tight so agents spend
-tokens on the task, not on re-reading project boilerplate. Limits enforced by
+Auto-loaded layers consume context on every run; keep them tight so agents spend
+tokens on the task, not boilerplate. Limits enforced by
 `scripts/check-instructions.mjs`:
 
 | Layer                    | Target      | Loaded           |
@@ -307,80 +267,61 @@ tokens on the task, not on re-reading project boilerplate. Limits enforced by
 | L7 Skill reference file  | ≤ 128 lines | on demand        |
 | L8 Checklist (per block) | ≤ 9 items   | auto (per skill) |
 
-The same principle applies across layers: keep the main file to its concern;
-push supporting material into co-located references or linked documents. L8 is
-gated by item count rather than line count because wrapped-line length is a
-formatting artifact, not cognitive load — nine binary assertions is the ceiling
-regardless of how wide they are.
+Same principle across layers: keep the main file to its concern; push supporting
+material into references or linked docs. L8 is gated by item count, not lines —
+wrapped-line length is a formatting artifact, not cognitive load.
 
 ### Skill structure
 
-Move supporting material out of SKILL.md into co-located subdirectories:
-
-```text
-.claude/skills/<skill-name>/
-  SKILL.md                     <- core instructions (always loaded)
-  scripts/<name>.sh|.mjs       <- executable automation
-  references/<name>.md         <- templates, examples, data tables
-```
-
-SKILL.md holds the decision-making procedure. `scripts/` holds repeatable
-commands the agent runs verbatim. `references/` holds content the agent reads on
-demand. Some skills are entirely instructional with nothing to extract — that's
-fine. Entry-point skills include tagged checklists as verification gates (see
-below).
+Move supporting material out of SKILL.md into co-located subdirectories.
+SKILL.md holds the procedure (always loaded); `scripts/<name>.sh|.mjs` holds
+commands run verbatim; `references/<name>.md` holds on-demand content
+(templates, examples, data tables). Purely instructional skills with nothing to
+extract are fine.
 
 ### Checklists
 
-Checklists are the lowest instruction layer (layer 8) — they verify that higher
-layers were followed without restating them. Two tagged types serve as gates at
-natural pause points:
+Checklists are L8 — they verify higher layers without restating them. Two tagged
+types serve as gates at natural pause points:
 
 - **`<read_do_checklist>`** — Entry gate. Read each item, then do it.
-- **`<do_confirm_checklist>`** — Exit gate. Do from memory, then confirm every
-  item before crossing a boundary.
+- **`<do_confirm_checklist>`** — Exit gate. Do from memory, then confirm before
+  crossing a boundary.
 
-The boundary between skill procedure and checklist is strict: if the agent needs
-the checklist item to _learn_ what to do, the item belongs in the procedure. If
-the agent already knows what to do and the item only confirms it was done, it
-belongs in the checklist. Duplicating procedural guidance into checklist items
-bloats the document and creates contradiction risk when one copy is updated
-without the other.
+The procedure/checklist boundary is strict: if an agent needs an item to _learn_
+what to do, it belongs in the procedure; if it only confirms a known step was
+done, it belongs in the checklist. Duplicating procedural guidance into
+checklists bloats the document and risks contradiction.
 
-Keep checklists short (5–9 items), action-oriented, and free of explanation.
+Keep checklists short (5–9 items), action-oriented, free of explanation.
 Entry-point skills embed domain-specific checklists; universal checklists live
-in CONTRIBUTING.md. See [CHECKLISTS.md](CHECKLISTS.md) for design rules, type
-selection, and authoring guidance.
+in CONTRIBUTING.md. See [CHECKLISTS.md](CHECKLISTS.md) for design rules.
 
 ### Publishing as a gate
 
-Autonomous agents default to human-loop handoff phrasing ("ready for PR when
-you'd like me to push") when no exit criterion requires external state change —
-they finish at the last locally-verifiable action. Any skill whose output is
-code (`fix/` or `spec/` branches) must rely on the universal DO-CONFIRM's push +
-PR item as its publishing gate; publishing steps described only in L6 procedural
-prose correlate with agents stopping after local commit on ephemeral runners,
-losing the work.
+Autonomous agents default to human-loop handoff ("ready for PR when you'd like
+me to push") when no exit criterion requires external state change. Any skill
+producing code (`fix/` or `spec/` branches) must rely on the universal
+DO-CONFIRM's push + PR item as its publishing gate — publishing steps described
+only in L6 prose correlate with agents stopping after local commit on ephemeral
+runners, losing the work. No skill restates the push + PR gate.
 
 ### Recursion-safe self-review
 
-Skills requiring independent review of their output must spawn a fresh sub-agent
-targeting a **leaf skill** (`kata-review`) whose process never spawns further
-sub-agents. This prevents infinite recursion. Defense-in-depth: the parent's
-review step also tells the sub-agent "do not invoke this skill." Callers spawn a
-**panel** of such leaf reviewers in parallel and merge findings by majority
-vote; panel size does not change the leaf invariant. See the `kata-review`
-caller protocol for panel sizes and merge algorithm.
+Skills needing independent review spawn a sub-agent targeting a **leaf skill**
+(`kata-review`) that never spawns further sub-agents, preventing infinite
+recursion. Defense-in-depth: the parent also tells the sub-agent "do not invoke
+this skill." Callers spawn a **panel** of leaf reviewers in parallel and merge
+findings by majority vote; panel size does not change the leaf invariant. See
+`kata-review`'s caller protocol for panel sizes and merge algorithm.
 
 ### Shared patterns
 
 Use identical wording for shared structural elements (memory instructions,
-prerequisites, section headings) across all agents and skills. Inconsistent
-wording correlated with agents skipping steps in trace analysis. Act-phase
-skills (those producing `fix/` or `spec/` branches) defer to the universal
-DO-CONFIRM for publishing — no skill restates the push + PR gate.
+prerequisites, section headings) across all agents and skills — inconsistent
+wording correlates with agents skipping steps in trace analysis.
 
 ### SDK caveat
 
 `resume()` does not persist `permissionMode` across resume boundaries — always
-pass all session configuration again when calling `resume()`.
+pass all session configuration when calling `resume()`.


### PR DESCRIPTION
## Summary

- Compress prose throughout KATA.md without dropping facts: opening summary, workflows intro, instruction-layering descriptions, and the Authoring Best Practices section.
- Merge redundant paragraphs in Shared Memory, Metrics, and Skill structure.
- Preserves all tables, mermaid diagrams, section structure, and policy content.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2446 pass)
- [x] `just check-instructions`


---
_Generated by [Claude Code](https://claude.ai/code/session_01So7G4kYHc9XYZSqqAe7oT3)_