### PR TITLE
ci: centralize agent step timeout in kata-action (default 45m)

### DIFF
--- a/.github/actions/kata-action/action.yml
+++ b/.github/actions/kata-action/action.yml
@@ -65,6 +65,10 @@ inputs:
   app-id:
     description: GitHub App ID for git identity email
     required: true
+  timeout-minutes:
+    description: Maximum minutes the agent step may run before being cancelled
+    required: false
+    default: "45"
 
 runs:
   using: composite
@@ -92,6 +96,7 @@ runs:
 
     - name: Run fit-eval
       shell: bash
+      timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
       env:
         MODE: ${{ inputs.mode }}
         TASK_FILE: ${{ inputs.task-file }}

--- a/.github/workflows/agent-conversation.yml
+++ b/.github/workflows/agent-conversation.yml
@@ -41,7 +41,6 @@ jobs:
     # Skip bot senders, and require issue_comment events to be on PRs (issue_comment also fires for issues).
     if: github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && ((github.event_name == 'issue_comment' && github.event.issue.pull_request != null) || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' || github.event_name == 'discussion' || github.event_name == 'discussion_comment'))
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/agent-product-manager.yml
+++ b/.github/workflows/agent-product-manager.yml
@@ -23,7 +23,6 @@ permissions:
 jobs:
   kata:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/agent-release-engineer.yml
+++ b/.github/workflows/agent-release-engineer.yml
@@ -23,7 +23,6 @@ permissions:
 jobs:
   kata:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/agent-security-engineer.yml
+++ b/.github/workflows/agent-security-engineer.yml
@@ -22,7 +22,6 @@ permissions:
 jobs:
   kata:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/agent-staff-engineer.yml
+++ b/.github/workflows/agent-staff-engineer.yml
@@ -23,7 +23,6 @@ permissions:
 jobs:
   kata:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/agent-technical-writer.yml
+++ b/.github/workflows/agent-technical-writer.yml
@@ -22,7 +22,6 @@ permissions:
 jobs:
   kata:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/interview-guide-setup.yml
+++ b/.github/workflows/interview-guide-setup.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
   evaluate:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/interview-landmark-setup.yml
+++ b/.github/workflows/interview-landmark-setup.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
   evaluate:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/interview-map-setup.yml
+++ b/.github/workflows/interview-map-setup.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
   evaluate:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/interview-summit-setup.yml
+++ b/.github/workflows/interview-summit-setup.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
   evaluate:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -22,7 +22,6 @@ permissions:
 jobs:
   kata:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Generate installation token
         id: ci-app

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -21,7 +21,6 @@ permissions:
 jobs:
   kata:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Generate installation token
         id: ci-app


### PR DESCRIPTION
## Summary

- The 30m job-level cap repeated across every agent/kata workflow was cancelling real work — agent-staff-engineer hit it 3× and kata-storyboard / agent-conversation 1× each in the last ~100 runs, with p95s sitting at the cap.
- Move `timeout-minutes` onto the long-running `Run fit-eval` step inside the shared `kata-action` so there's a single default to maintain.
- Raise the default to 45m (matches what `interview-*` workflows already used) — comfortably above observed uncensored max (~28m) with safety margin.
- Drop per-job `timeout-minutes` from all 12 consumer workflows.

### Run-time data sampled via `gh run list`

| Workflow | p50 | p90 | p95 | max | timeouts |
|---|---|---|---|---|---|
| agent-conversation | 1.9m | 18.0m | 24.2m | 30.4m | 1 |
| agent-product-manager | 4.4m | 10.6m | 14.0m | 15.8m | 0 |
| agent-release-engineer | 4.8m | 9.8m | 10.8m | 15.3m | 0 |
| agent-security-engineer | 8.4m | 12.0m | 12.6m | 13.3m | 0 |
| **agent-staff-engineer** | 10.0m | 26.1m | 30.4m | 30.4m | **3** |
| agent-technical-writer | 6.6m | 13.4m | 14.8m | 19.2m | 0 |
| kata-coaching | 8.1m | 14.7m | 16.2m | 17.6m | 0 |
| **kata-storyboard** | 20.3m | 27.4m | 28.8m | 30.5m | **1** |

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2446 pass, 0 fail)