### PR TITLE
fix(ci): trigger agent-conversation once per PR review

### DIFF
--- a/.github/workflows/agent-conversation.yml
+++ b/.github/workflows/agent-conversation.yml
@@ -39,7 +39,9 @@ permissions:
 jobs:
   kata:
     # Skip bot senders, and require issue_comment events to be on PRs (issue_comment also fires for issues).
-    if: github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && ((github.event_name == 'issue_comment' && github.event.issue.pull_request != null) || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' || github.event_name == 'discussion' || github.event_name == 'discussion_comment'))
+    # For pull_request_review_comment, only run on thread replies (in_reply_to_id set) — top-level
+    # review comments are delivered via the pull_request_review (submitted) event in a single batch.
+    if: github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && ((github.event_name == 'issue_comment' && github.event.issue.pull_request != null) || (github.event_name == 'pull_request_review_comment' && github.event.comment.in_reply_to_id != null) || github.event_name == 'pull_request_review' || github.event_name == 'discussion' || github.event_name == 'discussion_comment'))
     runs-on: ubuntu-latest
     steps:
       - name: Generate installation token


### PR DESCRIPTION
## Summary

- PR reviews with N comments fired `agent-conversation` N+1 times — once per `pull_request_review_comment` plus once on `pull_request_review` (submitted) — causing agents to duplicate work and step on each other.
- Gate `pull_request_review_comment` on `comment.in_reply_to_id` so only standalone thread replies trigger the workflow; batched review comments are now handled exclusively by the `pull_request_review` (submitted) event.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BFH8DNNEbgPDtd9D96YyjG)_