### PR TITLE
feat(kata-session,libxmr): partition storyboard and add fit-xmr summarize

### DIFF
--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -47,6 +47,9 @@ Participant Protocol below.
 - [ ] Identify which metrics CSVs to review from `wiki/metrics/`.
 - [ ] Run `bunx fit-xmr analyze --format json` against each metrics CSV and
       record the output.
+- [ ] For team storyboard runs, run `bunx fit-xmr summarize <csv> --markdown`
+      per agent-domain CSV to generate the deterministic stats block that goes
+      under the Current Condition table.
 
 </read_do_checklist>
 
@@ -58,7 +61,10 @@ Participant Protocol below.
       including XmR `status` and signal descriptions for each metric with
       sufficient data. Metrics with `insufficient_data` are noted.
 - [ ] Coaching metrics appended to CSV (see Facilitator Process step 6).
-- [ ] For team meetings: storyboard file updated and committed.
+- [ ] For team meetings: storyboard file updated and committed; Obstacles and
+      Experiments split into Active and Concluded (last 7 days) per the
+      partition protocol, items closed this session moved to Concluded, lines
+      older than 7 days deleted (date math, not judgment).
 - [ ] For 1-on-1: agent's findings written to its own memory.
 - [ ] Weekly log updated: append a `## YYYY-MM-DD` heading to the current week's
       log file recording meeting type, key metrics reviewed, obstacle addressed,

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -30,22 +30,41 @@ from wiki/metrics/. Always numbers, not narratives._
 Spark: last 12 data points via `bunx fit-xmr spark <csv> --metric <name>`. Bar
 height scales from ▁ (min) to █ (max) within the metric's own range.
 
+For the XmR summary block below the table, paste verbatim output from
+`bunx fit-xmr summarize <csv> --markdown` (one invocation per agent-domain CSV)
+and add a one-line interpretive note only for metrics whose `status` is
+`signals_present` or whose run-length is unusual. Stable metrics get no prose.
+
 **Last updated:** YYYY-MM-DD
 
 ## Obstacles
 
 _What stands between the current condition and the target condition. Discovered
-through experiments, not predicted upfront._
+through experiments, not predicted upfront. Use the partition below — never mix
+active and concluded items in the same list._
+
+### Active
 
 - **Current obstacle -->** [describe]
-- [other known obstacles]
+- [other open obstacles]
+
+### Concluded (last 7 days)
+
+_One line per item: status (RESOLVED/ABANDONED), date closed, one-sentence
+verdict. Items older than 7 days are deleted; the prior month's storyboard and
+git history are the permanent record._
+
+- ~~[obstacle]~~ — RESOLVED YYYY-MM-DD. [one-sentence verdict].
 
 ## Experiments
 
 _PDSA cycles run against the current obstacle. Record expected outcome before
-running, actual outcome after._
+running, actual outcome after. Use the partition below — never mix active and
+concluded experiments in the same list._
 
-### Experiment N
+### Active
+
+#### Experiment N — [short name]
 
 - **Obstacle:** [which obstacle this addresses]
 - **What:** [description of the experiment]
@@ -53,3 +72,20 @@ running, actual outcome after._
 - **Actual outcome:** [what actually happened — record after running]
 - **What did we learn?** [gap between expected and actual]
 - **Next step:** [continue, pivot, or new experiment]
+
+### Concluded (last 7 days)
+
+_One line per item: verdict (DELIVERED/PASS/FAIL/ABANDONED), date closed,
+one-sentence learning. Items older than 7 days are deleted._
+
+- **Experiment N — [short name]** — DELIVERED YYYY-MM-DD. [one-sentence
+  learning].
+
+## Retention rule
+
+When marking an obstacle RESOLVED or an experiment DELIVERED/PASS/FAIL, move the
+item from `Active` to `Concluded (last 7 days)` in the same edit. At the start
+of every storyboard session, scan `Concluded (last 7 days)` and delete any line
+whose closed-date is more than 7 days before today. The decision is mechanical —
+date math, not judgment. The prior month's storyboard file (and git history) is
+the permanent archive.

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -57,6 +57,30 @@ For each CSV-backed metric in the Current Condition table, generate a sparkline
 with `bunx fit-xmr spark <csv> --metric <name>` and write it to the Spark
 column.
 
+For the XmR analysis block under the Current Condition table, run
+`bunx fit-xmr summarize <csv> --markdown` once per agent-domain CSV and paste
+the output verbatim. Add a one-line interpretive note only for metrics whose
+`status` is `signals_present` or whose run-length is unusual; stable metrics get
+no prose. The summarize subcommand emits the deterministic stats table — agents
+add the cross-reference layer (e.g., "matches PR #535 burst") only where there
+is something to say.
+
+## Active / Concluded partition
+
+Obstacles and Experiments are partitioned into `### Active` and
+`### Concluded (last 7 days)` subsections. The rule is mechanical:
+
+1. When marking an obstacle RESOLVED or an experiment DELIVERED/PASS/FAIL, move
+   the item from `Active` to `Concluded (last 7 days)` in the same edit. The
+   Concluded entry is one line: status, date closed, one-sentence verdict.
+2. At the start of every storyboard session, scan `Concluded (last 7 days)` and
+   delete any line whose closed-date is more than 7 days before today. Date
+   math, not judgment.
+3. Never mix active and concluded items in the same list.
+
+The prior month's storyboard file and git history are the permanent archive —
+nothing is lost, the live document just stops carrying inert weight.
+
 ## Participant briefing template
 
 > "You are joining a team storyboard meeting. I will Ask you five questions;

--- a/libraries/libxmr/bin/fit-xmr.js
+++ b/libraries/libxmr/bin/fit-xmr.js
@@ -7,6 +7,7 @@ import { runAnalyzeCommand } from "../src/commands/analyze.js";
 import { runListCommand } from "../src/commands/list.js";
 import { runValidateCommand } from "../src/commands/validate.js";
 import { runSparkCommand } from "../src/commands/spark.js";
+import { runSummarizeCommand } from "../src/commands/summarize.js";
 
 const { version: VERSION } = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
@@ -51,6 +52,19 @@ const definition = {
         },
       },
     },
+    {
+      name: "summarize",
+      args: "<csv-path>",
+      description:
+        "Compact markdown table of XmR stats and classification per metric",
+      options: {
+        metric: {
+          type: "string",
+          short: "m",
+          description: "Filter to a single metric by name",
+        },
+      },
+    },
   ],
   globalOptions: {
     format: {
@@ -68,6 +82,8 @@ const definition = {
     "fit-xmr list wiki/metrics/security-engineer/audit/2026.csv",
     "fit-xmr validate wiki/metrics/security-engineer/audit/2026.csv",
     "fit-xmr spark wiki/metrics/security-engineer/audit/2026.csv --metric open_vulnerabilities",
+    "fit-xmr summarize wiki/metrics/security-engineer/audit/2026.csv",
+    "fit-xmr summarize wiki/metrics/security-engineer/audit/2026.csv --format json",
   ],
 };
 
@@ -78,6 +94,7 @@ const COMMANDS = {
   list: runListCommand,
   validate: runValidateCommand,
   spark: runSparkCommand,
+  summarize: runSummarizeCommand,
 };
 
 function main() {

--- a/libraries/libxmr/src/commands/summarize.js
+++ b/libraries/libxmr/src/commands/summarize.js
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs";
+
+import { analyze, classify } from "../xmr.js";
+
+export function runSummarizeCommand(values, args, cli) {
+  const csvPath = args[0];
+  if (!csvPath) {
+    cli.usageError("summarize requires a <csv-path> argument");
+    process.exit(2);
+  }
+
+  const text = readFileSync(csvPath, "utf-8");
+  const report = analyze(text);
+
+  if (values.metric) {
+    report.metrics = report.metrics.filter((m) => m.metric === values.metric);
+  }
+
+  const rows = report.metrics.map((m) => ({
+    metric: m.metric,
+    n: m.n,
+    classification: classify(m),
+    latest: m.latest?.value ?? null,
+    latest_date: m.latest?.date ?? null,
+    x_bar: m.x_bar ?? null,
+    unpl: m.unpl ?? null,
+    lnpl: m.lnpl ?? null,
+    signals: m.signals ?? [],
+  }));
+
+  if (values.format === "json") {
+    process.stdout.write(
+      JSON.stringify({ source: csvPath, rows }, null, 2) + "\n",
+    );
+    return;
+  }
+
+  process.stdout.write(renderMarkdown(csvPath, rows) + "\n");
+}
+
+function renderMarkdown(source, rows) {
+  const sufficient = rows.filter((r) => r.classification !== "insufficient");
+  const insufficient = rows.filter((r) => r.classification === "insufficient");
+  const today = new Date().toISOString().slice(0, 10);
+
+  const lines = [`**XmR — \`${source}\`** _(${today})_`, ""];
+
+  if (sufficient.length === 0 && insufficient.length === 0) {
+    lines.push("_No metrics found._");
+    return lines.join("\n");
+  }
+
+  if (sufficient.length > 0) {
+    lines.push(
+      "| metric | n | latest | x̄ | UNPL | LNPL | classification | signals |",
+      "| ------ | - | ------ | -- | ---- | ---- | -------------- | ------- |",
+    );
+    for (const r of sufficient) {
+      lines.push(
+        `| ${r.metric} | ${r.n} | ${r.latest} | ${r.x_bar} | ${r.unpl} | ${r.lnpl} | ${r.classification} | ${formatSignals(r.signals)} |`,
+      );
+    }
+  }
+
+  if (insufficient.length > 0) {
+    if (sufficient.length > 0) lines.push("");
+    const parts = insufficient.map((r) => `${r.metric} (n=${r.n})`);
+    lines.push(`_Insufficient data (n<15):_ ${parts.join(", ")}.`);
+  }
+
+  return lines.join("\n");
+}
+
+function formatSignals(signals) {
+  if (signals.length === 0) return "—";
+  return signals.map(formatSignal).join("; ");
+}
+
+function formatSignal(s) {
+  const span = s.date ? s.date : `${s.from}→${s.to}`;
+  if (s.rule === "run_above" || s.rule === "run_below") {
+    return `${s.rule} ${s.length} from ${s.from}`;
+  }
+  if (s.rule === "trend_up" || s.rule === "trend_down") {
+    return `${s.rule} ${s.moves} from ${s.from}`;
+  }
+  if (s.count !== undefined && s.count > 1) {
+    return `${s.rule} ${s.count} from ${s.from}`;
+  }
+  return `${s.rule} ${span}`;
+}

--- a/libraries/libxmr/src/index.js
+++ b/libraries/libxmr/src/index.js
@@ -3,6 +3,7 @@ export {
   computeXmR,
   detectSignals,
   analyze,
+  classify,
   validateCSV,
   listMetrics,
   sparkline,

--- a/libraries/libxmr/src/xmr.js
+++ b/libraries/libxmr/src/xmr.js
@@ -192,6 +192,21 @@ export function detectSignals(dates, values, mrs, stats) {
   );
 }
 
+// Classify a metric report from `analyze` into a coarse process-behavior
+// category. Deterministic — derived purely from `status` and the signal mix.
+//
+//   insufficient — fewer than MIN_POINTS data points, no limits computed.
+//   stable       — predictable; no signals.
+//   chaos        — moving range exceeds URL (mr_above_url signal); the limits
+//                  themselves are unreliable until the chaos is investigated.
+//   signals      — signals present but not chaos; investigate special cause.
+export function classify(metric) {
+  if (metric.status === "insufficient_data") return "insufficient";
+  if (metric.status === "predictable") return "stable";
+  if (metric.signals?.some((s) => s.rule === "mr_above_url")) return "chaos";
+  return "signals";
+}
+
 export function analyze(csvText) {
   const rows = parseCSV(csvText);
 

--- a/libraries/libxmr/test/summarize.test.js
+++ b/libraries/libxmr/test/summarize.test.js
@@ -1,0 +1,125 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const BIN = new URL("../bin/fit-xmr.js", import.meta.url).pathname;
+
+function makeCSV(metric, values, { unit = "count" } = {}) {
+  const header = "date,metric,value,unit,run,note";
+  const rows = values.map((v, i) => {
+    const day = String((i % 28) + 1).padStart(2, "0");
+    const month = String(Math.floor(i / 28) + 1).padStart(2, "0");
+    return `2026-${month}-${day},${metric},${v},${unit},,`;
+  });
+  return [header, ...rows].join("\n");
+}
+
+function withTempCSV(content, fn) {
+  const dir = mkdtempSync(path.join(tmpdir(), "fit-xmr-summarize-"));
+  const file = path.join(dir, "metrics.csv");
+  writeFileSync(file, content);
+  try {
+    return fn(file);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function run(args) {
+  return spawnSync("node", [BIN, ...args], { encoding: "utf-8" });
+}
+
+describe("summarize command", () => {
+  test("emits a markdown table for sufficient data", () => {
+    const values = Array.from({ length: 20 }, (_, i) => 10 + (i % 2));
+    const csv = makeCSV("stable_metric", values);
+
+    withTempCSV(csv, (file) => {
+      const result = run(["summarize", file]);
+      assert.strictEqual(result.status, 0, result.stderr);
+      const out = result.stdout;
+      assert.match(out, /\*\*XmR — `.*`\*\*/);
+      assert.match(
+        out,
+        /\| metric \| n \| latest \| x̄ \| UNPL \| LNPL \| classification \| signals \|/,
+      );
+      assert.match(out, /\| stable_metric \| 20 \|/);
+      assert.match(out, /\| stable \|/);
+    });
+  });
+
+  test("notes insufficient data without a stats row", () => {
+    const csv = makeCSV("new_metric", [1, 2, 3]);
+
+    withTempCSV(csv, (file) => {
+      const result = run(["summarize", file]);
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.match(
+        result.stdout,
+        /Insufficient data \(n<15\):_ new_metric \(n=3\)\./,
+      );
+      assert.doesNotMatch(result.stdout, /\| metric \| n \|/);
+    });
+  });
+
+  test("emits JSON when --format json", () => {
+    const values = Array.from({ length: 20 }, (_, i) => 10 + (i % 2));
+    const csv = makeCSV("m", values);
+
+    withTempCSV(csv, (file) => {
+      const result = run(["summarize", file, "--format", "json"]);
+      assert.strictEqual(result.status, 0, result.stderr);
+      const parsed = JSON.parse(result.stdout);
+      assert.strictEqual(parsed.rows.length, 1);
+      assert.strictEqual(parsed.rows[0].metric, "m");
+      assert.strictEqual(parsed.rows[0].classification, "stable");
+      assert.ok(parsed.rows[0].x_bar > 10);
+    });
+  });
+
+  test("filters by --metric", () => {
+    const csv = [
+      "date,metric,value,unit,run,note",
+      ...Array.from({ length: 20 }, (_, i) => {
+        const d = `2026-01-${String((i % 28) + 1).padStart(2, "0")}`;
+        return `${d},a,${10 + (i % 2)},count,,`;
+      }),
+      ...Array.from({ length: 20 }, (_, i) => {
+        const d = `2026-02-${String((i % 28) + 1).padStart(2, "0")}`;
+        return `${d},b,${20 + (i % 2)},count,,`;
+      }),
+    ].join("\n");
+
+    withTempCSV(csv, (file) => {
+      const result = run(["summarize", file, "--metric", "b"]);
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.match(result.stdout, /\| b \|/);
+      assert.doesNotMatch(result.stdout, /\| a \|/);
+    });
+  });
+
+  test("requires a csv-path argument", () => {
+    const result = run(["summarize"]);
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /requires a <csv-path>/);
+  });
+
+  test("flags signals classification for runs", () => {
+    // 10 above-mean then 10 below-mean -> run_above + run_below
+    const values = [
+      ...Array.from({ length: 10 }, () => 20),
+      ...Array.from({ length: 10 }, () => 5),
+    ];
+    const csv = makeCSV("shifty", values);
+
+    withTempCSV(csv, (file) => {
+      const result = run(["summarize", file, "--format", "json"]);
+      assert.strictEqual(result.status, 0, result.stderr);
+      const parsed = JSON.parse(result.stdout);
+      assert.notStrictEqual(parsed.rows[0].classification, "stable");
+    });
+  });
+});

--- a/libraries/libxmr/test/xmr.test.js
+++ b/libraries/libxmr/test/xmr.test.js
@@ -6,6 +6,7 @@ import {
   computeXmR,
   detectSignals,
   analyze,
+  classify,
   validateCSV,
   listMetrics,
   sparkline,
@@ -166,6 +167,42 @@ describe("analyze", () => {
     assert.ok(m.latest);
     assert.strictEqual(m.latest.value, values[values.length - 1]);
     assert.strictEqual(typeof m.latest.mr, "number");
+  });
+});
+
+describe("classify", () => {
+  test("returns insufficient for insufficient_data", () => {
+    assert.strictEqual(
+      classify({ status: "insufficient_data", n: 5 }),
+      "insufficient",
+    );
+  });
+
+  test("returns stable for predictable", () => {
+    assert.strictEqual(
+      classify({ status: "predictable", signals: [] }),
+      "stable",
+    );
+  });
+
+  test("returns signals for signals_present without mr_above_url", () => {
+    assert.strictEqual(
+      classify({
+        status: "signals_present",
+        signals: [{ rule: "run_above" }, { rule: "point_above_unpl" }],
+      }),
+      "signals",
+    );
+  });
+
+  test("returns chaos when mr_above_url is among signals", () => {
+    assert.strictEqual(
+      classify({
+        status: "signals_present",
+        signals: [{ rule: "run_above" }, { rule: "mr_above_url" }],
+      }),
+      "chaos",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Make storyboard scaling mechanical, not curatorial.

- **kata-session**: storyboard now partitions Obstacles and Experiments into `### Active` and `### Concluded (last 7 days)` subsections. Items closed during a session move to Concluded as a one-liner; lines older than 7 days are deleted (date math, not judgment). Prior month's storyboard and git history are the permanent archive.
- **libxmr**: add `fit-xmr summarize <csv>` subcommand emitting a compact markdown table per metric (n, latest, x̄, UNPL, LNPL, classification, signals) plus `--format json`. Adds `classify()` helper to `xmr.js` mapping signal mix to `stable` / `signals` / `chaos` / `insufficient`. Reduces agent thinking tokens on deterministic XmR analysis; agents add 1-line interpretive notes only for non-stable metrics.

Wiki M04 storyboard already adopted both changes — partitioned (597→353 lines) and XmR section regenerated via the new subcommand. The IC's W18-day1 session ran post-merge of the partition work and correctly extended it (added Exp 23 to Active, two new Active obstacles).

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2456 pass)
- [x] Smoke-tested `fit-xmr summarize` against real PM/Staff/RE/SE/TW/IC CSVs; output regenerated the storyboard XmR block
- [x] kata-session checklist still ≤9 items per L8 budget

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMePQB27PSESeK6cPph4LC)_