### PR TITLE
chore: remove dead docs-* justfile recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -328,20 +328,6 @@ build-apps: build-binaries
     just build-app-services
     just build-app-utilities
 
-# ── Docs ──────────────────────────────────────────────────────────
-
-# Build documentation
-docs-build:
-    bunx --workspace=@forwardimpact/libdoc docs-build
-
-# Serve documentation
-docs-serve:
-    bunx --workspace=@forwardimpact/libdoc docs-serve
-
-# Serve with live reload
-docs-watch:
-    bunx --workspace=@forwardimpact/libdoc docs-serve --watch
-
 # ── Quality ───────────────────────────────────────────────────────
 
 # Enforce instruction layer limits (KATA.md § Instruction length)


### PR DESCRIPTION
The docs-build, docs-serve, and docs-watch recipes invoked
`bunx --workspace=@forwardimpact/libdoc docs-build` (and docs-serve), but
libdoc only declares a `fit-doc` bin entry — these scripts have never
existed in the package.json since the spec 360 cli-library consolidation.
Running them 404s against the npm registry.

The canonical incantations (`bunx fit-doc build`, `bunx fit-doc serve
--watch`) are already documented in the website skill and used by the
website CI workflow, so no replacement is needed.