### PR TITLE
fix(libcli): satisfy preserve-caught-error and complexity lints

### DIFF
--- a/libraries/libcli/src/cli.js
+++ b/libraries/libcli/src/cli.js
@@ -39,7 +39,23 @@ export class Cli {
 
   parse(argv) {
     const command = this.#findCommand(argv);
+    const options = this.#buildOptions(command);
+    const { values, positionals } = this.#parseArgs(argv, options);
 
+    if (values.help) {
+      this.#renderHelp(command, values.json);
+      return null;
+    }
+
+    if (values.version && this.#definition.version) {
+      this.#proc.stdout.write(this.#definition.version + "\n");
+      return null;
+    }
+
+    return { values, positionals };
+  }
+
+  #buildOptions(command) {
     const globalOpts = this.#definition.globalOptions || {};
     const commandOpts = command?.options || {};
     const merged = { ...globalOpts, ...commandOpts };
@@ -51,54 +67,46 @@ export class Cli {
       if (opt.default !== undefined) options[name].default = opt.default;
       if (opt.multiple) options[name].multiple = opt.multiple;
     }
+    return options;
+  }
 
-    let values, positionals;
+  #parseArgs(argv, options) {
     try {
-      ({ values, positionals } = parseArgs({
-        options,
-        allowPositionals: true,
-        args: argv,
-      }));
+      return parseArgs({ options, allowPositionals: true, args: argv });
     } catch (err) {
       if (err.code === "ERR_PARSE_ARGS_UNKNOWN_OPTION") {
-        const match = err.message.match(/'(--?)([^']+)'/);
-        if (match) {
-          const bare = match[2];
-          const asCommand = this.#definition.commands?.find(
-            (c) => c.name === bare,
-          );
-          if (asCommand) {
-            const usage = asCommand.args
-              ? `${this.#definition.name} ${bare} ${asCommand.args}`
-              : `${this.#definition.name} ${bare}`;
-            throw new Error(
-              `Unknown option "${match[1]}${bare}". "${bare}" is a command, not an option. Usage: ${usage}`,
-            );
-          }
-        }
+        const commandError = this.#commandAsOptionError(err);
+        if (commandError) throw commandError;
       }
       throw err;
     }
+  }
 
-    if (values.help) {
-      if (values.json) {
-        this.#helpRenderer.renderJson(
-          this.#definition,
-          this.#proc.stdout,
-          command,
-        );
-      } else {
-        this.#helpRenderer.render(this.#definition, this.#proc.stdout, command);
-      }
-      return null;
+  #commandAsOptionError(err) {
+    const match = err.message.match(/'(--?)([^']+)'/);
+    if (!match) return null;
+    const bare = match[2];
+    const asCommand = this.#definition.commands?.find((c) => c.name === bare);
+    if (!asCommand) return null;
+    const usage = asCommand.args
+      ? `${this.#definition.name} ${bare} ${asCommand.args}`
+      : `${this.#definition.name} ${bare}`;
+    return new Error(
+      `Unknown option "${match[1]}${bare}". "${bare}" is a command, not an option. Usage: ${usage}`,
+      { cause: err },
+    );
+  }
+
+  #renderHelp(command, asJson) {
+    if (asJson) {
+      this.#helpRenderer.renderJson(
+        this.#definition,
+        this.#proc.stdout,
+        command,
+      );
+    } else {
+      this.#helpRenderer.render(this.#definition, this.#proc.stdout, command);
     }
-
-    if (values.version && this.#definition.version) {
-      this.#proc.stdout.write(this.#definition.version + "\n");
-      return null;
-    }
-
-    return { values, positionals };
   }
 
   #findCommand(argv) {

--- a/libraries/libsyntheticprose/src/prompts/pathway/capability.js
+++ b/libraries/libsyntheticprose/src/prompts/pathway/capability.js
@@ -79,18 +79,22 @@ export function buildCapabilityPrompt(skeleton, ctx, schema, priorOutput) {
             ...(priorOutput.levels && Array.isArray(priorOutput.levels)
               ? [
                   "Level titles and proficiency baselines:",
-                  ...priorOutput.levels.map(
-                    (l) =>
-                      `- ${l.id}: ${l.professionalTitle || l.id} (core: ${l.baseSkillProficiencies?.core || "N/A"})`,
-                  ),
+                  ...priorOutput.levels
+                    .filter(Boolean)
+                    .map(
+                      (l) =>
+                        `- ${l.id}: ${l.professionalTitle || l.id} (core: ${l.baseSkillProficiencies?.core || "N/A"})`,
+                    ),
                 ]
               : []),
             ...(priorOutput.behaviours && Array.isArray(priorOutput.behaviours)
               ? [
                   "Behaviour names:",
-                  ...priorOutput.behaviours.map(
-                    (b) => `- ${b._id || b.id}: ${b.name || b._id || b.id}`,
-                  ),
+                  ...priorOutput.behaviours
+                    .filter(Boolean)
+                    .map(
+                      (b) => `- ${b._id || b.id}: ${b.name || b._id || b.id}`,
+                    ),
                 ]
               : []),
           ]

--- a/libraries/libsyntheticprose/src/prompts/pathway/prior-context.js
+++ b/libraries/libsyntheticprose/src/prompts/pathway/prior-context.js
@@ -4,25 +4,31 @@
 
 /** @param {object[]} levels @returns {string[]} */
 function formatLevels(levels) {
+  const valid = levels.filter(Boolean);
+  if (valid.length === 0) return [];
   return [
     "Level titles:",
-    ...levels.map((l) => `- ${l.id}: ${l.professionalTitle || l.id}`),
+    ...valid.map((l) => `- ${l.id}: ${l.professionalTitle || l.id}`),
   ];
 }
 
 /** @param {object[]} behaviours @returns {string[]} */
 function formatBehaviours(behaviours) {
+  const valid = behaviours.filter(Boolean);
+  if (valid.length === 0) return [];
   return [
     "Behaviour names:",
-    ...behaviours.map((b) => `- ${b._id || b.id}: ${b.name || b._id || b.id}`),
+    ...valid.map((b) => `- ${b._id || b.id}: ${b.name || b._id || b.id}`),
   ];
 }
 
 /** @param {object[]} capabilities @returns {string[]} */
 function formatCapabilities(capabilities) {
+  const valid = capabilities.filter(Boolean);
+  if (valid.length === 0) return [];
   return [
     "Capability names and skill IDs:",
-    ...capabilities.map(
+    ...valid.map(
       (c) =>
         `- ${c._id || c.id}: ${c.name || c._id || c.id} (skills: ${(c.skills || []).map((s) => s.id || s).join(", ")})`,
     ),


### PR DESCRIPTION
ESLint's `preserve-caught-error` (recommended in ESLint 10) flagged the
re-thrown unknown-option error for losing its cause, and `parse` exceeded
the project's complexity:15 budget at 18. Extract option building, arg
parsing, command-as-option detection, and help rendering into private
helpers, and pass the original error as `{ cause }`.