### PR TITLE
feat(design): add Kata brand and productize the self-maintenance system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,8 @@ above.
 - **Design language** — [design/index.md](design/index.md)
 - **Security** — [CONTRIBUTING.md § Security](CONTRIBUTING.md#security)
 - **Dependency policy** — [CONTRIBUTING.md](CONTRIBUTING.md#dependency-policy)
-- **Repo self-maintenance** — [KATA.md](KATA.md)
+- **Repo self-maintenance** — [KATA.md](KATA.md) ·
+  [Internals](websites/fit/docs/internals/kata/) · [Brand](design/kata/)
 - **Shared agent memory** — [wiki/](wiki/) (GitHub wiki, cloned on demand)
 - **Operations** — [Operations](websites/fit/docs/internals/operations/)
 - **Kata agent skills** — [.claude/skills/kata-\*](.claude/skills/)

--- a/design/fit/index.md
+++ b/design/fit/index.md
@@ -323,6 +323,13 @@ Each product shares the core design system with subtle differentiators:
   --sand-400: #b8a88e;
   --sand-600: #8a7a62;
 
+  /* ── Family alias (cross-brand component contract) ── */
+  --accent-warm-50: var(--sand-50);
+  --accent-warm-100: var(--sand-100);
+  --accent-warm-200: var(--sand-200);
+  --accent-warm-400: var(--sand-400);
+  --accent-warm-600: var(--sand-600);
+
   /* ── Text ── */
   --text-primary: #0a0908;
   --text-heading: #1c1a18;

--- a/design/index.md
+++ b/design/index.md
@@ -439,7 +439,23 @@ inside the family.
   brand's site.
 - **Product visual language** — UI treatments per product (e.g. progress bar
   styles, dashboard overlays).
+- **Radii values** — concrete `--radius-sm/md/lg` numbers may differ per brand to
+  match the brand's material vocabulary (e.g. journal cards vs stamped paper).
+  Brands diverging on radii must restate the affected component specs in their
+  own `index.md`, since the family's component vocabulary in
+  [§ 9](#9-components) names sizes only by token.
 - **CSS design tokens** — the concrete `:root` realization of the above.
+
+### Cross-brand component contract
+
+Components inherited from [§ 9](#9-components) must reference the family
+**semantic tokens** (`--bg-page`, `--bg-warm`, `--text-primary`, `--border-strong`,
+`--accent-warm-200`, `--accent-warm-400`, etc.), never the brand-specific palette
+tokens (`--sand-200`, `--ink-400`, …). Each brand exposes its warm-signal ramp
+both under a brand-specific name (for use inside that brand's docs and worked
+examples) **and** under the family alias `--accent-warm-{50,100,200,400,600}`.
+Shared component code that targets `--accent-warm-*` then renders correctly
+under any brand's `:root`.
 
 ### File structure
 

--- a/design/index.md
+++ b/design/index.md
@@ -439,23 +439,23 @@ inside the family.
   brand's site.
 - **Product visual language** — UI treatments per product (e.g. progress bar
   styles, dashboard overlays).
-- **Radii values** — concrete `--radius-sm/md/lg` numbers may differ per brand to
-  match the brand's material vocabulary (e.g. journal cards vs stamped paper).
-  Brands diverging on radii must restate the affected component specs in their
-  own `index.md`, since the family's component vocabulary in
+- **Radii values** — concrete `--radius-sm/md/lg` numbers may differ per brand
+  to match the brand's material vocabulary (e.g. journal cards vs stamped
+  paper). Brands diverging on radii must restate the affected component specs in
+  their own `index.md`, since the family's component vocabulary in
   [§ 9](#9-components) names sizes only by token.
 - **CSS design tokens** — the concrete `:root` realization of the above.
 
 ### Cross-brand component contract
 
 Components inherited from [§ 9](#9-components) must reference the family
-**semantic tokens** (`--bg-page`, `--bg-warm`, `--text-primary`, `--border-strong`,
-`--accent-warm-200`, `--accent-warm-400`, etc.), never the brand-specific palette
-tokens (`--sand-200`, `--ink-400`, …). Each brand exposes its warm-signal ramp
-both under a brand-specific name (for use inside that brand's docs and worked
-examples) **and** under the family alias `--accent-warm-{50,100,200,400,600}`.
-Shared component code that targets `--accent-warm-*` then renders correctly
-under any brand's `:root`.
+**semantic tokens** (`--bg-page`, `--bg-warm`, `--text-primary`,
+`--border-strong`, `--accent-warm-200`, `--accent-warm-400`, etc.), never the
+brand-specific palette tokens (`--sand-200`, `--ink-400`, …). Each brand exposes
+its warm-signal ramp both under a brand-specific name (for use inside that
+brand's docs and worked examples) **and** under the family alias
+`--accent-warm-{50,100,200,400,600}`. Shared component code that targets
+`--accent-warm-*` then renders correctly under any brand's `:root`.
 
 ### File structure
 

--- a/design/index.md
+++ b/design/index.md
@@ -18,6 +18,7 @@ palette, and motif. The contract is in
 
 - [Forward Impact Team (FIT)](fit/index.md) · [scenes](fit/scenes.md) ·
   [icons](fit/icons.md)
+- [Kata](kata/index.md) · [scenes](kata/scenes.md) · [icons](kata/icons.md)
 
 ---
 

--- a/design/kata/icons.md
+++ b/design/kata/icons.md
@@ -61,20 +61,23 @@ hollow circle (the eye). Two cuts on the bit. Evokes the night watchman's
 ring — the Security Engineer's discipline of locking what should be locked
 and walking past what shouldn't.
 
-## Product Manager — The Kanban Rail
+## Product Manager — The Merge Gate
 
 ```
-   ──┯━━━━━━┯━━━━━━┯──   ← horizontal wire
-     ▢      ▢      ▢
-     ▢             ▢
-     ▢
+   ──┯━━━━━━┯━━━━━━┯─── │ →   ✓
+     ▢      ▢      ▢[●] │
+     ▢             ▢    │
+     ▢                  │  ← gate post
+                        ─
 ```
 
-A horizontal wire with three kanban cards pegged from it at varying
-depths. Cards are square, pegs implied by a small mark at each top edge.
-The wire extends slightly past the cards on either side — the line
-continues. Triage, review, intake — the three motions the Product Manager
-makes against the same rail.
+A horizontal kanban wire with three cards pegged from it at varying
+depths, terminating at the right in a small upright gate post. The
+rightmost card carries a single circular hanko mark (`--ink-400`) — the
+"approved" stamp on the card crossing the gate. The wire extends slightly
+past the gate, but only the stamped card crosses. Triage, review, gate —
+the three motions the Product Manager makes, ending in the only decision
+that touches main.
 
 ## Technical Writer — The Fountain Pen
 
@@ -114,9 +117,9 @@ slightly irregular line, micro-gaps in the stroke). A horizontal floor
 line beneath it grounds it on a surface. The circle is the coaching kata
 made visible: stand here, watch the work, ask what changed.
 
-**Filled variant:** A chalk-dust filled circle (`--gray-100`) for the
-moment after the coach has stepped out — used for completed coaching
-sessions in the storyboard.
+A "completed coaching" state for storyboard rendering uses a second
+overlapping circle stroke (a halo) — not a fill. The icon system's
+single-fill rule (the Release Engineer's hanko) is preserved.
 
 ---
 
@@ -126,47 +129,55 @@ sessions in the storyboard.
 | ----------- | --------------------------------------------------------------- |
 | Grid        | 24×24px with 2px padding (20px live area)                       |
 | Stroke      | 2px, round caps, round joins                                    |
-| Fill        | None, except Release Engineer's hanko stamp (`--ink-400`)       |
+| Fill        | None, except the hanko stamp in `--ink-400` (Release Engineer's crate, Product Manager's approved card) |
 | Color       | `--gray-900` default, `--gray-400` when inactive                |
 | Ground line | 1px stroke at bottom (Staff Engineer, Release Engineer, Coach)  |
 | Style       | Hand-stamped feel — slightly irregular corners, micro-variation |
 | Sizes       | 24px (inline), 32px (nav), 48px (cards), 96px (marketing)       |
 
-The single filled element in the system — the Release Engineer's hanko —
-mirrors FIT's only filled element (the Guide compass north). One brand
-mark per family per icon system: the warm signal showing through exactly
-once.
+The hanko stamp is the only filled mark in the system — `--ink-400` on
+white, appearing on the Release Engineer's crate (where the stamp is
+applied) and the Product Manager's approved card (where the stamp has
+been earned). Same mark, two placements — the two halves of the gate.
+This mirrors FIT's single filled element (the Guide compass north): one
+brand-specific warm-signal mark per icon system, no other fills.
 
 ---
 
 ## Combined Icon: The Kata Suite Mark
 
 ```
-   ╲          ┌────┐      ┌─┐      ──┯━━┯──    ╱│       ╱─╲
-    ╲         │ ●  │     ┌┴─┴┐      ▢   ▢    ╱ │       │   │
-   ┌─╲        │    │     │ ○ │                 ┌┴┐      ╲─╱
+   ╲          ┌────┐      ┌─┐     ──┯━━┯─[●]│   ╱│       ╱─╲
+    ╲         │ ●  │     ┌┴─┴┐     ▢   ▢   │  ╱ │       │   │
+   ┌─╲        │    │     │ ○ │              ── ┌┴┐      ╲─╱
    │  ╲       │    │     └┬─┬┘                 │ │      ───
    └───╲      └────┘      │                    └┬┘
                           ┝╾                    ╲
-   Staff      Release     Security    Product   Writer    Coach
+   Staff      Release     Security   Product    Writer    Coach
 ```
 
-Six icons on a shared ground line, evenly spaced. The Release Engineer's
-hanko stamp is the only filled mark in the row — the visual punctuation
-mark that distinguishes Kata's suite mark from FIT's six-icon suite.
+Six icons on a shared ground line, evenly spaced. Both the Release
+Engineer's hanko stamp on the crate and the Product Manager's hanko on the
+approved card use `--ink-400` — the same one mark, used twice (once where
+it's printed, once where it's earned). The icon system retains its
+single-fill-color rule (only the hanko ink) — though the hanko appears on
+two adjacent personas, signalling that "stamped" and "shipped" are the
+two halves of the same gate.
 
 ---
 
 ## Suite Wordmark
 
 The Kata wordmark sets the four letters **KATA** in Roboto Slab 700 with
-generous letter-spacing (`0.18em`). Optional: a small chalk-circle dot
-above the second `A`, sized at 0.4em — the Improvement Coach motif acting
-as a quiet brand signature on print materials and the dark footer.
+generous letter-spacing (`0.18em`). Above the second `A` sits a small
+**PDSA wheel** — the four-quadrant chalk circle defined in
+[index.md § 3 The PDSA Wheel](index.md#the-pdsa-wheel) — sized at 0.5em.
+The wheel acts as the brand's signature: a quiet visible reminder that
+every Kata page is a turn of the cycle.
 
 ```
    K A T A
-        ·     ← optional chalk-circle accent
+        ⊕     ← PDSA wheel (P · D · S · A clockwise)
 ```
 
 When the wordmark sits beside the trio silhouette in headers and footers,
@@ -174,3 +185,8 @@ the silhouette is on the left, wordmark on the right, separated by 16px.
 The trio's Stakeholder silhouette in this combined mark wears the flat cap
 — the only place where a single element of the trio composition carries a
 brand-specific accessory at signature scale.
+
+At very small sizes (under 16px wordmark height), the PDSA wheel reduces
+to a simple **stroke-only** circle in `--gray-700` — the quadrant marks
+are dropped, but the no-fill icon rule is preserved. Below 8px wordmark
+height the wheel is omitted entirely.

--- a/design/kata/icons.md
+++ b/design/kata/icons.md
@@ -1,0 +1,176 @@
+# Kata Agent Icons
+
+24px grid, 2px stroke, no fill — matching the characters' line weight.
+Should feel stamped into the same logbook as the trio.
+
+For the Kata brand context — palette, typography, agent taxonomy — see
+[index.md](index.md). For agent scenes that compose these icons with the
+three characters, see [scenes.md](scenes.md).
+
+---
+
+## Staff Engineer — The Set-Square
+
+```
+       ╲
+        ╲
+   ┌─────╲
+   │      ╲
+   │       ╲
+   │        ╲
+   └─────────╲
+```
+
+A right-angle set-square (drafting triangle) resting on an implied bench.
+Two clean perpendicular legs, one diagonal hypotenuse. The drafting tool
+that makes plans buildable — the Staff Engineer's discipline of turning
+spec into design into plan, without wishing the geometry away.
+
+## Release Engineer — The Stamped Crate
+
+```
+   ┌──────────┐
+   │  ╲╱      │
+   │  ╱╲      │  ← hanko stamp on lid
+   │          │
+   │  ▔▔▔▔▔  │
+   └──────────┘
+```
+
+A wooden shipping crate viewed three-quarters, with a small circular hanko
+stamp mark on the lid. The stamp is the only filled element in the icon
+system — `--ink-400` on white. The crate is sealed; the manifest is
+signed; the line moves on time.
+
+## Security Engineer — The Brass Key
+
+```
+       ┌─┐
+      ┌┴─┴┐
+      │ ○ │   ← key bow with eye
+      └┬─┬┘
+       │
+       │
+       ┝╾   ← key bit (teeth)
+       ┝╾
+       └
+```
+
+A vertical brass key, head up, teeth at the bottom. Round bow with a single
+hollow circle (the eye). Two cuts on the bit. Evokes the night watchman's
+ring — the Security Engineer's discipline of locking what should be locked
+and walking past what shouldn't.
+
+## Product Manager — The Kanban Rail
+
+```
+   ──┯━━━━━━┯━━━━━━┯──   ← horizontal wire
+     ▢      ▢      ▢
+     ▢             ▢
+     ▢
+```
+
+A horizontal wire with three kanban cards pegged from it at varying
+depths. Cards are square, pegs implied by a small mark at each top edge.
+The wire extends slightly past the cards on either side — the line
+continues. Triage, review, intake — the three motions the Product Manager
+makes against the same rail.
+
+## Technical Writer — The Fountain Pen
+
+```
+       ╱│
+      ╱ │
+     ╱  │   ← cap
+    ──  │
+       ┌┴┐
+       │ │
+       │ │  ← barrel
+       │ │
+       └┬┘
+        ╲   ← nib
+         ╲
+```
+
+A capped fountain pen viewed in profile, nib pointing down-right. The cap
+crown sits flush with the barrel. The nib has a single visible slit. The
+instrument of accurate, deliberate writing — the Technical Writer's tool
+for turning a week of work into a paragraph that will still be true a year
+later.
+
+## Improvement Coach — The Ohno Circle
+
+```
+        ╱ ─ ─ ╲
+      ╱         ╲
+     │           │   ← chalk circle
+      ╲         ╱
+        ╲ ─ ─ ╱
+       ━━━━━━━━━     ← floor line
+```
+
+A simple chalk circle drawn on the floor, intentionally hand-drawn (very
+slightly irregular line, micro-gaps in the stroke). A horizontal floor
+line beneath it grounds it on a surface. The circle is the coaching kata
+made visible: stand here, watch the work, ask what changed.
+
+**Filled variant:** A chalk-dust filled circle (`--gray-100`) for the
+moment after the coach has stepped out — used for completed coaching
+sessions in the storyboard.
+
+---
+
+## Icon System Rules
+
+| Rule        | Specification                                                   |
+| ----------- | --------------------------------------------------------------- |
+| Grid        | 24×24px with 2px padding (20px live area)                       |
+| Stroke      | 2px, round caps, round joins                                    |
+| Fill        | None, except Release Engineer's hanko stamp (`--ink-400`)       |
+| Color       | `--gray-900` default, `--gray-400` when inactive                |
+| Ground line | 1px stroke at bottom (Staff Engineer, Release Engineer, Coach)  |
+| Style       | Hand-stamped feel — slightly irregular corners, micro-variation |
+| Sizes       | 24px (inline), 32px (nav), 48px (cards), 96px (marketing)       |
+
+The single filled element in the system — the Release Engineer's hanko —
+mirrors FIT's only filled element (the Guide compass north). One brand
+mark per family per icon system: the warm signal showing through exactly
+once.
+
+---
+
+## Combined Icon: The Kata Suite Mark
+
+```
+   ╲          ┌────┐      ┌─┐      ──┯━━┯──    ╱│       ╱─╲
+    ╲         │ ●  │     ┌┴─┴┐      ▢   ▢    ╱ │       │   │
+   ┌─╲        │    │     │ ○ │                 ┌┴┐      ╲─╱
+   │  ╲       │    │     └┬─┬┘                 │ │      ───
+   └───╲      └────┘      │                    └┬┘
+                          ┝╾                    ╲
+   Staff      Release     Security    Product   Writer    Coach
+```
+
+Six icons on a shared ground line, evenly spaced. The Release Engineer's
+hanko stamp is the only filled mark in the row — the visual punctuation
+mark that distinguishes Kata's suite mark from FIT's six-icon suite.
+
+---
+
+## Suite Wordmark
+
+The Kata wordmark sets the four letters **KATA** in Roboto Slab 700 with
+generous letter-spacing (`0.18em`). Optional: a small chalk-circle dot
+above the second `A`, sized at 0.4em — the Improvement Coach motif acting
+as a quiet brand signature on print materials and the dark footer.
+
+```
+   K A T A
+        ·     ← optional chalk-circle accent
+```
+
+When the wordmark sits beside the trio silhouette in headers and footers,
+the silhouette is on the left, wordmark on the right, separated by 16px.
+The trio's Stakeholder silhouette in this combined mark wears the flat cap
+— the only place where a single element of the trio composition carries a
+brand-specific accessory at signature scale.

--- a/design/kata/icons.md
+++ b/design/kata/icons.md
@@ -1,11 +1,11 @@
 # Kata Agent Icons
 
-24px grid, 2px stroke, no fill — matching the characters' line weight.
-Should feel stamped into the same logbook as the trio.
+24px grid, 2px stroke, no fill — matching the characters' line weight. Should
+feel stamped into the same logbook as the trio.
 
 For the Kata brand context — palette, typography, agent taxonomy — see
-[index.md](index.md). For agent scenes that compose these icons with the
-three characters, see [scenes.md](scenes.md).
+[index.md](index.md). For agent scenes that compose these icons with the three
+characters, see [scenes.md](scenes.md).
 
 ---
 
@@ -21,10 +21,10 @@ three characters, see [scenes.md](scenes.md).
    └─────────╲
 ```
 
-A right-angle set-square (drafting triangle) resting on an implied bench.
-Two clean perpendicular legs, one diagonal hypotenuse. The drafting tool
-that makes plans buildable — the Staff Engineer's discipline of turning
-spec into design into plan, without wishing the geometry away.
+A right-angle set-square (drafting triangle) resting on an implied bench. Two
+clean perpendicular legs, one diagonal hypotenuse. The drafting tool that makes
+plans buildable — the Staff Engineer's discipline of turning spec into design
+into plan, without wishing the geometry away.
 
 ## Release Engineer — The Stamped Crate
 
@@ -37,10 +37,10 @@ spec into design into plan, without wishing the geometry away.
    └──────────┘
 ```
 
-A wooden shipping crate viewed three-quarters, with a small circular hanko
-stamp mark on the lid. The stamp is the only filled element in the icon
-system — `--ink-400` on white. The crate is sealed; the manifest is
-signed; the line moves on time.
+A wooden shipping crate viewed three-quarters, with a small circular hanko stamp
+mark on the lid. The stamp is the only filled element in the icon system —
+`--ink-400` on white. The crate is sealed; the manifest is signed; the line
+moves on time.
 
 ## Security Engineer — The Brass Key
 
@@ -57,9 +57,9 @@ signed; the line moves on time.
 ```
 
 A vertical brass key, head up, teeth at the bottom. Round bow with a single
-hollow circle (the eye). Two cuts on the bit. Evokes the night watchman's
-ring — the Security Engineer's discipline of locking what should be locked
-and walking past what shouldn't.
+hollow circle (the eye). Two cuts on the bit. Evokes the night watchman's ring —
+the Security Engineer's discipline of locking what should be locked and walking
+past what shouldn't.
 
 ## Product Manager — The Merge Gate
 
@@ -71,13 +71,12 @@ and walking past what shouldn't.
                         ─
 ```
 
-A horizontal kanban wire with three cards pegged from it at varying
-depths, terminating at the right in a small upright gate post. The
-rightmost card carries a single circular hanko mark (`--ink-400`) — the
-"approved" stamp on the card crossing the gate. The wire extends slightly
-past the gate, but only the stamped card crosses. Triage, review, gate —
-the three motions the Product Manager makes, ending in the only decision
-that touches main.
+A horizontal kanban wire with three cards pegged from it at varying depths,
+terminating at the right in a small upright gate post. The rightmost card
+carries a single circular hanko mark (`--ink-400`) — the "approved" stamp on the
+card crossing the gate. The wire extends slightly past the gate, but only the
+stamped card crosses. Triage, review, gate — the three motions the Product
+Manager makes, ending in the only decision that touches main.
 
 ## Technical Writer — The Fountain Pen
 
@@ -95,11 +94,10 @@ that touches main.
          ╲
 ```
 
-A capped fountain pen viewed in profile, nib pointing down-right. The cap
-crown sits flush with the barrel. The nib has a single visible slit. The
-instrument of accurate, deliberate writing — the Technical Writer's tool
-for turning a week of work into a paragraph that will still be true a year
-later.
+A capped fountain pen viewed in profile, nib pointing down-right. The cap crown
+sits flush with the barrel. The nib has a single visible slit. The instrument of
+accurate, deliberate writing — the Technical Writer's tool for turning a week of
+work into a paragraph that will still be true a year later.
 
 ## Improvement Coach — The Ohno Circle
 
@@ -113,34 +111,34 @@ later.
 ```
 
 A simple chalk circle drawn on the floor, intentionally hand-drawn (very
-slightly irregular line, micro-gaps in the stroke). A horizontal floor
-line beneath it grounds it on a surface. The circle is the coaching kata
-made visible: stand here, watch the work, ask what changed.
+slightly irregular line, micro-gaps in the stroke). A horizontal floor line
+beneath it grounds it on a surface. The circle is the coaching kata made
+visible: stand here, watch the work, ask what changed.
 
-A "completed coaching" state for storyboard rendering uses a second
-overlapping circle stroke (a halo) — not a fill. The icon system's
-single-fill rule (the Release Engineer's hanko) is preserved.
+A "completed coaching" state for storyboard rendering uses a second overlapping
+circle stroke (a halo) — not a fill. The icon system's single-fill rule (the
+Release Engineer's hanko) is preserved.
 
 ---
 
 ## Icon System Rules
 
-| Rule        | Specification                                                   |
-| ----------- | --------------------------------------------------------------- |
-| Grid        | 24×24px with 2px padding (20px live area)                       |
-| Stroke      | 2px, round caps, round joins                                    |
+| Rule        | Specification                                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------------------- |
+| Grid        | 24×24px with 2px padding (20px live area)                                                               |
+| Stroke      | 2px, round caps, round joins                                                                            |
 | Fill        | None, except the hanko stamp in `--ink-400` (Release Engineer's crate, Product Manager's approved card) |
-| Color       | `--gray-900` default, `--gray-400` when inactive                |
-| Ground line | 1px stroke at bottom (Staff Engineer, Release Engineer, Coach)  |
-| Style       | Hand-stamped feel — slightly irregular corners, micro-variation |
-| Sizes       | 24px (inline), 32px (nav), 48px (cards), 96px (marketing)       |
+| Color       | `--gray-900` default, `--gray-400` when inactive                                                        |
+| Ground line | 1px stroke at bottom (Staff Engineer, Release Engineer, Coach)                                          |
+| Style       | Hand-stamped feel — slightly irregular corners, micro-variation                                         |
+| Sizes       | 24px (inline), 32px (nav), 48px (cards), 96px (marketing)                                               |
 
-The hanko stamp is the only filled mark in the system — `--ink-400` on
-white, appearing on the Release Engineer's crate (where the stamp is
-applied) and the Product Manager's approved card (where the stamp has
-been earned). Same mark, two placements — the two halves of the gate.
-This mirrors FIT's single filled element (the Guide compass north): one
-brand-specific warm-signal mark per icon system, no other fills.
+The hanko stamp is the only filled mark in the system — `--ink-400` on white,
+appearing on the Release Engineer's crate (where the stamp is applied) and the
+Product Manager's approved card (where the stamp has been earned). Same mark,
+two placements — the two halves of the gate. This mirrors FIT's single filled
+element (the Guide compass north): one brand-specific warm-signal mark per icon
+system, no other fills.
 
 ---
 
@@ -156,37 +154,36 @@ brand-specific warm-signal mark per icon system, no other fills.
    Staff      Release     Security   Product    Writer    Coach
 ```
 
-Six icons on a shared ground line, evenly spaced. Both the Release
-Engineer's hanko stamp on the crate and the Product Manager's hanko on the
-approved card use `--ink-400` — the same one mark, used twice (once where
-it's printed, once where it's earned). The icon system retains its
-single-fill-color rule (only the hanko ink) — though the hanko appears on
-two adjacent personas, signalling that "stamped" and "shipped" are the
-two halves of the same gate.
+Six icons on a shared ground line, evenly spaced. Both the Release Engineer's
+hanko stamp on the crate and the Product Manager's hanko on the approved card
+use `--ink-400` — the same one mark, used twice (once where it's printed, once
+where it's earned). The icon system retains its single-fill-color rule (only the
+hanko ink) — though the hanko appears on two adjacent personas, signalling that
+"stamped" and "shipped" are the two halves of the same gate.
 
 ---
 
 ## Suite Wordmark
 
 The Kata wordmark sets the four letters **KATA** in Roboto Slab 700 with
-generous letter-spacing (`0.18em`). Above the second `A` sits a small
-**PDSA wheel** — the four-quadrant chalk circle defined in
-[index.md § 3 The PDSA Wheel](index.md#the-pdsa-wheel) — sized at 0.5em.
-The wheel acts as the brand's signature: a quiet visible reminder that
-every Kata page is a turn of the cycle.
+generous letter-spacing (`0.18em`). Above the second `A` sits a small **PDSA
+wheel** — the four-quadrant chalk circle defined in
+[index.md § 3 The PDSA Wheel](index.md#the-pdsa-wheel) — sized at 0.5em. The
+wheel acts as the brand's signature: a quiet visible reminder that every Kata
+page is a turn of the cycle.
 
 ```
    K A T A
         ⊕     ← PDSA wheel (P · D · S · A clockwise)
 ```
 
-When the wordmark sits beside the trio silhouette in headers and footers,
-the silhouette is on the left, wordmark on the right, separated by 16px.
-The trio's Stakeholder silhouette in this combined mark wears the flat cap
-— the only place where a single element of the trio composition carries a
-brand-specific accessory at signature scale.
+When the wordmark sits beside the trio silhouette in headers and footers, the
+silhouette is on the left, wordmark on the right, separated by 16px. The trio's
+Stakeholder silhouette in this combined mark wears the flat cap — the only place
+where a single element of the trio composition carries a brand-specific
+accessory at signature scale.
 
-At very small sizes (under 16px wordmark height), the PDSA wheel reduces
-to a simple **stroke-only** circle in `--gray-700` — the quadrant marks
-are dropped, but the no-fill icon rule is preserved. Below 8px wordmark
-height the wheel is omitted entirely.
+At very small sizes (under 16px wordmark height), the PDSA wheel reduces to a
+simple **stroke-only** circle in `--gray-700` — the quadrant marks are dropped,
+but the no-fill icon rule is preserved. Below 8px wordmark height the wheel is
+omitted entirely.

--- a/design/kata/index.md
+++ b/design/kata/index.md
@@ -2,25 +2,25 @@
 
 > The Kata realization of the [shared design language](../index.md): a
 > monochrome design system for the repo self-maintenance system, built around
-> the metaphor of a **mid-century Toyota production floor**. Six agent
-> personas — the **Staff Engineer**, **Release Engineer**, **Security
-> Engineer**, **Product Manager**, **Technical Writer**, and **Improvement
-> Coach** — work the line together, the way Taiichi Ohno's foremen worked the
-> shop floor in the 1940s and 50s.
+> the metaphor of a **mid-century Toyota production floor**. Six agent personas
+> — the **Staff Engineer**, **Release Engineer**, **Security Engineer**,
+> **Product Manager**, **Technical Writer**, and **Improvement Coach** — work
+> the line together, the way Taiichi Ohno's foremen worked the shop floor in the
+> 1940s and 50s.
 >
-> The brand evokes the dignity of practiced work: pressed suits, soft flat
-> caps, andon cords, kanban rails, the chalk circle on a polished concrete
-> floor. Black-and-white photography. Stamp-ink red on a white card. The
-> calm authority of someone who has stood on the gemba long enough to know
-> what good looks like.
+> The brand evokes the dignity of practiced work: pressed suits, soft flat caps,
+> andon cords, kanban rails, the chalk circle on a polished concrete floor.
+> Black-and-white photography. Stamp-ink red on a white card. The calm authority
+> of someone who has stood on the gemba long enough to know what good looks
+> like.
 
-This file specifies what is Kata-specific: the production-floor metaphor,
-Kata's reading of the family characters, the six agent personas, the concrete
-color palette, the typography choices, the type scale, the layout patterns,
-the agent visual language, and the CSS design tokens. The product scenes and
-agent icons live alongside in [scenes.md](scenes.md) and [icons.md](icons.md).
-For the abstract design language and the three characters' shared visual
-specifications, see [../index.md](../index.md).
+This file specifies what is Kata-specific: the production-floor metaphor, Kata's
+reading of the family characters, the six agent personas, the concrete color
+palette, the typography choices, the type scale, the layout patterns, the agent
+visual language, and the CSS design tokens. The product scenes and agent icons
+live alongside in [scenes.md](scenes.md) and [icons.md](icons.md). For the
+abstract design language and the three characters' shared visual specifications,
+see [../index.md](../index.md).
 
 ---
 
@@ -28,25 +28,24 @@ specifications, see [../index.md](../index.md).
 
 "The shop floor" — _gemba_ — draws from three simultaneous meanings:
 
-1. **The Toyota Production System era**: 1940s–50s post-war Japan. Taiichi
-   Ohno walking the floor in a soft cap and pressed suit, drawing chalk
-   circles, asking "why" five times. The unglamorous discipline of making
-   work visible and improving it one experiment at a time.
-2. **Kata as deliberate practice**: A pattern repeated until it becomes
-   reflex. The improvement kata and coaching kata are the same five questions
-   day after day, against an ever-moving target condition. Repetition is the
-   point, not the problem.
-3. **Industrial restraint**: Letterpress typography, stamped paperwork,
-   cotton lab coats, brass keys, manila folders, hand-lettered signage.
-   Tools designed for forty-year service lives. Nothing decorative; nothing
-   wasted.
+1. **The Toyota Production System era**: 1940s–50s post-war Japan. Taiichi Ohno
+   walking the floor in a soft cap and pressed suit, drawing chalk circles,
+   asking "why" five times. The unglamorous discipline of making work visible
+   and improving it one experiment at a time.
+2. **Kata as deliberate practice**: A pattern repeated until it becomes reflex.
+   The improvement kata and coaching kata are the same five questions day after
+   day, against an ever-moving target condition. Repetition is the point, not
+   the problem.
+3. **Industrial restraint**: Letterpress typography, stamped paperwork, cotton
+   lab coats, brass keys, manila folders, hand-lettered signage. Tools designed
+   for forty-year service lives. Nothing decorative; nothing wasted.
 
 The name **Kata** captures all three: a form practiced by hand, on the floor,
 with the calm conviction that the next iteration will be a little better than
 this one.
 
-The metaphor surfaces in illustration, iconography, and motif. The UI itself
-is clean and functional, not themed like a heritage poster.
+The metaphor surfaces in illustration, iconography, and motif. The UI itself is
+clean and functional, not themed like a heritage poster.
 
 ---
 
@@ -57,23 +56,20 @@ the production-floor metaphor. Their visual specifications are unchanged from
 the family — what follows are Kata-specific readings, not new shapes:
 
 - **Hand-drawn voice.** The 2px monochrome line-art reads, in Kata, as a
-  _foreman's notebook sketch_ — a quick mark made on the back of a kanban
-  card, between line walks.
+  _foreman's notebook sketch_ — a quick mark made on the back of a kanban card,
+  between line walks.
 - **The Stakeholder's cap.** In Kata scenes, the Stakeholder may wear a soft
   flat cap — the Ohno cap — when on the shop floor. Suit, tie, blazer, and
-  formal posture remain unchanged; the cap is a brand-context accessory, not
-  a substitution. They are still the domain expert who already knows the
+  formal posture remain unchanged; the cap is a brand-context accessory, not a
+  substitution. They are still the domain expert who already knows the
   territory; the cap signals _which_ territory.
 - **The Engineer's hoodie.** Reads, in Kata, as the modern descendant of the
-  cotton work-shirt: utility cloth, layered for the floor, ready for the
-  bench.
-- **The AI Agent's headphones.** Read, in Kata, as the line operator's
-  hearing protection — present, attentive, calibrated for the noise of the
-  shop.
+  cotton work-shirt: utility cloth, layered for the floor, ready for the bench.
+- **The AI Agent's headphones.** Read, in Kata, as the line operator's hearing
+  protection — present, attentive, calibrated for the noise of the shop.
 - **What the trio embodies.** Three people who chose the discipline of daily
-  improvement: hacker speed, machine precision, foreman's judgement. Working
-  the line together, in front of the storyboard, where the cards meet the
-  rail.
+  improvement: hacker speed, machine precision, foreman's judgement. Working the
+  line together, in front of the storyboard, where the cards meet the rail.
 
 ---
 
@@ -91,8 +87,8 @@ from the mid-century shop floor, mapped to a contemporary engineering role.
 | **Technical Writer**  | Is the manual accurate, and does the wiki reflect what we learned? |
 | **Improvement Coach** | What is the current condition, and what did we learn yesterday?    |
 
-Each agent has its own visual motif — drawn from the production-floor
-metaphor — that surfaces in icons and scenes but never in structural UI.
+Each agent has its own visual motif — drawn from the production-floor metaphor —
+that surfaces in icons and scenes but never in structural UI.
 
 | Agent                 | Motif                                  |
 | --------------------- | -------------------------------------- |
@@ -105,23 +101,22 @@ metaphor — that surfaces in icons and scenes but never in structural UI.
 
 ### The PDSA Wheel
 
-Above the six personas sits the **PDSA wheel** — a four-quadrant chalk
-circle marked **P · D · S · A** clockwise, the spine of
-[KATA.md](../../KATA.md) made visible. It is the brand's only repeating
-non-character motif, used as:
+Above the six personas sits the **PDSA wheel** — a four-quadrant chalk circle
+marked **P · D · S · A** clockwise, the spine of [KATA.md](../../KATA.md) made
+visible. It is the brand's only repeating non-character motif, used as:
 
 - The optional accent above the second `A` in the **KATA** wordmark (see
   [icons.md § Suite Wordmark](icons.md#suite-wordmark)).
-- A section divider on long pages — drawn at 16px, `--gray-300` stroke,
-  centred, with 96px of vertical breathing room either side.
-- A loading state — the wheel rotates one quadrant per 800ms, looping
-  P → D → S → A → P, respecting `prefers-reduced-motion` (static wheel).
+- A section divider on long pages — drawn at 16px, `--gray-300` stroke, centred,
+  with 96px of vertical breathing room either side.
+- A loading state — the wheel rotates one quadrant per 800ms, looping P → D → S
+  → A → P, respecting `prefers-reduced-motion` (static wheel).
 
-Each agent's "phase coverage" in [KATA.md § Skills](../../KATA.md#skills)
-maps to wheel quadrants, so the wheel is also functional: a Staff Engineer
-profile page may show the wheel with **P** and **D** lit; an Improvement
-Coach profile may show **S** lit. Lit quadrants use a 1.5px stroke;
-unlit quadrants use a 0.5px stroke. No fills.
+Each agent's "phase coverage" in [KATA.md § Skills](../../KATA.md#skills) maps
+to wheel quadrants, so the wheel is also functional: a Staff Engineer profile
+page may show the wheel with **P** and **D** lit; an Improvement Coach profile
+may show **S** lit. Lit quadrants use a 1.5px stroke; unlit quadrants use a
+0.5px stroke. No fills.
 
 ```
        P
@@ -140,9 +135,9 @@ unlit quadrants use a 0.5px stroke. No fills.
 ### Core Palette
 
 Warm-tinted grays, pulled toward the _sumi_ ink and pressed-paper end of the
-ramp. Slightly cooler than FIT's sandstone bias, slightly more graphite —
-think of a black-and-white photograph that has been kept in a manila folder
-for seventy years.
+ramp. Slightly cooler than FIT's sandstone bias, slightly more graphite — think
+of a black-and-white photograph that has been kept in a manila folder for
+seventy years.
 
 | Token          | Hex       | Usage                                       |
 | -------------- | --------- | ------------------------------------------- |
@@ -161,21 +156,21 @@ for seventy years.
 ### The Warm Signal: Hanko (Stamp Ink)
 
 A vermillion red drawn from the Japanese hanko (signature stamp) used to mark
-approved paperwork on the shop floor. Reads as ink on a card — the visible
-trace of a decision made.
+approved paperwork on the shop floor. Reads as ink on a card — the visible trace
+of a decision made.
 
-| Token        | Hex       | Usage                                  |
-| ------------ | --------- | -------------------------------------- |
-| `--ink-50`   | `#fbf3f1` | Warm section backgrounds               |
+| Token       | Hex       | Usage                                  |
+| ----------- | --------- | -------------------------------------- |
+| `--ink-50`  | `#fbf3f1` | Warm section backgrounds               |
 | `--ink-100` | `#f4ddd7` | Highlighted cards, selected states     |
 | `--ink-200` | `#e8b8ac` | Warm borders, active indicators        |
 | `--ink-400` | `#c25a47` | Warm tertiary elements                 |
 | `--ink-600` | `#8a3624` | Warm accent text (used very sparingly) |
 
-**Usage rule:** Hanko appears in backgrounds, borders, the terminal prompt,
-the andon-cord highlight, and the stamp-mark accent. **Never in body text or
-interactive elements.** It is the single warm signal — the ink on the card,
-not the card itself.
+**Usage rule:** Hanko appears in backgrounds, borders, the terminal prompt, the
+andon-cord highlight, and the stamp-mark accent. **Never in body text or
+interactive elements.** It is the single warm signal — the ink on the card, not
+the card itself.
 
 All grays are warm-tinted with a subtle graphite shift (~3–5% pull toward
 neutral-warm). The difference accumulates across a page — quieter than
@@ -187,42 +182,42 @@ sandstone, but still warmer than pure neutral. Like archival paper.
 
 ### Font Selection
 
-| Role               | Font                               | Fallback                                                    |
-| ------------------ | ---------------------------------- | ----------------------------------------------------------- |
-| **Display / Hero** | `"Roboto Slab"` (Google Fonts)     | `"Rockwell", Georgia, "Times New Roman", serif`             |
-| **Headings**       | `"IBM Plex Sans"` (Google Fonts)   | `-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif` |
-| **Body**           | `"IBM Plex Sans"`                  | Same                                                        |
-| **Mono / Code**    | `"IBM Plex Mono"` (Google Fonts)   | `"SF Mono", Consolas, "Liberation Mono", monospace`         |
+| Role               | Font                             | Fallback                                                    |
+| ------------------ | -------------------------------- | ----------------------------------------------------------- |
+| **Display / Hero** | `"Roboto Slab"` (Google Fonts)   | `"Rockwell", Georgia, "Times New Roman", serif`             |
+| **Headings**       | `"IBM Plex Sans"` (Google Fonts) | `-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif` |
+| **Body**           | `"IBM Plex Sans"`                | Same                                                        |
+| **Mono / Code**    | `"IBM Plex Mono"` (Google Fonts) | `"SF Mono", Consolas, "Liberation Mono", monospace`         |
 
-**Roboto Slab** is Kata's reading of the family's display serif: an
-industrial slab serif that evokes mid-century training manuals, factory
-signage, and stencilled crate markings — the vocabulary of writing things
-down on the shop floor.
+**Roboto Slab** is Kata's reading of the family's display serif: an industrial
+slab serif that evokes mid-century training manuals, factory signage, and
+stencilled crate markings — the vocabulary of writing things down on the shop
+floor.
 
-**IBM Plex Sans** is the sans pairing — a typeface designed explicitly to
-evoke mid-century corporate identity, with the geometric calm of a 1950s
-form. It pairs naturally with Roboto Slab through shared mid-century DNA.
+**IBM Plex Sans** is the sans pairing — a typeface designed explicitly to evoke
+mid-century corporate identity, with the geometric calm of a 1950s form. It
+pairs naturally with Roboto Slab through shared mid-century DNA.
 
 **IBM Plex Mono** completes the family — typewriter cadence without the
 typewriter's irregularity, suited for terminals and ledger-style data.
 
 ### Type Scale
 
-| Token                  | Size              | Weight | Line Height | Font            | Color        |
-| ---------------------- | ----------------- | ------ | ----------- | --------------- | ------------ |
-| `--text-hero`          | `4rem` (64px)     | 700    | 1.05        | Roboto Slab     | `--black`    |
-| `--text-display`       | `2.75rem` (44px)  | 600    | 1.1         | Roboto Slab     | `--gray-900` |
-| `--text-h1`            | `2rem` (32px)     | 600    | 1.2         | IBM Plex Sans   | `--gray-900` |
-| `--text-h2`            | `1.5rem` (24px)   | 600    | 1.25        | IBM Plex Sans   | `--gray-900` |
-| `--text-h3`            | `1.25rem` (20px)  | 500    | 1.3         | IBM Plex Sans   | `--gray-700` |
-| `--text-body`          | `1rem` (16px)     | 400    | 1.65        | IBM Plex Sans   | `--gray-500` |
-| `--text-body-emphasis` | `1rem` (16px)     | 500    | 1.65        | IBM Plex Sans   | `--gray-700` |
-| `--text-small`         | `0.875rem` (14px) | 400    | 1.5         | IBM Plex Sans   | `--gray-400` |
-| `--text-badge`         | `0.75rem` (12px)  | 600    | 1           | IBM Plex Sans   | `--gray-700` |
-| `--text-mono`          | `0.875rem` (14px) | 400    | 1.6         | IBM Plex Mono   | `--gray-500` |
+| Token                  | Size              | Weight | Line Height | Font          | Color        |
+| ---------------------- | ----------------- | ------ | ----------- | ------------- | ------------ |
+| `--text-hero`          | `4rem` (64px)     | 700    | 1.05        | Roboto Slab   | `--black`    |
+| `--text-display`       | `2.75rem` (44px)  | 600    | 1.1         | Roboto Slab   | `--gray-900` |
+| `--text-h1`            | `2rem` (32px)     | 600    | 1.2         | IBM Plex Sans | `--gray-900` |
+| `--text-h2`            | `1.5rem` (24px)   | 600    | 1.25        | IBM Plex Sans | `--gray-900` |
+| `--text-h3`            | `1.25rem` (20px)  | 500    | 1.3         | IBM Plex Sans | `--gray-700` |
+| `--text-body`          | `1rem` (16px)     | 400    | 1.65        | IBM Plex Sans | `--gray-500` |
+| `--text-body-emphasis` | `1rem` (16px)     | 500    | 1.65        | IBM Plex Sans | `--gray-700` |
+| `--text-small`         | `0.875rem` (14px) | 400    | 1.5         | IBM Plex Sans | `--gray-400` |
+| `--text-badge`         | `0.75rem` (12px)  | 600    | 1           | IBM Plex Sans | `--gray-700` |
+| `--text-mono`          | `0.875rem` (14px) | 400    | 1.6         | IBM Plex Mono | `--gray-500` |
 
-The Kata display weight is heavier than FIT's (700 vs 400) — slab serifs
-carry mid-century industrial weight, more poster than journal.
+The Kata display weight is heavier than FIT's (700 vs 400) — slab serifs carry
+mid-century industrial weight, more poster than journal.
 
 ### Hero Pattern
 
@@ -244,9 +239,9 @@ IBM Plex Sans, 18px, weight 400, gray-400:
 ## 6. Product Scenes
 
 The Kata product scenes — Storyboard Stand-up, Walking the Gemba, the Ohno
-Circle, the Andon Cord, the Kanban Rail, the Drafting Bench, the Shipping
-Bay, and the Archivist's Desk — and the scene usage matrix live in a sibling
-file: [scenes.md](scenes.md). They extend the
+Circle, the Andon Cord, the Kanban Rail, the Drafting Bench, the Shipping Bay,
+and the Archivist's Desk — and the scene usage matrix live in a sibling file:
+[scenes.md](scenes.md). They extend the
 [reusable base scenes](../index.md#4-reusable-base-scenes) with Kata
 production-floor symbols.
 
@@ -254,11 +249,11 @@ production-floor symbols.
 
 ## 7. Product Icons
 
-The six Kata agent icons — Staff Engineer, Release Engineer, Security
-Engineer, Product Manager, Technical Writer, Improvement Coach — plus the
-icon system rules and the combined suite mark live in a sibling file:
-[icons.md](icons.md). They share the family icon grid (24px, 2px stroke, no
-fill) and read as if stamped into the same logbook as the
+The six Kata agent icons — Staff Engineer, Release Engineer, Security Engineer,
+Product Manager, Technical Writer, Improvement Coach — plus the icon system
+rules and the combined suite mark live in a sibling file: [icons.md](icons.md).
+They share the family icon grid (24px, 2px stroke, no fill) and read as if
+stamped into the same logbook as the
 [characters](../index.md#2-the-three-characters).
 
 ---
@@ -266,15 +261,14 @@ fill) and read as if stamped into the same logbook as the
 ## 8. Layout Patterns
 
 Kata is the **internal** repo self-maintenance system. It has no public
-marketing site. The brand surfaces in four real places, ordered by how
-often a contributor or agent encounters them:
+marketing site. The brand surfaces in four real places, ordered by how often a
+contributor or agent encounters them:
 
 ### Surface 1 — The Internals Page
 
-The canonical home is
-`websites/fit/docs/internals/kata/index.md` — sibling to
-`internals/operations/`, `internals/codegen/`, `internals/librepl/`. This
-is where the brand renders for human contributors browsing the docs site.
+The canonical home is `websites/fit/docs/internals/kata/index.md` — sibling to
+`internals/operations/`, `internals/codegen/`, `internals/librepl/`. This is
+where the brand renders for human contributors browsing the docs site.
 
 ```
 ┌──────────────────────────────────────────────┐
@@ -315,48 +309,46 @@ is where the brand renders for human contributors browsing the docs site.
 
 ### Surface 2 — `KATA.md` Rendered on GitHub
 
-`KATA.md` at the repo root is read by every agent at the start of a Kata
-run (per the L2 instruction layer). On GitHub it renders as plain
-flavored markdown — the brand cannot inject CSS — so the brand surfaces
-through **structural cues** only: the trio mark in the header (linked
-SVG), section headings that match the persona names, the hanko stamp
-emoji-equivalent (`🟥`) reserved for the Trust Boundary section.
+`KATA.md` at the repo root is read by every agent at the start of a Kata run
+(per the L2 instruction layer). On GitHub it renders as plain flavored markdown
+— the brand cannot inject CSS — so the brand surfaces through **structural
+cues** only: the trio mark in the header (linked SVG), section headings that
+match the persona names, the hanko stamp emoji-equivalent (`🟥`) reserved for
+the Trust Boundary section.
 
 ### Surface 3 — Agent Comments and PR/Issue Bodies
 
-When a Kata agent posts on a PR or issue (via `agent-conversation`), it
-signs with its persona. The signature line is a single line of IBM Plex
-Mono using the convention:
+When a Kata agent posts on a PR or issue (via `agent-conversation`), it signs
+with its persona. The signature line is a single line of IBM Plex Mono using the
+convention:
 
 ```
 — {persona icon} {Persona Name} · {phase} · {run-id}
 ```
 
-Example: `— 📐 Staff Engineer · Plan · run-2026-04-28-night`. The icon is
-the persona's icon glyph; the phase is one of P/D/S/A; the run-id ties
-the comment back to the trace artifact.
+Example: `— 📐 Staff Engineer · Plan · run-2026-04-28-night`. The icon is the
+persona's icon glyph; the phase is one of P/D/S/A; the run-id ties the comment
+back to the trace artifact.
 
 ### Surface 4 — Storyboard Markdown and Wiki Summaries
 
-Daily storyboard files (`wiki/storyboard/{YYYY-MM-DD}.md`) and per-agent
-wiki summaries (`wiki/{persona}.md`) follow a fixed Kata template — the
-brand's typographic discipline applied to plain markdown. Persona name as
-H1, current condition as a blockquote, target condition as a level-2
-heading, the five kata questions as level-3 subsections, metrics as a
-mono-table.
+Daily storyboard files (`wiki/storyboard/{YYYY-MM-DD}.md`) and per-agent wiki
+summaries (`wiki/{persona}.md`) follow a fixed Kata template — the brand's
+typographic discipline applied to plain markdown. Persona name as H1, current
+condition as a blockquote, target condition as a level-2 heading, the five kata
+questions as level-3 subsections, metrics as a mono-table.
 
 ### Navigation Pattern (Internals Page)
 
-The Kata internals page lives inside the FIT docs nav. Within the Kata
-section, sub-nav routes to each persona:
+The Kata internals page lives inside the FIT docs nav. Within the Kata section,
+sub-nav routes to each persona:
 
 ```
 FIT Docs  ›  Internals  ›  Kata  ›  Staff · Release · Security · Product · Writer · Coach
 ```
 
-Current persona is bold (`600`). Others are regular (`400`) in
-`--gray-400`. The persona switcher is a horizontal row at the top of any
-persona sub-page.
+Current persona is bold (`600`). Others are regular (`400`) in `--gray-400`. The
+persona switcher is a horizontal row at the top of any persona sub-page.
 
 ### Warm/Cool Section Rhythm
 
@@ -369,37 +361,35 @@ Section 5: white (#ffffff)          — CTA / read the playbook
 Footer:    gray-900 (#161513)       — Dark footer (inverted), licenses
 ```
 
-The kata-rail texture is Kata's equivalent of FIT's contour lines: a
-repeating thin horizontal line in `--gray-100` on `--white-warm` or
-`--ink-50` sections, evoking the wire on which kanban cards slide. 1px
-stroke, spaced 28px apart, opacity 0.35. Never on pure white backgrounds.
+The kata-rail texture is Kata's equivalent of FIT's contour lines: a repeating
+thin horizontal line in `--gray-100` on `--white-warm` or `--ink-50` sections,
+evoking the wire on which kanban cards slide. 1px stroke, spaced 28px apart,
+opacity 0.35. Never on pure white backgrounds.
 
 ### Concrete Components
 
 The component patterns in [../index.md § 9](../index.md#9-components)
 instantiate with Kata colors:
 
-- **Buttons (Primary):** `background: --gray-900`, text `#ffffff`. Hover
-  shifts background to `--black`. The warm signal does not appear on
-  interactive elements — the brand's stamp-mark accent lives on cards,
-  paper, and the terminal prompt, never on a button or link.
+- **Buttons (Primary):** `background: --gray-900`, text `#ffffff`. Hover shifts
+  background to `--black`. The warm signal does not appear on interactive
+  elements — the brand's stamp-mark accent lives on cards, paper, and the
+  terminal prompt, never on a button or link.
 - **Buttons (Secondary / Product):** `border: 1.5px solid --gray-200`, text
   `--gray-900`. Hover darkens border to `--gray-700`.
-- **Cards:** `background: --white` (on warm bg) or `--white-warm` (on white
-  bg), `border: 1.5px solid --gray-200`. Selected/active state adds a
-  `--ink-400` left edge — the kanban-card "approved" stamp.
+- **Cards:** `background: --white` (on warm bg) or `--white-warm` (on white bg),
+  `border: 1.5px solid --gray-200`. Selected/active state adds a `--ink-400`
+  left edge — the kanban-card "approved" stamp.
 - **Terminal / Code Blocks:** `background: --gray-900` (`#161513`), text
   `#ebe8e1`, prompt `❯` in `--ink-400`, comments in `--gray-400`.
-- **Kanban-Rail Texture:** Repeating thin horizontal lines in `--gray-100`
-  on `--white-warm` or `--ink-50` sections. 1px stroke, 28px spacing,
-  opacity 0.35.
-- **Footer (Dark):** `background: --gray-900`, primary text `#ebe8e1`,
-  secondary text `--gray-300`, dividers `--gray-700`. Trio silhouette + the
-  word **KATA** (Roboto Slab 700, letter-spaced) in white. Licenses
-  (Apache-2.0 code, CC BY 4.0 docs) in `--gray-300`. (`--gray-300` is the
-  on-dark equivalent of `--gray-400` on light — a brand convention since
-  Kata's `--gray-400` is darker than the family default to satisfy AA on
-  white.)
+- **Kanban-Rail Texture:** Repeating thin horizontal lines in `--gray-100` on
+  `--white-warm` or `--ink-50` sections. 1px stroke, 28px spacing, opacity 0.35.
+- **Footer (Dark):** `background: --gray-900`, primary text `#ebe8e1`, secondary
+  text `--gray-300`, dividers `--gray-700`. Trio silhouette + the word **KATA**
+  (Roboto Slab 700, letter-spaced) in white. Licenses (Apache-2.0 code, CC BY
+  4.0 docs) in `--gray-300`. (`--gray-300` is the on-dark equivalent of
+  `--gray-400` on light — a brand convention since Kata's `--gray-400` is darker
+  than the family default to satisfy AA on white.)
 
 ---
 
@@ -407,33 +397,33 @@ instantiate with Kata colors:
 
 Each agent shares the core design system with subtle differentiators:
 
-| Agent                 | Accent Metaphor                          | Empty State                                   | Tone                                          |
-| --------------------- | ---------------------------------------- | --------------------------------------------- | --------------------------------------------- |
-| **Staff Engineer**    | Drafting — set-squares, plan grid        | Engineer at empty bench, sharpening pencil    | "Draw the plan before cutting metal."         |
-| **Release Engineer**  | Shipping — crates, manifest, time stamp  | Crate ready, stamp uninked                    | "The line moves on time."                     |
-| **Security Engineer** | Watch — brass keys, lantern, locked door | Lantern lit, ring of keys on a hook           | "Walk the floor with the lantern up."         |
-| **Product Manager**   | Kanban — cards on a wire, triage bin     | Empty rail, three pegs waiting                | "What's next on the rail?"                    |
-| **Technical Writer**  | Archive — fountain pen, manila folder    | Open ledger, fresh page                       | "If it isn't written, it didn't happen."      |
-| **Improvement Coach** | Coaching — chalk circle, five-question   | Empty circle drawn on the floor, chalk beside | "What is the current condition?"              |
+| Agent                 | Accent Metaphor                          | Empty State                                   | Tone                                     |
+| --------------------- | ---------------------------------------- | --------------------------------------------- | ---------------------------------------- |
+| **Staff Engineer**    | Drafting — set-squares, plan grid        | Engineer at empty bench, sharpening pencil    | "Draw the plan before cutting metal."    |
+| **Release Engineer**  | Shipping — crates, manifest, time stamp  | Crate ready, stamp uninked                    | "The line moves on time."                |
+| **Security Engineer** | Watch — brass keys, lantern, locked door | Lantern lit, ring of keys on a hook           | "Walk the floor with the lantern up."    |
+| **Product Manager**   | Kanban — cards on a wire, triage bin     | Empty rail, three pegs waiting                | "What's next on the rail?"               |
+| **Technical Writer**  | Archive — fountain pen, manila folder    | Open ledger, fresh page                       | "If it isn't written, it didn't happen." |
+| **Improvement Coach** | Coaching — chalk circle, five-question   | Empty circle drawn on the floor, chalk beside | "What is the current condition?"         |
 
 ### Agent-Specific UI Treatments
 
 - **Staff Engineer**: Plan documents render on a faint blueprint grid in
-  `--gray-100`. Spec / design / plan stages display as a 3-stage progress
-  line with stamped milestones.
+  `--gray-100`. Spec / design / plan stages display as a 3-stage progress line
+  with stamped milestones.
 - **Release Engineer**: Release notes use a manifest layout — version, date,
   payload, signer — rendered as a stamped shipping label.
-- **Security Engineer**: Vulnerability dashboards use a "lantern" pattern:
-  the unresolved CVE rows glow softly in `--ink-100`; resolved rows fall
-  back to `--gray-50`.
-- **Product Manager**: Issue and PR queues render as a kanban rail
-  (horizontal lanes, cards sliding right). The merge gate is a stamped seal.
+- **Security Engineer**: Vulnerability dashboards use a "lantern" pattern: the
+  unresolved CVE rows glow softly in `--ink-100`; resolved rows fall back to
+  `--gray-50`.
+- **Product Manager**: Issue and PR queues render as a kanban rail (horizontal
+  lanes, cards sliding right). The merge gate is a stamped seal.
 - **Technical Writer**: Wiki pages and weekly logs render in a "ledger"
-  treatment — narrow column, IBM Plex Mono for metadata lines, faint
-  horizontal rule between entries.
-- **Improvement Coach**: Storyboard meeting notes render inside a circle —
-  the Ohno circle — with the five kata questions arrayed around it. XmR
-  charts use a stamped grid.
+  treatment — narrow column, IBM Plex Mono for metadata lines, faint horizontal
+  rule between entries.
+- **Improvement Coach**: Storyboard meeting notes render inside a circle — the
+  Ohno circle — with the five kata questions arrayed around it. XmR charts use a
+  stamped grid.
 
 ---
 
@@ -523,5 +513,5 @@ the squared corners of mid-century industrial cards and stamped paper.
 
 ---
 
-_Kata brand implementation of the [shared design language](../index.md).
-Sibling brand to [FIT](../fit/index.md). Updated April 2026._
+_Kata brand implementation of the [shared design language](../index.md). Sibling
+brand to [FIT](../fit/index.md). Updated April 2026._

--- a/design/kata/index.md
+++ b/design/kata/index.md
@@ -1,0 +1,437 @@
+# Kata — Brand Implementation
+
+> The Kata realization of the [shared design language](../index.md): a
+> monochrome design system for the repo self-maintenance system, built around
+> the metaphor of a **mid-century Toyota production floor**. Six agent
+> personas — the **Staff Engineer**, **Release Engineer**, **Security
+> Engineer**, **Product Manager**, **Technical Writer**, and **Improvement
+> Coach** — work the line together, the way Taiichi Ohno's foremen worked the
+> shop floor in the 1940s and 50s.
+>
+> The brand evokes the dignity of practiced work: pressed suits, soft flat
+> caps, andon cords, kanban rails, the chalk circle on a polished concrete
+> floor. Black-and-white photography. Stamp-ink red on a white card. The
+> calm authority of someone who has stood on the gemba long enough to know
+> what good looks like.
+
+This file specifies what is Kata-specific: the production-floor metaphor,
+Kata's reading of the family characters, the six agent personas, the concrete
+color palette, the typography choices, the type scale, the layout patterns,
+the agent visual language, and the CSS design tokens. The product scenes and
+agent icons live alongside in [scenes.md](scenes.md) and [icons.md](icons.md).
+For the abstract design language and the three characters' shared visual
+specifications, see [../index.md](../index.md).
+
+---
+
+## 1. The Production-Floor Metaphor
+
+"The shop floor" — _gemba_ — draws from three simultaneous meanings:
+
+1. **The Toyota Production System era**: 1940s–50s post-war Japan. Taiichi
+   Ohno walking the floor in a soft cap and pressed suit, drawing chalk
+   circles, asking "why" five times. The unglamorous discipline of making
+   work visible and improving it one experiment at a time.
+2. **Kata as deliberate practice**: A pattern repeated until it becomes
+   reflex. The improvement kata and coaching kata are the same five questions
+   day after day, against an ever-moving target condition. Repetition is the
+   point, not the problem.
+3. **Industrial restraint**: Letterpress typography, stamped paperwork,
+   cotton lab coats, brass keys, manila folders, hand-lettered signage.
+   Tools designed for forty-year service lives. Nothing decorative; nothing
+   wasted.
+
+The name **Kata** captures all three: a form practiced by hand, on the floor,
+with the calm conviction that the next iteration will be a little better than
+this one.
+
+The metaphor surfaces in illustration, iconography, and motif. The UI itself
+is clean and functional, not themed like a heritage poster.
+
+---
+
+## 2. Characters on the Floor
+
+The [three family characters](../index.md#2-the-three-characters) live inside
+the production-floor metaphor. Their visual specifications are unchanged from
+the family — what follows are Kata-specific readings, not new shapes:
+
+- **Hand-drawn voice.** The 2px monochrome line-art reads, in Kata, as a
+  _foreman's notebook sketch_ — a quick mark made on the back of a kanban
+  card, between line walks.
+- **The Stakeholder's cap.** In Kata scenes, the Stakeholder may wear a soft
+  flat cap — the Ohno cap — when on the shop floor. Suit, tie, blazer, and
+  formal posture remain unchanged; the cap is a brand-context accessory, not
+  a substitution. They are still the domain expert who already knows the
+  territory; the cap signals _which_ territory.
+- **The Engineer's hoodie.** Reads, in Kata, as the modern descendant of the
+  cotton work-shirt: utility cloth, layered for the floor, ready for the
+  bench.
+- **The AI Agent's headphones.** Read, in Kata, as the line operator's
+  hearing protection — present, attentive, calibrated for the noise of the
+  shop.
+- **What the trio embodies.** Three people who chose the discipline of daily
+  improvement: hacker speed, machine precision, foreman's judgement. Working
+  the line together, in front of the storyboard, where the cards meet the
+  rail.
+
+---
+
+## 3. The Six Agent Personas
+
+Kata's "products" are the six agent personas — each a recognizable archetype
+from the mid-century shop floor, mapped to a contemporary engineering role.
+
+| Agent                 | Question it answers                                                |
+| --------------------- | ------------------------------------------------------------------ |
+| **Staff Engineer**    | What is the next experiment, and how do we run it?                 |
+| **Release Engineer**  | Is the line moving, and is the next release ready to ship?         |
+| **Security Engineer** | Is the floor safe — supply chain, dependencies, secrets?           |
+| **Product Manager**   | What enters the line, and what is ready to merge into main?        |
+| **Technical Writer**  | Is the manual accurate, and does the wiki reflect what we learned? |
+| **Improvement Coach** | What is the current condition, and what did we learn yesterday?    |
+
+Each agent has its own visual motif — drawn from the production-floor
+metaphor — that surfaces in icons and scenes but never in structural UI.
+
+| Agent                 | Motif                                  |
+| --------------------- | -------------------------------------- |
+| **Staff Engineer**    | The drafting bench (set-square, plan)  |
+| **Release Engineer**  | The shipping bay (crate, stamp)        |
+| **Security Engineer** | The night watch (brass key, lantern)   |
+| **Product Manager**   | The kanban rail (cards on a wire)      |
+| **Technical Writer**  | The archivist's desk (pen, ledger)     |
+| **Improvement Coach** | The Ohno circle (chalk ring, notebook) |
+
+---
+
+## 4. Color Palette
+
+### Core Palette
+
+Warm-tinted grays, pulled toward the _sumi_ ink and pressed-paper end of the
+ramp. Slightly cooler than FIT's sandstone bias, slightly more graphite —
+think of a black-and-white photograph that has been kept in a manila folder
+for seventy years.
+
+| Token          | Hex       | Usage                                       |
+| -------------- | --------- | ------------------------------------------- |
+| `--white`      | `#ffffff` | Page canvas                                 |
+| `--white-warm` | `#f8f6f1` | Alternate section backgrounds, card fills   |
+| `--gray-50`    | `#f1efe9` | Elevated surfaces, code blocks              |
+| `--gray-100`   | `#e4e1d9` | Hover states, active tabs, tag backgrounds  |
+| `--gray-200`   | `#cfcbc1` | Borders (strong), secondary button outlines |
+| `--gray-300`   | `#aeaba2` | Tertiary text, disabled states              |
+| `--gray-400`   | `#807d76` | Secondary text, descriptions                |
+| `--gray-500`   | `#5d5b55` | Body text                                   |
+| `--gray-700`   | `#33312d` | Emphasis text, card headings                |
+| `--gray-900`   | `#161513` | Headlines, primary text, filled buttons     |
+| `--black`      | `#080706` | Maximum contrast, hero headings             |
+
+### The Warm Signal: Hanko (Stamp Ink)
+
+A vermillion red drawn from the Japanese hanko (signature stamp) used to mark
+approved paperwork on the shop floor. Reads as ink on a card — the visible
+trace of a decision made.
+
+| Token        | Hex       | Usage                                  |
+| ------------ | --------- | -------------------------------------- |
+| `--ink-50`   | `#fbf3f1` | Warm section backgrounds               |
+| `--ink-100` | `#f4ddd7` | Highlighted cards, selected states     |
+| `--ink-200` | `#e8b8ac` | Warm borders, active indicators        |
+| `--ink-400` | `#c25a47` | Warm tertiary elements                 |
+| `--ink-600` | `#8a3624` | Warm accent text (used very sparingly) |
+
+**Usage rule:** Hanko appears in backgrounds, borders, the terminal prompt,
+the andon-cord highlight, and the stamp-mark accent. **Never in body text or
+interactive elements.** It is the single warm signal — the ink on the card,
+not the card itself.
+
+All grays are warm-tinted with a subtle graphite shift (~3–5% pull toward
+neutral-warm). The difference accumulates across a page — quieter than
+sandstone, but still warmer than pure neutral. Like archival paper.
+
+---
+
+## 5. Typography
+
+### Font Selection
+
+| Role               | Font                               | Fallback                                                    |
+| ------------------ | ---------------------------------- | ----------------------------------------------------------- |
+| **Display / Hero** | `"Roboto Slab"` (Google Fonts)     | `"Rockwell", Georgia, "Times New Roman", serif`             |
+| **Headings**       | `"IBM Plex Sans"` (Google Fonts)   | `-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif` |
+| **Body**           | `"IBM Plex Sans"`                  | Same                                                        |
+| **Mono / Code**    | `"IBM Plex Mono"` (Google Fonts)   | `"SF Mono", Consolas, "Liberation Mono", monospace`         |
+
+**Roboto Slab** is Kata's reading of the family's display serif: an
+industrial slab serif that evokes mid-century training manuals, factory
+signage, and stencilled crate markings — the vocabulary of writing things
+down on the shop floor.
+
+**IBM Plex Sans** is the sans pairing — a typeface designed explicitly to
+evoke mid-century corporate identity, with the geometric calm of a 1950s
+form. It pairs naturally with Roboto Slab through shared mid-century DNA.
+
+**IBM Plex Mono** completes the family — typewriter cadence without the
+typewriter's irregularity, suited for terminals and ledger-style data.
+
+### Type Scale
+
+| Token                  | Size              | Weight | Line Height | Font            | Color        |
+| ---------------------- | ----------------- | ------ | ----------- | --------------- | ------------ |
+| `--text-hero`          | `4rem` (64px)     | 700    | 1.05        | Roboto Slab     | `--black`    |
+| `--text-display`       | `2.75rem` (44px)  | 600    | 1.1         | Roboto Slab     | `--gray-900` |
+| `--text-h1`            | `2rem` (32px)     | 600    | 1.2         | IBM Plex Sans   | `--gray-900` |
+| `--text-h2`            | `1.5rem` (24px)   | 600    | 1.25        | IBM Plex Sans   | `--gray-900` |
+| `--text-h3`            | `1.25rem` (20px)  | 500    | 1.3         | IBM Plex Sans   | `--gray-700` |
+| `--text-body`          | `1rem` (16px)     | 400    | 1.65        | IBM Plex Sans   | `--gray-500` |
+| `--text-body-emphasis` | `1rem` (16px)     | 500    | 1.65        | IBM Plex Sans   | `--gray-700` |
+| `--text-small`         | `0.875rem` (14px) | 400    | 1.5         | IBM Plex Sans   | `--gray-400` |
+| `--text-badge`         | `0.75rem` (12px)  | 600    | 1           | IBM Plex Sans   | `--gray-700` |
+| `--text-mono`          | `0.875rem` (14px) | 400    | 1.6         | IBM Plex Mono   | `--gray-500` |
+
+The Kata display weight is heavier than FIT's (700 vs 400) — slab serifs
+carry mid-century industrial weight, more poster than journal.
+
+### Hero Pattern
+
+```
+Roboto Slab, 64px, weight 700:
+
+  Practice the form.
+  Trust the process.
+
+IBM Plex Sans, 18px, weight 400, gray-400:
+
+  Kata is the Forward Impact repo self-maintenance system. Six agent
+  personas walk the line together — planning, shipping, hardening,
+  triaging, documenting, and coaching — one daily kata at a time.
+```
+
+---
+
+## 6. Product Scenes
+
+The Kata product scenes — Storyboard Stand-up, Walking the Gemba, the Ohno
+Circle, the Andon Cord, the Kanban Rail, the Drafting Bench, the Shipping
+Bay, and the Archivist's Desk — and the scene usage matrix live in a sibling
+file: [scenes.md](scenes.md). They extend the
+[reusable base scenes](../index.md#4-reusable-base-scenes) with Kata
+production-floor symbols.
+
+---
+
+## 7. Product Icons
+
+The six Kata agent icons — Staff Engineer, Release Engineer, Security
+Engineer, Product Manager, Technical Writer, Improvement Coach — plus the
+icon system rules and the combined suite mark live in a sibling file:
+[icons.md](icons.md). They share the family icon grid (24px, 2px stroke, no
+fill) and read as if stamped into the same logbook as the
+[characters](../index.md#2-the-three-characters).
+
+---
+
+## 8. Layout Patterns
+
+### Suite Landing Page
+
+```
+┌──────────────────────────────────────────────┐
+│  [Trio mark]  KATA           [Nav]      [☰] │
+│                                              │
+│       ┌──────────────────────────┐           │
+│       │  Storyboard Stand-up     │           │
+│       └──────────────────────────┘           │
+│                                              │
+│     Practice the form.                       │  ← Roboto Slab 700
+│     Trust the process.                       │
+│                                              │
+│     Six agent personas walk the line —       │  ← IBM Plex Sans, gray-400
+│     planning, shipping, hardening, triaging, │
+│     documenting, and coaching — one daily    │
+│     kata at a time.                          │
+│                                              │
+│           [ Walk the floor → ]               │
+│                                              │
+├──────────────────────────────────────────────┤
+│ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐│
+│ │Staff │ │Releas│ │Securi│ │Prodct│ │Writer│ │Coach │ │
+│ └──────┘ └──────┘ └──────┘ └──────┘ └──────┘ └──────┘│
+├──────────────────────────────────────────────┤
+│  Background: kanban-rail texture             │
+│     "Without standards, there can be no      │  ← Roboto Slab 600
+│      kaizen."                                │
+│                  — Taiichi Ohno              │
+├──────────────────────────────────────────────┤
+│     [ Read the playbook → ]                  │
+│  © Forward Impact Team  ·  Apache-2.0 code  │
+│     CC BY 4.0 docs                           │
+└──────────────────────────────────────────────┘
+```
+
+### Navigation Pattern
+
+```
+[Trio mark]  KATA   |   Staff  ·  Release  ·  Security  ·  Product  ·  Writer  ·  Coach    [Docs]  [Sign in]
+```
+
+Current agent is bold (`600`). Others are regular (`400`) in `--gray-400`.
+On mobile, the agent switcher moves into the hamburger menu.
+
+### Warm/Cool Section Rhythm
+
+```
+Section 1: white (#ffffff)          — Hero
+Section 2: warm (#f8f6f1)           — Agent persona cards
+Section 3: white (#ffffff)          — How a daily kata runs
+Section 4: ink-50 (#fbf3f1) + rail  — Ohno quote
+Section 5: white (#ffffff)          — CTA / read the playbook
+Footer:    gray-900 (#161513)       — Dark footer (inverted), licenses
+```
+
+The kata-rail texture is Kata's equivalent of FIT's contour lines: a
+repeating thin horizontal line in `--gray-100` on `--white-warm` or
+`--ink-50` sections, evoking the wire on which kanban cards slide. 1px
+stroke, spaced 28px apart, opacity 0.35. Never on pure white backgrounds.
+
+### Concrete Components
+
+The component patterns in [../index.md § 9](../index.md#9-components)
+instantiate with Kata colors:
+
+- **Buttons (Primary):** `background: --gray-900`, text `#ffffff`. Hover
+  adds a 1px `--ink-400` underline beneath the label — the stamp-mark.
+- **Buttons (Secondary / Product):** `border: 1.5px solid --gray-200`, text
+  `--gray-900`. On hover, border warms to `--ink-200`.
+- **Cards:** `background: --white` (on warm bg) or `--white-warm` (on white
+  bg), `border: 1.5px solid --gray-200`. Selected/active state adds a
+  `--ink-400` left edge — the kanban-card "approved" stamp.
+- **Terminal / Code Blocks:** `background: --gray-900` (`#161513`), text
+  `#ebe8e1`, prompt `❯` in `--ink-400`, comments in `--gray-400`.
+- **Kanban-Rail Texture:** Repeating thin horizontal lines in `--gray-100`
+  on `--white-warm` or `--ink-50` sections. 1px stroke, 28px spacing,
+  opacity 0.35.
+- **Footer (Dark):** `background: --gray-900`, primary text `#ebe8e1`,
+  secondary text `--gray-400`, dividers `--gray-700`. Trio silhouette + the
+  word **KATA** (Roboto Slab 700, letter-spaced) in white. Licenses
+  (Apache-2.0 code, CC BY 4.0 docs) in `--gray-400`.
+
+---
+
+## 9. Agent Visual Language
+
+Each agent shares the core design system with subtle differentiators:
+
+| Agent                 | Accent Metaphor                          | Empty State                                   | Tone                                          |
+| --------------------- | ---------------------------------------- | --------------------------------------------- | --------------------------------------------- |
+| **Staff Engineer**    | Drafting — set-squares, plan grid        | Engineer at empty bench, sharpening pencil    | "Draw the plan before cutting metal."         |
+| **Release Engineer**  | Shipping — crates, manifest, time stamp  | Crate ready, stamp uninked                    | "The line moves on time."                     |
+| **Security Engineer** | Watch — brass keys, lantern, locked door | Lantern lit, ring of keys on a hook           | "Walk the floor with the lantern up."         |
+| **Product Manager**   | Kanban — cards on a wire, triage bin     | Empty rail, three pegs waiting                | "What's next on the rail?"                    |
+| **Technical Writer**  | Archive — fountain pen, manila folder    | Open ledger, fresh page                       | "If it isn't written, it didn't happen."      |
+| **Improvement Coach** | Coaching — chalk circle, five-question   | Empty circle drawn on the floor, chalk beside | "What is the current condition?"              |
+
+### Agent-Specific UI Treatments
+
+- **Staff Engineer**: Plan documents render on a faint blueprint grid in
+  `--gray-100`. Spec / design / plan stages display as a 3-stage progress
+  line with stamped milestones.
+- **Release Engineer**: Release notes use a manifest layout — version, date,
+  payload, signer — rendered as a stamped shipping label.
+- **Security Engineer**: Vulnerability dashboards use a "lantern" pattern:
+  the unresolved CVE rows glow softly in `--ink-100`; resolved rows fall
+  back to `--gray-50`.
+- **Product Manager**: Issue and PR queues render as a kanban rail
+  (horizontal lanes, cards sliding right). The merge gate is a stamped seal.
+- **Technical Writer**: Wiki pages and weekly logs render in a "ledger"
+  treatment — narrow column, IBM Plex Mono for metadata lines, faint
+  horizontal rule between entries.
+- **Improvement Coach**: Storyboard meeting notes render inside a circle —
+  the Ohno circle — with the five kata questions arrayed around it. XmR
+  charts use a stamped grid.
+
+---
+
+## 10. Design Tokens
+
+```css
+:root {
+  /* ── Surfaces ── */
+  --bg-page: #ffffff;
+  --bg-warm: #f8f6f1;
+  --bg-elevated: #f1efe9;
+  --bg-hover: #e4e1d9;
+  --bg-inverted: #161513;
+
+  /* ── Hanko (warm signal — stamp ink) ── */
+  --ink-50: #fbf3f1;
+  --ink-100: #f4ddd7;
+  --ink-200: #e8b8ac;
+  --ink-400: #c25a47;
+  --ink-600: #8a3624;
+
+  /* ── Text ── */
+  --text-primary: #080706;
+  --text-heading: #161513;
+  --text-body: #5d5b55;
+  --text-secondary: #807d76;
+  --text-tertiary: #aeaba2;
+  --text-on-dark: #ebe8e1;
+
+  /* ── Borders ── */
+  --border-default: #e4e1d9;
+  --border-strong: #cfcbc1;
+
+  /* ── Radii ── */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-pill: 999px;
+
+  /* ── Spacing ── */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+  --space-20: 80px;
+  --space-24: 96px;
+  --space-32: 128px;
+
+  /* ── Typography ── */
+  --font-display: "Roboto Slab", "Rockwell", Georgia, "Times New Roman", serif;
+  --font-sans: "IBM Plex Sans", -apple-system, BlinkMacSystemFont,
+               "Segoe UI", Roboto, sans-serif;
+  --font-mono: "IBM Plex Mono", "SF Mono", Consolas,
+               "Liberation Mono", monospace;
+
+  --text-hero-size: 4rem;
+  --text-display-size: 2.75rem;
+  --text-h1-size: 2rem;
+  --text-h2-size: 1.5rem;
+  --text-h3-size: 1.25rem;
+  --text-body-size: 1rem;
+  --text-small-size: 0.875rem;
+  --text-badge-size: 0.75rem;
+
+  /* ── Transitions ── */
+  --ease-default: cubic-bezier(0.25, 0.1, 0.25, 1);
+  --duration-fast: 150ms;
+  --duration-normal: 200ms;
+  --duration-slow: 400ms;
+}
+```
+
+The Kata radii are slightly tighter than FIT (6/10/14 vs 8/12/16) — closer to
+the squared corners of mid-century industrial cards and stamped paper.
+
+---
+
+_Kata brand implementation of the [shared design language](../index.md).
+Sibling brand to [FIT](../fit/index.md). Updated April 2026._

--- a/design/kata/index.md
+++ b/design/kata/index.md
@@ -103,6 +103,36 @@ metaphor — that surfaces in icons and scenes but never in structural UI.
 | **Technical Writer**  | The archivist's desk (pen, ledger)     |
 | **Improvement Coach** | The Ohno circle (chalk ring, notebook) |
 
+### The PDSA Wheel
+
+Above the six personas sits the **PDSA wheel** — a four-quadrant chalk
+circle marked **P · D · S · A** clockwise, the spine of
+[KATA.md](../../KATA.md) made visible. It is the brand's only repeating
+non-character motif, used as:
+
+- The optional accent above the second `A` in the **KATA** wordmark (see
+  [icons.md § Suite Wordmark](icons.md#suite-wordmark)).
+- A section divider on long pages — drawn at 16px, `--gray-300` stroke,
+  centred, with 96px of vertical breathing room either side.
+- A loading state — the wheel rotates one quadrant per 800ms, looping
+  P → D → S → A → P, respecting `prefers-reduced-motion` (static wheel).
+
+Each agent's "phase coverage" in [KATA.md § Skills](../../KATA.md#skills)
+maps to wheel quadrants, so the wheel is also functional: a Staff Engineer
+profile page may show the wheel with **P** and **D** lit; an Improvement
+Coach profile may show **S** lit. Lit quadrants use a 1.5px stroke;
+unlit quadrants use a 0.5px stroke. No fills.
+
+```
+       P
+   ╱─ ─ ─╲
+  ╱       ╲
+ │ A     D │
+  ╲       ╱
+   ╲─ ─ ─╱
+       S
+```
+
 ---
 
 ## 4. Color Palette
@@ -122,7 +152,7 @@ for seventy years.
 | `--gray-100`   | `#e4e1d9` | Hover states, active tabs, tag backgrounds  |
 | `--gray-200`   | `#cfcbc1` | Borders (strong), secondary button outlines |
 | `--gray-300`   | `#aeaba2` | Tertiary text, disabled states              |
-| `--gray-400`   | `#807d76` | Secondary text, descriptions                |
+| `--gray-400`   | `#74716a` | Secondary text, descriptions                |
 | `--gray-500`   | `#5d5b55` | Body text                                   |
 | `--gray-700`   | `#33312d` | Emphasis text, card headings                |
 | `--gray-900`   | `#161513` | Headlines, primary text, filled buttons     |
@@ -235,50 +265,98 @@ fill) and read as if stamped into the same logbook as the
 
 ## 8. Layout Patterns
 
-### Suite Landing Page
+Kata is the **internal** repo self-maintenance system. It has no public
+marketing site. The brand surfaces in four real places, ordered by how
+often a contributor or agent encounters them:
+
+### Surface 1 — The Internals Page
+
+The canonical home is
+`websites/fit/docs/internals/kata/index.md` — sibling to
+`internals/operations/`, `internals/codegen/`, `internals/librepl/`. This
+is where the brand renders for human contributors browsing the docs site.
 
 ```
 ┌──────────────────────────────────────────────┐
-│  [Trio mark]  KATA           [Nav]      [☰] │
+│  FIT Internals  ›  Kata                      │
 │                                              │
 │       ┌──────────────────────────┐           │
 │       │  Storyboard Stand-up     │           │
 │       └──────────────────────────┘           │
 │                                              │
-│     Practice the form.                       │  ← Roboto Slab 700
-│     Trust the process.                       │
+│     Kata                                     │  ← Roboto Slab 700, 44px
+│                                              │
+│     Practice the form. Trust the process.    │  ← Roboto Slab 600, 24px
 │                                              │
 │     Six agent personas walk the line —       │  ← IBM Plex Sans, gray-400
 │     planning, shipping, hardening, triaging, │
 │     documenting, and coaching — one daily    │
 │     kata at a time.                          │
 │                                              │
-│           [ Walk the floor → ]               │
-│                                              │
 ├──────────────────────────────────────────────┤
+│  ─── PDSA wheel section divider ───          │
+├──────────────────────────────────────────────┤
+│  The Six Personas                            │  ← H2
 │ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐│
 │ │Staff │ │Releas│ │Securi│ │Prodct│ │Writer│ │Coach │ │
 │ └──────┘ └──────┘ └──────┘ └──────┘ └──────┘ └──────┘│
+├──────────────────────────────────────────────┤
+│  The PDSA Loop · Workflows · Trust Boundary  │
+│  Coordination Channels · Metrics · Auth      │
+├──────────────────────────────────────────────┤
+│  ─── PDSA wheel section divider ───          │
 ├──────────────────────────────────────────────┤
 │  Background: kanban-rail texture             │
 │     "Without standards, there can be no      │  ← Roboto Slab 600
 │      kaizen."                                │
 │                  — Taiichi Ohno              │
-├──────────────────────────────────────────────┤
-│     [ Read the playbook → ]                  │
-│  © Forward Impact Team  ·  Apache-2.0 code  │
-│     CC BY 4.0 docs                           │
 └──────────────────────────────────────────────┘
 ```
 
-### Navigation Pattern
+### Surface 2 — `KATA.md` Rendered on GitHub
+
+`KATA.md` at the repo root is read by every agent at the start of a Kata
+run (per the L2 instruction layer). On GitHub it renders as plain
+flavored markdown — the brand cannot inject CSS — so the brand surfaces
+through **structural cues** only: the trio mark in the header (linked
+SVG), section headings that match the persona names, the hanko stamp
+emoji-equivalent (`🟥`) reserved for the Trust Boundary section.
+
+### Surface 3 — Agent Comments and PR/Issue Bodies
+
+When a Kata agent posts on a PR or issue (via `agent-conversation`), it
+signs with its persona. The signature line is a single line of IBM Plex
+Mono using the convention:
 
 ```
-[Trio mark]  KATA   |   Staff  ·  Release  ·  Security  ·  Product  ·  Writer  ·  Coach    [Docs]  [Sign in]
+— {persona icon} {Persona Name} · {phase} · {run-id}
 ```
 
-Current agent is bold (`600`). Others are regular (`400`) in `--gray-400`.
-On mobile, the agent switcher moves into the hamburger menu.
+Example: `— 📐 Staff Engineer · Plan · run-2026-04-28-night`. The icon is
+the persona's icon glyph; the phase is one of P/D/S/A; the run-id ties
+the comment back to the trace artifact.
+
+### Surface 4 — Storyboard Markdown and Wiki Summaries
+
+Daily storyboard files (`wiki/storyboard/{YYYY-MM-DD}.md`) and per-agent
+wiki summaries (`wiki/{persona}.md`) follow a fixed Kata template — the
+brand's typographic discipline applied to plain markdown. Persona name as
+H1, current condition as a blockquote, target condition as a level-2
+heading, the five kata questions as level-3 subsections, metrics as a
+mono-table.
+
+### Navigation Pattern (Internals Page)
+
+The Kata internals page lives inside the FIT docs nav. Within the Kata
+section, sub-nav routes to each persona:
+
+```
+FIT Docs  ›  Internals  ›  Kata  ›  Staff · Release · Security · Product · Writer · Coach
+```
+
+Current persona is bold (`600`). Others are regular (`400`) in
+`--gray-400`. The persona switcher is a horizontal row at the top of any
+persona sub-page.
 
 ### Warm/Cool Section Rhythm
 
@@ -302,9 +380,11 @@ The component patterns in [../index.md § 9](../index.md#9-components)
 instantiate with Kata colors:
 
 - **Buttons (Primary):** `background: --gray-900`, text `#ffffff`. Hover
-  adds a 1px `--ink-400` underline beneath the label — the stamp-mark.
+  shifts background to `--black`. The warm signal does not appear on
+  interactive elements — the brand's stamp-mark accent lives on cards,
+  paper, and the terminal prompt, never on a button or link.
 - **Buttons (Secondary / Product):** `border: 1.5px solid --gray-200`, text
-  `--gray-900`. On hover, border warms to `--ink-200`.
+  `--gray-900`. Hover darkens border to `--gray-700`.
 - **Cards:** `background: --white` (on warm bg) or `--white-warm` (on white
   bg), `border: 1.5px solid --gray-200`. Selected/active state adds a
   `--ink-400` left edge — the kanban-card "approved" stamp.
@@ -314,9 +394,12 @@ instantiate with Kata colors:
   on `--white-warm` or `--ink-50` sections. 1px stroke, 28px spacing,
   opacity 0.35.
 - **Footer (Dark):** `background: --gray-900`, primary text `#ebe8e1`,
-  secondary text `--gray-400`, dividers `--gray-700`. Trio silhouette + the
+  secondary text `--gray-300`, dividers `--gray-700`. Trio silhouette + the
   word **KATA** (Roboto Slab 700, letter-spaced) in white. Licenses
-  (Apache-2.0 code, CC BY 4.0 docs) in `--gray-400`.
+  (Apache-2.0 code, CC BY 4.0 docs) in `--gray-300`. (`--gray-300` is the
+  on-dark equivalent of `--gray-400` on light — a brand convention since
+  Kata's `--gray-400` is darker than the family default to satisfy AA on
+  white.)
 
 ---
 
@@ -372,11 +455,18 @@ Each agent shares the core design system with subtle differentiators:
   --ink-400: #c25a47;
   --ink-600: #8a3624;
 
+  /* ── Family alias (cross-brand component contract) ── */
+  --accent-warm-50: var(--ink-50);
+  --accent-warm-100: var(--ink-100);
+  --accent-warm-200: var(--ink-200);
+  --accent-warm-400: var(--ink-400);
+  --accent-warm-600: var(--ink-600);
+
   /* ── Text ── */
   --text-primary: #080706;
   --text-heading: #161513;
   --text-body: #5d5b55;
-  --text-secondary: #807d76;
+  --text-secondary: #74716a;
   --text-tertiary: #aeaba2;
   --text-on-dark: #ebe8e1;
 

--- a/design/kata/scenes.md
+++ b/design/kata/scenes.md
@@ -1,0 +1,278 @@
+# Kata Product Scenes
+
+These scenes extend the
+[reusable base scenes](../index.md#4-reusable-base-scenes) with Kata
+production-floor symbols. All follow the [scene grammar](../index.md#3-scene-grammar):
+2px monochrome line art on a clean white background.
+
+For the Kata brand context — palette, typography, agent taxonomy — see
+[index.md](index.md).
+
+A note on the **Stakeholder's cap.** In Kata scenes the Stakeholder may wear
+a soft flat cap (the Ohno cap) when on the shop floor — a brand-context
+accessory layered over the family character's standard suit-and-tie. The
+cap does not replace any inherited trait; it sits on top of "neat hair" the
+way a real cap would. In scenes set off-floor (welcome, documentation), the
+cap may be absent.
+
+---
+
+## Scene: Storyboard Stand-up — The Hero Scene
+
+**Context:** Kata landing page hero, suite-level marketing, daily
+storyboard documentation.
+
+Trio standing in front of a tall storyboard panel mounted on the wall — a
+horizontal wire runs across it with kanban cards clipped on by clothes-pegs.
+The board has three lanes (To Do · Doing · Done) labelled in slab serif. AI
+Agent center, holding a pointer to a card on the wire, head angled at the
+board with mechanical attention. Engineer left, hoodie ears bouncing,
+half-turned with one hand already reaching for a card to move it — eager,
+moving the card before the question has finished being asked. Stakeholder
+right in flat cap and tie, hands clasped behind their back, leaning slightly
+forward, studying — the foreman who has run this meeting a thousand times.
+
+```
+    ┌────────────────────────┐
+    │ TO DO │ DOING │ DONE   │  ← storyboard
+    │  ▢ ▢  │  ▢    │  ▢ ▢   │
+    │  ▢    │       │  ▢     │
+    └────────────────────────┘
+       🐰      🤖       👔
+       (reach) (point)  (cap, hands clasped)
+```
+
+**Key details:** The three speeds again — Engineer already moving the card,
+Agent still pointing at it, Stakeholder in no hurry to interrupt either.
+The storyboard is the visual anchor: cards on a wire say "this is a working
+board, not a slide deck." Stakeholder's cap is the brand mark — calm
+authority of someone who has stood here every morning for years.
+
+---
+
+## Scene: Walking the Gemba
+
+**Context:** "How a daily kata runs" page, agent profile pages, default
+brand scene below the hero.
+
+Trio walking the floor in single file along an implied line, AI Agent in
+front holding a clipboard at chest height, Engineer in the middle craning
+to read over Agent's shoulder, Stakeholder at the rear in cap and tie,
+hands behind their back, gaze tracking outward toward the floor — not at
+the clipboard. A few floor markings (taped lanes, station numbers) imply
+the gemba beneath their feet.
+
+```
+    🤖 ────→ 🐰 ────→ 👔
+    📋        ↗       (cap, hands behind back)
+    └─── floor markings ───┘
+```
+
+**Key details:** The procession is the frame. Agent leads with the data,
+Engineer chases the data, Stakeholder watches the work itself — the gemba
+walk principle: the floor tells you more than the report. Three different
+focal points (paper, screen, work) in one straight line.
+
+---
+
+## Scene: The Ohno Circle
+
+**Context:** Improvement Coach product page, coaching session
+documentation, kata-session skill page.
+
+A chalk circle drawn on the floor — clearly hand-drawn, slightly irregular,
+about character-width. Stakeholder stands inside it, cap pulled slightly
+forward, arms folded, simply observing — feet planted, in no rush to leave
+the circle. Engineer crouches just outside the circle, peering in with
+exaggerated curiosity, hoodie ears tilted — "what are you looking at?" AI
+Agent stands a respectful step further back, holding a notebook open,
+recording.
+
+```
+       🐰 (crouching, peering in)
+        ↘
+       ╭─────╮
+       │  👔  │  ← Stakeholder in chalk circle
+       ╰─────╯
+              🤖📓 (recording)
+```
+
+**Key details:** The circle is the icon and the scene. Stakeholder's
+posture — relaxed, observing — is the entire coaching kata in one frame.
+Engineer's curiosity is the audience surrogate ("why are they just
+standing there?"). Agent's notebook captures everything Stakeholder is
+choosing not to say.
+
+---
+
+## Scene: The Andon Cord
+
+**Context:** Security Engineer product page, vulnerability response
+documentation, "stop the line" coaching moments.
+
+A vertical cord hangs from above with a pull-handle at character height.
+Engineer has both hands wrapped around the cord, leaning into it with full
+weight — clearly _has_ pulled it, not is _about to_. AI Agent stands beside
+them, one hand half-raised — caught between approval and assessment.
+Stakeholder steps in from the right, cap slightly tilted, one hand raised
+in a calm "okay, talk me through it" gesture — not annoyed, not rushed.
+
+```
+           ┃
+           ┃  ← andon cord
+           ┃
+       🐰 ━┛
+       (pulling)   🤖   👔  (cap, palm up)
+                  (paused) "what did you see?"
+```
+
+**Key details:** The frame is "stopping the line is a normal Tuesday." No
+alarm; no panic. Engineer pulled because something looked wrong; Agent is
+already cross-referencing; Stakeholder is treating it as a coaching
+moment. The cord is the only vertical element — visually emphatic, like a
+plumb line.
+
+---
+
+## Scene: The Kanban Rail
+
+**Context:** Product Manager product page, issue and PR triage
+documentation, agent-conversation workflow.
+
+A horizontal wire stretches across the scene at chest height with kanban
+cards clothes-pegged along it. Stakeholder stands at one end of the wire,
+cap on, sliding a card from left to right with two fingers — calm,
+practiced motion. AI Agent stands center, examining a card pinched between
+thumb and forefinger, head tilted at the spec. Engineer stands at the far
+end, already pinning a freshly written card to the wire, leaning in too
+close — clearly wrote it five minutes ago and wants it on the line _now_.
+
+```
+    👔 ─── ▢ ─── ▢ ─── 🤖[▢] ─── ▢ ─── 🐰
+    (slide right) (examine)        (pin new card)
+    ──────────────────────────────────────  ← rail wire
+```
+
+**Key details:** Three roles around the same wire — triage, review, intake.
+Cards on a wire is unmistakably mid-century: kanban literally means "signal
+card." The horizontal wire becomes the page's compositional spine — orderly,
+left-to-right, unmistakably a line moving.
+
+---
+
+## Scene: The Drafting Bench
+
+**Context:** Staff Engineer product page, spec → design → plan
+documentation, plan execution flow.
+
+Trio gathered around a slanted drafting bench. A large sheet (the plan) is
+weighted down with a set-square at one corner and a coffee cup at another.
+AI Agent leans over the sheet on Agent's right, ruler in one hand, finger
+tracing a line. Engineer stands at the foot of the bench, both hands
+planted on the lower edge of the sheet, leaning forward — about to either
+ship it or cross it out. Stakeholder, cap and tie, is half-seated on a
+stool at the bench's right end, glasses pushed up onto the cap, reading
+the spec annotations in the margin.
+
+```
+        📐
+       ┌────────────┐
+       │ ▱ plan     │  ← drafting bench
+       │ ──────     │
+       │ ──── 🤖    │
+       │ 🐰         │ 👔📝 (cap, glasses up, reading)
+       └────────────┘
+```
+
+**Key details:** The drafting bench is the unmistakable workshop centerpiece
+— set-square, sheet, coffee, marginalia. Three relationships to the plan:
+Agent measuring it, Engineer ready to commit it, Stakeholder reading the
+why. The set-square corner is the scene's icon-level anchor.
+
+---
+
+## Scene: The Shipping Bay
+
+**Context:** Release Engineer product page, release readiness
+documentation, kata-ship and kata-release-review skill pages.
+
+A wooden crate sits center-frame, lid leaning beside it. A clipboard with
+a manifest hangs on a nail to the right. Engineer crouches at the crate,
+both hands on the lid, mid-action — closing it with body weight. AI Agent
+stands beside the manifest, pen poised over a checkbox, head turned toward
+the crate to confirm it's actually closed before the box gets ticked.
+Stakeholder, cap on, leans against the wall behind, holding a stamp and an
+inkpad — waiting for the manifest to come back signed before stamping the
+crate.
+
+```
+                 📋 (manifest)
+                 │
+        ┌───────┐│  🤖🖊
+        │ CRATE │
+        │       │       👔🔴  (cap, stamp + ink)
+        │   🐰  │
+        └───────┘
+       (closing lid)
+```
+
+**Key details:** The frame is the relay — close, sign, stamp. Three
+hand-off points, each one a checkpoint. The hanko stamp in Stakeholder's
+hand is the only `--ink-400` element in the scene, the only red dot on a
+black-and-white page. That's the brand motif, distilled.
+
+---
+
+## Scene: The Archivist's Desk
+
+**Context:** Technical Writer product page, wiki curation documentation,
+kata-documentation and kata-wiki-curate skill pages.
+
+A wooden desk with a manila folder open, a fountain pen lying across it,
+and a stack of weekly logs. AI Agent sits at the desk, feet flat, posture
+perfect, fountain pen in hand mid-stroke, copying entries into a ledger.
+Engineer sits cross-legged on top of the desk's right corner — perched
+where a chair should be — reading a log upside-down with sincere
+concentration. Stakeholder stands behind the desk, cap on, one hand
+resting on the desk edge, dictating a sentence — the others writing it
+down.
+
+```
+       👔  (cap, dictating)
+       ──────────────
+       │  manila folder  │
+       │  ✒  ledger ─────│  ← desk
+       │     🤖   📜🐰   │
+       │     (writing)  (perched, reading upside-down)
+       └─────────────────┘
+```
+
+**Key details:** Three relationships to the written record: Agent
+transcribes it precisely, Engineer reads it sideways (and somehow gets the
+gist), Stakeholder dictates the canonical version. The fountain pen and
+the manila folder anchor the era — pre-keyboard, but disciplined.
+
+---
+
+## Scene Usage Matrix
+
+| Context                       | Scene                  | Size      |
+| ----------------------------- | ---------------------- | --------- |
+| Suite landing page hero       | Storyboard Stand-up    | 400–480px |
+| "How a daily kata runs" intro | Walking the Gemba      | 320–400px |
+| Onboarding — first screen     | Welcome Wave (base)    | 320–400px |
+| Onboarding — getting started  | Documentation Dig (base)| 280–360px|
+| Staff Engineer hero           | The Drafting Bench     | 320–400px |
+| Release Engineer hero         | The Shipping Bay       | 320–400px |
+| Security Engineer hero        | The Andon Cord         | 320–400px |
+| Product Manager hero          | The Kanban Rail        | 320–400px |
+| Technical Writer hero         | The Archivist's Desk   | 320–400px |
+| Improvement Coach hero        | The Ohno Circle        | 320–400px |
+| Persona cards (suite page)    | Agent scenes (cropped) | 120–160px |
+| Error / empty states          | Single character       | 80–120px  |
+| Loading states                | AI Agent + clipboard   | 48–80px   |
+
+**Asset status:** The Kata scene set is specified above but not yet
+illustrated. They should follow the same 2px monochrome line-art style as
+the FIT scenes, with the addition of the Stakeholder's flat cap when on the
+shop floor.

--- a/design/kata/scenes.md
+++ b/design/kata/scenes.md
@@ -2,36 +2,35 @@
 
 These scenes extend the
 [reusable base scenes](../index.md#4-reusable-base-scenes) with Kata
-production-floor symbols. All follow the [scene grammar](../index.md#3-scene-grammar):
-2px monochrome line art on a clean white background.
+production-floor symbols. All follow the
+[scene grammar](../index.md#3-scene-grammar): 2px monochrome line art on a clean
+white background.
 
 For the Kata brand context — palette, typography, agent taxonomy — see
 [index.md](index.md).
 
-A note on the **Stakeholder's cap.** In Kata scenes the Stakeholder may wear
-a soft flat cap (the Ohno cap) when on the shop floor — a brand-context
-accessory layered over the family character's standard suit-and-tie. The
-cap does not replace any inherited trait; it sits on top of "neat hair" the
-way a real cap would. In scenes set off-floor (welcome, documentation), the
-cap may be absent.
+A note on the **Stakeholder's cap.** In Kata scenes the Stakeholder may wear a
+soft flat cap (the Ohno cap) when on the shop floor — a brand-context accessory
+layered over the family character's standard suit-and-tie. The cap does not
+replace any inherited trait; it sits on top of "neat hair" the way a real cap
+would. In scenes set off-floor (welcome, documentation), the cap may be absent.
 
 ---
 
 ## Scene: Storyboard Stand-up — The Hero Scene
 
-**Context:** Kata internals page hero
-(`websites/fit/docs/internals/kata/`), daily storyboard documentation,
-the default hero for any Kata-branded surface.
+**Context:** Kata internals page hero (`websites/fit/docs/internals/kata/`),
+daily storyboard documentation, the default hero for any Kata-branded surface.
 
 Trio standing in front of a tall storyboard panel mounted on the wall — a
-horizontal wire runs across it with kanban cards clipped on by clothes-pegs.
-The board has three lanes (To Do · Doing · Done) labelled in slab serif. AI
-Agent center, holding a pointer to a card on the wire, head angled at the
-board with mechanical attention. Engineer left, hoodie ears bouncing,
-half-turned with one hand already reaching for a card to move it — eager,
-moving the card before the question has finished being asked. Stakeholder
-right in flat cap and tie, hands clasped behind their back, leaning slightly
-forward, studying — the foreman who has run this meeting a thousand times.
+horizontal wire runs across it with kanban cards clipped on by clothes-pegs. The
+board has three lanes (To Do · Doing · Done) labelled in slab serif. AI Agent
+center, holding a pointer to a card on the wire, head angled at the board with
+mechanical attention. Engineer left, hoodie ears bouncing, half-turned with one
+hand already reaching for a card to move it — eager, moving the card before the
+question has finished being asked. Stakeholder right in flat cap and tie, hands
+clasped behind their back, leaning slightly forward, studying — the foreman who
+has run this meeting a thousand times.
 
 ```
     ┌────────────────────────┐
@@ -44,24 +43,23 @@ forward, studying — the foreman who has run this meeting a thousand times.
 ```
 
 **Key details:** The three speeds again — Engineer already moving the card,
-Agent still pointing at it, Stakeholder in no hurry to interrupt either.
-The storyboard is the visual anchor: cards on a wire say "this is a working
-board, not a slide deck." Stakeholder's cap is the brand mark — calm
-authority of someone who has stood here every morning for years.
+Agent still pointing at it, Stakeholder in no hurry to interrupt either. The
+storyboard is the visual anchor: cards on a wire say "this is a working board,
+not a slide deck." Stakeholder's cap is the brand mark — calm authority of
+someone who has stood here every morning for years.
 
 ---
 
 ## Scene: Walking the Gemba
 
-**Context:** "How a daily kata runs" page, agent profile pages, default
-brand scene below the hero.
+**Context:** "How a daily kata runs" page, agent profile pages, default brand
+scene below the hero.
 
-Trio walking the floor in single file along an implied line, AI Agent in
-front holding a clipboard at chest height, Engineer in the middle craning
-to read over Agent's shoulder, Stakeholder at the rear in cap and tie,
-hands behind their back, gaze tracking outward toward the floor — not at
-the clipboard. A few floor markings (taped lanes, station numbers) imply
-the gemba beneath their feet.
+Trio walking the floor in single file along an implied line, AI Agent in front
+holding a clipboard at chest height, Engineer in the middle craning to read over
+Agent's shoulder, Stakeholder at the rear in cap and tie, hands behind their
+back, gaze tracking outward toward the floor — not at the clipboard. A few floor
+markings (taped lanes, station numbers) imply the gemba beneath their feet.
 
 ```
     🤖 ────→ 🐰 ────→ 👔
@@ -70,24 +68,23 @@ the gemba beneath their feet.
 ```
 
 **Key details:** The procession is the frame. Agent leads with the data,
-Engineer chases the data, Stakeholder watches the work itself — the gemba
-walk principle: the floor tells you more than the report. Three different
-focal points (paper, screen, work) in one straight line.
+Engineer chases the data, Stakeholder watches the work itself — the gemba walk
+principle: the floor tells you more than the report. Three different focal
+points (paper, screen, work) in one straight line.
 
 ---
 
 ## Scene: The Ohno Circle
 
-**Context:** Improvement Coach product page, coaching session
-documentation, kata-session skill page.
+**Context:** Improvement Coach product page, coaching session documentation,
+kata-session skill page.
 
 A chalk circle drawn on the floor — clearly hand-drawn, slightly irregular,
 about character-width. Stakeholder stands inside it, cap pulled slightly
-forward, arms folded, simply observing — feet planted, in no rush to leave
-the circle. Engineer crouches just outside the circle, peering in with
-exaggerated curiosity, hoodie ears tilted — "what are you looking at?" AI
-Agent stands a respectful step further back, holding a notebook open,
-recording.
+forward, arms folded, simply observing — feet planted, in no rush to leave the
+circle. Engineer crouches just outside the circle, peering in with exaggerated
+curiosity, hoodie ears tilted — "what are you looking at?" AI Agent stands a
+respectful step further back, holding a notebook open, recording.
 
 ```
        🐰 (crouching, peering in)
@@ -98,11 +95,10 @@ recording.
               🤖📓 (recording)
 ```
 
-**Key details:** The circle is the icon and the scene. Stakeholder's
-posture — relaxed, observing — is the entire coaching kata in one frame.
-Engineer's curiosity is the audience surrogate ("why are they just
-standing there?"). Agent's notebook captures everything Stakeholder is
-choosing not to say.
+**Key details:** The circle is the icon and the scene. Stakeholder's posture —
+relaxed, observing — is the entire coaching kata in one frame. Engineer's
+curiosity is the audience surrogate ("why are they just standing there?").
+Agent's notebook captures everything Stakeholder is choosing not to say.
 
 ---
 
@@ -114,9 +110,9 @@ documentation, "stop the line" coaching moments.
 A vertical cord hangs from above with a pull-handle at character height.
 Engineer has both hands wrapped around the cord, leaning into it with full
 weight — clearly _has_ pulled it, not is _about to_. AI Agent stands beside
-them, one hand half-raised — caught between approval and assessment.
-Stakeholder steps in from the right, cap slightly tilted, one hand raised
-in a calm "okay, talk me through it" gesture — not annoyed, not rushed.
+them, one hand half-raised — caught between approval and assessment. Stakeholder
+steps in from the right, cap slightly tilted, one hand raised in a calm "okay,
+talk me through it" gesture — not annoyed, not rushed.
 
 ```
            ┃
@@ -127,29 +123,27 @@ in a calm "okay, talk me through it" gesture — not annoyed, not rushed.
                   (paused) "what did you see?"
 ```
 
-**Key details:** The frame is "stopping the line is a normal Tuesday." No
-alarm; no panic. Engineer pulled because something looked wrong; Agent is
-already cross-referencing; Stakeholder is treating it as a coaching
-moment. The cord is the only vertical element — visually emphatic, like a
-plumb line.
+**Key details:** The frame is "stopping the line is a normal Tuesday." No alarm;
+no panic. Engineer pulled because something looked wrong; Agent is already
+cross-referencing; Stakeholder is treating it as a coaching moment. The cord is
+the only vertical element — visually emphatic, like a plumb line.
 
 ---
 
 ## Scene: The Merge Gate
 
-**Context:** Product Manager product page, issue and PR triage
-documentation, agent-conversation workflow.
+**Context:** Product Manager product page, issue and PR triage documentation,
+agent-conversation workflow.
 
-A horizontal kanban wire runs left-to-right, ending in a wooden **gate**
-at the right edge — a small swing-gate, hip-height, with a hanko stamp
-hanging from a string beside it. Cards clothes-pegged along the wire.
-Engineer stands at the wire's left end, already pinning a freshly written
-card — leaning in too close, clearly wrote it five minutes ago and wants
-it on the line _now_. AI Agent stands center, examining a card pinched
-between thumb and forefinger, head tilted at the spec. Stakeholder stands
-**at the gate**, cap on, holding a single card up to read it — the hanko
-stamp in the other hand, inkpad ready. The card goes through the gate
-only if it's stamped.
+A horizontal kanban wire runs left-to-right, ending in a wooden **gate** at the
+right edge — a small swing-gate, hip-height, with a hanko stamp hanging from a
+string beside it. Cards clothes-pegged along the wire. Engineer stands at the
+wire's left end, already pinning a freshly written card — leaning in too close,
+clearly wrote it five minutes ago and wants it on the line _now_. AI Agent
+stands center, examining a card pinched between thumb and forefinger, head
+tilted at the spec. Stakeholder stands **at the gate**, cap on, holding a single
+card up to read it — the hanko stamp in the other hand, inkpad ready. The card
+goes through the gate only if it's stamped.
 
 ```
     🐰 ▢ ─── ▢ ─── 🤖[▢] ─── ▢ ─── 👔 │ →   ✓
@@ -159,30 +153,28 @@ only if it's stamped.
 ```
 
 **Key details:** This scene owns the **trust boundary** from
-[KATA.md § Trust Boundary](../../KATA.md#trust-boundary). Three roles
-around the wire — intake, review, gate — but only one of them stamps.
-The hanko in Stakeholder's hand is the only `--ink-400` element in the
-scene; the gate is unambiguous; the line moves only past the stamp. Cards
-on a wire is unmistakably mid-century: kanban literally means "signal
-card." The horizontal wire becomes the page's compositional spine —
-orderly, left-to-right, unmistakably a line moving — but it terminates,
-deliberately, in a decision.
+[KATA.md § Trust Boundary](../../KATA.md#trust-boundary). Three roles around the
+wire — intake, review, gate — but only one of them stamps. The hanko in
+Stakeholder's hand is the only `--ink-400` element in the scene; the gate is
+unambiguous; the line moves only past the stamp. Cards on a wire is unmistakably
+mid-century: kanban literally means "signal card." The horizontal wire becomes
+the page's compositional spine — orderly, left-to-right, unmistakably a line
+moving — but it terminates, deliberately, in a decision.
 
 ---
 
 ## Scene: The Drafting Bench
 
-**Context:** Staff Engineer product page, spec → design → plan
-documentation, plan execution flow.
+**Context:** Staff Engineer product page, spec → design → plan documentation,
+plan execution flow.
 
 Trio gathered around a slanted drafting bench. A large sheet (the plan) is
-weighted down with a set-square at one corner and a coffee cup at another.
-AI Agent leans over the sheet on Agent's right, ruler in one hand, finger
-tracing a line. Engineer stands at the foot of the bench, both hands
-planted on the lower edge of the sheet, leaning forward — about to either
-ship it or cross it out. Stakeholder, cap and tie, is half-seated on a
-stool at the bench's right end, glasses pushed up onto the cap, reading
-the spec annotations in the margin.
+weighted down with a set-square at one corner and a coffee cup at another. AI
+Agent leans over the sheet on Agent's right, ruler in one hand, finger tracing a
+line. Engineer stands at the foot of the bench, both hands planted on the lower
+edge of the sheet, leaning forward — about to either ship it or cross it out.
+Stakeholder, cap and tie, is half-seated on a stool at the bench's right end,
+glasses pushed up onto the cap, reading the spec annotations in the margin.
 
 ```
         📐
@@ -194,26 +186,25 @@ the spec annotations in the margin.
        └────────────┘
 ```
 
-**Key details:** The drafting bench is the unmistakable workshop centerpiece
-— set-square, sheet, coffee, marginalia. Three relationships to the plan:
-Agent measuring it, Engineer ready to commit it, Stakeholder reading the
-why. The set-square corner is the scene's icon-level anchor.
+**Key details:** The drafting bench is the unmistakable workshop centerpiece —
+set-square, sheet, coffee, marginalia. Three relationships to the plan: Agent
+measuring it, Engineer ready to commit it, Stakeholder reading the why. The
+set-square corner is the scene's icon-level anchor.
 
 ---
 
 ## Scene: The Shipping Bay
 
-**Context:** Release Engineer product page, release readiness
-documentation, kata-ship and kata-release-review skill pages.
+**Context:** Release Engineer product page, release readiness documentation,
+kata-ship and kata-release-review skill pages.
 
-A wooden crate sits center-frame, lid leaning beside it. A clipboard with
-a manifest hangs on a nail to the right. Engineer crouches at the crate,
-both hands on the lid, mid-action — closing it with body weight. AI Agent
-stands beside the manifest, pen poised over a checkbox, head turned toward
-the crate to confirm it's actually closed before the box gets ticked.
-Stakeholder, cap on, leans against the wall behind, holding a stamp and an
-inkpad — waiting for the manifest to come back signed before stamping the
-crate.
+A wooden crate sits center-frame, lid leaning beside it. A clipboard with a
+manifest hangs on a nail to the right. Engineer crouches at the crate, both
+hands on the lid, mid-action — closing it with body weight. AI Agent stands
+beside the manifest, pen poised over a checkbox, head turned toward the crate to
+confirm it's actually closed before the box gets ticked. Stakeholder, cap on,
+leans against the wall behind, holding a stamp and an inkpad — waiting for the
+manifest to come back signed before stamping the crate.
 
 ```
                  📋 (manifest)
@@ -226,27 +217,26 @@ crate.
        (closing lid)
 ```
 
-**Key details:** The frame is the relay — close, sign, stamp. Three
-hand-off points, each one a checkpoint. The hanko stamp in Stakeholder's
-hand is the only `--ink-400` element in the scene, the only red dot on a
-black-and-white page. That's the brand motif, distilled.
+**Key details:** The frame is the relay — close, sign, stamp. Three hand-off
+points, each one a checkpoint. The hanko stamp in Stakeholder's hand is the only
+`--ink-400` element in the scene, the only red dot on a black-and-white page.
+That's the brand motif, distilled.
 
 ---
 
 ## Scene: The Trace Tape
 
-**Context:** Improvement Coach trace-analysis pages, `kata-trace`
-documentation, grounded-theory coding flows, post-run review.
+**Context:** Improvement Coach trace-analysis pages, `kata-trace` documentation,
+grounded-theory coding flows, post-run review.
 
-A long strip of tractor-feed printer paper unspools from a wall-mounted
-spool at the upper-left of the scene and runs diagonally across the floor —
-the trace. The tape is marked at intervals with small horizontal rules
-(turns) and tiny stamped icons (tool calls). Stakeholder, cap on,
-crouches beside the tape with a magnifying glass, eyes following one
-specific line — coding the trace by hand. AI Agent stands further along
-the tape, holding a clipboard with a tally sheet, marking codes as
-Stakeholder reads them out. Engineer is up on the spool side, lifting a
-fresh fold of tape from the floor — keeping the read-head clear, eager
+A long strip of tractor-feed printer paper unspools from a wall-mounted spool at
+the upper-left of the scene and runs diagonally across the floor — the trace.
+The tape is marked at intervals with small horizontal rules (turns) and tiny
+stamped icons (tool calls). Stakeholder, cap on, crouches beside the tape with a
+magnifying glass, eyes following one specific line — coding the trace by hand.
+AI Agent stands further along the tape, holding a clipboard with a tally sheet,
+marking codes as Stakeholder reads them out. Engineer is up on the spool side,
+lifting a fresh fold of tape from the floor — keeping the read-head clear, eager
 to see what comes next.
 
 ```
@@ -260,25 +250,24 @@ to see what comes next.
 ```
 
 **Key details:** The tape is the visual anchor — trace data made physical,
-flowing across the floor like a 1960s mainframe printout. Three roles to
-the same record: the eye that reads, the hand that codes, the helper that
-keeps the paper moving. The diagonal sweep of the tape across the
-composition is the scene's distinguishing geometry — every other Kata
-scene is composed horizontally; the trace cuts across.
+flowing across the floor like a 1960s mainframe printout. Three roles to the
+same record: the eye that reads, the hand that codes, the helper that keeps the
+paper moving. The diagonal sweep of the tape across the composition is the
+scene's distinguishing geometry — every other Kata scene is composed
+horizontally; the trace cuts across.
 
 ## Scene: The Archivist's Desk
 
 **Context:** Technical Writer product page, wiki curation documentation,
 kata-documentation and kata-wiki-curate skill pages.
 
-A wooden desk with a manila folder open, a fountain pen lying across it,
-and a stack of weekly logs. AI Agent sits at the desk, feet flat, posture
-perfect, fountain pen in hand mid-stroke, copying entries into a ledger.
-Engineer sits cross-legged on top of the desk's right corner — perched
-where a chair should be — reading a log upside-down with sincere
-concentration. Stakeholder stands behind the desk, cap on, one hand
-resting on the desk edge, dictating a sentence — the others writing it
-down.
+A wooden desk with a manila folder open, a fountain pen lying across it, and a
+stack of weekly logs. AI Agent sits at the desk, feet flat, posture perfect,
+fountain pen in hand mid-stroke, copying entries into a ledger. Engineer sits
+cross-legged on top of the desk's right corner — perched where a chair should be
+— reading a log upside-down with sincere concentration. Stakeholder stands
+behind the desk, cap on, one hand resting on the desk edge, dictating a sentence
+— the others writing it down.
 
 ```
        👔  (cap, dictating)
@@ -290,33 +279,32 @@ down.
        └─────────────────┘
 ```
 
-**Key details:** Three relationships to the written record: Agent
-transcribes it precisely, Engineer reads it sideways (and somehow gets the
-gist), Stakeholder dictates the canonical version. The fountain pen and
-the manila folder anchor the era — pre-keyboard, but disciplined.
+**Key details:** Three relationships to the written record: Agent transcribes it
+precisely, Engineer reads it sideways (and somehow gets the gist), Stakeholder
+dictates the canonical version. The fountain pen and the manila folder anchor
+the era — pre-keyboard, but disciplined.
 
 ---
 
 ## Scene Usage Matrix
 
-| Context                       | Scene                  | Size      |
-| ----------------------------- | ---------------------- | --------- |
-| Internals page hero           | Storyboard Stand-up    | 400–480px |
-| "How a daily kata runs" intro | Walking the Gemba      | 320–400px |
-| Onboarding — first screen     | Welcome Wave (base)    | 320–400px |
-| Onboarding — getting started  | Documentation Dig (base)| 280–360px|
-| Staff Engineer hero           | The Drafting Bench     | 320–400px |
-| Release Engineer hero         | The Shipping Bay       | 320–400px |
-| Security Engineer hero        | The Andon Cord         | 320–400px |
-| Product Manager hero          | The Merge Gate         | 320–400px |
-| Technical Writer hero         | The Archivist's Desk   | 320–400px |
-| Improvement Coach hero        | The Ohno Circle        | 320–400px |
-| `kata-trace` documentation    | The Trace Tape         | 320–400px |
-| Persona cards (suite page)    | Agent scenes (cropped) | 120–160px |
-| Error / empty states          | Single character       | 80–120px  |
-| Loading states                | PDSA wheel + clipboard | 48–80px   |
+| Context                       | Scene                    | Size      |
+| ----------------------------- | ------------------------ | --------- |
+| Internals page hero           | Storyboard Stand-up      | 400–480px |
+| "How a daily kata runs" intro | Walking the Gemba        | 320–400px |
+| Onboarding — first screen     | Welcome Wave (base)      | 320–400px |
+| Onboarding — getting started  | Documentation Dig (base) | 280–360px |
+| Staff Engineer hero           | The Drafting Bench       | 320–400px |
+| Release Engineer hero         | The Shipping Bay         | 320–400px |
+| Security Engineer hero        | The Andon Cord           | 320–400px |
+| Product Manager hero          | The Merge Gate           | 320–400px |
+| Technical Writer hero         | The Archivist's Desk     | 320–400px |
+| Improvement Coach hero        | The Ohno Circle          | 320–400px |
+| `kata-trace` documentation    | The Trace Tape           | 320–400px |
+| Persona cards (suite page)    | Agent scenes (cropped)   | 120–160px |
+| Error / empty states          | Single character         | 80–120px  |
+| Loading states                | PDSA wheel + clipboard   | 48–80px   |
 
-**Asset status:** The Kata scene set is specified above but not yet
-illustrated. They should follow the same 2px monochrome line-art style as
-the FIT scenes, with the addition of the Stakeholder's flat cap when on the
-shop floor.
+**Asset status:** The Kata scene set is specified above but not yet illustrated.
+They should follow the same 2px monochrome line-art style as the FIT scenes,
+with the addition of the Stakeholder's flat cap when on the shop floor.

--- a/design/kata/scenes.md
+++ b/design/kata/scenes.md
@@ -19,8 +19,9 @@ cap may be absent.
 
 ## Scene: Storyboard Stand-up — The Hero Scene
 
-**Context:** Kata landing page hero, suite-level marketing, daily
-storyboard documentation.
+**Context:** Kata internals page hero
+(`websites/fit/docs/internals/kata/`), daily storyboard documentation,
+the default hero for any Kata-branded surface.
 
 Trio standing in front of a tall storyboard panel mounted on the wall — a
 horizontal wire runs across it with kanban cards clipped on by clothes-pegs.
@@ -134,29 +135,38 @@ plumb line.
 
 ---
 
-## Scene: The Kanban Rail
+## Scene: The Merge Gate
 
 **Context:** Product Manager product page, issue and PR triage
 documentation, agent-conversation workflow.
 
-A horizontal wire stretches across the scene at chest height with kanban
-cards clothes-pegged along it. Stakeholder stands at one end of the wire,
-cap on, sliding a card from left to right with two fingers — calm,
-practiced motion. AI Agent stands center, examining a card pinched between
-thumb and forefinger, head tilted at the spec. Engineer stands at the far
-end, already pinning a freshly written card to the wire, leaning in too
-close — clearly wrote it five minutes ago and wants it on the line _now_.
+A horizontal kanban wire runs left-to-right, ending in a wooden **gate**
+at the right edge — a small swing-gate, hip-height, with a hanko stamp
+hanging from a string beside it. Cards clothes-pegged along the wire.
+Engineer stands at the wire's left end, already pinning a freshly written
+card — leaning in too close, clearly wrote it five minutes ago and wants
+it on the line _now_. AI Agent stands center, examining a card pinched
+between thumb and forefinger, head tilted at the spec. Stakeholder stands
+**at the gate**, cap on, holding a single card up to read it — the hanko
+stamp in the other hand, inkpad ready. The card goes through the gate
+only if it's stamped.
 
 ```
-    👔 ─── ▢ ─── ▢ ─── 🤖[▢] ─── ▢ ─── 🐰
-    (slide right) (examine)        (pin new card)
-    ──────────────────────────────────────  ← rail wire
+    🐰 ▢ ─── ▢ ─── 🤖[▢] ─── ▢ ─── 👔 │ →   ✓
+    (pin new)    (examine)         (cap, stamp)│  past the gate
+    ──────────────────────────────────────────┤
+                                          gate post
 ```
 
-**Key details:** Three roles around the same wire — triage, review, intake.
-Cards on a wire is unmistakably mid-century: kanban literally means "signal
-card." The horizontal wire becomes the page's compositional spine — orderly,
-left-to-right, unmistakably a line moving.
+**Key details:** This scene owns the **trust boundary** from
+[KATA.md § Trust Boundary](../../KATA.md#trust-boundary). Three roles
+around the wire — intake, review, gate — but only one of them stamps.
+The hanko in Stakeholder's hand is the only `--ink-400` element in the
+scene; the gate is unambiguous; the line moves only past the stamp. Cards
+on a wire is unmistakably mid-century: kanban literally means "signal
+card." The horizontal wire becomes the page's compositional spine —
+orderly, left-to-right, unmistakably a line moving — but it terminates,
+deliberately, in a decision.
 
 ---
 
@@ -223,6 +233,39 @@ black-and-white page. That's the brand motif, distilled.
 
 ---
 
+## Scene: The Trace Tape
+
+**Context:** Improvement Coach trace-analysis pages, `kata-trace`
+documentation, grounded-theory coding flows, post-run review.
+
+A long strip of tractor-feed printer paper unspools from a wall-mounted
+spool at the upper-left of the scene and runs diagonally across the floor —
+the trace. The tape is marked at intervals with small horizontal rules
+(turns) and tiny stamped icons (tool calls). Stakeholder, cap on,
+crouches beside the tape with a magnifying glass, eyes following one
+specific line — coding the trace by hand. AI Agent stands further along
+the tape, holding a clipboard with a tally sheet, marking codes as
+Stakeholder reads them out. Engineer is up on the spool side, lifting a
+fresh fold of tape from the floor — keeping the read-head clear, eager
+to see what comes next.
+
+```
+    🐰 (lifting fresh tape)
+       ╲
+        ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  ← tractor-feed tape
+        │  │  │  │  │  │  │  │  │
+        ↓                  ↓
+        👔🔍               🤖📋
+        (coding)          (tallying)
+```
+
+**Key details:** The tape is the visual anchor — trace data made physical,
+flowing across the floor like a 1960s mainframe printout. Three roles to
+the same record: the eye that reads, the hand that codes, the helper that
+keeps the paper moving. The diagonal sweep of the tape across the
+composition is the scene's distinguishing geometry — every other Kata
+scene is composed horizontally; the trace cuts across.
+
 ## Scene: The Archivist's Desk
 
 **Context:** Technical Writer product page, wiki curation documentation,
@@ -258,19 +301,20 @@ the manila folder anchor the era — pre-keyboard, but disciplined.
 
 | Context                       | Scene                  | Size      |
 | ----------------------------- | ---------------------- | --------- |
-| Suite landing page hero       | Storyboard Stand-up    | 400–480px |
+| Internals page hero           | Storyboard Stand-up    | 400–480px |
 | "How a daily kata runs" intro | Walking the Gemba      | 320–400px |
 | Onboarding — first screen     | Welcome Wave (base)    | 320–400px |
 | Onboarding — getting started  | Documentation Dig (base)| 280–360px|
 | Staff Engineer hero           | The Drafting Bench     | 320–400px |
 | Release Engineer hero         | The Shipping Bay       | 320–400px |
 | Security Engineer hero        | The Andon Cord         | 320–400px |
-| Product Manager hero          | The Kanban Rail        | 320–400px |
+| Product Manager hero          | The Merge Gate         | 320–400px |
 | Technical Writer hero         | The Archivist's Desk   | 320–400px |
 | Improvement Coach hero        | The Ohno Circle        | 320–400px |
+| `kata-trace` documentation    | The Trace Tape         | 320–400px |
 | Persona cards (suite page)    | Agent scenes (cropped) | 120–160px |
 | Error / empty states          | Single character       | 80–120px  |
-| Loading states                | AI Agent + clipboard   | 48–80px   |
+| Loading states                | PDSA wheel + clipboard | 48–80px   |
 
 **Asset status:** The Kata scene set is specified above but not yet
 illustrated. They should follow the same 2px monochrome line-art style as

--- a/websites/fit/docs/internals/index.md
+++ b/websites/fit/docs/internals/index.md
@@ -128,8 +128,8 @@ the Forward Impact monorepo.
 
 ### Kata
 
-Repo self-maintenance system — six agent personas, eight workflows,
-eighteen skills, organized as a Plan-Do-Study-Act loop.
+Repo self-maintenance system — six agent personas, eight workflows, eighteen
+skills, organized as a Plan-Do-Study-Act loop.
 
 </a>
 

--- a/websites/fit/docs/internals/index.md
+++ b/websites/fit/docs/internals/index.md
@@ -124,4 +124,13 @@ the Forward Impact monorepo.
 
 </a>
 
+<a href="/docs/internals/kata/">
+
+### Kata
+
+Repo self-maintenance system — six agent personas, eight workflows,
+eighteen skills, organized as a Plan-Do-Study-Act loop.
+
+</a>
+
 </div>

--- a/websites/fit/docs/internals/kata/index.md
+++ b/websites/fit/docs/internals/kata/index.md
@@ -1,0 +1,231 @@
+---
+title: Kata
+description: "The repo self-maintenance system — six agent personas, eight workflows, eighteen skills, organized as a Plan-Do-Study-Act loop."
+---
+
+> "What does the pattern of the Improvement Kata give us? A means for
+> systematically and scientifically working toward a new desired condition,
+> in a way that is appropriate for the unpredictability and uncertainty
+> involved."
+>
+> — Mike Rother, _Toyota Kata_
+
+**Kata** is the Forward Impact repo self-maintenance system: autonomous
+agents on GitHub Actions that keep the codebase secure, release-ready, and
+steadily improving. The name follows Toyota Kata — agents grasp the current
+condition (via prior-run traces), establish target conditions (via specs),
+and experiment toward them (via implementation). Six agent personas, eight
+workflows, eighteen skills, organized around a daily **Plan-Do-Study-Act**
+loop.
+
+This page is the internal-contributor entry point. The canonical reference
+is [`KATA.md`](https://github.com/forwardimpact/monorepo/blob/main/KATA.md)
+at the repo root — read by every agent at the start of every Kata run.
+This page renders that material under the
+[Kata brand](https://github.com/forwardimpact/monorepo/blob/main/design/kata/index.md)
+for human contributors.
+
+---
+
+## The Six Personas
+
+<div class="grid">
+
+<a class="product-card" href="#staff-engineer">
+
+### Staff Engineer
+
+The drafting bench. Owns the full **spec → design → plan → implement** arc
+for approved specs. Plan and Do.
+
+</a>
+
+<a class="product-card" href="#release-engineer">
+
+### Release Engineer
+
+The shipping bay. Keeps PR branches merge-ready, repairs trivial CI, cuts
+releases. Do.
+
+</a>
+
+<a class="product-card" href="#security-engineer">
+
+### Security Engineer
+
+The night watch. Patches dependencies, hardens supply chain, enforces
+security policies. Do, Study, Act.
+
+</a>
+
+<a class="product-card" href="#product-manager">
+
+### Product Manager
+
+The merge gate. Triages issues and PRs, merges fix/bug/spec PRs, runs
+evaluations. The sole external merge point. Do, Study, Act.
+
+</a>
+
+<a class="product-card" href="#technical-writer">
+
+### Technical Writer
+
+The archivist's desk. Reviews docs for accuracy, curates wiki, fixes
+staleness, files spec gaps. Study, Act.
+
+</a>
+
+<a class="product-card" href="#improvement-coach">
+
+### Improvement Coach
+
+The Ohno circle. Facilitates storyboard meetings and 1-on-1 coaching
+sessions. Reads traces. Study.
+
+</a>
+
+</div>
+
+---
+
+## The PDSA Loop
+
+Every workflow belongs to a phase of the **Plan-Do-Study-Act** cycle (after
+Deming). Findings from Study always re-enter the loop as specs or fix PRs —
+nothing is observed without downstream action.
+
+- **Plan** — Turn approved `spec.md` (WHAT/WHY) into `design.md`
+  (WHICH/WHERE) then `plan-a.md` (HOW/WHEN) with steps, files, sequencing,
+  risks.
+- **Do** — Execute plans via implementation PRs; run scheduled workflows
+  that harden, release, and maintain. Every run captures a trace.
+- **Study** — Analyze Do outputs across four streams: security audits,
+  external feedback triage, one-topic-deep doc review, one-trace-deep
+  grounded theory.
+- **Act** — Trivial findings become **pushed fix PRs**; structural findings
+  become `spec.md` documents on **pushed spec branches**. A local commit is
+  not a PR — the URL is the only valid completion signal. `fix/` and
+  `spec/` branches never mix.
+
+---
+
+## The Trust Boundary
+
+The Product Manager is the **sole external merge point**. All other merge
+paths operate on trusted sources (our agents, Dependabot).
+
+| External PR type | What merges                     | Who implements                        |
+| ---------------- | ------------------------------- | ------------------------------------- |
+| `fix` / `bug`    | Contributor's code (small)      | The external contributor              |
+| `spec`           | Specification document only     | Trusted agents, never the contributor |
+| Everything else  | Nothing — requires human review | N/A                                   |
+
+Top-7 contributors pass the trust gate; `forward-impact-ci` PRs are
+trusted by identity. A compromised top contributor cannot inject code via
+this pipeline — specs merge only the document, not code.
+
+---
+
+## The Workflows
+
+Seven scheduled workflows run on a three-shift Europe/Paris rhythm —
+**night** by 07:00, **storyboard** at 08:00, **day** by 15:00, **swing**
+by 23:00 — plus an event-driven **agent-conversation** workflow on PR and
+discussion activity.
+
+| Workflow                    | Schedule (Paris, CEST)                | Agent                                    |
+| --------------------------- | ------------------------------------- | ---------------------------------------- |
+| **kata-storyboard**         | Daily 08:00                           | improvement-coach (facilitates 5 agents) |
+| **kata-coaching**           | `workflow_dispatch`                   | improvement-coach (facilitates 1 agent)  |
+| **agent-product-manager**   | Night 03:23 · Day 12:17 · Swing 20:17 | product-manager                          |
+| **agent-staff-engineer**    | Night 04:11 · Day 13:11 · Swing 21:11 | staff-engineer                           |
+| **agent-security-engineer** | Night 04:53                           | security-engineer                        |
+| **agent-technical-writer**  | Night 05:37                           | technical-writer                         |
+| **agent-release-engineer**  | Night 06:23 · Day 14:23 · Swing 22:23 | release-engineer                         |
+| **agent-conversation**      | On PR/discussion activity             | product-manager (facilitates 4 agents)   |
+
+Each shift forms a **producer → reviewer → shipper** chain: the product
+manager triages and merges so staff has a fresh backlog, staff implements,
+release ships. The night shift slots security-engineer and
+technical-writer between staff and release.
+
+---
+
+## Coordination Channels
+
+Five channels carry agent-to-agent and agent-to-human collaboration,
+distinguished by **time horizon** and **persistence**.
+
+| Channel               | Use for                                                          | Lifetime                        |
+| --------------------- | ---------------------------------------------------------------- | ------------------------------- |
+| **Wiki**              | Permanent curated memory: summaries, weekly logs, decisions      | Persistent                      |
+| **Storyboard**        | Daily current condition and next experiment                      | One day; captured into wiki     |
+| **Discussion**        | Open questions before they become decisions — RFCs, cross-policy | Until resolved into spec / wiki |
+| **PR / issue thread** | Real-time response on a specific artifact                        | Lives with the artifact         |
+| **Sub-agent**         | Specialized inline work within one run                           | Ephemeral (one task)            |
+
+Per-output routing is governed by
+[routing-protocol.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/routing-protocol.md);
+shared memory mechanics by
+[memory-protocol.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/memory-protocol.md).
+
+---
+
+## Metrics
+
+Agents record time-series data to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`
+after each run. The `kata-metrics` skill defines the CSV schema (six
+fields: date, metric, value, unit, run, note), storage convention, and
+metric design. The storyboard meeting answers "what is the actual
+condition now?" with numbers, not narratives, and XmR process behavior
+charts distinguish stable processes from special-cause reactions.
+
+---
+
+## Authentication
+
+Workflows authenticate via the **GitHub App** `forward-impact-kata`, not a
+PAT. Each run generates a 1-hour installation token via
+`actions/create-github-app-token` — no long-lived secrets to rotate. The
+token must generate before `actions/checkout` so checkout-token writes
+trigger downstream workflows.
+
+| Permission    | Why                                                               |
+| ------------- | ----------------------------------------------------------------- |
+| Contents      | Checkout, commit, push to `fix/`, `spec/`, release branches       |
+| Pull requests | Open, comment, merge PRs (release-engineer, product-manager)      |
+| Issues        | Triage, label, comment (product-manager)                          |
+| Discussions   | Reply on discussions and discussion comments (agent-conversation) |
+| Workflows     | Token-driven pushes re-trigger downstream workflows               |
+| Metadata      | Required by GitHub                                                |
+
+---
+
+## Where Each Agent Lives
+
+| Agent                 | Profile                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Staff Engineer**    | [staff-engineer.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/staff-engineer.md)       |
+| **Release Engineer**  | [release-engineer.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/release-engineer.md)   |
+| **Security Engineer** | [security-engineer.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/security-engineer.md) |
+| **Product Manager**   | [product-manager.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/product-manager.md)     |
+| **Technical Writer**  | [technical-writer.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/technical-writer.md)   |
+| **Improvement Coach** | [improvement-coach.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/improvement-coach.md) |
+
+---
+
+## Further Reading
+
+- **[KATA.md](https://github.com/forwardimpact/monorepo/blob/main/KATA.md)** — Canonical reference, read by every agent at the start of every run.
+- **[Kata Brand](https://github.com/forwardimpact/monorepo/blob/main/design/kata/index.md)** — Brand implementation: palette, typography, motifs, and design tokens.
+- **[Kata Scenes](https://github.com/forwardimpact/monorepo/blob/main/design/kata/scenes.md)** — Production-floor scenes: storyboard, gemba walk, Ohno circle, andon cord, merge gate, drafting bench, shipping bay, archivist's desk, trace tape.
+- **[Kata Icons](https://github.com/forwardimpact/monorepo/blob/main/design/kata/icons.md)** — Six agent icons and the suite mark.
+- **[CHECKLISTS.md](https://github.com/forwardimpact/monorepo/blob/main/CHECKLISTS.md)** — How `<read_do_checklist>` and `<do_confirm_checklist>` work.
+- **[CONTRIBUTING.md](https://github.com/forwardimpact/monorepo/blob/main/CONTRIBUTING.md)** — Universal READ-DO and DO-CONFIRM checklists every Kata run runs.
+
+---
+
+> "Without standards, there can be no kaizen."
+>
+> — Taiichi Ohno

--- a/websites/fit/docs/internals/kata/index.md
+++ b/websites/fit/docs/internals/kata/index.md
@@ -4,24 +4,22 @@ description: "The repo self-maintenance system — six agent personas, eight wor
 ---
 
 > "What does the pattern of the Improvement Kata give us? A means for
-> systematically and scientifically working toward a new desired condition,
-> in a way that is appropriate for the unpredictability and uncertainty
-> involved."
+> systematically and scientifically working toward a new desired condition, in a
+> way that is appropriate for the unpredictability and uncertainty involved."
 >
 > — Mike Rother, _Toyota Kata_
 
-**Kata** is the Forward Impact repo self-maintenance system: autonomous
-agents on GitHub Actions that keep the codebase secure, release-ready, and
-steadily improving. The name follows Toyota Kata — agents grasp the current
-condition (via prior-run traces), establish target conditions (via specs),
-and experiment toward them (via implementation). Six agent personas, eight
-workflows, eighteen skills, organized around a daily **Plan-Do-Study-Act**
-loop.
+**Kata** is the Forward Impact repo self-maintenance system: autonomous agents
+on GitHub Actions that keep the codebase secure, release-ready, and steadily
+improving. The name follows Toyota Kata — agents grasp the current condition
+(via prior-run traces), establish target conditions (via specs), and experiment
+toward them (via implementation). Six agent personas, eight workflows, eighteen
+skills, organized around a daily **Plan-Do-Study-Act** loop.
 
-This page is the internal-contributor entry point. The canonical reference
-is [`KATA.md`](https://github.com/forwardimpact/monorepo/blob/main/KATA.md)
-at the repo root — read by every agent at the start of every Kata run.
-This page renders that material under the
+This page is the internal-contributor entry point. The canonical reference is
+[`KATA.md`](https://github.com/forwardimpact/monorepo/blob/main/KATA.md) at the
+repo root — read by every agent at the start of every Kata run. This page
+renders that material under the
 [Kata brand](https://github.com/forwardimpact/monorepo/blob/main/design/kata/index.md)
 for human contributors.
 
@@ -35,8 +33,8 @@ for human contributors.
 
 ### Staff Engineer
 
-The drafting bench. Owns the full **spec → design → plan → implement** arc
-for approved specs. Plan and Do.
+The drafting bench. Owns the full **spec → design → plan → implement** arc for
+approved specs. Plan and Do.
 
 </a>
 
@@ -53,8 +51,8 @@ releases. Do.
 
 ### Security Engineer
 
-The night watch. Patches dependencies, hardens supply chain, enforces
-security policies. Do, Study, Act.
+The night watch. Patches dependencies, hardens supply chain, enforces security
+policies. Do, Study, Act.
 
 </a>
 
@@ -71,8 +69,8 @@ evaluations. The sole external merge point. Do, Study, Act.
 
 ### Technical Writer
 
-The archivist's desk. Reviews docs for accuracy, curates wiki, fixes
-staleness, files spec gaps. Study, Act.
+The archivist's desk. Reviews docs for accuracy, curates wiki, fixes staleness,
+files spec gaps. Study, Act.
 
 </a>
 
@@ -80,8 +78,8 @@ staleness, files spec gaps. Study, Act.
 
 ### Improvement Coach
 
-The Ohno circle. Facilitates storyboard meetings and 1-on-1 coaching
-sessions. Reads traces. Study.
+The Ohno circle. Facilitates storyboard meetings and 1-on-1 coaching sessions.
+Reads traces. Study.
 
 </a>
 
@@ -95,25 +93,23 @@ Every workflow belongs to a phase of the **Plan-Do-Study-Act** cycle (after
 Deming). Findings from Study always re-enter the loop as specs or fix PRs —
 nothing is observed without downstream action.
 
-- **Plan** — Turn approved `spec.md` (WHAT/WHY) into `design.md`
-  (WHICH/WHERE) then `plan-a.md` (HOW/WHEN) with steps, files, sequencing,
-  risks.
-- **Do** — Execute plans via implementation PRs; run scheduled workflows
-  that harden, release, and maintain. Every run captures a trace.
-- **Study** — Analyze Do outputs across four streams: security audits,
-  external feedback triage, one-topic-deep doc review, one-trace-deep
-  grounded theory.
+- **Plan** — Turn approved `spec.md` (WHAT/WHY) into `design.md` (WHICH/WHERE)
+  then `plan-a.md` (HOW/WHEN) with steps, files, sequencing, risks.
+- **Do** — Execute plans via implementation PRs; run scheduled workflows that
+  harden, release, and maintain. Every run captures a trace.
+- **Study** — Analyze Do outputs across four streams: security audits, external
+  feedback triage, one-topic-deep doc review, one-trace-deep grounded theory.
 - **Act** — Trivial findings become **pushed fix PRs**; structural findings
-  become `spec.md` documents on **pushed spec branches**. A local commit is
-  not a PR — the URL is the only valid completion signal. `fix/` and
-  `spec/` branches never mix.
+  become `spec.md` documents on **pushed spec branches**. A local commit is not
+  a PR — the URL is the only valid completion signal. `fix/` and `spec/`
+  branches never mix.
 
 ---
 
 ## The Trust Boundary
 
-The Product Manager is the **sole external merge point**. All other merge
-paths operate on trusted sources (our agents, Dependabot).
+The Product Manager is the **sole external merge point**. All other merge paths
+operate on trusted sources (our agents, Dependabot).
 
 | External PR type | What merges                     | Who implements                        |
 | ---------------- | ------------------------------- | ------------------------------------- |
@@ -121,18 +117,17 @@ paths operate on trusted sources (our agents, Dependabot).
 | `spec`           | Specification document only     | Trusted agents, never the contributor |
 | Everything else  | Nothing — requires human review | N/A                                   |
 
-Top-7 contributors pass the trust gate; `forward-impact-ci` PRs are
-trusted by identity. A compromised top contributor cannot inject code via
-this pipeline — specs merge only the document, not code.
+Top-7 contributors pass the trust gate; `forward-impact-ci` PRs are trusted by
+identity. A compromised top contributor cannot inject code via this pipeline —
+specs merge only the document, not code.
 
 ---
 
 ## The Workflows
 
-Seven scheduled workflows run on a three-shift Europe/Paris rhythm —
-**night** by 07:00, **storyboard** at 08:00, **day** by 15:00, **swing**
-by 23:00 — plus an event-driven **agent-conversation** workflow on PR and
-discussion activity.
+Seven scheduled workflows run on a three-shift Europe/Paris rhythm — **night**
+by 07:00, **storyboard** at 08:00, **day** by 15:00, **swing** by 23:00 — plus
+an event-driven **agent-conversation** workflow on PR and discussion activity.
 
 | Workflow                    | Schedule (Paris, CEST)                | Agent                                    |
 | --------------------------- | ------------------------------------- | ---------------------------------------- |
@@ -145,10 +140,10 @@ discussion activity.
 | **agent-release-engineer**  | Night 06:23 · Day 14:23 · Swing 22:23 | release-engineer                         |
 | **agent-conversation**      | On PR/discussion activity             | product-manager (facilitates 4 agents)   |
 
-Each shift forms a **producer → reviewer → shipper** chain: the product
-manager triages and merges so staff has a fresh backlog, staff implements,
-release ships. The night shift slots security-engineer and
-technical-writer between staff and release.
+Each shift forms a **producer → reviewer → shipper** chain: the product manager
+triages and merges so staff has a fresh backlog, staff implements, release
+ships. The night shift slots security-engineer and technical-writer between
+staff and release.
 
 ---
 
@@ -175,21 +170,21 @@ shared memory mechanics by
 ## Metrics
 
 Agents record time-series data to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`
-after each run. The `kata-metrics` skill defines the CSV schema (six
-fields: date, metric, value, unit, run, note), storage convention, and
-metric design. The storyboard meeting answers "what is the actual
-condition now?" with numbers, not narratives, and XmR process behavior
-charts distinguish stable processes from special-cause reactions.
+after each run. The `kata-metrics` skill defines the CSV schema (six fields:
+date, metric, value, unit, run, note), storage convention, and metric design.
+The storyboard meeting answers "what is the actual condition now?" with numbers,
+not narratives, and XmR process behavior charts distinguish stable processes
+from special-cause reactions.
 
 ---
 
 ## Authentication
 
-Workflows authenticate via the **GitHub App** `forward-impact-kata`, not a
-PAT. Each run generates a 1-hour installation token via
-`actions/create-github-app-token` — no long-lived secrets to rotate. The
-token must generate before `actions/checkout` so checkout-token writes
-trigger downstream workflows.
+Workflows authenticate via the **GitHub App** `forward-impact-kata`, not a PAT.
+Each run generates a 1-hour installation token via
+`actions/create-github-app-token` — no long-lived secrets to rotate. The token
+must generate before `actions/checkout` so checkout-token writes trigger
+downstream workflows.
 
 | Permission    | Why                                                               |
 | ------------- | ----------------------------------------------------------------- |
@@ -204,8 +199,8 @@ trigger downstream workflows.
 
 ## Where Each Agent Lives
 
-| Agent                 | Profile                                                                                                    |
-| --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Agent                 | Profile                                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------------------- |
 | **Staff Engineer**    | [staff-engineer.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/staff-engineer.md)       |
 | **Release Engineer**  | [release-engineer.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/release-engineer.md)   |
 | **Security Engineer** | [security-engineer.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/security-engineer.md) |
@@ -217,12 +212,19 @@ trigger downstream workflows.
 
 ## Further Reading
 
-- **[KATA.md](https://github.com/forwardimpact/monorepo/blob/main/KATA.md)** — Canonical reference, read by every agent at the start of every run.
-- **[Kata Brand](https://github.com/forwardimpact/monorepo/blob/main/design/kata/index.md)** — Brand implementation: palette, typography, motifs, and design tokens.
-- **[Kata Scenes](https://github.com/forwardimpact/monorepo/blob/main/design/kata/scenes.md)** — Production-floor scenes: storyboard, gemba walk, Ohno circle, andon cord, merge gate, drafting bench, shipping bay, archivist's desk, trace tape.
-- **[Kata Icons](https://github.com/forwardimpact/monorepo/blob/main/design/kata/icons.md)** — Six agent icons and the suite mark.
-- **[CHECKLISTS.md](https://github.com/forwardimpact/monorepo/blob/main/CHECKLISTS.md)** — How `<read_do_checklist>` and `<do_confirm_checklist>` work.
-- **[CONTRIBUTING.md](https://github.com/forwardimpact/monorepo/blob/main/CONTRIBUTING.md)** — Universal READ-DO and DO-CONFIRM checklists every Kata run runs.
+- **[KATA.md](https://github.com/forwardimpact/monorepo/blob/main/KATA.md)** —
+  Canonical reference, read by every agent at the start of every run.
+- **[Kata Brand](https://github.com/forwardimpact/monorepo/blob/main/design/kata/index.md)**
+  — Brand implementation: palette, typography, motifs, and design tokens.
+- **[Kata Scenes](https://github.com/forwardimpact/monorepo/blob/main/design/kata/scenes.md)**
+  — Production-floor scenes: storyboard, gemba walk, Ohno circle, andon cord,
+  merge gate, drafting bench, shipping bay, archivist's desk, trace tape.
+- **[Kata Icons](https://github.com/forwardimpact/monorepo/blob/main/design/kata/icons.md)**
+  — Six agent icons and the suite mark.
+- **[CHECKLISTS.md](https://github.com/forwardimpact/monorepo/blob/main/CHECKLISTS.md)**
+  — How `<read_do_checklist>` and `<do_confirm_checklist>` work.
+- **[CONTRIBUTING.md](https://github.com/forwardimpact/monorepo/blob/main/CONTRIBUTING.md)**
+  — Universal READ-DO and DO-CONFIRM checklists every Kata run runs.
 
 ---
 


### PR DESCRIPTION
## Summary

- New **Kata brand** at `design/kata/` — sibling to the FIT brand, premised on the mid-century Toyota Production System (Ohno's shop floor in flat caps, kanban rails, andon cords, chalk circles). Includes premise, six agent personas as products, palette (graphite-warm grays + hanko stamp-ink vermillion), Roboto Slab + IBM Plex typography, eight production-floor scenes, six agent icons, design tokens, and a four-quadrant **PDSA wheel** motif used as section divider, loading state, and wordmark accent.
- New **Kata internals page** at `websites/fit/docs/internals/kata/index.md` — sibling to `internals/operations/`, `internals/codegen/`, etc. The canonical entry point for human contributors browsing the docs site. Wired into the internals index and into CLAUDE.md's Documentation Map.
- **Cross-brand component contract** added to `design/index.md` § 12: shared components reference `--accent-warm-*` family aliases (now backfilled in both FIT's `--sand-*` and Kata's `--ink-*` token blocks); radii values are an explicit per-brand axis with the requirement that brands diverging on radii restate affected component specs.
- Brand passed a **five-PM panel review** on family consistency, audience fit, system coherence, implementation feasibility, and FIT-vs-Kata differentiation; HIGH/MEDIUM findings actioned in a follow-up commit:
  - Hanko (`--ink-400`) removed from button hover treatments — the warm signal no longer appears on interactive elements.
  - The Coach icon's "filled variant" replaced with a halo (second stroke), preserving the icon system's single-fill rule.
  - `--gray-400` lifted from `#807d76` (3.96:1) to `#74716a` (~4.7:1) so 14px body text passes WCAG AA on white; dark-footer secondary text reassigned to `--gray-300`.
  - "The Kanban Rail" sharpened to **"The Merge Gate"** — the Stakeholder stamps cards as they cross the gate, mapping directly to KATA.md's trust-boundary model.
  - New **"The Trace Tape"** scene, the only Kata scene composed across the diagonal, anchoring the `kata-trace` skill's grounded-theory workflow.

## Test plan

- [x] `bun run check` (format + lint + check-instructions + check-libharness) passes.
- [x] `bun run test` — 2502 tests across 220 files pass.
- [x] CLAUDE.md remains under the 192-line cap (verified by `scripts/check-instructions.mjs`).
- [x] Rebased cleanly on `origin/main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwZsnAZ9s6iLuxUZEYSXRn)_