### PR TITLE
feat(workflows): trigger agent-conversation on new issues, allow bot content

### DIFF
--- a/.github/workflows/agent-conversation.yml
+++ b/.github/workflows/agent-conversation.yml
@@ -1,6 +1,8 @@
 name: "Agent: Conversation"
 
 on:
+  issues:
+    types: [opened]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -35,10 +37,13 @@ permissions:
 
 jobs:
   kata:
-    # Skip bot senders, and require issue_comment events to be on PRs (issue_comment also fires for issues).
-    # For pull_request_review_comment, only run on thread replies (in_reply_to_id set) — top-level
-    # review comments are delivered via the pull_request_review (submitted) event in a single batch.
-    if: github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && ((github.event_name == 'issue_comment' && github.event.issue.pull_request != null) || (github.event_name == 'pull_request_review_comment' && github.event.comment.in_reply_to_id != null) || github.event_name == 'pull_request_review' || github.event_name == 'discussion' || github.event_name == 'discussion_comment'))
+    # Bot-authored content is allowed so this workflow can serve as an agent-to-agent coordination channel;
+    # the task text contains a recursion guard that stops the facilitator when the latest activity is already
+    # a participant agent's response. Require issue_comment events to be on PRs (issue_comment also fires for
+    # issues — new issues are handled via the dedicated `issues` event). For pull_request_review_comment, only
+    # run on thread replies (in_reply_to_id set) — top-level review comments are delivered via the
+    # pull_request_review (submitted) event in a single batch.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'issues' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) || (github.event_name == 'pull_request_review_comment' && github.event.comment.in_reply_to_id != null) || github.event_name == 'pull_request_review' || github.event_name == 'discussion' || github.event_name == 'discussion_comment'
     runs-on: ubuntu-latest
     steps:
       - name: Generate installation token
@@ -64,13 +69,14 @@ jobs:
           DISPATCH_TARGET_TYPE: ${{ inputs.target-type }}
           DISPATCH_TARGET_NUMBER: ${{ inputs.target-number }}
           PR_NUMBER_FROM_EVENT: ${{ github.event.issue.number || github.event.pull_request.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
           DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           DISCUSSION_NODE_ID: ${{ github.event.discussion.node_id }}
           DISCUSSION_TITLE: ${{ github.event.discussion.title }}
           DISCUSSION_CATEGORY: ${{ github.event.discussion.category.name }}
-          AUTHOR: ${{ github.event.comment.user.login || github.event.review.user.login || github.event.discussion.user.login || github.actor }}
-          AUTHOR_TYPE: ${{ github.event.comment.user.type || github.event.review.user.type || github.event.discussion.user.type || 'User' }}
-          ITEM_URL: ${{ github.event.comment.html_url || github.event.review.html_url || github.event.discussion.html_url || '' }}
+          AUTHOR: ${{ github.event.comment.user.login || github.event.review.user.login || github.event.discussion.user.login || github.event.issue.user.login || github.actor }}
+          AUTHOR_TYPE: ${{ github.event.comment.user.type || github.event.review.user.type || github.event.discussion.user.type || github.event.issue.user.type || 'User' }}
+          ITEM_URL: ${{ github.event.comment.html_url || github.event.review.html_url || github.event.discussion.html_url || github.event.issue.html_url || '' }}
         run: |
           set -euo pipefail
 
@@ -78,6 +84,12 @@ jobs:
           target_number="${PR_NUMBER_FROM_EVENT:-}"
 
           case "$EVENT_NAME" in
+            issues)
+              target_type="issue"
+              target_number="${PR_NUMBER_FROM_EVENT:-}"
+              context="A new issue was opened: \"$ISSUE_TITLE\" (#$target_number) by @$AUTHOR (user type: $AUTHOR_TYPE; event: $EVENT_NAME). Issue URL: $ITEM_URL."
+              action="decide which participant agent is most appropriate to respond based on the issue body, then ask that single agent to read the issue and post a single helpful reply via \`gh issue comment\`. Do not push any commits in response to a new issue."
+              ;;
             discussion)
               target_type="discussion"
               target_number="$DISCUSSION_NUMBER"
@@ -109,7 +121,9 @@ jobs:
               ;;
           esac
 
-          task="$context As facilitator, first verify the author is a trusted contributor and not a bot — if not, stop immediately without engaging any participant. Otherwise, $action"
+          task="$context As facilitator, $action
+
+          Recursion guard (this channel allows bot-authored content so agents can coordinate with each other): before engaging any participant, read the thread history. If the most recent activity is already a response from one of the participant agents you facilitate (product-manager, release-engineer, security-engineer, staff-engineer, technical-writer), stop immediately without engaging anyone — only respond when the latest content introduces a new question, request, or change for them to act on."
 
           {
             echo "target-type=$target_type"


### PR DESCRIPTION
Add `issues: opened` trigger so newly opened issues route through the
facilitator. Drop the sender-type bot filter so the workflow can serve as an
agent-to-agent coordination channel, and add a recursion guard to the task
text: the facilitator stops when the latest activity is already a response
from one of the participant agents it facilitates.