### PR TITLE
docs: rename Kata to Kata Agent Team and reframe end-to-end

### DIFF
--- a/.claude/agents/references/self-improvement.md
+++ b/.claude/agents/references/self-improvement.md
@@ -1,4 +1,4 @@
-# Self-Maintenance Writes Under `.claude/**`
+# Self-Improvement Writes Under `.claude/**`
 
 Claude Code's permission guard blocks `Write`, `Edit`, and sandboxed `Bash`
 calls targeting `.claude/**`. Until upstream regression

--- a/.claude/skills/kata-documentation/SKILL.md
+++ b/.claude/skills/kata-documentation/SKILL.md
@@ -71,7 +71,7 @@ Read memory per the agent profile (your summary, the current week's log, and
 teammates' summaries). Find last review dates per topic in the coverage map.
 
 > **Writing under `.claude/`:** If this run edits files under `.claude/skills/`,
-> follow [self-maintenance.md](../../agents/references/self-maintenance.md).
+> follow [self-improvement.md](../../agents/references/self-improvement.md).
 
 ### Topic selection
 

--- a/.claude/skills/kata-documentation/references/source-of-truth.md
+++ b/.claude/skills/kata-documentation/references/source-of-truth.md
@@ -3,24 +3,24 @@
 When writing or reviewing documentation, verify claims against the canonical
 source. Never trust documentation alone — read the code.
 
-| Documentation topic   | Verify against                                     |
-| --------------------- | -------------------------------------------------- |
-| Skills and levels     | `data/pathway/capabilities/`                       |
-| Behaviours            | `data/pathway/behaviours/`                         |
-| Disciplines           | `data/pathway/disciplines/`                        |
-| Tracks                | `data/pathway/tracks/`                             |
-| Levels                | `data/pathway/levels.yaml`                         |
-| Drivers               | `data/pathway/drivers.yaml`                        |
-| Job derivation        | `libraries/libskill/src/job.js`                    |
-| Agent derivation      | `libraries/libskill/src/agent.js`                  |
-| Map validation        | `products/map/src/`                                |
-| Pathway CLI           | `products/pathway/bin/fit-pathway.js`              |
-| Basecamp CLI          | `products/basecamp/bin/fit-basecamp.js`            |
-| Landmark CLI          | `products/landmark/bin/fit-landmark.js`            |
-| Summit CLI            | `products/summit/bin/fit-summit.js`                |
-| Terrain CLI           | `libraries/libterrain/bin/fit-terrain.js`          |
-| Templates             | `products/pathway/templates/`                      |
-| JSON Schema           | `products/map/schema/json/`                        |
-| RDF/SHACL Schema      | `products/map/schema/rdf/`                         |
-| LLM / SEO outputs     | `websites/fit/llms.txt`, `websites/fit/robots.txt` |
-| Kata Agent Team       | `KATA.md`                                          |
+| Documentation topic | Verify against                                     |
+| ------------------- | -------------------------------------------------- |
+| Skills and levels   | `data/pathway/capabilities/`                       |
+| Behaviours          | `data/pathway/behaviours/`                         |
+| Disciplines         | `data/pathway/disciplines/`                        |
+| Tracks              | `data/pathway/tracks/`                             |
+| Levels              | `data/pathway/levels.yaml`                         |
+| Drivers             | `data/pathway/drivers.yaml`                        |
+| Job derivation      | `libraries/libskill/src/job.js`                    |
+| Agent derivation    | `libraries/libskill/src/agent.js`                  |
+| Map validation      | `products/map/src/`                                |
+| Pathway CLI         | `products/pathway/bin/fit-pathway.js`              |
+| Basecamp CLI        | `products/basecamp/bin/fit-basecamp.js`            |
+| Landmark CLI        | `products/landmark/bin/fit-landmark.js`            |
+| Summit CLI          | `products/summit/bin/fit-summit.js`                |
+| Terrain CLI         | `libraries/libterrain/bin/fit-terrain.js`          |
+| Templates           | `products/pathway/templates/`                      |
+| JSON Schema         | `products/map/schema/json/`                        |
+| RDF/SHACL Schema    | `products/map/schema/rdf/`                         |
+| LLM / SEO outputs   | `websites/fit/llms.txt`, `websites/fit/robots.txt` |
+| Kata Agent Team     | `KATA.md`                                          |

--- a/.claude/skills/kata-documentation/references/source-of-truth.md
+++ b/.claude/skills/kata-documentation/references/source-of-truth.md
@@ -23,4 +23,4 @@ source. Never trust documentation alone — read the code.
 | JSON Schema           | `products/map/schema/json/`                        |
 | RDF/SHACL Schema      | `products/map/schema/rdf/`                         |
 | LLM / SEO outputs     | `websites/fit/llms.txt`, `websites/fit/robots.txt` |
-| Repo self-maintenance | `KATA.md`                                          |
+| Kata Agent Team       | `KATA.md`                                          |

--- a/.claude/skills/kata-implement/SKILL.md
+++ b/.claude/skills/kata-implement/SKILL.md
@@ -62,7 +62,7 @@ teammates' summaries). Extract specs previously implemented and any blockers
 from prior `staff-engineer` entries.
 
 > **Writing under `.claude/`:** If the plan targets files there, follow
-> [self-maintenance.md](../../agents/references/self-maintenance.md).
+> [self-improvement.md](../../agents/references/self-improvement.md).
 
 ### 1. Study the spec deeply
 

--- a/.claude/skills/kata-trace/SKILL.md
+++ b/.claude/skills/kata-trace/SKILL.md
@@ -11,8 +11,8 @@ description: >
 
 Go and see the work agents did by analyzing execution traces. Select one run,
 download its trace, study every turn via grounded theory, and produce findings
-with instruction-layer attribution. Operates within the Kata Agent Team
-defined in [KATA.md](../../../KATA.md).
+with instruction-layer attribution. Operates within the Kata Agent Team defined
+in [KATA.md](../../../KATA.md).
 
 ## When to Use
 

--- a/.claude/skills/kata-trace/SKILL.md
+++ b/.claude/skills/kata-trace/SKILL.md
@@ -11,8 +11,8 @@ description: >
 
 Go and see the work agents did by analyzing execution traces. Select one run,
 download its trace, study every turn via grounded theory, and produce findings
-with instruction-layer attribution. Operates within the Kata system defined in
-[KATA.md](../../../KATA.md).
+with instruction-layer attribution. Operates within the Kata Agent Team
+defined in [KATA.md](../../../KATA.md).
 
 ## When to Use
 

--- a/.claude/skills/kata-trace/SKILL.md
+++ b/.claude/skills/kata-trace/SKILL.md
@@ -154,7 +154,7 @@ Act on findings:
 Every PR branches directly from `main`.
 
 > **Writing under `.claude/`:** If a fix targets `.claude/`, follow
-> [self-maintenance.md](../../agents/references/self-maintenance.md).
+> [self-improvement.md](../../agents/references/self-improvement.md).
 
 ## Memory: what to record
 

--- a/.claude/skills/kata-wiki-curate/SKILL.md
+++ b/.claude/skills/kata-wiki-curate/SKILL.md
@@ -49,7 +49,7 @@ in `wiki/`:
 
 > **Writing under `.claude/`:** If this run edits files under `.claude/agents/`
 > or `.claude/skills/`, follow
-> [self-maintenance.md](../../agents/references/self-maintenance.md).
+> [self-improvement.md](../../agents/references/self-improvement.md).
 
 ### Step 1: Summary accuracy
 

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -148,8 +148,8 @@ jobs:
           cat > skills-repo/README.md << 'EOF'
           # Kata Skills
 
-          Agent skills for [Forward Impact](https://forwardimpact.team) repo
-          self-maintenance. Install with
+          Agent skills for the [Forward Impact](https://forwardimpact.team)
+          Kata Agent Team. Install with
           [npx skills](https://github.com/vercel-labs/skills):
 
           ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,11 +67,9 @@ staffing scenarios. [Overview](websites/fit/summit/index.md) ·
 
 ### Kata Agent Team — `kata-skills`
 
-An autonomous and continuously improving agentic development team that runs the
-full spec → design → plan → implement → release → improve loop. Specialized
-agents cover product management, engineering, security, releases, documentation,
-and coaching — coordinated as a Plan-Do-Study-Act cycle after Toyota Kata.
-[Internals](websites/fit/docs/internals/kata/)
+An autonomous, continuously improving agentic development team that runs the
+full spec → design → plan → implement → release → improve loop as a Toyota Kata
+PDSA cycle. [Internals](websites/fit/docs/internals/kata/)
 
 ## Distribution Model
 
@@ -180,12 +178,15 @@ Validate data: `bunx fit-map validate`. Vocabulary standards in the
 One home per policy; per-product pages: [§ Products](#products).
 
 **Internal:**
+
 - **Project identity & orientation** — [CLAUDE.md](CLAUDE.md)
 - **Contribution standards & security** — [CONTRIBUTING.md](CONTRIBUTING.md)
-- **Kata Agent Team** — [KATA.md](KATA.md) · [Internals](websites/fit/docs/internals/kata/)
+- **Kata Agent Team** — [KATA.md](KATA.md) ·
+  [Internals](websites/fit/docs/internals/kata/)
 - **Codegen pipeline** — [Codegen](websites/fit/docs/internals/codegen/)
 
 **External:**
+
 - **Getting started** — [Getting Started](websites/fit/docs/getting-started/)
 - **User guides** — [websites/fit/docs/guides/](websites/fit/docs/guides/)
 - **Published skills** — [fit-\*](.claude/skills/) · [kata-\*](.claude/skills/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,12 @@ Models team capability as a system: skill matrices, coverage gaps, risks, and
 staffing scenarios. [Overview](websites/fit/summit/index.md) ·
 [Internals](websites/fit/docs/internals/summit/index.md)
 
-### Kata — `kata-skills`
+### Kata Agent Team — `kata-skills`
 
-Helps agents answer _how do I maintain this repository?_ A team of specialized
-agents covering specs, design, planning, implementation, review, releases,
-security, and documentation — driven by Toyota Kata continuous improvement.
+An autonomous and continuously improving agentic development team that runs the
+full spec → design → plan → implement → release → improve loop. Specialized
+agents cover product management, engineering, security, releases, documentation,
+and coaching — coordinated as a Plan-Do-Study-Act cycle after Toyota Kata.
 [Internals](websites/fit/docs/internals/kata/)
 
 ## Distribution Model
@@ -85,7 +86,7 @@ they learn to use them, so skill clarity directly affects product quality. Two
 skill packs sync on push to `main`:
 
 - **`forwardimpact/fit-skills`** — `fit-*` skills for the framework products.
-- **`forwardimpact/kata-skills`** — `kata-*` skills for repo self-maintenance.
+- **`forwardimpact/kata-skills`** — `kata-*` skills for the Kata Agent Team.
 
 External users install with `npx skills add forwardimpact/fit-skills` (or
 `kata-skills`). Each published skill should teach agents how a product **works**
@@ -181,7 +182,7 @@ One home per policy; per-product pages: [§ Products](#products).
 **Internal:**
 - **Project identity & orientation** — [CLAUDE.md](CLAUDE.md)
 - **Contribution standards & security** — [CONTRIBUTING.md](CONTRIBUTING.md)
-- **Repo self-maintenance** — [KATA.md](KATA.md) · [Internals](websites/fit/docs/internals/kata/)
+- **Kata Agent Team** — [KATA.md](KATA.md) · [Internals](websites/fit/docs/internals/kata/)
 - **Codegen pipeline** — [Codegen](websites/fit/docs/internals/codegen/)
 
 **External:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ path from `config/config.example.json`), plus `proto/`, `src/`, `test/`, and
 ### `.claude/` — agent configuration
 
 `Edit` and `Write` are denied on `.claude/**` paths. Use
-[`scripts/claude-write.sh`](.claude/agents/references/self-maintenance.md)
+[`scripts/claude-write.sh`](.claude/agents/references/self-improvement.md)
 instead.
 
 ## Pull Request Workflow

--- a/KATA.md
+++ b/KATA.md
@@ -1,4 +1,4 @@
-# Kata
+# Kata Agent Team
 
 > "What does the pattern of the Improvement Kata give us? A means for
 > systematically and scientifically working toward a new desired condition, in a
@@ -6,14 +6,16 @@
 >
 > — Mike Rother, _Toyota Kata_
 
-Kata is the Forward Impact repo self-maintenance system: autonomous agents on
-GitHub Actions that keep the codebase secure, release-ready, and steadily
-improving. The name follows Toyota Kata — agents grasp the current condition
-(via prior-run traces), establish target conditions (via specs), and experiment
-toward them (via implementation). Eight workflows (five scheduled agent runs
-across three shifts, a daily storyboard, an on-demand coaching session, an
-event-driven conversation responder), six agent personas, and eighteen skills
-form a self-reinforcing PDSA cycle.
+The Kata Agent Team is an autonomous and continuously improving agentic
+development team running on GitHub Actions. It owns the full
+spec → design → plan → implement → release → improve loop end-to-end: shipping
+features, hardening security, cutting releases, curating docs, and improving
+its own practice. The name follows Toyota Kata — agents grasp the current
+condition (via prior-run traces), establish target conditions (via specs), and
+experiment toward them (via implementation). Eight workflows (five scheduled
+agent runs across three shifts, a daily storyboard, an on-demand coaching
+session, an event-driven conversation responder), six agent personas, and
+eighteen skills form a self-reinforcing PDSA cycle.
 
 ## Architecture
 

--- a/KATA.md
+++ b/KATA.md
@@ -7,15 +7,15 @@
 > — Mike Rother, _Toyota Kata_
 
 The Kata Agent Team is an autonomous and continuously improving agentic
-development team running on GitHub Actions. It owns the full
-spec → design → plan → implement → release → improve loop end-to-end: shipping
-features, hardening security, cutting releases, curating docs, and improving
-its own practice. The name follows Toyota Kata — agents grasp the current
-condition (via prior-run traces), establish target conditions (via specs), and
-experiment toward them (via implementation). Eight workflows (five scheduled
-agent runs across three shifts, a daily storyboard, an on-demand coaching
-session, an event-driven conversation responder), six agent personas, and
-eighteen skills form a self-reinforcing PDSA cycle.
+development team running on GitHub Actions. It owns the full spec → design →
+plan → implement → release → improve loop end-to-end: shipping features,
+hardening security, cutting releases, curating docs, and improving its own
+practice. The name follows Toyota Kata — agents grasp the current condition (via
+prior-run traces), establish target conditions (via specs), and experiment
+toward them (via implementation). Eight workflows (five scheduled agent runs
+across three shifts, a daily storyboard, an on-demand coaching session, an
+event-driven conversation responder), six agent personas, and eighteen skills
+form a self-reinforcing PDSA cycle.
 
 ## Architecture
 

--- a/design/kata/index.md
+++ b/design/kata/index.md
@@ -1,12 +1,11 @@
 # Kata — Brand Implementation
 
 > The Kata realization of the [shared design language](../index.md): a
-> monochrome design system for the Kata Agent Team, built around the metaphor
-> of a **mid-century Toyota production floor**. Six agent personas
-> — the **Staff Engineer**, **Release Engineer**, **Security Engineer**,
-> **Product Manager**, **Technical Writer**, and **Improvement Coach** — work
-> the line together, the way Taiichi Ohno's foremen worked the shop floor in the
-> 1940s and 50s.
+> monochrome design system for the Kata Agent Team, built around the metaphor of
+> a **mid-century Toyota production floor**. Six agent personas — the **Staff
+> Engineer**, **Release Engineer**, **Security Engineer**, **Product Manager**,
+> **Technical Writer**, and **Improvement Coach** — work the line together, the
+> way Taiichi Ohno's foremen worked the shop floor in the 1940s and 50s.
 >
 > The brand evokes the dignity of practiced work: pressed suits, soft flat caps,
 > andon cords, kanban rails, the chalk circle on a polished concrete floor.

--- a/design/kata/index.md
+++ b/design/kata/index.md
@@ -1,8 +1,8 @@
 # Kata — Brand Implementation
 
 > The Kata realization of the [shared design language](../index.md): a
-> monochrome design system for the repo self-maintenance system, built around
-> the metaphor of a **mid-century Toyota production floor**. Six agent personas
+> monochrome design system for the Kata Agent Team, built around the metaphor
+> of a **mid-century Toyota production floor**. Six agent personas
 > — the **Staff Engineer**, **Release Engineer**, **Security Engineer**,
 > **Product Manager**, **Technical Writer**, and **Improvement Coach** — work
 > the line together, the way Taiichi Ohno's foremen worked the shop floor in the
@@ -229,9 +229,10 @@ Roboto Slab, 64px, weight 700:
 
 IBM Plex Sans, 18px, weight 400, gray-400:
 
-  Kata is the Forward Impact repo self-maintenance system. Six agent
-  personas walk the line together — planning, shipping, hardening,
-  triaging, documenting, and coaching — one daily kata at a time.
+  The Kata Agent Team is Forward Impact's autonomous and continuously
+  improving agentic development team. Six agent personas walk the line
+  together — planning, shipping, hardening, triaging, documenting, and
+  coaching — one daily kata at a time.
 ```
 
 ---
@@ -260,9 +261,9 @@ stamped into the same logbook as the
 
 ## 8. Layout Patterns
 
-Kata is the **internal** repo self-maintenance system. It has no public
-marketing site. The brand surfaces in four real places, ordered by how often a
-contributor or agent encounters them:
+The Kata Agent Team is **internal**. It has no public marketing site. The brand
+surfaces in four real places, ordered by how often a contributor or agent
+encounters them:
 
 ### Surface 1 — The Internals Page
 

--- a/websites/fit/docs/internals/index.md
+++ b/websites/fit/docs/internals/index.md
@@ -126,10 +126,11 @@ the Forward Impact monorepo.
 
 <a href="/docs/internals/kata/">
 
-### Kata
+### Kata Agent Team
 
-Repo self-maintenance system — six agent personas, eight workflows, eighteen
-skills, organized as a Plan-Do-Study-Act loop.
+An autonomous and continuously improving agentic development team — six agent
+personas, eight workflows, eighteen skills, organized as a Plan-Do-Study-Act
+loop.
 
 </a>
 

--- a/websites/fit/docs/internals/kata/index.md
+++ b/websites/fit/docs/internals/kata/index.md
@@ -1,6 +1,6 @@
 ---
-title: Kata
-description: "The repo self-maintenance system — six agent personas, eight workflows, eighteen skills, organized as a Plan-Do-Study-Act loop."
+title: Kata Agent Team
+description: "An autonomous and continuously improving agentic development team — six agent personas, eight workflows, eighteen skills, organized as a Plan-Do-Study-Act loop."
 ---
 
 > "What does the pattern of the Improvement Kata give us? A means for
@@ -9,12 +9,15 @@ description: "The repo self-maintenance system — six agent personas, eight wor
 >
 > — Mike Rother, _Toyota Kata_
 
-**Kata** is the Forward Impact repo self-maintenance system: autonomous agents
-on GitHub Actions that keep the codebase secure, release-ready, and steadily
-improving. The name follows Toyota Kata — agents grasp the current condition
-(via prior-run traces), establish target conditions (via specs), and experiment
-toward them (via implementation). Six agent personas, eight workflows, eighteen
-skills, organized around a daily **Plan-Do-Study-Act** loop.
+The **Kata Agent Team** is an autonomous and continuously improving agentic
+development team running on GitHub Actions. It owns the full
+spec → design → plan → implement → release → improve loop end-to-end: shipping
+features, hardening security, cutting releases, curating docs, and improving
+its own practice. The name follows Toyota Kata — agents grasp the current
+condition (via prior-run traces), establish target conditions (via specs), and
+experiment toward them (via implementation). Six agent personas, eight
+workflows, eighteen skills, organized around a daily **Plan-Do-Study-Act**
+loop.
 
 This page is the internal-contributor entry point. The canonical reference is
 [`KATA.md`](https://github.com/forwardimpact/monorepo/blob/main/KATA.md) at the

--- a/websites/fit/docs/internals/kata/index.md
+++ b/websites/fit/docs/internals/kata/index.md
@@ -10,14 +10,13 @@ description: "An autonomous and continuously improving agentic development team 
 > — Mike Rother, _Toyota Kata_
 
 The **Kata Agent Team** is an autonomous and continuously improving agentic
-development team running on GitHub Actions. It owns the full
-spec → design → plan → implement → release → improve loop end-to-end: shipping
-features, hardening security, cutting releases, curating docs, and improving
-its own practice. The name follows Toyota Kata — agents grasp the current
-condition (via prior-run traces), establish target conditions (via specs), and
-experiment toward them (via implementation). Six agent personas, eight
-workflows, eighteen skills, organized around a daily **Plan-Do-Study-Act**
-loop.
+development team running on GitHub Actions. It owns the full spec → design →
+plan → implement → release → improve loop end-to-end: shipping features,
+hardening security, cutting releases, curating docs, and improving its own
+practice. The name follows Toyota Kata — agents grasp the current condition (via
+prior-run traces), establish target conditions (via specs), and experiment
+toward them (via implementation). Six agent personas, eight workflows, eighteen
+skills, organized around a daily **Plan-Do-Study-Act** loop.
 
 This page is the internal-contributor entry point. The canonical reference is
 [`KATA.md`](https://github.com/forwardimpact/monorepo/blob/main/KATA.md) at the


### PR DESCRIPTION
## Summary

- Rename **Kata** → **Kata Agent Team** and reframe as "an autonomous and continuously improving agentic development team" running the full spec → design → plan → implement → release → improve loop. The previous "repo self-maintenance system" framing was too narrow.
- Touches the canonical surfaces: `CLAUDE.md`, `KATA.md`, the website internals page and index, the `design/kata/` brand doc, and the `kata-documentation` source-of-truth table.
- Rename `.claude/agents/references/self-maintenance.md` → `self-improvement.md` to reinforce the continuous-improvement framing. Updates the four live referrers (`CONTRIBUTING.md`, `kata-implement`, `kata-trace`, `kata-documentation`, `kata-wiki-curate`) plus the published `kata-skills` README description in `publish-skills.yml`.
- Historical specs under `specs/610-claude-self-maintenance-write-protection/` keep their original wording — they document past decisions.

## Test plan

- [x] `node scripts/check-instructions.mjs` (CLAUDE.md fits the 192-line cap)
- [x] `bun run test` (2502/0 passing)
- [x] All `self-improvement.md` relative links resolve to the renamed file
- [ ] `bun run lint` and `bun run format` — currently broken on `main` itself with 8 pre-existing eslint errors and one prettier warning in files this branch does not touch (`libraries/libdoc/bin/fit-doc.js`, `scripts/vector-artifacts.mjs`, `scripts/vector-smoothen.mjs`, `scripts/vector-speckles.mjs`). To be addressed separately.

https://claude.ai/code/session_01AxE8HDdXCEinc2pcvzTc2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxE8HDdXCEinc2pcvzTc2P)_