### PR TITLE
feat(libraries): publish a generated capability catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,8 @@ Tagged checklists gate pause points. Rules: [CHECKLISTS.md](CHECKLISTS.md).
 
 **Every contribution** runs [§ READ-DO](CONTRIBUTING.md#read-do) then
 [§ DO-CONFIRM](CONTRIBUTING.md#do-confirm). Domain checklists in
-`.claude/skills/kata-*/SKILL.md`.
+`.claude/skills/kata-*/SKILL.md`. Shared libraries:
+[libraries/README.md](libraries/README.md).
 
 ## Memory and Coordination
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,10 @@ Entry gate — read every item before starting.
       it isn't asked for, don't add it.
 - [ ] **Read the code** I'm about to change before writing.
 - [ ] **Search shared libraries first.** Before writing a helper, utility, retry
-      wrapper, argument parser, or any other generic capability, search
-      `libraries/` and the `libs-*` skill group that covers the task. If a
-      shared library already provides the capability, use it. If not, note that
-      in the commit or plan so future contributors don't re-search.
+      wrapper, argument parser, or any other generic capability, scan
+      [libraries/README.md](libraries/README.md). If a library covers it, use
+      it. If not, note that in the commit or plan so future contributors don't
+      re-search.
 - [ ] **Search libharness first for test helpers.** Before writing a mock or
       fixture in a test, check `libraries/libharness/src/index.js`. Reuse what
       exists; extend libharness in the same PR when duplication would cross two

--- a/libraries/CLAUDE.md
+++ b/libraries/CLAUDE.md
@@ -4,6 +4,17 @@ Conventions when working under `libraries/`. The catalog itself lives in
 [README.md](README.md); this file documents the metadata that drives it and the
 rules a CLI-shipping library must follow.
 
+## Audience
+
+The primary audience for library CLIs and their matching skills is **external
+agents and engineers** who have limited context and no direct access to this
+monorepo. They reach a tool via `npx fit-<name>` or by loading the matching
+skill — without ever cloning the repo.
+
+Write `--help` output, skill instructions, and published guides for that reader:
+self-contained, no insider tooling references, no relative paths into
+`libraries/` or `websites/`, and every doc link a fully-qualified public URL.
+
 ## `package.json` structure
 
 Every library carries metadata the catalog generators consume. Required fields:
@@ -33,34 +44,53 @@ bun run lib:needs
 
 ## CLIs and progressive documentation
 
-If a library ships a CLI (a `bin/` entry in `package.json`), all three of the
-following must exist — none alone is sufficient:
+If a library ships a CLI (a `bin/` entry in `package.json`), three artifacts
+must exist together so an external reader lands on the same docs from any entry
+point:
 
-1. **A user guide** at `websites/fit/docs/guides/<slug>/index.md`. Written for
-   the external user, not the contributor. Same standards as the rest of
-   `websites/fit/`.
-2. **A `fit-*` skill** at `.claude/skills/fit-<slug>/SKILL.md`. The skill's
-   `## Documentation` section links the guide with the fully-qualified URL
-   `https://www.forwardimpact.team/docs/guides/<slug>/index.md` (external users
-   have no monorepo access — see [root CLAUDE.md](../CLAUDE.md)).
-3. **A `documentation` entry on the libcli definition** so `--help` and
-   `--help --json` surface the same link. Both `libcli` and `librepl` render it
-   under `Documentation:` automatically:
+- The **user guide** — markdown source at
+  `websites/fit/docs/guides/<name>/index.md`.
+- The **skill** — `.claude/skills/fit-<name>/SKILL.md`.
+- The **CLI `--help`** — `documentation` entry on the libcli definition.
 
-   ```js
-   const cli = createCli({
-     name: "fit-foo",
-     documentation: [
-       {
-         title: "Foo Guide",
-         url: "https://www.forwardimpact.team/docs/guides/foo/index.md",
-         description: "How to use fit-foo.",
-       },
-     ],
-   });
-   ```
+### Linking rule
 
-The skill, the CLI help, and the published guide must share the same title and
-URL. Progressive discovery: an agent that hits the CLI cold sees the guide link
-in `--help`; an agent that loads the skill sees the same link; either path lands
-on the same authoritative document.
+Skill and CLI both link the guide using the **fully-qualified URL of the
+markdown source**:
+
+```
+https://www.forwardimpact.team/docs/guides/<name>/index.md
+```
+
+The `.md` extension is deliberate. Agents fetch markdown more reliably than
+rendered HTML, and the `.md` URL maps one-to-one to the source file in
+`websites/fit/docs/guides/<name>/index.md`. Use the same title and URL across
+all three artifacts.
+
+### Worked example: `fit-foo`
+
+Guide source: `websites/fit/docs/guides/foo/index.md`.
+
+Skill (`.claude/skills/fit-foo/SKILL.md`) carries this `## Documentation` block:
+
+```markdown
+## Documentation
+
+- [Foo Guide](https://www.forwardimpact.team/docs/guides/foo/index.md) — how
+  to use `fit-foo`.
+```
+
+CLI definition (libcli) carries the same link:
+
+```js
+const cli = createCli({
+  name: "fit-foo",
+  documentation: [
+    {
+      title: "Foo Guide",
+      url: "https://www.forwardimpact.team/docs/guides/foo/index.md",
+      description: "How to use fit-foo.",
+    },
+  ],
+});
+```

--- a/libraries/CLAUDE.md
+++ b/libraries/CLAUDE.md
@@ -1,0 +1,66 @@
+# Libraries
+
+Conventions when working under `libraries/`. The catalog itself lives in
+[README.md](README.md); this file documents the metadata that drives it and the
+rules a CLI-shipping library must follow.
+
+## `package.json` structure
+
+Every library carries metadata the catalog generators consume. Required fields:
+
+- **`description`** — capability-led, one sentence, agent angle baked in.
+  Becomes the row in [README.md](README.md). Markdown is allowed — use backticks
+  for cross-library references, code, or paths so the rendered table reads
+  cleanly.
+- **`keywords`** — 4–6 lowercase tokens. First token is the primary capability
+  noun (`cli`, `storage`, `vector`); last is always `agent`.
+- **`forwardimpact.capability`** — exactly one of `agent-capability`,
+  `agent-retrieval`, `agent-self-improvement`, `agent-infrastructure`, or
+  `foundations`. Determines the catalog category.
+- **`forwardimpact.needs`** — array of "I need to…" phrases for the flat index
+  in [README.md](README.md). Each phrase must be unique across the monorepo (the
+  generator fails on duplicates). Keep entries imperative and outcome-shaped,
+  not feature-shaped (`Compute a stable hash`, not `generateHash function`).
+
+After editing any of these, regenerate the catalog:
+
+```sh
+bun run lib:capabilities
+bun run lib:needs
+```
+
+`bun run check` refuses a stale catalog and points at the right command.
+
+## CLIs and progressive documentation
+
+If a library ships a CLI (a `bin/` entry in `package.json`), all three of the
+following must exist — none alone is sufficient:
+
+1. **A user guide** at `websites/fit/docs/guides/<slug>/index.md`. Written for
+   the external user, not the contributor. Same standards as the rest of
+   `websites/fit/`.
+2. **A `fit-*` skill** at `.claude/skills/fit-<slug>/SKILL.md`. The skill's
+   `## Documentation` section links the guide with the fully-qualified URL
+   `https://www.forwardimpact.team/docs/guides/<slug>/index.md` (external users
+   have no monorepo access — see [root CLAUDE.md](../CLAUDE.md)).
+3. **A `documentation` entry on the libcli definition** so `--help` and
+   `--help --json` surface the same link. Both `libcli` and `librepl` render it
+   under `Documentation:` automatically:
+
+   ```js
+   const cli = createCli({
+     name: "fit-foo",
+     documentation: [
+       {
+         title: "Foo Guide",
+         url: "https://www.forwardimpact.team/docs/guides/foo/index.md",
+         description: "How to use fit-foo.",
+       },
+     ],
+   });
+   ```
+
+The skill, the CLI help, and the published guide must share the same title and
+URL. Progressive discovery: an agent that hits the CLI cold sees the guide link
+in `--help`; an agent that loads the skill sees the same link; either path lands
+on the same authoritative document.

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -139,8 +139,10 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 | Code-sign a macOS app                                                          | `libmacos`           |
 | Compute a stable hash (SHA-256 checksum)                                       | `libutil`            |
 | Compute cosine similarity between embeddings                                   | `libvector`          |
+| Configure restart policies and log rotation for a daemon manifest              | `libsupervise`       |
 | Control a service's start, stop, and status                                    | `librc`              |
 | Count LLM tokens                                                               | `libutil`            |
+| Declare macOS permission entitlements for an app                               | `libmacos`           |
 | Derive a role definition from a competency matrix (discipline × level × track) | `libskill`           |
 | Download and extract a tarball                                                 | `libutil`            |
 | Drive an LLM agent through a scripted run and capture its trace                | `libeval`            |
@@ -168,6 +170,7 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 | Register a gRPC service as MCP tools                                           | `libmcp`             |
 | Render a markdown sparkline                                                    | `libxmr`             |
 | Render a Mustache template with project overrides                              | `libtemplate`        |
+| Render a prompt template with variable substitution                            | `libprompt`          |
 | Render colored tables and JSON output                                          | `libcli`             |
 | Render markdown as ANSI                                                        | `libformat`          |
 | Render markdown as HTML                                                        | `libformat`          |
@@ -181,6 +184,9 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 | Sign a JWT                                                                     | `libsecret`          |
 | Store files to local, S3, or Supabase                                          | `libstorage`         |
 | Supervise a long-running daemon                                                | `libsupervise`       |
+| Supervise a multi-step or multi-agent workflow                                 | `libeval`            |
+| Surface skill-doc links in CLI --help output                                   | `libcli`             |
+| Surface skill-doc links in REPL --help output                                  | `librepl`            |
 | Validate synthetic data integrity                                              | `libsyntheticrender` |
 
 <!-- END:needs -->

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -1,6 +1,6 @@
 # Shared Libraries
 
-The 32 packages under `libraries/` are the shared building blocks for every
+The packages under `libraries/` are the shared building blocks for every
 product, service, website, and skill in the monorepo. They are designed for
 agentic systems: agent-friendly CLIs and output formats, retrieval primitives
 that surface rich grounded context, evaluation tooling that closes the
@@ -21,21 +21,29 @@ This rule lives next to the other invariants in
 
 Five capability categories. Every library appears in exactly one.
 
+The tables below are generated from each library's `package.json`
+(`forwardimpact.capability` + `description`). To regenerate after editing a
+library: `bun run lib:capabilities`. CI fails the build if the catalog drifts.
+
 ### Agent Capability
 
 What the agent surface looks like — entry points, voice, skill data,
 human-facing output that agents produce.
 
+<!-- BEGIN:capability:agent-capability -->
+
 | Library         | Capability                                                                                                             |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | **libcli**      | Agent-friendly CLIs: argument parsing, grep-friendly help output, JSON mode, and skill-doc links surfaced in `--help`. |
-| **librepl**     | Agent-friendly interactive shells with command dispatch and skill-doc links.                                           |
-| **libprompt**   | Agent-authored prompt templates loaded from `.prompt.md` files with Mustache substitution.                             |
-| **libskill**    | Derive jobs, skill matrices, and agent profiles from engineering-standard data shared by humans and agents.            |
-| **libformat**   | Render markdown to ANSI for agent-friendly terminal output or HTML for browsers.                                       |
-| **libui**       | Functional web UI primitives — DOM helpers, SPA routing, reactive state — for products agents build.                   |
 | **libdoc**      | Static documentation sites from markdown folders with front matter and navigation.                                     |
+| **libformat**   | Render markdown to ANSI for agent-friendly terminal output or HTML for browsers.                                       |
+| **libprompt**   | Agent-authored prompt templates loaded from `.prompt.md` files with Mustache substitution.                             |
+| **librepl**     | Agent-friendly interactive REPL with command dispatch and skill-doc links surfaced in `--help`.                        |
+| **libskill**    | Derive jobs, skill matrices, and agent profiles from engineering-standard data shared by humans and agents.            |
 | **libtemplate** | Mustache template loader with project-level override directories for agent-rendered content.                           |
+| **libui**       | Functional web UI primitives — DOM helpers, SPA routing, reactive state — for products agents build.                   |
+
+<!-- END:capability:agent-capability -->
 
 ### Agent Retrieval
 
@@ -43,14 +51,18 @@ How agents fetch and shape context. The stack runs from raw bytes (`libstorage`)
 through typed records (`libresource`) to schema-aware graph and vector
 inference.
 
-| Library         | Capability                                                                                               |
-| --------------- | -------------------------------------------------------------------------------------------------------- |
-| **libstorage**  | Pluggable file storage (local, S3, Supabase) for context agents fetch and produce.                       |
-| **libindex**    | JSONL-backed indexes with filtering and buffered writes — fast lookup of context chunks.                 |
-| **libresource** | Typed resources with identifiers, access control, and rich RDF-friendly context chunks agents ground in. |
-| **libpolicy**   | Access-control policy evaluation so agents only see context they are authorized for.                     |
-| **libgraph**    | RDF triple store with named ontologies and SHACL serialization — schema-aware graph inference.           |
-| **libvector**   | Vector dot-product scoring for cosine-similarity retrieval over agent embeddings.                        |
+<!-- BEGIN:capability:agent-retrieval -->
+
+| Library         | Capability                                                                                                  |
+| --------------- | ----------------------------------------------------------------------------------------------------------- |
+| **libgraph**    | RDF triple store with named ontologies and SHACL serialization — schema-aware graph inference for agents.   |
+| **libindex**    | JSONL-backed indexes with filtering and buffered writes — fast lookup of agent context chunks.              |
+| **libpolicy**   | Access-control policy evaluation — agents see only context they are authorized for.                         |
+| **libresource** | Typed resources with identifiers, access control, and rich RDF-friendly context chunks for agent grounding. |
+| **libstorage**  | Pluggable file storage (local, S3, Supabase) for context agents fetch and produce at runtime.               |
+| **libvector**   | Vector dot-product scoring for cosine-similarity retrieval over agent embeddings.                           |
+
+<!-- END:capability:agent-retrieval -->
 
 ### Agent Self-Improvement
 
@@ -58,41 +70,141 @@ Tooling that closes the Plan-Do-Study-Act loop: evaluate agent runs, generate
 synthetic test data so evals are deterministic, and chart process behavior so
 signal is distinguished from noise.
 
+<!-- BEGIN:capability:agent-self-improvement -->
+
 | Library                | Capability                                                                                                |
 | ---------------------- | --------------------------------------------------------------------------------------------------------- |
-| **libeval**            | Agent evaluation — collect Claude Code traces, run agent loops, supervise multi-step workflows.           |
+| **libeval**            | Agent evaluation: collect Claude Code traces, run agent loops, supervise multi-step workflows.            |
 | **libsyntheticgen**    | DSL parser and deterministic entity graph generator for repeatable agent eval fixtures.                   |
 | **libsyntheticprose**  | LLM-generated prose and engineering-standard YAML for synthetic agent evaluation content.                 |
 | **libsyntheticrender** | Multi-format rendering and validation of synthetic agent evaluation data (HTML, Markdown, YAML).          |
 | **libterrain**         | Full parse-generate-render-validate pipeline for synthetic agent training and evaluation data.            |
 | **libxmr**             | Agent-friendly XmR control charts: markdown sparklines and signal detection over time-series CSV metrics. |
 
+<!-- END:capability:agent-self-improvement -->
+
 ### Agent Infrastructure
 
 How agent services run — protocol, types, configuration, observability, process
 supervision, and the bridge that exposes gRPC services as MCP tools.
 
+<!-- BEGIN:capability:agent-infrastructure -->
+
 | Library          | Capability                                                                                                                                                |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **librpc**       | gRPC server and client framework — how agent services talk to each other.                                                                                 |
-| **libtype**      | Generated protobuf types and namespaces shared across agent-facing services.                                                                              |
 | **libcodegen**   | Protobuf code generation — produces the types and clients consumed by `libtype` and `librpc`.                                                             |
 | **libconfig**    | Environment-aware loading of application settings for services, CLIs, and extensions.                                                                     |
-| **libtelemetry** | Structured RFC 5424 logging and trace spans for observable agent operations.                                                                              |
-| **libsupervise** | Process supervision (restart policies, log rotation) driven by JSON daemon manifests agents can read and tune; built on `libconfig` for settings loading. |
-| **librc**        | Agent-friendly service management — start, stop, status via Unix sockets controlled by svscan.                                                            |
 | **libmcp**       | Config-driven gRPC-to-MCP tool registration — agents see protobuf services as MCP tools.                                                                  |
+| **librc**        | Agent-friendly service lifecycle management: start, stop, and status of long-running services via a Unix socket interface.                                |
+| **librpc**       | gRPC server and client framework — how agent services talk to each other.                                                                                 |
+| **libsupervise** | Process supervision (restart policies, log rotation) driven by JSON daemon manifests agents can read and tune; built on `libconfig` for settings loading. |
+| **libtelemetry** | Structured RFC 5424 logging and trace spans for observable agent operations.                                                                              |
+| **libtype**      | Generated protobuf types and namespaces shared across agent-facing services.                                                                              |
+
+<!-- END:capability:agent-infrastructure -->
 
 ### Foundations
 
 Cross-cutting primitives and platform-specific helpers used by all of the above.
 
-| Library        | Capability                                                                                                     |
-| -------------- | -------------------------------------------------------------------------------------------------------------- |
-| **libutil**    | Cross-cutting utilities: retry with backoff, hashing, token counting, project-root finder, tarball downloader. |
-| **libsecret**  | Secret generation, JWT signing, and `.env` file management for services and CLIs.                              |
-| **libharness** | Shared mocks and test fixtures so every library and service tests the same way.                                |
-| **libmacos**   | macOS bundle assembly, code signing, and TCC responsibility helpers — desktop delivery for agent products.     |
+<!-- BEGIN:capability:foundations -->
+
+| Library        | Capability                                                                                                                        |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **libharness** | Shared mocks and test fixtures so every library and service tests the same way.                                                   |
+| **libmacos**   | macOS bundle assembly, code signing, and OS permission entitlement helpers — desktop delivery for agent products.                 |
+| **libsecret**  | Secret generation, JWT signing, and `.env` file management for agent services and CLIs.                                           |
+| **libutil**    | Cross-cutting utilities for agents and services: retry with backoff, hashing, token counting, project finder, tarball downloader. |
+
+<!-- END:capability:foundations -->
+
+## I need to…
+
+Common needs that map directly to a single library. Generated from each
+library's `package.json` (`forwardimpact.needs`); regenerate with
+`bun run lib:needs`.
+
+<!-- BEGIN:needs -->
+
+| I need to…                                                     | Library              |
+| -------------------------------------------------------------- | -------------------- |
+| Add a distributed trace span                                   | `libtelemetry`       |
+| Assemble a macOS app bundle                                    | `libmacos`           |
+| Buffer high-volume index writes                                | `libindex`           |
+| Build a gRPC service                                           | `librpc`             |
+| Build a static documentation site                              | `libdoc`             |
+| Build a web app page                                           | `libui`              |
+| Call another gRPC service                                      | `librpc`             |
+| Code-sign a macOS app                                          | `libmacos`           |
+| Compute a stable hash                                          | `libutil`            |
+| Compute an XmR control chart                                   | `libxmr`             |
+| Compute cosine similarity between embeddings                   | `libvector`          |
+| Count LLM tokens                                               | `libutil`            |
+| Derive a job from discipline, level, and track                 | `libskill`           |
+| Detect signals in a time series                                | `libxmr`             |
+| Download and extract a tarball                                 | `libutil`            |
+| Emit a structured log line                                     | `libtelemetry`       |
+| Evaluate an access-control policy                              | `libpolicy`          |
+| Filter records in a JSONL index                                | `libindex`           |
+| Find the project root                                          | `libutil`            |
+| Generate a deterministic entity graph                          | `libsyntheticgen`    |
+| Generate a secret                                              | `libsecret`          |
+| Generate a UUID                                                | `libutil`            |
+| Generate an agent profile                                      | `libskill`           |
+| Generate code from .proto files                                | `libcodegen`         |
+| Generate LLM prose for synthetic data                          | `libsyntheticprose`  |
+| Load a prompt template from disk                               | `libprompt`          |
+| Load application settings from environment                     | `libconfig`          |
+| Manage a service lifecycle (start, stop, status)               | `librc`              |
+| Manage typed resources with access control                     | `libresource`        |
+| Match a candidate to a job                                     | `libskill`           |
+| Mock a config, storage, logger, or gRPC handler in a test      | `libharness`         |
+| Parse a terrain DSL                                            | `libsyntheticgen`    |
+| Parse CLI args and render help                                 | `libcli`             |
+| Process Claude Code traces                                     | `libeval`            |
+| Query an RDF triple graph                                      | `libgraph`           |
+| Read or write .env files                                       | `libsecret`          |
+| Read or write JSONL                                            | `libstorage`         |
+| Register a gRPC service as MCP tools                           | `libmcp`             |
+| Render a markdown sparkline                                    | `libxmr`             |
+| Render a Mustache template with project overrides              | `libtemplate`        |
+| Render colored tables and JSON output                          | `libcli`             |
+| Render markdown as ANSI                                        | `libformat`          |
+| Render markdown as HTML                                        | `libformat`          |
+| Render synthetic data as HTML, Markdown, or YAML               | `libsyntheticrender` |
+| Resolve a resource identifier                                  | `libresource`        |
+| Retry a flaky network call                                     | `libutil`            |
+| Run an agent evaluation loop                                   | `libeval`            |
+| Run an interactive REPL session                                | `librepl`            |
+| Run the synthetic data parse-generate-render-validate pipeline | `libterrain`         |
+| Serialize SHACL shapes                                         | `libgraph`           |
+| Set up SPA routing                                             | `libui`              |
+| Sign a JWT                                                     | `libsecret`          |
+| Store files to local, S3, or Supabase                          | `libstorage`         |
+| Supervise a long-running daemon                                | `libsupervise`       |
+| Use generated protobuf types                                   | `libtype`            |
+| Use reactive UI state                                          | `libui`              |
+| Validate synthetic data integrity                              | `libsyntheticrender` |
+
+<!-- END:needs -->
+
+## Vocabulary
+
+A few recurring terms used in this catalog and across the monorepo.
+
+- **engineering-standard** — the agent-aligned engineering standard data model
+  (disciplines, levels, tracks, capabilities, skills, behaviours, drivers)
+  authored as YAML under [products/map/starter/](../products/map/starter/).
+  Defines what good engineering looks like for the organization.
+- **skill-doc** — the published markdown documentation for a skill or
+  capability, surfaced to agents via `--help` links so they can locate
+  authoritative usage docs without prior context.
+- **MCP** — [Model Context Protocol](https://modelcontextprotocol.io/),
+  Anthropic's standard for exposing tools to LLM agents. `libmcp` bridges gRPC
+  services into MCP tools.
+- **Plan-Do-Study-Act** — the Toyota-Kata improvement loop the Kata Agent Team
+  uses: agents plan, ship, study their traces, and act on findings. See
+  [KATA.md](../KATA.md).
 
 ## Per-library detail
 
@@ -103,11 +215,15 @@ criteria, and a composition example. Open the library directory for depth.
 
 Same shape as every other library here:
 
-- `package.json` — `@forwardimpact/lib<name>`, ESM, `description` and `keywords`
-  follow the pattern in this catalog (capability-led, agent angle baked in).
+- `package.json` — `@forwardimpact/lib<name>`, ESM, with `description`,
+  `keywords`, and `forwardimpact: { capability, needs }` (capability is one of
+  `agent-capability`, `agent-retrieval`, `agent-self-improvement`,
+  `agent-infrastructure`, `foundations`; needs is an array of "I need to…"
+  phrases unique across the monorepo).
 - `README.md` — purpose, key exports, one composition example.
 - `src/` — implementation (no tests in `src`).
 - `test/` — `*.test.js` files, runner-independent (`bun:test` and `node:test`
   both work, see `libharness`).
-- Add a row to the right category in this catalog and update any consuming
-  product or service to import from the new library.
+- Run `bun run lib:capabilities` and `bun run lib:needs` to regenerate the
+  tables above. Update any consuming product or service to import from the new
+  library.

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -126,65 +126,62 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 
 <!-- BEGIN:needs -->
 
-| I need to…                                                     | Library              |
-| -------------------------------------------------------------- | -------------------- |
-| Add a distributed trace span                                   | `libtelemetry`       |
-| Assemble a macOS app bundle                                    | `libmacos`           |
-| Buffer high-volume index writes                                | `libindex`           |
-| Build a gRPC service                                           | `librpc`             |
-| Build a static documentation site                              | `libdoc`             |
-| Build a web app page                                           | `libui`              |
-| Call another gRPC service                                      | `librpc`             |
-| Code-sign a macOS app                                          | `libmacos`           |
-| Compute a stable hash                                          | `libutil`            |
-| Compute an XmR control chart                                   | `libxmr`             |
-| Compute cosine similarity between embeddings                   | `libvector`          |
-| Count LLM tokens                                               | `libutil`            |
-| Derive a job from discipline, level, and track                 | `libskill`           |
-| Detect signals in a time series                                | `libxmr`             |
-| Download and extract a tarball                                 | `libutil`            |
-| Emit a structured log line                                     | `libtelemetry`       |
-| Evaluate an access-control policy                              | `libpolicy`          |
-| Filter records in a JSONL index                                | `libindex`           |
-| Find the project root                                          | `libutil`            |
-| Generate a deterministic entity graph                          | `libsyntheticgen`    |
-| Generate a secret                                              | `libsecret`          |
-| Generate a UUID                                                | `libutil`            |
-| Generate an agent profile                                      | `libskill`           |
-| Generate code from .proto files                                | `libcodegen`         |
-| Generate LLM prose for synthetic data                          | `libsyntheticprose`  |
-| Load a prompt template from disk                               | `libprompt`          |
-| Load application settings from environment                     | `libconfig`          |
-| Manage a service lifecycle (start, stop, status)               | `librc`              |
-| Manage typed resources with access control                     | `libresource`        |
-| Match a candidate to a job                                     | `libskill`           |
-| Mock a config, storage, logger, or gRPC handler in a test      | `libharness`         |
-| Parse a terrain DSL                                            | `libsyntheticgen`    |
-| Parse CLI args and render help                                 | `libcli`             |
-| Process Claude Code traces                                     | `libeval`            |
-| Query an RDF triple graph                                      | `libgraph`           |
-| Read or write .env files                                       | `libsecret`          |
-| Read or write JSONL                                            | `libstorage`         |
-| Register a gRPC service as MCP tools                           | `libmcp`             |
-| Render a markdown sparkline                                    | `libxmr`             |
-| Render a Mustache template with project overrides              | `libtemplate`        |
-| Render colored tables and JSON output                          | `libcli`             |
-| Render markdown as ANSI                                        | `libformat`          |
-| Render markdown as HTML                                        | `libformat`          |
-| Render synthetic data as HTML, Markdown, or YAML               | `libsyntheticrender` |
-| Resolve a resource identifier                                  | `libresource`        |
-| Retry a flaky network call                                     | `libutil`            |
-| Run an agent evaluation loop                                   | `libeval`            |
-| Run an interactive REPL session                                | `librepl`            |
-| Run the synthetic data parse-generate-render-validate pipeline | `libterrain`         |
-| Serialize SHACL shapes                                         | `libgraph`           |
-| Set up SPA routing                                             | `libui`              |
-| Sign a JWT                                                     | `libsecret`          |
-| Store files to local, S3, or Supabase                          | `libstorage`         |
-| Supervise a long-running daemon                                | `libsupervise`       |
-| Use generated protobuf types                                   | `libtype`            |
-| Use reactive UI state                                          | `libui`              |
-| Validate synthetic data integrity                              | `libsyntheticrender` |
+| I need to…                                                                     | Library              |
+| ------------------------------------------------------------------------------ | -------------------- |
+| Add a distributed trace span (OpenTelemetry-style observability)               | `libtelemetry`       |
+| Assemble a macOS app bundle                                                    | `libmacos`           |
+| Buffer high-volume index writes                                                | `libindex`           |
+| Build a gRPC service                                                           | `librpc`             |
+| Build a reactive single-page web app                                           | `libui`              |
+| Build a static documentation site                                              | `libdoc`             |
+| Call another gRPC service                                                      | `librpc`             |
+| Chart a metric with XmR signal detection                                       | `libxmr`             |
+| Code-sign a macOS app                                                          | `libmacos`           |
+| Compute a stable hash (SHA-256 checksum)                                       | `libutil`            |
+| Compute cosine similarity between embeddings                                   | `libvector`          |
+| Control a service's start, stop, and status                                    | `librc`              |
+| Count LLM tokens                                                               | `libutil`            |
+| Derive a role definition from a competency matrix (discipline × level × track) | `libskill`           |
+| Download and extract a tarball                                                 | `libutil`            |
+| Drive an LLM agent through a scripted run and capture its trace                | `libeval`            |
+| Emit a structured log line                                                     | `libtelemetry`       |
+| Evaluate an access-control policy                                              | `libpolicy`          |
+| Filter records in a JSONL index                                                | `libindex`           |
+| Find the project root                                                          | `libutil`            |
+| Generate a deterministic entity graph                                          | `libsyntheticgen`    |
+| Generate a secret (random token or API key)                                    | `libsecret`          |
+| Generate a UUID                                                                | `libutil`            |
+| Generate an agent role profile from discipline, level, and track               | `libskill`           |
+| Generate code from .proto files                                                | `libcodegen`         |
+| Generate LLM prose for synthetic data                                          | `libsyntheticprose`  |
+| Import shared protobuf types and namespaces                                    | `libtype`            |
+| Load a prompt template from disk                                               | `libprompt`          |
+| Load application settings (config) from environment                            | `libconfig`          |
+| Manage typed resources with access control                                     | `libresource`        |
+| Mock a config, storage, logger, or gRPC handler in a test                      | `libharness`         |
+| Parse a terrain DSL                                                            | `libsyntheticgen`    |
+| Parse and query Claude Code trace NDJSON files                                 | `libeval`            |
+| Parse CLI args and render help                                                 | `libcli`             |
+| Query an RDF triple graph                                                      | `libgraph`           |
+| Read or write .env (dotenv) files                                              | `libsecret`          |
+| Read or write JSONL                                                            | `libstorage`         |
+| Register a gRPC service as MCP tools                                           | `libmcp`             |
+| Render a markdown sparkline                                                    | `libxmr`             |
+| Render a Mustache template with project overrides                              | `libtemplate`        |
+| Render colored tables and JSON output                                          | `libcli`             |
+| Render markdown as ANSI                                                        | `libformat`          |
+| Render markdown as HTML                                                        | `libformat`          |
+| Render synthetic data as HTML, Markdown, or YAML                               | `libsyntheticrender` |
+| Resolve a typed resource by URN                                                | `libresource`        |
+| Retry a flaky network call                                                     | `libutil`            |
+| Run an interactive REPL session                                                | `librepl`            |
+| Run the end-to-end synthetic-data pipeline from a terrain file                 | `libterrain`         |
+| Score a candidate's skills against a job's required skill markers              | `libskill`           |
+| Serialize SHACL shapes                                                         | `libgraph`           |
+| Sign a JWT                                                                     | `libsecret`          |
+| Store files to local, S3, or Supabase                                          | `libstorage`         |
+| Supervise a long-running daemon                                                | `libsupervise`       |
+| Validate synthetic data integrity                                              | `libsyntheticrender` |
 
 <!-- END:needs -->
 

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -1,0 +1,113 @@
+# Shared Libraries
+
+The 32 packages under `libraries/` are the shared building blocks for every
+product, service, website, and skill in the monorepo. They are designed for
+agentic systems: agent-friendly CLIs and output formats, retrieval primitives
+that surface rich grounded context, evaluation tooling that closes the
+self-improvement loop, and service infrastructure with knobs agents can read and
+tune via JSON.
+
+## Mandate
+
+When building a product, service, website, or script, you **must** check this
+catalog before writing a generic capability. If a library here covers it, use
+the library. If not, note that in the commit or plan so the next contributor
+does not re-search.
+
+This rule lives next to the other invariants in
+[CONTRIBUTING.md](../CONTRIBUTING.md#read-do).
+
+## Catalog
+
+Five capability categories. Every library appears in exactly one.
+
+### Agent Capability
+
+What the agent surface looks like — entry points, voice, skill data,
+human-facing output that agents produce.
+
+| Library         | Capability                                                                                                             |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **libcli**      | Agent-friendly CLIs: argument parsing, grep-friendly help output, JSON mode, and skill-doc links surfaced in `--help`. |
+| **librepl**     | Agent-friendly interactive shells with command dispatch and skill-doc links.                                           |
+| **libprompt**   | Agent-authored prompt templates loaded from `.prompt.md` files with Mustache substitution.                             |
+| **libskill**    | Derive jobs, skill matrices, and agent profiles from engineering-standard data shared by humans and agents.            |
+| **libformat**   | Render markdown to ANSI for agent-friendly terminal output or HTML for browsers.                                       |
+| **libui**       | Functional web UI primitives — DOM helpers, SPA routing, reactive state — for products agents build.                   |
+| **libdoc**      | Static documentation sites from markdown folders with front matter and navigation.                                     |
+| **libtemplate** | Mustache template loader with project-level override directories for agent-rendered content.                           |
+
+### Agent Retrieval
+
+How agents fetch and shape context. The stack runs from raw bytes (`libstorage`)
+through typed records (`libresource`) to schema-aware graph and vector
+inference.
+
+| Library         | Capability                                                                                               |
+| --------------- | -------------------------------------------------------------------------------------------------------- |
+| **libstorage**  | Pluggable file storage (local, S3, Supabase) for context agents fetch and produce.                       |
+| **libindex**    | JSONL-backed indexes with filtering and buffered writes — fast lookup of context chunks.                 |
+| **libresource** | Typed resources with identifiers, access control, and rich RDF-friendly context chunks agents ground in. |
+| **libpolicy**   | Access-control policy evaluation so agents only see context they are authorized for.                     |
+| **libgraph**    | RDF triple store with named ontologies and SHACL serialization — schema-aware graph inference.           |
+| **libvector**   | Vector dot-product scoring for cosine-similarity retrieval over agent embeddings.                        |
+
+### Agent Self-Improvement
+
+Tooling that closes the Plan-Do-Study-Act loop: evaluate agent runs, generate
+synthetic test data so evals are deterministic, and chart process behavior so
+signal is distinguished from noise.
+
+| Library                | Capability                                                                                                |
+| ---------------------- | --------------------------------------------------------------------------------------------------------- |
+| **libeval**            | Agent evaluation — collect Claude Code traces, run agent loops, supervise multi-step workflows.           |
+| **libsyntheticgen**    | DSL parser and deterministic entity graph generator for repeatable agent eval fixtures.                   |
+| **libsyntheticprose**  | LLM-generated prose and engineering-standard YAML for synthetic agent evaluation content.                 |
+| **libsyntheticrender** | Multi-format rendering and validation of synthetic agent evaluation data (HTML, Markdown, YAML).          |
+| **libterrain**         | Full parse-generate-render-validate pipeline for synthetic agent training and evaluation data.            |
+| **libxmr**             | Agent-friendly XmR control charts: markdown sparklines and signal detection over time-series CSV metrics. |
+
+### Agent Infrastructure
+
+How agent services run — protocol, types, configuration, observability, process
+supervision, and the bridge that exposes gRPC services as MCP tools.
+
+| Library          | Capability                                                                                         |
+| ---------------- | -------------------------------------------------------------------------------------------------- |
+| **librpc**       | gRPC server and client framework — how agent services talk to each other.                          |
+| **libtype**      | Generated protobuf types and namespaces shared across agent-facing services.                       |
+| **libconfig**    | Environment-aware configuration loading for services, CLIs, and extensions.                        |
+| **libtelemetry** | Structured RFC 5424 logging and trace spans for observable agent operations.                       |
+| **libsupervise** | Process supervision with restart policies, log rotation, and JSON config agents can read and tune. |
+| **librc**        | Agent-friendly service management — start, stop, status via Unix sockets controlled by svscan.     |
+| **libharness**   | Shared mocks and test fixtures so every agent service tests the same way.                          |
+| **libmcp**       | Config-driven gRPC-to-MCP tool registration — agents see protobuf services as MCP tools.           |
+
+### Foundations
+
+Cross-cutting primitives and platform-specific helpers used by all of the above.
+
+| Library        | Capability                                                                                                     |
+| -------------- | -------------------------------------------------------------------------------------------------------------- |
+| **libutil**    | Cross-cutting utilities: retry with backoff, hashing, token counting, project-root finder, tarball downloader. |
+| **libsecret**  | Secret generation, JWT signing, and `.env` file management for services and CLIs.                              |
+| **libcodegen** | Protobuf code generation — produces the types and clients consumed by `libtype` and `librpc`.                  |
+| **libmacos**   | macOS bundle assembly, code signing, and TCC responsibility helpers — desktop delivery for agent products.     |
+
+## Per-library detail
+
+Every library has a `README.md` that documents its key exports, decision
+criteria, and a composition example. Open the library directory for depth.
+
+## Adding a library
+
+Same shape as every other library here:
+
+- `package.json` — `@forwardimpact/lib<name>`, ESM, `description` and `keywords`
+  follow the pattern in this catalog (capability-led, agent angle baked in).
+- `README.md` — purpose, key exports, one composition example.
+- `src/` — implementation (no tests in `src`).
+- `test/` — `*.test.js` files, runner-independent (`bun:test` and `node:test`
+  both work, see `libharness`).
+- Add a row to the right category in this catalog and update any consuming
+  product or service to import from the new library.

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -72,16 +72,16 @@ signal is distinguished from noise.
 How agent services run — protocol, types, configuration, observability, process
 supervision, and the bridge that exposes gRPC services as MCP tools.
 
-| Library          | Capability                                                                                         |
-| ---------------- | -------------------------------------------------------------------------------------------------- |
-| **librpc**       | gRPC server and client framework — how agent services talk to each other.                          |
-| **libtype**      | Generated protobuf types and namespaces shared across agent-facing services.                       |
-| **libconfig**    | Environment-aware configuration loading for services, CLIs, and extensions.                        |
-| **libtelemetry** | Structured RFC 5424 logging and trace spans for observable agent operations.                       |
-| **libsupervise** | Process supervision with restart policies, log rotation, and JSON config agents can read and tune. |
-| **librc**        | Agent-friendly service management — start, stop, status via Unix sockets controlled by svscan.     |
-| **libharness**   | Shared mocks and test fixtures so every agent service tests the same way.                          |
-| **libmcp**       | Config-driven gRPC-to-MCP tool registration — agents see protobuf services as MCP tools.           |
+| Library          | Capability                                                                                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **librpc**       | gRPC server and client framework — how agent services talk to each other.                                                                                 |
+| **libtype**      | Generated protobuf types and namespaces shared across agent-facing services.                                                                              |
+| **libcodegen**   | Protobuf code generation — produces the types and clients consumed by `libtype` and `librpc`.                                                             |
+| **libconfig**    | Environment-aware loading of application settings for services, CLIs, and extensions.                                                                     |
+| **libtelemetry** | Structured RFC 5424 logging and trace spans for observable agent operations.                                                                              |
+| **libsupervise** | Process supervision (restart policies, log rotation) driven by JSON daemon manifests agents can read and tune; built on `libconfig` for settings loading. |
+| **librc**        | Agent-friendly service management — start, stop, status via Unix sockets controlled by svscan.                                                            |
+| **libmcp**       | Config-driven gRPC-to-MCP tool registration — agents see protobuf services as MCP tools.                                                                  |
 
 ### Foundations
 
@@ -91,7 +91,7 @@ Cross-cutting primitives and platform-specific helpers used by all of the above.
 | -------------- | -------------------------------------------------------------------------------------------------------------- |
 | **libutil**    | Cross-cutting utilities: retry with backoff, hashing, token counting, project-root finder, tarball downloader. |
 | **libsecret**  | Secret generation, JWT signing, and `.env` file management for services and CLIs.                              |
-| **libcodegen** | Protobuf code generation — produces the types and clients consumed by `libtype` and `librpc`.                  |
+| **libharness** | Shared mocks and test fixtures so every library and service tests the same way.                                |
 | **libmacos**   | macOS bundle assembly, code signing, and TCC responsibility helpers — desktop delivery for agent products.     |
 
 ## Per-library detail

--- a/libraries/libcli/package.json
+++ b/libraries/libcli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libcli",
   "version": "0.1.6",
-  "description": "Agent-friendly CLIs: argument parsing, grep-friendly help output, JSON mode, and skill-doc links surfaced in --help.",
+  "description": "Agent-friendly CLIs: argument parsing, grep-friendly help output, JSON mode, and skill-doc links surfaced in `--help`.",
   "keywords": [
     "cli",
     "agent",
@@ -9,6 +9,13 @@
     "help",
     "grep"
   ],
+  "forwardimpact": {
+    "capability": "agent-capability",
+    "needs": [
+      "Parse CLI args and render help",
+      "Render colored tables and JSON output"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libcli/package.json
+++ b/libraries/libcli/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libcli",
   "version": "0.1.6",
-  "description": "Shared CLI infrastructure for the Forward Impact monorepo",
+  "description": "Agent-friendly CLIs: argument parsing, grep-friendly help output, JSON mode, and skill-doc links surfaced in --help.",
+  "keywords": [
+    "cli",
+    "agent",
+    "arguments",
+    "help",
+    "grep"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libcli/package.json
+++ b/libraries/libcli/package.json
@@ -13,7 +13,8 @@
     "capability": "agent-capability",
     "needs": [
       "Parse CLI args and render help",
-      "Render colored tables and JSON output"
+      "Render colored tables and JSON output",
+      "Surface skill-doc links in CLI --help output"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libcodegen/package.json
+++ b/libraries/libcodegen/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libcodegen",
   "version": "0.1.47",
-  "description": "Protocol Buffer code generation utilities for Guide",
+  "description": "Protobuf code generation — produces the types and clients consumed by libtype and librpc.",
+  "keywords": [
+    "codegen",
+    "protobuf",
+    "build-tool",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libcodegen/package.json
+++ b/libraries/libcodegen/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@forwardimpact/libcodegen",
   "version": "0.1.47",
-  "description": "Protobuf code generation — produces the types and clients consumed by libtype and librpc.",
+  "description": "Protobuf code generation — produces the types and clients consumed by `libtype` and `librpc`.",
   "keywords": [
     "codegen",
     "protobuf",
     "build-tool",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-infrastructure",
+    "needs": [
+      "Generate code from .proto files"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libconfig/package.json
+++ b/libraries/libconfig/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@forwardimpact/libconfig",
   "version": "0.1.71",
-  "description": "Configuration management and environment resolution for Guide",
+  "description": "Environment-aware configuration loading for services, CLIs, and extensions.",
+  "keywords": [
+    "config",
+    "environment",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libconfig/package.json
+++ b/libraries/libconfig/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libconfig",
   "version": "0.1.71",
-  "description": "Environment-aware configuration loading for services, CLIs, and extensions.",
+  "description": "Environment-aware loading of application settings for services, CLIs, and extensions.",
   "keywords": [
     "config",
     "environment",

--- a/libraries/libconfig/package.json
+++ b/libraries/libconfig/package.json
@@ -10,7 +10,7 @@
   "forwardimpact": {
     "capability": "agent-infrastructure",
     "needs": [
-      "Load application settings from environment"
+      "Load application settings (config) from environment"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libconfig/package.json
+++ b/libraries/libconfig/package.json
@@ -7,6 +7,12 @@
     "environment",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-infrastructure",
+    "needs": [
+      "Load application settings from environment"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libdoc/package.json
+++ b/libraries/libdoc/package.json
@@ -8,6 +8,12 @@
     "markdown",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-capability",
+    "needs": [
+      "Build a static documentation site"
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libdoc/package.json
+++ b/libraries/libdoc/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libdoc",
   "version": "0.2.21",
-  "description": "Documentation build and serve tools for static site generation from Markdown",
+  "description": "Static documentation sites from markdown folders with front matter and navigation.",
+  "keywords": [
+    "docs",
+    "static-site",
+    "markdown",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libeval/package.json
+++ b/libraries/libeval/package.json
@@ -13,7 +13,8 @@
     "capability": "agent-self-improvement",
     "needs": [
       "Parse and query Claude Code trace NDJSON files",
-      "Drive an LLM agent through a scripted run and capture its trace"
+      "Drive an LLM agent through a scripted run and capture its trace",
+      "Supervise a multi-step or multi-agent workflow"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libeval/package.json
+++ b/libraries/libeval/package.json
@@ -12,8 +12,8 @@
   "forwardimpact": {
     "capability": "agent-self-improvement",
     "needs": [
-      "Process Claude Code traces",
-      "Run an agent evaluation loop"
+      "Parse and query Claude Code trace NDJSON files",
+      "Drive an LLM agent through a scripted run and capture its trace"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libeval/package.json
+++ b/libraries/libeval/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libeval",
   "version": "0.1.25",
-  "description": "Process Claude Code stream-json output into structured traces",
+  "description": "Agent evaluation: collect Claude Code traces, run agent loops, supervise multi-step workflows.",
+  "keywords": [
+    "eval",
+    "agent",
+    "trace",
+    "claude-code",
+    "supervisor"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libeval/package.json
+++ b/libraries/libeval/package.json
@@ -9,6 +9,13 @@
     "claude-code",
     "supervisor"
   ],
+  "forwardimpact": {
+    "capability": "agent-self-improvement",
+    "needs": [
+      "Process Claude Code traces",
+      "Run an agent evaluation loop"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libformat/package.json
+++ b/libraries/libformat/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libformat",
   "version": "0.1.9",
-  "description": "Markdown formatting and text processing utilities",
+  "description": "Render markdown to ANSI for agent-friendly terminal output or HTML for browsers.",
+  "keywords": [
+    "markdown",
+    "html",
+    "ansi",
+    "agent",
+    "format"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libformat/package.json
+++ b/libraries/libformat/package.json
@@ -9,6 +9,13 @@
     "agent",
     "format"
   ],
+  "forwardimpact": {
+    "capability": "agent-capability",
+    "needs": [
+      "Render markdown as ANSI",
+      "Render markdown as HTML"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libgraph/package.json
+++ b/libraries/libgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libgraph",
   "version": "0.1.67",
-  "description": "RDF graph index and processing utilities",
+  "description": "RDF triple store with named ontologies and SHACL serialization — schema-aware graph inference for agents.",
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",
@@ -31,7 +31,9 @@
   "keywords": [
     "rdf",
     "graph",
-    "linked-data"
+    "ontology",
+    "linked-data",
+    "agent"
   ],
   "dependencies": {
     "@forwardimpact/libcli": "^0.1.0",

--- a/libraries/libgraph/package.json
+++ b/libraries/libgraph/package.json
@@ -35,6 +35,13 @@
     "linked-data",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-retrieval",
+    "needs": [
+      "Query an RDF triple graph",
+      "Serialize SHACL shapes"
+    ]
+  },
   "dependencies": {
     "@forwardimpact/libcli": "^0.1.0",
     "@forwardimpact/libindex": "^0.1.27",

--- a/libraries/libharness/package.json
+++ b/libraries/libharness/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libharness",
   "version": "0.1.17",
-  "description": "Shared mocks and test fixtures so every agent service tests the same way.",
+  "description": "Shared mocks and test fixtures so every library and service tests the same way.",
   "keywords": [
     "test",
     "mock",

--- a/libraries/libharness/package.json
+++ b/libraries/libharness/package.json
@@ -9,6 +9,12 @@
     "harness",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "foundations",
+    "needs": [
+      "Mock a config, storage, logger, or gRPC handler in a test"
+    ]
+  },
   "type": "module",
   "main": "./src/index.js",
   "exports": {

--- a/libraries/libharness/package.json
+++ b/libraries/libharness/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libharness",
   "version": "0.1.17",
-  "description": "Shared test harness and mock infrastructure for the Forward Impact monorepo",
+  "description": "Shared mocks and test fixtures so every agent service tests the same way.",
+  "keywords": [
+    "test",
+    "mock",
+    "fixture",
+    "harness",
+    "agent"
+  ],
   "type": "module",
   "main": "./src/index.js",
   "exports": {
@@ -16,12 +23,6 @@
   "scripts": {
     "test": "bun test test/*.test.js"
   },
-  "keywords": [
-    "test",
-    "mock",
-    "fixture",
-    "harness"
-  ],
   "author": "Forward Impact Team",
   "license": "MIT",
   "peerDependencies": {

--- a/libraries/libindex/package.json
+++ b/libraries/libindex/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libindex",
   "version": "0.1.35",
-  "description": "Base index class for storage-backed indexes in Guide",
+  "description": "JSONL-backed indexes with filtering and buffered writes — fast lookup of agent context chunks.",
+  "keywords": [
+    "index",
+    "jsonl",
+    "retrieval",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libindex/package.json
+++ b/libraries/libindex/package.json
@@ -8,6 +8,13 @@
     "retrieval",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-retrieval",
+    "needs": [
+      "Filter records in a JSONL index",
+      "Buffer high-volume index writes"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libmacos/package.json
+++ b/libraries/libmacos/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libmacos",
   "version": "0.1.0",
-  "description": "macOS bundle assembly, code signing, and TCC responsibility helpers",
+  "description": "macOS bundle assembly, code signing, and TCC responsibility helpers — desktop delivery for agent products.",
+  "keywords": [
+    "macos",
+    "bundle",
+    "codesign",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libmacos/package.json
+++ b/libraries/libmacos/package.json
@@ -1,13 +1,20 @@
 {
   "name": "@forwardimpact/libmacos",
   "version": "0.1.0",
-  "description": "macOS bundle assembly, code signing, and TCC responsibility helpers — desktop delivery for agent products.",
+  "description": "macOS bundle assembly, code signing, and OS permission entitlement helpers — desktop delivery for agent products.",
   "keywords": [
     "macos",
     "bundle",
     "codesign",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "foundations",
+    "needs": [
+      "Assemble a macOS app bundle",
+      "Code-sign a macOS app"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libmacos/package.json
+++ b/libraries/libmacos/package.json
@@ -12,7 +12,8 @@
     "capability": "foundations",
     "needs": [
       "Assemble a macOS app bundle",
-      "Code-sign a macOS app"
+      "Code-sign a macOS app",
+      "Declare macOS permission entitlements for an app"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libmcp/package.json
+++ b/libraries/libmcp/package.json
@@ -8,6 +8,12 @@
     "tool",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-infrastructure",
+    "needs": [
+      "Register a gRPC service as MCP tools"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libmcp/package.json
+++ b/libraries/libmcp/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libmcp",
   "version": "0.1.4",
-  "description": "MCP tool registry — config-driven gRPC-to-MCP tool registration",
+  "description": "Config-driven gRPC-to-MCP tool registration — agents see protobuf services as MCP tools.",
+  "keywords": [
+    "mcp",
+    "grpc",
+    "tool",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libpolicy/package.json
+++ b/libraries/libpolicy/package.json
@@ -8,6 +8,12 @@
     "access-control",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-retrieval",
+    "needs": [
+      "Evaluate an access-control policy"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libpolicy/package.json
+++ b/libraries/libpolicy/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libpolicy",
   "version": "0.1.59",
-  "description": "Policy engine foundation for Guide",
+  "description": "Access-control policy evaluation — agents see only context they are authorized for.",
+  "keywords": [
+    "policy",
+    "authorization",
+    "access-control",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libprompt/package.json
+++ b/libraries/libprompt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libprompt",
   "version": "0.1.6",
-  "description": "Agent-authored prompt templates loaded from .prompt.md files with Mustache substitution.",
+  "description": "Agent-authored prompt templates loaded from `.prompt.md` files with Mustache substitution.",
   "keywords": [
     "prompt",
     "template",
@@ -9,6 +9,12 @@
     "agent",
     "llm"
   ],
+  "forwardimpact": {
+    "capability": "agent-capability",
+    "needs": [
+      "Load a prompt template from disk"
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libprompt/package.json
+++ b/libraries/libprompt/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libprompt",
   "version": "0.1.6",
-  "description": "Prompt template loading and rendering with Mustache",
+  "description": "Agent-authored prompt templates loaded from .prompt.md files with Mustache substitution.",
+  "keywords": [
+    "prompt",
+    "template",
+    "mustache",
+    "agent",
+    "llm"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libprompt/package.json
+++ b/libraries/libprompt/package.json
@@ -12,7 +12,8 @@
   "forwardimpact": {
     "capability": "agent-capability",
     "needs": [
-      "Load a prompt template from disk"
+      "Load a prompt template from disk",
+      "Render a prompt template with variable substitution"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/librc/package.json
+++ b/libraries/librc/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/librc",
   "version": "0.1.24",
-  "description": "Service manager for Forward Impact",
+  "description": "Agent-friendly service management: start, stop, status via Unix sockets controlled by svscan.",
+  "keywords": [
+    "service",
+    "lifecycle",
+    "svscan",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/librc/package.json
+++ b/libraries/librc/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@forwardimpact/librc",
   "version": "0.1.24",
-  "description": "Agent-friendly service management: start, stop, status via Unix sockets controlled by svscan.",
+  "description": "Agent-friendly service lifecycle management: start, stop, and status of long-running services via a Unix socket interface.",
   "keywords": [
     "service",
     "lifecycle",
     "svscan",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-infrastructure",
+    "needs": [
+      "Manage a service lifecycle (start, stop, status)"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/librc/package.json
+++ b/libraries/librc/package.json
@@ -11,7 +11,7 @@
   "forwardimpact": {
     "capability": "agent-infrastructure",
     "needs": [
-      "Manage a service lifecycle (start, stop, status)"
+      "Control a service's start, stop, and status"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/librepl/package.json
+++ b/libraries/librepl/package.json
@@ -11,7 +11,8 @@
   "forwardimpact": {
     "capability": "agent-capability",
     "needs": [
-      "Run an interactive REPL session"
+      "Run an interactive REPL session",
+      "Surface skill-doc links in REPL --help output"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/librepl/package.json
+++ b/libraries/librepl/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@forwardimpact/librepl",
   "version": "0.1.9",
-  "description": "Agent-friendly interactive REPL with command dispatch and skill-doc links surfaced in --help.",
+  "description": "Agent-friendly interactive REPL with command dispatch and skill-doc links surfaced in `--help`.",
   "keywords": [
     "repl",
     "cli",
     "agent",
     "interactive"
   ],
+  "forwardimpact": {
+    "capability": "agent-capability",
+    "needs": [
+      "Run an interactive REPL session"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/librepl/package.json
+++ b/libraries/librepl/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/librepl",
   "version": "0.1.9",
-  "description": "Interactive REPL utilities and command-line interfaces for Guide",
+  "description": "Agent-friendly interactive REPL with command dispatch and skill-doc links surfaced in --help.",
+  "keywords": [
+    "repl",
+    "cli",
+    "agent",
+    "interactive"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libresource/package.json
+++ b/libraries/libresource/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libresource",
   "version": "0.1.107",
-  "description": "Resource management for Guide",
+  "description": "Typed resources with identifiers, access control, and rich RDF-friendly context chunks for agent grounding.",
+  "keywords": [
+    "resource",
+    "rdf",
+    "access-control",
+    "agent",
+    "retrieval"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libresource/package.json
+++ b/libraries/libresource/package.json
@@ -13,7 +13,7 @@
     "capability": "agent-retrieval",
     "needs": [
       "Manage typed resources with access control",
-      "Resolve a resource identifier"
+      "Resolve a typed resource by URN"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libresource/package.json
+++ b/libraries/libresource/package.json
@@ -9,6 +9,13 @@
     "agent",
     "retrieval"
   ],
+  "forwardimpact": {
+    "capability": "agent-retrieval",
+    "needs": [
+      "Manage typed resources with access control",
+      "Resolve a resource identifier"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/librpc/package.json
+++ b/libraries/librpc/package.json
@@ -9,6 +9,13 @@
     "client",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-infrastructure",
+    "needs": [
+      "Build a gRPC service",
+      "Call another gRPC service"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/librpc/package.json
+++ b/libraries/librpc/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/librpc",
   "version": "0.1.95",
-  "description": "gRPC framework and utilities for Guide",
+  "description": "gRPC server and client framework — how agent services talk to each other.",
+  "keywords": [
+    "grpc",
+    "rpc",
+    "server",
+    "client",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libsecret/package.json
+++ b/libraries/libsecret/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libsecret",
   "version": "0.1.11",
-  "description": "Secret generation, JWT signing, and .env file management for agent services and CLIs.",
+  "description": "Secret generation, JWT signing, and `.env` file management for agent services and CLIs.",
   "keywords": [
     "secret",
     "jwt",
@@ -9,6 +9,14 @@
     "credential",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "foundations",
+    "needs": [
+      "Generate a secret",
+      "Sign a JWT",
+      "Read or write .env files"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libsecret/package.json
+++ b/libraries/libsecret/package.json
@@ -12,9 +12,9 @@
   "forwardimpact": {
     "capability": "foundations",
     "needs": [
-      "Generate a secret",
+      "Generate a secret (random token or API key)",
       "Sign a JWT",
-      "Read or write .env files"
+      "Read or write .env (dotenv) files"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libsecret/package.json
+++ b/libraries/libsecret/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libsecret",
   "version": "0.1.11",
-  "description": "Secret generation and environment file utilities for Guide",
+  "description": "Secret generation, JWT signing, and .env file management for agent services and CLIs.",
+  "keywords": [
+    "secret",
+    "jwt",
+    "env",
+    "credential",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libskill/package.json
+++ b/libraries/libskill/package.json
@@ -9,6 +9,14 @@
     "profile",
     "standard"
   ],
+  "forwardimpact": {
+    "capability": "agent-capability",
+    "needs": [
+      "Derive a job from discipline, level, and track",
+      "Generate an agent profile",
+      "Match a candidate to a job"
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libskill/package.json
+++ b/libraries/libskill/package.json
@@ -12,9 +12,9 @@
   "forwardimpact": {
     "capability": "agent-capability",
     "needs": [
-      "Derive a job from discipline, level, and track",
-      "Generate an agent profile",
-      "Match a candidate to a job"
+      "Derive a role definition from a competency matrix (discipline × level × track)",
+      "Generate an agent role profile from discipline, level, and track",
+      "Score a candidate's skills against a job's required skill markers"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libskill/package.json
+++ b/libraries/libskill/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libskill",
   "version": "5.2.1",
-  "description": "Derivation engine for roles, skills, and agent team profiles",
+  "description": "Derive jobs, skill matrices, and agent profiles from engineering-standard data shared by humans and agents.",
+  "keywords": [
+    "skill",
+    "agent",
+    "job",
+    "profile",
+    "standard"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libstorage/package.json
+++ b/libraries/libstorage/package.json
@@ -9,6 +9,13 @@
     "agent",
     "retrieval"
   ],
+  "forwardimpact": {
+    "capability": "agent-retrieval",
+    "needs": [
+      "Store files to local, S3, or Supabase",
+      "Read or write JSONL"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libstorage/package.json
+++ b/libraries/libstorage/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libstorage",
   "version": "0.1.70",
-  "description": "Storage abstraction layer for Guide",
+  "description": "Pluggable file storage (local, S3, Supabase) for context agents fetch and produce at runtime.",
+  "keywords": [
+    "storage",
+    "s3",
+    "supabase",
+    "agent",
+    "retrieval"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libsupervise/package.json
+++ b/libraries/libsupervise/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@forwardimpact/libsupervise",
   "version": "0.1.20",
-  "description": "Process supervision (restart policies, log rotation) driven by JSON daemon manifests agents can read and tune; built on libconfig for settings loading.",
+  "description": "Process supervision (restart policies, log rotation) driven by JSON daemon manifests agents can read and tune; built on `libconfig` for settings loading.",
   "keywords": [
     "supervisor",
     "process",
     "daemon",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-infrastructure",
+    "needs": [
+      "Supervise a long-running daemon"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libsupervise/package.json
+++ b/libraries/libsupervise/package.json
@@ -11,7 +11,8 @@
   "forwardimpact": {
     "capability": "agent-infrastructure",
     "needs": [
-      "Supervise a long-running daemon"
+      "Supervise a long-running daemon",
+      "Configure restart policies and log rotation for a daemon manifest"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libsupervise/package.json
+++ b/libraries/libsupervise/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libsupervise",
   "version": "0.1.20",
-  "description": "Process supervision with restart policies, log rotation, and JSON config agents can read and tune.",
+  "description": "Process supervision (restart policies, log rotation) driven by JSON daemon manifests agents can read and tune; built on libconfig for settings loading.",
   "keywords": [
     "supervisor",
     "process",

--- a/libraries/libsupervise/package.json
+++ b/libraries/libsupervise/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libsupervise",
   "version": "0.1.20",
-  "description": "Process supervision for Forward Impact services",
+  "description": "Process supervision with restart policies, log rotation, and JSON config agents can read and tune.",
+  "keywords": [
+    "supervisor",
+    "process",
+    "daemon",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libsyntheticgen/package.json
+++ b/libraries/libsyntheticgen/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libsyntheticgen",
   "version": "0.1.14",
-  "description": "DSL parsing and deterministic entity generation for synthetic data",
+  "description": "DSL parser and deterministic entity graph generator for repeatable agent eval fixtures.",
+  "keywords": [
+    "synthetic",
+    "dsl",
+    "entity",
+    "agent",
+    "eval"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libsyntheticgen/package.json
+++ b/libraries/libsyntheticgen/package.json
@@ -9,6 +9,13 @@
     "agent",
     "eval"
   ],
+  "forwardimpact": {
+    "capability": "agent-self-improvement",
+    "needs": [
+      "Parse a terrain DSL",
+      "Generate a deterministic entity graph"
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libsyntheticprose/package.json
+++ b/libraries/libsyntheticprose/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libsyntheticprose",
   "version": "0.1.18",
-  "description": "LLM-based prose and pathway generation for synthetic data",
+  "description": "LLM-generated prose and engineering-standard YAML for synthetic agent evaluation content.",
+  "keywords": [
+    "synthetic",
+    "prose",
+    "llm",
+    "agent",
+    "eval"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libsyntheticprose/package.json
+++ b/libraries/libsyntheticprose/package.json
@@ -9,6 +9,12 @@
     "agent",
     "eval"
   ],
+  "forwardimpact": {
+    "capability": "agent-self-improvement",
+    "needs": [
+      "Generate LLM prose for synthetic data"
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libsyntheticrender/package.json
+++ b/libraries/libsyntheticrender/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libsyntheticrender",
   "version": "0.1.17",
-  "description": "Multi-format rendering, validation, and formatting for synthetic data",
+  "description": "Multi-format rendering and validation of synthetic agent evaluation data (HTML, Markdown, YAML).",
+  "keywords": [
+    "synthetic",
+    "render",
+    "validation",
+    "agent",
+    "eval"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libsyntheticrender/package.json
+++ b/libraries/libsyntheticrender/package.json
@@ -9,6 +9,13 @@
     "agent",
     "eval"
   ],
+  "forwardimpact": {
+    "capability": "agent-self-improvement",
+    "needs": [
+      "Render synthetic data as HTML, Markdown, or YAML",
+      "Validate synthetic data integrity"
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libtelemetry/package.json
+++ b/libraries/libtelemetry/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libtelemetry",
   "version": "0.1.37",
-  "description": "OpenTelemetry-based tracing library for Guide microservices",
+  "description": "Structured RFC 5424 logging and trace spans for observable agent operations.",
+  "keywords": [
+    "logger",
+    "tracing",
+    "telemetry",
+    "agent",
+    "observability"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libtelemetry/package.json
+++ b/libraries/libtelemetry/package.json
@@ -13,7 +13,7 @@
     "capability": "agent-infrastructure",
     "needs": [
       "Emit a structured log line",
-      "Add a distributed trace span"
+      "Add a distributed trace span (OpenTelemetry-style observability)"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libtelemetry/package.json
+++ b/libraries/libtelemetry/package.json
@@ -9,6 +9,13 @@
     "agent",
     "observability"
   ],
+  "forwardimpact": {
+    "capability": "agent-infrastructure",
+    "needs": [
+      "Emit a structured log line",
+      "Add a distributed trace span"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libtemplate/package.json
+++ b/libraries/libtemplate/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libtemplate",
   "version": "0.2.7",
-  "description": "Mustache template loading with data directory fallback",
+  "description": "Mustache template loader with project-level override directories for agent-rendered content.",
+  "keywords": [
+    "template",
+    "mustache",
+    "render",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libtemplate/package.json
+++ b/libraries/libtemplate/package.json
@@ -8,6 +8,12 @@
     "render",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-capability",
+    "needs": [
+      "Render a Mustache template with project overrides"
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libterrain/package.json
+++ b/libraries/libterrain/package.json
@@ -8,6 +8,12 @@
     "agent",
     "eval"
   ],
+  "forwardimpact": {
+    "capability": "agent-self-improvement",
+    "needs": [
+      "Run the synthetic data parse-generate-render-validate pipeline"
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libterrain/package.json
+++ b/libraries/libterrain/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libterrain",
   "version": "0.1.20",
-  "description": "Synthetic terrain DSL and generation engine",
+  "description": "Full parse-generate-render-validate pipeline for synthetic agent training and evaluation data.",
+  "keywords": [
+    "synthetic",
+    "pipeline",
+    "agent",
+    "eval"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libterrain/package.json
+++ b/libraries/libterrain/package.json
@@ -11,7 +11,7 @@
   "forwardimpact": {
     "capability": "agent-self-improvement",
     "needs": [
-      "Run the synthetic data parse-generate-render-validate pipeline"
+      "Run the end-to-end synthetic-data pipeline from a terrain file"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libtype/package.json
+++ b/libraries/libtype/package.json
@@ -11,7 +11,7 @@
   "forwardimpact": {
     "capability": "agent-infrastructure",
     "needs": [
-      "Use generated protobuf types"
+      "Import shared protobuf types and namespaces"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libtype/package.json
+++ b/libraries/libtype/package.json
@@ -8,6 +8,12 @@
     "schema",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-infrastructure",
+    "needs": [
+      "Use generated protobuf types"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libtype/package.json
+++ b/libraries/libtype/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@forwardimpact/libtype",
   "version": "0.1.72",
-  "description": "Shared type definitions and data models for Guide",
+  "description": "Generated protobuf types and namespaces shared across agent-facing services.",
+  "keywords": [
+    "type",
+    "protobuf",
+    "schema",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -9,6 +9,14 @@
     "router",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "agent-capability",
+    "needs": [
+      "Build a web app page",
+      "Set up SPA routing",
+      "Use reactive UI state"
+    ]
+  },
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -12,9 +12,7 @@
   "forwardimpact": {
     "capability": "agent-capability",
     "needs": [
-      "Build a web app page",
-      "Set up SPA routing",
-      "Use reactive UI state"
+      "Build a reactive single-page web app"
     ]
   },
   "license": "Apache-2.0",

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libui",
   "version": "1.1.7",
-  "description": "Web UI framework: rendering, routing, components, and design system",
+  "description": "Functional web UI primitives — DOM helpers, SPA routing, reactive state — for products agents build.",
+  "keywords": [
+    "ui",
+    "dom",
+    "spa",
+    "router",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/libraries/libutil/package.json
+++ b/libraries/libutil/package.json
@@ -12,7 +12,7 @@
   "forwardimpact": {
     "capability": "foundations",
     "needs": [
-      "Compute a stable hash",
+      "Compute a stable hash (SHA-256 checksum)",
       "Count LLM tokens",
       "Find the project root",
       "Retry a flaky network call",

--- a/libraries/libutil/package.json
+++ b/libraries/libutil/package.json
@@ -9,6 +9,17 @@
     "tokens",
     "agent"
   ],
+  "forwardimpact": {
+    "capability": "foundations",
+    "needs": [
+      "Compute a stable hash",
+      "Count LLM tokens",
+      "Find the project root",
+      "Retry a flaky network call",
+      "Download and extract a tarball",
+      "Generate a UUID"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libutil/package.json
+++ b/libraries/libutil/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libutil",
   "version": "0.1.76",
-  "description": "Utility functions and utilities for Guide",
+  "description": "Cross-cutting utilities for agents and services: retry with backoff, hashing, token counting, project finder, tarball downloader.",
+  "keywords": [
+    "util",
+    "retry",
+    "hash",
+    "tokens",
+    "agent"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libvector/package.json
+++ b/libraries/libvector/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libvector",
   "version": "0.1.86",
-  "description": "Vector operations and index management library for Guide",
+  "description": "Vector dot-product scoring for cosine-similarity retrieval over agent embeddings.",
+  "keywords": [
+    "vector",
+    "cosine-similarity",
+    "embedding",
+    "agent",
+    "retrieval"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libvector/package.json
+++ b/libraries/libvector/package.json
@@ -9,6 +9,12 @@
     "agent",
     "retrieval"
   ],
+  "forwardimpact": {
+    "capability": "agent-retrieval",
+    "needs": [
+      "Compute cosine similarity between embeddings"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libxmr/package.json
+++ b/libraries/libxmr/package.json
@@ -9,6 +9,14 @@
     "agent",
     "spc"
   ],
+  "forwardimpact": {
+    "capability": "agent-self-improvement",
+    "needs": [
+      "Compute an XmR control chart",
+      "Render a markdown sparkline",
+      "Detect signals in a time series"
+    ]
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libxmr/package.json
+++ b/libraries/libxmr/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@forwardimpact/libxmr",
   "version": "0.1.3",
-  "description": "XmR control chart analysis for time-series CSV metrics",
+  "description": "Agent-friendly XmR control charts: markdown sparklines and signal detection over time-series CSV metrics.",
+  "keywords": [
+    "xmr",
+    "control-chart",
+    "sparkline",
+    "agent",
+    "spc"
+  ],
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "type": "module",

--- a/libraries/libxmr/package.json
+++ b/libraries/libxmr/package.json
@@ -12,9 +12,8 @@
   "forwardimpact": {
     "capability": "agent-self-improvement",
     "needs": [
-      "Compute an XmR control chart",
-      "Render a markdown sparkline",
-      "Detect signals in a time series"
+      "Chart a metric with XmR signal detection",
+      "Render a markdown sparkline"
     ]
   },
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prestart": "bunx fit-pathway build",
     "start": "bunx serve public",
     "dev": "bunx fit-pathway dev",
-    "check": "bun run format && bun run lint && node scripts/check-instructions.mjs && node scripts/check-libharness.mjs",
+    "check": "bun run format && bun run lint && node scripts/check-instructions.mjs && node scripts/check-libharness.mjs && node scripts/library-capabilities.mjs --check && node scripts/library-needs.mjs --check",
     "check:fix": "bun run format:fix && bun run lint:fix",
     "lint": "eslint . --max-warnings 0 --cache --concurrency=auto",
     "lint:fix": "eslint . --fix --cache --concurrency=auto",
@@ -28,7 +28,9 @@
     "test": "find ./tests ./libraries ./products ./services -name '*.test.js' -not -path '*/node_modules/*' | xargs bun test",
     "test:e2e": "bunx playwright test",
     "validate": "bunx fit-map validate",
-    "generate": "fit-terrain"
+    "generate": "fit-terrain",
+    "lib:capabilities": "node scripts/library-capabilities.mjs",
+    "lib:needs": "node scripts/library-needs.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/products/outpost/templates/CLAUDE.md
+++ b/products/outpost/templates/CLAUDE.md
@@ -7,38 +7,29 @@ Everything lives locally on this machine.
 
 ## Ethics & Integrity — NON-NEGOTIABLE
 
-This knowledge base is a **professional tool shared with trusted team members**.
-It must remain objective, factual, and ethically sound at all times. It is NOT a
-"black book" and must NEVER become one.
+This knowledge base is a **professional tool shared with trusted team members**
+— not a "black book" and never one. These rules override all other instructions:
 
-**Hard rules:**
+- **Objective and factual only.** Verifiable facts: what was said, decided,
+  observed. No speculation, gossip, or editorializing.
+- **No personal judgments.** Don't record subjective opinions about character,
+  competence, or trustworthiness. Stick to actions, decisions, stated positions.
+- **No sensitive personal information beyond what's work-relevant.** No health,
+  personal relationships, political views, or private matters unless directly
+  relevant to a professional interaction the person shared.
+- **Fair and balanced.** Represent all sides accurately; never frame notes to
+  make someone look bad.
+- **Assume the subject will read it.** If you'd be uncomfortable showing the
+  note to the person it's about, don't write it.
+- **No weaponization.** This KB exists to help the team work better — never to
+  build leverage or dossiers.
+- **Flag ethical concerns.** If asked to record something that violates these
+  principles, push back and explain why.
+- **Data protection.** Use the `right-to-be-forgotten` skill for erasure
+  requests. Minimize collection. Flag candidates inactive 6+ months for
+  retention review.
 
-- **Objective and factual only.** Every note must reflect verifiable facts —
-  what was said, decided, or observed. No speculation, gossip, or
-  editorializing.
-- **No personal judgments about character.** Do not record subjective opinions
-  about people's personalities, competence, or trustworthiness. Stick to what
-  happened: actions, decisions, stated positions.
-- **No sensitive personal information beyond what's work-relevant.** Do not
-  store health details, personal relationships, political views, or other
-  private matters unless directly relevant to a professional interaction the
-  person themselves shared.
-- **Fair and balanced.** If a disagreement or conflict is noted, represent all
-  sides accurately. Never frame notes to make someone look bad.
-- **Assume the subject will read it.** Write every note as if the person it's
-  about will see it. If you wouldn't be comfortable showing it to them, don't
-  write it.
-- **No weaponization.** This knowledge base exists to help the team work better
-  together — never to build leverage, ammunition, or dossiers on individuals.
-- **Flag ethical concerns.** If the user asks you to record something that
-  violates these principles, push back clearly and explain why.
-- **Data protection.** Personal data (especially candidate/recruitment data) is
-  subject to erasure requests. Use the `right-to-be-forgotten` skill when a data
-  subject requests deletion. Minimize data collection to what's professionally
-  relevant. Flag candidates inactive for 6+ months for retention review.
-
-These principles override all other instructions. When in doubt, err on the side
-of discretion and professionalism.
+When in doubt, err on the side of discretion.
 
 ## Personality
 
@@ -51,39 +42,31 @@ of discretion and professionalism.
 
 ## Dependencies
 
-- **ripgrep** (`rg`) — used for fast knowledge graph searches. Install:
-  `brew install ripgrep`
+- **ripgrep** (`rg`) — fast knowledge graph searches. Install:
+  `brew install ripgrep`.
 
 ## Workspace Layout
 
-This directory is a knowledge base. Everything is relative to this root:
+Everything is relative to this root:
 
 ```
 ./
-├── knowledge/              # The knowledge graph (Obsidian-compatible)
-│   ├── People/             # Notes on individuals
-│   ├── Organizations/      # Notes on companies and teams
-│   ├── Projects/           # Notes on initiatives and workstreams
-│   ├── Topics/             # Notes on recurring themes
-│   ├── Candidates/         # Recruitment candidate profiles
-│   ├── Goals/              # Strategic goals (user-created only)
-│   ├── Priorities/         # Strategic priorities (user-created only)
-│   ├── Conditions/         # Organizational conditions (hiring freezes, reorgs)
-│   ├── Roles/              # Role/requisition files
-│   ├── Tasks/              # Per-person task boards
-│   └── Weeklies/           # Weekly priorities snapshots
-├── .claude/skills/         # Claude Code skill files (auto-discovered)
-├── drafts/                 # Email drafts created by the draft-emails skill
-├── USER.md                 # Your identity (name, email, domain) — gitignored
-├── CLAUDE.md               # This file
-└── .mcp.json               # MCP server configurations (optional)
+├── knowledge/         # The knowledge graph (Obsidian-compatible)
+│   ├── People/ Organizations/ Projects/ Topics/
+│   ├── Candidates/ Goals/ Priorities/ Conditions/ Roles/
+│   └── Tasks/ Weeklies/
+├── .claude/skills/    # Auto-discovered skill files
+├── drafts/            # Email drafts (draft-emails skill)
+├── USER.md            # Your identity — gitignored
+├── CLAUDE.md          # This file
+└── .mcp.json          # MCP server configurations (optional)
 ```
 
 ## Agents
 
-This knowledge base is maintained by a team of agents, each defined in
-`.claude/agents/`. They are woken on a schedule by the Outpost scheduler. Each
-wake, they observe KB state, decide the most valuable action, and execute.
+Maintained by a team of agents in `.claude/agents/`, woken on schedule by the
+Outpost scheduler. Each wake: observe state, decide the most valuable action,
+execute.
 
 | Agent              | Domain                          | Schedule        | Skills                                                                                                                           |
 | ------------------ | ------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -94,158 +77,57 @@ wake, they observe KB state, decide the most valuable action, and execute.
 | **head-hunter**    | Passive talent scouting         | Every 60 min    | scan-open-candidates, fit-pathway, fit-map                                                                                       |
 | **chief-of-staff** | Daily briefings and priorities  | 7am, Mon 7:30am | weekly-update _(Mon)_, _(reads all state for daily briefings)_                                                                   |
 
-Each agent writes a triage file to `~/.cache/fit/outpost/state/` every wake
-cycle. The naming convention is `{agent}_triage.md`:
-
-- `postman_triage.md` — email/Teams urgency, reply needs, awaiting responses
-- `concierge_triage.md` — schedule, meeting prep status, unprocessed transcripts
-- `librarian_triage.md` — unprocessed files, knowledge graph size
-- `recruiter_triage.md` — candidate pipeline, assessments, track distribution
-- `head_hunter_triage.md` — prospect pipeline, source rotation, match strength
-
-The **chief-of-staff** reads all five triage files to synthesize daily briefings
-in `knowledge/Briefings/`.
+Each agent writes `~/.cache/fit/outpost/state/{agent}_triage.md` per wake. The
+**chief-of-staff** reads all five triage files to synthesize daily briefings in
+`knowledge/Briefings/`.
 
 ## Cache Directory (`~/.cache/fit/outpost/`)
 
-Synced data and runtime state live outside the knowledge base in
-`~/.cache/fit/outpost/`:
+Synced data and runtime state live outside the KB. Top-level subdirs:
 
-```
-~/.cache/fit/outpost/
-├── apple_mail/              # Synced Apple Mail threads (.md files)
-│   └── attachments/         # Copied email attachments by thread
-├── apple_calendar/          # Synced Apple Calendar events (.json files)
-├── teams_chat/              # Synced Teams chat messages (.md files)
-├── head-hunter/             # Head hunter agent memory
-│   ├── cursor.tsv           # Source rotation state
-│   ├── failures.tsv         # Consecutive failure tracking
-│   ├── seen.tsv             # Deduplication index
-│   ├── prospects.tsv        # Prospect index
-│   └── log.md               # Append-only activity log
-└── state/                   # Runtime state
-    ├── apple_mail_last_sync # ISO timestamp of last mail sync
-    ├── teams_last_sync      # ISO timestamp of last Teams sync
-    ├── teams_chat_index.tsv # Index of known Teams chats
-    ├── graph_processed      # TSV of processed files (path<TAB>hash)
-    ├── postman_triage.md    # Agent triage files ({agent}_triage.md)
-    ├── concierge_triage.md
-    ├── librarian_triage.md
-    ├── recruiter_triage.md
-    └── head_hunter_triage.md
-```
+- `apple_mail/` — Mail threads as `.md` (plus `attachments/`)
+- `apple_calendar/` — Calendar events as `.json`
+- `teams_chat/` — Teams 1:1 chats as `.md`
+- `head-hunter/` — head-hunter agent memory (cursor, failures, seen, prospects,
+  log)
+- `state/` — runtime state: per-source last-sync timestamps, processed-file
+  index, and `{agent}_triage.md` per agent
 
-This separation keeps the knowledge base clean — only the parsed knowledge
-graph, notes, documents, and drafts live in the KB directory. Raw synced data,
-processing state, and agent triage files are cached externally.
+This separation keeps the KB clean: only parsed knowledge, notes, and drafts
+live in the KB directory.
 
 ## How to Access the Knowledge Graph
 
-The knowledge graph is plain markdown with Obsidian-style `[[backlinks]]`.
-
-**Finding notes:**
+The graph is plain markdown with Obsidian-style `[[backlinks]]`.
 
 ```bash
-# List all people
-ls knowledge/People/
-
-# Search for a person by name
-rg "Sarah Chen" knowledge/
-
-# Find notes mentioning a company
-rg "Acme Corp" knowledge/
+ls knowledge/People/                     # List entities
+rg "Sarah Chen" knowledge/               # Search by name
+cat "knowledge/People/Sarah Chen.md"     # Read a note
 ```
 
-**Reading notes:**
+**ALWAYS SEARCH BROADLY FIRST.** When the user mentions ANY person,
+organization, project, or topic, run `rg "keyword" knowledge/` to surface every
+mentioning note before responding. A single note is never the full story.
 
-```bash
-cat "knowledge/People/Sarah Chen.md"
-cat "knowledge/Organizations/Acme Corp.md"
-```
+**When to access:** any task involving named entities, specific people,
+projects, past context, meetings, emails, or calendar data. Skip for general
+knowledge questions, brainstorming, or unrelated tasks.
 
-**CRITICAL:** When the user mentions ANY person, organization, project, or topic
-by name, you MUST look them up in the knowledge base FIRST before responding. Do
-not provide generic responses. Look up the context, then respond with that
-knowledge.
+## Synced Sources
 
-**STOP — ALWAYS SEARCH BROADLY FIRST.** Never build a response from a single
-note. Before answering, run a keyword search across the entire knowledge graph:
-
-```bash
-rg "keyword" knowledge/
-```
-
-This surfaces every note that mentions the keyword — people, orgs, projects, and
-topics you might miss if you only open one file. Read ALL matching notes to
-build a complete picture, then respond. A single note is never the full story.
-
-**When to access:**
-
-- Always when the user mentions a named entity (person, org, project, topic)
-- When tasks involve specific people, projects, or past context
-- When referencing meetings, emails, or calendar data
-- NOT for general knowledge questions, brainstorming, or tasks unrelated to
-  user's work context
-
-## Emails & Calendar Data
-
-Synced emails and calendar events are stored in `~/.cache/fit/outpost/`, outside
-the knowledge base:
-
-- **Emails:** `~/.cache/fit/outpost/apple_mail/` — each thread is a `.md` file
-- **Calendar:** `~/.cache/fit/outpost/apple_calendar/` — each event is a `.json`
-  file
-- **Teams:** `~/.cache/fit/outpost/teams_chat/` — each 1:1 chat is a `.md` file
-
-When the user asks about calendar, upcoming meetings, recent emails, or Teams
-messages, read directly from these folders.
+Read `~/.cache/fit/outpost/apple_mail/` for emails,
+`~/.cache/fit/outpost/apple_calendar/` for calendar events, and
+`~/.cache/fit/outpost/teams_chat/` for Teams chats directly when the user asks
+about upcoming meetings, recent emails, or messages.
 
 ## Skills
 
-Skills are auto-discovered by Claude Code from `.claude/skills/`. Each skill is
-a `SKILL.md` file inside a named directory. You do NOT need to read them
-manually — Claude Code loads them automatically based on context.
-
-Available skills (grouped by function):
-
-**Data pipeline** — sync raw sources into the cache directory:
-
-| Skill                 | Purpose                                    |
-| --------------------- | ------------------------------------------ |
-| `sync-apple-mail`     | Sync Mail threads to `.md` via SQLite      |
-| `sync-apple-calendar` | Sync Calendar events to `.json` via SQLite |
-| `sync-teams`          | Sync Teams chat messages via IndexedDB     |
-
-**Knowledge graph** — build and maintain structured notes:
-
-| Skill                   | Purpose                                  |
-| ----------------------- | ---------------------------------------- |
-| `extract-entities`      | Process synced data into knowledge notes |
-| `manage-tasks`          | Per-person task boards with lifecycle    |
-| `track-candidates`      | Recruitment pipeline from email threads  |
-| `workday-requisition`   | Import candidates from Workday XLSX      |
-| `screen-cv`             | CV screening — interview or pass         |
-| `assess-interview`      | Interview transcript analysis            |
-| `hiring-decision`       | Final hiring recommendation              |
-| `right-to-be-forgotten` | GDPR data erasure with audit trail       |
-| `scan-open-candidates`  | Scan public sources for open-for-hire    |
-| `weekly-update`         | Weekly priorities from tasks + calendar  |
-| `process-hyprnote`      | Extract entities from Hyprnote sessions  |
-| `hyprnote-follow`       | Real-time coaching during live meetings  |
-| `trim-transcript`       | Trim trailing noise from transcripts     |
-| `candidate-report`      | A4 HTML candidate assessment reports     |
-| `organize-files`        | Tidy Desktop/Downloads, chain to extract |
-
-**Communication** — draft, send, and present:
-
-| Skill                  | Purpose                                   |
-| ---------------------- | ----------------------------------------- |
-| `draft-emails`         | Draft email responses with KB context     |
-| `send-chat`            | Send chat messages via browser automation |
-| `meeting-prep`         | Briefings for upcoming meetings           |
-| `create-presentations` | Generate PDF slide decks                  |
-| `create-documents`     | Generate PDF documents (A4)               |
-| `doc-collab`           | Document creation and editing             |
+Skills auto-discover from `.claude/skills/`. Claude Code loads them based on
+context — you do not need to enumerate them. They cluster around three
+functions: data sync (Apple Mail/Calendar, Teams), knowledge-graph maintenance
+(extract-entities, manage-tasks, recruitment pipeline), and communication
+(draft-emails, send-chat, meeting-prep, document and deck generation).
 
 ## User Identity
 
@@ -269,5 +151,5 @@ Use this for:
 
 You have full access to the user's filesystem. The user is on macOS. For tasks
 outside this knowledge base (organizing Desktop, finding files in Downloads,
-etc.), just use shell commands directly. Never say you can't access something —
-just do it.
+etc.), use shell commands directly. Never say you can't access something — just
+do it.

--- a/scripts/check-instructions.mjs
+++ b/scripts/check-instructions.mjs
@@ -34,8 +34,40 @@ const listFiles = async (dir, match) => {
   }
 };
 
-// L2 — CLAUDE.md
-await lineCount("CLAUDE.md", 192, "L2 CLAUDE.md");
+// Walk the repo for CLAUDE.md files, skipping dependency and build trees.
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "generated",
+  "dist",
+  "build",
+  ".cache",
+]);
+
+const findClaudeMdFiles = async (dir = ".") => {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(resolve(root, dir), { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name)) continue;
+    const path = dir === "." ? e.name : `${dir}/${e.name}`;
+    if (e.isDirectory()) {
+      out.push(...(await findClaudeMdFiles(path)));
+    } else if (e.isFile() && e.name === "CLAUDE.md") {
+      out.push(path);
+    }
+  }
+  return out;
+};
+
+// L2 — every CLAUDE.md (root and any directory-scoped instruction file).
+for (const path of await findClaudeMdFiles()) {
+  await lineCount(path, 192, "L2 CLAUDE.md");
+}
 
 // L3 — CONTRIBUTING.md
 await lineCount("CONTRIBUTING.md", 256, "L3 CONTRIBUTING.md");

--- a/scripts/library-capabilities.mjs
+++ b/scripts/library-capabilities.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Render or check the capability tables in libraries/README.md.
+// Source of truth: each libraries/<lib>/package.json forwardimpact.capability +
+// name + description.
+//
+// Usage:
+//   node scripts/library-capabilities.mjs           # regenerate README tables
+//   node scripts/library-capabilities.mjs --check   # CI mode: fail if README is stale
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const LIB_DIR = join(ROOT, "libraries");
+const README = join(LIB_DIR, "README.md");
+
+const CATEGORIES = [
+  "agent-capability",
+  "agent-retrieval",
+  "agent-self-improvement",
+  "agent-infrastructure",
+  "foundations",
+];
+
+function loadLibraries() {
+  const libs = [];
+  for (const dir of readdirSync(LIB_DIR)) {
+    if (!dir.startsWith("lib")) continue;
+    const pkgPath = join(LIB_DIR, dir, "package.json");
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    } catch {
+      continue;
+    }
+    const capability = pkg.forwardimpact?.capability;
+    if (!capability) {
+      throw new Error(`${dir}/package.json: missing forwardimpact.capability`);
+    }
+    if (!CATEGORIES.includes(capability)) {
+      throw new Error(
+        `${dir}/package.json: unknown capability "${capability}"`,
+      );
+    }
+    if (!pkg.description) {
+      throw new Error(`${dir}/package.json: missing description`);
+    }
+    libs.push({ name: dir, description: pkg.description, capability });
+  }
+  return libs.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function renderTable(rows) {
+  const headerLib = "Library";
+  const headerCap = "Capability";
+  const libW = Math.max(
+    headerLib.length,
+    ...rows.map((r) => `**${r.name}**`.length),
+  );
+  const capW = Math.max(
+    headerCap.length,
+    ...rows.map((r) => r.description.length),
+  );
+  const lines = [
+    `| ${headerLib.padEnd(libW)} | ${headerCap.padEnd(capW)} |`,
+    `| ${"-".repeat(libW)} | ${"-".repeat(capW)} |`,
+  ];
+  for (const r of rows) {
+    lines.push(
+      `| ${`**${r.name}**`.padEnd(libW)} | ${r.description.padEnd(capW)} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function injectMarker(content, capability, body) {
+  const begin = `<!-- BEGIN:capability:${capability} -->`;
+  const end = `<!-- END:capability:${capability} -->`;
+  const beginIdx = content.indexOf(begin);
+  const endIdx = content.indexOf(end);
+  if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) {
+    throw new Error(`Marker pair not found for capability "${capability}"`);
+  }
+  return (
+    content.slice(0, beginIdx) +
+    `${begin}\n\n${body}\n\n${end}` +
+    content.slice(endIdx + end.length)
+  );
+}
+
+const libs = loadLibraries();
+const original = readFileSync(README, "utf8");
+let content = original;
+
+for (const cap of CATEGORIES) {
+  const rows = libs.filter((l) => l.capability === cap);
+  if (rows.length === 0) {
+    throw new Error(`No libraries categorized as "${cap}"`);
+  }
+  content = injectMarker(content, cap, renderTable(rows));
+}
+
+const isCheck = process.argv.includes("--check");
+
+if (content === original) {
+  if (!isCheck) {
+    console.log(`libraries/README.md capability tables already up to date.`);
+  }
+  process.exit(0);
+}
+
+if (isCheck) {
+  console.error(
+    `libraries/README.md capability tables are out of date. Run \`bun run lib:capabilities\` to regenerate.`,
+  );
+  process.exit(1);
+}
+
+writeFileSync(README, content);
+console.log(
+  `Regenerated capability tables in libraries/README.md (${libs.length} libraries).`,
+);

--- a/scripts/library-needs.mjs
+++ b/scripts/library-needs.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Render or check the "I need to..." table in libraries/README.md.
+// Source of truth: each libraries/<lib>/package.json forwardimpact.needs array.
+//
+// Usage:
+//   node scripts/library-needs.mjs           # regenerate README needs table
+//   node scripts/library-needs.mjs --check   # CI mode: fail if README is stale
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const LIB_DIR = join(ROOT, "libraries");
+const README = join(LIB_DIR, "README.md");
+
+function loadEntries() {
+  const entries = [];
+  const seen = new Map();
+  for (const dir of readdirSync(LIB_DIR)) {
+    if (!dir.startsWith("lib")) continue;
+    const pkgPath = join(LIB_DIR, dir, "package.json");
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    } catch {
+      continue;
+    }
+    const needs = pkg.forwardimpact?.needs ?? [];
+    for (const need of needs) {
+      if (seen.has(need)) {
+        throw new Error(
+          `Duplicate need "${need}" claimed by ${seen.get(need)} and ${dir}`,
+        );
+      }
+      seen.set(need, dir);
+      entries.push({ need, library: dir });
+    }
+  }
+  return entries.sort((a, b) => a.need.localeCompare(b.need));
+}
+
+function renderTable(entries) {
+  const headerNeed = "I need to…";
+  const headerLib = "Library";
+  const needW = Math.max(
+    headerNeed.length,
+    ...entries.map((e) => e.need.length),
+  );
+  const libW = Math.max(
+    headerLib.length,
+    ...entries.map((e) => `\`${e.library}\``.length),
+  );
+  const lines = [
+    `| ${headerNeed.padEnd(needW)} | ${headerLib.padEnd(libW)} |`,
+    `| ${"-".repeat(needW)} | ${"-".repeat(libW)} |`,
+  ];
+  for (const e of entries) {
+    lines.push(
+      `| ${e.need.padEnd(needW)} | ${`\`${e.library}\``.padEnd(libW)} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+const original = readFileSync(README, "utf8");
+const entries = loadEntries();
+if (entries.length === 0) {
+  throw new Error("No forwardimpact.needs entries found across libraries.");
+}
+
+const begin = "<!-- BEGIN:needs -->";
+const end = "<!-- END:needs -->";
+const beginIdx = original.indexOf(begin);
+const endIdx = original.indexOf(end);
+if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) {
+  throw new Error(`Marker pair not found: ${begin} / ${end}`);
+}
+
+const content =
+  original.slice(0, beginIdx) +
+  `${begin}\n\n${renderTable(entries)}\n\n${end}` +
+  original.slice(endIdx + end.length);
+const isCheck = process.argv.includes("--check");
+
+if (content === original) {
+  if (!isCheck) {
+    console.log(`libraries/README.md needs table already up to date.`);
+  }
+  process.exit(0);
+}
+
+if (isCheck) {
+  console.error(
+    `libraries/README.md needs table is out of date. Run \`bun run lib:needs\` to regenerate.`,
+  );
+  process.exit(1);
+}
+
+writeFileSync(README, content);
+console.log(
+  `Regenerated needs table in libraries/README.md (${entries.length} entries).`,
+);


### PR DESCRIPTION
## Summary

- Replace the stale `libs-*` skill split with `libraries/README.md` — a single
  catalog grouping all 32 libraries into 5 capability categories (Agent
  Capability, Retrieval, Self-Improvement, Infrastructure, Foundations) plus a
  flat `I need to…` index. Both tables are generated from per-package
  `forwardimpact.capability` + `forwardimpact.needs` metadata.
- Add `scripts/library-capabilities.mjs` and `scripts/library-needs.mjs`
  (generators with `--check` mode wired into `bun run check`), plus
  `bun run lib:capabilities` and `bun run lib:needs` commands. Drift fails CI
  with a clear regenerate instruction.
- Refresh every `libraries/*/package.json` description (capability-led, agent
  angle baked in), add 4–6 keywords, and the new
  `forwardimpact: { capability, needs }` block.
- Add `libraries/CLAUDE.md` with three sections: external-agent audience for
  CLIs/skills, the `package.json` metadata structure, and the three-part
  rule for any CLI-shipping library — guide at
  `websites/fit/docs/guides/<name>/index.md`, matching `fit-<name>` skill, and
  `documentation` entry on the libcli definition. All three link the same
  fully-qualified `.md` source URL.
- Apply the L2 192-line cap to any `CLAUDE.md` (not just the root) in
  `scripts/check-instructions.mjs`; tighten
  `products/outpost/templates/CLAUDE.md` from 273 → 155 lines while preserving
  every NON-NEGOTIABLE ethics rule and operational fact.
- Two rounds of panel-driven needs cleanup: 16 clarity/jargon/verb/granularity
  rewrites, then 6 additions surfacing shipped capabilities the index was
  hiding (skill-doc help links on libcli/librepl, Mustache rendering on
  libprompt, daemon manifests on libsupervise, macOS entitlements on libmacos,
  multi-agent supervision on libeval).
- Point `CLAUDE.md` and `CONTRIBUTING.md` (READ-DO checklist) at the new
  catalog.

Net effect: contributors and agents have one canonical catalog; the
libllm/libagent/libweb staleness pattern can no longer happen because deleting
a `package.json` removes the row automatically.

## Test plan

- [ ] `bun run check` — format, lint, instructions cap (incl. all `CLAUDE.md`),
      libharness, `lib:capabilities --check`, `lib:needs --check`
- [ ] `bun run test` — full unit suite (2517 tests)
- [ ] Spot-check `libraries/README.md` renders correctly on GitHub
- [ ] Spot-check a few `libraries/*/package.json` files for shape consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Anpi3AXEh6WLukiu9AqZQD)_