### PR TITLE
docs(libxmr): add fit-xmr library guide and skill

### DIFF
--- a/.claude/skills/fit-xmr/SKILL.md
+++ b/.claude/skills/fit-xmr/SKILL.md
@@ -19,7 +19,7 @@ process is stable or has shifted.
 - A metric is recorded over time (security backlog, lead time, error rate, agent
   token usage) and you need to know whether a recent change is signal or noise.
 - A team wants compact markdown status tables (with signals annotated) for a
-  wiki page, PR description, or weekly report.
+  status page, PR description, or weekly report.
 - Inline sparklines are needed in a markdown table for one-glance trend
   indicators.
 
@@ -56,24 +56,24 @@ Install and run via npm:
 npx fit-xmr <command> <csv-path> [options]
 ```
 
-| Command                       | Purpose                                              |
-| ----------------------------- | ---------------------------------------------------- |
-| `validate <csv>`              | Check the CSV against the schema                     |
-| `list <csv>`                  | One row per metric: count, unit, date range          |
-| `analyze <csv>`               | Full XmR report: limits, latest, signals, status     |
-| `summarize <csv>`             | Compact markdown table across metrics with signals   |
-| `spark <csv> --metric <name>` | 12-character braille sparkline of the last 12 points |
+| Command                       | Purpose                                                      |
+| ----------------------------- | ------------------------------------------------------------ |
+| `validate <csv>`              | Check the CSV against the schema                             |
+| `list <csv>`                  | One row per metric: count, unit, date range                  |
+| `analyze <csv>`               | Full XmR report: limits, latest, signals, status             |
+| `summarize <csv>`             | Compact markdown table across metrics with signals           |
+| `spark <csv> --metric <name>` | 12-character block-character sparkline of the last 12 points |
 
 ### Common Options
 
-| Flag                     | Purpose                                           |
-| ------------------------ | ------------------------------------------------- |
-| `--metric <name>` / `-m` | Filter `analyze` / `summarize` to a single metric |
-| `--format <text\|json>`  | Output format (default: text)                     |
-| `--help` / `-h`          | Show help                                         |
-| `--json`                 | Output help as JSON                               |
+| Flag                     | Purpose                                                                  |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `--metric <name>` / `-m` | Filter `analyze` / `summarize` to a single metric (required for `spark`) |
+| `--format <text\|json>`  | Output format on every command (default: text)                           |
+| `--help` / `-h`          | Show help (`--json` formats help itself as JSON)                         |
 
-`validate` exits non-zero on schema errors so it can gate CI.
+`validate` exits non-zero on schema errors so it can gate CI. Missing CSV path
+exits 2 with a friendly error, not a stack trace.
 
 ---
 
@@ -99,28 +99,46 @@ are unreliable until the chaos is investigated.
 
 ## Report Shape
 
-`analyze --format=json` is the canonical output. Each metric:
+`analyze --format=json` is the canonical output, wrapped in
+`{ source, generated, metrics: [...] }`:
 
 ```json
 {
-  "metric": "open_vulnerabilities",
-  "unit": "count",
-  "n": 105,
-  "from": "2026-01-01",
-  "to": "2026-04-14",
-  "x_bar": 16.79,
-  "mr_bar": 0.64,
-  "unpl": 18.5,
-  "lnpl": 15.08,
-  "url": 2.11,
-  "latest": { "date": "2026-04-14", "value": 13, "mr": 1 },
-  "signals": [
-    { "rule": "run_below", "from": "2026-02-25", "to": "2026-04-14", "length": 50 },
-    { "rule": "point_below_lnpl", "from": "2026-03-02", "to": "2026-04-14", "count": 45, "trough": 7 }
-  ],
-  "status": "signals_present"
+  "source": "observations.csv",
+  "generated": "2026-04-14",
+  "metrics": [
+    {
+      "metric": "open_vulnerabilities",
+      "unit": "count",
+      "n": 105,
+      "from": "2026-01-01",
+      "to": "2026-04-14",
+      "x_bar": 16.79,
+      "mr_bar": 0.64,
+      "unpl": 18.5,
+      "lnpl": 15.08,
+      "url": 2.11,
+      "latest": { "date": "2026-04-14", "value": 13, "mr": 1 },
+      "signals": [
+        { "rule": "run_above", "from": "2026-01-01", "to": "2026-02-24", "length": 55 },
+        { "rule": "run_below", "from": "2026-02-25", "to": "2026-04-14", "length": 50 },
+        { "rule": "trend_down", "from": "2026-02-19", "to": "2026-02-25", "moves": 6 },
+        { "rule": "point_below_lnpl", "from": "2026-03-02", "to": "2026-04-14", "count": 45, "trough": 7 }
+      ],
+      "status": "signals_present"
+    }
+  ]
 }
 ```
+
+`x_bar ± 2.66 * mr_bar` gives the upper/lower natural process limits;
+`3.27 * mr_bar` gives the upper range limit. The constants are XmR's calibration
+for n=2 moving range and apply to any process.
+
+Run signals carry `length`, trend signals carry `moves`, point/MR signals carry
+`count` plus `peak`/`trough`. `signals` is sorted by start date. `latest.mr` is
+the moving range at the most recent point — useful for "is today's change
+unusual?" without re-reading the whole array.
 
 `status` is one of:
 
@@ -138,7 +156,7 @@ column: `stable`, `signals`, `chaos` (when `mr_above_url` is present), or
 npx fit-xmr validate observations.csv
 npx fit-xmr list observations.csv
 npx fit-xmr analyze observations.csv --metric open_vulnerabilities
-npx fit-xmr summarize observations.csv               # paste into a wiki page
+npx fit-xmr summarize observations.csv               # paste into a status page
 npx fit-xmr spark observations.csv --metric open_vulnerabilities
 ```
 
@@ -153,10 +171,13 @@ investigate; summarize for the rollup; spark for inline indicators.
   whether to lock it in or roll it back.
 - **Out-of-limits points** confirm magnitude. The size of the shift matters for
   prioritization, not for the verdict.
+- **A series spanning a level shift** will surface signals on **both** sides of
+  `x_bar` (e.g. `run_above` for the pre-shift period, `run_below` for the
+  post-shift period). Once the shift is locked in, recompute by trimming the CSV
+  to post-shift dates so the limits describe the new process.
 - **`mr_above_url`** says volatility itself spiked. The limits are computed from
-  `mr_bar`; if the moving range is unstable, the limits don't yet describe a
-  stable process. Investigate the volatility before reading the rest of the
-  report.
+  `mr_bar`; an outlier moving range inflates `mr_bar` and pulls UNPL/LNPL wider,
+  so the rest of the report is unreliable until you investigate.
 - **Annotate the CSV `note` field** when you investigate a signal. The note is
   the record of why the process changed; future analyses depend on it.
 - **Don't set targets from the limits.** Targets come from the work; limits

--- a/.claude/skills/fit-xmr/SKILL.md
+++ b/.claude/skills/fit-xmr/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: fit-xmr
+description: >
+  Analyze time-series CSV metrics with XmR control charts to distinguish stable
+  processes from special causes. Use when a metric is being tracked over time
+  and the question is whether it has changed — covers signal rules, the report
+  shape, and how to interpret runs, trends, and out-of-limit points.
+---
+
+# XmR Analysis
+
+`fit-xmr` reads a CSV of dated observations, computes XmR (individuals and
+moving range) control limits, and detects special-cause signals. It turns a
+column of numbers over time into a structured judgement about whether the
+process is stable or has shifted.
+
+## When to Use
+
+- A metric is recorded over time (security backlog, lead time, error rate, agent
+  token usage) and you need to know whether a recent change is signal or noise.
+- A team wants compact markdown status tables (with signals annotated) for a
+  wiki page, PR description, or weekly report.
+- Inline sparklines are needed in a markdown table for one-glance trend
+  indicators.
+
+If the question is _"how is this metric trending?"_ — this is the right tool. If
+the question is _"what target should we set?"_ — this is **not** the right tool.
+Natural process limits describe what a process _does_, not what it _should_ do.
+
+## CSV Schema
+
+`fit-xmr` expects exactly this header:
+
+```
+date,metric,value,unit,run,note
+```
+
+- `date` — ISO 8601 (`YYYY-MM-DD`)
+- `metric` — metric name (one CSV may carry many metrics)
+- `value` — numeric
+- `unit` — free text (`count`, `days`, `pct`, ...)
+- `run` — optional URL or run id
+- `note` — annotate when a signal appears, with what you discovered
+
+Validate before analysis:
+
+```sh
+npx fit-xmr validate observations.csv
+```
+
+## CLI Reference
+
+Install and run via npm:
+
+```sh
+npx fit-xmr <command> <csv-path> [options]
+```
+
+| Command                       | Purpose                                              |
+| ----------------------------- | ---------------------------------------------------- |
+| `validate <csv>`              | Check the CSV against the schema                     |
+| `list <csv>`                  | One row per metric: count, unit, date range          |
+| `analyze <csv>`               | Full XmR report: limits, latest, signals, status     |
+| `summarize <csv>`             | Compact markdown table across metrics with signals   |
+| `spark <csv> --metric <name>` | 12-character braille sparkline of the last 12 points |
+
+### Common Options
+
+| Flag                     | Purpose                                           |
+| ------------------------ | ------------------------------------------------- |
+| `--metric <name>` / `-m` | Filter `analyze` / `summarize` to a single metric |
+| `--format <text\|json>`  | Output format (default: text)                     |
+| `--help` / `-h`          | Show help                                         |
+| `--json`                 | Output help as JSON                               |
+
+`validate` exits non-zero on schema errors so it can gate CI.
+
+---
+
+## Signal Rules
+
+Four families of special-cause signals. Each is a prompt to investigate, not a
+verdict.
+
+| Rule                                    | Meaning                                                 |
+| --------------------------------------- | ------------------------------------------------------- |
+| `point_above_unpl` / `point_below_lnpl` | Points outside natural process limits                   |
+| `run_above` / `run_below`               | 8+ consecutive points on the same side of `x_bar`       |
+| `trend_up` / `trend_down`               | 6+ consecutive increases or decreases                   |
+| `mr_above_url`                          | Moving range exceeds URL — unusual point-to-point churn |
+
+Consecutive out-of-bounds points are consolidated into one streak with `from`,
+`to`, `count`, and `peak`/`trough`. Single-point streaks use `date` instead of
+`from`/`to`.
+
+**Runs and trends are the most actionable** — they say the level has shifted.
+Point signals confirm the magnitude. `mr_above_url` means the limits themselves
+are unreliable until the chaos is investigated.
+
+## Report Shape
+
+`analyze --format=json` is the canonical output. Each metric:
+
+```json
+{
+  "metric": "open_vulnerabilities",
+  "unit": "count",
+  "n": 105,
+  "from": "2026-01-01",
+  "to": "2026-04-14",
+  "x_bar": 16.79,
+  "mr_bar": 0.64,
+  "unpl": 18.5,
+  "lnpl": 15.08,
+  "url": 2.11,
+  "latest": { "date": "2026-04-14", "value": 13, "mr": 1 },
+  "signals": [
+    { "rule": "run_below", "from": "2026-02-25", "to": "2026-04-14", "length": 50 },
+    { "rule": "point_below_lnpl", "from": "2026-03-02", "to": "2026-04-14", "count": 45, "trough": 7 }
+  ],
+  "status": "signals_present"
+}
+```
+
+`status` is one of:
+
+- `predictable` — stable process, no signals. Don't react to individual points.
+- `signals_present` — special cause detected. Read `signals`.
+- `insufficient_data` — fewer than 15 points. Keep recording.
+
+`summarize` reduces this to a markdown table with a coarse classification
+column: `stable`, `signals`, `chaos` (when `mr_above_url` is present), or
+`insufficient`.
+
+## Typical Workflow
+
+```sh
+npx fit-xmr validate observations.csv
+npx fit-xmr list observations.csv
+npx fit-xmr analyze observations.csv --metric open_vulnerabilities
+npx fit-xmr summarize observations.csv               # paste into a wiki page
+npx fit-xmr spark observations.csv --metric open_vulnerabilities
+```
+
+Validate first; list to see what's available; analyze a single metric to
+investigate; summarize for the rollup; spark for inline indicators.
+
+## Interpretation Guidance
+
+- **Predictable** processes vary within their natural limits. Reacting to a
+  single point is tampering — it makes the process worse on average.
+- **Runs and trends** mean something changed. Find what changed and decide
+  whether to lock it in or roll it back.
+- **Out-of-limits points** confirm magnitude. The size of the shift matters for
+  prioritization, not for the verdict.
+- **`mr_above_url`** says volatility itself spiked. The limits are computed from
+  `mr_bar`; if the moving range is unstable, the limits don't yet describe a
+  stable process. Investigate the volatility before reading the rest of the
+  report.
+- **Annotate the CSV `note` field** when you investigate a signal. The note is
+  the record of why the process changed; future analyses depend on it.
+- **Don't set targets from the limits.** Targets come from the work; limits
+  describe the work. Conflating them turns the chart into a stick.
+
+---
+
+## Documentation
+
+- [XmR Analysis](https://www.forwardimpact.team/docs/libraries/xmr-analysis/index.md)
+  — The full guide: CSV schema, commands, signal rules, a worked security
+  backlog example, and interpretation guidance.

--- a/.claude/skills/kata-metrics/SKILL.md
+++ b/.claude/skills/kata-metrics/SKILL.md
@@ -93,4 +93,6 @@ Outputs 12 bar characters scaled from ▁ (min) to █ (max) within the metric's
 range.
 
 See [`references/xmr.md`](references/xmr.md) for chart construction, signal
-rules, JSON report format, and interpretation guidance.
+rules, JSON report format, and interpretation guidance. The same material in
+public-facing form (for external readers) lives at the
+[XmR Analysis guide](https://www.forwardimpact.team/docs/libraries/xmr-analysis/index.md).

--- a/libraries/libxmr/bin/fit-xmr.js
+++ b/libraries/libxmr/bin/fit-xmr.js
@@ -43,7 +43,8 @@ const definition = {
     {
       name: "spark",
       args: "<csv-path>",
-      description: "Braille sparkline of last 12 points (for markdown tables)",
+      description:
+        "Block-character sparkline of last 12 points (for markdown tables)",
       options: {
         metric: {
           type: "string",

--- a/libraries/libxmr/bin/fit-xmr.js
+++ b/libraries/libxmr/bin/fit-xmr.js
@@ -85,6 +85,14 @@ const definition = {
     "fit-xmr summarize wiki/metrics/security-engineer/audit/2026.csv",
     "fit-xmr summarize wiki/metrics/security-engineer/audit/2026.csv --format json",
   ],
+  documentation: [
+    {
+      title: "XmR Analysis",
+      url: "https://www.forwardimpact.team/docs/libraries/xmr-analysis/index.md",
+      description:
+        "Distinguish stable processes from special causes with XmR control charts — CSV schema, signal rules, and how to read the report.",
+    },
+  ],
 };
 
 const cli = createCli(definition);

--- a/libraries/libxmr/src/commands/analyze.js
+++ b/libraries/libxmr/src/commands/analyze.js
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import {
   formatHeader,
   formatSection,
@@ -12,6 +12,10 @@ export function runAnalyzeCommand(values, args, cli) {
   const csvPath = args[0];
   if (!csvPath) {
     cli.usageError("analyze requires a <csv-path> argument");
+    process.exit(2);
+  }
+  if (!existsSync(csvPath)) {
+    cli.usageError(`cannot read CSV "${csvPath}": file not found`);
     process.exit(2);
   }
 

--- a/libraries/libxmr/src/commands/list.js
+++ b/libraries/libxmr/src/commands/list.js
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { formatHeader, formatTable } from "@forwardimpact/libcli";
 
 import { listMetrics } from "../xmr.js";
@@ -7,6 +7,10 @@ export function runListCommand(values, args, cli) {
   const csvPath = args[0];
   if (!csvPath) {
     cli.usageError("list requires a <csv-path> argument");
+    process.exit(2);
+  }
+  if (!existsSync(csvPath)) {
+    cli.usageError(`cannot read CSV "${csvPath}": file not found`);
     process.exit(2);
   }
 

--- a/libraries/libxmr/src/commands/spark.js
+++ b/libraries/libxmr/src/commands/spark.js
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 import { parseCSV, sparkline } from "../xmr.js";
 
@@ -10,6 +10,10 @@ export function runSparkCommand(values, args, cli) {
   }
   if (!values.metric) {
     cli.usageError("spark requires --metric");
+    process.exit(2);
+  }
+  if (!existsSync(csvPath)) {
+    cli.usageError(`cannot read CSV "${csvPath}": file not found`);
     process.exit(2);
   }
 

--- a/libraries/libxmr/src/commands/summarize.js
+++ b/libraries/libxmr/src/commands/summarize.js
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 import { analyze, classify } from "../xmr.js";
 
@@ -6,6 +6,10 @@ export function runSummarizeCommand(values, args, cli) {
   const csvPath = args[0];
   if (!csvPath) {
     cli.usageError("summarize requires a <csv-path> argument");
+    process.exit(2);
+  }
+  if (!existsSync(csvPath)) {
+    cli.usageError(`cannot read CSV "${csvPath}": file not found`);
     process.exit(2);
   }
 

--- a/libraries/libxmr/src/commands/validate.js
+++ b/libraries/libxmr/src/commands/validate.js
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import {
   formatHeader,
   formatSuccess,
@@ -12,6 +12,10 @@ export function runValidateCommand(values, args, cli) {
   const csvPath = args[0];
   if (!csvPath) {
     cli.usageError("validate requires a <csv-path> argument");
+    process.exit(2);
+  }
+  if (!existsSync(csvPath)) {
+    cli.usageError(`cannot read CSV "${csvPath}": file not found`);
     process.exit(2);
   }
 

--- a/websites/fit/docs/libraries/index.md
+++ b/websites/fit/docs/libraries/index.md
@@ -34,6 +34,15 @@ code observations, find patterns, and write grounded findings.
 
 </a>
 
+<a href="/docs/libraries/xmr-analysis/">
+
+### XmR Analysis
+
+Distinguish stable processes from special causes with `fit-xmr` — record
+observations over time, read signal rules, and turn variation into action.
+
+</a>
+
 </div>
 
 Looking for product workflows like authoring standards, agent teams, or landmark

--- a/websites/fit/docs/libraries/xmr-analysis/index.md
+++ b/websites/fit/docs/libraries/xmr-analysis/index.md
@@ -33,15 +33,18 @@ observation:
 date,metric,value,unit,run,note
 2026-01-01,open_vulnerabilities,12,count,https://example.com/run/1,
 2026-01-02,open_vulnerabilities,11,count,https://example.com/run/2,
-2026-01-03,open_vulnerabilities,11,count,https://example.com/run/3,
+2026-01-03,open_vulnerabilities,11,count,,
 ```
+
+Trailing commas keep the column count consistent when `run` and `note` are
+empty.
 
 | Field    | Required | Notes                                                                |
 | -------- | -------- | -------------------------------------------------------------------- |
 | `date`   | yes      | ISO 8601 (`YYYY-MM-DD`). Sort key.                                   |
 | `metric` | yes      | Metric name. One CSV may carry multiple metrics — they are grouped.  |
-| `value`  | yes      | Numeric. `NaN` is rejected by `validate`.                            |
-| `unit`   | yes      | Free text (`count`, `days`, `pct`, ...). Used in report headers.     |
+| `value`  | yes      | Numeric. Non-numeric strings are rejected by `validate`.             |
+| `unit`   | yes      | Free text (`count`, `days`, `pct`, ...). Empty `unit` is rejected.   |
 | `run`    | no       | Optional URL or identifier of the run that produced the observation. |
 | `note`   | no       | Free text — annotate with what you discovered when a signal appears. |
 
@@ -75,18 +78,23 @@ npx fit-xmr analyze observations.csv --metric open_vulnerabilities
 npx fit-xmr analyze observations.csv --format json
 ```
 
-For each metric the report prints:
+JSON output is the canonical shape; text is a pretty-print of the same data. The
+JSON document is wrapped in `{ source, generated, metrics: [...] }` — each
+metric in that array carries:
 
 - **`x_bar`** — central line, mean of all values.
-- **`mr_bar`** — average moving range (`|x_i - x_{i-1}|`).
+- **`mr_bar`** — average of the moving ranges `|x_i - x_{i-1}|`.
 - **`unpl`** / **`lnpl`** — upper / lower natural process limits
   (`x_bar ± 2.66 * mr_bar`; `lnpl` floors at 0 for counts).
 - **`url`** — upper range limit for the moving range chart (`3.27 * mr_bar`).
-- **`latest`** — the most recent observation.
-- **`signals`** — every special-cause signal detected.
+- **`latest`** — most recent observation as `{ date, value, mr }`. `mr` is the
+  moving range at that point — useful for "is today's change unusual?".
+- **`signals`** — special-cause signals, sorted by start date.
 - **`status`** — `predictable`, `signals_present`, or `insufficient_data`.
 
-The JSON output is the canonical shape; the text report is a pretty-print.
+The constants `2.66` and `3.27` are XmR's standard scale factors for the n=2
+moving range (≈ 3σ for individuals, D4 for the range chart). They are not
+tunable — that's what makes XmR limits comparable across processes.
 
 ## 3. Read the signals
 
@@ -100,28 +108,42 @@ to investigate, not a verdict.
 | `trend_up` / `trend_down`               | 6+ consecutive increases or decreases.                   |
 | `mr_above_url`                          | Moving range exceeds URL — unusual point-to-point churn. |
 
-Consecutive out-of-bounds points are consolidated into one streak signal with
-`from`, `to`, `count`, and `peak`/`trough`. Single-point streaks carry `date`
-instead of `from`/`to`.
+Signal payloads:
+
+- **Run signals** carry `from`, `to`, and `length` (point count).
+- **Trend signals** carry `from`, `to`, and `moves` (number of consecutive
+  same-direction transitions; 6 moves = 7 same-direction points).
+- **Point and mR signals** carry `count` plus `peak` (for above-limit) or
+  `trough` (for below-limit). Consecutive out-of-bounds points are consolidated
+  into one streak with `from`/`to`; single-point streaks carry `date` instead.
 
 **Runs and trends are usually the most actionable** — they say the process level
-has shifted. Point signals confirm the magnitude. `mr_above_url` says the limits
-themselves are unreliable until the chaos is investigated; treat the rest of the
-report cautiously when it appears.
+has shifted. Why those rules? A predictable process produces points that hop
+randomly across `x_bar`; under that null, eight consecutive points on one side
+or six consecutive same-direction moves are each rarer than 1%. Point signals
+confirm the magnitude of the shift; the size matters for prioritization, not for
+the verdict.
+
+`mr_above_url` is special. The limits are computed from `mr_bar`, so an outlier
+moving range inflates `mr_bar` and pulls UNPL/LNPL wider than the process
+actually warrants. Until you investigate the outlier — usually a single big jump
+— the rest of the report describes a stretched envelope, not a real one.
 
 ## 4. Summarize across metrics
 
 For a status overview across many metrics, `summarize` produces a markdown table
-you can paste into a wiki page or PR description:
+you can paste into a status page or PR description:
 
 ```sh
 npx fit-xmr summarize observations.csv
+npx fit-xmr summarize observations.csv --metric open_vulnerabilities
 npx fit-xmr summarize observations.csv --format json
 ```
 
-Each row carries the metric, sample count, latest value, `x_bar`, the limits, a
-coarse classification, and a compact list of signals. The classifications are
-deterministic:
+`--metric` filters to a single row; `--format json` returns the same data as
+JSON. Each row carries the metric, sample count, latest value, `x_bar`, the
+limits, a coarse classification, and a compact list of signals. The
+classifications are deterministic:
 
 - **`stable`** — `predictable` status, no signals.
 - **`signals`** — special cause detected; investigate.
@@ -134,16 +156,27 @@ crowd the active signals.
 ## 5. Sparklines for inline reporting
 
 For one-glance trend indicators in markdown tables, `spark` prints a
-twelve-character braille sparkline of the last twelve points:
+twelve-character block-element sparkline of the last twelve points:
 
 ```sh
 npx fit-xmr spark observations.csv --metric open_vulnerabilities
 # ▆▇█▇▆▅▄▃▃▂▁▁
 ```
 
-Sparklines are pure visual signal — no thresholds, no detection. Pair them with
-`summarize` for a status table that reads at a glance and drills into detail
-when needed.
+How to read it:
+
+- **Scale is per-series, not absolute** — the lowest of the last 12 points maps
+  to `▁`, the highest to `█`. Two sparklines from different metrics are not
+  comparable on visual height.
+- **Padding** — fewer than 12 points pad with leading spaces, so the bars always
+  right-align in markdown table cells.
+- **Flat or single-value series** render as a row of mid-bars (`▄`).
+- **Last 12 points only** — a level shift older than 12 observations is
+  invisible. Use `analyze` for shift detection; sparklines are situational
+  awareness.
+
+Pair them with `summarize` for a status table that reads at a glance and drills
+into detail when needed.
 
 ## Worked example: a security backlog
 
@@ -154,34 +187,47 @@ three months they run:
 npx fit-xmr analyze security/2026.csv --metric open_vulnerabilities
 ```
 
-The report shows `status: signals_present` with two signals: a `run_below` of 50
-days starting 2026-02-25, and a `point_below_lnpl` streak of 45 points in the
-same window. The interpretation:
+The report shows `status: signals_present` with three signals on the single
+metric:
 
-- **Run below `x_bar`** — the process has shifted. Open vulnerabilities are
-  consistently lower than they were in the first two months.
-- **Points below `lnpl`** — the magnitude of the shift is large enough to break
-  through the lower natural process limit.
+- A `run_above` of 55 points covering 2026-01-01 → 2026-02-24.
+- A `run_below` of 50 points covering 2026-02-25 → 2026-04-14.
+- A `point_below_lnpl` streak of 45 points in the post-shift window.
+
+This is the classic shape of a **level shift**: the global `x_bar` sits between
+the pre-shift and post-shift levels, so points fall consistently on one side
+then consistently on the other. Both runs are real signals — they say the
+process you have today is not the process you had in January.
 
 The team annotates the CSV `note` field on 2026-02-25 with the change that
 landed (a new pre-merge security gate) and treats the new level as the process
-baseline going forward. The next quarterly report will be computed against the
-post-shift data.
+baseline going forward. The next analysis is run against **post-shift data
+only** — otherwise `x_bar` keeps averaging across two different processes and
+the limits describe neither.
 
-This is the loop: record, analyze, investigate signals, annotate, repeat.
+This is the loop: record, analyze, investigate signals, annotate, recompute once
+a shift is locked in, repeat.
 
 ## Interpretation guidance
 
 - **Do not react to individual data points** when `status: predictable`. Routine
-  variation is noise, not signal.
+  variation is common-cause noise; treating it as a problem and intervening
+  makes the process worse on average. W. Edwards Deming called this _tampering_.
 - **Do not set targets based on the natural process limits.** They describe what
-  the process _does_, not what it _should_ do.
+  the process _does_, not what it _should_ do. Targets come from the work;
+  limits describe the work.
+- **A series spanning a level shift will surface signals on both sides** of
+  `x_bar` — that's not a bug. Once you confirm the shift is locked in, recompute
+  against the post-shift segment so the new limits describe the new process.
 - **Annotate the CSV** with what you discovered when a signal appears. The
-  `note` field is the record of why the process changed.
+  `note` field is the durable record of why the process changed.
 - **Keep at least 15 points** before reading limits. Below that the report marks
   the metric `insufficient_data` and computes nothing.
 
 ## Related
 
-- [`fit-xmr` reference](https://www.npmjs.com/package/@forwardimpact/libxmr) —
-  package on npm.
+- [`fit-xmr` on npm](https://www.npmjs.com/package/@forwardimpact/libxmr) —
+  installation and changelog.
+- [Trace Analysis](https://www.forwardimpact.team/docs/libraries/trace-analysis/index.md)
+  — qualitative analysis of agent traces; the same "let the data tell you"
+  posture applied to a different domain.

--- a/websites/fit/docs/libraries/xmr-analysis/index.md
+++ b/websites/fit/docs/libraries/xmr-analysis/index.md
@@ -1,0 +1,187 @@
+---
+title: XmR Analysis
+description: Distinguish stable processes from special causes with XmR control charts — record observations, read signal rules, and turn variation into action.
+---
+
+# XmR Analysis
+
+A metric on its own is a number. A metric over time is a process. **XmR control
+charts** (individuals and moving range) tell you whether that process is stable
+or reacting to a special cause — using the data itself to compute natural
+process limits, with no external targets required.
+
+`fit-xmr` reads a time-series CSV, computes the limits, detects four families of
+signals, and prints either a human-readable report, a compact markdown summary,
+or structured JSON for further analysis. It is the analysis surface on top of
+any CSV that records observations of a metric over time.
+
+This guide walks through the CSV schema, the commands, the signal rules, and how
+to interpret the report.
+
+## Prerequisites
+
+- Node.js 18+
+- A CSV of observations with the schema below
+- At least 15 data points per metric for limits to be meaningful
+
+## CSV schema
+
+`fit-xmr` expects the header `date,metric,value,unit,run,note` and one row per
+observation:
+
+```csv
+date,metric,value,unit,run,note
+2026-01-01,open_vulnerabilities,12,count,https://example.com/run/1,
+2026-01-02,open_vulnerabilities,11,count,https://example.com/run/2,
+2026-01-03,open_vulnerabilities,11,count,https://example.com/run/3,
+```
+
+| Field    | Required | Notes                                                                |
+| -------- | -------- | -------------------------------------------------------------------- |
+| `date`   | yes      | ISO 8601 (`YYYY-MM-DD`). Sort key.                                   |
+| `metric` | yes      | Metric name. One CSV may carry multiple metrics — they are grouped.  |
+| `value`  | yes      | Numeric. `NaN` is rejected by `validate`.                            |
+| `unit`   | yes      | Free text (`count`, `days`, `pct`, ...). Used in report headers.     |
+| `run`    | no       | Optional URL or identifier of the run that produced the observation. |
+| `note`   | no       | Free text — annotate with what you discovered when a signal appears. |
+
+Validate before analysis:
+
+```sh
+npx fit-xmr validate observations.csv
+```
+
+A non-zero exit code means the file does not match the schema.
+
+## 1. Get oriented
+
+List what's in the file before charting:
+
+```sh
+npx fit-xmr list observations.csv
+```
+
+Prints one row per metric with the count of observations and the date range.
+Useful when a CSV carries several metrics and you only want to chart one of
+them.
+
+## 2. Run the analysis
+
+The full report lives in `analyze`:
+
+```sh
+npx fit-xmr analyze observations.csv
+npx fit-xmr analyze observations.csv --metric open_vulnerabilities
+npx fit-xmr analyze observations.csv --format json
+```
+
+For each metric the report prints:
+
+- **`x_bar`** — central line, mean of all values.
+- **`mr_bar`** — average moving range (`|x_i - x_{i-1}|`).
+- **`unpl`** / **`lnpl`** — upper / lower natural process limits
+  (`x_bar ± 2.66 * mr_bar`; `lnpl` floors at 0 for counts).
+- **`url`** — upper range limit for the moving range chart (`3.27 * mr_bar`).
+- **`latest`** — the most recent observation.
+- **`signals`** — every special-cause signal detected.
+- **`status`** — `predictable`, `signals_present`, or `insufficient_data`.
+
+The JSON output is the canonical shape; the text report is a pretty-print.
+
+## 3. Read the signals
+
+`fit-xmr` detects four families of special-cause signals. Treat each as a prompt
+to investigate, not a verdict.
+
+| Rule                                    | Meaning                                                  |
+| --------------------------------------- | -------------------------------------------------------- |
+| `point_above_unpl` / `point_below_lnpl` | One or more points outside the natural process limits.   |
+| `run_above` / `run_below`               | 8+ consecutive points on the same side of `x_bar`.       |
+| `trend_up` / `trend_down`               | 6+ consecutive increases or decreases.                   |
+| `mr_above_url`                          | Moving range exceeds URL — unusual point-to-point churn. |
+
+Consecutive out-of-bounds points are consolidated into one streak signal with
+`from`, `to`, `count`, and `peak`/`trough`. Single-point streaks carry `date`
+instead of `from`/`to`.
+
+**Runs and trends are usually the most actionable** — they say the process level
+has shifted. Point signals confirm the magnitude. `mr_above_url` says the limits
+themselves are unreliable until the chaos is investigated; treat the rest of the
+report cautiously when it appears.
+
+## 4. Summarize across metrics
+
+For a status overview across many metrics, `summarize` produces a markdown table
+you can paste into a wiki page or PR description:
+
+```sh
+npx fit-xmr summarize observations.csv
+npx fit-xmr summarize observations.csv --format json
+```
+
+Each row carries the metric, sample count, latest value, `x_bar`, the limits, a
+coarse classification, and a compact list of signals. The classifications are
+deterministic:
+
+- **`stable`** — `predictable` status, no signals.
+- **`signals`** — special cause detected; investigate.
+- **`chaos`** — `mr_above_url` present; the limits are not trustworthy.
+- **`insufficient`** — fewer than 15 points; keep recording.
+
+Metrics with insufficient data are listed below the main table so they don't
+crowd the active signals.
+
+## 5. Sparklines for inline reporting
+
+For one-glance trend indicators in markdown tables, `spark` prints a
+twelve-character braille sparkline of the last twelve points:
+
+```sh
+npx fit-xmr spark observations.csv --metric open_vulnerabilities
+# ▆▇█▇▆▅▄▃▃▂▁▁
+```
+
+Sparklines are pure visual signal — no thresholds, no detection. Pair them with
+`summarize` for a status table that reads at a glance and drills into detail
+when needed.
+
+## Worked example: a security backlog
+
+A team records open vulnerability counts daily into `security/2026.csv`. After
+three months they run:
+
+```sh
+npx fit-xmr analyze security/2026.csv --metric open_vulnerabilities
+```
+
+The report shows `status: signals_present` with two signals: a `run_below` of 50
+days starting 2026-02-25, and a `point_below_lnpl` streak of 45 points in the
+same window. The interpretation:
+
+- **Run below `x_bar`** — the process has shifted. Open vulnerabilities are
+  consistently lower than they were in the first two months.
+- **Points below `lnpl`** — the magnitude of the shift is large enough to break
+  through the lower natural process limit.
+
+The team annotates the CSV `note` field on 2026-02-25 with the change that
+landed (a new pre-merge security gate) and treats the new level as the process
+baseline going forward. The next quarterly report will be computed against the
+post-shift data.
+
+This is the loop: record, analyze, investigate signals, annotate, repeat.
+
+## Interpretation guidance
+
+- **Do not react to individual data points** when `status: predictable`. Routine
+  variation is noise, not signal.
+- **Do not set targets based on the natural process limits.** They describe what
+  the process _does_, not what it _should_ do.
+- **Annotate the CSV** with what you discovered when a signal appears. The
+  `note` field is the record of why the process changed.
+- **Keep at least 15 points** before reading limits. Below that the report marks
+  the metric `insufficient_data` and computes nothing.
+
+## Related
+
+- [`fit-xmr` reference](https://www.npmjs.com/package/@forwardimpact/libxmr) —
+  package on npm.


### PR DESCRIPTION
## Summary

- New external-facing **XmR Analysis** guide at `websites/fit/docs/libraries/xmr-analysis/index.md` covering CSV schema, all five commands, the four signal-rule families with payload fields, the SPC framing for the 2.66/3.27 constants, sparkline reading, a worked level-shift example, and Deming-rooted interpretation guidance.
- New `fit-xmr` skill at `.claude/skills/fit-xmr/SKILL.md` matching the published guide and routing agents to the right tool.
- `documentation` block added to the `fit-xmr` CLI definition so `--help` surfaces the same fully-qualified guide URL — the three artifacts (skill, guide, CLI) all link to one canonical task slug per `libraries/CLAUDE.md`.
- `libraries/libxmr` CLI now exits 2 with a friendly `cannot read CSV "<path>": file not found` instead of a raw `ENOENT` stack across all five commands; spark help text corrected from "Braille" (the chars are Unicode block elements, not Braille code points).
- `kata-metrics/SKILL.md` cross-linked to the new public guide.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (2517 pass)
- [x] `node libraries/libxmr/bin/fit-xmr.js --help` renders the new Documentation section.
- [x] `node libraries/libxmr/bin/fit-xmr.js analyze /tmp/no-such.csv` exits 2 with friendly error (no stack trace).
- [x] Five-reviewer panel verified accuracy and depth of skill + guide; all valid findings applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SH1L6w9PHwJvrdT6YF8TsB)_