### PR TITLE
fix(kata): require prior phase merged on origin/main, not just approved

### DIFF
--- a/.claude/agents/references/coordination-protocol.md
+++ b/.claude/agents/references/coordination-protocol.md
@@ -51,9 +51,13 @@ equivalent forms — both first-class GitHub primitives:
 "ship it" from a trusted account) into one of the canonical forms before
 concluding.
 
-Phase progression is otherwise derived from `main`: the file's existence
-(`specs/NNN/spec.md`, `design-a.md`, `plan-a.md`) implies the prior phase was
-approved and merged. No separate status tracker.
+**Approval is not phase progression.** The approval signal authorizes
+`kata-release-merge` to merge the PR; it does not by itself advance the phase.
+Phase progression is derived only from `main`: the next phase begins when the
+prior phase's artifact (`specs/NNN/spec.md`, `design-a.md`, `plan-a.md`) is on
+`main` — i.e. the prior phase's PR has been merged. An approved-but-unmerged PR
+does not unblock the next phase, even when the same agent owns both. No separate
+status tracker.
 
 ## Decision questions
 

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -39,20 +39,20 @@ every GitHub comment and PR body with `— Staff Engineer 🛠️`.
 
 ## Assess
 
-Survey domain state, then choose the highest-priority action:
+Run `git fetch origin main` on every phase boundary, then route from
+`origin/main` only. A `<phase>:approved` label on an open PR — even one you just
+authored — does not advance routing. Pick the highest-priority action:
 
 0. **[Action routing](.claude/agents/references/memory-protocol.md#action-routing)**
    — read Tier 1; owned priorities and storyboard items preempt domain steps.
-1. **Approved specs without designs?** -- `kata-design` (specs/NNN/ where
-   `spec.md` is on `main` but `design-a.md` is not)
-2. **Approved designs without plans?** -- `kata-plan` (specs/NNN/ where
-   `design-a.md` is on `main` but `plan-a.md` is not)
-3. **Planned specs awaiting implementation?** -- `kata-implement` on a
-   `feat/<spec-slug>` branch (specs/NNN/ where `plan-a.md` is on `main` but no
-   merged PR carries `plan:implemented` referencing the spec)
+1. **Merged specs without designs?** -- `kata-design` (specs/NNN/ where
+   `spec.md` is on `origin/main` but `design-a.md` is not)
+2. **Merged designs without plans?** -- `kata-plan` (specs/NNN/ where
+   `design-a.md` is on `origin/main` but `plan-a.md` is not)
+3. **Merged plans awaiting implementation?** -- `kata-implement` on a
+   `feat/<spec-slug>` branch (specs/NNN/ where `plan-a.md` is on `origin/main`
+   but no merged PR carries `plan:implemented` referencing the spec)
 4. **Fallback** -- MEMORY.md items listing you under Agents, then report clean.
-
-After choosing, follow the selected skill's full procedure.
 
 ## Constraints
 

--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -22,8 +22,8 @@ is no commitment to implement, and a design has nothing to shape.
 
 ## When to Use
 
-- Turning an approved spec (`specs/NNN/spec.md` exists on `main`) into an
-  architectural design
+- Turning a merged spec (`specs/NNN/spec.md` on `origin/main`, not just a
+  `spec:approved` label on an open PR) into an architectural design
 - Reviewing a design before approval ("review design NNN", "is design NNN
   ready?")
 - Revisiting a design whose direction needs rethinking before planning
@@ -32,10 +32,10 @@ is no commitment to implement, and a design has nothing to shape.
 
 <read_do_checklist goal="Internalize design-writing boundaries before starting">
 
-- [ ] Confirm the spec is approved by checking `specs/NNN/spec.md` exists on
-      `main`: `git show main:specs/NNN/spec.md` succeeds. Do not rely on the
-      wiki, prior session memory, or PR descriptions.
-- [ ] A design requires an approved spec — if `spec.md` is not on `main`, stop.
+- [ ] Run `git fetch origin main`, then confirm `specs/NNN/spec.md` exists on
+      `origin/main` (`git show origin/main:specs/NNN/spec.md` succeeds). A
+      `spec:approved` label on an open PR is **not** sufficient — wait for the
+      spec PR to merge, even if you authored or approved it this session.
 - [ ] Do not write or revise the spec — return it to `draft` if it needs
       changes.
 - [ ] Do not write the plan — this skill writes the design; `kata-plan`
@@ -147,7 +147,9 @@ from prior `staff-engineer` entries.
 
 ### Steps
 
-1. **Find the spec.** Requires `specs/NNN/spec.md` on `main`; otherwise stop.
+1. **Find the spec.** Run `git fetch origin main`, then require
+   `specs/NNN/spec.md` on `origin/main`; otherwise stop. An open spec PR with
+   `spec:approved` does not satisfy this — wait for the merge.
 2. **Study the spec.** Read `spec.md` end to end.
 3. **Research the codebase.** Read the code areas the spec targets.
 4. **Write the design.** Create `design-a.md`. Stay under 200 lines. Each

--- a/.claude/skills/kata-implement/SKILL.md
+++ b/.claude/skills/kata-implement/SKILL.md
@@ -16,8 +16,7 @@ the plan to understand HOW and WHEN, then implement the changes methodically.
 
 ## When to Use
 
-- A spec and plan exist on `main` (`specs/NNN/spec.md` and `specs/NNN/plan-a.md`
-  both present)
+- Spec and plan are merged on `origin/main` (see READ-DO).
 - The user says "implement spec NNN", "implement the plan for spec NNN",
   "execute the plan for NNN", "build spec NNN", or "start implementation of NNN"
 - Resuming a partially completed implementation ("continue spec NNN", "finish
@@ -30,6 +29,8 @@ apply alongside the skill-specific ones below.
 
 <read_do_checklist goal="Internalize scope and constraints before coding">
 
+- [ ] Run `git fetch origin main`, then confirm `specs/NNN/plan-a.md` exists on
+      `origin/main` (an open `plan:approved` PR is not enough — wait for merge).
 - [ ] Read the full spec and all plan files before writing any code.
 - [ ] Implement plan-a unless explicitly directed to a different variant.
 - [ ] Implement only what the plan describes — no unrequested refactors,

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -19,8 +19,8 @@ there is no architectural direction to translate into implementation steps.
 
 ## When to Use
 
-- Turning an approved design (`specs/NNN/design-a.md` exists on `main`) into an
-  execution-ready plan
+- Turning a merged design (`specs/NNN/design-a.md` on `origin/main`, not just a
+  `design:approved` label on an open PR) into an execution-ready plan
 - Reviewing a plan before approval ("review plan NNN", "is plan NNN ready?")
 - Creating an alternative plan variant for the same spec
 
@@ -28,11 +28,10 @@ there is no architectural direction to translate into implementation steps.
 
 <read_do_checklist goal="Internalize plan-writing boundaries before starting">
 
-- [ ] Confirm the design is approved by checking `specs/NNN/design-a.md` exists
-      on `main`: `git show main:specs/NNN/design-a.md` succeeds. Do not rely on
-      the wiki, prior session memory, or PR descriptions.
-- [ ] A plan requires an approved design — if `design-a.md` is not on `main`,
-      stop.
+- [ ] Run `git fetch origin main`, then confirm `specs/NNN/design-a.md` exists
+      on `origin/main` (`git show origin/main:specs/NNN/design-a.md` succeeds).
+      A `design:approved` label on an open PR is **not** sufficient — wait for
+      the design PR to merge, even if you authored or approved it this session.
 - [ ] Do not write or revise the spec — return it to `draft` if it needs
       changes.
 - [ ] Do not implement — this skill writes the plan; `kata-implement` executes
@@ -165,8 +164,9 @@ deferred work from prior `staff-engineer` entries.
 
 ### Steps
 
-1. **Find the spec.** Requires `specs/NNN/design-a.md` on `main`; otherwise
-   stop.
+1. **Find the design.** Run `git fetch origin main`, then require
+   `specs/NNN/design-a.md` on `origin/main`; otherwise stop. An open design PR
+   with `design:approved` does not satisfy this — wait for the merge.
 2. **Study the spec and design.** Read both end to end.
 3. **Research the codebase.** Read the files the plan will target.
 4. **Write the plan.** Create `plan-a.md`. Each step independently verifiable.


### PR DESCRIPTION
## Summary

- Tightens phase-progression gating in the kata skills so a `<phase>:approved` label on an open PR no longer authorizes the next phase. The next phase begins only when the prior phase's artifact is on `origin/main`.
- Diagnosed from spec 630: the implementation branch (`feat/630-summit-validate-warnings`, PR #697) was created at 12:28 while the plan PR (#696) was still open with `plan:approved` applied — `git ls-tree` confirms `plan-a.md` is missing from the feat branch's tree.
- Spec 760 sequenced correctly on `origin/main` (spec #688 → design #691 → plan #693, all merged in order); 630 is the failure case this PR addresses.

## What changed

| File | Change |
| --- | --- |
| `.claude/agents/references/coordination-protocol.md` | § Approval signal: explicit "Approval is not phase progression" paragraph distinguishing label/review (= OK to merge) from artifact on `origin/main` (= next phase OK to begin). |
| `.claude/agents/staff-engineer.md` | Assess: `git fetch origin main` on every phase boundary; routing reads `origin/main` only; `<phase>:approved` on an open PR (including self-authored) does not advance routing; routing bullets renamed "Merged …" for parallelism. |
| `.claude/skills/kata-design/SKILL.md` | When-to-Use, READ-DO, and Process Step 1 each gate the spec on `origin/main` via `git fetch origin main` + `git show origin/main:specs/NNN/spec.md`. |
| `.claude/skills/kata-plan/SKILL.md` | Same tightening for `design-a.md`. |
| `.claude/skills/kata-implement/SKILL.md` | Same tightening for `plan-a.md`; explicit "wait for the plan PR to merge before branching the implementation". |

The merge gate at `kata-release-merge` already blocks implementation PRs whose parent plan-a.md isn't on main; this PR pushes that gate one step earlier (authoring time, not merge time).

## Process

3-reviewer kata-review panel against the diff: 0 blocker / 0 high after addressing consensus high (When-to-Use loose phrasing in kata-design and kata-plan) and consensus medium (mixed `main` vs `origin/main` labeling) findings. Singleton findings about residual "approved" wording in front-matter / intro sentences were dismissed as scope-creep beyond the merge-gate clarification — the operational gates (When-to-Use + READ-DO + Process Step 1 + coordination-protocol § Approval signal) now carry the strong rule.

## Test plan

- [x] `bun run check` passes (format, lint, harness, context limits — including the L3 64-line agent-profile cap and L4 192-line skill-procedure caps, which constrained final wording).

— Staff Engineer 🛠️