### PR TITLE
spec(770, 780): fit-wiki CLI and fit-xmr record

### DIFF
--- a/specs/770-agent-tooling-memo-metric/grounded-analysis.md
+++ b/specs/770-agent-tooling-memo-metric/grounded-analysis.md
@@ -1,0 +1,353 @@
+# SCRATCHPAD-6 — Grounded Theory Analysis: Memory and Metrics in Agent Traces
+
+> Trace corpus: 33 structured traces (18 distinct workflow runs), ~10,500 turns.
+> Traces span 2026-04-17 through 2026-05-02.
+> Workflow types: 6 storyboard sessions, 3 coaching sessions, 24 agent runs
+> (staff-engineer, product-manager, technical-writer, security-engineer,
+> release-engineer, react).
+
+## Method
+
+Open coding on raw trace data. No hypothesis at start. Observations labeled
+with the trace's own vocabulary (tool names, file paths, status codes).
+Saturation reached when new traces confirmed existing categories without
+producing new codes.
+
+---
+
+## Theme 1: How Memory Is Accessed and Used
+
+### 1.1 Three-layer memory architecture observed in practice
+
+Agents interact with three distinct memory layers, each with different read/write
+patterns:
+
+| Layer | Location | Read frequency | Write frequency | Primary accessor |
+|---|---|---|---|---|
+| **Memory protocol** | `.claude/agents/references/memory-protocol.md` | 20 reads across 20 traces | Never written by agents | All agents (early in run) |
+| **Wiki MEMORY.md** | `wiki/MEMORY.md` | 23 reads across 23 traces | Facilitator only | All agents (early in run) |
+| **Claude Code memory** | `~/.claude/projects/.../memory/MEMORY.md` | 3 reads across 3 traces | Never written by agents | SE, TW (early in run) |
+
+**Memo**: The memory-protocol is *instructions about how to use memory*, not
+memory itself. Wiki MEMORY.md is the *shared index*. Claude Code memory is the
+per-session local memory that doesn't exist in CI (always returns "File does not
+exist" in GitHub Actions).
+
+### 1.2 Initialization ritual: a stable boot sequence
+
+Solo agent runs show a remarkably consistent initialization sequence:
+
+```
+1. Read memory-protocol.md        (how to use memory)
+2. ls wiki/                        (discover what exists)
+3. Read wiki/<agent-name>.md       (own summary)
+4. Read wiki/MEMORY.md             (shared memory index)
+5. Read wiki/storyboard-2026-M0x.md (current month context)
+6. Read wiki/<agent-name>-2026-W<nn>.md  (own weekly log)
+```
+
+Observed in PM runs (24948297842, 25091268802), SE runs (25244600948,
+25251321109), TW runs (25037251150, 25245215992). The sequence order varies
+slightly (some agents read MEMORY.md before their own summary) but the set of
+files is near-identical.
+
+**Memo**: This is a self-orienting ritual. The agent has no persistent context
+between runs — each run starts cold. The boot sequence reconstructs "who am I,
+what have I been doing, what does the team know." The wiki summary acts as the
+agent's own résumé; MEMORY.md acts as the team's shared bulletin board.
+
+### 1.3 Storyboard: facilitator reads first, participants read later
+
+In storyboard sessions, the facilitator performs the boot sequence *before*
+spawning participants:
+
+```
+Facilitator:
+  Turn ~16-20: Read wiki/storyboard-2026-M0x.md
+  Turn ~16-20: Read wiki/improvement-coach-2026-W<nn>.md
+  Turn ~25-60: Run fit-xmr analyze on ALL metric CSVs
+
+Participants (spawned ~Turn 80-120):
+  Each reads own summary, then MEMORY.md, then metrics CSV
+```
+
+The facilitator front-loads all XmR analysis before anyone is asked a question.
+Participants never see the raw XmR JSON — the facilitator synthesizes it into
+Q2 briefings tailored to each participant's domain.
+
+### 1.4 Wiki summary files: the memory spine
+
+Every agent maintains two wiki files:
+
+- `wiki/<agent>.md` — **Summary** (capped at ~80 lines). Contains: last run
+  timestamp, curation state, documentation review state, watching list,
+  experiment status, open blockers, observations for teammates.
+- `wiki/<agent>-2026-W<nn>.md` — **Weekly log**. Append-only narrative of each
+  run's decisions, actions, and outcomes.
+
+The summary is the high-frequency read target (always read during boot). The
+weekly log is read less frequently — mainly by the agent itself when it needs
+to reconstruct its own history, or by the facilitator during coaching sessions.
+
+**Memo**: The summary is designed to be *small enough to read every time*. This
+is a deliberate constraint — 80 lines means the agent can always load its own
+state without context budget pressure. The weekly log absorbs everything that
+doesn't fit.
+
+### 1.5 Claude Code memory vs wiki memory: separate systems, separate purposes
+
+Three traces show agents attempting to read `~/.claude/projects/.../memory/MEMORY.md`
+in CI. It always returns "File does not exist." The agents immediately fall back
+to `wiki/MEMORY.md`.
+
+In trace 25247279159, security-engineer reads Claude Code MEMORY.md (Turn 113),
+gets "File does not exist", then reads `wiki/security-engineer.md` (Turn 132)
+without any visible disruption. The missing file causes no retry, no error
+handling — the agent just proceeds.
+
+**Memo**: Claude Code memory and wiki memory are *not the same system*. Claude
+Code memory is per-user, per-project, local. Wiki memory is team-shared,
+git-backed, available in CI. Agents in CI only have wiki memory. This duality is
+not explicitly documented in the traces — agents just discover it and adapt.
+
+### 1.6 Cross-team observations: memory as coordination channel
+
+The technical-writer summary contains an "Observations for Teammates" section
+(see coaching trace 25031652139, Turn 24). These are directed messages: "Staff
+engineer: audit X", "Security engineer: acknowledge Y", "All agents: study Z."
+
+This is memory *used as coordination*. The TW writes an observation addressed to
+SE; SE reads the TW summary during its next boot sequence and (ideally) acts on
+it. The traces show this works — but also show gaps: in the coaching trace, the
+improvement coach notes that an observation about `d642ff0c` has been
+"10 days unacknowledged by SE."
+
+**Memo**: The observation channel is asynchronous and unreliable. There is no
+delivery guarantee — it depends on the addressed agent *reading* the sender's
+summary and *recognizing* the observation as relevant. The coaching session
+surfaced this as a process gap.
+
+### 1.7 MEMORY.md curation: a dedicated TW responsibility
+
+The technical-writer explicitly tracks "memory-index" as a curation area with a
+last-curated date. In trace 25031652139, the TW summary shows:
+
+```
+| Area            | Last Curated |
+| memory-index    | 2026-04-27   |
+```
+
+The TW reads and updates `wiki/MEMORY.md` as part of its curation duties —
+refreshing stale entries, correcting status labels, removing resolved items.
+This is the only agent with *write* responsibility for MEMORY.md (beyond the
+facilitator who reads it for context).
+
+---
+
+## Theme 2: How Metrics and fit-xmr Are Accessed and Used
+
+### 2.1 The facilitator is the primary XmR consumer
+
+Across all 6 storyboard traces, the facilitator runs `bunx fit-xmr analyze`
+against **every** metrics CSV at the start of the session. The count of
+facilitator fit-xmr invocations per storyboard:
+
+| Storyboard date | fit-xmr analyze calls | fit-xmr chart calls |
+|---|---|---|
+| Apr 26 (24951520222) | 8 | 0 |
+| Apr 27 (24984886254) | 7 | 0 |
+| Apr 30 (25155517604) | 6 | 0 |
+| May 1 (25207876777) | 6 | 0 |
+| May 2 (25247279159) | 12 | 6 |
+
+The May 2 session is the first to use `fit-xmr chart`, generating ASCII XmR
+charts for 6 metrics. Earlier sessions relied solely on the JSON `analyze`
+output.
+
+### 2.2 Participants rarely run fit-xmr themselves
+
+Only 3 traces show a non-facilitator agent running `fit-xmr analyze`:
+
+- **product-manager** (25207876777, Turns 142/162): Ran analyze on own backlog
+  CSV during Q2 prep. Also ran `fit-xmr summarize` (Turn 482/484).
+- **security-engineer** (25207876777, Turns 390/392/470/473): Ran analyze on
+  own audit + triage CSVs. Piped output through Python for compact formatting.
+- **release-engineer** (25247279159, Turn 385): Ran analyze on own release CSV,
+  piped through Python for summary.
+
+Two traces show `fit-xmr validate` (staff-engineer checking CSV format) rather
+than `analyze`.
+
+**Memo**: The facilitator is the "XmR engine." Participants receive pre-digested
+XmR status through Q2 briefings. When participants do run fit-xmr themselves,
+it's for self-service verification — confirming the facilitator's synthesis or
+checking their latest append. This is a hub-and-spoke pattern, not peer-to-peer.
+
+### 2.3 XmR output flows through facilitator synthesis, not raw JSON
+
+The facilitator consumes raw fit-xmr JSON and produces human-readable briefings.
+Example from trace 25247279159, Turn 296 (Q2 to product-manager):
+
+```
+| domain | metric | n | status | μ | latest | signals |
+|---|---|---|---|---|---|---|
+| backlog | issues_triaged | 23 | signals_present (chaos) | 1.0 | 0 | xRule1... |
+```
+
+The JSON contains `stats.mu`, `stats.UPL`, `signals.xRule1[].description`, etc.
+The facilitator extracts these into a table, adds context ("the x=10.0
+outlier — likely the PR #551 wave triage burst"), and asks the participant to
+reconcile.
+
+**Memo**: The synthesis step is where *interpretation* happens. Raw XmR output
+is statistical — "xRule1 at slot 6, x=10.0 > UPL=5.8." The facilitator adds
+*provenance* — "likely the PR #551 wave triage burst." This is the gap between
+measurement and understanding.
+
+### 2.4 Metrics CSV: append-only protocol with structured rows
+
+Every agent appends rows to its own `wiki/metrics/<agent>/<domain>/2026.csv`
+using `cat >> ... <<'EOF'` (Bash heredoc). The row format is consistent:
+
+```
+date,metric,value,unit,run,note
+2026-04-26,open_prs,2,count,run-42,#460 hold + #528 feat...
+```
+
+The `run` field links back to a GitHub Actions run URL or a human-readable label
+(e.g., `storyboard-W17-day7`, `coaching-1on1-W18-day1-baseline`). The `note`
+field provides context that would otherwise be lost.
+
+Metrics are written **after** the agent's primary work is complete and **before**
+the wiki summary update. This ordering is consistent across 12 of 14 traces
+checked (2 traces showed summary-first, then metrics).
+
+### 2.5 Metric ownership is strict: agents write only their own CSVs
+
+No trace shows an agent writing to another agent's metrics CSV. The only
+exception is the **facilitator** (improvement-coach role in storyboard sessions)
+writing to `wiki/metrics/improvement-coach/coaching/2026.csv` — which is its own
+domain. The `cat >>` pattern means agents exclusively append — no agent ever
+edits or overwrites another agent's historical data.
+
+One notable exception: the technical-writer appended a row to
+`wiki/metrics/improvement-coach/coaching/2026.csv` in trace 24867602412 (Turn
+230). This was during a coaching session where the TW was the *participant*
+being coached, and the append was trace-analysis metrics for the coach's domain.
+This cross-write was discussed in the session and sanctioned by the facilitator.
+
+### 2.6 XmR status progression: the maturity model in practice
+
+Across the traces, metrics show a clear maturity progression:
+
+1. **insufficient_data** (n < 15): Most new metrics start here. Staff-engineer
+   `design` metrics at n=1 in the May 2 storyboard.
+2. **sufficient_data / predictable**: Reached when n >= 15 and no signals.
+   SE audit `findings_count` crossed from insufficient to predictable at n=16
+   in the May 2 storyboard.
+3. **signals_present** (chaos): PM `issues_triaged` at n=23 still shows
+   xRule1 signals — a legitimate outlier from the PR #551 triage wave.
+4. **Saturation**: TW `coverage` at 8/8 for 5+ days triggered retirement
+   proposals (Exp 19). The metric stopped being informative.
+
+**Memo**: XmR is not a pass/fail gate — it's a *voice of the process*. The
+facilitator uses status transitions as conversation starters: "SE just crossed
+to predictable — first step toward Dim 2 target of >= 6." Signals_present
+triggers root-cause investigation, not remediation.
+
+### 2.7 Experiment pre-registration: metrics as accountability
+
+Experiments are pre-registered with expected outcomes *before* the data is
+collected. From coaching trace 25031652139:
+
+```
+Expected outcome locked before-the-fact: next 2 artifact-driven entries
+each land in N=1 commits
+Verdict horizon 2026-05-12 23:59Z
+if n<2, declare insufficient_data and re-scope
+```
+
+This is the Deming-influenced PDSA cycle in action. The experiment defines
+the metric, the expected outcome, and the verdict conditions. The XmR chart
+provides the statistical lens for judging whether the outcome was achieved
+by the process (predictable change) vs. noise (signal within natural limits).
+
+### 2.8 kata-metrics SKILL.md: rarely read, protocol embedded in agents
+
+Only 2 traces show an agent reading `.claude/skills/kata-metrics/SKILL.md`
+(release-engineer in 25207876777, staff-engineer in 25244600948). Most agents
+appear to have the metrics protocol embedded in their agent definition rather
+than loading it from the skill at runtime.
+
+Similarly, the `wiki/xmr-analysis-protocol.md` file exists in the wiki but is
+never explicitly read by any agent in the trace corpus. The protocol knowledge
+appears to be carried by the facilitator's system prompt rather than loaded
+dynamically.
+
+---
+
+## Central Explanation
+
+The agent team operates a **two-tier memory system** that separates
+*orientation* from *measurement*:
+
+**Tier 1 — Orientation (wiki markdown)**: Summaries, weekly logs, MEMORY.md,
+and storyboard logs give agents enough context to self-orient on cold start.
+The boot sequence is a reconstruction ritual: the agent rebuilds its identity,
+its recent history, and its team context from files that fit within a single
+context load. This tier is human-readable, narrative-shaped, and curated by the
+technical-writer.
+
+**Tier 2 — Measurement (metrics CSV + fit-xmr)**: Append-only CSV rows give
+agents a time-series record of their process. `fit-xmr analyze` transforms
+those rows into statistical signals (predictable vs. chaos, rules violated,
+control limits). The facilitator is the primary consumer of this layer — it
+synthesizes raw XmR output into team-legible briefings during storyboard
+sessions.
+
+The two tiers connect through the **storyboard session**: the facilitator reads
+Tier 2 (metrics), synthesizes it, and presents it to participants who update
+Tier 1 (their wiki summaries) based on the discussion. Coaching sessions
+close the loop tighter: the coach analyzes individual traces and metrics,
+identifies obstacles, and locks experiments whose outcomes are measured in
+Tier 2 and discussed in the next Tier 1 update.
+
+### Key findings
+
+1. **Memory is read universally, written narrowly.** Wiki/MEMORY.md is read by
+   every agent on every run (23/23 traces). But only the facilitator and
+   technical-writer write to it. Individual agents write only their own summary
+   and weekly log.
+
+2. **XmR analysis is centralized in the facilitator.** 56 of 63 `fit-xmr
+   analyze` calls (89%) come from the facilitator. Participants run it
+   occasionally for self-verification but rely on the facilitator's synthesis
+   for team context.
+
+3. **Metrics ownership is strict; memory curation is shared.** Each agent
+   appends only its own CSV rows. But wiki summaries contain cross-team
+   observations — memory is a coordination channel, not just a personal journal.
+
+4. **The boot sequence is the most stable pattern in the system.** Despite no
+   explicit orchestration, every solo agent follows the same initialization
+   ritual: protocol → wiki ls → own summary → MEMORY.md → storyboard → weekly
+   log. This convergence suggests the memory-protocol.md instructions are
+   effective — or that the agents independently discovered the same optimal
+   loading order.
+
+5. **Claude Code memory is irrelevant in CI.** The `~/.claude/projects/.../
+   memory/MEMORY.md` path doesn't exist in GitHub Actions. Agents that check
+   it fail silently and fall back to wiki memory. This is a graceful
+   degradation, but it means CI agents and interactive agents have different
+   memory surfaces.
+
+6. **XmR chart output is new and rare.** Only the May 2 storyboard (the most
+   recent) uses `fit-xmr chart` for ASCII visualization. All prior sessions
+   used only `fit-xmr analyze --format json`. The charts were generated at
+   session close for the storyboard log, not for participant briefing.
+
+7. **Cross-team observations are asynchronous and unreliable.** The TW's
+   "Observations for Teammates" section is the primary cross-agent coordination
+   mechanism within wiki memory. But delivery is not guaranteed — it depends on
+   the target agent reading the TW summary. The coaching session identified a
+   10-day-unacknowledged observation as a process gap.

--- a/specs/770-agent-tooling-memo-metric/spec.md
+++ b/specs/770-agent-tooling-memo-metric/spec.md
@@ -1,4 +1,4 @@
-# Spec 770 — Agent tooling: `fit-memo` and `fit-xmr record`
+# Spec 770 — Agent tooling: `fit-wiki memo` and `fit-xmr record`
 
 ## Problem
 
@@ -36,15 +36,19 @@ tokens on file discovery, section parsing, or CSV formatting.
 
 ## Scope (in)
 
-### 1. `fit-memo` — cross-team observation utility
+### 1. `fit-wiki memo` — cross-team observation command
 
-A new CLI (new package or hosted in an existing library) that appends a
-timestamped observation to a target agent's wiki summary file.
+A new `memo` subcommand on a new `fit-wiki` CLI, provided by a new `libwiki`
+package (`@forwardimpact/libwiki`). The `fit-wiki` CLI is the operational
+layer for wiki lifecycle management in the Kata agent system; `memo` is its
+first subcommand. Future subcommands (refresh, push, pull, init) are scoped
+in follow-up specs.
 
 - **Marker-based insertion.** Each `wiki/<agent>.md` carries an HTML comment
   `<!-- memo:inbox -->` immediately before the "Observations for Teammates"
-  heading. `fit-memo` inserts the new observation as a bullet after the marker,
-  before any existing bullets. The marker is invisible in rendered markdown.
+  heading. `fit-wiki memo` inserts the new observation as a bullet after the
+  marker, before any existing bullets. The marker is invisible in rendered
+  markdown.
 - **CLI surface.** Accepts sender, target (or `all` for broadcast), and
   message. Produces one write per target.
 - **Migration.** One-time insertion of `<!-- memo:inbox -->` markers into all
@@ -55,6 +59,10 @@ timestamped observation to a target agent's wiki summary file.
   (section 5 of the "Permitted sections" list: `## Observations for
   Teammates`) gains the `<!-- memo:inbox -->` marker so that newly created
   summaries include it automatically.
+- **Package.** `libwiki` is a new library under `libraries/libwiki` with
+  `fit-wiki` as its CLI binary. It has no dependency on `libxmr` in this
+  spec's scope (the `memo` subcommand does not need XmR analysis). The
+  dependency is anticipated for follow-up work (`fit-wiki refresh`).
 
 ### 2. `fit-xmr record` — metrics recording command
 
@@ -103,7 +111,7 @@ summary.
   classification logic in libxmr.
 - Changes to `wiki/MEMORY.md` schema or the cross-cutting priority index.
 - Changes to the weekly log format or the Tier 1/Tier 2 memory tier structure.
-- Automated delivery confirmation for `fit-memo` (the spec addresses the
+- Automated delivery confirmation for `fit-wiki memo` (the spec addresses the
   recording side; read-side acknowledgement is a separate concern).
 - Changes to the storyboard session protocol (`kata-session`) beyond template
   path updates.
@@ -114,8 +122,8 @@ summary.
 
 | # | Claim | Verification |
 |---|-------|--------------|
-| 1 | `fit-memo --from <sender> --to <target> "<message>"` appends a timestamped bullet to `wiki/<target>.md` immediately after the `<!-- memo:inbox -->` marker. | Run the command; `git diff wiki/<target>.md` shows exactly one new bullet with ISO date, sender attribution, and message text. No other lines changed. |
-| 2 | `fit-memo --from <sender> --to all "<message>"` writes to all 6 agent summaries. | Run the command; `git diff wiki/` shows one new bullet in each of the 6 summary files. |
+| 1 | `fit-wiki memo --from <sender> --to <target> "<message>"` appends a timestamped bullet to `wiki/<target>.md` immediately after the `<!-- memo:inbox -->` marker. | Run the command; `git diff wiki/<target>.md` shows exactly one new bullet with ISO date, sender attribution, and message text. No other lines changed. |
+| 2 | `fit-wiki memo --from <sender> --to all "<message>"` writes to all 6 agent summaries. | Run the command; `git diff wiki/` shows one new bullet in each of the 6 summary files. |
 | 3 | `fit-xmr record --agent <name> <metric> <value>` appends a row to `wiki/metrics/<name>/{YYYY}.csv` and prints a one-line XmR summary to stdout. | Run the command; `tail -1 wiki/metrics/<name>/2026.csv` shows `<today>,<metric>,<value>,count,...`. Stdout contains metric name, n, status, and latest value. |
 | 4 | `fit-xmr record` creates the CSV with header row when the file does not exist. | Run against a non-existent agent directory; file exists afterward with header + 1 data row. |
 | 5 | All 6 existing agent summary files contain `<!-- memo:inbox -->` after migration. | `grep -c 'memo:inbox' wiki/*.md` returns 1 for each of the 6 agent summaries. |

--- a/specs/770-agent-tooling-memo-metric/spec.md
+++ b/specs/770-agent-tooling-memo-metric/spec.md
@@ -44,21 +44,18 @@ layer for wiki lifecycle management in the Kata agent system; `memo` is its
 first subcommand. Future subcommands (refresh, push, pull, init) are scoped
 in follow-up specs.
 
-- **Marker-based insertion.** Each `wiki/<agent>.md` carries an HTML comment
-  `<!-- memo:inbox -->` immediately before the "Observations for Teammates"
-  heading. `fit-wiki memo` inserts the new observation as a bullet after the
-  marker, before any existing bullets. The marker is invisible in rendered
-  markdown.
-- **CLI surface.** Accepts sender, target (or `all` for broadcast), and
-  message. Produces one write per target.
-- **Migration.** One-time insertion of `<!-- memo:inbox -->` markers into all
-  existing `wiki/<agent>.md` summary files (6 files: improvement-coach,
-  product-manager, release-engineer, security-engineer, staff-engineer,
-  technical-writer).
+- **Machine-locatable insertion point.** Each agent summary file gains an
+  insertion marker (such as `<!-- memo:inbox -->`) that `fit-wiki memo` uses
+  to locate the "Observations for Teammates" section and append new bullets
+  without reading or parsing the surrounding file. The marker is invisible
+  in rendered markdown.
+- **CLI surface.** Accepts sender, target (or broadcast to all agents), and
+  message text. Produces one write per target agent.
+- **Migration.** One-time insertion of the chosen marker into all existing
+  agent summary files under `wiki/`.
 - **Template update.** The summary section template in `memory-protocol.md`
-  (section 5 of the "Permitted sections" list: `## Observations for
-  Teammates`) gains the `<!-- memo:inbox -->` marker so that newly created
-  summaries include it automatically.
+  gains the insertion marker so that newly created summaries are
+  memo-ready from creation.
 - **Package.** `libwiki` is a new library under `libraries/libwiki` with
   `fit-wiki` as its CLI binary. It has no dependency on `libxmr` in this
   spec's scope (the `memo` subcommand does not need XmR analysis). The
@@ -75,35 +72,34 @@ summary.
   `wiki/metrics/{agent}/{YYYY}.csv` — one file per agent per year. The `domain`
   directory is removed. The `metric` column in each row already distinguishes
   metric names; `fit-xmr analyze --metric <name>` already filters by metric.
-- **Migration.** Concatenate each agent's per-domain CSVs into a single file,
-  preserving row order by date. Remove the empty domain directories.
-  Non-CSV content under `wiki/metrics/` (such as experiment artifact
-  directories) is out of scope for the CSV migration.
-- **CLI surface.** Accepts agent name, metric name, value, and optional unit
-  (default `count`), run tag (defaults to the CI run identifier when available),
-  and note. Resolves the CSV path, creates the file with header if missing,
-  appends the row, then prints a one-line XmR summary for that metric using
-  libxmr's existing analysis and formatting capabilities.
+- **Migration.** All existing CSV data rows across an agent's per-domain files
+  are consolidated into the flat file. Non-CSV content under `wiki/metrics/`
+  (such as `staff-engineer/trace-analysis/exp14/`) is out of scope.
+  Improvement-coach has no metrics directory and is not part of the metrics
+  migration (memo migration only).
+- **CLI surface.** Accepts agent name, metric name, value, and optional unit,
+  run tag, and note. Resolves the CSV path, creates the file with header if
+  missing, appends the row, then prints a one-line XmR summary for that
+  metric using libxmr's existing analysis and formatting capabilities.
 - **One-line summary.** After appending, the command prints a compact status
   line to stdout: metric name, n, status, latest value. This gives the agent
   immediate feedback without a separate `fit-xmr analyze` call.
 
 ### 3. Protocol and template updates
 
-- **`memory-protocol.md`** — Update the "Summary Contract" section to document
-  the `<!-- memo:inbox -->` marker. Update the "Metrics tables" exclusion to
-  reflect the flat `wiki/metrics/{agent}/{YYYY}.csv` path.
-- **`kata-metrics/SKILL.md`** — Update the Storage section path from
-  `wiki/metrics/{agent}/{domain}/{YYYY}.csv` to `wiki/metrics/{agent}/{YYYY}.csv`.
-  Update recording protocol to reference `fit-xmr record` instead of manual
-  `cat >>`. Update analysis examples to use the flat path.
-- **`kata-metrics/references/csv-schema.md`** — Update the storage path
-  reference.
-- **`storyboard-template.md`** — Update the `### {agent} — {domain}` heading
-  pattern to `### {agent}` (domain is now implicit in the metric name). Update
-  example `fit-xmr` paths.
-- **`fit-xmr` CLI help** — Update example paths in the CLI help output from
-  the domain-based path to the flat path.
+All protocol and template documents that reference the metrics storage path
+or the summary section structure are updated to reflect the new flat path
+and the memo insertion marker. Affected files:
+
+- **`memory-protocol.md`** — Summary Contract documents the insertion marker;
+  metrics path references use the flat structure.
+- **`kata-metrics/SKILL.md`** and **`kata-metrics/references/csv-schema.md`**
+  — Storage path, recording protocol, and analysis examples use the flat
+  path and reference `fit-xmr record`.
+- **`storyboard-template.md`** — Per-agent metric headings drop the domain
+  qualifier (domain is implicit in the metric name). Example paths use the
+  flat structure.
+- **`fit-xmr` CLI help** — Example paths use the flat structure.
 
 ## Scope (out)
 
@@ -122,22 +118,24 @@ summary.
 
 | # | Claim | Verification |
 |---|-------|--------------|
-| 1 | `fit-wiki memo --from <sender> --to <target> "<message>"` appends a timestamped bullet to `wiki/<target>.md` immediately after the `<!-- memo:inbox -->` marker. | Run the command; `git diff wiki/<target>.md` shows exactly one new bullet with ISO date, sender attribution, and message text. No other lines changed. |
-| 2 | `fit-wiki memo --from <sender> --to all "<message>"` writes to all 6 agent summaries. | Run the command; `git diff wiki/` shows one new bullet in each of the 6 summary files. |
-| 3 | `fit-xmr record --agent <name> <metric> <value>` appends a row to `wiki/metrics/<name>/{YYYY}.csv` and prints a one-line XmR summary to stdout. | Run the command; `tail -1 wiki/metrics/<name>/2026.csv` shows `<today>,<metric>,<value>,count,...`. Stdout contains metric name, n, status, and latest value. |
+| 1 | `fit-wiki memo` appends a timestamped observation to the target agent's summary file in the correct section. | Run the command targeting one agent; `git diff` shows exactly one new bullet appended in the observations section with date and sender attribution. |
+| 2 | `fit-wiki memo` with a broadcast target writes to every agent summary. | Run the command with broadcast; `git diff wiki/` shows one new bullet in each agent summary file. |
+| 3 | `fit-xmr record` appends a row to the agent's flat metrics CSV and prints a one-line XmR summary to stdout. | Run the command; last line of the CSV matches the recorded metric. Stdout contains metric name, data point count, and XmR status. |
 | 4 | `fit-xmr record` creates the CSV with header row when the file does not exist. | Run against a non-existent agent directory; file exists afterward with header + 1 data row. |
-| 5 | All 6 existing agent summary files contain `<!-- memo:inbox -->` after migration. | `grep -c 'memo:inbox' wiki/*.md` returns 1 for each of the 6 agent summaries. |
-| 6 | All existing metrics rows are preserved in the flat structure after migration. | `wc -l` on new flat CSVs equals sum of `wc -l` on old per-domain CSVs (minus duplicate header rows). |
-| 7 | `memory-protocol.md`, `kata-metrics/SKILL.md`, `kata-metrics/references/csv-schema.md`, `storyboard-template.md`, and the `fit-xmr` CLI help output reference the flat path `wiki/metrics/{agent}/{YYYY}.csv` and mention no `{domain}` directory. | `grep -r '{domain}' .claude/agents/references/memory-protocol.md .claude/skills/kata-metrics/ libraries/libxmr/` returns zero matches. |
+| 5 | All existing agent summary files contain the insertion marker after migration. | Each file matching `wiki/<agent>.md` (identified by the `# ... — Summary` H1) contains exactly one marker instance. |
+| 6 | All existing metrics rows are preserved in the flat structure after migration. | Row count of each migrated flat CSV equals the total data rows across all source CSVs for that agent. |
+| 7 | All protocol docs, templates, and CLI help reference the flat metrics path with no `{domain}` directory. | `grep -r '{domain}' .claude/agents/references/memory-protocol.md .claude/skills/kata-metrics/ .claude/skills/kata-session/references/storyboard-template.md libraries/libxmr/` returns zero matches. |
 | 8 | `storyboard-template.md` uses `### {agent}` headings (not `### {agent} — {domain}`). | Static inspection of the template file. |
-| 9 | `memory-protocol.md` "Summary Contract" section documents the `<!-- memo:inbox -->` marker as part of the permitted sections structure. | Static inspection; the marker appears in the section 5 documentation. |
+| 9 | `memory-protocol.md` "Summary Contract" documents the insertion marker as part of the permitted sections structure. | Static inspection; the marker format appears in the section 5 documentation. |
 
 ## Notes
 
 ### Evidence source
 
-Findings are from SCRATCHPAD-6.md (grounded theory trace analysis, May 2 2026).
-Key quantitative observations:
+Findings are from the grounded theory trace analysis in
+[`grounded-analysis.md`](grounded-analysis.md) (May 2 2026, committed
+alongside this spec). Trace corpus: 33 structured traces from 18 workflow
+runs. Key quantitative observations:
 
 - 23/23 traced agent runs read `wiki/MEMORY.md` during boot.
 - 56/63 `fit-xmr analyze` calls (89%) originate from the facilitator.

--- a/specs/770-agent-tooling-memo-metric/spec.md
+++ b/specs/770-agent-tooling-memo-metric/spec.md
@@ -1,0 +1,159 @@
+# Spec 770 — Agent tooling: `fit-memo` and `fit-xmr record`
+
+## Problem
+
+Agents spend 5-15 turns on procedural wiki operations that produce no
+value-bearing output. Grounded theory analysis across 33 traces (~10,500 turns,
+Apr 17 -- May 2 2026) identified two hot paths:
+
+**Cross-team observations.** An agent records a finding for a teammate by
+reading `wiki/<target>.md`, locating the "Observations for Teammates" section,
+composing an Edit with the right indentation, and writing the file. The trace
+corpus shows this channel is asynchronous and unreliable: one observation went
+10 days unacknowledged because the target agent never read the sender's summary.
+Each observation costs the sender 3-5 tool calls (ls, Read summary, find
+section, Edit) and the target agent an equivalent read-and-scan cost on every
+boot.
+
+**Metrics recording.** Every agent appends CSV rows to
+`wiki/metrics/{agent}/{domain}/{YYYY}.csv` after completing primary work. The
+procedure — discover the directory, read the CSV header, compose a `cat >>`
+heredoc — costs 2-4 turns per append. The `{domain}` directory level adds a
+discovery step that provides no analytical value: the CSV format already carries
+a `metric` column that distinguishes metric names, and `fit-xmr analyze`
+already filters by `--metric`. No agent has ever placed two semantically
+different domains in a single CSV; the directory just mirrors what the rows
+already encode.
+
+Both paths are pure ceremony. The information is valuable; the file-finding and
+format-matching are not.
+
+## Goal
+
+Two CLI commands that collapse the procedural overhead to a single invocation
+each, so agents can record observations and metrics without spending thinking
+tokens on file discovery, section parsing, or CSV formatting.
+
+## Scope (in)
+
+### 1. `fit-memo` — cross-team observation utility
+
+A new CLI (new package or hosted in an existing library) that appends a
+timestamped observation to a target agent's wiki summary file.
+
+- **Marker-based insertion.** Each `wiki/<agent>.md` carries an HTML comment
+  `<!-- memo:inbox -->` immediately before the "Observations for Teammates"
+  heading. `fit-memo` inserts the new observation as a bullet after the marker,
+  before any existing bullets. The marker is invisible in rendered markdown.
+- **CLI surface.** Accepts sender, target (or `all` for broadcast), and
+  message. Produces one write per target.
+- **Migration.** One-time insertion of `<!-- memo:inbox -->` markers into all
+  existing `wiki/<agent>.md` summary files (6 files: improvement-coach,
+  product-manager, release-engineer, security-engineer, staff-engineer,
+  technical-writer).
+- **Template update.** The summary section template in `memory-protocol.md`
+  (section 5 of the "Permitted sections" list: `## Observations for
+  Teammates`) gains the `<!-- memo:inbox -->` marker so that newly created
+  summaries include it automatically.
+
+### 2. `fit-xmr record` — metrics recording command
+
+A new `record` command on the existing `fit-xmr` CLI (provided by
+`@forwardimpact/libxmr`) that appends a CSV row and prints a one-line XmR
+summary.
+
+- **Flat directory structure.** Metrics move from
+  `wiki/metrics/{agent}/{domain}/{YYYY}.csv` to
+  `wiki/metrics/{agent}/{YYYY}.csv` — one file per agent per year. The `domain`
+  directory is removed. The `metric` column in each row already distinguishes
+  metric names; `fit-xmr analyze --metric <name>` already filters by metric.
+- **Migration.** Concatenate each agent's per-domain CSVs into a single file,
+  preserving row order by date. Remove the empty domain directories.
+  Non-CSV content under `wiki/metrics/` (such as experiment artifact
+  directories) is out of scope for the CSV migration.
+- **CLI surface.** Accepts agent name, metric name, value, and optional unit
+  (default `count`), run tag (defaults to the CI run identifier when available),
+  and note. Resolves the CSV path, creates the file with header if missing,
+  appends the row, then prints a one-line XmR summary for that metric using
+  libxmr's existing analysis and formatting capabilities.
+- **One-line summary.** After appending, the command prints a compact status
+  line to stdout: metric name, n, status, latest value. This gives the agent
+  immediate feedback without a separate `fit-xmr analyze` call.
+
+### 3. Protocol and template updates
+
+- **`memory-protocol.md`** — Update the "Summary Contract" section to document
+  the `<!-- memo:inbox -->` marker. Update the "Metrics tables" exclusion to
+  reflect the flat `wiki/metrics/{agent}/{YYYY}.csv` path.
+- **`kata-metrics/SKILL.md`** — Update the Storage section path from
+  `wiki/metrics/{agent}/{domain}/{YYYY}.csv` to `wiki/metrics/{agent}/{YYYY}.csv`.
+  Update recording protocol to reference `fit-xmr record` instead of manual
+  `cat >>`. Update analysis examples to use the flat path.
+- **`kata-metrics/references/csv-schema.md`** — Update the storage path
+  reference.
+- **`storyboard-template.md`** — Update the `### {agent} — {domain}` heading
+  pattern to `### {agent}` (domain is now implicit in the metric name). Update
+  example `fit-xmr` paths.
+- **`fit-xmr` CLI help** — Update example paths in the CLI help output from
+  the domain-based path to the flat path.
+
+## Scope (out)
+
+- Changes to the XmR statistical engine, chart rendering, signal detection, or
+  classification logic in libxmr.
+- Changes to `wiki/MEMORY.md` schema or the cross-cutting priority index.
+- Changes to the weekly log format or the Tier 1/Tier 2 memory tier structure.
+- Automated delivery confirmation for `fit-memo` (the spec addresses the
+  recording side; read-side acknowledgement is a separate concern).
+- Changes to the storyboard session protocol (`kata-session`) beyond template
+  path updates.
+- Archival or deletion of historical metrics data — migration preserves all
+  existing rows.
+
+## Success criteria
+
+| # | Claim | Verification |
+|---|-------|--------------|
+| 1 | `fit-memo --from <sender> --to <target> "<message>"` appends a timestamped bullet to `wiki/<target>.md` immediately after the `<!-- memo:inbox -->` marker. | Run the command; `git diff wiki/<target>.md` shows exactly one new bullet with ISO date, sender attribution, and message text. No other lines changed. |
+| 2 | `fit-memo --from <sender> --to all "<message>"` writes to all 6 agent summaries. | Run the command; `git diff wiki/` shows one new bullet in each of the 6 summary files. |
+| 3 | `fit-xmr record --agent <name> <metric> <value>` appends a row to `wiki/metrics/<name>/{YYYY}.csv` and prints a one-line XmR summary to stdout. | Run the command; `tail -1 wiki/metrics/<name>/2026.csv` shows `<today>,<metric>,<value>,count,...`. Stdout contains metric name, n, status, and latest value. |
+| 4 | `fit-xmr record` creates the CSV with header row when the file does not exist. | Run against a non-existent agent directory; file exists afterward with header + 1 data row. |
+| 5 | All 6 existing agent summary files contain `<!-- memo:inbox -->` after migration. | `grep -c 'memo:inbox' wiki/*.md` returns 1 for each of the 6 agent summaries. |
+| 6 | All existing metrics rows are preserved in the flat structure after migration. | `wc -l` on new flat CSVs equals sum of `wc -l` on old per-domain CSVs (minus duplicate header rows). |
+| 7 | `memory-protocol.md`, `kata-metrics/SKILL.md`, `kata-metrics/references/csv-schema.md`, `storyboard-template.md`, and the `fit-xmr` CLI help output reference the flat path `wiki/metrics/{agent}/{YYYY}.csv` and mention no `{domain}` directory. | `grep -r '{domain}' .claude/agents/references/memory-protocol.md .claude/skills/kata-metrics/ libraries/libxmr/` returns zero matches. |
+| 8 | `storyboard-template.md` uses `### {agent}` headings (not `### {agent} — {domain}`). | Static inspection of the template file. |
+| 9 | `memory-protocol.md` "Summary Contract" section documents the `<!-- memo:inbox -->` marker as part of the permitted sections structure. | Static inspection; the marker appears in the section 5 documentation. |
+
+## Notes
+
+### Evidence source
+
+Findings are from SCRATCHPAD-6.md (grounded theory trace analysis, May 2 2026).
+Key quantitative observations:
+
+- 23/23 traced agent runs read `wiki/MEMORY.md` during boot.
+- 56/63 `fit-xmr analyze` calls (89%) originate from the facilitator.
+- Agents use `cat >> ... <<'EOF'` for CSV appends in 61 of 70 observed metric
+  writes (87%); the remaining 9 use Edit.
+- The boot sequence (protocol, wiki ls, own summary, MEMORY.md, storyboard,
+  weekly log) is stable across all traced agent types.
+
+### Domain removal rationale
+
+Current domain directories and their contents:
+
+| Agent | CSV domains | Metrics per domain | Non-CSV content |
+|-------|------------|-------------------|-----------------|
+| improvement-coach | _(none)_ | — | — |
+| product-manager | backlog, evaluation | 1 each (`issues_triaged`, `issues_created`) | — |
+| release-engineer | merge, release | 1 each (`prs_merged`, `releases_cut`) | — |
+| security-engineer | audit, triage | 1 each (`findings_count`, `prs_actioned`) | — |
+| staff-engineer | spec, implementation, trace | 1 each (`specs_drafted`, `implementations_shipped`, `findings_count`) | `trace-analysis/exp14/` (experiment NDJSON artifacts, not CSV — out of scope for migration) |
+| technical-writer | documentation, wiki | 1 each (`errors_found`, `summary_corrections`) | — |
+
+Every CSV domain directory contains exactly one metric. The
+single-metric-per-skill protocol (ratified May 1 2026) makes multi-metric
+domains structurally impossible going forward. The domain directory is redundant
+storage for information already carried in the `metric` column.
+Improvement-coach records no metrics of its own (the facilitator role records
+coaching metrics under its own CSV).

--- a/specs/780-wiki-lifecycle-commands/spec.md
+++ b/specs/780-wiki-lifecycle-commands/spec.md
@@ -13,7 +13,7 @@ specific pain points:
 ASCII output, and pastes it into a fenced code block inside the storyboard
 markdown. Across 6 storyboard traces (Apr 17 -- May 2 2026), the facilitator
 runs 6-12 `fit-xmr analyze` calls and 0-6 `fit-xmr chart` calls per session
-(SCRATCHPAD-6.md). This paste-and-format work costs 10-20 turns per session and
+(see [`../770-agent-tooling-memo-metric/grounded-analysis.md`](../770-agent-tooling-memo-metric/grounded-analysis.md)). This paste-and-format work costs 10-20 turns per session and
 is error-prone: the facilitator must also write the `**Latest:**`,
 `**Status:**`, and `**Signals:**` lines by hand, reconciling JSON output with
 markdown formatting.

--- a/specs/780-wiki-lifecycle-commands/spec.md
+++ b/specs/780-wiki-lifecycle-commands/spec.md
@@ -1,0 +1,199 @@
+# Spec 780 — Wiki lifecycle commands: refresh, init, push, pull
+
+## Problem
+
+The Kata agent system's wiki operations are split across three bespoke shell
+scripts (`wiki-sync.sh`, `wiki-audit.sh`, `bootstrap.sh`), a justfile, a
+composite GitHub Action (`bootstrap/action.yml`), and manual facilitator
+work — none of which are portable to downstream Kata installations. Three
+specific pain points:
+
+**Storyboard XmR charts are manually pasted.** The facilitator runs
+`bunx fit-xmr chart <csv> --metric <name>` for each metric, copies the 14-line
+ASCII output, and pastes it into a fenced code block inside the storyboard
+markdown. Across 6 storyboard traces (Apr 17 -- May 2 2026), the facilitator
+runs 6-12 `fit-xmr analyze` calls and 0-6 `fit-xmr chart` calls per session
+(SCRATCHPAD-6.md). This paste-and-format work costs 10-20 turns per session and
+is error-prone: the facilitator must also write the `**Latest:**`,
+`**Status:**`, and `**Signals:**` lines by hand, reconciling JSON output with
+markdown formatting.
+
+**Wiki clone/push/pull is shell-script plumbing.** `scripts/wiki-sync.sh`
+handles git credential injection, clone-if-missing, rebase-on-pull,
+commit-and-push. The justfile exposes `wiki-pull` and `wiki-push` as thin
+wrappers. The bootstrap GitHub Action pre-checks out the wiki and registers a
+post-run step to push. This plumbing works but is not distributable: downstream
+Kata installations must recreate it from scratch because the scripts assume the
+monorepo's directory layout, token variables, and justfile recipes.
+
+**No portable initialization.** Setting up a wiki for a new Kata installation
+requires manually cloning the `.wiki.git` repo, creating the directory
+structure (`wiki/metrics/<agent>/`), and wiring hooks. There is no single
+command that bootstraps a working wiki directory.
+
+## Goal
+
+Expand the `fit-wiki` CLI (introduced in spec 770 as `libwiki`) with three
+subcommands — `refresh`, `init`, and `push`/`pull` — that make wiki lifecycle
+operations portable across Kata installations. After this spec, a downstream
+installation can `npx fit-wiki init`, have agents use `npx fit-wiki push/pull`
+in hooks, and run `npx fit-wiki refresh` to keep storyboard charts current —
+without copying shell scripts or composite actions.
+
+## Scope (in)
+
+### 1. `fit-wiki refresh` — templated XmR storyboard updates
+
+A subcommand that scans a storyboard markdown file for HTML comment markers,
+regenerates the XmR chart and metadata for each marked metric block, and
+writes the updated content back to the file.
+
+- **Marker format.** Each metric block in the storyboard is bracketed by a
+  pair of HTML comments that name the CSV path and metric:
+  `<!-- xmr:wiki/metrics/<agent>/<YYYY>.csv:<metric_name> -->` before the
+  block and `<!-- /xmr -->` after. Everything between the markers is
+  regenerated on refresh.
+- **Generated content.** For each marker pair, `fit-wiki refresh` produces:
+  the `**Latest:** {value} · **Status:** {status}` line, the fenced XmR
+  chart, and the `**Signals:**` line. The `#### {metric_name}` heading is
+  outside the markers and is not regenerated.
+- **Dependency on libxmr.** `libwiki` gains `@forwardimpact/libxmr` as a
+  dependency. `fit-wiki refresh` uses libxmr to produce XmR analysis and
+  chart output for each marked metric.
+- **Storyboard template migration.** The storyboard template
+  (`storyboard-template.md`) gains `<!-- xmr:... -->` / `<!-- /xmr -->`
+  marker pairs around the example metric block so new storyboards are
+  refresh-ready from creation.
+- **Existing storyboard migration.** `wiki/storyboard-2026-M05.md` is updated
+  with markers around each existing metric block. Past storyboards
+  (`storyboard-2026-M04.md`) are left as-is (historical records).
+- **Idempotent.** Running `fit-wiki refresh` twice produces the same output.
+  Running it on a storyboard with no markers is a no-op.
+
+### 2. `fit-wiki init` — wiki bootstrap
+
+A subcommand that sets up a working wiki directory for a Kata installation.
+
+- **Clone.** Clones the repository's wiki into `./wiki/` if the directory does
+  not already exist or is not a git repository. Authenticates using ambient
+  GitHub credentials (`GITHUB_TOKEN` or `GH_TOKEN`).
+- **Directory creation.** Creates `wiki/metrics/<agent>/` directories for each
+  agent in the installation.
+- **Identity.** Commits in the wiki repo are attributed to the same identity
+  as the parent repository.
+- **Idempotent.** Running `init` on an already-initialized wiki is a no-op
+  for each step that has already completed.
+
+### 3. `fit-wiki push` and `fit-wiki pull` — wiki sync
+
+Subcommands that replace `scripts/wiki-sync.sh` with portable equivalents
+distributed via npm.
+
+- **`fit-wiki pull`** — Incorporates remote changes into the local wiki. Exits
+  non-zero with a diagnostic message on conflict.
+- **`fit-wiki push`** — Commits local changes and syncs to remote, resolving
+  conflicts in favor of local state. No-op when there are no local changes.
+- **Credential handling.** Authenticates using ambient GitHub credentials
+  (`GITHUB_TOKEN` or `GH_TOKEN`). No tokens written to `.git/config`.
+- **Hook compatibility.** `fit-wiki push` and `fit-wiki pull` are designed to
+  be used in Claude Code hooks (`SessionStart` → `npx fit-wiki pull`,
+  `Stop` → `npx fit-wiki push`) and in GitHub Actions post-run steps.
+
+### 4. Protocol and template updates
+
+- **`storyboard-template.md`** — Add `<!-- xmr:... -->` / `<!-- /xmr -->`
+  markers around the example metric block in the Current Condition section.
+- **`team-storyboard.md`** — Update the "Storyboard updates" section to
+  reference `fit-wiki refresh` as the preferred method for updating Current
+  Condition charts. The manual paste workflow remains documented as a
+  fallback.
+- **`kata-session/SKILL.md`** — Update any facilitator checklist steps that
+  currently instruct running `bunx fit-xmr chart` manually to reference
+  `fit-wiki refresh` instead.
+- **justfile** — `wiki-pull` and `wiki-push` recipes switch from
+  `bash scripts/wiki-sync.sh` to `bunx fit-wiki pull` / `bunx fit-wiki push`.
+
+## Scope (out)
+
+- The `fit-wiki memo` subcommand (delivered in spec 770).
+- The `fit-xmr record` command (delivered in spec 770).
+- Changes to the XmR statistical engine, chart rendering, or signal detection
+  in libxmr. `fit-wiki refresh` consumes libxmr's public API as-is.
+- Deletion of `scripts/wiki-sync.sh` or `scripts/wiki-audit.sh`. The sync
+  script is superseded by `fit-wiki push/pull`; the audit script may become
+  `fit-wiki audit` in a future spec. Both remain in the repo.
+- Changes to the GitHub Actions bootstrap composite action
+  (`bootstrap/action.yml`). The action continues to call `just wiki-push`;
+  the justfile recipe is what changes underneath.
+- Storyboard creation or planning logic. `fit-wiki refresh` updates existing
+  metric blocks; it does not create new storyboards or decide which metrics
+  to include.
+- Changes to the Challenge, Target Condition, Obstacles, or Experiments
+  sections of the storyboard. Only the Current Condition metric blocks are
+  affected.
+
+## Success criteria
+
+| # | Claim | Verification |
+|---|-------|--------------|
+| 1 | `fit-wiki refresh <storyboard.md>` regenerates every `<!-- xmr:... -->` block with current XmR chart, latest value, status, and signals from the referenced CSV. | Insert a marker pair referencing a known CSV with >=15 data points; run refresh; the block between markers contains an XmR chart, correct latest value, and correct status matching `bunx fit-xmr analyze` output for that metric. |
+| 2 | `fit-wiki refresh` is idempotent. | Run refresh twice on the same storyboard; `diff` between the two outputs is empty (assuming no CSV changes between runs). |
+| 3 | `fit-wiki refresh` is a no-op on files with no `<!-- xmr:... -->` markers. | Run refresh on a storyboard with no markers; file is unchanged (`git diff` is empty). |
+| 4 | `fit-wiki init` clones the wiki repo into `./wiki/` and creates metrics directories. | Run init in a directory with no `wiki/`; afterward `git -C wiki rev-parse --git-dir` succeeds and `wiki/metrics/` exists. |
+| 5 | `fit-wiki init` is idempotent. | Run init twice; second run produces no errors and no filesystem changes. |
+| 6 | `fit-wiki push` commits and pushes local wiki changes. | Make a local change to a wiki file; run push; `git -C wiki log -1 --oneline` shows the new commit and `git -C wiki diff origin/master` is empty. |
+| 7 | `fit-wiki push` is a no-op when no changes exist. | Run push with no local changes; exit code 0, no new commit created. |
+| 8 | `fit-wiki pull` fetches and rebases local state onto remote. | Push a change from another clone; run pull in the first clone; the change appears in the local working tree. |
+| 9 | `storyboard-template.md` contains `<!-- xmr:... -->` / `<!-- /xmr -->` marker pairs around the example metric block. | `grep -c 'xmr:' .claude/skills/kata-session/references/storyboard-template.md` returns >=1. |
+| 10 | `team-storyboard.md` references `fit-wiki refresh` for chart updates. | Static inspection; the Storyboard updates section mentions `fit-wiki refresh`. |
+| 11 | justfile `wiki-pull` and `wiki-push` recipes call `bunx fit-wiki` instead of `bash scripts/wiki-sync.sh`. | Static inspection of the justfile. |
+| 12 | `libwiki` depends on `@forwardimpact/libxmr` in `package.json`. | `jq '.dependencies["@forwardimpact/libxmr"]' libraries/libwiki/package.json` returns a version string. |
+
+## Notes
+
+### Relationship to spec 770
+
+This spec extends the `libwiki` package and `fit-wiki` CLI introduced in spec
+770. Spec 770 delivers the package scaffold, `fit-wiki memo`, `fit-xmr
+record`, and the flat metrics directory structure. This spec adds `refresh`,
+`init`, `push`, and `pull`.
+
+**Ordering constraint:** `fit-wiki refresh` markers reference the flat
+`wiki/metrics/<agent>/<YYYY>.csv` paths introduced by spec 770's migration.
+Spec 770's package scaffold and metrics migration must land before the
+`refresh` marker migration runs. The `init`, `push`, and `pull` subcommands
+have no dependency on spec 770 and can be implemented independently.
+
+### Marker format rationale
+
+The `<!-- xmr:path:metric -->` / `<!-- /xmr -->` pattern mirrors how static
+site generators handle auto-generated sections (e.g., Hugo shortcodes,
+Jekyll includes). HTML comments are invisible in GitHub's markdown renderer,
+so the storyboard reads identically with or without markers. The closing
+`<!-- /xmr -->` tag makes the block boundaries unambiguous for the parser —
+no need to guess where the chart ends by counting code fences.
+
+### Portability model
+
+After specs 770 and 780, a downstream Kata installation's wiki lifecycle is:
+
+```sh
+npx fit-wiki init                          # clone wiki, create directories
+npx fit-wiki memo --from se --to all "..."  # record cross-team observations
+npx fit-xmr record --agent se findings 0   # record a metric
+npx fit-wiki refresh wiki/storyboard.md    # regenerate XmR charts
+npx fit-wiki push                          # commit and sync
+```
+
+No shell scripts, no justfile, no composite actions. The entire workflow is
+npm-distributable.
+
+### Current shell script coverage
+
+| Operation | Current implementation | Spec 780 replacement |
+|-----------|----------------------|---------------------|
+| Clone wiki | `wiki-sync.sh` + `bootstrap/action.yml` | `fit-wiki init` |
+| Pull | `wiki-sync.sh pull` → `just wiki-pull` | `fit-wiki pull` |
+| Push | `wiki-sync.sh push` → `just wiki-push` | `fit-wiki push` |
+| Audit | `wiki-audit.sh` → `just wiki-audit` | _(out of scope)_ |
+| XmR charts | Manual paste by facilitator | `fit-wiki refresh` |


### PR DESCRIPTION
## Summary

Two specs that give the Kata agent system portable wiki lifecycle tooling:

**Spec 770 — `fit-wiki memo` and `fit-xmr record`**
- `fit-wiki memo` appends cross-team observations to teammate summaries via `<!-- memo:inbox -->` markers
- `fit-xmr record` appends metrics CSV rows and prints a one-line XmR summary (hosted in libxmr)
- Flattens `wiki/metrics/{agent}/{domain}/{YYYY}.csv` to `wiki/metrics/{agent}/{YYYY}.csv`
- Introduces `libwiki` (`@forwardimpact/libwiki`) as the wiki operations package

**Spec 780 — `fit-wiki refresh`, `init`, `push`, `pull`**
- `fit-wiki refresh` scans storyboard markdown for `<!-- xmr:path:metric -->` markers and regenerates XmR charts using libxmr
- `fit-wiki init` bootstraps a wiki directory (clone, metrics dirs, identity)
- `fit-wiki push` / `fit-wiki pull` replace `scripts/wiki-sync.sh` with npm-distributable commands
- Spec 780 depends on 770 for the libwiki scaffold and flat metrics paths

Together they enable a portable workflow for downstream Kata installations:
```sh
npx fit-wiki init
npx fit-wiki memo --from se --to all "..."
npx fit-xmr record --agent se findings 0
npx fit-wiki refresh wiki/storyboard.md
npx fit-wiki push
```

## Test plan

- [ ] Spec 770: verify problem evidence, scope, and success criteria
- [ ] Spec 780: verify problem evidence, scope, and success criteria
- [ ] Confirm domain removal rationale against current `wiki/metrics/` structure
- [ ] Confirm ordering constraint between 770 and 780

🤖 Generated with [Claude Code](https://claude.com/claude-code)