### PR TITLE
feat(libui,libcli): shared invocation surfaces (#760)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.14",
         "@playwright/test": "^1.59.1",
+        "acorn": "^8.16.0",
         "serve": "^14.2.6",
       },
     },
@@ -395,6 +396,9 @@
     "libraries/libui": {
       "name": "@forwardimpact/libui",
       "version": "1.1.8",
+      "devDependencies": {
+        "happy-dom": "^20.9.0",
+      },
     },
     "libraries/libutil": {
       "name": "@forwardimpact/libutil",
@@ -1105,6 +1109,8 @@
 
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@zeit/schemas": ["@zeit/schemas@2.36.0", "", {}, "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg=="],
@@ -1344,6 +1350,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1802,6 +1810,10 @@
     "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "happy-dom/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 

--- a/libraries/CLAUDE.md
+++ b/libraries/CLAUDE.md
@@ -41,6 +41,16 @@ bun run lib:fix
 
 `bun run check` refuses a stale catalog and points at the right command.
 
+## Invocation context
+
+Libraries that ship a CLI can opt into `InvocationContext` — a frozen
+`{ data, args, options }` contract that libcli produces from argv. Declare
+named positionals with `args: string[]` on the subcommand definition and a
+`handler: (ctx) => …`; call `cli.dispatch(parsed, { data })` to receive a
+context with named args instead of a raw positionals array. See the
+[CLI Development guide](websites/fit/docs/internals/libcli/index.md) for the
+full contract and dispatch pattern.
+
 ## CLIs and progressive documentation
 
 If a library ships a CLI (a `bin/` entry in `package.json`), three artifacts

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -31,16 +31,16 @@ human-facing output that agents produce.
 
 <!-- BEGIN:capability:agent-capability -->
 
-| Library         | Capability                                                                                                             |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **libcli**      | Agent-friendly CLIs: argument parsing, grep-friendly help output, JSON mode, and skill-doc links surfaced in `--help`. |
-| **libdoc**      | Static documentation sites from markdown folders with front matter and navigation.                                     |
-| **libformat**   | Render markdown to ANSI for agent-friendly terminal output or HTML for browsers.                                       |
-| **libprompt**   | Agent-authored prompt templates loaded from `.prompt.md` files with Mustache substitution.                             |
-| **librepl**     | Agent-friendly interactive REPL with command dispatch and skill-doc links surfaced in `--help`.                        |
-| **libskill**    | Derive jobs, skill matrices, and agent profiles from engineering-standard data shared by humans and agents.            |
-| **libtemplate** | Mustache template loader with project-level override directories for agent-rendered content.                           |
-| **libui**       | Functional web UI primitives — DOM helpers, SPA routing, reactive state — for products agents build.                   |
+| Library         | Capability                                                                                                                                               |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **libcli**      | Agent-friendly CLIs: argument parsing, handler dispatch via `InvocationContext`, grep-friendly help, JSON mode, and skill-doc links in `--help`.         |
+| **libdoc**      | Static documentation sites from markdown folders with front matter and navigation.                                                                       |
+| **libformat**   | Render markdown to ANSI for agent-friendly terminal output or HTML for browsers.                                                                         |
+| **libprompt**   | Agent-authored prompt templates loaded from `.prompt.md` files with Mustache substitution.                                                               |
+| **librepl**     | Agent-friendly interactive REPL with command dispatch and skill-doc links surfaced in `--help`.                                                          |
+| **libskill**    | Derive jobs, skill matrices, and agent profiles from engineering-standard data shared by humans and agents.                                              |
+| **libtemplate** | Mustache template loader with project-level override directories for agent-rendered content.                                                             |
+| **libui**       | Agent-friendly web surfaces — SPA routing, reactive state, and route-to-CLI bindings that share handler logic with `libcli` through `InvocationContext`. |
 
 <!-- END:capability:agent-capability -->
 

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -31,16 +31,16 @@ human-facing output that agents produce.
 
 <!-- BEGIN:capability:agent-capability -->
 
-| Library         | Capability                                                                                                                                               |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **libcli**      | Agent-friendly CLIs: argument parsing, handler dispatch via `InvocationContext`, grep-friendly help, JSON mode, and skill-doc links in `--help`.         |
-| **libdoc**      | Static documentation sites from markdown folders with front matter and navigation.                                                                       |
-| **libformat**   | Render markdown to ANSI for agent-friendly terminal output or HTML for browsers.                                                                         |
-| **libprompt**   | Agent-authored prompt templates loaded from `.prompt.md` files with Mustache substitution.                                                               |
-| **librepl**     | Agent-friendly interactive REPL with command dispatch and skill-doc links surfaced in `--help`.                                                          |
-| **libskill**    | Derive jobs, skill matrices, and agent profiles from engineering-standard data shared by humans and agents.                                              |
-| **libtemplate** | Mustache template loader with project-level override directories for agent-rendered content.                                                             |
-| **libui**       | Agent-friendly web surfaces — SPA routing, reactive state, and route-to-CLI bindings that share handler logic with `libcli` through `InvocationContext`. |
+| Library         | Capability                                                                                                                             |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **libcli**      | Agent-friendly CLIs: argument parsing, handler dispatch, grep-friendly help, JSON mode, and skill-doc links in `--help`.               |
+| **libdoc**      | Static documentation sites from markdown folders with front matter and navigation.                                                     |
+| **libformat**   | Render markdown to ANSI for agent-friendly terminal output or HTML for browsers.                                                       |
+| **libprompt**   | Agent-authored prompt templates loaded from `.prompt.md` files with Mustache substitution.                                             |
+| **librepl**     | Agent-friendly interactive REPL with command dispatch and skill-doc links surfaced in `--help`.                                        |
+| **libskill**    | Derive jobs, skill matrices, and agent profiles from engineering-standard data shared by humans and agents.                            |
+| **libtemplate** | Mustache template loader with project-level override directories for agent-rendered content.                                           |
+| **libui**       | Agent-friendly web surfaces — SPA routing, reactive state, and route-to-CLI bindings that share handler logic across web and terminal. |
 
 <!-- END:capability:agent-capability -->
 

--- a/libraries/libcli/package.json
+++ b/libraries/libcli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libcli",
   "version": "0.1.7",
-  "description": "Agent-friendly CLIs: argument parsing, grep-friendly help output, JSON mode, and skill-doc links surfaced in `--help`.",
+  "description": "Agent-friendly CLIs: argument parsing, handler dispatch via `InvocationContext`, grep-friendly help, JSON mode, and skill-doc links in `--help`.",
   "keywords": [
     "cli",
     "agent",

--- a/libraries/libcli/package.json
+++ b/libraries/libcli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libcli",
   "version": "0.1.7",
-  "description": "Agent-friendly CLIs: argument parsing, handler dispatch via `InvocationContext`, grep-friendly help, JSON mode, and skill-doc links in `--help`.",
+  "description": "Agent-friendly CLIs: argument parsing, handler dispatch, grep-friendly help, JSON mode, and skill-doc links in `--help`.",
   "keywords": [
     "cli",
     "agent",

--- a/libraries/libcli/src/cli.js
+++ b/libraries/libcli/src/cli.js
@@ -1,5 +1,6 @@
 import { parseArgs } from "node:util";
 import { HelpRenderer } from "./help.js";
+import { freezeInvocationContext } from "./invocation-context.js";
 
 export class Cli {
   #definition;
@@ -91,8 +92,11 @@ export class Cli {
     const bare = match[2];
     const asCommand = this.#definition.commands?.find((c) => c.name === bare);
     if (!asCommand) return null;
-    const usage = asCommand.args
-      ? `${this.#definition.name} ${bare} ${asCommand.args}`
+    const argsStr = Array.isArray(asCommand.args)
+      ? asCommand.argsUsage
+      : asCommand.args;
+    const usage = argsStr
+      ? `${this.#definition.name} ${bare} ${argsStr}`
       : `${this.#definition.name} ${bare}`;
     return new Error(
       `Unknown option "${match[1]}${bare}". "${bare}" is a command, not an option. Usage: ${usage}`,
@@ -124,6 +128,31 @@ export class Cli {
       if (found) return found;
     }
     return null;
+  }
+
+  dispatch(parsed, { data }) {
+    const command = this.#findCommand(parsed.positionals);
+    if (!command) {
+      throw new Error(`${this.#definition.name}: no matching subcommand`);
+    }
+    if (typeof command.handler !== "function") {
+      throw new Error(
+        `${this.#definition.name}: subcommand "${command.name}" lacks a handler — ` +
+          `dispatch() requires { args: string[], handler: (ctx) => any }`,
+      );
+    }
+    const consumed = command.name.split(" ").length;
+    const argv = parsed.positionals.slice(consumed);
+    const argNames = Array.isArray(command.args) ? command.args : [];
+    const args = Object.fromEntries(
+      argNames.map((n, i) => [n, argv[i]]).filter(([, v]) => v !== undefined),
+    );
+    const ctx = freezeInvocationContext({
+      data,
+      args,
+      options: parsed.values,
+    });
+    return command.handler(ctx);
   }
 
   showHelp() {

--- a/libraries/libcli/src/help.js
+++ b/libraries/libcli/src/help.js
@@ -32,16 +32,23 @@ export class HelpRenderer {
     return [`Usage: ${definition.name} [options]`, ""];
   }
 
+  #argsDisplay(cmd) {
+    if (Array.isArray(cmd.args)) return cmd.argsUsage || "";
+    return cmd.args || "";
+  }
+
   #renderCommands(definition) {
     if (!definition.commands || definition.commands.length === 0) return [];
     const lines = [this.#sectionHeader("Commands:")];
     const maxWidth = Math.max(
-      ...definition.commands.map(
-        (c) => c.name.length + (c.args ? c.args.length + 1 : 0),
-      ),
+      ...definition.commands.map((c) => {
+        const argsStr = this.#argsDisplay(c);
+        return c.name.length + (argsStr ? argsStr.length + 1 : 0);
+      }),
     );
     for (const cmd of definition.commands) {
-      const left = cmd.args ? `${cmd.name} ${cmd.args}` : cmd.name;
+      const argsStr = this.#argsDisplay(cmd);
+      const left = argsStr ? `${cmd.name} ${argsStr}` : cmd.name;
       lines.push(`  ${left.padEnd(maxWidth)}  ${cmd.description}`);
     }
     lines.push("");
@@ -106,15 +113,16 @@ export class HelpRenderer {
   }
 
   #renderCommand(definition, stream, command) {
+    const argsStr = this.#argsDisplay(command);
     let header = `${definition.name} ${command.name}`;
-    if (command.args) header += ` ${command.args}`;
+    if (argsStr) header += ` ${argsStr}`;
     if (command.description) header += ` \u2014 ${command.description}`;
     const formatted = supportsColor(this.#proc)
       ? formatHeader(header, this.#proc)
       : header;
 
     let usage = `Usage: ${definition.name} ${command.name}`;
-    if (command.args) usage += ` ${command.args}`;
+    if (argsStr) usage += ` ${argsStr}`;
     usage += " [options]";
 
     const globalWithoutVersion = definition.globalOptions

--- a/libraries/libcli/src/index.js
+++ b/libraries/libcli/src/index.js
@@ -1,4 +1,5 @@
 export { Cli, createCli } from "./cli.js";
+export { freezeInvocationContext } from "./invocation-context.js";
 export { HelpRenderer } from "./help.js";
 export { SummaryRenderer } from "./summary.js";
 export { colors, supportsColor, colorize } from "./color.js";

--- a/libraries/libcli/src/invocation-context.js
+++ b/libraries/libcli/src/invocation-context.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {Object} InvocationContext
+ * @property {Object} data
+ * @property {Readonly<Object<string,string>>} args
+ * @property {Readonly<Object<string,string|boolean|string[]>>} options
+ */
+
+/**
+ * Deep-freeze an invocation context so handlers may assume immutability.
+ * @param {{ data: Object, args: Object<string,string>, options: Object<string,string|boolean|string[]> }} raw
+ * @returns {InvocationContext}
+ */
+export function freezeInvocationContext({ data, args, options }) {
+  for (const v of Object.values(options)) {
+    if (Array.isArray(v)) Object.freeze(v);
+  }
+  return Object.freeze({
+    data,
+    args: Object.freeze({ ...args }),
+    options: Object.freeze({ ...options }),
+  });
+}

--- a/libraries/libcli/src/invocation-context.js
+++ b/libraries/libcli/src/invocation-context.js
@@ -1,8 +1,40 @@
 /**
  * @typedef {Object} InvocationContext
+ *
+ * The shape libui and libcli both produce from their native inputs.
+ * Handlers consume the context and return a view; surface-specific
+ * formatters render the view. The context carries no information about
+ * which surface produced it — surface dispatch happens one level above the
+ * handler.
+ *
+ * Invariants:
+ * - No surface affordances — no DOM nodes, streams, Request/Response, or
+ *   surface tag. Anything that exists on only one surface stays out.
+ * - Uniform value shapes — args values are strings; options values are one
+ *   of string, boolean true, or string[]. No nulls, no numbers.
+ * - Frozen at all levels — the context, args, options, and any array
+ *   inside options are Object.freeze'd by the producer.
+ *
  * @property {Object} data
- * @property {Readonly<Object<string,string>>} args
- * @property {Readonly<Object<string,string|boolean|string[]>>} options
+ *   Host's data dependencies, opaque to libui and libcli. Shape is the
+ *   product's responsibility. Anything a handler needs that is not a
+ *   positional or named argument lives here, including surface-specific
+ *   runtime dependencies the host folds in before invocation. The handler
+ *   treats data as immutable input.
+ *
+ * @property {Readonly<Object<string, string>>} args
+ *   Named positional arguments. On the web side: route-pattern parameters
+ *   keyed by their name. On the CLI side: the subcommand's declared
+ *   positional argument names mapped to their argv values. Values are
+ *   always strings; consumers parse if they need other types.
+ *
+ * @property {Readonly<Object<string, string | boolean | string[]>>} options
+ *   Named non-positional arguments. On the web side: the URL hash query
+ *   string parsed once. On the CLI side: parsed CLI flags. Values are one
+ *   of: a string, the boolean true (for a presence-only flag or an
+ *   empty-valued query parameter), or an array of strings (when the same
+ *   key appears more than once). Absent options are not present in the
+ *   object — 'foo' in ctx.options is the membership test.
  */
 
 /**

--- a/libraries/libcli/test/cli.test.js
+++ b/libraries/libcli/test/cli.test.js
@@ -343,4 +343,132 @@ describe("Cli", () => {
       assert.strictEqual(proc.exitCode, 2);
     });
   });
+
+  describe("dispatch", () => {
+    test("maps positional names to argv values and calls handler with frozen ctx", () => {
+      const proc = createProc();
+      const received = [];
+      const def = {
+        name: "fit-test",
+        commands: [
+          {
+            name: "skill",
+            args: ["id"],
+            argsUsage: "[<id>]",
+            description: "Show skill",
+            handler: (ctx) => received.push(ctx),
+          },
+        ],
+        globalOptions: {
+          json: { type: "boolean", description: "JSON output" },
+          help: { type: "boolean", short: "h", description: "Show help" },
+        },
+      };
+      const helpRenderer = new HelpRenderer({ process: proc });
+      const cli = new Cli(def, { process: proc, helpRenderer });
+      const parsed = cli.parse(["skill", "testing", "--json"]);
+      cli.dispatch(parsed, { data: { skills: [] } });
+
+      assert.strictEqual(received.length, 1);
+      const ctx = received[0];
+      assert.strictEqual(ctx.args.id, "testing");
+      assert.strictEqual(ctx.options.json, true);
+      assert.strictEqual(Object.isFrozen(ctx), true);
+      assert.strictEqual(Object.isFrozen(ctx.args), true);
+    });
+
+    test("omits missing trailing positionals from args", () => {
+      const proc = createProc();
+      const received = [];
+      const def = {
+        name: "fit-test",
+        commands: [
+          {
+            name: "skill",
+            args: ["id", "format"],
+            argsUsage: "[<id>] [<format>]",
+            description: "Show skill",
+            handler: (ctx) => received.push(ctx),
+          },
+        ],
+        globalOptions: {
+          help: { type: "boolean", short: "h", description: "Show help" },
+        },
+      };
+      const helpRenderer = new HelpRenderer({ process: proc });
+      const cli = new Cli(def, { process: proc, helpRenderer });
+      const parsed = cli.parse(["skill", "testing"]);
+      cli.dispatch(parsed, { data: {} });
+
+      assert.strictEqual(received[0].args.id, "testing");
+      assert.strictEqual(received[0].args.format, undefined);
+    });
+
+    test("legacy string-shaped args still work with parse()", () => {
+      const proc = createProc();
+      const def = {
+        name: "fit-test",
+        commands: [
+          {
+            name: "run",
+            args: "<file>",
+            description: "Run a file",
+          },
+        ],
+        globalOptions: {
+          help: { type: "boolean", short: "h", description: "Show help" },
+        },
+      };
+      const helpRenderer = new HelpRenderer({ process: proc });
+      const cli = new Cli(def, { process: proc, helpRenderer });
+      const result = cli.parse(["run", "main.js"]);
+      assert.deepStrictEqual(result.positionals, ["run", "main.js"]);
+    });
+
+    test("throws when no matching subcommand", () => {
+      const proc = createProc();
+      const def = {
+        name: "fit-test",
+        commands: [
+          {
+            name: "skill",
+            args: ["id"],
+            handler: () => {},
+          },
+        ],
+        globalOptions: {
+          help: { type: "boolean", short: "h", description: "Show help" },
+        },
+      };
+      const helpRenderer = new HelpRenderer({ process: proc });
+      const cli = new Cli(def, { process: proc, helpRenderer });
+      const parsed = cli.parse(["bogus"]);
+      assert.throws(() => cli.dispatch(parsed, { data: {} }), {
+        message: /no matching subcommand/,
+      });
+    });
+
+    test("throws when command lacks handler", () => {
+      const proc = createProc();
+      const def = {
+        name: "fit-test",
+        commands: [
+          {
+            name: "skill",
+            args: ["id"],
+            description: "Show skill",
+          },
+        ],
+        globalOptions: {
+          help: { type: "boolean", short: "h", description: "Show help" },
+        },
+      };
+      const helpRenderer = new HelpRenderer({ process: proc });
+      const cli = new Cli(def, { process: proc, helpRenderer });
+      const parsed = cli.parse(["skill", "testing"]);
+      assert.throws(() => cli.dispatch(parsed, { data: {} }), {
+        message: /lacks a handler/,
+      });
+    });
+  });
 });

--- a/libraries/libcli/test/help.test.js
+++ b/libraries/libcli/test/help.test.js
@@ -319,4 +319,67 @@ describe("HelpRenderer", () => {
       assert.ok(!parsed.globalOptions.version);
     });
   });
+
+  describe("args: string[] with argsUsage", () => {
+    test("renders argsUsage in commands list when args is an array", () => {
+      const stream = createStream();
+      const def = {
+        name: "fit-test",
+        commands: [
+          {
+            name: "skill",
+            args: ["id"],
+            argsUsage: "[<id>]",
+            description: "Show skill",
+          },
+        ],
+        globalOptions: {
+          help: { type: "boolean", short: "h", description: "Show help" },
+        },
+      };
+      createRenderer().render(def, stream);
+      assert.ok(stream.output.includes("skill [<id>]"));
+      assert.ok(stream.output.includes("Show skill"));
+    });
+
+    test("renders argsUsage in per-command help when args is an array", () => {
+      const stream = createStream();
+      const def = {
+        name: "fit-test",
+        commands: [
+          {
+            name: "skill",
+            args: ["id"],
+            argsUsage: "[<id>]",
+            description: "Show skill",
+          },
+        ],
+        globalOptions: {
+          help: { type: "boolean", short: "h", description: "Show help" },
+        },
+      };
+      createRenderer().render(def, stream, def.commands[0]);
+      assert.ok(stream.output.includes("fit-test skill [<id>]"));
+    });
+
+    test("handles args: string[] without argsUsage gracefully", () => {
+      const stream = createStream();
+      const def = {
+        name: "fit-test",
+        commands: [
+          {
+            name: "skill",
+            args: ["id"],
+            description: "Show skill",
+          },
+        ],
+        globalOptions: {
+          help: { type: "boolean", short: "h", description: "Show help" },
+        },
+      };
+      createRenderer().render(def, stream);
+      assert.ok(stream.output.includes("skill"));
+      assert.ok(stream.output.includes("Show skill"));
+    });
+  });
 });

--- a/libraries/libcli/test/invocation-context.test.js
+++ b/libraries/libcli/test/invocation-context.test.js
@@ -1,0 +1,72 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+import { freezeInvocationContext } from "../src/invocation-context.js";
+
+// Fixture is intentionally identical to libraries/libui/test/invocation-context.test.js
+// to serve as a drift gate (design D1). Change both together.
+const fixture = {
+  data: { skills: ["a", "b"] },
+  args: { id: "testing" },
+  options: { json: true, format: "table", tag: ["a", "b"] },
+};
+
+describe("freezeInvocationContext", () => {
+  test("returns a frozen object with data, args, and options", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx), true);
+    assert.deepStrictEqual(ctx.data, fixture.data);
+    assert.strictEqual(ctx.args.id, "testing");
+    assert.strictEqual(ctx.options.json, true);
+    assert.strictEqual(ctx.options.format, "table");
+    assert.deepStrictEqual(ctx.options.tag, ["a", "b"]);
+  });
+
+  test("freezes args", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx.args), true);
+    assert.throws(() => {
+      ctx.args.id = "other";
+    }, TypeError);
+  });
+
+  test("freezes options", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx.options), true);
+    assert.throws(() => {
+      ctx.options.json = false;
+    }, TypeError);
+  });
+
+  test("freezes array values inside options", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx.options.tag), true);
+    assert.throws(() => {
+      ctx.options.tag.push("c");
+    }, TypeError);
+  });
+
+  test("membership test works on frozen options", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual("json" in ctx.options, true);
+    assert.strictEqual("missing" in ctx.options, false);
+  });
+
+  test("does not freeze data (host-owned)", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx.data), false);
+  });
+
+  test("copies args and options so mutations to the original do not propagate", () => {
+    const raw = {
+      data: {},
+      args: { id: "x" },
+      options: { json: true },
+    };
+    const ctx = freezeInvocationContext(raw);
+    raw.args.id = "mutated";
+    raw.options.json = false;
+    assert.strictEqual(ctx.args.id, "x");
+    assert.strictEqual(ctx.options.json, true);
+  });
+});

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -48,6 +48,12 @@
     "src/css/",
     "README.md"
   ],
+  "scripts": {
+    "test": "bun test test/*.test.js"
+  },
+  "devDependencies": {
+    "happy-dom": "^20.9.0"
+  },
   "engines": {
     "bun": ">=1.2.0",
     "node": ">=18.0.0"

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -38,6 +38,11 @@
     "./yaml-loader": "./src/yaml-loader.js",
     "./markdown": "./src/markdown.js",
     "./utils": "./src/utils.js",
+    "./invocation-context": "./src/invocation-context.js",
+    "./route-descriptor": "./src/route-descriptor.js",
+    "./bound-router": "./src/bound-router.js",
+    "./command-bar": "./src/command-bar.js",
+    "./json-ld-script": "./src/json-ld-script.js",
     "./components": "./src/components/index.js",
     "./components/*": "./src/components/*.js",
     "./css/*": "./src/css/*"

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libui",
   "version": "1.1.8",
-  "description": "Functional web UI primitives — DOM helpers, SPA routing, reactive state — for products agents build.",
+  "description": "Agent-friendly web surfaces — SPA routing, reactive state, and route-to-CLI bindings that share handler logic with `libcli` through `InvocationContext`.",
   "keywords": [
     "ui",
     "dom",

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libui",
   "version": "1.1.8",
-  "description": "Agent-friendly web surfaces — SPA routing, reactive state, and route-to-CLI bindings that share handler logic with `libcli` through `InvocationContext`.",
+  "description": "Agent-friendly web surfaces — SPA routing, reactive state, and route-to-CLI bindings that share handler logic across web and terminal.",
   "keywords": [
     "ui",
     "dom",

--- a/libraries/libui/src/bound-router.js
+++ b/libraries/libui/src/bound-router.js
@@ -1,0 +1,136 @@
+/**
+ * Bound Router — registry + dispatcher that produces InvocationContext
+ * on each route match and exposes activeRoute as a reactive.
+ */
+
+import { parsePattern } from "./router-core.js";
+import { createReactive } from "./reactive.js";
+import { freezeInvocationContext } from "./invocation-context.js";
+import { withErrorBoundary } from "./error-boundary.js";
+
+/**
+ * @typedef {Object} BoundRouter
+ * @property {(descriptor: import('./route-descriptor.js').RouteDescriptor) => void} register
+ * @property {() => import('./route-descriptor.js').RouteDescriptor[]} routes
+ * @property {() => void} start
+ * @property {() => void} stop
+ * @property {(path: string) => void} navigate
+ * @property {() => string} currentPath
+ * @property {import('./reactive.js').Reactive<{ descriptor: import('./route-descriptor.js').RouteDescriptor, ctx: import('./invocation-context.js').InvocationContext } | null>} activeRoute
+ */
+
+/**
+ * @param {{ data?: Object, vocabularyBase?: string, onNotFound?: (path: string) => void, onError?: (error: Error) => void, renderError?: (title: string, message: string) => void }} [options]
+ * @returns {BoundRouter}
+ */
+export function createBoundRouter(options = {}) {
+  const {
+    data,
+    vocabularyBase,
+    onNotFound = () => {},
+    onError,
+    renderError,
+  } = options;
+
+  const entries = [];
+  const activeRoute = createReactive(null);
+  let hashChangeHandler = null;
+  let originalReplaceState = null;
+  let started = false;
+
+  function register(descriptor) {
+    const { regex, paramNames } = parsePattern(descriptor.pattern);
+    const wrappedPage = withErrorBoundary(descriptor.page, {
+      onError,
+      backPath: "/",
+      backText: "← Back to Home",
+      renderErrorFn: renderError,
+    });
+    entries.push({ descriptor, regex, paramNames, wrappedPage });
+  }
+
+  function routes() {
+    return entries.map((e) => e.descriptor);
+  }
+
+  function currentPath() {
+    return window.location.hash.slice(1) || "/";
+  }
+
+  function parseQueryString(qs) {
+    const options = {};
+    if (!qs) return options;
+    const params = new URLSearchParams(qs);
+    for (const key of params.keys()) {
+      const values = params.getAll(key);
+      if (values.length > 1) {
+        options[key] = values;
+      } else {
+        const v = values[0];
+        options[key] = v === "" ? true : v;
+      }
+    }
+    return options;
+  }
+
+  function handleRoute() {
+    const fullPath = currentPath();
+    const [pathPart, queryPart] = fullPath.split("?");
+
+    for (const entry of entries) {
+      const match = pathPart.match(entry.regex);
+      if (match) {
+        const args = {};
+        entry.paramNames.forEach((name, i) => {
+          args[name] = decodeURIComponent(match[i + 1]);
+        });
+        const queryOptions = parseQueryString(queryPart);
+        const ctx = freezeInvocationContext({
+          data,
+          args,
+          options: queryOptions,
+        });
+        activeRoute.set({ descriptor: entry.descriptor, ctx });
+        window.scrollTo(0, 0);
+        entry.wrappedPage(ctx, { vocabularyBase });
+        return;
+      }
+    }
+    activeRoute.set(null);
+    onNotFound(pathPart);
+  }
+
+  function start() {
+    if (started) return;
+    started = true;
+    hashChangeHandler = () => handleRoute();
+    window.addEventListener("hashchange", hashChangeHandler);
+
+    originalReplaceState = history.replaceState;
+    history.replaceState = (...args) => {
+      originalReplaceState.apply(history, args);
+      handleRoute();
+    };
+
+    handleRoute();
+  }
+
+  function stop() {
+    if (!started) return;
+    started = false;
+    if (hashChangeHandler) {
+      window.removeEventListener("hashchange", hashChangeHandler);
+      hashChangeHandler = null;
+    }
+    if (originalReplaceState) {
+      history.replaceState = originalReplaceState;
+      originalReplaceState = null;
+    }
+  }
+
+  function navigate(path) {
+    window.location.hash = path;
+  }
+
+  return { register, routes, start, stop, navigate, currentPath, activeRoute };
+}

--- a/libraries/libui/src/command-bar.js
+++ b/libraries/libui/src/command-bar.js
@@ -1,0 +1,70 @@
+/**
+ * Command bar component — subscribes to a bound router's activeRoute
+ * and displays the CLI equivalent of the current route.
+ */
+
+/**
+ * @param {import('./bound-router.js').BoundRouter} router
+ * @param {{ mountInto: HTMLElement }} options
+ * @returns {{ destroy: () => void }}
+ */
+export function createCommandBar(router, { mountInto }) {
+  const root = document.createElement("div");
+  root.className = "command-bar";
+
+  const commandEl = document.createElement("span");
+  commandEl.className = "command-bar__command";
+
+  const copyButton = document.createElement("button");
+  copyButton.className = "command-bar__copy";
+  copyButton.setAttribute("aria-label", "Copy command");
+  copyButton.disabled = true;
+
+  root.appendChild(commandEl);
+  root.appendChild(copyButton);
+  mountInto.appendChild(root);
+
+  function applyEntry(entry) {
+    const text = entry?.descriptor.cli ? entry.descriptor.cli(entry.ctx) : "";
+    commandEl.textContent = text;
+    copyButton.disabled = text === "";
+  }
+
+  applyEntry(router.activeRoute.get());
+  const unsubscribe = router.activeRoute.subscribe(applyEntry);
+
+  async function handleCopy() {
+    const text = commandEl.textContent;
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      copyButton.classList.add("copied");
+      copyButton.setAttribute("aria-label", "Copied!");
+      setTimeout(() => {
+        copyButton.classList.remove("copied");
+        copyButton.setAttribute("aria-label", "Copy command");
+      }, 2000);
+    } catch {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      copyButton.classList.add("copied");
+      setTimeout(() => copyButton.classList.remove("copied"), 2000);
+    }
+  }
+
+  copyButton.addEventListener("click", handleCopy);
+
+  return {
+    destroy() {
+      unsubscribe();
+      copyButton.removeEventListener("click", handleCopy);
+      mountInto.removeChild(root);
+    },
+  };
+}

--- a/libraries/libui/src/index.js
+++ b/libraries/libui/src/index.js
@@ -77,3 +77,14 @@ export { markdownToHtml } from "./markdown.js";
 
 // Utilities
 export { getItemsByIds } from "./utils.js";
+
+// Invocation context
+export { freezeInvocationContext } from "./invocation-context.js";
+
+// Route descriptors and bound router
+export { defineRoute } from "./route-descriptor.js";
+export { createBoundRouter } from "./bound-router.js";
+
+// UI helpers tied to the bound router
+export { createCommandBar } from "./command-bar.js";
+export { createJsonLdScript } from "./json-ld-script.js";

--- a/libraries/libui/src/invocation-context.js
+++ b/libraries/libui/src/invocation-context.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {Object} InvocationContext
+ * @property {Object} data
+ * @property {Readonly<Object<string,string>>} args
+ * @property {Readonly<Object<string,string|boolean|string[]>>} options
+ */
+
+/**
+ * Deep-freeze an invocation context so handlers may assume immutability.
+ * @param {{ data: Object, args: Object<string,string>, options: Object<string,string|boolean|string[]> }} raw
+ * @returns {InvocationContext}
+ */
+export function freezeInvocationContext({ data, args, options }) {
+  for (const v of Object.values(options)) {
+    if (Array.isArray(v)) Object.freeze(v);
+  }
+  return Object.freeze({
+    data,
+    args: Object.freeze({ ...args }),
+    options: Object.freeze({ ...options }),
+  });
+}

--- a/libraries/libui/src/invocation-context.js
+++ b/libraries/libui/src/invocation-context.js
@@ -1,8 +1,40 @@
 /**
  * @typedef {Object} InvocationContext
+ *
+ * The shape libui and libcli both produce from their native inputs.
+ * Handlers consume the context and return a view; surface-specific
+ * formatters render the view. The context carries no information about
+ * which surface produced it — surface dispatch happens one level above the
+ * handler.
+ *
+ * Invariants:
+ * - No surface affordances — no DOM nodes, streams, Request/Response, or
+ *   surface tag. Anything that exists on only one surface stays out.
+ * - Uniform value shapes — args values are strings; options values are one
+ *   of string, boolean true, or string[]. No nulls, no numbers.
+ * - Frozen at all levels — the context, args, options, and any array
+ *   inside options are Object.freeze'd by the producer.
+ *
  * @property {Object} data
- * @property {Readonly<Object<string,string>>} args
- * @property {Readonly<Object<string,string|boolean|string[]>>} options
+ *   Host's data dependencies, opaque to libui and libcli. Shape is the
+ *   product's responsibility. Anything a handler needs that is not a
+ *   positional or named argument lives here, including surface-specific
+ *   runtime dependencies the host folds in before invocation. The handler
+ *   treats data as immutable input.
+ *
+ * @property {Readonly<Object<string, string>>} args
+ *   Named positional arguments. On the web side: route-pattern parameters
+ *   keyed by their name. On the CLI side: the subcommand's declared
+ *   positional argument names mapped to their argv values. Values are
+ *   always strings; consumers parse if they need other types.
+ *
+ * @property {Readonly<Object<string, string | boolean | string[]>>} options
+ *   Named non-positional arguments. On the web side: the URL hash query
+ *   string parsed once. On the CLI side: parsed CLI flags. Values are one
+ *   of: a string, the boolean true (for a presence-only flag or an
+ *   empty-valued query parameter), or an array of strings (when the same
+ *   key appears more than once). Absent options are not present in the
+ *   object — 'foo' in ctx.options is the membership test.
  */
 
 /**

--- a/libraries/libui/src/json-ld-script.js
+++ b/libraries/libui/src/json-ld-script.js
@@ -1,0 +1,25 @@
+/**
+ * JSON-LD script helper — mints @id through a descriptor's graph formatter.
+ */
+
+/**
+ * @param {((ctx: import('./invocation-context.js').InvocationContext, vocabularyBase: string) => string)|undefined} graphFormatter
+ * @param {import('./invocation-context.js').InvocationContext} ctx
+ * @param {Object} body
+ * @param {{ vocabularyBase: string }} options
+ * @returns {HTMLScriptElement|null}
+ */
+export function createJsonLdScript(
+  graphFormatter,
+  ctx,
+  body,
+  { vocabularyBase },
+) {
+  if (!graphFormatter) return null;
+  const id = graphFormatter(ctx, vocabularyBase);
+  const payload = { "@context": vocabularyBase, "@id": id, ...body };
+  const script = document.createElement("script");
+  script.type = "application/ld+json";
+  script.textContent = JSON.stringify(payload);
+  return script;
+}

--- a/libraries/libui/src/route-descriptor.js
+++ b/libraries/libui/src/route-descriptor.js
@@ -1,0 +1,18 @@
+/**
+ * @typedef {Object} RouteDescriptor
+ * @property {string} pattern
+ * @property {(ctx: import('./invocation-context.js').InvocationContext, opts: { vocabularyBase?: string }) => void} page
+ * @property {((ctx: import('./invocation-context.js').InvocationContext) => string)=} cli
+ * @property {((ctx: import('./invocation-context.js').InvocationContext, vocabularyBase: string) => string)=} graph
+ */
+
+/**
+ * Build a frozen route descriptor binding a URL pattern to its page, CLI, and graph channels.
+ * @param {{ pattern: string, page: Function, cli?: Function, graph?: Function }} spec
+ * @returns {RouteDescriptor}
+ */
+export function defineRoute({ pattern, page, cli, graph }) {
+  if (typeof pattern !== "string") throw new TypeError("pattern: string");
+  if (typeof page !== "function") throw new TypeError("page: function");
+  return Object.freeze({ pattern, page, cli, graph });
+}

--- a/libraries/libui/src/router-core.js
+++ b/libraries/libui/src/router-core.js
@@ -36,7 +36,7 @@ import { withErrorBoundary } from "./error-boundary.js";
  * @param {string} pattern
  * @returns {{ regex: RegExp, paramNames: string[] }}
  */
-function parsePattern(pattern) {
+export function parsePattern(pattern) {
   const paramNames = [];
   const regexStr = pattern
     .replace(/:([^/]+)/g, (_, name) => {

--- a/libraries/libui/src/router-core.js
+++ b/libraries/libui/src/router-core.js
@@ -33,6 +33,7 @@ import { withErrorBoundary } from "./error-boundary.js";
 
 /**
  * Parse route pattern into regex and param names
+ * @internal Exported for bound-router.js — not part of the public API.
  * @param {string} pattern
  * @returns {{ regex: RegExp, paramNames: string[] }}
  */

--- a/libraries/libui/test/bound-router.test.js
+++ b/libraries/libui/test/bound-router.test.js
@@ -6,6 +6,9 @@ import { createBoundRouter } from "../src/bound-router.js";
 import { defineRoute } from "../src/route-descriptor.js";
 
 let win;
+const savedWindow = globalThis.window;
+const savedHistory = globalThis.history;
+const savedDocument = globalThis.document;
 
 beforeEach(() => {
   win = new Window({ url: "http://localhost" });
@@ -15,9 +18,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete globalThis.window;
-  delete globalThis.history;
-  delete globalThis.document;
+  globalThis.window = savedWindow;
+  globalThis.history = savedHistory;
+  globalThis.document = savedDocument;
 });
 
 describe("createBoundRouter", () => {

--- a/libraries/libui/test/bound-router.test.js
+++ b/libraries/libui/test/bound-router.test.js
@@ -1,0 +1,208 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { Window } from "happy-dom";
+
+import { createBoundRouter } from "../src/bound-router.js";
+import { defineRoute } from "../src/route-descriptor.js";
+
+let win;
+
+beforeEach(() => {
+  win = new Window({ url: "http://localhost" });
+  globalThis.window = win;
+  globalThis.history = win.history;
+  globalThis.document = win.document;
+});
+
+afterEach(() => {
+  delete globalThis.window;
+  delete globalThis.history;
+  delete globalThis.document;
+});
+
+describe("createBoundRouter", () => {
+  test("matches a route with :id param and query options", () => {
+    const pages = [];
+    const router = createBoundRouter({
+      data: { skills: [] },
+    });
+    router.register(
+      defineRoute({
+        pattern: "/skill/:id",
+        page: (ctx) => pages.push(ctx),
+      }),
+    );
+
+    win.location.hash = "#/skill/testing?json=1&tag=a&tag=b";
+    router.start();
+
+    assert.strictEqual(pages.length, 1);
+    const ctx = pages[0];
+    assert.strictEqual(ctx.args.id, "testing");
+    assert.strictEqual(ctx.options.json, "1");
+    assert.deepStrictEqual(ctx.options.tag, ["a", "b"]);
+
+    router.stop();
+  });
+
+  test("triggers onNotFound for unmatched paths", () => {
+    const notFound = [];
+    const router = createBoundRouter({
+      onNotFound: (path) => notFound.push(path),
+    });
+    router.register(defineRoute({ pattern: "/skill/:id", page: () => {} }));
+
+    win.location.hash = "#/unknown";
+    router.start();
+
+    assert.strictEqual(notFound.length, 1);
+    assert.strictEqual(notFound[0], "/unknown");
+
+    router.stop();
+  });
+
+  test("activeRoute subscribers fire on route change", () => {
+    const received = [];
+    const router = createBoundRouter({
+      data: { skills: [] },
+    });
+    const desc = defineRoute({
+      pattern: "/skill/:id",
+      page: () => {},
+    });
+    router.register(desc);
+    router.activeRoute.subscribe((entry) => received.push(entry));
+
+    win.location.hash = "#/skill/testing";
+    router.start();
+
+    assert.strictEqual(received.length, 1);
+    assert.strictEqual(received[0].descriptor, desc);
+    assert.strictEqual(received[0].ctx.args.id, "testing");
+
+    router.stop();
+  });
+
+  test("activeRoute updates on history.replaceState", () => {
+    const received = [];
+    const router = createBoundRouter({
+      data: {},
+    });
+    router.register(defineRoute({ pattern: "/a", page: () => {} }));
+    router.register(defineRoute({ pattern: "/b", page: () => {} }));
+    router.activeRoute.subscribe((entry) => received.push(entry));
+
+    win.location.hash = "#/a";
+    router.start();
+
+    assert.strictEqual(received.length, 1);
+    assert.strictEqual(received[0].descriptor.pattern, "/a");
+
+    win.history.replaceState(null, "", "#/b");
+
+    assert.strictEqual(received.length, 2);
+    assert.strictEqual(received[1].descriptor.pattern, "/b");
+
+    router.stop();
+  });
+
+  test("routes() returns registered descriptors", () => {
+    const router = createBoundRouter();
+    const d1 = defineRoute({ pattern: "/a", page: () => {} });
+    const d2 = defineRoute({ pattern: "/b", page: () => {} });
+    router.register(d1);
+    router.register(d2);
+
+    const result = router.routes();
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0], d1);
+    assert.strictEqual(result[1], d2);
+  });
+
+  test("stop() restores original history.replaceState", () => {
+    const original = win.history.replaceState;
+    const router = createBoundRouter({ data: {} });
+    router.register(defineRoute({ pattern: "/a", page: () => {} }));
+
+    win.location.hash = "#/a";
+    router.start();
+
+    assert.notStrictEqual(win.history.replaceState, original);
+
+    router.stop();
+
+    assert.strictEqual(win.history.replaceState, original);
+  });
+
+  test("double start() does not double-wrap replaceState", () => {
+    const router = createBoundRouter({ data: {} });
+    router.register(defineRoute({ pattern: "/a", page: () => {} }));
+
+    win.location.hash = "#/a";
+    router.start();
+    const patchedFirst = win.history.replaceState;
+    router.start();
+    assert.strictEqual(win.history.replaceState, patchedFirst);
+
+    router.stop();
+  });
+
+  test("empty-value query param becomes true", () => {
+    const pages = [];
+    const router = createBoundRouter({ data: {} });
+    router.register(
+      defineRoute({
+        pattern: "/skill/:id",
+        page: (ctx) => pages.push(ctx),
+      }),
+    );
+
+    win.location.hash = "#/skill/testing?json";
+    router.start();
+
+    assert.strictEqual(pages[0].options.json, true);
+
+    router.stop();
+  });
+
+  test("activeRoute is null for unmatched path", () => {
+    const received = [];
+    const router = createBoundRouter({
+      onNotFound: () => {},
+    });
+    router.register(defineRoute({ pattern: "/skill/:id", page: () => {} }));
+    router.activeRoute.subscribe((entry) => received.push(entry));
+
+    win.location.hash = "#/unknown";
+    router.start();
+
+    assert.strictEqual(received.length, 1);
+    assert.strictEqual(received[0], null);
+
+    router.stop();
+  });
+
+  test("page receives vocabularyBase", () => {
+    const calls = [];
+    const router = createBoundRouter({
+      data: {},
+      vocabularyBase: "https://example.invalid/schema/rdf/",
+    });
+    router.register(
+      defineRoute({
+        pattern: "/skill/:id",
+        page: (ctx, opts) => calls.push(opts),
+      }),
+    );
+
+    win.location.hash = "#/skill/testing";
+    router.start();
+
+    assert.strictEqual(
+      calls[0].vocabularyBase,
+      "https://example.invalid/schema/rdf/",
+    );
+
+    router.stop();
+  });
+});

--- a/libraries/libui/test/command-bar.test.js
+++ b/libraries/libui/test/command-bar.test.js
@@ -6,6 +6,9 @@ import { createCommandBar } from "../src/command-bar.js";
 import { createReactive } from "../src/reactive.js";
 
 let win;
+const savedWindow = globalThis.window;
+const savedDocument = globalThis.document;
+const savedNavigator = globalThis.navigator;
 
 beforeEach(() => {
   win = new Window({ url: "http://localhost" });
@@ -15,9 +18,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete globalThis.window;
-  delete globalThis.document;
-  delete globalThis.navigator;
+  globalThis.window = savedWindow;
+  globalThis.document = savedDocument;
+  globalThis.navigator = savedNavigator;
 });
 
 function createMockRouter(initial) {

--- a/libraries/libui/test/command-bar.test.js
+++ b/libraries/libui/test/command-bar.test.js
@@ -1,0 +1,127 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { Window } from "happy-dom";
+
+import { createCommandBar } from "../src/command-bar.js";
+import { createReactive } from "../src/reactive.js";
+
+let win;
+
+beforeEach(() => {
+  win = new Window({ url: "http://localhost" });
+  globalThis.window = win;
+  globalThis.document = win.document;
+  globalThis.navigator = win.navigator;
+});
+
+afterEach(() => {
+  delete globalThis.window;
+  delete globalThis.document;
+  delete globalThis.navigator;
+});
+
+function createMockRouter(initial) {
+  const activeRoute = createReactive(initial ?? null);
+  return { activeRoute };
+}
+
+function getBarParts(container) {
+  const root = container.children[0];
+  const commandEl = root.children[0];
+  const copyBtn = root.children[1];
+  return { root, commandEl, copyBtn };
+}
+
+describe("createCommandBar", () => {
+  test("renders CLI text from activeRoute", () => {
+    const ctx = Object.freeze({
+      data: {},
+      args: Object.freeze({ id: "testing" }),
+      options: Object.freeze({}),
+    });
+    const descriptor = {
+      pattern: "/skill/:id",
+      page: () => {},
+      cli: (c) => `npx fit-pathway skill ${c.args.id}`,
+    };
+    const router = createMockRouter({ descriptor, ctx });
+    const container = win.document.createElement("div");
+
+    const bar = createCommandBar(router, { mountInto: container });
+    const { commandEl, copyBtn } = getBarParts(container);
+
+    assert.strictEqual(commandEl.textContent, "npx fit-pathway skill testing");
+    assert.strictEqual(copyBtn.disabled, false);
+
+    bar.destroy();
+  });
+
+  test("renders empty text when descriptor has no cli slot", () => {
+    const ctx = Object.freeze({
+      data: {},
+      args: Object.freeze({}),
+      options: Object.freeze({}),
+    });
+    const descriptor = { pattern: "/", page: () => {} };
+    const router = createMockRouter({ descriptor, ctx });
+    const container = win.document.createElement("div");
+
+    const bar = createCommandBar(router, { mountInto: container });
+    const { commandEl, copyBtn } = getBarParts(container);
+
+    assert.strictEqual(commandEl.textContent, "");
+    assert.strictEqual(copyBtn.disabled, true);
+
+    bar.destroy();
+  });
+
+  test("tracks activeRoute sequence: cli-bound → no-cli → cli-bound", () => {
+    const router = createMockRouter(null);
+    const container = win.document.createElement("div");
+    const bar = createCommandBar(router, { mountInto: container });
+    const { commandEl, copyBtn } = getBarParts(container);
+
+    assert.strictEqual(commandEl.textContent, "");
+    assert.strictEqual(copyBtn.disabled, true);
+
+    const ctx1 = Object.freeze({
+      data: {},
+      args: Object.freeze({ id: "x" }),
+      options: Object.freeze({}),
+    });
+    router.activeRoute.set({
+      descriptor: { pattern: "/skill/:id", page: () => {}, cli: () => "cmd1" },
+      ctx: ctx1,
+    });
+    assert.strictEqual(commandEl.textContent, "cmd1");
+    assert.strictEqual(copyBtn.disabled, false);
+
+    router.activeRoute.set({
+      descriptor: { pattern: "/about", page: () => {} },
+      ctx: ctx1,
+    });
+    assert.strictEqual(commandEl.textContent, "");
+    assert.strictEqual(copyBtn.disabled, true);
+
+    router.activeRoute.set({
+      descriptor: { pattern: "/skill/:id", page: () => {}, cli: () => "cmd2" },
+      ctx: ctx1,
+    });
+    assert.strictEqual(commandEl.textContent, "cmd2");
+    assert.strictEqual(copyBtn.disabled, false);
+
+    bar.destroy();
+  });
+
+  test("destroy removes the root element and unsubscribes", () => {
+    const router = createMockRouter(null);
+    const container = win.document.createElement("div");
+    const bar = createCommandBar(router, { mountInto: container });
+
+    assert.strictEqual(container.children.length, 1);
+
+    bar.destroy();
+
+    assert.strictEqual(container.children.length, 0);
+  });
+});

--- a/libraries/libui/test/invocation-context.test.js
+++ b/libraries/libui/test/invocation-context.test.js
@@ -1,0 +1,72 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+import { freezeInvocationContext } from "../src/invocation-context.js";
+
+// Fixture is intentionally identical to libraries/libcli/test/invocation-context.test.js
+// to serve as a drift gate (design D1). Change both together.
+const fixture = {
+  data: { skills: ["a", "b"] },
+  args: { id: "testing" },
+  options: { json: true, format: "table", tag: ["a", "b"] },
+};
+
+describe("freezeInvocationContext", () => {
+  test("returns a frozen object with data, args, and options", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx), true);
+    assert.deepStrictEqual(ctx.data, fixture.data);
+    assert.strictEqual(ctx.args.id, "testing");
+    assert.strictEqual(ctx.options.json, true);
+    assert.strictEqual(ctx.options.format, "table");
+    assert.deepStrictEqual(ctx.options.tag, ["a", "b"]);
+  });
+
+  test("freezes args", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx.args), true);
+    assert.throws(() => {
+      ctx.args.id = "other";
+    }, TypeError);
+  });
+
+  test("freezes options", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx.options), true);
+    assert.throws(() => {
+      ctx.options.json = false;
+    }, TypeError);
+  });
+
+  test("freezes array values inside options", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx.options.tag), true);
+    assert.throws(() => {
+      ctx.options.tag.push("c");
+    }, TypeError);
+  });
+
+  test("membership test works on frozen options", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual("json" in ctx.options, true);
+    assert.strictEqual("missing" in ctx.options, false);
+  });
+
+  test("does not freeze data (host-owned)", () => {
+    const ctx = freezeInvocationContext(fixture);
+    assert.strictEqual(Object.isFrozen(ctx.data), false);
+  });
+
+  test("copies args and options so mutations to the original do not propagate", () => {
+    const raw = {
+      data: {},
+      args: { id: "x" },
+      options: { json: true },
+    };
+    const ctx = freezeInvocationContext(raw);
+    raw.args.id = "mutated";
+    raw.options.json = false;
+    assert.strictEqual(ctx.args.id, "x");
+    assert.strictEqual(ctx.options.json, true);
+  });
+});

--- a/libraries/libui/test/json-ld-script.test.js
+++ b/libraries/libui/test/json-ld-script.test.js
@@ -1,0 +1,86 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { Window } from "happy-dom";
+
+import { createJsonLdScript } from "../src/json-ld-script.js";
+import { freezeInvocationContext } from "../src/invocation-context.js";
+
+let win;
+
+beforeEach(() => {
+  win = new Window({ url: "http://localhost" });
+  globalThis.document = win.document;
+});
+
+afterEach(() => {
+  delete globalThis.document;
+});
+
+describe("createJsonLdScript", () => {
+  test("returns null when graphFormatter is absent", () => {
+    const ctx = freezeInvocationContext({
+      data: {},
+      args: { id: "testing" },
+      options: {},
+    });
+    const result = createJsonLdScript(
+      undefined,
+      ctx,
+      {},
+      {
+        vocabularyBase: "https://example.invalid/schema/rdf/",
+      },
+    );
+    assert.strictEqual(result, null);
+  });
+
+  test("returns a script element with correct type and content", () => {
+    const ctx = freezeInvocationContext({
+      data: {},
+      args: { id: "testing" },
+      options: {},
+    });
+    const graphFormatter = (c, base) => `${base}Skill/${c.args.id}`;
+    const body = { "@type": "Skill", name: "Testing" };
+
+    const script = createJsonLdScript(graphFormatter, ctx, body, {
+      vocabularyBase: "https://example.invalid/schema/rdf/",
+    });
+
+    assert.strictEqual(script.type, "application/ld+json");
+
+    const parsed = JSON.parse(script.textContent);
+    assert.strictEqual(
+      parsed["@id"],
+      "https://example.invalid/schema/rdf/Skill/testing",
+    );
+    assert.strictEqual(
+      parsed["@context"],
+      "https://example.invalid/schema/rdf/",
+    );
+    assert.strictEqual(parsed["@type"], "Skill");
+    assert.strictEqual(parsed.name, "Testing");
+  });
+
+  test("body fields are merged into the payload", () => {
+    const ctx = freezeInvocationContext({
+      data: {},
+      args: { id: "clarity" },
+      options: {},
+    });
+    const graphFormatter = (c, base) => `${base}Behaviour/${c.args.id}`;
+    const body = {
+      "@type": "Behaviour",
+      name: "Clarity of thought",
+      description: "Thinks clearly",
+    };
+
+    const script = createJsonLdScript(graphFormatter, ctx, body, {
+      vocabularyBase: "https://example.invalid/schema/rdf/",
+    });
+
+    const parsed = JSON.parse(script.textContent);
+    assert.strictEqual(parsed.name, "Clarity of thought");
+    assert.strictEqual(parsed.description, "Thinks clearly");
+  });
+});

--- a/libraries/libui/test/json-ld-script.test.js
+++ b/libraries/libui/test/json-ld-script.test.js
@@ -6,6 +6,7 @@ import { createJsonLdScript } from "../src/json-ld-script.js";
 import { freezeInvocationContext } from "../src/invocation-context.js";
 
 let win;
+const savedDocument = globalThis.document;
 
 beforeEach(() => {
   win = new Window({ url: "http://localhost" });
@@ -13,7 +14,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete globalThis.document;
+  globalThis.document = savedDocument;
 });
 
 describe("createJsonLdScript", () => {

--- a/libraries/libui/test/route-descriptor.test.js
+++ b/libraries/libui/test/route-descriptor.test.js
@@ -1,0 +1,47 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+import { defineRoute } from "../src/route-descriptor.js";
+
+describe("defineRoute", () => {
+  test("returns a frozen descriptor with pattern and page", () => {
+    const page = () => {};
+    const desc = defineRoute({ pattern: "/skill/:id", page });
+    assert.strictEqual(desc.pattern, "/skill/:id");
+    assert.strictEqual(desc.page, page);
+    assert.strictEqual(Object.isFrozen(desc), true);
+  });
+
+  test("cli and graph are optional", () => {
+    const desc = defineRoute({ pattern: "/", page: () => {} });
+    assert.strictEqual(desc.cli, undefined);
+    assert.strictEqual(desc.graph, undefined);
+  });
+
+  test("carries cli and graph when provided", () => {
+    const cli = (ctx) => `npx fit-pathway skill ${ctx.args.id}`;
+    const graph = (ctx, base) => `${base}Skill/${ctx.args.id}`;
+    const desc = defineRoute({
+      pattern: "/skill/:id",
+      page: () => {},
+      cli,
+      graph,
+    });
+    assert.strictEqual(desc.cli, cli);
+    assert.strictEqual(desc.graph, graph);
+  });
+
+  test("throws TypeError when pattern is missing", () => {
+    assert.throws(() => defineRoute({ page: () => {} }), {
+      name: "TypeError",
+      message: "pattern: string",
+    });
+  });
+
+  test("throws TypeError when page is missing", () => {
+    assert.throws(() => defineRoute({ pattern: "/" }), {
+      name: "TypeError",
+      message: "page: function",
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.14",
     "@playwright/test": "^1.59.1",
+    "acorn": "^8.16.0",
     "serve": "^14.2.6"
   },
   "overrides": {

--- a/products/CLAUDE.md
+++ b/products/CLAUDE.md
@@ -17,6 +17,17 @@ Write `--help` output, skill instructions, and published guides for that reader:
 self-contained, no insider tooling references, no relative paths into
 `products/` or `websites/`, and every doc link a fully-qualified public URL.
 
+## Invocation context
+
+Products with both a web UI and a CLI can share handler logic through
+`InvocationContext` — a frozen `{ data, args, options }` contract that libui's
+`createBoundRouter` produces from the URL and libcli's `dispatch()` produces
+from argv. Use `defineRoute` to bind a URL pattern to its CLI command and graph
+entity in one descriptor; the shared presenter receives the same context shape
+from both surfaces. See the
+[CLI Development guide](websites/fit/docs/internals/libcli/index.md) for the
+full contract.
+
 ## CLIs and progressive documentation
 
 Every product ships a CLI (a `bin/` entry in `package.json`). Three artifacts

--- a/tests/no-legacy-handler-shape.test.js
+++ b/tests/no-legacy-handler-shape.test.js
@@ -69,18 +69,30 @@ function isLegacyParams(param) {
   return param.type === "Identifier" && param.name === "params";
 }
 
-function walkAst(node, visitor) {
-  if (!node || typeof node !== "object") return;
-  visitor(node);
+function isAstNode(v) {
+  return v && typeof v === "object" && typeof v.type === "string";
+}
+
+function astChildren(node) {
+  const out = [];
   for (const key of Object.keys(node)) {
     const child = node[key];
     if (Array.isArray(child)) {
       for (const item of child) {
-        if (item && typeof item.type === "string") walkAst(item, visitor);
+        if (isAstNode(item)) out.push(item);
       }
-    } else if (child && typeof child.type === "string") {
-      walkAst(child, visitor);
+    } else if (isAstNode(child)) {
+      out.push(child);
     }
+  }
+  return out;
+}
+
+function walkAst(node, visitor) {
+  if (!isAstNode(node)) return;
+  visitor(node);
+  for (const child of astChildren(node)) {
+    walkAst(child, visitor);
   }
 }
 

--- a/tests/no-legacy-handler-shape.test.js
+++ b/tests/no-legacy-handler-shape.test.js
@@ -1,0 +1,132 @@
+/**
+ * Enforces that no newly introduced handler uses the legacy parameter shapes:
+ * - ({ data, args, options }) — CLI-side legacy (any superset of all three keys)
+ * - (params) — web-side legacy (single identifier named "params")
+ *
+ * Adapted from plan 760-a-01 Step 9 (originally an ESLint rule; the repo
+ * migrated to Biome which lacks custom AST rules). This test achieves the
+ * same enforcement — it runs during `bun run test` which gates every commit.
+ *
+ * Scope: libraries/libui/, libraries/libcli/ (Part 01).
+ * Part 02 adds products/pathway/ after migration.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { parse } from "acorn";
+
+const SCOPED_DIRS = ["libraries/libui/src", "libraries/libcli/src"];
+
+const ALLOWED_FILES = new Set([
+  "libraries/libui/src/invocation-context.js",
+  "libraries/libcli/src/invocation-context.js",
+]);
+
+const LEGACY_KEYS = new Set(["data", "args", "options"]);
+
+function collectJsFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      files.push(...collectJsFiles(full));
+    } else if (entry.endsWith(".js")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function getFirstParam(node) {
+  let fn = null;
+  if (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  ) {
+    fn = node;
+  }
+  if (!fn || fn.params.length === 0) return null;
+  return fn.params[0];
+}
+
+function isLegacyDestructured(param) {
+  if (param.type !== "ObjectPattern") return false;
+  const names = new Set(
+    param.properties
+      .filter((p) => p.type === "Property" && p.key.type === "Identifier")
+      .map((p) => p.key.name),
+  );
+  for (const key of LEGACY_KEYS) {
+    if (!names.has(key)) return false;
+  }
+  return true;
+}
+
+function isLegacyParams(param) {
+  return param.type === "Identifier" && param.name === "params";
+}
+
+function walkAst(node, visitor) {
+  if (!node || typeof node !== "object") return;
+  visitor(node);
+  for (const key of Object.keys(node)) {
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (item && typeof item.type === "string") walkAst(item, visitor);
+      }
+    } else if (child && typeof child.type === "string") {
+      walkAst(child, visitor);
+    }
+  }
+}
+
+function findViolations(filePath) {
+  const source = readFileSync(filePath, "utf-8");
+  const ast = parse(source, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    locations: true,
+  });
+
+  const violations = [];
+  walkAst(ast, (node) => {
+    const param = getFirstParam(node);
+    if (!param) return;
+    if (isLegacyDestructured(param)) {
+      violations.push({
+        line: param.loc.start.line,
+        kind: "destructured { data, args, options }",
+      });
+    }
+    if (isLegacyParams(param)) {
+      violations.push({
+        line: param.loc.start.line,
+        kind: 'identifier named "params"',
+      });
+    }
+  });
+  return violations;
+}
+
+describe("no-legacy-handler-shape", () => {
+  for (const dir of SCOPED_DIRS) {
+    const files = collectJsFiles(dir);
+    for (const file of files) {
+      const rel = relative(".", file);
+      if (ALLOWED_FILES.has(rel)) continue;
+      test(`${rel} has no legacy handler shapes`, () => {
+        const violations = findViolations(file);
+        assert.strictEqual(
+          violations.length,
+          0,
+          `Legacy handler shape(s) found in ${rel}:\n` +
+            violations.map((v) => `  line ${v.line}: ${v.kind}`).join("\n"),
+        );
+      });
+    }
+  }
+});

--- a/websites/fit/docs/internals/libcli/index.md
+++ b/websites/fit/docs/internals/libcli/index.md
@@ -1,75 +1,54 @@
 ---
 title: libcli — CLI Development
-description: Standard patterns for building CLI programs in the Forward Impact monorepo.
+description: Internal reference for CLI argument parsing, help rendering, handler dispatch, and the InvocationContext contract.
 layout: product
 ---
 
-## Logger Conventions
+## Architecture
 
-CLI programs use libtelemetry's Logger for operational output and reserve
-`console.log` / direct stdout writes for primary data output. The decision
-matrix:
-
-| Output type           | Use Logger? | Why                                  |
-| --------------------- | ----------- | ------------------------------------ |
-| Progress updates      | Yes         | Structured attributes beat free text |
-| Errors and exceptions | Yes         | Preserves trace context              |
-| Help text             | No          | Rendered by libcli                   |
-| Pure data output      | No          | Primary result for piping            |
-| Version string        | No          | Single value, rendered by libcli     |
-
-### Creating a Logger
-
-```js
-import { createLogger } from "@forwardimpact/libtelemetry";
-
-const logger = createLogger("codegen");
-```
-
-**Domain naming:** use the package name without the `lib` prefix. Examples:
-`"codegen"` for libcodegen, `"rc"` for librc, `"pathway"` for fit-pathway.
-
-### Level usage
-
-- **`debug`** — internal tracing, invisible unless `LOG_LEVEL=debug`
-- **`info`** — operational output the user expects to see
-- **`error`** — errors with context attributes
-- **`exception`** — caught errors with stack traces (use in `catch` blocks)
-
-### Structuring attributes
-
-Attributes make log lines parseable by both humans and agents:
-
-```js
-logger.info("step", "Generated types", { files: "12" });
-logger.error("compile", "Proto compilation failed", { path: "agent.proto" });
-```
-
-### Suppression
-
-The `--silent` / `--quiet` pattern (established in fit-rc) suppresses Logger
-output. When a CLI supports these flags, configure the Logger's minimum level
-accordingly — `--silent` raises it above `error`, `--quiet` raises it above
-`info`.
-
-### Output format
-
-Logger emits RFC 5424 structured messages:
+libcli has two layers. The **parse layer** (`Cli.parse()`) wraps `node:util`
+`parseArgs` with command identification, option scoping, and help/version
+interception. The **dispatch layer** (`Cli.dispatch()`) maps parsed positionals
+to named arguments, builds a frozen `InvocationContext`, and calls the
+subcommand handler. The parse layer exists in every CLI; the dispatch layer is
+opt-in for CLIs that want named args and shared handler logic with a web UI.
 
 ```
-{level} {timestamp} {domain} {appId} {procId} {msgId} [{attrs}] {message}
+argv
+ │
+ ▼
+Cli.parse(argv)
+ ├─ --help / --version → render, return null
+ └─ { values, positionals }
+      │
+      ▼
+  ┌──────────────────────────────┐
+  │ Legacy path (most CLIs)      │
+  │ Caller unpacks positionals   │
+  │ and values manually          │
+  └──────────────────────────────┘
+      │
+      ▼
+  ┌──────────────────────────────┐
+  │ Dispatch path (opt-in)       │
+  │ Cli.dispatch(parsed, {data}) │
+  │  → freezeInvocationContext   │
+  │  → command.handler(ctx)      │
+  └──────────────────────────────┘
 ```
+
+Both paths coexist. A definition can mix legacy `args: "<usage>"` commands with
+`args: string[]` + `handler` commands — `dispatch()` only activates for commands
+that have a `handler` function.
+
+Source: `libraries/libcli/src/cli.js`.
 
 ---
 
-## Help Text
+## Definition Schema
 
-libcli renders help from a **definition object** — a plain data structure that
-declares the CLI's name, version, description, commands, options, and examples.
-Options are scoped: `globalOptions` apply to every command, while per-command
-`options` apply only to the command they belong to.
-
-### Definition schema
+The definition object drives help rendering, argument parsing, and dispatch. All
+fields are plain data — no class instances, no callbacks (except `handler`).
 
 ```js
 const definition = {
@@ -79,36 +58,28 @@ const definition = {
   commands: [
     {
       name: "coverage",
-      args: "<team>",
+      args: "<team>",                // legacy: free-form usage string
       description: "Show capability coverage",
       options: {
-        evidenced: { type: "boolean", description: "Include practiced capability from Map evidence data" },
-        "lookback-months": { type: "string", description: "Lookback window for practice patterns (default: 12)" },
+        evidenced: { type: "boolean", description: "Include practiced capability" },
       },
-      examples: [
-        "fit-summit coverage platform",
-        "fit-summit coverage platform --evidenced --lookback-months=6",
-      ],
+      examples: ["fit-summit coverage platform --evidenced"],
     },
-    { name: "validate", args: "", description: "Validate roster file" },
+    {
+      name: "skill",
+      args: ["id"],                  // dispatch: declared positional names
+      argsUsage: "[<id>]",           // display string for help output
+      description: "Show skill detail",
+      handler: (ctx) => showSkill(ctx),
+    },
   ],
   globalOptions: {
-    data: { type: "string", description: "Path to Map data directory" },
-    roster: { type: "string", description: "Path to summit.yaml" },
-    format: { type: "string", default: "text", description: "Output format: text, json, markdown (default: text)" },
+    data: { type: "string", description: "Path to data directory" },
     help: { type: "boolean", short: "h", description: "Show help" },
     version: { type: "boolean", short: "v", description: "Show version" },
   },
-  examples: [
-    "fit-summit coverage platform",
-    "fit-summit what-if platform --add 'Jane, senior, backend'",
-  ],
+  examples: ["fit-summit coverage platform"],
   documentation: [
-    {
-      title: "Team Capability Guide",
-      url: "https://www.forwardimpact.team/docs/products/team-capability/index.md",
-      description: "Coverage heatmaps, structural risks, and what-if scenarios.",
-    },
     {
       title: "Summit Overview",
       url: "https://www.forwardimpact.team/summit/index.md",
@@ -117,162 +88,235 @@ const definition = {
 };
 ```
 
-**Key fields:**
+### Field reference
 
-- **`globalOptions`** — Options that apply to every command. Shown under
-  `Options:` in global help and `Global options:` in per-command help.
-- **`commands[].options`** — Options specific to one command. Only shown in that
-  command's per-command help. Not visible in global help.
-- **`commands[].examples`** — Per-command examples, shown only in per-command
-  help.
-- **`examples`** — Top-level examples, shown only in global help.
-- **`documentation`** — Array of `{ title, url, description? }` entries that
-  link out to published guides on the fit-doc site. Mirrors the matching
-  SKILL.md `## Documentation` section so agents reaching the CLI without the
-  skill loaded get the same progressive-disclosure links from `--help`. URLs
-  must be fully qualified and end with `/index.md` — see
-  [§ Documentation links](#documentation-links).
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | `string` | yes | CLI binary name |
+| `version` | `string` | no | Shown by `--version` |
+| `description` | `string` | no | One-line description after name in help |
+| `usage` | `string` | no | Custom usage line; overrides auto-generated one |
+| `commands` | `Command[]` | no | Subcommands |
+| `globalOptions` | `Options` | no | Options accepted by every command |
+| `examples` | `string[]` | no | Global-help examples |
+| `documentation` | `DocEntry[]` | no | Links rendered in `Documentation:` section |
 
-**Legacy schema rejected:** Passing a top-level `options` field (instead of
-`globalOptions`) throws at startup with a migration message. See
-[spec 430](../../../../specs/430-per-command-help/spec.md) for background.
+### Command fields
 
-**Option name collisions:** If a command option shares a name with a global
-option, the constructor throws. Command options are merged with global options
-for parsing — a collision would silently shadow the global option.
+| Field | Type | Notes |
+|---|---|---|
+| `name` | `string` | May be multi-word (`"org show"`) |
+| `args` | `string \| string[]` | `string`: legacy free-form usage. `string[]`: named positionals for dispatch |
+| `argsUsage` | `string` | Display string for help when `args` is an array |
+| `description` | `string` | One-line description |
+| `options` | `Options` | Command-scoped options |
+| `examples` | `string[]` | Per-command examples |
+| `handler` | `(ctx) => any` | Dispatch handler; required only when using `dispatch()` |
 
-### Global help (`--help`)
+### Option fields
 
-Global help lists all commands and global options. Per-command options do not
-appear — global help is a scannable index, not a dump of every flag.
+Each key in an `Options` object maps to:
 
-```
-fit-summit 1.0.0 — Team capability planning from skill data.
+| Field | Type | Notes |
+|---|---|---|
+| `type` | `"string" \| "boolean"` | Passed to `parseArgs` |
+| `short` | `string` | Single-char alias (`-h`) |
+| `default` | `any` | Default value |
+| `multiple` | `boolean` | Accept repeated flags into an array |
+| `description` | `string` | Help text |
 
-Usage: fit-summit <command> [options]
+**Legacy schema rejected.** A top-level `options` field (instead of
+`globalOptions`) throws at construction with a migration message.
 
-Commands:
-  coverage <team>            Show capability coverage
-  validate                   Validate roster file
+**Option name collisions.** A command option sharing a name with a global option
+throws at construction. Command options merge with global options for the
+`parseArgs` call — a collision would silently shadow the global.
 
-Options:
-  --data=<string>            Path to Map data directory
-  --roster=<string>          Path to summit.yaml
-  --format=<string>          Output format: text, json, markdown (default: text)
-  --help, -h                 Show help
-  --version, -v              Show version
+---
 
-Examples:
-  fit-summit coverage platform
-  fit-summit what-if platform --add 'Jane, senior, backend'
+## Argument Parsing
 
-Documentation:
-  Team Capability Guide
-    https://www.forwardimpact.team/docs/products/team-capability/index.md
-    Coverage heatmaps, structural risks, and what-if scenarios.
-  Summit Overview
-    https://www.forwardimpact.team/summit/index.md
+`cli.parse(argv)` is the entry point. It returns `{ values, positionals }` or
+`null` (when `--help` or `--version` was handled).
 
-Use fit-summit <command> --help for command-specific options.
-```
+### How parse works internally
 
-The Documentation section appears between Examples and the hint line, and is
-omitted entirely when `documentation` is unset. The hint line at the bottom is
-the only indication that per-command help exists.
+1. **Command identification.** `#findCommand(argv)` filters out flags, then
+   tries the longest positional prefix (up to 3 tokens) against
+   `commands[].name`. This handles multi-word commands like `"org show"` —
+   `parse(["org", "show", "--help"])` matches the two-word entry.
 
-### Per-command help (`<command> --help`)
+2. **Option merging.** `#buildOptions(command)` merges the matched command's
+   `options` with `globalOptions`. The merged set is passed to `parseArgs` — a
+   flag not in the merged set throws `ERR_PARSE_ARGS_UNKNOWN_OPTION`.
 
-Per-command help shows the command's own options under `Options:` and global
-options (minus `--version`) under `Global options:`. Each section aligns columns
-independently.
+3. **parseArgs.** `node:util` `parseArgs` runs with `allowPositionals: true`.
+   The result is `{ values, positionals }`.
 
-```
-fit-summit coverage <team> — Show capability coverage
+4. **Help/version interception.** If `values.help` is truthy, `#renderHelp`
+   fires and `parse()` returns `null`. Same for `values.version`. The caller
+   should exit cleanly on `null`.
 
-Usage: fit-summit coverage <team> [options]
+5. **Command-as-option hint.** If `parseArgs` throws on an unknown flag whose
+   name matches a command, the error message suggests the command form:
+   `Unknown option "--daemon". "daemon" is a command, not an option.`
 
-Options:
-  --evidenced                Include practiced capability from Map evidence data
-  --lookback-months=<string>   Lookback window for practice patterns (default: 12)
-
-Global options:
-  --data=<string>            Path to Map data directory
-  --roster=<string>          Path to summit.yaml
-  --format=<string>          Output format: text, json, markdown (default: text)
-  --help, -h                 Show help
-
-Examples:
-  fit-summit coverage platform
-  fit-summit coverage platform --evidenced --lookback-months=6
+```js
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+const { values, positionals } = parsed;
 ```
 
-Commands with no `options` omit the `Options:` section and show only
-`Global options:`.
+Positional validation is the caller's responsibility — libcli does not enforce
+required positionals because usage patterns vary.
 
-### Grep-friendliness
+---
 
-Every command and every option occupies exactly one self-contained line. A grep
-for any keyword returns a complete, actionable line — no wrapping to a second
-line.
+## Handler Dispatch
 
-```sh
-# Global help — find the command
-$ fit-summit -h | grep coverage
-  coverage <team>            Show capability coverage
+The dispatch layer is opt-in. A subcommand opts in by declaring `args` as
+`string[]` (named positional names) and providing a `handler` function. The
+legacy `args: "<usage>"` string form continues to work for commands that don't
+need dispatch.
 
-# Per-command help — find the flag
-$ fit-summit coverage -h | grep evidenced
-  --evidenced                Include practiced capability from Map evidence data
+### How dispatch works internally
 
-# Command-specific options don't leak into global help
-$ fit-summit -h | grep add
-# (no output — --add is what-if-specific)
+`Cli.dispatch(parsed, { data })` does the following:
+
+1. **Find command.** Calls `#findCommand(parsed.positionals)` — same logic as
+   `parse()`. Throws if no match.
+
+2. **Validate handler.** Throws if the matched command has no `handler` function.
+
+3. **Consume subcommand prefix.** `command.name.split(" ").length` gives the
+   number of positional tokens the command name consumed (1 for `"skill"`, 2 for
+   `"org show"`). The remaining positionals are the actual arguments.
+
+4. **Build named args.** Zips the command's `args` array against the remaining
+   positionals: `args[0]` maps to the first remaining positional, `args[1]` to
+   the second, etc. Missing trailing positionals are omitted (not set to
+   `undefined`).
+
+5. **Freeze.** Calls `freezeInvocationContext({ data, args, options: parsed.values })`.
+   This deep-freezes the context, `args`, `options`, and any array values inside
+   `options`.
+
+6. **Call handler.** `command.handler(ctx)`.
+
+```js
+// argv: ["skill", "testing", "--json"]
+// command.args: ["id"]
+// → consumed prefix: 1 ("skill")
+// → remaining: ["testing"]
+// → args: { id: "testing" }
+// → options: { json: true } (from parsed.values)
 ```
 
-### Human and machine modes
+Source: `libraries/libcli/src/cli.js`, `dispatch()` method.
 
-- `--help` renders human-readable formatted text to stdout
-- `--help --json` emits structured JSON
+---
 
-Global `--help --json` emits the full definition object — including the
-`documentation` array verbatim, so agents that consume help via JSON get the
-links as structured data rather than parsing them out of the rendered text.
-Per-command `--help --json` emits a focused object with `parent`, `name`,
-`args`, `description`, `options`, `globalOptions` (without `--version`), and
-`examples`.
+## InvocationContext
 
-Both modes are handled automatically by `cli.parse()`.
+`InvocationContext` is a frozen `{ data, args, options }` object produced by
+both libcli's `dispatch()` (from argv) and libui's `createBoundRouter` (from a
+URL hash). The handler receives the same shape regardless of surface.
 
-### Documentation links
-
-The `documentation` field is the bridge between a CLI and its skill. Each fit-\*
-skill ends with a `## Documentation` section listing fully qualified `.md` URLs
-published by the fit-doc static site generator; the same entries belong on the
-CLI definition so an agent that reaches the CLI without the skill — no skill
-installed, the skill omitted to save context, or a direct invocation in CI —
-gets the same progressive-disclosure links.
-
-Each entry is a plain object:
+### Shape
 
 ```js
 {
-  title: "Team Capability Guide",
-  url: "https://www.forwardimpact.team/docs/products/team-capability/index.md",
-  description: "Coverage heatmaps, structural risks, and what-if scenarios.",
+  data,     // Object — host-provided dependencies, opaque to the libraries
+  args,     // Readonly<Object<string, string>> — named positionals
+  options,  // Readonly<Object<string, string | boolean | string[]>> — flags/query params
 }
 ```
 
-The `description` is optional; entries without one render as title + URL only.
-URLs should end with `/index.md` so agents fetching them receive raw markdown
-rather than rendered HTML — fit-doc emits an `index.md` companion for every HTML
-page and advertises it via `<link rel="alternate" type="text/markdown">`.
+### Three invariants
 
-When wiring a CLI, copy the entries directly from the matching
-`.claude/skills/fit-*/SKILL.md` so both surfaces stay in sync.
+- **No surface affordances.** No DOM nodes, streams, `Request`/`Response`, or
+  surface tag. Anything that exists on only one surface stays out.
+- **Uniform value shapes.** `args` values are always strings. `options` values
+  are one of `string`, `boolean true`, or `string[]`. No nulls, no numbers.
+- **Frozen at all levels.** `Object.freeze` on the context, `args`, `options`,
+  and any array inside `options`. Handlers may assume immutability without
+  checking.
 
-[librepl](#composition-with-other-libraries) accepts the same `documentation`
-field with the same shape, so REPL-based CLIs (fit-guide) expose the section
-under `--help` alongside their interactive command list.
+### freezeInvocationContext
+
+The helper is duplicated in both libraries (design decision D1 — a shared
+package was rejected for ~40 lines). Each library's test suite runs the same
+fixture through its own copy; the identical fixture serves as a drift gate.
+
+The freeze is shallow on `data` (host-owned, may be mutated by the host between
+invocations) and deep on `args` and `options` (contract-owned, must not be
+mutated by handlers). Arrays inside `options` are individually frozen.
+
+Source: `libraries/libui/src/invocation-context.js`,
+`libraries/libcli/src/invocation-context.js`.
+
+### How each surface produces it
+
+| Surface | Producer | args source | options source |
+|---|---|---|---|
+| CLI | `Cli.dispatch()` | positionals zipped against `command.args` names | `parsed.values` from `parseArgs` |
+| Web | `createBoundRouter` | route-pattern capture groups keyed by param names | `URLSearchParams` from the hash query string |
+
+The web side parses query strings as: repeated keys become `string[]`, empty
+values become `true`, everything else is `string`. This matches the shape
+`parseArgs` produces from CLI flags.
+
+---
+
+## Help Rendering
+
+`HelpRenderer` formats the definition into text or JSON. libcli owns the
+renderer; the `Cli` class delegates to it.
+
+### args display logic
+
+When `args` is a string, it renders directly (`<team>`). When `args` is an
+array (the dispatch form), the renderer reads `argsUsage` instead. If
+`argsUsage` is absent, the command renders with no args suffix. This applies to
+both the commands list in global help and the header in per-command help.
+
+Source: `libraries/libcli/src/help.js`, `#argsDisplay()`.
+
+### Global help sections (in order)
+
+1. Header — name, version, description
+2. Usage — auto-generated or custom `usage` string
+3. Commands — one line per command, aligned
+4. Options — global options, aligned
+5. Examples — top-level examples
+6. Documentation — title, URL, optional description
+7. Hint line — "Use \<name\> \<command\> --help for command-specific options."
+
+Sections with no data are omitted entirely.
+
+### Per-command help sections (in order)
+
+1. Header — name + command + args + description
+2. Usage — name + command + args + `[options]`
+3. Options — command-scoped options
+4. Global options — global options minus `--version`
+5. Examples — per-command examples
+
+### JSON mode
+
+`--help --json` emits the full definition as JSON (global) or a focused
+`{ parent, name, args, description, options, globalOptions, examples,
+documentation }` object (per-command). Both handled by `cli.parse()`.
+
+### Documentation links
+
+The `documentation` array bridges the CLI and its matching skill. Each entry is
+`{ title, url, description? }` with a fully qualified `.md` URL. This way an
+agent that reaches the CLI without the skill loaded gets the same
+progressive-disclosure links from `--help`.
+
+URLs end with `/index.md` so agents receive raw markdown. Copy entries from the
+matching `.claude/skills/fit-*/SKILL.md` to keep both in sync.
 
 ---
 
@@ -280,7 +324,7 @@ under `--help` alongside their interactive command list.
 
 ### Standard format
 
-All errors write to stderr in a consistent format with no ANSI color codes:
+All errors write to stderr with no ANSI codes:
 
 ```
 cli-name: error: message
@@ -288,23 +332,12 @@ cli-name: error: message
 
 ### Exit codes
 
-| Code | Meaning       | Method             |
-| ---- | ------------- | ------------------ |
-| 1    | Runtime error | `cli.error()`      |
-| 2    | Usage error   | `cli.usageError()` |
+| Code | Meaning | Method |
+|---|---|---|
+| 1 | Runtime error | `cli.error()` |
+| 2 | Usage error | `cli.usageError()` |
 
-`cli.error(message)` writes the formatted error and sets `process.exitCode = 1`.
-Use it for runtime failures — file not found, network errors, invalid data.
-
-`cli.usageError(message)` writes the same format but sets
-`process.exitCode = 2`. Use it for bad arguments — missing positionals, unknown
-flags, invalid combinations.
-
-### Exception logging
-
-In `catch` blocks, use `logger.exception()` for operational errors before
-calling `cli.error()`. This preserves the stack trace in structured logs while
-showing a clean message on stderr:
+### Exception pattern
 
 ```js
 main().catch((error) => {
@@ -319,275 +352,137 @@ main().catch((error) => {
 ## Summary Output
 
 `SummaryRenderer` prints a post-command summary — a title line followed by
-aligned label/description pairs.
+aligned label/description pairs:
 
 ```js
-import { SummaryRenderer } from "@forwardimpact/libcli";
-
 const summary = new SummaryRenderer({ process });
-
 summary.render({
   title: "Generated 3 files",
   items: [
-    { label: "types.js",    description: "Compiled proto types" },
-    { label: "clients.js",  description: "Service client stubs" },
-    { label: "index.js",    description: "Re-export barrel" },
+    { label: "types.js",   description: "Compiled proto types" },
+    { label: "clients.js", description: "Service client stubs" },
   ],
 });
 ```
 
-Output:
-
-```
-Generated 3 files
-  types.js    — Compiled proto types
-  clients.js  — Service client stubs
-  index.js    — Re-export barrel
-```
-
-The data structure is `{ title: string, items: Array<{ label, description }> }`.
-The fit-codegen CLI is the reference pattern for summary usage.
-
 ---
 
-## Argument Parsing
+## Logger Conventions
 
-`cli.parse(argv)` wraps `node:util` `parseArgs` with `allowPositionals: true`.
-It returns `{ values, positionals }` on success, or `null` if `--help` or
-`--version` was handled (the caller should exit cleanly).
+CLI programs use libtelemetry's Logger for operational output and reserve
+`console.log` / direct stdout writes for primary data output.
 
-### Command identification
-
-When the definition has `commands`, `parse()` identifies the command by scanning
-non-flag tokens and trying the longest match against `commands[].name`. This
-handles multi-word commands like `org show` in fit-landmark —
-`parse(["org", "show", "--help"])` correctly matches the `org show` entry.
-
-### Option merging and scoping
-
-Once a command is identified, its `options` are merged with `globalOptions` for
-the `parseArgs()` call. Only the merged set is accepted — passing a
-command-specific option on the wrong command throws
-`ERR_PARSE_ARGS_UNKNOWN_OPTION`.
-
-This is a tightening over the pre-spec-430 behavior: previously every option was
-accepted on every command (the handler simply ignored irrelevant flags). Now
-input validation is stricter while command behavior is unchanged.
+| Output type | Use Logger? | Why |
+|---|---|---|
+| Progress updates | Yes | Structured attributes beat free text |
+| Errors and exceptions | Yes | Preserves trace context |
+| Help text | No | Rendered by libcli |
+| Pure data output | No | Primary result for piping |
 
 ```js
-const parsed = cli.parse(process.argv.slice(2));
-if (!parsed) process.exit(0);
+import { createLogger } from "@forwardimpact/libtelemetry";
+const logger = createLogger("codegen");
 
-const { values, positionals } = parsed;
+logger.info("step", "Generated types", { files: "12" });
+logger.error("compile", "Proto compilation failed", { path: "agent.proto" });
 ```
 
-Positional validation is the caller's responsibility — libcli does not enforce
-required positionals because usage patterns vary across CLIs:
+**Domain naming:** package name without `lib` prefix — `"codegen"` for
+libcodegen, `"pathway"` for fit-pathway.
 
-```js
-const [input] = positionals;
-if (!input) {
-  cli.usageError("missing required argument <input>");
-  process.exit(2);
-}
-```
+**Levels:** `debug` (invisible unless `LOG_LEVEL=debug`), `info` (expected
+output), `error` (with context), `exception` (with stack trace, use in `catch`).
 
----
-
-## Handler Dispatch and InvocationContext
-
-Products that share handler logic between a web UI and a CLI can opt into
-`InvocationContext` — a frozen `{ data, args, options }` object that both
-surfaces produce from their native inputs. The handler never knows which
-surface invoked it.
-
-### Subcommand definition
-
-Declare named positionals with `args: string[]` and provide a `handler`.
-The legacy `args: "<usage>"` string form still works for CLIs that don't
-need dispatch.
-
-```js
-const definition = {
-  name: "fit-pathway",
-  commands: [
-    {
-      name: "skill",
-      args: ["id"],
-      argsUsage: "[<id>]",
-      description: "Show skill detail",
-      handler: (ctx) => runSkillCommand(ctx),
-    },
-  ],
-  globalOptions: {
-    data: { type: "string", description: "Path to data directory" },
-    json: { type: "boolean", description: "JSON output" },
-    help: { type: "boolean", short: "h", description: "Show help" },
-  },
-};
-```
-
-### Dispatching
-
-After `parse()`, call `dispatch()` with the host's data dependencies:
-
-```js
-const parsed = cli.parse(process.argv.slice(2));
-if (!parsed) process.exit(0);
-
-cli.dispatch(parsed, { data: { skills, disciplines } });
-```
-
-`dispatch()` maps argv positionals to the declared `args` names, merges
-parsed flags into `options`, deep-freezes everything via
-`freezeInvocationContext`, and calls the handler. The handler receives:
-
-```js
-function runSkillCommand(ctx) {
-  // ctx.data    — host-provided dependencies (skills, disciplines, …)
-  // ctx.args    — { id: "testing" } (named, not positional)
-  // ctx.options — { json: true } (parsed flags)
-}
-```
-
-### The InvocationContext contract
-
-Three invariants:
-
-- **No surface affordances.** No DOM nodes, streams, or surface tags. Anything
-  that exists on only one surface stays out.
-- **Uniform value shapes.** `args` values are strings; `options` values are one
-  of `string`, `boolean true`, or `string[]`. No nulls, no numbers.
-- **Frozen at all levels.** The context, `args`, `options`, and any array inside
-  `options` are `Object.freeze`'d by the producer.
-
-### Shared presenters
-
-The handler calls a shared presenter that returns a view, then renders it
-through surface-specific formatters. One presenter per capability, exercised
-by both surfaces against synthetic contexts in tests:
-
-```js
-// shared presenter — no DOM, no stdout
-function presentSkill(ctx) {
-  const skill = ctx.data.skills.find((s) => s.id === ctx.args.id);
-  return { name: skill.name, proficiencies: skill.proficiencies };
-}
-
-// CLI handler
-function runSkillCommand(ctx) {
-  const view = presentSkill(ctx);
-  formatDetailToStdout(view, ctx.options);
-}
-
-// Web page (via libui's defineRoute)
-function renderSkillPage(ctx) {
-  const view = presentSkill(ctx);
-  renderDetailToDOM(view, ctx.options);
-}
-```
-
-### Web-side pairing with libui
-
-Products with web UIs use libui's `createBoundRouter` and `defineRoute` to
-produce the same `InvocationContext` from URL hash routes. The route
-descriptor binds the URL pattern, page handler, CLI command string, and graph
-IRI in one place:
-
-```js
-import { createBoundRouter, defineRoute } from "@forwardimpact/libui";
-
-const router = createBoundRouter({ data, vocabularyBase });
-router.register(defineRoute({
-  pattern: "/skill/:id",
-  page: (ctx) => renderSkillPage(ctx),
-  cli: (ctx) => `npx fit-pathway skill ${ctx.args.id}`,
-  graph: (ctx, base) => `${base}Skill/${ctx.args.id}`,
-}));
-```
-
-See `@forwardimpact/libui` for the full bound-router API.
+**Suppression:** `--silent` raises the minimum level above `error`, `--quiet`
+raises it above `info`.
 
 ---
 
 ## Composition with Other Libraries
 
-libcli covers CLI chrome. Other libraries handle content and sessions:
-
-| Library          | Scope                                                                                         |
-| ---------------- | --------------------------------------------------------------------------------------------- |
-| **libcli**       | CLI chrome: help, errors, summaries, argument parsing, color                                  |
-| **libformat**    | Content rendering: markdown to HTML or ANSI terminal output                                   |
-| **librepl**      | Interactive sessions: command loops, state, history, `documentation` pass-through in `--help` |
-| **libtelemetry** | Operational diagnostics: Logger, Tracer, Observer                                             |
-
-A CLI that renders markdown (fit-guide) uses **libformat** for content and
-**libcli** for chrome. A REPL-based CLI uses **libcli** for initial argument
-parsing and **librepl** for the interactive session.
+| Library | Scope |
+|---|---|
+| **libcli** | CLI chrome: help, errors, summaries, argument parsing, color |
+| **libui** | Web UI: routing, `createBoundRouter`, `defineRoute`, `createCommandBar` |
+| **libformat** | Content rendering: markdown to HTML or ANSI terminal output |
+| **librepl** | Interactive sessions: command loops, state, history |
+| **libtelemetry** | Operational diagnostics: Logger, Tracer, Observer |
 
 ---
 
-## Minimal CLI Example
+## Legacy Handler Shape Enforcement
 
-A complete, runnable CLI showing the standard pattern from shebang to exit code:
+An AST-based test (`tests/no-legacy-handler-shape.test.js`) scans
+`libraries/libui/src/` and `libraries/libcli/src/` for functions whose first
+parameter is either a destructured `{ data, args, options }` or an identifier
+named `params`. These are the pre-InvocationContext handler shapes. The test
+runs during `bun run test` and gates every commit.
+
+The `invocation-context.js` files in both libraries are allowlisted since
+`freezeInvocationContext` itself destructures `{ data, args, options }` by
+design.
+
+---
+
+## Minimal Examples
+
+### Legacy parse path
 
 ```js
 #!/usr/bin/env node
-
 import { createCli } from "@forwardimpact/libcli";
-import { createLogger } from "@forwardimpact/libtelemetry";
 
-const definition = {
+const cli = createCli({
   name: "fit-example",
   version: "0.1.0",
-  description: "Example CLI showing standard pattern",
+  description: "Example CLI",
   usage: "fit-example <input>",
   globalOptions: {
-    output:  { type: "string", description: "Output path" },
-    json:    { type: "boolean", description: "Output as JSON" },
-    help:    { type: "boolean", short: "h", description: "Show this help" },
+    json: { type: "boolean", description: "JSON output" },
+    help: { type: "boolean", short: "h", description: "Show help" },
     version: { type: "boolean", description: "Show version" },
   },
-  examples: [
-    "fit-example data.yaml",
-    "fit-example data.yaml --json",
-  ],
-  documentation: [
-    {
-      title: "Example Guide",
-      url: "https://www.forwardimpact.team/docs/libraries/example/index.md",
-      description: "Task-oriented walkthrough for fit-example.",
-    },
-  ],
-};
-
-const logger = createLogger("example");
-const cli = createCli(definition);
-
-async function main() {
-  const parsed = cli.parse(process.argv.slice(2));
-  if (!parsed) process.exit(0);
-
-  const { values, positionals } = parsed;
-  const [input] = positionals;
-
-  if (!input) {
-    cli.usageError("missing required argument <input>");
-    process.exit(2);
-  }
-
-  // ... do work, using logger for operational output
-  logger.info("main", "Processing complete", { file: input });
-}
-
-main().catch((error) => {
-  logger.exception("main", error);
-  cli.error(error.message);
-  process.exit(1);
 });
+
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+const [input] = parsed.positionals;
+if (!input) { cli.usageError("missing <input>"); process.exit(2); }
 ```
 
-This demonstrates: shebang line, imports, definition as data, Logger creation,
-`cli.parse()` with null check, positional validation with usage error,
-documentation links mirroring the matching SKILL.md, and the top-level catch
-pattern with exception logging.
+### Dispatch path
+
+```js
+#!/usr/bin/env node
+import { createCli } from "@forwardimpact/libcli";
+
+const cli = createCli({
+  name: "fit-example",
+  version: "0.1.0",
+  description: "Example CLI with dispatch",
+  commands: [
+    {
+      name: "show",
+      args: ["id"],
+      argsUsage: "<id>",
+      description: "Show an item",
+      handler: (ctx) => {
+        const item = ctx.data.items.find((i) => i.id === ctx.args.id);
+        console.log(ctx.options.json ? JSON.stringify(item) : item.name);
+      },
+    },
+  ],
+  globalOptions: {
+    json: { type: "boolean", description: "JSON output" },
+    help: { type: "boolean", short: "h", description: "Show help" },
+    version: { type: "boolean", description: "Show version" },
+  },
+});
+
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+const data = { items: [{ id: "a", name: "Alpha" }] };
+cli.dispatch(parsed, { data });
+```

--- a/websites/fit/docs/internals/libcli/index.md
+++ b/websites/fit/docs/internals/libcli/index.md
@@ -394,6 +394,122 @@ if (!input) {
 
 ---
 
+## Handler Dispatch and InvocationContext
+
+Products that share handler logic between a web UI and a CLI can opt into
+`InvocationContext` — a frozen `{ data, args, options }` object that both
+surfaces produce from their native inputs. The handler never knows which
+surface invoked it.
+
+### Subcommand definition
+
+Declare named positionals with `args: string[]` and provide a `handler`.
+The legacy `args: "<usage>"` string form still works for CLIs that don't
+need dispatch.
+
+```js
+const definition = {
+  name: "fit-pathway",
+  commands: [
+    {
+      name: "skill",
+      args: ["id"],
+      argsUsage: "[<id>]",
+      description: "Show skill detail",
+      handler: (ctx) => runSkillCommand(ctx),
+    },
+  ],
+  globalOptions: {
+    data: { type: "string", description: "Path to data directory" },
+    json: { type: "boolean", description: "JSON output" },
+    help: { type: "boolean", short: "h", description: "Show help" },
+  },
+};
+```
+
+### Dispatching
+
+After `parse()`, call `dispatch()` with the host's data dependencies:
+
+```js
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+cli.dispatch(parsed, { data: { skills, disciplines } });
+```
+
+`dispatch()` maps argv positionals to the declared `args` names, merges
+parsed flags into `options`, deep-freezes everything via
+`freezeInvocationContext`, and calls the handler. The handler receives:
+
+```js
+function runSkillCommand(ctx) {
+  // ctx.data    — host-provided dependencies (skills, disciplines, …)
+  // ctx.args    — { id: "testing" } (named, not positional)
+  // ctx.options — { json: true } (parsed flags)
+}
+```
+
+### The InvocationContext contract
+
+Three invariants:
+
+- **No surface affordances.** No DOM nodes, streams, or surface tags. Anything
+  that exists on only one surface stays out.
+- **Uniform value shapes.** `args` values are strings; `options` values are one
+  of `string`, `boolean true`, or `string[]`. No nulls, no numbers.
+- **Frozen at all levels.** The context, `args`, `options`, and any array inside
+  `options` are `Object.freeze`'d by the producer.
+
+### Shared presenters
+
+The handler calls a shared presenter that returns a view, then renders it
+through surface-specific formatters. One presenter per capability, exercised
+by both surfaces against synthetic contexts in tests:
+
+```js
+// shared presenter — no DOM, no stdout
+function presentSkill(ctx) {
+  const skill = ctx.data.skills.find((s) => s.id === ctx.args.id);
+  return { name: skill.name, proficiencies: skill.proficiencies };
+}
+
+// CLI handler
+function runSkillCommand(ctx) {
+  const view = presentSkill(ctx);
+  formatDetailToStdout(view, ctx.options);
+}
+
+// Web page (via libui's defineRoute)
+function renderSkillPage(ctx) {
+  const view = presentSkill(ctx);
+  renderDetailToDOM(view, ctx.options);
+}
+```
+
+### Web-side pairing with libui
+
+Products with web UIs use libui's `createBoundRouter` and `defineRoute` to
+produce the same `InvocationContext` from URL hash routes. The route
+descriptor binds the URL pattern, page handler, CLI command string, and graph
+IRI in one place:
+
+```js
+import { createBoundRouter, defineRoute } from "@forwardimpact/libui";
+
+const router = createBoundRouter({ data, vocabularyBase });
+router.register(defineRoute({
+  pattern: "/skill/:id",
+  page: (ctx) => renderSkillPage(ctx),
+  cli: (ctx) => `npx fit-pathway skill ${ctx.args.id}`,
+  graph: (ctx, base) => `${base}Skill/${ctx.args.id}`,
+}));
+```
+
+See `@forwardimpact/libui` for the full bound-router API.
+
+---
+
 ## Composition with Other Libraries
 
 libcli covers CLI chrome. Other libraries handle content and sessions:

--- a/websites/fit/docs/libraries/agent-surfaces/index.md
+++ b/websites/fit/docs/libraries/agent-surfaces/index.md
@@ -31,9 +31,9 @@ Both surfaces produce the same object:
 
 ```js
 {
-  data,     // Object — your app's data (skills, items, etc.)
-  args,     // { id: "testing" } — named positional arguments
-  options,  // { json: true } — flags or query parameters
+  data,     // Object — your app's data (cities, forecasts, etc.)
+  args,     // { city: "london" } — named positional arguments
+  options,  // { units: "metric" } — flags or query parameters
 }
 ```
 
@@ -50,14 +50,17 @@ The presenter takes an `InvocationContext`, looks up data, and returns a plain
 view object. No DOM, no stdout — just data in, data out.
 
 ```js
-// src/present-skill.js
-export function presentSkill(ctx) {
-  const skill = ctx.data.skills.find((s) => s.id === ctx.args.id);
-  if (!skill) throw new Error(`Unknown skill: ${ctx.args.id}`);
+// src/present-forecast.js
+export function presentForecast(ctx) {
+  const city = ctx.data.cities.find((c) => c.id === ctx.args.city);
+  if (!city) throw new Error(`Unknown city: ${ctx.args.city}`);
+  const forecast = city.forecast;
   return {
-    name: skill.name,
-    level: skill.level,
-    description: skill.description,
+    city: city.name,
+    temp: forecast.temp,
+    units: ctx.options.units || "metric",
+    condition: forecast.condition,
+    wind: forecast.wind,
   };
 }
 ```
@@ -66,14 +69,23 @@ This function is testable with a synthetic context — no browser, no process:
 
 ```js
 import { freezeInvocationContext } from "@forwardimpact/libcli";
+import { presentForecast } from "../src/present-forecast.js";
 
 const ctx = freezeInvocationContext({
-  data: { skills: [{ id: "testing", name: "Testing", level: "advanced", description: "..." }] },
-  args: { id: "testing" },
-  options: {},
+  data: {
+    cities: [{
+      id: "london",
+      name: "London",
+      forecast: { temp: 14, condition: "Cloudy", wind: "12 km/h" },
+    }],
+  },
+  args: { city: "london" },
+  options: { units: "metric" },
 });
-const view = presentSkill(ctx);
-assert.strictEqual(view.name, "Testing");
+
+const view = presentForecast(ctx);
+assert.strictEqual(view.city, "London");
+assert.strictEqual(view.temp, 14);
 ```
 
 ## Step 2: Build the CLI surface
@@ -83,33 +95,33 @@ The CLI definition declares named positionals with `args: string[]` and a
 
 ```js
 #!/usr/bin/env node
-// bin/fit-myapp.js
+// bin/weather.js
 import { createCli } from "@forwardimpact/libcli";
-import { presentSkill } from "../src/present-skill.js";
-import { loadData } from "../src/data.js";
+import { presentForecast } from "../src/present-forecast.js";
+import { loadCities } from "../src/data.js";
 
 const cli = createCli({
-  name: "fit-myapp",
+  name: "weather",
   version: "0.1.0",
-  description: "My app",
+  description: "Weather forecasts from the terminal",
   commands: [
     {
-      name: "skill",
-      args: ["id"],
-      argsUsage: "<id>",
-      description: "Show a skill",
+      name: "forecast",
+      args: ["city"],
+      argsUsage: "<city>",
+      description: "Show forecast for a city",
       handler: (ctx) => {
-        const view = presentSkill(ctx);
+        const view = presentForecast(ctx);
         if (ctx.options.json) {
           console.log(JSON.stringify(view, null, 2));
         } else {
-          console.log(`${view.name} (${view.level})\n${view.description}`);
+          console.log(`${view.city}: ${view.temp}° ${view.condition}, wind ${view.wind}`);
         }
       },
     },
   ],
   globalOptions: {
-    data: { type: "string", description: "Path to data directory" },
+    units: { type: "string", description: "Temperature units (metric|imperial)" },
     json: { type: "boolean", description: "JSON output" },
     help: { type: "boolean", short: "h", description: "Show help" },
     version: { type: "boolean", description: "Show version" },
@@ -119,14 +131,20 @@ const cli = createCli({
 const parsed = cli.parse(process.argv.slice(2));
 if (!parsed) process.exit(0);
 
-const data = loadData(parsed.values.data);
+const data = { cities: loadCities() };
 cli.dispatch(parsed, { data });
 ```
 
-Running `npx fit-myapp skill testing --json` produces:
+Running `weather forecast london` produces:
 
 ```
-{ "name": "Testing", "level": "advanced", "description": "..." }
+London: 14° Cloudy, wind 12 km/h
+```
+
+Running `weather forecast london --json` produces:
+
+```json
+{ "city": "London", "temp": 14, "units": "metric", "condition": "Cloudy", "wind": "12 km/h" }
 ```
 
 ## Step 3: Build the web surface
@@ -141,23 +159,23 @@ import {
   defineRoute,
   createCommandBar,
 } from "@forwardimpact/libui";
-import { presentSkill } from "./present-skill.js";
-import { renderSkillToDOM } from "./render-skill.js";
+import { presentForecast } from "./present-forecast.js";
+import { renderForecastCard } from "./render-forecast.js";
 
-const data = await fetch("/data.json").then((r) => r.json());
+const data = await fetch("/api/cities.json").then((r) => r.json());
 
 const router = createBoundRouter({
   data,
-  onNotFound: () => document.body.textContent = "Not found",
+  onNotFound: () => document.body.textContent = "City not found",
 });
 
 router.register(defineRoute({
-  pattern: "/skill/:id",
+  pattern: "/forecast/:city",
   page: (ctx) => {
-    const view = presentSkill(ctx);
-    renderSkillToDOM(view, ctx.options);
+    const view = presentForecast(ctx);
+    renderForecastCard(view);
   },
-  cli: (ctx) => `npx fit-myapp skill ${ctx.args.id}`,
+  cli: (ctx) => `weather forecast ${ctx.args.city}`,
 }));
 
 createCommandBar(router, {
@@ -167,16 +185,18 @@ createCommandBar(router, {
 router.start();
 ```
 
-When the user navigates to `#/skill/testing`, the bound router:
+When the user navigates to `#/forecast/london`, the bound router:
 
-1. Matches the pattern, extracts `{ id: "testing" }` as `args`
+1. Matches the pattern, extracts `{ city: "london" }` as `args`
 2. Parses the query string (if any) into `options`
 3. Freezes everything into an `InvocationContext`
 4. Calls `page(ctx, { vocabularyBase })`
 
+The command bar displays `weather forecast london` with a copy button. An agent
+or user can paste that command into a terminal to get the same result.
+
 The `cli` function on the descriptor is optional. When present, the command bar
-displays the equivalent CLI command and offers copy-to-clipboard. Routes without
-`cli` render the bar empty.
+displays the equivalent CLI command. Routes without `cli` render the bar empty.
 
 ## How `createBoundRouter` works
 
@@ -196,13 +216,13 @@ The bound router wraps libui's hash-based routing with three additions:
 ```js
 const router = createBoundRouter({ data, onNotFound, onError, renderError });
 
-router.register(descriptor);   // mount a route descriptor
-router.routes();                // list registered descriptors
-router.start();                 // listen for hashchange + replaceState
-router.stop();                  // remove listeners, restore replaceState
-router.navigate("/skill/x");   // set window.location.hash
-router.currentPath();           // read current hash path
-router.activeRoute;             // reactive: { descriptor, ctx } | null
+router.register(descriptor);      // mount a route descriptor
+router.routes();                   // list registered descriptors
+router.start();                    // listen for hashchange + replaceState
+router.stop();                     // remove listeners, restore replaceState
+router.navigate("/forecast/nyc");  // set window.location.hash
+router.currentPath();              // read current hash path
+router.activeRoute;                // reactive: { descriptor, ctx } | null
 ```
 
 ### Query string parsing
@@ -212,8 +232,8 @@ The query string after `?` in the hash is parsed with `URLSearchParams`:
 | Input | Result |
 |---|---|
 | `?json` | `{ json: true }` |
-| `?json=1` | `{ json: "1" }` |
-| `?tag=a&tag=b` | `{ tag: ["a", "b"] }` |
+| `?units=imperial` | `{ units: "imperial" }` |
+| `?tag=rain&tag=wind` | `{ tag: ["rain", "wind"] }` |
 | (no query) | `{}` |
 
 Empty values become `true`; repeated keys become arrays; everything else is a
@@ -236,16 +256,23 @@ object and returns plain data, tests need no DOM and no process:
 
 ```js
 import { freezeInvocationContext } from "@forwardimpact/libcli";
-import { presentSkill } from "../src/present-skill.js";
+import { presentForecast } from "../src/present-forecast.js";
 
 const ctx = freezeInvocationContext({
-  data: { skills: [{ id: "testing", name: "Testing", level: "advanced" }] },
-  args: { id: "testing" },
-  options: { json: true },
+  data: {
+    cities: [{
+      id: "london",
+      name: "London",
+      forecast: { temp: 14, condition: "Cloudy", wind: "12 km/h" },
+    }],
+  },
+  args: { city: "london" },
+  options: { units: "metric" },
 });
 
-const view = presentSkill(ctx);
-assert.strictEqual(view.name, "Testing");
+const view = presentForecast(ctx);
+assert.strictEqual(view.city, "London");
+assert.strictEqual(view.condition, "Cloudy");
 ```
 
 Both surfaces call the same function, so a passing presenter test covers the

--- a/websites/fit/docs/libraries/agent-surfaces/index.md
+++ b/websites/fit/docs/libraries/agent-surfaces/index.md
@@ -1,0 +1,250 @@
+---
+title: Web + CLI Surfaces
+description: Build a product with both a web UI and a CLI that share handler logic through a single InvocationContext contract.
+---
+
+# Web + CLI Surfaces
+
+Some products serve the same capability through two surfaces — a web app for
+browsers and a CLI for terminals. Without a shared contract the handler logic
+diverges: the web page reads route params and query strings, the CLI reads
+positionals and flags, and the two slowly drift apart.
+
+`@forwardimpact/libui` and `@forwardimpact/libcli` solve this with
+**InvocationContext** — a frozen `{ data, args, options }` object that both
+surfaces produce from their native inputs. The handler never knows which surface
+called it.
+
+This guide walks through building the simplest possible pairing: one entity, one
+shared presenter, two surfaces.
+
+## Prerequisites
+
+- Node.js 18+
+- `npm install @forwardimpact/libui @forwardimpact/libcli`
+
+## The InvocationContext shape
+
+Both surfaces produce the same object:
+
+```js
+{
+  data,     // Object — your app's data (skills, items, etc.)
+  args,     // { id: "testing" } — named positional arguments
+  options,  // { json: true } — flags or query parameters
+}
+```
+
+The context is frozen. Handlers can rely on immutability without checking.
+
+**Value types are uniform across surfaces.** `args` values are always strings.
+`options` values are `string`, `boolean` (`true` for presence-only flags or
+empty query params), or `string[]` (repeated keys). No nulls, no numbers — if
+you need a number, parse it in the handler.
+
+## Step 1: Write the shared presenter
+
+The presenter takes an `InvocationContext`, looks up data, and returns a plain
+view object. No DOM, no stdout — just data in, data out.
+
+```js
+// src/present-skill.js
+export function presentSkill(ctx) {
+  const skill = ctx.data.skills.find((s) => s.id === ctx.args.id);
+  if (!skill) throw new Error(`Unknown skill: ${ctx.args.id}`);
+  return {
+    name: skill.name,
+    level: skill.level,
+    description: skill.description,
+  };
+}
+```
+
+This function is testable with a synthetic context — no browser, no process:
+
+```js
+import { freezeInvocationContext } from "@forwardimpact/libcli";
+
+const ctx = freezeInvocationContext({
+  data: { skills: [{ id: "testing", name: "Testing", level: "advanced", description: "..." }] },
+  args: { id: "testing" },
+  options: {},
+});
+const view = presentSkill(ctx);
+assert.strictEqual(view.name, "Testing");
+```
+
+## Step 2: Build the CLI surface
+
+The CLI definition declares named positionals with `args: string[]` and a
+`handler` that calls the shared presenter:
+
+```js
+#!/usr/bin/env node
+// bin/fit-myapp.js
+import { createCli } from "@forwardimpact/libcli";
+import { presentSkill } from "../src/present-skill.js";
+import { loadData } from "../src/data.js";
+
+const cli = createCli({
+  name: "fit-myapp",
+  version: "0.1.0",
+  description: "My app",
+  commands: [
+    {
+      name: "skill",
+      args: ["id"],
+      argsUsage: "<id>",
+      description: "Show a skill",
+      handler: (ctx) => {
+        const view = presentSkill(ctx);
+        if (ctx.options.json) {
+          console.log(JSON.stringify(view, null, 2));
+        } else {
+          console.log(`${view.name} (${view.level})\n${view.description}`);
+        }
+      },
+    },
+  ],
+  globalOptions: {
+    data: { type: "string", description: "Path to data directory" },
+    json: { type: "boolean", description: "JSON output" },
+    help: { type: "boolean", short: "h", description: "Show help" },
+    version: { type: "boolean", description: "Show version" },
+  },
+});
+
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+const data = loadData(parsed.values.data);
+cli.dispatch(parsed, { data });
+```
+
+Running `npx fit-myapp skill testing --json` produces:
+
+```
+{ "name": "Testing", "level": "advanced", "description": "..." }
+```
+
+## Step 3: Build the web surface
+
+The web side uses `defineRoute` to declare a route and `createBoundRouter` to
+dispatch it. The route descriptor's `page` function calls the same presenter:
+
+```js
+// src/main.js
+import {
+  createBoundRouter,
+  defineRoute,
+  createCommandBar,
+} from "@forwardimpact/libui";
+import { presentSkill } from "./present-skill.js";
+import { renderSkillToDOM } from "./render-skill.js";
+
+const data = await fetch("/data.json").then((r) => r.json());
+
+const router = createBoundRouter({
+  data,
+  onNotFound: () => document.body.textContent = "Not found",
+});
+
+router.register(defineRoute({
+  pattern: "/skill/:id",
+  page: (ctx) => {
+    const view = presentSkill(ctx);
+    renderSkillToDOM(view, ctx.options);
+  },
+  cli: (ctx) => `npx fit-myapp skill ${ctx.args.id}`,
+}));
+
+createCommandBar(router, {
+  mountInto: document.getElementById("command-bar"),
+});
+
+router.start();
+```
+
+When the user navigates to `#/skill/testing`, the bound router:
+
+1. Matches the pattern, extracts `{ id: "testing" }` as `args`
+2. Parses the query string (if any) into `options`
+3. Freezes everything into an `InvocationContext`
+4. Calls `page(ctx, { vocabularyBase })`
+
+The `cli` function on the descriptor is optional. When present, the command bar
+displays the equivalent CLI command and offers copy-to-clipboard. Routes without
+`cli` render the bar empty.
+
+## How `createBoundRouter` works
+
+The bound router wraps libui's hash-based routing with three additions:
+
+- **InvocationContext production.** Each match builds a frozen context from route
+  params + query string, matching what `cli.dispatch()` builds from argv.
+- **`activeRoute` reactive.** A reactive value carrying
+  `{ descriptor, ctx } | null` that subscribers (like the command bar) observe.
+- **`history.replaceState` interception.** Some pages rewrite the hash without
+  firing `hashchange` (e.g., updating query params in place). The bound router
+  patches `replaceState` in `start()` and restores it in `stop()` so
+  `activeRoute` stays current.
+
+### API
+
+```js
+const router = createBoundRouter({ data, onNotFound, onError, renderError });
+
+router.register(descriptor);   // mount a route descriptor
+router.routes();                // list registered descriptors
+router.start();                 // listen for hashchange + replaceState
+router.stop();                  // remove listeners, restore replaceState
+router.navigate("/skill/x");   // set window.location.hash
+router.currentPath();           // read current hash path
+router.activeRoute;             // reactive: { descriptor, ctx } | null
+```
+
+### Query string parsing
+
+The query string after `?` in the hash is parsed with `URLSearchParams`:
+
+| Input | Result |
+|---|---|
+| `?json` | `{ json: true }` |
+| `?json=1` | `{ json: "1" }` |
+| `?tag=a&tag=b` | `{ tag: ["a", "b"] }` |
+| (no query) | `{}` |
+
+Empty values become `true`; repeated keys become arrays; everything else is a
+string.
+
+## How `createCommandBar` works
+
+`createCommandBar(router, { mountInto })` creates a `<div>` with a command
+display and a copy button, appends it to `mountInto`, and subscribes to
+`router.activeRoute`. On each route change it calls `descriptor.cli(ctx)` to get
+the command string. Routes without a `cli` slot render empty text and disable
+the copy button.
+
+Returns `{ destroy }` to unsubscribe and remove the DOM elements.
+
+## Testing
+
+The shared presenter is the primary test surface. Since it takes a plain frozen
+object and returns plain data, tests need no DOM and no process:
+
+```js
+import { freezeInvocationContext } from "@forwardimpact/libcli";
+import { presentSkill } from "../src/present-skill.js";
+
+const ctx = freezeInvocationContext({
+  data: { skills: [{ id: "testing", name: "Testing", level: "advanced" }] },
+  args: { id: "testing" },
+  options: { json: true },
+});
+
+const view = presentSkill(ctx);
+assert.strictEqual(view.name, "Testing");
+```
+
+Both surfaces call the same function, so a passing presenter test covers the
+core logic for both CLI and web.

--- a/websites/fit/docs/libraries/agent-surfaces/index.md
+++ b/websites/fit/docs/libraries/agent-surfaces/index.md
@@ -1,22 +1,24 @@
 ---
-title: Web + CLI Surfaces
-description: Build a product with both a web UI and a CLI that share handler logic through a single InvocationContext contract.
+title: Agent-Friendly Surfaces
+description: Build a product with both a web UI and a CLI that share handler logic through a single InvocationContext contract — agent-friendly by design.
 ---
 
-# Web + CLI Surfaces
+# Agent-Friendly Surfaces
 
-Some products serve the same capability through two surfaces — a web app for
-browsers and a CLI for terminals. Without a shared contract the handler logic
-diverges: the web page reads route params and query strings, the CLI reads
-positionals and flags, and the two slowly drift apart.
+Some products serve the same capability through two agent-friendly surfaces — a
+web app for browsers and a CLI for terminals. Without a shared contract the
+handler logic diverges: the web page reads route params and query strings, the
+CLI reads positionals and flags, and the two slowly drift apart.
 
 `@forwardimpact/libui` and `@forwardimpact/libcli` solve this with
 **InvocationContext** — a frozen `{ data, args, options }` object that both
 surfaces produce from their native inputs. The handler never knows which surface
-called it.
+called it, and both surfaces are agent-friendly: the CLI prints grep-friendly
+help with JSON mode, the web app exposes the equivalent CLI command for
+copy-to-clipboard.
 
 This guide walks through building the simplest possible pairing: one entity, one
-shared presenter, two surfaces.
+shared presenter, two agent-friendly surfaces.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Implements plan 760-a-01 (Part 01 of 3): shared invocation surfaces for
  LibUI and LibCLI.
- Adds five new libui exports — `freezeInvocationContext`, `defineRoute`,
  `createBoundRouter`, `createCommandBar`, `createJsonLdScript` — that bind
  a web route to its CLI command and graph entity through a single
  `RouteDescriptor`.
- Amends libcli with `freezeInvocationContext` (duplicated per design D1)
  and an additive `dispatch()` method that maps declared positional names
  to a named args map before calling the handler with `InvocationContext`.
- Existing CLIs using legacy `args: "<usage>"` definitions are unaffected
  (`fit-landmark --help` smoke-tested).
- Adds an AST-based test (adapted from plan's ESLint rule — repo now uses
  Biome) enforcing no legacy `({ data, args, options })` or `(params)`
  handler shapes in libui/libcli.

**Plan deviation:** Step 9 specified an ESLint custom rule at
`tools/eslint-rules/`. The repo migrated to Biome (commit 3895bced) which
lacks custom AST rules — adapted to an acorn-based test at
`tests/no-legacy-handler-shape.test.js` with identical scope and detection.

## Test plan

- [x] `bun run check` passes (format + lint)
- [x] `bun run test` passes (2663 tests, 0 failures)
- [x] `bun products/landmark/bin/fit-landmark.js --help` exits 0 (legacy
  consumer smoke test)
- [x] 5-reviewer panel completed, all blocker/high/medium findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)