### PR TITLE
feat(libwiki,libxmr): agent tooling — fit-wiki memo + fit-xmr record (#770)

### DIFF
--- a/.claude/agents/references/memory-protocol.md
+++ b/.claude/agents/references/memory-protocol.md
@@ -82,7 +82,9 @@ Each `wiki/<agent>.md` conforms to a mechanically-checkable contract.
 3. Agent-specific state section(s) using H2
 4. `## Open Blockers` — currently-blocking items only
 5. `## Observations for Teammates` — items not yet promoted to the priority
-   index; agent-to-agent callouts
+   index; agent-to-agent callouts. Each section begins with the marker
+   `<!-- memo:inbox -->` directly under the heading; `fit-wiki memo` writes
+   new bullets immediately after it.
 
 **Excluded from summaries** (with correct homes):
 
@@ -90,7 +92,7 @@ Each `wiki/<agent>.md` conforms to a mechanically-checkable contract.
   history) → weekly log
 - Storyboard commitments → storyboard file
 - Policy clarifications → CONTRIBUTING.md or skill docs
-- Metrics tables → CSV under `wiki/metrics/{agent}/{domain}/`
+- Metrics tables → CSV under `wiki/metrics/{skill}/`
 
 **Line budget: 80 lines.** Checked mechanically: `wc -l wiki/<agent>.md ≤ 80`.
 Summaries are state, not history. The line budget forces the discipline.

--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: fit-wiki
+description: >
+  Manage the Kata agent team wiki: send cross-team observations (memos),
+  discover the agent roster, and migrate insertion markers. Use when an agent
+  needs to record an observation for a teammate or broadcast to all agents.
+---
+
+# Wiki Operations
+
+`fit-wiki` is the operational CLI for the Kata agent wiki. It writes to wiki
+summary files so agents can communicate observations without spending thinking
+tokens on file discovery, section parsing, or indentation matching.
+
+## When to Use
+
+- You observed something another agent should know about and want to record it
+  in their summary's "Observations for Teammates" section.
+- You want to broadcast an observation to every agent on the team.
+- You need to ensure all agent summaries have the `<!-- memo:inbox -->` marker
+  for machine-writable observations.
+
+## Commands
+
+### `memo` — Send a cross-team observation
+
+Appends a timestamped bullet to the target agent's wiki summary, directly after
+the `<!-- memo:inbox -->` marker in the "Observations for Teammates" section.
+
+```sh
+npx fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"
+npx fit-wiki memo --from technical-writer --to all --message "new XmR baseline"
+```
+
+| Flag          | Required | Description                                                           |
+| ------------- | -------- | --------------------------------------------------------------------- |
+| `--from`      | No       | Sender name (falls back to `LIBEVAL_AGENT_PROFILE` env var)           |
+| `--to`        | Yes      | Target agent name, or `all` to broadcast to every agent               |
+| `--message`   | Yes      | Observation text                                                      |
+| `--wiki-root` | No       | Override wiki root directory (default: auto-detected from project root) |
+
+The bullet format is `- YYYY-MM-DD **{sender}**: {message}`, inserted on the
+line immediately following the marker (newest-first within the section).
+
+### Exit codes
+
+| Code | Meaning                                                    |
+| ---- | ---------------------------------------------------------- |
+| 0    | Success — bullet written to all targets                    |
+| 2    | Usage error — missing flag, missing target file, or marker |
+
+### Marker contract
+
+Each agent summary must contain exactly one `<!-- memo:inbox -->` HTML comment
+directly under the `## Observations for Teammates` heading. The marker is
+invisible in rendered markdown and anchors `fit-wiki memo` writes. If the
+marker is absent, the command exits 2 with a diagnostic message.
+
+## Programmatic API
+
+```js
+import { writeMemo, listAgents, insertMarkers } from "@forwardimpact/libwiki";
+```
+
+- `writeMemo({ summaryPath, sender, message, today })` — append one bullet
+- `listAgents({ agentsDir, wikiRoot })` — discover agents from `.claude/agents/*.md`
+- `insertMarkers({ agentsDir, wikiRoot })` — idempotent marker insertion

--- a/.claude/skills/fit-xmr/SKILL.md
+++ b/.claude/skills/fit-xmr/SKILL.md
@@ -69,6 +69,7 @@ npx fit-xmr <command> <csv-path> [options]
 | `analyze <csv>`   | Full XmR report: chart, limits, signals, classification               |
 | `chart <csv>`     | The 14-line Wheeler/Vacanti chart for one metric                      |
 | `summarize <csv>` | Compact markdown table across metrics with classification and signals |
+| `record`           | Append a metric row to the skill CSV and print a one-line XmR summary |
 
 ### Common Options
 

--- a/.claude/skills/kata-documentation/SKILL.md
+++ b/.claude/skills/kata-documentation/SKILL.md
@@ -164,8 +164,8 @@ Append to the current week's log (see agent profile for the file path):
 - **Accuracy errors** — Specific docs that diverged from source code
 - **Observations for teammates** — Callouts for agents whose work affects docs
 - **Metrics** — Record at least one measurement to
-  `wiki/metrics/{agent}/{domain}/` per the
-  KATA.md § Metrics. If no CSV exists, create
+  `wiki/metrics/{skill}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.
 
 ## Coordination Channels

--- a/.claude/skills/kata-product-evaluation/SKILL.md
+++ b/.claude/skills/kata-product-evaluation/SKILL.md
@@ -143,6 +143,6 @@ Append to the current week's log (see agent profile for the file path):
 - **Key friction points** — Where the agent struggled most
 - **Issues created or updated** — Issue numbers and their categories
 - **Metrics** — Record at least one measurement to
-  `wiki/metrics/{agent}/{domain}/` per the
-  KATA.md § Metrics. If no CSV exists, create
+  `wiki/metrics/{skill}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.

--- a/.claude/skills/kata-product-issue/SKILL.md
+++ b/.claude/skills/kata-product-issue/SKILL.md
@@ -123,8 +123,8 @@ Append to the current week's log (see agent profile for the file path):
 - **Recurring themes** — Patterns across issues, with frequency and alignment
 - **Hand-offs** — Which follow-up skills were invoked for which issues
 - **Metrics** — Record at least one measurement to
-  `wiki/metrics/{agent}/{domain}/` per the
-  KATA.md § Metrics. If no CSV exists, create
+  `wiki/metrics/{skill}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.
 
 ## Coordination Channels

--- a/.claude/skills/kata-release-cut/SKILL.md
+++ b/.claude/skills/kata-release-cut/SKILL.md
@@ -161,8 +161,8 @@ Append to the current week's log (see agent profile for the file path):
 - **Publish failures** — Package and reason (so the next run can revisit)
 - **Main branch CI state** — Green or broken, and what was repaired
 - **Metrics** — Record at least one measurement to
-  `wiki/metrics/{agent}/{domain}/` per the
-  KATA.md § Metrics. If no CSV exists, create
+  `wiki/metrics/{skill}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.
 
 ## Edge Cases

--- a/.claude/skills/kata-security-audit/SKILL.md
+++ b/.claude/skills/kata-security-audit/SKILL.md
@@ -127,8 +127,8 @@ Append to the current week's log (see agent profile for the file path):
 - CVEs evaluated and their status
 - Policy violations found and whether fixed or spec'd
 - **Metrics** — Record at least one measurement to
-  `wiki/metrics/{agent}/{domain}/` per the
-  KATA.md § Metrics. If no CSV exists, create
+  `wiki/metrics/{skill}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.
 
 ## Coordination Channels

--- a/.claude/skills/kata-security-update/SKILL.md
+++ b/.claude/skills/kata-security-update/SKILL.md
@@ -155,6 +155,6 @@ Append to the current week's log (see agent profile for the file path):
 - **Compatibility blockers** — Packages closed due to Check 8
 - **Reverted merges** — PRs merged then reverted, with root cause
 - **Metrics** — Record at least one measurement to
-  `wiki/metrics/{agent}/{domain}/` per the
-  KATA.md § Metrics. If no CSV exists, create
+  `wiki/metrics/{skill}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.

--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -161,8 +161,8 @@ briefing.
 1. **Prepare for Q2.** Gather your domain's current measured state from live
    data (`gh`, `bun`, repo files) — not memory or narrative.
 2. **Record metrics to CSV.** Before answering, append one row per metric to
-   `wiki/metrics/{your-agent}/{domain}/{YYYY}.csv` per KATA.md § Metrics,
-   creating the directory
+   `wiki/metrics/{skill}/{YYYY}.csv` per the
+   [`kata-metrics`](../kata-metrics/SKILL.md) protocol, creating the directory
    and header if needed. The CSV is authoritative; your `Answer` summarizes it.
 3. **Answer with measured data.** Report numbers via `Answer`, referencing the
    CSV rows. Use counts and durations — not narratives like "improving." Use

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -32,7 +32,7 @@ threshold crossed, classification flip). Empty if nothing changed — write
 
 - `{agent}` / `{metric}` — {value} {trend/badge} — {one-line reason}
 
-### {agent} — {domain}
+### {agent}
 
 #### {metric_name}
 
@@ -52,7 +52,7 @@ _Note:_ {one line, only when `status` is `signals_present` or a fired rule needs
 cross-referencing to a specific event; stable metrics get no prose}.
 
 (Repeat one `#### metric_name` block per metric, grouped under
-`### {agent} — {domain}`. The chart from `bunx fit-xmr chart` is the
+`### {agent}`. The chart from `bunx fit-xmr chart` is the
 visualization — do not duplicate its values in surrounding prose. Agents add the
 cross-reference layer only where there is something to say.)
 

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -46,14 +46,15 @@ vs. expected), update Obstacles, and plan the next experiment.
 
 ## Metrics
 
-Each participant records to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`. See
-[`metrics.md`](metrics.md) for suggested coaching-side metrics. Use
-`bunx fit-xmr --help` for the XmR analysis CLI reference.
+Each participant records to `wiki/metrics/{skill}/{YYYY}.csv`. See
+[`metrics.md`](metrics.md) for suggested coaching-side metrics; authoritative
+XmR protocol reference at
+[`../../kata-metrics/references/xmr.md`](../../kata-metrics/references/xmr.md).
 
 ## Storyboard updates
 
 Current Condition is rendered as per-metric blocks under
-`### {agent} — {domain}` headings (no overview table). For each CSV-backed
+`### {agent}` headings (no overview table). For each CSV-backed
 metric, write a `#### {metric_name}` block containing:
 
 1. A status header — `**Latest:** {value} · **Status:** {status}`. No trend
@@ -111,5 +112,5 @@ Discussion, not four parallel coaching dispatches.
 
 > "You are joining a team storyboard meeting. I will Ask you five questions;
 > reply to each with Answer. Before answering Q2, record your domain metrics to
-> `wiki/metrics/{your-agent}/{domain}/{YYYY}.csv`; your Answer references the
+> `wiki/metrics/{skill}/{YYYY}.csv`; your Answer references the
 > CSV row."

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -131,6 +131,6 @@ Append to the current week's log (see agent profile for the file path):
 - **Review results** — Specs reviewed and disposition (approved/changes needed)
 - **Deferred work** — Findings not yet captured as specs
 - **Metrics** — Record at least one measurement to
-  `wiki/metrics/{agent}/{domain}/` per the
-  KATA.md § Metrics. If no CSV exists, create
+  `wiki/metrics/{skill}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.

--- a/.claude/skills/kata-wiki-curate/SKILL.md
+++ b/.claude/skills/kata-wiki-curate/SKILL.md
@@ -159,6 +159,6 @@ Append to the current week's log (see agent profile for the file path):
 - **MEMORY.md changes** — What was added/updated
 - **Observations for teammates** — Specific callouts based on wiki findings
 - **Metrics** — Record at least one measurement to
-  `wiki/metrics/{agent}/{domain}/` per the
-  KATA.md § Metrics. If no CSV exists, create
+  `wiki/metrics/{skill}/` per the
+  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
   it with the header row. These feed XmR analysis in the storyboard meeting.

--- a/KATA.md
+++ b/KATA.md
@@ -266,7 +266,7 @@ throughput is the only shape that, plotted run-over-run, distinguishes a stable
 process from a special-cause shift.
 
 Each measurement is one CSV row appended to
-`wiki/metrics/{agent}/{domain}/{YYYY}.csv` after the run. The storyboard meeting
+`wiki/metrics/{skill}/{YYYY}.csv` after the run. The storyboard meeting
 reads these via `fit-xmr` and answers "what is the actual condition now?" with
 control limits and signals — numbers, not narratives.
 

--- a/bun.lock
+++ b/bun.lock
@@ -433,6 +433,20 @@
         "@forwardimpact/libutil": "^0.1.60",
       },
     },
+    "libraries/libwiki": {
+      "name": "@forwardimpact/libwiki",
+      "version": "0.1.0",
+      "bin": {
+        "fit-wiki": "./bin/fit-wiki.js",
+      },
+      "dependencies": {
+        "@forwardimpact/libcli": "^0.1.0",
+        "@forwardimpact/libutil": "^0.1.0",
+      },
+      "devDependencies": {
+        "@forwardimpact/libharness": "^0.1.5",
+      },
+    },
     "libraries/libxmr": {
       "name": "@forwardimpact/libxmr",
       "version": "1.0.0",
@@ -441,6 +455,7 @@
       },
       "dependencies": {
         "@forwardimpact/libcli": "^0.1.0",
+        "@forwardimpact/libutil": "^0.1.0",
       },
       "devDependencies": {
         "@forwardimpact/libharness": "^0.1.5",
@@ -878,6 +893,8 @@
     "@forwardimpact/libutil": ["@forwardimpact/libutil@workspace:libraries/libutil"],
 
     "@forwardimpact/libvector": ["@forwardimpact/libvector@workspace:libraries/libvector"],
+
+    "@forwardimpact/libwiki": ["@forwardimpact/libwiki@workspace:libraries/libwiki"],
 
     "@forwardimpact/libxmr": ["@forwardimpact/libxmr@workspace:libraries/libxmr"],
 

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -78,6 +78,7 @@ signal is distinguished from noise.
 | **libsyntheticprose**  | LLM-generated prose and engineering-standard YAML for synthetic agent evaluation content.                                                     |
 | **libsyntheticrender** | Multi-format rendering and validation of synthetic agent evaluation data (HTML, Markdown, YAML).                                              |
 | **libterrain**         | Full parse-generate-render-validate pipeline for synthetic agent training and evaluation data.                                                |
+| **libwiki**            | Wiki lifecycle primitives for the Kata agent system: cross-team memos, agent roster discovery, and marker migration.                          |
 | **libxmr**             | Agent-friendly Wheeler/Vacanti XmR control charts: 14-line ASCII charts and the canonical three detection rules over time-series CSV metrics. |
 
 <!-- END:capability:agent-self-improvement -->
@@ -128,6 +129,7 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 | I need to…                                                                     | Library              |
 | ------------------------------------------------------------------------------ | -------------------- |
 | Add a distributed trace span (OpenTelemetry-style observability)               | `libtelemetry`       |
+| Append a cross-team observation to a wiki summary                              | `libwiki`            |
 | Assemble a macOS app bundle                                                    | `libmacos`           |
 | Buffer high-volume index writes                                                | `libindex`           |
 | Build a gRPC service                                                           | `librpc`             |
@@ -166,6 +168,7 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 | Query an RDF triple graph                                                      | `libgraph`           |
 | Read or write .env (dotenv) files                                              | `libsecret`          |
 | Read or write JSONL                                                            | `libstorage`         |
+| Record a metric and print its current XmR status                               | `libxmr`             |
 | Register a gRPC service as MCP tools                                           | `libmcp`             |
 | Render a Mustache template with project overrides                              | `libtemplate`        |
 | Render a prompt template with variable substitution                            | `libprompt`          |

--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -211,8 +211,9 @@ export class AgentRunner {
     if (message.type === "system" && message.subtype === "init") {
       this.sessionId = message.session_id;
     }
-    if (message.type === "assistant" && hasTextBlock(message)) {
-      state.assistantTextCount++;
+    if (message.type === "assistant") {
+      if (hasTextBlock(message)) state.assistantTextCount++;
+      trackSkillInvocation(message);
     }
   }
 
@@ -291,6 +292,20 @@ export function hasTextBlock(message) {
     if (block.type === "text" && block.text) return true;
   }
   return false;
+}
+
+function trackSkillInvocation(message) {
+  const content = message.message?.content ?? message.content;
+  if (!Array.isArray(content)) return;
+  for (const block of content) {
+    if (
+      block.type === "tool_use" &&
+      block.name === "Skill" &&
+      block.input?.skill
+    ) {
+      process.env.LIBEVAL_SKILL = block.input.skill;
+    }
+  }
 }
 
 /**

--- a/libraries/libeval/src/commands/facilitate.js
+++ b/libraries/libeval/src/commands/facilitate.js
@@ -73,6 +73,10 @@ export async function runFacilitateCommand(values, _args) {
       })
     : process.stdout;
 
+  if (opts.facilitatorProfile) {
+    process.env.LIBEVAL_AGENT_PROFILE = opts.facilitatorProfile;
+  }
+
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
   const facilitator = createFacilitator({
     facilitatorCwd: opts.facilitatorCwd,

--- a/libraries/libeval/src/commands/run.js
+++ b/libraries/libeval/src/commands/run.js
@@ -78,6 +78,10 @@ export async function runRunCommand(values, _args) {
     );
   };
 
+  if (agentProfile) {
+    process.env.LIBEVAL_AGENT_PROFILE = agentProfile;
+  }
+
   const systemPrompt = agentProfile
     ? composeProfilePrompt(agentProfile, {
         profilesDir: resolve(cwd, ".claude/agents"),

--- a/libraries/libeval/src/commands/supervise.js
+++ b/libraries/libeval/src/commands/supervise.js
@@ -71,6 +71,10 @@ export async function runSuperviseCommand(values, _args) {
       })
     : process.stdout;
 
+  if (opts.agentProfile) {
+    process.env.LIBEVAL_AGENT_PROFILE = opts.agentProfile;
+  }
+
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
   const supervisor = createSupervisor({
     supervisorCwd: opts.supervisorCwd,

--- a/libraries/libeval/test/agent-runner-skill-env.test.js
+++ b/libraries/libeval/test/agent-runner-skill-env.test.js
@@ -1,0 +1,121 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+
+import { AgentRunner } from "@forwardimpact/libeval";
+import { createMockAgentQuery as mockQuery } from "@forwardimpact/libharness";
+
+describe("AgentRunner LIBEVAL_SKILL env var", () => {
+  let savedSkill;
+
+  beforeEach(() => {
+    savedSkill = process.env.LIBEVAL_SKILL;
+    delete process.env.LIBEVAL_SKILL;
+  });
+
+  afterEach(() => {
+    if (savedSkill !== undefined) {
+      process.env.LIBEVAL_SKILL = savedSkill;
+    } else {
+      delete process.env.LIBEVAL_SKILL;
+    }
+  });
+
+  test("Skill tool_use sets LIBEVAL_SKILL", async () => {
+    const messages = [
+      { type: "system", subtype: "init", session_id: "s1" },
+      {
+        type: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "Skill",
+            input: { skill: "kata-metrics" },
+          },
+        ],
+      },
+      { type: "result", subtype: "success", result: "done" },
+    ];
+
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: mockQuery(messages),
+      output: new PassThrough(),
+    });
+
+    await runner.run("test");
+    assert.equal(process.env.LIBEVAL_SKILL, "kata-metrics");
+  });
+
+  test("second Skill tool_use updates LIBEVAL_SKILL", async () => {
+    const messages = [
+      { type: "system", subtype: "init", session_id: "s1" },
+      {
+        type: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "Skill",
+            input: { skill: "kata-metrics" },
+          },
+        ],
+      },
+      {
+        type: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "Skill",
+            input: { skill: "kata-review" },
+          },
+        ],
+      },
+      { type: "result", subtype: "success", result: "done" },
+    ];
+
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: mockQuery(messages),
+      output: new PassThrough(),
+    });
+
+    await runner.run("test");
+    assert.equal(process.env.LIBEVAL_SKILL, "kata-review");
+  });
+
+  test("non-Skill tool_use leaves LIBEVAL_SKILL unchanged", async () => {
+    const messages = [
+      { type: "system", subtype: "init", session_id: "s1" },
+      {
+        type: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "Skill",
+            input: { skill: "kata-metrics" },
+          },
+        ],
+      },
+      {
+        type: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "Bash",
+            input: { command: "ls" },
+          },
+        ],
+      },
+      { type: "result", subtype: "success", result: "done" },
+    ];
+
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: mockQuery(messages),
+      output: new PassThrough(),
+    });
+
+    await runner.run("test");
+    assert.equal(process.env.LIBEVAL_SKILL, "kata-metrics");
+  });
+});

--- a/libraries/libwiki/README.md
+++ b/libraries/libwiki/README.md
@@ -1,0 +1,24 @@
+# libwiki
+
+Wiki lifecycle primitives for the Kata agent system. Provides cross-team memo
+delivery, agent roster discovery, and insertion-marker migration.
+
+## Getting Started
+
+```sh
+npx fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"
+npx fit-wiki memo --from staff-engineer --to all --message "new XmR baseline"
+```
+
+```js
+import { writeMemo, listAgents, insertMarkers } from "@forwardimpact/libwiki";
+```
+
+## Key Exports
+
+- `writeMemo({ summaryPath, sender, message, today })` — append a timestamped
+  observation bullet after the `<!-- memo:inbox -->` marker in a wiki summary.
+- `listAgents({ agentsDir, wikiRoot })` — discover agents from
+  `.claude/agents/*.md` and derive wiki summary paths.
+- `insertMarkers({ agentsDir, wikiRoot })` — idempotent insertion of the memo
+  marker into existing summaries.

--- a/libraries/libwiki/bin/fit-wiki.js
+++ b/libraries/libwiki/bin/fit-wiki.js
@@ -52,6 +52,14 @@ const definition = {
     'fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"',
     'fit-wiki memo --from technical-writer --to all --message "new XmR baseline"',
   ],
+  documentation: [
+    {
+      title: "Wiki Operations",
+      url: "https://www.forwardimpact.team/docs/libraries/wiki-operations/index.md",
+      description:
+        "Send cross-team observations, discover agents, and manage wiki markers.",
+    },
+  ],
 };
 
 const cli = createCli(definition);

--- a/libraries/libwiki/bin/fit-wiki.js
+++ b/libraries/libwiki/bin/fit-wiki.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { createCli } from "@forwardimpact/libcli";
+
+import { runMemoCommand } from "../src/commands/memo.js";
+
+const { version: VERSION } = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+
+const definition = {
+  name: "fit-wiki",
+  version: VERSION,
+  description: "Wiki lifecycle management for the Kata agent system",
+  commands: [
+    {
+      name: "memo",
+      description:
+        "Append a cross-team observation to a teammate's wiki summary",
+      options: {
+        from: {
+          type: "string",
+          description:
+            "Sender agent name (falls back to LIBEVAL_AGENT_PROFILE env var)",
+        },
+        to: {
+          type: "string",
+          description:
+            'Target agent name, or "all" to broadcast to every agent',
+        },
+        message: {
+          type: "string",
+          description: "Observation text",
+        },
+        "wiki-root": {
+          type: "string",
+          description: "Override wiki root directory (default: auto-detected)",
+        },
+      },
+    },
+  ],
+  globalOptions: {
+    help: { type: "boolean", short: "h", description: "Show this help" },
+    version: { type: "boolean", description: "Show version" },
+    json: {
+      type: "boolean",
+      description: "Render --help output as JSON",
+    },
+  },
+  examples: [
+    'fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"',
+    'fit-wiki memo --from technical-writer --to all --message "new XmR baseline"',
+  ],
+};
+
+const cli = createCli(definition);
+
+const COMMANDS = {
+  memo: runMemoCommand,
+};
+
+function main() {
+  const parsed = cli.parse(process.argv.slice(2));
+  if (!parsed) process.exit(0);
+
+  const { values, positionals } = parsed;
+
+  if (positionals.length === 0) {
+    cli.showHelp();
+    process.exit(0);
+  }
+
+  const [command, ...args] = positionals;
+  const handler = COMMANDS[command];
+
+  if (!handler) {
+    cli.usageError(`unknown command "${command}"`);
+    process.exit(2);
+  }
+
+  handler(values, args, cli);
+}
+
+main();

--- a/libraries/libwiki/package.json
+++ b/libraries/libwiki/package.json
@@ -1,39 +1,35 @@
 {
-  "name": "@forwardimpact/libxmr",
-  "version": "1.0.0",
-  "description": "Agent-friendly Wheeler/Vacanti XmR control charts: 14-line ASCII charts and the canonical three detection rules over time-series CSV metrics.",
+  "name": "@forwardimpact/libwiki",
+  "version": "0.1.0",
+  "description": "Wiki lifecycle primitives for the Kata agent system: cross-team memos, agent roster discovery, and marker migration.",
   "keywords": [
-    "xmr",
-    "control-chart",
-    "wheeler",
-    "vacanti",
-    "spc",
+    "wiki",
+    "memo",
+    "observation",
     "agent"
   ],
   "homepage": "https://www.forwardimpact.team",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/forwardimpact/monorepo.git",
-    "directory": "libraries/libxmr"
+    "directory": "libraries/libwiki"
   },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
   "forwardimpact": {
     "capability": "agent-self-improvement",
     "needs": [
-      "Chart a metric with the canonical Wheeler/Vacanti XmR rules",
-      "Render an XmR control chart as monospace text",
-      "Record a metric and print its current XmR status"
+      "Append a cross-team observation to a wiki summary"
     ]
   },
   "type": "module",
   "main": "./src/index.js",
   "exports": {
     ".": "./src/index.js",
-    "./bin/fit-xmr.js": "./bin/fit-xmr.js"
+    "./bin/fit-wiki.js": "./bin/fit-wiki.js"
   },
   "bin": {
-    "fit-xmr": "./bin/fit-xmr.js"
+    "fit-wiki": "./bin/fit-wiki.js"
   },
   "files": [
     "src/**/*.js",

--- a/libraries/libwiki/src/agent-roster.js
+++ b/libraries/libwiki/src/agent-roster.js
@@ -1,0 +1,32 @@
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { BROADCAST_TARGET } from "./constants.js";
+
+export function listAgents(
+  { agentsDir, wikiRoot },
+  fs = { readdirSync, statSync },
+) {
+  const entries = fs.readdirSync(agentsDir);
+  const agents = [];
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".md")) continue;
+    const fullPath = path.join(agentsDir, entry);
+    const stat = fs.statSync(fullPath);
+    if (!stat.isFile()) continue;
+
+    const agent = entry.slice(0, -3);
+    if (agent === BROADCAST_TARGET) {
+      throw new Error(
+        `agent name '${BROADCAST_TARGET}' is reserved for broadcast`,
+      );
+    }
+
+    agents.push({
+      agent,
+      summaryPath: path.join(wikiRoot, agent + ".md"),
+    });
+  }
+
+  return agents;
+}

--- a/libraries/libwiki/src/commands/memo.js
+++ b/libraries/libwiki/src/commands/memo.js
@@ -1,0 +1,59 @@
+import { existsSync } from "node:fs";
+import fsAsync from "node:fs/promises";
+import path from "node:path";
+import { Finder } from "@forwardimpact/libutil";
+import { writeMemo } from "../memo-writer.js";
+import { listAgents } from "../agent-roster.js";
+import { BROADCAST_TARGET } from "../constants.js";
+
+function writeAndCheck(summaryPath, sender, message, today) {
+  const result = writeMemo({ summaryPath, sender, message, today });
+  if (!result.written) {
+    process.stderr.write(`summary lacks memo:inbox marker: ${result.path}\n`);
+    process.exit(2);
+  }
+  process.stdout.write(`wrote ${result.path}\n`);
+}
+
+export function runMemoCommand(values, _args, cli) {
+  const sender = values.from || process.env.LIBEVAL_AGENT_PROFILE;
+
+  if (!sender) {
+    cli.usageError(
+      "memo requires --from <sender> or LIBEVAL_AGENT_PROFILE env var",
+    );
+    process.exit(2);
+  }
+
+  if (!values.to) {
+    cli.usageError("memo requires --to <target|all>");
+    process.exit(2);
+  }
+
+  if (!values.message) {
+    cli.usageError("memo requires --message <text>");
+    process.exit(2);
+  }
+
+  const logger = { debug() {} };
+  const finder = new Finder(fsAsync, logger, process);
+  const projectRoot = finder.findProjectRoot(process.cwd());
+
+  const wikiRoot = values["wiki-root"] || path.join(projectRoot, "wiki");
+  const agentsDir = path.join(projectRoot, ".claude", "agents");
+  const today = new Date().toISOString().slice(0, 10);
+
+  if (values.to === BROADCAST_TARGET) {
+    const agents = listAgents({ agentsDir, wikiRoot });
+    for (const { summaryPath } of agents) {
+      writeAndCheck(summaryPath, sender, values.message, today);
+    }
+  } else {
+    const summaryPath = path.join(wikiRoot, values.to + ".md");
+    if (!existsSync(summaryPath)) {
+      cli.usageError(`target summary not found: ${summaryPath}`);
+      process.exit(2);
+    }
+    writeAndCheck(summaryPath, sender, values.message, today);
+  }
+}

--- a/libraries/libwiki/src/constants.js
+++ b/libraries/libwiki/src/constants.js
@@ -1,0 +1,3 @@
+export const MEMO_INBOX_MARKER = "<!-- memo:inbox -->";
+export const OBSERVATIONS_HEADING = "## Observations for Teammates";
+export const BROADCAST_TARGET = "all";

--- a/libraries/libwiki/src/index.js
+++ b/libraries/libwiki/src/index.js
@@ -1,0 +1,8 @@
+export { writeMemo } from "./memo-writer.js";
+export { listAgents } from "./agent-roster.js";
+export { insertMarkers } from "./marker-migrator.js";
+export {
+  MEMO_INBOX_MARKER,
+  OBSERVATIONS_HEADING,
+  BROADCAST_TARGET,
+} from "./constants.js";

--- a/libraries/libwiki/src/marker-migrator.js
+++ b/libraries/libwiki/src/marker-migrator.js
@@ -1,0 +1,38 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { MEMO_INBOX_MARKER, OBSERVATIONS_HEADING } from "./constants.js";
+import { listAgents } from "./agent-roster.js";
+
+export function insertMarkers(
+  { agentsDir, wikiRoot },
+  fs = { readFileSync, writeFileSync },
+) {
+  const agents = listAgents({ agentsDir, wikiRoot });
+  const inserted = [];
+  const skipped = [];
+  const errors = [];
+
+  for (const { agent, summaryPath } of agents) {
+    const content = fs.readFileSync(summaryPath, "utf-8");
+
+    if (content.includes(MEMO_INBOX_MARKER)) {
+      skipped.push(agent);
+      continue;
+    }
+
+    const lines = content.split("\n");
+    const headingIndex = lines.findIndex(
+      (line) => line.trim() === OBSERVATIONS_HEADING,
+    );
+
+    if (headingIndex === -1) {
+      errors.push({ agent, reason: "missing-heading" });
+      continue;
+    }
+
+    lines.splice(headingIndex + 1, 0, "", MEMO_INBOX_MARKER);
+    fs.writeFileSync(summaryPath, lines.join("\n"));
+    inserted.push(agent);
+  }
+
+  return { inserted, skipped, errors };
+}

--- a/libraries/libwiki/src/memo-writer.js
+++ b/libraries/libwiki/src/memo-writer.js
@@ -1,0 +1,26 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { MEMO_INBOX_MARKER } from "./constants.js";
+
+export function writeMemo(
+  { summaryPath, sender, message, today },
+  fs = { readFileSync, writeFileSync },
+) {
+  const content = fs.readFileSync(summaryPath, "utf-8");
+  const lines = content.split("\n");
+
+  const markerIndex = lines.findIndex(
+    (line) => line.trim() === MEMO_INBOX_MARKER,
+  );
+
+  if (markerIndex === -1) {
+    return { written: false, reason: "missing-marker", path: summaryPath };
+  }
+
+  const flatMessage = message.replace(/\n/g, " ");
+  const bullet = `- ${today} **${sender}**: ${flatMessage}`;
+
+  lines.splice(markerIndex + 1, 0, bullet);
+  fs.writeFileSync(summaryPath, lines.join("\n"));
+
+  return { written: true, path: summaryPath };
+}

--- a/libraries/libwiki/test/agent-roster.test.js
+++ b/libraries/libwiki/test/agent-roster.test.js
@@ -1,0 +1,68 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { listAgents } from "../src/agent-roster.js";
+
+describe("listAgents", () => {
+  function makeTmpDir() {
+    return mkdtempSync(join(tmpdir(), "roster-"));
+  }
+
+  test("discovers agent files and derives summary paths", () => {
+    const dir = makeTmpDir();
+    const agentsDir = join(dir, "agents");
+    mkdirSync(agentsDir);
+    writeFileSync(join(agentsDir, "staff-engineer.md"), "# Staff Engineer");
+    writeFileSync(join(agentsDir, "product-manager.md"), "# PM");
+
+    const result = listAgents({ agentsDir, wikiRoot: "wiki" });
+
+    assert.equal(result.length, 2);
+    const names = result.map((r) => r.agent).sort();
+    assert.deepStrictEqual(names, ["product-manager", "staff-engineer"]);
+    assert.equal(
+      result.find((r) => r.agent === "staff-engineer").summaryPath,
+      join("wiki", "staff-engineer.md"),
+    );
+  });
+
+  test("excludes subdirectories", () => {
+    const dir = makeTmpDir();
+    const agentsDir = join(dir, "agents");
+    mkdirSync(agentsDir);
+    writeFileSync(join(agentsDir, "staff-engineer.md"), "");
+    mkdirSync(join(agentsDir, "references"));
+    writeFileSync(join(agentsDir, "references", "protocol.md"), "");
+
+    const result = listAgents({ agentsDir, wikiRoot: "wiki" });
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].agent, "staff-engineer");
+  });
+
+  test("throws on broadcast collision", () => {
+    const dir = makeTmpDir();
+    const agentsDir = join(dir, "agents");
+    mkdirSync(agentsDir);
+    writeFileSync(join(agentsDir, "all.md"), "");
+
+    assert.throws(
+      () => listAgents({ agentsDir, wikiRoot: "wiki" }),
+      /reserved for broadcast/,
+    );
+  });
+
+  test("skips non-.md files", () => {
+    const dir = makeTmpDir();
+    const agentsDir = join(dir, "agents");
+    mkdirSync(agentsDir);
+    writeFileSync(join(agentsDir, "staff-engineer.md"), "");
+    writeFileSync(join(agentsDir, "README.txt"), "");
+
+    const result = listAgents({ agentsDir, wikiRoot: "wiki" });
+
+    assert.equal(result.length, 1);
+  });
+});

--- a/libraries/libwiki/test/cli-memo.test.js
+++ b/libraries/libwiki/test/cli-memo.test.js
@@ -1,0 +1,154 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { MEMO_INBOX_MARKER } from "../src/constants.js";
+
+const CLI_PATH = new URL("../bin/fit-wiki.js", import.meta.url).pathname;
+
+describe("fit-wiki memo CLI", () => {
+  let dir;
+  let agentsDir;
+  let wikiRoot;
+  let savedEnv;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "wiki-cli-"));
+    agentsDir = join(dir, ".claude", "agents");
+    wikiRoot = join(dir, "wiki");
+    mkdirSync(agentsDir, { recursive: true });
+    mkdirSync(wikiRoot);
+    writeFileSync(join(dir, "package.json"), '{"name":"root"}');
+
+    writeFileSync(join(agentsDir, "staff-engineer.md"), "# SE");
+    writeFileSync(join(agentsDir, "product-manager.md"), "# PM");
+
+    writeFileSync(
+      join(wikiRoot, "staff-engineer.md"),
+      `# Staff Engineer\n\n## Observations for Teammates\n\n${MEMO_INBOX_MARKER}\n\n- old bullet\n`,
+    );
+    writeFileSync(
+      join(wikiRoot, "product-manager.md"),
+      `# PM\n\n## Observations for Teammates\n\n${MEMO_INBOX_MARKER}\n\n- old bullet\n`,
+    );
+
+    savedEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  function run(args, env = {}) {
+    return execFileSync("node", [CLI_PATH, ...args], {
+      cwd: dir,
+      env: { ...process.env, ...env, PATH: process.env.PATH },
+      encoding: "utf-8",
+    });
+  }
+
+  function runFail(args, env = {}) {
+    try {
+      execFileSync("node", [CLI_PATH, ...args], {
+        cwd: dir,
+        env: { ...process.env, ...env, PATH: process.env.PATH },
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+      assert.fail("expected non-zero exit");
+    } catch (err) {
+      return { status: err.status, stderr: err.stderr, stdout: err.stdout };
+    }
+  }
+
+  test("single-target write", () => {
+    const stdout = run([
+      "memo",
+      "--from",
+      "technical-writer",
+      "--to",
+      "staff-engineer",
+      "--message",
+      "audit d642ff0c",
+    ]);
+
+    assert.ok(stdout.includes("wrote"));
+
+    const content = readFileSync(join(wikiRoot, "staff-engineer.md"), "utf-8");
+    assert.ok(content.includes("**technical-writer**: audit d642ff0c"));
+  });
+
+  test("broadcast writes to every agent", () => {
+    run([
+      "memo",
+      "--from",
+      "technical-writer",
+      "--to",
+      "all",
+      "--message",
+      "check baselines",
+    ]);
+
+    const se = readFileSync(join(wikiRoot, "staff-engineer.md"), "utf-8");
+    const pm = readFileSync(join(wikiRoot, "product-manager.md"), "utf-8");
+    assert.ok(se.includes("check baselines"));
+    assert.ok(pm.includes("check baselines"));
+  });
+
+  test("missing-marker exits 2", () => {
+    writeFileSync(
+      join(wikiRoot, "staff-engineer.md"),
+      "# SE\n\n## Observations for Teammates\n\n- no marker\n",
+    );
+
+    const { status, stderr } = runFail([
+      "memo",
+      "--from",
+      "x",
+      "--to",
+      "staff-engineer",
+      "--message",
+      "test",
+    ]);
+
+    assert.equal(status, 2);
+    assert.ok(stderr.includes("memo:inbox marker"));
+  });
+
+  test("missing target file exits 2", () => {
+    const { status } = runFail([
+      "memo",
+      "--from",
+      "x",
+      "--to",
+      "nonexistent",
+      "--message",
+      "test",
+    ]);
+
+    assert.equal(status, 2);
+  });
+
+  test("LIBEVAL_AGENT_PROFILE fallback when --from omitted", () => {
+    const stdout = run(
+      ["memo", "--to", "staff-engineer", "--message", "env test"],
+      { LIBEVAL_AGENT_PROFILE: "security-engineer" },
+    );
+
+    assert.ok(stdout.includes("wrote"));
+
+    const content = readFileSync(join(wikiRoot, "staff-engineer.md"), "utf-8");
+    assert.ok(content.includes("**security-engineer**: env test"));
+  });
+
+  test("exits 2 when neither --from nor env var set", () => {
+    const { status } = runFail(
+      ["memo", "--to", "staff-engineer", "--message", "test"],
+      { LIBEVAL_AGENT_PROFILE: "" },
+    );
+
+    assert.equal(status, 2);
+  });
+});

--- a/libraries/libwiki/test/marker-migrator.test.js
+++ b/libraries/libwiki/test/marker-migrator.test.js
@@ -1,0 +1,82 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { insertMarkers } from "../src/marker-migrator.js";
+import { MEMO_INBOX_MARKER } from "../src/constants.js";
+
+describe("insertMarkers", () => {
+  function setup(agents) {
+    const dir = mkdtempSync(join(tmpdir(), "migrator-"));
+    const agentsDir = join(dir, "agents");
+    const wikiRoot = join(dir, "wiki");
+    mkdirSync(agentsDir);
+    mkdirSync(wikiRoot);
+
+    for (const [name, content] of Object.entries(agents)) {
+      writeFileSync(join(agentsDir, name + ".md"), "# " + name);
+      writeFileSync(join(wikiRoot, name + ".md"), content);
+    }
+
+    return { agentsDir, wikiRoot };
+  }
+
+  test("inserts marker on first run", () => {
+    const { agentsDir, wikiRoot } = setup({
+      "staff-engineer":
+        "# Staff Engineer\n\n## Observations for Teammates\n\n- existing bullet\n",
+    });
+
+    const result = insertMarkers({ agentsDir, wikiRoot });
+
+    assert.deepStrictEqual(result.inserted, ["staff-engineer"]);
+    assert.deepStrictEqual(result.skipped, []);
+    assert.deepStrictEqual(result.errors, []);
+
+    const content = readFileSync(join(wikiRoot, "staff-engineer.md"), "utf-8");
+    assert.ok(content.includes(MEMO_INBOX_MARKER));
+  });
+
+  test("skips on second run (idempotent)", () => {
+    const { agentsDir, wikiRoot } = setup({
+      "staff-engineer":
+        "# Staff Engineer\n\n## Observations for Teammates\n\n- existing bullet\n",
+    });
+
+    insertMarkers({ agentsDir, wikiRoot });
+    const result = insertMarkers({ agentsDir, wikiRoot });
+
+    assert.deepStrictEqual(result.inserted, []);
+    assert.deepStrictEqual(result.skipped, ["staff-engineer"]);
+  });
+
+  test("reports error when heading missing", () => {
+    const { agentsDir, wikiRoot } = setup({
+      "staff-engineer": "# Staff Engineer\n\nNo observations section here.\n",
+    });
+
+    const result = insertMarkers({ agentsDir, wikiRoot });
+
+    assert.deepStrictEqual(result.errors, [
+      { agent: "staff-engineer", reason: "missing-heading" },
+    ]);
+  });
+
+  test("marker placed directly under heading", () => {
+    const { agentsDir, wikiRoot } = setup({
+      "staff-engineer": "## Observations for Teammates\n\n- existing bullet\n",
+    });
+
+    insertMarkers({ agentsDir, wikiRoot });
+
+    const lines = readFileSync(
+      join(wikiRoot, "staff-engineer.md"),
+      "utf-8",
+    ).split("\n");
+    const headingIdx = lines.findIndex(
+      (l) => l.trim() === "## Observations for Teammates",
+    );
+    assert.equal(lines[headingIdx + 2], MEMO_INBOX_MARKER);
+  });
+});

--- a/libraries/libwiki/test/memo-writer.test.js
+++ b/libraries/libwiki/test/memo-writer.test.js
@@ -1,0 +1,90 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { writeMemo } from "../src/memo-writer.js";
+import { MEMO_INBOX_MARKER } from "../src/constants.js";
+
+function createFakeFs(content) {
+  let written = null;
+  return {
+    readFileSync: () => content,
+    writeFileSync: (_path, data) => {
+      written = data;
+    },
+    get written() {
+      return written;
+    },
+  };
+}
+
+describe("writeMemo", () => {
+  const base = {
+    summaryPath: "wiki/staff-engineer.md",
+    sender: "technical-writer",
+    message: "audit d642ff0c",
+    today: "2026-05-02",
+  };
+
+  test("appends bullet after marker", () => {
+    const content = [
+      "## Observations for Teammates",
+      MEMO_INBOX_MARKER,
+      "",
+      "Some other content",
+    ].join("\n");
+
+    const fs = createFakeFs(content);
+    const result = writeMemo(base, fs);
+
+    assert.deepStrictEqual(result, {
+      written: true,
+      path: "wiki/staff-engineer.md",
+    });
+
+    const lines = fs.written.split("\n");
+    assert.equal(lines[1], MEMO_INBOX_MARKER);
+    assert.equal(lines[2], "- 2026-05-02 **technical-writer**: audit d642ff0c");
+  });
+
+  test("returns missing-marker when marker absent", () => {
+    const content = "## Observations for Teammates\n\nNo marker here.\n";
+    const fs = createFakeFs(content);
+    const result = writeMemo(base, fs);
+
+    assert.deepStrictEqual(result, {
+      written: false,
+      reason: "missing-marker",
+      path: "wiki/staff-engineer.md",
+    });
+    assert.equal(fs.written, null);
+  });
+
+  test("marker is preserved after write", () => {
+    const content = [
+      "## Observations for Teammates",
+      MEMO_INBOX_MARKER,
+      "",
+    ].join("\n");
+
+    const fs = createFakeFs(content);
+    writeMemo(base, fs);
+
+    assert.ok(fs.written.includes(MEMO_INBOX_MARKER));
+  });
+
+  test("multi-line message collapsed to single line", () => {
+    const content = [
+      "## Observations for Teammates",
+      MEMO_INBOX_MARKER,
+      "",
+    ].join("\n");
+
+    const fs = createFakeFs(content);
+    writeMemo({ ...base, message: "line one\nline two\nline three" }, fs);
+
+    const lines = fs.written.split("\n");
+    assert.equal(
+      lines[2],
+      "- 2026-05-02 **technical-writer**: line one line two line three",
+    );
+  });
+});

--- a/libraries/libxmr/README.md
+++ b/libraries/libxmr/README.md
@@ -9,6 +9,7 @@ the three Wheeler detection rules (plus mR Rule 1).
 ```sh
 npx fit-xmr --help
 npx fit-xmr chart observations.csv --metric latency
+npx fit-xmr record --skill kata-product-issue --metric issues_triaged --value 3
 ```
 
 ```js

--- a/libraries/libxmr/bin/fit-xmr.js
+++ b/libraries/libxmr/bin/fit-xmr.js
@@ -8,6 +8,7 @@ import { runListCommand } from "../src/commands/list.js";
 import { runValidateCommand } from "../src/commands/validate.js";
 import { runChartCommand } from "../src/commands/chart.js";
 import { runSummarizeCommand } from "../src/commands/summarize.js";
+import { runRecordCommand } from "../src/commands/record.js";
 
 const { version: VERSION } = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
@@ -68,6 +69,46 @@ const definition = {
         },
       },
     },
+    {
+      name: "record",
+      description:
+        "Append a metric row to the skill's CSV and print a one-line XmR summary",
+      options: {
+        skill: {
+          type: "string",
+          description: "Skill name (falls back to LIBEVAL_SKILL env var)",
+        },
+        metric: {
+          type: "string",
+          short: "m",
+          description: "Metric name",
+        },
+        value: {
+          type: "string",
+          description: "Numeric value to record",
+        },
+        unit: {
+          type: "string",
+          description: "Unit of measurement (default: count)",
+        },
+        run: {
+          type: "string",
+          description: "Run identifier (optional)",
+        },
+        note: {
+          type: "string",
+          description: "Contextual note (optional)",
+        },
+        date: {
+          type: "string",
+          description: "ISO date (default: today)",
+        },
+        "wiki-root": {
+          type: "string",
+          description: "Override wiki root directory (default: auto-detected)",
+        },
+      },
+    },
   ],
   globalOptions: {
     format: {
@@ -88,15 +129,16 @@ const definition = {
     },
   },
   examples: [
-    "fit-xmr analyze wiki/metrics/security-engineer/audit/2026.csv",
-    "fit-xmr analyze wiki/metrics/security-engineer/audit/2026.csv --metric open_vulnerabilities",
-    "fit-xmr analyze wiki/metrics/security-engineer/audit/2026.csv --format json",
-    "fit-xmr chart wiki/metrics/security-engineer/audit/2026.csv --metric open_vulnerabilities",
-    "fit-xmr chart wiki/metrics/security-engineer/audit/2026.csv --metric open_vulnerabilities --ascii",
-    "fit-xmr list wiki/metrics/security-engineer/audit/2026.csv",
-    "fit-xmr validate wiki/metrics/security-engineer/audit/2026.csv",
-    "fit-xmr summarize wiki/metrics/security-engineer/audit/2026.csv",
-    "fit-xmr summarize wiki/metrics/security-engineer/audit/2026.csv --format json",
+    "fit-xmr analyze wiki/metrics/kata-security-audit/2026.csv",
+    "fit-xmr analyze wiki/metrics/kata-security-audit/2026.csv --metric findings_count",
+    "fit-xmr analyze wiki/metrics/kata-security-audit/2026.csv --format json",
+    "fit-xmr chart wiki/metrics/kata-security-audit/2026.csv --metric findings_count",
+    "fit-xmr chart wiki/metrics/kata-security-audit/2026.csv --metric findings_count --ascii",
+    "fit-xmr list wiki/metrics/kata-security-audit/2026.csv",
+    "fit-xmr validate wiki/metrics/kata-security-audit/2026.csv",
+    "fit-xmr summarize wiki/metrics/kata-security-audit/2026.csv",
+    "fit-xmr summarize wiki/metrics/kata-security-audit/2026.csv --format json",
+    "fit-xmr record --skill kata-product-issue --metric issues_triaged --value 3",
   ],
   documentation: [
     {
@@ -116,6 +158,7 @@ const COMMANDS = {
   list: runListCommand,
   validate: runValidateCommand,
   summarize: runSummarizeCommand,
+  record: runRecordCommand,
 };
 
 function main() {

--- a/libraries/libxmr/src/commands/record.js
+++ b/libraries/libxmr/src/commands/record.js
@@ -1,0 +1,92 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import fsAsync from "node:fs/promises";
+import path from "node:path";
+import { Finder } from "@forwardimpact/libutil";
+import { analyze } from "../analyze.js";
+import { EXPECTED_HEADER } from "../constants.js";
+
+const csvField = (v) => {
+  const s = String(v);
+  return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+};
+
+function parseRecordOptions(values, cli) {
+  const skill = values.skill || process.env.LIBEVAL_SKILL;
+  if (!skill) {
+    cli.usageError("record requires --skill <name> or LIBEVAL_SKILL env var");
+    process.exit(2);
+  }
+
+  if (!values.metric) {
+    cli.usageError("record requires --metric <name>");
+    process.exit(2);
+  }
+
+  if (values.value === undefined || values.value === null) {
+    cli.usageError("record requires --value <number>");
+    process.exit(2);
+  }
+
+  return {
+    skill,
+    metric: values.metric,
+    numValue: Number(values.value),
+    date: values.date || new Date().toISOString().slice(0, 10),
+    unit: values.unit || "count",
+    run: values.run || "",
+    note: values.note || "",
+    wikiRootOverride: values["wiki-root"],
+  };
+}
+
+function printSummary(csvPath, metric) {
+  try {
+    const text = readFileSync(csvPath, "utf-8");
+    const report = analyze(text);
+    const m = report.metrics.find((r) => r.metric === metric);
+
+    if (m) {
+      const latest = m.latest ? m.latest.value : m.values[m.values.length - 1];
+      process.stdout.write(
+        `metric=${m.metric} n=${m.n} status=${m.status} latest=${latest}\n`,
+      );
+    }
+  } catch (err) {
+    process.stderr.write(`warning: analyze failed: ${err.message}\n`);
+  }
+}
+
+export function runRecordCommand(values, _args, cli) {
+  const opts = parseRecordOptions(values, cli);
+
+  const logger = { debug() {} };
+  const finder = new Finder(fsAsync, logger, process);
+  const projectRoot = finder.findProjectRoot(process.cwd());
+
+  const wikiRoot = opts.wikiRootOverride || path.join(projectRoot, "wiki");
+  const year = opts.date.slice(0, 4);
+  const csvDir = path.join(wikiRoot, "metrics", opts.skill);
+  const csvPath = path.join(csvDir, `${year}.csv`);
+
+  if (!existsSync(csvDir)) {
+    mkdirSync(csvDir, { recursive: true });
+  }
+
+  if (!existsSync(csvPath)) {
+    writeFileSync(csvPath, EXPECTED_HEADER + "\n");
+  }
+
+  const row = [
+    opts.date,
+    opts.metric,
+    opts.numValue,
+    opts.unit,
+    opts.run,
+    opts.note,
+  ]
+    .map(csvField)
+    .join(",");
+  writeFileSync(csvPath, readFileSync(csvPath, "utf-8") + row + "\n");
+
+  printSummary(csvPath, opts.metric);
+}

--- a/libraries/libxmr/test/record.test.js
+++ b/libraries/libxmr/test/record.test.js
@@ -1,0 +1,203 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { EXPECTED_HEADER } from "../src/constants.js";
+
+const CLI_PATH = new URL("../bin/fit-xmr.js", import.meta.url).pathname;
+
+describe("fit-xmr record", () => {
+  let dir;
+  let wikiRoot;
+  let savedEnv;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "xmr-record-"));
+    wikiRoot = join(dir, "wiki");
+    mkdirSync(join(wikiRoot, "metrics"), { recursive: true });
+    writeFileSync(join(dir, "package.json"), '{"name":"root"}');
+    savedEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  function run(args, env = {}) {
+    return execFileSync("node", [CLI_PATH, ...args], {
+      cwd: dir,
+      env: { ...process.env, ...env, PATH: process.env.PATH },
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+  }
+
+  function runFail(args, env = {}) {
+    try {
+      execFileSync("node", [CLI_PATH, ...args], {
+        cwd: dir,
+        env: { ...process.env, ...env, PATH: process.env.PATH },
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+      assert.fail("expected non-zero exit");
+    } catch (err) {
+      return { status: err.status, stderr: err.stderr };
+    }
+  }
+
+  test("new file gets header + 1 row (criterion #4)", () => {
+    run([
+      "record",
+      "--skill",
+      "kata-test",
+      "--metric",
+      "test_count",
+      "--value",
+      "5",
+      "--date",
+      "2026-05-02",
+      "--wiki-root",
+      wikiRoot,
+    ]);
+
+    const csvPath = join(wikiRoot, "metrics", "kata-test", "2026.csv");
+    assert.ok(existsSync(csvPath));
+
+    const lines = readFileSync(csvPath, "utf-8").trim().split("\n");
+    assert.equal(lines[0], EXPECTED_HEADER);
+    assert.equal(lines.length, 2);
+    assert.ok(lines[1].startsWith("2026-05-02,test_count,5,count,"));
+  });
+
+  test("append-only on existing file", () => {
+    const csvDir = join(wikiRoot, "metrics", "kata-test");
+    mkdirSync(csvDir, { recursive: true });
+    writeFileSync(
+      join(csvDir, "2026.csv"),
+      EXPECTED_HEADER + "\n2026-05-01,test_count,3,count,,\n",
+    );
+
+    run([
+      "record",
+      "--skill",
+      "kata-test",
+      "--metric",
+      "test_count",
+      "--value",
+      "7",
+      "--date",
+      "2026-05-02",
+      "--wiki-root",
+      wikiRoot,
+    ]);
+
+    const lines = readFileSync(join(csvDir, "2026.csv"), "utf-8")
+      .trim()
+      .split("\n");
+    assert.equal(lines.length, 3);
+    assert.ok(lines[2].startsWith("2026-05-02,test_count,7,count,"));
+  });
+
+  test("one-line output format (criterion #3)", () => {
+    const stdout = run([
+      "record",
+      "--skill",
+      "kata-test",
+      "--metric",
+      "test_count",
+      "--value",
+      "5",
+      "--date",
+      "2026-05-02",
+      "--wiki-root",
+      wikiRoot,
+    ]);
+
+    assert.match(stdout, /metric=test_count/);
+    assert.match(stdout, /n=1/);
+    assert.match(stdout, /status=insufficient_data/);
+    assert.match(stdout, /latest=5/);
+  });
+
+  test("missing required --metric exits 2", () => {
+    const { status } = runFail([
+      "record",
+      "--skill",
+      "kata-test",
+      "--value",
+      "5",
+      "--wiki-root",
+      wikiRoot,
+    ]);
+
+    assert.equal(status, 2);
+  });
+
+  test("custom --wiki-root honoured", () => {
+    const customWiki = join(dir, "custom-wiki");
+    mkdirSync(join(customWiki, "metrics"), { recursive: true });
+
+    run([
+      "record",
+      "--skill",
+      "kata-test",
+      "--metric",
+      "test_count",
+      "--value",
+      "1",
+      "--date",
+      "2026-05-02",
+      "--wiki-root",
+      customWiki,
+    ]);
+
+    assert.ok(existsSync(join(customWiki, "metrics", "kata-test", "2026.csv")));
+  });
+
+  test("LIBEVAL_SKILL fallback when --skill omitted", () => {
+    run(
+      [
+        "record",
+        "--metric",
+        "test_count",
+        "--value",
+        "1",
+        "--date",
+        "2026-05-02",
+        "--wiki-root",
+        wikiRoot,
+      ],
+      { LIBEVAL_SKILL: "kata-env-test" },
+    );
+
+    assert.ok(
+      existsSync(join(wikiRoot, "metrics", "kata-env-test", "2026.csv")),
+    );
+  });
+
+  test("exits 2 when neither --skill nor env var set", () => {
+    const { status } = runFail(
+      [
+        "record",
+        "--metric",
+        "test_count",
+        "--value",
+        "1",
+        "--wiki-root",
+        wikiRoot,
+      ],
+      { LIBEVAL_SKILL: "" },
+    );
+
+    assert.equal(status, 2);
+  });
+});

--- a/scripts/migrate-memo-markers.mjs
+++ b/scripts/migrate-memo-markers.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { insertMarkers } from "@forwardimpact/libwiki";
+
+const result = insertMarkers({
+  agentsDir: ".claude/agents",
+  wikiRoot: "wiki",
+});
+
+console.log("inserted:", result.inserted);
+console.log("skipped:", result.skipped);
+if (result.errors.length) console.log("errors:", result.errors);

--- a/scripts/migrate-metrics-to-skill.mjs
+++ b/scripts/migrate-metrics-to-skill.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  readdirSync,
+  existsSync,
+} from "node:fs";
+import path from "node:path";
+import { EXPECTED_HEADER } from "@forwardimpact/libxmr";
+
+const WIKI_METRICS = path.resolve("wiki/metrics");
+
+const MAPPING = {
+  "product-manager/backlog": "kata-product-issue",
+  "product-manager/evaluation": "kata-product-evaluation",
+  "release-engineer/merge": "kata-release-merge",
+  "release-engineer/release": "kata-release-cut",
+  "security-engineer/audit": "kata-security-audit",
+  "security-engineer/triage": "kata-security-update",
+  "staff-engineer/implementation": "kata-implement",
+  "staff-engineer/spec": "kata-spec",
+  "staff-engineer/trace": "kata-trace",
+  "technical-writer/documentation": "kata-documentation",
+  "technical-writer/wiki": "kata-wiki-curate",
+};
+
+const skillRows = {};
+
+for (const [source, skill] of Object.entries(MAPPING)) {
+  const sourceDir = path.join(WIKI_METRICS, source);
+  const csvFiles = readdirSync(sourceDir).filter((f) => f.endsWith(".csv"));
+
+  for (const csvFile of csvFiles) {
+    const csvPath = path.join(sourceDir, csvFile);
+    const content = readFileSync(csvPath, "utf-8")
+      .replace(/\r\n/g, "\n")
+      .trim();
+    const lines = content.split("\n");
+    const header = lines[0];
+    if (header !== EXPECTED_HEADER) {
+      console.error(`unexpected header in ${csvPath}: ${header}`);
+      process.exit(1);
+    }
+
+    const dataRows = lines.slice(1);
+    const year = csvFile.replace(".csv", "");
+    const key = `${skill}/${year}`;
+
+    if (!skillRows[key])
+      skillRows[key] = { skill, year, rows: [], sources: [] };
+    skillRows[key].rows.push(...dataRows);
+    skillRows[key].sources.push(`${source}/${csvFile}`);
+  }
+}
+
+let totalSourceRows = 0;
+let totalOutputRows = 0;
+
+for (const { skill, year, rows, sources } of Object.values(skillRows)) {
+  rows.sort((a, b) => {
+    const dateA = a.split(",")[0];
+    const dateB = b.split(",")[0];
+    if (dateA !== dateB) return dateA.localeCompare(dateB);
+    const metricA = a.split(",")[1];
+    const metricB = b.split(",")[1];
+    return metricA.localeCompare(metricB);
+  });
+
+  const targetDir = path.join(WIKI_METRICS, skill);
+  mkdirSync(targetDir, { recursive: true });
+  const targetPath = path.join(targetDir, `${year}.csv`);
+  writeFileSync(targetPath, EXPECTED_HEADER + "\n" + rows.join("\n") + "\n");
+
+  totalSourceRows += rows.length;
+  totalOutputRows += rows.length;
+  console.log(`${skill}: ${rows.length} rows from ${sources.join(", ")}`);
+}
+
+if (totalSourceRows !== totalOutputRows) {
+  console.error(
+    `ROW COUNT MISMATCH: source=${totalSourceRows} output=${totalOutputRows}`,
+  );
+  process.exit(1);
+}
+
+for (const source of Object.keys(MAPPING)) {
+  const sourceDir = path.join(WIKI_METRICS, source);
+  const csvFiles = readdirSync(sourceDir).filter((f) => f.endsWith(".csv"));
+  for (const csvFile of csvFiles) {
+    rmSync(path.join(sourceDir, csvFile));
+  }
+
+  const remaining = readdirSync(sourceDir);
+  if (remaining.length === 0) {
+    rmSync(sourceDir, { recursive: true });
+    const agentDir = path.dirname(sourceDir);
+    if (existsSync(agentDir) && readdirSync(agentDir).length === 0) {
+      rmSync(agentDir, { recursive: true });
+    }
+  }
+}
+
+console.log(`\nMigration complete: ${totalOutputRows} total rows preserved.`);

--- a/websites/fit/docs/internals/kata/index.md
+++ b/websites/fit/docs/internals/kata/index.md
@@ -1,6 +1,6 @@
 ---
 title: Kata Agent Team
-description: "An autonomous and continuously improving agentic development team — six agent personas, eight workflows, fifteen skills, organized as a Plan-Do-Study-Act loop."
+description: "An autonomous and continuously improving agentic development team — six agent personas, eight workflows, eighteen skills, organized as a Plan-Do-Study-Act loop."
 ---
 
 > "What does the pattern of the Improvement Kata give us? A means for
@@ -16,7 +16,7 @@ features and hardening the repo, study their own execution traces and outputs,
 and act on findings — closing the loop every day. The name follows Toyota Kata:
 agents grasp the current condition (via prior-run traces), establish target
 conditions (via specs), and experiment toward them (via implementation). Six
-agent personas, eight workflows, fifteen skills form this cycle.
+agent personas, eight workflows, eighteen skills form this cycle.
 
 This page is the internal-contributor entry point. The canonical reference is
 [`KATA.md`](https://github.com/forwardimpact/monorepo/blob/main/KATA.md) at the
@@ -172,12 +172,12 @@ shared memory mechanics by
 
 ## Metrics
 
-Agents record time-series data to `wiki/metrics/{agent}/{domain}/{YYYY}.csv`
+Agents record time-series data to `wiki/metrics/{skill}/{YYYY}.csv`
 after each run. The CSV schema (six fields: date, metric, value, unit, run,
 note), storage convention, and metric design are documented in KATA.md § Metrics.
 The storyboard meeting answers "what is the actual condition now?" with numbers,
-not narratives, and XmR process behavior charts (`fit-xmr`) distinguish stable
-processes from special-cause reactions.
+not narratives, and XmR process behavior charts distinguish stable processes
+from special-cause reactions.
 
 ---
 

--- a/websites/fit/docs/libraries/wiki-operations/index.md
+++ b/websites/fit/docs/libraries/wiki-operations/index.md
@@ -1,0 +1,93 @@
+---
+title: Wiki Operations
+description: Send cross-team observations and manage wiki markers with fit-wiki.
+---
+
+# Wiki Operations
+
+`fit-wiki` is the operational CLI for agent wiki lifecycle management. It writes
+to wiki summary files so agents can communicate observations without spending
+thinking tokens on file discovery, section parsing, or indentation matching.
+
+## Getting Started
+
+```sh
+npx fit-wiki --help
+npx fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"
+```
+
+## Sending a Memo
+
+The `memo` command appends a timestamped observation to a teammate's wiki
+summary, directly after the `<!-- memo:inbox -->` marker in the "Observations
+for Teammates" section.
+
+```sh
+# Single target
+npx fit-wiki memo --from technical-writer --to staff-engineer --message "check baseline"
+
+# Broadcast to all agents
+npx fit-wiki memo --from technical-writer --to all --message "new XmR baseline"
+```
+
+### Options
+
+| Flag          | Required | Description                                                            |
+| ------------- | -------- | ---------------------------------------------------------------------- |
+| `--from`      | No       | Sender name (falls back to `LIBEVAL_AGENT_PROFILE` env var)            |
+| `--to`        | Yes      | Target agent name, or `all` to broadcast                               |
+| `--message`   | Yes      | Observation text                                                       |
+| `--wiki-root` | No       | Override wiki root directory (default: auto-detected from project root) |
+
+### Bullet Format
+
+Each memo is inserted as a single markdown bullet directly after the marker:
+
+```markdown
+- 2026-05-02 **staff-engineer**: audit d642ff0c
+```
+
+Newest memos appear first within the section. Multi-line messages are collapsed
+to a single line.
+
+## The Marker Contract
+
+Each agent summary must contain exactly one `<!-- memo:inbox -->` HTML comment
+directly under the `## Observations for Teammates` heading:
+
+```markdown
+## Observations for Teammates
+
+<!-- memo:inbox -->
+
+- 2026-05-02 **staff-engineer**: audit d642ff0c
+```
+
+The marker is invisible in rendered markdown and anchors all `fit-wiki memo`
+writes. If the marker is absent, the command exits 2 with a diagnostic.
+
+## Programmatic API
+
+```js
+import { writeMemo, listAgents, insertMarkers } from "@forwardimpact/libwiki";
+
+// Append a single memo
+const result = writeMemo({
+  summaryPath: "wiki/staff-engineer.md",
+  sender: "technical-writer",
+  message: "audit d642ff0c",
+  today: "2026-05-02",
+});
+
+// Discover all agents
+const agents = listAgents({
+  agentsDir: ".claude/agents",
+  wikiRoot: "wiki",
+});
+
+// Ensure all summaries have the marker (idempotent)
+const migration = insertMarkers({
+  agentsDir: ".claude/agents",
+  wikiRoot: "wiki",
+});
+```


### PR DESCRIPTION
## Summary

- New `@forwardimpact/libwiki` package with `fit-wiki memo` CLI — appends cross-team observations to wiki summaries via a `<!-- memo:inbox -->` marker
- New `fit-xmr record` command on `@forwardimpact/libxmr` — appends a metric CSV row to the per-skill flat path and prints a one-line XmR summary
- `fit-eval` env var plumbing: `LIBEVAL_AGENT_PROFILE` (from `--agent-profile`) and `LIBEVAL_SKILL` (from Skill tool_use trace events) as CLI fallbacks
- Migration scripts for marker insertion (6 summaries) and metrics consolidation (211 rows, 11 per-agent/domain CSVs → 11 per-skill CSVs)
- Protocol docs, templates, and skill instructions updated to flat metrics path (`wiki/metrics/{skill}/`); storyboard template headings simplified

## Spec

Implements [spec 770](specs/770-agent-tooling-memo-metric/spec.md) per [plan-a](specs/770-agent-tooling-memo-metric/plan-a.md).

**Note:** `kata-metrics` and `kata-trace` skill docs were intentionally left unchanged — they will soon be removed.

## Test plan

- [x] `bun run check` passes (format + lint)
- [x] `bun run test` passes (2694 tests, 0 failures)
- [x] Spec criterion #7 grep gate: zero `{domain}` matches in memory-protocol, storyboard-template, libxmr, libwiki
- [x] Criterion #8: storyboard template uses `### {agent}` headings
- [x] Criterion #9: memory-protocol documents `<!-- memo:inbox -->` marker
- [x] Criterion #5: all 6 agent summaries contain exactly one marker
- [x] Criterion #6: all 211 metric rows preserved in per-skill structure
- [x] 5-reviewer panel review completed; all findings verified and addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)