### PR TITLE
design(780): wiki lifecycle commands

### DIFF
--- a/specs/780-wiki-lifecycle-commands/design-a.md
+++ b/specs/780-wiki-lifecycle-commands/design-a.md
@@ -29,7 +29,7 @@ graph LR
 | `MarkerScanner`          | libwiki | Parse a markdown file; return `[{metric, csvPath, openLine, closeLine}]` for each `<!-- xmr:metric:path -->` … `<!-- /xmr -->` pair.                            |
 | `BlockRenderer`          | libwiki | Given metric + csvPath, call `libxmr.analyze`, filter to the metric, format the `**Latest:** … **Status:** …` line, fenced chart, and `**Signals:** …` line.   |
 | `refresh` command        | libwiki | Orchestrates `MarkerScanner` and `BlockRenderer` over a storyboard file; produces a single rewrite with all owned spans replaced.                                |
-| `WikiRepo`                | libwiki | Wrap the `./wiki/` git working tree. Methods: `ensureCloned(url)`, `pull()`, `commitAndPush(message)`, `isClean()`. Owns credential helper + identity inheritance. |
+| `WikiRepo`                | libwiki | Wrap the `./wiki/` git working tree. Methods: `ensureCloned(url)`, `pull()`, `commitAndPush(message)`, `isClean()` (used by `push` to short-circuit when no local changes — criterion #7). Owns credential helper + identity inheritance. |
 | `SkillRoster`            | libwiki | Discover the skills in the installation; derive `wiki/metrics/<skill>/` paths.                                                                                   |
 | `init` command           | libwiki | `WikiRepo.ensureCloned` for the wiki URL; for each `SkillRoster` entry create `wiki/metrics/<skill>/`. Idempotent.                                              |
 | `push` / `pull` commands | libwiki | One-line wrappers over `WikiRepo.commitAndPush` / `WikiRepo.pull`.                                                                                              |
@@ -135,6 +135,11 @@ sequenceDiagram
   `bunx fit-wiki push` underneath.
 - Existing `scripts/wiki-sync.sh` and `scripts/wiki-audit.sh` remain in the
   repo — superseded but not deleted (per spec § Scope (out)).
+- Spec § Scope 4 lists protocol/template/skill text updates
+  (`storyboard-template.md`, `team-storyboard.md`, `kata-session/SKILL.md`,
+  `justfile`) and an existing-storyboard migration. These are content edits,
+  not architectural components, and are owned by the plan rather than this
+  design.
 
 ## Risks
 

--- a/specs/780-wiki-lifecycle-commands/design-a.md
+++ b/specs/780-wiki-lifecycle-commands/design-a.md
@@ -28,9 +28,9 @@ graph LR
 | ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MarkerScanner`          | libwiki | Parse a markdown file; return `[{metric, csvPath, openLine, closeLine}]` for each `<!-- xmr:metric:path -->` … `<!-- /xmr -->` pair.                            |
 | `BlockRenderer`          | libwiki | Given metric + csvPath, call `libxmr.analyze`, filter to the metric, format the `**Latest:** … **Status:** …` line, fenced chart, and `**Signals:** …` line.   |
-| `refresh` command        | libwiki | Read storyboard → scan → render each block → splice between marker line indices → single atomic write.                                                           |
+| `refresh` command        | libwiki | Orchestrates `MarkerScanner` and `BlockRenderer` over a storyboard file; produces a single rewrite with all owned spans replaced.                                |
 | `WikiRepo`                | libwiki | Wrap the `./wiki/` git working tree. Methods: `ensureCloned(url)`, `pull()`, `commitAndPush(message)`, `isClean()`. Owns credential helper + identity inheritance. |
-| `SkillRoster`            | libwiki | Discover skills by globbing `.claude/skills/kata-*/SKILL.md`; derive `wiki/metrics/<skill>/` paths.                                                              |
+| `SkillRoster`            | libwiki | Discover the skills in the installation; derive `wiki/metrics/<skill>/` paths.                                                                                   |
 | `init` command           | libwiki | `WikiRepo.ensureCloned` for the wiki URL; for each `SkillRoster` entry create `wiki/metrics/<skill>/`. Idempotent.                                              |
 | `push` / `pull` commands | libwiki | One-line wrappers over `WikiRepo.commitAndPush` / `WikiRepo.pull`.                                                                                              |
 
@@ -51,8 +51,11 @@ contract:
   `refresh` and are replaced wholesale. The marker lines themselves and the
   preceding `#### {metric_name}` heading are preserved.
 - **Generated content.** Three parts in order: `**Latest:** {value} ·
-  **Status:** {status}` line, blank line, fenced 14-line chart from
+  **Status:** {status}` line, blank line, fenced chart from
   `libxmr.renderChart`, blank line, `**Signals:** {rules or "—"}` line.
+  `{status}` is the value libxmr returns verbatim
+  (`predictable | signals_present | insufficient_data`); no statuses are
+  invented in this layer.
 
 ## Refresh flow
 
@@ -78,10 +81,9 @@ sequenceDiagram
 - **No-op on no markers.** When `MarkerScanner` returns empty, skip the
   write entirely (`git diff` empty, criterion #3).
 - **Idempotent.** Output is a pure function of the storyboard markers and
-  the referenced CSV contents (criterion #2).
-- **Insufficient data.** When `analyze` reports `n < MIN_POINTS`,
-  `BlockRenderer` emits the Latest/Status line with `status=insufficient_data`
-  and skips the chart fence. The marker pair survives.
+  the referenced CSV contents (criterion #2). `BlockRenderer` defers all
+  status semantics — including low-N behaviour — to `libxmr.analyze` and
+  `libxmr.renderChart`.
 
 ## Init / push / pull flow
 
@@ -99,18 +101,10 @@ sequenceDiagram
   Repo-->>CLI: result
 ```
 
-- **Credential helper.** When `GITHUB_TOKEN` or `GH_TOKEN` is set,
-  `WikiRepo` adds `-c credential.helper=…` to each `git` invocation so the
-  token never lands in `.git/config` (matches `wiki-sync.sh`'s `auth_git`).
 - **Wiki URL.** Derived from the parent repo's `origin` URL by appending
-  `.wiki.git`. `init --wiki-url` overrides for forks.
-- **Identity.** On first call `WikiRepo` copies `user.name` and `user.email`
-  from the parent repo's `git config` into `wiki/.git/config`.
-- **Push conflict policy.** On rebase failure during `commitAndPush`, fall
-  back to `git merge origin/master -X ours --no-edit` (local-wins, matches
-  existing `wiki-sync.sh` push semantics).
-- **Pull conflict policy.** On rebase failure during `pull`, abort and exit
-  non-zero with a diagnostic line. Matches existing `wiki-sync.sh pull`.
+  `.wiki.git`.
+- See decisions W2–W3 and W5 below for credential, push-conflict, and
+  pull-conflict policies; I3 covers identity inheritance.
 
 ## Key decisions
 
@@ -124,9 +118,10 @@ sequenceDiagram
 | W1  | Git operations                  | Shell out to system `git` via `child_process.spawn`.                                                                                                               | Use isomorphic-git — 1.5 MB dependency and a second git implementation; existing `wiki-sync.sh` behaviour is already specified in terms of system git.                |
 | W2  | Credential injection            | Inline `-c credential.helper=…` per call.                                                                                                                          | Write token to `.git/config` — leaks credentials onto disk and persists across sessions.                                                                                |
 | W3  | Push conflict policy            | Local wins via `merge -X ours` after rebase failure.                                                                                                               | Hard-fail on conflict — wiki writes are streaming agent output; failing push aborts the whole session. Local-wins matches the wiki's role as agent-authored memory.   |
-| W4  | Wiki URL discovery              | Derive from parent repo's `origin` + `.wiki.git`. `--wiki-url` flag overrides.                                                                                     | Hardcode the monorepo URL — kills portability to downstream Kata installations (the spec's central goal).                                                              |
-| I1  | Skill discovery for init        | Glob `.claude/skills/kata-*/SKILL.md`; derive skill name from directory basename.                                                                                  | Hardcoded list — edit every time a skill is added. Glob `wiki/metrics/*/` — circular (the directory may not exist yet on first init).                                  |
-| I2  | Empty-directory persistence     | Skip placeholder files. `record` creates the directory on demand if missing.                                                                                       | Drop a `.gitkeep` per skill — clutters the wiki with zero-content files; `record`'s `mkdirSync(..., {recursive:true})` already handles missing directories.            |
+| W4  | Wiki URL discovery              | Derive from parent repo's `origin` + `.wiki.git`.                                                                                                                  | Hardcode the monorepo URL — kills portability to downstream Kata installations (the spec's central goal).                                                              |
+| W5  | Pull conflict policy            | Abort the rebase and exit non-zero with a diagnostic line — matches `wiki-sync.sh pull`.                                                                          | Auto-resolve in favour of remote — silently overwrites locally drafted memos that have not yet been pushed.                                                            |
+| I1  | Skill discovery for init        | Enumerate the installed kata skills under `.claude/skills/`; derive directory names from their slugs.                                                              | Hardcoded list — edit every time a skill is added. Glob `wiki/metrics/*/` — circular (the directory may not exist yet on first init).                                  |
+| I2  | Empty-directory persistence     | Skip placeholder files. `record` creates the directory on demand if missing.                                                                                       | Drop a `.gitkeep` per skill — clutters the wiki with zero-content files; on-demand creation is already supported.                                                       |
 | I3  | Identity source                 | Inherit from parent repo's `git config user.name/email`.                                                                                                           | CLI flags for identity — agents would replumb identity through every command; the parent repo already declares it.                                                    |
 
 ## Boundaries
@@ -145,8 +140,8 @@ sequenceDiagram
 
 | Risk                                                                            | Mitigation                                                                                                                                                                            |
 | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `libxmr.analyze` throws on a malformed CSV during refresh, aborting the file.   | `BlockRenderer` catches per-block; on failure emits `**Status:** error: <msg>` between the markers and continues. The marker pair survives so the next refresh retries cleanly.       |
+| `libxmr.analyze` throws on a malformed CSV during refresh, aborting the file.   | `BlockRenderer` catches per-block; on failure leaves the existing block contents untouched and prints `refresh-error <file:line> <reason>` to stderr. The marker pair survives so the next refresh retries cleanly. |
 | Unmatched open marker without a `<!-- /xmr -->`.                                | `MarkerScanner` skips the unmatched open, prints a `dangling-marker file:line` warning to stderr, and continues with the well-formed pairs. Refresh exit code stays 0.                |
 | Credentials missing in non-CI use.                                              | `WikiRepo` falls back to plain `git` (anonymous). For a private wiki, the underlying `git` call fails with its own message — the credential helper is additive, not required.        |
 | Skill set drifts between `init` time and runtime.                               | `record` already calls `mkdirSync(..., {recursive:true})` — new skills materialize their directory on first use. Init pre-creates the known set; drift is self-healing.              |
-| Two agents push to the wiki concurrently.                                       | `WikiRepo.commitAndPush` re-fetches and rebases on every call; conflict path falls through to `merge -X ours`. Same race characteristics as today's `wiki-sync.sh` (per spec design). |
+| Two agents push to the wiki concurrently.                                       | `WikiRepo.commitAndPush` re-fetches and rebases on every call; conflict path falls through to `merge -X ours`. Same race characteristics as today's `wiki-sync.sh`.                   |

--- a/specs/780-wiki-lifecycle-commands/design-a.md
+++ b/specs/780-wiki-lifecycle-commands/design-a.md
@@ -1,0 +1,152 @@
+# Design A — Spec 780 Wiki lifecycle commands
+
+## Architecture
+
+Spec 780 extends the `fit-wiki` CLI (introduced in spec 770) with three
+operational subcommands. Each subcommand is a thin orchestrator over a small
+component owned by `libwiki`. `refresh` is the only command with a new
+cross-library edge — it depends on `libxmr` for analyze + chart rendering.
+`init`, `push`, and `pull` operate purely on the wiki git working tree.
+
+```mermaid
+graph LR
+  CLI[fit-wiki CLI] --> Refresh[refresh command]
+  CLI --> Init[init command]
+  CLI --> Sync[push / pull commands]
+  Refresh --> Scanner[MarkerScanner]
+  Refresh --> Renderer[BlockRenderer]
+  Renderer -->|analyze + renderChart| Libxmr[(libxmr)]
+  Init --> WikiRepo
+  Init --> SkillRoster
+  Sync --> WikiRepo
+  WikiRepo -->|spawn git| Git[(git binary)]
+```
+
+## Components
+
+| Component                | Package | Responsibility                                                                                                                                                  |
+| ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MarkerScanner`          | libwiki | Parse a markdown file; return `[{metric, csvPath, openLine, closeLine}]` for each `<!-- xmr:metric:path -->` … `<!-- /xmr -->` pair.                            |
+| `BlockRenderer`          | libwiki | Given metric + csvPath, call `libxmr.analyze`, filter to the metric, format the `**Latest:** … **Status:** …` line, fenced chart, and `**Signals:** …` line.   |
+| `refresh` command        | libwiki | Read storyboard → scan → render each block → splice between marker line indices → single atomic write.                                                           |
+| `WikiRepo`                | libwiki | Wrap the `./wiki/` git working tree. Methods: `ensureCloned(url)`, `pull()`, `commitAndPush(message)`, `isClean()`. Owns credential helper + identity inheritance. |
+| `SkillRoster`            | libwiki | Discover skills by globbing `.claude/skills/kata-*/SKILL.md`; derive `wiki/metrics/<skill>/` paths.                                                              |
+| `init` command           | libwiki | `WikiRepo.ensureCloned` for the wiki URL; for each `SkillRoster` entry create `wiki/metrics/<skill>/`. Idempotent.                                              |
+| `push` / `pull` commands | libwiki | One-line wrappers over `WikiRepo.commitAndPush` / `WikiRepo.pull`.                                                                                              |
+
+The dependency graph stays a tree: `libwiki → libxmr`, `libwiki → libutil`
+(Finder, reused from `memo`). `libxmr` does not import `libwiki`.
+
+## Marker contract
+
+Spec § Scope 1 fixes the marker shape; the design pins the concrete
+contract:
+
+- **Token order.** `xmr:<metric>:<path>` — metric first (primary identifier),
+  CSV path second (locator). Single colon separator.
+- **Path format.** Relative to the project root (resolved via `Finder`),
+  forward-slash separated. Example:
+  `<!-- xmr:findings_count:wiki/metrics/kata-security-audit/2026.csv -->`.
+- **Owned span.** Lines strictly between open and close markers belong to
+  `refresh` and are replaced wholesale. The marker lines themselves and the
+  preceding `#### {metric_name}` heading are preserved.
+- **Generated content.** Three parts in order: `**Latest:** {value} ·
+  **Status:** {status}` line, blank line, fenced 14-line chart from
+  `libxmr.renderChart`, blank line, `**Signals:** {rules or "—"}` line.
+
+## Refresh flow
+
+```mermaid
+sequenceDiagram
+  participant CLI as fit-wiki refresh
+  participant FS as filesystem
+  participant Lib as libxmr
+  CLI->>FS: read storyboard
+  CLI->>CLI: MarkerScanner → blocks
+  loop per block (bottom-up)
+    CLI->>FS: read csvPath
+    CLI->>Lib: analyze(csv); filter to metric
+    CLI->>Lib: renderChart for the metric
+    CLI->>CLI: BlockRenderer formats Latest/Chart/Signals
+    CLI->>CLI: splice into line buffer
+  end
+  CLI->>FS: write storyboard once
+```
+
+- **Single read + single write.** Splicing is bottom-up (highest open-line
+  first) so earlier line indices remain valid throughout the loop.
+- **No-op on no markers.** When `MarkerScanner` returns empty, skip the
+  write entirely (`git diff` empty, criterion #3).
+- **Idempotent.** Output is a pure function of the storyboard markers and
+  the referenced CSV contents (criterion #2).
+- **Insufficient data.** When `analyze` reports `n < MIN_POINTS`,
+  `BlockRenderer` emits the Latest/Status line with `status=insufficient_data`
+  and skips the chart fence. The marker pair survives.
+
+## Init / push / pull flow
+
+`WikiRepo` shells out to system `git`, inheriting the credential pattern
+from `scripts/wiki-sync.sh`:
+
+```mermaid
+sequenceDiagram
+  participant CLI as fit-wiki <init|pull|push>
+  participant Repo as WikiRepo
+  participant Git as git binary
+  CLI->>Repo: ensureCloned() / pull() / commitAndPush()
+  Repo->>Git: spawn with inline credential helper
+  Git-->>Repo: stdout/stderr/exit
+  Repo-->>CLI: result
+```
+
+- **Credential helper.** When `GITHUB_TOKEN` or `GH_TOKEN` is set,
+  `WikiRepo` adds `-c credential.helper=…` to each `git` invocation so the
+  token never lands in `.git/config` (matches `wiki-sync.sh`'s `auth_git`).
+- **Wiki URL.** Derived from the parent repo's `origin` URL by appending
+  `.wiki.git`. `init --wiki-url` overrides for forks.
+- **Identity.** On first call `WikiRepo` copies `user.name` and `user.email`
+  from the parent repo's `git config` into `wiki/.git/config`.
+- **Push conflict policy.** On rebase failure during `commitAndPush`, fall
+  back to `git merge origin/master -X ours --no-edit` (local-wins, matches
+  existing `wiki-sync.sh` push semantics).
+- **Pull conflict policy.** On rebase failure during `pull`, abort and exit
+  non-zero with a diagnostic line. Matches existing `wiki-sync.sh pull`.
+
+## Key decisions
+
+| #   | Choice                          | Decision                                                                                                                                                          | Rejected alternative                                                                                                                                                    |
+| --- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | Marker token order              | `xmr:<metric>:<path>` — metric first.                                                                                                                              | `xmr:<path>:<metric>` — reads as a file locator with metric appended; metric-first foregrounds the primary identifier.                                                 |
+| R2  | Block parser                    | Line-based scan for the two literal comment patterns.                                                                                                              | Full markdown AST — pulls a parser into libwiki for one regex-equivalent task; the marker is unambiguous on its own line.                                              |
+| R3  | Chart rendering source          | Reuse `libxmr.analyze` + `libxmr.renderChart` unchanged.                                                                                                           | Reimplement chart formatting in libwiki — duplicates the canonical 14-line chart logic and risks drift between `fit-xmr chart` and `fit-wiki refresh` output.          |
+| R4  | Splicing direction              | Bottom-up (highest open-line index first).                                                                                                                         | Top-down — every splice shifts subsequent indices and forces a re-scan after each block.                                                                                |
+| R5  | Path resolution                 | CSV path in marker is relative to the project root; `Finder.findProjectRoot` joins it (matches `memo` and `record`).                                              | Absolute paths in markers — unportable across clones and CI runners. Wiki-relative paths — diverges from the agent-facing path everyone already types.                  |
+| W1  | Git operations                  | Shell out to system `git` via `child_process.spawn`.                                                                                                               | Use isomorphic-git — 1.5 MB dependency and a second git implementation; existing `wiki-sync.sh` behaviour is already specified in terms of system git.                |
+| W2  | Credential injection            | Inline `-c credential.helper=…` per call.                                                                                                                          | Write token to `.git/config` — leaks credentials onto disk and persists across sessions.                                                                                |
+| W3  | Push conflict policy            | Local wins via `merge -X ours` after rebase failure.                                                                                                               | Hard-fail on conflict — wiki writes are streaming agent output; failing push aborts the whole session. Local-wins matches the wiki's role as agent-authored memory.   |
+| W4  | Wiki URL discovery              | Derive from parent repo's `origin` + `.wiki.git`. `--wiki-url` flag overrides.                                                                                     | Hardcode the monorepo URL — kills portability to downstream Kata installations (the spec's central goal).                                                              |
+| I1  | Skill discovery for init        | Glob `.claude/skills/kata-*/SKILL.md`; derive skill name from directory basename.                                                                                  | Hardcoded list — edit every time a skill is added. Glob `wiki/metrics/*/` — circular (the directory may not exist yet on first init).                                  |
+| I2  | Empty-directory persistence     | Skip placeholder files. `record` creates the directory on demand if missing.                                                                                       | Drop a `.gitkeep` per skill — clutters the wiki with zero-content files; `record`'s `mkdirSync(..., {recursive:true})` already handles missing directories.            |
+| I3  | Identity source                 | Inherit from parent repo's `git config user.name/email`.                                                                                                           | CLI flags for identity — agents would replumb identity through every command; the parent repo already declares it.                                                    |
+
+## Boundaries
+
+- `libwiki → libxmr` is the only new cross-package edge. `libxmr` stays
+  unchanged for this spec.
+- `WikiRepo` depends on Node `child_process` only — no libxmr, no libutil.
+  It is a pure git wrapper, reusable beyond this spec.
+- The bootstrap composite action (`bootstrap/action.yml`) is unchanged. It
+  continues to call `just wiki-push`; the recipe is what flips to
+  `bunx fit-wiki push` underneath.
+- Existing `scripts/wiki-sync.sh` and `scripts/wiki-audit.sh` remain in the
+  repo — superseded but not deleted (per spec § Scope (out)).
+
+## Risks
+
+| Risk                                                                            | Mitigation                                                                                                                                                                            |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `libxmr.analyze` throws on a malformed CSV during refresh, aborting the file.   | `BlockRenderer` catches per-block; on failure emits `**Status:** error: <msg>` between the markers and continues. The marker pair survives so the next refresh retries cleanly.       |
+| Unmatched open marker without a `<!-- /xmr -->`.                                | `MarkerScanner` skips the unmatched open, prints a `dangling-marker file:line` warning to stderr, and continues with the well-formed pairs. Refresh exit code stays 0.                |
+| Credentials missing in non-CI use.                                              | `WikiRepo` falls back to plain `git` (anonymous). For a private wiki, the underlying `git` call fails with its own message — the credential helper is additive, not required.        |
+| Skill set drifts between `init` time and runtime.                               | `record` already calls `mkdirSync(..., {recursive:true})` — new skills materialize their directory on first use. Init pre-creates the known set; drift is self-healing.              |
+| Two agents push to the wiki concurrently.                                       | `WikiRepo.commitAndPush` re-fetches and rebases on every call; conflict path falls through to `merge -X ours`. Same race characteristics as today's `wiki-sync.sh` (per spec design). |

--- a/specs/780-wiki-lifecycle-commands/spec.md
+++ b/specs/780-wiki-lifecycle-commands/spec.md
@@ -49,8 +49,8 @@ regenerates the XmR chart and metadata for each marked metric block, and
 writes the updated content back to the file.
 
 - **Marker format.** Each metric block in the storyboard is bracketed by a
-  pair of HTML comments that name the CSV path and metric:
-  `<!-- xmr:wiki/metrics/<skill>/<YYYY>.csv:<metric_name> -->` before the
+  pair of HTML comments that name the metric and CSV path:
+  `<!-- xmr:<metric_name>:wiki/metrics/<skill>/<YYYY>.csv -->` before the
   block and `<!-- /xmr -->` after. Everything between the markers is
   regenerated on refresh.
 - **Generated content.** For each marker pair, `fit-wiki refresh` produces:
@@ -167,7 +167,7 @@ have no dependency on spec 770 and can be implemented independently.
 
 ### Marker format rationale
 
-The `<!-- xmr:path:metric -->` / `<!-- /xmr -->` pattern mirrors how static
+The `<!-- xmr:metric:path -->` / `<!-- /xmr -->` pattern mirrors how static
 site generators handle auto-generated sections (e.g., Hugo shortcodes,
 Jekyll includes). HTML comments are invisible in GitHub's markdown renderer,
 so the storyboard reads identically with or without markers. The closing

--- a/specs/780-wiki-lifecycle-commands/spec.md
+++ b/specs/780-wiki-lifecycle-commands/spec.md
@@ -28,7 +28,7 @@ monorepo's directory layout, token variables, and justfile recipes.
 
 **No portable initialization.** Setting up a wiki for a new Kata installation
 requires manually cloning the `.wiki.git` repo, creating the directory
-structure (`wiki/metrics/<agent>/`), and wiring hooks. There is no single
+structure (`wiki/metrics/<skill>/`), and wiring hooks. There is no single
 command that bootstraps a working wiki directory.
 
 ## Goal
@@ -50,7 +50,7 @@ writes the updated content back to the file.
 
 - **Marker format.** Each metric block in the storyboard is bracketed by a
   pair of HTML comments that name the CSV path and metric:
-  `<!-- xmr:wiki/metrics/<agent>/<YYYY>.csv:<metric_name> -->` before the
+  `<!-- xmr:wiki/metrics/<skill>/<YYYY>.csv:<metric_name> -->` before the
   block and `<!-- /xmr -->` after. Everything between the markers is
   regenerated on refresh.
 - **Generated content.** For each marker pair, `fit-wiki refresh` produces:
@@ -77,8 +77,8 @@ A subcommand that sets up a working wiki directory for a Kata installation.
 - **Clone.** Clones the repository's wiki into `./wiki/` if the directory does
   not already exist or is not a git repository. Authenticates using ambient
   GitHub credentials (`GITHUB_TOKEN` or `GH_TOKEN`).
-- **Directory creation.** Creates `wiki/metrics/<agent>/` directories for each
-  agent in the installation.
+- **Directory creation.** Creates `wiki/metrics/<skill>/` directories for each
+  skill in the installation.
 - **Identity.** Commits in the wiki repo are attributed to the same identity
   as the parent repository.
 - **Idempotent.** Running `init` on an already-initialized wiki is a no-op
@@ -155,11 +155,12 @@ distributed via npm.
 
 This spec extends the `libwiki` package and `fit-wiki` CLI introduced in spec
 770. Spec 770 delivers the package scaffold, `fit-wiki memo`, `fit-xmr
-record`, and the flat metrics directory structure. This spec adds `refresh`,
-`init`, `push`, and `pull`.
+record`, and the per-skill flat metrics directory structure
+(`wiki/metrics/<skill>/<YYYY>.csv`). This spec adds `refresh`, `init`, `push`,
+and `pull`.
 
 **Ordering constraint:** `fit-wiki refresh` markers reference the flat
-`wiki/metrics/<agent>/<YYYY>.csv` paths introduced by spec 770's migration.
+`wiki/metrics/<skill>/<YYYY>.csv` paths introduced by spec 770's migration.
 Spec 770's package scaffold and metrics migration must land before the
 `refresh` marker migration runs. The `init`, `push`, and `pull` subcommands
 have no dependency on spec 770 and can be implemented independently.
@@ -178,11 +179,11 @@ no need to guess where the chart ends by counting code fences.
 After specs 770 and 780, a downstream Kata installation's wiki lifecycle is:
 
 ```sh
-npx fit-wiki init                          # clone wiki, create directories
-npx fit-wiki memo --from se --to all "..."  # record cross-team observations
-npx fit-xmr record --agent se findings 0   # record a metric
-npx fit-wiki refresh wiki/storyboard.md    # regenerate XmR charts
-npx fit-wiki push                          # commit and sync
+npx fit-wiki init                                                              # clone wiki, create directories
+npx fit-wiki memo --from se --to all --message "..."                           # record cross-team observations
+npx fit-xmr record --skill kata-spec --metric findings --value 0               # record a metric
+npx fit-wiki refresh wiki/storyboard.md                                        # regenerate XmR charts
+npx fit-wiki push                                                              # commit and sync
 ```
 
 No shell scripts, no justfile, no composite actions. The entire workflow is


### PR DESCRIPTION
## Summary

- Aligns spec 780 with spec 770's implemented behaviour: per-skill metrics path (`wiki/metrics/<skill>/<YYYY>.csv`), `fit-xmr record --skill/--metric/--value` CLI surface, `fit-wiki memo --message` flag.
- Switches the `refresh` storyboard marker format to `<!-- xmr:<metric>:<path> -->` (metric first, path second).
- Adds `design-a.md` covering `MarkerScanner`, `BlockRenderer`, `WikiRepo`, `SkillRoster`, and the four new subcommands. The only new cross-library edge is `libwiki → libxmr` for `refresh`; `init`/`push`/`pull` operate purely on the wiki git working tree.

## Test plan

- [ ] Static review of `specs/780-wiki-lifecycle-commands/spec.md` for consistency with the merged spec 770 implementation.
- [ ] Static review of `specs/780-wiki-lifecycle-commands/design-a.md` against `kata-design` quality criteria (architecture-only, decisions name rejected alternatives, under 200 lines).
- [ ] Clean sub-agent review panel via `kata-review`.

https://claude.ai/code/session_01Ed4hcLKb5Xr2oaS57AxL3C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ed4hcLKb5Xr2oaS57AxL3C)_