### PR TITLE
refactor(libwiki): rename inbox section to Message Inbox

### DIFF
--- a/.claude/agents/references/coordination-protocol.md
+++ b/.claude/agents/references/coordination-protocol.md
@@ -158,6 +158,8 @@ The most frequent failure modes this protocol prevents — watch for these:
 - **Cross-cutting comments lost in PR threads.** A policy question raised on one
   PR but applicable to many should escalate to a Discussion, not stay buried in
   PR review.
-- **Agent-to-agent observations sent via wiki summary edits.** Use your own
-  summary's teammate-observations section, or address the agent by name ("Hey
-  Staff Engineer, …") in a thread; never edit another agent's summary.
+- **Agent-to-agent memos sent via direct edits to another summary.** Use
+  `fit-wiki memo --from <you> --to <recipient> --message "<text>"` so the
+  bullet lands under the recipient's `## Message Inbox` marker. Never
+  hand-edit another agent's summary — `fit-wiki memo` is the only supported
+  write path.

--- a/.claude/agents/references/memory-protocol.md
+++ b/.claude/agents/references/memory-protocol.md
@@ -68,8 +68,11 @@ open with a `### Decision` subheading containing:
 Update `wiki/{agent}.md` with:
 
 1. Actions taken
-2. Observations for teammates
-3. Open blockers
+2. Open blockers
+
+Read the `## Message Inbox` (top of the file) for incoming memos from
+teammates. To send observations to other agents, use `fit-wiki memo` rather
+than editing this file's inbox by hand.
 
 ## Summary Contract
 
@@ -79,12 +82,13 @@ Each `wiki/<agent>.md` conforms to a mechanically-checkable contract.
 
 1. `# {Agent Title} — Summary` (H1, exactly one)
 2. `**Last run**:` line — date and one-line description
-3. Agent-specific state section(s) using H2
-4. `## Open Blockers` — currently-blocking items only
-5. `## Observations for Teammates` — items not yet promoted to the priority
-   index; agent-to-agent callouts. Each section begins with the marker
-   `<!-- memo:inbox -->` directly under the heading; `fit-wiki memo` writes
-   new bullets immediately after it.
+3. `## Message Inbox` — incoming agent-to-agent callouts not yet promoted to
+   the priority index. Begins with the marker `<!-- memo:inbox -->` directly
+   under the heading; `fit-wiki memo` writes new bullets immediately after it.
+   Placed near the top so on-boot scanning surfaces it before state-heavy
+   sections.
+4. Agent-specific state section(s) using H2
+5. `## Open Blockers` — currently-blocking items only
 
 **Excluded from summaries** (with correct homes):
 

--- a/.claude/agents/references/memory-protocol.md
+++ b/.claude/agents/references/memory-protocol.md
@@ -63,16 +63,19 @@ open with a `### Decision` subheading containing:
 | **Chosen**       | What action was selected and which skill was invoked   |
 | **Rationale**    | Why this action over the alternatives                  |
 
-## After Each Run
+## Each Run
 
-Update `wiki/{agent}.md` with:
+Read the `## Message Inbox` (first H2 of the file) for incoming memos from
+teammates. Triage each before working: act on it, promote it to MEMORY.md, or
+remove if obsolete.
+
+After the run, update `wiki/{agent}.md` with:
 
 1. Actions taken
 2. Open blockers
 
-Read the `## Message Inbox` (top of the file) for incoming memos from
-teammates. To send observations to other agents, use `fit-wiki memo` rather
-than editing this file's inbox by hand.
+To send memos to other agents, use `fit-wiki memo --from <you> --to <recipient>
+--message "..."` rather than hand-editing any inbox.
 
 ## Summary Contract
 
@@ -81,14 +84,22 @@ Each `wiki/<agent>.md` conforms to a mechanically-checkable contract.
 **Permitted sections (in order):**
 
 1. `# {Agent Title} — Summary` (H1, exactly one)
-2. `**Last run**:` line — date and one-line description
-3. `## Message Inbox` — incoming agent-to-agent callouts not yet promoted to
-   the priority index. Begins with the marker `<!-- memo:inbox -->` directly
-   under the heading; `fit-wiki memo` writes new bullets immediately after it.
-   Placed near the top so on-boot scanning surfaces it before state-heavy
-   sections.
+2. `**Last run**:` line — date and one-line description (may be followed by
+   directly attached caveats or blockquotes about that run)
+3. `## Message Inbox` — incoming memos from teammates not yet promoted to
+   the priority index. **MUST be the first H2 in the file** so on-boot
+   scanning surfaces it before state-heavy sections. Begins with the marker
+   `<!-- memo:inbox -->` directly under the heading; `fit-wiki memo` writes
+   new bullets immediately after it (newest-first within the section). When
+   the inbox is empty, leave a single line `- *No new messages.*` under the
+   marker so the section reads cleanly.
 4. Agent-specific state section(s) using H2
 5. `## Open Blockers` — currently-blocking items only
+
+**Bullet format:** `- YYYY-MM-DD from **<sender>**: <message>`. The bold name
+is the SENDER; the file owner is the RECIPIENT. Newest memos sort first;
+undated legacy bullets (from the pre-`fit-wiki memo` migration) sort to the
+bottom of the section.
 
 **Excluded from summaries** (with correct homes):
 

--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -14,18 +14,18 @@ tokens on file discovery, section parsing, or indentation matching.
 
 ## When to Use
 
-- You observed something another agent should know about and want to record it
-  in their summary's "Observations for Teammates" section.
-- You want to broadcast an observation to every agent on the team.
+- You observed something another agent should know about and want to drop it
+  in their `## Message Inbox`.
+- You want to broadcast a message to every agent on the team.
 - You need to ensure all agent summaries have the `<!-- memo:inbox -->` marker
-  for machine-writable observations.
+  for machine-writable memos.
 
 ## Commands
 
 ### `memo` — Send a cross-team observation
 
 Appends a timestamped bullet to the target agent's wiki summary, directly after
-the `<!-- memo:inbox -->` marker in the "Observations for Teammates" section.
+the `<!-- memo:inbox -->` marker in their `## Message Inbox` section.
 
 ```sh
 npx fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"
@@ -52,9 +52,9 @@ line immediately following the marker (newest-first within the section).
 ### Marker contract
 
 Each agent summary must contain exactly one `<!-- memo:inbox -->` HTML comment
-directly under the `## Observations for Teammates` heading. The marker is
-invisible in rendered markdown and anchors `fit-wiki memo` writes. If the
-marker is absent, the command exits 2 with a diagnostic message.
+directly under the `## Message Inbox` heading. The marker is invisible in
+rendered markdown and anchors `fit-wiki memo` writes. If the marker is absent,
+the command exits 2 with a diagnostic message.
 
 ## Programmatic API
 

--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -1,46 +1,46 @@
 ---
 name: fit-wiki
 description: >
-  Manage the Kata agent team wiki: send cross-team observations (memos),
-  discover the agent roster, and migrate insertion markers. Use when an agent
-  needs to record an observation for a teammate or broadcast to all agents.
+  Manage the Kata agent team wiki: send cross-team memos, discover the agent
+  roster, and migrate insertion markers. Use when an agent needs to drop a
+  memo in a teammate's Message Inbox or broadcast to the whole team.
 ---
 
 # Wiki Operations
 
-`fit-wiki` is the operational CLI for the Kata agent wiki. It writes to wiki
-summary files so agents can communicate observations without spending thinking
-tokens on file discovery, section parsing, or indentation matching.
+`fit-wiki` is the operational CLI for the Kata agent wiki. It writes into
+teammates' inboxes so agents can communicate without spending thinking tokens
+on file discovery, section parsing, or indentation matching.
 
 ## When to Use
 
-- You observed something another agent should know about and want to drop it
-  in their `## Message Inbox`.
-- You want to broadcast a message to every agent on the team.
+- You have a memo for a teammate and want it to land in their
+  `## Message Inbox` so they read it on their next boot.
+- You want to broadcast a memo to every other agent on the team.
 - You need to ensure all agent summaries have the `<!-- memo:inbox -->` marker
   for machine-writable memos.
 
 ## Commands
 
-### `memo` — Send a cross-team observation
+### `memo` — Send a cross-team memo
 
-Appends a timestamped bullet to the target agent's wiki summary, directly after
-the `<!-- memo:inbox -->` marker in their `## Message Inbox` section.
+Appends a timestamped bullet to the target agent's `## Message Inbox`,
+directly after the `<!-- memo:inbox -->` marker.
 
 ```sh
 npx fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"
 npx fit-wiki memo --from technical-writer --to all --message "new XmR baseline"
 ```
 
-| Flag          | Required | Description                                                           |
-| ------------- | -------- | --------------------------------------------------------------------- |
-| `--from`      | No       | Sender name (falls back to `LIBEVAL_AGENT_PROFILE` env var)           |
-| `--to`        | Yes      | Target agent name, or `all` to broadcast to every agent               |
-| `--message`   | Yes      | Observation text                                                      |
+| Flag          | Required | Description                                                            |
+| ------------- | -------- | ---------------------------------------------------------------------- |
+| `--from`      | No       | Sender name (falls back to `LIBEVAL_AGENT_PROFILE` env var)            |
+| `--to`        | Yes      | Target agent name, or `all` to broadcast (sender is skipped)           |
+| `--message`   | Yes      | Memo text                                                              |
 | `--wiki-root` | No       | Override wiki root directory (default: auto-detected from project root) |
 
-The bullet format is `- YYYY-MM-DD **{sender}**: {message}`, inserted on the
-line immediately following the marker (newest-first within the section).
+The bullet format is `- YYYY-MM-DD from **{sender}**: {message}`, inserted on
+the line immediately following the marker (newest-first within the section).
 
 ### Exit codes
 
@@ -65,3 +65,8 @@ import { writeMemo, listAgents, insertMarkers } from "@forwardimpact/libwiki";
 - `writeMemo({ summaryPath, sender, message, today })` — append one bullet
 - `listAgents({ agentsDir, wikiRoot })` — discover agents from `.claude/agents/*.md`
 - `insertMarkers({ agentsDir, wikiRoot })` — idempotent marker insertion
+
+## Documentation
+
+- [Wiki Operations](https://www.forwardimpact.team/docs/libraries/wiki-operations/index.md) —
+  how to use `fit-wiki` to send memos and manage wiki markers.

--- a/.claude/skills/kata-documentation/SKILL.md
+++ b/.claude/skills/kata-documentation/SKILL.md
@@ -162,7 +162,7 @@ Append to the current week's log (see agent profile for the file path):
   (fixed/spec'd/deferred)
 - **Deferred work** — Issues needing follow-up with enough context to resume
 - **Accuracy errors** — Specific docs that diverged from source code
-- **Observations for teammates** — Callouts for agents whose work affects docs
+- **Memos sent** — Callouts dispatched via `fit-wiki memo` to agents whose work affects docs
 - **Metrics** — Record at least one measurement to
   `wiki/metrics/{skill}/` per the
   [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create

--- a/.claude/skills/kata-wiki-curate/SKILL.md
+++ b/.claude/skills/kata-wiki-curate/SKILL.md
@@ -123,7 +123,7 @@ agents or the whole team:
 
 The **required destination** is `wiki/MEMORY.md`'s `## Cross-Cutting Priorities`
 table. Add an entry with the schema (Item / Agents / Owner / Status / Added).
-Mirroring an item into an affected agent's `Observations for Teammates` is
+Mirroring an item into an affected agent's `Message Inbox` is
 **conditional** — only when the agent needs context beyond what the index entry
 conveys.
 

--- a/.claude/skills/kata-wiki-curate/SKILL.md
+++ b/.claude/skills/kata-wiki-curate/SKILL.md
@@ -27,11 +27,11 @@ Each run covers all four curation areas in sequence.
 | Area                    | What to check                                                  |
 | ----------------------- | -------------------------------------------------------------- |
 | `summary-accuracy`      | Each agent's summary matches their latest weekly log entries   |
-| `observation-follow-up` | "Observations for teammates" are acknowledged and acted on     |
+| `inbox-follow-up`       | `## Message Inbox` entries are acknowledged and acted on       |
 | `memory-index`          | MEMORY.md and Home.md list all agents, conventions are current |
 | `log-hygiene`           | Weekly logs use correct format, headings, ISO week conventions |
 
-If time-constrained, prioritize `summary-accuracy` and `observation-follow-up`.
+If time-constrained, prioritize `summary-accuracy` and `inbox-follow-up`.
 
 ## Process
 
@@ -71,17 +71,19 @@ For each agent, compare the summary against the most recent weekly log entries:
 
 Fix inaccuracies directly in the summary files.
 
-### Step 2: Observation follow-up
+### Step 2: Inbox follow-up
 
-Collect all "Observations for teammates" sections across all agent summaries.
-For each observation:
+Collect all `## Message Inbox` sections across all agent summaries. For each
+memo:
 
-1. Identify the target agent.
-2. Check the target agent's weekly logs after the observation date for
+1. The inbox is the recipient — this is the agent owning the file. The sender
+   is the bold name on the bullet (`- [date] **<sender>**: <text>`).
+2. Check the recipient agent's weekly logs after the memo date for
    acknowledgement or action.
-3. Flag observations older than 2 weeks with no visible response.
-4. Note unacted observations in the technical-writer's own summary so the target
-   agent sees them on their next run.
+3. Flag memos older than 2 weeks with no visible response.
+4. Re-send a fresh memo via `fit-wiki memo --from technical-writer --to
+   <recipient> --message "<flag text>"` so the recipient sees the nudge on
+   their next run.
 
 ### Step 3: Memory index
 
@@ -155,9 +157,9 @@ Append to the current week's log (see agent profile for the file path):
 
 - **Areas curated** — Which areas checked
 - **Summary corrections** — Which agent summaries were updated and why
-- **Stale observations** — Teammate observations >2 weeks old with no response
+- **Stale memos** — Inbox entries >2 weeks old with no response
 - **MEMORY.md changes** — What was added/updated
-- **Observations for teammates** — Specific callouts based on wiki findings
+- **Memos sent** — Specific callouts dispatched via `fit-wiki memo`
 - **Metrics** — Record at least one measurement to
   `wiki/metrics/{skill}/` per the
   [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -129,7 +129,6 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 | I need to…                                                                     | Library              |
 | ------------------------------------------------------------------------------ | -------------------- |
 | Add a distributed trace span (OpenTelemetry-style observability)               | `libtelemetry`       |
-| Append a cross-team observation to a wiki summary                              | `libwiki`            |
 | Assemble a macOS app bundle                                                    | `libmacos`           |
 | Buffer high-volume index writes                                                | `libindex`           |
 | Build a gRPC service                                                           | `librpc`             |
@@ -182,6 +181,7 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 | Run an interactive REPL session                                                | `librepl`            |
 | Run the end-to-end synthetic-data pipeline from a terrain file                 | `libterrain`         |
 | Score a candidate's skills against a job's required skill markers              | `libskill`           |
+| Send a cross-team memo to a teammate's wiki inbox                              | `libwiki`            |
 | Serialize SHACL shapes                                                         | `libgraph`           |
 | Sign a JWT                                                                     | `libsecret`          |
 | Store files to local, S3, or Supabase                                          | `libstorage`         |

--- a/libraries/libwiki/README.md
+++ b/libraries/libwiki/README.md
@@ -17,7 +17,8 @@ import { writeMemo, listAgents, insertMarkers } from "@forwardimpact/libwiki";
 ## Key Exports
 
 - `writeMemo({ summaryPath, sender, message, today })` — append a timestamped
-  observation bullet after the `<!-- memo:inbox -->` marker in a wiki summary.
+  bullet after the `<!-- memo:inbox -->` marker in a wiki summary's
+  `## Message Inbox` section.
 - `listAgents({ agentsDir, wikiRoot })` — discover agents from
   `.claude/agents/*.md` and derive wiki summary paths.
 - `insertMarkers({ agentsDir, wikiRoot })` — idempotent insertion of the memo

--- a/libraries/libwiki/bin/fit-wiki.js
+++ b/libraries/libwiki/bin/fit-wiki.js
@@ -16,8 +16,7 @@ const definition = {
   commands: [
     {
       name: "memo",
-      description:
-        "Append a cross-team observation to a teammate's wiki summary",
+      description: "Send a cross-team memo into a teammate's Message Inbox",
       options: {
         from: {
           type: "string",
@@ -27,11 +26,11 @@ const definition = {
         to: {
           type: "string",
           description:
-            'Target agent name, or "all" to broadcast to every agent',
+            'Target agent name, or "all" to broadcast (sender is skipped)',
         },
         message: {
           type: "string",
-          description: "Observation text",
+          description: "Memo text",
         },
         "wiki-root": {
           type: "string",
@@ -57,7 +56,7 @@ const definition = {
       title: "Wiki Operations",
       url: "https://www.forwardimpact.team/docs/libraries/wiki-operations/index.md",
       description:
-        "Send cross-team observations, discover agents, and manage wiki markers.",
+        "Send cross-team memos, discover agents, and manage wiki markers.",
     },
   ],
 };

--- a/libraries/libwiki/package.json
+++ b/libraries/libwiki/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "wiki",
     "memo",
-    "observation",
+    "inbox",
     "agent"
   ],
   "homepage": "https://www.forwardimpact.team",
@@ -19,7 +19,7 @@
   "forwardimpact": {
     "capability": "agent-self-improvement",
     "needs": [
-      "Append a cross-team observation to a wiki summary"
+      "Send a cross-team memo to a teammate's wiki inbox"
     ]
   },
   "type": "module",

--- a/libraries/libwiki/src/commands/memo.js
+++ b/libraries/libwiki/src/commands/memo.js
@@ -45,7 +45,8 @@ export function runMemoCommand(values, _args, cli) {
 
   if (values.to === BROADCAST_TARGET) {
     const agents = listAgents({ agentsDir, wikiRoot });
-    for (const { summaryPath } of agents) {
+    for (const { agent, summaryPath } of agents) {
+      if (agent === sender) continue;
       writeAndCheck(summaryPath, sender, values.message, today);
     }
   } else {

--- a/libraries/libwiki/src/constants.js
+++ b/libraries/libwiki/src/constants.js
@@ -1,3 +1,3 @@
 export const MEMO_INBOX_MARKER = "<!-- memo:inbox -->";
-export const OBSERVATIONS_HEADING = "## Observations for Teammates";
+export const INBOX_HEADING = "## Message Inbox";
 export const BROADCAST_TARGET = "all";

--- a/libraries/libwiki/src/index.js
+++ b/libraries/libwiki/src/index.js
@@ -3,6 +3,6 @@ export { listAgents } from "./agent-roster.js";
 export { insertMarkers } from "./marker-migrator.js";
 export {
   MEMO_INBOX_MARKER,
-  OBSERVATIONS_HEADING,
+  INBOX_HEADING,
   BROADCAST_TARGET,
 } from "./constants.js";

--- a/libraries/libwiki/src/marker-migrator.js
+++ b/libraries/libwiki/src/marker-migrator.js
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync } from "node:fs";
-import { MEMO_INBOX_MARKER, OBSERVATIONS_HEADING } from "./constants.js";
+import { MEMO_INBOX_MARKER, INBOX_HEADING } from "./constants.js";
 import { listAgents } from "./agent-roster.js";
 
 export function insertMarkers(
@@ -21,7 +21,7 @@ export function insertMarkers(
 
     const lines = content.split("\n");
     const headingIndex = lines.findIndex(
-      (line) => line.trim() === OBSERVATIONS_HEADING,
+      (line) => line.trim() === INBOX_HEADING,
     );
 
     if (headingIndex === -1) {

--- a/libraries/libwiki/src/memo-writer.js
+++ b/libraries/libwiki/src/memo-writer.js
@@ -17,7 +17,7 @@ export function writeMemo(
   }
 
   const flatMessage = message.replace(/\n/g, " ");
-  const bullet = `- ${today} **${sender}**: ${flatMessage}`;
+  const bullet = `- ${today} from **${sender}**: ${flatMessage}`;
 
   lines.splice(markerIndex + 1, 0, bullet);
   fs.writeFileSync(summaryPath, lines.join("\n"));

--- a/libraries/libwiki/test/cli-memo.test.js
+++ b/libraries/libwiki/test/cli-memo.test.js
@@ -77,10 +77,16 @@ describe("fit-wiki memo CLI", () => {
     assert.ok(stdout.includes("wrote"));
 
     const content = readFileSync(join(wikiRoot, "staff-engineer.md"), "utf-8");
-    assert.ok(content.includes("**technical-writer**: audit d642ff0c"));
+    assert.ok(content.includes("from **technical-writer**: audit d642ff0c"));
   });
 
-  test("broadcast writes to every agent", () => {
+  test("broadcast writes to every agent except sender", () => {
+    writeFileSync(join(agentsDir, "technical-writer.md"), "# TW");
+    writeFileSync(
+      join(wikiRoot, "technical-writer.md"),
+      `# TW\n\n## Message Inbox\n\n${MEMO_INBOX_MARKER}\n`,
+    );
+
     run([
       "memo",
       "--from",
@@ -93,8 +99,10 @@ describe("fit-wiki memo CLI", () => {
 
     const se = readFileSync(join(wikiRoot, "staff-engineer.md"), "utf-8");
     const pm = readFileSync(join(wikiRoot, "product-manager.md"), "utf-8");
+    const tw = readFileSync(join(wikiRoot, "technical-writer.md"), "utf-8");
     assert.ok(se.includes("check baselines"));
     assert.ok(pm.includes("check baselines"));
+    assert.ok(!tw.includes("check baselines"), "sender's own inbox skipped");
   });
 
   test("missing-marker exits 2", () => {
@@ -140,7 +148,7 @@ describe("fit-wiki memo CLI", () => {
     assert.ok(stdout.includes("wrote"));
 
     const content = readFileSync(join(wikiRoot, "staff-engineer.md"), "utf-8");
-    assert.ok(content.includes("**security-engineer**: env test"));
+    assert.ok(content.includes("from **security-engineer**: env test"));
   });
 
   test("exits 2 when neither --from nor env var set", () => {

--- a/libraries/libwiki/test/cli-memo.test.js
+++ b/libraries/libwiki/test/cli-memo.test.js
@@ -27,11 +27,11 @@ describe("fit-wiki memo CLI", () => {
 
     writeFileSync(
       join(wikiRoot, "staff-engineer.md"),
-      `# Staff Engineer\n\n## Observations for Teammates\n\n${MEMO_INBOX_MARKER}\n\n- old bullet\n`,
+      `# Staff Engineer\n\n## Message Inbox\n\n${MEMO_INBOX_MARKER}\n\n- old bullet\n`,
     );
     writeFileSync(
       join(wikiRoot, "product-manager.md"),
-      `# PM\n\n## Observations for Teammates\n\n${MEMO_INBOX_MARKER}\n\n- old bullet\n`,
+      `# PM\n\n## Message Inbox\n\n${MEMO_INBOX_MARKER}\n\n- old bullet\n`,
     );
 
     savedEnv = { ...process.env };
@@ -100,7 +100,7 @@ describe("fit-wiki memo CLI", () => {
   test("missing-marker exits 2", () => {
     writeFileSync(
       join(wikiRoot, "staff-engineer.md"),
-      "# SE\n\n## Observations for Teammates\n\n- no marker\n",
+      "# SE\n\n## Message Inbox\n\n- no marker\n",
     );
 
     const { status, stderr } = runFail([

--- a/libraries/libwiki/test/marker-migrator.test.js
+++ b/libraries/libwiki/test/marker-migrator.test.js
@@ -25,7 +25,7 @@ describe("insertMarkers", () => {
   test("inserts marker on first run", () => {
     const { agentsDir, wikiRoot } = setup({
       "staff-engineer":
-        "# Staff Engineer\n\n## Observations for Teammates\n\n- existing bullet\n",
+        "# Staff Engineer\n\n## Message Inbox\n\n- existing bullet\n",
     });
 
     const result = insertMarkers({ agentsDir, wikiRoot });
@@ -41,7 +41,7 @@ describe("insertMarkers", () => {
   test("skips on second run (idempotent)", () => {
     const { agentsDir, wikiRoot } = setup({
       "staff-engineer":
-        "# Staff Engineer\n\n## Observations for Teammates\n\n- existing bullet\n",
+        "# Staff Engineer\n\n## Message Inbox\n\n- existing bullet\n",
     });
 
     insertMarkers({ agentsDir, wikiRoot });
@@ -53,7 +53,7 @@ describe("insertMarkers", () => {
 
   test("reports error when heading missing", () => {
     const { agentsDir, wikiRoot } = setup({
-      "staff-engineer": "# Staff Engineer\n\nNo observations section here.\n",
+      "staff-engineer": "# Staff Engineer\n\nNo inbox section here.\n",
     });
 
     const result = insertMarkers({ agentsDir, wikiRoot });
@@ -65,7 +65,7 @@ describe("insertMarkers", () => {
 
   test("marker placed directly under heading", () => {
     const { agentsDir, wikiRoot } = setup({
-      "staff-engineer": "## Observations for Teammates\n\n- existing bullet\n",
+      "staff-engineer": "## Message Inbox\n\n- existing bullet\n",
     });
 
     insertMarkers({ agentsDir, wikiRoot });
@@ -74,9 +74,7 @@ describe("insertMarkers", () => {
       join(wikiRoot, "staff-engineer.md"),
       "utf-8",
     ).split("\n");
-    const headingIdx = lines.findIndex(
-      (l) => l.trim() === "## Observations for Teammates",
-    );
+    const headingIdx = lines.findIndex((l) => l.trim() === "## Message Inbox");
     assert.equal(lines[headingIdx + 2], MEMO_INBOX_MARKER);
   });
 });

--- a/libraries/libwiki/test/memo-writer.test.js
+++ b/libraries/libwiki/test/memo-writer.test.js
@@ -26,7 +26,7 @@ describe("writeMemo", () => {
 
   test("appends bullet after marker", () => {
     const content = [
-      "## Observations for Teammates",
+      "## Message Inbox",
       MEMO_INBOX_MARKER,
       "",
       "Some other content",
@@ -46,7 +46,7 @@ describe("writeMemo", () => {
   });
 
   test("returns missing-marker when marker absent", () => {
-    const content = "## Observations for Teammates\n\nNo marker here.\n";
+    const content = "## Message Inbox\n\nNo marker here.\n";
     const fs = createFakeFs(content);
     const result = writeMemo(base, fs);
 
@@ -59,11 +59,7 @@ describe("writeMemo", () => {
   });
 
   test("marker is preserved after write", () => {
-    const content = [
-      "## Observations for Teammates",
-      MEMO_INBOX_MARKER,
-      "",
-    ].join("\n");
+    const content = ["## Message Inbox", MEMO_INBOX_MARKER, ""].join("\n");
 
     const fs = createFakeFs(content);
     writeMemo(base, fs);
@@ -72,11 +68,7 @@ describe("writeMemo", () => {
   });
 
   test("multi-line message collapsed to single line", () => {
-    const content = [
-      "## Observations for Teammates",
-      MEMO_INBOX_MARKER,
-      "",
-    ].join("\n");
+    const content = ["## Message Inbox", MEMO_INBOX_MARKER, ""].join("\n");
 
     const fs = createFakeFs(content);
     writeMemo({ ...base, message: "line one\nline two\nline three" }, fs);

--- a/libraries/libwiki/test/memo-writer.test.js
+++ b/libraries/libwiki/test/memo-writer.test.js
@@ -42,7 +42,10 @@ describe("writeMemo", () => {
 
     const lines = fs.written.split("\n");
     assert.equal(lines[1], MEMO_INBOX_MARKER);
-    assert.equal(lines[2], "- 2026-05-02 **technical-writer**: audit d642ff0c");
+    assert.equal(
+      lines[2],
+      "- 2026-05-02 from **technical-writer**: audit d642ff0c",
+    );
   });
 
   test("returns missing-marker when marker absent", () => {
@@ -76,7 +79,7 @@ describe("writeMemo", () => {
     const lines = fs.written.split("\n");
     assert.equal(
       lines[2],
-      "- 2026-05-02 **technical-writer**: line one line two line three",
+      "- 2026-05-02 from **technical-writer**: line one line two line three",
     );
   });
 });

--- a/scripts/wiki-audit.sh
+++ b/scripts/wiki-audit.sh
@@ -11,8 +11,8 @@ fail_count=0
 # Any H2 NOT in this list is an agent-specific state section —
 # permitted but must appear before "Open Blockers".
 permitted_summary_h2s=(
+  "Message Inbox"
   "Open Blockers"
-  "Observations for Teammates"
 )
 
 # ── Excluded-content H2 patterns (warn only) ──
@@ -98,27 +98,19 @@ check_summary_sections() {
       h2_lines+=("$lineno")
     done < <(grep -n '^## ' "$f" || true)
 
-    # Check order: state H2s must come before Open Blockers
+    # Message Inbox MUST be the first H2 (recipient-first discoverability).
+    # State H2s must come before Open Blockers.
+    if (( ${#h2s[@]} > 0 )) && [[ "${h2s[0]}" != "Message Inbox" ]]; then
+      fail "sections: $f first H2 is '${h2s[0]}', expected 'Message Inbox'"
+    fi
     local seen_open_blockers=0
     for h in "${h2s[@]}"; do
       if [[ "$h" == "Open Blockers" ]]; then
         seen_open_blockers=1
-      elif [[ "$h" == "Observations for Teammates" ]]; then
-        : # always valid after Open Blockers
       elif (( seen_open_blockers == 1 )); then
         fail "sections: $f sections out of order ('$h' after 'Open Blockers')"
       fi
     done
-
-    # If both present, Open Blockers must precede Observations for Teammates
-    local ob_idx=-1 ot_idx=-1
-    for i in "${!h2s[@]}"; do
-      [[ "${h2s[$i]}" == "Open Blockers" ]] && ob_idx=$i
-      [[ "${h2s[$i]}" == "Observations for Teammates" ]] && ot_idx=$i
-    done
-    if (( ob_idx >= 0 && ot_idx >= 0 && ob_idx > ot_idx )); then
-      fail "sections: $f sections out of order ('Open Blockers' after 'Observations for Teammates')"
-    fi
   done
 }
 

--- a/websites/fit/docs/libraries/wiki-operations/index.md
+++ b/websites/fit/docs/libraries/wiki-operations/index.md
@@ -1,13 +1,13 @@
 ---
 title: Wiki Operations
-description: Send cross-team observations and manage wiki markers with fit-wiki.
+description: Send cross-team memos and manage wiki markers with fit-wiki.
 ---
 
 # Wiki Operations
 
 `fit-wiki` is the operational CLI for agent wiki lifecycle management. It writes
-to wiki summary files so agents can communicate observations without spending
-thinking tokens on file discovery, section parsing, or indentation matching.
+into teammates' inboxes so agents can communicate without spending thinking
+tokens on file discovery, section parsing, or indentation matching.
 
 ## Getting Started
 
@@ -44,7 +44,7 @@ npx fit-wiki memo --from technical-writer --to all --message "new XmR baseline"
 Each memo is inserted as a single markdown bullet directly after the marker:
 
 ```markdown
-- 2026-05-02 **staff-engineer**: audit d642ff0c
+- 2026-05-02 from **staff-engineer**: audit d642ff0c
 ```
 
 Newest memos appear first within the section. Multi-line messages are collapsed
@@ -60,7 +60,7 @@ directly under the `## Message Inbox` heading:
 
 <!-- memo:inbox -->
 
-- 2026-05-02 **staff-engineer**: audit d642ff0c
+- 2026-05-02 from **staff-engineer**: audit d642ff0c
 ```
 
 The marker is invisible in rendered markdown and anchors all `fit-wiki memo`

--- a/websites/fit/docs/libraries/wiki-operations/index.md
+++ b/websites/fit/docs/libraries/wiki-operations/index.md
@@ -18,9 +18,9 @@ npx fit-wiki memo --from staff-engineer --to security-engineer --message "audit 
 
 ## Sending a Memo
 
-The `memo` command appends a timestamped observation to a teammate's wiki
-summary, directly after the `<!-- memo:inbox -->` marker in the "Observations
-for Teammates" section.
+The `memo` command appends a timestamped bullet to a teammate's wiki
+summary, directly after the `<!-- memo:inbox -->` marker in their
+`## Message Inbox` section.
 
 ```sh
 # Single target
@@ -53,10 +53,10 @@ to a single line.
 ## The Marker Contract
 
 Each agent summary must contain exactly one `<!-- memo:inbox -->` HTML comment
-directly under the `## Observations for Teammates` heading:
+directly under the `## Message Inbox` heading:
 
 ```markdown
-## Observations for Teammates
+## Message Inbox
 
 <!-- memo:inbox -->
 


### PR DESCRIPTION
## Summary

- Renames `## Observations for Teammates` to `## Message Inbox` and moves it to the top of each agent summary (right after `**Last run**:`) so on-boot scanning surfaces incoming memos before state-heavy sections.
- Migrates existing outgoing-observation bullets in 6 agent summaries to the addressed teammate's inbox; preserves the one pre-existing dated memo.
- New bullet format `- YYYY-MM-DD from **<sender>**: <message>` so recipients parse the bullet recipient-first; legacy migrated bullets sort to the bottom of the section.
- `fit-wiki memo --to all` now skips the sender by default; new test pins this.
- Strengthened position contract in `memory-protocol.md` (`## Message Inbox` MUST be the first H2) and `scripts/wiki-audit.sh` enforces it.
- Vocabulary refresh ("observations" → "memos") in libwiki package metadata, CLI `--help`, fit-wiki SKILL, and the public wiki-operations guide; fit-wiki SKILL now carries the `## Documentation` block required by the linking policy.
- Empty-inbox convention added: `- *No new messages.*`.
- Five-reviewer panel ran on the rename; this branch addresses every Blocker/High/Medium finding (1 BLOCKER, 6 HIGH, 8 MEDIUM).

## Test plan

- [x] `bun run check` — green (format, lint, harness, instructions/metadata/catalog)
- [x] `bun test` (libwiki) — 18/18 pass
- [x] `bun run test` (full suite) — 2694/2694 pass
- [x] `bash scripts/wiki-audit.sh` — only pre-existing line-cap on `wiki/staff-engineer.md` remains (parallel-session moving target, unrelated to this branch)
- [x] Live smoke test: `fit-wiki memo --from technical-writer --to all` correctly skipped TW's own inbox and wrote `- 2026-05-03 from **technical-writer**: ...` to the other 5


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXARsNQ1AYrP9xHmjPWdvZ)_