### PR TITLE
feat(libwiki): add refresh, init, push, pull commands (#780)

### DIFF
--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -1,24 +1,25 @@
 ---
 name: fit-wiki
 description: >
-  Manage the Kata agent team wiki: send cross-team memos, discover the agent
-  roster, and migrate insertion markers. Use when an agent needs to drop a
-  memo in a teammate's Message Inbox or broadcast to the whole team.
+  Manage the Kata agent team wiki: send cross-team memos, refresh storyboard
+  XmR charts, bootstrap and sync the wiki. Use when an agent needs to
+  communicate with teammates, update storyboard metrics, or sync wiki state.
 ---
 
 # Wiki Operations
 
-`fit-wiki` is the operational CLI for the Kata agent wiki. It writes into
-teammates' inboxes so agents can communicate without spending thinking tokens
-on file discovery, section parsing, or indentation matching.
+`fit-wiki` is the operational CLI for the Kata agent wiki. It handles cross-team
+memos, storyboard chart maintenance, and wiki git lifecycle — so agents can
+focus on domain work instead of file plumbing.
 
 ## When to Use
 
 - You have a memo for a teammate and want it to land in their
   `## Message Inbox` so they read it on their next boot.
 - You want to broadcast a memo to every other agent on the team.
-- You need to ensure all agent summaries have the `<!-- memo:inbox -->` marker
-  for machine-writable memos.
+- You need to regenerate XmR chart blocks in a storyboard markdown file.
+- You need to bootstrap a wiki working tree for a new Kata installation.
+- You need to sync wiki changes to/from the remote repository.
 
 ## Commands
 
@@ -39,14 +40,65 @@ npx fit-wiki memo --from technical-writer --to all --message "new XmR baseline"
 | `--message`   | Yes      | Memo text                                                              |
 | `--wiki-root` | No       | Override wiki root directory (default: auto-detected from project root) |
 
-The bullet format is `- YYYY-MM-DD from **{sender}**: {message}`, inserted on
-the line immediately following the marker (newest-first within the section).
+### `refresh` — Regenerate storyboard XmR charts
+
+Scans a storyboard markdown file for `<!-- xmr:metric:path -->` /
+`<!-- /xmr -->` marker pairs and regenerates each block with the current XmR
+chart, latest value, status, and signals from the referenced CSV.
+
+```sh
+npx fit-wiki refresh wiki/storyboard-2026-M05.md
+```
+
+Idempotent — running it twice produces the same output. No-op on files without
+markers. Use this after recording metrics to keep the storyboard's Current
+Condition section up to date.
+
+### `init` — Bootstrap a wiki working tree
+
+Clones the repository's wiki into `./wiki/` and creates
+`wiki/metrics/<skill>/` directories for each kata skill in the installation.
+
+```sh
+npx fit-wiki init
+```
+
+| Flag           | Required | Description                                       |
+| -------------- | -------- | ------------------------------------------------- |
+| `--wiki-root`  | No       | Override wiki root directory (default: wiki)       |
+| `--skills-dir` | No       | Override skills directory (default: .claude/skills) |
+
+Idempotent — safe to run on an already-initialized wiki.
+
+### `push` — Push wiki changes to remote
+
+Commits local wiki changes and pushes to the remote. No-op when no local
+changes exist. Resolves push conflicts in favor of local state.
+
+```sh
+npx fit-wiki push
+```
+
+Designed for use in Claude Code hooks (`Stop` → `npx fit-wiki push`) and
+GitHub Actions post-run steps.
+
+### `pull` — Pull remote wiki changes
+
+Fetches and rebases local wiki state onto the remote. Exits non-zero with a
+diagnostic message on conflict.
+
+```sh
+npx fit-wiki pull
+```
+
+Designed for use in Claude Code hooks (`SessionStart` → `npx fit-wiki pull`).
 
 ### Exit codes
 
 | Code | Meaning                                                    |
 | ---- | ---------------------------------------------------------- |
-| 0    | Success — bullet written to all targets                    |
+| 0    | Success                                                    |
+| 1    | Pull conflict — local divergence detected                  |
 | 2    | Usage error — missing flag, missing target file, or marker |
 
 ### Marker contract
@@ -59,14 +111,26 @@ the command exits 2 with a diagnostic message.
 ## Programmatic API
 
 ```js
-import { writeMemo, listAgents, insertMarkers } from "@forwardimpact/libwiki";
+import {
+  writeMemo,
+  listAgents,
+  insertMarkers,
+  scanMarkers,
+  renderBlock,
+  WikiRepo,
+  listSkills,
+} from "@forwardimpact/libwiki";
 ```
 
 - `writeMemo({ summaryPath, sender, message, today })` — append one bullet
 - `listAgents({ agentsDir, wikiRoot })` — discover agents from `.claude/agents/*.md`
 - `insertMarkers({ agentsDir, wikiRoot })` — idempotent marker insertion
+- `scanMarkers(text)` — find `<!-- xmr:... -->` marker pairs in markdown
+- `renderBlock({ metric, csvPath, projectRoot })` — render one XmR chart block
+- `new WikiRepo({ wikiDir, parentDir })` — git wrapper for wiki operations
+- `listSkills({ skillsDir })` — discover kata skills from `.claude/skills/`
 
 ## Documentation
 
 - [Wiki Operations](https://www.forwardimpact.team/docs/libraries/wiki-operations/index.md) —
-  how to use `fit-wiki` to send memos and manage wiki markers.
+  how to use `fit-wiki` to send memos, refresh storyboards, and sync the wiki.

--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -47,12 +47,13 @@ Scans a storyboard markdown file for `<!-- xmr:metric:path -->` /
 chart, latest value, status, and signals from the referenced CSV.
 
 ```sh
+npx fit-wiki refresh
 npx fit-wiki refresh wiki/storyboard-2026-M05.md
 ```
 
-Idempotent — running it twice produces the same output. No-op on files without
-markers. Use this after recording metrics to keep the storyboard's Current
-Condition section up to date.
+Without a path argument, defaults to the current month's storyboard
+(`wiki/storyboard-YYYY-MNN.md`). Idempotent — running it twice produces the
+same output. No-op on files without markers.
 
 ### `init` — Bootstrap a wiki working tree
 

--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -47,9 +47,8 @@ Participant Protocol below.
 - [ ] Identify which metrics CSVs to review from `wiki/metrics/`.
 - [ ] Run `bunx fit-xmr analyze --format json` against each metrics CSV and
       record the `status`, fired-rule `signals`, and `latest` for each metric.
-- [ ] For team storyboard runs, run
-      `bunx fit-wiki refresh wiki/storyboard-{YYYY}-M{MM}.md` to regenerate all
-      XmR chart blocks in the Current Condition section.
+- [ ] For team storyboard runs, run `bunx fit-wiki refresh` to regenerate all
+      XmR chart blocks in the current month's storyboard.
 
 </read_do_checklist>
 
@@ -121,9 +120,8 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
 4. **Run XmR analysis.** For every CSV in `wiki/metrics/`, run
    `bunx fit-xmr analyze <csv> --format json` and use the `status`, fired-rule
    `signals`, and `latest` fields when reporting the Condition. For team
-   storyboard runs, run
-   `bunx fit-wiki refresh wiki/storyboard-{YYYY}-M{MM}.md` to regenerate all
-   XmR chart blocks in the Current Condition section. Note any
+   storyboard runs, run `bunx fit-wiki refresh` to regenerate all XmR chart
+   blocks in the current month's storyboard. Note any
    `insufficient_data` metric. In facilitated mode, include `status` and
    fired-rule signals in the Q2 `Ask`.
 5. **Run the five questions.** Follow the overlay's wording. In facilitated

--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -47,9 +47,9 @@ Participant Protocol below.
 - [ ] Identify which metrics CSVs to review from `wiki/metrics/`.
 - [ ] Run `bunx fit-xmr analyze --format json` against each metrics CSV and
       record the `status`, fired-rule `signals`, and `latest` for each metric.
-- [ ] For team storyboard runs, render an X+mR chart per canonical metric
-      (`bunx fit-xmr chart <csv> --metric <name>`) for the Current Condition
-      section.
+- [ ] For team storyboard runs, run
+      `bunx fit-wiki refresh wiki/storyboard-{YYYY}-M{MM}.md` to regenerate all
+      XmR chart blocks in the Current Condition section.
 
 </read_do_checklist>
 
@@ -121,10 +121,9 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
 4. **Run XmR analysis.** For every CSV in `wiki/metrics/`, run
    `bunx fit-xmr analyze <csv> --format json` and use the `status`, fired-rule
    `signals`, and `latest` fields when reporting the Condition. For team
-   storyboard runs, also run `bunx fit-xmr chart <csv> --metric <name>` per
-   canonical metric and paste the resulting X+mR chart into the storyboard's
-   Current Condition — the chart is the visualization, so do not duplicate `μ`,
-   `UPL`, `LPL`, or zone values in surrounding prose. Note any
+   storyboard runs, run
+   `bunx fit-wiki refresh wiki/storyboard-{YYYY}-M{MM}.md` to regenerate all
+   XmR chart blocks in the Current Condition section. Note any
    `insufficient_data` metric. In facilitated mode, include `status` and
    fired-rule signals in the Q2 `Ask`.
 5. **Run the five questions.** Follow the overlay's wording. In facilitated

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -36,25 +36,27 @@ threshold crossed, classification flip). Empty if nothing changed — write
 
 #### {metric_name}
 
+<!-- xmr:{metric_name}:wiki/metrics/{skill}/{YYYY}.csv -->
 **Latest:** {value} · **Status:** {status from `bunx fit-xmr analyze`}
 
 ```
-{paste the 14-line Wheeler/Vacanti X+mR chart from
-`bunx fit-xmr chart <csv> --metric <name>` verbatim. The chart already labels
-μ, UPL, LPL, ±1.5σ zones, URL, R, and the run index — do not restate any of
-those numbers outside the chart.}
+{14-line Wheeler/Vacanti X+mR chart. The chart labels μ, UPL, LPL, ±1.5σ
+zones, URL, R, and the run index — do not restate any of those numbers outside
+the chart.}
 ```
 
-**Signals:** {fired-rule list from `bunx fit-xmr analyze` (`xRule1`, `xRule2`,
-`xRule3`, `mrRule1`), or `—` if none}
+**Signals:** {fired-rule list (`xRule1`, `xRule2`, `xRule3`, `mrRule1`), or `—`
+if none}
+<!-- /xmr -->
 
 _Note:_ {one line, only when `status` is `signals_present` or a fired rule needs
 cross-referencing to a specific event; stable metrics get no prose}.
 
-(Repeat one `#### metric_name` block per metric, grouped under
-`### {agent}`. The chart from `bunx fit-xmr chart` is the
-visualization — do not duplicate its values in surrounding prose. Agents add the
-cross-reference layer only where there is something to say.)
+(Repeat one `#### metric_name` block per metric, grouped under `### {agent}`.
+Run `bunx fit-wiki refresh <storyboard.md>` to regenerate all marker blocks
+from CSV data. The chart is the visualization — do not duplicate its values in
+surrounding prose. Agents add the cross-reference layer only where there is
+something to say.)
 
 ## Obstacles
 

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -53,25 +53,21 @@ XmR protocol reference at
 
 ## Storyboard updates
 
-Current Condition is rendered as per-metric blocks under
-`### {agent}` headings (no overview table). For each CSV-backed
-metric, write a `#### {metric_name}` block containing:
+Run `bunx fit-wiki refresh wiki/storyboard-YYYY-MNN.md` to regenerate all
+`<!-- xmr:... -->` / `<!-- /xmr -->` blocks in Current Condition. Idempotent.
 
-1. A status header — `**Latest:** {value} · **Status:** {status}`. No trend
-   arrows or alert glyphs.
-2. The visualization: paste the 14-line X+mR chart from
-   `bunx fit-xmr chart <csv> --metric <name>` verbatim in a fenced code block.
-   The chart labels `μ`, `UPL`, `LPL`, `±1.5σ`, `URL`, `R`, and the run index —
-   **do not restate any of these in prose**.
+Each `#### {metric_name}` block is bracketed by markers. Everything between
+them is regenerated; the heading and `_Note:_` prose sit outside.
 
-   Chart the whole CSV. The process is continuous; the storyboard month is a
-   coaching artifact, not a process reset. Don't filter to "this month" — every
-   storyboard renders the same series.
+The rendered block contains:
 
-3. A `**Signals:**` line listing fired Wheeler rules (`xRule1`, `xRule2`,
-   `xRule3`, `mrRule1`), or `—` if none.
-4. An optional one-line note only when `status` is `signals_present` and a fired
-   rule needs cross-referencing. Stable metrics get no prose.
+1. `**Latest:** {value} · **Status:** {status}`. No trend arrows.
+2. The X+mR chart in a fenced code block. Chart the whole CSV — **do not
+   restate `μ`, `UPL`, `LPL`, or zone values in prose**.
+3. `**Signals:**` — fired Wheeler rules or `—`.
+4. Optional one-line note only when `signals_present` needs cross-referencing.
+
+Without markers, fall back to `bunx fit-xmr chart` and paste manually.
 
 Above the agent-domain sections, write a tight `### Headlines` list naming only
 metrics whose status changed since the last meeting. Agents add cross-reference

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -53,8 +53,9 @@ XmR protocol reference at
 
 ## Storyboard updates
 
-Run `bunx fit-wiki refresh wiki/storyboard-YYYY-MNN.md` to regenerate all
-`<!-- xmr:... -->` / `<!-- /xmr -->` blocks in Current Condition. Idempotent.
+Run `bunx fit-wiki refresh` to regenerate all `<!-- xmr:... -->` /
+`<!-- /xmr -->` blocks in the current month's storyboard. Idempotent. Pass an
+explicit path to target a different file.
 
 Each `#### {metric_name}` block is bracketed by markers. Everything between
 them is regenerated; the heading and `_Note:_` prose sit outside.

--- a/bun.lock
+++ b/bun.lock
@@ -16,14 +16,14 @@
     },
     "libraries/libcli": {
       "name": "@forwardimpact/libcli",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "devDependencies": {
         "@forwardimpact/libharness": "^0.1.14",
       },
     },
     "libraries/libcodegen": {
       "name": "@forwardimpact/libcodegen",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "bin": {
         "fit-codegen": "./bin/fit-codegen.js",
       },
@@ -43,7 +43,7 @@
     },
     "libraries/libconfig": {
       "name": "@forwardimpact/libconfig",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
         "@forwardimpact/libstorage": "^0.1.53",
       },
@@ -53,7 +53,7 @@
     },
     "libraries/libdoc": {
       "name": "@forwardimpact/libdoc",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "bin": {
         "fit-doc": "./bin/fit-doc.js",
       },
@@ -77,7 +77,7 @@
     },
     "libraries/libeval": {
       "name": "@forwardimpact/libeval",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "bin": {
         "fit-eval": "./bin/fit-eval.js",
         "fit-trace": "./bin/fit-trace.js",
@@ -95,7 +95,7 @@
     },
     "libraries/libformat": {
       "name": "@forwardimpact/libformat",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "marked": "^18.0.2",
         "marked-terminal": "^7.3.0",
@@ -107,7 +107,7 @@
     },
     "libraries/libgraph": {
       "name": "@forwardimpact/libgraph",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "bin": {
         "fit-process-graphs": "./bin/fit-process-graphs.js",
         "fit-subjects": "./bin/fit-subjects.js",
@@ -128,14 +128,14 @@
     },
     "libraries/libharness": {
       "name": "@forwardimpact/libharness",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "peerDependencies": {
         "@forwardimpact/libtype": "*",
       },
     },
     "libraries/libindex": {
       "name": "@forwardimpact/libindex",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "dependencies": {
         "@forwardimpact/libtype": "^0.1.63",
       },
@@ -152,7 +152,7 @@
     },
     "libraries/libmcp": {
       "name": "@forwardimpact/libmcp",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@forwardimpact/libtype": "^0.1.0",
         "zod": "^4.4.1",
@@ -163,7 +163,7 @@
     },
     "libraries/libpolicy": {
       "name": "@forwardimpact/libpolicy",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
         "@forwardimpact/libstorage": "^0.1.53",
       },
@@ -173,14 +173,14 @@
     },
     "libraries/libprompt": {
       "name": "@forwardimpact/libprompt",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "mustache": "^4.2.0",
       },
     },
     "libraries/librc": {
       "name": "@forwardimpact/librc",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "bin": {
         "fit-rc": "./bin/fit-rc.js",
       },
@@ -196,7 +196,7 @@
     },
     "libraries/librepl": {
       "name": "@forwardimpact/librepl",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@forwardimpact/libformat": "^0.1.0",
       },
@@ -206,7 +206,7 @@
     },
     "libraries/libresource": {
       "name": "@forwardimpact/libresource",
-      "version": "0.1.108",
+      "version": "0.1.109",
       "bin": {
         "fit-process-resources": "./bin/fit-process-resources.js",
       },
@@ -229,7 +229,7 @@
     },
     "libraries/librpc": {
       "name": "@forwardimpact/librpc",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "bin": {
         "fit-unary": "./bin/fit-unary.js",
       },
@@ -246,11 +246,11 @@
     },
     "libraries/libsecret": {
       "name": "@forwardimpact/libsecret",
-      "version": "0.1.12",
+      "version": "0.1.13",
     },
     "libraries/libskill": {
       "name": "@forwardimpact/libskill",
-      "version": "5.2.3",
+      "version": "5.2.4",
       "dependencies": {
         "@forwardimpact/map": "^0.15.0",
       },
@@ -260,7 +260,7 @@
     },
     "libraries/libstorage": {
       "name": "@forwardimpact/libstorage",
-      "version": "0.1.71",
+      "version": "0.1.72",
       "bin": {
         "fit-storage": "./bin/fit-storage.js",
       },
@@ -279,7 +279,7 @@
     },
     "libraries/libsupervise": {
       "name": "@forwardimpact/libsupervise",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "bin": {
         "fit-logger": "./bin/fit-logger.js",
         "fit-svscan": "./bin/fit-svscan.js",
@@ -294,7 +294,7 @@
     },
     "libraries/libsyntheticgen": {
       "name": "@forwardimpact/libsyntheticgen",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.61",
         "seedrandom": "^3.0.5",
@@ -308,7 +308,7 @@
     },
     "libraries/libsyntheticprose": {
       "name": "@forwardimpact/libsyntheticprose",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@forwardimpact/libprompt": "^0.1.0",
         "@forwardimpact/libtelemetry": "^0.1.23",
@@ -320,7 +320,7 @@
     },
     "libraries/libsyntheticrender": {
       "name": "@forwardimpact/libsyntheticrender",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@forwardimpact/libsyntheticgen": "^0.1.0",
         "@forwardimpact/libtemplate": "^0.2.0",
@@ -339,7 +339,7 @@
     },
     "libraries/libtelemetry": {
       "name": "@forwardimpact/libtelemetry",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "bin": {
         "fit-visualize": "./bin/fit-visualize.js",
       },
@@ -354,14 +354,14 @@
     },
     "libraries/libtemplate": {
       "name": "@forwardimpact/libtemplate",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "mustache": "^4.2.0",
       },
     },
     "libraries/libterrain": {
       "name": "@forwardimpact/libterrain",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "bin": {
         "fit-terrain": "./bin/fit-terrain.js",
       },
@@ -384,7 +384,7 @@
     },
     "libraries/libtype": {
       "name": "@forwardimpact/libtype",
-      "version": "0.1.73",
+      "version": "0.1.74",
       "dependencies": {
         "@forwardimpact/libsecret": "^0.1.3",
         "@forwardimpact/libutil": "^0.1.60",
@@ -395,14 +395,14 @@
     },
     "libraries/libui": {
       "name": "@forwardimpact/libui",
-      "version": "1.1.8",
+      "version": "1.2.0",
       "devDependencies": {
         "happy-dom": "^20.9.0",
       },
     },
     "libraries/libutil": {
       "name": "@forwardimpact/libutil",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "bin": {
         "fit-download-bundle": "./bin/fit-download-bundle.js",
         "fit-tiktoken": "./bin/fit-tiktoken.js",
@@ -417,7 +417,7 @@
     },
     "libraries/libvector": {
       "name": "@forwardimpact/libvector",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "bin": {
         "fit-process-vectors": "./bin/fit-process-vectors.js",
         "fit-search": "./bin/fit-search.js",
@@ -442,6 +442,7 @@
       "dependencies": {
         "@forwardimpact/libcli": "^0.1.0",
         "@forwardimpact/libutil": "^0.1.0",
+        "@forwardimpact/libxmr": "^1.1.0",
       },
       "devDependencies": {
         "@forwardimpact/libharness": "^0.1.5",
@@ -449,7 +450,7 @@
     },
     "libraries/libxmr": {
       "name": "@forwardimpact/libxmr",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": {
         "fit-xmr": "./bin/fit-xmr.js",
       },
@@ -463,7 +464,7 @@
     },
     "products/guide": {
       "name": "@forwardimpact/guide",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "bin": {
         "fit-guide": "./bin/fit-guide.js",
       },
@@ -489,7 +490,7 @@
     },
     "products/landmark": {
       "name": "@forwardimpact/landmark",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "bin": {
         "fit-landmark": "./bin/fit-landmark.js",
       },
@@ -508,7 +509,7 @@
     },
     "products/map": {
       "name": "@forwardimpact/map",
-      "version": "0.15.38",
+      "version": "0.15.39",
       "bin": {
         "fit-map": "./bin/fit-map.js",
       },
@@ -544,7 +545,7 @@
     },
     "products/pathway": {
       "name": "@forwardimpact/pathway",
-      "version": "0.25.43",
+      "version": "0.25.44",
       "bin": {
         "fit-pathway": "./bin/fit-pathway.js",
       },
@@ -562,7 +563,7 @@
     },
     "products/summit": {
       "name": "@forwardimpact/summit",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "bin": {
         "fit-summit": "./bin/fit-summit.js",
       },

--- a/justfile
+++ b/justfile
@@ -9,11 +9,11 @@ ARGS := ""
 
 # Pull latest agent memory from wiki
 wiki-pull:
-    bash scripts/wiki-sync.sh pull
+    bunx fit-wiki pull
 
 # Commit and push agent memory to wiki
 wiki-push:
-    bash scripts/wiki-sync.sh push
+    bunx fit-wiki push
 
 # Audit agent memory against the wiki contract
 wiki-audit:

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -78,7 +78,7 @@ signal is distinguished from noise.
 | **libsyntheticprose**  | LLM-generated prose and engineering-standard YAML for synthetic agent evaluation content.                                                     |
 | **libsyntheticrender** | Multi-format rendering and validation of synthetic agent evaluation data (HTML, Markdown, YAML).                                              |
 | **libterrain**         | Full parse-generate-render-validate pipeline for synthetic agent training and evaluation data.                                                |
-| **libwiki**            | Wiki lifecycle primitives for the Kata agent system: cross-team memos, agent roster discovery, and marker migration.                          |
+| **libwiki**            | Wiki lifecycle primitives for the Kata agent system: cross-team memos, storyboard XmR chart refresh, wiki bootstrap, and git sync.            |
 | **libxmr**             | Agent-friendly Wheeler/Vacanti XmR control charts: 14-line ASCII charts and the canonical three detection rules over time-series CSV metrics. |
 
 <!-- END:capability:agent-self-improvement -->
@@ -130,6 +130,7 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 | ------------------------------------------------------------------------------ | -------------------- |
 | Add a distributed trace span (OpenTelemetry-style observability)               | `libtelemetry`       |
 | Assemble a macOS app bundle                                                    | `libmacos`           |
+| Bootstrap a wiki working tree for a Kata installation                          | `libwiki`            |
 | Buffer high-volume index writes                                                | `libindex`           |
 | Build a gRPC service                                                           | `librpc`             |
 | Build a reactive single-page web app                                           | `libui`              |
@@ -164,10 +165,13 @@ library's `package.json` (`forwardimpact.needs`); regenerate with
 | Parse a terrain DSL                                                            | `libsyntheticgen`    |
 | Parse and query Claude Code trace NDJSON files                                 | `libeval`            |
 | Parse CLI args and render help                                                 | `libcli`             |
+| Pull remote wiki changes into the local working tree                           | `libwiki`            |
+| Push agent-authored wiki changes to the remote                                 | `libwiki`            |
 | Query an RDF triple graph                                                      | `libgraph`           |
 | Read or write .env (dotenv) files                                              | `libsecret`          |
 | Read or write JSONL                                                            | `libstorage`         |
 | Record a metric and print its current XmR status                               | `libxmr`             |
+| Refresh XmR chart blocks inside a storyboard markdown file                     | `libwiki`            |
 | Register a gRPC service as MCP tools                                           | `libmcp`             |
 | Render a Mustache template with project overrides                              | `libtemplate`        |
 | Render a prompt template with variable substitution                            | `libprompt`          |

--- a/libraries/libwiki/bin/fit-wiki.js
+++ b/libraries/libwiki/bin/fit-wiki.js
@@ -45,7 +45,7 @@ const definition = {
       name: "refresh",
       description:
         "Regenerate XmR chart blocks inside a storyboard markdown file",
-      args: "<storyboard-path>",
+      args: "[storyboard-path]",
     },
     {
       name: "init",
@@ -93,6 +93,7 @@ const definition = {
   examples: [
     'fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"',
     'fit-wiki memo --from technical-writer --to all --message "new XmR baseline"',
+    "fit-wiki refresh",
     "fit-wiki refresh wiki/storyboard-2026-M05.md",
     "fit-wiki init",
     "fit-wiki push",

--- a/libraries/libwiki/bin/fit-wiki.js
+++ b/libraries/libwiki/bin/fit-wiki.js
@@ -4,6 +4,9 @@ import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
 
 import { runMemoCommand } from "../src/commands/memo.js";
+import { runRefreshCommand } from "../src/commands/refresh.js";
+import { runInitCommand } from "../src/commands/init.js";
+import { runPushCommand, runPullCommand } from "../src/commands/sync.js";
 
 const { version: VERSION } = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
@@ -38,6 +41,46 @@ const definition = {
         },
       },
     },
+    {
+      name: "refresh",
+      description:
+        "Regenerate XmR chart blocks inside a storyboard markdown file",
+      args: "<storyboard-path>",
+    },
+    {
+      name: "init",
+      description: "Bootstrap a wiki working tree for a Kata installation",
+      options: {
+        "wiki-root": {
+          type: "string",
+          description: "Override wiki root directory (default: wiki)",
+        },
+        "skills-dir": {
+          type: "string",
+          description: "Override skills directory (default: .claude/skills)",
+        },
+      },
+    },
+    {
+      name: "push",
+      description: "Commit and push local wiki changes to the remote",
+      options: {
+        "wiki-root": {
+          type: "string",
+          description: "Override wiki root directory (default: wiki)",
+        },
+      },
+    },
+    {
+      name: "pull",
+      description: "Pull remote wiki changes into the local working tree",
+      options: {
+        "wiki-root": {
+          type: "string",
+          description: "Override wiki root directory (default: wiki)",
+        },
+      },
+    },
   ],
   globalOptions: {
     help: { type: "boolean", short: "h", description: "Show this help" },
@@ -50,13 +93,17 @@ const definition = {
   examples: [
     'fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"',
     'fit-wiki memo --from technical-writer --to all --message "new XmR baseline"',
+    "fit-wiki refresh wiki/storyboard-2026-M05.md",
+    "fit-wiki init",
+    "fit-wiki push",
+    "fit-wiki pull",
   ],
   documentation: [
     {
       title: "Wiki Operations",
       url: "https://www.forwardimpact.team/docs/libraries/wiki-operations/index.md",
       description:
-        "Send cross-team memos, discover agents, and manage wiki markers.",
+        "Send cross-team memos, refresh storyboard charts, and sync the wiki.",
     },
   ],
 };
@@ -65,6 +112,10 @@ const cli = createCli(definition);
 
 const COMMANDS = {
   memo: runMemoCommand,
+  refresh: runRefreshCommand,
+  init: runInitCommand,
+  push: runPushCommand,
+  pull: runPullCommand,
 };
 
 function main() {

--- a/libraries/libwiki/package.json
+++ b/libraries/libwiki/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@forwardimpact/libwiki",
   "version": "0.1.1",
-  "description": "Wiki lifecycle primitives for the Kata agent system: cross-team memos, agent roster discovery, and marker migration.",
+  "description": "Wiki lifecycle primitives for the Kata agent system: cross-team memos, storyboard XmR chart refresh, wiki bootstrap, and git sync.",
   "keywords": [
     "wiki",
     "memo",
-    "inbox",
+    "storyboard",
+    "xmr",
     "agent"
   ],
   "homepage": "https://www.forwardimpact.team",
@@ -19,7 +20,11 @@
   "forwardimpact": {
     "capability": "agent-self-improvement",
     "needs": [
-      "Send a cross-team memo to a teammate's wiki inbox"
+      "Send a cross-team memo to a teammate's wiki inbox",
+      "Refresh XmR chart blocks inside a storyboard markdown file",
+      "Bootstrap a wiki working tree for a Kata installation",
+      "Push agent-authored wiki changes to the remote",
+      "Pull remote wiki changes into the local working tree"
     ]
   },
   "type": "module",
@@ -41,7 +46,8 @@
   },
   "dependencies": {
     "@forwardimpact/libcli": "^0.1.0",
-    "@forwardimpact/libutil": "^0.1.0"
+    "@forwardimpact/libutil": "^0.1.0",
+    "@forwardimpact/libxmr": "^1.1.0"
   },
   "devDependencies": {
     "@forwardimpact/libharness": "^0.1.5"

--- a/libraries/libwiki/src/block-renderer.js
+++ b/libraries/libwiki/src/block-renderer.js
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { analyze, renderChart, MIN_POINTS } from "@forwardimpact/libxmr";
+
+export class BlockRenderError extends Error {
+  constructor(reason) {
+    super(reason);
+    this.name = "BlockRenderError";
+  }
+}
+
+export function renderBlock({
+  metric,
+  csvPath,
+  projectRoot,
+  fs = { readFileSync },
+}) {
+  const fullPath = path.resolve(projectRoot, csvPath);
+  let csvText;
+  try {
+    csvText = fs.readFileSync(fullPath, "utf-8");
+  } catch {
+    throw new BlockRenderError(`csv-not-found: ${csvPath}`);
+  }
+  const report = analyze(csvText);
+
+  const m = report.metrics.find((entry) => entry.metric === metric);
+  if (!m) {
+    throw new BlockRenderError(`metric-not-found: ${metric}`);
+  }
+
+  const latestValue = m.latest?.value ?? m.values[m.values.length - 1] ?? "—";
+  const status = m.status;
+
+  let chartLines;
+  if (status === "insufficient_data") {
+    chartLines = [
+      `Insufficient data: ${m.n} points (need at least ${MIN_POINTS}).`,
+    ];
+  } else {
+    const chartText = renderChart(m.values, m.stats, m.signals);
+    chartLines = chartText.split("\n");
+  }
+
+  const signalLine = formatSignals(m.signals);
+
+  return [
+    `**Latest:** ${latestValue} · **Status:** ${status}`,
+    "",
+    "```",
+    ...chartLines,
+    "```",
+    "",
+    `**Signals:** ${signalLine}`,
+  ];
+}
+
+function formatSignals(signals) {
+  if (!signals) return "—";
+  const fired = [];
+  for (const rule of ["xRule1", "xRule2", "xRule3", "mrRule1"]) {
+    if (signals[rule]?.length > 0) fired.push(rule);
+  }
+  return fired.length > 0 ? fired.join(", ") : "—";
+}

--- a/libraries/libwiki/src/commands/init.js
+++ b/libraries/libwiki/src/commands/init.js
@@ -1,0 +1,55 @@
+import { mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import fsAsync from "node:fs/promises";
+import { Finder } from "@forwardimpact/libutil";
+import { WikiRepo } from "../wiki-repo.js";
+import { listSkills } from "../skill-roster.js";
+
+function deriveWikiUrl(parentDir) {
+  const r = spawnSync("git", ["-C", parentDir, "remote", "get-url", "origin"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  if (r.status !== 0) return null;
+  const origin = r.stdout.trim();
+  const base = origin.replace(/\.git$/, "");
+  return base + ".wiki.git";
+}
+
+export function runInitCommand(values, _args, cli) {
+  const logger = { debug() {} };
+  const finder = new Finder(fsAsync, logger, process);
+  const projectRoot = finder.findProjectRoot(process.cwd());
+
+  const wikiDir = path.resolve(projectRoot, values["wiki-root"] ?? "wiki");
+  const skillsDir = path.resolve(
+    projectRoot,
+    values["skills-dir"] ?? path.join(".claude", "skills"),
+  );
+
+  const wikiUrl = deriveWikiUrl(projectRoot);
+  if (!wikiUrl) {
+    process.stderr.write(
+      "init: could not determine wiki URL from origin remote\n",
+    );
+    return;
+  }
+
+  const repo = new WikiRepo({ wikiDir, parentDir: projectRoot });
+
+  const cloneResult = repo.ensureCloned(wikiUrl);
+  if (!cloneResult.cloned) {
+    process.stderr.write("init: could not clone wiki, skipping\n");
+    return;
+  }
+
+  repo.inheritIdentity();
+
+  const skills = listSkills({ skillsDir });
+  for (const slug of skills) {
+    mkdirSync(path.join(wikiDir, "metrics", slug), { recursive: true });
+  }
+
+  process.stdout.write(`init: wiki ready at ${wikiDir}\n`);
+}

--- a/libraries/libwiki/src/commands/refresh.js
+++ b/libraries/libwiki/src/commands/refresh.js
@@ -5,17 +5,22 @@ import { Finder } from "@forwardimpact/libutil";
 import { scanMarkers } from "../marker-scanner.js";
 import { renderBlock, BlockRenderError } from "../block-renderer.js";
 
-export function runRefreshCommand(values, args, cli) {
-  if (!args[0]) {
-    cli.usageError("refresh requires a <storyboard-path> argument");
-    process.exit(2);
-  }
+function currentStoryboardPath() {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  return `wiki/storyboard-${yyyy}-M${mm}.md`;
+}
 
+export function runRefreshCommand(values, args, cli) {
   const logger = { debug() {} };
   const finder = new Finder(fsAsync, logger, process);
   const projectRoot = finder.findProjectRoot(process.cwd());
 
-  const storyboardPath = path.resolve(projectRoot, args[0]);
+  const storyboardPath = path.resolve(
+    projectRoot,
+    args[0] || currentStoryboardPath(),
+  );
   const text = readFileSync(storyboardPath, "utf-8");
   const blocks = scanMarkers(text);
 

--- a/libraries/libwiki/src/commands/refresh.js
+++ b/libraries/libwiki/src/commands/refresh.js
@@ -1,0 +1,50 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import fsAsync from "node:fs/promises";
+import { Finder } from "@forwardimpact/libutil";
+import { scanMarkers } from "../marker-scanner.js";
+import { renderBlock, BlockRenderError } from "../block-renderer.js";
+
+export function runRefreshCommand(values, args, cli) {
+  if (!args[0]) {
+    cli.usageError("refresh requires a <storyboard-path> argument");
+    process.exit(2);
+  }
+
+  const logger = { debug() {} };
+  const finder = new Finder(fsAsync, logger, process);
+  const projectRoot = finder.findProjectRoot(process.cwd());
+
+  const storyboardPath = path.resolve(projectRoot, args[0]);
+  const text = readFileSync(storyboardPath, "utf-8");
+  const blocks = scanMarkers(text);
+
+  if (blocks.length === 0) return;
+
+  const lines = text.split("\n");
+  let spliced = false;
+
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const block = blocks[i];
+    try {
+      const rendered = renderBlock({
+        metric: block.metric,
+        csvPath: block.csvPath,
+        projectRoot,
+      });
+      lines.splice(
+        block.openLine + 1,
+        block.closeLine - block.openLine - 1,
+        ...rendered,
+      );
+      spliced = true;
+    } catch (err) {
+      if (!(err instanceof BlockRenderError)) throw err;
+      process.stderr.write(
+        `refresh-error ${storyboardPath}:${block.openLine + 1} ${err.message}\n`,
+      );
+    }
+  }
+
+  if (spliced) writeFileSync(storyboardPath, lines.join("\n"));
+}

--- a/libraries/libwiki/src/commands/sync.js
+++ b/libraries/libwiki/src/commands/sync.js
@@ -1,0 +1,44 @@
+import path from "node:path";
+import fsAsync from "node:fs/promises";
+import { Finder } from "@forwardimpact/libutil";
+import { WikiRepo, WikiPullConflict } from "../wiki-repo.js";
+
+export function runPushCommand(values, _args, cli) {
+  const logger = { debug() {} };
+  const finder = new Finder(fsAsync, logger, process);
+  const projectRoot = finder.findProjectRoot(process.cwd());
+  const wikiDir = path.resolve(projectRoot, values["wiki-root"] ?? "wiki");
+
+  const repo = new WikiRepo({ wikiDir, parentDir: projectRoot });
+  repo.inheritIdentity();
+
+  const result = repo.commitAndPush("wiki: update from session");
+  if (result.pushed) {
+    process.stdout.write("push: committed and pushed\n");
+  } else {
+    process.stdout.write("push: nothing to push\n");
+  }
+}
+
+export function runPullCommand(values, _args, cli) {
+  const logger = { debug() {} };
+  const finder = new Finder(fsAsync, logger, process);
+  const projectRoot = finder.findProjectRoot(process.cwd());
+  const wikiDir = path.resolve(projectRoot, values["wiki-root"] ?? "wiki");
+
+  const repo = new WikiRepo({ wikiDir, parentDir: projectRoot });
+  repo.inheritIdentity();
+
+  try {
+    repo.pull();
+    process.stdout.write("pull: up to date\n");
+  } catch (err) {
+    if (err instanceof WikiPullConflict) {
+      process.stderr.write(
+        "fit-wiki pull: rebase conflict — local divergence detected; resolve manually or push first\n",
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/libraries/libwiki/src/index.js
+++ b/libraries/libwiki/src/index.js
@@ -6,3 +6,7 @@ export {
   INBOX_HEADING,
   BROADCAST_TARGET,
 } from "./constants.js";
+export { scanMarkers } from "./marker-scanner.js";
+export { renderBlock } from "./block-renderer.js";
+export { WikiRepo } from "./wiki-repo.js";
+export { listSkills } from "./skill-roster.js";

--- a/libraries/libwiki/src/marker-scanner.js
+++ b/libraries/libwiki/src/marker-scanner.js
@@ -1,0 +1,42 @@
+const OPEN_RE = /^<!--\s*xmr:([^:\s]+):([^\s]+)\s*-->\s*$/;
+const CLOSE_RE = /^<!--\s*\/xmr\s*-->\s*$/;
+
+export function scanMarkers(text) {
+  const lines = text.split("\n");
+  const pairs = [];
+  let open = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const openMatch = lines[i].match(OPEN_RE);
+    if (openMatch) {
+      if (open) {
+        process.stderr.write(
+          `dangling-marker ${open.metric} at line ${open.openLine + 1}\n`,
+        );
+      }
+      open = { metric: openMatch[1], csvPath: openMatch[2], openLine: i };
+      continue;
+    }
+
+    if (CLOSE_RE.test(lines[i])) {
+      if (open) {
+        pairs.push({
+          metric: open.metric,
+          csvPath: open.csvPath,
+          openLine: open.openLine,
+          closeLine: i,
+        });
+        open = null;
+      }
+      continue;
+    }
+  }
+
+  if (open) {
+    process.stderr.write(
+      `dangling-marker ${open.metric} at line ${open.openLine + 1}\n`,
+    );
+  }
+
+  return pairs;
+}

--- a/libraries/libwiki/src/skill-roster.js
+++ b/libraries/libwiki/src/skill-roster.js
@@ -1,0 +1,18 @@
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+export function listSkills({ skillsDir }, fs = { readdirSync, statSync }) {
+  const entries = fs.readdirSync(skillsDir);
+  const skills = [];
+
+  for (const entry of entries) {
+    if (entry.startsWith(".")) continue;
+    if (!entry.startsWith("kata-")) continue;
+    const fullPath = path.join(skillsDir, entry);
+    const stat = fs.statSync(fullPath);
+    if (!stat.isDirectory()) continue;
+    skills.push(entry);
+  }
+
+  return skills.sort();
+}

--- a/libraries/libwiki/src/wiki-repo.js
+++ b/libraries/libwiki/src/wiki-repo.js
@@ -1,0 +1,121 @@
+import { spawnSync } from "node:child_process";
+
+const CREDENTIAL_HELPER_BODY =
+  '!f() { echo username=x-access-token; echo "password=${GH_TOKEN:-$GITHUB_TOKEN}"; }; f';
+
+export class WikiPullConflict extends Error {
+  constructor(stderr) {
+    super("rebase conflict on pull");
+    this.name = "WikiPullConflict";
+    this.stderr = stderr;
+  }
+}
+
+export function buildAuthArgs(args, token) {
+  if (token) {
+    return [
+      "-c",
+      "credential.helper=",
+      "-c",
+      `credential.helper=${CREDENTIAL_HELPER_BODY}`,
+      ...args,
+    ];
+  }
+  return [...args];
+}
+
+export class WikiRepo {
+  #wikiDir;
+  #parentDir;
+
+  constructor({ wikiDir, parentDir }) {
+    this.#wikiDir = wikiDir;
+    this.#parentDir = parentDir;
+  }
+
+  isCloned() {
+    const r = spawnSync(
+      "git",
+      ["-C", this.#wikiDir, "rev-parse", "--git-dir"],
+      {
+        stdio: "pipe",
+      },
+    );
+    return r.status === 0;
+  }
+
+  ensureCloned(url) {
+    if (this.isCloned()) return { cloned: true, reason: "already-cloned" };
+    const r = this.#authGit(["clone", url, this.#wikiDir]);
+    if (r.status !== 0) {
+      return {
+        cloned: false,
+        reason: r.stderr?.toString().trim() || "clone failed",
+      };
+    }
+    return { cloned: true, reason: "cloned" };
+  }
+
+  inheritIdentity() {
+    const name = this.#parentConfig("user.name");
+    const email = this.#parentConfig("user.email");
+    if (name) this.#git(["config", "user.name", name]);
+    if (email) this.#git(["config", "user.email", email]);
+  }
+
+  fetch() {
+    this.#authGit(["-C", this.#wikiDir, "fetch", "origin", "master"]);
+  }
+
+  isClean() {
+    const r = this.#git(["status", "--porcelain"]);
+    return r.stdout.toString().trim() === "";
+  }
+
+  pull() {
+    this.fetch();
+    const r = this.#git(["rebase", "origin/master"]);
+    if (r.status !== 0) {
+      this.#git(["rebase", "--abort"]);
+      throw new WikiPullConflict(r.stderr?.toString().trim() || "");
+    }
+  }
+
+  commitAndPush(message) {
+    if (this.isClean()) return { pushed: false, reason: "clean" };
+    this.#git(["add", "-A"]);
+    this.#git(["commit", "-m", message]);
+    this.fetch();
+    const rebase = this.#git(["rebase", "origin/master"]);
+    if (rebase.status !== 0) {
+      this.#git(["rebase", "--abort"]);
+      this.#git(["merge", "origin/master", "-X", "ours", "--no-edit"]);
+    }
+    this.#authGit(["-C", this.#wikiDir, "push", "origin", "master"]);
+    return { pushed: true, reason: "pushed" };
+  }
+
+  #parentConfig(key) {
+    const r = spawnSync(
+      "git",
+      ["-C", this.#parentDir, "config", "--get", key],
+      {
+        stdio: "pipe",
+      },
+    );
+    return r.status === 0 ? r.stdout.toString().trim() : null;
+  }
+
+  #git(args) {
+    return spawnSync("git", ["-C", this.#wikiDir, ...args], { stdio: "pipe" });
+  }
+
+  #authGit(args) {
+    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+    const fullArgs = buildAuthArgs(args, token);
+    return spawnSync("git", fullArgs, {
+      stdio: "pipe",
+      env: token ? process.env : undefined,
+    });
+  }
+}

--- a/libraries/libwiki/test/block-renderer.test.js
+++ b/libraries/libwiki/test/block-renderer.test.js
@@ -1,0 +1,96 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { renderBlock, BlockRenderError } from "../src/block-renderer.js";
+import { analyze, renderChart } from "@forwardimpact/libxmr";
+
+const HEADER = "date,metric,value,unit,run,note";
+
+function makeCSV(metric, values) {
+  const rows = values.map(
+    (v, i) =>
+      `2026-01-${String(i + 1).padStart(2, "0")},${metric},${v},count,,`,
+  );
+  return [HEADER, ...rows].join("\n");
+}
+
+describe("renderBlock", () => {
+  test("predictable metric renders Latest, chart, and Signals", () => {
+    const dir = mkdtempSync(join(tmpdir(), "block-"));
+    const values = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10];
+    writeFileSync(join(dir, "test.csv"), makeCSV("findings", values));
+
+    const lines = renderBlock({
+      metric: "findings",
+      csvPath: "test.csv",
+      projectRoot: dir,
+    });
+
+    assert.ok(lines[0].startsWith("**Latest:** 10"));
+    assert.ok(lines[0].includes("**Status:** predictable"));
+    assert.equal(lines[1], "");
+    assert.equal(lines[2], "```");
+
+    const report = analyze(makeCSV("findings", values));
+    const m = report.metrics[0];
+    const expectedChart = renderChart(m.values, m.stats, m.signals);
+    const chartContent = lines.slice(3, lines.indexOf("```", 3)).join("\n");
+    assert.equal(chartContent, expectedChart);
+
+    const lastLine = lines[lines.length - 1];
+    assert.ok(lastLine.startsWith("**Signals:**"));
+    assert.ok(lastLine.includes("—"));
+  });
+
+  test("signals_present metric lists fired rules", () => {
+    const dir = mkdtempSync(join(tmpdir(), "block-"));
+    const values = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 50];
+    writeFileSync(join(dir, "test.csv"), makeCSV("outlier", values));
+
+    const lines = renderBlock({
+      metric: "outlier",
+      csvPath: "test.csv",
+      projectRoot: dir,
+    });
+
+    assert.ok(lines[0].includes("**Status:** signals_present"));
+    const signalLine = lines[lines.length - 1];
+    assert.ok(signalLine.includes("xRule1") || signalLine.includes("mrRule1"));
+  });
+
+  test("insufficient_data metric shows insufficient message", () => {
+    const dir = mkdtempSync(join(tmpdir(), "block-"));
+    const values = [10, 20, 30, 40, 50];
+    writeFileSync(join(dir, "test.csv"), makeCSV("few", values));
+
+    const lines = renderBlock({
+      metric: "few",
+      csvPath: "test.csv",
+      projectRoot: dir,
+    });
+
+    assert.ok(lines[0].includes("**Latest:** 50"));
+    assert.ok(lines[0].includes("**Status:** insufficient_data"));
+
+    const chartLine = lines[3];
+    assert.ok(chartLine.includes("Insufficient data"));
+    assert.ok(chartLine.includes("5 points"));
+  });
+
+  test("throws BlockRenderError for missing metric", () => {
+    const dir = mkdtempSync(join(tmpdir(), "block-"));
+    writeFileSync(join(dir, "test.csv"), makeCSV("exists", [10, 20, 30]));
+
+    assert.throws(
+      () =>
+        renderBlock({
+          metric: "nonexistent",
+          csvPath: "test.csv",
+          projectRoot: dir,
+        }),
+      BlockRenderError,
+    );
+  });
+});

--- a/libraries/libwiki/test/cli-init.test.js
+++ b/libraries/libwiki/test/cli-init.test.js
@@ -1,0 +1,79 @@
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { WikiRepo } from "../src/wiki-repo.js";
+import { listSkills } from "../src/skill-roster.js";
+import { git, createBareRepo, seedBareRepo } from "./helpers.js";
+
+describe("init command", () => {
+  let projectDir;
+  let bare;
+  let wikiDir;
+  let skillsDir;
+
+  beforeEach(() => {
+    bare = createBareRepo();
+    seedBareRepo(bare);
+
+    projectDir = mkdtempSync(join(tmpdir(), "wiki-project-"));
+    wikiDir = join(projectDir, "wiki");
+    skillsDir = join(projectDir, ".claude", "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    mkdirSync(join(skillsDir, "kata-spec"));
+    mkdirSync(join(skillsDir, "kata-plan"));
+    mkdirSync(join(skillsDir, "fit-wiki"));
+
+    git(projectDir, "init");
+    git(projectDir, "config", "user.name", "Project User");
+    git(projectDir, "config", "user.email", "project@example.com");
+  });
+
+  test("clones wiki and creates metrics directories", () => {
+    const repo = new WikiRepo({ wikiDir, parentDir: projectDir });
+    const result = repo.ensureCloned(bare);
+    assert.equal(result.cloned, true);
+
+    repo.inheritIdentity();
+
+    const skills = listSkills({ skillsDir });
+    for (const slug of skills) {
+      mkdirSync(join(wikiDir, "metrics", slug), { recursive: true });
+    }
+
+    const gitDir = git(wikiDir, "rev-parse", "--git-dir");
+    assert.ok(gitDir);
+
+    assert.ok(existsSync(join(wikiDir, "metrics", "kata-spec")));
+    assert.ok(existsSync(join(wikiDir, "metrics", "kata-plan")));
+    assert.ok(!existsSync(join(wikiDir, "metrics", "fit-wiki")));
+  });
+
+  test("idempotent — second run produces no error", () => {
+    const repo = new WikiRepo({ wikiDir, parentDir: projectDir });
+    repo.ensureCloned(bare);
+    repo.inheritIdentity();
+
+    const skills = listSkills({ skillsDir });
+    for (const slug of skills) {
+      mkdirSync(join(wikiDir, "metrics", slug), { recursive: true });
+    }
+
+    const result = repo.ensureCloned(bare);
+    assert.equal(result.cloned, true);
+    assert.equal(result.reason, "already-cloned");
+
+    for (const slug of skills) {
+      mkdirSync(join(wikiDir, "metrics", slug), { recursive: true });
+    }
+
+    assert.ok(existsSync(join(wikiDir, "metrics", "kata-spec")));
+  });
+
+  test("ensureCloned returns cloned:false for unreachable URL", () => {
+    const repo = new WikiRepo({ wikiDir, parentDir: projectDir });
+    const result = repo.ensureCloned("/nonexistent/repo.git");
+    assert.equal(result.cloned, false);
+  });
+});

--- a/libraries/libwiki/test/cli-refresh.test.js
+++ b/libraries/libwiki/test/cli-refresh.test.js
@@ -1,0 +1,199 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+const CLI_PATH = new URL("../bin/fit-wiki.js", import.meta.url).pathname;
+const HEADER = "date,metric,value,unit,run,note";
+
+function makeCSV(metric, values) {
+  const rows = values.map(
+    (v, i) =>
+      `2026-01-${String(i + 1).padStart(2, "0")},${metric},${v},count,,`,
+  );
+  return [HEADER, ...rows].join("\n");
+}
+
+function createProject() {
+  const dir = mkdtempSync(join(tmpdir(), "refresh-"));
+  writeFileSync(join(dir, "package.json"), '{"name":"root"}');
+  execFileSync("git", ["init", dir], { stdio: "pipe" });
+  return dir;
+}
+
+function run(cwd, storyboardPath) {
+  return execFileSync("node", [CLI_PATH, "refresh", storyboardPath], {
+    cwd,
+    encoding: "utf-8",
+    env: { ...process.env, PATH: process.env.PATH },
+    stdio: "pipe",
+  });
+}
+
+describe("fit-wiki refresh CLI", () => {
+  test("no markers — file unchanged", () => {
+    const dir = createProject();
+    const storyboard = join(dir, "storyboard.md");
+    const original = "# Storyboard\n\nSome prose.\n";
+    writeFileSync(storyboard, original);
+
+    run(dir, "storyboard.md");
+
+    const after = readFileSync(storyboard, "utf-8");
+    assert.equal(after, original);
+  });
+
+  test("one marker — block regenerated with chart", () => {
+    const dir = createProject();
+    const csvDir = join(dir, "wiki", "metrics", "kata-spec");
+    mkdirSync(csvDir, { recursive: true });
+    const values = Array(15).fill(10);
+    writeFileSync(join(csvDir, "2026.csv"), makeCSV("findings", values));
+
+    const storyboard = join(dir, "storyboard.md");
+    writeFileSync(
+      storyboard,
+      [
+        "#### findings",
+        "<!-- xmr:findings:wiki/metrics/kata-spec/2026.csv -->",
+        "old content here",
+        "<!-- /xmr -->",
+        "trailing prose",
+      ].join("\n"),
+    );
+
+    run(dir, "storyboard.md");
+
+    const after = readFileSync(storyboard, "utf-8");
+    assert.ok(after.includes("**Latest:** 10"));
+    assert.ok(after.includes("**Status:** predictable"));
+    assert.ok(after.includes("**Signals:**"));
+    assert.ok(after.includes("```"));
+    assert.ok(after.includes("trailing prose"));
+    assert.ok(!after.includes("old content here"));
+  });
+
+  test("idempotent — second refresh produces same output", () => {
+    const dir = createProject();
+    const csvDir = join(dir, "wiki", "metrics", "kata-spec");
+    mkdirSync(csvDir, { recursive: true });
+    const values = Array(15).fill(10);
+    writeFileSync(join(csvDir, "2026.csv"), makeCSV("findings", values));
+
+    const storyboard = join(dir, "storyboard.md");
+    writeFileSync(
+      storyboard,
+      [
+        "<!-- xmr:findings:wiki/metrics/kata-spec/2026.csv -->",
+        "placeholder",
+        "<!-- /xmr -->",
+      ].join("\n"),
+    );
+
+    run(dir, "storyboard.md");
+    const after1 = readFileSync(storyboard, "utf-8");
+
+    run(dir, "storyboard.md");
+    const after2 = readFileSync(storyboard, "utf-8");
+
+    assert.equal(after1, after2);
+  });
+
+  test("two markers — both blocks regenerated", () => {
+    const dir = createProject();
+    const csvDir = join(dir, "wiki", "metrics", "kata-spec");
+    mkdirSync(csvDir, { recursive: true });
+    const csv = [
+      HEADER,
+      ...Array(15)
+        .fill(null)
+        .map(
+          (_, i) =>
+            `2026-01-${String(i + 1).padStart(2, "0")},alpha,${10 + i},count,,`,
+        ),
+      ...Array(15)
+        .fill(null)
+        .map(
+          (_, i) =>
+            `2026-01-${String(i + 1).padStart(2, "0")},beta,${20 + i},count,,`,
+        ),
+    ].join("\n");
+    writeFileSync(join(csvDir, "2026.csv"), csv);
+
+    const storyboard = join(dir, "storyboard.md");
+    writeFileSync(
+      storyboard,
+      [
+        "#### alpha",
+        "<!-- xmr:alpha:wiki/metrics/kata-spec/2026.csv -->",
+        "old alpha",
+        "<!-- /xmr -->",
+        "",
+        "#### beta",
+        "<!-- xmr:beta:wiki/metrics/kata-spec/2026.csv -->",
+        "old beta",
+        "<!-- /xmr -->",
+      ].join("\n"),
+    );
+
+    run(dir, "storyboard.md");
+
+    const after = readFileSync(storyboard, "utf-8");
+    assert.ok(after.includes("**Latest:** 24"));
+    assert.ok(after.includes("**Latest:** 34"));
+    assert.ok(!after.includes("old alpha"));
+    assert.ok(!after.includes("old beta"));
+  });
+
+  test("missing CSV — block unchanged, exit 0", () => {
+    const dir = createProject();
+    const storyboard = join(dir, "storyboard.md");
+    const original = [
+      "<!-- xmr:metric:nonexistent.csv -->",
+      "preserved content",
+      "<!-- /xmr -->",
+    ].join("\n");
+    writeFileSync(storyboard, original);
+
+    run(dir, "storyboard.md");
+
+    const after = readFileSync(storyboard, "utf-8");
+    assert.ok(after.includes("preserved content"));
+  });
+
+  test("working-directory independence", () => {
+    const dir = createProject();
+    const csvDir = join(dir, "wiki", "metrics", "kata-spec");
+    mkdirSync(csvDir, { recursive: true });
+    writeFileSync(
+      join(csvDir, "2026.csv"),
+      makeCSV("metric", Array(15).fill(5)),
+    );
+
+    const storyboard = join(dir, "storyboard.md");
+    writeFileSync(
+      storyboard,
+      [
+        "<!-- xmr:metric:wiki/metrics/kata-spec/2026.csv -->",
+        "old",
+        "<!-- /xmr -->",
+      ].join("\n"),
+    );
+
+    const subdir = join(dir, "deep", "nested");
+    mkdirSync(subdir, { recursive: true });
+
+    execFileSync("node", [CLI_PATH, "refresh", "storyboard.md"], {
+      cwd: subdir,
+      encoding: "utf-8",
+      env: { ...process.env, PATH: process.env.PATH },
+      stdio: "pipe",
+    });
+
+    const after = readFileSync(storyboard, "utf-8");
+    assert.ok(after.includes("**Latest:** 5"));
+    assert.ok(!after.includes("old"));
+  });
+});

--- a/libraries/libwiki/test/cli-refresh.test.js
+++ b/libraries/libwiki/test/cli-refresh.test.js
@@ -196,4 +196,39 @@ describe("fit-wiki refresh CLI", () => {
     assert.ok(after.includes("**Latest:** 5"));
     assert.ok(!after.includes("old"));
   });
+
+  test("defaults to current month storyboard when no path given", () => {
+    const dir = createProject();
+    const csvDir = join(dir, "wiki", "metrics", "kata-spec");
+    mkdirSync(csvDir, { recursive: true });
+    writeFileSync(
+      join(csvDir, "2026.csv"),
+      makeCSV("metric", Array(15).fill(7)),
+    );
+
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const defaultPath = join(dir, "wiki", `storyboard-${yyyy}-M${mm}.md`);
+    mkdirSync(join(dir, "wiki"), { recursive: true });
+    writeFileSync(
+      defaultPath,
+      [
+        "<!-- xmr:metric:wiki/metrics/kata-spec/2026.csv -->",
+        "old",
+        "<!-- /xmr -->",
+      ].join("\n"),
+    );
+
+    execFileSync("node", [CLI_PATH, "refresh"], {
+      cwd: dir,
+      encoding: "utf-8",
+      env: { ...process.env, PATH: process.env.PATH },
+      stdio: "pipe",
+    });
+
+    const after = readFileSync(defaultPath, "utf-8");
+    assert.ok(after.includes("**Latest:** 7"));
+    assert.ok(!after.includes("old"));
+  });
 });

--- a/libraries/libwiki/test/cli-sync.test.js
+++ b/libraries/libwiki/test/cli-sync.test.js
@@ -1,0 +1,78 @@
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { WikiRepo, WikiPullConflict } from "../src/wiki-repo.js";
+import { git, createBareRepo, seedBareRepo, cloneRepo } from "./helpers.js";
+
+describe("push/pull commands", () => {
+  let bare;
+
+  beforeEach(() => {
+    bare = createBareRepo();
+    seedBareRepo(bare);
+  });
+
+  test("push with no local changes is no-op", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "push-noop");
+    git(wikiDir, "checkout", "master");
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+
+    const result = repo.commitAndPush("wiki: update");
+    assert.equal(result.pushed, false);
+    assert.equal(result.reason, "clean");
+  });
+
+  test("push with local change commits and pushes", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "push-dirty");
+    git(wikiDir, "checkout", "master");
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+
+    writeFileSync(join(wikiDir, "new.md"), "content");
+    const result = repo.commitAndPush("wiki: update from session");
+    assert.equal(result.pushed, true);
+
+    const log = git(wikiDir, "log", "-1", "--oneline");
+    assert.ok(log.includes("wiki: update from session"));
+
+    const diff = git(wikiDir, "diff", "origin/master");
+    assert.equal(diff, "");
+  });
+
+  test("pull picks up external commit", () => {
+    const { wikiDir: w1 } = cloneRepo(bare, "pull-ext1");
+    const { parent: p2, wikiDir: w2 } = cloneRepo(bare, "pull-ext2");
+    git(w1, "checkout", "master");
+    git(w2, "checkout", "master");
+
+    writeFileSync(join(w1, "external.md"), "from another clone");
+    git(w1, "add", "-A");
+    git(w1, "commit", "-m", "external push");
+    git(w1, "push", "origin", "master");
+
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    repo2.pull();
+
+    const content = readFileSync(join(w2, "external.md"), "utf-8");
+    assert.equal(content.trim(), "from another clone");
+  });
+
+  test("pull with diverging local edit throws WikiPullConflict", () => {
+    const { wikiDir: w1 } = cloneRepo(bare, "pull-div1");
+    const { parent: p2, wikiDir: w2 } = cloneRepo(bare, "pull-div2");
+    git(w1, "checkout", "master");
+    git(w2, "checkout", "master");
+
+    writeFileSync(join(w1, "README.md"), "remote edit");
+    git(w1, "add", "-A");
+    git(w1, "commit", "-m", "remote");
+    git(w1, "push", "origin", "master");
+
+    writeFileSync(join(w2, "README.md"), "local edit");
+    git(w2, "add", "-A");
+    git(w2, "commit", "-m", "local");
+
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    assert.throws(() => repo2.pull(), WikiPullConflict);
+  });
+});

--- a/libraries/libwiki/test/helpers.js
+++ b/libraries/libwiki/test/helpers.js
@@ -1,0 +1,41 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+export function git(dir, ...args) {
+  return execFileSync("git", ["-C", dir, ...args], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  }).trim();
+}
+
+export function createBareRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "wiki-bare-"));
+  execFileSync("git", ["init", "--bare", dir], { stdio: "pipe" });
+  return dir;
+}
+
+export function seedBareRepo(bare) {
+  const tmp = mkdtempSync(join(tmpdir(), "wiki-seed-"));
+  execFileSync("git", ["clone", bare, tmp], { stdio: "pipe" });
+  git(tmp, "config", "user.name", "Seed");
+  git(tmp, "config", "user.email", "seed@example.com");
+  git(tmp, "checkout", "-b", "master");
+  writeFileSync(join(tmp, "README.md"), "# Wiki\n");
+  git(tmp, "add", "-A");
+  git(tmp, "commit", "-m", "init");
+  git(tmp, "push", "origin", "master");
+}
+
+export function cloneRepo(bare, name) {
+  const parent = mkdtempSync(join(tmpdir(), `wiki-${name}-`));
+  execFileSync("git", ["clone", bare, "wiki"], {
+    cwd: parent,
+    stdio: "pipe",
+  });
+  const wikiDir = join(parent, "wiki");
+  git(wikiDir, "config", "user.name", "Test User");
+  git(wikiDir, "config", "user.email", "test@example.com");
+  return { parent, wikiDir };
+}

--- a/libraries/libwiki/test/marker-scanner.test.js
+++ b/libraries/libwiki/test/marker-scanner.test.js
@@ -1,0 +1,86 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { scanMarkers } from "../src/marker-scanner.js";
+
+describe("scanMarkers", () => {
+  test("returns [] for text with no markers", () => {
+    const text = "# Storyboard\n\nSome prose here.\n";
+    assert.deepEqual(scanMarkers(text), []);
+  });
+
+  test("finds one marker pair", () => {
+    const text = [
+      "#### findings_count",
+      "<!-- xmr:findings_count:wiki/metrics/kata-spec/2026.csv -->",
+      "**Latest:** 3 · **Status:** predictable",
+      "<!-- /xmr -->",
+      "some prose",
+    ].join("\n");
+
+    const pairs = scanMarkers(text);
+    assert.equal(pairs.length, 1);
+    assert.equal(pairs[0].metric, "findings_count");
+    assert.equal(pairs[0].csvPath, "wiki/metrics/kata-spec/2026.csv");
+    assert.equal(pairs[0].openLine, 1);
+    assert.equal(pairs[0].closeLine, 3);
+  });
+
+  test("finds two marker pairs separated by prose", () => {
+    const text = [
+      "<!-- xmr:alpha:a.csv -->",
+      "content a",
+      "<!-- /xmr -->",
+      "prose between",
+      "<!-- xmr:beta:b.csv -->",
+      "content b",
+      "<!-- /xmr -->",
+    ].join("\n");
+
+    const pairs = scanMarkers(text);
+    assert.equal(pairs.length, 2);
+    assert.equal(pairs[0].metric, "alpha");
+    assert.equal(pairs[1].metric, "beta");
+  });
+
+  test("skips dangling open marker", () => {
+    const text = ["<!-- xmr:orphan:o.csv -->", "never closed"].join("\n");
+
+    const pairs = scanMarkers(text);
+    assert.equal(pairs.length, 0);
+  });
+
+  test("malformed close marker is not recognized", () => {
+    const text = [
+      "<!-- xmr:metric:path.csv -->",
+      "content",
+      "<!-- xmr -->",
+    ].join("\n");
+
+    const pairs = scanMarkers(text);
+    assert.equal(pairs.length, 0);
+  });
+
+  test("second open before close resets to new marker", () => {
+    const text = [
+      "<!-- xmr:first:a.csv -->",
+      "content",
+      "<!-- xmr:second:b.csv -->",
+      "replaced content",
+      "<!-- /xmr -->",
+    ].join("\n");
+
+    const pairs = scanMarkers(text);
+    assert.equal(pairs.length, 1);
+    assert.equal(pairs[0].metric, "second");
+    assert.equal(pairs[0].csvPath, "b.csv");
+    assert.equal(pairs[0].openLine, 2);
+    assert.equal(pairs[0].closeLine, 4);
+  });
+
+  test("close without open is ignored", () => {
+    const text = ["<!-- /xmr -->", "stray close"].join("\n");
+
+    const pairs = scanMarkers(text);
+    assert.equal(pairs.length, 0);
+  });
+});

--- a/libraries/libwiki/test/skill-roster.test.js
+++ b/libraries/libwiki/test/skill-roster.test.js
@@ -1,0 +1,46 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { listSkills } from "../src/skill-roster.js";
+
+describe("listSkills", () => {
+  test("empty dir returns []", () => {
+    const dir = mkdtempSync(join(tmpdir(), "skills-"));
+    assert.deepEqual(listSkills({ skillsDir: dir }), []);
+  });
+
+  test("returns only kata-* directories", () => {
+    const dir = mkdtempSync(join(tmpdir(), "skills-"));
+    mkdirSync(join(dir, "kata-spec"));
+    mkdirSync(join(dir, "kata-plan"));
+    mkdirSync(join(dir, "fit-wiki"));
+    mkdirSync(join(dir, "kata-session"));
+    writeFileSync(join(dir, "kata-file.txt"), "not a dir");
+
+    const result = listSkills({ skillsDir: dir });
+    assert.deepEqual(result, ["kata-plan", "kata-session", "kata-spec"]);
+  });
+
+  test("ignores dot-prefixed entries", () => {
+    const dir = mkdtempSync(join(tmpdir(), "skills-"));
+    mkdirSync(join(dir, ".DS_Store_kata-hidden"));
+    mkdirSync(join(dir, "kata-real"));
+
+    const result = listSkills({ skillsDir: dir });
+    assert.deepEqual(result, ["kata-real"]);
+  });
+
+  test("sorted output is stable", () => {
+    const dir = mkdtempSync(join(tmpdir(), "skills-"));
+    mkdirSync(join(dir, "kata-z"));
+    mkdirSync(join(dir, "kata-a"));
+    mkdirSync(join(dir, "kata-m"));
+
+    const r1 = listSkills({ skillsDir: dir });
+    const r2 = listSkills({ skillsDir: dir });
+    assert.deepEqual(r1, ["kata-a", "kata-m", "kata-z"]);
+    assert.deepEqual(r1, r2);
+  });
+});

--- a/libraries/libwiki/test/wiki-repo.test.js
+++ b/libraries/libwiki/test/wiki-repo.test.js
@@ -1,0 +1,186 @@
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { WikiRepo, WikiPullConflict, buildAuthArgs } from "../src/wiki-repo.js";
+import { git, createBareRepo, seedBareRepo, cloneRepo } from "./helpers.js";
+
+describe("WikiRepo", () => {
+  let bare;
+
+  beforeEach(() => {
+    bare = createBareRepo();
+    seedBareRepo(bare);
+  });
+
+  test("isCloned returns false for empty dir", () => {
+    const dir = mkdtempSync(join(tmpdir(), "wiki-empty-"));
+    const repo = new WikiRepo({ wikiDir: join(dir, "wiki"), parentDir: dir });
+    assert.equal(repo.isCloned(), false);
+  });
+
+  test("ensureCloned clones and isCloned returns true", () => {
+    const parent = mkdtempSync(join(tmpdir(), "wiki-parent-"));
+    const wikiDir = join(parent, "wiki");
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+
+    const result = repo.ensureCloned(bare);
+    assert.equal(result.cloned, true);
+    assert.equal(repo.isCloned(), true);
+  });
+
+  test("ensureCloned is no-op when already cloned", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "noop");
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+
+    const result = repo.ensureCloned(bare);
+    assert.equal(result.cloned, true);
+    assert.equal(result.reason, "already-cloned");
+  });
+
+  test("ensureCloned returns cloned:false for bad URL", () => {
+    const parent = mkdtempSync(join(tmpdir(), "wiki-bad-"));
+    const wikiDir = join(parent, "wiki");
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+
+    const result = repo.ensureCloned("/nonexistent/path.git");
+    assert.equal(result.cloned, false);
+  });
+
+  test("isClean detects dirty tree", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "dirty");
+    git(wikiDir, "checkout", "master");
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+
+    assert.equal(repo.isClean(), true);
+    writeFileSync(join(wikiDir, "new.md"), "content");
+    assert.equal(repo.isClean(), false);
+  });
+
+  test("inheritIdentity propagates parent config", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "identity");
+    git(parent, "init");
+    git(parent, "config", "user.name", "Parent Name");
+    git(parent, "config", "user.email", "parent@example.com");
+
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    repo.inheritIdentity();
+
+    assert.equal(git(wikiDir, "config", "--get", "user.name"), "Parent Name");
+    assert.equal(
+      git(wikiDir, "config", "--get", "user.email"),
+      "parent@example.com",
+    );
+  });
+
+  test("pull picks up remote changes", () => {
+    const { wikiDir: w1 } = cloneRepo(bare, "pull1");
+    const { parent: p2, wikiDir: w2 } = cloneRepo(bare, "pull2");
+    git(w1, "checkout", "master");
+    git(w2, "checkout", "master");
+
+    writeFileSync(join(w1, "change.md"), "from clone1");
+    git(w1, "add", "-A");
+    git(w1, "commit", "-m", "clone1 change");
+    git(w1, "push", "origin", "master");
+
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    repo2.pull();
+
+    const content = execFileSync("cat", [join(w2, "change.md")], {
+      encoding: "utf-8",
+    });
+    assert.equal(content.trim(), "from clone1");
+  });
+
+  test("pull throws WikiPullConflict on divergence", () => {
+    const { wikiDir: w1 } = cloneRepo(bare, "conflict1");
+    const { parent: p2, wikiDir: w2 } = cloneRepo(bare, "conflict2");
+    git(w1, "checkout", "master");
+    git(w2, "checkout", "master");
+
+    writeFileSync(join(w1, "README.md"), "clone1 edit");
+    git(w1, "add", "-A");
+    git(w1, "commit", "-m", "clone1");
+    git(w1, "push", "origin", "master");
+
+    writeFileSync(join(w2, "README.md"), "clone2 edit");
+    git(w2, "add", "-A");
+    git(w2, "commit", "-m", "clone2");
+
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    assert.throws(() => repo2.pull(), WikiPullConflict);
+  });
+
+  test("commitAndPush is no-op on clean tree", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "clean");
+    git(wikiDir, "checkout", "master");
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+
+    const result = repo.commitAndPush("test");
+    assert.equal(result.pushed, false);
+    assert.equal(result.reason, "clean");
+  });
+
+  test("commitAndPush commits and pushes dirty tree", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "push");
+    git(wikiDir, "checkout", "master");
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+
+    writeFileSync(join(wikiDir, "update.md"), "new content");
+    const result = repo.commitAndPush("wiki: test push");
+    assert.equal(result.pushed, true);
+
+    const log = git(wikiDir, "log", "-1", "--oneline");
+    assert.ok(log.includes("wiki: test push"));
+
+    const diff = git(wikiDir, "diff", "origin/master");
+    assert.equal(diff, "");
+  });
+
+  test("commitAndPush recovers via merge -X ours on divergence", () => {
+    const { wikiDir: w1 } = cloneRepo(bare, "merge1");
+    const { parent: p2, wikiDir: w2 } = cloneRepo(bare, "merge2");
+    git(w1, "checkout", "master");
+    git(w2, "checkout", "master");
+
+    writeFileSync(join(w1, "README.md"), "remote change");
+    git(w1, "add", "-A");
+    git(w1, "commit", "-m", "remote");
+    git(w1, "push", "origin", "master");
+
+    writeFileSync(join(w2, "README.md"), "local wins");
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    const result = repo2.commitAndPush("wiki: local update");
+    assert.equal(result.pushed, true);
+
+    const content = execFileSync("cat", [join(w2, "README.md")], {
+      encoding: "utf-8",
+    });
+    assert.equal(content.trim(), "local wins");
+  });
+});
+
+describe("buildAuthArgs", () => {
+  test("prepends credential helper flags when token is set", () => {
+    const args = ["-C", "/wiki", "fetch", "origin", "master"];
+    const result = buildAuthArgs(args, "ghp_test123");
+
+    assert.equal(result[0], "-c");
+    assert.equal(result[1], "credential.helper=");
+    assert.equal(result[2], "-c");
+    assert.ok(result[3].startsWith("credential.helper=!f()"));
+    assert.ok(result[3].includes("x-access-token"));
+    assert.ok(result[3].includes("GH_TOKEN"));
+    assert.deepEqual(result.slice(4), args);
+  });
+
+  test("passes args through without flags when no token", () => {
+    const args = ["clone", "https://example.com/repo.git", "/wiki"];
+    const result = buildAuthArgs(args, undefined);
+
+    assert.deepEqual(result, args);
+  });
+});

--- a/websites/fit/docs/libraries/wiki-operations/index.md
+++ b/websites/fit/docs/libraries/wiki-operations/index.md
@@ -1,11 +1,11 @@
 ---
 title: Wiki Operations
-description: Send cross-team memos and manage wiki markers with fit-wiki.
+description: Send cross-team memos, refresh storyboard charts, and sync the wiki with fit-wiki.
 ---
 
-`fit-wiki` is the operational CLI for agent wiki lifecycle management. It writes
-into teammates' inboxes so agents can communicate without spending thinking
-tokens on file discovery, section parsing, or indentation matching.
+`fit-wiki` is the operational CLI for agent wiki lifecycle management. It
+handles cross-team memos, storyboard chart maintenance, and wiki git
+lifecycle — so agents can focus on domain work instead of file plumbing.
 
 ## Getting Started
 
@@ -48,6 +48,53 @@ Each memo is inserted as a single markdown bullet directly after the marker:
 Newest memos appear first within the section. Multi-line messages are collapsed
 to a single line.
 
+## Refreshing Storyboards
+
+The `refresh` command scans a storyboard markdown file for
+`<!-- xmr:metric:path -->` / `<!-- /xmr -->` marker pairs and regenerates each
+block with the current XmR chart, latest value, status, and signals from the
+referenced CSV.
+
+```sh
+npx fit-wiki refresh wiki/storyboard-2026-M05.md
+```
+
+The command is idempotent — running it twice produces the same output. Files
+without markers are left unchanged. Use this after recording metrics with
+`npx fit-xmr record` to keep the storyboard's Current Condition section current.
+
+## Initializing the Wiki
+
+The `init` command bootstraps a wiki working tree for a Kata installation. It
+clones the repository's wiki into `./wiki/` and creates
+`wiki/metrics/<skill>/` directories for each kata skill.
+
+```sh
+npx fit-wiki init
+```
+
+Idempotent — safe to run on an already-initialized wiki. Authenticates using
+ambient GitHub credentials (`GITHUB_TOKEN` or `GH_TOKEN`).
+
+## Syncing the Wiki
+
+The `push` and `pull` commands replace shell-script plumbing with portable npm
+commands.
+
+```sh
+# Pull remote changes (e.g. in SessionStart hook)
+npx fit-wiki pull
+
+# Commit and push local changes (e.g. in Stop hook)
+npx fit-wiki push
+```
+
+`push` is a no-op when no local changes exist. On push conflicts, local state
+wins. `pull` exits non-zero with a diagnostic message on conflict.
+
+Both commands are designed for use in Claude Code hooks and GitHub Actions
+post-run steps.
+
 ## The Marker Contract
 
 Each agent summary must contain exactly one `<!-- memo:inbox -->` HTML comment
@@ -67,7 +114,15 @@ writes. If the marker is absent, the command exits 2 with a diagnostic.
 ## Programmatic API
 
 ```js
-import { writeMemo, listAgents, insertMarkers } from "@forwardimpact/libwiki";
+import {
+  writeMemo,
+  listAgents,
+  insertMarkers,
+  scanMarkers,
+  renderBlock,
+  WikiRepo,
+  listSkills,
+} from "@forwardimpact/libwiki";
 
 // Append a single memo
 const result = writeMemo({
@@ -87,5 +142,15 @@ const agents = listAgents({
 const migration = insertMarkers({
   agentsDir: ".claude/agents",
   wikiRoot: "wiki",
+});
+
+// Scan storyboard for XmR marker pairs
+const blocks = scanMarkers(storyboardText);
+
+// Render one XmR chart block
+const lines = renderBlock({
+  metric: "findings",
+  csvPath: "wiki/metrics/kata-spec/2026.csv",
+  projectRoot: "/path/to/project",
 });
 ```

--- a/websites/fit/docs/libraries/wiki-operations/index.md
+++ b/websites/fit/docs/libraries/wiki-operations/index.md
@@ -56,12 +56,16 @@ block with the current XmR chart, latest value, status, and signals from the
 referenced CSV.
 
 ```sh
+# Current month's storyboard (default)
+npx fit-wiki refresh
+
+# Explicit path
 npx fit-wiki refresh wiki/storyboard-2026-M05.md
 ```
 
-The command is idempotent — running it twice produces the same output. Files
-without markers are left unchanged. Use this after recording metrics with
-`npx fit-xmr record` to keep the storyboard's Current Condition section current.
+Without a path argument, defaults to the current month's storyboard
+(`wiki/storyboard-YYYY-MNN.md`). Idempotent — running it twice produces the
+same output. Files without markers are left unchanged.
 
 ## Initializing the Wiki
 


### PR DESCRIPTION
## Summary

- Add four subcommands to `fit-wiki`: `refresh` (regenerate XmR storyboard charts), `init` (bootstrap wiki), `push`/`pull` (sync wiki git)
- New modules: `WikiRepo`, `SkillRoster`, `MarkerScanner`, `BlockRenderer` with 59 tests
- Update storyboard template with `<!-- xmr:... -->` markers, justfile recipes switch to `bunx fit-wiki`, skill/guide docs expanded

## Test plan

- [x] `bun run check` passes (format, lint, instructions, catalog)
- [x] `bun run test` passes (2732 tests across 250 files)
- [x] 59 libwiki tests pass (7 new test files + existing)
- [x] `bunx fit-wiki --help` lists all 5 commands
- [x] Refresh idempotency verified (criterion #2)
- [x] Refresh no-op on unmarked files (criterion #3)
- [x] `buildAuthArgs` credential helper test covers plan risk mitigation
- [x] Clean 5-reviewer panel — all blocker/high/medium findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)