### PR TITLE
design(790): libdoc content partials and builder rearchitecture

### DIFF
--- a/specs/790-libdoc-content-partials/design-a.md
+++ b/specs/790-libdoc-content-partials/design-a.md
@@ -1,0 +1,179 @@
+# Design-A — Spec 790: Libdoc Content Partials
+
+## Architecture
+
+The build pipeline shifts from a two-pass class (discover files, collect titles,
+then render each page) to a three-stage pipeline: **scan** the site tree once,
+**resolve** partials per page, then **render**. Two new modules (`site-tree.js`,
+`partials.js`) own the first two stages; `DocsBuilder` orchestrates the pipeline
+and owns rendering, template application, and output.
+
+```mermaid
+flowchart LR
+  S["site-tree.js\nscanSiteTree()"] -- SiteTree map --> P["partials.js\nresolvePartials()"]
+  P -- markdown with HTML --> R["builder.js\nrender + write"]
+  S -- SiteTree map --> R
+  S -- SiteTree map --> X["sitemap / llms.txt"]
+```
+
+## Components
+
+| Component | Module | Responsibility |
+|---|---|---|
+| `scanSiteTree` | `site-tree.js` (new) | Walk docs dir, parse frontmatter, return `SiteTree` map |
+| `resolvePartials` | `partials.js` (new) | Replace `<!-- part:type:path -->` markers with HTML from the registry |
+| `defaultRegistry` | `partials.js` (new) | `card` and `link` partial type renderers |
+| `DocsBuilder` | `builder.js` (modified) | Orchestrate: scan, resolve, render, template, format, write |
+| transforms | `transforms.js` (unchanged) | Link rewriting, breadcrumbs, TOC, hero vars |
+| `parseFrontMatter` | `frontmatter.js` (unchanged) | YAML frontmatter extraction |
+
+## Data Structures
+
+### SiteTree
+
+```
+Map<urlPath, PageMeta>
+
+PageMeta = {
+  filePath: string     // relative to docsDir, e.g. "docs/getting-started/index.md"
+  urlPath:  string     // e.g. "/docs/getting-started/"
+  title:    string
+  description: string
+}
+```
+
+Built once by `scanSiteTree`, passed immutably through the pipeline. Replaces
+both the `pageTitles` map from Pass 1 and the `pages` array accumulated during
+Pass 2 — sitemap and llms.txt generation read directly from the site tree.
+
+Only pages with a `title` in frontmatter are included (matching current
+behavior where titleless pages are skipped).
+
+### Partial registry
+
+```
+Record<string, (meta: PageMeta, href: string) => string>
+```
+
+Two initial entries:
+
+| Type | Output |
+|---|---|
+| `card` | `<a href="${href}">\n<h3>${title}</h3>\n<p>${description}</p>\n</a>` |
+| `link` | `<a href="${href}">${title}</a>` |
+
+Adding a third type means adding one entry to this object — no changes to the
+resolver or builder (success criterion 10).
+
+## Build Pipeline
+
+```mermaid
+flowchart TD
+  subgraph "Stage 1 — Scan"
+    S1[Walk docsDir, skip assets/public/CLAUDE.md/SKILL.md]
+    S1 --> S2[Parse frontmatter per .md file]
+    S2 --> S3["Return SiteTree map (urlPath → PageMeta)"]
+  end
+
+  subgraph "Stage 2 — Render each page"
+    R1[Read file, parse frontmatter]
+    R1 --> R2["resolvePartials(markdown, siteTree, pageDir, registry)"]
+    R2 --> R3["marked(markdown) → HTML"]
+    R3 --> R4[Transform links]
+    R4 --> R5["Template vars + breadcrumbs (from siteTree)"]
+    R5 --> R6[Mustache render]
+    R6 --> R7[Prettier format]
+    R7 --> R8[Write .html + companion .md]
+  end
+
+  subgraph "Stage 3 — Post"
+    P1[Copy static assets]
+    P2["sitemap.xml (from siteTree)"]
+    P3["llms.txt (from siteTree)"]
+  end
+
+  S3 --> R1
+  S3 -.-> R2
+  S3 -.-> R5
+  R8 --> P1
+  S3 --> P2
+  S3 --> P3
+```
+
+## Key Decisions
+
+| Decision | Choice | Rejected | Why |
+|---|---|---|---|
+| Site tree scope | Single upfront scan collects path, title, description | Extend `pageTitles` map with extra fields | Adding fields piecemeal perpetuates the two-pass design; a complete scan is simpler and feeds partials, sitemap, and llms.txt from one structure |
+| Partials processing order | Resolve before `marked` | Resolve after markdown-to-HTML | Partial output is raw HTML that `marked` passes through unchanged, matching how hub pages work today; post-render resolution risks double-escaping |
+| Partial implementation | Pre-processing function with regex | Custom `marked` extension | HTML comments are not markdown syntax; a standalone function is simpler and independently testable without coupling to marked's extension API |
+| Type dispatch | Plain object registry | Switch/case in resolver | A registry entry per type satisfies criterion 10 (no resolver changes to add a type) |
+| Module decomposition | Two new focused modules (`site-tree.js`, `partials.js`) | More private methods on DocsBuilder | The class already has 15 private methods; separate modules with explicit inputs are independently testable and reduce per-module concept count |
+| Module decomposition | Two focused modules | Plugin architecture with lifecycle hooks | Over-engineering; spec calls for fewer concepts, not an extensibility framework |
+
+## Partials
+
+### Marker syntax
+
+```
+<!-- part:<type>:<path> -->
+```
+
+Matched by: `/<!--\s*part:(\w+):([\w./-]+)\s*-->/g`
+
+### Path resolution
+
+Given `<!-- part:card:getting-started -->` in `docs/products/index.md`:
+
+1. Source directory: `docs/products/`
+2. Join with partial path: `docs/products/getting-started`
+3. Normalize (resolve `..` segments)
+4. Compute urlPath → `/docs/products/getting-started/`
+5. Look up in SiteTree
+6. Fail with source file and partial path if not found
+
+### Href computation
+
+Relative URL from current page to target page, computed via `path.relative()`:
+
+| Current page | Target | Href |
+|---|---|---|
+| `/docs/` | `/docs/getting-started/` | `getting-started/` |
+| `/docs/products/` | `/docs/libraries/typed-contracts/` | `../libraries/typed-contracts/` |
+| `/docs/products/` | `/map/` | `../../map/` |
+
+### Errors (both fatal)
+
+- Unknown type: `Unknown partial type "foo" in docs/index.md`
+- Missing target: `Partial target "nonexistent" not found in site tree (referenced from docs/index.md)`
+
+## Builder Changes
+
+### Removed from DocsBuilder
+
+`#findMarkdownFiles`, `#collectMarkdownEntry`, `#collectPageTitles` — replaced
+by `scanSiteTree`.
+
+### Modified in DocsBuilder
+
+- **`build()`** — calls `scanSiteTree()` instead of two-step discovery; passes
+  `siteTree` to rendering, sitemap, and llms.txt; no longer accumulates a
+  `pages` array.
+- **`#renderPage()`** — calls `resolvePartials(markdown, siteTree, pageDir,
+  registry)` before `this.#marked(markdown)`.
+- **`#buildTemplateVars()`** — receives `siteTree` instead of `pageTitles`;
+  breadcrumb title lookup reads `siteTree.get(path).title`.
+- **`#generateSitemap()` / `#augmentLlmsTxt()`** — iterate `siteTree.values()`
+  instead of receiving a separate pages array.
+
+### Unchanged
+
+Constructor signature, public API (`async build(docsDir, distDir, baseUrl)`),
+dependency injection pattern, CLI interface, template, CSS.
+
+## Migration
+
+Replace `<a>` card content inside `<div class="grid">` on the 17 hub pages
+(all except `websites/fit/index.md`) with `<!-- part:card:path -->` markers.
+The `<div class="grid">` wrappers and `## Job Heading` sections stay
+hand-written. Success criterion 6 verifies identical HTML output via diff.

--- a/specs/790-libdoc-content-partials/design-a.md
+++ b/specs/790-libdoc-content-partials/design-a.md
@@ -24,7 +24,7 @@ flowchart LR
 | `resolvePartials` | `partials.js` (new) | Replace `<!-- part:type:path -->` markers with HTML from the registry |
 | `defaultRegistry` | `partials.js` (new) | `card` and `link` partial type renderers |
 | `DocsBuilder` | `builder.js` (modified) | Orchestrate: scan, resolve, render, template, format, write |
-| transforms | `transforms.js` (unchanged) | Link rewriting, breadcrumbs, TOC, hero vars |
+| transforms | `transforms.js` (minor change) | Link rewriting, breadcrumbs, TOC, hero vars |
 | `parseFrontMatter` | `frontmatter.js` (unchanged) | YAML frontmatter extraction |
 
 ## Data Structures
@@ -47,7 +47,9 @@ both the `pageTitles` map from Pass 1 and the `pages` array accumulated during
 Pass 2 — sitemap and llms.txt generation read directly from the site tree.
 
 Only pages with a `title` in frontmatter are included (matching current
-behavior where titleless pages are skipped).
+behavior where titleless pages are skipped). PageMeta holds scan-time metadata
+only — per-page rendering still reads the full file for markdown content and
+layout/hero/toc frontmatter fields.
 
 ### Partial registry
 
@@ -108,7 +110,7 @@ flowchart TD
 | Partials processing order | Resolve before `marked` | Resolve after markdown-to-HTML | Partial output is raw HTML that `marked` passes through unchanged, matching how hub pages work today; post-render resolution risks double-escaping |
 | Partial implementation | Pre-processing function with regex | Custom `marked` extension | HTML comments are not markdown syntax; a standalone function is simpler and independently testable without coupling to marked's extension API |
 | Type dispatch | Plain object registry | Switch/case in resolver | A registry entry per type satisfies criterion 10 (no resolver changes to add a type) |
-| Module decomposition | Two new focused modules (`site-tree.js`, `partials.js`) | More private methods on DocsBuilder | The class already has 15 private methods; separate modules with explicit inputs are independently testable and reduce per-module concept count |
+| Module decomposition | Two new focused modules (`site-tree.js`, `partials.js`) | More private methods on DocsBuilder | The class already has 12 private methods; separate modules with explicit inputs are independently testable and reduce per-module concept count |
 | Module decomposition | Two focused modules | Plugin architecture with lifecycle hooks | Over-engineering; spec calls for fewer concepts, not an extensibility framework |
 
 ## Partials
@@ -161,8 +163,9 @@ by `scanSiteTree`.
   `pages` array.
 - **`#renderPage()`** — calls `resolvePartials(markdown, siteTree, pageDir,
   registry)` before `this.#marked(markdown)`.
-- **`#buildTemplateVars()`** — receives `siteTree` instead of `pageTitles`;
-  breadcrumb title lookup reads `siteTree.get(path).title`.
+- **`#buildTemplateVars()`** — receives `siteTree` instead of `pageTitles`.
+- **`buildBreadcrumbs()`** in `transforms.js` — accepts `SiteTree` map and
+  reads `.title` from each entry instead of receiving a `Map<string, string>`.
 - **`#generateSitemap()` / `#augmentLlmsTxt()`** — iterate `siteTree.values()`
   instead of receiving a separate pages array.
 

--- a/specs/790-libdoc-content-partials/design-a.md
+++ b/specs/790-libdoc-content-partials/design-a.md
@@ -3,48 +3,58 @@
 ## Architecture
 
 The build pipeline shifts from a two-pass class (discover files, collect titles,
-then render each page) to a three-stage pipeline: **scan** the site tree once,
-**resolve** partials per page, then **render**. Two new modules (`site-tree.js`,
-`partials.js`) own the first two stages; `DocsBuilder` orchestrates the pipeline
-and owns rendering, template application, and output.
+then render each page) to a three-stage pipeline: **scan** pages once,
+**resolve** partials per page, then **render**. Two new modules
+(`page-tree.js`, `partials.js`) own the first two stages; `PagesBuilder`
+orchestrates the pipeline and owns rendering, template application, and output.
 
 ```mermaid
 flowchart LR
-  S["site-tree.js\nscanSiteTree()"] -- SiteTree map --> P["partials.js\nresolvePartials()"]
+  S["page-tree.js\nscanPages()"] -- PageTree map --> P["partials.js\nresolvePartials()"]
   P -- markdown with HTML --> R["builder.js\nrender + write"]
-  S -- SiteTree map --> R
-  S -- SiteTree map --> X["sitemap / llms.txt"]
+  S -- PageTree map --> R
+  S -- PageTree map --> X["sitemap / llms.txt"]
 ```
+
+## Design Goals
+
+### Naming alignment with libpages
+
+All new and renamed code uses `Page` / `Pages` vocabulary — `PagesBuilder`,
+`PageTree`, `scanPages`, `pagesDir` — instead of the current `Docs` / `Site`
+naming. The rearchitecture is the natural moment to align internal names before
+the planned libdoc-to-libpages rename. Clean break, no backward-compatibility
+shims for old names.
 
 ## Components
 
 | Component | Module | Responsibility |
 |---|---|---|
-| `scanSiteTree` | `site-tree.js` (new) | Walk docs dir, parse frontmatter, return `SiteTree` map |
+| `scanPages` | `page-tree.js` (new) | Walk pages dir, parse frontmatter, return `PageTree` map |
 | `resolvePartials` | `partials.js` (new) | Replace `<!-- part:type:path -->` markers with HTML from the registry |
 | `defaultRegistry` | `partials.js` (new) | `card` and `link` partial type renderers |
-| `DocsBuilder` | `builder.js` (modified) | Orchestrate: scan, resolve, render, template, format, write |
+| `PagesBuilder` | `builder.js` (modified) | Orchestrate: scan, resolve, render, template, format, write |
 | transforms | `transforms.js` (minor change) | Link rewriting, breadcrumbs, TOC, hero vars |
 | `parseFrontMatter` | `frontmatter.js` (unchanged) | YAML frontmatter extraction |
 
 ## Data Structures
 
-### SiteTree
+### PageTree
 
 ```
 Map<urlPath, PageMeta>
 
 PageMeta = {
-  filePath: string     // relative to docsDir, e.g. "docs/getting-started/index.md"
+  filePath: string     // relative to pagesDir, e.g. "docs/getting-started/index.md"
   urlPath:  string     // e.g. "/docs/getting-started/"
   title:    string
   description: string
 }
 ```
 
-Built once by `scanSiteTree`, passed immutably through the pipeline. Replaces
-both the `pageTitles` map from Pass 1 and the `pages` array accumulated during
-Pass 2 — sitemap and llms.txt generation read directly from the site tree.
+Built once by `scanPages`, passed immutably through the pipeline. Replaces both
+the `pageTitles` map from Pass 1 and the `pages` array accumulated during
+Pass 2 — sitemap and llms.txt generation read directly from the page tree.
 
 Only pages with a `title` in frontmatter are included (matching current
 behavior where titleless pages are skipped). PageMeta holds scan-time metadata
@@ -72,17 +82,17 @@ resolver or builder (success criterion 10).
 ```mermaid
 flowchart TD
   subgraph "Stage 1 — Scan"
-    S1[Walk docsDir, skip assets/public/CLAUDE.md/SKILL.md]
+    S1[Walk pagesDir, skip assets/public/CLAUDE.md/SKILL.md]
     S1 --> S2[Parse frontmatter per .md file]
-    S2 --> S3["Return SiteTree map (urlPath → PageMeta)"]
+    S2 --> S3["Return PageTree map (urlPath → PageMeta)"]
   end
 
   subgraph "Stage 2 — Render each page"
     R1[Read file, parse frontmatter]
-    R1 --> R2["resolvePartials(markdown, siteTree, pageDir, registry)"]
+    R1 --> R2["resolvePartials(markdown, pageTree, pageDir, registry)"]
     R2 --> R3["marked(markdown) → HTML"]
     R3 --> R4[Transform links]
-    R4 --> R5["Template vars + breadcrumbs (from siteTree)"]
+    R4 --> R5["Template vars + breadcrumbs (from pageTree)"]
     R5 --> R6[Mustache render]
     R6 --> R7[Prettier format]
     R7 --> R8[Write .html + companion .md]
@@ -90,8 +100,8 @@ flowchart TD
 
   subgraph "Stage 3 — Post"
     P1[Copy static assets]
-    P2["sitemap.xml (from siteTree)"]
-    P3["llms.txt (from siteTree)"]
+    P2["sitemap.xml (from pageTree)"]
+    P3["llms.txt (from pageTree)"]
   end
 
   S3 --> R1
@@ -106,11 +116,12 @@ flowchart TD
 
 | Decision | Choice | Rejected | Why |
 |---|---|---|---|
-| Site tree scope | Single upfront scan collects path, title, description | Extend `pageTitles` map with extra fields | Adding fields piecemeal perpetuates the two-pass design; a complete scan is simpler and feeds partials, sitemap, and llms.txt from one structure |
+| Naming vocabulary | `Page`/`Pages` throughout (`PagesBuilder`, `PageTree`, `scanPages`, `pagesDir`) | Keep `Docs`/`Site` names from current codebase | Rearchitecture is the natural moment to align before the planned libdoc → libpages rename; a clean break avoids a future rename-only churn commit |
+| Page tree scope | Single upfront scan collects path, title, description | Extend `pageTitles` map with extra fields | Adding fields piecemeal perpetuates the two-pass design; a complete scan is simpler and feeds partials, sitemap, and llms.txt from one structure |
 | Partials processing order | Resolve before `marked` | Resolve after markdown-to-HTML | Partial output is raw HTML that `marked` passes through unchanged, matching how hub pages work today; post-render resolution risks double-escaping |
 | Partial implementation | Pre-processing function with regex | Custom `marked` extension | HTML comments are not markdown syntax; a standalone function is simpler and independently testable without coupling to marked's extension API |
 | Type dispatch | Plain object registry | Switch/case in resolver | A registry entry per type satisfies criterion 10 (no resolver changes to add a type) |
-| Module decomposition | Two new focused modules (`site-tree.js`, `partials.js`) | More private methods on DocsBuilder | The class already has 12 private methods; separate modules with explicit inputs are independently testable and reduce per-module concept count |
+| Module decomposition | Two new focused modules (`page-tree.js`, `partials.js`) | More private methods on PagesBuilder | The class already has 12 private methods; separate modules with explicit inputs are independently testable and reduce per-module concept count |
 | Module decomposition | Two focused modules | Plugin architecture with lifecycle hooks | Over-engineering; spec calls for fewer concepts, not an extensibility framework |
 
 ## Partials
@@ -131,7 +142,7 @@ Given `<!-- part:card:getting-started -->` in `docs/products/index.md`:
 2. Join with partial path: `docs/products/getting-started`
 3. Normalize (resolve `..` segments)
 4. Compute urlPath → `/docs/products/getting-started/`
-5. Look up in SiteTree
+5. Look up in PageTree
 6. Fail with source file and partial path if not found
 
 ### Href computation
@@ -147,32 +158,38 @@ Relative URL from current page to target page, computed via `path.relative()`:
 ### Errors (both fatal)
 
 - Unknown type: `Unknown partial type "foo" in docs/index.md`
-- Missing target: `Partial target "nonexistent" not found in site tree (referenced from docs/index.md)`
+- Missing target: `Partial target "nonexistent" not found in page tree (referenced from docs/index.md)`
 
 ## Builder Changes
 
-### Removed from DocsBuilder
+### Renamed
+
+`DocsBuilder` → `PagesBuilder`. The `docsDir` parameter becomes `pagesDir`
+across the public API and all internal methods. The `DocsServer` in `server.js`
+becomes `PagesServer`.
+
+### Removed from PagesBuilder
 
 `#findMarkdownFiles`, `#collectMarkdownEntry`, `#collectPageTitles` — replaced
-by `scanSiteTree`.
+by `scanPages`.
 
-### Modified in DocsBuilder
+### Modified in PagesBuilder
 
-- **`build()`** — calls `scanSiteTree()` instead of two-step discovery; passes
-  `siteTree` to rendering, sitemap, and llms.txt; no longer accumulates a
+- **`build()`** — calls `scanPages()` instead of two-step discovery; passes
+  `pageTree` to rendering, sitemap, and llms.txt; no longer accumulates a
   `pages` array.
-- **`#renderPage()`** — calls `resolvePartials(markdown, siteTree, pageDir,
+- **`#renderPage()`** — calls `resolvePartials(markdown, pageTree, pageDir,
   registry)` before `this.#marked(markdown)`.
-- **`#buildTemplateVars()`** — receives `siteTree` instead of `pageTitles`.
-- **`buildBreadcrumbs()`** in `transforms.js` — accepts `SiteTree` map and
+- **`#buildTemplateVars()`** — receives `pageTree` instead of `pageTitles`.
+- **`buildBreadcrumbs()`** in `transforms.js` — accepts `PageTree` map and
   reads `.title` from each entry instead of receiving a `Map<string, string>`.
-- **`#generateSitemap()` / `#augmentLlmsTxt()`** — iterate `siteTree.values()`
+- **`#generateSitemap()` / `#augmentLlmsTxt()`** — iterate `pageTree.values()`
   instead of receiving a separate pages array.
 
 ### Unchanged
 
-Constructor signature, public API (`async build(docsDir, distDir, baseUrl)`),
-dependency injection pattern, CLI interface, template, CSS.
+Public API shape (`async build(pagesDir, distDir, baseUrl)`), dependency
+injection pattern, CLI interface, template, CSS.
 
 ## Migration
 

--- a/specs/790-libdoc-content-partials/spec.md
+++ b/specs/790-libdoc-content-partials/spec.md
@@ -1,0 +1,174 @@
+# Spec 790 — libdoc content partials and builder rearchitecture
+
+## Problem
+
+The fit website's hub pages contain hand-written card grids where each card
+duplicates the target page's title and description. Eighteen hub pages use
+`<div class="grid">` card grids — `docs/products/index.md` has 20 cards,
+`docs/libraries/index.md` has 22, and `docs/services/index.md` has 9, with
+the remainder spread across product pages, getting-started pages, and
+`docs/index.md`. Across the site, over 90 card links carry hardcoded titles
+and descriptions copied from their target page's frontmatter.
+
+When a page's title or description changes, every card referencing it must be
+found and updated manually. The build system has no way to detect stale card
+content — the mismatch is invisible until a reader notices. This friction
+discourages improving titles and descriptions because the blast radius is
+unknown.
+
+The builder (`libraries/libdoc/src/builder.js`) already does a two-pass build:
+first collecting page titles for breadcrumbs, then rendering pages. Adding
+partials resolution requires the second pass to look up any page's frontmatter
+by path — not just its title. The current architecture intermixes file
+discovery, frontmatter parsing, markdown rendering, template application, and
+output writing in a single class, making this extension harder than it needs
+to be.
+
+**Persona and job:** Platform Builders — stand up typed services and shared
+infrastructure. Content partials eliminate a class of manual synchronization
+that scales with the number of hub pages.
+
+## Goal
+
+Add a content partials system to libdoc so that markdown authors write
+`<!-- part:card:path -->` or `<!-- part:link:path -->` instead of manually
+copying titles and descriptions. Rearchitect the builder around an upfront
+site tree scan that maps every page's path and frontmatter, making partials
+resolution (and future extensions) straightforward.
+
+## Scope (in)
+
+### 1. Site tree scan
+
+An upfront pass that walks the docs directory and produces an in-memory map of
+every page: its file path, URL path, and parsed frontmatter. This map is the
+single source of truth for the build — breadcrumb title lookup, partials
+resolution, sitemap generation, and llms.txt augmentation all read from it.
+
+- Replaces the current two-step process (file discovery then title collection)
+  with a single scan that collects everything needed.
+- The map is built once and passed (not mutated) through the build pipeline.
+- libdoc sites are small enough (tens to low hundreds of pages) that holding
+  all frontmatter in memory is not a concern.
+
+### 2. Content partials
+
+A processing step that finds `<!-- part:type:path -->` markers in markdown
+content and replaces each with HTML generated from the referenced page's
+frontmatter.
+
+- **Marker syntax.** `<!-- part:<type>:<path> -->` where `<type>` selects the
+  rendering template and `<path>` is resolved relative to the current page's
+  directory (the directory containing the source markdown file).
+- **Path resolution.** Paths follow the same conventions as filesystem paths:
+  `getting-started` resolves to a sibling directory, `../pathway` resolves to
+  a parent's sibling. The resolved path must correspond to a page in the site
+  tree (a directory containing `index.md`). The build fails with a clear error
+  if a partial references a path that does not exist in the site tree.
+- **Partial types.** The system accepts a registry of named partial types, each
+  providing a function that receives the referenced page's metadata and returns
+  an HTML string. Two types ship initially:
+
+  **`card`** — renders a linked card with title and description:
+
+  ```html
+  <a href="../relative/link/">
+  <h3>[title from frontmatter]</h3>
+  <p>[description from frontmatter]</p>
+  </a>
+  ```
+
+  **`link`** — renders an inline link with the page title as text:
+
+  ```html
+  <a href="../relative/link/">[title from frontmatter]</a>
+  ```
+
+- **Href computation.** The `href` value is a relative URL from the current
+  page's URL path to the referenced page's URL path — the same kind of
+  relative path a hand-written link would use.
+- **Processing order.** Partial output participates in markdown rendering —
+  the `card` type's `<h3>` inside an `<a>` follows the same pattern hub pages
+  use today. See Notes for rationale.
+- **Unknown types.** The build fails with a clear error if a partial marker
+  uses an unregistered type.
+
+### 3. Builder rearchitecture
+
+Restructure the builder so that distinct concerns — site tree scanning,
+partials resolution, markdown rendering, template application, and output
+writing — live in separate modules with explicit dependencies rather than
+interleaved in a single class.
+
+- The site tree map is the shared data structure that flows through the build
+  pipeline: scan produces it, partials resolution reads it, rendering reads it,
+  sitemap/llms.txt generation reads it.
+- New modules follow the existing dependency injection pattern.
+- The public API (`build(docsDir, distDir, baseUrl)`) and CLI interface remain
+  unchanged. The rearchitecture is internal.
+
+### 4. Migration of existing hub pages
+
+Convert the existing hand-written card grids on hub pages to use
+`<!-- part:card:path -->` markers. Convert inline cross-references where
+appropriate to use `<!-- part:link:path -->` markers.
+
+- Hub pages affected: every page under `websites/fit/` that contains a
+  `<div class="grid">` card grid linking to other pages within the site.
+  Currently 17 pages including `docs/index.md`, `docs/products/index.md`,
+  `docs/libraries/index.md`, `docs/services/index.md`,
+  `docs/getting-started/index.md`, `docs/internals/index.md`,
+  `docs/reference/index.md`, product pages (`map/`, `pathway/`, `guide/`,
+  `landmark/`, `summit/`, `outpost/`, `gear/`), and getting-started sub-pages.
+- The `<div class="grid">` wrapper and `## Job Heading` sections remain
+  hand-written — only the `<a>` card content inside them is replaced by
+  partials.
+
+## Scope (out)
+
+- Migration of `websites/fit/index.md`. The landing page is fully handcrafted
+  and stays that way.
+- New partial types beyond `card` and `link`. The registry design supports
+  future types; this spec delivers only these two.
+- Changes to the mustache template (`index.template.html`) or CSS. The partial
+  output uses the same HTML structure the hub pages use today.
+- Changes to the dev server (`server.js`) beyond ensuring it works with the
+  rearchitected builder.
+- Build-time broken link detection. Partials validate that their target exists,
+  but hand-written links are not checked.
+- Changes to the `fit-doc` CLI interface or its `--help` output.
+- Performance optimization. The site tree scan adds one upfront pass over tens
+  of files; no caching or incremental build is needed.
+
+## Success criteria
+
+| # | Claim | Verification |
+|---|-------|--------------|
+| 1 | `<!-- part:card:path -->` renders an `<a>` containing an `<h3>` with the target page's frontmatter title and a `<p>` with its description. | Write a test page with a card partial pointing to a page with known frontmatter; build; the output HTML contains the expected `<a><h3>title</h3><p>description</p></a>` structure. |
+| 2 | `<!-- part:link:path -->` renders an `<a>` with the target page's frontmatter title as link text. | Write a test page with a link partial pointing to a page with known frontmatter; build; the output HTML contains `<a href="...">title</a>`. |
+| 3 | Partial paths resolve relative to the source page's directory. | A partial in `docs/index.md` with path `getting-started` resolves to `docs/getting-started/index.md`. A partial with path `../pathway` resolves to `pathway/index.md`. Both verified by building and checking output. |
+| 4 | The build fails with a clear error when a partial references a nonexistent page. | Add `<!-- part:card:nonexistent -->` to a page; run build; the process exits non-zero with an error message naming the partial path and the source file. |
+| 5 | The build fails with a clear error when a partial uses an unknown type. | Add `<!-- part:unknown:path -->` to a page; run build; the process exits non-zero with an error message naming the unknown type. |
+| 6 | Migrated hub pages produce identical HTML output. | Diff the built output of every migrated hub page before and after migration; the rendered HTML is identical (modulo whitespace normalization by prettier). |
+| 7 | The site tree scan produces a map containing every page's URL path, title, and description. | Unit test: scan a test directory with 3 pages; the returned map has 3 entries with correct url paths, titles, and descriptions. |
+| 8 | The builder's public API is unchanged. | `build(docsDir, distDir, baseUrl)` signature and return type are identical; `bunx fit-doc build --src websites/fit` succeeds. |
+| 9 | Existing tests pass. | `bun test libraries/libdoc/` exits zero. |
+| 10 | Adding a new partial type requires only adding an entry to the type registry — no changes to the partials engine or builder. | Static inspection: adding a third partial type requires one new registry entry and no other module changes. |
+
+## Notes
+
+### Why resolve before markdown rendering
+
+Resolving partials in the markdown source (before `marked` processes it) means
+the partial output is plain HTML that `marked` passes through unchanged. This
+matches how hub pages work today — their `<a><h3>...</h3></a>` blocks inside
+`<div class="grid">` are raw HTML in markdown that `marked` preserves. If
+partials were resolved after rendering, the output would need to avoid
+double-escaping and could not participate in markdown structures.
+
+### Rearchitecture scope
+
+The rearchitecture is motivated by the partials feature but scoped to make the
+builder maintainable, not to redesign the entire system. The goal is fewer
+concepts per module and explicit data flow — the site tree map flows from scan
+to partials to render to output — not a plugin architecture or event system.


### PR DESCRIPTION
## Summary

- Introduces a three-stage build pipeline (scan → resolve → render) replacing the current two-pass class architecture
- Two new modules: `site-tree.js` for upfront frontmatter collection into an immutable `SiteTree` map, and `partials.js` for `<!-- part:type:path -->` marker resolution with a type registry
- Builder slimmed to orchestrator role; `transforms.js` gets a minor `buildBreadcrumbs` signature change

## Spec dependency

Spec PR #735 is approved but not yet merged. This design branch includes the spec file so it can be reviewed independently. Once the spec merges, rebase this branch.

## Review panel

3-reviewer panel completed. Consensus findings addressed:
- **High (2/3):** transforms.js contradiction — fixed by marking it as "minor change" and documenting the `buildBreadcrumbs` signature update
- **Medium (3/3):** private method count corrected from 15 to 12
- **Medium (1/3, verified):** clarified PageMeta is scan-time metadata only

## Test plan

- [ ] Verify design stays within spec scope (no new partial types, no template/CSS changes, no CLI changes)
- [ ] Verify design stays at architectural level (no file-level changes or execution ordering)
- [ ] Verify all key decisions name a rejected alternative
- [ ] Verify under 200 lines (currently 182)

🤖 Generated with [Claude Code](https://claude.com/claude-code)