### PR TITLE
feat(libdoc): content partials and builder rearchitecture (#790)

### DIFF
--- a/.claude/skills/fit-doc/SKILL.md
+++ b/.claude/skills/fit-doc/SKILL.md
@@ -154,6 +154,21 @@ with `toc: false` in front matter.
 Auto-generated for pages two or more levels deep, using titles collected from
 all pages' front matter.
 
+## Content Partials
+
+Markers like `<!-- part:card:path -->` pull the target page's front matter
+`title` and `description` at build time, replacing the marker with HTML.
+
+| Type   | Output |
+| ------ | ------ |
+| `card` | `<a href="…"><h3>title</h3><p>description</p></a>` |
+| `link` | `<a href="…">title</a>` |
+
+`<path>` resolves relative to the current page's directory (`../sibling`
+works). The build fails if the target page does not exist or the type is
+unregistered. To add a type, add an entry to `defaultRegistry` in
+`libraries/libdoc/src/partials.js`.
+
 ## Pre-Build Hook
 
 When a `justfile` exists in the source directory with a `build` recipe,

--- a/libraries/libdoc/bin/fit-doc.js
+++ b/libraries/libdoc/bin/fit-doc.js
@@ -11,7 +11,7 @@ import prettier from "prettier";
 
 import { createCli, formatBullet } from "@forwardimpact/libcli";
 import { createLogger } from "@forwardimpact/libtelemetry";
-import { DocsBuilder, DocsServer } from "../src/index.js";
+import { PagesBuilder, PagesServer } from "../src/index.js";
 import { parseFrontMatter } from "../src/frontmatter.js";
 
 const { version: VERSION } = JSON.parse(
@@ -76,19 +76,19 @@ const cli = createCli(definition);
 const logger = createLogger("doc");
 
 /**
- * @param {import("../builder.js").DocsBuilder} builder
- * @param {string} docsDir
+ * @param {import("../builder.js").PagesBuilder} builder
+ * @param {string} pagesDir
  * @param {string} distDir
  * @param {string} [baseUrl]
  */
-function runPreBuildHook(docsDir) {
-  const justfilePath = path.join(docsDir, "justfile");
+function runPreBuildHook(pagesDir) {
+  const justfilePath = path.join(pagesDir, "justfile");
   if (!fs.existsSync(justfilePath)) return;
 
   logger.info("Running pre-build hook (justfile)...");
 
   try {
-    execFileSync("just", ["build"], { cwd: docsDir, stdio: "pipe" });
+    execFileSync("just", ["build"], { cwd: pagesDir, stdio: "pipe" });
     logger.info("  ✓ pre-build hook complete");
   } catch (err) {
     if (err.code === "ENOENT") {
@@ -102,34 +102,34 @@ function runPreBuildHook(docsDir) {
   }
 }
 
-async function runBuild(builder, docsDir, distDir, baseUrl) {
-  if (!fs.existsSync(docsDir)) {
-    cli.error(`source directory not found: ${docsDir}`);
+async function runBuild(builder, pagesDir, distDir, baseUrl) {
+  if (!fs.existsSync(pagesDir)) {
+    cli.error(`source directory not found: ${pagesDir}`);
     process.exit(1);
   }
 
-  runPreBuildHook(docsDir);
-  await builder.build(docsDir, distDir, baseUrl);
+  runPreBuildHook(pagesDir);
+  await builder.build(pagesDir, distDir, baseUrl);
 }
 
 /**
- * @param {import("../builder.js").DocsBuilder} builder
- * @param {import("../server.js").DocsServer} server
- * @param {string} docsDir
+ * @param {import("../builder.js").PagesBuilder} builder
+ * @param {import("../server.js").PagesServer} server
+ * @param {string} pagesDir
  * @param {string} distDir
  * @param {{ port: number, watch: boolean, baseUrl: string }} options
  */
-async function runServe(builder, server, docsDir, distDir, options) {
-  if (!fs.existsSync(docsDir)) {
-    cli.error(`source directory not found: ${docsDir}`);
+async function runServe(builder, server, pagesDir, distDir, options) {
+  if (!fs.existsSync(pagesDir)) {
+    cli.error(`source directory not found: ${pagesDir}`);
     process.exit(1);
   }
 
-  runPreBuildHook(docsDir);
-  await builder.build(docsDir, distDir, options.baseUrl);
+  runPreBuildHook(pagesDir);
+  await builder.build(pagesDir, distDir, options.baseUrl);
 
   if (options.watch) {
-    server.watch(docsDir, distDir);
+    server.watch(pagesDir, distDir);
   }
 
   server.serve(distDir, { port: options.port, hostname: "0.0.0.0" });
@@ -154,11 +154,11 @@ async function main() {
   }
 
   const workingDir = process.env.INIT_CWD || process.cwd();
-  const docsDir = path.resolve(workingDir, values.src);
+  const pagesDir = path.resolve(workingDir, values.src);
   const distDir = path.resolve(workingDir, values.out);
   const baseUrl = values["base-url"];
 
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     fs,
     path,
     marked,
@@ -169,10 +169,10 @@ async function main() {
 
   try {
     if (command === "build") {
-      await runBuild(builder, docsDir, distDir, baseUrl);
+      await runBuild(builder, pagesDir, distDir, baseUrl);
     } else {
-      const server = new DocsServer(fs, Hono, serve, builder);
-      await runServe(builder, server, docsDir, distDir, {
+      const server = new PagesServer(fs, Hono, serve, builder);
+      await runServe(builder, server, pagesDir, distDir, {
         port: parseInt(values.port || "3000", 10),
         watch: values.watch,
         baseUrl,

--- a/libraries/libdoc/package.json
+++ b/libraries/libdoc/package.json
@@ -22,7 +22,9 @@
     ".": "./src/index.js",
     "./builder": "./src/builder.js",
     "./server": "./src/server.js",
-    "./frontmatter": "./src/frontmatter.js"
+    "./frontmatter": "./src/frontmatter.js",
+    "./page-tree": "./src/page-tree.js",
+    "./partials": "./src/partials.js"
   },
   "bin": {
     "fit-doc": "./bin/fit-doc.js"

--- a/libraries/libdoc/src/builder.js
+++ b/libraries/libdoc/src/builder.js
@@ -61,6 +61,7 @@ export class PagesBuilder {
     this.#marked.use(
       markedHighlight({
         langPrefix: "language-",
+        // Prism.js handles highlighting on the client side
         highlight(code, _lang) {
           return code;
         },
@@ -270,6 +271,7 @@ export class PagesBuilder {
       pageDir,
       defaultRegistry,
       { path: this.#path },
+      mdFile,
     );
     const rawHtml = this.#marked(resolved);
     const html = transformMarkdownLinks(rawHtml, baseUrl);
@@ -283,7 +285,7 @@ export class PagesBuilder {
     );
     const outputHtml = this.#mustacheRender(template, vars);
     const finalHtml = await this.#formatAndPostProcess(outputHtml);
-    const companionContent = `# ${frontMatter.title}\n\n${transformMarkdownBodyLinks(markdown, baseUrl)}`;
+    const companionContent = `# ${frontMatter.title}\n\n${transformMarkdownBodyLinks(resolved, baseUrl)}`;
 
     this.#writePageFiles(mdFile, distDir, finalHtml, companionContent);
   }

--- a/libraries/libdoc/src/builder.js
+++ b/libraries/libdoc/src/builder.js
@@ -11,13 +11,15 @@ import {
   transformMarkdownLinks,
   urlPathFromMdFile,
 } from "./transforms.js";
+import { scanPages } from "./page-tree.js";
+import { resolvePartials, defaultRegistry } from "./partials.js";
 
 const logger = createLogger("libdoc");
 
 /**
- * Documentation builder for converting Markdown files to HTML
+ * Pages builder for converting Markdown files to HTML
  */
-export class DocsBuilder {
+export class PagesBuilder {
   #fs;
   #path;
   #marked;
@@ -26,7 +28,7 @@ export class DocsBuilder {
   #prettier;
 
   /**
-   * Creates a new DocsBuilder instance
+   * Creates a new PagesBuilder instance
    * @param {object} fs - File system module
    * @param {object} path - Path module
    * @param {Function} markedParser - Marked parser function
@@ -52,16 +54,14 @@ export class DocsBuilder {
     // Configure marked with extensions
     this.#marked.use(
       gfmHeadingId({
-        prefix: "", // No prefix for heading IDs
+        prefix: "",
       }),
     );
 
     this.#marked.use(
       markedHighlight({
-        langPrefix: "language-", // Adds 'language-' prefix to code block classes
+        langPrefix: "language-",
         highlight(code, _lang) {
-          // Return the code as-is with proper language class
-          // Prism.js will handle highlighting on the client side
           return code;
         },
       }),
@@ -92,24 +92,22 @@ export class DocsBuilder {
 
   /**
    * Copy static assets to distribution directory
-   * @param {string} docsDir - Source docs directory
+   * @param {string} pagesDir - Source pages directory
    * @param {string} distDir - Destination distribution directory
    */
-  #copyStaticAssets(docsDir, distDir) {
-    // Copy assets directory (CSS, JS, images)
+  #copyStaticAssets(pagesDir, distDir) {
     if (
       this.#copyDir(
-        this.#path.join(docsDir, "assets"),
+        this.#path.join(pagesDir, "assets"),
         this.#path.join(distDir, "assets"),
       )
     ) {
       logger.info("  ✓ assets/");
     }
 
-    // Copy root-level static files (robots.txt, llms.txt, etc.)
     const skipFiles = new Set(["index.template.html", "CNAME"]);
     this.#fs
-      .readdirSync(docsDir, { withFileTypes: true })
+      .readdirSync(pagesDir, { withFileTypes: true })
       .filter(
         (entry) =>
           entry.isFile() &&
@@ -118,53 +116,11 @@ export class DocsBuilder {
       )
       .forEach((entry) => {
         this.#fs.copyFileSync(
-          this.#path.join(docsDir, entry.name),
+          this.#path.join(pagesDir, entry.name),
           this.#path.join(distDir, entry.name),
         );
         logger.info(`  ✓ ${entry.name}`);
       });
-  }
-
-  /**
-   * Recursively find all Markdown files in a directory
-   * @param {string} dir - Directory to search
-   * @param {string} baseDir - Base directory for relative paths
-   * @returns {string[]} Array of relative paths to Markdown files
-   */
-  #findMarkdownFiles(dir, baseDir = dir) {
-    const results = [];
-    const entries = this.#fs.readdirSync(dir);
-
-    for (const entryName of entries) {
-      if (["assets", "public"].includes(entryName)) continue;
-      if (["CLAUDE.md", "SKILL.md"].includes(entryName)) continue;
-      const fullPath = this.#path.join(dir, entryName);
-      this.#collectMarkdownEntry(fullPath, entryName, baseDir, results);
-    }
-    return results;
-  }
-
-  /**
-   * Classify a single directory entry and collect it (or recurse) into results
-   * @param {string} fullPath - Absolute path to the entry
-   * @param {string} entryName - Basename of the entry
-   * @param {string} baseDir - Root directory for relative path computation
-   * @param {string[]} results - Accumulator for relative markdown paths
-   */
-  #collectMarkdownEntry(fullPath, entryName, baseDir, results) {
-    try {
-      const stat = this.#fs.statSync(fullPath);
-      if (stat.isDirectory && stat.isDirectory()) {
-        results.push(...this.#findMarkdownFiles(fullPath, baseDir));
-      } else if (entryName.endsWith(".md")) {
-        results.push(fullPath.slice(baseDir.length + 1));
-      }
-    } catch {
-      // Skip files that can't be stat'd (e.g., template files)
-      if (entryName.endsWith(".md")) {
-        results.push(fullPath.slice(baseDir.length + 1));
-      }
-    }
   }
 
   /**
@@ -223,12 +179,12 @@ export class DocsBuilder {
   /**
    * Resolve the base URL from an explicit value or CNAME file
    * @param {string|undefined} baseUrl - Explicit base URL
-   * @param {string} docsDir - Source docs directory
+   * @param {string} pagesDir - Source pages directory
    * @returns {string|undefined}
    */
-  #resolveBaseUrl(baseUrl, docsDir) {
+  #resolveBaseUrl(baseUrl, pagesDir) {
     if (baseUrl) return baseUrl;
-    const cnamePath = this.#path.join(docsDir, "CNAME");
+    const cnamePath = this.#path.join(pagesDir, "CNAME");
     if (this.#fs.existsSync(cnamePath)) {
       const hostname = this.#fs.readFileSync(cnamePath, "utf-8").trim();
       return `https://${hostname}`;
@@ -237,36 +193,17 @@ export class DocsBuilder {
   }
 
   /**
-   * Collect page titles from all markdown files (first pass)
-   * @param {string[]} mdFiles - Relative paths to markdown files
-   * @param {string} docsDir - Source docs directory
-   * @returns {Map<string, string>}
-   */
-  #collectPageTitles(mdFiles, docsDir) {
-    const pageTitles = new Map();
-    for (const mdFile of mdFiles) {
-      const { data } = this.#matter(
-        this.#fs.readFileSync(this.#path.join(docsDir, mdFile), "utf-8"),
-      );
-      if (data.title) {
-        pageTitles.set(urlPathFromMdFile(mdFile), data.title);
-      }
-    }
-    return pageTitles;
-  }
-
-  /**
    * Build template variables from front matter and rendered HTML
    * @param {object} frontMatter - Parsed front matter
    * @param {string} html - Rendered HTML content
    * @param {string} urlPath - URL path for this page
-   * @param {Map<string, string>} pageTitles - Map of URL paths to page titles
+   * @param {import("./page-tree.js").PageTree} pageTree - Map of URL paths to page metadata
    * @param {string|undefined} baseUrl - Base URL for canonical links
    * @returns {object} Mustache template variables
    */
-  #buildTemplateVars(frontMatter, html, urlPath, pageTitles, baseUrl) {
+  #buildTemplateVars(frontMatter, html, urlPath, pageTree, baseUrl) {
     const toc = frontMatter.toc !== false ? generateToc(html) : "";
-    const breadcrumbs = buildBreadcrumbs(urlPath, pageTitles);
+    const breadcrumbs = buildBreadcrumbs(urlPath, pageTree);
 
     return {
       title: frontMatter.title,
@@ -314,31 +251,34 @@ export class DocsBuilder {
   /**
    * Render a single markdown file to HTML and write output files
    * @param {string} mdFile - Relative path to the markdown file
-   * @param {string} docsDir - Source docs directory
+   * @param {string} pagesDir - Source pages directory
    * @param {string} distDir - Destination distribution directory
    * @param {string} template - HTML template string
-   * @param {Map<string, string>} pageTitles - Map of URL paths to page titles
+   * @param {import("./page-tree.js").PageTree} pageTree - Map of URL paths to page metadata
    * @param {string|undefined} baseUrl - Base URL for canonical links
-   * @returns {Promise<{mdFile: string, urlPath: string, title: string, description: string}|null>}
+   * @returns {Promise<void>}
    */
-  async #renderPage(mdFile, docsDir, distDir, template, pageTitles, baseUrl) {
+  async #renderPage(mdFile, pagesDir, distDir, template, pageTree, baseUrl) {
     const { data: frontMatter, content: markdown } = this.#matter(
-      this.#fs.readFileSync(this.#path.join(docsDir, mdFile), "utf-8"),
+      this.#fs.readFileSync(this.#path.join(pagesDir, mdFile), "utf-8"),
     );
 
-    if (!frontMatter.title) {
-      console.error(`Error: Missing 'title' in front matter of ${mdFile}`);
-      return null;
-    }
-
-    const rawHtml = this.#marked(markdown);
+    const pageDir = this.#path.dirname(mdFile);
+    const resolved = resolvePartials(
+      markdown,
+      pageTree,
+      pageDir,
+      defaultRegistry,
+      { path: this.#path },
+    );
+    const rawHtml = this.#marked(resolved);
     const html = transformMarkdownLinks(rawHtml, baseUrl);
     const urlPath = urlPathFromMdFile(mdFile);
     const vars = this.#buildTemplateVars(
       frontMatter,
       html,
       urlPath,
-      pageTitles,
+      pageTree,
       baseUrl,
     );
     const outputHtml = this.#mustacheRender(template, vars);
@@ -346,13 +286,6 @@ export class DocsBuilder {
     const companionContent = `# ${frontMatter.title}\n\n${transformMarkdownBodyLinks(markdown, baseUrl)}`;
 
     this.#writePageFiles(mdFile, distDir, finalHtml, companionContent);
-
-    return {
-      mdFile,
-      urlPath,
-      title: frontMatter.title,
-      description: frontMatter.description || "",
-    };
   }
 
   /**
@@ -389,57 +322,57 @@ export class DocsBuilder {
 
   /**
    * Build documentation from Markdown files
-   * @param {string} docsDir - Source documentation directory
+   * @param {string} pagesDir - Source pages directory
    * @param {string} distDir - Destination distribution directory
    * @param {string} [baseUrl] - Base URL for sitemap, canonical links, and llms.txt
    * @returns {Promise<void>}
    */
-  async build(docsDir, distDir, baseUrl) {
+  async build(pagesDir, distDir, baseUrl) {
     logger.info("Building documentation...");
 
-    baseUrl = this.#resolveBaseUrl(baseUrl, docsDir);
+    baseUrl = this.#resolveBaseUrl(baseUrl, pagesDir);
 
-    // Clean and create dist directory
     if (this.#fs.existsSync(distDir)) {
       this.#fs.rmSync(distDir, { recursive: true });
     }
     this.#fs.mkdirSync(distDir, { recursive: true });
 
-    // Read and validate template
-    const templatePath = this.#path.join(docsDir, "index.template.html");
+    const templatePath = this.#path.join(pagesDir, "index.template.html");
     if (!this.#fs.existsSync(templatePath)) {
-      throw new Error(`index.template.html not found in ${docsDir}`);
+      throw new Error(`index.template.html not found in ${pagesDir}`);
     }
     const template = this.#fs.readFileSync(templatePath, "utf-8");
 
-    const mdFiles = this.#findMarkdownFiles(docsDir);
+    const pageTree = scanPages(pagesDir, {
+      fs: this.#fs,
+      path: this.#path,
+      matter: this.#matter,
+    });
 
-    if (mdFiles.length === 0) {
-      console.warn(`Warning: No Markdown files found in ${docsDir}`);
+    if (pageTree.size === 0) {
+      console.warn(`Warning: No Markdown files found in ${pagesDir}`);
     }
 
-    const pageTitles = this.#collectPageTitles(mdFiles, docsDir);
-
-    const pages = [];
-    for (const mdFile of mdFiles) {
-      const page = await this.#renderPage(
-        mdFile,
-        docsDir,
+    for (const entry of pageTree.values()) {
+      await this.#renderPage(
+        entry.filePath,
+        pagesDir,
         distDir,
         template,
-        pageTitles,
+        pageTree,
         baseUrl,
       );
-      if (page) pages.push(page);
     }
 
-    pages.sort((a, b) => a.urlPath.localeCompare(b.urlPath));
+    const sortedPages = [...pageTree.values()].sort((a, b) =>
+      a.urlPath.localeCompare(b.urlPath),
+    );
 
-    this.#copyStaticAssets(docsDir, distDir);
+    this.#copyStaticAssets(pagesDir, distDir);
 
     if (baseUrl) {
-      this.#generateSitemap(pages, baseUrl, distDir);
-      this.#augmentLlmsTxt(pages, baseUrl, distDir);
+      this.#generateSitemap(sortedPages, baseUrl, distDir);
+      this.#augmentLlmsTxt(sortedPages, baseUrl, distDir);
     }
 
     logger.info("Documentation build complete!");

--- a/libraries/libdoc/src/index.js
+++ b/libraries/libdoc/src/index.js
@@ -1,3 +1,5 @@
-export { DocsBuilder } from "./builder.js";
-export { DocsServer } from "./server.js";
+export { PagesBuilder } from "./builder.js";
+export { PagesServer } from "./server.js";
 export { parseFrontMatter } from "./frontmatter.js";
+export { scanPages } from "./page-tree.js";
+export { resolvePartials, defaultRegistry } from "./partials.js";

--- a/libraries/libdoc/src/page-tree.js
+++ b/libraries/libdoc/src/page-tree.js
@@ -1,0 +1,65 @@
+import { urlPathFromMdFile } from "./transforms.js";
+
+/**
+ * @typedef {{ filePath: string, urlPath: string, title: string, description: string }} PageMeta
+ * @typedef {Map<string, PageMeta>} PageTree
+ */
+
+/**
+ * Walk pagesDir recursively and build a PageTree map
+ * @param {string} pagesDir - Root directory to scan
+ * @param {{ fs: object, path: object, matter: Function }} deps
+ * @returns {PageTree}
+ */
+export function scanPages(pagesDir, { fs, path, matter }) {
+  /** @type {PageTree} */
+  const pageTree = new Map();
+  walk(pagesDir, pagesDir, pageTree, { fs, path, matter });
+  return pageTree;
+}
+
+function collectPage(fullPath, baseDir, pageTree, { fs, matter }) {
+  const filePath = fullPath.slice(baseDir.length + 1);
+  const content = fs.readFileSync(fullPath, "utf-8");
+  const { data } = matter(content);
+  if (!data.title) return;
+  const urlPath = urlPathFromMdFile(filePath);
+  pageTree.set(urlPath, {
+    filePath,
+    urlPath,
+    title: data.title,
+    description: data.description || "",
+  });
+}
+
+const SKIP_ENTRIES = new Set(["assets", "public", "CLAUDE.md", "SKILL.md"]);
+
+function isDirectory(fs, fullPath) {
+  try {
+    const stat = fs.statSync(fullPath);
+    return stat.isDirectory && stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function walk(dir, baseDir, pageTree, deps) {
+  const { fs, path } = deps;
+  const entries = fs.readdirSync(dir);
+
+  for (const entryName of entries) {
+    if (SKIP_ENTRIES.has(entryName)) continue;
+
+    const fullPath = path.join(dir, entryName);
+
+    if (isDirectory(fs, fullPath)) {
+      walk(fullPath, baseDir, pageTree, deps);
+    } else if (entryName.endsWith(".md")) {
+      try {
+        collectPage(fullPath, baseDir, pageTree, deps);
+      } catch {
+        // Skip files that can't be read
+      }
+    }
+  }
+}

--- a/libraries/libdoc/src/partials.js
+++ b/libraries/libdoc/src/partials.js
@@ -15,6 +15,7 @@ const PARTIAL_RE = /<!--\s*part:(\w+):([\w./-]+)\s*-->/g;
  * @param {string} currentPageDir - Directory of the current page (relative to pagesDir)
  * @param {Record<string, (meta: import("./page-tree.js").PageMeta, href: string) => string>} registry
  * @param {{ path: object }} deps
+ * @param {string} [sourceFile] - Source file path for error messages
  * @returns {string}
  */
 export function resolvePartials(
@@ -23,12 +24,12 @@ export function resolvePartials(
   currentPageDir,
   registry,
   { path },
+  sourceFile,
 ) {
+  const src = sourceFile || currentPageDir + "/index.md";
   return markdown.replace(PARTIAL_RE, (_match, type, partialPath) => {
     if (!registry[type]) {
-      throw new Error(
-        `Unknown partial type "${type}" in ${currentPageDir}/index.md`,
-      );
+      throw new Error(`Unknown partial type "${type}" in ${src}`);
     }
 
     const resolved = path.normalize(path.join(currentPageDir, partialPath));
@@ -37,14 +38,15 @@ export function resolvePartials(
 
     if (!meta) {
       throw new Error(
-        `Partial target "${partialPath}" not found in page tree (referenced from ${currentPageDir}/index.md)`,
+        `Partial target "${partialPath}" not found in page tree (referenced from ${src})`,
       );
     }
 
-    const currentUrlDir = urlPathFromMdFile(currentPageDir + "/index.md");
-    const targetUrlDir = urlPath;
-    const fromDir = currentUrlDir.replace(/\/$/, "");
-    const toDir = targetUrlDir.replace(/\/$/, "");
+    const currentUrlPath = urlPathFromMdFile(
+      currentPageDir === "." ? "index.md" : currentPageDir + "/index.md",
+    );
+    const fromDir = currentUrlPath.replace(/\/$/, "") || "/";
+    const toDir = urlPath.replace(/\/$/, "") || "/";
     let href = path.relative(fromDir, toDir);
     if (!href.endsWith("/")) href += "/";
 

--- a/libraries/libdoc/src/partials.js
+++ b/libraries/libdoc/src/partials.js
@@ -1,0 +1,53 @@
+import { urlPathFromMdFile } from "./transforms.js";
+
+export const defaultRegistry = {
+  card: (meta, href) =>
+    `<a href="${href}">\n<h3>${meta.title}</h3>\n<p>${meta.description}</p>\n</a>`,
+  link: (meta, href) => `<a href="${href}">${meta.title}</a>`,
+};
+
+const PARTIAL_RE = /<!--\s*part:(\w+):([\w./-]+)\s*-->/g;
+
+/**
+ * Replace <!-- part:type:path --> markers with HTML from the registry
+ * @param {string} markdown - Markdown content
+ * @param {import("./page-tree.js").PageTree} pageTree
+ * @param {string} currentPageDir - Directory of the current page (relative to pagesDir)
+ * @param {Record<string, (meta: import("./page-tree.js").PageMeta, href: string) => string>} registry
+ * @param {{ path: object }} deps
+ * @returns {string}
+ */
+export function resolvePartials(
+  markdown,
+  pageTree,
+  currentPageDir,
+  registry,
+  { path },
+) {
+  return markdown.replace(PARTIAL_RE, (_match, type, partialPath) => {
+    if (!registry[type]) {
+      throw new Error(
+        `Unknown partial type "${type}" in ${currentPageDir}/index.md`,
+      );
+    }
+
+    const resolved = path.normalize(path.join(currentPageDir, partialPath));
+    const urlPath = urlPathFromMdFile(resolved + "/index.md");
+    const meta = pageTree.get(urlPath);
+
+    if (!meta) {
+      throw new Error(
+        `Partial target "${partialPath}" not found in page tree (referenced from ${currentPageDir}/index.md)`,
+      );
+    }
+
+    const currentUrlDir = urlPathFromMdFile(currentPageDir + "/index.md");
+    const targetUrlDir = urlPath;
+    const fromDir = currentUrlDir.replace(/\/$/, "");
+    const toDir = targetUrlDir.replace(/\/$/, "");
+    let href = path.relative(fromDir, toDir);
+    if (!href.endsWith("/")) href += "/";
+
+    return registry[type](meta, href);
+  });
+}

--- a/libraries/libdoc/src/server.js
+++ b/libraries/libdoc/src/server.js
@@ -5,7 +5,7 @@ const logger = createLogger("libdoc");
 /**
  * Documentation server for serving built documentation and watching for changes
  */
-export class DocsServer {
+export class PagesServer {
   #fs;
   #Hono;
   #serve;
@@ -13,11 +13,11 @@ export class DocsServer {
   #watcher;
 
   /**
-   * Creates a new DocsServer instance
+   * Creates a new PagesServer instance
    * @param {object} fs - File system module
    * @param {Function} HonoConstructor - Hono constructor (optional, required for serve())
    * @param {Function} serveFn - Hono serve function from @hono/node-server (optional, required for serve())
-   * @param {import("./builder.js").DocsBuilder} builder - DocsBuilder instance
+   * @param {import("./builder.js").PagesBuilder} builder - PagesBuilder instance
    */
   constructor(fs, HonoConstructor, serveFn, builder) {
     if (!fs) throw new Error("fs is required");
@@ -32,15 +32,15 @@ export class DocsServer {
 
   /**
    * Start watching for changes and rebuild
-   * @param {string} docsDir - Documentation directory to watch
+   * @param {string} pagesDir - Documentation directory to watch
    * @param {string} distDir - Distribution directory for output
    * @returns {void}
    */
-  watch(docsDir, distDir) {
-    logger.info(`Watching for changes in ${docsDir}...`);
+  watch(pagesDir, distDir) {
+    logger.info(`Watching for changes in ${pagesDir}...`);
 
     this.#watcher = this.#fs.watch(
-      docsDir,
+      pagesDir,
       { recursive: true },
       (eventType, filename) => {
         if (
@@ -50,7 +50,7 @@ export class DocsServer {
             filename.startsWith("assets/"))
         ) {
           logger.info(`\nRebuilding due to change in ${filename}...`);
-          this.#builder.build(docsDir, distDir).catch((error) => {
+          this.#builder.build(pagesDir, distDir).catch((error) => {
             console.error("Build error:", error);
           });
         }

--- a/libraries/libdoc/src/transforms.js
+++ b/libraries/libdoc/src/transforms.js
@@ -88,10 +88,10 @@ export function urlPathFromMdFile(mdFile) {
 /**
  * Build breadcrumb HTML for pages two or more levels deep
  * @param {string} urlPath - URL path of the current page
- * @param {Map<string, string>} pageTitles - Map of URL paths to page titles
+ * @param {Map<string, {title: string}>} pageTree - Map of URL paths to page metadata
  * @returns {string} Breadcrumb HTML or empty string
  */
-export function buildBreadcrumbs(urlPath, pageTitles) {
+export function buildBreadcrumbs(urlPath, pageTree) {
   const segments = urlPath.split("/").filter(Boolean);
   if (segments.length < 2) return "";
 
@@ -103,11 +103,12 @@ export function buildBreadcrumbs(urlPath, pageTitles) {
   const parts = [];
   for (let i = 0; i < segments.length - 1; i++) {
     const ancestorPath = "/" + segments.slice(0, i + 1).join("/") + "/";
-    const title = pageTitles.get(ancestorPath) || segments[i];
+    const title = pageTree.get(ancestorPath)?.title || segments[i];
     parts.push(`<a href="${ancestorPath}">${breadcrumbLabel(title)}</a>`);
   }
 
-  const currentTitle = pageTitles.get(urlPath) || segments[segments.length - 1];
+  const currentTitle =
+    pageTree.get(urlPath)?.title || segments[segments.length - 1];
   parts.push(`<span>${breadcrumbLabel(currentTitle)}</span>`);
 
   return parts.join(" / ");

--- a/libraries/libdoc/test/libdoc-builder.test.js
+++ b/libraries/libdoc/test/libdoc-builder.test.js
@@ -1,42 +1,43 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { DocsBuilder, DocsServer } from "../src/index.js";
+import { PagesBuilder, PagesServer } from "../src/index.js";
 import { assertThrowsMessage } from "@forwardimpact/libharness";
 
-test("DocsBuilder constructor validates dependencies", () => {
+test("PagesBuilder constructor validates dependencies", () => {
   assertThrowsMessage(
-    () => new DocsBuilder(null, null, null, null, null, null),
+    () => new PagesBuilder(null, null, null, null, null, null),
     /fs is required/,
   );
 
   const mockFs = {};
   assertThrowsMessage(
-    () => new DocsBuilder(mockFs, null, null, null, null, null),
+    () => new PagesBuilder(mockFs, null, null, null, null, null),
     /path is required/,
   );
 
   const mockPath = {};
   assertThrowsMessage(
-    () => new DocsBuilder(mockFs, mockPath, null, null, null, null),
+    () => new PagesBuilder(mockFs, mockPath, null, null, null, null),
     /markedParser is required/,
   );
 
   const mockMarked = Object.assign(() => {}, { use: () => {} });
   assertThrowsMessage(
-    () => new DocsBuilder(mockFs, mockPath, mockMarked, null, null, null),
+    () => new PagesBuilder(mockFs, mockPath, mockMarked, null, null, null),
     /matterParser is required/,
   );
 
   const mockMatter = () => {};
   assertThrowsMessage(
-    () => new DocsBuilder(mockFs, mockPath, mockMarked, mockMatter, null, null),
+    () =>
+      new PagesBuilder(mockFs, mockPath, mockMarked, mockMatter, null, null),
     /mustacheRender is required/,
   );
 
   const mockMustache = () => {};
   assertThrowsMessage(
     () =>
-      new DocsBuilder(
+      new PagesBuilder(
         mockFs,
         mockPath,
         mockMarked,
@@ -48,7 +49,7 @@ test("DocsBuilder constructor validates dependencies", () => {
   );
 
   const mockPrettier = { format: async (html) => html };
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     mockFs,
     mockPath,
     mockMarked,
@@ -56,50 +57,48 @@ test("DocsBuilder constructor validates dependencies", () => {
     mockMustache,
     mockPrettier,
   );
-  assert.ok(builder instanceof DocsBuilder);
+  assert.ok(builder instanceof PagesBuilder);
 });
 
-test("DocsServer constructor validates dependencies", () => {
+test("PagesServer constructor validates dependencies", () => {
   assertThrowsMessage(
-    () => new DocsServer(null, null, null, null),
+    () => new PagesServer(null, null, null, null),
     /fs is required/,
   );
 
   const mockFs = {};
   assertThrowsMessage(
-    () => new DocsServer(mockFs, null, null, null),
+    () => new PagesServer(mockFs, null, null, null),
     /builder is required/,
   );
 
   const mockBuilder = {};
-  const server = new DocsServer(mockFs, null, null, mockBuilder);
-  assert.ok(server instanceof DocsServer);
+  const server = new PagesServer(mockFs, null, null, mockBuilder);
+  assert.ok(server instanceof PagesServer);
 
-  // Test with Hono dependencies provided
   const mockHono = function () {};
   const mockServe = () => {};
-  const serverWithHono = new DocsServer(
+  const serverWithHono = new PagesServer(
     mockFs,
     mockHono,
     mockServe,
     mockBuilder,
   );
-  assert.ok(serverWithHono instanceof DocsServer);
+  assert.ok(serverWithHono instanceof PagesServer);
 });
 
-test("DocsServer stopWatch handles null watcher", () => {
+test("PagesServer stopWatch handles null watcher", () => {
   const mockFs = {};
   const mockHono = function () {};
   const mockServe = () => {};
   const mockBuilder = {};
 
-  const server = new DocsServer(mockFs, mockHono, mockServe, mockBuilder);
+  const server = new PagesServer(mockFs, mockHono, mockServe, mockBuilder);
 
-  // Should not throw when watcher is null
   assert.doesNotThrow(() => server.stopWatch());
 });
 
-test("DocsBuilder generates correct output paths", async () => {
+test("PagesBuilder generates correct output paths", async () => {
   const files = new Map();
   const dirs = new Set();
 
@@ -147,6 +146,23 @@ test("DocsBuilder generates correct output paths", async () => {
   const mockPath = {
     join: (...parts) => parts.join("/"),
     dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+    normalize: (p) => {
+      const parts = p.split("/").filter(Boolean);
+      const result = [];
+      for (const part of parts) {
+        if (part === "..") result.pop();
+        else if (part !== ".") result.push(part);
+      }
+      return result.join("/") || ".";
+    },
+    relative: (from, to) => {
+      const f = from.split("/").filter(Boolean);
+      const t = to.split("/").filter(Boolean);
+      let i = 0;
+      while (i < f.length && i < t.length && f[i] === t[i]) i++;
+      const ups = f.length - i;
+      return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+    },
   };
 
   const mockMarked = Object.assign((md) => `<p>${md}</p>`, { use: () => {} });
@@ -162,7 +178,7 @@ test("DocsBuilder generates correct output paths", async () => {
     template.replace(/\{\{(\w+)\}\}/g, (_, key) => context[key] || "");
   const mockPrettier = { format: async (html) => html };
 
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     mockFs,
     mockPath,
     mockMarked,
@@ -173,10 +189,8 @@ test("DocsBuilder generates correct output paths", async () => {
 
   await builder.build("docs", "dist");
 
-  // Verify index.md -> dist/index.html
   assert.ok(files.has("dist/index.html"), "index.html should be at root");
 
-  // Verify architecture.md -> dist/architecture/index.html
   assert.ok(
     dirs.has("dist/architecture"),
     "architecture directory should be created",
@@ -186,14 +200,12 @@ test("DocsBuilder generates correct output paths", async () => {
     "architecture/index.html should exist",
   );
 
-  // Verify concepts.md -> dist/concepts/index.html
   assert.ok(dirs.has("dist/concepts"), "concepts directory should be created");
   assert.ok(
     files.has("dist/concepts/index.html"),
     "concepts/index.html should exist",
   );
 
-  // Verify markdown companions
   assert.ok(files.has("dist/index.md"), "index.md companion should exist");
   assert.ok(
     files.has("dist/architecture/index.md"),
@@ -205,7 +217,7 @@ test("DocsBuilder generates correct output paths", async () => {
   );
 });
 
-test("DocsBuilder handles multiple markdown files correctly", async () => {
+test("PagesBuilder handles multiple markdown files correctly", async () => {
   const files = new Map();
   const dirs = new Set();
 
@@ -247,6 +259,23 @@ test("DocsBuilder handles multiple markdown files correctly", async () => {
   const mockPath = {
     join: (...parts) => parts.join("/"),
     dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+    normalize: (p) => {
+      const parts = p.split("/").filter(Boolean);
+      const result = [];
+      for (const part of parts) {
+        if (part === "..") result.pop();
+        else if (part !== ".") result.push(part);
+      }
+      return result.join("/") || ".";
+    },
+    relative: (from, to) => {
+      const f = from.split("/").filter(Boolean);
+      const t = to.split("/").filter(Boolean);
+      let i = 0;
+      while (i < f.length && i < t.length && f[i] === t[i]) i++;
+      const ups = f.length - i;
+      return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+    },
   };
 
   const mockMarked = Object.assign((md) => `<p>${md}</p>`, { use: () => {} });
@@ -257,7 +286,7 @@ test("DocsBuilder handles multiple markdown files correctly", async () => {
   const mockMustache = (template, context) => context.title;
   const mockPrettier = { format: async (html) => html };
 
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     mockFs,
     mockPath,
     mockMarked,
@@ -268,19 +297,17 @@ test("DocsBuilder handles multiple markdown files correctly", async () => {
 
   await builder.build("docs", "dist");
 
-  // Verify all files are created with correct paths
   assert.ok(files.has("dist/index.html"));
   assert.ok(files.has("dist/reference/index.html"));
   assert.ok(files.has("dist/configuration/index.html"));
   assert.ok(files.has("dist/deployment/index.html"));
 
-  // Verify directories were created
   assert.ok(dirs.has("dist/reference"));
   assert.ok(dirs.has("dist/configuration"));
   assert.ok(dirs.has("dist/deployment"));
 });
 
-test("DocsBuilder skips CLAUDE.md and SKILL.md files", async () => {
+test("PagesBuilder skips CLAUDE.md and SKILL.md files", async () => {
   const files = new Map();
   const dirs = new Set();
 
@@ -317,6 +344,23 @@ test("DocsBuilder skips CLAUDE.md and SKILL.md files", async () => {
   const mockPath = {
     join: (...parts) => parts.join("/"),
     dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+    normalize: (p) => {
+      const parts = p.split("/").filter(Boolean);
+      const result = [];
+      for (const part of parts) {
+        if (part === "..") result.pop();
+        else if (part !== ".") result.push(part);
+      }
+      return result.join("/") || ".";
+    },
+    relative: (from, to) => {
+      const f = from.split("/").filter(Boolean);
+      const t = to.split("/").filter(Boolean);
+      let i = 0;
+      while (i < f.length && i < t.length && f[i] === t[i]) i++;
+      const ups = f.length - i;
+      return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+    },
   };
 
   const mockMarked = Object.assign((md) => `<p>${md}</p>`, { use: () => {} });
@@ -327,7 +371,7 @@ test("DocsBuilder skips CLAUDE.md and SKILL.md files", async () => {
   const mockMustache = (template, context) => context.title;
   const mockPrettier = { format: async (html) => html };
 
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     mockFs,
     mockPath,
     mockMarked,
@@ -338,14 +382,12 @@ test("DocsBuilder skips CLAUDE.md and SKILL.md files", async () => {
 
   await builder.build("docs", "dist");
 
-  // CLAUDE.md and SKILL.md should not be built
   assert.ok(
     !files.has("dist/CLAUDE/index.html"),
     "CLAUDE.md should be skipped",
   );
   assert.ok(!files.has("dist/SKILL/index.html"), "SKILL.md should be skipped");
 
-  // Regular markdown files should still be built
   assert.ok(files.has("dist/index.html"), "index.html should exist");
   assert.ok(
     files.has("dist/guide/index.html"),
@@ -353,7 +395,7 @@ test("DocsBuilder skips CLAUDE.md and SKILL.md files", async () => {
   );
 });
 
-test("DocsServer handles directory requests correctly", async () => {
+test("PagesServer handles directory requests correctly", async () => {
   const files = new Map();
   files.set("dist/index.html", "Home");
   files.set("dist/architecture/index.html", "Architecture");
@@ -361,7 +403,6 @@ test("DocsServer handles directory requests correctly", async () => {
 
   const mockFs = {
     existsSync: (path) => {
-      // Handle both directory and file checks
       if (
         path === "dist/architecture" ||
         path === "dist/concepts" ||
@@ -395,14 +436,12 @@ test("DocsServer handles directory requests correctly", async () => {
   const mockServe = () => ({});
   const mockBuilder = {};
 
-  const server = new DocsServer(mockFs, mockHono, mockServe, mockBuilder);
+  const server = new PagesServer(mockFs, mockHono, mockServe, mockBuilder);
   server.serve("dist", { port: 3000, hostname: "0.0.0.0" });
 
-  // Get the handler for "*"
   const handler = mockApp.routes.get("*");
   assert.ok(handler, "Should register wildcard route handler");
 
-  // Test root request
   const rootResult = await handler({
     req: { path: "/" },
     text: (msg, status) => ({ body: msg, status }),
@@ -410,7 +449,6 @@ test("DocsServer handles directory requests correctly", async () => {
   });
   assert.strictEqual(rootResult.content, "Home");
 
-  // Test directory request without trailing slash
   const archResult = await handler({
     req: { path: "/architecture" },
     text: (msg, status) => ({ body: msg, status }),
@@ -418,7 +456,6 @@ test("DocsServer handles directory requests correctly", async () => {
   });
   assert.strictEqual(archResult.content, "Architecture");
 
-  // Test directory request with trailing slash
   const conceptsResult = await handler({
     req: { path: "/concepts/" },
     text: (msg, status) => ({ body: msg, status }),

--- a/libraries/libdoc/test/libdoc-companion.test.js
+++ b/libraries/libdoc/test/libdoc-companion.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { DocsBuilder } from "../src/index.js";
+import { PagesBuilder } from "../src/index.js";
 
 function createTestHarness({
   sourceFiles,
@@ -51,6 +51,23 @@ function createTestHarness({
   const mockPath = {
     join: (...parts) => parts.join("/"),
     dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+    normalize: (p) => {
+      const parts = p.split("/").filter(Boolean);
+      const result = [];
+      for (const part of parts) {
+        if (part === "..") result.pop();
+        else if (part !== ".") result.push(part);
+      }
+      return result.join("/") || ".";
+    },
+    relative: (from, to) => {
+      const f = from.split("/").filter(Boolean);
+      const t = to.split("/").filter(Boolean);
+      let i = 0;
+      while (i < f.length && i < t.length && f[i] === t[i]) i++;
+      const ups = f.length - i;
+      return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+    },
   };
 
   const mockMarked = Object.assign((md) => `<p>${md}</p>`, { use: () => {} });
@@ -76,7 +93,7 @@ function createTestHarness({
       .replace(/\{\{(\w+)\}\}/g, (_, key) => ctx[key] || "");
   const mockPrettier = { format: async (html) => html };
 
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     mockFs,
     mockPath,
     mockMarked,
@@ -88,7 +105,7 @@ function createTestHarness({
   return { files, dirs, copied, builder };
 }
 
-test("DocsBuilder writes markdown companion with title prepend", async () => {
+test("PagesBuilder writes markdown companion with title prepend", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nWelcome content"],
     ["src/about.md", "---\ntitle: About\n---\nAbout content"],
@@ -115,7 +132,7 @@ test("DocsBuilder writes markdown companion with title prepend", async () => {
   );
 });
 
-test("DocsBuilder transforms markdown body links in companions", async () => {
+test("PagesBuilder transforms markdown body links in companions", async () => {
   const sourceFiles = new Map([
     [
       "src/index.md",
@@ -138,7 +155,7 @@ test("DocsBuilder transforms markdown body links in companions", async () => {
   assert.ok(md.includes("[Hash](core/#section)"), "hash fragment preserved");
 });
 
-test("DocsBuilder leaves external .md links untouched in companions", async () => {
+test("PagesBuilder leaves external .md links untouched in companions", async () => {
   const sourceFiles = new Map([
     [
       "src/index.md",
@@ -169,7 +186,7 @@ test("DocsBuilder leaves external .md links untouched in companions", async () =
   );
 });
 
-test("DocsBuilder treats absolute .md links as external when no baseUrl", async () => {
+test("PagesBuilder treats absolute .md links as external when no baseUrl", async () => {
   const sourceFiles = new Map([
     [
       "src/index.md",
@@ -192,7 +209,7 @@ test("DocsBuilder treats absolute .md links as external when no baseUrl", async 
   );
 });
 
-test("DocsBuilder generates sitemap.xml with baseUrl", async () => {
+test("PagesBuilder generates sitemap.xml with baseUrl", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nContent"],
     ["src/about.md", "---\ntitle: About\n---\nContent"],
@@ -214,7 +231,7 @@ test("DocsBuilder generates sitemap.xml with baseUrl", async () => {
   assert.ok(sitemap.includes("<loc>https://example.com/about/</loc>"));
 });
 
-test("DocsBuilder sorts sitemap entries alphabetically", async () => {
+test("PagesBuilder sorts sitemap entries alphabetically", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nContent"],
     ["src/zebra.md", "---\ntitle: Zebra\n---\nContent"],
@@ -237,7 +254,7 @@ test("DocsBuilder sorts sitemap entries alphabetically", async () => {
   ]);
 });
 
-test("DocsBuilder skips sitemap when no baseUrl", async () => {
+test("PagesBuilder skips sitemap when no baseUrl", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nContent"],
   ]);
@@ -250,14 +267,13 @@ test("DocsBuilder skips sitemap when no baseUrl", async () => {
   await builder.build("src", "dist");
 
   assert.ok(!files.has("dist/sitemap.xml"), "no sitemap without baseUrl");
-  // Companions should still be produced
   assert.ok(
     files.has("dist/index.md"),
     "companion still produced without baseUrl",
   );
 });
 
-test("DocsBuilder adds alternate and canonical link tags", async () => {
+test("PagesBuilder adds alternate and canonical link tags", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nContent"],
   ]);
@@ -281,7 +297,7 @@ test("DocsBuilder adds alternate and canonical link tags", async () => {
   );
 });
 
-test("DocsBuilder omits canonical tag when no baseUrl", async () => {
+test("PagesBuilder omits canonical tag when no baseUrl", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nContent"],
   ]);

--- a/libraries/libdoc/test/libdoc-llms.test.js
+++ b/libraries/libdoc/test/libdoc-llms.test.js
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { DocsBuilder } from "../src/index.js";
+import { PagesBuilder } from "../src/index.js";
 
 function createTestHarness({
   sourceFiles,
@@ -51,6 +51,23 @@ function createTestHarness({
   const mockPath = {
     join: (...parts) => parts.join("/"),
     dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+    normalize: (p) => {
+      const parts = p.split("/").filter(Boolean);
+      const result = [];
+      for (const part of parts) {
+        if (part === "..") result.pop();
+        else if (part !== ".") result.push(part);
+      }
+      return result.join("/") || ".";
+    },
+    relative: (from, to) => {
+      const f = from.split("/").filter(Boolean);
+      const t = to.split("/").filter(Boolean);
+      let i = 0;
+      while (i < f.length && i < t.length && f[i] === t[i]) i++;
+      const ups = f.length - i;
+      return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+    },
   };
 
   const mockMarked = Object.assign((md) => `<p>${md}</p>`, { use: () => {} });
@@ -76,7 +93,7 @@ function createTestHarness({
       .replace(/\{\{(\w+)\}\}/g, (_, key) => ctx[key] || "");
   const mockPrettier = { format: async (html) => html };
 
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     mockFs,
     mockPath,
     mockMarked,
@@ -88,7 +105,7 @@ function createTestHarness({
   return { files, dirs, copied, builder };
 }
 
-test("DocsBuilder augments llms.txt with page links", async () => {
+test("PagesBuilder augments llms.txt with page links", async () => {
   const llmsContent = [
     "# Test Site",
     "",
@@ -123,13 +140,11 @@ test("DocsBuilder augments llms.txt with page links", async () => {
   assert.ok(files.has("dist/llms.txt"), "llms.txt should exist");
   const llms = files.get("dist/llms.txt");
 
-  // Product pages under Products section
   assert.ok(
     llms.includes("- [Map](https://example.com/map/index.md): Data product"),
     "map under Products",
   );
 
-  // Optional pages
   assert.ok(
     llms.includes("- [Home](https://example.com/index.md)"),
     "home under Optional",
@@ -140,7 +155,7 @@ test("DocsBuilder augments llms.txt with page links", async () => {
   );
 });
 
-test("DocsBuilder skips llms.txt when no curated file exists", async () => {
+test("PagesBuilder skips llms.txt when no curated file exists", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nContent"],
   ]);
@@ -155,7 +170,7 @@ test("DocsBuilder skips llms.txt when no curated file exists", async () => {
   assert.ok(!files.has("dist/llms.txt"), "no llms.txt without curated file");
 });
 
-test("DocsBuilder uses CNAME fallback when no baseUrl provided", async () => {
+test("PagesBuilder uses CNAME fallback when no baseUrl provided", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nContent"],
     ["src/CNAME", "example.com"],
@@ -176,7 +191,7 @@ test("DocsBuilder uses CNAME fallback when no baseUrl provided", async () => {
   );
 });
 
-test("DocsBuilder prefers explicit baseUrl over CNAME", async () => {
+test("PagesBuilder prefers explicit baseUrl over CNAME", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nContent"],
     ["src/CNAME", "cname.example.com"],
@@ -200,7 +215,7 @@ test("DocsBuilder prefers explicit baseUrl over CNAME", async () => {
   );
 });
 
-test("DocsBuilder copies root-level static files and skips .md, template, CNAME", async () => {
+test("PagesBuilder copies root-level static files and skips .md, template, CNAME", async () => {
   const sourceFiles = new Map([
     ["src/index.md", "---\ntitle: Home\n---\nContent"],
     ["src/robots.txt", "User-agent: *"],
@@ -255,6 +270,23 @@ test("DocsBuilder copies root-level static files and skips .md, template, CNAME"
   const mockPath = {
     join: (...parts) => parts.join("/"),
     dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+    normalize: (p) => {
+      const parts = p.split("/").filter(Boolean);
+      const result = [];
+      for (const part of parts) {
+        if (part === "..") result.pop();
+        else if (part !== ".") result.push(part);
+      }
+      return result.join("/") || ".";
+    },
+    relative: (from, to) => {
+      const f = from.split("/").filter(Boolean);
+      const t = to.split("/").filter(Boolean);
+      let i = 0;
+      while (i < f.length && i < t.length && f[i] === t[i]) i++;
+      const ups = f.length - i;
+      return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+    },
   };
 
   const mockMarked = Object.assign((md) => `<p>${md}</p>`, { use: () => {} });
@@ -265,7 +297,7 @@ test("DocsBuilder copies root-level static files and skips .md, template, CNAME"
   const mockMustache = (_tpl, ctx) => ctx.title;
   const mockPrettier = { format: async (html) => html };
 
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     mockFs,
     mockPath,
     mockMarked,
@@ -287,7 +319,7 @@ test("DocsBuilder copies root-level static files and skips .md, template, CNAME"
   );
 });
 
-test("DocsBuilder classifies docs pages under Documentation in llms.txt", async () => {
+test("PagesBuilder classifies docs pages under Documentation in llms.txt", async () => {
   const llmsContent =
     "# Site\n\n## Products\n\n## Documentation\n\n## Optional\n";
 
@@ -340,6 +372,23 @@ test("DocsBuilder classifies docs pages under Documentation in llms.txt", async 
   const mockPath = {
     join: (...parts) => parts.join("/"),
     dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+    normalize: (p) => {
+      const parts = p.split("/").filter(Boolean);
+      const result = [];
+      for (const part of parts) {
+        if (part === "..") result.pop();
+        else if (part !== ".") result.push(part);
+      }
+      return result.join("/") || ".";
+    },
+    relative: (from, to) => {
+      const f = from.split("/").filter(Boolean);
+      const t = to.split("/").filter(Boolean);
+      let i = 0;
+      while (i < f.length && i < t.length && f[i] === t[i]) i++;
+      const ups = f.length - i;
+      return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+    },
   };
 
   const mockMarked = Object.assign((md) => `<p>${md}</p>`, { use: () => {} });
@@ -358,7 +407,7 @@ test("DocsBuilder classifies docs pages under Documentation in llms.txt", async 
   const mockMustache = (_tpl, ctx) => ctx.title;
   const mockPrettier = { format: async (html) => html };
 
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     mockFs,
     mockPath,
     mockMarked,

--- a/libraries/libdoc/test/libdoc-page-tree.test.js
+++ b/libraries/libdoc/test/libdoc-page-tree.test.js
@@ -1,0 +1,162 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { scanPages } from "../src/page-tree.js";
+
+function createMockDeps(fileTree) {
+  const mockFs = {
+    readdirSync: (dir) => {
+      const entries = fileTree[dir];
+      if (!entries) return [];
+      return Object.keys(entries);
+    },
+    statSync: (fullPath) => {
+      for (const [dir, entries] of Object.entries(fileTree)) {
+        for (const [name, value] of Object.entries(entries)) {
+          const entryPath = dir + "/" + name;
+          if (entryPath === fullPath) {
+            return {
+              isDirectory: () => typeof value === "object" && value !== null,
+              isFile: () => typeof value === "string",
+            };
+          }
+        }
+      }
+      throw new Error(`ENOENT: ${fullPath}`);
+    },
+    readFileSync: (fullPath) => {
+      for (const [dir, entries] of Object.entries(fileTree)) {
+        for (const [name, value] of Object.entries(entries)) {
+          if (dir + "/" + name === fullPath && typeof value === "string") {
+            return value;
+          }
+        }
+      }
+      throw new Error(`ENOENT: ${fullPath}`);
+    },
+  };
+
+  const mockPath = {
+    join: (...parts) => parts.join("/"),
+    dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+    normalize: (p) => {
+      const parts = p.split("/").filter(Boolean);
+      const result = [];
+      for (const part of parts) {
+        if (part === "..") result.pop();
+        else if (part !== ".") result.push(part);
+      }
+      return result.join("/") || ".";
+    },
+    relative: (from, to) => {
+      const f = from.split("/").filter(Boolean);
+      const t = to.split("/").filter(Boolean);
+      let i = 0;
+      while (i < f.length && i < t.length && f[i] === t[i]) i++;
+      const ups = f.length - i;
+      return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+    },
+  };
+
+  const mockMatter = (content) => {
+    const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+    if (match) {
+      const data = {};
+      for (const line of match[1].split("\n")) {
+        const kv = line.match(/^(\w+): (.+)$/);
+        if (kv) data[kv[1]] = kv[2];
+      }
+      return { data, content: match[2] };
+    }
+    return { data: {}, content };
+  };
+
+  return { fs: mockFs, path: mockPath, matter: mockMatter };
+}
+
+test("scanPages returns map with 3 entries for 3-page directory", () => {
+  const fileTree = {
+    src: {
+      "index.md": "---\ntitle: Home\ndescription: Welcome\n---\nContent",
+      about: {},
+      docs: {},
+    },
+    "src/about": {
+      "index.md":
+        "---\ntitle: About Us\ndescription: About page\n---\nAbout content",
+    },
+    "src/docs": {
+      "index.md":
+        "---\ntitle: Documentation\ndescription: Docs hub\n---\nDocs content",
+    },
+  };
+
+  const deps = createMockDeps(fileTree);
+  const pageTree = scanPages("src", deps);
+
+  assert.strictEqual(pageTree.size, 3);
+
+  const home = pageTree.get("/");
+  assert.ok(home);
+  assert.strictEqual(home.title, "Home");
+  assert.strictEqual(home.description, "Welcome");
+  assert.strictEqual(home.filePath, "index.md");
+  assert.strictEqual(home.urlPath, "/");
+
+  const about = pageTree.get("/about/");
+  assert.ok(about);
+  assert.strictEqual(about.title, "About Us");
+  assert.strictEqual(about.description, "About page");
+  assert.strictEqual(about.filePath, "about/index.md");
+
+  const docs = pageTree.get("/docs/");
+  assert.ok(docs);
+  assert.strictEqual(docs.title, "Documentation");
+  assert.strictEqual(docs.description, "Docs hub");
+});
+
+test("scanPages excludes pages without title in frontmatter", () => {
+  const fileTree = {
+    src: {
+      "index.md": "---\ntitle: Home\n---\nContent",
+      "notitle.md": "---\ndescription: No title here\n---\nContent",
+    },
+  };
+
+  const deps = createMockDeps(fileTree);
+  const pageTree = scanPages("src", deps);
+
+  assert.strictEqual(pageTree.size, 1);
+  assert.ok(pageTree.has("/"));
+  assert.ok(!pageTree.has("/notitle/"));
+});
+
+test("scanPages skips CLAUDE.md, SKILL.md, assets/, public/", () => {
+  const fileTree = {
+    src: {
+      "index.md": "---\ntitle: Home\n---\nContent",
+      "CLAUDE.md": "---\ntitle: Claude\n---\nContent",
+      "SKILL.md": "---\ntitle: Skill\n---\nContent",
+      assets: {},
+      public: {},
+    },
+  };
+
+  const deps = createMockDeps(fileTree);
+  const pageTree = scanPages("src", deps);
+
+  assert.strictEqual(pageTree.size, 1);
+  assert.ok(pageTree.has("/"));
+});
+
+test("scanPages defaults description to empty string", () => {
+  const fileTree = {
+    src: {
+      "index.md": "---\ntitle: Home\n---\nContent",
+    },
+  };
+
+  const deps = createMockDeps(fileTree);
+  const pageTree = scanPages("src", deps);
+
+  assert.strictEqual(pageTree.get("/").description, "");
+});

--- a/libraries/libdoc/test/libdoc-partials.test.js
+++ b/libraries/libdoc/test/libdoc-partials.test.js
@@ -1,0 +1,190 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolvePartials, defaultRegistry } from "../src/partials.js";
+import { assertThrowsMessage } from "@forwardimpact/libharness";
+
+const mockPath = {
+  join: (...parts) => parts.join("/"),
+  dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+  normalize: (p) => {
+    const parts = p.split("/").filter(Boolean);
+    const result = [];
+    for (const part of parts) {
+      if (part === "..") result.pop();
+      else if (part !== ".") result.push(part);
+    }
+    return result.join("/") || ".";
+  },
+  relative: (from, to) => {
+    const f = from.split("/").filter(Boolean);
+    const t = to.split("/").filter(Boolean);
+    let i = 0;
+    while (i < f.length && i < t.length && f[i] === t[i]) i++;
+    const ups = f.length - i;
+    return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+  },
+};
+
+function makePageTree(entries) {
+  const map = new Map();
+  for (const entry of entries) {
+    map.set(entry.urlPath, entry);
+  }
+  return map;
+}
+
+test("card partial renders a tag with h3 and p", () => {
+  const pageTree = makePageTree([
+    {
+      filePath: "docs/getting-started/index.md",
+      urlPath: "/docs/getting-started/",
+      title: "Getting Started",
+      description: "Learn the basics",
+    },
+  ]);
+
+  const markdown = "Some text\n<!-- part:card:getting-started -->\nMore text";
+  const result = resolvePartials(markdown, pageTree, "docs", defaultRegistry, {
+    path: mockPath,
+  });
+
+  assert.ok(result.includes('<a href="getting-started/">'));
+  assert.ok(result.includes("<h3>Getting Started</h3>"));
+  assert.ok(result.includes("<p>Learn the basics</p>"));
+  assert.ok(result.includes("Some text"));
+  assert.ok(result.includes("More text"));
+});
+
+test("link partial renders a tag with title text", () => {
+  const pageTree = makePageTree([
+    {
+      filePath: "docs/getting-started/index.md",
+      urlPath: "/docs/getting-started/",
+      title: "Getting Started",
+      description: "Learn the basics",
+    },
+  ]);
+
+  const markdown = "See <!-- part:link:getting-started --> for details";
+  const result = resolvePartials(markdown, pageTree, "docs", defaultRegistry, {
+    path: mockPath,
+  });
+
+  assert.ok(result.includes('<a href="getting-started/">Getting Started</a>'));
+});
+
+test("sibling path resolves correctly", () => {
+  const pageTree = makePageTree([
+    {
+      filePath: "docs/getting-started/index.md",
+      urlPath: "/docs/getting-started/",
+      title: "Getting Started",
+      description: "Intro",
+    },
+  ]);
+
+  const markdown = "<!-- part:card:getting-started -->";
+  const result = resolvePartials(markdown, pageTree, "docs", defaultRegistry, {
+    path: mockPath,
+  });
+
+  assert.ok(result.includes('<a href="getting-started/">'));
+});
+
+test("parent path resolves with ..", () => {
+  const pageTree = makePageTree([
+    {
+      filePath: "pathway/index.md",
+      urlPath: "/pathway/",
+      title: "Pathway",
+      description: "Career paths",
+    },
+  ]);
+
+  const markdown = "<!-- part:card:../pathway -->";
+  const result = resolvePartials(markdown, pageTree, "docs", defaultRegistry, {
+    path: mockPath,
+  });
+
+  assert.ok(result.includes("<h3>Pathway</h3>"));
+  assert.ok(result.includes('<a href="../pathway/">'));
+});
+
+test("unknown type throws with type name in message", () => {
+  const pageTree = makePageTree([]);
+
+  assertThrowsMessage(
+    () =>
+      resolvePartials(
+        "<!-- part:unknown:foo -->",
+        pageTree,
+        "docs",
+        defaultRegistry,
+        { path: mockPath },
+      ),
+    /Unknown partial type "unknown"/,
+  );
+});
+
+test("missing target throws with path and source in message", () => {
+  const pageTree = makePageTree([]);
+
+  assertThrowsMessage(
+    () =>
+      resolvePartials(
+        "<!-- part:card:nonexistent -->",
+        pageTree,
+        "docs",
+        defaultRegistry,
+        { path: mockPath },
+      ),
+    /Partial target "nonexistent" not found in page tree.*docs/,
+  );
+});
+
+test("multiple partials in one page all resolve", () => {
+  const pageTree = makePageTree([
+    {
+      filePath: "docs/a/index.md",
+      urlPath: "/docs/a/",
+      title: "Page A",
+      description: "First",
+    },
+    {
+      filePath: "docs/b/index.md",
+      urlPath: "/docs/b/",
+      title: "Page B",
+      description: "Second",
+    },
+  ]);
+
+  const markdown = "<!-- part:card:a -->\n<!-- part:card:b -->";
+  const result = resolvePartials(markdown, pageTree, "docs", defaultRegistry, {
+    path: mockPath,
+  });
+
+  assert.ok(result.includes("<h3>Page A</h3>"));
+  assert.ok(result.includes("<h3>Page B</h3>"));
+});
+
+test("href is relative URL between current and target pages", () => {
+  const pageTree = makePageTree([
+    {
+      filePath: "docs/libraries/typed-contracts/index.md",
+      urlPath: "/docs/libraries/typed-contracts/",
+      title: "Typed Contracts",
+      description: "Types",
+    },
+  ]);
+
+  const markdown = "<!-- part:card:../libraries/typed-contracts -->";
+  const result = resolvePartials(
+    markdown,
+    pageTree,
+    "docs/products",
+    defaultRegistry,
+    { path: mockPath },
+  );
+
+  assert.ok(result.includes('<a href="../libraries/typed-contracts/">'));
+});

--- a/libraries/libdoc/test/test-harness.js
+++ b/libraries/libdoc/test/test-harness.js
@@ -1,4 +1,4 @@
-import { DocsBuilder } from "../src/index.js";
+import { PagesBuilder } from "../src/index.js";
 
 /**
  * Create a mock fs/path/builder setup for tests
@@ -7,7 +7,7 @@ import { DocsBuilder } from "../src/index.js";
  * @param {string[]} options.mdFiles - Markdown file names in source dir
  * @param {string[]} [options.rootFiles] - Non-md files in source root
  * @param {string} [options.template] - Template content
- * @returns {{ files: Map, dirs: Set, builder: DocsBuilder, copied: Map }}
+ * @returns {{ files: Map, dirs: Set, builder: PagesBuilder, copied: Map }}
  */
 export function createTestHarness({
   sourceFiles,
@@ -58,6 +58,23 @@ export function createTestHarness({
   const mockPath = {
     join: (...parts) => parts.join("/"),
     dirname: (p) => p.split("/").slice(0, -1).join("/") || ".",
+    normalize: (p) => {
+      const parts = p.split("/").filter(Boolean);
+      const result = [];
+      for (const part of parts) {
+        if (part === "..") result.pop();
+        else if (part !== ".") result.push(part);
+      }
+      return result.join("/") || ".";
+    },
+    relative: (from, to) => {
+      const f = from.split("/").filter(Boolean);
+      const t = to.split("/").filter(Boolean);
+      let i = 0;
+      while (i < f.length && i < t.length && f[i] === t[i]) i++;
+      const ups = f.length - i;
+      return [...Array(ups).fill(".."), ...t.slice(i)].join("/") || ".";
+    },
   };
 
   const mockMarked = Object.assign((md) => `<p>${md}</p>`, { use: () => {} });
@@ -83,7 +100,7 @@ export function createTestHarness({
       .replace(/\{\{(\w+)\}\}/g, (_, key) => ctx[key] || "");
   const mockPrettier = { format: async (html) => html };
 
-  const builder = new DocsBuilder(
+  const builder = new PagesBuilder(
     mockFs,
     mockPath,
     mockMarked,

--- a/websites/CLAUDE.md
+++ b/websites/CLAUDE.md
@@ -28,9 +28,13 @@ Every page is a directory containing `index.md`. No other `.md` filenames.
   relative, not `index.md`). External links use full URLs.
 - **Code blocks** — always specify a language tag (`sh`, `yaml`, `json`,
   `mermaid`, etc.).
-- **Navigation is manual.** When a page is added, moved, or removed, update
-  every hub page and card grid that references it. There is no build-time check
-  for stale links.
+- **Card grids use content partials.** Hub page cards are
+  `<!-- part:card:relative-path -->` markers that resolve to the target page's
+  frontmatter `title` and `description` at build time. The build fails if a
+  partial references a nonexistent page. Hand-written `<a>` cards are only used
+  for external links or same-page anchors.
+- **Hand-written links are not checked.** Partials validate their targets, but
+  inline markdown links are not verified at build time.
 
 ## Page Types
 
@@ -51,23 +55,25 @@ Product pages (`/map/`, `/pathway/`, etc.) follow a consistent structure:
 
 ### Hub Pages
 
-Collection pages use `toc: false` and a grid of anchor cards to link to
+Collection pages use `toc: false` and a grid of content partials to link to
 children. Cards are organized under `##` job headings with a persona label.
 
 ```html
 <div class="grid">
-<a href="/docs/products/agent-teams/">
-
-### Agent Teams
-
-Configure agents to meet your engineering standard...
-
-</a>
+<!-- part:card:agent-teams -->
+<!-- part:card:agent-teams/organizational-context -->
 </div>
 ```
 
-Navigation is not generated from the file tree. When a page is added, moved, or
-removed, update every hub page and card grid that references it.
+Each `<!-- part:card:path -->` resolves to an `<a>` with the target page's
+`title` and `description` from frontmatter. Paths are relative to the current
+page's directory — `agent-teams` for a sibling, `../docs/libraries` for a
+cross-tree reference. The build fails if a target page does not exist, so stale
+card references are caught automatically.
+
+Hand-written `<a>` cards are still used for external links (GitHub URLs) and
+same-page anchors (`href="#section"`). See `gear/index.md` and
+`docs/internals/kata/index.md` for examples.
 
 ### Getting Started Pages
 

--- a/websites/fit/docs/getting-started/engineers/index.md
+++ b/websites/fit/docs/getting-started/engineers/index.md
@@ -12,40 +12,12 @@ product from install to first use.
 
 <div class="grid">
 
-<a href="/docs/getting-started/engineers/pathway/">
+<!-- part:card:pathway -->
 
-### Pathway
+<!-- part:card:guide -->
 
-Browse career paths, generate AI agent teams, and explore job definitions from
-the CLI and web app.
+<!-- part:card:landmark -->
 
-</a>
-
-<a href="/docs/getting-started/engineers/guide/">
-
-### Guide
-
-Set up the AI agent that understands your agent-aligned engineering standard —
-onboarding, career advice, skill assessment, and contextual help.
-
-</a>
-
-<a href="/docs/getting-started/engineers/landmark/">
-
-### Landmark
-
-Check your evidence record, promotion readiness, growth timeline, and skill
-coverage against your agent-aligned engineering standard markers.
-
-</a>
-
-<a href="/docs/getting-started/engineers/outpost/">
-
-### Outpost
-
-Initialize your personal knowledge base, configure background AI tasks, and
-start the scheduler.
-
-</a>
+<!-- part:card:outpost -->
 
 </div>

--- a/websites/fit/docs/getting-started/index.md
+++ b/websites/fit/docs/getting-started/index.md
@@ -7,32 +7,10 @@ toc: false
 
 <div class="grid">
 
-<a href="/docs/getting-started/leadership/">
+<!-- part:card:leadership -->
 
-### Leadership
+<!-- part:card:engineers -->
 
-Go from an unwritten engineering standard to a validated, previewable
-definition — with career paths, capability signals, and team analysis ready to
-use.
-
-</a>
-
-<a href="/docs/getting-started/engineers/">
-
-### Engineers
-
-Go from unfamiliar tooling to a clear view of your level, growth guidance
-grounded in your standard, and a knowledge base that stays current.
-
-</a>
-
-<a href="/docs/getting-started/contributors/">
-
-### Contributors
-
-Go from a fresh clone to a working development environment — with synthetic
-data, passing checks, and a clear picture of the project structure.
-
-</a>
+<!-- part:card:contributors -->
 
 </div>

--- a/websites/fit/docs/getting-started/leadership/index.md
+++ b/websites/fit/docs/getting-started/leadership/index.md
@@ -12,41 +12,12 @@ through a single product from install to working output.
 
 <div class="grid">
 
-<a href="/docs/getting-started/leadership/map/">
+<!-- part:card:map -->
 
-### Map
+<!-- part:card:pathway -->
 
-Define your agent-aligned engineering standard in YAML, validate against
-schemas, set up the activity layer, and ingest operational signals from GitHub
-and GetDX.
+<!-- part:card:landmark -->
 
-</a>
-
-<a href="/docs/getting-started/leadership/pathway/">
-
-### Pathway
-
-Preview your agent-aligned engineering standard in the browser, generate job
-definitions, and create interview question sets.
-
-</a>
-
-<a href="/docs/getting-started/leadership/landmark/">
-
-### Landmark
-
-Analyze engineering signals — marker evidence, snapshot trends, practice
-patterns, team health, and engineer voice.
-
-</a>
-
-<a href="/docs/getting-started/leadership/summit/">
-
-### Summit
-
-Model team capability — coverage heatmaps, structural risks, what-if staffing
-scenarios, growth alignment, and trajectory over time.
-
-</a>
+<!-- part:card:summit -->
 
 </div>

--- a/websites/fit/docs/index.md
+++ b/websites/fit/docs/index.md
@@ -11,59 +11,16 @@ hero:
 
 <div class="grid">
 
-<a href="/docs/getting-started/">
+<!-- part:card:getting-started -->
 
-### Getting Started
+<!-- part:card:products -->
 
-Go from zero to your first meaningful result — whether you're defining standards, exploring expectations, or running the codebase.
+<!-- part:card:libraries -->
 
-</a>
+<!-- part:card:services -->
 
-<a href="/docs/products/">
+<!-- part:card:reference -->
 
-### Product Guides
-
-Guides for engineers and leaders — from unclear expectations to visible
-standards, from vague growth feedback to concrete evidence, from unverified
-agent output to trusted delivery.
-
-</a>
-
-<a href="/docs/libraries/">
-
-### Library Guides
-
-Guides for engineers and platform builders — from scattered agent state to
-persistent memory, from isolated knowledge stores to shared infrastructure,
-from manual service wiring to managed lifecycle.
-
-</a>
-
-<a href="/docs/services/">
-
-### Service Guides
-
-Guides for platform builders — from per-product infrastructure to shared gRPC
-services for knowledge graphs, vector search, standard queries, trace
-collection, and agent tools.
-
-</a>
-
-<a href="/docs/reference/">
-
-### Reference
-
-Find the exact command, entity shape, lifecycle phase, or YAML field you need — without reading end-to-end guides.
-
-</a>
-
-<a href="/docs/internals/">
-
-### Internals
-
-Understand how the system works under the hood — architecture and code for
-Map, Pathway, Guide, Summit, Outpost, and supporting libraries.
-
-</a>
+<!-- part:card:internals -->
 
 </div>

--- a/websites/fit/docs/internals/index.md
+++ b/websites/fit/docs/internals/index.md
@@ -7,40 +7,12 @@ toc: false
 
 <div class="grid">
 
-<a href="/docs/internals/librepl/">
+<!-- part:card:librepl -->
 
-### librepl
+<!-- part:card:vectors -->
 
-Interactive REPL library — Repl class, custom commands, state persistence, and
-dual-mode (interactive/piped) CLI interfaces.
+<!-- part:card:operations -->
 
-</a>
-
-<a href="/docs/internals/vectors/">
-
-### Vectors
-
-Vector embedding pipeline — TEI setup, resource processing, index format, and
-integration with the vector service.
-
-</a>
-
-<a href="/docs/internals/operations/">
-
-### Operations
-
-Environment configuration, service management, and common development tasks for
-the Forward Impact monorepo.
-
-</a>
-
-<a href="/docs/internals/kata/">
-
-### Kata Agent Team
-
-An autonomous and continuously improving agentic development team organized as a
-daily Plan-Do-Study-Act cycle with spec-driven development.
-
-</a>
+<!-- part:card:kata -->
 
 </div>

--- a/websites/fit/docs/libraries/index.md
+++ b/websites/fit/docs/libraries/index.md
@@ -11,32 +11,11 @@ Engineers
 
 <div class="grid">
 
-<a href="/docs/libraries/predictable-team/">
+<!-- part:card:predictable-team -->
 
-### Set Up Persistent Memory and Metrics
+<!-- part:card:predictable-team/wiki-operations -->
 
-Give your agent team persistent memory and real signal detection — wiki-backed
-state, XmR control charts, and evidence that agents act on changes, not noise.
-
-</a>
-
-<a href="/docs/libraries/predictable-team/wiki-operations/">
-
-### Send a Memo or Update a Storyboard
-
-Communicate across your agent team and keep storyboards current — without
-managing the wiki infrastructure yourself.
-
-</a>
-
-<a href="/docs/libraries/predictable-team/xmr-analysis/">
-
-### Chart a Metric and Check Variation
-
-Know whether a metric has actually changed or just varied — natural process
-limits and Wheeler's detection rules separate signal from noise.
-
-</a>
+<!-- part:card:predictable-team/xmr-analysis -->
 
 </div>
 
@@ -46,23 +25,9 @@ Builders
 
 <div class="grid">
 
-<a href="/docs/libraries/every-surface/">
+<!-- part:card:every-surface -->
 
-### Give Agents and Humans the Same Interface
-
-Capabilities that work on every surface — one presenter, one contract, and one
-formatter shared between CLI and web, with no separate integrations.
-
-</a>
-
-<a href="/docs/libraries/every-surface/add-capability/">
-
-### Add a Capability to Both Surfaces
-
-Ship a feature to terminal and browser at once — one presenter, one
-registration, both surfaces.
-
-</a>
+<!-- part:card:every-surface/add-capability -->
 
 </div>
 
@@ -72,51 +37,15 @@ Builders
 
 <div class="grid">
 
-<a href="/docs/libraries/ground-agents/">
+<!-- part:card:ground-agents -->
 
-### Give Agents Typed, Retrievable Knowledge
+<!-- part:card:ground-agents/query-graph -->
 
-Agents that can answer relationship questions, look up context, and find
-related content — backed by typed knowledge infrastructure with no external
-engines.
+<!-- part:card:ground-agents/lookup-context -->
 
-</a>
+<!-- part:card:ground-agents/resolve-resource -->
 
-<a href="/docs/libraries/ground-agents/query-graph/">
-
-### Query a Knowledge Graph
-
-Answer relationship questions from an RDF graph index — triple patterns and
-type-filtered listings, no join logic or SPARQL endpoint.
-
-</a>
-
-<a href="/docs/libraries/ground-agents/lookup-context/">
-
-### Look Up Context Fast
-
-Retrieve exactly the context you need from a JSONL-backed index — prefix,
-limit, and token-budget filters without loading everything into memory.
-
-</a>
-
-<a href="/docs/libraries/ground-agents/resolve-resource/">
-
-### Resolve a Resource
-
-Give agents rich, typed context from a resource identifier — provenance, access
-control, and RDF content instead of raw files.
-
-</a>
-
-<a href="/docs/libraries/ground-agents/search-semantically/">
-
-### Search Semantically
-
-Find related content by meaning, not keywords — ranked results from a vector
-index without standing up a vector database.
-
-</a>
+<!-- part:card:ground-agents/search-semantically -->
 
 </div>
 
@@ -126,24 +55,9 @@ Builders
 
 <div class="grid">
 
-<a href="/docs/libraries/integrate-standard/">
+<!-- part:card:integrate-standard -->
 
-### Turn Standard Definitions into Queryable Data
-
-Engineering standard YAML becomes queryable data — derive skill matrices,
-behaviour profiles, and agent configurations programmatically from a single
-load.
-
-</a>
-
-<a href="/docs/libraries/integrate-standard/derive-profile/">
-
-### Derive a Skill Matrix or Agent Profile
-
-Go from discipline, level, and track to a complete skill matrix or agent
-profile — without parsing YAML by hand.
-
-</a>
+<!-- part:card:integrate-standard/derive-profile -->
 
 </div>
 
@@ -153,32 +67,11 @@ Builders
 
 <div class="grid">
 
-<a href="/docs/libraries/typed-contracts/">
+<!-- part:card:typed-contracts -->
 
-### Keep Types Synced with Proto Definitions
+<!-- part:card:typed-contracts/expose-tool -->
 
-Proto changes flow through to JavaScript types, MCP tools, and service
-endpoints automatically — one source of truth from definition to runtime.
-
-</a>
-
-<a href="/docs/libraries/typed-contracts/expose-tool/">
-
-### Expose a Proto Method as an Agent Tool
-
-A new gRPC method becomes an agent tool with one config entry — no glue code,
-no hand-written schema.
-
-</a>
-
-<a href="/docs/libraries/typed-contracts/ship-endpoint/">
-
-### Ship a Service Endpoint
-
-Ship a gRPC service with typed contracts, authentication, retries, and health
-checks — without reimplementing transport.
-
-</a>
+<!-- part:card:typed-contracts/ship-endpoint -->
 
 </div>
 
@@ -188,32 +81,11 @@ Builders
 
 <div class="grid">
 
-<a href="/docs/libraries/service-lifecycle/">
+<!-- part:card:service-lifecycle -->
 
-### Manage Service Lifecycle from One Interface
+<!-- part:card:service-lifecycle/manage-service -->
 
-Services that stay running and problems that surface before they escalate —
-supervision and observability from one interface.
-
-</a>
-
-<a href="/docs/libraries/service-lifecycle/manage-service/">
-
-### Start, Stop, or Check a Service
-
-Start, stop, restart, check status, and read logs through one interface —
-without remembering each service's specific incantation.
-
-</a>
-
-<a href="/docs/libraries/service-lifecycle/add-observability/">
-
-### Add Observability
-
-Structured, machine-readable logs and traces without configuring a logging
-framework — drop in a log line or trace span and it works.
-
-</a>
+<!-- part:card:service-lifecycle/add-observability -->
 
 </div>
 
@@ -223,41 +95,13 @@ Builders
 
 <div class="grid">
 
-<a href="/docs/libraries/prove-changes/">
+<!-- part:card:prove-changes -->
 
-### Prove Agent Changes
+<!-- part:card:prove-changes/run-eval -->
 
-Reproducible evidence that agent changes improved outcomes — from dataset
-generation through evaluation to trace analysis.
+<!-- part:card:prove-changes/trace-analysis -->
 
-</a>
-
-<a href="/docs/libraries/prove-changes/run-eval/">
-
-### Run an Eval
-
-Know whether agent changes improved outcomes — an agent-as-judge eval wired
-into CI with traceable results.
-
-</a>
-
-<a href="/docs/libraries/prove-changes/trace-analysis/">
-
-### Analyze Traces
-
-See exactly what an agent did and why — download traces, query turns, filter by
-tool or error, and measure token cost.
-
-</a>
-
-<a href="/docs/libraries/prove-changes/generate-dataset/">
-
-### Generate an Eval Dataset
-
-Go from a DSL file to a complete, validated evaluation dataset — entities
-generated, prose resolved, output rendered, and results verified.
-
-</a>
+<!-- part:card:prove-changes/generate-dataset -->
 
 </div>
 

--- a/websites/fit/docs/products/index.md
+++ b/websites/fit/docs/products/index.md
@@ -9,32 +9,11 @@ toc: false
 
 <div class="grid">
 
-<a href="/docs/products/authoring-standards/">
+<!-- part:card:authoring-standards -->
 
-### Authoring Agent-Aligned Engineering Standards
+<!-- part:card:authoring-standards/update-standard -->
 
-Turn 'good engineering' into an operational definition so evaluations start
-from a shared foundation instead of private mental models.
-
-</a>
-
-<a href="/docs/products/authoring-standards/update-standard/">
-
-### Validate and Update the Standard
-
-Evolve your engineering standard with confidence — structural mistakes surface
-during validation, not after the team has adopted the change.
-
-</a>
-
-<a href="/docs/products/authoring-standards/define-role/">
-
-### Define a New Role
-
-Move from a blank slate to a well-structured role definition — built from
-existing disciplines and tracks, then customized to fit.
-
-</a>
+<!-- part:card:authoring-standards/define-role -->
 
 </div>
 
@@ -42,23 +21,9 @@ existing disciplines and tracks, then customized to fit.
 
 <div class="grid">
 
-<a href="/docs/products/career-paths/">
+<!-- part:card:career-paths -->
 
-### See What's Expected at Your Level
-
-Stop guessing what your level requires — see the skills, behaviours, and scope
-so expectations are clear before your next review.
-
-</a>
-
-<a href="/docs/products/career-paths/autonomy-scope/">
-
-### Understand Autonomy and Scope
-
-Understand what independence, decision-making authority, and complexity look
-like at your level — so scope conversations start from shared definitions.
-
-</a>
+<!-- part:card:career-paths/autonomy-scope -->
 
 </div>
 
@@ -66,32 +31,11 @@ like at your level — so scope conversations start from shared definitions.
 
 <div class="grid">
 
-<a href="/docs/products/growth-areas/">
+<!-- part:card:growth-areas -->
 
-### Find Growth Areas and Build Evidence
+<!-- part:card:growth-areas/growth-question -->
 
-When a promotion conversation ends with 'not yet' and no specifics, use Guide
-and Landmark to find what's missing and show concrete evidence of growth.
-
-</a>
-
-<a href="/docs/products/growth-areas/growth-question/">
-
-### Ask a Growth Question
-
-Get growth advice grounded in your organization's actual skill and behaviour
-definitions — not generic career guidance.
-
-</a>
-
-<a href="/docs/products/growth-areas/check-progress/">
-
-### Check Progress Toward Next Level
-
-See whether recent engineering work shows visible movement toward the next level
-by reviewing your readiness checklist and growth timeline.
-
-</a>
+<!-- part:card:growth-areas/check-progress -->
 
 </div>
 
@@ -99,32 +43,11 @@ by reviewing your readiness checklist and growth timeline.
 
 <div class="grid">
 
-<a href="/docs/products/trust-output/">
+<!-- part:card:trust-output -->
 
-### Verify Agent Work Against the Standard
+<!-- part:card:trust-output/second-opinion -->
 
-Catch convention violations that look correct on the surface — review agent
-output against your engineering standard instead of reading every line.
-
-</a>
-
-<a href="/docs/products/trust-output/second-opinion/">
-
-### Get a Second Opinion on a Deliverable
-
-Know what meets the bar and what falls short before you approve — assessed
-against your engineering standard, not intuition.
-
-</a>
-
-<a href="/docs/products/trust-output/expected-output/">
-
-### See What the Standard Expects Before Reviewing
-
-Know what to check before you start reviewing — the skill proficiencies,
-behaviour maturities, and expectations your standard defines for the role.
-
-</a>
+<!-- part:card:trust-output/expected-output -->
 
 </div>
 
@@ -132,24 +55,9 @@ behaviour maturities, and expectations your standard defines for the role.
 
 <div class="grid">
 
-<a href="/docs/products/agent-teams/">
+<!-- part:card:agent-teams -->
 
-### Configure Agents to Meet Your Engineering Standard
-
-End the cycle of rejecting agent output for following generic practices —
-agents configured against the same standard the organization holds for human
-contributors.
-
-</a>
-
-<a href="/docs/products/agent-teams/organizational-context/">
-
-### Give Agents Organizational Context
-
-Keep agents aligned as your engineering standard evolves — guidance stays clear
-and non-conflicting without manual reconciliation.
-
-</a>
+<!-- part:card:agent-teams/organizational-context -->
 
 </div>
 
@@ -157,23 +65,9 @@ and non-conflicting without manual reconciliation.
 
 <div class="grid">
 
-<a href="/docs/products/engineering-outcomes/">
+<!-- part:card:engineering-outcomes -->
 
-### Demonstrate Engineering Progress
-
-Walk into a quarterly review with system-level trends, marker evidence, and
-engineer voice — demonstrating progress without singling out individuals.
-
-</a>
-
-<a href="/docs/products/engineering-outcomes/culture-investments/">
-
-### Tell Whether Culture Investments Are Working
-
-Know whether mentorship programs, tooling changes, and process improvements are
-producing measurable results — before the next budget cycle, not after.
-
-</a>
+<!-- part:card:engineering-outcomes/culture-investments -->
 
 </div>
 
@@ -181,32 +75,11 @@ producing measurable results — before the next budget cycle, not after.
 
 <div class="grid">
 
-<a href="/docs/products/team-capability/">
+<!-- part:card:team-capability -->
 
-### Make Staffing Decisions You Can Defend
+<!-- part:card:team-capability/evaluate-candidate -->
 
-Replace staffing intuition with evidence — coverage heatmaps, structural
-risks, and what-if scenarios that show what each role requires.
-
-</a>
-
-<a href="/docs/products/team-capability/evaluate-candidate/">
-
-### Evaluate a Candidate Against Team Gaps
-
-Know whether a candidate fills the team's actual capability gap before making
-an offer — not after onboarding reveals the mismatch.
-
-</a>
-
-<a href="/docs/products/team-capability/surface-gaps/">
-
-### Surface Capability Gaps
-
-See capability gaps before they become incidents — structural risks, coverage
-trends, and growth opportunities made visible.
-
-</a>
+<!-- part:card:team-capability/surface-gaps -->
 
 </div>
 
@@ -214,23 +87,9 @@ trends, and growth opportunities made visible.
 
 <div class="grid">
 
-<a href="/docs/products/knowledge-systems/">
+<!-- part:card:knowledge-systems -->
 
-### Keep Track of Context Without Effort
-
-Stop walking into meetings cold — Outpost assembles and maintains awareness of
-people, projects, and threads in the background.
-
-</a>
-
-<a href="/docs/products/knowledge-systems/meeting-prep/">
-
-### Walk Into Every Meeting Already Oriented
-
-Walk into any meeting already oriented — attendee context, open items, and
-talking points assembled before you sit down.
-
-</a>
+<!-- part:card:knowledge-systems/meeting-prep -->
 
 </div>
 

--- a/websites/fit/docs/reference/index.md
+++ b/websites/fit/docs/reference/index.md
@@ -7,31 +7,10 @@ toc: false
 
 <div class="grid">
 
-<a href="/docs/reference/model/">
+<!-- part:card:model -->
 
-### Core Model
+<!-- part:card:lifecycle -->
 
-Entity definitions — disciplines, levels, tracks, skills, capabilities,
-behaviours, and drivers. How they combine into job definitions.
-
-</a>
-
-<a href="/docs/reference/lifecycle/">
-
-### Lifecycle
-
-Workflow phases — specify, plan, scaffold, code, review, deploy — with handoff
-triggers, constraints, and checklists.
-
-</a>
-
-<a href="/docs/reference/yaml-schema/">
-
-### YAML Schema
-
-File format reference for every entity type, with examples and links to
-published JSON Schema and RDF/SHACL definitions.
-
-</a>
+<!-- part:card:yaml-schema -->
 
 </div>

--- a/websites/fit/docs/services/index.md
+++ b/websites/fit/docs/services/index.md
@@ -9,32 +9,11 @@ toc: false
 
 <div class="grid">
 
-<a href="/docs/services/ground-agents/">
+<!-- part:card:ground-agents -->
 
-### Traverse Knowledge and Search Semantically
+<!-- part:card:ground-agents/query-graph -->
 
-Products that query relationships and search content without per-product
-stores — shared graph and vector gRPC services.
-
-</a>
-
-<a href="/docs/services/ground-agents/query-graph/">
-
-### Answer Relationship Questions from a Product
-
-Answer relationship questions from any product — triple patterns against the
-shared graph service, no join logic.
-
-</a>
-
-<a href="/docs/services/ground-agents/search-content/">
-
-### Search for Related Content from a Product
-
-Find semantically related content from any product — shared vector service, no
-embeddings storage to manage.
-
-</a>
+<!-- part:card:ground-agents/search-content -->
 
 </div>
 
@@ -42,23 +21,9 @@ embeddings storage to manage.
 
 <div class="grid">
 
-<a href="/docs/services/integrate-standard/">
+<!-- part:card:integrate-standard -->
 
-### Query the Engineering Standard from Any Product
-
-Products that access derived roles and profiles without embedding derivation
-logic — shared pathway gRPC service.
-
-</a>
-
-<a href="/docs/services/integrate-standard/fetch-profile/">
-
-### Fetch a Derived Role or Agent Profile
-
-Get a derived role or agent profile without reimplementing derivation — pass
-coordinates to the pathway service, receive Turtle RDF.
-
-</a>
+<!-- part:card:integrate-standard/fetch-profile -->
 
 </div>
 
@@ -66,23 +31,9 @@ coordinates to the pathway service, receive Turtle RDF.
 
 <div class="grid">
 
-<a href="/docs/services/typed-contracts/">
+<!-- part:card:typed-contracts -->
 
-### Expose Backend Services as Agent Tools
-
-Every gRPC endpoint becomes an agent tool from a single configuration file —
-no per-endpoint integration code.
-
-</a>
-
-<a href="/docs/services/typed-contracts/add-service/">
-
-### Add a Service to the MCP Surface
-
-A new gRPC service becomes agent-accessible with one registration — no
-integration code.
-
-</a>
+<!-- part:card:typed-contracts/add-service -->
 
 </div>
 
@@ -90,23 +41,9 @@ integration code.
 
 <div class="grid">
 
-<a href="/docs/services/prove-changes/">
+<!-- part:card:prove-changes -->
 
-### Collect Trace Spans from Any Product
-
-Products that emit trace spans without managing storage — shared trace gRPC
-service with a single collection point.
-
-</a>
-
-<a href="/docs/services/prove-changes/send-spans/">
-
-### Send Spans from a Product
-
-Trace spans emitted and immediately queryable — without managing storage
-infrastructure.
-
-</a>
+<!-- part:card:prove-changes/send-spans -->
 
 </div>
 

--- a/websites/fit/gear/index.md
+++ b/websites/fit/gear/index.md
@@ -104,14 +104,7 @@ npx skills add forwardimpact/fit-skills
 
 <div class="grid">
 
-<a href="/docs/libraries/">
-
-### Library Guides
-
-Task-oriented walkthroughs for evaluations, multi-agent collaboration, and trace
-analysis using the Gear catalog.
-
-</a>
+<!-- part:card:../docs/libraries -->
 
 <a href="https://github.com/forwardimpact/monorepo/tree/main/libraries">
 

--- a/websites/fit/guide/index.md
+++ b/websites/fit/guide/index.md
@@ -61,13 +61,6 @@ npx fit-guide                         # CLI (Claude Agent SDK)
 
 <div class="grid">
 
-<a href="/docs/getting-started/engineers/guide/">
-
-### Empowered Engineers
-
-Install, configure, and start using Guide — from codegen to your first
-conversation.
-
-</a>
+<!-- part:card:../docs/getting-started/engineers/guide -->
 
 </div>

--- a/websites/fit/landmark/index.md
+++ b/websites/fit/landmark/index.md
@@ -148,23 +148,9 @@ npx fit-landmark marker task_completion
 
 <div class="grid">
 
-<a href="/docs/getting-started/leadership/landmark/">
+<!-- part:card:../docs/getting-started/leadership/landmark -->
 
-### Engineering Leaders
-
-Analyze engineering signals — marker evidence, snapshot trends, practice
-patterns, team health, and engineer voice.
-
-</a>
-
-<a href="/docs/getting-started/engineers/landmark/">
-
-### Empowered Engineers
-
-Check your evidence record, promotion readiness, growth timeline, and skill
-coverage against your agent-aligned engineering standard markers.
-
-</a>
+<!-- part:card:../docs/getting-started/engineers/landmark -->
 
 </div>
 

--- a/websites/fit/map/index.md
+++ b/websites/fit/map/index.md
@@ -47,13 +47,6 @@ npx fit-map validate
 
 <div class="grid">
 
-<a href="/docs/getting-started/leadership/map/">
-
-### Engineering Leaders
-
-Initialize your agent-aligned engineering standard, validate schemas, set up the
-activity layer, and ingest operational signals from GitHub and GetDX.
-
-</a>
+<!-- part:card:../docs/getting-started/leadership/map -->
 
 </div>

--- a/websites/fit/outpost/index.md
+++ b/websites/fit/outpost/index.md
@@ -94,13 +94,6 @@ Privacy & Security > Files & Folders**:
 
 <div class="grid">
 
-<a href="/docs/getting-started/engineers/outpost/">
-
-### Empowered Engineers
-
-Initialize your personal knowledge base, configure background AI tasks, and
-start the scheduler.
-
-</a>
+<!-- part:card:../docs/getting-started/engineers/outpost -->
 
 </div>

--- a/websites/fit/pathway/index.md
+++ b/websites/fit/pathway/index.md
@@ -67,22 +67,8 @@ npx fit-pathway job software_engineering J060 --track=platform  # Job definition
 
 <div class="grid">
 
-<a href="/docs/getting-started/leadership/pathway/">
+<!-- part:card:../docs/getting-started/leadership/pathway -->
 
-### Engineering Leaders
-
-Preview your agent-aligned engineering standard in the browser, generate job
-definitions, and create interview question sets.
-
-</a>
-
-<a href="/docs/getting-started/engineers/pathway/">
-
-### Empowered Engineers
-
-Browse career paths, generate AI agent teams, and explore job definitions from
-the CLI and web app.
-
-</a>
+<!-- part:card:../docs/getting-started/engineers/pathway -->
 
 </div>

--- a/websites/fit/summit/index.md
+++ b/websites/fit/summit/index.md
@@ -145,13 +145,6 @@ npx fit-summit risks platform --roster ./summit.yaml
 
 <div class="grid">
 
-<a href="/docs/getting-started/leadership/summit/">
-
-### Engineering Leaders
-
-Create a roster, model team capability, run what-if staffing scenarios, and
-track trajectory over time.
-
-</a>
+<!-- part:card:../docs/getting-started/leadership/summit -->
 
 </div>


### PR DESCRIPTION
## Summary

- Add content partials system to libdoc: `<!-- part:card:path -->` and `<!-- part:link:path -->` markers resolve to HTML from the target page's frontmatter
- Rearchitect the builder around an upfront `scanPages` PageTree map — replaces the two-pass file-discovery approach with a single scan that feeds partials, breadcrumbs, sitemap, and llms.txt
- Rename `DocsBuilder` → `PagesBuilder`, `DocsServer` → `PagesServer`, `docsDir` → `pagesDir` to align with the planned libpages vocabulary
- Migrate 16 hub pages from hand-written card grids to `<!-- part:card:path -->` markers, eliminating ~600 lines of duplicated titles and descriptions

## Test plan

- [x] `bun test libraries/libdoc/` — 34 tests pass (6 new: page-tree + partials)
- [x] `bun run check` — format, lint, harness, context all pass
- [x] `node libraries/libdoc/bin/fit-doc.js build --src websites/fit` — full site builds successfully
- [x] Companion .md files contain resolved partial HTML, not raw markers
- [x] Root-level partials resolve correctly (pageDir = ".")
- [x] Error messages include actual source file path, not hardcoded "index.md"
- [x] Adding a new partial type requires only a registry entry (SC10)
- [x] 5-member review panel completed; all blocker/high/medium findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)