### PR TITLE
feat(websites): standardize cross-links with content partials

### DIFF
--- a/websites/CLAUDE.md
+++ b/websites/CLAUDE.md
@@ -35,6 +35,13 @@ Every page is a directory containing `index.md`. No other `.md` filenames.
   for external links or same-page anchors.
 - **Hand-written links are not checked.** Partials validate their targets, but
   inline markdown links are not verified at build time.
+- **Cross-links** — every non-hub page ends with a `## What's next` section.
+  Cards use content partials only (`<!-- part:card:path -->`), never markdown
+  links. Maximum four cards. When a page has a `## Verify` section,
+  `## What's next` follows it. Card targets follow JTBD structure: Big Hire
+  guides link to their Little Hire children; Little Hire guides link back to
+  the parent Big Hire and sibling Little Hires; Getting Started pages link to
+  the product page and primary guide.
 
 ## Page Types
 

--- a/websites/fit/docs/getting-started/contributors/index.md
+++ b/websites/fit/docs/getting-started/contributors/index.md
@@ -103,9 +103,10 @@ include `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, and `spec`. Scope is
 the package name (e.g., `map`, `libskill`, `pathway`). Add `!` after scope for
 breaking changes.
 
-## Next steps
+## What's next
 
-- [Architecture internals](/docs/internals/) — dependency chains, data flow, and
-  design decisions
-- [CONTRIBUTING.md](https://github.com/forwardimpact/monorepo/blob/main/CONTRIBUTING.md)
-  — full contributing guide with PR checklist and release process
+<div class="grid">
+
+<!-- part:card:../../internals/operations -->
+
+</div>

--- a/websites/fit/docs/getting-started/engineers/guide/index.md
+++ b/websites/fit/docs/getting-started/engineers/guide/index.md
@@ -157,10 +157,11 @@ missing environment variables or port conflicts.
 
 ---
 
-## Next steps
+## What's next
 
-- [Guide product page](/guide/) — feature overview and surface options
-- [Finding your bearing](/docs/products/growth-areas/) — Guide usage and
-  configuration
-- Run `npx fit-guide --help` (then `/help` inside the REPL) for the full command
-  surface
+<div class="grid">
+
+<!-- part:card:../../../../guide -->
+<!-- part:card:../../../products/growth-areas -->
+
+</div>

--- a/websites/fit/docs/getting-started/engineers/landmark/index.md
+++ b/websites/fit/docs/getting-started/engineers/landmark/index.md
@@ -99,9 +99,11 @@ All Landmark commands support `--format text|json|markdown`.
 
 ---
 
-## Next steps
+## What's next
 
-- [Landmark product page](/landmark/) — audience model and architecture overview
-- [Landmark quickstart](/docs/products/engineering-outcomes/) — step-by-step
-  guide from install to a working health view
-- Run `npx fit-landmark --help` for the full command surface
+<div class="grid">
+
+<!-- part:card:../../../../landmark -->
+<!-- part:card:../../../products/engineering-outcomes -->
+
+</div>

--- a/websites/fit/docs/getting-started/engineers/outpost/index.md
+++ b/websites/fit/docs/getting-started/engineers/outpost/index.md
@@ -68,8 +68,11 @@ Privacy & Security > Files & Folders**:
 
 ---
 
-## Next steps
+## What's next
 
-- [Outpost product page](/outpost/) — feature overview and core skills
-- [Knowledge systems](/docs/products/knowledge-systems/) — deep dive into
-  Outpost features
+<div class="grid">
+
+<!-- part:card:../../../../outpost -->
+<!-- part:card:../../../products/knowledge-systems -->
+
+</div>

--- a/websites/fit/docs/getting-started/engineers/pathway/index.md
+++ b/websites/fit/docs/getting-started/engineers/pathway/index.md
@@ -81,11 +81,11 @@ directory.
 
 ---
 
-## Next steps
+## What's next
 
-- [Pathway product page](/pathway/) — web app features, CLI commands, and static
-  site generation
-- [Agent teams](/docs/products/agent-teams/) — configure agents to meet your
-  organization's engineering standard
-- [Career paths](/docs/products/career-paths/) — understand progression and
-  skill development
+<div class="grid">
+
+<!-- part:card:../../../../pathway -->
+<!-- part:card:../../../products/career-paths -->
+
+</div>

--- a/websites/fit/docs/getting-started/leadership/landmark/index.md
+++ b/websites/fit/docs/getting-started/leadership/landmark/index.md
@@ -213,10 +213,11 @@ All Landmark commands support `--format text|json|markdown`. The default is
 
 ---
 
-## Next steps
+## What's next
 
-- [Landmark product page](/landmark/) — audience model and architecture overview
-- [Landmark quickstart](/docs/products/engineering-outcomes/) — step-by-step
-  guide from install to a working health view
-- [Team capability](/docs/products/team-capability/) — deep dive into Summit
-  coverage, risks, and scenario planning
+<div class="grid">
+
+<!-- part:card:../../../../landmark -->
+<!-- part:card:../../../products/engineering-outcomes -->
+
+</div>

--- a/websites/fit/docs/getting-started/leadership/map/index.md
+++ b/websites/fit/docs/getting-started/leadership/map/index.md
@@ -448,11 +448,11 @@ Guide.
 
 ---
 
-## Next steps
+## What's next
 
-- [Map product page](/map/) — feature overview and command reference
-- [Authoring agent-aligned engineering standards](/docs/products/authoring-standards/)
-  — full guide to defining all entity types: levels, disciplines, tracks,
-  capabilities, skills, behaviours, stages, and drivers
-- [YAML schema reference](/docs/reference/yaml-schema/) — complete file format
-  documentation
+<div class="grid">
+
+<!-- part:card:../../../../map -->
+<!-- part:card:../../../products/authoring-standards -->
+
+</div>

--- a/websites/fit/docs/getting-started/leadership/pathway/index.md
+++ b/websites/fit/docs/getting-started/leadership/pathway/index.md
@@ -50,11 +50,11 @@ npx fit-pathway interview software_engineering J060
 
 ---
 
-## Next steps
+## What's next
 
-- [Pathway product page](/pathway/) — web app features, CLI commands, and static
-  site generation
-- [Authoring agent-aligned engineering standards](/docs/products/authoring-standards/)
-  — full guide to defining all entity types
-- [YAML schema reference](/docs/reference/yaml-schema/) — complete file format
-  documentation
+<div class="grid">
+
+<!-- part:card:../../../../pathway -->
+<!-- part:card:../../../products/career-paths -->
+
+</div>

--- a/websites/fit/docs/getting-started/leadership/summit/index.md
+++ b/websites/fit/docs/getting-started/leadership/summit/index.md
@@ -254,10 +254,11 @@ npx fit-summit coverage platform --roster ./summit.yaml --audience director
 
 ---
 
-## Next steps
+## What's next
 
-- [Summit product page](/summit/) — design principles and detailed examples
-- [Team capability](/docs/products/team-capability/) — deep dive into Summit
-  coverage, risks, and scenario planning
-- [Authoring agent-aligned engineering standards](/docs/products/authoring-standards/)
-  — full guide to defining all entity types
+<div class="grid">
+
+<!-- part:card:../../../../summit -->
+<!-- part:card:../../../products/team-capability -->
+
+</div>

--- a/websites/fit/docs/internals/librepl/index.md
+++ b/websites/fit/docs/internals/librepl/index.md
@@ -317,7 +317,10 @@ const repl = new Repl(
 
 ---
 
-## Related Documentation
+## What's next
 
-- [Operations Reference](/docs/internals/operations/) — Service management and
-  environment setup
+<div class="grid">
+
+<!-- part:card:../operations -->
+
+</div>

--- a/websites/fit/docs/internals/operations/index.md
+++ b/websites/fit/docs/internals/operations/index.md
@@ -208,11 +208,11 @@ and distribute them.
 
 ---
 
-## Related Documentation
+## What's next
 
-- [CONTRIBUTING.md](https://github.com/forwardimpact/monorepo/blob/main/CONTRIBUTING.md)
-  -- Development workflow and quality guidelines
-- [Getting Started: Contributors](/docs/getting-started/contributors/) --
-  Environment setup walkthrough
-- [Kata Agent Team internals](/docs/internals/kata/) -- Agent architecture,
-  workflows, and PDSA cycle
+<div class="grid">
+
+<!-- part:card:../kata -->
+<!-- part:card:../../getting-started/contributors -->
+
+</div>

--- a/websites/fit/docs/internals/vectors/index.md
+++ b/websites/fit/docs/internals/vectors/index.md
@@ -191,3 +191,11 @@ Verify `data/resources/` contains files with non-empty content fields.
 **Model download stalls** — The first TEI startup downloads the model from
 HuggingFace. Check network access and `~/.cache/huggingface/` for partial
 downloads.
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:../../libraries/ground-agents -->
+
+</div>

--- a/websites/fit/docs/libraries/every-surface/add-capability/index.md
+++ b/websites/fit/docs/libraries/every-surface/add-capability/index.md
@@ -196,5 +196,8 @@ regardless of which surface produced the context.
 
 ## What's next
 
-- [Agent-Friendly Surfaces](/docs/libraries/every-surface/) -- return to the
-  full guide for the shared contract, query string parsing, and formatter details
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/libraries/every-surface/index.md
+++ b/websites/fit/docs/libraries/every-surface/index.md
@@ -300,8 +300,8 @@ produces `{ tag: ["rain", "wind"] }`.
 
 ## What's next
 
-Once both surfaces share a presenter, adding a new capability is a bounded task:
-write the presenter, register a CLI command, register a route, and both surfaces
-gain the feature at once. See
-[Add a Capability](/docs/libraries/every-surface/add-capability/) for the
-step-by-step procedure.
+<div class="grid">
+
+<!-- part:card:add-capability -->
+
+</div>

--- a/websites/fit/docs/libraries/ground-agents/index.md
+++ b/websites/fit/docs/libraries/ground-agents/index.md
@@ -286,17 +286,11 @@ exist before graphs, and resources must exist before vectors.
 
 ## What's next
 
-Each query mode has a dedicated guide for deeper work:
+<div class="grid">
 
-- [Query the Graph](/docs/libraries/ground-agents/query-graph/) -- write
-  triple-pattern queries, filter by type, and traverse relationships in the
-  RDF graph.
-- [Look Up Context](/docs/libraries/ground-agents/lookup-context/) -- retrieve
-  resources by identifier, apply prefix filters, and manage token budgets with
-  the index API.
-- [Resolve a Resource](/docs/libraries/ground-agents/resolve-resource/) -- load
-  a typed resource by identifier with access control and inspect its content
-  and metadata.
-- [Search Semantically](/docs/libraries/ground-agents/search-semantically/) --
-  embed a query, score against the vector index, and rank results by
-  relevance.
+<!-- part:card:query-graph -->
+<!-- part:card:lookup-context -->
+<!-- part:card:resolve-resource -->
+<!-- part:card:search-semantically -->
+
+</div>

--- a/websites/fit/docs/libraries/ground-agents/lookup-context/index.md
+++ b/websites/fit/docs/libraries/ground-agents/lookup-context/index.md
@@ -180,13 +180,11 @@ once -- but the storage write is deferred until the next flush. Always call
 Both `IndexBase` and `BufferedIndex` defer loading until the first read. If the
 storage file does not exist, the index initializes empty rather than throwing.
 
-## Related
+## What's next
 
-- [Ground Agents in Context](/docs/libraries/ground-agents/) -- the end-to-end
-  workflow for building and querying a context pipeline.
-- [Query a Graph](/docs/libraries/ground-agents/query-graph/) -- when the
-  question is about relationships between entities, not flat lookups.
-- [Search Semantically](/docs/libraries/ground-agents/search-semantically/) --
-  when you need ranked similarity rather than prefix-based filtering.
-- [`@forwardimpact/libindex` on npm](https://www.npmjs.com/package/@forwardimpact/libindex)
-  -- installation and changelog.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../query-graph -->
+
+</div>

--- a/websites/fit/docs/libraries/ground-agents/query-graph/index.md
+++ b/websites/fit/docs/libraries/ground-agents/query-graph/index.md
@@ -184,14 +184,11 @@ memory and populates the N3 store -- subsequent queries run entirely in memory.
 An `ontology.ttl` file alongside the index captures SHACL shapes inferred from
 the data. The ontology is regenerated when `fit-process-graphs` runs.
 
-## Related
+## What's next
 
-- [Ground Agents in Context](/docs/libraries/ground-agents/) -- the end-to-end
-  workflow for building and querying the knowledge graph.
-- [Resolve a Resource](/docs/libraries/ground-agents/resolve-resource/) --
-  retrieve the full context chunk behind a resource identifier returned by
-  `fit-query`.
-- [Search Semantically](/docs/libraries/ground-agents/search-semantically/) --
-  when you need ranked similarity rather than exact triple matching.
-- [`@forwardimpact/libgraph` on npm](https://www.npmjs.com/package/@forwardimpact/libgraph)
-  -- installation and changelog.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../lookup-context -->
+
+</div>

--- a/websites/fit/docs/libraries/ground-agents/resolve-resource/index.md
+++ b/websites/fit/docs/libraries/ground-agents/resolve-resource/index.md
@@ -172,13 +172,11 @@ for (const chunk of chunks) {
 The graph answers "which entities match?" and the resource index answers "what
 do those entities contain?" -- each library owns one step.
 
-## Related
+## What's next
 
-- [Ground Agents in Context](/docs/libraries/ground-agents/) -- the end-to-end
-  workflow for ingesting knowledge and building the retrieval pipeline.
-- [Query a Graph](/docs/libraries/ground-agents/query-graph/) -- find
-  identifiers by relationship pattern before resolving them here.
-- [Look Up Context](/docs/libraries/ground-agents/lookup-context/) -- find
-  identifiers by prefix or structural filter.
-- [`@forwardimpact/libresource` on npm](https://www.npmjs.com/package/@forwardimpact/libresource)
-  -- installation and changelog.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../query-graph -->
+
+</div>

--- a/websites/fit/docs/libraries/ground-agents/search-semantically/index.md
+++ b/websites/fit/docs/libraries/ground-agents/search-semantically/index.md
@@ -185,15 +185,11 @@ const ranked = await vectorIndex.queryItems(queryVectors, {
 const chunks = await resources.get(ranked.map(String));
 ```
 
-## Related
+## What's next
 
-- [Ground Agents in Context](/docs/libraries/ground-agents/) -- the end-to-end
-  workflow for building the embedding pipeline and retrieval stack.
-- [Resolve a Resource](/docs/libraries/ground-agents/resolve-resource/) --
-  retrieve the full context chunk behind a ranked identifier.
-- [Query a Graph](/docs/libraries/ground-agents/query-graph/) -- when the
-  question is about explicit relationships, not semantic similarity.
-- [Look Up Context](/docs/libraries/ground-agents/lookup-context/) -- when you
-  need structural filtering rather than ranked scoring.
-- [`@forwardimpact/libvector` on npm](https://www.npmjs.com/package/@forwardimpact/libvector)
-  -- installation and changelog.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../query-graph -->
+
+</div>

--- a/websites/fit/docs/libraries/integrate-standard/derive-profile/index.md
+++ b/websites/fit/docs/libraries/integrate-standard/derive-profile/index.md
@@ -188,8 +188,8 @@ You have reached the outcome of this guide when:
 
 ## What's next
 
-- [Integrate with the Engineering Standard](/docs/libraries/integrate-standard/)
-  -- return to the full guide for validation, caching, display views, and
-  generating all valid roles.
-- [Data Model Reference](/docs/reference/model/) -- how disciplines, tracks,
-  skills, and levels relate in the underlying model.
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/libraries/integrate-standard/index.md
+++ b/websites/fit/docs/libraries/integrate-standard/index.md
@@ -391,10 +391,8 @@ You have reached the outcome of this guide when:
 
 ## What's next
 
-- [Derive a skill matrix or agent profile](/docs/libraries/integrate-standard/derive-profile/)
-  -- a focused walkthrough for the most common bounded task: turning a
-  discipline, level, and track into a profile without parsing YAML by hand.
-- [Data Model Reference](/docs/reference/model/) -- how disciplines, tracks,
-  skills, and levels relate in the underlying model.
-- [Authoring Standards](/docs/products/authoring-standards/) -- how to define
-  and validate the YAML data that this library consumes.
+<div class="grid">
+
+<!-- part:card:derive-profile -->
+
+</div>

--- a/websites/fit/docs/libraries/predictable-team/index.md
+++ b/websites/fit/docs/libraries/predictable-team/index.md
@@ -373,12 +373,9 @@ Confirm the full memory system is working by running through this checklist:
 
 ## What's next
 
-This guide covered the end-to-end setup: bootstrapping the wiki, recording
-observations, charting them, embedding charts in a storyboard, and keeping
-everything in sync. From here:
+<div class="grid">
 
-- [Wiki Operations](/docs/libraries/predictable-team/wiki-operations/) -- bounded tasks for
-  sending memos, refreshing charts, and syncing state when the wiki is already
-  set up.
-- [XmR Analysis](/docs/libraries/predictable-team/xmr-analysis/) -- deeper coverage of signal
-  rules, chart anatomy, and how to respond when a metric shifts.
+<!-- part:card:wiki-operations -->
+<!-- part:card:xmr-analysis -->
+
+</div>

--- a/websites/fit/docs/libraries/predictable-team/wiki-operations/index.md
+++ b/websites/fit/docs/libraries/predictable-team/wiki-operations/index.md
@@ -164,11 +164,11 @@ This clones the repository's wiki into `wiki/` and creates
 Idempotent -- safe to run on an already-initialized wiki. Authenticates using
 ambient GitHub credentials (`GITHUB_TOKEN` or `GH_TOKEN`).
 
-## Related
+## What's next
 
-- [Persistent Memory](/docs/libraries/predictable-team/) --
-  end-to-end guide to how the wiki serves as memory for your agent team.
-- [XmR Analysis](/docs/libraries/predictable-team/xmr-analysis/) -- understanding the control
-  charts that `refresh` renders into your storyboard.
-- [`fit-wiki` on npm](https://www.npmjs.com/package/@forwardimpact/libwiki) --
-  installation and changelog.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../xmr-analysis -->
+
+</div>

--- a/websites/fit/docs/libraries/predictable-team/xmr-analysis/index.md
+++ b/websites/fit/docs/libraries/predictable-team/xmr-analysis/index.md
@@ -185,15 +185,10 @@ Do not react to individual data points when the classification is `stable`.
 Routine variation is common-cause noise; treating it as a problem and
 intervening makes the process worse on average.
 
-## Next steps
+## What's next
 
-This guide covers the bounded task of charting a metric and reading the latest
-point. For the full workflow of building persistent process memory for an agent
-team -- recording observations over time, detecting level shifts, and acting on
-findings across daily cycles -- see [Persistent Process
-Memory](/docs/libraries/predictable-team/).
+<div class="grid">
 
-## Related
+<!-- part:card:.. -->
 
-- [`@forwardimpact/libxmr` on npm](https://www.npmjs.com/package/@forwardimpact/libxmr)
-  -- installation and changelog.
+</div>

--- a/websites/fit/docs/libraries/prove-changes/generate-dataset/index.md
+++ b/websites/fit/docs/libraries/prove-changes/generate-dataset/index.md
@@ -181,6 +181,8 @@ pipeline table above: `parse`, `entities`, `prose-keys`, `cache-lookup`,
 
 ## What's next
 
-- [Prove Whether Agent Changes Improved Outcomes](/docs/libraries/prove-changes/)
-  -- the full workflow from dataset generation through evaluation sessions to
-  trace analysis.
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/libraries/prove-changes/index.md
+++ b/websites/fit/docs/libraries/prove-changes/index.md
@@ -334,12 +334,10 @@ and writing findings that are grounded, testable, and actionable -- see the
 
 ## What's next
 
-This guide covered the full arc from dataset definition through session
-execution to trace verification. Each stage has a dedicated guide for deeper
-work:
+<div class="grid">
 
-- [Agent Evaluations](/docs/libraries/prove-changes/run-eval/) -- write judge
-  profiles, wire evals into CI with GitHub Actions, and scale to a matrix suite.
-- [Trace Analysis](/docs/libraries/prove-changes/trace-analysis/) -- the grounded-theory
-  analysis method with two worked examples: an eval that failed and a
-  multi-agent session that stalled.
+<!-- part:card:run-eval -->
+<!-- part:card:trace-analysis -->
+<!-- part:card:generate-dataset -->
+
+</div>

--- a/websites/fit/docs/libraries/prove-changes/run-eval/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-eval/index.md
@@ -189,12 +189,11 @@ first failure.
   but does not bind it. Treat eval verdicts like a code review from a strong but
   fallible reviewer -- useful signal, not ground truth.
 
-## Next steps
+## What's next
 
-This guide covers evaluations -- a single judge verifying a single agent. When
-the goal is coordinating multiple specialists rather than rendering a verdict,
-see [Agent Collaboration](/docs/libraries/prove-changes/), which uses
-`fit-eval facilitate` and the same trace format.
+<div class="grid">
 
-For a deep dive on reading the traces this guide produces, including a worked
-example of a failed eval, see [Trace Analysis](/docs/libraries/prove-changes/trace-analysis/).
+<!-- part:card:.. -->
+<!-- part:card:../trace-analysis -->
+
+</div>

--- a/websites/fit/docs/libraries/prove-changes/trace-analysis/index.md
+++ b/websites/fit/docs/libraries/prove-changes/trace-analysis/index.md
@@ -176,10 +176,11 @@ When verifying an improvement, compare `stats` across before-and-after runs.
 Fewer retries, lower token usage, and shorter duration are the signals that a
 profile or prompt change improved outcomes.
 
-## Related
+## What's next
 
-- [Agent Collaboration](/docs/libraries/prove-changes/) -- produce traces
-  with `fit-eval facilitate`; the per-source `split` is essential for
-  multi-agent traces.
-- [Agent Evaluations](/docs/libraries/prove-changes/run-eval/) -- produce traces with
-  `fit-eval supervise`; the trace is what you analyze here.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../run-eval -->
+
+</div>

--- a/websites/fit/docs/libraries/service-lifecycle/add-observability/index.md
+++ b/websites/fit/docs/libraries/service-lifecycle/add-observability/index.md
@@ -191,7 +191,11 @@ spans are created, and the gRPC calls proceed without trace context. This means
 you can add the observer first and wire up tracing later without changing your
 handler code.
 
-## Related
+## What's next
 
-- [Service Lifecycle](/docs/libraries/service-lifecycle/) -- the full setup guide
-- [Manage a Service](/docs/libraries/service-lifecycle/manage-service/) -- start, stop, check
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../manage-service -->
+
+</div>

--- a/websites/fit/docs/libraries/service-lifecycle/index.md
+++ b/websites/fit/docs/libraries/service-lifecycle/index.md
@@ -323,16 +323,9 @@ await manager.stop();          // Stop all services and daemon
 
 ## What's next
 
-- [Start, stop, or check a service](/docs/libraries/service-lifecycle/manage-service/)
-  -- the bounded task for managing a service.
-- [Add observability](/docs/libraries/service-lifecycle/add-observability/)
-  -- the bounded task for adding structured logs or trace spans to a service.
+<div class="grid">
 
-## Related
+<!-- part:card:manage-service -->
+<!-- part:card:add-observability -->
 
-- [`@forwardimpact/librc` on npm](https://www.npmjs.com/package/@forwardimpact/librc)
-  -- installation and changelog.
-- [`@forwardimpact/libsupervise` on npm](https://www.npmjs.com/package/@forwardimpact/libsupervise)
-  -- installation and changelog.
-- [`@forwardimpact/libtelemetry` on npm](https://www.npmjs.com/package/@forwardimpact/libtelemetry)
-  -- installation and changelog.
+</div>

--- a/websites/fit/docs/libraries/service-lifecycle/manage-service/index.md
+++ b/websites/fit/docs/libraries/service-lifecycle/manage-service/index.md
@@ -166,11 +166,11 @@ optional service name with the same slicing behavior as the CLI: `start` takes
 everything up to and including the named service; `stop` takes the named service
 and everything after it.
 
-## Related
+## What's next
 
-- [Service Lifecycle](/docs/libraries/service-lifecycle/) -- the full setup
-  guide covering configuration, supervision, and observability.
-- [Add Observability](/docs/libraries/service-lifecycle/add-observability/)
-  -- add structured logs or trace spans to a service.
-- [`@forwardimpact/librc` on npm](https://www.npmjs.com/package/@forwardimpact/librc)
-  -- installation and changelog.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../add-observability -->
+
+</div>

--- a/websites/fit/docs/libraries/typed-contracts/expose-tool/index.md
+++ b/websites/fit/docs/libraries/typed-contracts/expose-tool/index.md
@@ -168,10 +168,11 @@ These comments produce tool parameters described as "Discipline id (e.g.
 - [ ] Proto field comments are descriptive enough for agents to understand each
       parameter without reading the proto file
 
-## Related
+## What's next
 
-- [Keep Service Contracts Typed](/docs/libraries/typed-contracts/) -- the
-  end-to-end workflow for the typed contract libraries including libmcp,
-  libtype, librpc, and libcodegen
-- [`@forwardimpact/libmcp` on npm](https://www.npmjs.com/package/@forwardimpact/libmcp)
-  -- installation and changelog
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../ship-endpoint -->
+
+</div>

--- a/websites/fit/docs/libraries/typed-contracts/index.md
+++ b/websites/fit/docs/libraries/typed-contracts/index.md
@@ -361,12 +361,11 @@ subdirectory under `generated/services/`.
   `fit-codegen` because it may define custom proto files. Generated code is
   never bundled in published npm packages.
 
-## Next steps
+## What's next
 
-This guide covers the end-to-end pipeline from proto to typed runtime. For the
-bounded tasks within this workflow:
+<div class="grid">
 
-- [Expose a gRPC Method as an MCP Tool](/docs/libraries/typed-contracts/expose-tool/) --
-  add a new MCP tool entry for an existing gRPC service method.
-- [Ship a Service Endpoint](/docs/libraries/typed-contracts/ship-endpoint/) --
-  add a new RPC method to an existing service and regenerate.
+<!-- part:card:expose-tool -->
+<!-- part:card:ship-endpoint -->
+
+</div>

--- a/websites/fit/docs/libraries/typed-contracts/ship-endpoint/index.md
+++ b/websites/fit/docs/libraries/typed-contracts/ship-endpoint/index.md
@@ -191,5 +191,8 @@ You have reached the outcome of this guide when:
 
 ## What's next
 
-- [Typed Contracts](/docs/libraries/typed-contracts/) -- the
-  end-to-end workflow from proto definition through codegen to deployment.
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/products/agent-teams/index.md
+++ b/websites/fit/docs/products/agent-teams/index.md
@@ -160,14 +160,9 @@ confirm the following:
 
 ## What's next
 
-Your agents are now configured against the same standard the organization holds
-for human contributors. The configuration is derived from your standard data --
-when the standard evolves, regenerate to keep agents aligned.
+<div class="grid">
 
-- [Give Agents Organizational Context](/docs/products/agent-teams/organizational-context/)
-  -- maintain alignment as your standard evolves, structure team instructions
-  and skills so agents receive clear, non-conflicting guidance.
-- [Authoring Agent-Aligned Engineering Standards](/docs/products/authoring-standards/)
-  -- update the YAML definitions that agent configurations are derived from.
-- [Career Paths](/docs/products/career-paths/) -- browse the same role
-  definitions your agents are built from.
+<!-- part:card:organizational-context -->
+<!-- part:card:../authoring-standards -->
+
+</div>

--- a/websites/fit/docs/products/agent-teams/organizational-context/index.md
+++ b/websites/fit/docs/products/agent-teams/organizational-context/index.md
@@ -184,9 +184,9 @@ Your organizational context is well-structured when:
 
 ## What's next
 
-- [Configure Agents to Meet Your Engineering Standard](/docs/products/agent-teams/)
-  -- return to the end-to-end setup if you need to add a new agent role.
-- [Authoring Agent-Aligned Engineering Standards](/docs/products/authoring-standards/)
-  -- update the YAML definitions that agent configurations are derived from.
-- [Validate and Update the Standard](/docs/products/authoring-standards/update-standard/)
-  -- confirm structural soundness after making changes.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../../authoring-standards -->
+
+</div>

--- a/websites/fit/docs/products/authoring-standards/define-role/index.md
+++ b/websites/fit/docs/products/authoring-standards/define-role/index.md
@@ -198,3 +198,11 @@ site_reliability      J060  platform
 ```
 
 The new discipline appears with every level it supports.
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/products/authoring-standards/index.md
+++ b/websites/fit/docs/products/authoring-standards/index.md
@@ -380,20 +380,12 @@ Supporting Skills (adjusted by track)
 For common validation errors and their fixes, see the
 [YAML Schema Reference](/docs/reference/yaml-schema/).
 
-## What to do next
+## What's next
 
-You now have a validated, previewable engineering standard — a shared definition
-that makes quality visible and evaluations defensible.
+<div class="grid">
 
-Common next steps:
+<!-- part:card:update-standard -->
+<!-- part:card:define-role -->
+<!-- part:card:../career-paths -->
 
-- [Validate and update the standard](/docs/products/authoring-standards/update-standard/) --
-  change definitions and trust that structural mistakes get caught before they
-  ship.
-- [Define a new role](/docs/products/authoring-standards/define-role/) --
-  create requirements for a new role without starting from a blank page.
-- [Career Paths](/docs/products/career-paths/) -- browse derived roles, analyze
-  progression between levels, and generate gap analyses.
-- [Agent Teams](/docs/products/agent-teams/) -- export agent team configurations
-  derived from the same standard, so AI coding agents meet the same expectations
-  as human contributors.
+</div>

--- a/websites/fit/docs/products/authoring-standards/update-standard/index.md
+++ b/websites/fit/docs/products/authoring-standards/update-standard/index.md
@@ -165,3 +165,11 @@ The update is complete when all three conditions are true:
 For the full field reference -- required vs. optional fields, ID patterns, and
 allowed values -- see the
 [YAML Schema Reference](/docs/reference/yaml-schema/).
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/products/career-paths/autonomy-scope/index.md
+++ b/websites/fit/docs/products/career-paths/autonomy-scope/index.md
@@ -188,9 +188,9 @@ at two adjacent levels and compare the Expectations sections.
 
 ## What's next
 
-- [See What's Expected at Your Level](/docs/products/career-paths/) -- return
-  to the full role definition for skills, behaviours, and driver coverage
-- [Find Growth Areas](/docs/products/growth-areas/) -- identify specific
-  gaps and build evidence of progress
-- [Data Model Reference](/docs/reference/model/) -- how disciplines, tracks,
-  skills, and levels relate in the underlying model
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../../growth-areas -->
+
+</div>

--- a/websites/fit/docs/products/career-paths/index.md
+++ b/websites/fit/docs/products/career-paths/index.md
@@ -335,13 +335,9 @@ detail for any skill or behaviour using `npx fit-pathway skill <id>` or
 
 ## What's next
 
-You now have a concrete picture of what your level expects -- the skills,
-behaviours, scope, and autonomy your role requires, grounded in your
-organization's own standard.
+<div class="grid">
 
-- [Understand autonomy and scope](/docs/products/career-paths/autonomy-scope/)
-  -- see what your level implies for independence and decision-making
-- [Find Growth Areas](/docs/products/growth-areas/) -- identify specific
-  gaps and build evidence of progress
-- [Data Model Reference](/docs/reference/model/) -- how disciplines, tracks,
-  skills, and levels relate in the underlying model
+<!-- part:card:autonomy-scope -->
+<!-- part:card:../growth-areas -->
+
+</div>

--- a/websites/fit/docs/products/engineering-outcomes/culture-investments/index.md
+++ b/websites/fit/docs/products/engineering-outcomes/culture-investments/index.md
@@ -171,3 +171,11 @@ The assessment is complete when you can answer three questions with data:
 If all three signals align -- rising trend, positive delta, supportive comments
 -- you have evidence that the investment is working. If they diverge, the data
 gives you a specific starting point for investigating why.
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/products/engineering-outcomes/index.md
+++ b/websites/fit/docs/products/engineering-outcomes/index.md
@@ -339,12 +339,8 @@ presentations.
 
 ## What's next
 
-Once you can demonstrate overall progress, a natural follow-up is checking
-whether specific culture investments -- mentorship programs, tooling changes,
-process improvements -- are producing measurable results before the next budget
-cycle. See
-[Tell Whether Culture Investments Are Working](/docs/products/engineering-outcomes/culture-investments/)
-for that workflow.
+<div class="grid">
 
-For the full command reference and audience model, see the
-[Landmark product page](/landmark/).
+<!-- part:card:culture-investments -->
+
+</div>

--- a/websites/fit/docs/products/growth-areas/check-progress/index.md
+++ b/websites/fit/docs/products/growth-areas/check-progress/index.md
@@ -172,3 +172,11 @@ You have completed this guide when you can answer these questions:
 If any of these are unclear, revisit the relevant step. The readiness checklist
 is the most direct measure -- when missing markers from a previous check start
 showing as evidenced, recent work is producing visible movement toward the bar.
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/products/growth-areas/growth-question/index.md
+++ b/websites/fit/docs/products/growth-areas/growth-question/index.md
@@ -180,3 +180,11 @@ You have reached the outcome of this guide when:
 - **You know how to get back here.** For the full workflow -- finding gaps,
   checking your evidence record, and tracking progress over time -- return to
   [Find Growth Areas and Build Evidence](/docs/products/growth-areas/).
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/products/growth-areas/index.md
+++ b/websites/fit/docs/products/growth-areas/index.md
@@ -302,16 +302,9 @@ start showing as evidenced, you are making progress.
 
 ## What's next
 
-This guide covered the end-to-end workflow for finding growth areas and building
-evidence. For specific tasks within this workflow, see:
+<div class="grid">
 
-- [Ask a Growth Question](/docs/products/growth-areas/growth-question/)
-  -- ask a specific question and get advice grounded in your actual standard
-- [Check Progress Toward Next Level](/docs/products/growth-areas/check-progress/)
-  -- see whether recent work shows visible movement toward the bar
-- [See What's Expected at Your Level](/docs/products/career-paths/) -- understand
-  the full expectations for your current role
-- [Data Model Reference](/docs/reference/model/) -- how skills, levels, and
-  behaviours are structured in the underlying model
-- [Authoring Agent-Aligned Engineering Standards](/docs/products/authoring-standards/)
-  -- how to define the standard that Guide and Landmark reason about
+<!-- part:card:growth-question -->
+<!-- part:card:check-progress -->
+
+</div>

--- a/websites/fit/docs/products/knowledge-systems/index.md
+++ b/websites/fit/docs/products/knowledge-systems/index.md
@@ -276,8 +276,8 @@ review the logs at `~/.fit/outpost/logs/`.
 
 ## What's next
 
-- [Walk Into Every Meeting Already Oriented](/docs/products/knowledge-systems/meeting-prep/)
-  -- use Outpost briefings and the knowledge graph to prepare for specific
-  meetings without a morning scramble
-- [Agent Teams](/docs/products/agent-teams/) -- how agent skills are generated
-  from your organization's engineering standard
+<div class="grid">
+
+<!-- part:card:meeting-prep -->
+
+</div>

--- a/websites/fit/docs/products/knowledge-systems/meeting-prep/index.md
+++ b/websites/fit/docs/products/knowledge-systems/meeting-prep/index.md
@@ -171,8 +171,8 @@ accumulate data. Check that the postman and librarian agents are running --
 
 ## What's next
 
-- [Keep Track of Context Without Effort](/docs/products/knowledge-systems/) --
-  return to the full Outpost setup guide for agent configuration, schedule
-  customization, and knowledge graph maintenance
-- [Agent Teams](/docs/products/agent-teams/) -- how agent skills are generated
-  from your organization's engineering standard
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/products/team-capability/evaluate-candidate/index.md
+++ b/websites/fit/docs/products/team-capability/evaluate-candidate/index.md
@@ -148,3 +148,12 @@ If the `what-if` output shows the candidate's role resolves none of your
 identified risks, re-examine whether the position description matches the gap.
 The problem may not be the candidate -- it may be that the role was defined
 around the position description rather than the team's actual needs.
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../surface-gaps -->
+
+</div>

--- a/websites/fit/docs/products/team-capability/index.md
+++ b/websites/fit/docs/products/team-capability/index.md
@@ -351,21 +351,9 @@ from your Pathway and Summit output:
 
 ## What's next
 
-This guide covered the end-to-end workflow for evidence-based staffing. Two
-follow-up guides cover bounded tasks you will revisit regularly:
+<div class="grid">
 
-- [Evaluate a candidate against team gaps](/docs/products/team-capability/evaluate-candidate/) --
-  check whether a specific candidate fills the team's actual gap, not just the
-  position description
-- [Surface capability gaps](/docs/products/team-capability/surface-gaps/) --
-  spot gaps before someone gets set up to fail, using coverage, risk, and
-  trajectory analysis
+<!-- part:card:evaluate-candidate -->
+<!-- part:card:surface-gaps -->
 
-For reference material and deeper context:
-
-- [Data Model Reference](/docs/reference/model/) -- how skills, levels, and
-  disciplines define team capability
-- [Authoring Agent-Aligned Engineering Standards](/docs/products/authoring-standards/) --
-  full guide to defining the standard that Pathway and Summit read from
-- [Career Paths](/docs/products/career-paths/) -- browse role definitions,
-  skill proficiencies, and career progression from the engineer's perspective
+</div>

--- a/websites/fit/docs/products/team-capability/surface-gaps/index.md
+++ b/websites/fit/docs/products/team-capability/surface-gaps/index.md
@@ -198,3 +198,12 @@ Summit output:
 - **Who is best positioned to close the gaps?** You have run
   `npx fit-summit growth` and can name the recommended growth paths for
   high-impact gaps.
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../evaluate-candidate -->
+
+</div>

--- a/websites/fit/docs/products/trust-output/expected-output/index.md
+++ b/websites/fit/docs/products/trust-output/expected-output/index.md
@@ -189,9 +189,9 @@ from your Pathway output:
 
 ## What's next
 
-- [Verify Agent Work Against the Standard](/docs/products/trust-output/) --
-  return to the full review workflow
-- [See What's Expected at Your Level](/docs/products/career-paths/) -- explore
-  your own role expectations in depth
-- [Data Model Reference](/docs/reference/model/) -- how disciplines, tracks,
-  skills, and levels relate in the underlying model
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../second-opinion -->
+
+</div>

--- a/websites/fit/docs/products/trust-output/index.md
+++ b/websites/fit/docs/products/trust-output/index.md
@@ -290,16 +290,9 @@ define the quality bar and Guide to apply it.
 
 ## What's next
 
-This guide covered the end-to-end workflow for verifying agent output against
-the standard. For specific tasks within this workflow, see:
+<div class="grid">
 
-- [Get a Second Opinion on a Deliverable](/docs/products/trust-output/second-opinion/)
-  -- ask Guide to evaluate a specific piece of work before approving it
-- [Check Expected Output for a Role](/docs/products/trust-output/expected-output/)
-  -- see what the standard expects the agent to produce before reviewing
-- [See What's Expected at Your Level](/docs/products/career-paths/) -- full
-  role expectation workflow for understanding any position in the standard
-- [Configure Agents to Meet Your Engineering Standard](/docs/products/agent-teams/)
-  -- ensure agents are configured against the standard before they produce work
-- [Data Model Reference](/docs/reference/model/) -- how skills, levels, and
-  behaviours are structured in the underlying model
+<!-- part:card:second-opinion -->
+<!-- part:card:expected-output -->
+
+</div>

--- a/websites/fit/docs/products/trust-output/second-opinion/index.md
+++ b/websites/fit/docs/products/trust-output/second-opinion/index.md
@@ -164,3 +164,12 @@ You have reached the outcome of this guide when:
 For the full workflow -- understanding what to expect from agent output at each
 role level and building a systematic review practice -- return to
 [Verify Agent Work Against the Standard](/docs/products/trust-output/).
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../expected-output -->
+
+</div>

--- a/websites/fit/docs/reference/lifecycle/index.md
+++ b/websites/fit/docs/reference/lifecycle/index.md
@@ -169,7 +169,11 @@ Run `npx fit-pathway agent --help` for the full command surface.
 
 ---
 
-## Related Documentation
+## What's next
 
-- [Core Model](/docs/reference/model/) — Entity overview and derivation formula
-- [Agent Teams](/docs/products/agent-teams/) — Building and using agent teams
+<div class="grid">
+
+<!-- part:card:../model -->
+<!-- part:card:../yaml-schema -->
+
+</div>

--- a/websites/fit/docs/reference/model/index.md
+++ b/websites/fit/docs/reference/model/index.md
@@ -296,9 +296,11 @@ meaningful differentiation between tracks.
 
 ---
 
-## Related Documentation
+## What's next
 
-- [Lifecycle](/docs/reference/lifecycle/) — Phases, handoffs, and checklists
-- [Career Paths](/docs/products/career-paths/) -- Using progression and gap
-  analysis
-- [Agent Teams](/docs/products/agent-teams/) -- Agent profile generation
+<div class="grid">
+
+<!-- part:card:../lifecycle -->
+<!-- part:card:../yaml-schema -->
+
+</div>

--- a/websites/fit/docs/reference/yaml-schema/index.md
+++ b/websites/fit/docs/reference/yaml-schema/index.md
@@ -267,9 +267,11 @@ Validation checks:
 
 ---
 
-## Related Documentation
+## What's next
 
-- [Authoring Agent-Aligned Engineering Standards](/docs/products/authoring-standards/)
-  -- Writing and maintaining standard data
-- [Core Model](/docs/reference/model/) -- How entities combine into role
-  definitions
+<div class="grid">
+
+<!-- part:card:../model -->
+<!-- part:card:../lifecycle -->
+
+</div>

--- a/websites/fit/docs/services/ground-agents/index.md
+++ b/websites/fit/docs/services/ground-agents/index.md
@@ -266,12 +266,9 @@ and port for each service.
 
 ## What's next
 
-Each service has a dedicated guide for common bounded tasks:
+<div class="grid">
 
-- [Query the Graph](/docs/services/ground-agents/query-graph/) -- answer
-  relationship questions from a product using triple-pattern queries.
-- [Search for Related Content](/docs/services/ground-agents/search-content/) --
-  find semantically related content from a product without managing embeddings.
-- [Ground Agents in Context](/docs/libraries/ground-agents/) -- the library
-  guide for building and populating the underlying indexes from HTML knowledge
-  sources.
+<!-- part:card:query-graph -->
+<!-- part:card:search-content -->
+
+</div>

--- a/websites/fit/docs/services/ground-agents/query-graph/index.md
+++ b/websites/fit/docs/services/ground-agents/query-graph/index.md
@@ -174,11 +174,11 @@ You have reached the outcome of this guide when:
   predicates.
 - Applying a `filter` with `limit` constrains the result count.
 
-## Related
+## What's next
 
-- [Ground Agents in Context](/docs/services/ground-agents/) -- the end-to-end
-  setup for connecting to both the graph and vector services.
-- [Search for Related Content](/docs/services/ground-agents/search-content/) --
-  when you need ranked similarity rather than exact triple matching.
-- [Query a Graph](/docs/libraries/ground-agents/query-graph/) -- the library
-  guide for querying the graph index directly without the gRPC service.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../search-content -->
+
+</div>

--- a/websites/fit/docs/services/ground-agents/search-content/index.md
+++ b/websites/fit/docs/services/ground-agents/search-content/index.md
@@ -162,12 +162,11 @@ You have reached the outcome of this guide when:
 - Resolving returned identifiers through `libresource` produces the expected
   content.
 
-## Related
+## What's next
 
-- [Ground Agents in Context](/docs/services/ground-agents/) -- the end-to-end
-  setup for connecting to both the graph and vector services.
-- [Query the Graph](/docs/services/ground-agents/query-graph/) -- when you need
-  exact relationship matching rather than ranked similarity.
-- [Search Semantically](/docs/libraries/ground-agents/search-semantically/) --
-  the library guide for querying the vector index directly without the gRPC
-  service.
+<div class="grid">
+
+<!-- part:card:.. -->
+<!-- part:card:../query-graph -->
+
+</div>

--- a/websites/fit/docs/services/integrate-standard/fetch-profile/index.md
+++ b/websites/fit/docs/services/integrate-standard/fetch-profile/index.md
@@ -155,13 +155,10 @@ You have reached the outcome of this guide when:
 - Invalid coordinates produce a gRPC error with a message that names the
   invalid entity.
 
-## Related
+## What's next
 
-- [Query the Engineering Standard](/docs/services/integrate-standard/) --
-  return to the full guide for all six RPCs, including progression analysis
-  and software toolkit derivation.
-- [Derive a Skill Matrix or Agent Profile](/docs/libraries/integrate-standard/derive-profile/)
-  -- the library guide for embedding derivation logic directly when a gRPC
-  round trip is not appropriate.
-- [Data Model Reference](/docs/reference/model/) -- how disciplines, tracks,
-  skills, and levels relate in the underlying model.
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/services/integrate-standard/index.md
+++ b/websites/fit/docs/services/integrate-standard/index.md
@@ -228,11 +228,8 @@ and port for the pathway service.
 
 ## What's next
 
-- [Fetch a Derived Role or Agent Profile](/docs/services/integrate-standard/fetch-profile/)
-  -- a focused walkthrough of the most common bounded task: getting a single
-  derived entity from the pathway service.
-- [Integrate with the Engineering Standard](/docs/libraries/integrate-standard/)
-  -- the library guide for embedding derivation logic directly when a gRPC
-  round trip is not appropriate.
-- [Data Model Reference](/docs/reference/model/) -- how disciplines, tracks,
-  skills, and levels relate in the underlying model.
+<div class="grid">
+
+<!-- part:card:fetch-profile -->
+
+</div>

--- a/websites/fit/docs/services/prove-changes/index.md
+++ b/websites/fit/docs/services/prove-changes/index.md
@@ -277,8 +277,8 @@ If the connection fails, confirm the trace service is running with
 
 ## What's next
 
-- [Send Spans from a Product](/docs/services/prove-changes/send-spans/) -- a
-  focused walkthrough of the most common bounded task: emitting spans and
-  verifying they are queryable.
-- [Trace Analysis](/docs/libraries/prove-changes/trace-analysis/) -- the library guide for
-  analyzing traces as qualitative research with `fit-trace`.
+<div class="grid">
+
+<!-- part:card:send-spans -->
+
+</div>

--- a/websites/fit/docs/services/prove-changes/send-spans/index.md
+++ b/websites/fit/docs/services/prove-changes/send-spans/index.md
@@ -175,10 +175,10 @@ You have reached the outcome of this guide when:
 - Error spans preserve their status code and message.
 - `QuerySpans` returns all spans sent under the same `trace_id`.
 
-## Related
+## What's next
 
-- [Collect Trace Spans from Any Product](/docs/services/prove-changes/) --
-  return to the full guide for architecture context, query options, and tree
-  reconstruction.
-- [Trace Analysis](/docs/libraries/prove-changes/trace-analysis/) -- analyze stored traces
-  as qualitative research with `fit-trace`.
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/services/typed-contracts/add-service/index.md
+++ b/websites/fit/docs/services/typed-contracts/add-service/index.md
@@ -190,8 +190,10 @@ You have reached the outcome of this guide when:
 - `listTools` includes your new tool with the configured description.
 - `callTool` with valid parameters returns a response from your backend service.
 
-## Related
+## What's next
 
-- [Expose Backend Services as Agent Tools](/docs/services/typed-contracts/) --
-  return to the full guide for MCP service architecture, session management,
-  and authentication.
+<div class="grid">
+
+<!-- part:card:.. -->
+
+</div>

--- a/websites/fit/docs/services/typed-contracts/index.md
+++ b/websites/fit/docs/services/typed-contracts/index.md
@@ -236,10 +236,8 @@ tool calls if the backend it delegates to is unreachable.
 
 ## What's next
 
-- [Add a Service to the MCP Surface](/docs/services/typed-contracts/add-service/)
-  -- register a new backend service as agent tools without writing integration
-  code.
-- [Ground Agents in Context](/docs/services/ground-agents/) -- the graph and
-  vector services that the MCP service delegates to for knowledge queries.
-- [Query the Engineering Standard](/docs/services/integrate-standard/) -- the
-  pathway service that the MCP service delegates to for derivation queries.
+<div class="grid">
+
+<!-- part:card:add-service -->
+
+</div>


### PR DESCRIPTION
## Summary

- Standardize every non-hub documentation page to end with `## What's next` containing `<!-- part:card:path -->` content partials inside a `<div class="grid">`, replacing five inconsistent heading variants and markdown bullet links across 66 pages
- Card targets follow JTBD structure: Big Hire guides → Little Hire children, Little Hires → parent + siblings, Getting Started → product page + primary guide
- Document the cross-link convention in `websites/CLAUDE.md` under Page Conventions

## Test plan

- [x] `bunx fit-doc build --src=websites/fit` succeeds — all partial references resolve (build fails on missing targets)
- [x] `grep -r "## Next steps" websites/fit/docs/` returns zero results
- [x] `grep -r "## Related Documentation" websites/fit/docs/` returns zero results
- [x] `grep -rn "^## Related$" websites/fit/docs/` returns zero results
- [x] `grep -r "## What to do next" websites/fit/docs/` returns zero results
- [ ] Visual spot-check: preview the site and confirm card grids render correctly on a sample of pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)