### PR TITLE
plan(800): address review panel findings

### DIFF
--- a/specs/800-landmark-evidence-pipeline/plan-a-01.md
+++ b/specs/800-landmark-evidence-pipeline/plan-a-01.md
@@ -128,14 +128,15 @@ Extend `transformTeams()` to write `getdx_team_id` back to
 `organization_people` for each contributor found in the team data.
 
 **Modified:** `products/map/src/activity/transform/getdx.js`,
-`libraries/libsyntheticrender/src/render/raw.js`
+`libraries/libsyntheticrender/src/render/raw.js`,
+`libraries/libsyntheticgen/src/engine/activity.js`
 
 After the team upsert in `transformTeams()` (line 120), add:
 
 ```js
 const contributorUpdates = [];
 for (const team of teams) {
-  const contributors = team.contributors || [];
+  const contributors = team.contributor_list || team.contributors || [];
   if (!Array.isArray(contributors)) continue;
   for (const contributor of contributors) {
     if (contributor.email) {
@@ -156,32 +157,41 @@ if (contributorUpdates.length > 0) {
 }
 ```
 
-The synthetic teams render currently writes `contributors` as a count (number).
-Extend it to write contributor email arrays so the transform can populate
-`getdx_team_id`. In `renderGetDXPayloads()` (raw.js line 76), change
-`contributors: t.contributors || 0` to:
+The synthetic teams render currently writes `contributors` as a count (number),
+and `generateScores()` (activity.js lines 251, 253) uses `team.contributors`
+as a number for `randomInt()` and `contributor_count`. To avoid a type break,
+keep `contributors` as a count and add a separate `contributor_list` array.
+
+In `buildLeafTeamEntries()` (line 137), add a `contributor_list` field after
+`contributors: team.size` (line 152). Pass `people` as a fourth parameter:
 
 ```js
-contributors: Array.isArray(t.contributors) ? t.contributors : [],
-```
-
-Then in `libsyntheticgen/src/engine/activity.js`, extend the leaf team builder
-(`buildLeafTeamEntries`, line 137) to populate `contributors` with email arrays
-from the people roster:
-
-**Modified:** `libraries/libsyntheticgen/src/engine/activity.js`
-
-In `buildLeafTeamEntries()`, replace `contributors: team.size` (line 152)
-with a lookup against the people array (passed as an additional parameter):
-
-```js
-contributors: people
+contributors: team.size,
+contributor_list: people
   .filter((p) => p.team_id === team.id)
   .map((p) => ({ email: p.email, name: p.name })),
 ```
 
-Thread the `people` array through from `buildActivityData()` to
-`buildLeafTeamEntries()`.
+Update call sites to thread `people`:
+- `buildActivityTeams()` (line 160): add `people` parameter, pass to
+  `buildLeafTeamEntries(teams, deptMap, orgMap, people)` at line 167.
+- `generateActivity()` (line 69): pass `people` to
+  `buildActivityTeams(ast, teams, people)`.
+
+In `renderGetDXPayloads()` (raw.js line 76), add `contributor_list` to the
+teams-list output after `contributors` (line 82):
+
+```js
+contributors: t.contributors || 0,
+contributor_list: t.contributor_list || [],
+```
+
+Update the `transformTeams()` code added above to read `contributor_list`
+instead of `contributors`:
+
+```js
+const contributors = team.contributor_list || [];
+```
 
 **Verify:** After `bunx fit-map activity seed`, query
 `SELECT email, getdx_team_id FROM activity.organization_people WHERE

--- a/specs/800-landmark-evidence-pipeline/plan-a-01.md
+++ b/specs/800-landmark-evidence-pipeline/plan-a-01.md
@@ -2,13 +2,14 @@
 
 ## Step 1: Schema migrations
 
-Create three migration files.
+Create four migration files.
 
 **Created:**
 
 - `products/map/supabase/migrations/20250504000001_org_people_getdx_team_id.sql`
 - `products/map/supabase/migrations/20250504000002_evidence_not_null.sql`
 - `products/map/supabase/migrations/20250504000003_comments_driver_name.sql`
+- `products/map/supabase/migrations/20250504000004_evidence_upsert_key.sql`
 
 **`20250504000001_org_people_getdx_team_id.sql`:**
 
@@ -37,8 +38,16 @@ ALTER TABLE activity.evidence ALTER COLUMN level_id SET NOT NULL;
 ALTER TABLE activity.getdx_snapshot_comments ADD COLUMN driver_name TEXT;
 ```
 
-**Verify:** `bunx supabase migration list` shows all three; schema matches
-design § Data model changes.
+**`20250504000004_evidence_upsert_key.sql`:**
+
+```sql
+CREATE UNIQUE INDEX idx_evidence_upsert_key
+  ON activity.evidence(artifact_id, skill_id, level_id, marker_text);
+```
+
+**Verify:** `bunx supabase migration list` shows all four; schema matches
+design § Data model changes. Inserting a duplicate
+`(artifact_id, skill_id, level_id, marker_text)` row raises a unique violation.
 
 ---
 
@@ -72,7 +81,7 @@ if (options.managerEmail) {
 
 ### `snapshots.js` — `getItemTrend()` (line 63)
 
-Replace lines 69–78 (`if (options.managerEmail)` block):
+Replace lines 69–79 (`if (options.managerEmail)` block):
 
 ```js
 if (options.managerEmail) {
@@ -118,14 +127,16 @@ containing Athena's direct reports only.
 Extend `transformTeams()` to write `getdx_team_id` back to
 `organization_people` for each contributor found in the team data.
 
-**Modified:** `products/map/src/activity/transform/getdx.js`
+**Modified:** `products/map/src/activity/transform/getdx.js`,
+`libraries/libsyntheticrender/src/render/raw.js`
 
-After the team upsert (line 120), add:
+After the team upsert in `transformTeams()` (line 120), add:
 
 ```js
 const contributorUpdates = [];
 for (const team of teams) {
   const contributors = team.contributors || [];
+  if (!Array.isArray(contributors)) continue;
   for (const contributor of contributors) {
     if (contributor.email) {
       contributorUpdates.push({
@@ -145,24 +156,60 @@ if (contributorUpdates.length > 0) {
 }
 ```
 
+The synthetic teams render currently writes `contributors` as a count (number).
+Extend it to write contributor email arrays so the transform can populate
+`getdx_team_id`. In `renderGetDXPayloads()` (raw.js line 76), change
+`contributors: t.contributors || 0` to:
+
+```js
+contributors: Array.isArray(t.contributors) ? t.contributors : [],
+```
+
+Then in `libsyntheticgen/src/engine/activity.js`, extend the leaf team builder
+(`buildLeafTeamEntries`, line 137) to populate `contributors` with email arrays
+from the people roster:
+
+**Modified:** `libraries/libsyntheticgen/src/engine/activity.js`
+
+In `buildLeafTeamEntries()`, replace `contributors: team.size` (line 152)
+with a lookup against the people array (passed as an additional parameter):
+
+```js
+contributors: people
+  .filter((p) => p.team_id === team.id)
+  .map((p) => ({ email: p.email, name: p.name })),
+```
+
+Thread the `people` array through from `buildActivityData()` to
+`buildLeafTeamEntries()`.
+
 **Verify:** After `bunx fit-map activity seed`, query
 `SELECT email, getdx_team_id FROM activity.organization_people WHERE
 getdx_team_id IS NOT NULL` returns rows.
 
 ---
 
-## Step 4: `driver_name` capture in comment transform
+## Step 4: `driver_name` capture in comment transform and render
 
-**Modified:** `products/map/src/activity/transform/getdx.js`
+**Modified:** `products/map/src/activity/transform/getdx.js`,
+`libraries/libsyntheticrender/src/render/raw.js`
 
-In `transformSnapshotComments()`, line 252 (the row object literal), add:
+In `transformSnapshotComments()` (getdx.js), line 252 (the row object
+literal), add:
 
 ```js
 driver_name: comment.driver_name || null,
 ```
 
+In `renderGetDXComments()` (raw.js), line 275 (the return object inside the
+comment map), add:
+
+```js
+driver_name: ck.driver_name || null,
+```
+
 **Verify:** After `bunx fit-map activity seed`, `getdx_snapshot_comments` rows
-with source data containing `driver_name` have non-null values.
+have non-null `driver_name` values.
 
 ---
 
@@ -183,6 +230,9 @@ if (options.managerEmail) {
 }
 ```
 
+Org-wide scope requires no code change — calling `getUnscoredArtifacts` with
+no `email` or `managerEmail` already returns all artifacts.
+
 **Verify:** `getUnscoredArtifacts(supabase, { managerEmail:
 "athena@bionova.example" })` returns only artifacts for Athena's team members.
 
@@ -191,7 +241,9 @@ if (options.managerEmail) {
 ## Step 6: Initiative removal
 
 Remove the initiative command group from Landmark, the initiative query module
-from Map, and the initiative transform from the GetDX sync.
+from Map, and the initiative transform from the GetDX sync. Keep the initiative
+migration file in place so existing databases with the table applied do not
+show schema drift.
 
 **Deleted:**
 
@@ -201,7 +253,6 @@ from Map, and the initiative transform from the GetDX sync.
 - `products/landmark/test/initiative.test.js`
 - `products/landmark/test/initiative-helpers.test.js`
 - `products/map/src/activity/queries/initiatives.js`
-- `products/map/supabase/migrations/20250101000004_getdx_initiatives.sql`
 
 **Modified:**
 
@@ -211,9 +262,9 @@ from Map, and the initiative transform from the GetDX sync.
 | `products/landmark/src/formatters/index.js` | Remove `initiativeFormatter` import (line 20) and `initiative: initiativeFormatter` entry (line 34) |
 | `products/landmark/src/commands/health.js` | Remove `listInitiatives` import (line 18). Remove `listInitiatives` from the `q` default object (line 46). Remove `fetchInitiatives()` call (line 91), `attachInitiatives()` call (line 92), and both functions `fetchInitiatives` (lines 258–272) and `attachInitiatives` (lines 275–281). Remove `initiatives: []` from driver objects in `buildDriverRows` (line 190) |
 | `products/landmark/src/formatters/health.js` | Remove `renderTextInitiatives` (lines 61–68), `renderMdInitiatives` (lines 111–118), `formatInitPct` (lines 34–36). Remove calls to these from `renderTextDriver` (line 83) and `renderMdDriver` (line 129) |
-| `products/landmark/src/lib/empty-state.js` | Remove `NO_INITIATIVES` entry (line 22–23) |
-| `products/landmark/test/empty-state.test.js` | Remove the assertion referencing `NO_INITIATIVES` (line 37) |
-| `products/map/src/activity/transform/getdx.js` | Remove `transformInitiatives()` function (lines 283–346), its call site in `transformAllGetDX()` (lines 65–75), `initiativeCount` variable (line 65), and `initiatives` from the return object (line 78) |
+| `products/landmark/src/lib/empty-state.js` | Remove `NO_INITIATIVES` entry (lines 22–23) |
+| `products/landmark/test/empty-state.test.js` | Remove the `NO_INITIATIVES` test case (lines 36–38) |
+| `products/map/src/activity/transform/getdx.js` | Remove `transformInitiatives()` function (lines 283–346), its call site in `transformAllGetDX()` (lines 65–75), `initiativeCount` variable (line 65), and `initiatives` from the return object (line 82) |
 
 **Verify:** `bunx fit-landmark initiative` exits with "unknown command"
 (exit code 2). `bunx fit-landmark health` runs without errors.
@@ -225,7 +276,7 @@ from Map, and the initiative transform from the GetDX sync.
 
 **Modified:** `libraries/libsyntheticprose/src/prompts/pathway/capability.js`
 
-After the `agent.confirmChecklist` instructions (line 72), add:
+After the `agent.confirmChecklist` instructions (line 73), add:
 
 ```js
 "  - markers: An object keyed by proficiency level",
@@ -238,6 +289,13 @@ After the `agent.confirmChecklist` instructions (line 72), add:
 "    Markers describe concrete, observable evidence of skill proficiency",
 "    at that level. Higher levels show broader scope and autonomy.",
 ```
+
+`libsyntheticrender` requires no changes — `renderPathway()` calls
+`toYaml(stripInternal(entity))` which serializes the full entity including
+`markers`. The Map loader already preserves `markers` on skills
+(loader.js lines 112, 126). `data/synthetic/story.dsl` requires no changes —
+the entity generator already populates `manager_email` from team manager
+declarations.
 
 **Verify:** After `bunx fit-terrain generate`, inspect a capability YAML in
 `data/pathway/capabilities/` — each skill has a `markers` block. After

--- a/specs/800-landmark-evidence-pipeline/plan-a-02.md
+++ b/specs/800-landmark-evidence-pipeline/plan-a-02.md
@@ -318,9 +318,10 @@ export class MapService extends MapBase {
 
 ---
 
-## Step 5: svcmap `server.js` + `package.json`
+## Step 5: svcmap `server.js`, `package.json`, `README.md`, `test/`
 
-**Created:** `services/map/server.js`
+**Created:** `services/map/server.js`, `services/map/README.md`,
+`services/map/test/map.test.js`
 
 ```js
 #!/usr/bin/env node
@@ -410,16 +411,28 @@ await server.start();
 }
 ```
 
-**Verify:** `bun install` resolves deps. `node services/map/server.js` starts
-without errors (assuming Supabase and svcpathway are running).
+**Created:** `services/map/README.md` — Purpose, key exports, one composition
+example. Follow `services/graph/README.md` as template.
+
+**Created:** `services/map/test/map.test.js` — Unit tests for each RPC method
+using a mock Supabase client and mock pathwayClient.
+
+**Verify:** `bun install` resolves deps. `bun test services/map/test/` passes.
+`node services/map/server.js` starts without errors (assuming Supabase and
+svcpathway are running).
 
 ---
 
-## Step 6: svcmcp — add `mapClient`
+## Step 6: Service URL + svcmcp wiring
+
+**Modified:** `products/guide/src/commands/init.js`
+
+Add `SERVICE_MAP_URL: "grpc://localhost:3006"` to the `serviceUrls` object
+(after `SERVICE_MCP_URL` at line 25).
 
 **Modified:** `services/mcp/server.js`
 
-Add after the pathwayClient creation (line 14):
+Add after the pathwayClient creation (line 15):
 
 ```js
 const mapClient = await createClient("map", logger, tracer);
@@ -505,13 +518,15 @@ appear in the MCP tool listing.
 
 ---
 
-## Step 8: Codegen
+## Step 8: Codegen + catalog
 
 ```sh
 just codegen
+bun run context:fix
 ```
 
 **Verify:** `generated/services/bases/MapBase.js` exists.
 `generated/services/clients/MapClient.js` exists. `PathwayBase` includes
 `GetMarkersForProfile`. `generated/types/metadata.js` includes entries for
-`map.Map.*` and `pathway.Pathway.GetMarkersForProfile`.
+`map.Map.*` and `pathway.Pathway.GetMarkersForProfile`. `services/README.md`
+lists svcmap in the catalog.

--- a/specs/800-landmark-evidence-pipeline/plan-a-03.md
+++ b/specs/800-landmark-evidence-pipeline/plan-a-03.md
@@ -2,17 +2,17 @@
 
 Depends on Part 02 (MCP tools must be registered).
 
-## Step 1: Evaluation skill
+## Step 1: Evaluation protocol in Guide system prompt
 
-Create the artifact-evaluation protocol that Guide follows when piped an
-evaluation prompt. `fit-guide` already supports non-interactive stdin mode via
-`librepl` (librepl/src/index.js lines 389–407: detects `!stdin.isTTY`,
-buffers all input, processes each line, then exits). No changes to `fit-guide`
-or `librepl` are needed.
+Append the artifact-evaluation protocol to Guide's system prompt so the
+Claude SDK receives it alongside the MCP tools. `fit-guide` already supports
+non-interactive stdin mode via `librepl` (librepl/src/index.js lines 389–407:
+detects `!stdin.isTTY`, buffers all input, processes each line, then exits).
+No changes to `fit-guide` or `librepl` are needed.
 
-**Created:** `services/mcp/prompts/evaluation.md`
+**Modified:** `services/mcp/prompts/guide-default.md`
 
-Content — a concise protocol document (~60–80 lines) covering:
+Append a `## Artifact Evaluation` section (~60–80 lines) covering:
 
 1. **Trigger:** Prompt contains "evaluate" and a scope (person email, manager
    email for team, or "all" for org).
@@ -40,32 +40,6 @@ Content — a concise protocol document (~60–80 lines) covering:
 4. **Multi-source note:** `GetArtifact` returns different structures per source
    type. Evaluate based on what the artifact contains (title, description,
    diff context for PRs; review body for reviews; commit message for commits).
-
-**Verify:** File exists and is well-formed markdown.
-
----
-
-## Step 2: Guide system prompt — evaluation awareness
-
-Include the evaluation protocol in Guide's system prompt.
-
-**Modified:** `services/mcp/prompts/guide-default.md`
-
-Append at the end of the existing prompt:
-
-```markdown
-## Artifact Evaluation
-
-When asked to evaluate artifacts, follow the evaluation protocol below.
-
-{inline contents of evaluation.md}
-```
-
-The prompt loading in `services/mcp/index.js` reads a single file
-(`readFile(promptPath, "utf8")`). Inline the evaluation protocol directly
-into `guide-default.md` — do not create a separate file. The `evaluation.md`
-from Step 1 is the draft; its content is appended into `guide-default.md` in
-this step, then `evaluation.md` is deleted.
 
 **Verify:** `echo "evaluate unscored artifacts for actaeon@bionova.example" |
 bunx fit-guide` invokes `GetUnscoredArtifacts`, evaluates artifacts, calls

--- a/specs/800-landmark-evidence-pipeline/plan-a-03.md
+++ b/specs/800-landmark-evidence-pipeline/plan-a-03.md
@@ -61,11 +61,11 @@ When asked to evaluate artifacts, follow the evaluation protocol below.
 {inline contents of evaluation.md}
 ```
 
-If the prompt loading in `services/mcp/index.js` (`readFile(promptPath,
-"utf8")`) reads a single file, inline the evaluation protocol directly into
-`guide-default.md`. If multi-file loading is preferred, extend `makeServer()`
-to concatenate both files — but the single-file approach is simpler and
-matches the current architecture.
+The prompt loading in `services/mcp/index.js` reads a single file
+(`readFile(promptPath, "utf8")`). Inline the evaluation protocol directly
+into `guide-default.md` — do not create a separate file. The `evaluation.md`
+from Step 1 is the draft; its content is appended into `guide-default.md` in
+this step, then `evaluation.md` is deleted.
 
 **Verify:** `echo "evaluate unscored artifacts for actaeon@bionova.example" |
 bunx fit-guide` invokes `GetUnscoredArtifacts`, evaluates artifacts, calls

--- a/specs/800-landmark-evidence-pipeline/plan-a.md
+++ b/specs/800-landmark-evidence-pipeline/plan-a.md
@@ -24,16 +24,15 @@ entities), `libsyntheticrender` (raw payloads), `@supabase/supabase-js`
 | Part | Summary | Files | Depends on |
 |------|---------|-------|------------|
 | [plan-a-01.md](plan-a-01.md) | Data layer + synthetic data | 13 modified, 4 created, 6 deleted | — |
-| [plan-a-02.md](plan-a-02.md) | Service layer (svcpathway, svcmap, svcmcp) | 8 modified, 6 created | Part 01 |
+| [plan-a-02.md](plan-a-02.md) | Service layer (svcpathway, svcmap, svcmcp) | 7 modified, 6 created | Part 01 |
 | [plan-a-03.md](plan-a-03.md) | Evaluation skill | 1 modified | Part 02 |
 
 ## Risks
 
 | Risk | Mitigation |
 |------|------------|
-| NOT NULL migration on `activity.evidence` fails if synthetic rows have null `rationale` or `level_id` | Migration backfills defaults before adding constraint |
-| `getdx_team_id` population depends on teams-list containing contributor email arrays | Synthetic terrain extended to render contributor arrays; real path uses same transform |
-| Marker-grounding validation in `WriteEvidence` depends on svcpathway availability | svcmap constructor requires pathwayClient; service topology starts pathway before map |
+| `getdx_team_id` population depends on teams-list containing `contributor_list` arrays | Synthetic terrain extended to render arrays; real path needs teams.info per team (future sync spec) |
+| Marker-grounding validation in `WriteEvidence` adds a gRPC call per unique profile in the batch | Cache markers per `(discipline, level, track)` within the batch if profiling shows latency |
 | `createClient("map")` requires `SERVICE_MAP_URL` to resolve | init.js updated in Part 02 Step 6; port 3006 assigned |
 
 ## Execution

--- a/specs/800-landmark-evidence-pipeline/plan-a.md
+++ b/specs/800-landmark-evidence-pipeline/plan-a.md
@@ -12,28 +12,29 @@ svcpathway, new `svcmap` gRPC service with four methods and a source-type
 registry, wired through svcmcp), then add the evaluation skill to Guide's
 system prompt. Each part is independently verifiable and sequentially ordered.
 
-Libraries used: `libskill` (deriveJob, skill markers), `librpc` (Server,
-createClient, MapBase), `libmcp` (registerToolsFromConfig), `libconfig`
+Libraries used: `libskill` (deriveJob), `librpc` (Server, createClient,
+MapBase), `libmcp` (registerToolsFromConfig), `libconfig`
 (createServiceConfig), `libtelemetry` (createLogger), `libtype` (generated
-types), `libsyntheticprose` (capability prompt), `@supabase/supabase-js`
+types), `libsyntheticprose` (capability prompt), `libsyntheticgen` (activity
+entities), `libsyntheticrender` (raw payloads), `@supabase/supabase-js`
 (activity DB).
 
 ## Parts
 
 | Part | Summary | Files | Depends on |
 |------|---------|-------|------------|
-| [plan-a-01.md](plan-a-01.md) | Data layer + synthetic data | 13 modified, 3 created, 7 deleted | — |
-| [plan-a-02.md](plan-a-02.md) | Service layer (svcpathway, svcmap, svcmcp) | 6 modified, 4 created | Part 01 |
-| [plan-a-03.md](plan-a-03.md) | Evaluation skill | 1 modified, 1 created | Part 02 |
+| [plan-a-01.md](plan-a-01.md) | Data layer + synthetic data | 13 modified, 4 created, 6 deleted | — |
+| [plan-a-02.md](plan-a-02.md) | Service layer (svcpathway, svcmap, svcmcp) | 8 modified, 6 created | Part 01 |
+| [plan-a-03.md](plan-a-03.md) | Evaluation skill | 1 modified | Part 02 |
 
 ## Risks
 
 | Risk | Mitigation |
 |------|------------|
 | NOT NULL migration on `activity.evidence` fails if synthetic rows have null `rationale` or `level_id` | Migration backfills defaults before adding constraint |
-| `getdx_team_id` population depends on teams-list containing contributor data | Synthetic terrain already includes contributors; real path extends GetDX sync |
-| Markers schema mismatch between LLM-generated prose and JSON schema | Capability prompt includes the exact schema `$defs/skillMarkers` structure |
+| `getdx_team_id` population depends on teams-list containing contributor email arrays | Synthetic terrain extended to render contributor arrays; real path uses same transform |
 | Marker-grounding validation in `WriteEvidence` depends on svcpathway availability | svcmap constructor requires pathwayClient; service topology starts pathway before map |
+| `createClient("map")` requires `SERVICE_MAP_URL` to resolve | init.js updated in Part 02 Step 6; port 3006 assigned |
 
 ## Execution
 


### PR DESCRIPTION
## Summary

- Adds unique constraint migration on `evidence(artifact_id, skill_id, level_id, marker_text)` for `WriteEvidence` upsert idempotency
- Extends synthetic teams render to include contributor email arrays for `getdx_team_id` population
- Adds `driver_name` to synthetic comment render output
- Adds `SERVICE_MAP_URL` to `init.js` (port 3006) so `createClient("map")` resolves
- Adds svcmap `README.md` and `test/` directory per `services/CLAUDE.md` conventions
- Adds `context:fix` step after codegen
- Keeps initiative migration file to avoid schema drift
- Clarifies evaluation skill inlining approach (single file, not ambiguous)
- Fixes blast radius counts and libraries-used line

Follow-up to merged #747. Addresses all blocker and high findings from the three-reviewer panel.

## Test plan

- [ ] Verify unique constraint migration applies cleanly
- [ ] Verify synthetic teams-list includes contributor email arrays after terrain generate
- [ ] Verify `getdx_team_id` populated on `organization_people` after seed
- [ ] Verify `driver_name` non-null in `getdx_snapshot_comments` after seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)