### PR TITLE
fix(700): address review panel findings in plan-a

### DIFF
--- a/specs/700-git-installable-packs/plan-a-01.md
+++ b/specs/700-git-installable-packs/plan-a-01.md
@@ -47,8 +47,25 @@ Register libpack in the Bun workspace.
   "name": "@forwardimpact/libpack",
   "version": "0.1.0",
   "description": "Pack distribution — tarballs, bare git repos, and skill discovery indices",
+  "keywords": ["pack", "distribution", "git", "tarball", "agent"],
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "libraries/libpack"
+  },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Platform Builders",
+      "goal": "Integrate with the Engineering Standard",
+      "trigger": "Needing engineers to install skill packs and realizing each ecosystem expects a different artifact format.",
+      "bigHire": "distribute skill packs so agents and engineers can install them through their preferred tool.",
+      "littleHire": "add a distribution format without reimplementing the staging and orchestration loop.",
+      "competesWith": "inlining pack logic in each product command; hand-rolling tar and git plumbing per consumer; maintaining parallel format-specific scripts"
+    }
+  ],
   "type": "module",
   "main": "./src/index.js",
   "exports": {
@@ -397,6 +414,10 @@ export class PackBuilder {
   async build({ combinations, outputDir, version }) { ... }
 }
 ```
+
+All paths in the orchestration table below are relative to `outputDir`.
+`_packs/` is a temporary staging directory created and cleaned up by `build`;
+`packs/` is the final output directory containing published artifacts.
 
 `combinations` shape:
 

--- a/specs/700-git-installable-packs/plan-a-02.md
+++ b/specs/700-git-installable-packs/plan-a-02.md
@@ -73,7 +73,9 @@ Replace the internals of `build-packs.js` with libpack calls. The public
 
 - `stageApmBundle`, `archiveApmPack` from `./build-packs-apm.js`
 - `writeSkillReferences` from `./agent-io.js` (no longer called; references are
-  now pre-formatted via `formatContent` and written by `PackStager.stageFull`)
+  now pre-formatted via `formatContent` and written by `PackStager.stageFull`).
+  `writeSkillReferences` itself stays in `agent-io.js` — it is still called by
+  `writeSkills` in that module. Only the import in `build-packs.js` is removed.
 
 **Keep** in `build-packs.js`:
 
@@ -124,10 +126,14 @@ function formatContent(
 }
 ```
 
-Add `formatReference` to the existing import from `../formatters/agent/skill.js`
-(it is already exported from that module but not currently imported by
-`build-packs.js` — it was previously consumed indirectly via
-`writeSkillReferences` in `agent-io.js`).
+**Import changes** in `build-packs.js`:
+
+- The existing import `{ formatAgentSkill, formatInstallScript }` from
+  `../formatters/agent/skill.js` gains `formatReference` (already exported at
+  line 156 of that module, but not currently imported by `build-packs.js` — it
+  was consumed indirectly via `writeSkillReferences` in `agent-io.js`).
+- All other existing imports (`formatAgentProfile`, `formatTeamInstructions`,
+  etc.) stay unchanged.
 
 **Rewrite** `generatePacks` body:
 
@@ -217,18 +223,88 @@ export function getSkillsGitCommand(siteUrl, packName) {
 }
 ```
 
-Update `createInstallSection` — reorder and add cards per design-c table:
-
-| Group      | Card             | Command                                           | Note text                                                  |
-| ---------- | ---------------- | ------------------------------------------------- | ---------------------------------------------------------- |
-| **Full**   | Direct download  | `curl -sL .../packs/{name}.raw.tar.gz \| tar xz` | Recommended. Installs everything: skills, agents, ...      |
-| **APM**    | `apm install`    | `apm install .../packs/{name}.apm.git`            | Recommended for APM users. Installs skills, agents, ...    |
-|            | `apm unpack`     | `curl -sLO ... && apm unpack {name}.apm.tar.gz`  | Offline alternative. Downloads the tarball, then unpacks.  |
-| **Skills** | `npx skills add` | `npx skills add .../packs/{name}`                 | Installs skills only. Does not include agents or CLAUDE.md. |
-|            | `git clone`      | `git clone .../packs/{name}.skills.git`           | Clone skills as a git repository.                          |
-
+Update `createInstallSection` — reorder and add cards per design-c table.
 `apm install` is the primary APM command (uses native `git ls-remote`);
 `apm unpack` becomes the offline fallback. No card is removed (Spec Req 7).
+
+Rewrite the `createInstallSection` body. The existing three-card structure
+(lines 96–145) becomes five cards grouped by layout:
+
+```javascript
+export function createInstallSection({ discipline, track, siteUrl }) {
+  if (!siteUrl) return null;
+
+  const packName = getPackName(discipline, track);
+
+  return section(
+    {
+      className: "agent-install-section",
+      "aria-labelledby": INSTALL_HEADING_ID,
+    },
+    div(
+      { className: "agent-install-header" },
+      h2({ id: INSTALL_HEADING_ID }, "📦 Install This Agent Team"),
+      p(
+        { className: "text-muted agent-install-description" },
+        "Install the pre-built pack for this discipline × track combination " +
+          "directly through an ecosystem package manager. The pack contains " +
+          "the same agent profile, skills, team instructions, and Claude Code " +
+          "settings shown below — installed into your project's ",
+        code({}, ".claude/"),
+        " directory.",
+      ),
+    ),
+    div(
+      { className: "agent-install-commands" },
+      div(
+        { className: "agent-install-command" },
+        p({ className: "agent-install-command-label" }, "Direct download"),
+        createCommandPrompt(getRawCommand(siteUrl, packName)),
+        p(
+          { className: "text-muted agent-install-note" },
+          "Recommended. Installs everything: skills, agents, CLAUDE.md, and settings (Claude Code + VS Code).",
+        ),
+      ),
+      div(
+        { className: "agent-install-command" },
+        p({ className: "agent-install-command-label" }, "apm install"),
+        createCommandPrompt(getApmInstallCommand(siteUrl, packName)),
+        p(
+          { className: "text-muted agent-install-note" },
+          "Recommended for APM users. Installs skills, agents, and team instructions via native git resolution.",
+        ),
+      ),
+      div(
+        { className: "agent-install-command" },
+        p({ className: "agent-install-command-label" }, "apm unpack"),
+        createCommandPrompt(getApmCommand(siteUrl, packName)),
+        p(
+          { className: "text-muted agent-install-note" },
+          "Offline alternative. Downloads the tarball, then unpacks. Does not include settings.",
+        ),
+      ),
+      div(
+        { className: "agent-install-command" },
+        p({ className: "agent-install-command-label" }, "npx skills"),
+        createCommandPrompt(getSkillsCommand(siteUrl, packName)),
+        p(
+          { className: "text-muted agent-install-note" },
+          "Installs skills only. Does not include agents or CLAUDE.md.",
+        ),
+      ),
+      div(
+        { className: "agent-install-command" },
+        p({ className: "agent-install-command-label" }, "git clone"),
+        createCommandPrompt(getSkillsGitCommand(siteUrl, packName)),
+        p(
+          { className: "text-muted agent-install-note" },
+          "Clone skills as a git repository.",
+        ),
+      ),
+    ),
+  );
+}
+```
 
 **Verify:** Manual inspection of rendered card structure; `bun run check`
 passes.

--- a/specs/700-git-installable-packs/plan-a.md
+++ b/specs/700-git-installable-packs/plan-a.md
@@ -50,6 +50,7 @@ Libraries used: none (Node built-ins only).
 | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | Git version differences produce different packfile bytes | Pin `--no-reuse-delta`, use plumbing commands, epoch-pinned timestamps. Byte-equality CI assertion catches drift |
 | `git init --bare` scaffold varies across git versions    | Write `config` and `description` explicitly; strip output to the 8 design-specified files        |
+| `apm.yml` URL changes from `.apm.tar.gz` to `.apm.git`  | Behavioral change for existing APM consumers. Tarball still emitted (Spec Req 7); `apm install` gains native git resolution. Consumers using `apm unpack` are unaffected — that command reads the tarball directly, not `apm.yml` |
 
 ## Execution
 


### PR DESCRIPTION
## Summary

- Ran a 3-reviewer panel on plan-a (spec 700) per the caller-protocol, merged findings, verified against source, and fixed 6 confirmed issues across `plan-a.md`, `plan-a-01.md`, and `plan-a-02.md`
- Consensus fixes: missing `package.json` metadata fields (`keywords`, `jobs`, `homepage`, `repository`), concrete `createInstallSection` rewrite (5-card UI), `PackBuilder` output path clarification, explicit import delta for `formatReference`
- Singleton fixes: `writeSkillReferences` stays in `agent-io.js` note, `apm.yml` URL behavioral change added to Risks table

## Test plan

- [ ] Verify `plan-a-01.md` package.json scaffold matches `libraries/CLAUDE.md` requirements (`keywords`, `jobs`, `homepage`, `repository`)
- [ ] Verify `plan-a-02.md` install UI rewrite matches existing `agent-builder-install.js` rendering pattern (5 cards, correct CSS classes, correct command functions)
- [ ] Verify `plan-a-01.md` Step 7 output path clarification is consistent with `plan-a-02.md` Step 2 `generatePacks` rewrite
- [ ] Verify all markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)