### PR TITLE
fix(740): align plan-a with spec after fit-basecamp removal

### DIFF
--- a/specs/740-seed-homebrew-tap/design-a.md
+++ b/specs/740-seed-homebrew-tap/design-a.md
@@ -2,14 +2,14 @@
 
 ## Architecture
 
-Four components collaborate. Eight cask files in the tap repo define what
+Four components collaborate. Seven cask files in the tap repo define what
 Homebrew installs. The publish-brew workflow writes version and sha256 into
 those casks on each release. A conventions document in the monorepo prescribes
 how casks are authored. The tap README bridges tap and monorepo.
 
 | Component       | Location                                       | Purpose                                              |
 | --------------- | ---------------------------------------------- | ---------------------------------------------------- |
-| Cask files (x8) | `forwardimpact/homebrew-tap/Casks/`            | Homebrew cask definitions installed by `brew install` |
+| Cask files (x7) | `forwardimpact/homebrew-tap/Casks/`            | Homebrew cask definitions installed by `brew install` |
 | Publish workflow | `.github/workflows/publish-brew.yml` in mono   | Builds bundle, uploads asset, sed-rewrites cask      |
 | Conventions doc | `websites/fit/docs/internals/release/` in mono | Authoring rules, sed contract, binary-stanza mapping |
 | Tap README      | `forwardimpact/homebrew-tap/README.md`          | Links to conventions doc via published URL           |
@@ -27,13 +27,11 @@ graph TD
         outpost[fit-outpost]
     end
     gear[fit-gear]
-    basecamp[fit-basecamp] -.->|deprecated, replaced by| outpost
 ```
 
-All eight casks are independently installable — no `depends_on cask:` between
+All seven casks are independently installable — no `depends_on cask:` between
 them. Product casks each expose a single CLI. The shared `fit-gear` cask bundles
-all service and library CLIs (25 total). `fit-basecamp` is a deprecated alias
-that redirects users to `fit-outpost`.
+all service and library CLIs (25 total).
 
 ## Cask Anatomy
 
@@ -126,20 +124,6 @@ installed `.app` in `/Applications/Forward Impact/` but is not placed on PATH.
 
 Rejected: exposing `Outpost` on PATH — it is a native GUI launcher, not a CLI.
 
-## Deprecated Cask (`fit-basecamp`)
-
-Uses Homebrew's `deprecate!` DSL:
-
-```ruby
-deprecate! date: "2026-04-30", because: "renamed to fit-outpost"
-```
-
-The cask retains `url` and `sha256` fields pointing to the `outpost` release
-asset (so the sed contract still functions) but has no `app`, `binary`, or
-`livecheck` stanzas. It exists for discoverability via `brew search`. Its `desc`
-names `fit-outpost` as the replacement and references the storage-path migration
-command from #625 phase 8d.
-
 ## Conventions Document
 
 A single document under `websites/fit/docs/internals/release/` covering:
@@ -161,6 +145,5 @@ together. The tap README links to this document via its published URL.
 | Shared bundle consolidation | Single `fit-gear` cask | Separate `fit-services` + `fit-utilities` | One bundle simplifies install, tag management, and release workflow |
 | Inter-cask dependencies | None — all casks independently installable | Products depend on gear via `depends_on cask:` | Users install only what they need; forced deps pull 25 CLIs for a single-CLI product |
 | Livecheck strategy | `:github_releases` with anchored per-cask regex | `:url` against atom feed | Anchored `^{name}@v…$` regex cleanly filters the multi-bundle releases page |
-| Deprecated cask form | Standalone `fit-basecamp.rb` with `deprecate!` | Caveats on `fit-outpost` | `brew search fit-basecamp` must surface results |
 | App install path | `Forward Impact/` subdirectory | Flat install to `/Applications/` | Groups eight bundles visually; avoids cluttering the top-level Applications folder |
 | Conventions doc location | Monorepo `internals/release/` | Tap repo README | Conventions co-decay with the workflow |

--- a/specs/740-seed-homebrew-tap/design-a.md
+++ b/specs/740-seed-homebrew-tap/design-a.md
@@ -92,7 +92,7 @@ monorepo's shared releases.
 ### App Install Path
 
 All casks install to a `Forward Impact/` subdirectory under `/Applications/`
-to keep eight `.app` bundles visually grouped rather than scattered among
+to keep seven `.app` bundles visually grouped rather than scattered among
 unrelated applications:
 
 ```ruby
@@ -145,5 +145,5 @@ together. The tap README links to this document via its published URL.
 | Shared bundle consolidation | Single `fit-gear` cask | Separate `fit-services` + `fit-utilities` | One bundle simplifies install, tag management, and release workflow |
 | Inter-cask dependencies | None — all casks independently installable | Products depend on gear via `depends_on cask:` | Users install only what they need; forced deps pull 25 CLIs for a single-CLI product |
 | Livecheck strategy | `:github_releases` with anchored per-cask regex | `:url` against atom feed | Anchored `^{name}@v…$` regex cleanly filters the multi-bundle releases page |
-| App install path | `Forward Impact/` subdirectory | Flat install to `/Applications/` | Groups eight bundles visually; avoids cluttering the top-level Applications folder |
+| App install path | `Forward Impact/` subdirectory | Flat install to `/Applications/` | Groups seven bundles visually; avoids cluttering the top-level Applications folder |
 | Conventions doc location | Monorepo `internals/release/` | Tap repo README | Conventions co-decay with the workflow |

--- a/specs/740-seed-homebrew-tap/plan-a.md
+++ b/specs/740-seed-homebrew-tap/plan-a.md
@@ -4,18 +4,17 @@
 
 ## Approach
 
-The eight cask files already live on `forwardimpact/homebrew-tap/main` in the
+The seven cask files already live on `forwardimpact/homebrew-tap/main` in the
 shape the design prescribes (single `fit-gear` shared bundle, `Forward Impact/`
-app subdirectory, `:github_releases` livecheck with anchored per-cask regex,
-`fit-basecamp` deprecated alias). Three monorepo-side gaps remain before the
-spec's success criteria pass: `publish-brew.yml` and `justfile` still build,
-sign, and publish under the legacy `services@v*` / `utilities@v*` tag pair, so
-the `tap-pr` job's sed contract targets cask filenames that no longer exist;
-the conventions document the spec's SC6 names is missing; and no end-to-end
-check has confirmed the seeded casks survive the workflow's sed contract. This
-plan closes those three gaps in two parallel strands and ends with a
-verification pass that also reconciles any drift between the seeded cask bodies
-and the design tables.
+app subdirectory, `:github_releases` livecheck with anchored per-cask regex).
+Three monorepo-side gaps remain before the spec's success criteria pass:
+`publish-brew.yml` and `justfile` still build, sign, and publish under the
+legacy `services@v*` / `utilities@v*` tag pair, so the `tap-pr` job's sed
+contract targets cask filenames that no longer exist; the conventions document
+the spec's SC5 names is missing; and no end-to-end check has confirmed the
+seeded casks survive the workflow's sed contract. This plan closes those three
+gaps in two parallel strands and ends with a verification pass that also
+reconciles any drift between the seeded cask bodies and the design tables.
 
 ## Files at a glance
 
@@ -27,7 +26,7 @@ and the design tables.
 | Create | `macos/gear/entitlements.plist`                                                                | Codesign entitlements for `fit-gear.app` (byte-copy of the existing services plist) |
 | Delete | `macos/services/Info.plist`, `macos/services/entitlements.plist`                               | Replaced by `macos/gear/`                                               |
 | Delete | `macos/libraries/Info.plist`, `macos/libraries/entitlements.plist`                             | Replaced by `macos/gear/`                                               |
-| Create | `websites/fit/docs/internals/release/index.md`                                                 | Conventions document (spec § In scope, SC6)                             |
+| Create | `websites/fit/docs/internals/release/index.md`                                                 | Conventions document (spec § In scope, SC5)                             |
 | Modify | `websites/fit/docs/internals/index.md`                                                         | Add `release` card to the internals hub grid                            |
 
 ## Steps
@@ -136,10 +135,9 @@ File modified: `.github/workflows/publish-brew.yml` (lines 205–208). Replace w
 
 ```yaml
 # Only the version and sha256 lines are updated per release. The rest of the
-# cask body — binary stanzas, livecheck regex, deprecate! on fit-basecamp — is
-# human-edited in the tap repo and survives releases unchanged. The casks
-# declare no inter-cask dependencies, so each release rewrites exactly one
-# cask file.
+# cask body — binary stanzas, livecheck regex — is human-edited in the tap
+# repo and survives releases unchanged. The casks declare no inter-cask
+# dependencies, so each release rewrites exactly one cask file.
 ```
 
 Verify: `git grep -nE 'depends_on graph' -- .github` returns no matches across the repo (catches the same outdated phrase if it migrated to any other workflow file).
@@ -313,18 +311,17 @@ Body sections (one section per cross-cutting decision named in spec § In scope;
 | --- | --- |
 | `## Overview` | The tap repo's role; the `publish-brew.yml` workflow's role; where each authored field lives. Two paragraphs. |
 | `## Sed contract` | The two fields the workflow rewrites (`version`, `sha256`); literal `sed -i` invocation; required two-space indent + double-quoted shape; what survives unchanged across releases. |
-| `## Cask topology` | No inter-cask `depends_on`; six product casks each expose one CLI; `fit-gear` exposes 25 CLIs; `fit-basecamp` is a deprecated alias. Reproduce the Mermaid diagram from design § Cask Topology — the conventions doc is the long-lived reference for tap reviewers and stands on its own without a hop to the design. |
+| `## Cask topology` | No inter-cask `depends_on`; six product casks each expose one CLI; `fit-gear` exposes 25 CLIs. Reproduce the Mermaid diagram from design § Cask Topology — the conventions doc is the long-lived reference for tap reviewers and stands on its own without a hop to the design. |
 | `## Binary stanza mapping` | Authoritative table — same rows as design § Binary Stanza Mapping. |
 | `## Livecheck regex pattern` | `:github_releases` strategy with the cask's own download URL; per-cask `^{name}@v(\d+(?:\.\d+)+)$` regex anchoring; rationale for `^...$` against the multi-bundle releases page. |
 | `## App install path` | `Forward Impact/` subdirectory under `/Applications/`; how `app` and `binary` stanzas reference it; why grouping (vs. flat install) was chosen. |
 | `## Zap and uninstall paths` | `~/Library/Preferences/team.forwardimpact.{name}.plist` per cask; one row per cask. |
 | `## Verification commands` | `brew style Casks/*.rb` and `brew audit --new-cask Casks/{cask}.rb`; what a human reviewer runs before merging a tap PR; how to dry-run the workflow's sed locally. |
-| `## Deprecation precedent` | `fit-basecamp` rationale; date `2026-04-30`; rename target `fit-outpost`; reference to the storage-path migration command from #625 phase 8d. |
 | `## What's next` | Partial-card grid (`<!-- part:card:... -->` only — no markdown link cards per `websites/CLAUDE.md`). Targets: `../operations`, `../kata`. Maximum four cards. |
 
 Tables in the doc are denormalized from the design so editing one cask's conventions doesn't require touching the design. The conventions doc is the long-lived reference for tap reviewers; once it lands, the tap README's existing link to `https://www.forwardimpact.team/docs/internals/release/` resolves (the README already targets this URL — no monorepo edit to the tap README is needed).
 
-Verify: `bunx fit-doc build --src=websites/fit` exits 0 and produces `dist/docs/internals/release/index.html`; `grep -c '^## ' websites/fit/docs/internals/release/index.md` returns exactly `10` (one per row of the table above — Overview, Sed contract, Cask topology, Binary stanza mapping, Livecheck regex pattern, App install path, Zap and uninstall paths, Verification commands, Deprecation precedent, What's next).
+Verify: `bunx fit-doc build --src=websites/fit` exits 0 and produces `dist/docs/internals/release/index.html`; `grep -c '^## ' websites/fit/docs/internals/release/index.md` returns exactly `9` (one per row of the table above — Overview, Sed contract, Cask topology, Binary stanza mapping, Livecheck regex pattern, App install path, Zap and uninstall paths, Verification commands, What's next).
 
 ### 9. Add the release card to the internals hub
 
@@ -336,13 +333,12 @@ Verify: `grep -c 'part:card:release' websites/fit/docs/internals/index.md` retur
 
 ### 10. Audit the seeded tap casks against the design
 
-No files created or modified inside the monorepo. The eight cask files exist on `forwardimpact/homebrew-tap/main` (verified 2026-05-04 via `gh api repos/forwardimpact/homebrew-tap/git/trees/main?recursive=1`): `fit-pathway.rb`, `fit-map.rb`, `fit-guide.rb`, `fit-landmark.rb`, `fit-summit.rb`, `fit-outpost.rb`, `fit-gear.rb`, `fit-basecamp.rb`. Run a structural audit:
+No files created or modified inside the monorepo. The seven cask files exist on `forwardimpact/homebrew-tap/main` (verified 2026-05-04 via `gh api repos/forwardimpact/homebrew-tap/git/trees/main?recursive=1`): `fit-pathway.rb`, `fit-map.rb`, `fit-guide.rb`, `fit-landmark.rb`, `fit-summit.rb`, `fit-outpost.rb`, `fit-gear.rb`. Run a structural audit:
 
-- For each live cask, confirm the stanzas design § Cask Anatomy prescribes are present in the prescribed shape: `version`, `sha256`, `url`, `name`, `desc`, `homepage`, `depends_on arch: :arm64`, `app … target: "Forward Impact/…"`, `binary` stanzas referencing `#{appdir}/Forward Impact/…`, `livecheck` block with `:github_releases` strategy and anchored regex, `zap trash:` clause.
-- For `fit-basecamp.rb`, confirm `deprecate! date: "2026-04-30", because: …` matches design § Deprecated Cask. The cask carries `url`/`sha256` but no `app`, `binary`, or `livecheck`. **Also** confirm the `desc` field names the storage-path manual-migration command from #625 phase 8d as spec § In scope requires — the seeded cask's `desc` reads "Renamed to fit-outpost — install forwardimpact/tap/fit-outpost instead", which does **not** name the migration command and is therefore expected to fail this row of the audit.
+- For each cask, confirm the stanzas design § Cask Anatomy prescribes are present in the prescribed shape: `version`, `sha256`, `url`, `name`, `desc`, `homepage`, `depends_on arch: :arm64`, `app … target: "Forward Impact/…"`, `binary` stanzas referencing `#{appdir}/Forward Impact/…`, `livecheck` block with `:github_releases` strategy and anchored regex, `zap trash:` clause.
 - Cross-check binary stanzas against design § Binary Stanza Mapping — exact name match, no extras, no omissions: 25 entries for `fit-gear.rb`, one entry per product cask.
 
-Reconciliation: the staff-engineer cannot push to `forwardimpact/homebrew-tap` (no `HOMEBREW_TAP_PAT`). For each failing row, file a comment on this plan's PR with the deviation and open a tap-side issue at `forwardimpact/homebrew-tap` titled `spec/740: <cask> drift — <criterion>`, assigning the release-engineer. SC4 ("executable names match … performed at seed time") passes for the live casks whose audit row is clean, and is conditionally pending for any failing row until the tap-side reconciliation issue closes. The basecamp `desc` row above is the known expected failure.
+Reconciliation: the staff-engineer cannot push to `forwardimpact/homebrew-tap` (no `HOMEBREW_TAP_PAT`). For each failing row, file a comment on this plan's PR with the deviation and open a tap-side issue at `forwardimpact/homebrew-tap` titled `spec/740: <cask> drift — <criterion>`, assigning the release-engineer. SC3 ("executable names match … performed at seed time") passes for the casks whose audit row is clean, and is conditionally pending for any failing row until the tap-side reconciliation issue closes.
 
 Verify: a written audit log enumerates each cask with a pass/fail row per criterion; every failing row carries a tap-side issue link assigned to `release-engineer` (no failing row is left unowned).
 
@@ -381,7 +377,7 @@ for CASK in fit-pathway fit-map fit-guide fit-landmark fit-summit fit-outpost fi
 done
 ```
 
-Verify: every iteration of the loop produces a clean `brew style` (exit 0) with no `FAIL` line emitted; the loop exits 0 overall. `fit-basecamp.rb` is excluded — the workflow's case statement maps `outpost@v*` to `fit-outpost`, never `fit-basecamp`, so `fit-basecamp.rb` is not sed-rewritten and the dry-run does not apply.
+Verify: every iteration of the loop produces a clean `brew style` (exit 0) with no `FAIL` line emitted; the loop exits 0 overall.
 
 ## Libraries used: none.
 
@@ -391,21 +387,16 @@ How each spec § Success criterion is verified by this plan, and which carry con
 
 | Spec SC | Verified by | At plan close-out |
 | --- | --- | --- |
-| SC1 (every bundle has a cask in the tap) | Tap state already satisfies (8 cask files on `forwardimpact/homebrew-tap/main`); step 10's audit re-confirms | Pass |
+| SC1 (every bundle has a cask in the tap) | Tap state already satisfies (7 cask files on `forwardimpact/homebrew-tap/main`); step 10's audit re-confirms | Pass |
 | SC2 (sed contract succeeds against every live cask) | Step 11 dry-run | Pass on macOS-arm64 / gnu-sed or Linux/Linuxbrew; **deferred to release-engineer's first `gear@v*` rehearsal** if no compatible host is available |
 | SC3 (each live cask passes `brew style` / `brew audit --new-cask`) | Step 11 (`brew style`) | Pass; same host caveat as SC2 |
-| SC4 (executable names match bundle source) | Step 10 audit | Pass for clean rows; **conditionally pending for any failing audit row** until the matching tap-side reconciliation issue closes (the basecamp `desc` storage-path migration row is the known expected fail) |
-| SC5 (`fit-basecamp` is `brew search`-discoverable and visibly deprecated) | Manual `brew search` against the published tap | Pass; not gated by this plan |
-| SC6 (conventions doc covers every cross-cutting decision) | Step 8 (10-section heading check) | Pass |
+| SC4 (executable names match bundle source) | Step 10 audit | Pass for clean rows; **conditionally pending for any failing audit row** until the matching tap-side reconciliation issue closes |
+| SC5 (conventions doc covers every cross-cutting decision) | Step 8 (9-section heading check) | Pass |
 
 ## Risks
 
 - **`HOMEBREW_TAP_PAT` not yet provisioned on the monorepo.** The `tap-pr` job at line 190 authenticates against `forwardimpact/homebrew-tap` via `secrets.HOMEBREW_TAP_PAT`. State-of audit § Must-have item 5 flags this secret as not yet set on `forwardimpact/monorepo`. This plan does not add the secret — a repo admin (release-engineer) creates it out-of-band (classic PAT scoped `repo` to `forwardimpact/homebrew-tap` only, ≤ 1-year expiry) before the first `gear@v*` or product tag is pushed, or `tap-pr` will fail at checkout. Owner: `release-engineer`. Verification gate: secret presence audit during the first `kata-release-cut` rehearsal that follows this plan's merge.
-- **Cask drift from design.** The tap was seeded externally (commit "feat: seed tap with initial casks", state-of.md § Step 3). Step 10 audits each cask against the design tables before this plan's verification gate closes; the basecamp `desc`-vs-spec row is a known expected fail. Reconciliation requires a `HOMEBREW_TAP_PAT` holder, so the staff-engineer files an issue per failing row at `forwardimpact/homebrew-tap` (title pattern `spec/740: <cask> drift — <criterion>`) and assigns `release-engineer`. SC4 conditionally passes for clean rows and remains pending for failing rows until each tap-side issue closes.
-
-## Known limitations (visible from this plan; surface as follow-up, not blocking)
-
-- **`fit-basecamp.rb` placeholder URL resolves to a 404 after the first `outpost@v*` release.** The workflow's case statement maps `outpost@v*` to `CASK=fit-outpost`, never `fit-basecamp`; the sed step never updates `fit-basecamp.rb`. The basecamp cask's `url` interpolates `outpost@v#{version}` against the cask's own placeholder `version "0.0.0"`, resolving to a non-existent release. A user who runs `brew install --cask fit-basecamp` after deprecation sees a 404 rather than the cleaner deprecation error. The cask has no `app` or `binary` so install was never the intended path — `brew search` discoverability is the contract — but the failure mode is worth tracking. Owner: `release-engineer` files a follow-up issue at `forwardimpact/homebrew-tap` titled `fit-basecamp: replace placeholder url with versionless deprecated stub` after this plan merges.
+- **Cask drift from design.** The tap was seeded externally (commit "feat: seed tap with initial casks", state-of.md § Step 3). Step 10 audits each cask against the design tables before this plan's verification gate closes. Reconciliation requires a `HOMEBREW_TAP_PAT` holder, so the staff-engineer files an issue per failing row at `forwardimpact/homebrew-tap` (title pattern `spec/740: <cask> drift — <criterion>`) and assigns `release-engineer`. SC4 conditionally passes for clean rows and remains pending for failing rows until each tap-side issue closes.
 
 ## Execution
 
@@ -415,7 +406,7 @@ Three strands. The two PR-shipping strands (steps 1–7 and 8–9) and the verif
 | --- | --- | --- | --- |
 | 1, 2, 3, 4, 5, 6, 7 | `staff-engineer` | `feat(740): consolidate gear bundle into publish-brew + justfile` | All monorepo edits in one branch. Steps 1–5 are workflow YAML; step 6 is the justfile; step 7 is plist creation/deletion. |
 | 8, 9 | `technical-writer` | `docs(740): homebrew cask conventions` | Conventions doc + internals card in one branch. Step 8 lands first within the PR's commit history so step 9's `part:card:release` partial resolves at build time. Independent of the consolidation PR; can land in either order. |
-| 10, 11 | `staff-engineer` (audit) + macOS host (sed dry-run) | (verification only — no monorepo PR) | Audit log filed as a comment on this plan's PR. Step 11's `brew style` dry-run requires a macOS arm64 host with Homebrew installed; if the runner is Linux-only, defer step 11 to the release-engineer's first `gear@v*` rehearsal. Tap-side reconciliation issues, if any, are opened separately at `forwardimpact/homebrew-tap` and assigned to the release-engineer. |
+| 10, 11 | `staff-engineer` (audit) + macOS host (sed dry-run) | (verification only — no monorepo PR) | Audit log filed as a comment on this plan's PR. Step 11's `brew style` dry-run requires a macOS arm64 host with Homebrew installed; if the runner is Linux-only, defer step 11 to the release-engineer's first `gear@v*` rehearsal. |
 
 Sequencing: 1–7 ‖ 8–9 (parallel); 10–11 follows the consolidation PR merge for context, but does not block on it (the audit can run against tap main any time).
 

--- a/specs/740-seed-homebrew-tap/plan-a.md
+++ b/specs/740-seed-homebrew-tap/plan-a.md
@@ -372,8 +372,6 @@ graph TD
 | `fit-outpost` | `fit-outpost` | 1 |
 | `fit-gear` | `fit-svcgraph`, `fit-svcmcp`, `fit-svcpathway`, `fit-svctrace`, `fit-svcvector`, `fit-codegen`, `fit-terrain`, `fit-eval`, `fit-doc`, `fit-rc`, `fit-xmr`, `fit-storage`, `fit-logger`, `fit-svscan`, `fit-trace`, `fit-visualize`, `fit-query`, `fit-subjects`, `fit-process-graphs`, `fit-process-resources`, `fit-process-vectors`, `fit-search`, `fit-unary`, `fit-tiktoken`, `fit-download-bundle` | 25 |
 
-Tables in the doc are denormalized from the design so editing one cask's conventions doesn't require touching the design. The conventions doc is the long-lived reference for tap reviewers; once it lands, the tap README's existing link to `https://www.forwardimpact.team/docs/internals/release/` resolves (the README already targets this URL — no monorepo edit to the tap README is needed).
-
 Verify: `bunx fit-doc build --src=websites/fit` exits 0 and produces `dist/docs/internals/release/index.html`; `grep -c '^## ' websites/fit/docs/internals/release/index.md` returns exactly `9` (one per row of the table above — Overview, Sed contract, Cask topology, Binary stanza mapping, Livecheck regex pattern, App install path, Zap and uninstall paths, Verification commands, What's next).
 
 ### 9. Add the release card to the internals hub
@@ -391,22 +389,13 @@ No files created or modified inside the monorepo. The seven cask files exist on 
 - For each cask, confirm the stanzas design § Cask Anatomy prescribes are present in the prescribed shape: `version`, `sha256`, `url`, `name`, `desc`, `homepage`, `depends_on arch: :arm64`, `app … target: "Forward Impact/…"`, `binary` stanzas referencing `#{appdir}/Forward Impact/…`, `livecheck` block with `:github_releases` strategy and anchored regex, `zap trash:` clause.
 - Cross-check binary stanzas against design § Binary Stanza Mapping — exact name match, no extras, no omissions: 25 entries for `fit-gear.rb`, one entry per product cask.
 
-Reconciliation: the staff-engineer cannot push to `forwardimpact/homebrew-tap` (no `HOMEBREW_TAP_PAT`). For each failing row, file a comment on this plan's PR with the deviation and open a tap-side issue at `forwardimpact/homebrew-tap` titled `spec/740: <cask> drift — <criterion>`, assigning the release-engineer. SC3 ("executable names match … performed at seed time") passes for the casks whose audit row is clean, and is conditionally pending for any failing row until the tap-side reconciliation issue closes.
+Reconciliation: the staff-engineer cannot push to `forwardimpact/homebrew-tap` (no `HOMEBREW_TAP_PAT`). For each failing row, file a comment on this plan's PR with the deviation and open a tap-side issue at `forwardimpact/homebrew-tap` titled `spec/740: <cask> drift — <criterion>`, assigning the release-engineer. SC4 ("executable names match … performed at seed time") passes for the casks whose audit row is clean, and is conditionally pending for any failing row until the tap-side reconciliation issue closes.
 
 Verify: a written audit log enumerates each cask with a pass/fail row per criterion; every failing row carries a tap-side issue link assigned to `release-engineer` (no failing row is left unowned).
 
 ### 11. Dry-run the workflow's sed contract against each live cask
 
-No files created or modified. The dry-run runs the workflow's literal `sed -i` against each live cask with sample values, confirms the diff is exactly two changed lines, then runs `brew style` against the rewritten file.
-
-Host requirement: the workflow runs on `ubuntu-latest` (GNU sed). The dry-run must replicate the same `sed` semantics. Two options:
-
-1. **Linux host with Linuxbrew.** Native GNU sed; install Homebrew on Linux and `brew tap homebrew/cask`. Cask support on Linuxbrew is partial and may surface false negatives on `brew style` cask-specific rules, so accept that style failures from this host need a macOS confirmation pass.
-2. **macOS arm64 with `gnu-sed` installed.** Run `brew install gnu-sed` and substitute `gsed` for `sed` in the loop below — BSD sed's `-i` requires a backup suffix as the next argument and would treat the leading `-e` as the suffix, so the literal contract does not run on default macOS sed.
-
-The two options exist because the literal `sed` on `ubuntu-latest` is GNU; replicating it on macOS requires `gsed`.
-
-If neither host is available to the `staff-engineer` agent, defer this step to the release-engineer's first `gear@v*` release rehearsal — at which point spec **SC2** (sed substitution dry-run) is verified by the rehearsal itself rather than by this plan. The plan close-out audit log records SC2 as deferred-to-rehearsal in that case. Deadline: the deferral expires when the first `gear@v*` or product `@v*` tag is pushed; SC2 must be verified before that tag, because a broken sed contract would cause the `tap-pr` job to fail on a real release.
+No files created or modified. Run the workflow's literal `sed -i` against each live cask with sample values, confirm the diff is exactly two changed lines, then run `brew style` and `brew audit --new-cask` against the rewritten file. On macOS, use `gsed` (install via `brew install gnu-sed`) — see Risks § GNU sed requirement.
 
 ```sh
 # Linux: use `sed`. macOS: install gnu-sed and substitute `gsed` for `sed` below.
@@ -426,11 +415,12 @@ for CASK in fit-pathway fit-map fit-guide fit-landmark fit-summit fit-outpost fi
   CHANGED=$(diff "/tmp/${CASK}.rb.bak" "Casks/${CASK}.rb" | grep -c '^[<>]')
   test "$CHANGED" -eq 4 || { echo "FAIL ${CASK}: expected 4 changed-line markers, got ${CHANGED}"; exit 1; }
   brew style "Casks/${CASK}.rb"
+  brew audit --new-cask "Casks/${CASK}.rb"
   mv "/tmp/${CASK}.rb.bak" "Casks/${CASK}.rb"
 done
 ```
 
-Verify: every iteration of the loop produces a clean `brew style` (exit 0) with no `FAIL` line emitted; the loop exits 0 overall.
+Verify: every iteration produces clean `brew style` and `brew audit --new-cask` (both exit 0) with no `FAIL` line emitted; the loop exits 0 overall.
 
 ## Libraries used: none.
 
@@ -442,13 +432,14 @@ How each spec § Success criterion is verified by this plan, and which carry con
 | --- | --- | --- |
 | SC1 (every bundle has a cask in the tap) | Tap state already satisfies (7 cask files on `forwardimpact/homebrew-tap/main`); step 10's audit re-confirms | Pass |
 | SC2 (sed contract succeeds against every live cask) | Step 11 dry-run | Pass on macOS-arm64 / gnu-sed or Linux/Linuxbrew; **deferred to release-engineer's first `gear@v*` rehearsal** if no compatible host is available |
-| SC3 (each live cask passes `brew style` / `brew audit --new-cask`) | Step 11 (`brew style`) | Pass; same host caveat as SC2 |
+| SC3 (each live cask passes `brew style` / `brew audit --new-cask`) | Step 11 (`brew style` + `brew audit --new-cask`) | Pass; same host caveat as SC2 |
 | SC4 (executable names match bundle source) | Step 10 audit | Pass for clean rows; **conditionally pending for any failing audit row** until the matching tap-side reconciliation issue closes |
 | SC5 (conventions doc covers every cross-cutting decision) | Step 8 (9-section heading check) | Pass |
 
 ## Risks
 
 - **`HOMEBREW_TAP_PAT` not yet provisioned on the monorepo.** The `tap-pr` job at line 190 authenticates against `forwardimpact/homebrew-tap` via `secrets.HOMEBREW_TAP_PAT`. State-of audit § Must-have item 5 flags this secret as not yet set on `forwardimpact/monorepo`. This plan does not add the secret — a repo admin (release-engineer) creates it out-of-band (classic PAT scoped `repo` to `forwardimpact/homebrew-tap` only, ≤ 1-year expiry) before the first `gear@v*` or product tag is pushed, or `tap-pr` will fail at checkout. Owner: `release-engineer`. Verification gate: secret presence audit during the first `kata-release-cut` rehearsal that follows this plan's merge.
+- **GNU sed requirement for step 11.** The workflow runs on `ubuntu-latest` (GNU sed). BSD sed's `-i` requires a backup suffix, so the literal sed contract does not run on default macOS sed. On macOS, install `gnu-sed` (`brew install gnu-sed`) and substitute `gsed` for `sed`. If neither a Linux host nor `gsed` is available, defer step 11 to the release-engineer's first `gear@v*` release rehearsal. Deadline: SC2/SC3 must be verified before the first release tag is pushed.
 - **Cask drift from design.** The tap was seeded externally (commit "feat: seed tap with initial casks", state-of.md § Step 3). Step 10 audits each cask against the design tables before this plan's verification gate closes. Reconciliation requires a `HOMEBREW_TAP_PAT` holder, so the staff-engineer files an issue per failing row at `forwardimpact/homebrew-tap` (title pattern `spec/740: <cask> drift — <criterion>`) and assigns `release-engineer`. SC4 conditionally passes for clean rows and remains pending for failing rows until each tap-side issue closes.
 
 ## Execution

--- a/specs/740-seed-homebrew-tap/plan-a.md
+++ b/specs/740-seed-homebrew-tap/plan-a.md
@@ -64,9 +64,9 @@ Verify: `grep -E '^\s+- "[a-z]+@v\*"' .github/workflows/publish-brew.yml | wc -l
 
 ### 2. Collapse both `case "$NAME"` blocks onto a single `gear` branch
 
-File modified: `.github/workflows/publish-brew.yml`. Two identical-shape blocks: the `build` job's "Extract bundle and version from tag" step (lines 33–37) and the `tap-pr` job's "Extract bundle and version from tag" step (lines 158–162).
+File modified: `.github/workflows/publish-brew.yml`. Two case blocks need updating: the `build` job's "Extract bundle and version from tag" step (lines 33–37) and the `tap-pr` job's "Extract bundle and version from tag" step (lines 158–161). The blocks differ — the `build` block sets `KIND`, `BUNDLE`, and `CASK`; the `tap-pr` block sets only `KIND` and `CASK` (no `BUNDLE`). Replace each separately:
 
-Replace each occurrence:
+**Build job** (lines 33–37):
 
 ```sh
 # Before
@@ -83,7 +83,22 @@ case "$NAME" in
 esac
 ```
 
-The `tap-pr` block today omits `BUNDLE` from the `${GITHUB_OUTPUT}` echoes; preserve that omission.
+**Tap-pr job** (lines 158–161 — no `BUNDLE` variable):
+
+```sh
+# Before
+case "$NAME" in
+  services)   KIND=services;   CASK=fit-services  ;;
+  utilities)  KIND=utilities;  CASK=fit-utilities ;;
+  *)          KIND=product;    CASK=fit-${NAME}   ;;
+esac
+
+# After
+case "$NAME" in
+  gear)  KIND=gear;     CASK=fit-gear    ;;
+  *)     KIND=product;  CASK=fit-${NAME} ;;
+esac
+```
 
 Verify: `grep -n 'KIND=services\|KIND=utilities\|fit-services\|fit-utilities\|FIT Services\|FIT Utilities' .github/workflows/publish-brew.yml` returns no matches.
 
@@ -310,14 +325,52 @@ Body sections (one section per cross-cutting decision named in spec § In scope;
 | Section heading | Coverage |
 | --- | --- |
 | `## Overview` | The tap repo's role; the `publish-brew.yml` workflow's role; where each authored field lives. Two paragraphs. |
-| `## Sed contract` | The two fields the workflow rewrites (`version`, `sha256`); literal `sed -i` invocation; required two-space indent + double-quoted shape; what survives unchanged across releases. |
-| `## Cask topology` | No inter-cask `depends_on`; six product casks each expose one CLI; `fit-gear` exposes 25 CLIs. Reproduce the Mermaid diagram from design § Cask Topology — the conventions doc is the long-lived reference for tap reviewers and stands on its own without a hop to the design. |
-| `## Binary stanza mapping` | Authoritative table — same rows as design § Binary Stanza Mapping. |
+| `## Sed contract` | The two fields the workflow rewrites (`version`, `sha256`); literal `sed -i` invocation (verbatim block below); required two-space indent + double-quoted shape; what survives unchanged across releases. |
+| `## Cask topology` | No inter-cask `depends_on`; six product casks each expose one CLI; `fit-gear` exposes 25 CLIs. Include the Mermaid diagram verbatim (below). |
+| `## Binary stanza mapping` | Authoritative table (verbatim below). |
 | `## Livecheck regex pattern` | `:github_releases` strategy with the cask's own download URL; per-cask `^{name}@v(\d+(?:\.\d+)+)$` regex anchoring; rationale for `^...$` against the multi-bundle releases page. |
 | `## App install path` | `Forward Impact/` subdirectory under `/Applications/`; how `app` and `binary` stanzas reference it; why grouping (vs. flat install) was chosen. |
 | `## Zap and uninstall paths` | `~/Library/Preferences/team.forwardimpact.{name}.plist` per cask; one row per cask. |
 | `## Verification commands` | `brew style Casks/*.rb` and `brew audit --new-cask Casks/{cask}.rb`; what a human reviewer runs before merging a tap PR; how to dry-run the workflow's sed locally. |
 | `## What's next` | Partial-card grid (`<!-- part:card:... -->` only — no markdown link cards per `websites/CLAUDE.md`). Targets: `../operations`, `../kata`. Maximum four cards. |
+
+Verbatim content for sections referencing the design:
+
+**Sed contract** — include this code block:
+
+```sh
+sed -i \
+  -e "s|^  version \".*\"|  version \"${VERSION}\"|" \
+  -e "s|^  sha256 \".*\"|  sha256 \"${SHA256}\"|" \
+  "tap/Casks/${CASK}.rb"
+```
+
+**Cask topology** — include this Mermaid diagram:
+
+```mermaid
+graph TD
+    subgraph Products
+        pathway[fit-pathway]
+        map[fit-map]
+        guide[fit-guide]
+        landmark[fit-landmark]
+        summit[fit-summit]
+        outpost[fit-outpost]
+    end
+    gear[fit-gear]
+```
+
+**Binary stanza mapping** — include this table:
+
+| Cask | Executables on PATH | Count |
+| --- | --- | --- |
+| `fit-pathway` | `fit-pathway` | 1 |
+| `fit-map` | `fit-map` | 1 |
+| `fit-guide` | `fit-guide` | 1 |
+| `fit-landmark` | `fit-landmark` | 1 |
+| `fit-summit` | `fit-summit` | 1 |
+| `fit-outpost` | `fit-outpost` | 1 |
+| `fit-gear` | `fit-svcgraph`, `fit-svcmcp`, `fit-svcpathway`, `fit-svctrace`, `fit-svcvector`, `fit-codegen`, `fit-terrain`, `fit-eval`, `fit-doc`, `fit-rc`, `fit-xmr`, `fit-storage`, `fit-logger`, `fit-svscan`, `fit-trace`, `fit-visualize`, `fit-query`, `fit-subjects`, `fit-process-graphs`, `fit-process-resources`, `fit-process-vectors`, `fit-search`, `fit-unary`, `fit-tiktoken`, `fit-download-bundle` | 25 |
 
 Tables in the doc are denormalized from the design so editing one cask's conventions doesn't require touching the design. The conventions doc is the long-lived reference for tap reviewers; once it lands, the tap README's existing link to `https://www.forwardimpact.team/docs/internals/release/` resolves (the README already targets this URL — no monorepo edit to the tap README is needed).
 
@@ -353,7 +406,7 @@ Host requirement: the workflow runs on `ubuntu-latest` (GNU sed). The dry-run mu
 
 The two options exist because the literal `sed` on `ubuntu-latest` is GNU; replicating it on macOS requires `gsed`.
 
-If neither host is available to the `staff-engineer` agent, defer this step to the release-engineer's first `gear@v*` release rehearsal — at which point spec **SC2** (sed substitution dry-run) is verified by the rehearsal itself rather than by this plan. The plan close-out audit log records SC2 as deferred-to-rehearsal in that case.
+If neither host is available to the `staff-engineer` agent, defer this step to the release-engineer's first `gear@v*` release rehearsal — at which point spec **SC2** (sed substitution dry-run) is verified by the rehearsal itself rather than by this plan. The plan close-out audit log records SC2 as deferred-to-rehearsal in that case. Deadline: the deferral expires when the first `gear@v*` or product `@v*` tag is pushed; SC2 must be verified before that tag, because a broken sed contract would cause the `tap-pr` job to fail on a real release.
 
 ```sh
 # Linux: use `sed`. macOS: install gnu-sed and substitute `gsed` for `sed` below.

--- a/specs/740-seed-homebrew-tap/spec.md
+++ b/specs/740-seed-homebrew-tap/spec.md
@@ -13,9 +13,6 @@ fails downstream of this gap:
 - The workflow's tag filter on lines 9–16 covers seven bundles — `outpost`,
   `guide`, `landmark`, `map`, `pathway`, `summit`, `gear` — all of which require
   a corresponding `Casks/{cask}.rb` to be updateable on release.
-- Issue #625 phase 8a was scoped as "copy `Casks/fit-basecamp.rb` →
-  `Casks/fit-outpost.rb`". The source cask does not exist either, so phase 8a
-  cannot run as written.
 - Issue #627 documents 20+ consecutive brew-publish failures (earliest visible:
   2026-04-28; most recent: 2026-04-30 21:35Z) for all five product publishes
   attempted to date. The runtime `__dirname`/bunfs failure that #627 names is
@@ -23,9 +20,8 @@ fails downstream of this gap:
   surface because the smoke test fails first.
 
 The first cask authored sets the precedent the next six inherit. The livecheck
-regex shape against the `<bundle>@v<semver>` tag scheme, the binary stanzas that
-surface every CLI on PATH, and the deprecation precedent for the
-`basecamp → outpost` rename are cross-cutting first-mover decisions. Authoring
+regex shape against the `<bundle>@v<semver>` tag scheme and the binary stanzas
+that surface every CLI on PATH are cross-cutting first-mover decisions. Authoring
 them once, in concert, is qualitatively different from copy-pasting an existing
 template — there is no template yet.
 
@@ -39,9 +35,8 @@ Two distribution promises are unmet until the tap is seeded:
    `fit-gear` bundle is independently installable for users who also want the
    service and library CLIs. Today no `brew install` command resolves at all —
    the tap has no casks to install.
-2. **Issue #625 8a–8d.** The Outpost rename's cross-repo follow-ups (cask
-   author, tag, npm deprecate, release notes) are blocked behind 8a. 8b/8c/8d
-   remain queued.
+2. **Issue #625 8b–8d.** The Outpost rename's cross-repo follow-ups (tag, npm
+   deprecate, release notes) are blocked behind this spec's tap seeding.
 
 Seeding the tap also retires a class of confusion. The publish-brew workflow's
 existing comment ("the rest of the cask body — depends_on graph, binary stanzas,
@@ -54,10 +49,9 @@ can fulfill.
 
 ### In scope
 
-- Authoring seven live casks plus one deprecated cask in
-  `forwardimpact/homebrew-tap`, written in concert so the livecheck strategy,
-  binary stanzas, zap/uninstall paths, and the publish-brew sed contract are
-  consistent across all of them.
+- Authoring seven casks in `forwardimpact/homebrew-tap`, written in concert so
+  the livecheck strategy, binary stanzas, zap/uninstall paths, and the
+  publish-brew sed contract are consistent across all of them.
 - A cask conventions document inside the monorepo, under
   `websites/fit/docs/internals/release/`. The tap repo's README links to it but
   does not duplicate it. Rationale: the conventions describe an artifact whose
@@ -65,14 +59,6 @@ can fulfill.
   the conventions decay together with the workflow when either changes, and
   review of a workflow PR co-locates with review of the conventions PR. Exact
   filename and any further sub-pathing are plan-level decisions.
-- A deprecated `fit-basecamp` cask whose visible properties redirect legacy
-  users to `fit-outpost`: deprecation date 2026-04-30 (matching #625 8a),
-  rename-reason rationale, and a description that names the storage-path
-  manual-migration command from #625 8d. Reason: legacy users who run
-  `brew search fit-basecamp` after the tap is published must be told the cask is
-  deprecated and pointed at the rename target; an absent cask surfaces nothing,
-  and a live cask with no deprecation property lies about supported state.
-
 ### Out of scope
 
 - The runtime `__dirname`/bunfs fix tracked in #627. That is a substantive
@@ -106,7 +92,6 @@ All seven bundles whose tags `publish-brew.yml` accepts:
 | `summit@v*`   | `fit-summit`   | product          | `fit-summit.app` |
 | `outpost@v*`  | `fit-outpost`  | product          | `fit-outpost.app`|
 | `gear@v*`     | `fit-gear`     | shared           | `fit-gear.app`   |
-| (none)        | `fit-basecamp` | deprecated alias | (none)           |
 
 ## Success criteria
 
@@ -116,11 +101,10 @@ unrelated runtime fix to land first.
 
 | Claim                                                                                                                                                                                                                            | Verifiable by                                                                                                                                                                                                                                                                                                                                             |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Every bundle that `publish-brew.yml` accepts has a corresponding cask in the tap, plus a deprecated alias for the basecamp → outpost rename.                                                                                     | `gh api repos/forwardimpact/homebrew-tap/contents/Casks` returns eight entries matching the table above.                                                                                                                                                                                                                                                  |
+| Every bundle that `publish-brew.yml` accepts has a corresponding cask in the tap.                                                                                                                                                 | `gh api repos/forwardimpact/homebrew-tap/contents/Casks` returns seven entries matching the table above.                                                                                                                                                                                                                                                  |
 | The `tap-pr` job's sed step (lines 210–213 of `publish-brew.yml`) succeeds against every live cask without manual edits.                                                                                                         | A dry-run of the workflow's sed substitutions executed against each live cask file modifies exactly one occurrence per field; the resulting cask still parses under `brew style`.                                                                                                                                                                         |
 | Each live cask passes Homebrew's authoring checks.                                                                                                                                                                               | `brew style Casks/*.rb` exits 0 against the seeded tap and `brew audit --new-cask Casks/{cask}.rb` exits 0 for each live cask.                                                                                                                                                                                                                            |
 | For each cask, the executable names it advertises match the executable names produced by that cask's source bundle.                                                                                                               | A static cross-check between each cask file and the corresponding product or gear bundle's declared executables (e.g. `package.json` `bin` entries or the `just build-binary` invocations) shows the cask advertises exactly those names with no extras. Performed at seed time, before any tag is pushed.                                                |
-| `fit-basecamp` is discoverable by `brew search` once the tap is published and is visibly deprecated, redirecting users to `fit-outpost`.                                                                                         | After `brew tap forwardimpact/tap`, `brew search fit-basecamp` lists the cask and `brew info fit-basecamp` shows the deprecation date 2026-04-30, the rename rationale, and references `fit-outpost` as the rename target.                                                                                                                                |
 | The conventions doc covers every cross-cutting decision named in the In-scope section.                                                                                                                                           | A document under `websites/fit/docs/internals/release/` exists, is linked from the release-internals index and the tap repo's `README.md`, and addresses each cross-cutting decision the In-scope section names. The document's structure is a plan-level decision; the contract is coverage, not heading shape.                                          |
 
 ## Notes
@@ -133,9 +117,6 @@ unrelated runtime fix to land first.
   each cask. Every other authored field is human-edited in the tap repo and
   survives releases unchanged. Casks must be authored with that asymmetry in
   mind.
-- The `fit-basecamp` deprecation date `2026-04-30` matches the date stipulated
-  in #625 phase 8a and aligns with the Outpost rename's clean-break stance
-  (USPTO Reg. 3202059).
 - This spec lives in the monorepo because the design and plan that follow
   describe how monorepo conventions and tap conventions stay coherent. The
   resulting cask files land in `forwardimpact/homebrew-tap`, which is outside

--- a/specs/740-seed-homebrew-tap/state-of.md
+++ b/specs/740-seed-homebrew-tap/state-of.md
@@ -6,7 +6,7 @@ Research date: 2026-05-04
 
 Spec 740 has three goals: (1) seed the tap, (2) consolidate shared bundles into
 `fit-gear`, and (3) document the brew install path on product pages. The tap is
-now seeded — `forwardimpact/homebrew-tap` contains 8 cask files reflecting the
+now seeded — `forwardimpact/homebrew-tap` contains 7 cask files reflecting the
 gear consolidation. But the monorepo side is not yet updated: `publish-brew.yml`
 still accepts `services@v*` and `utilities@v*` tags (not `gear@v*`), the
 justfile still has separate `build-app-services` / `build-app-utilities`
@@ -74,15 +74,15 @@ sed -i \
   "tap/Casks/${CASK}.rb"
 ```
 
-### Step 2b — Basecamp/Outpost TCC verification: NO EVIDENCE
+### Step 2b — Outpost TCC verification: NO EVIDENCE
 
-No explicit record of the manual hardware TCC test. Outpost was renamed from
-Basecamp post-spec-600; the TCC responsibility chain should be re-verified
-against the Outpost bundle identity before the first `outpost@v*` tag.
+No explicit record of the manual hardware TCC test. The TCC responsibility
+chain should be verified against the Outpost bundle identity before the first
+`outpost@v*` tag.
 
 ### Step 3 — Homebrew tap repository: SEEDED
 
-`forwardimpact/homebrew-tap` was seeded on 2026-05-04 with 8 cask files:
+`forwardimpact/homebrew-tap` was seeded on 2026-05-04 with 7 cask files:
 
 | Cask file          | Type       | CLIs on PATH |
 | ------------------ | ---------- | ------------ |
@@ -93,13 +93,10 @@ against the Outpost bundle identity before the first `outpost@v*` tag.
 | `fit-summit.rb`    | product    | 1            |
 | `fit-outpost.rb`   | product    | 1            |
 | `fit-gear.rb`      | shared     | 25           |
-| `fit-basecamp.rb`  | deprecated | 0            |
 
 All casks use placeholder version `0.0.0` and zero sha256. The `fit-gear` cask
-contains 5 gRPC service binaries and 20 library CLI binaries. The
-`fit-basecamp` cask is deprecated (date 2026-04-30) and points to
-`fit-outpost`. No `depends_on cask:` between casks — all are independently
-installable.
+contains 5 gRPC service binaries and 20 library CLI binaries. No
+`depends_on cask:` between casks — all are independently installable.
 
 The commit message: "feat: seed tap with initial casks".
 
@@ -137,7 +134,7 @@ consolidation in the monorepo, tap seeding (done), and documentation.
 
 ### What spec 740 covers (updated)
 
-Eight cask files for the tap repo (already seeded):
+Seven cask files for the tap repo (already seeded):
 1. `fit-pathway.rb` — product cask
 2. `fit-map.rb` — product cask
 3. `fit-guide.rb` — product cask
@@ -145,7 +142,6 @@ Eight cask files for the tap repo (already seeded):
 5. `fit-summit.rb` — product cask
 6. `fit-outpost.rb` — product cask
 7. `fit-gear.rb` — shared bundle (5 gRPC servers + 20 library CLIs)
-8. `fit-basecamp.rb` — deprecated alias → `fit-outpost`
 
 Plus monorepo changes:
 - Consolidate `build-app-services` / `build-app-utilities` into gear
@@ -172,9 +168,7 @@ Resolved by the tap seeding commit. The tap now contains 8 cask files.
 
 ### #625 — Outpost rename: Phase 8 cross-repo follow-ups: OPEN
 
-Phases 8a–8d status:
-- **8a**: Author `fit-outpost.rb` cask + deprecate `fit-basecamp` — **DONE**
-  (both casks exist in the tap)
+Phases 8b–8d status:
 - **8b**: Tag `outpost@v3.0.0`, verify publish-brew + publish-macos — blocked
   by workflow gear consolidation
 - **8c**: `npm deprecate @forwardimpact/basecamp` — independent, can proceed
@@ -257,7 +251,7 @@ fit-process-vectors, fit-search, fit-unary, fit-tiktoken, fit-download-bundle
 
 ### Must-have (blocks end-to-end brew install)
 
-1. ~~**Seed the tap** (spec 740)~~: **DONE.** 8 cask files landed in
+1. ~~**Seed the tap** (spec 740)~~: **DONE.** 7 cask files landed in
    `forwardimpact/homebrew-tap`.
 2. **Consolidate monorepo build to gear** (spec 740): Update
    `publish-brew.yml` tag filter (`gear@v*` replaces `services@v*` +


### PR DESCRIPTION
## Summary

- Remove all `fit-basecamp` references from `plan-a.md` to match spec and design updates (c8a73cc)
- Adjust cask counts from 8 to 7, SC numbering (SC6→SC5), conventions doc heading count (10→9)
- Drop the "Known limitations" section about fit-basecamp placeholder URL
- Clean up success-criteria mapping and risks sections

## Context

The spec and design were updated to remove `fit-basecamp` from scope after the
plan was merged via PR #755. This PR brings the plan into alignment.

## Test plan

- [x] `grep -n 'basecamp' specs/740-seed-homebrew-tap/plan-a.md` returns no matches
- [x] SC numbering matches the updated spec's success criteria table
- [x] Cask counts consistently say 7 throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)