### PR TITLE
refactor(kata-skills): normalise formatting and generics across all 15 skills

### DIFF
--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -11,11 +11,11 @@ description: >
 # Write and Review Designs
 
 A design defines WHICH components exist, WHERE they interact, and what
-interfaces connect them. It sits between the
-[`kata-spec`](../kata-spec/SKILL.md) skill (WHAT/WHY) and the
-[`kata-plan`](../kata-plan/SKILL.md) skill (HOW/WHEN). The spec captures the
-problem and scope; the design captures components, interfaces, and data flow;
-the plan translates those into file-level changes and execution ordering.
+interfaces connect them. Design sits in the
+[spec](../kata-spec/SKILL.md) → design → [plan](../kata-plan/SKILL.md) →
+[implement](../kata-implement/SKILL.md) pipeline: the spec captures WHAT/WHY,
+the design captures WHICH/WHERE, the plan captures HOW/WHEN, and implementation
+executes the plan.
 
 **A design requires an existing approved spec.** Without an approved spec there
 is no commitment to implement, and a design has nothing to shape.
@@ -142,24 +142,41 @@ label.
 
 Read memory per the agent profile (your summary, the current week's log, and
 teammates' summaries). Extract specs previously designed and any deferred work
-from prior `staff-engineer` entries.
+from prior entries.
 
-### Steps
+### Step 1: Find the spec
 
-1. **Find the spec.** Run `git fetch origin main`, then require
-   `specs/NNN/spec.md` on `origin/main`; otherwise stop. An open spec PR with
-   `spec:approved` does not satisfy this — wait for the merge.
-2. **Study the spec.** Read `spec.md` end to end.
-3. **Research the codebase.** Read the code areas the spec targets.
-4. **Write the design.** Create `design-a.md`. Stay under 200 lines. Each
-   architectural choice names a rejected alternative.
-5. **Open a `design(NNN): …` PR.** The PR title carries the spec id.
-6. **Clean sub-agent review panel.** Follow the
-   [`kata-review` caller protocol](../kata-review/references/caller-protocol.md).
-   Tell each reviewer not to invoke `kata-design`. Address every confirmed
-   blocker/high/medium finding before advancing.
-7. **Apply approval signal.** When the panel passes, run
-   `gh pr edit <number> --add-label design:approved`.
+Run `git fetch origin main`, then confirm `specs/NNN/spec.md` exists on
+`origin/main`. An open PR with a `spec:approved` label is not sufficient — wait
+for the merge.
+
+### Step 2: Study the spec
+
+Read `spec.md` end to end.
+
+### Step 3: Research the codebase
+
+Read the code areas the spec targets.
+
+### Step 4: Write the design
+
+Create `design-a.md`. Stay under 200 lines. Each architectural choice names a
+rejected alternative.
+
+### Step 5: Open a design PR
+
+The PR title carries the spec id: `design(NNN): …`.
+
+### Step 6: Clean sub-agent review panel
+
+Follow the [`kata-review` caller
+protocol](../kata-review/references/caller-protocol.md). Tell each reviewer not
+to invoke `kata-design`. Address every confirmed blocker/high/medium finding
+before advancing.
+
+### Step 7: Apply approval signal
+
+When the panel passes, run `gh pr edit <number> --add-label design:approved`.
 
 ## Memory: what to record
 
@@ -170,6 +187,6 @@ Append to the current week's log (see agent profile for the file path):
   context)
 - **Deferred specs** — Specs skipped and why (not approved, missing info, etc.)
 
-This skill produces a design document — work-in-progress for the downstream plan
-and implementation — so it does not record metrics. See KATA.md § Metrics for
-the recording-eligibility rule.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.

--- a/.claude/skills/kata-design/references/metrics.md
+++ b/.claude/skills/kata-design/references/metrics.md
@@ -1,0 +1,10 @@
+# Metrics — Design
+
+Record per KATA.md § Metrics. Append one row per run.
+
+| Metric          | Unit  | Description                          | Data source |
+| --------------- | ----- | ------------------------------------ | ----------- |
+| designs_drafted | count | Design PRs opened or merged this run | gh pr list  |
+
+Design backlog (`specs/` with `spec.md` but no `design-a.md`) is queried,
+not recorded.

--- a/.claude/skills/kata-documentation/SKILL.md
+++ b/.claude/skills/kata-documentation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kata-documentation
 description: >
-  Write and review documentation in the websites/fit/ folder. Scheduled runs review
+  Write and review documentation in the websites/ folder. Scheduled runs review
   one topic in depth for accuracy, audience purity, and staleness. Interactive
   runs write or update pages following documentation standards. Use when
   writing, editing, auditing, or reviewing documentation, or running scheduled
@@ -19,7 +19,7 @@ modes of operation:
 ## When to Use
 
 - Scheduled documentation review (one topic per run)
-- Writing or updating pages in `websites/fit/`
+- Writing or updating pages in `websites/`
 - Auditing documentation accuracy against source code
 
 ## Checklists
@@ -56,15 +56,15 @@ Each run covers **one topic** in depth.
 
 | Topic                    | What to review                                                                        |
 | ------------------------ | ------------------------------------------------------------------------------------- |
-| `getting-started`        | `websites/fit/docs/getting-started/` — onboarding accuracy, CLI examples              |
-| `products`               | `websites/fit/docs/products/` — product-task accuracy, audience purity, completeness  |
-| `libraries`              | `websites/fit/docs/libraries/` — library-task accuracy, audience purity, completeness |
-| `services`               | `websites/fit/docs/services/` — service-task accuracy, audience purity, completeness  |
-| `reference`              | `websites/fit/docs/reference/` — CLI synopsis, entity definitions, schema             |
-| `internals`              | `websites/fit/docs/internals/` — architecture accuracy, code path validity            |
-| `product-pages`          | `websites/fit/{map,pathway,guide,outpost,landmark,summit,gear}/` — overviews          |
+| `getting-started`        | `websites/docs/getting-started/` — onboarding accuracy, CLI examples                  |
+| `products`               | `websites/docs/products/` — product-task accuracy, audience purity, completeness      |
+| `libraries`              | `websites/docs/libraries/` — library-task accuracy, audience purity, completeness     |
+| `services`               | `websites/docs/services/` — service-task accuracy, audience purity, completeness      |
+| `reference`              | `websites/docs/reference/` — CLI synopsis, entity definitions, schema                 |
+| `internals`              | `websites/docs/internals/` — architecture accuracy, code path validity                |
+| `product-pages`          | Product overview pages under `websites/` — overviews                                  |
 | `root-docs`              | `CLAUDE.md`, `CONTRIBUTING.md`, `KATA.md`, `SECURITY.md`                              |
-| `llms-txt-and-seo`       | `websites/fit/llms.txt`, `websites/fit/robots.txt`, sitemap completeness              |
+| `llms-txt-and-seo`       | `websites/llms.txt`, `websites/robots.txt`, sitemap completeness                      |
 | `cross-page-consistency` | Terminology, proficiency scales, field names across all pages                         |
 
 ### Step 0: Read Memory
@@ -91,9 +91,9 @@ teammates' summaries). Find last review dates per topic in the coverage map.
 4. Check audience purity — flag contributor content in user-facing pages (per
    [`references/standards.md`](references/standards.md)).
 5. Run CLI examples shown in docs, verify output matches.
-6. Check YAML examples against JSON schemas in `products/map/schema/json/`.
+6. Check YAML examples against the product's JSON schema directory.
 7. Verify all internal cross-links resolve.
-8. Run `bunx fit-doc build --src=websites/fit --out=dist` to confirm build.
+8. Run `bunx fit-doc build` to confirm build.
 9. Check `git log --oneline -20 -- <paths>` for recent code changes that may
    have invalidated docs.
 
@@ -120,14 +120,14 @@ Run the DO-CONFIRM checklist at the top of this skill.
    entity names against `data/pathway/`.
 6. **Add cross-links.** Guides → Reference for details. Getting Started → Guides
    for next steps. Internals → Reference for the user-facing model.
-7. **Build and check.** Run `bunx fit-doc build --src=websites/fit --out=dist`.
+7. **Build and check.** Run `bunx fit-doc build`.
 
 ### Updating existing pages
 
 1. Read the page and its source of truth — check actual code, not just docs.
 2. Check audience purity — move contributor content to Internals if needed.
 3. Verify CLI examples. Run every command shown.
-4. Verify YAML examples against `products/map/schema/json/`.
+4. Verify YAML examples against the product's JSON schema directory.
 5. Check cross-links resolve.
 6. Build and check.
 
@@ -164,10 +164,9 @@ Append to the current week's log (see agent profile for the file path):
 - **Deferred work** — Issues needing follow-up with enough context to resume
 - **Accuracy errors** — Specific docs that diverged from source code
 - **Memos sent** — Callouts dispatched via `fit-wiki memo` to agents whose work affects docs
-- **Metrics** — Record at least one measurement to
-  `wiki/metrics/{skill}/` per the
-  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
-  it with the header row. These feed XmR analysis in the storyboard meeting.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.
 
 ## Coordination Channels
 
@@ -175,7 +174,7 @@ This skill produces these non-wiki outputs (per
 [coordination-protocol.md](../../agents/references/coordination-protocol.md)):
 
 - **PR comment** — Doc-impact callouts on code PRs that change behaviour
-  documented in `websites/fit/`.
+  documented in `websites/`.
 - **Discussion** — Doc gaps that reflect an unsettled product question rather
   than a writing task.
 

--- a/.claude/skills/kata-documentation/references/source-of-truth.md
+++ b/.claude/skills/kata-documentation/references/source-of-truth.md
@@ -3,24 +3,15 @@
 When writing or reviewing documentation, verify claims against the canonical
 source. Never trust documentation alone — read the code.
 
-| Documentation topic | Verify against                                     |
-| ------------------- | -------------------------------------------------- |
-| Skills and levels   | `data/pathway/capabilities/`                       |
-| Behaviours          | `data/pathway/behaviours/`                         |
-| Disciplines         | `data/pathway/disciplines/`                        |
-| Tracks              | `data/pathway/tracks/`                             |
-| Levels              | `data/pathway/levels.yaml`                         |
-| Drivers             | `data/pathway/drivers.yaml`                        |
-| Job derivation      | `libraries/libskill/src/job.js`                    |
-| Agent derivation    | `libraries/libskill/src/agent.js`                  |
-| Map validation      | `products/map/src/`                                |
-| Pathway CLI         | `products/pathway/bin/fit-pathway.js`              |
-| Outpost CLI         | `products/outpost/bin/fit-outpost.js`              |
-| Landmark CLI        | `products/landmark/bin/fit-landmark.js`            |
-| Summit CLI          | `products/summit/bin/fit-summit.js`                |
-| Terrain CLI         | `libraries/libterrain/bin/fit-terrain.js`          |
-| Templates           | `products/pathway/templates/`                      |
-| JSON Schema         | `products/map/schema/json/`                        |
-| RDF/SHACL Schema    | `products/map/schema/rdf/`                         |
-| LLM / SEO outputs   | `websites/fit/llms.txt`, `websites/fit/robots.txt` |
-| Kata Agent Team     | `KATA.md`                                          |
+| Documentation topic  | Verify against                                   |
+| -------------------- | ------------------------------------------------ |
+| Entity definitions   | `data/pathway/` (capabilities, behaviours, etc.) |
+| Library derivations  | `libraries/{lib}/src/`                           |
+| Product validation   | `products/{product}/src/`                        |
+| Product CLIs         | `products/{product}/bin/fit-{product}.js`        |
+| Library CLIs         | `libraries/{lib}/bin/fit-{lib}.js`               |
+| Templates            | `products/{product}/templates/`                  |
+| JSON Schema          | `products/{product}/schema/json/`                |
+| RDF/SHACL Schema     | `products/{product}/schema/rdf/`                 |
+| LLM / SEO outputs    | `websites/llms.txt`, `websites/robots.txt`       |
+| Kata Agent Team      | `KATA.md`                                        |

--- a/.claude/skills/kata-documentation/references/standards.md
+++ b/.claude/skills/kata-documentation/references/standards.md
@@ -2,7 +2,7 @@
 
 ## Information Architecture
 
-Six-tier hierarchy under `websites/fit/docs/` serving four user groups
+Six-tier hierarchy under `websites/docs/` serving four user groups
 (Leadership, Engineers, Builders and Agents, Contributors):
 
 | Tier              | Intent                              | Subsections                                                                                                                                                                               |
@@ -40,8 +40,8 @@ libraries.
 **Reference is lookup, not tutorial.** Structured, scannable — no prose
 narrative.
 
-**Link to existing artifacts, don't duplicate.** Published JSON Schema lives at
-`/schema/json/` and RDF/SHACL at `/schema/rdf/` — link to them instead of
+**Link to existing artifacts, don't duplicate.** Published JSON Schema and
+RDF/SHACL live under the product's schema directory — link to them instead of
 reproducing. Published SKILL.md files link to Product Guides, Library Guides,
 and Reference markdown companions for progressive disclosure.
 
@@ -68,9 +68,9 @@ in the Authoring Standards guide; copies must match exactly.
 
 Tier names in `baseSkillProficiencies` match discipline `<tier>Skills` arrays.
 
-**Required/optional fields** — Verify against the JSON schema in
-`products/map/schema/json/`. The schema's `required` array is the single source
-of truth — do not guess from examples.
+**Required/optional fields** — Verify against the product's JSON schema
+directory. The schema's `required` array is the single source of truth — do not
+guess from examples.
 
 **Casing** — Table cells lowercase unless proper nouns or sentence starts.
 Proficiency levels always lowercase (`awareness`). Behaviour maturities

--- a/.claude/skills/kata-implement/SKILL.md
+++ b/.claude/skills/kata-implement/SKILL.md
@@ -64,12 +64,12 @@ apply alongside the skill-specific ones below.
 
 Read memory per the agent profile (your summary, the current week's log, and
 teammates' summaries). Extract specs previously implemented and any blockers
-from prior `staff-engineer` entries.
+from prior entries.
 
 > **Writing under `.claude/`:** If the plan targets files there, follow
 > [self-improvement.md](../../agents/references/self-improvement.md).
 
-### 1. Study the spec deeply
+### Step 1: Study the spec deeply
 
 Read every file in the spec directory — `spec.md`, all `plan-*.md` files, and
 any supporting documents. Understand the **problem** (the gap and its
@@ -78,7 +78,7 @@ out of scope), and the **success criteria** (what "done" looks like and how it
 is verified). Do not start coding until you can explain the problem and its
 boundaries without referring back to the spec.
 
-### 2. Select and study the plan
+### Step 2: Select and study the plan
 
 **Default rule: implement plan-a.** When multiple plan variants exist
 (`plan-a.md`, `plan-b.md`, etc.), implement `plan-a.md` unless the user or the
@@ -94,7 +94,7 @@ Read the selected plan thoroughly. Understand:
   what?
 - **Design decisions.** Why were non-obvious choices made?
 - **Execution recommendation.** How does the plan recommend executing — single
-  agent, or parallel `staff-engineer` agents for independent parts?
+  agent, or parallel engineering agents for independent parts?
 
 **Multi-part plans.** If the plan is decomposed into parts (`plan-a.md` +
 `plan-a-01.md`, `plan-a-02.md`, etc.), start by reading the overview in
@@ -102,10 +102,10 @@ Read the selected plan thoroughly. Understand:
 work through parts in numbered order. Each part is independently executable —
 complete and verify each part before moving to the next. When the plan
 recommends parallel execution for independent parts, the caller is responsible
-for launching concurrent `staff-engineer` agents — a single agent implements one
+for launching concurrent engineering agents — a single agent implements one
 part at a time.
 
-### 3. Research the current codebase
+### Step 3: Research the current codebase
 
 Before making any change, read the files that the plan targets. Verify:
 
@@ -118,7 +118,7 @@ If the codebase has diverged from the plan's assumptions, flag the discrepancies
 to the user before proceeding. Adapt the implementation to the current state —
 the plan describes intent, not a script to replay blindly.
 
-### 4. Build a task list
+### Step 4: Build a task list
 
 Break the plan into ordered, atomic tasks. Each task should:
 
@@ -132,7 +132,7 @@ Use TodoWrite to track progress. Group related changes that must land together
 For multi-part plans, organize tasks by part — complete all tasks for part 01
 before starting part 02, unless the plan explicitly allows parallel execution.
 
-### 5. Implement step by step
+### Step 5: Implement step by step
 
 For each task:
 
@@ -146,19 +146,16 @@ For each task:
    following the repository's git workflow (`type(scope): subject`). Commit
    after each verified step — do not batch unrelated changes.
 
-### 6. Final verification
+### Step 6: Final verification
 
 After all tasks are complete, run the DO-CONFIRM checklist above.
 
-### 7. Clean sub-agent review panel
+### Step 7: Clean sub-agent review panel
 
-Follow the
-[`kata-review` caller protocol](../kata-review/references/caller-protocol.md) to
-launch a parallel panel of fresh sub-agents that each grade the full diff
-(`git diff origin/main...HEAD`). Provide each reviewer with spec path, design
-path, plan path, and branch name so they can act independently. Tell each
-reviewer not to invoke `kata-implement`. Merge panel findings per the protocol,
-verify, and address all confirmed blocker/high/medium issues before pushing.
+Follow the [`kata-review` caller
+protocol](../kata-review/references/caller-protocol.md). Tell each reviewer not
+to invoke `kata-implement`. Address every confirmed blocker/high/medium finding
+before advancing.
 
 Push all commits to the remote branch only after the panel review is clean.
 
@@ -185,5 +182,6 @@ Append to the current week's log (see agent profile for the file path):
 - **Blockers encountered** — Plan deviations, codebase divergences, test
   failures, and how they were resolved
 - **Deferred specs** — Specs skipped and why (not ready, missing plan, etc.)
-- **Metrics** — Record at least one measurement per
-  KATA.md § Metrics.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.

--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -7,7 +7,7 @@ description: >
   findings as GitHub issues classified against the chosen job.
 ---
 
-# Kata Interview
+# Switching Interview
 
 You are the supervisor in a `fit-eval supervise` relay running a **JTBD
 switching interview**: an agent, briefed only with a persona derived from a
@@ -80,6 +80,9 @@ Hire, Competes With, Forces (Push, Pull, Habit, Anxiety), Fired When.
 
 The workflow has run `bunx fit-terrain build` and installed `supabase`
 globally. Copy the subset the chosen product needs into `$AGENT_CWD`:
+
+The table below shows the default staging configuration. Adjust for your
+installation's products.
 
 | Product          | Stage into `$AGENT_CWD`                                                                  |
 | ---------------- | ---------------------------------------------------------------------------------------- |
@@ -187,6 +190,6 @@ Append to the current week's log:
 - **Outcome** — done / abandoned / partial
 - **Forces observed** — Push/Pull/Habit/Anxiety/Competes/Fired
 - **Issues created or updated** — numbers and categories
-- **Metrics** — at least one measurement to `wiki/metrics/{skill}/` per the
-  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. See
-  `references/metrics.md`.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.

--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -79,10 +79,8 @@ Hire, Competes With, Forces (Push, Pull, Habit, Anxiety), Fired When.
 ### Step 3: Stage the Agent Workspace
 
 The workflow has run `bunx fit-terrain build` and installed `supabase`
-globally. Copy the subset the chosen product needs into `$AGENT_CWD`:
-
-The table below shows the default staging configuration. Adjust for your
-installation's products.
+globally. Copy the subset the chosen product needs into `$AGENT_CWD` (adjust
+for your installation's products):
 
 | Product          | Stage into `$AGENT_CWD`                                                                  |
 | ---------------- | ---------------------------------------------------------------------------------------- |
@@ -190,6 +188,5 @@ Append to the current week's log:
 - **Outcome** — done / abandoned / partial
 - **Forces observed** — Push/Pull/Habit/Anxiety/Competes/Fired
 - **Issues created or updated** — numbers and categories
-- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
-  per `references/metrics.md`. See KATA.md § Metrics for the
-  recording-eligibility rule.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/` per
+  `references/metrics.md`. See KATA.md § Metrics for recording eligibility.

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -62,55 +62,27 @@ there is no architectural direction to translate into implementation steps.
 
 ## Naming Convention
 
-Plans live alongside their spec in `specs/{NNN}-{name}/`.
-
-### Default plan
-
-The first (and usually only) plan is always **`plan-a.md`**. Do not use
-`plan.md` or other shorthands — the letter suffix keeps naming consistent
-whether one plan or several exist.
-
-### Alternative plans
-
-When exploring competing approaches for the same spec, create additional
-variants using sequential letters:
-
-```
-plan-a.md    ← default (always created first)
-plan-b.md    ← alternative approach
-plan-c.md    ← another alternative
-```
-
-Each variant should open with a brief rationale explaining how it differs from
-plan-a. When the plan is approved, **plan-a is the plan that will be
-implemented** unless the approver explicitly selects a different variant.
+Plans live alongside their spec in `specs/{NNN}-{name}/`. The first plan is
+always **`plan-a.md`**. Alternative variants use sequential letters
+(`plan-b.md`, `plan-c.md`); each opens with a rationale. **plan-a is
+implemented** unless the approver selects a different variant.
 
 ### Large plan decomposition
 
-When a plan is too large to implement as a single unit — many files, multiple
-independent phases, or risk of exceeding context — decompose it into numbered
-parts:
+When too large for a single unit, decompose into numbered parts:
 
 ```
 plan-a.md       ← overview, strategy, and part index
 plan-a-01.md    ← part 1 (independently executable)
 plan-a-02.md    ← part 2 (independently executable)
-plan-a-03.md    ← part 3 (independently executable)
 ```
 
-**Rules for decomposition:**
+- `plan-a.md` holds approach, cross-cutting concerns, and a numbered index.
+- Each `plan-a-NN.md` is independently executable; state inter-part dependencies.
+- Decompose only when there is concrete benefit (size, independence, parallelism).
+- Include an **Execution** section: parallel vs sequential, agent routing.
 
-- `plan-a.md` holds the approach, cross-cutting concerns, and a numbered index
-  with a one-line summary per part.
-- Each `plan-a-NN.md` is independently executable (its own scope, files,
-  ordering, verification) and numbered in execution order. State inter-part
-  dependencies explicitly.
-- Decompose only when there is concrete benefit (size, independence,
-  parallelism).
-- `plan-a.md` includes an **Execution** section: which parts run in parallel vs
-  sequentially, and which agent each part routes to.
-
-Alternative plans can also be decomposed (`plan-b.md`, `plan-b-01.md`, etc.).
+Alternative plans can also be decomposed (`plan-b-01.md`, etc.).
 
 ## Writing a Plan (HOW + WHEN)
 
@@ -204,7 +176,6 @@ Append to the current week's log (see agent profile for the file path):
 - **Plan decisions** — Key approach choices and why (so the implementer has
   context)
 - **Deferred specs** — Specs skipped and why (not approved, missing info, etc.)
-
 - **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
   per `references/metrics.md`. See KATA.md § Metrics for the
   recording-eligibility rule.

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -9,10 +9,11 @@ description: >
 
 # Write and Review Plans
 
-A plan defines HOW to implement and WHEN to sequence changes. Pair with the
-[`kata-spec`](../kata-spec/SKILL.md) and
-[`kata-design`](../kata-design/SKILL.md) skills — the spec captures WHAT/WHY,
-the design captures WHICH/WHERE, the plan captures HOW/WHEN.
+A plan defines HOW to implement and WHEN to sequence changes. Plan sits in the
+[spec](../kata-spec/SKILL.md) → [design](../kata-design/SKILL.md) → plan →
+[implement](../kata-implement/SKILL.md) pipeline: the spec captures WHAT/WHY,
+the design captures WHICH/WHERE, the plan captures HOW/WHEN, and implementation
+executes the plan.
 
 **A plan requires an existing approved design.** Without an approved design
 there is no architectural direction to translate into implementation steps.
@@ -127,8 +128,8 @@ The plan translates an approved design into concrete implementation steps.
   `Libraries used: none.` No section heading, no paragraph.
 - **Risks.** List risks the implementer cannot see from reading the plan. If the
   mitigation is "do the plan correctly", it is not a risk.
-- **Execution recommendation.** Route parts to matching agents —
-  `staff-engineer` for code, `technical-writer` for docs. For decomposed plans,
+- **Execution recommendation.** Route parts to the most suitable agent —
+  engineering agents for code, `technical-writer` for docs. For decomposed plans,
   state which parts can run in parallel vs sequentially.
 
 **Form follows content.** Prefer tables for shared-structure lists, bullets for
@@ -159,24 +160,41 @@ When multiple variants exist, note which is recommended (plan-a is the default).
 ### Step 0: Read Memory
 
 Read memory per the agent profile. Extract specs previously planned and any
-deferred work from prior `staff-engineer` entries.
+deferred work from prior entries.
 
-### Steps
+### Step 1: Find the design
 
-1. **Find the design.** Run `git fetch origin main`, then require
-   `specs/NNN/design-a.md` on `origin/main`; otherwise stop. An open design PR
-   with `design:approved` does not satisfy this — wait for the merge.
-2. **Study the spec and design.** Read both end to end.
-3. **Research the codebase.** Read the files the plan will target.
-4. **Write the plan.** Create `plan-a.md`. Each step independently verifiable.
-   Decompose into parts if large (see § Large plan decomposition).
-5. **Open a `plan(NNN): …` PR.** The PR title carries the spec id.
-6. **Clean sub-agent review panel.** Follow the
-   [`kata-review` caller protocol](../kata-review/references/caller-protocol.md).
-   Tell each reviewer not to invoke `kata-plan`. Address every confirmed
-   blocker/high/medium finding before advancing.
-7. **Apply approval signal.** When the panel passes, run
-   `gh pr edit <number> --add-label plan:approved`.
+Run `git fetch origin main`, then confirm `specs/NNN/design-a.md` exists on
+`origin/main`. An open PR with a `design:approved` label is not sufficient —
+wait for the merge.
+
+### Step 2: Study the spec and design
+
+Read both end to end.
+
+### Step 3: Research the codebase
+
+Read the files the plan will target.
+
+### Step 4: Write the plan
+
+Create `plan-a.md`. Each step independently verifiable. Decompose into parts if
+large (see § Large plan decomposition).
+
+### Step 5: Open a plan PR
+
+The PR title carries the spec id: `plan(NNN): …`.
+
+### Step 6: Clean sub-agent review panel
+
+Follow the [`kata-review` caller
+protocol](../kata-review/references/caller-protocol.md). Tell each reviewer not
+to invoke `kata-plan`. Address every confirmed blocker/high/medium finding
+before advancing.
+
+### Step 7: Apply approval signal
+
+When the panel passes, run `gh pr edit <number> --add-label plan:approved`.
 
 ## Memory: what to record
 
@@ -187,5 +205,6 @@ Append to the current week's log (see agent profile for the file path):
   context)
 - **Deferred specs** — Specs skipped and why (not approved, missing info, etc.)
 
-No metrics — plans are work-in-progress; see KATA.md § Metrics for recording
-eligibility.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.

--- a/.claude/skills/kata-plan/references/metrics.md
+++ b/.claude/skills/kata-plan/references/metrics.md
@@ -1,0 +1,10 @@
+# Metrics — Plan
+
+Record per KATA.md § Metrics. Append one row per run.
+
+| Metric        | Unit  | Description                        | Data source |
+| ------------- | ----- | ---------------------------------- | ----------- |
+| plans_drafted | count | Plan PRs opened or merged this run | gh pr list  |
+
+Plan backlog (`specs/` with `design-a.md` but no `plan-a.md`) is queried,
+not recorded.

--- a/.claude/skills/kata-product-issue/SKILL.md
+++ b/.claude/skills/kata-product-issue/SKILL.md
@@ -24,6 +24,10 @@ triage decisions captured here.
 - A specific issue needs an on-demand product-alignment decision
 - Never for PRs — use [`kata-release-merge`](../kata-release-merge/SKILL.md)
 
+## Prerequisites
+
+All comment templates are in `references/templates.md`.
+
 ## Checklists
 
 <read_do_checklist goal="Hold the triage boundary before classifying issues">
@@ -36,10 +40,6 @@ triage decisions captured here.
 - [ ] Record reasoning for each classification — future runs audit decisions.
 
 </read_do_checklist>
-
-## Prerequisites
-
-All comment templates are in `references/templates.md`.
 
 ## Classification
 
@@ -63,7 +63,7 @@ project's products should fulfil for its personas.
 
 Read memory per the agent profile (your summary, the current week's log, and
 teammates' summaries). Extract issues previously processed and recurring themes
-from prior `product-manager` entries.
+from prior entries.
 
 ### Step 1: List Open Issues
 
@@ -92,17 +92,9 @@ one-line rationale. The report is the deliverable of this skill.
 
 ### Step 4: Hand Off
 
-The triage report is consumed by the calling agent, which then takes action:
-
-- **Trivial fix/bug** → make the fix on a `fix/<short-name>` branch from `main`,
-  run `bun run check` and `bun run test`, open a PR. Templates in
-  `references/templates.md` § Fix PRs. Label the issue `triaged`.
-- **Product-aligned** → invoke the `kata-spec` skill to draft a spec,
-  referencing the issue. Label the issue `triaged` and `needs-spec`.
-- **Cross-product policy** → open a Discussion citing the issue; do not write a
-  spec until the policy question resolves. Label the issue `triaged`.
-- **Out of scope** → comment with explanation per `references/templates.md` §
-  Issue Comments and apply the appropriate label.
+The triage report is consumed by the calling agent, which acts on each category
+per the classification table above. Templates are in `references/templates.md`.
+Label each processed issue `triaged`.
 
 The READ-DO checklist defines this phase boundary.
 
@@ -113,10 +105,9 @@ Append to the current week's log (see agent profile for the file path):
 - **Issue triage table** — Each issue with category, action, and rationale
 - **Recurring themes** — Patterns across issues, with frequency and alignment
 - **Hand-offs** — Which follow-up skills were invoked for which issues
-- **Metrics** — Record at least one measurement to
-  `wiki/metrics/{skill}/` per the
-  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
-  it with the header row. These feed XmR analysis in the storyboard meeting.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.
 
 ## Coordination Channels
 

--- a/.claude/skills/kata-release-cut/SKILL.md
+++ b/.claude/skills/kata-release-cut/SKILL.md
@@ -46,7 +46,7 @@ determine version bumps, and cut releases.
 
 Read memory per the agent profile (your summary, the current week's log, and
 teammates' summaries). Extract previous release outcomes and any packages that
-had publish failures from prior `release-engineer` entries.
+had publish failures from prior entries.
 
 ### Step 1: Pre-Flight — Verify Main Branch CI
 
@@ -74,8 +74,8 @@ git push origin main
 
 ### Version Rules
 
-- **Pre-1.0** (`0.x.y`): bump **patch** for any change
-- **Post-1.0**: breaking (`!` suffix) → **major**; `feat` → **minor**; else →
+- **Pre-1.0** (`0.x.y`) — bump **patch** for any change
+- **Post-1.0** — breaking (`!` suffix) → **major**; `feat` → **minor**; else →
   **patch**
 
 ### Step 2: Enumerate Changed Packages
@@ -160,10 +160,9 @@ Append to the current week's log (see agent profile for the file path):
   status
 - **Publish failures** — Package and reason (so the next run can revisit)
 - **Main branch CI state** — Green or broken, and what was repaired
-- **Metrics** — Record at least one measurement to
-  `wiki/metrics/{skill}/` per the
-  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
-  it with the header row. These feed XmR analysis in the storyboard meeting.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.
 
 ## Edge Cases
 

--- a/.claude/skills/kata-release-merge/SKILL.md
+++ b/.claude/skills/kata-release-merge/SKILL.md
@@ -178,7 +178,9 @@ Append to the current week's log:
   § Invariants)
 - **Approval signals consumed** — label vs APPROVED review
 - **PRs merged this run** and **merge failures** with reasons
-- **Metrics** — record at least one measurement per KATA.md § Metrics.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.
 
 ## Coordination Channels
 

--- a/.claude/skills/kata-review/references/caller-protocol.md
+++ b/.claude/skills/kata-review/references/caller-protocol.md
@@ -19,10 +19,10 @@ for a given artifact in a single message so they run in parallel.
 | Caller           | Artifact                    | Panel     | `subagent_type`   | Reviewers |
 | ---------------- | --------------------------- | --------- | ----------------- | --------- |
 | `kata-spec`      | `spec.md`                   | product   | `product-manager` | 3         |
-| `kata-spec`      | `spec.md`                   | technical | `staff-engineer`  | 3         |
-| `kata-design`    | `design-a.md`               | technical | `staff-engineer`  | 3         |
-| `kata-plan`      | `plan-a.md` (+ parts)       | technical | `staff-engineer`  | 3         |
-| `kata-implement` | diff (`origin/main...HEAD`) | technical | `staff-engineer`  | 5         |
+| `kata-spec`      | `spec.md`                   | technical | engineering agent  | 3         |
+| `kata-design`    | `design-a.md`               | technical | engineering agent  | 3         |
+| `kata-plan`      | `plan-a.md` (+ parts)       | technical | engineering agent  | 3         |
+| `kata-implement` | diff (`origin/main...HEAD`) | technical | engineering agent  | 5         |
 
 Implementation diffs get 5 because the artifact is larger, the step is
 irreversible (code lands on `main`), and the surface area for subtle bugs and

--- a/.claude/skills/kata-security-audit/SKILL.md
+++ b/.claude/skills/kata-security-audit/SKILL.md
@@ -126,10 +126,9 @@ Append to the current week's log (see agent profile for the file path):
 - **Deferred work** — Issues needing follow-up with enough context to resume
 - CVEs evaluated and their status
 - Policy violations found and whether fixed or spec'd
-- **Metrics** — Record at least one measurement to
-  `wiki/metrics/{skill}/` per the
-  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
-  it with the header row. These feed XmR analysis in the storyboard meeting.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.
 
 ## Coordination Channels
 

--- a/.claude/skills/kata-security-update/SKILL.md
+++ b/.claude/skills/kata-security-update/SKILL.md
@@ -154,7 +154,6 @@ Append to the current week's log (see agent profile for the file path):
 - **PR triage table** — Each PR with action, failed checks, and reason
 - **Compatibility blockers** — Packages closed due to Check 8
 - **Reverted merges** — PRs merged then reverted, with root cause
-- **Metrics** — Record at least one measurement to
-  `wiki/metrics/{skill}/` per the
-  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
-  it with the header row. These feed XmR analysis in the storyboard meeting.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.

--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -158,9 +158,8 @@ briefing.
 1. **Prepare for Q2.** Gather your domain's current measured state from live
    data (`gh`, `bun`, repo files) — not memory or narrative.
 2. **Record metrics to CSV.** Before answering, append one row per metric to
-   `wiki/metrics/{skill}/{YYYY}.csv` per the
-   [`kata-metrics`](../kata-metrics/SKILL.md) protocol, creating the directory
-   and header if needed. The CSV is authoritative; your `Answer` summarizes it.
+   `wiki/metrics/{skill}/{YYYY}.csv` per the skill's
+   `references/metrics.md`, creating the directory and header if needed. The CSV is authoritative; your `Answer` summarizes it.
 3. **Answer with measured data.** Report numbers via `Answer`, referencing the
    CSV rows. Use counts and durations — not narratives like "improving." Use
    `Announce` only for unsolicited team-wide context.

--- a/.claude/skills/kata-session/references/one-on-one.md
+++ b/.claude/skills/kata-session/references/one-on-one.md
@@ -30,9 +30,11 @@ participant fetches it under Q2.
 
 ## Participant briefing template
 
-> "You are in a 1-on-1 coaching session. I will Ask you five questions; reply to
-> each with Answer. Under Q2, run `fit-trace` on your most recent workflow
-> trace and include the numeric findings in your Answer."
+```markdown
+You are in a 1-on-1 coaching session. I will Ask you five questions; reply to
+each with Answer. Under Q2, run `fit-trace` on your most recent workflow
+trace and include the numeric findings in your Answer.
+```
 
 ## Memory
 

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -47,9 +47,8 @@ vs. expected), update Obstacles, and plan the next experiment.
 ## Metrics
 
 Each participant records to `wiki/metrics/{skill}/{YYYY}.csv`. See
-[`metrics.md`](metrics.md) for suggested coaching-side metrics; authoritative
-XmR protocol reference at
-[`../../kata-metrics/references/xmr.md`](../../kata-metrics/references/xmr.md).
+[`metrics.md`](metrics.md) for suggested coaching-side metrics and KATA.md §
+Metrics for the recording-eligibility rule.
 
 ## Storyboard updates
 
@@ -107,7 +106,9 @@ Discussion, not four parallel coaching dispatches.
 
 ## Participant briefing template
 
-> "You are joining a team storyboard meeting. I will Ask you five questions;
-> reply to each with Answer. Before answering Q2, record your domain metrics to
-> `wiki/metrics/{skill}/{YYYY}.csv`; your Answer references the
-> CSV row."
+```markdown
+You are joining a team storyboard meeting. I will Ask you five questions;
+reply to each with Answer. Before answering Q2, record your domain metrics to
+`wiki/metrics/{skill}/{YYYY}.csv`; your Answer references the
+CSV row.
+```

--- a/.claude/skills/kata-setup/SKILL.md
+++ b/.claude/skills/kata-setup/SKILL.md
@@ -31,7 +31,7 @@ facilitated sessions, and event-driven responses.
 
 <read_do_checklist goal="Gather all configuration before generating files">
 
-- [ ] Ask which agents to enable -- do not assume all six.
+- [ ] Ask which agents to enable — do not assume all six.
 - [ ] Confirm timezone for schedule generation.
 - [ ] Confirm secrets are configured before writing workflows.
 - [ ] Use fully-qualified action references
@@ -56,34 +56,35 @@ facilitated sessions, and event-driven responses.
 
 Ask these questions. Skip any already answered in the task prompt.
 
-1. **GitHub App** -- "Do you have a GitHub App for your agents, or should I help
+1. **GitHub App** — "Do you have a GitHub App for your agents, or should I help
    you create one?" If creating, walk through `references/github-app.md`. If
    existing, ask for the App slug.
 
-2. **Secrets** -- "Have you configured these repository secrets?"
-   - `KATA_APP_ID` -- GitHub App ID
-   - `KATA_APP_PRIVATE_KEY` -- GitHub App private key (PEM)
-   - `ANTHROPIC_API_KEY` -- Anthropic API key
+2. **Secrets** — "Have you configured these repository secrets?"
+   - `KATA_APP_ID` — GitHub App ID
+   - `KATA_APP_PRIVATE_KEY` — GitHub App private key (PEM)
+   - `ANTHROPIC_API_KEY` — Anthropic API key
 
-3. **Agents** -- "Which agents do you want to run?" Present:
-   - **product-manager** -- Triage issues and PRs, merge fixes, run evaluations
-   - **staff-engineer** -- Spec, design, plan, and implement features
-   - **security-engineer** -- Patch dependencies, harden supply chain
-   - **release-engineer** -- Keep branches merge-ready, cut releases
-   - **technical-writer** -- Review docs, curate wiki, fix staleness
-   - **improvement-coach** -- Facilitate storyboard and coaching sessions
+3. **Agents** — "Which agents do you want to run?" Present:
+   - **product-manager** — Triage issues and PRs, merge fixes, run evaluations
+   - **engineering agent** — Spec, design, plan, and implement features (default
+     profile: `staff-engineer`)
+   - **security-engineer** — Patch dependencies, harden supply chain
+   - **release-engineer** — Keep branches merge-ready, cut releases
+   - **technical-writer** — Review docs, curate wiki, fix staleness
+   - **improvement-coach** — Facilitate storyboard and coaching sessions
 
    Default: all six. Let the user pick a subset.
 
-4. **Timezone** -- "What timezone are your agents working in?" Default:
+4. **Timezone** — "What timezone are your agents working in?" Default:
    Europe/Paris. Use `references/schedules.md` for cron expressions.
 
-5. **Wiki** -- "Do you want agents to share persistent memory via a GitHub
+5. **Wiki** — "Do you want agents to share persistent memory via a GitHub
    wiki?" Default: yes. If no, set `wiki: "false"` in generated workflows.
 
-6. **Model** -- "Which Claude model?" Default: `claude-opus-4-7[1m]`.
+6. **Model** — "Which Claude model?" Default: `claude-opus-4-7[1m]`.
 
-7. **Agent profiles** -- "Do you have custom agent profiles, or should I use the
+7. **Agent profiles** — "Do you have custom agent profiles, or should I use the
    defaults from kata-skills?" If defaults, confirm
    `npx skills add forwardimpact/kata-skills` is installed.
 
@@ -107,7 +108,7 @@ from `references/workflow-react.md`.
 
 Run verification:
 
-- `gh secret list` -- confirm secrets are configured
+- `gh secret list` — confirm secrets are configured
 - Confirm workflow files were written to `.github/workflows/`
 - Suggest a test run: `gh workflow run "Agent: <name>"`
 

--- a/.claude/skills/kata-setup/references/schedules.md
+++ b/.claude/skills/kata-setup/references/schedules.md
@@ -3,12 +3,13 @@
 Kata agents run on a **three-shift** (night, day, swing) producer-reviewer-
 shipper chain:
 
-1. **product-manager** -- triages a fresh backlog
-2. **staff-engineer** -- implements from the backlog
-3. **security-engineer** -- reviews code (night only)
-4. **technical-writer** -- reviews docs (night only)
-5. **release-engineer** -- ships what passed review
-6. **improvement-coach** -- storyboard, daily after night
+1. **product-manager** — triages a fresh backlog
+2. **engineering agent** — implements from the backlog (default profile:
+   `staff-engineer`)
+3. **security-engineer** — reviews code (night only)
+4. **technical-writer** — reviews docs (night only)
+5. **release-engineer** — ships what passed review
+6. **improvement-coach** — storyboard, daily after night
 
 Security and technical-writer run only at night.
 

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -10,11 +10,11 @@ description: >
 
 # Write and Review Specs
 
-A spec defines WHAT to build and WHY. Pair with the
-[`kata-design`](../kata-design/SKILL.md) and
-[`kata-plan`](../kata-plan/SKILL.md) skills — once a spec is approved, the staff
-engineer shapes it into an architectural design (WHICH/WHERE) and then a
-concrete plan (HOW/WHEN).
+A spec defines WHAT to build and WHY. Spec sits in the spec →
+[design](../kata-design/SKILL.md) → [plan](../kata-plan/SKILL.md) →
+[implement](../kata-implement/SKILL.md) pipeline: the spec captures WHAT/WHY,
+the design captures WHICH/WHERE, the plan captures HOW/WHEN, and implementation
+executes the plan.
 
 **Spec and plan are independent deliverables.** Only produce the one the user
 asked for. If they ask for a spec, write the spec and stop.
@@ -109,20 +109,35 @@ label.
 
 ## Process
 
-1. **Clarify first.** Ask about motivation, scope, constraints, and success
-   before writing.
-2. **Research.** Read relevant code, data, and existing specs.
-3. **Write the spec.** WHAT and WHY only.
-4. **Open a `spec(NNN): …` PR.** The PR title carries the spec id; merge of that
-   PR is what advances the phase.
-5. **Clean sub-agent review panel.** Follow the
-   [`kata-review` caller protocol](../kata-review/references/caller-protocol.md).
-   Tell each reviewer not to invoke `kata-spec`. Address every confirmed
-   blocker/high/medium finding before advancing.
-6. **Apply approval signal.** When the panel passes and the DO-CONFIRM checks
-   are met, run `gh pr edit <number> --add-label spec:approved` so
-   `kata-release-merge` lets the PR through. Stop at the spec — the plan is the
-   staff engineer's job.
+### Step 1: Clarify
+
+Ask about motivation, scope, constraints, and success before writing.
+
+### Step 2: Research
+
+Read relevant code, data, and existing specs.
+
+### Step 3: Write the spec
+
+WHAT and WHY only.
+
+### Step 4: Open a spec PR
+
+The PR title carries the spec id: `spec(NNN): …`. Merge of that PR is what
+advances the phase.
+
+### Step 5: Clean sub-agent review panel
+
+Follow the [`kata-review` caller
+protocol](../kata-review/references/caller-protocol.md). Tell each reviewer not
+to invoke `kata-spec`. Address every confirmed blocker/high/medium finding
+before advancing.
+
+### Step 6: Apply approval signal
+
+When the panel passes and the DO-CONFIRM checks are met, run
+`gh pr edit <number> --add-label spec:approved` so `kata-release-merge` lets
+the PR through.
 
 ## Memory: what to record
 
@@ -131,7 +146,6 @@ Append to the current week's log (see agent profile for the file path):
 - **Specs written** — Spec number, name, and status
 - **Review results** — Specs reviewed and disposition (approved/changes needed)
 - **Deferred work** — Findings not yet captured as specs
-- **Metrics** — Record at least one measurement to
-  `wiki/metrics/{skill}/` per the
-  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
-  it with the header row. These feed XmR analysis in the storyboard meeting.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.

--- a/.claude/skills/kata-wiki-curate/SKILL.md
+++ b/.claude/skills/kata-wiki-curate/SKILL.md
@@ -160,7 +160,6 @@ Append to the current week's log (see agent profile for the file path):
 - **Stale memos** — Inbox entries >2 weeks old with no response
 - **MEMORY.md changes** — What was added/updated
 - **Memos sent** — Specific callouts dispatched via `fit-wiki memo`
-- **Metrics** — Record at least one measurement to
-  `wiki/metrics/{skill}/` per the
-  [`kata-metrics`](../kata-metrics/SKILL.md) protocol. If no CSV exists, create
-  it with the header row. These feed XmR analysis in the storyboard meeting.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.


### PR DESCRIPTION
## Summary

- Standardise section ordering, process step format (`### Step N: Title`),
  bold-lead delimiter styles, and metrics recording lines across all 15 kata-*
  skills
- Replace hardcoded `staff-engineer` agent role with generic "engineering agent"
  phrasing; fix broken `kata-metrics` links; generalise product-specific paths
  in documentation skills
- Add `references/metrics.md` for kata-design and kata-plan; convert briefing
  templates from blockquotes to fenced code blocks

## Test plan

- [x] `bun run check` passes (including 192-line skill cap)
- [x] `bun run test` — pre-existing codegen failures only, no regressions
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)