### PR TITLE
docs+websites: extract MONOREPO/COALIGNED layers, add placeholder sites, restructure FIT footer

### DIFF
--- a/.github/workflows/website-coaligned.yaml
+++ b/.github/workflows/website-coaligned.yaml
@@ -1,0 +1,60 @@
+name: "Website: Publish the Co-Aligned pages"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "websites/coaligned/**"
+      - "libraries/libdoc/**"
+      - ".github/workflows/website-coaligned.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "website-coaligned"
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/bootstrap
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - uses: ./.github/actions/audit
+
+      - name: Build website
+        run: bunx fit-doc build --src=websites/coaligned --out=dist
+
+      - name: Copy CNAME file
+        run: cp websites/coaligned/CNAME dist/
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coaligned-pages
+          path: dist
+
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+          repositories: coaligned-pages
+
+      - name: Trigger deployment
+        env:
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+        run: |
+          gh api repos/forwardimpact/coaligned-pages/dispatches \
+            -f event_type=deploy \
+            -f "client_payload[run_id]=${{ github.run_id }}"

--- a/.github/workflows/website-monorepo.yaml
+++ b/.github/workflows/website-monorepo.yaml
@@ -1,0 +1,60 @@
+name: "Website: Publish the Monorepo pages"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "websites/monorepo/**"
+      - "libraries/libdoc/**"
+      - ".github/workflows/website-monorepo.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "website-monorepo"
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/bootstrap
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - uses: ./.github/actions/audit
+
+      - name: Build website
+        run: bunx fit-doc build --src=websites/monorepo --out=dist
+
+      - name: Copy CNAME file
+        run: cp websites/monorepo/CNAME dist/
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: monorepo-pages
+          path: dist
+
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+          repositories: monorepo-pages
+
+      - name: Trigger deployment
+        env:
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+        run: |
+          gh api repos/forwardimpact/monorepo-pages/dispatches \
+            -f event_type=deploy \
+            -f "client_payload[run_id]=${{ github.run_id }}"

--- a/COALIGNED.md
+++ b/COALIGNED.md
@@ -1,14 +1,23 @@
 # Co-Aligned Teams of Humans & Coding Agents
 
-This is the design manifest for creating aligned coding agents. It draws on two
-well-publicized ideas:
+> "The volume and complexity of what we know has exceeded our individual
+> ability to deliver its benefits correctly, safely, or reliably."
+>
+> — Atul Gawande, _The Checklist Manifesto_
+
+This is the design manifest for creating aligned coding agents. It is built on
+top of the repository's general structure — see [MONOREPO.md](MONOREPO.md) for
+the top-level directories, root manifest files, and the JTBD entry structure
+and tagging convention this manifest assumes.
+
+It draws on two well-publicized ideas:
 
 1. **Jobs To Be Done** (Christensen, Moesta) — agents align to the progress
    each persona seeks in specific circumstances, not to feature lists. See
    [JTBD.md](JTBD.md).
-2. **The Checklist Manifesto** (Gawande) — complex work fails not from ignorance
-   but from inattention under load. Structured instructions ensure existing
-   knowledge is consistently applied — by humans and agents alike.
+2. **The Checklist Manifesto** (Gawande) — complex work fails not from
+   ignorance but from inattention under load. Structured instructions ensure
+   existing knowledge is consistently applied — by humans and agents alike.
 
 Together they answer _what_ agents align to (the jobs) and _how_ alignment
 holds under load (the layered instruction architecture). The more expert the
@@ -19,13 +28,13 @@ must; experts skip them because they think they don't need to.
 
 Instructions span seven layers, ascending from most general (every contributor,
 every run) to most specific (one pause point). Each layer has one job. A defect
-in one layer is a different class of problem from a defect in another, and trace
-attribution depends on the separation.
+in one layer is a different class of problem from a defect in another, and
+trace attribution depends on the separation.
 
 0. **System prompt** — harness mechanics: turns, tool calls, completion signal.
-1. **CLAUDE.md** — project identity: goal, users, products, distribution, maps.
-2. **CONTRIBUTING.md** — contribution standards: invariants, technical rules,
-   git workflow, security. **JTBD.md** — jobs each users hires products to do.
+1. **CLAUDE.md** — project identity. See [MONOREPO.md](MONOREPO.md).
+2. **CONTRIBUTING.md** & **JTBD.md** — contribution standards and jobs. See
+   [MONOREPO.md](MONOREPO.md).
 3. **Agent profile** — persona, voice, skill routing, scope constraints.
 4. **Skill procedure (SKILL.md)** — decision-making, sequencing, rationale.
 5. **Skill references (`references/`)** — data the procedure consults:
@@ -37,24 +46,6 @@ L4/L5/L6 share a skill folder but serve different concerns: L4 is _procedural_,
 L5 is _declarative_, L6 is _verificational_. Trace attribution requires the
 separation — "wrong procedure" is a different class of defect from "stale data"
 or "missing verification."
-
-### Tagging for Progressive Discovery
-
-Jobs and checklists are distributed across the codebase — Big Hires in JTBD.md,
-Little Hires in product READMEs, checklists in SKILL.md files and
-CONTRIBUTING.md. Semantic tags (`<job>`, `<read_do_checklist>`,
-`<do_confirm_checklist>`) make them discoverable without knowing where they live:
-
-```sh
-rg '<job '                  # Big Hires in JTBD.md, Little Hires near the code
-rg '<read_do_checklist'     # Entry gates — read each item, then do it
-rg '<do_confirm_checklist'  # Exit gates — do from memory, then confirm
-```
-
-- Tag attributes (`user`, `goal`) make search results self-describing —
-  each match shows purpose without opening the file.
-- Keep the full opening tag on one line within 74 characters so `rg`
-  output stays coherent.
 
 ### Layer Rules
 
@@ -87,108 +78,13 @@ interactive runs or `libeval` prompt for agent workflows.
 ## L1 — Project Identity (CLAUDE.md)
 
 Auto-loaded via `settingSources: ["project"]`. Orients every contributor on
-every run.
+every run. Properties of a good `CLAUDE.md` are defined upstream in
+[MONOREPO.md](MONOREPO.md).
 
-### Properties of Good Project Identity
+## L2 — Contribution Standards & Jobs (CONTRIBUTING.md, JTBD.md)
 
-1. **Orients, doesn't govern.** Answers what, who, where. Rules and policies
-   belong in L2.
-2. **Navigation hub.** Points to everything, restates nothing. A link is cheaper
-   than a duplicate.
-3. **Stable.** Changes rarely — frequent churn means content belongs elsewhere.
-4. **Budget-conscious.** Every line loads on every run. If a section is only
-   relevant to one workflow, push it to L2 or L4.
-5. **Surfaces the tagging conventions.** Includes a section that briefly
-   explains checklists and jobs, and how to discover them (`rg '<job '`,
-   `rg '<read_do_checklist'`).
-
-## L2 — Contribution Standards & Jobs
-
-CONTRIBUTING.md and JTBD.md are read on demand, not auto-loaded. One governs
-how contributors work; the other captures what progress each persona seeks.
-
-### Properties of Good Contribution Standards
-
-1. **Rules, not procedures.** What to do and what not to do — step-by-step
-   sequencing belongs in L4.
-2. **Universal scope.** Every item applies to every contribution. Workflow-
-   specific rules belong in the skill that owns that workflow.
-3. **Verifiable.** Each rule should be checkable — by a human, a script, or a
-   checklist item. Aspirational guidance that can't be verified drifts.
-
-### JTBD Entry Structure
-
-Each entry in [JTBD.md](JTBD.md) follows a fixed structure. The first five
-elements are required for all entries. _Forces_ and _Fired When_ are required
-for _Products_ but omitted for _Services_ and _Libraries_.
-
-- **User** — persona hiring the product (`##` heading).
-- **Goal** — high-level progress sought (`###` heading).
-- **Trigger** — a specific moment that creates the job, not a role description.
-- **Big Hire** — "{progress}." — the adoption decision; why this gets hired
-  over the alternatives. Rendered as "Help me {progress}." with a product arrow.
-- **Little Hire** — "{progress}." — the repeated daily use; what brings
-  the user back each time. Rendered the same way.
-- **Competes With** — what currently gets hired instead; semicolon-delimited.
-- **Forces** — Four forces: _Push_ (status quo pain), _Pull_ (desired future
-  state, not features), _Habit_ (current behavior resisting change), _Anxiety_
-  (fear blocking adoption).
-- **Fired When** — Conditions under which the product gets abandoned; include at
-  least one environmental shift beyond product failure.
-
-### Properties of Good JTBD Entries
-
-Drawing from Christensen and Moesta's methodology:
-
-1. **Progress, not features.** "Help me make staffing decisions I can defend" is
-   a job. "Help me run what-if staffing scenarios" is a feature request wearing
-   job syntax. If removing the product arrow makes the statement meaningless,
-   the job is too solution-shaped.
-
-2. **Trigger is a moment, not a role.** "Starting the third project that needs
-   the same plumbing" is a moment. "Building systems consumed by both humans and
-   agents" is a role description. A good trigger answers "what just happened?"
-
-3. **Competing hires include nonconsumption.** Every Competes With list must
-   include a "hire nothing" option. Nonconsumption is usually the real
-   incumbent.
-
-4. **Pull describes a desired future, not a feature list.** "Confidence that a
-   staffing change strengthens the team" is a future state. "System-level team
-   views and what-if scenarios" is a feature list.
-
-5. **Forces are asymmetric.** One force often dominates. If all four feel
-   equally weighted, the analysis was filled in from a template rather than
-   reconstructed from a decision story.
-
-6. **Fired When includes the world, not just the product.** Products get
-   abandoned when the environment shifts — a reorg, a budget cut, a tool ban.
-
-7. **Field-validated, not desk-authored.** JTBD entries are hypotheses until
-   confirmed by customer struggle stories. An entry that surprises the product
-   team is more likely correct than one that confirms existing assumptions.
-
-### Tagging Convention
-
-**Big Hires** live in [JTBD.md](JTBD.md) — the full entry structure above,
-one per persona-outcome pair. **Little Hires** can live anywhere — product
-READMEs, skill files, design docs — capturing narrower jobs closer to the code
-that serves them. Wrap both in a semantic tag for discoverability:
-
-```markdown
-<job user="Engineering Leaders" goal="Staff Teams to Succeed">
-
-**Trigger:** A post-mortem surfaces the same skill gap that caused the last
-incident.
-
-**Big Hire:** Help me make staffing decisions I can defend with evidence, not
-intuition. → **Summit**
-
-**Little Hire:** Help me spot capability gaps before someone gets set up to
-fail. → **Summit**
-
-</job>
-```
+Read on demand, not auto-loaded. Properties of `CONTRIBUTING.md` and the JTBD
+entry structure are defined upstream in [MONOREPO.md](MONOREPO.md).
 
 ## L3 — Agent Profile
 
@@ -262,22 +158,16 @@ Drawing from Gawande's findings:
 
 1. **Goal statement.** Every checklist begins with a stated goal — the outcome
    it protects. Without a goal, compliance becomes mechanical box-checking.
-
 2. **5–7 items.** Working memory limits. Beyond 7 items, contributors skip
    entries or treat the list as formality.
-
 3. **Precise.** Each item is a single, unambiguous action or verification. Two
    contributors should interpret each item the same way.
-
 4. **Killer items only.** Every item addresses a failure mode that has actually
    occurred or is highly likely. A list full of obvious steps wastes attention.
-
 5. **Action or verification, never explanation.** A verb phrase, not a
    paragraph. If it needs explanation, the contributor needs training.
-
 6. **One checklist, one moment.** Tied to a single pause point. The pause point
    must be natural — artificial ones get skipped.
-
 7. **Tested and revised.** Use it, observe what still goes wrong, revise. A
    stale checklist trains contributors to treat checklists as noise.
 
@@ -302,6 +192,16 @@ Wrap each checklist in a semantic tag encoding its type and goal:
 
 </do_confirm_checklist>
 ```
+
+Discover checklists from anywhere in the repo:
+
+```sh
+rg '<read_do_checklist'     # entry gates — read each item, then do it
+rg '<do_confirm_checklist'  # exit gates — do from memory, then confirm
+```
+
+Keep the full opening tag on one line within 74 characters so `rg` output stays
+coherent.
 
 ## Length and Loading
 

--- a/KATA.md
+++ b/KATA.md
@@ -17,6 +17,10 @@ workflows (five scheduled agent runs across three shifts, a daily storyboard, an
 on-demand coaching session, an event-driven conversation responder), six agent
 personas, and fifteen skills form this cycle.
 
+Kata is an implementation of two upstream standards: the repository structure
+in [MONOREPO.md](MONOREPO.md) and the instruction architecture in
+[COALIGNED.md](COALIGNED.md). Everything below assumes both.
+
 ## Architecture
 
 ```mermaid
@@ -284,11 +288,9 @@ for the full permission and event subscription reference.
 
 ## Authoring
 
-Instruction architecture, length limits, skill structure, checklist design,
-publishing gates, recursion-safe review, and shared-wording rules — including
-the eight-layer model that governs where new instructions belong — live in
-[CO-ALIGNED.md](CO-ALIGNED.md). It is the design manifest for creating aligned
-coding agents, derived from Jobs To Be Done and The Checklist Manifesto.
+Instruction architecture, length limits, skill structure, checklist design, and
+the seven-layer model that governs where new instructions belong live in
+[COALIGNED.md](COALIGNED.md).
 
 ## Invariants
 

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -1,0 +1,183 @@
+# Monorepo Structure
+
+> "A system is a network of interdependent components that work together to try
+> to accomplish the aim of the system. A system must have an aim. Without an
+> aim, there is no system."
+>
+> — W. Edwards Deming, _The New Economics_
+
+This manifest describes the structural conventions of a repository shared by
+humans and coding agents — the top-level directories, the root manifest files,
+and the way jobs are captured and discovered. Everything else builds on this
+shape.
+
+## Top-Level Directories
+
+Three directories carry shippable code, each with its own `README.md` capturing
+the jobs that directory exists to serve:
+
+- **`products/`** — User-facing products. Each product has a `README.md` that
+  names the personas it serves and the progress it helps them make.
+- **`services/`** — Long-running services consumed by products. Each service
+  has a `README.md` that captures the jobs it does for the products and
+  platform builders that depend on it.
+- **`libraries/`** — Shared code consumed by products and services. Each
+  library has a `README.md` that captures the jobs it does for the platform
+  builders that depend on it.
+
+These three READMEs are the canonical home for narrower jobs ("Little Hires") —
+captured next to the code that serves them.
+
+Two directories support the shippable code without being shipped themselves:
+
+- **`websites/`** — Documentation hubs. The top-level `README.md` maps every
+  guide to a Big Hire or Little Hire so documentation traces back to the jobs
+  it serves.
+- **`infrastructure/`** — Deployment assets (Docker, gateway, database, load
+  balancer). Subdirectories carry their own READMEs for the specific
+  deployment concern they cover.
+
+## Root Manifest Files
+
+Three root files orient every contributor. Each has one job; none restates
+another.
+
+### Project Identity (CLAUDE.md)
+
+Orients every contributor on every run. Answers _what_ the project is, _who_ it
+serves, and _where_ to find things.
+
+#### Properties of a Good Project Identity
+
+1. **Orients, doesn't govern.** Answers what, who, where. Rules and policies
+   belong in `CONTRIBUTING.md`.
+2. **Navigation hub.** Points to everything, restates nothing. A link is
+   cheaper than a duplicate.
+3. **Stable.** Changes rarely — frequent churn means content belongs elsewhere.
+4. **Budget-conscious.** Every line loads on every run. If a section is only
+   relevant to one workflow, push it deeper.
+5. **Surfaces tagging conventions.** Briefly explains how jobs are tagged and
+   how to discover them with `rg`.
+
+### Contribution Standards (CONTRIBUTING.md)
+
+Read on demand. Governs _how_ contributors work — invariants, technical rules,
+git workflow, security policies.
+
+#### Properties of Good Contribution Standards
+
+1. **Rules, not procedures.** What to do and what not to do — step-by-step
+   sequencing belongs closer to the work.
+2. **Universal scope.** Every item applies to every contribution. Workflow-
+   specific rules belong with the workflow that owns them.
+3. **Verifiable.** Each rule should be checkable — by a human, a script, or a
+   list. Aspirational guidance that can't be verified drifts.
+
+### Jobs To Be Done (JTBD.md)
+
+The canonical catalogue of "Big Hires" — one entry per persona-outcome pair.
+Captures _what progress each persona seeks_ from the products in this repo.
+
+#### Entry Structure
+
+Each entry follows a fixed structure. The first five elements are required for
+all entries. _Forces_ and _Fired When_ are required for **products** but
+omitted for **services** and **libraries**.
+
+- **User** — persona hiring the product (`##` heading).
+- **Goal** — high-level progress sought (`###` heading).
+- **Trigger** — a specific moment that creates the job, not a role
+  description.
+- **Big Hire** — "{progress}." — the adoption decision; why this gets hired
+  over the alternatives. Rendered as "Help me {progress}." with a product
+  arrow.
+- **Little Hire** — "{progress}." — the repeated daily use; what brings the
+  user back each time. Rendered the same way.
+- **Competes With** — what currently gets hired instead; semicolon-delimited.
+- **Forces** — Four forces: _Push_ (status quo pain), _Pull_ (desired future
+  state, not features), _Habit_ (current behavior resisting change), _Anxiety_
+  (fear blocking adoption).
+- **Fired When** — Conditions under which the product gets abandoned; include
+  at least one environmental shift beyond product failure.
+
+#### Properties of Good JTBD Entries
+
+Drawing from Christensen and Moesta's methodology:
+
+1. **Progress, not features.** "Help me make staffing decisions I can defend"
+   is a job. "Help me run what-if staffing scenarios" is a feature request
+   wearing job syntax. If removing the product arrow makes the statement
+   meaningless, the job is too solution-shaped.
+2. **Trigger is a moment, not a role.** "Starting the third project that
+   needs the same plumbing" is a moment. "Building systems consumed by both
+   humans and agents" is a role description. A good trigger answers "what
+   just happened?"
+3. **Competing hires include nonconsumption.** Every Competes With list must
+   include a "hire nothing" option. Nonconsumption is usually the real
+   incumbent.
+4. **Pull describes a desired future, not a feature list.** "Confidence that
+   a staffing change strengthens the team" is a future state. "System-level
+   team views and what-if scenarios" is a feature list.
+5. **Forces are asymmetric.** One force often dominates. If all four feel
+   equally weighted, the analysis was filled in from a template rather than
+   reconstructed from a decision story.
+6. **Fired When includes the world, not just the product.** Products get
+   abandoned when the environment shifts — a reorg, a budget cut, a tool ban.
+7. **Field-validated, not desk-authored.** JTBD entries are hypotheses until
+   confirmed by customer struggle stories. An entry that surprises the product
+   team is more likely correct than one that confirms existing assumptions.
+
+## Jobs: Big Hires and Little Hires
+
+Jobs are distributed across the codebase so they live near the code that
+serves them:
+
+- **Big Hires** — the adoption decision per persona-outcome pair. Live in
+  [JTBD.md](JTBD.md). Use the full entry structure above.
+- **Little Hires** — narrower, repeated daily jobs. Live wherever they fit
+  best: product, service, and library READMEs; design docs; nearby code.
+
+### `<job>` Tagging Convention
+
+Wrap every job — Big or Little — in a semantic tag so it can be discovered
+without knowing where it lives:
+
+```markdown
+<job user="Engineering Leaders" goal="Staff Teams to Succeed">
+
+**Trigger:** A post-mortem surfaces the same skill gap that caused the last
+incident.
+
+**Big Hire:** Help me make staffing decisions I can defend with evidence, not
+intuition. → **Summit**
+
+**Little Hire:** Help me spot capability gaps before someone gets set up to
+fail. → **Summit**
+
+</job>
+```
+
+- Tag attributes (`user`, `goal`) make search results self-describing — each
+  match shows purpose without opening the file.
+- Keep the full opening tag on one line within 74 characters so `rg` output
+  stays coherent.
+
+Discover jobs from anywhere in the repo:
+
+```sh
+rg '<job '   # all jobs — Big in JTBD.md, Little near the code
+```
+
+## Internal Contributors vs External Users
+
+The monorepo is open source but exists primarily for internal contributors.
+External users consume products as published artifacts and never read the
+source. Two consequences shape the structure:
+
+- Internal-only conventions (build tooling, codegen, internal scripts) live in
+  the monorepo and don't appear in published artifacts.
+- Documentation aimed at external users lives where they can reach it
+  (published packages, hosted sites), not in internal-only files.
+
+`CLAUDE.md` is the canonical place to spell out the specific tooling split —
+package manager, task runner, codegen.

--- a/websites/CLAUDE.md
+++ b/websites/CLAUDE.md
@@ -1,18 +1,23 @@
 # Websites
 
-Two sites built by `fit-doc`
-([internals](fit/docs/internals/fit-doc/index.md)).
+Four sites built by `fit-doc`
+([internals](fit/docs/internals/fit-doc/index.md)). Two are live; two are
+placeholders pending content and a publish workflow.
 
-| Site                       | Source           | Domain                   |
-| -------------------------- | ---------------- | ------------------------ |
-| Forward Impact Engineering | `websites/fit/`  | `www.forwardimpact.team` |
-| Kata Agent Team            | `websites/kata/` | `www.kata.team`          |
+| Site                       | Source                | Domain                   | Status      |
+| -------------------------- | --------------------- | ------------------------ | ----------- |
+| Forward Impact Engineering | `websites/fit/`       | `www.forwardimpact.team` | Live        |
+| Kata Agent Team            | `websites/kata/`      | `www.kata.team`          | Live        |
+| Co-Aligned                 | `websites/coaligned/` | `www.coaligned.team`     | Placeholder |
+| Monorepo Structure         | `websites/monorepo/`  | `www.monorepo.team`      | Placeholder |
 
 Preview locally:
 
 ```sh
 bunx fit-doc serve --src=websites/fit --watch
 bunx fit-doc serve --src=websites/kata --watch
+bunx fit-doc serve --src=websites/coaligned --watch
+bunx fit-doc serve --src=websites/monorepo --watch
 ```
 
 ## Page Conventions
@@ -115,13 +120,16 @@ pre-build hook. Asset paths in pages are absolute (`/assets/scene-guide.svg`).
 
 ## Publishing Pipeline
 
-Both sites share the same deployment pattern. Workflows in
+Live sites share the same deployment pattern. Workflows in
 `.github/workflows/`:
 
 | Workflow            | Artifact     | Pages repo                 |
 | ------------------- | ------------ | -------------------------- |
 | `website-fit.yaml`  | `fit-pages`  | `forwardimpact/fit-pages`  |
 | `website-kata.yaml` | `kata-pages` | `forwardimpact/kata-pages` |
+
+The Co-Aligned and Monorepo placeholder sites do not yet have publish
+workflows; they will be added when the sites are ready to ship.
 
 Push to `main` (path-filtered) triggers: build with `fit-doc`, upload artifact,
 dispatch to the pages repo via GitHub App token. The pages repo deploys to

--- a/websites/coaligned/CNAME
+++ b/websites/coaligned/CNAME
@@ -1,0 +1,1 @@
+www.coaligned.team

--- a/websites/coaligned/index.md
+++ b/websites/coaligned/index.md
@@ -1,0 +1,19 @@
+---
+title: Co-Aligned Teams of Humans & Coding Agents
+description: A design manifest for creating aligned coding agents — a layered instruction architecture grounded in Jobs To Be Done and The Checklist Manifesto.
+toc: false
+---
+
+A design manifest for creating aligned coding agents. A layered instruction
+architecture — grounded in Jobs To Be Done and The Checklist Manifesto —
+keeps humans and agents aligned to the progress each persona seeks, and keeps
+that alignment under load.
+
+Co-Aligned builds on the [Monorepo](https://www.monorepo.team/) repository
+structure and is the upstream architecture that the
+[Kata Agent Team](https://www.kata.team/) implements.
+
+## Learn more
+
+- [COALIGNED.md on GitHub](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
+- [View on GitHub](https://github.com/forwardimpact/monorepo/)

--- a/websites/coaligned/index.template.html
+++ b/websites/coaligned/index.template.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {{#description}}
+    <meta name="description" content="{{description}}" />
+    {{/description}}
+    <title>Co-Aligned – {{title}}</title>
+    <link rel="alternate" type="text/markdown" href="{{markdownUrl}}" />
+    {{#canonicalUrl}}
+    <link rel="canonical" href="{{canonicalUrl}}" />
+    {{/canonicalUrl}}
+  </head>
+  <body>
+    <main>
+      <h1>{{title}}</h1>
+      {{{content}}}
+    </main>
+  </body>
+</html>

--- a/websites/coaligned/robots.txt
+++ b/websites/coaligned/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.coaligned.team/sitemap.xml

--- a/websites/fit/assets/main.css
+++ b/websites/fit/assets/main.css
@@ -860,15 +860,35 @@ pre code {
   align-items: center;
 }
 
-.footer-brand {
+.footer-column {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: var(--space-2);
+}
+
+.footer-column-left {
+  align-items: flex-start;
+}
+
+.footer-column-right {
+  align-items: flex-end;
+}
+
+.footer-heading {
   font-family: var(--font-sans);
   font-weight: 700;
   font-size: 0.9375rem;
   color: var(--text-on-dark);
-  text-decoration: none;
+}
+
+.footer-column a {
+  color: var(--gray-300);
+  font-size: var(--text-small-size);
+  text-decoration-color: var(--gray-500);
+}
+
+.footer-column a:hover {
+  text-decoration-color: var(--gray-300);
 }
 
 .footer-social {
@@ -893,21 +913,6 @@ pre code {
   width: 24px;
   height: 24px;
   display: block;
-}
-
-.footer-license {
-  color: var(--gray-300);
-  font-size: var(--text-small-size);
-  text-align: right;
-}
-
-.footer-license a {
-  color: var(--gray-300);
-  text-decoration-color: var(--gray-500);
-}
-
-.footer-license a:hover {
-  text-decoration-color: var(--gray-300);
 }
 
 /* ── Mermaid Diagrams ──────────────────────────────────────────── */
@@ -1111,11 +1116,7 @@ pre:has(.language-mermaid) {
     text-align: center;
   }
 
-  .footer-brand {
-    justify-content: center;
-  }
-
-  .footer-license {
-    text-align: center;
+  .footer-column {
+    align-items: center;
   }
 }

--- a/websites/fit/index.template.html
+++ b/websites/fit/index.template.html
@@ -31,7 +31,6 @@
           <li><a href="/gear/">Gear</a></li>
           <li class="nav-spacer"></li>
           <li class="nav-secondary"><a href="/docs/">Docs</a></li>
-          <li class="nav-secondary"><a href="/about/">About</a></li>
         </ul>
         <button class="nav-toggle" aria-label="Toggle navigation">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
@@ -85,7 +84,11 @@
 
     <footer class="site-footer">
       <div class="footer-inner">
-        <div class="footer-brand">Forward Impact Engineering</div>
+        <div class="footer-column footer-column-left">
+          <span class="footer-heading">Forward Impact Engineering</span>
+          <a href="/about/">About</a>
+          <a href="/meta/">Meta</a>
+        </div>
         <div class="footer-social">
           <a href="https://github.com/forwardimpact/monorepo" target="_blank" aria-label="GitHub">
             <img src="https://cdn.simpleicons.org/github/9ca3af" alt="" width="24" height="24" />
@@ -94,10 +97,10 @@
             <img src="https://cdn.simpleicons.org/npm/9ca3af" alt="" width="24" height="24" />
           </a>
         </div>
-        <div class="footer-license">
-          Code licensed
-          <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache 2.0</a>, docs
-          <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a>
+        <div class="footer-column footer-column-right">
+          <span class="footer-heading">Copyright 2026</span>
+          <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">Code: Apache 2.0</a>
+          <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">Docs: CC BY 4.0</a>
         </div>
       </div>
     </footer>

--- a/websites/fit/meta/index.md
+++ b/websites/fit/meta/index.md
@@ -1,0 +1,30 @@
+---
+title: Meta
+description: The system that emerged from building the Forward Impact products — Monorepo, Co-Aligned, and Kata.
+toc: false
+---
+
+Building the Forward Impact products surfaced a system underneath them — three
+layers of structure and discipline, each built on the one below. We named the
+layers and made them their own thing.
+
+```text
+   Kata          ← autonomous agent team running PDSA
+      ▲
+   Co-Aligned    ← layered instruction architecture
+      ▲
+   Monorepo      ← structural conventions
+```
+
+**[Monorepo](https://www.monorepo.team/)** — Structural conventions for a
+repository shared by humans and coding agents. Top-level directories, root
+manifest files, a jobs catalogue.
+
+**[Co-Aligned](https://www.coaligned.team/)** — A layered instruction
+architecture grounded in Jobs To Be Done and The Checklist Manifesto. Builds
+on Monorepo.
+
+**[Kata](https://www.kata.team/)** — An autonomous agentic development team
+running a daily Plan-Do-Study-Act loop. Implements both upstream standards.
+
+The Forward Impact products are now downstream consumers of all three layers.

--- a/websites/kata/index.md
+++ b/websites/kata/index.md
@@ -9,6 +9,10 @@ daily Plan-Do-Study-Act cycle. Agents use spec-driven development to plan and
 ship, then study their own traces and act on findings — closing the loop every
 day.
 
+Kata is an implementation of two upstream standards: the
+[Monorepo](https://www.monorepo.team/) repository structure and the
+[Co-Aligned](https://www.coaligned.team/) instruction architecture.
+
 ## Learn more
 
 - [Kata Internals](https://www.forwardimpact.team/docs/internals/kata/)

--- a/websites/monorepo/CNAME
+++ b/websites/monorepo/CNAME
@@ -1,0 +1,1 @@
+www.monorepo.team

--- a/websites/monorepo/index.md
+++ b/websites/monorepo/index.md
@@ -1,0 +1,20 @@
+---
+title: Monorepo Structure
+description: Structural conventions for repositories shared by humans and coding agents — top-level directories, root manifest files, and a jobs catalogue.
+toc: false
+---
+
+Structural conventions for a repository shared by humans and coding agents.
+Top-level directories carry shippable code, root manifest files orient every
+contributor, and a jobs catalogue grounds them in the progress each persona
+seeks.
+
+This is the upstream structure that
+[Co-Aligned](https://www.coaligned.team/) layers an instruction architecture
+on top of, and that the [Kata Agent Team](https://www.kata.team/) implements
+as a running Plan-Do-Study-Act loop.
+
+## Learn more
+
+- [MONOREPO.md on GitHub](https://github.com/forwardimpact/monorepo/blob/main/MONOREPO.md)
+- [View on GitHub](https://github.com/forwardimpact/monorepo/)

--- a/websites/monorepo/index.template.html
+++ b/websites/monorepo/index.template.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {{#description}}
+    <meta name="description" content="{{description}}" />
+    {{/description}}
+    <title>Monorepo – {{title}}</title>
+    <link rel="alternate" type="text/markdown" href="{{markdownUrl}}" />
+    {{#canonicalUrl}}
+    <link rel="canonical" href="{{canonicalUrl}}" />
+    {{/canonicalUrl}}
+  </head>
+  <body>
+    <main>
+      <h1>{{title}}</h1>
+      {{{content}}}
+    </main>
+  </body>
+</html>

--- a/websites/monorepo/robots.txt
+++ b/websites/monorepo/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.monorepo.team/sitemap.xml


### PR DESCRIPTION
## Summary

Three coherent commits, three concerns:

1. **`docs: establish monorepo / coaligned / kata manifest layers`**
   Extract the generic monorepo structure from `COALIGNED.md` into a new
   upstream `MONOREPO.md`. Make `COALIGNED.md` downstream of it and `KATA.md`
   downstream of both. Add Deming and Gawande epigraphs. Align voice, heading
   patterns, and list spacing across all three manifests.

2. **`feat(websites): add monorepo.team and coaligned.team placeholder sites`**
   Mirror `websites/kata/` for two new placeholder sites with two-paragraph
   index pages cross-linking the trio. List them in `websites/CLAUDE.md` with
   a Status column. Add `website-monorepo.yaml` and `website-coaligned.yaml`
   publishing workflows mirroring `website-kata.yaml`. Pages repos
   `forwardimpact/monorepo-pages` and `forwardimpact/coaligned-pages` were
   created out-of-tree with matching `deploy.yaml` workflows.

3. **`feat(fit-website): add /meta/ page and restructure footer`**
   New `/meta/` page summarising the three-layer system with a tight ASCII
   stack diagram. Move About from header nav into a generalised footer brand
   column. Add a Copyright/license column matching the brand column structure
   — both columns share `.footer-column` + `.footer-heading`, differing only
   in alignment.

## Test plan

- [x] `bun run check` passes locally
- [x] `bun run test` — pre-existing wiki-infra failures on `main`, unaffected
      by this branch (verified by running tests on `main` alone)
- [x] `bunx fit-doc build websites/{fit,monorepo,coaligned}` all build cleanly

## Manual follow-ups (out of PR scope)

For `monorepo.team` and `coaligned.team` to actually serve:

- Configure GitHub Pages on `forwardimpact/monorepo-pages` and
  `forwardimpact/coaligned-pages` (Source: GitHub Actions, custom domain)
- Install `kata-agent-team` GitHub App on the two new pages repos
- Add `KATA_APP_ID` and `KATA_APP_PRIVATE_KEY` secrets to each pages repo
- DNS: CNAME `www.{monorepo,coaligned}.team` → `forwardimpact.github.io`,
  apex A records to GitHub Pages IPs

https://claude.ai/code/session_01LgfeQ9tsA2hijVN49bJJSC