### PR TITLE
feat(eval): add --mcp-server to fit-eval and eval-guide workflow

### DIFF
--- a/.github/actions/kata-action-eval/action.yml
+++ b/.github/actions/kata-action-eval/action.yml
@@ -54,6 +54,9 @@ inputs:
   task-amend:
     description: Additional text appended to the task prompt for steering
     required: false
+  mcp-server:
+    description: "MCP service name to connect to (e.g. guide); adds mcp__<name>__* to allowed tools"
+    required: false
   trace:
     description: Enable trace capture and artifact upload
     required: false
@@ -92,6 +95,7 @@ runs:
         FACILITATOR_PROFILE: ${{ inputs.facilitator-profile }}
         AGENT_PROFILES: ${{ inputs.agent-profiles }}
         TASK_AMEND: ${{ inputs.task-amend }}
+        MCP_SERVER: ${{ inputs.mcp-server }}
         TRACE_ENABLED: ${{ inputs.trace }}
         TRACE_DIR: ${{ steps.setup.outputs.trace-dir }}
         TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
@@ -122,6 +126,10 @@ runs:
 
         if [ -n "$TASK_AMEND" ]; then
           args+=("--task-amend=$TASK_AMEND")
+        fi
+
+        if [ -n "$MCP_SERVER" ]; then
+          args+=("--mcp-server=$MCP_SERVER")
         fi
 
         if [ "$TRACE_ENABLED" = "true" ] && [ -n "$TRACE_DIR" ]; then

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -1,0 +1,83 @@
+name: "Eval Guide"
+
+on:
+  workflow_dispatch:
+    inputs:
+      task-amend:
+        description: "Additional text appended to the task prompt for steering"
+        required: false
+        type: string
+
+concurrency:
+  group: eval-guide
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  eval-guide:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.ci-app.outputs.token }}
+
+      - uses: ./.github/actions/bootstrap
+        with:
+          token: ${{ steps.ci-app.outputs.token }}
+          app-slug: kata-agent-team
+          app-id: ${{ secrets.KATA_APP_ID }}
+
+      - name: Build data pipeline
+        shell: bash
+        run: |
+          just data-init
+          just synthetic
+          just process-fast
+
+      - name: Start services
+        shell: bash
+        run: |
+          just env-setup
+          just rc-start
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:3005/health > /dev/null 2>&1 && break
+            [ "$i" -eq 30 ] && { echo "::error::MCP service failed to start"; exit 1; }
+            sleep 1
+          done
+
+      - name: Prepare agent workspace
+        id: agent-workspace
+        shell: bash
+        run: echo "dir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
+
+      - name: Run eval
+        uses: ./.github/actions/kata-action-eval
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+        with:
+          mode: "supervise"
+          task-text: "Ask the agent to find the engineering standard for data engineering. The agent has MCP tools to query the knowledge base. Review the agent's findings for accuracy and completeness, then call Conclude with a summary indicating success or failure."
+          supervisor-cwd: "."
+          agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
+          model: "claude-opus-4-7[1m]"
+          max-turns: "200"
+          allowed-tools: "Bash,Read,Glob,Grep,Write,Edit"
+          mcp-server: "guide"
+          task-amend: ${{ inputs.task-amend }}
+
+      - name: Stop services
+        if: always()
+        shell: bash
+        run: just rc-stop || true

--- a/libraries/libeval/bin/fit-eval.js
+++ b/libraries/libeval/bin/fit-eval.js
@@ -59,6 +59,11 @@ const definition = {
           type: "string",
           description: "Comma-separated tool allowlist",
         },
+        "mcp-server": {
+          type: "string",
+          description:
+            "Connect to the MCP service (e.g. --mcp-server=guide); adds mcp__<name>__* to allowed tools",
+        },
       },
     },
     {
@@ -105,6 +110,11 @@ const definition = {
         "supervisor-allowed-tools": {
           type: "string",
           description: "Supervisor tool allowlist",
+        },
+        "mcp-server": {
+          type: "string",
+          description:
+            "Connect to the MCP service (e.g. --mcp-server=guide); adds mcp__<name>__* to allowed tools",
         },
       },
     },

--- a/libraries/libeval/src/commands/run.js
+++ b/libraries/libeval/src/commands/run.js
@@ -5,6 +5,7 @@ import { createAgentRunner } from "../agent-runner.js";
 import { composeProfilePrompt } from "../profile-prompt.js";
 import { createTeeWriter } from "../tee-writer.js";
 import { SequenceCounter } from "../sequence-counter.js";
+import { createServiceConfig } from "@forwardimpact/libconfig";
 
 /**
  * Parse and validate run command options from parsed values.
@@ -35,6 +36,7 @@ function parseRunOptions(values) {
       values["allowed-tools"] ??
       "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"
     ).split(","),
+    mcpServer: values["mcp-server"] ?? undefined,
   };
 }
 
@@ -56,6 +58,7 @@ export async function runRunCommand(values, _args) {
     outputPath,
     agentProfile,
     allowedTools,
+    mcpServer,
   } = parseRunOptions(values);
 
   // When --output is specified, stream text to stdout while writing NDJSON to file.
@@ -77,6 +80,19 @@ export async function runRunCommand(values, _args) {
       JSON.stringify({ source: "agent", seq: counter.next(), event }) + "\n",
     );
   };
+
+  let mcpServers = null;
+  if (mcpServer) {
+    const mcpConfig = await createServiceConfig("mcp");
+    mcpServers = {
+      [mcpServer]: {
+        type: "http",
+        url: mcpConfig.url,
+        headers: { Authorization: `Bearer ${mcpConfig.mcpToken()}` },
+      },
+    };
+    allowedTools.push(`mcp__${mcpServer}__*`);
+  }
 
   if (agentProfile) {
     process.env.LIBEVAL_AGENT_PROFILE = agentProfile;
@@ -100,6 +116,7 @@ export async function runRunCommand(values, _args) {
     settingSources: ["project"],
     systemPrompt,
     taskAmend,
+    mcpServers,
   });
 
   const result = await runner.run(taskContent);

--- a/libraries/libeval/src/commands/supervise.js
+++ b/libraries/libeval/src/commands/supervise.js
@@ -3,6 +3,7 @@ import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createSupervisor } from "../supervisor.js";
 import { createTeeWriter } from "../tee-writer.js";
+import { createServiceConfig } from "@forwardimpact/libconfig";
 
 /**
  * Parse all supervise flags from parsed values into an options object.
@@ -44,6 +45,7 @@ function parseSuperviseOptions(values) {
     supervisorAllowedTools: supervisorAllowedToolsRaw
       ? supervisorAllowedToolsRaw.split(",")
       : undefined,
+    mcpServer: values["mcp-server"] ?? undefined,
   };
 }
 
@@ -71,6 +73,19 @@ export async function runSuperviseCommand(values, _args) {
       })
     : process.stdout;
 
+  let agentMcpServers = null;
+  if (opts.mcpServer) {
+    const mcpConfig = await createServiceConfig("mcp");
+    agentMcpServers = {
+      [opts.mcpServer]: {
+        type: "http",
+        url: mcpConfig.url,
+        headers: { Authorization: `Bearer ${mcpConfig.mcpToken()}` },
+      },
+    };
+    opts.allowedTools.push(`mcp__${opts.mcpServer}__*`);
+  }
+
   if (opts.agentProfile) {
     process.env.LIBEVAL_AGENT_PROFILE = opts.agentProfile;
   }
@@ -88,6 +103,7 @@ export async function runSuperviseCommand(values, _args) {
     supervisorProfile: opts.supervisorProfile,
     agentProfile: opts.agentProfile,
     taskAmend: opts.taskAmend,
+    agentMcpServers,
   });
 
   const result = await supervisor.run(opts.taskContent);

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -466,6 +466,7 @@ const devNull = new Writable({
  * @param {string} [deps.agentProfile] - Agent profile name; resolved into the main-thread system prompt via `composeProfilePrompt`.
  * @param {string} [deps.profilesDir] - Directory containing `<name>.md` profile files. Defaults to `<supervisorCwd>/.claude/agents`. Resolved once from the orchestrator's cwd so profiles travel with the project, not with a per-agent sandbox.
  * @param {string} [deps.taskAmend] - Opaque addendum appended to the task before delivery.
+ * @param {Record<string, object>} [deps.agentMcpServers] - Additional MCP servers exposed to the agent (merged alongside the orchestration server).
  * @returns {Supervisor}
  */
 export function createSupervisor({
@@ -482,6 +483,7 @@ export function createSupervisor({
   agentProfile,
   profilesDir,
   taskAmend,
+  agentMcpServers,
 }) {
   const resolvedProfilesDir =
     profilesDir ?? resolve(supervisorCwd, ".claude/agents");
@@ -521,7 +523,7 @@ export function createSupervisor({
     onLine,
     settingSources: ["project"],
     systemPrompt: systemPromptFor(agentProfile, AGENT_SYSTEM_PROMPT),
-    mcpServers: { orchestration: agentServer },
+    mcpServers: { orchestration: agentServer, ...agentMcpServers },
   });
 
   const defaultDisallowed = ["Agent", "Task", "TaskOutput", "TaskStop"];

--- a/libraries/libeval/test/supervisor-factory.test.js
+++ b/libraries/libeval/test/supervisor-factory.test.js
@@ -98,4 +98,16 @@ describe("Supervisor - createSupervisor factory", () => {
     assert.ok(s.supervisorRunner.mcpServers);
     assert.strictEqual(s.supervisorRunner.mcpServers.orchestration.type, "sdk");
   });
+
+  test("merges agentMcpServers into agent runner only", () => {
+    const s = createSupervisor({
+      ...baseOpts(),
+      agentMcpServers: {
+        guide: { type: "http", url: "http://localhost:3005" },
+      },
+    });
+    assert.strictEqual(s.agentRunner.mcpServers.orchestration.type, "sdk");
+    assert.strictEqual(s.agentRunner.mcpServers.guide.type, "http");
+    assert.strictEqual(s.supervisorRunner.mcpServers.guide, undefined);
+  });
 });


### PR DESCRIPTION
## Summary

- Add `--mcp-server` flag to `fit-eval run` and `fit-eval supervise` commands
- Wire MCP server config through `createSupervisor()` factory to agent runner
- Add `mcp-server` input to `kata-action-eval` composite action
- Create `eval-guide.yml` workflow: data pipeline → services → supervised MCP eval

## Test plan

- [x] 305 libeval tests pass (including new merge test)
- [ ] Trigger eval-guide workflow and verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)