### PR TITLE
fix(eval): strip SearchContent in CI; derive routing from tool config

### DIFF
--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -50,6 +50,22 @@ jobs:
         shell: bash
         run: node -e "const m = await import('./products/guide/src/commands/init.js'); await m.runInitCommand();"
 
+      # SearchContent depends on the vector index, which `just process-fast`
+      # skips because building embeddings is heavy. Strip the tool here so the
+      # eval doesn't expose a wired-up tool that has no data behind it. The
+      # starter config keeps SearchContent for normal users who run the full
+      # `just process` pipeline.
+      - name: Strip SearchContent from eval config
+        shell: bash
+        run: |
+          node -e "
+            const fs = require('node:fs');
+            const path = 'config/config.json';
+            const cfg = JSON.parse(fs.readFileSync(path, 'utf8'));
+            delete cfg.service.mcp.tools.SearchContent;
+            fs.writeFileSync(path, JSON.stringify(cfg, null, 2) + '\n');
+          "
+
       - name: Start services
         shell: bash
         run: |

--- a/products/guide/starter/config.json
+++ b/products/guide/starter/config.json
@@ -36,7 +36,7 @@
   },
   "service": {
     "mcp": {
-      "systemPrompt": "These tools query an agent-aligned engineering standard — disciplines, levels, tracks, capabilities, skills, behaviours, and career progression. Ground every claim in tool results. Never fabricate entities, levels, or skills. If data is insufficient, say so.\n\nCall `GetOntology` first to learn entity types and predicates, then route:\n- Jobs/roles → `DescribeJob`, `ListJobs`\n- Skills for a capability → `QueryByPattern` with capability URI\n- Behaviour maturity → `QueryByPattern` with behaviour URI\n- Progression deltas → `DescribeProgression`\n- Agent profiles → `ListAgentProfiles`, `DescribeAgentProfile`\n- Open-ended questions → `SearchContent`\n- Entity discovery → `GetSubjects`",
+      "systemPrompt": "These tools query an agent-aligned engineering standard — disciplines, levels, tracks, capabilities, skills, behaviours, and career progression. Ground every claim in tool results. Never fabricate entities, levels, or skills. If data is insufficient, say so.\n\nCall `GetOntology` first to learn entity types and predicates, then route:",
       "tools": {
         "GetOntology": {
           "method": "graph.Graph.GetOntology",
@@ -44,35 +44,46 @@
         },
         "GetSubjects": {
           "method": "graph.Graph.GetSubjects",
-          "description": "Lists entity URIs in the graph, optionally filtered by type."
+          "description": "Lists entity URIs in the graph, optionally filtered by type.",
+          "routing": ["Entity discovery"]
         },
         "QueryByPattern": {
           "method": "graph.Graph.QueryByPattern",
-          "description": "Retrieves structured data by traversing graph relationships using triple patterns."
+          "description": "Retrieves structured data by traversing graph relationships using triple patterns.",
+          "routing": [
+            "Skills for a capability (use capability URI)",
+            "Behaviour maturity (use behaviour URI)"
+          ]
         },
         "SearchContent": {
           "method": "vector.Vector.SearchContent",
-          "description": "Find detailed content using semantic similarity search."
+          "description": "Find detailed content using semantic similarity search.",
+          "routing": ["Open-ended questions"]
         },
         "ListJobs": {
           "method": "pathway.Pathway.ListJobs",
-          "description": "List jobs (discipline x level x track) defined in the pathway standard."
+          "description": "List jobs (discipline x level x track) defined in the pathway standard.",
+          "routing": ["Jobs/roles"]
         },
         "DescribeJob": {
           "method": "pathway.Pathway.DescribeJob",
-          "description": "Describe a job at (discipline, level, optional track) including skills, behaviours, and responsibilities."
+          "description": "Describe a job at (discipline, level, optional track) including skills, behaviours, and responsibilities.",
+          "routing": ["Jobs/roles"]
         },
         "ListAgentProfiles": {
           "method": "pathway.Pathway.ListAgentProfiles",
-          "description": "List static agent profile (discipline, track) combinations."
+          "description": "List static agent profile (discipline, track) combinations.",
+          "routing": ["Agent profiles"]
         },
         "DescribeAgentProfile": {
           "method": "pathway.Pathway.DescribeAgentProfile",
-          "description": "Describe stage agent profiles for a (discipline, track)."
+          "description": "Describe stage agent profiles for a (discipline, track).",
+          "routing": ["Agent profiles"]
         },
         "DescribeProgression": {
           "method": "pathway.Pathway.DescribeProgression",
-          "description": "Compute the progression delta between two levels of the same discipline."
+          "description": "Compute the progression delta between two levels of the same discipline.",
+          "routing": ["Progression deltas"]
         },
         "ListJobSoftware": {
           "method": "pathway.Pathway.ListJobSoftware",

--- a/products/guide/test/cli.test.js
+++ b/products/guide/test/cli.test.js
@@ -34,10 +34,17 @@ describe("fit-guide CLI", () => {
     assert.ok(source.includes("options.systemPrompt = systemPrompt"));
   });
 
-  test("tracks session ID across turns", () => {
-    assert.ok(source.includes("sessionId"));
+  test("tracks session ID across turns within a single process", () => {
+    assert.ok(source.includes("let sessionId = null"));
     assert.ok(source.includes("session_id"));
-    assert.ok(source.includes("options.resume = state.sessionId"));
+    assert.ok(source.includes("options.resume = sessionId"));
+  });
+
+  test("does not persist session ID to disk across process restarts", () => {
+    assert.ok(
+      !source.includes("state.sessionId"),
+      "sessionId must not live on librepl state — librepl persists state to storage and SDK sessions are ephemeral",
+    );
   });
 
   test("no process.exit(0) after repl.start()", () => {

--- a/services/mcp/index.js
+++ b/services/mcp/index.js
@@ -10,6 +10,26 @@ const SESSION_IDLE_MS = 30 * 60 * 1000;
 const SESSION_SWEEP_MS = 60_000;
 const SHUTDOWN_TIMEOUT_MS = 5000;
 
+/**
+ * Builds the MCP prompt by appending one routing line per (tool, statement)
+ * pair. Tools omitted from config — including those stripped post-init for a
+ * particular environment — contribute no lines, keeping the prompt in sync
+ * with actual tool wiring.
+ *
+ * @param {string} systemPrompt - Static prompt text from config
+ * @param {Record<string, { routing?: string[] }>} [tools] - Tool definitions
+ * @returns {string} Composed prompt text
+ */
+export function buildPromptText(systemPrompt, tools) {
+  const lines = [];
+  for (const [name, def] of Object.entries(tools || {})) {
+    for (const stmt of def.routing || []) {
+      lines.push(`${stmt} -> ${name}`);
+    }
+  }
+  return lines.length ? `${systemPrompt}\n${lines.join("\n")}` : systemPrompt;
+}
+
 function sendJson(res, status, body) {
   res.writeHead(status, { "Content-Type": "application/json" });
   res.end(JSON.stringify(body));
@@ -111,7 +131,7 @@ export function createMcpService({
   }
 
   async function start() {
-    const promptText = config.systemPrompt;
+    const promptText = buildPromptText(config.systemPrompt, config.tools);
     const host = config.host || "0.0.0.0";
     const port = config.port || 3005;
     const expectedToken = config.mcpToken();

--- a/services/mcp/test/mcp.test.js
+++ b/services/mcp/test/mcp.test.js
@@ -2,7 +2,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert";
 import { spy } from "@forwardimpact/libharness";
 
-import { createMcpService } from "../index.js";
+import { buildPromptText, createMcpService } from "../index.js";
 import { registerToolsFromConfig } from "@forwardimpact/libmcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -98,6 +98,48 @@ async function callTool(mcpServer, toolName, args = {}) {
   if (!tool) throw new Error(`Tool ${toolName} not registered`);
   return tool.handler({ name: toolName, arguments: args });
 }
+
+describe("buildPromptText", () => {
+  test("returns systemPrompt unchanged when no tools have routing", () => {
+    const result = buildPromptText("intro", {
+      A: { method: "x.X.A", description: "a" },
+    });
+    assert.strictEqual(result, "intro");
+  });
+
+  test("appends one line per (tool, routing statement) pair", () => {
+    const result = buildPromptText("intro", {
+      ListJobs: { method: "p.P.ListJobs", routing: ["Jobs/roles"] },
+      DescribeJob: { method: "p.P.DescribeJob", routing: ["Jobs/roles"] },
+      QueryByPattern: {
+        method: "g.G.QueryByPattern",
+        routing: ["Skills (capability URI)", "Behaviour maturity"],
+      },
+    });
+    assert.strictEqual(
+      result,
+      [
+        "intro",
+        "Jobs/roles -> ListJobs",
+        "Jobs/roles -> DescribeJob",
+        "Skills (capability URI) -> QueryByPattern",
+        "Behaviour maturity -> QueryByPattern",
+      ].join("\n"),
+    );
+  });
+
+  test("omits routing lines for tools that are removed", () => {
+    const result = buildPromptText("intro", {
+      ListJobs: { method: "p.P.ListJobs", routing: ["Jobs/roles"] },
+    });
+    assert.ok(!result.includes("SearchContent"));
+    assert.ok(result.includes("Jobs/roles -> ListJobs"));
+  });
+
+  test("handles missing tools object", () => {
+    assert.strictEqual(buildPromptText("intro", undefined), "intro");
+  });
+});
 
 describe("MCP service", () => {
   describe("tool registration", () => {


### PR DESCRIPTION
SearchContent depends on a populated vector index, which `just process-fast`
in eval-guide.yml skips because building embeddings is heavy. The eval was
exposing a wired-up tool whose backend had no data and no service running.

- Add a CI-only step that deletes SearchContent from the eval workspace's
  config.json after `runInitCommand`, so external users still get the tool
  by default when they run the full `just process` pipeline.
- Move the per-tool routing list out of the static MCP system prompt and
  into a `routing` array on each tool definition. The MCP service now
  composes the prompt by appending `<statement> -> <ToolName>` lines, so
  removing a tool's wiring also removes its routing line automatically.

https://claude.ai/code/session_01EqmFcrHbSAjZf4HmejFU3h