### PR TITLE
feat(eval): 5-case eval-guide matrix with verdict-aware Conclude

### DIFF
--- a/.github/actions/kata-action-eval/action.yml
+++ b/.github/actions/kata-action-eval/action.yml
@@ -65,6 +65,10 @@ inputs:
     description: Maximum minutes the agent step may run before being cancelled
     required: false
     default: "45"
+  artifact-suffix:
+    description: Suffix appended to uploaded trace artifact names (required to disambiguate matrix runs)
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -201,7 +205,7 @@ runs:
       if: always() && inputs.trace == 'true' && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: agent-trace
+        name: agent-trace${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
         path: |
           ${{ (inputs.mode == 'supervise' || inputs.mode == 'facilitate') && format('{0}/trace-agent.ndjson', steps.setup.outputs.trace-dir) || format('{0}/trace.ndjson', steps.setup.outputs.trace-dir) }}
 
@@ -209,21 +213,21 @@ runs:
       if: always() && inputs.trace == 'true' && inputs.mode == 'supervise' && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: supervisor-trace
+        name: supervisor-trace${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
         path: ${{ steps.setup.outputs.trace-dir }}/trace-supervisor.ndjson
 
     - name: Upload facilitator trace
       if: always() && inputs.trace == 'true' && inputs.mode == 'facilitate' && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: facilitator-trace
+        name: facilitator-trace${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
         path: ${{ steps.setup.outputs.trace-dir }}/trace-facilitator.ndjson
 
     - name: Upload per-agent traces
       if: always() && inputs.trace == 'true' && inputs.mode == 'facilitate' && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: per-agent-traces
+        name: per-agent-traces${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
         path: |
           ${{ steps.setup.outputs.trace-dir }}/trace-*.ndjson
           !${{ steps.setup.outputs.trace-dir }}/trace-facilitator.ndjson
@@ -233,5 +237,5 @@ runs:
       if: always() && inputs.trace == 'true' && (inputs.mode == 'supervise' || inputs.mode == 'facilitate') && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: combined-trace
+        name: combined-trace${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
         path: ${{ steps.setup.outputs.trace-dir }}/trace.ndjson

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -18,6 +18,61 @@ permissions:
 jobs:
   eval-guide:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        case:
+          - id: discipline-core-skills
+            task: >-
+              Ask the agent: "What are the core skills of the Data Engineering
+              discipline?" The agent has MCP tools to query the engineering
+              standard knowledge base. Ground your conclusion only in
+              data/synthetic/story.dsl — read that file directly to verify the
+              agent's answer. Conclude success only if the agent lists exactly
+              these three core skills: data_integration, data_modeling,
+              performance_optimization. Otherwise, Conclude with failure and
+              explain what was wrong.
+
+          - id: capability-skills
+            task: >-
+              Ask the agent: "Which skills make up the Reliability capability?"
+              The agent has MCP tools to query the engineering standard. Ground
+              your conclusion only in data/synthetic/story.dsl — read that file
+              directly to verify the agent's answer. Conclude success only if
+              the agent lists exactly: sre_practices, incident_management,
+              observability, change_management. Otherwise, Conclude with failure
+              and explain.
+
+          - id: level-title
+            task: >-
+              Ask the agent: "What is the title of level J090 in the engineering
+              standard?" Ground your conclusion only in data/synthetic/story.dsl
+              — read that file directly to verify. Conclude success only if the
+              agent answers "Staff Engineer". Otherwise, Conclude with failure.
+
+          - id: project-team-managers
+            task: >-
+              Ask the agent: "Which teams work on the MolecularForge project,
+              and who manages each of those teams?" The agent has MCP tools to
+              query the knowledge graph. Ground your conclusion only in
+              data/synthetic/story.dsl — read that file directly to verify.
+              Conclude success only if the agent identifies both teams (Platform
+              Engineering and Data Science & AI) and both managers (Athena and
+              Prometheus). Otherwise, Conclude with failure and explain.
+
+          - id: nonexistent-discipline
+            task: >-
+              Ask the agent: "Describe the Security Engineering discipline in
+              the engineering standard — what are its core skills and
+              responsibilities?" Ground your conclusion only in
+              data/synthetic/story.dsl — read that file directly to verify. The
+              standard defines exactly five disciplines: software_engineering,
+              data_engineering, engineering_management, clinical_informatics,
+              and quality_engineering. "security" is a track, not a discipline.
+              Conclude success only if the agent reports that no Security
+              Engineering discipline exists in the standard. Conclude failure
+              if the agent fabricates skills, responsibilities, or any other
+              content for it.
     env:
       GRPC_DNS_RESOLVER: native
     steps:
@@ -93,7 +148,7 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           mode: "supervise"
-          task-text: "Ask the agent to find the engineering standard for data engineering. The agent has MCP tools to query the knowledge base. Review the agent's findings for accuracy and completeness, then call Conclude with a summary indicating success or failure."
+          task-text: ${{ matrix.case.task }}
           supervisor-cwd: "."
           agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
           model: "claude-opus-4-7[1m]"
@@ -101,6 +156,7 @@ jobs:
           allowed-tools: "Bash,Read,Glob,Grep,Write,Edit"
           mcp-server: "guide"
           task-amend: ${{ inputs.task-amend }}
+          artifact-suffix: ${{ matrix.case.id }}
 
       - name: Dump service logs
         if: failure()

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -24,14 +24,20 @@ jobs:
         case:
           - id: discipline-core-skills
             task: >-
-              Ask the agent: "What are the core skills of the Data Engineering
-              discipline?" The agent has MCP tools to query the engineering
-              standard knowledge base. Ground your conclusion only in
-              data/synthetic/story.dsl — read that file directly to verify the
-              agent's answer. Conclude with verdict="success" only if the agent lists exactly
-              these three core skills: data_integration, data_modeling,
-              performance_optimization. Otherwise, Conclude with verdict="failure" and
-              explain what was wrong.
+              Ask the agent: "In the engineering standard, the Data Engineering
+              discipline groups skills into three tiers: 'core', 'supporting',
+              and 'broad'. List ONLY the skills assigned to the 'core' tier.
+              Do not include any supporting-tier or broad-tier skills." The
+              agent has MCP tools to query the engineering standard. Ground
+              your conclusion only in data/synthetic/story.dsl — read that
+              file directly to verify (line 622: `core [data_integration,
+              data_modeling, performance_optimization]`). Conclude with
+              verdict="success" only if the agent's answer contains exactly
+              these three skills and no others: data_integration,
+              data_modeling, performance_optimization. If the agent includes
+              any supporting or broad skill (e.g. architecture_design,
+              cloud_platforms, stakeholder_management, regulatory_compliance),
+              Conclude with verdict="failure" and call out the leak.
 
           - id: capability-skills
             task: >-
@@ -43,12 +49,18 @@ jobs:
               observability, change_management. Otherwise, Conclude with verdict="failure"
               and explain.
 
-          - id: level-title
+          - id: job-title
             task: >-
-              Ask the agent: "What is the title of level J090 in the engineering
-              standard?" Ground your conclusion only in data/synthetic/story.dsl
-              — read that file directly to verify. Conclude with verdict="success" only if the
-              agent answers "Staff Engineer". Otherwise, Conclude with verdict="failure".
+              Ask the agent: "Use the DescribeJob tool to look up the job at
+              discipline=software_engineering, level=J080. What is the full
+              job title that DescribeJob returns?" Ground your conclusion only
+              in data/synthetic/story.dsl — read that file directly. The
+              expected answer is "Lead Engineer Software Engineer", composed
+              from the level title at J080 ("Lead Engineer", line 574) and
+              the software_engineering discipline's roleTitle ("Software
+              Engineer", line 612). Conclude with verdict="success" only if
+              the agent's answer contains both parts in that order.
+              Otherwise, Conclude with verdict="failure".
 
           - id: project-team-managers
             task: >-

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -28,9 +28,9 @@ jobs:
               discipline?" The agent has MCP tools to query the engineering
               standard knowledge base. Ground your conclusion only in
               data/synthetic/story.dsl — read that file directly to verify the
-              agent's answer. Conclude success only if the agent lists exactly
+              agent's answer. Conclude with verdict="success" only if the agent lists exactly
               these three core skills: data_integration, data_modeling,
-              performance_optimization. Otherwise, Conclude with failure and
+              performance_optimization. Otherwise, Conclude with verdict="failure" and
               explain what was wrong.
 
           - id: capability-skills
@@ -38,17 +38,17 @@ jobs:
               Ask the agent: "Which skills make up the Reliability capability?"
               The agent has MCP tools to query the engineering standard. Ground
               your conclusion only in data/synthetic/story.dsl — read that file
-              directly to verify the agent's answer. Conclude success only if
+              directly to verify the agent's answer. Conclude with verdict="success" only if
               the agent lists exactly: sre_practices, incident_management,
-              observability, change_management. Otherwise, Conclude with failure
+              observability, change_management. Otherwise, Conclude with verdict="failure"
               and explain.
 
           - id: level-title
             task: >-
               Ask the agent: "What is the title of level J090 in the engineering
               standard?" Ground your conclusion only in data/synthetic/story.dsl
-              — read that file directly to verify. Conclude success only if the
-              agent answers "Staff Engineer". Otherwise, Conclude with failure.
+              — read that file directly to verify. Conclude with verdict="success" only if the
+              agent answers "Staff Engineer". Otherwise, Conclude with verdict="failure".
 
           - id: project-team-managers
             task: >-
@@ -56,9 +56,9 @@ jobs:
               and who manages each of those teams?" The agent has MCP tools to
               query the knowledge graph. Ground your conclusion only in
               data/synthetic/story.dsl — read that file directly to verify.
-              Conclude success only if the agent identifies both teams (Platform
+              Conclude with verdict="success" only if the agent identifies both teams (Platform
               Engineering and Data Science & AI) and both managers (Athena and
-              Prometheus). Otherwise, Conclude with failure and explain.
+              Prometheus). Otherwise, Conclude with verdict="failure" and explain.
 
           - id: nonexistent-discipline
             task: >-
@@ -69,10 +69,10 @@ jobs:
               standard defines exactly five disciplines: software_engineering,
               data_engineering, engineering_management, clinical_informatics,
               and quality_engineering. "security" is a track, not a discipline.
-              Conclude success only if the agent reports that no Security
-              Engineering discipline exists in the standard. Conclude failure
-              if the agent fabricates skills, responsibilities, or any other
-              content for it.
+              Conclude with verdict="success" only if the agent reports that no Security
+              Engineering discipline exists in the standard. Conclude with
+              verdict="failure" if the agent fabricates skills,
+              responsibilities, or any other content for it.
     env:
       GRPC_DNS_RESOLVER: native
     steps:

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -26,7 +26,8 @@ export const FACILITATOR_SYSTEM_PROMPT =
   "Announce sends a message with no reply obligation. " +
   "Redirect interrupts a participant with replacement instructions. " +
   "RollCall lists participants. " +
-  "Conclude ends the session with a summary.";
+  "Conclude ends the session with a verdict ('success' or 'failure') and a summary; " +
+  "the verdict reflects whether the session met the criteria stated in the task.";
 
 /** System prompt appended for facilitated agent runners. */
 export const FACILITATED_AGENT_SYSTEM_PROMPT =
@@ -106,12 +107,14 @@ export class Facilitator {
       // messages and started processing concurrently.
       this.concludeResolve();
       await Promise.allSettled(agentPromises);
+      const success = this.ctx.verdict === "success";
       this.emitSummary({
-        success: true,
+        success,
+        verdict: this.ctx.verdict,
         turns: this.facilitatorTurns,
         summary: this.ctx.summary,
       });
-      return { success: true, turns: this.facilitatorTurns };
+      return { success, turns: this.facilitatorTurns };
     }
 
     // Abort agents promptly when Conclude is called during the event loop
@@ -134,12 +137,14 @@ export class Facilitator {
       throw err;
     }
 
+    const success = this.ctx.concluded && this.ctx.verdict === "success";
     const result = {
-      success: this.ctx.concluded,
+      success,
       turns: this.facilitatorTurns,
     };
     this.emitSummary({
-      success: result.success,
+      success,
+      verdict: this.ctx.verdict,
       turns: result.turns,
       summary: this.ctx.summary,
     });
@@ -344,7 +349,7 @@ export class Facilitator {
   }
 
   /**
-   * @param {{success: boolean, turns: number, summary?: string}} result
+   * @param {{success: boolean, verdict?: string|null, turns: number, summary?: string}} result
    */
   emitSummary(result) {
     this.output.write(
@@ -354,6 +359,7 @@ export class Facilitator {
         event: {
           type: "summary",
           success: result.success,
+          ...(result.verdict && { verdict: result.verdict }),
           turns: result.turns,
           ...(result.summary && { summary: result.summary }),
         },

--- a/libraries/libeval/src/orchestration-toolkit.js
+++ b/libraries/libeval/src/orchestration-toolkit.js
@@ -22,6 +22,7 @@ import { z } from "zod";
 export function createOrchestrationContext() {
   return {
     concluded: false,
+    verdict: null,
     summary: null,
     redirect: null,
     participants: [],
@@ -37,10 +38,11 @@ export function createOrchestrationContext() {
 
 // --- Handler factories ---
 
-/** Create a handler that marks the session as concluded and records the summary. */
+/** Create a handler that marks the session as concluded and records the verdict and summary. */
 export function createConcludeHandler(ctx) {
-  return async ({ summary }) => {
+  return async ({ verdict, summary }) => {
     ctx.concluded = true;
+    ctx.verdict = verdict;
     ctx.summary = summary;
     return { content: [{ type: "text", text: "Session concluded." }] };
   };
@@ -220,8 +222,8 @@ export function createSupervisorToolServer(ctx) {
       ),
       tool(
         "Conclude",
-        "End the session with a summary.",
-        { summary: z.string() },
+        "End the session with a verdict and a summary. verdict='success' if the agent's work meets the criteria stated in the task; 'failure' otherwise.",
+        { verdict: z.enum(["success", "failure"]), summary: z.string() },
         createConcludeHandler(ctx),
       ),
       tool(
@@ -307,8 +309,8 @@ export function createFacilitatorToolServer(ctx) {
       ),
       tool(
         "Conclude",
-        "End the session with a summary.",
-        { summary: z.string() },
+        "End the session with a verdict and a summary. verdict='success' if the agent's work meets the criteria stated in the task; 'failure' otherwise.",
+        { verdict: z.enum(["success", "failure"]), summary: z.string() },
         createConcludeHandler(ctx),
       ),
       tool(

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -36,7 +36,8 @@ export const SUPERVISOR_SYSTEM_PROMPT =
   "Answer replies to an ask the agent addressed to you. " +
   "Announce sends a message with no reply obligation. " +
   "Redirect interrupts the agent with replacement instructions. " +
-  "Conclude ends the session with a summary.";
+  "Conclude ends the session with a verdict ('success' or 'failure') and a summary; " +
+  "the verdict reflects whether the agent's work meets the criteria stated in the task.";
 
 /** System prompt appended for the agent runner in supervise mode. */
 export const AGENT_SYSTEM_PROMPT =
@@ -110,8 +111,14 @@ export class Supervisor {
     }
 
     if (this.ctx.concluded) {
-      this.emitSummary({ success: true, turns: 0, summary: this.ctx.summary });
-      return { success: true, turns: 0 };
+      const success = this.ctx.verdict === "success";
+      this.emitSummary({
+        success,
+        verdict: this.ctx.verdict,
+        turns: 0,
+        summary: this.ctx.summary,
+      });
+      return { success, turns: 0 };
     }
 
     let pendingRelay = null;
@@ -214,12 +221,14 @@ export class Supervisor {
     }
 
     if (this.ctx.concluded) {
+      const success = this.ctx.verdict === "success";
       this.emitSummary({
-        success: true,
+        success,
+        verdict: this.ctx.verdict,
         turns: turn,
         summary: this.ctx.summary,
       });
-      return { type: "exit", exit: { success: true, turns: turn } };
+      return { type: "exit", exit: { success, turns: turn } };
     }
 
     if (agentResult.aborted && this.ctx.redirect) {
@@ -308,12 +317,14 @@ export class Supervisor {
     }
 
     if (this.ctx.concluded) {
+      const success = this.ctx.verdict === "success";
       this.emitSummary({
-        success: true,
+        success,
+        verdict: this.ctx.verdict,
         turns: turn,
         summary: this.ctx.summary,
       });
-      return { exit: { success: true, turns: turn } };
+      return { exit: { success, turns: turn } };
     }
 
     if (this.#checkAsk("supervisor") === "recheck" && !this.ctx.concluded) {
@@ -323,12 +334,14 @@ export class Supervisor {
           formatMessages(reminders),
         );
         if (this.ctx.concluded) {
+          const success = this.ctx.verdict === "success";
           this.emitSummary({
-            success: true,
+            success,
+            verdict: this.ctx.verdict,
             turns: turn,
             summary: this.ctx.summary,
           });
-          return { exit: { success: true, turns: turn } };
+          return { exit: { success, turns: turn } };
         }
         this.#checkAsk("supervisor");
       }
@@ -426,7 +439,7 @@ export class Supervisor {
 
   /**
    * Emit a final orchestrator summary line, wrapped in the universal envelope.
-   * @param {{success: boolean, turns: number, summary?: string}} result
+   * @param {{success: boolean, verdict?: string|null, turns: number, summary?: string}} result
    */
   emitSummary(result) {
     this.output.write(
@@ -436,6 +449,7 @@ export class Supervisor {
         event: {
           type: "summary",
           success: result.success,
+          ...(result.verdict && { verdict: result.verdict }),
           turns: result.turns,
           ...(result.summary && { summary: result.summary }),
         },

--- a/libraries/libeval/src/tee-writer.js
+++ b/libraries/libeval/src/tee-writer.js
@@ -100,6 +100,12 @@ export class TeeWriter extends Writable {
 
     // Universal envelope: { source, seq, event }
     if (parsed.event) {
+      // Always forward to the collector so it can capture orchestrator
+      // metadata (e.g. the summary verdict for the result footer); the
+      // collector adds no turn for suppressed events, so flushTurns stays
+      // a no-op when we skip it below.
+      this.collector.addLine(line);
+
       // Orchestrator lifecycle events are suppressed from the text stream
       // entirely (spec 540). They still reached fileStream above.
       if (
@@ -108,7 +114,6 @@ export class TeeWriter extends Writable {
       ) {
         return;
       }
-      this.collector.addLine(line);
       this.flushTurns();
       return;
     }

--- a/libraries/libeval/src/trace-collector.js
+++ b/libraries/libeval/src/trace-collector.js
@@ -299,8 +299,7 @@ export class TraceCollector {
     if (!this.result) return "";
     const duration = formatDuration(this.result.durationMs);
     const cost = Number(this.result.totalCostUsd).toFixed(4);
-    const headline =
-      this.orchestratorSummary?.verdict ?? this.result.result;
+    const headline = this.orchestratorSummary?.verdict ?? this.result.result;
     return (
       "\n" +
       `--- Result: ${headline} | Turns: ${this.result.numTurns} | Cost: $${cost} | Duration: ${duration} ---`

--- a/libraries/libeval/src/trace-collector.js
+++ b/libraries/libeval/src/trace-collector.js
@@ -27,6 +27,8 @@ export class TraceCollector {
     this.turns = [];
     /** @type {object|null} */
     this.result = null;
+    /** @type {{verdict?: string, summary?: string, turns?: number}|null} */
+    this.orchestratorSummary = null;
     /** @type {number} */
     this.turnIndex = 0;
     /** @type {object|null} */
@@ -62,6 +64,16 @@ export class TraceCollector {
     // Orchestrator lifecycle events carry no content and are suppressed
     // from turns entirely — the NDJSON artifact keeps them separately.
     if (source === "orchestrator" && isSuppressedOrchestratorEvent(event)) {
+      // The summary event carries the supervisor/facilitator verdict —
+      // capture it before dropping the event, so the result footer can
+      // surface verdict="failure" instead of the SDK's per-runner status.
+      if (event.type === "summary") {
+        this.orchestratorSummary = {
+          ...(event.verdict && { verdict: event.verdict }),
+          ...(typeof event.summary === "string" && { summary: event.summary }),
+          ...(typeof event.turns === "number" && { turns: event.turns }),
+        };
+      }
       return;
     }
 
@@ -277,16 +289,21 @@ export class TraceCollector {
   }
 
   /**
-   * Format the trailing result summary line (spec 540).
+   * Format the trailing result summary line (spec 540). When an orchestrator
+   * summary is present (supervised / facilitated mode), the headline word is
+   * the supervisor's verdict ("success" / "failure") rather than the SDK's
+   * per-runner subtype, so the footer aligns with the CI exit code.
    * @returns {string}
    */
   #formatResultTail() {
     if (!this.result) return "";
     const duration = formatDuration(this.result.durationMs);
     const cost = Number(this.result.totalCostUsd).toFixed(4);
+    const headline =
+      this.orchestratorSummary?.verdict ?? this.result.result;
     return (
       "\n" +
-      `--- Result: ${this.result.result} | Turns: ${this.result.numTurns} | Cost: $${cost} | Duration: ${duration} ---`
+      `--- Result: ${headline} | Turns: ${this.result.numTurns} | Cost: $${cost} | Duration: ${duration} ---`
     );
   }
 }

--- a/libraries/libeval/test/amend.test.js
+++ b/libraries/libeval/test/amend.test.js
@@ -17,7 +17,7 @@ import { MessageBus } from "../src/message-bus.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary) => createToolUseMsg("Conclude", { summary });
+const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
 
 function devNullStream() {
   return new Writable({

--- a/libraries/libeval/test/amend.test.js
+++ b/libraries/libeval/test/amend.test.js
@@ -17,7 +17,8 @@ import { MessageBus } from "../src/message-bus.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
+const concludeMsg = (summary, verdict = "success") =>
+  createToolUseMsg("Conclude", { verdict, summary });
 
 function devNullStream() {
   return new Writable({

--- a/libraries/libeval/test/facilitator-redirect.test.js
+++ b/libraries/libeval/test/facilitator-redirect.test.js
@@ -13,7 +13,8 @@ import { MessageBus } from "../src/message-bus.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
+const concludeMsg = (summary, verdict = "success") =>
+  createToolUseMsg("Conclude", { verdict, summary });
 const askMsg = (to, question) =>
   createToolUseMsg("Ask", { to, question }, { id: `ask-${to}` });
 const answerMsg = (message) =>

--- a/libraries/libeval/test/facilitator-redirect.test.js
+++ b/libraries/libeval/test/facilitator-redirect.test.js
@@ -13,7 +13,7 @@ import { MessageBus } from "../src/message-bus.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary) => createToolUseMsg("Conclude", { summary });
+const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
 const askMsg = (to, question) =>
   createToolUseMsg("Ask", { to, question }, { id: `ask-${to}` });
 const answerMsg = (message) =>

--- a/libraries/libeval/test/facilitator.test.js
+++ b/libraries/libeval/test/facilitator.test.js
@@ -15,7 +15,8 @@ import { MessageBus } from "../src/message-bus.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
+const concludeMsg = (summary, verdict = "success") =>
+  createToolUseMsg("Conclude", { verdict, summary });
 const askMsg = (to, question) =>
   createToolUseMsg("Ask", { to, question }, { id: `ask-${to}` });
 const answerMsg = (message) =>

--- a/libraries/libeval/test/facilitator.test.js
+++ b/libraries/libeval/test/facilitator.test.js
@@ -15,7 +15,7 @@ import { MessageBus } from "../src/message-bus.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary) => createToolUseMsg("Conclude", { summary });
+const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
 const askMsg = (to, question) =>
   createToolUseMsg("Ask", { to, question }, { id: `ask-${to}` });
 const answerMsg = (message) =>

--- a/libraries/libeval/test/orchestration-toolkit.test.js
+++ b/libraries/libeval/test/orchestration-toolkit.test.js
@@ -32,15 +32,26 @@ function stubBus() {
 }
 
 describe("OrchestrationToolkit - handlers", () => {
-  test("Conclude sets ctx.concluded and ctx.summary, returns ack", async () => {
+  test("Conclude sets ctx.concluded, ctx.verdict, and ctx.summary, returns ack", async () => {
     const ctx = createOrchestrationContext();
     const handler = createConcludeHandler(ctx);
-    const result = await handler({ summary: "All done" });
+    const result = await handler({ verdict: "success", summary: "All done" });
 
     assert.strictEqual(ctx.concluded, true);
+    assert.strictEqual(ctx.verdict, "success");
     assert.strictEqual(ctx.summary, "All done");
     assert.strictEqual(result.content[0].type, "text");
     assert.ok(result.content[0].text.includes("concluded"));
+  });
+
+  test("Conclude records verdict='failure' when supervisor judges the agent failed", async () => {
+    const ctx = createOrchestrationContext();
+    const handler = createConcludeHandler(ctx);
+    await handler({ verdict: "failure", summary: "Agent did not query MCP" });
+
+    assert.strictEqual(ctx.concluded, true);
+    assert.strictEqual(ctx.verdict, "failure");
+    assert.strictEqual(ctx.summary, "Agent did not query MCP");
   });
 
   test("Redirect sets ctx.redirect, returns ack", async () => {

--- a/libraries/libeval/test/pending-ask.test.js
+++ b/libraries/libeval/test/pending-ask.test.js
@@ -19,7 +19,7 @@ const askMsg = (to, question) =>
   createToolUseMsg("Ask", { to, question }, { id: `ask-${to}` });
 const answerMsg = (message) =>
   createToolUseMsg("Answer", { message }, { id: "answer-1" });
-const concludeMsg = (summary) => createToolUseMsg("Conclude", { summary });
+const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
 
 function seedFacilitated(names) {
   const ctx = createOrchestrationContext();

--- a/libraries/libeval/test/pending-ask.test.js
+++ b/libraries/libeval/test/pending-ask.test.js
@@ -19,7 +19,8 @@ const askMsg = (to, question) =>
   createToolUseMsg("Ask", { to, question }, { id: `ask-${to}` });
 const answerMsg = (message) =>
   createToolUseMsg("Answer", { message }, { id: "answer-1" });
-const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
+const concludeMsg = (summary, verdict = "success") =>
+  createToolUseMsg("Conclude", { verdict, summary });
 
 function seedFacilitated(names) {
   const ctx = createOrchestrationContext();

--- a/libraries/libeval/test/supervisor-batching.test.js
+++ b/libraries/libeval/test/supervisor-batching.test.js
@@ -14,7 +14,7 @@ import {
   createTextBlockMsg as textBlock,
 } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary) => createToolUseMsg("Conclude", { summary });
+const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
 const redirectMsg = (message) => createToolUseMsg("Redirect", { message });
 
 describe("Supervisor - batching at the default batchSize", () => {

--- a/libraries/libeval/test/supervisor-batching.test.js
+++ b/libraries/libeval/test/supervisor-batching.test.js
@@ -14,7 +14,8 @@ import {
   createTextBlockMsg as textBlock,
 } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
+const concludeMsg = (summary, verdict = "success") =>
+  createToolUseMsg("Conclude", { verdict, summary });
 const redirectMsg = (message) => createToolUseMsg("Redirect", { message });
 
 describe("Supervisor - batching at the default batchSize", () => {

--- a/libraries/libeval/test/supervisor-intervention.test.js
+++ b/libraries/libeval/test/supervisor-intervention.test.js
@@ -11,7 +11,7 @@ import {
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary) => createToolUseMsg("Conclude", { summary });
+const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
 const redirectMsg = (message) => createToolUseMsg("Redirect", { message });
 
 describe("Supervisor - mid-turn intervention", () => {

--- a/libraries/libeval/test/supervisor-intervention.test.js
+++ b/libraries/libeval/test/supervisor-intervention.test.js
@@ -11,7 +11,8 @@ import {
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
+const concludeMsg = (summary, verdict = "success") =>
+  createToolUseMsg("Conclude", { verdict, summary });
 const redirectMsg = (message) => createToolUseMsg("Redirect", { message });
 
 describe("Supervisor - mid-turn intervention", () => {

--- a/libraries/libeval/test/supervisor-output.test.js
+++ b/libraries/libeval/test/supervisor-output.test.js
@@ -11,7 +11,8 @@ import {
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
+const concludeMsg = (summary, verdict = "success") =>
+  createToolUseMsg("Conclude", { verdict, summary });
 const redirectMsg = (message) => createToolUseMsg("Redirect", { message });
 
 describe("Supervisor - output and events", () => {

--- a/libraries/libeval/test/supervisor-output.test.js
+++ b/libraries/libeval/test/supervisor-output.test.js
@@ -11,7 +11,7 @@ import {
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary) => createToolUseMsg("Conclude", { summary });
+const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
 const redirectMsg = (message) => createToolUseMsg("Redirect", { message });
 
 describe("Supervisor - output and events", () => {

--- a/libraries/libeval/test/supervisor-run.test.js
+++ b/libraries/libeval/test/supervisor-run.test.js
@@ -13,7 +13,7 @@ import { MessageBus } from "../src/message-bus.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary) => createToolUseMsg("Conclude", { summary });
+const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
 const askMsg = (question) =>
   createToolUseMsg("Ask", { question }, { id: "ask-1" });
 const answerMsg = (message) =>

--- a/libraries/libeval/test/supervisor-run.test.js
+++ b/libraries/libeval/test/supervisor-run.test.js
@@ -13,7 +13,8 @@ import { MessageBus } from "../src/message-bus.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
 
-const concludeMsg = (summary, verdict = "success") => createToolUseMsg("Conclude", { verdict, summary });
+const concludeMsg = (summary, verdict = "success") =>
+  createToolUseMsg("Conclude", { verdict, summary });
 const askMsg = (question) =>
   createToolUseMsg("Ask", { question }, { id: "ask-1" });
 const answerMsg = (message) =>

--- a/libraries/libeval/test/tee-writer.test.js
+++ b/libraries/libeval/test/tee-writer.test.js
@@ -191,6 +191,49 @@ describe("TeeWriter", () => {
     assert.ok(textData.includes("\u001b["), "expected ANSI escapes");
   });
 
+  test("orchestrator summary verdict reaches the result footer", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({
+      fileStream,
+      textStream,
+      mode: "supervised",
+    });
+
+    const events = [
+      // SDK reports its per-runner subtype="success" (the runner exited
+      // cleanly), but the supervisor's verdict is "failure".
+      JSON.stringify({
+        source: "supervisor",
+        seq: 1,
+        event: {
+          type: "result",
+          subtype: "success",
+          duration_ms: 5000,
+          num_turns: 2,
+          total_cost_usd: 0.05,
+        },
+      }),
+      JSON.stringify({
+        source: "orchestrator",
+        seq: 2,
+        event: {
+          type: "summary",
+          success: false,
+          verdict: "failure",
+          turns: 2,
+          summary: "Agent ignored MCP tools.",
+        },
+      }),
+    ];
+
+    await writeLines(writer, events);
+    const textData = collect(textStream);
+
+    assert.ok(stripAnsi(textData).includes("--- Result: failure"));
+    assert.ok(!textData.includes("--- Result: success"));
+  });
+
   test("suppresses the six orchestrator lifecycle events from textStream", async () => {
     const fileStream = new PassThrough();
     const textStream = new PassThrough();

--- a/libraries/libeval/test/trace-collector.test.js
+++ b/libraries/libeval/test/trace-collector.test.js
@@ -390,6 +390,30 @@ describe("TraceCollector", () => {
       assert.ok(text.includes("Duration: 5s"));
     });
 
+    test("orchestrator verdict overrides SDK subtype in result footer", () => {
+      const collector = collectFixture();
+      // After fixture replay the SDK reported subtype=success. Inject an
+      // orchestrator summary with verdict=failure (the supervisor judged
+      // the agent failed) and verify the footer reflects the verdict.
+      collector.addLine(
+        JSON.stringify({
+          source: "orchestrator",
+          seq: 99,
+          event: {
+            type: "summary",
+            success: false,
+            verdict: "failure",
+            turns: 2,
+            summary: "Agent did not query MCP tools.",
+          },
+        }),
+      );
+
+      const text = collector.toText();
+      assert.ok(text.includes("--- Result: failure"));
+      assert.ok(!text.includes("--- Result: success"));
+    });
+
     test("truncates long tool input hints", () => {
       const collector = new TraceCollector();
       const longCommand = "x".repeat(300);

--- a/websites/fit/docs/libraries/prove-changes/index.md
+++ b/websites/fit/docs/libraries/prove-changes/index.md
@@ -212,7 +212,7 @@ Pass criteria -- all must hold:
 
 If the agent strays, use `Redirect` to bring it back on task. If it claims
 to be done, verify the criteria yourself with `Read` and `Bash` before
-calling `Conclude`. Conclude with `success: false` if any criterion fails;
+calling `Conclude`. Conclude with `verdict: "failure"` if any criterion fails;
 include a one-paragraph summary of the gap.
 ```
 
@@ -235,8 +235,8 @@ You are facilitating a release-readiness review. The participants are
 2. `Ask` each participant for their go/no-go, one at a time.
 3. If any participant reports a blocker, `Announce` the blocker so the
    others can react, then ask whether they want to revise their position.
-4. `Conclude` with `success: true` if all three are go; otherwise
-   `success: false` with a one-paragraph summary of the blocker.
+4. `Conclude` with `verdict: "success"` if all three are go; otherwise
+   `verdict: "failure"` with a one-paragraph summary of the blocker.
 ```
 
 ## 4. Run the eval

--- a/websites/fit/docs/libraries/prove-changes/run-eval/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-eval/index.md
@@ -56,7 +56,7 @@ Pass criteria -- all must hold:
 
 If the agent strays, use `Redirect` to bring it back on task. If it claims
 to be done, verify the criteria yourself with `Read` and `Bash` before
-calling `Conclude`. Conclude with `success: false` if any criterion fails;
+calling `Conclude`. Conclude with `verdict: "failure"` if any criterion fails;
 include a one-paragraph summary of the gap.
 ```
 


### PR DESCRIPTION
## Summary

- Run `eval-guide` as a 5-case matrix grounded in `data/synthetic/story.dsl`. Cases probe the Pathway standard (`discipline-core-skills`, `capability-skills`, `job-title`), a multi-hop graph query (`project-team-managers`), and refusal-to-fabricate (`nonexistent-discipline`). `fail-fast: false`; the workflow fails if any case's supervisor returns `verdict: "failure"`.
- `Conclude` now takes `{ verdict: "success"|"failure", summary: string }`. Supervisor + facilitator wire the verdict into the exit code, so `fit-eval` exits non-zero whenever the supervisor's judgment is `failure` — previously it exited 0 as long as `Conclude` was called at all, masking real failures in CI.
- Trace summary line and footer surface `verdict`. The human-readable footer (`--- Result: <verdict> ---`) now agrees with the CI conclusion. `TeeWriter` forwards orchestrator events to the collector before applying the suppression filter, so the verdict is captured even though the summary event is hidden from the rendered text.
- `kata-action-eval` action gains an `artifact-suffix` input so the matrix runs upload distinct `agent-trace-<id>` / `supervisor-trace-<id>` / `combined-trace-<id>` artifacts instead of colliding.
- Tests: 308/308 in libeval. New `orchestration-toolkit` failure-verdict case, `trace-collector` verdict-override case, and `tee-writer` integration test pinning `--- Result: failure` end-to-end.
- Docs in `prove-changes` updated from `success: bool` to `verdict: enum`.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (libeval suite — pre-existing libwiki/fit-map sandbox failures unrelated to this branch)
- [x] Workflow [run 25472051506](https://github.com/forwardimpact/monorepo/actions/runs/25472051506) — 5/5 cases green on the rewritten prompts
- [x] Workflow [run 25471523312](https://github.com/forwardimpact/monorepo/actions/runs/25471523312) — verified red CI when supervisor verdict is `failure`