### PR TITLE
fit-eval: full MCP args, drop success Result lines in TeeWriter output

### DIFF
--- a/libraries/libeval/src/render/tool-hints.js
+++ b/libraries/libeval/src/render/tool-hints.js
@@ -97,28 +97,15 @@ export function simplifyToolName(name) {
 }
 
 /**
- * MCP-prefixed tool names (e.g. `mcp__orchestration__Ask`, `mcp__github__…`)
- * render their full input as compact single-line JSON. The method name is
- * surfaced via `simplifyToolName`; this returns the rest of the line.
- * Returns null if the name does not match an MCP prefix.
- * @param {string} name
- * @param {object} input
- * @returns {string|null}
- */
-function hintForMcp(name, input) {
-  if (name.startsWith("mcp__")) {
-    return JSON.stringify(input);
-  }
-  return null;
-}
-
-/**
  * Map a tool name and input to a one-line human hint.
  *
- * Unknown tools return an empty hint — the caller still shows the tool
- * name, just without extra detail. Sanitization is uniform: every branch
- * ends with `sanitize`, so the output is guaranteed free of `{`, `}`, `"`
- * from the input object (success criterion #2).
+ * Three branches, in priority order:
+ *  - A built-in tool with an entry in `HINT_HANDLERS` → sanitized hint, no
+ *    `{` / `"` from the input (spec 540 criterion #2 for non-MCP tools).
+ *  - An MCP-prefixed tool (`mcp__*`) → full input rendered as compact
+ *    single-line JSON; `{` and `"` intentionally appear so readers see
+ *    the actual MCP payload.
+ *  - Anything else → "" (the caller still shows the bare tool name).
  *
  * @param {string} name - Tool name (e.g. "Bash", "Read", "mcp__orchestration__Ask")
  * @param {object|null|undefined} input - Raw tool input object from the trace
@@ -131,8 +118,7 @@ export function hintForCall(name, input) {
   const handler = HINT_HANDLERS[name];
   if (handler) return handler(safeInput);
 
-  const mcp = hintForMcp(name, safeInput);
-  if (mcp !== null) return mcp;
+  if (name.startsWith("mcp__")) return JSON.stringify(safeInput);
 
   return "";
 }
@@ -153,32 +139,15 @@ export function previewForResult(content, isError) {
       : typeof content === "string"
         ? content
         : JSON.stringify(content);
-  const lines = normalized.split(/\r?\n/);
-  let firstNonBlank = "";
-  for (const line of lines) {
-    if (line.trim().length > 0) {
-      firstNonBlank = line.trim();
-      break;
-    }
-  }
+  const firstNonBlank =
+    normalized
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .find((l) => l.length > 0) ?? "";
 
-  if (isError) {
-    const body = firstNonBlank || "(no output)";
-    return {
-      text:
-        body.length <= MAX_HINT_CHARS
-          ? body
-          : body.slice(0, MAX_HINT_CHARS - 3) + "...",
-      isError: true,
-    };
-  }
-
-  if (!firstNonBlank) return { text: "(ok)", isError: false };
+  const fallback = isError ? "(no output)" : "(ok)";
   return {
-    text:
-      firstNonBlank.length <= MAX_HINT_CHARS
-        ? firstNonBlank
-        : firstNonBlank.slice(0, MAX_HINT_CHARS - 3) + "...",
-    isError: false,
+    text: truncate(firstNonBlank || fallback),
+    isError,
   };
 }

--- a/libraries/libeval/src/render/tool-hints.js
+++ b/libraries/libeval/src/render/tool-hints.js
@@ -6,6 +6,11 @@
  * tool (file path, command, pattern, …) sanitized to strip JSON punctuation
  * (`{`, `}`, `"`) and collapsed to a single line ≤ 80 chars.
  *
+ * MCP-prefixed tools (`mcp__*`) are an intentional carve-out: their hint is
+ * the full input rendered as compact single-line JSON, so `{` and `"` do
+ * appear on those lines. Readers of GitHub workflow logs need the full MCP
+ * payload to know what was actually sent across the protocol.
+ *
  * `previewForResult(content, isError)` collapses a tool result to a single
  * line ≤ 80 chars and flags errors so the renderer can apply the reserved
  * error color and the `Error:` label.
@@ -92,23 +97,17 @@ export function simplifyToolName(name) {
 }
 
 /**
- * MCP-prefixed tool names (e.g. `mcp__orchestration__Ask`) take a different
- * handler path. The method name itself is surfaced via `simplifyToolName`,
- * so this only adds the `to/from` decorators for orchestration calls.
- * Returns null if the name does not match any MCP prefix.
+ * MCP-prefixed tool names (e.g. `mcp__orchestration__Ask`, `mcp__github__…`)
+ * render their full input as compact single-line JSON. The method name is
+ * surfaced via `simplifyToolName`; this returns the rest of the line.
+ * Returns null if the name does not match an MCP prefix.
  * @param {string} name
  * @param {object} input
  * @returns {string|null}
  */
 function hintForMcp(name, input) {
-  if (name.startsWith("mcp__orchestration__")) {
-    const parts = [];
-    if (input.to) parts.push(`to ${sanitize(input.to)}`);
-    if (input.from) parts.push(`from ${sanitize(input.from)}`);
-    return truncate(parts.join(" "));
-  }
   if (name.startsWith("mcp__")) {
-    return "";
+    return JSON.stringify(input);
   }
   return null;
 }

--- a/libraries/libeval/src/render/turn-renderer.js
+++ b/libraries/libeval/src/render/turn-renderer.js
@@ -57,10 +57,13 @@ function renderAssistantTurn(turn, withPrefix) {
 
 /** @param {object} turn @param {boolean} withPrefix @returns {string[]} */
 function renderToolResultTurn(turn, withPrefix) {
+  // Successful tool results emit no preview line — the trace document keeps
+  // the structured turn, but readers of the streamed log only see errors.
+  if (!turn.isError) return [];
   return [
     renderToolResultLine({
       source: turn.source,
-      preview: previewForResult(turn.content, turn.isError),
+      preview: previewForResult(turn.content, true),
       withPrefix,
     }),
   ];

--- a/libraries/libeval/src/render/turn-renderer.js
+++ b/libraries/libeval/src/render/turn-renderer.js
@@ -25,12 +25,7 @@ import {
  * @returns {string[]} Array of rendered line strings
  */
 export function renderTurnLines(turn, withPrefix) {
-  if (turn.role === "assistant") return renderAssistantTurn(turn, withPrefix);
-  if (turn.role === "tool_result")
-    return renderToolResultTurn(turn, withPrefix);
-  if (turn.role === "system") return renderSystemTurn(turn, withPrefix);
-  if (turn.role === "user") return renderUserTurn(turn, withPrefix);
-  return [];
+  return TURN_RENDERERS[turn.role]?.(turn, withPrefix) ?? [];
 }
 
 /** @param {object} turn @param {boolean} withPrefix @returns {string[]} */
@@ -93,3 +88,10 @@ function renderUserTurn(turn, withPrefix) {
   }
   return lines;
 }
+
+const TURN_RENDERERS = {
+  assistant: renderAssistantTurn,
+  tool_result: renderToolResultTurn,
+  system: renderSystemTurn,
+  user: renderUserTurn,
+};

--- a/libraries/libeval/test/tee-writer.test.js
+++ b/libraries/libeval/test/tee-writer.test.js
@@ -304,7 +304,7 @@ describe("TeeWriter", () => {
     assert.match(textData, /^staff-engineer: \u001b\[/);
   });
 
-  test("renders tool results tied to each tool call, errors in red", async () => {
+  test("suppresses success Result lines, renders Error lines in red", async () => {
     const fileStream = new PassThrough();
     const textStream = new PassThrough();
     const writer = new TeeWriter({
@@ -395,9 +395,20 @@ describe("TeeWriter", () => {
     const plain = stripAnsi(textData);
 
     assert.ok(plain.includes("Bash: pwd"));
-    assert.ok(plain.includes("Result: /home/user"));
     assert.ok(plain.includes("Read: /nope"));
     assert.ok(plain.includes("Error: ENOENT: no such file"));
+
+    // No per-tool-call success preview line: nothing should start with
+    // `Result:` (the trailing `--- Result: <verdict> ---` footer has a
+    // distinct shape and is filtered out below).
+    const previewLines = plain
+      .split("\n")
+      .filter(
+        (l) =>
+          (l.startsWith("Result:") || l.includes(": Result:")) &&
+          !l.startsWith("---"),
+      );
+    assert.deepStrictEqual(previewLines, []);
 
     // The error preview line carries the reserved red escape.
     const errorLine = textData
@@ -407,6 +418,71 @@ describe("TeeWriter", () => {
     assert.ok(
       errorLine.includes("\u001b[38;2;241;76;76m"),
       "error line should carry the reserved red escape",
+    );
+  });
+
+  test("MCP tool calls render the full input as single-line JSON", async () => {
+    const fileStream = new PassThrough();
+    const textStream = new PassThrough();
+    const writer = new TeeWriter({ fileStream, textStream, mode: "raw" });
+
+    const ghInput = {
+      owner: "forwardimpact",
+      repo: "monorepo",
+      issue_number: 1,
+      body: "hello",
+    };
+    const askInput = { to: "alice", from: "bob", message: "hi" };
+
+    const events = [
+      JSON.stringify({
+        source: "agent",
+        seq: 0,
+        event: {
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "mcp__github__add_issue_comment",
+                input: ghInput,
+              },
+            ],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+        },
+      }),
+      JSON.stringify({
+        source: "agent",
+        seq: 1,
+        event: {
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "t2",
+                name: "mcp__orchestration__Ask",
+                input: askInput,
+              },
+            ],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+        },
+      }),
+    ];
+
+    await writeLines(writer, events);
+
+    const plain = stripAnsi(collect(textStream));
+    assert.ok(
+      plain.includes(`add_issue_comment: ${JSON.stringify(ghInput)}`),
+      `expected full JSON for github tool, got:\n${plain}`,
+    );
+    assert.ok(
+      plain.includes(`Ask: ${JSON.stringify(askInput)}`),
+      `expected full JSON for orchestration tool, got:\n${plain}`,
     );
   });
 

--- a/libraries/libeval/test/tool-hints.test.js
+++ b/libraries/libeval/test/tool-hints.test.js
@@ -8,7 +8,9 @@ import {
 } from "../src/render/tool-hints.js";
 
 /**
- * Assert a hint contains no `{`, `}`, or `"` characters — success criterion #2.
+ * Assert a hint contains no `{`, `}`, or `"` characters — success criterion #2,
+ * which applies to non-MCP tools only. MCP tools intentionally render full
+ * single-line JSON and DO contain `{` and `"`.
  * @param {string} hint
  */
 function assertNoJsonPunctuation(hint) {
@@ -144,29 +146,41 @@ describe("hintForCall", () => {
     assert.strictEqual(hint, "summarise the diff");
   });
 
-  test("mcp__orchestration__RollCall — no decorators, empty hint", () => {
+  test("mcp__orchestration__RollCall — empty input renders as `{}`", () => {
     const hint = hintForCall("mcp__orchestration__RollCall", {});
-    assert.strictEqual(hint, "");
+    assert.strictEqual(hint, "{}");
   });
 
-  test("mcp__orchestration__Ask — renders to decorator only", () => {
-    const hint = hintForCall("mcp__orchestration__Ask", {
-      to: "staff-engineer",
-      question: "go",
-    });
-    assert.strictEqual(hint, "to staff-engineer");
+  test("mcp__orchestration__Ask — renders full input as single-line JSON", () => {
+    const input = { to: "staff-engineer", question: "go" };
+    const hint = hintForCall("mcp__orchestration__Ask", input);
+    assert.strictEqual(hint, JSON.stringify(input));
   });
 
-  test("mcp__orchestration__Announce — no decorators, empty hint", () => {
-    const hint = hintForCall("mcp__orchestration__Announce", {
-      message: 'Say "hello"',
-    });
-    assert.strictEqual(hint, "");
+  test("mcp__orchestration__Announce — preserves embedded quotes via JSON", () => {
+    const input = { message: 'Say "hello"' };
+    const hint = hintForCall("mcp__orchestration__Announce", input);
+    assert.strictEqual(hint, JSON.stringify(input));
+    assert.ok(hint.includes('\\"'), "JSON should escape embedded quotes");
   });
 
-  test("mcp__github__list_branches — no decorators, empty hint", () => {
-    const hint = hintForCall("mcp__github__list_branches", { owner: "foo" });
-    assert.strictEqual(hint, "");
+  test("mcp__github__list_branches — renders full input as single-line JSON", () => {
+    const input = { owner: "foo" };
+    const hint = hintForCall("mcp__github__list_branches", input);
+    assert.strictEqual(hint, JSON.stringify(input));
+  });
+
+  test("MCP hint stays on a single line even with rich nested input", () => {
+    const input = {
+      owner: "forwardimpact",
+      repo: "monorepo",
+      issue_number: 1,
+      labels: ["bug", "p0"],
+      meta: { source: "ci" },
+    };
+    const hint = hintForCall("mcp__github__add_issue_comment", input);
+    assert.strictEqual(hint, JSON.stringify(input));
+    assert.ok(!hint.includes("\n"), "MCP hint must be single-line");
   });
 
   test("unknown tool — returns empty string", () => {

--- a/libraries/libeval/test/trace-collector.test.js
+++ b/libraries/libeval/test/trace-collector.test.js
@@ -371,13 +371,61 @@ describe("TraceCollector", () => {
       assert.ok(!text.includes("{"));
     });
 
-    test("includes a tool_result preview line tied to each tool call", () => {
+    test("successful tool_result emits no preview line", () => {
       const collector = collectFixture();
       const text = collector.toText();
 
-      // The fixture's tool_result content begins with `total 42\n...`.
-      // Preview is the first non-blank line, rendered as `  Result: total 42`.
-      assert.ok(text.includes("Result: total 42"));
+      // The fixture's tool_result is a success (`total 42\n...`). Per the
+      // updated rendering rule, successful tool results are silently dropped
+      // from text output — only `Error:` lines remain. The trailing
+      // `--- Result: <verdict> ---` footer is a different shape.
+      const previewLines = text
+        .split("\n")
+        .filter(
+          (l) =>
+            (l.startsWith("Result:") || l.includes(": Result:")) &&
+            !l.startsWith("---"),
+        );
+      assert.deepStrictEqual(previewLines, []);
+      assert.ok(!text.includes("Result: total 42"));
+    });
+
+    test("failing tool_result emits an Error: preview line", () => {
+      const collector = new TraceCollector();
+      collector.addLine(
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "t1",
+                name: "Read",
+                input: { file_path: "/nope" },
+              },
+            ],
+          },
+        }),
+      );
+      collector.addLine(
+        JSON.stringify({
+          type: "user",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "t1",
+                is_error: true,
+                content: "ENOENT: no such file",
+              },
+            ],
+          },
+        }),
+      );
+
+      const text = collector.toText();
+      assert.ok(text.includes("Error: ENOENT: no such file"));
     });
 
     test("includes result summary line", () => {

--- a/specs/540-readable-agent-workflow-logs/spec.md
+++ b/specs/540-readable-agent-workflow-logs/spec.md
@@ -209,13 +209,20 @@ No dependency on in-flight specs.
    distinct colors for at least the cast size of the largest existing workflow
    (five domain agents plus facilitator), and red is reserved for errors and
    never assigned to a profile.
-2. No tool-call line in the streamed log contains a `{` or `"` character from
-   the tool's input object. Each tool call renders as a tool name plus a
-   single-line human-readable hint.
-3. Every tool call in the streamed log is followed by exactly one preview line
-   describing the tool's result. Multi-line tool output never reaches the
-   streamed log. Previews for error results render in the reserved error color
-   regardless of the calling agent's assigned color.
+2. No tool-call line for a **non-MCP** tool in the streamed log contains a `{`
+   or `"` character from the tool's input object. Each non-MCP tool call
+   renders as a tool name plus a single-line human-readable hint.
+   **MCP-prefixed tools (`mcp__*`) are an explicit carve-out**: their tool-call
+   line shows the simplified method name plus the full input rendered as
+   compact single-line JSON (so `{` and `"` do appear). Readers of GitHub
+   workflow logs need the full MCP payload to understand what was sent across
+   the protocol.
+3. Every **failed** tool call in the streamed log is followed by exactly one
+   `Error:` preview line describing the failure, rendered in the reserved
+   error color regardless of the calling agent's assigned color. Successful
+   tool calls emit no preview line — the structured result is preserved in
+   the NDJSON trace, but the streamed log stays scannable. Multi-line tool
+   output never reaches the streamed log.
 4. No line in the streamed log is produced by an orchestrator `session_start`,
    `agent_start`, `ask_received`, `ask_answered`, `redirect`, or `summary`
    event, and the `--- Evaluation … ---` footer previously emitted by


### PR DESCRIPTION
## Summary

- Every `mcp__*` tool call now renders its full input as compact single-line JSON in the streamed log, so readers see the actual MCP payload (question text, tool args, etc.) instead of an empty hint or a truncated `to/from` short form.
- Successful tool calls no longer emit a per-call `Result: …` preview line. `Error: …` lines remain in the reserved red color, and the trailing `--- Result: <verdict> | Turns | Cost | Duration ---` summary footer is unchanged.
- Change lives in the shared renderer (`tool-hints.js`, `turn-renderer.js`) so the live `TeeWriter` stream and offline `fit-eval output --format=text` replay stay in sync (spec 540 criterion #6).
- Spec 540 success criteria #2 and #3 amended to reflect the MCP carve-out and the errors-only preview policy.
- Second commit consolidates the rendering pipeline without changing behavior: inlined the now-trivial `hintForMcp`, factored `previewForResult` to reuse `truncate()`, and replaced the `renderTurnLines` if-chain with a `TURN_RENDERERS` dispatch table (53 lines removed, 24 added).

## Test plan

- [x] `bun run check`
- [x] `bun run test` (libeval: 311/311 pass; 13 pre-existing libwiki failures unrelated, also fail on `main` — sandbox commit-signing)
- [x] Eval Guide workflow run on this branch ([25479759578](https://github.com/forwardimpact/monorepo/actions/runs/25479759578)) — rendered traces show full MCP args (`Ask: {"question":"…"}`, `DescribeJob: {"discipline":"…","level":"J080"}`) and zero per-tool `Result:` lines

https://claude.ai/code/session_01SU78JiuXqL1vU2pqx8BT25