### PR TITLE
feat(libeval): unified trace--<case>--<participant>.<role>.ndjson convention

### DIFF
--- a/.claude/skills/fit-trace/SKILL.md
+++ b/.claude/skills/fit-trace/SKILL.md
@@ -70,10 +70,13 @@ Search options: `--limit N` (max results), `--context N` (surrounding turns),
 
 Reasoning options: `--from N` and `--to N` to limit turn range.
 
-Split mode: `run` (no-op), `supervise`, or `facilitate`. Produces
-`trace-{name}.ndjson` files (e.g., `trace-agent.ndjson`,
-`trace-facilitator.ndjson`, `trace-security-engineer.ndjson`). Use
-`--output-dir` to control where files are written.
+Split modes: `run`, `supervise`, or `facilitate`. Produces files named
+`trace--<case>--<participant>.<role>.ndjson` (e.g.,
+`trace--default--agent.agent.ndjson`,
+`trace--default--facilitator.facilitator.ndjson`,
+`trace--demo--security-engineer.agent.ndjson`). Pass `--case <id>` to embed a
+case identifier (defaults to `default`) and `--output-dir` to control where
+files are written.
 
 ### Global Options
 

--- a/.github/actions/kata-action-eval/README.md
+++ b/.github/actions/kata-action-eval/README.md
@@ -39,17 +39,24 @@ Claude Agent SDK. Handles trace capture, splitting, and artifact upload.
 | `task-amend`          | No       | —                     | Text appended to the task                |
 | `trace`               | No       | `true`                | Enable trace capture                     |
 | `timeout-minutes`     | No       | `45`                  | Max runtime in minutes                   |
+| `case`                | No       | `default`             | Case id embedded in trace filenames      |
 
 \*Exactly one of `task-text` or `task-file` is required.
 
 ## Trace Artifacts
 
-When `trace` is enabled, the action uploads these GitHub artifacts:
+When `trace` is enabled, the action uploads one artifact per run named
+`trace--<case>` containing every trace file produced. Files inside follow the
+`trace--<case>--<participant>.<role>.ndjson` convention:
 
-| Artifact            | Contents                                              | Modes                 |
-| ------------------- | ----------------------------------------------------- | --------------------- |
-| `agent-trace`       | Agent events (`trace-agent.ndjson` or `trace.ndjson`) | All                   |
-| `supervisor-trace`  | Supervisor events (`trace-supervisor.ndjson`)         | supervise             |
-| `facilitator-trace` | Facilitator events (`trace-facilitator.ndjson`)       | facilitate            |
-| `per-agent-traces`  | Per-agent files (`trace-{name}.ndjson`)               | facilitate            |
-| `combined-trace`    | Raw combined trace (`trace.ndjson`)                   | supervise, facilitate |
+| File                                              | Contents                                                   | Modes                  |
+| ------------------------------------------------- | ---------------------------------------------------------- | ---------------------- |
+| `trace--<case>.raw.ndjson`                        | Combined trace with `{source, seq, event}` envelopes       | All                    |
+| `trace--<case>--agent.agent.ndjson`               | Unwrapped agent events (run, supervise)                    | run, supervise         |
+| `trace--<case>--<profile>.agent.ndjson`           | Per-agent unwrapped events, one file per facilitate agent  | facilitate             |
+| `trace--<case>--supervisor.supervisor.ndjson`     | Unwrapped supervisor events                                | supervise              |
+| `trace--<case>--facilitator.facilitator.ndjson`   | Unwrapped facilitator events                               | facilitate             |
+
+`<case>` defaults to `default` for non-matrix runs; matrix workflows pass
+`case: ${{ matrix.<dim>.id }}` to disambiguate per-shard artifacts. The legacy
+`artifact-suffix` input is honored with a deprecation warning.

--- a/.github/actions/kata-action-eval/action.yml
+++ b/.github/actions/kata-action-eval/action.yml
@@ -65,8 +65,12 @@ inputs:
     description: Maximum minutes the agent step may run before being cancelled
     required: false
     default: "45"
+  case:
+    description: Case identifier embedded in trace artifact filenames (use the matrix case id for matrix runs; defaults to "default")
+    required: false
+    default: "default"
   artifact-suffix:
-    description: Suffix appended to uploaded trace artifact names (required to disambiguate matrix runs)
+    description: (Deprecated — pass `case` instead) Legacy alias for `case`; honored with a warning when set
     required: false
     default: ""
 
@@ -77,9 +81,24 @@ runs:
       if: inputs.trace == 'true'
       id: setup
       shell: bash
+      env:
+        CASE_INPUT: ${{ inputs.case }}
+        SUFFIX_INPUT: ${{ inputs.artifact-suffix }}
       run: |
         TRACE_DIR=$(mktemp -d)
         echo "trace-dir=$TRACE_DIR" >> "$GITHUB_OUTPUT"
+        # Resolve effective case. Explicit `case` (non-default) wins; legacy
+        # `artifact-suffix` is honored with a deprecation warning; otherwise
+        # fall through to "default".
+        if [ -n "$CASE_INPUT" ] && [ "$CASE_INPUT" != "default" ]; then
+          EFFECTIVE_CASE="$CASE_INPUT"
+        elif [ -n "$SUFFIX_INPUT" ]; then
+          echo "::warning::artifact-suffix is deprecated; pass case=<id> instead"
+          EFFECTIVE_CASE="$SUFFIX_INPUT"
+        else
+          EFFECTIVE_CASE="default"
+        fi
+        echo "case=$EFFECTIVE_CASE" >> "$GITHUB_OUTPUT"
 
     - name: Run fit-eval
       shell: bash
@@ -102,6 +121,7 @@ runs:
         MCP_SERVER: ${{ inputs.mcp-server }}
         TRACE_ENABLED: ${{ inputs.trace }}
         TRACE_DIR: ${{ steps.setup.outputs.trace-dir }}
+        TRACE_CASE: ${{ steps.setup.outputs.case }}
         TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
       run: |
         # Resolve CLI — prefer local install, fall back to npx for third-party
@@ -137,7 +157,7 @@ runs:
         fi
 
         if [ "$TRACE_ENABLED" = "true" ] && [ -n "$TRACE_DIR" ]; then
-          args+=("--output=$TRACE_DIR/trace.ndjson")
+          args+=("--output=$TRACE_DIR/trace--${TRACE_CASE}.raw.ndjson")
         fi
 
         # Mode-invariant flags. --max-turns is always forwarded; the CLI
@@ -186,11 +206,12 @@ runs:
         fi
 
     - name: Split trace
-      if: always() && inputs.trace == 'true' && inputs.mode != 'run' && steps.setup.outputs.trace-dir != ''
+      if: always() && inputs.trace == 'true' && steps.setup.outputs.trace-dir != ''
       shell: bash
       env:
         TRACE_DIR: ${{ steps.setup.outputs.trace-dir }}
         MODE: ${{ inputs.mode }}
+        TRACE_CASE: ${{ steps.setup.outputs.case }}
       run: |
         if command -v fit-trace &>/dev/null; then
           TRACE_CMD="fit-trace"
@@ -199,43 +220,14 @@ runs:
         else
           TRACE_CMD="npx --yes @forwardimpact/libeval fit-trace"
         fi
-        $TRACE_CMD split "$TRACE_DIR/trace.ndjson" --mode="$MODE" --output-dir="$TRACE_DIR"
+        $TRACE_CMD split "$TRACE_DIR/trace--${TRACE_CASE}.raw.ndjson" \
+          --mode="$MODE" \
+          --case="$TRACE_CASE" \
+          --output-dir="$TRACE_DIR"
 
-    - name: Upload agent trace
+    - name: Upload trace bundle
       if: always() && inputs.trace == 'true' && steps.setup.outputs.trace-dir != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: agent-trace${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
-        path: |
-          ${{ (inputs.mode == 'supervise' || inputs.mode == 'facilitate') && format('{0}/trace-agent.ndjson', steps.setup.outputs.trace-dir) || format('{0}/trace.ndjson', steps.setup.outputs.trace-dir) }}
-
-    - name: Upload supervisor trace
-      if: always() && inputs.trace == 'true' && inputs.mode == 'supervise' && steps.setup.outputs.trace-dir != ''
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: supervisor-trace${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
-        path: ${{ steps.setup.outputs.trace-dir }}/trace-supervisor.ndjson
-
-    - name: Upload facilitator trace
-      if: always() && inputs.trace == 'true' && inputs.mode == 'facilitate' && steps.setup.outputs.trace-dir != ''
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: facilitator-trace${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
-        path: ${{ steps.setup.outputs.trace-dir }}/trace-facilitator.ndjson
-
-    - name: Upload per-agent traces
-      if: always() && inputs.trace == 'true' && inputs.mode == 'facilitate' && steps.setup.outputs.trace-dir != ''
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: per-agent-traces${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
-        path: |
-          ${{ steps.setup.outputs.trace-dir }}/trace-*.ndjson
-          !${{ steps.setup.outputs.trace-dir }}/trace-facilitator.ndjson
-          !${{ steps.setup.outputs.trace-dir }}/trace-agent.ndjson
-
-    - name: Upload combined trace
-      if: always() && inputs.trace == 'true' && (inputs.mode == 'supervise' || inputs.mode == 'facilitate') && steps.setup.outputs.trace-dir != ''
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: combined-trace${{ inputs.artifact-suffix && format('-{0}', inputs.artifact-suffix) || '' }}
-        path: ${{ steps.setup.outputs.trace-dir }}/trace.ndjson
+        name: trace--${{ steps.setup.outputs.case }}
+        path: ${{ steps.setup.outputs.trace-dir }}/trace--*.ndjson

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -168,7 +168,7 @@ jobs:
           allowed-tools: "Bash,Read,Glob,Grep,Write,Edit"
           mcp-server: "guide"
           task-amend: ${{ inputs.task-amend }}
-          artifact-suffix: ${{ matrix.case.id }}
+          case: ${{ matrix.case.id }}
 
       - name: Dump service logs
         if: failure()

--- a/libraries/libeval/bin/fit-trace.js
+++ b/libraries/libeval/bin/fit-trace.js
@@ -182,11 +182,16 @@ const definition = {
       name: "split",
       args: "<file>",
       description:
-        "Split a combined trace into per-source files (one per agent or supervisor)",
+        "Split a combined trace into per-source files following the `trace--<case>--<participant>.<role>.ndjson` convention",
       options: {
         mode: {
           type: "string",
-          description: "Execution mode: run (no-op), supervise, or facilitate",
+          description: "Execution mode: run, supervise, or facilitate",
+        },
+        case: {
+          type: "string",
+          description:
+            "Case identifier embedded in output filenames (default: default)",
         },
         "output-dir": {
           type: "string",

--- a/libraries/libeval/src/commands/trace.js
+++ b/libraries/libeval/src/commands/trace.js
@@ -152,11 +152,22 @@ export async function runFilterCommand(values, args) {
 
 // --- Split command ---
 
-/** Valid agent source name pattern: lowercase letter, then lowercase alphanumeric or hyphen */
+/** Valid source name pattern: lowercase letter, then lowercase alphanumeric or hyphen. */
 const VALID_SOURCE_NAME = /^[a-z][a-z0-9-]*$/;
 
+/** Sources whose name is itself a structural role; classified into the role they represent. */
+const STRUCTURAL_ROLES = new Set(["agent", "supervisor", "facilitator"]);
+
 /**
- * Split a combined NDJSON trace into per-source files.
+ * Split a combined NDJSON trace into per-source files using the
+ * `trace--<case>--<participant>.<role>.ndjson` convention.
+ *
+ * Each valid envelope source becomes one output file. Structural sources
+ * (`agent`, `supervisor`, `facilitator`) classify into the matching role and
+ * use their own name as participant; profile-named sources (e.g.
+ * `staff-engineer`) classify as agents with the profile in the participant
+ * slot. Orchestrator events and invalid source names are dropped.
+ *
  * @param {object} values - Parsed option values
  * @param {string[]} args - [file]
  */
@@ -166,24 +177,24 @@ export async function runSplitCommand(values, args) {
 
   const mode = values.mode;
   if (!mode) throw new Error("split: --mode is required");
-
-  if (mode === "run") {
-    process.stdout.write(
-      "run mode: trace is already in final form, no split needed\n",
-    );
-    return;
+  if (!["run", "supervise", "facilitate"].includes(mode)) {
+    throw new Error(`split: invalid --mode "${mode}"`);
   }
 
+  const caseId = values.case ?? "default";
   const outputDir = values["output-dir"] || dirname(file);
   mkdirSync(outputDir, { recursive: true });
 
   const buckets = parseBuckets(readFileSync(file, "utf8"));
 
-  if (mode === "supervise") {
-    writeBucket(buckets, "agent", outputDir);
-    writeBucket(buckets, "supervisor", outputDir);
-  } else if (mode === "facilitate") {
-    splitFacilitated(buckets, outputDir);
+  for (const [source, lines] of buckets.entries()) {
+    if (!VALID_SOURCE_NAME.test(source)) continue;
+    const role = STRUCTURAL_ROLES.has(source) ? source : "agent";
+    const outPath = join(
+      outputDir,
+      `trace--${caseId}--${source}.${role}.ndjson`,
+    );
+    writeFileSync(outPath, lines.join("\n") + "\n");
   }
 }
 
@@ -217,44 +228,6 @@ function parseBuckets(content) {
   }
 
   return buckets;
-}
-
-/**
- * Write facilitated mode split: facilitator, per-agent, and combined agent files.
- * @param {Map<string, string[]>} buckets
- * @param {string} outputDir
- */
-function splitFacilitated(buckets, outputDir) {
-  writeBucket(buckets, "facilitator", outputDir);
-
-  const agentSources = [...buckets.keys()].filter(
-    (s) => s !== "facilitator" && VALID_SOURCE_NAME.test(s),
-  );
-
-  for (const name of agentSources) {
-    writeBucket(buckets, name, outputDir);
-  }
-
-  const combinedLines = agentSources.flatMap((n) => buckets.get(n) ?? []);
-  if (combinedLines.length > 0) {
-    writeFileSync(
-      join(outputDir, "trace-agent.ndjson"),
-      combinedLines.join("\n") + "\n",
-    );
-  }
-}
-
-/**
- * Write a single source bucket to a trace-{name}.ndjson file.
- * @param {Map<string, string[]>} buckets
- * @param {string} name
- * @param {string} outputDir
- */
-function writeBucket(buckets, name, outputDir) {
-  const lines = buckets.get(name);
-  if (!lines || lines.length === 0) return;
-  const outPath = join(outputDir, `trace-${name}.ndjson`);
-  writeFileSync(outPath, lines.join("\n") + "\n");
 }
 
 // --- Shared helpers ---

--- a/libraries/libeval/src/trace-github.js
+++ b/libraries/libeval/src/trace-github.js
@@ -65,8 +65,10 @@ export class TraceGitHub {
   /**
    * Download a trace artifact from a workflow run and extract it.
    *
-   * Tries artifact names in order: combined-trace, agent-trace.
-   * The artifact zip is downloaded and extracted to the output directory.
+   * When `opts.name` is set, looks up that exact artifact. Otherwise picks the
+   * best match from the unified `trace--<case>--<participant>.<role>` naming
+   * convention: prefer a `*.raw` artifact (combined log), then any `*.agent`,
+   * then the first `trace--*` artifact found.
    *
    * @param {number|string} runId
    * @param {object} [opts]
@@ -84,13 +86,18 @@ export class TraceGitHub {
     const artifacts = data.artifacts ?? [];
 
     // Find the trace artifact.
-    const preferredNames = opts.name
-      ? [opts.name]
-      : ["combined-trace", "agent-trace"];
     let artifact = null;
-    for (const name of preferredNames) {
-      artifact = artifacts.find((a) => a.name === name);
-      if (artifact) break;
+    if (opts.name) {
+      artifact = artifacts.find((a) => a.name === opts.name);
+    } else {
+      const traceArtifacts = artifacts.filter((a) =>
+        a.name.startsWith("trace--"),
+      );
+      artifact =
+        traceArtifacts.find((a) => a.name.endsWith(".raw")) ??
+        traceArtifacts.find((a) => a.name.endsWith(".agent")) ??
+        traceArtifacts[0] ??
+        null;
     }
 
     if (!artifact) {

--- a/libraries/libeval/test/trace-split.test.js
+++ b/libraries/libeval/test/trace-split.test.js
@@ -119,9 +119,7 @@ describe("fit-trace split", () => {
         type: "assistant",
         message: { content: [{ type: "text", text: "hi" }] },
       };
-      const { dir, file } = setupTrace([
-        { source: "agent", seq: 0, event },
-      ]);
+      const { dir, file } = setupTrace([{ source: "agent", seq: 0, event }]);
 
       runSplitCommand({ mode: "run", case: "demo" }, [file]);
 
@@ -139,9 +137,7 @@ describe("fit-trace split", () => {
         type: "assistant",
         message: { content: [{ type: "text", text: "hi" }] },
       };
-      const { dir, file } = setupTrace([
-        { source: "agent", seq: 0, event },
-      ]);
+      const { dir, file } = setupTrace([{ source: "agent", seq: 0, event }]);
 
       runSplitCommand({ mode: "run" }, [file]);
 
@@ -181,9 +177,7 @@ describe("fit-trace split", () => {
         ),
       );
       assert.ok(
-        !fs.existsSync(
-          path.join(dir, "trace--demo--UPPER_CASE.agent.ndjson"),
-        ),
+        !fs.existsSync(path.join(dir, "trace--demo--UPPER_CASE.agent.ndjson")),
       );
       assert.ok(
         !fs.existsSync(
@@ -307,9 +301,7 @@ describe("fit-trace split", () => {
       );
 
       assert.ok(
-        fs.existsSync(
-          path.join(outDir, "trace--demo--agent.agent.ndjson"),
-        ),
+        fs.existsSync(path.join(outDir, "trace--demo--agent.agent.ndjson")),
       );
       assert.ok(
         fs.existsSync(
@@ -342,9 +334,7 @@ describe("fit-trace split", () => {
       );
 
       assert.ok(
-        fs.existsSync(
-          path.join(outDir, "trace--demo--agent.agent.ndjson"),
-        ),
+        fs.existsSync(path.join(outDir, "trace--demo--agent.agent.ndjson")),
       );
     });
   });

--- a/libraries/libeval/test/trace-split.test.js
+++ b/libraries/libeval/test/trace-split.test.js
@@ -13,7 +13,7 @@ import { runSplitCommand } from "../src/commands/trace.js";
  */
 function setupTrace(envelopes) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "trace-split-"));
-  const file = path.join(dir, "trace.ndjson");
+  const file = path.join(dir, "trace--demo.raw.ndjson");
   const content = envelopes.map((e) => JSON.stringify(e)).join("\n") + "\n";
   fs.writeFileSync(file, content);
   return { dir, file };
@@ -34,7 +34,7 @@ function readNdjson(filePath) {
 
 describe("fit-trace split", () => {
   describe("supervise mode", () => {
-    test("produces trace-agent.ndjson and trace-supervisor.ndjson with unwrapped events", () => {
+    test("emits agent and supervisor files keyed by case and source", () => {
       const agentEvent = {
         type: "assistant",
         message: { content: [{ type: "text", text: "hello" }] },
@@ -49,14 +49,16 @@ describe("fit-trace split", () => {
         { source: "supervisor", seq: 1, event: supervisorEvent },
       ]);
 
-      runSplitCommand({ mode: "supervise" }, [file]);
+      runSplitCommand({ mode: "supervise", case: "demo" }, [file]);
 
-      const agentLines = readNdjson(path.join(dir, "trace-agent.ndjson"));
+      const agentLines = readNdjson(
+        path.join(dir, "trace--demo--agent.agent.ndjson"),
+      );
       assert.strictEqual(agentLines.length, 1);
       assert.deepStrictEqual(agentLines[0], agentEvent);
 
       const supervisorLines = readNdjson(
-        path.join(dir, "trace-supervisor.ndjson"),
+        path.join(dir, "trace--demo--supervisor.supervisor.ndjson"),
       );
       assert.strictEqual(supervisorLines.length, 1);
       assert.deepStrictEqual(supervisorLines[0], supervisorEvent);
@@ -64,7 +66,7 @@ describe("fit-trace split", () => {
   });
 
   describe("facilitate mode", () => {
-    test("produces trace-facilitator.ndjson, trace-agent.ndjson, and per-agent files", () => {
+    test("emits one file per profile-named agent and one for the facilitator", () => {
       const facEvent = {
         type: "assistant",
         message: { content: [{ type: "text", text: "facilitating" }] },
@@ -84,57 +86,73 @@ describe("fit-trace split", () => {
         { source: "security-engineer", seq: 2, event: eng2Event },
       ]);
 
-      runSplitCommand({ mode: "facilitate" }, [file]);
+      runSplitCommand({ mode: "facilitate", case: "demo" }, [file]);
 
-      // Facilitator trace
-      const facLines = readNdjson(path.join(dir, "trace-facilitator.ndjson"));
+      const facLines = readNdjson(
+        path.join(dir, "trace--demo--facilitator.facilitator.ndjson"),
+      );
       assert.strictEqual(facLines.length, 1);
       assert.deepStrictEqual(facLines[0], facEvent);
 
-      // Per-agent traces
       const eng1Lines = readNdjson(
-        path.join(dir, "trace-staff-engineer.ndjson"),
+        path.join(dir, "trace--demo--staff-engineer.agent.ndjson"),
       );
       assert.strictEqual(eng1Lines.length, 1);
       assert.deepStrictEqual(eng1Lines[0], eng1Event);
 
       const eng2Lines = readNdjson(
-        path.join(dir, "trace-security-engineer.ndjson"),
+        path.join(dir, "trace--demo--security-engineer.agent.ndjson"),
       );
       assert.strictEqual(eng2Lines.length, 1);
       assert.deepStrictEqual(eng2Lines[0], eng2Event);
 
-      // Combined agent trace
-      const combinedLines = readNdjson(path.join(dir, "trace-agent.ndjson"));
-      assert.strictEqual(combinedLines.length, 2);
-      assert.deepStrictEqual(combinedLines[0], eng1Event);
-      assert.deepStrictEqual(combinedLines[1], eng2Event);
+      // No merged combined-agents file under the new convention.
+      assert.ok(
+        !fs.existsSync(path.join(dir, "trace--demo--agent.agent.ndjson")),
+      );
     });
   });
 
   describe("run mode", () => {
-    test("produces no output files (no-op)", () => {
+    test("emits a single agent file using the unified convention", () => {
+      const event = {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "hi" }] },
+      };
       const { dir, file } = setupTrace([
-        {
-          source: "agent",
-          seq: 0,
-          event: {
-            type: "assistant",
-            message: { content: [{ type: "text", text: "hi" }] },
-          },
-        },
+        { source: "agent", seq: 0, event },
+      ]);
+
+      runSplitCommand({ mode: "run", case: "demo" }, [file]);
+
+      const agentLines = readNdjson(
+        path.join(dir, "trace--demo--agent.agent.ndjson"),
+      );
+      assert.strictEqual(agentLines.length, 1);
+      assert.deepStrictEqual(agentLines[0], event);
+    });
+  });
+
+  describe("default case", () => {
+    test("uses 'default' as the case when --case is omitted", () => {
+      const event = {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "hi" }] },
+      };
+      const { dir, file } = setupTrace([
+        { source: "agent", seq: 0, event },
       ]);
 
       runSplitCommand({ mode: "run" }, [file]);
 
-      // Only the original trace.ndjson should exist
-      const files = fs.readdirSync(dir);
-      assert.deepStrictEqual(files, ["trace.ndjson"]);
+      assert.ok(
+        fs.existsSync(path.join(dir, "trace--default--agent.agent.ndjson")),
+      );
     });
   });
 
   describe("invalid agent names filtered", () => {
-    test("sources not matching [a-z][a-z0-9-]* are skipped in facilitate mode", () => {
+    test("sources not matching [a-z][a-z0-9-]* are skipped", () => {
       const validEvent = {
         type: "assistant",
         message: { content: [{ type: "text", text: "valid" }] },
@@ -152,18 +170,26 @@ describe("fit-trace split", () => {
         { source: "-starts-hyphen", seq: 4, event: invalidEvent },
       ]);
 
-      runSplitCommand({ mode: "facilitate" }, [file]);
+      runSplitCommand({ mode: "facilitate", case: "demo" }, [file]);
 
-      // Only valid-agent should get its own trace file
-      assert.ok(fs.existsSync(path.join(dir, "trace-valid-agent.ndjson")));
-      assert.ok(!fs.existsSync(path.join(dir, "trace-123-bad-name.ndjson")));
-      assert.ok(!fs.existsSync(path.join(dir, "trace-UPPER_CASE.ndjson")));
-      assert.ok(!fs.existsSync(path.join(dir, "trace--starts-hyphen.ndjson")));
-
-      // Combined agent trace only has valid-agent events
-      const combinedLines = readNdjson(path.join(dir, "trace-agent.ndjson"));
-      assert.strictEqual(combinedLines.length, 1);
-      assert.deepStrictEqual(combinedLines[0], validEvent);
+      assert.ok(
+        fs.existsSync(path.join(dir, "trace--demo--valid-agent.agent.ndjson")),
+      );
+      assert.ok(
+        !fs.existsSync(
+          path.join(dir, "trace--demo--123-bad-name.agent.ndjson"),
+        ),
+      );
+      assert.ok(
+        !fs.existsSync(
+          path.join(dir, "trace--demo--UPPER_CASE.agent.ndjson"),
+        ),
+      );
+      assert.ok(
+        !fs.existsSync(
+          path.join(dir, "trace--demo---starts-hyphen.agent.ndjson"),
+        ),
+      );
     });
   });
 
@@ -175,7 +201,7 @@ describe("fit-trace split", () => {
       };
 
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), "trace-split-"));
-      const file = path.join(dir, "trace.ndjson");
+      const file = path.join(dir, "trace--demo.raw.ndjson");
       const content = [
         "",
         "   ",
@@ -187,22 +213,23 @@ describe("fit-trace split", () => {
       ].join("\n");
       fs.writeFileSync(file, content);
 
-      runSplitCommand({ mode: "supervise" }, [file]);
+      runSplitCommand({ mode: "supervise", case: "demo" }, [file]);
 
-      const agentLines = readNdjson(path.join(dir, "trace-agent.ndjson"));
+      const agentLines = readNdjson(
+        path.join(dir, "trace--demo--agent.agent.ndjson"),
+      );
       assert.strictEqual(agentLines.length, 1);
       assert.deepStrictEqual(agentLines[0], event);
 
       const supervisorLines = readNdjson(
-        path.join(dir, "trace-supervisor.ndjson"),
+        path.join(dir, "trace--demo--supervisor.supervisor.ndjson"),
       );
       assert.strictEqual(supervisorLines.length, 1);
     });
 
     test("lines without envelope format are skipped", () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), "trace-split-"));
-      const file = path.join(dir, "trace.ndjson");
-      // Raw events without the { source, event } envelope
+      const file = path.join(dir, "trace--demo.raw.ndjson");
       const content = [
         JSON.stringify({ type: "assistant", message: { content: [] } }),
         JSON.stringify({
@@ -213,9 +240,11 @@ describe("fit-trace split", () => {
       ].join("\n");
       fs.writeFileSync(file, content);
 
-      runSplitCommand({ mode: "supervise" }, [file]);
+      runSplitCommand({ mode: "supervise", case: "demo" }, [file]);
 
-      const agentLines = readNdjson(path.join(dir, "trace-agent.ndjson"));
+      const agentLines = readNdjson(
+        path.join(dir, "trace--demo--agent.agent.ndjson"),
+      );
       assert.strictEqual(agentLines.length, 1);
     });
   });
@@ -234,12 +263,17 @@ describe("fit-trace split", () => {
         { source: "supervisor", seq: 2, event: agentEvent },
       ]);
 
-      runSplitCommand({ mode: "supervise" }, [file]);
+      runSplitCommand({ mode: "supervise", case: "demo" }, [file]);
 
-      // No orchestrator file should exist
-      assert.ok(!fs.existsSync(path.join(dir, "trace-orchestrator.ndjson")));
+      assert.ok(
+        !fs.existsSync(
+          path.join(dir, "trace--demo--orchestrator.agent.ndjson"),
+        ),
+      );
 
-      const agentLines = readNdjson(path.join(dir, "trace-agent.ndjson"));
+      const agentLines = readNdjson(
+        path.join(dir, "trace--demo--agent.agent.ndjson"),
+      );
       assert.strictEqual(agentLines.length, 1);
     });
   });
@@ -267,10 +301,21 @@ describe("fit-trace split", () => {
 
       const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "trace-out-"));
 
-      runSplitCommand({ mode: "supervise", "output-dir": outDir }, [file]);
+      runSplitCommand(
+        { mode: "supervise", case: "demo", "output-dir": outDir },
+        [file],
+      );
 
-      assert.ok(fs.existsSync(path.join(outDir, "trace-agent.ndjson")));
-      assert.ok(fs.existsSync(path.join(outDir, "trace-supervisor.ndjson")));
+      assert.ok(
+        fs.existsSync(
+          path.join(outDir, "trace--demo--agent.agent.ndjson"),
+        ),
+      );
+      assert.ok(
+        fs.existsSync(
+          path.join(outDir, "trace--demo--supervisor.supervisor.ndjson"),
+        ),
+      );
     });
 
     test("creates output directory if it does not exist", () => {
@@ -291,9 +336,33 @@ describe("fit-trace split", () => {
         "nested",
       );
 
-      runSplitCommand({ mode: "supervise", "output-dir": outDir }, [file]);
+      runSplitCommand(
+        { mode: "supervise", case: "demo", "output-dir": outDir },
+        [file],
+      );
 
-      assert.ok(fs.existsSync(path.join(outDir, "trace-agent.ndjson")));
+      assert.ok(
+        fs.existsSync(
+          path.join(outDir, "trace--demo--agent.agent.ndjson"),
+        ),
+      );
+    });
+  });
+
+  describe("invalid mode", () => {
+    test("rejects unknown --mode values", async () => {
+      const { file } = setupTrace([
+        {
+          source: "agent",
+          seq: 0,
+          event: { type: "assistant", message: { content: [] } },
+        },
+      ]);
+
+      await assert.rejects(
+        runSplitCommand({ mode: "bogus", case: "demo" }, [file]),
+        /invalid --mode/,
+      );
     });
   });
 });

--- a/websites/fit/docs/libraries/prove-changes/index.md
+++ b/websites/fit/docs/libraries/prove-changes/index.md
@@ -252,7 +252,7 @@ npx fit-eval supervise \
   --agent-cwd=/tmp/refactor-sandbox \
   --allowed-tools=Read,Edit,Write,Bash,Grep,Glob \
   --max-turns=50 \
-  --output=trace.ndjson
+  --output=trace--demo.raw.ndjson
 ```
 
 Exit code `0` means the judge concluded with `success: true`; exit code `1`
@@ -268,7 +268,7 @@ npx fit-eval facilitate \
   --agent-profiles=security-engineer,release-engineer,technical-writer \
   --agent-cwd=. \
   --max-turns=20 \
-  --output=trace.ndjson
+  --output=trace--demo.raw.ndjson
 ```
 
 Participants share `--agent-cwd` by default. If two participants might edit the
@@ -286,9 +286,9 @@ After the run, confirm the trace file exists and contains the expected structure
 before investing time in analysis:
 
 ```sh
-npx fit-trace overview trace.ndjson
-npx fit-trace timeline trace.ndjson
-npx fit-trace stats trace.ndjson
+npx fit-trace overview trace--demo.raw.ndjson
+npx fit-trace timeline trace--demo.raw.ndjson
+npx fit-trace stats trace--demo.raw.ndjson
 ```
 
 `overview` reports metadata, turn count, and tool usage frequency. `timeline`
@@ -299,14 +299,19 @@ For supervised and facilitated runs, split the combined trace into per-source
 files:
 
 ```sh
-npx fit-trace split trace.ndjson --mode=supervise
-npx fit-trace split trace.ndjson --mode=facilitate
+npx fit-trace split trace--demo.raw.ndjson --mode=supervise --case=demo
+npx fit-trace split trace--demo.raw.ndjson --mode=facilitate --case=demo
 ```
 
-This produces `trace-agent.ndjson` and `trace-supervisor.ndjson` (for
-`supervise`) or `trace-facilitator.ndjson` and `trace-<participant>.ndjson`
-(for `facilitate`). Per-source traces are essential when participants disagreed
--- you can read each one's view independently.
+This produces files following the
+`trace--<case>--<participant>.<role>.ndjson` convention — for `supervise`,
+`trace--demo--agent.agent.ndjson` and
+`trace--demo--supervisor.supervisor.ndjson`; for `facilitate`,
+`trace--demo--facilitator.facilitator.ndjson` plus one
+`trace--demo--<participant>.agent.ndjson` per participant. `--case` defaults
+to `default`; pass it to disambiguate matrix shards. Per-source traces are
+essential when participants disagreed -- you can read each one's view
+independently.
 
 ## 6. Analyze traces for findings
 
@@ -315,12 +320,12 @@ like a researcher, not running a checklist. Drill into specific tools and
 message exchanges:
 
 ```sh
-npx fit-trace tool trace.ndjson Conclude
-npx fit-trace tool trace.ndjson Ask
-npx fit-trace tool trace.ndjson Announce
-npx fit-trace filter trace.ndjson --tool Edit
-npx fit-trace search trace.ndjson 'error|fail' --context 1
-npx fit-trace reasoning trace.ndjson
+npx fit-trace tool trace--demo.raw.ndjson Conclude
+npx fit-trace tool trace--demo.raw.ndjson Ask
+npx fit-trace tool trace--demo.raw.ndjson Announce
+npx fit-trace filter trace--demo.raw.ndjson --tool Edit
+npx fit-trace search trace--demo.raw.ndjson 'error|fail' --context 1
+npx fit-trace reasoning trace--demo.raw.ndjson
 ```
 
 The `Conclude` call carries the verdict -- start there when an eval fails, then

--- a/websites/fit/docs/libraries/prove-changes/run-eval/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-eval/index.md
@@ -74,7 +74,7 @@ npx fit-eval supervise \
   --supervisor-allowed-tools=Read,Grep,Bash \
   --agent-cwd=/tmp/refactor-sandbox \
   --max-turns=20 \
-  --output=trace.ndjson
+  --output=trace--default.raw.ndjson
 ```
 
 `--agent-cwd` should be a sandbox copy of your repo since the target agent edits
@@ -121,28 +121,30 @@ jobs:
             --supervisor-allowed-tools=Read,Grep,Bash \
             --agent-cwd=/tmp/sandbox \
             --max-turns=20 \
-            --output=/tmp/trace/trace.ndjson
+            --output=/tmp/trace/trace--default.raw.ndjson
 
       - name: Split trace
         if: always()
         run: |
           npx --yes @forwardimpact/libeval fit-trace split \
-            /tmp/trace/trace.ndjson \
+            /tmp/trace/trace--default.raw.ndjson \
             --mode=supervise \
+            --case=default \
             --output-dir=/tmp/trace
 
       - name: Upload trace
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: eval-trace
-          path: /tmp/trace/*.ndjson
+          name: trace--default
+          path: /tmp/trace/trace--*.ndjson
 ```
 
 `if: always()` on the split and upload steps preserves the trace even when the
-eval fails -- which is when you most need it. `split --mode=supervise` produces
-`trace-agent.ndjson` and `trace-supervisor.ndjson` alongside the original
-combined trace.
+eval fails -- which is when you most need it. `split --mode=supervise --case=default`
+produces `trace--default--agent.agent.ndjson` and
+`trace--default--supervisor.supervisor.ndjson` alongside the original
+`trace--default.raw.ndjson`.
 
 ## Read the results
 

--- a/websites/fit/docs/libraries/prove-changes/trace-analysis/index.md
+++ b/websites/fit/docs/libraries/prove-changes/trace-analysis/index.md
@@ -23,8 +23,10 @@ npx fit-trace runs                        # list recent workflow runs
 npx fit-trace download 24497273755        # downloads to /tmp/trace-24497273755/
 ```
 
-The download produces `trace.ndjson` and `structured.json`. Both formats work
-as input to every query command below.
+The download extracts the artifact zip (`trace--<case>--<participant>.<role>.ndjson`
+files plus the combined `trace--<case>.raw.ndjson`) and produces a
+`structured.json` derived from the first NDJSON file. Both NDJSON files and
+`structured.json` work as input to every query command below.
 
 ## Orient with the overview
 
@@ -138,15 +140,19 @@ For supervised or facilitated runs, split the combined trace into per-source
 files so you can see what each agent saw independently:
 
 ```sh
-npx fit-trace split /tmp/trace-24497273755/structured.json --mode=facilitate
+npx fit-trace split /tmp/trace-24497273755/structured.json --mode=facilitate --case=demo
 ```
 
-This produces `trace-facilitator.ndjson`, `trace-<participant>.ndjson`, and a
-combined `trace-agent.ndjson` in the same directory. Each file works as input
-to every query command above.
+This produces files in the same directory following the
+`trace--<case>--<participant>.<role>.ndjson` convention:
+`trace--demo--facilitator.facilitator.ndjson` and one
+`trace--demo--<participant>.agent.ndjson` per participant. Each file works as
+input to every query command above.
 
-For supervised runs, use `--mode=supervise` to get `trace-agent.ndjson` and
-`trace-supervisor.ndjson`.
+For supervised runs, use `--mode=supervise` to get
+`trace--<case>--agent.agent.ndjson` and
+`trace--<case>--supervisor.supervisor.ndjson`. `--case` defaults to `default`;
+matrix workflows pass the case id so per-shard artifacts stay isolated.
 
 ## Navigate individual turns
 


### PR DESCRIPTION
## Summary

Collapses the five mode-keyed trace artifact names (`agent-trace`, `supervisor-trace`, `facilitator-trace`, `per-agent-traces`, `combined-trace`) and three mode-keyed file shapes into one rule that covers single-agent, supervise, facilitate, and matrix-eval workflows uniformly.

New convention: `trace--<case>--<participant>.<role>.ndjson`, with `<case>=default` for non-matrix runs and the role name as the participant fallback when no profile exists (e.g. `eval-guide`'s supervisor → `trace--<case>--supervisor.supervisor.ndjson`).

- **`fit-trace split`**: drops the run-mode early return and the merged combined-agents file; classifies by source (structural roles `agent`/`supervisor`/`facilitator` keep their role; everything else is an agent); accepts a new `--case` flag.
- **`kata-action-eval` composite action**: replaces five upload steps with a single `trace--<case>` bundle; adds a `case` input; `artifact-suffix` still works but emits a deprecation warning.
- **`fit-trace download`**: replaces the hardcoded `[combined-trace, agent-trace]` fallback list with a `trace--*` glob preferring `*.raw` then `*.agent`.
- **`eval-guide.yml`**: passes `case: ${{ matrix.case.id }}` instead of the legacy `artifact-suffix`.
- **Docs**: `fit-trace` skill, three `prove-changes/*` guides, and the `kata-action-eval` README rewritten around the new shape.

## Test plan

- [x] `bun run check`
- [x] `bun run test` — 313/313 libeval tests pass; 13 unrelated libwiki failures from sandbox commit-signing (pre-existing environmental issue, untouched by this change)
- [x] CLI smoke: `fit-trace split` on a synthetic NDJSON produces the expected `trace--demo--<participant>.<role>.ndjson` files

https://claude.ai/code/session_01Kcbv2cefwnujRqr5qMWK29

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kcbv2cefwnujRqr5qMWK29)_