### PR TITLE
fix(agent-team): drop shift concept, fix matrix-context dispatch error

### DIFF
--- a/.github/workflows/agent-team.yml
+++ b/.github/workflows/agent-team.yml
@@ -1,28 +1,17 @@
 name: "Agent: Team"
 
-# Sequential agent team across three shifts. The roster lives in the `plan`
-# job below — add or remove an agent by editing one JSON line. Within a shift,
-# agents run in roster declaration order (one at a time, via `max-parallel:
-# 1`). Each row's `shifts` array controls participation; agents whose shifts
-# do not include the current shift are filtered out before the matrix
-# expands. KATA.md describes the shift rhythm.
+# Sequential agent team. The matrix below is the roster — add or remove an
+# agent by editing one line. Agents run in declaration order, one at a time
+# (`max-parallel: 1`), on every scheduled or manual invocation. KATA.md
+# describes the rhythm.
 
 on:
   schedule:
-    - cron: "0 1 * * *" # Night shift — 03:00 Paris (CEST), full PDSA chain incl. security-engineer
-    - cron: "0 10 * * *" # Day shift   — 12:00 Paris (CEST)
-    - cron: "0 18 * * *" # Swing shift — 20:00 Paris (CEST)
+    - cron: "0 1 * * *" # 03:00 Paris (CEST)
+    - cron: "0 10 * * *" # 12:00 Paris (CEST)
+    - cron: "0 18 * * *" # 20:00 Paris (CEST)
   workflow_dispatch:
     inputs:
-      shift:
-        description: "Shift to run (controls which agents participate)"
-        required: false
-        default: night
-        type: choice
-        options:
-          - night
-          - day
-          - swing
       task-amend:
         description: "Additional text appended to the task prompt for steering"
         required: false
@@ -32,54 +21,20 @@ permissions:
   contents: write
 
 jobs:
-  plan:
-    name: Plan shift
-    runs-on: ubuntu-latest
-    outputs:
-      shift: ${{ steps.derive.outputs.shift }}
-      agents: ${{ steps.derive.outputs.agents }}
-    steps:
-      - id: derive
-        env:
-          EVENT_SCHEDULE: ${{ github.event.schedule }}
-          INPUT_SHIFT: ${{ inputs.shift }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          case "${EVENT_SCHEDULE:-}" in
-            "0 1 * * *")  shift=night ;;
-            "0 10 * * *") shift=day ;;
-            "0 18 * * *") shift=swing ;;
-            "")           shift="${INPUT_SHIFT:-night}" ;;
-            *)            echo "::error::Unrecognized schedule: $EVENT_SCHEDULE"; exit 1 ;;
-          esac
-
-          # Roster: edit to add or remove agents. Order = execution order
-          # within a shift. `max-turns` defaults to "200" if omitted.
-          roster='[
-            {"name":"product-manager",  "shifts":["night","day","swing"]},
-            {"name":"staff-engineer",   "shifts":["night","day","swing"], "max-turns":"0"},
-            {"name":"security-engineer","shifts":["night"]},
-            {"name":"technical-writer", "shifts":["night","day","swing"]},
-            {"name":"release-engineer", "shifts":["night","day","swing"]},
-            {"name":"improvement-coach","shifts":["night","day","swing"]}
-          ]'
-
-          agents=$(jq -c --arg s "$shift" '[.[] | select(.shifts | index($s))]' <<<"$roster")
-          echo "shift=$shift" >> "$GITHUB_OUTPUT"
-          echo "agents=$agents" >> "$GITHUB_OUTPUT"
-          echo "Shift: $shift"
-          echo "Agents: $agents"
-
   agent:
-    needs: plan
     name: ${{ matrix.agent.name }}
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
-        agent: ${{ fromJSON(needs.plan.outputs.agents) }}
+        agent:
+          - { name: product-manager }
+          - { name: staff-engineer, max-turns: "0" }
+          - { name: security-engineer }
+          - { name: technical-writer }
+          - { name: release-engineer }
+          - { name: improvement-coach }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/kata-action-agent

--- a/.github/workflows/agent-team.yml
+++ b/.github/workflows/agent-team.yml
@@ -1,11 +1,11 @@
 name: "Agent: Team"
 
-# Sequential agent team across three shifts. The matrix below is the roster —
-# add or remove an agent by editing one line. Within a shift, agents run in
-# matrix declaration order (one at a time, via `max-parallel: 1`). Each row's
-# `shifts` field is a comma-separated list controlling participation; rows
-# whose shifts do not include the current shift are skipped via the job-level
-# `if:`. KATA.md describes the shift rhythm.
+# Sequential agent team across three shifts. The roster lives in the `plan`
+# job below — add or remove an agent by editing one JSON line. Within a shift,
+# agents run in roster declaration order (one at a time, via `max-parallel:
+# 1`). Each row's `shifts` array controls participation; agents whose shifts
+# do not include the current shift are filtered out before the matrix
+# expands. KATA.md describes the shift rhythm.
 
 on:
   schedule:
@@ -32,11 +32,12 @@ permissions:
   contents: write
 
 jobs:
-  shift:
-    name: Determine shift
+  plan:
+    name: Plan shift
     runs-on: ubuntu-latest
     outputs:
-      name: ${{ steps.derive.outputs.name }}
+      shift: ${{ steps.derive.outputs.shift }}
+      agents: ${{ steps.derive.outputs.agents }}
     steps:
       - id: derive
         env:
@@ -46,31 +47,39 @@ jobs:
         run: |
           set -euo pipefail
           case "${EVENT_SCHEDULE:-}" in
-            "0 1 * * *")  name=night ;;
-            "0 10 * * *") name=day ;;
-            "0 18 * * *") name=swing ;;
-            "")           name="${INPUT_SHIFT:-night}" ;;
+            "0 1 * * *")  shift=night ;;
+            "0 10 * * *") shift=day ;;
+            "0 18 * * *") shift=swing ;;
+            "")           shift="${INPUT_SHIFT:-night}" ;;
             *)            echo "::error::Unrecognized schedule: $EVENT_SCHEDULE"; exit 1 ;;
           esac
-          echo "name=$name" >> "$GITHUB_OUTPUT"
-          echo "Shift: $name"
+
+          # Roster: edit to add or remove agents. Order = execution order
+          # within a shift. `max-turns` defaults to "200" if omitted.
+          roster='[
+            {"name":"product-manager",  "shifts":["night","day","swing"]},
+            {"name":"staff-engineer",   "shifts":["night","day","swing"], "max-turns":"0"},
+            {"name":"security-engineer","shifts":["night"]},
+            {"name":"technical-writer", "shifts":["night","day","swing"]},
+            {"name":"release-engineer", "shifts":["night","day","swing"]},
+            {"name":"improvement-coach","shifts":["night","day","swing"]}
+          ]'
+
+          agents=$(jq -c --arg s "$shift" '[.[] | select(.shifts | index($s))]' <<<"$roster")
+          echo "shift=$shift" >> "$GITHUB_OUTPUT"
+          echo "agents=$agents" >> "$GITHUB_OUTPUT"
+          echo "Shift: $shift"
+          echo "Agents: $agents"
 
   agent:
-    needs: shift
+    needs: plan
     name: ${{ matrix.agent.name }}
     runs-on: ubuntu-latest
-    if: contains(matrix.agent.shifts, needs.shift.outputs.name)
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
-        agent:
-          - { name: product-manager, shifts: "night,day,swing" }
-          - { name: staff-engineer, shifts: "night,day,swing", max-turns: "0" }
-          - { name: security-engineer, shifts: "night" }
-          - { name: technical-writer, shifts: "night,day,swing" }
-          - { name: release-engineer, shifts: "night,day,swing" }
-          - { name: improvement-coach, shifts: "night,day,swing" }
+        agent: ${{ fromJSON(needs.plan.outputs.agents) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/kata-action-agent

--- a/KATA.md
+++ b/KATA.md
@@ -93,32 +93,30 @@ fallback. An agent reports clean only after exhausting all four levels.
 ## Workflows
 
 A single scheduled workflow, **agent-team**, runs the producer → reviewer →
-shipper chain on a three-shift Europe/Paris rhythm: **night** kicks off at
-03:00, **storyboard** at 08:00, **day** at 12:00, **swing** at 20:00. Each
-shift's matrix runs sequentially: product-manager triages and approves spec
-quality so staff has a fresh backlog, staff implements, technical-writer
-reviews docs, release-engineer gates and ships, improvement-coach reviews the
-shift. The night shift — the full cycle before the morning storyboard —
-additionally slots security-engineer between staff and technical-writer to
-review code before it ships; day and swing skip security (CVE-driven work runs
-on demand via Dependabot). Adding or removing an agent is a one-line edit to
-the matrix in `.github/workflows/agent-team.yml`. Crons are authored in UTC;
-Paris times below use CEST (UTC+2), the tighter summer bound. A separate
-event-driven workflow, **agent-react**, runs on PR comments, new discussions,
-and discussion comments — the release engineer facilitates and routes the
-comment to the participant best suited to respond, and translates
-conversational approvals into the canonical `<phase>:approved` label or
-APPROVED review. All workflows support `workflow_dispatch`, use concurrency
-groups, and time out at 30 minutes. Agent workflows send a generic prompt; the
-agent's Assess section picks the action. Storyboard and coaching send specific
-prompts to the improvement coach.
+shipper chain three times daily on a Europe/Paris rhythm — 03:00, 12:00, and
+20:00 — plus the daily storyboard at 08:00. The full chain runs in
+declaration order on every invocation: product-manager triages and approves
+spec quality so staff has a fresh backlog, staff implements, security-engineer
+reviews code before it ships, technical-writer reviews docs, release-engineer
+gates and ships, improvement-coach reviews the run. Adding or removing an
+agent is a one-line edit to the matrix in
+`.github/workflows/agent-team.yml`. Crons are authored in UTC; Paris times
+below use CEST (UTC+2), the tighter summer bound. A separate event-driven
+workflow, **agent-react**, runs on PR comments, new discussions, and
+discussion comments — the release engineer facilitates and routes the comment
+to the participant best suited to respond, and translates conversational
+approvals into the canonical `<phase>:approved` label or APPROVED review. All
+workflows support `workflow_dispatch`, use concurrency groups, and time out
+at 30 minutes. Agent workflows send a generic prompt; the agent's Assess
+section picks the action. Storyboard and coaching send specific prompts to
+the improvement coach.
 
-| Workflow            | Schedule (Paris, CEST)              | Agent                                                                                                                  |
-| ------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **kata-storyboard** | Daily 08:00                         | improvement-coach (facilitates 5 agents)                                                                               |
-| **kata-coaching**   | `workflow_dispatch`                 | improvement-coach (facilitates 1 agent)                                                                                |
-| **agent-team**      | Night 03:00 · Day 12:00 · Swing 20:00 | product-manager → staff-engineer → security-engineer (night only) → technical-writer → release-engineer → improvement-coach |
-| **agent-react**     | On PR/discussion activity           | release-engineer (facilitates 4 agents)                                                                                |
+| Workflow            | Schedule (Paris, CEST)        | Agent                                                                                                       |
+| ------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **kata-storyboard** | Daily 08:00                   | improvement-coach (facilitates 5 agents)                                                                    |
+| **kata-coaching**   | `workflow_dispatch`           | improvement-coach (facilitates 1 agent)                                                                     |
+| **agent-team**      | Daily 03:00 · 12:00 · 20:00   | product-manager → staff-engineer → security-engineer → technical-writer → release-engineer → improvement-coach |
+| **agent-react**     | On PR/discussion activity     | release-engineer (facilitates 4 agents)                                                                     |
 
 ## Skills
 

--- a/websites/fit/docs/internals/kata/index.md
+++ b/websites/fit/docs/internals/kata/index.md
@@ -128,25 +128,24 @@ specs merge only the document, not code.
 ## The Workflows
 
 A single scheduled **agent-team** workflow runs the producer → reviewer →
-shipper chain on a three-shift Europe/Paris rhythm — **night** kicks off at
-03:00, **storyboard** at 08:00, **day** at 12:00, **swing** at 20:00 — plus an
-event-driven **agent-react** workflow on PR and discussion activity, and an
-on-demand **kata-coaching** workflow dispatched manually.
+shipper chain three times daily on a Europe/Paris rhythm — 03:00, 12:00, and
+20:00 — plus the daily **storyboard** at 08:00, an event-driven
+**agent-react** workflow on PR and discussion activity, and an on-demand
+**kata-coaching** workflow dispatched manually.
 
-| Workflow            | Schedule (Paris, CEST)              | Agent                                                                                                                  |
-| ------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **kata-storyboard** | Daily 08:00                         | improvement-coach (facilitates 5 agents)                                                                               |
-| **kata-coaching**   | `workflow_dispatch`                 | improvement-coach (facilitates 1 agent)                                                                                |
-| **agent-team**      | Night 03:00 · Day 12:00 · Swing 20:00 | product-manager → staff-engineer → security-engineer (night only) → technical-writer → release-engineer → improvement-coach |
-| **agent-react**     | On PR/discussion activity           | release-engineer (facilitates 4 agents)                                                                                |
+| Workflow            | Schedule (Paris, CEST)        | Agent                                                                                                       |
+| ------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **kata-storyboard** | Daily 08:00                   | improvement-coach (facilitates 5 agents)                                                                    |
+| **kata-coaching**   | `workflow_dispatch`           | improvement-coach (facilitates 1 agent)                                                                     |
+| **agent-team**      | Daily 03:00 · 12:00 · 20:00   | product-manager → staff-engineer → security-engineer → technical-writer → release-engineer → improvement-coach |
+| **agent-react**     | On PR/discussion activity     | release-engineer (facilitates 4 agents)                                                                     |
 
-Within each shift the agent-team matrix runs sequentially: the product manager
-triages and approves spec quality so staff has a fresh backlog, staff
-implements, technical-writer reviews docs, release-engineer gates and ships,
-improvement-coach reviews the shift. The night shift additionally slots
-security-engineer between staff and technical-writer; day and swing skip
-security. Adding or removing an agent is a one-line edit to the matrix in
-`.github/workflows/agent-team.yml`.
+The agent-team matrix runs sequentially in declaration order on every
+invocation: the product manager triages and approves spec quality so staff
+has a fresh backlog, staff implements, security-engineer reviews code before
+it ships, technical-writer reviews docs, release-engineer gates and ships,
+improvement-coach reviews the run. Adding or removing an agent is a one-line
+edit to the matrix in `.github/workflows/agent-team.yml`.
 
 ---
 


### PR DESCRIPTION
## Summary

Two follow-ups to PR #820:

- **fix**: replace the static matrix's job-level `if: contains(matrix.agent.shifts, ...)` with a dynamic-matrix shape. GitHub Actions does not allow `matrix` context in job-level `if:` (the parser rejects it: `Unrecognized named-value: 'matrix'`), so `workflow_dispatch` was failing to queue.
- **refactor**: drop the `shift` abstraction entirely. The roster is now a flat YAML matrix; all six agents run in declaration order on every scheduled or manual invocation. Three daily crons (03:00, 12:00, 20:00 Paris CEST) replace the per-shift filtering. The dispatch input is now just `task-amend`. Adding/removing an agent remains a one-line edit.

Behavior change worth flagging: `security-engineer` now runs on all three daily invocations instead of only the night one. KATA.md and `websites/fit/docs/internals/kata/index.md` are updated to match the simplified rhythm.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- [ ] `workflow_dispatch` `agent-team.yml` and confirm all six matrix entries queue and run sequentially in declaration order (product-manager → staff-engineer → security-engineer → technical-writer → release-engineer → improvement-coach).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ckbo86NLXtbB6ioR1gr1G4)_