### PR TITLE
spec(860): measurement-system change protocol for canonical metrics

### DIFF
--- a/specs/860-measurement-system-change-protocol/design-a.md
+++ b/specs/860-measurement-system-change-protocol/design-a.md
@@ -1,0 +1,152 @@
+# Design 860-A — Measurement-system change protocol
+
+> **Process note:** Spec 860 is not yet merged on `main` at the time
+> this design is being written. The design proceeds at user direction;
+> under normal kata-design preconditions the spec PR would merge first.
+
+## Architecture summary
+
+Add one new agent-level reference,
+`.claude/agents/references/measurement-protocol.md`, that names the
+repair-move typology, the Measurement Change Disclosure (MCD) shape, the
+no-silent-amendment rule, and the canonical-11 list (the team's
+canonical metric set, anchored in this reference rather than re-stated
+in storyboard files). KATA.md § Metrics gains one paragraph linking to
+it. The `kata-release-merge` skill becomes the producer of one new
+canonical metric, `time_to_first_approval_hours`, recorded one row per
+run to `wiki/metrics/kata-release-merge/{YYYY}-approval.csv` (sibling
+file to its existing `prs_merged` CSV, preserving the one-skill /
+one-CSV / one-metric coupling per skill-CSV pair). The
+`kata-storyboard` skill's meeting template references the MCD shape and
+the canonical-11 list in the new reference, so canonical-11 changes are
+gated on a linked MCD without restating the rule. No agent-persona
+files change.
+
+## Components
+
+| Component | Lives in | Responsibility |
+| --- | --- | --- |
+| `measurement-protocol.md` | `.claude/agents/references/` | Names repair-move typology, MCD shape, no-silent-amendment rule, canonical-11 list. Sibling of `coordination-protocol.md` and `memory-protocol.md`. |
+| KATA.md § Metrics extension | `KATA.md` | One-paragraph addition pointing to the new reference. No re-statement of the rule or the typology. |
+| `time_to_first_approval_hours` metric | `wiki/metrics/kata-release-merge/{YYYY}-approval.csv` | New canonical-11 entry. Producer = `kata-release-merge`. One row per run; value is the median hours-to-first-`<phase>:approved`-signal across PRs the run touched. |
+| `kata-release-merge` `references/metrics.md` extension | `.claude/skills/kata-release-merge/references/metrics.md` | Adds the new metric's row alongside `prs_merged`; declares the sibling CSV path. |
+| Storyboard MCD hook | `.claude/skills/kata-storyboard/SKILL.md` | Two checklist additions: every canonical-11 change item carries a `MCD:` link; cohort read-out items enumerate the day's MCDs. |
+| MCD authoring locus | Existing `experiment` and `obstacle` GitHub issue bodies | The MCD is a section template inside the issue body, not a new artifact type. |
+
+## Repair-move typology (eight named moves)
+
+| Move | Definition | Existing precedent |
+| --- | --- | --- |
+| `producer-rehoming` | Reassign a metric's producing skill when the original is removed/split/renamed; record continuity tag on first row under new producer. | #788, RFC #804 |
+| `mode-restriction` | Narrow recording to one activation mode of a multi-mode skill so the series is unimodal. | #772, PR #773 |
+| `historical-phasing` | Annotate a series with a Phase boundary; XmR analysis windows on Phase 1; no CSV backfill. | #809, PR #811 |
+| `sidecar-pre-flight` | Record a candidate metric to a sibling CSV while the canonical metric continues; no denominator change until ratification. | #787 |
+| `stock-vs-flow-recast` | Replace a flow-rate metric with a stock metric on the same axis when burst architecture trips XmR by construction. | #768, #770 |
+| `event-driven-recast` | Replace per-day cadence with per-activation ("no row, no event"). | #810 |
+| `rule-semantics-rfc` | Challenge an XmR rule's blocking effect on `predictable` via Discussion RFC; quorum required. | #814 |
+| `habit-to-policy` | Promote an undocumented defensive habit into a SKILL.md check after a defect surfaces. | #817, PR #655 |
+
+The list is closed at design time, but the protocol allows new moves to
+be added to the reference via an MCD whose `move:` field is `new-move`
+and whose body proposes the addition. New entries land via the same
+spec/design/plan/implement chain.
+
+## MCD shape
+
+```yaml
+mcd:
+  move: producer-rehoming | mode-restriction | historical-phasing |
+        sidecar-pre-flight | stock-vs-flow-recast | event-driven-recast |
+        rule-semantics-rfc | habit-to-policy | new-move
+  affected_metrics: [{skill: <skill>, metric: <metric>}]
+  falsifier_set: [<predicate>, ...]
+  verdict_horizon: <YYYY-MM-DD>
+  cohort_readout: <YYYY-MM-DD>
+  denominator_effect: none | sidecar | conditional-amend | amend
+  links:
+    obstacle_issue: <#NNN>?
+    experiment_issue: <#NNN>?
+    pr: <#NNN>?
+```
+
+The MCD is an embeddable YAML block (fenced) inside an experiment or
+obstacle issue body, not a new artifact type. Its
+`denominator_effect` field is the explicit hook for the no-silent-
+amendment rule: any value other than `none` requires a cohort read-out
+date and a linked storyboard line.
+
+## No-silent-amendment rule
+
+> No change to the canonical-11 denominator (additions, removals,
+> conditional or unconditional amendments) lands without an MCD whose
+> `denominator_effect` is non-`none`, a cohort read-out date on or
+> before the storyboard meeting at which the change takes effect, and a
+> linked storyboard headline that surfaces the change up-front.
+
+This single statement lives in `measurement-protocol.md`. KATA.md § Metrics
+links to it; no other file restates it.
+
+## Approval-throughput metric
+
+`time_to_first_approval_hours` (median per run) reads the binding
+constraint #572 names. Design choice (decision #5 below) prefers a
+per-run median over a per-PR row because (a) it preserves one row per
+run as KATA.md § Metrics requires, and (b) median absorbs both
+approval-fast and approval-slow PRs without manufacturing ties. The
+producer is `kata-release-merge` because that skill already iterates
+phase PRs, already reads `<phase>:approved` signals, and already
+records `prs_merged` to the same `wiki/metrics/kata-release-merge/`
+directory.
+
+## Data flow
+
+```mermaid
+flowchart LR
+  CHG[Canonical-11 change<br/>proposed in issue] --> MCD[MCD YAML block in issue body]
+  MCD --> SB{Storyboard MCD hook}
+  SB --> READ[Cohort read-out at horizon date]
+  READ --> RAT{Ratify?}
+  RAT -- yes --> AMEND[Storyboard line updates;<br/>denominator change lands]
+  RAT -- no --> ROLL[Sidecar / phase / mode<br/>change rolled back]
+  KATA["KATA.md § Metrics"] -.-> REF[measurement-protocol.md]
+  STORY[wiki/storyboard-*.md] -.-> REF
+  RM[kata-release-merge run] --> CSV[wiki/metrics/kata-release-merge/<br/>{YYYY}-approval.csv]
+  XMR[fit-xmr analyze] --> CSV
+  XMR --> CSV2[wiki/metrics/kata-release-merge/{YYYY}.csv]
+  REF -.->|enumerates| MOVES[Eight repair moves]
+  REF -.->|defines| MCD
+  REF -.->|owns| RULE[No-silent-amendment rule]
+  REF -.->|lists| C11[canonical-11 set]
+```
+
+## Key decisions
+
+| # | Decision | Rejected alternative | Why |
+| --- | --- | --- | --- |
+| 1 | Locate the typology, MCD, rule, and canonical-11 list in one new agent-level reference (`measurement-protocol.md`). | Inline the typology and rule in KATA.md § Metrics. | KATA.md is identity-and-orientation per the project's "one home per policy" rule (CLAUDE.md § Documentation Map). Protocol detail belongs with siblings `coordination-protocol.md` and `memory-protocol.md`. KATA.md links and does not restate. |
+| 2 | MCD is a YAML block embedded in existing experiment/obstacle issues. | New issue type or new file type per change. | Repair moves already coincide with experiment/obstacle issues today; adding a parallel artifact type doubles routing. The YAML block makes the MCD greppable without inventing a new surface. |
+| 3 | Repair-move list is closed at design time; extensions land via spec/design/plan/implement. | Open list with free-form move names per issue. | A closed list is the legible part of the protocol; an open list reverts to the current ad-hoc state. Extension path preserves growth. |
+| 4 | Producer for `time_to_first_approval_hours` is `kata-release-merge`. | New `kata-approval-meter` skill; or producer = `kata-storyboard`. | `kata-release-merge` already iterates phase PRs and reads `<phase>:approved` signals. New skill adds an agent-team matrix entry for one metric. `kata-storyboard` is a once-daily facilitator and would miss between-meeting churn. |
+| 5 | Metric value = median hours from PR open to first `<phase>:approved` signal across PRs the run touched. | Mean; per-PR rows; count of `<2h` PRs. | Mean is volatile under bursty merge cadence (#566 ESCALATION_COST_TRACKED). Per-PR rows violate KATA.md § Metrics' one-row-per-run rule. Count loses magnitude. Median compresses to one row, retains magnitude, and is XmR-stable for the bursty distribution. |
+| 6 | Sibling CSV (`{YYYY}-approval.csv`) under the existing `kata-release-merge/` directory rather than a new metric directory. | A new `wiki/metrics/kata-release-throughput/` directory. | KATA.md § Metrics maps directories to skills, not to metrics. The sibling-CSV form preserves the skill-directory mapping while admitting that one skill can produce multiple metrics if each carries one-row-per-run discipline (the existing rule was "one metric per skill" — this design proposes "one metric per skill-CSV pair," which is the minimum extension that admits the binding-constraint metric). |
+| 7 | Storyboard hook is two checklist items in the `kata-storyboard` skill, not a template-text edit. | Bake the MCD link requirement into the meeting prose template. | Checklist items are greppable and machine-checkable (criterion 6); prose drifts. |
+| 8 | `denominator_effect: conditional-amend` admitted as a first-class value, with a cohort read-out date as the firing condition. | Conditional amendments expressed in free prose per RFC. | The team has already used conditional amendments (#804, Dim 2 → Dim 2/10). A first-class field makes the firing condition machine-readable and lets storyboard pre-surface the conditional line. |
+
+## Migration boundary
+
+`kata-release-merge` records the new metric prospectively from
+implementation onwards; no historical backfill (consistent with
+`historical-phasing`). Existing experiments and obstacles need not file
+retroactive MCDs — the protocol applies to canonical-11 changes
+proposed after `measurement-protocol.md` lands on `main`. Storyboard
+files updated forward; the canonical-11 list moves authoritatively to
+`measurement-protocol.md` on the implementation PR, with one
+storyboard line citing the reference.
+
+## Out of scope (re-affirming spec)
+
+`fit-xmr` rule semantics; per-skill metric definitions other than
+`time_to_first_approval_hours`; rerunning open experiments; CSV
+backfill; branch-protection installation; agent-react routing changes
+beyond the storyboard MCD link surface; skill-pack publishing; agent
+persona changes; the choice of any other binding-constraint metric.

--- a/specs/860-measurement-system-change-protocol/design-a.md
+++ b/specs/860-measurement-system-change-protocol/design-a.md
@@ -1,55 +1,51 @@
 # Design 860-A — Measurement-system change protocol
 
-> **Process note:** Spec 860 is not yet merged on `main` at the time
-> this design is being written. The design proceeds at user direction;
-> under normal kata-design preconditions the spec PR would merge first.
-
 ## Architecture summary
 
 Add one new agent-level reference,
 `.claude/agents/references/measurement-protocol.md`, that names the
-repair-move typology, the Measurement Change Disclosure (MCD) shape, the
-no-silent-amendment rule, and the canonical-11 list (the team's
-canonical metric set, anchored in this reference rather than re-stated
-in storyboard files). KATA.md § Metrics gains one paragraph linking to
-it. The `kata-release-merge` skill becomes the producer of one new
-canonical metric, `time_to_first_approval_hours`, recorded one row per
-run to `wiki/metrics/kata-release-merge/{YYYY}-approval.csv` (sibling
-file to its existing `prs_merged` CSV, preserving the one-skill /
-one-CSV / one-metric coupling per skill-CSV pair). The
-`kata-storyboard` skill's meeting template references the MCD shape and
-the canonical-11 list in the new reference, so canonical-11 changes are
-gated on a linked MCD without restating the rule. No agent-persona
-files change.
+repair-move typology, the Measurement Change Disclosure (MCD) shape, and
+the no-silent-amendment rule. KATA.md § Metrics gains one paragraph
+linking to it and a small extension admitting the binding-constraint
+metric (see decision #6). The canonical-11 enumeration stays where it
+lives today (`wiki/storyboard-*.md`); the reference defines the
+protocol around it, not the list itself. The `kata-release-merge`
+skill becomes the producer of one new canonical metric,
+`time_to_first_approval_hours`, written one row per run to its existing
+`wiki/metrics/kata-release-merge/{YYYY}.csv` (the file is already long-
+format — `date,metric,value,unit,run,note` — so the new metric joins as
+additional rows, distinguished by the `metric` column, alongside the
+existing `prs_merged` rows). The `kata-session` skill's team-storyboard
+overlay gains two checklist items so canonical-11 changes are gated on a
+linked MCD without restating the rule. No agent-persona files change.
 
 ## Components
 
 | Component | Lives in | Responsibility |
 | --- | --- | --- |
-| `measurement-protocol.md` | `.claude/agents/references/` | Names repair-move typology, MCD shape, no-silent-amendment rule, canonical-11 list. Sibling of `coordination-protocol.md` and `memory-protocol.md`. |
-| KATA.md § Metrics extension | `KATA.md` | One-paragraph addition pointing to the new reference. No re-statement of the rule or the typology. |
-| `time_to_first_approval_hours` metric | `wiki/metrics/kata-release-merge/{YYYY}-approval.csv` | New canonical-11 entry. Producer = `kata-release-merge`. One row per run; value is the median hours-to-first-`<phase>:approved`-signal across PRs the run touched. |
-| `kata-release-merge` `references/metrics.md` extension | `.claude/skills/kata-release-merge/references/metrics.md` | Adds the new metric's row alongside `prs_merged`; declares the sibling CSV path. |
-| Storyboard MCD hook | `.claude/skills/kata-storyboard/SKILL.md` | Two checklist additions: every canonical-11 change item carries a `MCD:` link; cohort read-out items enumerate the day's MCDs. |
-| MCD authoring locus | Existing `experiment` and `obstacle` GitHub issue bodies | The MCD is a section template inside the issue body, not a new artifact type. |
+| `measurement-protocol.md` | `.claude/agents/references/` | Names repair-move typology, MCD shape, no-silent-amendment rule. Sibling of `coordination-protocol.md` and `memory-protocol.md`. |
+| KATA.md § Metrics extension | `KATA.md` | One paragraph linking to the new reference, plus one sentence admitting the binding-constraint metric (decision #6). |
+| `time_to_first_approval_hours` metric | `wiki/metrics/kata-release-merge/{YYYY}.csv` (additional rows; `metric` column distinguishes from `prs_merged`) | New canonical-11 entry. Producer = `kata-release-merge`. One row per run; value is the median hours-to-first-`<phase>:approved`-signal across qualifying PRs (cohort and empty-day rules below). |
+| `kata-release-merge` `references/metrics.md` extension | `.claude/skills/kata-release-merge/references/metrics.md` | Adds the new metric's row alongside `prs_merged`; documents the cohort predicate and the empty-day rule. |
+| Storyboard MCD hook | `.claude/skills/kata-session/references/team-storyboard.md` | Two checklist additions: every canonical-11 change item carries an `MCD:` link; cohort read-out items enumerate the day's MCDs. |
+| MCD authoring locus | Existing `experiment` and `obstacle` GitHub issue bodies | The MCD is a YAML section template inside the issue body, not a new artifact type. Canonical-11 change diffs cite it by issue link. |
 
 ## Repair-move typology (eight named moves)
 
-| Move | Definition | Existing precedent |
-| --- | --- | --- |
-| `producer-rehoming` | Reassign a metric's producing skill when the original is removed/split/renamed; record continuity tag on first row under new producer. | #788, RFC #804 |
-| `mode-restriction` | Narrow recording to one activation mode of a multi-mode skill so the series is unimodal. | #772, PR #773 |
-| `historical-phasing` | Annotate a series with a Phase boundary; XmR analysis windows on Phase 1; no CSV backfill. | #809, PR #811 |
-| `sidecar-pre-flight` | Record a candidate metric to a sibling CSV while the canonical metric continues; no denominator change until ratification. | #787 |
-| `stock-vs-flow-recast` | Replace a flow-rate metric with a stock metric on the same axis when burst architecture trips XmR by construction. | #768, #770 |
-| `event-driven-recast` | Replace per-day cadence with per-activation ("no row, no event"). | #810 |
-| `rule-semantics-rfc` | Challenge an XmR rule's blocking effect on `predictable` via Discussion RFC; quorum required. | #814 |
-| `habit-to-policy` | Promote an undocumented defensive habit into a SKILL.md check after a defect surfaces. | #817, PR #655 |
+Each move binds a one-sentence definition and the kind of falsifier-set
+predicates an instance MCD must include. The list is closed: extensions
+land via the spec/design/plan/implement chain, not via the MCD form.
 
-The list is closed at design time, but the protocol allows new moves to
-be added to the reference via an MCD whose `move:` field is `new-move`
-and whose body proposes the addition. New entries land via the same
-spec/design/plan/implement chain.
+| Move | Definition | Falsifier-set kind | Existing precedent |
+| --- | --- | --- | --- |
+| `producer-rehoming` | Reassign a metric's producing skill when the original is removed/split/renamed; record continuity tag on first row under new producer. | "structural-zero rows present after rehoming run" | #788, RFC #804 |
+| `mode-restriction` | Narrow recording to one activation mode of a multi-mode skill so the series is unimodal. | "post-restriction series remains bimodal under XmR" | #772, PR #773 |
+| `historical-phasing` | Annotate a series with a Phase boundary; XmR analysis windows on Phase 1; no CSV backfill. | "Phase 1 cannot reach `predictable` after horizon" | #809, PR #811 |
+| `sidecar-pre-flight` | Record a candidate metric to a sibling CSV while the canonical metric continues; no denominator change until ratification. | "sidecar diverges from canonical at horizon" | #787 |
+| `stock-vs-flow-recast` | Replace a flow-rate metric with a stock metric on the same axis when burst architecture trips XmR by construction. | "stock series fires `xRule1` or `mrRule1` post-recast" | #768, #770 |
+| `event-driven-recast` | Replace per-day cadence with per-activation ("no row, no event"). | "per-activation series remains `insufficient_data` at horizon" | #810 |
+| `rule-semantics-rfc` | Challenge an XmR rule's blocking effect on `predictable` via Discussion RFC; quorum required. | "RFC quorum not reached by horizon" | #814 |
+| `habit-to-policy` | Promote an undocumented defensive habit into a SKILL.md check after a defect surfaces. | "post-promotion defect of the same shape recurs" | #817, PR #655 |
 
 ## MCD shape
 
@@ -57,9 +53,9 @@ spec/design/plan/implement chain.
 mcd:
   move: producer-rehoming | mode-restriction | historical-phasing |
         sidecar-pre-flight | stock-vs-flow-recast | event-driven-recast |
-        rule-semantics-rfc | habit-to-policy | new-move
+        rule-semantics-rfc | habit-to-policy
   affected_metrics: [{skill: <skill>, metric: <metric>}]
-  falsifier_set: [<predicate>, ...]
+  falsifier_set: [<predicate>, ...]   # at least one predicate of the kind named for the move
   verdict_horizon: <YYYY-MM-DD>
   cohort_readout: <YYYY-MM-DD>
   denominator_effect: none | sidecar | conditional-amend | amend
@@ -70,10 +66,13 @@ mcd:
 ```
 
 The MCD is an embeddable YAML block (fenced) inside an experiment or
-obstacle issue body, not a new artifact type. Its
-`denominator_effect` field is the explicit hook for the no-silent-
-amendment rule: any value other than `none` requires a cohort read-out
-date and a linked storyboard line.
+obstacle issue body. `denominator_effect` is the explicit hook for the
+no-silent-amendment rule: any value other than `none` requires a cohort
+read-out date and a linked storyboard line. Spec Success #6 is satisfied
+because every canonical-11 change diff carries an `MCD: #NNN` link
+inline (in the producer skill's `references/metrics.md`, in the
+`measurement-protocol.md` reference's change log, or in the storyboard
+file): the link sits in `git diff`; the body lives in the issue.
 
 ## No-silent-amendment rule
 
@@ -88,15 +87,31 @@ links to it; no other file restates it.
 
 ## Approval-throughput metric
 
-`time_to_first_approval_hours` (median per run) reads the binding
-constraint #572 names. Design choice (decision #5 below) prefers a
-per-run median over a per-PR row because (a) it preserves one row per
-run as KATA.md § Metrics requires, and (b) median absorbs both
-approval-fast and approval-slow PRs without manufacturing ties. The
-producer is `kata-release-merge` because that skill already iterates
-phase PRs, already reads `<phase>:approved` signals, and already
-records `prs_merged` to the same `wiki/metrics/kata-release-merge/`
-directory.
+`time_to_first_approval_hours` reads the binding constraint #572 names.
+The metric is a **duration**, not a count — KATA.md § Metrics today
+binds metrics to the count of units of work; admitting a duration metric
+for the binding constraint is the smallest extension that satisfies the
+spec's Success #4 (decision #6).
+
+- **Producer:** `kata-release-merge` — the skill already iterates phase
+  PRs and reads `<phase>:approved` signals.
+- **Cohort:** PRs whose **first** `<phase>:approved` signal was observed
+  for the first time during this run (the "fresh-approval" cohort). A
+  PR contributes its time-to-first-approval value once, not on every
+  subsequent run that touches it.
+- **Empty cohort:** a run with zero qualifying PRs appends a row with
+  empty `value` (preserving one-row-per-run discipline). `fit-xmr`
+  treats an empty value as a missing observation, not as zero — distinct
+  from the structural-zero failure mode #788 surfaced.
+- **Signal predicate:** label-add events for `spec:approved`,
+  `design:approved`, `plan:approved`, and `plan:implemented` (read via
+  `gh api repos/.../issues/{n}/timeline`), plus PR-review APPROVED
+  events (read via `gh pr view --json reviews`). The earlier of the two
+  per PR is the first-approval timestamp.
+- **Aggregation:** median hours from PR open to first-approval timestamp
+  across the cohort. Median compresses to one row, retains magnitude,
+  and is XmR-stable for the bursty distribution (mean is volatile under
+  Dependabot waves).
 
 ## Data flow
 
@@ -108,40 +123,38 @@ flowchart LR
   READ --> RAT{Ratify?}
   RAT -- yes --> AMEND[Storyboard line updates;<br/>denominator change lands]
   RAT -- no --> ROLL[Sidecar / phase / mode<br/>change rolled back]
-  KATA["KATA.md § Metrics"] -.-> REF[measurement-protocol.md]
-  STORY[wiki/storyboard-*.md] -.-> REF
-  RM[kata-release-merge run] --> CSV[wiki/metrics/kata-release-merge/<br/>{YYYY}-approval.csv]
-  XMR[fit-xmr analyze] --> CSV
-  XMR --> CSV2[wiki/metrics/kata-release-merge/{YYYY}.csv]
+  KATA["KATA.md § Metrics"] -.->|links to| REF[measurement-protocol.md]
+  STORY[wiki/storyboard-*.md] -.->|links to| REF
+  RM[kata-release-merge run] --> CSV[wiki/metrics/kata-release-merge/{YYYY}.csv]
+  CSV --> XMR[fit-xmr analyze]
   REF -.->|enumerates| MOVES[Eight repair moves]
   REF -.->|defines| MCD
   REF -.->|owns| RULE[No-silent-amendment rule]
-  REF -.->|lists| C11[canonical-11 set]
 ```
 
 ## Key decisions
 
 | # | Decision | Rejected alternative | Why |
 | --- | --- | --- | --- |
-| 1 | Locate the typology, MCD, rule, and canonical-11 list in one new agent-level reference (`measurement-protocol.md`). | Inline the typology and rule in KATA.md § Metrics. | KATA.md is identity-and-orientation per the project's "one home per policy" rule (CLAUDE.md § Documentation Map). Protocol detail belongs with siblings `coordination-protocol.md` and `memory-protocol.md`. KATA.md links and does not restate. |
-| 2 | MCD is a YAML block embedded in existing experiment/obstacle issues. | New issue type or new file type per change. | Repair moves already coincide with experiment/obstacle issues today; adding a parallel artifact type doubles routing. The YAML block makes the MCD greppable without inventing a new surface. |
-| 3 | Repair-move list is closed at design time; extensions land via spec/design/plan/implement. | Open list with free-form move names per issue. | A closed list is the legible part of the protocol; an open list reverts to the current ad-hoc state. Extension path preserves growth. |
-| 4 | Producer for `time_to_first_approval_hours` is `kata-release-merge`. | New `kata-approval-meter` skill; or producer = `kata-storyboard`. | `kata-release-merge` already iterates phase PRs and reads `<phase>:approved` signals. New skill adds an agent-team matrix entry for one metric. `kata-storyboard` is a once-daily facilitator and would miss between-meeting churn. |
-| 5 | Metric value = median hours from PR open to first `<phase>:approved` signal across PRs the run touched. | Mean; per-PR rows; count of `<2h` PRs. | Mean is volatile under bursty merge cadence (#566 ESCALATION_COST_TRACKED). Per-PR rows violate KATA.md § Metrics' one-row-per-run rule. Count loses magnitude. Median compresses to one row, retains magnitude, and is XmR-stable for the bursty distribution. |
-| 6 | Sibling CSV (`{YYYY}-approval.csv`) under the existing `kata-release-merge/` directory rather than a new metric directory. | A new `wiki/metrics/kata-release-throughput/` directory. | KATA.md § Metrics maps directories to skills, not to metrics. The sibling-CSV form preserves the skill-directory mapping while admitting that one skill can produce multiple metrics if each carries one-row-per-run discipline (the existing rule was "one metric per skill" — this design proposes "one metric per skill-CSV pair," which is the minimum extension that admits the binding-constraint metric). |
-| 7 | Storyboard hook is two checklist items in the `kata-storyboard` skill, not a template-text edit. | Bake the MCD link requirement into the meeting prose template. | Checklist items are greppable and machine-checkable (criterion 6); prose drifts. |
+| 1 | Locate the typology, MCD, and rule in one new agent-level reference (`measurement-protocol.md`). | Inline the typology and rule in KATA.md § Metrics. | KATA.md is identity-and-orientation per CLAUDE.md § Documentation Map. Protocol detail belongs with siblings `coordination-protocol.md` and `memory-protocol.md`. |
+| 2 | MCD is a YAML block embedded in existing experiment/obstacle issues. | New issue type or new file type per change. | Repair moves already coincide with existing issues. The YAML block makes the MCD greppable inside its issue body; the change-diff carries the issue link. |
+| 3 | Repair-move list is closed at design time; extensions land via spec/design/plan/implement. | Open list with a `move: new-move` enum value usable at MCD time. | A closed list is the legible part of the protocol; an open list reverts to the current ad-hoc state. Forcing extensions through the spec chain preserves growth without diluting closure. |
+| 4 | Producer for `time_to_first_approval_hours` is `kata-release-merge`. | New `kata-approval-meter` skill; or producer = `kata-session`. | `kata-release-merge` already iterates phase PRs and reads `<phase>:approved` signals. A new skill adds an agent-team matrix entry for one metric. `kata-session` is a once-daily facilitator and would miss between-meeting churn. |
+| 5 | Metric value = median across the fresh-approval cohort, with empty `value` on zero-cohort runs. | Mean; per-PR rows; rolling-cohort with all carry-forward PRs; row omission on zero-cohort runs. | Mean is volatile under bursty cadence. Per-PR rows violate one-row-per-run. Rolling cohort double-counts a PR's dwell across runs. Row omission breaks `fit-xmr`'s expectation of one row per run; an empty value preserves the discipline and is treated as a missing observation, not a structural zero. |
+| 6 | New metric joins the existing `kata-release-merge/{YYYY}.csv` as additional rows (long-format CSV; `metric` column distinguishes). KATA.md § Metrics extends to admit one binding-constraint duration metric per producer skill alongside its count metric. | Sibling CSV (`{YYYY}-approval.csv`); new directory. | The CSV is already long-format with a `metric` column; adding rows is the lightest possible extension. The KATA.md edit is the minimum a duration binding-constraint metric requires (count rule preserved as the default; binding-constraint metric admitted as the named exception). |
+| 7 | Storyboard hook is two checklist items in `kata-session/references/team-storyboard.md`. | Bake the MCD link requirement into prose; add to `kata-session/SKILL.md`; add to `wiki/storyboard-*.md` template. | Checklists are greppable and machine-checkable (Success #6). The team-storyboard overlay is the canonical home for storyboard-meeting checks; SKILL.md is the umbrella, prose drifts. |
 | 8 | `denominator_effect: conditional-amend` admitted as a first-class value, with a cohort read-out date as the firing condition. | Conditional amendments expressed in free prose per RFC. | The team has already used conditional amendments (#804, Dim 2 → Dim 2/10). A first-class field makes the firing condition machine-readable and lets storyboard pre-surface the conditional line. |
 
 ## Migration boundary
 
-`kata-release-merge` records the new metric prospectively from
-implementation onwards; no historical backfill (consistent with
+`kata-release-merge` records the new metric prospectively from the
+implementation run forward; no historical backfill (consistent with
 `historical-phasing`). Existing experiments and obstacles need not file
 retroactive MCDs — the protocol applies to canonical-11 changes
-proposed after `measurement-protocol.md` lands on `main`. Storyboard
-files updated forward; the canonical-11 list moves authoritatively to
-`measurement-protocol.md` on the implementation PR, with one
-storyboard line citing the reference.
+proposed after `measurement-protocol.md` lands on `main`. The
+canonical-11 enumeration stays in `wiki/storyboard-*.md`; the new
+reference is linked from KATA.md § Metrics and from each storyboard
+file's canonical-11 section.
 
 ## Out of scope (re-affirming spec)
 

--- a/specs/860-measurement-system-change-protocol/design-a.md
+++ b/specs/860-measurement-system-change-protocol/design-a.md
@@ -8,7 +8,7 @@ repair-move typology, the Measurement Change Disclosure (MCD) shape and
 one filled-in example, the no-silent-amendment rule, and the
 detection-grep recipe that satisfies Success #6. KATA.md § Metrics
 gains one paragraph linking to it plus one sentence admitting the
-binding-constraint metric (decision #6). The canonical-11 enumeration
+binding-constraint metric (decision #7). The canonical-11 enumeration
 gains an explicit bulleted list in `wiki/storyboard-*.md` (replacing
 the inline "11 canonical metrics" prose), with the new metric included.
 The `kata-release-merge` skill becomes the producer of one new
@@ -26,8 +26,8 @@ rule. No agent-persona files change.
 | Component | Lives in | Responsibility |
 | --- | --- | --- |
 | `measurement-protocol.md` | `.claude/agents/references/` | Names the typology, MCD shape (with one worked example), no-silent-amendment rule, and the detection-grep recipe. Sibling of `coordination-protocol.md` and `memory-protocol.md`. |
-| KATA.md § Metrics extension | `KATA.md` | One paragraph linking to the new reference, plus one sentence admitting the binding-constraint duration metric (decision #6). |
-| `time_to_first_approval_hours` metric | `wiki/metrics/kata-release-merge/{YYYY}.csv` (additional rows; `metric` column distinguishes from `prs_merged`) | New canonical-11 entry. Producer = `kata-release-merge`. One row per run; value defined under "Approval-throughput metric" below. |
+| KATA.md § Metrics extension | `KATA.md` | One paragraph linking to the new reference, plus one sentence admitting the binding-constraint duration metric (decision #7) — this is the constitutional delta, not just a pointer addition. |
+| `time_to_first_approval_hours` metric | `wiki/metrics/kata-release-merge/{YYYY}.csv` (additional rows; `metric` column distinguishes from `prs_merged`; `unit=hours`) | New canonical-11 entry. Producer = `kata-release-merge`. One row per run; value defined under "Approval-throughput metric" below. |
 | Canonical-11 enumeration | `wiki/storyboard-*.md` | New bulleted list under § Metrics, one bullet per metric mapping `{metric → producer skill}`. Replaces the current inline "11 canonical metrics" prose. |
 | `kata-release-merge` `references/metrics.md` extension | `.claude/skills/kata-release-merge/references/metrics.md` | Adds the new metric's row alongside `prs_merged`; documents the cohort predicate. |
 | Storyboard MCD hook | `.claude/skills/kata-session/references/team-storyboard.md` | Two `<do_confirm_checklist>` items: every canonical-11 change item carries an `MCD:` link; cohort read-out items enumerate the day's MCDs. |
@@ -69,11 +69,15 @@ mcd:
 ```
 
 The MCD is an embeddable YAML block (fenced) inside its host body.
-`denominator_effect` is the explicit hook for the no-silent-amendment
-rule: any value other than `none` requires a cohort read-out date and a
-linked storyboard line. One filled-in example illustrating SE Exp 33
-#787 (sidecar pre-flight) lives next to the shape in
-`measurement-protocol.md`, satisfying spec Success #2.
+`verdict_horizon` is the date the falsifier predicates are checked;
+`cohort_readout` is the storyboard meeting at which the cohort
+ratifies. The two may coincide; `verdict_horizon` ≤ `cohort_readout`
+is the only ordering constraint (predicates are checked before
+ratification, not after). `denominator_effect` is the explicit hook for
+the no-silent-amendment rule: any value other than `none` requires a
+cohort read-out date and a linked storyboard line. The reference
+`measurement-protocol.md` carries one filled-in example (illustrating
+the SE Exp 33 #787 sidecar pre-flight pattern), satisfying spec Success #2.
 
 ## Detection (Success #6)
 
@@ -102,29 +106,35 @@ links to it; no other file restates it.
 The metric is a **duration**, not a count — KATA.md § Metrics today
 binds metrics to the count of units of work; admitting a duration
 binding-constraint metric is the smallest extension that satisfies
-spec Success #4 (decision #6).
+spec Success #4 (decision #7).
 
-- **Producer:** `kata-release-merge` — the skill already iterates open
-  phase PRs and reads `<phase>:approved` signals.
-- **Cohort:** all open phase PRs surveyed this run (the same set the
-  skill already visits via `gh pr list`). For each PR, compute hours
-  from PR open to its first `<phase>:approved` signal if approved, or
-  hours from PR open to the run's start time if still open
-  (right-censored). The right-censored carry-forward interpretation
-  matches the rolling-cohort dwell that the skill's existing run notes
-  already report (`Mean dwell=… / median=… / max=…`).
-- **Signal source:** the GitHub label-event timeline plus PR-review
-  events, both of which the skill already reads. The earlier of the
-  first `<phase>:approved` label-add and the first APPROVED review per
-  PR is the first-approval timestamp. `plan:implemented` is excluded —
-  it is a state label, not an approval signal.
-- **Aggregation:** median across the cohort, in hours. Median
-  compresses to one row, retains magnitude, and is XmR-stable for the
-  bursty distribution (mean is volatile under Dependabot waves).
+- **Producer:** `kata-release-merge`. The skill already reads
+  current label/review snapshots via `gh pr view`; the new metric adds
+  the issue/PR timeline API (`gh api repos/.../issues/{n}/timeline`)
+  for first-event timestamps — an additive read-side surface on the
+  existing producer, not a new component.
+- **Cohort:** all open phase PRs surveyed this run (the set the skill
+  already visits via `gh pr list`). For each PR, compute hours from
+  PR open to its first `<phase>:approved` signal if approved, or to
+  the run start time if still open (right-censored). This matches the
+  rolling-cohort dwell already recorded in the existing CSV `note`
+  column (`Mean dwell=… / median=… / max=…` from run-68 onward). An
+  empty cohort (zero open PRs surveyed) skips the row for that run —
+  `event-driven-recast` semantics applied from day 1, avoiding the
+  empty-`value`-parses-as-`0` failure mode decision #5 cites.
+- **Signal source:** GitHub label-event timeline (`<phase>:approved`
+  label-adds) plus first-approval-review events. The earlier of the
+  two per PR is the first-approval timestamp. `plan:implemented` is a
+  state label, not an approval signal — excluded.
+- **Aggregation:** median across the cohort, in hours. Median is
+  XmR-stable for bursty cadence (mean volatile under Dependabot
+  waves). The metric is intentionally **stock-shaped** —
+  carry-forward dwell drift IS the binding-constraint signal #572
+  names; XmR here reads "approval-queue dwell stability," not
+  "per-event throughput rate."
 - **Cadence:** one row per run. `kata-release-merge` runs three times
-  daily; each run's row is distinguished by the `run` column, matching
-  the existing `prs_merged` recording shape (multiple rows per
-  calendar date are normal).
+  daily; each row is distinguished by the `run` column, matching the
+  existing `prs_merged` shape.
 
 ## Data flow
 
@@ -165,9 +175,15 @@ flowchart LR
 implementation run forward; no historical backfill (consistent with
 `historical-phasing`). Existing experiments and obstacles need not
 file retroactive MCDs — the protocol applies to canonical-11 changes
-proposed after `measurement-protocol.md` lands on `main`. Each
-storyboard file's existing inline canonical-11 prose is replaced with
-the bulleted enumeration on the implementation PR.
+proposed after `measurement-protocol.md` lands on `main`. The
+implementation PR for spec 860 is itself grandfathered: it lands the
+rule and its first canonical-set addition together; subsequent
+canonical changes use the MCD form. Each storyboard file's existing
+inline canonical-11 prose is replaced with the bulleted enumeration on
+the implementation PR; the set's cardinality grows from 11 to 12, and
+the storyboard's "≥6 of 11" target-condition denominator is updated to
+"≥6 of 12" in the same diff. The name "canonical-11" is retained
+historically as a corpus identifier even after the cardinality change.
 
 ## Out of scope (re-affirming spec)
 

--- a/specs/860-measurement-system-change-protocol/design-a.md
+++ b/specs/860-measurement-system-change-protocol/design-a.md
@@ -4,31 +4,34 @@
 
 Add one new agent-level reference,
 `.claude/agents/references/measurement-protocol.md`, that names the
-repair-move typology, the Measurement Change Disclosure (MCD) shape, and
-the no-silent-amendment rule. KATA.md § Metrics gains one paragraph
-linking to it and a small extension admitting the binding-constraint
-metric (see decision #6). The canonical-11 enumeration stays where it
-lives today (`wiki/storyboard-*.md`); the reference defines the
-protocol around it, not the list itself. The `kata-release-merge`
-skill becomes the producer of one new canonical metric,
-`time_to_first_approval_hours`, written one row per run to its existing
-`wiki/metrics/kata-release-merge/{YYYY}.csv` (the file is already long-
-format — `date,metric,value,unit,run,note` — so the new metric joins as
-additional rows, distinguished by the `metric` column, alongside the
-existing `prs_merged` rows). The `kata-session` skill's team-storyboard
-overlay gains two checklist items so canonical-11 changes are gated on a
-linked MCD without restating the rule. No agent-persona files change.
+repair-move typology, the Measurement Change Disclosure (MCD) shape and
+one filled-in example, the no-silent-amendment rule, and the
+detection-grep recipe that satisfies Success #6. KATA.md § Metrics
+gains one paragraph linking to it plus one sentence admitting the
+binding-constraint metric (decision #6). The canonical-11 enumeration
+gains an explicit bulleted list in `wiki/storyboard-*.md` (replacing
+the inline "11 canonical metrics" prose), with the new metric included.
+The `kata-release-merge` skill becomes the producer of one new
+canonical metric, `time_to_first_approval_hours`, written one row per
+run to its existing `wiki/metrics/kata-release-merge/{YYYY}.csv` (the
+file is already long-format — `date,metric,value,unit,run,note` — so
+the new metric joins as additional rows tagged by the `metric` column,
+alongside the existing `prs_merged` rows). The `kata-session` skill's
+team-storyboard overlay gains two `<do_confirm_checklist>` items so
+canonical-11 changes are gated on a linked MCD without restating the
+rule. No agent-persona files change.
 
 ## Components
 
 | Component | Lives in | Responsibility |
 | --- | --- | --- |
-| `measurement-protocol.md` | `.claude/agents/references/` | Names repair-move typology, MCD shape, no-silent-amendment rule. Sibling of `coordination-protocol.md` and `memory-protocol.md`. |
-| KATA.md § Metrics extension | `KATA.md` | One paragraph linking to the new reference, plus one sentence admitting the binding-constraint metric (decision #6). |
-| `time_to_first_approval_hours` metric | `wiki/metrics/kata-release-merge/{YYYY}.csv` (additional rows; `metric` column distinguishes from `prs_merged`) | New canonical-11 entry. Producer = `kata-release-merge`. One row per run; value is the median hours-to-first-`<phase>:approved`-signal across qualifying PRs (cohort and empty-day rules below). |
-| `kata-release-merge` `references/metrics.md` extension | `.claude/skills/kata-release-merge/references/metrics.md` | Adds the new metric's row alongside `prs_merged`; documents the cohort predicate and the empty-day rule. |
-| Storyboard MCD hook | `.claude/skills/kata-session/references/team-storyboard.md` | Two checklist additions: every canonical-11 change item carries an `MCD:` link; cohort read-out items enumerate the day's MCDs. |
-| MCD authoring locus | Existing `experiment` and `obstacle` GitHub issue bodies | The MCD is a YAML section template inside the issue body, not a new artifact type. Canonical-11 change diffs cite it by issue link. |
+| `measurement-protocol.md` | `.claude/agents/references/` | Names the typology, MCD shape (with one worked example), no-silent-amendment rule, and the detection-grep recipe. Sibling of `coordination-protocol.md` and `memory-protocol.md`. |
+| KATA.md § Metrics extension | `KATA.md` | One paragraph linking to the new reference, plus one sentence admitting the binding-constraint duration metric (decision #6). |
+| `time_to_first_approval_hours` metric | `wiki/metrics/kata-release-merge/{YYYY}.csv` (additional rows; `metric` column distinguishes from `prs_merged`) | New canonical-11 entry. Producer = `kata-release-merge`. One row per run; value defined under "Approval-throughput metric" below. |
+| Canonical-11 enumeration | `wiki/storyboard-*.md` | New bulleted list under § Metrics, one bullet per metric mapping `{metric → producer skill}`. Replaces the current inline "11 canonical metrics" prose. |
+| `kata-release-merge` `references/metrics.md` extension | `.claude/skills/kata-release-merge/references/metrics.md` | Adds the new metric's row alongside `prs_merged`; documents the cohort predicate. |
+| Storyboard MCD hook | `.claude/skills/kata-session/references/team-storyboard.md` | Two `<do_confirm_checklist>` items: every canonical-11 change item carries an `MCD:` link; cohort read-out items enumerate the day's MCDs. |
+| MCD authoring locus | Existing experiment/obstacle GitHub issue bodies, or a code PR body when the canonical-11 change rides on a PR with no preceding issue (e.g. skill removal in a feature PR). | The MCD is a YAML section template inside the host body, not a new artifact type. The change diff cites it by issue or PR link. |
 
 ## Repair-move typology (eight named moves)
 
@@ -65,14 +68,22 @@ mcd:
     pr: <#NNN>?
 ```
 
-The MCD is an embeddable YAML block (fenced) inside an experiment or
-obstacle issue body. `denominator_effect` is the explicit hook for the
-no-silent-amendment rule: any value other than `none` requires a cohort
-read-out date and a linked storyboard line. Spec Success #6 is satisfied
-because every canonical-11 change diff carries an `MCD: #NNN` link
-inline (in the producer skill's `references/metrics.md`, in the
-`measurement-protocol.md` reference's change log, or in the storyboard
-file): the link sits in `git diff`; the body lives in the issue.
+The MCD is an embeddable YAML block (fenced) inside its host body.
+`denominator_effect` is the explicit hook for the no-silent-amendment
+rule: any value other than `none` requires a cohort read-out date and a
+linked storyboard line. One filled-in example illustrating SE Exp 33
+#787 (sidecar pre-flight) lives next to the shape in
+`measurement-protocol.md`, satisfying spec Success #2.
+
+## Detection (Success #6)
+
+Spec Success #6 requires a `git diff` recipe that pairs canonical-11
+metric edits with their MCD link. The recipe lives in
+`measurement-protocol.md`: any line in `measurement-protocol.md`,
+`wiki/storyboard-*.md`, or `.claude/skills/*/references/metrics.md`
+that names a canonical-11 metric must, in the same diff hunk, carry an
+`MCD: #NNN` link to the host issue or PR. The reference states the
+ripgrep invocation as the canonical detection.
 
 ## No-silent-amendment rule
 
@@ -89,35 +100,37 @@ links to it; no other file restates it.
 
 `time_to_first_approval_hours` reads the binding constraint #572 names.
 The metric is a **duration**, not a count — KATA.md § Metrics today
-binds metrics to the count of units of work; admitting a duration metric
-for the binding constraint is the smallest extension that satisfies the
-spec's Success #4 (decision #6).
+binds metrics to the count of units of work; admitting a duration
+binding-constraint metric is the smallest extension that satisfies
+spec Success #4 (decision #6).
 
-- **Producer:** `kata-release-merge` — the skill already iterates phase
-  PRs and reads `<phase>:approved` signals.
-- **Cohort:** PRs whose **first** `<phase>:approved` signal was observed
-  for the first time during this run (the "fresh-approval" cohort). A
-  PR contributes its time-to-first-approval value once, not on every
-  subsequent run that touches it.
-- **Empty cohort:** a run with zero qualifying PRs appends a row with
-  empty `value` (preserving one-row-per-run discipline). `fit-xmr`
-  treats an empty value as a missing observation, not as zero — distinct
-  from the structural-zero failure mode #788 surfaced.
-- **Signal predicate:** label-add events for `spec:approved`,
-  `design:approved`, `plan:approved`, and `plan:implemented` (read via
-  `gh api repos/.../issues/{n}/timeline`), plus PR-review APPROVED
-  events (read via `gh pr view --json reviews`). The earlier of the two
-  per PR is the first-approval timestamp.
-- **Aggregation:** median hours from PR open to first-approval timestamp
-  across the cohort. Median compresses to one row, retains magnitude,
-  and is XmR-stable for the bursty distribution (mean is volatile under
-  Dependabot waves).
+- **Producer:** `kata-release-merge` — the skill already iterates open
+  phase PRs and reads `<phase>:approved` signals.
+- **Cohort:** all open phase PRs surveyed this run (the same set the
+  skill already visits via `gh pr list`). For each PR, compute hours
+  from PR open to its first `<phase>:approved` signal if approved, or
+  hours from PR open to the run's start time if still open
+  (right-censored). The right-censored carry-forward interpretation
+  matches the rolling-cohort dwell that the skill's existing run notes
+  already report (`Mean dwell=… / median=… / max=…`).
+- **Signal source:** the GitHub label-event timeline plus PR-review
+  events, both of which the skill already reads. The earlier of the
+  first `<phase>:approved` label-add and the first APPROVED review per
+  PR is the first-approval timestamp. `plan:implemented` is excluded —
+  it is a state label, not an approval signal.
+- **Aggregation:** median across the cohort, in hours. Median
+  compresses to one row, retains magnitude, and is XmR-stable for the
+  bursty distribution (mean is volatile under Dependabot waves).
+- **Cadence:** one row per run. `kata-release-merge` runs three times
+  daily; each run's row is distinguished by the `run` column, matching
+  the existing `prs_merged` recording shape (multiple rows per
+  calendar date are normal).
 
 ## Data flow
 
 ```mermaid
 flowchart LR
-  CHG[Canonical-11 change<br/>proposed in issue] --> MCD[MCD YAML block in issue body]
+  CHG[Canonical-11 change<br/>proposed in issue/PR] --> MCD[MCD YAML block in host body]
   MCD --> SB{Storyboard MCD hook}
   SB --> READ[Cohort read-out at horizon date]
   READ --> RAT{Ratify?}
@@ -136,25 +149,25 @@ flowchart LR
 
 | # | Decision | Rejected alternative | Why |
 | --- | --- | --- | --- |
-| 1 | Locate the typology, MCD, and rule in one new agent-level reference (`measurement-protocol.md`). | Inline the typology and rule in KATA.md § Metrics. | KATA.md is identity-and-orientation per CLAUDE.md § Documentation Map. Protocol detail belongs with siblings `coordination-protocol.md` and `memory-protocol.md`. |
-| 2 | MCD is a YAML block embedded in existing experiment/obstacle issues. | New issue type or new file type per change. | Repair moves already coincide with existing issues. The YAML block makes the MCD greppable inside its issue body; the change-diff carries the issue link. |
+| 1 | Locate the typology, MCD shape, rule, and grep recipe in one new agent-level reference (`measurement-protocol.md`). | Inline in KATA.md § Metrics. | KATA.md is identity-and-orientation per CLAUDE.md § Documentation Map. Protocol detail belongs with siblings `coordination-protocol.md` and `memory-protocol.md`. |
+| 2 | MCD is a YAML block embedded in the host issue/PR body. | New issue type or new file type per change. | Repair moves already coincide with existing issues/PRs. The YAML block is greppable inside its host; the change diff carries the host link. |
 | 3 | Repair-move list is closed at design time; extensions land via spec/design/plan/implement. | Open list with a `move: new-move` enum value usable at MCD time. | A closed list is the legible part of the protocol; an open list reverts to the current ad-hoc state. Forcing extensions through the spec chain preserves growth without diluting closure. |
-| 4 | Producer for `time_to_first_approval_hours` is `kata-release-merge`. | New `kata-approval-meter` skill; or producer = `kata-session`. | `kata-release-merge` already iterates phase PRs and reads `<phase>:approved` signals. A new skill adds an agent-team matrix entry for one metric. `kata-session` is a once-daily facilitator and would miss between-meeting churn. |
-| 5 | Metric value = median across the fresh-approval cohort, with empty `value` on zero-cohort runs. | Mean; per-PR rows; rolling-cohort with all carry-forward PRs; row omission on zero-cohort runs. | Mean is volatile under bursty cadence. Per-PR rows violate one-row-per-run. Rolling cohort double-counts a PR's dwell across runs. Row omission breaks `fit-xmr`'s expectation of one row per run; an empty value preserves the discipline and is treated as a missing observation, not a structural zero. |
-| 6 | New metric joins the existing `kata-release-merge/{YYYY}.csv` as additional rows (long-format CSV; `metric` column distinguishes). KATA.md § Metrics extends to admit one binding-constraint duration metric per producer skill alongside its count metric. | Sibling CSV (`{YYYY}-approval.csv`); new directory. | The CSV is already long-format with a `metric` column; adding rows is the lightest possible extension. The KATA.md edit is the minimum a duration binding-constraint metric requires (count rule preserved as the default; binding-constraint metric admitted as the named exception). |
-| 7 | Storyboard hook is two checklist items in `kata-session/references/team-storyboard.md`. | Bake the MCD link requirement into prose; add to `kata-session/SKILL.md`; add to `wiki/storyboard-*.md` template. | Checklists are greppable and machine-checkable (Success #6). The team-storyboard overlay is the canonical home for storyboard-meeting checks; SKILL.md is the umbrella, prose drifts. |
-| 8 | `denominator_effect: conditional-amend` admitted as a first-class value, with a cohort read-out date as the firing condition. | Conditional amendments expressed in free prose per RFC. | The team has already used conditional amendments (#804, Dim 2 → Dim 2/10). A first-class field makes the firing condition machine-readable and lets storyboard pre-surface the conditional line. |
+| 4 | Producer for `time_to_first_approval_hours` is `kata-release-merge`. | New `kata-approval-meter` skill; or producer = `kata-session`. | `kata-release-merge` already iterates phase PRs and reads `<phase>:approved` signals. A new skill adds an agent-team matrix entry for one metric; `kata-session` is once-daily and would miss between-meeting churn. |
+| 5 | Cohort = all surveyed open phase PRs (right-censored on carry-forwards); aggregation = median in hours. | Fresh-approval-only cohort (drops carry-forwards); mean; per-PR rows; count of `<2h` PRs. | Fresh-approval-only requires cross-run state and creates empty cohorts that `libxmr/csv.js` cannot represent (empty `value` parses as `0`, recreating the #788 structural-zero failure). Mean is volatile under bursty cadence; per-PR rows violate one-row-per-run; count loses magnitude. The right-censored rolling cohort matches the skill's existing run-note practice. |
+| 6 | New metric joins the existing `kata-release-merge/{YYYY}.csv` as additional rows (long-format CSV; `metric` column distinguishes). | Sibling CSV (`{YYYY}-approval.csv`); new metric directory. | The CSV is already long-format with a `metric` column; adding rows is the lightest possible extension and matches the spec's literal `{YYYY}.csv` path. |
+| 7 | KATA.md § Metrics extends to admit one binding-constraint **duration** metric per producer skill alongside its count metric. | A count proxy such as `approvals_signaled_per_run`; a separate "binding-constraint" recording surface outside KATA.md. | A count proxy loses dwell magnitude (the binding constraint #572 is fundamentally a dwell, not a rate). A separate surface fragments KATA.md § Metrics' "one home per policy" stance. The named extension is the smallest delta that admits the binding-constraint metric. |
+| 8 | Storyboard hook is two `<do_confirm_checklist>` items in `kata-session/references/team-storyboard.md`. | Bake into prose; add to `kata-session/SKILL.md`; add to `wiki/storyboard-*.md` template. | `<do_confirm_checklist>` items are greppable and machine-checkable (Success #6). The team-storyboard overlay is the canonical home for storyboard-meeting checks; SKILL.md is the umbrella; prose drifts. Exit-gate placement (do-confirm) is correct because the check is "did this meeting surface the day's MCDs?", not a pre-meeting prerequisite. |
+| 9 | `denominator_effect: conditional-amend` admitted as a first-class value, with a cohort read-out date as the firing condition. | Conditional amendments expressed in free prose per RFC. | The team has already used conditional amendments (#804, Dim 2 → Dim 2/10). A first-class field makes the firing condition machine-readable and lets storyboard pre-surface the conditional line. |
 
 ## Migration boundary
 
 `kata-release-merge` records the new metric prospectively from the
 implementation run forward; no historical backfill (consistent with
-`historical-phasing`). Existing experiments and obstacles need not file
-retroactive MCDs — the protocol applies to canonical-11 changes
-proposed after `measurement-protocol.md` lands on `main`. The
-canonical-11 enumeration stays in `wiki/storyboard-*.md`; the new
-reference is linked from KATA.md § Metrics and from each storyboard
-file's canonical-11 section.
+`historical-phasing`). Existing experiments and obstacles need not
+file retroactive MCDs — the protocol applies to canonical-11 changes
+proposed after `measurement-protocol.md` lands on `main`. Each
+storyboard file's existing inline canonical-11 prose is replaced with
+the bulleted enumeration on the implementation PR.
 
 ## Out of scope (re-affirming spec)
 

--- a/specs/860-measurement-system-change-protocol/design-b.md
+++ b/specs/860-measurement-system-change-protocol/design-b.md
@@ -1,0 +1,199 @@
+# Design 860-B — Measurement-system change protocol (alternative)
+
+## How this differs from design-a
+
+Design-a creates a new `measurement-protocol.md` sibling reference, embeds the
+Measurement Change Disclosure (MCD) as a YAML block inside GitHub issue/PR
+bodies, picks `time_to_first_approval_hours` (a duration) as the canonical-11
+addition, and amends KATA.md § Metrics to admit duration metrics.
+
+Design-b makes four different decisions:
+
+1. **Home** — extend the existing `coordination-protocol.md` (which already owns
+   the approval-signal vocabulary) with a § Measurement-system changes section.
+   No new sibling reference.
+2. **MCD = file artifact** — each MCD lives at
+   `wiki/mcd/{YYYY-MM-DD}-{slug}.md`, versioned in the repo. Any canonical-11
+   edit must include the MCD file in the same PR. Detection is filesystem-grep,
+   not GitHub-issue-grep.
+3. **Count metric, not duration** — the new canonical-11 entry is
+   `approvals_recorded_per_run` (count of `<phase>:approved` label-add events
+   observed during this run's PR sweep). KATA.md § Metrics' "count of units of
+   work" rule is preserved; only the link to the protocol is added.
+4. **Storyboard hook is structural** — the MCD requirement is baked into
+   `storyboard-template.md` (the canonical scaffold), not added as a
+   `<do_confirm_checklist>` item in the team-storyboard overlay.
+
+The repair-move typology (eight moves), the MCD shape, and the
+no-silent-amendment rule itself carry over unchanged in content; their **home,
+artifact form, and enforcement surface** change.
+
+## Architecture summary
+
+`coordination-protocol.md` gains a § Measurement-system changes section that
+names the eight repair moves, the MCD shape, the no-silent-amendment rule, and
+the detection recipe. Each canonical-11 change lands a `wiki/mcd/{YYYY-MM-DD}-
+{slug}.md` file in the same PR — the file IS the MCD. KATA.md § Metrics gains
+one linking paragraph. `kata-release-merge` records `approvals_recorded_per_run`
+as new rows in its existing `wiki/metrics/kata-release-merge/{YYYY}.csv`. The
+canonical-11 enumeration in `wiki/storyboard-*.md` becomes a bulleted list
+including the new metric. `storyboard-template.md` requires canonical-11 change
+items to link an MCD path.
+
+## Components
+
+| Component | Lives in | Responsibility |
+| --- | --- | --- |
+| § Measurement-system changes | `.claude/agents/references/coordination-protocol.md` | Names the eight moves, MCD shape, no-silent-amendment rule, MCD-file detection-grep recipe. Sibling section to § Approval signal. |
+| KATA.md § Metrics extension | `KATA.md` | One paragraph linking to the new section. No constitutional change to "count of units of work." |
+| `wiki/mcd/` directory | `wiki/mcd/{YYYY-MM-DD}-{slug}.md` | One file per MCD. The file IS the disclosure; PRs that touch canonical-11 edges include their MCD file in the same diff. |
+| `approvals_recorded_per_run` metric | `wiki/metrics/kata-release-merge/{YYYY}.csv` (additional rows; `metric` column; `unit=count`) | New canonical-11 entry. Producer = `kata-release-merge`. One row per run. |
+| Canonical-11 enumeration | `wiki/storyboard-*.md` | New bulleted list under § Metrics; one bullet per metric mapping `{metric → producer skill}`. Replaces inline "11 canonical metrics" prose. |
+| `kata-release-merge` `references/metrics.md` extension | `.claude/skills/kata-release-merge/references/metrics.md` | New row alongside `prs_merged`. |
+| Storyboard MCD hook | `.claude/skills/kata-session/references/storyboard-template.md` | Template requires every canonical-11 change line carries an `MCD: wiki/mcd/...md` link; cohort read-out items enumerate that day's MCD files. |
+
+## Repair-move typology
+
+Eight named moves, identical content to design-a (closure of the list is the
+same architectural choice), located in `coordination-protocol.md` § Measurement-
+system changes: `producer-rehoming`, `mode-restriction`, `historical-phasing`,
+`sidecar-pre-flight`, `stock-vs-flow-recast`, `event-driven-recast`,
+`rule-semantics-rfc`, `habit-to-policy`. Each binds a one-sentence definition
+and a falsifier-set kind. The list is **closed** at design time; extensions
+land via the spec/design/plan/implement chain (matches design-a #3). Adding a
+ninth move (e.g., `canonical-set-addition` for net-new metrics) is the
+natural next-spec follow-on — see Migration boundary.
+
+## MCD shape (file artifact)
+
+```yaml
+---
+move: producer-rehoming | mode-restriction | historical-phasing |
+      sidecar-pre-flight | stock-vs-flow-recast | event-driven-recast |
+      rule-semantics-rfc | habit-to-policy
+affected_metrics:
+  - {skill: <skill>, metric: <metric>}
+falsifier_set:
+  - <predicate>
+verdict_horizon: <YYYY-MM-DD>
+cohort_readout: <YYYY-MM-DD>      # >= verdict_horizon
+denominator_effect: none | sidecar | conditional-amend | amend
+links:
+  obstacle_issue: <#NNN>?
+  experiment_issue: <#NNN>?
+  pr: <#NNN>?
+---
+
+# MCD — <human-readable title>
+
+<one-paragraph context: what changed, why this move, what the cohort ratifies>
+```
+
+The file is YAML front-matter plus a brief prose body. `denominator_effect`
+non-`none` requires a linked storyboard headline and a cohort read-out date.
+`verdict_horizon ≤ cohort_readout` is the only ordering constraint.
+
+## Detection (Success #6)
+
+The rule is `git diff`-native, stated in `coordination-protocol.md`: **any
+commit touching a canonical-11 metric edge must, in the same commit, add or
+modify a `wiki/mcd/*.md` file.** Edges are edits to lines naming a canonical-11
+metric in `wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, or
+`coordination-protocol.md` § Measurement-system changes (which mirrors the
+canonical-11 enumeration for git-grep symmetry). Recipe:
+
+```sh
+# Commits that edit canonical-11 edges but do NOT touch wiki/mcd/.
+for c in $(git log --format=%H --since="<date>" -- \
+    'wiki/storyboard-*.md' \
+    '.claude/skills/*/references/metrics.md' \
+    '.claude/agents/references/coordination-protocol.md'); do
+  git diff-tree --no-commit-id --name-only -r "$c" \
+    | grep -q '^wiki/mcd/' || echo "$c missing MCD"
+done
+```
+
+CI mechanisation on `HEAD...main` is the natural follow-on (out of scope).
+
+## No-silent-amendment rule
+
+> No change to the canonical-11 denominator (additions, removals, conditional
+> or unconditional amendments) lands without an MCD file at
+> `wiki/mcd/{YYYY-MM-DD}-{slug}.md` whose `denominator_effect` is non-`none`,
+> a cohort read-out date on or before the storyboard meeting at which the
+> change takes effect, and a linked storyboard headline.
+
+This single statement lives in `coordination-protocol.md` § Measurement-system
+changes. KATA.md § Metrics links to it; no other file restates it.
+
+## Approval-throughput metric
+
+`approvals_recorded_per_run` reads the binding constraint #572 names without
+amending KATA.md.
+
+- **Producer:** `kata-release-merge`. Already iterates phase PRs and reads
+  label state; the new metric counts label-add events from the current run's
+  sweep. No new GitHub-API surface beyond the existing
+  `gh pr view --json labels,timelineItems`.
+- **Definition:** count of `<phase>:approved` label-add events with timestamp
+  in `[previous_run_start, current_run_start)` for any open phase PR observed
+  this run. `APPROVED` review events count as one each. `plan:implemented` is
+  a state label, excluded.
+- **Cadence:** one row per run (three times daily).
+- **Stock-vs-flow note:** count is flow-shaped (matches every other canonical
+  metric). Approval-queue dwell — the stock signal design-a records — is
+  recoverable from the same timeline data and is the natural future sidecar
+  (would file its own MCD with `move: sidecar-pre-flight`).
+- **Empty-run row:** zero is recorded as `0` (matches every count metric;
+  structural-zero risk applies only when the producer is missing).
+
+## Data flow
+
+```mermaid
+flowchart LR
+  CHG[Canonical-11 change in PR] --> MCD[wiki/mcd/...md<br/>same PR]
+  MCD --> READ[Cohort read-out at horizon]
+  READ --> RAT{Ratify?}
+  RAT -- yes --> AMEND[Storyboard line updates]
+  RAT -- no --> ROLL[Change rolled back]
+  KATA[KATA.md § Metrics] -.-> REF[coordination-protocol.md<br/>§ Measurement-system changes]
+  STORY[wiki/storyboard-*.md] -.-> REF
+  RM[kata-release-merge] --> CSV[metrics CSV] --> XMR[fit-xmr analyze]
+  REF -. owns .-> MOVES[Eight moves + MCD shape + rule]
+  CI[git-diff grep] -. pairs .-> MCD
+```
+
+## Key decisions
+
+| # | Decision | Rejected alternative | Why |
+| --- | --- | --- | --- |
+| 1 | Locate the typology, MCD shape, rule, and grep recipe inside `coordination-protocol.md` as a new § section. | New sibling `measurement-protocol.md` (design-a #1). | The MCD-and-approval-signal vocabularies are tightly coupled (approvals are how cohort ratification happens; `<phase>:approved` is the binding constraint metric). Co-locating keeps one home for one coherent topic; a new file fragments protocol space and adds a navigation hop. **Size impact:** `coordination-protocol.md` is 165 lines today; the new section adds ~70 lines (typology table + MCD shape + rule + grep), pushing it to ~235 lines. References do not carry the 200-line cap that designs do (no soft cap is documented in CONTRIBUTING.md or CLAUDE.md for this directory); design-a's choice of a separate file was made for topic separation, not size. |
+| 2 | MCD is a file artifact at `wiki/mcd/{YYYY-MM-DD}-{slug}.md`, included in the same PR as the canonical-11 change. | YAML block embedded in GitHub issue/PR body (design-a #2). | Issue/PR bodies are mutable post-merge and live outside `git`. A file artifact is review-gated, history-bearing, and lets detection be `git diff`-native (Success #6) rather than dependent on GitHub-API queries. CI can mechanise the pairing check; embedded YAML cannot. |
+| 3 | Producer for the approval-throughput metric is `kata-release-merge`. | New `kata-approval-meter` skill; or `kata-session`. | Same reasoning as design-a #4 — `kata-release-merge` already iterates phase PRs and reads label state; new skill adds matrix entry for one metric; `kata-session` runs once daily and would miss between-meeting churn. (Design-a and -b agree here.) |
+| 4 | The new metric is `approvals_recorded_per_run` (count of fresh `<phase>:approved` events observed this run), preserving KATA.md "count of units of work." | `time_to_first_approval_hours` (duration; design-a #7) — requires KATA.md § Metrics constitutional extension. | **Acknowledged trade-off:** count reads approval throughput as a *rate* and detects rate drops via `xRule2`; it does NOT directly surface queue-dwell drift the way design-a's duration metric does. Design-a sees dwell-stock-shape as the binding-constraint signal #572 names; design-b takes the position that dwell is a derivable signal a future sidecar can read (move: `sidecar-pre-flight`, filed as its own MCD) once the count metric establishes the producer cadence. The win is that no KATA.md amendment is required to admit either count or any subsequent sidecar. The cost is one cycle of latency before dwell becomes a first-class signal. Reviewers should weigh: is preserving "count of units of work" worth deferring the dwell signal? |
+| 5 | Repair-move list is closed at design time (matches design-a #3). | Open list, or a `tbd` provisional. | Spec Scope-in enumerates the eight moves explicitly — the closure is spec-level. A `tbd` provisional reverts to ad-hoc; an open list with `new-move` defeats the typology. New moves land via spec/design/plan/implement, same as design-a. (Both designs agree.) |
+| 6 | New metric joins existing `kata-release-merge/{YYYY}.csv` as additional rows. | Sibling CSV. | (Same as design-a #6 — both designs agree.) |
+| 7 | Storyboard hook lives in `storyboard-template.md` (every storyboard inherits the MCD requirement structurally). | `<do_confirm_checklist>` items in `team-storyboard.md` (design-a #8). | A template inclusion is a structural property of every storyboard file; a checklist item runs once per meeting and is human-checked. Template inclusion makes the MCD link a visible scaffold the meeting fills in, not a check-the-box gate. Detection (Success #6) becomes part of the template-rendered file itself. |
+| 8 | `denominator_effect: conditional-amend` admitted as a first-class enum value. | (Same as design-a #9 — both designs agree.) | Identical reasoning. |
+
+## Migration boundary
+
+The implementation PR for spec 860 is **explicitly grandfathered**: it is the
+founding diff and predates the protocol it lands. It records the denominator
+change (11→12) in the spec and storyboard diffs but does not file an MCD —
+none of the eight named moves cleanly cover "net-new-metric addition to the
+canonical set." Acknowledged gap: the first follow-on spec adds a ninth move
+(`canonical-set-addition`) and its falsifier-set kind. From that spec forward,
+every canonical-11 change uses an MCD file. Existing experiments and obstacles
+do not file retroactive MCDs. Each storyboard's inline "11 canonical metrics"
+prose becomes the bulleted enumeration on the implementation PR; "≥6 of 11"
+becomes "≥6 of 12" in the same diff. "Canonical-11" is retained historically.
+
+## Out of scope (re-affirming spec)
+
+`fit-xmr` semantics; per-skill metric definitions other than the new entry;
+re-running open experiments; CSV backfill; branch-protection installation;
+`agent-react` routing changes; skill-pack publishing; agent-persona changes;
+the choice of any other binding-constraint metric. CI enforcement of the
+MCD-pairing grep is acknowledged as a desirable follow-on, not part of this
+spec.

--- a/specs/860-measurement-system-change-protocol/spec.md
+++ b/specs/860-measurement-system-change-protocol/spec.md
@@ -1,0 +1,171 @@
+# Spec 860 — Measurement-system change protocol for canonical metrics
+
+## Problem
+
+The Kata Agent Team
+([JTBD § Teams Using Agents](../../JTBD.md#teams-using-agents-run-an-autonomous-continuously-improving-development-team))
+runs a daily PDSA loop whose Study phase reads canonical metrics (the
+"canonical-11" set referenced by the May Target Condition in
+`wiki/storyboard-2026-M05.md`) through XmR signals. KATA.md § Metrics
+binds each metric to exactly one producing skill — "each such skill
+records exactly one metric." That coupling is load-bearing, and there is
+no protocol describing what happens when a producing skill changes,
+moves, or is removed. The team has invented and applied a recurring
+typology of safe repair moves to keep the measurement system honest, but
+the typology has no canonical home, the discipline that gates it ("no
+silent amendment of the canonical-11 denominator") has no canonical
+home, and the binding constraint on enacting any of these repairs —
+human approval throughput — is not itself one of the canonical metrics
+the loop reads.
+
+### Skill change destabilises the metric without a repair protocol
+
+Removing the `kata-trace` skill in PR #715 left
+`wiki/metrics/kata-trace/2026.csv` without a producer. The XmR analyzer
+flipped `findings_count` from `predictable` to `signals_present` via
+`xRule3` on five consecutive structural-zero rows tagged `skill-removed`
+(obstacle issue #788). The signal is honest under XmR semantics but its
+cause is the measurement protocol, not the process — yet the canonical-11
+denominator still counts the metric. Five days passed before the team
+proposed a producer rehoming path (RFC #804). The same coupling shows up
+across the open obstacles and experiments:
+
+| Trigger | Metric impact | Repair move applied | Issue |
+| --- | --- | --- | --- |
+| Skill removal (`kata-trace` in PR #715) | `findings_count` lost producer; structural zeros | Producer rehoming via `fit-xmr record` direct invocation | #788, RFC #804 |
+| Mode-mixed activations on `kata-documentation` | `errors_found` bimodal; `xRule2` below-μ run length 13 | Mode-restriction (record only on review-mode activations) | #772, PR #773 |
+| Phase-0 first-pass discovery row anchors `xRule1` | `errors_found` cannot reach `predictable` | Historical phasing (Phase-0 / Phase-1 series boundary) | #809, PR #811 |
+| Bursty Dependabot waves on `prs_actioned` | `xRule1` + `mrRule1` by construction; structurally unreachable | Sidecar pre-flight + stock-vs-flow recast | #787, #770, #768 |
+| Calendar framing on event-driven `issues_created` | `insufficient_data` as steady state | Event-driven recast ("no-row-no-event") | #810 |
+| Single-slot historical-residual `mrRule1` fire on `findings_count` | Permanent signal under sliding URL math | XmR rule-semantics RFC | #814 |
+| Override-shadowed Dependabot bundle ships dirty | Discretionary post-merge re-audit habit catches it | Habit-to-policy promotion (Check 9 in SKILL.md) | #817 |
+
+These repair moves work, but they are reinvented per case. Each issue
+restates what counts as a safe move, what the falsifier set looks like,
+and what discipline applies to the canonical-11 denominator while the
+move is in flight. There is no shared definition for any of: the move
+typology, the disclosure that must accompany a canonical-11 change, or
+the cohort read-out that ratifies one.
+
+### The "no-silent-amendment" rule has no canonical home
+
+RFC #804 invokes a "no-silent-amendment rule" to surface a conditional
+canonical-11 → canonical-10 amendment up-front, and SE Exp 33 (#787)
+keeps a sidecar CSV explicitly to "preserve the May denominator" until
+the 1-on-1 ratifies a redefinition. Both treat the rule as authoritative
+but cite no document. KATA.md § Metrics, the agent references
+(`coordination-protocol.md`, `memory-protocol.md`), and the storyboard
+templates do not state it. New agents and new metrics cannot consult the
+rule before changing it.
+
+### Approval throughput is the binding constraint and is not a canonical metric
+
+Obstacle #572 (umbrella) and instances #565, #567, #571 identify human
+approval throughput as the binding constraint on the loop's ability to
+enact any repair: PRs sit CI-green awaiting `<phase>:approved` while
+their absence prevents the spec/design/plan/implement chain from
+advancing. RE Exp 38 (#813) is structured as a self-test — it routes
+through the same approval gate it tests. None of the canonical-11
+metrics measure this constraint directly. The loop cannot detect
+approval-throughput drift through XmR because there is no producer for
+it.
+
+## Goal
+
+Canonicalise the measurement-system change protocol the team is already
+running implicitly. Name the safe repair moves; require a disclosure
+artifact for any change to a canonical-11 metric; place the no-silent-
+amendment rule in a single shared reference; and add an approval-
+throughput metric to the canonical-11 frame so the binding constraint is
+itself read by the same loop. The loop continues to read XmR signals
+unchanged; what changes is the protocol that surrounds canonical-11
+metric churn and the set of metrics the loop reads.
+
+## Scope (in)
+
+- **Repair-move typology.** Name the moves the team has already used:
+  producer rehoming, mode restriction, historical phasing, sidecar
+  pre-flight, stock-vs-flow recast, event-driven recast, XmR
+  rule-semantics RFC, and habit-to-policy promotion. Each move's name
+  binds to a one-sentence definition and a falsifier-set requirement.
+- **Measurement Change Disclosure (MCD).** A required artifact shape for
+  any change to a canonical-11 metric: skill removal/rename/split,
+  metric definition change, sidecar opening, denominator amendment,
+  rule-semantics challenge. The MCD names the move, the affected
+  metric(s), the falsifier set, the verdict horizon, and the cohort
+  read-out date.
+- **No-silent-amendment rule, canonical home.** A single reference
+  defining it. KATA.md § Metrics links to it.
+- **Canonical-11 entry for approval throughput.** Add one
+  approval-throughput metric to the canonical set, with a named
+  producer skill and the same one-row-per-run discipline the existing
+  metrics carry. The producer skill records the metric per
+  `wiki/metrics/{skill}/{YYYY}.csv`. The metric reads the binding
+  constraint #572 names.
+- **Storyboard hook.** The storyboard meeting template requires that any
+  canonical-11 change reference an MCD, and that any cohort read-out
+  consumes the MCD set for the day.
+- **KATA.md § Metrics extension.** § Metrics extends to point to the
+  repair-move typology, the MCD shape, the no-silent-amendment rule,
+  and the approval-throughput entry.
+
+## Scope (out)
+
+- **The XmR analyzer itself** (`fit-xmr`). Rule semantics, URL math,
+  control-limit computation are unchanged.
+- **Per-skill metric definitions** other than the new approval-
+  throughput entry. Existing `references/metrics.md` files under
+  `.claude/skills/kata-*/references/` stay where they are.
+- **Re-running open experiments** (#674, #767, #768, #769, #770, #772,
+  #787, #809, #810, #813, #814, #817). They keep their pre-registered
+  predictions and verdict horizons; the protocol applies prospectively
+  to changes filed after merge.
+- **Historical CSV backfill or rewrite.** The historical-phasing repair
+  move is annotation-only by design (per #809).
+- **Branch-protection installation** (#564 governance gap). The
+  protocol covers measurement; governance is a separate workstream.
+- **Agent-react / Discussion routing changes** beyond surfacing the MCD
+  link in cohort read-out items.
+- **Skill-pack publishing.** No external skill-pack contract changes;
+  internal references only.
+- **Agent persona / scope-constraint changes.** Agents continue to own
+  the same skills; the protocol describes what an agent must surface,
+  not which agent owns what.
+- **Choosing the producer skill or the exact name of the approval-
+  throughput metric.** Design picks both, constrained by Success #4.
+- **Choosing where the typology and rule live** (KATA.md inline vs. a
+  new `references/measurement-protocol.md` vs. extending an existing
+  reference). Design picks the location, constrained by Success #1–#3.
+
+## Success criteria
+
+| # | Claim | Verification |
+| --- | --- | --- |
+| 1 | The repair-move typology is enumerated in one place; each named move has a one-sentence definition and a falsifier-set requirement. | Grep for the named moves (`producer-rehoming`, `mode-restriction`, `historical-phasing`, `sidecar-pre-flight`, `stock-vs-flow-recast`, `event-driven-recast`, `rule-semantics-rfc`, `habit-to-policy`) returns one canonical definition each from a single reference file. |
+| 2 | The Measurement Change Disclosure has a named shape with required fields: move name, affected metric(s), falsifier set, verdict horizon, cohort read-out date. | Static inspection of the reference: an MCD section enumerates required fields and provides one filled-in example drawn from an existing experiment (e.g. SE Exp 33 #787 sidecar pre-flight). |
+| 3 | The no-silent-amendment rule has a canonical home and is reachable from KATA.md § Metrics. | KATA.md § Metrics contains a link to a single reference section that states the rule; no other file restates it. |
+| 4 | An approval-throughput metric is added to the canonical-11 set with a named producer skill, a one-row-per-run discipline, and a CSV path under `wiki/metrics/{skill}/{YYYY}.csv`. | The metric appears in (a) the producer skill's `references/metrics.md`, (b) the canonical-11 enumeration in `wiki/storyboard-*.md`, and (c) one example row written under the producer skill's CSV path during the implementation run. |
+| 5 | The storyboard meeting template requires canonical-11 changes to reference an MCD. | The template (in the `kata-storyboard` skill or the agent persona) names the MCD as a required link for any canonical-11 change item; a worked example references an MCD by its issue or section anchor. |
+| 6 | A change to a canonical-11 metric without an MCD is detectable from `git diff` alone. | A grep for canonical-11 metric edits in the protocol's reference, in `wiki/storyboard-*.md`, or in a producer skill's `references/metrics.md` returns each change paired with a link to its MCD. The protocol's reference states the grep recipe. |
+
+## Notes — evidence pointers (for design)
+
+- Repair-move corpus: #788 (orphaned producer); #804 (RFC fallback,
+  three-path decision, falsifier set F1–F4, conditional Dim 2
+  amendment); #772 + PR #773 (mode restriction); #809 + PR #811
+  (historical phasing); #787 (sidecar pre-flight, "no silent
+  denominator change" citation); #768, #770 (stock-vs-flow dual-record
+  cohort); #810 (event-driven recast); #814 (XmR rule-semantics RFC);
+  #817 + #655 (habit-to-policy promotion).
+- Approval-throughput evidence: #572 (umbrella), #565, #567, #571, #813
+  (self-reflexive design).
+- Existing metrics surface: KATA.md § Metrics (lines 256–273); per-skill
+  `references/metrics.md` files under
+  `.claude/skills/kata-*/references/`.
+- Existing protocol references:
+  `.claude/agents/references/coordination-protocol.md`,
+  `memory-protocol.md`, `self-improvement.md`.
+- Storyboard surface: `wiki/storyboard-*.md` (canonical-11 enumeration,
+  Dim 2 line, conditional-amendment lines).
+- Cohort read-out precedent: 5/12 cluster across SE Exp 33, RE Exp 34,
+  TW Exp 34, PM Exp 32, plus 5/13 conditional Dim 2 amendment.


### PR DESCRIPTION
Codify the safe-repair-move typology, Operational Redefinition shape, no-silent-redefinition rule, and an approval-throughput canonical metric so canonical-11 metric churn from skill changes (e.g. the producer orphaning in #788/#804) follows a stated protocol instead of ad-hoc reinvention. Spec captures WHAT/WHY; design picks `measurement-protocol.md` as the home, `kata-release-merge` as the producer for `time_to_first_approval_hours`, and embeds the redefinition as a YAML block inside existing experiment/obstacle issues.

## Addresses

### Directly addressed (the meta-trigger)

- #788 — orphaned producer for trace `findings_count`. Codifies `producer-rehoming` as a named move; the no-silent-redefinition rule would have required PR #715 to file an Operational Redefinition.
- #804 — RFC: post-PR-#715 producer choice. The spec absorbs this RFC&#39;s mechanics (three-path decision, falsifier set, conditional Dim 2 amendment) into a reusable redefinition shape with a first-class `denominator_effect: conditional-amend` field.

### Binding-constraint instrumented (`time_to_first_approval_hours`)

- #572 — umbrella obstacle (multiple human gates in series).
- #565, #567, #571 — approval-blocked instances.
- #813 — RE Exp 38 self-reflexive design; the new metric supplies the standing meter the experiment was synthesising by hand.

### Repair-move codified (named in the typology; precedent cited)

| Move | Issue precedent |
| --- | --- |
| `sidecar-pre-flight` | #787 |
| `stock-vs-flow-recast` | #768, #770 |
| `mode-restriction` | #772 |
| `historical-phasing` | #809 |
| `event-driven-recast` | #810 |
| `rule-semantics-rfc` | #814 |
| `habit-to-policy` | #817 |
| (axis classifier upstream of `mode-restriction` / `stock-vs-flow-recast`) | #767 |

These experiments keep their pre-registered verdicts; the spec gives the next instance a named move and a redefinition form to use instead of restating the cohort context.

## Test plan

- [x] Spec problem section grounded in obstacle/experiment evidence (table at lines 17–25 of `spec.md`).
- [x] Six verifiable success criteria; criterion #6 names a `git diff` recipe.
- [x] Design under 200 lines; eight key decisions, each with a rejected alternative.
- [ ] Sub-agent review panels (`kata-review`) for `spec.md` and `design-a.md` per the kata-spec / kata-design DO-CONFIRM checklists.
- [ ] APPROVED review or `spec:approved` label per `kata-release-merge` gate.

https://claude.ai/code/session_017fXRXK9yKzuwu69ca7YWUp