### PR TITLE
feat(kata-pattern-synthesis): coach-owned grounded-synthesis skill

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -40,23 +40,15 @@ Survey domain state, then choose the highest-priority action:
    `gh workflow run kata-coaching.yml -f agent=<name>` for the agent with the
    oldest or no recent 1-on-1 session. Verify no coaching session is currently
    in progress before dispatching.
-2. **Backlog synthesis eligible?** — When the corpus of open obstacle and
-   experiment issues plus their PRs is large enough to be reinventing the same
-   repair moves, run `kata-pattern-synthesis` (see that skill's "Triggers" for
-   the queryable thresholds). Eligibility:
-   `gh issue list --label obstacle,experiment --state open --json number | jq 'length' >= 10`
-   AND ≥3 distinct repair-adjacent moves visible in recent obstacles, OR a
-   producer-orphaning event landed on `main` since the last synthesis. At most
-   one synthesis run per ISO week unless a producer-orphaning event forces it.
+2. **Backlog synthesis eligible?** — Run `kata-pattern-synthesis` when its
+   `## Triggers` thresholds hold; at most one run per ISO week.
 3. **Fallback** — MEMORY.md items listing you under Agents, then report clean.
 
 ## Constraints
 
 - Facilitation only — you ask questions, agents do domain work. No merging PRs,
-  no application logic changes, no writing specs or fix PRs. **Exception:**
-  `kata-pattern-synthesis` is the one path that authorizes you to write a spec
-  + design pair. The exception is scoped to that skill only — every other
-  context still falls under facilitation.
+  no application logic changes, no writing specs or fix PRs (exception:
+  `kata-pattern-synthesis`).
 - Ground findings in trace evidence — quote tool calls, errors, token counts
 - Wiki files are committed and pushed by the session hooks — do not run git
   commands in `wiki/`. Write files and move on.

--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -7,6 +7,7 @@ description: >
 skills:
   - kata-session
   - kata-review
+  - kata-pattern-synthesis
 ---
 
 You are the improvement coach — a devoted student of Deming who dispatches and
@@ -39,12 +40,23 @@ Survey domain state, then choose the highest-priority action:
    `gh workflow run kata-coaching.yml -f agent=<name>` for the agent with the
    oldest or no recent 1-on-1 session. Verify no coaching session is currently
    in progress before dispatching.
-2. **Fallback** — MEMORY.md items listing you under Agents, then report clean.
+2. **Backlog synthesis eligible?** — When the corpus of open obstacle and
+   experiment issues plus their PRs is large enough to be reinventing the same
+   repair moves, run `kata-pattern-synthesis` (see that skill's "Triggers" for
+   the queryable thresholds). Eligibility:
+   `gh issue list --label obstacle,experiment --state open --json number | jq 'length' >= 10`
+   AND ≥3 distinct repair-adjacent moves visible in recent obstacles, OR a
+   producer-orphaning event landed on `main` since the last synthesis. At most
+   one synthesis run per ISO week unless a producer-orphaning event forces it.
+3. **Fallback** — MEMORY.md items listing you under Agents, then report clean.
 
 ## Constraints
 
 - Facilitation only — you ask questions, agents do domain work. No merging PRs,
-  no application logic changes, no writing specs or fix PRs.
+  no application logic changes, no writing specs or fix PRs. **Exception:**
+  `kata-pattern-synthesis` is the one path that authorizes you to write a spec
+  + design pair. The exception is scoped to that skill only — every other
+  context still falls under facilitation.
 - Ground findings in trace evidence — quote tool calls, errors, token counts
 - Wiki files are committed and pushed by the session hooks — do not run git
   commands in `wiki/`. Write files and move on.

--- a/.claude/skills/kata-pattern-synthesis/SKILL.md
+++ b/.claude/skills/kata-pattern-synthesis/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: kata-pattern-synthesis
+description: >
+  Synthesize a system-level pattern from a corpus of open obstacle, experiment,
+  and PR items via grounded coding (open → axial → selective). Produces a
+  proposition, a kata-spec, a kata-design, and a corpus map that closes the loop
+  on the items that fed it. Run when the corpus is large enough that ad-hoc
+  per-item handling is reinventing the same repair moves. Improvement coach
+  scope extension — owned by the coach, with explicit authorization to write
+  spec and design via `kata-spec` and `kata-design` for this skill only.
+---
+
+# Pattern Synthesis from Backlog
+
+A facilitation skill for the improvement coach. The coach reads the open corpus
+of obstacle and experiment issues and the PRs that touch them, codes the corpus
+to surface the system-level pattern those items collectively name, and turns
+that pattern into a single spec + design that addresses the meta-trigger,
+instruments the binding constraint, and codifies the repair moves the team has
+already invented case by case. The coach then closes the loop on every corpus
+item that fed the synthesis.
+
+This skill is the only path through which the coach writes specs or designs.
+The general "facilitation only" constraint in
+[`improvement-coach.md`](../../agents/improvement-coach.md) still applies to
+every other context.
+
+## When to Use
+
+- A storyboard meeting Q3 surfaces ≥3 obstacles whose repair moves visibly
+  rhyme (e.g., multiple "redefine the metric without tampering" patterns).
+- A producer-orphaning event lands on `main` (skill removed, renamed, or split)
+  and a metric loses its producer — immediate trigger.
+- An RFC issue routes through `obstacle` because a richer channel was
+  unavailable (e.g., `gh discussion create` failed) and the same RFC shape has
+  appeared more than once.
+- A user explicitly requests a backlog synthesis run.
+
+Do **not** run when the corpus is small (under ~10 open obstacle+experiment
+items) or when fewer than 3 distinct repair-adjacent moves appear. Premature
+synthesis manufactures patterns where there is only noise.
+
+## Triggers (queryable thresholds)
+
+```sh
+# Corpus size (open obstacles + experiments)
+gh issue list --label obstacle,experiment --state open --limit 100 \
+  --json number | jq 'length'   # ≥10 → eligible
+```
+
+```sh
+# Producer-orphaning events on main since last synthesis
+gh search commits 'PR #715' --repo "$REPO" --json sha,commit \
+  --jq '.[] | select(.commit.message | test("remove|delete")) | .sha'
+```
+
+```sh
+# Distinct repair-adjacent moves in recent obstacles (open + last 30 days)
+gh issue list --label obstacle --state all --search "updated:>$(date -d '30 days ago' +%F)" \
+  --json title,body --jq '[.[] | .body | scan("sidecar|dual-record|stock|recast|phase|rehom|habit|RFC")] | unique | length'
+# ≥3 → eligible
+```
+
+The synthesis runs at most once per ISO week unless a producer-orphaning event
+forces it.
+
+## Checklists
+
+<read_do_checklist goal="Hold the synthesis boundary before coding the corpus">
+
+- [ ] Confirm at least one trigger threshold is met. Record which.
+- [ ] Close the corpus before coding begins; later items do not bias the codes.
+- [ ] Memos and codes are written to a scratch location, not to the wiki, until
+      the proposition is selected.
+- [ ] No claim enters the spec or design without an issue/PR number anchor.
+- [ ] The synthesis stops at one core category. If two compete, stop and route
+      to a coaching session — the corpus is two patterns, not one.
+
+</read_do_checklist>
+
+<do_confirm_checklist goal="Verify synthesis quality before opening artifacts">
+
+- [ ] Every corpus item has a memo (3–5 sentences max).
+- [ ] Every memo has at least one in-vivo or descriptive code.
+- [ ] Codes group into 3–7 axial categories with stated relations.
+- [ ] One core category is named; storyline paragraph reads end-to-end without
+      referencing the codes table.
+- [ ] One-sentence theoretical proposition is recorded.
+- [ ] Spec drafted via `kata-spec` with verifiable success criteria (no HOW).
+- [ ] Design drafted via `kata-design` (≤200 lines, each decision rejects an
+      alternative).
+- [ ] Corpus map records, for every original item, one of: directly addressed,
+      binding-constraint instrumented, repair-move codified, or out of scope.
+- [ ] Closure broadcast posted on every addressed item; **out-of-scope items
+      not tagged**.
+
+</do_confirm_checklist>
+
+## The Eight Phases
+
+The synthesis runs as a sequence. Output of each phase is the input to the
+next; nothing is invented without an anchor in the prior phase.
+
+### 1 — Corpus gather
+
+Define topic keywords (default: `obstacle`, `experiment`, plus PRs that
+reference any of those issues). Search by label, then by keyword, then dedupe.
+Persist issue/PR bodies to a scratch file under `/tmp/`. The corpus is closed
+before phase 2.
+
+### 2 — Field memos (one per item)
+
+3–5 sentences each: the central incident, the in-vivo language the author
+used, what the case adds. One file collecting all memos. Brevity is a
+discipline — long memos overweight verbose authors.
+
+### 3 — Open coding
+
+Tag each incident with one or more codes. Prefer in-vivo (`HABIT_TO_POLICY`,
+`MERGE_AS_APPROVAL_SIGNAL`) over descriptive. Build an `incident → code` table.
+
+### 4 — Axial coding
+
+Group codes into 3–7 categories. For each: sub-codes, relations, causal
+condition, consequence. Stop when a new code lands cleanly in an existing
+category.
+
+### 5 — Selective coding
+
+Identify the core category that integrates the others. Write a one-paragraph
+storyline and a one-sentence theoretical proposition. The proposition is the
+architectural target.
+
+### 6 — Spec via `kata-spec`
+
+WHAT/WHY only. Problem section grounds every claim in a `#NNN` anchor. Scope
+(in) names specific files; Scope (out) names what is deferred. Success
+criteria are verifiable. Stop after `spec.md`.
+
+### 7 — Design via `kata-design`
+
+WHICH/WHERE only. ≤200 lines. Each decision names a rejected alternative.
+Mermaid for relationships and flows. Stays inside spec scope.
+
+### 8 — Map back to corpus and broadcast
+
+Re-read the corpus. Classify every item as **directly addressed**,
+**binding-constraint instrumented**, **repair-move codified**, or **out of
+scope**. Update the PR body with an "Addresses" section listing only the first
+three buckets. Comment once on each addressed item with a back-reference to
+the PR. **Do not touch out-of-scope items** — signal hygiene matters; the
+items not addressed should not be tagged into the synthesis PR's notification
+graph.
+
+## Mapping back to corpus — categories
+
+| Category | Trigger | Comment shape |
+| --- | --- | --- |
+| **Directly addressed** | The synthesis's meta-trigger; the spec resolves or absorbs the item. | "Spec NNN codifies `<move>` as a named move; the no-silent-amendment rule would have surfaced this when …" |
+| **Binding-constraint instrumented** | The item flagged the binding constraint; the spec adds the metric that reads it. | "Spec NNN Success #N adds `<metric>` to canonical-11; the metric is the standing meter for the constraint this issue exemplifies." |
+| **Repair-move codified** | The item invented or applied a move that the spec now names. | "Spec NNN names `<move>` in the typology; this issue is the cited precedent. Future runs file an MCD instead of restating the cohort context." |
+| **Out of scope** | Spec's Scope (out) names the item or its category. | (no comment) |
+
+## Stopping conditions
+
+The skill stops and routes to a coaching session in these cases:
+
+- Corpus splits into two competing core categories — file two coaching asks,
+  one per category, and re-run synthesis on each subset later.
+- Open coding produces a category with one code and one incident — the corpus
+  is too small for that category to be a pattern.
+- Phase 6 cannot draft a spec whose Problem section grounds every claim in a
+  cited issue — the proposition is unsupported; return to phase 4.
+
+## Cross-skill dependencies
+
+| Phase | Skill invoked | Owner |
+| --- | --- | --- |
+| 6 | `kata-spec` | improvement-coach (this skill only) |
+| 7 | `kata-design` | improvement-coach (this skill only) |
+| 8 (broadcast) | direct GitHub MCP / `gh` | improvement-coach |
+
+The coach's general "no writing specs or fix PRs" constraint
+([`improvement-coach.md`](../../agents/improvement-coach.md)) is extended here
+because the synthesis is observation-as-architecture, not domain work — the
+spec is a write-up of what the team has already implicitly decided across the
+corpus, not a new feature.
+
+## Memory: what to record
+
+Append to the current week's coach log
+(`wiki/improvement-coach-$(date +%G-W%V).md`):
+
+- **Trigger** — Which threshold fired, with the count and date.
+- **Corpus** — Item numbers gathered (e.g., "12 obstacles, 14 experiments,
+  4 PRs").
+- **Core category** — The one selected, plus the rejected alternative if more
+  than one was considered.
+- **Proposition** — The one-sentence proposition.
+- **Spec / design / PR** — Numbers and links.
+- **Corpus map** — A table of corpus item → category. Out-of-scope items are
+  recorded here even though they receive no comment.
+- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+  per `references/metrics.md`. See KATA.md § Metrics for the
+  recording-eligibility rule.
+
+## Coordination Channels
+
+This skill produces these non-wiki outputs (per
+[coordination-protocol.md](../../agents/references/coordination-protocol.md)):
+
+- **PR body** — The synthesis spec/design PR carries the Addresses overview.
+- **Issue comment** — One per addressed item; never on out-of-scope items.
+- **Storyboard headline** — The next storyboard meeting after a synthesis run
+  surfaces the synthesis PR as a Q1 target-condition reference.
+
+If two storyboard meetings pass without the spec PR being approved, the coach
+files an obstacle (the synthesis PR is itself subject to the binding-
+constraint metric the spec proposed).

--- a/.claude/skills/kata-pattern-synthesis/SKILL.md
+++ b/.claude/skills/kata-pattern-synthesis/SKILL.md
@@ -1,68 +1,50 @@
 ---
 name: kata-pattern-synthesis
 description: >
-  Synthesize a system-level pattern from a corpus of open obstacle, experiment,
-  and PR items via grounded coding (open → axial → selective). Produces a
-  proposition, a kata-spec, a kata-design, and a corpus map that closes the loop
-  on the items that fed it. Run when the corpus is large enough that ad-hoc
-  per-item handling is reinventing the same repair moves. Improvement coach
-  scope extension — owned by the coach, with explicit authorization to write
-  spec and design via `kata-spec` and `kata-design` for this skill only.
+  Synthesize a system-level pattern from a corpus of related obstacle,
+  experiment, and PR items via grounded coding. Use when the corpus is large
+  enough that ad-hoc per-item handling is reinventing the same moves.
+  Improvement-coach scope extension — produces a `kata-spec`, a `kata-design`,
+  and a corpus map that closes the loop on the items that fed it.
 ---
 
 # Pattern Synthesis from Backlog
 
-A facilitation skill for the improvement coach. The coach reads the open corpus
-of obstacle and experiment issues and the PRs that touch them, codes the corpus
-to surface the system-level pattern those items collectively name, and turns
-that pattern into a single spec + design that addresses the meta-trigger,
-instruments the binding constraint, and codifies the repair moves the team has
-already invented case by case. The coach then closes the loop on every corpus
-item that fed the synthesis.
+Read a corpus of related issues and PRs, code it to surface the pattern those
+items collectively name, and turn that pattern into a single spec + design
+that addresses the meta-trigger, instruments any binding constraint surfaced
+across the corpus, and codifies the moves the team has been inventing per
+case.
 
-This skill is the only path through which the coach writes specs or designs.
-The general "facilitation only" constraint in
+This skill is the only path through which the improvement coach writes specs
+or designs. The general "facilitation only" constraint in
 [`improvement-coach.md`](../../agents/improvement-coach.md) still applies to
 every other context.
 
 ## When to Use
 
-- A storyboard meeting Q3 surfaces ≥3 obstacles whose repair moves visibly
-  rhyme (e.g., multiple "redefine the metric without tampering" patterns).
-- A producer-orphaning event lands on `main` (skill removed, renamed, or split)
-  and a metric loses its producer — immediate trigger.
-- An RFC issue routes through `obstacle` because a richer channel was
-  unavailable (e.g., `gh discussion create` failed) and the same RFC shape has
-  appeared more than once.
+- A storyboard meeting Q3 surfaces multiple obstacles whose repair shapes
+  visibly rhyme.
+- A producer-orphaning event lands on `main` (skill removed, renamed, or
+  split) and a metric loses its producer — immediate trigger.
+- The same RFC shape has appeared more than once because a richer channel was
+  unavailable.
 - A user explicitly requests a backlog synthesis run.
 
-Do **not** run when the corpus is small (under ~10 open obstacle+experiment
+Do not run when the corpus is small (under ~10 open obstacle+experiment
 items) or when fewer than 3 distinct repair-adjacent moves appear. Premature
 synthesis manufactures patterns where there is only noise.
 
-## Triggers (queryable thresholds)
+## Triggers
 
 ```sh
-# Corpus size (open obstacles + experiments)
-gh issue list --label obstacle,experiment --state open --limit 100 \
-  --json number | jq 'length'   # ≥10 → eligible
+# Eligibility — at least one threshold must hold
+gh issue list --label obstacle,experiment --state open --json number \
+  | jq 'length'   # ≥10 → eligible
 ```
 
-```sh
-# Producer-orphaning events on main since last synthesis
-gh search commits 'PR #715' --repo "$REPO" --json sha,commit \
-  --jq '.[] | select(.commit.message | test("remove|delete")) | .sha'
-```
-
-```sh
-# Distinct repair-adjacent moves in recent obstacles (open + last 30 days)
-gh issue list --label obstacle --state all --search "updated:>$(date -d '30 days ago' +%F)" \
-  --json title,body --jq '[.[] | .body | scan("sidecar|dual-record|stock|recast|phase|rehom|habit|RFC")] | unique | length'
-# ≥3 → eligible
-```
-
-The synthesis runs at most once per ISO week unless a producer-orphaning event
-forces it.
+The synthesis runs at most once per ISO week unless a producer-orphaning
+event forces it.
 
 ## Checklists
 
@@ -70,121 +52,114 @@ forces it.
 
 - [ ] Confirm at least one trigger threshold is met. Record which.
 - [ ] Close the corpus before coding begins; later items do not bias the codes.
-- [ ] Memos and codes are written to a scratch location, not to the wiki, until
-      the proposition is selected.
+- [ ] Memos and codes go to a scratch location, not to the wiki, until the
+      proposition is selected.
 - [ ] No claim enters the spec or design without an issue/PR number anchor.
-- [ ] The synthesis stops at one core category. If two compete, stop and route
-      to a coaching session — the corpus is two patterns, not one.
+- [ ] Stop at one core category. If two compete, the corpus is two patterns,
+      not one — route to a coaching session and re-run later on each subset.
 
 </read_do_checklist>
 
 <do_confirm_checklist goal="Verify synthesis quality before opening artifacts">
 
 - [ ] Every corpus item has a memo (3–5 sentences max).
-- [ ] Every memo has at least one in-vivo or descriptive code.
-- [ ] Codes group into 3–7 axial categories with stated relations.
-- [ ] One core category is named; storyline paragraph reads end-to-end without
+- [ ] Every memo has at least one code.
+- [ ] Codes group into 3–7 categories with stated relations.
+- [ ] One core category is named; storyline reads end-to-end without
       referencing the codes table.
-- [ ] One-sentence theoretical proposition is recorded.
+- [ ] One-sentence proposition recorded.
 - [ ] Spec drafted via `kata-spec` with verifiable success criteria (no HOW).
 - [ ] Design drafted via `kata-design` (≤200 lines, each decision rejects an
       alternative).
-- [ ] Corpus map records, for every original item, one of: directly addressed,
+- [ ] Corpus map records, for every item, one of: directly addressed,
       binding-constraint instrumented, repair-move codified, or out of scope.
 - [ ] Closure broadcast posted on every addressed item; **out-of-scope items
       not tagged**.
 
 </do_confirm_checklist>
 
-## The Eight Phases
+## Method
 
-The synthesis runs as a sequence. Output of each phase is the input to the
-next; nothing is invented without an anchor in the prior phase.
+Synthesis works as qualitative research, not checklist verification.
+**Grounded theory** is the recommended approach: let the pattern emerge from
+the corpus rather than testing a preformed hypothesis.
 
-### 1 — Corpus gather
+### Core Principles
 
-Define topic keywords (default: `obstacle`, `experiment`, plus PRs that
-reference any of those issues). Search by label, then by keyword, then dedupe.
-Persist issue/PR bodies to a scratch file under `/tmp/`. The corpus is closed
-before phase 2.
+1. **Begin with no proposition.** Read the corpus before forming opinions
+   about the system-level pattern.
+2. **Use the corpus's own language.** Label observations with terms from the
+   actual issue/PR text — in-vivo phrases — not abstract categories you bring
+   to the analysis.
+3. **Write memos as you go.** 3–5 sentences per item capturing the central
+   incident and what makes it surprising. Memos written during analysis are
+   far more valuable than retrospective summaries.
+4. **Read every item.** Skimming produces shallow patterns. Items that look
+   similar in the title often diverge in the body.
+5. **Seek a central explanation, not a category list.** The most useful
+   output is a proposition that connects multiple observations across
+   categories.
 
-### 2 — Field memos (one per item)
+### From Corpus to Spec
 
-3–5 sentences each: the central incident, the in-vivo language the author
-used, what the case adds. One file collecting all memos. Brevity is a
-discipline — long memos overweight verbose authors.
+As you read, assign short labels (codes) to meaningful events. Group related
+codes into categories by asking: what triggered this, what discipline was
+applied, what was the consequence, and what failed when the discipline
+lapsed?
 
-### 3 — Open coding
+Look for: repair moves invented per case, binding constraints that surface
+repeatedly without ever being measured directly, disciplines cited without a
+canonical home, and producer/consumer couplings where a single change
+rippled unexpectedly.
 
-Tag each incident with one or more codes. Prefer in-vivo (`HABIT_TO_POLICY`,
-`MERGE_AS_APPROVAL_SIGNAL`) over descriptive. Build an `incident → code` table.
+The strongest propositions are **grounded** (traceable to specific items),
+**testable** (a future corpus can confirm or refute the pattern), and
+**actionable** (they imply a single spec).
 
-### 4 — Axial coding
+### Phase Boundaries
 
-Group codes into 3–7 categories. For each: sub-codes, relations, causal
-condition, consequence. Stop when a new code lands cleanly in an existing
-category.
+The work passes through six checkpoints. Output of each is the input to the
+next; nothing is invented without an anchor in the prior step.
 
-### 5 — Selective coding
+1. Gather the corpus (closed before coding).
+2. Memo each item.
+3. Code, group, name a core category.
+4. Draft the proposition; reject if any code refused to fit.
+5. Spec via `kata-spec`; design via `kata-design`.
+6. Map back to the corpus; broadcast on addressed items only.
 
-Identify the core category that integrates the others. Write a one-paragraph
-storyline and a one-sentence theoretical proposition. The proposition is the
-architectural target.
+## Mapping Back to Corpus
 
-### 6 — Spec via `kata-spec`
-
-WHAT/WHY only. Problem section grounds every claim in a `#NNN` anchor. Scope
-(in) names specific files; Scope (out) names what is deferred. Success
-criteria are verifiable. Stop after `spec.md`.
-
-### 7 — Design via `kata-design`
-
-WHICH/WHERE only. ≤200 lines. Each decision names a rejected alternative.
-Mermaid for relationships and flows. Stays inside spec scope.
-
-### 8 — Map back to corpus and broadcast
-
-Re-read the corpus. Classify every item as **directly addressed**,
-**binding-constraint instrumented**, **repair-move codified**, or **out of
-scope**. Update the PR body with an "Addresses" section listing only the first
-three buckets. Comment once on each addressed item with a back-reference to
-the PR. **Do not touch out-of-scope items** — signal hygiene matters; the
-items not addressed should not be tagged into the synthesis PR's notification
-graph.
-
-## Mapping back to corpus — categories
+Re-read the corpus and classify every item. The PR body lists only the first
+three buckets; **out-of-scope items receive no comment** — signal hygiene
+matters.
 
 | Category | Trigger | Comment shape |
 | --- | --- | --- |
-| **Directly addressed** | The synthesis's meta-trigger; the spec resolves or absorbs the item. | "Spec NNN codifies `<move>` as a named move; the no-silent-amendment rule would have surfaced this when …" |
-| **Binding-constraint instrumented** | The item flagged the binding constraint; the spec adds the metric that reads it. | "Spec NNN Success #N adds `<metric>` to canonical-11; the metric is the standing meter for the constraint this issue exemplifies." |
-| **Repair-move codified** | The item invented or applied a move that the spec now names. | "Spec NNN names `<move>` in the typology; this issue is the cited precedent. Future runs file an MCD instead of restating the cohort context." |
+| **Directly addressed** | The synthesis's meta-trigger; the spec resolves or absorbs the item. | "Spec NNN codifies `<move>` as a named move; the discipline would have surfaced this when …" |
+| **Binding-constraint instrumented** | The item flagged the binding constraint; the spec adds the metric that reads it. | "Spec NNN Success #N adds `<metric>`; the metric is the standing meter for the constraint this issue exemplifies." |
+| **Repair-move codified** | The item invented or applied a move that the spec now names. | "Spec NNN names `<move>` in the typology; this issue is the cited precedent." |
 | **Out of scope** | Spec's Scope (out) names the item or its category. | (no comment) |
 
-## Stopping conditions
+## Stopping Conditions
 
-The skill stops and routes to a coaching session in these cases:
+Stop and route to a coaching session in any of these cases:
 
-- Corpus splits into two competing core categories — file two coaching asks,
-  one per category, and re-run synthesis on each subset later.
-- Open coding produces a category with one code and one incident — the corpus
-  is too small for that category to be a pattern.
-- Phase 6 cannot draft a spec whose Problem section grounds every claim in a
-  cited issue — the proposition is unsupported; return to phase 4.
+- The corpus splits into two competing core categories — file two coaching
+  asks, one per category.
+- Open coding produces a category with one code and one incident — the
+  corpus is too small for that category to be a pattern.
+- The spec's Problem section cannot ground every claim in a cited item — the
+  proposition is unsupported; return to coding.
 
-## Cross-skill dependencies
-
-| Phase | Skill invoked | Owner |
-| --- | --- | --- |
-| 6 | `kata-spec` | improvement-coach (this skill only) |
-| 7 | `kata-design` | improvement-coach (this skill only) |
-| 8 (broadcast) | direct GitHub MCP / `gh` | improvement-coach |
+## Coach Scope Exception
 
 The coach's general "no writing specs or fix PRs" constraint
-([`improvement-coach.md`](../../agents/improvement-coach.md)) is extended here
-because the synthesis is observation-as-architecture, not domain work — the
-spec is a write-up of what the team has already implicitly decided across the
-corpus, not a new feature.
+([`improvement-coach.md`](../../agents/improvement-coach.md)) is extended
+here because the synthesis is observation-as-architecture, not domain work —
+the spec is a write-up of what the team has already implicitly decided
+across the corpus, not a new feature. The exception is scoped to this skill
+only.
 
 ## Memory: what to record
 
@@ -192,8 +167,7 @@ Append to the current week's coach log
 (`wiki/improvement-coach-$(date +%G-W%V).md`):
 
 - **Trigger** — Which threshold fired, with the count and date.
-- **Corpus** — Item numbers gathered (e.g., "12 obstacles, 14 experiments,
-  4 PRs").
+- **Corpus** — Item numbers gathered (counts by label).
 - **Core category** — The one selected, plus the rejected alternative if more
   than one was considered.
 - **Proposition** — The one-sentence proposition.
@@ -209,11 +183,11 @@ Append to the current week's coach log
 This skill produces these non-wiki outputs (per
 [coordination-protocol.md](../../agents/references/coordination-protocol.md)):
 
-- **PR body** — The synthesis spec/design PR carries the Addresses overview.
+- **PR body** — Synthesis spec/design PR carries an Addresses overview.
 - **Issue comment** — One per addressed item; never on out-of-scope items.
-- **Storyboard headline** — The next storyboard meeting after a synthesis run
-  surfaces the synthesis PR as a Q1 target-condition reference.
+- **Storyboard headline** — The next storyboard meeting after a synthesis
+  run surfaces the synthesis PR as a Q1 target-condition reference.
 
-If two storyboard meetings pass without the spec PR being approved, the coach
-files an obstacle (the synthesis PR is itself subject to the binding-
-constraint metric the spec proposed).
+If two storyboard meetings pass without the spec PR being approved, file an
+obstacle — the synthesis PR is itself subject to whatever binding constraint
+the spec proposed.

--- a/.claude/skills/kata-pattern-synthesis/SKILL.md
+++ b/.claude/skills/kata-pattern-synthesis/SKILL.md
@@ -10,16 +10,10 @@ description: >
 
 # Pattern Synthesis from Backlog
 
-Read a corpus of related issues and PRs, code it to surface the pattern those
-items collectively name, and turn that pattern into a single spec + design
-that addresses the meta-trigger, instruments any binding constraint surfaced
-across the corpus, and codifies the moves the team has been inventing per
-case.
-
-This skill is the only path through which the improvement coach writes specs
-or designs. The general "facilitation only" constraint in
-[`improvement-coach.md`](../../agents/improvement-coach.md) still applies to
-every other context.
+Read a corpus of related issues and PRs, code it to surface the pattern, and
+turn that pattern into a single spec + design that addresses the meta-trigger,
+instruments any binding constraint, and codifies the moves the team has been
+inventing per case.
 
 ## When to Use
 
@@ -118,8 +112,7 @@ The strongest propositions are **grounded** (traceable to specific items),
 
 ### Phase Boundaries
 
-The work passes through six checkpoints. Output of each is the input to the
-next; nothing is invented without an anchor in the prior step.
+Six checkpoints; output of each feeds the next.
 
 1. Gather the corpus (closed before coding).
 2. Memo each item.

--- a/KATA.md
+++ b/KATA.md
@@ -137,6 +137,7 @@ for utilities). An agent's skill list reveals its phase coverage.
 | `kata-interview`          | Study   | JTBD switching interviews                     |
 | `kata-documentation`      | Study   | One topic deep per run                        |
 | `kata-wiki-curate`        | Study   | Agent memory hygiene                          |
+| `kata-pattern-synthesis`  | Study   | Coach-owned grounded coding of an obstacle/experiment/PR corpus into one spec + design |
 | `kata-spec`               | Act     | Write specs capturing WHAT/WHY                |
 | `kata-review`             | Utility | Grade a single artifact (leaf, no sub-agents) |
 | `kata-session`            | Utility | Toyota Kata coaching protocol for sessions    |


### PR DESCRIPTION
Coach-owned grounded-synthesis skill that codifies the eight-phase backlog-synthesis process: corpus gather → field memos → open / axial / selective coding → spec via `kata-spec` → design via `kata-design` → corpus map and broadcast.

## Trigger thresholds (queryable)

The skill runs at most once per ISO week, gated on at least one of:

```sh
gh issue list --label obstacle,experiment --state open --json number | jq 'length' >= 10
```

≥3 distinct repair-adjacent moves visible in obstacles updated in the last 30 days, **or** a producer-orphaning event (skill removed/renamed/split) on `main` since the last synthesis.

## Why coach-owned

The synthesis is observation-as-architecture, not domain work — it is a write-up of decisions the team has already implicitly made across the corpus. The improvement-coach gains an **explicit one-skill exception** to the "no writing specs or fix PRs" constraint; every other coach context still falls under facilitation.

## Output

Each run produces:

1. A synthesis report with codes, axial categories, and a one-sentence theoretical proposition.
2. One spec via `kata-spec` and one design via `kata-design`.
3. A corpus map classifying every original item as **directly addressed**, **binding-constraint instrumented**, **repair-move codified**, or **out of scope**.
4. A closure broadcast: PR body lists the first three buckets; one comment per addressed item; **out-of-scope items are not tagged** (signal hygiene).

## Stopping conditions

- Corpus splits into two competing core categories → file two coaching asks; do not synthesise both at once.
- A category has one code and one incident → too small to be a pattern.
- Spec Problem section cannot anchor every claim in a cited issue → return to axial coding.

## Provenance

This skill was extracted from a worked run on PR #838 (spec 860 — measurement-system change protocol). The eight-phase process matches what was applied there; the skill canonicalises it so a future improvement-coach run can re-apply the method without rediscovering it.

## Test plan

- [x] Skill registered in available-skills surface (verified — `kata-pattern-synthesis` appears in the SessionStart skill listing).
- [x] Improvement-coach agent skills list updated (`.claude/agents/improvement-coach.md`).
- [x] Improvement-coach Assess section gains a queryable eligibility step.
- [x] Constraint exception scoped to this skill only.
- [x] KATA.md skills table row added (Study phase).
- [ ] Sub-agent review panel via `kata-review` per the kata-skill DO-CONFIRM checklists.
- [ ] APPROVED review or `spec:approved` label per `kata-release-merge` gate.

https://claude.ai/code/session_017fXRXK9yKzuwu69ca7YWUp

---
_Generated by [Claude Code](https://claude.ai/code/session_017fXRXK9yKzuwu69ca7YWUp)_