### PR TITLE
spec(870): fit-benchmark coding agent task families

### DIFF
--- a/specs/870-fit-benchmark-coding-tasks/design-a.md
+++ b/specs/870-fit-benchmark-coding-tasks/design-a.md
@@ -5,17 +5,21 @@
 | Component | Where | Role |
 | --- | --- | --- |
 | `fit-benchmark` CLI | `libraries/libeval/bin/fit-benchmark.js` (new) | Entry point. Parses subcommand (`run`/`score`/`report`), wires real dependencies, delegates to the matching command handler. Mirrors `bin/fit-eval.js` shape. Same `@forwardimpact/libeval` package; separate bin. |
-| `BenchmarkRunner` | `libraries/libeval/src/benchmark/runner.js` (new) | Sole orchestrator. Owns phase ordering for a family run: invokes `install` once, then drives each `(task, runIndex)` through the lifecycle by directly calling the named subsystems. Composes libeval primitives. Emits `ResultRecord`s as an async iterable. There is no separate `LifecycleDriver` — the runner is the driver. |
+| `BenchmarkRunner` | `libraries/libeval/src/benchmark/runner.js` (new) | Sole orchestrator. Owns phase ordering for a family run: invokes `install` once, then drives each `(task, runIndex)` serially through the lifecycle by directly calling the named subsystems. Composes libeval's `Supervisor` + `AgentRunner`. Emits `ResultRecord`s as an async iterable. v1 is serial across `(task, runIndex)`; concurrent runs deferred. |
 | `TaskFamily` | `libraries/libeval/src/benchmark/task-family.js` (new) | Loaded family: `rootPath`, `apm.lock.yaml` bytes, `familyRevision`, iterable of `Task`. Loaded once at family `install`; immutable thereafter. |
 | `Task` | same module | One task: `id` = METR-style `task_family_name/task_name`, paths to `instructions.md`, `supervisor.task.md`, `judge.task.md`, `specs/`, `workdir/`, `scoring/`; declared `permissions` array. |
-| `ApmInstaller` | `libraries/libeval/src/benchmark/apm-installer.js` (new) | Reads family `apm.yaml`/`apm.lock.yaml` (extensions match libpack at `libraries/libpack/src/stager.js:126`), materialises declared skills/agents into a per-task temp CWD's `.claude/`. Produces `skillSetHash` (sha256 over `apm.lock.yaml` bytes after LF normalisation — prevents cross-OS hash drift). |
-| `WorkdirManager` | `libraries/libeval/src/benchmark/workdir.js` (new) | Per-task: creates a temp CWD, copies `workdir/` and `specs/` into it (never `scoring/`), runs the pre-flight smoke probe, owns process-group cleanup at teardown (port free, processes reaped via process-group SIGTERM then SIGKILL after a 5 s grace). |
-| `Scorer` | `libraries/libeval/src/benchmark/scorer.js` (new) | Invokes `<template>/tasks/<task>/scoring/run.sh` from the **template** path with `$WORKDIR` = post-run agent CWD, `$RESULTS_FD` = a captured file descriptor receiving NDJSON `{ test, pass, message? }` rows. Returns `{ verdict, details, exitCode }`; `verdict` derived from exit code (`0` → `pass`, non-zero → `fail`). |
-| `Judge` | `libraries/libeval/src/benchmark/judge.js` (new) | Wraps a libeval `Supervisor` over a single `AgentRunner`. Supervisor task = the family's `judge.task.md`; agent task = a structured "produce a verdict" prompt with `scoringPath` and `tracePath` exposed via env. The supervisor's `Conclude` summary becomes `judgeVerdict`. A bare `AgentRunner` cannot emit `Conclude` (registered only on supervisor/facilitator tool servers — `orchestration-toolkit.js:207,283`); the wrapper is required. |
-| `PermissionsBroker` | `libraries/libeval/src/benchmark/permissions.js` (new) | Translates METR-aligned permission strings into `AgentRunner` `allowedTools`/`disallowedTools` only. v1 closed set: `["full_internet"]`. Mapping: `"full_internet"` → include `WebFetch`; absent → exclude `WebFetch` and apply a Bash command-prefix disallowlist (`curl`, `wget`, `nc`, `ssh`). OS-level network gating is the deferred containerised-isolation work. |
-| `ResultRecord` | `libraries/libeval/src/benchmark/result.js` (new) | JSON shape per task-run, written one-per-line as JSONL to `<run-output>/results.jsonl`. Schema declared in § Result-record schema below; the same schema is consumed by `ReportAggregator` and exposed for fixture validation. |
-| `ReportAggregator` | `libraries/libeval/src/benchmark/report.js` (new) | `report` subcommand backend. Walks a run directory, groups records by `taskId`, computes pass@k via OpenAI HumanEval `1 - C(n-c, k) / C(n, k)`. |
+| `ApmInstaller` | `libraries/libeval/src/benchmark/apm-installer.js` (new) | At family `install`: reads `apm.yaml`/`apm.lock.yaml` (extensions match libpack at `libraries/libpack/src/stager.js:126`), materialises declared skills/agents into a single staging directory (`<output>/.apm-staging/.claude/`). Computes `skillSetHash` (sha256 over `apm.lock.yaml` bytes after LF normalisation — prevents cross-OS hash drift). At each task `start`, `WorkdirManager` copies the staging tree into the per-task CWD; `ApmInstaller` does not run per task. |
+| `WorkdirManager` | `libraries/libeval/src/benchmark/workdir.js` (new) | Per-task: creates a temp CWD, copies `workdir/` and `specs/` into it (never `scoring/`), copies the apm staging tree into the CWD's `.claude/`, runs the pre-flight smoke probe, owns process-group cleanup at teardown (port free, processes reaped via process-group SIGTERM then SIGKILL after a 5 s grace). Returns a `Workdir` handle. |
+| `Workdir` | same module | `{ cwd, port, pgid, scaffold, agentTracePath, judgeTracePath, preflightError? }`. Threaded through `runAgent` → `score` → `judge` → `teardown`. |
+| `Scorer` | `libraries/libeval/src/benchmark/scorer.js` (new) | Spawns `<template>/tasks/<task>/scoring/run.sh` from the **template** path with `node:child_process.spawn` using `stdio: ['inherit', 'pipe', 'pipe', 'pipe']`. The 4th stdio entry is the parent-readable pipe for NDJSON `{ test, pass, message? }` rows; the script writes to fd 3 (`$RESULTS_FD=3`). `$WORKDIR` env is the post-run agent CWD. Returns `{ verdict, details, exitCode }`; `verdict` derived from exit code (`0` → `"pass"`, non-zero → `"fail"`). |
+| `Judge` | `libraries/libeval/src/benchmark/judge.js` (new) | Wraps a libeval `Supervisor` over a single `AgentRunner` with its own `TraceCollector` writing to `Workdir.judgeTracePath`. Supervisor task = the family's `judge.task.md`; agent task = a structured "produce a verdict" prompt with `scoringPath` and `tracePath` (the agent-under-test trace) exposed via env. `Conclude` is registered only on supervisor/facilitator tool servers (`orchestration-toolkit.js:224,311`); a bare `AgentRunner` cannot emit it, so the wrapper is required. The supervisor's `Conclude` arguments (`{verdict, summary}`, where `verdict ∈ {"success","failure"}`) are mapped into the result record by the runner: `judgeVerdict = { verdict: conclude.verdict === "success" ? "pass" : "fail", summary: conclude.summary }`. |
+| `PermissionsBroker` | `libraries/libeval/src/benchmark/permissions.js` (new) | Translates METR-aligned permission strings into `AgentRunner` `allowedTools`/`disallowedTools` only. v1 closed set: `["full_internet"]`. Mapping: `"full_internet"` → include `WebFetch`; absent → exclude `WebFetch`. v1 enforcement is best-effort: a coding agent invoking `Bash` can still issue `curl`, `node -e "fetch(...)"`, etc. The harness adds a Bash command-prefix disallowlist (`curl`, `wget`, `nc`, `ssh`, `gh api`, `git fetch`) as advisory hardening, but acknowledges OS-level egress gating is the deferred containerised-isolation work. The spec verification tests the `WebFetch` path only. |
+| `ResultRecord` validator | `libraries/libeval/src/benchmark/result.js` (new) | Schema — declared in § Result-record schema below — and a runtime validator (`validateResultRecord(record)`) that the runner calls before each JSONL append. Records are written one-per-line to `<output>/results.jsonl`. The same validator is consumed by `ReportAggregator` to reject malformed inputs. |
+| `ReportAggregator` | `libraries/libeval/src/benchmark/report.js` (new) | `report` subcommand backend. Walks a run directory, validates each record, groups by `taskId`, computes pass@k via OpenAI HumanEval `1 - C(n-c, k) / C(n, k)`. |
 | Subcommand handlers | `libraries/libeval/src/commands/benchmark-{run,score,report}.js` (new) | Parse CLI args, validate paths, build `BenchmarkRunner` or `ReportAggregator`, write output. Mirrors existing `commands/run.js` shape. |
+
+`Supervisor` and `AgentRunner` are libeval primitives composed by
+`BenchmarkRunner` and `Judge`; they are not new components.
 
 ## Component graph
 
@@ -30,13 +34,15 @@ graph TD
   BR --> SC[Scorer]
   BR --> JD[Judge]
   BR --> PB[PermissionsBroker]
+  BR --> RR[ResultRecord validator]
   SV1 --> AR1[AgentRunner: agent under test]
   JD --> SV2[libeval Supervisor: judge]
   SV2 --> AR2[AgentRunner: judge agent]
-  AR1 --> TC[libeval TraceCollector]
-  WM -. "scoring/ stays in template" .-> SC
+  AR1 --> TC1[TraceCollector → agentTracePath]
+  AR2 --> TC2[TraceCollector → judgeTracePath]
   PB --> AR1
-  SC --> RR[results.jsonl]
+  SC -. "scoring/ stays in template" .-> SC
+  SC --> RR
   JD --> RR
   CMD --> RA[ReportAggregator]
   RA --> RR
@@ -49,22 +55,22 @@ sequenceDiagram
   participant CLI as fit-benchmark run
   participant BR as BenchmarkRunner
   participant WM as WorkdirManager
-  participant AR as Supervisor+AgentRunner
+  participant SV as Supervisor + AgentRunner
   participant SC as Scorer
   participant JD as Judge
   CLI->>BR: family + runs=N
-  BR->>BR: install(family)
-  loop task × runIndex
+  BR->>BR: install(family)  [ApmInstaller stages once]
+  loop task × runIndex (serial)
     BR->>WM: start(task, i)
-    WM-->>BR: Workdir (workdir/+specs/ copied; scoring/ excluded)
-    BR->>AR: runAgent(task, workdir)
-    AR-->>BR: tracePath, submission
+    WM-->>BR: Workdir { cwd, port, pgid, agentTracePath, judgeTracePath }
+    BR->>SV: runAgent(task, workdir) [trace → agentTracePath]
+    SV-->>BR: { submission, costUsd, turns }
     BR->>SC: score(task, workdir)
     SC-->>BR: { verdict, details, exitCode }
-    BR->>JD: judge(scoring, trace)
-    JD-->>BR: judge verdict
+    BR->>JD: judge(workdir, scoring) [trace → judgeTracePath]
+    JD-->>BR: { verdict, summary }  [verdict mapped success→pass]
     BR->>WM: teardown(workdir)
-    BR-->>CLI: ResultRecord (JSONL append)
+    BR-->>CLI: ResultRecord (validated, JSONL append)
   end
 ```
 
@@ -72,61 +78,70 @@ sequenceDiagram
 
 | Field | Type | Notes |
 |---|---|---|
-| `taskId` | string | `task_family_name/task_name` (METR-style) |
+| `taskId` | string | `task_family_name/task_name` |
 | `runIndex` | integer | 0-based |
-| `verdict` | `"pass" \| "fail"` | combined gate: pass iff `scoring.verdict === "pass"` AND `judgeVerdict.verdict === "pass"` |
-| `scoring` | `{ verdict, details, exitCode }` | nested; `details` is the parsed NDJSON from `$RESULTS_FD` |
-| `submission` | string | METR `submission` — the agent's final assistant text |
-| `judgeVerdict` | `{ verdict, summary }` | from the judge supervisor's `Conclude` call |
-| `costUsd` | number | total agent cost from the trace |
-| `turns` | integer | total turns from the trace |
-| `tracePath` | string | absolute path to the run-output NDJSON trace |
-| `profiles` | `{ agent, supervisor, judge }` | profile names used for each role |
+| `verdict` | `"pass" \| "fail"` | combined gate: `"pass"` iff `scoring.verdict === "pass"` AND `judgeVerdict.verdict === "pass"` |
+| `scoring` | `{ verdict, details, exitCode }` | `verdict` ∈ `{"pass","fail"}`; `details` parsed from `$RESULTS_FD` |
+| `submission` | string | METR `submission` — the agent-under-test's final assistant text, extracted from `agentTracePath` |
+| `judgeVerdict` | `{ verdict, summary }` | `verdict` ∈ `{"pass","fail"}`, mapped from libeval's `Conclude` (`success`→`pass`, `failure`→`fail`); `summary` is the supervisor's `Conclude.summary` verbatim |
+| `costUsd` | number | total agent cost from the agent-under-test trace |
+| `turns` | integer | total turns from the agent-under-test trace |
+| `tracePath` | string | absolute path to `agentTracePath` (the agent-under-test NDJSON trace) |
+| `judgeTracePath` | string | absolute path to the judge session's NDJSON trace |
+| `profiles` | `{ agent, supervisor, judge }` | each is a profile name string passed to libeval at construction |
 | `model` | string | model id (e.g. `claude-opus-4-7`) |
 | `skillSetHash` | string | `sha256:` over `apm.lock.yaml` bytes after LF normalisation |
-| `familyRevision` | string | git SHA when family is sourced from a repo, else `sha256:` per algorithm below |
-| `permissions` | `string[]` | METR permission strings; v1 closed set: `["full_internet"]` |
+| `familyRevision` | string | git SHA when family is sourced from a repo, else canonical sorted-tree sha256 (algorithm: design owns, plan implements) |
+| `permissions` | `("full_internet")[]` | METR-aligned closed set for v1 |
 | `durationMs` | integer | wall-clock from `start` to `teardown` |
-
-`familyRevision` for non-git families: list tracked files (`tasks/**`,
-`apm.yaml`, `apm.lock.yaml`, root scaffolding), sort by relative path, hash
-each file with sha256, concatenate `<path>\0<sha256-hex>\n` rows in order,
-sha256 the concatenation, prefix `sha256:`.
+| `preflightError?` | `{ phase, message, exitCode }` | present only on pre-flight failure; the record is otherwise minimal (`costUsd: 0`, no submission, no scoring) |
 
 ## Pre-flight contract
 
-Each task's `workdir/scripts/preflight.sh` (executable) is invoked by
-`WorkdirManager` after the copy step. Exit `0` = scaffolding boots; non-zero
-= broken template. If the file is absent, the harness boots the scaffold via
-`npm run start` (resolved from `workdir/package.json`) with `$PORT` set, polls
-`http://localhost:$PORT/health` for up to 30 s, and treats a 2xx response as
-success. Either path failing surfaces as a structured `preflightError` field
-on the result record with `costUsd: 0`.
+`workdir/scripts/preflight.sh` (executable) is invoked by `WorkdirManager`
+after the copy step. Exit `0` = scaffolding boots; non-zero = broken
+template. If the file is absent, the harness boots the scaffold via
+`npm run start` with `$PORT` set, polls `http://localhost:$PORT/health` for
+up to 30 s, and treats a 2xx response as success. The default path assumes a
+Node-style scaffold; non-Node families must provide the override.
 
 ## Interfaces
 
 ```js
 // runner.js
 class BenchmarkRunner {
-  constructor({ family, runs, output, model, redactor, ...opts });
+  constructor({
+    family,                       // TaskFamily | path | git url
+    runs,
+    output,                       // run-output directory
+    model,
+    profiles,                     // { agent, supervisor, judge } — names
+    ...opts
+  });
   async *run(): AsyncIterable<ResultRecord>;
 }
+
+// runAgent flow inside BenchmarkRunner (not a separate class):
+//   compose Supervisor over AgentRunner, with TraceCollector → agentTracePath,
+//   tools gated by PermissionsBroker(task.permissions);
+//   on session end, parse agentTracePath to extract `submission`
+//   (final assistant text block before any orchestration tool call).
 
 // task-family.js
 loadTaskFamily(rootPathOrGitUrl): Promise<TaskFamily>
 TaskFamily: { rootPath, familyRevision, apmLockBytes, tasks(): Iterable<Task> }
 Task: {
-  id,                            // "task_family_name/task_name"
-  paths: { instructions, supervisor, judge, specs, workdir, scoring },
-  permissions: string[],         // v1 closed set: ["full_internet"]
+  id, paths: { instructions, supervisor, judge, specs, workdir, scoring },
+  permissions: ("full_internet")[],
 }
 
 // scorer.js
 runScoring(task, workdir): Promise<{
-  verdict: "pass" | "fail",
-  details: object[],             // NDJSON parsed from $RESULTS_FD
-  exitCode: number,
+  verdict: "pass" | "fail", details: object[], exitCode: number,
 }>
+
+// result.js
+validateResultRecord(record): void   // throws on schema mismatch
 ```
 
 ## Key Decisions
@@ -135,15 +150,17 @@ runScoring(task, workdir): Promise<{
 | --- | --- | --- | --- |
 | 1 | Separate CLI `fit-benchmark` rather than a `fit-eval bench` subcommand. Same package. | Add `bench` to `fit-eval`. | Keeps `fit-eval` a low-level generic tool with stable surface. The benchmark layer carries opinionated semantics (lifecycle, scoring, judge, aggregation) that don't belong in the generic CLI. |
 | 2 | Adopt METR task-standard vocabulary (`task family`, `instructions`, `permissions`, lifecycle hook names, `submission`, `task_family_name/task_name` ids). | Invent monorepo-specific names. | Portability — METR's standard is in production at multiple orgs. Vocabulary alignment lets the format absorb existing METR families and lets ours flow outward without renaming. |
-| 3 | Hidden `scoring/` directory lives only in the template; never copied into the agent's CWD. The Scorer invokes scripts from the template path with `$WORKDIR` as an argument. | Copy `scoring/` to a sibling dir in the temp CWD; rely on the supervisor to keep the agent away. | Structural beats procedural. If `scoring/` is never on disk in the agent's CWD, peeking is impossible. |
-| 4 | Skill-set lockfile at family root is `apm.lock.yaml` (matching libpack); `skillSetHash` is sha256 over its bytes after LF normalisation. | `apm.lock.yml`; raw byte hash without normalisation. | `.yaml` matches `libraries/libpack/src/stager.js:126`; `.yml` would silently miss the file. LF normalisation prevents Windows/Unix CRLF flipping the hash on the same lockfile. |
-| 5 | Compose libeval primitives (`AgentRunner`, `Supervisor`, `TraceCollector`); do not fork. | New `BenchmarkAgentRunner` subclass. | One source of truth for agent execution; libeval improvements (redaction, profiles, trace shape) flow through automatically. |
-| 6 | `BenchmarkRunner` is the sole orchestrator. No separate `LifecycleDriver`. | Two-tier orchestrator with `LifecycleDriver` wrapping phases. | Fewer indirection layers; phase ordering lives in one place. v1 has one orchestrator shape. |
-| 7 | Judge runs through a libeval `Supervisor` over a single `AgentRunner` — not a bare `AgentRunner`. | Bare `AgentRunner` parsing final assistant text; reuse the live supervisor. | `Conclude` is registered only on supervisor/facilitator tool servers (`orchestration-toolkit.js:207,283`); a bare `AgentRunner` cannot emit it. Reusing the live supervisor conflates help-incentives with grade-incentives. |
-| 8 | Permissions enforced by `AgentRunner` `allowedTools`/`disallowedTools` only. v1 closed set: `["full_internet"]`. | OS-level network gating; per-monorepo permission vocabulary; default-on internet. | `AgentRunner` exposes only tool allow/deny; OS-level gating is the deferred containerised-isolation work. Default-deny aligns with METR. |
-| 9 | One result record per task-run, JSONL-appended to `<run-output>/results.jsonl`. | Aggregated JSON per run. | Append-only writes survive partial failures and concurrent runs. Per-record format makes individual results easy to grep and diff. |
-| 10 | `familyRevision` is the git SHA when the family is a git repo, else the canonical sorted-tree hash defined above. | Always content-hash; always require git. | Git source is the cheap common path; non-git is a real local-development case the harness must support, with a defined hash algorithm. |
-| 11 | Pre-flight contract: `workdir/scripts/preflight.sh` if present, else default `npm run start` + HTTP 2xx on `/health`. | Require every task to provide its own probe; or skip pre-flight. | A default keeps simple HTTP-service tasks zero-config; the override hook supports anything else. Skipping pre-flight makes broken-template failures attributable to the agent. |
+| 3 | Hidden `scoring/` directory lives only in the template; `WorkdirManager` never copies it. The Scorer invokes scripts from the template path with `$WORKDIR` as an argument. | Copy `scoring/` to a sibling dir; rely on the supervisor to keep the agent away. | Structural beats procedural. If `scoring/` is never on disk in the agent's CWD, peeking is impossible. |
+| 4 | Lockfile at family root is `apm.lock.yaml` (matching libpack); `skillSetHash` is sha256 over its bytes after LF normalisation. | `apm.lock.yml`; raw byte hash without normalisation. | `.yaml` matches `libraries/libpack/src/stager.js:126`; `.yml` would silently miss the file. LF normalisation prevents Windows/Unix CRLF flipping the hash. |
+| 5 | Compose libeval primitives (`AgentRunner`, `Supervisor`, `TraceCollector`); do not fork. | New `BenchmarkAgentRunner` subclass. | One source of truth for agent execution; libeval improvements flow through automatically. |
+| 6 | `BenchmarkRunner` is the sole orchestrator. No separate `LifecycleDriver`. v1 is serial across `(task, runIndex)`. | Two-tier orchestrator; concurrent runs in v1. | Fewer indirection layers; concurrency adds JSONL-append synchronisation, port-allocation, and teardown-race surface that v1 doesn't need to validate the format. |
+| 7 | Judge runs through a libeval `Supervisor` over a single `AgentRunner` — not a bare `AgentRunner`. | Bare `AgentRunner` parsing final text; reuse the live supervisor. | `Conclude` is registered only on supervisor/facilitator tool servers (`orchestration-toolkit.js:224,311`); a bare `AgentRunner` cannot emit it. Reusing the live supervisor conflates help-incentives with grade-incentives — a spec-level concern. |
+| 8 | `judgeVerdict` shape is `{ verdict: "pass"\|"fail", summary }`; the runner maps libeval's `Conclude.verdict` `"success"`→`"pass"` and `"failure"`→`"fail"`. | Use libeval's `success`/`failure` enum on the wire. | The result record speaks user-facing pass/fail (matching pass@k vocabulary); libeval's enum is preserved on the trace itself for round-trip. The mapping is a one-line normalisation, named here so neither side invents it. |
+| 9 | v1 network policy enforced by `AgentRunner` `allowedTools`/`disallowedTools` plus a Bash command-prefix advisory disallowlist. Closed set: `["full_internet"]`. | OS-level network gating; trust the agent. | `AgentRunner` exposes only tool allow/deny. Bash bypasses (`/usr/bin/curl`, `node -e fetch(...)`) are real and acknowledged; OS-level isolation is the deferred containerised-isolation follow-up. The spec test validates the `WebFetch` path only. |
+| 10 | One result record per task-run, JSONL-appended to `<output>/results.jsonl`. Each record passes a runtime schema validator before append. | Aggregated JSON per run; no validator. | Append-only writes survive partial failures. Validator catches schema drift at write time rather than at report time. |
+| 11 | `ApmInstaller` runs once per family `install`, materialising into a single staging directory; `WorkdirManager` copies the staged tree into each per-task CWD. | Re-install per task; reference-count a shared `.claude/`. | Hashes once, copies many. Staged tree is read-only after install — task isolation is provided by the per-task copy. |
+| 12 | `Scorer` passes results via fd 3 (`$RESULTS_FD=3`) using `child_process.spawn` `stdio: ['inherit','pipe','pipe','pipe']`. POSIX-only in v1. | Sentinel file in `$WORKDIR`; stdout interleaved. | Sentinel file pollutes the post-run workdir (visible in repo-state grading); stdout interleaving requires a delimiter convention. Fd 3 is portable across POSIX shells; Windows support is deferred. |
+| 13 | Two trace files per task-run (`agentTracePath`, `judgeTracePath`). `tracePath` on the record points at the agent-under-test trace; `judgeTracePath` is a sibling field. | Single trace shared between supervisor and judge; discard judge trace. | The judge is an independent session — its trace is a first-class artifact for debugging "why did the judge fail this run?" The runner-of-records cares about the agent-under-test trace primarily, hence `tracePath` aliases the agent trace for `fit-trace overview` ergonomics. |
 
 ## Test surfaces
 
@@ -151,14 +168,14 @@ The design names two surfaces; the plan picks the layering and fixture compositi
 
 | Surface | What it covers |
 | --- | --- |
-| `benchmark/*.js` unit | `WorkdirManager` excludes `scoring/` from the copy. `ApmInstaller` produces a stable `skillSetHash` across runs and changes on a one-byte lockfile edit. `Scorer` parses `$RESULTS_FD` NDJSON and exit codes. `PermissionsBroker` maps METR strings to `allowedTools`/`disallowedTools`. `ReportAggregator` computes pass@k. |
-| End-to-end fixture | A minimal task family driving the full lifecycle, asserting result-record schema validation, scoring isolation (sentinel-filename property), pre-flight failure path, network-policy enforcement, and JSONL append integrity. |
+| `benchmark/*.js` unit | `WorkdirManager` excludes `scoring/`. `ApmInstaller` produces stable `skillSetHash` and runs once per family. `Scorer` parses fd-3 NDJSON and exit codes. `PermissionsBroker` maps METR strings to `allowedTools`/`disallowedTools`. `validateResultRecord` rejects malformed records. `ReportAggregator` computes pass@k. |
+| End-to-end fixture | A minimal task family driving the full lifecycle, asserting result-record validation, scoring isolation (sentinel-filename property), pre-flight failure path, network-policy enforcement on the `WebFetch` surface, JSONL append integrity, and verdict-enum mapping (`success`→`pass`). |
 
 ## Out of scope (carried from spec)
 
-Containerised isolation, library/CLI test surfaces beyond HTTP, cross-model
-leaderboards, live PR-gate integration, retroactive grading of historical
-traces, family-level cost caps, replay-from-trace, and intermediate scoring
-are unchanged from spec § Out of scope, deferred.
+Containerised isolation, library-API and CLI-invocation grading, cross-model
+leaderboards, live PR-gate integration, retroactive grading, family-level
+cost caps, replay-from-trace, intermediate scoring, concurrent runs, and
+Windows scoring-channel support are unchanged from spec § Out of scope, deferred.
 
 — Staff Engineer 🛠️

--- a/specs/870-fit-benchmark-coding-tasks/design-a.md
+++ b/specs/870-fit-benchmark-coding-tasks/design-a.md
@@ -11,9 +11,9 @@
 | `ApmInstaller` | `libraries/libeval/src/benchmark/apm-installer.js` (new) | At family `install`: reads `apm.yaml`/`apm.lock.yaml` (extensions match libpack at `libraries/libpack/src/stager.js:126`), materialises declared skills/agents into a single staging directory (`<output>/.apm-staging/.claude/`). Computes `skillSetHash` (sha256 over `apm.lock.yaml` bytes after LF normalisation — prevents cross-OS hash drift). At each task `start`, `WorkdirManager` copies the staging tree into the per-task CWD; `ApmInstaller` does not run per task. |
 | `WorkdirManager` | `libraries/libeval/src/benchmark/workdir.js` (new) | Per-task: creates a temp CWD, copies `workdir/` and `specs/` into it (never `scoring/`), copies the apm staging tree into the CWD's `.claude/`, runs the pre-flight smoke probe, owns process-group cleanup at teardown (port free, processes reaped via process-group SIGTERM then SIGKILL after a 5 s grace). Returns a `Workdir` handle. |
 | `Workdir` | same module | `{ cwd, port, pgid, scaffold, agentTracePath, judgeTracePath, preflightError? }`. Threaded through `runAgent` → `score` → `judge` → `teardown`. |
-| `Scorer` | `libraries/libeval/src/benchmark/scorer.js` (new) | Spawns `<template>/tasks/<task>/scoring/run.sh` from the **template** path with `node:child_process.spawn` using `stdio: ['inherit', 'pipe', 'pipe', 'pipe']`. The 4th stdio entry is the parent-readable pipe for NDJSON `{ test, pass, message? }` rows; the script writes to fd 3 (`$RESULTS_FD=3`). `$WORKDIR` env is the post-run agent CWD. Returns `{ verdict, details, exitCode }`; `verdict` derived from exit code (`0` → `"pass"`, non-zero → `"fail"`). |
-| `Judge` | `libraries/libeval/src/benchmark/judge.js` (new) | Wraps a libeval `Supervisor` over a single `AgentRunner` with its own `TraceCollector` writing to `Workdir.judgeTracePath`. Supervisor task = the family's `judge.task.md`; agent task = a structured "produce a verdict" prompt with `scoringPath` and `tracePath` (the agent-under-test trace) exposed via env. `Conclude` is registered only on supervisor/facilitator tool servers (`orchestration-toolkit.js:224,311`); a bare `AgentRunner` cannot emit it, so the wrapper is required. The supervisor's `Conclude` arguments (`{verdict, summary}`, where `verdict ∈ {"success","failure"}`) are mapped into the result record by the runner: `judgeVerdict = { verdict: conclude.verdict === "success" ? "pass" : "fail", summary: conclude.summary }`. |
-| `PermissionsBroker` | `libraries/libeval/src/benchmark/permissions.js` (new) | Translates METR-aligned permission strings into `AgentRunner` `allowedTools`/`disallowedTools` only. v1 closed set: `["full_internet"]`. Mapping: `"full_internet"` → include `WebFetch`; absent → exclude `WebFetch`. v1 enforcement is best-effort: a coding agent invoking `Bash` can still issue `curl`, `node -e "fetch(...)"`, etc. The harness adds a Bash command-prefix disallowlist (`curl`, `wget`, `nc`, `ssh`, `gh api`, `git fetch`) as advisory hardening, but acknowledges OS-level egress gating is the deferred containerised-isolation work. The spec verification tests the `WebFetch` path only. |
+| `Scorer` | `libraries/libeval/src/benchmark/scorer.js` (new) | Spawns `<template>/tasks/<task>/scoring/run.sh` from the **template** path with `node:child_process.spawn` using `stdio: ['inherit', 'pipe', 'pipe', 'pipe']`. The 4th stdio entry is the parent-readable pipe for NDJSON `{ test, pass, message? }` rows; the script writes to fd 3 (`$RESULTS_FD=3`). `$WORKDIR` env is the post-run agent CWD. Returns `{ verdict, details, exitCode }`. **Exit code is authoritative**: `verdict = "pass"` iff `exitCode === 0`. The fd-3 NDJSON is diagnostic (per-test breakdowns surfaced on the result record) and never overrides the exit-code verdict. |
+| `Judge` | `libraries/libeval/src/benchmark/judge.js` (new) | Wraps a libeval `Supervisor` over a single `AgentRunner` with its own `TraceCollector` writing to `Workdir.judgeTracePath`. Supervisor task = the family's `judge.task.md`; agent task = a structured "produce a verdict" prompt with `scoringPath` and `agentTracePath` exposed via env. `Conclude` is registered only on supervisor/facilitator tool servers (`orchestration-toolkit.js:224,311`); a bare `AgentRunner` cannot emit it, so the wrapper is required. The supervisor's `Conclude` arguments (`{verdict, summary}`, where `verdict ∈ {"success","failure"}`) are mapped into the result record by the runner: `judgeVerdict = { verdict: conclude.verdict === "success" ? "pass" : "fail", summary: conclude.summary }`. |
+| `PermissionsBroker` | `libraries/libeval/src/benchmark/permissions.js` (new) | Translates METR-aligned permission strings into `AgentRunner` `allowedTools`/`disallowedTools` only. v1 closed set: `["full_internet"]`. Mapping: `"full_internet"` → include `WebFetch`; absent → exclude `WebFetch`. The spec's network-policy criterion is observable against the `WebFetch` surface only; Bash-shell egress (`/usr/bin/curl`, `node -e "fetch(...)"`, etc.) is a known v1 limitation closed only by the deferred containerised-isolation work. The plan owns any best-effort Bash-prefix advisory hardening; the design does not commit to a list. |
 | `ResultRecord` validator | `libraries/libeval/src/benchmark/result.js` (new) | Schema — declared in § Result-record schema below — and a runtime validator (`validateResultRecord(record)`) that the runner calls before each JSONL append. Records are written one-per-line to `<output>/results.jsonl`. The same validator is consumed by `ReportAggregator` to reject malformed inputs. |
 | `ReportAggregator` | `libraries/libeval/src/benchmark/report.js` (new) | `report` subcommand backend. Walks a run directory, validates each record, groups by `taskId`, computes pass@k via OpenAI HumanEval `1 - C(n-c, k) / C(n, k)`. |
 | Subcommand handlers | `libraries/libeval/src/commands/benchmark-{run,score,report}.js` (new) | Parse CLI args, validate paths, build `BenchmarkRunner` or `ReportAggregator`, write output. Mirrors existing `commands/run.js` shape. |
@@ -86,24 +86,37 @@ sequenceDiagram
 | `judgeVerdict` | `{ verdict, summary }` | `verdict` ∈ `{"pass","fail"}`, mapped from libeval's `Conclude` (`success`→`pass`, `failure`→`fail`); `summary` is the supervisor's `Conclude.summary` verbatim |
 | `costUsd` | number | total agent cost from the agent-under-test trace |
 | `turns` | integer | total turns from the agent-under-test trace |
-| `tracePath` | string | absolute path to `agentTracePath` (the agent-under-test NDJSON trace) |
+| `agentTracePath` | string | absolute path to the agent-under-test NDJSON trace |
 | `judgeTracePath` | string | absolute path to the judge session's NDJSON trace |
 | `profiles` | `{ agent, supervisor, judge }` | each is a profile name string passed to libeval at construction |
 | `model` | string | model id (e.g. `claude-opus-4-7`) |
 | `skillSetHash` | string | `sha256:` over `apm.lock.yaml` bytes after LF normalisation |
-| `familyRevision` | string | git SHA when family is sourced from a repo, else canonical sorted-tree sha256 (algorithm: design owns, plan implements) |
+| `familyRevision` | string | `git:<SHA>` when family is sourced from a git repo (HEAD SHA at clone time); else `sha256:` per the canonical-tree algorithm in § Family revision algorithm |
 | `permissions` | `("full_internet")[]` | METR-aligned closed set for v1 |
 | `durationMs` | integer | wall-clock from `start` to `teardown` |
 | `preflightError?` | `{ phase, message, exitCode }` | present only on pre-flight failure; the record is otherwise minimal (`costUsd: 0`, no submission, no scoring) |
 
 ## Pre-flight contract
 
-`workdir/scripts/preflight.sh` (executable) is invoked by `WorkdirManager`
-after the copy step. Exit `0` = scaffolding boots; non-zero = broken
-template. If the file is absent, the harness boots the scaffold via
-`npm run start` with `$PORT` set, polls `http://localhost:$PORT/health` for
-up to 30 s, and treats a 2xx response as success. The default path assumes a
-Node-style scaffold; non-Node families must provide the override.
+`workdir/scripts/preflight.sh` is the sole pre-flight mechanism. Each task
+in a family must ship one (executable). `WorkdirManager` invokes it after
+the copy step with `$WORKDIR` = the per-task agent CWD and `$PORT` =
+harness-allocated TCP port; exit `0` = scaffolding boots, non-zero = broken
+template. The harness fails the family at `install` if any task's
+`workdir/scripts/preflight.sh` is missing or non-executable, before any
+agent session starts. Tasks that need no probe can `exit 0` immediately.
+The harness commits to no language- or transport-specific defaults.
+
+## Family revision algorithm
+
+For non-git families, `familyRevision` is computed as: list every regular
+file under the family root excluding `.git/` and `node_modules/`; resolve
+each symlink to its target before reading; sort the resulting paths
+lexicographically by their root-relative POSIX path string; for each path
+compute sha256 of the file's bytes; concatenate `<rel-path>\0<hex-sha>\n`
+rows in the sorted order; sha256 the concatenation; prefix `sha256:`. The
+algorithm uses NFC-normalised UTF-8 for paths and LF-only line endings for
+the row separator so the result is byte-identical across operating systems.
 
 ## Interfaces
 
@@ -156,11 +169,11 @@ validateResultRecord(record): void   // throws on schema mismatch
 | 6 | `BenchmarkRunner` is the sole orchestrator. No separate `LifecycleDriver`. v1 is serial across `(task, runIndex)`. | Two-tier orchestrator; concurrent runs in v1. | Fewer indirection layers; concurrency adds JSONL-append synchronisation, port-allocation, and teardown-race surface that v1 doesn't need to validate the format. |
 | 7 | Judge runs through a libeval `Supervisor` over a single `AgentRunner` — not a bare `AgentRunner`. | Bare `AgentRunner` parsing final text; reuse the live supervisor. | `Conclude` is registered only on supervisor/facilitator tool servers (`orchestration-toolkit.js:224,311`); a bare `AgentRunner` cannot emit it. Reusing the live supervisor conflates help-incentives with grade-incentives — a spec-level concern. |
 | 8 | `judgeVerdict` shape is `{ verdict: "pass"\|"fail", summary }`; the runner maps libeval's `Conclude.verdict` `"success"`→`"pass"` and `"failure"`→`"fail"`. | Use libeval's `success`/`failure` enum on the wire. | The result record speaks user-facing pass/fail (matching pass@k vocabulary); libeval's enum is preserved on the trace itself for round-trip. The mapping is a one-line normalisation, named here so neither side invents it. |
-| 9 | v1 network policy enforced by `AgentRunner` `allowedTools`/`disallowedTools` plus a Bash command-prefix advisory disallowlist. Closed set: `["full_internet"]`. | OS-level network gating; trust the agent. | `AgentRunner` exposes only tool allow/deny. Bash bypasses (`/usr/bin/curl`, `node -e fetch(...)`) are real and acknowledged; OS-level isolation is the deferred containerised-isolation follow-up. The spec test validates the `WebFetch` path only. |
+| 9 | v1 network policy enforced through `AgentRunner` `allowedTools`/`disallowedTools` only. Closed set: `["full_internet"]`. The spec's network-policy success criterion is observable on the `WebFetch` surface; Bash-shell egress is a documented v1 limitation. | OS-level network gating in v1. | `AgentRunner` exposes only tool allow/deny; OS-level isolation is the deferred containerised-isolation follow-up. Constraining v1 to the tool surface keeps the spec criterion verifiable without committing to fragile Bash-prefix heuristics. |
 | 10 | One result record per task-run, JSONL-appended to `<output>/results.jsonl`. Each record passes a runtime schema validator before append. | Aggregated JSON per run; no validator. | Append-only writes survive partial failures. Validator catches schema drift at write time rather than at report time. |
 | 11 | `ApmInstaller` runs once per family `install`, materialising into a single staging directory; `WorkdirManager` copies the staged tree into each per-task CWD. | Re-install per task; reference-count a shared `.claude/`. | Hashes once, copies many. Staged tree is read-only after install — task isolation is provided by the per-task copy. |
 | 12 | `Scorer` passes results via fd 3 (`$RESULTS_FD=3`) using `child_process.spawn` `stdio: ['inherit','pipe','pipe','pipe']`. POSIX-only in v1. | Sentinel file in `$WORKDIR`; stdout interleaved. | Sentinel file pollutes the post-run workdir (visible in repo-state grading); stdout interleaving requires a delimiter convention. Fd 3 is portable across POSIX shells; Windows support is deferred. |
-| 13 | Two trace files per task-run (`agentTracePath`, `judgeTracePath`). `tracePath` on the record points at the agent-under-test trace; `judgeTracePath` is a sibling field. | Single trace shared between supervisor and judge; discard judge trace. | The judge is an independent session — its trace is a first-class artifact for debugging "why did the judge fail this run?" The runner-of-records cares about the agent-under-test trace primarily, hence `tracePath` aliases the agent trace for `fit-trace overview` ergonomics. |
+| 13 | Two symmetric trace fields per task-run: `agentTracePath` and `judgeTracePath`. No `tracePath` alias. | Single trace shared between supervisor and judge; discard judge trace; expose only one trace via `tracePath`. | The judge is an independent session — its trace is a first-class artifact for debugging "why did the judge fail this run?" Symmetric naming avoids the drift that arises when two field names refer to the same value, and keeps the schema explicit about which trace consumers want. |
 
 ## Test surfaces
 

--- a/specs/870-fit-benchmark-coding-tasks/design-a.md
+++ b/specs/870-fit-benchmark-coding-tasks/design-a.md
@@ -4,20 +4,18 @@
 
 | Component | Where | Role |
 | --- | --- | --- |
-| `fit-benchmark` CLI | `libraries/libeval/bin/fit-benchmark.js` (new) | Entry point. Parses subcommand (`run`/`score`/`report`), wires real dependencies, delegates to the matching command handler. Mirrors `bin/fit-eval.js` shape for parity. |
-| `BenchmarkRunner` | `libraries/libeval/src/benchmark/runner.js` (new) | Orchestrates a family run: `install` once, then for each `task × runIndex` drive the lifecycle. Composes libeval primitives rather than wrapping them. Emits `ResultRecord`s as an async iterable. |
-| `TaskFamily` | `libraries/libeval/src/benchmark/task-family.js` (new) | In-memory representation of a loaded family: `rootPath`, `apm.lock.yml` content, `familySha` (git SHA when sourced from a repo, else content hash of the family root), iterable of `Task`. Loaded once at family `install`; immutable thereafter. |
-| `Task` | same module | One task: `id` (METR-style `task_family/task_name`), paths to `instructions.md`, `supervisor.task.md`, `judge.task.md`, `specs/`, `workdir/`, `scoring/`; declared `permissions`. |
-| `LifecycleDriver` | `libraries/libeval/src/benchmark/lifecycle.js` (new) | Sequences the per-task hooks (`start`, run, `score`, `judge`, `teardown`) with explicit per-phase error boundaries. Hook names borrowed from METR's `TaskFamily` to keep the format portable. The driver is the only owner of phase ordering. |
-| `ApmInstaller` | `libraries/libeval/src/benchmark/apm-installer.js` (new) | Reads family `apm.yml`/`apm.lock.yml`, materialises declared skills/agents into a per-task temp CWD's `.claude/`. Produces `skillSetHash` (sha256 over `apm.lock.yml` bytes) for the result record. |
-| `WorkdirManager` | `libraries/libeval/src/benchmark/workdir.js` (new) | Per-task: creates a temp CWD, copies `workdir/` and `specs/` into it (never `scoring/`), runs the family-conventional pre-flight smoke probe. Returns a `Workdir` handle threaded through later phases. Also owns final cleanup (`teardown`). |
-| `Scorer` | `libraries/libeval/src/benchmark/scorer.js` (new) | Invokes the task's `scoring/run.sh` from the **template** path with the post-run workdir as `$WORKDIR` and a structured-output channel. Captures NDJSON results and exit-code-derived verdict. Does not interpret semantics. |
-| `Judge` | `libraries/libeval/src/benchmark/judge.js` (new) | Spawns one libeval `AgentRunner` session with `judge.task.md` as the prompt and `{scoringPath, tracePath}` exposed via env. Reads the final `Conclude` summary as `judgeVerdict`. Distinct from the live supervisor. |
-| `PermissionsBroker` | `libraries/libeval/src/benchmark/permissions.js` (new) | Translates METR-aligned permission strings (`"full_internet"`) into `AgentRunner` constructor options (allowed-tools, network policy). Default-deny. |
-| `ResultRecord` | `libraries/libeval/src/benchmark/result.js` (new) | Pure JSON shape per task-run; written one-per-line as JSONL to the run-output directory. |
-| `ReportAggregator` | `libraries/libeval/src/benchmark/report.js` (new) | `report` subcommand backend. Walks a run directory, groups records by `taskId`, computes pass@k, totals cost and turns. |
+| `fit-benchmark` CLI | `libraries/libeval/bin/fit-benchmark.js` (new) | Entry point. Parses subcommand (`run`/`score`/`report`), wires real dependencies, delegates to the matching command handler. Mirrors `bin/fit-eval.js` shape. Same `@forwardimpact/libeval` package; separate bin. |
+| `BenchmarkRunner` | `libraries/libeval/src/benchmark/runner.js` (new) | Sole orchestrator. Owns phase ordering for a family run: invokes `install` once, then drives each `(task, runIndex)` through the lifecycle by directly calling the named subsystems. Composes libeval primitives. Emits `ResultRecord`s as an async iterable. There is no separate `LifecycleDriver` — the runner is the driver. |
+| `TaskFamily` | `libraries/libeval/src/benchmark/task-family.js` (new) | Loaded family: `rootPath`, `apm.lock.yaml` bytes, `familyRevision`, iterable of `Task`. Loaded once at family `install`; immutable thereafter. |
+| `Task` | same module | One task: `id` = METR-style `task_family_name/task_name`, paths to `instructions.md`, `supervisor.task.md`, `judge.task.md`, `specs/`, `workdir/`, `scoring/`; declared `permissions` array. |
+| `ApmInstaller` | `libraries/libeval/src/benchmark/apm-installer.js` (new) | Reads family `apm.yaml`/`apm.lock.yaml` (extensions match libpack at `libraries/libpack/src/stager.js:126`), materialises declared skills/agents into a per-task temp CWD's `.claude/`. Produces `skillSetHash` (sha256 over `apm.lock.yaml` bytes after LF normalisation — prevents cross-OS hash drift). |
+| `WorkdirManager` | `libraries/libeval/src/benchmark/workdir.js` (new) | Per-task: creates a temp CWD, copies `workdir/` and `specs/` into it (never `scoring/`), runs the pre-flight smoke probe, owns process-group cleanup at teardown (port free, processes reaped via process-group SIGTERM then SIGKILL after a 5 s grace). |
+| `Scorer` | `libraries/libeval/src/benchmark/scorer.js` (new) | Invokes `<template>/tasks/<task>/scoring/run.sh` from the **template** path with `$WORKDIR` = post-run agent CWD, `$RESULTS_FD` = a captured file descriptor receiving NDJSON `{ test, pass, message? }` rows. Returns `{ verdict, details, exitCode }`; `verdict` derived from exit code (`0` → `pass`, non-zero → `fail`). |
+| `Judge` | `libraries/libeval/src/benchmark/judge.js` (new) | Wraps a libeval `Supervisor` over a single `AgentRunner`. Supervisor task = the family's `judge.task.md`; agent task = a structured "produce a verdict" prompt with `scoringPath` and `tracePath` exposed via env. The supervisor's `Conclude` summary becomes `judgeVerdict`. A bare `AgentRunner` cannot emit `Conclude` (registered only on supervisor/facilitator tool servers — `orchestration-toolkit.js:207,283`); the wrapper is required. |
+| `PermissionsBroker` | `libraries/libeval/src/benchmark/permissions.js` (new) | Translates METR-aligned permission strings into `AgentRunner` `allowedTools`/`disallowedTools` only. v1 closed set: `["full_internet"]`. Mapping: `"full_internet"` → include `WebFetch`; absent → exclude `WebFetch` and apply a Bash command-prefix disallowlist (`curl`, `wget`, `nc`, `ssh`). OS-level network gating is the deferred containerised-isolation work. |
+| `ResultRecord` | `libraries/libeval/src/benchmark/result.js` (new) | JSON shape per task-run, written one-per-line as JSONL to `<run-output>/results.jsonl`. Schema declared in § Result-record schema below; the same schema is consumed by `ReportAggregator` and exposed for fixture validation. |
+| `ReportAggregator` | `libraries/libeval/src/benchmark/report.js` (new) | `report` subcommand backend. Walks a run directory, groups records by `taskId`, computes pass@k via OpenAI HumanEval `1 - C(n-c, k) / C(n, k)`. |
 | Subcommand handlers | `libraries/libeval/src/commands/benchmark-{run,score,report}.js` (new) | Parse CLI args, validate paths, build `BenchmarkRunner` or `ReportAggregator`, write output. Mirrors existing `commands/run.js` shape. |
-| `fit-benchmark` skill | `.claude/skills/fit-benchmark/SKILL.md` (new) | User-facing skill matching the published CLI per the parity rule in `.claude/skills/CLAUDE.md`. |
 
 ## Component graph
 
@@ -26,23 +24,84 @@ graph TD
   CLI[fit-benchmark CLI] --> CMD[run / score / report handlers]
   CMD --> BR[BenchmarkRunner]
   BR --> TF[TaskFamily]
-  BR --> LD[LifecycleDriver]
-  LD --> AI[ApmInstaller]
-  LD --> WM[WorkdirManager]
-  LD --> SV[libeval Supervisor]
-  LD --> SC[Scorer]
-  LD --> JD[Judge]
-  SV --> AR[libeval AgentRunner]
-  JD --> AR
-  AR --> TC[libeval TraceCollector]
+  BR --> AI[ApmInstaller]
+  BR --> WM[WorkdirManager]
+  BR --> SV1[libeval Supervisor: live]
+  BR --> SC[Scorer]
+  BR --> JD[Judge]
+  BR --> PB[PermissionsBroker]
+  SV1 --> AR1[AgentRunner: agent under test]
+  JD --> SV2[libeval Supervisor: judge]
+  SV2 --> AR2[AgentRunner: judge agent]
+  AR1 --> TC[libeval TraceCollector]
   WM -. "scoring/ stays in template" .-> SC
-  SC --> RR[ResultRecord JSONL]
+  PB --> AR1
+  SC --> RR[results.jsonl]
   JD --> RR
   CMD --> RA[ReportAggregator]
   RA --> RR
-  LD --> PB[PermissionsBroker]
-  PB --> AR
 ```
+
+## Lifecycle sequence
+
+```mermaid
+sequenceDiagram
+  participant CLI as fit-benchmark run
+  participant BR as BenchmarkRunner
+  participant WM as WorkdirManager
+  participant AR as Supervisor+AgentRunner
+  participant SC as Scorer
+  participant JD as Judge
+  CLI->>BR: family + runs=N
+  BR->>BR: install(family)
+  loop task × runIndex
+    BR->>WM: start(task, i)
+    WM-->>BR: Workdir (workdir/+specs/ copied; scoring/ excluded)
+    BR->>AR: runAgent(task, workdir)
+    AR-->>BR: tracePath, submission
+    BR->>SC: score(task, workdir)
+    SC-->>BR: { verdict, details, exitCode }
+    BR->>JD: judge(scoring, trace)
+    JD-->>BR: judge verdict
+    BR->>WM: teardown(workdir)
+    BR-->>CLI: ResultRecord (JSONL append)
+  end
+```
+
+## Result-record schema
+
+| Field | Type | Notes |
+|---|---|---|
+| `taskId` | string | `task_family_name/task_name` (METR-style) |
+| `runIndex` | integer | 0-based |
+| `verdict` | `"pass" \| "fail"` | combined gate: pass iff `scoring.verdict === "pass"` AND `judgeVerdict.verdict === "pass"` |
+| `scoring` | `{ verdict, details, exitCode }` | nested; `details` is the parsed NDJSON from `$RESULTS_FD` |
+| `submission` | string | METR `submission` — the agent's final assistant text |
+| `judgeVerdict` | `{ verdict, summary }` | from the judge supervisor's `Conclude` call |
+| `costUsd` | number | total agent cost from the trace |
+| `turns` | integer | total turns from the trace |
+| `tracePath` | string | absolute path to the run-output NDJSON trace |
+| `profiles` | `{ agent, supervisor, judge }` | profile names used for each role |
+| `model` | string | model id (e.g. `claude-opus-4-7`) |
+| `skillSetHash` | string | `sha256:` over `apm.lock.yaml` bytes after LF normalisation |
+| `familyRevision` | string | git SHA when family is sourced from a repo, else `sha256:` per algorithm below |
+| `permissions` | `string[]` | METR permission strings; v1 closed set: `["full_internet"]` |
+| `durationMs` | integer | wall-clock from `start` to `teardown` |
+
+`familyRevision` for non-git families: list tracked files (`tasks/**`,
+`apm.yaml`, `apm.lock.yaml`, root scaffolding), sort by relative path, hash
+each file with sha256, concatenate `<path>\0<sha256-hex>\n` rows in order,
+sha256 the concatenation, prefix `sha256:`.
+
+## Pre-flight contract
+
+Each task's `workdir/scripts/preflight.sh` (executable) is invoked by
+`WorkdirManager` after the copy step. Exit `0` = scaffolding boots; non-zero
+= broken template. If the file is absent, the harness boots the scaffold via
+`npm run start` (resolved from `workdir/package.json`) with `$PORT` set, polls
+`http://localhost:$PORT/health` for up to 30 s, and treats a 2xx response as
+success. Either path failing surfaces as a structured `preflightError` field
+on the result record with `costUsd: 0`.
 
 ## Interfaces
 
@@ -55,105 +114,51 @@ class BenchmarkRunner {
 
 // task-family.js
 loadTaskFamily(rootPathOrGitUrl): Promise<TaskFamily>
-TaskFamily: { rootPath, familySha, apmLockBytes, tasks(): Iterable<Task> }
+TaskFamily: { rootPath, familyRevision, apmLockBytes, tasks(): Iterable<Task> }
 Task: {
-  id,                          // "task_family/task_name"
+  id,                            // "task_family_name/task_name"
   paths: { instructions, supervisor, judge, specs, workdir, scoring },
-  permissions: string[],       // METR vocabulary; default []
-}
-
-// lifecycle.js
-class LifecycleDriver {
-  async install(family): Promise<InstallContext>;
-  async start(task, runIndex, ctx): Promise<Workdir>;
-  async runAgent(task, workdir, ctx): Promise<{ tracePath, submission }>;
-  async score(task, workdir, ctx): Promise<ScoringResult>;
-  async judge(task, scoring, trace, ctx): Promise<JudgeVerdict>;
-  async teardown(workdir, ctx): Promise<void>;
+  permissions: string[],         // v1 closed set: ["full_internet"]
 }
 
 // scorer.js
 runScoring(task, workdir): Promise<{
   verdict: "pass" | "fail",
-  details: object[],     // NDJSON parsed
+  details: object[],             // NDJSON parsed from $RESULTS_FD
   exitCode: number,
 }>
-
-// result.js
-ResultRecord: {
-  taskId, runIndex,
-  verdict,                                  // pass|fail (combined gate)
-  scoring: { verdict, details, exitCode },
-  submission,                               // METR: agent's final string
-  judgeVerdict: { verdict, summary },
-  costUsd, turns, tracePath,
-  profiles: { agent, supervisor, judge },
-  model, skillSetHash, familySha,
-  permissions, durationMs,
-}
-```
-
-`runAgent` runs a libeval `Supervisor` over an `AgentRunner` against the
-task's `instructions.md` (agent prompt) and `supervisor.task.md` (supervisor
-prompt). Final assistant text is captured as `submission` (METR vocabulary).
-
-## Lifecycle sequence
-
-```mermaid
-sequenceDiagram
-  participant CLI as fit-benchmark run
-  participant BR as BenchmarkRunner
-  participant LD as LifecycleDriver
-  participant AR as AgentRunner+Supervisor
-  participant SC as Scorer
-  participant JD as Judge
-  CLI->>BR: family + runs=N
-  BR->>LD: install(family)
-  loop task × runIndex
-    BR->>LD: start(task, i)
-    LD-->>BR: Workdir (workdir/+specs/ copied; scoring/ excluded)
-    BR->>AR: runAgent(task, workdir)
-    AR-->>BR: tracePath, submission
-    BR->>SC: score(task, workdir)
-    SC-->>BR: scoring result
-    BR->>JD: judge(task, scoring, trace)
-    JD-->>BR: judge verdict
-    BR->>LD: teardown(workdir)
-    BR-->>CLI: ResultRecord (JSONL append)
-  end
 ```
 
 ## Key Decisions
 
 | # | Decision | Rejected alternative | Why |
 | --- | --- | --- | --- |
-| 1 | New CLI `fit-benchmark` rather than a `fit-eval bench` subcommand. | Add `bench` to `fit-eval`. | Keeps `fit-eval` a low-level generic tool with stable surface. The benchmark layer carries opinionated semantics (lifecycle, scoring, judge, aggregation) that don't belong in the generic CLI. Independent versioning is also valuable — benchmark-format breaking changes shouldn't bump `fit-eval`. |
-| 2 | Adopt METR task-standard vocabulary (`task family`, `instructions`, `permissions`, hook names `install`/`start`/`score`/`teardown`, METR-style `task_family/task_name` ids, `submission`). | Invent monorepo-specific names. | Portability — METR's standard is in production at the UK AISI and other orgs. Borrowing the vocabulary lets the format absorb existing METR families and lets ours flow outward without renaming. The cost is one constraint on naming. |
-| 3 | Hidden `scoring/` directory lives only in the template; never copied into the agent's CWD. The Scorer invokes scripts from the **template** path with the post-run workdir as an argument. | Copy `scoring/` to a sibling dir in the temp CWD; rely on the supervisor to keep the agent away. | Structural beats procedural. If `scoring/` is never on disk in the agent's CWD, peeking is impossible. Reviewers cannot weaken the property without changing `WorkdirManager` itself; the supervisor cannot regress it. |
-| 4 | Skill set under test declared at family root via `apm.yml`/`apm.lock.yml`; reproducibility hash is sha256 over `apm.lock.yml` bytes. | Per-task skill declarations; or runtime-detected from the host repo. | Family-level declaration matches the unit of measurement (skills are evaluated as a set). Lockfile-based hashing makes "same skill set" a verifiable property of the result record without resolving versions at report time. Per-task duplication would be noisy and easy to drift. |
-| 5 | Compose libeval primitives (`AgentRunner`, `Supervisor`, `TraceCollector`, `MessageBus`); do not fork or wrap. | New `BenchmarkAgentRunner` subclass with benchmark-specific behaviour. | One source of truth for agent execution. Behaviour changes in libeval (redaction, profiles, trace shape) flow through automatically. Composition leaves the benchmark layer focused on lifecycle and scoring. |
-| 6 | Outside-in test surface only in v1 (HTTP probes, file existence, exit codes). | Library-import probes; CLI subprocess probes. | The contract is enforced by skills under test (the agent learns to start an HTTP service via the skill being evaluated). HTTP-only keeps scaffolding simple and the contract surface narrow; other surfaces are mechanically straightforward to add later when a concrete task needs them. |
-| 7 | Judge runs as a separate libeval session (`AgentRunner` only) after scoring. | Reuse the live supervisor as the judge. | The supervisor's job during the run is to help the agent finish; using it to also grade conflicts those incentives. A fresh judge sees trace and scoring as artifacts and issues an independent verdict. The cost is one extra session per task-run; the gain is role-separation. |
-| 8 | METR-aligned permissions: default empty; `permissions: ["full_internet"]` opts in to network. | Per-monorepo permission vocabulary, or default-on internet. | Portability with METR families. Default-deny matches the "fresh engineer in a sandboxed env" mental model and prevents the agent from incidentally using paid APIs or external services to game tests. |
-| 9 | One result record per task-run, JSONL-appended to the run-output directory. | One aggregated JSON per run. | Append-only writes survive partial failures and concurrent runs. The aggregator can be re-run cheaply. JSON-per-record makes individual results easy to grep and diff. |
-| 10 | Pre-flight smoke probe runs unmodified `workdir/` before the agent starts. | Skip pre-flight; trust template authors. | Template breakage and harness breakage look identical from the result record. Catching it before agent cost is spent makes failures attributable and avoids spending tokens on a broken scaffold. |
+| 1 | Separate CLI `fit-benchmark` rather than a `fit-eval bench` subcommand. Same package. | Add `bench` to `fit-eval`. | Keeps `fit-eval` a low-level generic tool with stable surface. The benchmark layer carries opinionated semantics (lifecycle, scoring, judge, aggregation) that don't belong in the generic CLI. |
+| 2 | Adopt METR task-standard vocabulary (`task family`, `instructions`, `permissions`, lifecycle hook names, `submission`, `task_family_name/task_name` ids). | Invent monorepo-specific names. | Portability — METR's standard is in production at multiple orgs. Vocabulary alignment lets the format absorb existing METR families and lets ours flow outward without renaming. |
+| 3 | Hidden `scoring/` directory lives only in the template; never copied into the agent's CWD. The Scorer invokes scripts from the template path with `$WORKDIR` as an argument. | Copy `scoring/` to a sibling dir in the temp CWD; rely on the supervisor to keep the agent away. | Structural beats procedural. If `scoring/` is never on disk in the agent's CWD, peeking is impossible. |
+| 4 | Skill-set lockfile at family root is `apm.lock.yaml` (matching libpack); `skillSetHash` is sha256 over its bytes after LF normalisation. | `apm.lock.yml`; raw byte hash without normalisation. | `.yaml` matches `libraries/libpack/src/stager.js:126`; `.yml` would silently miss the file. LF normalisation prevents Windows/Unix CRLF flipping the hash on the same lockfile. |
+| 5 | Compose libeval primitives (`AgentRunner`, `Supervisor`, `TraceCollector`); do not fork. | New `BenchmarkAgentRunner` subclass. | One source of truth for agent execution; libeval improvements (redaction, profiles, trace shape) flow through automatically. |
+| 6 | `BenchmarkRunner` is the sole orchestrator. No separate `LifecycleDriver`. | Two-tier orchestrator with `LifecycleDriver` wrapping phases. | Fewer indirection layers; phase ordering lives in one place. v1 has one orchestrator shape. |
+| 7 | Judge runs through a libeval `Supervisor` over a single `AgentRunner` — not a bare `AgentRunner`. | Bare `AgentRunner` parsing final assistant text; reuse the live supervisor. | `Conclude` is registered only on supervisor/facilitator tool servers (`orchestration-toolkit.js:207,283`); a bare `AgentRunner` cannot emit it. Reusing the live supervisor conflates help-incentives with grade-incentives. |
+| 8 | Permissions enforced by `AgentRunner` `allowedTools`/`disallowedTools` only. v1 closed set: `["full_internet"]`. | OS-level network gating; per-monorepo permission vocabulary; default-on internet. | `AgentRunner` exposes only tool allow/deny; OS-level gating is the deferred containerised-isolation work. Default-deny aligns with METR. |
+| 9 | One result record per task-run, JSONL-appended to `<run-output>/results.jsonl`. | Aggregated JSON per run. | Append-only writes survive partial failures and concurrent runs. Per-record format makes individual results easy to grep and diff. |
+| 10 | `familyRevision` is the git SHA when the family is a git repo, else the canonical sorted-tree hash defined above. | Always content-hash; always require git. | Git source is the cheap common path; non-git is a real local-development case the harness must support, with a defined hash algorithm. |
+| 11 | Pre-flight contract: `workdir/scripts/preflight.sh` if present, else default `npm run start` + HTTP 2xx on `/health`. | Require every task to provide its own probe; or skip pre-flight. | A default keeps simple HTTP-service tasks zero-config; the override hook supports anything else. Skipping pre-flight makes broken-template failures attributable to the agent. |
 
 ## Test surfaces
 
-The design names two surfaces; the plan picks the layering.
+The design names two surfaces; the plan picks the layering and fixture composition.
 
 | Surface | What it covers |
 | --- | --- |
-| `benchmark/*.js` unit | `WorkdirManager` excludes `scoring/` (criterion: scoring isolation). `ApmInstaller` produces stable `skillSetHash`. `Scorer` parses NDJSON output and exit codes correctly. `PermissionsBroker` maps METR strings to libeval options. `ReportAggregator` computes pass@k from a fixture record set. |
-| End-to-end fixture | A minimal task family (`fixtures/task-family/`) with two tasks: one passing, one failing. Stub agent (a deterministic libeval `AgentRunner` mock) drives the full lifecycle; assertions cover record schema, scoring isolation (sentinel filename never appears in trace), pre-flight failure path, network policy enforcement, and JSONL append integrity. |
+| `benchmark/*.js` unit | `WorkdirManager` excludes `scoring/` from the copy. `ApmInstaller` produces a stable `skillSetHash` across runs and changes on a one-byte lockfile edit. `Scorer` parses `$RESULTS_FD` NDJSON and exit codes. `PermissionsBroker` maps METR strings to `allowedTools`/`disallowedTools`. `ReportAggregator` computes pass@k. |
+| End-to-end fixture | A minimal task family driving the full lifecycle, asserting result-record schema validation, scoring isolation (sentinel-filename property), pre-flight failure path, network-policy enforcement, and JSONL append integrity. |
 
 ## Out of scope (carried from spec)
 
 Containerised isolation, library/CLI test surfaces beyond HTTP, cross-model
 leaderboards, live PR-gate integration, retroactive grading of historical
 traces, family-level cost caps, replay-from-trace, and intermediate scoring
-are unchanged from spec § Out of scope, deferred. The lifecycle and scoring
-surface alone gives Platform Builders reproducible coding-agent evaluation;
-the deferred items remain worthwhile but separable.
+are unchanged from spec § Out of scope, deferred.
 
 — Staff Engineer 🛠️

--- a/specs/870-fit-benchmark-coding-tasks/design-a.md
+++ b/specs/870-fit-benchmark-coding-tasks/design-a.md
@@ -1,0 +1,159 @@
+# Design 870-a — fit-benchmark Coding Agent Task Families
+
+## Components
+
+| Component | Where | Role |
+| --- | --- | --- |
+| `fit-benchmark` CLI | `libraries/libeval/bin/fit-benchmark.js` (new) | Entry point. Parses subcommand (`run`/`score`/`report`), wires real dependencies, delegates to the matching command handler. Mirrors `bin/fit-eval.js` shape for parity. |
+| `BenchmarkRunner` | `libraries/libeval/src/benchmark/runner.js` (new) | Orchestrates a family run: `install` once, then for each `task × runIndex` drive the lifecycle. Composes libeval primitives rather than wrapping them. Emits `ResultRecord`s as an async iterable. |
+| `TaskFamily` | `libraries/libeval/src/benchmark/task-family.js` (new) | In-memory representation of a loaded family: `rootPath`, `apm.lock.yml` content, `familySha` (git SHA when sourced from a repo, else content hash of the family root), iterable of `Task`. Loaded once at family `install`; immutable thereafter. |
+| `Task` | same module | One task: `id` (METR-style `task_family/task_name`), paths to `instructions.md`, `supervisor.task.md`, `judge.task.md`, `specs/`, `workdir/`, `scoring/`; declared `permissions`. |
+| `LifecycleDriver` | `libraries/libeval/src/benchmark/lifecycle.js` (new) | Sequences the per-task hooks (`start`, run, `score`, `judge`, `teardown`) with explicit per-phase error boundaries. Hook names borrowed from METR's `TaskFamily` to keep the format portable. The driver is the only owner of phase ordering. |
+| `ApmInstaller` | `libraries/libeval/src/benchmark/apm-installer.js` (new) | Reads family `apm.yml`/`apm.lock.yml`, materialises declared skills/agents into a per-task temp CWD's `.claude/`. Produces `skillSetHash` (sha256 over `apm.lock.yml` bytes) for the result record. |
+| `WorkdirManager` | `libraries/libeval/src/benchmark/workdir.js` (new) | Per-task: creates a temp CWD, copies `workdir/` and `specs/` into it (never `scoring/`), runs the family-conventional pre-flight smoke probe. Returns a `Workdir` handle threaded through later phases. Also owns final cleanup (`teardown`). |
+| `Scorer` | `libraries/libeval/src/benchmark/scorer.js` (new) | Invokes the task's `scoring/run.sh` from the **template** path with the post-run workdir as `$WORKDIR` and a structured-output channel. Captures NDJSON results and exit-code-derived verdict. Does not interpret semantics. |
+| `Judge` | `libraries/libeval/src/benchmark/judge.js` (new) | Spawns one libeval `AgentRunner` session with `judge.task.md` as the prompt and `{scoringPath, tracePath}` exposed via env. Reads the final `Conclude` summary as `judgeVerdict`. Distinct from the live supervisor. |
+| `PermissionsBroker` | `libraries/libeval/src/benchmark/permissions.js` (new) | Translates METR-aligned permission strings (`"full_internet"`) into `AgentRunner` constructor options (allowed-tools, network policy). Default-deny. |
+| `ResultRecord` | `libraries/libeval/src/benchmark/result.js` (new) | Pure JSON shape per task-run; written one-per-line as JSONL to the run-output directory. |
+| `ReportAggregator` | `libraries/libeval/src/benchmark/report.js` (new) | `report` subcommand backend. Walks a run directory, groups records by `taskId`, computes pass@k, totals cost and turns. |
+| Subcommand handlers | `libraries/libeval/src/commands/benchmark-{run,score,report}.js` (new) | Parse CLI args, validate paths, build `BenchmarkRunner` or `ReportAggregator`, write output. Mirrors existing `commands/run.js` shape. |
+| `fit-benchmark` skill | `.claude/skills/fit-benchmark/SKILL.md` (new) | User-facing skill matching the published CLI per the parity rule in `.claude/skills/CLAUDE.md`. |
+
+## Component graph
+
+```mermaid
+graph TD
+  CLI[fit-benchmark CLI] --> CMD[run / score / report handlers]
+  CMD --> BR[BenchmarkRunner]
+  BR --> TF[TaskFamily]
+  BR --> LD[LifecycleDriver]
+  LD --> AI[ApmInstaller]
+  LD --> WM[WorkdirManager]
+  LD --> SV[libeval Supervisor]
+  LD --> SC[Scorer]
+  LD --> JD[Judge]
+  SV --> AR[libeval AgentRunner]
+  JD --> AR
+  AR --> TC[libeval TraceCollector]
+  WM -. "scoring/ stays in template" .-> SC
+  SC --> RR[ResultRecord JSONL]
+  JD --> RR
+  CMD --> RA[ReportAggregator]
+  RA --> RR
+  LD --> PB[PermissionsBroker]
+  PB --> AR
+```
+
+## Interfaces
+
+```js
+// runner.js
+class BenchmarkRunner {
+  constructor({ family, runs, output, model, redactor, ...opts });
+  async *run(): AsyncIterable<ResultRecord>;
+}
+
+// task-family.js
+loadTaskFamily(rootPathOrGitUrl): Promise<TaskFamily>
+TaskFamily: { rootPath, familySha, apmLockBytes, tasks(): Iterable<Task> }
+Task: {
+  id,                          // "task_family/task_name"
+  paths: { instructions, supervisor, judge, specs, workdir, scoring },
+  permissions: string[],       // METR vocabulary; default []
+}
+
+// lifecycle.js
+class LifecycleDriver {
+  async install(family): Promise<InstallContext>;
+  async start(task, runIndex, ctx): Promise<Workdir>;
+  async runAgent(task, workdir, ctx): Promise<{ tracePath, submission }>;
+  async score(task, workdir, ctx): Promise<ScoringResult>;
+  async judge(task, scoring, trace, ctx): Promise<JudgeVerdict>;
+  async teardown(workdir, ctx): Promise<void>;
+}
+
+// scorer.js
+runScoring(task, workdir): Promise<{
+  verdict: "pass" | "fail",
+  details: object[],     // NDJSON parsed
+  exitCode: number,
+}>
+
+// result.js
+ResultRecord: {
+  taskId, runIndex,
+  verdict,                                  // pass|fail (combined gate)
+  scoring: { verdict, details, exitCode },
+  submission,                               // METR: agent's final string
+  judgeVerdict: { verdict, summary },
+  costUsd, turns, tracePath,
+  profiles: { agent, supervisor, judge },
+  model, skillSetHash, familySha,
+  permissions, durationMs,
+}
+```
+
+`runAgent` runs a libeval `Supervisor` over an `AgentRunner` against the
+task's `instructions.md` (agent prompt) and `supervisor.task.md` (supervisor
+prompt). Final assistant text is captured as `submission` (METR vocabulary).
+
+## Lifecycle sequence
+
+```mermaid
+sequenceDiagram
+  participant CLI as fit-benchmark run
+  participant BR as BenchmarkRunner
+  participant LD as LifecycleDriver
+  participant AR as AgentRunner+Supervisor
+  participant SC as Scorer
+  participant JD as Judge
+  CLI->>BR: family + runs=N
+  BR->>LD: install(family)
+  loop task × runIndex
+    BR->>LD: start(task, i)
+    LD-->>BR: Workdir (workdir/+specs/ copied; scoring/ excluded)
+    BR->>AR: runAgent(task, workdir)
+    AR-->>BR: tracePath, submission
+    BR->>SC: score(task, workdir)
+    SC-->>BR: scoring result
+    BR->>JD: judge(task, scoring, trace)
+    JD-->>BR: judge verdict
+    BR->>LD: teardown(workdir)
+    BR-->>CLI: ResultRecord (JSONL append)
+  end
+```
+
+## Key Decisions
+
+| # | Decision | Rejected alternative | Why |
+| --- | --- | --- | --- |
+| 1 | New CLI `fit-benchmark` rather than a `fit-eval bench` subcommand. | Add `bench` to `fit-eval`. | Keeps `fit-eval` a low-level generic tool with stable surface. The benchmark layer carries opinionated semantics (lifecycle, scoring, judge, aggregation) that don't belong in the generic CLI. Independent versioning is also valuable — benchmark-format breaking changes shouldn't bump `fit-eval`. |
+| 2 | Adopt METR task-standard vocabulary (`task family`, `instructions`, `permissions`, hook names `install`/`start`/`score`/`teardown`, METR-style `task_family/task_name` ids, `submission`). | Invent monorepo-specific names. | Portability — METR's standard is in production at the UK AISI and other orgs. Borrowing the vocabulary lets the format absorb existing METR families and lets ours flow outward without renaming. The cost is one constraint on naming. |
+| 3 | Hidden `scoring/` directory lives only in the template; never copied into the agent's CWD. The Scorer invokes scripts from the **template** path with the post-run workdir as an argument. | Copy `scoring/` to a sibling dir in the temp CWD; rely on the supervisor to keep the agent away. | Structural beats procedural. If `scoring/` is never on disk in the agent's CWD, peeking is impossible. Reviewers cannot weaken the property without changing `WorkdirManager` itself; the supervisor cannot regress it. |
+| 4 | Skill set under test declared at family root via `apm.yml`/`apm.lock.yml`; reproducibility hash is sha256 over `apm.lock.yml` bytes. | Per-task skill declarations; or runtime-detected from the host repo. | Family-level declaration matches the unit of measurement (skills are evaluated as a set). Lockfile-based hashing makes "same skill set" a verifiable property of the result record without resolving versions at report time. Per-task duplication would be noisy and easy to drift. |
+| 5 | Compose libeval primitives (`AgentRunner`, `Supervisor`, `TraceCollector`, `MessageBus`); do not fork or wrap. | New `BenchmarkAgentRunner` subclass with benchmark-specific behaviour. | One source of truth for agent execution. Behaviour changes in libeval (redaction, profiles, trace shape) flow through automatically. Composition leaves the benchmark layer focused on lifecycle and scoring. |
+| 6 | Outside-in test surface only in v1 (HTTP probes, file existence, exit codes). | Library-import probes; CLI subprocess probes. | The contract is enforced by skills under test (the agent learns to start an HTTP service via the skill being evaluated). HTTP-only keeps scaffolding simple and the contract surface narrow; other surfaces are mechanically straightforward to add later when a concrete task needs them. |
+| 7 | Judge runs as a separate libeval session (`AgentRunner` only) after scoring. | Reuse the live supervisor as the judge. | The supervisor's job during the run is to help the agent finish; using it to also grade conflicts those incentives. A fresh judge sees trace and scoring as artifacts and issues an independent verdict. The cost is one extra session per task-run; the gain is role-separation. |
+| 8 | METR-aligned permissions: default empty; `permissions: ["full_internet"]` opts in to network. | Per-monorepo permission vocabulary, or default-on internet. | Portability with METR families. Default-deny matches the "fresh engineer in a sandboxed env" mental model and prevents the agent from incidentally using paid APIs or external services to game tests. |
+| 9 | One result record per task-run, JSONL-appended to the run-output directory. | One aggregated JSON per run. | Append-only writes survive partial failures and concurrent runs. The aggregator can be re-run cheaply. JSON-per-record makes individual results easy to grep and diff. |
+| 10 | Pre-flight smoke probe runs unmodified `workdir/` before the agent starts. | Skip pre-flight; trust template authors. | Template breakage and harness breakage look identical from the result record. Catching it before agent cost is spent makes failures attributable and avoids spending tokens on a broken scaffold. |
+
+## Test surfaces
+
+The design names two surfaces; the plan picks the layering.
+
+| Surface | What it covers |
+| --- | --- |
+| `benchmark/*.js` unit | `WorkdirManager` excludes `scoring/` (criterion: scoring isolation). `ApmInstaller` produces stable `skillSetHash`. `Scorer` parses NDJSON output and exit codes correctly. `PermissionsBroker` maps METR strings to libeval options. `ReportAggregator` computes pass@k from a fixture record set. |
+| End-to-end fixture | A minimal task family (`fixtures/task-family/`) with two tasks: one passing, one failing. Stub agent (a deterministic libeval `AgentRunner` mock) drives the full lifecycle; assertions cover record schema, scoring isolation (sentinel filename never appears in trace), pre-flight failure path, network policy enforcement, and JSONL append integrity. |
+
+## Out of scope (carried from spec)
+
+Containerised isolation, library/CLI test surfaces beyond HTTP, cross-model
+leaderboards, live PR-gate integration, retroactive grading of historical
+traces, family-level cost caps, replay-from-trace, and intermediate scoring
+are unchanged from spec § Out of scope, deferred. The lifecycle and scoring
+surface alone gives Platform Builders reproducible coding-agent evaluation;
+the deferred items remain worthwhile but separable.
+
+— Staff Engineer 🛠️

--- a/specs/870-fit-benchmark-coding-tasks/spec.md
+++ b/specs/870-fit-benchmark-coding-tasks/spec.md
@@ -12,8 +12,8 @@ better at writing code?
 Three things are missing from the current `libeval` surface:
 
 1. **A reusable task layout.** Each scenario today encodes its own conventions
-   for task file location, working-directory contents, and grading. There is no
-   standard "this is a coding task" structure that can be cloned, run, and
+   for task file location, working-directory contents, and grading. There is
+   no standard "this is a coding task" structure that can be cloned, run, and
    graded reproducibly across runs and across skill-set versions.
 
 2. **A grading pass the agent cannot see.** When the agent is told to "build a
@@ -26,34 +26,34 @@ Three things are missing from the current `libeval` surface:
    single run is a coin flip. Today there is no mechanism for "run this task
    family multiple times across two skill-pack versions and report pass@k."
 
-The blast radius of the gap is the central JTBD for `libeval`: Platform
+A fourth structural concern motivates an additional decision the design must
+honour: **the live supervisor and the post-hoc grader should not be the same
+agent.** A supervisor whose job during the run is to help the agent finish
+cannot also issue an unbiased verdict. The harness must run the live
+supervisor and the post-hoc judge as separate sessions.
+
+The blast radius of the gap is the central JTBD this surface serves: Platform
 Builders cannot prove whether a skill change improved coding-agent outcomes.
 Skill PRs ship on subjective review.
 
 The METR Task Standard
 ([github.com/METR/task-standard](https://github.com/METR/task-standard))
 provides a vocabulary for portable agent-evaluation tasks (`task family`,
-`task`, `instructions`, `permissions`, lifecycle hook names) that the design
-will adopt. METR's specification expresses each task family as a Python
-`TaskFamily` class; this spec borrows the vocabulary and the lifecycle
-structure but not the Python class format. Vocabulary alignment is the
-portability claim; the file format is a design decision.
-
----
+`task`, `instructions`, `permissions`, lifecycle hook names) the design will
+adopt. Vocabulary alignment is the portability claim; the format the
+vocabulary lands in is a design decision.
 
 ## Personas and Jobs
 
-The harness serves Platform Builders. Their Big Hire is to "prove whether agent
-changes improved outcomes with reproducible evidence" ([JTBD.md](../../JTBD.md)
-§ Platform Builders: Evaluate and Improve Agents); `libeval`/`fit-eval` is the
-surface they hire. Without a reproducible coding-task harness, a skill change
-(e.g., a new `fit-pathway` authoring rule, a `kata-spec` revision) cannot be
-measured as cause-of-effect — skill PRs ship on review impressions. Closing
-this gap is what unblocks the Big Hire. Empowered Engineers running
-skill-equipped agents inherit the benefit downstream but are not the direct
-hire for this spec.
-
----
+The harness serves Platform Builders. Their Big Hire is to "Help me prove
+whether agent changes improved outcomes with reproducible evidence"
+([JTBD.md](../../JTBD.md) § Platform Builders: Evaluate and Improve Agents),
+hired against **Gear** — the umbrella product `libeval`/`fit-eval` ships
+under. Without a reproducible coding-task harness, a skill change (a new
+`fit-pathway` authoring rule, a `kata-spec` revision) cannot be measured as
+cause-of-effect — skill PRs ship on review impressions. Closing this gap is
+what unblocks the Big Hire. Empowered Engineers running skill-equipped agents
+inherit the benefit downstream but are not the direct hire.
 
 ## Scope
 
@@ -61,49 +61,51 @@ hire for this spec.
 
 | Component | What changes |
 |---|---|
-| Benchmark CLI | A new CLI delivered through the same package as `fit-eval` and `fit-trace`, exposing capabilities to execute a task family, re-grade an archived run, and aggregate results across runs. |
-| Task family format | A conventional layout (local path or git remote) for grouping related coding tasks. The format borrows METR Task Standard vocabulary; the on-disk shape is a design decision. |
-| Per-task artifacts | Each task carries: an agent-visible task description, a supervisor prompt for the live run, a judge prompt for the post-hoc evaluator, work specs the agent reads, scaffolding for the agent's working directory, and a hidden grading harness. The grading harness is never copied into the agent's working directory. |
-| Skill set under test | The task family declares the set of skills/agents installed in each task's working directory through a lockfile-style manifest. The manifest is the unit of measurement — different lockfile contents produce comparable result records, with a stable identifier on each record. |
-| Lifecycle | The harness drives a fixed sequence of phases per task: setup, agent execution, scoring, judging, and teardown. The harness pre-flights the unmodified scaffolding before agent execution to catch broken templates without spending agent cost. |
-| Judge phase | A separate evaluator session runs after scoring, consumes the scoring outcome and the agent trace, and emits a final verdict via libeval's `Conclude` tool. The judge is distinct from the live supervisor to keep evaluation incentives separate from helping incentives. |
-| Multi-run aggregation | The harness supports running each task multiple times in one invocation and aggregates pass@k across runs. |
-| Result records | One result record per task per run. Records carry the information needed to compute pass@k, attribute outcomes to a skill-set version, and reproduce a run. The wire schema is fixed in the design and shared by the harness and the report command. |
-| Network policy | Per-task permissions declaration aligned with METR vocabulary. Default deny external network; an explicit opt-in enables it. The enforcement mechanism is a design decision. |
-| Test surface (initial) | v1 supports tasks gradable by HTTP probes against the running app, source-file existence and content checks, and command exit codes. Module-import probes and CLI-subprocess probes are deferred. |
+| Benchmark CLI | A new CLI exposing capabilities to execute a task family, re-grade an archived run, and aggregate results across runs. The CLI's location and packaging are design decisions. |
+| Task family format | A conventional layout (local path or git remote) for grouping related coding tasks. The format borrows METR Task Standard vocabulary and lifecycle structure; the on-disk shape is a design decision. |
+| Per-task content | Each task carries enough material to: prompt the agent, guide a live supervisor, guide a post-hoc judge, anchor the agent in the desired outcome (work specifications), seed the agent's working directory, and grade the agent's output. The grading material is never accessible from the agent's working directory. |
+| Skill set under test | The task family declares the skills/agents installed in each task's working directory through a content-addressable manifest. The manifest is the unit of measurement — different manifest contents produce comparable result records, with a stable identifier on each record. |
+| Lifecycle | The harness drives a fixed sequence of phases per task: setup, agent execution, scoring, judging, and teardown. The harness rejects broken task templates without spending agent cost. |
+| Judge phase | A separate evaluator session runs after scoring, consumes the scoring outcome and the agent trace, and emits a final verdict that the result record records. The judge runs as an independent session from the live supervisor. |
+| Multi-run aggregation | The harness supports running each task multiple times in one invocation and aggregates pass@k across runs per the OpenAI HumanEval convention. |
+| Result records | One result record per task per run. Records carry the information needed to compute pass@k, attribute outcomes to a skill-set version, and reproduce a run. The record schema is a single declared shape shared by the harness and the report command. |
+| Network policy | Per-task permissions declaration aligned with METR vocabulary. Default deny external network; an explicit opt-in enables it. The enforcement mechanism is a design decision. v1 enforcement is best-effort within libeval's existing tool-permission surface; OS-level isolation is the deferred containerised-isolation work. |
+| Test surface (this scope) | The harness grades by three categories of outcome: running-service behaviour (probing the post-run app), repository state (file existence and content checks against the post-run working directory), and process exit (command exit codes). Library-API and CLI-invocation grading are deferred. |
 | Documentation | A user-facing skill matching the published CLI per the skill–CLI parity rule (`.claude/skills/CLAUDE.md`), and a corresponding guide. |
 
 ### Out of scope, deferred
 
 - **Containerised isolation.** Tasks run on the host. Sandboxing via Docker
-  or a VM is a follow-up.
-- **Library/CLI test surfaces.** v1 is HTTP-only.
+  or a VM is a follow-up; v1 network policy is best-effort within tool
+  permissions.
+- **Library-API and CLI-invocation grading.** This scope is HTTP / file
+  state / exit code only.
 - **Cross-model leaderboards.** The result schema supports model comparison;
   rendering that comparison is deferred.
 - **Live PR-gate integration.** The CLI is release-time. Wiring benchmark
-  runs into the `kata-release-merge` gate is a separate spec.
+  runs into automated merge gating is a separate spec.
 - **Retroactive grading of historical fit-eval traces.** New tool, new traces.
-- **Family-level cost-budget enforcement.** Per-task budgets are surfaced
-  from libeval.
+- **Family-level cost-budget enforcement.** Per-task budgets surface from
+  libeval.
 - **Determinism / replay from trace.** Each run is a fresh agent session.
-- **Intermediate scoring.** Only end-of-run scoring in v1.
-
----
+- **Intermediate scoring.** Only end-of-run scoring in this scope.
 
 ## Success Criteria
 
 | Claim | Verification |
 |---|---|
-| The harness clones (or copies) a task family, executes every task in it the configured number of times, and writes one result record per task per run. | Test: a fixture family with two tasks and a run count of two produces four result records and four trace files in the run-output directory; each record references a distinct trace path. |
-| The hidden grading harness for a task is never present in the agent's working directory during the run. | Test: a sentinel filename inside the hidden grading harness is unreadable from the agent's working directory; an end-to-end run with an agent attempting to enumerate the directory tree produces a trace whose lines never contain the sentinel. |
-| Hidden tests run against the post-run agent working directory from the template directory and produce a pass/fail per task. | Test: a fixture task whose grading script HTTP-probes the agent's app on a known port and asserts a JSON shape; with a stub agent producing a passing app, the result record's grading verdict is `"pass"`; with a stub producing a failing app, it is `"fail"`. |
-| The judge phase consumes the scoring outcome and the trace and emits a final verdict via `Conclude`. | Test: a fixture judge prompt referencing scoring results yields a judge-verdict on the result record; a known-bad scoring outcome plus a known-good trace produces `"fail"`. |
-| Tasks declare network permissions and the harness honours them. | Test: a task with default permissions, when the agent attempts to fetch an external URL, produces a tool-result error (request denied or no tool available); a task that opts into external network succeeds in the same scenario. |
-| The skill set under test is reproducible across runs. | Test: two consecutive runs against the same skill-set lockfile produce result records whose skill-set identifier matches; a one-byte change to the lockfile produces a different identifier. |
-| Pre-flight catches broken task templates before the agent runs. | Test: a task whose unmodified scaffolding fails its own start fails at the pre-flight phase with a non-zero exit and a structured error in the result record; the result record's agent cost is zero. |
-| Result aggregation across runs reports pass@k. | Test: the report command, given five runs of the same task with verdicts pass/fail/fail/pass/fail, reports `pass@1 = 2/5` and `pass@3 = 9/10` per the OpenAI HumanEval convention `pass@k = 1 - C(n-c, k)/C(n, k)`. |
+| The harness clones (or copies) a task family, executes every task in it the configured number of times, and writes one result record per task per run. | Test: a fixture family with two tasks and a run count of two produces four result records and four trace files in the run-output directory; each record carries a distinct `(taskId, runIndex)` pair and references an existing, distinct trace file. |
+| The grading material for a task is never present in the agent's working directory during the run. | Test: a sentinel filename inside the grading material is unreadable from the agent's working directory; an end-to-end run with an agent attempting to enumerate the directory tree produces a trace whose lines never contain the sentinel. |
+| Hidden grading runs against the post-run agent working directory and produces a pass/fail per task via the running-service surface. | Test: a fixture task whose grading script HTTP-probes the agent's app on a known port and asserts a JSON shape; with a stub agent producing a passing app, the result record's grading verdict is pass; with a stub producing a failing app, it is fail. |
+| Hidden grading produces a pass/fail per task via the repository-state surface. | Test: a fixture task whose grading script asserts the existence and SHA-256 content of one or more files under the post-run working directory; a stub agent meeting the assertions produces a passing record; one missing the file produces a failing record. |
+| Hidden grading produces a pass/fail per task via the process-exit surface. | Test: a fixture task whose grading script invokes a command in the post-run working directory and treats exit-zero as pass; the result record's grading verdict tracks the command's exit code. |
+| The judge phase consumes the scoring outcome and the agent trace and emits a final verdict that the result record records. | Test: a fixture judge prompt referencing scoring results yields a judge-verdict on the result record; a known-bad scoring outcome plus a known-good trace produces a failing verdict. |
+| Tasks declare network permissions and the harness honours them through the v1 enforcement mechanism named in the design. | Test: a task with default permissions, when the agent attempts to fetch an external URL through libeval's tool surface, produces a tool-result error; a task that opts in succeeds in the same scenario. (Bash-shell egress bypasses are a known v1 limitation; closing them is the deferred isolation work.) |
+| The skill set under test is reproducible across runs. | Test: two consecutive runs against the same skill-set manifest produce result records whose skill-set identifier matches; a one-byte content change to the manifest produces a different identifier. |
+| Pre-flight catches broken task templates before the agent runs. | Test: a task whose unmodified scaffolding fails its own start fails before agent execution with a non-zero exit and a structured error in the result record; the result record's agent cost is zero. |
+| Result aggregation across runs reports pass@k per the OpenAI HumanEval convention. | Test: the report command, given five runs of the same task with verdicts pass/fail/fail/pass/fail, reports `pass@1 = 0.4` and `pass@3 = 0.9`; the formula is documented in the design. |
 | Teardown leaves no dangling processes or occupied ports. | Test: after a task that starts an HTTP server on a known port, the port is free and no child of the harness PID remains. |
 | The harness produces NDJSON traces in the format consumed by `fit-trace`. | Test: a trace from a benchmark run is accepted by `fit-trace overview` without errors; turn count matches between the source NDJSON and `fit-trace`'s output. |
-| The result-record schema is fixed in the design and validated at write time. | Test: each result record validates against the schema declared in `design-a.md` § Result-record schema; the schema lives in one place and is referenced by both the harness and the report command. |
+| Result records share a single declared schema validated at write time. | Test: every record produced by the harness validates against the record's runtime schema validator; the report command validates inputs against the same validator and rejects records that fail. |
 
 — Staff Engineer 🛠️

--- a/specs/870-fit-benchmark-coding-tasks/spec.md
+++ b/specs/870-fit-benchmark-coding-tasks/spec.md
@@ -20,30 +20,38 @@ Three things are missing from the current `libeval` surface:
    TODO API matching the spec," tests written by the agent during the session
    are not independent verification — they grade themselves. Reproducible
    evaluation needs fail-to-pass tests that ship with the task and never enter
-   the agent's CWD.
+   the agent's working directory.
 
 3. **Aggregation across runs and tasks.** LLM output is non-deterministic. A
    single run is a coin flip. Today there is no mechanism for "run this task
-   family three times across these two skill-pack versions and report pass@k."
+   family multiple times across two skill-pack versions and report pass@k."
 
 The blast radius of the gap is the central JTBD for `libeval`: Platform
 Builders cannot prove whether a skill change improved coding-agent outcomes.
 Skill PRs ship on subjective review.
 
 The METR Task Standard
-([github.com/METR/task-standard](https://github.com/METR/task-standard)) is a
-production format for portable agent-evaluation tasks (over 1,000 tasks across
-AI R&D, cybersecurity, and general autonomy; in use at the UK AI Safety
-Institute). Adopting its vocabulary lets the monorepo's coding-task families
-exchange tasks with the broader ecosystem rather than fork.
+([github.com/METR/task-standard](https://github.com/METR/task-standard))
+provides a vocabulary for portable agent-evaluation tasks (`task family`,
+`task`, `instructions`, `permissions`, lifecycle hook names) that the design
+will adopt. METR's specification expresses each task family as a Python
+`TaskFamily` class; this spec borrows the vocabulary and the lifecycle
+structure but not the Python class format. Vocabulary alignment is the
+portability claim; the file format is a design decision.
 
 ---
 
 ## Personas and Jobs
 
-| Persona | Job | How the gap blocks progress |
-|---|---|---|
-| Platform Builders | Evaluate and Improve Agents — Big Hire is to prove whether agent changes improved outcomes with reproducible evidence; hired on Gear, of which `libeval`/`fit-eval` is the surface ([JTBD.md](../../JTBD.md) § Platform Builders: Evaluate and Improve Agents) | A skill change today (e.g., a new `fit-pathway` authoring rule, a `kata-spec` revision) cannot be measured as cause-of-effect because there is no reproducible coding-task harness. Skill changes ship on PR-review impressions. The harness gap is what blocks the Big Hire. |
+The harness serves Platform Builders. Their Big Hire is to "prove whether agent
+changes improved outcomes with reproducible evidence" ([JTBD.md](../../JTBD.md)
+§ Platform Builders: Evaluate and Improve Agents); `libeval`/`fit-eval` is the
+surface they hire. Without a reproducible coding-task harness, a skill change
+(e.g., a new `fit-pathway` authoring rule, a `kata-spec` revision) cannot be
+measured as cause-of-effect — skill PRs ship on review impressions. Closing
+this gap is what unblocks the Big Hire. Empowered Engineers running
+skill-equipped agents inherit the benefit downstream but are not the direct
+hire for this spec.
 
 ---
 
@@ -53,35 +61,32 @@ exchange tasks with the broader ecosystem rather than fork.
 
 | Component | What changes |
 |---|---|
-| `fit-benchmark` CLI | New CLI in `libraries/libeval/bin/fit-benchmark.js`, published via `@forwardimpact/libeval` alongside `fit-eval` and `fit-trace`. Subcommands: `run` (execute a task family or single task), `score` (re-grade an archived run), `report` (aggregate across runs/tasks). |
-| Task family format | Conventional directory layout (local path or git remote) for grouping related coding tasks. Names follow METR's task-standard convention — snake_case directory, one task per subdirectory under `tasks/`. |
-| Task layout | Per-task: `instructions.md` (the only task description shown to the agent), `supervisor.task.md` (libeval supervisor prompt), `judge.task.md` (post-hoc evaluator prompt), `specs/` (work specs the agent reads), `workdir/` (scaffold copied to the agent's temp CWD), `scoring/` (hidden grading harness — never copied into the agent's CWD). |
-| Skill set under test | `apm.yml`/`apm.lock.yml` at the task-family root declares which skills/agents are installed in each task's temp CWD. This is the dimension being evaluated — different `apm.lock.yml` SHAs produce comparable result records. |
-| Lifecycle hooks | METR-aligned phases: `install` (family-level: clone, install apm), `start` (per-task: temp CWD, copy `workdir/` and `specs/`, pre-flight smoke probe), run (libeval `Supervisor` + `AgentRunner`), `score` (hidden `scoring/` runs against post-run workdir, then judge), `teardown` (process-group kill, port free, archive). |
-| Multi-run aggregation | `--runs` flag, default `3`. Each run produces an isolated temp CWD and an independent result record. Reports aggregate as pass@k. |
-| Result records | One JSON record per task per run, persisted under a run-output directory. Schema fixed by this spec — fields named in § Success Criteria. |
-| Network policy | Per-task `permissions` declaration, default no internet. `"full_internet"` opts in. Aligned with METR's `get_permissions()`. |
-| Test surface (initial) | Outside-in only: HTTP probes against the running app, source-file existence and content checks, command exit codes. The contract is enforced by skills under test, not by file protection. |
-| Documentation | New `.claude/skills/fit-benchmark/SKILL.md` and a `websites/fit/docs/libraries/prove-changes/run-benchmark/` guide. Both linked per the skill–CLI parity rule (`.claude/skills/CLAUDE.md`). |
+| Benchmark CLI | A new CLI delivered through the same package as `fit-eval` and `fit-trace`, exposing capabilities to execute a task family, re-grade an archived run, and aggregate results across runs. |
+| Task family format | A conventional layout (local path or git remote) for grouping related coding tasks. The format borrows METR Task Standard vocabulary; the on-disk shape is a design decision. |
+| Per-task artifacts | Each task carries: an agent-visible task description, a supervisor prompt for the live run, a judge prompt for the post-hoc evaluator, work specs the agent reads, scaffolding for the agent's working directory, and a hidden grading harness. The grading harness is never copied into the agent's working directory. |
+| Skill set under test | The task family declares the set of skills/agents installed in each task's working directory through a lockfile-style manifest. The manifest is the unit of measurement — different lockfile contents produce comparable result records, with a stable identifier on each record. |
+| Lifecycle | The harness drives a fixed sequence of phases per task: setup, agent execution, scoring, judging, and teardown. The harness pre-flights the unmodified scaffolding before agent execution to catch broken templates without spending agent cost. |
+| Judge phase | A separate evaluator session runs after scoring, consumes the scoring outcome and the agent trace, and emits a final verdict via libeval's `Conclude` tool. The judge is distinct from the live supervisor to keep evaluation incentives separate from helping incentives. |
+| Multi-run aggregation | The harness supports running each task multiple times in one invocation and aggregates pass@k across runs. |
+| Result records | One result record per task per run. Records carry the information needed to compute pass@k, attribute outcomes to a skill-set version, and reproduce a run. The wire schema is fixed in the design and shared by the harness and the report command. |
+| Network policy | Per-task permissions declaration aligned with METR vocabulary. Default deny external network; an explicit opt-in enables it. The enforcement mechanism is a design decision. |
+| Test surface (initial) | v1 supports tasks gradable by HTTP probes against the running app, source-file existence and content checks, and command exit codes. Module-import probes and CLI-subprocess probes are deferred. |
+| Documentation | A user-facing skill matching the published CLI per the skill–CLI parity rule (`.claude/skills/CLAUDE.md`), and a corresponding guide. |
 
 ### Out of scope, deferred
 
-- **Containerised isolation.** Tasks run in a temp CWD on the host. Sandboxing
-  via Docker or a VM (METR's `aux_vm_spec`) is a follow-up.
-- **Library/CLI test surfaces.** v1 is HTTP-only. Module-import probes and
-  CLI-subprocess probes are deferred until a concrete task needs them.
+- **Containerised isolation.** Tasks run on the host. Sandboxing via Docker
+  or a VM is a follow-up.
+- **Library/CLI test surfaces.** v1 is HTTP-only.
 - **Cross-model leaderboards.** The result schema supports model comparison;
-  the `report` subcommand does not yet render leaderboards.
-- **Live PR-gate integration.** The CLI is release-time. Wiring benchmark runs
-  into the `kata-release-merge` gate is a separate spec.
+  rendering that comparison is deferred.
+- **Live PR-gate integration.** The CLI is release-time. Wiring benchmark
+  runs into the `kata-release-merge` gate is a separate spec.
 - **Retroactive grading of historical fit-eval traces.** New tool, new traces.
-- **Cost-budget enforcement at family level.** Per-task budgets (max-turns,
-  time, cost) are surfaced from libeval. Family-level aggregate caps deferred.
-- **Determinism / replay.** No re-execution against a recorded trace; each run
-  is a fresh agent session. `score` re-grades an archived workdir, not a
-  re-played agent.
-- **Intermediate scoring.** Only end-of-run scoring in v1 (METR's
-  `intermediate_score`/`aggregate_scores` are deferred).
+- **Family-level cost-budget enforcement.** Per-task budgets are surfaced
+  from libeval.
+- **Determinism / replay from trace.** Each run is a fresh agent session.
+- **Intermediate scoring.** Only end-of-run scoring in v1.
 
 ---
 
@@ -89,16 +94,16 @@ exchange tasks with the broader ecosystem rather than fork.
 
 | Claim | Verification |
 |---|---|
-| `fit-benchmark run <family>` clones (or copies) the task family, executes every task in it `--runs N` times, and writes one result record per task per run. | Test: a fixture family with two tasks and `--runs 2` produces 4 result records and 4 trace files in the run-output directory; each record references a distinct trace path. |
-| The `scoring/` directory of a task is never present in the agent's CWD during the run. | Test: a sentinel filename in `scoring/` is unreadable from the agent's CWD; an end-to-end run with an agent attempting `ls -R` produces a trace whose lines never contain the sentinel. |
-| Hidden tests run against the post-run workdir from the template directory and produce a pass/fail per task. | Test: a fixture task whose `scoring/run.sh` HTTP-probes the agent's app at `localhost:$PORT` and asserts a JSON shape; with a stub agent that produces a passing app, the result record's scoring verdict is `"pass"`; with a stub that produces a failing app, it is `"fail"`. |
-| The judge phase consumes scoring output and the NDJSON trace and emits a final verdict via `Conclude`. | Test: a fixture `judge.task.md` referencing scoring results yields a `judgeVerdict` field on the result record; a known-bad scoring outcome plus a known-good trace produces `"fail"`. |
-| Tasks declare network permissions and the harness honours them. | Test: a task with default permissions cannot reach an external URL from the agent's tools; a task with `permissions: ["full_internet"]` can. |
-| Skill set under test is reproducible: the same `apm.lock.yml` content produces identical skill installations across runs and a stable `skillSetHash` field on the result record. | Test: two consecutive runs against the same `apm.lock.yml` produce result records whose `skillSetHash` matches; a one-byte change to `apm.lock.yml` changes the hash. |
-| Pre-flight smoke probe catches broken task templates before the agent runs. | Test: a task whose `workdir/` does not boot fails at the `start` phase with a clear error and zero agent cost spent on it. |
-| Result aggregation across runs reports pass@k. | Test: `fit-benchmark report <run-id>` over three runs of the same task with verdicts pass/fail/pass emits `pass@1: 2/3, pass@3: 1/1`. |
+| The harness clones (or copies) a task family, executes every task in it the configured number of times, and writes one result record per task per run. | Test: a fixture family with two tasks and a run count of two produces four result records and four trace files in the run-output directory; each record references a distinct trace path. |
+| The hidden grading harness for a task is never present in the agent's working directory during the run. | Test: a sentinel filename inside the hidden grading harness is unreadable from the agent's working directory; an end-to-end run with an agent attempting to enumerate the directory tree produces a trace whose lines never contain the sentinel. |
+| Hidden tests run against the post-run agent working directory from the template directory and produce a pass/fail per task. | Test: a fixture task whose grading script HTTP-probes the agent's app on a known port and asserts a JSON shape; with a stub agent producing a passing app, the result record's grading verdict is `"pass"`; with a stub producing a failing app, it is `"fail"`. |
+| The judge phase consumes the scoring outcome and the trace and emits a final verdict via `Conclude`. | Test: a fixture judge prompt referencing scoring results yields a judge-verdict on the result record; a known-bad scoring outcome plus a known-good trace produces `"fail"`. |
+| Tasks declare network permissions and the harness honours them. | Test: a task with default permissions, when the agent attempts to fetch an external URL, produces a tool-result error (request denied or no tool available); a task that opts into external network succeeds in the same scenario. |
+| The skill set under test is reproducible across runs. | Test: two consecutive runs against the same skill-set lockfile produce result records whose skill-set identifier matches; a one-byte change to the lockfile produces a different identifier. |
+| Pre-flight catches broken task templates before the agent runs. | Test: a task whose unmodified scaffolding fails its own start fails at the pre-flight phase with a non-zero exit and a structured error in the result record; the result record's agent cost is zero. |
+| Result aggregation across runs reports pass@k. | Test: the report command, given five runs of the same task with verdicts pass/fail/fail/pass/fail, reports `pass@1 = 2/5` and `pass@3 = 9/10` per the OpenAI HumanEval convention `pass@k = 1 - C(n-c, k)/C(n, k)`. |
 | Teardown leaves no dangling processes or occupied ports. | Test: after a task that starts an HTTP server on a known port, the port is free and no child of the harness PID remains. |
-| `fit-benchmark` shares libeval's primitives — no duplicated agent/supervisor logic. | Code review: `fit-benchmark`'s run path composes `AgentRunner`, `Supervisor`, `TraceCollector`, `MessageBus` from `@forwardimpact/libeval`; no fork of those classes. |
-| Result-record schema is stable. | Each record contains: `taskId`, `runIndex`, `verdict`, `scoring`, `submission`, `judgeVerdict`, `costUsd`, `turns`, `tracePath`, `profiles`, `model`, `skillSetHash`, `familySha`, `permissions`, `durationMs`. Documented in the design and exercised in a schema-fixture test. |
+| The harness produces NDJSON traces in the format consumed by `fit-trace`. | Test: a trace from a benchmark run is accepted by `fit-trace overview` without errors; turn count matches between the source NDJSON and `fit-trace`'s output. |
+| The result-record schema is fixed in the design and validated at write time. | Test: each result record validates against the schema declared in `design-a.md` § Result-record schema; the schema lives in one place and is referenced by both the harness and the report command. |
 
 — Staff Engineer 🛠️

--- a/specs/870-fit-benchmark-coding-tasks/spec.md
+++ b/specs/870-fit-benchmark-coding-tasks/spec.md
@@ -26,11 +26,10 @@ Three things are missing from the current `libeval` surface:
    single run is a coin flip. Today there is no mechanism for "run this task
    family multiple times across two skill-pack versions and report pass@k."
 
-A fourth structural concern motivates an additional decision the design must
-honour: **the live supervisor and the post-hoc grader should not be the same
-agent.** A supervisor whose job during the run is to help the agent finish
-cannot also issue an unbiased verdict. The harness must run the live
-supervisor and the post-hoc judge as separate sessions.
+A fourth structural concern motivates a downstream design decision: the live
+supervisor and the post-hoc grader should not be the same agent. A supervisor
+whose job during the run is to help the agent finish cannot also issue an
+unbiased verdict.
 
 The blast radius of the gap is the central JTBD this surface serves: Platform
 Builders cannot prove whether a skill change improved coding-agent outcomes.
@@ -38,12 +37,11 @@ Skill PRs ship on subjective review.
 
 The METR Task Standard
 ([github.com/METR/task-standard](https://github.com/METR/task-standard))
-provides a vocabulary for portable agent-evaluation tasks (`task family`,
-`task`, `instructions`, `permissions`, lifecycle hook names) the design will
-adopt. Vocabulary alignment is the portability claim; the format the
-vocabulary lands in is a design decision.
+provides a vocabulary for portable agent-evaluation tasks the design will
+adopt — `task family`, `task`, `instructions`, `permissions`, lifecycle hook
+names. Vocabulary alignment is the portability claim.
 
-## Personas and Jobs
+## Personas and Job
 
 The harness serves Platform Builders. Their Big Hire is to "Help me prove
 whether agent changes improved outcomes with reproducible evidence"
@@ -53,7 +51,8 @@ under. Without a reproducible coding-task harness, a skill change (a new
 `fit-pathway` authoring rule, a `kata-spec` revision) cannot be measured as
 cause-of-effect — skill PRs ship on review impressions. Closing this gap is
 what unblocks the Big Hire. Empowered Engineers running skill-equipped agents
-inherit the benefit downstream but are not the direct hire.
+inherit the benefit downstream but are not the direct hire. End users running
+agents in production are not in scope.
 
 ## Scope
 
@@ -61,51 +60,52 @@ inherit the benefit downstream but are not the direct hire.
 
 | Component | What changes |
 |---|---|
-| Benchmark CLI | A new CLI exposing capabilities to execute a task family, re-grade an archived run, and aggregate results across runs. The CLI's location and packaging are design decisions. |
+| Benchmark capability | A new executable capability that runs benchmarks against a task family and aggregates results across runs. The CLI surface composition (subcommands, packaging) is a design decision. |
 | Task family format | A conventional layout (local path or git remote) for grouping related coding tasks. The format borrows METR Task Standard vocabulary and lifecycle structure; the on-disk shape is a design decision. |
 | Per-task content | Each task carries enough material to: prompt the agent, guide a live supervisor, guide a post-hoc judge, anchor the agent in the desired outcome (work specifications), seed the agent's working directory, and grade the agent's output. The grading material is never accessible from the agent's working directory. |
-| Skill set under test | The task family declares the skills/agents installed in each task's working directory through a content-addressable manifest. The manifest is the unit of measurement — different manifest contents produce comparable result records, with a stable identifier on each record. |
+| Skill set under test | The task family declares the skills/agents installed in each task's working directory through a manifest whose contents uniquely identify the skill set. The manifest is the unit of measurement — different manifest contents produce comparable result records, with a stable identifier on each record. |
 | Lifecycle | The harness drives a fixed sequence of phases per task: setup, agent execution, scoring, judging, and teardown. The harness rejects broken task templates without spending agent cost. |
-| Judge phase | A separate evaluator session runs after scoring, consumes the scoring outcome and the agent trace, and emits a final verdict that the result record records. The judge runs as an independent session from the live supervisor. |
-| Multi-run aggregation | The harness supports running each task multiple times in one invocation and aggregates pass@k across runs per the OpenAI HumanEval convention. |
-| Result records | One result record per task per run. Records carry the information needed to compute pass@k, attribute outcomes to a skill-set version, and reproduce a run. The record schema is a single declared shape shared by the harness and the report command. |
-| Network policy | Per-task permissions declaration aligned with METR vocabulary. Default deny external network; an explicit opt-in enables it. The enforcement mechanism is a design decision. v1 enforcement is best-effort within libeval's existing tool-permission surface; OS-level isolation is the deferred containerised-isolation work. |
-| Test surface (this scope) | The harness grades by three categories of outcome: running-service behaviour (probing the post-run app), repository state (file existence and content checks against the post-run working directory), and process exit (command exit codes). Library-API and CLI-invocation grading are deferred. |
+| Judge phase | A separate evaluator session runs after scoring, consumes the scoring outcome and the agent trace, and emits a final verdict that the result record records. |
+| Multi-run aggregation | The harness supports running each task multiple times in one invocation and aggregates pass@k across runs per the OpenAI HumanEval unbiased estimator. |
+| Result records | One result record per task per run, even when tasks fail at any phase. Records carry the information needed to compute pass@k, attribute outcomes to a skill-set version, and reproduce a run. The record schema is a single declared shape shared by the harness and the report tooling. |
+| Network policy | Per-task permissions declaration aligned with METR vocabulary. Default deny external network; an explicit opt-in enables it. Observable against libeval's `WebFetch` tool surface; Bash-shell egress is acknowledged as a v1 limitation pending containerised isolation. |
+| Grading surface | The harness grades tasks via three post-run outcome categories: running-service behaviour, repository state, and process exit. |
 | Documentation | A user-facing skill matching the published CLI per the skill–CLI parity rule (`.claude/skills/CLAUDE.md`), and a corresponding guide. |
 
 ### Out of scope, deferred
 
 - **Containerised isolation.** Tasks run on the host. Sandboxing via Docker
-  or a VM is a follow-up; v1 network policy is best-effort within tool
-  permissions.
-- **Library-API and CLI-invocation grading.** This scope is HTTP / file
-  state / exit code only.
+  or a VM is a follow-up.
+- **Library-API and CLI-invocation grading.** Beyond the three grading
+  surfaces in scope.
 - **Cross-model leaderboards.** The result schema supports model comparison;
   rendering that comparison is deferred.
-- **Live PR-gate integration.** The CLI is release-time. Wiring benchmark
-  runs into automated merge gating is a separate spec.
+- **Live PR-gate integration.** The capability is release-time. Wiring
+  benchmark runs into automated merge gating is a separate spec.
 - **Retroactive grading of historical fit-eval traces.** New tool, new traces.
 - **Family-level cost-budget enforcement.** Per-task budgets surface from
   libeval.
 - **Determinism / replay from trace.** Each run is a fresh agent session.
 - **Intermediate scoring.** Only end-of-run scoring in this scope.
+- **Concurrent runs across `(task, runIndex)` pairs.** v1 is serial.
 
 ## Success Criteria
 
 | Claim | Verification |
 |---|---|
-| The harness clones (or copies) a task family, executes every task in it the configured number of times, and writes one result record per task per run. | Test: a fixture family with two tasks and a run count of two produces four result records and four trace files in the run-output directory; each record carries a distinct `(taskId, runIndex)` pair and references an existing, distinct trace file. |
+| The harness clones (or copies) a task family, executes every task in it the configured number of times, and writes one result record per task per run including for failures. | Test: a fixture family with one passing task and one task that fails its agent execution at a run count of two produces four result records and four trace files in the run-output directory; each record carries a distinct `(taskId, runIndex)` pair and references an existing, distinct trace file. |
 | The grading material for a task is never present in the agent's working directory during the run. | Test: a sentinel filename inside the grading material is unreadable from the agent's working directory; an end-to-end run with an agent attempting to enumerate the directory tree produces a trace whose lines never contain the sentinel. |
-| Hidden grading runs against the post-run agent working directory and produces a pass/fail per task via the running-service surface. | Test: a fixture task whose grading script HTTP-probes the agent's app on a known port and asserts a JSON shape; with a stub agent producing a passing app, the result record's grading verdict is pass; with a stub producing a failing app, it is fail. |
+| Hidden grading produces a pass/fail per task via the running-service surface. | Test: a fixture task whose grading script HTTP-probes the agent's app on a known port and asserts a JSON shape; with a stub agent producing a passing app, the result record's grading verdict is pass; with a stub producing a failing app, it is fail. |
 | Hidden grading produces a pass/fail per task via the repository-state surface. | Test: a fixture task whose grading script asserts the existence and SHA-256 content of one or more files under the post-run working directory; a stub agent meeting the assertions produces a passing record; one missing the file produces a failing record. |
 | Hidden grading produces a pass/fail per task via the process-exit surface. | Test: a fixture task whose grading script invokes a command in the post-run working directory and treats exit-zero as pass; the result record's grading verdict tracks the command's exit code. |
 | The judge phase consumes the scoring outcome and the agent trace and emits a final verdict that the result record records. | Test: a fixture judge prompt referencing scoring results yields a judge-verdict on the result record; a known-bad scoring outcome plus a known-good trace produces a failing verdict. |
-| Tasks declare network permissions and the harness honours them through the v1 enforcement mechanism named in the design. | Test: a task with default permissions, when the agent attempts to fetch an external URL through libeval's tool surface, produces a tool-result error; a task that opts in succeeds in the same scenario. (Bash-shell egress bypasses are a known v1 limitation; closing them is the deferred isolation work.) |
+| Tasks declare network permissions and the harness denies external network on default permissions, allows on opt-in, observable against libeval's `WebFetch` tool. | Test: a task with default permissions, when the agent attempts to fetch an external URL through libeval's `WebFetch` tool, produces a tool-result error; a task that opts in succeeds in the same scenario. |
 | The skill set under test is reproducible across runs. | Test: two consecutive runs against the same skill-set manifest produce result records whose skill-set identifier matches; a one-byte content change to the manifest produces a different identifier. |
 | Pre-flight catches broken task templates before the agent runs. | Test: a task whose unmodified scaffolding fails its own start fails before agent execution with a non-zero exit and a structured error in the result record; the result record's agent cost is zero. |
-| Result aggregation across runs reports pass@k per the OpenAI HumanEval convention. | Test: the report command, given five runs of the same task with verdicts pass/fail/fail/pass/fail, reports `pass@1 = 0.4` and `pass@3 = 0.9`; the formula is documented in the design. |
-| Teardown leaves no dangling processes or occupied ports. | Test: after a task that starts an HTTP server on a known port, the port is free and no child of the harness PID remains. |
-| The harness produces NDJSON traces in the format consumed by `fit-trace`. | Test: a trace from a benchmark run is accepted by `fit-trace overview` without errors; turn count matches between the source NDJSON and `fit-trace`'s output. |
-| Result records share a single declared schema validated at write time. | Test: every record produced by the harness validates against the record's runtime schema validator; the report command validates inputs against the same validator and rejects records that fail. |
+| Result aggregation across runs reports pass@k per the OpenAI HumanEval unbiased estimator. | Test: the report tooling, given five runs of the same task with verdicts pass/fail/fail/pass/fail, reports `pass@1 = 0.4` and `pass@3 = 0.9` (the unbiased estimator `1 - C(n-c, k) / C(n, k)`). |
+| Teardown leaves no descendant of the harness's process group. | Test: after a task that starts an HTTP server on a known port, the port is free and no descendant in the harness's process group remains. |
+| The harness produces traces consumable by the monorepo's standard trace-analysis tooling. | Test: a trace from a benchmark run is accepted by the standard trace-analysis tool's overview command without errors; turn count matches between the source trace and the tool's output. |
+| Result records share a single declared schema validated at write time. | Test: every record produced by the harness validates against the record's runtime schema validator; the report tooling validates inputs against the same validator and rejects records that fail. |
+| The published skill and CLI carry parity per `.claude/skills/CLAUDE.md`. | Test: the skill's `## Documentation` list and the CLI's documentation array carry the same entries in the same order. |
 
 — Staff Engineer 🛠️

--- a/specs/870-fit-benchmark-coding-tasks/spec.md
+++ b/specs/870-fit-benchmark-coding-tasks/spec.md
@@ -1,0 +1,104 @@
+# Spec 870 — fit-benchmark Coding Agent Task Families
+
+## Problem
+
+Today the only way to evaluate a coding agent in the monorepo is to write a
+one-off `fit-eval supervise` invocation: a task file, a supervisor profile, an
+agent profile, and a working directory the agent edits. This works for ad-hoc
+evals but does not scale to the central question Platform Builders need
+answered: do our skills (the `fit-*`/`kata-*` packs) actually make agents
+better at writing code?
+
+Three things are missing from the current `libeval` surface:
+
+1. **A reusable task layout.** Each scenario today encodes its own conventions
+   for task file location, working-directory contents, and grading. There is no
+   standard "this is a coding task" structure that can be cloned, run, and
+   graded reproducibly across runs and across skill-set versions.
+
+2. **A grading pass the agent cannot see.** When the agent is told to "build a
+   TODO API matching the spec," tests written by the agent during the session
+   are not independent verification — they grade themselves. Reproducible
+   evaluation needs fail-to-pass tests that ship with the task and never enter
+   the agent's CWD.
+
+3. **Aggregation across runs and tasks.** LLM output is non-deterministic. A
+   single run is a coin flip. Today there is no mechanism for "run this task
+   family three times across these two skill-pack versions and report pass@k."
+
+The blast radius of the gap is the central JTBD for `libeval`: Platform
+Builders cannot prove whether a skill change improved coding-agent outcomes.
+Skill PRs ship on subjective review.
+
+The METR Task Standard
+([github.com/METR/task-standard](https://github.com/METR/task-standard)) is a
+production format for portable agent-evaluation tasks (over 1,000 tasks across
+AI R&D, cybersecurity, and general autonomy; in use at the UK AI Safety
+Institute). Adopting its vocabulary lets the monorepo's coding-task families
+exchange tasks with the broader ecosystem rather than fork.
+
+---
+
+## Personas and Jobs
+
+| Persona | Job | How the gap blocks progress |
+|---|---|---|
+| Platform Builders | Evaluate and Improve Agents — Big Hire is to prove whether agent changes improved outcomes with reproducible evidence; hired on Gear, of which `libeval`/`fit-eval` is the surface ([JTBD.md](../../JTBD.md) § Platform Builders: Evaluate and Improve Agents) | A skill change today (e.g., a new `fit-pathway` authoring rule, a `kata-spec` revision) cannot be measured as cause-of-effect because there is no reproducible coding-task harness. Skill changes ship on PR-review impressions. The harness gap is what blocks the Big Hire. |
+
+---
+
+## Scope
+
+### In scope
+
+| Component | What changes |
+|---|---|
+| `fit-benchmark` CLI | New CLI in `libraries/libeval/bin/fit-benchmark.js`, published via `@forwardimpact/libeval` alongside `fit-eval` and `fit-trace`. Subcommands: `run` (execute a task family or single task), `score` (re-grade an archived run), `report` (aggregate across runs/tasks). |
+| Task family format | Conventional directory layout (local path or git remote) for grouping related coding tasks. Names follow METR's task-standard convention — snake_case directory, one task per subdirectory under `tasks/`. |
+| Task layout | Per-task: `instructions.md` (the only task description shown to the agent), `supervisor.task.md` (libeval supervisor prompt), `judge.task.md` (post-hoc evaluator prompt), `specs/` (work specs the agent reads), `workdir/` (scaffold copied to the agent's temp CWD), `scoring/` (hidden grading harness — never copied into the agent's CWD). |
+| Skill set under test | `apm.yml`/`apm.lock.yml` at the task-family root declares which skills/agents are installed in each task's temp CWD. This is the dimension being evaluated — different `apm.lock.yml` SHAs produce comparable result records. |
+| Lifecycle hooks | METR-aligned phases: `install` (family-level: clone, install apm), `start` (per-task: temp CWD, copy `workdir/` and `specs/`, pre-flight smoke probe), run (libeval `Supervisor` + `AgentRunner`), `score` (hidden `scoring/` runs against post-run workdir, then judge), `teardown` (process-group kill, port free, archive). |
+| Multi-run aggregation | `--runs` flag, default `3`. Each run produces an isolated temp CWD and an independent result record. Reports aggregate as pass@k. |
+| Result records | One JSON record per task per run, persisted under a run-output directory. Schema fixed by this spec — fields named in § Success Criteria. |
+| Network policy | Per-task `permissions` declaration, default no internet. `"full_internet"` opts in. Aligned with METR's `get_permissions()`. |
+| Test surface (initial) | Outside-in only: HTTP probes against the running app, source-file existence and content checks, command exit codes. The contract is enforced by skills under test, not by file protection. |
+| Documentation | New `.claude/skills/fit-benchmark/SKILL.md` and a `websites/fit/docs/libraries/prove-changes/run-benchmark/` guide. Both linked per the skill–CLI parity rule (`.claude/skills/CLAUDE.md`). |
+
+### Out of scope, deferred
+
+- **Containerised isolation.** Tasks run in a temp CWD on the host. Sandboxing
+  via Docker or a VM (METR's `aux_vm_spec`) is a follow-up.
+- **Library/CLI test surfaces.** v1 is HTTP-only. Module-import probes and
+  CLI-subprocess probes are deferred until a concrete task needs them.
+- **Cross-model leaderboards.** The result schema supports model comparison;
+  the `report` subcommand does not yet render leaderboards.
+- **Live PR-gate integration.** The CLI is release-time. Wiring benchmark runs
+  into the `kata-release-merge` gate is a separate spec.
+- **Retroactive grading of historical fit-eval traces.** New tool, new traces.
+- **Cost-budget enforcement at family level.** Per-task budgets (max-turns,
+  time, cost) are surfaced from libeval. Family-level aggregate caps deferred.
+- **Determinism / replay.** No re-execution against a recorded trace; each run
+  is a fresh agent session. `score` re-grades an archived workdir, not a
+  re-played agent.
+- **Intermediate scoring.** Only end-of-run scoring in v1 (METR's
+  `intermediate_score`/`aggregate_scores` are deferred).
+
+---
+
+## Success Criteria
+
+| Claim | Verification |
+|---|---|
+| `fit-benchmark run <family>` clones (or copies) the task family, executes every task in it `--runs N` times, and writes one result record per task per run. | Test: a fixture family with two tasks and `--runs 2` produces 4 result records and 4 trace files in the run-output directory; each record references a distinct trace path. |
+| The `scoring/` directory of a task is never present in the agent's CWD during the run. | Test: a sentinel filename in `scoring/` is unreadable from the agent's CWD; an end-to-end run with an agent attempting `ls -R` produces a trace whose lines never contain the sentinel. |
+| Hidden tests run against the post-run workdir from the template directory and produce a pass/fail per task. | Test: a fixture task whose `scoring/run.sh` HTTP-probes the agent's app at `localhost:$PORT` and asserts a JSON shape; with a stub agent that produces a passing app, the result record's scoring verdict is `"pass"`; with a stub that produces a failing app, it is `"fail"`. |
+| The judge phase consumes scoring output and the NDJSON trace and emits a final verdict via `Conclude`. | Test: a fixture `judge.task.md` referencing scoring results yields a `judgeVerdict` field on the result record; a known-bad scoring outcome plus a known-good trace produces `"fail"`. |
+| Tasks declare network permissions and the harness honours them. | Test: a task with default permissions cannot reach an external URL from the agent's tools; a task with `permissions: ["full_internet"]` can. |
+| Skill set under test is reproducible: the same `apm.lock.yml` content produces identical skill installations across runs and a stable `skillSetHash` field on the result record. | Test: two consecutive runs against the same `apm.lock.yml` produce result records whose `skillSetHash` matches; a one-byte change to `apm.lock.yml` changes the hash. |
+| Pre-flight smoke probe catches broken task templates before the agent runs. | Test: a task whose `workdir/` does not boot fails at the `start` phase with a clear error and zero agent cost spent on it. |
+| Result aggregation across runs reports pass@k. | Test: `fit-benchmark report <run-id>` over three runs of the same task with verdicts pass/fail/pass emits `pass@1: 2/3, pass@3: 1/1`. |
+| Teardown leaves no dangling processes or occupied ports. | Test: after a task that starts an HTTP server on a known port, the port is free and no child of the harness PID remains. |
+| `fit-benchmark` shares libeval's primitives — no duplicated agent/supervisor logic. | Code review: `fit-benchmark`'s run path composes `AgentRunner`, `Supervisor`, `TraceCollector`, `MessageBus` from `@forwardimpact/libeval`; no fork of those classes. |
+| Result-record schema is stable. | Each record contains: `taskId`, `runIndex`, `verdict`, `scoring`, `submission`, `judgeVerdict`, `costUsd`, `turns`, `tracePath`, `profiles`, `model`, `skillSetHash`, `familySha`, `permissions`, `durationMs`. Documented in the design and exercised in a schema-fixture test. |
+
+— Staff Engineer 🛠️


### PR DESCRIPTION
## Summary

Adds spec 870 — `fit-benchmark` coding-agent task families — and its design-a.

The spec defines a higher-level harness on top of `libeval` for running coding-agent evaluations against task families. Three structural gaps it closes:
- A reusable task layout for grouping coding tasks portably.
- A grading pass the agent cannot see (hidden `scoring/` never enters the agent's CWD).
- Multi-run aggregation reporting pass@k.

Vocabulary is METR Task Standard-aligned (`task family`, `task`, `instructions`, `permissions`, lifecycle hook names) so families can interchange with the broader ecosystem.

The design locks the concrete decisions (per project request "the design should not leave them open"): `apm.lock.yaml` extension matching libpack, `Conclude` verdict mapping (`success`→`pass`), `child_process.spawn` fd-3 scoring channel, two symmetric trace fields (`agentTracePath`/`judgeTracePath`), `BenchmarkRunner` as sole orchestrator, and a fully specified `familyRevision` algorithm for non-git families.

## Process

Spec and design went through three rounds of `kata-review` panels (3 product + 3 technical for the spec, 3 technical for the design — 9 reviewers per round). Round 3 design panel: 0 blockers, 0 highs, only mediums/lows — all consensus findings addressed in 536d8af6.

## Test plan

- [x] `bun run check`
- [x] `bun run format:fix`
- [x] Round-3 panel review consensus addressed
- [x] Spec under default page budget; design 194 lines (under 200 ceiling)

https://claude.ai/code/session_0168UAq6iSo8ivDFaA2YDyGi

---
_Generated by [Claude Code](https://claude.ai/code/session_0168UAq6iSo8ivDFaA2YDyGi)_