### PR TITLE
spec(860): rename MCD → operational redefinition

### DIFF
--- a/specs/860-measurement-system-change-protocol/design-a.md
+++ b/specs/860-measurement-system-change-protocol/design-a.md
@@ -4,8 +4,8 @@
 
 Add one new agent-level reference,
 `.claude/agents/references/measurement-protocol.md`, that names the
-repair-move typology, the Measurement Change Disclosure (MCD) shape and
-one filled-in example, the no-silent-amendment rule, and the
+repair-move typology, the Operational Redefinition shape and one
+filled-in example, the no-silent-redefinition rule, and the
 detection-grep recipe that satisfies Success #6. KATA.md § Metrics
 gains one paragraph linking to it plus one sentence admitting the
 binding-constraint metric (decision #7). The canonical-11 enumeration
@@ -18,26 +18,27 @@ file is already long-format — `date,metric,value,unit,run,note` — so
 the new metric joins as additional rows tagged by the `metric` column,
 alongside the existing `prs_merged` rows). The `kata-session` skill's
 team-storyboard overlay gains two `<do_confirm_checklist>` items so
-canonical-11 changes are gated on a linked MCD without restating the
-rule. No agent-persona files change.
+canonical-11 changes are gated on a linked redefinition without
+restating the rule. No agent-persona files change.
 
 ## Components
 
 | Component | Lives in | Responsibility |
 | --- | --- | --- |
-| `measurement-protocol.md` | `.claude/agents/references/` | Names the typology, MCD shape (with one worked example), no-silent-amendment rule, and the detection-grep recipe. Sibling of `coordination-protocol.md` and `memory-protocol.md`. |
+| `measurement-protocol.md` | `.claude/agents/references/` | Names the typology, redefinition shape (with one worked example), no-silent-redefinition rule, and the detection-grep recipe. Sibling of `coordination-protocol.md` and `memory-protocol.md`. |
 | KATA.md § Metrics extension | `KATA.md` | One paragraph linking to the new reference, plus one sentence admitting the binding-constraint duration metric (decision #7) — this is the constitutional delta, not just a pointer addition. |
 | `time_to_first_approval_hours` metric | `wiki/metrics/kata-release-merge/{YYYY}.csv` (additional rows; `metric` column distinguishes from `prs_merged`; `unit=hours`) | New canonical-11 entry. Producer = `kata-release-merge`. One row per run; value defined under "Approval-throughput metric" below. |
 | Canonical-11 enumeration | `wiki/storyboard-*.md` | New bulleted list under § Metrics, one bullet per metric mapping `{metric → producer skill}`. Replaces the current inline "11 canonical metrics" prose. |
 | `kata-release-merge` `references/metrics.md` extension | `.claude/skills/kata-release-merge/references/metrics.md` | Adds the new metric's row alongside `prs_merged`; documents the cohort predicate. |
-| Storyboard MCD hook | `.claude/skills/kata-session/references/team-storyboard.md` | Two `<do_confirm_checklist>` items: every canonical-11 change item carries an `MCD:` link; cohort read-out items enumerate the day's MCDs. |
-| MCD authoring locus | Existing experiment/obstacle GitHub issue bodies, or a code PR body when the canonical-11 change rides on a PR with no preceding issue (e.g. skill removal in a feature PR). | The MCD is a YAML section template inside the host body, not a new artifact type. The change diff cites it by issue or PR link. |
+| Storyboard redefinition hook | `.claude/skills/kata-session/references/team-storyboard.md` | Two `<do_confirm_checklist>` items: every canonical-11 change item carries a `Redefinition:` link; cohort read-out items enumerate the day's redefinitions. |
+| Redefinition authoring locus | Existing experiment/obstacle GitHub issue bodies, or a code PR body when the canonical-11 change rides on a PR with no preceding issue (e.g. skill removal in a feature PR). | The redefinition is a YAML section template inside the host body, not a new artifact type. The change diff cites it by issue or PR link. |
 
 ## Repair-move typology (eight named moves)
 
 Each move binds a one-sentence definition and the kind of falsifier-set
-predicates an instance MCD must include. The list is closed: extensions
-land via the spec/design/plan/implement chain, not via the MCD form.
+predicates an instance redefinition must include. The list is closed:
+extensions land via the spec/design/plan/implement chain, not via the
+redefinition form.
 
 | Move | Definition | Falsifier-set kind | Existing precedent |
 | --- | --- | --- | --- |
@@ -50,10 +51,10 @@ land via the spec/design/plan/implement chain, not via the MCD form.
 | `rule-semantics-rfc` | Challenge an XmR rule's blocking effect on `predictable` via Discussion RFC; quorum required. | "RFC quorum not reached by horizon" | #814 |
 | `habit-to-policy` | Promote an undocumented defensive habit into a SKILL.md check after a defect surfaces. | "post-promotion defect of the same shape recurs" | #817, PR #655 |
 
-## MCD shape
+## Redefinition shape
 
 ```yaml
-mcd:
+redefinition:
   move: producer-rehoming | mode-restriction | historical-phasing |
         sidecar-pre-flight | stock-vs-flow-recast | event-driven-recast |
         rule-semantics-rfc | habit-to-policy
@@ -68,13 +69,13 @@ mcd:
     pr: <#NNN>?
 ```
 
-The MCD is an embeddable YAML block (fenced) inside its host body.
-`verdict_horizon` is the date the falsifier predicates are checked;
-`cohort_readout` is the storyboard meeting at which the cohort
+The redefinition is an embeddable YAML block (fenced) inside its host
+body. `verdict_horizon` is the date the falsifier predicates are
+checked; `cohort_readout` is the storyboard meeting at which the cohort
 ratifies. The two may coincide; `verdict_horizon` ≤ `cohort_readout`
 is the only ordering constraint (predicates are checked before
 ratification, not after). `denominator_effect` is the explicit hook for
-the no-silent-amendment rule: any value other than `none` requires a
+the no-silent-redefinition rule: any value other than `none` requires a
 cohort read-out date and a linked storyboard line. The reference
 `measurement-protocol.md` carries one filled-in example (illustrating
 the SE Exp 33 #787 sidecar pre-flight pattern), satisfying spec Success #2.
@@ -82,20 +83,21 @@ the SE Exp 33 #787 sidecar pre-flight pattern), satisfying spec Success #2.
 ## Detection (Success #6)
 
 Spec Success #6 requires a `git diff` recipe that pairs canonical-11
-metric edits with their MCD link. The recipe lives in
+metric edits with their redefinition link. The recipe lives in
 `measurement-protocol.md`: any line in `measurement-protocol.md`,
 `wiki/storyboard-*.md`, or `.claude/skills/*/references/metrics.md`
-that names a canonical-11 metric must, in the same diff hunk, carry an
-`MCD: #NNN` link to the host issue or PR. The reference states the
-ripgrep invocation as the canonical detection.
+that names a canonical-11 metric must, in the same diff hunk, carry a
+`Redefinition: #NNN` link to the host issue or PR. The reference states
+the ripgrep invocation as the canonical detection.
 
-## No-silent-amendment rule
+## No-silent-redefinition rule
 
 > No change to the canonical-11 denominator (additions, removals,
-> conditional or unconditional amendments) lands without an MCD whose
-> `denominator_effect` is non-`none`, a cohort read-out date on or
-> before the storyboard meeting at which the change takes effect, and a
-> linked storyboard headline that surfaces the change up-front.
+> conditional or unconditional redefinitions) lands without a
+> redefinition whose `denominator_effect` is non-`none`, a cohort
+> read-out date on or before the storyboard meeting at which the change
+> takes effect, and a linked storyboard headline that surfaces the
+> change up-front.
 
 This single statement lives in `measurement-protocol.md`. KATA.md § Metrics
 links to it; no other file restates it.
@@ -140,8 +142,8 @@ spec Success #4 (decision #7).
 
 ```mermaid
 flowchart LR
-  CHG[Canonical-11 change<br/>proposed in issue/PR] --> MCD[MCD YAML block in host body]
-  MCD --> SB{Storyboard MCD hook}
+  CHG[Canonical-11 change<br/>proposed in issue/PR] --> RDF[Redefinition YAML block in host body]
+  RDF --> SB{Storyboard redefinition hook}
   SB --> READ[Cohort read-out at horizon date]
   READ --> RAT{Ratify?}
   RAT -- yes --> AMEND[Storyboard line updates;<br/>denominator change lands]
@@ -151,22 +153,22 @@ flowchart LR
   RM[kata-release-merge run] --> CSV[wiki/metrics/kata-release-merge/{YYYY}.csv]
   CSV --> XMR[fit-xmr analyze]
   REF -.->|enumerates| MOVES[Eight repair moves]
-  REF -.->|defines| MCD
-  REF -.->|owns| RULE[No-silent-amendment rule]
+  REF -.->|defines| RDF
+  REF -.->|owns| RULE[No-silent-redefinition rule]
 ```
 
 ## Key decisions
 
 | # | Decision | Rejected alternative | Why |
 | --- | --- | --- | --- |
-| 1 | Locate the typology, MCD shape, rule, and grep recipe in one new agent-level reference (`measurement-protocol.md`). | Inline in KATA.md § Metrics. | KATA.md is identity-and-orientation per CLAUDE.md § Documentation Map. Protocol detail belongs with siblings `coordination-protocol.md` and `memory-protocol.md`. |
-| 2 | MCD is a YAML block embedded in the host issue/PR body. | New issue type or new file type per change. | Repair moves already coincide with existing issues/PRs. The YAML block is greppable inside its host; the change diff carries the host link. |
-| 3 | Repair-move list is closed at design time; extensions land via spec/design/plan/implement. | Open list with a `move: new-move` enum value usable at MCD time. | A closed list is the legible part of the protocol; an open list reverts to the current ad-hoc state. Forcing extensions through the spec chain preserves growth without diluting closure. |
+| 1 | Locate the typology, redefinition shape, rule, and grep recipe in one new agent-level reference (`measurement-protocol.md`). | Inline in KATA.md § Metrics. | KATA.md is identity-and-orientation per CLAUDE.md § Documentation Map. Protocol detail belongs with siblings `coordination-protocol.md` and `memory-protocol.md`. |
+| 2 | Redefinition is a YAML block embedded in the host issue/PR body. | New issue type or new file type per change. | Repair moves already coincide with existing issues/PRs. The YAML block is greppable inside its host; the change diff carries the host link. |
+| 3 | Repair-move list is closed at design time; extensions land via spec/design/plan/implement. | Open list with a `move: new-move` enum value usable at redefinition time. | A closed list is the legible part of the protocol; an open list reverts to the current ad-hoc state. Forcing extensions through the spec chain preserves growth without diluting closure. |
 | 4 | Producer for `time_to_first_approval_hours` is `kata-release-merge`. | New `kata-approval-meter` skill; or producer = `kata-session`. | `kata-release-merge` already iterates phase PRs and reads `<phase>:approved` signals. A new skill adds an agent-team matrix entry for one metric; `kata-session` is once-daily and would miss between-meeting churn. |
 | 5 | Cohort = all surveyed open phase PRs (right-censored on carry-forwards); aggregation = median in hours. | Fresh-approval-only cohort (drops carry-forwards); mean; per-PR rows; count of `<2h` PRs. | Fresh-approval-only requires cross-run state and creates empty cohorts that `libxmr/csv.js` cannot represent (empty `value` parses as `0`, recreating the #788 structural-zero failure). Mean is volatile under bursty cadence; per-PR rows violate one-row-per-run; count loses magnitude. The right-censored rolling cohort matches the skill's existing run-note practice. |
 | 6 | New metric joins the existing `kata-release-merge/{YYYY}.csv` as additional rows (long-format CSV; `metric` column distinguishes). | Sibling CSV (`{YYYY}-approval.csv`); new metric directory. | The CSV is already long-format with a `metric` column; adding rows is the lightest possible extension and matches the spec's literal `{YYYY}.csv` path. |
 | 7 | KATA.md § Metrics extends to admit one binding-constraint **duration** metric per producer skill alongside its count metric. | A count proxy such as `approvals_signaled_per_run`; a separate "binding-constraint" recording surface outside KATA.md. | A count proxy loses dwell magnitude (the binding constraint #572 is fundamentally a dwell, not a rate). A separate surface fragments KATA.md § Metrics' "one home per policy" stance. The named extension is the smallest delta that admits the binding-constraint metric. |
-| 8 | Storyboard hook is two `<do_confirm_checklist>` items in `kata-session/references/team-storyboard.md`. | Bake into prose; add to `kata-session/SKILL.md`; add to `wiki/storyboard-*.md` template. | `<do_confirm_checklist>` items are greppable and machine-checkable (Success #6). The team-storyboard overlay is the canonical home for storyboard-meeting checks; SKILL.md is the umbrella; prose drifts. Exit-gate placement (do-confirm) is correct because the check is "did this meeting surface the day's MCDs?", not a pre-meeting prerequisite. |
+| 8 | Storyboard hook is two `<do_confirm_checklist>` items in `kata-session/references/team-storyboard.md`. | Bake into prose; add to `kata-session/SKILL.md`; add to `wiki/storyboard-*.md` template. | `<do_confirm_checklist>` items are greppable and machine-checkable (Success #6). The team-storyboard overlay is the canonical home for storyboard-meeting checks; SKILL.md is the umbrella; prose drifts. Exit-gate placement (do-confirm) is correct because the check is "did this meeting surface the day's redefinitions?", not a pre-meeting prerequisite. |
 | 9 | `denominator_effect: conditional-amend` admitted as a first-class value, with a cohort read-out date as the firing condition. | Conditional amendments expressed in free prose per RFC. | The team has already used conditional amendments (#804, Dim 2 → Dim 2/10). A first-class field makes the firing condition machine-readable and lets storyboard pre-surface the conditional line. |
 
 ## Migration boundary
@@ -174,11 +176,11 @@ flowchart LR
 `kata-release-merge` records the new metric prospectively from the
 implementation run forward; no historical backfill (consistent with
 `historical-phasing`). Existing experiments and obstacles need not
-file retroactive MCDs — the protocol applies to canonical-11 changes
-proposed after `measurement-protocol.md` lands on `main`. The
+file retroactive redefinitions — the protocol applies to canonical-11
+changes proposed after `measurement-protocol.md` lands on `main`. The
 implementation PR for spec 860 is itself grandfathered: it lands the
 rule and its first canonical-set addition together; subsequent
-canonical changes use the MCD form. Each storyboard file's existing
+canonical changes use the redefinition form. Each storyboard file's existing
 inline canonical-11 prose is replaced with the bulleted enumeration on
 the implementation PR; the set's cardinality grows from 11 to 12, and
 the storyboard's "≥6 of 11" target-condition denominator is updated to
@@ -190,5 +192,5 @@ historically as a corpus identifier even after the cardinality change.
 `fit-xmr` rule semantics; per-skill metric definitions other than
 `time_to_first_approval_hours`; rerunning open experiments; CSV
 backfill; branch-protection installation; agent-react routing changes
-beyond the storyboard MCD link surface; skill-pack publishing; agent
+beyond the storyboard redefinition link surface; skill-pack publishing; agent
 persona changes; the choice of any other binding-constraint metric.

--- a/specs/860-measurement-system-change-protocol/design-b.md
+++ b/specs/860-measurement-system-change-protocol/design-b.md
@@ -3,54 +3,55 @@
 ## How this differs from design-a
 
 Design-a creates a new `measurement-protocol.md` sibling reference, embeds the
-Measurement Change Disclosure (MCD) as a YAML block inside GitHub issue/PR
-bodies, picks `time_to_first_approval_hours` (a duration) as the canonical-11
-addition, and amends KATA.md § Metrics to admit duration metrics.
+Operational Redefinition as a YAML block inside GitHub issue/PR bodies, picks
+`time_to_first_approval_hours` (a duration) as the canonical-11 addition, and
+amends KATA.md § Metrics to admit duration metrics.
 
 Design-b makes four different decisions:
 
 1. **Home** — extend the existing `coordination-protocol.md` (which already owns
    the approval-signal vocabulary) with a § Measurement-system changes section.
    No new sibling reference.
-2. **MCD = file artifact** — each MCD lives at
-   `wiki/mcd/{YYYY-MM-DD}-{slug}.md`, versioned in the repo. Any canonical-11
-   edit must include the MCD file in the same PR. Detection is filesystem-grep,
-   not GitHub-issue-grep.
+2. **Redefinition = file artifact** — each redefinition lives at
+   `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md`, versioned in the repo. Any
+   canonical-11 edit must include the redefinition file in the same PR.
+   Detection is filesystem-grep, not GitHub-issue-grep.
 3. **Count metric, not duration** — the new canonical-11 entry is
    `approvals_recorded_per_run` (count of `<phase>:approved` label-add events
    observed during this run's PR sweep). KATA.md § Metrics' "count of units of
    work" rule is preserved; only the link to the protocol is added.
-4. **Storyboard hook is structural** — the MCD requirement is baked into
-   `storyboard-template.md` (the canonical scaffold), not added as a
+4. **Storyboard hook is structural** — the redefinition requirement is baked
+   into `storyboard-template.md` (the canonical scaffold), not added as a
    `<do_confirm_checklist>` item in the team-storyboard overlay.
 
-The repair-move typology (eight moves), the MCD shape, and the
-no-silent-amendment rule itself carry over unchanged in content; their **home,
-artifact form, and enforcement surface** change.
+The repair-move typology (eight moves), the redefinition shape, and the
+no-silent-redefinition rule itself carry over unchanged in content; their
+**home, artifact form, and enforcement surface** change.
 
 ## Architecture summary
 
 `coordination-protocol.md` gains a § Measurement-system changes section that
-names the eight repair moves, the MCD shape, the no-silent-amendment rule, and
-the detection recipe. Each canonical-11 change lands a `wiki/mcd/{YYYY-MM-DD}-
-{slug}.md` file in the same PR — the file IS the MCD. KATA.md § Metrics gains
-one linking paragraph. `kata-release-merge` records `approvals_recorded_per_run`
-as new rows in its existing `wiki/metrics/kata-release-merge/{YYYY}.csv`. The
-canonical-11 enumeration in `wiki/storyboard-*.md` becomes a bulleted list
-including the new metric. `storyboard-template.md` requires canonical-11 change
-items to link an MCD path.
+names the eight repair moves, the redefinition shape, the no-silent-redefinition
+rule, and the detection recipe. Each canonical-11 change lands a
+`wiki/redefinitions/{YYYY-MM-DD}-{slug}.md` file in the same PR — the file IS
+the redefinition. KATA.md § Metrics gains one linking paragraph.
+`kata-release-merge` records `approvals_recorded_per_run` as new rows in its
+existing `wiki/metrics/kata-release-merge/{YYYY}.csv`. The canonical-11
+enumeration in `wiki/storyboard-*.md` becomes a bulleted list including the new
+metric. `storyboard-template.md` requires canonical-11 change items to link a
+redefinition path.
 
 ## Components
 
 | Component | Lives in | Responsibility |
 | --- | --- | --- |
-| § Measurement-system changes | `.claude/agents/references/coordination-protocol.md` | Names the eight moves, MCD shape, no-silent-amendment rule, MCD-file detection-grep recipe. Sibling section to § Approval signal. |
+| § Measurement-system changes | `.claude/agents/references/coordination-protocol.md` | Names the eight moves, redefinition shape, no-silent-redefinition rule, redefinition-file detection-grep recipe. Sibling section to § Approval signal. |
 | KATA.md § Metrics extension | `KATA.md` | One paragraph linking to the new section. No constitutional change to "count of units of work." |
-| `wiki/mcd/` directory | `wiki/mcd/{YYYY-MM-DD}-{slug}.md` | One file per MCD. The file IS the disclosure; PRs that touch canonical-11 edges include their MCD file in the same diff. |
+| `wiki/redefinitions/` directory | `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md` | One file per redefinition. The file IS the redefinition; PRs that touch canonical-11 edges include their redefinition file in the same diff. |
 | `approvals_recorded_per_run` metric | `wiki/metrics/kata-release-merge/{YYYY}.csv` (additional rows; `metric` column; `unit=count`) | New canonical-11 entry. Producer = `kata-release-merge`. One row per run. |
 | Canonical-11 enumeration | `wiki/storyboard-*.md` | New bulleted list under § Metrics; one bullet per metric mapping `{metric → producer skill}`. Replaces inline "11 canonical metrics" prose. |
 | `kata-release-merge` `references/metrics.md` extension | `.claude/skills/kata-release-merge/references/metrics.md` | New row alongside `prs_merged`. |
-| Storyboard MCD hook | `.claude/skills/kata-session/references/storyboard-template.md` | Template requires every canonical-11 change line carries an `MCD: wiki/mcd/...md` link; cohort read-out items enumerate that day's MCD files. |
+| Storyboard redefinition hook | `.claude/skills/kata-session/references/storyboard-template.md` | Template requires every canonical-11 change line carries a `Redefinition: wiki/redefinitions/...md` link; cohort read-out items enumerate that day's redefinition files. |
 
 ## Repair-move typology
 
@@ -64,7 +65,7 @@ land via the spec/design/plan/implement chain (matches design-a #3). Adding a
 ninth move (e.g., `canonical-set-addition` for net-new metrics) is the
 natural next-spec follow-on — see Migration boundary.
 
-## MCD shape (file artifact)
+## Redefinition shape (file artifact)
 
 ```yaml
 ---
@@ -84,7 +85,7 @@ links:
   pr: <#NNN>?
 ---
 
-# MCD — <human-readable title>
+# Redefinition — <human-readable title>
 
 <one-paragraph context: what changed, why this move, what the cohort ratifies>
 ```
@@ -97,31 +98,32 @@ non-`none` requires a linked storyboard headline and a cohort read-out date.
 
 The rule is `git diff`-native, stated in `coordination-protocol.md`: **any
 commit touching a canonical-11 metric edge must, in the same commit, add or
-modify a `wiki/mcd/*.md` file.** Edges are edits to lines naming a canonical-11
-metric in `wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, or
-`coordination-protocol.md` § Measurement-system changes (which mirrors the
-canonical-11 enumeration for git-grep symmetry). Recipe:
+modify a `wiki/redefinitions/*.md` file.** Edges are edits to lines naming a
+canonical-11 metric in `wiki/storyboard-*.md`,
+`.claude/skills/*/references/metrics.md`, or `coordination-protocol.md`
+§ Measurement-system changes (which mirrors the canonical-11 enumeration for
+git-grep symmetry). Recipe:
 
 ```sh
-# Commits that edit canonical-11 edges but do NOT touch wiki/mcd/.
+# Commits that edit canonical-11 edges but do NOT touch wiki/redefinitions/.
 for c in $(git log --format=%H --since="<date>" -- \
     'wiki/storyboard-*.md' \
     '.claude/skills/*/references/metrics.md' \
     '.claude/agents/references/coordination-protocol.md'); do
   git diff-tree --no-commit-id --name-only -r "$c" \
-    | grep -q '^wiki/mcd/' || echo "$c missing MCD"
+    | grep -q '^wiki/redefinitions/' || echo "$c missing redefinition"
 done
 ```
 
 CI mechanisation on `HEAD...main` is the natural follow-on (out of scope).
 
-## No-silent-amendment rule
+## No-silent-redefinition rule
 
 > No change to the canonical-11 denominator (additions, removals, conditional
-> or unconditional amendments) lands without an MCD file at
-> `wiki/mcd/{YYYY-MM-DD}-{slug}.md` whose `denominator_effect` is non-`none`,
-> a cohort read-out date on or before the storyboard meeting at which the
-> change takes effect, and a linked storyboard headline.
+> or unconditional redefinitions) lands without a redefinition file at
+> `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md` whose `denominator_effect` is
+> non-`none`, a cohort read-out date on or before the storyboard meeting at
+> which the change takes effect, and a linked storyboard headline.
 
 This single statement lives in `coordination-protocol.md` § Measurement-system
 changes. KATA.md § Metrics links to it; no other file restates it.
@@ -143,7 +145,7 @@ amending KATA.md.
 - **Stock-vs-flow note:** count is flow-shaped (matches every other canonical
   metric). Approval-queue dwell — the stock signal design-a records — is
   recoverable from the same timeline data and is the natural future sidecar
-  (would file its own MCD with `move: sidecar-pre-flight`).
+  (would file its own redefinition with `move: sidecar-pre-flight`).
 - **Empty-run row:** zero is recorded as `0` (matches every count metric;
   structural-zero risk applies only when the producer is missing).
 
@@ -151,41 +153,42 @@ amending KATA.md.
 
 ```mermaid
 flowchart LR
-  CHG[Canonical-11 change in PR] --> MCD[wiki/mcd/...md<br/>same PR]
-  MCD --> READ[Cohort read-out at horizon]
+  CHG[Canonical-11 change in PR] --> RDF[wiki/redefinitions/...md<br/>same PR]
+  RDF --> READ[Cohort read-out at horizon]
   READ --> RAT{Ratify?}
   RAT -- yes --> AMEND[Storyboard line updates]
   RAT -- no --> ROLL[Change rolled back]
   KATA[KATA.md § Metrics] -.-> REF[coordination-protocol.md<br/>§ Measurement-system changes]
   STORY[wiki/storyboard-*.md] -.-> REF
   RM[kata-release-merge] --> CSV[metrics CSV] --> XMR[fit-xmr analyze]
-  REF -. owns .-> MOVES[Eight moves + MCD shape + rule]
-  CI[git-diff grep] -. pairs .-> MCD
+  REF -. owns .-> MOVES[Eight moves + redefinition shape + rule]
+  CI[git-diff grep] -. pairs .-> RDF
 ```
 
 ## Key decisions
 
 | # | Decision | Rejected alternative | Why |
 | --- | --- | --- | --- |
-| 1 | Locate the typology, MCD shape, rule, and grep recipe inside `coordination-protocol.md` as a new § section. | New sibling `measurement-protocol.md` (design-a #1). | The MCD-and-approval-signal vocabularies are tightly coupled (approvals are how cohort ratification happens; `<phase>:approved` is the binding constraint metric). Co-locating keeps one home for one coherent topic; a new file fragments protocol space and adds a navigation hop. **Size impact:** `coordination-protocol.md` is 165 lines today; the new section adds ~70 lines (typology table + MCD shape + rule + grep), pushing it to ~235 lines. References do not carry the 200-line cap that designs do (no soft cap is documented in CONTRIBUTING.md or CLAUDE.md for this directory); design-a's choice of a separate file was made for topic separation, not size. |
-| 2 | MCD is a file artifact at `wiki/mcd/{YYYY-MM-DD}-{slug}.md`, included in the same PR as the canonical-11 change. | YAML block embedded in GitHub issue/PR body (design-a #2). | Issue/PR bodies are mutable post-merge and live outside `git`. A file artifact is review-gated, history-bearing, and lets detection be `git diff`-native (Success #6) rather than dependent on GitHub-API queries. CI can mechanise the pairing check; embedded YAML cannot. |
+| 1 | Locate the typology, redefinition shape, rule, and grep recipe inside `coordination-protocol.md` as a new § section. | New sibling `measurement-protocol.md` (design-a #1). | The redefinition-and-approval-signal vocabularies are tightly coupled (approvals are how cohort ratification happens; `<phase>:approved` is the binding constraint metric). Co-locating keeps one home for one coherent topic; a new file fragments protocol space and adds a navigation hop. **Size impact:** `coordination-protocol.md` is 165 lines today; the new section adds ~70 lines (typology table + redefinition shape + rule + grep), pushing it to ~235 lines. References do not carry the 200-line cap that designs do (no soft cap is documented in CONTRIBUTING.md or CLAUDE.md for this directory); design-a's choice of a separate file was made for topic separation, not size. |
+| 2 | Redefinition is a file artifact at `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md`, included in the same PR as the canonical-11 change. | YAML block embedded in GitHub issue/PR body (design-a #2). | Issue/PR bodies are mutable post-merge and live outside `git`. A file artifact is review-gated, history-bearing, and lets detection be `git diff`-native (Success #6) rather than dependent on GitHub-API queries. CI can mechanise the pairing check; embedded YAML cannot. |
 | 3 | Producer for the approval-throughput metric is `kata-release-merge`. | New `kata-approval-meter` skill; or `kata-session`. | Same reasoning as design-a #4 — `kata-release-merge` already iterates phase PRs and reads label state; new skill adds matrix entry for one metric; `kata-session` runs once daily and would miss between-meeting churn. (Design-a and -b agree here.) |
-| 4 | The new metric is `approvals_recorded_per_run` (count of fresh `<phase>:approved` events observed this run), preserving KATA.md "count of units of work." | `time_to_first_approval_hours` (duration; design-a #7) — requires KATA.md § Metrics constitutional extension. | **Acknowledged trade-off:** count reads approval throughput as a *rate* and detects rate drops via `xRule2`; it does NOT directly surface queue-dwell drift the way design-a's duration metric does. Design-a sees dwell-stock-shape as the binding-constraint signal #572 names; design-b takes the position that dwell is a derivable signal a future sidecar can read (move: `sidecar-pre-flight`, filed as its own MCD) once the count metric establishes the producer cadence. The win is that no KATA.md amendment is required to admit either count or any subsequent sidecar. The cost is one cycle of latency before dwell becomes a first-class signal. Reviewers should weigh: is preserving "count of units of work" worth deferring the dwell signal? |
+| 4 | The new metric is `approvals_recorded_per_run` (count of fresh `<phase>:approved` events observed this run), preserving KATA.md "count of units of work." | `time_to_first_approval_hours` (duration; design-a #7) — requires KATA.md § Metrics constitutional extension. | **Acknowledged trade-off:** count reads approval throughput as a *rate* and detects rate drops via `xRule2`; it does NOT directly surface queue-dwell drift the way design-a's duration metric does. Design-a sees dwell-stock-shape as the binding-constraint signal #572 names; design-b takes the position that dwell is a derivable signal a future sidecar can read (move: `sidecar-pre-flight`, filed as its own redefinition) once the count metric establishes the producer cadence. The win is that no KATA.md amendment is required to admit either count or any subsequent sidecar. The cost is one cycle of latency before dwell becomes a first-class signal. Reviewers should weigh: is preserving "count of units of work" worth deferring the dwell signal? |
 | 5 | Repair-move list is closed at design time (matches design-a #3). | Open list, or a `tbd` provisional. | Spec Scope-in enumerates the eight moves explicitly — the closure is spec-level. A `tbd` provisional reverts to ad-hoc; an open list with `new-move` defeats the typology. New moves land via spec/design/plan/implement, same as design-a. (Both designs agree.) |
 | 6 | New metric joins existing `kata-release-merge/{YYYY}.csv` as additional rows. | Sibling CSV. | (Same as design-a #6 — both designs agree.) |
-| 7 | Storyboard hook lives in `storyboard-template.md` (every storyboard inherits the MCD requirement structurally). | `<do_confirm_checklist>` items in `team-storyboard.md` (design-a #8). | A template inclusion is a structural property of every storyboard file; a checklist item runs once per meeting and is human-checked. Template inclusion makes the MCD link a visible scaffold the meeting fills in, not a check-the-box gate. Detection (Success #6) becomes part of the template-rendered file itself. |
+| 7 | Storyboard hook lives in `storyboard-template.md` (every storyboard inherits the redefinition requirement structurally). | `<do_confirm_checklist>` items in `team-storyboard.md` (design-a #8). | A template inclusion is a structural property of every storyboard file; a checklist item runs once per meeting and is human-checked. Template inclusion makes the redefinition link a visible scaffold the meeting fills in, not a check-the-box gate. Detection (Success #6) becomes part of the template-rendered file itself. |
 | 8 | `denominator_effect: conditional-amend` admitted as a first-class enum value. | (Same as design-a #9 — both designs agree.) | Identical reasoning. |
 
 ## Migration boundary
 
 The implementation PR for spec 860 is **explicitly grandfathered**: it is the
 founding diff and predates the protocol it lands. It records the denominator
-change (11→12) in the spec and storyboard diffs but does not file an MCD —
-none of the eight named moves cleanly cover "net-new-metric addition to the
-canonical set." Acknowledged gap: the first follow-on spec adds a ninth move
-(`canonical-set-addition`) and its falsifier-set kind. From that spec forward,
-every canonical-11 change uses an MCD file. Existing experiments and obstacles
-do not file retroactive MCDs. Each storyboard's inline "11 canonical metrics"
+change (11→12) in the spec and storyboard diffs but does not file a
+redefinition — none of the eight named moves cleanly cover "net-new-metric
+addition to the canonical set." Acknowledged gap: the first follow-on spec adds
+a ninth move (`canonical-set-addition`) and its falsifier-set kind. From that
+spec forward, every canonical-11 change uses a redefinition file. Existing
+experiments and obstacles do not file retroactive redefinitions. Each
+storyboard's inline "11 canonical metrics"
 prose becomes the bulleted enumeration on the implementation PR; "≥6 of 11"
 becomes "≥6 of 12" in the same diff. "Canonical-11" is retained historically.
 
@@ -195,5 +198,5 @@ becomes "≥6 of 12" in the same diff. "Canonical-11" is retained historically.
 re-running open experiments; CSV backfill; branch-protection installation;
 `agent-react` routing changes; skill-pack publishing; agent-persona changes;
 the choice of any other binding-constraint metric. CI enforcement of the
-MCD-pairing grep is acknowledged as a desirable follow-on, not part of this
+redefinition-pairing grep is acknowledged as a desirable follow-on, not part of this
 spec.

--- a/specs/860-measurement-system-change-protocol/spec.md
+++ b/specs/860-measurement-system-change-protocol/spec.md
@@ -13,7 +13,7 @@ no protocol describing what happens when a producing skill changes,
 moves, or is removed. The team has invented and applied a recurring
 typology of safe repair moves to keep the measurement system honest, but
 the typology has no canonical home, the discipline that gates it ("no
-silent amendment of the canonical-11 denominator") has no canonical
+silent redefinition of the canonical-11 denominator") has no canonical
 home, and the binding constraint on enacting any of these repairs —
 human approval throughput — is not itself one of the canonical metrics
 the loop reads.
@@ -44,12 +44,12 @@ These repair moves work, but they are reinvented per case. Each issue
 restates what counts as a safe move, what the falsifier set looks like,
 and what discipline applies to the canonical-11 denominator while the
 move is in flight. There is no shared definition for any of: the move
-typology, the disclosure that must accompany a canonical-11 change, or
+typology, the redefinition that must accompany a canonical-11 change, or
 the cohort read-out that ratifies one.
 
-### The "no-silent-amendment" rule has no canonical home
+### The "no-silent-redefinition" rule has no canonical home
 
-RFC #804 invokes a "no-silent-amendment rule" to surface a conditional
+RFC #804 invokes a "no-silent-redefinition rule" to surface a conditional
 canonical-11 → canonical-10 amendment up-front, and SE Exp 33 (#787)
 keeps a sidecar CSV explicitly to "preserve the May denominator" until
 the 1-on-1 ratifies a redefinition. Both treat the rule as authoritative
@@ -73,11 +73,11 @@ it.
 ## Goal
 
 Canonicalise the measurement-system change protocol the team is already
-running implicitly. Name the safe repair moves; require a disclosure
-artifact for any change to a canonical-11 metric; place the no-silent-
-amendment rule in a single shared reference; and add an approval-
-throughput metric to the canonical-11 frame so the binding constraint is
-itself read by the same loop. The loop continues to read XmR signals
+running implicitly. Name the safe repair moves; require an operational
+redefinition artifact for any change to a canonical-11 metric; place the
+no-silent-redefinition rule in a single shared reference; and add an
+approval-throughput metric to the canonical-11 frame so the binding
+constraint is itself read by the same loop. The loop continues to read XmR signals
 unchanged; what changes is the protocol that surrounds canonical-11
 metric churn and the set of metrics the loop reads.
 
@@ -88,13 +88,13 @@ metric churn and the set of metrics the loop reads.
   pre-flight, stock-vs-flow recast, event-driven recast, XmR
   rule-semantics RFC, and habit-to-policy promotion. Each move's name
   binds to a one-sentence definition and a falsifier-set requirement.
-- **Measurement Change Disclosure (MCD).** A required artifact shape for
-  any change to a canonical-11 metric: skill removal/rename/split,
-  metric definition change, sidecar opening, denominator amendment,
-  rule-semantics challenge. The MCD names the move, the affected
+- **Operational Redefinition (Redefinition).** A required artifact shape
+  for any change to a canonical-11 metric: skill removal/rename/split,
+  metric definition change, sidecar opening, denominator redefinition,
+  rule-semantics challenge. The redefinition names the move, the affected
   metric(s), the falsifier set, the verdict horizon, and the cohort
   read-out date.
-- **No-silent-amendment rule, canonical home.** A single reference
+- **No-silent-redefinition rule, canonical home.** A single reference
   defining it. KATA.md § Metrics links to it.
 - **Canonical-11 entry for approval throughput.** Add one
   approval-throughput metric to the canonical set, with a named
@@ -103,11 +103,11 @@ metric churn and the set of metrics the loop reads.
   `wiki/metrics/{skill}/{YYYY}.csv`. The metric reads the binding
   constraint #572 names.
 - **Storyboard hook.** The storyboard meeting template requires that any
-  canonical-11 change reference an MCD, and that any cohort read-out
-  consumes the MCD set for the day.
+  canonical-11 change reference a redefinition, and that any cohort
+  read-out consumes the redefinition set for the day.
 - **KATA.md § Metrics extension.** § Metrics extends to point to the
-  repair-move typology, the MCD shape, the no-silent-amendment rule,
-  and the approval-throughput entry.
+  repair-move typology, the redefinition shape, the no-silent-redefinition
+  rule, and the approval-throughput entry.
 
 ## Scope (out)
 
@@ -124,8 +124,8 @@ metric churn and the set of metrics the loop reads.
   move is annotation-only by design (per #809).
 - **Branch-protection installation** (#564 governance gap). The
   protocol covers measurement; governance is a separate workstream.
-- **Agent-react / Discussion routing changes** beyond surfacing the MCD
-  link in cohort read-out items.
+- **Agent-react / Discussion routing changes** beyond surfacing the
+  redefinition link in cohort read-out items.
 - **Skill-pack publishing.** No external skill-pack contract changes;
   internal references only.
 - **Agent persona / scope-constraint changes.** Agents continue to own
@@ -142,11 +142,11 @@ metric churn and the set of metrics the loop reads.
 | # | Claim | Verification |
 | --- | --- | --- |
 | 1 | The repair-move typology is enumerated in one place; each named move has a one-sentence definition and a falsifier-set requirement. | Grep for the named moves (`producer-rehoming`, `mode-restriction`, `historical-phasing`, `sidecar-pre-flight`, `stock-vs-flow-recast`, `event-driven-recast`, `rule-semantics-rfc`, `habit-to-policy`) returns one canonical definition each from a single reference file. |
-| 2 | The Measurement Change Disclosure has a named shape with required fields: move name, affected metric(s), falsifier set, verdict horizon, cohort read-out date. | Static inspection of the reference: an MCD section enumerates required fields and provides one filled-in example drawn from an existing experiment (e.g. SE Exp 33 #787 sidecar pre-flight). |
-| 3 | The no-silent-amendment rule has a canonical home and is reachable from KATA.md § Metrics. | KATA.md § Metrics contains a link to a single reference section that states the rule; no other file restates it. |
+| 2 | The Operational Redefinition has a named shape with required fields: move name, affected metric(s), falsifier set, verdict horizon, cohort read-out date. | Static inspection of the reference: a redefinition section enumerates required fields and provides one filled-in example drawn from an existing experiment (e.g. SE Exp 33 #787 sidecar pre-flight). |
+| 3 | The no-silent-redefinition rule has a canonical home and is reachable from KATA.md § Metrics. | KATA.md § Metrics contains a link to a single reference section that states the rule; no other file restates it. |
 | 4 | An approval-throughput metric is added to the canonical-11 set with a named producer skill, a one-row-per-run discipline, and a CSV path under `wiki/metrics/{skill}/{YYYY}.csv`. | The metric appears in (a) the producer skill's `references/metrics.md`, (b) the canonical-11 enumeration in `wiki/storyboard-*.md`, and (c) one example row written under the producer skill's CSV path during the implementation run. |
-| 5 | The storyboard meeting template requires canonical-11 changes to reference an MCD. | The template (in the `kata-storyboard` skill or the agent persona) names the MCD as a required link for any canonical-11 change item; a worked example references an MCD by its issue or section anchor. |
-| 6 | A change to a canonical-11 metric without an MCD is detectable from `git diff` alone. | A grep for canonical-11 metric edits in the protocol's reference, in `wiki/storyboard-*.md`, or in a producer skill's `references/metrics.md` returns each change paired with a link to its MCD. The protocol's reference states the grep recipe. |
+| 5 | The storyboard meeting template requires canonical-11 changes to reference a redefinition. | The template (in the `kata-storyboard` skill or the agent persona) names the redefinition as a required link for any canonical-11 change item; a worked example references a redefinition by its issue or section anchor. |
+| 6 | A change to a canonical-11 metric without a redefinition is detectable from `git diff` alone. | A grep for canonical-11 metric edits in the protocol's reference, in `wiki/storyboard-*.md`, or in a producer skill's `references/metrics.md` returns each change paired with a link to its redefinition. The protocol's reference states the grep recipe. |
 
 ## Notes — evidence pointers (for design)
 


### PR DESCRIPTION
## Summary

- Rename "Measurement Change Disclosure (MCD)" → "Operational Redefinition (Redefinition)" across spec 860 (`spec.md`, `design-a.md`, `design-b.md`).
- Rename rule "no-silent-amendment" → "no-silent-redefinition".
- Rename design-b directory `wiki/mcd/` → `wiki/redefinitions/`, YAML key `mcd:` → `redefinition:`, and link prefix `MCD:` → `Redefinition:`.

Operational definitions are Deming's term of art; redefining one is the natural verb. Plural-noun directory matches the existing `wiki/metrics/` convention. Companion edits (PR #838 description, PR/issue comments referencing the rename, wiki entries) were applied out-of-band so the canonical vocabulary is consistent everywhere it surfaces.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (13 wiki-test-fixture failures are pre-existing in this env, unrelated to MD-only changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_012S34ZrGnj1WXK8wj2kHvr6)_