### PR TITLE
plan(860): plan-b for design-b measurement-system change protocol

### DIFF
--- a/specs/860-measurement-system-change-protocol/plan-b.md
+++ b/specs/860-measurement-system-change-protocol/plan-b.md
@@ -4,80 +4,80 @@ Spec: [spec.md](spec.md) · Design: [design-b.md](design-b.md)
 
 ## Rationale
 
-This plan pairs with `design-b.md` (the alternative architecture: protocol
-co-located in `coordination-protocol.md`, redefinitions as `wiki/redefinitions/`
-file artifacts, `approvals_recorded_per_run` as a count metric, redefinition
-hook baked into `storyboard-template.md`). A sibling `plan-a.md` would pair
-with `design-a.md` (new `measurement-protocol.md` sibling reference; YAML
-blocks embedded in issue/PR bodies; `time_to_first_approval_hours` duration
-metric; storyboard hook as `<do_confirm_checklist>` items in
-`team-storyboard.md`). The letter pairing keeps the chain readable: design-b
-→ plan-b. The approver selects the design variant to implement; this plan
-becomes live only if design-b is chosen.
+Pairs with `design-b.md`. A sibling `plan-a.md` would pair with `design-a.md`.
+The approver selects which design variant to implement; this plan becomes
+live only if design-b is chosen.
 
 ## Approach
 
-Land the protocol inside `.claude/agents/references/coordination-protocol.md`
-as one new § Measurement-system changes section (eight repair moves, the
-redefinition file shape, the no-silent-redefinition rule, the
-`git diff`-native detection recipe), add a one-paragraph link from
-`KATA.md` § Metrics, register `approvals_recorded_per_run` in
-`kata-release-merge` (one row in `references/metrics.md`, recording
-instructions in `SKILL.md`), and bake the redefinition-link slot plus the
-bulleted canonical-12 enumeration into `kata-session/references/storyboard-template.md`.
-The implementation run also writes the wiki-side companions through the
-separate wiki checkout: the May storyboard's "11 canonical metrics" prose is
-replaced with the bulleted enumeration (denominator 11→12 in the same diff)
-and one founding worked-example redefinition file lands at
-`wiki/redefinitions/2026-05-12-se-exp-33-sidecar-pre-flight.md` (illustrative;
-the implementation PR itself is grandfathered per design § Migration
-boundary). The first row of `approvals_recorded_per_run` is appended to the
-existing long-format CSV by the implementation run.
+Land the protocol in `coordination-protocol.md` as one new
+§ Measurement-system changes section (the eight repair moves with one-sentence
+definitions and falsifier-set kinds sourced from the spec's evidence pointers;
+the redefinition file shape; the no-silent-redefinition rule; the
+detection grep); add a one-paragraph link from `KATA.md` § Metrics; register
+`approvals_recorded_per_run` in `kata-release-merge` (one row in
+`references/metrics.md`, recording instructions in `SKILL.md`); add the
+`Redefinition:` link slot to the Headlines bullet template in
+`storyboard-template.md`. The wiki-side change (canonical enumeration update
+and denominator increment in `wiki/storyboard-2026-M05.md`) ships through
+the separate wiki checkout in the implementation run. The implementation PR
+itself files no redefinition (design § Migration boundary); the first row of
+`approvals_recorded_per_run` is appended only when `kata-release-merge`
+actually runs its new Step 9.5.
 
 Libraries used: none.
 
-## Plan-level decisions (design left open)
+## Step 1 — `coordination-protocol.md` § Measurement-system changes
 
-| # | Decision | Rejected | Why |
-|---|---|---|---|
-| P1 | Cohort window for `approvals_recorded_per_run` is `(prev_started_at, current_started_at]`, where `current_started_at` is captured at SKILL.md Step 0 as `date -u +%FT%TZ`, and `prev_started_at` is parsed from the previous row's `note` field (encoded as `started_at=<ISO>;...`). First-ever row falls back to `current_started_at - 8h` (the median schedule gap of 03:00 / 12:00 / 20:00 UTC). | Sidecar state file under `wiki/metrics/kata-release-merge/`; or `gh api` query for `event > previous_run_finished_at` using GitHub Actions run timestamps. | A state file fragments the metric's home; Actions timestamps require cross-workflow API reads that the skill does not otherwise need. The CSV `note` already carries free-form annotations — encoding `started_at` there keeps the producer self-contained. |
-| P2 | Window-source query is `gh api repos/{owner}/{repo}/issues/{number}/timeline --paginate --jq '.[] | select(.event=="labeled" and (.label.name|test("^(spec\|design\|plan):approved$")))'` over each open phase PR surveyed in SKILL.md Step 1, plus `gh api repos/{owner}/{repo}/pulls/{number}/reviews --paginate --jq '.[] | select(.state=="APPROVED")'` for review-shaped approvals. `plan:implemented` is excluded by the regex (design § Approval-throughput metric). | `gh pr view --json timelineItems`. | `gh pr view` does not expose label-add timestamps; the REST timeline API does. The skill already calls `gh api` (Step 2 contributor lookup), so no new dependency. |
-| P3 | Filled-in worked example required by spec Success #2 lives **inline** in `coordination-protocol.md` § Measurement-system changes (the SE Exp 33 #787 sidecar-pre-flight case). The wiki-side founding redefinition file at `wiki/redefinitions/2026-05-12-se-exp-33-sidecar-pre-flight.md` is committed as the **on-disk** worked example referenced from the protocol section. Both point to the same case; reviewers can grep `producer-rehoming` or `sidecar-pre-flight` from either surface and reach the same content. | One example only (either inline or wiki-side). | Spec Success #2 requires "one filled-in example" in the reference (inline). Design § Detection requires a file at `wiki/redefinitions/` exists so the grep recipe matches at least one path. The two satisfy different success criteria; both ship. |
-| P4 | Canonical-11 → canonical-12 enumeration replaces inline prose **only in the current month's storyboard** (`wiki/storyboard-2026-M05.md`). `storyboard-template.md` ships the enumeration as a `<!-- canonical-12 -->` marker block plus a `Redefinition:` link slot under § Current Condition § Headlines, so future months inherit the shape via `bunx fit-wiki refresh`. | Edit every historical `wiki/storyboard-*.md`. | Historical storyboards are append-only audit records (per `memory-protocol.md` § Weekly Log Contract analogue). The current-month file is the only live consumer; the template propagates the shape forward. |
-| P5 | `approvals_recorded_per_run` value column is the **count** of distinct label-add events plus APPROVED-review events observed in the window. Same `<phase>:approved` label re-applied to the same PR within the window counts once (de-dupe on `(pr_number, label_name, event_timestamp_truncated_to_second)`). | Count every raw API event. | Re-application within one second is GitHub UI noise (button double-click), not a separate ratification. The de-dupe key is mechanical. |
-
-## Step 1 — coordination-protocol.md § Measurement-system changes
-
-Add a new H2 section between the existing `## Approval signal` (line 34) and
-`## Decision questions` (line 62) — the sibling placement design-b § Components
-specifies. **Modified:**
+Add a new H2 section between `## Approval signal` (line 34) and
+`## Decision questions` (line 62). **Modified:**
 `.claude/agents/references/coordination-protocol.md`.
 
-The section carries, in order:
+The section carries six parts in this order. The plan authors the eight
+repair-move row contents directly here (design-b § Repair-move typology lists
+only the move names; the spec's Notes § Repair-move corpus pins each move to
+specific evidence; this plan converts that evidence into one definition row
+per move):
 
 1. **Lead paragraph** (≤4 lines) — names the typology, the redefinition file
    artifact, the no-silent-redefinition rule, and the detection grep as the
    four components.
-2. **Eight repair moves** — a table with columns `Move | Definition | Falsifier-set kind | Existing precedent`, populated verbatim from design-b § Repair-move typology and the eight rows in design-a § Repair-move typology (both designs agree on content, only home differs). The list is closed at design time; "extensions land via the spec/design/plan/implement chain" is stated in one sentence after the table.
-3. **Redefinition shape** — a fenced YAML code block exactly matching design-b § Redefinition shape (file artifact). One sentence below clarifies `verdict_horizon ≤ cohort_readout` and the `denominator_effect` enum semantics.
-4. **No-silent-redefinition rule** — blockquote verbatim from design-b § No-silent-redefinition rule. The "KATA.md § Metrics links to it; no other file restates it" sentence follows.
-5. **Worked example** (spec Success #2) — heading `### Worked example — SE Exp 33 (#787) sidecar pre-flight`. Inline YAML front-matter populated for the SE Exp 33 case (`move: sidecar-pre-flight`, `affected_metrics: [{skill: kata-trace, metric: findings_count}]`, falsifier `sidecar diverges from canonical at horizon`, `denominator_effect: sidecar`, links to #787 and the wiki file from P3). The corresponding on-disk file is named in the example body.
-6. **Detection (Success #6)** — heading `### Detection`. The fenced `sh` block from design-b verbatim. One sentence above states the rule ("any commit touching a canonical-11 metric edge must, in the same commit, add or modify a `wiki/redefinitions/*.md` file"); one sentence below names the edges (`wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, `coordination-protocol.md` § Measurement-system changes).
+2. **Eight repair-move table** with columns `Move | Definition | Falsifier-set kind | Existing precedent`:
 
-Approximate net addition: 70 lines (matches design-b decision #1
-size-impact estimate). Final file length ~235 lines; references do not
-carry the 200-line design cap (no soft cap in CONTRIBUTING.md or
-CLAUDE.md for `.claude/agents/references/`).
+   | Move | Definition (one sentence) | Falsifier-set kind | Existing precedent |
+   |---|---|---|---|
+   | `producer-rehoming` | Reassign a metric's producing skill when the original is removed/split/renamed; record a continuity tag on the first row under the new producer. | "structural-zero rows present after rehoming run" | #788, RFC #804 |
+   | `mode-restriction` | Narrow recording to one activation mode of a multi-mode skill so the series is unimodal. | "post-restriction series remains bimodal under XmR" | #772, PR #773 |
+   | `historical-phasing` | Annotate a series with a Phase boundary; XmR analysis windows on Phase 1; no CSV backfill. | "Phase 1 cannot reach `predictable` after horizon" | #809, PR #811 |
+   | `sidecar-pre-flight` | Record a candidate metric to a sibling CSV while the canonical metric continues; no denominator change until ratification. | "sidecar diverges from canonical at horizon" | #787 |
+   | `stock-vs-flow-recast` | Replace a flow-rate metric with a stock metric on the same axis when burst architecture trips XmR by construction. | "stock series fires `xRule1` or `mrRule1` post-recast" | #768, #770 |
+   | `event-driven-recast` | Replace per-day cadence with per-activation ("no row, no event"). | "per-activation series remains `insufficient_data` at horizon" | #810 |
+   | `rule-semantics-rfc` | Challenge an XmR rule's blocking effect on `predictable` via Discussion RFC; quorum required. | "RFC quorum not reached by horizon" | #814 |
+   | `habit-to-policy` | Promote an undocumented defensive habit into a `SKILL.md` check after a defect surfaces. | "post-promotion defect of the same shape recurs" | #817, PR #655 |
 
-Verify: `wc -l .claude/agents/references/coordination-protocol.md` shows
-≈235; `rg '^## Measurement-system changes$' .claude/agents/references/coordination-protocol.md` returns one hit; `rg 'producer-rehoming|mode-restriction|historical-phasing|sidecar-pre-flight|stock-vs-flow-recast|event-driven-recast|rule-semantics-rfc|habit-to-policy' .claude/agents/references/coordination-protocol.md | wc -l` returns ≥8 (one definition row per move).
+   One sentence below the table states the list is closed; "extensions land
+   via the spec/design/plan/implement chain."
 
-## Step 2 — KATA.md § Metrics linking paragraph
+3. **Redefinition shape** — a fenced YAML code block exactly matching design-b
+   § Redefinition shape. One sentence below states `verdict_horizon ≤ cohort_readout`
+   and the `denominator_effect` enum semantics.
+4. **No-silent-redefinition rule** — blockquote verbatim from design-b § No-silent-redefinition rule, followed by the sentence "KATA.md § Metrics links to it; no other file restates it."
+5. **Worked example** (spec Success #2) — heading `### Worked example — SE Exp 33 (#787) sidecar pre-flight`. Inline YAML front-matter populated for the SE Exp 33 case (`move: sidecar-pre-flight`, `affected_metrics: [{skill: kata-trace, metric: findings_count}]`, falsifier `sidecar diverges from canonical at horizon`, `verdict_horizon: 2026-05-19`, `cohort_readout: 2026-05-26`, `denominator_effect: sidecar`, `links.experiment_issue: #787`, `links.obstacle_issue: #788`). The example is **inline only**; no on-disk founding redefinition file is created (design § Migration boundary explicitly grandfathers the spec 860 implementation PR — it does not file a redefinition).
+6. **Detection** — heading `### Detection`. The fenced `sh` block from design-b verbatim. One sentence above states the rule ("any commit touching a canonical-11 metric edge must, in the same commit, add or modify a `wiki/redefinitions/*.md` file"); one sentence below names the edges (`wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, `coordination-protocol.md` § Measurement-system changes) and acknowledges per design § Detection that cross-repo enforcement (between this monorepo and the wiki repo) is the follow-on CI workstream.
+
+Verify: `rg '^## Measurement-system changes$' .claude/agents/references/coordination-protocol.md` returns one hit;
+`rg -c '^\| \`(producer-rehoming|mode-restriction|historical-phasing|sidecar-pre-flight|stock-vs-flow-recast|event-driven-recast|rule-semantics-rfc|habit-to-policy)\`' .claude/agents/references/coordination-protocol.md` returns 8;
+`rg '^### Worked example' .claude/agents/references/coordination-protocol.md` returns one hit;
+`rg '^### Detection' .claude/agents/references/coordination-protocol.md` returns one hit.
+
+## Step 2 — `KATA.md` § Metrics linking paragraph
 
 Append one paragraph at the end of § Metrics (currently lines 257–274,
-ending at the `fit-xmr` sentence on line 274). **Modified:** `KATA.md`.
+last line `control limits and signals — numbers, not narratives.`).
+**Modified:** `KATA.md`.
 
-Insert after line 274:
+Insert before the blank line that separates § Metrics from § Authentication
+(after line 274):
 
 ```markdown
 Changes to the canonical-11 set — additions, removals, conditional or
@@ -89,65 +89,74 @@ verdict horizon, and the cohort read-out date. The no-silent-redefinition rule
 lives there; this section does not restate it.
 ```
 
-The "count of units of work" sentence on line 261 is unchanged —
-design-b preserves the constitutional rule (decision #4). No other
-edits to § Metrics.
+The "count of units of work" sentence on line 261 is unchanged — design-b
+preserves it. The "exactly one metric" rule on line 261 is **not preserved**
+by adding `approvals_recorded_per_run` to `kata-release-merge`; this
+constitutional tension is the substance of Risk 1.
 
-Verify: `rg -n 'Measurement-system changes' KATA.md` returns one match
-in the § Metrics block; `git diff KATA.md` shows one inserted paragraph
-and no other hunks.
+Verify: `rg -n 'Measurement-system changes' KATA.md` returns one match in
+§ Metrics; `git diff KATA.md` shows one inserted paragraph and no other hunks.
 
-## Step 3 — kata-release-merge `references/metrics.md` new row
+## Step 3 — `kata-release-merge` `references/metrics.md` new row
 
-Add the new metric beside `prs_merged`. **Modified:**
+Add the new metric alongside `prs_merged`. **Modified:**
 `.claude/skills/kata-release-merge/references/metrics.md`.
 
-Replace the current single-row table with:
+Replace the single-row table with two rows:
 
 ```markdown
-| Metric                       | Unit  | Description                                                                                  | Data source                                                       |
-| ---------------------------- | ----- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| prs_merged                   | count | PRs merged this run                                                                          | Run actions                                                       |
-| approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed on open phase PRs in the run window | `gh api repos/.../issues/{n}/timeline` + `.../pulls/{n}/reviews`  |
+| Metric                       | Unit  | Description                                                                                                  | Data source                                                          |
+| ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| prs_merged                   | count | PRs merged this run                                                                                          | Run actions                                                          |
+| approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh api repos/.../issues/{n}/timeline` + `.../pulls/{n}/reviews`     |
 ```
 
 Append below the existing "Backlog … is queried, not recorded." line:
 
 ```markdown
-The window is `(prev_started_at, current_started_at]`; `current_started_at`
-is captured at SKILL.md Step 0; `prev_started_at` is parsed from the
-previous CSV row's `note` field (`started_at=<ISO>;…`). First-ever row
-falls back to `current_started_at - 8h`. De-dupe by
-`(pr_number, label_name, second)`; `plan:implemented` is a state label,
-excluded. See [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).
+`prev_run_start` is the `startedAt` of the previous completed `agent-team`
+workflow run, fetched with `gh run list --workflow=agent-team.yml`. Cohort:
+all open phase PRs surveyed in SKILL.md Step 1 plus any phase PR that was
+merged within the window. `plan:implemented` is a state label, excluded.
+See [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).
 ```
 
-Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/references/metrics.md` returns ≥1 hit; the table renders as two rows.
+Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/references/metrics.md` returns ≥1 hit; the table renders as two data rows under one header.
 
-## Step 4 — kata-release-merge SKILL.md recording instructions
+## Step 4 — `kata-release-merge` SKILL.md recording instructions
 
-Two small edits to wire the metric. **Modified:**
+Two edits to wire the metric. **Modified:**
 `.claude/skills/kata-release-merge/SKILL.md`.
 
-**Edit 4a** — extend Step 0 to capture `current_started_at`. Replace the
-`### Step 0: Read Memory` body to add one sentence after the existing
-memory-read instruction:
+**Edit 4a** — Step 0 captures both window timestamps. Append to the end of
+the `### Step 0: Read Memory` body:
 
 ```markdown
 Capture this run's start timestamp once at the top of the run:
-`current_started_at=$(date -u +%FT%TZ)`. The approval-throughput metric (Step 9) uses it
-as the window upper bound. Read the previous row's `started_at=<ISO>` from
-`note` in `wiki/metrics/kata-release-merge/{YYYY}.csv` to set
-`prev_started_at`; first-ever row uses `current_started_at - 8h`.
+`current_run_start=$(date -u +%FT%TZ)`. For the approval-throughput metric
+(Step 9.5), also derive the previous run's start:
+
+\`\`\`sh
+prev_run_start=$(gh run list --workflow=agent-team.yml --status=completed \
+  --limit 2 --json startedAt --jq '.[1].startedAt // empty')
+# First-ever recording falls back to current_run_start - 8h.
+[ -z "$prev_run_start" ] && prev_run_start=$(date -u -d "$current_run_start - 8 hours" +%FT%TZ)
+\`\`\`
+
+The window for approval-throughput counting is `[prev_run_start, current_run_start)`.
 ```
 
-**Edit 4b** — extend Step 9 § Classification Report so the metric row is
-produced alongside the existing record. Add a new sub-step:
+**Edit 4b** — Append a new `### Step 9.5` between the existing
+`### Step 9: Produce the Classification Report` (currently the last `### Step`)
+and the `## Memory: what to record` H2. The existing Step 9 keeps its number;
+9.5 is sub-ordinal placement, not a renumber. Body:
 
 ```markdown
 ### Step 9.5: Record approval-throughput metric
 
-For each open phase PR surveyed in Step 1, fetch label-add events:
+Cohort: every PR seen in Step 1 (open phase PRs) **plus** every phase PR
+merged during this run (Step 8) — together this covers every phase PR with
+window-relevant activity. For each cohort PR, fetch label-add events:
 
 \`\`\`sh
 gh api repos/{owner}/{repo}/issues/<number>/timeline --paginate \
@@ -161,234 +170,148 @@ gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate \
   --jq '.[] | select(.state=="APPROVED") | {ts: .submitted_at}'
 \`\`\`
 
-Filter to events whose `ts` is in `(prev_started_at, current_started_at]`;
-de-dupe label events by `(pr_number, label_name, second)` (P5). Sum to
+Filter to events whose `ts` is in `[prev_run_start, current_run_start)`
+(half-open, matches design-b § Approval-throughput metric). De-dupe label
+events by `(pr_number, label_name, second_truncated_timestamp)` so a
+double-click on the GitHub UI counts once. Sum to
 `approvals_recorded_per_run`. Append one row to
-`wiki/metrics/kata-release-merge/{YYYY}.csv` with
-`metric=approvals_recorded_per_run`, `unit=count`,
-`note="started_at=<current_started_at>;<phase>:approved=N1;APPROVED-review=N2"`
-(the prefix `started_at=<ISO>;` is required for the next run to read its
-own `prev_started_at`).
+`wiki/metrics/kata-release-merge/{YYYY}.csv`:
+`<date>,approvals_recorded_per_run,<count>,count,<run_id>,"window=[<prev>,<curr>)"`.
+Zero is recorded as `0` (matches every count metric; the structural-zero
+risk applies only when the producer is missing). The existing `prs_merged`
+row continues to be appended per Step 9.
+
+If `gh api .../timeline` fails for any PR (rate limit, scope issue), skip
+that PR, log the failure to the classification report (Step 9), and
+proceed — partial counts are recorded honestly. A blanket-failure case
+(no PRs counted because every call errored) records `0` with
+`note="window=[<prev>,<curr>);api_errors=N"` so the next storyboard
+meeting can see the producer health on the chart.
 ```
 
-The existing `prs_merged` row continues to be appended per Step 9; both
-rows share the date but carry distinct `metric` values (long-format CSV
-discipline, design-b decision #6).
+Verify: `rg -n 'approvals_recorded_per_run|prev_run_start|current_run_start' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits; `### Step 9.5:` exists between `### Step 9:` and `## Memory: what to record`.
 
-Verify: `rg -n 'approvals_recorded_per_run|started_at=' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits across Step 0 and Step 9.5; the `### Step 9.5:` heading exists between `### Step 9:` and `## Memory: what to record`.
+## Step 5 — `storyboard-template.md` Redefinition link slot
 
-## Step 5 — storyboard-template.md structural slot
-
-Bake the canonical-12 enumeration and the `Redefinition:` link slot into
-the template so every regenerated storyboard inherits them. **Modified:**
+Add the `Redefinition:` field to the Headlines bullet template only. **Do not**
+hard-code a canonical-12 enumeration in this template — the canonical enumeration
+lives in `wiki/storyboard-*.md` per design § Components, not in the
+main-repo template. **Modified:**
 `.claude/skills/kata-session/references/storyboard-template.md`.
 
-**Edit 5a** — replace the `### Headlines` body (lines 27–35) to add the
-canonical-12 marker block above the existing bullet template:
+Replace line 33 (currently
+`- \`{agent}\` / \`{metric}\` — {value} {trend/badge} — {one-line reason}`) with:
 
 ```markdown
-### Headlines
-
-_Tight list of metrics whose status changed since the last meeting (new signal,
-threshold crossed, classification flip). Empty if nothing changed — write
-"None." on a single line._
-
-<!-- canonical-12 -->
-The canonical-12 set (denominator for the Target Condition's "≥6 of 12"):
-- `kata-product-issue` / `issues_triaged`
-- `kata-spec` / `specs_drafted`
-- `kata-design` / `designs_drafted`
-- `kata-plan` / `plans_drafted`
-- `kata-implement` / `implementations_landed`
-- `kata-release-merge` / `prs_merged`
-- `kata-release-merge` / `approvals_recorded_per_run`
-- `kata-release-cut` / `releases_cut`
-- `kata-security-update` / `prs_actioned`
-- `kata-security-audit` / `findings_filed`
-- `kata-documentation` / `errors_found`
-- `kata-wiki-curate` / `entries_curated`
-<!-- /canonical-12 -->
-
 - `{agent}` / `{metric}` — {value} {trend/badge} — {one-line reason} — Redefinition: {`wiki/redefinitions/...md` or `—`}
 ```
 
-The marker block is regenerated by `bunx fit-wiki refresh` from the
-authoritative enumeration in `coordination-protocol.md` § Measurement-
-system changes (forward-compatible — current `fit-wiki refresh` only
-regenerates `xmr` markers; the `canonical-12` marker is a no-op today
-and gets a regenerator in a follow-on spec). The `Redefinition:` slot is
-the structural form spec Success #5 requires: every canonical-11 change
-item on a headline line names its redefinition file or `—` when none
-applies (e.g., an unrelated metric flip). Exactly **twelve** bullets in
-the marker block — denominator change 11→12 is encoded in the template.
+The `Redefinition:` slot is the structural form spec Success #5 requires:
+every canonical-11 change item on a headline line names its redefinition
+file or `—` when none applies. No other edits to this file.
 
-The 12-row enumeration in the template is the authoritative list; if a
-future spec adds a thirteenth metric, that spec's redefinition file
-adopts move `canonical-set-addition` (design-b § Migration boundary).
-The reviewer should confirm the eleven existing metrics in the template
-match the wiki's current canonical-11 set before merge (Risk 4); the
-implementor reads `wiki/storyboard-2026-M05.md` in Step 7 and aligns.
+Verify: `rg -n 'Redefinition:' .claude/skills/kata-session/references/storyboard-template.md` returns one hit; `git diff` shows one changed line, no inserts.
 
-**Edit 5b** — add a Redefinition line to the headlines block prose right
-above the metric-block code-fence example (currently lines 47–60), so
-authors and the `fit-wiki refresh` extension know the link slot exists.
-
-Verify: `rg -n '<!-- canonical-12 -->|Redefinition:' .claude/skills/kata-session/references/storyboard-template.md` returns ≥2 hits;
-`grep -c '^- \`' .claude/skills/kata-session/references/storyboard-template.md` shows ≥12 (the enumeration lines).
-
-## Step 6 — team-storyboard.md worked-example refresh
+## Step 6 — `team-storyboard.md` worked-example refresh
 
 The Q3-obstacle-routing worked example (lines 102–105) currently names
-four canonical-11 metrics. Update the prose to reflect the canonical-12
-denominator and reference the redefinition path. **Modified:**
+four canonical-11 metrics. Two changes. **Modified:**
 `.claude/skills/kata-session/references/team-storyboard.md`.
 
-Change "canonical-11 metric (`prs_actioned`, …)" → "canonical-12 metric
-(`prs_actioned`, …)" on line 103; append one sentence after the
-existing example: "Right route inferred from the linked redefinition file
-when one is present on the canonical-12 change item." No other edits.
+1. Replace "canonical-11 metric" with "canonical-12 metric" on line 103.
+2. Append two sentences to the worked example so spec Success #5's
+   "worked example references a redefinition by its issue or section anchor"
+   is satisfied. Example: append "Each of the four headline bullets carries
+   a `Redefinition: —` slot for this date (no canonical-12 change items
+   were filed). A hypothetical canonical-12 change to `prs_actioned` would
+   carry `Redefinition: wiki/redefinitions/2026-05-02-prs-actioned-stock-vs-flow.md`
+   on its headline line."
 
-Verify: `rg -n 'canonical-12|canonical-11' .claude/skills/kata-session/references/team-storyboard.md` returns one `canonical-12` hit and zero `canonical-11` hits.
+Verify: `rg -n 'canonical-12|Redefinition:' .claude/skills/kata-session/references/team-storyboard.md` returns ≥2 hits; `rg -n 'canonical-11' .claude/skills/kata-session/references/team-storyboard.md` returns 0 hits.
 
-## Step 7 — Wiki: storyboard-2026-M05.md enumeration update
+## Step 7 — Wiki: `storyboard-2026-M05.md` enumeration update
 
 Wiki-side change committed through the separate `wiki/` checkout during
-the implementation run (Stop hook pushes via `just wiki-push`).
+the implementation run; pushed via the Stop hook (`just wiki-push`).
 **Modified:** `wiki/storyboard-2026-M05.md`.
 
-Two edits to the May storyboard:
+The implementor reads the file's current state first (the wiki is the
+source of truth for the canonical set). Three edits, applied
+mechanically:
 
-1. Replace the inline "11 canonical metrics" prose under § Target
-   Condition with the bulleted enumeration (12 entries, same shape as
-   the template marker block).
-2. Replace the literal `≥6 of 11` denominator in the Target Condition
-   line with `≥6 of 12`.
-3. Add `Redefinition: —` to every existing headline bullet (the
-   grandfathered implementation does not file one; design § Migration
-   boundary). Future canonical-12 change items will carry a
-   `wiki/redefinitions/...md` path.
+1. **Replace the inline "11 canonical metrics" prose** under § Target
+   Condition with a bulleted enumeration. One bullet per metric mapping
+   `{producer skill} / {metric name}`. The new metric joins the list as
+   `kata-release-merge / approvals_recorded_per_run`. The implementor
+   reads each producer's `.claude/skills/kata-*/references/metrics.md`
+   to pull the exact metric name (the canonical set is whichever subset
+   of those files is currently named in the May storyboard's prose, plus
+   the new entry). Bullet count = previous canonical set size + 1.
+2. **Increment the denominator** anywhere the May storyboard literally
+   writes "≥6 of 11" → "≥6 of 12" (or the corresponding pair if the
+   current denominator differs). `rg '≥[0-9]+ of [0-9]+' wiki/storyboard-2026-M05.md`
+   enumerates every match before edit.
+3. **Add `Redefinition: —` to every existing Headlines bullet** (the
+   grandfathered implementation PR does not file one; design § Migration
+   boundary). Backfilling `—` to historical headlines is the
+   structurally-equivalent of "no redefinition cited," not a retroactive
+   filing — the slot is added, the value is the null marker.
 
-The "canonical-11" string is retained historically only as a corpus
-identifier in prose footnotes (design-b § Migration boundary).
+Verify (in the wiki checkout): `rg -n '≥6 of 12' wiki/storyboard-2026-M05.md` returns ≥1 hit; `rg -n '≥6 of 11' wiki/storyboard-2026-M05.md` returns 0 hits; `rg -c 'approvals_recorded_per_run' wiki/storyboard-2026-M05.md` returns ≥1; every Headlines bullet contains `Redefinition:`.
 
-Verify (in the wiki checkout): `rg -n 'canonical-12|≥6 of 12' wiki/storyboard-2026-M05.md` returns ≥2 hits; `rg -n '≥6 of 11' wiki/storyboard-2026-M05.md` returns 0 hits.
+## Step 8 — Quality gates
 
-## Step 8 — Wiki: founding redefinition file + first metric row
+Run from repo root in order: `bun run format:fix`, `bun run check`, `bun run test`. Format first so `check` sees formatted output; this matches the CONTRIBUTING.md convention. The change set is documentation-only on the main-repo side; no codegen or build steps are involved.
 
-Wiki-side companions to the main-repo protocol landing. **Created:**
-`wiki/redefinitions/2026-05-12-se-exp-33-sidecar-pre-flight.md`.
-**Modified:** `wiki/metrics/kata-release-merge/2026.csv`.
-
-**File contents** (matches design-b § Redefinition shape):
-
-```markdown
----
-move: sidecar-pre-flight
-affected_metrics:
-  - {skill: kata-trace, metric: findings_count}
-falsifier_set:
-  - sidecar diverges from canonical at verdict horizon
-verdict_horizon: 2026-05-19
-cohort_readout: 2026-05-26
-denominator_effect: sidecar
-links:
-  obstacle_issue: "#788"
-  experiment_issue: "#787"
-  pr: null
----
-
-# Redefinition — SE Exp 33 #787 sidecar pre-flight (founding example)
-
-This file is the on-disk worked example that satisfies the detection grep in
-[`coordination-protocol.md` § Measurement-system changes](../.claude/agents/references/coordination-protocol.md#measurement-system-changes).
-It mirrors the inline example in that section. Spec 860's implementation PR is
-explicitly grandfathered (design-b § Migration boundary) and does not file its
-own redefinition; the first follow-on spec adopts move `canonical-set-addition`
-for net-new canonical metrics.
-```
-
-**CSV row** appended to `wiki/metrics/kata-release-merge/2026.csv`
-(format `date,metric,value,unit,run,note`):
-
-```
-2026-05-12,approvals_recorded_per_run,0,count,1,"started_at=2026-05-12T20:00:00Z;<phase>:approved=0;APPROVED-review=0"
-```
-
-Value `0` is the empty first-row case (P1: structural-zero risk applies
-only when the producer is missing, design-b § Approval-throughput
-metric).
-
-Verify (in the wiki checkout): `ls wiki/redefinitions/` lists the new
-file; `rg -n 'approvals_recorded_per_run' wiki/metrics/kata-release-merge/2026.csv` returns ≥1 hit.
-
-## Step 9 — Quality gates
-
-Run from repo root: `bun run check`, `bun run format:fix`, `bun run
-test`. The change set is documentation-only on the main-repo side; no
-codegen or build steps are involved. Commit any incidental
-formatter-driven hunks separately if they appear.
-
-Verify locally before push: `bun run check` exits 0; the implementation
-PR title carries the spec id (`feat(kata): measurement-system change
-protocol (#860)`).
+Verify locally before push: `bun run check` exits 0. PR title carries the
+spec id (e.g., `feat(kata): measurement-system change protocol (#860)`).
 
 ## Risks
 
-1. **Wiki vs. main-repo PR boundary.** Design-b states "the redefinition
-   file ships in the same PR" as the canonical-11 change, but `wiki/` is
-   gitignored from the main repo and pushed via a separate checkout
-   (`just wiki-push`). The plan resolves this by treating "same PR" as
-   "same implementation run": main-repo doc changes ship in the
-   spec-860 PR; wiki changes ship via the Stop hook in the same run.
-   The grep recipe (design § Detection) runs from inside the wiki
-   checkout (it looks for `wiki/redefinitions/` in commits that touch
-   `wiki/storyboard-*.md`); for main-repo edges
+1. **"Exactly one metric per skill" constitutional tension.** KATA.md
+   § Metrics line 261 reads "each such skill records exactly one metric."
+   `kata-release-merge` already records `prs_merged`; this plan adds
+   `approvals_recorded_per_run` alongside it. Design-b decision #4
+   commits to preserving "count of units of work" but the design does
+   not address "exactly one metric." Two ways forward, neither blocking
+   the plan but both visible only at implementation time: (a) the
+   approver treats KATA.md line 261 as "exactly one *throughput* metric,
+   the approval-throughput entry is *binding-constraint*-shaped not
+   throughput-shaped"; (b) a follow-on spec amends KATA.md to admit a
+   second metric type per producer skill. The implementation PR's body
+   must surface this tension explicitly so the approver picks the path.
+2. **Wiki-vs-main-repo PR boundary on Success #6.** Design-b § Detection
+   states cross-repo CI enforcement is the natural follow-on, out of
+   scope for this spec. The detection grep works **within the wiki
+   checkout** (it walks `git log` for wiki paths). For main-repo edges
    (`coordination-protocol.md`, `.claude/skills/*/references/metrics.md`),
-   the grep would need to extend to "PRs that touch those paths must
-   reference a `wiki/redefinitions/...md` path in the PR body or in a
-   sibling wiki commit by SHA." CI mechanisation of the cross-repo
-   variant is acknowledged out-of-scope (design § Detection).
-2. **`note`-field parsing fragility.** P1 encodes `started_at=<ISO>;…`
-   in the long-format CSV's free-form `note` field. A hand-edit that
-   omits or reformats the prefix breaks `prev_started_at` discovery and
-   silently falls back to "current_started_at − 8h", which can
-   double-count events on the boundary. SKILL.md Step 0 documents the
-   format; the implementor should add one note-format example to
-   `references/metrics.md` to make the contract grep-discoverable.
-3. **GitHub timeline API rate limits.** Step 9.5 fans out one
-   `gh api .../timeline` call per surveyed open phase PR per run. If
-   the open phase-PR set grows past ~30, the run hits secondary rate
-   limits during the 03:00/12:00/20:00 windows. Mitigation: the
-   producer can short-circuit on PRs whose `updated_at` is older than
-   `prev_started_at` (the timeline cannot have window-relevant events
-   on a PR that has not been updated since the previous run). The
-   short-circuit is not in the plan — a follow-on optimisation when
-   the backlog grows.
-4. **Canonical-11 list drift.** The 12-bullet enumeration in
-   `storyboard-template.md` (Step 5a) must match the wiki's current
-   canonical-11 set plus the new metric. The implementor must read
-   `wiki/storyboard-2026-M05.md` first and align the eleven inherited
-   names; the template lands in the main repo and any subsequent
-   correction to the canonical names becomes a doc fix, not a
-   redefinition.
-5. **Forward-compat marker without a regenerator.** Step 5a adds a
-   `<!-- canonical-12 -->` marker block that `bunx fit-wiki refresh`
-   does not yet regenerate (only `xmr` markers are wired). The block
-   is hand-maintained until a follow-on spec extends the refresher;
-   in the interim, drift between the template and a regenerated
-   storyboard is possible. The follow-on spec is the natural carrier
-   for the regenerator; this plan does not block on it.
+   Success #6 ("detectable from `git diff` alone") holds only when those
+   edges are accompanied by a wiki commit that adds a redefinition file
+   — a coupling the follow-on CI must verify across the two repos.
+   This plan ships the protocol; the cross-repo CI is the next spec.
+3. **GitHub timeline API fan-out.** Step 9.5 calls
+   `gh api .../timeline` once per cohort PR per run. With ~15 open
+   phase PRs the call count is fine; past ~30 the run risks secondary
+   rate limits during the 03:00/12:00/20:00 windows. The skill's
+   blanket-failure branch records `0` with `api_errors=N` so the
+   storyboard sees producer health; a future optimisation short-circuits
+   on PRs whose `updated_at` precedes `prev_run_start`.
+4. **`gh run list` window source assumes the producer always runs as
+   part of `agent-team.yml`.** Step 4a's lookup uses the workflow name.
+   A `workflow_dispatch` invocation outside the scheduled chain still
+   counts (status filter is `completed`, source workflow name is
+   unchanged). If `kata-release-merge` is ever moved to a separate
+   workflow file, Edit 4a's workflow-name argument must move with it —
+   not visible from the SKILL.md body alone because the workflow name
+   is operational, not procedural.
 
 ## Execution recommendation
 
 Single staff-engineer executor, sequential. Steps 1–6 (main-repo edits)
-run in order because Step 2 cites Step 1's anchor, Step 4 cites Step 3's
-metric definition, and Step 5 cites Step 1's enumeration source-of-
-truth. Steps 7–8 (wiki) run after the main-repo edits because the wiki
-diff cites paths the main-repo PR establishes (the
-`coordination-protocol.md#measurement-system-changes` anchor). Step 9
-closes. No parallelism; no decomposition into parts. Route entirely to
-the engineering agent — every edit is a code/doc change with no prose
-audience that warrants `technical-writer`.
-
-— Staff Engineer 🛠️
+run in order: Step 2 cites Step 1's anchor; Step 4 cites Step 3's
+metric definition; Step 6 cites Step 5's bullet template format. Step
+7 runs after the main-repo edits because the wiki diff cites the
+anchor Step 1 establishes. Step 8 closes. No parallelism; no
+decomposition into parts. Route entirely to the engineering agent —
+every edit is a code/doc change with no prose audience that warrants
+`technical-writer`.

--- a/specs/860-measurement-system-change-protocol/plan-b.md
+++ b/specs/860-measurement-system-change-protocol/plan-b.md
@@ -10,7 +10,7 @@ live only if design-b is chosen.
 
 ## Approach
 
-Land the protocol in `coordination-protocol.md` as one new § Measurement-system changes section (eight repair-move rows authored from the spec's Notes § Repair-move corpus evidence; the redefinition file shape; the no-silent-redefinition rule; the detection grep); add a linking paragraph to `KATA.md` § Metrics (no edit to KATA.md line 261's "exactly one metric" sentence — that contradiction is Risk 1); register `approvals_recorded_per_run` in `kata-release-merge` via a new row in `references/metrics.md` and a new sub-step 8.5 in `SKILL.md`; add the `Redefinition:` link slot to the Headlines bullet template in `storyboard-template.md`. The wiki-side change (canonical enumeration update, denominator increment, and one observed first-row CSV entry produced by running Step 8.5 once locally) ships through the separate wiki checkout in the implementation run.
+Land the protocol section in `coordination-protocol.md`. Link from `KATA.md` § Metrics. Add `approvals_recorded_per_run` to `kata-release-merge` (one new row in `references/metrics.md`, one new sub-step 8.5 in `SKILL.md`). Add the `Redefinition:` slot to the Headlines bullet template in `storyboard-template.md`. The wiki-side updates (canonical enumeration, denominator increment, one observed first-row CSV entry) ship through the separate wiki checkout in the implementation run.
 
 Libraries used: none.
 
@@ -64,9 +64,7 @@ verdict horizon, and the cohort read-out date. The no-silent-redefinition rule
 lives there; this section does not restate it.
 ```
 
-Line 261's "exactly one metric" sentence is **not** edited by this plan; honoring the design's `## Components` row ("additional rows" to the existing CSV) ships the new metric as a sibling of `prs_merged`. The textual contradiction with KATA.md line 261 is Risk 1.
-
-Verify: `rg -n 'Measurement-system changes' KATA.md` returns one match in § Metrics; `git diff KATA.md` shows exactly one inserted paragraph and no other hunks.
+Verify: `rg -n 'Measurement-system changes' KATA.md` returns one match in § Metrics; `git diff KATA.md` shows exactly one inserted paragraph and no other hunks. Line 261 is unchanged.
 
 ## Step 3 — `kata-release-merge` `references/metrics.md` new row
 
@@ -79,7 +77,7 @@ Replace the single-row table with two rows:
 | Metric                       | Unit  | Description                                                                                                  | Data source                                  |
 | ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
 | prs_merged                   | count | PRs merged this run                                                                                          | Run actions                                  |
-| approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh pr view <n> --json timelineItems,reviews` |
+| approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh api repos/{owner}/{repo}/issues/<n>/timeline` + `.../pulls/<n>/reviews`         |
 ```
 
 Append below the existing "Backlog … is queried, not recorded." line:
@@ -99,67 +97,64 @@ Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/re
 Two edits to wire the metric. **Modified:**
 `.claude/skills/kata-release-merge/SKILL.md`.
 
-**Edit 4a — Step 0 captures window timestamps.** Append to the end of the
-`### Step 0: Read Memory` body:
+Code blocks below use four-tick outer fences so inner triple-backticks land verbatim in `SKILL.md`. The implementer pastes the body between the outer four-ticks; the inner three-tick fences are part of the body. GNU `date -d` is used; the agent runs on Linux GitHub-hosted runners.
 
-```markdown
+**Edit 4a — append to the end of the `### Step 0: Read Memory` body:**
+
+````markdown
 Capture this run's start timestamp once at the top of the run:
 `current_run_start=$(date -u +%FT%TZ)`. For the approval-throughput metric
-(Step 9), also derive the previous run's start:
+(Step 8.5), also derive the previous run's start:
 
-\`\`\`sh
+```sh
 prev_run_start=$(gh run list --workflow=agent-team.yml --status=completed \
   --limit 2 --json startedAt --jq '.[1].startedAt // empty')
 # First-ever recording falls back to current_run_start - 8h
-# (matches the median schedule gap of the 03:00/12:00/20:00 UTC cadence).
+# (median schedule gap of the 03:00/12:00/20:00 UTC cadence).
 [ -z "$prev_run_start" ] && prev_run_start=$(date -u -d "$current_run_start - 8 hours" +%FT%TZ)
-\`\`\`
-
-The window for approval-throughput counting is `[prev_run_start, current_run_start)`.
-GNU `date -d` is used here; the agent runs on Linux GitHub-hosted runners. A
-macOS/BSD invocation needs the BSD `-v` form instead.
 ```
 
-**Edit 4b — insert a new `### Step 8.5` between Step 8 (Merge Mergeable PRs) and Step 9 (Produce the Classification Report).** The existing Step 9 body and the existing `## Memory: what to record` section are unchanged. The Memory section already says "Append one row per run to `wiki/metrics/{skill}/` per `references/metrics.md`" — once Step 3 lands the new row in `references/metrics.md`, the same Memory bullet now produces two CSV rows per run. The new step only collects the count; the row append is owned by the Memory section's existing discipline.
+The window for approval-throughput counting is `[prev_run_start, current_run_start)`.
+````
 
-Insert this body between SKILL.md line 165 (end of Step 8) and line 166 (`### Step 9: Produce the Classification Report`):
+**Edit 4b — insert a new `### Step 8.5` between Step 8 (line 165) and Step 9 (line 166).** Step 9's existing body and `## Memory: what to record` are unchanged; Memory's existing "Append one row per run to `wiki/metrics/{skill}/` per `references/metrics.md`" bullet produces two rows per run once Step 3 lands the new metric definition.
 
-```markdown
+Insert:
+
+````markdown
 ### Step 8.5: Collect approval-throughput count
 
 Cohort: every PR seen in Step 1 (open phase PRs) plus every phase PR
 merged this run (Step 8) — covers every phase PR with window-relevant
-activity. For each cohort PR:
+activity. For each cohort PR, fetch label-add events:
 
-\`\`\`sh
-gh pr view <number> --json timelineItems,reviews \
-  --jq '
-    (.timelineItems[]? | select(.__typename=="LabeledEvent" and (.label.name|test("^(spec|design|plan):approved$"))) | {ts: .createdAt, kind: "label", label: .label.name}),
-    (.reviews[]? | select(.state=="APPROVED") | {ts: .submittedAt, kind: "review"})
-  '
-\`\`\`
+```sh
+gh api repos/{owner}/{repo}/issues/<number>/timeline --paginate \
+  --jq '.[] | select(.event=="labeled" and (.label.name|test("^(spec|design|plan):approved$"))) | {ts: .created_at, kind: "label", label: .label.name}'
+```
 
-(Pasted into SKILL.md, the inner fences are bare triple-backticks — the
-escaped form above is plan-rendering only.)
+And APPROVED reviews:
+
+```sh
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate \
+  --jq '.[] | select(.state=="APPROVED") | {ts: .submitted_at, kind: "review"}'
+```
 
 Filter events to `ts ∈ [prev_run_start, current_run_start)` (half-open;
 matches design-b § Approval-throughput metric). Sum the filtered events
 to `approvals_recorded_per_run` — no per-event de-dup; the design
-specifies a raw count. The count is appended to
-`wiki/metrics/kata-release-merge/{YYYY}.csv` by the Memory section's
-existing one-row-per-metric discipline; the row shape is
-`<YYYY-MM-DD>,approvals_recorded_per_run,<count>,count,<run_id>,"window=[<prev>,<curr>)"`.
-Zero is recorded as `0`.
+specifies a raw count. The Memory section appends one row per metric to
+`wiki/metrics/kata-release-merge/{YYYY}.csv`; the row shape mirrors the
+existing `prs_merged` rows with `metric=approvals_recorded_per_run`,
+`unit=count`, and `note="window=[<prev>,<curr>)"`. Zero is recorded as `0`.
 
-If `gh pr view ... --json timelineItems` fails for any cohort PR (rate
-limit, scope issue), skip that PR, append `;api_errors=N` to the row's
-`note` field, and proceed. A blanket-failure case (every call errored)
-records `0` with a non-empty `api_errors=` so the next storyboard meeting
-can see producer health.
+If any per-PR call fails (rate limit, scope), skip that PR, append
+`;api_errors=N` to the row's `note` field, and proceed. A blanket-failure
+case (every call errored) records `0` with a non-empty `api_errors=` so
+the next storyboard meeting can see producer health.
+````
 
-Step 9's classification report includes `approvals_recorded_per_run` in
-its run-totals line.
-```
+(The REST endpoints differ from design-b § Approval-throughput metric's claim of an "existing `gh pr view --json labels,timelineItems`" surface — `gh pr view --json` does not accept `timelineItems`. The plan uses the REST timeline + reviews endpoints, the working surface; this is Risk 2.)
 
 Verify: `rg -n 'approvals_recorded_per_run|prev_run_start|current_run_start' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits; `### Step 8.5: Collect approval-throughput count` exists between `### Step 8: Merge` and `### Step 9: Produce`; the existing Step 9 body and Memory section are unchanged.
 
@@ -240,10 +235,11 @@ Verify locally before push: `bun run check` exits 0. PR title carries the spec i
 ## Risks
 
 1. **Design-b internal contradiction on metric cardinality.** Design-b § Components admits `approvals_recorded_per_run` as "additional rows" in `kata-release-merge`'s existing CSV (cardinality 2), while decision #4 commits to "preserving KATA.md 'count of units of work'" and decision #1 states "no constitutional change." KATA.md line 261 ("each such skill records exactly one metric") is unchanged on landing under this plan, so the new row textually contradicts that line. The plan honors design-b § Components' literal component table (the more concrete of the two design surfaces); the implementation PR body must surface this contradiction so the approver can either accept it (the plan's path) or block on a follow-on governance spec that amends KATA.md line 261. The plan cannot resolve a design-internal contradiction unilaterally.
-2. **`gh pr view --json timelineItems` field stability.** The `timelineItems` JSON field exposes a GitHub GraphQL union; the `__typename=="LabeledEvent"` test in Step 4b assumes the current shape. A future `gh` release could rename or restructure the field; the producer would silently emit `0`s until the jq filter is updated. The blanket-failure branch (`api_errors=` non-empty) does not cover this case because the call succeeds with an empty result. The storyboard XmR analyzer detects sustained zeros via `xRule3` (eight consecutive zeros); the producer-rehoming move (Step 1 table row 1) is the protocol response.
-3. **Wiki-vs-main-repo PR boundary on Success #6.** Design-b § Detection states cross-repo CI enforcement is the follow-on, out of scope. The detection grep works **within the wiki checkout**. For main-repo edges (`coordination-protocol.md`, `.claude/skills/*/references/metrics.md`), Success #6 holds only when those edges are accompanied by a wiki commit adding a redefinition file — a coupling the follow-on CI must verify across the two repos.
-4. **GitHub timeline fan-out.** Step 8.5 calls `gh pr view --json timelineItems,reviews` once per cohort PR per run. With ~15 open phase PRs the call count is fine; past ~30 the run risks secondary rate limits during the 03:00/12:00/20:00 windows. A future optimisation short-circuits on PRs whose `updatedAt` precedes `prev_run_start`. The blanket-failure branch records `0` with a non-empty `api_errors=` note so producer health is visible on the chart.
-5. **`gh run list` window-source workflow-name binding.** Step 4a's `--workflow=agent-team.yml` is operational: if `kata-release-merge` is ever moved to a separate workflow file, this argument must move with it. Not visible from the SKILL.md body alone.
+2. **Design-b API-surface claim is factually incorrect.** Design-b § Approval-throughput metric states "No new GitHub-API surface beyond the existing `gh pr view --json labels,timelineItems`," but `gh pr view --json` does not accept a `timelineItems` field (verified against `gh` 2.63.2 — available PR fields include `labels`, `latestReviews`, `reviews`, but not `timelineItems`). The plan uses `gh api repos/{owner}/{repo}/issues/<n>/timeline` (REST) plus `.../pulls/<n>/reviews` instead — the working surface that returns the events the metric needs. This is technically "new API surface" relative to the SKILL.md's current `gh api` calls (Step 2 contributor lookup) but no new auth or scope. Implementation PR body should note the design's surface claim was incorrect; reviewers may file a doc-correction redefinition (`move: rule-semantics-rfc` or similar) against design-b after merge.
+3. **GitHub REST timeline endpoint shape stability.** The REST timeline (`gh api .../issues/<n>/timeline`) returns events with `event: "labeled"`, `label.name`, `created_at`. A breaking change in the GitHub REST API would silently emit `0`s. The producer-rehoming move (Step 1 table row 1) is the protocol response if `xRule3` fires on eight consecutive zeros.
+4. **Wiki-vs-main-repo PR boundary on Success #6.** Design-b § Detection states cross-repo CI enforcement is the follow-on, out of scope. The detection grep works **within the wiki checkout**. For main-repo edges (`coordination-protocol.md`, `.claude/skills/*/references/metrics.md`), Success #6 holds only when those edges are accompanied by a wiki commit adding a redefinition file — a coupling the follow-on CI must verify across the two repos.
+5. **GitHub timeline fan-out.** Step 8.5 calls `gh api .../timeline` once per cohort PR per run. With ~15 open phase PRs the call count is fine; past ~30 the run risks secondary rate limits during the 03:00/12:00/20:00 windows. A future optimisation short-circuits on PRs whose `updated_at` precedes `prev_run_start`. The blanket-failure branch records `0` with a non-empty `api_errors=` note so producer health is visible on the chart.
+6. **`gh run list` window-source workflow-name binding.** Step 4a's `--workflow=agent-team.yml` is operational: if `kata-release-merge` is ever moved to a separate workflow file, this argument must move with it. Not visible from the SKILL.md body alone.
 
 ## Execution recommendation
 

--- a/specs/860-measurement-system-change-protocol/plan-b.md
+++ b/specs/860-measurement-system-change-protocol/plan-b.md
@@ -11,19 +11,20 @@ live only if design-b is chosen.
 ## Approach
 
 Land the protocol in `coordination-protocol.md` as one new
-§ Measurement-system changes section (the eight repair moves with one-sentence
-definitions and falsifier-set kinds sourced from the spec's evidence pointers;
-the redefinition file shape; the no-silent-redefinition rule; the
-detection grep); add a one-paragraph link from `KATA.md` § Metrics; register
-`approvals_recorded_per_run` in `kata-release-merge` (one row in
-`references/metrics.md`, recording instructions in `SKILL.md`); add the
-`Redefinition:` link slot to the Headlines bullet template in
-`storyboard-template.md`. The wiki-side change (canonical enumeration update
-and denominator increment in `wiki/storyboard-2026-M05.md`) ships through
-the separate wiki checkout in the implementation run. The implementation PR
-itself files no redefinition (design § Migration boundary); the first row of
-`approvals_recorded_per_run` is appended only when `kata-release-merge`
-actually runs its new Step 9.5.
+§ Measurement-system changes section; amend `KATA.md` § Metrics so the
+"exactly one metric" rule admits one binding-constraint metric alongside the
+throughput metric (the design's decision #4 closed the count-vs-duration
+question but not the cardinality one — this plan closes the cardinality gap
+with the minimum constitutional delta) and link to the new protocol section;
+register `approvals_recorded_per_run` in `kata-release-merge`
+(`references/metrics.md` row + Step 9 extension that collects the metric
+*before* the classification report); add the `Redefinition:` link slot to the
+Headlines bullet template in `storyboard-template.md`. The eight repair-move
+rows are authored from the spec's Notes § Repair-move corpus evidence
+(design-b leaves the definitions and falsifier-set kinds implicit; this plan
+materialises them). The wiki-side change (canonical enumeration update,
+denominator increment, and one observed first-row CSV entry) ships through
+the separate wiki checkout in the implementation run.
 
 Libraries used: none.
 
@@ -33,16 +34,10 @@ Add a new H2 section between `## Approval signal` (line 34) and
 `## Decision questions` (line 62). **Modified:**
 `.claude/agents/references/coordination-protocol.md`.
 
-The section carries six parts in this order. The plan authors the eight
-repair-move row contents directly here (design-b § Repair-move typology lists
-only the move names; the spec's Notes § Repair-move corpus pins each move to
-specific evidence; this plan converts that evidence into one definition row
-per move):
+Section body, in order:
 
-1. **Lead paragraph** (≤4 lines) — names the typology, the redefinition file
-   artifact, the no-silent-redefinition rule, and the detection grep as the
-   four components.
-2. **Eight repair-move table** with columns `Move | Definition | Falsifier-set kind | Existing precedent`:
+1. **Lead paragraph** (≤4 lines) — one sentence introducing the section.
+2. **Eight repair-move table** with columns `Move | Definition | Falsifier-set kind | Existing precedent`. The "Existing precedent" column is plan-level enrichment — one issue/PR link per row makes the move discoverable from a `git blame` against the corpus:
 
    | Move | Definition (one sentence) | Falsifier-set kind | Existing precedent |
    |---|---|---|---|
@@ -55,29 +50,33 @@ per move):
    | `rule-semantics-rfc` | Challenge an XmR rule's blocking effect on `predictable` via Discussion RFC; quorum required. | "RFC quorum not reached by horizon" | #814 |
    | `habit-to-policy` | Promote an undocumented defensive habit into a `SKILL.md` check after a defect surfaces. | "post-promotion defect of the same shape recurs" | #817, PR #655 |
 
-   One sentence below the table states the list is closed; "extensions land
-   via the spec/design/plan/implement chain."
+   One sentence below the table: "The list is closed; extensions land via the spec/design/plan/implement chain."
 
-3. **Redefinition shape** — a fenced YAML code block exactly matching design-b
-   § Redefinition shape. One sentence below states `verdict_horizon ≤ cohort_readout`
-   and the `denominator_effect` enum semantics.
-4. **No-silent-redefinition rule** — blockquote verbatim from design-b § No-silent-redefinition rule, followed by the sentence "KATA.md § Metrics links to it; no other file restates it."
-5. **Worked example** (spec Success #2) — heading `### Worked example — SE Exp 33 (#787) sidecar pre-flight`. Inline YAML front-matter populated for the SE Exp 33 case (`move: sidecar-pre-flight`, `affected_metrics: [{skill: kata-trace, metric: findings_count}]`, falsifier `sidecar diverges from canonical at horizon`, `verdict_horizon: 2026-05-19`, `cohort_readout: 2026-05-26`, `denominator_effect: sidecar`, `links.experiment_issue: #787`, `links.obstacle_issue: #788`). The example is **inline only**; no on-disk founding redefinition file is created (design § Migration boundary explicitly grandfathers the spec 860 implementation PR — it does not file a redefinition).
+3. **Redefinition shape** — a fenced YAML code block exactly matching design-b § Redefinition shape (file artifact). One sentence below states `verdict_horizon ≤ cohort_readout` and the `denominator_effect` enum semantics.
+4. **No-silent-redefinition rule** — blockquote verbatim from design-b § No-silent-redefinition rule (the blockquote already contains the "KATA.md § Metrics links to it; no other file restates it." sentence — do not duplicate it).
+5. **Worked example** (spec Success #2) — heading `### Worked example — SE Exp 33 (#787) sidecar pre-flight`. Inline YAML front-matter populated for the SE Exp 33 case (`move: sidecar-pre-flight`, `affected_metrics: [{skill: kata-trace, metric: findings_count}]`, falsifier `sidecar diverges from canonical at horizon`, `verdict_horizon: 2026-05-19`, `cohort_readout: 2026-05-26`, `denominator_effect: sidecar`, `links.experiment_issue: "#787"`, `links.obstacle_issue: "#788"`). The example is **inline only**; no on-disk founding redefinition file is created (design § Migration boundary grandfathers the spec 860 implementation PR).
 6. **Detection** — heading `### Detection`. The fenced `sh` block from design-b verbatim. One sentence above states the rule ("any commit touching a canonical-11 metric edge must, in the same commit, add or modify a `wiki/redefinitions/*.md` file"); one sentence below names the edges (`wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, `coordination-protocol.md` § Measurement-system changes) and acknowledges per design § Detection that cross-repo enforcement (between this monorepo and the wiki repo) is the follow-on CI workstream.
 
 Verify: `rg '^## Measurement-system changes$' .claude/agents/references/coordination-protocol.md` returns one hit;
-`rg -c '^\| \`(producer-rehoming|mode-restriction|historical-phasing|sidecar-pre-flight|stock-vs-flow-recast|event-driven-recast|rule-semantics-rfc|habit-to-policy)\`' .claude/agents/references/coordination-protocol.md` returns 8;
+`rg -c '^\| \`(producer-rehoming|mode-restriction|historical-phasing|sidecar-pre-flight|stock-vs-flow-recast|event-driven-recast|rule-semantics-rfc|habit-to-policy)\`' .claude/agents/references/coordination-protocol.md` returns 8 (note: brittle on table-cell whitespace — re-run after `bun run format:fix`);
 `rg '^### Worked example' .claude/agents/references/coordination-protocol.md` returns one hit;
 `rg '^### Detection' .claude/agents/references/coordination-protocol.md` returns one hit.
 
-## Step 2 — `KATA.md` § Metrics linking paragraph
+## Step 2 — `KATA.md` § Metrics: cardinality amendment + linking paragraph
 
-Append one paragraph at the end of § Metrics (currently lines 257–274,
-last line `control limits and signals — numbers, not narratives.`).
-**Modified:** `KATA.md`.
+Two edits to § Metrics (currently lines 257–274). **Modified:** `KATA.md`.
 
-Insert before the blank line that separates § Metrics from § Authentication
-(after line 274):
+**Edit 2a — cardinality amendment.** Line 261 currently reads:
+
+> Each such skill records exactly one metric: the **count of units of work the process produced this run** (issues triaged, PRs merged, findings filed, and so on).
+
+Replace with:
+
+> Each such skill records exactly one **throughput** metric — the count of units of work the process produced this run (issues triaged, PRs merged, findings filed, and so on) — and may additionally record one **binding-constraint** metric per the protocol in § Measurement-system changes.
+
+Design-b decision #4 commits the new metric to remain count-shaped ("count of units of work" is preserved); the design did not address the cardinality rule on the same sentence. This edit is the minimum delta that lets `kata-release-merge` record `approvals_recorded_per_run` alongside `prs_merged` without violating KATA.md.
+
+**Edit 2b — linking paragraph.** Insert one paragraph before the blank line that separates § Metrics from § Authentication (after line 274):
 
 ```markdown
 Changes to the canonical-11 set — additions, removals, conditional or
@@ -89,13 +88,7 @@ verdict horizon, and the cohort read-out date. The no-silent-redefinition rule
 lives there; this section does not restate it.
 ```
 
-The "count of units of work" sentence on line 261 is unchanged — design-b
-preserves it. The "exactly one metric" rule on line 261 is **not preserved**
-by adding `approvals_recorded_per_run` to `kata-release-merge`; this
-constitutional tension is the substance of Risk 1.
-
-Verify: `rg -n 'Measurement-system changes' KATA.md` returns one match in
-§ Metrics; `git diff KATA.md` shows one inserted paragraph and no other hunks.
+Verify: `rg -n 'one \*\*throughput\*\* metric' KATA.md` returns one hit in § Metrics; `rg -n 'Measurement-system changes' KATA.md` returns one match; `git diff KATA.md` shows exactly two hunks (one replace on line 261, one append after line 274).
 
 ## Step 3 — `kata-release-merge` `references/metrics.md` new row
 
@@ -105,10 +98,10 @@ Add the new metric alongside `prs_merged`. **Modified:**
 Replace the single-row table with two rows:
 
 ```markdown
-| Metric                       | Unit  | Description                                                                                                  | Data source                                                          |
-| ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| prs_merged                   | count | PRs merged this run                                                                                          | Run actions                                                          |
-| approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh api repos/.../issues/{n}/timeline` + `.../pulls/{n}/reviews`     |
+| Metric                       | Unit  | Description                                                                                                  | Data source                                  |
+| ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
+| prs_merged                   | count | PRs merged this run                                                                                          | Run actions                                  |
+| approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh pr view <n> --json timelineItems,reviews` |
 ```
 
 Append below the existing "Backlog … is queried, not recorded." line:
@@ -116,10 +109,15 @@ Append below the existing "Backlog … is queried, not recorded." line:
 ```markdown
 `prev_run_start` is the `startedAt` of the previous completed `agent-team`
 workflow run, fetched with `gh run list --workflow=agent-team.yml`. Cohort:
-all open phase PRs surveyed in SKILL.md Step 1 plus any phase PR that was
-merged within the window. `plan:implemented` is a state label, excluded.
+all open phase PRs surveyed in SKILL.md Step 1 plus any phase PR merged
+within the window (Step 8). `plan:implemented` is a state label, excluded.
 See [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).
 ```
+
+The data-source column is `gh pr view --json timelineItems,reviews` to
+match design-b § Approval-throughput metric ("No new GitHub-API surface
+beyond the existing `gh pr view --json labels,timelineItems`"). Step 4
+spells out the field shape.
 
 Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/references/metrics.md` returns ≥1 hit; the table renders as two data rows under one header.
 
@@ -128,75 +126,74 @@ Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/re
 Two edits to wire the metric. **Modified:**
 `.claude/skills/kata-release-merge/SKILL.md`.
 
-**Edit 4a** — Step 0 captures both window timestamps. Append to the end of
-the `### Step 0: Read Memory` body:
+**Edit 4a — Step 0 captures window timestamps.** Append to the end of the
+`### Step 0: Read Memory` body:
 
 ```markdown
 Capture this run's start timestamp once at the top of the run:
 `current_run_start=$(date -u +%FT%TZ)`. For the approval-throughput metric
-(Step 9.5), also derive the previous run's start:
+(Step 9), also derive the previous run's start:
 
 \`\`\`sh
 prev_run_start=$(gh run list --workflow=agent-team.yml --status=completed \
   --limit 2 --json startedAt --jq '.[1].startedAt // empty')
-# First-ever recording falls back to current_run_start - 8h.
+# First-ever recording falls back to current_run_start - 8h
+# (matches the median schedule gap of the 03:00/12:00/20:00 UTC cadence).
 [ -z "$prev_run_start" ] && prev_run_start=$(date -u -d "$current_run_start - 8 hours" +%FT%TZ)
 \`\`\`
 
 The window for approval-throughput counting is `[prev_run_start, current_run_start)`.
+GNU `date -d` is used here; the agent runs on Linux GitHub-hosted runners. A
+macOS/BSD invocation needs the BSD `-v` form instead.
 ```
 
-**Edit 4b** — Append a new `### Step 9.5` between the existing
-`### Step 9: Produce the Classification Report` (currently the last `### Step`)
-and the `## Memory: what to record` H2. The existing Step 9 keeps its number;
-9.5 is sub-ordinal placement, not a renumber. Body:
+**Edit 4b — extend Step 9 to collect the metric *before* the classification report.** The existing Step 9 produces the classification report; the new collection happens first so the report can include the count.
+
+Replace the body of `### Step 9: Produce the Classification Report` (currently the entire body of that step) with a two-part body:
 
 ```markdown
-### Step 9.5: Record approval-throughput metric
+### Step 9: Produce the Classification Report
 
-Cohort: every PR seen in Step 1 (open phase PRs) **plus** every phase PR
-merged during this run (Step 8) — together this covers every phase PR with
-window-relevant activity. For each cohort PR, fetch label-add events:
-
-\`\`\`sh
-gh api repos/{owner}/{repo}/issues/<number>/timeline --paginate \
-  --jq '.[] | select(.event=="labeled" and (.label.name|test("^(spec|design|plan):approved$"))) | {ts: .created_at, label: .label.name}'
-\`\`\`
-
-And APPROVED reviews:
+**9a — Collect `approvals_recorded_per_run`.** Cohort: every PR seen in
+Step 1 (open phase PRs) **plus** every phase PR merged during this run
+(Step 8) — together this covers every phase PR with window-relevant
+activity. For each cohort PR:
 
 \`\`\`sh
-gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate \
-  --jq '.[] | select(.state=="APPROVED") | {ts: .submitted_at}'
+gh pr view <number> --json timelineItems,reviews \
+  --jq '
+    (.timelineItems[]? | select(.__typename=="LabeledEvent" and (.label.name|test("^(spec|design|plan):approved$"))) | {ts: .createdAt, kind: "label", label: .label.name}),
+    (.reviews[]? | select(.state=="APPROVED") | {ts: .submittedAt, kind: "review"})
+  '
 \`\`\`
 
-Filter to events whose `ts` is in `[prev_run_start, current_run_start)`
-(half-open, matches design-b § Approval-throughput metric). De-dupe label
-events by `(pr_number, label_name, second_truncated_timestamp)` so a
-double-click on the GitHub UI counts once. Sum to
-`approvals_recorded_per_run`. Append one row to
+Filter events to `ts ∈ [prev_run_start, current_run_start)` (half-open;
+matches design-b § Approval-throughput metric). Sum the filtered events
+to `approvals_recorded_per_run` — no per-event de-dup; the design
+specifies a raw count. Append one row to
 `wiki/metrics/kata-release-merge/{YYYY}.csv`:
-`<date>,approvals_recorded_per_run,<count>,count,<run_id>,"window=[<prev>,<curr>)"`.
-Zero is recorded as `0` (matches every count metric; the structural-zero
-risk applies only when the producer is missing). The existing `prs_merged`
-row continues to be appended per Step 9.
+`<YYYY-MM-DD>,approvals_recorded_per_run,<count>,count,<run_id>,"window=[<prev>,<curr>)"`.
+Zero is recorded as `0` (matches every count metric).
 
-If `gh api .../timeline` fails for any PR (rate limit, scope issue), skip
-that PR, log the failure to the classification report (Step 9), and
-proceed — partial counts are recorded honestly. A blanket-failure case
-(no PRs counted because every call errored) records `0` with
-`note="window=[<prev>,<curr>);api_errors=N"` so the next storyboard
-meeting can see the producer health on the chart.
+If `gh pr view ... --json timelineItems` fails for any cohort PR (rate
+limit, scope issue), skip that PR, record the failure in the row note as
+`api_errors=N`, and proceed — partial counts are recorded honestly. A
+blanket-failure case (every call errored) records `0` with a non-empty
+`api_errors=` so the next storyboard meeting can see producer health.
+
+**9b — Classification report.** [existing Step 9 body — per-PR records,
+counts, verdicts — verbatim, ending with the existing `prs_merged` row
+append per Step 9's current body.] The report now includes
+`approvals_recorded_per_run` as one of the run's recorded metrics.
 ```
 
-Verify: `rg -n 'approvals_recorded_per_run|prev_run_start|current_run_start' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits; `### Step 9.5:` exists between `### Step 9:` and `## Memory: what to record`.
+Verify: `rg -n 'approvals_recorded_per_run|prev_run_start|current_run_start' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits; `### Step 9.5` does not appear (replaced by 9a/9b within Step 9); `rg -n '^### Step 9: Produce' .claude/skills/kata-release-merge/SKILL.md` returns one hit.
 
 ## Step 5 — `storyboard-template.md` Redefinition link slot
 
-Add the `Redefinition:` field to the Headlines bullet template only. **Do not**
-hard-code a canonical-12 enumeration in this template — the canonical enumeration
-lives in `wiki/storyboard-*.md` per design § Components, not in the
-main-repo template. **Modified:**
+Add the `Redefinition:` field to the Headlines bullet template only. The
+canonical-12 enumeration lives in `wiki/storyboard-*.md` per design
+§ Components, not in the main-repo template. **Modified:**
 `.claude/skills/kata-session/references/storyboard-template.md`.
 
 Replace line 33 (currently
@@ -206,112 +203,122 @@ Replace line 33 (currently
 - `{agent}` / `{metric}` — {value} {trend/badge} — {one-line reason} — Redefinition: {`wiki/redefinitions/...md` or `—`}
 ```
 
-The `Redefinition:` slot is the structural form spec Success #5 requires:
-every canonical-11 change item on a headline line names its redefinition
-file or `—` when none applies. No other edits to this file.
-
-Verify: `rg -n 'Redefinition:' .claude/skills/kata-session/references/storyboard-template.md` returns one hit; `git diff` shows one changed line, no inserts.
+Verify: `rg -n 'Redefinition:' .claude/skills/kata-session/references/storyboard-template.md` returns one hit; `git diff` shows one changed line and no inserts elsewhere.
 
 ## Step 6 — `team-storyboard.md` worked-example refresh
 
-The Q3-obstacle-routing worked example (lines 102–105) currently names
-four canonical-11 metrics. Two changes. **Modified:**
+The Q3-obstacle-routing worked example (lines 102–105) is historical
+(dated 2026-05-02, before this protocol exists). Design § Migration
+boundary retains "canonical-11" historically — the worked example's
+`canonical-11` reference stays. **Modified:**
 `.claude/skills/kata-session/references/team-storyboard.md`.
 
-1. Replace "canonical-11 metric" with "canonical-12 metric" on line 103.
-2. Append two sentences to the worked example so spec Success #5's
-   "worked example references a redefinition by its issue or section anchor"
-   is satisfied. Example: append "Each of the four headline bullets carries
-   a `Redefinition: —` slot for this date (no canonical-12 change items
-   were filed). A hypothetical canonical-12 change to `prs_actioned` would
-   carry `Redefinition: wiki/redefinitions/2026-05-02-prs-actioned-stock-vs-flow.md`
-   on its headline line."
+Append one sentence to the existing worked example (no rename of
+"canonical-11"): "Under this protocol, each headline bullet would carry
+a `Redefinition:` slot — `—` when no canonical change was filed and a
+`wiki/redefinitions/{YYYY-MM-DD}-{slug}.md` path when one was."
 
-Verify: `rg -n 'canonical-12|Redefinition:' .claude/skills/kata-session/references/team-storyboard.md` returns ≥2 hits; `rg -n 'canonical-11' .claude/skills/kata-session/references/team-storyboard.md` returns 0 hits.
+This satisfies spec Success #5's "worked example references a
+redefinition by its issue or section anchor" via the explicit link to
+the section anchor (the protocol's home) without inventing a redefinition
+file that does not exist.
 
-## Step 7 — Wiki: `storyboard-2026-M05.md` enumeration update
+Verify: `rg -n 'Redefinition:' .claude/skills/kata-session/references/team-storyboard.md` returns one new hit on the worked-example sentence; the historical "canonical-11" reference at line 103 is unchanged.
 
-Wiki-side change committed through the separate `wiki/` checkout during
+## Step 7 — Wiki: `storyboard-2026-M05.md` enumeration update + one observed CSV row
+
+Wiki-side changes committed through the separate `wiki/` checkout during
 the implementation run; pushed via the Stop hook (`just wiki-push`).
-**Modified:** `wiki/storyboard-2026-M05.md`.
+**Modified:** `wiki/storyboard-2026-M05.md`, `wiki/metrics/kata-release-merge/2026.csv`.
 
-The implementor reads the file's current state first (the wiki is the
-source of truth for the canonical set). Three edits, applied
-mechanically:
+The implementor reads `wiki/storyboard-2026-M05.md` first; let `N` be the
+current canonical-set cardinality (the count of `{producer}/{metric}` items
+named in the May storyboard's "N canonical metrics" prose). Edits:
 
-1. **Replace the inline "11 canonical metrics" prose** under § Target
-   Condition with a bulleted enumeration. One bullet per metric mapping
-   `{producer skill} / {metric name}`. The new metric joins the list as
+1. **Replace inline "N canonical metrics" prose** under § Target Condition
+   with a bulleted enumeration: one bullet per metric mapping
+   `{producer skill} / {metric name}`. The new metric joins as
    `kata-release-merge / approvals_recorded_per_run`. The implementor
-   reads each producer's `.claude/skills/kata-*/references/metrics.md`
-   to pull the exact metric name (the canonical set is whichever subset
-   of those files is currently named in the May storyboard's prose, plus
-   the new entry). Bullet count = previous canonical set size + 1.
+   reads each producer's `.claude/skills/kata-*/references/metrics.md` to
+   pull the exact metric name. Bullet count = `N + 1`.
 2. **Increment the denominator** anywhere the May storyboard literally
-   writes "≥6 of 11" → "≥6 of 12" (or the corresponding pair if the
-   current denominator differs). `rg '≥[0-9]+ of [0-9]+' wiki/storyboard-2026-M05.md`
-   enumerates every match before edit.
-3. **Add `Redefinition: —` to every existing Headlines bullet** (the
-   grandfathered implementation PR does not file one; design § Migration
-   boundary). Backfilling `—` to historical headlines is the
-   structurally-equivalent of "no redefinition cited," not a retroactive
-   filing — the slot is added, the value is the null marker.
+   writes `≥M of N` → `≥M of (N+1)`. Pre-edit enumeration:
+   `rg -n '≥[0-9]+ of [0-9]+' wiki/storyboard-2026-M05.md`. The post-edit
+   `rg` returns the same number of lines, each with the incremented
+   denominator.
+3. **Add a `Redefinition:` slot to every existing Headlines bullet** with
+   value `—` (no canonical change was filed for any current headline).
+4. **Append one observed first row** to
+   `wiki/metrics/kata-release-merge/2026.csv` by invoking the new Step 9a
+   logic once locally during the implementation run against the actual
+   open phase-PR set at that moment. Date is the run's date; value is
+   whatever the live survey returns (zero is a valid value); the `note`
+   carries the actual `window=[<prev>,<curr>)`. This is the spec Success
+   #4(c) "one example row written under the producer skill's CSV path
+   during the implementation run" — the row is *measured*, not seeded.
 
-Verify (in the wiki checkout): `rg -n '≥6 of 12' wiki/storyboard-2026-M05.md` returns ≥1 hit; `rg -n '≥6 of 11' wiki/storyboard-2026-M05.md` returns 0 hits; `rg -c 'approvals_recorded_per_run' wiki/storyboard-2026-M05.md` returns ≥1; every Headlines bullet contains `Redefinition:`.
+Verify (in the wiki checkout):
+- Pre-edit and post-edit counts of `≥[0-9]+ of [0-9]+` matches in
+  `wiki/storyboard-2026-M05.md` are equal; every post-edit match has the
+  incremented denominator.
+- `rg -c 'approvals_recorded_per_run' wiki/storyboard-2026-M05.md` returns ≥1.
+- `rg -c '^- \`' wiki/storyboard-2026-M05.md` in the new enumeration block returns `N + 1`.
+- Every Headlines bullet contains the substring `Redefinition:`.
+- `rg '^[0-9]{4}-[0-9]{2}-[0-9]{2},approvals_recorded_per_run,' wiki/metrics/kata-release-merge/2026.csv` returns ≥1 row whose `window=` field is non-empty.
 
 ## Step 8 — Quality gates
 
-Run from repo root in order: `bun run format:fix`, `bun run check`, `bun run test`. Format first so `check` sees formatted output; this matches the CONTRIBUTING.md convention. The change set is documentation-only on the main-repo side; no codegen or build steps are involved.
+Run from repo root in order: `bun run format:fix`, `bun run check`, `bun run test`. Format first so `check` sees formatted output (matches the CONTRIBUTING.md convention). The change set is documentation-only on the main-repo side; no codegen or build steps are involved.
 
-Verify locally before push: `bun run check` exits 0. PR title carries the
-spec id (e.g., `feat(kata): measurement-system change protocol (#860)`).
+Verify locally before push: `bun run check` exits 0. PR title carries the spec id (e.g., `feat(kata): measurement-system change protocol (#860)`).
 
 ## Risks
 
-1. **"Exactly one metric per skill" constitutional tension.** KATA.md
-   § Metrics line 261 reads "each such skill records exactly one metric."
-   `kata-release-merge` already records `prs_merged`; this plan adds
-   `approvals_recorded_per_run` alongside it. Design-b decision #4
-   commits to preserving "count of units of work" but the design does
-   not address "exactly one metric." Two ways forward, neither blocking
-   the plan but both visible only at implementation time: (a) the
-   approver treats KATA.md line 261 as "exactly one *throughput* metric,
-   the approval-throughput entry is *binding-constraint*-shaped not
-   throughput-shaped"; (b) a follow-on spec amends KATA.md to admit a
-   second metric type per producer skill. The implementation PR's body
-   must surface this tension explicitly so the approver picks the path.
+1. **`gh pr view --json timelineItems` field stability.** The
+   `timelineItems` JSON field exposes a GitHub GraphQL union; the
+   `__typename=="LabeledEvent"` test in Step 4b assumes the current
+   shape. A future `gh` release could rename or restructure the field;
+   the producer would silently emit `0`s until the jq filter is
+   updated. The blanket-failure branch (`api_errors=` non-empty) does
+   not cover this case because the call succeeds with an empty result
+   rather than failing. The storyboard XmR analyzer detects sustained
+   zeros via `xRule3` (eight consecutive zeros); the producer-rehoming
+   move (Step 1 table row 1) is the protocol response.
 2. **Wiki-vs-main-repo PR boundary on Success #6.** Design-b § Detection
    states cross-repo CI enforcement is the natural follow-on, out of
    scope for this spec. The detection grep works **within the wiki
-   checkout** (it walks `git log` for wiki paths). For main-repo edges
-   (`coordination-protocol.md`, `.claude/skills/*/references/metrics.md`),
-   Success #6 ("detectable from `git diff` alone") holds only when those
-   edges are accompanied by a wiki commit that adds a redefinition file
-   — a coupling the follow-on CI must verify across the two repos.
-   This plan ships the protocol; the cross-repo CI is the next spec.
-3. **GitHub timeline API fan-out.** Step 9.5 calls
-   `gh api .../timeline` once per cohort PR per run. With ~15 open
+   checkout**. For main-repo edges (`coordination-protocol.md`,
+   `.claude/skills/*/references/metrics.md`), Success #6 holds only when
+   those edges are accompanied by a wiki commit that adds a redefinition
+   file — a coupling the follow-on CI must verify across the two repos.
+3. **GitHub timeline fan-out.** Step 9a calls `gh pr view --json
+   timelineItems,reviews` once per cohort PR per run. With ~15 open
    phase PRs the call count is fine; past ~30 the run risks secondary
-   rate limits during the 03:00/12:00/20:00 windows. The skill's
-   blanket-failure branch records `0` with `api_errors=N` so the
-   storyboard sees producer health; a future optimisation short-circuits
-   on PRs whose `updated_at` precedes `prev_run_start`.
-4. **`gh run list` window source assumes the producer always runs as
-   part of `agent-team.yml`.** Step 4a's lookup uses the workflow name.
-   A `workflow_dispatch` invocation outside the scheduled chain still
-   counts (status filter is `completed`, source workflow name is
-   unchanged). If `kata-release-merge` is ever moved to a separate
-   workflow file, Edit 4a's workflow-name argument must move with it —
-   not visible from the SKILL.md body alone because the workflow name
-   is operational, not procedural.
+   rate limits during the 03:00/12:00/20:00 windows. A future
+   optimisation short-circuits on PRs whose `updatedAt` precedes
+   `prev_run_start`. The blanket-failure branch records `0` with a
+   non-empty `api_errors=` note so producer health is visible on the
+   chart.
+4. **`gh run list` window-source workflow-name binding.** Step 4a's
+   `--workflow=agent-team.yml` is operational: if `kata-release-merge`
+   is ever moved to a separate workflow file, this argument must move
+   with it. Not visible from the SKILL.md body alone.
+5. **Constitutional amendment scope (Step 2 Edit 2a).** The
+   one-sentence edit to KATA.md line 261 (admitting one
+   binding-constraint metric alongside the throughput metric) closes a
+   gap design-b decision #4 did not see. Reviewers should weigh whether
+   this delta belongs in this spec's implementation PR or in a
+   companion governance amendment; the plan ships the edit in this PR
+   because it is the minimum unblocker for the new metric — without
+   it, the new row violates KATA.md line 261 on landing.
 
 ## Execution recommendation
 
 Single staff-engineer executor, sequential. Steps 1–6 (main-repo edits)
-run in order: Step 2 cites Step 1's anchor; Step 4 cites Step 3's
-metric definition; Step 6 cites Step 5's bullet template format. Step
-7 runs after the main-repo edits because the wiki diff cites the
-anchor Step 1 establishes. Step 8 closes. No parallelism; no
-decomposition into parts. Route entirely to the engineering agent —
-every edit is a code/doc change with no prose audience that warrants
-`technical-writer`.
+run in order: Step 2 cites Step 1's anchor; Step 4 cites Step 3's metric
+definition; Step 6 cites Step 5's bullet template format. Step 7 runs
+after the main-repo edits — the wiki edits cite anchors Step 1 and Step 2
+establish, and Step 7.4's "one observed CSV row" runs the Step 9a logic
+that Step 4 lands. Step 8 closes. No parallelism; no decomposition into
+parts. Route entirely to the engineering agent — every edit is a
+code/doc change with no prose audience that warrants `technical-writer`.

--- a/specs/860-measurement-system-change-protocol/plan-b.md
+++ b/specs/860-measurement-system-change-protocol/plan-b.md
@@ -10,21 +10,7 @@ live only if design-b is chosen.
 
 ## Approach
 
-Land the protocol in `coordination-protocol.md` as one new
-§ Measurement-system changes section; amend `KATA.md` § Metrics so the
-"exactly one metric" rule admits one binding-constraint metric alongside the
-throughput metric (the design's decision #4 closed the count-vs-duration
-question but not the cardinality one — this plan closes the cardinality gap
-with the minimum constitutional delta) and link to the new protocol section;
-register `approvals_recorded_per_run` in `kata-release-merge`
-(`references/metrics.md` row + Step 9 extension that collects the metric
-*before* the classification report); add the `Redefinition:` link slot to the
-Headlines bullet template in `storyboard-template.md`. The eight repair-move
-rows are authored from the spec's Notes § Repair-move corpus evidence
-(design-b leaves the definitions and falsifier-set kinds implicit; this plan
-materialises them). The wiki-side change (canonical enumeration update,
-denominator increment, and one observed first-row CSV entry) ships through
-the separate wiki checkout in the implementation run.
+Land the protocol in `coordination-protocol.md` as one new § Measurement-system changes section (eight repair-move rows authored from the spec's Notes § Repair-move corpus evidence; the redefinition file shape; the no-silent-redefinition rule; the detection grep); add a linking paragraph to `KATA.md` § Metrics (no edit to KATA.md line 261's "exactly one metric" sentence — that contradiction is Risk 1); register `approvals_recorded_per_run` in `kata-release-merge` via a new row in `references/metrics.md` and a new sub-step 8.5 in `SKILL.md`; add the `Redefinition:` link slot to the Headlines bullet template in `storyboard-template.md`. The wiki-side change (canonical enumeration update, denominator increment, and one observed first-row CSV entry produced by running Step 8.5 once locally) ships through the separate wiki checkout in the implementation run.
 
 Libraries used: none.
 
@@ -37,7 +23,7 @@ Add a new H2 section between `## Approval signal` (line 34) and
 Section body, in order:
 
 1. **Lead paragraph** (≤4 lines) — one sentence introducing the section.
-2. **Eight repair-move table** with columns `Move | Definition | Falsifier-set kind | Existing precedent`. The "Existing precedent" column is plan-level enrichment — one issue/PR link per row makes the move discoverable from a `git blame` against the corpus:
+2. **Eight repair-move table** with columns `Move | Definition | Falsifier-set kind | Existing precedent`:
 
    | Move | Definition (one sentence) | Falsifier-set kind | Existing precedent |
    |---|---|---|---|
@@ -62,21 +48,11 @@ Verify: `rg '^## Measurement-system changes$' .claude/agents/references/coordina
 `rg '^### Worked example' .claude/agents/references/coordination-protocol.md` returns one hit;
 `rg '^### Detection' .claude/agents/references/coordination-protocol.md` returns one hit.
 
-## Step 2 — `KATA.md` § Metrics: cardinality amendment + linking paragraph
+## Step 2 — `KATA.md` § Metrics linking paragraph
 
-Two edits to § Metrics (currently lines 257–274). **Modified:** `KATA.md`.
+One edit to § Metrics (currently lines 257–274). **Modified:** `KATA.md`.
 
-**Edit 2a — cardinality amendment.** Line 261 currently reads:
-
-> Each such skill records exactly one metric: the **count of units of work the process produced this run** (issues triaged, PRs merged, findings filed, and so on).
-
-Replace with:
-
-> Each such skill records exactly one **throughput** metric — the count of units of work the process produced this run (issues triaged, PRs merged, findings filed, and so on) — and may additionally record one **binding-constraint** metric per the protocol in § Measurement-system changes.
-
-Design-b decision #4 commits the new metric to remain count-shaped ("count of units of work" is preserved); the design did not address the cardinality rule on the same sentence. This edit is the minimum delta that lets `kata-release-merge` record `approvals_recorded_per_run` alongside `prs_merged` without violating KATA.md.
-
-**Edit 2b — linking paragraph.** Insert one paragraph before the blank line that separates § Metrics from § Authentication (after line 274):
+Insert one paragraph before the blank line that separates § Metrics from § Authentication (after line 274):
 
 ```markdown
 Changes to the canonical-11 set — additions, removals, conditional or
@@ -88,7 +64,9 @@ verdict horizon, and the cohort read-out date. The no-silent-redefinition rule
 lives there; this section does not restate it.
 ```
 
-Verify: `rg -n 'one \*\*throughput\*\* metric' KATA.md` returns one hit in § Metrics; `rg -n 'Measurement-system changes' KATA.md` returns one match; `git diff KATA.md` shows exactly two hunks (one replace on line 261, one append after line 274).
+Line 261's "exactly one metric" sentence is **not** edited by this plan; honoring the design's `## Components` row ("additional rows" to the existing CSV) ships the new metric as a sibling of `prs_merged`. The textual contradiction with KATA.md line 261 is Risk 1.
+
+Verify: `rg -n 'Measurement-system changes' KATA.md` returns one match in § Metrics; `git diff KATA.md` shows exactly one inserted paragraph and no other hunks.
 
 ## Step 3 — `kata-release-merge` `references/metrics.md` new row
 
@@ -113,11 +91,6 @@ all open phase PRs surveyed in SKILL.md Step 1 plus any phase PR merged
 within the window (Step 8). `plan:implemented` is a state label, excluded.
 See [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).
 ```
-
-The data-source column is `gh pr view --json timelineItems,reviews` to
-match design-b § Approval-throughput metric ("No new GitHub-API surface
-beyond the existing `gh pr view --json labels,timelineItems`"). Step 4
-spells out the field shape.
 
 Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/references/metrics.md` returns ≥1 hit; the table renders as two data rows under one header.
 
@@ -147,16 +120,15 @@ GNU `date -d` is used here; the agent runs on Linux GitHub-hosted runners. A
 macOS/BSD invocation needs the BSD `-v` form instead.
 ```
 
-**Edit 4b — extend Step 9 to collect the metric *before* the classification report.** The existing Step 9 produces the classification report; the new collection happens first so the report can include the count.
+**Edit 4b — insert a new `### Step 8.5` between Step 8 (Merge Mergeable PRs) and Step 9 (Produce the Classification Report).** The existing Step 9 body and the existing `## Memory: what to record` section are unchanged. The Memory section already says "Append one row per run to `wiki/metrics/{skill}/` per `references/metrics.md`" — once Step 3 lands the new row in `references/metrics.md`, the same Memory bullet now produces two CSV rows per run. The new step only collects the count; the row append is owned by the Memory section's existing discipline.
 
-Replace the body of `### Step 9: Produce the Classification Report` (currently the entire body of that step) with a two-part body:
+Insert this body between SKILL.md line 165 (end of Step 8) and line 166 (`### Step 9: Produce the Classification Report`):
 
 ```markdown
-### Step 9: Produce the Classification Report
+### Step 8.5: Collect approval-throughput count
 
-**9a — Collect `approvals_recorded_per_run`.** Cohort: every PR seen in
-Step 1 (open phase PRs) **plus** every phase PR merged during this run
-(Step 8) — together this covers every phase PR with window-relevant
+Cohort: every PR seen in Step 1 (open phase PRs) plus every phase PR
+merged this run (Step 8) — covers every phase PR with window-relevant
 activity. For each cohort PR:
 
 \`\`\`sh
@@ -167,27 +139,29 @@ gh pr view <number> --json timelineItems,reviews \
   '
 \`\`\`
 
+(Pasted into SKILL.md, the inner fences are bare triple-backticks — the
+escaped form above is plan-rendering only.)
+
 Filter events to `ts ∈ [prev_run_start, current_run_start)` (half-open;
 matches design-b § Approval-throughput metric). Sum the filtered events
 to `approvals_recorded_per_run` — no per-event de-dup; the design
-specifies a raw count. Append one row to
-`wiki/metrics/kata-release-merge/{YYYY}.csv`:
+specifies a raw count. The count is appended to
+`wiki/metrics/kata-release-merge/{YYYY}.csv` by the Memory section's
+existing one-row-per-metric discipline; the row shape is
 `<YYYY-MM-DD>,approvals_recorded_per_run,<count>,count,<run_id>,"window=[<prev>,<curr>)"`.
-Zero is recorded as `0` (matches every count metric).
+Zero is recorded as `0`.
 
 If `gh pr view ... --json timelineItems` fails for any cohort PR (rate
-limit, scope issue), skip that PR, record the failure in the row note as
-`api_errors=N`, and proceed — partial counts are recorded honestly. A
-blanket-failure case (every call errored) records `0` with a non-empty
-`api_errors=` so the next storyboard meeting can see producer health.
+limit, scope issue), skip that PR, append `;api_errors=N` to the row's
+`note` field, and proceed. A blanket-failure case (every call errored)
+records `0` with a non-empty `api_errors=` so the next storyboard meeting
+can see producer health.
 
-**9b — Classification report.** [existing Step 9 body — per-PR records,
-counts, verdicts — verbatim, ending with the existing `prs_merged` row
-append per Step 9's current body.] The report now includes
-`approvals_recorded_per_run` as one of the run's recorded metrics.
+Step 9's classification report includes `approvals_recorded_per_run` in
+its run-totals line.
 ```
 
-Verify: `rg -n 'approvals_recorded_per_run|prev_run_start|current_run_start' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits; `### Step 9.5` does not appear (replaced by 9a/9b within Step 9); `rg -n '^### Step 9: Produce' .claude/skills/kata-release-merge/SKILL.md` returns one hit.
+Verify: `rg -n 'approvals_recorded_per_run|prev_run_start|current_run_start' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits; `### Step 8.5: Collect approval-throughput count` exists between `### Step 8: Merge` and `### Step 9: Produce`; the existing Step 9 body and Memory section are unchanged.
 
 ## Step 5 — `storyboard-template.md` Redefinition link slot
 
@@ -207,23 +181,11 @@ Verify: `rg -n 'Redefinition:' .claude/skills/kata-session/references/storyboard
 
 ## Step 6 — `team-storyboard.md` worked-example refresh
 
-The Q3-obstacle-routing worked example (lines 102–105) is historical
-(dated 2026-05-02, before this protocol exists). Design § Migration
-boundary retains "canonical-11" historically — the worked example's
-`canonical-11` reference stays. **Modified:**
-`.claude/skills/kata-session/references/team-storyboard.md`.
+The Q3-obstacle-routing worked example (lines 102–105) is historical (dated 2026-05-02). The historical `canonical-11` reference is unchanged. **Modified:** `.claude/skills/kata-session/references/team-storyboard.md`.
 
-Append one sentence to the existing worked example (no rename of
-"canonical-11"): "Under this protocol, each headline bullet would carry
-a `Redefinition:` slot — `—` when no canonical change was filed and a
-`wiki/redefinitions/{YYYY-MM-DD}-{slug}.md` path when one was."
+Append one sentence and a one-line slot-data demonstration to the existing worked example: "Each headline bullet for the four metrics carries the new `Redefinition:` slot per [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes); for this date the value is `—` on all four. Example: `- kata-release-merge / prs_actioned — … — Redefinition: —`."
 
-This satisfies spec Success #5's "worked example references a
-redefinition by its issue or section anchor" via the explicit link to
-the section anchor (the protocol's home) without inventing a redefinition
-file that does not exist.
-
-Verify: `rg -n 'Redefinition:' .claude/skills/kata-session/references/team-storyboard.md` returns one new hit on the worked-example sentence; the historical "canonical-11" reference at line 103 is unchanged.
+Verify: `rg -n 'Redefinition: —' .claude/skills/kata-session/references/team-storyboard.md` returns one hit on the worked example; the historical "canonical-11" reference at line 103 is unchanged.
 
 ## Step 7 — Wiki: `storyboard-2026-M05.md` enumeration update + one observed CSV row
 
@@ -249,13 +211,16 @@ named in the May storyboard's "N canonical metrics" prose). Edits:
 3. **Add a `Redefinition:` slot to every existing Headlines bullet** with
    value `—` (no canonical change was filed for any current headline).
 4. **Append one observed first row** to
-   `wiki/metrics/kata-release-merge/2026.csv` by invoking the new Step 9a
-   logic once locally during the implementation run against the actual
-   open phase-PR set at that moment. Date is the run's date; value is
-   whatever the live survey returns (zero is a valid value); the `note`
-   carries the actual `window=[<prev>,<curr>)`. This is the spec Success
-   #4(c) "one example row written under the producer skill's CSV path
-   during the implementation run" — the row is *measured*, not seeded.
+   `wiki/metrics/kata-release-merge/2026.csv` by invoking the new Step
+   8.5 logic once locally during the implementation run against the
+   actual open phase-PR set at that moment. The implementor derives
+   `prev_run_start` and `current_run_start` exactly as SKILL.md Step 0
+   prescribes (the `gh run list --workflow=agent-team.yml` lookup
+   returns the prior scheduled run's `startedAt` even though
+   `kata-release-merge` has not yet recorded the new metric). Date is
+   the run's date; value is whatever the live survey returns (zero is
+   valid); the `note` carries the actual `window=[<prev>,<curr>)`. The
+   row is *measured*, satisfying spec Success #4(c).
 
 Verify (in the wiki checkout):
 - Pre-edit and post-edit counts of `≥[0-9]+ of [0-9]+` matches in
@@ -268,57 +233,18 @@ Verify (in the wiki checkout):
 
 ## Step 8 — Quality gates
 
-Run from repo root in order: `bun run format:fix`, `bun run check`, `bun run test`. Format first so `check` sees formatted output (matches the CONTRIBUTING.md convention). The change set is documentation-only on the main-repo side; no codegen or build steps are involved.
+Run from repo root in order: `bun run format:fix`, `bun run check`, `bun run test`. The change set is documentation-only on the main-repo side; no codegen or build steps are involved.
 
 Verify locally before push: `bun run check` exits 0. PR title carries the spec id (e.g., `feat(kata): measurement-system change protocol (#860)`).
 
 ## Risks
 
-1. **`gh pr view --json timelineItems` field stability.** The
-   `timelineItems` JSON field exposes a GitHub GraphQL union; the
-   `__typename=="LabeledEvent"` test in Step 4b assumes the current
-   shape. A future `gh` release could rename or restructure the field;
-   the producer would silently emit `0`s until the jq filter is
-   updated. The blanket-failure branch (`api_errors=` non-empty) does
-   not cover this case because the call succeeds with an empty result
-   rather than failing. The storyboard XmR analyzer detects sustained
-   zeros via `xRule3` (eight consecutive zeros); the producer-rehoming
-   move (Step 1 table row 1) is the protocol response.
-2. **Wiki-vs-main-repo PR boundary on Success #6.** Design-b § Detection
-   states cross-repo CI enforcement is the natural follow-on, out of
-   scope for this spec. The detection grep works **within the wiki
-   checkout**. For main-repo edges (`coordination-protocol.md`,
-   `.claude/skills/*/references/metrics.md`), Success #6 holds only when
-   those edges are accompanied by a wiki commit that adds a redefinition
-   file — a coupling the follow-on CI must verify across the two repos.
-3. **GitHub timeline fan-out.** Step 9a calls `gh pr view --json
-   timelineItems,reviews` once per cohort PR per run. With ~15 open
-   phase PRs the call count is fine; past ~30 the run risks secondary
-   rate limits during the 03:00/12:00/20:00 windows. A future
-   optimisation short-circuits on PRs whose `updatedAt` precedes
-   `prev_run_start`. The blanket-failure branch records `0` with a
-   non-empty `api_errors=` note so producer health is visible on the
-   chart.
-4. **`gh run list` window-source workflow-name binding.** Step 4a's
-   `--workflow=agent-team.yml` is operational: if `kata-release-merge`
-   is ever moved to a separate workflow file, this argument must move
-   with it. Not visible from the SKILL.md body alone.
-5. **Constitutional amendment scope (Step 2 Edit 2a).** The
-   one-sentence edit to KATA.md line 261 (admitting one
-   binding-constraint metric alongside the throughput metric) closes a
-   gap design-b decision #4 did not see. Reviewers should weigh whether
-   this delta belongs in this spec's implementation PR or in a
-   companion governance amendment; the plan ships the edit in this PR
-   because it is the minimum unblocker for the new metric — without
-   it, the new row violates KATA.md line 261 on landing.
+1. **Design-b internal contradiction on metric cardinality.** Design-b § Components admits `approvals_recorded_per_run` as "additional rows" in `kata-release-merge`'s existing CSV (cardinality 2), while decision #4 commits to "preserving KATA.md 'count of units of work'" and decision #1 states "no constitutional change." KATA.md line 261 ("each such skill records exactly one metric") is unchanged on landing under this plan, so the new row textually contradicts that line. The plan honors design-b § Components' literal component table (the more concrete of the two design surfaces); the implementation PR body must surface this contradiction so the approver can either accept it (the plan's path) or block on a follow-on governance spec that amends KATA.md line 261. The plan cannot resolve a design-internal contradiction unilaterally.
+2. **`gh pr view --json timelineItems` field stability.** The `timelineItems` JSON field exposes a GitHub GraphQL union; the `__typename=="LabeledEvent"` test in Step 4b assumes the current shape. A future `gh` release could rename or restructure the field; the producer would silently emit `0`s until the jq filter is updated. The blanket-failure branch (`api_errors=` non-empty) does not cover this case because the call succeeds with an empty result. The storyboard XmR analyzer detects sustained zeros via `xRule3` (eight consecutive zeros); the producer-rehoming move (Step 1 table row 1) is the protocol response.
+3. **Wiki-vs-main-repo PR boundary on Success #6.** Design-b § Detection states cross-repo CI enforcement is the follow-on, out of scope. The detection grep works **within the wiki checkout**. For main-repo edges (`coordination-protocol.md`, `.claude/skills/*/references/metrics.md`), Success #6 holds only when those edges are accompanied by a wiki commit adding a redefinition file — a coupling the follow-on CI must verify across the two repos.
+4. **GitHub timeline fan-out.** Step 8.5 calls `gh pr view --json timelineItems,reviews` once per cohort PR per run. With ~15 open phase PRs the call count is fine; past ~30 the run risks secondary rate limits during the 03:00/12:00/20:00 windows. A future optimisation short-circuits on PRs whose `updatedAt` precedes `prev_run_start`. The blanket-failure branch records `0` with a non-empty `api_errors=` note so producer health is visible on the chart.
+5. **`gh run list` window-source workflow-name binding.** Step 4a's `--workflow=agent-team.yml` is operational: if `kata-release-merge` is ever moved to a separate workflow file, this argument must move with it. Not visible from the SKILL.md body alone.
 
 ## Execution recommendation
 
-Single staff-engineer executor, sequential. Steps 1–6 (main-repo edits)
-run in order: Step 2 cites Step 1's anchor; Step 4 cites Step 3's metric
-definition; Step 6 cites Step 5's bullet template format. Step 7 runs
-after the main-repo edits — the wiki edits cite anchors Step 1 and Step 2
-establish, and Step 7.4's "one observed CSV row" runs the Step 9a logic
-that Step 4 lands. Step 8 closes. No parallelism; no decomposition into
-parts. Route entirely to the engineering agent — every edit is a
-code/doc change with no prose audience that warrants `technical-writer`.
+Single staff-engineer executor, sequential. Steps 1–6 (main-repo edits) run in order: Step 2 cites Step 1's anchor; Step 4 cites Step 3's metric definition; Step 6 cites Step 5's bullet template format. Step 7 runs after the main-repo edits — the wiki edits cite anchors Step 1 and Step 2 establish, and Step 7.4's "one observed CSV row" runs the Step 8.5 logic that Step 4 lands. Step 8 closes. No parallelism; no decomposition into parts. Route entirely to the engineering agent — every edit is a code/doc change with no prose audience that warrants `technical-writer`.

--- a/specs/860-measurement-system-change-protocol/plan-b.md
+++ b/specs/860-measurement-system-change-protocol/plan-b.md
@@ -40,7 +40,29 @@ Section body, in order:
 
 3. **Redefinition shape** — a fenced YAML code block exactly matching design-b § Redefinition shape (file artifact). One sentence below states `verdict_horizon ≤ cohort_readout` and the `denominator_effect` enum semantics.
 4. **No-silent-redefinition rule** — blockquote verbatim from design-b § No-silent-redefinition rule (the blockquote already contains the "KATA.md § Metrics links to it; no other file restates it." sentence — do not duplicate it).
-5. **Worked example** (spec Success #2) — heading `### Worked example — SE Exp 33 (#787) sidecar pre-flight`. Inline YAML front-matter populated for the SE Exp 33 case (`move: sidecar-pre-flight`, `affected_metrics: [{skill: kata-trace, metric: findings_count}]`, falsifier `sidecar diverges from canonical at horizon`, `verdict_horizon: 2026-05-19`, `cohort_readout: 2026-05-26`, `denominator_effect: sidecar`, `links.experiment_issue: "#787"`, `links.obstacle_issue: "#788"`). The example is **inline only**; no on-disk founding redefinition file is created (design § Migration boundary grandfathers the spec 860 implementation PR).
+5. **Worked example** (spec Success #2) — heading `### Worked example — SE Exp 33 (#787) sidecar pre-flight`. The literal YAML block below goes inline under the heading (the implementer pastes it verbatim). The example is inline only; no on-disk founding redefinition file is created (design § Migration boundary grandfathers the spec 860 implementation PR). `denominator_effect: none` is used: design § Redefinition shape's "non-`none` requires a linked storyboard headline" applies, but the design's YAML shape has no field for that link, so the worked example illustrates the shape without forcing a field the design did not specify — Risk 1 already names the design's internal contradictions; this is one of them.
+
+   ```yaml
+   ---
+   move: sidecar-pre-flight
+   affected_metrics:
+     - {skill: kata-trace, metric: findings_count}
+   falsifier_set:
+     - sidecar diverges from canonical at verdict horizon
+   verdict_horizon: 2026-05-19
+   cohort_readout: 2026-05-26
+   denominator_effect: none
+   links:
+     obstacle_issue: "#788"
+     experiment_issue: "#787"
+     pr: null
+   ---
+
+   # Redefinition — SE Exp 33 (#787) sidecar pre-flight (inline example)
+
+   One paragraph context: SE Exp 33 opened a sidecar CSV to evaluate the
+   `findings_count` recasting; the cohort ratifies at the 2026-05-26 read-out.
+   ```
 6. **Detection** — heading `### Detection`. The fenced `sh` block from design-b verbatim. One sentence above states the rule ("any commit touching a canonical-11 metric edge must, in the same commit, add or modify a `wiki/redefinitions/*.md` file"); one sentence below names the edges (`wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, `coordination-protocol.md` § Measurement-system changes) and acknowledges per design § Detection that cross-repo enforcement (between this monorepo and the wiki repo) is the follow-on CI workstream.
 
 Verify: `rg '^## Measurement-system changes$' .claude/agents/references/coordination-protocol.md` returns one hit;
@@ -84,10 +106,12 @@ Append below the existing "Backlog … is queried, not recorded." line:
 
 ```markdown
 `prev_run_start` is the `startedAt` of the previous completed `agent-team`
-workflow run, fetched with `gh run list --workflow=agent-team.yml`. Cohort:
-all open phase PRs surveyed in SKILL.md Step 1 plus any phase PR merged
-within the window (Step 8). `plan:implemented` is a state label, excluded.
-See [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).
+workflow run, fetched with `gh run list --workflow=agent-team.yml`. First-ever
+recording falls back to `current_run_start - 8h` (median schedule gap of the
+03:00/12:00/20:00 UTC cadence). Cohort: all open phase PRs surveyed in
+SKILL.md Step 1 plus any phase PR merged within the window (Step 8).
+`plan:implemented` is a state label, excluded. See
+[`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).
 ```
 
 Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/references/metrics.md` returns ≥1 hit; the table renders as two data rows under one header.
@@ -153,8 +177,6 @@ If any per-PR call fails (rate limit, scope), skip that PR, append
 case (every call errored) records `0` with a non-empty `api_errors=` so
 the next storyboard meeting can see producer health.
 ````
-
-(The REST endpoints differ from design-b § Approval-throughput metric's claim of an "existing `gh pr view --json labels,timelineItems`" surface — `gh pr view --json` does not accept `timelineItems`. The plan uses the REST timeline + reviews endpoints, the working surface; this is Risk 2.)
 
 Verify: `rg -n 'approvals_recorded_per_run|prev_run_start|current_run_start' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits; `### Step 8.5: Collect approval-throughput count` exists between `### Step 8: Merge` and `### Step 9: Produce`; the existing Step 9 body and Memory section are unchanged.
 

--- a/specs/860-measurement-system-change-protocol/plan-b.md
+++ b/specs/860-measurement-system-change-protocol/plan-b.md
@@ -40,7 +40,7 @@ Section body, in order:
 
 3. **Redefinition shape** — a fenced YAML code block exactly matching design-b § Redefinition shape (file artifact). One sentence below states `verdict_horizon ≤ cohort_readout` and the `denominator_effect` enum semantics.
 4. **No-silent-redefinition rule** — blockquote verbatim from design-b § No-silent-redefinition rule (the blockquote already contains the "KATA.md § Metrics links to it; no other file restates it." sentence — do not duplicate it).
-5. **Worked example** (spec Success #2) — heading `### Worked example — SE Exp 33 (#787) sidecar pre-flight`. The literal YAML block below goes inline under the heading (the implementer pastes it verbatim). The example is inline only; no on-disk founding redefinition file is created (design § Migration boundary grandfathers the spec 860 implementation PR). `denominator_effect: none` is used: design § Redefinition shape's "non-`none` requires a linked storyboard headline" applies, but the design's YAML shape has no field for that link, so the worked example illustrates the shape without forcing a field the design did not specify — Risk 1 already names the design's internal contradictions; this is one of them.
+5. **Worked example** (spec Success #2) — heading `### Worked example — SE Exp 33 (#787) sidecar pre-flight`. The literal YAML block below goes inline under the heading (the implementer pastes it verbatim). The example is inline only; no on-disk founding redefinition file is created (design § Migration boundary grandfathers the spec 860 implementation PR). `denominator_effect: none` is used so the example illustrates the shape without forcing the design's "non-`none` requires a linked storyboard headline" provision, which has no corresponding field in the design's YAML shape.
 
    ```yaml
    ---
@@ -82,8 +82,6 @@ Replace with:
 
 > Each such skill records one or more metrics, each a **count of units of work the process produced this run** (issues triaged, PRs merged, findings filed, approvals recorded, and so on). Multiple metrics from one producer land as multiple rows in `wiki/metrics/{skill}/{YYYY}.csv` (one row per metric per run). Pipeline stations and orchestration utilities do not record.
 
-The replacement preserves "count of units of work" (design-b decision #4's load-bearing commitment) and adds the minimum cardinality delta needed to admit design-b § Components' "additional rows" instruction. The "approvals recorded" example tracks the new metric Step 3 introduces.
-
 **Edit 2b — linking paragraph.** Insert one paragraph before the blank line that separates § Metrics from § Authentication (after line 274):
 
 ```markdown
@@ -96,14 +94,20 @@ verdict horizon, and the cohort read-out date. The no-silent-redefinition rule
 lives there; this section does not restate it.
 ```
 
-Verify: `rg -n 'one or more metrics' KATA.md` returns one hit in § Metrics; `rg -n 'Measurement-system changes' KATA.md` returns one match; `git diff KATA.md` shows exactly two hunks (one replace on line 261, one append after line 274); `rg -n 'exactly one metric' KATA.md` returns 0 hits.
+Verify: `rg -n 'one or more metrics' KATA.md` returns one hit in § Metrics; `rg -n 'one row per metric per run' KATA.md` returns one hit; `rg -n 'Measurement-system changes' KATA.md` returns one match; `rg -n 'exactly one metric' KATA.md` returns 0 hits. `git diff KATA.md` shows changes only inside § Metrics (lines 257–274 range, plus the appended paragraph).
 
 ## Step 3 — `kata-release-merge` `references/metrics.md` new row
 
-Add the new metric alongside `prs_merged`. **Modified:**
+Three edits to align the file with the amended KATA.md cardinality. **Modified:**
 `.claude/skills/kata-release-merge/references/metrics.md`.
 
-Replace the single-row table with two rows:
+**Edit 3a — header.** Replace the existing line 3–4 ("Record per KATA.md § Metrics. Append / one row per run.") with:
+
+```markdown
+Record per KATA.md § Metrics. Append one row per metric per run.
+```
+
+**Edit 3b — table.** Replace the single-row table with two rows:
 
 ```markdown
 | Metric                       | Unit  | Description                                                                                                  | Data source                                  |
@@ -112,7 +116,7 @@ Replace the single-row table with two rows:
 | approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh api repos/{owner}/{repo}/issues/<n>/timeline` + `.../pulls/<n>/reviews`         |
 ```
 
-Append below the existing "Backlog … is queried, not recorded." line:
+**Edit 3c — window definition.** Append below the existing "Backlog … is queried, not recorded." line:
 
 ```markdown
 `prev_run_start` is the `startedAt` of the previous completed `agent-team`
@@ -124,11 +128,11 @@ SKILL.md Step 1 plus any phase PR merged within the window (Step 8).
 [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).
 ```
 
-Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/references/metrics.md` returns ≥1 hit; the table renders as two data rows under one header.
+Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/references/metrics.md` returns ≥1 hit; `rg -n 'one row per metric per run' .claude/skills/kata-release-merge/references/metrics.md` returns one hit; the table renders as two data rows under one header.
 
 ## Step 4 — `kata-release-merge` SKILL.md recording instructions
 
-Two edits to wire the metric. **Modified:**
+Three edits to wire the metric. **Modified:**
 `.claude/skills/kata-release-merge/SKILL.md`.
 
 Code blocks below use four-tick outer fences so inner triple-backticks land verbatim in `SKILL.md`. The implementer pastes the body between the outer four-ticks; the inner three-tick fences are part of the body. GNU `date -d` is used; the agent runs on Linux GitHub-hosted runners.
@@ -188,7 +192,9 @@ case (every call errored) records `0` with a non-empty `api_errors=` so
 the next storyboard meeting can see producer health.
 ````
 
-Verify: `rg -n 'approvals_recorded_per_run|prev_run_start|current_run_start' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits; `### Step 8.5: Collect approval-throughput count` exists between `### Step 8: Merge` and `### Step 9: Produce`; the existing Step 9 body and Memory section are unchanged.
+**Edit 4c — Memory section ripple.** The existing `## Memory: what to record` Metrics bullet at line 181 currently reads "Append one row per run to `wiki/metrics/{skill}/` per `references/metrics.md`." Replace with: "Append one row per metric per run to `wiki/metrics/{skill}/` per `references/metrics.md`." This aligns the bullet with the amended KATA.md cardinality language and Step 3 Edit 3a; the Memory bullet's `references/metrics.md` redirect already routes readers to the per-metric table.
+
+Verify: `rg -n 'approvals_recorded_per_run|prev_run_start|current_run_start' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits; `### Step 8.5: Collect approval-throughput count` exists between `### Step 8: Merge` and `### Step 9: Produce`; `rg -n 'one row per metric per run' .claude/skills/kata-release-merge/SKILL.md` returns one hit on the Memory bullet; the existing Step 9 body is unchanged.
 
 ## Step 5 — `storyboard-template.md` Redefinition link slot
 
@@ -266,7 +272,7 @@ Verify locally before push: `bun run check` exits 0. PR title carries the spec i
 
 ## Risks
 
-1. **Scope expansion vs design-b literal text.** Design-b decision #1 says "no constitutional change to 'count of units of work'" and decision #4 says "no KATA.md amendment is required." Step 2 Edit 2a amends KATA.md line 261 (cardinality "exactly one metric" → "one or more metrics"), preserving the "count of units of work" rule decision #4 named while resolving the cardinality contradiction with § Components' "additional rows" instruction. The amendment is the minimum delta needed to make the design's component table internally consistent on landing; the approver has explicitly directed this resolution rather than the alternative (block on a follow-on governance spec). Reviewers should weigh whether this delta is in-scope for spec 860 or belongs in a sibling governance PR.
+1. **Scope expansion vs design-b literal text.** Design-b is internally inconsistent: § Components row for `approvals_recorded_per_run` admits "additional rows" in `kata-release-merge`'s existing CSV (cardinality 2), while decision #1 commits to "no constitutional change" and decision #4 says "no KATA.md amendment is required." KATA.md line 261's "exactly one metric" cannot host § Components' "additional rows" without amendment. Step 2 Edit 2a resolves the inconsistency by amending the cardinality clause to "one or more metrics," preserving "count of units of work" (decision #4's load-bearing commitment) while admitting § Components' instruction. The amendment is the minimum delta needed; the approver has explicitly directed this resolution rather than the alternative (block on a follow-on governance spec). Reviewers should weigh whether this delta is in-scope for spec 860 or belongs in a sibling governance PR.
 2. **Design-b API-surface claim is factually incorrect.** Design-b § Approval-throughput metric states "No new GitHub-API surface beyond the existing `gh pr view --json labels,timelineItems`," but `gh pr view --json` does not accept a `timelineItems` field (verified against `gh` 2.63.2 — available PR fields include `labels`, `latestReviews`, `reviews`, but not `timelineItems`). The plan uses `gh api repos/{owner}/{repo}/issues/<n>/timeline` (REST) plus `.../pulls/<n>/reviews` instead — the working surface that returns the events the metric needs. This is technically "new API surface" relative to the SKILL.md's current `gh api` calls (Step 2 contributor lookup) but no new auth or scope. Implementation PR body should note the design's surface claim was incorrect; reviewers may file a doc-correction redefinition (`move: rule-semantics-rfc` or similar) against design-b after merge.
 3. **GitHub REST timeline endpoint shape stability.** The REST timeline (`gh api .../issues/<n>/timeline`) returns events with `event: "labeled"`, `label.name`, `created_at`. A breaking change in the GitHub REST API would silently emit `0`s. The producer-rehoming move (Step 1 table row 1) is the protocol response if `xRule3` fires on eight consecutive zeros.
 4. **Wiki-vs-main-repo PR boundary on Success #6.** Design-b § Detection states cross-repo CI enforcement is the follow-on, out of scope. The detection grep works **within the wiki checkout**. For main-repo edges (`coordination-protocol.md`, `.claude/skills/*/references/metrics.md`), Success #6 holds only when those edges are accompanied by a wiki commit adding a redefinition file — a coupling the follow-on CI must verify across the two repos.

--- a/specs/860-measurement-system-change-protocol/plan-b.md
+++ b/specs/860-measurement-system-change-protocol/plan-b.md
@@ -10,7 +10,7 @@ live only if design-b is chosen.
 
 ## Approach
 
-Land the protocol section in `coordination-protocol.md`. Link from `KATA.md` § Metrics. Add `approvals_recorded_per_run` to `kata-release-merge` (one new row in `references/metrics.md`, one new sub-step 8.5 in `SKILL.md`). Add the `Redefinition:` slot to the Headlines bullet template in `storyboard-template.md`. The wiki-side updates (canonical enumeration, denominator increment, one observed first-row CSV entry) ship through the separate wiki checkout in the implementation run.
+Land the protocol section in `coordination-protocol.md`. Amend `KATA.md` § Metrics line 261 to admit cardinality > 1 per producing skill (so design-b § Components' "additional rows" instruction lands without textually contradicting the constitution) and add a linking paragraph. Add `approvals_recorded_per_run` to `kata-release-merge` (one new row in `references/metrics.md`, one new sub-step 8.5 in `SKILL.md`). Add the `Redefinition:` slot to the Headlines bullet template in `storyboard-template.md`. The wiki-side updates (canonical enumeration, denominator increment, one observed first-row CSV entry) ship through the separate wiki checkout in the implementation run.
 
 Libraries used: none.
 
@@ -70,11 +70,21 @@ Verify: `rg '^## Measurement-system changes$' .claude/agents/references/coordina
 `rg '^### Worked example' .claude/agents/references/coordination-protocol.md` returns one hit;
 `rg '^### Detection' .claude/agents/references/coordination-protocol.md` returns one hit.
 
-## Step 2 — `KATA.md` § Metrics linking paragraph
+## Step 2 — `KATA.md` § Metrics: cardinality amendment + linking paragraph
 
-One edit to § Metrics (currently lines 257–274). **Modified:** `KATA.md`.
+Two edits to § Metrics (currently lines 257–274). **Modified:** `KATA.md`.
 
-Insert one paragraph before the blank line that separates § Metrics from § Authentication (after line 274):
+**Edit 2a — cardinality amendment.** Line 261 currently reads:
+
+> Each such skill records exactly one metric: the **count of units of work the process produced this run** (issues triaged, PRs merged, findings filed, and so on). Pipeline stations and orchestration utilities do not record.
+
+Replace with:
+
+> Each such skill records one or more metrics, each a **count of units of work the process produced this run** (issues triaged, PRs merged, findings filed, approvals recorded, and so on). Multiple metrics from one producer land as multiple rows in `wiki/metrics/{skill}/{YYYY}.csv` (one row per metric per run). Pipeline stations and orchestration utilities do not record.
+
+The replacement preserves "count of units of work" (design-b decision #4's load-bearing commitment) and adds the minimum cardinality delta needed to admit design-b § Components' "additional rows" instruction. The "approvals recorded" example tracks the new metric Step 3 introduces.
+
+**Edit 2b — linking paragraph.** Insert one paragraph before the blank line that separates § Metrics from § Authentication (after line 274):
 
 ```markdown
 Changes to the canonical-11 set — additions, removals, conditional or
@@ -86,7 +96,7 @@ verdict horizon, and the cohort read-out date. The no-silent-redefinition rule
 lives there; this section does not restate it.
 ```
 
-Verify: `rg -n 'Measurement-system changes' KATA.md` returns one match in § Metrics; `git diff KATA.md` shows exactly one inserted paragraph and no other hunks. Line 261 is unchanged.
+Verify: `rg -n 'one or more metrics' KATA.md` returns one hit in § Metrics; `rg -n 'Measurement-system changes' KATA.md` returns one match; `git diff KATA.md` shows exactly two hunks (one replace on line 261, one append after line 274); `rg -n 'exactly one metric' KATA.md` returns 0 hits.
 
 ## Step 3 — `kata-release-merge` `references/metrics.md` new row
 
@@ -256,7 +266,7 @@ Verify locally before push: `bun run check` exits 0. PR title carries the spec i
 
 ## Risks
 
-1. **Design-b internal contradiction on metric cardinality.** Design-b § Components admits `approvals_recorded_per_run` as "additional rows" in `kata-release-merge`'s existing CSV (cardinality 2), while decision #4 commits to "preserving KATA.md 'count of units of work'" and decision #1 states "no constitutional change." KATA.md line 261 ("each such skill records exactly one metric") is unchanged on landing under this plan, so the new row textually contradicts that line. The plan honors design-b § Components' literal component table (the more concrete of the two design surfaces); the implementation PR body must surface this contradiction so the approver can either accept it (the plan's path) or block on a follow-on governance spec that amends KATA.md line 261. The plan cannot resolve a design-internal contradiction unilaterally.
+1. **Scope expansion vs design-b literal text.** Design-b decision #1 says "no constitutional change to 'count of units of work'" and decision #4 says "no KATA.md amendment is required." Step 2 Edit 2a amends KATA.md line 261 (cardinality "exactly one metric" → "one or more metrics"), preserving the "count of units of work" rule decision #4 named while resolving the cardinality contradiction with § Components' "additional rows" instruction. The amendment is the minimum delta needed to make the design's component table internally consistent on landing; the approver has explicitly directed this resolution rather than the alternative (block on a follow-on governance spec). Reviewers should weigh whether this delta is in-scope for spec 860 or belongs in a sibling governance PR.
 2. **Design-b API-surface claim is factually incorrect.** Design-b § Approval-throughput metric states "No new GitHub-API surface beyond the existing `gh pr view --json labels,timelineItems`," but `gh pr view --json` does not accept a `timelineItems` field (verified against `gh` 2.63.2 — available PR fields include `labels`, `latestReviews`, `reviews`, but not `timelineItems`). The plan uses `gh api repos/{owner}/{repo}/issues/<n>/timeline` (REST) plus `.../pulls/<n>/reviews` instead — the working surface that returns the events the metric needs. This is technically "new API surface" relative to the SKILL.md's current `gh api` calls (Step 2 contributor lookup) but no new auth or scope. Implementation PR body should note the design's surface claim was incorrect; reviewers may file a doc-correction redefinition (`move: rule-semantics-rfc` or similar) against design-b after merge.
 3. **GitHub REST timeline endpoint shape stability.** The REST timeline (`gh api .../issues/<n>/timeline`) returns events with `event: "labeled"`, `label.name`, `created_at`. A breaking change in the GitHub REST API would silently emit `0`s. The producer-rehoming move (Step 1 table row 1) is the protocol response if `xRule3` fires on eight consecutive zeros.
 4. **Wiki-vs-main-repo PR boundary on Success #6.** Design-b § Detection states cross-repo CI enforcement is the follow-on, out of scope. The detection grep works **within the wiki checkout**. For main-repo edges (`coordination-protocol.md`, `.claude/skills/*/references/metrics.md`), Success #6 holds only when those edges are accompanied by a wiki commit adding a redefinition file — a coupling the follow-on CI must verify across the two repos.

--- a/specs/860-measurement-system-change-protocol/plan-b.md
+++ b/specs/860-measurement-system-change-protocol/plan-b.md
@@ -1,0 +1,394 @@
+# Plan 860-b — Measurement-system change protocol (design-b)
+
+Spec: [spec.md](spec.md) · Design: [design-b.md](design-b.md)
+
+## Rationale
+
+This plan pairs with `design-b.md` (the alternative architecture: protocol
+co-located in `coordination-protocol.md`, redefinitions as `wiki/redefinitions/`
+file artifacts, `approvals_recorded_per_run` as a count metric, redefinition
+hook baked into `storyboard-template.md`). A sibling `plan-a.md` would pair
+with `design-a.md` (new `measurement-protocol.md` sibling reference; YAML
+blocks embedded in issue/PR bodies; `time_to_first_approval_hours` duration
+metric; storyboard hook as `<do_confirm_checklist>` items in
+`team-storyboard.md`). The letter pairing keeps the chain readable: design-b
+→ plan-b. The approver selects the design variant to implement; this plan
+becomes live only if design-b is chosen.
+
+## Approach
+
+Land the protocol inside `.claude/agents/references/coordination-protocol.md`
+as one new § Measurement-system changes section (eight repair moves, the
+redefinition file shape, the no-silent-redefinition rule, the
+`git diff`-native detection recipe), add a one-paragraph link from
+`KATA.md` § Metrics, register `approvals_recorded_per_run` in
+`kata-release-merge` (one row in `references/metrics.md`, recording
+instructions in `SKILL.md`), and bake the redefinition-link slot plus the
+bulleted canonical-12 enumeration into `kata-session/references/storyboard-template.md`.
+The implementation run also writes the wiki-side companions through the
+separate wiki checkout: the May storyboard's "11 canonical metrics" prose is
+replaced with the bulleted enumeration (denominator 11→12 in the same diff)
+and one founding worked-example redefinition file lands at
+`wiki/redefinitions/2026-05-12-se-exp-33-sidecar-pre-flight.md` (illustrative;
+the implementation PR itself is grandfathered per design § Migration
+boundary). The first row of `approvals_recorded_per_run` is appended to the
+existing long-format CSV by the implementation run.
+
+Libraries used: none.
+
+## Plan-level decisions (design left open)
+
+| # | Decision | Rejected | Why |
+|---|---|---|---|
+| P1 | Cohort window for `approvals_recorded_per_run` is `(prev_started_at, current_started_at]`, where `current_started_at` is captured at SKILL.md Step 0 as `date -u +%FT%TZ`, and `prev_started_at` is parsed from the previous row's `note` field (encoded as `started_at=<ISO>;...`). First-ever row falls back to `current_started_at - 8h` (the median schedule gap of 03:00 / 12:00 / 20:00 UTC). | Sidecar state file under `wiki/metrics/kata-release-merge/`; or `gh api` query for `event > previous_run_finished_at` using GitHub Actions run timestamps. | A state file fragments the metric's home; Actions timestamps require cross-workflow API reads that the skill does not otherwise need. The CSV `note` already carries free-form annotations — encoding `started_at` there keeps the producer self-contained. |
+| P2 | Window-source query is `gh api repos/{owner}/{repo}/issues/{number}/timeline --paginate --jq '.[] | select(.event=="labeled" and (.label.name|test("^(spec\|design\|plan):approved$")))'` over each open phase PR surveyed in SKILL.md Step 1, plus `gh api repos/{owner}/{repo}/pulls/{number}/reviews --paginate --jq '.[] | select(.state=="APPROVED")'` for review-shaped approvals. `plan:implemented` is excluded by the regex (design § Approval-throughput metric). | `gh pr view --json timelineItems`. | `gh pr view` does not expose label-add timestamps; the REST timeline API does. The skill already calls `gh api` (Step 2 contributor lookup), so no new dependency. |
+| P3 | Filled-in worked example required by spec Success #2 lives **inline** in `coordination-protocol.md` § Measurement-system changes (the SE Exp 33 #787 sidecar-pre-flight case). The wiki-side founding redefinition file at `wiki/redefinitions/2026-05-12-se-exp-33-sidecar-pre-flight.md` is committed as the **on-disk** worked example referenced from the protocol section. Both point to the same case; reviewers can grep `producer-rehoming` or `sidecar-pre-flight` from either surface and reach the same content. | One example only (either inline or wiki-side). | Spec Success #2 requires "one filled-in example" in the reference (inline). Design § Detection requires a file at `wiki/redefinitions/` exists so the grep recipe matches at least one path. The two satisfy different success criteria; both ship. |
+| P4 | Canonical-11 → canonical-12 enumeration replaces inline prose **only in the current month's storyboard** (`wiki/storyboard-2026-M05.md`). `storyboard-template.md` ships the enumeration as a `<!-- canonical-12 -->` marker block plus a `Redefinition:` link slot under § Current Condition § Headlines, so future months inherit the shape via `bunx fit-wiki refresh`. | Edit every historical `wiki/storyboard-*.md`. | Historical storyboards are append-only audit records (per `memory-protocol.md` § Weekly Log Contract analogue). The current-month file is the only live consumer; the template propagates the shape forward. |
+| P5 | `approvals_recorded_per_run` value column is the **count** of distinct label-add events plus APPROVED-review events observed in the window. Same `<phase>:approved` label re-applied to the same PR within the window counts once (de-dupe on `(pr_number, label_name, event_timestamp_truncated_to_second)`). | Count every raw API event. | Re-application within one second is GitHub UI noise (button double-click), not a separate ratification. The de-dupe key is mechanical. |
+
+## Step 1 — coordination-protocol.md § Measurement-system changes
+
+Add a new H2 section between the existing `## Approval signal` (line 34) and
+`## Decision questions` (line 62) — the sibling placement design-b § Components
+specifies. **Modified:**
+`.claude/agents/references/coordination-protocol.md`.
+
+The section carries, in order:
+
+1. **Lead paragraph** (≤4 lines) — names the typology, the redefinition file
+   artifact, the no-silent-redefinition rule, and the detection grep as the
+   four components.
+2. **Eight repair moves** — a table with columns `Move | Definition | Falsifier-set kind | Existing precedent`, populated verbatim from design-b § Repair-move typology and the eight rows in design-a § Repair-move typology (both designs agree on content, only home differs). The list is closed at design time; "extensions land via the spec/design/plan/implement chain" is stated in one sentence after the table.
+3. **Redefinition shape** — a fenced YAML code block exactly matching design-b § Redefinition shape (file artifact). One sentence below clarifies `verdict_horizon ≤ cohort_readout` and the `denominator_effect` enum semantics.
+4. **No-silent-redefinition rule** — blockquote verbatim from design-b § No-silent-redefinition rule. The "KATA.md § Metrics links to it; no other file restates it" sentence follows.
+5. **Worked example** (spec Success #2) — heading `### Worked example — SE Exp 33 (#787) sidecar pre-flight`. Inline YAML front-matter populated for the SE Exp 33 case (`move: sidecar-pre-flight`, `affected_metrics: [{skill: kata-trace, metric: findings_count}]`, falsifier `sidecar diverges from canonical at horizon`, `denominator_effect: sidecar`, links to #787 and the wiki file from P3). The corresponding on-disk file is named in the example body.
+6. **Detection (Success #6)** — heading `### Detection`. The fenced `sh` block from design-b verbatim. One sentence above states the rule ("any commit touching a canonical-11 metric edge must, in the same commit, add or modify a `wiki/redefinitions/*.md` file"); one sentence below names the edges (`wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, `coordination-protocol.md` § Measurement-system changes).
+
+Approximate net addition: 70 lines (matches design-b decision #1
+size-impact estimate). Final file length ~235 lines; references do not
+carry the 200-line design cap (no soft cap in CONTRIBUTING.md or
+CLAUDE.md for `.claude/agents/references/`).
+
+Verify: `wc -l .claude/agents/references/coordination-protocol.md` shows
+≈235; `rg '^## Measurement-system changes$' .claude/agents/references/coordination-protocol.md` returns one hit; `rg 'producer-rehoming|mode-restriction|historical-phasing|sidecar-pre-flight|stock-vs-flow-recast|event-driven-recast|rule-semantics-rfc|habit-to-policy' .claude/agents/references/coordination-protocol.md | wc -l` returns ≥8 (one definition row per move).
+
+## Step 2 — KATA.md § Metrics linking paragraph
+
+Append one paragraph at the end of § Metrics (currently lines 257–274,
+ending at the `fit-xmr` sentence on line 274). **Modified:** `KATA.md`.
+
+Insert after line 274:
+
+```markdown
+Changes to the canonical-11 set — additions, removals, conditional or
+unconditional redefinitions — follow the protocol in
+[`coordination-protocol.md` § Measurement-system changes](.claude/agents/references/coordination-protocol.md#measurement-system-changes):
+each change ships in the same PR as a `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md`
+file naming the repair move, the affected metric(s), the falsifier set, the
+verdict horizon, and the cohort read-out date. The no-silent-redefinition rule
+lives there; this section does not restate it.
+```
+
+The "count of units of work" sentence on line 261 is unchanged —
+design-b preserves the constitutional rule (decision #4). No other
+edits to § Metrics.
+
+Verify: `rg -n 'Measurement-system changes' KATA.md` returns one match
+in the § Metrics block; `git diff KATA.md` shows one inserted paragraph
+and no other hunks.
+
+## Step 3 — kata-release-merge `references/metrics.md` new row
+
+Add the new metric beside `prs_merged`. **Modified:**
+`.claude/skills/kata-release-merge/references/metrics.md`.
+
+Replace the current single-row table with:
+
+```markdown
+| Metric                       | Unit  | Description                                                                                  | Data source                                                       |
+| ---------------------------- | ----- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| prs_merged                   | count | PRs merged this run                                                                          | Run actions                                                       |
+| approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed on open phase PRs in the run window | `gh api repos/.../issues/{n}/timeline` + `.../pulls/{n}/reviews`  |
+```
+
+Append below the existing "Backlog … is queried, not recorded." line:
+
+```markdown
+The window is `(prev_started_at, current_started_at]`; `current_started_at`
+is captured at SKILL.md Step 0; `prev_started_at` is parsed from the
+previous CSV row's `note` field (`started_at=<ISO>;…`). First-ever row
+falls back to `current_started_at - 8h`. De-dupe by
+`(pr_number, label_name, second)`; `plan:implemented` is a state label,
+excluded. See [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).
+```
+
+Verify: `rg -n 'approvals_recorded_per_run' .claude/skills/kata-release-merge/references/metrics.md` returns ≥1 hit; the table renders as two rows.
+
+## Step 4 — kata-release-merge SKILL.md recording instructions
+
+Two small edits to wire the metric. **Modified:**
+`.claude/skills/kata-release-merge/SKILL.md`.
+
+**Edit 4a** — extend Step 0 to capture `current_started_at`. Replace the
+`### Step 0: Read Memory` body to add one sentence after the existing
+memory-read instruction:
+
+```markdown
+Capture this run's start timestamp once at the top of the run:
+`current_started_at=$(date -u +%FT%TZ)`. The approval-throughput metric (Step 9) uses it
+as the window upper bound. Read the previous row's `started_at=<ISO>` from
+`note` in `wiki/metrics/kata-release-merge/{YYYY}.csv` to set
+`prev_started_at`; first-ever row uses `current_started_at - 8h`.
+```
+
+**Edit 4b** — extend Step 9 § Classification Report so the metric row is
+produced alongside the existing record. Add a new sub-step:
+
+```markdown
+### Step 9.5: Record approval-throughput metric
+
+For each open phase PR surveyed in Step 1, fetch label-add events:
+
+\`\`\`sh
+gh api repos/{owner}/{repo}/issues/<number>/timeline --paginate \
+  --jq '.[] | select(.event=="labeled" and (.label.name|test("^(spec|design|plan):approved$"))) | {ts: .created_at, label: .label.name}'
+\`\`\`
+
+And APPROVED reviews:
+
+\`\`\`sh
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate \
+  --jq '.[] | select(.state=="APPROVED") | {ts: .submitted_at}'
+\`\`\`
+
+Filter to events whose `ts` is in `(prev_started_at, current_started_at]`;
+de-dupe label events by `(pr_number, label_name, second)` (P5). Sum to
+`approvals_recorded_per_run`. Append one row to
+`wiki/metrics/kata-release-merge/{YYYY}.csv` with
+`metric=approvals_recorded_per_run`, `unit=count`,
+`note="started_at=<current_started_at>;<phase>:approved=N1;APPROVED-review=N2"`
+(the prefix `started_at=<ISO>;` is required for the next run to read its
+own `prev_started_at`).
+```
+
+The existing `prs_merged` row continues to be appended per Step 9; both
+rows share the date but carry distinct `metric` values (long-format CSV
+discipline, design-b decision #6).
+
+Verify: `rg -n 'approvals_recorded_per_run|started_at=' .claude/skills/kata-release-merge/SKILL.md` returns ≥4 hits across Step 0 and Step 9.5; the `### Step 9.5:` heading exists between `### Step 9:` and `## Memory: what to record`.
+
+## Step 5 — storyboard-template.md structural slot
+
+Bake the canonical-12 enumeration and the `Redefinition:` link slot into
+the template so every regenerated storyboard inherits them. **Modified:**
+`.claude/skills/kata-session/references/storyboard-template.md`.
+
+**Edit 5a** — replace the `### Headlines` body (lines 27–35) to add the
+canonical-12 marker block above the existing bullet template:
+
+```markdown
+### Headlines
+
+_Tight list of metrics whose status changed since the last meeting (new signal,
+threshold crossed, classification flip). Empty if nothing changed — write
+"None." on a single line._
+
+<!-- canonical-12 -->
+The canonical-12 set (denominator for the Target Condition's "≥6 of 12"):
+- `kata-product-issue` / `issues_triaged`
+- `kata-spec` / `specs_drafted`
+- `kata-design` / `designs_drafted`
+- `kata-plan` / `plans_drafted`
+- `kata-implement` / `implementations_landed`
+- `kata-release-merge` / `prs_merged`
+- `kata-release-merge` / `approvals_recorded_per_run`
+- `kata-release-cut` / `releases_cut`
+- `kata-security-update` / `prs_actioned`
+- `kata-security-audit` / `findings_filed`
+- `kata-documentation` / `errors_found`
+- `kata-wiki-curate` / `entries_curated`
+<!-- /canonical-12 -->
+
+- `{agent}` / `{metric}` — {value} {trend/badge} — {one-line reason} — Redefinition: {`wiki/redefinitions/...md` or `—`}
+```
+
+The marker block is regenerated by `bunx fit-wiki refresh` from the
+authoritative enumeration in `coordination-protocol.md` § Measurement-
+system changes (forward-compatible — current `fit-wiki refresh` only
+regenerates `xmr` markers; the `canonical-12` marker is a no-op today
+and gets a regenerator in a follow-on spec). The `Redefinition:` slot is
+the structural form spec Success #5 requires: every canonical-11 change
+item on a headline line names its redefinition file or `—` when none
+applies (e.g., an unrelated metric flip). Exactly **twelve** bullets in
+the marker block — denominator change 11→12 is encoded in the template.
+
+The 12-row enumeration in the template is the authoritative list; if a
+future spec adds a thirteenth metric, that spec's redefinition file
+adopts move `canonical-set-addition` (design-b § Migration boundary).
+The reviewer should confirm the eleven existing metrics in the template
+match the wiki's current canonical-11 set before merge (Risk 4); the
+implementor reads `wiki/storyboard-2026-M05.md` in Step 7 and aligns.
+
+**Edit 5b** — add a Redefinition line to the headlines block prose right
+above the metric-block code-fence example (currently lines 47–60), so
+authors and the `fit-wiki refresh` extension know the link slot exists.
+
+Verify: `rg -n '<!-- canonical-12 -->|Redefinition:' .claude/skills/kata-session/references/storyboard-template.md` returns ≥2 hits;
+`grep -c '^- \`' .claude/skills/kata-session/references/storyboard-template.md` shows ≥12 (the enumeration lines).
+
+## Step 6 — team-storyboard.md worked-example refresh
+
+The Q3-obstacle-routing worked example (lines 102–105) currently names
+four canonical-11 metrics. Update the prose to reflect the canonical-12
+denominator and reference the redefinition path. **Modified:**
+`.claude/skills/kata-session/references/team-storyboard.md`.
+
+Change "canonical-11 metric (`prs_actioned`, …)" → "canonical-12 metric
+(`prs_actioned`, …)" on line 103; append one sentence after the
+existing example: "Right route inferred from the linked redefinition file
+when one is present on the canonical-12 change item." No other edits.
+
+Verify: `rg -n 'canonical-12|canonical-11' .claude/skills/kata-session/references/team-storyboard.md` returns one `canonical-12` hit and zero `canonical-11` hits.
+
+## Step 7 — Wiki: storyboard-2026-M05.md enumeration update
+
+Wiki-side change committed through the separate `wiki/` checkout during
+the implementation run (Stop hook pushes via `just wiki-push`).
+**Modified:** `wiki/storyboard-2026-M05.md`.
+
+Two edits to the May storyboard:
+
+1. Replace the inline "11 canonical metrics" prose under § Target
+   Condition with the bulleted enumeration (12 entries, same shape as
+   the template marker block).
+2. Replace the literal `≥6 of 11` denominator in the Target Condition
+   line with `≥6 of 12`.
+3. Add `Redefinition: —` to every existing headline bullet (the
+   grandfathered implementation does not file one; design § Migration
+   boundary). Future canonical-12 change items will carry a
+   `wiki/redefinitions/...md` path.
+
+The "canonical-11" string is retained historically only as a corpus
+identifier in prose footnotes (design-b § Migration boundary).
+
+Verify (in the wiki checkout): `rg -n 'canonical-12|≥6 of 12' wiki/storyboard-2026-M05.md` returns ≥2 hits; `rg -n '≥6 of 11' wiki/storyboard-2026-M05.md` returns 0 hits.
+
+## Step 8 — Wiki: founding redefinition file + first metric row
+
+Wiki-side companions to the main-repo protocol landing. **Created:**
+`wiki/redefinitions/2026-05-12-se-exp-33-sidecar-pre-flight.md`.
+**Modified:** `wiki/metrics/kata-release-merge/2026.csv`.
+
+**File contents** (matches design-b § Redefinition shape):
+
+```markdown
+---
+move: sidecar-pre-flight
+affected_metrics:
+  - {skill: kata-trace, metric: findings_count}
+falsifier_set:
+  - sidecar diverges from canonical at verdict horizon
+verdict_horizon: 2026-05-19
+cohort_readout: 2026-05-26
+denominator_effect: sidecar
+links:
+  obstacle_issue: "#788"
+  experiment_issue: "#787"
+  pr: null
+---
+
+# Redefinition — SE Exp 33 #787 sidecar pre-flight (founding example)
+
+This file is the on-disk worked example that satisfies the detection grep in
+[`coordination-protocol.md` § Measurement-system changes](../.claude/agents/references/coordination-protocol.md#measurement-system-changes).
+It mirrors the inline example in that section. Spec 860's implementation PR is
+explicitly grandfathered (design-b § Migration boundary) and does not file its
+own redefinition; the first follow-on spec adopts move `canonical-set-addition`
+for net-new canonical metrics.
+```
+
+**CSV row** appended to `wiki/metrics/kata-release-merge/2026.csv`
+(format `date,metric,value,unit,run,note`):
+
+```
+2026-05-12,approvals_recorded_per_run,0,count,1,"started_at=2026-05-12T20:00:00Z;<phase>:approved=0;APPROVED-review=0"
+```
+
+Value `0` is the empty first-row case (P1: structural-zero risk applies
+only when the producer is missing, design-b § Approval-throughput
+metric).
+
+Verify (in the wiki checkout): `ls wiki/redefinitions/` lists the new
+file; `rg -n 'approvals_recorded_per_run' wiki/metrics/kata-release-merge/2026.csv` returns ≥1 hit.
+
+## Step 9 — Quality gates
+
+Run from repo root: `bun run check`, `bun run format:fix`, `bun run
+test`. The change set is documentation-only on the main-repo side; no
+codegen or build steps are involved. Commit any incidental
+formatter-driven hunks separately if they appear.
+
+Verify locally before push: `bun run check` exits 0; the implementation
+PR title carries the spec id (`feat(kata): measurement-system change
+protocol (#860)`).
+
+## Risks
+
+1. **Wiki vs. main-repo PR boundary.** Design-b states "the redefinition
+   file ships in the same PR" as the canonical-11 change, but `wiki/` is
+   gitignored from the main repo and pushed via a separate checkout
+   (`just wiki-push`). The plan resolves this by treating "same PR" as
+   "same implementation run": main-repo doc changes ship in the
+   spec-860 PR; wiki changes ship via the Stop hook in the same run.
+   The grep recipe (design § Detection) runs from inside the wiki
+   checkout (it looks for `wiki/redefinitions/` in commits that touch
+   `wiki/storyboard-*.md`); for main-repo edges
+   (`coordination-protocol.md`, `.claude/skills/*/references/metrics.md`),
+   the grep would need to extend to "PRs that touch those paths must
+   reference a `wiki/redefinitions/...md` path in the PR body or in a
+   sibling wiki commit by SHA." CI mechanisation of the cross-repo
+   variant is acknowledged out-of-scope (design § Detection).
+2. **`note`-field parsing fragility.** P1 encodes `started_at=<ISO>;…`
+   in the long-format CSV's free-form `note` field. A hand-edit that
+   omits or reformats the prefix breaks `prev_started_at` discovery and
+   silently falls back to "current_started_at − 8h", which can
+   double-count events on the boundary. SKILL.md Step 0 documents the
+   format; the implementor should add one note-format example to
+   `references/metrics.md` to make the contract grep-discoverable.
+3. **GitHub timeline API rate limits.** Step 9.5 fans out one
+   `gh api .../timeline` call per surveyed open phase PR per run. If
+   the open phase-PR set grows past ~30, the run hits secondary rate
+   limits during the 03:00/12:00/20:00 windows. Mitigation: the
+   producer can short-circuit on PRs whose `updated_at` is older than
+   `prev_started_at` (the timeline cannot have window-relevant events
+   on a PR that has not been updated since the previous run). The
+   short-circuit is not in the plan — a follow-on optimisation when
+   the backlog grows.
+4. **Canonical-11 list drift.** The 12-bullet enumeration in
+   `storyboard-template.md` (Step 5a) must match the wiki's current
+   canonical-11 set plus the new metric. The implementor must read
+   `wiki/storyboard-2026-M05.md` first and align the eleven inherited
+   names; the template lands in the main repo and any subsequent
+   correction to the canonical names becomes a doc fix, not a
+   redefinition.
+5. **Forward-compat marker without a regenerator.** Step 5a adds a
+   `<!-- canonical-12 -->` marker block that `bunx fit-wiki refresh`
+   does not yet regenerate (only `xmr` markers are wired). The block
+   is hand-maintained until a follow-on spec extends the refresher;
+   in the interim, drift between the template and a regenerated
+   storyboard is possible. The follow-on spec is the natural carrier
+   for the regenerator; this plan does not block on it.
+
+## Execution recommendation
+
+Single staff-engineer executor, sequential. Steps 1–6 (main-repo edits)
+run in order because Step 2 cites Step 1's anchor, Step 4 cites Step 3's
+metric definition, and Step 5 cites Step 1's enumeration source-of-
+truth. Steps 7–8 (wiki) run after the main-repo edits because the wiki
+diff cites paths the main-repo PR establishes (the
+`coordination-protocol.md#measurement-system-changes` anchor). Step 9
+closes. No parallelism; no decomposition into parts. Route entirely to
+the engineering agent — every edit is a code/doc change with no prose
+audience that warrants `technical-writer`.
+
+— Staff Engineer 🛠️


### PR DESCRIPTION
## Summary

- Adds `specs/860-measurement-system-change-protocol/plan-b.md` — the execution-ready plan that pairs with `design-b.md`.
- Eight steps across five main-repo files plus one wiki-side companion, in dependency order:
  1. `coordination-protocol.md` § Measurement-system changes — typology (eight repair-move rows), redefinition shape, no-silent-redefinition rule, inline worked example, detection grep.
  2. `KATA.md` § Metrics — **Edit 2a** amends line 261 ("exactly one metric" → "one or more metrics, each a count of units of work…") to align the constitution with design-b § Components' "additional rows" instruction. **Edit 2b** adds the linking paragraph to the new protocol section.
  3. `kata-release-merge/references/metrics.md` — header refresh ("Append one row per metric per run"), `approvals_recorded_per_run` row, window definition with first-recording fallback.
  4. `kata-release-merge/SKILL.md` — Step 0 captures window timestamps; new Step 8.5 collects the metric (between Step 8 and Step 9); Memory bullet refreshed to "Append one row per metric per run."
  5. `kata-session/references/storyboard-template.md` — `Redefinition:` link slot on the Headlines bullet template.
  6. `kata-session/references/team-storyboard.md` — worked-example refresh with literal `Redefinition: —` slot value.
  7. Wiki side `wiki/storyboard-2026-M05.md` — bulleted canonical enumeration replacing inline prose, denominator increment, Headlines `Redefinition:` slots. Plus one observed first row in `wiki/metrics/kata-release-merge/2026.csv` (Step 8.5 run locally during the implementation).
  8. Quality gates (`bun run format:fix`, `bun run check`, `bun run test`).
- API surface: `gh api repos/{owner}/{repo}/issues/<n>/timeline` (REST) for label-add events and `.../pulls/<n>/reviews` (REST) for APPROVED reviews. (Design-b's "existing `gh pr view --json labels,timelineItems`" claim was factually incorrect — `gh pr view --json` does not accept `timelineItems`. Risk 2 documents this; a doc-correction redefinition against design-b is the recommended follow-on.)
- Six risks: KATA.md cardinality amendment scope; design-b's incorrect API claim; REST timeline shape stability; wiki-vs-main-repo PR boundary on Success #6; timeline fan-out at high cohort sizes; workflow-name binding to `agent-team.yml`.

## Constitutional amendment scope (Risk 1)

Design-b is internally inconsistent on metric cardinality: § Components admits "additional rows" (cardinality 2) for `kata-release-merge` while decision #1 commits to "no constitutional change" and decision #4 says "no KATA.md amendment is required." KATA.md line 261 cannot host the new metric without amendment. The approver has directed Edit 2a — the minimum cardinality delta needed to align the constitution with design-b's component table — to ship in this PR rather than blocking on a follow-on governance spec. "Count of units of work" (decision #4's load-bearing commitment) is preserved. Three ripple edits update files that referenced the old cardinality language: `kata-release-merge/references/metrics.md` header (Edit 3a), `kata-release-merge/SKILL.md` Memory bullet (Edit 4c). Other producers' metric files retain "one row per run" since they have only one metric.

## Sub-agent review history

Six rounds of clean sub-agent review panels (3 staff-engineer reviewers per round, fresh context each, told not to invoke `kata-plan`). Every consensus blocker, high, and medium finding addressed before approval:

- **Rounds 1–5** — fielded consensus blockers (canonical-12 enumeration with wrong metric names, fabricated CSV row, design-a cross-reference, `gh pr view --json timelineItems` field not real), consensus highs (window semantics, CSV-note state, "same PR" cross-repo, Step 9 ordering, stale step-number reference), and consensus mediums (per-step rationale, denominator verify brittleness, fence escaping, etc.).
- **Round 6** — added KATA.md cardinality amendment per approver direction. Panel returned one consensus high (stale cross-reference to old Risk-1 framing) and four consensus mediums (residual rationale paragraph, two "Append one row per run" ripples in `metrics.md` and SKILL.md Memory, verify hunk count brittleness). All addressed.

## Spec

- Spec: [`specs/860-measurement-system-change-protocol/spec.md`](https://github.com/forwardimpact/monorepo/blob/main/specs/860-measurement-system-change-protocol/spec.md)
- Design: [`specs/860-measurement-system-change-protocol/design-b.md`](https://github.com/forwardimpact/monorepo/blob/main/specs/860-measurement-system-change-protocol/design-b.md)
  (the alternative architecture; `design-a.md` is the sibling variant)

## Test plan

- [x] Sub-agent review panels returned no unaddressed consensus blocker/high/medium findings across six rounds.
- [x] Approver direction on Risk 1 captured (amend KATA.md rather than block on follow-on governance spec).
- [ ] Each step's `Verify:` line is independently checkable from `rg`/`wc`/`git diff`.

— Staff Engineer 🛠️