### PR TITLE
ci(publish-skills): publish in APM layout with versioned tags

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - ".claude/skills/fit-*/**"
       - ".claude/skills/kata-*/**"
+      - ".claude/agents/*.md"
+      - "products/gear/package.json"
       - ".github/workflows/publish-skills.yml"
   workflow_dispatch:
 
@@ -33,6 +35,7 @@ jobs:
           repository: forwardimpact/fit-skills
           token: ${{ steps.ci-app.outputs.token }}
           path: skills-repo
+          fetch-depth: 0
 
       - uses: ./monorepo/.github/actions/audit
         with:
@@ -40,15 +43,49 @@ jobs:
           vulnerability-scanning: "false"
           secret-scanning: "true"
 
+      - name: Read version
+        run: |
+          VERSION=$(jq -r '.version' monorepo/products/gear/package.json)
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
       - name: Sync skills
         run: |
-          rm -rf skills-repo/skills
+          inject_skill_frontmatter() {
+            local file="$1" version="$2"
+            awk -v ver="$version" '
+              NR == 1 && $0 == "---" { print; in_fm = 1; next }
+              in_fm && $0 == "---" {
+                print "license: Apache-2.0"
+                print "metadata:"
+                print "  version: \"" ver "\""
+                print "  author: forwardimpact"
+                print
+                in_fm = 0
+                next
+              }
+              { print }
+            ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+          }
 
+          rm -rf skills-repo/skills
           mkdir -p skills-repo/skills
           for skill_dir in monorepo/.claude/skills/fit-*/; do
             skill_name=$(basename "$skill_dir")
             cp -r "$skill_dir" "skills-repo/skills/$skill_name"
+            inject_skill_frontmatter "skills-repo/skills/$skill_name/SKILL.md" "$VERSION"
           done
+
+      - name: Generate apm.yml
+        run: |
+          cat > skills-repo/apm.yml <<EOF
+          name: fit-skills
+          version: ${VERSION}
+          description: >-
+            Agent skills for the Forward Impact engineering standard.
+          author: forwardimpact
+          license: Apache-2.0
+          includes: auto
+          EOF
 
       - name: Generate README
         run: |
@@ -56,11 +93,32 @@ jobs:
           # Forward Impact Skills
 
           Agent skills for the [Forward Impact](https://forwardimpact.team)
-          engineering standard. Install with
-          [npx skills](https://github.com/vercel-labs/skills):
+          engineering standard.
+
+          ## Install
+
+          With [npx skills](https://github.com/vercel-labs/skills):
 
           ```bash
           npx skills add forwardimpact/fit-skills
+          ```
+
+          With [APM](https://microsoft.github.io/apm/), add to your `apm.yml`:
+
+          ```yaml
+          dependencies:
+            apm:
+              - forwardimpact/fit-skills
+          ```
+
+          Then `apm install` deploys the skills to your active client
+          (Claude Code, Copilot, Cursor, OpenCode, Codex, or Gemini). To pull a
+          single skill, reference it by path:
+
+          ```yaml
+          dependencies:
+            apm:
+              - forwardimpact/fit-skills/skills/fit-doc
           ```
 
           ## Available Skills
@@ -71,29 +129,33 @@ jobs:
 
           sed -i 's/^          //' skills-repo/README.md
 
+          extract_desc() {
+            awk '
+              /^description:/ {
+                sub(/^description: *>? */, "")
+                if ($0 != "") { desc = $0 }
+                while (getline > 0) {
+                  if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
+                  else { break }
+                }
+                gsub(/^ +/, "", desc)
+                gsub(/ +$/, "", desc)
+                print desc
+                exit
+              }
+            ' "$1"
+          }
+
           for skill_dir in skills-repo/skills/*/; do
             skill_md="$skill_dir/SKILL.md"
             if [ -f "$skill_md" ]; then
               name=$(sed -n 's/^name: *//p' "$skill_md" | head -1)
-              desc=$(awk '
-                /^description:/ {
-                  sub(/^description: *>? */, "")
-                  if ($0 != "") { desc = $0 }
-                  while (getline > 0) {
-                    if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
-                    else { break }
-                  }
-                  gsub(/^ +/, "", desc)
-                  gsub(/ +$/, "", desc)
-                  print desc
-                  exit
-                }
-              ' "$skill_md")
+              desc=$(extract_desc "$skill_md")
               echo "| **${name}** | ${desc} |" >> skills-repo/README.md
             fi
           done
 
-      - name: Commit and push
+      - name: Commit, push, tag
         working-directory: skills-repo
         run: |
           git config user.name "kata-agent-team[bot]"
@@ -102,8 +164,15 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to publish"
           else
-            git commit -m "chore: sync skills from monorepo"
+            git commit -m "chore: sync skills from monorepo @ v${VERSION}"
             git push
+          fi
+
+          if git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists upstream"
+          else
+            git tag "v${VERSION}"
+            git push origin "v${VERSION}"
           fi
 
   publish-kata-skills:
@@ -126,6 +195,7 @@ jobs:
           repository: forwardimpact/kata-skills
           token: ${{ steps.ci-app.outputs.token }}
           path: skills-repo
+          fetch-depth: 0
 
       - uses: ./monorepo/.github/actions/audit
         with:
@@ -133,27 +203,95 @@ jobs:
           vulnerability-scanning: "false"
           secret-scanning: "true"
 
+      - name: Read version
+        run: |
+          VERSION=$(jq -r '.version' monorepo/products/gear/package.json)
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
       - name: Sync skills
         run: |
-          rm -rf skills-repo/skills
+          inject_skill_frontmatter() {
+            local file="$1" version="$2"
+            awk -v ver="$version" '
+              NR == 1 && $0 == "---" { print; in_fm = 1; next }
+              in_fm && $0 == "---" {
+                print "license: Apache-2.0"
+                print "metadata:"
+                print "  version: \"" ver "\""
+                print "  author: forwardimpact"
+                print
+                in_fm = 0
+                next
+              }
+              { print }
+            ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+          }
 
+          rm -rf skills-repo/skills
           mkdir -p skills-repo/skills
           for skill_dir in monorepo/.claude/skills/kata-*/; do
             skill_name=$(basename "$skill_dir")
             cp -r "$skill_dir" "skills-repo/skills/$skill_name"
+            inject_skill_frontmatter "skills-repo/skills/$skill_name/SKILL.md" "$VERSION"
           done
+
+      - name: Sync agents
+        run: |
+          rm -rf skills-repo/agents
+          mkdir -p skills-repo/agents
+          for agent_file in monorepo/.claude/agents/*.md; do
+            [ -f "$agent_file" ] || continue
+            agent_name=$(basename "$agent_file" .md)
+            cp "$agent_file" "skills-repo/agents/${agent_name}.agent.md"
+          done
+
+      - name: Generate apm.yml
+        run: |
+          cat > skills-repo/apm.yml <<EOF
+          name: kata-skills
+          version: ${VERSION}
+          description: >-
+            Forward Impact Kata Agent Team — domain agents and skills for the
+            spec → design → plan → implement workflow, releases, security, and
+            product-issue triage.
+          author: forwardimpact
+          license: Apache-2.0
+          includes: auto
+          EOF
 
       - name: Generate README
         run: |
           cat > skills-repo/README.md << 'EOF'
           # Kata Skills
 
-          Agent skills for the [Forward Impact](https://forwardimpact.team)
-          Kata Agent Team. Install with
-          [npx skills](https://github.com/vercel-labs/skills):
+          Agents and skills for the [Forward Impact](https://forwardimpact.team)
+          Kata Agent Team.
+
+          ## Install
+
+          With [npx skills](https://github.com/vercel-labs/skills):
 
           ```bash
           npx skills add forwardimpact/kata-skills
+          ```
+
+          With [APM](https://microsoft.github.io/apm/), add to your `apm.yml`:
+
+          ```yaml
+          dependencies:
+            apm:
+              - forwardimpact/kata-skills
+          ```
+
+          Then `apm install` deploys the skills and agents to your active
+          client (Claude Code, Copilot, Cursor, OpenCode, Codex, or Gemini).
+          To pull a single primitive, reference it by path:
+
+          ```yaml
+          dependencies:
+            apm:
+              - forwardimpact/kata-skills/skills/kata-spec
+              - forwardimpact/kata-skills/agents/release-engineer.agent.md
           ```
 
           ## Available Skills
@@ -164,29 +302,48 @@ jobs:
 
           sed -i 's/^          //' skills-repo/README.md
 
+          extract_desc() {
+            awk '
+              /^description:/ {
+                sub(/^description: *>? */, "")
+                if ($0 != "") { desc = $0 }
+                while (getline > 0) {
+                  if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
+                  else { break }
+                }
+                gsub(/^ +/, "", desc)
+                gsub(/ +$/, "", desc)
+                print desc
+                exit
+              }
+            ' "$1"
+          }
+
           for skill_dir in skills-repo/skills/*/; do
             skill_md="$skill_dir/SKILL.md"
             if [ -f "$skill_md" ]; then
               name=$(sed -n 's/^name: *//p' "$skill_md" | head -1)
-              desc=$(awk '
-                /^description:/ {
-                  sub(/^description: *>? */, "")
-                  if ($0 != "") { desc = $0 }
-                  while (getline > 0) {
-                    if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
-                    else { break }
-                  }
-                  gsub(/^ +/, "", desc)
-                  gsub(/ +$/, "", desc)
-                  print desc
-                  exit
-                }
-              ' "$skill_md")
+              desc=$(extract_desc "$skill_md")
               echo "| **${name}** | ${desc} |" >> skills-repo/README.md
             fi
           done
 
-      - name: Commit and push
+          cat >> skills-repo/README.md << 'EOF'
+
+          ## Available Agents
+
+          | Agent | Description |
+          | --- | --- |
+          EOF
+
+          for agent_file in skills-repo/agents/*.agent.md; do
+            [ -f "$agent_file" ] || continue
+            name=$(sed -n 's/^name: *//p' "$agent_file" | head -1)
+            desc=$(extract_desc "$agent_file")
+            echo "| **${name}** | ${desc} |" >> skills-repo/README.md
+          done
+
+      - name: Commit, push, tag
         working-directory: skills-repo
         run: |
           git config user.name "kata-agent-team[bot]"
@@ -195,6 +352,13 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to publish"
           else
-            git commit -m "chore: sync skills from monorepo"
+            git commit -m "chore: sync skills from monorepo @ v${VERSION}"
             git push
+          fi
+
+          if git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists upstream"
+          else
+            git tag "v${VERSION}"
+            git push origin "v${VERSION}"
           fi


### PR DESCRIPTION
Workflow now produces the same shape forwardimpact/kata-skills was manually
restructured to serve via APM, and assumes forwardimpact/fit-skills is being
converted the same way (skills-only, no agents/).

Per job:
- Read version from products/gear/package.json.
- Sync skills, injecting `license: Apache-2.0` and a `metadata: {version,
  author}` block into each SKILL.md frontmatter at publish time so monorepo
  source files stay minimal.
- Generate apm.yml at the downstream repo root with name, version,
  description, author, license, includes: auto.
- README is rebuilt with both `npx skills` and APM install instructions,
  plus an "Available Agents" table on the kata job.
- Kata job also syncs .claude/agents/*.md to agents/<name>.agent.md.
- After push, create and push tag `v<version>` if it doesn't already exist
  on the downstream origin.

Trigger paths extended to include .claude/agents/*.md and
products/gear/package.json so version bumps and agent edits both fire the
workflow. Downstream checkout uses fetch-depth: 0 so the tag-existence
check can see full history.

https://claude.ai/code/session_01NZkboY7R2ZCak8uhhK7yeC