### PR TITLE
feat(libeval): redact secrets in trace artifacts before disk (#850)

### DIFF
--- a/.github/actions/kata-action-eval/README.md
+++ b/.github/actions/kata-action-eval/README.md
@@ -60,3 +60,25 @@ When `trace` is enabled, the action uploads one artifact per run named
 `<case>` defaults to `default` for non-matrix runs; matrix workflows pass
 `case: ${{ matrix.<dim>.id }}` to disambiguate per-shard artifacts. The legacy
 `artifact-suffix` input is honored with a deprecation warning.
+
+## Trace redaction
+
+The underlying `fit-eval` CLI redacts secrets in trace artifacts before they
+reach disk. Two layers compose:
+
+- **Env-var allowlist**, defaulting to `ANTHROPIC_API_KEY`, `GH_TOKEN`,
+  `GITHUB_TOKEN`. The runtime values of these vars are replaced with
+  `[REDACTED:env:NAME]` wherever they appear in tool inputs, tool outputs,
+  assistant text, or orchestrator summaries. Override the list with
+  `LIBEVAL_REDACTION_ENV_VARS=NAME1,NAME2,…` (replaces, not extends).
+- **Credential-shape patterns**, covering Anthropic API keys (`sk-ant-`),
+  GitHub PATs (`ghp_`), installation tokens (`ghs_`), OAuth tokens (`gho_`),
+  and fine-grained PATs (`github_pat_`). Pattern hits become
+  `[REDACTED:pattern:KIND]`.
+
+Redaction is on by default. To disable, set `LIBEVAL_REDACTION_DISABLED=1` in
+the workflow `env:` block — a stderr warning fires once per run. Setting this
+in workflow YAML is reviewable in the PR diff and is **prohibited on
+public-repo CI**: workflow artifacts there are downloadable through the
+retention window, and a redaction-disabled trace could carry the workflow's
+`ANTHROPIC_API_KEY` and `GH_TOKEN` to anyone with read access.

--- a/libraries/libeval/README.md
+++ b/libraries/libeval/README.md
@@ -12,3 +12,23 @@ reproducible evidence.
 ```js
 import { createTraceCollector, createTraceQuery, createAgentRunner } from '@forwardimpact/libeval';
 ```
+
+## Trace redaction
+
+`fit-eval run`, `fit-eval supervise`, and `fit-eval facilitate` redact
+secrets in trace artifacts before they reach disk. Two layers compose:
+
+- **Env-var allowlist**, defaulting to `ANTHROPIC_API_KEY`, `GH_TOKEN`,
+  `GITHUB_TOKEN`. The runtime values of these vars are replaced with
+  `[REDACTED:env:NAME]` wherever they appear in tool inputs, tool
+  outputs, assistant text, or orchestrator summaries. Override the list
+  with `LIBEVAL_REDACTION_ENV_VARS=NAME1,NAME2,…` (replaces, not extends).
+- **Credential-shape patterns**, covering Anthropic API keys (`sk-ant-`),
+  GitHub PATs (`ghp_`), installation tokens (`ghs_`), OAuth tokens
+  (`gho_`), and fine-grained PATs (`github_pat_`). Pattern hits become
+  `[REDACTED:pattern:KIND]`.
+
+Redaction is on by default. To disable, set `LIBEVAL_REDACTION_DISABLED=1`
+— a stderr warning fires once per run. Never set this in CI on a public
+repository: workflow artifacts there are downloadable through the
+retention window.

--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -54,7 +54,9 @@ export class AgentRunner {
     if (!deps.cwd) throw new Error("cwd is required");
     if (!deps.query) throw new Error("query is required");
     if (!deps.output) throw new Error("output is required");
+    if (!deps.redactor) throw new Error("redactor is required");
     Object.assign(this, applyDefaults(deps));
+    this.redactor = deps.redactor;
     this.sessionId = null;
     this.buffer = [];
     /** @type {AbortController|null} */
@@ -203,12 +205,16 @@ export class AgentRunner {
    * @param {{pendingBatch: string[], assistantTextCount: number}} state
    */
   #recordLine(message, state) {
-    const line = JSON.stringify(message);
+    const redacted = this.redactor.redactValue(message);
+    const line = JSON.stringify(redacted);
     this.output.write(line + "\n");
     this.buffer.push(line);
     if (this.onLine) this.onLine(line);
     if (this.onBatch) state.pendingBatch.push(line);
 
+    // Session-id / text-block tracking reads the ORIGINAL message —
+    // these fields are not secret carriers, and the trackers rely on
+    // shape, not string contents.
     if (message.type === "system" && message.subtype === "init") {
       this.sessionId = message.session_id;
     }

--- a/libraries/libeval/src/commands/facilitate.js
+++ b/libraries/libeval/src/commands/facilitate.js
@@ -1,6 +1,7 @@
 import { readFileSync, createWriteStream } from "node:fs";
 import { resolve } from "node:path";
 import { createFacilitator } from "../facilitator.js";
+import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
 
 /**
@@ -62,6 +63,11 @@ function parseFacilitateOptions(values) {
 export async function runFacilitateCommand(values, _args) {
   const opts = parseFacilitateOptions(values);
 
+  // Build the redactor as the first observable side-effect after option
+  // parsing — the env snapshot must freeze BEFORE any in-process
+  // process.env writes the command performs (e.g. LIBEVAL_AGENT_PROFILE).
+  const redactor = createRedactor();
+
   const fileStream = opts.outputPath
     ? createWriteStream(opts.outputPath)
     : null;
@@ -87,6 +93,7 @@ export async function runFacilitateCommand(values, _args) {
     maxTurns: opts.maxTurns,
     facilitatorProfile: opts.facilitatorProfile,
     taskAmend: opts.taskAmend,
+    redactor,
   });
 
   const result = await facilitator.run(opts.taskContent);

--- a/libraries/libeval/src/commands/run.js
+++ b/libraries/libeval/src/commands/run.js
@@ -3,6 +3,7 @@ import { Writable } from "node:stream";
 import { resolve } from "node:path";
 import { createAgentRunner } from "../agent-runner.js";
 import { composeProfilePrompt } from "../profile-prompt.js";
+import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
 import { SequenceCounter } from "../sequence-counter.js";
 import { createServiceConfig } from "@forwardimpact/libconfig";
@@ -61,6 +62,11 @@ export async function runRunCommand(values, _args) {
     mcpServer,
   } = parseRunOptions(values);
 
+  // Build the redactor as the first observable side-effect after option
+  // parsing — the env snapshot must freeze BEFORE any in-process
+  // process.env writes the command performs (e.g. LIBEVAL_AGENT_PROFILE).
+  const redactor = createRedactor();
+
   // When --output is specified, stream text to stdout while writing NDJSON to file.
   // Otherwise, write NDJSON directly to stdout (backwards-compatible).
   const fileStream = outputPath ? createWriteStream(outputPath) : null;
@@ -76,9 +82,8 @@ export async function runRunCommand(values, _args) {
   });
   const onLine = (line) => {
     const event = JSON.parse(line);
-    output.write(
-      JSON.stringify({ source: "agent", seq: counter.next(), event }) + "\n",
-    );
+    const tagged = { source: "agent", seq: counter.next(), event };
+    output.write(JSON.stringify(redactor.redactValue(tagged)) + "\n");
   };
 
   let mcpServers = null;
@@ -117,6 +122,7 @@ export async function runRunCommand(values, _args) {
     systemPrompt,
     taskAmend,
     mcpServers,
+    redactor,
   });
 
   const result = await runner.run(taskContent);

--- a/libraries/libeval/src/commands/supervise.js
+++ b/libraries/libeval/src/commands/supervise.js
@@ -2,6 +2,7 @@ import { readFileSync, createWriteStream, mkdtempSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createSupervisor } from "../supervisor.js";
+import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 
@@ -60,6 +61,11 @@ function parseSuperviseOptions(values) {
 export async function runSuperviseCommand(values, _args) {
   const opts = parseSuperviseOptions(values);
 
+  // Build the redactor as the first observable side-effect after option
+  // parsing — the env snapshot must freeze BEFORE any in-process
+  // process.env writes the command performs (e.g. LIBEVAL_AGENT_PROFILE).
+  const redactor = createRedactor();
+
   // When --output is specified, stream text to stdout while writing NDJSON to file.
   // Otherwise, write NDJSON directly to stdout (backwards-compatible).
   const fileStream = opts.outputPath
@@ -104,6 +110,7 @@ export async function runSuperviseCommand(values, _args) {
     agentProfile: opts.agentProfile,
     taskAmend: opts.taskAmend,
     agentMcpServers,
+    redactor,
   });
 
   const result = await supervisor.run(opts.taskContent);

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -59,7 +59,10 @@ export class Facilitator {
     ctx,
     eventQueue,
     taskAmend,
+    redactor,
   }) {
+    if (!redactor) throw new Error("redactor is required");
+    this.redactor = redactor;
     this.facilitatorRunner = facilitatorRunner;
     this.agents = agents;
     this.messageBus = messageBus;
@@ -327,11 +330,13 @@ export class Facilitator {
   emitLine(source, line) {
     const event = JSON.parse(line);
     this.output.write(
-      JSON.stringify({
-        source,
-        seq: this.counter.next(),
-        event,
-      }) + "\n",
+      JSON.stringify(
+        this.redactor.redactValue({
+          source,
+          seq: this.counter.next(),
+          event,
+        }),
+      ) + "\n",
     );
   }
 
@@ -340,11 +345,13 @@ export class Facilitator {
    */
   emitOrchestratorEvent(event) {
     this.output.write(
-      JSON.stringify({
-        source: "orchestrator",
-        seq: this.counter.next(),
-        event,
-      }) + "\n",
+      JSON.stringify(
+        this.redactor.redactValue({
+          source: "orchestrator",
+          seq: this.counter.next(),
+          event,
+        }),
+      ) + "\n",
     );
   }
 
@@ -353,17 +360,19 @@ export class Facilitator {
    */
   emitSummary(result) {
     this.output.write(
-      JSON.stringify({
-        source: "orchestrator",
-        seq: this.counter.next(),
-        event: {
-          type: "summary",
-          success: result.success,
-          ...(result.verdict && { verdict: result.verdict }),
-          turns: result.turns,
-          ...(result.summary && { summary: result.summary }),
-        },
-      }) + "\n",
+      JSON.stringify(
+        this.redactor.redactValue({
+          source: "orchestrator",
+          seq: this.counter.next(),
+          event: {
+            type: "summary",
+            success: result.success,
+            ...(result.verdict && { verdict: result.verdict }),
+            turns: result.turns,
+            ...(result.summary && { summary: result.summary }),
+          },
+        }),
+      ) + "\n",
     );
   }
 }
@@ -398,7 +407,9 @@ export function createFacilitator({
   facilitatorProfile,
   profilesDir,
   taskAmend,
+  redactor,
 }) {
+  if (!redactor) throw new Error("redactor is required");
   const resolvedProfilesDir =
     profilesDir ?? resolve(facilitatorCwd, ".claude/agents");
   const systemPromptFor = (profile, trailer) => {
@@ -446,6 +457,7 @@ export function createFacilitator({
       mcpServers: { orchestration: agentServer },
       settingSources: ["project"],
       systemPrompt: systemPromptFor(config.agentProfile, agentTrailer),
+      redactor,
     });
 
     return { name: config.name, role: config.role, runner };
@@ -464,6 +476,7 @@ export function createFacilitator({
       facilitatorProfile,
       FACILITATOR_SYSTEM_PROMPT,
     ),
+    redactor,
   });
 
   facilitator = new Facilitator({
@@ -475,6 +488,7 @@ export function createFacilitator({
     ctx,
     eventQueue,
     taskAmend,
+    redactor,
   });
   return facilitator;
 }

--- a/libraries/libeval/src/index.js
+++ b/libraries/libeval/src/index.js
@@ -31,3 +31,10 @@ export {
   FACILITATOR_SYSTEM_PROMPT,
   FACILITATED_AGENT_SYSTEM_PROMPT,
 } from "./facilitator.js";
+export {
+  Redactor,
+  createRedactor,
+  createNoopRedactor,
+  DEFAULT_ENV_ALLOWLIST,
+  DEFAULT_PATTERNS,
+} from "./redaction.js";

--- a/libraries/libeval/src/redaction.js
+++ b/libraries/libeval/src/redaction.js
@@ -1,0 +1,163 @@
+/**
+ * Redactor — replaces secrets in JSON-serialisable values before they reach
+ * the trace artifact. Composes two layers: an env-var value allowlist and a
+ * set of credential-shape regexes. Both run on every primitive string.
+ *
+ * Stateless after construction: `env` is captured once so in-process
+ * `process.env` writes (e.g. agent-runner.js LIBEVAL_SKILL, commands/run.js
+ * LIBEVAL_AGENT_PROFILE) cannot smuggle a value past the redactor.
+ */
+
+export const DEFAULT_ENV_ALLOWLIST = Object.freeze([
+  "ANTHROPIC_API_KEY",
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+]);
+
+// Anchored prefixes per
+// https://github.blog/security/application-security/behind-githubs-new-authentication-token-formats/
+// Anthropic prefix is heuristic — the env-allowlist layer is the primary
+// defence for Anthropic keys.
+export const DEFAULT_PATTERNS = Object.freeze([
+  { kind: "anthropic", regex: /sk-ant-[A-Za-z0-9_-]{80,}/g },
+  { kind: "gh-pat", regex: /\bghp_[A-Za-z0-9]{36}\b/g },
+  { kind: "gh-installation", regex: /\bghs_[A-Za-z0-9]{36}\b/g },
+  { kind: "gh-oauth", regex: /\bgho_[A-Za-z0-9]{36}\b/g },
+  { kind: "gh-fine-grained", regex: /\bgithub_pat_[A-Za-z0-9_]{82}\b/g },
+]);
+
+const ENV_PLACEHOLDER = (name) => `[REDACTED:env:${name}]`;
+const PATTERN_PLACEHOLDER = (kind) => `[REDACTED:pattern:${kind}]`;
+
+/**
+ * Build a frozen { name → value } snapshot of the requested env vars.
+ * Empty strings are skipped — a leaked empty env var would otherwise
+ * cause every empty string in the trace to be replaced.
+ */
+function snapshotEnv(env, allowlist) {
+  const snap = {};
+  for (const name of allowlist) {
+    const v = env[name];
+    if (typeof v === "string" && v.length > 0) snap[name] = v;
+  }
+  return Object.freeze(snap);
+}
+
+/** Recursively walk and redact a JSON-serialisable value in place-free style. */
+function walk(value, redactString) {
+  if (typeof value === "string") return redactString(value);
+  if (Array.isArray(value)) return value.map((v) => walk(v, redactString));
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const k of Object.keys(value)) out[k] = walk(value[k], redactString);
+    return out;
+  }
+  return value;
+}
+
+/** Stateless secret redactor — composes env-allowlist and pattern layers. */
+export class Redactor {
+  /**
+   * @param {object} deps
+   * @param {Readonly<Record<string, string>>} deps.envSnapshot - Frozen { name → secret } map captured at construction time.
+   * @param {ReadonlyArray<{kind: string, regex: RegExp}>} deps.patterns - Credential-shape regexes; each match becomes `[REDACTED:pattern:KIND]`.
+   * @param {boolean} deps.enabled - When false, `redactValue` returns its input by reference.
+   */
+  constructor({ envSnapshot, patterns, enabled }) {
+    this.envSnapshot = envSnapshot;
+    this.patterns = patterns;
+    this.enabled = enabled;
+  }
+
+  /**
+   * Redact any JSON-serialisable value by deep-walking and replacing secrets
+   * in every primitive string. Identity on the input when disabled.
+   * @param {unknown} value
+   * @returns {unknown}
+   */
+  redactValue(value) {
+    if (!this.enabled) return value;
+    return walk(value, (s) => this.#redactString(s));
+  }
+
+  /**
+   * Apply the env-allowlist and pattern layers to a single string.
+   * @param {string} s
+   * @returns {string}
+   */
+  #redactString(s) {
+    let out = s;
+    for (const [name, secret] of Object.entries(this.envSnapshot)) {
+      if (out.includes(secret)) {
+        out = out.split(secret).join(ENV_PLACEHOLDER(name));
+      }
+    }
+    for (const { kind, regex } of this.patterns) {
+      out = out.replace(regex, PATTERN_PLACEHOLDER(kind));
+    }
+    return out;
+  }
+}
+
+/**
+ * Build a redactor. Reads `LIBEVAL_REDACTION_DISABLED` and
+ * `LIBEVAL_REDACTION_ENV_VARS` from the supplied env (defaults to
+ * `process.env`). Fires a one-shot stderr warning when constructed
+ * disabled — bypass via `createNoopRedactor()` for silent fixtures.
+ * @param {object} [opts]
+ * @param {Record<string, string|undefined>} [opts.env] - Environment to snapshot. Defaults to `process.env`.
+ * @param {string[]} [opts.allowlist] - Override the env-var name list. Defaults to `DEFAULT_ENV_ALLOWLIST` or the parsed `LIBEVAL_REDACTION_ENV_VARS` value.
+ * @param {ReadonlyArray<{kind: string, regex: RegExp}>} [opts.patterns] - Credential-shape regexes. Defaults to `DEFAULT_PATTERNS`.
+ * @param {boolean} [opts.enabled] - Force enabled/disabled; bypasses `LIBEVAL_REDACTION_DISABLED`.
+ * @returns {Redactor}
+ */
+export function createRedactor({
+  env = process.env,
+  allowlist,
+  patterns = DEFAULT_PATTERNS,
+  enabled,
+} = {}) {
+  const envDisabled = env.LIBEVAL_REDACTION_DISABLED === "1";
+  const resolvedEnabled = enabled ?? !envDisabled;
+  const resolvedAllowlist = allowlist ?? resolveAllowlistFromEnv(env);
+  const envSnapshot = resolvedEnabled
+    ? snapshotEnv(env, resolvedAllowlist)
+    : Object.freeze({});
+  if (!resolvedEnabled) {
+    process.stderr.write(
+      "libeval: trace redaction DISABLED via LIBEVAL_REDACTION_DISABLED — secrets may appear in trace artifact\n",
+    );
+  }
+  return new Redactor({ envSnapshot, patterns, enabled: resolvedEnabled });
+}
+
+/**
+ * Parse `LIBEVAL_REDACTION_ENV_VARS` into a trimmed, non-empty name list.
+ * Falls back to `DEFAULT_ENV_ALLOWLIST` when unset or empty.
+ * @param {Record<string, string|undefined>} env
+ * @returns {string[]}
+ */
+function resolveAllowlistFromEnv(env) {
+  const override = env.LIBEVAL_REDACTION_ENV_VARS;
+  if (typeof override !== "string" || override.length === 0) {
+    return DEFAULT_ENV_ALLOWLIST;
+  }
+  return override
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Build a disabled redactor whose `redactValue` is the identity function.
+ * Test-fixture form — bypasses `createRedactor` so no stderr warning
+ * fires regardless of env state.
+ * @returns {Redactor}
+ */
+export function createNoopRedactor() {
+  return new Redactor({
+    envSnapshot: Object.freeze({}),
+    patterns: [],
+    enabled: false,
+  });
+}

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -74,10 +74,13 @@ export class Supervisor {
     ctx,
     messageBus,
     taskAmend,
+    redactor,
   }) {
     if (!agentRunner) throw new Error("agentRunner is required");
     if (!supervisorRunner) throw new Error("supervisorRunner is required");
     if (!output) throw new Error("output is required");
+    if (!redactor) throw new Error("redactor is required");
+    this.redactor = redactor;
     this.agentRunner = agentRunner;
     this.supervisorRunner = supervisorRunner;
     this.output = output;
@@ -406,7 +409,7 @@ export class Supervisor {
       seq: this.counter.next(),
       event,
     };
-    this.output.write(JSON.stringify(tagged) + "\n");
+    this.output.write(JSON.stringify(this.redactor.redactValue(tagged)) + "\n");
   }
 
   /**
@@ -429,11 +432,13 @@ export class Supervisor {
    */
   emitOrchestratorEvent(event) {
     this.output.write(
-      JSON.stringify({
-        source: "orchestrator",
-        seq: this.counter.next(),
-        event,
-      }) + "\n",
+      JSON.stringify(
+        this.redactor.redactValue({
+          source: "orchestrator",
+          seq: this.counter.next(),
+          event,
+        }),
+      ) + "\n",
     );
   }
 
@@ -443,17 +448,19 @@ export class Supervisor {
    */
   emitSummary(result) {
     this.output.write(
-      JSON.stringify({
-        source: "orchestrator",
-        seq: this.counter.next(),
-        event: {
-          type: "summary",
-          success: result.success,
-          ...(result.verdict && { verdict: result.verdict }),
-          turns: result.turns,
-          ...(result.summary && { summary: result.summary }),
-        },
-      }) + "\n",
+      JSON.stringify(
+        this.redactor.redactValue({
+          source: "orchestrator",
+          seq: this.counter.next(),
+          event: {
+            type: "summary",
+            success: result.success,
+            ...(result.verdict && { verdict: result.verdict }),
+            turns: result.turns,
+            ...(result.summary && { summary: result.summary }),
+          },
+        }),
+      ) + "\n",
     );
   }
 }
@@ -498,7 +505,9 @@ export function createSupervisor({
   profilesDir,
   taskAmend,
   agentMcpServers,
+  redactor,
 }) {
+  if (!redactor) throw new Error("redactor is required");
   const resolvedProfilesDir =
     profilesDir ?? resolve(supervisorCwd, ".claude/agents");
   const systemPromptFor = (profile, trailer) => {
@@ -538,6 +547,7 @@ export function createSupervisor({
     settingSources: ["project"],
     systemPrompt: systemPromptFor(agentProfile, AGENT_SYSTEM_PROMPT),
     mcpServers: { orchestration: agentServer, ...agentMcpServers },
+    redactor,
   });
 
   const defaultDisallowed = ["Agent", "Task", "TaskOutput", "TaskStop"];
@@ -564,6 +574,7 @@ export function createSupervisor({
     settingSources: ["project"],
     systemPrompt: systemPromptFor(supervisorProfile, SUPERVISOR_SYSTEM_PROMPT),
     mcpServers: { orchestration: supervisorServer },
+    redactor,
   });
 
   supervisor = new Supervisor({
@@ -574,6 +585,7 @@ export function createSupervisor({
     ctx,
     messageBus,
     taskAmend,
+    redactor,
   });
   return supervisor;
 }

--- a/libraries/libeval/test/agent-runner-batching.test.js
+++ b/libraries/libeval/test/agent-runner-batching.test.js
@@ -3,10 +3,13 @@ import assert from "node:assert";
 import { PassThrough } from "node:stream";
 
 import { AgentRunner } from "@forwardimpact/libeval";
+import { createNoopRedactor } from "../src/redaction.js";
 import {
   createMockAgentQuery as mockQuery,
   createTextBlockMsg,
 } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 const textBlock = (t) => createTextBlockMsg(t);
 
@@ -23,6 +26,7 @@ describe("AgentRunner - onBatch batching", () => {
       cwd: "/tmp",
       query: async function* () {},
       output: new PassThrough(),
+      redactor: noop(),
     });
     assert.strictEqual(runner.batchSize, 3);
   });
@@ -46,6 +50,7 @@ describe("AgentRunner - onBatch batching", () => {
       cwd: "/tmp",
       query: mockQuery(messages),
       output: new PassThrough(),
+      redactor: noop(),
     });
     runner.onBatch = async (lines) => {
       batches.push(lines.map((l) => JSON.parse(l)));
@@ -76,6 +81,7 @@ describe("AgentRunner - onBatch batching", () => {
       query: mockQuery(messages),
       output: new PassThrough(),
       batchSize: 2,
+      redactor: noop(),
     });
     runner.onBatch = async (lines) => {
       batches.push(lines.length);
@@ -103,6 +109,7 @@ describe("AgentRunner - onBatch batching", () => {
       query: mockQuery(messages),
       output: new PassThrough(),
       batchSize: 1,
+      redactor: noop(),
     });
     runner.onBatch = async (lines) => {
       batches.push(lines.map((l) => JSON.parse(l)));
@@ -135,6 +142,7 @@ describe("AgentRunner - onBatch batching", () => {
       query: mockQuery(messages),
       output: new PassThrough(),
       batchSize: 5,
+      redactor: noop(),
     });
     runner.onBatch = async (lines) => {
       batches.push(lines.length);
@@ -163,6 +171,7 @@ describe("AgentRunner - terminal flush on abnormal end", () => {
       cwd: "/tmp",
       query: () => crashingQuery(),
       output: new PassThrough(),
+      redactor: noop(),
     });
     runner.onBatch = async (lines) => {
       batches.push(lines.map((l) => JSON.parse(l)));
@@ -195,6 +204,7 @@ describe("AgentRunner - terminal flush on abnormal end", () => {
       query: () => crashingQuery(),
       output: new PassThrough(),
       batchSize: 2,
+      redactor: noop(),
     });
     runner.onBatch = async (lines) => {
       batches.push(lines.length);
@@ -223,6 +233,7 @@ describe("AgentRunner - terminal flush on abnormal end", () => {
       query: () => noResultQuery(),
       output: new PassThrough(),
       batchSize: 3,
+      redactor: noop(),
     });
     runner.onBatch = async (lines) => {
       batches.push(lines.length);
@@ -247,6 +258,7 @@ describe("AgentRunner - terminal flush on abnormal end", () => {
       query: () => crashingQuery(),
       output: new PassThrough(),
       batchSize: 3,
+      redactor: noop(),
     });
     runner.onBatch = async () => {
       throw new Error("flush failure");

--- a/libraries/libeval/test/agent-runner-skill-env.test.js
+++ b/libraries/libeval/test/agent-runner-skill-env.test.js
@@ -3,7 +3,10 @@ import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
 
 import { AgentRunner } from "@forwardimpact/libeval";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockAgentQuery as mockQuery } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 describe("AgentRunner LIBEVAL_SKILL env var", () => {
   let savedSkill;
@@ -41,6 +44,7 @@ describe("AgentRunner LIBEVAL_SKILL env var", () => {
       cwd: "/tmp",
       query: mockQuery(messages),
       output: new PassThrough(),
+      redactor: noop(),
     });
 
     await runner.run("test");
@@ -77,6 +81,7 @@ describe("AgentRunner LIBEVAL_SKILL env var", () => {
       cwd: "/tmp",
       query: mockQuery(messages),
       output: new PassThrough(),
+      redactor: noop(),
     });
 
     await runner.run("test");
@@ -113,6 +118,7 @@ describe("AgentRunner LIBEVAL_SKILL env var", () => {
       cwd: "/tmp",
       query: mockQuery(messages),
       output: new PassThrough(),
+      redactor: noop(),
     });
 
     await runner.run("test");

--- a/libraries/libeval/test/agent-runner.test.js
+++ b/libraries/libeval/test/agent-runner.test.js
@@ -3,7 +3,10 @@ import assert from "node:assert";
 import { PassThrough } from "node:stream";
 
 import { AgentRunner, createAgentRunner } from "@forwardimpact/libeval";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockAgentQuery as mockQuery } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 /**
  * Collect all NDJSON lines written to a PassThrough stream.
@@ -50,11 +53,24 @@ describe("AgentRunner", () => {
     );
   });
 
+  test("constructor throws on missing redactor", () => {
+    assert.throws(
+      () =>
+        new AgentRunner({
+          cwd: "/tmp",
+          query: async function* () {},
+          output: new PassThrough(),
+        }),
+      /redactor is required/,
+    );
+  });
+
   test("constructor uses defaults for optional params", () => {
     const runner = new AgentRunner({
       cwd: "/tmp",
       query: async function* () {},
       output: new PassThrough(),
+      redactor: noop(),
     });
     assert.strictEqual(runner.model, "claude-opus-4-7[1m]");
     assert.strictEqual(runner.maxTurns, 50);
@@ -82,6 +98,7 @@ describe("AgentRunner", () => {
       cwd: "/tmp",
       query: mockQuery(messages),
       output,
+      redactor: noop(),
     });
 
     const result = await runner.run("Test task");
@@ -107,6 +124,7 @@ describe("AgentRunner", () => {
       cwd: "/tmp",
       query: mockQuery(messages),
       output,
+      redactor: noop(),
     });
 
     await runner.run("Task");
@@ -131,6 +149,7 @@ describe("AgentRunner", () => {
       maxTurns: 10,
       allowedTools: ["Read", "Grep"],
       settingSources: ["project"],
+      redactor: noop(),
     });
 
     await runner.run("My task");
@@ -160,6 +179,7 @@ describe("AgentRunner", () => {
       query,
       output,
       maxTurns: 0,
+      redactor: noop(),
     });
 
     await runner.run("Task");
@@ -175,6 +195,7 @@ describe("AgentRunner", () => {
       cwd: "/tmp",
       query: mockQuery(messages),
       output,
+      redactor: noop(),
     });
 
     const result = await runner.run("Task");
@@ -202,7 +223,12 @@ describe("AgentRunner", () => {
     };
 
     const output = new PassThrough();
-    const runner = new AgentRunner({ cwd: "/tmp", query, output });
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query,
+      output,
+      redactor: noop(),
+    });
 
     await runner.run("Initial task");
     const result = await runner.resume("Follow up");
@@ -240,6 +266,7 @@ describe("AgentRunner", () => {
       query,
       output,
       mcpServers,
+      redactor: noop(),
     });
 
     await runner.run("Initial task");
@@ -263,6 +290,7 @@ describe("AgentRunner", () => {
       cwd: "/tmp",
       query: mockQuery(messages),
       output,
+      redactor: noop(),
     });
 
     await runner.run("Task");
@@ -289,6 +317,7 @@ describe("AgentRunner", () => {
       cwd: "/tmp",
       query: () => failingQuery(),
       output,
+      redactor: noop(),
     });
 
     const result = await runner.run("Task");
@@ -320,7 +349,12 @@ describe("AgentRunner", () => {
     };
 
     const output = new PassThrough();
-    const runner = new AgentRunner({ cwd: "/tmp", query, output });
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query,
+      output,
+      redactor: noop(),
+    });
 
     await runner.run("Task");
     const result = await runner.resume("Continue");
@@ -342,6 +376,7 @@ describe("AgentRunner", () => {
       cwd: "/tmp",
       query: () => creditExhaustedQuery(),
       output,
+      redactor: noop(),
     });
 
     const result = await runner.run("Task");
@@ -356,6 +391,7 @@ describe("AgentRunner", () => {
       cwd: "/tmp",
       query: async function* () {},
       output: new PassThrough(),
+      redactor: noop(),
     });
     assert.ok(runner instanceof AgentRunner);
   });

--- a/libraries/libeval/test/amend.test.js
+++ b/libraries/libeval/test/amend.test.js
@@ -14,8 +14,11 @@ import {
   createConcludeHandler,
 } from "../src/orchestration-toolkit.js";
 import { MessageBus } from "../src/message-bus.js";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 const concludeMsg = (summary, verdict = "success") =>
   createToolUseMsg("Conclude", { verdict, summary });
@@ -42,6 +45,7 @@ describe("systemPromptAmend delivery (SC 7 a)", () => {
       ],
       query: async function* () {},
       output: devNullStream(),
+      redactor: noop(),
     });
     const append = facilitator.agents[0].runner.systemPrompt.append;
     assert.ok(append.includes(FACILITATED_AGENT_SYSTEM_PROMPT));
@@ -58,6 +62,7 @@ describe("systemPromptAmend delivery (SC 7 a)", () => {
       agentConfigs: [{ name: "agent-1", role: "worker", cwd: "/tmp/agent" }],
       query: async function* () {},
       output: devNullStream(),
+      redactor: noop(),
     });
     assert.strictEqual(
       facilitator.agents[0].runner.systemPrompt.append,
@@ -77,6 +82,7 @@ describe("taskAmend delivery (SC 7 b)", () => {
       },
       output: devNullStream(),
       taskAmend: "<TEST_APPEND>",
+      redactor: noop(),
     });
     await runner.run("base task");
     assert.strictEqual(captured, "base task\n\n<TEST_APPEND>");
@@ -109,6 +115,7 @@ describe("taskAmend delivery (SC 7 b)", () => {
       maxTurns: 10,
       ctx,
       taskAmend: "<TEST_APPEND>",
+      redactor: noop(),
     });
     await facilitator.run("base task");
     assert.strictEqual(capturedTask, "base task\n\n<TEST_APPEND>");
@@ -143,6 +150,7 @@ describe("taskAmend delivery (SC 7 b)", () => {
       ctx,
       messageBus,
       taskAmend: "<TEST_APPEND>",
+      redactor: noop(),
     });
     await supervisor.run("base task");
     assert.strictEqual(capturedTask, "base task\n\n<TEST_APPEND>");

--- a/libraries/libeval/test/facilitator-redirect.test.js
+++ b/libraries/libeval/test/facilitator-redirect.test.js
@@ -10,8 +10,11 @@ import {
   createAnswerHandler,
 } from "../src/orchestration-toolkit.js";
 import { MessageBus } from "../src/message-bus.js";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 const concludeMsg = (summary, verdict = "success") =>
   createToolUseMsg("Conclude", { verdict, summary });
@@ -72,6 +75,7 @@ describe("Facilitator - re-Ask recovery", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     const result = await facilitator.run("Test re-Ask recovery");

--- a/libraries/libeval/test/facilitator.test.js
+++ b/libraries/libeval/test/facilitator.test.js
@@ -2,7 +2,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert";
 import { PassThrough } from "node:stream";
 
-import { Facilitator } from "@forwardimpact/libeval";
+import { Facilitator, createFacilitator } from "@forwardimpact/libeval";
 import {
   createOrchestrationContext,
   createConcludeHandler,
@@ -411,5 +411,22 @@ describe("Facilitator - messaging", () => {
     assert.strictEqual(parsed.length, 2);
     assert.strictEqual(parsed[0].name, "facilitator");
     assert.strictEqual(parsed[1].name, "agent-1");
+  });
+});
+
+describe("Facilitator - factory required deps", () => {
+  test("createFacilitator throws on missing redactor", () => {
+    assert.throws(
+      () =>
+        createFacilitator({
+          facilitatorCwd: "/tmp/fac",
+          agentConfigs: [
+            { name: "agent-1", role: "worker", cwd: "/tmp/agent" },
+          ],
+          query: async function* () {},
+          output: new PassThrough(),
+        }),
+      /redactor is required/,
+    );
   });
 });

--- a/libraries/libeval/test/facilitator.test.js
+++ b/libraries/libeval/test/facilitator.test.js
@@ -12,8 +12,11 @@ import {
   createAnnounceHandler,
 } from "../src/orchestration-toolkit.js";
 import { MessageBus } from "../src/message-bus.js";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 const concludeMsg = (summary, verdict = "success") =>
   createToolUseMsg("Conclude", { verdict, summary });
@@ -63,6 +66,7 @@ describe("Facilitator - core orchestration", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     const result = await facilitator.run("Quick task");
@@ -130,6 +134,7 @@ describe("Facilitator - core orchestration", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     const result = await facilitator.run("Test task");
@@ -185,6 +190,7 @@ describe("Facilitator - core orchestration", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
     facilitatorRunner.onLine = (line) =>
       facilitator.emitLine("facilitator", line);
@@ -254,6 +260,7 @@ describe("Facilitator - core orchestration", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     await assert.rejects(() => facilitator.run("Test fail-fast"), {
@@ -321,6 +328,7 @@ describe("Facilitator - messaging", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     await facilitator.run("Coordinate");
@@ -375,6 +383,7 @@ describe("Facilitator - messaging", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     await facilitator.run("Broadcast test");

--- a/libraries/libeval/test/mock-runner.js
+++ b/libraries/libeval/test/mock-runner.js
@@ -16,6 +16,7 @@
 import { PassThrough } from "node:stream";
 import { AgentRunner } from "@forwardimpact/libeval";
 import { hasTextBlock } from "../src/agent-runner.js";
+import { createNoopRedactor } from "../src/redaction.js";
 
 async function dispatchTools(toolDispatcher, message) {
   if (!toolDispatcher || message.type !== "assistant") return;
@@ -45,6 +46,7 @@ export function createMockRunner(responses, messages, { toolDispatcher } = {}) {
     cwd: "/tmp",
     query: async function* () {},
     output,
+    redactor: createNoopRedactor(),
   });
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: decomposing this closure breaks abort-callback semantics that pending-ask tests depend on

--- a/libraries/libeval/test/pending-ask.test.js
+++ b/libraries/libeval/test/pending-ask.test.js
@@ -12,8 +12,11 @@ import {
 } from "../src/orchestration-toolkit.js";
 import { isSuppressedOrchestratorEvent } from "../src/render/orchestrator-filter.js";
 import { MessageBus } from "../src/message-bus.js";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 const askMsg = (to, question) =>
   createToolUseMsg("Ask", { to, question }, { id: `ask-${to}` });
@@ -107,6 +110,7 @@ describe("Pending-ask enforcement — facilitated mode (SC 3)", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     const result = await facilitator.run("Start");
@@ -157,6 +161,7 @@ describe("Pending-ask enforcement — facilitated mode (SC 3)", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     const result = await facilitator.run("Start");
@@ -203,6 +208,7 @@ describe("Pending-ask enforcement — facilitated mode (SC 3)", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     const result = await facilitator.run("Start");
@@ -260,6 +266,7 @@ describe("Pending-ask enforcement — supervised mode (SC 3)", () => {
       maxTurns: 5,
       ctx,
       messageBus,
+      redactor: noop(),
     });
 
     const result = await supervisor.run("Task");
@@ -323,6 +330,7 @@ describe("Pending-ask enforcement — broadcast Ask (SC 3)", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     const result = await facilitator.run("Start");

--- a/libraries/libeval/test/redaction-pipeline.test.js
+++ b/libraries/libeval/test/redaction-pipeline.test.js
@@ -1,0 +1,494 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { PassThrough, Writable } from "node:stream";
+
+import { AgentRunner, Supervisor, Facilitator } from "@forwardimpact/libeval";
+import { createRedactor } from "../src/redaction.js";
+import {
+  createOrchestrationContext,
+  createConcludeHandler,
+} from "../src/orchestration-toolkit.js";
+import { MessageBus } from "../src/message-bus.js";
+import { TraceCollector } from "../src/trace-collector.js";
+import { createTeeWriter } from "../src/tee-writer.js";
+import { createMockRunner } from "./mock-runner.js";
+import { createToolUseMsg } from "@forwardimpact/libharness";
+
+/**
+ * JSON-stable guard: sentinels are printable ASCII without `"`, `\`, or
+ * control chars so a substring scan over JSON-encoded bytes gives a sound
+ * check (design § Test surfaces).
+ */
+function assertJsonStableSentinel(s) {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: validating absence of control chars in test sentinels
+  if (/[\x00-\x1f\x7f"\\]/.test(s)) {
+    throw new Error(`sentinel is not JSON-stable: ${JSON.stringify(s)}`);
+  }
+}
+
+/** Capture bytes written to a Writable into an array of strings. */
+function captureSink() {
+  const chunks = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  return {
+    stream,
+    get text() {
+      return chunks.join("");
+    },
+  };
+}
+
+const ANTH_SENT = "ANTHROPIC_PIPELINE_SENTINEL";
+const GH_SENT = "GH_TOKEN_PIPELINE_SENTINEL";
+const GITHUB_SENT = "GITHUB_TOKEN_PIPELINE_SENTINEL";
+
+for (const s of [ANTH_SENT, GH_SENT, GITHUB_SENT]) {
+  assertJsonStableSentinel(s);
+}
+
+describe("Producer pipeline — sentinel sweep (criterion 1)", () => {
+  test("sentinels in every carrier shape are redacted before reaching fileStream", async () => {
+    const SESSION_PAYLOAD = `boot ${GITHUB_SENT}`;
+    const sink = captureSink();
+
+    const redactor = createRedactor({
+      env: {
+        ANTHROPIC_API_KEY: ANTH_SENT,
+        GH_TOKEN: GH_SENT,
+        GITHUB_TOKEN: GITHUB_SENT,
+      },
+    });
+
+    // Real AgentRunner driven by a scripted async-generator query that
+    // yields messages with the sentinels embedded in each carrier shape.
+    const scripted = [
+      {
+        type: "system",
+        subtype: "init",
+        session_id: "sess-1",
+        boot_payload: SESSION_PAYLOAD,
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "tu_1",
+              name: "Bash",
+              input: { command: `echo ${ANTH_SENT}`, description: "leak" },
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tu_1",
+              content: `stdout: ${GH_SENT}\nstderr:`,
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tu_2",
+              content: JSON.stringify({ stdout: `embed ${ANTH_SENT}` }),
+            },
+          ],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: `assistant leaked ${GH_SENT}` }],
+        },
+      },
+      { type: "result", subtype: "success", result: `final ${GITHUB_SENT}` },
+    ];
+
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: async function* () {
+        for (const m of scripted) yield m;
+      },
+      output: sink.stream,
+      redactor,
+    });
+
+    await runner.run("Task");
+
+    const out = sink.text;
+    assert.ok(!out.includes(ANTH_SENT), "ANTH sentinel leaked to fileStream");
+    assert.ok(!out.includes(GH_SENT), "GH sentinel leaked to fileStream");
+    assert.ok(
+      !out.includes(GITHUB_SENT),
+      "GITHUB sentinel leaked to fileStream",
+    );
+    assert.ok(out.includes("[REDACTED:env:ANTHROPIC_API_KEY]"));
+    assert.ok(out.includes("[REDACTED:env:GH_TOKEN]"));
+    assert.ok(out.includes("[REDACTED:env:GITHUB_TOKEN]"));
+  });
+});
+
+describe("Producer pipeline — patterns (criterion 2)", () => {
+  test("pattern hits redact when no env vars are configured", async () => {
+    const sink = captureSink();
+    const redactor = createRedactor({ env: {} });
+
+    const anth = "sk-ant-" + "a".repeat(95);
+    const ghp = "ghp_" + "A".repeat(36);
+    const ghs = "ghs_" + "B".repeat(36);
+    const gho = "gho_" + "C".repeat(36);
+    const ghfg = "github_pat_" + "x".repeat(82);
+
+    const scripted = [
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: `anth=${anth}` },
+            { type: "text", text: `ghp=${ghp}` },
+            { type: "text", text: `ghs=${ghs}` },
+            { type: "text", text: `gho=${gho}` },
+            { type: "text", text: `ghfg=${ghfg}` },
+          ],
+        },
+      },
+      { type: "result", subtype: "success", result: "ok" },
+    ];
+
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: async function* () {
+        for (const m of scripted) yield m;
+      },
+      output: sink.stream,
+      redactor,
+    });
+    await runner.run("task");
+
+    const out = sink.text;
+    for (const secret of [anth, ghp, ghs, gho, ghfg]) {
+      assert.ok(
+        !out.includes(secret),
+        `pattern secret leaked: ${secret.slice(0, 12)}…`,
+      );
+    }
+    assert.ok(out.includes("[REDACTED:pattern:anthropic]"));
+    assert.ok(out.includes("[REDACTED:pattern:gh-pat]"));
+    assert.ok(out.includes("[REDACTED:pattern:gh-installation]"));
+    assert.ok(out.includes("[REDACTED:pattern:gh-oauth]"));
+    assert.ok(out.includes("[REDACTED:pattern:gh-fine-grained]"));
+  });
+});
+
+describe("Producer pipeline — opt-out warning (criterion 4)", () => {
+  test("LIBEVAL_REDACTION_DISABLED=1 emits stderr warning; sentinels reach fileStream unredacted", async () => {
+    const sink = captureSink();
+
+    // Construct the redactor under test. Capture stderr from this site
+    // only — avoid mutating process.env (other tests run in parallel).
+    let redactor;
+    let stderrCaptured;
+    stderrCaptured = "";
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => {
+      stderrCaptured += String(chunk);
+      return true;
+    };
+    try {
+      redactor = createRedactor({
+        env: {
+          LIBEVAL_REDACTION_DISABLED: "1",
+          ANTHROPIC_API_KEY: ANTH_SENT,
+        },
+      });
+    } finally {
+      process.stderr.write = orig;
+    }
+
+    assert.match(stderrCaptured, /libeval: trace redaction DISABLED/);
+    assert.strictEqual(
+      (stderrCaptured.match(/redaction DISABLED/g) ?? []).length,
+      1,
+      "warning must fire exactly once per construction",
+    );
+
+    const scripted = [
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: `leak ${ANTH_SENT}` }],
+        },
+      },
+      { type: "result", subtype: "success", result: "ok" },
+    ];
+
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: async function* () {
+        for (const m of scripted) yield m;
+      },
+      output: sink.stream,
+      redactor,
+    });
+    await runner.run("task");
+
+    // Opt-out: sentinel reaches fileStream unredacted.
+    assert.ok(sink.text.includes(ANTH_SENT));
+    assert.ok(!sink.text.includes("[REDACTED:env:ANTHROPIC_API_KEY]"));
+  });
+});
+
+describe("Producer pipeline — toText() byte-for-byte placeholder fidelity (criterion 5)", () => {
+  test("captured NDJSON replays placeholders identically through TraceCollector.toText()", async () => {
+    const sink = captureSink();
+    const redactor = createRedactor({
+      env: { ANTHROPIC_API_KEY: ANTH_SENT, GH_TOKEN: GH_SENT },
+    });
+
+    const anth = "sk-ant-" + "a".repeat(85);
+
+    const scripted = [
+      { type: "system", subtype: "init", session_id: "sess-fid" },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: `the env value is ${ANTH_SENT}` },
+            { type: "text", text: `pattern hit ${anth}` },
+            { type: "text", text: `gh ${GH_SENT}` },
+          ],
+        },
+      },
+      { type: "result", subtype: "success", result: "done" },
+    ];
+
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: async function* () {
+        for (const m of scripted) yield m;
+      },
+      output: sink.stream,
+      redactor,
+    });
+    await runner.run("task");
+
+    const ndjsonText = sink.text;
+    const collector = new TraceCollector();
+    for (const line of ndjsonText.split("\n")) {
+      if (line.trim()) collector.addLine(line);
+    }
+    const replayed = collector.toText();
+
+    // Both placeholder forms must appear in the rendered output identically.
+    assert.ok(
+      replayed.includes("[REDACTED:env:ANTHROPIC_API_KEY]"),
+      "env placeholder missing from replay",
+    );
+    assert.ok(
+      replayed.includes("[REDACTED:env:GH_TOKEN]"),
+      "env placeholder missing from replay",
+    );
+    assert.ok(
+      replayed.includes("[REDACTED:pattern:anthropic]"),
+      "pattern placeholder missing from replay",
+    );
+    // And no sentinel survives the replay.
+    assert.ok(!replayed.includes(ANTH_SENT));
+    assert.ok(!replayed.includes(GH_SENT));
+    assert.ok(!replayed.includes(anth));
+  });
+
+  test("TeeWriter file path delivers redacted bytes to fileStream", async () => {
+    const fileSink = captureSink();
+    const textSink = captureSink();
+    const tee = createTeeWriter({
+      fileStream: fileSink.stream,
+      textStream: textSink.stream,
+      mode: "raw",
+    });
+
+    const redactor = createRedactor({
+      env: { GH_TOKEN: GH_SENT },
+    });
+
+    const scripted = [
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: `gh ${GH_SENT}` }],
+        },
+      },
+      { type: "result", subtype: "success", result: "ok" },
+    ];
+
+    // Drive a small command-style pipeline: a real runner emits to devNull,
+    // and an envelope-redacting onLine writes the tagged event to the tee.
+    const devNull = new Writable({
+      write(_c, _e, cb) {
+        cb();
+      },
+    });
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: async function* () {
+        for (const m of scripted) yield m;
+      },
+      output: devNull,
+      redactor,
+      onLine: (line) => {
+        const event = JSON.parse(line);
+        const tagged = { source: "agent", seq: 0, event };
+        tee.write(JSON.stringify(redactor.redactValue(tagged)) + "\n");
+      },
+    });
+    await runner.run("task");
+    await new Promise((r) => tee.end(r));
+
+    assert.ok(!fileSink.text.includes(GH_SENT));
+    assert.ok(fileSink.text.includes("[REDACTED:env:GH_TOKEN]"));
+  });
+});
+
+describe("Producer pipeline — Supervisor.emitSummary covers Conclude-handler text", () => {
+  test("sentinel-bearing Conclude summary is redacted in the orchestrator summary line", async () => {
+    const ctx = createOrchestrationContext();
+    const messageBus = new MessageBus({
+      participants: ["supervisor", "agent"],
+    });
+    ctx.messageBus = messageBus;
+    ctx.participants = [
+      { name: "supervisor", role: "supervisor" },
+      { name: "agent", role: "agent" },
+    ];
+    const concludeHandler = createConcludeHandler(ctx);
+
+    const SECRET_SUMMARY = `wrap-up with secret ${GH_SENT}`;
+    const supervisorRunner = createMockRunner(
+      [{ text: "Done" }],
+      [
+        [
+          createToolUseMsg("Conclude", {
+            verdict: "success",
+            summary: SECRET_SUMMARY,
+          }),
+        ],
+      ],
+      {
+        toolDispatcher: {
+          Conclude: (input) => concludeHandler(input),
+        },
+      },
+    );
+    const agentRunner = createMockRunner([]);
+
+    const sink = captureSink();
+    const redactor = createRedactor({ env: { GH_TOKEN: GH_SENT } });
+
+    const supervisor = new Supervisor({
+      agentRunner,
+      supervisorRunner,
+      output: sink.stream,
+      maxTurns: 5,
+      ctx,
+      messageBus,
+      redactor,
+    });
+
+    const result = await supervisor.run("Do the thing");
+    assert.strictEqual(result.success, true);
+
+    // The summary line is the orchestrator-source event.
+    const summaryLines = sink.text
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l))
+      .filter(
+        (e) => e.source === "orchestrator" && e.event?.type === "summary",
+      );
+
+    assert.strictEqual(summaryLines.length, 1);
+    const evt = summaryLines[0].event;
+    assert.ok(
+      !evt.summary.includes(GH_SENT),
+      "GH_TOKEN sentinel leaked into supervisor summary",
+    );
+    assert.ok(evt.summary.includes("[REDACTED:env:GH_TOKEN]"));
+  });
+});
+
+describe("Producer pipeline — Facilitator.emitSummary covers Conclude-handler text", () => {
+  test("sentinel-bearing Conclude summary is redacted in the facilitator summary line", async () => {
+    const ctx = createOrchestrationContext();
+    const messageBus = new MessageBus({
+      participants: ["facilitator", "agent-1"],
+    });
+    ctx.messageBus = messageBus;
+    ctx.participants = [
+      { name: "facilitator", role: "facilitator" },
+      { name: "agent-1", role: "agent" },
+    ];
+    const concludeHandler = createConcludeHandler(ctx);
+
+    const SECRET_SUMMARY = `facilitator wrap ${GH_SENT}`;
+    const facilitatorRunner = createMockRunner(
+      [{ text: "Wrap" }],
+      [
+        [
+          createToolUseMsg("Conclude", {
+            verdict: "success",
+            summary: SECRET_SUMMARY,
+          }),
+        ],
+      ],
+      { toolDispatcher: { Conclude: (input) => concludeHandler(input) } },
+    );
+    const agentRunner = createMockRunner([]);
+
+    const sink = captureSink();
+    const redactor = createRedactor({ env: { GH_TOKEN: GH_SENT } });
+
+    const facilitator = new Facilitator({
+      facilitatorRunner,
+      agents: [{ name: "agent-1", role: "worker", runner: agentRunner }],
+      messageBus,
+      output: sink.stream,
+      maxTurns: 5,
+      ctx,
+      redactor,
+    });
+
+    const result = await facilitator.run("Coordinate");
+    assert.strictEqual(result.success, true);
+
+    const summaryLines = sink.text
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l))
+      .filter(
+        (e) => e.source === "orchestrator" && e.event?.type === "summary",
+      );
+
+    assert.strictEqual(summaryLines.length, 1);
+    const evt = summaryLines[0].event;
+    assert.ok(
+      !evt.summary.includes(GH_SENT),
+      "GH_TOKEN sentinel leaked into facilitator summary",
+    );
+    assert.ok(evt.summary.includes("[REDACTED:env:GH_TOKEN]"));
+  });
+});

--- a/libraries/libeval/test/redaction.test.js
+++ b/libraries/libeval/test/redaction.test.js
@@ -1,0 +1,381 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+
+import {
+  Redactor,
+  createRedactor,
+  createNoopRedactor,
+  DEFAULT_ENV_ALLOWLIST,
+  DEFAULT_PATTERNS,
+} from "../src/redaction.js";
+
+/**
+ * Guard helper: sentinels must be JSON-stable (printable ASCII without `"`,
+ * `\`, or control characters) so a substring scan over JSON-encoded bytes
+ * gives a sound check. A non-stable sentinel would JSON-escape and pass
+ * the substring check even when redaction missed.
+ */
+function assertJsonStableSentinel(s) {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: validating absence of control chars in test sentinels
+  if (/[\x00-\x1f\x7f"\\]/.test(s)) {
+    throw new Error(`sentinel is not JSON-stable: ${JSON.stringify(s)}`);
+  }
+}
+
+/**
+ * Capture stderr writes from a callback. Restores the original write
+ * regardless of throw outcome.
+ */
+function captureStderr(fn) {
+  const captured = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => {
+    captured.push(String(chunk));
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stderr.write = orig;
+  }
+  return captured.join("");
+}
+
+describe("Redactor — env-var allowlist (criterion 1)", () => {
+  test("replaces sentinels with [REDACTED:env:NAME] across deep-walked carrier shapes", () => {
+    const ANTHROPIC = "ANTHROPIC_SENTINEL_VALUE";
+    const GH = "GH_TOKEN_SENTINEL_VALUE";
+    const GITHUB = "GITHUB_TOKEN_SENTINEL_VALUE";
+    assertJsonStableSentinel(ANTHROPIC);
+    assertJsonStableSentinel(GH);
+    assertJsonStableSentinel(GITHUB);
+
+    const r = createRedactor({
+      env: {
+        ANTHROPIC_API_KEY: ANTHROPIC,
+        GH_TOKEN: GH,
+        GITHUB_TOKEN: GITHUB,
+      },
+    });
+
+    const fixture = {
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            name: "Bash",
+            input: {
+              command: `echo ${ANTHROPIC}`,
+              description: "leak attempt",
+            },
+          },
+          {
+            type: "tool_result",
+            content: `stdout: token=${GH}`,
+          },
+          { type: "text", text: `Leaked GITHUB=${GITHUB}` },
+        ],
+      },
+      session: {
+        nested: [
+          { payload: `combo ${ANTHROPIC} and ${GH}` },
+          [`array slot ${GITHUB}`],
+        ],
+      },
+      summary: `wrap-up ${ANTHROPIC}`,
+    };
+
+    const out = JSON.stringify(r.redactValue(fixture));
+    assert.ok(!out.includes(ANTHROPIC), "ANTHROPIC sentinel leaked");
+    assert.ok(!out.includes(GH), "GH sentinel leaked");
+    assert.ok(!out.includes(GITHUB), "GITHUB sentinel leaked");
+    assert.ok(out.includes("[REDACTED:env:ANTHROPIC_API_KEY]"));
+    assert.ok(out.includes("[REDACTED:env:GH_TOKEN]"));
+    assert.ok(out.includes("[REDACTED:env:GITHUB_TOKEN]"));
+  });
+
+  test("multiple occurrences of the same sentinel in a single string all redacted", () => {
+    const SENT = "MULTI_HIT_SENTINEL";
+    const r = createRedactor({ env: { GH_TOKEN: SENT } });
+    const out = r.redactValue(`${SENT} and ${SENT} again ${SENT}`);
+    assert.strictEqual(
+      out,
+      "[REDACTED:env:GH_TOKEN] and [REDACTED:env:GH_TOKEN] again [REDACTED:env:GH_TOKEN]",
+    );
+  });
+
+  test("empty-string env values do not poison redaction", () => {
+    const r = createRedactor({
+      env: { GH_TOKEN: "", GITHUB_TOKEN: "", ANTHROPIC_API_KEY: "" },
+    });
+    // Empty string input must come through identically; redactor must
+    // not turn every empty string into a placeholder.
+    assert.strictEqual(r.redactValue(""), "");
+    assert.strictEqual(r.redactValue("hello"), "hello");
+    const obj = { a: "", b: "x" };
+    const out = r.redactValue(obj);
+    assert.deepStrictEqual(out, { a: "", b: "x" });
+  });
+
+  test("LIBEVAL_REDACTION_ENV_VARS replaces (not extends) the default allowlist", () => {
+    const r = createRedactor({
+      env: {
+        LIBEVAL_REDACTION_ENV_VARS: "FOO,BAR",
+        FOO: "foo-secret",
+        BAR: "bar-secret",
+        ANTHROPIC_API_KEY: "anth-secret",
+      },
+    });
+    assert.strictEqual(r.redactValue("foo-secret"), "[REDACTED:env:FOO]");
+    assert.strictEqual(r.redactValue("bar-secret"), "[REDACTED:env:BAR]");
+    // Default name not in override is NOT redacted via env layer.
+    assert.strictEqual(r.redactValue("anth-secret"), "anth-secret");
+  });
+
+  test("LIBEVAL_REDACTION_ENV_VARS trims whitespace and ignores empty entries", () => {
+    const r = createRedactor({
+      env: {
+        LIBEVAL_REDACTION_ENV_VARS: "  FOO , , BAR  ",
+        FOO: "foo-secret",
+        BAR: "bar-secret",
+      },
+    });
+    assert.strictEqual(r.redactValue("foo-secret"), "[REDACTED:env:FOO]");
+    assert.strictEqual(r.redactValue("bar-secret"), "[REDACTED:env:BAR]");
+  });
+});
+
+describe("Redactor — credential patterns (criterion 2)", () => {
+  test("each default pattern at canonical length yields [REDACTED:pattern:KIND]", () => {
+    const r = createRedactor({ env: {} });
+
+    // Anthropic prefix + 80 url-safe chars.
+    const anth = "sk-ant-" + "a".repeat(80);
+    assert.strictEqual(r.redactValue(anth), "[REDACTED:pattern:anthropic]");
+
+    // gh-pat: ghp_ + exactly 36 word chars.
+    const ghp = "ghp_" + "A".repeat(36);
+    assert.strictEqual(r.redactValue(ghp), "[REDACTED:pattern:gh-pat]");
+
+    // gh-installation: ghs_ + 36.
+    const ghs = "ghs_" + "B".repeat(36);
+    assert.strictEqual(
+      r.redactValue(ghs),
+      "[REDACTED:pattern:gh-installation]",
+    );
+
+    // gh-oauth: gho_ + 36.
+    const gho = "gho_" + "C".repeat(36);
+    assert.strictEqual(r.redactValue(gho), "[REDACTED:pattern:gh-oauth]");
+
+    // gh-fine-grained: github_pat_ + 82 [A-Za-z0-9_].
+    const ghfg = "github_pat_" + "x".repeat(82);
+    assert.strictEqual(
+      r.redactValue(ghfg),
+      "[REDACTED:pattern:gh-fine-grained]",
+    );
+  });
+
+  test("anthropic pattern hit inside tool_result.content JSON-string", () => {
+    const r = createRedactor({ env: {} });
+    const anth = "sk-ant-" + "z".repeat(95);
+    const message = {
+      type: "user",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            content: JSON.stringify({ stdout: `KEY=${anth}\n` }),
+          },
+        ],
+      },
+    };
+    const out = JSON.stringify(r.redactValue(message));
+    assert.ok(!out.includes(anth));
+    assert.ok(out.includes("[REDACTED:pattern:anthropic]"));
+  });
+});
+
+describe("Redactor — benign content unchanged (criterion 3)", () => {
+  const r = createRedactor({ env: {} });
+  const benign = [
+    "Hello world — this is plain prose.",
+    "# Markdown header\n\n- item 1\n- item 2",
+    "https://www.forwardimpact.team/docs/products/index.md",
+    "Visit https://github.com/forwardimpact/monorepo/pull/123.",
+    // git SHA (40 hex)
+    "7dd76efba1234567890abcdef0123456789abcde",
+    // UUID
+    "550e8400-e29b-41d4-a716-446655440000",
+    // ghp_ prefix at less than 36 chars — should NOT match
+    "ghp_short",
+    "ghp_" + "A".repeat(35),
+    // quoted shell commands
+    "echo 'hello world' | grep -v foo",
+    'curl -X POST -d "{\\"foo\\":1}" http://example.com',
+  ];
+  for (const text of benign) {
+    test(`round-trips identically: ${JSON.stringify(text).slice(0, 60)}`, () => {
+      assert.strictEqual(r.redactValue(text), text);
+    });
+  }
+});
+
+describe("Redactor — opt-out (criterion 4, design § Opt-out surface)", () => {
+  test("LIBEVAL_REDACTION_DISABLED=1 disables and emits stderr warning exactly once", () => {
+    let r;
+    const stderr = captureStderr(() => {
+      r = createRedactor({
+        env: {
+          LIBEVAL_REDACTION_DISABLED: "1",
+          GH_TOKEN: "would-have-redacted",
+        },
+      });
+    });
+    assert.strictEqual(r.enabled, false);
+    assert.strictEqual(
+      r.redactValue("would-have-redacted"),
+      "would-have-redacted",
+    );
+    assert.match(stderr, /libeval: trace redaction DISABLED/);
+    // Single warning per construction.
+    const matches = stderr.match(/redaction DISABLED/g) ?? [];
+    assert.strictEqual(matches.length, 1);
+  });
+
+  test('LIBEVAL_REDACTION_DISABLED="true" does NOT disable (literal "1" is the contract)', () => {
+    let r;
+    const stderr = captureStderr(() => {
+      r = createRedactor({
+        env: { LIBEVAL_REDACTION_DISABLED: "true", GH_TOKEN: "secret-value" },
+      });
+    });
+    assert.strictEqual(r.enabled, true);
+    assert.strictEqual(
+      r.redactValue("secret-value"),
+      "[REDACTED:env:GH_TOKEN]",
+    );
+    assert.strictEqual(stderr, "");
+  });
+
+  test('LIBEVAL_REDACTION_DISABLED="yes" does NOT disable (literal "1" is the contract)', () => {
+    let r;
+    const stderr = captureStderr(() => {
+      r = createRedactor({
+        env: { LIBEVAL_REDACTION_DISABLED: "yes", GH_TOKEN: "secret-value" },
+      });
+    });
+    assert.strictEqual(r.enabled, true);
+    assert.strictEqual(
+      r.redactValue("secret-value"),
+      "[REDACTED:env:GH_TOKEN]",
+    );
+    assert.strictEqual(stderr, "");
+  });
+
+  test("createRedactor({ enabled: false }) fires the stderr warning regardless of env state", () => {
+    let r;
+    const stderr = captureStderr(() => {
+      r = createRedactor({ env: {}, enabled: false });
+    });
+    assert.strictEqual(r.enabled, false);
+    assert.match(stderr, /libeval: trace redaction DISABLED/);
+  });
+
+  test("disabled redactor returns top-level input by reference (identity contract)", () => {
+    const r = createNoopRedactor();
+    const obj = { type: "assistant", message: { content: [{ text: "hi" }] } };
+    assert.strictEqual(r.redactValue(obj), obj);
+    const arr = [1, "two", { three: 3 }];
+    assert.strictEqual(r.redactValue(arr), arr);
+    assert.strictEqual(r.redactValue("plain"), "plain");
+  });
+});
+
+describe("createNoopRedactor", () => {
+  test("returns a Redactor whose redactValue is identity", () => {
+    const r = createNoopRedactor();
+    assert.ok(r instanceof Redactor);
+    assert.strictEqual(r.enabled, false);
+    const v = { a: "x" };
+    assert.strictEqual(r.redactValue(v), v);
+  });
+
+  test("never fires the stderr warning regardless of env state", () => {
+    // Even though disabled, the noop helper must NOT write to stderr —
+    // it is intended for test fixtures that need a silent disabled
+    // redactor.
+    const stderr = captureStderr(() => {
+      createNoopRedactor();
+    });
+    assert.strictEqual(stderr, "");
+  });
+});
+
+describe("Redactor — word boundary adversarial cases (Risks table)", () => {
+  const r = createRedactor({ env: {} });
+  const body = "A".repeat(36);
+  const token = `ghp_${body}`;
+
+  test("'-ghp_<36>' matches (\\b between '-' and 'g')", () => {
+    const out = r.redactValue(`prefix-${token} trailing`);
+    assert.ok(out.includes("[REDACTED:pattern:gh-pat]"));
+    assert.ok(!out.includes(token));
+  });
+
+  test("'_ghp_<36>' does NOT match (no \\b between '_' and 'g')", () => {
+    const out = r.redactValue(`under_${token} trailing`);
+    assert.strictEqual(out, `under_${token} trailing`);
+  });
+
+  test("'.ghp_<36>' matches", () => {
+    const out = r.redactValue(`x.${token}`);
+    assert.ok(out.includes("[REDACTED:pattern:gh-pat]"));
+  });
+
+  test("ghp_<36> followed by ',' / ';' / '\\n' matches", () => {
+    for (const sep of [",", ";", "\n"]) {
+      const out = r.redactValue(`pre ${token}${sep}post`);
+      assert.ok(
+        out.includes("[REDACTED:pattern:gh-pat]"),
+        `failed for separator ${JSON.stringify(sep)}`,
+      );
+      assert.ok(
+        !out.includes(token),
+        `token leaked for ${JSON.stringify(sep)}`,
+      );
+    }
+  });
+
+  test("ghp_<37> (one extra word char) does NOT match (anchored to 36)", () => {
+    const longer = `ghp_${"A".repeat(37)}`;
+    assert.strictEqual(r.redactValue(longer), longer);
+  });
+});
+
+describe("Redactor — exports and defaults", () => {
+  test("DEFAULT_ENV_ALLOWLIST is the documented contract", () => {
+    assert.deepStrictEqual(
+      [...DEFAULT_ENV_ALLOWLIST],
+      ["ANTHROPIC_API_KEY", "GH_TOKEN", "GITHUB_TOKEN"],
+    );
+  });
+
+  test("DEFAULT_PATTERNS covers the five documented kinds", () => {
+    const kinds = DEFAULT_PATTERNS.map((p) => p.kind);
+    assert.deepStrictEqual(kinds, [
+      "anthropic",
+      "gh-pat",
+      "gh-installation",
+      "gh-oauth",
+      "gh-fine-grained",
+    ]);
+  });
+
+  test("createRedactor() with no options falls back to process.env", () => {
+    // Smoke check — must not throw, and must produce a Redactor.
+    const r = createRedactor();
+    assert.ok(r instanceof Redactor);
+  });
+});

--- a/libraries/libeval/test/supervisor-batching.test.js
+++ b/libraries/libeval/test/supervisor-batching.test.js
@@ -8,11 +8,14 @@ import {
   createConcludeHandler,
   createRedirectHandler,
 } from "../src/orchestration-toolkit.js";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockRunner } from "./mock-runner.js";
 import {
   createToolUseMsg,
   createTextBlockMsg as textBlock,
 } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 const concludeMsg = (summary, verdict = "success") =>
   createToolUseMsg("Conclude", { verdict, summary });
@@ -65,6 +68,7 @@ describe("Supervisor - batching at the default batchSize", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
     agentRunner.onLine = (line) => supervisor.emitLine(line);
     supervisorRunner.onLine = (line) => supervisor.emitLine(line);
@@ -135,6 +139,7 @@ describe("Supervisor - batching at the default batchSize", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
     agentRunner.onLine = (line) => supervisor.emitLine(line);
     supervisorRunner.onLine = (line) => supervisor.emitLine(line);

--- a/libraries/libeval/test/supervisor-factory.test.js
+++ b/libraries/libeval/test/supervisor-factory.test.js
@@ -8,17 +8,27 @@ import {
   SUPERVISOR_SYSTEM_PROMPT,
   AGENT_SYSTEM_PROMPT,
 } from "@forwardimpact/libeval";
+import { createNoopRedactor } from "../src/redaction.js";
 
 const baseOpts = () => ({
   supervisorCwd: "/tmp/sup",
   agentCwd: "/tmp/agent",
   query: async function* () {},
   output: new PassThrough(),
+  redactor: createNoopRedactor(),
 });
 
 describe("Supervisor - createSupervisor factory", () => {
   test("returns a Supervisor instance", () => {
     assert.ok(createSupervisor(baseOpts()) instanceof Supervisor);
+  });
+
+  test("createSupervisor throws on missing redactor", () => {
+    const { redactor: _omitted, ...withoutRedactor } = baseOpts();
+    assert.throws(
+      () => createSupervisor(withoutRedactor),
+      /redactor is required/,
+    );
   });
 
   test("uses default supervisor tools when none specified", () => {

--- a/libraries/libeval/test/supervisor-intervention.test.js
+++ b/libraries/libeval/test/supervisor-intervention.test.js
@@ -8,8 +8,11 @@ import {
   createConcludeHandler,
   createRedirectHandler,
 } from "../src/orchestration-toolkit.js";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 const concludeMsg = (summary, verdict = "success") =>
   createToolUseMsg("Conclude", { verdict, summary });
@@ -58,6 +61,7 @@ describe("Supervisor - mid-turn intervention", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
     agentRunner.onLine = (line) => supervisor.emitLine(line);
     supervisorRunner.onLine = (line) => supervisor.emitLine(line);
@@ -161,6 +165,7 @@ describe("Supervisor - mid-turn intervention", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
     agentRunner.onLine = (line) => supervisor.emitLine(line);
     supervisorRunner.onLine = (line) => supervisor.emitLine(line);
@@ -254,6 +259,7 @@ describe("Supervisor - mid-turn intervention", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
     agentRunner.onLine = (line) => supervisor.emitLine(line);
     supervisorRunner.onLine = (line) => supervisor.emitLine(line);

--- a/libraries/libeval/test/supervisor-output.test.js
+++ b/libraries/libeval/test/supervisor-output.test.js
@@ -8,8 +8,11 @@ import {
   createConcludeHandler,
   createRedirectHandler,
 } from "../src/orchestration-toolkit.js";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 const concludeMsg = (summary, verdict = "success") =>
   createToolUseMsg("Conclude", { verdict, summary });
@@ -40,6 +43,7 @@ describe("Supervisor - output and events", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
     agentRunner.onLine = (line) => supervisor.emitLine(line);
     supervisorRunner.onLine = (line) => supervisor.emitLine(line);
@@ -105,6 +109,7 @@ describe("Supervisor - output and events", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
     agentRunner.onLine = (line) => supervisor.emitLine(line);
     supervisorRunner.onLine = (line) => supervisor.emitLine(line);
@@ -179,6 +184,7 @@ describe("Supervisor - output and events", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
     agentRunner.onLine = (line) => supervisor.emitLine(line);
     supervisorRunner.onLine = (line) => supervisor.emitLine(line);
@@ -231,6 +237,7 @@ describe("Supervisor - output and events", () => {
       supervisorRunner,
       output,
       maxTurns: 10,
+      redactor: noop(),
     });
     agentRunner.onLine = (line) => supervisor.emitLine(line);
     supervisorRunner.onLine = (line) => supervisor.emitLine(line);
@@ -276,6 +283,7 @@ describe("Supervisor - output and events", () => {
       output,
       maxTurns: 10,
       ctx,
+      redactor: noop(),
     });
 
     await supervisor.run("Task");

--- a/libraries/libeval/test/supervisor-run.test.js
+++ b/libraries/libeval/test/supervisor-run.test.js
@@ -10,8 +10,11 @@ import {
   createAnswerHandler,
 } from "../src/orchestration-toolkit.js";
 import { MessageBus } from "../src/message-bus.js";
+import { createNoopRedactor } from "../src/redaction.js";
 import { createMockRunner } from "./mock-runner.js";
 import { createToolUseMsg } from "@forwardimpact/libharness";
+
+const noop = () => createNoopRedactor();
 
 const concludeMsg = (summary, verdict = "success") =>
   createToolUseMsg("Conclude", { verdict, summary });
@@ -89,6 +92,7 @@ describe("Supervisor - run and turns", () => {
       maxTurns: 10,
       ctx,
       messageBus,
+      redactor: noop(),
     });
 
     const result = await supervisor.run("Install stuff");
@@ -127,6 +131,7 @@ describe("Supervisor - run and turns", () => {
       maxTurns: 10,
       ctx,
       messageBus,
+      redactor: noop(),
     });
 
     const result = await supervisor.run("Install stuff");
@@ -195,6 +200,7 @@ describe("Supervisor - run and turns", () => {
       maxTurns: 10,
       ctx,
       messageBus,
+      redactor: noop(),
     });
 
     await supervisor.run("Evaluate the product");
@@ -242,6 +248,7 @@ describe("Supervisor - run and turns", () => {
       maxTurns: 10,
       ctx,
       messageBus,
+      redactor: noop(),
     });
 
     const result = await supervisor.run("Do the work");
@@ -271,6 +278,7 @@ describe("Supervisor - run and turns", () => {
       maxTurns: 2,
       ctx,
       messageBus,
+      redactor: noop(),
     });
 
     const result = await supervisor.run("Endless task");
@@ -348,6 +356,7 @@ describe("Supervisor - run and turns", () => {
       maxTurns: 10,
       ctx,
       messageBus,
+      redactor: noop(),
     });
 
     const result = await supervisor.run("Install task");


### PR DESCRIPTION
## Summary

Implements [spec 850](specs/850-libeval-trace-redaction/spec.md) under
[design-a](specs/850-libeval-trace-redaction/design-a.md) /
[plan-a](specs/850-libeval-trace-redaction/plan-a.md).

- New `Redactor` (`libraries/libeval/src/redaction.js`) composes an
  env-var allowlist (default `ANTHROPIC_API_KEY`, `GH_TOKEN`,
  `GITHUB_TOKEN`; override via `LIBEVAL_REDACTION_ENV_VARS`) and
  credential-shape regexes (Anthropic, GitHub PAT/installation/OAuth/
  fine-grained). Stable placeholders: `[REDACTED:env:NAME]` and
  `[REDACTED:pattern:KIND]`.
- Wired as a **required** constructor dep at every persistent-sink
  seam — `AgentRunner.#recordLine`, `Supervisor`/`Facilitator`
  `emit*` (covers Conclude-handler text on `emitSummary` without
  traversing `#recordLine`), and the `run.js` `onLine` envelope as
  defence-in-depth.
- Command entrypoints (`run.js`, `supervise.js`, `facilitate.js`)
  build the redactor as the first observable side-effect after option
  parsing so the env snapshot freezes before any in-process
  `process.env` write.
- Opt-out via `LIBEVAL_REDACTION_DISABLED=1` with a one-shot stderr
  warning; documented in `libraries/libeval/README.md` and
  `kata-action-eval/README.md` as prohibited on public-repo CI.

## Test plan

- [x] `bun run check`
- [x] `bun run test` — 355 libeval tests pass (32 new unit + 7
      producer-pipeline integration).
- [x] kata-review panel of 5 — no blockers/highs; one medium
      (missing `createFacilitator` throws-on-missing-redactor test)
      addressed; remaining 6 mediums dismissed with rationale in the
      panel commit message.

https://claude.ai/code/session_011AoWFwsnkwfRSuUHJFh1NR

---
_Generated by [Claude Code](https://claude.ai/code/session_011AoWFwsnkwfRSuUHJFh1NR)_