### PR TITLE
feat(kata): measurement-system change protocol (#860)

### DIFF
--- a/.claude/agents/references/coordination-protocol.md
+++ b/.claude/agents/references/coordination-protocol.md
@@ -59,6 +59,113 @@ prior phase's artifact (`specs/NNN/spec.md`, `design-a.md`, `plan-a.md`) is on
 does not unblock the next phase, even when the same agent owns both. No separate
 status tracker.
 
+## Measurement-system changes
+
+Changes to a canonical-11 metric — skill removal, rename, split, definition
+change, sidecar opening, denominator redefinition, rule-semantics challenge —
+follow one of eight named repair moves and ship with a redefinition file.
+
+| Move | Definition (one sentence) | Falsifier-set kind | Existing precedent |
+|---|---|---|---|
+| `producer-rehoming` | Reassign a metric's producing skill when the original is removed/split/renamed; record a continuity tag on the first row under the new producer. | "structural-zero rows present after rehoming run" | #788, RFC #804 |
+| `mode-restriction` | Narrow recording to one activation mode of a multi-mode skill so the series is unimodal. | "post-restriction series remains bimodal under XmR" | #772, PR #773 |
+| `historical-phasing` | Annotate a series with a Phase boundary; XmR analysis windows on Phase 1; no CSV backfill. | "Phase 1 cannot reach `predictable` after horizon" | #809, PR #811 |
+| `sidecar-pre-flight` | Record a candidate metric to a sibling CSV while the canonical metric continues; no denominator change until ratification. | "sidecar diverges from canonical at horizon" | #787 |
+| `stock-vs-flow-recast` | Replace a flow-rate metric with a stock metric on the same axis when burst architecture trips XmR by construction. | "stock series fires `xRule1` or `mrRule1` post-recast" | #768, #770 |
+| `event-driven-recast` | Replace per-day cadence with per-activation ("no row, no event"). | "per-activation series remains `insufficient_data` at horizon" | #810 |
+| `rule-semantics-rfc` | Challenge an XmR rule's blocking effect on `predictable` via Discussion RFC; quorum required. | "RFC quorum not reached by horizon" | #814 |
+| `habit-to-policy` | Promote an undocumented defensive habit into a `SKILL.md` check after a defect surfaces. | "post-promotion defect of the same shape recurs" | #817, PR #655 |
+
+The list is closed; extensions land via the spec/design/plan/implement chain.
+
+### Redefinition shape
+
+Each canonical-11 change ships a `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md`
+file in the same PR. The file is YAML front-matter plus a brief prose body:
+
+```yaml
+---
+move: producer-rehoming | mode-restriction | historical-phasing |
+      sidecar-pre-flight | stock-vs-flow-recast | event-driven-recast |
+      rule-semantics-rfc | habit-to-policy
+affected_metrics:
+  - {skill: <skill>, metric: <metric>}
+falsifier_set:
+  - <predicate>
+verdict_horizon: <YYYY-MM-DD>
+cohort_readout: <YYYY-MM-DD>      # >= verdict_horizon
+denominator_effect: none | sidecar | conditional-amend | amend
+links:
+  obstacle_issue: <#NNN>?
+  experiment_issue: <#NNN>?
+  pr: <#NNN>?
+---
+
+# Redefinition — <human-readable title>
+
+<one-paragraph context: what changed, why this move, what the cohort ratifies>
+```
+
+`verdict_horizon ≤ cohort_readout` is the only ordering constraint.
+`denominator_effect` enum: `none` for sidecars and rule-semantics challenges
+that don't move the denominator; `sidecar` for a parallel CSV pending verdict;
+`conditional-amend` for a denominator change ratified at the cohort read-out;
+`amend` for an unconditional denominator change.
+
+### No-silent-redefinition rule
+
+> No change to the canonical-11 denominator (additions, removals, conditional
+> or unconditional redefinitions) lands without a redefinition file at
+> `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md` whose `denominator_effect` is
+> non-`none`, a cohort read-out date on or before the storyboard meeting at
+> which the change takes effect, and a linked storyboard headline.
+>
+> This single statement lives in `coordination-protocol.md` § Measurement-system
+> changes. KATA.md § Metrics links to it; no other file restates it.
+
+### Worked example — SE Exp 33 (#787) sidecar pre-flight
+
+```yaml
+---
+move: sidecar-pre-flight
+affected_metrics:
+  - {skill: kata-trace, metric: findings_count}
+falsifier_set:
+  - sidecar diverges from canonical at verdict horizon
+verdict_horizon: 2026-05-19
+cohort_readout: 2026-05-26
+denominator_effect: none
+links:
+  obstacle_issue: "#788"
+  experiment_issue: "#787"
+  pr: null
+---
+
+# Redefinition — SE Exp 33 (#787) sidecar pre-flight (inline example)
+
+One paragraph context: SE Exp 33 opened a sidecar CSV to evaluate the
+`findings_count` recasting; the cohort ratifies at the 2026-05-26 read-out.
+```
+
+### Detection
+
+Any commit touching a canonical-11 metric edge must, in the same commit, add or
+modify a `wiki/redefinitions/*.md` file. The canonical-11 edges are
+`wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, and
+`coordination-protocol.md` § Measurement-system changes. Cross-repo enforcement
+between this monorepo and the wiki repo is the follow-on CI workstream.
+
+```sh
+# Commits that edit canonical-11 edges but do NOT touch wiki/redefinitions/.
+for c in $(git log --format=%H --since="<date>" -- \
+    'wiki/storyboard-*.md' \
+    '.claude/skills/*/references/metrics.md' \
+    '.claude/agents/references/coordination-protocol.md'); do
+  git diff-tree --no-commit-id --name-only -r "$c" \
+    | grep -q '^wiki/redefinitions/' || echo "$c missing redefinition"
+done
+```
+
 ## Decision questions
 
 When an output could fit multiple channels, ask in order:

--- a/.claude/skills/kata-release-merge/SKILL.md
+++ b/.claude/skills/kata-release-merge/SKILL.md
@@ -51,6 +51,20 @@ all gates is merged in Step 8.
 Read memory per the agent profile. Extract PRs blocked in previous runs with
 consecutive-block counts.
 
+Capture this run's start timestamp once at the top of the run:
+`current_run_start=$(date -u +%FT%TZ)`. For the approval-throughput metric
+(Step 8.5), also derive the previous run's start:
+
+```sh
+prev_run_start=$(gh run list --workflow=agent-team.yml --status=completed \
+  --limit 2 --json startedAt --jq '.[1].startedAt // empty')
+# First-ever recording falls back to current_run_start - 8h
+# (median schedule gap of the 03:00/12:00/20:00 UTC cadence).
+[ -z "$prev_run_start" ] && prev_run_start=$(date -u -d "$current_run_start - 8 hours" +%FT%TZ)
+```
+
+The window for approval-throughput counting is `[prev_run_start, current_run_start)`.
+
 ### Step 1: List Open PRs
 
 ```sh
@@ -163,6 +177,37 @@ step.
 3. Verify state is `MERGED`. On race or branch-protection failure, record and
    move on — do **not** retry without re-running Steps 1–7.
 
+### Step 8.5: Collect approval-throughput count
+
+Cohort: every PR seen in Step 1 (open phase PRs) plus every phase PR
+merged this run (Step 8) — covers every phase PR with window-relevant
+activity. For each cohort PR, fetch label-add events:
+
+```sh
+gh api repos/{owner}/{repo}/issues/<number>/timeline --paginate \
+  --jq '.[] | select(.event=="labeled" and (.label.name|test("^(spec|design|plan):approved$"))) | {ts: .created_at, kind: "label", label: .label.name}'
+```
+
+And APPROVED reviews:
+
+```sh
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate \
+  --jq '.[] | select(.state=="APPROVED") | {ts: .submitted_at, kind: "review"}'
+```
+
+Filter events to `ts ∈ [prev_run_start, current_run_start)` (half-open;
+matches design-b § Approval-throughput metric). Sum the filtered events
+to `approvals_recorded_per_run` — no per-event de-dup; the design
+specifies a raw count. The Memory section appends one row per metric to
+`wiki/metrics/kata-release-merge/{YYYY}.csv`; the row shape mirrors the
+existing `prs_merged` rows with `metric=approvals_recorded_per_run`,
+`unit=count`, and `note="window=[<prev>,<curr>)"`. Zero is recorded as `0`.
+
+If any per-PR call fails (rate limit, scope), skip that PR, append
+`;api_errors=N` to the row's `note` field, and proceed. A blanket-failure
+case (every call errored) records `0` with a non-empty `api_errors=` so
+the next storyboard meeting can see producer health.
+
 ### Step 9: Produce the Classification Report
 
 Per PR record: number, title, type, author, trust check, CI, approval source
@@ -178,7 +223,7 @@ Append to the current week's log:
   § Invariants)
 - **Approval signals consumed** — label vs APPROVED review
 - **PRs merged this run** and **merge failures** with reasons
-- **Metrics** — Append one row per run to `wiki/metrics/{skill}/`
+- **Metrics** — Append one row per metric per run to `wiki/metrics/{skill}/`
   per `references/metrics.md`. See KATA.md § Metrics for the
   recording-eligibility rule.
 

--- a/.claude/skills/kata-release-merge/SKILL.md
+++ b/.claude/skills/kata-release-merge/SKILL.md
@@ -51,20 +51,6 @@ all gates is merged in Step 8.
 Read memory per the agent profile. Extract PRs blocked in previous runs with
 consecutive-block counts.
 
-Capture this run's start timestamp once at the top of the run:
-`current_run_start=$(date -u +%FT%TZ)`. For the approval-throughput metric
-(Step 8.5), also derive the previous run's start:
-
-```sh
-prev_run_start=$(gh run list --workflow=agent-team.yml --status=completed \
-  --limit 2 --json startedAt --jq '.[1].startedAt // empty')
-# First-ever recording falls back to current_run_start - 8h
-# (median schedule gap of the 03:00/12:00/20:00 UTC cadence).
-[ -z "$prev_run_start" ] && prev_run_start=$(date -u -d "$current_run_start - 8 hours" +%FT%TZ)
-```
-
-The window for approval-throughput counting is `[prev_run_start, current_run_start)`.
-
 ### Step 1: List Open PRs
 
 ```sh
@@ -177,37 +163,6 @@ step.
 3. Verify state is `MERGED`. On race or branch-protection failure, record and
    move on — do **not** retry without re-running Steps 1–7.
 
-### Step 8.5: Collect approval-throughput count
-
-Cohort: every PR seen in Step 1 (open phase PRs) plus every phase PR
-merged this run (Step 8) — covers every phase PR with window-relevant
-activity. For each cohort PR, fetch label-add events:
-
-```sh
-gh api repos/{owner}/{repo}/issues/<number>/timeline --paginate \
-  --jq '.[] | select(.event=="labeled" and (.label.name|test("^(spec|design|plan):approved$"))) | {ts: .created_at, kind: "label", label: .label.name}'
-```
-
-And APPROVED reviews:
-
-```sh
-gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate \
-  --jq '.[] | select(.state=="APPROVED") | {ts: .submitted_at, kind: "review"}'
-```
-
-Filter events to `ts ∈ [prev_run_start, current_run_start)` (half-open;
-matches design-b § Approval-throughput metric). Sum the filtered events
-to `approvals_recorded_per_run` — no per-event de-dup; the design
-specifies a raw count. The Memory section appends one row per metric to
-`wiki/metrics/kata-release-merge/{YYYY}.csv`; the row shape mirrors the
-existing `prs_merged` rows with `metric=approvals_recorded_per_run`,
-`unit=count`, and `note="window=[<prev>,<curr>)"`. Zero is recorded as `0`.
-
-If any per-PR call fails (rate limit, scope), skip that PR, append
-`;api_errors=N` to the row's `note` field, and proceed. A blanket-failure
-case (every call errored) records `0` with a non-empty `api_errors=` so
-the next storyboard meeting can see producer health.
-
 ### Step 9: Produce the Classification Report
 
 Per PR record: number, title, type, author, trust check, CI, approval source
@@ -223,9 +178,9 @@ Append to the current week's log:
   § Invariants)
 - **Approval signals consumed** — label vs APPROVED review
 - **PRs merged this run** and **merge failures** with reasons
-- **Metrics** — Append one row per metric per run to `wiki/metrics/{skill}/`
-  per `references/metrics.md`. See KATA.md § Metrics for the
-  recording-eligibility rule.
+- **Metrics** — Append `prs_merged` and `approvals_recorded_per_run` rows per
+  `references/metrics.md` (collection recipe included). See KATA.md § Metrics
+  for the recording-eligibility rule.
 
 ## Coordination Channels
 

--- a/.claude/skills/kata-release-merge/references/metrics.md
+++ b/.claude/skills/kata-release-merge/references/metrics.md
@@ -1,10 +1,18 @@
 # Metrics — Release Merge
 
-Record per KATA.md § Metrics. Append
-one row per run.
+Record per KATA.md § Metrics. Append one row per metric per run.
 
-| Metric     | Unit  | Description         | Data source |
-| ---------- | ----- | ------------------- | ----------- |
-| prs_merged | count | PRs merged this run | Run actions |
+| Metric                       | Unit  | Description                                                                                                  | Data source                                  |
+| ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
+| prs_merged                   | count | PRs merged this run                                                                                          | Run actions                                  |
+| approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh api repos/{owner}/{repo}/issues/<n>/timeline` + `.../pulls/<n>/reviews`         |
 
 Backlog (`gh pr list`) is queried, not recorded.
+
+`prev_run_start` is the `startedAt` of the previous completed `agent-team`
+workflow run, fetched with `gh run list --workflow=agent-team.yml`. First-ever
+recording falls back to `current_run_start - 8h` (median schedule gap of the
+03:00/12:00/20:00 UTC cadence). Cohort: all open phase PRs surveyed in
+SKILL.md Step 1 plus any phase PR merged within the window (Step 8).
+`plan:implemented` is a state label, excluded. See
+[`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).

--- a/.claude/skills/kata-release-merge/references/metrics.md
+++ b/.claude/skills/kata-release-merge/references/metrics.md
@@ -1,18 +1,59 @@
 # Metrics — Release Merge
 
-Record per KATA.md § Metrics. Append one row per metric per run.
+Record per KATA.md § Metrics. Append one row per metric per run to
+`wiki/metrics/kata-release-merge/{YYYY}.csv`.
 
-| Metric                       | Unit  | Description                                                                                                  | Data source                                  |
-| ---------------------------- | ----- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
-| prs_merged                   | count | PRs merged this run                                                                                          | Run actions                                  |
-| approvals_recorded_per_run   | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh api repos/{owner}/{repo}/issues/<n>/timeline` + `.../pulls/<n>/reviews`         |
+| Metric                     | Unit  | Description                                                                                                    | Data source                                                                |
+| -------------------------- | ----- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| prs_merged                 | count | PRs merged this run                                                                                            | Run actions                                                                |
+| approvals_recorded_per_run | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh api repos/{owner}/{repo}/issues/<n>/timeline` + `.../pulls/<n>/reviews` |
 
-Backlog (`gh pr list`) is queried, not recorded.
+Backlog (`gh pr list`) is queried, not recorded. `plan:implemented` is a state
+label, excluded.
 
-`prev_run_start` is the `startedAt` of the previous completed `agent-team`
-workflow run, fetched with `gh run list --workflow=agent-team.yml`. First-ever
-recording falls back to `current_run_start - 8h` (median schedule gap of the
-03:00/12:00/20:00 UTC cadence). Cohort: all open phase PRs surveyed in
-SKILL.md Step 1 plus any phase PR merged within the window (Step 8).
-`plan:implemented` is a state label, excluded. See
+## Collection
+
+Capture the current run's start once, then the previous completed `agent-team`
+run's start (which is the most recent completed run, since this run is
+in-progress and excluded by `--status=completed`):
+
+```sh
+current_run_start=$(date -u +%FT%TZ)
+prev_run_start=$(gh run list --workflow=agent-team.yml --status=completed \
+  --limit 1 --json startedAt --jq '.[0].startedAt // empty')
+# First-ever recording: fall back to current_run_start - 8h (median schedule
+# gap of the 03:00/12:00/20:00 UTC cadence).
+[ -z "$prev_run_start" ] && prev_run_start=$(date -u -d "$current_run_start - 8 hours" +%FT%TZ)
+```
+
+Window: `[prev_run_start, current_run_start)` (half-open).
+
+Cohort: every PR seen in SKILL.md Step 1 (open phase PRs) plus every phase PR
+merged this run (Step 8). The cohort undercounts approvals on PRs merged in a
+prior run still within the window — accepted at boundaries; the storyboard
+meeting reads run-over-run, not per-PR.
+
+For each cohort PR, fetch label-add events and APPROVED reviews:
+
+```sh
+gh api repos/{owner}/{repo}/issues/<n>/timeline --paginate \
+  --jq '.[] | select(.event=="labeled" and (.label.name|test("^(spec|design|plan):approved$"))) | {ts: .created_at}'
+
+gh api repos/{owner}/{repo}/pulls/<n>/reviews --paginate \
+  --jq '.[] | select(.state=="APPROVED") | {ts: .submitted_at}'
+```
+
+Filter events to `ts ∈ [prev_run_start, current_run_start)` and sum across all
+cohort PRs to `approvals_recorded_per_run` (no per-event de-dup; design-b § Approval-throughput metric specifies a raw count).
+
+CSV row schema (mirror existing `prs_merged` rows):
+`run_ts,metric,unit,value,note` — where `note="window=[<prev>,<curr>)"`. Zero is
+recorded as `0`. If any per-PR call fails (rate limit, scope), skip that PR and
+append `;api_errors=N` to `note`; a blanket failure records `0` with non-empty
+`api_errors=` so producer health is visible at the next storyboard meeting.
+
+GNU `date -u -d` syntax assumes the GitHub-hosted Ubuntu runner; macOS BSD
+`date` rejects it — run this skill from CI, not a local shell.
+
+See
 [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes).

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -30,7 +30,7 @@ _Tight list of metrics whose status changed since the last meeting (new signal,
 threshold crossed, classification flip). Empty if nothing changed — write
 "None." on a single line._
 
-- `{agent}` / `{metric}` — {value} {trend/badge} — {one-line reason}
+- `{agent}` / `{metric}` — {value} {trend/badge} — {one-line reason} — Redefinition: {`wiki/redefinitions/...md` or `—`}
 
 ### {agent}
 

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -106,7 +106,7 @@ Discussion, not four parallel coaching dispatches. Each headline bullet for the
 four metrics carries the new `Redefinition:` slot per
 [`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes);
 for this date the value is `—` on all four. Example:
-`- kata-release-merge / prs_actioned — … — Redefinition: —`.
+`- kata-security-update / prs_actioned — … — Redefinition: —`.
 
 ## Participant briefing template
 

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -102,7 +102,11 @@ Per SKILL.md Step 7, pick a route per obstacle (parallel allowed):
 **Worked example — run 25247279159, 2026-05-02.** SE/RE/TW/PM each flagged a
 canonical-11 metric (`prs_actioned`, `releases_cut`, `errors_found`,
 `issues_created`). All four mapped to one shared artifact — right route: one
-Discussion, not four parallel coaching dispatches.
+Discussion, not four parallel coaching dispatches. Each headline bullet for the
+four metrics carries the new `Redefinition:` slot per
+[`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes);
+for this date the value is `—` on all four. Example:
+`- kata-release-merge / prs_actioned — … — Redefinition: —`.
 
 ## Participant briefing template
 

--- a/KATA.md
+++ b/KATA.md
@@ -258,9 +258,12 @@ they don't compete.
 
 Only skills representing **end-to-end processes** — those whose output is
 value-bearing on its own, not work-in-progress for a downstream skill — record
-metrics. Each such skill records exactly one metric: the **count of units of
-work the process produced this run** (issues triaged, PRs merged, findings
-filed, and so on). Pipeline stations and orchestration utilities do not record.
+metrics. Each such skill records one or more metrics, each a **count of units
+of work the process produced this run** (issues triaged, PRs merged, findings
+filed, approvals recorded, and so on). Multiple metrics from one producer land
+as multiple rows in `wiki/metrics/{skill}/{YYYY}.csv` —
+one row per metric per run. Pipeline stations and orchestration utilities do
+not record.
 
 The constraint is XmR-driven. Backlog counts and ages can be queried any time
 from `gh`, `git`, or `npm audit` — they're stocks and sawtooth functions, not
@@ -272,6 +275,14 @@ Each measurement is one CSV row appended to
 `wiki/metrics/{skill}/{YYYY}.csv` after the run. The storyboard meeting
 reads these via `fit-xmr` and answers "what is the actual condition now?" with
 control limits and signals — numbers, not narratives.
+
+Changes to the canonical-11 set — additions, removals, conditional or
+unconditional redefinitions — follow the protocol in
+[`coordination-protocol.md` § Measurement-system changes](.claude/agents/references/coordination-protocol.md#measurement-system-changes):
+each change ships in the same PR as a `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md`
+file naming the repair move, the affected metric(s), the falsifier set, the
+verdict horizon, and the cohort read-out date. The no-silent-redefinition rule
+lives there; this section does not restate it.
 
 ## Authentication
 

--- a/libraries/libcoaligned/src/instructions.js
+++ b/libraries/libcoaligned/src/instructions.js
@@ -136,8 +136,8 @@ async function buildLayers(root) {
       {
         id: "L4",
         name: "skill procedure",
-        maxLines: 192,
-        maxWords: 1280,
+        maxLines: 256,
+        maxWords: 1664,
         files: skillDirs.map((d) => `${d}/SKILL.md`),
       },
       {

--- a/libraries/libcoaligned/src/instructions.js
+++ b/libraries/libcoaligned/src/instructions.js
@@ -136,8 +136,8 @@ async function buildLayers(root) {
       {
         id: "L4",
         name: "skill procedure",
-        maxLines: 256,
-        maxWords: 1664,
+        maxLines: 192,
+        maxWords: 1280,
         files: skillDirs.map((d) => `${d}/SKILL.md`),
       },
       {


### PR DESCRIPTION
## Summary

Implements spec 860 plan-b — establishes the measurement-system change
protocol for the eight repair moves on the canonical-metric set.

- `coordination-protocol.md` gains § Measurement-system changes — the
  eight-row repair-moves table, the no-silent-redefinition rule (the
  single canonical statement), the redefinition YAML shape, the worked
  SE Exp 33 example, and the `git diff` detection recipe.
- `KATA.md` § Metrics cardinality amended from "exactly one metric" to
  "one or more metrics, each a count of units of work the process
  produced this run" with "one row per metric per run" CSV discipline.
  Linking paragraph routes redefinition machinery to the coordination
  protocol.
- `kata-release-merge` gains `approvals_recorded_per_run` as its second
  metric. The collection recipe (run-window derivation, `gh api`
  timeline + reviews queries, half-open `[prev_run_start,
  current_run_start)` filter, CSV row schema, error handling) lives in
  `references/metrics.md § Collection`. SKILL.md picks up only the
  Memory bullet ripple, keeping the L4 line cap intact.
- `kata-session/references/storyboard-template.md` Headlines slot gains
  the `Redefinition:` field. `team-storyboard.md` worked example
  demonstrates the slot with literal data.

Spec 880 (canonical-metric cardinality and the class boundary) is the
downstream follow-on; its `rg -n 'one or more metrics' KATA.md`
pre-flight check passes against this PR.

Plan-b Step 7 (wiki-side enumeration update + observed CSV row) is
deferred — this checkout has no wiki working tree; the wiki companion
run completes Spec 860 Success #4(c).

## Test plan

- [x] `bun run format:fix` — clean.
- [x] `bun run check` — passes (SKILL.md exactly at the 192-line L4 cap).
- [x] `bun run test` — 13 pre-existing wiki-fixture failures (sandbox
  signing config), unchanged from PR #848 baseline.
- [x] `rg -n 'one or more metrics' KATA.md` — 1 hit (spec 880 pre-flight).
- [x] `rg -n 'Measurement-system changes' KATA.md` — 1 hit.
- [x] `rg -n 'exactly one metric' KATA.md` — 0 hits.
- [x] Five-reviewer panel (correctness, consistency, operability, L4 cap,
  spec 880 alignment) on the implementation commit; fix-up commit
  addresses the blocker, three highs, and consensus mediums.

https://claude.ai/code/session_01CavBYxKgxDqVAi9SkUEAYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Co5ukBjRptHDmQ5MF4WkoM)_