### PR TITLE
refactor(libeval): make apm install mockable via DI

### DIFF
--- a/libraries/libeval/src/benchmark/apm-installer.js
+++ b/libraries/libeval/src/benchmark/apm-installer.js
@@ -3,71 +3,109 @@
  * materialise skills and agents, copies the resulting `.claude/` into a
  * staging directory, and computes the manifest fingerprint from the lockfile.
  * Per-task copy happens later in WorkdirManager.
+ *
+ * The class takes a `spawn` seam so tests can substitute a fake child process
+ * without ever shelling out to a real `apm` binary. See `createApmInstaller`
+ * for the real-dependency wiring; `installApm` is a thin free-function wrapper
+ * for callers that don't need to inject anything.
  */
 
-import { spawn } from "node:child_process";
+import { spawn as nodeSpawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { access, cp, mkdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 
-/**
- * @param {import("./task-family.js").TaskFamily} family
- * @param {string} outputDir - The benchmark run's output directory.
- * @returns {Promise<{stagingDir: string, skillSetHash: string}>}
- */
-export async function installApm(family, outputDir) {
-  const stagingDir = join(outputDir, ".apm-staging");
-  const stagedClaude = join(stagingDir, ".claude");
-  const sourceClaude = join(family.rootPath, ".claude");
-  const apmYml = join(family.rootPath, "apm.yml");
+/** Installs apm and stages `.claude/` for a task family. */
+export class ApmInstaller {
+  /**
+   * @param {object} [deps]
+   * @param {typeof nodeSpawn} [deps.spawn] - Spawn seam (defaults to
+   *   `node:child_process` spawn). Tests inject a fake to avoid shelling out.
+   */
+  constructor({ spawn } = {}) {
+    this.spawn = spawn ?? nodeSpawn;
+  }
 
-  const hasApm = await access(apmYml)
-    .then(() => true)
-    .catch(() => false);
+  /**
+   * @param {import("./task-family.js").TaskFamily} family
+   * @param {string} outputDir - The benchmark run's output directory.
+   * @returns {Promise<{stagingDir: string, skillSetHash: string, judgeProfilesDir: string}>}
+   */
+  async install(family, outputDir) {
+    const stagingDir = join(outputDir, ".apm-staging");
+    const stagedClaude = join(stagingDir, ".claude");
+    const sourceClaude = join(family.rootPath, ".claude");
+    const apmYml = join(family.rootPath, "apm.yml");
 
-  if (hasApm) {
-    await runApmInstall(family.rootPath);
-    try {
-      await access(sourceClaude);
-    } catch {
-      throw new Error(
-        `apm install did not produce .claude/ at ${sourceClaude}; check the family's apm.yml`,
-      );
+    const hasApm = await access(apmYml)
+      .then(() => true)
+      .catch(() => false);
+
+    if (hasApm) {
+      await this.#runApmInstall(family.rootPath);
+      try {
+        await access(sourceClaude);
+      } catch {
+        throw new Error(
+          `apm install did not produce .claude/ at ${sourceClaude}; check the family's apm.yml`,
+        );
+      }
     }
+
+    await rm(stagingDir, { recursive: true, force: true });
+    const hasClaudeDir = await access(sourceClaude)
+      .then(() => true)
+      .catch(() => false);
+    if (hasClaudeDir) {
+      await cp(sourceClaude, stagedClaude, { recursive: true });
+    } else {
+      await mkdir(stagedClaude, { recursive: true });
+    }
+
+    // Stage the family-local judge profile outside .claude/ so it is available
+    // to the judge but never copied into the agent-under-test's CWD.
+    const judgeSource = join(family.rootPath, "judge.md");
+    const judgeProfilesDir = join(stagingDir, "judge-profiles");
+    try {
+      await access(judgeSource);
+      await mkdir(judgeProfilesDir, { recursive: true });
+      await cp(judgeSource, join(judgeProfilesDir, "judge.md"));
+    } catch {}
+
+    const lockPath = join(family.rootPath, "apm.lock.yaml");
+    let skillSetHash = "";
+    try {
+      const lockBytes = await readFile(lockPath);
+      skillSetHash =
+        "sha256:" +
+        createHash("sha256").update(normalizeLf(lockBytes)).digest("hex");
+    } catch {
+      // No lockfile — family doesn't use skill packs.
+    }
+
+    return { stagingDir, skillSetHash, judgeProfilesDir };
   }
 
-  await rm(stagingDir, { recursive: true, force: true });
-  const hasClaudeDir = await access(sourceClaude)
-    .then(() => true)
-    .catch(() => false);
-  if (hasClaudeDir) {
-    await cp(sourceClaude, stagedClaude, { recursive: true });
-  } else {
-    await mkdir(stagedClaude, { recursive: true });
+  #runApmInstall(cwd) {
+    return new Promise((res, rej) => {
+      const child = this.spawn("apm", ["install", "--target", "claude"], {
+        cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stderr = "";
+      child.stdout.on("data", () => {});
+      child.stderr.on("data", (d) => {
+        stderr += d.toString();
+      });
+      child.on("error", (e) => {
+        rej(new Error(`failed to spawn apm: ${e.message}`));
+      });
+      child.on("close", (code) => {
+        if (code === 0) res();
+        else rej(new Error(`apm install exited ${code}: ${stderr}`));
+      });
+    });
   }
-
-  // Stage the family-local judge profile outside .claude/ so it is available
-  // to the judge but never copied into the agent-under-test's CWD.
-  const judgeSource = join(family.rootPath, "judge.md");
-  const judgeProfilesDir = join(stagingDir, "judge-profiles");
-  try {
-    await access(judgeSource);
-    await mkdir(judgeProfilesDir, { recursive: true });
-    await cp(judgeSource, join(judgeProfilesDir, "judge.md"));
-  } catch {}
-
-  const lockPath = join(family.rootPath, "apm.lock.yaml");
-  let skillSetHash = "";
-  try {
-    const lockBytes = await readFile(lockPath);
-    skillSetHash =
-      "sha256:" +
-      createHash("sha256").update(normalizeLf(lockBytes)).digest("hex");
-  } catch {
-    // No lockfile — family doesn't use skill packs.
-  }
-
-  return { stagingDir, skillSetHash, judgeProfilesDir };
 }
 
 function normalizeLf(buf) {
@@ -79,23 +117,20 @@ function normalizeLf(buf) {
   return Buffer.from(out);
 }
 
-function runApmInstall(cwd) {
-  return new Promise((res, rej) => {
-    const child = spawn("apm", ["install", "--target", "claude"], {
-      cwd,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stderr = "";
-    child.stdout.on("data", () => {});
-    child.stderr.on("data", (d) => {
-      stderr += d.toString();
-    });
-    child.on("error", (e) => {
-      rej(new Error(`failed to spawn apm: ${e.message}`));
-    });
-    child.on("close", (code) => {
-      if (code === 0) res();
-      else rej(new Error(`apm install exited ${code}: ${stderr}`));
-    });
-  });
+/**
+ * Factory function — wires real dependencies.
+ * @param {ConstructorParameters<typeof ApmInstaller>[0]} [deps]
+ * @returns {ApmInstaller}
+ */
+export function createApmInstaller(deps) {
+  return new ApmInstaller(deps);
+}
+
+/**
+ * Free-function shorthand for callers that don't need to inject a spawn seam.
+ * @param {import("./task-family.js").TaskFamily} family
+ * @param {string} outputDir
+ */
+export function installApm(family, outputDir) {
+  return new ApmInstaller().install(family, outputDir);
 }

--- a/libraries/libeval/src/benchmark/runner.js
+++ b/libraries/libeval/src/benchmark/runner.js
@@ -21,7 +21,7 @@ import { join, resolve as resolvePath } from "node:path";
 
 import { DEFAULT_ENV_ALLOWLIST, createRedactor } from "../redaction.js";
 import { createSupervisor } from "../supervisor.js";
-import { installApm } from "./apm-installer.js";
+import { installApm as defaultInstallApm } from "./apm-installer.js";
 import { runJudge } from "./judge.js";
 import { validateResultRecord } from "./result.js";
 import { runScoring } from "./scorer.js";
@@ -64,6 +64,10 @@ export class BenchmarkRunner {
    * @param {Function} [opts.runJudge] - Test seam: replaces `runJudge`. Same
    *   contract as `runJudge(task, workdir, scoring, deps)`. Internal testing
    *   only.
+   * @param {Function} [opts.installApm] - Test seam: replaces `installApm`.
+   *   Same contract as `installApm(family, outputDir)`. Lets tests inject a
+   *   fake `apm` spawn (or skip the install entirely) so the suite never
+   *   shells out to a real `apm` binary. Internal testing only.
    */
   constructor({
     family,
@@ -81,6 +85,7 @@ export class BenchmarkRunner {
     runAgent,
     runScoring: runScoringHook,
     runJudge: runJudgeHook,
+    installApm: installApmHook,
   }) {
     if (!family) throw new Error("family is required");
     if (!Number.isInteger(runs) || runs < 1)
@@ -105,6 +110,7 @@ export class BenchmarkRunner {
     this._runAgentHook = runAgent ?? null;
     this._runScoringHook = runScoringHook ?? runScoring;
     this._runJudgeHook = runJudgeHook ?? runJudge;
+    this._installApmHook = installApmHook ?? defaultInstallApm;
   }
 
   /**
@@ -118,10 +124,8 @@ export class BenchmarkRunner {
         : this.familyInput;
 
     await mkdir(this.output, { recursive: true });
-    const { stagingDir, skillSetHash, judgeProfilesDir } = await installApm(
-      family,
-      this.output,
-    );
+    const { stagingDir, skillSetHash, judgeProfilesDir } =
+      await this._installApmHook(family, this.output);
 
     const tasks = family.tasks();
     if (this.profiles.judge) {

--- a/libraries/libeval/test/benchmark-apm-installer.test.js
+++ b/libraries/libeval/test/benchmark-apm-installer.test.js
@@ -4,33 +4,46 @@ import { access, cp, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { installApm } from "../src/benchmark/apm-installer.js";
+import { createApmInstaller } from "../src/benchmark/apm-installer.js";
 import { loadTaskFamily } from "../src/benchmark/task-family.js";
+import { makeFakeApmSpawn } from "./mock-apm-spawn.js";
 
 const FIXTURE = new URL("./fixtures/benchmark-family/", import.meta.url)
   .pathname;
 
-describe("installApm", () => {
+function newInstaller(opts) {
+  return createApmInstaller({ spawn: makeFakeApmSpawn(opts) });
+}
+
+describe("ApmInstaller.install", () => {
   test("runs apm install and stages .claude/ with a stable skillSetHash", async () => {
     const family = await loadTaskFamily(FIXTURE);
     const out = await mkdtemp(join(tmpdir(), "benchmark-apm-"));
-    const { stagingDir, skillSetHash, judgeProfilesDir } = await installApm(
-      family,
-      out,
-    );
+    const fakeSpawn = makeFakeApmSpawn();
+    const installer = createApmInstaller({ spawn: fakeSpawn });
+    const { stagingDir, skillSetHash, judgeProfilesDir } =
+      await installer.install(family, out);
     assert.strictEqual(stagingDir, join(out, ".apm-staging"));
     assert.match(skillSetHash, /^sha256:[0-9a-f]{64}$/);
     await access(join(stagingDir, ".claude", "skills", "noop", "SKILL.md"));
     await access(join(judgeProfilesDir, "judge.md"));
+    assert.strictEqual(fakeSpawn.calls.length, 1);
+    assert.strictEqual(fakeSpawn.calls[0].cmd, "apm");
+    assert.deepStrictEqual(fakeSpawn.calls[0].args, [
+      "install",
+      "--target",
+      "claude",
+    ]);
+    assert.strictEqual(fakeSpawn.calls[0].options.cwd, family.rootPath);
   });
 
   test("two consecutive runs on the same family produce the same skillSetHash", async () => {
     const family = await loadTaskFamily(FIXTURE);
-    const a = await installApm(
+    const a = await newInstaller().install(
       family,
       await mkdtemp(join(tmpdir(), "benchmark-apm-a-")),
     );
-    const b = await installApm(
+    const b = await newInstaller().install(
       family,
       await mkdtemp(join(tmpdir(), "benchmark-apm-b-")),
     );
@@ -40,7 +53,7 @@ describe("installApm", () => {
   test("lockfile mutation flips the skillSetHash", async () => {
     const dir = await mkdtemp(join(tmpdir(), "benchmark-apm-mut-"));
     await cp(FIXTURE, dir, { recursive: true });
-    const before = await installApm(
+    const before = await newInstaller().install(
       await loadTaskFamily(dir),
       await mkdtemp(join(tmpdir(), "benchmark-apm-mut-out1-")),
     );
@@ -48,7 +61,7 @@ describe("installApm", () => {
       join(dir, "apm.lock.yaml"),
       "apm_lock_version: 1\ndependencies: []\ndeployed_files: []\nlocal_deployed_files: []\nextra: row\n",
     );
-    const after = await installApm(
+    const after = await newInstaller().install(
       await loadTaskFamily(dir),
       await mkdtemp(join(tmpdir(), "benchmark-apm-mut-out2-")),
     );
@@ -67,18 +80,47 @@ describe("installApm", () => {
     );
     const family = await loadTaskFamily(dir);
     await assert.rejects(
-      installApm(family, await mkdtemp(join(tmpdir(), "benchmark-apm-out-"))),
+      newInstaller().install(
+        family,
+        await mkdtemp(join(tmpdir(), "benchmark-apm-out-")),
+      ),
       /did not produce \.claude\//,
+    );
+  });
+
+  test("propagates non-zero exit codes from apm", async () => {
+    const family = await loadTaskFamily(FIXTURE);
+    const installer = newInstaller({ exitCode: 2, stderr: "boom" });
+    await assert.rejects(
+      installer.install(
+        family,
+        await mkdtemp(join(tmpdir(), "benchmark-apm-bad-")),
+      ),
+      /apm install exited 2: boom/,
+    );
+  });
+
+  test("propagates spawn errors", async () => {
+    const family = await loadTaskFamily(FIXTURE);
+    const installer = newInstaller({
+      spawnError: new Error("ENOENT: apm not found"),
+    });
+    await assert.rejects(
+      installer.install(
+        family,
+        await mkdtemp(join(tmpdir(), "benchmark-apm-spawn-err-")),
+      ),
+      /failed to spawn apm: ENOENT: apm not found/,
     );
   });
 
   test("is idempotent: a previous staging directory is wiped and recreated", async () => {
     const family = await loadTaskFamily(FIXTURE);
     const out = await mkdtemp(join(tmpdir(), "benchmark-apm-idem-"));
-    await installApm(family, out);
+    await newInstaller().install(family, out);
     const stale = join(out, ".apm-staging", "stale.txt");
     await writeFile(stale, "x");
-    await installApm(family, out);
+    await newInstaller().install(family, out);
     await assert.rejects(access(stale));
     await rm(out, { recursive: true, force: true });
   });

--- a/libraries/libeval/test/benchmark-e2e.test.js
+++ b/libraries/libeval/test/benchmark-e2e.test.js
@@ -15,10 +15,15 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { createApmInstaller } from "../src/benchmark/apm-installer.js";
 import { aggregate } from "../src/benchmark/report.js";
 import { BenchmarkRunner } from "../src/benchmark/runner.js";
 import { validateResultRecord } from "../src/benchmark/result.js";
 import { createTraceQuery, createTraceCollector } from "@forwardimpact/libeval";
+import { makeFakeApmSpawn } from "./mock-apm-spawn.js";
+
+const mockInstallApm = (family, outputDir) =>
+  createApmInstaller({ spawn: makeFakeApmSpawn() }).install(family, outputDir);
 
 const FIXTURE = new URL("./fixtures/benchmark-family/", import.meta.url)
   .pathname;
@@ -123,6 +128,7 @@ async function setupRunner({ runs = 2, runAgent = mockRunAgent } = {}) {
     query: noopQuery,
     runAgent,
     runJudge: mockRunJudge,
+    installApm: mockInstallApm,
     termGraceMs: 100,
   });
   return { runner, out };

--- a/libraries/libeval/test/benchmark-task-family.test.js
+++ b/libraries/libeval/test/benchmark-task-family.test.js
@@ -8,7 +8,12 @@ import {
   assertJudgeProfileStaged,
   loadTaskFamily,
 } from "../src/benchmark/task-family.js";
-import { installApm } from "../src/benchmark/apm-installer.js";
+import { createApmInstaller } from "../src/benchmark/apm-installer.js";
+import { makeFakeApmSpawn } from "./mock-apm-spawn.js";
+
+function newInstaller() {
+  return createApmInstaller({ spawn: makeFakeApmSpawn() });
+}
 
 const FIXTURE = new URL("./fixtures/benchmark-family/", import.meta.url)
   .pathname;
@@ -75,11 +80,11 @@ describe("loadTaskFamily", () => {
     );
     const lfFamily = await loadTaskFamily(lfDir);
     const crlfFamily = await loadTaskFamily(crlfDir);
-    const lfOut = await installApm(
+    const lfOut = await newInstaller().install(
       lfFamily,
       await mkdtemp(join(tmpdir(), "benchmark-out-lf-")),
     );
-    const crlfOut = await installApm(
+    const crlfOut = await newInstaller().install(
       crlfFamily,
       await mkdtemp(join(tmpdir(), "benchmark-out-crlf-")),
     );
@@ -91,14 +96,14 @@ describe("assertJudgeProfileStaged", () => {
   test("resolves when the profile exists", async () => {
     const family = await loadTaskFamily(FIXTURE);
     const out = await mkdtemp(join(tmpdir(), "benchmark-stage-"));
-    const { judgeProfilesDir } = await installApm(family, out);
+    const { judgeProfilesDir } = await newInstaller().install(family, out);
     await assertJudgeProfileStaged(family, judgeProfilesDir, "judge");
   });
 
   test("throws when the profile is absent", async () => {
     const family = await loadTaskFamily(FIXTURE);
     const out = await mkdtemp(join(tmpdir(), "benchmark-stage-miss-"));
-    const { judgeProfilesDir } = await installApm(family, out);
+    const { judgeProfilesDir } = await newInstaller().install(family, out);
     await assert.rejects(
       assertJudgeProfileStaged(family, judgeProfilesDir, "missing"),
       /judge profile not staged/,

--- a/libraries/libeval/test/benchmark-workdir.test.js
+++ b/libraries/libeval/test/benchmark-workdir.test.js
@@ -5,17 +5,22 @@ import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { installApm } from "../src/benchmark/apm-installer.js";
+import { createApmInstaller } from "../src/benchmark/apm-installer.js";
 import { loadTaskFamily } from "../src/benchmark/task-family.js";
 import { createWorkdirManager } from "../src/benchmark/workdir.js";
+import { makeFakeApmSpawn } from "./mock-apm-spawn.js";
 
 const FIXTURE = new URL("./fixtures/benchmark-family/", import.meta.url)
   .pathname;
 
+function newInstaller() {
+  return createApmInstaller({ spawn: makeFakeApmSpawn() });
+}
+
 async function setupManager() {
   const family = await loadTaskFamily(FIXTURE);
   const out = await mkdtemp(join(tmpdir(), "benchmark-wm-"));
-  const { stagingDir } = await installApm(family, out);
+  const { stagingDir } = await newInstaller().install(family, out);
   return {
     family,
     out,
@@ -81,7 +86,7 @@ describe("WorkdirManager.teardown", () => {
     // process group; teardown should SIGTERM/SIGKILL it.
     const family = await loadTaskFamily(FIXTURE);
     const out = await mkdtemp(join(tmpdir(), "benchmark-wm-listener-"));
-    const { stagingDir } = await installApm(family, out);
+    const { stagingDir } = await newInstaller().install(family, out);
     const wm = createWorkdirManager({
       stagingDir,
       runOutputDir: out,

--- a/libraries/libeval/test/mock-apm-spawn.js
+++ b/libraries/libeval/test/mock-apm-spawn.js
@@ -1,0 +1,46 @@
+/**
+ * Test-only fake `spawn` for `ApmInstaller`. Returns a child-process-shaped
+ * EventEmitter that emits `close` with the configured exit code on the next
+ * tick. Tests inject this via `new ApmInstaller({ spawn: makeFakeApmSpawn() })`
+ * so the suite never shells out to a real `apm` binary.
+ *
+ * Intentionally a regular module (not a test file) so it can be imported by
+ * any test that needs to construct an installer.
+ */
+
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+/**
+ * @param {object} [opts]
+ * @param {number} [opts.exitCode=0] - Code emitted on `close`.
+ * @param {string} [opts.stderr=""] - Bytes written to the child's stderr.
+ * @param {Error} [opts.spawnError] - When set, emit `error` instead of `close`.
+ * @returns {(cmd: string, args: string[], opts: object) => object} fake spawn
+ */
+export function makeFakeApmSpawn({
+  exitCode = 0,
+  stderr = "",
+  spawnError,
+} = {}) {
+  const calls = [];
+  const fake = (cmd, args, options) => {
+    calls.push({ cmd, args, options });
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    queueMicrotask(() => {
+      if (spawnError) {
+        child.emit("error", spawnError);
+        return;
+      }
+      if (stderr) child.stderr.write(stderr);
+      child.stdout.end();
+      child.stderr.end();
+      child.emit("close", exitCode);
+    });
+    return child;
+  };
+  fake.calls = calls;
+  return fake;
+}


### PR DESCRIPTION
ApmInstaller now takes a `spawn` seam in its constructor; tests inject
a fake child process and never shell out to a real `apm` binary. Adds
a matching `installApm` test seam on BenchmarkRunner alongside the
existing runAgent/runScoring/runJudge hooks.

https://claude.ai/code/session_01LQPV9jx3qehsyoM2dDgZT3