### PR TITLE
feat(landmark): identity issuance — `fit-landmark login` + `fit-map auth issue`

### DIFF
--- a/.claude/skills/fit-landmark/SKILL.md
+++ b/.claude/skills/fit-landmark/SKILL.md
@@ -125,3 +125,5 @@ npx fit-landmark health                  # Should display team health overview
   — See where you stand against level expectations
 - [List Engineering Data Sources](https://www.forwardimpact.team/docs/products/engineering-data-sources/index.md)
   — List the activity rows retained about an engineer and their fall-off dates
+- [Sign In to Landmark](https://www.forwardimpact.team/docs/products/signing-in-to-landmark/index.md)
+  — Sign in via Supabase magic-link so commands resolve your identity automatically

--- a/.claude/skills/fit-map/SKILL.md
+++ b/.claude/skills/fit-map/SKILL.md
@@ -155,3 +155,5 @@ npx fit-map validate
   — File format reference for every entity type
 - [Provision Engineer Auth Users](https://www.forwardimpact.team/docs/products/provisioning-engineers/index.md)
   — Reconcile auth.users against the roster so identity-derived RLS works
+- [Issue Service-Account Tokens](https://www.forwardimpact.team/docs/products/issuing-service-account-tokens/index.md)
+  — Mint long-lived Supabase JWTs for unattended agents

--- a/bun.lock
+++ b/bun.lock
@@ -551,6 +551,7 @@
       },
       "devDependencies": {
         "@forwardimpact/libharness": "^0.1.14",
+        "@forwardimpact/libsecret": "^0.1.14",
       },
     },
     "products/map": {
@@ -561,6 +562,7 @@
       },
       "dependencies": {
         "@forwardimpact/libcli": "^0.1.0",
+        "@forwardimpact/libsecret": "^0.1.14",
         "@forwardimpact/libtemplate": "^0.2.0",
         "@forwardimpact/libutil": "^0.1.64",
         "@supabase/supabase-js": "^2.105.4",

--- a/libraries/libsecret/src/index.js
+++ b/libraries/libsecret/src/index.js
@@ -152,3 +152,54 @@ export function generateJWT(payload, secret) {
     .digest("base64url");
   return `${headerB64}.${payloadB64}.${signature}`;
 }
+
+/**
+ * Mint a Supabase-shaped HS256 JWT. Wraps generateJWT with the standard
+ * claims Supabase Auth expects on a caller token.
+ *
+ * @param {object} params
+ * @param {string} params.email - Caller email, becomes the `email` claim
+ * @param {string} params.secret - Supabase JWT secret (HMAC key)
+ * @param {number} [params.ttlSeconds] - Token lifetime in seconds
+ * @param {object} [params.claims] - Extra claims merged into the payload
+ * @returns {string} Signed JWT
+ */
+export function mintSupabaseJwt({
+  email,
+  secret,
+  ttlSeconds = 3600,
+  claims = {},
+}) {
+  if (!secret) throw new Error("mintSupabaseJwt: secret required");
+  if (!email) throw new Error("mintSupabaseJwt: email required");
+  const now = Math.floor(Date.now() / 1000);
+  return generateJWT(
+    {
+      role: "authenticated",
+      aud: "authenticated",
+      email,
+      sub: crypto.randomUUID(),
+      iss: "supabase",
+      iat: now,
+      exp: now + ttlSeconds,
+      ...claims,
+    },
+    secret,
+  );
+}
+
+/**
+ * Parse a duration string like "8760h", "365d", or "1y" into seconds.
+ * Accepted suffixes: h (hours), d (days, 86400s), y (years, 31536000s).
+ *
+ * @param {string} value
+ * @returns {number}
+ */
+export function parseDuration(value) {
+  const match = /^(\d+)([hdy])$/.exec(value);
+  if (!match) throw new Error(`parseDuration: invalid duration "${value}"`);
+  const n = Number(match[1]);
+  if (match[2] === "h") return n * 3600;
+  if (match[2] === "d") return n * 86400;
+  return n * 31536000;
+}

--- a/libraries/libsecret/test/libsecret.test.js
+++ b/libraries/libsecret/test/libsecret.test.js
@@ -15,6 +15,8 @@ import {
   generateSecret,
   generateBase64Secret,
   generateJWT,
+  mintSupabaseJwt,
+  parseDuration,
 } from "../src/index.js";
 
 describe("libsecret", () => {
@@ -164,6 +166,106 @@ describe("libsecret", () => {
       const jwt1 = generateJWT(payload, "secret-1");
       const jwt2 = generateJWT(payload, "secret-2");
       assert.notStrictEqual(jwt1, jwt2);
+    });
+  });
+
+  describe("mintSupabaseJwt", () => {
+    const secret = "supabase-test-secret";
+
+    test("mints a 3-part JWT with HS256 header and Supabase claims", () => {
+      const jwt = mintSupabaseJwt({ email: "alice@example.com", secret });
+      const [headerB64, payloadB64, sig] = jwt.split(".");
+      assert.ok(sig);
+
+      const header = JSON.parse(Buffer.from(headerB64, "base64url").toString());
+      assert.deepStrictEqual(header, { alg: "HS256", typ: "JWT" });
+
+      const payload = JSON.parse(
+        Buffer.from(payloadB64, "base64url").toString(),
+      );
+      assert.strictEqual(payload.email, "alice@example.com");
+      assert.strictEqual(payload.role, "authenticated");
+      assert.strictEqual(payload.aud, "authenticated");
+      assert.strictEqual(payload.iss, "supabase");
+      assert.strictEqual(typeof payload.sub, "string");
+      assert.strictEqual(typeof payload.iat, "number");
+      assert.strictEqual(payload.exp - payload.iat, 3600);
+    });
+
+    test("honours ttlSeconds", () => {
+      const jwt = mintSupabaseJwt({
+        email: "alice@example.com",
+        secret,
+        ttlSeconds: 60,
+      });
+      const payload = JSON.parse(
+        Buffer.from(jwt.split(".")[1], "base64url").toString(),
+      );
+      assert.strictEqual(payload.exp - payload.iat, 60);
+    });
+
+    test("merges extra claims", () => {
+      const jwt = mintSupabaseJwt({
+        email: "alice@example.com",
+        secret,
+        claims: { custom: "x" },
+      });
+      const payload = JSON.parse(
+        Buffer.from(jwt.split(".")[1], "base64url").toString(),
+      );
+      assert.strictEqual(payload.custom, "x");
+    });
+
+    test("signature verifies under the same secret", () => {
+      const jwt = mintSupabaseJwt({ email: "alice@example.com", secret });
+      const [h, p, s] = jwt.split(".");
+      const expected = createHmac("sha256", secret)
+        .update(`${h}.${p}`)
+        .digest("base64url");
+      assert.strictEqual(s, expected);
+    });
+
+    test("throws when secret missing", () => {
+      assert.throws(
+        () => mintSupabaseJwt({ email: "x@y", secret: "" }),
+        /secret required/,
+      );
+    });
+
+    test("throws when email missing", () => {
+      assert.throws(
+        () => mintSupabaseJwt({ email: "", secret }),
+        /email required/,
+      );
+    });
+  });
+
+  describe("parseDuration", () => {
+    test("parses hours", () => {
+      assert.strictEqual(parseDuration("1h"), 3600);
+      assert.strictEqual(parseDuration("24h"), 86400);
+    });
+
+    test("parses days", () => {
+      assert.strictEqual(parseDuration("1d"), 86400);
+      assert.strictEqual(parseDuration("365d"), 31536000);
+    });
+
+    test("parses years", () => {
+      assert.strictEqual(parseDuration("1y"), 31536000);
+      assert.strictEqual(parseDuration("2y"), 63072000);
+    });
+
+    test("rejects bare numbers", () => {
+      assert.throws(() => parseDuration("60"), /invalid duration/);
+    });
+
+    test("rejects unknown suffix", () => {
+      assert.throws(() => parseDuration("5m"), /invalid duration/);
+    });
+
+    test("rejects empty string", () => {
+      assert.throws(() => parseDuration(""), /invalid duration/);
     });
   });
 

--- a/libraries/libsyntheticgen/src/dsl/parser-blocks.js
+++ b/libraries/libsyntheticgen/src/dsl/parser-blocks.js
@@ -109,9 +109,28 @@ export function createBlockParsers(helpers) {
     return map;
   }
 
+  function parseServiceAccount() {
+    const id = parseStringOrIdent();
+    expect("LBRACE");
+    const sa = { id };
+    consumeFields(
+      {
+        name: () => {
+          sa.name = parseStringValue();
+        },
+        email: () => {
+          sa.email = parseStringValue();
+        },
+      },
+      "service_account",
+    );
+    expect("RBRACE");
+    return sa;
+  }
+
   function parsePeople() {
     expect("LBRACE");
-    const people = {};
+    const people = { service_accounts: [] };
     consumeFields(
       {
         count: () => {
@@ -128,6 +147,9 @@ export function createBlockParsers(helpers) {
         },
         archetypes: () => {
           people.archetypes = parsePeopleMap();
+        },
+        service_account: () => {
+          people.service_accounts.push(parseServiceAccount());
         },
       },
       "people",

--- a/libraries/libsyntheticgen/src/engine/entities.js
+++ b/libraries/libsyntheticgen/src/engine/entities.js
@@ -185,6 +185,14 @@ function generatePeople(ast, rng, teams, domain, logger) {
     );
   }
 
+  // Service-account rows declared in the DSL ride the same people array
+  // because that is the structure downstream renderers and ingestion
+  // already iterate. The `kind` discriminator keeps them distinguishable
+  // from human rows for filters and the DB check constraint.
+  for (const sa of ast.people.service_accounts ?? []) {
+    people.push(makeServiceAccount(sa, domain));
+  }
+
   return people;
 }
 
@@ -198,6 +206,7 @@ function makePerson(
   managerEmail,
   hireDate = "2023-01-15",
   archetype = "steady_contributor",
+  kind = "human",
 ) {
   const id = name.toLowerCase().replace(/\s+/g, "-");
   return {
@@ -215,6 +224,36 @@ function makePerson(
     manager_email: managerEmail,
     hire_date: hireDate,
     archetype,
+    kind,
+    iri: `https://${domain}/id/person/${id}`,
+  };
+}
+
+// Service-account rows share organization_people with humans but carry
+// no Pathway job profile. They keep the `kind`, `email`, `name`, and
+// `iri` fields filled; level / manager_email / team / department are
+// null because the DB check constraint enforces `level IS NULL` when
+// `kind = 'service_account'`.
+function makeServiceAccount(sa, domain) {
+  const id = sa.id.toLowerCase().replace(/[^a-z0-9-]+/g, "-");
+  const name = sa.name || sa.id;
+  const email = sa.email || `${id}@${domain}`.replace(/\s+/g, "-");
+  return {
+    id,
+    name,
+    email,
+    github: null,
+    github_username: null,
+    discipline: "system",
+    level: null,
+    track: null,
+    team_id: null,
+    department: null,
+    is_manager: false,
+    manager_email: null,
+    hire_date: null,
+    archetype: null,
+    kind: "service_account",
     iri: `https://${domain}/id/person/${id}`,
   };
 }

--- a/libraries/libsyntheticgen/test/dsl-service-accounts.test.js
+++ b/libraries/libsyntheticgen/test/dsl-service-accounts.test.js
@@ -1,0 +1,92 @@
+/**
+ * Coverage for the synthetic DSL's `service_account` sub-block under
+ * `people {}`. Asserts both the parser shape and the entity-generation
+ * pipeline (`kind="service_account"` rows, no level, no manager_email,
+ * discipline "system").
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { tokenize } from "../src/dsl/tokenizer.js";
+import { parse } from "../src/dsl/parser.js";
+import { buildEntities } from "../src/engine/entities.js";
+import { createSeededRNG } from "../src/engine/rng.js";
+
+function parseDsl(source) {
+  return parse(tokenize(source));
+}
+
+const MIN_DSL = (extra = "") => `terrain test {
+  domain "example.test"
+  seed 1
+  org acme { name "Acme" }
+  department core { team alpha { size 2 manager "Manager Alpha" } }
+  people {
+    count 2
+    names "greek"
+    distribution { mid 100% }
+    disciplines { backend 100% }
+    archetypes { steady_contributor 100% }
+    ${extra}
+  }
+}`;
+
+describe("DSL service_account block", () => {
+  test("parser collects service_account entries", () => {
+    const ast = parseDsl(
+      MIN_DSL(`
+        service_account "kata-agent-team" {
+          name "Kata Agent Team"
+          email "kata-agent-team@example.test"
+        }
+        service_account qa_bot { email "qa@example.test" }
+      `),
+    );
+    assert.equal(ast.people.service_accounts.length, 2);
+    assert.deepEqual(ast.people.service_accounts[0], {
+      id: "kata-agent-team",
+      name: "Kata Agent Team",
+      email: "kata-agent-team@example.test",
+    });
+    assert.equal(ast.people.service_accounts[1].id, "qa_bot");
+    assert.equal(ast.people.service_accounts[1].email, "qa@example.test");
+  });
+
+  test("parser defaults service_accounts to empty when absent", () => {
+    const ast = parseDsl(MIN_DSL());
+    assert.deepEqual(ast.people.service_accounts, []);
+  });
+
+  test("entity generator emits kind='service_account' rows", () => {
+    const ast = parseDsl(
+      MIN_DSL(`
+        service_account "kata-agent-team" {
+          name "Kata Agent Team"
+          email "kata-agent-team@example.test"
+        }
+      `),
+    );
+    const rng = createSeededRNG(`${ast.seed}:test`);
+    const { people } = buildEntities(ast, rng);
+
+    const sa = people.find((p) => p.kind === "service_account");
+    assert.ok(sa, "service_account row not generated");
+    assert.equal(sa.email, "kata-agent-team@example.test");
+    assert.equal(sa.name, "Kata Agent Team");
+    assert.equal(sa.level, null);
+    assert.equal(sa.manager_email, null);
+    assert.equal(sa.team_id, null);
+    assert.equal(sa.discipline, "system");
+  });
+
+  test("human rows default to kind='human'", () => {
+    const ast = parseDsl(MIN_DSL());
+    const rng = createSeededRNG(`${ast.seed}:test`);
+    const { people } = buildEntities(ast, rng);
+    assert.ok(people.length > 0);
+    for (const p of people) {
+      assert.equal(p.kind, "human");
+    }
+  });
+});

--- a/libraries/libsyntheticrender/src/render/raw.js
+++ b/libraries/libsyntheticrender/src/render/raw.js
@@ -365,7 +365,7 @@ function renderRoster(entities) {
     id: person.id,
     name: person.name,
     email: person.email,
-    github_username: person.github_username || person.github,
+    github_username: person.github_username || person.github || null,
     team: person.team_id,
     department: person.department,
     discipline: person.discipline,
@@ -375,6 +375,7 @@ function renderRoster(entities) {
     hire_date: person.hire_date,
     is_manager: person.is_manager || false,
     archetype: person.archetype || "steady_contributor",
+    kind: person.kind || "human",
   }));
 
   return YAML.stringify({ roster }, { lineWidth: 120 });

--- a/products/landmark/bin/fit-landmark.js
+++ b/products/landmark/bin/fit-landmark.js
@@ -26,6 +26,8 @@ import { runPracticedCommand } from "../src/commands/practiced.js";
 import { runHealthCommand } from "../src/commands/health.js";
 import { runVoiceCommand } from "../src/commands/voice.js";
 import { runSourcesCommand } from "../src/commands/sources.js";
+import { runLoginCommand } from "../src/commands/login.js";
+import { runLogoutCommand } from "../src/commands/logout.js";
 import { resolveDataDir } from "../src/lib/cli.js";
 import { buildContext } from "../src/lib/context.js";
 import { SupabaseUnavailableError } from "../src/lib/supabase.js";
@@ -58,6 +60,8 @@ const COMMANDS = {
   health: { handler: runHealthCommand, needsSupabase: true },
   voice: { handler: runVoiceCommand, needsSupabase: true },
   sources: { handler: runSourcesCommand, needsSupabase: true },
+  login: { handler: runLoginCommand, needsSupabase: false },
+  logout: { handler: runLogoutCommand, needsSupabase: false },
 };
 
 const definition = {
@@ -182,6 +186,21 @@ const definition = {
         },
       },
     },
+    {
+      name: "login",
+      description: "Sign in via Supabase magic-link (browser or --otp)",
+      options: {
+        email: { type: "string", description: "Email to sign in as" },
+        otp: {
+          type: "boolean",
+          description: "Skip the browser; prompt for the 6-digit code instead",
+        },
+      },
+    },
+    {
+      name: "logout",
+      description: "Delete the local credentials file",
+    },
   ],
   globalOptions: {
     data: { type: "string", description: "Path to Map data directory" },
@@ -238,6 +257,12 @@ const definition = {
       description:
         "List the activity rows retained about an engineer and their fall-off dates.",
     },
+    {
+      title: "Sign In to Landmark",
+      url: "https://www.forwardimpact.team/docs/products/signing-in-to-landmark/index.md",
+      description:
+        "Sign in via Supabase magic-link so commands resolve your identity automatically.",
+    },
   ],
 };
 
@@ -263,7 +288,7 @@ async function main() {
   try {
     const dataDir = resolveDataDir(values);
     let identity = null;
-    if (entry.needsSupabase) identity = resolveIdentity();
+    if (entry.needsSupabase) identity = await resolveIdentity();
     const ctx = await buildContext({
       dataDir,
       options: values,

--- a/products/landmark/package.json
+++ b/products/landmark/package.json
@@ -73,7 +73,8 @@
     "@supabase/supabase-js": "^2.105.4"
   },
   "devDependencies": {
-    "@forwardimpact/libharness": "^0.1.14"
+    "@forwardimpact/libharness": "^0.1.14",
+    "@forwardimpact/libsecret": "^0.1.14"
   },
   "engines": {
     "bun": ">=1.2.0",

--- a/products/landmark/src/commands/login.js
+++ b/products/landmark/src/commands/login.js
@@ -93,7 +93,27 @@ function persistSession(session, email, env) {
   );
 }
 
-function resolveAnonClient({ env, createClient }) {
+// In-process storage for the PKCE code verifier. supabase-js writes the
+// verifier here on `signInWithOtp` and reads it back on
+// `exchangeCodeForSession` — both calls run inside the same CLI process,
+// so a Map outlives the call sequence and dies when the process exits.
+// `persistSession: false` plus `autoRefreshToken: false` keep the client
+// from trying to write the session itself; we manage that via
+// `writeCredentials` once exchange succeeds.
+function createPkceStorage() {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+  };
+}
+
+function resolveAnonClient({ env, createClient, flowType = "implicit" }) {
   const url = env.MAP_SUPABASE_URL;
   const anonKey = env.MAP_SUPABASE_ANON_KEY;
   if (!url || !anonKey) {
@@ -103,7 +123,14 @@ function resolveAnonClient({ env, createClient }) {
         "from your Supabase project settings (hosted).",
     );
   }
-  return createClient(url, anonKey);
+  return createClient(url, anonKey, {
+    auth: {
+      flowType,
+      storage: createPkceStorage(),
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
 }
 
 /**
@@ -126,14 +153,19 @@ export async function runLoginCommand({
   if (!createClient) {
     ({ createClient } = await import("@supabase/supabase-js"));
   }
-  const client = resolveAnonClient({ env, createClient });
 
   const email = options.email ?? (await promptEmail(io));
   if (!email) throw new Error("fit-landmark login: email is required");
 
   if (options.otp) {
+    const client = resolveAnonClient({ env, createClient });
     return runOtpFlow({ client, email, io, env });
   }
+  // Browser flow needs PKCE so the magic-link redirect lands `?code=` (a
+  // query param the localhost listener can read) rather than the default
+  // implicit flow's `#access_token=...` URL fragment (which browsers strip
+  // before sending the request — making it invisible to the listener).
+  const client = resolveAnonClient({ env, createClient, flowType: "pkce" });
   return runBrowserFlow({ client, email, io, env, openListener });
 }
 
@@ -155,15 +187,21 @@ async function runBrowserFlow({ client, email, io, env, openListener }) {
       ".\n",
   );
 
-  const code = await Promise.race([
-    codePromise,
-    new Promise((_, rej) =>
-      setTimeout(
-        () => rej(new Error("login timed out after 5 minutes")),
-        DEFAULT_TIMEOUT_MS,
-      ),
-    ),
-  ]);
+  let timer;
+  const timeoutPromise = new Promise((_, rej) => {
+    timer = setTimeout(
+      () => rej(new Error("login timed out after 5 minutes")),
+      DEFAULT_TIMEOUT_MS,
+    );
+  });
+  let code;
+  try {
+    code = await Promise.race([codePromise, timeoutPromise]);
+  } finally {
+    // Unref so the timer never holds the event loop open past a fast
+    // successful login; clear so it doesn't fire after the fact either.
+    clearTimeout(timer);
+  }
 
   const { data, error: exchErr } =
     await client.auth.exchangeCodeForSession(code);

--- a/products/landmark/src/commands/login.js
+++ b/products/landmark/src/commands/login.js
@@ -1,0 +1,209 @@
+/**
+ * `fit-landmark login` — sign an engineer in via Supabase magic-link.
+ *
+ * Two modes:
+ *
+ *   - Browser flow (default): start a localhost listener; ask Supabase to
+ *     email a magic-link that redirects to the listener; capture the PKCE
+ *     `code` query param; exchange it for a session.
+ *
+ *   - OTP flow (`--otp`): ask Supabase to email a 6-digit code; prompt
+ *     for it on stdin; verify and persist the resulting session.
+ *
+ * Persistence lives in `products/landmark/src/lib/credentials.js`.
+ */
+
+import { createServer } from "node:http";
+import { createInterface } from "node:readline/promises";
+
+import { formatSuccess, formatBullet } from "@forwardimpact/libcli";
+
+import { writeCredentials } from "../lib/credentials.js";
+
+export const needsSupabase = false;
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes for the engineer to click.
+
+function startCallbackServer() {
+  let resolveCode, rejectCode;
+  const codePromise = new Promise((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url, "http://127.0.0.1");
+    const code = url.searchParams.get("code");
+    const error = url.searchParams.get("error_description");
+    if (error) {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end(`Login failed: ${error}`);
+      rejectCode(new Error(error));
+      server.close();
+      return;
+    }
+    if (!code) {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("Missing `code` query parameter.");
+      rejectCode(new Error("missing code"));
+      server.close();
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("Login successful. You can close this tab.");
+    server.close();
+    resolveCode(code);
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      resolve({ port, codePromise, close: () => server.close() });
+    });
+  });
+}
+
+async function promptEmail(io) {
+  const rl = createInterface({ input: io.stdin, output: io.stdout });
+  try {
+    return (await rl.question("Email: ")).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+async function promptOtp(io) {
+  const rl = createInterface({ input: io.stdin, output: io.stdout });
+  try {
+    return (await rl.question("Code: ")).trim();
+  } finally {
+    rl.close();
+  }
+}
+
+function persistSession(session, email, env) {
+  return writeCredentials(
+    {
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+      expires_at: Date.now() + (session.expires_in ?? 3600) * 1000,
+      email: session.user?.email ?? email,
+    },
+    env,
+  );
+}
+
+function resolveAnonClient({ env, createClient }) {
+  const url = env.MAP_SUPABASE_URL;
+  const anonKey = env.MAP_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "fit-landmark login: MAP_SUPABASE_URL and MAP_SUPABASE_ANON_KEY " +
+        "must be set. Run `fit-map activity start` (local) or copy them " +
+        "from your Supabase project settings (hosted).",
+    );
+  }
+  return createClient(url, anonKey);
+}
+
+/**
+ * Run the login command.
+ *
+ * @param {object} params
+ * @param {{email?:string, otp?:boolean}} params.options
+ * @param {{stdin?:NodeJS.ReadableStream,stdout?:NodeJS.WritableStream}} [params.io]
+ * @param {NodeJS.ProcessEnv} [params.env]
+ * @param {(url:string,key:string)=>any} [params.createClient]
+ * @param {() => Promise<{port:number,codePromise:Promise<string>,close:()=>void}>} [params.openListener]
+ */
+export async function runLoginCommand({
+  options = {},
+  io = { stdin: process.stdin, stdout: process.stdout },
+  env = process.env,
+  createClient,
+  openListener = startCallbackServer,
+} = {}) {
+  if (!createClient) {
+    ({ createClient } = await import("@supabase/supabase-js"));
+  }
+  const client = resolveAnonClient({ env, createClient });
+
+  const email = options.email ?? (await promptEmail(io));
+  if (!email) throw new Error("fit-landmark login: email is required");
+
+  if (options.otp) {
+    return runOtpFlow({ client, email, io, env });
+  }
+  return runBrowserFlow({ client, email, io, env, openListener });
+}
+
+async function runBrowserFlow({ client, email, io, env, openListener }) {
+  const { port, codePromise } = await openListener();
+  const redirectTo = `http://127.0.0.1:${port}/cb`;
+  const { error } = await client.auth.signInWithOtp({
+    email,
+    options: { emailRedirectTo: redirectTo, shouldCreateUser: false },
+  });
+  if (error) throw new Error(`signInWithOtp: ${error.message}`);
+
+  io.stdout.write(
+    "Sent a magic link to " +
+      email +
+      ".\nOpen the email on this machine and click the link — the CLI is " +
+      "listening on 127.0.0.1:" +
+      port +
+      ".\n",
+  );
+
+  const code = await Promise.race([
+    codePromise,
+    new Promise((_, rej) =>
+      setTimeout(
+        () => rej(new Error("login timed out after 5 minutes")),
+        DEFAULT_TIMEOUT_MS,
+      ),
+    ),
+  ]);
+
+  const { data, error: exchErr } =
+    await client.auth.exchangeCodeForSession(code);
+  if (exchErr) throw new Error(`exchangeCodeForSession: ${exchErr.message}`);
+  if (!data?.session)
+    throw new Error("exchangeCodeForSession returned no session");
+
+  await persistSession(data.session, email, env);
+  io.stdout.write(
+    formatSuccess(`Logged in as ${data.user?.email ?? email}.`) + "\n",
+  );
+  return { meta: { ok: true }, summary: { email: data.user?.email ?? email } };
+}
+
+async function runOtpFlow({ client, email, io, env }) {
+  const { error } = await client.auth.signInWithOtp({
+    email,
+    options: { shouldCreateUser: false },
+  });
+  if (error) throw new Error(`signInWithOtp: ${error.message}`);
+  io.stdout.write(
+    formatBullet(`Sent a 6-digit code to ${email}. Paste it below.`, 0) + "\n",
+  );
+
+  const token = await promptOtp(io);
+  if (!/^\d{6}$/.test(token)) {
+    throw new Error("fit-landmark login: code must be 6 digits");
+  }
+
+  const { data, error: verifyErr } = await client.auth.verifyOtp({
+    email,
+    token,
+    type: "email",
+  });
+  if (verifyErr) throw new Error(`verifyOtp: ${verifyErr.message}`);
+  if (!data?.session) throw new Error("verifyOtp returned no session");
+
+  await persistSession(data.session, email, env);
+  io.stdout.write(
+    formatSuccess(`Logged in as ${data.user?.email ?? email}.`) + "\n",
+  );
+  return { meta: { ok: true }, summary: { email: data.user?.email ?? email } };
+}

--- a/products/landmark/src/commands/logout.js
+++ b/products/landmark/src/commands/logout.js
@@ -1,0 +1,31 @@
+/**
+ * `fit-landmark logout` — delete the credentials store written by
+ * `fit-landmark login`. A no-op when no session is present.
+ */
+
+import { formatSuccess } from "@forwardimpact/libcli";
+
+import { clearCredentials, readCredentials } from "../lib/credentials.js";
+
+export const needsSupabase = false;
+
+/**
+ * Run the logout command.
+ *
+ * @param {object} [params]
+ * @param {{stdout?:NodeJS.WritableStream}} [params.io]
+ * @param {NodeJS.ProcessEnv} [params.env]
+ */
+export async function runLogoutCommand({
+  io = { stdout: process.stdout },
+  env = process.env,
+} = {}) {
+  const creds = await readCredentials(env);
+  if (!creds) {
+    io.stdout.write("Already logged out.\n");
+    return { meta: { ok: true }, summary: { previousEmail: null } };
+  }
+  await clearCredentials(env);
+  io.stdout.write(formatSuccess(`Logged out ${creds.email}.`) + "\n");
+  return { meta: { ok: true }, summary: { previousEmail: creds.email } };
+}

--- a/products/landmark/src/formatters/index.js
+++ b/products/landmark/src/formatters/index.js
@@ -18,6 +18,16 @@ import * as practicedFormatter from "./practiced.js";
 import * as healthFormatter from "./health.js";
 import * as voiceFormatter from "./voice.js";
 import * as sourcesFormatter from "./sources.js";
+
+// Login and logout write their UX directly to stdout; the dispatcher's
+// formatResult() pass would otherwise dump the {meta,summary} result on
+// top of the human-readable lines. A silent formatter sidesteps that.
+const silent = {
+  toText: () => "",
+  toJson: (_, meta) => JSON.stringify({ meta }, null, 2),
+  toMarkdown: () => "",
+};
+
 const formatters = {
   org: orgFormatter,
   snapshot: snapshotFormatter,
@@ -31,6 +41,8 @@ const formatters = {
   health: healthFormatter,
   voice: voiceFormatter,
   sources: sourcesFormatter,
+  login: silent,
+  logout: silent,
 };
 
 /**

--- a/products/landmark/src/lib/credentials.js
+++ b/products/landmark/src/lib/credentials.js
@@ -2,14 +2,14 @@
  * Per-user credentials store for the Landmark CLI.
  *
  * Persists a Supabase session ({access_token, refresh_token, expires_at,
- * email}) at an XDG-aware location with 0600 permissions:
+ * email}) at a per-platform location with 0600 permissions:
  *
- *   - $XDG_CONFIG_HOME/landmark/credentials.json (if XDG_CONFIG_HOME is set)
- *   - $HOME/.config/landmark/credentials.json   (Linux / macOS default)
- *   - %APPDATA%/landmark/credentials.json       (Windows)
- *
- * The path is overridable via `$LANDMARK_CREDENTIALS_FILE` for tests and
- * uncommon deployments.
+ *   - $LANDMARK_CREDENTIALS_FILE                              (override)
+ *   - $XDG_CONFIG_HOME/landmark/credentials.json              (XDG override)
+ *   - %APPDATA%/landmark/credentials.json                     (Windows)
+ *   - $HOME/Library/Application Support/landmark/             (macOS)
+ *     credentials.json
+ *   - $HOME/.config/landmark/credentials.json                 (Linux + other)
  *
  * No dependency on libconfig: that library's "config" bucket is rooted at
  * the codebase's config/ directory, which is right for internal contributors
@@ -23,13 +23,24 @@ import os from "node:os";
 const FILE_NAME = "credentials.json";
 const NAMESPACE = "landmark";
 
-/** Resolve the credentials file path with XDG precedence. */
+/** Resolve the credentials file path with per-platform precedence. */
 export function credentialsPath(env = process.env) {
   if (env.LANDMARK_CREDENTIALS_FILE) return env.LANDMARK_CREDENTIALS_FILE;
+  // XDG_CONFIG_HOME is honoured on every platform so a power user can
+  // override the native default. It is set on Linux by default and
+  // sometimes set on macOS by users running Homebrew-style configs.
   const xdg = env.XDG_CONFIG_HOME;
   if (xdg) return path.join(xdg, NAMESPACE, FILE_NAME);
   if (process.platform === "win32" && env.APPDATA)
     return path.join(env.APPDATA, NAMESPACE, FILE_NAME);
+  if (process.platform === "darwin")
+    return path.join(
+      os.homedir(),
+      "Library",
+      "Application Support",
+      NAMESPACE,
+      FILE_NAME,
+    );
   return path.join(os.homedir(), ".config", NAMESPACE, FILE_NAME);
 }
 

--- a/products/landmark/src/lib/credentials.js
+++ b/products/landmark/src/lib/credentials.js
@@ -1,0 +1,72 @@
+/**
+ * Per-user credentials store for the Landmark CLI.
+ *
+ * Persists a Supabase session ({access_token, refresh_token, expires_at,
+ * email}) at an XDG-aware location with 0600 permissions:
+ *
+ *   - $XDG_CONFIG_HOME/landmark/credentials.json (if XDG_CONFIG_HOME is set)
+ *   - $HOME/.config/landmark/credentials.json   (Linux / macOS default)
+ *   - %APPDATA%/landmark/credentials.json       (Windows)
+ *
+ * The path is overridable via `$LANDMARK_CREDENTIALS_FILE` for tests and
+ * uncommon deployments.
+ *
+ * No dependency on libconfig: that library's "config" bucket is rooted at
+ * the codebase's config/ directory, which is right for internal contributors
+ * but wrong for external `npx fit-landmark` users.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const FILE_NAME = "credentials.json";
+const NAMESPACE = "landmark";
+
+/** Resolve the credentials file path with XDG precedence. */
+export function credentialsPath(env = process.env) {
+  if (env.LANDMARK_CREDENTIALS_FILE) return env.LANDMARK_CREDENTIALS_FILE;
+  const xdg = env.XDG_CONFIG_HOME;
+  if (xdg) return path.join(xdg, NAMESPACE, FILE_NAME);
+  if (process.platform === "win32" && env.APPDATA)
+    return path.join(env.APPDATA, NAMESPACE, FILE_NAME);
+  return path.join(os.homedir(), ".config", NAMESPACE, FILE_NAME);
+}
+
+/** Read the persisted session; returns null when no file exists. */
+export async function readCredentials(env = process.env) {
+  const file = credentialsPath(env);
+  try {
+    const raw = await fs.readFile(file, "utf8");
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/**
+ * Persist the session. Always writes with 0600 so the access/refresh
+ * tokens are owner-readable only.
+ *
+ * @param {{access_token:string, refresh_token:string, expires_at:number, email:string}} creds
+ * @param {NodeJS.ProcessEnv} [env]
+ */
+export async function writeCredentials(creds, env = process.env) {
+  const file = credentialsPath(env);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const body = JSON.stringify(creds, null, 2);
+  await fs.writeFile(file, body + "\n", { mode: 0o600 });
+  // writeFile's mode only applies on creation; chmod covers the update path.
+  if (process.platform !== "win32") await fs.chmod(file, 0o600);
+}
+
+/** Delete the persisted session; no-op if it does not exist. */
+export async function clearCredentials(env = process.env) {
+  const file = credentialsPath(env);
+  try {
+    await fs.unlink(file);
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+}

--- a/products/landmark/src/lib/identity.js
+++ b/products/landmark/src/lib/identity.js
@@ -1,5 +1,11 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+import {
+  readCredentials,
+  writeCredentials,
+  clearCredentials,
+} from "./credentials.js";
+
 /** Thrown when no usable caller identity can be derived from the env. */
 export class IdentityUnresolvedError extends Error {
   /** Wrap the reason in a prefixed message and attach code "LANDMARK_IDENTITY_UNRESOLVED". */
@@ -12,6 +18,10 @@ export class IdentityUnresolvedError extends Error {
 // HS256 HMAC-SHA256 digest is fixed at 32 bytes; reject any signature whose
 // decoded length deviates before invoking timingSafeEqual.
 const HS256_DIGEST_BYTES = 32;
+
+// Refresh slightly before the access token's expires_at so a long-running
+// command never trips PostgREST's own clock-skew check mid-batch.
+const REFRESH_LEAD_MS = 60_000;
 
 /** Decode a JWT segment as JSON; throws IdentityUnresolvedError on failure. */
 function parseJwtSegment(seg, label) {
@@ -33,26 +43,17 @@ function parseJwtSegment(seg, label) {
 }
 
 /**
- * Resolve the caller's identity from a Supabase Auth JWT in
- * `LANDMARK_AUTH_TOKEN`.
- *
- * @param {NodeJS.ProcessEnv} [env]
- * @returns {{email: string, jwt: string}}
- * @throws {IdentityUnresolvedError}
+ * Validate the structure, expiry, and (when the secret is available)
+ * HMAC of `LANDMARK_AUTH_TOKEN`. Returns the resolved identity. The
+ * production engineer-side path runs without the secret — the JWT is
+ * trusted at the shape level, and Postgres rejects forgeries at the
+ * RLS clamp on the next round trip.
  */
-export function resolveIdentity(env = process.env) {
-  const jwt = env.LANDMARK_AUTH_TOKEN;
-  if (!jwt)
-    throw new IdentityUnresolvedError(
-      "LANDMARK_AUTH_TOKEN is not set. The Landmark CLI requires an authenticated caller.",
-    );
+function resolveFromJwt(jwt, env) {
   const parts = jwt.split(".");
   if (parts.length !== 3)
     throw new IdentityUnresolvedError("LANDMARK_AUTH_TOKEN is not a JWT");
 
-  // Header must announce HS256 + JWT — never trust an `alg: none` token,
-  // even if PostgREST would also reject it; we want the failure surface
-  // here so downstream code never sees a forged email.
   const header = parseJwtSegment(parts[0], "header");
   if (header.alg !== "HS256" || header.typ !== "JWT")
     throw new IdentityUnresolvedError(
@@ -67,11 +68,6 @@ export function resolveIdentity(env = process.env) {
   if (typeof claims.exp !== "number" || claims.exp * 1000 <= Date.now())
     throw new IdentityUnresolvedError("LANDMARK_AUTH_TOKEN is expired");
 
-  // Defense in depth: when MAP_SUPABASE_JWT_SECRET is available (test
-  // harness, local dev) verify the HMAC ourselves before trusting any
-  // claim. Production engineer-side callers will not have the secret;
-  // for them the contract is that `email` is opaque until the first
-  // PostgREST round-trip succeeds — never log or branch on it before.
   if (env.MAP_SUPABASE_JWT_SECRET) {
     const actual = Buffer.from(parts[2], "base64url");
     if (actual.length !== HS256_DIGEST_BYTES)
@@ -87,4 +83,79 @@ export function resolveIdentity(env = process.env) {
       );
   }
   return { email: claims.email, jwt };
+}
+
+/**
+ * Refresh an expiring session via Supabase Auth's refresh endpoint and
+ * persist the new tokens. On failure, clear the store and throw with a
+ * "run login" prompt — a stale refresh token cannot recover itself.
+ *
+ * @param {{access_token:string,refresh_token:string,expires_at:number,email:string}} creds
+ * @param {NodeJS.ProcessEnv} env
+ * @param {(url:string,key:string) => any} createClient
+ */
+async function refreshSession(creds, env, createClient) {
+  const url = env.MAP_SUPABASE_URL;
+  const anonKey = env.MAP_SUPABASE_ANON_KEY;
+  if (!url || !anonKey)
+    throw new IdentityUnresolvedError(
+      "session refresh needs MAP_SUPABASE_URL and MAP_SUPABASE_ANON_KEY",
+    );
+  const sb = createClient(url, anonKey);
+  const { data, error } = await sb.auth.refreshSession({
+    refresh_token: creds.refresh_token,
+  });
+  if (error || !data?.session) {
+    await clearCredentials(env);
+    throw new IdentityUnresolvedError(
+      "session expired and refresh failed — run `fit-landmark login` again",
+    );
+  }
+  const next = {
+    access_token: data.session.access_token,
+    refresh_token: data.session.refresh_token ?? creds.refresh_token,
+    expires_at: Date.now() + (data.session.expires_in ?? 3600) * 1000,
+    email: data.user?.email ?? creds.email,
+  };
+  await writeCredentials(next, env);
+  return next;
+}
+
+/**
+ * Resolve the caller's identity. Precedence:
+ *
+ *   1. `LANDMARK_AUTH_TOKEN` — env override (CI, signTestToken, operator-
+ *      issued long-lived tokens). The JWT is validated for shape and
+ *      (when the JWT secret is available) signature, then returned as-is.
+ *   2. Credentials store — populated by `fit-landmark login`. If the
+ *      access token has expired (or is within REFRESH_LEAD_MS of doing so),
+ *      attempt a Supabase refresh and persist the result.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {{createClient?: (url:string,key:string)=>any}} [opts]
+ * @returns {Promise<{email: string, jwt: string}>}
+ * @throws {IdentityUnresolvedError}
+ */
+export async function resolveIdentity(env = process.env, opts = {}) {
+  if (env.LANDMARK_AUTH_TOKEN) {
+    return resolveFromJwt(env.LANDMARK_AUTH_TOKEN, env);
+  }
+
+  const creds = await readCredentials(env);
+  if (!creds)
+    throw new IdentityUnresolvedError(
+      "no session found — run `fit-landmark login`",
+    );
+
+  if (
+    typeof creds.expires_at === "number" &&
+    Date.now() >= creds.expires_at - REFRESH_LEAD_MS
+  ) {
+    const createClient =
+      opts.createClient ?? (await import("@supabase/supabase-js")).createClient;
+    const refreshed = await refreshSession(creds, env, createClient);
+    return { email: refreshed.email, jwt: refreshed.access_token };
+  }
+
+  return { email: creds.email, jwt: creds.access_token };
 }

--- a/products/landmark/test/commands/login.test.js
+++ b/products/landmark/test/commands/login.test.js
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for `fit-landmark login` — covers both flows by injecting
+ * a fake Supabase client and (for the browser flow) a fake localhost
+ * listener so the test never touches a real network.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { runLoginCommand } from "../../src/commands/login.js";
+import { readCredentials } from "../../src/lib/credentials.js";
+
+function makeIo({ otp } = {}) {
+  const chunks = [];
+  return {
+    io: {
+      stdin: otp ? makeStdinFor(otp) : null,
+      stdout: {
+        write: (s) => {
+          chunks.push(s);
+          return true;
+        },
+      },
+    },
+    text: () => chunks.join(""),
+  };
+}
+
+function makeStdinFor(line) {
+  // node:readline/promises reads until EOL. A Readable that emits the line
+  // and then closes is enough — readline's question() resolves on first
+  // line break or end-of-stream.
+  const { Readable } = require("node:stream");
+  const stream = Readable.from([`${line}\n`]);
+  return stream;
+}
+
+function makeSupabaseStub({ session, onOtp, onVerify, onExchange } = {}) {
+  return {
+    auth: {
+      async signInWithOtp(opts) {
+        if (onOtp) onOtp(opts);
+        return { data: {}, error: null };
+      },
+      async verifyOtp(opts) {
+        if (onVerify) onVerify(opts);
+        return {
+          data: { session, user: { email: opts.email } },
+          error: null,
+        };
+      },
+      async exchangeCodeForSession(code) {
+        if (onExchange) onExchange(code);
+        return {
+          data: {
+            session,
+            user: { email: session?.email ?? "captured@example.com" },
+          },
+          error: null,
+        };
+      },
+    },
+  };
+}
+
+const okSession = {
+  access_token: "ACCESS",
+  refresh_token: "REFRESH",
+  expires_in: 3600,
+  email: "alice@example.com",
+};
+
+describe("runLoginCommand — OTP flow", () => {
+  let tempDir;
+  let env;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "landmark-login-"));
+    env = {
+      LANDMARK_CREDENTIALS_FILE: path.join(tempDir, "credentials.json"),
+      MAP_SUPABASE_URL: "http://supabase.local",
+      MAP_SUPABASE_ANON_KEY: "anon",
+    };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("verifies the OTP, persists the session, and prints the email", async () => {
+    let otpArgs, verifyArgs;
+    const stub = makeSupabaseStub({
+      session: okSession,
+      onOtp: (a) => (otpArgs = a),
+      onVerify: (a) => (verifyArgs = a),
+    });
+    const { io, text } = makeIo({ otp: "123456" });
+    const result = await runLoginCommand({
+      options: { email: "alice@example.com", otp: true },
+      io,
+      env,
+      createClient: () => stub,
+    });
+    assert.equal(otpArgs.email, "alice@example.com");
+    assert.equal(verifyArgs.email, "alice@example.com");
+    assert.equal(verifyArgs.token, "123456");
+    assert.equal(verifyArgs.type, "email");
+
+    const persisted = await readCredentials(env);
+    assert.equal(persisted.access_token, "ACCESS");
+    assert.equal(persisted.refresh_token, "REFRESH");
+    assert.equal(persisted.email, "alice@example.com");
+    assert.ok(persisted.expires_at > Date.now());
+    assert.match(text(), /Logged in as alice@example\.com/);
+    assert.equal(result.meta.ok, true);
+  });
+
+  test("rejects a non-6-digit code", async () => {
+    const stub = makeSupabaseStub({ session: okSession });
+    const { io } = makeIo({ otp: "abc" });
+    await assert.rejects(
+      () =>
+        runLoginCommand({
+          options: { email: "alice@example.com", otp: true },
+          io,
+          env,
+          createClient: () => stub,
+        }),
+      /code must be 6 digits/,
+    );
+  });
+});
+
+describe("runLoginCommand — browser flow", () => {
+  let tempDir;
+  let env;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "landmark-login-"));
+    env = {
+      LANDMARK_CREDENTIALS_FILE: path.join(tempDir, "credentials.json"),
+      MAP_SUPABASE_URL: "http://supabase.local",
+      MAP_SUPABASE_ANON_KEY: "anon",
+    };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("captures ?code at the listener and exchanges it for a session", async () => {
+    let otpArgs, exchanged;
+    const stub = makeSupabaseStub({
+      session: okSession,
+      onOtp: (a) => (otpArgs = a),
+      onExchange: (c) => (exchanged = c),
+    });
+
+    const listener = () =>
+      Promise.resolve({
+        port: 54321,
+        codePromise: Promise.resolve("the-code"),
+        close: () => {},
+      });
+
+    const { io, text } = makeIo();
+    const result = await runLoginCommand({
+      options: { email: "alice@example.com" },
+      io,
+      env,
+      createClient: () => stub,
+      openListener: listener,
+    });
+
+    assert.equal(otpArgs.options.emailRedirectTo, "http://127.0.0.1:54321/cb");
+    assert.equal(exchanged, "the-code");
+    const persisted = await readCredentials(env);
+    assert.equal(persisted.access_token, "ACCESS");
+    assert.match(text(), /Logged in as alice@example\.com/);
+    assert.equal(result.summary.email, "alice@example.com");
+  });
+
+  test("rejects when MAP_SUPABASE_URL is missing", async () => {
+    await assert.rejects(
+      () =>
+        runLoginCommand({
+          options: { email: "alice@example.com" },
+          io: makeIo().io,
+          env: { LANDMARK_CREDENTIALS_FILE: env.LANDMARK_CREDENTIALS_FILE },
+          createClient: () => makeSupabaseStub({}),
+        }),
+      /MAP_SUPABASE_URL and MAP_SUPABASE_ANON_KEY/,
+    );
+  });
+});

--- a/products/landmark/test/commands/login.test.js
+++ b/products/landmark/test/commands/login.test.js
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { Readable } from "node:stream";
 
 import { runLoginCommand } from "../../src/commands/login.js";
 import { readCredentials } from "../../src/lib/credentials.js";
@@ -33,9 +34,7 @@ function makeStdinFor(line) {
   // node:readline/promises reads until EOL. A Readable that emits the line
   // and then closes is enough — readline's question() resolves on first
   // line break or end-of-stream.
-  const { Readable } = require("node:stream");
-  const stream = Readable.from([`${line}\n`]);
-  return stream;
+  return Readable.from([`${line}\n`]);
 }
 
 function makeSupabaseStub({ session, onOtp, onVerify, onExchange } = {}) {

--- a/products/landmark/test/commands/logout.test.js
+++ b/products/landmark/test/commands/logout.test.js
@@ -1,0 +1,80 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { runLogoutCommand } from "../../src/commands/logout.js";
+import {
+  writeCredentials,
+  readCredentials,
+} from "../../src/lib/credentials.js";
+
+function makeIo() {
+  const chunks = [];
+  return {
+    io: {
+      stdout: {
+        write: (s) => {
+          chunks.push(s);
+          return true;
+        },
+      },
+    },
+    text: () => chunks.join(""),
+  };
+}
+
+describe("runLogoutCommand", () => {
+  let tempDir;
+  let env;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "landmark-logout-"));
+    env = { LANDMARK_CREDENTIALS_FILE: path.join(tempDir, "credentials.json") };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("no-op when no session present", async () => {
+    const { io, text } = makeIo();
+    const result = await runLogoutCommand({ io, env });
+    assert.match(text(), /Already logged out/);
+    assert.equal(result.summary.previousEmail, null);
+  });
+
+  test("deletes the credentials file and reports the previous email", async () => {
+    await writeCredentials(
+      {
+        access_token: "a",
+        refresh_token: "r",
+        expires_at: Date.now() + 3600_000,
+        email: "alice@example.com",
+      },
+      env,
+    );
+    const { io, text } = makeIo();
+    const result = await runLogoutCommand({ io, env });
+    assert.match(text(), /Logged out alice@example\.com/);
+    assert.equal(result.summary.previousEmail, "alice@example.com");
+    assert.equal(await readCredentials(env), null);
+  });
+
+  test("second logout is a no-op", async () => {
+    await writeCredentials(
+      {
+        access_token: "a",
+        refresh_token: "r",
+        expires_at: 0,
+        email: "x@y",
+      },
+      env,
+    );
+    await runLogoutCommand({ io: makeIo().io, env });
+    const { io, text } = makeIo();
+    await runLogoutCommand({ io, env });
+    assert.match(text(), /Already logged out/);
+  });
+});

--- a/products/landmark/test/dispatcher.test.js
+++ b/products/landmark/test/dispatcher.test.js
@@ -36,14 +36,15 @@ function run(args, env) {
 }
 
 describe("fit-landmark dispatcher exit codes", () => {
-  test("exits 4 when LANDMARK_AUTH_TOKEN is missing on a Supabase-using command", () => {
-    const res = run(
-      ["voice", "--email", "a@b.example", "--data", DATA_DIR],
-      {},
-    );
+  test("exits 4 when no identity can be resolved on a Supabase-using command", () => {
+    const res = run(["voice", "--email", "a@b.example", "--data", DATA_DIR], {
+      // Point the credentials store at a guaranteed-absent file so the
+      // store fallback does not pick up a real engineer's session.
+      LANDMARK_CREDENTIALS_FILE: "/nonexistent/landmark-creds.json",
+    });
     assert.equal(res.status, 4);
     assert.match(res.stderr, /Authentication required/);
-    assert.match(res.stderr, /LANDMARK_AUTH_TOKEN/);
+    assert.match(res.stderr, /fit-landmark login/);
   });
 
   test("exits 3 when token present but MAP_SUPABASE_URL is unset", () => {

--- a/products/landmark/test/lib/credentials.test.js
+++ b/products/landmark/test/lib/credentials.test.js
@@ -40,13 +40,26 @@ describe("landmark credentials store", () => {
     );
   });
 
-  test("credentialsPath falls back to ~/.config/landmark/credentials.json", () => {
+  test("credentialsPath falls back to the platform-native location", () => {
     const env = {};
     if (process.platform === "win32") return; // covered by APPDATA branch
-    assert.equal(
-      credentialsPath(env),
-      path.join(os.homedir(), ".config", "landmark", "credentials.json"),
-    );
+    if (process.platform === "darwin") {
+      assert.equal(
+        credentialsPath(env),
+        path.join(
+          os.homedir(),
+          "Library",
+          "Application Support",
+          "landmark",
+          "credentials.json",
+        ),
+      );
+    } else {
+      assert.equal(
+        credentialsPath(env),
+        path.join(os.homedir(), ".config", "landmark", "credentials.json"),
+      );
+    }
   });
 
   test("read returns null when file missing", async () => {

--- a/products/landmark/test/lib/credentials.test.js
+++ b/products/landmark/test/lib/credentials.test.js
@@ -1,0 +1,132 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  credentialsPath,
+  readCredentials,
+  writeCredentials,
+  clearCredentials,
+} from "../../src/lib/credentials.js";
+
+function makeEnv(file) {
+  return { LANDMARK_CREDENTIALS_FILE: file };
+}
+
+describe("landmark credentials store", () => {
+  let tempDir;
+  let file;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "landmark-creds-"));
+    file = path.join(tempDir, "credentials.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("credentialsPath honours LANDMARK_CREDENTIALS_FILE override", () => {
+    assert.equal(credentialsPath(makeEnv(file)), file);
+  });
+
+  test("credentialsPath honours XDG_CONFIG_HOME", () => {
+    const env = { XDG_CONFIG_HOME: "/tmp/xdg" };
+    assert.equal(
+      credentialsPath(env),
+      path.join("/tmp/xdg", "landmark", "credentials.json"),
+    );
+  });
+
+  test("credentialsPath falls back to ~/.config/landmark/credentials.json", () => {
+    const env = {};
+    if (process.platform === "win32") return; // covered by APPDATA branch
+    assert.equal(
+      credentialsPath(env),
+      path.join(os.homedir(), ".config", "landmark", "credentials.json"),
+    );
+  });
+
+  test("read returns null when file missing", async () => {
+    const result = await readCredentials(makeEnv(file));
+    assert.equal(result, null);
+  });
+
+  test("write + read round-trips", async () => {
+    const creds = {
+      access_token: "a",
+      refresh_token: "r",
+      expires_at: 1_700_000_000_000,
+      email: "alice@example.com",
+    };
+    await writeCredentials(creds, makeEnv(file));
+
+    const read = await readCredentials(makeEnv(file));
+    assert.deepEqual(read, creds);
+  });
+
+  test("write creates parent directories", async () => {
+    const nested = path.join(tempDir, "a", "b", "credentials.json");
+    await writeCredentials(
+      {
+        access_token: "a",
+        refresh_token: "r",
+        expires_at: 0,
+        email: "x@y",
+      },
+      makeEnv(nested),
+    );
+    const stat = await fs.stat(nested);
+    assert.ok(stat.isFile());
+  });
+
+  test("write enforces 0600 mode on POSIX", async () => {
+    if (process.platform === "win32") return;
+    await writeCredentials(
+      {
+        access_token: "a",
+        refresh_token: "r",
+        expires_at: 0,
+        email: "x@y",
+      },
+      makeEnv(file),
+    );
+    const stat = await fs.stat(file);
+    assert.equal(stat.mode & 0o777, 0o600);
+  });
+
+  test("write tightens permissions on update", async () => {
+    if (process.platform === "win32") return;
+    const creds = {
+      access_token: "a",
+      refresh_token: "r",
+      expires_at: 0,
+      email: "x@y",
+    };
+    await writeCredentials(creds, makeEnv(file));
+    await fs.chmod(file, 0o644);
+    await writeCredentials(creds, makeEnv(file));
+    const stat = await fs.stat(file);
+    assert.equal(stat.mode & 0o777, 0o600);
+  });
+
+  test("clear removes the file", async () => {
+    await writeCredentials(
+      {
+        access_token: "a",
+        refresh_token: "r",
+        expires_at: 0,
+        email: "x@y",
+      },
+      makeEnv(file),
+    );
+    await clearCredentials(makeEnv(file));
+    assert.equal(await readCredentials(makeEnv(file)), null);
+  });
+
+  test("clear is a no-op when file missing", async () => {
+    await assert.doesNotReject(() => clearCredentials(makeEnv(file)));
+  });
+});

--- a/products/landmark/test/lib/identity.test.js
+++ b/products/landmark/test/lib/identity.test.js
@@ -1,11 +1,18 @@
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { createHmac } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
 import {
   IdentityUnresolvedError,
   resolveIdentity,
 } from "../../src/lib/identity.js";
+import {
+  writeCredentials,
+  readCredentials,
+} from "../../src/lib/credentials.js";
 import { signTestToken } from "./sign-test-token.js";
 
 const SECRET = "test-secret-do-not-reuse";
@@ -14,26 +21,25 @@ function envWith(overrides = {}) {
   return { ...overrides };
 }
 
-describe("resolveIdentity", () => {
-  it("throws when LANDMARK_AUTH_TOKEN is missing", () => {
-    assert.throws(() => resolveIdentity(envWith()), IdentityUnresolvedError);
-    try {
-      resolveIdentity(envWith());
-    } catch (err) {
-      assert.equal(err.code, "LANDMARK_IDENTITY_UNRESOLVED");
-      assert.match(err.message, /LANDMARK_AUTH_TOKEN is not set/);
-    }
+describe("resolveIdentity — env-only path", () => {
+  it("rejects when neither LANDMARK_AUTH_TOKEN nor a session is set", async () => {
+    const env = envWith({ LANDMARK_CREDENTIALS_FILE: "/nonexistent/file" });
+    await assert.rejects(() => resolveIdentity(env), IdentityUnresolvedError);
+    await assert.rejects(
+      () => resolveIdentity(env),
+      /run `fit-landmark login`/,
+    );
   });
 
-  it("throws on a non-JWT shape", () => {
-    assert.throws(
+  it("throws on a non-JWT shape", async () => {
+    await assert.rejects(
       () =>
         resolveIdentity(envWith({ LANDMARK_AUTH_TOKEN: "not.a.jwt.really" })),
       /not a JWT/,
     );
   });
 
-  it("throws on a header that does not announce HS256 + JWT", () => {
+  it("throws on a header that does not announce HS256 + JWT", async () => {
     const header = Buffer.from(
       JSON.stringify({ alg: "none", typ: "JWT" }),
     ).toString("base64url");
@@ -45,27 +51,25 @@ describe("resolveIdentity", () => {
     ).toString("base64url");
     const sig = "a".repeat(43);
     const bad = `${header}.${payload}.${sig}`;
-    assert.throws(
+    await assert.rejects(
       () => resolveIdentity(envWith({ LANDMARK_AUTH_TOKEN: bad })),
       /header rejected/,
     );
   });
 
-  it("throws on malformed JSON payload", () => {
+  it("throws on malformed JSON payload", async () => {
     const header = Buffer.from(
       JSON.stringify({ alg: "HS256", typ: "JWT" }),
     ).toString("base64url");
     const payload = Buffer.from("not-json").toString("base64url");
     const bad = `${header}.${payload}.aaaa`;
-    assert.throws(
+    await assert.rejects(
       () => resolveIdentity(envWith({ LANDMARK_AUTH_TOKEN: bad })),
       /payload is not valid JSON/,
     );
   });
 
-  it("throws when email claim is missing", () => {
-    const token = signTestToken({ email: "", secret: SECRET });
-    // Strip out the email by re-signing with no email at all.
+  it("throws when email claim is missing", async () => {
     const header = Buffer.from(
       JSON.stringify({ alg: "HS256", typ: "JWT" }),
     ).toString("base64url");
@@ -80,7 +84,7 @@ describe("resolveIdentity", () => {
       .update(`${header}.${payload}`)
       .digest("base64url");
     const noEmail = `${header}.${payload}.${sig}`;
-    assert.throws(
+    await assert.rejects(
       () =>
         resolveIdentity(
           envWith({
@@ -90,11 +94,9 @@ describe("resolveIdentity", () => {
         ),
       /missing string email claim/,
     );
-    // Sanity: signTestToken still produced a token (not the test path).
-    assert.ok(token.split(".").length === 3);
   });
 
-  it("throws when email claim is not a string", () => {
+  it("throws when email claim is not a string", async () => {
     const header = Buffer.from(
       JSON.stringify({ alg: "HS256", typ: "JWT" }),
     ).toString("base64url");
@@ -105,13 +107,13 @@ describe("resolveIdentity", () => {
       }),
     ).toString("base64url");
     const bad = `${header}.${payload}.aaaa`;
-    assert.throws(
+    await assert.rejects(
       () => resolveIdentity(envWith({ LANDMARK_AUTH_TOKEN: bad })),
       /missing string email claim/,
     );
   });
 
-  it("throws when exp claim is not a number", () => {
+  it("throws when exp claim is not a number", async () => {
     const header = Buffer.from(
       JSON.stringify({ alg: "HS256", typ: "JWT" }),
     ).toString("base64url");
@@ -119,13 +121,13 @@ describe("resolveIdentity", () => {
       JSON.stringify({ email: "a@b", exp: "soon" }),
     ).toString("base64url");
     const bad = `${header}.${payload}.aaaa`;
-    assert.throws(
+    await assert.rejects(
       () => resolveIdentity(envWith({ LANDMARK_AUTH_TOKEN: bad })),
       /expired/,
     );
   });
 
-  it("throws on expired token", () => {
+  it("throws on expired token", async () => {
     const header = Buffer.from(
       JSON.stringify({ alg: "HS256", typ: "JWT" }),
     ).toString("base64url");
@@ -139,7 +141,7 @@ describe("resolveIdentity", () => {
       .update(`${header}.${payload}`)
       .digest("base64url");
     const expired = `${header}.${payload}.${sig}`;
-    assert.throws(
+    await assert.rejects(
       () =>
         resolveIdentity(
           envWith({
@@ -151,11 +153,11 @@ describe("resolveIdentity", () => {
     );
   });
 
-  it("throws on a forged signature when the secret is present", () => {
+  it("throws on a forged signature when the secret is present", async () => {
     const token = signTestToken({ email: "alice@example.com", secret: SECRET });
     const [h, p] = token.split(".");
     const bad = `${h}.${p}.${"a".repeat(43)}`;
-    assert.throws(
+    await assert.rejects(
       () =>
         resolveIdentity(
           envWith({
@@ -167,9 +169,9 @@ describe("resolveIdentity", () => {
     );
   });
 
-  it("returns { email, jwt } on a happy path with the secret present", () => {
+  it("returns { email, jwt } on a happy path with the secret present", async () => {
     const token = signTestToken({ email: "alice@example.com", secret: SECRET });
-    const out = resolveIdentity(
+    const out = await resolveIdentity(
       envWith({
         LANDMARK_AUTH_TOKEN: token,
         MAP_SUPABASE_JWT_SECRET: SECRET,
@@ -179,10 +181,156 @@ describe("resolveIdentity", () => {
     assert.equal(out.jwt, token);
   });
 
-  it("trusts the JWT shape when the secret is absent (production path)", () => {
-    // No MAP_SUPABASE_JWT_SECRET in env — defense-in-depth is skipped.
+  it("trusts the JWT shape when the secret is absent (production path)", async () => {
     const token = signTestToken({ email: "bob@example.com", secret: SECRET });
-    const out = resolveIdentity(envWith({ LANDMARK_AUTH_TOKEN: token }));
+    const out = await resolveIdentity(envWith({ LANDMARK_AUTH_TOKEN: token }));
     assert.equal(out.email, "bob@example.com");
+  });
+});
+
+describe("resolveIdentity — credentials-store fallback", () => {
+  let tempDir;
+  let credsFile;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "landmark-identity-"));
+    credsFile = path.join(tempDir, "credentials.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("reads a valid (unexpired) session from the store", async () => {
+    const env = envWith({ LANDMARK_CREDENTIALS_FILE: credsFile });
+    await writeCredentials(
+      {
+        access_token: "access-from-store",
+        refresh_token: "r",
+        expires_at: Date.now() + 3600_000,
+        email: "carol@example.com",
+      },
+      env,
+    );
+    const out = await resolveIdentity(env);
+    assert.equal(out.email, "carol@example.com");
+    assert.equal(out.jwt, "access-from-store");
+  });
+
+  it("env LANDMARK_AUTH_TOKEN takes precedence over the store", async () => {
+    const env = envWith({ LANDMARK_CREDENTIALS_FILE: credsFile });
+    await writeCredentials(
+      {
+        access_token: "from-store",
+        refresh_token: "r",
+        expires_at: Date.now() + 3600_000,
+        email: "carol@example.com",
+      },
+      env,
+    );
+    const token = signTestToken({ email: "dave@example.com", secret: SECRET });
+    const out = await resolveIdentity({
+      ...env,
+      LANDMARK_AUTH_TOKEN: token,
+      MAP_SUPABASE_JWT_SECRET: SECRET,
+    });
+    assert.equal(out.email, "dave@example.com");
+    assert.equal(out.jwt, token);
+  });
+
+  it("refreshes when expires_at is past and persists new tokens", async () => {
+    const env = envWith({
+      LANDMARK_CREDENTIALS_FILE: credsFile,
+      MAP_SUPABASE_URL: "http://supabase.local",
+      MAP_SUPABASE_ANON_KEY: "anon",
+    });
+    await writeCredentials(
+      {
+        access_token: "stale",
+        refresh_token: "old-refresh",
+        expires_at: Date.now() - 60_000,
+        email: "eve@example.com",
+      },
+      env,
+    );
+
+    let refreshArgs;
+    const createClient = (url, key) => {
+      assert.equal(url, "http://supabase.local");
+      assert.equal(key, "anon");
+      return {
+        auth: {
+          async refreshSession({ refresh_token }) {
+            refreshArgs = refresh_token;
+            return {
+              data: {
+                session: {
+                  access_token: "new-access",
+                  refresh_token: "new-refresh",
+                  expires_in: 3600,
+                },
+                user: { email: "eve@example.com" },
+              },
+              error: null,
+            };
+          },
+        },
+      };
+    };
+
+    const out = await resolveIdentity(env, { createClient });
+    assert.equal(refreshArgs, "old-refresh");
+    assert.equal(out.email, "eve@example.com");
+    assert.equal(out.jwt, "new-access");
+
+    const persisted = await readCredentials(env);
+    assert.equal(persisted.access_token, "new-access");
+    assert.equal(persisted.refresh_token, "new-refresh");
+    assert.ok(persisted.expires_at > Date.now());
+  });
+
+  it("clears the store and throws when refresh fails", async () => {
+    const env = envWith({
+      LANDMARK_CREDENTIALS_FILE: credsFile,
+      MAP_SUPABASE_URL: "http://supabase.local",
+      MAP_SUPABASE_ANON_KEY: "anon",
+    });
+    await writeCredentials(
+      {
+        access_token: "stale",
+        refresh_token: "dead",
+        expires_at: Date.now() - 60_000,
+        email: "frank@example.com",
+      },
+      env,
+    );
+
+    const createClient = () => ({
+      auth: {
+        async refreshSession() {
+          return { data: null, error: { message: "refresh failed" } };
+        },
+      },
+    });
+
+    await assert.rejects(
+      () => resolveIdentity(env, { createClient }),
+      /refresh failed.*run `fit-landmark login`/s,
+    );
+    assert.equal(await readCredentials(env), null);
+  });
+
+  it("rejects when refresh is needed but MAP_SUPABASE_URL is missing", async () => {
+    const env = envWith({ LANDMARK_CREDENTIALS_FILE: credsFile });
+    await writeCredentials(
+      {
+        access_token: "stale",
+        refresh_token: "r",
+        expires_at: Date.now() - 60_000,
+        email: "x@y",
+      },
+      env,
+    );
+    await assert.rejects(() => resolveIdentity(env), /MAP_SUPABASE_URL/);
   });
 });

--- a/products/landmark/test/lib/sign-test-token.js
+++ b/products/landmark/test/lib/sign-test-token.js
@@ -1,6 +1,4 @@
-import { createHmac, randomUUID } from "node:crypto";
-
-const b64url = (b) => Buffer.from(b).toString("base64url");
+import { mintSupabaseJwt } from "@forwardimpact/libsecret";
 
 /**
  * HMAC-sign a Supabase-shaped JWT for use in tests and local fixtures.
@@ -18,21 +16,5 @@ export function signTestToken({
 }) {
   if (!secret)
     throw new Error("signTestToken: MAP_SUPABASE_JWT_SECRET not set");
-  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
-  const now = Math.floor(Date.now() / 1000);
-  const payload = b64url(
-    JSON.stringify({
-      role: "authenticated",
-      aud: "authenticated",
-      email,
-      sub: randomUUID(),
-      iss: "supabase",
-      iat: now,
-      exp: now + ttlSeconds,
-    }),
-  );
-  const sig = createHmac("sha256", secret)
-    .update(`${header}.${payload}`)
-    .digest("base64url");
-  return `${header}.${payload}.${sig}`;
+  return mintSupabaseJwt({ email, secret, ttlSeconds });
 }

--- a/products/map/bin/fit-map.js
+++ b/products/map/bin/fit-map.js
@@ -88,6 +88,19 @@ const definition = {
         "base-url": { type: "string", description: "GetDX API base URL" },
       },
     },
+    {
+      name: "auth",
+      args: "issue",
+      description: "Issue a Supabase-shaped JWT for an existing roster row",
+      options: {
+        url: { type: "string", description: "Supabase URL" },
+        email: { type: "string", description: "Caller email to issue for" },
+        ttl: {
+          type: "string",
+          description: "Token lifetime, e.g. 8760h (1y), 30d. Default 8760h.",
+        },
+      },
+    },
   ],
   globalOptions: {
     data: { type: "string", description: "Path to data directory" },
@@ -139,6 +152,11 @@ const definition = {
       url: "https://www.forwardimpact.team/docs/products/provisioning-engineers/index.md",
       description:
         "Reconcile auth.users against the roster so identity-derived RLS works.",
+    },
+    {
+      title: "Issue Service-Account Tokens",
+      url: "https://www.forwardimpact.team/docs/products/issuing-service-account-tokens/index.md",
+      description: "Mint long-lived Supabase JWTs for unattended agents.",
     },
   ],
 };
@@ -434,6 +452,25 @@ async function dispatchGetdx(subcommand, rest, values) {
   }
 }
 
+async function dispatchAuth(subcommand, _rest, values) {
+  switch (subcommand) {
+    case "issue": {
+      const supabase = await mapClient(values);
+      const { runAuthIssueCommand } = await import(
+        "../src/commands/auth-issue.js"
+      );
+      await runAuthIssueCommand({
+        supabase,
+        options: { email: values.email, ttl: values.ttl },
+      });
+      return 0;
+    }
+    default:
+      cli.usageError(`unknown auth subcommand: ${subcommand || "(none)"}`);
+      return 1;
+  }
+}
+
 /**
  * Main entry point
  */
@@ -490,6 +527,9 @@ async function main() {
         break;
       case "getdx":
         exitCode = await dispatchGetdx(subcommand, rest, values);
+        break;
+      case "auth":
+        exitCode = await dispatchAuth(subcommand, rest, values);
         break;
       default:
         cli.usageError(`unknown command "${command}"`);

--- a/products/map/package.json
+++ b/products/map/package.json
@@ -76,6 +76,7 @@
   },
   "dependencies": {
     "@forwardimpact/libcli": "^0.1.0",
+    "@forwardimpact/libsecret": "^0.1.14",
     "@forwardimpact/libtemplate": "^0.2.0",
     "@forwardimpact/libutil": "^0.1.64",
     "@supabase/supabase-js": "^2.105.4",

--- a/products/map/src/activity/parse-people.js
+++ b/products/map/src/activity/parse-people.js
@@ -19,6 +19,9 @@ export function parseYamlPeople(content) {
   return rows.map((row) => ({
     ...row,
     github_username: row.github_username || row.github || null,
+    // Default to 'human' so legacy YAML files (no `kind` field) keep
+    // ingesting against the new check constraint on organization_people.
+    kind: row.kind || "human",
   }));
 }
 
@@ -33,7 +36,11 @@ export function parseCsv(csv) {
   const headers = lines[0].split(",").map((h) => h.trim());
   return lines.slice(1).map((line) => {
     const values = line.split(",").map((v) => v.trim());
-    return Object.fromEntries(headers.map((h, i) => [h, values[i] || null]));
+    const row = Object.fromEntries(
+      headers.map((h, i) => [h, values[i] || null]),
+    );
+    row.kind = row.kind || "human";
+    return row;
   });
 }
 

--- a/products/map/src/activity/transform/people.js
+++ b/products/map/src/activity/transform/people.js
@@ -47,16 +47,23 @@ async function importPeople(supabase, people) {
     if (batch.length === 0) continue;
 
     const { error } = await supabase.from("organization_people").upsert(
-      batch.map((p) => ({
-        email: p.email,
-        name: p.name,
-        github_username: p.github_username || null,
-        discipline: p.discipline,
-        level: p.level,
-        track: p.track || null,
-        manager_email: p.manager_email || null,
-        updated_at: new Date().toISOString(),
-      })),
+      batch.map((p) => {
+        const kind = p.kind || "human";
+        // The DB check constraint enforces `level IS NULL` when
+        // `kind = 'service_account'`. Drop level for service accounts so
+        // a stale `level` field in the input does not trip the constraint.
+        return {
+          email: p.email,
+          name: p.name,
+          github_username: p.github_username || null,
+          discipline: p.discipline,
+          level: kind === "service_account" ? null : p.level,
+          track: p.track || null,
+          manager_email: p.manager_email || null,
+          kind,
+          updated_at: new Date().toISOString(),
+        };
+      }),
       { onConflict: "email" },
     );
 

--- a/products/map/src/activity/validate/people.js
+++ b/products/map/src/activity/validate/people.js
@@ -40,6 +40,17 @@ function validatePersonRow(person, ids) {
 
   if (!person.email) rowErrors.push("missing email");
   if (!person.name) rowErrors.push("missing name");
+
+  // Service-account rows carry no Pathway job profile. Validate just the
+  // shape (email/name above; level-null below) and skip the discipline/
+  // level/track checks the human rows go through. The DB check
+  // constraint enforces level IS NULL for these rows.
+  if (person.kind === "service_account") {
+    if (person.level)
+      rowErrors.push("service_account rows must have level=null");
+    return rowErrors;
+  }
+
   if (!person.discipline) {
     rowErrors.push("missing discipline");
   } else if (!ids.disciplineIds.has(person.discipline)) {
@@ -63,14 +74,16 @@ function validatePersonRow(person, ids) {
  * @returns {object}
  */
 function normalizePersonRecord(person) {
+  const kind = person.kind || "human";
   return {
     email: person.email,
     name: person.name,
     github_username: person.github_username || null,
     discipline: person.discipline,
-    level: person.level,
+    level: kind === "service_account" ? null : person.level,
     track: person.track || null,
     manager_email: person.manager_email || null,
+    kind,
   };
 }
 

--- a/products/map/src/commands/auth-issue.js
+++ b/products/map/src/commands/auth-issue.js
@@ -1,0 +1,100 @@
+/**
+ * `fit-map auth issue --email <e>` — mint a long-lived Supabase-shaped JWT
+ * for an existing roster identity.
+ *
+ * Operator-only verb. Uses the service-role client (which we already need
+ * to read `organization_people` and list `auth.users`) to verify both rows
+ * exist before signing, then HMACs a JWT against MAP_SUPABASE_JWT_SECRET.
+ * Output goes to stdout so the operator can capture it into `.env`, a
+ * secret manager, or pipe it to an agent's `LANDMARK_AUTH_TOKEN` setting.
+ */
+
+import {
+  formatHeader,
+  formatSuccess,
+  formatBullet,
+} from "@forwardimpact/libcli";
+import { mintSupabaseJwt, parseDuration } from "@forwardimpact/libsecret";
+
+const DEFAULT_TTL = "8760h"; // 1 year.
+
+async function findAuthUser(supabase, email) {
+  // Roster size in the hundreds; one page covers any practical org.
+  // listUsers() returns paginated results; iterate to be safe.
+  let page = 1;
+  while (true) {
+    const { data, error } = await supabase.auth.admin.listUsers({
+      page,
+      perPage: 1000,
+    });
+    if (error) throw new Error(`listUsers: ${error.message}`);
+    const match = data.users.find((u) => u.email === email);
+    if (match) return match;
+    if (data.users.length < 1000) return null;
+    page += 1;
+  }
+}
+
+/**
+ * Run the auth-issue command.
+ *
+ * @param {object} params
+ * @param {import("@supabase/supabase-js").SupabaseClient} params.supabase
+ * @param {{email?: string, ttl?: string}} params.options
+ * @returns {Promise<{summary: object, meta: object}>}
+ */
+export async function runAuthIssueCommand({ supabase, options }) {
+  const email = options.email;
+  if (!email) {
+    throw new Error("auth issue: --email <e> is required");
+  }
+  const ttlString = options.ttl ?? DEFAULT_TTL;
+  const ttlSeconds = parseDuration(ttlString);
+  const secret = process.env.MAP_SUPABASE_JWT_SECRET;
+  if (!secret) {
+    throw new Error(
+      "auth issue: MAP_SUPABASE_JWT_SECRET is not set. Run `fit-map " +
+        "activity start` (local) or fetch the JWT secret from your Supabase " +
+        "project's API settings (hosted) and export it.",
+    );
+  }
+
+  const { data: row, error: rowErr } = await supabase
+    .from("organization_people")
+    .select("email,kind")
+    .eq("email", email)
+    .maybeSingle();
+  if (rowErr) throw new Error(`organization_people: ${rowErr.message}`);
+  if (!row) {
+    throw new Error(
+      `auth issue: no organization_people row for ${email}. ` +
+        "Run `fit-map people push` first.",
+    );
+  }
+
+  const authUser = await findAuthUser(supabase, email);
+  if (!authUser) {
+    throw new Error(
+      `auth issue: no auth.users row for ${email}. ` +
+        "Run `fit-map people provision` first.",
+    );
+  }
+
+  const jwt = mintSupabaseJwt({ email, secret, ttlSeconds });
+  process.stdout.write(
+    formatHeader(`Issued JWT for ${email} (${row.kind}, ttl=${ttlString})`) +
+      "\n\n",
+  );
+  process.stdout.write(jwt + "\n\n");
+  process.stdout.write(
+    formatBullet(
+      "Export: LANDMARK_AUTH_TOKEN=<jwt above>; never commit or echo it.",
+      0,
+    ) + "\n",
+  );
+  process.stdout.write(formatSuccess("Done.") + "\n");
+  return {
+    summary: { email, kind: row.kind, ttlSeconds },
+    meta: { ok: true },
+  };
+}

--- a/products/map/supabase/config.toml
+++ b/products/map/supabase/config.toml
@@ -21,6 +21,10 @@ enabled = true
 site_url = "http://localhost:3000"
 jwt_expiry = 3600
 enable_signup = false
+# `fit-landmark login` (PKCE magic-link) starts a listener on an ephemeral
+# 127.0.0.1 port and asks Supabase to redirect the email link back to it.
+# The wildcard admits any port without per-engineer config churn.
+additional_redirect_urls = ["http://127.0.0.1/*"]
 
 [auth.email]
 enable_signup = false

--- a/products/map/supabase/migrations/20260514000000_organization_people_kind.sql
+++ b/products/map/supabase/migrations/20260514000000_organization_people_kind.sql
@@ -1,0 +1,24 @@
+-- Add a `kind` discriminator to organization_people so service-account rows
+-- (operator-minted, no human owner) can sit alongside engineer rows without
+-- abusing the human-only columns. RLS policies from
+-- 20260510000000_landmark_rls.sql remain unchanged: both kinds share the
+-- same per-row-class scope rule.
+
+ALTER TABLE activity.organization_people
+  ADD COLUMN kind TEXT NOT NULL DEFAULT 'human'
+  CHECK (kind IN ('human', 'service_account'));
+
+-- Service-account rows carry no Pathway job profile. Relax the NOT NULL
+-- on `level` and enforce the kind-specific shape via a check constraint:
+-- human rows must have a level; service-account rows must not.
+ALTER TABLE activity.organization_people
+  ALTER COLUMN level DROP NOT NULL;
+
+ALTER TABLE activity.organization_people
+  ADD CONSTRAINT organization_people_kind_level_check CHECK (
+    (kind = 'human' AND level IS NOT NULL)
+    OR (kind = 'service_account' AND level IS NULL)
+  );
+
+CREATE INDEX IF NOT EXISTS idx_organization_people_kind
+  ON activity.organization_people(kind);

--- a/products/map/test/activity/auth-issue.test.js
+++ b/products/map/test/activity/auth-issue.test.js
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for `fit-map auth issue` — uses an in-memory Supabase mock so
+ * the verb's branching (missing roster row, missing auth.users row, happy
+ * path, --ttl propagation) is covered without a live stack.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { runAuthIssueCommand } from "../../src/commands/auth-issue.js";
+
+/** Build a Supabase-shaped stub with the two surfaces auth-issue calls. */
+function makeStub({ rosterRow, authUsers = [] }) {
+  return {
+    from(table) {
+      if (table !== "organization_people")
+        throw new Error(`unexpected table ${table}`);
+      return {
+        select() {
+          return this;
+        },
+        eq() {
+          return this;
+        },
+        async maybeSingle() {
+          return { data: rosterRow ?? null, error: null };
+        },
+      };
+    },
+    auth: {
+      admin: {
+        async listUsers() {
+          return { data: { users: authUsers }, error: null };
+        },
+      },
+    },
+  };
+}
+
+function captureStdout() {
+  const chunks = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+    return true;
+  };
+  return {
+    text: () => chunks.join(""),
+    restore: () => {
+      process.stdout.write = orig;
+    },
+  };
+}
+
+describe("runAuthIssueCommand", () => {
+  const savedSecret = process.env.MAP_SUPABASE_JWT_SECRET;
+  let out;
+
+  beforeEach(() => {
+    process.env.MAP_SUPABASE_JWT_SECRET = "test-secret";
+    out = captureStdout();
+  });
+  afterEach(() => {
+    out.restore();
+    if (savedSecret === undefined) delete process.env.MAP_SUPABASE_JWT_SECRET;
+    else process.env.MAP_SUPABASE_JWT_SECRET = savedSecret;
+  });
+
+  test("happy path mints a JWT for a human row", async () => {
+    const supabase = makeStub({
+      rosterRow: { email: "alice@example.com", kind: "human" },
+      authUsers: [{ id: "u1", email: "alice@example.com" }],
+    });
+    const result = await runAuthIssueCommand({
+      supabase,
+      options: { email: "alice@example.com" },
+    });
+    assert.equal(result.meta.ok, true);
+    assert.equal(result.summary.email, "alice@example.com");
+    assert.equal(result.summary.kind, "human");
+    // 8760h = 365 * 24 * 3600 = 31_536_000 seconds.
+    assert.equal(result.summary.ttlSeconds, 31_536_000);
+
+    const printed = out.text();
+    // The JWT is the first multi-segment dot string of length ≥3.
+    const jwtMatch = printed.match(/[\w-]+\.[\w-]+\.[\w-]+/);
+    assert.ok(jwtMatch, "JWT not present in stdout");
+    const parts = jwtMatch[0].split(".");
+    assert.equal(parts.length, 3);
+  });
+
+  test("mints a JWT for a service_account row", async () => {
+    const supabase = makeStub({
+      rosterRow: { email: "agent@example.com", kind: "service_account" },
+      authUsers: [{ id: "u2", email: "agent@example.com" }],
+    });
+    const result = await runAuthIssueCommand({
+      supabase,
+      options: { email: "agent@example.com" },
+    });
+    assert.equal(result.summary.kind, "service_account");
+  });
+
+  test("--ttl propagates", async () => {
+    const supabase = makeStub({
+      rosterRow: { email: "alice@example.com", kind: "human" },
+      authUsers: [{ id: "u1", email: "alice@example.com" }],
+    });
+    const result = await runAuthIssueCommand({
+      supabase,
+      options: { email: "alice@example.com", ttl: "30d" },
+    });
+    assert.equal(result.summary.ttlSeconds, 30 * 86_400);
+  });
+
+  test("rejects missing --email", async () => {
+    const supabase = makeStub({});
+    await assert.rejects(
+      () => runAuthIssueCommand({ supabase, options: {} }),
+      /--email <e> is required/,
+    );
+  });
+
+  test("rejects missing JWT secret", async () => {
+    delete process.env.MAP_SUPABASE_JWT_SECRET;
+    const supabase = makeStub({
+      rosterRow: { email: "alice@example.com", kind: "human" },
+      authUsers: [{ id: "u1", email: "alice@example.com" }],
+    });
+    await assert.rejects(
+      () =>
+        runAuthIssueCommand({
+          supabase,
+          options: { email: "alice@example.com" },
+        }),
+      /MAP_SUPABASE_JWT_SECRET is not set/,
+    );
+  });
+
+  test("missing organization_people row points at `people push`", async () => {
+    const supabase = makeStub({
+      rosterRow: null,
+      authUsers: [{ id: "u1", email: "alice@example.com" }],
+    });
+    await assert.rejects(
+      () =>
+        runAuthIssueCommand({
+          supabase,
+          options: { email: "alice@example.com" },
+        }),
+      /no organization_people row[\s\S]*fit-map people push/,
+    );
+  });
+
+  test("missing auth.users row points at `people provision`", async () => {
+    const supabase = makeStub({
+      rosterRow: { email: "alice@example.com", kind: "human" },
+      authUsers: [],
+    });
+    await assert.rejects(
+      () =>
+        runAuthIssueCommand({
+          supabase,
+          options: { email: "alice@example.com" },
+        }),
+      /no auth\.users row[\s\S]*fit-map people provision/,
+    );
+  });
+
+  test("rejects bad --ttl format", async () => {
+    const supabase = makeStub({
+      rosterRow: { email: "alice@example.com", kind: "human" },
+      authUsers: [{ id: "u1", email: "alice@example.com" }],
+    });
+    await assert.rejects(
+      () =>
+        runAuthIssueCommand({
+          supabase,
+          options: { email: "alice@example.com", ttl: "5m" },
+        }),
+      /invalid duration/,
+    );
+  });
+});

--- a/websites/fit/docs/products/issuing-service-account-tokens/index.md
+++ b/websites/fit/docs/products/issuing-service-account-tokens/index.md
@@ -1,0 +1,123 @@
+---
+title: Issue Service-Account Tokens
+description: Mint long-lived Supabase JWTs for unattended agents that take on a service-account identity in Landmark.
+---
+
+Magic-link login works when a human is in front of the email client; it
+breaks down for unattended agents. The `fit-map auth issue` verb closes
+that gap: it mints a Supabase-shaped JWT for an existing roster row, and
+the operator hands the token to the agent as `LANDMARK_AUTH_TOKEN`.
+
+The same verb works for human emails too, but the canonical use case is a
+service-account row — an identity that exists solely so an agent can take
+it on. Service-account rows live in the same `organization_people` table
+as humans (with `kind = 'service_account'`) and share the same row-level
+security clamp.
+
+This guide is for **operators** running the verb against a Supabase
+project. Engineers do not run it.
+
+## Prerequisites
+
+- `MAP_SUPABASE_URL`, `MAP_SUPABASE_SERVICE_ROLE_KEY`, and
+  `MAP_SUPABASE_JWT_SECRET` exported in your shell.
+  - **Local stack** — `fit-map activity start` prints all three.
+  - **Hosted Supabase** — find them in Project Settings → API → Project URL,
+    Service Role Key, and JWT Secret.
+- The target email already has both an `organization_people` row and an
+  `auth.users` row. Run `fit-map people push` then `fit-map people provision`
+  if it doesn't.
+
+## Mint a token
+
+```sh
+fit-map auth issue --email kata-agent-team@example.com
+```
+
+The verb prints the JWT followed by an export hint:
+
+```
+Issued JWT for kata-agent-team@example.com (service_account, ttl=8760h)
+
+eyJhbGciOi...
+
+  Export: LANDMARK_AUTH_TOKEN=<jwt above>; never commit or echo it.
+
+  Done.
+```
+
+The default TTL is one year. Override with `--ttl`:
+
+| Suffix | Meaning | Example |
+| --- | --- | --- |
+| `h` | hours | `--ttl 24h` |
+| `d` | days | `--ttl 90d` |
+| `y` | years | `--ttl 1y` (equivalent to `--ttl 365d` or `--ttl 8760h`) |
+
+## Service-account rows in the synthetic DSL
+
+Terrain fixtures declare service-account rows alongside humans:
+
+```text
+people {
+  count 50
+  ...
+  service_account "kata-agent-team" {
+    name "Kata Agent Team"
+    email "kata-agent-team@example.com"
+  }
+}
+```
+
+The renderer emits these as `kind: service_account` entries with no
+`level`, `manager_email`, or `team`. `fit-map people push` accepts the
+field; the DB check constraint enforces `level IS NULL` when
+`kind = 'service_account'`.
+
+## Hand the token to the agent
+
+Write the JWT to the agent's `.env` (or your secret manager). Once
+`LANDMARK_AUTH_TOKEN` is exported in the agent's environment, every
+`fit-landmark` invocation resolves identity directly from the token:
+
+```sh
+LANDMARK_AUTH_TOKEN=$JWT fit-landmark voice
+```
+
+No magic-link, no refresh flow — the long-lived JWT verifies under
+`MAP_SUPABASE_JWT_SECRET` on the Postgres side, RLS clamps the result to
+the service-account's row class, and the agent runs unattended.
+
+## Security guidance
+
+Treat the JWT like an SSH key:
+
+- **Never commit it.** Even in a private repo, a leaked one-year token is
+  a one-year leak.
+- **Store it in a secret manager.** GitHub Actions secrets, AWS Secrets
+  Manager, HashiCorp Vault — anywhere with audit logging.
+- **Scope per agent.** Mint a separate token per agent identity so a
+  compromise can be contained by banning that one `auth.users` row.
+- **Rotate proactively.** A year is the default ceiling, not a target.
+  Shorter TTLs cap exposure.
+
+## Revoke a token
+
+There is no separate revocation verb. Tokens revoke at the `auth.users`
+level: ban the row, and every outstanding JWT for it stops resolving on
+the next Supabase Auth check.
+
+```sh
+# Remove the row from organization_people and re-run provision —
+# the auth.users row gets banned (banned_until ≥100 years).
+fit-map people provision
+```
+
+To bring the identity back, re-add the roster row and run `provision`
+again. Then mint a fresh token; the old one stays inert.
+
+## Related
+
+- [Sign In to Landmark](https://www.forwardimpact.team/docs/products/signing-in-to-landmark/index.md)
+- [Provision Engineer Auth Users](https://www.forwardimpact.team/docs/products/provisioning-engineers/index.md)
+- [Map Overview](https://www.forwardimpact.team/map/index.md)

--- a/websites/fit/docs/products/signing-in-to-landmark/index.md
+++ b/websites/fit/docs/products/signing-in-to-landmark/index.md
@@ -1,0 +1,121 @@
+---
+title: Sign In to Landmark
+description: Sign in via Supabase magic-link so Landmark commands resolve your identity without managing a long-lived token.
+---
+
+Every Landmark read requires an authenticated caller. The privacy substrate
+keys row-level security off the JWT's `email` claim, so before any verb can
+return data it needs to know who is asking.
+
+`fit-landmark login` walks you through Supabase's magic-link flow, captures
+the session at a localhost callback, and stores it under
+`~/.config/landmark/credentials.json` (0600). Subsequent commands resolve
+identity automatically; you only run `login` again when the session expires
+or you change machines.
+
+This guide is for **engineers** signing in to read Landmark from the CLI.
+Operators issuing tokens for unattended agents follow a different path —
+see [Issue Service-Account Tokens](https://www.forwardimpact.team/docs/products/issuing-service-account-tokens/index.md).
+
+## Prerequisites
+
+- An `auth.users` row paired with your roster entry. Your operator runs
+  `fit-map people provision` to keep these synchronized — if your email is
+  not in the roster, login will fail.
+- `MAP_SUPABASE_URL` and `MAP_SUPABASE_ANON_KEY` exported in your shell.
+  Local stacks get these from `fit-map activity start`; hosted Supabase
+  projects expose them in Project Settings → API.
+
+## Browser flow (default)
+
+```sh
+fit-landmark login --email you@example.com
+```
+
+The CLI starts a listener on `127.0.0.1` and prints a port. Supabase emails
+you a magic-link; clicking it from the same machine redirects the browser
+to the listener, which captures the PKCE code and exchanges it for a
+session. The credentials file is written with mode 0600.
+
+```
+Sent a magic link to you@example.com.
+Open the email on this machine and click the link — the CLI is listening on 127.0.0.1:54321.
+Logged in as you@example.com.
+```
+
+## OTP flow (headless / SSH)
+
+When you cannot open a browser on the machine running the CLI — an SSH
+session, a sandboxed agent, a container — use the OTP flow instead:
+
+```sh
+fit-landmark login --otp --email you@example.com
+```
+
+Supabase emails you a six-digit code. Paste it at the prompt; the CLI
+verifies it and persists the same session shape as the browser flow.
+
+```
+Sent a 6-digit code to you@example.com. Paste it below.
+Code: 123456
+Logged in as you@example.com.
+```
+
+## Where the session lives
+
+| Platform | Path |
+| --- | --- |
+| Linux / macOS | `~/.config/landmark/credentials.json` |
+| Windows | `%APPDATA%\landmark\credentials.json` |
+| XDG-aware | `$XDG_CONFIG_HOME/landmark/credentials.json` |
+
+The file holds `access_token`, `refresh_token`, `expires_at`, and `email`.
+Treat it like an SSH private key — never commit it, never copy it to a
+shared filesystem. The 0600 permission is enforced on POSIX systems.
+
+You can override the path with `LANDMARK_CREDENTIALS_FILE`; useful for
+isolating sessions per project or for test harnesses.
+
+## When the session expires
+
+Supabase access tokens are short-lived (an hour by default) but the
+refresh token persists for weeks. The Landmark identity resolver checks
+`expires_at` on every command and calls Supabase's refresh endpoint
+automatically when the access token is within a minute of expiry. The
+refreshed tokens are written back to the same credentials file.
+
+When the refresh token itself has aged out, you'll see:
+
+```
+Authentication required: session expired and refresh failed — run `fit-landmark login` again
+```
+
+Run `fit-landmark login` again to start a new session.
+
+## Sign out
+
+```sh
+fit-landmark logout
+```
+
+Removes the credentials file. A subsequent `login` starts fresh.
+
+## Power-user override
+
+If you have been issued a long-lived JWT (operator-minted via
+`fit-map auth issue`), export it as `LANDMARK_AUTH_TOKEN` and the resolver
+will skip the credentials store entirely:
+
+```sh
+export LANDMARK_AUTH_TOKEN=<jwt>
+fit-landmark voice
+```
+
+This is the path unattended agents take. Treat the token like a credential —
+it grants the same scope your magic-link session would.
+
+## Related
+
+- [Provision Engineer Auth Users](https://www.forwardimpact.team/docs/products/provisioning-engineers/index.md)
+- [Issue Service-Account Tokens](https://www.forwardimpact.team/docs/products/issuing-service-account-tokens/index.md)
+- [Landmark Overview](https://www.forwardimpact.team/landmark/index.md)

--- a/websites/fit/docs/products/signing-in-to-landmark/index.md
+++ b/websites/fit/docs/products/signing-in-to-landmark/index.md
@@ -65,9 +65,10 @@ Logged in as you@example.com.
 
 | Platform | Path |
 | --- | --- |
-| Linux / macOS | `~/.config/landmark/credentials.json` |
+| Linux | `~/.config/landmark/credentials.json` |
+| macOS | `~/Library/Application Support/landmark/credentials.json` |
 | Windows | `%APPDATA%\landmark\credentials.json` |
-| XDG-aware | `$XDG_CONFIG_HOME/landmark/credentials.json` |
+| XDG override | `$XDG_CONFIG_HOME/landmark/credentials.json` (any platform) |
 
 The file holds `access_token`, `refresh_token`, `expires_at`, and `email`.
 Treat it like an SSH private key — never commit it, never copy it to a


### PR DESCRIPTION
## Summary

Closes the gap left by spec 840 (#829 slice 1.5): the privacy substrate
requires a Supabase JWT for every Landmark read, but engineers and
unattended agents had no way to obtain one.

- **`fit-landmark login`** — Supabase magic-link flow. Browser default
  with PKCE (`flowType: 'pkce'` + in-process Map-backed verifier storage
  so the verifier survives between `signInWithOtp` and
  `exchangeCodeForSession`). `--otp` fallback for headless / SSH.
  Persists the session under `~/.config/landmark/credentials.json` on
  Linux, `~/Library/Application Support/landmark/credentials.json` on
  macOS, `%APPDATA%\landmark\credentials.json` on Windows (XDG override
  honoured on all platforms). 0600 mode.
- **`fit-landmark logout`** — clears the credentials file.
- **`fit-map auth issue --email <e> [--ttl 8760h]`** — operator verb
  that mints a long-lived Supabase JWT for an existing roster +
  `auth.users` row. Used to hand identity to unattended agents.
- **`resolveIdentity` is now async.** Precedence: env
  `LANDMARK_AUTH_TOKEN` → credentials store → Supabase refresh near
  expiry → throw `IdentityUnresolvedError` with a "run login" prompt.
- **Synthetic DSL** gains `service_account "<id>" { name "..." email
  "..." }` under `people {}`. Renderer and ingestion carry the `kind`
  field end-to-end; the new migration adds a check constraint
  enforcing `level IS NULL` when `kind = 'service_account'` (and drops
  the prior `NOT NULL` on `level` to allow that shape).
- **`libsecret`** gains `mintSupabaseJwt` + `parseDuration`;
  `signTestToken` becomes a thin wrapper so HMAC lives in one place.
- **Docs:** two new task guides (`signing-in-to-landmark`,
  `issuing-service-account-tokens`) linked from the matching skill
  `## Documentation` lists and CLI `documentation[]` arrays.
- **config.toml:** `additional_redirect_urls = ["http://127.0.0.1/*"]`
  added to `[auth]` so the local stack admits the magic-link callback.

Slice 1 (spec 840, PR #850) is the precondition.

## Test plan

- [x] `bun run check` — format, lint, jsdoc, harness, context all green
- [x] `bun run test` — 149 landmark + 179 map + 152 libsyntheticgen + 53
      libsecret tests pass. The 13 libwiki failures observed at the
      monorepo level are pre-existing on clean `main` (verified via
      clean-tree comparison) and unrelated to this branch.
- [ ] Manual: `bunx fit-map activity start && bunx fit-map auth issue
      --email <e>` mints a JWT; `LANDMARK_AUTH_TOKEN=$JWT bunx
      fit-landmark voice` returns rows.
- [ ] Manual: `bunx fit-landmark login --otp --email <e>` captures a
      session from Inbucket; subsequent `bunx fit-landmark voice` works
      without the env var.
- [ ] Manual: `bunx fit-landmark logout` removes the file.

https://claude.ai/code/session_01MSkBK7AMF1fnEKHSqPgzNN

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSkBK7AMF1fnEKHSqPgzNN)_