### PR TITLE
feat(kata)!: panel-before-PR + wiki/STATUS.md approval record

### DIFF
--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -2,8 +2,9 @@
 name: product-manager
 description: >
   Repository product manager. Triages open issues against the product vision,
-  reviews spec quality, and writes specs for product-aligned requests. Spec
-  quality is signaled to the merge gate via the `spec:approved` PR label.
+  reviews spec quality, and writes specs for product-aligned requests. Reports
+  spec-review findings via PR comment so a trusted human can apply the
+  approval signal; never applies `spec:approved` autonomously.
 skills:
   - kata-product-issue
   - kata-interview
@@ -36,14 +37,13 @@ Survey all open work items, then act on the highest-priority bucket:
 0. **[Action routing](.claude/agents/references/memory-protocol.md#action-routing)**
    — read Tier 1; owned priorities and storyboard items preempt domain steps.
 1. **Survey.** `gh pr list --search 'spec(' --state open` +
-   `gh issue list --search "-label:experiment -label:obstacle"`. Buckets: **P1**
-   open spec PRs without `spec:approved` label and without an APPROVED review.
-   **P2** issues labeled `needs-spec`. **P3** untriaged issues (no `triaged`
-   label).
-2. **Act on highest bucket.** P1 → `kata-spec` review on the spec PR; on pass
-   apply `gh pr edit <n> --add-label spec:approved`. P2 → `kata-spec` to write a
-   spec for the oldest issue. P3 → `kata-product-issue` to triage. All empty →
-   fallback per step 0, then clean.
+   `gh issue list --search "-label:experiment -label:obstacle"` +
+   `wiki/STATUS.md`. Buckets: **P1** open spec PRs whose STATUS row is still
+   `spec draft`. **P2** issues labeled `needs-spec`. **P3** untriaged issues.
+2. **Act.** P1 → `kata-spec` review; post findings via PR comment (never
+   apply `spec:approved` and never write STATUS — both human-only for specs).
+   P2 → `kata-spec` to write a spec for the oldest issue. P3 →
+   `kata-product-issue` to triage. All empty → fallback, then clean.
 
 `kata-interview` is supervisor-initiated, not part of scheduled runs.
 
@@ -51,8 +51,8 @@ Survey all open work items, then act on the highest-priority bucket:
 
 - **Users**: [JTBD.md](JTBD.md) — know which persona and job every issue and
   spec serves.
-- Spec quality is your gate — `spec:approved` is your contract with
-  `kata-release-merge`. Apply the label only after `kata-spec` review passes.
+- Spec quality is your gate — PR-comment findings signal a trusted human to
+  write `wiki/STATUS.md`. Never apply `spec:approved`; never write STATUS.
 - Never make code changes on PR branches (release-engineer scope) — only on your
   own `fix/` branches from issues.
 - **Memory**: [memory-protocol.md](.claude/agents/references/memory-protocol.md)

--- a/.claude/agents/references/approval-signals.md
+++ b/.claude/agents/references/approval-signals.md
@@ -1,0 +1,57 @@
+# Approval Signals
+
+Approval state for spec, design, and plan phases is recorded in
+`wiki/STATUS.md` — the canonical record. STATUS is read by
+`kata-release-merge` to decide which phase PRs may merge. Multiple signal
+types feed STATUS; the agent that observes the signal validates trust and
+writes the row.
+
+## The signals
+
+| Signal | Source | Captured by |
+|---|---|---|
+| `<phase>:approved` label on PR | Human or `/ship-it` | `agent-react` (label event) |
+| `gh pr review --approve` | Trusted-account approver | `agent-react` (review event) |
+| Approval comment ("approve", "LGTM", "ship it") | Trusted contributor on PR | `agent-react` (comment event) |
+| Direct user message in interactive session | Trusted user | Active agent (in-session) |
+| `kata-plan` panel-clean | `staff-engineer` (plans only) | `kata-plan` skill |
+| Implementation merge | `kata-release-merge` | Skill (writes `plan implemented`) |
+
+## Trust rule
+
+Spec and design approvals must originate from a trusted human. Agents
+**never** autonomously originate `spec approved` or `design approved` —
+they only propagate signals already expressed by a trusted human. Plans
+may be approved by `staff-engineer` after a clean `kata-plan` panel
+review.
+
+The release engineer's trust gate (top-7 contributor or `kata-agent-team`)
+is the canonical trust check. `agent-react` runs the same check before
+writing STATUS in response to a PR-side signal.
+
+## In-session approval
+
+When a trusted user explicitly approves a spec, design, or plan in an
+interactive coding session ("approve spec 880", "this design is good,
+mark it approved"), the active agent edits `wiki/STATUS.md` to set the
+matching row, commits the wiki, and lets the Stop hook push. No GitHub
+action is required — STATUS is the canonical record. The merge happens on
+the next `kata-release-merge` run.
+
+## Writing STATUS
+
+`wiki/STATUS.md` wraps a tab-separated body in a fenced code block. To
+update a row, locate the line in the code block and replace it in place.
+Format: `{id}\t{phase}\t{status}`. Phases: `spec`, `design`, `plan`.
+Statuses: `draft`, `approved`, `implemented` (plan only), `cancelled`.
+Lifecycle: `spec draft → spec approved → design draft → design approved →
+plan draft → plan approved → plan implemented`. Cancelled is terminal.
+
+Commit the wiki edit alongside any other wiki updates from the same
+session; the Stop hook pushes wiki commits.
+
+## Labels remain as input signals
+
+Humans may still apply `<phase>:approved` labels for PR UI visibility.
+The label fires `agent-react`, which validates trust and writes STATUS.
+The label is no longer the merge gate.

--- a/.claude/agents/references/coordination-protocol.md
+++ b/.claude/agents/references/coordination-protocol.md
@@ -34,30 +34,41 @@ Valid labels: `agent:staff-engineer`, `agent:product-manager`,
 ## Approval signal
 
 Phase artifacts (specs, designs, plans, implementations) are gated into `main`
-by `kata-release-merge` via a uniform, machine-readable approval signal. Two
-equivalent forms — both first-class GitHub primitives:
+by `kata-release-merge`. Approval state is recorded in `wiki/STATUS.md` — a
+markdown page in the wiki wrapping a tab-separated body, one row per spec:
+`{id}\t{phase}\t{status}`. STATUS is the canonical approval record; see
+[`approval-signals.md`](approval-signals.md) for the full signal catalogue
+and write protocol.
 
-1. **Label** — `<phase>:approved` applied to the PR. Phase labels:
-   - `spec:approved` (applied by product-manager after `kata-spec` review)
-   - `design:approved` (applied by staff-engineer after `kata-design` review)
-   - `plan:approved` (applied by staff-engineer after `kata-plan` review)
-   - `plan:implemented` (applied by `kata-release-merge` on the implementation
-     PR before merge)
-2. **APPROVED PR review** by a trusted account (top-7 contributor or
-   `kata-agent-team`): `gh pr review --approve`.
+Signals from any source below feed STATUS:
 
-`kata-release-merge` accepts either form. The `agent-react` facilitator
-(release-engineer) translates conversational approvals (e.g. "approved", "LGTM",
-"ship it" from a trusted account) into one of the canonical forms before
-concluding.
+- `<phase>:approved` label applied to the PR (human or `/ship-it`)
+- `gh pr review --approve` by a trusted account
+- Approval comment ("approve", "LGTM", "ship it") from a trusted contributor
+- Direct user message in an interactive coding session (trusted user)
+- `kata-plan` panel-clean (`staff-engineer`, plans only)
 
-**Approval is not phase progression.** The approval signal authorizes
-`kata-release-merge` to merge the PR; it does not by itself advance the phase.
-Phase progression is derived only from `main`: the next phase begins when the
-prior phase's artifact (`specs/NNN/spec.md`, `design-a.md`, `plan-a.md`) is on
-`main` — i.e. the prior phase's PR has been merged. An approved-but-unmerged PR
-does not unblock the next phase, even when the same agent owns both. No separate
-status tracker.
+**Trust rule.** Spec and design approvals must originate from a trusted human.
+Agents never autonomously originate `spec approved` or `design approved`; they
+only propagate signals already expressed by a trusted human. Plans may be
+approved by `staff-engineer` after `kata-plan` review.
+
+`agent-react` is the bridge from PR-side signals (labels, comments, reviews)
+to STATUS — it validates trust (using the same gate as `kata-release-merge`)
+and writes the matching STATUS row. The facilitator does **not** apply any
+approval label or submit an APPROVED review on behalf of any contributor; it
+only propagates signals already expressed by trusted humans into STATUS.
+
+**Approval is not phase progression.** A STATUS row at `{phase} approved`
+authorizes `kata-release-merge` to merge that PR; it does not by itself advance
+the phase. Phase progression is derived only from `main`: the next phase begins
+when the prior phase's artifact (`specs/NNN/spec.md`, `design-a.md`,
+`plan-a.md`) is on `main` — i.e. the prior phase's PR has been merged. An
+approved-but-unmerged PR does not unblock the next phase.
+
+**Labels remain as input signals**, not as gates. Humans may apply
+`<phase>:approved` labels for PR UI visibility; the label fires `agent-react`
+which validates trust and writes STATUS.
 
 ## Measurement-system changes
 

--- a/.claude/agents/references/metric-class-guidance.md
+++ b/.claude/agents/references/metric-class-guidance.md
@@ -20,8 +20,8 @@ A new `system-health` metric **co-locates with an existing producer** skill
 that already reads the relevant state for its existing process-throughput
 work; do not create a new skill solely to host a `system-health` metric.
 Worked precedent: `kata-release-merge` records `approvals_recorded_per_run`
-alongside its existing `prs_merged` work because the skill already reads
-`<phase>:approved` label state.
+alongside its existing `prs_merged` work because the skill already iterates
+phase PRs and is the natural place to observe approval-signal events.
 
 ## Cardinality (process-throughput)
 

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -31,8 +31,9 @@ every GitHub comment and PR body with `— Staff Engineer 🛠️`.
 ## Assess
 
 Run `git fetch origin main` on every phase boundary, then route from
-`origin/main` only. A `<phase>:approved` label on an open PR — even one you just
-authored — does not advance routing. Pick the highest-priority action:
+`origin/main` only. A STATUS row at `{phase} approved` on an open PR — even
+one you just authored — does not advance routing; only merge of the prior
+phase's PR puts the artifact on `main`. Pick the highest-priority action:
 
 0. **[Action routing](.claude/agents/references/memory-protocol.md#action-routing)**
    — read Tier 1; owned priorities and storyboard items preempt domain steps.
@@ -42,7 +43,7 @@ authored — does not advance routing. Pick the highest-priority action:
    `design-a.md` is on `origin/main` but `plan-a.md` is not)
 3. **Merged plans awaiting implementation?** -- `kata-implement` on a
    `feat/<spec-slug>` branch (specs/NNN/ where `plan-a.md` is on `origin/main`
-   but no merged PR carries `plan:implemented` referencing the spec)
+   and `wiki/STATUS.md` does not yet show `plan implemented` for the spec)
 4. **Fallback** -- MEMORY.md items listing you under Agents, then report clean.
 
 ## Constraints

--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -5,7 +5,8 @@ description: >
   max-200-line architectural sketch — components, interfaces, data flow, and
   key decisions with trade-offs — that gives reviewers a high-leverage point
   to redirect architecture before the full plan is written. Design is approved
-  when its PR carries the `design:approved` label or an APPROVED review.
+  when `wiki/STATUS.md` shows the spec row at `design approved` — written
+  there by a human signal that `agent-react` or the active agent propagates.
 ---
 
 # Write and Review Designs
@@ -22,8 +23,8 @@ is no commitment to implement, and a design has nothing to shape.
 
 ## When to Use
 
-- Turning a merged spec (`specs/NNN/spec.md` on `origin/main`, not just a
-  `spec:approved` label on an open PR) into an architectural design
+- Turning a merged spec (`specs/NNN/spec.md` on `origin/main`) into an
+  architectural design
 - Reviewing a design before approval ("review design NNN", "is design NNN
   ready?")
 - Revisiting a design whose direction needs rethinking before planning
@@ -33,8 +34,8 @@ is no commitment to implement, and a design has nothing to shape.
 <read_do_checklist goal="Internalize design-writing boundaries before starting">
 
 - [ ] Confirm `specs/NNN/spec.md` exists on `origin/main` after
-      `git fetch origin main`. A `spec:approved` label on an open PR is not
-      sufficient — wait for the merge.
+      `git fetch origin main` — wait for the spec PR to merge before
+      starting a design.
 - [ ] Do not write or revise the spec — return it to `draft` if it needs
       changes.
 - [ ] Do not write the plan — this skill writes the design; `kata-plan`
@@ -119,25 +120,22 @@ not restate what the artifact already shows.
 
 ## Approval
 
-A design is approved when its PR carries the `design:approved` label **or** has
-an APPROVED review by a trusted account. Once the design PR merges,
-`specs/NNN/design-a.md` exists on `main` and the phase is by definition
-complete. See
-[`coordination-protocol.md` § Approval signal](../../agents/references/coordination-protocol.md#approval-signal).
+A design is approved when `wiki/STATUS.md` shows its row at `design
+approved`. **Human-only**: agents never originate `design approved` — they
+only propagate signals already expressed by a trusted human (label, APPROVED
+review, approval comment, or in-session message), which `agent-react` or
+the active agent writes to STATUS. See
+[`approval-signals.md`](../../agents/references/approval-signals.md).
 
 ## Reviewing a Design
 
-Evaluate `design-a.md` against the qualities listed in "Writing a Design" above,
-then run the DO-CONFIRM checklist at the top of this skill.
+Evaluate `design-a.md` against the qualities listed in "Writing a Design"
+above, then run the DO-CONFIRM checklist. Report findings via PR comment.
 
-If all criteria are met, apply the approval signal:
-
-```sh
-gh pr edit <number> --add-label design:approved
-```
-
-If any criterion falls short, request changes via PR comment — do not apply the
-label.
+**Do not recommend approval, and do not apply the `design:approved` label.**
+Deciding on approval is a human-only action. Your job is to evaluate quality
+and surface findings; the release engineer reads `wiki/STATUS.md` to gate
+merge. If criteria fall short, request changes via PR comment.
 
 ## Process
 
@@ -150,8 +148,7 @@ from prior entries.
 ### Step 1: Find the spec
 
 Run `git fetch origin main`, then confirm `specs/NNN/spec.md` exists on
-`origin/main`. An open PR with a `spec:approved` label is not sufficient — wait
-for the merge.
+`origin/main` — wait for the spec PR to merge before starting a design.
 
 ### Step 2: Study the spec
 
@@ -163,23 +160,22 @@ Read the code areas the spec targets.
 
 ### Step 4: Write the design
 
-Create `design-a.md`. Stay under 200 lines. Each architectural choice names a
-rejected alternative.
+Create `design-a.md` locally; do not push yet. Stay under 200 lines. Each
+architectural choice names a rejected alternative.
 
-### Step 5: Open a design PR
-
-The PR title carries the spec id: `design(NNN): …`.
-
-### Step 6: Clean sub-agent review panel
+### Step 5: Clean sub-agent review panel
 
 Follow the [`kata-review` caller
-protocol](../kata-review/references/caller-protocol.md). Tell each reviewer not
-to invoke `kata-design`. Address every confirmed blocker/high/medium finding
-before advancing.
+protocol](../kata-review/references/caller-protocol.md), invoked on the local
+`design-a.md` before push. Tell each reviewer not to invoke `kata-design`.
+Address every confirmed blocker/high/medium finding before opening the PR —
+the PR should not become visible to `agent-react` until the panel is clean.
 
-### Step 7: Apply approval signal
+### Step 6: Open a design PR
 
-When the panel passes, run `gh pr edit <number> --add-label design:approved`.
+The PR title carries the spec id: `design(NNN): …`. Do not apply the
+`design:approved` label and do not recommend approval — those are human-only
+actions; see § Approval.
 
 ## Memory: what to record
 

--- a/.claude/skills/kata-implement/SKILL.md
+++ b/.claude/skills/kata-implement/SKILL.md
@@ -30,7 +30,7 @@ apply alongside the skill-specific ones below.
 <read_do_checklist goal="Internalize scope and constraints before coding">
 
 - [ ] Run `git fetch origin main`, then confirm `specs/NNN/plan-a.md` exists on
-      `origin/main` (an open `plan:approved` PR is not enough — wait for merge).
+      `origin/main` — wait for the plan PR to merge before implementing.
 - [ ] Enter a new worktree with `EnterWorktree` (e.g. name `impl/NNN`). All
       implementation work happens in the worktree — never on the main working
       tree.

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -3,8 +3,9 @@ name: kata-plan
 description: >
   Write implementation plans (HOW/WHEN) for approved designs. Translate an
   approved design into concrete steps, file changes, sequencing, and risks
-  for a trusted agent to execute. Plan is approved when its PR carries the
-  `plan:approved` label or an APPROVED review.
+  for a trusted agent to execute. Plan is approved when `wiki/STATUS.md`
+  shows the spec row at `plan approved` — `staff-engineer` writes this row
+  after a clean panel review (plans may be approved by agents).
 ---
 
 # Write and Review Plans
@@ -20,8 +21,8 @@ there is no architectural direction to translate into implementation steps.
 
 ## When to Use
 
-- Turning a merged design (`specs/NNN/design-a.md` on `origin/main`, not just a
-  `design:approved` label on an open PR) into an execution-ready plan
+- Turning a merged design (`specs/NNN/design-a.md` on `origin/main`) into an
+  execution-ready plan
 - Reviewing a plan before approval ("review plan NNN", "is plan NNN ready?")
 - Creating an alternative plan variant for the same spec
 
@@ -30,8 +31,8 @@ there is no architectural direction to translate into implementation steps.
 <read_do_checklist goal="Internalize plan-writing boundaries before starting">
 
 - [ ] Confirm `specs/NNN/design-a.md` exists on `origin/main` after
-      `git fetch origin main`. A `design:approved` label on an open PR is not
-      sufficient — wait for the merge.
+      `git fetch origin main` — wait for the design PR to merge before
+      starting a plan.
 - [ ] Do not write or revise the spec — return it to `draft` if it needs
       changes.
 - [ ] Do not implement — this skill writes the plan; `kata-implement` executes
@@ -110,20 +111,23 @@ row, make it a row.
 
 ## Approval
 
-Plan is approved when its PR carries `plan:approved` or has an APPROVED review
-by a trusted account. See
+A plan is approved when `wiki/STATUS.md` shows the spec row at `plan
+approved`. Plans may be approved by `staff-engineer` after a clean
+`kata-plan` panel review; alternatively, the same human-driven signals that
+gate spec/design (label, PR comment, APPROVED review, in-session user
+message) also feed STATUS for plans. See
+[`approval-signals.md`](../../agents/references/approval-signals.md) and
 [`coordination-protocol.md` § Approval signal](../../agents/references/coordination-protocol.md#approval-signal).
 
 ## Reviewing a Plan
 
-Evaluate the plan against the DO-CONFIRM checklist. If all criteria are met,
-apply the approval signal:
+Evaluate the plan against the DO-CONFIRM checklist. If all criteria are
+met, edit `wiki/STATUS.md` to set the spec's row to `{NNN}\tplan\tapproved`
+and commit the wiki edit; the Stop hook pushes it. `kata-release-merge` will
+then merge the plan PR.
 
-```sh
-gh pr edit <number> --add-label plan:approved
-```
-
-If any falls short, request changes via PR comment — do not apply the label.
+If any criterion falls short, request changes via PR comment — do not write
+STATUS until the criteria are met.
 
 When multiple variants exist, note which is recommended (plan-a is the default).
 
@@ -137,8 +141,7 @@ deferred work from prior entries.
 ### Step 1: Find the design
 
 Run `git fetch origin main`, then confirm `specs/NNN/design-a.md` exists on
-`origin/main`. An open PR with a `design:approved` label is not sufficient —
-wait for the merge.
+`origin/main` — wait for the design PR to merge before starting a plan.
 
 ### Step 2: Study the spec and design
 
@@ -150,23 +153,28 @@ Read the files the plan will target.
 
 ### Step 4: Write the plan
 
-Create `plan-a.md`. Each step independently verifiable. Decompose into parts if
-large (see § Large plan decomposition).
+Create `plan-a.md` locally; do not push yet. Each step independently
+verifiable. Decompose into parts if large (see § Large plan decomposition).
 
-### Step 5: Open a plan PR
+### Step 5: Clean sub-agent review panel
+
+Follow the [`kata-review` caller
+protocol](../kata-review/references/caller-protocol.md), invoked on the local
+`plan-a.md` (and any parts) before push. Tell each reviewer not to invoke
+`kata-plan`. Address every confirmed blocker/high/medium finding before
+opening the PR — the PR should not become visible to `agent-react` until the
+panel is clean.
+
+### Step 6: Open a plan PR
 
 The PR title carries the spec id: `plan(NNN): …`.
 
-### Step 6: Clean sub-agent review panel
+### Step 7: Write STATUS
 
-Follow the [`kata-review` caller
-protocol](../kata-review/references/caller-protocol.md). Tell each reviewer not
-to invoke `kata-plan`. Address every confirmed blocker/high/medium finding
-before advancing.
-
-### Step 7: Apply approval signal
-
-When the panel passes, run `gh pr edit <number> --add-label plan:approved`.
+When the panel passes and the DO-CONFIRM checks are met, edit
+`wiki/STATUS.md` to set the spec's row to `{NNN}\tplan\tapproved`. Commit the
+wiki edit alongside any other wiki updates from this session; the Stop hook
+pushes the wiki commit. `kata-release-merge` will then merge the plan PR.
 
 ## Memory: what to record
 

--- a/.claude/skills/kata-release-merge/SKILL.md
+++ b/.claude/skills/kata-release-merge/SKILL.md
@@ -3,8 +3,8 @@ name: kata-release-merge
 description: >
   Merge gate for open pull requests. Verify contributor trust, classify PR
   type, rebase branches on main, fix mechanical CI failures, gate on the
-  generalized approval signal (`<phase>:approved` label or APPROVED review),
-  and merge PRs that pass all gates. Sole external merge point.
+  approval state recorded in `wiki/STATUS.md`, and merge PRs that pass all
+  gates. Sole external merge point.
 ---
 
 # Release Merge
@@ -35,8 +35,8 @@ Comment templates and the report format are in `references/templates.md`.
 - [ ] Author is trusted — CI app identity or top-7 contributor lookup ran.
 - [ ] PR type parsed from title prefix.
 - [ ] All CI checks pass (after mechanical fixes if needed).
-- [ ] Approval signal present: `<phase>:approved` label OR APPROVED review by a
-      trusted account.
+- [ ] `wiki/STATUS.md` row for the spec id shows the matching phase at
+      `approved` (or `implemented` for the terminal plan row).
 - [ ] For implementation PRs: parent spec's `plan-a.md` exists on `main`.
 
 </do_confirm_checklist>
@@ -82,9 +82,9 @@ PR).
 
 Parse the title using `type(scope): subject`. Each type maps to a phase:
 
-- `spec` → spec phase, gate label `spec:approved`
-- `design` → design phase, gate label `design:approved`
-- `plan` → plan phase, gate label `plan:approved`
+- `spec` → spec phase, gate STATUS row `{NNN}\tspec\tapproved`
+- `design` → design phase, gate STATUS row `{NNN}\tdesign\tapproved`
+- `plan` → plan phase, gate STATUS row `{NNN}\tplan\tapproved`
 - `feat`, `fix`, `bug`, `refactor`, `chore` → implementation phase
 - `!` breaking variants retain the base type
 - Any other type → mark **blocked**
@@ -128,18 +128,13 @@ git push --force-with-lease origin <pr-branch>
 
 ### Step 6: Approval Gate
 
-A PR passes when **at least one** holds:
-
-1. The PR carries the matching phase label (`spec:approved` / `design:approved`
-   / `plan:approved`).
-2. The PR has at least one APPROVED review by a trusted account (top-7
-   contributor or `kata-agent-team`):
-   ```sh
-   gh pr view <number> --json reviews \
-     --jq '[.reviews[] | select(.state == "APPROVED")] | length'
-   ```
-
-If neither holds, mark **blocked** with reason `awaiting approval signal`.
+Read `wiki/STATUS.md` for the PR's spec id (`grep -P "^${spec_id}\t"`). The
+PR passes when the row shows the PR's classified phase at `approved` (or
+`implemented` for the terminal plan row on implementation PRs). If absent
+or `draft`/`cancelled`, mark **blocked** with reason `awaiting approval
+signal`. Labels and APPROVED reviews are inputs to STATUS captured by
+`agent-react`; not consulted directly here. See
+[`approval-signals.md`](../../agents/references/approval-signals.md).
 
 ### Step 7: Implementation PR Spec Check
 
@@ -148,10 +143,8 @@ spec id (e.g. `feat(...): … (#NNN)` or "implements spec NNN"):
 
 - Confirm `specs/NNN/plan-a.md` exists on `main`. If absent, mark **blocked**
   with reason `parent spec plan not on main`.
-- Apply the terminal label before merging:
-  ```sh
-  gh pr edit <number> --add-label plan:implemented
-  ```
+- Update `wiki/STATUS.md` before merging — set the spec's row to
+  `{NNN}\tplan\timplemented`. Commit the wiki change; the Stop hook pushes it.
 
 PRs not referencing a spec (one-off mechanical fixes, doc patches) skip this
 step.
@@ -172,11 +165,12 @@ Per PR record: number, title, type, author, trust check, CI, approval source
 
 Append to the current week's log:
 
-- **PR classification table** — type, author, trust, CI, approval source,
+- **PR classification table** — type, author, trust, CI, STATUS row,
   verdict, consecutive-block count
 - **Contributor trust decisions** — checked by the invariant audit (KATA.md
   § Invariants)
-- **Approval signals consumed** — label vs APPROVED review
+- **STATUS rows consumed and written** — gate reads and `plan implemented`
+  writes
 - **PRs merged this run** and **merge failures** with reasons
 - **Metrics** — Append `prs_merged` and `approvals_recorded_per_run` rows per
   `references/metrics.md` (collection recipe included). See KATA.md § Metrics

--- a/.claude/skills/kata-release-merge/references/metrics.md
+++ b/.claude/skills/kata-release-merge/references/metrics.md
@@ -6,10 +6,9 @@ Record per KATA.md § Metrics. Append one row per metric per run to
 | Metric                     | Unit  | Description                                                                                                    | Data source                                                                |
 | -------------------------- | ----- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | prs_merged                 | count | PRs merged this run                                                                                            | Run actions                                                                |
-| approvals_recorded_per_run | count | `<phase>:approved` label-add events + APPROVED review events observed in `[prev_run_start, current_run_start)` | `gh api repos/{owner}/{repo}/issues/<n>/timeline` + `.../pulls/<n>/reviews` |
+| approvals_recorded_per_run | count | Inbound human approval signals — `<phase>:approved` label-add events + APPROVED review events — observed in `[prev_run_start, current_run_start)`. These signals feed `wiki/STATUS.md` via `agent-react`. | `gh api repos/{owner}/{repo}/issues/<n>/timeline` + `.../pulls/<n>/reviews` |
 
-Backlog (`gh pr list`) is queried, not recorded. `plan:implemented` is a state
-label, excluded.
+Backlog (`gh pr list`) is queried, not recorded.
 
 ## Collection
 

--- a/.claude/skills/kata-release-merge/references/templates.md
+++ b/.claude/skills/kata-release-merge/references/templates.md
@@ -19,7 +19,7 @@ gh pr comment <number> --body "Release merge: skipping — PR type \`<type>\` re
 ### Awaiting Approval Signal
 
 ```sh
-gh pr comment <number> --body "Release merge: blocked — awaiting approval signal. Apply \`<phase>:approved\` label or submit an APPROVED review."
+gh pr comment <number> --body "Release merge: blocked — \`wiki/STATUS.md\` row for spec NNN does not yet show \`<phase>\tapproved\`. Apply \`<phase>:approved\` label, submit an APPROVED review, or post an approval comment from a trusted account; \`agent-react\` will propagate it into STATUS."
 ```
 
 ### CI Failing
@@ -35,7 +35,7 @@ gh pr comment <number> --body "Release merge: blocked — substantive conflicts 
 ## Merge Comment
 
 ```sh
-gh pr comment <number> --body "Release merge: all gates pass — type \`<type>\`, CI green, author trusted, approval via \`<label|review>\`. Merging."
+gh pr comment <number> --body "Release merge: all gates pass — type \`<type>\`, CI green, author trusted, STATUS row \`<phase>\tapproved\`. Merging."
 gh pr merge <number> --merge --delete-branch
 ```
 
@@ -50,12 +50,12 @@ If still `OPEN`, note in the summary rather than reporting as merged.
 ## Report Summary
 
 ```
-| PR  | Title                          | Type | Author | CI    | Approval | Action  | Reason                          |
-| --- | ------------------------------ | ---- | ------ | ----- | -------- | ------- | ------------------------------- |
-| #42 | fix(map): schema validation    | fix  | alice  | green | label    | merged  | All gates pass                  |
-| #38 | spec(security): SSRF hardening | spec | bob    | green | —        | blocked | Awaiting approval signal        |
-| #35 | feat(pathway): export feature  | feat | carol  | red   | —        | blocked | CI failing: format check        |
-| #31 | fix(libui): color contrast     | fix  | eve    | green | —        | blocked | Author not in top contributors  |
+| PR  | Title                          | Type | Author | CI    | STATUS         | Action  | Reason                          |
+| --- | ------------------------------ | ---- | ------ | ----- | -------------- | ------- | ------------------------------- |
+| #42 | fix(map): schema validation    | fix  | alice  | green | n/a            | merged  | All gates pass                  |
+| #38 | spec(security): SSRF hardening | spec | bob    | green | spec draft     | blocked | STATUS row not at spec approved |
+| #35 | feat(pathway): export feature  | feat | carol  | red   | plan approved  | blocked | CI failing: format check        |
+| #31 | fix(libui): color contrast     | fix  | eve    | green | n/a            | blocked | Author not in top contributors  |
 ```
 
 **Flag PRs blocked across 3+ consecutive runs** prominently above the table —

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -2,10 +2,12 @@
 name: kata-spec
 description: >
   Write specifications (WHAT/WHY) for features, changes, and improvements.
-  Spec is approved when its PR carries the `spec:approved` label or an
-  APPROVED review by a trusted account. Use when proposing changes, capturing
-  findings as actionable specs, or evaluating spec quality. Pair with the
-  `kata-plan` skill for the HOW side.
+  Spec is approved when `wiki/STATUS.md` shows the spec row at `spec
+  approved` — written there by a human signal (label, comment, APPROVED
+  review, or in-session message) that `agent-react` or the active agent
+  propagates. Use when proposing changes, capturing findings as actionable
+  specs, or evaluating spec quality. Pair with the `kata-plan` skill for
+  the HOW side.
 ---
 
 # Write and Review Specs
@@ -87,25 +89,36 @@ not restate what the artifact already shows.
 
 ## Approval
 
-A spec is approved when its PR carries the `spec:approved` label **or** has an
-APPROVED review by a trusted account (top-7 contributor or `kata-agent-team`).
-Phase progression is derived from `main`: once a spec PR merges,
-`specs/NNN/spec.md` exists on `main` and the spec is by definition approved. See
+A spec is approved when `wiki/STATUS.md` shows its row at `spec approved`.
+The decision is **human-only**: agents never autonomously originate `spec
+approved`. STATUS is written when a trusted human's signal is observed —
+`<phase>:approved` label, APPROVED review, approval comment on the PR, or a
+direct message in an interactive session. `agent-react` validates trust and
+propagates PR-side signals into STATUS; an in-session agent writes STATUS
+when the user explicitly approves. See
+[`approval-signals.md`](../../agents/references/approval-signals.md) and
 [`coordination-protocol.md` § Approval signal](../../agents/references/coordination-protocol.md#approval-signal).
+
+Phase progression is derived from `main`: once the spec PR merges,
+`specs/NNN/spec.md` exists on `main` and the next phase may begin. A STATUS
+row at `spec approved` authorizes the merge but does not by itself advance
+the phase.
 
 ## Reviewing a Spec
 
-Evaluate `spec.md` against the qualities listed in "Writing a Spec" above, then
-run the DO-CONFIRM checklist at the top of this skill.
+Evaluate `spec.md` against the qualities listed in "Writing a Spec" above,
+then run the DO-CONFIRM checklist at the top of this skill. Report your
+findings via PR comment so a trusted human reviewing the PR can act on
+them.
 
-If all criteria are met, apply the approval signal:
+**Do not recommend approval, and do not apply the `spec:approved` label.**
+Deciding on approval is a human-only action. The release engineer detects
+approval signals across multiple channels — labels, PR comments, APPROVED
+reviews, in-session user messages — and reads `wiki/STATUS.md` as the
+canonical record. Your job here is to evaluate quality and surface
+findings, not to gate the approval signal.
 
-```sh
-gh pr edit <number> --add-label spec:approved
-```
-
-If any criterion falls short, request changes via PR comment — do not apply the
-label.
+If criteria fall short, request changes via PR comment.
 
 ## Process
 
@@ -119,25 +132,22 @@ Read relevant code, data, and existing specs.
 
 ### Step 3: Write the spec
 
-WHAT and WHY only.
+WHAT and WHY only. Write `specs/NNN/spec.md` locally; do not push yet.
 
-### Step 4: Open a spec PR
-
-The PR title carries the spec id: `spec(NNN): …`. Merge of that PR is what
-advances the phase.
-
-### Step 5: Clean sub-agent review panel
+### Step 4: Clean sub-agent review panel
 
 Follow the [`kata-review` caller
-protocol](../kata-review/references/caller-protocol.md). Tell each reviewer not
-to invoke `kata-spec`. Address every confirmed blocker/high/medium finding
-before advancing.
+protocol](../kata-review/references/caller-protocol.md), invoked on the local
+`specs/NNN/spec.md` before push. Tell each reviewer not to invoke
+`kata-spec`. Address every confirmed blocker/high/medium finding before
+opening the PR — the PR should not become visible to `agent-react` until the
+panel is clean.
 
-### Step 6: Apply approval signal
+### Step 5: Open a spec PR
 
-When the panel passes and the DO-CONFIRM checks are met, run
-`gh pr edit <number> --add-label spec:approved` so `kata-release-merge` lets
-the PR through.
+The PR title carries the spec id: `spec(NNN): …`. Merge of that PR is what
+advances the phase. Do not apply the `spec:approved` label and do not
+recommend approval — those are human-only actions; see § Approval.
 
 ## Memory: what to record
 

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -34,16 +34,17 @@ advancing to the next phase. Examples:
 - **Implementation branch** — contains code changes implementing an approved
   plan. Ship the implementation.
 - **Non-spec branch** — contains code changes unrelated to a spec (bug fix,
-  chore, docs). Ship as-is with no STATUS update.
+  chore, docs). Ship as-is with no STATUS write.
 
 If the work on the branch is incomplete or broken, **stop and tell the user** —
 do not attempt to finish it.
 
 ## Shipping Implies Approval
 
-Shipping a spec-tracked deliverable inherently means approving it. Step 2
-applies the matching `<phase>:approved` label to the PR before the mechanical
-ship process begins.
+Shipping a spec-tracked deliverable inherently means approving it. The human
+invoker is the approver; the skill performs the typing. Step 2 writes the
+matching row in `wiki/STATUS.md` — the canonical approval record — before
+the mechanical ship process begins.
 
 ## Checklists
 
@@ -51,7 +52,7 @@ ship process begins.
 
 - [ ] Current branch is not `main`.
 - [ ] Scope limited to work already on the branch.
-- [ ] `<phase>:approved` label applied to the PR (if spec-tracked).
+- [ ] `wiki/STATUS.md` row updated for the spec (if spec-tracked).
 - [ ] Rebased cleanly on `origin/main` (no unresolved conflicts).
 - [ ] `bun run check` and `bun run test` pass locally.
 - [ ] PR exists and its body follows the repo's Summary / Test plan template.
@@ -79,20 +80,19 @@ fi
 ### Step 2: Approve the Work (spec-tracked branches only)
 
 If the branch contains spec-tracked work (a spec, design, plan, or
-implementation), apply the matching label to the PR before proceeding. The PR
-must already exist (Step 6 handles creation when it doesn't); for first ships,
-push the branch and open the PR first, then return here for the label.
+implementation), edit `wiki/STATUS.md` to set the matching row before
+proceeding. The wiki commit is pushed by the Stop hook.
 
-| Deliverable    | Label              |
-| -------------- | ------------------ |
-| `spec.md`      | `spec:approved`    |
-| `design-a.md`  | `design:approved`  |
-| `plan-a.md`    | `plan:approved`    |
-| Implementation | `plan:implemented` |
+| Deliverable    | STATUS row           |
+| -------------- | -------------------- |
+| `spec.md`      | `{NNN}\tspec\tapproved`    |
+| `design-a.md`  | `{NNN}\tdesign\tapproved`  |
+| `plan-a.md`    | `{NNN}\tplan\tapproved`    |
+| Implementation | `{NNN}\tplan\timplemented` |
 
-```sh
-gh pr edit <number> --add-label <phase>:approved
-```
+Locate the row for the spec id in the fenced code block of `wiki/STATUS.md`
+and replace it in place. If the row is absent (new spec), insert it in
+sorted-id order.
 
 Skip this step for branches with no spec association (bug fixes, chores, docs).
 

--- a/.github/workflows/agent-react.yml
+++ b/.github/workflows/agent-react.yml
@@ -162,7 +162,7 @@ jobs:
 
           Ensure follow-through: when the agent answers, verify they acted on what was within their scope. If they acknowledged but deferred actionable work, send them back to complete it before you conclude.
 
-          Approval translation: when a thread participant signals approval on a phase PR (e.g. 'approved', 'LGTM', 'ship it' on a spec/design/plan PR by a trusted account), translate it into the canonical signal — \`gh pr review --approve\` and/or \`gh pr edit --add-label <phase>:approved\` — before concluding.
+          Approval propagation: when a trusted-contributor approval signal appears on a phase PR (e.g. \`<phase>:approved\` label applied, APPROVED review submitted, or an approval comment such as 'approved', 'LGTM', 'ship it'), validate trust using the release-engineer trust gate (top-7 contributor or \`kata-agent-team\`) and edit \`wiki/STATUS.md\` to set the spec's row to the matching \`{phase} approved\` state. Commit the wiki edit; the Stop hook pushes it. Do **not** apply any approval label or submit an APPROVED review on behalf of any contributor — only propagate signals already expressed by trusted humans. See \`.claude/agents/references/approval-signals.md\` for the full signal catalogue.
 
           Recursion guard (this channel allows bot-authored content so agents can coordinate with each other): before engaging any participant, read the thread history. If the most recent activity is already a response from one of the participant agents you facilitate (product-manager, release-engineer, security-engineer, staff-engineer, technical-writer), stop immediately without engaging anyone — only respond when the latest content introduces a new question, request, or change for them to act on."
 

--- a/KATA.md
+++ b/KATA.md
@@ -104,8 +104,8 @@ agent is a one-line edit to the matrix in
 below use CEST (UTC+2), the tighter summer bound. A separate event-driven
 workflow, **agent-react**, runs on PR comments, new discussions, and
 discussion comments — the release engineer facilitates and routes the comment
-to the participant best suited to respond, and translates conversational
-approvals into the canonical `<phase>:approved` label or APPROVED review. All
+to the participant best suited to respond, and propagates trusted-contributor
+approval signals into `wiki/STATUS.md`. All
 workflows support `workflow_dispatch` and time out at 45 minutes; storyboard,
 coaching, and react also use concurrency groups (agent-team serializes via the
 matrix's `max-parallel: 1`). Agent workflows send a generic prompt; the agent's Assess
@@ -147,13 +147,16 @@ for utilities). An agent's skill list reveals its phase coverage.
 
 The release engineer is the sole external merge point; all other merge paths
 operate on trusted sources (our agents, Dependabot). The product manager gates
-spec **quality** off the critical path via the `spec:approved` label.
+spec **quality** off the critical path via PR-comment findings; trusted
+humans translate those findings into `wiki/STATUS.md` writes that release
+engineer reads at merge time.
 
 ```mermaid
 graph TD
-    EXT["External PR"] --> RE["Release Engineer<br/>trust + CI gate"]
-    ISS["External Issue"] --> PM["Product Manager<br/>spec quality"]
-    PM -- "spec:approved" --> RE
+    EXT["External PR"] --> RE["Release Engineer<br/>trust + CI + STATUS gate"]
+    ISS["External Issue"] --> PM["Product Manager<br/>spec quality findings"]
+    PM -.->|"findings"| HU["Trusted Human<br/>writes STATUS"]
+    HU -.->|"wiki/STATUS.md"| RE
     RE -- "merge fix/bug/spec" --> CB["Codebase (main)"]
     style RE fill:#a855f7,stroke:#7c3aed,color:#fff
     CB -- "approved spec" --> TA["Trusted Agents<br/>plan + implement"]
@@ -173,21 +176,30 @@ specs merge only the document, not code.
 
 ## Approval Signal
 
-Phase progression is derived from `main` (artifact files exist) plus a uniform,
-machine-readable approval signal applied to PRs. The signal has two equivalent
-forms — both are first-class GitHub primitives, queryable, and auditable:
+Approval state is recorded in the wiki at `STATUS.md` — a markdown page
+wrapping a tab-separated body, one row per spec:
+`{id}\t{phase}\t{status}`. STATUS is the canonical approval record;
+`kata-release-merge` reads it to decide which phase PRs may merge. Signals
+from any source below feed STATUS.
 
-1. **Label** — `<phase>:approved` applied via `gh pr edit --add-label`.
-2. **APPROVED review** — `gh pr review --approve` by a trusted account (top-7
-   contributor or `kata-agent-team`).
+| Signal | Source | Captured by |
+|---|---|---|
+| `<phase>:approved` label | Human or `/ship-it` | `agent-react` |
+| APPROVED review | Trusted-account approver | `agent-react` |
+| Approval comment ("LGTM", "ship it") | Trusted contributor | `agent-react` |
+| In-session user message | Trusted user | Active agent |
+| `kata-plan` panel-clean | `staff-engineer` (plans only) | `kata-plan` skill |
 
-Four labels span the four phases: `spec:approved`, `design:approved`,
-`plan:approved`, and the terminal `plan:implemented` (set by
-`kata-release-merge` on the implementation PR before merge).
+**Human-only for spec/design.** Agents never autonomously originate `spec
+approved` or `design approved` — they only propagate signals from trusted
+humans. Plans may be approved by `staff-engineer` after `kata-plan` review.
 
-`kata-release-merge` checks for either form before merging any phase PR. The
-`agent-react` facilitator translates conversational approvals (e.g. "LGTM" from
-a trusted account) into the canonical signal.
+Phase progression is derived from `main`: a STATUS row at `{phase} approved`
+authorizes `kata-release-merge` to merge the PR; merging the PR puts the
+artifact on `main` and the next phase may begin. `kata-release-merge` writes
+the terminal `plan implemented` row on the implementation PR before merge.
+See [approval-signals.md](.claude/agents/references/approval-signals.md) for
+the full protocol.
 
 ## Design Principles
 
@@ -219,12 +231,15 @@ gitignored, and only the `Stop` hook publishes wiki commits; never
 
 Each agent maintains a **summary** (`<agent>.md`) — latest state, backlog,
 blockers, teammate observations — and a **weekly log**
-(`<agent>-<YYYY>-W<VV>.md`), one file per agent per ISO week. The canonical
-read-summary, append-log, update-summary cadence is defined in
+(`<agent>-<YYYY>-W<VV>.md`), one file per agent per ISO week. The wiki also
+holds `STATUS.md`, the canonical approval record for every spec (see §
+Approval Signal). The canonical read-summary, append-log, update-summary
+cadence is defined in
 [`memory-protocol.md`](.claude/agents/references/memory-protocol.md), an
 agent-level shared reference. Entry-point skills include a read step and a
-"Memory: what to record" section; sub-skills and utility skills are exempt. The
-wiki holds settled state — open questions live in Discussions until answered.
+"Memory: what to record" section; sub-skills and utility skills are exempt.
+The wiki holds settled state — open questions live in Discussions until
+answered.
 
 ## Coordination Channels
 
@@ -349,7 +364,8 @@ The trust gate is the most critical invariant in the system:
   PR before a mergeable verdict. Author verified against the result. A merge
   without a visible lookup is high-severity.
 - CI status checked before every mergeable verdict.
-- Phase PRs gated on `<phase>:approved` label or APPROVED review before merge.
+- Phase PRs gated on `wiki/STATUS.md` showing the spec at `{phase} approved`
+  before merge.
 - `--force-with-lease` used for rebase pushes, never `--force`.
 - Tags pushed individually, not via `--tags`.
 - Releases performed in dependency order.
@@ -366,7 +382,9 @@ The trust gate is the most critical invariant in the system:
 
 ### Product manager
 
-- Spec quality reviewed (`kata-spec` review) before applying `spec:approved`.
+- Spec quality reviewed (`kata-spec` review) and findings posted via PR
+  comment; never applies `spec:approved` and never writes the spec's STATUS
+  row directly.
 - Spec written for `needs-spec` issues when no spec PRs are pending review.
 
 ### Security engineer


### PR DESCRIPTION
## Summary

Tighten the kata spec → design → plan → implement pipeline against two
structural problems: the **race window during in-PR panel review** (panels
ran after the PR opened, allowing `agent-react` to spawn parallel agents on
the same branch), and the **agent-applied approval gate** (agents
autonomously decided spec/design approval after panel review).

Three coordinated changes:

1. **Panel-before-PR across all phase skills.** `kata-spec`, `kata-design`,
   `kata-plan` now run the `kata-review` panel against the local artifact
   before opening the PR — converging on the ordering `kata-implement`
   already uses. The PR never becomes visible to `agent-react` until the
   panel is clean.

2. **`wiki/STATUS.md` becomes the canonical approval record.** Reintroduces
   the historical `specs/STATUS` (removed in `420a99d4`) at a single
   per-repo wiki location, fixing the branch-divergence problem that killed
   the original. Tab-separated body inside a markdown wrapper so the GitHub
   wiki web UI renders it natively. Phase lifecycle and format unchanged.

3. **Human-only approval for spec/design.** `kata-spec` and `kata-design` no
   longer apply `<phase>:approved` labels. `agent-react` (on PR-side
   trusted-contributor signals) and in-session agents (on direct user
   approval) propagate signals into STATUS. Plans may still be approved by
   `staff-engineer` after `kata-plan` panel review.

Other simplifications:
- `kata-release-merge` Step 6 reads `wiki/STATUS.md` (replaces label/review
  gate); Step 7 writes STATUS `plan implemented` (replaces
  `plan:implemented` label)
- `/ship-it` Step 2 writes STATUS instead of applying labels
- `product-manager` Assess routes via STATUS row state
- `agent-react` task text: facilitator propagates signals into STATUS,
  never originates approval labels or reviews
- `KATA.md § Approval Signal` collapses prose to a 5-row table
- New `approval-signals.md` reference codifies the full signal catalogue
  and the in-session approval pattern

Plan file: `/root/.claude/plans/i-want-to-tighten-merry-moth.md` (in
container; reviewer approved). Net source-tree delta: +312 / −218.

## Deployment dependency: wiki seed

The wiki cannot be written from this container, so the initial
`STATUS.md` page is supplied below. **A maintainer must create the wiki
page at `STATUS.md` with the content of the fenced block** after this PR
merges. Until that page exists, `kata-release-merge` and downstream phase
skills will treat every spec as `draft`.

The content below is auto-generated from `specs/*/` directories on the
target branch. For each spec it picks the most advanced phase present:
`plan-a.md` → `plan implemented`, `design-a.md` → `design approved`,
`spec.md` → `spec approved`. Two spec ids (160, 660) have duplicate
directory prefixes — both directories have merged plans, so the row is
`plan implemented` for the single canonical row.

<details>
<summary>Wiki seed: <code>STATUS.md</code> (paste verbatim into the wiki page)</summary>

````markdown
# Spec Status

Format: `{id}<TAB>{phase}<TAB>{status}`. Phases: `spec`, `design`, `plan`.
Statuses: `draft`, `approved`, `implemented` (plan only), `cancelled`.

Lifecycle: spec draft → spec approved → design draft → design approved →
plan draft → plan approved → plan implemented. Any row may transition to
`{phase} cancelled` at any point; cancelled is terminal. One row per spec,
updated in place.

```
010	plan	implemented
020	plan	implemented
040	plan	implemented
050	plan	implemented
051	plan	implemented
052	plan	implemented
060	plan	implemented
061	plan	implemented
062	plan	implemented
063	plan	implemented
070	plan	implemented
080	plan	implemented
090	plan	implemented
100	plan	implemented
110	plan	implemented
120	plan	implemented
130	plan	implemented
140	plan	implemented
150	plan	implemented
160	plan	implemented
170	plan	implemented
180	plan	implemented
190	plan	implemented
200	plan	implemented
210	plan	implemented
220	plan	implemented
230	plan	implemented
240	plan	implemented
250	plan	implemented
260	design	approved
270	plan	implemented
280	plan	implemented
290	plan	implemented
300	plan	implemented
310	plan	implemented
320	plan	implemented
330	plan	implemented
340	plan	implemented
350	plan	implemented
360	plan	implemented
370	plan	implemented
380	plan	implemented
390	plan	implemented
400	plan	implemented
410	plan	implemented
420	plan	implemented
430	plan	implemented
440	plan	implemented
450	plan	implemented
460	plan	implemented
470	plan	implemented
480	plan	implemented
490	plan	implemented
500	plan	implemented
510	design	approved
520	plan	implemented
530	plan	implemented
540	plan	implemented
550	plan	implemented
560	plan	implemented
570	plan	implemented
580	plan	implemented
590	plan	implemented
600	plan	implemented
610	plan	implemented
620	plan	implemented
630	plan	implemented
640	spec	approved
650	spec	approved
660	plan	implemented
670	plan	implemented
680	plan	implemented
690	plan	implemented
700	plan	implemented
710	plan	implemented
720	plan	implemented
730	plan	implemented
740	plan	implemented
750	plan	implemented
760	plan	implemented
770	plan	implemented
780	plan	implemented
790	plan	implemented
800	plan	implemented
810	plan	implemented
820	plan	implemented
830	plan	implemented
840	plan	implemented
850	plan	implemented
860	design	approved
870	plan	implemented
880	plan	implemented
890	plan	implemented
900	spec	approved
910	spec	approved
920	plan	implemented
930	plan	implemented
950	spec	approved
960	plan	implemented
```
````

</details>

## Test plan

- [ ] `bun run check` passes (verified locally on the branch).
- [ ] `bun run test` — pre-existing infrastructure failures (72 "Signing
      failed" errors in fit-wiki seed tests) are present identically on
      `main`; no new failures introduced.
- [ ] **Wiki seed**: maintainer creates wiki page `STATUS.md` with the
      fenced content above. Verify the page renders correctly in the GitHub
      wiki UI.
- [ ] **Panel-before-PR verification**: run `kata-spec` against a small new
      spec request. Verify the agent does not push the PR until the panel
      is reported clean.
- [ ] **Merge-gate readback**: apply `spec:approved` on a fresh open spec
      PR. Trigger `agent-react`. Verify the facilitator validates trust and
      updates `wiki/STATUS.md`. Trigger `kata-release-merge` and verify the
      spec PR merges based on STATUS.
- [ ] **Negative trust check**: have a non-trusted account comment "LGTM"
      on a spec PR. Verify no STATUS update occurs.
- [ ] **Plan path still agent-approvable**: run `kata-plan` end-to-end.
      Verify Step 7 writes STATUS to `plan approved` and
      `kata-release-merge` merges on its next run.
- [ ] **Interactive-session approval**: instruct an agent "approve spec
      NNN" in an interactive session. Verify the agent edits
      `wiki/STATUS.md`, commits, and pushes; the spec PR merges on the
      next `kata-release-merge` run.

## Breaking change

This is a `feat(kata)!:` breaking change — partially reverses `420a99d4`
("replace specs/STATUS with phase labels"). After this PR merges and the
wiki page exists, the merge gate reads STATUS, not labels; agents stop
applying `spec:approved` and `design:approved` autonomously.

https://claude.ai/code/session_01Mk2hdZKHBiQBQEsPfT9ebH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mk2hdZKHBiQBQEsPfT9ebH)_