### PR TITLE
fix(libwiki): bootstrap wiki in proxy-restricted hooks and require explicit token resolver

### DIFF
--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -79,12 +79,9 @@ npx fit-wiki init
 | `--wiki-root`  | No       | Override wiki root directory (default: wiki)       |
 | `--skills-dir` | No       | Override skills directory (default: .claude/skills) |
 
-Idempotent — safe to run on an already-initialized wiki. The clone URL is
-derived from the parent repo's `origin` remote by appending `.wiki.git`. In
-sandboxed environments where `origin` is rewritten to a local proxy that does
-not serve the wiki, set `FIT_WIKI_URL` to the canonical wiki URL (e.g.
-`https://github.com/<owner>/<repo>.wiki.git`) and it takes precedence over
-the derivation.
+Idempotent — safe to run on an already-initialized wiki. Set
+`FIT_WIKI_URL` to override the wiki URL when the default derivation
+from `origin` does not resolve.
 
 ### `push` — Push wiki changes to remote
 
@@ -143,10 +140,7 @@ import {
 - `insertMarkers({ agentsDir, wikiRoot })` — idempotent marker insertion
 - `scanMarkers(text)` — find `<!-- xmr:... -->` marker pairs in markdown
 - `renderBlock({ metric, csvPath, projectRoot })` — render one XmR chart block
-- `new WikiRepo({ wikiDir, parentDir, resolveToken })` — git wrapper for wiki
-  operations; `resolveToken` is a callback returning a GitHub token string
-  (authenticate) or `null` (anonymous). Thrown errors propagate. Pair with
-  `@forwardimpact/libconfig` for env → `.env` → `gh auth token` resolution.
+- `new WikiRepo({ wikiDir, parentDir, resolveToken })` — git wrapper for wiki operations
 - `listSkills({ skillsDir })` — discover kata skills from `.claude/skills/`
 
 ## Documentation

--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -79,7 +79,12 @@ npx fit-wiki init
 | `--wiki-root`  | No       | Override wiki root directory (default: wiki)       |
 | `--skills-dir` | No       | Override skills directory (default: .claude/skills) |
 
-Idempotent — safe to run on an already-initialized wiki.
+Idempotent — safe to run on an already-initialized wiki. The clone URL is
+derived from the parent repo's `origin` remote by appending `.wiki.git`. In
+sandboxed environments where `origin` is rewritten to a local proxy that does
+not serve the wiki, set `FIT_WIKI_URL` to the canonical wiki URL (e.g.
+`https://github.com/<owner>/<repo>.wiki.git`) and it takes precedence over
+the derivation.
 
 ### `push` — Push wiki changes to remote
 
@@ -138,7 +143,10 @@ import {
 - `insertMarkers({ agentsDir, wikiRoot })` — idempotent marker insertion
 - `scanMarkers(text)` — find `<!-- xmr:... -->` marker pairs in markdown
 - `renderBlock({ metric, csvPath, projectRoot })` — render one XmR chart block
-- `new WikiRepo({ wikiDir, parentDir })` — git wrapper for wiki operations
+- `new WikiRepo({ wikiDir, parentDir, resolveToken })` — git wrapper for wiki
+  operations; `resolveToken` is a callback returning a GitHub token string
+  (authenticate) or `null` (anonymous). Thrown errors propagate. Pair with
+  `@forwardimpact/libconfig` for env → `.env` → `gh auth token` resolution.
 - `listSkills({ skillsDir })` — discover kata skills from `.claude/skills/`
 
 ## Documentation

--- a/bun.lock
+++ b/bun.lock
@@ -461,6 +461,7 @@
       },
       "dependencies": {
         "@forwardimpact/libcli": "^0.1.0",
+        "@forwardimpact/libconfig": "^0.1.77",
         "@forwardimpact/libutil": "^0.1.0",
         "@forwardimpact/libxmr": "^1.1.0",
       },

--- a/libraries/libwiki/package.json
+++ b/libraries/libwiki/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@forwardimpact/libcli": "^0.1.0",
+    "@forwardimpact/libconfig": "^0.1.77",
     "@forwardimpact/libutil": "^0.1.0",
     "@forwardimpact/libxmr": "^1.1.0"
   },

--- a/libraries/libwiki/src/commands/init.js
+++ b/libraries/libwiki/src/commands/init.js
@@ -6,7 +6,10 @@ import { Finder } from "@forwardimpact/libutil";
 import { WikiRepo } from "../wiki-repo.js";
 import { listSkills } from "../skill-roster.js";
 
-function deriveWikiUrl(parentDir) {
+/** Resolve the wiki clone URL. Honors the FIT_WIKI_URL env var as an explicit override (for sandboxed environments where `origin` is rewritten to a local proxy that does not serve wiki repos); otherwise derives the URL by appending `.wiki.git` to the parent repo's `origin` remote. */
+export function deriveWikiUrl(parentDir) {
+  if (process.env.FIT_WIKI_URL) return process.env.FIT_WIKI_URL;
+
   const r = spawnSync("git", ["-C", parentDir, "remote", "get-url", "origin"], {
     encoding: "utf-8",
     stdio: "pipe",

--- a/libraries/libwiki/src/commands/init.js
+++ b/libraries/libwiki/src/commands/init.js
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import fsAsync from "node:fs/promises";
 import { Finder } from "@forwardimpact/libutil";
+import { createScriptConfig } from "@forwardimpact/libconfig";
 import { WikiRepo } from "../wiki-repo.js";
 import { listSkills } from "../skill-roster.js";
 
@@ -21,7 +22,7 @@ export function deriveWikiUrl(parentDir) {
 }
 
 /** Clone the wiki if not already present (URL derived from origin remote), copy git identity from the parent repo, and create metric directories for each kata skill. */
-export function runInitCommand(values, _args, cli) {
+export async function runInitCommand(values, _args, cli) {
   const logger = { debug() {} };
   const finder = new Finder(fsAsync, logger, process);
   const projectRoot = finder.findProjectRoot(process.cwd());
@@ -40,7 +41,12 @@ export function runInitCommand(values, _args, cli) {
     return;
   }
 
-  const repo = new WikiRepo({ wikiDir, parentDir: projectRoot });
+  const config = await createScriptConfig("wiki");
+  const repo = new WikiRepo({
+    wikiDir,
+    parentDir: projectRoot,
+    resolveToken: () => config.ghToken(),
+  });
 
   const cloneResult = repo.ensureCloned(wikiUrl);
   if (!cloneResult.cloned) {

--- a/libraries/libwiki/src/commands/sync.js
+++ b/libraries/libwiki/src/commands/sync.js
@@ -1,16 +1,26 @@
 import path from "node:path";
 import fsAsync from "node:fs/promises";
 import { Finder } from "@forwardimpact/libutil";
+import { createScriptConfig } from "@forwardimpact/libconfig";
 import { WikiRepo, WikiPullConflict } from "../wiki-repo.js";
 
-/** Commit all wiki changes and push them to the remote wiki repository. */
-export function runPushCommand(values, _args, cli) {
+async function buildRepo(values) {
   const logger = { debug() {} };
   const finder = new Finder(fsAsync, logger, process);
   const projectRoot = finder.findProjectRoot(process.cwd());
   const wikiDir = path.resolve(projectRoot, values["wiki-root"] ?? "wiki");
 
-  const repo = new WikiRepo({ wikiDir, parentDir: projectRoot });
+  const config = await createScriptConfig("wiki");
+  return new WikiRepo({
+    wikiDir,
+    parentDir: projectRoot,
+    resolveToken: () => config.ghToken(),
+  });
+}
+
+/** Commit all wiki changes and push them to the remote wiki repository. */
+export async function runPushCommand(values, _args, cli) {
+  const repo = await buildRepo(values);
   repo.inheritIdentity();
 
   const result = repo.commitAndPush("wiki: update from session");
@@ -22,13 +32,8 @@ export function runPushCommand(values, _args, cli) {
 }
 
 /** Fetch and rebase the local wiki on origin/master; on rebase conflict, exit the process with code 1 and a message to resolve manually or push first. */
-export function runPullCommand(values, _args, cli) {
-  const logger = { debug() {} };
-  const finder = new Finder(fsAsync, logger, process);
-  const projectRoot = finder.findProjectRoot(process.cwd());
-  const wikiDir = path.resolve(projectRoot, values["wiki-root"] ?? "wiki");
-
-  const repo = new WikiRepo({ wikiDir, parentDir: projectRoot });
+export async function runPullCommand(values, _args, cli) {
+  const repo = await buildRepo(values);
   repo.inheritIdentity();
 
   try {

--- a/libraries/libwiki/src/wiki-repo.js
+++ b/libraries/libwiki/src/wiki-repo.js
@@ -44,6 +44,12 @@ export class WikiRepo {
    *   `() => config.ghToken()` from `@forwardimpact/libconfig`.
    */
   constructor({ wikiDir, parentDir, resolveToken }) {
+    if (typeof wikiDir !== "string" || wikiDir === "") {
+      throw new TypeError("WikiRepo: wikiDir must be a non-empty string");
+    }
+    if (typeof parentDir !== "string" || parentDir === "") {
+      throw new TypeError("WikiRepo: parentDir must be a non-empty string");
+    }
     if (typeof resolveToken !== "function") {
       throw new TypeError("WikiRepo: resolveToken callback is required");
     }

--- a/libraries/libwiki/src/wiki-repo.js
+++ b/libraries/libwiki/src/wiki-repo.js
@@ -35,13 +35,18 @@ export class WikiRepo {
 
   /**
    * Create a WikiRepo targeting the given wiki directory and its parent project directory.
-   * @param {{ wikiDir: string, parentDir: string, resolveToken?: () => string | null | undefined }} opts
-   *   `resolveToken` is called lazily per network operation to obtain a GitHub token.
-   *   When omitted, falls back to reading `GH_TOKEN` or `GITHUB_TOKEN` from `process.env`.
-   *   Commands typically pass `() => config.ghToken()` so the libconfig resolution chain
-   *   (env → `.env` overrides → `gh auth token`) is honored.
+   * @param {{ wikiDir: string, parentDir: string, resolveToken: () => string | null }} opts
+   *   `resolveToken` is called lazily before each network operation. Return a
+   *   GitHub token string to authenticate, or `null` to run anonymously. The
+   *   callback owns the entire resolution policy — libwiki does not read
+   *   `process.env` directly. Throws propagate to the caller so credential
+   *   misconfiguration surfaces loudly. Commands typically pass
+   *   `() => config.ghToken()` from `@forwardimpact/libconfig`.
    */
   constructor({ wikiDir, parentDir, resolveToken }) {
+    if (typeof resolveToken !== "function") {
+      throw new TypeError("WikiRepo: resolveToken callback is required");
+    }
     this.#wikiDir = wikiDir;
     this.#parentDir = parentDir;
     this.#resolveToken = resolveToken;
@@ -132,25 +137,14 @@ export class WikiRepo {
   }
 
   #authGit(args) {
-    const token = this.#token();
+    const token = this.#resolveToken();
     const fullArgs = buildAuthArgs(args, token);
     // The credential helper body keeps `${GH_TOKEN:-$GITHUB_TOKEN}` literal so
     // git's child shell expands it at auth time — the token never sits in argv.
-    // When libconfig resolves a token from `.env` or `gh auth token` (i.e. it
-    // is not on `process.env`), inject GH_TOKEN into the spawn env so the
-    // helper's lazy expansion still finds it.
+    // Inject the resolved token into the spawn env so the helper's lazy
+    // expansion finds it even when the resolver pulled from `.env` or
+    // `gh auth token` rather than the ambient process env.
     const env = token ? { ...process.env, GH_TOKEN: token } : undefined;
     return spawnSync("git", fullArgs, { stdio: "pipe", env });
-  }
-
-  #token() {
-    if (this.#resolveToken) {
-      try {
-        return this.#resolveToken() || null;
-      } catch {
-        return null;
-      }
-    }
-    return process.env.GH_TOKEN || process.env.GITHUB_TOKEN || null;
   }
 }

--- a/libraries/libwiki/src/wiki-repo.js
+++ b/libraries/libwiki/src/wiki-repo.js
@@ -31,11 +31,20 @@ export function buildAuthArgs(args, token) {
 export class WikiRepo {
   #wikiDir;
   #parentDir;
+  #resolveToken;
 
-  /** Create a WikiRepo targeting the given wiki directory and its parent project directory. */
-  constructor({ wikiDir, parentDir }) {
+  /**
+   * Create a WikiRepo targeting the given wiki directory and its parent project directory.
+   * @param {{ wikiDir: string, parentDir: string, resolveToken?: () => string | null | undefined }} opts
+   *   `resolveToken` is called lazily per network operation to obtain a GitHub token.
+   *   When omitted, falls back to reading `GH_TOKEN` or `GITHUB_TOKEN` from `process.env`.
+   *   Commands typically pass `() => config.ghToken()` so the libconfig resolution chain
+   *   (env → `.env` overrides → `gh auth token`) is honored.
+   */
+  constructor({ wikiDir, parentDir, resolveToken }) {
     this.#wikiDir = wikiDir;
     this.#parentDir = parentDir;
+    this.#resolveToken = resolveToken;
   }
 
   /** Check whether the wiki directory is an initialized git repository. */
@@ -123,11 +132,25 @@ export class WikiRepo {
   }
 
   #authGit(args) {
-    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+    const token = this.#token();
     const fullArgs = buildAuthArgs(args, token);
-    return spawnSync("git", fullArgs, {
-      stdio: "pipe",
-      env: token ? process.env : undefined,
-    });
+    // The credential helper body keeps `${GH_TOKEN:-$GITHUB_TOKEN}` literal so
+    // git's child shell expands it at auth time — the token never sits in argv.
+    // When libconfig resolves a token from `.env` or `gh auth token` (i.e. it
+    // is not on `process.env`), inject GH_TOKEN into the spawn env so the
+    // helper's lazy expansion still finds it.
+    const env = token ? { ...process.env, GH_TOKEN: token } : undefined;
+    return spawnSync("git", fullArgs, { stdio: "pipe", env });
+  }
+
+  #token() {
+    if (this.#resolveToken) {
+      try {
+        return this.#resolveToken() || null;
+      } catch {
+        return null;
+      }
+    }
+    return process.env.GH_TOKEN || process.env.GITHUB_TOKEN || null;
   }
 }

--- a/libraries/libwiki/test/cli-init.test.js
+++ b/libraries/libwiki/test/cli-init.test.js
@@ -32,7 +32,11 @@ describe("init command", () => {
   });
 
   test("clones wiki and creates metrics directories", () => {
-    const repo = new WikiRepo({ wikiDir, parentDir: projectDir, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: projectDir,
+      resolveToken: () => null,
+    });
     const result = repo.ensureCloned(bare);
     assert.equal(result.cloned, true);
 
@@ -52,7 +56,11 @@ describe("init command", () => {
   });
 
   test("idempotent — second run produces no error", () => {
-    const repo = new WikiRepo({ wikiDir, parentDir: projectDir, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: projectDir,
+      resolveToken: () => null,
+    });
     repo.ensureCloned(bare);
     repo.inheritIdentity();
 
@@ -73,7 +81,11 @@ describe("init command", () => {
   });
 
   test("ensureCloned returns cloned:false for unreachable URL", () => {
-    const repo = new WikiRepo({ wikiDir, parentDir: projectDir, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: projectDir,
+      resolveToken: () => null,
+    });
     const result = repo.ensureCloned("/nonexistent/repo.git");
     assert.equal(result.cloned, false);
   });
@@ -93,7 +105,8 @@ describe("deriveWikiUrl", () => {
 
   test("FIT_WIKI_URL env var takes precedence over origin remote", () => {
     git(projectDir, "remote", "add", "origin", "https://example.com/foo/bar");
-    process.env.FIT_WIKI_URL = "https://github.com/forwardimpact/monorepo.wiki.git";
+    process.env.FIT_WIKI_URL =
+      "https://github.com/forwardimpact/monorepo.wiki.git";
     try {
       assert.equal(
         deriveWikiUrl(projectDir),
@@ -107,12 +120,24 @@ describe("deriveWikiUrl", () => {
 
   test("derives wiki URL by appending .wiki.git to origin", () => {
     git(projectDir, "remote", "add", "origin", "https://github.com/foo/bar");
-    assert.equal(deriveWikiUrl(projectDir), "https://github.com/foo/bar.wiki.git");
+    assert.equal(
+      deriveWikiUrl(projectDir),
+      "https://github.com/foo/bar.wiki.git",
+    );
   });
 
   test("strips trailing .git before appending .wiki.git", () => {
-    git(projectDir, "remote", "add", "origin", "https://github.com/foo/bar.git");
-    assert.equal(deriveWikiUrl(projectDir), "https://github.com/foo/bar.wiki.git");
+    git(
+      projectDir,
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/foo/bar.git",
+    );
+    assert.equal(
+      deriveWikiUrl(projectDir),
+      "https://github.com/foo/bar.wiki.git",
+    );
   });
 
   test("returns null when no origin remote configured", () => {

--- a/libraries/libwiki/test/cli-init.test.js
+++ b/libraries/libwiki/test/cli-init.test.js
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { WikiRepo } from "../src/wiki-repo.js";
 import { listSkills } from "../src/skill-roster.js";
+import { deriveWikiUrl } from "../src/commands/init.js";
 import { git, createBareRepo, seedBareRepo } from "./helpers.js";
 
 describe("init command", () => {
@@ -75,5 +76,46 @@ describe("init command", () => {
     const repo = new WikiRepo({ wikiDir, parentDir: projectDir });
     const result = repo.ensureCloned("/nonexistent/repo.git");
     assert.equal(result.cloned, false);
+  });
+});
+
+describe("deriveWikiUrl", () => {
+  let projectDir;
+  let priorEnv;
+
+  beforeEach(() => {
+    priorEnv = process.env.FIT_WIKI_URL;
+    delete process.env.FIT_WIKI_URL;
+
+    projectDir = mkdtempSync(join(tmpdir(), "wiki-derive-"));
+    git(projectDir, "init");
+  });
+
+  test("FIT_WIKI_URL env var takes precedence over origin remote", () => {
+    git(projectDir, "remote", "add", "origin", "https://example.com/foo/bar");
+    process.env.FIT_WIKI_URL = "https://github.com/forwardimpact/monorepo.wiki.git";
+    try {
+      assert.equal(
+        deriveWikiUrl(projectDir),
+        "https://github.com/forwardimpact/monorepo.wiki.git",
+      );
+    } finally {
+      if (priorEnv === undefined) delete process.env.FIT_WIKI_URL;
+      else process.env.FIT_WIKI_URL = priorEnv;
+    }
+  });
+
+  test("derives wiki URL by appending .wiki.git to origin", () => {
+    git(projectDir, "remote", "add", "origin", "https://github.com/foo/bar");
+    assert.equal(deriveWikiUrl(projectDir), "https://github.com/foo/bar.wiki.git");
+  });
+
+  test("strips trailing .git before appending .wiki.git", () => {
+    git(projectDir, "remote", "add", "origin", "https://github.com/foo/bar.git");
+    assert.equal(deriveWikiUrl(projectDir), "https://github.com/foo/bar.wiki.git");
+  });
+
+  test("returns null when no origin remote configured", () => {
+    assert.equal(deriveWikiUrl(projectDir), null);
   });
 });

--- a/libraries/libwiki/test/cli-init.test.js
+++ b/libraries/libwiki/test/cli-init.test.js
@@ -32,7 +32,7 @@ describe("init command", () => {
   });
 
   test("clones wiki and creates metrics directories", () => {
-    const repo = new WikiRepo({ wikiDir, parentDir: projectDir });
+    const repo = new WikiRepo({ wikiDir, parentDir: projectDir, resolveToken: () => null });
     const result = repo.ensureCloned(bare);
     assert.equal(result.cloned, true);
 
@@ -52,7 +52,7 @@ describe("init command", () => {
   });
 
   test("idempotent — second run produces no error", () => {
-    const repo = new WikiRepo({ wikiDir, parentDir: projectDir });
+    const repo = new WikiRepo({ wikiDir, parentDir: projectDir, resolveToken: () => null });
     repo.ensureCloned(bare);
     repo.inheritIdentity();
 
@@ -73,7 +73,7 @@ describe("init command", () => {
   });
 
   test("ensureCloned returns cloned:false for unreachable URL", () => {
-    const repo = new WikiRepo({ wikiDir, parentDir: projectDir });
+    const repo = new WikiRepo({ wikiDir, parentDir: projectDir, resolveToken: () => null });
     const result = repo.ensureCloned("/nonexistent/repo.git");
     assert.equal(result.cloned, false);
   });

--- a/libraries/libwiki/test/cli-sync.test.js
+++ b/libraries/libwiki/test/cli-sync.test.js
@@ -16,7 +16,11 @@ describe("push/pull commands", () => {
   test("push with no local changes is no-op", () => {
     const { parent, wikiDir } = cloneRepo(bare, "push-noop");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
 
     const result = repo.commitAndPush("wiki: update");
     assert.equal(result.pushed, false);
@@ -26,7 +30,11 @@ describe("push/pull commands", () => {
   test("push with local change commits and pushes", () => {
     const { parent, wikiDir } = cloneRepo(bare, "push-dirty");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
 
     writeFileSync(join(wikiDir, "new.md"), "content");
     const result = repo.commitAndPush("wiki: update from session");
@@ -50,7 +58,11 @@ describe("push/pull commands", () => {
     git(w1, "commit", "-m", "external push");
     git(w1, "push", "origin", "master");
 
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
+    const repo2 = new WikiRepo({
+      wikiDir: w2,
+      parentDir: p2,
+      resolveToken: () => null,
+    });
     repo2.pull();
 
     const content = readFileSync(join(w2, "external.md"), "utf-8");
@@ -72,7 +84,11 @@ describe("push/pull commands", () => {
     git(w2, "add", "-A");
     git(w2, "commit", "-m", "local");
 
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
+    const repo2 = new WikiRepo({
+      wikiDir: w2,
+      parentDir: p2,
+      resolveToken: () => null,
+    });
     assert.throws(() => repo2.pull(), WikiPullConflict);
   });
 });

--- a/libraries/libwiki/test/cli-sync.test.js
+++ b/libraries/libwiki/test/cli-sync.test.js
@@ -16,7 +16,7 @@ describe("push/pull commands", () => {
   test("push with no local changes is no-op", () => {
     const { parent, wikiDir } = cloneRepo(bare, "push-noop");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
 
     const result = repo.commitAndPush("wiki: update");
     assert.equal(result.pushed, false);
@@ -26,7 +26,7 @@ describe("push/pull commands", () => {
   test("push with local change commits and pushes", () => {
     const { parent, wikiDir } = cloneRepo(bare, "push-dirty");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
 
     writeFileSync(join(wikiDir, "new.md"), "content");
     const result = repo.commitAndPush("wiki: update from session");
@@ -50,7 +50,7 @@ describe("push/pull commands", () => {
     git(w1, "commit", "-m", "external push");
     git(w1, "push", "origin", "master");
 
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
     repo2.pull();
 
     const content = readFileSync(join(w2, "external.md"), "utf-8");
@@ -72,7 +72,7 @@ describe("push/pull commands", () => {
     git(w2, "add", "-A");
     git(w2, "commit", "-m", "local");
 
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
     assert.throws(() => repo2.pull(), WikiPullConflict);
   });
 });

--- a/libraries/libwiki/test/wiki-repo.test.js
+++ b/libraries/libwiki/test/wiki-repo.test.js
@@ -17,14 +17,22 @@ describe("WikiRepo", () => {
 
   test("isCloned returns false for empty dir", () => {
     const dir = mkdtempSync(join(tmpdir(), "wiki-empty-"));
-    const repo = new WikiRepo({ wikiDir: join(dir, "wiki"), parentDir: dir, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir: join(dir, "wiki"),
+      parentDir: dir,
+      resolveToken: () => null,
+    });
     assert.equal(repo.isCloned(), false);
   });
 
   test("ensureCloned clones and isCloned returns true", () => {
     const parent = mkdtempSync(join(tmpdir(), "wiki-parent-"));
     const wikiDir = join(parent, "wiki");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
 
     const result = repo.ensureCloned(bare);
     assert.equal(result.cloned, true);
@@ -33,7 +41,11 @@ describe("WikiRepo", () => {
 
   test("ensureCloned is no-op when already cloned", () => {
     const { parent, wikiDir } = cloneRepo(bare, "noop");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
 
     const result = repo.ensureCloned(bare);
     assert.equal(result.cloned, true);
@@ -43,7 +55,11 @@ describe("WikiRepo", () => {
   test("ensureCloned returns cloned:false for bad URL", () => {
     const parent = mkdtempSync(join(tmpdir(), "wiki-bad-"));
     const wikiDir = join(parent, "wiki");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
 
     const result = repo.ensureCloned("/nonexistent/path.git");
     assert.equal(result.cloned, false);
@@ -52,7 +68,11 @@ describe("WikiRepo", () => {
   test("isClean detects dirty tree", () => {
     const { parent, wikiDir } = cloneRepo(bare, "dirty");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
 
     assert.equal(repo.isClean(), true);
     writeFileSync(join(wikiDir, "new.md"), "content");
@@ -65,7 +85,11 @@ describe("WikiRepo", () => {
     git(parent, "config", "user.name", "Parent Name");
     git(parent, "config", "user.email", "parent@example.com");
 
-    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
     repo.inheritIdentity();
 
     assert.equal(git(wikiDir, "config", "--get", "user.name"), "Parent Name");
@@ -86,7 +110,11 @@ describe("WikiRepo", () => {
     git(w1, "commit", "-m", "clone1 change");
     git(w1, "push", "origin", "master");
 
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
+    const repo2 = new WikiRepo({
+      wikiDir: w2,
+      parentDir: p2,
+      resolveToken: () => null,
+    });
     repo2.pull();
 
     const content = execFileSync("cat", [join(w2, "change.md")], {
@@ -110,14 +138,22 @@ describe("WikiRepo", () => {
     git(w2, "add", "-A");
     git(w2, "commit", "-m", "clone2");
 
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
+    const repo2 = new WikiRepo({
+      wikiDir: w2,
+      parentDir: p2,
+      resolveToken: () => null,
+    });
     assert.throws(() => repo2.pull(), WikiPullConflict);
   });
 
   test("commitAndPush is no-op on clean tree", () => {
     const { parent, wikiDir } = cloneRepo(bare, "clean");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
 
     const result = repo.commitAndPush("test");
     assert.equal(result.pushed, false);
@@ -127,7 +163,11 @@ describe("WikiRepo", () => {
   test("commitAndPush commits and pushes dirty tree", () => {
     const { parent, wikiDir } = cloneRepo(bare, "push");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
 
     writeFileSync(join(wikiDir, "update.md"), "new content");
     const result = repo.commitAndPush("wiki: test push");
@@ -152,7 +192,11 @@ describe("WikiRepo", () => {
     git(w1, "push", "origin", "master");
 
     writeFileSync(join(w2, "README.md"), "local wins");
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
+    const repo2 = new WikiRepo({
+      wikiDir: w2,
+      parentDir: p2,
+      resolveToken: () => null,
+    });
     const result = repo2.commitAndPush("wiki: local update");
     assert.equal(result.pushed, true);
 

--- a/libraries/libwiki/test/wiki-repo.test.js
+++ b/libraries/libwiki/test/wiki-repo.test.js
@@ -17,14 +17,14 @@ describe("WikiRepo", () => {
 
   test("isCloned returns false for empty dir", () => {
     const dir = mkdtempSync(join(tmpdir(), "wiki-empty-"));
-    const repo = new WikiRepo({ wikiDir: join(dir, "wiki"), parentDir: dir });
+    const repo = new WikiRepo({ wikiDir: join(dir, "wiki"), parentDir: dir, resolveToken: () => null });
     assert.equal(repo.isCloned(), false);
   });
 
   test("ensureCloned clones and isCloned returns true", () => {
     const parent = mkdtempSync(join(tmpdir(), "wiki-parent-"));
     const wikiDir = join(parent, "wiki");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
 
     const result = repo.ensureCloned(bare);
     assert.equal(result.cloned, true);
@@ -33,7 +33,7 @@ describe("WikiRepo", () => {
 
   test("ensureCloned is no-op when already cloned", () => {
     const { parent, wikiDir } = cloneRepo(bare, "noop");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
 
     const result = repo.ensureCloned(bare);
     assert.equal(result.cloned, true);
@@ -43,7 +43,7 @@ describe("WikiRepo", () => {
   test("ensureCloned returns cloned:false for bad URL", () => {
     const parent = mkdtempSync(join(tmpdir(), "wiki-bad-"));
     const wikiDir = join(parent, "wiki");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
 
     const result = repo.ensureCloned("/nonexistent/path.git");
     assert.equal(result.cloned, false);
@@ -52,7 +52,7 @@ describe("WikiRepo", () => {
   test("isClean detects dirty tree", () => {
     const { parent, wikiDir } = cloneRepo(bare, "dirty");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
 
     assert.equal(repo.isClean(), true);
     writeFileSync(join(wikiDir, "new.md"), "content");
@@ -65,7 +65,7 @@ describe("WikiRepo", () => {
     git(parent, "config", "user.name", "Parent Name");
     git(parent, "config", "user.email", "parent@example.com");
 
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
     repo.inheritIdentity();
 
     assert.equal(git(wikiDir, "config", "--get", "user.name"), "Parent Name");
@@ -86,7 +86,7 @@ describe("WikiRepo", () => {
     git(w1, "commit", "-m", "clone1 change");
     git(w1, "push", "origin", "master");
 
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
     repo2.pull();
 
     const content = execFileSync("cat", [join(w2, "change.md")], {
@@ -110,14 +110,14 @@ describe("WikiRepo", () => {
     git(w2, "add", "-A");
     git(w2, "commit", "-m", "clone2");
 
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
     assert.throws(() => repo2.pull(), WikiPullConflict);
   });
 
   test("commitAndPush is no-op on clean tree", () => {
     const { parent, wikiDir } = cloneRepo(bare, "clean");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
 
     const result = repo.commitAndPush("test");
     assert.equal(result.pushed, false);
@@ -127,7 +127,7 @@ describe("WikiRepo", () => {
   test("commitAndPush commits and pushes dirty tree", () => {
     const { parent, wikiDir } = cloneRepo(bare, "push");
     git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+    const repo = new WikiRepo({ wikiDir, parentDir: parent, resolveToken: () => null });
 
     writeFileSync(join(wikiDir, "update.md"), "new content");
     const result = repo.commitAndPush("wiki: test push");
@@ -152,7 +152,7 @@ describe("WikiRepo", () => {
     git(w1, "push", "origin", "master");
 
     writeFileSync(join(w2, "README.md"), "local wins");
-    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2 });
+    const repo2 = new WikiRepo({ wikiDir: w2, parentDir: p2, resolveToken: () => null });
     const result = repo2.commitAndPush("wiki: local update");
     assert.equal(result.pushed, true);
 
@@ -230,7 +230,7 @@ describe("WikiRepo resolveToken", () => {
     assert.equal(calls, 0);
   });
 
-  test("falls back gracefully when resolveToken throws", () => {
+  test("propagates errors thrown by resolveToken", () => {
     const { parent, wikiDir } = cloneRepo(bare, "tokenthrow");
     git(wikiDir, "checkout", "master");
     const repo = new WikiRepo({
@@ -241,18 +241,13 @@ describe("WikiRepo resolveToken", () => {
       },
     });
 
-    // fetch against a local bare repo doesn't need auth — the call should
-    // simply proceed without the credential helper instead of propagating.
-    assert.doesNotThrow(() => repo.fetch());
+    assert.throws(() => repo.fetch(), /not configured/);
   });
 
-  test("without resolveToken, falls back to process.env GH_TOKEN/GITHUB_TOKEN", () => {
-    const { parent, wikiDir } = cloneRepo(bare, "tokenenv");
-    git(wikiDir, "checkout", "master");
-    const repo = new WikiRepo({ wikiDir, parentDir: parent });
-
-    // No callback provided — fetch should succeed against local bare regardless
-    // of whether env vars are set; the constructor must accept the omission.
-    assert.doesNotThrow(() => repo.fetch());
+  test("constructor rejects missing resolveToken", () => {
+    assert.throws(
+      () => new WikiRepo({ wikiDir: "/tmp/x", parentDir: "/tmp/y" }),
+      TypeError,
+    );
   });
 });

--- a/libraries/libwiki/test/wiki-repo.test.js
+++ b/libraries/libwiki/test/wiki-repo.test.js
@@ -184,3 +184,75 @@ describe("buildAuthArgs", () => {
     assert.deepEqual(result, args);
   });
 });
+
+describe("WikiRepo resolveToken", () => {
+  let bare;
+
+  beforeEach(() => {
+    bare = createBareRepo();
+    seedBareRepo(bare);
+  });
+
+  test("invokes resolveToken on network operations", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "tokencb");
+    git(wikiDir, "checkout", "master");
+    let calls = 0;
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => {
+        calls++;
+        return "ghp_fromcallback";
+      },
+    });
+
+    repo.fetch();
+    assert.ok(calls >= 1, "resolveToken should be called by fetch()");
+  });
+
+  test("does not invoke resolveToken on local-only operations", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "tokenlocal");
+    git(wikiDir, "checkout", "master");
+    let calls = 0;
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => {
+        calls++;
+        return "ghp_unused";
+      },
+    });
+
+    repo.isCloned();
+    repo.isClean();
+    repo.inheritIdentity();
+
+    assert.equal(calls, 0);
+  });
+
+  test("falls back gracefully when resolveToken throws", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "tokenthrow");
+    git(wikiDir, "checkout", "master");
+    const repo = new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => {
+        throw new Error("not configured");
+      },
+    });
+
+    // fetch against a local bare repo doesn't need auth — the call should
+    // simply proceed without the credential helper instead of propagating.
+    assert.doesNotThrow(() => repo.fetch());
+  });
+
+  test("without resolveToken, falls back to process.env GH_TOKEN/GITHUB_TOKEN", () => {
+    const { parent, wikiDir } = cloneRepo(bare, "tokenenv");
+    git(wikiDir, "checkout", "master");
+    const repo = new WikiRepo({ wikiDir, parentDir: parent });
+
+    // No callback provided — fetch should succeed against local bare regardless
+    // of whether env vars are set; the constructor must accept the omission.
+    assert.doesNotThrow(() => repo.fetch());
+  });
+});

--- a/libraries/libwiki/test/wiki-repo.test.js
+++ b/libraries/libwiki/test/wiki-repo.test.js
@@ -294,4 +294,28 @@ describe("WikiRepo resolveToken", () => {
       TypeError,
     );
   });
+
+  test("constructor rejects non-string wikiDir", () => {
+    assert.throws(
+      () =>
+        new WikiRepo({
+          wikiDir: undefined,
+          parentDir: "/tmp/y",
+          resolveToken: () => null,
+        }),
+      /wikiDir must be a non-empty string/,
+    );
+  });
+
+  test("constructor rejects non-string parentDir", () => {
+    assert.throws(
+      () =>
+        new WikiRepo({
+          wikiDir: "/tmp/x",
+          parentDir: undefined,
+          resolveToken: () => null,
+        }),
+      /parentDir must be a non-empty string/,
+    );
+  });
 });

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -32,3 +32,21 @@ if ! command -v just &>/dev/null; then
 fi
 
 just install
+
+# ── Wiki sync ────────────────────────────────────────────────────
+# Some sandboxed environments rewrite `origin` to a local git proxy that
+# only serves the main repo, not the GitHub wiki repo. When origin does
+# not point at github.com, parse owner/repo from the URL's trailing path
+# segments and point libwiki at the canonical wiki URL via FIT_WIKI_URL.
+# Auth uses GH_TOKEN/GITHUB_TOKEN via libwiki's credential helper.
+origin_url=$(git remote get-url origin 2>/dev/null || true)
+if [[ -n "$origin_url" && "$origin_url" != *github.com* ]]; then
+  if [[ "$origin_url" =~ /([^/]+)/([^/]+)/?$ ]]; then
+    owner="${BASH_REMATCH[1]}"
+    repo="${BASH_REMATCH[2]%.git}"
+    export FIT_WIKI_URL="https://github.com/${owner}/${repo}.wiki.git"
+  fi
+fi
+
+bunx fit-wiki init || echo "bootstrap: wiki init skipped (continuing)" >&2
+bunx fit-wiki pull || echo "bootstrap: wiki pull skipped (continuing)" >&2

--- a/websites/fit/docs/libraries/predictable-team/wiki-operations/index.md
+++ b/websites/fit/docs/libraries/predictable-team/wiki-operations/index.md
@@ -159,16 +159,12 @@ init: wiki ready at wiki
 
 This clones the repository's wiki into `wiki/` and creates
 `wiki/metrics/<skill>/` directories for each skill found under
-`.claude/skills/`. The wiki URL is derived from your repository's origin
-remote. In sandboxed environments where `origin` is rewritten to a local
-proxy that does not serve the wiki, set `FIT_WIKI_URL` to the canonical
-wiki URL (e.g. `https://github.com/<owner>/<repo>.wiki.git`) and it takes
-precedence over the derivation.
+`.claude/skills/`. Set `FIT_WIKI_URL` to override the wiki URL when the
+default derivation from `origin` does not resolve.
 
 Idempotent -- safe to run on an already-initialized wiki. Authenticates
-using GitHub credentials resolved in order: `GH_TOKEN` / `GITHUB_TOKEN`
-from the environment, then a `.env` file in the working directory, then
-`gh auth token` from a logged-in `gh` CLI.
+using `GH_TOKEN` or `GITHUB_TOKEN` from the environment, or a logged-in
+`gh` CLI.
 
 ## What's next
 

--- a/websites/fit/docs/libraries/predictable-team/wiki-operations/index.md
+++ b/websites/fit/docs/libraries/predictable-team/wiki-operations/index.md
@@ -159,10 +159,16 @@ init: wiki ready at wiki
 
 This clones the repository's wiki into `wiki/` and creates
 `wiki/metrics/<skill>/` directories for each skill found under
-`.claude/skills/`. The wiki URL is derived from your repository's origin remote.
+`.claude/skills/`. The wiki URL is derived from your repository's origin
+remote. In sandboxed environments where `origin` is rewritten to a local
+proxy that does not serve the wiki, set `FIT_WIKI_URL` to the canonical
+wiki URL (e.g. `https://github.com/<owner>/<repo>.wiki.git`) and it takes
+precedence over the derivation.
 
-Idempotent -- safe to run on an already-initialized wiki. Authenticates using
-ambient GitHub credentials (`GITHUB_TOKEN` or `GH_TOKEN`).
+Idempotent -- safe to run on an already-initialized wiki. Authenticates
+using GitHub credentials resolved in order: `GH_TOKEN` / `GITHUB_TOKEN`
+from the environment, then a `.env` file in the working directory, then
+`gh auth token` from a logged-in `gh` CLI.
 
 ## What's next
 


### PR DESCRIPTION
## Summary

- **Proxy bootstrap fix.** When `origin` is rewritten to a local git proxy (sandboxed sessions), the derived wiki URL points at the proxy too, which does not serve the GitHub wiki repo. `deriveWikiUrl` now honors `FIT_WIKI_URL` as an explicit override, and `scripts/bootstrap.sh` detects non-github origins, parses owner/repo, and exports the canonical wiki URL before running `fit-wiki init` + `fit-wiki pull`. The clone bakes the github.com remote into `wiki/.git/config`, so later push/pull bypass the proxy and authenticate via libwiki's credential helper.
- **libconfig credential resolution.** `WikiRepo` accepts a `resolveToken` callback so commands route through `Config.ghToken()` (`@forwardimpact/libconfig`) — env → `.env` overrides → `gh auth token`. The credential helper body stays literal `${GH_TOKEN:-$GITHUB_TOKEN}`; the resolved token is injected into the spawn env so git's child shell finds it at auth time without sitting in argv.
- **Clean break — `resolveToken` required.** Constructor throws `TypeError` when omitted. No implicit `process.env` reads, no swallow-on-throw — the callback owns the entire policy: string (authenticate), `null` (anonymous), throw (fail loud).
- **Docs.** SKILL.md `WikiRepo` example shows the corrected signature; `init` section and the wiki-operations guide each carry a one-line `FIT_WIKI_URL` escape hatch and updated auth note (env or `gh` CLI). Internals stay in source/JSDoc.

## Test plan

- [x] `bun run check` — pass
- [x] `bun run test` — 69 libwiki tests pass with `GIT_CONFIG_GLOBAL=/dev/null`; the 16 local failures are a sandbox commit-signing quirk that does not affect CI
- [x] End-to-end: `bunx fit-wiki init` clones from `https://github.com/forwardimpact/monorepo.wiki.git`, `just wiki-push` round-trips edits to the live wiki via the proxy-bypassing remote
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1t9DKVfwZZjfg7T6bFbPE)_