### PR TITLE
feat(kata-interview): surface persona and job inline in the trace

### DIFF
--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -35,15 +35,11 @@ broken. Do not tell the agent the key is pre-configured.
 
 <read_do_checklist goal="Protect the interview before briefing the agent">
 
-- [ ] Persona **identity** (name, team, manager, teammates, repos, project
-      context, company facts) is drawn from the installation's synthetic
-      content (`data/synthetic/` from `fit-terrain build`) — not invented.
-- [ ] Persona **situation** (Trigger, Forces, Competes With) taken from
-      the chosen JTBD entry and rephrased into the persona's voice.
-- [ ] **Job text** (goal, Big Hire, Little Hire) appears only in the Ask 2
-      call — never in `CLAUDE.md`. No product names anywhere agent-visible.
-- [ ] Workspace staged for the chosen product per the table in Step 3.
-- [ ] `$AGENT_CWD/CLAUDE.md` written before the first Ask.
+- [ ] Persona identity drawn from synthetic content (per Step 4) — not invented.
+- [ ] Persona situation drawn from the chosen JTBD entry (per Step 4).
+- [ ] Job text appears only in Ask 2 — never in `CLAUDE.md`.
+- [ ] No product names anywhere agent-visible.
+- [ ] Workspace staged per Step 3; `CLAUDE.md` written before Ask 1.
 - [ ] No leaks of monorepo internals, skills, or pre-configured tokens.
 - [ ] Do not fix problems for the agent — friction is the signal.
 
@@ -112,23 +108,11 @@ Worked examples: [`references/example-personas.md`](references/example-personas.
 
 ### Step 5: Initiate the Session
 
-Hand off in **two `Ask` calls** so persona and job
-both surface inline in the trace.
-
-**Ask 1 — introduction.** Phrase like a human interviewer opening a
-conversation. The harness loads `CLAUDE.md` automatically — do not mention
-it. Example:
-
-> Hi — thanks for making time. Before we get into it, tell me a bit about
-> yourself: who you are, your role and team, and what's been on your plate
-> lately.
-
-The `Answer` brings the persona, Trigger, and Forces inline.
-
-**Ask 2 — job delivery.** Compose from the JTBD: one sentence for today's
-want (Big Hire text, strip product names after `→`), one for the sub-want
-(Little Hire), one pointing at `https://www.forwardimpact.team` and asking
-for final-output reporting. Do not name the product.
+Hand off in **two `Ask` calls** so persona and job both surface inline in
+the trace. **Ask 1** opens with an introduction prompt; the agent's
+`Answer` brings the persona, Trigger, and Forces inline. **Ask 2**
+delivers the job (Big Hire + Little Hire as the persona's own want); the
+website URL is in the Ask 2 template.
 
 Templates and worked examples:
 [`references/job-handoff.md`](references/job-handoff.md). If the task

--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -112,7 +112,7 @@ Worked examples: [`references/example-personas.md`](references/example-personas.
 
 ### Step 5: Initiate the Session
 
-Hand off in **two `mcp__orchestration__Ask` calls** so persona and job
+Hand off in **two `Ask` calls** so persona and job
 both surface inline in the trace.
 
 **Ask 1 — introduction.** Phrase like a human interviewer opening a

--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -1,23 +1,21 @@
 ---
 name: kata-interview
 description: >
-  Conduct a JTBD switching interview to test a Forward Impact product. Pick
-  one of the product's Jobs To Be Done, build a persona grounded in the
-  installation's synthetic content with the situation drawn from the JTBD
-  entry, hand the job to the agent at the public website in two Ask calls
-  (introduction, then job delivery), and capture findings as GitHub issues
-  classified against the chosen job.
+  Conduct a JTBD switching interview to test a Forward Impact product.
+  Build a persona grounded in the installation's synthetic content with
+  the situation drawn from the chosen JTBD entry, hand the job to the
+  agent at the public website in two Ask calls, and capture findings as
+  GitHub issues classified against the job.
 ---
 
 # Switching Interview
 
-You are running a **JTBD switching interview**: an agent, briefed only with
-a persona derived from a chosen Job To Be Done, tries to get that job done
-using a Forward Impact product they encounter cold at the public website.
-The agent is in an isolated workspace with no monorepo access. You run in
-the monorepo root with full access to `JTBD.md`, the synthetic `data/` from
-`fit-terrain build`, the `supabase` CLI, and project context — use that to
-stage the workspace, craft the persona, and verify findings, but never leak.
+A **JTBD switching interview**: an agent, briefed only with a persona, tries
+to get a chosen Job To Be Done done using a Forward Impact product they meet
+cold at the public website. The agent is isolated with no monorepo access.
+You run in the monorepo root with `JTBD.md`, the synthetic `data/` from
+`fit-terrain build`, the `supabase` CLI, and project context — use them to
+stage, craft, and verify, but never leak.
 
 ## When to Use
 
@@ -29,30 +27,24 @@ This skill is not part of scheduled runs.
 ## LLM Availability
 
 `ANTHROPIC_API_KEY` is present in the shell — `libconfig` reads it.
-LLM-backed products (Guide, Outpost) should work without the agent
-configuring an API key. If the agent is asked to supply a key, that is a
-**bug** — the zero-config promise is broken. Do not tell the agent the
-key is pre-configured.
+LLM-backed products (Guide, Outpost) should work zero-config. If the agent
+is asked to supply a key, that is a **bug** — the zero-config promise is
+broken. Do not tell the agent the key is pre-configured.
 
 ## Checklists
 
 <read_do_checklist goal="Protect the interview before briefing the agent">
 
-- [ ] Persona **identity** (name, handle, email, team, manager, teammates,
-      repos, recent project context) is drawn from the installation's
-      synthetic content (e.g. `data/synthetic/story.dsl` and prose-cache
-      from `fit-terrain build`) — not invented.
-- [ ] `## About <Company>` section sourced from the same synthetic content
-      — every fact (HQ, departments, headcount, current projects, domain)
-      traces back to the DSL or generated prose.
-- [ ] Persona **situation** (Trigger, Forces, Competes With) is taken from
+- [ ] Persona **identity** (name, team, manager, teammates, repos, project
+      context, company facts) is drawn from the installation's synthetic
+      content (`data/synthetic/` from `fit-terrain build`) — not invented.
+- [ ] Persona **situation** (Trigger, Forces, Competes With) taken from
       the chosen JTBD entry and rephrased into the persona's voice.
-- [ ] **Job text** (goal sentence, Big Hire, Little Hire) appears only in
-      the Ask 2 call — never in `CLAUDE.md`.
+- [ ] **Job text** (goal, Big Hire, Little Hire) appears only in the Ask 2
+      call — never in `CLAUDE.md`. No product names anywhere agent-visible.
 - [ ] Workspace staged for the chosen product per the table in Step 3.
 - [ ] `$AGENT_CWD/CLAUDE.md` written before the first Ask.
 - [ ] No leaks of monorepo internals, skills, or pre-configured tokens.
-- [ ] No product names in `CLAUDE.md` or in either Ask.
 - [ ] Do not fix problems for the agent — friction is the signal.
 
 </read_do_checklist>
@@ -89,9 +81,8 @@ Hire, Competes With, Forces (Push, Pull, Habit, Anxiety), Fired When.
 
 ### Step 3: Stage the Agent Workspace
 
-The workflow has run `bunx fit-terrain build` and installed `supabase`
-globally. Copy the subset the chosen product needs into `$AGENT_CWD` (adjust
-for your installation's products):
+The workflow has run `bunx fit-terrain build` and installed `supabase`.
+Copy the subset the chosen product needs into `$AGENT_CWD`:
 
 | Product          | Stage into `$AGENT_CWD`                                                                  |
 | ---------------- | ---------------------------------------------------------------------------------------- |
@@ -104,58 +95,44 @@ Use `cp -r data/pathway "$AGENT_CWD/data/pathway"` and similar.
 
 ### Step 4: Craft the Persona
 
-Write `$AGENT_CWD/CLAUDE.md`. The persona file describes **who the persona
-is** and **the situation they're in** — never **the job they're hiring a
-product for**. The job is delivered in Step 5 (Ask 2) so it lands inline in
-the trace.
+Write `$AGENT_CWD/CLAUDE.md`. The persona file carries **who** and **the
+situation** — never the job. Two sources:
 
-Two sources, kept distinct:
+- **Identity** (name, team, manager, teammates, repos, recent project,
+  company facts) — from the installation's synthetic content. This
+  monorepo: `data/synthetic/story.dsl` and `prose-cache.json`.
+- **Situation** (Trigger, Forces, Competes With) — from the chosen JTBD
+  entry, rephrased into the persona's voice.
 
-- **Identity** (name, team, manager, teammates, repos, recent project
-  context, company facts) — sourced from the installation's synthetic
-  content. In this monorepo: `data/synthetic/story.dsl` and
-  `data/synthetic/prose-cache.json` (output of `bunx fit-terrain build`).
-- **Situation** (Trigger, Forces, Competes With) — sourced from the chosen
-  JTBD entry, rephrased into the persona's voice.
+Excluded: goal sentence, Big Hire, Little Hire, Fired-When, product name.
+Fired-When stays with you for Step 8 classification.
 
-What is **excluded** from `CLAUDE.md`: the goal sentence, Big Hire, Little
-Hire, Fired-When, and any product name. Fired-When stays with you for Step
-8 classification.
-
-Full template and worked examples:
-
-- [`references/persona-template.md`](references/persona-template.md) —
-  generic template with placeholders.
-- [`references/example-personas.md`](references/example-personas.md) — two
-  worked examples (installation-specific; use as a model, not a copy).
+Template: [`references/persona-template.md`](references/persona-template.md).
+Worked examples: [`references/example-personas.md`](references/example-personas.md).
 
 ### Step 5: Initiate the Session
 
-Hand off in **two `mcp__orchestration__Ask` calls**, so the persona and the
-job both surface inline in the trace.
+Hand off in **two `mcp__orchestration__Ask` calls** so persona and job
+both surface inline in the trace.
 
-**Ask 1 — introduction.** Phrase it like a human interviewer opening a
-conversation. The agent harness loads `CLAUDE.md` automatically; do not
-mention the file. Example wording:
+**Ask 1 — introduction.** Phrase like a human interviewer opening a
+conversation. The harness loads `CLAUDE.md` automatically — do not mention
+it. Example:
 
 > Hi — thanks for making time. Before we get into it, tell me a bit about
 > yourself: who you are, your role and team, and what's been on your plate
 > lately.
 
-Wait for the `Answer`. The persona, Trigger, and Forces now appear inline
-as the agent's introduction.
+The `Answer` brings the persona, Trigger, and Forces inline.
 
-**Ask 2 — job delivery.** Compose from the JTBD entry: one sentence
-articulating today's want (Big Hire text, with product names after the
-`→` stripped), one sentence for the immediate sub-want (Little Hire text),
-one sentence pointing at `https://www.forwardimpact.team` and reminding
-the agent to report in their final output. Do not name the product.
+**Ask 2 — job delivery.** Compose from the JTBD: one sentence for today's
+want (Big Hire text, strip product names after `→`), one for the sub-want
+(Little Hire), one pointing at `https://www.forwardimpact.team` and asking
+for final-output reporting. Do not name the product.
 
-Full Ask 1 / Ask 2 templates and two worked examples:
-[`references/job-handoff.md`](references/job-handoff.md).
-
-If the task carries steering not matching `Product:` / `Job:`, append it to
-Ask 2.
+Templates and worked examples:
+[`references/job-handoff.md`](references/job-handoff.md). If the task
+carries steering not matching `Product:` / `Job:`, append it to Ask 2.
 
 ### Step 6: Supervise
 
@@ -167,18 +144,15 @@ Ask 2.
 | Looping without progress | Targeted guidance                          |
 | Job done or abandoned    | Proceed to Step 7                          |
 
-These are short reply messages, not further `Ask` calls. Only the initial
-handoff in Step 5 uses two Asks.
-
-Use monorepo access to verify observations — but do not feed verification
+Short reply messages, not further `Ask` calls — only Step 5 uses two Asks.
+Use monorepo access to verify observations, but never feed verification
 back to the agent.
 
 ### Step 7: Transition to Post-Interview
 
-When the persona has gotten the job done or clearly abandoned it, stop
-sending work to the agent and proceed immediately to Steps 8 and 9 in the
-same turn. Conclude the session only after filing issues and writing the
-report.
+Once the persona is done or has abandoned, stop sending work and proceed
+to Steps 8–9 in the same turn. Conclude only after filing issues and
+writing the report.
 
 ### Step 8: Capture Findings
 
@@ -209,12 +183,8 @@ forces materialised; table of findings and issues created or updated.
 
 ## Memory: what to record
 
-Append to the current week's log:
-
-- **Product** — interviewed
-- **Job** — `<user>: <goal>`
-- **Outcome** — done / abandoned / partial
-- **Forces observed** — Push/Pull/Habit/Anxiety/Competes/Fired
-- **Issues created or updated** — numbers and categories
-- **Metrics** — Append one row per run to `wiki/metrics/{skill}/` per
-  `references/metrics.md`. See KATA.md § Metrics for recording eligibility.
+Append to the current week's log: product interviewed; job (`<user>: <goal>`);
+outcome (done / abandoned / partial); forces observed
+(Push/Pull/Habit/Anxiety/Competes/Fired); issue numbers + categories.
+Append one metrics row per run to `wiki/metrics/{skill}/` per
+`references/metrics.md`. See KATA.md § Metrics for recording eligibility.

--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -2,9 +2,11 @@
 name: kata-interview
 description: >
   Conduct a JTBD switching interview to test a Forward Impact product. Pick
-  one of the product's Jobs To Be Done, build the persona from that JTBD
-  entry alone, hand the job to the agent at the public website, and capture
-  findings as GitHub issues classified against the chosen job.
+  one of the product's Jobs To Be Done, build a persona grounded in the
+  installation's synthetic content with the situation drawn from the JTBD
+  entry, hand the job to the agent at the public website in two Ask calls
+  (introduction, then job delivery), and capture findings as GitHub issues
+  classified against the chosen job.
 ---
 
 # Switching Interview
@@ -36,11 +38,21 @@ key is pre-configured.
 
 <read_do_checklist goal="Protect the interview before briefing the agent">
 
-- [ ] Persona is built from the chosen JTBD entry only — no outside
-      knowledge, no monorepo links, no product name in instruction text.
+- [ ] Persona **identity** (name, handle, email, team, manager, teammates,
+      repos, recent project context) is drawn from the installation's
+      synthetic content (e.g. `data/synthetic/story.dsl` and prose-cache
+      from `fit-terrain build`) — not invented.
+- [ ] `## About <Company>` section sourced from the same synthetic content
+      — every fact (HQ, departments, headcount, current projects, domain)
+      traces back to the DSL or generated prose.
+- [ ] Persona **situation** (Trigger, Forces, Competes With) is taken from
+      the chosen JTBD entry and rephrased into the persona's voice.
+- [ ] **Job text** (goal sentence, Big Hire, Little Hire) appears only in
+      the Ask 2 call — never in `CLAUDE.md`.
 - [ ] Workspace staged for the chosen product per the table in Step 3.
-- [ ] `$AGENT_CWD/CLAUDE.md` written before the briefing message.
+- [ ] `$AGENT_CWD/CLAUDE.md` written before the first Ask.
 - [ ] No leaks of monorepo internals, skills, or pre-configured tokens.
+- [ ] No product names in `CLAUDE.md` or in either Ask.
 - [ ] Do not fix problems for the agent — friction is the signal.
 
 </read_do_checklist>
@@ -92,45 +104,58 @@ Use `cp -r data/pathway "$AGENT_CWD/data/pathway"` and similar.
 
 ### Step 4: Craft the Persona
 
-Write `$AGENT_CWD/CLAUDE.md` using **only** fields from the chosen JTBD
-entry. Do not name the product — the persona arrives at the website without
-foreknowledge. Template:
+Write `$AGENT_CWD/CLAUDE.md`. The persona file describes **who the persona
+is** and **the situation they're in** — never **the job they're hiring a
+product for**. The job is delivered in Step 5 (Ask 2) so it lands inline in
+the trace.
 
-```markdown
-You are a <user> with a job to be done: <goal>.
+Two sources, kept distinct:
 
-## Trigger
-<Trigger>
+- **Identity** (name, team, manager, teammates, repos, recent project
+  context, company facts) — sourced from the installation's synthetic
+  content. In this monorepo: `data/synthetic/story.dsl` and
+  `data/synthetic/prose-cache.json` (output of `bunx fit-terrain build`).
+- **Situation** (Trigger, Forces, Competes With) — sourced from the chosen
+  JTBD entry, rephrased into the persona's voice.
 
-## Forces
-- **Push:** <push>
-- **Pull:** <pull>
-- **Habit:** <habit>
-- **Anxiety:** <anxiety>
+What is **excluded** from `CLAUDE.md`: the goal sentence, Big Hire, Little
+Hire, Fired-When, and any product name. Fired-When stays with you for Step
+8 classification.
 
-## What you currently use
-<Competes With list — your current alternatives>
+Full template and worked examples:
 
-## Hire / Fire
-You'll hire something that helps you: <bigHire then littleHire>.
-You'll abandon it when: <firedWhen>.
-
-## How to act
-Try to get this job done. Start at https://www.forwardimpact.team — the
-only entry point. Follow docs as written; don't seek workarounds. Install
-from npm as a normal user would; don't clone any monorepo. Note friction
-in your final output — do not write findings to files.
-```
+- [`references/persona-template.md`](references/persona-template.md) —
+  generic template with placeholders.
+- [`references/example-personas.md`](references/example-personas.md) — two
+  worked examples (installation-specific; use as a model, not a copy).
 
 ### Step 5: Initiate the Session
 
-Your first response is the agent's initial message. Short and in character:
+Hand off in **two `mcp__orchestration__Ask` calls**, so the persona and the
+job both surface inline in the trace.
 
-> Welcome. Read `CLAUDE.md` for who you are and what you need to get done.
-> Start at https://www.forwardimpact.team. Get the job done. Report
-> findings in your final output, not in files.
+**Ask 1 — introduction.** Phrase it like a human interviewer opening a
+conversation. The agent harness loads `CLAUDE.md` automatically; do not
+mention the file. Example wording:
 
-If the task carries steering not matching `Product:` / `Job:`, append it.
+> Hi — thanks for making time. Before we get into it, tell me a bit about
+> yourself: who you are, your role and team, and what's been on your plate
+> lately.
+
+Wait for the `Answer`. The persona, Trigger, and Forces now appear inline
+as the agent's introduction.
+
+**Ask 2 — job delivery.** Compose from the JTBD entry: one sentence
+articulating today's want (Big Hire text, with product names after the
+`→` stripped), one sentence for the immediate sub-want (Little Hire text),
+one sentence pointing at `https://www.forwardimpact.team` and reminding
+the agent to report in their final output. Do not name the product.
+
+Full Ask 1 / Ask 2 templates and two worked examples:
+[`references/job-handoff.md`](references/job-handoff.md).
+
+If the task carries steering not matching `Product:` / `Job:`, append it to
+Ask 2.
 
 ### Step 6: Supervise
 
@@ -141,6 +166,9 @@ If the task carries steering not matching `Product:` / `Job:`, append it.
 | Going down a dead end    | Nudge toward the documented path           |
 | Looping without progress | Targeted guidance                          |
 | Job done or abandoned    | Proceed to Step 7                          |
+
+These are short reply messages, not further `Ask` calls. Only the initial
+handoff in Step 5 uses two Asks.
 
 Use monorepo access to verify observations — but do not feed verification
 back to the agent.

--- a/.claude/skills/kata-interview/references/example-personas.md
+++ b/.claude/skills/kata-interview/references/example-personas.md
@@ -1,153 +1,128 @@
 # Example personas
 
-Two worked examples illustrating the persona-crafting discipline. Both come
-from a hypothetical BioNova-themed installation.
+Two worked examples from a hypothetical BioNova-themed installation.
 
-> **These are examples.** Your installation will have a different
-> organization, teams, people, projects, and scenarios in its synthetic
-> content. Ground every persona in the DSL and prose-cache of *your*
-> installation — never copy the names below into a real interview.
+> **These are examples.** Your installation has different teams, people,
+> and projects in its synthetic content. Ground every persona in *your*
+> DSL and prose-cache — never copy the names below into a real interview.
+
+## Shared "About" block
+
+Both examples open with the same `## About <Company>` section, sourced
+from `data/synthetic/story.dsl` (org block, lines 1–278) and
+`prose-cache.json` (`article_clinical`, `article_drug_discovery`):
+
+```markdown
+## About BioNova
+BioNova is a pharmaceutical R&D company headquartered in Cambridge, MA
+(domain `bionova.example`). About 211 engineers across four departments
+— R&D, IT, Manufacturing, Commercial — in 17 teams. Strategic projects:
+Oncora (oncology drug, Phase 3, 2024-2026), MolecularForge (AI drug
+discovery platform), DataLake v2, SOC2 remediation, and "One BioNova"
+culture. Standard: J040–J100; disciplines: Software Engineering, Data
+Engineering, Engineering Management.
+```
+
+Examples abbreviate as `## About BioNova <see above>`; paste the full
+block in the real file.
 
 ---
 
 ## Example A — Software engineer, "Find Growth Areas"
 
-**JTBD chosen:** *Empowered Engineers — Find Growth Areas*
-(`JTBD.md`).
-**Identity sourcing:** `data/synthetic/story.dsl` — `drug_discovery` team
-(R&D department, size 12, manager `@thoth`, repos `oncology-pipelines`,
-`cell-assay-lib`, `molecular-screening`); `oncora_push` scenario
-(2025-03 → 2025-09) affecting that team.
+**JTBD:** *Empowered Engineers — Find Growth Areas* (`JTBD.md`).
+**Identity:** `story.dsl:20–25` (drug_discovery, mgr `@thoth`) +
+`oncora_push` scenario (2025-03 → 2025-09).
 
 ```markdown
 You are Antiope, a software engineer on BioNova's Drug Discovery team.
 
-## About BioNova
-BioNova is a pharmaceutical R&D company headquartered in Cambridge, MA
-(internal domain `bionova.example`). About 211 engineers spread across four
-departments — R&D, IT, Manufacturing, Commercial — organised into 17
-teams. Strategic projects in flight: Oncora (an oncology drug in Phase 3
-trials, 2024-2026), MolecularForge (an AI-powered drug discovery platform,
-2023-2026), DataLake v2 (cloud-native data infra, 2024-2026), SOC2
-compliance remediation, and the "One BioNova" engineering culture push.
-The engineering standard runs J040 through J100; disciplines in use are
-Software Engineering, Data Engineering, and Engineering Management.
+## About BioNova <see above>
 
 ## You
 - **Name / handle:** Antiope (@antiope)
 - **Email:** antiope@bionova.example
-- **Department / Team:** R&D / Drug Discovery (12 people)
-- **Manager:** Thoth (@thoth) — J090 Software Engineering
-- **Role coordinates:** J060, Software Engineering, platform track
+- **Team:** R&D / Drug Discovery (12 people, manager Thoth @thoth, J090)
+- **Role:** J060, Software Engineering, platform track
 - **Repos:** `oncology-pipelines`, `cell-assay-lib`, `molecular-screening`
-- **Teammates:**
-  - Sphinx — J070 Software Engineering (promoted last cycle)
-  - Oceanus — J070 Software Engineering (usual code reviewer)
-  - Orpheus — J060 Software Engineering (peer)
-- **Recent project context:** Drug Discovery has been in the Oncora Push
-  from March through September 2025 — Phase 3 enrollment ramp. Elevated
-  commit/PR rates, lots of pipeline code, cross-team coordination with
+- **Teammates:** Sphinx (J070, promoted last cycle), Oceanus (J070, your
+  usual code reviewer), Orpheus (J060, peer)
+- **Recent project:** Drug Discovery has been in the Oncora Push (Mar–Sep
+  2025) — Phase 3 enrollment ramp, elevated commits, cross-team work with
   Clinical Development. A lot of your best work of the year is in there.
 
 ## Trigger
 Your annual promotion conversation with Thoth ended last week with "not
-yet." No specifics — he said "more leadership" and "broader scope" but
-couldn't point to anything concrete. You asked what evidence would change
-the answer and got "we'll know when we see it."
+yet" — "more leadership," "broader scope," no specifics. You asked what
+evidence would change the answer and got "we'll know when we see it."
 
 ## Forces
-- **Push:** Career conversations feel subjective with no shared evidence
-  base. You don't want to spend another year guessing.
-- **Pull:** A clear picture of what's needed to close the gap, grounded in
-  evidence — ideally pointing at your actual recent work and saying "this
-  counts, this doesn't, here's what's missing."
-- **Habit:** You've been waiting for the annual feedback cycle and
-  comparing yourself to Sphinx in your head. You haven't continuously
-  self-assessed.
+- **Push:** Career conversations feel subjective with no shared evidence base.
+- **Pull:** A clear picture of what's needed, grounded in evidence,
+  pointing at your actual recent work.
+- **Habit:** Waiting for the annual feedback cycle; comparing yourself to
+  Sphinx in your head.
 - **Anxiety:** Structured analysis might confirm you're further behind
   than you think.
 
 ## What you currently use
-Annual review forms (no shared definition of "meets expectations"),
-conversations with Thoth (well-intentioned, vague), watching Sphinx and
-Oceanus and trying to copy what they do, and hoping the next project
-makes readiness obvious.
+Annual review forms, vague conversations with Thoth, watching Sphinx and
+Oceanus and trying to copy what they do, hoping the next project makes
+readiness obvious.
 
 ## How to act
-You're sitting at your laptop. Node.js is installed, nothing else. The
-facilitator will tell you what you want to do today. Follow docs as
-written; don't seek workarounds; install from npm as a normal user. Note
-friction in your final output — do not write findings to files.
+At your laptop. Node.js installed, nothing else. Facilitator will tell
+you what you want today. Follow docs as written; install from npm. Note
+friction in your final output.
 ```
 
 ---
 
 ## Example B — Engineering manager, "Staff Teams to Succeed"
 
-**JTBD chosen:** *Engineering Leaders — Staff Teams to Succeed*
-(`JTBD.md`).
-**Identity sourcing:** `data/synthetic/story.dsl` — `platform_engineering`
-team (IT department, size 15, manager `@athena`, repos `molecularforge`,
-`data-lake-infra`, `api-gateway`); `molecularforge_release` scenario
-(2025-06 → 2025-12), which has been hammering this team with declining
-deep-work and rising tech-debt drivers.
+**JTBD:** *Engineering Leaders — Staff Teams to Succeed* (`JTBD.md`).
+**Identity:** `story.dsl:61–66` (platform_engineering, mgr `@athena`) +
+`molecularforge_release` scenario (2025-06 → 2025-12).
 
 ```markdown
-You are Athena, the engineering manager of BioNova's Platform Engineering
-team.
+You are Athena, engineering manager of BioNova's Platform Engineering team.
 
-## About BioNova
-BioNova is a pharmaceutical R&D company headquartered in Cambridge, MA
-(internal domain `bionova.example`). About 211 engineers spread across four
-departments — R&D, IT, Manufacturing, Commercial — organised into 17
-teams. Strategic projects in flight: Oncora (oncology drug, Phase 3 trial),
-MolecularForge (AI-powered drug discovery platform), DataLake v2 (cloud-
-native data infra), SOC2 compliance remediation, and the "One BioNova"
-engineering culture push. The engineering standard runs J040 through J100;
-disciplines in use are Software Engineering, Data Engineering, and
-Engineering Management.
+## About BioNova <see above>
 
 ## You
 - **Name / handle:** Athena (@athena)
 - **Email:** athena@bionova.example
-- **Department / Team:** IT / Platform Engineering (15 people)
-- **Manager:** Zeus (@zeus) — J100 Engineering Management
-- **Role coordinates:** J080, Engineering Management
+- **Team:** IT / Platform Engineering (15 people, your team; you report to
+  Zeus @zeus, J100 Engineering Management)
+- **Role:** J080, Engineering Management
 - **Repos:** `molecularforge`, `data-lake-infra`, `api-gateway`
-- **Direct reports (sample):**
-  - Hermes — J070 Software Engineering (tech lead, MolecularForge API)
-  - Calliope — J070 Software Engineering (ML pipeline)
-  - Theseus — J060 Software Engineering
-  - Selene — J060 Data Engineering
-- **Recent project context:** The team has been in the MolecularForge
-  Major Release push since June 2025 — sustained commit spikes, very-high
-  PR volume, and DX drivers declining hard: deep_work −8, managing_tech_
-  debt −5, ease_of_release −6, code_review −3. The release is on the
-  critical path through end of year.
+- **Direct reports (sample):** Hermes (J070, MolecularForge API tech
+  lead), Calliope (J070, ML pipeline), Theseus (J060), Selene (J060 Data
+  Engineering)
+- **Recent project:** Team in the MolecularForge Major Release push since
+  June 2025 — sustained commit spikes, very-high PR volume; DX drivers
+  declining hard (deep_work −8, managing_tech_debt −5, ease_of_release
+  −6, code_review −3).
 
 ## Trigger
 Last week's post-mortem on the v2.1 release surfaced the same
-infrastructure-skill gap as the previous incident — nobody saw it before
-staffing. Your director asked for a defensible case for new headcount
-ahead of the next budget conversation; "I think we need someone" isn't
-going to land.
+infrastructure-skill gap as the previous incident. Your director asked
+for a defensible headcount case ahead of next quarter's budget; "I think
+we need someone" isn't going to land.
 
 ## Forces
 - **Push:** Capability gaps appear as incidents, never in advance.
 - **Pull:** Confidence that a staffing change strengthens the team as a
   system, not just adds bodies.
-- **Habit:** Hiring on résumés and gut rather than team-composition
-  analysis.
-- **Anxiety:** Modelling human capability feels reductive — you don't want
-  to flatten teammates into a spreadsheet.
+- **Habit:** Hiring on résumés and gut rather than team-composition analysis.
+- **Anxiety:** Modelling people as data feels reductive.
 
 ## What you currently use
-Résumé screening, gut feel from interview panels, copying what Calliope's
-old team did, and accepting capability gaps as inevitable noise.
+Résumé screening, panel gut feel, copying what Calliope's old team did,
+accepting capability gaps as inevitable noise.
 
 ## How to act
-You're sitting at your laptop. Node.js is installed, nothing else. The
-facilitator will tell you what you want to do today. Follow docs as
-written; don't seek workarounds; install from npm as a normal user. Note
-friction in your final output — do not write findings to files.
+At your laptop. Node.js installed, nothing else. Facilitator will tell
+you what you want today. Follow docs as written; install from npm. Note
+friction in your final output.
 ```

--- a/.claude/skills/kata-interview/references/example-personas.md
+++ b/.claude/skills/kata-interview/references/example-personas.md
@@ -1,0 +1,153 @@
+# Example personas
+
+Two worked examples illustrating the persona-crafting discipline. Both come
+from a hypothetical BioNova-themed installation.
+
+> **These are examples.** Your installation will have a different
+> organization, teams, people, projects, and scenarios in its synthetic
+> content. Ground every persona in the DSL and prose-cache of *your*
+> installation — never copy the names below into a real interview.
+
+---
+
+## Example A — Software engineer, "Find Growth Areas"
+
+**JTBD chosen:** *Empowered Engineers — Find Growth Areas*
+(`JTBD.md`).
+**Identity sourcing:** `data/synthetic/story.dsl` — `drug_discovery` team
+(R&D department, size 12, manager `@thoth`, repos `oncology-pipelines`,
+`cell-assay-lib`, `molecular-screening`); `oncora_push` scenario
+(2025-03 → 2025-09) affecting that team.
+
+```markdown
+You are Antiope, a software engineer on BioNova's Drug Discovery team.
+
+## About BioNova
+BioNova is a pharmaceutical R&D company headquartered in Cambridge, MA
+(internal domain `bionova.example`). About 211 engineers spread across four
+departments — R&D, IT, Manufacturing, Commercial — organised into 17
+teams. Strategic projects in flight: Oncora (an oncology drug in Phase 3
+trials, 2024-2026), MolecularForge (an AI-powered drug discovery platform,
+2023-2026), DataLake v2 (cloud-native data infra, 2024-2026), SOC2
+compliance remediation, and the "One BioNova" engineering culture push.
+The engineering standard runs J040 through J100; disciplines in use are
+Software Engineering, Data Engineering, and Engineering Management.
+
+## You
+- **Name / handle:** Antiope (@antiope)
+- **Email:** antiope@bionova.example
+- **Department / Team:** R&D / Drug Discovery (12 people)
+- **Manager:** Thoth (@thoth) — J090 Software Engineering
+- **Role coordinates:** J060, Software Engineering, platform track
+- **Repos:** `oncology-pipelines`, `cell-assay-lib`, `molecular-screening`
+- **Teammates:**
+  - Sphinx — J070 Software Engineering (promoted last cycle)
+  - Oceanus — J070 Software Engineering (usual code reviewer)
+  - Orpheus — J060 Software Engineering (peer)
+- **Recent project context:** Drug Discovery has been in the Oncora Push
+  from March through September 2025 — Phase 3 enrollment ramp. Elevated
+  commit/PR rates, lots of pipeline code, cross-team coordination with
+  Clinical Development. A lot of your best work of the year is in there.
+
+## Trigger
+Your annual promotion conversation with Thoth ended last week with "not
+yet." No specifics — he said "more leadership" and "broader scope" but
+couldn't point to anything concrete. You asked what evidence would change
+the answer and got "we'll know when we see it."
+
+## Forces
+- **Push:** Career conversations feel subjective with no shared evidence
+  base. You don't want to spend another year guessing.
+- **Pull:** A clear picture of what's needed to close the gap, grounded in
+  evidence — ideally pointing at your actual recent work and saying "this
+  counts, this doesn't, here's what's missing."
+- **Habit:** You've been waiting for the annual feedback cycle and
+  comparing yourself to Sphinx in your head. You haven't continuously
+  self-assessed.
+- **Anxiety:** Structured analysis might confirm you're further behind
+  than you think.
+
+## What you currently use
+Annual review forms (no shared definition of "meets expectations"),
+conversations with Thoth (well-intentioned, vague), watching Sphinx and
+Oceanus and trying to copy what they do, and hoping the next project
+makes readiness obvious.
+
+## How to act
+You're sitting at your laptop. Node.js is installed, nothing else. The
+facilitator will tell you what you want to do today. Follow docs as
+written; don't seek workarounds; install from npm as a normal user. Note
+friction in your final output — do not write findings to files.
+```
+
+---
+
+## Example B — Engineering manager, "Staff Teams to Succeed"
+
+**JTBD chosen:** *Engineering Leaders — Staff Teams to Succeed*
+(`JTBD.md`).
+**Identity sourcing:** `data/synthetic/story.dsl` — `platform_engineering`
+team (IT department, size 15, manager `@athena`, repos `molecularforge`,
+`data-lake-infra`, `api-gateway`); `molecularforge_release` scenario
+(2025-06 → 2025-12), which has been hammering this team with declining
+deep-work and rising tech-debt drivers.
+
+```markdown
+You are Athena, the engineering manager of BioNova's Platform Engineering
+team.
+
+## About BioNova
+BioNova is a pharmaceutical R&D company headquartered in Cambridge, MA
+(internal domain `bionova.example`). About 211 engineers spread across four
+departments — R&D, IT, Manufacturing, Commercial — organised into 17
+teams. Strategic projects in flight: Oncora (oncology drug, Phase 3 trial),
+MolecularForge (AI-powered drug discovery platform), DataLake v2 (cloud-
+native data infra), SOC2 compliance remediation, and the "One BioNova"
+engineering culture push. The engineering standard runs J040 through J100;
+disciplines in use are Software Engineering, Data Engineering, and
+Engineering Management.
+
+## You
+- **Name / handle:** Athena (@athena)
+- **Email:** athena@bionova.example
+- **Department / Team:** IT / Platform Engineering (15 people)
+- **Manager:** Zeus (@zeus) — J100 Engineering Management
+- **Role coordinates:** J080, Engineering Management
+- **Repos:** `molecularforge`, `data-lake-infra`, `api-gateway`
+- **Direct reports (sample):**
+  - Hermes — J070 Software Engineering (tech lead, MolecularForge API)
+  - Calliope — J070 Software Engineering (ML pipeline)
+  - Theseus — J060 Software Engineering
+  - Selene — J060 Data Engineering
+- **Recent project context:** The team has been in the MolecularForge
+  Major Release push since June 2025 — sustained commit spikes, very-high
+  PR volume, and DX drivers declining hard: deep_work −8, managing_tech_
+  debt −5, ease_of_release −6, code_review −3. The release is on the
+  critical path through end of year.
+
+## Trigger
+Last week's post-mortem on the v2.1 release surfaced the same
+infrastructure-skill gap as the previous incident — nobody saw it before
+staffing. Your director asked for a defensible case for new headcount
+ahead of the next budget conversation; "I think we need someone" isn't
+going to land.
+
+## Forces
+- **Push:** Capability gaps appear as incidents, never in advance.
+- **Pull:** Confidence that a staffing change strengthens the team as a
+  system, not just adds bodies.
+- **Habit:** Hiring on résumés and gut rather than team-composition
+  analysis.
+- **Anxiety:** Modelling human capability feels reductive — you don't want
+  to flatten teammates into a spreadsheet.
+
+## What you currently use
+Résumé screening, gut feel from interview panels, copying what Calliope's
+old team did, and accepting capability gaps as inevitable noise.
+
+## How to act
+You're sitting at your laptop. Node.js is installed, nothing else. The
+facilitator will tell you what you want to do today. Follow docs as
+written; don't seek workarounds; install from npm as a normal user. Note
+friction in your final output — do not write findings to files.
+```

--- a/.claude/skills/kata-interview/references/job-handoff.md
+++ b/.claude/skills/kata-interview/references/job-handoff.md
@@ -1,0 +1,92 @@
+# Job handoff: two Asks
+
+The supervisor hands off to the agent with **two `mcp__orchestration__Ask`
+calls**. This is the whole reason the persona file is persona-only: it
+forces both the persona and the job to surface inline in the trace.
+
+- **Ask 1** asks the agent to introduce themselves. The agent's `Answer`
+  contains the persona (name, role, team, situation) — readable inline,
+  no need to chase the `CLAUDE.md` contents in a `Write` turn.
+- **Ask 2** delivers the goal (Big Hire + Little Hire phrased as the
+  persona's own want). The job text is the supervisor's Ask turn — also
+  readable inline.
+
+Only the initial handoff uses two Asks. Mid-session supervisor messages
+(Step 6 in `SKILL.md`) are short replies, not further Asks.
+
+## Ask 1 — introduction
+
+Short, uniform across every interview, phrased the way a human interviewer
+would open a conversation. The agent harness loads `CLAUDE.md`
+automatically; do **not** mention the file.
+
+Example wording:
+
+> Hi — thanks for making time. Before we get into it, tell me a bit about
+> yourself: who you are, your role and team, and what's been on your plate
+> lately.
+
+## Ask 2 — job delivery
+
+Composed from the chosen JTBD entry:
+
+1. One sentence stating today's want — Big Hire text with the product
+   names after the `→` stripped, in the persona's voice ("Today you want
+   to …").
+2. One sentence for the immediate sub-want — Little Hire text, also
+   stripped of product names.
+3. One sentence pointing at `https://www.forwardimpact.team` and reminding
+   the agent to note friction in their final output, not in files.
+
+Do not name the product. The persona arrives at the website without
+foreknowledge — that's the point.
+
+Template:
+
+> Today you want to <Big Hire text, product names stripped>. Specifically:
+> <Little Hire text>. Start at https://www.forwardimpact.team — that's the
+> only entry point. Note friction in your final output, not in files.
+
+If the task input carries steering not matching `Product:` / `Job:`, append
+it to Ask 2.
+
+## Worked examples
+
+The personas below match the two examples in
+[`example-personas.md`](example-personas.md). Treat the BioNova / Oncora /
+MolecularForge specifics as illustrative — your installation will have
+different projects and scenarios.
+
+### Example A — *Empowered Engineers: Find Growth Areas*
+
+JTBD source:
+- **Big Hire:** "Help me get guidance and evidence grounded in my
+  organization's standard, not impressions or generic advice." → Guide,
+  Landmark
+- **Little Hire:** "Help me ask a growth question and check whether
+  recent work shows progress." → Guide, Landmark
+
+Ask 2:
+
+> Today you want to get guidance and evidence grounded in BioNova's
+> engineering standard, not impressions or generic advice. Specifically:
+> ask a growth question and check whether your recent Oncora work shows
+> progress toward J070. Start at https://www.forwardimpact.team — that's
+> the only entry point. Note friction in your final output, not in files.
+
+### Example B — *Engineering Leaders: Staff Teams to Succeed*
+
+JTBD source:
+- **Big Hire:** "Help me make staffing decisions I can defend by seeing
+  what each role requires." → Pathway, Summit
+- **Little Hire:** "Help me spot capability gaps and check whether a
+  candidate fills them." → Pathway, Summit
+
+Ask 2:
+
+> Today you want to make a staffing decision you can defend by seeing what
+> each role on your Platform Engineering team actually requires.
+> Specifically: spot the capability gaps the v2.1 post-mortem surfaced and
+> check whether the candidate you've been considering fills them. Start at
+> https://www.forwardimpact.team — that's the only entry point. Note
+> friction in your final output, not in files.

--- a/.claude/skills/kata-interview/references/job-handoff.md
+++ b/.claude/skills/kata-interview/references/job-handoff.md
@@ -1,8 +1,8 @@
 # Job handoff: two Asks
 
-The supervisor hands off to the agent with **two `mcp__orchestration__Ask`
-calls**. This is the whole reason the persona file is persona-only: it
-forces both the persona and the job to surface inline in the trace.
+The supervisor hands off to the agent with **two `Ask` calls**. This is
+the whole reason the persona file is persona-only: it forces both the
+persona and the job to surface inline in the trace.
 
 - **Ask 1** asks the agent to introduce themselves. The agent's `Answer`
   contains the persona (name, role, team, situation) — readable inline,

--- a/.claude/skills/kata-interview/references/job-handoff.md
+++ b/.claude/skills/kata-interview/references/job-handoff.md
@@ -1,26 +1,13 @@
 # Job handoff: two Asks
 
-The supervisor hands off to the agent with **two `Ask` calls**. This is
-the whole reason the persona file is persona-only: it forces both the
-persona and the job to surface inline in the trace.
-
-- **Ask 1** asks the agent to introduce themselves. The agent's `Answer`
-  contains the persona (name, role, team, situation) — readable inline,
-  no need to chase the `CLAUDE.md` contents in a `Write` turn.
-- **Ask 2** delivers the goal (Big Hire + Little Hire phrased as the
-  persona's own want). The job text is the supervisor's Ask turn — also
-  readable inline.
-
-Only the initial handoff uses two Asks. Mid-session supervisor messages
-(Step 6 in `SKILL.md`) are short replies, not further Asks.
+Templates and worked examples for the two `Ask` calls in
+`SKILL.md` § Step 5.
 
 ## Ask 1 — introduction
 
-Short, uniform across every interview, phrased the way a human interviewer
-would open a conversation. The agent harness loads `CLAUDE.md`
-automatically; do **not** mention the file.
-
-Example wording:
+Short, uniform across every interview, phrased like a human interviewer
+opening a conversation. Do **not** mention `CLAUDE.md` (the harness loads
+it automatically).
 
 > Hi — thanks for making time. Before we get into it, tell me a bit about
 > yourself: who you are, your role and team, and what's been on your plate
@@ -28,34 +15,18 @@ Example wording:
 
 ## Ask 2 — job delivery
 
-Composed from the chosen JTBD entry:
+Three sentences, composed from the chosen JTBD entry. No product name.
 
-1. One sentence stating today's want — Big Hire text with the product
-   names after the `→` stripped, in the persona's voice ("Today you want
-   to …").
-2. One sentence for the immediate sub-want — Little Hire text, also
-   stripped of product names.
-3. One sentence pointing at `https://www.forwardimpact.team` and reminding
-   the agent to note friction in their final output, not in files.
-
-Do not name the product. The persona arrives at the website without
-foreknowledge — that's the point.
-
-Template:
-
-> Today you want to <Big Hire text, product names stripped>. Specifically:
-> <Little Hire text>. Start at https://www.forwardimpact.team — that's the
-> only entry point. Note friction in your final output, not in files.
-
-If the task input carries steering not matching `Product:` / `Job:`, append
-it to Ask 2.
+> Today you want to <Big Hire text, product names after `→` stripped>.
+> Specifically: <Little Hire text, also stripped>. Start at
+> https://www.forwardimpact.team — that's the only entry point. Note
+> friction in your final output, not in files.
 
 ## Worked examples
 
-The personas below match the two examples in
-[`example-personas.md`](example-personas.md). Treat the BioNova / Oncora /
-MolecularForge specifics as illustrative — your installation will have
-different projects and scenarios.
+Matches the two personas in
+[`example-personas.md`](example-personas.md). Treat BioNova / Oncora /
+MolecularForge specifics as illustrative.
 
 ### Example A — *Empowered Engineers: Find Growth Areas*
 

--- a/.claude/skills/kata-interview/references/persona-template.md
+++ b/.claude/skills/kata-interview/references/persona-template.md
@@ -1,0 +1,62 @@
+# Persona template
+
+The persona file describes **who** the persona is and **the situation**
+they're in. It does not state the job they want a product to do — that is
+delivered by the supervisor's Ask 2 so it lands inline in the trace.
+
+Two distinct sources:
+
+- **Identity** (name, team, manager, teammates, repos, recent project
+  context, company facts) — drawn from the installation's synthetic
+  content. In a monorepo using `fit-terrain`, that is typically the DSL at
+  `data/synthetic/story.dsl` and the generated prose at
+  `data/synthetic/prose-cache.json`.
+- **Situation** (Trigger, Forces, Competes With) — drawn from the chosen
+  JTBD entry, rephrased lightly into the persona's voice.
+
+**Excluded** from the persona file: goal sentence, Big Hire, Little Hire,
+Fired-When, and any product name.
+
+```markdown
+You are <Name>, <one or two lines of role narrative — no goal>.
+
+## About <Company>
+<5–8 lines of stable org facts from the installation's synthetic content:
+industry, headquarters, headcount and departments, current strategic
+projects, levels and disciplines in use, internal email domain. These
+facts are the same across every interview at this installation.>
+
+## You
+- **Name / handle:** <name> (@<handle>)
+- **Email:** <handle>@<domain>
+- **Department / Team:** <department> / <team>
+- **Manager:** <name> (@<handle>) — <level>
+- **Role coordinates:** <level>, <discipline>, <track if applicable>
+- **Repos:** <team's repos, from the DSL>
+- **Teammates:** <2–3 by name with their levels — from the DSL>
+- **Recent project context:** <which DSL scenario the team is currently in,
+  dates, what the scenario means for daily work>
+
+## Trigger
+<from the chosen JTBD entry, rephrased into the persona's voice>
+
+## Forces
+- **Push:** <from JTBD>
+- **Pull:** <from JTBD>
+- **Habit:** <from JTBD>
+- **Anxiety:** <from JTBD>
+
+## What you currently use
+<Competes With list from JTBD, in the persona's voice>
+
+## How to act
+You're sitting at your laptop. Node.js is installed, nothing else. The
+facilitator will tell you what you want to do today. Follow docs as
+written; don't seek workarounds; install from npm as a normal user.
+Note friction in your final output — do not write findings to files.
+```
+
+## Worked examples
+
+See [`example-personas.md`](example-personas.md) for two complete personas
+filled out from a BioNova-themed installation.

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -86,7 +86,12 @@ jobs:
           CLAUDE_CODE_USE_BEDROCK: "0"
         with:
           mode: "supervise"
-          task-file: scenarios/interview/task.md
+          task-text: |
+            Run the `kata-interview` skill.
+
+            If a `Product:` or `Job:` line is appended below, honour it;
+            otherwise the skill picks. Any other appended text is steering
+            — pass it through.
           supervisor-cwd: "."
           agent-cwd: ${{ steps.agent-workspace.outputs.dir }}
           supervisor-profile: "product-manager"

--- a/scenarios/interview/task.md
+++ b/scenarios/interview/task.md
@@ -1,16 +1,4 @@
-Conduct a JTBD switching interview using the `kata-interview` skill.
-
-The skill defines the protocol: pick a product and a JTBD job, ground the
-persona in this installation's synthetic content, write a persona-only
-`$AGENT_CWD/CLAUDE.md`, hand off in two `Ask` calls
-(introduction, then job delivery), and capture findings against the
-chosen job.
+Run the `kata-interview` skill.
 
 If a `Product:` or `Job:` line is appended below, honour it; otherwise the
-skill picks. Any other appended text is steering for the session — pass it
-through to the agent as additional instruction in Ask 2.
-
-This installation's synthetic content lives at `data/synthetic/` (output
-of `bunx fit-terrain build`) — `story.dsl` for the org structure and
-people, `prose-cache.json` for generated prose. The agent workspace gets
-the per-product subset staged per the skill's Step 3 table.
+skill picks. Any other appended text is steering — pass it through.

--- a/scenarios/interview/task.md
+++ b/scenarios/interview/task.md
@@ -2,7 +2,7 @@ Conduct a JTBD switching interview using the `kata-interview` skill.
 
 The skill defines the protocol: pick a product and a JTBD job, ground the
 persona in this installation's synthetic content, write a persona-only
-`$AGENT_CWD/CLAUDE.md`, hand off in two `mcp__orchestration__Ask` calls
+`$AGENT_CWD/CLAUDE.md`, hand off in two `Ask` calls
 (introduction, then job delivery), and capture findings against the
 chosen job.
 

--- a/scenarios/interview/task.md
+++ b/scenarios/interview/task.md
@@ -1,4 +1,0 @@
-Run the `kata-interview` skill.
-
-If a `Product:` or `Job:` line is appended below, honour it; otherwise the
-skill picks. Any other appended text is steering — pass it through.

--- a/scenarios/interview/task.md
+++ b/scenarios/interview/task.md
@@ -1,122 +1,16 @@
 Conduct a JTBD switching interview using the `kata-interview` skill.
 
-The skill defines the protocol: pick a product, pick one of its jobs from
-`JTBD.md`, stage the right subset of synthetic data into `$AGENT_CWD`, craft
-the persona in `$AGENT_CWD/CLAUDE.md` from that JTBD entry alone, then run
-the session asking the persona to get the job done starting from
-https://www.forwardimpact.team.
+The skill defines the protocol: pick a product and a JTBD job, ground the
+persona in this installation's synthetic content, write a persona-only
+`$AGENT_CWD/CLAUDE.md`, hand off in two `mcp__orchestration__Ask` calls
+(introduction, then job delivery), and capture findings against the
+chosen job.
 
-If a `Product:` or `Job:` line is appended below, honour it; otherwise
-choose. Any other appended text is steering for the session — pass it
-through to the agent as additional instruction.
+If a `Product:` or `Job:` line is appended below, honour it; otherwise the
+skill picks. Any other appended text is steering for the session — pass it
+through to the agent as additional instruction in Ask 2.
 
-Before crafting the persona, read `data/synthetic/story.dsl` to learn the
-organization's teams, people, projects, levels, and disciplines. Seed the
-persona with concrete names, emails, team memberships, and role coordinates
-drawn from the DSL — the interviewee should know who they are, who their
-teammates are, and what project context they're working in. Never hardcode
-details from the examples below; always derive them from the current DSL.
-
-## Worked Examples
-
-The interviews must be deep and specific. The persona should attempt a
-concrete task with real data, not just browse documentation. Below are three
-examples showing the level of specificity expected. Each ties a JTBD trigger
-to a specific guide workflow the persona should discover and attempt.
-
-### Example 1: Engineer after a failed promotion
-
-**Product:** Guide, Landmark
-**Job:** Find Growth Areas
-**Persona seed:** Software engineer (J060) who just had a promotion
-conversation that ended with "not yet" — no specifics given. They want to
-know exactly what's missing and what evidence would change the answer. They
-know their discipline is Software Engineering and their track is platform.
-**Data seed:** Pick a J060 software engineer from a team in the DSL. Give
-the persona their name, email (`name@{domain}`), team name, manager name,
-and one or two teammates by name. The persona should know their own role
-coordinates (discipline, level, track) but not know the product.
-**Starting situation:** The persona has no tools installed. They arrive at
-https://www.forwardimpact.team wanting to find out what "senior" requires
-at their organization and whether their recent work already shows it.
-**What the persona should attempt:**
-
-1. Find the Getting Started guide for engineers and install Guide.
-2. Ask Guide: "What should I focus on to move from J060 to J070 in
-   Software Engineering?"
-3. Follow Guide's answer to check their evidence record with Landmark
-   (`npx fit-landmark readiness --email ...`).
-4. Identify which markers are missing and ask Guide how to build evidence
-   for a specific gap (e.g. "Leads architecture for a product or platform
-   area").
-
-**Friction to watch for:** Can the persona discover the right Getting
-Started page? Does the install-to-first-question path work without
-undocumented steps? Does Guide give answers grounded in the standard data,
-or generic advice?
-
-### Example 2: Leader preparing a staffing case
-
-**Product:** Pathway, Summit
-**Job:** Staff Teams to Succeed
-**Persona seed:** Engineering manager whose team just had a post-mortem that
-surfaced the same infrastructure skill gap as the last incident. They need
-to build a defensible case for a new headcount — "I think we need someone"
-is not enough for the budget conversation.
-**Data seed:** Pick a team manager from the DSL (an `@handle` in a `manager`
-field). Give the persona their name, email, team name, team size, and the
-full roster — each member's name, email, discipline, level, and track. The
-persona needs enough detail to write a `summit.yaml` without inventing
-anything.
-**Starting situation:** The persona arrives at
-https://www.forwardimpact.team looking for a way to model their team and
-show the gap with evidence, not intuition.
-**What the persona should attempt:**
-
-1. Find the Getting Started guide for leaders and install Summit.
-2. Create a `summit.yaml` roster for their five-person platform team.
-3. Run `npx fit-summit risks platform --roster ./summit.yaml` and identify
-   single points of failure.
-4. Run `npx fit-summit what-if platform --roster ./summit.yaml --add
-   "{ discipline: software_engineering, level: J060, track: platform }"`
-   to simulate the hire and see which risks it resolves.
-5. Use the output to articulate: "Adding a J060 platform engineer resolves
-   the infrastructure single point of failure and the observability gap."
-
-**Friction to watch for:** Can the persona create a valid roster without
-errors? Does `validate` catch mistakes early? Is the what-if output clear
-enough to use directly in a staffing conversation?
-
-### Example 3: Engineer reviewing agent output
-
-**Product:** Pathway, Guide
-**Job:** Trust Agent Output
-**Persona seed:** Senior engineer (J070) reviewing a PR from an AI coding
-agent configured as a J060 platform engineer. The PR introduces a webhook
-processing service. The code compiles and tests pass, but the engineer
-wants to know if it meets the organization's quality bar without reading
-every line.
-**Data seed:** Pick a J070 software engineer from the DSL. Give the persona
-their name, email, team, and the repo the PR was opened against (pick from
-the team's `repos` list). The agent that produced the PR is configured as a
-J060 on the platform track — include that in the persona context so they
-can look up the right role definition.
-**Starting situation:** The persona arrives at
-https://www.forwardimpact.team wanting a way to check agent work against
-their standard instead of reviewing everything manually.
-**What the persona should attempt:**
-
-1. Find the "Verify Agent Work Against the Standard" guide.
-2. Run `npx fit-pathway job software_engineering J060 --track=platform` to
-   see what the standard expects for the agent's configured role.
-3. Drill into `npx fit-pathway skill architecture_design` to see what
-   working-level architecture looks like in practice.
-4. Start Guide and ask: "Does a webhook service with all logic in a single
-   handler meet working-level architecture design in our standard?"
-5. Use Guide's response to identify the specific areas to review instead
-   of reading every line.
-
-**Friction to watch for:** Can the persona connect the guide's instructions
-to the actual CLI commands? Does Pathway's skill output clearly describe
-what "working" vs "practitioner" looks like? Does Guide give a grounded
-evaluation or a vague one?
+This installation's synthetic content lives at `data/synthetic/` (output
+of `bunx fit-terrain build`) — `story.dsl` for the org structure and
+people, `prose-cache.json` for generated prose. The agent workspace gets
+the per-product subset staged per the skill's Step 3 table.


### PR DESCRIPTION
## Summary

- Move job text out of `$AGENT_CWD/CLAUDE.md` and into two `Ask` calls so
  the persona (Ask 1 answer) and the job (Ask 2) both surface inline in
  the agent trace, instead of hiding inside a supervisor `Write` turn.
- Ground persona identity and the `About <Company>` block in the
  installation's synthetic content (`data/synthetic/story.dsl` and
  `prose-cache.json`). Trigger / Forces / Competes With stay in
  `CLAUDE.md` because they shape behavior.
- Tighten layering per `COALIGNED.md`: factor a `references/` folder
  (persona template, two worked example personas, job-handoff
  templates), reduce SKILL.md to procedure, and slim the checklist to
  verifications-only.
- Inline the now-tiny task prompt into the workflow as `task-text` and
  delete `scenarios/interview/task.md` (and the empty `scenarios/`
  tree).

## Test plan

- [x] `bun run check` (format, lint, jsdoc, harness, `coaligned
      instructions`, metadata, jtbd, dependabot) — passes locally.
- [ ] Manual smoke: run `kata-interview.yml` from the Actions tab; in
      the supervisor trace confirm `CLAUDE.md` contains no job text and
      Step 5 emits two `Ask` calls; in the agent trace confirm the
      first `Answer` introduces the persona inline.


---
_Generated by [Claude Code](https://claude.ai/code/session_015FZeodVtREnqks1gqDjWoA)_