### PR TITLE
fix(kata-session): seed xmr markers so fit-wiki refresh stops no-opping

### DIFF
--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -47,8 +47,10 @@ Participant Protocol below.
 - [ ] Identify which metrics CSVs to review from `wiki/metrics/`.
 - [ ] Run `bunx fit-xmr analyze --format json` against each metrics CSV and
       record the `status`, fired-rule `signals`, and `latest` for each metric.
-- [ ] For team storyboard runs, run `bunx fit-wiki refresh` to regenerate all
-      XmR chart blocks in the current month's storyboard.
+- [ ] For team storyboard runs, seed any missing `<!-- xmr:... -->` marker
+      pair from
+      [`references/storyboard-template.md`](references/storyboard-template.md),
+      then run `bunx fit-wiki refresh`.
 
 </read_do_checklist>
 
@@ -60,8 +62,9 @@ Participant Protocol below.
       including XmR `status` and signal descriptions for each metric with
       sufficient data. Metrics with `insufficient_data` are noted.
 - [ ] Coaching metrics appended to CSV (see Facilitator Process step 6).
-- [ ] For team meetings: storyboard updated per partition protocol; experiments
-      and obstacles managed as labeled GitHub issues per
+- [ ] For team meetings: storyboard updated per partition protocol; every
+      metric block carries refresh-rendered content between `<!-- xmr:... -->`
+      markers; experiments and obstacles managed as labeled GitHub issues per
       [`issue-lifecycle.md`](references/issue-lifecycle.md).
 - [ ] For 1-on-1: agent's findings written to its own memory.
 - [ ] Weekly log updated under `## YYYY-MM-DD` with meeting type, metrics,
@@ -120,8 +123,11 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
 4. **Run XmR analysis.** For every CSV in `wiki/metrics/`, run
    `bunx fit-xmr analyze <csv> --format json` and use the `status`, fired-rule
    `signals`, and `latest` fields when reporting the Condition. For team
-   storyboard runs, run `bunx fit-wiki refresh` to regenerate all XmR chart
-   blocks in the current month's storyboard. Note any
+   storyboard runs, refresh chart blocks per
+   [`team-storyboard.md` § Storyboard updates](references/team-storyboard.md#storyboard-updates) —
+   seed any missing `<!-- xmr:... -->` marker pair from
+   [`storyboard-template.md`](references/storyboard-template.md), then run
+   `bunx fit-wiki refresh`. A no-op refresh is a missing-marker bug. Note any
    `insufficient_data` metric. In facilitated mode, include `status` and
    fired-rule signals in the Q2 `Ask`.
 5. **Run the five questions.** Follow the overlay's wording. In facilitated

--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -62,9 +62,9 @@ Participant Protocol below.
       including XmR `status` and signal descriptions for each metric with
       sufficient data. Metrics with `insufficient_data` are noted.
 - [ ] Coaching metrics appended to CSV (see Facilitator Process step 6).
-- [ ] For team meetings: storyboard updated per partition protocol; every
-      metric block carries refresh-rendered content between `<!-- xmr:... -->`
-      markers; experiments and obstacles managed as labeled GitHub issues per
+- [ ] For team meetings: storyboard updated per partition protocol;
+      `bunx fit-wiki refresh` rendered every metric block (no no-op, no manual
+      paste); experiments and obstacles managed as labeled GitHub issues per
       [`issue-lifecycle.md`](references/issue-lifecycle.md).
 - [ ] For 1-on-1: agent's findings written to its own memory.
 - [ ] Weekly log updated under `## YYYY-MM-DD` with meeting type, metrics,
@@ -124,12 +124,9 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    `bunx fit-xmr analyze <csv> --format json` and use the `status`, fired-rule
    `signals`, and `latest` fields when reporting the Condition. For team
    storyboard runs, refresh chart blocks per
-   [`team-storyboard.md` § Storyboard updates](references/team-storyboard.md#storyboard-updates) —
-   seed any missing `<!-- xmr:... -->` marker pair from
-   [`storyboard-template.md`](references/storyboard-template.md), then run
-   `bunx fit-wiki refresh`. A no-op refresh is a missing-marker bug. Note any
-   `insufficient_data` metric. In facilitated mode, include `status` and
-   fired-rule signals in the Q2 `Ask`.
+   [`team-storyboard.md` § Storyboard updates](references/team-storyboard.md#storyboard-updates).
+   Note any `insufficient_data` metric. In facilitated mode, include `status`
+   and fired-rule signals in the Q2 `Ask`.
 5. **Run the five questions.** Follow the overlay's wording. In facilitated
    mode, pose each question via `Ask` and collect `Answer` replies before
    advancing. Use `Announce` for between-question transitions or any status that

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -14,11 +14,11 @@ Experiments. Full template at
 
 **Planning meeting** — first meeting of the month or no storyboard exists.
 Create the storyboard from [`storyboard-template.md`](storyboard-template.md):
-for every `wiki/metrics/{skill}/{YYYY}.csv`, instantiate a `#### {metric_name}`
-block bracketed by `<!-- xmr:{metric}:{csv} -->` / `<!-- /xmr -->` — that pair
-is the contract `bunx fit-wiki refresh` depends on. Then lead the team
-through: the Challenge, the Target Condition (measurable, by month end), the
-Current Condition from metrics CSVs, initial Obstacles, and the first
+for every `wiki/metrics/{skill}/{YYYY}.csv`, instantiate one
+`#### {metric_name}` block under `### {skill}` with its
+`<!-- xmr:{metric}:{csv} -->` / `<!-- /xmr -->` marker pair. Then lead the
+team through: the Challenge, the Target Condition (measurable, by month end),
+the Current Condition from metrics CSVs, initial Obstacles, and the first
 Experiment.
 
 **Review meeting** — all other team meetings. Walk through the five questions,

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -13,10 +13,13 @@ Experiments. Full template at
 ## Planning vs. Review
 
 **Planning meeting** — first meeting of the month or no storyboard exists.
-Create the storyboard from the template. Lead the team through: establishing or
-confirming the Challenge, setting the Target Condition (measurable, by month
-end), measuring the Current Condition from metrics CSVs, identifying initial
-Obstacles, and planning the first Experiment.
+Create the storyboard from [`storyboard-template.md`](storyboard-template.md):
+for every `wiki/metrics/{skill}/{YYYY}.csv`, instantiate a `#### {metric_name}`
+block bracketed by `<!-- xmr:{metric}:{csv} -->` / `<!-- /xmr -->` — that pair
+is the contract `bunx fit-wiki refresh` depends on. Then lead the team
+through: the Challenge, the Target Condition (measurable, by month end), the
+Current Condition from metrics CSVs, initial Obstacles, and the first
+Experiment.
 
 **Review meeting** — all other team meetings. Walk through the five questions,
 update Current Condition with fresh metrics, record experiment outcomes (actual
@@ -52,22 +55,17 @@ Metrics for the recording-eligibility rule.
 
 ## Storyboard updates
 
-Run `bunx fit-wiki refresh` to regenerate all `<!-- xmr:... -->` /
-`<!-- /xmr -->` blocks in the current month's storyboard. Idempotent. Pass an
-explicit path to target a different file.
+Run `bunx fit-wiki refresh` to regenerate every `<!-- xmr:... -->` block in
+the current month's storyboard. Idempotent; pass an explicit path to target a
+different file. The headings and `_Note:_` prose sit outside the markers and
+are preserved. Rendered block contents — `**Latest:**` / `**Status:**`, the
+X+mR chart, `**Signals:**` — match the template; **do not restate `μ`, `UPL`,
+`LPL`, or zone values in prose** outside the chart.
 
-Each `#### {metric_name}` block is bracketed by markers. Everything between
-them is regenerated; the heading and `_Note:_` prose sit outside.
-
-The rendered block contains:
-
-1. `**Latest:** {value} · **Status:** {status}`. No trend arrows.
-2. The X+mR chart in a fenced code block. Chart the whole CSV — **do not
-   restate `μ`, `UPL`, `LPL`, or zone values in prose**.
-3. `**Signals:**` — fired Wheeler rules or `—`.
-4. Optional one-line note only when `signals_present` needs cross-referencing.
-
-Without markers, fall back to `bunx fit-xmr chart` and paste manually.
+If a metric is missing its marker pair, seed it from
+[`storyboard-template.md`](storyboard-template.md), then re-run
+`bunx fit-wiki refresh`. A no-op refresh is a missing-marker bug — repair,
+never paste charts by hand.
 
 Above the agent-domain sections, write a tight `### Headlines` list naming only
 metrics whose status changed since the last meeting. Agents add cross-reference


### PR DESCRIPTION
## Summary

`bunx fit-wiki refresh` was silently no-opping against every recent storyboard. The `refresh` command preserves markers correctly — `libraries/libwiki/src/commands/refresh.js:41-45` splices content strictly *between* `<!-- xmr:... -->` / `<!-- /xmr -->` lines — but the coach has been creating storyboards without ever seeding the marker pairs (M04 and M05 had zero markers from their initial commits). A documented fallback (*"Without markers, fall back to `bunx fit-xmr chart` and paste manually"*) normalized the broken state so it never surfaced as a defect.

This branch tightens the `kata-session` instructions instead of adding new tooling:

- **L4 SKILL.md step 4** directs to `team-storyboard.md § Storyboard updates` (single directive; no inline duplication).
- **L5 `team-storyboard.md`** — Planning section now concretely instantiates one marker-bracketed `#### {metric}` block per `wiki/metrics/{skill}/{YYYY}.csv`. The "fall back to manual paste" escape hatch is replaced with a repair instruction: *"A no-op refresh is a missing-marker bug — repair, never paste charts by hand."*
- **L6 checklists** — READ-DO entry gate carries the seed-then-refresh constraint; DO-CONFIRM exit gate names the killer failure modes directly (*no no-op, no manual paste*).

All edits validated against COALIGNED.md layer separation and word/checklist-item budgets via `bunx coaligned instructions`.

## Test plan

- [x] `bun run check` — passes (includes `coaligned instructions` and `coaligned jtbd`)
- [x] `bunx coaligned instructions` — clean; line/word/item budgets all within caps
- [x] `libwiki` marker code paths (`cli-refresh.test.js`, `marker-scanner.test.js`) — 14/14 pass
- [x] Refresh works end-to-end on the real wiki — verified by seeding markers in `wiki/storyboard-2026-M05.md` and running `bunx fit-wiki refresh` (324 lines rewritten, all 12 metric blocks regenerated from CSVs)

Note: `bun run test` shows 17 pre-existing failures in `libwiki` git-commit tests, all environment-level (`signing server returned status 400` from this sandbox's commit-signing proxy). The same failures reproduce against `origin/main`'s test files; they don't touch any code this branch modifies.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Y1kKSSL1yaESUm2nzzqSU)_