### PR TITLE
ci(eval-kata): restrict to workflow_dispatch only

### DIFF
--- a/.github/workflows/eval-kata.yml
+++ b/.github/workflows/eval-kata.yml
@@ -2,14 +2,6 @@ name: "Eval: Kata"
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 6 * * 1"
-  pull_request:
-    paths:
-      - ".claude/skills/kata-*/**"
-      - ".claude/agents/*.md"
-      - "benchmarks/kata-skills/**"
-      - ".github/workflows/eval-kata.yml"
 
 concurrency:
   group: eval-kata-${{ github.ref }}


### PR DESCRIPTION
Drop the weekly schedule and pull_request triggers so eval-kata only
runs on manual dispatch, matching eval-guide.