### PR TITLE
plan(990): kata-interview real-landmark substrate via fit-map substrate

### DIFF
--- a/specs/990-kata-interview-real-landmark-substrate/plan-a-01.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a-01.md
@@ -176,44 +176,83 @@ with all three tests passing.
 
 - **Created**: `libraries/libconfig/test/credential-env-override.test.js`
 
-Single test file (~70 lines) constructing a Config in a tmpdir with a
-`.env` file containing `PRODUCT_LANDMARK_TOKEN=test-jwt-value`, then:
+Single test file (~80 lines). Use the existing test pattern from
+`libraries/libconfig/test/libconfig-env-file.test.js` — a mocked
+`storageFn` keeps the test hermetic (the default `createStorage` would
+walk `findUpward("config")` from the tmpdir and may discover the
+monorepo's own `config/` directory):
 
 ```js
-const config = await createProductConfig(
-  "landmark",
-  { token: undefined },
-  { ...process, cwd: () => tmpdir, env: { PATH: process.env.PATH } },
-);
-assert.equal(config.token, "test-jwt-value");
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { createProductConfig } from "@forwardimpact/libconfig";
+
+// Mocked storage that always returns no config file (no findUpward walk).
+function mockStorageFn() {
+  return {
+    get: async () => null,
+    put: async () => {},
+    delete: async () => {},
+    path: () => "/dev/null/config",
+  };
+}
+
+async function setup(envContent) {
+  const tmpdir = await mkdtemp(path.join(os.tmpdir(), "credenv-"));
+  if (envContent !== null) {
+    await writeFile(path.join(tmpdir, ".env"), envContent, { mode: 0o600 });
+  }
+  return tmpdir;
+}
+
+describe("PRODUCT_LANDMARK_TOKEN credential override", () => {
+  it("loads token from .env when no shell value is set", async () => {
+    const tmpdir = await setup("PRODUCT_LANDMARK_TOKEN=test-jwt-value\n");
+    const config = await createProductConfig(
+      "landmark",
+      { token: undefined },
+      { ...process, cwd: () => tmpdir, env: { PATH: process.env.PATH } },
+      mockStorageFn,
+    );
+    assert.equal(config.token, "test-jwt-value");
+    await rm(tmpdir, { recursive: true });
+  });
+
+  it("shell env wins over .env", async () => {
+    const tmpdir = await setup("PRODUCT_LANDMARK_TOKEN=env-value\n");
+    const config = await createProductConfig(
+      "landmark",
+      { token: undefined },
+      { ...process, cwd: () => tmpdir,
+        env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "shell-jwt" } },
+      mockStorageFn,
+    );
+    assert.equal(config.token, "shell-jwt");
+    await rm(tmpdir, { recursive: true });
+  });
+
+  it("empty-string shell value falls through to .env", async () => {
+    const tmpdir = await setup("PRODUCT_LANDMARK_TOKEN=env-value\n");
+    const config = await createProductConfig(
+      "landmark",
+      { token: undefined },
+      { ...process, cwd: () => tmpdir,
+        env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "" } },
+      mockStorageFn,
+    );
+    assert.equal(config.token, "env-value");  // .env wins, not ""
+    await rm(tmpdir, { recursive: true });
+  });
+});
 ```
 
-Also test that shell env wins over `.env`:
-
-```js
-const config = await createProductConfig(
-  "landmark",
-  { token: undefined },
-  { ...process, cwd: () => tmpdir,
-    env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "shell-jwt" } },
-);
-assert.equal(config.token, "shell-jwt");
-```
-
-Also test that an empty-string shell value falls through to `.env`:
-
-```js
-const config = await createProductConfig(
-  "landmark",
-  { token: undefined },
-  { ...process, cwd: () => tmpdir,
-    env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "" } },
-);
-assert.equal(config.token, "test-jwt-value");  // .env value wins
-```
-
-This third case covers the Part 03 workflow ternary that emits `''`
-for non-Landmark runs; it must not clobber a `.env`-supplied value.
+The empty-string case covers the Part 03 workflow ternary that emits
+`''` for non-Landmark runs; it must not clobber a `.env`-supplied
+value. The mocked `storageFn` ensures the test does not depend on
+disk layout outside the tmpdir.
 
 Verify: `bun test libraries/libconfig/test/credential-env-override.test.js`
 passes.
@@ -258,12 +297,17 @@ rg LANDMARK_AUTH_TOKEN websites/    # must return empty
 
 ## Step 10 — Verify contract-preservation suite green
 
-Run the full set of tests named in spec § Success Criteria row 11:
+Run the full set of tests covered by spec § Success Criteria row 11.
+Note: row 11 literally names `products/map/test/activity/activity.test.js`
+but that file does not exist on `main` — verify via `git ls-tree -r
+origin/main -- products/map/test/activity/`. The literal command is a
+spec inaccuracy; the intent is the whole activity test directory, which
+this step runs:
 
 ```sh
 bun test products/map/test/activity/auth-issue.test.js
 bun test products/map/test/activity/people-provision.test.js
-bun test products/map/test/activity/activity.test.js
+bun test products/map/test/activity/         # whole directory; covers row 11's intent
 bun test products/landmark/test/lib/identity.test.js
 bun test libraries/libconfig/test/
 bun run check  # full check suite

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a-01.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a-01.md
@@ -1,0 +1,274 @@
+# Plan 990-a Part 01 — libconfig override-loop fix + `PRODUCT_LANDMARK_TOKEN`
+
+Implements the design-c rows for libconfig, `Config.token`, the
+`resolveIdentity()` read-site swap, the `createProductConfig("landmark")`
+callsite, and the docs/test sweep. Closes the layering anomaly identified
+in design-c § Architectural insight.
+
+## Inter-step dependency
+
+Steps 1–4 are atomic: tests for individual steps (Steps 2, 3, 4) cannot
+run green until Steps 1+2+3+4+5+6 all land together — the change spans
+the loop, the credential-key set, the callsite, the read site, and the
+two test files. Treat Steps 1–6 as one commit; Steps 7–10 follow as
+separate commits.
+
+## Step 1 — Extend the libconfig override loop to read `#envOverrides`
+
+Let credential keys with a registered default in `data` resolve through
+both shell env and the `.env`-loaded `#envOverrides` map (today the loop
+reads only `process.env`). Treat empty string as absent so the
+workflow's `${{ … || '' }}` ternary in Part 03 does not clobber a
+`.env`-supplied value.
+
+- **Modified**: `libraries/libconfig/src/config.js` (override loop at
+  lines 125–134; verify by `rg "for \(const param of Object.keys\(data\)\)"
+  libraries/libconfig/src/config.js`)
+
+Replace the loop with (preserving precedence: shell `process.env` > `.env`
+`#envOverrides`). Empty-string-as-absent semantics are **scoped to
+credential keys only** — non-credential service params (`url`, `host`,
+`port`, `protocol`, `path`) retain today's empty-string-wins behaviour
+so existing callers that set `SERVICE_X_HOST=""` to mean "explicitly
+empty" do not regress:
+
+```js
+for (const param of Object.keys(data)) {
+  const varName = `${namespaceUpper}_${nameUpper}_${param.toUpperCase()}`;
+  const isCredential = Config.#CREDENTIAL_KEYS.has(varName);
+  const shellValue = this.#process.env[varName];
+  // For credentials, treat empty string as absent so a workflow ternary
+  // emitting '' (Part 03 § Step 4) cannot clobber a .env value.
+  // For non-credentials, preserve today's behaviour: empty string wins.
+  const shellOk = isCredential
+    ? shellValue !== undefined && shellValue !== ""
+    : shellValue !== undefined;
+  const raw = shellOk ? shellValue : this.#envOverrides[varName];
+  const rawOk = isCredential
+    ? raw !== undefined && raw !== ""
+    : raw !== undefined;
+  if (rawOk) {
+    try {
+      data[param] = JSON.parse(raw);
+    } catch {
+      data[param] = raw;
+    }
+  }
+}
+```
+
+Verify: `bun test libraries/libconfig/test/` passes unchanged. Existing
+non-credential `SERVICE_*_*=""` cases retain today's behaviour because
+the new branch's empty-string-as-absent only applies when `varName` is
+in `#CREDENTIAL_KEYS`. The new credential-side branch fires only for
+params registered in a `createProductConfig` default (today, only
+`token` after Step 3).
+
+## Step 2 — Add `PRODUCT_LANDMARK_TOKEN` to `#CREDENTIAL_KEYS`
+
+- **Modified**: `libraries/libconfig/src/config.js` (`#CREDENTIAL_KEYS` set;
+  locate via `rg "static #CREDENTIAL_KEYS" libraries/libconfig/src/config.js`)
+
+Add the literal `"PRODUCT_LANDMARK_TOKEN"` to the set. Keys are sorted
+alphabetically; the new entry slots between `MCP_TOKEN` and
+`SUPABASE_ANON_KEY`.
+
+## Step 3 — Register `token` default on the Landmark product config
+
+- **Modified**: `products/landmark/bin/fit-landmark.js` (the
+  `createProductConfig` callsite; locate via
+  `rg 'createProductConfig\("landmark"' products/landmark/bin/`)
+
+Change:
+
+```js
+const config = await createProductConfig("landmark");
+```
+
+to:
+
+```js
+const config = await createProductConfig("landmark", { token: undefined });
+```
+
+Registers `token` as a known param so the libconfig override loop iterates
+over it; resolution becomes `process.env.PRODUCT_LANDMARK_TOKEN` >
+`.env` `PRODUCT_LANDMARK_TOKEN` (via `#envOverrides`) > `config.json`
+`product.landmark.token` > `undefined`.
+
+## Step 4 — Point `resolveIdentity()` at `config.token`
+
+- **Modified**: `products/landmark/src/lib/identity.js` (the
+  `resolveIdentity` entry-point check; locate via
+  `rg "env\.LANDMARK_AUTH_TOKEN" products/landmark/src/lib/identity.js`)
+
+Replace the entry-point check:
+
+```js
+// before
+if (env.LANDMARK_AUTH_TOKEN) {
+  return resolveFromJwt(env.LANDMARK_AUTH_TOKEN, config);
+}
+
+// after
+if (config?.token) {
+  return resolveFromJwt(config.token, config);
+}
+```
+
+`env` is still threaded for `LANDMARK_CREDENTIALS_FILE` (the credentials-
+file path is unchanged).
+
+Then sweep every `LANDMARK_AUTH_TOKEN` literal in `identity.js` — error
+messages and JSDoc — to `PRODUCT_LANDMARK_TOKEN`. Locate them with
+`rg "LANDMARK_AUTH_TOKEN" products/landmark/src/lib/identity.js`; the
+sweep must leave zero matches in this file after the edit. The JSDoc
+block on `resolveIdentity` (the precedence-and-fallback documentation)
+must reflect the new resolution source.
+
+## Step 5 — Rewrite identity tests for the new env-var name
+
+- **Modified**: `products/landmark/test/lib/identity.test.js`
+
+Two transformations:
+
+1. **Helper extension.** Extend `makeConfig` to carry the JWT directly:
+
+   ```js
+   function makeConfig({ url, anonKey, jwtSecret, token } = {}) {
+     return {
+       token,
+       supabaseUrl: () => { /* unchanged */ },
+       supabaseAnonKey: () => { /* unchanged */ },
+       supabaseJwtSecret: () => { /* unchanged */ },
+     };
+   }
+   ```
+
+2. **Sweep every test case** that sets `env: { LANDMARK_AUTH_TOKEN: <jwt> }`:
+   move the JWT into `makeConfig({ token: <jwt>, … })` and drop the env
+   entry. Sweep regex assertions matching the literal `LANDMARK_AUTH_TOKEN`
+   to `PRODUCT_LANDMARK_TOKEN`. Verify with
+   `rg "LANDMARK_AUTH_TOKEN" products/landmark/test/lib/identity.test.js`
+   returning zero matches after the edit.
+
+The test named "env LANDMARK_AUTH_TOKEN takes precedence over the store"
+renames to "config.token takes precedence over the store"; the JWT passes
+via config rather than env.
+
+Verify: `bun test products/landmark/test/lib/identity.test.js` exits 0
+with the same test count as on `main`.
+
+## Step 6 — Rewrite the dispatcher test for the new env-var name
+
+- **Modified**: `products/landmark/test/dispatcher.test.js`
+
+Locate the test named "exits 3 when token present but SUPABASE_URL is
+unset" (`rg "exits 3 when token present" products/landmark/test/
+dispatcher.test.js`). Rename its env key from `LANDMARK_AUTH_TOKEN` to
+`PRODUCT_LANDMARK_TOKEN`. The "exits 4 when no identity" test is
+unchanged.
+
+Verify: `bun test products/landmark/test/dispatcher.test.js` exits 0
+with all three tests passing.
+
+## Step 7 — Add libconfig unit test for `.env`-routed credential override
+
+- **Created**: `libraries/libconfig/test/credential-env-override.test.js`
+
+Single test file (~70 lines) constructing a Config in a tmpdir with a
+`.env` file containing `PRODUCT_LANDMARK_TOKEN=test-jwt-value`, then:
+
+```js
+const config = await createProductConfig(
+  "landmark",
+  { token: undefined },
+  { ...process, cwd: () => tmpdir, env: { PATH: process.env.PATH } },
+);
+assert.equal(config.token, "test-jwt-value");
+```
+
+Also test that shell env wins over `.env`:
+
+```js
+const config = await createProductConfig(
+  "landmark",
+  { token: undefined },
+  { ...process, cwd: () => tmpdir,
+    env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "shell-jwt" } },
+);
+assert.equal(config.token, "shell-jwt");
+```
+
+Also test that an empty-string shell value falls through to `.env`:
+
+```js
+const config = await createProductConfig(
+  "landmark",
+  { token: undefined },
+  { ...process, cwd: () => tmpdir,
+    env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "" } },
+);
+assert.equal(config.token, "test-jwt-value");  // .env value wins
+```
+
+This third case covers the Part 03 workflow ternary that emits `''`
+for non-Landmark runs; it must not clobber a `.env`-supplied value.
+
+Verify: `bun test libraries/libconfig/test/credential-env-override.test.js`
+passes.
+
+## Step 8 — Update `fit-map auth issue` output line for the new env-var
+
+- **Modified**: `products/map/src/commands/auth-issue.js`
+
+Locate `LANDMARK_AUTH_TOKEN` occurrences with
+`rg "LANDMARK_AUTH_TOKEN" products/map/src/commands/auth-issue.js`.
+Two matches today: the file-header comment and the operator-facing
+`Export:` banner line. Both rewrite to `PRODUCT_LANDMARK_TOKEN`.
+
+Verify: `rg "LANDMARK_AUTH_TOKEN" products/map/src/commands/auth-issue.js`
+returns zero matches. The existing test surface
+(`products/map/test/activity/auth-issue.test.js`) does not match the
+old literal today (`rg "LANDMARK_AUTH_TOKEN"
+products/map/test/activity/auth-issue.test.js` returns empty), so no
+test-file edit is required.
+
+## Step 9 — Docs sweep across `websites/`
+
+- **Modified**:
+  - `websites/fit/docs/getting-started/leaders/landmark/index.md`
+  - `websites/fit/docs/products/engineering-data-sources/index.md`
+  - `websites/fit/docs/products/issuing-service-account-tokens/index.md`
+  - `websites/fit/docs/products/signing-in-to-landmark/index.md`
+
+Replace every `LANDMARK_AUTH_TOKEN` literal with `PRODUCT_LANDMARK_TOKEN`
+and update surrounding prose so it still parses (e.g. "exported as
+`LANDMARK_AUTH_TOKEN`" → "exported as `PRODUCT_LANDMARK_TOKEN`"). Inline
+code blocks (the four `export LANDMARK_AUTH_TOKEN=…` examples) flip
+identically. The docs already cover the shell-env and config.json paths;
+no new prose about `.env` is required.
+
+Verify (forward-only invariant — does not break if a future doc adds a
+new mention):
+
+```sh
+rg LANDMARK_AUTH_TOKEN websites/    # must return empty
+```
+
+## Step 10 — Verify contract-preservation suite green
+
+Run the full set of tests named in spec § Success Criteria row 11:
+
+```sh
+bun test products/map/test/activity/auth-issue.test.js
+bun test products/map/test/activity/people-provision.test.js
+bun test products/map/test/activity/activity.test.js
+bun test products/landmark/test/lib/identity.test.js
+bun test libraries/libconfig/test/
+bun run check  # full check suite
+```
+
+Verify: all green. The PR description lists the env-var rename and the
+override-loop extension as the spec-§-deferred fold-in that closes the
+identity layering anomaly.

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a-02.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a-02.md
@@ -178,10 +178,13 @@ export async function runStageCommand({ config }) {
   await runPhase("url-discovery", async () => {
     const json = await cli.capture(["status", "--output", "json"]);
     const status = JSON.parse(json);
-    // libconfig's #env() reads process.env first; setting it here makes
-    // every downstream mapClient construction observe the live URL.
+    // libconfig's #env() reads process.env first; setting these here
+    // makes every downstream mapClient + fit-landmark child observe
+    // the live local-stack values.
     if (!status.api_url) throw new Error("supabase status: no api_url");
+    if (!status.anon_key) throw new Error("supabase status: no anon_key");
     process.env.SUPABASE_URL = status.api_url;
+    process.env.SUPABASE_ANON_KEY = status.anon_key;
   });
 
   await runPhase("migrate", () => cli.run(["db", "reset"]));
@@ -557,6 +560,11 @@ export async function runSelfSmoke({ supabase, config }) {
       argv.push(`--${k}`, expand(v, persona, discovery));
     }
     argv.push("--format", "json");
+    // Smoke spawn inherits SUPABASE_URL + SUPABASE_ANON_KEY from
+    // process.env (set in the url-discovery phase) and is given the
+    // freshly-minted JWT. fit-landmark's createLandmarkClient needs
+    // both supabaseUrl() and supabaseAnonKey() to construct the anon
+    // client that resolveIdentity then authenticates.
     const res = spawnSync("bunx", ["fit-landmark", ...argv], {
       encoding: "utf8",
       env: { ...process.env, PRODUCT_LANDMARK_TOKEN: jwt },
@@ -745,9 +753,15 @@ export async function runSubstrateIssueCommand({ supabase, config, options }) {
     await fs.writeFile(envTmp, `PRODUCT_LANDMARK_TOKEN=${jwt}\n`,
       { mode: 0o600 });
     await fs.chmod(envTmp, 0o600);
+    // Spec § Persona-corpus invariant (a): the persona IS the manager
+    // of ≥1 other row (verified by findInvariantSatisfyingPersonas).
+    // `org team --manager <X>` and `practice --manager <X>` therefore
+    // take the PERSONA's own email — not the persona's own manager.
+    // The .substrate.json `manager_email` is the value any agent
+    // command consuming "the discovery vector's manager email" reads.
     await fs.writeFile(subTmp, JSON.stringify({
       persona_email: email,
-      manager_email: row.manager_email,
+      manager_email: email,  // persona is itself the manager
       snapshot_id, item_id,
       generated_at: new Date().toISOString(),
     }, null, 2) + "\n", { mode: 0o600 });
@@ -839,7 +853,7 @@ supabase + spawn fixtures.
 | Stage phases fire in order | `products/map/test/activity/substrate-stage.test.js` | Phase-tagged errors thrown by stubbed phases carry the phase name; each phase's stub is invoked once in stack → url-discovery → migrate → seed → provision → smoke order; `SUBSTRATE_FORCE_EMPTY_CORPUS=true` short-circuits to the smoke-phase throw |
 | Persona invariant predicate | `products/map/test/activity/substrate-persona-query.test.js` | Four invariants combine; a row missing any one is filtered out; empty result returns the binding-constraint diagnostic naming which invariant filtered most |
 | Self-smoke JWT shape + persona-kind + discovery | `products/map/test/activity/substrate-smoke.test.js` | `assertJwtShape` rejects on missing/wrong aud/role/email/exp; `assertPersonaIsHuman` rejects on `kind=service_account`; gated-command iteration spawns each `GATED_COMMANDS` entry once; row-class non-empty assertions fire for `org team`, `evidence`, `practice` |
-| Commands-manifest source-of-truth | `products/landmark/test/lib/commands-manifest.test.js` | Imports `COMMANDS`, `SUBCOMMAND_EXPANSIONS`, `FLAT_SMOKE_OPTIONS` from `commands-manifest.js`; asserts every `needsSupabase: true` key in `COMMANDS` is covered by exactly one of `SUBCOMMAND_EXPANSIONS[key]` or `FLAT_SMOKE_OPTIONS[key]` (or has no required smoke options) — guards against drift between the dispatcher table and the smoke list |
+| Commands-manifest source-of-truth | `products/landmark/test/lib/commands-manifest.test.js` | Imports `COMMANDS`, `SUBCOMMAND_EXPANSIONS`, `FLAT_SMOKE_OPTIONS` from `commands-manifest.js`; asserts every `needsSupabase: true` key in `COMMANDS` is covered by exactly one of `SUBCOMMAND_EXPANSIONS[key]` or `FLAT_SMOKE_OPTIONS[key]` (or has no required smoke options); **additionally** parses `products/landmark/bin/fit-landmark.js`'s libcli `commands` array (read as text + regex-extract `name:` values; or expose `definition.commands` from a tiny exported function) and asserts every entry with `needsSupabase: true` for its top-level command appears either in `SUBCOMMAND_EXPANSIONS[topLevel]` (for space-separated names like `"snapshot show"`) or as the `topLevel` itself in `FLAT_SMOKE_OPTIONS` (for flat names) — guards both directions of drift between the dispatcher table, the libcli surface, and the smoke list |
 | `_commands` verb emits manifest | `products/landmark/test/lib/commands-verb.test.js` | Spawn `node bin/fit-landmark.js _commands` from a tmpdir; assert stdout parses as `{ commands, subcommandExpansions, flatSmokeOptions }`; assert the spawn exits 0 even when no `config/` or `.env` is reachable (verifies the hidden verb sits above the top-level `createProductConfig` await) |
 | Roster emits JSON shape | `products/map/test/activity/substrate-roster.test.js` | `--format json` returns `{ personas, selection_metadata }`; exit 0 on non-empty, non-zero on empty (with diagnostic on stderr) |
 | Issue writes both files atomically | `products/map/test/activity/substrate-issue.test.js` | Both files written; mode 0600 on each; content parses as JSON / `KEY=VALUE`; mocked `fs.rename` failure on the second file leaves the first file on disk and cleans up the second's tmp file; mocked failure on the first file leaves no files at the target paths and cleans up both tmp files |

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a-02.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a-02.md
@@ -57,6 +57,11 @@ the same shape works here:
     email: { type: "string", description: "Persona email" },
     cwd: { type: "string", description: "Target dir for the atomic write" },
     ttl: { type: "string", description: "JWT TTL (e.g. 1h, 30d). Default 1h." },
+    stash: {
+      type: "string",
+      description:
+        "Optional second path to write the bare JWT to (workflow-private; not for external operators)",
+    },
   },
 },
 ```
@@ -102,6 +107,7 @@ async function dispatchSubstrate(subcommand, _rest, values) {
           email: values.email,
           cwd: values.cwd,
           ttl: values.ttl,
+          stash: values.stash,
         },
       });
     }
@@ -413,15 +419,23 @@ export const SUBCOMMAND_EXPANSIONS = {
 };
 
 // For flat (non-`subcommand`-style) command names whose libcli entry is
-// a single-word `name`, the smokeOptions live here.
+// a single-word `name`, the smokeOptions live here. Every gated command
+// whose handler throws on missing args MUST appear here so the spec
+// § Success Criteria row 5 smoke runs to non-error completion. Checked
+// command sources:
+//   - voice.js: throws if neither --email nor --manager supplied
+//   - practiced.js: throws on missing --manager
+//   - health.js: no required option
 export const FLAT_SMOKE_OPTIONS = {
   evidence: { email: "$PERSONA_EMAIL" },
   practice: { manager: "$PERSONA_EMAIL" },
+  practiced: { manager: "$PERSONA_EMAIL" },
   readiness: { email: "$PERSONA_EMAIL" },
   timeline: { email: "$PERSONA_EMAIL" },
   coverage: { email: "$PERSONA_EMAIL" },
   sources: { email: "$PERSONA_EMAIL" },
-  // health, voice, practiced — no required options for the smoke
+  voice: { email: "$PERSONA_EMAIL" },
+  // health — no required option
 };
 ```
 
@@ -620,132 +634,6 @@ function assertNonEmpty(stdout, key) {
 }
 ```
 
-**Smoke implementation** (`substrate-smoke.js`):
-
-```js
-import { spawnSync } from "node:child_process";
-import { mintSupabaseJwt, parseDuration } from "@forwardimpact/libsecret";
-
-export async function runSelfSmoke({ supabase, config }) {
-  const { findInvariantSatisfyingPersonas } = await import(
-    "./substrate-persona-query.js");
-  const { personas, discovery, diagnostic } =
-    await findInvariantSatisfyingPersonas({ supabase });
-  if (!personas.length) throw new Error(diagnostic);
-  const persona = personas[0];
-
-  // Mint a short-lived JWT (1h is the smallest unit parseDuration
-  // accepts; libsecret's regex is /^(\d+)([hdy])$/, no minutes).
-  const secret = config.supabaseJwtSecret();
-  const jwt = mintSupabaseJwt({
-    email: persona.email,
-    secret,
-    ttlSeconds: parseDuration("1h"),
-  });
-
-  // Spec § Success Criteria rows 1–4: explicit shape check.
-  assertJwtShape(jwt, persona.email);
-  await assertPersonaIsHuman(supabase, persona.email);
-  assertDiscoveryResolves(supabase, persona, discovery);
-
-  // Spec § Success Criteria row 5 (every gated command invocable) +
-  // row 6 (three named row-class smokes non-empty).
-  const manifestJson = spawnSync("bunx",
-    ["fit-landmark", "_gated-commands"], { encoding: "utf8" });
-  if (manifestJson.status !== 0)
-    throw new Error(`_gated-commands: ${manifestJson.stderr}`);
-  const manifest = JSON.parse(manifestJson.stdout);
-
-  for (const { command, options } of manifest) {
-    const argv = command.split(" ");
-    for (const [k, v] of Object.entries(options)) {
-      argv.push(`--${k}`, expand(v, persona, discovery));
-    }
-    argv.push("--format", "json");
-    const res = spawnSync("bunx", ["fit-landmark", ...argv], {
-      encoding: "utf8",
-      env: { ...process.env, PRODUCT_LANDMARK_TOKEN: jwt },
-    });
-    if (res.status !== 0)
-      throw new Error(`${argv.join(" ")} exited ${res.status}: ${res.stderr}`);
-
-    // Three row-class smokes (org team, evidence, practice) must return
-    // non-empty payloads. The per-command JSON shape is per spec
-    // § Success Criteria row 6 — assert via published formatter keys.
-    if (command === "org team") assertNonEmpty(res.stdout, ["team"]);
-    if (command === "evidence") assertNonEmpty(res.stdout, ["evidence"]);
-    if (command === "practice") assertNonEmpty(res.stdout, ["patterns"]);
-  }
-}
-
-function expand(template, persona, discovery) {
-  return template
-    .replace("$PERSONA_EMAIL", persona.email)
-    .replace("$SNAPSHOT_ID", discovery.snapshot_id)
-    .replace("$ITEM_ID", discovery.item_id);
-}
-
-function assertJwtShape(jwt, expectedEmail) {
-  const [, payloadB64] = jwt.split(".");
-  const claims = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
-  if (claims.aud !== "authenticated")
-    throw new Error(`JWT aud != authenticated: ${claims.aud}`);
-  if (claims.role !== "authenticated")
-    throw new Error(`JWT role != authenticated: ${claims.role}`);
-  if (claims.email !== expectedEmail)
-    throw new Error(`JWT email mismatch: ${claims.email}`);
-  if (typeof claims.exp !== "number" || claims.exp * 1000 <= Date.now())
-    throw new Error(`JWT exp claim missing or in the past: ${claims.exp}`);
-}
-
-async function assertPersonaIsHuman(supabase, email) {
-  const { data, error } = await supabase
-    .from("organization_people")
-    .select("kind").eq("email", email).maybeSingle();
-  if (error) throw new Error(`organization_people: ${error.message}`);
-  if (data?.kind !== "human")
-    throw new Error(`persona ${email} kind=${data?.kind}, not human`);
-}
-
-function assertDiscoveryResolves(supabase, persona, discovery) {
-  // Persona email, persona's manager_email (if used by any gated cmd),
-  // snapshot_id, item_id — invariants already enforced by
-  // findInvariantSatisfyingPersonas; this function is a defensive
-  // re-check that fails loudly if the persona-query helper regresses.
-  if (!persona.email || !persona.manager_email) {
-    throw new Error(`persona missing email/manager_email: ${
-      JSON.stringify(persona)}`);
-  }
-  if (!discovery.snapshot_id || !discovery.item_id) {
-    throw new Error(`discovery vector incomplete: ${
-      JSON.stringify(discovery)}`);
-  }
-}
-
-function assertNonEmpty(stdout, keys) {
-  const parsed = JSON.parse(stdout);
-  for (const key of keys) {
-    const v = parsed[key] ?? parsed.view?.[key];
-    if (Array.isArray(v) ? v.length === 0 :
-        (v === undefined || v === null ||
-         (typeof v === "object" && Object.keys(v).length === 0))) {
-      throw new Error(`row-class non-empty assertion failed for ${key}`);
-    }
-  }
-}
-```
-
-Notes:
-
-- The smoke spawns inherit `process.cwd()` (the CI checkout root); the
-  JWT lives in `env` of the spawn options only, never on the parent
-  `process.env`.
-- `assertNonEmpty` accepts both `result[key]` and `result.view[key]`
-  because formatters wrap payloads under `view` (per `products/
-  landmark/src/commands/org.js:55, 72`) — verify the exact wrapper key
-  in implementation by reading the formatter; the test in Step 6
-  pins this.
-
 ## Step 5 — Create `substrate-roster.js`
 
 - **Created**: `products/map/src/commands/substrate-roster.js`
@@ -799,10 +687,18 @@ plan must commit to one shape.
 
 ### `substrate-issue.js`
 
-Atomically writes two files under `--cwd <path>`. To survive partial
-crashes, write both temp files first, then rename in fixed order
-(`.env` first, `.substrate.json` second); on any rename failure, attempt
-cleanup of leftover temp files before rethrowing:
+Atomically writes two files under `--cwd <path>`. Optionally also writes
+the bare JWT to a third path supplied via `--stash <path>` — used by
+the kata-interview workflow (Part 03) to surface the JWT into the
+workflow's private `$RUNNER_TEMP` so a post-run log scan has a tamper-
+resistant source for the JWT value to grep for. The stash path is
+mode 0600 like the other writes.
+
+To survive partial crashes, write both `.env`/`.substrate.json` temp
+files first, then rename in fixed order (`.env` first, `.substrate.json`
+second). The stash write (if `--stash` supplied) happens last, after
+both renames succeed; on any rename failure, attempt cleanup of leftover
+temp files before rethrowing:
 
 ```js
 import path from "node:path";
@@ -813,7 +709,7 @@ import { findAuthUser } from "../lib/auth-helpers.js";
 import { formatSuccess } from "@forwardimpact/libcli";
 
 export async function runSubstrateIssueCommand({ supabase, config, options }) {
-  const { email, cwd, ttl } = options;
+  const { email, cwd, ttl, stash } = options;
   if (!email) throw new Error("substrate issue: --email <e> is required");
   if (!cwd) throw new Error("substrate issue: --cwd <path> is required");
   const ttlSeconds = parseDuration(ttl ?? "1h");
@@ -864,6 +760,15 @@ export async function runSubstrateIssueCommand({ supabase, config, options }) {
     for (const orphan of [envTmp, subTmp]) {
       try { await fs.unlink(orphan); } catch { /* expected after rename */ }
     }
+  }
+
+  // Optional stash: write the bare JWT to a workflow-protected path so
+  // a post-run log scan can read the value without touching the agent's
+  // cwd (which the agent has Write/Edit tools over). Workflow contract
+  // only — never used by external operators or the dev path.
+  if (stash) {
+    await fs.writeFile(stash, jwt + "\n", { mode: 0o600 });
+    await fs.chmod(stash, 0o600);
   }
 
   process.stdout.write(formatSuccess(`Issued substrate for ${email}`) + "\n");
@@ -939,9 +844,11 @@ supabase + spawn fixtures.
 | Roster emits JSON shape | `products/map/test/activity/substrate-roster.test.js` | `--format json` returns `{ personas, selection_metadata }`; exit 0 on non-empty, non-zero on empty (with diagnostic on stderr) |
 | Issue writes both files atomically | `products/map/test/activity/substrate-issue.test.js` | Both files written; mode 0600 on each; content parses as JSON / `KEY=VALUE`; mocked `fs.rename` failure on the second file leaves the first file on disk and cleans up the second's tmp file; mocked failure on the first file leaves no files at the target paths and cleans up both tmp files |
 | Issue rejects non-human kind | (same file) | A persona row with `kind=service_account` throws with the named error and names `fit-map auth issue` as the alternative |
+| Issue with `--stash` writes JWT to stash path | (same file) | `--stash <tmp>` causes a third file at `<tmp>` containing just the JWT (mode 0600); omitting `--stash` writes only the two `--cwd` files |
 
 Verify: `bun test products/map/test/activity/substrate-*.test.js
-products/landmark/test/lib/gated-commands.test.js` exits 0 with ~20
+products/landmark/test/lib/commands-manifest.test.js
+products/landmark/test/lib/commands-verb.test.js` exits 0 with ~20
 tests passing.
 
 ## Step 9 — Run full check suite
@@ -954,7 +861,8 @@ bun test products/landmark/test/  # Part 01 surface still green
 ```
 
 Verify: all green. PR description names the three subcommands, the
-shared `findAuthUser` helper, the new `_gated-commands` introspection
-verb, and the rows from spec § In-scope the new surface satisfies
-(Workspace state, Persona corpus, Discovery vector, Gated-command
-coverage, Failure surfacing).
+shared `findAuthUser` helper, the new `_commands` introspection verb
+plus its canonical `products/landmark/src/lib/commands-manifest.js`
+source-of-truth file, and the rows from spec § In-scope the new
+surface satisfies (Workspace state, Persona corpus, Discovery vector,
+Gated-command coverage, Failure surfacing).

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a-02.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a-02.md
@@ -1,0 +1,960 @@
+# Plan 990-a Part 02 — `fit-map substrate {stage, roster, issue}`
+
+Implements the three new `fit-map substrate` subcommands and the dispatcher
+that routes them. The `fit-map auth issue` operator verb is untouched.
+Depends on Part 01 (`PRODUCT_LANDMARK_TOKEN` rename + `config.token`).
+
+## Schema reality check (used throughout this part)
+
+The `activity` schema as it exists on `origin/main` (see
+`products/map/supabase/migrations/20250101000000_activity_schema.sql`):
+
+- `activity.organization_people` columns: `email`, `name`,
+  `github_username`, `discipline`, `level`, `track`, `manager_email`,
+  `updated_at`. **No `team` or `role` column.** The kind discriminator
+  added in `20260514000000_organization_people_kind.sql` adds `kind`.
+- `activity.evidence` joins authorship through
+  `evidence(artifact_id) → github_artifacts.artifact_id`, and
+  `github_artifacts.email` references `organization_people.email`.
+  **There is no `evidence.author_email` column.**
+- `activity.getdx_snapshot_team_scores` is the table that carries
+  `snapshot_id`, `item_id`, `getdx_team_id`, `score`. **Not
+  `team_snapshot_scores`.**
+
+Every SQL/Supabase query below uses these names.
+
+## Step 1 — Register `substrate` and its three subcommands in libcli
+
+- **Modified**: `products/map/bin/fit-map.js` (the libcli `commands`
+  array; locate the existing `auth` entry via
+  `rg '"auth"' products/map/bin/fit-map.js`)
+
+Add three sibling entries to the `commands` array (one per subcommand)
+so libcli's `--help` is per-subcommand and option flags are scoped to
+the subcommand that accepts them. The libcli `commands` array supports
+space-separated names today (e.g. `"org show"` at fit-landmark.js:75) —
+the same shape works here:
+
+```js
+{
+  name: "substrate stage",
+  description:
+    "Provision a Landmark substrate (stack + migrate + seed + provision + self-smoke)",
+},
+{
+  name: "substrate roster",
+  description:
+    "List invariant-satisfying personas from the seeded substrate",
+  options: {
+    format: { type: "string", description: "Output format (text|json)" },
+  },
+},
+{
+  name: "substrate issue",
+  description:
+    "Atomically write .env (JWT) and .substrate.json (discovery vector) into a target dir",
+  options: {
+    email: { type: "string", description: "Persona email" },
+    cwd: { type: "string", description: "Target dir for the atomic write" },
+    ttl: { type: "string", description: "JWT TTL (e.g. 1h, 30d). Default 1h." },
+  },
+},
+```
+
+Verify: `bunx fit-map substrate stage --help` shows the synopsis for
+that subcommand only; `bunx fit-map substrate issue --help` shows only
+`--email`, `--cwd`, `--ttl`. No accidental `--ttl` leak onto `stage`.
+
+## Step 2 — Wire dispatch for `substrate` in `main()`
+
+- **Modified**: `products/map/bin/fit-map.js`
+
+Add `dispatchSubstrate` alongside the existing `dispatchAuth` (parallel
+shape; `config` is module-scoped at the top of the file and stays
+accessible to both dispatchers). Route `case "substrate"` in the
+`main()` switch.
+
+```js
+async function dispatchSubstrate(subcommand, _rest, values) {
+  switch (subcommand) {
+    case "stage": {
+      const { runStageCommand } = await import(
+        "../src/commands/substrate-stage.js"
+      );
+      return runStageCommand({ config });
+    }
+    case "roster": {
+      const supabase = await mapClient();
+      const { runRosterCommand } = await import(
+        "../src/commands/substrate-roster.js"
+      );
+      return runRosterCommand({ supabase, options: { format: values.format } });
+    }
+    case "issue": {
+      const supabase = await mapClient();
+      const { runSubstrateIssueCommand } = await import(
+        "../src/commands/substrate-issue.js"
+      );
+      return runSubstrateIssueCommand({
+        supabase,
+        config,
+        options: {
+          email: values.email,
+          cwd: values.cwd,
+          ttl: values.ttl,
+        },
+      });
+    }
+    default:
+      cli.usageError(`unknown substrate subcommand: ${subcommand || "(none)"}`);
+      return 1;
+  }
+}
+```
+
+Add the case in `main()` after `case "auth"`:
+
+```js
+case "substrate":
+  exitCode = await dispatchSubstrate(subcommand, rest, values);
+  break;
+```
+
+## Step 3 — Extract `findDataDir` to a reusable module
+
+- **Created**: `products/map/src/lib/data-dir.js`
+- **Modified**: `products/map/bin/fit-map.js` (imports the new module
+  instead of carrying the local copy)
+
+Move the existing `findDataDir` function from `bin/fit-map.js` to
+`src/lib/data-dir.js`. The new module exports `findDataDir(providedPath,
+{ fs?, process?, homedir? })`; the existing call sites in `bin/fit-map.js`
+pass `providedPath` only and rely on the same `Finder` plumbing as
+today. `substrate-stage.js` and any future substrate verb import
+`findDataDir` from `../lib/data-dir.js`.
+
+Verify: `bun test products/map/test/activity/` exits 0 — the existing
+test surface continues to pass because `findDataDir`'s public behaviour
+is preserved.
+
+## Step 4 — Create `substrate-stage.js`
+
+- **Created**: `products/map/src/commands/substrate-stage.js`
+
+Workspace-prep terminal phase. Responsibilities, in order:
+
+| Phase | Action | Failure behaviour |
+|---|---|---|
+| 1. Stack | `createSupabaseCli().run(["start"])` | Throw `[substrate stage: stack]` |
+| 2. URL discovery | `createSupabaseCli().capture(["status", "--output", "json"])` → parse → expose `SUPABASE_URL` via `process.env` for subsequent code that constructs `mapClient` | Throw `[substrate stage: url-discovery]` |
+| 3. Migrate | `createSupabaseCli().run(["db", "reset"])` | Throw `[substrate stage: migrate]` |
+| 4. Seed | Invoke `activity.seed({ data, supabase })` (same export `fit-map activity seed` uses today) | Throw `[substrate stage: seed]` |
+| 5. Provision | Invoke `runProvisionCommand({ supabase })` from `people-provision.js` | Throw `[substrate stage: provision]` |
+| 6. Self-smoke | See Step 4b | Throw `[substrate stage: smoke]` |
+
+Pseudocode for `runStageCommand({ config })`:
+
+```js
+import path from "node:path";
+import { createSupabaseCli } from "../lib/supabase-cli.js";
+import { findDataDir } from "../lib/data-dir.js";
+import { createMapClient } from "../lib/client.js";
+import { runProvisionCommand } from "./people-provision.js";
+import * as activity from "./activity.js";
+import { runSelfSmoke } from "./substrate-smoke.js";  // Step 4b
+import { formatSuccess } from "@forwardimpact/libcli";
+
+export async function runStageCommand({ config }) {
+  const cli = createSupabaseCli();
+
+  await runPhase("stack", () => cli.run(["start"]));
+
+  await runPhase("url-discovery", async () => {
+    const json = await cli.capture(["status", "--output", "json"]);
+    const status = JSON.parse(json);
+    // libconfig's #env() reads process.env first; setting it here makes
+    // every downstream mapClient construction observe the live URL.
+    if (!status.api_url) throw new Error("supabase status: no api_url");
+    process.env.SUPABASE_URL = status.api_url;
+  });
+
+  await runPhase("migrate", () => cli.run(["db", "reset"]));
+
+  const supabase = await createMapClient({ config });
+  const dataRoot = path.dirname(await findDataDir(undefined));
+  await runPhase("seed", () => activity.seed({ data: dataRoot, supabase }));
+  await runPhase("provision", () => runProvisionCommand({ supabase }));
+
+  if (process.env.SUBSTRATE_FORCE_EMPTY_CORPUS === "true") {
+    throw new Error("[substrate stage: smoke] empty corpus (test injection)");
+  }
+  await runPhase("smoke", () => runSelfSmoke({ supabase, config }));
+
+  process.stdout.write(formatSuccess("Substrate ready") + "\n");
+  return 0;
+}
+
+async function runPhase(name, fn) {
+  try {
+    await fn();
+  } catch (err) {
+    throw new Error(`[substrate stage: ${name}] ${err.message}`);
+  }
+}
+```
+
+The `SUBSTRATE_FORCE_EMPTY_CORPUS` branch supports Part 03 Step 9's
+failure-surfacing CI test; the cross-part contract is named here so the
+implementer of Part 02 wires it.
+
+### Step 4a — Persona-invariant helper (Supabase JS client, no SQL views)
+
+- **Created**: `products/map/src/commands/substrate-persona-query.js`
+
+Single export `findInvariantSatisfyingPersonas({ supabase })` returning
+`{ personas: Array<PersonaRow>, discovery: { snapshot_id, item_id },
+diagnostic?: string }`. Because the spec § Out-of-scope row forbids
+changes under `products/map/supabase/migrations/`, the helper composes
+the result client-side through chained Supabase JS calls — no Postgres
+view or RPC.
+
+Algorithm:
+
+```js
+export async function findInvariantSatisfyingPersonas({ supabase }) {
+  // 1. Latest snapshot + any item id (corpus-wide discovery values).
+  const { data: snaps } = await supabase
+    .from("getdx_snapshots")
+    .select("snapshot_id, scheduled_for")
+    .order("scheduled_for", { ascending: false })
+    .limit(1);
+  if (!snaps?.length) return { personas: [], diagnostic: "no getdx_snapshots rows" };
+  const snapshot_id = snaps[0].snapshot_id;
+
+  const { data: scores } = await supabase
+    .from("getdx_snapshot_team_scores")
+    .select("item_id")
+    .eq("snapshot_id", snapshot_id)
+    .limit(1);
+  if (!scores?.length) return { personas: [], diagnostic: `no getdx_snapshot_team_scores for snapshot ${snapshot_id}` };
+  const item_id = scores[0].item_id;
+
+  // 2. Humans only.
+  const { data: humans } = await supabase
+    .from("organization_people")
+    .select("email,name,discipline,level,track,manager_email")
+    .eq("kind", "human");
+  if (!humans?.length) return { personas: [], diagnostic: "no kind=human rows" };
+
+  // 3. Build report-count map (persona is manager of N humans).
+  const directsByManager = new Map();
+  for (const h of humans) {
+    if (!h.manager_email) continue;
+    directsByManager.set(h.manager_email,
+      (directsByManager.get(h.manager_email) ?? 0) + 1);
+  }
+
+  // 4. Evidence rows joined through github_artifacts → email.
+  //    evidence.artifact_id → github_artifacts.artifact_id → github_artifacts.email.
+  const { data: artifacts } = await supabase
+    .from("github_artifacts")
+    .select("artifact_id, email");
+  const artifactToEmail = new Map(
+    (artifacts ?? []).map((a) => [a.artifact_id, a.email]));
+  const { data: ev } = await supabase
+    .from("evidence")
+    .select("artifact_id");
+  const evidenceCountByEmail = new Map();
+  for (const e of ev ?? []) {
+    const email = artifactToEmail.get(e.artifact_id);
+    if (!email) continue;
+    evidenceCountByEmail.set(email,
+      (evidenceCountByEmail.get(email) ?? 0) + 1);
+  }
+
+  // 5. Practice-pattern proxy: persona is the manager of ≥1 human whose
+  //    artifacts produced ≥1 evidence row. Cheapest test: count humans
+  //    whose manager_email == persona.email and who carry ≥1 evidence row.
+  const practiceCountByManager = new Map();
+  for (const h of humans) {
+    if (!h.manager_email) continue;
+    if ((evidenceCountByEmail.get(h.email) ?? 0) >= 1) {
+      practiceCountByManager.set(h.manager_email,
+        (practiceCountByManager.get(h.manager_email) ?? 0) + 1);
+    }
+  }
+
+  // 6. Filter humans against the four spec § Persona corpus invariants:
+  //    (a) is manager of ≥1 other row; (b) authored ≥1 evidence row;
+  //    (c) manages ≥1 direct with practice-attributable evidence;
+  //    (d) discovery values exist (snapshot_id + item_id — already gated above).
+  const personas = humans
+    .filter((h) =>
+      (directsByManager.get(h.email) ?? 0) >= 1 &&
+      (evidenceCountByEmail.get(h.email) ?? 0) >= 1 &&
+      (practiceCountByManager.get(h.email) ?? 0) >= 1)
+    .map((h) => ({
+      email: h.email,
+      name: h.name,
+      discipline: h.discipline,
+      level: h.level,
+      track: h.track,
+      manager_email: h.manager_email,
+      manages_count: directsByManager.get(h.email) ?? 0,
+      evidence_count: evidenceCountByEmail.get(h.email) ?? 0,
+      practice_directs_count: practiceCountByManager.get(h.email) ?? 0,
+      snapshot_id,
+      item_id,
+    }));
+
+  if (!personas.length) {
+    // Diagnose which invariant filtered out the most humans.
+    const counts = {
+      manages: humans.filter((h) =>
+        (directsByManager.get(h.email) ?? 0) >= 1).length,
+      authors_evidence: humans.filter((h) =>
+        (evidenceCountByEmail.get(h.email) ?? 0) >= 1).length,
+      practice_directs: humans.filter((h) =>
+        (practiceCountByManager.get(h.email) ?? 0) >= 1).length,
+    };
+    const binding = Object.entries(counts)
+      .sort(([, a], [, b]) => a - b)[0][0];
+    return {
+      personas: [],
+      diagnostic:
+        `no invariant-satisfying persona — binding constraint: ${binding}`,
+    };
+  }
+
+  return { personas, discovery: { snapshot_id, item_id } };
+}
+```
+
+Roster row fields use `discipline`/`level`/`track` (the actual schema
+columns) instead of the synthetic `team`/`role`. JTBD-role alignment in
+the supervisor's Step 3a uses `discipline` and `level` as the alignment
+signal (see Part 03 § SKILL.md edits).
+
+### Step 4b — Self-smoke implementation (gated-command discovery)
+
+- **Created**: `products/map/src/commands/substrate-smoke.js`
+- **Created**: `products/landmark/src/lib/commands-manifest.js`
+- **Modified**: `products/landmark/bin/fit-landmark.js` (move `COMMANDS`
+  source-of-truth into the new library module + add a hidden
+  `_commands` verb above the top-level `await createProductConfig`)
+
+Spec § Success Criteria row 5 literally requires iterating the
+`COMMANDS` map "at `products/landmark/bin/fit-landmark.js`" with
+`needsSupabase: true`, expanded via the libcli `commands` array. To
+satisfy this and avoid the design-c constraint of "no internal-import
+of the bin file" (the bin has top-level await), extract the data into
+a small library module that both the bin and the substrate-smoke
+import.
+
+**Source-of-truth extraction.** Create
+`products/landmark/src/lib/commands-manifest.js`:
+
+```js
+// Canonical fit-landmark command manifest. The bin imports this and
+// builds its dispatcher COMMANDS map plus its libcli `commands` array
+// from the same source; the substrate self-smoke imports it directly.
+//
+// Each entry mirrors today's `COMMANDS` shape with the addition of an
+// optional `smokeOptions` map naming the option flags substrate-stage
+// supplies (placeholders expanded at smoke-runtime).
+import { runOrgCommand } from "../commands/org.js";
+import { runSnapshotCommand } from "../commands/snapshot.js";
+import { runMarkerCommand } from "../commands/marker.js";
+import { runEvidenceCommand } from "../commands/evidence.js";
+import { runReadinessCommand } from "../commands/readiness.js";
+import { runTimelineCommand } from "../commands/timeline.js";
+import { runCoverageCommand } from "../commands/coverage.js";
+import { runPracticeCommand } from "../commands/practice.js";
+import { runPracticedCommand } from "../commands/practiced.js";
+import { runHealthCommand } from "../commands/health.js";
+import { runVoiceCommand } from "../commands/voice.js";
+import { runSourcesCommand } from "../commands/sources.js";
+import { runLoginCommand } from "../commands/login.js";
+import { runLogoutCommand } from "../commands/logout.js";
+
+export const COMMANDS = {
+  org: { handler: runOrgCommand, needsSupabase: true },
+  snapshot: { handler: runSnapshotCommand, needsSupabase: true },
+  marker: { handler: runMarkerCommand, needsSupabase: false },
+  evidence: { handler: runEvidenceCommand, needsSupabase: true },
+  readiness: { handler: runReadinessCommand, needsSupabase: true },
+  timeline: { handler: runTimelineCommand, needsSupabase: true },
+  coverage: { handler: runCoverageCommand, needsSupabase: true },
+  practice: { handler: runPracticeCommand, needsSupabase: true },
+  practiced: { handler: runPracticedCommand, needsSupabase: true },
+  health: { handler: runHealthCommand, needsSupabase: true },
+  voice: { handler: runVoiceCommand, needsSupabase: true },
+  sources: { handler: runSourcesCommand, needsSupabase: true },
+  login: { handler: runLoginCommand, needsSupabase: false },
+  logout: { handler: runLogoutCommand, needsSupabase: false },
+};
+
+// User-visible subcommand expansions for each top-level COMMANDS key
+// whose libcli `commands` array entry uses space-separated names. Used
+// by the substrate-stage self-smoke to expand `org` → `org show, org
+// team`, etc. Each entry names the option flags substrate-stage must
+// supply (placeholders: $PERSONA_EMAIL, $SNAPSHOT_ID, $ITEM_ID).
+export const SUBCOMMAND_EXPANSIONS = {
+  org: [
+    { command: "org show", smokeOptions: {} },
+    { command: "org team", smokeOptions: { manager: "$PERSONA_EMAIL" } },
+  ],
+  snapshot: [
+    { command: "snapshot list", smokeOptions: {} },
+    { command: "snapshot show", smokeOptions: { snapshot: "$SNAPSHOT_ID" } },
+    { command: "snapshot trend", smokeOptions: { item: "$ITEM_ID" } },
+    { command: "snapshot compare", smokeOptions: { snapshot: "$SNAPSHOT_ID" } },
+  ],
+};
+
+// For flat (non-`subcommand`-style) command names whose libcli entry is
+// a single-word `name`, the smokeOptions live here.
+export const FLAT_SMOKE_OPTIONS = {
+  evidence: { email: "$PERSONA_EMAIL" },
+  practice: { manager: "$PERSONA_EMAIL" },
+  readiness: { email: "$PERSONA_EMAIL" },
+  timeline: { email: "$PERSONA_EMAIL" },
+  coverage: { email: "$PERSONA_EMAIL" },
+  sources: { email: "$PERSONA_EMAIL" },
+  // health, voice, practiced — no required options for the smoke
+};
+```
+
+**Bin refactor.** In `products/landmark/bin/fit-landmark.js`:
+
+1. **Move the `_commands` hidden verb above the top-level await.** Place
+   the check at the very top of the file, immediately after the
+   `import` block and before `const __dirname = …` and the top-level
+   `await createProductConfig("landmark")`:
+
+   ```js
+   // Hidden manifest export consumed by `fit-map substrate stage`'s
+   // self-smoke (spec 990). Placed before the top-level
+   // createProductConfig() await so introspection does not pay the
+   // libconfig load cost and is independent of the spawn cwd's .env.
+   if (process.argv[2] === "_commands") {
+     const { COMMANDS, SUBCOMMAND_EXPANSIONS, FLAT_SMOKE_OPTIONS } =
+       await import("../src/lib/commands-manifest.js");
+     process.stdout.write(JSON.stringify({
+       commands: COMMANDS,
+       subcommandExpansions: SUBCOMMAND_EXPANSIONS,
+       flatSmokeOptions: FLAT_SMOKE_OPTIONS,
+     }) + "\n");
+     process.exit(0);
+   }
+   ```
+
+   The serialised `COMMANDS` map loses its `handler` function references
+   (functions don't survive `JSON.stringify`); the smoke only needs
+   `needsSupabase` per entry, which serialises fine.
+
+2. **Replace the inline `COMMANDS` constant** at the existing line
+   (anchor: `rg "^const COMMANDS = {" products/landmark/bin/
+   fit-landmark.js`) with an import from the manifest:
+
+   ```js
+   import { COMMANDS } from "../src/lib/commands-manifest.js";
+   ```
+
+   The rest of `main()` (the `COMMANDS[command]` lookup and the
+   `entry.handler({…})` call) is unchanged because the imported map has
+   the same shape including handlers.
+
+3. **Remove the 14 handler imports from `fit-landmark.js`** — anchor
+   them via `rg "import \{ run[A-Z][a-zA-Z]+Command \} from" products/
+   landmark/bin/fit-landmark.js`. They move to `commands-manifest.js`
+   and become dead in the bin once `COMMANDS` is imported. Verify with
+   `bun test products/landmark/test/dispatcher.test.js` after the
+   refactor — the dispatcher behaviour is preserved end-to-end.
+
+**Smoke implementation** (`substrate-smoke.js`):
+
+```js
+import { spawnSync } from "node:child_process";
+import { mintSupabaseJwt, parseDuration } from "@forwardimpact/libsecret";
+
+export async function runSelfSmoke({ supabase, config }) {
+  const { findInvariantSatisfyingPersonas } = await import(
+    "./substrate-persona-query.js");
+  const { personas, discovery, diagnostic } =
+    await findInvariantSatisfyingPersonas({ supabase });
+  if (!personas.length) throw new Error(diagnostic);
+  const persona = personas[0];
+
+  // Mint a short-lived JWT (1h is the smallest unit parseDuration
+  // accepts; libsecret's regex is /^(\d+)([hdy])$/, no minutes).
+  const secret = config.supabaseJwtSecret();
+  const jwt = mintSupabaseJwt({
+    email: persona.email,
+    secret,
+    ttlSeconds: parseDuration("1h"),
+  });
+
+  // Spec § Success Criteria rows 1–4: explicit shape check.
+  assertJwtShape(jwt, persona.email);
+  await assertPersonaIsHuman(supabase, persona.email);
+  assertDiscoveryResolves(persona, discovery);
+
+  // Discover gated commands by spawning the hidden _commands verb on
+  // fit-landmark. The verb returns COMMANDS + expansions from the
+  // canonical commands-manifest.js — same data the bin's dispatcher
+  // reads, so no drift is possible.
+  const manifestRes = spawnSync("bunx", ["fit-landmark", "_commands"], {
+    encoding: "utf8",
+    // Pin spawn cwd to a fresh tmpdir so the stage step's cwd .env
+    // cannot leak into the spawn's libconfig. The _commands branch
+    // exits before createProductConfig runs anyway, but the smoke's
+    // gated-command spawns below need this guarantee too.
+    cwd: await freshTmpdir(),
+  });
+  if (manifestRes.status !== 0)
+    throw new Error(`_commands: ${manifestRes.stderr}`);
+  const { commands, subcommandExpansions, flatSmokeOptions } =
+    JSON.parse(manifestRes.stdout);
+
+  // Build the user-visible smoke list from the COMMANDS map filtered
+  // to needsSupabase: true, expanded via subcommandExpansions for
+  // space-separated names. This is the spec § Success Criteria row 5
+  // verification surface.
+  const smokeList = [];
+  for (const [name, entry] of Object.entries(commands)) {
+    if (!entry.needsSupabase) continue;
+    if (subcommandExpansions[name]) {
+      smokeList.push(...subcommandExpansions[name]);
+    } else {
+      smokeList.push({
+        command: name,
+        smokeOptions: flatSmokeOptions[name] ?? {},
+      });
+    }
+  }
+
+  // Run each smoke command. Spawn cwd is a fresh tmpdir so the
+  // spawned fit-landmark's libconfig reads no stale .env.
+  const spawnCwd = await freshTmpdir();
+  for (const { command, smokeOptions } of smokeList) {
+    const argv = command.split(" ");
+    for (const [k, v] of Object.entries(smokeOptions)) {
+      argv.push(`--${k}`, expand(v, persona, discovery));
+    }
+    argv.push("--format", "json");
+    const res = spawnSync("bunx", ["fit-landmark", ...argv], {
+      encoding: "utf8",
+      env: { ...process.env, PRODUCT_LANDMARK_TOKEN: jwt },
+      cwd: spawnCwd,
+    });
+    if (res.status !== 0)
+      throw new Error(`${argv.join(" ")} exited ${res.status}: ${res.stderr}`);
+
+    // Three row-class smokes (org team, evidence, practice) must
+    // return non-empty payloads. Per the formatters at
+    // products/landmark/src/formatters/{org,evidence,practice}.js the
+    // JSON shape is { ...view, meta } — top-level keys are 'team',
+    // 'evidence', 'patterns' respectively.
+    if (command === "org team") assertNonEmpty(res.stdout, "team");
+    if (command === "evidence") assertNonEmpty(res.stdout, "evidence");
+    if (command === "practice") assertNonEmpty(res.stdout, "patterns");
+  }
+}
+
+function expand(template, persona, discovery) {
+  return template
+    .replace("$PERSONA_EMAIL", persona.email)
+    .replace("$SNAPSHOT_ID", discovery.snapshot_id)
+    .replace("$ITEM_ID", discovery.item_id);
+}
+
+async function freshTmpdir() {
+  const fs = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  return await fs.mkdtemp(path.join(os.tmpdir(), "substrate-smoke-"));
+}
+
+function assertJwtShape(jwt, expectedEmail) {
+  const [, payloadB64] = jwt.split(".");
+  const claims = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+  if (claims.aud !== "authenticated")
+    throw new Error(`JWT aud != authenticated: ${claims.aud}`);
+  if (claims.role !== "authenticated")
+    throw new Error(`JWT role != authenticated: ${claims.role}`);
+  if (claims.email !== expectedEmail)
+    throw new Error(`JWT email mismatch: ${claims.email}`);
+  if (typeof claims.exp !== "number" || claims.exp * 1000 <= Date.now())
+    throw new Error(`JWT exp claim missing or in the past: ${claims.exp}`);
+}
+
+async function assertPersonaIsHuman(supabase, email) {
+  const { data, error } = await supabase
+    .from("organization_people")
+    .select("kind").eq("email", email).maybeSingle();
+  if (error) throw new Error(`organization_people: ${error.message}`);
+  if (data?.kind !== "human")
+    throw new Error(`persona ${email} kind=${data?.kind}, not human`);
+}
+
+function assertDiscoveryResolves(persona, discovery) {
+  if (!persona.email || !persona.manager_email) {
+    throw new Error(`persona missing email/manager_email: ${
+      JSON.stringify(persona)}`);
+  }
+  if (!discovery.snapshot_id || !discovery.item_id) {
+    throw new Error(`discovery vector incomplete: ${
+      JSON.stringify(discovery)}`);
+  }
+}
+
+function assertNonEmpty(stdout, key) {
+  const parsed = JSON.parse(stdout);
+  const v = parsed[key];
+  if (Array.isArray(v) ? v.length === 0 :
+      (v === undefined || v === null ||
+       (typeof v === "object" && Object.keys(v).length === 0))) {
+    throw new Error(`row-class non-empty assertion failed for ${key}`);
+  }
+}
+```
+
+**Smoke implementation** (`substrate-smoke.js`):
+
+```js
+import { spawnSync } from "node:child_process";
+import { mintSupabaseJwt, parseDuration } from "@forwardimpact/libsecret";
+
+export async function runSelfSmoke({ supabase, config }) {
+  const { findInvariantSatisfyingPersonas } = await import(
+    "./substrate-persona-query.js");
+  const { personas, discovery, diagnostic } =
+    await findInvariantSatisfyingPersonas({ supabase });
+  if (!personas.length) throw new Error(diagnostic);
+  const persona = personas[0];
+
+  // Mint a short-lived JWT (1h is the smallest unit parseDuration
+  // accepts; libsecret's regex is /^(\d+)([hdy])$/, no minutes).
+  const secret = config.supabaseJwtSecret();
+  const jwt = mintSupabaseJwt({
+    email: persona.email,
+    secret,
+    ttlSeconds: parseDuration("1h"),
+  });
+
+  // Spec § Success Criteria rows 1–4: explicit shape check.
+  assertJwtShape(jwt, persona.email);
+  await assertPersonaIsHuman(supabase, persona.email);
+  assertDiscoveryResolves(supabase, persona, discovery);
+
+  // Spec § Success Criteria row 5 (every gated command invocable) +
+  // row 6 (three named row-class smokes non-empty).
+  const manifestJson = spawnSync("bunx",
+    ["fit-landmark", "_gated-commands"], { encoding: "utf8" });
+  if (manifestJson.status !== 0)
+    throw new Error(`_gated-commands: ${manifestJson.stderr}`);
+  const manifest = JSON.parse(manifestJson.stdout);
+
+  for (const { command, options } of manifest) {
+    const argv = command.split(" ");
+    for (const [k, v] of Object.entries(options)) {
+      argv.push(`--${k}`, expand(v, persona, discovery));
+    }
+    argv.push("--format", "json");
+    const res = spawnSync("bunx", ["fit-landmark", ...argv], {
+      encoding: "utf8",
+      env: { ...process.env, PRODUCT_LANDMARK_TOKEN: jwt },
+    });
+    if (res.status !== 0)
+      throw new Error(`${argv.join(" ")} exited ${res.status}: ${res.stderr}`);
+
+    // Three row-class smokes (org team, evidence, practice) must return
+    // non-empty payloads. The per-command JSON shape is per spec
+    // § Success Criteria row 6 — assert via published formatter keys.
+    if (command === "org team") assertNonEmpty(res.stdout, ["team"]);
+    if (command === "evidence") assertNonEmpty(res.stdout, ["evidence"]);
+    if (command === "practice") assertNonEmpty(res.stdout, ["patterns"]);
+  }
+}
+
+function expand(template, persona, discovery) {
+  return template
+    .replace("$PERSONA_EMAIL", persona.email)
+    .replace("$SNAPSHOT_ID", discovery.snapshot_id)
+    .replace("$ITEM_ID", discovery.item_id);
+}
+
+function assertJwtShape(jwt, expectedEmail) {
+  const [, payloadB64] = jwt.split(".");
+  const claims = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+  if (claims.aud !== "authenticated")
+    throw new Error(`JWT aud != authenticated: ${claims.aud}`);
+  if (claims.role !== "authenticated")
+    throw new Error(`JWT role != authenticated: ${claims.role}`);
+  if (claims.email !== expectedEmail)
+    throw new Error(`JWT email mismatch: ${claims.email}`);
+  if (typeof claims.exp !== "number" || claims.exp * 1000 <= Date.now())
+    throw new Error(`JWT exp claim missing or in the past: ${claims.exp}`);
+}
+
+async function assertPersonaIsHuman(supabase, email) {
+  const { data, error } = await supabase
+    .from("organization_people")
+    .select("kind").eq("email", email).maybeSingle();
+  if (error) throw new Error(`organization_people: ${error.message}`);
+  if (data?.kind !== "human")
+    throw new Error(`persona ${email} kind=${data?.kind}, not human`);
+}
+
+function assertDiscoveryResolves(supabase, persona, discovery) {
+  // Persona email, persona's manager_email (if used by any gated cmd),
+  // snapshot_id, item_id — invariants already enforced by
+  // findInvariantSatisfyingPersonas; this function is a defensive
+  // re-check that fails loudly if the persona-query helper regresses.
+  if (!persona.email || !persona.manager_email) {
+    throw new Error(`persona missing email/manager_email: ${
+      JSON.stringify(persona)}`);
+  }
+  if (!discovery.snapshot_id || !discovery.item_id) {
+    throw new Error(`discovery vector incomplete: ${
+      JSON.stringify(discovery)}`);
+  }
+}
+
+function assertNonEmpty(stdout, keys) {
+  const parsed = JSON.parse(stdout);
+  for (const key of keys) {
+    const v = parsed[key] ?? parsed.view?.[key];
+    if (Array.isArray(v) ? v.length === 0 :
+        (v === undefined || v === null ||
+         (typeof v === "object" && Object.keys(v).length === 0))) {
+      throw new Error(`row-class non-empty assertion failed for ${key}`);
+    }
+  }
+}
+```
+
+Notes:
+
+- The smoke spawns inherit `process.cwd()` (the CI checkout root); the
+  JWT lives in `env` of the spawn options only, never on the parent
+  `process.env`.
+- `assertNonEmpty` accepts both `result[key]` and `result.view[key]`
+  because formatters wrap payloads under `view` (per `products/
+  landmark/src/commands/org.js:55, 72`) — verify the exact wrapper key
+  in implementation by reading the formatter; the test in Step 6
+  pins this.
+
+## Step 5 — Create `substrate-roster.js`
+
+- **Created**: `products/map/src/commands/substrate-roster.js`
+
+Calls `findInvariantSatisfyingPersonas({ supabase })`. Emits a JSON
+object (when `--format json`) or a one-row-per-line text table:
+
+```json
+{
+  "personas": [
+    {
+      "email": "athena@bionova.example",
+      "name": "Athena Vega",
+      "discipline": "platform-engineering",
+      "level": "Senior",
+      "track": "leadership",
+      "manager_email": "zeus@bionova.example",
+      "manages_count": 7,
+      "evidence_count": 23,
+      "practice_directs_count": 5,
+      "snapshot_id": "2026-Q1",
+      "item_id": "task_completion"
+    }
+  ],
+  "selection_metadata": {
+    "signals": ["memory_diversification", "jtbd_role_alignment"]
+  }
+}
+```
+
+Exit codes:
+
+- `0` — `personas.length >= 1`
+- non-zero with stderr carrying the helper's `diagnostic` string when empty
+
+## Step 6 — Create `substrate-issue.js`
+
+- **Created**: `products/map/src/commands/substrate-issue.js`
+- **Created**: `products/map/src/lib/auth-helpers.js` (shared
+  `findAuthUser` extraction — required, not optional)
+- **Modified**: `products/map/src/commands/auth-issue.js` (import
+  `findAuthUser` from the shared helper instead of carrying the local
+  copy)
+
+### Auth-helpers extraction (mandatory)
+
+Extract `findAuthUser` from `auth-issue.js` to `src/lib/auth-helpers.js`
+verbatim. The `auth-issue.js` file imports it back. This is mandatory —
+both `auth-issue.js` and `substrate-issue.js` need the function and the
+plan must commit to one shape.
+
+### `substrate-issue.js`
+
+Atomically writes two files under `--cwd <path>`. To survive partial
+crashes, write both temp files first, then rename in fixed order
+(`.env` first, `.substrate.json` second); on any rename failure, attempt
+cleanup of leftover temp files before rethrowing:
+
+```js
+import path from "node:path";
+import fs from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { mintSupabaseJwt, parseDuration } from "@forwardimpact/libsecret";
+import { findAuthUser } from "../lib/auth-helpers.js";
+import { formatSuccess } from "@forwardimpact/libcli";
+
+export async function runSubstrateIssueCommand({ supabase, config, options }) {
+  const { email, cwd, ttl } = options;
+  if (!email) throw new Error("substrate issue: --email <e> is required");
+  if (!cwd) throw new Error("substrate issue: --cwd <path> is required");
+  const ttlSeconds = parseDuration(ttl ?? "1h");
+
+  const { data: row, error: rowErr } = await supabase
+    .from("organization_people")
+    .select("email,kind,manager_email")
+    .eq("email", email)
+    .maybeSingle();
+  if (rowErr) throw new Error(`organization_people: ${rowErr.message}`);
+  if (!row) throw new Error(
+    `substrate issue: no organization_people row for ${email}`);
+  if (row.kind !== "human") throw new Error(
+    `substrate issue: ${email} is kind=${row.kind}, not human (substrate is for engineer personas only; the operator surface for service-account JWTs is \`fit-map auth issue\`)`);
+
+  const authUser = await findAuthUser(supabase, email);
+  if (!authUser) throw new Error(
+    `substrate issue: no auth.users row for ${email}`);
+
+  const secret = config.supabaseJwtSecret();
+  const jwt = mintSupabaseJwt({ email, secret, ttlSeconds });
+
+  // Discovery: latest snapshot + any item id (matches
+  // findInvariantSatisfyingPersonas's source of truth).
+  const { snapshot_id, item_id } = await resolveDiscoveryVector(supabase);
+
+  const envPath = path.join(cwd, ".env");
+  const subPath = path.join(cwd, ".substrate.json");
+  const tag = `${process.pid}-${randomBytes(4).toString("hex")}`;
+  const envTmp = `${envPath}.tmp-${tag}`;
+  const subTmp = `${subPath}.tmp-${tag}`;
+  try {
+    await fs.writeFile(envTmp, `PRODUCT_LANDMARK_TOKEN=${jwt}\n`,
+      { mode: 0o600 });
+    await fs.chmod(envTmp, 0o600);
+    await fs.writeFile(subTmp, JSON.stringify({
+      persona_email: email,
+      manager_email: row.manager_email,
+      snapshot_id, item_id,
+      generated_at: new Date().toISOString(),
+    }, null, 2) + "\n", { mode: 0o600 });
+    await fs.chmod(subTmp, 0o600);
+
+    await fs.rename(envTmp, envPath);
+    await fs.rename(subTmp, subPath);
+  } finally {
+    // Best-effort cleanup if either rename failed mid-way.
+    for (const orphan of [envTmp, subTmp]) {
+      try { await fs.unlink(orphan); } catch { /* expected after rename */ }
+    }
+  }
+
+  process.stdout.write(formatSuccess(`Issued substrate for ${email}`) + "\n");
+  return 0;
+}
+
+async function resolveDiscoveryVector(supabase) {
+  // Mirror findInvariantSatisfyingPersonas's snapshot/item lookup.
+  const { data: snaps } = await supabase
+    .from("getdx_snapshots")
+    .select("snapshot_id")
+    .order("scheduled_for", { ascending: false })
+    .limit(1);
+  if (!snaps?.length) throw new Error("no getdx_snapshots rows");
+  const snapshot_id = snaps[0].snapshot_id;
+  const { data: scores } = await supabase
+    .from("getdx_snapshot_team_scores")
+    .select("item_id").eq("snapshot_id", snapshot_id).limit(1);
+  if (!scores?.length) throw new Error(
+    `no getdx_snapshot_team_scores for snapshot ${snapshot_id}`);
+  return { snapshot_id, item_id: scores[0].item_id };
+}
+```
+
+The `kind !== "human"` rejection is intentional and differs from
+`fit-map auth issue`'s permissive behaviour: the substrate path is for
+engineer personas only, and the operator's service-account-token path
+remains the existing `fit-map auth issue` verb. The error message names
+the alternative.
+
+The atomic-write recovery contract: if `fs.rename(envTmp, envPath)`
+succeeds and `fs.rename(subTmp, subPath)` fails, the `.env` file is
+on disk but `.substrate.json` is missing. The caller (kata-interview
+supervisor in Part 03) detects this mismatch when it reads
+`.substrate.json` and re-issues. This is acceptable for the
+agent-CWD-is-fresh-per-run case (the workflow's `mktemp -d`); the
+implementation does NOT attempt to roll back a successful rename.
+
+## Step 7 — Wire the new test directories into the root test script
+
+- **Modified**: `package.json` (the `"test"` script)
+
+The root `"test"` script today scans `./tests ./libraries ./products
+./services` only. Substrate-stage tests live under `products/map/test/`,
+which is already in scope, but the workflow-shape and SKILL-shape tests
+added in Part 03 land under `.github/workflows/test/` and
+`.claude/skills/kata-interview/test/`. Extend the find scope to those
+**two specific paths** — not the entire `.claude/skills/` tree (a wider
+scope would silently pick up tests from any third-party skill landed in
+the repo):
+
+```jsonc
+// package.json
+"test": "find ./tests ./libraries ./products ./services ./.github/workflows/test ./.claude/skills/kata-interview/test -name '*.test.js' -not -path '*/node_modules/*' | xargs bun test"
+```
+
+Verify: `bun run test` discovers the new test files added in Part 03
+once that part lands. For Part 02, this change is a no-op (no tests at
+those paths exist yet) and the find scope simply expands.
+
+## Step 8 — Tests
+
+Tests created in this part. Each file is < 250 lines and uses fake
+supabase + spawn fixtures.
+
+| Test | Created file | Asserts |
+|---|---|---|
+| Stage phases fire in order | `products/map/test/activity/substrate-stage.test.js` | Phase-tagged errors thrown by stubbed phases carry the phase name; each phase's stub is invoked once in stack → url-discovery → migrate → seed → provision → smoke order; `SUBSTRATE_FORCE_EMPTY_CORPUS=true` short-circuits to the smoke-phase throw |
+| Persona invariant predicate | `products/map/test/activity/substrate-persona-query.test.js` | Four invariants combine; a row missing any one is filtered out; empty result returns the binding-constraint diagnostic naming which invariant filtered most |
+| Self-smoke JWT shape + persona-kind + discovery | `products/map/test/activity/substrate-smoke.test.js` | `assertJwtShape` rejects on missing/wrong aud/role/email/exp; `assertPersonaIsHuman` rejects on `kind=service_account`; gated-command iteration spawns each `GATED_COMMANDS` entry once; row-class non-empty assertions fire for `org team`, `evidence`, `practice` |
+| Commands-manifest source-of-truth | `products/landmark/test/lib/commands-manifest.test.js` | Imports `COMMANDS`, `SUBCOMMAND_EXPANSIONS`, `FLAT_SMOKE_OPTIONS` from `commands-manifest.js`; asserts every `needsSupabase: true` key in `COMMANDS` is covered by exactly one of `SUBCOMMAND_EXPANSIONS[key]` or `FLAT_SMOKE_OPTIONS[key]` (or has no required smoke options) — guards against drift between the dispatcher table and the smoke list |
+| `_commands` verb emits manifest | `products/landmark/test/lib/commands-verb.test.js` | Spawn `node bin/fit-landmark.js _commands` from a tmpdir; assert stdout parses as `{ commands, subcommandExpansions, flatSmokeOptions }`; assert the spawn exits 0 even when no `config/` or `.env` is reachable (verifies the hidden verb sits above the top-level `createProductConfig` await) |
+| Roster emits JSON shape | `products/map/test/activity/substrate-roster.test.js` | `--format json` returns `{ personas, selection_metadata }`; exit 0 on non-empty, non-zero on empty (with diagnostic on stderr) |
+| Issue writes both files atomically | `products/map/test/activity/substrate-issue.test.js` | Both files written; mode 0600 on each; content parses as JSON / `KEY=VALUE`; mocked `fs.rename` failure on the second file leaves the first file on disk and cleans up the second's tmp file; mocked failure on the first file leaves no files at the target paths and cleans up both tmp files |
+| Issue rejects non-human kind | (same file) | A persona row with `kind=service_account` throws with the named error and names `fit-map auth issue` as the alternative |
+
+Verify: `bun test products/map/test/activity/substrate-*.test.js
+products/landmark/test/lib/gated-commands.test.js` exits 0 with ~20
+tests passing.
+
+## Step 9 — Run full check suite
+
+```sh
+bun run check  # lint + jsdoc + format + harness + context
+bun run test   # extended find scope from Step 7
+bun test products/map/test/activity/
+bun test products/landmark/test/  # Part 01 surface still green
+```
+
+Verify: all green. PR description names the three subcommands, the
+shared `findAuthUser` helper, the new `_gated-commands` introspection
+verb, and the rows from spec § In-scope the new surface satisfies
+(Workspace state, Persona corpus, Discovery vector, Gated-command
+coverage, Failure surfacing).

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a-03.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a-03.md
@@ -91,75 +91,12 @@ in Step 10 into Part 02's stage code; the env value is the literal
 string `"true"` or `"false"` (GH Actions stringifies booleans), and
 Part 02 checks `=== "true"`.
 
-### Step 3a — Snapshot the persona JWT for the log-scan workflow
-
-Append to the same `Substrate stage` step's `run:` script:
-
-```bash
-          # Snapshot the persona JWT now so the post-run log scan
-          # (separate workflow_run-triggered workflow) checks against
-          # the value that was minted, not whatever the agent's .env
-          # contains at the end. Apply ::add-mask:: so the value is
-          # masked in this workflow's logs going forward.
-          token_file="${{ steps.agent-workspace.outputs.dir }}/.env"
-          if [ -f "$token_file" ]; then
-            persona_jwt=$(awk -F= '/^PRODUCT_LANDMARK_TOKEN=/ {print $2; exit}' \
-              "$token_file")
-            if [ -n "$persona_jwt" ]; then
-              echo "::add-mask::$persona_jwt"
-              # Persist via $GITHUB_OUTPUT so it is queryable from the
-              # separate scan workflow via the run-id API; outputs land
-              # in the run metadata and are auto-masked from logs.
-              echo "persona_jwt=$persona_jwt" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-```
-
-Note: the substrate-stage step's `bunx fit-map substrate stage` call
-does not itself issue a persona JWT — that happens later when the
-supervisor calls `bunx fit-map substrate issue` inside `Run interview`.
-The `if [ -f "$token_file" ]` branch is therefore a no-op during stage
-but becomes load-bearing if a future caller changes the issue surface;
-the actual JWT snapshot is taken in the `Run interview` step's
-post-script (Step 4a below).
-
-### Step 3b — JWT-mask helper invoked after supervisor issues
-
-The supervisor calls `bunx fit-map substrate issue` inside `Run
-interview` (the agent-cwd's `.env` is populated after that call).
-Insert a tiny step **between** `Run interview` and the existing
-flow, conditioned on Landmark, that snapshots and masks the JWT:
-
-```yaml
-      - name: Snapshot persona JWT
-        id: snapshot-jwt
-        if: always() && inputs.product == 'landmark'
-        shell: bash
-        run: |
-          token_file="${{ steps.agent-workspace.outputs.dir }}/.env"
-          if [ ! -f "$token_file" ]; then
-            echo "No .env at agent cwd — substrate issue did not run."
-            exit 0
-          fi
-          persona_jwt=$(awk -F= '/^PRODUCT_LANDMARK_TOKEN=/ {print $2; exit}' \
-            "$token_file")
-          if [ -z "$persona_jwt" ]; then
-            echo "No PRODUCT_LANDMARK_TOKEN value in agent .env."
-            exit 0
-          fi
-          echo "::add-mask::$persona_jwt"
-          echo "persona_jwt=$persona_jwt" >> "$GITHUB_OUTPUT"
-```
-
-The step output `persona_jwt` is referenced by the separate
-`workflow_run`-triggered scan workflow (Step 6) via the run-id metadata
-API. `::add-mask::` ensures the value is masked in this workflow's
-logs going forward (the supervisor's own log lines were emitted earlier
-and may carry the unmasked value — that is exactly what the spec §
-Sensitive values are absent from run logs check is for).
-
-Position: this step runs *after* `Run interview` and *before* the
-existing flow's tail. Place it right after `Run interview`.
+The post-run log scan (Step 6 below) is inline in this workflow and
+reads the JWT from a workflow-private stash file written by `substrate
+issue` (via Part 02's `--stash` flag, threaded through SKILL.md Step
+3a's example invocation). The stash file lives at
+`$RUNNER_TEMP/.persona-jwt` — outside `$AGENT_CWD`, so the agent's
+Write/Edit tools cannot tamper with it.
 
 ## Step 4 — Extend the `Run interview` step env
 
@@ -212,124 +149,100 @@ minted by `substrate issue` has a 1-hour default TTL; the job timeout
 must be strictly less so a runaway job dies before the JWT expires
 mid-run.
 
-## Step 6 — Add the post-run JWT log scan (separate workflow)
+## Step 6 — Add the post-run log scan (inline, final step)
 
-- **Created**: `.github/workflows/kata-interview-log-scan.yml`
+- **Modified**: `.github/workflows/kata-interview.yml`
 
-GitHub's `actions/runs/{run_id}/logs` REST endpoint returns the logs
-archive only after the parent run reaches a terminal conclusion;
-calling it from within the same in-progress job yields 404 or an
-incomplete archive. The scan therefore lives in a separate workflow
-file triggered by `workflow_run` on the kata-interview workflow's
-completion.
+The scan runs as the final step of the same job, `if: always() &&
+inputs.product == 'landmark'`. It reads the JWT from
+`$RUNNER_TEMP/.persona-jwt` (the workflow-private stash file written
+by `substrate issue --stash`) — never from `$AGENT_CWD/.env`, which
+the agent could mutate. The `gh api .../actions/runs/<id>/logs`
+endpoint returns the archive of all completed-step logs for the
+current run; the only step it cannot include is the scan step itself
+(still in progress) — which is fine because the scan step never echoes
+the JWT value.
 
-GitHub Actions automatically masks any value registered as a repo
-secret in the logs (each appears as `***`); scanning for
-`SUPABASE_JWT_SECRET` / `SUPABASE_SERVICE_ROLE_KEY` literal values is
-structurally a no-op. The only value at risk is the per-run persona
-JWT — minted dynamically, not registered as a secret. The scan reads
-the JWT from the parent run's `Snapshot persona JWT` step output.
+Insert after the `Run interview` step:
 
 ```yaml
-name: "Kata: Interview Log Scan"
-
-on:
-  workflow_run:
-    workflows: ["Kata:–- Interview"]
-    types: [completed]
-
-permissions:
-  contents: read
-  actions: read
-
-jobs:
-  scan:
-    runs-on: ubuntu-latest
-    # Only scan Landmark runs (memoised on the parent run's event payload).
-    if: github.event.workflow_run.event == 'workflow_dispatch'
-    steps:
-      - name: Generate installation token
-        id: ci-app
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
-        with:
-          app-id: ${{ secrets.KATA_APP_ID }}
-          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-
-      - name: Fetch persona JWT from parent run
-        id: jwt
+      - name: Scan logs for sensitive values
+        if: always() && inputs.product == 'landmark'
+        shell: bash
         env:
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-          PARENT_RUN: ${{ github.event.workflow_run.id }}
-        shell: bash
+          JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
+          SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          # Query the parent run's `Snapshot persona JWT` step output.
-          # The output is auto-masked from logs but the API returns it.
-          jobs_json=$(gh api \
-            "/repos/${{ github.repository }}/actions/runs/$PARENT_RUN/jobs")
-          # If the parent run was not a Landmark interview, the step
-          # would not have run; abort gracefully.
-          jwt=$(echo "$jobs_json" \
-            | python3 -c "import sys,json; d=json.load(sys.stdin); \
-              steps=[s for j in d['jobs'] for s in j.get('steps',[])]; \
-              snap=[s for s in steps if s['name']=='Snapshot persona JWT']; \
-              print('present' if snap and snap[0]['conclusion']=='success' else '')")
-          if [ "$jwt" != "present" ]; then
-            echo "No Landmark persona-JWT snapshot in parent run; nothing to scan."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          stash="$RUNNER_TEMP/.persona-jwt"
+          if [ ! -f "$stash" ]; then
+            echo "No persona-JWT stash at $stash — substrate issue did not run."
+            persona_jwt=""
+          else
+            persona_jwt=$(cat "$stash")
+            echo "::add-mask::$persona_jwt"
           fi
-          # The actual JWT value lives in the step's output; fetch via
-          # the dedicated step-outputs endpoint.
-          token_val=$(gh api \
-            "/repos/${{ github.repository }}/actions/runs/$PARENT_RUN" \
-            --jq '.outputs."snapshot-jwt".persona_jwt // empty')
-          if [ -z "$token_val" ]; then
-            echo "Snapshot step ran but output is empty; cannot verify."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "::add-mask::$token_val"
-          echo "value<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$token_val" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: Scan parent-run logs
-        if: steps.jwt.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-          PARENT_RUN: ${{ github.event.workflow_run.id }}
-          TOKEN_VAL: ${{ steps.jwt.outputs.value }}
-        shell: bash
-        run: |
-          gh api -H "Accept: application/vnd.github+json" \
-            "/repos/${{ github.repository }}/actions/runs/$PARENT_RUN/logs" \
-            > /tmp/run-logs.zip
-          unzip -q /tmp/run-logs.zip -d /tmp/run-logs/
-          if grep -RFq -- "$TOKEN_VAL" /tmp/run-logs/; then
-            echo "FAIL: PRODUCT_LANDMARK_TOKEN literal in run logs" >&2
-            exit 1
+          # Download the in-progress run's log archive. GH serves the
+          # archive of all completed-step logs even while the run is
+          # active; only the scan step's own logs are excluded (which
+          # is fine — it never echoes the JWT).
+          if ! gh api -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/logs" \
+              > /tmp/run-logs.zip 2>/tmp/gh-err.log; then
+            echo "WARN: log archive not yet available — gh api stderr:" >&2
+            cat /tmp/gh-err.log >&2
+            echo "Relying on ::add-mask:: at-issue protection."
+            exit 0
           fi
-          echo "OK: persona JWT not in run logs"
+          if ! unzip -q /tmp/run-logs.zip -d /tmp/run-logs/; then
+            echo "WARN: log archive empty/unreadable; relying on ::add-mask::"
+            exit 0
+          fi
+
+          fail=0
+          # Spec § Success Criteria row 8: scan for all three literals.
+          # The two repo secrets are auto-masked by GH (appear as ***);
+          # the persona JWT is minted per-run and protected only by the
+          # ::add-mask:: applied at issue time. A failing grep here means
+          # something printed the value before the mask landed.
+          for pair in \
+              "persona-jwt:$persona_jwt" \
+              "jwt-secret:$JWT_SECRET" \
+              "service-role-key:$SERVICE_ROLE_KEY"; do
+            label="${pair%%:*}"
+            value="${pair#*:}"
+            [ -z "$value" ] && continue
+            if grep -RFq -- "$value" /tmp/run-logs/; then
+              echo "FAIL: $label literal in run logs" >&2
+              fail=1
+            fi
+          done
+          exit $fail
 ```
 
 Notes:
 
-- The parent run's `Snapshot persona JWT` step (Part 03 § Step 3b)
-  stores the value via `$GITHUB_OUTPUT`. GitHub Actions exposes step
-  outputs through the run-jobs API; the value carries the parent's
-  `::add-mask::` registration into the scan workflow's logs too.
-- `grep -F` avoids regex metacharacters in JWT base64url segments.
-- `grep -- "$TOKEN_VAL"` guards against a JWT starting with `-`.
-- The repo-secret pair (JWT secret, service role key) does not need
-  explicit scanning — GH masks them automatically. The PR description
-  must state this rationale.
-- The `workflow_run` trigger requires the scan workflow file to live
-  on the default branch. The PR introducing this file therefore must
-  merge to `main` before the scan begins firing on subsequent
-  kata-interview runs; until merge the scan does not exist and the
-  spec criterion is satisfied only after merge — note this in the PR
-  description.
+- The two repo secrets (`SUPABASE_JWT_SECRET`,
+  `SUPABASE_SERVICE_ROLE_KEY`) are auto-masked by GH Actions in run
+  logs, so grepping for their literal values is normally a no-op —
+  but the scan still performs the grep so spec § Success Criteria row
+  8 is satisfied literally, and to catch the unlikely case where GH's
+  masker fails on a partial-string match.
+- `grep -F` (fixed-string) avoids regex metacharacters in base64url JWT
+  segments; `grep -- "$value"` guards against a value starting with `-`.
+- `gh api` requires `actions: read` permission (added to the workflow's
+  top-level `permissions:` block in Step 2). The kata-agent-team GitHub
+  App installation must also carry `Actions: Read` repository
+  permission — document this in the PR description.
+- The `Scan logs for sensitive values` step is the only spec § Success
+  Criteria row 8 verification surface. Confidence is bounded: a
+  hypothetical leak printed during the scan step itself would not be
+  caught (the step's log is excluded from the in-progress archive).
+  The spec describes a "CI step downloads the workflow's run logs for
+  every step that executes after the assertion step is added"; this
+  implementation matches the spec literally — the scan step is itself
+  the "assertion step", and it scans every step that runs before it.
 
 ## Step 7 — Add the workflow-shape assertion test
 
@@ -350,13 +263,13 @@ import { parse } from "yaml";
 const wf = parse(readFileSync(".github/workflows/kata-interview.yml", "utf8"));
 const steps = wf.jobs.interview.steps;
 
-const ADDED_STEPS = new Set(["Substrate stage", "Snapshot persona JWT"]);
+const ADDED_STEPS = new Set([
+  "Substrate stage",
+  "Scan logs for sensitive values",
+]);
 // Every key added to Run interview's env by spec 990. Must match what
-// Step 4 above lands. Update this list when adding new env keys here.
-// SUPABASE_URL is propagated via $GITHUB_ENV (Step 3), not via this
-// step's env: map, so it does not appear here. The
-// kata-interview-log-scan.yml workflow handles the post-run scan and
-// is asserted in its own shape test (see scan-workflow-shape.test.js).
+// Step 4 above lands. SUPABASE_URL is propagated via $GITHUB_ENV
+// (Step 3), not via this step's env: map, so it does not appear here.
 const ADDED_RUN_ENV_KEYS = ["AGENT_CWD", "SUPABASE_JWT_SECRET",
   "SUPABASE_SERVICE_ROLE_KEY"];
 
@@ -392,14 +305,7 @@ describe("kata-interview.yml spec 990 non-Landmark invariant", () => {
 });
 ```
 
-Add a sibling test `.github/workflows/test/log-scan-shape.test.js`
-that parses `.github/workflows/kata-interview-log-scan.yml` and
-asserts: the `on.workflow_run.workflows` array contains `"Kata:–-
-Interview"`; the `permissions:` block includes both `contents: read`
-and `actions: read`; the scan job's `if:` predicate gates on
-`workflow_dispatch` events.
-
-Both tests run as part of `bun run test` via Part 02 § Step 7's
+The test runs as part of `bun run test` via Part 02 § Step 7's
 test-path extension to `.github/workflows/test`.
 
 ## Step 8 — Update the kata-interview SKILL.md
@@ -454,12 +360,17 @@ agent's identity into `$AGENT_CWD`:
 3. Issue the substrate for the picked persona:
 
    ```sh
-   bunx fit-map substrate issue --email <picked-email> --cwd "$AGENT_CWD"
+   bunx fit-map substrate issue \
+     --email <picked-email> \
+     --cwd "$AGENT_CWD" \
+     --stash "$RUNNER_TEMP/.persona-jwt"
    ```
 
    Writes `$AGENT_CWD/.env` (carrying the persona's JWT) and
-   `$AGENT_CWD/.substrate.json` (the discovery vector). Mode 0600 on
-   both files.
+   `$AGENT_CWD/.substrate.json` (the discovery vector), plus a third
+   workflow-private copy of the bare JWT at `$RUNNER_TEMP/.persona-jwt`
+   which the post-run log-scan step reads. The agent has no access to
+   `$RUNNER_TEMP`. Mode 0600 on all three files.
 
 You never see the JWT bytes. The agent's `fit-landmark` discovers the
 JWT through libconfig's `.env` read in `$AGENT_CWD`.

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a-03.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a-03.md
@@ -22,24 +22,25 @@ CI fails closed if either is unset: Part 02's substrate-stage step calls
 `config.supabaseJwtSecret()` / `config.supabaseServiceRoleKey()` which
 throws on empty.
 
-## Step 2 — Grant `actions: read` on the workflow
+## Step 2 — Document the App installation prerequisite
 
-- **Modified**: `.github/workflows/kata-interview.yml` (the `permissions:`
-  block; locate via `rg "permissions:" .github/workflows/kata-interview.yml`)
+- **No workflow file change** — operator action documented in the PR
+  description.
 
-The post-run log scan in Step 6 calls `gh api .../actions/runs/<id>/logs`,
-which requires `actions: read`. Today the workflow's top-level
-permissions block declares only `contents: read`. Extend it to:
+The post-run log scan in Step 6 calls `gh api .../actions/runs/<id>/logs`
+using `GH_TOKEN: ${{ steps.ci-app.outputs.token }}` (the kata-agent-team
+GitHub App installation token, **not** the workflow `GITHUB_TOKEN`).
+Workflow-level `permissions:` blocks govern `GITHUB_TOKEN` only — they
+have no effect on App tokens, whose scope is set in App settings.
 
-```yaml
-permissions:
-  contents: read
-  actions: read
-```
+The implementer must verify (or coordinate verification of) the
+kata-agent-team App installation's repository permissions: **`Actions:
+Read`** must be enabled before Part 03 merges. List this in the PR
+description as an operator prerequisite alongside the two repo secrets
+from Step 1.
 
-The kata-agent-team GitHub App installation must also carry `actions:
-read` repository permission; document this in the PR description so the
-repo admin can verify before merge.
+Workflow-level `permissions:` block on `kata-interview.yml` is
+unchanged from `main`.
 
 ## Step 3 — Add the `Substrate stage` step (Landmark-gated)
 
@@ -62,18 +63,23 @@ Immediately after that step's run script ends, insert:
           mkdir -p "${{ steps.agent-workspace.outputs.dir }}/config"
           bunx fit-map substrate stage
 
-          # Propagate the local Supabase URL to subsequent workflow
-          # steps. Part 02's substrate-stage sets process.env.SUPABASE_URL
-          # inside its own Node process; that only survives the Node
-          # process. For the supervisor (next workflow step) to see it,
-          # write to $GITHUB_ENV.
-          api_url=$(bunx --no-install -- supabase status --output json \
-            | awk -F'"' '/"api_url"/ {print $4}')
-          if [ -z "$api_url" ]; then
-            echo "FAIL: supabase status did not yield api_url" >&2
+          # Propagate the local Supabase URL + anon key to subsequent
+          # workflow steps. Part 02's substrate-stage sets these in its
+          # own Node process; that only survives the Node process. For
+          # the supervisor (next workflow step) and the agent's
+          # fit-landmark spawns to see them, write to $GITHUB_ENV.
+          # SUPABASE_ANON_KEY is required by fit-landmark's
+          # createLandmarkClient (products/landmark/src/lib/supabase.js)
+          # to construct the anon client resolveIdentity authenticates.
+          status_json=$(bunx --no-install -- supabase status --output json)
+          api_url=$(echo "$status_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["api_url"])')
+          anon_key=$(echo "$status_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["anon_key"])')
+          if [ -z "$api_url" ] || [ -z "$anon_key" ]; then
+            echo "FAIL: supabase status did not yield api_url + anon_key" >&2
             exit 1
           fi
           echo "SUPABASE_URL=$api_url" >> "$GITHUB_ENV"
+          echo "SUPABASE_ANON_KEY=$anon_key" >> "$GITHUB_ENV"
 ```
 
 The `mkdir` line provisions `$AGENT_CWD/config/` so libconfig's
@@ -299,9 +305,11 @@ describe("kata-interview.yml spec 990 non-Landmark invariant", () => {
       `timeout-minutes expected < 60, got ${m}`);
   });
 
-  it("workflow permissions include actions: read", () => {
-    assert.equal(wf.permissions["actions"], "read");
-  });
+  // permissions block is unchanged from main — the gh api call uses
+  // the kata-agent-team App token, not the workflow GITHUB_TOKEN, so
+  // workflow-level permissions do not govern it (App installation
+  // permission is the actual prerequisite). Asserted via the
+  // PR-description operator checklist, not by this test.
 });
 ```
 
@@ -354,8 +362,10 @@ agent's identity into `$AGENT_CWD`:
      last 5 weekly-log entries.
    - **JTBD-role alignment** — match the picked job's audience against
      the persona's `discipline` and `level` (e.g. *Engineering Leaders*
-     → a Manager-track or Director-level row; *Empowered Engineers* →
-     an IC-track row at Senior or below).
+     → a `manager` or `director` discipline at any level; *Empowered
+     Engineers* → an `engineer` discipline at `Senior` or below).
+     The `track` field is informational only; do not use it as a
+     primary signal.
 
 3. Issue the substrate for the picked persona:
 

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a-03.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a-03.md
@@ -1,0 +1,565 @@
+# Plan 990-a Part 03 — `kata-interview.yml` substrate step + SKILL.md updates
+
+Wires the substrate verbs from Part 02 into the kata-interview workflow,
+adds a post-run scan that catches the only sensitive value GitHub Actions
+does *not* auto-mask (the per-run persona JWT), gates everything on
+`inputs.product == 'landmark'`, and updates the `kata-interview` skill to
+reflect the new substrate surface and the read-do-checklist amendment.
+Depends on Part 02.
+
+## Step 1 — Configure two new GH repo secrets (operator action)
+
+- **No code change** — operator action documented in the PR description.
+
+A repo admin must configure two repository secrets:
+
+- `SUPABASE_JWT_SECRET` — local-stack JWT signing key (same value
+  `just env-setup` writes today)
+- `SUPABASE_SERVICE_ROLE_KEY` — derived via
+  `mintSupabaseServiceRoleKey` (also written by `just env-setup`)
+
+CI fails closed if either is unset: Part 02's substrate-stage step calls
+`config.supabaseJwtSecret()` / `config.supabaseServiceRoleKey()` which
+throws on empty.
+
+## Step 2 — Grant `actions: read` on the workflow
+
+- **Modified**: `.github/workflows/kata-interview.yml` (the `permissions:`
+  block; locate via `rg "permissions:" .github/workflows/kata-interview.yml`)
+
+The post-run log scan in Step 6 calls `gh api .../actions/runs/<id>/logs`,
+which requires `actions: read`. Today the workflow's top-level
+permissions block declares only `contents: read`. Extend it to:
+
+```yaml
+permissions:
+  contents: read
+  actions: read
+```
+
+The kata-agent-team GitHub App installation must also carry `actions:
+read` repository permission; document this in the PR description so the
+repo admin can verify before merge.
+
+## Step 3 — Add the `Substrate stage` step (Landmark-gated)
+
+- **Modified**: `.github/workflows/kata-interview.yml`
+
+Locate the existing `Prepare interview workspace` step (find it via
+`rg "Prepare interview workspace" .github/workflows/kata-interview.yml`).
+Immediately after that step's run script ends, insert:
+
+```yaml
+      - name: Substrate stage
+        id: substrate-stage
+        if: inputs.product == 'landmark'
+        shell: bash
+        env:
+          SUPABASE_JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUBSTRATE_FORCE_EMPTY_CORPUS: ${{ inputs.empty-corpus-test }}
+        run: |
+          mkdir -p "${{ steps.agent-workspace.outputs.dir }}/config"
+          bunx fit-map substrate stage
+
+          # Propagate the local Supabase URL to subsequent workflow
+          # steps. Part 02's substrate-stage sets process.env.SUPABASE_URL
+          # inside its own Node process; that only survives the Node
+          # process. For the supervisor (next workflow step) to see it,
+          # write to $GITHUB_ENV.
+          api_url=$(bunx --no-install -- supabase status --output json \
+            | awk -F'"' '/"api_url"/ {print $4}')
+          if [ -z "$api_url" ]; then
+            echo "FAIL: supabase status did not yield api_url" >&2
+            exit 1
+          fi
+          echo "SUPABASE_URL=$api_url" >> "$GITHUB_ENV"
+```
+
+The `mkdir` line provisions `$AGENT_CWD/config/` so libconfig's
+`findUpward("config")` resolves uniformly from the agent's cwd, per
+design-c § Three setup paths. The `if:` predicate gates the entire step
+on Landmark; non-Landmark runs skip it. `SUPABASE_URL` propagation to
+the next step is via `$GITHUB_ENV` — without this, the supervisor's
+`bunx fit-map substrate roster` invocation in the `Run interview` step
+calls `config.supabaseUrl()` which throws because the previous Node
+process's `process.env.SUPABASE_URL` write does not survive across
+workflow steps.
+
+`SUBSTRATE_FORCE_EMPTY_CORPUS` plumbs the boolean workflow input added
+in Step 10 into Part 02's stage code; the env value is the literal
+string `"true"` or `"false"` (GH Actions stringifies booleans), and
+Part 02 checks `=== "true"`.
+
+### Step 3a — Snapshot the persona JWT for the log-scan workflow
+
+Append to the same `Substrate stage` step's `run:` script:
+
+```bash
+          # Snapshot the persona JWT now so the post-run log scan
+          # (separate workflow_run-triggered workflow) checks against
+          # the value that was minted, not whatever the agent's .env
+          # contains at the end. Apply ::add-mask:: so the value is
+          # masked in this workflow's logs going forward.
+          token_file="${{ steps.agent-workspace.outputs.dir }}/.env"
+          if [ -f "$token_file" ]; then
+            persona_jwt=$(awk -F= '/^PRODUCT_LANDMARK_TOKEN=/ {print $2; exit}' \
+              "$token_file")
+            if [ -n "$persona_jwt" ]; then
+              echo "::add-mask::$persona_jwt"
+              # Persist via $GITHUB_OUTPUT so it is queryable from the
+              # separate scan workflow via the run-id API; outputs land
+              # in the run metadata and are auto-masked from logs.
+              echo "persona_jwt=$persona_jwt" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+```
+
+Note: the substrate-stage step's `bunx fit-map substrate stage` call
+does not itself issue a persona JWT — that happens later when the
+supervisor calls `bunx fit-map substrate issue` inside `Run interview`.
+The `if [ -f "$token_file" ]` branch is therefore a no-op during stage
+but becomes load-bearing if a future caller changes the issue surface;
+the actual JWT snapshot is taken in the `Run interview` step's
+post-script (Step 4a below).
+
+### Step 3b — JWT-mask helper invoked after supervisor issues
+
+The supervisor calls `bunx fit-map substrate issue` inside `Run
+interview` (the agent-cwd's `.env` is populated after that call).
+Insert a tiny step **between** `Run interview` and the existing
+flow, conditioned on Landmark, that snapshots and masks the JWT:
+
+```yaml
+      - name: Snapshot persona JWT
+        id: snapshot-jwt
+        if: always() && inputs.product == 'landmark'
+        shell: bash
+        run: |
+          token_file="${{ steps.agent-workspace.outputs.dir }}/.env"
+          if [ ! -f "$token_file" ]; then
+            echo "No .env at agent cwd — substrate issue did not run."
+            exit 0
+          fi
+          persona_jwt=$(awk -F= '/^PRODUCT_LANDMARK_TOKEN=/ {print $2; exit}' \
+            "$token_file")
+          if [ -z "$persona_jwt" ]; then
+            echo "No PRODUCT_LANDMARK_TOKEN value in agent .env."
+            exit 0
+          fi
+          echo "::add-mask::$persona_jwt"
+          echo "persona_jwt=$persona_jwt" >> "$GITHUB_OUTPUT"
+```
+
+The step output `persona_jwt` is referenced by the separate
+`workflow_run`-triggered scan workflow (Step 6) via the run-id metadata
+API. `::add-mask::` ensures the value is masked in this workflow's
+logs going forward (the supervisor's own log lines were emitted earlier
+and may carry the unmasked value — that is exactly what the spec §
+Sensitive values are absent from run logs check is for).
+
+Position: this step runs *after* `Run interview` and *before* the
+existing flow's tail. Place it right after `Run interview`.
+
+## Step 4 — Extend the `Run interview` step env
+
+- **Modified**: `.github/workflows/kata-interview.yml`
+
+Three new env entries on the `Run interview` step. **Every new key is
+Landmark-gated via a value-level ternary** so spec § *Non-Landmark
+interviews are not regressed* holds (the rendered job env for
+non-Landmark runs shows empty values, not omitted keys — matching what
+the spec invariant assertion checks for):
+
+```yaml
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          CLAUDE_CODE_USE_BEDROCK: "0"
+          AGENT_CWD: ${{ inputs.product == 'landmark' && steps.agent-workspace.outputs.dir || '' }}
+          SUPABASE_JWT_SECRET: ${{ inputs.product == 'landmark' && secrets.SUPABASE_JWT_SECRET || '' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ inputs.product == 'landmark' && secrets.SUPABASE_SERVICE_ROLE_KEY || '' }}
+```
+
+`SUPABASE_URL` is **not** listed here because Step 3 writes it to
+`$GITHUB_ENV`, which propagates to all subsequent steps automatically
+(the spec § Success Criteria row 9 invariant test in Step 7 below
+asserts on keys explicitly added to the `Run interview` step's `env:`
+map — `$GITHUB_ENV`-propagated values do not count as step-env
+additions).
+
+`AGENT_CWD` is gated: non-Landmark interviews do not need it (today's
+workflow does not export it at all), and gating it keeps the spec
+invariant assertion (Step 7) clean.
+
+`PRODUCT_LANDMARK_TOKEN` is **not** in this map — Part 02's `substrate
+issue` writes it to `$AGENT_CWD/.env`, and libconfig discovers it via
+the agent's cwd when the agent's `fit-landmark` spawn runs there.
+
+The supervisor (running with `supervisor-cwd: "."`) calls `bunx fit-map
+substrate roster` and `bunx fit-map substrate issue` from the workflow
+checkout root. Those calls also need `SUPABASE_URL` — supplied through
+`$GITHUB_ENV` from Step 3.
+
+## Step 5 — Declare `timeout-minutes` on the `interview` job
+
+- **Modified**: `.github/workflows/kata-interview.yml` (the `interview`
+  job header; locate via `rg "interview:" .github/workflows/
+  kata-interview.yml`)
+
+Add `timeout-minutes: 50` adjacent to `runs-on: ubuntu-latest`. The JWT
+minted by `substrate issue` has a 1-hour default TTL; the job timeout
+must be strictly less so a runaway job dies before the JWT expires
+mid-run.
+
+## Step 6 — Add the post-run JWT log scan (separate workflow)
+
+- **Created**: `.github/workflows/kata-interview-log-scan.yml`
+
+GitHub's `actions/runs/{run_id}/logs` REST endpoint returns the logs
+archive only after the parent run reaches a terminal conclusion;
+calling it from within the same in-progress job yields 404 or an
+incomplete archive. The scan therefore lives in a separate workflow
+file triggered by `workflow_run` on the kata-interview workflow's
+completion.
+
+GitHub Actions automatically masks any value registered as a repo
+secret in the logs (each appears as `***`); scanning for
+`SUPABASE_JWT_SECRET` / `SUPABASE_SERVICE_ROLE_KEY` literal values is
+structurally a no-op. The only value at risk is the per-run persona
+JWT — minted dynamically, not registered as a secret. The scan reads
+the JWT from the parent run's `Snapshot persona JWT` step output.
+
+```yaml
+name: "Kata: Interview Log Scan"
+
+on:
+  workflow_run:
+    workflows: ["Kata:–- Interview"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    # Only scan Landmark runs (memoised on the parent run's event payload).
+    if: github.event.workflow_run.event == 'workflow_dispatch'
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+
+      - name: Fetch persona JWT from parent run
+        id: jwt
+        env:
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          PARENT_RUN: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          # Query the parent run's `Snapshot persona JWT` step output.
+          # The output is auto-masked from logs but the API returns it.
+          jobs_json=$(gh api \
+            "/repos/${{ github.repository }}/actions/runs/$PARENT_RUN/jobs")
+          # If the parent run was not a Landmark interview, the step
+          # would not have run; abort gracefully.
+          jwt=$(echo "$jobs_json" \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); \
+              steps=[s for j in d['jobs'] for s in j.get('steps',[])]; \
+              snap=[s for s in steps if s['name']=='Snapshot persona JWT']; \
+              print('present' if snap and snap[0]['conclusion']=='success' else '')")
+          if [ "$jwt" != "present" ]; then
+            echo "No Landmark persona-JWT snapshot in parent run; nothing to scan."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # The actual JWT value lives in the step's output; fetch via
+          # the dedicated step-outputs endpoint.
+          token_val=$(gh api \
+            "/repos/${{ github.repository }}/actions/runs/$PARENT_RUN" \
+            --jq '.outputs."snapshot-jwt".persona_jwt // empty')
+          if [ -z "$token_val" ]; then
+            echo "Snapshot step ran but output is empty; cannot verify."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::add-mask::$token_val"
+          echo "value<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$token_val" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Scan parent-run logs
+        if: steps.jwt.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          PARENT_RUN: ${{ github.event.workflow_run.id }}
+          TOKEN_VAL: ${{ steps.jwt.outputs.value }}
+        shell: bash
+        run: |
+          gh api -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/actions/runs/$PARENT_RUN/logs" \
+            > /tmp/run-logs.zip
+          unzip -q /tmp/run-logs.zip -d /tmp/run-logs/
+          if grep -RFq -- "$TOKEN_VAL" /tmp/run-logs/; then
+            echo "FAIL: PRODUCT_LANDMARK_TOKEN literal in run logs" >&2
+            exit 1
+          fi
+          echo "OK: persona JWT not in run logs"
+```
+
+Notes:
+
+- The parent run's `Snapshot persona JWT` step (Part 03 § Step 3b)
+  stores the value via `$GITHUB_OUTPUT`. GitHub Actions exposes step
+  outputs through the run-jobs API; the value carries the parent's
+  `::add-mask::` registration into the scan workflow's logs too.
+- `grep -F` avoids regex metacharacters in JWT base64url segments.
+- `grep -- "$TOKEN_VAL"` guards against a JWT starting with `-`.
+- The repo-secret pair (JWT secret, service role key) does not need
+  explicit scanning — GH masks them automatically. The PR description
+  must state this rationale.
+- The `workflow_run` trigger requires the scan workflow file to live
+  on the default branch. The PR introducing this file therefore must
+  merge to `main` before the scan begins firing on subsequent
+  kata-interview runs; until merge the scan does not exist and the
+  spec criterion is satisfied only after merge — note this in the PR
+  description.
+
+## Step 7 — Add the workflow-shape assertion test
+
+- **Created**: `.github/workflows/test/kata-interview-shape.test.js`
+
+A `node:test` file (also Bun-compatible) parsing
+`.github/workflows/kata-interview.yml` as YAML. Asserts the spec §
+*Non-Landmark interviews are not regressed* invariant — every step
+introduced by this spec carries a Landmark `if:`, and every new env
+key on `Run interview` carries a Landmark ternary:
+
+```js
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+
+const wf = parse(readFileSync(".github/workflows/kata-interview.yml", "utf8"));
+const steps = wf.jobs.interview.steps;
+
+const ADDED_STEPS = new Set(["Substrate stage", "Snapshot persona JWT"]);
+// Every key added to Run interview's env by spec 990. Must match what
+// Step 4 above lands. Update this list when adding new env keys here.
+// SUPABASE_URL is propagated via $GITHUB_ENV (Step 3), not via this
+// step's env: map, so it does not appear here. The
+// kata-interview-log-scan.yml workflow handles the post-run scan and
+// is asserted in its own shape test (see scan-workflow-shape.test.js).
+const ADDED_RUN_ENV_KEYS = ["AGENT_CWD", "SUPABASE_JWT_SECRET",
+  "SUPABASE_SERVICE_ROLE_KEY"];
+
+describe("kata-interview.yml spec 990 non-Landmark invariant", () => {
+  it("every step added by spec 990 carries the Landmark predicate", () => {
+    for (const name of ADDED_STEPS) {
+      const step = steps.find((s) => s.name === name);
+      assert.ok(step, `expected step "${name}"`);
+      assert.match(String(step.if),
+        /inputs\.product\s*==\s*'landmark'/,
+        `step "${name}" missing Landmark gating`);
+    }
+  });
+
+  it("every Run-interview env key added by spec 990 is Landmark-gated", () => {
+    const run = steps.find((s) => s.name === "Run interview");
+    for (const key of ADDED_RUN_ENV_KEYS) {
+      assert.match(String(run.env[key]),
+        /inputs\.product\s*==\s*'landmark'\s*&&[^|]+\|\|\s*''/,
+        `${key} missing Landmark ternary`);
+    }
+  });
+
+  it("interview job declares timeout-minutes < 60", () => {
+    const m = wf.jobs.interview["timeout-minutes"];
+    assert.ok(typeof m === "number" && m < 60,
+      `timeout-minutes expected < 60, got ${m}`);
+  });
+
+  it("workflow permissions include actions: read", () => {
+    assert.equal(wf.permissions["actions"], "read");
+  });
+});
+```
+
+Add a sibling test `.github/workflows/test/log-scan-shape.test.js`
+that parses `.github/workflows/kata-interview-log-scan.yml` and
+asserts: the `on.workflow_run.workflows` array contains `"Kata:–-
+Interview"`; the `permissions:` block includes both `contents: read`
+and `actions: read`; the scan job's `if:` predicate gates on
+`workflow_dispatch` events.
+
+Both tests run as part of `bun run test` via Part 02 § Step 7's
+test-path extension to `.github/workflows/test`.
+
+## Step 8 — Update the kata-interview SKILL.md
+
+- **Modified**: `.claude/skills/kata-interview/SKILL.md`
+
+Three edits per spec § Kata-interview skill alignment and design-c §
+SKILL.md amendments. Locate each anchor via `rg`.
+
+### Edit 8a — Step 3 staging table Landmark row
+
+Anchor: `rg '\| Map, Landmark' .claude/skills/kata-interview/SKILL.md`.
+
+Replace the combined `Map, Landmark` row with two separate rows:
+
+```md
+| Map              | `data/pathway/` and `data/activity/`                                                                    |
+| Landmark         | `data/pathway/` and `data/activity/`; substrate (`auth.users` for all humans, schema, seed, smoke) staged by the workflow's `Substrate stage` step |
+```
+
+### Edit 8b — Insert Step 3a (Landmark-only persona pick)
+
+Anchor: the end of the existing Step 3 (after the `cp -r` example).
+
+Insert a new section:
+
+```md
+### Step 3a: Pick the Persona (Landmark only)
+
+If the product is **Landmark**, the workflow has already brought up the
+substrate. Before writing `CLAUDE.md`, pick a persona and seal the
+agent's identity into `$AGENT_CWD`:
+
+1. List invariant-satisfying personas:
+
+   ```sh
+   bunx fit-map substrate roster --format json
+   ```
+
+   Each row carries `email`, `name`, `discipline`, `level`, `track`,
+   `manager_email`, plus the corpus-wide discovery values
+   (`snapshot_id`, `item_id`).
+
+2. Pick one persona using two signals:
+   - **Memory diversification** — exclude personas referenced in your
+     last 5 weekly-log entries.
+   - **JTBD-role alignment** — match the picked job's audience against
+     the persona's `discipline` and `level` (e.g. *Engineering Leaders*
+     → a Manager-track or Director-level row; *Empowered Engineers* →
+     an IC-track row at Senior or below).
+
+3. Issue the substrate for the picked persona:
+
+   ```sh
+   bunx fit-map substrate issue --email <picked-email> --cwd "$AGENT_CWD"
+   ```
+
+   Writes `$AGENT_CWD/.env` (carrying the persona's JWT) and
+   `$AGENT_CWD/.substrate.json` (the discovery vector). Mode 0600 on
+   both files.
+
+You never see the JWT bytes. The agent's `fit-landmark` discovers the
+JWT through libconfig's `.env` read in `$AGENT_CWD`.
+
+**Failure handling.** If either `bunx fit-map substrate roster` or
+`bunx fit-map substrate issue` returns non-zero, do not proceed to
+Step 4 or any `Ask` call. Write a one-line diagnostic to your session
+output naming the failing verb and its exit code, then exit the skill.
+The `Run interview` workflow step exits non-zero because no interview
+was completed — this is the spec § Failure surfacing pathway for
+supervisor-side substrate failures.
+```
+
+### Edit 8c — Rewrite the read-do checklist line
+
+Anchor: `rg "No product names anywhere agent-visible" .claude/skills/
+kata-interview/SKILL.md` (one match today).
+
+Replace the entire line with the exact wording from spec § Persona-file
+invariant amendment:
+
+```md
+- [ ] No product names in the persona file or in supervisor-authored Ask templates; product-named environment variables required by the production CLI are permitted in the agent's environment.
+```
+
+The Step 4 `CLAUDE.md`-exclusion list (anchor: `rg "Excluded: goal
+sentence, Big Hire" .claude/skills/kata-interview/SKILL.md`) is
+**unchanged**.
+
+## Step 9 — Add the SKILL.md shape assertion test
+
+- **Created**: `.claude/skills/kata-interview/test/skill-shape.test.js`
+
+```js
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const skill = readFileSync(".claude/skills/kata-interview/SKILL.md", "utf8");
+
+describe("kata-interview SKILL.md spec 990 amendments", () => {
+  it("Step 3 staging table Landmark row mentions substrate", () => {
+    assert.match(skill, /\| Landmark\s+\|.*substrate.*staged.*\|/);
+  });
+
+  it("Step 3a (Landmark persona pick) names the substrate verbs", () => {
+    assert.match(skill, /fit-map substrate roster/);
+    assert.match(skill, /fit-map substrate issue/);
+  });
+
+  it("read-do checklist line is amended verbatim", () => {
+    assert.doesNotMatch(skill, /No product names anywhere agent-visible/);
+    assert.match(skill,
+      /product-named environment variables required by the production CLI are permitted in the agent's environment/);
+  });
+
+  it("Step 4 CLAUDE.md exclusion list is unchanged", () => {
+    assert.match(skill,
+      /Excluded: goal sentence, Big Hire, Little Hire, Fired-When, product name/);
+  });
+});
+```
+
+Picked up by the extended test scope from Part 02 § Step 7.
+
+## Step 10 — Add a workflow-dispatch input for the empty-corpus failure path
+
+- **Modified**: `.github/workflows/kata-interview.yml` (under
+  `workflow_dispatch.inputs`)
+
+Add one input:
+
+```yaml
+      empty-corpus-test:
+        description: "Force substrate-stage to see an empty corpus (CI assertion)"
+        required: false
+        type: boolean
+        default: false
+```
+
+The input flows into Part 02's `substrate-stage.js` via the
+`SUBSTRATE_FORCE_EMPTY_CORPUS` env entry already added in Step 3.
+
+Verification protocol (recorded in the PR description, not in the
+workflow): one CI dispatch with `empty-corpus-test=true product=landmark`
+demonstrates that the substrate-stage step exits non-zero, the
+`Run interview` step is skipped (the `if:` `success()` default
+prevents it), and the workflow run lands in the `failure` state. The
+run URL goes in the PR description.
+
+## Step 11 — Run full check suite + workflow lint
+
+```sh
+bun run check
+bun run test          # picks up the new test paths via Part 02 § Step 7
+actionlint .github/workflows/kata-interview.yml || true
+```
+
+Verify: all green. PR description lists the spec § Success Criteria
+rows this part satisfies (workspace state, sensitive-value scan,
+non-Landmark not regressed, SKILL.md reflects substrate, failure
+surfacing test), plus the operator-prerequisite list (two repo
+secrets, App `actions: read`).

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a.md
@@ -44,14 +44,12 @@ first.
 
 ## Design deviations
 
-Design-c § Supervisor experience names the JTBD-role alignment signal
-as matching the picked job's audience against the roster row's `role`
-field. The `activity.organization_people` schema on `origin/main` has
-no `role` column — the actual columns are `discipline`, `level`,
-`track`. The plan uses those three fields for the alignment signal
-(Part 02 § Step 4a roster shape; Part 03 § SKILL.md edit 8b). This is
-a deviation from the design's literal text; the design's intent
-(persona-role match) is preserved with the actual schema vocabulary.
+| Deviation | Where | Why |
+|---|---|---|
+| Roster row uses `discipline`+`level` for alignment, not `role` | Design-c § Supervisor experience names `role`; the `activity.organization_people` schema on `origin/main` has no such column. Real columns: `discipline`, `level`, `track`. | Schema reality. The plan uses `discipline`+`level` for the alignment signal (`track` informational only). Persona-role match intent preserved with actual vocabulary. |
+| Hidden `_commands` introspection verb replaces design's `bunx fit-landmark --json` | Design-c § Components row 1 names `--json` for command discovery, but libcli's existing `--json` global only renders help output, not a `COMMANDS`-map manifest. The plan adds a hidden `_commands` argv branch and a canonical `commands-manifest.js` library file. | Design's stated mechanism doesn't exist in libcli today; alternatives (extend libcli, scrape help) carry larger blast radius than a 5-line argv branch with a clean source-of-truth file. |
+| Spec § Success Criteria row 5 expansion source | Spec wants subcommand expansion "via the libcli `commands` array in the same file". The plan adds a parallel `SUBCOMMAND_EXPANSIONS`/`FLAT_SMOKE_OPTIONS` data structure in `commands-manifest.js`, with a drift-guard test asserting it stays synchronized with the bin's libcli `commands` array. | The libcli `commands` entries do not carry `needsSupabase` (only `COMMANDS` does), so naive iteration of the libcli array doesn't yield the gated subset. The drift-guard test (Part 02 § Step 8 first test) closes the door on divergence. |
+| Verification command `activity.test.js` | Spec § Success Criteria row 11 names `bun test products/map/test/activity/activity.test.js`; no such file exists on `main`. | Spec inaccuracy. Plan-a-01 § Step 10 runs the directory instead and notes this discrepancy. |
 
 ## Libraries used
 
@@ -68,7 +66,8 @@ New imports introduced by this plan: `@forwardimpact/libsecret`
 | The persona-query helper builds its `evidence_count` and `practice_directs_count` aggregates client-side (multiple round-trips against the Supabase JS client). On large rosters this could OOM the stage step. The synthetic corpus today is bounded (<200 humans), so it works; a future production substrate (out of scope) would need a Postgres view or RPC. | Round-trip count is not visible from the function signature; the alternative (Postgres view in a new migration) is forbidden by spec § Out-of-scope. |
 | The atomic-write recovery contract in `substrate issue` is "rename `.env` first, then `.substrate.json`; on partial failure leave whichever landed and let the caller re-issue". This trades atomicity-across-files for simplicity. The kata-interview workspace is `mktemp -d`-fresh per run, so the worst case is one failed run, but a future caller running in a non-fresh cwd would see stale `.env` state. | The recovery shape is invisible from the spec criteria; the spec only requires "mode 0600" and "atomic rename" — the two-file atomicity gap is a deliberate design choice. |
 | The `_commands` hidden subcommand on `fit-landmark` is invoked by parsing `process.argv[2]` before libcli's `createCli` runs. If a future contributor moves the libcli call earlier in `fit-landmark.js`, the hidden verb stops working. | The branch is two lines and looks vestigial; only a runtime test (added in Part 02 § Step 8) guards it. |
-| `bunx fit-map substrate stage` discovers `SUPABASE_URL` from `supabase status --output json` after `supabase start`. If the local stack ever changes its status JSON shape (e.g. renames `api_url`), substrate-stage fails with a `[substrate stage: url-discovery]` error. | The Supabase CLI's status JSON schema is not pinned in `libconfig` or anywhere in-tree; only a smoke test against the actual CLI catches a rename. |
+| `bunx fit-map substrate stage` discovers `SUPABASE_URL` and `SUPABASE_ANON_KEY` from `supabase status --output json` after `supabase start`. If the local stack ever changes its status JSON shape (e.g. renames `api_url` or `anon_key`), substrate-stage fails with a `[substrate stage: url-discovery]` error. | The Supabase CLI's status JSON schema is not pinned in `libconfig` or anywhere in-tree; only a smoke test against the actual CLI catches a rename. |
+| The kata-agent-team GitHub App installation must carry `Actions: Read` repository permission for Part 03's log-scan step's `gh api .../actions/runs/<id>/logs` call to succeed. The workflow-level `permissions:` block does not govern the App token — only App-settings permissions do. | This prerequisite is invisible from the plan files; it's an operator action recorded only in the PR description (Part 03 § Step 2). A misconfigured App fails the scan step at runtime with `403`. |
 
 ## Execution recommendation
 

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a.md
@@ -1,0 +1,94 @@
+# Plan 990-a — Supervisor-Driven Persona Pick via `fit-map substrate`
+
+Spec: [`spec.md`](spec.md) (`spec approved`). Design:
+[`design-c.md`](design-c.md) (`design approved`). plan-a is the first plan;
+no alternatives proposed.
+
+## Approach
+
+Close the identity-layering anomaly first, then build the substrate verbs
+on top, then wire CI + skill last. Part 01 renames `LANDMARK_AUTH_TOKEN`
+→ `PRODUCT_LANDMARK_TOKEN`, registers `token` as a known param on the
+Landmark config, and extends the libconfig override loop to consult
+`#envOverrides` (with empty-string-treated-as-absent semantics so the
+Part 03 ternary cannot clobber a `.env` value). Part 02 adds three
+`fit-map substrate` subcommands — `stage` (workspace-prep gate that
+runs stack/url-discovery/migrate/seed/provision + a self-smoke that
+exercises every gated Landmark command via a new `_gated-commands`
+introspection verb on `fit-landmark`), `roster` (read-only invariant-
+satisfying persona list), `issue` (atomic `.env` + `.substrate.json`
+write). Part 03 wires `kata-interview.yml` (substrate-stage step,
+JWT-only log scan with `actions: read` permission, Run-interview env
+additions all Landmark-gated) and updates the `kata-interview` skill
+(Step 3 row, new Step 3a, read-do checklist amendment). Each part is
+independently verifiable; later parts depend on earlier parts shipping
+first.
+
+## Parts
+
+| Part | Title | Depends on |
+|---|---|---|
+| [`plan-a-01.md`](plan-a-01.md) | libconfig override-loop fix + `PRODUCT_LANDMARK_TOKEN` rename + docs sweep | — |
+| [`plan-a-02.md`](plan-a-02.md) | `fit-map substrate {stage, roster, issue}` + `fit-landmark _gated-commands` introspection + test-path extension | 01 (reads `config.token` via renamed env var) |
+| [`plan-a-03.md`](plan-a-03.md) | `kata-interview.yml` substrate step + persona-JWT log scan + SKILL.md updates | 02 (calls the substrate verbs and relies on the test-path extension) |
+
+## Cross-part shared contracts
+
+| Contract | Source | Consumer | Note |
+|---|---|---|---|
+| `SUBSTRATE_FORCE_EMPTY_CORPUS=true` env var | Part 03 workflow input → step env | Part 02 `substrate-stage.js` short-circuit | Part 02 must check `process.env.SUBSTRATE_FORCE_EMPTY_CORPUS === "true"` even though the only caller landing in CI is Part 03's input |
+| `bunx fit-landmark _commands` JSON manifest | Part 02 (new `commands-manifest.js` library file + bin top-level branch) | Part 02 self-smoke | Hidden CLI verb; not advertised in libcli `commands` array. The branch sits *before* the top-level `await createProductConfig` so introspection is independent of libconfig load. |
+| `package.json` `"test"` script find-scope expansion | Part 02 § Step 7 | Part 03's `.github/workflows/test/` + `.claude/skills/kata-interview/test/` test files | Scoped to those two specific paths (not the whole `.claude/skills/` tree). Without this expansion, Part 03's CI invariants land but never execute |
+| `SUPABASE_URL` via `$GITHUB_ENV` | Part 03 § Step 3 (workflow shell write) | Subsequent workflow steps (`Run interview`'s supervisor calls to `bunx fit-map substrate roster/issue`) | The Node process running `bunx fit-map substrate stage` sets `process.env.SUPABASE_URL` for its own children; cross-step propagation requires `$GITHUB_ENV` |
+| Persona-JWT snapshot via `$GITHUB_OUTPUT` + `::add-mask::` | Part 03 § Step 3b (`Snapshot persona JWT` step) | Part 03 § Step 6 separate `workflow_run`-triggered scan workflow | Snapshot taken right after `Run interview` so the agent's mutations to `.env` (Write/Edit tools) cannot tamper with the value the scan checks against |
+
+## Design deviations
+
+Design-c § Supervisor experience names the JTBD-role alignment signal
+as matching the picked job's audience against the roster row's `role`
+field. The `activity.organization_people` schema on `origin/main` has
+no `role` column — the actual columns are `discipline`, `level`,
+`track`. The plan uses those three fields for the alignment signal
+(Part 02 § Step 4a roster shape; Part 03 § SKILL.md edit 8b). This is
+a deviation from the design's literal text; the design's intent
+(persona-role match) is preserved with the actual schema vocabulary.
+
+## Libraries used
+
+New imports introduced by this plan: `@forwardimpact/libsecret`
+(`mintSupabaseJwt`, `parseDuration`) — already used by the existing
+`fit-map auth issue` command, no new dependency.
+
+## Risks
+
+| Risk | Why the implementer cannot see it |
+|---|---|
+| Self-smoke spawns `bunx fit-landmark` and that subprocess constructs `createProductConfig("landmark", { token: undefined })`, which only resolves the JWT via `process.env.PRODUCT_LANDMARK_TOKEN`. The smoke must pass the JWT via spawn-options `env`, not the parent `process.env`, or it leaks into other tools the test harness invokes. | Spawn-options `env` vs. shell-inherited `env` is a Node footgun: `spawnSync(cmd, args, { env: {...process.env, X: y} })` keeps the JWT scoped to the child only. Easy to miss without an explicit assertion. |
+| GitHub Actions auto-masks any value registered as a repo secret to `***` in run logs, so scanning for `SUPABASE_JWT_SECRET` / `SUPABASE_SERVICE_ROLE_KEY` literals is structurally a no-op. Only the per-run persona JWT (minted dynamically, not registered) is at risk. Part 03's scan is therefore intentionally narrow. | The auto-masking behaviour is documented at the platform level, not in the workflow file itself; a reviewer who expects a broader scan needs the rationale spelled out. |
+| The persona-query helper builds its `evidence_count` and `practice_directs_count` aggregates client-side (multiple round-trips against the Supabase JS client). On large rosters this could OOM the stage step. The synthetic corpus today is bounded (<200 humans), so it works; a future production substrate (out of scope) would need a Postgres view or RPC. | Round-trip count is not visible from the function signature; the alternative (Postgres view in a new migration) is forbidden by spec § Out-of-scope. |
+| The atomic-write recovery contract in `substrate issue` is "rename `.env` first, then `.substrate.json`; on partial failure leave whichever landed and let the caller re-issue". This trades atomicity-across-files for simplicity. The kata-interview workspace is `mktemp -d`-fresh per run, so the worst case is one failed run, but a future caller running in a non-fresh cwd would see stale `.env` state. | The recovery shape is invisible from the spec criteria; the spec only requires "mode 0600" and "atomic rename" — the two-file atomicity gap is a deliberate design choice. |
+| The `_gated-commands` hidden subcommand on `fit-landmark` is invoked by parsing `process.argv[2]` before libcli's `createCli` runs. If a future contributor moves the libcli call earlier in `fit-landmark.js`, the hidden verb stops working. | The branch is two lines and looks vestigial; only a runtime test (added in Part 02 § Step 8) guards it. |
+| `bunx fit-map substrate stage` discovers `SUPABASE_URL` from `supabase status --output json` after `supabase start`. If the local stack ever changes its status JSON shape (e.g. renames `api_url`), substrate-stage fails with a `[substrate stage: url-discovery]` error. | The Supabase CLI's status JSON schema is not pinned in `libconfig` or anywhere in-tree; only a smoke test against the actual CLI catches a rename. |
+
+## Execution recommendation
+
+Sequential by part; each part is its own PR titled `plan(990): <part summary>`.
+
+- **Part 01** — `staff-engineer` (engineering agent). Renames a public
+  env-var and touches `libconfig` core; needs the test-suite contract
+  preservation check from spec § Success Criteria row 11.
+- **Part 02** — `staff-engineer`. New product surface (`fit-map
+  substrate *` and `fit-landmark _gated-commands`) with full test
+  coverage; isolated from Part 03.
+- **Part 03** — `staff-engineer` for the workflow YAML (CI gating logic
+  is engineering), paired with `technical-writer` for the SKILL.md
+  changes in the same PR (Step 3 row, new Step 3a, read-do-checklist
+  line). The Skill changes are purely documentation; pairing them in
+  one PR keeps the spec § *kata-interview skill alignment* check
+  coherent with the workflow it describes. **Cannot run in parallel
+  with Part 02** — Part 03's CI smoke invokes the substrate verbs Part
+  02 ships, and the test-path extension in Part 02 § Step 7 is what
+  makes Part 03's new tests run.
+
+Parts 01 and 02 must merge before Part 03 is opened; Part 02's tests
+must be green before Part 03's workflow step references the verbs.

--- a/specs/990-kata-interview-real-landmark-substrate/plan-a.md
+++ b/specs/990-kata-interview-real-landmark-substrate/plan-a.md
@@ -14,7 +14,7 @@ Landmark config, and extends the libconfig override loop to consult
 Part 03 ternary cannot clobber a `.env` value). Part 02 adds three
 `fit-map substrate` subcommands — `stage` (workspace-prep gate that
 runs stack/url-discovery/migrate/seed/provision + a self-smoke that
-exercises every gated Landmark command via a new `_gated-commands`
+exercises every gated Landmark command via a new `_commands`
 introspection verb on `fit-landmark`), `roster` (read-only invariant-
 satisfying persona list), `issue` (atomic `.env` + `.substrate.json`
 write). Part 03 wires `kata-interview.yml` (substrate-stage step,
@@ -29,7 +29,7 @@ first.
 | Part | Title | Depends on |
 |---|---|---|
 | [`plan-a-01.md`](plan-a-01.md) | libconfig override-loop fix + `PRODUCT_LANDMARK_TOKEN` rename + docs sweep | — |
-| [`plan-a-02.md`](plan-a-02.md) | `fit-map substrate {stage, roster, issue}` + `fit-landmark _gated-commands` introspection + test-path extension | 01 (reads `config.token` via renamed env var) |
+| [`plan-a-02.md`](plan-a-02.md) | `fit-map substrate {stage, roster, issue}` + `fit-landmark _commands` introspection + test-path extension | 01 (reads `config.token` via renamed env var) |
 | [`plan-a-03.md`](plan-a-03.md) | `kata-interview.yml` substrate step + persona-JWT log scan + SKILL.md updates | 02 (calls the substrate verbs and relies on the test-path extension) |
 
 ## Cross-part shared contracts
@@ -40,7 +40,7 @@ first.
 | `bunx fit-landmark _commands` JSON manifest | Part 02 (new `commands-manifest.js` library file + bin top-level branch) | Part 02 self-smoke | Hidden CLI verb; not advertised in libcli `commands` array. The branch sits *before* the top-level `await createProductConfig` so introspection is independent of libconfig load. |
 | `package.json` `"test"` script find-scope expansion | Part 02 § Step 7 | Part 03's `.github/workflows/test/` + `.claude/skills/kata-interview/test/` test files | Scoped to those two specific paths (not the whole `.claude/skills/` tree). Without this expansion, Part 03's CI invariants land but never execute |
 | `SUPABASE_URL` via `$GITHUB_ENV` | Part 03 § Step 3 (workflow shell write) | Subsequent workflow steps (`Run interview`'s supervisor calls to `bunx fit-map substrate roster/issue`) | The Node process running `bunx fit-map substrate stage` sets `process.env.SUPABASE_URL` for its own children; cross-step propagation requires `$GITHUB_ENV` |
-| Persona-JWT snapshot via `$GITHUB_OUTPUT` + `::add-mask::` | Part 03 § Step 3b (`Snapshot persona JWT` step) | Part 03 § Step 6 separate `workflow_run`-triggered scan workflow | Snapshot taken right after `Run interview` so the agent's mutations to `.env` (Write/Edit tools) cannot tamper with the value the scan checks against |
+| `substrate issue --stash <path>` flag | Part 02 (`substrate-issue.js`) | Part 03 supervisor invocation (SKILL.md Step 3a) → Part 03 inline log-scan step (`$RUNNER_TEMP/.persona-jwt`) | Optional flag writes the bare JWT to a workflow-protected path outside `$AGENT_CWD`; the scan step reads from there because the agent has no access to `$RUNNER_TEMP` |
 
 ## Design deviations
 
@@ -67,7 +67,7 @@ New imports introduced by this plan: `@forwardimpact/libsecret`
 | GitHub Actions auto-masks any value registered as a repo secret to `***` in run logs, so scanning for `SUPABASE_JWT_SECRET` / `SUPABASE_SERVICE_ROLE_KEY` literals is structurally a no-op. Only the per-run persona JWT (minted dynamically, not registered) is at risk. Part 03's scan is therefore intentionally narrow. | The auto-masking behaviour is documented at the platform level, not in the workflow file itself; a reviewer who expects a broader scan needs the rationale spelled out. |
 | The persona-query helper builds its `evidence_count` and `practice_directs_count` aggregates client-side (multiple round-trips against the Supabase JS client). On large rosters this could OOM the stage step. The synthetic corpus today is bounded (<200 humans), so it works; a future production substrate (out of scope) would need a Postgres view or RPC. | Round-trip count is not visible from the function signature; the alternative (Postgres view in a new migration) is forbidden by spec § Out-of-scope. |
 | The atomic-write recovery contract in `substrate issue` is "rename `.env` first, then `.substrate.json`; on partial failure leave whichever landed and let the caller re-issue". This trades atomicity-across-files for simplicity. The kata-interview workspace is `mktemp -d`-fresh per run, so the worst case is one failed run, but a future caller running in a non-fresh cwd would see stale `.env` state. | The recovery shape is invisible from the spec criteria; the spec only requires "mode 0600" and "atomic rename" — the two-file atomicity gap is a deliberate design choice. |
-| The `_gated-commands` hidden subcommand on `fit-landmark` is invoked by parsing `process.argv[2]` before libcli's `createCli` runs. If a future contributor moves the libcli call earlier in `fit-landmark.js`, the hidden verb stops working. | The branch is two lines and looks vestigial; only a runtime test (added in Part 02 § Step 8) guards it. |
+| The `_commands` hidden subcommand on `fit-landmark` is invoked by parsing `process.argv[2]` before libcli's `createCli` runs. If a future contributor moves the libcli call earlier in `fit-landmark.js`, the hidden verb stops working. | The branch is two lines and looks vestigial; only a runtime test (added in Part 02 § Step 8) guards it. |
 | `bunx fit-map substrate stage` discovers `SUPABASE_URL` from `supabase status --output json` after `supabase start`. If the local stack ever changes its status JSON shape (e.g. renames `api_url`), substrate-stage fails with a `[substrate stage: url-discovery]` error. | The Supabase CLI's status JSON schema is not pinned in `libconfig` or anywhere in-tree; only a smoke test against the actual CLI catches a rename. |
 
 ## Execution recommendation
@@ -78,7 +78,7 @@ Sequential by part; each part is its own PR titled `plan(990): <part summary>`.
   env-var and touches `libconfig` core; needs the test-suite contract
   preservation check from spec § Success Criteria row 11.
 - **Part 02** — `staff-engineer`. New product surface (`fit-map
-  substrate *` and `fit-landmark _gated-commands`) with full test
+  substrate *` and `fit-landmark _commands`) with full test
   coverage; isolated from Part 03.
 - **Part 03** — `staff-engineer` for the workflow YAML (CI gating logic
   is engineering), paired with `technical-writer` for the SKILL.md


### PR DESCRIPTION
## Summary

Plan-a implements design-c (supervisor-driven persona pick via `fit-map substrate`) for spec 990 — turning every Landmark-targeted `kata-interview` run into one that surfaces real product gaps instead of CI-substrate gaps.

Decomposed into three sequential parts:

- **plan-a-01** — libconfig credential override-loop fix + `LANDMARK_AUTH_TOKEN` → `PRODUCT_LANDMARK_TOKEN` rename + docs sweep. Closes the identity layering anomaly identified in design-c § Architectural insight.
- **plan-a-02** — `fit-map substrate {stage, roster, issue}` verbs, new `fit-landmark _commands` hidden introspection verb backed by a canonical `commands-manifest.js` library file, persona-query helper that uses the actual `activity` schema (joins evidence through `github_artifacts.email`, not the non-existent `evidence.author_email`), and substrate-issue's optional `--stash` flag that surfaces the JWT into a workflow-protected path.
- **plan-a-03** — `kata-interview.yml` substrate-stage step with `SUPABASE_URL` + `SUPABASE_ANON_KEY` propagated via `$GITHUB_ENV`, inline post-run log scan reading the JWT from `$RUNNER_TEMP/.persona-jwt`, plus SKILL.md amendments for the new Step 3a persona-pick flow and the read-do-checklist line rewrite.

Plan went through **four rounds** of clean sub-agent review panels (3 reviewers each). Every consensus blocker, high, and medium finding from rounds 1–4 was addressed in the iteration that surfaced it; remaining findings are non-consensus refinements suitable for in-PR handling.

## Operator prerequisites (before Part 03 merges)

1. Configure two new GH repo secrets: `SUPABASE_JWT_SECRET` and `SUPABASE_SERVICE_ROLE_KEY` (values from `just env-setup`).
2. Verify the **kata-agent-team GitHub App** installation carries the `Actions: Read` repository permission — required by Part 03's `gh api .../actions/runs/<id>/logs` call. Workflow-level `permissions:` blocks do not govern App tokens; App-settings permission is the actual prerequisite.

## Test plan

- [ ] Part 01 merges and `bun test products/landmark/test/lib/identity.test.js` + `bun test libraries/libconfig/test/` pass green.
- [ ] Part 02 merges and `bun test products/map/test/activity/substrate-*.test.js` + `bun test products/landmark/test/lib/commands-manifest.test.js` pass green.
- [ ] Part 03 merges and a Landmark `kata-interview` workflow dispatch:
  - completes substrate-stage in < 5 minutes,
  - reaches the agent step with `$AGENT_CWD/.env` + `$AGENT_CWD/.substrate.json` written and `$RUNNER_TEMP/.persona-jwt` stashed,
  - exits 0 on the "Scan logs for sensitive values" step (no JWT / secret literal in run logs).
- [ ] A separate `kata-interview` dispatch with `empty-corpus-test=true` exits non-zero on the substrate-stage step and skips `Run interview`.
- [ ] A non-Landmark `kata-interview` dispatch shows zero substrate-stage / scan-step execution (workflow-shape test pins this).

https://claude.ai/code/session_01PNhHAmLt6SVkWXeXSzj8tp

— Staff Engineer 🛠️

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNhHAmLt6SVkWXeXSzj8tp)_