### PR TITLE
fix: remove stray dashes from kata-interview workflow name

### DIFF
--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -1,4 +1,4 @@
-name: "Kata:–- Interview"
+name: "Kata: Interview"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The workflow name contained an en-dash and hyphen ("Kata:–-
Interview"). Clean it up to "Kata: Interview".