### PR TITLE
plan(990): kata-interview real-landmark substrate + spec(1000) follow-up

### DIFF
--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -26,10 +26,9 @@ This skill is not part of scheduled runs.
 
 ## LLM Availability
 
-`ANTHROPIC_API_KEY` is present in the shell — `libconfig` reads it.
-LLM-backed products (Guide, Outpost) should work zero-config. If the agent
-is asked to supply a key, that is a **bug** — the zero-config promise is
-broken. Do not tell the agent the key is pre-configured.
+`ANTHROPIC_API_KEY` is in the shell — `libconfig` reads it. LLM-backed
+products (Guide, Outpost) work zero-config; if the agent asks for a key,
+that is a **bug**. Do not tell the agent the key is pre-configured.
 
 ## Checklists
 
@@ -38,7 +37,7 @@ broken. Do not tell the agent the key is pre-configured.
 - [ ] Persona identity drawn from synthetic content (per Step 4) — not invented.
 - [ ] Persona situation drawn from the chosen JTBD entry (per Step 4).
 - [ ] Job text appears only in Ask 2 — never in `CLAUDE.md`.
-- [ ] No product names anywhere agent-visible.
+- [ ] No product names in the persona file or in supervisor-authored Ask templates; product-named environment variables required by the production CLI are permitted in the agent's environment.
 - [ ] Workspace staged per Step 3; `CLAUDE.md` written before Ask 1.
 - [ ] No leaks of monorepo internals, skills, or pre-configured tokens.
 - [ ] Do not fix problems for the agent — friction is the signal.
@@ -77,17 +76,37 @@ Hire, Competes With, Forces (Push, Pull, Habit, Anxiety), Fired When.
 
 ### Step 3: Stage the Agent Workspace
 
-The workflow has run `bunx fit-terrain build` and installed `supabase`.
+The workflow ran `bunx fit-terrain build` and installed `supabase`.
 Copy the subset the chosen product needs into `$AGENT_CWD`:
 
-| Product          | Stage into `$AGENT_CWD`                                                                  |
-| ---------------- | ---------------------------------------------------------------------------------------- |
-| Guide, Outpost   | nothing                                                                                  |
-| Pathway          | `data/pathway/`                                                                          |
-| Map, Landmark    | `data/pathway/` and `data/activity/`                                                     |
-| Summit           | `data/pathway/` and `data/activity/raw/activity/summit.yaml` (as `summit.yaml` at root)  |
+| Product          | Stage into `$AGENT_CWD`                                                                                                                            |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Guide, Outpost   | nothing                                                                                                                                            |
+| Pathway          | `data/pathway/`                                                                                                                                    |
+| Map              | `data/pathway/` and `data/activity/`                                                                                                               |
+| Landmark         | `data/pathway/` and `data/activity/`; substrate (`auth.users` for all humans, schema, seed, smoke) staged by the workflow's `Substrate stage` step |
+| Summit           | `data/pathway/` and `data/activity/raw/activity/summit.yaml` (as `summit.yaml` at root)                                                            |
 
 Use `cp -r data/pathway "$AGENT_CWD/data/pathway"` and similar.
+
+### Step 3a: Pick the Persona (Landmark only)
+
+For **Landmark**, the workflow already brought up the substrate. Before
+`CLAUDE.md`, pick a persona and seal identity:
+
+1. `bunx fit-map substrate roster --format json` lists candidates
+   (`email`, `discipline`, `level`, `manager_email`, `snapshot_id`,
+   `item_id`).
+2. Pick using **memory diversification** (skip personas in your last 5
+   log entries) and **JTBD-role alignment** (`discipline`/`level`;
+   `track` is informational).
+3. `bunx fit-map substrate issue --email <picked> --cwd "$AGENT_CWD"
+   --stash "$RUNNER_TEMP/.persona-jwt"` writes `.env`, `.substrate.json`,
+   and a workflow-private JWT copy (mode 0600 on all three). You never
+   see the JWT bytes; the agent has no `$RUNNER_TEMP` access.
+
+If either verb exits non-zero, write a diagnostic naming the verb and
+exit the skill — do not proceed to Step 4.
 
 ### Step 4: Craft the Persona
 
@@ -134,9 +153,8 @@ back to the agent.
 
 ### Step 7: Transition to Post-Interview
 
-Once the persona is done or has abandoned, stop sending work and proceed
-to Steps 8–9 in the same turn. Conclude only after filing issues and
-writing the report.
+Once done or abandoned, stop sending work and proceed to Steps 8–9 in
+the same turn. Conclude only after filing issues and writing the report.
 
 ### Step 8: Capture Findings
 

--- a/.claude/skills/kata-interview/test/skill-shape.test.js
+++ b/.claude/skills/kata-interview/test/skill-shape.test.js
@@ -1,0 +1,46 @@
+/**
+ * Shape assertion for the kata-interview SKILL.md amendments from spec
+ * 990. Guards three invariants from spec § *Kata-interview skill
+ * alignment*:
+ *   - Step 3 staging table mentions substrate on the Landmark row.
+ *   - Step 3a (Landmark persona pick) names the substrate verbs.
+ *   - The read-do-checklist line is the amended wording (the literal
+ *     "No product names anywhere agent-visible" must be gone).
+ *   - Step 4 CLAUDE.md exclusion list is unchanged.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILL_PATH = join(__dirname, "..", "SKILL.md");
+const skill = readFileSync(SKILL_PATH, "utf8");
+
+describe("kata-interview SKILL.md spec 990 amendments", () => {
+  it("Step 3 staging table Landmark row mentions substrate", () => {
+    assert.match(skill, /\| Landmark\s+\|.*substrate.*staged.*\|/);
+  });
+
+  it("Step 3a (Landmark persona pick) names the substrate verbs", () => {
+    assert.match(skill, /fit-map substrate roster/);
+    assert.match(skill, /fit-map substrate issue/);
+  });
+
+  it("read-do checklist line is amended verbatim", () => {
+    assert.doesNotMatch(skill, /No product names anywhere agent-visible/);
+    assert.match(
+      skill,
+      /product-named environment variables required by the production CLI are permitted in the agent's environment/,
+    );
+  });
+
+  it("Step 4 CLAUDE.md exclusion list is unchanged", () => {
+    assert.match(
+      skill,
+      /Excluded: goal sentence, Big Hire, Little Hire, Fired-When, product name/,
+    );
+  });
+});

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -159,18 +159,21 @@ jobs:
           # Download the in-progress run's log archive. GH serves the
           # archive of all completed-step logs even while the run is
           # active; only the scan step's own logs are excluded — fine,
-          # since the scan step never echoes the JWT.
+          # since the scan step never echoes the JWT. Spec § Success
+          # Criteria row 8 requires the assertion to fire non-zero on a
+          # literal hit; a fail-open `exit 0` on download failure would
+          # silently disarm the gate, so we fail closed.
           if ! gh api -H "Accept: application/vnd.github+json" \
               "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/logs" \
               > /tmp/run-logs.zip 2>/tmp/gh-err.log; then
-            echo "WARN: log archive not yet available — gh api stderr:" >&2
+            echo "FAIL: log archive download failed — gh api stderr:" >&2
             cat /tmp/gh-err.log >&2
-            echo "Relying on ::add-mask:: at-issue protection."
-            exit 0
+            echo "App installation must carry 'Actions: Read'; see PR description." >&2
+            exit 1
           fi
           if ! unzip -q /tmp/run-logs.zip -d /tmp/run-logs/; then
-            echo "WARN: log archive empty/unreadable; relying on ::add-mask::"
-            exit 0
+            echo "FAIL: log archive empty/unreadable — cannot verify scan." >&2
+            exit 1
           fi
 
           fail=0

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -15,6 +15,11 @@ on:
         description: "Additional text appended to the task prompt for steering"
         required: false
         type: string
+      empty-corpus-test:
+        description: "Force substrate-stage to see an empty corpus (CI assertion)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: kata-interview
@@ -26,6 +31,7 @@ permissions:
 jobs:
   interview:
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     steps:
       - name: Generate installation token
         id: ci-app
@@ -62,6 +68,36 @@ jobs:
 
           echo "dir=$agent_dir" >> "$GITHUB_OUTPUT"
 
+      - name: Substrate stage
+        id: substrate-stage
+        if: inputs.product == 'landmark'
+        shell: bash
+        env:
+          SUPABASE_JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUBSTRATE_FORCE_EMPTY_CORPUS: ${{ inputs.empty-corpus-test }}
+        run: |
+          # Provision $AGENT_CWD/config/ so libconfig's findUpward("config")
+          # resolves uniformly from the agent's cwd.
+          mkdir -p "${{ steps.agent-workspace.outputs.dir }}/config"
+          bunx fit-map substrate stage
+
+          # Propagate the local Supabase URL + anon key to subsequent
+          # workflow steps. The Node process running `bunx fit-map
+          # substrate stage` sets these in its own process.env only;
+          # the supervisor's later `bunx fit-map substrate roster/issue`
+          # invocations and the agent's `fit-landmark` spawns need them
+          # via $GITHUB_ENV.
+          status_json=$(bunx --no-install -- supabase status --output json)
+          api_url=$(echo "$status_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["api_url"])')
+          anon_key=$(echo "$status_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["anon_key"])')
+          if [ -z "$api_url" ] || [ -z "$anon_key" ]; then
+            echo "FAIL: supabase status did not yield api_url + anon_key" >&2
+            exit 1
+          fi
+          echo "SUPABASE_URL=$api_url" >> "$GITHUB_ENV"
+          echo "SUPABASE_ANON_KEY=$anon_key" >> "$GITHUB_ENV"
+
       - name: Compose task amendment
         id: amend
         shell: bash
@@ -84,6 +120,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
+          AGENT_CWD: ${{ inputs.product == 'landmark' && steps.agent-workspace.outputs.dir || '' }}
+          SUPABASE_JWT_SECRET: ${{ inputs.product == 'landmark' && secrets.SUPABASE_JWT_SECRET || '' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ inputs.product == 'landmark' && secrets.SUPABASE_SERVICE_ROLE_KEY || '' }}
         with:
           mode: "supervise"
           task-text: |
@@ -99,3 +138,57 @@ jobs:
           allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,WebFetch,WebSearch"
           supervisor-allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,Skill,TodoWrite"
           task-amend: ${{ steps.amend.outputs.amend }}
+
+      - name: Scan logs for sensitive values
+        if: always() && inputs.product == 'landmark'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+          JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
+          SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          stash="$RUNNER_TEMP/.persona-jwt"
+          if [ ! -f "$stash" ]; then
+            echo "No persona-JWT stash at $stash — substrate issue did not run."
+            persona_jwt=""
+          else
+            persona_jwt=$(cat "$stash")
+            echo "::add-mask::$persona_jwt"
+          fi
+
+          # Download the in-progress run's log archive. GH serves the
+          # archive of all completed-step logs even while the run is
+          # active; only the scan step's own logs are excluded — fine,
+          # since the scan step never echoes the JWT.
+          if ! gh api -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/logs" \
+              > /tmp/run-logs.zip 2>/tmp/gh-err.log; then
+            echo "WARN: log archive not yet available — gh api stderr:" >&2
+            cat /tmp/gh-err.log >&2
+            echo "Relying on ::add-mask:: at-issue protection."
+            exit 0
+          fi
+          if ! unzip -q /tmp/run-logs.zip -d /tmp/run-logs/; then
+            echo "WARN: log archive empty/unreadable; relying on ::add-mask::"
+            exit 0
+          fi
+
+          fail=0
+          # Spec § Success Criteria row 8: scan for all three literals.
+          # GH Actions auto-masks the two repo secrets, so grepping for
+          # them is normally a no-op — but the scan still performs the
+          # grep so the criterion is satisfied literally and to catch the
+          # unlikely case where GH's masker fails on a partial match.
+          for pair in \
+              "persona-jwt:$persona_jwt" \
+              "jwt-secret:$JWT_SECRET" \
+              "service-role-key:$SERVICE_ROLE_KEY"; do
+            label="${pair%%:*}"
+            value="${pair#*:}"
+            [ -z "$value" ] && continue
+            if grep -RFq -- "$value" /tmp/run-logs/; then
+              echo "FAIL: $label literal in run logs" >&2
+              fail=1
+            fi
+          done
+          exit $fail

--- a/.github/workflows/test/kata-interview-shape.test.js
+++ b/.github/workflows/test/kata-interview-shape.test.js
@@ -1,0 +1,64 @@
+/**
+ * Workflow-shape assertion for spec 990 § *Non-Landmark interviews are
+ * not regressed*. Parses `.github/workflows/kata-interview.yml` as YAML
+ * and verifies every step + every Run-interview env key added by spec
+ * 990 carries a Landmark predicate, and the interview job declares a
+ * timeout-minutes strictly less than the JWT's 1-hour default TTL.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WORKFLOW_PATH = join(__dirname, "..", "kata-interview.yml");
+
+const wf = parse(readFileSync(WORKFLOW_PATH, "utf8"));
+const steps = wf.jobs.interview.steps;
+
+const ADDED_STEPS = ["Substrate stage", "Scan logs for sensitive values"];
+// Every key added to `Run interview`'s env by spec 990. Must match what
+// Step 4 of plan-a-03 lands. SUPABASE_URL is propagated via $GITHUB_ENV
+// (Step 3) and does not appear in the env: map here.
+const ADDED_RUN_ENV_KEYS = [
+  "AGENT_CWD",
+  "SUPABASE_JWT_SECRET",
+  "SUPABASE_SERVICE_ROLE_KEY",
+];
+
+describe("kata-interview.yml spec 990 non-Landmark invariant", () => {
+  it("every step added by spec 990 carries the Landmark predicate", () => {
+    for (const name of ADDED_STEPS) {
+      const step = steps.find((s) => s.name === name);
+      assert.ok(step, `expected step "${name}"`);
+      assert.match(
+        String(step.if),
+        /inputs\.product\s*==\s*'landmark'/,
+        `step "${name}" missing Landmark gating`,
+      );
+    }
+  });
+
+  it("every Run-interview env key added by spec 990 is Landmark-gated", () => {
+    const run = steps.find((s) => s.name === "Run interview");
+    assert.ok(run, "expected 'Run interview' step");
+    for (const key of ADDED_RUN_ENV_KEYS) {
+      assert.match(
+        String(run.env[key]),
+        /inputs\.product\s*==\s*'landmark'\s*&&[^|]+\|\|\s*''/,
+        `${key} missing Landmark ternary`,
+      );
+    }
+  });
+
+  it("interview job declares timeout-minutes < 60", () => {
+    const m = wf.jobs.interview["timeout-minutes"];
+    assert.ok(
+      typeof m === "number" && m < 60,
+      `timeout-minutes expected < 60, got ${m}`,
+    );
+  });
+});

--- a/libraries/libconfig/src/config.js
+++ b/libraries/libconfig/src/config.js
@@ -19,6 +19,19 @@ function stripQuotes(value) {
 }
 
 /**
+ * Parse an env value as JSON when possible, falling back to the raw string.
+ * @param {string} raw
+ * @returns {*}
+ */
+function parseEnvValue(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/**
  * Parses one line of a .env file.
  * @param {string} line
  * @returns {{ key: string, value: string } | null}
@@ -50,6 +63,7 @@ export class Config {
     "GH_TOKEN",
     "GITHUB_TOKEN",
     "MCP_TOKEN",
+    "PRODUCT_LANDMARK_TOKEN",
     "SUPABASE_ANON_KEY",
     "SUPABASE_SERVICE_ROLE_KEY",
     "SUPABASE_JWT_SECRET",
@@ -120,17 +134,14 @@ export class Config {
     data.url = `${data.protocol}://${data.host}:${data.port}${data.path}`;
 
     // 3. Environment overrides — SERVICE_{NAME}_{PARAM} env vars win over
-    //    config file values. These are on process.env (set by shell or by
-    //    #loadEnvFile for non-credential keys like SERVICE_MCP_URL).
+    //    config file values. Shell process.env wins over .env #envOverrides.
+    //    Credential keys treat empty string as absent so a workflow ternary
+    //    emitting '' cannot clobber a .env-supplied value; non-credential
+    //    service params keep today's empty-string-wins behaviour.
     for (const param of Object.keys(data)) {
       const varName = `${namespaceUpper}_${nameUpper}_${param.toUpperCase()}`;
-      if (this.#process.env[varName] !== undefined) {
-        try {
-          data[param] = JSON.parse(this.#process.env[varName]);
-        } catch {
-          data[param] = this.#process.env[varName];
-        }
-      }
+      const resolved = this.#resolveOverride(varName);
+      if (resolved !== undefined) data[param] = resolved;
     }
 
     // 4. Re-parse URL after overrides so host/port/protocol stay consistent
@@ -326,6 +337,29 @@ export class Config {
    */
   #env(key) {
     return this.#process.env[key] ?? this.#envOverrides[key];
+  }
+
+  /**
+   * Resolves a config-param override against shell env then #envOverrides,
+   * applying credential-key semantics (empty string treated as absent so a
+   * workflow ternary emitting '' cannot clobber a .env value). Returns the
+   * JSON-parsed value or raw string, or undefined if nothing is set.
+   * @param {string} varName - Fully-qualified env var name
+   * @returns {*|undefined}
+   * @private
+   */
+  #resolveOverride(varName) {
+    const isCredential = Config.#CREDENTIAL_KEYS.has(varName);
+    const shell = this.#process.env[varName];
+    const shellOk = isCredential
+      ? shell !== undefined && shell !== ""
+      : shell !== undefined;
+    if (shellOk) return parseEnvValue(shell);
+    const fallback = this.#envOverrides[varName];
+    const fallbackOk = isCredential
+      ? fallback !== undefined && fallback !== ""
+      : fallback !== undefined;
+    return fallbackOk ? parseEnvValue(fallback) : undefined;
   }
 
   /**

--- a/libraries/libconfig/test/credential-env-override.test.js
+++ b/libraries/libconfig/test/credential-env-override.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { createProductConfig } from "../src/index.js";
+
+// Mocked storage that always returns no config file (no findUpward walk).
+function mockStorageFn() {
+  return {
+    get: async () => null,
+    put: async () => {},
+    delete: async () => {},
+    path: () => "/dev/null/config",
+  };
+}
+
+async function setup(envContent) {
+  const tmpdir = await mkdtemp(path.join(os.tmpdir(), "credenv-"));
+  if (envContent !== null) {
+    await writeFile(path.join(tmpdir, ".env"), envContent, { mode: 0o600 });
+  }
+  return tmpdir;
+}
+
+describe("PRODUCT_LANDMARK_TOKEN credential override", () => {
+  it("loads token from .env when no shell value is set", async () => {
+    const tmpdir = await setup("PRODUCT_LANDMARK_TOKEN=test-jwt-value\n");
+    const config = await createProductConfig(
+      "landmark",
+      { token: undefined },
+      { ...process, cwd: () => tmpdir, env: { PATH: process.env.PATH } },
+      mockStorageFn,
+    );
+    assert.equal(config.token, "test-jwt-value");
+    await rm(tmpdir, { recursive: true });
+  });
+
+  it("shell env wins over .env", async () => {
+    const tmpdir = await setup("PRODUCT_LANDMARK_TOKEN=env-value\n");
+    const config = await createProductConfig(
+      "landmark",
+      { token: undefined },
+      {
+        ...process,
+        cwd: () => tmpdir,
+        env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "shell-jwt" },
+      },
+      mockStorageFn,
+    );
+    assert.equal(config.token, "shell-jwt");
+    await rm(tmpdir, { recursive: true });
+  });
+
+  it("empty-string shell value falls through to .env", async () => {
+    const tmpdir = await setup("PRODUCT_LANDMARK_TOKEN=env-value\n");
+    const config = await createProductConfig(
+      "landmark",
+      { token: undefined },
+      {
+        ...process,
+        cwd: () => tmpdir,
+        env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "" },
+      },
+      mockStorageFn,
+    );
+    // .env wins, not ""
+    assert.equal(config.token, "env-value");
+    await rm(tmpdir, { recursive: true });
+  });
+});

--- a/libraries/libconfig/test/no-supabase-env-in-src.test.js
+++ b/libraries/libconfig/test/no-supabase-env-in-src.test.js
@@ -7,11 +7,18 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, "..", "..", "..");
 
-// Permanent exemptions. Both are documented in spec 960 design § Per-module
-// injection seams. Do not add entries without a corresponding design-doc note.
+// Permanent exemptions. Documented in spec 960 design § Per-module injection
+// seams and spec 990 design-c § Three setup paths. Do not add entries without
+// a corresponding design-doc note.
 const ALLOW = new Set([
   // libstorage: libconfig depends on libstorage; threading Config would cycle.
   "libraries/libstorage/src/index.js",
+  // substrate-stage: discovers SUPABASE_URL/SUPABASE_ANON_KEY from the local
+  // stack after `supabase start` (only known post-bring-up). The values must
+  // propagate to in-process createMapClient (libconfig #env() reads
+  // process.env first); cross-step propagation is via $GITHUB_ENV in the
+  // workflow. Spec 990 design-c documents this seam.
+  "products/map/src/commands/substrate-stage.js",
 ]);
 
 // Walks one directory tree (src/ or bin/ or a flat services entry) and yields

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "format": "biome format .",
     "format:fix": "biome format --write .",
     "harness": "bun scripts/check-libharness.mjs",
-    "test": "find ./tests ./libraries ./products ./services -name '*.test.js' -not -path '*/node_modules/*' | xargs bun test",
+    "test": "find ./tests ./libraries ./products ./services ./.github/workflows/test ./.claude/skills/kata-interview/test -name '*.test.js' -not -path '*/node_modules/*' | xargs bun test",
     "test:e2e": "bunx playwright test",
     "generate": "fit-terrain build",
     "data": "bun run data:check-prose && bun run data:check-schema",

--- a/products/landmark/bin/fit-landmark.js
+++ b/products/landmark/bin/fit-landmark.js
@@ -48,7 +48,7 @@ const VERSION =
   JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"))
     .version;
 
-const config = await createProductConfig("landmark");
+const config = await createProductConfig("landmark", { token: undefined });
 
 const COMMANDS = {
   org: { handler: runOrgCommand, needsSupabase: true },

--- a/products/landmark/bin/fit-landmark.js
+++ b/products/landmark/bin/fit-landmark.js
@@ -15,20 +15,7 @@ import { fileURLToPath } from "node:url";
 import { createCli } from "@forwardimpact/libcli";
 import { createProductConfig } from "@forwardimpact/libconfig";
 
-import { runOrgCommand } from "../src/commands/org.js";
-import { runSnapshotCommand } from "../src/commands/snapshot.js";
-import { runMarkerCommand } from "../src/commands/marker.js";
-import { runEvidenceCommand } from "../src/commands/evidence.js";
-import { runReadinessCommand } from "../src/commands/readiness.js";
-import { runTimelineCommand } from "../src/commands/timeline.js";
-import { runCoverageCommand } from "../src/commands/coverage.js";
-import { runPracticeCommand } from "../src/commands/practice.js";
-import { runPracticedCommand } from "../src/commands/practiced.js";
-import { runHealthCommand } from "../src/commands/health.js";
-import { runVoiceCommand } from "../src/commands/voice.js";
-import { runSourcesCommand } from "../src/commands/sources.js";
-import { runLoginCommand } from "../src/commands/login.js";
-import { runLogoutCommand } from "../src/commands/logout.js";
+import { COMMANDS } from "../src/lib/commands-manifest.js";
 import { resolveDataDir } from "../src/lib/cli.js";
 import { buildContext } from "../src/lib/context.js";
 import { SupabaseUnavailableError } from "../src/lib/supabase.js";
@@ -37,6 +24,28 @@ import {
   IdentityUnresolvedError,
 } from "../src/lib/identity.js";
 import { formatResult } from "../src/formatters/index.js";
+
+// Hidden manifest export consumed by `fit-map substrate stage`'s self-smoke
+// (spec 990). Placed before the top-level createProductConfig() await so
+// introspection does not pay the libconfig load cost and is independent of
+// the spawn cwd's .env. The branch must sit above the top-level await — if
+// future contributors move createProductConfig earlier in this file, the
+// products/landmark/test/lib/commands-verb.test.js runtime test fails.
+if (process.argv[2] === "_commands") {
+  const { SUBCOMMAND_EXPANSIONS, FLAT_SMOKE_OPTIONS } = await import(
+    "../src/lib/commands-manifest.js"
+  );
+  // JSON.stringify drops handler function references — that's intentional:
+  // the smoke only needs needsSupabase per entry, which serialises fine.
+  process.stdout.write(
+    JSON.stringify({
+      commands: COMMANDS,
+      subcommandExpansions: SUBCOMMAND_EXPANSIONS,
+      flatSmokeOptions: FLAT_SMOKE_OPTIONS,
+    }) + "\n",
+  );
+  process.exit(0);
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -49,23 +58,6 @@ const VERSION =
     .version;
 
 const config = await createProductConfig("landmark", { token: undefined });
-
-const COMMANDS = {
-  org: { handler: runOrgCommand, needsSupabase: true },
-  snapshot: { handler: runSnapshotCommand, needsSupabase: true },
-  marker: { handler: runMarkerCommand, needsSupabase: false },
-  evidence: { handler: runEvidenceCommand, needsSupabase: true },
-  readiness: { handler: runReadinessCommand, needsSupabase: true },
-  timeline: { handler: runTimelineCommand, needsSupabase: true },
-  coverage: { handler: runCoverageCommand, needsSupabase: true },
-  practice: { handler: runPracticeCommand, needsSupabase: true },
-  practiced: { handler: runPracticedCommand, needsSupabase: true },
-  health: { handler: runHealthCommand, needsSupabase: true },
-  voice: { handler: runVoiceCommand, needsSupabase: true },
-  sources: { handler: runSourcesCommand, needsSupabase: true },
-  login: { handler: runLoginCommand, needsSupabase: false },
-  logout: { handler: runLogoutCommand, needsSupabase: false },
-};
 
 const definition = {
   name: "fit-landmark",

--- a/products/landmark/src/lib/commands-manifest.js
+++ b/products/landmark/src/lib/commands-manifest.js
@@ -1,0 +1,82 @@
+/**
+ * Canonical fit-landmark command manifest. The bin imports this and
+ * builds its dispatcher COMMANDS map from the same source; the
+ * substrate self-smoke imports it directly so its gated-command list
+ * cannot drift from the dispatcher.
+ *
+ * Each entry mirrors today's `COMMANDS` shape. `SUBCOMMAND_EXPANSIONS`
+ * and `FLAT_SMOKE_OPTIONS` describe the user-visible subcommand
+ * expansions and option placeholders the substrate-stage self-smoke
+ * supplies; placeholders are expanded at smoke-runtime against the
+ * chosen persona and discovery vector.
+ */
+
+import { runOrgCommand } from "../commands/org.js";
+import { runSnapshotCommand } from "../commands/snapshot.js";
+import { runMarkerCommand } from "../commands/marker.js";
+import { runEvidenceCommand } from "../commands/evidence.js";
+import { runReadinessCommand } from "../commands/readiness.js";
+import { runTimelineCommand } from "../commands/timeline.js";
+import { runCoverageCommand } from "../commands/coverage.js";
+import { runPracticeCommand } from "../commands/practice.js";
+import { runPracticedCommand } from "../commands/practiced.js";
+import { runHealthCommand } from "../commands/health.js";
+import { runVoiceCommand } from "../commands/voice.js";
+import { runSourcesCommand } from "../commands/sources.js";
+import { runLoginCommand } from "../commands/login.js";
+import { runLogoutCommand } from "../commands/logout.js";
+
+export const COMMANDS = {
+  org: { handler: runOrgCommand, needsSupabase: true },
+  snapshot: { handler: runSnapshotCommand, needsSupabase: true },
+  marker: { handler: runMarkerCommand, needsSupabase: false },
+  evidence: { handler: runEvidenceCommand, needsSupabase: true },
+  readiness: { handler: runReadinessCommand, needsSupabase: true },
+  timeline: { handler: runTimelineCommand, needsSupabase: true },
+  coverage: { handler: runCoverageCommand, needsSupabase: true },
+  practice: { handler: runPracticeCommand, needsSupabase: true },
+  practiced: { handler: runPracticedCommand, needsSupabase: true },
+  health: { handler: runHealthCommand, needsSupabase: true },
+  voice: { handler: runVoiceCommand, needsSupabase: true },
+  sources: { handler: runSourcesCommand, needsSupabase: true },
+  login: { handler: runLoginCommand, needsSupabase: false },
+  logout: { handler: runLogoutCommand, needsSupabase: false },
+};
+
+// User-visible subcommand expansions for top-level COMMANDS keys whose
+// libcli `commands` array entries use space-separated names. Each entry
+// names the option flags substrate-stage must supply with placeholders
+// expanded at smoke-runtime: $PERSONA_EMAIL, $SNAPSHOT_ID, $ITEM_ID.
+export const SUBCOMMAND_EXPANSIONS = {
+  org: [
+    { command: "org show", smokeOptions: {} },
+    { command: "org team", smokeOptions: { manager: "$PERSONA_EMAIL" } },
+  ],
+  snapshot: [
+    { command: "snapshot list", smokeOptions: {} },
+    { command: "snapshot show", smokeOptions: { snapshot: "$SNAPSHOT_ID" } },
+    { command: "snapshot trend", smokeOptions: { item: "$ITEM_ID" } },
+    {
+      command: "snapshot compare",
+      smokeOptions: { snapshot: "$SNAPSHOT_ID" },
+    },
+  ],
+};
+
+// Flat (non-subcommand-style) command options. Every gated command whose
+// handler throws on missing args must appear here so the spec 990 § Success
+// Criteria row 5 smoke runs to non-error completion.
+//   - voice.js: throws if neither --email nor --manager supplied
+//   - practiced.js: throws on missing --manager
+//   - health.js: no required option
+export const FLAT_SMOKE_OPTIONS = {
+  evidence: { email: "$PERSONA_EMAIL" },
+  practice: { manager: "$PERSONA_EMAIL" },
+  practiced: { manager: "$PERSONA_EMAIL" },
+  readiness: { email: "$PERSONA_EMAIL" },
+  timeline: { email: "$PERSONA_EMAIL" },
+  coverage: { email: "$PERSONA_EMAIL" },
+  sources: { email: "$PERSONA_EMAIL" },
+  voice: { email: "$PERSONA_EMAIL" },
+  // health — no required option
+};

--- a/products/landmark/src/lib/identity.js
+++ b/products/landmark/src/lib/identity.js
@@ -30,43 +30,43 @@ function parseJwtSegment(seg, label) {
     raw = Buffer.from(seg, "base64url").toString("utf8");
   } catch {
     throw new IdentityUnresolvedError(
-      `LANDMARK_AUTH_TOKEN ${label} is not valid base64url`,
+      `PRODUCT_LANDMARK_TOKEN ${label} is not valid base64url`,
     );
   }
   try {
     return JSON.parse(raw);
   } catch {
     throw new IdentityUnresolvedError(
-      `LANDMARK_AUTH_TOKEN ${label} is not valid JSON`,
+      `PRODUCT_LANDMARK_TOKEN ${label} is not valid JSON`,
     );
   }
 }
 
 /**
  * Validate the structure, expiry, and (when the secret is available)
- * HMAC of `LANDMARK_AUTH_TOKEN`. Returns the resolved identity. The
- * production engineer-side path runs without the secret — the JWT is
- * trusted at the shape level, and Postgres rejects forgeries at the
- * RLS clamp on the next round trip.
+ * HMAC of the caller's JWT (sourced from `config.token`). Returns the
+ * resolved identity. The production engineer-side path runs without
+ * the secret — the JWT is trusted at the shape level, and Postgres
+ * rejects forgeries at the RLS clamp on the next round trip.
  */
 function resolveFromJwt(jwt, config) {
   const parts = jwt.split(".");
   if (parts.length !== 3)
-    throw new IdentityUnresolvedError("LANDMARK_AUTH_TOKEN is not a JWT");
+    throw new IdentityUnresolvedError("PRODUCT_LANDMARK_TOKEN is not a JWT");
 
   const header = parseJwtSegment(parts[0], "header");
   if (header.alg !== "HS256" || header.typ !== "JWT")
     throw new IdentityUnresolvedError(
-      "LANDMARK_AUTH_TOKEN header rejected (HS256 + JWT required)",
+      "PRODUCT_LANDMARK_TOKEN header rejected (HS256 + JWT required)",
     );
 
   const claims = parseJwtSegment(parts[1], "payload");
   if (typeof claims.email !== "string" || !claims.email)
     throw new IdentityUnresolvedError(
-      "LANDMARK_AUTH_TOKEN missing string email claim",
+      "PRODUCT_LANDMARK_TOKEN missing string email claim",
     );
   if (typeof claims.exp !== "number" || claims.exp * 1000 <= Date.now())
-    throw new IdentityUnresolvedError("LANDMARK_AUTH_TOKEN is expired");
+    throw new IdentityUnresolvedError("PRODUCT_LANDMARK_TOKEN is expired");
 
   // HMAC verification is best-effort: monorepo contributors get the
   // secret via `just env-setup`; external `npx fit-landmark login` users
@@ -81,14 +81,14 @@ function resolveFromJwt(jwt, config) {
     const actual = Buffer.from(parts[2], "base64url");
     if (actual.length !== HS256_DIGEST_BYTES)
       throw new IdentityUnresolvedError(
-        "LANDMARK_AUTH_TOKEN signature does not verify",
+        "PRODUCT_LANDMARK_TOKEN signature does not verify",
       );
     const expected = createHmac("sha256", secret)
       .update(`${parts[0]}.${parts[1]}`)
       .digest();
     if (!timingSafeEqual(expected, actual))
       throw new IdentityUnresolvedError(
-        "LANDMARK_AUTH_TOKEN signature does not verify",
+        "PRODUCT_LANDMARK_TOKEN signature does not verify",
       );
   }
   return { email: claims.email, jwt };
@@ -137,16 +137,20 @@ async function refreshSession(creds, config, env, createClient) {
 /**
  * Resolve the caller's identity. Precedence:
  *
- *   1. `LANDMARK_AUTH_TOKEN` — env override (CI, signTestToken, operator-
- *      issued long-lived tokens). The JWT is validated for shape and
- *      (when the JWT secret is available) signature, then returned as-is.
+ *   1. `config.token` — the Landmark product config's `token` param,
+ *      resolved by libconfig from `PRODUCT_LANDMARK_TOKEN` (shell env)
+ *      → `.env` `PRODUCT_LANDMARK_TOKEN` → `config.json`
+ *      `product.landmark.token` (CI, signTestToken, operator-issued
+ *      long-lived tokens, kata-interview substrate). The JWT is
+ *      validated for shape and (when the JWT secret is available)
+ *      signature, then returned as-is.
  *   2. Credentials store — populated by `fit-landmark login`. If the
  *      access token has expired (or is within REFRESH_LEAD_MS of doing so),
  *      attempt a Supabase refresh and persist the result.
  *
  * @param {object} params
  * @param {object} params.config - libconfig Config for the landmark product.
- * @param {NodeJS.ProcessEnv} [params.env] - Process env; carries LANDMARK_AUTH_TOKEN and LANDMARK_CREDENTIALS_FILE.
+ * @param {NodeJS.ProcessEnv} [params.env] - Process env; carries LANDMARK_CREDENTIALS_FILE.
  * @param {(url:string,key:string)=>any} [params.createClient]
  * @returns {Promise<{email: string, jwt: string}>}
  * @throws {IdentityUnresolvedError}
@@ -156,8 +160,8 @@ export async function resolveIdentity({
   env = process.env,
   createClient,
 } = {}) {
-  if (env.LANDMARK_AUTH_TOKEN) {
-    return resolveFromJwt(env.LANDMARK_AUTH_TOKEN, config);
+  if (config?.token) {
+    return resolveFromJwt(config.token, config);
   }
 
   const creds = await readCredentials(env);

--- a/products/landmark/test/dispatcher.test.js
+++ b/products/landmark/test/dispatcher.test.js
@@ -3,7 +3,7 @@
  *
  * Spawns the bin/fit-landmark.js entrypoint via `node` with a controlled
  * env and asserts the documented exit codes:
- *   - 4: IdentityUnresolvedError (no LANDMARK_AUTH_TOKEN)
+ *   - 4: IdentityUnresolvedError (no PRODUCT_LANDMARK_TOKEN)
  *   - 3: SupabaseUnavailableError (token present but no SUPABASE_*)
  *   - 0: marker (needsSupabase: false, dispatcher skips identity)
  *
@@ -69,7 +69,7 @@ describe("fit-landmark dispatcher exit codes", () => {
     const res = run(
       ["voice", "--email", "alice@example.com", "--data", DATA_DIR],
       {
-        LANDMARK_AUTH_TOKEN: token,
+        PRODUCT_LANDMARK_TOKEN: token,
         // Important: do not set SUPABASE_URL or SUPABASE_ANON_KEY.
       },
     );

--- a/products/landmark/test/lib/commands-manifest.test.js
+++ b/products/landmark/test/lib/commands-manifest.test.js
@@ -1,0 +1,77 @@
+/**
+ * Drift-guard tests for `products/landmark/src/lib/commands-manifest.js`.
+ *
+ * Two directions of drift are guarded:
+ *
+ *   1. `SUBCOMMAND_EXPANSIONS`/`FLAT_SMOKE_OPTIONS` cover every
+ *      needsSupabase command from the canonical COMMANDS map.
+ *   2. The bin's libcli `commands` array — read as text + regex-extracted
+ *      — declares user-visible subcommands whose top-level name is
+ *      represented by either `SUBCOMMAND_EXPANSIONS[top]` (space-separated
+ *      names) or `FLAT_SMOKE_OPTIONS[top]` (flat names).
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  COMMANDS,
+  SUBCOMMAND_EXPANSIONS,
+  FLAT_SMOKE_OPTIONS,
+} from "../../src/lib/commands-manifest.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN_PATH = join(__dirname, "..", "..", "bin", "fit-landmark.js");
+
+describe("commands-manifest covers every gated command", () => {
+  test("each needsSupabase: true command has a smoke entry", () => {
+    for (const [name, entry] of Object.entries(COMMANDS)) {
+      if (!entry.needsSupabase) continue;
+      const inSubcommands = Object.hasOwn(SUBCOMMAND_EXPANSIONS, name);
+      const inFlat = Object.hasOwn(FLAT_SMOKE_OPTIONS, name);
+      const noRequiredFlags = name === "health";
+      assert.ok(
+        inSubcommands || inFlat || noRequiredFlags,
+        `gated command "${name}" is in neither SUBCOMMAND_EXPANSIONS nor FLAT_SMOKE_OPTIONS`,
+      );
+    }
+  });
+
+  test("every needsSupabase command in libcli array appears in the manifest", () => {
+    const binSource = readFileSync(BIN_PATH, "utf8");
+    // Pull every `name:` literal from the libcli definition.
+    const nameRegex = /name:\s*"([^"]+)"/g;
+    const names = [];
+    let m;
+    while ((m = nameRegex.exec(binSource))) names.push(m[1]);
+
+    // Filter to the user-visible command names (those that match a top-level
+    // COMMANDS key). marker is the only top-level name we permit to lack
+    // smoke options since marker.needsSupabase is false.
+    for (const fullName of names) {
+      const top = fullName.split(" ")[0];
+      if (!Object.hasOwn(COMMANDS, top)) continue;
+      if (!COMMANDS[top].needsSupabase) continue;
+      const isExpanded =
+        Object.hasOwn(SUBCOMMAND_EXPANSIONS, top) ||
+        Object.hasOwn(FLAT_SMOKE_OPTIONS, top);
+      const noRequiredFlags = top === "health";
+      assert.ok(
+        isExpanded || noRequiredFlags,
+        `libcli surface "${fullName}" (top="${top}") missing from manifest`,
+      );
+    }
+  });
+
+  test("SUBCOMMAND_EXPANSIONS entries reference real top-level commands", () => {
+    for (const top of Object.keys(SUBCOMMAND_EXPANSIONS)) {
+      assert.ok(
+        Object.hasOwn(COMMANDS, top),
+        `SUBCOMMAND_EXPANSIONS["${top}"] has no matching COMMANDS entry`,
+      );
+    }
+  });
+});

--- a/products/landmark/test/lib/commands-verb.test.js
+++ b/products/landmark/test/lib/commands-verb.test.js
@@ -1,12 +1,16 @@
 /**
- * Verifies the hidden `_commands` argv branch on fit-landmark.js. This
+ * Verifies the hidden `_commands` argv branch on fit-landmark.js. The
  * branch must run BEFORE the top-level `await createProductConfig` so
- * substrate-smoke's introspection does not pay the libconfig load cost
- * and is independent of the spawn cwd's `.env` or `config/` walk.
+ * substrate-smoke's introspection does not pay the libconfig load cost.
  *
- * If a future contributor moves createProductConfig earlier in the bin,
- * this test will fail because the spawn will be unable to find a
- * supabase URL/anon key and exit with an unrelated error.
+ * Two spawn paths exercised:
+ *   1. Direct `node bin/fit-landmark.js _commands` from a fresh tmpdir —
+ *      proves the verb is above the libconfig load (no .env / config/
+ *      walk required).
+ *   2. `bunx fit-landmark _commands` from the parent (workspace) cwd —
+ *      proves substrate-smoke's production spawn shape resolves the
+ *      package via workspace `node_modules/.bin` rather than fetching
+ *      from npm (which would 404 the published "fit-landmark" name).
  */
 
 import { describe, test } from "node:test";
@@ -20,16 +24,20 @@ import { tmpdir } from "node:os";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BIN = resolve(__dirname, "..", "..", "bin", "fit-landmark.js");
 
+function assertManifestShape(stdout) {
+  const parsed = JSON.parse(stdout);
+  assert.ok(parsed.commands, "missing commands");
+  assert.ok(parsed.subcommandExpansions, "missing subcommandExpansions");
+  assert.ok(parsed.flatSmokeOptions, "missing flatSmokeOptions");
+  assert.ok(parsed.commands.org, "missing org command");
+  assert.equal(parsed.commands.org.needsSupabase, true);
+}
+
 describe("fit-landmark _commands hidden verb", () => {
-  test("emits the manifest JSON shape and exits 0 with no config", () => {
-    // Pin spawn cwd to a fresh tmpdir so libconfig has neither a .env
-    // nor a discoverable config/ directory; this verifies the verb sits
-    // above the top-level createProductConfig await.
+  test("node bin _commands exits 0 with no env/config (verb above libconfig load)", () => {
     const cwd = mkdtempSync(resolve(tmpdir(), "landmark-_commands-"));
     try {
       const res = spawnSync("node", [BIN, "_commands"], {
-        // Strip every PRODUCT_LANDMARK_*, SUPABASE_* env to make sure
-        // the verb does not depend on them.
         env: { PATH: process.env.PATH },
         encoding: "utf8",
         cwd,
@@ -39,12 +47,7 @@ describe("fit-landmark _commands hidden verb", () => {
         0,
         `_commands exited ${res.status}: ${res.stderr}`,
       );
-      const parsed = JSON.parse(res.stdout);
-      assert.ok(parsed.commands, "missing commands");
-      assert.ok(parsed.subcommandExpansions, "missing subcommandExpansions");
-      assert.ok(parsed.flatSmokeOptions, "missing flatSmokeOptions");
-      assert.ok(parsed.commands.org, "missing org command");
-      assert.equal(parsed.commands.org.needsSupabase, true);
+      assertManifestShape(res.stdout);
     } finally {
       try {
         rmSync(cwd, { recursive: true });
@@ -52,5 +55,21 @@ describe("fit-landmark _commands hidden verb", () => {
         // ignore
       }
     }
+  });
+
+  test("bunx fit-landmark _commands resolves via the workspace (smoke spawn path)", () => {
+    // Run from the test file's directory so bunx walks up to the
+    // workspace node_modules/.bin and finds fit-landmark — exactly the
+    // path substrate-smoke takes when it spawns from the CI checkout.
+    const res = spawnSync("bunx", ["fit-landmark", "_commands"], {
+      encoding: "utf8",
+      cwd: __dirname,
+    });
+    assert.equal(
+      res.status,
+      0,
+      `bunx _commands exited ${res.status}: ${res.stderr}`,
+    );
+    assertManifestShape(res.stdout);
   });
 });

--- a/products/landmark/test/lib/commands-verb.test.js
+++ b/products/landmark/test/lib/commands-verb.test.js
@@ -1,0 +1,56 @@
+/**
+ * Verifies the hidden `_commands` argv branch on fit-landmark.js. This
+ * branch must run BEFORE the top-level `await createProductConfig` so
+ * substrate-smoke's introspection does not pay the libconfig load cost
+ * and is independent of the spawn cwd's `.env` or `config/` walk.
+ *
+ * If a future contributor moves createProductConfig earlier in the bin,
+ * this test will fail because the spawn will be unable to find a
+ * supabase URL/anon key and exit with an unrelated error.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = resolve(__dirname, "..", "..", "bin", "fit-landmark.js");
+
+describe("fit-landmark _commands hidden verb", () => {
+  test("emits the manifest JSON shape and exits 0 with no config", () => {
+    // Pin spawn cwd to a fresh tmpdir so libconfig has neither a .env
+    // nor a discoverable config/ directory; this verifies the verb sits
+    // above the top-level createProductConfig await.
+    const cwd = mkdtempSync(resolve(tmpdir(), "landmark-_commands-"));
+    try {
+      const res = spawnSync("node", [BIN, "_commands"], {
+        // Strip every PRODUCT_LANDMARK_*, SUPABASE_* env to make sure
+        // the verb does not depend on them.
+        env: { PATH: process.env.PATH },
+        encoding: "utf8",
+        cwd,
+      });
+      assert.equal(
+        res.status,
+        0,
+        `_commands exited ${res.status}: ${res.stderr}`,
+      );
+      const parsed = JSON.parse(res.stdout);
+      assert.ok(parsed.commands, "missing commands");
+      assert.ok(parsed.subcommandExpansions, "missing subcommandExpansions");
+      assert.ok(parsed.flatSmokeOptions, "missing flatSmokeOptions");
+      assert.ok(parsed.commands.org, "missing org command");
+      assert.equal(parsed.commands.org.needsSupabase, true);
+    } finally {
+      try {
+        rmSync(cwd, { recursive: true });
+      } catch {
+        // ignore
+      }
+    }
+  });
+});

--- a/products/landmark/test/lib/identity.test.js
+++ b/products/landmark/test/lib/identity.test.js
@@ -17,8 +17,9 @@ import { signTestToken } from "./sign-test-token.js";
 
 const SECRET = "test-secret-do-not-reuse";
 
-function makeConfig({ url, anonKey, jwtSecret } = {}) {
+function makeConfig({ url, anonKey, jwtSecret, token } = {}) {
   return {
+    token,
     supabaseUrl: () => {
       if (!url) throw new Error("SUPABASE_URL not found in environment");
       return url;
@@ -37,7 +38,7 @@ function makeConfig({ url, anonKey, jwtSecret } = {}) {
 }
 
 describe("resolveIdentity — env-only path", () => {
-  it("rejects when neither LANDMARK_AUTH_TOKEN nor a session is set", async () => {
+  it("rejects when neither config.token nor a session is set", async () => {
     const env = { LANDMARK_CREDENTIALS_FILE: "/nonexistent/file" };
     await assert.rejects(
       () => resolveIdentity({ config: makeConfig(), env }),
@@ -53,8 +54,7 @@ describe("resolveIdentity — env-only path", () => {
     await assert.rejects(
       () =>
         resolveIdentity({
-          config: makeConfig(),
-          env: { LANDMARK_AUTH_TOKEN: "not.a.jwt.really" },
+          config: makeConfig({ token: "not.a.jwt.really" }),
         }),
       /not a JWT/,
     );
@@ -75,8 +75,7 @@ describe("resolveIdentity — env-only path", () => {
     await assert.rejects(
       () =>
         resolveIdentity({
-          config: makeConfig(),
-          env: { LANDMARK_AUTH_TOKEN: bad },
+          config: makeConfig({ token: bad }),
         }),
       /header rejected/,
     );
@@ -91,8 +90,7 @@ describe("resolveIdentity — env-only path", () => {
     await assert.rejects(
       () =>
         resolveIdentity({
-          config: makeConfig(),
-          env: { LANDMARK_AUTH_TOKEN: bad },
+          config: makeConfig({ token: bad }),
         }),
       /payload is not valid JSON/,
     );
@@ -116,8 +114,7 @@ describe("resolveIdentity — env-only path", () => {
     await assert.rejects(
       () =>
         resolveIdentity({
-          config: makeConfig({ jwtSecret: SECRET }),
-          env: { LANDMARK_AUTH_TOKEN: noEmail },
+          config: makeConfig({ jwtSecret: SECRET, token: noEmail }),
         }),
       /missing string email claim/,
     );
@@ -137,8 +134,7 @@ describe("resolveIdentity — env-only path", () => {
     await assert.rejects(
       () =>
         resolveIdentity({
-          config: makeConfig(),
-          env: { LANDMARK_AUTH_TOKEN: bad },
+          config: makeConfig({ token: bad }),
         }),
       /missing string email claim/,
     );
@@ -155,8 +151,7 @@ describe("resolveIdentity — env-only path", () => {
     await assert.rejects(
       () =>
         resolveIdentity({
-          config: makeConfig(),
-          env: { LANDMARK_AUTH_TOKEN: bad },
+          config: makeConfig({ token: bad }),
         }),
       /expired/,
     );
@@ -179,8 +174,7 @@ describe("resolveIdentity — env-only path", () => {
     await assert.rejects(
       () =>
         resolveIdentity({
-          config: makeConfig({ jwtSecret: SECRET }),
-          env: { LANDMARK_AUTH_TOKEN: expired },
+          config: makeConfig({ jwtSecret: SECRET, token: expired }),
         }),
       /expired/,
     );
@@ -193,8 +187,7 @@ describe("resolveIdentity — env-only path", () => {
     await assert.rejects(
       () =>
         resolveIdentity({
-          config: makeConfig({ jwtSecret: SECRET }),
-          env: { LANDMARK_AUTH_TOKEN: bad },
+          config: makeConfig({ jwtSecret: SECRET, token: bad }),
         }),
       /signature does not verify/,
     );
@@ -203,8 +196,7 @@ describe("resolveIdentity — env-only path", () => {
   it("returns { email, jwt } on a happy path with the secret present", async () => {
     const token = signTestToken({ email: "alice@example.com", secret: SECRET });
     const out = await resolveIdentity({
-      config: makeConfig({ jwtSecret: SECRET }),
-      env: { LANDMARK_AUTH_TOKEN: token },
+      config: makeConfig({ jwtSecret: SECRET, token }),
     });
     assert.equal(out.email, "alice@example.com");
     assert.equal(out.jwt, token);
@@ -213,8 +205,7 @@ describe("resolveIdentity — env-only path", () => {
   it("trusts the JWT shape when the secret is absent (production path)", async () => {
     const token = signTestToken({ email: "bob@example.com", secret: SECRET });
     const out = await resolveIdentity({
-      config: makeConfig(),
-      env: { LANDMARK_AUTH_TOKEN: token },
+      config: makeConfig({ token }),
     });
     assert.equal(out.email, "bob@example.com");
   });
@@ -249,7 +240,7 @@ describe("resolveIdentity — credentials-store fallback", () => {
     assert.equal(out.jwt, "access-from-store");
   });
 
-  it("env LANDMARK_AUTH_TOKEN takes precedence over the store", async () => {
+  it("config.token takes precedence over the store", async () => {
     const env = { LANDMARK_CREDENTIALS_FILE: credsFile };
     await writeCredentials(
       {
@@ -262,8 +253,8 @@ describe("resolveIdentity — credentials-store fallback", () => {
     );
     const token = signTestToken({ email: "dave@example.com", secret: SECRET });
     const out = await resolveIdentity({
-      config: makeConfig({ jwtSecret: SECRET }),
-      env: { ...env, LANDMARK_AUTH_TOKEN: token },
+      config: makeConfig({ jwtSecret: SECRET, token }),
+      env,
     });
     assert.equal(out.email, "dave@example.com");
     assert.equal(out.jwt, token);

--- a/products/map/bin/fit-map.js
+++ b/products/map/bin/fit-map.js
@@ -15,6 +15,7 @@ import { homedir } from "os";
 import { Finder } from "@forwardimpact/libutil";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { createProductConfig } from "@forwardimpact/libconfig";
+import { findDataDir } from "../src/lib/data-dir.js";
 import {
   createCli,
   SummaryRenderer,
@@ -95,6 +96,37 @@ const definition = {
         },
       },
     },
+    {
+      name: "substrate stage",
+      description:
+        "Provision a Landmark substrate (stack + migrate + seed + provision + self-smoke)",
+    },
+    {
+      name: "substrate roster",
+      description:
+        "List invariant-satisfying personas from the seeded substrate",
+      options: {
+        format: { type: "string", description: "Output format (text|json)" },
+      },
+    },
+    {
+      name: "substrate issue",
+      description:
+        "Atomically write .env (JWT) and .substrate.json (discovery vector) into a target dir",
+      options: {
+        email: { type: "string", description: "Persona email" },
+        cwd: { type: "string", description: "Target dir for the atomic write" },
+        ttl: {
+          type: "string",
+          description: "JWT TTL (e.g. 1h, 30d). Default 1h.",
+        },
+        stash: {
+          type: "string",
+          description:
+            "Optional second path to write the bare JWT to (workflow-private; not for external operators)",
+        },
+      },
+    },
   ],
   globalOptions: {
     data: { type: "string", description: "Path to data directory" },
@@ -156,33 +188,6 @@ const definition = {
 };
 
 const cli = createCli(definition);
-
-/**
- * Find the data directory
- * @param {string|undefined} providedPath - Explicit path from --data flag
- * @returns {Promise<string>} Resolved data directory path
- */
-async function findDataDir(providedPath) {
-  if (providedPath) {
-    const resolved = resolve(providedPath);
-    try {
-      await fs.access(resolved);
-    } catch {
-      throw new Error(`Data directory not found: ${providedPath}`);
-    }
-    return resolved;
-  }
-
-  const logger = createLogger("map");
-  const finder = new Finder(fs, logger, process);
-  try {
-    return join(finder.findData("data", homedir()), "pathway");
-  } catch {
-    throw new Error(
-      "No data directory found. Use --data=<path> to specify location.",
-    );
-  }
-}
 
 /**
  * Format validation results for display using libcli helpers.
@@ -466,6 +471,46 @@ async function dispatchAuth(subcommand, _rest, values) {
   }
 }
 
+async function dispatchSubstrate(subcommand, _rest, values) {
+  switch (subcommand) {
+    case "stage": {
+      const { runStageCommand } = await import(
+        "../src/commands/substrate-stage.js"
+      );
+      return runStageCommand({ config });
+    }
+    case "roster": {
+      const supabase = await mapClient();
+      const { runRosterCommand } = await import(
+        "../src/commands/substrate-roster.js"
+      );
+      return runRosterCommand({
+        supabase,
+        options: { format: values.format },
+      });
+    }
+    case "issue": {
+      const supabase = await mapClient();
+      const { runSubstrateIssueCommand } = await import(
+        "../src/commands/substrate-issue.js"
+      );
+      return runSubstrateIssueCommand({
+        supabase,
+        config,
+        options: {
+          email: values.email,
+          cwd: values.cwd,
+          ttl: values.ttl,
+          stash: values.stash,
+        },
+      });
+    }
+    default:
+      cli.usageError(`unknown substrate subcommand: ${subcommand || "(none)"}`);
+      return 1;
+  }
+}
+
 /**
  * Main entry point
  */
@@ -525,6 +570,9 @@ async function main() {
         break;
       case "auth":
         exitCode = await dispatchAuth(subcommand, rest, values);
+        break;
+      case "substrate":
+        exitCode = await dispatchSubstrate(subcommand, rest, values);
         break;
       default:
         cli.usageError(`unknown command "${command}"`);

--- a/products/map/src/commands/auth-issue.js
+++ b/products/map/src/commands/auth-issue.js
@@ -15,25 +15,9 @@ import {
   formatBullet,
 } from "@forwardimpact/libcli";
 import { mintSupabaseJwt, parseDuration } from "@forwardimpact/libsecret";
+import { findAuthUser } from "../lib/auth-helpers.js";
 
 const DEFAULT_TTL = "8760h"; // 1 year.
-
-async function findAuthUser(supabase, email) {
-  // Roster size in the hundreds; one page covers any practical org.
-  // listUsers() returns paginated results; iterate to be safe.
-  let page = 1;
-  while (true) {
-    const { data, error } = await supabase.auth.admin.listUsers({
-      page,
-      perPage: 1000,
-    });
-    if (error) throw new Error(`listUsers: ${error.message}`);
-    const match = data.users.find((u) => u.email === email);
-    if (match) return match;
-    if (data.users.length < 1000) return null;
-    page += 1;
-  }
-}
 
 /**
  * Run the auth-issue command.

--- a/products/map/src/commands/auth-issue.js
+++ b/products/map/src/commands/auth-issue.js
@@ -6,7 +6,7 @@
  * to read `organization_people` and list `auth.users`) to verify both rows
  * exist before signing, then HMACs a JWT against SUPABASE_JWT_SECRET.
  * Output goes to stdout so the operator can capture it into `.env`, a
- * secret manager, or pipe it to an agent's `LANDMARK_AUTH_TOKEN` setting.
+ * secret manager, or pipe it to an agent's `PRODUCT_LANDMARK_TOKEN` setting.
  */
 
 import {
@@ -91,7 +91,7 @@ export async function runAuthIssueCommand({ supabase, config, options }) {
   process.stdout.write(jwt + "\n\n");
   process.stdout.write(
     formatBullet(
-      "Export: LANDMARK_AUTH_TOKEN=<jwt above>; never commit or echo it.",
+      "Export: PRODUCT_LANDMARK_TOKEN=<jwt above>; never commit or echo it.",
       0,
     ) + "\n",
   );

--- a/products/map/src/commands/substrate-issue.js
+++ b/products/map/src/commands/substrate-issue.js
@@ -1,0 +1,140 @@
+/**
+ * `fit-map substrate issue --email <e> --cwd <p>` — workflow-facing verb
+ * that atomically writes the Landmark substrate for a chosen persona
+ * into a target directory.
+ *
+ * Two files land under `--cwd`:
+ *   - `.env` — `PRODUCT_LANDMARK_TOKEN=<jwt>` (one line, mode 0600)
+ *   - `.substrate.json` — discovery vector (persona email, manager,
+ *     snapshot id, item id; mode 0600)
+ *
+ * An optional `--stash <path>` flag writes the bare JWT to a third
+ * workflow-private path (used by kata-interview.yml so a post-run log
+ * scan has a tamper-resistant source for the JWT to grep for; the agent
+ * has no access to `$RUNNER_TEMP`). Mode 0600.
+ *
+ * Rejects `kind != "human"` rows on purpose — service-account JWTs are
+ * issued via `fit-map auth issue`. The substrate path is for engineer
+ * personas only.
+ */
+
+import path from "node:path";
+import fs from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { mintSupabaseJwt, parseDuration } from "@forwardimpact/libsecret";
+import { findAuthUser } from "../lib/auth-helpers.js";
+import { formatSuccess } from "@forwardimpact/libcli";
+
+/**
+ * @param {object} params
+ * @param {import("@supabase/supabase-js").SupabaseClient} params.supabase
+ * @param {{supabaseJwtSecret: () => string}} params.config
+ * @param {{email?: string, cwd?: string, ttl?: string, stash?: string}} params.options
+ * @returns {Promise<number>}
+ */
+export async function runSubstrateIssueCommand({ supabase, config, options }) {
+  const { email, cwd, ttl, stash } = options;
+  if (!email) throw new Error("substrate issue: --email <e> is required");
+  if (!cwd) throw new Error("substrate issue: --cwd <path> is required");
+  const ttlSeconds = parseDuration(ttl ?? "1h");
+
+  const { data: row, error: rowErr } = await supabase
+    .from("organization_people")
+    .select("email,kind,manager_email")
+    .eq("email", email)
+    .maybeSingle();
+  if (rowErr) throw new Error(`organization_people: ${rowErr.message}`);
+  if (!row) {
+    throw new Error(`substrate issue: no organization_people row for ${email}`);
+  }
+  if (row.kind !== "human") {
+    throw new Error(
+      `substrate issue: ${email} is kind=${row.kind}, not human ` +
+        "(substrate is for engineer personas only; the operator surface " +
+        "for service-account JWTs is `fit-map auth issue`)",
+    );
+  }
+
+  const authUser = await findAuthUser(supabase, email);
+  if (!authUser) {
+    throw new Error(`substrate issue: no auth.users row for ${email}`);
+  }
+
+  const secret = config.supabaseJwtSecret();
+  const jwt = mintSupabaseJwt({ email, secret, ttlSeconds });
+
+  const { snapshot_id, item_id } = await resolveDiscoveryVector(supabase);
+
+  const envPath = path.join(cwd, ".env");
+  const subPath = path.join(cwd, ".substrate.json");
+  const tag = `${process.pid}-${randomBytes(4).toString("hex")}`;
+  const envTmp = `${envPath}.tmp-${tag}`;
+  const subTmp = `${subPath}.tmp-${tag}`;
+  try {
+    await fs.writeFile(envTmp, `PRODUCT_LANDMARK_TOKEN=${jwt}\n`, {
+      mode: 0o600,
+    });
+    await fs.chmod(envTmp, 0o600);
+    // Spec § Persona-corpus invariant (a): the persona IS the manager of
+    // ≥1 other row (verified by findInvariantSatisfyingPersonas), so
+    // `org team --manager <X>` and `practice --manager <X>` take the
+    // persona's OWN email — not the persona's own manager.
+    await fs.writeFile(
+      subTmp,
+      JSON.stringify(
+        {
+          persona_email: email,
+          manager_email: email,
+          snapshot_id,
+          item_id,
+          generated_at: new Date().toISOString(),
+        },
+        null,
+        2,
+      ) + "\n",
+      { mode: 0o600 },
+    );
+    await fs.chmod(subTmp, 0o600);
+
+    await fs.rename(envTmp, envPath);
+    await fs.rename(subTmp, subPath);
+  } finally {
+    // Best-effort cleanup if either rename failed mid-way.
+    for (const orphan of [envTmp, subTmp]) {
+      try {
+        await fs.unlink(orphan);
+      } catch {
+        // expected after successful rename
+      }
+    }
+  }
+
+  if (stash) {
+    await fs.writeFile(stash, jwt + "\n", { mode: 0o600 });
+    await fs.chmod(stash, 0o600);
+  }
+
+  process.stdout.write(formatSuccess(`Issued substrate for ${email}`) + "\n");
+  return 0;
+}
+
+async function resolveDiscoveryVector(supabase) {
+  const { data: snaps } = await supabase
+    .from("getdx_snapshots")
+    .select("snapshot_id")
+    .order("scheduled_for", { ascending: false })
+    .limit(1);
+  if (!snaps?.length) throw new Error("no getdx_snapshots rows");
+  const snapshot_id = snaps[0].snapshot_id;
+  const { data: scores } = await supabase
+    .from("getdx_snapshot_team_scores")
+    .select("item_id")
+    .eq("snapshot_id", snapshot_id)
+    .limit(1);
+  if (!scores?.length) {
+    throw new Error(
+      `no getdx_snapshot_team_scores for snapshot ${snapshot_id}`,
+    );
+  }
+  return { snapshot_id, item_id: scores[0].item_id };
+}

--- a/products/map/src/commands/substrate-persona-query.js
+++ b/products/map/src/commands/substrate-persona-query.js
@@ -1,0 +1,164 @@
+/**
+ * Find personas in the seeded substrate that satisfy every spec 990
+ * § Persona-corpus invariant. The helper composes the result client-side
+ * via chained Supabase JS calls — no Postgres view or RPC, because spec
+ * § Out-of-scope forbids changes under `products/map/supabase/migrations/`.
+ *
+ * Invariants required of a chosen persona row:
+ *   (a) IS the manager of at least one other row (manager_email match),
+ *       so `org team --manager <persona-email>` returns a non-empty payload.
+ *   (b) Has authored at least one evidence row (joined via
+ *       github_artifacts → email).
+ *   (c) Manages at least one direct who has authored ≥1 evidence row
+ *       (practice-pattern proxy: practice --manager <persona-email>
+ *       returns ≥1 row).
+ *   (d) Corpus carries ≥1 organization snapshot id and ≥1 driver/item id
+ *       (the discovery vector).
+ */
+
+async function loadDiscovery(supabase) {
+  const { data: snaps } = await supabase
+    .from("getdx_snapshots")
+    .select("snapshot_id, scheduled_for")
+    .order("scheduled_for", { ascending: false })
+    .limit(1);
+  if (!snaps?.length) {
+    return { diagnostic: "no getdx_snapshots rows" };
+  }
+  const snapshot_id = snaps[0].snapshot_id;
+  const { data: scores } = await supabase
+    .from("getdx_snapshot_team_scores")
+    .select("item_id")
+    .eq("snapshot_id", snapshot_id)
+    .limit(1);
+  if (!scores?.length) {
+    return {
+      diagnostic: `no getdx_snapshot_team_scores for snapshot ${snapshot_id}`,
+    };
+  }
+  return { snapshot_id, item_id: scores[0].item_id };
+}
+
+function countDirectsByManager(humans) {
+  const m = new Map();
+  for (const h of humans) {
+    if (!h.manager_email) continue;
+    m.set(h.manager_email, (m.get(h.manager_email) ?? 0) + 1);
+  }
+  return m;
+}
+
+async function loadEvidenceCounts(supabase) {
+  const { data: artifacts } = await supabase
+    .from("github_artifacts")
+    .select("artifact_id, email");
+  const artifactToEmail = new Map(
+    (artifacts ?? []).map((a) => [a.artifact_id, a.email]),
+  );
+  const { data: ev } = await supabase.from("evidence").select("artifact_id");
+  const counts = new Map();
+  for (const e of ev ?? []) {
+    const email = artifactToEmail.get(e.artifact_id);
+    if (!email) continue;
+    counts.set(email, (counts.get(email) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function countPracticeDirectsByManager(humans, evidenceCountByEmail) {
+  const m = new Map();
+  for (const h of humans) {
+    if (!h.manager_email) continue;
+    if ((evidenceCountByEmail.get(h.email) ?? 0) >= 1) {
+      m.set(h.manager_email, (m.get(h.manager_email) ?? 0) + 1);
+    }
+  }
+  return m;
+}
+
+function diagnoseBindingConstraint(
+  humans,
+  directsByManager,
+  evidenceCountByEmail,
+  practiceCountByManager,
+) {
+  const counts = {
+    manages: humans.filter((h) => (directsByManager.get(h.email) ?? 0) >= 1)
+      .length,
+    authors_evidence: humans.filter(
+      (h) => (evidenceCountByEmail.get(h.email) ?? 0) >= 1,
+    ).length,
+    practice_directs: humans.filter(
+      (h) => (practiceCountByManager.get(h.email) ?? 0) >= 1,
+    ).length,
+  };
+  return Object.entries(counts).sort(([, a], [, b]) => a - b)[0][0];
+}
+
+/**
+ * @param {object} params
+ * @param {import("@supabase/supabase-js").SupabaseClient} params.supabase
+ * @returns {Promise<{
+ *   personas: Array<object>,
+ *   discovery?: { snapshot_id: string, item_id: string },
+ *   diagnostic?: string,
+ * }>}
+ */
+export async function findInvariantSatisfyingPersonas({ supabase }) {
+  const discovery = await loadDiscovery(supabase);
+  if (discovery.diagnostic) {
+    return { personas: [], diagnostic: discovery.diagnostic };
+  }
+  const { snapshot_id, item_id } = discovery;
+
+  const { data: humans } = await supabase
+    .from("organization_people")
+    .select("email,name,discipline,level,track,manager_email")
+    .eq("kind", "human");
+  if (!humans?.length) {
+    return { personas: [], diagnostic: "no kind=human rows" };
+  }
+
+  const directsByManager = countDirectsByManager(humans);
+  const evidenceCountByEmail = await loadEvidenceCounts(supabase);
+  const practiceCountByManager = countPracticeDirectsByManager(
+    humans,
+    evidenceCountByEmail,
+  );
+
+  const personas = humans
+    .filter(
+      (h) =>
+        (directsByManager.get(h.email) ?? 0) >= 1 &&
+        (evidenceCountByEmail.get(h.email) ?? 0) >= 1 &&
+        (practiceCountByManager.get(h.email) ?? 0) >= 1,
+    )
+    .map((h) => ({
+      email: h.email,
+      name: h.name,
+      discipline: h.discipline,
+      level: h.level,
+      track: h.track,
+      manager_email: h.manager_email,
+      manages_count: directsByManager.get(h.email) ?? 0,
+      evidence_count: evidenceCountByEmail.get(h.email) ?? 0,
+      practice_directs_count: practiceCountByManager.get(h.email) ?? 0,
+      snapshot_id,
+      item_id,
+    }));
+
+  if (!personas.length) {
+    const binding = diagnoseBindingConstraint(
+      humans,
+      directsByManager,
+      evidenceCountByEmail,
+      practiceCountByManager,
+    );
+    return {
+      personas: [],
+      diagnostic: `no invariant-satisfying persona — binding constraint: ${binding}`,
+    };
+  }
+
+  return { personas, discovery: { snapshot_id, item_id } };
+}

--- a/products/map/src/commands/substrate-roster.js
+++ b/products/map/src/commands/substrate-roster.js
@@ -1,0 +1,62 @@
+/**
+ * `fit-map substrate roster` — list invariant-satisfying personas from
+ * the seeded substrate. Used by the kata-interview supervisor to pick
+ * a persona before invoking `fit-map substrate issue`.
+ *
+ * Read-only verb: queries `organization_people`, `evidence`,
+ * `github_artifacts`, `getdx_snapshots`, and
+ * `getdx_snapshot_team_scores` via the helper, then renders one row per
+ * persona. Exits non-zero with a diagnostic on an empty result so the
+ * caller can surface the binding constraint to the operator.
+ */
+
+import { formatHeader, formatBullet, formatError } from "@forwardimpact/libcli";
+
+/**
+ * @param {object} params
+ * @param {import("@supabase/supabase-js").SupabaseClient} params.supabase
+ * @param {{format?: string}} params.options
+ * @returns {Promise<number>}
+ */
+export async function runRosterCommand({ supabase, options }) {
+  const { findInvariantSatisfyingPersonas } = await import(
+    "./substrate-persona-query.js"
+  );
+  const { personas, discovery, diagnostic } =
+    await findInvariantSatisfyingPersonas({ supabase });
+
+  if (!personas.length) {
+    process.stderr.write(
+      formatError(`substrate roster: ${diagnostic ?? "no personas"}`) + "\n",
+    );
+    return 1;
+  }
+
+  const payload = {
+    personas,
+    selection_metadata: {
+      signals: ["memory_diversification", "jtbd_role_alignment"],
+    },
+    discovery,
+  };
+
+  if (options?.format === "json") {
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+    return 0;
+  }
+
+  process.stdout.write(
+    formatHeader(`Invariant-satisfying personas (${personas.length})`) + "\n\n",
+  );
+  for (const p of personas) {
+    process.stdout.write(
+      formatBullet(
+        `${p.email} — ${p.name} (${p.discipline}/${p.level}/${p.track ?? "-"}) ` +
+          `manages=${p.manages_count} evidence=${p.evidence_count} ` +
+          `practice_directs=${p.practice_directs_count}`,
+        0,
+      ) + "\n",
+    );
+  }
+  return 0;
+}

--- a/products/map/src/commands/substrate-roster.js
+++ b/products/map/src/commands/substrate-roster.js
@@ -22,8 +22,9 @@ export async function runRosterCommand({ supabase, options }) {
   const { findInvariantSatisfyingPersonas } = await import(
     "./substrate-persona-query.js"
   );
-  const { personas, discovery, diagnostic } =
-    await findInvariantSatisfyingPersonas({ supabase });
+  const { personas, diagnostic } = await findInvariantSatisfyingPersonas({
+    supabase,
+  });
 
   if (!personas.length) {
     process.stderr.write(
@@ -32,12 +33,15 @@ export async function runRosterCommand({ supabase, options }) {
     return 1;
   }
 
+  // snapshot_id/item_id are carried per-row on each persona; the
+  // kata-interview supervisor reads them off the picked row. The
+  // SKILL.md Step 3a documents that shape, so no separate top-level
+  // discovery field is exposed here.
   const payload = {
     personas,
     selection_metadata: {
       signals: ["memory_diversification", "jtbd_role_alignment"],
     },
-    discovery,
   };
 
   if (options?.format === "json") {

--- a/products/map/src/commands/substrate-smoke.js
+++ b/products/map/src/commands/substrate-smoke.js
@@ -9,9 +9,6 @@
  */
 
 import { spawnSync } from "node:child_process";
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { Buffer } from "node:buffer";
 import { mintSupabaseJwt, parseDuration } from "@forwardimpact/libsecret";
 
@@ -21,11 +18,19 @@ const ROW_CLASS_KEYS = {
   practice: "patterns",
 };
 
-async function fetchManifest() {
-  const manifestRes = spawnSync("bunx", ["fit-landmark", "_commands"], {
+// Use the parent process's cwd (the CI checkout root) for bunx spawns so
+// fit-landmark resolves via the workspace; a fresh tmpdir would push bunx
+// up the filesystem looking for node_modules, hit nothing, and 404 from
+// npm. JWT/secret isolation comes from spawn-options env, not cwd.
+function fitLandmarkSpawn(argv, extraEnv = {}) {
+  return spawnSync("bunx", ["fit-landmark", ...argv], {
     encoding: "utf8",
-    cwd: await freshTmpdir(),
+    env: { ...process.env, ...extraEnv },
   });
+}
+
+function fetchManifest() {
+  const manifestRes = fitLandmarkSpawn(["_commands"]);
   if (manifestRes.status !== 0) {
     throw new Error(`_commands: ${manifestRes.stderr}`);
   }
@@ -54,12 +59,8 @@ function buildSmokeArgv({ command, smokeOptions }, persona, discovery) {
   return argv;
 }
 
-function runSmokeCommand(argv, jwt, cwd) {
-  const res = spawnSync("bunx", ["fit-landmark", ...argv], {
-    encoding: "utf8",
-    env: { ...process.env, PRODUCT_LANDMARK_TOKEN: jwt },
-    cwd,
-  });
+function runSmokeCommand(argv, jwt) {
+  const res = fitLandmarkSpawn(argv, { PRODUCT_LANDMARK_TOKEN: jwt });
   if (res.status !== 0) {
     throw new Error(`${argv.join(" ")} exited ${res.status}: ${res.stderr}`);
   }
@@ -96,13 +97,12 @@ export async function runSelfSmoke({ supabase, config }) {
   await assertPersonaIsHuman(supabase, persona.email);
   assertDiscoveryResolves(persona, discovery);
 
-  const manifest = await fetchManifest();
+  const manifest = fetchManifest();
   const smokeList = buildSmokeList(manifest);
 
-  const spawnCwd = await freshTmpdir();
   for (const item of smokeList) {
     const argv = buildSmokeArgv(item, persona, discovery);
-    const res = runSmokeCommand(argv, jwt, spawnCwd);
+    const res = runSmokeCommand(argv, jwt);
     const rowKey = ROW_CLASS_KEYS[item.command];
     if (rowKey) assertNonEmpty(res.stdout, rowKey);
   }
@@ -113,10 +113,6 @@ function expand(template, persona, discovery) {
     .replace("$PERSONA_EMAIL", persona.email)
     .replace("$SNAPSHOT_ID", discovery.snapshot_id)
     .replace("$ITEM_ID", discovery.item_id);
-}
-
-async function freshTmpdir() {
-  return fs.mkdtemp(path.join(os.tmpdir(), "substrate-smoke-"));
 }
 
 /**

--- a/products/map/src/commands/substrate-smoke.js
+++ b/products/map/src/commands/substrate-smoke.js
@@ -1,0 +1,194 @@
+/**
+ * Self-smoke for `fit-map substrate stage`. Mints a short-lived JWT for
+ * the first invariant-satisfying persona and invokes every
+ * `needsSupabase: true` command in fit-landmark's COMMANDS map to confirm
+ * the seeded substrate answers every gated command to non-error
+ * completion. Three row-class commands (`org team`, `evidence`,
+ * `practice`) additionally assert non-empty payloads scoped to the
+ * persona.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Buffer } from "node:buffer";
+import { mintSupabaseJwt, parseDuration } from "@forwardimpact/libsecret";
+
+const ROW_CLASS_KEYS = {
+  "org team": "team",
+  evidence: "evidence",
+  practice: "patterns",
+};
+
+async function fetchManifest() {
+  const manifestRes = spawnSync("bunx", ["fit-landmark", "_commands"], {
+    encoding: "utf8",
+    cwd: await freshTmpdir(),
+  });
+  if (manifestRes.status !== 0) {
+    throw new Error(`_commands: ${manifestRes.stderr}`);
+  }
+  return JSON.parse(manifestRes.stdout);
+}
+
+function buildSmokeList({ commands, subcommandExpansions, flatSmokeOptions }) {
+  const list = [];
+  for (const [name, entry] of Object.entries(commands)) {
+    if (!entry.needsSupabase) continue;
+    if (subcommandExpansions[name]) {
+      list.push(...subcommandExpansions[name]);
+    } else {
+      list.push({ command: name, smokeOptions: flatSmokeOptions[name] ?? {} });
+    }
+  }
+  return list;
+}
+
+function buildSmokeArgv({ command, smokeOptions }, persona, discovery) {
+  const argv = command.split(" ");
+  for (const [k, v] of Object.entries(smokeOptions)) {
+    argv.push(`--${k}`, expand(v, persona, discovery));
+  }
+  argv.push("--format", "json");
+  return argv;
+}
+
+function runSmokeCommand(argv, jwt, cwd) {
+  const res = spawnSync("bunx", ["fit-landmark", ...argv], {
+    encoding: "utf8",
+    env: { ...process.env, PRODUCT_LANDMARK_TOKEN: jwt },
+    cwd,
+  });
+  if (res.status !== 0) {
+    throw new Error(`${argv.join(" ")} exited ${res.status}: ${res.stderr}`);
+  }
+  return res;
+}
+
+/**
+ * Run the self-smoke. Throws with a descriptive `[substrate stage: smoke]`-
+ * style error on any failure; caller wraps in a phase tag.
+ *
+ * @param {object} params
+ * @param {import("@supabase/supabase-js").SupabaseClient} params.supabase
+ * @param {{supabaseJwtSecret: () => string}} params.config
+ * @returns {Promise<void>}
+ */
+export async function runSelfSmoke({ supabase, config }) {
+  const { findInvariantSatisfyingPersonas } = await import(
+    "./substrate-persona-query.js"
+  );
+  const { personas, discovery, diagnostic } =
+    await findInvariantSatisfyingPersonas({ supabase });
+  if (!personas.length) throw new Error(diagnostic);
+  const persona = personas[0];
+
+  const secret = config.supabaseJwtSecret();
+  const jwt = mintSupabaseJwt({
+    email: persona.email,
+    secret,
+    ttlSeconds: parseDuration("1h"),
+  });
+
+  // Spec § Success Criteria rows 1–4: explicit shape check.
+  assertJwtShape(jwt, persona.email);
+  await assertPersonaIsHuman(supabase, persona.email);
+  assertDiscoveryResolves(persona, discovery);
+
+  const manifest = await fetchManifest();
+  const smokeList = buildSmokeList(manifest);
+
+  const spawnCwd = await freshTmpdir();
+  for (const item of smokeList) {
+    const argv = buildSmokeArgv(item, persona, discovery);
+    const res = runSmokeCommand(argv, jwt, spawnCwd);
+    const rowKey = ROW_CLASS_KEYS[item.command];
+    if (rowKey) assertNonEmpty(res.stdout, rowKey);
+  }
+}
+
+function expand(template, persona, discovery) {
+  return template
+    .replace("$PERSONA_EMAIL", persona.email)
+    .replace("$SNAPSHOT_ID", discovery.snapshot_id)
+    .replace("$ITEM_ID", discovery.item_id);
+}
+
+async function freshTmpdir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "substrate-smoke-"));
+}
+
+/**
+ * Verify a JWT's payload carries the Supabase-Auth claims spec 990 § Success
+ * Criteria rows 2 requires (aud, role, email, future exp). Throws on any
+ * mismatch.
+ * @param {string} jwt
+ * @param {string} expectedEmail
+ */
+export function assertJwtShape(jwt, expectedEmail) {
+  const [, payloadB64] = jwt.split(".");
+  const claims = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+  if (claims.aud !== "authenticated") {
+    throw new Error(`JWT aud != authenticated: ${claims.aud}`);
+  }
+  if (claims.role !== "authenticated") {
+    throw new Error(`JWT role != authenticated: ${claims.role}`);
+  }
+  if (claims.email !== expectedEmail) {
+    throw new Error(`JWT email mismatch: ${claims.email}`);
+  }
+  if (typeof claims.exp !== "number" || claims.exp * 1000 <= Date.now()) {
+    throw new Error(`JWT exp claim missing or in the past: ${claims.exp}`);
+  }
+}
+
+/**
+ * Confirm an `organization_people` row exists for `email` and carries
+ * `kind = "human"`. Throws otherwise.
+ * @param {import("@supabase/supabase-js").SupabaseClient} supabase
+ * @param {string} email
+ */
+export async function assertPersonaIsHuman(supabase, email) {
+  const { data, error } = await supabase
+    .from("organization_people")
+    .select("kind")
+    .eq("email", email)
+    .maybeSingle();
+  if (error) throw new Error(`organization_people: ${error.message}`);
+  if (data?.kind !== "human") {
+    throw new Error(`persona ${email} kind=${data?.kind}, not human`);
+  }
+}
+
+/**
+ * Verify both the persona row and discovery vector carry the values the
+ * smoke loop will substitute into command argv placeholders.
+ * @param {object} persona
+ * @param {{snapshot_id: string, item_id: string}} discovery
+ */
+export function assertDiscoveryResolves(persona, discovery) {
+  if (!persona.email || !persona.manager_email) {
+    throw new Error(
+      `persona missing email/manager_email: ${JSON.stringify(persona)}`,
+    );
+  }
+  if (!discovery.snapshot_id || !discovery.item_id) {
+    throw new Error(
+      `discovery vector incomplete: ${JSON.stringify(discovery)}`,
+    );
+  }
+}
+
+function assertNonEmpty(stdout, key) {
+  const parsed = JSON.parse(stdout);
+  const v = parsed[key];
+  const empty =
+    v === undefined ||
+    v === null ||
+    (Array.isArray(v) && v.length === 0) ||
+    (!Array.isArray(v) && typeof v === "object" && Object.keys(v).length === 0);
+  if (empty) {
+    throw new Error(`row-class non-empty assertion failed for ${key}`);
+  }
+}

--- a/products/map/src/commands/substrate-smoke.js
+++ b/products/map/src/commands/substrate-smoke.js
@@ -37,7 +37,17 @@ function fetchManifest() {
   return JSON.parse(manifestRes.stdout);
 }
 
-function buildSmokeList({ commands, subcommandExpansions, flatSmokeOptions }) {
+/**
+ * Expand the manifest into a flat list of {command, smokeOptions} pairs
+ * the smoke loop spawns. Exported for unit-testing the iteration logic.
+ * @param {{commands: object, subcommandExpansions: object, flatSmokeOptions: object}} manifest
+ * @returns {Array<{command: string, smokeOptions: object}>}
+ */
+export function buildSmokeList({
+  commands,
+  subcommandExpansions,
+  flatSmokeOptions,
+}) {
   const list = [];
   for (const [name, entry] of Object.entries(commands)) {
     if (!entry.needsSupabase) continue;
@@ -50,7 +60,14 @@ function buildSmokeList({ commands, subcommandExpansions, flatSmokeOptions }) {
   return list;
 }
 
-function buildSmokeArgv({ command, smokeOptions }, persona, discovery) {
+/**
+ * Build the argv array for one smoke invocation. Exported for tests.
+ * @param {{command: string, smokeOptions: object}} item
+ * @param {object} persona
+ * @param {{snapshot_id: string, item_id: string}} discovery
+ * @returns {string[]}
+ */
+export function buildSmokeArgv({ command, smokeOptions }, persona, discovery) {
   const argv = command.split(" ");
   for (const [k, v] of Object.entries(smokeOptions)) {
     argv.push(`--${k}`, expand(v, persona, discovery));
@@ -176,7 +193,13 @@ export function assertDiscoveryResolves(persona, discovery) {
   }
 }
 
-function assertNonEmpty(stdout, key) {
+/**
+ * Assert the named row collection in a JSON stdout payload is non-empty.
+ * Exported for tests.
+ * @param {string} stdout
+ * @param {string} key
+ */
+export function assertNonEmpty(stdout, key) {
   const parsed = JSON.parse(stdout);
   const v = parsed[key];
   const empty =

--- a/products/map/src/commands/substrate-stage.js
+++ b/products/map/src/commands/substrate-stage.js
@@ -1,0 +1,87 @@
+/**
+ * `fit-map substrate stage` — workspace-prep terminal phase for the
+ * kata-interview workflow targeting Landmark. Brings up the local
+ * Supabase stack, discovers its URL/anon key, migrates the schema,
+ * seeds the activity data, provisions auth.users for the roster, and
+ * runs a self-smoke against every gated Landmark command.
+ *
+ * Designed to be invoked once per interview run from CI; not a developer
+ * verb (use `fit-map activity start` + manual seed in dev flows).
+ */
+
+import path from "node:path";
+import { createSupabaseCli as defaultCreateCli } from "../lib/supabase-cli.js";
+import { findDataDir as defaultFindDataDir } from "../lib/data-dir.js";
+import { createMapClient as defaultCreateMapClient } from "../lib/client.js";
+import { formatSuccess } from "@forwardimpact/libcli";
+
+/**
+ * Run the staging pipeline. Each phase is wrapped so failures surface
+ * with a `[substrate stage: <phase>] <reason>` error so the CI step's
+ * stderr identifies which substrate step failed.
+ *
+ * Dependencies are injectable for tests; production callers pass only
+ * `config` and the defaults wire up the real Supabase CLI, mapClient,
+ * data-dir resolver, seed, provision, and smoke surfaces.
+ *
+ * @param {object} params
+ * @param {object} params.config - libconfig product config for "map".
+ * @param {object} [deps]
+ * @returns {Promise<number>}
+ */
+export async function runStageCommand(
+  { config },
+  {
+    createSupabaseCli = defaultCreateCli,
+    findDataDir = defaultFindDataDir,
+    createMapClient = defaultCreateMapClient,
+    loadSeed = () => import("./activity.js").then((m) => m.seed),
+    loadProvision = () =>
+      import("./people-provision.js").then((m) => m.runProvisionCommand),
+    loadSmoke = () =>
+      import("./substrate-smoke.js").then((m) => m.runSelfSmoke),
+  } = {},
+) {
+  const cli = createSupabaseCli();
+
+  await runPhase("stack", () => cli.run(["start"]));
+
+  await runPhase("url-discovery", async () => {
+    const json = await cli.capture(["status", "--output", "json"]);
+    const status = JSON.parse(json);
+    if (!status.api_url) throw new Error("supabase status: no api_url");
+    if (!status.anon_key) throw new Error("supabase status: no anon_key");
+    // libconfig's #env() reads process.env first; setting these here
+    // makes the createMapClient call below (and any same-process
+    // children) observe the live local-stack values.
+    process.env.SUPABASE_URL = status.api_url;
+    process.env.SUPABASE_ANON_KEY = status.anon_key;
+  });
+
+  await runPhase("migrate", () => cli.run(["db", "reset"]));
+
+  const supabase = createMapClient({ config });
+  const dataDir = await findDataDir(undefined);
+  const dataRoot = path.dirname(dataDir);
+  const seed = await loadSeed();
+  const runProvisionCommand = await loadProvision();
+  await runPhase("seed", () => seed({ data: dataRoot, supabase }));
+  await runPhase("provision", () => runProvisionCommand({ supabase }));
+
+  if (process.env.SUBSTRATE_FORCE_EMPTY_CORPUS === "true") {
+    throw new Error("[substrate stage: smoke] empty corpus (test injection)");
+  }
+  const runSelfSmoke = await loadSmoke();
+  await runPhase("smoke", () => runSelfSmoke({ supabase, config }));
+
+  process.stdout.write(formatSuccess("Substrate ready") + "\n");
+  return 0;
+}
+
+async function runPhase(name, fn) {
+  try {
+    await fn();
+  } catch (err) {
+    throw new Error(`[substrate stage: ${name}] ${err.message}`);
+  }
+}

--- a/products/map/src/lib/auth-helpers.js
+++ b/products/map/src/lib/auth-helpers.js
@@ -1,0 +1,33 @@
+/**
+ * Shared helpers for fit-map commands that need to reconcile
+ * `organization_people` roster rows against the underlying
+ * `auth.users` table via the Supabase admin API.
+ *
+ * Used by both `fit-map auth issue` (operator-facing) and
+ * `fit-map substrate issue` (workflow-facing).
+ */
+
+/**
+ * Look up a Supabase `auth.users` row by email via the admin API.
+ * Iterates pages so it works on rosters larger than the API's page size.
+ *
+ * @param {import("@supabase/supabase-js").SupabaseClient} supabase
+ * @param {string} email
+ * @returns {Promise<object | null>} The matching user row, or null if absent.
+ */
+export async function findAuthUser(supabase, email) {
+  // Roster size in the hundreds; one page covers any practical org.
+  // listUsers() returns paginated results; iterate to be safe.
+  let page = 1;
+  while (true) {
+    const { data, error } = await supabase.auth.admin.listUsers({
+      page,
+      perPage: 1000,
+    });
+    if (error) throw new Error(`listUsers: ${error.message}`);
+    const match = data.users.find((u) => u.email === email);
+    if (match) return match;
+    if (data.users.length < 1000) return null;
+    page += 1;
+  }
+}

--- a/products/map/src/lib/data-dir.js
+++ b/products/map/src/lib/data-dir.js
@@ -1,0 +1,48 @@
+/**
+ * Locate the Map data directory for the running process.
+ *
+ * If `providedPath` is given, resolve it against the current cwd and verify
+ * it exists. Otherwise walk upward from the cwd using the shared `Finder`
+ * helper, returning the `pathway/` subdirectory of whatever `data/` root is
+ * found. Callers downstream of `findDataDir` (seed, transform) that need the
+ * `data/` root use `path.dirname(findDataDir(...))`.
+ */
+
+import fs from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { homedir as defaultHomedir } from "node:os";
+import { Finder } from "@forwardimpact/libutil";
+import { createLogger } from "@forwardimpact/libtelemetry";
+
+/**
+ * @param {string|undefined} providedPath - Explicit path from --data flag.
+ * @param {object} [deps]
+ * @param {typeof fs} [deps.fs] - Node fs/promises namespace (for tests).
+ * @param {object} [deps.process] - Process object (cwd, env).
+ * @param {() => string} [deps.homedir] - homedir() override.
+ * @returns {Promise<string>} Resolved data directory (pathway/) path.
+ */
+export async function findDataDir(
+  providedPath,
+  { fs: fsImpl = fs, process: proc = process, homedir = defaultHomedir } = {},
+) {
+  if (providedPath) {
+    const resolved = resolve(providedPath);
+    try {
+      await fsImpl.access(resolved);
+    } catch {
+      throw new Error(`Data directory not found: ${providedPath}`);
+    }
+    return resolved;
+  }
+
+  const logger = createLogger("map");
+  const finder = new Finder(fsImpl, logger, proc);
+  try {
+    return join(finder.findData("data", homedir()), "pathway");
+  } catch {
+    throw new Error(
+      "No data directory found. Use --data=<path> to specify location.",
+    );
+  }
+}

--- a/products/map/test/activity/substrate-issue.test.js
+++ b/products/map/test/activity/substrate-issue.test.js
@@ -230,4 +230,66 @@ describe("substrate issue", () => {
       /no auth.users row/,
     );
   });
+
+  test("rename failure on .env: no target files land, tmp files cleaned up", async () => {
+    // Make `.env` an existing non-empty directory so fs.rename(envTmp, envPath)
+    // fails with EISDIR/ENOTDIR before .substrate.json's rename runs.
+    await fs.mkdir(path.join(tmpdir, ".env"));
+    await fs.writeFile(path.join(tmpdir, ".env", "marker"), "blocker");
+
+    const supabase = makeSupabase({
+      personRow: { email: "alice@x", kind: "human", manager_email: null },
+    });
+    await assert.rejects(() =>
+      runSubstrateIssueCommand({
+        supabase,
+        config,
+        options: { email: "alice@x", cwd: tmpdir },
+      }),
+    );
+
+    const entries = await fs.readdir(tmpdir);
+    // No orphan .env.tmp-* or .substrate.json.tmp-* left behind.
+    assert.equal(
+      entries.filter((e) => e.includes(".tmp-")).length,
+      0,
+      `expected no orphan tmp files, got ${entries.join(", ")}`,
+    );
+    // .substrate.json must not exist (first rename failed before second).
+    assert.equal(entries.includes(".substrate.json"), false);
+  });
+
+  test("rename failure on .substrate.json: .env lands, .substrate.json absent, tmp files cleaned up", async () => {
+    // .env is plain (so its rename succeeds), but .substrate.json is a
+    // non-empty directory so fs.rename(subTmp, subPath) fails.
+    await fs.mkdir(path.join(tmpdir, ".substrate.json"));
+    await fs.writeFile(
+      path.join(tmpdir, ".substrate.json", "marker"),
+      "blocker",
+    );
+
+    const supabase = makeSupabase({
+      personRow: { email: "alice@x", kind: "human", manager_email: null },
+    });
+    await assert.rejects(() =>
+      runSubstrateIssueCommand({
+        supabase,
+        config,
+        options: { email: "alice@x", cwd: tmpdir },
+      }),
+    );
+
+    const entries = await fs.readdir(tmpdir);
+    // .env landed (first rename succeeded — atomicity is per-file, not
+    // cross-file; plan-a-02 § Step 6 commits to this contract).
+    assert.equal(entries.includes(".env"), true);
+    const envContent = await fs.readFile(path.join(tmpdir, ".env"), "utf8");
+    assert.match(envContent, /^PRODUCT_LANDMARK_TOKEN=/);
+    // No orphan tmp files.
+    assert.equal(
+      entries.filter((e) => e.includes(".tmp-")).length,
+      0,
+      `expected no orphan tmp files, got ${entries.join(", ")}`,
+    );
+  });
 });

--- a/products/map/test/activity/substrate-issue.test.js
+++ b/products/map/test/activity/substrate-issue.test.js
@@ -1,0 +1,233 @@
+/**
+ * Tests for `fit-map substrate issue` — covers atomic write, mode 0600
+ * on each file, the kind=human gate, and the optional --stash path.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { runSubstrateIssueCommand } from "../../src/commands/substrate-issue.js";
+
+function makeSupabase({
+  personRow,
+  authUsers = [{ email: "alice@x" }],
+  snapshots = [{ snapshot_id: "S1" }],
+  scores = [{ item_id: "ITEM1", snapshot_id: "S1" }],
+}) {
+  return {
+    from(table) {
+      let rows;
+      let filter = (rs) => rs;
+      switch (table) {
+        case "organization_people":
+          rows = personRow ? [personRow] : [];
+          break;
+        case "getdx_snapshots":
+          rows = snapshots;
+          break;
+        case "getdx_snapshot_team_scores":
+          rows = scores;
+          break;
+        default:
+          throw new Error(`unexpected table ${table}`);
+      }
+      let filtered = rows;
+      const builder = {
+        select() {
+          filtered = filter(rows);
+          return builder;
+        },
+        eq(col, val) {
+          filtered = filtered.filter((r) => r[col] === val);
+          return builder;
+        },
+        order() {
+          return builder;
+        },
+        limit() {
+          return Promise.resolve({ data: filtered, error: null });
+        },
+        async maybeSingle() {
+          return { data: filtered[0] ?? null, error: null };
+        },
+        then(resolve, reject) {
+          return Promise.resolve({ data: filtered, error: null }).then(
+            resolve,
+            reject,
+          );
+        },
+      };
+      return builder;
+    },
+    auth: {
+      admin: {
+        async listUsers() {
+          return { data: { users: authUsers }, error: null };
+        },
+      },
+    },
+  };
+}
+
+const config = {
+  supabaseJwtSecret: () =>
+    "long-enough-test-secret-for-hs256-min-32-bytes-aaaa",
+};
+
+describe("substrate issue", () => {
+  let tmpdir;
+  let stdoutWrite;
+
+  beforeEach(async () => {
+    tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), "substrate-issue-"));
+    stdoutWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = () => true;
+  });
+
+  afterEach(async () => {
+    process.stdout.write = stdoutWrite;
+    await fs.rm(tmpdir, { recursive: true, force: true });
+  });
+
+  test("writes .env (PRODUCT_LANDMARK_TOKEN) and .substrate.json with mode 0600", async () => {
+    const supabase = makeSupabase({
+      personRow: {
+        email: "alice@x",
+        kind: "human",
+        manager_email: null,
+      },
+    });
+    const code = await runSubstrateIssueCommand({
+      supabase,
+      config,
+      options: { email: "alice@x", cwd: tmpdir },
+    });
+    assert.equal(code, 0);
+
+    const envContent = await fs.readFile(path.join(tmpdir, ".env"), "utf8");
+    assert.match(envContent, /^PRODUCT_LANDMARK_TOKEN=[^\s]+\n$/);
+
+    const envStat = await fs.stat(path.join(tmpdir, ".env"));
+    assert.equal(envStat.mode & 0o777, 0o600);
+
+    const subRaw = await fs.readFile(
+      path.join(tmpdir, ".substrate.json"),
+      "utf8",
+    );
+    const parsed = JSON.parse(subRaw);
+    assert.equal(parsed.persona_email, "alice@x");
+    assert.equal(parsed.manager_email, "alice@x");
+    assert.equal(parsed.snapshot_id, "S1");
+    assert.equal(parsed.item_id, "ITEM1");
+
+    const subStat = await fs.stat(path.join(tmpdir, ".substrate.json"));
+    assert.equal(subStat.mode & 0o777, 0o600);
+  });
+
+  test("rejects kind=service_account with named alternative", async () => {
+    const supabase = makeSupabase({
+      personRow: {
+        email: "svc@x",
+        kind: "service_account",
+        manager_email: null,
+      },
+    });
+    await assert.rejects(
+      () =>
+        runSubstrateIssueCommand({
+          supabase,
+          config,
+          options: { email: "svc@x", cwd: tmpdir },
+        }),
+      /kind=service_account, not human.*fit-map auth issue/s,
+    );
+  });
+
+  test("--stash writes a third file containing just the JWT (mode 0600)", async () => {
+    const stashPath = path.join(tmpdir, "stash.jwt");
+    const supabase = makeSupabase({
+      personRow: {
+        email: "alice@x",
+        kind: "human",
+        manager_email: null,
+      },
+    });
+    const code = await runSubstrateIssueCommand({
+      supabase,
+      config,
+      options: { email: "alice@x", cwd: tmpdir, stash: stashPath },
+    });
+    assert.equal(code, 0);
+
+    const stashContent = await fs.readFile(stashPath, "utf8");
+    assert.match(
+      stashContent,
+      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\n$/,
+    );
+
+    const stashStat = await fs.stat(stashPath);
+    assert.equal(stashStat.mode & 0o777, 0o600);
+  });
+
+  test("missing --email throws", async () => {
+    const supabase = makeSupabase({ personRow: null });
+    await assert.rejects(
+      () =>
+        runSubstrateIssueCommand({
+          supabase,
+          config,
+          options: { cwd: tmpdir },
+        }),
+      /--email <e> is required/,
+    );
+  });
+
+  test("missing --cwd throws", async () => {
+    const supabase = makeSupabase({ personRow: null });
+    await assert.rejects(
+      () =>
+        runSubstrateIssueCommand({
+          supabase,
+          config,
+          options: { email: "alice@x" },
+        }),
+      /--cwd <path> is required/,
+    );
+  });
+
+  test("rejects when no organization_people row exists", async () => {
+    const supabase = makeSupabase({ personRow: null });
+    await assert.rejects(
+      () =>
+        runSubstrateIssueCommand({
+          supabase,
+          config,
+          options: { email: "ghost@x", cwd: tmpdir },
+        }),
+      /no organization_people row/,
+    );
+  });
+
+  test("rejects when no auth.users row exists", async () => {
+    const supabase = makeSupabase({
+      personRow: {
+        email: "alice@x",
+        kind: "human",
+        manager_email: null,
+      },
+      authUsers: [],
+    });
+    await assert.rejects(
+      () =>
+        runSubstrateIssueCommand({
+          supabase,
+          config,
+          options: { email: "alice@x", cwd: tmpdir },
+        }),
+      /no auth.users row/,
+    );
+  });
+});

--- a/products/map/test/activity/substrate-persona-query.test.js
+++ b/products/map/test/activity/substrate-persona-query.test.js
@@ -1,0 +1,205 @@
+/**
+ * Tests for `findInvariantSatisfyingPersonas` — covers each spec 990
+ * § Persona-corpus invariant and the binding-constraint diagnostic.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { findInvariantSatisfyingPersonas } from "../../src/commands/substrate-persona-query.js";
+
+/**
+ * Build a Supabase-shaped stub with the five tables the helper queries.
+ * Each table's stub returns rows; chained calls (select/eq/order/limit)
+ * are tolerated as no-ops so the helper's call patterns work.
+ */
+function makeStub({
+  snapshots = [],
+  scores = [],
+  humans = [],
+  artifacts = [],
+  evidence = [],
+} = {}) {
+  return {
+    from(table) {
+      let rows;
+      let filter = (rs) => rs;
+      switch (table) {
+        case "getdx_snapshots":
+          rows = snapshots;
+          break;
+        case "getdx_snapshot_team_scores":
+          rows = scores;
+          break;
+        case "organization_people":
+          rows = humans;
+          // helper filters `.eq("kind", "human")`
+          filter = (rs) => rs.filter((r) => r.kind === "human");
+          break;
+        case "github_artifacts":
+          rows = artifacts;
+          break;
+        case "evidence":
+          rows = evidence;
+          break;
+        default:
+          throw new Error(`unexpected table ${table}`);
+      }
+      let filtered = rows;
+      const builder = {
+        select() {
+          filtered = filter(rows);
+          return builder;
+        },
+        eq(col, val) {
+          filtered = filtered.filter((r) => r[col] === val);
+          return builder;
+        },
+        order() {
+          return builder;
+        },
+        limit() {
+          return Promise.resolve({ data: filtered, error: null });
+        },
+        then(resolve, reject) {
+          return Promise.resolve({ data: filtered, error: null }).then(
+            resolve,
+            reject,
+          );
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe("findInvariantSatisfyingPersonas", () => {
+  test("returns empty + diagnostic when no snapshots exist", async () => {
+    const supabase = makeStub({});
+    const out = await findInvariantSatisfyingPersonas({ supabase });
+    assert.equal(out.personas.length, 0);
+    assert.match(out.diagnostic, /no getdx_snapshots/);
+  });
+
+  test("returns empty + diagnostic when no scores for snapshot", async () => {
+    const supabase = makeStub({
+      snapshots: [{ snapshot_id: "S1", scheduled_for: "2026-01-01" }],
+    });
+    const out = await findInvariantSatisfyingPersonas({ supabase });
+    assert.equal(out.personas.length, 0);
+    assert.match(out.diagnostic, /no getdx_snapshot_team_scores/);
+  });
+
+  test("returns empty + diagnostic when no human rows", async () => {
+    const supabase = makeStub({
+      snapshots: [{ snapshot_id: "S1", scheduled_for: "2026-01-01" }],
+      scores: [{ item_id: "ITEM1", snapshot_id: "S1" }],
+      humans: [],
+    });
+    const out = await findInvariantSatisfyingPersonas({ supabase });
+    assert.equal(out.personas.length, 0);
+    assert.match(out.diagnostic, /no kind=human/);
+  });
+
+  test("filters out humans that fail any invariant; diagnoses binding constraint", async () => {
+    // alice manages bob, bob authored evidence → alice passes (a)(b? no — alice no evidence)(c)
+    const supabase = makeStub({
+      snapshots: [{ snapshot_id: "S1", scheduled_for: "2026-01-01" }],
+      scores: [{ item_id: "ITEM1", snapshot_id: "S1" }],
+      humans: [
+        {
+          email: "alice@x",
+          name: "A",
+          kind: "human",
+          discipline: "d",
+          level: "L1",
+          track: null,
+          manager_email: null,
+        },
+        {
+          email: "bob@x",
+          name: "B",
+          kind: "human",
+          discipline: "d",
+          level: "L1",
+          track: null,
+          manager_email: "alice@x",
+        },
+      ],
+      artifacts: [{ artifact_id: "ART1", email: "bob@x" }],
+      evidence: [{ artifact_id: "ART1" }],
+    });
+    const out = await findInvariantSatisfyingPersonas({ supabase });
+    // alice fails (b) — has no evidence row of her own. No persona qualifies.
+    assert.equal(out.personas.length, 0);
+    assert.match(
+      out.diagnostic,
+      /no invariant-satisfying persona — binding constraint:/,
+    );
+  });
+
+  test("returns a persona that satisfies all four invariants", async () => {
+    // alice manages bob AND has her own evidence; bob authored evidence
+    // (so practice_directs_count >= 1 for alice).
+    const supabase = makeStub({
+      snapshots: [{ snapshot_id: "S1", scheduled_for: "2026-01-01" }],
+      scores: [{ item_id: "ITEM1", snapshot_id: "S1" }],
+      humans: [
+        {
+          email: "alice@x",
+          name: "A",
+          kind: "human",
+          discipline: "d",
+          level: "L1",
+          track: null,
+          manager_email: null,
+        },
+        {
+          email: "bob@x",
+          name: "B",
+          kind: "human",
+          discipline: "d",
+          level: "L1",
+          track: null,
+          manager_email: "alice@x",
+        },
+      ],
+      artifacts: [
+        { artifact_id: "ART1", email: "alice@x" },
+        { artifact_id: "ART2", email: "bob@x" },
+      ],
+      evidence: [{ artifact_id: "ART1" }, { artifact_id: "ART2" }],
+    });
+    const out = await findInvariantSatisfyingPersonas({ supabase });
+    assert.equal(out.personas.length, 1);
+    assert.equal(out.personas[0].email, "alice@x");
+    assert.equal(out.discovery.snapshot_id, "S1");
+    assert.equal(out.discovery.item_id, "ITEM1");
+    assert.equal(out.personas[0].manages_count, 1);
+    assert.equal(out.personas[0].evidence_count, 1);
+    assert.equal(out.personas[0].practice_directs_count, 1);
+  });
+
+  test("excludes service_account rows from the humans pool", async () => {
+    const supabase = makeStub({
+      snapshots: [{ snapshot_id: "S1", scheduled_for: "2026-01-01" }],
+      scores: [{ item_id: "ITEM1", snapshot_id: "S1" }],
+      humans: [
+        {
+          email: "svc@x",
+          name: "Svc",
+          kind: "service_account",
+          discipline: "d",
+          level: "L1",
+          track: null,
+          manager_email: null,
+        },
+      ],
+      artifacts: [],
+      evidence: [],
+    });
+    const out = await findInvariantSatisfyingPersonas({ supabase });
+    assert.equal(out.personas.length, 0);
+    assert.match(out.diagnostic, /no kind=human/);
+  });
+});

--- a/products/map/test/activity/substrate-roster.test.js
+++ b/products/map/test/activity/substrate-roster.test.js
@@ -134,7 +134,7 @@ describe("substrate-roster JSON output", () => {
     err.restore();
   });
 
-  test("--format json returns { personas, selection_metadata, discovery }", async () => {
+  test("--format json returns { personas, selection_metadata } with per-row discovery", async () => {
     const supabase = makeStub(supabasePersonaArtifacts);
     const code = await runRosterCommand({
       supabase,
@@ -148,8 +148,11 @@ describe("substrate-roster JSON output", () => {
       "memory_diversification",
       "jtbd_role_alignment",
     ]);
-    assert.equal(parsed.discovery.snapshot_id, "S1");
-    assert.equal(parsed.discovery.item_id, "ITEM1");
+    // snapshot_id/item_id are per-persona-row (consistent with SKILL.md
+    // Step 3a). No top-level `discovery` field is exposed.
+    assert.equal(parsed.personas[0].snapshot_id, "S1");
+    assert.equal(parsed.personas[0].item_id, "ITEM1");
+    assert.equal(parsed.discovery, undefined);
   });
 
   test("non-empty corpus exits 0 with text output", async () => {

--- a/products/map/test/activity/substrate-roster.test.js
+++ b/products/map/test/activity/substrate-roster.test.js
@@ -1,0 +1,168 @@
+/**
+ * Tests for `fit-map substrate roster` — verifies JSON output shape,
+ * exit codes on non-empty vs. empty corpora, and stderr diagnostic
+ * propagation.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { runRosterCommand } from "../../src/commands/substrate-roster.js";
+
+const supabasePersonaArtifacts = {
+  snapshots: [{ snapshot_id: "S1", scheduled_for: "2026-01-01" }],
+  scores: [{ item_id: "ITEM1", snapshot_id: "S1" }],
+  humans: [
+    {
+      email: "alice@x",
+      name: "Alice",
+      kind: "human",
+      discipline: "d",
+      level: "L1",
+      track: "core",
+      manager_email: null,
+    },
+    {
+      email: "bob@x",
+      name: "Bob",
+      kind: "human",
+      discipline: "d",
+      level: "L1",
+      track: null,
+      manager_email: "alice@x",
+    },
+  ],
+  artifacts: [
+    { artifact_id: "ART1", email: "alice@x" },
+    { artifact_id: "ART2", email: "bob@x" },
+  ],
+  evidence: [{ artifact_id: "ART1" }, { artifact_id: "ART2" }],
+};
+
+function makeStub(seed) {
+  return {
+    from(table) {
+      let rows;
+      let filter = (rs) => rs;
+      switch (table) {
+        case "getdx_snapshots":
+          rows = seed.snapshots ?? [];
+          break;
+        case "getdx_snapshot_team_scores":
+          rows = seed.scores ?? [];
+          break;
+        case "organization_people":
+          rows = seed.humans ?? [];
+          filter = (rs) => rs.filter((r) => r.kind === "human");
+          break;
+        case "github_artifacts":
+          rows = seed.artifacts ?? [];
+          break;
+        case "evidence":
+          rows = seed.evidence ?? [];
+          break;
+        default:
+          throw new Error(`unexpected table ${table}`);
+      }
+      let filtered = rows;
+      const builder = {
+        select() {
+          filtered = filter(rows);
+          return builder;
+        },
+        eq(col, val) {
+          filtered = filtered.filter((r) => r[col] === val);
+          return builder;
+        },
+        order() {
+          return builder;
+        },
+        limit() {
+          return Promise.resolve({ data: filtered, error: null });
+        },
+        then(resolve, reject) {
+          return Promise.resolve({ data: filtered, error: null }).then(
+            resolve,
+            reject,
+          );
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+function captureStdout() {
+  const chunks = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+    return true;
+  };
+  return {
+    text: () => chunks.join(""),
+    restore: () => {
+      process.stdout.write = orig;
+    },
+  };
+}
+
+function captureStderr() {
+  const chunks = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+    return true;
+  };
+  return {
+    text: () => chunks.join(""),
+    restore: () => {
+      process.stderr.write = orig;
+    },
+  };
+}
+
+describe("substrate-roster JSON output", () => {
+  let out;
+  let err;
+  beforeEach(() => {
+    out = captureStdout();
+    err = captureStderr();
+  });
+  afterEach(() => {
+    out.restore();
+    err.restore();
+  });
+
+  test("--format json returns { personas, selection_metadata, discovery }", async () => {
+    const supabase = makeStub(supabasePersonaArtifacts);
+    const code = await runRosterCommand({
+      supabase,
+      options: { format: "json" },
+    });
+    assert.equal(code, 0);
+    const parsed = JSON.parse(out.text());
+    assert.equal(parsed.personas.length, 1);
+    assert.equal(parsed.personas[0].email, "alice@x");
+    assert.deepEqual(parsed.selection_metadata.signals, [
+      "memory_diversification",
+      "jtbd_role_alignment",
+    ]);
+    assert.equal(parsed.discovery.snapshot_id, "S1");
+    assert.equal(parsed.discovery.item_id, "ITEM1");
+  });
+
+  test("non-empty corpus exits 0 with text output", async () => {
+    const supabase = makeStub(supabasePersonaArtifacts);
+    const code = await runRosterCommand({ supabase, options: {} });
+    assert.equal(code, 0);
+    assert.match(out.text(), /alice@x/);
+  });
+
+  test("empty corpus exits non-zero with diagnostic on stderr", async () => {
+    const supabase = makeStub({});
+    const code = await runRosterCommand({ supabase, options: {} });
+    assert.notEqual(code, 0);
+    assert.match(err.text(), /substrate roster:/);
+  });
+});

--- a/products/map/test/activity/substrate-smoke.test.js
+++ b/products/map/test/activity/substrate-smoke.test.js
@@ -1,7 +1,10 @@
 /**
- * Tests for substrate-smoke's pure assertion helpers. The spawn-based
- * iterator is covered by integration in the actual stage run; here we
- * verify the shape/email/exp/role-claim guards and persona kind check.
+ * Tests for substrate-smoke's pure assertion helpers and iteration
+ * builders. The actual `bunx fit-landmark` spawn loop is covered by
+ * integration in the live stage run; here we verify every pure
+ * surface the smoke composes from (shape/email/exp/role-claim guards,
+ * persona kind check, smoke-list expansion, argv build, row-class
+ * non-empty assertion).
  */
 
 import { describe, test } from "node:test";
@@ -9,9 +12,12 @@ import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
 
 import {
-  assertJwtShape,
-  assertPersonaIsHuman,
   assertDiscoveryResolves,
+  assertJwtShape,
+  assertNonEmpty,
+  assertPersonaIsHuman,
+  buildSmokeArgv,
+  buildSmokeList,
 } from "../../src/commands/substrate-smoke.js";
 
 function makeJwt(claims) {
@@ -152,6 +158,166 @@ describe("assertDiscoveryResolves", () => {
       assertDiscoveryResolves(
         { email: "a@x", manager_email: "a@x" },
         { snapshot_id: "S", item_id: "I" },
+      ),
+    );
+  });
+});
+
+describe("buildSmokeList expands manifest to iteration items", () => {
+  // A miniature manifest mirroring the real fit-landmark shape.
+  const manifest = {
+    commands: {
+      org: { needsSupabase: true },
+      snapshot: { needsSupabase: true },
+      evidence: { needsSupabase: true },
+      practice: { needsSupabase: true },
+      health: { needsSupabase: true },
+      marker: { needsSupabase: false },
+    },
+    subcommandExpansions: {
+      org: [
+        { command: "org show", smokeOptions: {} },
+        { command: "org team", smokeOptions: { manager: "$PERSONA_EMAIL" } },
+      ],
+      snapshot: [
+        { command: "snapshot list", smokeOptions: {} },
+        {
+          command: "snapshot show",
+          smokeOptions: { snapshot: "$SNAPSHOT_ID" },
+        },
+      ],
+    },
+    flatSmokeOptions: {
+      evidence: { email: "$PERSONA_EMAIL" },
+      practice: { manager: "$PERSONA_EMAIL" },
+    },
+  };
+
+  test("skips needsSupabase=false commands", () => {
+    const list = buildSmokeList(manifest);
+    assert.equal(
+      list.find((i) => i.command === "marker"),
+      undefined,
+    );
+  });
+
+  test("expands subcommand-style entries via SUBCOMMAND_EXPANSIONS", () => {
+    const list = buildSmokeList(manifest);
+    const orgs = list.filter((i) => i.command.startsWith("org "));
+    assert.equal(orgs.length, 2);
+    assert.deepEqual(
+      orgs.map((i) => i.command),
+      ["org show", "org team"],
+    );
+  });
+
+  test("flat commands carry FLAT_SMOKE_OPTIONS", () => {
+    const list = buildSmokeList(manifest);
+    const ev = list.find((i) => i.command === "evidence");
+    assert.deepEqual(ev.smokeOptions, { email: "$PERSONA_EMAIL" });
+  });
+
+  test("flat commands with no smoke options resolve to {}", () => {
+    const list = buildSmokeList(manifest);
+    const health = list.find((i) => i.command === "health");
+    assert.deepEqual(health.smokeOptions, {});
+  });
+});
+
+describe("buildSmokeArgv substitutes placeholders", () => {
+  const persona = {
+    email: "alice@x",
+    manager_email: "alice@x",
+  };
+  const discovery = { snapshot_id: "S1", item_id: "ITEM1" };
+
+  test("substitutes $PERSONA_EMAIL into option flags", () => {
+    const argv = buildSmokeArgv(
+      { command: "evidence", smokeOptions: { email: "$PERSONA_EMAIL" } },
+      persona,
+      discovery,
+    );
+    assert.deepEqual(argv, [
+      "evidence",
+      "--email",
+      "alice@x",
+      "--format",
+      "json",
+    ]);
+  });
+
+  test("substitutes $SNAPSHOT_ID and $ITEM_ID", () => {
+    const trend = buildSmokeArgv(
+      { command: "snapshot trend", smokeOptions: { item: "$ITEM_ID" } },
+      persona,
+      discovery,
+    );
+    assert.deepEqual(trend, [
+      "snapshot",
+      "trend",
+      "--item",
+      "ITEM1",
+      "--format",
+      "json",
+    ]);
+    const show = buildSmokeArgv(
+      { command: "snapshot show", smokeOptions: { snapshot: "$SNAPSHOT_ID" } },
+      persona,
+      discovery,
+    );
+    assert.deepEqual(show, [
+      "snapshot",
+      "show",
+      "--snapshot",
+      "S1",
+      "--format",
+      "json",
+    ]);
+  });
+
+  test("flat commands with no smoke options still get --format json", () => {
+    const argv = buildSmokeArgv(
+      { command: "health", smokeOptions: {} },
+      persona,
+      discovery,
+    );
+    assert.deepEqual(argv, ["health", "--format", "json"]);
+  });
+});
+
+describe("assertNonEmpty row-class trigger", () => {
+  test("throws on empty array under the named key", () => {
+    assert.throws(
+      () => assertNonEmpty(JSON.stringify({ team: [] }), "team"),
+      /row-class non-empty assertion failed for team/,
+    );
+  });
+
+  test("throws on missing key", () => {
+    assert.throws(
+      () => assertNonEmpty(JSON.stringify({ other: [{ x: 1 }] }), "team"),
+      /row-class non-empty assertion failed for team/,
+    );
+  });
+
+  test("throws on empty object", () => {
+    assert.throws(
+      () => assertNonEmpty(JSON.stringify({ evidence: {} }), "evidence"),
+      /row-class non-empty assertion failed for evidence/,
+    );
+  });
+
+  test("accepts non-empty array", () => {
+    assert.doesNotThrow(() =>
+      assertNonEmpty(JSON.stringify({ team: [{ email: "a@x" }] }), "team"),
+    );
+  });
+
+  test("accepts non-empty object (e.g. evidence by skillId)", () => {
+    assert.doesNotThrow(() =>
+      assertNonEmpty(
+        JSON.stringify({ evidence: { task_completion: [{ id: 1 }] } }),
+        "evidence",
       ),
     );
   });

--- a/products/map/test/activity/substrate-smoke.test.js
+++ b/products/map/test/activity/substrate-smoke.test.js
@@ -1,0 +1,158 @@
+/**
+ * Tests for substrate-smoke's pure assertion helpers. The spawn-based
+ * iterator is covered by integration in the actual stage run; here we
+ * verify the shape/email/exp/role-claim guards and persona kind check.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+
+import {
+  assertJwtShape,
+  assertPersonaIsHuman,
+  assertDiscoveryResolves,
+} from "../../src/commands/substrate-smoke.js";
+
+function makeJwt(claims) {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+function future() {
+  return Math.floor(Date.now() / 1000) + 600;
+}
+
+describe("assertJwtShape", () => {
+  test("rejects wrong aud", () => {
+    const jwt = makeJwt({
+      aud: "anon",
+      role: "authenticated",
+      email: "a@b",
+      exp: future(),
+    });
+    assert.throws(() => assertJwtShape(jwt, "a@b"), /aud != authenticated/);
+  });
+
+  test("rejects wrong role", () => {
+    const jwt = makeJwt({
+      aud: "authenticated",
+      role: "anon",
+      email: "a@b",
+      exp: future(),
+    });
+    assert.throws(() => assertJwtShape(jwt, "a@b"), /role != authenticated/);
+  });
+
+  test("rejects email mismatch", () => {
+    const jwt = makeJwt({
+      aud: "authenticated",
+      role: "authenticated",
+      email: "wrong@x",
+      exp: future(),
+    });
+    assert.throws(() => assertJwtShape(jwt, "right@x"), /email mismatch/);
+  });
+
+  test("rejects expired exp", () => {
+    const jwt = makeJwt({
+      aud: "authenticated",
+      role: "authenticated",
+      email: "a@b",
+      exp: Math.floor(Date.now() / 1000) - 60,
+    });
+    assert.throws(() => assertJwtShape(jwt, "a@b"), /exp claim/);
+  });
+
+  test("accepts a well-shaped JWT", () => {
+    const jwt = makeJwt({
+      aud: "authenticated",
+      role: "authenticated",
+      email: "a@b",
+      exp: future(),
+    });
+    assert.doesNotThrow(() => assertJwtShape(jwt, "a@b"));
+  });
+});
+
+describe("assertPersonaIsHuman", () => {
+  function makeSupabase(row, error = null) {
+    return {
+      from() {
+        return {
+          select() {
+            return this;
+          },
+          eq() {
+            return this;
+          },
+          async maybeSingle() {
+            return { data: row, error };
+          },
+        };
+      },
+    };
+  }
+
+  test("rejects kind=service_account", async () => {
+    const sb = makeSupabase({ kind: "service_account" });
+    await assert.rejects(() => assertPersonaIsHuman(sb, "svc@x"), /not human/);
+  });
+
+  test("rejects missing row", async () => {
+    const sb = makeSupabase(null);
+    await assert.rejects(
+      () => assertPersonaIsHuman(sb, "missing@x"),
+      /not human/,
+    );
+  });
+
+  test("rejects on supabase error", async () => {
+    const sb = makeSupabase(null, { message: "boom" });
+    await assert.rejects(
+      () => assertPersonaIsHuman(sb, "x@x"),
+      /organization_people: boom/,
+    );
+  });
+
+  test("accepts kind=human", async () => {
+    const sb = makeSupabase({ kind: "human" });
+    await assert.doesNotReject(() => assertPersonaIsHuman(sb, "p@x"));
+  });
+});
+
+describe("assertDiscoveryResolves", () => {
+  test("rejects persona missing manager_email", () => {
+    assert.throws(
+      () =>
+        assertDiscoveryResolves(
+          { email: "a@x" },
+          { snapshot_id: "S", item_id: "I" },
+        ),
+      /missing email\/manager_email/,
+    );
+  });
+
+  test("rejects discovery missing snapshot_id", () => {
+    assert.throws(
+      () =>
+        assertDiscoveryResolves(
+          { email: "a@x", manager_email: "a@x" },
+          { snapshot_id: null, item_id: "I" },
+        ),
+      /discovery vector incomplete/,
+    );
+  });
+
+  test("accepts a fully populated persona + discovery", () => {
+    assert.doesNotThrow(() =>
+      assertDiscoveryResolves(
+        { email: "a@x", manager_email: "a@x" },
+        { snapshot_id: "S", item_id: "I" },
+      ),
+    );
+  });
+});

--- a/products/map/test/activity/substrate-stage.test.js
+++ b/products/map/test/activity/substrate-stage.test.js
@@ -44,16 +44,28 @@ function buildDeps({ failPhase = null, invocations }) {
 describe("substrate-stage phase ordering", () => {
   let invocations;
   let stdoutWrite;
+  let prevSupabaseUrl;
+  let prevSupabaseAnonKey;
 
   beforeEach(() => {
     invocations = [];
     delete process.env.SUBSTRATE_FORCE_EMPTY_CORPUS;
+    // The url-discovery phase writes SUPABASE_URL/ANON_KEY to process.env
+    // (intentional in production; see no-supabase-env-in-src.test.js ALLOW
+    // entry). Snapshot whatever's there and restore in afterEach so
+    // subsequent tests in this Bun process don't inherit the stub values.
+    prevSupabaseUrl = process.env.SUPABASE_URL;
+    prevSupabaseAnonKey = process.env.SUPABASE_ANON_KEY;
     stdoutWrite = process.stdout.write.bind(process.stdout);
     process.stdout.write = () => true;
   });
 
   afterEach(() => {
     delete process.env.SUBSTRATE_FORCE_EMPTY_CORPUS;
+    if (prevSupabaseUrl === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = prevSupabaseUrl;
+    if (prevSupabaseAnonKey === undefined) delete process.env.SUPABASE_ANON_KEY;
+    else process.env.SUPABASE_ANON_KEY = prevSupabaseAnonKey;
     process.stdout.write = stdoutWrite;
   });
 

--- a/products/map/test/activity/substrate-stage.test.js
+++ b/products/map/test/activity/substrate-stage.test.js
@@ -1,0 +1,99 @@
+/**
+ * Tests for `fit-map substrate stage` — uses injected dependency
+ * overrides to stub out the Supabase CLI, mapClient, seed, provision,
+ * and the self-smoke so the phase ordering is verifiable without a
+ * live stack.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { runStageCommand } from "../../src/commands/substrate-stage.js";
+
+function buildDeps({ failPhase = null, invocations }) {
+  function recorded(name, fn = async () => undefined) {
+    return async (...args) => {
+      invocations.push(name);
+      if (failPhase === name) throw new Error(`stubbed ${name} failure`);
+      return fn(...args);
+    };
+  }
+  const cliStub = {
+    run: async (args) => {
+      if (args[0] === "start") return recorded("stack")();
+      if (args[0] === "db" && args[1] === "reset") return recorded("migrate")();
+      throw new Error(`unexpected supabase run: ${args.join(" ")}`);
+    },
+    capture: recorded("url-discovery", async () =>
+      JSON.stringify({
+        api_url: "http://supabase.local",
+        anon_key: "anon-key",
+      }),
+    ),
+  };
+  return {
+    createSupabaseCli: () => cliStub,
+    createMapClient: () => ({ stub: true }),
+    findDataDir: async () => "/tmp/data/pathway",
+    loadSeed: async () => recorded("seed"),
+    loadProvision: async () => recorded("provision"),
+    loadSmoke: async () => recorded("smoke"),
+  };
+}
+
+describe("substrate-stage phase ordering", () => {
+  let invocations;
+  let stdoutWrite;
+
+  beforeEach(() => {
+    invocations = [];
+    delete process.env.SUBSTRATE_FORCE_EMPTY_CORPUS;
+    stdoutWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = () => true;
+  });
+
+  afterEach(() => {
+    delete process.env.SUBSTRATE_FORCE_EMPTY_CORPUS;
+    process.stdout.write = stdoutWrite;
+  });
+
+  test("invokes phases in stack → url-discovery → migrate → seed → provision → smoke order", async () => {
+    const deps = buildDeps({ invocations });
+    const config = { supabaseJwtSecret: () => "secret" };
+    await runStageCommand({ config }, deps);
+    assert.deepEqual(invocations, [
+      "stack",
+      "url-discovery",
+      "migrate",
+      "seed",
+      "provision",
+      "smoke",
+    ]);
+  });
+
+  test("SUBSTRATE_FORCE_EMPTY_CORPUS=true short-circuits smoke phase with named error", async () => {
+    process.env.SUBSTRATE_FORCE_EMPTY_CORPUS = "true";
+    const deps = buildDeps({ invocations });
+    const config = { supabaseJwtSecret: () => "secret" };
+    await assert.rejects(
+      () => runStageCommand({ config }, deps),
+      /\[substrate stage: smoke\] empty corpus/,
+    );
+    assert.deepEqual(invocations, [
+      "stack",
+      "url-discovery",
+      "migrate",
+      "seed",
+      "provision",
+    ]);
+  });
+
+  test("each phase failure is wrapped in [substrate stage: <phase>] prefix", async () => {
+    const deps = buildDeps({ invocations, failPhase: "seed" });
+    const config = { supabaseJwtSecret: () => "secret" };
+    await assert.rejects(
+      () => runStageCommand({ config }, deps),
+      /\[substrate stage: seed\] stubbed seed failure/,
+    );
+  });
+});

--- a/specs/1000-product-init-config-parity/spec.md
+++ b/specs/1000-product-init-config-parity/spec.md
@@ -1,0 +1,130 @@
+# Spec 1000 — Cross-product `init` parity for `config/` and `.env` bootstrap
+
+## Problem
+
+A contributor (human or agent) running a Forward Impact product CLI against
+a clean directory hits one of two failure modes today: the CLI either
+silently anchors its configuration against an unrelated `config/` directory
+somewhere up the filesystem tree, or refuses to load configuration the
+caller assumed was implicit. The first failure produces wrong-source bugs
+that manifest far from their cause; the second produces "why doesn't this
+work?" friction at the moment a new user is forming their model of the
+tool.
+
+The cause is structural. Every product CLI loads its configuration through
+[`createProductConfig`](../../libraries/libconfig/src/index.js), and
+configuration anchoring relies on a `config/` directory existing at the
+project root (the
+[`createStorage("config", …)`](../../libraries/libstorage/src/index.js)
+helper walks up the filesystem looking for one). Product `init` verbs that
+bootstrap a project to that contract are inconsistent across the family:
+
+| CLI | Creates `config/` | Writes `config.json` | Writes `.env` | Init verb today |
+|---|---|---|---|---|
+| `fit-guide init` ([init.js](../../products/guide/src/commands/init.js)) | yes | yes (from `starter/config.json`) | yes (service URLs + credential generation) | shipped |
+| `fit-map init` ([init.js](../../products/map/src/commands/init.js)) | no | no | no | shipped (data-only) |
+| `fit-pathway` | n/a | n/a | n/a | not shipped; in-flight [spec 230](../230-pathway-init-npm/spec.md) |
+| `fit-landmark` | n/a | n/a | n/a | not shipped |
+| `fit-summit` | n/a | n/a | n/a | not shipped |
+| `fit-outpost` | n/a | n/a | n/a | not shipped |
+
+Two concrete failures follow from this asymmetry:
+
+**1. Anchor escape, observed.** During spec 990's implementation, the
+kata-interview workflow had to add a workaround step
+([kata-interview.yml § Substrate stage](../../.github/workflows/kata-interview.yml))
+because invoking a fit-map CLI verb from an `$AGENT_CWD` without `config/`
+caused the upward-walk to resolve outside `$AGENT_CWD`. Spec 990 ships that
+workaround as a one-line `mkdir -p`. Every other caller that runs a Forward
+Impact CLI outside a `fit-guide`-initialised project re-encounters the same
+escape and has to know the workaround.
+
+**2. Bootstrap re-derivation, forecast.** `fit-guide init` already carries
+~50 lines of `config/` creation, starter-config copy, and `.env`
+provisioning logic. Spec 230 proposes an `fit-pathway init` that will
+re-derive the same shape; every future product that adopts `init` faces the
+same decision. Two products with non-overlapping top-level config
+namespaces (`product.guide` + `service.mcp` from Guide; whatever Map ships)
+are safe to merge given a shared writer, but each per-product `init` today
+either has to skip writing `config/` (fit-map's current path) or risk
+truncating a sibling product's contributions (a hypothetical fit-map init
+that overwrote `config/config.json`).
+
+The user-facing job impacted is the closest match in
+[JTBD.md § Platform Builders: Build Agent-Capable Systems](../../JTBD.md).
+Its **Trigger** — *"Building an agent that needs structured knowledge or
+typed contracts — and the alternative is reimplementing plumbing from
+scratch"* — applies directly: a contributor adopting a new product CLI is
+reimplementing project-bootstrap plumbing if every product's `init`
+makes its own choices. Its **Competes With** clause names "ad-hoc
+frameworks" as the alternative to defeat. The mapping isn't perfect —
+the JTBD's Big/Little Hire route to **Gear**, not to product CLIs
+directly — but the underlying job (give the family a shared capability
+through one interface) is the one this spec serves.
+
+## Scope
+
+### In scope
+
+| Component | What changes |
+|---|---|
+| Shared init capability | One callable interface, exposed from a Forward Impact library, that a product's `init` verb hands its starter material to. The interface receives at least: a target directory, a `config.json` fragment scoped to one or more top-level namespaces the product owns, and a set of `.env` entries the product wants written. Where the interface lives (which library) and what it's named is a design choice. |
+| Namespace ownership semantics | The shared interface treats top-level keys in `config.json` as product-owned: keys present at the same path with the same value across two callers are a successful no-op; keys present at the same path with different values are a refusal-by-default that requires the caller to signal explicit overwrite intent. Cross-namespace writes always succeed. The mechanism for signalling overwrite intent is a design choice. |
+| `.env` write semantics | Same ownership model as `config.json` at the key granularity, expressed against the actual `.env` file the libconfig credential-override loop reads. Same-key-same-value writes are no-ops; same-key-different-value writes refuse without explicit overwrite intent. The shared interface preserves whatever permissions the existing `.env` writer maintains today; if no permission guarantee exists today, this spec does not introduce one. |
+| Read-side coherence with spec 990 | Spec 990 introduced credential-override semantics where shell env wins over `.env`, and empty-string shell values are treated as absent for credential keys. The `.env` write semantics this spec introduces apply only to the *writer*. The reader's resolution order is unchanged; an empty-string write to `.env` is therefore equivalent to absence on the read path. |
+| `fit-map init` behaviour change | `fit-map init` adopts the shared interface and starts producing a `config/` directory at the init target. Whether it ships a starter `config.json` fragment carrying a `product.map` namespace is a design choice; the spec requires only that subsequent fit-map CLI invocations from that target resolve config-anchoring locally (rather than escaping upward). The existing `data/pathway/` write is unchanged. |
+| `fit-guide init` behaviour preservation | `fit-guide init` adopts the shared interface; the set of files it produces on disk, the set of `.env` keys it writes, and its exit-code contract for the same user invocations all match the pre-spec behaviour. |
+| New-product onboarding | A documented contract — surfaced at one home (the design picks where) — describes how a future product's `init` verb adopts the shared interface: package its starter material, declare the namespaces it owns, hand both to the interface. |
+| Failure surfacing | A refused write (same-key-different-value, no overwrite intent) exits non-zero with a diagnostic that names the conflicting key path and what the caller would do to signal overwrite intent. Whether the diagnostic also names the *first writer* is left to the design — recording first-writer identity may be unimplementable without a marker the spec does not require. |
+
+### Out of scope, deferred
+
+- **Removing the kata-interview workflow's `mkdir -p config/` workaround.**
+  That line ships under spec 990 and stays until a downstream consumer
+  supersedes it. Removal belongs in a follow-up spec once `fit-map init`
+  is the canonical path.
+- **Adding new `init` verbs.** `fit-landmark`, `fit-summit`, and
+  `fit-outpost` do not ship `init` today. Whether they should is a
+  per-product decision deferred to per-product specs. `fit-pathway init`
+  is owned by spec 230 — coordinating the two specs is in scope (this
+  spec should not contradict 230), but writing 230's plan is not.
+- **Schema validation of merged `config.json`.** The spec covers merge
+  ownership and conflict-refusal, not whether the merged document
+  validates against a JSON schema. A future spec may add a schema once
+  enough products ship namespaced sections.
+- **Versioning of the shared interface's contract.** Forward-only via
+  the library's own semver; a versioned `config.json` document is
+  deferred.
+- **Hosted secret stores for `.env` values.** Local-file write only.
+- **Cross-file atomicity of `config.json` + `.env`.** If a process dies
+  between the two writes, the project layout is left in a half-state.
+  `fit-guide init` carries the same property today; this spec preserves
+  rather than tightens it. A separate spec may add cross-file atomicity
+  if the failure mode is reported in the field.
+- **Migrating non-init callers that create `config/` themselves** (the
+  kata-interview substrate-stage workflow, any future direct caller).
+  The spec is scoped to product `init` verbs.
+
+## Preconditions
+
+This spec assumes spec 990 has merged before implementation begins. Spec
+990 ships the `mkdir -p config/` workaround that today represents the
+**1. Anchor escape, observed** failure mode in the Problem statement; the
+implementation surface of this spec replaces (and eventually allows
+removal of) that line. If 990 changes shape during its panel review or
+post-merge fixes, this spec's Problem evidence may need to be re-anchored.
+
+## Success Criteria
+
+| Claim | Verification |
+|---|---|
+| Two products with disjoint top-level namespaces produce a `config/config.json` carrying both starters' contributions. | A test invokes the shared interface against the same target directory with two starters declaring different top-level namespaces, then reads `config.json` and asserts every top-level key from both starters is present with its original value. |
+| Re-invoking the shared interface with the same starter is a no-op. | A test invokes the interface twice with identical inputs against the same target, asserts the second call exits zero, and asserts the on-disk `config.json` and `.env` bytes are identical between calls. |
+| Re-invoking with two products' starters in alternating order converges to a stable result. | A test invokes the interface as A → B → A → B against the same target with the same two disjoint starters, asserts the final on-disk state is byte-identical to the state after the first A → B pair. |
+| Same-key, different-value writes refuse by default and name what the caller would do to opt in. | A test invokes the interface once writing `product.x.foo = "a"`, then again writing `product.x.foo = "b"` without overwrite intent; asserts the second call exits non-zero, the on-disk `config.json` is byte-identical to the state after the first call, and the stderr diagnostic carries the conflicting key path and a reference to the overwrite-intent surface. |
+| Same-key, same-value writes are no-ops. | Same test setup with `product.x.foo = "a"` written twice exits zero on the second call and produces byte-identical on-disk state. |
+| `.env` writes follow the same ownership semantics. | A test invokes the interface with a starter declaring two `.env` entries against a target that already carries a third disjoint `.env` entry from prior provisioning; asserts the result carries all three entries with their original values, the pre-existing entry is byte-unchanged, and a subsequent same-key-different-value write refuses non-zero. |
+| `fit-map init` produces a project layout where subsequent fit-map invocations anchor at the init target. | A test runs `fit-map init` against a fresh tmpdir, then runs a fit-map verb that loads libconfig from a subdirectory of the tmpdir; asserts libconfig's resolved anchor is the init target rather than any ancestor. |
+| `fit-guide init`'s observable contract is preserved. | The existing fit-guide init test suite stays green. Specifically: the same set of files lands on disk for the same user invocations (a `config/config.json`, a `.env` carrying the same key set, a `package.json` when one didn't exist, a `.claude/skills/` tree when starter skills exist), and the same exit codes are returned. |
+| The new-product onboarding contract is discoverable from at least one entry point a new contributor will naturally find. | A test runs `bunx fit-<product> init --help` for every product that ships `init` after this spec lands, asserts the rendered help text references the shared contract by name or surface. |
+| Existing in-tree tests for libconfig, libsecret, and the affected product CLIs stay green. | `bun run test` exits zero on the implementation branch. |

--- a/websites/fit/docs/getting-started/leaders/landmark/index.md
+++ b/websites/fit/docs/getting-started/leaders/landmark/index.md
@@ -19,7 +19,7 @@ in the Map guide.
 - Node.js 18+
 - npm
 - Map's activity layer running and populated
-- A Supabase Auth JWT exported as `LANDMARK_AUTH_TOKEN` — see
+- A Supabase Auth JWT exported as `PRODUCT_LANDMARK_TOKEN` — see
   [Authentication](#authentication) below
 
 ## Install
@@ -30,7 +30,7 @@ npm install @forwardimpact/landmark
 
 ## Authentication
 
-Every Landmark command except `marker` reads `LANDMARK_AUTH_TOKEN` from the
+Every Landmark command except `marker` reads `PRODUCT_LANDMARK_TOKEN` from the
 environment and rejects requests without it. The token is a Supabase Auth JWT
 bound to your email — row-level security uses the `email` claim to scope every
 query, so the token both authenticates you and determines what you can see.
@@ -61,7 +61,7 @@ Today's minimum stand-up is four steps under Map:
    export it:
 
    ```sh
-   export LANDMARK_AUTH_TOKEN=<your signed JWT>
+   export PRODUCT_LANDMARK_TOKEN=<your signed JWT>
    ```
 
    The signing recipe — header `{alg: "HS256", typ: "JWT"}`, payload with
@@ -70,7 +70,7 @@ Today's minimum stand-up is four steps under Map:
    `products/landmark/test/lib/sign-test-token.js` in the monorepo source
    is a reference implementation.
 
-Once `LANDMARK_AUTH_TOKEN` is set, every command in the rest of this guide
+Once `PRODUCT_LANDMARK_TOKEN` is set, every command in the rest of this guide
 works against your scope. The token is not honored offline — there is no
 `--data`-only fallback for analytical commands today
 ([#921](https://github.com/forwardimpact/monorepo/issues/921) tracks that

--- a/websites/fit/docs/products/engineering-data-sources/index.md
+++ b/websites/fit/docs/products/engineering-data-sources/index.md
@@ -15,7 +15,7 @@ to find out.
 ## Prerequisites
 
 - A Supabase Auth JWT bound to your engineer email. The CLI reads it from
-  `LANDMARK_AUTH_TOKEN`. Test harnesses and CI fixtures mint JWTs against
+  `PRODUCT_LANDMARK_TOKEN`. Test harnesses and CI fixtures mint JWTs against
   `SUPABASE_JWT_SECRET` via the `signTestToken` helper; production-side
   issuance flows (login, magic-link, SSO) are a follow-up — until then the
   command requires a manually-injected token.

--- a/websites/fit/docs/products/issuing-service-account-tokens/index.md
+++ b/websites/fit/docs/products/issuing-service-account-tokens/index.md
@@ -6,7 +6,7 @@ description: Mint long-lived Supabase JWTs for unattended agents that take on a 
 Magic-link login works when a human is in front of the email client; it
 breaks down for unattended agents. The `fit-map auth issue` verb closes
 that gap: it mints a Supabase-shaped JWT for an existing roster row, and
-the operator hands the token to the agent as `LANDMARK_AUTH_TOKEN`.
+the operator hands the token to the agent as `PRODUCT_LANDMARK_TOKEN`.
 
 The same verb works for human emails too, but the canonical use case is a
 service-account row — an identity that exists solely so an agent can take
@@ -41,7 +41,7 @@ Issued JWT for kata-agent-team@example.com (service_account, ttl=8760h)
 
 eyJhbGciOi...
 
-  Export: LANDMARK_AUTH_TOKEN=<jwt above>; never commit or echo it.
+  Export: PRODUCT_LANDMARK_TOKEN=<jwt above>; never commit or echo it.
 
   Done.
 ```
@@ -77,11 +77,11 @@ field; the DB check constraint enforces `level IS NULL` when
 ## Hand the token to the agent
 
 Write the JWT to the agent's `.env` (or your secret manager). Once
-`LANDMARK_AUTH_TOKEN` is exported in the agent's environment, every
+`PRODUCT_LANDMARK_TOKEN` is exported in the agent's environment, every
 `fit-landmark` invocation resolves identity directly from the token:
 
 ```sh
-LANDMARK_AUTH_TOKEN=$JWT fit-landmark voice
+PRODUCT_LANDMARK_TOKEN=$JWT fit-landmark voice
 ```
 
 No magic-link, no refresh flow — the long-lived JWT verifies under

--- a/websites/fit/docs/products/signing-in-to-landmark/index.md
+++ b/websites/fit/docs/products/signing-in-to-landmark/index.md
@@ -104,11 +104,11 @@ Removes the credentials file. A subsequent `login` starts fresh.
 ## Power-user override
 
 If you have been issued a long-lived JWT (operator-minted via
-`fit-map auth issue`), export it as `LANDMARK_AUTH_TOKEN` and the resolver
+`fit-map auth issue`), export it as `PRODUCT_LANDMARK_TOKEN` and the resolver
 will skip the credentials store entirely:
 
 ```sh
-export LANDMARK_AUTH_TOKEN=<jwt>
+export PRODUCT_LANDMARK_TOKEN=<jwt>
 fit-landmark voice
 ```
 


### PR DESCRIPTION
## Summary

Ships spec 990's three-part implementation (kata-interview real-landmark
substrate) plus spec 1000 (cross-product init parity follow-up surfaced
during 990's panel review).

### Spec 990 — kata-interview real-landmark substrate

Three sequential parts, each its own commit, atomic on this branch and
collapsed at squash-merge:

- **Part 01** (`94907576`) — libconfig credential override + `LANDMARK_AUTH_TOKEN`
  → `PRODUCT_LANDMARK_TOKEN` rename. Closes the identity-layering anomaly
  design-c named: registers `token` as a known param on the Landmark
  product config, extends the libconfig override loop to consult
  `#envOverrides`, treats empty-string credential values as absent so the
  Part 03 workflow ternary cannot clobber a `.env` value. JWT now flows
  through `config.token` rather than `env.LANDMARK_AUTH_TOKEN`.
- **Part 02** (`5aa81a34`) — `fit-map substrate {stage, roster, issue}` +
  hidden `fit-landmark _commands` introspection verb. Substrate stage
  runs the full pipeline (stack + url-discovery + migrate + seed +
  provision + self-smoke against every gated Landmark command). Substrate
  roster lists invariant-satisfying personas. Substrate issue atomically
  writes `.env` + `.substrate.json` (+ optional `--stash` for the
  workflow-private JWT). `_commands` exports the canonical COMMANDS
  manifest above the libconfig load.
- **Part 03** (`c811f3ca`) — `kata-interview.yml` substrate stage +
  SKILL.md updates. Substrate stage step (Landmark-gated), Run-interview
  env additions (ternary-gated), post-run sensitive-value log scan
  (`gh api` + grep, fail-closed on download failure), `timeout-minutes:
  50`, `empty-corpus-test` workflow input for the failure-surfacing CI
  assertion. SKILL.md gains Step 3a (Landmark persona pick) and the
  amended read-do checklist line; Step 4 `CLAUDE.md` exclusion list is
  unchanged.

Two rounds of clean sub-agent panel reviews (5 reviewers each) addressed
in two follow-up commits:

- **Round 1** (`eee139db`) — Blocker: substrate-smoke spawned `bunx
  fit-landmark` with `cwd: <fresh tmpdir>` which 404s from npm; dropped
  the cwd override so bunx resolves via workspace. Consensus medium:
  atomic-write recovery tests for `substrate-issue.js` rename failures
  added. High: fail-closed log scan on `gh api` failure. Medium: test
  env pollution snapshot/restore in `substrate-stage.test.js`.
- **Round 2** (`96636de9`) — Singleton mediums: smoke iteration unit
  tests via `buildSmokeList`/`buildSmokeArgv`/`assertNonEmpty` exports;
  roster JSON `discovery` field removed (duplicated per-row data).

### Spec 1000 — cross-product `init` parity (`f2aeec88`)

Follow-up surfaced during 990 implementation. The kata-interview
workflow ships a `mkdir -p $AGENT_CWD/config/` workaround because
libconfig walks up looking for a `config/` directory and would otherwise
escape `$AGENT_CWD`. fit-guide init already creates `config/` and
writes `.env`; fit-map init does neither; spec 230 (`fit-pathway init`)
is in flight. Spec proposes a shared init capability with namespace-
ownership semantics (cross-namespace merges succeed; same-key conflicts
refuse-by-default) and migrates the two shipping init verbs onto it.

Six-reviewer panel (3 product + 3 staff-engineer) flagged 1 Blocker
(JTBD mis-citation to non-existent "Stand Up Typed Services"),
unanimous High findings (HOW leakage across multiple rows, anti-
criterion verifying absence of a workflow line, `chmod 0o600` claim
asserting behavior libsecret doesn't provide), and consensus Mediums
(missing `fit-pathway` from inventory, discoverability criterion
measuring plumbing not behavior, undefined deterministic-order, spec
990 dependency not stated). All consensus blocker/high/medium
addressed in the same commit before push.

### STATUS rows

- `990 plan implemented`
- `1000 spec approved`

## Test plan

- [x] `bun run check` — green
- [x] `bun run test` — 17 pre-existing failures (wiki/libwiki git-signing
  in the sandbox, not regressions; same baseline as `origin/main`)
- [x] Manual integration tests (30 cases) covering: per-subcommand
  `--help` flag scoping, hidden `_commands` verb above libconfig load,
  phase-tagged failure messages, three credential resolution paths
  (`.env`/shell/empty-string), end-to-end JWT minting + identity
  routing, atomic-write recovery on rename failure, non-Landmark
  workflow regression invariant
- [x] Two-round clean panel review (5 + 5 reviewers) on spec 990
  implementation
- [x] Clean six-reviewer panel on spec 1000

## Notes

- This PR ships the `mkdir -p config/` workaround in kata-interview.yml.
  Spec 1000 names removing that line as a follow-up once `fit-map init`
  adopts the shared init capability.
- The kata-agent-team App installation must carry `Actions: Read` for
  the post-run log scan's `gh api` call to succeed. This is an operator
  prerequisite called out in the spec — verify before merging if not
  already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019G24h2fZ2pMAaPntcWke5r)_