### PR TITLE
design(1000): alternative design-c — bootstrap writer in libconfig

### DIFF
--- a/specs/1000-product-init-config-parity/design-c.md
+++ b/specs/1000-product-init-config-parity/design-c.md
@@ -4,34 +4,31 @@ Alternative to [design-a](design-a.md) and [design-b](design-b.md). Design-a
 introduces a new `@forwardimpact/libinit` library; design-b extends three
 existing libraries with a generic plan/apply coordinator. **This design
 extends exactly one existing library — libconfig — with a single
-`bootstrapProductConfig` entry that mirrors the existing `createProductConfig`
-factory.** It delegates `.env` writes to `libsecret.updateEnvFile` per key
-(unchanged) and reuses libstorage's `createStorage("config", …)` for anchor
-resolution so the writer shares one path-discovery implementation with every
-reader in the family.
+`bootstrapProject` entry that takes an explicit target directory and
+delegates `.env` writes to `libsecret`.** No new library, no new error
+class, no new env-writing surface; the writer never upward-walks, so
+`fit-map init` cannot escape into an ancestor `config/`.
 
 ## Components
 
 | Component | Home | Role |
 |---|---|---|
-| `bootstrapProductConfig` | `libraries/libconfig/src/bootstrap.js` | Single entry. Accepts `{ name, fragment, env, overwrites }`; converges on-disk state or throws. Mirrors `createProductConfig(name, …)` naming so read-side and write-side are visibly paired. |
-| `mergeConfigFragment` | `libraries/libconfig/src/merge.js` | Pure function over `{ existing, fragment, overwrites }`; returns merged object or throws. Top-level-namespace ownership with leaf-path diagnostic. |
-| Anchor resolution | reuses `createStorage("config", …)` | Writer calls the same libstorage factory the readers do; the target directory is whichever ancestor `Finder.findUpward` would resolve, falling through to `process.cwd()` and materialising `config/` there when no ancestor exists. Reader and writer cannot drift. |
-| `.env` writes | `libsecret.updateEnvFile` per key | Unchanged libsecret surface. `0o600`, comment-rewrite, and trailing-newline guarantees hold transitively. |
-| Refusal | plain `Error` with `cause: { kind, path, overwriteSurface }` | Matches the in-tree `throw new Error("[substrate stage: <phase>] …")` idiom (`products/map/src/commands/substrate-stage.js:85`). No new error class. |
-| `fit-guide init` adapter | `products/guide/src/commands/init.js` | Materialises secrets via `getOrGenerateSecret` before the bootstrap call; passes one fragment + one env object. Existing `package.json` / `.claude/skills/` writes stay local — those are not config or env. |
-| `fit-map init` adapter | `products/map/src/commands/init.js` | Calls `bootstrapProductConfig` with `fragment: {}`; existing `data/pathway/` copy becomes idempotent; the writer materialises `config/config.json` as `{}` if absent. |
-| `fit-map substrate stage` | `products/map/src/commands/substrate-stage.js` | Gains `runPhase("init", () => runInit(target))` as the first phase, alongside the existing `stack`/`url-discovery`/`migrate`/`seed`/`provision`/`smoke` array. |
-| Workflow cleanup | `.github/workflows/kata-interview.yml` | Substrate stage step drops the `mkdir -p "$AGENT_CWD/config"` line; Landmark gate (`if: inputs.product == 'landmark'`) preserved. |
-| README home | `libraries/libconfig/README.md` § *Bootstrap* | Extends the existing "Environment-aware application settings" framing with the onboarding contract: entry point, namespace-declaration step, overwrite-intent parameter. |
+| `bootstrapProject` | `libraries/libconfig/src/bootstrap.js` | Single entry. `{ target, fragment, env, overwrites } → void`; throws on refused write. Writes `config/config.json` at `target` and delegates `.env` writes to libsecret. |
+| `mergeConfigFragment` | `libraries/libconfig/src/merge.js` | Pure classifier over `{ existing, fragment, overwrites }`. Same shape applies to the `.env` table over bare keys. |
+| Refusal | `libraries/libconfig/src/errors.js` | `Error` whose message names the conflicting key and the overwrite-intent parameter; `cause` carries the structured fields. The product CLI's existing stderr-then-exit-non-zero behaviour renders it without per-CLI templating. |
+| `fit-guide init` adapter | `products/guide/src/commands/init.js` | Materialises generated secrets before the bootstrap call so a re-run classifies them same-key-same-value; preserves first-run output and exit code. |
+| `fit-map init` adapter | `products/map/src/commands/init.js` | Calls `bootstrapProject` with an empty fragment. Existing `data/pathway/` copy becomes idempotent so substrate stage can re-stage. |
+| `fit-map substrate stage` adapter | `products/map/src/commands/substrate-stage.js` | Runs `runInit` as a new first phase before the existing Supabase-stack phases. Re-reads config after init so subsequent phases see the materialised `config.json`. |
+| Workflow cleanup | `.github/workflows/kata-interview.yml` | Drops the `mkdir -p .../config` line in the Substrate stage step; Landmark gate preserved. |
+| Onboarding contract | `libraries/libconfig/README.md` § *Bootstrap* | Names the entry point, the namespace-declaration step, the overwrite-intent parameter, and a one-line cross-link to libsecret's `.env` primitives. |
 
 ## Interface
 
 ```js
-import { bootstrapProductConfig } from "@forwardimpact/libconfig";
+import { bootstrapProject } from "@forwardimpact/libconfig";
 
-await bootstrapProductConfig({
-  name: "guide",                       // product slug; anchors via createStorage("config", …)
+await bootstrapProject({
+  target,                              // absolute path; defaults to process.cwd()
   fragment: {                          // top-level keys are product-owned namespaces; {} or omitted is allowed
     "product.guide": { systemPrompt: "…" },
     "service.mcp":   { systemPrompt: "…", tools: { … } },
@@ -41,124 +38,131 @@ await bootstrapProductConfig({
     MCP_TOKEN:      "…",
   },
   overwrites: {
-    config: ["product.guide"],         // top-level namespace names
+    config: ["product.guide"],         // top-level namespace names (single segment)
     env:    ["MCP_TOKEN"],             // bare keys
   },
 });
 ```
 
-Returns `void` on success; throws `Error` with structured `cause` on refused
-write. The writer **always materialises `config/config.json`** at the resolved
-anchor (`{}` when fragment is empty and the file is absent) — this satisfies
-the spec's anchoring criterion for `fit-map init` without a `product.map`
-starter fragment. `.env` is created only when at least one entry is supplied.
+`bootstrapProject` **always materialises `target/config/config.json`** (`{}`
+when fragment is empty and the file is absent) — this is what satisfies the
+spec's anchoring criterion for `fit-map init` without a `product.map`
+starter fragment. `.env` is created only when at least one entry is
+supplied; an empty `env` against an existing `.env` is a no-op regardless
+of the file's contents.
 
 ## Data flow
 
 ```mermaid
 sequenceDiagram
   participant CLI as Product CLI (init verb)
-  participant Lib as libconfig.bootstrapProductConfig
-  participant St  as libstorage.createStorage("config", …)
-  participant Sec as libsecret.updateEnvFile
-  participant FS  as Target dir
+  participant Lib as libconfig.bootstrapProject
+  participant Sec as libsecret
+  participant FS  as target dir
 
-  CLI->>Lib: { name, fragment, env, overwrites }
-  Lib->>St: resolve config/ anchor (same as reader)
+  CLI->>Lib: { target, fragment, env, overwrites }
   Lib->>FS: read config/config.json (or {} if absent)
-  Lib->>FS: read .env (or "" if absent)
-  Lib->>Lib: mergeConfigFragment(existing, fragment, overwrites.config)
-  Lib->>Lib: classify .env entries against overwrites.env
-  alt conflict
+  Lib->>Sec: readEnvFile per env key (or "" if absent)
+  Lib->>Lib: classify config + env entries against overwrites
+  alt any conflict
     Lib-->>CLI: throw Error(msg, { cause: { kind, path, overwriteSurface } })
     CLI-->>CLI: stderr diagnostic + non-zero exit
   else clean
-    Lib->>FS: mkdir -p config/ (if absent)
-    Lib->>FS: write config/config.json (canonical JSON)
+    Lib->>FS: mkdir -p target/config/ (if absent)
+    Lib->>FS: write target/config/config.json (canonical JSON)
     loop per merged env key
       Lib->>Sec: updateEnvFile(key, value)
     end
   end
 ```
 
-Merges complete and classify before any FS mutation — a `.env` conflict never
-leaves a half-written `config.json` on disk.
+Both classifications complete before any FS mutation, so a **refused write**
+never leaves a half-written `config.json` on disk. Cross-file **FS
+atomicity** (mid-loop crash after `config.json` is written) remains
+spec-deferred — the existing `fit-guide init` property is preserved, not
+tightened.
 
 ## Namespace ownership semantics
 
-Ownership is enforced at the **top-level key** of `config.json` (the spec's
-literal framing). Each top-level key classifies against the existing on-disk
-subtree:
+Ownership is enforced at the top-level key; diagnostics name the leaf that
+disagrees. Each top-level key classifies:
 
 | Pre-state | Fragment subtree | Result |
 |---|---|---|
 | absent | any | write subtree |
 | present, deep-equal (canonical JSON) | same | no-op |
-| present, different | different | refuse, unless top-level key ∈ `overwrites.config` |
+| present, **any leaf** disagrees | any | refuse, unless top-level key ∈ `overwrites.config` |
 
-"Deep-equal canonical JSON" = sorted-key, no-whitespace serialisation compared
-as strings — the normalisation rule that makes A→B→A→B converge regardless of
-input key order or whitespace.
+"Deep-equal canonical JSON" = sorted-key, no-whitespace string compare —
+what makes A→B→A→B converge regardless of input order. On refusal the
+diagnostic carries the disagreeing leaf path (e.g. `product.x.foo`) so the
+spec's success-criterion test passes; the `overwrites.config` entry the
+caller passes remains the **top-level key** (`product.x`). Forcing a single
+leaf write forgives the entire top-level namespace by design — see
+Decision #3.
 
-**Ownership granularity is top-level; diagnostic granularity is leaf.** When a
-top-level subtree differs, the writer enumerates the leaf paths that disagree
-into `cause.path` (dotted), so a write of `product.x.foo = "b"` against
-existing `product.x.foo = "a"` produces a diagnostic naming `product.x.foo`
-(satisfying spec § *Failure surfacing*) while the overwrite-intent surface
-remains the top-level namespace `product.x`. See Decision #3.
-
-For `.env`, the same three rows apply at bare-key granularity against
+For `.env`, the same three rows at bare-key granularity against
 `overwrites.env`. Value comparison is byte-for-byte after `KEY=`.
+
+## Reader/writer anchor invariant
+
+The writer never upward-walks: it operates on `target` (default
+`process.cwd()`). The reader continues to use libstorage's
+`createStorage("config", …)` upward walk, which lands locally on the
+writer's freshly-planted `config/` for any subsequent invocation. The
+invariant a future reader refactor must preserve: **once `config/` exists
+at the working directory, the reader resolves there.** Decision #4 captures
+the trade-off against sharing resolution code with the reader.
 
 ## fit-map init ↔ fit-map substrate stage
 
-The spec leaves the *which-invokes-which* arrangement as a design choice.
-This design picks **substrate stage delegates to init**: a new first phase
-calls `runInit` inside the existing `runPhase` array
-(`substrate-stage.js:47-75`). The kata-interview workflow keeps
-`bunx fit-map substrate stage` as its only substrate entry point; the
-`mkdir -p` line goes away. Bootstrap-shape parity is structural — both
-`fit-map init` and `fit-map substrate stage` run the same `runInit` body, so
-the spec's "two fresh tmpdirs" criterion holds by construction.
+The spec leaves the *which-invokes-which* arrangement open. This design
+picks **substrate stage delegates to init**: substrate stage's first phase
+calls `runInit` against its own target. Because `createProductConfig`
+tolerates an absent `config.json` (the fallback path), the existing
+module-top config load in `fit-map.js` is not blocked by an unbootstrapped
+workspace; substrate stage re-reads config after its init phase so the
+remaining Supabase-stack phases see the materialised state. The kata-interview
+workflow keeps `bunx fit-map substrate stage` as its only substrate entry
+point.
 
 ## Re-run semantics
 
-**fit-guide init**: The adapter uses `libsecret.getOrGenerateSecret` to
-materialise `SERVICE_SECRET` / `MCP_TOKEN` **before** the bootstrap call. The
-fragment carries whatever value is already in `.env`; the merge classifies it
-same-key-same-value and writes nothing. The pre-spec `"config/ already
-exists, skipping starter copy"` line is dropped.
+The spec's re-run requirements drop out of the merge rules:
 
-**fit-map init**: Pre-spec exits non-zero with `./data/pathway/ already
-exists`. The adapter changes the existence check to a no-op; re-running
-becomes byte-stable and makes `substrate stage` idempotent against an
-already-bootstrapped workspace.
+- **fit-guide init** — generated secrets are materialised via
+  `libsecret.getOrGenerateSecret` *before* the bootstrap call, so a re-run
+  classifies them same-key-same-value (no-op). First-run `formatSuccess`
+  output and exit code are preserved; the pre-spec `"config/ already
+  exists, skipping starter copy"` line is dropped.
+- **fit-map init** — the pre-spec `./data/pathway/ already exists`
+  non-zero exit becomes a no-op so substrate stage re-running against a
+  bootstrapped workspace is byte-stable.
 
 ## Key decisions
 
 | # | Decision | Rejected alternative | Reason |
 |---|---|---|---|
-| 1 | Bootstrap writer lives in **libconfig**, not a new library, and not split across libconfig + libsecret. | (a) New library `@forwardimpact/libinit` (design-a). (b) Per-surface writers split across libconfig + libsecret (design-b). | `libraries/CLAUDE.md` mandates checking the catalog before writing a generic capability. libconfig's concern is `config.json` semantics — the read/write split is incidental, not architectural. Splitting the namespace-ownership knowledge across two libraries forces it to depend on whichever library hosts the writer. One library, one README, one entry. |
-| 2 | Single `bootstrapProductConfig` entry; product CLI calls it once. | Per-surface writers (design-b). | The spec's "one callable interface" language is singular. Per-surface writers force callers to discipline call ordering; a single entry makes refuse-before-mutate structural. |
-| 3 | Top-level-namespace ownership; **leaf-path diagnostic**. | (a) Leaf-path ownership (design-a #5). (b) Top-level diagnostic. | (a) Top-level ownership matches the spec's normative text and how products think about their slice; leaf-path is stronger than asked. (b) Top-level diagnostic alone would name only `product.x` and fail the spec's success-criterion that the diagnostic carries `product.x.foo`. Splitting ownership granularity from diagnostic granularity satisfies both clauses with one contract pair. |
-| 4 | Anchor resolution reuses `createStorage("config", …)`. | New target-dir argument resolved by `bootstrapProductConfig` itself. | Reader and writer share one path-discovery implementation. The spec's *fit-map init anchors locally* criterion becomes a structural property of libstorage, not a behavioural assertion on the writer. Eliminates an entire class of drift between read and write. |
-| 5 | Refusal is a plain `Error` with `cause: { kind, path, overwriteSurface }`. | A dedicated `ConflictError` class (design-a) or `WriterConflict` aggregate (design-b). | The in-tree pattern in `substrate-stage.js:85` is `throw new Error("[…] …")`. Node's `Error.cause` carries the structured fields without a new public class to import, test, and document. The spec's "greppable for both" requirement is satisfied by the message text. |
-| 6 | `.env` writer reuses `libsecret.updateEnvFile` per merged key. | (a) New `updateEnvEntries` batch wrapper in libsecret (design-b). (b) New env writer inside libconfig. | `updateEnvFile` already preserves `0o600` + comment-rewrite + trailing-newline; per-key invocation matches the existing `fit-guide init` pattern verbatim. A batch wrapper would be a thin pass-through; an env writer inside libconfig would re-implement guarantees libsecret already owns. |
-| 7 | `substrate stage` delegates to `runInit` via the existing `runPhase` helper. | Workflow sequences `init` + `stage` as two subprocesses (design-b). | Bootstrap-shape parity is structural (one code path) rather than asserted (one CI test). `substrate-stage.js` already uses `runPhase("stack", …)`, `runPhase("url-discovery", …)`, etc. — `runPhase("init", …)` is the minimal extension of an established pattern. |
+| 1 | Bootstrap writer lives in **libconfig**. | (a) New library `@forwardimpact/libinit` (design-a). (b) Per-surface writers split across libconfig + libsecret (design-b). | The dominant complexity is namespace-ownership over `config.json` — that knowledge belongs alongside libconfig's existing `config.json` semantics. Env writes are a one-call delegation. `libraries/CLAUDE.md` mandates checking the catalog before adding a generic capability; libconfig's identity widens from "read-side config" to "config concerns" rather than splintering into a new library. |
+| 2 | Single `bootstrapProject` entry. | Per-surface writers + coordinator (design-b). | The spec's "one callable interface" admits a coordinator reading, but a single entry makes refuse-before-mutate structural (one classification, one decision point) rather than caller-disciplined. Design-b's `runTwoPhase` ships a generic abstraction the spec doesn't ask for. |
+| 3 | Top-level-namespace **ownership**; leaf-path **diagnostic**. | (a) Leaf-path ownership (design-a #5). (b) Top-level diagnostic. | Top-level ownership matches the spec's literal framing and how products think about their slice; the leaf-path diagnostic in the message and `cause.path` satisfies spec § *Failure surfacing*'s `product.x.foo` test. **Any** leaf disagreement under a top-level key triggers refusal at that top-level — the table in § *Namespace ownership semantics* is the canonical home. |
+| 4 | Writer takes explicit `target` (defaults to `process.cwd()`); never upward-walks. | Share `findUpward` with the reader. | The reader's upward walk is precisely the failure spec § *Anchor escape* exists to fix; making the writer share it would re-introduce the escape on the init path. The invariant in § *Reader/writer anchor invariant* records what a future reader refactor must preserve. |
+| 5 | Refusal is a plain `Error` with structured `cause`; the library composes the message. | (a) `ConflictError` class (design-a). (b) `WriterConflict` aggregate (design-b). | The message names the conflicting key and overwrite-intent parameter; `cause` carries the same fields structurally. Spec's "greppable for both" lands on stderr; structured `cause` is for callers wanting programmatic introspection. Extends the in-tree plain-`Error` pattern with Node's standard `cause` slot — no new exported class. |
+| 6 | `.env` writes reuse `libsecret.updateEnvFile`; reads use `libsecret.readEnvFile`. | (a) New batch wrapper in libsecret (design-b). (b) New env writer inside libconfig. | `updateEnvFile` already preserves `0o600` + comment-rewrite + trailing-newline; `readEnvFile` is the corresponding read primitive. No new libsecret surface; per-key invocation matches the existing `fit-guide init` pattern. |
+| 7 | Substrate stage runs `runInit` as a new first phase and re-reads config after init. | Workflow sequences `init` + `stage` as two subprocesses (design-b). | Bootstrap-shape parity becomes structural (one code path) rather than asserted (one CI test). Re-reading config is the architectural consequence of running init in-process after the verb's module-top config load. |
 | 8 | `runInit` becomes idempotent on `data/pathway/`. | Keep the non-zero exit. | Spec § *Re-invoking* idempotency requires it; substrate stage re-running against a bootstrapped workspace requires it. |
-| 9 | Always materialise `config/config.json`; never auto-create empty `.env`. | Symmetric auto-creation of `.env`. | Spec's anchoring criterion needs `config/config.json` to exist; `.env` has no equivalent anchoring role. Auto-creating an empty `0o600` `.env` would surprise developers. |
-| 10 | Empty-string `.env` values written verbatim. | Skip empty values. | Spec 990 makes empty-string-on-shell-env equivalent to absent on the **read** path; the writer's job is bytes, not read semantics. |
-| 11 | Onboarding docs in `libraries/libconfig/README.md` § *Bootstrap*. | A new `libinit/README.md` (design-a) or cross-linked sections across three READMEs (design-b). | Spec § *New-product onboarding* mandates "the shared library's README" — singular. One library, one README, no cross-links. |
-| 12 | libconfig adds a `@forwardimpact/libsecret` dep. | Keep libconfig dep-free of libsecret; require callers to invoke libsecret themselves. | libstorage already depends on libsecret (`generateUUID`); the cross-library line is already crossed in this neighborhood. Keeping callers single-call requires the delegation. |
+| 9 | Always materialise `config/config.json`; never auto-create empty `.env`; empty-env on existing `.env` is a no-op. | Symmetric auto-creation. | The anchoring criterion needs `config/config.json` to exist; `.env` has no anchoring role. Auto-creating an empty `0o600` `.env` would surprise developers and mask absence on the read path. |
+| 10 | Empty-string `.env` values written verbatim. | Skip empty values. | Spec § *Read-side coherence with spec 990* preserves spec 990's empty-string-equals-absent rule for credential keys on the *read* path; the writer's job is bytes for any key. No write-side filtering. |
+| 11 | Onboarding docs in `libraries/libconfig/README.md` § *Bootstrap* with a one-sentence cross-link to libsecret env primitives. | (a) New `libinit/README.md` (design-a). (b) Three sections across three READMEs (design-b). | Spec § *New-product onboarding* mandates "the shared library's README." The orchestrator lives in libconfig, so libconfig is the shared library; a single cross-link is not the fan-out design-b incurs. |
+| 12 | libconfig adds a direct `@forwardimpact/libsecret` dependency. | Have product CLIs call libsecret directly after libconfig's merge. | Refuse-before-mutate requires the orchestrator to own both surfaces. Layering: libconfig → libstorage → libsecret already exists transitively but doesn't re-export the env primitives, so a direct edge is needed; no cycle, since libsecret has no libconfig dep. |
 
 ## Coherence with spec 990
 
-- **`mkdir -p` workaround** — removed. The substrate stage step in
-  `kata-interview.yml` keeps the `if: inputs.product == 'landmark'` gate;
-  only the `mkdir` line goes.
-- **Credential-override read order** — unchanged. libconfig's writer
-  produces bytes only; libconfig's reader still resolves shell env > `.env`
-  > defaults. Empty-string writes to `.env` produce `KEY=` on disk; the
+- **`mkdir -p` workaround** — removed. The Landmark gate on the Substrate
+  stage step is preserved; only the `mkdir` line goes.
+- **Credential-override read order** — unchanged. The writer produces
+  bytes only; libconfig's reader still resolves shell env > `.env` >
+  defaults. Empty-string writes to `.env` produce `KEY=` on disk; the
   credential-override loop independently treats shell-empty-string as
   absent.
 
@@ -166,13 +170,14 @@ already-bootstrapped workspace.
 
 | Success criterion | Surface |
 |---|---|
-| Two-namespace merge, idempotent re-invoke, A→B→A→B convergence, refuse + leaf-path diagnostic | libconfig unit tests (extends existing suite) |
-| `.env` ownership + `0o600` mode + diagnostic | libconfig unit tests (mode assertion via `fs.stat`) |
-| `fit-map init` anchors locally after init | fit-map product test |
+| Two-namespace merge, idempotent re-invoke, A→B→A→B convergence, refuse + leaf-path diagnostic | libconfig unit tests |
+| `.env` ownership + `0o600` mode | libconfig unit tests |
+| Stderr diagnostic carries both conflicting key and overwrite-intent parameter | libconfig CLI-integration test (greps stderr for both substrings) |
+| `fit-map init` anchors locally even when an ancestor `config/` exists | fit-map product test |
 | Workflow runs end-to-end without in-workflow `mkdir`; Landmark interview prep preserved (substrate roster non-empty, substrate issue writes `.env` + `.substrate.json`, `resolveIdentity()` succeeds, Landmark self-smoke green) | kata-interview CI on the implementation branch + workflow source grep |
-| Bootstrap-shape parity (`fit-map init` vs substrate stage) | fit-map product test (structural — both call `runInit`) |
+| Bootstrap-shape parity (`fit-map init` vs substrate stage) | fit-map product test (both call `runInit`) |
 | `fit-guide init` first-run + re-run preservation | fit-guide product test + existing suite |
-| README documents onboarding contract | libconfig README test (grep for entry point, namespace step, overwrite-intent param) |
+| README documents onboarding contract | libconfig README test |
 | Existing in-tree tests stay green | `bun run test` on the implementation branch |
 
 ## Out of scope (deferred to plan or follow-ups)
@@ -181,8 +186,3 @@ already-bootstrapped workspace.
 - Cross-file atomicity between `config.json` and `.env` — deferred per spec.
 - Schema validation of the merged `config.json` — deferred per spec.
 - Secret rotation as a separate verb — deferred per spec.
-- Cleaning up libutil's lower-fidelity `updateEnvFile`
-  (`libraries/libutil/src/index.js:19`) — follow-up; no in-scope consumer
-  touches it.
-
-— Staff Engineer 🛠️

--- a/specs/1000-product-init-config-parity/design-c.md
+++ b/specs/1000-product-init-config-parity/design-c.md
@@ -1,0 +1,188 @@
+# Design 1000-c — Bootstrap writer in libconfig (no new library)
+
+Alternative to [design-a](design-a.md) and [design-b](design-b.md). Design-a
+introduces a new `@forwardimpact/libinit` library; design-b extends three
+existing libraries with a generic plan/apply coordinator. **This design
+extends exactly one existing library — libconfig — with a single
+`bootstrapProductConfig` entry that mirrors the existing `createProductConfig`
+factory.** It delegates `.env` writes to `libsecret.updateEnvFile` per key
+(unchanged) and reuses libstorage's `createStorage("config", …)` for anchor
+resolution so the writer shares one path-discovery implementation with every
+reader in the family.
+
+## Components
+
+| Component | Home | Role |
+|---|---|---|
+| `bootstrapProductConfig` | `libraries/libconfig/src/bootstrap.js` | Single entry. Accepts `{ name, fragment, env, overwrites }`; converges on-disk state or throws. Mirrors `createProductConfig(name, …)` naming so read-side and write-side are visibly paired. |
+| `mergeConfigFragment` | `libraries/libconfig/src/merge.js` | Pure function over `{ existing, fragment, overwrites }`; returns merged object or throws. Top-level-namespace ownership with leaf-path diagnostic. |
+| Anchor resolution | reuses `createStorage("config", …)` | Writer calls the same libstorage factory the readers do; the target directory is whichever ancestor `Finder.findUpward` would resolve, falling through to `process.cwd()` and materialising `config/` there when no ancestor exists. Reader and writer cannot drift. |
+| `.env` writes | `libsecret.updateEnvFile` per key | Unchanged libsecret surface. `0o600`, comment-rewrite, and trailing-newline guarantees hold transitively. |
+| Refusal | plain `Error` with `cause: { kind, path, overwriteSurface }` | Matches the in-tree `throw new Error("[substrate stage: <phase>] …")` idiom (`products/map/src/commands/substrate-stage.js:85`). No new error class. |
+| `fit-guide init` adapter | `products/guide/src/commands/init.js` | Materialises secrets via `getOrGenerateSecret` before the bootstrap call; passes one fragment + one env object. Existing `package.json` / `.claude/skills/` writes stay local — those are not config or env. |
+| `fit-map init` adapter | `products/map/src/commands/init.js` | Calls `bootstrapProductConfig` with `fragment: {}`; existing `data/pathway/` copy becomes idempotent; the writer materialises `config/config.json` as `{}` if absent. |
+| `fit-map substrate stage` | `products/map/src/commands/substrate-stage.js` | Gains `runPhase("init", () => runInit(target))` as the first phase, alongside the existing `stack`/`url-discovery`/`migrate`/`seed`/`provision`/`smoke` array. |
+| Workflow cleanup | `.github/workflows/kata-interview.yml` | Substrate stage step drops the `mkdir -p "$AGENT_CWD/config"` line; Landmark gate (`if: inputs.product == 'landmark'`) preserved. |
+| README home | `libraries/libconfig/README.md` § *Bootstrap* | Extends the existing "Environment-aware application settings" framing with the onboarding contract: entry point, namespace-declaration step, overwrite-intent parameter. |
+
+## Interface
+
+```js
+import { bootstrapProductConfig } from "@forwardimpact/libconfig";
+
+await bootstrapProductConfig({
+  name: "guide",                       // product slug; anchors via createStorage("config", …)
+  fragment: {                          // top-level keys are product-owned namespaces; {} or omitted is allowed
+    "product.guide": { systemPrompt: "…" },
+    "service.mcp":   { systemPrompt: "…", tools: { … } },
+  },
+  env: {                               // .env entries; {} or omitted is allowed
+    SERVICE_SECRET: "…",
+    MCP_TOKEN:      "…",
+  },
+  overwrites: {
+    config: ["product.guide"],         // top-level namespace names
+    env:    ["MCP_TOKEN"],             // bare keys
+  },
+});
+```
+
+Returns `void` on success; throws `Error` with structured `cause` on refused
+write. The writer **always materialises `config/config.json`** at the resolved
+anchor (`{}` when fragment is empty and the file is absent) — this satisfies
+the spec's anchoring criterion for `fit-map init` without a `product.map`
+starter fragment. `.env` is created only when at least one entry is supplied.
+
+## Data flow
+
+```mermaid
+sequenceDiagram
+  participant CLI as Product CLI (init verb)
+  participant Lib as libconfig.bootstrapProductConfig
+  participant St  as libstorage.createStorage("config", …)
+  participant Sec as libsecret.updateEnvFile
+  participant FS  as Target dir
+
+  CLI->>Lib: { name, fragment, env, overwrites }
+  Lib->>St: resolve config/ anchor (same as reader)
+  Lib->>FS: read config/config.json (or {} if absent)
+  Lib->>FS: read .env (or "" if absent)
+  Lib->>Lib: mergeConfigFragment(existing, fragment, overwrites.config)
+  Lib->>Lib: classify .env entries against overwrites.env
+  alt conflict
+    Lib-->>CLI: throw Error(msg, { cause: { kind, path, overwriteSurface } })
+    CLI-->>CLI: stderr diagnostic + non-zero exit
+  else clean
+    Lib->>FS: mkdir -p config/ (if absent)
+    Lib->>FS: write config/config.json (canonical JSON)
+    loop per merged env key
+      Lib->>Sec: updateEnvFile(key, value)
+    end
+  end
+```
+
+Merges complete and classify before any FS mutation — a `.env` conflict never
+leaves a half-written `config.json` on disk.
+
+## Namespace ownership semantics
+
+Ownership is enforced at the **top-level key** of `config.json` (the spec's
+literal framing). Each top-level key classifies against the existing on-disk
+subtree:
+
+| Pre-state | Fragment subtree | Result |
+|---|---|---|
+| absent | any | write subtree |
+| present, deep-equal (canonical JSON) | same | no-op |
+| present, different | different | refuse, unless top-level key ∈ `overwrites.config` |
+
+"Deep-equal canonical JSON" = sorted-key, no-whitespace serialisation compared
+as strings — the normalisation rule that makes A→B→A→B converge regardless of
+input key order or whitespace.
+
+**Ownership granularity is top-level; diagnostic granularity is leaf.** When a
+top-level subtree differs, the writer enumerates the leaf paths that disagree
+into `cause.path` (dotted), so a write of `product.x.foo = "b"` against
+existing `product.x.foo = "a"` produces a diagnostic naming `product.x.foo`
+(satisfying spec § *Failure surfacing*) while the overwrite-intent surface
+remains the top-level namespace `product.x`. See Decision #3.
+
+For `.env`, the same three rows apply at bare-key granularity against
+`overwrites.env`. Value comparison is byte-for-byte after `KEY=`.
+
+## fit-map init ↔ fit-map substrate stage
+
+The spec leaves the *which-invokes-which* arrangement as a design choice.
+This design picks **substrate stage delegates to init**: a new first phase
+calls `runInit` inside the existing `runPhase` array
+(`substrate-stage.js:47-75`). The kata-interview workflow keeps
+`bunx fit-map substrate stage` as its only substrate entry point; the
+`mkdir -p` line goes away. Bootstrap-shape parity is structural — both
+`fit-map init` and `fit-map substrate stage` run the same `runInit` body, so
+the spec's "two fresh tmpdirs" criterion holds by construction.
+
+## Re-run semantics
+
+**fit-guide init**: The adapter uses `libsecret.getOrGenerateSecret` to
+materialise `SERVICE_SECRET` / `MCP_TOKEN` **before** the bootstrap call. The
+fragment carries whatever value is already in `.env`; the merge classifies it
+same-key-same-value and writes nothing. The pre-spec `"config/ already
+exists, skipping starter copy"` line is dropped.
+
+**fit-map init**: Pre-spec exits non-zero with `./data/pathway/ already
+exists`. The adapter changes the existence check to a no-op; re-running
+becomes byte-stable and makes `substrate stage` idempotent against an
+already-bootstrapped workspace.
+
+## Key decisions
+
+| # | Decision | Rejected alternative | Reason |
+|---|---|---|---|
+| 1 | Bootstrap writer lives in **libconfig**, not a new library, and not split across libconfig + libsecret. | (a) New library `@forwardimpact/libinit` (design-a). (b) Per-surface writers split across libconfig + libsecret (design-b). | `libraries/CLAUDE.md` mandates checking the catalog before writing a generic capability. libconfig's concern is `config.json` semantics — the read/write split is incidental, not architectural. Splitting the namespace-ownership knowledge across two libraries forces it to depend on whichever library hosts the writer. One library, one README, one entry. |
+| 2 | Single `bootstrapProductConfig` entry; product CLI calls it once. | Per-surface writers (design-b). | The spec's "one callable interface" language is singular. Per-surface writers force callers to discipline call ordering; a single entry makes refuse-before-mutate structural. |
+| 3 | Top-level-namespace ownership; **leaf-path diagnostic**. | (a) Leaf-path ownership (design-a #5). (b) Top-level diagnostic. | (a) Top-level ownership matches the spec's normative text and how products think about their slice; leaf-path is stronger than asked. (b) Top-level diagnostic alone would name only `product.x` and fail the spec's success-criterion that the diagnostic carries `product.x.foo`. Splitting ownership granularity from diagnostic granularity satisfies both clauses with one contract pair. |
+| 4 | Anchor resolution reuses `createStorage("config", …)`. | New target-dir argument resolved by `bootstrapProductConfig` itself. | Reader and writer share one path-discovery implementation. The spec's *fit-map init anchors locally* criterion becomes a structural property of libstorage, not a behavioural assertion on the writer. Eliminates an entire class of drift between read and write. |
+| 5 | Refusal is a plain `Error` with `cause: { kind, path, overwriteSurface }`. | A dedicated `ConflictError` class (design-a) or `WriterConflict` aggregate (design-b). | The in-tree pattern in `substrate-stage.js:85` is `throw new Error("[…] …")`. Node's `Error.cause` carries the structured fields without a new public class to import, test, and document. The spec's "greppable for both" requirement is satisfied by the message text. |
+| 6 | `.env` writer reuses `libsecret.updateEnvFile` per merged key. | (a) New `updateEnvEntries` batch wrapper in libsecret (design-b). (b) New env writer inside libconfig. | `updateEnvFile` already preserves `0o600` + comment-rewrite + trailing-newline; per-key invocation matches the existing `fit-guide init` pattern verbatim. A batch wrapper would be a thin pass-through; an env writer inside libconfig would re-implement guarantees libsecret already owns. |
+| 7 | `substrate stage` delegates to `runInit` via the existing `runPhase` helper. | Workflow sequences `init` + `stage` as two subprocesses (design-b). | Bootstrap-shape parity is structural (one code path) rather than asserted (one CI test). `substrate-stage.js` already uses `runPhase("stack", …)`, `runPhase("url-discovery", …)`, etc. — `runPhase("init", …)` is the minimal extension of an established pattern. |
+| 8 | `runInit` becomes idempotent on `data/pathway/`. | Keep the non-zero exit. | Spec § *Re-invoking* idempotency requires it; substrate stage re-running against a bootstrapped workspace requires it. |
+| 9 | Always materialise `config/config.json`; never auto-create empty `.env`. | Symmetric auto-creation of `.env`. | Spec's anchoring criterion needs `config/config.json` to exist; `.env` has no equivalent anchoring role. Auto-creating an empty `0o600` `.env` would surprise developers. |
+| 10 | Empty-string `.env` values written verbatim. | Skip empty values. | Spec 990 makes empty-string-on-shell-env equivalent to absent on the **read** path; the writer's job is bytes, not read semantics. |
+| 11 | Onboarding docs in `libraries/libconfig/README.md` § *Bootstrap*. | A new `libinit/README.md` (design-a) or cross-linked sections across three READMEs (design-b). | Spec § *New-product onboarding* mandates "the shared library's README" — singular. One library, one README, no cross-links. |
+| 12 | libconfig adds a `@forwardimpact/libsecret` dep. | Keep libconfig dep-free of libsecret; require callers to invoke libsecret themselves. | libstorage already depends on libsecret (`generateUUID`); the cross-library line is already crossed in this neighborhood. Keeping callers single-call requires the delegation. |
+
+## Coherence with spec 990
+
+- **`mkdir -p` workaround** — removed. The substrate stage step in
+  `kata-interview.yml` keeps the `if: inputs.product == 'landmark'` gate;
+  only the `mkdir` line goes.
+- **Credential-override read order** — unchanged. libconfig's writer
+  produces bytes only; libconfig's reader still resolves shell env > `.env`
+  > defaults. Empty-string writes to `.env` produce `KEY=` on disk; the
+  credential-override loop independently treats shell-empty-string as
+  absent.
+
+## Verification surfaces
+
+| Success criterion | Surface |
+|---|---|
+| Two-namespace merge, idempotent re-invoke, A→B→A→B convergence, refuse + leaf-path diagnostic | libconfig unit tests (extends existing suite) |
+| `.env` ownership + `0o600` mode + diagnostic | libconfig unit tests (mode assertion via `fs.stat`) |
+| `fit-map init` anchors locally after init | fit-map product test |
+| Workflow runs end-to-end without in-workflow `mkdir`; Landmark interview prep preserved (substrate roster non-empty, substrate issue writes `.env` + `.substrate.json`, `resolveIdentity()` succeeds, Landmark self-smoke green) | kata-interview CI on the implementation branch + workflow source grep |
+| Bootstrap-shape parity (`fit-map init` vs substrate stage) | fit-map product test (structural — both call `runInit`) |
+| `fit-guide init` first-run + re-run preservation | fit-guide product test + existing suite |
+| README documents onboarding contract | libconfig README test (grep for entry point, namespace step, overwrite-intent param) |
+| Existing in-tree tests stay green | `bun run test` on the implementation branch |
+
+## Out of scope (deferred to plan or follow-ups)
+
+- File-level changes inside the three adapters — plan scope.
+- Cross-file atomicity between `config.json` and `.env` — deferred per spec.
+- Schema validation of the merged `config.json` — deferred per spec.
+- Secret rotation as a separate verb — deferred per spec.
+- Cleaning up libutil's lower-fidelity `updateEnvFile`
+  (`libraries/libutil/src/index.js:19`) — follow-up; no in-scope consumer
+  touches it.
+
+— Staff Engineer 🛠️


### PR DESCRIPTION
## Summary

Third design variant for [spec 1000](https://github.com/forwardimpact/monorepo/blob/main/specs/1000-product-init-config-parity/spec.md). Where [design-a](https://github.com/forwardimpact/monorepo/blob/main/specs/1000-product-init-config-parity/design-a.md) creates a new `@forwardimpact/libinit` library and [design-b](https://github.com/forwardimpact/monorepo/blob/main/specs/1000-product-init-config-parity/design-b.md) extends three libraries with a generic plan/apply coordinator, **design-c extends exactly one existing library — libconfig — with a single `bootstrapProject` entry**, delegating `.env` writes to `libsecret.updateEnvFile` per key.

### Distinguishing features

- **No new library.** The bootstrap writer lives next to the existing read-side factories in libconfig. `libraries/CLAUDE.md` mandates checking the catalog before adding a generic capability; the dominant complexity (namespace ownership over `config.json`) belongs alongside libconfig's existing `config.json` semantics.
- **Explicit `target` parameter** — the writer never upward-walks, so `fit-map init` cannot escape into an ancestor `config/`. The reader's `findUpward` lands locally on subsequent invocations because the writer just planted `config/` at `target`.
- **No new error class.** Library throws plain `Error` with a message naming the conflicting key + overwrite-intent parameter; `cause` carries the structured fields. Extends Node's standard `Error.cause` slot rather than introducing `ConflictError` (design-a) or `WriterConflict` (design-b).
- **Substrate stage delegates to init via a new first phase** — bootstrap-shape parity becomes structural rather than test-asserted.
- **Top-level ownership, leaf-path diagnostic** — faithful to spec normative text; matches design-b's split, satisfies the spec's `product.x.foo` success-criterion test.

### Process notes

Drafted and revised through two sub-agent review panels (3 reviewers each, parallel, cold) per `kata-review` caller protocol. The second commit on this branch addresses consensus findings from the second panel — primarily stripping plan-scope leakage (file:line citations, literal `Error` construction), fixing a factual claim about `fit-map.js`'s module-top `createProductConfig` load, inlining the classification table, and narrowing Decision #10 to spec 990's actual credential-only scope.

Approval is human-only — I am not requesting a `design:approved` label.

## Test plan

- [ ] Reviewer reads design-c.md end-to-end and confirms it stays within spec scope.
- [ ] Reviewer compares Decision #1 (libconfig as home) with design-a #1 (new library) and design-b #1 (per-surface) and picks the variant that best fits the catalog-first rule + single-README mandate.
- [ ] Reviewer confirms Decision #4 (explicit target; no upward walk) addresses the anchor-escape failure mode the spec exists to fix.
- [ ] Reviewer confirms Decision #7 (substrate stage delegates to init in-process) is preferable to design-b's two-subprocess workflow sequencing.

https://claude.ai/code/session_01D8pN7K6MQMaDohnLkUyiak

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8pN7K6MQMaDohnLkUyiak)_