### PR TITLE
feat(libconfig,guide,map)!: bootstrapProject writer surface; cross-product init parity (#1000)

### DIFF
--- a/.claude/skills/fit-guide/SKILL.md
+++ b/.claude/skills/fit-guide/SKILL.md
@@ -36,7 +36,7 @@ Chat.
 
 **Setup and operations:**
 
-- Bootstrap a new project — `npx fit-guide init`
+- Bootstrap a new project — `npx fit-guide --init` (safe to re-run; no-op on existing projects)
 - Authenticate — `npx fit-guide login`
 - Start the service stack — `npx fit-rc start`
 - Check system readiness — `npx fit-guide status`
@@ -92,14 +92,16 @@ agent combine precise graph lookups with fuzzy semantic retrieval.
 
 ## Initialization
 
-Run `npx fit-guide init` once in a fresh project directory. It produces `.env`
+Run `npx fit-guide --init` in a fresh project directory. It produces `.env`
 (token and port assignments) and `config/config.json` (service composition).
-Then authenticate and set up the stack:
+Re-runs are byte-stable no-ops — generated `SERVICE_SECRET` and `MCP_TOKEN`
+are preserved across invocations, so running init again to pick up a starter
+update never rotates credentials. Then authenticate and set up the stack:
 
 ```sh
-npx fit-guide init          # Creates .env and config/config.json
+npx fit-guide --init        # Bootstrap .env + config/config.json (idempotent)
 npx fit-codegen --all       # Generate gRPC stubs and field metadata
-npx fit-guide login         # OAuth PKCE login (or set ANTHROPIC_API_KEY in .env)
+npx fit-guide --login       # OAuth PKCE login (or set ANTHROPIC_API_KEY in .env)
 npx fit-process-resources   # Process starter knowledge HTML
 npx fit-process-graphs      # Build the RDF index
 npx fit-process-vectors     # Build the vector index (skip if no embeddings backend)

--- a/.claude/skills/fit-guide/references/cli.md
+++ b/.claude/skills/fit-guide/references/cli.md
@@ -6,12 +6,12 @@
 npx fit-guide                              # Send a question (piped or as args)
 npx fit-guide --help                       # Show help
 npx fit-guide --version                    # Print package version
-npx fit-guide init                         # First-run bootstrap
-npx fit-guide login                        # OAuth PKCE login with Anthropic
-npx fit-guide logout                       # Clear stored credentials
-npx fit-guide resume                       # Resume previous conversation
-npx fit-guide status                       # Check system readiness
-npx fit-guide status --json                # Machine-readable status
+npx fit-guide --init                       # Bootstrap .env + config/ + .claude/skills/ (idempotent re-runs)
+npx fit-guide --login                      # OAuth PKCE login with Anthropic
+npx fit-guide --logout                     # Clear stored credentials
+npx fit-guide --resume                     # Resume previous conversation
+npx fit-guide --status                     # Check system readiness
+npx fit-guide --status --json              # Machine-readable status
 echo "Tell me about X" | npx fit-guide     # Piped single prompt
 ```
 

--- a/.claude/skills/fit-guide/references/config.md
+++ b/.claude/skills/fit-guide/references/config.md
@@ -27,4 +27,4 @@ Controls the service startup order for `fit-rc`:
 }
 ```
 
-To restore the starter config, delete `config/` and re-run `npx fit-guide init`.
+Re-running `npx fit-guide --init` against an existing project is a same-key-same-value no-op — the merged `config/config.json` and `.env` are byte-stable, and `SERVICE_SECRET` / `MCP_TOKEN` are preserved rather than rotated. To roll back hand-edits, delete the specific top-level key under `config/config.json` (or the whole file) and re-run; the starter shape is restored without disturbing other products' contributions.

--- a/.claude/skills/fit-map/references/cli.md
+++ b/.claude/skills/fit-map/references/cli.md
@@ -3,7 +3,7 @@
 ### Agent-Aligned Engineering Standard commands
 
 ```sh
-npx fit-map init                            # Create ./data/pathway/ with starter standard data
+npx fit-map init                            # Bootstrap ./data/pathway/ + ./config/config.json; re-runs are idempotent
 npx fit-map validate                        # Validate all data (JSON schema + referential)
 npx fit-map validate --shacl                # Validate RDF/SHACL syntax
 npx fit-map validate --data=PATH            # Validate a specific data directory

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -77,10 +77,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SUBSTRATE_FORCE_EMPTY_CORPUS: ${{ inputs.empty-corpus-test }}
         run: |
-          # Provision $AGENT_CWD/config/ so libconfig's findUpward("config")
-          # resolves uniformly from the agent's cwd.
-          mkdir -p "${{ steps.agent-workspace.outputs.dir }}/config"
-          bunx fit-map substrate stage
+          bunx fit-map substrate stage --cwd "${{ steps.agent-workspace.outputs.dir }}"
 
           # Propagate the local Supabase URL + anon key to subsequent
           # workflow steps. The Node process running `bunx fit-map

--- a/libraries/libconfig/README.md
+++ b/libraries/libconfig/README.md
@@ -14,3 +14,53 @@ import { createConfig, createServiceConfig } from '@forwardimpact/libconfig';
 
 const config = await createServiceConfig('myservice', { port: 3000 });
 ```
+
+## Bootstrap
+
+A product's `init` verb hands its starter material to `bootstrapProject`,
+which writes `config/config.json` and `.env` under namespace-scoped
+ownership semantics. Same-key-same-value writes are no-ops; same-key-
+different-value writes refuse without explicit overwrite intent, so two
+products with disjoint top-level namespaces can converge against the same
+target directory.
+
+```js
+import { bootstrapProject } from '@forwardimpact/libconfig';
+
+await bootstrapProject({
+  target,                              // absolute path; defaults to process.cwd()
+  fragment: {                          // top-level keys are product-owned namespaces; {} or omitted is allowed
+    'product.guide': { systemPrompt: '…' },
+    'service.mcp':   { systemPrompt: '…' },
+  },
+  env: {                               // .env entries; {} or omitted is allowed
+    SERVICE_SECRET: '…',
+    MCP_TOKEN:      '…',
+  },
+  overwrites: {                        // explicit overwrite intent, partitioned per file
+    config: ['product.guide'],         // top-level namespace names (single segment)
+    env:    ['MCP_TOKEN'],             // bare keys
+  },
+});
+```
+
+- **Entry point** — `bootstrapProject({ target, fragment, env, overwrites })`.
+  Returns `void` on success; throws a refusal `Error` whose `cause` carries
+  `{ kind, path, overwriteSurface }` when a write conflicts and the caller
+  did not signal overwrite intent.
+- **Namespace declaration** — the top-level keys of `fragment` are the
+  namespaces the product owns. Cross-namespace writes never collide;
+  within a namespace, any leaf disagreement refuses at the top-level.
+- **Overwrite intent** — pass `overwrites.config: [topLevelKey]` (single-
+  segment names) or `overwrites.env: [bareKey]` to opt in to replacing
+  a conflicting value. The refusal message names both the conflicting key
+  and the surface so the caller's CLI can render a greppable diagnostic.
+- **`.env` primitives** — `bootstrapProject` delegates per-key `.env`
+  writes to `@forwardimpact/libsecret`'s `updateEnvFile`, which preserves
+  comment lines, the trailing newline, and mode `0o600`.
+
+`bootstrapProject` always materialises `target/config/config.json` (writing
+`{}` when fragment is empty and the file is absent) so subsequent reader
+invocations anchor locally rather than upward-walking into an ancestor
+`config/`. `.env` is created only when at least one entry is supplied; an
+empty `env` against an existing `.env` is a no-op.

--- a/libraries/libconfig/README.md
+++ b/libraries/libconfig/README.md
@@ -30,15 +30,19 @@ import { bootstrapProject } from '@forwardimpact/libconfig';
 await bootstrapProject({
   target,                              // absolute path; defaults to process.cwd()
   fragment: {                          // top-level keys are product-owned namespaces; {} or omitted is allowed
-    'product.guide': { systemPrompt: '…' },
-    'service.mcp':   { systemPrompt: '…' },
+    product: {
+      guide: { systemPrompt: '…' },    // fit-guide's slice under top-level `product`
+    },
+    service: {
+      mcp:   { systemPrompt: '…' },    // fit-guide's slice under top-level `service`
+    },
   },
   env: {                               // .env entries; {} or omitted is allowed
     SERVICE_SECRET: '…',
     MCP_TOKEN:      '…',
   },
   overwrites: {                        // explicit overwrite intent, partitioned per file
-    config: ['product.guide'],         // top-level namespace names (single segment)
+    config: ['product'],               // top-level namespace names (single segment)
     env:    ['MCP_TOKEN'],             // bare keys
   },
 });
@@ -49,12 +53,19 @@ await bootstrapProject({
   `{ kind, path, overwriteSurface }` when a write conflicts and the caller
   did not signal overwrite intent.
 - **Namespace declaration** — the top-level keys of `fragment` are the
-  namespaces the product owns. Cross-namespace writes never collide;
-  within a namespace, any leaf disagreement refuses at the top-level.
+  namespaces a product owns. Use the **nested form** (`{ product: { guide:
+  … } }`) — that's the shape the libconfig reader resolves and the shape
+  every in-tree caller emits. Cross-namespace writes (different top-level
+  keys, or disjoint sub-keys under a shared top-level) never collide;
+  within a namespace, any leaf disagreement refuses with a leaf-path
+  diagnostic.
 - **Overwrite intent** — pass `overwrites.config: [topLevelKey]` (single-
   segment names) or `overwrites.env: [bareKey]` to opt in to replacing
-  a conflicting value. The refusal message names both the conflicting key
-  and the surface so the caller's CLI can render a greppable diagnostic.
+  a conflicting value. The refusal message names both the conflicting
+  leaf path (e.g. `product.guide.systemPrompt`) and the surface; the
+  overwrite-intent entry remains the **top-level** key (`product`) —
+  forgiving a single leaf forgives the whole namespace by design, so
+  pick the smallest top-level that contains the disputed leaf.
 - **`.env` primitives** — `bootstrapProject` delegates per-key `.env`
   writes to `@forwardimpact/libsecret`'s `updateEnvFile`, which preserves
   comment lines, the trailing newline, and mode `0o600`.

--- a/libraries/libconfig/package.json
+++ b/libraries/libconfig/package.json
@@ -28,6 +28,7 @@
     "test": "bun test test/*.test.js"
   },
   "dependencies": {
+    "@forwardimpact/libsecret": "^0.1.15",
     "@forwardimpact/libstorage": "^0.1.53"
   },
   "devDependencies": {

--- a/libraries/libconfig/src/bootstrap.js
+++ b/libraries/libconfig/src/bootstrap.js
@@ -1,0 +1,92 @@
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { readEnvFile, updateEnvFile } from "@forwardimpact/libsecret";
+
+import { mergeConfigFragment, mergeEnvEntries } from "./merge.js";
+import { bootstrapRefusal } from "./errors.js";
+
+/**
+ * Bootstrap a Forward Impact product directory.
+ *
+ * Materialises `target/config/config.json` (always) and `target/.env`
+ * (when at least one entry is supplied), under namespace-scoped ownership
+ * semantics. A same-key-different-value write refuses by default with
+ * `bootstrapRefusal`; pass `overwrites.config` (top-level keys) or
+ * `overwrites.env` (bare keys) to opt in.
+ *
+ * Both surfaces are classified before any filesystem mutation, so a refused
+ * write never leaves a half-written `config.json` on disk. Cross-file
+ * atomicity between `config.json` and `.env` mid-write remains deferred
+ * (spec § *Out of scope*).
+ *
+ * @param {object} params
+ * @param {string} [params.target]   Absolute path; defaults to `process.cwd()`.
+ * @param {object} [params.fragment] Top-level keys are product-owned
+ *   namespaces; may be `{}` or omitted.
+ * @param {Record<string,string>} [params.env] `.env` entries the product
+ *   wants written; may be `{}` or omitted.
+ * @param {{ config?: string[], env?: string[] }} [params.overwrites]
+ *   Explicit overwrite intent, partitioned per file. `config` entries are
+ *   top-level namespace names (single segment); `env` entries are bare keys.
+ * @returns {Promise<void>}
+ */
+export async function bootstrapProject({
+  target = process.cwd(),
+  fragment = {},
+  env = {},
+  overwrites = {},
+} = {}) {
+  const configDir = path.join(target, "config");
+  const configPath = path.join(configDir, "config.json");
+  const envPath = path.join(target, ".env");
+
+  const existingConfig = await readJsonOrEmpty(configPath);
+  const existingEnv = await readEnvSubset(Object.keys(env), envPath);
+
+  const cfg = mergeConfigFragment({
+    existing: existingConfig,
+    fragment,
+    overwrites: overwrites.config ?? [],
+  });
+  const ev = mergeEnvEntries({
+    existing: existingEnv,
+    fragment: env,
+    overwrites: overwrites.env ?? [],
+  });
+  // Config conflicts take precedence over env conflicts so stderr
+  // diagnostics surface deterministically regardless of input ordering.
+  const conflicts = [...cfg.conflicts, ...ev.conflicts];
+  if (conflicts.length > 0) throw bootstrapRefusal(conflicts[0]);
+
+  await mkdir(configDir, { recursive: true });
+  await writeFile(configPath, JSON.stringify(cfg.result, null, 2) + "\n");
+
+  // Iterate the input `env`, not `ev.result`. Same-key-same-value writes are
+  // idempotent line rewrites in updateEnvFile (the line content is unchanged),
+  // and updateEnvFile's per-call chmod 0o600 is the mechanism that re-enforces
+  // mode 0o600 on every invocation — required for the spec's `.env` mode
+  // criterion to survive a pre-existing .env with mode 0o644. The merged
+  // `ev.result` is computed for classification only.
+  for (const [key, value] of Object.entries(env)) {
+    await updateEnvFile(key, value, envPath);
+  }
+}
+
+async function readJsonOrEmpty(filePath) {
+  try {
+    const text = await readFile(filePath, "utf8");
+    return JSON.parse(text);
+  } catch (err) {
+    if (err.code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+async function readEnvSubset(keys, envPath) {
+  const out = {};
+  for (const key of keys) {
+    const value = await readEnvFile(key, envPath);
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}

--- a/libraries/libconfig/src/errors.js
+++ b/libraries/libconfig/src/errors.js
@@ -1,0 +1,24 @@
+/**
+ * Construct the refusal `Error` `bootstrapProject` throws when a write
+ * conflicts with the on-disk state and the caller did not signal overwrite
+ * intent. The message names the conflicting key and the overwrite-intent
+ * surface so a contributor reading stderr can suppress the refusal without
+ * reading the library source; `cause` carries the structured fields for
+ * programmatic introspection.
+ *
+ * @param {{ kind: "config" | "env", path: string }} args
+ * @returns {Error}
+ */
+export function bootstrapRefusal({ kind, path }) {
+  const overwriteSurface =
+    kind === "config" ? "overwrites.config" : "overwrites.env";
+  const subject =
+    kind === "config" ? `config key "${path}"` : `.env key "${path}"`;
+  const topKey = kind === "config" ? path.split(".")[0] : path;
+  const err = new Error(
+    `bootstrapProject: refused to overwrite ${subject}; ` +
+      `pass ${overwriteSurface}: ["${topKey}"] to allow.`,
+  );
+  err.cause = { kind, path, overwriteSurface };
+  return err;
+}

--- a/libraries/libconfig/src/index.js
+++ b/libraries/libconfig/src/index.js
@@ -127,3 +127,6 @@ export async function createInitConfig(
 
 // Re-export Config class for advanced use cases
 export { Config } from "./config.js";
+
+// Writer surface — see src/bootstrap.js
+export { bootstrapProject } from "./bootstrap.js";

--- a/libraries/libconfig/src/merge.js
+++ b/libraries/libconfig/src/merge.js
@@ -1,0 +1,106 @@
+/**
+ * Pure namespace-ownership classifier used by `bootstrapProject`.
+ *
+ * `mergeConfigFragment` enforces ownership at the **top-level key** but
+ * surfaces diagnostics at the **leaf path** that disagrees — design 1000-c
+ * Decision #3. `mergeEnvEntries` applies the same three rows at bare-key
+ * granularity.
+ */
+
+function canonicalize(value) {
+  if (value === undefined) {
+    throw new Error("canonicalize: undefined not allowed");
+  }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return JSON.stringify(value);
+  }
+  const sortedKeys = Object.keys(value).sort();
+  const parts = sortedKeys.map(
+    (k) => `${JSON.stringify(k)}:${canonicalize(value[k])}`,
+  );
+  return `{${parts.join(",")}}`;
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function walkLeafConflicts(existing, fragment, prefix, conflicts) {
+  if (isPlainObject(existing) && isPlainObject(fragment)) {
+    const keys = new Set([...Object.keys(existing), ...Object.keys(fragment)]);
+    for (const key of keys) {
+      const nextPath = `${prefix}.${key}`;
+      if (!(key in existing) || !(key in fragment)) continue;
+      if (canonicalize(existing[key]) === canonicalize(fragment[key])) continue;
+      walkLeafConflicts(existing[key], fragment[key], nextPath, conflicts);
+    }
+    return;
+  }
+  // At least one side is a scalar/array, or the two sides have different
+  // shapes (object vs scalar) — record the conflict at the parent path.
+  conflicts.push({ kind: "config", path: prefix });
+}
+
+/**
+ * Classify a config fragment against the on-disk subtree.
+ * @param {object} params
+ * @param {object} [params.existing]   Current `config.json` contents (or `{}`).
+ * @param {object} [params.fragment]   Caller's proposed contribution.
+ * @param {string[]} [params.overwrites]  Top-level keys the caller has signed
+ *   off to replace wholesale.
+ * @returns {{ result: object, conflicts: {kind: "config", path: string}[] }}
+ */
+export function mergeConfigFragment({
+  existing = {},
+  fragment = {},
+  overwrites = [],
+} = {}) {
+  const overwriteSet = new Set(overwrites);
+  const conflicts = [];
+  const result = { ...existing };
+  for (const [topKey, subtree] of Object.entries(fragment)) {
+    if (!(topKey in existing)) {
+      result[topKey] = subtree;
+      continue;
+    }
+    if (canonicalize(existing[topKey]) === canonicalize(subtree)) continue;
+    if (overwriteSet.has(topKey)) {
+      result[topKey] = subtree;
+      continue;
+    }
+    walkLeafConflicts(existing[topKey], subtree, topKey, conflicts);
+  }
+  return { result, conflicts };
+}
+
+/**
+ * Classify `.env` entries at bare-key granularity. Value comparison is
+ * byte-for-byte after `KEY=`.
+ * @param {object} params
+ * @param {Record<string,string>} [params.existing]
+ * @param {Record<string,string>} [params.fragment]
+ * @param {string[]} [params.overwrites]
+ * @returns {{ result: Record<string,string>, conflicts: {kind: "env", path: string}[] }}
+ */
+export function mergeEnvEntries({
+  existing = {},
+  fragment = {},
+  overwrites = [],
+} = {}) {
+  const overwriteSet = new Set(overwrites);
+  const conflicts = [];
+  const result = { ...existing };
+  for (const [key, value] of Object.entries(fragment)) {
+    if (!(key in existing)) {
+      result[key] = value;
+      continue;
+    }
+    if (existing[key] === value) continue;
+    if (overwriteSet.has(key)) {
+      result[key] = value;
+      continue;
+    }
+    conflicts.push({ kind: "env", path: key });
+  }
+  return { result, conflicts };
+}

--- a/libraries/libconfig/src/merge.js
+++ b/libraries/libconfig/src/merge.js
@@ -25,20 +25,39 @@ function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function walkLeafConflicts(existing, fragment, prefix, conflicts) {
+/**
+ * Recursively merge `fragment` into `existing`, recording per-leaf
+ * conflicts at their dotted path. When both sides are plain objects with
+ * disjoint sub-keys (no leaf disagrees), the result is the deep-merge of
+ * the two subtrees — this is the cross-namespace-always-succeeds rule
+ * applied one level deeper than the top-level. When a leaf disagrees
+ * (or shapes mismatch), the conflict is recorded at that leaf path and
+ * the existing value is preserved in the partial result (which the
+ * orchestrator discards when conflicts is non-empty).
+ */
+function deepMergeOrConflict(existing, fragment, prefix, conflicts) {
+  if (canonicalize(existing) === canonicalize(fragment)) return existing;
   if (isPlainObject(existing) && isPlainObject(fragment)) {
-    const keys = new Set([...Object.keys(existing), ...Object.keys(fragment)]);
-    for (const key of keys) {
-      const nextPath = `${prefix}.${key}`;
-      if (!(key in existing) || !(key in fragment)) continue;
-      if (canonicalize(existing[key]) === canonicalize(fragment[key])) continue;
-      walkLeafConflicts(existing[key], fragment[key], nextPath, conflicts);
+    const result = { ...existing };
+    for (const [key, value] of Object.entries(fragment)) {
+      const subPath = `${prefix}.${key}`;
+      if (!(key in existing)) {
+        result[key] = value;
+        continue;
+      }
+      result[key] = deepMergeOrConflict(
+        existing[key],
+        value,
+        subPath,
+        conflicts,
+      );
     }
-    return;
+    return result;
   }
   // At least one side is a scalar/array, or the two sides have different
-  // shapes (object vs scalar) — record the conflict at the parent path.
+  // shapes (object vs scalar) — record the conflict at this path.
   conflicts.push({ kind: "config", path: prefix });
+  return existing;
 }
 
 /**
@@ -68,7 +87,12 @@ export function mergeConfigFragment({
       result[topKey] = subtree;
       continue;
     }
-    walkLeafConflicts(existing[topKey], subtree, topKey, conflicts);
+    result[topKey] = deepMergeOrConflict(
+      existing[topKey],
+      subtree,
+      topKey,
+      conflicts,
+    );
   }
   return { result, conflicts };
 }

--- a/libraries/libconfig/test/bootstrap.test.js
+++ b/libraries/libconfig/test/bootstrap.test.js
@@ -1,0 +1,229 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { bootstrapProject } from "../src/bootstrap.js";
+
+let testDir;
+
+beforeEach(async () => {
+  testDir = await fs.mkdtemp(path.join(tmpdir(), "libconfig-bootstrap-"));
+});
+
+afterEach(async () => {
+  try {
+    await fs.rm(testDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe("bootstrapProject — config writer", () => {
+  test("empty fragment + absent config/config.json → writes {} ", async () => {
+    await bootstrapProject({ target: testDir });
+    const text = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+      "utf8",
+    );
+    assert.equal(JSON.parse(text).constructor, Object);
+    assert.deepEqual(JSON.parse(text), {});
+  });
+
+  test("two disjoint top-level namespaces merge into a single config.json", async () => {
+    await bootstrapProject({
+      target: testDir,
+      fragment: { "product.guide": { systemPrompt: "g" } },
+    });
+    await bootstrapProject({
+      target: testDir,
+      fragment: { "service.mcp": { systemPrompt: "m" } },
+    });
+    const text = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+      "utf8",
+    );
+    const parsed = JSON.parse(text);
+    assert.deepEqual(parsed, {
+      "product.guide": { systemPrompt: "g" },
+      "service.mcp": { systemPrompt: "m" },
+    });
+  });
+
+  test("re-invoking with same input is byte-stable", async () => {
+    const input = {
+      target: testDir,
+      fragment: { "product.guide": { systemPrompt: "g" } },
+      env: { SERVICE_SECRET: "abc" },
+    };
+    await bootstrapProject(input);
+    const configBefore = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+    );
+    const envBefore = await fs.readFile(path.join(testDir, ".env"));
+    await bootstrapProject(input);
+    const configAfter = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+    );
+    const envAfter = await fs.readFile(path.join(testDir, ".env"));
+    assert.equal(configBefore.equals(configAfter), true);
+    assert.equal(envBefore.equals(envAfter), true);
+  });
+
+  test("A→B→A→B converges to post-AB byte state", async () => {
+    const a = { fragment: { "product.guide": { v: 1 } } };
+    const b = { fragment: { "service.mcp": { v: 2 } } };
+    await bootstrapProject({ target: testDir, ...a });
+    await bootstrapProject({ target: testDir, ...b });
+    const after_ab = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+    );
+    await bootstrapProject({ target: testDir, ...a });
+    await bootstrapProject({ target: testDir, ...b });
+    const after_abab = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+    );
+    assert.equal(after_ab.equals(after_abab), true);
+  });
+
+  test("same-key-different-value refuses; config.json byte-unchanged", async () => {
+    await bootstrapProject({
+      target: testDir,
+      fragment: { product: { x: { foo: "a" } } },
+    });
+    const before = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+    );
+    await assert.rejects(
+      () =>
+        bootstrapProject({
+          target: testDir,
+          fragment: { product: { x: { foo: "b" } } },
+        }),
+      (err) => {
+        assert.ok(err.message.includes("product.x.foo"));
+        assert.ok(err.message.includes("overwrites.config"));
+        assert.deepEqual(err.cause, {
+          kind: "config",
+          path: "product.x.foo",
+          overwriteSurface: "overwrites.config",
+        });
+        return true;
+      },
+    );
+    const after = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+    );
+    assert.equal(before.equals(after), true);
+  });
+
+  test("same-key-different-value overwritten when top-level key in overwrites.config", async () => {
+    await bootstrapProject({
+      target: testDir,
+      fragment: { product: { x: { foo: "a" } } },
+    });
+    await bootstrapProject({
+      target: testDir,
+      fragment: { product: { x: { foo: "b" } } },
+      overwrites: { config: ["product"] },
+    });
+    const text = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+      "utf8",
+    );
+    assert.deepEqual(JSON.parse(text), { product: { x: { foo: "b" } } });
+  });
+});
+
+describe("bootstrapProject — env writer", () => {
+  test(".env mode is 0o600 after a fresh write", async () => {
+    await bootstrapProject({
+      target: testDir,
+      env: { SERVICE_SECRET: "abc", MCP_TOKEN: "xyz" },
+    });
+    const envPath = path.join(testDir, ".env");
+    const stats = await fs.stat(envPath);
+    assert.equal(stats.mode & 0o777, 0o600);
+  });
+
+  test(".env mode is re-enforced to 0o600 against a pre-existing 0o644 file", async () => {
+    const envPath = path.join(testDir, ".env");
+    await fs.writeFile(envPath, "PRE_EXISTING=disjoint\n", { mode: 0o644 });
+    await fs.chmod(envPath, 0o644);
+    await bootstrapProject({
+      target: testDir,
+      env: { SERVICE_SECRET: "abc" },
+    });
+    const stats = await fs.stat(envPath);
+    assert.equal(stats.mode & 0o777, 0o600);
+    // Pre-existing disjoint entry preserved.
+    const text = await fs.readFile(envPath, "utf8");
+    assert.ok(text.includes("PRE_EXISTING=disjoint"));
+    assert.ok(text.includes("SERVICE_SECRET=abc"));
+  });
+
+  test("empty env against existing .env → file byte-unchanged", async () => {
+    const envPath = path.join(testDir, ".env");
+    await fs.writeFile(envPath, "PRE_EXISTING=disjoint\n", { mode: 0o600 });
+    const before = await fs.readFile(envPath);
+    await bootstrapProject({ target: testDir, env: {} });
+    const after = await fs.readFile(envPath);
+    assert.equal(before.equals(after), true);
+  });
+
+  test("same-key-different-value .env refuses with bare-key diagnostic", async () => {
+    await bootstrapProject({
+      target: testDir,
+      env: { MCP_TOKEN: "old" },
+    });
+    await assert.rejects(
+      () =>
+        bootstrapProject({
+          target: testDir,
+          env: { MCP_TOKEN: "new" },
+        }),
+      (err) => {
+        assert.ok(err.message.includes("MCP_TOKEN"));
+        assert.ok(err.message.includes("overwrites.env"));
+        assert.equal(err.cause.kind, "env");
+        assert.equal(err.cause.path, "MCP_TOKEN");
+        return true;
+      },
+    );
+  });
+
+  test("same-key-different-value .env overwritten when key in overwrites.env", async () => {
+    await bootstrapProject({
+      target: testDir,
+      env: { MCP_TOKEN: "old" },
+    });
+    await bootstrapProject({
+      target: testDir,
+      env: { MCP_TOKEN: "new" },
+      overwrites: { env: ["MCP_TOKEN"] },
+    });
+    const text = await fs.readFile(path.join(testDir, ".env"), "utf8");
+    assert.ok(text.includes("MCP_TOKEN=new"));
+    assert.ok(!text.includes("MCP_TOKEN=old"));
+  });
+
+  test("config conflict short-circuits before any .env mutation", async () => {
+    await bootstrapProject({
+      target: testDir,
+      fragment: { product: { x: "a" } },
+    });
+    const envPath = path.join(testDir, ".env");
+    // No .env exists yet.
+    await assert.rejects(() =>
+      bootstrapProject({
+        target: testDir,
+        fragment: { product: { x: "b" } },
+        env: { SERVICE_SECRET: "abc" },
+      }),
+    );
+    // The .env was never created because we threw on the config conflict
+    // before any FS mutation.
+    await assert.rejects(() => fs.stat(envPath), { code: "ENOENT" });
+  });
+});

--- a/libraries/libconfig/test/bootstrap.test.js
+++ b/libraries/libconfig/test/bootstrap.test.js
@@ -31,14 +31,18 @@ describe("bootstrapProject — config writer", () => {
     assert.deepEqual(JSON.parse(text), {});
   });
 
-  test("two disjoint top-level namespaces merge into a single config.json", async () => {
+  test("two products with disjoint top-level namespaces merge into a single config.json (nested form)", async () => {
+    // Production callers ship nested top-level keys (fit-guide ships
+    // `init`/`product`/`service`); the spec's first success criterion
+    // calls for two callers' contributions to co-exist after sequential
+    // bootstrapProject calls against the same target.
     await bootstrapProject({
       target: testDir,
-      fragment: { "product.guide": { systemPrompt: "g" } },
+      fragment: { product: { guide: { systemPrompt: "g" } } },
     });
     await bootstrapProject({
       target: testDir,
-      fragment: { "service.mcp": { systemPrompt: "m" } },
+      fragment: { service: { mcp: { systemPrompt: "m" } } },
     });
     const text = await fs.readFile(
       path.join(testDir, "config", "config.json"),
@@ -46,15 +50,39 @@ describe("bootstrapProject — config writer", () => {
     );
     const parsed = JSON.parse(text);
     assert.deepEqual(parsed, {
-      "product.guide": { systemPrompt: "g" },
-      "service.mcp": { systemPrompt: "m" },
+      product: { guide: { systemPrompt: "g" } },
+      service: { mcp: { systemPrompt: "m" } },
+    });
+  });
+
+  test("two products sharing a top-level key but disjoint nested namespaces merge", async () => {
+    // The encoding fit-guide actually uses — both callers contribute
+    // under top-level `product`, but with disjoint nested namespaces
+    // (`product.guide` vs `product.map`). The merge classifier must
+    // deep-merge rather than refusing or silently dropping.
+    await bootstrapProject({
+      target: testDir,
+      fragment: { product: { guide: { systemPrompt: "g" } } },
+    });
+    await bootstrapProject({
+      target: testDir,
+      fragment: { product: { map: { systemPrompt: "m" } } },
+    });
+    const parsed = JSON.parse(
+      await fs.readFile(path.join(testDir, "config", "config.json"), "utf8"),
+    );
+    assert.deepEqual(parsed, {
+      product: {
+        guide: { systemPrompt: "g" },
+        map: { systemPrompt: "m" },
+      },
     });
   });
 
   test("re-invoking with same input is byte-stable", async () => {
     const input = {
       target: testDir,
-      fragment: { "product.guide": { systemPrompt: "g" } },
+      fragment: { product: { guide: { systemPrompt: "g" } } },
       env: { SERVICE_SECRET: "abc" },
     };
     await bootstrapProject(input);
@@ -71,9 +99,9 @@ describe("bootstrapProject — config writer", () => {
     assert.equal(envBefore.equals(envAfter), true);
   });
 
-  test("A→B→A→B converges to post-AB byte state", async () => {
-    const a = { fragment: { "product.guide": { v: 1 } } };
-    const b = { fragment: { "service.mcp": { v: 2 } } };
+  test("A→B→A→B converges to post-AB byte state (nested form)", async () => {
+    const a = { fragment: { product: { guide: { v: 1 } } } };
+    const b = { fragment: { service: { mcp: { v: 2 } } } };
     await bootstrapProject({ target: testDir, ...a });
     await bootstrapProject({ target: testDir, ...b });
     const after_ab = await fs.readFile(

--- a/libraries/libconfig/test/merge.test.js
+++ b/libraries/libconfig/test/merge.test.js
@@ -1,0 +1,140 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+
+import { mergeConfigFragment, mergeEnvEntries } from "../src/merge.js";
+
+describe("mergeConfigFragment — namespace ownership table", () => {
+  test("absent top-level key → write subtree", () => {
+    const { result, conflicts } = mergeConfigFragment({
+      existing: { a: { x: 1 } },
+      fragment: { b: { y: 2 } },
+    });
+    assert.deepEqual(result, { a: { x: 1 }, b: { y: 2 } });
+    assert.deepEqual(conflicts, []);
+  });
+
+  test("present, deep-equal subtree → no-op", () => {
+    const { result, conflicts } = mergeConfigFragment({
+      existing: { a: { x: 1, y: 2 } },
+      fragment: { a: { y: 2, x: 1 } }, // key order intentionally different
+    });
+    assert.deepEqual(result, { a: { x: 1, y: 2 } });
+    assert.deepEqual(conflicts, []);
+  });
+
+  test("present, leaf disagrees → refuse with leaf-path diagnostic", () => {
+    const { result, conflicts } = mergeConfigFragment({
+      existing: { product: { x: { foo: "a" } } },
+      fragment: { product: { x: { foo: "b" } } },
+    });
+    assert.deepEqual(result, { product: { x: { foo: "a" } } });
+    assert.deepEqual(conflicts, [{ kind: "config", path: "product.x.foo" }]);
+  });
+
+  test("present, leaf disagrees but top-level in overwrites → write", () => {
+    const { result, conflicts } = mergeConfigFragment({
+      existing: { product: { x: { foo: "a" } } },
+      fragment: { product: { x: { foo: "b" } } },
+      overwrites: ["product"],
+    });
+    assert.deepEqual(result, { product: { x: { foo: "b" } } });
+    assert.deepEqual(conflicts, []);
+  });
+
+  test("scalar/object shape mismatch → conflict at parent path", () => {
+    const { conflicts } = mergeConfigFragment({
+      existing: { product: { x: "scalar" } },
+      fragment: { product: { x: { foo: "b" } } },
+    });
+    assert.deepEqual(conflicts, [{ kind: "config", path: "product.x" }]);
+  });
+
+  test("array contents differ → conflict at the array path", () => {
+    const { conflicts } = mergeConfigFragment({
+      existing: { product: { items: [1, 2] } },
+      fragment: { product: { items: [1, 3] } },
+    });
+    assert.deepEqual(conflicts, [{ kind: "config", path: "product.items" }]);
+  });
+});
+
+describe("mergeConfigFragment — convergence", () => {
+  test("disjoint top-level keys: A→B and B→A produce identical canonical bytes", () => {
+    const fragA = { "product.guide": { systemPrompt: "g" } };
+    const fragB = { "service.mcp": { systemPrompt: "m" } };
+    const ab = mergeConfigFragment({
+      existing: mergeConfigFragment({ existing: {}, fragment: fragA }).result,
+      fragment: fragB,
+    }).result;
+    const ba = mergeConfigFragment({
+      existing: mergeConfigFragment({ existing: {}, fragment: fragB }).result,
+      fragment: fragA,
+    }).result;
+    assert.equal(canonical(ab), canonical(ba));
+  });
+
+  test("A→B→A→B converges to the post-AB state byte-for-byte", () => {
+    const fragA = { "product.guide": { v: 1 } };
+    const fragB = { "service.mcp": { v: 2 } };
+    let state = {};
+    state = mergeConfigFragment({ existing: state, fragment: fragA }).result;
+    state = mergeConfigFragment({ existing: state, fragment: fragB }).result;
+    const ab = canonical(state);
+    state = mergeConfigFragment({ existing: state, fragment: fragA }).result;
+    state = mergeConfigFragment({ existing: state, fragment: fragB }).result;
+    assert.equal(canonical(state), ab);
+  });
+});
+
+describe("mergeEnvEntries — namespace ownership table", () => {
+  test("absent key → write", () => {
+    const { result, conflicts } = mergeEnvEntries({
+      existing: { A: "1" },
+      fragment: { B: "2" },
+    });
+    assert.deepEqual(result, { A: "1", B: "2" });
+    assert.deepEqual(conflicts, []);
+  });
+
+  test("present, same value → no-op", () => {
+    const { result, conflicts } = mergeEnvEntries({
+      existing: { A: "1" },
+      fragment: { A: "1" },
+    });
+    assert.deepEqual(result, { A: "1" });
+    assert.deepEqual(conflicts, []);
+  });
+
+  test("present, different value → refuse with bare-key path", () => {
+    const { result, conflicts } = mergeEnvEntries({
+      existing: { MCP_TOKEN: "old" },
+      fragment: { MCP_TOKEN: "new" },
+    });
+    assert.deepEqual(result, { MCP_TOKEN: "old" });
+    assert.deepEqual(conflicts, [{ kind: "env", path: "MCP_TOKEN" }]);
+  });
+
+  test("present, different value, overwrites contains key → write", () => {
+    const { result, conflicts } = mergeEnvEntries({
+      existing: { MCP_TOKEN: "old" },
+      fragment: { MCP_TOKEN: "new" },
+      overwrites: ["MCP_TOKEN"],
+    });
+    assert.deepEqual(result, { MCP_TOKEN: "new" });
+    assert.deepEqual(conflicts, []);
+  });
+
+  test("empty-string fragment value distinct from undefined existing → write", () => {
+    const { result, conflicts } = mergeEnvEntries({
+      existing: {},
+      fragment: { A: "" },
+    });
+    assert.deepEqual(result, { A: "" });
+    assert.deepEqual(conflicts, []);
+  });
+});
+
+function canonical(obj) {
+  const keys = Object.keys(obj).sort();
+  return JSON.stringify(obj, keys);
+}

--- a/libraries/libconfig/test/merge.test.js
+++ b/libraries/libconfig/test/merge.test.js
@@ -56,12 +56,51 @@ describe("mergeConfigFragment — namespace ownership table", () => {
     });
     assert.deepEqual(conflicts, [{ kind: "config", path: "product.items" }]);
   });
+
+  test("disjoint sub-keys under shared top-level key deep-merge (cross-namespace one level deeper)", () => {
+    const { result, conflicts } = mergeConfigFragment({
+      existing: { product: { guide: { sys: "g" } } },
+      fragment: { product: { map: { sys: "m" } } },
+    });
+    assert.deepEqual(result, {
+      product: { guide: { sys: "g" }, map: { sys: "m" } },
+    });
+    assert.deepEqual(conflicts, []);
+  });
+
+  test("disjoint sub-keys plus matching leaves under shared top-level merge", () => {
+    const { result, conflicts } = mergeConfigFragment({
+      existing: { product: { shared: { v: 1 }, guide: { sys: "g" } } },
+      fragment: { product: { shared: { v: 1 }, map: { sys: "m" } } },
+    });
+    assert.deepEqual(result, {
+      product: {
+        shared: { v: 1 },
+        guide: { sys: "g" },
+        map: { sys: "m" },
+      },
+    });
+    assert.deepEqual(conflicts, []);
+  });
+
+  test("disjoint sibling plus one leaf disagreement → refuse at the disagreeing leaf", () => {
+    const { conflicts } = mergeConfigFragment({
+      existing: { product: { guide: { sys: "g" }, shared: { v: 1 } } },
+      fragment: { product: { map: { sys: "m" }, shared: { v: 2 } } },
+    });
+    assert.deepEqual(conflicts, [{ kind: "config", path: "product.shared.v" }]);
+  });
 });
 
-describe("mergeConfigFragment — convergence", () => {
-  test("disjoint top-level keys: A→B and B→A produce identical canonical bytes", () => {
-    const fragA = { "product.guide": { systemPrompt: "g" } };
-    const fragB = { "service.mcp": { systemPrompt: "m" } };
+describe("mergeConfigFragment — convergence (production nested encoding)", () => {
+  // Use the nested form fit-guide actually emits — top-level keys
+  // `init`/`product`/`service` with product/service slices nested
+  // beneath. Tests that use literal-dotted top-level keys
+  // (`"product.guide"`) wouldn't catch a regression in the
+  // disjoint-sub-key merge path the real callers walk.
+  test("disjoint nested namespaces under shared top-level: A→B and B→A produce identical canonical bytes", () => {
+    const fragA = { product: { guide: { systemPrompt: "g" } } };
+    const fragB = { product: { map: { systemPrompt: "m" } } };
     const ab = mergeConfigFragment({
       existing: mergeConfigFragment({ existing: {}, fragment: fragA }).result,
       fragment: fragB,
@@ -73,9 +112,9 @@ describe("mergeConfigFragment — convergence", () => {
     assert.equal(canonical(ab), canonical(ba));
   });
 
-  test("A→B→A→B converges to the post-AB state byte-for-byte", () => {
-    const fragA = { "product.guide": { v: 1 } };
-    const fragB = { "service.mcp": { v: 2 } };
+  test("A→B→A→B converges to the post-AB state byte-for-byte (nested form)", () => {
+    const fragA = { product: { guide: { v: 1 } }, service: { mcp: { v: 1 } } };
+    const fragB = { product: { map: { v: 2 } }, service: { other: { v: 2 } } };
     let state = {};
     state = mergeConfigFragment({ existing: state, fragment: fragA }).result;
     state = mergeConfigFragment({ existing: state, fragment: fragB }).result;

--- a/libraries/libconfig/test/readme.test.js
+++ b/libraries/libconfig/test/readme.test.js
@@ -1,0 +1,31 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("libconfig README — Bootstrap onboarding contract", () => {
+  test("documents entry point, namespace declaration, overwrite-intent, and libsecret cross-link", async () => {
+    const text = await readFile(join(__dirname, "..", "README.md"), "utf8");
+    const heading = "## Bootstrap";
+    const idx = text.indexOf(heading);
+    assert.ok(idx >= 0, "README is missing the `## Bootstrap` section");
+    // Scope substring assertions to the new section so unrelated mentions
+    // elsewhere can't satisfy them.
+    const nextHeading = text.indexOf("\n## ", idx + heading.length);
+    const section = text.slice(idx, nextHeading >= 0 ? nextHeading : undefined);
+    for (const needle of [
+      "bootstrapProject",
+      "fragment",
+      "overwrites",
+      "libsecret",
+    ]) {
+      assert.ok(
+        section.includes(needle),
+        `README ## Bootstrap section missing "${needle}"`,
+      );
+    }
+  });
+});

--- a/libraries/libconfig/test/stderr-integration.test.js
+++ b/libraries/libconfig/test/stderr-integration.test.js
@@ -1,0 +1,85 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+
+let testDir;
+
+beforeEach(async () => {
+  testDir = await fs.mkdtemp(path.join(tmpdir(), "libconfig-stderr-"));
+});
+
+afterEach(async () => {
+  try {
+    await fs.rm(testDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe("bootstrapProject — refusal stderr greppability", () => {
+  test("child process exit non-zero; stderr names leaf path and overwrite surface", async () => {
+    await fs.mkdir(path.join(testDir, "config"));
+    await fs.writeFile(
+      path.join(testDir, "config", "config.json"),
+      JSON.stringify({ product: { x: { foo: "a" } } }, null, 2) + "\n",
+    );
+
+    const script = `
+      import { bootstrapProject } from "${pathToFileUrl(
+        path.join(repoRoot, "libraries", "libconfig", "src", "bootstrap.js"),
+      )}";
+      try {
+        await bootstrapProject({
+          target: ${JSON.stringify(testDir)},
+          fragment: { product: { x: { foo: "b" } } },
+        });
+        process.exit(0);
+      } catch (err) {
+        process.stderr.write(err.message + "\\n");
+        process.exit(1);
+      }
+    `;
+
+    const { code, stderr } = await runNode(script);
+    assert.equal(code, 1);
+    assert.ok(
+      stderr.includes("product.x.foo"),
+      `stderr did not include leaf path: ${stderr}`,
+    );
+    assert.ok(
+      stderr.includes("overwrites.config"),
+      `stderr did not include overwrite surface: ${stderr}`,
+    );
+  });
+});
+
+function pathToFileUrl(p) {
+  return new URL(`file://${p}`).toString();
+}
+
+function runNode(script) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--input-type=module", "-e", script],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        cwd: repoRoot,
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk.toString()));
+    child.stderr.on("data", (chunk) => (stderr += chunk.toString()));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}

--- a/products/guide/src/commands/init.js
+++ b/products/guide/src/commands/init.js
@@ -1,35 +1,53 @@
 import fs from "node:fs/promises";
 import { resolve } from "node:path";
-import { generateSecret, updateEnvFile } from "@forwardimpact/libsecret";
+import { generateSecret, getOrGenerateSecret } from "@forwardimpact/libsecret";
+import { bootstrapProject } from "@forwardimpact/libconfig";
 import {
   SummaryRenderer,
   formatHeader,
   formatSuccess,
   formatError,
-  formatBullet,
 } from "@forwardimpact/libcli";
 
 /** Bootstrap a Guide project by generating secrets, writing default service URLs to .env, and copying starter configuration. */
 export async function runInitCommand() {
-  const serviceSecret = generateSecret();
-  const mcpToken = generateSecret();
+  const serviceSecret = await getOrGenerateSecret("SERVICE_SECRET", () =>
+    generateSecret(),
+  );
+  const mcpToken = await getOrGenerateSecret("MCP_TOKEN", () =>
+    generateSecret(),
+  );
 
-  await updateEnvFile("SERVICE_SECRET", serviceSecret);
-  await updateEnvFile("MCP_TOKEN", mcpToken);
+  const starterDir = new URL("../../starter", import.meta.url).pathname;
+  const skillsDir = resolve(".claude", "skills");
 
-  const serviceUrls = {
-    SERVICE_TRACE_URL: "grpc://localhost:3001",
-    SERVICE_VECTOR_URL: "grpc://localhost:3002",
-    SERVICE_GRAPH_URL: "grpc://localhost:3003",
-    SERVICE_PATHWAY_URL: "grpc://localhost:3004",
-    SERVICE_MAP_URL: "grpc://localhost:3006",
-    SERVICE_MCP_URL: "http://localhost:3005",
-    EMBEDDING_BASE_URL: "http://localhost:8090",
-  };
-
-  for (const [key, url] of Object.entries(serviceUrls)) {
-    await updateEnvFile(key, url);
+  try {
+    await fs.access(starterDir);
+  } catch {
+    process.stderr.write(
+      formatError("Starter data not found in package.") + "\n",
+    );
+    process.exit(1);
   }
+
+  const starterConfig = JSON.parse(
+    await fs.readFile(resolve(starterDir, "config.json"), "utf8"),
+  );
+
+  await bootstrapProject({
+    fragment: starterConfig,
+    env: {
+      SERVICE_SECRET: serviceSecret,
+      MCP_TOKEN: mcpToken,
+      SERVICE_TRACE_URL: "grpc://localhost:3001",
+      SERVICE_VECTOR_URL: "grpc://localhost:3002",
+      SERVICE_GRAPH_URL: "grpc://localhost:3003",
+      SERVICE_PATHWAY_URL: "grpc://localhost:3004",
+      SERVICE_MAP_URL: "grpc://localhost:3006",
+      SERVICE_MCP_URL: "http://localhost:3005",
+      EMBEDDING_BASE_URL: "http://localhost:8090",
+    },
+  });
 
   // Ensure package.json exists (needed by fit-codegen for project root detection)
   const pkgPath = resolve("package.json");
@@ -59,7 +77,7 @@ export async function runInitCommand() {
     items: [
       { label: "SERVICE_SECRET", description: "generated" },
       { label: "MCP_TOKEN", description: "generated" },
-      { label: "Service URLs", description: "ports 3001\u20133005" },
+      { label: "Service URLs", description: "ports 3001–3005" },
       {
         label: "ANTHROPIC_API_KEY",
         description: "set manually or run fit-guide login",
@@ -67,35 +85,6 @@ export async function runInitCommand() {
     ],
   });
   if (summary.shouldRender(true)) process.stdout.write("\n");
-
-  // Copy starter files into project
-  const starterDir = new URL("../../starter", import.meta.url).pathname;
-  const configDir = resolve("config");
-  const skillsDir = resolve(".claude", "skills");
-
-  try {
-    await fs.access(starterDir);
-  } catch {
-    process.stderr.write(
-      formatError("Starter data not found in package.") + "\n",
-    );
-    process.exit(1);
-  }
-
-  // Copy config.json → config/
-  const starterConfig = resolve(starterDir, "config.json");
-  try {
-    await fs.access(configDir);
-    process.stdout.write(
-      formatBullet("config/ already exists, skipping starter copy.", 0) + "\n",
-    );
-  } catch {
-    await fs.mkdir(configDir, { recursive: true });
-    await fs.cp(starterConfig, resolve(configDir, "config.json"));
-    process.stdout.write(
-      formatSuccess("config/ created with starter configuration.") + "\n",
-    );
-  }
 
   // Copy skills → .claude/skills/
   const starterSkills = resolve(starterDir, "skills");

--- a/products/guide/test/init.test.js
+++ b/products/guide/test/init.test.js
@@ -1,0 +1,127 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { runInitCommand } from "../src/commands/init.js";
+
+let testDir;
+let prevCwd;
+let prevWrite;
+let prevErr;
+
+beforeEach(async () => {
+  testDir = await fs.mkdtemp(path.join(tmpdir(), "fit-guide-init-"));
+  prevCwd = process.cwd();
+  process.chdir(testDir);
+  prevWrite = process.stdout.write.bind(process.stdout);
+  prevErr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = () => true;
+  process.stderr.write = () => true;
+});
+
+afterEach(async () => {
+  process.chdir(prevCwd);
+  process.stdout.write = prevWrite;
+  process.stderr.write = prevErr;
+  try {
+    await fs.rm(testDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe("fit-guide init", () => {
+  test("first run materialises config/, .env, and package.json with starter top-level keys", async () => {
+    await runInitCommand();
+    const config = JSON.parse(
+      await fs.readFile(path.join(testDir, "config", "config.json"), "utf8"),
+    );
+    // Starter ships init + product + service top-level namespaces.
+    assert.deepEqual(Object.keys(config).sort(), [
+      "init",
+      "product",
+      "service",
+    ]);
+    const env = await fs.readFile(path.join(testDir, ".env"), "utf8");
+    for (const key of [
+      "SERVICE_SECRET",
+      "MCP_TOKEN",
+      "SERVICE_TRACE_URL",
+      "SERVICE_VECTOR_URL",
+      "SERVICE_GRAPH_URL",
+      "SERVICE_PATHWAY_URL",
+      "SERVICE_MAP_URL",
+      "SERVICE_MCP_URL",
+      "EMBEDDING_BASE_URL",
+    ]) {
+      assert.ok(env.includes(`${key}=`), `.env missing ${key}`);
+    }
+    const pkg = JSON.parse(
+      await fs.readFile(path.join(testDir, "package.json"), "utf8"),
+    );
+    assert.equal(pkg.name, "my-guide-project");
+    const skillsDir = path.join(testDir, ".claude", "skills");
+    const skillStats = await fs.stat(skillsDir);
+    assert.equal(skillStats.isDirectory(), true);
+  });
+
+  test("re-run is byte-identical across config/, .env, package.json, .claude/skills/", async () => {
+    await runInitCommand();
+    const configBefore = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+    );
+    const envBefore = await fs.readFile(path.join(testDir, ".env"));
+    const pkgBefore = await fs.readFile(path.join(testDir, "package.json"));
+    const skillsListBefore = await listTree(
+      path.join(testDir, ".claude", "skills"),
+    );
+
+    // Parse env so we can compare specific secret values byte-for-byte.
+    const secretBefore = matchEnvValue(
+      envBefore.toString("utf8"),
+      "SERVICE_SECRET",
+    );
+    const tokenBefore = matchEnvValue(envBefore.toString("utf8"), "MCP_TOKEN");
+
+    await runInitCommand();
+
+    const configAfter = await fs.readFile(
+      path.join(testDir, "config", "config.json"),
+    );
+    const envAfter = await fs.readFile(path.join(testDir, ".env"));
+    const pkgAfter = await fs.readFile(path.join(testDir, "package.json"));
+    const skillsListAfter = await listTree(
+      path.join(testDir, ".claude", "skills"),
+    );
+
+    assert.equal(configBefore.equals(configAfter), true);
+    assert.equal(envBefore.equals(envAfter), true);
+    assert.equal(pkgBefore.equals(pkgAfter), true);
+    assert.deepEqual(skillsListBefore, skillsListAfter);
+
+    const secretAfter = matchEnvValue(
+      envAfter.toString("utf8"),
+      "SERVICE_SECRET",
+    );
+    const tokenAfter = matchEnvValue(envAfter.toString("utf8"), "MCP_TOKEN");
+    assert.equal(secretAfter, secretBefore);
+    assert.equal(tokenAfter, tokenBefore);
+  });
+});
+
+function matchEnvValue(text, key) {
+  for (const line of text.split("\n")) {
+    if (line.startsWith(`${key}=`)) return line.slice(key.length + 1);
+  }
+  return undefined;
+}
+
+async function listTree(dir) {
+  const entries = await fs.readdir(dir, {
+    withFileTypes: true,
+    recursive: true,
+  });
+  return entries.map((e) => `${e.parentPath ?? e.path}/${e.name}`).sort();
+}

--- a/products/map/bin/fit-map.js
+++ b/products/map/bin/fit-map.js
@@ -99,7 +99,13 @@ const definition = {
     {
       name: "substrate stage",
       description:
-        "Provision a Landmark substrate (stack + migrate + seed + provision + self-smoke)",
+        "Provision a Landmark substrate (init + stack + migrate + seed + provision + self-smoke)",
+      options: {
+        cwd: {
+          type: "string",
+          description: "Target dir for the init bootstrap (default: cwd)",
+        },
+      },
     },
     {
       name: "substrate roster",
@@ -477,7 +483,7 @@ async function dispatchSubstrate(subcommand, _rest, values) {
       const { runStageCommand } = await import(
         "../src/commands/substrate-stage.js"
       );
-      return runStageCommand({ config });
+      return runStageCommand({ config, target: values.cwd });
     }
     case "roster": {
       const supabase = await mapClient();

--- a/products/map/src/commands/init.js
+++ b/products/map/src/commands/init.js
@@ -7,6 +7,7 @@
 import { cp, access } from "fs/promises";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import { bootstrapProject } from "@forwardimpact/libconfig";
 import {
   formatError,
   formatSuccess,
@@ -26,16 +27,6 @@ export async function runInit(targetPath) {
   const target = targetPath || process.cwd();
   const dataDir = join(target, "data", "pathway");
 
-  // Check if data/pathway/ already exists
-  try {
-    await access(dataDir);
-    process.stderr.write(formatError("./data/pathway/ already exists.") + "\n");
-    process.stderr.write("Remove it first or use a different directory.\n");
-    process.exit(1);
-  } catch {
-    // Directory doesn't exist, proceed
-  }
-
   // Verify starter data is available
   try {
     await access(starterDir);
@@ -49,9 +40,19 @@ export async function runInit(targetPath) {
     process.exit(1);
   }
 
-  // Copy starter data
+  // Copy starter data — idempotent so substrate stage can re-stage a
+  // workspace produced by `fit-map init` as a no-op.
   process.stdout.write("Creating ./data/pathway/ with starter data...\n\n");
-  await cp(starterDir, dataDir, { recursive: true });
+  await cp(starterDir, dataDir, {
+    recursive: true,
+    force: false,
+    errorOnExist: false,
+  });
+
+  // Materialise target/config/config.json so subsequent fit-map invocations
+  // anchor at the init target rather than upward-walking into an ancestor
+  // config/. No product.map starter fragment is shipped this spec.
+  await bootstrapProject({ target, fragment: {} });
 
   process.stdout.write(
     formatSuccess("Created ./data/pathway/ with starter data.") + "\n\n",

--- a/products/map/src/commands/substrate-stage.js
+++ b/products/map/src/commands/substrate-stage.js
@@ -1,9 +1,10 @@
 /**
  * `fit-map substrate stage` — workspace-prep terminal phase for the
- * kata-interview workflow targeting Landmark. Brings up the local
- * Supabase stack, discovers its URL/anon key, migrates the schema,
- * seeds the activity data, provisions auth.users for the roster, and
- * runs a self-smoke against every gated Landmark command.
+ * kata-interview workflow targeting Landmark. Runs init against the
+ * target dir, brings up the local Supabase stack, discovers its URL/anon
+ * key, migrates the schema, seeds the activity data, provisions
+ * auth.users for the roster, and runs a self-smoke against every gated
+ * Landmark command.
  *
  * Designed to be invoked once per interview run from CI; not a developer
  * verb (use `fit-map activity start` + manual seed in dev flows).
@@ -13,6 +14,7 @@ import path from "node:path";
 import { createSupabaseCli as defaultCreateCli } from "../lib/supabase-cli.js";
 import { findDataDir as defaultFindDataDir } from "../lib/data-dir.js";
 import { createMapClient as defaultCreateMapClient } from "../lib/client.js";
+import { createProductConfig } from "@forwardimpact/libconfig";
 import { formatSuccess } from "@forwardimpact/libcli";
 
 /**
@@ -21,17 +23,21 @@ import { formatSuccess } from "@forwardimpact/libcli";
  * stderr identifies which substrate step failed.
  *
  * Dependencies are injectable for tests; production callers pass only
- * `config` and the defaults wire up the real Supabase CLI, mapClient,
- * data-dir resolver, seed, provision, and smoke surfaces.
+ * `config` (and optionally `target`) and the defaults wire up the real
+ * Supabase CLI, mapClient, data-dir resolver, init, seed, provision,
+ * and smoke surfaces.
  *
  * @param {object} params
  * @param {object} params.config - libconfig product config for "map".
+ * @param {string} [params.target] - Target dir for the init bootstrap
+ *   (default: process.cwd()).
  * @param {object} [deps]
  * @returns {Promise<number>}
  */
 export async function runStageCommand(
-  { config },
+  { config, target = process.cwd() },
   {
+    loadInit = () => import("./init.js").then((m) => m.runInit),
     createSupabaseCli = defaultCreateCli,
     findDataDir = defaultFindDataDir,
     createMapClient = defaultCreateMapClient,
@@ -40,8 +46,19 @@ export async function runStageCommand(
       import("./people-provision.js").then((m) => m.runProvisionCommand),
     loadSmoke = () =>
       import("./substrate-smoke.js").then((m) => m.runSelfSmoke),
+    reloadConfig = () => createProductConfig("map"),
   } = {},
 ) {
+  const runInit = await loadInit();
+  await runPhase("init", () => runInit(target));
+  // After init has materialised target/config/config.json, re-read libconfig
+  // so subsequent phases observe the bootstrapped state. fit-map.js's
+  // module-top config load ran before init in this subprocess.
+  const liveConfig = await reloadConfig();
+  // Production passes a config object; tests may stub `reloadConfig` to
+  // return their own. Use whichever value the stage observes after init.
+  const stageConfig = liveConfig ?? config;
+
   const cli = createSupabaseCli();
 
   await runPhase("stack", () => cli.run(["start"]));
@@ -60,7 +77,7 @@ export async function runStageCommand(
 
   await runPhase("migrate", () => cli.run(["db", "reset"]));
 
-  const supabase = createMapClient({ config });
+  const supabase = createMapClient({ config: stageConfig });
   const dataDir = await findDataDir(undefined);
   const dataRoot = path.dirname(dataDir);
   const seed = await loadSeed();
@@ -72,7 +89,9 @@ export async function runStageCommand(
     throw new Error("[substrate stage: smoke] empty corpus (test injection)");
   }
   const runSelfSmoke = await loadSmoke();
-  await runPhase("smoke", () => runSelfSmoke({ supabase, config }));
+  await runPhase("smoke", () =>
+    runSelfSmoke({ supabase, config: stageConfig }),
+  );
 
   process.stdout.write(formatSuccess("Substrate ready") + "\n");
   return 0;

--- a/products/map/src/commands/substrate-stage.js
+++ b/products/map/src/commands/substrate-stage.js
@@ -46,18 +46,26 @@ export async function runStageCommand(
       import("./people-provision.js").then((m) => m.runProvisionCommand),
     loadSmoke = () =>
       import("./substrate-smoke.js").then((m) => m.runSelfSmoke),
-    reloadConfig = () => createProductConfig("map"),
+    // Anchor the re-read at `target` so the post-init load observes the
+    // bootstrapped target/config/config.json. fit-map.js's module-top
+    // createProductConfig("map") ran from process.cwd() before init —
+    // in CI that's the monorepo root, not the agent workspace — so a
+    // plain createProductConfig() here would re-read the same root
+    // config and silently no-op against the writer's contribution.
+    reloadConfig = () =>
+      createProductConfig(
+        "map",
+        {},
+        {
+          cwd: () => target,
+          env: process.env,
+        },
+      ),
   } = {},
 ) {
   const runInit = await loadInit();
   await runPhase("init", () => runInit(target));
-  // After init has materialised target/config/config.json, re-read libconfig
-  // so subsequent phases observe the bootstrapped state. fit-map.js's
-  // module-top config load ran before init in this subprocess.
-  const liveConfig = await reloadConfig();
-  // Production passes a config object; tests may stub `reloadConfig` to
-  // return their own. Use whichever value the stage observes after init.
-  const stageConfig = liveConfig ?? config;
+  const stageConfig = (await reloadConfig()) ?? config;
 
   const cli = createSupabaseCli();
 

--- a/products/map/test/activity/substrate-stage.test.js
+++ b/products/map/test/activity/substrate-stage.test.js
@@ -1,14 +1,18 @@
 /**
  * Tests for `fit-map substrate stage` — uses injected dependency
- * overrides to stub out the Supabase CLI, mapClient, seed, provision,
- * and the self-smoke so the phase ordering is verifiable without a
- * live stack.
+ * overrides to stub out the init phase, Supabase CLI, mapClient, seed,
+ * provision, and the self-smoke so the phase ordering is verifiable
+ * without a live stack.
  */
 
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
 
 import { runStageCommand } from "../../src/commands/substrate-stage.js";
+import { runInit } from "../../src/commands/init.js";
 
 function buildDeps({ failPhase = null, invocations }) {
   function recorded(name, fn = async () => undefined) {
@@ -32,12 +36,14 @@ function buildDeps({ failPhase = null, invocations }) {
     ),
   };
   return {
+    loadInit: async () => recorded("init"),
     createSupabaseCli: () => cliStub,
     createMapClient: () => ({ stub: true }),
     findDataDir: async () => "/tmp/data/pathway",
     loadSeed: async () => recorded("seed"),
     loadProvision: async () => recorded("provision"),
     loadSmoke: async () => recorded("smoke"),
+    reloadConfig: async () => ({ supabaseJwtSecret: () => "secret" }),
   };
 }
 
@@ -69,11 +75,12 @@ describe("substrate-stage phase ordering", () => {
     process.stdout.write = stdoutWrite;
   });
 
-  test("invokes phases in stack → url-discovery → migrate → seed → provision → smoke order", async () => {
+  test("invokes phases in init → stack → url-discovery → migrate → seed → provision → smoke order", async () => {
     const deps = buildDeps({ invocations });
     const config = { supabaseJwtSecret: () => "secret" };
     await runStageCommand({ config }, deps);
     assert.deepEqual(invocations, [
+      "init",
       "stack",
       "url-discovery",
       "migrate",
@@ -92,6 +99,7 @@ describe("substrate-stage phase ordering", () => {
       /\[substrate stage: smoke\] empty corpus/,
     );
     assert.deepEqual(invocations, [
+      "init",
       "stack",
       "url-discovery",
       "migrate",
@@ -108,4 +116,112 @@ describe("substrate-stage phase ordering", () => {
       /\[substrate stage: seed\] stubbed seed failure/,
     );
   });
+
+  test("explicit target is plumbed to the init phase", async () => {
+    let initTarget;
+    const deps = buildDeps({ invocations });
+    deps.loadInit = async () => async (t) => {
+      invocations.push("init");
+      initTarget = t;
+    };
+    const config = { supabaseJwtSecret: () => "secret" };
+    const tmpDir = await fs.mkdtemp(path.join(tmpdir(), "substrate-target-"));
+    try {
+      await runStageCommand({ config, target: tmpDir }, deps);
+      assert.equal(initTarget, tmpDir);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
+
+describe("substrate-stage / fit-map init bootstrap-shape parity", () => {
+  let tmpA;
+  let tmpB;
+  let prevStdout;
+  let prevStderr;
+
+  beforeEach(async () => {
+    tmpA = await fs.mkdtemp(path.join(tmpdir(), "substrate-parity-a-"));
+    tmpB = await fs.mkdtemp(path.join(tmpdir(), "substrate-parity-b-"));
+    prevStdout = process.stdout.write.bind(process.stdout);
+    prevStderr = process.stderr.write.bind(process.stderr);
+    process.stdout.write = () => true;
+    process.stderr.write = () => true;
+  });
+
+  afterEach(async () => {
+    process.stdout.write = prevStdout;
+    process.stderr.write = prevStderr;
+    for (const d of [tmpA, tmpB]) {
+      try {
+        await fs.rm(d, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  test("runInit(tmpA) and substrate stage init phase against tmpB produce identical project root trees", async () => {
+    await runInit(tmpA);
+
+    // Run only the init phase of substrate stage against tmpB. Stubbing
+    // every other phase isolates the bootstrap surface — what substrate
+    // stage materialises at the target dir.
+    const invocations = [];
+    function recorded(name, fn = async () => undefined) {
+      return async (...args) => {
+        invocations.push(name);
+        return fn(...args);
+      };
+    }
+    await runStageCommand(
+      {
+        config: { supabaseJwtSecret: () => "secret" },
+        target: tmpB,
+      },
+      {
+        loadInit: async () => runInit,
+        createSupabaseCli: () => ({
+          run: recorded("noop"),
+          capture: recorded("noop", async () =>
+            JSON.stringify({
+              api_url: "http://x",
+              anon_key: "a",
+            }),
+          ),
+        }),
+        createMapClient: () => ({ stub: true }),
+        findDataDir: async () => "/tmp/data/pathway",
+        loadSeed: async () => recorded("noop"),
+        loadProvision: async () => recorded("noop"),
+        loadSmoke: async () => recorded("noop"),
+        reloadConfig: async () => ({ supabaseJwtSecret: () => "secret" }),
+      },
+    );
+
+    const treeA = await listTree(tmpA);
+    const treeB = await listTree(tmpB);
+    assert.deepEqual(treeA, treeB);
+  });
+});
+
+async function listTree(root) {
+  const out = [];
+  async function walk(dir, rel) {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      const r = rel ? `${rel}/${e.name}` : e.name;
+      if (e.isDirectory()) {
+        out.push(r + "/");
+        await walk(full, r);
+      } else {
+        out.push(r);
+      }
+    }
+  }
+  await walk(root, "");
+  out.sort();
+  return out;
+}

--- a/products/map/test/init.test.js
+++ b/products/map/test/init.test.js
@@ -79,16 +79,20 @@ describe("fit-map init", () => {
     await runInit(inner);
 
     process.chdir(sub);
-    await createProductConfig("map");
-    const localConfig = JSON.parse(
-      await fs.readFile(path.join(inner, "config", "config.json"), "utf8"),
-    );
-    // The local config materialised by runInit has no `marker` field.
-    assert.equal(localConfig.marker, undefined);
+    const config = await createProductConfig("map");
+    // Assert against libconfig's resolved anchor: the rootDir Config
+    // exposes is the parent of the resolved `config/` directory. After
+    // runInit(inner), the upward walk from `sub` must land on
+    // `inner/config/`, so rootDir resolves to `inner`. realpath both
+    // sides to normalise on platforms that symlink tmpdir.
+    assert.equal(await fs.realpath(config.rootDir), await fs.realpath(inner));
   });
 
   test("anchoring control: without runInit, createProductConfig resolves the ancestor decoy", async () => {
-    // Without bootstrap, the upward walk lands on the planted decoy.
+    // Without bootstrap, the upward walk from `sub` skips the empty
+    // `inner` and lands on the planted `<baseDir>/config/`. Asserting
+    // on the resolved anchor proves the resolver actually walked
+    // upward — not merely that the decoy file still exists on disk.
     const decoyDir = path.join(baseDir, "config");
     await fs.mkdir(decoyDir, { recursive: true });
     await fs.writeFile(
@@ -100,14 +104,8 @@ describe("fit-map init", () => {
     await fs.mkdir(sub, { recursive: true });
 
     process.chdir(sub);
-    await createProductConfig("map");
-    // The ancestor decoy is what would have been read on this layout.
-    // Re-read it explicitly to assert the path-direction parity (the
-    // decoy still exists; runInit was never called).
-    const ancestor = JSON.parse(
-      await fs.readFile(path.join(decoyDir, "config.json"), "utf8"),
-    );
-    assert.equal(ancestor.marker, "decoy");
+    const config = await createProductConfig("map");
+    assert.equal(await fs.realpath(config.rootDir), await fs.realpath(baseDir));
     // And no local config was planted at <inner>/config/.
     await assert.rejects(() => fs.stat(path.join(inner, "config")), {
       code: "ENOENT",

--- a/products/map/test/init.test.js
+++ b/products/map/test/init.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for `fit-map init` — covers the bootstrap writer adoption + the
+ * idempotency requirement that lets `substrate stage` re-stage a
+ * workspace produced by direct `fit-map init` invocation.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { runInit } from "../src/commands/init.js";
+import { createProductConfig } from "@forwardimpact/libconfig";
+
+let baseDir;
+let prevCwd;
+let prevStdout;
+let prevStderr;
+
+beforeEach(async () => {
+  baseDir = await fs.mkdtemp(path.join(tmpdir(), "fit-map-init-"));
+  prevCwd = process.cwd();
+  prevStdout = process.stdout.write.bind(process.stdout);
+  prevStderr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = () => true;
+  process.stderr.write = () => true;
+});
+
+afterEach(async () => {
+  process.chdir(prevCwd);
+  process.stdout.write = prevStdout;
+  process.stderr.write = prevStderr;
+  try {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe("fit-map init", () => {
+  test("fresh tmpdir → produces data/pathway/ (non-empty) and config/config.json = {}", async () => {
+    await runInit(baseDir);
+    const pathwayEntries = await fs.readdir(
+      path.join(baseDir, "data", "pathway"),
+    );
+    assert.ok(pathwayEntries.length > 0, "data/pathway/ should be non-empty");
+    const config = JSON.parse(
+      await fs.readFile(path.join(baseDir, "config", "config.json"), "utf8"),
+    );
+    assert.deepEqual(config, {});
+  });
+
+  test("re-run against same dir is byte-stable (no `./data/pathway/ already exists` error)", async () => {
+    await runInit(baseDir);
+    const configBefore = await fs.readFile(
+      path.join(baseDir, "config", "config.json"),
+    );
+    await runInit(baseDir);
+    const configAfter = await fs.readFile(
+      path.join(baseDir, "config", "config.json"),
+    );
+    assert.equal(configBefore.equals(configAfter), true);
+  });
+
+  test("anchoring: after runInit at <outer>/inner, createProductConfig from <outer>/inner/sub resolves the local config/", async () => {
+    // Plant a decoy ancestor config so a broken anchor would land on it.
+    const decoyDir = path.join(baseDir, "config");
+    await fs.mkdir(decoyDir, { recursive: true });
+    await fs.writeFile(
+      path.join(decoyDir, "config.json"),
+      JSON.stringify({ marker: "decoy" }) + "\n",
+    );
+
+    const inner = path.join(baseDir, "inner");
+    const sub = path.join(inner, "sub");
+    await fs.mkdir(sub, { recursive: true });
+
+    await runInit(inner);
+
+    process.chdir(sub);
+    await createProductConfig("map");
+    const localConfig = JSON.parse(
+      await fs.readFile(path.join(inner, "config", "config.json"), "utf8"),
+    );
+    // The local config materialised by runInit has no `marker` field.
+    assert.equal(localConfig.marker, undefined);
+  });
+
+  test("anchoring control: without runInit, createProductConfig resolves the ancestor decoy", async () => {
+    // Without bootstrap, the upward walk lands on the planted decoy.
+    const decoyDir = path.join(baseDir, "config");
+    await fs.mkdir(decoyDir, { recursive: true });
+    await fs.writeFile(
+      path.join(decoyDir, "config.json"),
+      JSON.stringify({ marker: "decoy" }) + "\n",
+    );
+    const inner = path.join(baseDir, "inner");
+    const sub = path.join(inner, "sub");
+    await fs.mkdir(sub, { recursive: true });
+
+    process.chdir(sub);
+    await createProductConfig("map");
+    // The ancestor decoy is what would have been read on this layout.
+    // Re-read it explicitly to assert the path-direction parity (the
+    // decoy still exists; runInit was never called).
+    const ancestor = JSON.parse(
+      await fs.readFile(path.join(decoyDir, "config.json"), "utf8"),
+    );
+    assert.equal(ancestor.marker, "decoy");
+    // And no local config was planted at <inner>/config/.
+    await assert.rejects(() => fs.stat(path.join(inner, "config")), {
+      code: "ENOENT",
+    });
+  });
+});

--- a/websites/fit/docs/getting-started/leaders/map/index.md
+++ b/websites/fit/docs/getting-started/leaders/map/index.md
@@ -38,9 +38,12 @@ npx fit-map init
 ```
 
 This creates `./data/pathway/` with starter definitions for levels, disciplines,
-capabilities, skills, behaviours, stages, drivers, and tracks. The starter data
-is a working agent-aligned engineering standard you can customize to match your
-organization.
+capabilities, skills, behaviours, stages, drivers, and tracks, plus a
+`./config/config.json` so subsequent `fit-map` commands anchor their
+configuration at the project root. The starter data is a working
+agent-aligned engineering standard you can customize to match your
+organization. Re-running `npx fit-map init` against an existing project is
+a no-op — already-copied files are preserved.
 
 ## Agent-Aligned Engineering Standard: validate
 


### PR DESCRIPTION
## Summary

Implements [spec 1000](specs/1000-product-init-config-parity/spec.md) per [design-c](specs/1000-product-init-config-parity/design-c.md) and [plan-a](specs/1000-product-init-config-parity/plan-a.md).

- **libconfig** gains `bootstrapProject({ target, fragment, env, overwrites })` — a single callable writer that materialises `config/config.json` and `.env` under namespace-scoped ownership semantics. Two products with disjoint top-level (or disjoint sub-keys under a shared top-level) merge cleanly; same-key-different-value refuses with a leaf-path diagnostic naming both the conflicting key and the `overwrites.config` / `overwrites.env` surface.
- **fit-guide init** routes through `bootstrapProject`; secrets are materialised via `getOrGenerateSecret` before the call so re-runs are byte-stable no-ops (no more `SERVICE_SECRET` / `MCP_TOKEN` rotation).
- **fit-map init** writes `config/config.json` so subsequent invocations anchor locally rather than upward-walking; `data/pathway/` copy is now idempotent.
- **fit-map substrate stage** runs `runInit` as its new first phase and re-reads libconfig anchored at `target`; the kata-interview workflow now invokes `substrate stage --cwd "$AGENT_CWD"` and the `mkdir -p config/` workaround from spec 990 is removed.

Skill + doc updates land in the same PR: the `fit-map init` description in skill/getting-started docs names the new config/ creation and idempotency; the `fit-guide` skill files migrate `init` → `--init` (technical-writer's W19 memo's pre-existing tech debt cleared while in scope) and drop the "once" framing.

## Test plan

- [x] `bun run check` clean
- [x] 119/119 tests pass across `libraries/libconfig/test/`, `products/guide/test/`, `products/map/test/init.test.js`, `products/map/test/activity/substrate-stage.test.js`
- [x] Manual 31-scenario smoke run against `/tmp/spec-1000-manual/` covering: pure-library merge classifier (disjoint top-level + shared-top-level disjoint sub-keys + array handling + refusal), idempotency, .env 0o600 enforcement against pre-existing 0o644 files, real `fit-guide --init` + `fit-map init` CLIs, anchoring success criterion (with control direction), substrate-stage delegation to `runInit` with `--cwd` plumbing, two-product convergence in both orders, refuse-before-mutate across both surfaces, subprocess stderr greppability.
- [x] R1 cold panel (5 staff-engineer reviewers): 1 verified BLOCKER (merge classifier silently dropped fragments under shared-top-level disjoint sub-keys) + 1 consensus HIGH (map anchoring test discarded resolver's return) + 2 consensus MEDIUM (substrate-stage `reloadConfig` anchor mismatch; README/test using dotted-literal keys instead of nested production shape) — all fixed in `4d799979`.
- [x] R2 cold panel (5 fresh staff-engineer reviewers): 0 blockers, 0 highs, 0 consensus mediums — all R1 fixes verified; remaining singletons are test-surface gaps and doc nits.
- [ ] kata-interview Landmark CI run on this branch verifies end-to-end (substrate stage subprocess actually anchors at `$AGENT_CWD`; agent-workspace artefact carries `config/` from `runInit`; identity + self-smoke green) — release-engineer's gating surface per `kata-release-merge`.

— Staff Engineer 🛠️

---
_Generated by [Claude Code](https://claude.ai/code/session_0168smgrnKaq5J8jtBGtWfHW)_