### PR TITLE
agent-react: ad-hoc prompt input for manual dispatch

### DIFF
--- a/.claude/skills/kata-setup/references/workflow-react.md
+++ b/.claude/skills/kata-setup/references/workflow-react.md
@@ -22,14 +22,8 @@ on:
     types: [created]
   workflow_dispatch:
     inputs:
-      target-type:
-        description: "Target type (pull_request or discussion)"
-        required: true
-        type: choice
-        default: pull_request
-        options: [pull_request, discussion]
-      target-number:
-        description: "PR or discussion number"
+      prompt:
+        description: "Ad-hoc prompt for the facilitator"
         required: true
         type: string
 permissions:
@@ -61,8 +55,7 @@ jobs:
         id: task
         env:
           EVENT: ${{ github.event_name }}
-          DT: ${{ inputs.target-type }}
-          DN: ${{ inputs.target-number }}
+          DP: ${{ inputs.prompt }}
           PN: ${{ github.event.issue.number || github.event.pull_request.number }}
           IT: ${{ github.event.issue.title }}
           DNUM: ${{ github.event.discussion.number }}
@@ -79,11 +72,12 @@ jobs:
             issues) t="issue"; ctx="New issue \"$IT\" (#$n) by @$AU. $URL"; act="assess the issue." ;;
             discussion) t="discussion"; n="$DNUM"; ctx="New discussion \"$DTIT\" (#$n, $DCAT) by @$AU. $URL Node: $DNID."; act="assess. Reply via gh api graphql (addDiscussionComment)." ;;
             discussion_comment) t="discussion"; n="$DNUM"; ctx="Comment on \"$DTIT\" (#$n) by @$AU. $URL Node: $DNID."; act="assess. Reply via gh api graphql (addDiscussionComment, pass replyToId)." ;;
-            workflow_dispatch) if [ "$DT" = "discussion" ]; then t="discussion"; n="$DN"; ctx="Dispatch: discussion #$n."; act="assess."; else t="pull_request"; n="$DN"; ctx="Dispatch: PR #$n."; act="assess."; fi ;;
+            workflow_dispatch) t=""; n="" ;;
             issue_comment) if [ "$IPR" = "true" ]; then ctx="Comment on PR #$n by @$AU. $URL"; act="assess."; else t="issue"; ctx="Comment on \"$IT\" (#$n) by @$AU. $URL"; act="assess."; fi ;;
             *) ctx="Comment on PR #$n by @$AU. $URL"; act="assess." ;;
           esac
-          task="$ctx As facilitator, route to the best-suited agent to $act
+          if [ "$EVENT" = "workflow_dispatch" ]; then prefix="$DP"; else prefix="$ctx As facilitator, route to the best-suited agent to $act"; fi
+          task="$prefix
           Recursion guard: if the latest activity is already an agent response, stop."
           { echo "target-type=$t"; echo "target-number=$n"; echo "task<<EOF"; echo "$task"; echo "EOF"; } >> "$GITHUB_OUTPUT"
       - name: Assess and Act

--- a/.github/workflows/agent-react.yml
+++ b/.github/workflows/agent-react.yml
@@ -17,16 +17,8 @@ on:
     types: [created]
   workflow_dispatch:
     inputs:
-      target-type:
-        description: "Target type (pull_request or discussion)"
-        required: true
-        type: choice
-        default: pull_request
-        options:
-          - pull_request
-          - discussion
-      target-number:
-        description: "PR or discussion number to act on (manual trigger for verification)"
+      prompt:
+        description: "Ad-hoc prompt for the facilitator"
         required: true
         type: string
 
@@ -37,7 +29,7 @@ permissions:
 # Triage flows fire `opened` plus several `labeled` events within ~1s; without this, each one
 # spawns an independent facilitator → independent agent → independent PR (observed on #647 / #654).
 concurrency:
-  group: agent-react-${{ github.event.issue.number || github.event.pull_request.number || github.event.discussion.number || inputs.target-number || github.run_id }}
+  group: agent-react-${{ github.event.issue.number || github.event.pull_request.number || github.event.discussion.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -79,8 +71,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
-          DISPATCH_TARGET_TYPE: ${{ inputs.target-type }}
-          DISPATCH_TARGET_NUMBER: ${{ inputs.target-number }}
+          DISPATCH_PROMPT: ${{ inputs.prompt }}
           PR_NUMBER_FROM_EVENT: ${{ github.event.issue.number || github.event.pull_request.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -130,17 +121,8 @@ jobs:
               action="route to the best-suited agent and ask them to assess the comment and act on it. To reply, use \`gh api graphql\` (mutation \`addDiscussionComment\` with the discussion node ID; pass \`replyToId\` to thread the reply)."
               ;;
             workflow_dispatch)
-              if [ "$DISPATCH_TARGET_TYPE" = "discussion" ]; then
-                target_type="discussion"
-                target_number="$DISPATCH_TARGET_NUMBER"
-                context="Manual dispatch targeting discussion #$target_number (event: $EVENT_NAME)."
-                action="route to the best-suited agent and ask them to assess the discussion and act on it. To reply, use \`gh api graphql\` (mutation \`addDiscussionComment\`)."
-              else
-                target_type="pull_request"
-                target_number="$DISPATCH_TARGET_NUMBER"
-                context="Manual dispatch targeting PR #$target_number (event: $EVENT_NAME)."
-                action="route to the best-suited agent and ask them to assess the PR and act on it."
-              fi
+              target_type=""
+              target_number=""
               ;;
             issue_comment)
               if [ "$IS_PR" = "true" ]; then
@@ -158,7 +140,13 @@ jobs:
               ;;
           esac
 
-          task="$context As facilitator, $action
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            task_prefix="$DISPATCH_PROMPT"
+          else
+            task_prefix="$context As facilitator, $action"
+          fi
+
+          task="$task_prefix
 
           Ensure follow-through: when the agent answers, verify they acted on what was within their scope. If they acknowledged but deferred actionable work, send them back to complete it before you conclude.
 


### PR DESCRIPTION
Manual dispatch no longer requires a PR or discussion to react to. Replace
the target-type/target-number inputs with a single `prompt` input so the
workflow can be invoked on an ad-hoc question or instruction.

The compose-task step now uses the prompt directly as the task prefix when
the event is workflow_dispatch, leaving the context+action wrapping in
place for all real GitHub events. Mirror the change in the kata-setup
workflow-react.md template so new installations match.