### PR TITLE
fix(ci): forward token as GH_TOKEN so fit-wiki pull authenticates

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -65,6 +65,8 @@ runs:
 
     - name: Bootstrap
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
       run: ./scripts/bootstrap.sh
 
     - name: Push wiki changes


### PR DESCRIPTION
Without GH_TOKEN in the env, scripts/bootstrap.sh's `bunx fit-wiki pull`
call fails inside libconfig's #resolveGhCli: env has no GH_TOKEN or
GITHUB_TOKEN, and `gh auth token` is not logged in on the runner. The
bootstrap.sh `||` fallback hides the exit code but the stack trace and
"Error: GH_TOKEN not found in environment..." still land in the logs
every run, and the wiki never actually pulls.

The bootstrap composite action already receives the GitHub App token via
inputs.token (used for actions/checkout against the wiki repo). Pass it
through as GH_TOKEN on the Bootstrap step so libwiki's resolver finds it.

When inputs.token is the default empty string, libconfig's credential
resolver treats GH_TOKEN="" as unset (#resolveOverride excludes empty
credential values), so callers that don't pass a token are unaffected.