### PR TITLE
feat(libeval): block sub-agent spawn tools on facilitator

### DIFF
--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -472,9 +472,8 @@ export function createFacilitator({
   });
 
   // Block the SDK's sub-agent spawn tools on the facilitator: its job is to
-  // coordinate participants through the libeval orchestration harness
-  // (Ask / Answer / Announce / Redirect / RollCall / Conclude), not to fan
-  // work out to ad-hoc Claude Code sub-agents. Mirrors the supervisor.
+  // coordinate participants through the libeval orchestration harness, not
+  // to fan work out to ad-hoc Claude Code sub-agents. Mirrors the supervisor.
   const defaultDisallowed = ["Agent", "Task", "TaskOutput", "TaskStop"];
   const disallowedTools = facilitatorDisallowedTools
     ? [...new Set([...defaultDisallowed, ...facilitatorDisallowedTools])]

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -394,6 +394,8 @@ const devNull = new Writable({
  * @param {string} [deps.agentModel] - Agent model override (falls back to `model`).
  * @param {string} [deps.facilitatorModel] - Facilitator model override (falls back to `model`).
  * @param {number} [deps.maxTurns]
+ * @param {string[]} [deps.facilitatorAllowedTools] - Tools the facilitator may use; defaults to a read/write file-edit set.
+ * @param {string[]} [deps.facilitatorDisallowedTools] - Additional tools to block on the facilitator; merged with the sub-agent spawn defaults (Agent/Task/TaskOutput/TaskStop).
  * @param {string} [deps.facilitatorProfile] - Facilitator profile name; resolved into the main-thread system prompt via `composeProfilePrompt`.
  * @param {string} [deps.profilesDir] - Directory containing `<name>.md` profile files. Defaults to `<facilitatorCwd>/.claude/agents`. Resolved once from the facilitator's cwd so profiles travel with the project, not with per-agent sandboxes.
  * @param {string} [deps.taskAmend] - Opaque addendum appended to the task before delivery.
@@ -408,6 +410,8 @@ export function createFacilitator({
   agentModel,
   facilitatorModel,
   maxTurns,
+  facilitatorAllowedTools,
+  facilitatorDisallowedTools,
   facilitatorProfile,
   profilesDir,
   taskAmend,
@@ -467,12 +471,30 @@ export function createFacilitator({
     return { name: config.name, role: config.role, runner };
   });
 
+  // Block the SDK's sub-agent spawn tools on the facilitator: its job is to
+  // coordinate participants through the libeval orchestration harness
+  // (Ask / Answer / Announce / Redirect / RollCall / Conclude), not to fan
+  // work out to ad-hoc Claude Code sub-agents. Mirrors the supervisor.
+  const defaultDisallowed = ["Agent", "Task", "TaskOutput", "TaskStop"];
+  const disallowedTools = facilitatorDisallowedTools
+    ? [...new Set([...defaultDisallowed, ...facilitatorDisallowedTools])]
+    : defaultDisallowed;
+
   const facilitatorRunner = createAgentRunner({
     cwd: facilitatorCwd,
     query,
     output: devNull,
     model: facilitatorModel ?? model,
     maxTurns: maxTurns ?? 20,
+    allowedTools: facilitatorAllowedTools ?? [
+      "Bash",
+      "Read",
+      "Glob",
+      "Grep",
+      "Write",
+      "Edit",
+    ],
+    disallowedTools,
     onLine: (line) => facilitator.emitLine("facilitator", line),
     mcpServers: { orchestration: facilitatorServer },
     settingSources: ["project"],

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -562,9 +562,8 @@ export function createSupervisor({
   });
 
   // Block the SDK's sub-agent spawn tools on the supervisor: its job is to
-  // coordinate the agent through the libeval orchestration harness (Ask /
-  // Answer / Announce / Redirect / Conclude), not to fan work out to ad-hoc
-  // Claude Code sub-agents. Mirrors the facilitator.
+  // coordinate the agent through the libeval orchestration harness, not to
+  // fan work out to ad-hoc Claude Code sub-agents. Mirrors the facilitator.
   const defaultDisallowed = ["Agent", "Task", "TaskOutput", "TaskStop"];
   const disallowedTools = supervisorDisallowedTools
     ? [...new Set([...defaultDisallowed, ...supervisorDisallowedTools])]

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -561,6 +561,10 @@ export function createSupervisor({
     redactor,
   });
 
+  // Block the SDK's sub-agent spawn tools on the supervisor: its job is to
+  // coordinate the agent through the libeval orchestration harness (Ask /
+  // Answer / Announce / Redirect / Conclude), not to fan work out to ad-hoc
+  // Claude Code sub-agents. Mirrors the facilitator.
   const defaultDisallowed = ["Agent", "Task", "TaskOutput", "TaskStop"];
   const disallowedTools = supervisorDisallowedTools
     ? [...new Set([...defaultDisallowed, ...supervisorDisallowedTools])]

--- a/libraries/libeval/test/facilitator-factory.test.js
+++ b/libraries/libeval/test/facilitator-factory.test.js
@@ -1,0 +1,143 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { PassThrough } from "node:stream";
+
+import {
+  Facilitator,
+  createFacilitator,
+  FACILITATOR_SYSTEM_PROMPT,
+  FACILITATED_AGENT_SYSTEM_PROMPT,
+} from "@forwardimpact/libeval";
+import { createNoopRedactor } from "../src/redaction.js";
+
+const baseOpts = () => ({
+  facilitatorCwd: "/tmp/fac",
+  agentConfigs: [
+    { name: "agent-1", role: "worker", cwd: "/tmp/agent-1" },
+    { name: "agent-2", role: "reviewer", cwd: "/tmp/agent-2" },
+  ],
+  query: async function* () {},
+  output: new PassThrough(),
+  redactor: createNoopRedactor(),
+});
+
+const findAgent = (f, name) => f.agents.find((a) => a.name === name);
+
+describe("Facilitator - createFacilitator factory", () => {
+  test("returns a Facilitator instance", () => {
+    assert.ok(createFacilitator(baseOpts()) instanceof Facilitator);
+  });
+
+  test("createFacilitator throws on missing redactor", () => {
+    const { redactor: _omitted, ...withoutRedactor } = baseOpts();
+    assert.throws(
+      () => createFacilitator(withoutRedactor),
+      /redactor is required/,
+    );
+  });
+
+  test("uses default facilitator tools when none specified", () => {
+    const f = createFacilitator(baseOpts());
+    assert.deepStrictEqual(f.facilitatorRunner.allowedTools, [
+      "Bash",
+      "Read",
+      "Glob",
+      "Grep",
+      "Write",
+      "Edit",
+    ]);
+  });
+
+  test("passes custom facilitator tools", () => {
+    const f = createFacilitator({
+      ...baseOpts(),
+      facilitatorAllowedTools: ["Read", "Glob", "Grep"],
+    });
+    assert.deepStrictEqual(f.facilitatorRunner.allowedTools, [
+      "Read",
+      "Glob",
+      "Grep",
+    ]);
+  });
+
+  test("wires system prompts to facilitator and every agent runner", () => {
+    const f = createFacilitator(baseOpts());
+    assert.deepStrictEqual(f.facilitatorRunner.systemPrompt, {
+      type: "preset",
+      preset: "claude_code",
+      append: FACILITATOR_SYSTEM_PROMPT,
+    });
+    for (const agent of f.agents) {
+      assert.deepStrictEqual(agent.runner.systemPrompt, {
+        type: "preset",
+        preset: "claude_code",
+        append: FACILITATED_AGENT_SYSTEM_PROMPT,
+      });
+    }
+  });
+
+  test("blocks sub-agent spawn tools on facilitator by default", () => {
+    const f = createFacilitator(baseOpts());
+    assert.deepStrictEqual(f.facilitatorRunner.disallowedTools, [
+      "Agent",
+      "Task",
+      "TaskOutput",
+      "TaskStop",
+    ]);
+    for (const agent of f.agents) {
+      assert.deepStrictEqual(agent.runner.disallowedTools, []);
+    }
+  });
+
+  test("merges custom facilitatorDisallowedTools with defaults", () => {
+    const f = createFacilitator({
+      ...baseOpts(),
+      facilitatorDisallowedTools: ["WebSearch", "Task"],
+    });
+    const d = f.facilitatorRunner.disallowedTools;
+    assert.ok(d.includes("Agent"));
+    assert.ok(d.includes("Task"));
+    assert.ok(d.includes("TaskOutput"));
+    assert.ok(d.includes("TaskStop"));
+    assert.ok(d.includes("WebSearch"));
+    assert.strictEqual(d.length, new Set(d).size);
+  });
+
+  test("system prompt constants are non-empty strings", () => {
+    assert.ok(typeof FACILITATOR_SYSTEM_PROMPT === "string");
+    assert.ok(typeof FACILITATED_AGENT_SYSTEM_PROMPT === "string");
+    assert.ok(FACILITATOR_SYSTEM_PROMPT.length > 0);
+    assert.ok(FACILITATED_AGENT_SYSTEM_PROMPT.length > 0);
+  });
+
+  test("wires MCP servers to facilitator and every agent runner", () => {
+    const f = createFacilitator(baseOpts());
+    assert.ok(f.facilitatorRunner.mcpServers);
+    assert.strictEqual(
+      f.facilitatorRunner.mcpServers.orchestration.type,
+      "sdk",
+    );
+    for (const agent of f.agents) {
+      assert.ok(agent.runner.mcpServers);
+      assert.strictEqual(agent.runner.mcpServers.orchestration.type, "sdk");
+    }
+  });
+
+  test("per-agent allowedTools and maxTurns propagate", () => {
+    const f = createFacilitator({
+      ...baseOpts(),
+      agentConfigs: [
+        {
+          name: "agent-1",
+          role: "worker",
+          cwd: "/tmp/agent-1",
+          allowedTools: ["Read", "Grep"],
+          maxTurns: 7,
+        },
+      ],
+    });
+    const a = findAgent(f, "agent-1");
+    assert.deepStrictEqual(a.runner.allowedTools, ["Read", "Grep"]);
+    assert.strictEqual(a.runner.maxTurns, 7);
+  });
+});

--- a/libraries/libeval/test/facilitator.test.js
+++ b/libraries/libeval/test/facilitator.test.js
@@ -2,7 +2,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert";
 import { PassThrough } from "node:stream";
 
-import { Facilitator, createFacilitator } from "@forwardimpact/libeval";
+import { Facilitator } from "@forwardimpact/libeval";
 import {
   createOrchestrationContext,
   createConcludeHandler,
@@ -411,22 +411,5 @@ describe("Facilitator - messaging", () => {
     assert.strictEqual(parsed.length, 2);
     assert.strictEqual(parsed[0].name, "facilitator");
     assert.strictEqual(parsed[1].name, "agent-1");
-  });
-});
-
-describe("Facilitator - factory required deps", () => {
-  test("createFacilitator throws on missing redactor", () => {
-    assert.throws(
-      () =>
-        createFacilitator({
-          facilitatorCwd: "/tmp/fac",
-          agentConfigs: [
-            { name: "agent-1", role: "worker", cwd: "/tmp/agent" },
-          ],
-          query: async function* () {},
-          output: new PassThrough(),
-        }),
-      /redactor is required/,
-    );
   });
 });


### PR DESCRIPTION
The facilitator was reaching for the Agent tool to hand off work to
participants, bypassing the libeval orchestration harness
(Ask/Answer/Announce/Redirect/RollCall/Conclude). Block Agent / Task /
TaskOutput / TaskStop on the facilitator runner — mirrors the supervisor
which already did this — and add a facilitatorDisallowedTools knob that
merges with the defaults, parallel to supervisorDisallowedTools.

Adds an inline comment in both src/facilitator.js and src/supervisor.js
explaining why these tools are blocked, and moves the lone factory test
out of facilitator.test.js into a new facilitator-factory.test.js that
parallels supervisor-factory.test.js.