### PR TITLE
fix(libeval,workflows): raise --max-turns + wall-clock, unify supervise/facilitate semantics

### DIFF
--- a/.claude/skills/fit-eval/references/cli.md
+++ b/.claude/skills/fit-eval/references/cli.md
@@ -22,7 +22,7 @@ npx fit-eval <command> [options]
 | `--task-text`   | Inline task text (alternative to `--task-file`)                             |
 | `--task-amend`  | Additional text appended to the task                                        |
 | `--agent-model` | Claude model for agents (default: `claude-opus-4-7[1m]`)                    |
-| `--max-turns`   | Max agentic turns (default: 50 run, 20 supervise/facilitate; 0 = unlimited) |
+| `--max-turns`   | Max agentic turns per runner invocation (default: 50 run, 200 supervise, 20 facilitate; 0 = unlimited) |
 | `--output`      | Write the NDJSON trace to a file                                            |
 
 ## Run-Only Options

--- a/.github/workflows/agent-react.yml
+++ b/.github/workflows/agent-react.yml
@@ -183,3 +183,4 @@ jobs:
           facilitator-profile: "release-engineer"
           agent-profiles: "product-manager,security-engineer,staff-engineer,technical-writer"
           max-turns: "1500"
+          timeout-minutes: "300"

--- a/.github/workflows/agent-react.yml
+++ b/.github/workflows/agent-react.yml
@@ -182,4 +182,4 @@ jobs:
           task-text: ${{ steps.task.outputs.task }}
           facilitator-profile: "release-engineer"
           agent-profiles: "product-manager,security-engineer,staff-engineer,technical-writer"
-          max-turns: "200"
+          max-turns: "1500"

--- a/.github/workflows/agent-team.yml
+++ b/.github/workflows/agent-team.yml
@@ -44,6 +44,7 @@ jobs:
           agent-profile: ${{ matrix.agent.name }}
           case: ${{ matrix.agent.name }}
           max-turns: ${{ matrix.agent.max-turns || '1500' }}
+          timeout-minutes: "300"
           task-text: >-
             Assess the current state of your domain and act on the highest-priority finding.
           task-amend: ${{ inputs.task-amend }}

--- a/.github/workflows/agent-team.yml
+++ b/.github/workflows/agent-team.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         agent:
           - { name: product-manager }
-          - { name: staff-engineer, max-turns: "0" }
+          - { name: staff-engineer }
           - { name: security-engineer }
           - { name: technical-writer }
           - { name: release-engineer }
@@ -43,7 +43,7 @@ jobs:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           agent-profile: ${{ matrix.agent.name }}
           case: ${{ matrix.agent.name }}
-          max-turns: ${{ matrix.agent.max-turns || '200' }}
+          max-turns: ${{ matrix.agent.max-turns || '1500' }}
           task-text: >-
             Assess the current state of your domain and act on the highest-priority finding.
           task-amend: ${{ inputs.task-amend }}

--- a/libraries/libeval/bin/fit-eval.js
+++ b/libraries/libeval/bin/fit-eval.js
@@ -100,7 +100,8 @@ const definition = {
         },
         "max-turns": {
           type: "string",
-          description: "Max agentic turns (default: 20, 0 = unlimited)",
+          description:
+            "Max agentic turns per runner invocation (default: 200, 0 = unlimited)",
         },
         output: {
           type: "string",

--- a/libraries/libeval/src/commands/facilitate.js
+++ b/libraries/libeval/src/commands/facilitate.js
@@ -18,11 +18,13 @@ function parseAgentProfiles(raw, cwd, maxTurns) {
 }
 
 /**
- * Parse and validate facilitate command options.
+ * Parse and validate facilitate command options. Exported for test
+ * coverage of the `--max-turns` → per-agent threading contract; not part
+ * of the package's public API.
  * @param {object} values - Parsed option values
  * @returns {object} Parsed options
  */
-function parseFacilitateOptions(values) {
+export function parseFacilitateOptions(values) {
   const taskFile = values["task-file"];
   const taskText = values["task-text"];
   if (taskFile && taskText)

--- a/libraries/libeval/src/commands/facilitate.js
+++ b/libraries/libeval/src/commands/facilitate.js
@@ -10,10 +10,10 @@ import { createTeeWriter } from "../tee-writer.js";
  * @param {string} cwd - Shared working directory for all agents
  * @returns {Array<{name: string, role: string, cwd: string, agentProfile: string}>}
  */
-function parseAgentProfiles(raw, cwd) {
+function parseAgentProfiles(raw, cwd, maxTurns) {
   return raw.split(",").map((entry) => {
     const name = entry.trim();
-    return { name, role: name, cwd, agentProfile: name };
+    return { name, role: name, cwd, agentProfile: name, maxTurns };
   });
 }
 
@@ -36,9 +36,15 @@ function parseFacilitateOptions(values) {
   const profilesRaw = values["agent-profiles"];
   if (!profilesRaw) throw new Error("--agent-profiles is required");
   const agentCwd = resolve(values["agent-cwd"] ?? ".");
-  const agentConfigs = parseAgentProfiles(profilesRaw, agentCwd);
 
   const maxTurnsRaw = values["max-turns"] ?? "20";
+  const maxTurns = maxTurnsRaw === "0" ? 0 : parseInt(maxTurnsRaw, 10);
+
+  // Thread --max-turns into each participant: without this, every facilitated
+  // agent silently falls back to the 50-turn default in facilitator.js even
+  // when the caller raises the budget. Observed in run 26078312414 where
+  // staff-engineer terminated at 51 turns despite --max-turns=200.
+  const agentConfigs = parseAgentProfiles(profilesRaw, agentCwd, maxTurns);
 
   return {
     taskContent,
@@ -47,7 +53,7 @@ function parseFacilitateOptions(values) {
     facilitatorCwd: resolve(values["facilitator-cwd"] ?? "."),
     agentModel: values["agent-model"] ?? "claude-opus-4-7[1m]",
     facilitatorModel: values["facilitator-model"] ?? "claude-opus-4-7[1m]",
-    maxTurns: maxTurnsRaw === "0" ? 0 : parseInt(maxTurnsRaw, 10),
+    maxTurns,
     outputPath: values.output,
     facilitatorProfile: values["facilitator-profile"] ?? undefined,
   };

--- a/libraries/libeval/src/commands/supervise.js
+++ b/libraries/libeval/src/commands/supervise.js
@@ -35,7 +35,7 @@ function parseSuperviseOptions(values) {
     agentModel: values["agent-model"] ?? "claude-opus-4-7[1m]",
     supervisorModel: values["supervisor-model"] ?? "claude-opus-4-7[1m]",
     maxTurns: (() => {
-      const raw = values["max-turns"] ?? "20";
+      const raw = values["max-turns"] ?? "200";
       return raw === "0" ? 0 : parseInt(raw, 10);
     })(),
     outputPath: values.output,

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -393,7 +393,7 @@ const devNull = new Writable({
  * @param {string} [deps.model] - Default model for all participants.
  * @param {string} [deps.agentModel] - Agent model override (falls back to `model`).
  * @param {string} [deps.facilitatorModel] - Facilitator model override (falls back to `model`).
- * @param {number} [deps.maxTurns]
+ * @param {number} [deps.maxTurns] - Facilitator's own per-invocation turn budget (default 20). Each participating agent's budget is taken from `config.maxTurns` on its entry in `agentConfigs` (default 50 when unset). The CLI command (`commands/facilitate.js`) threads `--max-turns` into both this parameter and every agent config so a single CLI value bounds all participants uniformly.
  * @param {string[]} [deps.facilitatorAllowedTools] - Tools the facilitator may use; defaults to a read/write file-edit set.
  * @param {string[]} [deps.facilitatorDisallowedTools] - Additional tools to block on the facilitator; merged with the sub-agent spawn defaults (Agent/Task/TaskOutput/TaskStop).
  * @param {string} [deps.facilitatorProfile] - Facilitator profile name; resolved into the main-thread system prompt via `composeProfilePrompt`.

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -50,9 +50,16 @@ export const AGENT_SYSTEM_PROMPT =
  * Maximum number of mid-turn interventions allowed within a single agent turn.
  * Bounded so a looping supervisor exhausts its quota fast (observability) but
  * leaves headroom for legitimate "intervene, observe, intervene again" patterns.
- * The outer maxTurns budget still bounds overall runtime.
+ * The outer exchange budget still bounds overall runtime.
  */
 const MAX_INTERVENTIONS_PER_TURN = 5;
+
+/**
+ * Default cap on supervisor↔agent exchanges in a single run. Not exposed via
+ * CLI — `--max-turns` governs the per-runner invocation budget instead. When
+ * a `--max-exchanges` flag is added this becomes the default for that flag.
+ */
+const DEFAULT_MAX_EXCHANGES = 100;
 
 /** Orchestrate a relay loop between a supervisor LLM and an agent LLM with mid-turn review. */
 export class Supervisor {
@@ -485,7 +492,7 @@ const devNull = new Writable({
  * @param {string} [deps.model] - Default model for both runners.
  * @param {string} [deps.agentModel] - Agent model override (falls back to `model`).
  * @param {string} [deps.supervisorModel] - Supervisor model override (falls back to `model`).
- * @param {number} [deps.maxTurns]
+ * @param {number} [deps.maxTurns] - Per-runner invocation budget for both the supervisor and the agent (default 200; 0 = unlimited). Outer supervisor↔agent exchanges are bounded separately by `DEFAULT_MAX_EXCHANGES` (passes through to unlimited when `maxTurns === 0`).
  * @param {string[]} [deps.allowedTools]
  * @param {string[]} [deps.supervisorAllowedTools]
  * @param {string[]} [deps.supervisorDisallowedTools]
@@ -544,8 +551,13 @@ export function createSupervisor({
 
   const onLine = (line) => supervisor.emitLine(line);
 
-  const perInvocationTurns =
-    maxTurns === 0 ? 0 : Math.max(maxTurns ?? 100, 200);
+  // `maxTurns` is the per-runner invocation budget — matches `run` and
+  // `facilitate` semantics. The outer supervisor↔agent exchange loop is
+  // bounded separately by `DEFAULT_MAX_EXCHANGES`; when --max-exchanges is
+  // added it will become a parameter. `maxTurns === 0` propagates through
+  // to mean unlimited on both axes.
+  const perInvocationTurns = maxTurns ?? 200;
+  const exchangeBudget = maxTurns === 0 ? 0 : DEFAULT_MAX_EXCHANGES;
 
   const agentRunner = createAgentRunner({
     cwd: agentCwd,
@@ -595,7 +607,7 @@ export function createSupervisor({
     agentRunner,
     supervisorRunner,
     output,
-    maxTurns,
+    maxTurns: exchangeBudget,
     ctx,
     messageBus,
     taskAmend,

--- a/libraries/libeval/test/facilitate-command.test.js
+++ b/libraries/libeval/test/facilitate-command.test.js
@@ -1,0 +1,42 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+
+import { parseFacilitateOptions } from "../src/commands/facilitate.js";
+
+// These tests lock in the contract that `--max-turns` from the CLI threads
+// into every facilitated agent's config — without it, the participants
+// silently fall back to the 50-turn default in facilitator.js. See run
+// 26078312414, where staff-engineer terminated at numTurns 51 despite the
+// workflow passing --max-turns=200.
+describe("facilitate command - parseFacilitateOptions", () => {
+  const minimal = (extra = {}) => ({
+    "task-text": "do the thing",
+    "agent-profiles": "alice,bob,carol",
+    ...extra,
+  });
+
+  test("--max-turns threads into every agent config", () => {
+    const opts = parseFacilitateOptions(minimal({ "max-turns": "1500" }));
+    assert.strictEqual(opts.maxTurns, 1500);
+    assert.strictEqual(opts.agentConfigs.length, 3);
+    for (const cfg of opts.agentConfigs) {
+      assert.strictEqual(cfg.maxTurns, 1500);
+    }
+  });
+
+  test("--max-turns=0 threads as 0 (unlimited) to every agent", () => {
+    const opts = parseFacilitateOptions(minimal({ "max-turns": "0" }));
+    assert.strictEqual(opts.maxTurns, 0);
+    for (const cfg of opts.agentConfigs) {
+      assert.strictEqual(cfg.maxTurns, 0);
+    }
+  });
+
+  test("omitting --max-turns falls back to the documented CLI default", () => {
+    const opts = parseFacilitateOptions(minimal());
+    assert.strictEqual(opts.maxTurns, 20);
+    for (const cfg of opts.agentConfigs) {
+      assert.strictEqual(cfg.maxTurns, 20);
+    }
+  });
+});

--- a/libraries/libeval/test/supervisor-factory.test.js
+++ b/libraries/libeval/test/supervisor-factory.test.js
@@ -120,4 +120,31 @@ describe("Supervisor - createSupervisor factory", () => {
     assert.strictEqual(s.agentRunner.mcpServers.guide.type, "http");
     assert.strictEqual(s.supervisorRunner.mcpServers.guide, undefined);
   });
+
+  // The factory `maxTurns` parameter is the per-runner invocation budget for
+  // both the supervisor and the agent — matching `run` and `facilitate`
+  // semantics. The outer supervisor↔agent exchange loop is bounded separately
+  // by an internal default (currently 100). `maxTurns === 0` propagates as
+  // unlimited on both axes. These three tests lock that contract — see the
+  // commit that introduced them for the history of the silent 200-floor bug.
+  test("maxTurns sets per-runner budget; exchange loop bounded separately", () => {
+    const s = createSupervisor({ ...baseOpts(), maxTurns: 50 });
+    assert.strictEqual(s.agentRunner.maxTurns, 50);
+    assert.strictEqual(s.supervisorRunner.maxTurns, 50);
+    assert.strictEqual(s.maxTurns, 100); // exchange budget — independent of maxTurns
+  });
+
+  test("maxTurns=0 propagates as unlimited on both axes", () => {
+    const s = createSupervisor({ ...baseOpts(), maxTurns: 0 });
+    assert.strictEqual(s.agentRunner.maxTurns, 0);
+    assert.strictEqual(s.supervisorRunner.maxTurns, 0);
+    assert.strictEqual(s.maxTurns, 0);
+  });
+
+  test("default maxTurns yields 200 per runner and bounded exchanges", () => {
+    const s = createSupervisor(baseOpts());
+    assert.strictEqual(s.agentRunner.maxTurns, 200);
+    assert.strictEqual(s.supervisorRunner.maxTurns, 200);
+    assert.strictEqual(s.maxTurns, 100);
+  });
 });

--- a/websites/fit/docs/libraries/prove-changes/index.md
+++ b/websites/fit/docs/libraries/prove-changes/index.md
@@ -251,12 +251,15 @@ npx fit-eval supervise \
   --supervisor-allowed-tools=Read,Grep,Bash \
   --agent-cwd=/tmp/refactor-sandbox \
   --allowed-tools=Read,Edit,Write,Bash,Grep,Glob \
-  --max-turns=50 \
+  --max-turns=200 \
   --output=trace--demo.raw.ndjson
 ```
 
-Exit code `0` means the judge concluded with `success: true`; exit code `1`
-means it concluded `success: false`, ran out of turns, or errored.
+`--max-turns` is the per-runner invocation budget for both the judge and the
+agent. The supervisor↔agent relay loop is bounded separately by an internal
+cap. `0` removes both caps. Exit code `0` means the judge concluded with
+`success: true`; exit code `1` means it concluded `success: false`, ran out of
+turns, or errored.
 
 For a **facilitated session** (one facilitator, N participants):
 
@@ -267,14 +270,16 @@ npx fit-eval facilitate \
   --facilitator-cwd=. \
   --agent-profiles=security-engineer,release-engineer,technical-writer \
   --agent-cwd=. \
-  --max-turns=20 \
+  --max-turns=200 \
   --output=trace--demo.raw.ndjson
 ```
 
 Participants share `--agent-cwd` by default. If two participants might edit the
 same file, give each its own working directory or restrict tool allowlists so
-only one can write. `--max-turns=20` is the default for `facilitate` -- always
-set a budget so a stuck participant cannot run the session indefinitely.
+only one can write. `--max-turns` is applied uniformly to the facilitator and
+to every participant -- always set a budget so a stuck participant cannot run
+the session indefinitely. The CLI default is `20`; raise it for sessions that
+do real implementation work.
 
 The `--task-file` content is visible to every agent in the session as the
 opening prompt. The facilitator profile steers how the goal is pursued; the

--- a/websites/fit/docs/libraries/prove-changes/run-eval/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-eval/index.md
@@ -73,13 +73,15 @@ npx fit-eval supervise \
   --supervisor-cwd=. \
   --supervisor-allowed-tools=Read,Grep,Bash \
   --agent-cwd=/tmp/refactor-sandbox \
-  --max-turns=20 \
+  --max-turns=200 \
   --output=trace--default.raw.ndjson
 ```
 
 `--agent-cwd` should be a sandbox copy of your repo since the target agent edits
 files there. When omitted, `fit-eval` creates a temporary directory. The judge
 stays in `--supervisor-cwd` to inspect the target's work without writing to it.
+`--max-turns` is the per-runner invocation budget (default `200`); the judge↔
+agent relay loop is bounded separately. `--max-turns=0` removes both caps.
 
 Exit code `0` means the judge concluded with `success: true`. Exit code `1`
 means `success: false`, the turn limit was reached, or an error occurred.
@@ -120,7 +122,7 @@ jobs:
             --supervisor-cwd=. \
             --supervisor-allowed-tools=Read,Grep,Bash \
             --agent-cwd=/tmp/sandbox \
-            --max-turns=20 \
+            --max-turns=200 \
             --output=/tmp/trace/trace--default.raw.ndjson
 
       - name: Split trace
@@ -183,7 +185,8 @@ first failure.
 
 ## Tips
 
-- **`--max-turns=0`** removes the turn cap. Use it for exploratory local runs;
+- **`--max-turns=0`** removes both caps (per-runner invocations and the
+  supervisor↔agent exchange loop). Use it for exploratory local runs;
   always set a real budget in CI.
 - **`--task-amend`** appends extra text to the task without editing the task
   file -- useful for parameterizing the same task across a matrix.


### PR DESCRIPTION
## Summary

Root cause analysis of run [26078312414](https://github.com/forwardimpact/monorepo/actions/runs/26078312414/job/76673894680) where `staff-engineer` died at numTurns 51 with only Part 01 of plan 1060's 5 parts completed. Three coupled fixes:

- **libeval `facilitate` bug** — `commands/facilitate.js` was never threading `--max-turns` into agent configs, so every facilitated agent silently fell back to the 50-turn default in `facilitator.js` regardless of the CLI value. Fixed `parseAgentProfiles` to attach `maxTurns` to each entry.
- **libeval `supervise` semantics** — `--max-turns` was the outer supervisor↔agent *exchange* budget with a silent 200-floor on per-runner turns; now means "per-runner invocation budget" uniformly with `run` and `facilitate`. Outer exchange loop hardcoded to an internal default (100). 200 is now a regular default, not a floor; CLI default raised 20 → 200 to match prior effective behavior.
- **Workflows** — `agent-react.yml` `max-turns: "200"` → `"1500"`, `timeout-minutes: "300"`; `agent-team.yml` matrix default `"200"` → `"1500"`, dropped per-row override on `staff-engineer`, `timeout-minutes: "300"`. Sized for plan 1060 (~470 realistic / ~700 worst-case turns × ~17s/turn from trace) with healthy buffer.

Tests: +6 (482 total pass). Lock in factory semantics in `supervisor-factory.test.js` and CLI threading in a new `facilitate-command.test.js`. Inline JSDoc + external docs (`prove-changes/index.md`, `prove-changes/run-eval/index.md`, `fit-eval/references/cli.md`) updated for the new uniform semantics.

## Test plan

- [x] `bun run check` — passes
- [x] `bun run test` (libeval) — 482 / 482 pass
- [x] Sanity check: `createSupervisor({maxTurns: 50})` → per-runner 50, exchanges 100; `maxTurns=0` → both 0; default → 200/100
- [ ] Post-merge: dispatch `agent-react` with a prompt to resume spec 1060 implementation

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7xaBRezPYUqcRswqFwK3x)_