### PR TITLE
remove fit-wiki audit Stop-hook auto-install

### DIFF
--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -24,8 +24,7 @@ cross-team memos, storyboard chart maintenance, audit, and git lifecycle.
 - **Cross-team memo** — `memo --to <agent> --message "..."`.
 - **Storyboard refresh** — `refresh` regenerates XmR and
   obstacle/experiment marker blocks.
-- **Bootstrap** — `init` clones the wiki, scaffolds Active Claims, installs
-  the audit Stop-hook.
+- **Bootstrap** — `init` clones the wiki and scaffolds Active Claims.
 - **Audit** — `audit` runs the gate; replaces `scripts/wiki-audit.sh`.
 - **Git lifecycle** — `push` / `pull`.
 
@@ -113,9 +112,9 @@ npx fit-wiki refresh [storyboard-path]
 
 ### `init` — Bootstrap a wiki tree
 
-Clones the wiki, scaffolds `MEMORY.md ## Active Claims`, installs the audit
-Stop-hook in `.claude/settings.json`, and creates `wiki/metrics/<skill>/`.
-Idempotent. Set `FIT_WIKI_URL` to override default URL derivation.
+Clones the wiki, scaffolds `MEMORY.md ## Active Claims`, and creates
+`wiki/metrics/<skill>/`. Idempotent. Set `FIT_WIKI_URL` to override default
+URL derivation.
 
 ```sh
 npx fit-wiki init
@@ -123,8 +122,7 @@ npx fit-wiki init
 
 ### `push` / `pull` — Git lifecycle
 
-Designed for Claude Code hooks (`SessionStart` → `pull`; `Stop` → `push` and
-`audit`).
+Designed for Claude Code hooks (`SessionStart` → `pull`; `Stop` → `push`).
 
 ```sh
 npx fit-wiki push

--- a/libraries/libwiki/bin/fit-wiki.js
+++ b/libraries/libwiki/bin/fit-wiki.js
@@ -192,8 +192,7 @@ const definition = {
     },
     {
       name: "init",
-      description:
-        "Bootstrap a wiki working tree, scaffold Active Claims, install audit Stop-hook",
+      description: "Bootstrap a wiki working tree and scaffold Active Claims",
       options: {
         ...wikiRootOpt,
         "skills-dir": {

--- a/libraries/libwiki/src/commands/init.js
+++ b/libraries/libwiki/src/commands/init.js
@@ -55,66 +55,6 @@ function scaffoldActiveClaims(memoryPath) {
   return true;
 }
 
-const AUDIT_HOOK_COMMAND = "bunx fit-wiki audit";
-
-function readSettings(settingsPath) {
-  if (!existsSync(settingsPath)) return {};
-  try {
-    return JSON.parse(readFileSync(settingsPath, "utf-8"));
-  } catch {
-    process.stderr.write(
-      `init: ${settingsPath} is not valid JSON; skipping stop-hook install\n`,
-    );
-    return null;
-  }
-}
-
-function hasAuditHook(settings) {
-  if (!settings.hooks || !Array.isArray(settings.hooks.Stop)) return false;
-  for (const group of settings.hooks.Stop) {
-    if (!group || !Array.isArray(group.hooks)) continue;
-    if (
-      group.hooks.some(
-        (h) =>
-          h &&
-          typeof h.command === "string" &&
-          h.command.includes("fit-wiki audit"),
-      )
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function addAuditHook(settings) {
-  if (!settings.hooks) settings.hooks = {};
-  if (!Array.isArray(settings.hooks.Stop)) settings.hooks.Stop = [];
-  if (settings.hooks.Stop.length === 0) {
-    settings.hooks.Stop.push({
-      hooks: [{ type: "command", command: AUDIT_HOOK_COMMAND }],
-    });
-    return;
-  }
-  if (!Array.isArray(settings.hooks.Stop[0].hooks)) {
-    settings.hooks.Stop[0].hooks = [];
-  }
-  settings.hooks.Stop[0].hooks.push({
-    type: "command",
-    command: AUDIT_HOOK_COMMAND,
-  });
-}
-
-function installStopHook(settingsPath) {
-  const settings = readSettings(settingsPath);
-  if (settings === null) return false;
-  if (hasAuditHook(settings)) return false;
-  addAuditHook(settings);
-  mkdirSync(path.dirname(settingsPath), { recursive: true });
-  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
-  return true;
-}
-
 async function maybeCloneWiki(projectRoot, wikiDir) {
   const wikiUrl = deriveWikiUrl(projectRoot);
   if (!wikiUrl) {
@@ -139,7 +79,7 @@ async function maybeCloneWiki(projectRoot, wikiDir) {
   }
 }
 
-/** Clone the wiki if not already present, scaffold Active Claims in MEMORY.md, install the audit Stop-hook, and create per-skill metric directories. */
+/** Clone the wiki if not already present, scaffold Active Claims in MEMORY.md, and create per-skill metric directories. */
 export async function runInitCommand(values, _args, _cli) {
   const logger = { debug() {} };
   const finder = new Finder(fsAsync, logger, process);
@@ -150,7 +90,6 @@ export async function runInitCommand(values, _args, _cli) {
     projectRoot,
     values["skills-dir"] ?? path.join(".claude", "skills"),
   );
-  const settingsPath = path.resolve(projectRoot, ".claude", "settings.json");
 
   await maybeCloneWiki(projectRoot, wikiDir);
 
@@ -167,12 +106,6 @@ export async function runInitCommand(values, _args, _cli) {
         `init: scaffolded ${ACTIVE_CLAIMS_HEADING} in ${memoryPath}\n`,
       );
     }
-  }
-
-  if (installStopHook(settingsPath)) {
-    process.stdout.write(
-      `init: installed Stop-hook audit entry in ${settingsPath}\n`,
-    );
   }
 
   process.stdout.write(`init: wiki ready at ${wikiDir}\n`);

--- a/libraries/libwiki/test/cli-init.test.js
+++ b/libraries/libwiki/test/cli-init.test.js
@@ -155,16 +155,14 @@ describe("deriveWikiUrl", () => {
   });
 });
 
-describe("init Active Claims + Stop-hook install", () => {
+describe("init Active Claims scaffolding", () => {
   let dir;
   let wikiRoot;
-  let settingsPath;
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "init-active-"));
     wikiRoot = join(dir, "wiki");
     mkdirSync(wikiRoot, { recursive: true });
     writeFileSync(join(dir, "package.json"), '{"name":"root"}');
-    settingsPath = join(dir, ".claude", "settings.json");
   });
 
   function runInit(env = {}) {
@@ -173,7 +171,7 @@ describe("init Active Claims + Stop-hook install", () => {
       encoding: "utf-8",
       // GH_TOKEN: ensure config.ghToken() resolves without invoking `gh auth`
       // — clone of /nonexistent/repo.git fails by design, and init falls
-      // through to the local-only Active Claims / Stop-hook scaffolding.
+      // through to the local-only Active Claims scaffolding.
       env: {
         ...process.env,
         ...env,
@@ -208,62 +206,5 @@ describe("init Active Claims + Stop-hook install", () => {
     const text = readFileSync(join(wikiRoot, "MEMORY.md"), "utf-8");
     const matches = text.match(/## Active Claims/g) || [];
     assert.equal(matches.length, 1);
-  });
-
-  test("creates settings.json with Stop hook when absent", () => {
-    writeFileSync(
-      join(wikiRoot, "MEMORY.md"),
-      "## Cross-Cutting Priorities\n\n| Item | Agents | Owner | Status | Added |\n| --- | --- | --- | --- | --- |\n| *None* | — | — | — | — |\n",
-    );
-    runInit();
-    assert.equal(existsSync(settingsPath), true);
-    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
-    const hooks = settings.hooks.Stop[0].hooks;
-    assert.ok(hooks.some((h) => h.command.includes("fit-wiki audit")));
-  });
-
-  test("appends audit hook alongside existing entries (preserved)", () => {
-    mkdirSync(join(dir, ".claude"), { recursive: true });
-    writeFileSync(
-      settingsPath,
-      JSON.stringify(
-        {
-          hooks: {
-            Stop: [{ hooks: [{ type: "command", command: "just wiki-push" }] }],
-          },
-        },
-        null,
-        2,
-      ),
-    );
-    writeFileSync(
-      join(wikiRoot, "MEMORY.md"),
-      "## Cross-Cutting Priorities\n\n| Item | Agents | Owner | Status | Added |\n| --- | --- | --- | --- | --- |\n| *None* | — | — | — | — |\n",
-    );
-    runInit();
-    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
-    const hooks = settings.hooks.Stop[0].hooks;
-    assert.ok(
-      hooks.some((h) => h.command === "just wiki-push"),
-      "existing hook preserved",
-    );
-    assert.ok(
-      hooks.some((h) => h.command.includes("fit-wiki audit")),
-      "audit hook added",
-    );
-  });
-
-  test("idempotent — second init does not re-add audit hook", () => {
-    writeFileSync(
-      join(wikiRoot, "MEMORY.md"),
-      "## Cross-Cutting Priorities\n\n| Item | Agents | Owner | Status | Added |\n| --- | --- | --- | --- | --- |\n| *None* | — | — | — | — |\n",
-    );
-    runInit();
-    runInit();
-    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
-    const auditEntries = settings.hooks.Stop[0].hooks.filter((h) =>
-      h.command.includes("fit-wiki audit"),
-    );
-    assert.equal(auditEntries.length, 1);
   });
 });


### PR DESCRIPTION
The hook ran `bunx fit-wiki audit` on every Stop event and was getting
re-installed by `fit-wiki init` on every bootstrap, making it annoying
to keep removed from .claude/settings.json. Drop the install logic from
init, the related tests, and stale references in the SKILL and CLI
descriptions. The `audit` command itself is unchanged — agents can still
invoke it manually.