### PR TITLE
fix(libwiki): log note appends under open decision

### DIFF
--- a/libraries/libwiki/src/commands/log.js
+++ b/libraries/libwiki/src/commands/log.js
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from "node:fs";
 import fsAsync from "node:fs/promises";
 import path from "node:path";
 import { Finder } from "@forwardimpact/libutil";
@@ -28,10 +29,14 @@ function commonContext(values) {
   return { agent, wikiRoot, today };
 }
 
-function ensureDateHeading(body, today) {
-  const heading = `## ${today}`;
-  if (body.startsWith(heading) || body.startsWith("## ")) return body;
-  return `${heading}\n\n${body}`;
+function lastDateHeading(text) {
+  // Match `## YYYY-MM-DD` at the start of a line, optionally followed by
+  // suffix text (e.g. `## 2026-05-19 (third activation)`).
+  const re = /^## (\d{4}-\d{2}-\d{2})/gm;
+  let last = null;
+  let match;
+  while ((match = re.exec(text)) !== null) last = match[1];
+  return last;
 }
 
 function runDecision(values) {
@@ -67,13 +72,15 @@ function runNote(values) {
     process.stderr.write("log note requires --field and --body\n");
     process.exit(2);
   }
-  const body = ensureDateHeading(
-    `### ${values.field}\n\n${values.body}\n`,
-    today,
-  );
-  const lineCount = body.split("\n").length;
-  rotateIfOverBudget(wikiRoot, agent, today, lineCount);
+  const fieldBlock = `### ${values.field}\n\n${values.body}\n`;
+  // Conservative line budget: assume we'll prepend a date heading.
+  const withHeading = `## ${today}\n\n${fieldBlock}`;
+  rotateIfOverBudget(wikiRoot, agent, today, withHeading.split("\n").length);
   const target = weeklyLogPath(wikiRoot, agent, today);
+  // Append under the open entry if the file's last `## YYYY-MM-DD` is today;
+  // otherwise open a new entry by prepending a date heading.
+  const existing = existsSync(target) ? readFileSync(target, "utf-8") : "";
+  const body = lastDateHeading(existing) === today ? fieldBlock : withHeading;
   appendEntry(target, body, agent, today);
   process.stdout.write(`logged note to ${target}\n`);
 }

--- a/libraries/libwiki/test/cli-log.test.js
+++ b/libraries/libwiki/test/cli-log.test.js
@@ -66,4 +66,99 @@ describe("fit-wiki log CLI", () => {
       assert.equal(err.status, 2);
     }
   });
+
+  test("log note appends under the open decision's date heading", () => {
+    const args = (sub, extra) => [
+      CLI_PATH,
+      "log",
+      sub,
+      "--agent",
+      "staff-engineer",
+      "--today",
+      "2026-05-19",
+      ...extra,
+    ];
+    execFileSync(
+      "node",
+      args("decision", [
+        "--surveyed",
+        "owned",
+        "--chosen",
+        "x",
+        "--rationale",
+        "y",
+      ]),
+      { cwd: dir, encoding: "utf-8" },
+    );
+    execFileSync(
+      "node",
+      args("note", ["--field", "Actions taken", "--body", "Did stuff"]),
+      { cwd: dir, encoding: "utf-8" },
+    );
+    execFileSync(
+      "node",
+      args("note", ["--field", "Findings", "--body", "All clean"]),
+      { cwd: dir, encoding: "utf-8" },
+    );
+    execFileSync("node", args("done", []), { cwd: dir, encoding: "utf-8" });
+
+    const text = readFileSync(
+      join(wikiRoot, "staff-engineer-2026-W21.md"),
+      "utf-8",
+    );
+    const dateHeadings = text.match(/^## 2026-05-19/gm) || [];
+    assert.equal(
+      dateHeadings.length,
+      1,
+      "note/done must not start a new date heading under the open entry",
+    );
+    assert.match(
+      text,
+      /### Decision[\s\S]*### Actions taken[\s\S]*### Findings[\s\S]*### Closed/,
+    );
+  });
+
+  test("log note for a new day opens its own entry", () => {
+    const base = ["--agent", "staff-engineer", "--wiki-root", wikiRoot];
+    execFileSync(
+      "node",
+      [
+        CLI_PATH,
+        "log",
+        "decision",
+        ...base,
+        "--today",
+        "2026-05-19",
+        "--surveyed",
+        "s",
+        "--chosen",
+        "c",
+        "--rationale",
+        "r",
+      ],
+      { cwd: dir, encoding: "utf-8" },
+    );
+    execFileSync(
+      "node",
+      [
+        CLI_PATH,
+        "log",
+        "note",
+        ...base,
+        "--today",
+        "2026-05-20",
+        "--field",
+        "Followup",
+        "--body",
+        "Next day",
+      ],
+      { cwd: dir, encoding: "utf-8" },
+    );
+    const text = readFileSync(
+      join(wikiRoot, "staff-engineer-2026-W21.md"),
+      "utf-8",
+    );
+    assert.match(text, /^## 2026-05-19/m);
+    assert.match(text, /^## 2026-05-20/m);
+  });
 });


### PR DESCRIPTION
## Summary

- `fit-wiki log note` always prepended a fresh `## YYYY-MM-DD` heading because the prior `ensureDateHeading` helper inspected the *body* (always `### Field…`) instead of the file. As a result the open decision entry was split: every note inserted a duplicate date heading, breaking the documented contract ("decision opens, note appends, done closes") and the established weekly-log shape.
- Read the file's last `## YYYY-MM-DD` heading instead; only prepend a new one when no prior entry exists for today. Cross-date notes still open their own entry.
- Adds regression tests for both paths.

## Test plan

- [x] `bun test test/cli-log.test.js` in `libraries/libwiki` (4/4 pass)
- [x] `bun run check`
- [x] `bun run test` (3360 pass; 17 pre-existing sandbox signing-server failures in `wiki-repo` / `init` / `push-pull` tests, unrelated to this change)
- [x] Manual end-to-end check of all `fit-wiki` commands (boot/init/pull/push/audit/claim/release/inbox/log/memo/refresh/rotate)

---
_Generated by [Claude Code](https://claude.ai/code/session_015LMk12E8FhGq8JvaZZKN2D)_