### PR TITLE
feat(libterrain): clinical domain parts 6-8 + spec 1190 (FHIR microdata HTML)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ design/scripts/bun.lock
 
 # Pitch material
 pitch/
+
+# Synthea JAR (downloaded on demand via `just synthea-install`)
+vendor/synthea/

--- a/justfile
+++ b/justfile
@@ -482,3 +482,36 @@ tei-install:
 # Start TEI embedding service (foreground, Ctrl-C to stop)
 tei-start:
     text-embeddings-router --model-id BAAI/bge-small-en-v1.5 --port 8090 --json-output
+
+# ── Synthea ───────────────────────────────────────────────────────
+
+synthea_version := "3.3.0"
+synthea_jar := "vendor/synthea/synthea-with-dependencies.jar"
+
+# Download the Synthea JAR into vendor/synthea/ if not already present
+synthea-install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -f "{{synthea_jar}}" ]; then
+        echo "synthea: already installed at {{synthea_jar}}"
+        exit 0
+    fi
+    mkdir -p vendor/synthea
+    echo "Downloading Synthea v{{synthea_version}}..."
+    curl -fSL -o "{{synthea_jar}}" \
+        "https://github.com/synthetichealth/synthea/releases/download/v{{synthea_version}}/synthea-with-dependencies.jar"
+    echo "synthea: installed at {{synthea_jar}}"
+
+# Report Synthea install status and Java availability
+synthea-status:
+    #!/usr/bin/env bash
+    if [ ! -f "{{synthea_jar}}" ]; then
+        echo "synthea: not installed (run 'just synthea-install')"
+        exit 1
+    fi
+    if ! command -v java &>/dev/null; then
+        echo "synthea: Java not found (install Java 11+)"
+        exit 1
+    fi
+    java_version=$(java -version 2>&1 | head -1)
+    echo "synthea: ok (${java_version})"

--- a/libraries/libsyntheticgen/src/dsl/parser-standard.js
+++ b/libraries/libsyntheticgen/src/dsl/parser-standard.js
@@ -249,6 +249,9 @@ export function createStandardParsers(helpers) {
     modules: (ds) => {
       ds.config.modules = parseArray();
     },
+    conditions: (ds) => {
+      ds.config.conditions = parseArray();
+    },
     metadata: (ds) => {
       ds.config.metadata = parseStringValue();
     },

--- a/libraries/libsyntheticgen/src/engine/clinical-entities.js
+++ b/libraries/libsyntheticgen/src/engine/clinical-entities.js
@@ -97,7 +97,14 @@ export function buildClinicalEntities(
 
   const researchers = Array.from(researcherMap.values());
 
-  return { conditions, sites, trials, criteria, researchers };
+  return {
+    conditions,
+    sites,
+    trials,
+    criteria,
+    researchers,
+    content: clinicalAst.content || null,
+  };
 }
 
 function buildManagerLookup(people) {

--- a/libraries/libsyntheticgen/src/tools/synthea.js
+++ b/libraries/libsyntheticgen/src/tools/synthea.js
@@ -36,9 +36,8 @@ export class SyntheaTool {
     } catch {
       throw new Error(
         `Synthea requires Java and ${this.syntheaJar}. ` +
-          "Install Java (java.com) and download Synthea " +
-          "(github.com/synthetichealth/synthea/releases). " +
-          "Set SYNTHEA_JAR to the jar path.",
+          "Run 'just synthea-install' to download the JAR, " +
+          "or set SYNTHEA_JAR to a custom path.",
       );
     }
   }
@@ -100,6 +99,8 @@ export class SyntheaTool {
       }
     }
 
+    filterByConditions(byType, config.conditions);
+
     // Return one dataset per resource type
     const datasets = [];
     for (const [type, records] of byType) {
@@ -115,6 +116,47 @@ export class SyntheaTool {
     await this.fsFns.rm(tmpDir, { recursive: true });
 
     return datasets;
+  }
+}
+
+/**
+ * Restrict the flattened FHIR resources to patients whose Condition entries
+ * match one of the supplied clinical condition IDs. Matches on `code.coding[].code`
+ * exactly, or `code.coding[].display` normalized to lowercase-underscored form
+ * (the DSL convention).
+ *
+ * Mutates `byType` in place. No-op when conditions is empty/undefined, when
+ * there are no FHIR Condition resources, or when no patients match (so a
+ * mis-spelled condition does not silently drop the entire dataset).
+ */
+function filterByConditions(byType, conditions) {
+  if (!conditions?.length) return;
+  const patientType = byType.get("Patient");
+  const conditionType = byType.get("Condition");
+  if (!patientType || !conditionType) return;
+
+  const matchedPatientIds = new Set();
+  for (const cond of conditionType) {
+    const coding = cond.code?.coding || [];
+    const matches = coding.some(
+      (c) =>
+        conditions.includes(c.code) ||
+        conditions.includes(c.display?.toLowerCase().replace(/\s+/g, "_")),
+    );
+    if (!matches) continue;
+    const ref = cond.subject?.reference;
+    if (ref) matchedPatientIds.add(ref.replace("urn:uuid:", ""));
+  }
+  if (matchedPatientIds.size === 0) return;
+
+  for (const [type, records] of byType) {
+    byType.set(
+      type,
+      records.filter((r) => {
+        const id = r.id || r.subject?.reference?.replace("urn:uuid:", "");
+        return !id || matchedPatientIds.has(id);
+      }),
+    );
   }
 }
 

--- a/libraries/libsyntheticgen/src/tools/synthea.js
+++ b/libraries/libsyntheticgen/src/tools/synthea.js
@@ -48,6 +48,10 @@ export class SyntheaTool {
    * @param {string} config.name - Dataset name from DSL
    * @param {number} [config.population=100] - Number of patients
    * @param {string[]} [config.modules] - Synthea modules to enable
+   * @param {string[]} [config.conditions] - Clinical condition IDs to filter
+   *   patients by, matched against `Condition.code.coding[].code` exactly or
+   *   `.display` normalized to `lowercase_underscored` form (the DSL
+   *   condition-id convention).
    * @param {number} config.seed - RNG seed
    * @returns {Promise<Dataset[]>}
    */
@@ -144,8 +148,8 @@ function filterByConditions(byType, conditions) {
         conditions.includes(c.display?.toLowerCase().replace(/\s+/g, "_")),
     );
     if (!matches) continue;
-    const ref = cond.subject?.reference;
-    if (ref) matchedPatientIds.add(ref.replace("urn:uuid:", ""));
+    const patientId = normalizePatientRef(cond.subject?.reference);
+    if (patientId) matchedPatientIds.add(patientId);
   }
   if (matchedPatientIds.size === 0) return;
 
@@ -153,11 +157,22 @@ function filterByConditions(byType, conditions) {
     byType.set(
       type,
       records.filter((r) => {
-        const id = r.id || r.subject?.reference?.replace("urn:uuid:", "");
-        return !id || matchedPatientIds.has(id);
+        // Patient resources carry their own UUID in `id`. All other FHIR
+        // resources (Condition, Encounter, Observation, ...) also carry their
+        // own UUID in `id` — the link back to the patient lives on
+        // `subject.reference`. Prefer the patient reference when present.
+        const subjectId = normalizePatientRef(r.subject?.reference);
+        if (subjectId) return matchedPatientIds.has(subjectId);
+        if (type === "Patient") return matchedPatientIds.has(r.id);
+        return true;
       }),
     );
   }
+}
+
+function normalizePatientRef(ref) {
+  if (!ref) return null;
+  return ref.replace(/^urn:uuid:/, "").replace(/^Patient\//, "");
 }
 
 /**

--- a/libraries/libsyntheticgen/test/parser-dataset.test.js
+++ b/libraries/libsyntheticgen/test/parser-dataset.test.js
@@ -140,4 +140,45 @@ describe("dataset and output parsing", () => {
     assert.strictEqual(ast.datasets[0].id, "a");
     assert.strictEqual(ast.datasets[1].id, "b");
   });
+
+  test("parses conditions field on dataset", () => {
+    const ast = parseDsl(`terrain test {
+      dataset trial_patients {
+        tool synthea
+        population 100
+        conditions [lung_cancer, diabetes_t2, cardiovascular]
+      }
+    }`);
+    const ds = ast.datasets[0];
+    assert.deepStrictEqual(ds.config.conditions, [
+      "lung_cancer",
+      "diabetes_t2",
+      "cardiovascular",
+    ]);
+  });
+
+  test("parses conditions alongside modules — both coexist", () => {
+    const ast = parseDsl(`terrain test {
+      dataset trial_patients {
+        tool synthea
+        modules [hypertension]
+        conditions [lung_cancer]
+      }
+    }`);
+    const ds = ast.datasets[0];
+    assert.deepStrictEqual(ds.config.modules, ["hypertension"]);
+    assert.deepStrictEqual(ds.config.conditions, ["lung_cancer"]);
+  });
+
+  test("parses conditions without modules", () => {
+    const ast = parseDsl(`terrain test {
+      dataset trial_patients {
+        tool synthea
+        conditions [lung_cancer]
+      }
+    }`);
+    const ds = ast.datasets[0];
+    assert.strictEqual(ds.config.modules, undefined);
+    assert.deepStrictEqual(ds.config.conditions, ["lung_cancer"]);
+  });
 });

--- a/libraries/libsyntheticgen/test/synthea.test.js
+++ b/libraries/libsyntheticgen/test/synthea.test.js
@@ -45,6 +45,21 @@ describe("SyntheaTool", () => {
     );
   });
 
+  test("checkAvailability error message references 'just synthea-install'", async () => {
+    const tool = new SyntheaTool({
+      logger,
+      syntheaJar: "/missing.jar",
+      execFileFn: async () => {
+        throw new Error("not found");
+      },
+      fsFns: { readFile: async () => Buffer.from("") },
+    });
+    await assertRejectsMessage(
+      () => tool.checkAvailability(),
+      /just synthea-install/,
+    );
+  });
+
   test("passes correct args to java", async () => {
     let capturedArgs;
     const fhirBundle = {
@@ -99,4 +114,135 @@ describe("SyntheaTool", () => {
     assert.strictEqual(patientDs.metadata.tool, "synthea");
     assert.strictEqual(patientDs.metadata.resourceType, "Patient");
   });
+
+  test("filterByConditions keeps only patients with matching FHIR Condition codes", async () => {
+    // 5 patients, 3 with diabetes — output should contain those 3 only.
+    const bundles = makeFhirBundles([
+      { patient: "p1", conditions: [{ display: "Diabetes" }] },
+      { patient: "p2", conditions: [{ display: "Hypertension" }] },
+      { patient: "p3", conditions: [{ display: "Diabetes" }] },
+      { patient: "p4", conditions: [{ display: "Diabetes" }] },
+      { patient: "p5", conditions: [{ display: "Migraine" }] },
+    ]);
+
+    const tool = makeToolWithBundles(bundles, "/synthea.jar");
+    const datasets = await tool.generate({
+      name: "trial_patients",
+      population: 5,
+      conditions: ["diabetes"],
+      seed: 1,
+    });
+
+    const patientDs = datasets.find((d) => d.name === "trial_patients_patient");
+    assert.strictEqual(patientDs.records.length, 3);
+    const ids = patientDs.records.map((r) => r.id).sort();
+    assert.deepStrictEqual(ids, ["p1", "p3", "p4"]);
+  });
+
+  test("filterByConditions matches by FHIR code over display text", async () => {
+    const bundles = makeFhirBundles([
+      { patient: "p1", conditions: [{ code: "E11", display: "Type 2" }] },
+      { patient: "p2", conditions: [{ code: "I10", display: "Hypertension" }] },
+    ]);
+    const tool = makeToolWithBundles(bundles, "/synthea.jar");
+    const datasets = await tool.generate({
+      name: "trial_patients",
+      population: 2,
+      conditions: ["E11"],
+      seed: 1,
+    });
+    const patientDs = datasets.find((d) => d.name === "trial_patients_patient");
+    assert.strictEqual(patientDs.records.length, 1);
+    assert.strictEqual(patientDs.records[0].id, "p1");
+  });
+
+  test("no conditions field — no filtering applied", async () => {
+    const bundles = makeFhirBundles([
+      { patient: "p1", conditions: [{ display: "Diabetes" }] },
+      { patient: "p2", conditions: [{ display: "Hypertension" }] },
+    ]);
+    const tool = makeToolWithBundles(bundles, "/synthea.jar");
+    const datasets = await tool.generate({
+      name: "patients",
+      population: 2,
+      seed: 1,
+    });
+    const patientDs = datasets.find((d) => d.name === "patients_patient");
+    assert.strictEqual(patientDs.records.length, 2);
+  });
+
+  test("filterByConditions handles empty Condition list — no patient drop", async () => {
+    const bundles = [
+      {
+        entry: [
+          { resource: { resourceType: "Patient", id: "p1" } },
+          { resource: { resourceType: "Patient", id: "p2" } },
+        ],
+      },
+    ];
+    const tool = makeToolWithBundles(bundles, "/synthea.jar");
+    const datasets = await tool.generate({
+      name: "patients",
+      population: 2,
+      conditions: ["diabetes"],
+      seed: 1,
+    });
+    // No Condition resources → no patient gets a match, but the no-match
+    // branch leaves data untouched rather than wiping it.
+    const patientDs = datasets.find((d) => d.name === "patients_patient");
+    assert.strictEqual(patientDs.records.length, 2);
+  });
+
+  test("empty FHIR output — generate returns no datasets without error", async () => {
+    const tool = makeToolWithBundles([], "/synthea.jar");
+    const datasets = await tool.generate({
+      name: "patients",
+      population: 0,
+      seed: 1,
+    });
+    assert.strictEqual(datasets.length, 0);
+  });
 });
+
+/**
+ * Build FHIR bundles where each patient has a set of Condition resources
+ * referencing them. `conditions[].code` and `.display` are optional fields
+ * on the FHIR `code.coding` element.
+ */
+function makeFhirBundles(patientSpecs) {
+  const bundles = [];
+  for (const spec of patientSpecs) {
+    const entry = [{ resource: { resourceType: "Patient", id: spec.patient } }];
+    for (const c of spec.conditions) {
+      entry.push({
+        resource: {
+          resourceType: "Condition",
+          code: {
+            coding: [{ code: c.code, display: c.display }],
+          },
+          subject: { reference: `urn:uuid:${spec.patient}` },
+        },
+      });
+    }
+    bundles.push({ entry });
+  }
+  return bundles;
+}
+
+function makeToolWithBundles(bundles, syntheaJar) {
+  return new SyntheaTool({
+    logger,
+    syntheaJar,
+    execFileFn: async () => ({ stdout: "" }),
+    fsFns: {
+      readFile: async (path) => {
+        if (path === syntheaJar) return Buffer.from("");
+        const idx = parseInt(path.split("/").pop().replace(/\D/g, ""), 10) - 1;
+        return JSON.stringify(bundles[idx] || { entry: [] });
+      },
+      readdir: async () => bundles.map((_, i) => `bundle${i + 1}.json`),
+      mkdtemp: async () => "/tmp/synthea-test",
+      rm: async () => {},
+    },
+  });
+}

--- a/libraries/libsyntheticgen/test/synthea.test.js
+++ b/libraries/libsyntheticgen/test/synthea.test.js
@@ -193,6 +193,115 @@ describe("SyntheaTool", () => {
     assert.strictEqual(patientDs.records.length, 2);
   });
 
+  test("filterByConditions retains linked Encounters/Observations of matched patients", async () => {
+    // Real Synthea bundles include Encounter, Observation, etc., each with
+    // their own resource id and a `subject.reference` back to the patient.
+    // The filter must walk subject.reference, not r.id, for non-Patient rows.
+    const bundles = [
+      {
+        entry: [
+          { resource: { resourceType: "Patient", id: "p1" } },
+          {
+            resource: {
+              resourceType: "Condition",
+              id: "cond-1",
+              code: { coding: [{ display: "Diabetes" }] },
+              subject: { reference: "urn:uuid:p1" },
+            },
+          },
+          {
+            resource: {
+              resourceType: "Encounter",
+              id: "enc-1",
+              subject: { reference: "urn:uuid:p1" },
+            },
+          },
+          {
+            resource: {
+              resourceType: "Observation",
+              id: "obs-1",
+              subject: { reference: "urn:uuid:p1" },
+            },
+          },
+        ],
+      },
+      {
+        entry: [
+          { resource: { resourceType: "Patient", id: "p2" } },
+          {
+            resource: {
+              resourceType: "Condition",
+              id: "cond-2",
+              code: { coding: [{ display: "Hypertension" }] },
+              subject: { reference: "urn:uuid:p2" },
+            },
+          },
+          {
+            resource: {
+              resourceType: "Encounter",
+              id: "enc-2",
+              subject: { reference: "urn:uuid:p2" },
+            },
+          },
+        ],
+      },
+    ];
+    const tool = makeToolWithBundles(bundles, "/synthea.jar");
+    const datasets = await tool.generate({
+      name: "patients",
+      population: 2,
+      conditions: ["diabetes"],
+      seed: 1,
+    });
+    const byType = Object.fromEntries(
+      datasets.map((d) => [d.metadata.resourceType, d.records]),
+    );
+    assert.strictEqual(byType.Patient.length, 1);
+    assert.strictEqual(byType.Patient[0].id, "p1");
+    assert.strictEqual(byType.Condition.length, 1);
+    assert.strictEqual(byType.Condition[0].id, "cond-1");
+    assert.strictEqual(byType.Encounter.length, 1);
+    assert.strictEqual(byType.Encounter[0].id, "enc-1");
+    assert.strictEqual(byType.Observation.length, 1);
+  });
+
+  test("filterByConditions handles Patient/<id> reference form", async () => {
+    const bundles = [
+      {
+        entry: [
+          { resource: { resourceType: "Patient", id: "p1" } },
+          {
+            resource: {
+              resourceType: "Condition",
+              id: "cond-1",
+              code: { coding: [{ display: "Diabetes" }] },
+              subject: { reference: "Patient/p1" },
+            },
+          },
+          {
+            resource: {
+              resourceType: "Encounter",
+              id: "enc-1",
+              subject: { reference: "Patient/p1" },
+            },
+          },
+        ],
+      },
+    ];
+    const tool = makeToolWithBundles(bundles, "/synthea.jar");
+    const datasets = await tool.generate({
+      name: "patients",
+      population: 1,
+      conditions: ["diabetes"],
+      seed: 1,
+    });
+    const byType = Object.fromEntries(
+      datasets.map((d) => [d.metadata.resourceType, d.records]),
+    );
+    assert.strictEqual(byType.Patient.length, 1);
+    assert.strictEqual(byType.Encounter.length, 1);
+  });
+
   test("empty FHIR output — generate returns no datasets without error", async () => {
     const tool = makeToolWithBundles([], "/synthea.jar");
     const datasets = await tool.generate({
@@ -206,17 +315,21 @@ describe("SyntheaTool", () => {
 
 /**
  * Build FHIR bundles where each patient has a set of Condition resources
- * referencing them. `conditions[].code` and `.display` are optional fields
- * on the FHIR `code.coding` element.
+ * referencing them. Every resource gets its own `id` UUID — matching real
+ * Synthea output, where Patient, Condition, Encounter, Observation, etc.
+ * all carry independent resource IDs and link back via `subject.reference`.
  */
 function makeFhirBundles(patientSpecs) {
   const bundles = [];
+  let condCounter = 0;
   for (const spec of patientSpecs) {
     const entry = [{ resource: { resourceType: "Patient", id: spec.patient } }];
     for (const c of spec.conditions) {
+      condCounter++;
       entry.push({
         resource: {
           resourceType: "Condition",
+          id: `cond-${condCounter}`,
           code: {
             coding: [{ code: c.code, display: c.display }],
           },

--- a/libraries/libsyntheticrender/src/render/html-clinical.js
+++ b/libraries/libsyntheticrender/src/render/html-clinical.js
@@ -1,0 +1,249 @@
+/**
+ * Clinical HTML rendering — patient-facing pages with Schema.org microdata.
+ *
+ * Pass 1 produces deterministic templates with `data-enrich="clinical_..."`
+ * placeholders. The cache-lookup stage fills those placeholders from the
+ * prose cache before write; the LLM enricher (enricher.js) leaves them
+ * untouched because no handler matches the `clinical_` prefix.
+ */
+
+function titleCase(str) {
+  return str.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function buildConditionData(conditions, trials, prose) {
+  return conditions.map((cond) => ({
+    id: cond.id,
+    name: cond.name,
+    iri: cond.iri,
+    severity: cond.severity || "",
+    icd10List: (cond.icd10 || []).map((code) => ({ code })),
+    synonymList: (cond.synonyms || []).map((synonym) => ({ synonym })),
+    trialLinks: (cond.trials || [])
+      .map((tid) => trials.find((t) => t.id === tid))
+      .filter(Boolean)
+      .map((t) => ({ iri: t.iri })),
+    prose:
+      prose.get(`clinical_condition_explainer_${cond.id}`) ||
+      `${cond.name} — patient-facing overview.`,
+  }));
+}
+
+function buildTherapyData(content, prose) {
+  if (!content?.therapy_topics) return [];
+  return content.therapy_topics.map((topic) => ({
+    topic,
+    title: titleCase(topic),
+    iri: `#therapy-${topic}`,
+    prose:
+      prose.get(`clinical_therapy_description_${topic}`) ||
+      `${titleCase(topic)} treatment overview.`,
+  }));
+}
+
+function buildTrialFaqData(trials, conditions, prose) {
+  return trials.map((trial) => ({
+    id: trial.id,
+    name: trial.name,
+    iri: trial.iri,
+    protocol_id: trial.protocol_id || "",
+    phase: trial.phase || "",
+    status: trial.status || "",
+    sponsor: trial.sponsor || "",
+    conditionLinks: (trial.conditions || [])
+      .map((cid) => conditions.find((c) => c.id === cid))
+      .filter(Boolean)
+      .map((c) => ({ iri: c.iri })),
+    prose:
+      prose.get(`clinical_trial_faq_${trial.id}`) || `FAQ for ${trial.name}.`,
+  }));
+}
+
+function buildConsentData(trials, criteria, prose) {
+  return trials.map((trial) => {
+    const crit = criteria.find((c) => c.trial_id === trial.id);
+    const inc = crit?.inclusion || null;
+    const eligibility =
+      inc?.age_min != null || inc?.age_max != null
+        ? [
+            {
+              eligibleMinAge: inc.age_min ?? "",
+              eligibleMaxAge: inc.age_max ?? "",
+            },
+          ]
+        : [];
+    return {
+      id: trial.id,
+      name: trial.name,
+      iri: trial.iri,
+      protocol_id: trial.protocol_id || "",
+      phase: trial.phase || "",
+      eligibilitySummary: eligibility,
+      prose:
+        prose.get(`clinical_consent_summary_${trial.id}`) ||
+        `Consent summary for ${trial.name}.`,
+    };
+  });
+}
+
+function buildSiteData(sites, trials, prose) {
+  return sites.map((site) => ({
+    id: site.id,
+    name: site.name,
+    iri: site.iri,
+    address: site.address || "",
+    city: site.city || "",
+    state: site.state || "",
+    country: site.country || "",
+    specialtyList: (site.specialties || []).map((specialty) => ({ specialty })),
+    activeTrialLinks: (site.trials || [])
+      .map((tid) => trials.find((t) => t.id === tid))
+      .filter((t) => t && t.status === "recruiting")
+      .map((t) => ({ iri: t.iri })),
+    prose:
+      prose.get(`clinical_site_description_${site.id}`) ||
+      `${site.name} — site information.`,
+  }));
+}
+
+function buildPatientStoryData(conditions, content, prose, domain) {
+  if (!content?.patient_story_conditions?.length) return [];
+  const total = content.patient_stories || 0;
+  const perCondition = Math.ceil(
+    total / Math.max(content.patient_story_conditions.length, 1),
+  );
+  const stories = [];
+  for (const condId of content.patient_story_conditions) {
+    const cond = conditions.find((c) => c.id === condId);
+    if (!cond) continue;
+    for (let i = 0; i < perCondition; i++) {
+      stories.push({
+        conditionId: condId,
+        conditionIri:
+          cond.iri || `https://${domain}/id/clinical/condition/${condId}`,
+        conditionName: cond.name,
+        index: i,
+        title: `Living with ${cond.name} — story ${i + 1}`,
+        prose:
+          prose.get(`clinical_patient_story_${condId}_${i}`) ||
+          `Patient story about ${cond.name}.`,
+      });
+    }
+  }
+  return stories;
+}
+
+function buildTrialCardData(trials, conditions, sites) {
+  return trials.map((trial) => ({
+    id: trial.id,
+    name: trial.name,
+    iri: trial.iri,
+    protocol_id: trial.protocol_id || "",
+    phase: trial.phase || "",
+    status: trial.status || "",
+    therapeutic_area: trial.therapeutic_area || "",
+    sponsor: trial.sponsor || "",
+    conditionLinks: (trial.conditions || [])
+      .map((cid) => conditions.find((c) => c.id === cid))
+      .filter(Boolean)
+      .map((c) => ({ iri: c.iri })),
+    siteLinks: (trial.sites || [])
+      .map((sid) => sites.find((s) => s.id === sid))
+      .filter(Boolean)
+      .map((s) => ({ iri: s.iri })),
+  }));
+}
+
+/**
+ * Render 7 clinical HTML files into `files`. The `page` wrapper is supplied
+ * by the caller so clinical pages share the org-wide page chrome.
+ *
+ * @param {Map<string,string>} files
+ * @param {object} entities - Must include `entities.clinical`
+ * @param {Map<string,string>} prose
+ * @param {import('@forwardimpact/libtemplate/loader').TemplateLoader} templates
+ * @param {string} domain
+ * @param {(title: string, body: string) => string} pageWrap
+ */
+export function renderClinicalPages(
+  files,
+  entities,
+  prose,
+  templates,
+  domain,
+  pageWrap,
+) {
+  const clinical = entities.clinical;
+  if (!clinical) return;
+  const { conditions, sites, trials, criteria, content } = clinical;
+
+  files.set(
+    "condition-explainers.html",
+    pageWrap(
+      "Condition Explainers",
+      templates.render("condition-explainer.html", {
+        conditions: buildConditionData(conditions, trials, prose),
+      }),
+    ),
+  );
+
+  files.set(
+    "therapy-descriptions.html",
+    pageWrap(
+      "Therapy Descriptions",
+      templates.render("therapy-description.html", {
+        therapies: buildTherapyData(content, prose),
+      }),
+    ),
+  );
+
+  files.set(
+    "trial-faqs.html",
+    pageWrap(
+      "Trial FAQs",
+      templates.render("trial-faq.html", {
+        trials: buildTrialFaqData(trials, conditions, prose),
+      }),
+    ),
+  );
+
+  files.set(
+    "consent-summaries.html",
+    pageWrap(
+      "Consent Summaries",
+      templates.render("consent-summary.html", {
+        trials: buildConsentData(trials, criteria || [], prose),
+      }),
+    ),
+  );
+
+  files.set(
+    "site-descriptions.html",
+    pageWrap(
+      "Site Descriptions",
+      templates.render("site-description.html", {
+        sites: buildSiteData(sites, trials, prose),
+      }),
+    ),
+  );
+
+  files.set(
+    "patient-stories.html",
+    pageWrap(
+      "Patient Stories",
+      templates.render("patient-story.html", {
+        stories: buildPatientStoryData(conditions, content, prose, domain),
+      }),
+    ),
+  );
+
+  files.set(
+    "trial-cards.html",
+    pageWrap(
+      "Trials",
+      templates.render("trial-card.html", {
+        trials: buildTrialCardData(trials, conditions, sites),
+      }),
+    ),
+  );
+}

--- a/libraries/libsyntheticrender/src/render/html-clinical.js
+++ b/libraries/libsyntheticrender/src/render/html-clinical.js
@@ -1,10 +1,18 @@
 /**
  * Clinical HTML rendering — patient-facing pages with Schema.org microdata.
  *
- * Pass 1 produces deterministic templates with `data-enrich="clinical_..."`
- * placeholders. The cache-lookup stage fills those placeholders from the
- * prose cache before write; the LLM enricher (enricher.js) leaves them
- * untouched because no handler matches the `clinical_` prefix.
+ * Each `build*Data` helper looks up the prose key for the entity (e.g.
+ * `clinical_condition_explainer_${id}`) in the prose cache and slots the
+ * resolved prose into the template at Pass-1 render time via Mustache. The
+ * `data-enrich="clinical_..."` attribute is left on the output element as
+ * a marker only — the LLM enricher (`enricher.js`) iterates `data-enrich`
+ * blocks but matches handlers by prefix (`project_`, `drug_`, ...), so
+ * `clinical_` keys are never re-enriched and the cached prose survives
+ * intact to disk.
+ *
+ * Prose is interpolated with triple-brace Mustache (`{{{prose}}}`) so the
+ * patient-facing prompt's inline Schema.org spans land as live microdata
+ * rather than HTML-escaped text.
  */
 
 function titleCase(str) {
@@ -109,11 +117,13 @@ function buildSiteData(sites, trials, prose) {
 function buildPatientStoryData(conditions, content, prose, domain) {
   if (!content?.patient_story_conditions?.length) return [];
   const total = content.patient_stories || 0;
-  const perCondition = Math.ceil(
-    total / Math.max(content.patient_story_conditions.length, 1),
-  );
+  const condIds = content.patient_story_conditions;
+  // Mirror the prose-key generator's cardinality math (clinical-prose-keys.js).
+  // Generate exactly `perCondition` stories per condition so the data-enrich
+  // keys here line up 1:1 with the keys collected upstream.
+  const perCondition = Math.ceil(total / Math.max(condIds.length, 1));
   const stories = [];
-  for (const condId of content.patient_story_conditions) {
+  for (const condId of condIds) {
     const cond = conditions.find((c) => c.id === condId);
     if (!cond) continue;
     for (let i = 0; i < perCondition; i++) {

--- a/libraries/libsyntheticrender/src/render/html.js
+++ b/libraries/libsyntheticrender/src/render/html.js
@@ -13,6 +13,7 @@ import {
   enrichPlatformsWithLinks,
   enrichDrugsWithLinks,
 } from "./html-helpers.js";
+import { renderClinicalPages } from "./html-clinical.js";
 
 /** Wrap inner HTML in the page shell. */
 function page(templates, title, body, domain) {
@@ -403,6 +404,11 @@ export function renderHTML(entities, prose, templates) {
 
   if (gc) {
     renderContentPages(files, gc, linked, entities, prose, templates, domain);
+  }
+
+  if (entities.clinical) {
+    const pageWrap = (title, body) => page(templates, title, body, domain);
+    renderClinicalPages(files, entities, prose, templates, domain, pageWrap);
   }
 
   return { files, linked };

--- a/libraries/libsyntheticrender/templates/condition-explainer.html
+++ b/libraries/libsyntheticrender/templates/condition-explainer.html
@@ -1,0 +1,26 @@
+{{#conditions}}
+<section
+  itemscope
+  itemtype="https://schema.org/MedicalCondition"
+  itemid="{{{iri}}}"
+>
+  <h2 itemprop="name">{{name}}</h2>
+  {{#icd10List}}
+  <meta itemprop="code" content="{{code}}" />
+  {{/icd10List}} {{#synonymList}}
+  <meta itemprop="alternateName" content="{{synonym}}" />
+  {{/synonymList}}
+  <meta itemprop="riskFactor" content="{{severity}}" />
+
+  {{#trialLinks}}
+  <link itemprop="study" href="{{{iri}}}" />
+  {{/trialLinks}}
+
+  <div
+    itemprop="description"
+    data-enrich="clinical_condition_explainer_{{id}}"
+  >
+    {{prose}}
+  </div>
+</section>
+{{/conditions}}

--- a/libraries/libsyntheticrender/templates/condition-explainer.html
+++ b/libraries/libsyntheticrender/templates/condition-explainer.html
@@ -9,10 +9,9 @@
   <meta itemprop="code" content="{{code}}" />
   {{/icd10List}} {{#synonymList}}
   <meta itemprop="alternateName" content="{{synonym}}" />
-  {{/synonymList}}
-  <meta itemprop="riskFactor" content="{{severity}}" />
-
-  {{#trialLinks}}
+  {{/synonymList}} {{#severity}}
+  <meta itemprop="status" content="{{severity}}" />
+  {{/severity}} {{#trialLinks}}
   <link itemprop="study" href="{{{iri}}}" />
   {{/trialLinks}}
 
@@ -20,7 +19,7 @@
     itemprop="description"
     data-enrich="clinical_condition_explainer_{{id}}"
   >
-    {{prose}}
+    {{{prose}}}
   </div>
 </section>
 {{/conditions}}

--- a/libraries/libsyntheticrender/templates/consent-summary.html
+++ b/libraries/libsyntheticrender/templates/consent-summary.html
@@ -1,0 +1,22 @@
+{{#trials}}
+<section
+  itemscope
+  itemtype="https://schema.org/MedicalTrial"
+  itemid="{{{iri}}}"
+>
+  <h2 itemprop="name">{{name}} — Consent Summary</h2>
+  <meta itemprop="identifier" content="{{protocol_id}}" />
+  <meta itemprop="phase" content="{{phase}}" />
+  {{#eligibilitySummary}}
+  <meta itemprop="eligibleMaxAge" content="{{eligibleMaxAge}}" />
+  <meta itemprop="eligibleMinAge" content="{{eligibleMinAge}}" />
+  {{/eligibilitySummary}}
+
+  <div
+    itemprop="description"
+    data-enrich="clinical_consent_summary_{{id}}"
+  >
+    {{prose}}
+  </div>
+</section>
+{{/trials}}

--- a/libraries/libsyntheticrender/templates/consent-summary.html
+++ b/libraries/libsyntheticrender/templates/consent-summary.html
@@ -5,9 +5,11 @@
   itemid="{{{iri}}}"
 >
   <h2 itemprop="name">{{name}} — Consent Summary</h2>
+  {{#protocol_id}}
   <meta itemprop="identifier" content="{{protocol_id}}" />
+  {{/protocol_id}} {{#phase}}
   <meta itemprop="phase" content="{{phase}}" />
-  {{#eligibilitySummary}}
+  {{/phase}} {{#eligibilitySummary}}
   <meta itemprop="eligibleMaxAge" content="{{eligibleMaxAge}}" />
   <meta itemprop="eligibleMinAge" content="{{eligibleMinAge}}" />
   {{/eligibilitySummary}}
@@ -16,7 +18,7 @@
     itemprop="description"
     data-enrich="clinical_consent_summary_{{id}}"
   >
-    {{prose}}
+    {{{prose}}}
   </div>
 </section>
 {{/trials}}

--- a/libraries/libsyntheticrender/templates/patient-story.html
+++ b/libraries/libsyntheticrender/templates/patient-story.html
@@ -1,0 +1,17 @@
+{{#stories}}
+<article
+  itemscope
+  itemtype="https://schema.org/MedicalCondition"
+  itemid="{{{conditionIri}}}"
+>
+  <h2 itemprop="name">{{title}}</h2>
+  <meta itemprop="alternateName" content="{{conditionName}}" />
+
+  <div
+    itemprop="description"
+    data-enrich="clinical_patient_story_{{conditionId}}_{{index}}"
+  >
+    {{prose}}
+  </div>
+</article>
+{{/stories}}

--- a/libraries/libsyntheticrender/templates/patient-story.html
+++ b/libraries/libsyntheticrender/templates/patient-story.html
@@ -11,7 +11,7 @@
     itemprop="description"
     data-enrich="clinical_patient_story_{{conditionId}}_{{index}}"
   >
-    {{prose}}
+    {{{prose}}}
   </div>
 </article>
 {{/stories}}

--- a/libraries/libsyntheticrender/templates/site-description.html
+++ b/libraries/libsyntheticrender/templates/site-description.html
@@ -1,0 +1,31 @@
+{{#sites}}
+<section
+  itemscope
+  itemtype="https://schema.org/MedicalClinic"
+  itemid="{{{iri}}}"
+>
+  <h2 itemprop="name">{{name}}</h2>
+  <div itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
+    {{#address}}
+    <span itemprop="streetAddress">{{address}}</span>
+    {{/address}}
+    <span itemprop="addressLocality">{{city}}</span>
+    <span itemprop="addressRegion">{{state}}</span>
+    {{#country}}
+    <span itemprop="addressCountry">{{country}}</span>
+    {{/country}}
+  </div>
+  {{#specialtyList}}
+  <meta itemprop="medicalSpecialty" content="{{specialty}}" />
+  {{/specialtyList}} {{#activeTrialLinks}}
+  <link itemprop="availableService" href="{{{iri}}}" />
+  {{/activeTrialLinks}}
+
+  <div
+    itemprop="description"
+    data-enrich="clinical_site_description_{{id}}"
+  >
+    {{prose}}
+  </div>
+</section>
+{{/sites}}

--- a/libraries/libsyntheticrender/templates/site-description.html
+++ b/libraries/libsyntheticrender/templates/site-description.html
@@ -8,10 +8,11 @@
   <div itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
     {{#address}}
     <span itemprop="streetAddress">{{address}}</span>
-    {{/address}}
+    {{/address}} {{#city}}
     <span itemprop="addressLocality">{{city}}</span>
+    {{/city}} {{#state}}
     <span itemprop="addressRegion">{{state}}</span>
-    {{#country}}
+    {{/state}} {{#country}}
     <span itemprop="addressCountry">{{country}}</span>
     {{/country}}
   </div>
@@ -25,7 +26,7 @@
     itemprop="description"
     data-enrich="clinical_site_description_{{id}}"
   >
-    {{prose}}
+    {{{prose}}}
   </div>
 </section>
 {{/sites}}

--- a/libraries/libsyntheticrender/templates/therapy-description.html
+++ b/libraries/libsyntheticrender/templates/therapy-description.html
@@ -1,0 +1,17 @@
+{{#therapies}}
+<section
+  itemscope
+  itemtype="https://schema.org/MedicalTherapy"
+  itemid="{{{iri}}}"
+>
+  <h2 itemprop="name">{{title}}</h2>
+  <meta itemprop="identifier" content="{{topic}}" />
+
+  <div
+    itemprop="description"
+    data-enrich="clinical_therapy_description_{{topic}}"
+  >
+    {{prose}}
+  </div>
+</section>
+{{/therapies}}

--- a/libraries/libsyntheticrender/templates/therapy-description.html
+++ b/libraries/libsyntheticrender/templates/therapy-description.html
@@ -11,7 +11,7 @@
     itemprop="description"
     data-enrich="clinical_therapy_description_{{topic}}"
   >
-    {{prose}}
+    {{{prose}}}
   </div>
 </section>
 {{/therapies}}

--- a/libraries/libsyntheticrender/templates/trial-card.html
+++ b/libraries/libsyntheticrender/templates/trial-card.html
@@ -1,0 +1,21 @@
+{{#trials}}
+<article
+  itemscope
+  itemtype="https://schema.org/MedicalTrial"
+  itemid="{{{iri}}}"
+>
+  <h3 itemprop="name">{{name}}</h3>
+  <meta itemprop="identifier" content="{{protocol_id}}" />
+  <span itemprop="phase">{{phase}}</span>
+  <span itemprop="status">{{status}}</span>
+  {{#therapeutic_area}}
+  <meta itemprop="medicalSpecialty" content="{{therapeutic_area}}" />
+  {{/therapeutic_area}} {{#sponsor}}
+  <meta itemprop="sponsor" content="{{sponsor}}" />
+  {{/sponsor}} {{#conditionLinks}}
+  <link itemprop="healthCondition" href="{{{iri}}}" />
+  {{/conditionLinks}} {{#siteLinks}}
+  <link itemprop="location" href="{{{iri}}}" />
+  {{/siteLinks}}
+</article>
+{{/trials}}

--- a/libraries/libsyntheticrender/templates/trial-faq.html
+++ b/libraries/libsyntheticrender/templates/trial-faq.html
@@ -1,0 +1,21 @@
+{{#trials}}
+<section
+  itemscope
+  itemtype="https://schema.org/MedicalTrial"
+  itemid="{{{iri}}}"
+>
+  <h2 itemprop="name">{{name}}</h2>
+  <meta itemprop="identifier" content="{{protocol_id}}" />
+  <meta itemprop="phase" content="{{phase}}" />
+  <meta itemprop="status" content="{{status}}" />
+  {{#sponsor}}
+  <meta itemprop="sponsor" content="{{sponsor}}" />
+  {{/sponsor}} {{#conditionLinks}}
+  <link itemprop="healthCondition" href="{{{iri}}}" />
+  {{/conditionLinks}}
+
+  <div itemprop="description" data-enrich="clinical_trial_faq_{{id}}">
+    {{prose}}
+  </div>
+</section>
+{{/trials}}

--- a/libraries/libsyntheticrender/templates/trial-faq.html
+++ b/libraries/libsyntheticrender/templates/trial-faq.html
@@ -5,17 +5,20 @@
   itemid="{{{iri}}}"
 >
   <h2 itemprop="name">{{name}}</h2>
+  {{#protocol_id}}
   <meta itemprop="identifier" content="{{protocol_id}}" />
+  {{/protocol_id}} {{#phase}}
   <meta itemprop="phase" content="{{phase}}" />
+  {{/phase}} {{#status}}
   <meta itemprop="status" content="{{status}}" />
-  {{#sponsor}}
+  {{/status}} {{#sponsor}}
   <meta itemprop="sponsor" content="{{sponsor}}" />
   {{/sponsor}} {{#conditionLinks}}
   <link itemprop="healthCondition" href="{{{iri}}}" />
   {{/conditionLinks}}
 
   <div itemprop="description" data-enrich="clinical_trial_faq_{{id}}">
-    {{prose}}
+    {{{prose}}}
   </div>
 </section>
 {{/trials}}

--- a/libraries/libsyntheticrender/test/render-clinical-html.test.js
+++ b/libraries/libsyntheticrender/test/render-clinical-html.test.js
@@ -1,0 +1,282 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { TemplateLoader } from "@forwardimpact/libtemplate/loader";
+import { renderHTML } from "../src/render/html.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_DIR = join(__dirname, "..", "templates");
+
+function makeTemplates() {
+  return new TemplateLoader(TEMPLATE_DIR);
+}
+
+function makeMinimalEntities(overrides = {}) {
+  const base = {
+    domain: "example.com",
+    industry: "healthcare",
+    orgs: [
+      { id: "org1", name: "BioNova", iri: "https://example.com/id/org/org1" },
+    ],
+    departments: [],
+    teams: [],
+    people: [],
+    projects: [],
+    scenarios: [],
+    snapshots: [],
+    standard: {},
+    content: [],
+    activity: {},
+  };
+  return { ...base, ...overrides };
+}
+
+function makeClinicalFixture() {
+  return {
+    conditions: [
+      {
+        id: "diabetes_t2",
+        name: "Type 2 Diabetes",
+        icd10: ["E11"],
+        synonyms: ["high blood sugar"],
+        severity: "chronic",
+        trials: ["oncora_p3"],
+        iri: "https://example.com/id/clinical/condition/diabetes_t2",
+      },
+      {
+        id: "lung_cancer",
+        name: "Lung Cancer",
+        icd10: ["C34"],
+        synonyms: [],
+        severity: "severe",
+        trials: [],
+        iri: "https://example.com/id/clinical/condition/lung_cancer",
+      },
+    ],
+    sites: [
+      {
+        id: "cambridge",
+        name: "Cambridge Center",
+        address: "100 Main St",
+        city: "Cambridge",
+        state: "MA",
+        country: "USA",
+        specialties: ["oncology"],
+        trials: ["oncora_p3"],
+        iri: "https://example.com/id/clinical/site/cambridge",
+      },
+    ],
+    trials: [
+      {
+        id: "oncora_p3",
+        name: "ONCORA-301",
+        protocol_id: "ONC-301",
+        phase: "phase_3",
+        therapeutic_area: "oncology",
+        status: "recruiting",
+        sponsor: "BioNova",
+        conditions: ["diabetes_t2"],
+        sites: ["cambridge"],
+        iri: "https://example.com/id/clinical/trial/oncora_p3",
+      },
+    ],
+    criteria: [
+      {
+        trial_id: "oncora_p3",
+        inclusion: { age_min: 18, age_max: 75 },
+        exclusion: {},
+        iri: "https://example.com/id/clinical/criterion/oncora_p3",
+      },
+    ],
+    researchers: [],
+    content: {
+      patient_stories: 2,
+      patient_story_conditions: ["diabetes_t2"],
+      therapy_topics: ["immunotherapy"],
+    },
+  };
+}
+
+describe("renderClinicalPages", () => {
+  test("produces 7 clinical HTML files", () => {
+    const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
+    const { files } = renderHTML(entities, new Map(), makeTemplates());
+
+    const clinicalFiles = [
+      "condition-explainers.html",
+      "therapy-descriptions.html",
+      "trial-faqs.html",
+      "consent-summaries.html",
+      "site-descriptions.html",
+      "patient-stories.html",
+      "trial-cards.html",
+    ];
+    for (const name of clinicalFiles) {
+      assert.ok(files.has(name), `expected ${name} in output`);
+    }
+  });
+
+  test("Schema.org microdata uses correct itemtype URLs", () => {
+    const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
+    const { files } = renderHTML(entities, new Map(), makeTemplates());
+
+    assert.match(
+      files.get("condition-explainers.html"),
+      /itemtype="https:\/\/schema\.org\/MedicalCondition"/,
+    );
+    assert.match(
+      files.get("therapy-descriptions.html"),
+      /itemtype="https:\/\/schema\.org\/MedicalTherapy"/,
+    );
+    assert.match(
+      files.get("trial-faqs.html"),
+      /itemtype="https:\/\/schema\.org\/MedicalTrial"/,
+    );
+    assert.match(
+      files.get("consent-summaries.html"),
+      /itemtype="https:\/\/schema\.org\/MedicalTrial"/,
+    );
+    assert.match(
+      files.get("site-descriptions.html"),
+      /itemtype="https:\/\/schema\.org\/MedicalClinic"/,
+    );
+    assert.match(
+      files.get("patient-stories.html"),
+      /itemtype="https:\/\/schema\.org\/MedicalCondition"/,
+    );
+    assert.match(
+      files.get("trial-cards.html"),
+      /itemtype="https:\/\/schema\.org\/MedicalTrial"/,
+    );
+  });
+
+  test("data-enrich keys follow clinical_ prefix pattern", () => {
+    const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
+    const { files } = renderHTML(entities, new Map(), makeTemplates());
+
+    assert.match(
+      files.get("condition-explainers.html"),
+      /data-enrich="clinical_condition_explainer_diabetes_t2"/,
+    );
+    assert.match(
+      files.get("therapy-descriptions.html"),
+      /data-enrich="clinical_therapy_description_immunotherapy"/,
+    );
+    assert.match(
+      files.get("trial-faqs.html"),
+      /data-enrich="clinical_trial_faq_oncora_p3"/,
+    );
+    assert.match(
+      files.get("consent-summaries.html"),
+      /data-enrich="clinical_consent_summary_oncora_p3"/,
+    );
+    assert.match(
+      files.get("site-descriptions.html"),
+      /data-enrich="clinical_site_description_cambridge"/,
+    );
+    assert.match(
+      files.get("patient-stories.html"),
+      /data-enrich="clinical_patient_story_diabetes_t2_0"/,
+    );
+  });
+
+  test("empty prose cache falls back to placeholder strings", () => {
+    const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
+    const { files } = renderHTML(entities, new Map(), makeTemplates());
+
+    assert.match(
+      files.get("condition-explainers.html"),
+      /Type 2 Diabetes — patient-facing overview\./,
+    );
+    assert.match(files.get("trial-faqs.html"), /FAQ for ONCORA-301\./);
+  });
+
+  test("populated prose cache replaces fallback in output", () => {
+    const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
+    const prose = new Map([
+      [
+        "clinical_condition_explainer_diabetes_t2",
+        "Diabetes affects how your body uses sugar.",
+      ],
+      ["clinical_trial_faq_oncora_p3", "Common questions about ONCORA-301."],
+    ]);
+    const { files } = renderHTML(entities, prose, makeTemplates());
+
+    assert.match(
+      files.get("condition-explainers.html"),
+      /Diabetes affects how your body uses sugar\./,
+    );
+    assert.match(
+      files.get("trial-faqs.html"),
+      /Common questions about ONCORA-301\./,
+    );
+  });
+
+  test("trial-cards has no data-enrich attribute", () => {
+    const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
+    const { files } = renderHTML(entities, new Map(), makeTemplates());
+
+    assert.doesNotMatch(files.get("trial-cards.html"), /data-enrich/);
+  });
+
+  test("no clinical block produces zero clinical files, leaves others unaffected", () => {
+    const entities = makeMinimalEntities({ clinical: null });
+    const { files } = renderHTML(entities, new Map(), makeTemplates());
+
+    const clinicalFiles = [
+      "condition-explainers.html",
+      "therapy-descriptions.html",
+      "trial-faqs.html",
+      "consent-summaries.html",
+      "site-descriptions.html",
+      "patient-stories.html",
+      "trial-cards.html",
+    ];
+    for (const name of clinicalFiles) {
+      assert.ok(!files.has(name), `did not expect ${name} in output`);
+    }
+    // Existing structural pages still emit.
+    assert.ok(files.has("organization-leadership.html"));
+  });
+
+  test("condition study link points to trial IRIs", () => {
+    const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
+    const { files } = renderHTML(entities, new Map(), makeTemplates());
+
+    assert.match(
+      files.get("condition-explainers.html"),
+      /<link itemprop="study" href="https:\/\/example\.com\/id\/clinical\/trial\/oncora_p3"/,
+    );
+  });
+
+  test("site availableService link includes only recruiting trials", () => {
+    const clinical = makeClinicalFixture();
+    clinical.trials.push({
+      id: "completed_trial",
+      name: "Completed Trial",
+      protocol_id: "X",
+      phase: "phase_2",
+      therapeutic_area: "oncology",
+      status: "completed",
+      sponsor: "BioNova",
+      conditions: [],
+      sites: ["cambridge"],
+      iri: "https://example.com/id/clinical/trial/completed_trial",
+    });
+    clinical.sites[0].trials.push("completed_trial");
+
+    const entities = makeMinimalEntities({ clinical });
+    const { files } = renderHTML(entities, new Map(), makeTemplates());
+
+    const siteHtml = files.get("site-descriptions.html");
+    assert.match(
+      siteHtml,
+      /<link itemprop="availableService" href="https:\/\/example\.com\/id\/clinical\/trial\/oncora_p3"/,
+    );
+    assert.doesNotMatch(
+      siteHtml,
+      /availableService" href="https:\/\/example\.com\/id\/clinical\/trial\/completed_trial"/,
+    );
+  });
+});

--- a/libraries/libterrain/src/cli-helpers.js
+++ b/libraries/libterrain/src/cli-helpers.js
@@ -112,7 +112,8 @@ export function createPipeline(opts) {
         return new SyntheaTool({
           logger: deps.logger,
           syntheaJar:
-            process.env.SYNTHEA_JAR || "synthea-with-dependencies.jar",
+            process.env.SYNTHEA_JAR ||
+            "vendor/synthea/synthea-with-dependencies.jar",
           execFileFn,
           fsFns: {
             readFile,

--- a/libraries/libterrain/src/nodes.js
+++ b/libraries/libterrain/src/nodes.js
@@ -201,6 +201,7 @@ export function buildNodes(ctx) {
           parse.seed,
           toolFactory,
           logger,
+          parse.clinical,
         );
         await renderDatasetOutputs(parse.outputs, datasets, files, logger);
         return { files };
@@ -253,10 +254,17 @@ export function buildNodes(ctx) {
 }
 
 /** Run each dataset tool and collect results into a Map by name. */
-async function generateDatasets(definitions, seed, toolFactory, logger) {
+async function generateDatasets(
+  definitions,
+  seed,
+  toolFactory,
+  logger,
+  clinical,
+) {
   logger.info("pipeline", `Generating ${definitions.length} dataset(s)`);
   const datasets = new Map();
   for (const ds of definitions) {
+    resolveDatasetConditions(ds, clinical);
     const tool = toolFactory(ds.tool, { logger });
     try {
       await tool.checkAvailability();
@@ -277,6 +285,16 @@ async function generateDatasets(definitions, seed, toolFactory, logger) {
     }
   }
   return datasets;
+}
+
+function resolveDatasetConditions(ds, clinical) {
+  if (!ds.config.conditions || !clinical?.conditions) return;
+  ds.config.modules = ds.config.conditions
+    .map(
+      (condId) =>
+        clinical.conditions.find((c) => c.id === condId)?.synthea_module,
+    )
+    .filter(Boolean);
 }
 
 /** Render dataset outputs and merge into the files map. */

--- a/libraries/libterrain/src/nodes.js
+++ b/libraries/libterrain/src/nodes.js
@@ -264,7 +264,7 @@ async function generateDatasets(
   logger.info("pipeline", `Generating ${definitions.length} dataset(s)`);
   const datasets = new Map();
   for (const ds of definitions) {
-    resolveDatasetConditions(ds, clinical);
+    const config = resolveDatasetConfig(ds, clinical, logger);
     const tool = toolFactory(ds.tool, { logger });
     try {
       await tool.checkAvailability();
@@ -276,7 +276,7 @@ async function generateDatasets(
       continue;
     }
     const results = await tool.generate({
-      ...ds.config,
+      ...config,
       seed,
       name: ds.id,
     });
@@ -287,14 +287,42 @@ async function generateDatasets(
   return datasets;
 }
 
-function resolveDatasetConditions(ds, clinical) {
-  if (!ds.config.conditions || !clinical?.conditions) return;
-  ds.config.modules = ds.config.conditions
-    .map(
-      (condId) =>
-        clinical.conditions.find((c) => c.id === condId)?.synthea_module,
-    )
-    .filter(Boolean);
+/**
+ * Build the per-dataset config passed to the tool. Resolves clinical
+ * `conditions` to Synthea modules and merges with any modules the DSL
+ * declares explicitly. Returns a shallow copy of `ds.config` — never mutates
+ * the parsed AST node, so re-runs of the datasets stage see the same input.
+ */
+function resolveDatasetConfig(ds, clinical, logger) {
+  const config = { ...ds.config };
+  if (!config.conditions?.length || !clinical?.conditions?.length)
+    return config;
+
+  const resolved = [];
+  for (const condId of config.conditions) {
+    const cond = clinical.conditions.find((c) => c.id === condId);
+    if (cond?.synthea_module) {
+      resolved.push(cond.synthea_module);
+    } else {
+      logger.info(
+        "pipeline",
+        `Dataset '${ds.id}' condition '${condId}' has no synthea_module; skipped`,
+      );
+    }
+  }
+  if (resolved.length === 0) return config;
+
+  const existing = config.modules || [];
+  const seen = new Set(existing);
+  const merged = [...existing];
+  for (const m of resolved) {
+    if (!seen.has(m)) {
+      seen.add(m);
+      merged.push(m);
+    }
+  }
+  config.modules = merged;
+  return config;
 }
 
 /** Render dataset outputs and merge into the files map. */

--- a/libraries/libterrain/test/datasets.test.js
+++ b/libraries/libterrain/test/datasets.test.js
@@ -1,0 +1,137 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { buildNodes } from "../src/nodes.js";
+
+function makeLogger() {
+  return { info: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
+}
+
+/**
+ * Build a fake tool that records the config it was invoked with and produces
+ * an empty result set. Lets tests assert on the `modules` that nodes.js
+ * resolved before calling the tool.
+ */
+function makeRecordingFactory() {
+  const calls = [];
+  function factory() {
+    return {
+      checkAvailability: async () => true,
+      generate: async (config) => {
+        calls.push(config);
+        return [];
+      },
+    };
+  }
+  return { factory, calls };
+}
+
+function runDatasetsNode(parse, { clinical, factory }) {
+  const nodes = buildNodes({
+    dslParser: null,
+    entityGenerator: null,
+    proseGenerator: null,
+    pathwayGenerator: null,
+    renderer: null,
+    validator: null,
+    proseCacheSink: { flush: () => {} },
+    toolFactory: factory,
+    logger: makeLogger(),
+    options: {},
+  });
+  return nodes.datasets.run({ parse: { ...parse, clinical } });
+}
+
+describe("datasets node — condition resolution", () => {
+  test("resolves clinical conditions to Synthea modules", async () => {
+    const { factory, calls } = makeRecordingFactory();
+    const parse = {
+      datasets: [
+        {
+          id: "trial_patients",
+          tool: "synthea",
+          config: { conditions: ["diabetes_t2", "lung_cancer"] },
+        },
+      ],
+      outputs: [],
+      seed: 42,
+    };
+    const clinical = {
+      conditions: [
+        { id: "diabetes_t2", synthea_module: "diabetes" },
+        { id: "lung_cancer", synthea_module: "lung_cancer" },
+      ],
+    };
+
+    await runDatasetsNode(parse, { clinical, factory });
+
+    assert.strictEqual(calls.length, 1);
+    assert.deepStrictEqual(calls[0].modules, ["diabetes", "lung_cancer"]);
+  });
+
+  test("silently skips unknown condition refs", async () => {
+    const { factory, calls } = makeRecordingFactory();
+    const parse = {
+      datasets: [
+        {
+          id: "trial_patients",
+          tool: "synthea",
+          config: { conditions: ["diabetes_t2", "unknown_condition"] },
+        },
+      ],
+      outputs: [],
+      seed: 42,
+    };
+    const clinical = {
+      conditions: [{ id: "diabetes_t2", synthea_module: "diabetes" }],
+    };
+
+    await runDatasetsNode(parse, { clinical, factory });
+
+    assert.deepStrictEqual(calls[0].modules, ["diabetes"]);
+  });
+
+  test("ignores conditions when no clinical block, leaves modules untouched", async () => {
+    const { factory, calls } = makeRecordingFactory();
+    const parse = {
+      datasets: [
+        {
+          id: "trial_patients",
+          tool: "synthea",
+          config: {
+            modules: ["hypertension"],
+            conditions: ["lung_cancer"],
+          },
+        },
+      ],
+      outputs: [],
+      seed: 42,
+    };
+
+    await runDatasetsNode(parse, { clinical: null, factory });
+
+    assert.deepStrictEqual(calls[0].modules, ["hypertension"]);
+    assert.deepStrictEqual(calls[0].conditions, ["lung_cancer"]);
+  });
+
+  test("leaves config.modules untouched when dataset has no conditions field", async () => {
+    const { factory, calls } = makeRecordingFactory();
+    const parse = {
+      datasets: [
+        {
+          id: "trial_patients",
+          tool: "synthea",
+          config: { modules: ["diabetes"] },
+        },
+      ],
+      outputs: [],
+      seed: 42,
+    };
+    const clinical = {
+      conditions: [{ id: "diabetes_t2", synthea_module: "diabetes" }],
+    };
+
+    await runDatasetsNode(parse, { clinical, factory });
+
+    assert.deepStrictEqual(calls[0].modules, ["diabetes"]);
+  });
+});

--- a/libraries/libterrain/test/datasets.test.js
+++ b/libraries/libterrain/test/datasets.test.js
@@ -134,4 +134,51 @@ describe("datasets node — condition resolution", () => {
 
     assert.deepStrictEqual(calls[0].modules, ["diabetes"]);
   });
+
+  test("merges explicit modules with conditions-derived modules, deduped", async () => {
+    const { factory, calls } = makeRecordingFactory();
+    const ds = {
+      id: "trial_patients",
+      tool: "synthea",
+      config: {
+        modules: ["hypertension"],
+        conditions: ["diabetes_t2", "hypertension_dsl"],
+      },
+    };
+    const parse = { datasets: [ds], outputs: [], seed: 42 };
+    const clinical = {
+      conditions: [
+        { id: "diabetes_t2", synthea_module: "diabetes" },
+        // Both DSL conditions can resolve to the same Synthea module —
+        // the merge dedupes so we don't load the same module twice.
+        { id: "hypertension_dsl", synthea_module: "hypertension" },
+      ],
+    };
+
+    await runDatasetsNode(parse, { clinical, factory });
+
+    assert.deepStrictEqual(calls[0].modules, ["hypertension", "diabetes"]);
+    // The parsed AST node must stay clean for any re-run of the stage.
+    assert.deepStrictEqual(ds.config.modules, ["hypertension"]);
+  });
+
+  test("does not mutate parse.datasets[i].config", async () => {
+    const { factory } = makeRecordingFactory();
+    const ds = {
+      id: "trial_patients",
+      tool: "synthea",
+      config: { conditions: ["diabetes_t2"] },
+    };
+    const parse = { datasets: [ds], outputs: [], seed: 42 };
+    const clinical = {
+      conditions: [{ id: "diabetes_t2", synthea_module: "diabetes" }],
+    };
+
+    await runDatasetsNode(parse, { clinical, factory });
+
+    // Original AST node still only carries `conditions`; nothing wrote
+    // `modules` onto it.
+    assert.strictEqual(ds.config.modules, undefined);
+    assert.deepStrictEqual(ds.config.conditions, ["diabetes_t2"]);
+  });
 });

--- a/specs/1190-fhir-microdata-html-output/spec.md
+++ b/specs/1190-fhir-microdata-html-output/spec.md
@@ -1,0 +1,218 @@
+# Spec 1190 — FHIR Microdata HTML Output Format
+
+**JTBD:** Platform Builders / Build Agent-Capable Systems
+(→ [Gear](../../JTBD.md)). When a platform builder generates a synthetic
+healthcare deployment with `fit-terrain` and stands up Guide against it,
+the DSL-declared trials and sites appear in the knowledge graph but the
+generated patients do not — leaving the agent unable to answer queries
+that span the platform's two existing capabilities (synthetic data
+generation and knowledge-graph retrieval).
+
+## Problem
+
+### Evidence — generated patient data is invisible to the knowledge graph
+
+The Guide ingest pipeline consumes Schema.org microdata HTML and emits
+RDF main items, accepting `itemtype` values from `https://schema.org/`
+and `https://www.forwardimpact.team/schema/rdf/`. The terrain pipeline
+already produces such HTML for DSL-declared trials, sites, conditions,
+and clinical knowledge pages (spec 1140 part 7). The Synthea-generated
+patients that fill those trials produce no microdata at all — the
+dataset renderer surface registered through the DSL `output` block
+covers JSON, YAML, CSV, Markdown, Parquet, SQL, plus the spec 1140
+additions `supabase_migration` and `embeddings_jsonl`, none of which
+emit Schema.org-shaped HTML. A platform builder querying Guide for
+"patients enrolled in ONCORA-301" gets back the trial node but no
+patient nodes.
+
+### Evidence — the trial → patient edge is missing
+
+The `clinical {}` block declares trials with `target_enrollment` and
+`current_enrollment` as scalars. The Synthea pipeline emits patients
+whose FHIR `Condition.code.coding[].display` may match the trial's
+declared `conditions` (`filterByConditions` already exploits this
+relationship), yet the rendered trial-card and condition-explainer
+pages link only to other DSL-declared entities. No edge exists in the
+knowledge graph from a trial to a real enrolled patient, so an agent
+cannot answer "show me one patient currently enrolled in this trial."
+
+### Evidence — FHIR-to-Schema.org mapping
+
+Several FHIR resource types map cleanly to Schema.org; others have no
+native fit:
+
+| FHIR | Schema.org type | Mapping quality |
+|------|----------------|-----------------|
+| `Patient` | `Person` | clean — `Person` is the closest Schema.org type and is already accepted by libresource |
+| `Condition` | `MedicalCondition` | clean — already used by spec 1140 part 7 |
+| `Procedure` | `MedicalProcedure` | clean |
+| `MedicationRequest` | `DrugPrescription` | clean |
+| `Encounter` | none | no native Schema.org type |
+| `Observation` | none | no native Schema.org type |
+| `DiagnosticReport` | none | no clean Schema.org type |
+
+The four clean mappings cover what a patient-facing agent surfaces:
+who the patient is, what they have, what was done to them, and what
+they are taking. Encounter / Observation / DiagnosticReport are dense
+auxiliary data; the platform already exposes them through the existing
+tabular formats and they do not need a knowledge-graph edge.
+
+### Who is affected
+
+- **A platform builder standing up the Kata stack with Synthea-backed
+  patient data** — Guide returns trial nodes but no patient nodes,
+  forcing each demo or evaluation app to reimplement a FHIR→microdata
+  bridge.
+- **Spec 1160 (BioNova Finder)** — the in-tree reference implementation
+  consuming this output; without it the demo cannot demonstrate
+  patient-matching against a populated knowledge graph.
+
+## Proposal
+
+### 1. A patient-shaped output format
+
+A new dataset output format that accepts Synthea-produced patient data
+and emits HTML pages whose Schema.org microdata `libresource` extracts
+as RDF main items. Usable in the existing `output` DSL block, the
+format takes a directory path and writes one HTML file per patient plus
+one index file.
+
+### 2. Patient IRI scheme
+
+Patient pages mint stable IRIs under the same `/id/clinical/` namespace
+the DSL `clinical {}` block uses (defined in spec 1140), shaped
+`https://{domain}/id/clinical/patient/{patient_id}`, where `{domain}`
+is the terrain `domain` and `{patient_id}` derives deterministically
+from the FHIR `Patient.id`. The shared namespace is what enables
+cross-references between DSL-declared and synthetically-generated
+entities.
+
+### 3. Resource coverage
+
+The format renders four FHIR resource types as microdata, each carrying
+the Schema.org type from the mapping table:
+
+- `Patient` → `Person`
+- `Condition` → `MedicalCondition`
+- `Procedure` → `MedicalProcedure`
+- `MedicationRequest` → `DrugPrescription`
+
+Each patient page contains exactly one `Person` main item with the
+patient's stable IRI, plus inline microdata items for that patient's
+Conditions, Procedures, and MedicationRequests, related to the patient
+through Schema.org properties such that libresource's RDF extraction
+yields quads connecting the patient IRI to each linked resource.
+
+### 4. Trial → patient cross-references
+
+When a FHIR `Condition` on a generated patient matches a DSL-declared
+`clinical.conditions[].id` (matched by the same rule
+`filterByConditions` uses today — `Condition.code.coding[].code`
+exact match, or `display` normalized to lowercase with whitespace
+replaced by underscore), the patient page links to every trial whose
+`conditions` list contains that id. The reverse link (trial-card →
+patient) is treated separately under proposal §5.
+
+### 5. Reverse cross-links from existing clinical pages
+
+The spec 1140 trial-card, condition-explainer, and site-description
+templates are extended to emit links to every patient whose synthetic
+Condition matches the page's entity, using the same matching rule as
+§4. This is a behavior change to already-rendered output from spec
+1140: when this format is wired up and a Synthea Patient dataset is
+present, those three page types gain new outgoing edges; when no
+Synthea dataset is present, they render identically to before.
+
+### 6. Aggregate index
+
+A single `index.html` at the configured path listing every patient
+with name and condition summary, sufficient for Guide's crawler to
+discover the per-Patient pages without requiring filesystem listings.
+
+## Scope
+
+### Included
+
+- A new `output` format keyword usable in DSL `output` blocks against
+  a Synthea-produced Patient dataset.
+- Rendering of per-Patient HTML pages and an index page covering the
+  four FHIR resource types from §3.
+- Trial → patient cross-references on the new patient pages (§4).
+- Reverse patient → trial / patient → site links on the existing spec
+  1140 templates (§5).
+- An end-to-end test that runs Synthea, renders the format, parses the
+  output through libresource's microdata parser, and asserts the
+  expected items and cross-references appear in the extracted RDF.
+
+### Excluded
+
+- `Encounter`, `Observation`, `DiagnosticReport`, `Claim`,
+  `ExplanationOfBenefit`, `Immunization`, `AllergyIntolerance`, and
+  other FHIR resource types not listed in §3.
+- A FHIR-as-RDF (Turtle / JSON-LD / N-Triples) output format —
+  separate concern, deferred until a SPARQL-consuming downstream
+  exists.
+- LLM-enriched patient prose summaries — patient pages stay
+  deterministic at this scope; enrichment can be added later without
+  changing the output contract.
+- Modifications to libresource or Guide's ingest pipeline — Schema.org
+  microdata is the existing contract; this spec produces compliant
+  output, not new ingest behavior.
+- Changes to Synthea's `filterByConditions` or to how clinical
+  conditions resolve to Synthea modules — that pipeline stage stays
+  unchanged.
+- A generalization to non-FHIR datasets — the format is specific to
+  Synthea-shaped patient data; other tools (faker, sdv) keep their
+  existing renderer surface.
+
+## Success Criteria
+
+1. A DSL file declaring a Synthea dataset with this output format
+   produces one HTML file per patient plus one index file under the
+   configured path. Verify: `bun test` in `libsyntheticrender` passes
+   a fixture-based test asserting one file per FHIR Patient record
+   plus exactly one `index.html`.
+
+2. Every per-Patient page contains exactly one Schema.org main item
+   typed `Person` with `itemid` matching `https://{domain}/id/clinical/patient/{patient_id}`.
+   Verify: parsing the rendered HTML through libresource's
+   `Parser.parseHTML()` returns exactly one main item per file whose
+   `itemtype` is `https://schema.org/Person` and whose IRI shape
+   matches the pattern.
+
+3. Each patient page produces inline microdata items for that
+   patient's Conditions, Procedures, and MedicationRequests, related
+   through Schema.org properties to the patient. Verify: RDF quads
+   extracted by `libresource` include subject=patient-IRI predicates
+   linking to each `MedicalCondition`, `MedicalProcedure`, and
+   `DrugPrescription` item rendered on that page.
+
+4. When a FHIR Condition matches a DSL-declared
+   `clinical.conditions[].id` under the §4 matching rule, the patient
+   page emits a link to every trial whose `conditions` list contains
+   that id. Verify: integration test seeds a clinical block with a
+   condition and a trial referencing it, runs Synthea, asserts the
+   rendered patient page's extracted RDF contains a quad from the
+   patient IRI to the trial IRI.
+
+5. The spec 1140 trial-card, condition-explainer, and site-description
+   pages emit reverse links to matching patients when a Synthea
+   Patient dataset is present. Verify: extending the spec 1140 clinical
+   HTML test suite, assert that when the test fixture includes a
+   matching synthetic patient, the trial-card page's extracted RDF
+   contains a quad from the trial IRI to the patient IRI.
+
+6. Running the libresource parser stack against the rendered output
+   produces an RDF graph where the patient IRI and the matching trial
+   IRI are connected by at least one quad in each direction. Verify:
+   the end-to-end test calls `libresource`'s `Parser.parseHTML()` on
+   both the per-Patient page and the trial-card page, asserts the
+   expected quads exist by inspecting the returned items.
+
+7. Terrain DSL files that do not wire this new format produce output
+   byte-identical to before. Verify: `bun test` covers a regression
+   fixture that exercises the spec 1140 clinical block without the
+   new output format and asserts each rendered file matches a stored
+   snapshot. The §5 reverse-link addition fires only when a Synthea
+   Patient dataset is rendered through this format; absent that, the
+   1140 pages render unchanged.


### PR DESCRIPTION
## Summary

- **Spec 1140 parts 6-8** — dataset evolution (DSL `conditions` field on Synthea datasets, resolved to modules via the `clinical {}` block), 7 patient-facing HTML templates with Schema.org microdata wired through `renderHTML()`, and Synthea operationalization (`just synthea-install` / `synthea-status`, JAR default path, FHIR `filterByConditions` post-processing).
- **Spec 1190** — proposes a new `fhir_microdata_html` output format that emits per-Patient pages Guide's knowledge-graph ingest can crawl, mints patient IRIs under the same `/id/clinical/` namespace the DSL `clinical {}` block uses, and adds reverse trial → enrolled-patient edges so the knowledge graph closes the loop between DSL-declared trials and Synthea-generated patients.

Review-panel-driven fixes folded in:
- `filterByConditions` now walks `subject.reference` first (handling both `urn:uuid:` and `Patient/<id>` forms) and only falls back to `r.id` for Patient itself, so Conditions / Encounters / Observations linked to matched patients survive filtering. Verified end-to-end against a real 8-patient Synthea run.
- `resolveDatasetConfig` returns a fresh config and merges explicit `modules` with conditions-derived modules instead of overwriting; the parsed AST is never mutated.
- `entities.clinical.content` propagates from the AST so patient-story and therapy-description prose keys actually emit in real runs.
- Template optional metas guarded with `{{#field}}…{{/field}}`; `riskFactor` swapped for `status` (Schema.org `riskFactor` is risk-of-developing, not severity); clinical prose blocks use `{{{prose}}}` so the patient-facing prompt's inline microdata lands as live spans.

## Test plan

- [x] `bun run check` — green
- [x] `bun test libraries/libsyntheticgen libraries/libterrain libraries/libsyntheticrender` — 303 pass / 0 fail
- [x] Live Synthea integration verified: 8 patients → 2 carrying `acute_bronchitis_(disorder)` after `filterByConditions`, with 32 Conditions / 45 Encounters / 327 Observations correctly retained for those patients only
- [x] `just synthea-install && just synthea-status` works end-to-end (175 MB JAR, Java 21)

STATUS rows updated: `1140 plan implemented`, `1190 spec approved`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxCCApo7aihBZpLTzxBqxg)_