### PR TITLE
docs(fit-terrain): document clinical domain, Synthea install, new output formats

### DIFF
--- a/.claude/skills/fit-terrain/SKILL.md
+++ b/.claude/skills/fit-terrain/SKILL.md
@@ -28,6 +28,13 @@ rendering into multiple output formats.
 - Producing organizational documents, activity records, and KB content
 - Testing pipeline changes end-to-end with synthetic data
 
+**Build a healthcare deployment:**
+
+- Declaring trials, sites, and conditions in a `clinical {}` DSL block
+- Generating Synthea-backed patient cohorts filtered to those conditions
+- Rendering patient-facing prose and Schema.org `MedicalCondition` /
+  `MedicalTrial` / `MedicalClinic` microdata pages
+
 ---
 
 ## How It Works
@@ -36,19 +43,25 @@ rendering into multiple output formats.
 
 Generation flows through four stages:
 
-1. **DSL parsing** — the terrain file is tokenized and parsed into an AST
-   containing organizational hierarchy, people, projects, agent-aligned
-   engineering standard definitions, and content specifications
-2. **Entity generation** — the AST is expanded deterministically (using a seeded
-   RNG) into a full entity graph: orgs, departments, teams, people with roles
-   and skill assignments, repos, and projects
-3. **Prose generation** — prose keys are collected from the entity graph (one
-   per article, FAQ, briefing, etc.) with context (topic, tone, length). The
-   `build` verb reads from `prose-cache.json`; the `generate` verb sends each
-   key to an LLM and writes the result back to the cache before building
-4. **Rendering** — entities and prose are rendered into output formats: YAML
-   standard files (`pathway`), HTML articles (`html`), JSON/YAML activity
-   records (`raw`), and Markdown briefings (`markdown`)
+1. **DSL parsing** — the terrain file is parsed into an AST containing the
+   org hierarchy, people, projects, engineering-standard definitions, content
+   specs, and optionally a `clinical {}` domain (conditions, sites, trials,
+   criteria, content keys).
+2. **Entity generation** — the AST is expanded deterministically (seeded RNG)
+   into a full entity graph: orgs, departments, teams, people, repos,
+   projects, and — when `clinical {}` is present — conditions, sites, trials,
+   criteria, and researchers with bidirectional cross-references.
+3. **Prose generation** — prose keys are collected (one per article, FAQ,
+   briefing, condition explainer, trial FAQ, etc.) with context (topic, tone,
+   length). The `build` verb reads from `prose-cache.json`; `generate` sends
+   each key to an LLM and writes the result back to the cache before
+   building. Clinical prose uses a medical-communications system prompt.
+4. **Rendering** — entities and prose render into YAML standard files
+   (`pathway`), HTML articles + clinical pages with Schema.org microdata
+   (`html`), JSON/YAML activity records (`raw`), Markdown briefings
+   (`markdown`). External `dataset` blocks emit through `output` blocks to
+   formats including JSON, CSV, Parquet, SQL, `supabase_migration`, and
+   `embeddings_jsonl`.
 
 ### Content Validation
 
@@ -59,19 +72,15 @@ schemas.
 
 ### Prose Caching
 
-The prose cache maps each content key to its generated text. The `build` verb
-reads from the cache, making generation fully repeatable without LLM calls. The
-`generate` verb regenerates all entries and writes the updated cache, then runs
-the same render+write the `build` verb performs.
+The prose cache maps each content key to its generated text. `build` reads
+from the cache (no LLM calls). `generate` regenerates entries and writes the
+updated cache, then runs the same render+write as `build`.
 
-Structured pathway entities (agent-aligned engineering standard, levels,
-behaviours, capabilities, etc.) use a stable cache key derived from the entity
-key alone (e.g. `pathway:track:platform`). This means prompt changes (such as
-adding context forwarding or updating preambles) do not invalidate existing
-cache entries — use `fit-terrain generate` to regenerate with updated prompts.
-
-General prose entries (articles, comments, briefings) use a cache key that
-includes the content context (topic, tone, length).
+Structured pathway entities use a stable cache key derived from the entity
+key alone (e.g. `pathway:track:platform`), so prompt changes (such as
+preamble updates) do not invalidate existing entries — use `generate` to
+refresh them. General prose entries (articles, comments, briefings) use a
+cache key that includes the content context (topic, tone, length).
 
 ### Output Cleanup
 
@@ -133,6 +142,13 @@ ANTHROPIC_API_KEY=<your-key> npx fit-terrain generate
 
 The `check`, `validate`, and `build` verbs require no LLM credentials — they
 read from the prose cache.
+
+DSL files that declare a Synthea `dataset` block also need Java 11+ on
+`PATH` and the Synthea JAR available via `SYNTHEA_JAR` (or in the default
+`vendor/synthea/synthea-with-dependencies.jar` location). When either is
+missing the pipeline logs an "unavailable" line and skips the Synthea block
+— it does not fail the run. See
+[`references/datasets.md`](references/datasets.md) for the one-time install.
 
 ---
 

--- a/.claude/skills/fit-terrain/references/cli.md
+++ b/.claude/skills/fit-terrain/references/cli.md
@@ -29,12 +29,15 @@ Run `npx fit-terrain <verb> --help` for verb-scoped options.
 
 `build --only=<type>` renders a single content type:
 
-| Type       | Output Directory | Contents                        |
-| ---------- | ---------------- | ------------------------------- |
-| `html`     | `data/knowledge` | Articles, guides, FAQs, courses |
-| `pathway`  | `data/pathway`   | YAML standard files             |
-| `raw`      | `data/activity`  | Roster, GitHub events, evidence |
-| `markdown` | `data/personal`  | Briefings, notes, KB content    |
+| Type       | Output Directory | Contents                                                            |
+| ---------- | ---------------- | ------------------------------------------------------------------- |
+| `html`     | `data/knowledge` | Articles, guides, FAQs, courses; plus the seven clinical pages when the DSL declares a `clinical {}` block |
+| `pathway`  | `data/pathway`   | YAML standard files                                                 |
+| `raw`      | `data/activity`  | Roster, GitHub events, evidence                                     |
+| `markdown` | `data/personal`  | Briefings, notes, KB content                                        |
+
+Dataset outputs (declared via `output` blocks in the DSL) are written
+regardless of `--only` to the paths each `output` block names.
 
 ### Global Flags
 

--- a/.claude/skills/fit-terrain/references/datasets.md
+++ b/.claude/skills/fit-terrain/references/datasets.md
@@ -1,17 +1,117 @@
 # Dataset Blocks
 
-The terrain DSL may include `dataset` and `output` blocks that use external
-tools (Synthea, SDV, Faker). Unavailable tools are automatically skipped with an
-info log — the pipeline continues and writes all other generated files normally.
+The terrain DSL may include `dataset` and `output` blocks that invoke
+external tools (Faker, Synthea, SDV). Unavailable tools are skipped with an
+info log — the pipeline continues and writes all other generated files.
 
-Tool availability:
+| Tool    | Requirement              | Always available? |
+| ------- | ------------------------ | ----------------- |
+| Faker   | Built-in (pure JS)       | Yes               |
+| Synthea | Java 11+ and the JAR     | No                |
+| SDV     | Python with `sdv` module | No                |
 
-| Tool    | Requirement         | Always available? |
-| ------- | ------------------- | ----------------- |
-| Faker   | Built-in (pure JS)  | Yes               |
-| Synthea | Java + JAR file     | No                |
-| SDV     | Python + sdv module | No                |
+The `--only` flag gates render types (html, pathway, raw, markdown). It does
+**not** affect dataset generation.
 
-**Note:** The `--only` flag gates which render types execute (html, pathway,
-raw, markdown). It does **not** affect dataset generation — datasets run when
-present in the DSL but skip gracefully if the tool is unavailable.
+## Installing Synthea
+
+Download the JAR once, set `SYNTHEA_JAR`:
+
+```sh
+mkdir -p vendor/synthea
+curl -fSL \
+  -o vendor/synthea/synthea-with-dependencies.jar \
+  https://github.com/synthetichealth/synthea/releases/download/v3.3.0/synthea-with-dependencies.jar
+export SYNTHEA_JAR="$(pwd)/vendor/synthea/synthea-with-dependencies.jar"
+```
+
+`fit-terrain` checks `SYNTHEA_JAR` first, then falls back to
+`vendor/synthea/synthea-with-dependencies.jar` relative to the working
+directory. Confirm `java -version` reports 11 or newer.
+
+## Dataset Block Reference
+
+A `dataset` block names the generator tool and its config; an `output` block
+names a dataset and renders it to a file format.
+
+```dsl
+dataset trial_patients {
+  tool synthea
+  population 100
+  conditions [diabetes_t2, hypertension]
+}
+
+output trial_patients_patient json    { path "output/patients.json" }
+output trial_patients_patient parquet { path "output/patients.parquet" }
+```
+
+### Synthea fields
+
+| Field        | Type     | Purpose                                              |
+| ------------ | -------- | ---------------------------------------------------- |
+| `tool`       | ident    | Must be `synthea`                                    |
+| `population` | number   | Patient count to request from Synthea                |
+| `modules`    | ident[]  | Synthea modules to enable (optional)                 |
+| `conditions` | ident[]  | DSL `clinical.condition` ids; resolved to modules and used to keep only patients carrying a matching FHIR Condition |
+
+When the DSL contains a `clinical {}` block, each id in `conditions` is
+looked up against `clinical.condition.{id}.synthea_module`. The resolved
+modules merge with any explicit `modules` entries. After Synthea runs,
+patients whose FHIR `Condition` resources do not match any of the requested
+conditions are dropped from the output, along with the Encounter,
+Observation, and other linked resources belonging to those patients.
+
+When the DSL has no `clinical {}` block, `conditions` is ignored and only
+`modules` controls Synthea's module set; no post-generation filtering runs.
+
+### Faker fields
+
+| Field    | Type   | Purpose                                          |
+| -------- | ------ | ------------------------------------------------ |
+| `tool`   | ident  | Must be `faker`                                  |
+| `rows`   | number | Record count                                     |
+| `fields` | block  | Map of field name to Faker namespace path        |
+
+### SDV fields
+
+| Field      | Type   | Purpose                                       |
+| ---------- | ------ | --------------------------------------------- |
+| `tool`     | ident  | Must be `sdv`                                 |
+| `metadata` | string | Path to SDV metadata JSON                     |
+| `data`     | block  | Map of table name to CSV file path            |
+| `rows`     | number | Synthetic record count per table              |
+
+## Output Formats
+
+The `output` block routes a dataset through a format-specific renderer.
+
+| Format               | Output                                                            |
+| -------------------- | ----------------------------------------------------------------- |
+| `json`               | Single JSON file with the records as an array                     |
+| `yaml`               | YAML document                                                     |
+| `csv`                | One CSV file with header row                                      |
+| `markdown`           | Markdown table                                                    |
+| `parquet`            | Apache Parquet binary file                                        |
+| `sql`                | Single SQL `INSERT` statement                                     |
+| `supabase_migration` | Numbered SQL migration files (CREATE TABLE + INSERT + RLS) applicable via `supabase db push` |
+| `embeddings_jsonl`   | JSONL where each line is `{ id, table, text }`, ready for vector embedding |
+
+`supabase_migration` and `embeddings_jsonl` are the natural fit for clinical
+datasets: the first lands schemas + seed data in a Supabase project; the
+second produces text blocks combining entity fields with cached prose for
+downstream embedding into pgvector or another vector store.
+
+## Output Naming for Synthea Datasets
+
+Synthea produces one underlying dataset per FHIR resource type
+(`Patient`, `Condition`, `Encounter`, `Observation`, etc.), so a single
+`dataset trial_patients { tool synthea }` block fans out into
+`trial_patients_patient`, `trial_patients_condition`,
+`trial_patients_encounter`, and so on. Reference each one in its own
+`output` block:
+
+```dsl
+output trial_patients_patient    json { path "output/patients.json" }
+output trial_patients_condition  json { path "output/conditions.json" }
+output trial_patients_encounter  json { path "output/encounters.json" }
+```

--- a/.claude/skills/fit-terrain/references/dsl.md
+++ b/.claude/skills/fit-terrain/references/dsl.md
@@ -1,9 +1,7 @@
 # Terrain DSL
 
-Terrain files define a complete synthetic environment. This monorepo's terrain
-DSL is at `data/synthetic/story.dsl`. A minimal reference DSL ships with
-libsyntheticgen at `libraries/libsyntheticgen/data/default.dsl` for quick
-testing; projects provide their own DSL file.
+Terrain files define a complete synthetic environment. A minimal reference DSL
+ships with the package; projects supply their own DSL file via `--story=path`.
 
 ### Top-Level Blocks
 
@@ -20,29 +18,110 @@ terrain Name {
   project alpha { ... }
   snapshots { ... }
   scenario launch_push { ... }
-  agent-aligned engineering standard { ... }
+  standard { ... }
   content guide_html { ... }
   content outpost_markdown { ... }
+
+  clinical { ... }      // optional — patient/trial domain
+
+  dataset patients { ... }
+  output patients_patient json { ... }
 }
 ```
 
 ### Key Blocks
 
-**org / department / team** — Organizational hierarchy with headcounts,
-managers, and repo assignments.
+| Block | Role |
+| ----- | ---- |
+| `org` / `department` / `team` | Hierarchy with headcounts, managers, repos |
+| `people` | Count, name theme, level + discipline distributions |
+| `project` | Cross-team initiatives with timelines and prose topics |
+| `snapshots` | GetDX snapshot generation (quarterly intervals) |
+| `scenario` | Time-bounded team effects (commit volume, DX trajectories, evidence) |
+| `standard` | Pathway engineering standard: levels, capabilities, behaviours, disciplines, tracks, drivers |
+| `content` | Article/blog/FAQ counts, persona configs, briefing counts |
+| `clinical` | Optional patient-and-trial domain — see § Clinical Block |
+| `dataset` / `output` | Faker, Synthea, SDV inputs and rendered formats — see [`datasets.md`](datasets.md) |
 
-**people** — Count, name theme, level distribution, discipline distribution.
+---
 
-**project** — Cross-team initiatives with timelines and prose topics.
+## Clinical Block
 
-**snapshots** — GetDX snapshot generation (quarterly intervals).
+The `clinical {}` block declares a patient-and-trial domain that maps onto
+Synthea-backed patient data and patient-facing prose. Only
+`trial.principal_investigator` and `site.org` link it to the org graph.
 
-**scenario** — Time-bounded effects on teams (commit volume, DX driver
-trajectories, evidence generation).
+```dsl
+clinical {
+  condition diabetes_t2 {
+    name "Type 2 Diabetes"
+    icd10 ["E11"]
+    synonyms ["high blood sugar"]
+    synthea_module diabetes
+    severity chronic
+    prose_topic "diabetes for patients"
+    prose_tone "empathetic"
+  }
 
-**agent-aligned engineering standard** — Full pathway agent-aligned engineering
-standard: levels, capabilities with skills, behaviours, disciplines with skill
-tiers, tracks, drivers, and stages.
+  site cambridge {
+    name "Cambridge Medical Center"
+    city "Cambridge" state "MA"
+    org headquarters
+    specialties ["endocrinology"]
+  }
 
-**content** — Output content blocks specifying article/blog/FAQ counts, persona
-configurations, and briefing counts.
+  trial oncora_p3 {
+    name "ONCORA-301"
+    phase "phase_3"
+    conditions [diabetes_t2]
+    sites [cambridge]
+    principal_investigator @sarah_chen
+    sponsor "Acme Bio"
+    status "recruiting"
+    target_enrollment 450
+    start_date 2025-03
+    estimated_end_date 2027-06
+    criteria { inclusion { age_min 18 age_max 75 } }
+  }
+
+  content {
+    condition_explainers per_condition
+    trial_faqs per_trial
+    consent_summaries per_trial
+    patient_stories 4
+    patient_story_conditions [diabetes_t2]
+  }
+}
+```
+
+### Sub-blocks
+
+- **condition** — ICD-10, synonyms, `synthea_module` (so `dataset.conditions`
+  resolves to a Synthea module), optional `prose_topic` / `prose_tone`.
+- **site** — `org` references an org id from the parent terrain.
+- **trial** — `principal_investigator @name` references a `people` manager;
+  `project` optionally references a project id; `conditions` and `sites` are
+  ids from this block; `criteria { inclusion {} exclusion {} }` declares
+  eligibility.
+- **content** — Counts accept a number or one of `per_condition`,
+  `per_trial`, `per_site` (scales with declared entities).
+
+### Cross-domain references
+
+| From | To | Resolved at |
+| ---- | -- | ----------- |
+| `trial.principal_investigator` | person (manager) | entity generation |
+| `trial.project` | project id | entity generation |
+| `site.org` | org id | entity generation |
+| `dataset.conditions[]` | clinical.condition.id → `synthea_module` | dataset stage |
+
+### Rendered output
+
+A `clinical {}` block adds seven HTML files under the knowledge output
+directory (`condition-explainers`, `therapy-descriptions`, `trial-faqs`,
+`consent-summaries`, `site-descriptions`, `patient-stories`, `trial-cards`),
+each carrying Schema.org microdata (`MedicalCondition`, `MedicalTrial`,
+`MedicalClinic`, `MedicalTherapy`) the Guide knowledge-graph ingest crawls.
+
+Patient-facing prose uses a medical-communications system prompt; the
+existing `generate` verb and prose cache cover it without extra flags.

--- a/websites/fit/docs/libraries/prove-changes/generate-dataset/index.md
+++ b/websites/fit/docs/libraries/prove-changes/generate-dataset/index.md
@@ -79,6 +79,84 @@ levels is shown in the
 The `seed` field makes the entity graph deterministic -- the same seed produces
 the same people, assignments, and proficiency ratings on every run.
 
+For healthcare deployments, add a `clinical {}` block declaring conditions,
+sites, and trials. The pipeline then generates a parallel patient-and-trial
+entity graph, emits seven patient-facing HTML pages with Schema.org
+`MedicalCondition` / `MedicalTrial` / `MedicalClinic` microdata, and resolves
+`dataset.conditions [...]` references to the Synthea modules that filter
+generated patient cohorts:
+
+```dsl
+clinical {
+  condition diabetes_t2 {
+    name "Type 2 Diabetes"
+    icd10 ["E11"]
+    synthea_module diabetes
+    severity chronic
+  }
+
+  site cambridge {
+    name "Cambridge Medical Center"
+    city "Cambridge"
+    state "MA"
+    org headquarters
+    specialties ["endocrinology"]
+  }
+
+  trial oncora_p3 {
+    name "ONCORA-301"
+    phase "phase_3"
+    conditions [diabetes_t2]
+    sites [cambridge]
+    principal_investigator @sarah_chen
+    sponsor "Acme Bio"
+    status "recruiting"
+    target_enrollment 450
+    start_date 2025-03
+    estimated_end_date 2027-06
+
+    criteria {
+      inclusion { age_min 18 age_max 75 conditions_required [diabetes_t2] }
+    }
+  }
+
+  content {
+    condition_explainers per_condition
+    trial_faqs per_trial
+    consent_summaries per_trial
+    patient_stories 4
+    patient_story_conditions [diabetes_t2]
+  }
+}
+
+dataset trial_patients {
+  tool synthea
+  population 100
+  conditions [diabetes_t2]
+}
+
+output trial_patients_patient   json { path "output/patients.json" }
+output trial_patients_condition json { path "output/conditions.json" }
+```
+
+`synthea_module` maps each DSL condition to a Synthea module name. The
+`dataset.conditions` field resolves through those mappings and is also used
+to post-filter the generated cohort to patients carrying a matching FHIR
+`Condition` resource.
+
+Synthea needs Java 11+ and the `synthea-with-dependencies.jar` available at
+`$SYNTHEA_JAR` (or in `vendor/synthea/` relative to the working directory).
+Without either, the dataset stage logs an "unavailable" line and skips the
+block — the rest of the pipeline still runs:
+
+```sh
+mkdir -p vendor/synthea
+curl -fSL \
+  -o vendor/synthea/synthea-with-dependencies.jar \
+  https://github.com/synthetichealth/synthea/releases/download/v3.3.0/synthea-with-dependencies.jar
+export SYNTHEA_JAR="$(pwd)/vendor/synthea/synthea-with-dependencies.jar"
+```
+
 ## Generate the dataset
 
 Run `generate` to fill the prose cache and build all output:
@@ -89,20 +167,20 @@ npx fit-terrain generate --story=evals/terrain/story.dsl
 
 The pipeline walks a DAG of stages in dependency order:
 
-| Stage          | What it does                                                  |
-| -------------- | ------------------------------------------------------------- |
-| `parse`        | Reads and parses the DSL file                                 |
-| `entities`     | Generates the organization graph, people, and assignments     |
-| `prose-keys`   | Collects every key that needs prose (bios, summaries, reviews)|
-| `cache-lookup` | Resolves each key through an LLM, caching results to disk    |
-| `skeleton`     | Renders deterministic HTML structure for knowledge documents  |
-| `enriched`     | Fills the skeleton with cached prose                          |
-| `raw`          | Renders raw activity documents                                |
-| `markdown`     | Renders personal markdown documents                           |
-| `pathway`      | Renders engineering standard YAML from the `standard` block   |
-| `datasets`     | Runs any external dataset tools (Faker, Synthea, SDV)         |
-| `validate`     | Checks entity consistency and HTML structure                  |
-| `write`        | Merges all output and writes to disk                          |
+| Stage          | What it does                                                                |
+| -------------- | --------------------------------------------------------------------------- |
+| `parse`        | Reads and parses the DSL file                                               |
+| `entities`     | Generates the organization graph, people, assignments — and, when the DSL declares a `clinical {}` block, also the conditions, sites, trials, criteria, and researchers |
+| `prose-keys`   | Collects every key that needs prose (bios, summaries, reviews, condition explainers, trial FAQs, consent summaries) |
+| `cache-lookup` | Resolves each key through an LLM, caching results to disk                   |
+| `skeleton`     | Renders deterministic HTML structure for knowledge documents and patient-facing clinical pages |
+| `enriched`     | Fills the skeleton with cached prose                                        |
+| `raw`          | Renders raw activity documents                                              |
+| `markdown`     | Renders personal markdown documents                                         |
+| `pathway`      | Renders engineering standard YAML from the `standard` block                 |
+| `datasets`     | Runs any external dataset tools (Faker, Synthea, SDV); resolves the `dataset.conditions` field against the clinical block when both are present |
+| `validate`     | Checks entity consistency and HTML structure                                |
+| `write`        | Merges all output and writes to disk                                        |
 
 The prose cache persists to `data/synthetic/prose-cache.json` by default.
 Subsequent runs with the same DSL reuse cached prose, so only new or changed
@@ -114,10 +192,18 @@ After the run completes, the `data/` directory contains the full dataset:
 data/
   pathway/          Engineering standard YAML (capabilities, levels, disciplines)
   knowledge/        HTML knowledge-base documents with microdata
+                    (plus seven patient-facing pages when the DSL declares a clinical {} block)
   personal/         Personal markdown documents
   activity/         Activity records and evidence
   synthetic/        Prose cache
 ```
+
+Datasets declared via `dataset` + `output` blocks land at the paths each
+`output` block names. Available output formats include `json`, `yaml`,
+`csv`, `markdown`, `parquet`, `sql`, plus `supabase_migration` (numbered
+SQL files applicable via `supabase db push`) and `embeddings_jsonl` (one
+JSON object per line, combining entity fields with cached prose, ready for
+vector embedding).
 
 ## Verify without regenerating
 

--- a/websites/fit/docs/libraries/prove-changes/index.md
+++ b/websites/fit/docs/libraries/prove-changes/index.md
@@ -131,9 +131,13 @@ terrain Acme {
 ```
 
 The DSL supports additional blocks -- `project`, `scenario`, `snapshots`,
-`content`, `dataset`, and `output` -- that add projects, time-based scenarios,
-external tool-generated datasets (Synthea, SDV, Faker), and rendered output
-files. Start small and add blocks as your evaluation demands more context.
+`content`, `clinical`, `dataset`, and `output` -- that add projects,
+time-based scenarios, a patient-and-trial domain with Schema.org microdata
+output, external tool-generated datasets (Synthea, SDV, Faker), and rendered
+output files. Start small and add blocks as your evaluation demands more
+context. See the
+[Generate an Eval Dataset](/docs/libraries/prove-changes/generate-dataset/)
+guide for examples of each.
 
 ## 2. Generate and validate the dataset
 


### PR DESCRIPTION
## Summary

Brings the published `fit-terrain` skill and the `prove-changes` guides on www.forwardimpact.team into line with the spec 1140 capabilities now on main:

- `clinical {}` DSL block — conditions, sites, trials with criteria, cross-domain refs (`trial → person`, `site → org`, `dataset.conditions → synthea_module`), and the content sub-block driving patient-facing prose
- Seven clinical HTML pages rendered with Schema.org microdata (`MedicalCondition`, `MedicalTrial`, `MedicalClinic`, `MedicalTherapy`)
- `supabase_migration` and `embeddings_jsonl` output formats
- Generic Synthea install — `curl` the JAR from the upstream releases page and set `SYNTHEA_JAR` — replacing the internal `just synthea-install` recipe for external users
- Pipeline stage table refreshed to reflect clinical entity generation and `conditions` → module resolution

External-only audience: no monorepo paths, no `just`/`bun` invocations, no internal recipe references.

## Test plan

- [x] `bun run check` — green (line/word budgets respected on SKILL.md and references)
- [x] Skill ↔ CLI `documentation[]` parity preserved (same two URLs, same order)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxCCApo7aihBZpLTzxBqxg)_