### PR TITLE
test(spec-1140): complete missing parts 4-5 + fix 3 bugs surfaced by testing

### DIFF
--- a/libraries/libsyntheticgen/src/dsl/parser-standard.js
+++ b/libraries/libsyntheticgen/src/dsl/parser-standard.js
@@ -24,7 +24,7 @@ export function createStandardParsers(helpers) {
     parseArray,
   } = helpers;
 
-  const { consumeFields } = createDispatchHelpers(helpers);
+  const { consumeFields, parseMappedArrays } = createDispatchHelpers(helpers);
 
   /**
    * Parse a brace-delimited block of keyword–value pairs using a dispatch
@@ -225,6 +225,8 @@ export function createStandardParsers(helpers) {
     "markdown",
     "parquet",
     "sql",
+    "supabase_migration",
+    "embeddings_jsonl",
   ]);
 
   function parseDatasetFields() {
@@ -283,6 +285,31 @@ export function createStandardParsers(helpers) {
     return ds;
   }
 
+  function parseBooleanIdent() {
+    return parseStringOrIdent() === "true";
+  }
+
+  const OUTPUT_DISPATCH = {
+    path: (out) => {
+      out.config.path = parseStringValue();
+    },
+    table: (out) => {
+      out.config.table = parseStringValue();
+    },
+    prefix: (out) => {
+      out.config.prefix = parseStringValue();
+    },
+    entities: (out) => {
+      out.config.entities = parseArray();
+    },
+    include_embeddings: (out) => {
+      out.config.include_embeddings = parseBooleanIdent();
+    },
+    text_fields: (out) => {
+      out.config.text_fields = parseMappedArrays("text_fields");
+    },
+  };
+
   function parseOutput(datasetId) {
     const format = parseStringOrIdent();
     if (!DATASET_FORMATS.has(format)) {
@@ -292,16 +319,10 @@ export function createStandardParsers(helpers) {
     }
     expect("LBRACE");
     const out = { dataset: datasetId, format, config: {} };
-    while (peek().type !== "RBRACE") {
-      const kw = advance();
-      if (kw.value === "path") out.config.path = parseStringValue();
-      else if (kw.value === "table") out.config.table = parseStringValue();
-      else
-        throw new Error(
-          `Unexpected '${kw.value}' in output at line ${kw.line}`,
-        );
-    }
-    expect("RBRACE");
+    consumeFields(OUTPUT_DISPATCH, "output", {
+      target: out,
+      consumeRBrace: true,
+    });
     return out;
   }
 

--- a/libraries/libsyntheticgen/test/parser-dataset.test.js
+++ b/libraries/libsyntheticgen/test/parser-dataset.test.js
@@ -82,14 +82,84 @@ describe("dataset and output parsing", () => {
     assert.strictEqual(ast.outputs[1].config.table, "my_claims");
   });
 
-  test("parses all six output formats", () => {
-    const formats = ["json", "yaml", "csv", "markdown", "parquet", "sql"];
+  test("parses all eight output formats", () => {
+    const formats = [
+      "json",
+      "yaml",
+      "csv",
+      "markdown",
+      "parquet",
+      "sql",
+      "supabase_migration",
+      "embeddings_jsonl",
+    ];
     for (const fmt of formats) {
       const ast = parseDsl(
         `terrain test { output ds ${fmt} { path "out/file" } }`,
       );
       assert.strictEqual(ast.outputs[0].format, fmt);
     }
+  });
+
+  test("parses supabase_migration output config", () => {
+    const ast = parseDsl(`terrain test {
+      output clinical supabase_migration {
+        prefix "bionova"
+        entities [clinical.conditions, clinical.sites, clinical.trials]
+        include_embeddings true
+      }
+    }`);
+    const out = ast.outputs[0];
+    assert.strictEqual(out.format, "supabase_migration");
+    assert.strictEqual(out.config.prefix, "bionova");
+    assert.deepStrictEqual(out.config.entities, [
+      "clinical.conditions",
+      "clinical.sites",
+      "clinical.trials",
+    ]);
+    assert.strictEqual(out.config.include_embeddings, true);
+  });
+
+  test("include_embeddings defaults to false when set to 'false'", () => {
+    const ast = parseDsl(`terrain test {
+      output clinical supabase_migration {
+        prefix "x"
+        entities [clinical.conditions]
+        include_embeddings false
+      }
+    }`);
+    assert.strictEqual(ast.outputs[0].config.include_embeddings, false);
+  });
+
+  test("parses embeddings_jsonl output with text_fields", () => {
+    const ast = parseDsl(`terrain test {
+      output clinical embeddings_jsonl {
+        path "out/embed.jsonl"
+        entities [clinical.conditions, clinical.trials]
+        text_fields {
+          clinical.conditions [name, synonyms, prose_explainer]
+          clinical.trials [name, therapeutic_area, arms, prose_description]
+        }
+      }
+    }`);
+    const out = ast.outputs[0];
+    assert.strictEqual(out.format, "embeddings_jsonl");
+    assert.strictEqual(out.config.path, "out/embed.jsonl");
+    assert.deepStrictEqual(out.config.entities, [
+      "clinical.conditions",
+      "clinical.trials",
+    ]);
+    assert.deepStrictEqual(out.config.text_fields["clinical.conditions"], [
+      "name",
+      "synonyms",
+      "prose_explainer",
+    ]);
+    assert.deepStrictEqual(out.config.text_fields["clinical.trials"], [
+      "name",
+      "therapeutic_area",
+      "arms",
+      "prose_description",
+    ]);
   });
 
   test("throws on unknown output format", () => {

--- a/libraries/libsyntheticrender/src/index.js
+++ b/libraries/libsyntheticrender/src/index.js
@@ -5,4 +5,6 @@ export { generateDrugs, generatePlatforms } from "./render/industry-data.js";
 export { assignLinks } from "./render/link-assigner.js";
 export { validateLinks, validateHTML } from "./render/validate-links.js";
 export { renderDataset } from "./render/dataset-renderers.js";
+export { renderSql } from "./render/render-sql.js";
+export { renderEmbeddings } from "./render/render-embeddings.js";
 export { validateEvalReferences } from "./validate-eval.js";

--- a/libraries/libsyntheticrender/src/render/html-clinical.js
+++ b/libraries/libsyntheticrender/src/render/html-clinical.js
@@ -37,12 +37,12 @@ function buildConditionData(conditions, trials, prose) {
   }));
 }
 
-function buildTherapyData(content, prose) {
+function buildTherapyData(content, prose, domain) {
   if (!content?.therapy_topics) return [];
   return content.therapy_topics.map((topic) => ({
     topic,
     title: titleCase(topic),
-    iri: `#therapy-${topic}`,
+    iri: `https://${domain}/id/clinical/therapy/${topic}`,
     prose:
       prose.get(`clinical_therapy_description_${topic}`) ||
       `${titleCase(topic)} treatment overview.`,
@@ -202,7 +202,7 @@ export function renderClinicalPages(
     pageWrap(
       "Therapy Descriptions",
       templates.render("therapy-description.html", {
-        therapies: buildTherapyData(content, prose),
+        therapies: buildTherapyData(content, prose, domain),
       }),
     ),
   );

--- a/libraries/libsyntheticrender/src/render/render-embeddings.js
+++ b/libraries/libsyntheticrender/src/render/render-embeddings.js
@@ -1,0 +1,68 @@
+/**
+ * Embeddings JSONL renderer for clinical entities.
+ *
+ * Walks `outputConfig.entities`, concatenates fields listed in
+ * `outputConfig.text_fields`, and emits one JSONL line per entity with
+ * `{ id, table, text }`. Synthetic fields (`prose_*`) resolve against
+ * the prose cache; missing entries are silently omitted.
+ *
+ * @module libsyntheticrender/render/render-embeddings
+ */
+
+const SYNTHETIC_FIELDS = {
+  prose_explainer: (id) => `clinical_condition_explainer_${id}`,
+  prose_description: (id) => `clinical_consent_summary_${id}`,
+};
+
+/**
+ * @param {object} clinicalEntities - `entities.clinical`
+ * @param {Map<string, string>|object} proseCache - key → prose text
+ * @param {object} outputConfig - `{ path, entities, text_fields }`
+ * @returns {Map<string, string>} path → JSONL content
+ */
+export function renderEmbeddings(clinicalEntities, proseCache, outputConfig) {
+  const cache = toCache(proseCache);
+  const textFields = outputConfig.text_fields ?? {};
+  const lines = [];
+
+  for (const entityRef of outputConfig.entities ?? []) {
+    const table = stripDomain(entityRef);
+    const records = clinicalEntities[table] ?? [];
+    const fields = textFields[entityRef] ?? [];
+
+    for (const rec of records) {
+      const text = buildText(rec, fields, cache);
+      lines.push(JSON.stringify({ id: rec.id, table, text }));
+    }
+  }
+
+  const content = lines.length === 0 ? "" : lines.join("\n") + "\n";
+  return new Map([[outputConfig.path, content]]);
+}
+
+function buildText(rec, fields, cache) {
+  const parts = [];
+  for (const field of fields) {
+    const value = readField(rec, field, cache);
+    if (value !== null) parts.push(value);
+  }
+  return parts.join(" ");
+}
+
+function readField(rec, field, cache) {
+  const synthetic = SYNTHETIC_FIELDS[field];
+  if (synthetic) return cache.get(synthetic(rec.id)) ?? null;
+  const v = rec[field];
+  if (v === null || v === undefined) return null;
+  return Array.isArray(v) ? v.join(" ") : String(v);
+}
+
+function toCache(cache) {
+  if (cache instanceof Map) return cache;
+  return new Map(Object.entries(cache ?? {}));
+}
+
+function stripDomain(entityRef) {
+  const dot = entityRef.indexOf(".");
+  return dot === -1 ? entityRef : entityRef.slice(dot + 1);
+}

--- a/libraries/libsyntheticrender/src/render/render-sql.js
+++ b/libraries/libsyntheticrender/src/render/render-sql.js
@@ -1,0 +1,308 @@
+/**
+ * Coordinated Supabase migration renderer for clinical entities.
+ *
+ * Emits a numbered set of SQL files containing dependency-ordered
+ * `CREATE TABLE` + `INSERT` statements, junction tables for array
+ * cross-references, RLS policies, and an optional pgvector embeddings
+ * table — loadable via `supabase db push`.
+ *
+ * @module libsyntheticrender/render/render-sql
+ */
+
+const TABLE_SPEC = [
+  {
+    key: "conditions",
+    table: "conditions",
+    pk: "id",
+    skip: new Set(["trials", "iri"]),
+  },
+  {
+    key: "sites",
+    table: "sites",
+    pk: "id",
+    skip: new Set(["org", "trials", "iri"]),
+  },
+  {
+    key: "researchers",
+    table: "researchers",
+    pk: "id",
+    skip: new Set(["iri"]),
+  },
+  {
+    key: "trials",
+    table: "trials",
+    pk: "id",
+    skip: new Set([
+      "conditions",
+      "sites",
+      "principal_investigator",
+      "project",
+      "criteria",
+      "iri",
+    ]),
+    extraColumns: [
+      {
+        name: "principal_investigator_id",
+        type: "text",
+        value: (t) => t.principal_investigator?.person?.id ?? null,
+      },
+      {
+        name: "project_id",
+        type: "text",
+        value: (t) => t.project_ref ?? null,
+      },
+    ],
+    foreignKeys: [
+      { column: "principal_investigator_id", references: "researchers(id)" },
+    ],
+  },
+  {
+    key: "criteria",
+    table: "criteria",
+    pk: "trial_id",
+    skip: new Set(["iri"]),
+    foreignKeys: [{ column: "trial_id", references: "trials(id)" }],
+  },
+];
+
+const JUNCTIONS = [
+  {
+    table: "trial_sites",
+    sourceKey: "trials",
+    arrayField: "sites",
+    leftColumn: "trial_id",
+    rightColumn: "site_id",
+    leftRef: "trials(id)",
+    rightRef: "sites(id)",
+  },
+  {
+    table: "trial_conditions",
+    sourceKey: "trials",
+    arrayField: "conditions",
+    leftColumn: "trial_id",
+    rightColumn: "condition_id",
+    leftRef: "trials(id)",
+    rightRef: "conditions(id)",
+  },
+];
+
+/**
+ * Render coordinated Supabase migration files for a clinical entity graph.
+ *
+ * @param {object} clinicalEntities - `entities.clinical` from the generator
+ * @param {object} outputConfig - `{ path, prefix, entities, include_embeddings }`.
+ *   `path`, when present, prefixes every emitted filename (directory layout).
+ * @returns {Map<string, string>} path → file content
+ */
+export function renderSql(clinicalEntities, outputConfig) {
+  const prefix = outputConfig.prefix ?? "clinical";
+  const dir = normalizeDir(outputConfig.path);
+  const requested = new Set(
+    (outputConfig.entities ?? []).map((e) => stripDomain(e)),
+  );
+
+  const includedSpecs = TABLE_SPEC.filter((s) => requested.has(s.key));
+  const includedKeys = new Set(includedSpecs.map((s) => s.key));
+  const includedJunctions = JUNCTIONS.filter(
+    (j) => includedKeys.has(j.sourceKey) && includedKeys.has(j.arrayField),
+  );
+
+  const files = new Map();
+  let index = 0;
+  const next = () => String(++index).padStart(3, "0");
+  const filePath = (basename) => `${dir}${basename}`;
+
+  for (const spec of includedSpecs) {
+    const records = clinicalEntities[spec.key] ?? [];
+    files.set(
+      filePath(`${prefix}_${next()}_${spec.table}.sql`),
+      renderEntityTable(spec, records),
+    );
+  }
+
+  for (const j of includedJunctions) {
+    const records = clinicalEntities[j.sourceKey] ?? [];
+    files.set(
+      filePath(`${prefix}_${next()}_${j.table}.sql`),
+      renderJunctionTable(j, records),
+    );
+  }
+
+  const allTables = [
+    ...includedSpecs.map((s) => s.table),
+    ...includedJunctions.map((j) => j.table),
+  ];
+  files.set(filePath(`${prefix}_${next()}_rls.sql`), renderRls(allTables));
+
+  if (outputConfig.include_embeddings) {
+    files.set(
+      filePath(`${prefix}_${next()}_condition_embeddings.sql`),
+      renderEmbeddingsTable(),
+    );
+  }
+
+  return files;
+}
+
+function normalizeDir(path) {
+  if (!path) return "";
+  return path.endsWith("/") ? path : `${path}/`;
+}
+
+function stripDomain(entityRef) {
+  const dot = entityRef.indexOf(".");
+  return dot === -1 ? entityRef : entityRef.slice(dot + 1);
+}
+
+function renderEntityTable(spec, records) {
+  const columns = inferColumns(spec, records);
+  const pk = spec.pk;
+  const colDefs = columns.map((c) => {
+    const parts = [`"${c.name}"`, c.type];
+    if (c.name === pk) parts.push("PRIMARY KEY");
+    return `  ${parts.join(" ")}`;
+  });
+  for (const fk of spec.foreignKeys ?? []) {
+    colDefs.push(`  FOREIGN KEY ("${fk.column}") REFERENCES ${fk.references}`);
+  }
+  const create = `CREATE TABLE IF NOT EXISTS "${spec.table}" (\n${colDefs.join(",\n")}\n);\n`;
+
+  if (records.length === 0) {
+    return `${create}\n-- No records for ${spec.table}\n`;
+  }
+
+  const columnNames = columns.map((c) => `"${c.name}"`).join(", ");
+  const rows = records.map((rec) => {
+    const values = columns.map((c) => sqlLiteral(c.read(rec), c.type));
+    return `(${values.join(", ")})`;
+  });
+  const insert = `INSERT INTO "${spec.table}" (${columnNames}) VALUES\n${rows.join(",\n")};\n`;
+
+  return `${create}\n${insert}`;
+}
+
+function inferColumns(spec, records) {
+  const direct = [];
+  const seen = new Set();
+  for (const rec of records) {
+    for (const key of Object.keys(rec)) {
+      if (seen.has(key)) continue;
+      if (spec.skip.has(key)) continue;
+      seen.add(key);
+      direct.push({
+        name: key,
+        type: inferType(records, (r) => r[key]),
+        read: (r) => r[key],
+      });
+    }
+  }
+  for (const extra of spec.extraColumns ?? []) {
+    direct.push({
+      name: extra.name,
+      type: extra.type,
+      read: extra.value,
+    });
+  }
+  return direct;
+}
+
+function inferType(records, read) {
+  for (const rec of records) {
+    const v = read(rec);
+    if (v === null || v === undefined) continue;
+    return typeOfValue(v);
+  }
+  return "text";
+}
+
+function typeOfValue(v) {
+  if (typeof v === "boolean") return "boolean";
+  if (typeof v === "number")
+    return Number.isInteger(v) ? "integer" : "double precision";
+  if (Array.isArray(v)) return arrayTypeOf(v);
+  if (typeof v === "object") return "jsonb";
+  return "text";
+}
+
+function arrayTypeOf(arr) {
+  const inner = arr.find((x) => x !== null && x !== undefined);
+  return typeof inner === "number" ? "integer[]" : "text[]";
+}
+
+const SCALAR_LITERALS = {
+  boolean: (v) => (v ? "TRUE" : "FALSE"),
+  integer: (v) => String(v),
+  "double precision": (v) => String(v),
+  jsonb: (v) => `${dollarQuote(JSON.stringify(v))}::jsonb`,
+};
+
+function sqlLiteral(value, type) {
+  if (value === null || value === undefined) return "NULL";
+  const scalar = SCALAR_LITERALS[type];
+  if (scalar) return scalar(value);
+  if (type === "text[]" || type === "integer[]")
+    return arrayLiteral(value, type);
+  return dollarQuote(String(value));
+}
+
+function arrayLiteral(value, type) {
+  if (!Array.isArray(value)) return "NULL";
+  if (value.length === 0) return `ARRAY[]::${type}`;
+  if (type === "integer[]") return `ARRAY[${value.join(", ")}]`;
+  const items = value.map((s) => `'${String(s).replace(/'/g, "''")}'`);
+  return `ARRAY[${items.join(", ")}]`;
+}
+
+function dollarQuote(s) {
+  if (!s.includes("$$")) return `$$${s}$$`;
+  let i = 0;
+  while (s.includes(`$t${i}$`)) i++;
+  return `$t${i}$${s}$t${i}$`;
+}
+
+function renderJunctionTable(j, sourceRecords) {
+  const create = `CREATE TABLE IF NOT EXISTS "${j.table}" (
+  "${j.leftColumn}" text NOT NULL REFERENCES ${j.leftRef},
+  "${j.rightColumn}" text NOT NULL REFERENCES ${j.rightRef},
+  PRIMARY KEY ("${j.leftColumn}", "${j.rightColumn}")
+);
+`;
+
+  const rows = [];
+  for (const rec of sourceRecords) {
+    const left = rec.id;
+    const arr = rec[j.arrayField] ?? [];
+    for (const right of arr) {
+      rows.push(
+        `(${dollarQuote(String(left))}, ${dollarQuote(String(right))})`,
+      );
+    }
+  }
+  if (rows.length === 0) return `${create}\n-- No records for ${j.table}\n`;
+
+  const insert = `INSERT INTO "${j.table}" ("${j.leftColumn}", "${j.rightColumn}") VALUES\n${rows.join(",\n")};\n`;
+  return `${create}\n${insert}`;
+}
+
+function renderRls(tables) {
+  const lines = ["-- Row level security: public read access\n"];
+  for (const t of tables) {
+    lines.push(`ALTER TABLE "${t}" ENABLE ROW LEVEL SECURITY;`);
+    lines.push(
+      `CREATE POLICY "public_read" ON "${t}" FOR SELECT USING (true);`,
+    );
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function renderEmbeddingsTable() {
+  return `CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS "condition_embeddings" (
+  "id" text PRIMARY KEY,
+  "condition_id" text REFERENCES "conditions"(id),
+  "embedding" vector(384)
+);
+`;
+}

--- a/libraries/libsyntheticrender/test/render-embeddings.test.js
+++ b/libraries/libsyntheticrender/test/render-embeddings.test.js
@@ -1,0 +1,148 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { renderEmbeddings } from "../src/render/render-embeddings.js";
+
+function makeClinical() {
+  return {
+    conditions: [
+      {
+        id: "diabetes_t2",
+        name: "Type 2 Diabetes",
+        synonyms: ["high blood sugar", "T2D"],
+        prose_topic: "diabetes",
+      },
+      {
+        id: "cardio",
+        name: "Cardiovascular Disease",
+        synonyms: ["heart disease"],
+      },
+    ],
+    trials: [
+      {
+        id: "oncora_p3",
+        name: "ONCORA-301",
+        therapeutic_area: "oncology",
+        arms: ["mAb + SoC", "placebo + SoC"],
+      },
+    ],
+  };
+}
+
+describe("renderEmbeddings", () => {
+  test("produces one JSONL line per entity", () => {
+    const out = renderEmbeddings(makeClinical(), new Map(), {
+      path: "out/embed.jsonl",
+      entities: ["clinical.conditions", "clinical.trials"],
+      text_fields: {
+        "clinical.conditions": ["name"],
+        "clinical.trials": ["name"],
+      },
+    });
+    const content = out.get("out/embed.jsonl");
+    const lines = content.trim().split("\n");
+    assert.strictEqual(lines.length, 3);
+    for (const l of lines) {
+      const parsed = JSON.parse(l);
+      assert.ok(parsed.id);
+      assert.ok(parsed.table);
+      assert.ok(parsed.text);
+    }
+  });
+
+  test("each line has id, table, and text fields", () => {
+    const out = renderEmbeddings(makeClinical(), new Map(), {
+      path: "out/embed.jsonl",
+      entities: ["clinical.conditions"],
+      text_fields: { "clinical.conditions": ["name"] },
+    });
+    const first = JSON.parse(out.get("out/embed.jsonl").trim().split("\n")[0]);
+    assert.strictEqual(first.id, "diabetes_t2");
+    assert.strictEqual(first.table, "conditions");
+    assert.strictEqual(first.text, "Type 2 Diabetes");
+  });
+
+  test("arrays are space-joined", () => {
+    const out = renderEmbeddings(makeClinical(), new Map(), {
+      path: "out/embed.jsonl",
+      entities: ["clinical.conditions"],
+      text_fields: { "clinical.conditions": ["name", "synonyms"] },
+    });
+    const first = JSON.parse(out.get("out/embed.jsonl").trim().split("\n")[0]);
+    assert.strictEqual(first.text, "Type 2 Diabetes high blood sugar T2D");
+  });
+
+  test("synthetic prose_explainer resolves against cache", () => {
+    const cache = new Map([
+      [
+        "clinical_condition_explainer_diabetes_t2",
+        "Diabetes happens when your body cannot use sugar well.",
+      ],
+    ]);
+    const out = renderEmbeddings(makeClinical(), cache, {
+      path: "out/embed.jsonl",
+      entities: ["clinical.conditions"],
+      text_fields: {
+        "clinical.conditions": ["name", "prose_explainer"],
+      },
+    });
+    const lines = out.get("out/embed.jsonl").trim().split("\n").map(JSON.parse);
+    const diabetes = lines.find((l) => l.id === "diabetes_t2");
+    assert.ok(diabetes.text.includes("Diabetes happens"));
+  });
+
+  test("synthetic prose_description resolves against consent summary key", () => {
+    const cache = new Map([
+      ["clinical_consent_summary_oncora_p3", "Consent summary text."],
+    ]);
+    const out = renderEmbeddings(makeClinical(), cache, {
+      path: "out/embed.jsonl",
+      entities: ["clinical.trials"],
+      text_fields: {
+        "clinical.trials": ["name", "prose_description"],
+      },
+    });
+    const trial = JSON.parse(out.get("out/embed.jsonl").trim().split("\n")[0]);
+    assert.strictEqual(trial.text, "ONCORA-301 Consent summary text.");
+  });
+
+  test("missing cache entries are silently omitted", () => {
+    const out = renderEmbeddings(makeClinical(), new Map(), {
+      path: "out/embed.jsonl",
+      entities: ["clinical.conditions"],
+      text_fields: {
+        "clinical.conditions": ["name", "prose_explainer"],
+      },
+    });
+    const lines = out.get("out/embed.jsonl").trim().split("\n").map(JSON.parse);
+    for (const l of lines) {
+      // text should still contain the name
+      assert.ok(l.text.length > 0);
+    }
+  });
+
+  test("accepts plain object as prose cache", () => {
+    const out = renderEmbeddings(
+      makeClinical(),
+      { clinical_condition_explainer_cardio: "Heart disease prose." },
+      {
+        path: "out/embed.jsonl",
+        entities: ["clinical.conditions"],
+        text_fields: {
+          "clinical.conditions": ["name", "prose_explainer"],
+        },
+      },
+    );
+    const lines = out.get("out/embed.jsonl").trim().split("\n").map(JSON.parse);
+    const cardio = lines.find((l) => l.id === "cardio");
+    assert.ok(cardio.text.includes("Heart disease prose."));
+  });
+
+  test("empty entities list yields empty file", () => {
+    const out = renderEmbeddings(makeClinical(), new Map(), {
+      path: "out/embed.jsonl",
+      entities: [],
+      text_fields: {},
+    });
+    assert.strictEqual(out.get("out/embed.jsonl"), "");
+  });
+});

--- a/libraries/libsyntheticrender/test/render-sql.test.js
+++ b/libraries/libsyntheticrender/test/render-sql.test.js
@@ -1,0 +1,320 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { renderSql } from "../src/render/render-sql.js";
+
+function makeClinical() {
+  return {
+    conditions: [
+      {
+        id: "diabetes_t2",
+        name: "Type 2 Diabetes",
+        icd10: ["E11"],
+        synonyms: ["high blood sugar"],
+        synthea_module: "diabetes",
+        severity: "chronic",
+        prose_topic: "diabetes",
+        prose_tone: "empathetic",
+        trials: ["oncora_p3"],
+        iri: "https://example.com/id/clinical/condition/diabetes_t2",
+      },
+      {
+        id: "cardio",
+        name: "Cardiovascular Disease",
+        icd10: ["I25"],
+        synonyms: ["heart disease"],
+        synthea_module: "cardiovascular",
+        severity: "chronic",
+        prose_topic: null,
+        prose_tone: null,
+        trials: ["oncora_p3"],
+        iri: "https://example.com/id/clinical/condition/cardio",
+      },
+    ],
+    sites: [
+      {
+        id: "cambridge",
+        name: "Cambridge Center",
+        address: "200 Park Dr",
+        city: "Cambridge",
+        state: "MA",
+        country: "US",
+        org_ref: "hq",
+        org: { id: "hq", name: "HQ", iri: "https://example.com/id/org/hq" },
+        capacity: 500,
+        specialties: ["oncology"],
+        trials: ["oncora_p3"],
+        iri: "https://example.com/id/clinical/site/cambridge",
+      },
+    ],
+    researchers: [
+      {
+        id: "thoth",
+        person_ref: "thoth",
+        name: 'Thoth\'s "Lab"', // contains quotes
+        email: "thoth@example.com",
+        role: "principal_investigator",
+        trial_ids: ["oncora_p3"],
+        specialty: "data_science",
+        iri: "https://example.com/id/clinical/researcher/thoth",
+      },
+    ],
+    trials: [
+      {
+        id: "oncora_p3",
+        name: "ONCORA-301",
+        protocol_id: "BNV-ONC-2024-301",
+        phase: "phase_3",
+        therapeutic_area: "oncology",
+        conditions: ["diabetes_t2", "cardio"],
+        sites: ["cambridge"],
+        principal_investigator: {
+          ref: "thoth",
+          person: { id: "thoth", name: "Thoth" },
+        },
+        project_ref: "oncora",
+        project: { id: "oncora", name: "Oncora" },
+        sponsor: "BioNova",
+        status: "recruiting",
+        target_enrollment: 450,
+        current_enrollment: 287,
+        start_date: "2024-06",
+        estimated_end_date: "2026-06",
+        arms: ["mAb + SoC", "placebo + SoC"],
+        prose_topic: null,
+        prose_tone: null,
+        criteria: { inclusion: {}, exclusion: {} },
+        iri: "https://example.com/id/clinical/trial/oncora_p3",
+      },
+    ],
+    criteria: [
+      {
+        trial_id: "oncora_p3",
+        inclusion: { age_min: 18, age_max: 75 },
+        exclusion: { active_autoimmune: true },
+        iri: "https://example.com/id/clinical/criterion/oncora_p3",
+      },
+    ],
+  };
+}
+
+const ALL_ENTITIES = [
+  "clinical.conditions",
+  "clinical.sites",
+  "clinical.researchers",
+  "clinical.trials",
+  "clinical.criteria",
+];
+
+describe("renderSql", () => {
+  test("emits 8 files without include_embeddings, 9 with", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+    });
+    assert.strictEqual(out.size, 8);
+
+    const withEmb = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+      include_embeddings: true,
+    });
+    assert.strictEqual(withEmb.size, 9);
+  });
+
+  test("files are numbered in dependency order", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+      include_embeddings: true,
+    });
+    const paths = [...out.keys()];
+    assert.deepStrictEqual(paths, [
+      "bn_001_conditions.sql",
+      "bn_002_sites.sql",
+      "bn_003_researchers.sql",
+      "bn_004_trials.sql",
+      "bn_005_criteria.sql",
+      "bn_006_trial_sites.sql",
+      "bn_007_trial_conditions.sql",
+      "bn_008_rls.sql",
+      "bn_009_condition_embeddings.sql",
+    ]);
+  });
+
+  test("each entity file contains CREATE TABLE IF NOT EXISTS", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+    });
+    for (const [path, content] of out) {
+      if (path.endsWith("_rls.sql")) continue;
+      assert.ok(
+        content.includes("CREATE TABLE IF NOT EXISTS"),
+        `${path} missing CREATE TABLE`,
+      );
+    }
+  });
+
+  test("INSERT statements include each entity record", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+    });
+    const conditions = out.get("bn_001_conditions.sql");
+    assert.ok(conditions.includes('INSERT INTO "conditions"'));
+    assert.ok(conditions.includes("diabetes_t2"));
+    assert.ok(conditions.includes("cardio"));
+  });
+
+  test("text array columns use ARRAY[...] literal", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+    });
+    const conditions = out.get("bn_001_conditions.sql");
+    assert.ok(conditions.includes('"icd10" text[]'));
+    assert.ok(conditions.includes("ARRAY['E11']"));
+  });
+
+  test("junction tables generated for trial.sites and trial.conditions", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+    });
+    const trialSites = out.get("bn_006_trial_sites.sql");
+    assert.ok(trialSites.includes('CREATE TABLE IF NOT EXISTS "trial_sites"'));
+    assert.ok(trialSites.includes("trial_id"));
+    assert.ok(trialSites.includes("site_id"));
+    assert.ok(trialSites.includes("$$oncora_p3$$"));
+    assert.ok(trialSites.includes("$$cambridge$$"));
+
+    const trialConditions = out.get("bn_007_trial_conditions.sql");
+    assert.ok(trialConditions.includes("condition_id"));
+    assert.ok(trialConditions.includes("$$diabetes_t2$$"));
+  });
+
+  test("RLS file enables row level security on every table", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+    });
+    const rls = out.get("bn_008_rls.sql");
+    for (const t of [
+      "conditions",
+      "sites",
+      "researchers",
+      "trials",
+      "criteria",
+      "trial_sites",
+      "trial_conditions",
+    ]) {
+      assert.ok(
+        rls.includes(`ALTER TABLE "${t}" ENABLE ROW LEVEL SECURITY`),
+        `RLS missing ALTER for ${t}`,
+      );
+      assert.ok(
+        rls.includes(`CREATE POLICY "public_read" ON "${t}"`),
+        `RLS missing policy for ${t}`,
+      );
+    }
+  });
+
+  test("embeddings table uses vector(384)", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+      include_embeddings: true,
+    });
+    const emb = out.get("bn_009_condition_embeddings.sql");
+    assert.ok(emb.includes("CREATE EXTENSION IF NOT EXISTS vector"));
+    assert.ok(emb.includes("vector(384)"));
+    assert.ok(!emb.includes("INSERT INTO"));
+  });
+
+  test("strings with single quotes are dollar-quoted safely", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ["clinical.researchers"],
+    });
+    const researchers = out.get("bn_001_researchers.sql");
+    assert.ok(researchers.includes('$$Thoth\'s "Lab"$$'));
+  });
+
+  test("integer columns use plain numeric literals", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ["clinical.sites"],
+    });
+    const sites = out.get("bn_001_sites.sql");
+    assert.ok(sites.includes('"capacity" integer'));
+    assert.ok(/VALUES[\s\S]*500/.test(sites));
+  });
+
+  test("object fields serialize as jsonb", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ["clinical.criteria"],
+    });
+    const criteria = out.get("bn_001_criteria.sql");
+    assert.ok(criteria.includes('"inclusion" jsonb'));
+    assert.ok(criteria.includes("::jsonb"));
+  });
+
+  test("foreign keys declared on dependent tables", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ALL_ENTITIES,
+    });
+    const trials = out.get("bn_004_trials.sql");
+    assert.ok(trials.includes('"principal_investigator_id" text'));
+    assert.ok(
+      trials.includes(
+        'FOREIGN KEY ("principal_investigator_id") REFERENCES researchers(id)',
+      ),
+    );
+
+    const criteria = out.get("bn_005_criteria.sql");
+    assert.ok(
+      criteria.includes('FOREIGN KEY ("trial_id") REFERENCES trials(id)'),
+    );
+  });
+
+  test("subset of entities produces fewer files and skips junctions", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ["clinical.conditions"],
+    });
+    // 1 conditions file + 1 RLS file
+    assert.strictEqual(out.size, 2);
+    assert.ok(out.has("bn_001_conditions.sql"));
+    assert.ok(out.has("bn_002_rls.sql"));
+  });
+
+  test("path config prefixes every emitted filename", () => {
+    const out = renderSql(makeClinical(), {
+      path: "supabase/migrations/",
+      prefix: "bn",
+      entities: ["clinical.conditions"],
+    });
+    assert.strictEqual(out.size, 2);
+    assert.ok(out.has("supabase/migrations/bn_001_conditions.sql"));
+    assert.ok(out.has("supabase/migrations/bn_002_rls.sql"));
+  });
+
+  test("path config normalizes trailing slash", () => {
+    const out = renderSql(makeClinical(), {
+      path: "supabase/migrations",
+      prefix: "bn",
+      entities: ["clinical.conditions"],
+    });
+    assert.ok(out.has("supabase/migrations/bn_001_conditions.sql"));
+  });
+
+  test("no path config keeps bare filenames (backwards compatible)", () => {
+    const out = renderSql(makeClinical(), {
+      prefix: "bn",
+      entities: ["clinical.conditions"],
+    });
+    assert.ok(out.has("bn_001_conditions.sql"));
+  });
+});

--- a/libraries/libterrain/bin/fit-terrain.js
+++ b/libraries/libterrain/bin/fit-terrain.js
@@ -202,8 +202,8 @@ async function runVerb(options) {
 
   // Bind to `import.meta` so the helper can invoke it under Bun, which
   // requires `import.meta.resolve` to be called with `this === import.meta`.
-  const { promptDir, templateDir } = resolvePackagePaths(
-    (specifier) => import.meta.resolve(specifier),
+  const { promptDir, templateDir } = resolvePackagePaths((specifier) =>
+    import.meta.resolve(specifier),
   );
 
   const pipeline = createPipeline({

--- a/libraries/libterrain/bin/fit-terrain.js
+++ b/libraries/libterrain/bin/fit-terrain.js
@@ -200,7 +200,11 @@ async function runVerb(options) {
     options.cache ||
     join(monorepoRoot, "data", "synthetic", "prose-cache.json");
 
-  const { promptDir, templateDir } = resolvePackagePaths(import.meta.resolve);
+  // Bind to `import.meta` so the helper can invoke it under Bun, which
+  // requires `import.meta.resolve` to be called with `this === import.meta`.
+  const { promptDir, templateDir } = resolvePackagePaths(
+    (specifier) => import.meta.resolve(specifier),
+  );
 
   const pipeline = createPipeline({
     logger,

--- a/libraries/libterrain/src/nodes.js
+++ b/libraries/libterrain/src/nodes.js
@@ -15,6 +15,8 @@ import {
   validateLinks,
   validateHTML,
   renderDataset,
+  renderSql,
+  renderEmbeddings,
 } from "@forwardimpact/libsyntheticrender";
 import { collectProseKeys } from "@forwardimpact/libsyntheticgen";
 import { loadSchemas } from "@forwardimpact/libsyntheticprose/pathway";
@@ -208,6 +210,34 @@ export function buildNodes(ctx) {
       },
     },
 
+    "clinical-output": {
+      deps: ["parse", "entities", "cache-lookup"],
+      run({ parse, entities, "cache-lookup": prose }) {
+        const files = new Map();
+        if (!entities.clinical) return { files };
+
+        const clinicalOutputs = (parse.outputs || []).filter(
+          (o) =>
+            o.format === "supabase_migration" ||
+            o.format === "embeddings_jsonl",
+        );
+        if (clinicalOutputs.length === 0) return { files };
+
+        logger.info(
+          "pipeline",
+          `Rendering ${clinicalOutputs.length} clinical output(s)`,
+        );
+
+        for (const out of clinicalOutputs) {
+          const rendered = renderClinicalOutput(out, entities.clinical, prose);
+          for (const [path, content] of rendered) files.set(path, content);
+        }
+
+        logger.info("pipeline", `Clinical output: ${files.size} files`);
+        return { files };
+      },
+    },
+
     validate: {
       deps: ["enriched", "entities"],
       run({ enriched, entities }) {
@@ -235,8 +265,24 @@ export function buildNodes(ctx) {
     },
 
     write: {
-      deps: ["enriched", "raw", "markdown", "pathway", "datasets", "validate"],
-      run({ enriched, raw, markdown, pathway, datasets, validate }) {
+      deps: [
+        "enriched",
+        "raw",
+        "markdown",
+        "pathway",
+        "datasets",
+        "clinical-output",
+        "validate",
+      ],
+      run({
+        enriched,
+        raw,
+        markdown,
+        pathway,
+        datasets,
+        "clinical-output": clinicalOutput,
+        validate,
+      }) {
         const files = mergeOutputFiles(
           options.only,
           enriched,
@@ -244,6 +290,7 @@ export function buildNodes(ctx) {
           markdown,
           pathway,
           datasets,
+          clinicalOutput,
         );
         const include = (type) => !options.only || options.only === type;
         const rawDocuments = include("raw") ? raw.rawDocuments : new Map();
@@ -345,7 +392,15 @@ async function renderDatasetOutputs(outputs, datasets, files, logger) {
 }
 
 /** Merge files from each content type, respecting the --only filter. */
-function mergeOutputFiles(only, enriched, raw, markdown, pathway, datasets) {
+function mergeOutputFiles(
+  only,
+  enriched,
+  raw,
+  markdown,
+  pathway,
+  datasets,
+  clinicalOutput,
+) {
   const files = new Map();
   const include = (type) => !only || only === type;
 
@@ -360,10 +415,18 @@ function mergeOutputFiles(only, enriched, raw, markdown, pathway, datasets) {
       for (const [k, v] of source) files.set(k, v);
     }
   }
-  // datasets are always included regardless of --only
+  // datasets and clinical output are always included regardless of --only
   for (const [k, v] of datasets.files) files.set(k, v);
+  for (const [k, v] of clinicalOutput.files) files.set(k, v);
 
   return files;
+}
+
+function renderClinicalOutput(out, clinical, prose) {
+  if (out.format === "supabase_migration") {
+    return renderSql(clinical, out.config);
+  }
+  return renderEmbeddings(clinical, prose, out.config);
 }
 
 /**

--- a/libraries/libterrain/src/pipeline.js
+++ b/libraries/libterrain/src/pipeline.js
@@ -17,13 +17,16 @@
  *   markdown      ← entities, cache-lookup
  *   pathway       ← entities
  *   datasets      ← parse
+ *   clinical-output ← parse, entities, cache-lookup
  *   validate      ← enriched, entities
- *   write         ← enriched, raw, markdown, pathway, datasets, validate
+ *   write         ← enriched, raw, markdown, pathway, datasets,
+ *                    clinical-output, validate
  *
  * Verb terminal-closure walks (the cost-shifting payoff of Phase D):
  *   check    → parse, entities, prose-keys, cache-lookup
  *   validate → ...above + skeleton, enriched, validate
- *   build    → all of the above + raw, markdown, pathway, datasets, write
+ *   build    → all of the above + raw, markdown, pathway, datasets,
+ *              clinical-output, write
  *
  * Node table definitions live in nodes.js.
  *
@@ -45,6 +48,7 @@ export const STAGES = [
   "markdown",
   "pathway",
   "datasets",
+  "clinical-output",
   "validate",
   "write",
 ];

--- a/libraries/libterrain/test/fixtures/clinical.dsl
+++ b/libraries/libterrain/test/fixtures/clinical.dsl
@@ -1,0 +1,131 @@
+terrain clinical {
+  domain "test.example"
+  industry "pharmaceutical"
+  seed 42
+
+  org testorg {
+    name "Test Organization"
+  }
+
+  department eng {
+    name "Engineering"
+    parent testorg
+    headcount 5
+
+    team alpha {
+      name "Alpha Team"
+      size 5
+      manager @alpha_lead
+      repos ["alpha-service"]
+    }
+  }
+
+  people {
+    count 5
+    distribution {
+      J040 60%
+      J050 40%
+    }
+    disciplines {
+      software_engineering 100%
+    }
+  }
+
+  project oncora {
+    name "Oncora"
+    type "drug"
+    teams [alpha]
+    prose_topic "Phase 3 oncology program"
+    prose_tone "clinical"
+  }
+
+  standard {
+    proficiencies [awareness, foundational, working, practitioner, expert]
+    maturities [emerging, developing, practicing, role_modeling, exemplifying]
+
+    levels {
+      J040 { title "Software Engineer" rank 1 experience "0-2 years" }
+      J050 { title "Senior Engineer" rank 2 experience "2-5 years" }
+    }
+
+    capabilities {
+      coding { name "Coding" skills [python_dev, code_review] }
+    }
+
+    behaviours {
+      collaboration { name "Collaboration" }
+    }
+
+    disciplines {
+      software_engineering {
+        roleTitle "Software Engineer"
+        core [python_dev]
+        supporting [code_review]
+      }
+    }
+
+    tracks {
+      backend { name "Backend" }
+    }
+
+    drivers {
+      clear_direction {
+        name "Clear Direction"
+        skills [python_dev]
+        behaviours [collaboration]
+      }
+    }
+  }
+
+  clinical {
+    condition diabetes_t2 {
+      name "Type 2 Diabetes"
+      icd10 [E11]
+      synonyms ["high blood sugar"]
+      synthea_module diabetes
+      severity chronic
+    }
+
+    site cambridge {
+      name "Cambridge Center"
+      address "200 Park Dr"
+      city "Cambridge"
+      state "MA"
+      country "US"
+      org testorg
+      capacity 500
+      specialties [oncology]
+    }
+
+    trial oncora_p3 {
+      name "ONCORA-301"
+      protocol_id "BNV-ONC-2024-301"
+      project oncora
+      phase "phase_3"
+      therapeutic_area "oncology"
+      conditions [diabetes_t2]
+      sites [cambridge]
+      principal_investigator @alpha_lead
+      sponsor "BioNova"
+      status "recruiting"
+      target_enrollment 450
+      current_enrollment 287
+      start_date 2024-06
+      estimated_end_date 2026-06
+      arms ["mAb + SoC", "placebo + SoC"]
+    }
+  }
+
+  output clinical_db supabase_migration {
+    prefix "bn"
+    entities [clinical.conditions, clinical.sites, clinical.researchers, clinical.trials]
+  }
+
+  output clinical_embed embeddings_jsonl {
+    path "out/clinical.jsonl"
+    entities [clinical.conditions]
+    text_fields {
+      clinical.conditions [name, synonyms]
+    }
+  }
+}

--- a/libraries/libterrain/test/pipeline.test.js
+++ b/libraries/libterrain/test/pipeline.test.js
@@ -24,6 +24,7 @@ import { NullProseCacheSink } from "../src/sinks.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_PATH = join(__dirname, "fixtures", "minimal.dsl");
+const CLINICAL_FIXTURE_PATH = join(__dirname, "fixtures", "clinical.dsl");
 
 function makeLogger() {
   return {
@@ -235,6 +236,60 @@ describe("Pipeline integration", () => {
         () => pipeline.run({ storyPath: FIXTURE_PATH, terminal: "nonsense" }),
         /Unknown stage 'nonsense'/,
       );
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  test("clinical-output produces zero files when no clinical block", async () => {
+    const { tmpDir, deps } = makePipelineDeps({ mode: "no-prose" });
+    try {
+      const pipeline = new Pipeline(deps);
+      const result = await pipeline.run({
+        storyPath: FIXTURE_PATH,
+        terminal: "clinical-output",
+      });
+      assert.strictEqual(result.output.files.size, 0);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  test("clinical-output renders SQL and JSONL files", async () => {
+    const { tmpDir, deps } = makePipelineDeps({ mode: "no-prose" });
+    try {
+      const pipeline = new Pipeline(deps);
+      const result = await pipeline.run({
+        storyPath: CLINICAL_FIXTURE_PATH,
+        terminal: "clinical-output",
+      });
+      const paths = [...result.output.files.keys()];
+      assert.ok(
+        paths.some((p) => p.startsWith("bn_") && p.endsWith(".sql")),
+        `Expected SQL migration files, got: ${paths.join(", ")}`,
+      );
+      assert.ok(
+        paths.includes("out/clinical.jsonl"),
+        `Expected embeddings JSONL, got: ${paths.join(", ")}`,
+      );
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  test("write stage merges clinical output alongside other files", async () => {
+    const { tmpDir, deps } = makePipelineDeps({ mode: "no-prose" });
+    try {
+      const pipeline = new Pipeline(deps);
+      const result = await pipeline.run({
+        storyPath: CLINICAL_FIXTURE_PATH,
+        terminal: "write",
+      });
+      const paths = [...result.files.keys()];
+      assert.ok(paths.some((p) => p.startsWith("bn_") && p.endsWith(".sql")));
+      assert.ok(paths.includes("out/clinical.jsonl"));
+      // Existing knowledge files still produced
+      assert.ok(paths.some((p) => p.startsWith("data/knowledge/")));
     } finally {
       rmSync(tmpDir, { recursive: true });
     }


### PR DESCRIPTION
## Summary

Spec 1140 is marked `plan implemented` in `wiki/STATUS.md`, but extensive testing
against the implementation showed it had drifted from the original spec in two
ways:

1. **Parts 4 and 5 never landed on `main`.** They exist as commits
   `0c921e8` and `8bbf8f1` on `origin/claude/study-spec-1140-wYLKx`, but were
   not picked up by the merges that brought parts 1–3 and 6–8 to `main`.
   Without them, success criteria #4 (`supabase_migration` SQL files) and #5
   (`embeddings_jsonl`) can't be satisfied — and downstream specs 1150 and
   1160 lose their data-seeding path.
2. **Three live bugs in the parts that did land**, all caught by exercising the
   pipeline end-to-end with Synthea installed and a custom clinical DSL.

This PR restores Parts 4 and 5 from the study branch and fixes the bugs.
With it, the implementation now matches all eight success criteria in
spec 1140 — so specs 1150 and 1160 do **not** need to be adjusted.

## What I tested

- `just synthea-install` + `just synthea-status` — JAR downloaded (174 MB),
  Java 21 detected.
- Custom DSL with `clinical { condition, site, trial, criteria, content }`
  plus `output … supabase_migration` and `output … embeddings_jsonl` blocks:
  parse → entities → prose-keys → clinical-output → write all succeed; 11
  clinical prose keys and 10 clinical output files produced (9 SQL + 1 JSONL).
- Real Synthea generation (`population=5`, condition filter `diabetes_t2`) —
  patients flow through correctly; the condition filter is a pass-through
  when the population is too small to materialise the diagnosis, matching
  existing behaviour.
- `data/synthetic/story.dsl` (no clinical block) — 99 files / 13 248 raw
  documents / 0 validation failures, no regression.
- `bun test libraries/` — 2 369 pass / 17 fail; the 17 failures are all
  `libwiki` git-signing issues in this remote execution environment,
  unrelated to spec 1140.

## Restored parts

- **Part 4** (`libsyntheticrender` + `libsyntheticgen`) — `supabase_migration`
  and `embeddings_jsonl` added to `DATASET_FORMATS`; `parseOutput` accepts
  `prefix`, `entities`, `include_embeddings`, `text_fields`. `renderSql`
  emits numbered SQL with `CREATE TABLE` + `INSERT` + junction tables + RLS
  + optional pgvector. `renderEmbeddings` emits JSONL with prose-cache
  lookups for `prose_explainer` / `prose_description`.
- **Part 5** (`libterrain`) — new `clinical-output` DAG stage wires
  `entities.clinical` + cache-lookup through the new renderers; `write`
  stage merges its files alongside `datasets`; pipeline tests cover
  no-clinical, clinical-output terminal, and write merging.

## Bugs fixed

- `libterrain/bin/fit-terrain.js` — `import.meta.resolve` was passed as a
  bare function reference. Bun enforces the spec and throws
  `import.meta.resolve must be bound to an import.meta object`; Node
  tolerates the rebinding. Wrapped the call so `resolvePackagePaths`
  receives a closure bound to `import.meta`. The same pattern was
  previously fixed for `fit-pathway` in `0395a44e`.
- `libsyntheticrender/render/html-clinical.js` — therapy IRIs were emitted
  as relative anchors (`#therapy-{topic}`), which tripped the
  `enriched_iri_namespace` validation when a DSL declared therapies.
  Switched to the same domain-prefixed pattern conditions / sites / trials
  already use (`https://{domain}/id/clinical/therapy/{topic}`). The
  template's `itemid="{{{iri}}}"` now resolves to a domain-scoped IRI.
- `libsyntheticrender/render/render-sql.js` — the DSL `path` field on
  `supabase_migration` outputs was silently ignored. `output … { path
  "supabase/migrations/" }` was writing files to the workspace root instead
  of the requested directory, which would have broken spec 1150 success
  criterion #6 (files at `products/finder/site/supabase/migrations/`).
  Every emitted filename is now prefixed with the normalised `path` (added
  three tests covering trailing-slash, missing-slash, and backwards-compat
  bare-filename behaviour).

## Test plan

- [x] `bun test libraries/libsyntheticgen libraries/libsyntheticprose libraries/libsyntheticrender libraries/libterrain` — 372 pass / 0 fail.
- [x] `bun run libraries/libterrain/bin/fit-terrain.js build` against `data/synthetic/story.dsl` — 99 files / 31 checks / 0 failures.
- [x] `bun run libraries/libterrain/bin/fit-terrain.js inspect clinical-output` against a clinical DSL — 10 files (9 SQL migrations + 1 JSONL) with paths honouring the `path` config.
- [x] `just synthea-install && just synthea-status` — succeeds; Synthea JAR present, Java 21 detected.
- [x] End-to-end Synthea generation with condition filter — patients produced, dataset outputs written.

https://claude.ai/code/session_011w9LVw1YsapFkgxT1aoWsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_011w9LVw1YsapFkgxT1aoWsJ)_