### PR TITLE
refactor(facilitator,agent-react): L0/L4 split for multi-addressee fan-out

### DIFF
--- a/.github/workflows/agent-react.yml
+++ b/.github/workflows/agent-react.yml
@@ -119,13 +119,13 @@ jobs:
               target_type="discussion"
               target_number="$DISCUSSION_NUMBER"
               context="A new discussion was opened: \"$DISCUSSION_TITLE\" (#$target_number, category: $DISCUSSION_CATEGORY) by @$AUTHOR (user type: $AUTHOR_TYPE; event: $EVENT_NAME). Discussion URL: $ITEM_URL. Discussion node ID: $DISCUSSION_NODE_ID."
-              action="route to the best-suited agent and ask them to assess the discussion and act on it. To reply, use \`gh api graphql\` (mutation \`addDiscussionComment\` with the discussion node ID)."
+              action="if the body directly addresses multiple participants by role (headers like \"**Release engineer** — your view\"; \"**Staff engineer** — your view\"), Ask each named addressee in one parallel tool-call batch — one Ask per addressee — then post each Answer as a separate discussion comment via \`gh api graphql\` (mutation \`addDiscussionComment\` with the discussion node ID). Self-overlap rule: if your facilitator profile matches one of the addressees, you may answer that part yourself, but must still Ask the other named addressees via orchestration — naming them in your reply text does not count as engaging them. Otherwise (single addressee or untargeted), route to the best-suited agent and ask them to assess the discussion and act on it; reply via the same \`addDiscussionComment\` mutation."
               ;;
             discussion_comment)
               target_type="discussion"
               target_number="$DISCUSSION_NUMBER"
               context="A new comment was posted on discussion \"$DISCUSSION_TITLE\" (#$target_number, category: $DISCUSSION_CATEGORY) by @$AUTHOR (user type: $AUTHOR_TYPE; event: $EVENT_NAME). Comment URL: $ITEM_URL. Discussion node ID: $DISCUSSION_NODE_ID."
-              action="route to the best-suited agent and ask them to assess the comment and act on it. To reply, use \`gh api graphql\` (mutation \`addDiscussionComment\` with the discussion node ID; pass \`replyToId\` to thread the reply)."
+              action="if the comment directly addresses multiple participants by role, Ask each named addressee in one parallel tool-call batch — one Ask per addressee — then post each Answer as a separate threaded reply via \`gh api graphql\` (mutation \`addDiscussionComment\` with the discussion node ID; pass \`replyToId\` to thread the reply). Self-overlap rule: if your facilitator profile matches one of the addressees, you may answer that part yourself, but must still Ask the other named addressees via orchestration. Otherwise (single addressee or untargeted), route to the best-suited agent and ask them to assess the comment and act on it; reply via the same mutation."
               ;;
             workflow_dispatch)
               target_type=""

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -21,13 +21,13 @@ import { createAsyncQueue, formatMessages } from "./orchestrator-helpers.js";
 
 /** System prompt appended for the facilitator runner. */
 export const FACILITATOR_SYSTEM_PROMPT =
-  "You coordinate multiple participants. " +
-  "Ask sends a question to a participant; omit the addressee to broadcast. " +
-  "Announce sends a message with no reply obligation. " +
-  "Redirect interrupts a participant with replacement instructions. " +
-  "RollCall lists participants. " +
-  "Conclude ends the session with a verdict ('success' or 'failure') and a summary; " +
-  "the verdict reflects whether the session met the criteria stated in the task.";
+  "You coordinate multiple participants via these tools: " +
+  "Ask delivers a question to one named participant — or broadcasts when no addressee is named — and blocks until that participant answers. " +
+  "Announce delivers a message with no reply obligation. " +
+  "Redirect interrupts an in-progress participant with replacement instructions. " +
+  "RollCall returns the participant roster. " +
+  "Conclude ends the session with a verdict ('success' or 'failure') and a summary. " +
+  "Ask and Announce calls issued in the same turn dispatch in parallel.";
 
 /** System prompt appended for facilitated agent runners. */
 export const FACILITATED_AGENT_SYSTEM_PROMPT =


### PR DESCRIPTION
## Summary

Fixes the failure mode observed on [discussion #1022](https://github.com/forwardimpact/monorepo/discussions/1022): a multi-addressee RFC got exactly one reply (release-engineer) instead of the four it asked for.

Trace analysis showed two interacting causes:

- **First run** (`discussion` event, [run 26077915407](https://github.com/forwardimpact/monorepo/actions/runs/26077915407)): the facilitator (release-engineer profile) read the discussion, recognized itself as one of the named addressees, and answered directly via `Bash`+`addDiscussionComment` — **never** calling `mcp__orchestration__Ask`. The task text said *"route to the best-suited agent"* (singular), and the facilitator interpreted that as routing-to-self.
- **Follow-up run** ([run 26077997685](https://github.com/forwardimpact/monorepo/actions/runs/26077997685)): the `discussion_comment` event fired, the recursion guard saw the latest comment was from a participant (release-engineer), and stopped after one `Bash` call. This correctly prevents loops but also prevents the *other* named addressees from being engaged via subsequent runs.

Concurrency rules (`cancel-in-progress: false`) were not the cause — the follow-up run did execute; it just exited early on the recursion guard.

### Structural fix per COALIGNED.md

The current `FACILITATOR_SYSTEM_PROMPT` mixed L0 mechanic descriptions with L4 directives (*"the verdict reflects whether the session met the criteria"*). Adding more directives at L0 would deepen the violation. Instead:

- **L0** (`libraries/libeval/src/facilitator.js`) — pure mechanics, descriptive voice. Drops the L4-leak about verdict selection. Adds the missing mechanic: *"Ask and Announce calls issued in the same turn dispatch in parallel."*
- **L4** (`.github/workflows/agent-react.yml`, `discussion` and `discussion_comment` branches) — adds explicit fan-out directive in imperative voice: when the thread directly addresses multiple participants by role (e.g. *"**Release engineer** — your view"*), `Ask` each addressee in one parallel tool-call batch and post each Answer as a separate comment. Self-overlap rule: if the facilitator profile matches an addressee, it may answer that part itself but must still `Ask` the other addressees via orchestration — naming them in the reply text does not count as engaging them. Single-addressee or untargeted threads keep the existing best-suited routing.

The recursion guard is left alone — fan-out happens inside the first run, so follow-up `discussion_comment` events correctly short-circuit by the time they execute.

## Test plan

- [x] `bun test` in `libraries/libeval/` — 482/482 pass, including the 15 prompt-contract tests (Ask/Announce naming, no enforcement phrasing, no domain vocab, no Tell/Share)
- [x] `bun run check:fix` and `bun run check` clean
- [x] YAML parses (Python `yaml.safe_load`)
- [ ] CI green
- [ ] Next multi-addressee RFC fans out via parallel `Ask` calls (validate in the wild)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gv9MoxenYRXCXwHA7pUS5j)_