### PR TITLE
plan(1200): Microsoft Teams bridge for the Kata agent team

### DIFF
--- a/specs/1200-teams-agent-bridge/design-a.md
+++ b/specs/1200-teams-agent-bridge/design-a.md
@@ -1,0 +1,183 @@
+# Design 1200-a — Microsoft Teams Bridge for the Kata Agent Team
+
+Architectural design for [spec 1200](spec.md). Three components: a bridge
+service, a workflow return-path extension, and a dev-tunnel exposure.
+
+## Components
+
+```mermaid
+graph LR
+  subgraph "Developer Machine"
+    B["Bridge Service<br/>(Bot Framework + webhook)"]
+    T["Dev Tunnel"]
+  end
+
+  subgraph "Microsoft Teams"
+    U["Engineer in<br/>group chat / channel"]
+  end
+
+  subgraph "GitHub Actions"
+    W["agent-react.yml<br/>(workflow_dispatch)"]
+    F["fit-eval facilitate<br/>(unchanged)"]
+    CB["Callback step<br/>(new)"]
+  end
+
+  U -- "@bot message" --> T
+  T -- "Bot Framework activity" --> B
+  B -- "workflow_dispatch<br/>(prompt + callback_url)" --> W
+  W --> F
+  F -- "NDJSON trace file" --> CB
+  CB -- "fit-eval callback<br/>POST verdict + summary" --> T
+  T --> B
+  B -- "proactive message" --> U
+```
+
+| Component | Location | Role |
+|---|---|---|
+| **Bridge service** | `services/msteams/` | Receives Teams messages, triggers workflow_dispatch, receives callbacks, posts responses |
+| **Callback step** | `.github/workflows/agent-react.yml` | Invokes a libeval CLI utility that reads the NDJSON trace and POSTs the conclusion to the caller-supplied URL |
+| **Dev tunnel** | External tooling (devtunnel / ngrok) | Exposes the bridge's localhost endpoints to Teams and GitHub Actions |
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+  participant E as Engineer (Teams)
+  participant B as Bridge Service
+  participant G as GitHub API
+  participant W as agent-react.yml
+  participant F as fit-eval facilitate
+
+  E->>B: @bot "review test coverage for libeval"
+  B->>B: Store conversation reference + generate correlation ID
+  B->>E: "Working on it..."
+  B->>G: POST workflow_dispatch (prompt, callback_url, correlation_id)
+  G->>W: workflow_dispatch event
+  W->>F: Compose task, run facilitate session
+  Note over F: Facilitator routes to agents,<br/>agents act, facilitator concludes
+  F-->>W: NDJSON trace written to file
+  W->>W: fit-eval callback reads trace
+  W->>B: POST callback_url {correlation_id, verdict, summary}
+  B->>B: Look up conversation reference by correlation_id
+  B->>E: Proactive message with facilitator summary
+```
+
+## Interfaces
+
+### Bridge → GitHub (outbound trigger)
+
+GitHub REST API `POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches`:
+
+```json
+{
+  "ref": "main",
+  "inputs": {
+    "prompt": "<user message + conversation context>",
+    "callback_url": "https://<tunnel>/api/callback/<token>",
+    "correlation_id": "<uuid>"
+  }
+}
+```
+
+`callback_url` and `correlation_id` are new optional inputs on
+agent-react.yml's `workflow_dispatch`. Existing callers (manual dispatch
+via GitHub UI) omit them and behavior is unchanged.
+
+### Workflow → Bridge (callback)
+
+A small CLI utility in libeval (`fit-eval callback` or similar) reads
+the NDJSON trace file produced by the facilitate session, extracts the
+orchestrator summary event (`{type: "summary", verdict, summary, turns}`),
+and POSTs it to the callback URL (capability URL — the token in the path
+authenticates the caller). The post-step in agent-react.yml invokes this
+utility.
+
+Payload:
+
+```json
+{
+  "correlation_id": "<uuid>",
+  "verdict": "success",
+  "summary": "Routed to staff-engineer who reviewed...",
+  "run_url": "https://github.com/.../actions/runs/12345"
+}
+```
+
+This requires the fit-eval step to write its NDJSON trace to a file
+(via `--output`). The callback utility reads the trace, finds the
+summary event, and delivers it — no stdout parsing needed.
+
+### Bridge ↔ Teams (Bot Framework)
+
+Standard Bot Framework v4 activity protocol over HTTPS. The bridge uses
+the `ConversationReference` stored on the inbound turn to send proactive
+messages back to the same thread. No Adaptive Cards — plain text only.
+
+## Conversation Continuity
+
+The bridge maintains an in-memory map keyed by Teams thread ID:
+
+```
+threadId → {
+  conversationReference,  // Bot Framework proactive-messaging handle
+  history: [              // rolling window of prior exchanges
+    { role: "user", text: "..." },
+    { role: "assistant", text: "..." }
+  ]
+}
+```
+
+Follow-up messages in the same thread prepend the history to the
+workflow_dispatch prompt so the facilitator has conversation context.
+The history window is bounded (the plan determines the limit) to stay
+within the `prompt` input's size constraints.
+
+## Key Decisions
+
+| Decision | Chosen | Rejected | Why |
+|---|---|---|---|
+| Return path | Callback webhook | Polling GitHub API for run completion | The bridge already exposes a public endpoint (required for Teams). Callback delivers the response immediately on session completion; polling adds latency and a background loop. |
+| Trigger mechanism | `workflow_dispatch` | `repository_dispatch` / new workflow | workflow_dispatch already exists on agent-react.yml with a free-form prompt. Adding optional inputs is a smaller change than a new event type or workflow. |
+| Bot framework | Bot Framework SDK v4 (Node.js) | Direct Microsoft Graph API | Bot Framework handles Teams authentication handshake, conversation references, and proactive messaging. Direct Graph API requires manual OAuth and state management. |
+| Conversation store | In-memory Map | File or database | Prototype is single-process, local-only. Persistent storage adds complexity without prototype value. State is lost on restart — acceptable for a demo. |
+| Bridge location | `services/msteams/` | Standalone repo / products/ | It is a running service (protocol bridge), consistent with `services/mcp` which bridges MCP to backend services. Unlike gRPC services it uses HTTP/Bot Framework and does not follow the `server.js`/`proto/` structure — this divergence is acceptable for a prototype; production placement is a follow-up concern. |
+| Summary extraction | CLI utility in libeval reads NDJSON trace | Parse stdout / modify fit-eval action outputs | The NDJSON trace already contains the structured summary event. A small CLI utility in libeval reads it directly — no stdout parsing fragility, no fit-eval action changes. |
+
+## Workflow Changes
+
+agent-react.yml gains two additions (no existing behavior changes):
+
+1. **New optional inputs** on `workflow_dispatch`: `callback_url` (string,
+   optional) and `correlation_id` (string, optional). Absent inputs
+   preserve current behavior — the callback step is skipped.
+
+2. **New post-step** after "Assess and Act": extracts the facilitator's
+   verdict and summary, and POSTs them to `callback_url` with the
+   `correlation_id`. Fires regardless of whether the facilitate session
+   succeeded or failed.
+
+## Security
+
+- **Callback authentication**: The bridge embeds an unguessable token in
+  the callback URL path (capability URL pattern — the URL itself is the
+  credential). The bridge generates and stores the token per dispatch;
+  the callback step does not need a separate secret input. This avoids
+  passing secrets through workflow_dispatch inputs, which are visible in
+  the Actions UI and API.
+
+- **Tunnel exposure**: The dev tunnel exposes only the bridge's two HTTP
+  endpoints (Bot Framework messaging endpoint, callback webhook). No
+  filesystem or shell access.
+
+- **GitHub token scope**: The bridge uses a personal access token (or
+  GitHub App token) with `actions:write` scope to trigger
+  workflow_dispatch. No broader repository access needed for the trigger
+  path.
+
+## What This Design Does Not Cover
+
+- Teams bot publishing or Azure AD multi-tenant registration (prototype
+  uses a single-tenant dev registration).
+- Rich formatting, Adaptive Cards, or file attachments.
+- The specific CLI subcommand name and argument interface for the
+  callback utility (plan concern).

--- a/specs/1200-teams-agent-bridge/msteams-config.md
+++ b/specs/1200-teams-agent-bridge/msteams-config.md
@@ -1,0 +1,409 @@
+# Microsoft Teams Configuration — Spec 1200
+
+Step-by-step configuration required on the Microsoft side before the bridge
+service can connect. Everything below targets a **single-tenant developer
+environment** — no organizational publishing, no multi-tenant Azure AD
+setup.
+
+This guide covers only the Microsoft/Azure side. The bridge service code
+lives at `services/msteams/` — see that directory's `SETUP.md` for
+installation and startup instructions.
+
+## Prerequisites
+
+- A Microsoft 365 developer tenant. Free via the
+  [Microsoft 365 Developer Program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
+  (provides a renewable E5 sandbox with 25 user licenses).
+- An Azure subscription linked to the same tenant. The developer program
+  tenant comes with an Azure AD directory; create a free Azure subscription
+  under it if one does not exist.
+- Global admin or application admin role on the tenant (the developer
+  program tenant grants this by default).
+- A dev tunnel tool: [VS Code Dev Tunnels](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/)
+  (`devtunnel` CLI) or [ngrok](https://ngrok.com/).
+
+## 1. Azure AD App Registration
+
+The bot authenticates to the Bot Framework using an Azure AD (Entra ID)
+app registration. This produces the `MICROSOFT_APP_ID`,
+`MICROSOFT_APP_PASSWORD`, and `MICROSOFT_APP_TENANT_ID` the bridge needs.
+
+1. Go to [Azure Portal → App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade).
+2. Click **New registration**.
+3. Configure:
+   - **Name:** `Kata Agent Bridge` (or any descriptive name).
+   - **Supported account types:** Select **Accounts in this organizational
+     directory only** (single tenant).
+   - **Redirect URI:** Leave blank (not needed for bot authentication).
+4. Click **Register**.
+5. On the overview page, copy the **Application (client) ID** — this is
+   `MICROSOFT_APP_ID`.
+6. Copy the **Directory (tenant) ID** — this is `MICROSOFT_APP_TENANT_ID`.
+   Required for single-tenant bot authentication;
+   `ConfigurationBotFrameworkAuthentication` defaults to multi-tenant
+   validation when the tenant ID is absent, causing all inbound activities
+   to fail with 401.
+
+### Create a client secret
+
+1. In the app registration, go to **Certificates & secrets**.
+2. Click **New client secret**.
+3. Set a description (`bridge-dev`) and expiration (e.g. 6 months).
+4. Click **Add**.
+5. Copy the secret **Value** immediately (it is shown only once) — this is
+   `MICROSOFT_APP_PASSWORD`.
+
+### API permissions
+
+The default `User.Read` permission (delegated, Microsoft Graph) is added
+automatically by Azure but is not used by the bot. The bot uses app-level
+authentication through the Bot Framework, not Graph API calls. No
+additional API permissions are required.
+
+Do **not** add application permissions unless the bridge later needs to
+call the Graph API directly (e.g. to look up user profiles).
+
+## 2. Azure Bot Resource
+
+The Azure Bot resource connects the app registration to the Bot Framework
+and registers the messaging endpoint (the URL where Teams sends activities).
+
+1. Go to [Azure Portal → Create a resource](https://portal.azure.com/#create/hub)
+   and search for **Azure Bot** (may appear as **Azure AI Bot Service** in
+   some portal regions).
+2. Click **Create**.
+3. Configure:
+   - **Bot handle:** `kata-agent-bridge` (globally unique identifier).
+   - **Subscription / Resource group:** Use an existing group or create
+     `rg-kata-bridge-dev`.
+   - **Pricing tier:** **F0 (Free)** — 10,000 messages/month, sufficient
+     for development.
+   - **Type of app:** **Single Tenant**.
+   - **Creation type:** **Use existing app registration**.
+   - **App ID:** Paste the `MICROSOFT_APP_ID` from § 1.
+   - **App tenant ID:** Paste `MICROSOFT_APP_TENANT_ID` from § 1.
+4. Click **Review + Create**, then **Create**.
+
+### Configure the messaging endpoint
+
+The messaging endpoint is the public URL where the Bot Framework delivers
+activities to the bridge. It must be HTTPS and publicly reachable.
+
+1. In the Azure Bot resource, go to **Settings → Configuration** (the
+   Configuration blade is under the Settings group in the left nav).
+2. Set **Messaging endpoint** to:
+   ```
+   https://<your-tunnel-domain>/api/messages
+   ```
+   Replace `<your-tunnel-domain>` with the tunnel's public hostname (set up
+   in § 4 below). This URL can be updated at any time when the tunnel
+   restarts with a new domain.
+
+### Enable the Teams channel
+
+1. In the Azure Bot resource, go to **Channels**.
+2. Click **Microsoft Teams** (the Teams icon).
+3. Accept the Terms of Service.
+4. Leave all settings at their defaults (Messaging enabled, Calling
+   disabled).
+5. Click **Apply**.
+
+The bot is now registered with Teams but not yet installed in any
+conversation. That happens in § 3.
+
+## 3. Teams App Package (Sideloading)
+
+The bot must be packaged as a Teams app and sideloaded into the developer
+tenant. Sideloading allows installing custom apps without publishing to the
+Teams App Store.
+
+### Enable sideloading on the tenant
+
+Two toggles must be on — missing either one causes sideloading to silently
+fail:
+
+1. **Org-wide setting:**
+   Go to [Teams Admin Center → Teams apps → Manage apps](https://admin.teams.microsoft.com/policies/manage-apps).
+   Click **Org-wide app settings** (top bar). Ensure **Allow interaction
+   with custom apps** is toggled **On**. Save.
+
+2. **Setup policy:**
+   Go to [Teams Admin Center → Teams apps → Setup policies](https://admin.teams.microsoft.com/policies/app-setup).
+   Click the **Global (Org-wide default)** policy. Ensure **Upload custom
+   apps** (also labeled **Allow users to upload custom apps**) is toggled
+   **On**. Save.
+
+Changes can take up to 24 hours to propagate (usually minutes in a
+developer tenant). To verify propagation: open Teams → Apps → Manage your
+apps — the **Upload an app** button should be visible.
+
+### Create the app manifest
+
+Create a directory for the app package with three files:
+
+**`manifest.json`:**
+
+```json
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.17",
+  "version": "0.1.0",
+  "id": "<MICROSOFT_APP_ID>",
+  "packageName": "com.forwardimpact.kata-agent-bridge",
+  "developer": {
+    "name": "Forward Impact",
+    "websiteUrl": "https://www.forwardimpact.team",
+    "privacyUrl": "https://www.forwardimpact.team/privacy",
+    "termsOfUseUrl": "https://www.forwardimpact.team/terms"
+  },
+  "name": {
+    "short": "Kata Agent",
+    "full": "Kata Agent Team Bridge"
+  },
+  "description": {
+    "short": "Invoke the Kata agent team from Teams",
+    "full": "Bridge between Microsoft Teams and the Kata agent team. Send a message to get the facilitator's conclusion back in the same thread."
+  },
+  "icons": {
+    "outline": "outline.png",
+    "color": "color.png"
+  },
+  "accentColor": "#4F46E5",
+  "bots": [
+    {
+      "botId": "<MICROSOFT_APP_ID>",
+      "scopes": ["team", "groupChat"],
+      "supportsFiles": false,
+      "isNotificationOnly": false
+    }
+  ],
+  "permissions": ["messageTeamMembers"],
+  "validDomains": ["<your-tunnel-domain>"]
+}
+```
+
+Replace both `<MICROSOFT_APP_ID>` placeholders with the Application
+(client) ID from § 1. Replace `<your-tunnel-domain>` with the tunnel
+hostname from § 4 (e.g. `abc123.use2.devtunnels.ms`). Update
+`validDomains` whenever the tunnel domain changes.
+
+**Scopes:** `team` (channel conversations) and `groupChat` (group chats).
+`personal` (1:1 chat with the bot) is excluded — the spec targets group
+contexts only. When adding to a team, the Teams UI may offer "Also open"
+for a personal tab — ignore this; the bot has no personal tab.
+
+**`color.png`:** 192x192 PNG icon (full color). For development, generate a
+solid-color placeholder:
+
+```sh
+# Using ImageMagick
+convert -size 192x192 xc:'#4F46E5' color.png
+
+# Or using Python (Pillow)
+python3 -c "from PIL import Image; Image.new('RGB',(192,192),(79,70,229)).save('color.png')"
+
+# Or use any 192x192 PNG file
+```
+
+**`outline.png`:** 32x32 PNG icon (white on transparent background):
+
+```sh
+convert -size 32x32 xc:white outline.png
+```
+
+### Package and sideload
+
+1. Zip the three files (`manifest.json`, `color.png`, `outline.png`) into
+   a file named `kata-agent-bridge.zip`. The files must be at the root of
+   the zip — no subdirectory.
+
+   ```sh
+   zip kata-agent-bridge.zip manifest.json color.png outline.png
+   ```
+
+2. Open Microsoft Teams (desktop or web client).
+3. Go to **Apps** (left sidebar) → **Manage your apps** → **Upload an app**.
+4. Select **Upload a custom app** and choose `kata-agent-bridge.zip`.
+5. Teams shows the app details. Click **Add**.
+6. Choose where to install:
+   - **Add to a team** — select a team and channel.
+   - **Add to a chat** — select a group chat.
+
+The bot now appears as a member of the selected team/chat. Users invoke it
+by @mentioning: `@Kata Agent <message>`.
+
+## 4. Dev Tunnel Setup
+
+The bridge runs on `localhost:3978`. A single tunnel exposes both the Bot
+Framework messaging endpoint (`/api/messages`) and the GitHub Actions
+callback webhook (`/api/callback/:token`) to the public internet. Both the
+Bot Framework connector and GitHub Actions POST to the same tunnel domain.
+
+### Option A: VS Code Dev Tunnels (`devtunnel` CLI)
+
+```sh
+# Install (macOS/Linux)
+curl -sL https://aka.ms/DevTunnelCliInstall | bash
+
+# Login (uses the Microsoft account linked to the dev tenant)
+devtunnel user login
+
+# Create a persistent tunnel (--allow-anonymous is required because the
+# Bot Framework connector does not pass tunnel auth credentials)
+devtunnel create kata-bridge --allow-anonymous
+
+# Map port 3978
+devtunnel port create kata-bridge --port-number 3978
+
+# Start the tunnel
+devtunnel host kata-bridge
+```
+
+`--allow-anonymous` allows unauthenticated access to the tunnel endpoints.
+This is acceptable for development: the Bot Framework messaging endpoint is
+protected by JWT token validation (the adapter verifies tokens signed by
+the Bot Framework connector), and the callback endpoint is protected by
+capability URLs (unguessable token in the path). Do **not** use anonymous
+tunnels in non-prototype contexts.
+
+The output shows the public URL, e.g.
+`https://abc123.use2.devtunnels.ms`. Use this as:
+- **Messaging endpoint** in the Azure Bot resource (§ 2):
+  `https://abc123.use2.devtunnels.ms/api/messages`
+- **`CALLBACK_BASE_URL`** environment variable (§ 5):
+  `https://abc123.use2.devtunnels.ms`
+- **`validDomains`** in manifest.json (§ 3):
+  `abc123.use2.devtunnels.ms`
+
+### Option B: ngrok
+
+```sh
+ngrok http 3978
+```
+
+Copy the `https://...ngrok-free.app` forwarding URL. Same three uses as
+above. Free ngrok URLs change on every restart — when the URL changes,
+update all three locations:
+
+1. Azure Bot messaging endpoint (§ 2).
+2. `CALLBACK_BASE_URL` environment variable — restart the bridge.
+3. `validDomains` in manifest.json — re-zip and re-upload the app package.
+
+## 5. Environment Variables Summary
+
+After completing sections 1–4, set these environment variables before
+starting the bridge:
+
+| Variable | Source | Example |
+|---|---|---|
+| `MICROSOFT_APP_ID` | § 1 — App registration overview → Application (client) ID | `a1b2c3d4-e5f6-7890-abcd-ef1234567890` |
+| `MICROSOFT_APP_PASSWORD` | § 1 — Certificates & secrets → client secret Value | `abc~DEF123...` |
+| `MICROSOFT_APP_TENANT_ID` | § 1 — App registration overview → Directory (tenant) ID | `f1e2d3c4-b5a6-7890-abcd-ef1234567890` |
+| `GH_TOKEN` | GitHub PAT or App token with `actions:write` scope only | `ghp_xxxx` |
+| `GITHUB_REPO` | `owner/repo` format | `forwardimpact/monorepo` |
+| `CALLBACK_BASE_URL` | § 4 — tunnel public URL (no trailing slash) | `https://abc123.use2.devtunnels.ms` |
+| `PORT` | Optional, defaults to `3978` | `3978` |
+
+For `GH_TOKEN`, create a fine-grained PAT scoped to the target repository
+with only the **Actions (write)** permission. Avoid using classic PATs with
+broad `repo` scope.
+
+Quick check that all required vars are set:
+
+```sh
+node -e "for (const v of ['MICROSOFT_APP_ID','MICROSOFT_APP_PASSWORD','MICROSOFT_APP_TENANT_ID','GH_TOKEN','GITHUB_REPO','CALLBACK_BASE_URL']) if (!process.env[v]) { console.error('Missing: ' + v); process.exit(1); }; console.log('All set')"
+```
+
+## 6. Verification Checklist
+
+After all configuration is complete:
+
+- [ ] App registration exists with a client secret that has not expired.
+- [ ] Azure Bot resource shows the Teams channel as **Configured** (in the
+      Channels blade).
+- [ ] Messaging endpoint in the Azure Bot Configuration blade matches the
+      running tunnel URL + `/api/messages`.
+- [ ] Both sideloading toggles are on (org-wide custom apps + setup policy
+      upload).
+- [ ] The app package is installed in at least one team or group chat.
+- [ ] The tunnel is running and forwarding to `localhost:3978`.
+- [ ] All environment variables pass the quick-check script above.
+- [ ] `node server.js` starts without error and logs the listening port.
+- [ ] Sending `@Kata Agent hello` in the configured team/chat produces a
+      `"Working on it..."` reply in the same thread.
+- [ ] After the workflow completes, a reply with the facilitator's verdict
+      and summary appears in the same Teams thread.
+- [ ] Sending a follow-up message in the same thread triggers a new
+      workflow run whose prompt includes prior conversation context.
+
+## Troubleshooting
+
+**Bot does not respond to `@Kata Agent hello`:**
+
+1. Verify the tunnel is running: `curl -s https://<tunnel>/api/messages`
+   should return a 405 (Method Not Allowed — the endpoint only accepts
+   POST). If it times out, the tunnel is not forwarding.
+2. Check the messaging endpoint in Azure Bot Configuration — it must
+   exactly match `https://<tunnel>/api/messages`.
+3. Verify `MICROSOFT_APP_ID`, `MICROSOFT_APP_PASSWORD`, and
+   `MICROSOFT_APP_TENANT_ID` are correct. Wrong credentials cause the Bot
+   Framework adapter to silently reject incoming activities (returns 401 to
+   the Bot Framework connector; no error is visible in Teams).
+4. Check the bridge's console output for errors. If no request arrives at
+   all, the messaging endpoint or tunnel is misconfigured.
+5. Verify the app is sideloaded in the specific team/chat you are testing
+   in (Apps → Manage your apps → check the install list).
+6. Wait for sideloading policy propagation if the app was just uploaded.
+
+**`"Working on it..."` appears but no facilitator response arrives:**
+
+1. Check `CALLBACK_BASE_URL` — it must be the tunnel's public URL, not
+   `http://localhost:3978`. GitHub Actions cannot reach localhost.
+2. Verify `GH_TOKEN` has `actions:write` scope and the token has not
+   expired.
+3. Check the GitHub Actions workflow run log — confirm the workflow was
+   triggered and the "Deliver callback" step ran.
+4. If the "Deliver callback" step shows "unknown command: callback", the
+   published `fit-eval` version does not yet include the `callback`
+   command. See plan-a.md § Risks (libeval publish timing).
+
+**Manifest upload fails:**
+
+1. Ensure all three files (`manifest.json`, `color.png`, `outline.png`)
+   are at the zip root — not inside a subdirectory.
+2. Validate the manifest against the schema: paste it into the
+   [Teams App Validation Tool](https://dev.teams.microsoft.com/appvalidation.html)
+   or use `npx @microsoft/teamsfx-cli validate`.
+3. Check that `<MICROSOFT_APP_ID>` placeholders were replaced with the
+   actual Application (client) ID.
+4. Verify icon dimensions: `color.png` must be exactly 192x192,
+   `outline.png` must be exactly 32x32.
+
+## Credential Rotation
+
+- **Client secret** expires per the configured lifetime (max 24 months).
+  Create a new secret first, update `MICROSOFT_APP_PASSWORD`, verify the
+  bridge works, then delete the old secret (zero-downtime rotation).
+- **GitHub token** — if using a fine-grained PAT, note the expiration date
+  and create a replacement before it expires (GitHub → Settings → Developer
+  settings → Personal access tokens). GitHub App installation tokens
+  auto-rotate.
+- **Tunnel URL** — free ngrok URLs change on restart. Dev Tunnels with a
+  named tunnel persist the URL across restarts. When the tunnel URL
+  changes, update all three locations: Azure Bot messaging endpoint,
+  `CALLBACK_BASE_URL` env var (restart the bridge), and `validDomains` in
+  the manifest (re-zip and re-upload).
+
+## Tenant Cleanup
+
+To remove the prototype from the tenant:
+
+1. Uninstall the app from all teams/chats (Teams → Apps → Manage your
+   apps → Remove).
+2. Delete the Azure Bot resource.
+3. Delete the app registration (Azure Portal → App registrations →
+   select → Delete).
+4. Optionally delete the resource group (`rg-kata-bridge-dev`).
+5. Revoke the GitHub PAT if one was created specifically for this prototype
+   (GitHub → Settings → Developer settings → Personal access tokens →
+   Delete).

--- a/specs/1200-teams-agent-bridge/plan-a.md
+++ b/specs/1200-teams-agent-bridge/plan-a.md
@@ -1,0 +1,477 @@
+# Plan 1200-a — Microsoft Teams Bridge for the Kata Agent Team
+
+Implementation plan for [spec 1200](spec.md) following
+[design 1200-a](design-a.md).
+
+## Approach
+
+The bridge is a standalone Node.js service under `services/msteams/` that
+receives Bot Framework activities from Teams via a dev tunnel, dispatches
+`workflow_dispatch` events to GitHub, and listens for callback POSTs to
+deliver the facilitator's conclusion back to the originating thread. The
+workflow side adds two optional inputs to agent-react.yml and a post-step
+that invokes a new `fit-eval callback` CLI command — a thin NDJSON reader in
+libeval that extracts the summary event and POSTs it. Conversation continuity
+is an in-memory map keyed by Teams thread ID with a bounded history window.
+
+## Steps
+
+### Step 1 — Add `fit-eval callback` command to libeval
+
+**Intent:** Give the workflow a CLI tool that reads a trace file, extracts
+the orchestrator summary event, and POSTs it to a callback URL.
+
+| Action | File |
+|---|---|
+| Create | `libraries/libeval/src/commands/callback.js` |
+| Modify | `libraries/libeval/bin/fit-eval.js` |
+
+`callback.js`:
+
+```js
+import { readFileSync } from "node:fs";
+
+export async function runCallbackCommand(values, _args) {
+  const traceFile = values["trace-file"];
+  const callbackUrl = values["callback-url"];
+  const correlationId = values["correlation-id"];
+  const runUrl = values["run-url"] ?? "";
+
+  if (!traceFile) throw new Error("--trace-file is required");
+  if (!callbackUrl) throw new Error("--callback-url is required");
+
+  const lines = readFileSync(traceFile, "utf8").split("\n");
+  let verdict = null;
+  let summary = "";
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const record = JSON.parse(line);
+    if (
+      record.source === "orchestrator" &&
+      record.event?.type === "summary"
+    ) {
+      verdict = record.event.verdict ?? "failure";
+      summary = record.event.summary ?? "";
+    }
+  }
+
+  if (verdict === null) throw new Error("No orchestrator summary event found in trace");
+
+  const payload = { correlation_id: correlationId, verdict, summary, run_url: runUrl };
+  const res = await fetch(callbackUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`Callback POST failed: ${res.status}`);
+}
+```
+
+Register `callback` in `fit-eval.js`:
+
+```js
+import { runCallbackCommand } from "../src/commands/callback.js";
+// add to COMMANDS map:
+callback: runCallbackCommand,
+```
+
+Add CLI definition entry:
+
+```js
+{
+  name: "callback",
+  args: "",
+  description: "Extract the facilitator summary from an NDJSON trace and POST it to a callback URL",
+  options: {
+    "trace-file": { type: "string", description: "Path to the NDJSON trace file" },
+    "callback-url": { type: "string", description: "URL to POST the summary to" },
+    "correlation-id": { type: "string", description: "Correlation ID to include in the payload" },
+    "run-url": { type: "string", description: "GitHub Actions run URL (optional)" },
+  },
+}
+```
+
+The `callback` command is infrastructure-only (runs inside GitHub Actions,
+not by external engineers). It does not need a documentation entry in the
+fit-eval skill or CLI `documentation` array — those link user-facing task
+guides, not CI plumbing. The command will appear in `fit-eval --help`
+output but intentionally has no linked guide.
+
+**Verify:** `echo '{"source":"orchestrator","seq":1,"event":{"type":"summary","verdict":"success","summary":"test"}}' > /tmp/trace.ndjson && bunx fit-eval callback --trace-file=/tmp/trace.ndjson --callback-url=http://localhost:3978/api/callback/test --correlation-id=abc` succeeds (against a running bridge or a simple echo server).
+
+### Step 2 — Update fit-eval@v1 composite action
+
+**Intent:** Add `output` as an accepted input on the published composite
+action so agent-react.yml can write the trace to a file.
+
+| Action | File |
+|---|---|
+| Modify | `tmp/fit-eval/action.yml` (external repo: `forwardimpact/fit-eval`) |
+
+Follow `.github/CLAUDE.md` § Editing a published action:
+
+```sh
+gh repo clone forwardimpact/fit-eval tmp/fit-eval
+```
+
+Add `output` to `action.yml`'s inputs and thread it to the CLI's `--output`
+flag. Commit, force-move the `v1` tag, push.
+
+**Verify:** The updated action accepts `output: "trace.ndjson"` and the
+trace file is written.
+
+### Step 3 — Add callback inputs and post-step to agent-react.yml
+
+**Intent:** Let external callers supply a callback URL and correlation ID
+via workflow_dispatch, and deliver the facilitator's conclusion after the
+session completes.
+
+Depends on: Step 1 (callback command exists), Step 2 (action accepts
+`output`).
+
+| Action | File |
+|---|---|
+| Modify | `.github/workflows/agent-react.yml` |
+
+Add two optional inputs to `workflow_dispatch`:
+
+```yaml
+workflow_dispatch:
+  inputs:
+    prompt:
+      description: "Ad-hoc prompt for the facilitator"
+      required: true
+      type: string
+    callback_url:
+      description: "URL to POST the facilitator conclusion to (optional)"
+      required: false
+      type: string
+    correlation_id:
+      description: "Correlation ID returned in the callback payload (optional)"
+      required: false
+      type: string
+```
+
+Add `output` to the fit-eval step:
+
+```yaml
+- name: Assess and Act
+  uses: forwardimpact/fit-eval@v1
+  # ... (existing env and with unchanged)
+  with:
+    # ... (existing inputs unchanged)
+    output: "trace.ndjson"
+```
+
+Add post-step after "Assess and Act". Use `env:` block for expression
+interpolation — never inline `${{ inputs.* }}` in `run:` shell blocks:
+
+```yaml
+- name: Deliver callback
+  if: github.event_name == 'workflow_dispatch' && always() && inputs.callback_url != ''
+  env:
+    CALLBACK_URL: ${{ inputs.callback_url }}
+    CORRELATION_ID: ${{ inputs.correlation_id }}
+    RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  run: |
+    npx fit-eval callback \
+      --trace-file=trace.ndjson \
+      --callback-url="$CALLBACK_URL" \
+      --correlation-id="$CORRELATION_ID" \
+      --run-url="$RUN_URL"
+```
+
+`github.event_name == 'workflow_dispatch'` prevents this step from firing
+on non-dispatch events (issues, PRs, discussions) where `inputs` is null.
+`always()` ensures the callback fires even when the facilitate session
+fails, matching the design's stated guarantee.
+
+**Verify:** Trigger a manual workflow_dispatch without `callback_url` —
+existing behavior unchanged. Trigger with `callback_url` pointing to a test
+endpoint — callback POST arrives with verdict and summary.
+
+### Step 4 — Create the bridge service scaffolding
+
+**Intent:** Set up the `services/msteams/` package with its entry point,
+dependencies, and configuration.
+
+| Action | File |
+|---|---|
+| Create | `services/msteams/package.json` |
+| Create | `services/msteams/server.js` |
+| Create | `services/msteams/index.js` |
+| Create | `services/msteams/README.md` |
+
+`package.json`:
+
+```json
+{
+  "name": "@forwardimpact/svcmsteams",
+  "version": "0.1.0",
+  "description": "Microsoft Teams bridge — relay messages between Teams conversations and the Kata agent team.",
+  "keywords": ["teams", "bridge", "bot", "relay", "agent"],
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "services/msteams"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Teams Using Agents",
+      "goal": "Reach the Agent Team from Teams",
+      "trigger": "Discussing work in Microsoft Teams and needing to context-switch to GitHub to ask the agent team anything.",
+      "bigHire": "invoke the Kata agent team from a Teams conversation without leaving Teams.",
+      "littleHire": "send a message and get the facilitator's conclusion back in the same thread.",
+      "competesWith": "manually creating GitHub issues; copy-pasting between Teams and GitHub; leaving the agent team unreachable from daily conversation"
+    }
+  ],
+  "type": "module",
+  "main": "./index.js",
+  "bin": { "fit-svcmsteams": "./server.js" },
+  "files": ["index.js", "server.js"],
+  "scripts": { "test": "bun test test/*.test.js" },
+  "dependencies": {
+    "botbuilder": "^4.24.0",
+    "express": "^4.21.0"
+  },
+  "engines": { "bun": ">=1.2.0", "node": ">=18.0.0" },
+  "private": true
+}
+```
+
+`private: true` deviates from the service convention (other services use
+`publishConfig`). This is deliberate — the bridge is a prototype with no npm
+consumers. Revisit before promoting beyond prototype status. The `jobs` user
+persona is `"Teams Using Agents"` rather than the conventional
+`"Platform Builders"` used by other services — the bridge is user-facing
+(Teams engineers invoke it directly), not a backend consumed by other
+products.
+
+`server.js` — entry point. Departs from the standard service bootstrap
+sequence (`createServiceConfig` / `createLogger` / `createTracer`) because
+the bridge is an HTTP/Bot Framework service, not a gRPC service — it has no
+`libconfig` config stanza, no proto definitions, and no `librpc` server.
+Logger and tracer are also omitted: the prototype uses `console.log` for
+diagnostic output; wiring `createLogger` requires a `libconfig` service
+config entry that does not exist for this service. Revisit if the bridge
+moves beyond prototype. Env vars are read directly at the composition root:
+
+```js
+#!/usr/bin/env node
+import { createBridge } from "./index.js";
+
+const bridge = createBridge({
+  microsoftAppId: process.env.MICROSOFT_APP_ID ?? "",
+  microsoftAppPassword: process.env.MICROSOFT_APP_PASSWORD ?? "",
+  microsoftAppTenantId: process.env.MICROSOFT_APP_TENANT_ID ?? "",
+  githubToken: process.env.GH_TOKEN,
+  githubRepo: process.env.GITHUB_REPO,
+  callbackBaseUrl: process.env.CALLBACK_BASE_URL,
+  port: parseInt(process.env.PORT ?? "3978", 10),
+});
+
+await bridge.start();
+```
+
+**Verify:** `cd services/msteams && bun install && node server.js` starts
+without error (no Teams connection yet — exits cleanly if env vars are
+missing).
+
+### Step 5 — Implement the bridge service
+
+**Intent:** Wire Bot Framework message handling, GitHub workflow dispatch,
+callback webhook, and conversation continuity.
+
+| Action | File |
+|---|---|
+| Modify | `services/msteams/index.js` |
+
+`index.js` exports `createBridge(config)` returning `{ start() }`.
+Internally constructs the adapter, stores, and Express app — the factory
+function is the composition root; collaborators (adapter, stores) are
+created inside and exposed on the returned object for test access.
+
+```
+createBridge(config) → {
+  start(),
+  conversations,      // Map<threadId, { ref, history }> — exposed for tests
+  pendingCallbacks,   // Map<token, { correlationId, threadId }> — exposed for tests
+  buildPrompt(text, history),  // pure function — exposed for tests
+}
+```
+
+Internal structure:
+
+1. **Express app** with two routes:
+   - `POST /api/messages` — Bot Framework messaging endpoint.
+   - `POST /api/callback/:token` — Callback webhook.
+
+2. **Bot Framework adapter** — `CloudAdapter` with
+   `ConfigurationBotFrameworkAuthentication`. `botbuilder` is CJS-only; use
+   default import with destructuring:
+   `import botbuilder from "botbuilder"; const { CloudAdapter, ... } = botbuilder;`.
+   `ConfigurationBotFrameworkAuthentication` requires `MicrosoftAppId`,
+   `MicrosoftAppPassword`, and `MicrosoftAppTenantId` (all three from
+   config) for single-tenant authentication. Processes incoming activities
+   via the `/api/messages` route. `continueConversationAsync` receives the
+   `microsoftAppId` from config.
+
+3. **Activity handler** — On `message` activity type:
+   - Extract thread ID from `activity.conversation.id`.
+   - Look up or create conversation state in `conversations`.
+   - Save the `ConversationReference` from
+     `TurnContext.getConversationReference(activity)`.
+   - Build the prompt via `buildPrompt(text, history)`: prepend last 5
+     exchanges (~4000 chars max), then the current message.
+   - Generate a correlation ID and a callback token (both via
+     `crypto.randomUUID()` — Node.js built-in, no `uuid` dependency).
+   - Store `{ correlationId, threadId }` in `pendingCallbacks` keyed by
+     the callback token.
+   - Send an acknowledgement reply: `"Working on it..."`.
+   - POST `workflow_dispatch` to GitHub REST API with `prompt`,
+     `callback_url` (`{callbackBaseUrl}/api/callback/{callbackToken}`), and
+     `correlation_id`.
+   - Append `{ role: "user", text }` to conversation history.
+
+4. **Callback handler** — On `POST /api/callback/:token`:
+   - Look up `pendingCallbacks` by the `:token` path parameter.
+   - Return 404 if not found (token is one-time use).
+   - Parse the JSON body: `{ correlation_id, verdict, summary, run_url }`.
+   - Look up conversation state via the stored `threadId`.
+   - Format reply text: `"**{verdict}** — {summary}"` (with run URL link
+     if present).
+   - Send proactive message to the stored `ConversationReference` using
+     `adapter.continueConversationAsync()`.
+   - Append `{ role: "assistant", text: summary }` to conversation history.
+   - Delete the `pendingCallbacks` entry.
+
+5. **Conversation store** — `Map<threadId, { ref, history }>`. History
+   bounded to 5 exchanges (10 entries). Keyed by Teams thread ID so
+   follow-up messages in the same thread carry context.
+
+6. **Pending callbacks store** — `Map<token, { correlationId, threadId }>`.
+   Keyed by the callback token (the value extracted from the URL path) so
+   lookups are O(1).
+
+**Verify:** Start the bridge with valid env vars. Send a message in Teams.
+Observe `"Working on it..."` reply and a workflow run triggered with the
+message text. Manually POST to the callback URL — observe the response
+message in the same Teams thread. Send a follow-up in the same thread —
+verify the dispatched prompt includes both the original message and the
+prior response summary.
+
+### Step 6 — Add tests
+
+**Intent:** Verify the callback command and bridge core logic without
+external dependencies.
+
+| Action | File |
+|---|---|
+| Create | `libraries/libeval/test/callback.test.js` |
+| Create | `services/msteams/test/bridge.test.js` |
+
+`callback.test.js`:
+
+- Writes a temp NDJSON trace file with an orchestrator summary event.
+- Starts a local HTTP server (`node:http`) to receive the callback.
+  `libharness` does not provide a callback-receiver helper (checked:
+  `createMockRequest`/`createMockResponse` mock Express req/res objects,
+  not a listening server).
+- Runs `runCallbackCommand` with the temp file and server URL.
+- Asserts the received payload contains the correct verdict, summary, and
+  correlation ID.
+- Tests the error case: trace with no summary event throws
+  `"No orchestrator summary event found in trace"`.
+
+`bridge.test.js` — imports `createBridge` and tests the extracted helpers:
+
+- `buildPrompt(text, history)`: returns just the text when history is empty;
+  prepends history entries when present; truncates history to 5 exchanges
+  (10 entries, oldest discarded first); total prompt stays within ~4000
+  chars (character cap applied after entry-count cap).
+- `pendingCallbacks` store: token-based insert, O(1) lookup, cleanup after
+  delivery.
+- `conversations` store: history append, bounded rollover.
+
+The HTTP routing and Bot Framework adapter are not unit-tested — they
+require a live Teams tenant. This is a known limitation acceptable for a
+prototype.
+
+**Verify:** `bun test libraries/libeval/test/callback.test.js` and
+`bun test services/msteams/test/bridge.test.js` pass.
+
+### Step 7 — Add setup documentation
+
+**Intent:** Document how to set up the dev environment and run the
+prototype.
+
+| Action | File |
+|---|---|
+| Create | `services/msteams/SETUP.md` |
+
+Contents:
+
+1. **Prerequisites** — Node.js 18+, a Microsoft 365 developer tenant, Azure
+   Bot registration (single-tenant), a dev tunnel tool (VS Code Dev Tunnels
+   or ngrok).
+2. **Bot registration** — Step-by-step for creating a single-tenant Azure
+   Bot registration, configuring the messaging endpoint URL.
+3. **Environment variables** — `MICROSOFT_APP_ID`, `MICROSOFT_APP_PASSWORD`,
+   `GH_TOKEN` (with `actions:write`), `GITHUB_REPO` (owner/repo),
+   `CALLBACK_BASE_URL` (the tunnel's public URL), `PORT` (default 3978).
+4. **Running** — `cd services/msteams && bun install && node server.js`.
+5. **Dev tunnel** — Start tunnel, copy the public URL to
+   `CALLBACK_BASE_URL` and the bot registration's messaging endpoint.
+6. **Testing** — Send a message to the bot in Teams, observe the
+   round-trip.
+
+### Step 8 — Regenerate catalogs
+
+**Intent:** Update generated catalog tables to include the new service.
+
+| Action | File |
+|---|---|
+| Modify | `services/README.md` (generated) |
+
+Run `bun run context:fix` to regenerate the service catalog in
+`services/README.md`. The bridge is intentionally excluded from
+`config/config.example.json` — it is not part of the init system that
+`just guide` manages (it runs standalone via `node server.js`).
+
+**Verify:** `services/README.md` includes the `msteams` row. `bun run check`
+passes.
+
+## Risks
+
+- **fit-eval@v1 action `output` input**: The published composite action may
+  not accept an `output` input. Step 2 addresses this as a prerequisite,
+  but the exact action.yml shape is unknown until inspected. The edit
+  procedure is documented in `.github/CLAUDE.md`.
+- **`botbuilder` CJS-only under ESM**: `botbuilder` ships CommonJS only.
+  Named imports (`import { CloudAdapter } from "botbuilder"`) will fail
+  under ESM. Use default import with destructuring (see Step 5 §2). Bun
+  may have additional interop issues; run the bridge with Node.js.
+- **libeval publish timing**: The workflow's `npx fit-eval callback` invokes
+  the published npm version. If the callback command is not yet released
+  when the workflow change lands, the step will fail with "unknown command."
+  Sequence: merge libeval, cut a release, then merge the workflow change.
+
+Libraries used: `botbuilder` (CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext), `express` (HTTP server).
+
+## Execution
+
+Sequential, single agent (`staff-engineer`); Step 7 (docs) can be
+delegated to `technical-writer` in parallel. Ordering:
+
+1. Step 1 (callback command) — no dependencies.
+2. Step 2 (fit-eval@v1 action update) — depends on Step 1 being released.
+3. Step 3 (workflow change) — depends on Steps 1 and 2.
+4. Step 4 (bridge scaffolding) — independent of Steps 1–3.
+5. Step 5 (bridge implementation) — depends on Step 4.
+6. Step 6 (tests) — accompanies Steps 1 and 5.
+7. Step 7 (docs) — can run in parallel with engineering steps.
+8. Step 8 (catalogs) — last, after Step 4.

--- a/specs/1200-teams-agent-bridge/spec.md
+++ b/specs/1200-teams-agent-bridge/spec.md
@@ -1,0 +1,149 @@
+# Spec 1200 — Microsoft Teams Bridge for the Kata Agent Team
+
+**JTBD:** Teams Using Agents / Run an Autonomous Development Team
+(→ [Kata](../../KATA.md)). The Kata agent team is described in CLAUDE.md
+as serving teams that "run an autonomous, continuously improving
+development team that plans, ships, studies its own traces, and acts on
+findings." This spec extends the team's reach to where engineering
+conversations already happen.
+
+## Problem
+
+### Evidence — the agent team is unreachable from where work is discussed
+
+The Kata agent team (agent-react.yml) responds to GitHub events: issues,
+PRs, comments, discussions, and workflow_dispatch. Teams that discuss work
+in Microsoft Teams cannot engage the agents without leaving the
+conversation, creating a GitHub artifact, waiting for the response, and
+manually relaying the result. This friction discourages adoption — the
+agent team is powerful but inaccessible from the tool where conversations
+already happen.
+
+### Evidence — workflow_dispatch exists but has no return path
+
+agent-react.yml accepts a free-form `prompt` via `workflow_dispatch`,
+which routes to the facilitator without any GitHub artifact as context.
+This proves the workflow can accept ad-hoc requests. But the response has
+no return path — the facilitator's conclusion (verdict and summary) is
+captured in the NDJSON trace and logged to stdout, but neither is exposed
+to subsequent workflow steps or external systems. The workflow ends and
+the conclusion is trapped in the run log.
+
+### Evidence — the facilitate session already produces a structured conclusion
+
+When the facilitator calls `Conclude`, the orchestration context captures
+a verdict ("success" / "failure") and a free-text summary. The
+`Facilitator` emits this as an NDJSON summary event of shape
+`{type: "summary", verdict, summary, turns}`. This structured output is
+the natural content for a response message — it just has no delivery
+mechanism beyond the trace file today.
+
+### Who is affected
+
+- **Engineers whose daily work happens in Microsoft Teams** — they must
+  context-switch to GitHub to ask the agent team anything, even a simple
+  question.
+- **Engineering leaders evaluating Kata adoption** — the gap between
+  "where we talk" and "where agents live" is a barrier to demonstrating
+  value.
+
+## Proposal
+
+A bridge service that connects Microsoft Teams directly to the Kata agent
+team. Microsoft Teams and GitHub (issues, PRs, discussions) are two
+parallel channels to the same agent team — the bridge does not tunnel
+through GitHub artifacts.
+
+### 1. Teams presence
+
+Engineers invoke the Kata agent team from within a Microsoft Teams
+conversation — group chats or channels — without leaving Teams. The bot
+persona represents the Release Engineer (the facilitator of the agent
+team).
+
+### 2. Bidirectional message relay
+
+Messages from Teams reach the agent team as facilitator tasks. The
+facilitator's structured conclusion (verdict + summary) reaches the
+originating Teams conversation after the facilitate session completes.
+Microsoft Teams and GitHub remain independent channels — the bridge does
+not create GitHub issues, discussions, or other artifacts as part of the
+relay.
+
+### 3. Response delivery from agent-react.yml
+
+agent-react.yml currently has no mechanism to deliver the facilitator's
+conclusion outside the workflow run. The bridge requires a return path:
+when an external caller triggers a facilitate session, the workflow
+delivers the conclusion to that caller after the session completes.
+
+### 4. Conversation continuity
+
+Follow-up messages in the same Teams conversation thread carry prior
+exchange context so the facilitator can treat them as a continuing
+conversation. Each thread maintains continuity independently.
+
+### 5. Developer-local prototype
+
+The prototype runs entirely on a developer's machine against a
+developer/test Microsoft Teams tenant. No cloud hosting required.
+
+## Scope
+
+### Included
+
+- A bridge service that runs locally and connects to a developer/test MS
+  Teams instance.
+- A Teams bot registration that engineers can invoke from group chats and
+  channels.
+- Triggering the Kata agent team with the user's message as a facilitator
+  task.
+- A return-path capability on agent-react.yml so the facilitator's
+  conclusion reaches an external caller when one is specified.
+- Posting the facilitator's response back to the originating Teams
+  conversation thread.
+- Conversation continuity across follow-up messages within a thread.
+- Setup instructions for the developer/test environment.
+
+### Excluded
+
+- Tunneling through GitHub Discussions, issues, or other GitHub artifacts
+  as relay — Teams is a parallel channel, not a GitHub frontend.
+- Changes to agent profiles or the fit-eval composite action.
+- Changes to libeval's orchestration or agent-running logic (a small
+  trace-reading utility is in scope).
+- Production deployment (Azure, container hosting, managed identity).
+- Multi-tenant support or organizational bot publishing.
+- Rich message formatting (Adaptive Cards, images, file attachments) —
+  plain text relay only.
+- Authentication federation between Teams and GitHub identities.
+- Rate limiting, retry logic, or graceful degradation beyond what the
+  prototype needs to function.
+- Message editing or deletion synchronization.
+- Streaming partial responses during the facilitate session — the
+  response is delivered after the session concludes.
+
+## Success Criteria
+
+1. An engineer invokes the bot in a Teams group chat or channel with a
+   message. The Kata agent team's facilitate session fires with that
+   message as the task. Verify: the GitHub Actions run log shows a
+   workflow run triggered by the bridge containing the message text.
+
+2. The facilitate session runs and the facilitator's conclusion (verdict +
+   summary text) is delivered to the originating Teams conversation
+   thread. Verify: a reply containing the facilitator's summary text
+   appears in the same Teams thread where the message was sent, and the
+   verdict is indicated.
+
+3. A follow-up message in the same Teams thread triggers a new facilitate
+   session whose task includes the prior exchange (at minimum, the
+   original message and the prior response). Verify: the workflow run's
+   prompt input contains text from both the original message and the
+   prior facilitator summary; the response appears in the same thread.
+
+4. The prototype runs on a developer machine with no cloud-hosted
+   infrastructure beyond GitHub Actions and the Teams API. Verify: the
+   bridge process starts on localhost, connects to a developer/test
+   Teams tenant, and criteria 1–3 pass without any deployed cloud
+   service.


### PR DESCRIPTION
## Summary

- Spec, design, implementation plan, and MS Teams configuration guide for
  a bridge service that connects Microsoft Teams to the Kata agent team as
  a parallel channel to GitHub.
- Plan covers: `fit-eval callback` CLI command, workflow return-path
  extension (new inputs + post-step on agent-react.yml), Bot Framework
  bridge service at `services/msteams/`, and conversation continuity.
- Config guide details Azure AD app registration, Azure Bot resource, app
  manifest sideloading, dev tunnel setup, and troubleshooting.

## Test plan

- [ ] `bun run check`
- [ ] Plan reviewed via two rounds of 3-reviewer panels (all blocker/high/medium findings addressed)
- [ ] MS Teams config guide reviewed for technical accuracy against Bot Framework v4, Azure AD, and Teams development

🤖 Generated with [Claude Code](https://claude.com/claude-code)