### PR TITLE
feat(msteams,libeval): Microsoft Teams bridge for the Kata agent team (#1200)

### DIFF
--- a/.github/workflows/agent-react.yml
+++ b/.github/workflows/agent-react.yml
@@ -197,14 +197,20 @@ jobs:
       # Microsoft Teams bridge) when one is specified via workflow_dispatch.
       # Skipped on issue/PR/discussion events where `inputs` is null. Runs on
       # both success and failure of the facilitate step so callers always get
-      # a verdict.
+      # a verdict — even when no trace was produced, we POST a failure
+      # placeholder so the caller is never stranded.
       #
       # fit-eval@v1 writes its NDJSON trace to a mktemp directory under /tmp
       # (path `trace--<case>.raw.ndjson`) and does not expose that path as a
       # composite-action output. Until the action exposes `trace-dir` or
-      # accepts an `output` input, we locate the trace via glob — the
-      # workflow runner reuses a fresh /tmp per job, so at most one trace
-      # file matches.
+      # accepts an `output` input, we locate the trace via glob and pick the
+      # newest match by mtime so a stale trace from a previous step on a
+      # self-hosted runner cannot win. Tracked as a follow-up to spec 1200.
+      #
+      # The callback subcommand is invoked from the monorepo workspace
+      # (`node libraries/libeval/bin/fit-eval.js`) rather than via `npx
+      # fit-eval` so this workflow does not depend on libeval being
+      # published before the workflow change lands.
       - name: Deliver callback
         if: github.event_name == 'workflow_dispatch' && always() && inputs.callback_url != ''
         env:
@@ -213,14 +219,20 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          TRACE_FILE=$(find /tmp -maxdepth 3 -name 'trace--*.raw.ndjson' 2>/dev/null | head -1)
-          if [ -z "$TRACE_FILE" ]; then
-            echo "::error::No trace file found under /tmp — fit-eval may have failed to start"
-            exit 1
+          TRACE_FILE=$(find /tmp -maxdepth 3 -name 'trace--*.raw.ndjson' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2-)
+          if [ -n "$TRACE_FILE" ] && [ -f "$TRACE_FILE" ]; then
+            echo "Using trace file: $TRACE_FILE"
+            node libraries/libeval/bin/fit-eval.js callback \
+              --trace-file="$TRACE_FILE" \
+              --callback-url="$CALLBACK_URL" \
+              --correlation-id="$CORRELATION_ID" \
+              --run-url="$RUN_URL"
+          else
+            echo "::warning::No trace file found — posting failure placeholder so the caller is not stranded"
+            curl -fsS -X POST "$CALLBACK_URL" \
+              -H 'Content-Type: application/json' \
+              -d "$(jq -n \
+                --arg cid "$CORRELATION_ID" \
+                --arg run "$RUN_URL" \
+                '{correlation_id: $cid, verdict: "failure", summary: "Facilitator session did not produce a trace; see run log.", run_url: $run}')"
           fi
-          echo "Using trace file: $TRACE_FILE"
-          npx fit-eval callback \
-            --trace-file="$TRACE_FILE" \
-            --callback-url="$CALLBACK_URL" \
-            --correlation-id="$CORRELATION_ID" \
-            --run-url="$RUN_URL"

--- a/.github/workflows/agent-react.yml
+++ b/.github/workflows/agent-react.yml
@@ -178,6 +178,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Assess and Act
+        id: assess
         uses: forwardimpact/fit-eval@v1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -200,16 +201,11 @@ jobs:
       # a verdict — even when no trace was produced, we POST a failure
       # placeholder so the caller is never stranded.
       #
-      # fit-eval@v1 writes its NDJSON trace to a mktemp directory under /tmp
-      # (path `trace--<case>.raw.ndjson`) and does not expose that path as a
-      # composite-action output. Until the action exposes `trace-dir` or
-      # accepts an `output` input, we locate the trace via glob and pick the
-      # newest match by mtime so a stale trace from a previous step on a
-      # self-hosted runner cannot win. Tracked as a follow-up to spec 1200.
-      #
-      # The callback subcommand is invoked from the monorepo workspace
-      # (`node libraries/libeval/bin/fit-eval.js`) rather than via `npx
-      # fit-eval` so this workflow does not depend on libeval being
+      # fit-eval@v1 exposes the raw NDJSON trace path as a composite output
+      # (`steps.assess.outputs.trace-file`). The callback subcommand is
+      # invoked from the monorepo workspace
+      # (`node libraries/libeval/bin/fit-eval.js`) rather than via
+      # `npx fit-eval` so this workflow does not depend on libeval being
       # published before the workflow change lands.
       - name: Deliver callback
         if: github.event_name == 'workflow_dispatch' && always() && inputs.callback_url != ''
@@ -217,9 +213,9 @@ jobs:
           CALLBACK_URL: ${{ inputs.callback_url }}
           CORRELATION_ID: ${{ inputs.correlation_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TRACE_FILE: ${{ steps.assess.outputs.trace-file }}
         run: |
           set -euo pipefail
-          TRACE_FILE=$(find /tmp -maxdepth 3 -name 'trace--*.raw.ndjson' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2-)
           if [ -n "$TRACE_FILE" ] && [ -f "$TRACE_FILE" ]; then
             echo "Using trace file: $TRACE_FILE"
             node libraries/libeval/bin/fit-eval.js callback \

--- a/.github/workflows/agent-react.yml
+++ b/.github/workflows/agent-react.yml
@@ -21,6 +21,14 @@ on:
         description: "Ad-hoc prompt for the facilitator"
         required: true
         type: string
+      callback_url:
+        description: "URL to POST the facilitator conclusion to (optional)"
+        required: false
+        type: string
+      correlation_id:
+        description: "Correlation ID returned in the callback payload (optional)"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -184,3 +192,35 @@ jobs:
           agent-profiles: "product-manager,security-engineer,staff-engineer,technical-writer"
           max-turns: "1500"
           timeout-minutes: "300"
+
+      # Deliver the facilitator's conclusion to an external caller (e.g. the
+      # Microsoft Teams bridge) when one is specified via workflow_dispatch.
+      # Skipped on issue/PR/discussion events where `inputs` is null. Runs on
+      # both success and failure of the facilitate step so callers always get
+      # a verdict.
+      #
+      # fit-eval@v1 writes its NDJSON trace to a mktemp directory under /tmp
+      # (path `trace--<case>.raw.ndjson`) and does not expose that path as a
+      # composite-action output. Until the action exposes `trace-dir` or
+      # accepts an `output` input, we locate the trace via glob — the
+      # workflow runner reuses a fresh /tmp per job, so at most one trace
+      # file matches.
+      - name: Deliver callback
+        if: github.event_name == 'workflow_dispatch' && always() && inputs.callback_url != ''
+        env:
+          CALLBACK_URL: ${{ inputs.callback_url }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TRACE_FILE=$(find /tmp -maxdepth 3 -name 'trace--*.raw.ndjson' 2>/dev/null | head -1)
+          if [ -z "$TRACE_FILE" ]; then
+            echo "::error::No trace file found under /tmp — fit-eval may have failed to start"
+            exit 1
+          fi
+          echo "Using trace file: $TRACE_FILE"
+          npx fit-eval callback \
+            --trace-file="$TRACE_FILE" \
+            --callback-url="$CALLBACK_URL" \
+            --correlation-id="$CORRELATION_ID" \
+            --run-url="$RUN_URL"

--- a/bun.lock
+++ b/bun.lock
@@ -319,7 +319,7 @@
     },
     "libraries/libsyntheticgen": {
       "name": "@forwardimpact/libsyntheticgen",
-      "version": "0.1.22",
+      "version": "0.1.24",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.61",
         "seedrandom": "^3.0.5",
@@ -335,7 +335,7 @@
     },
     "libraries/libsyntheticprose": {
       "name": "@forwardimpact/libsyntheticprose",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "dependencies": {
         "@forwardimpact/libprompt": "^0.1.0",
         "@forwardimpact/libsyntheticgen": "^0.1.21",
@@ -348,7 +348,7 @@
     },
     "libraries/libsyntheticrender": {
       "name": "@forwardimpact/libsyntheticrender",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "dependencies": {
         "@forwardimpact/libsyntheticgen": "^0.1.0",
         "@forwardimpact/libtemplate": "^0.2.0",
@@ -392,7 +392,7 @@
     },
     "libraries/libterrain": {
       "name": "@forwardimpact/libterrain",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "bin": {
         "fit-terrain": "./bin/fit-terrain.js",
       },
@@ -471,7 +471,7 @@
     },
     "libraries/libwiki": {
       "name": "@forwardimpact/libwiki",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "bin": {
         "fit-wiki": "./bin/fit-wiki.js",
       },
@@ -718,6 +718,17 @@
         "@forwardimpact/libharness": "^0.1.13",
       },
     },
+    "services/msteams": {
+      "name": "@forwardimpact/svcmsteams",
+      "version": "0.1.0",
+      "bin": {
+        "fit-svcmsteams": "./server.js",
+      },
+      "dependencies": {
+        "botbuilder": "^4.23.3",
+        "express": "^4.21.0",
+      },
+    },
     "services/pathway": {
       "name": "@forwardimpact/svcpathway",
       "version": "0.1.15",
@@ -886,6 +897,30 @@
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
 
+    "@azure/abort-controller": ["@azure/abort-controller@2.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA=="],
+
+    "@azure/core-auth": ["@azure/core-auth@1.10.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-util": "^1.13.0", "tslib": "^2.6.2" } }, "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg=="],
+
+    "@azure/core-client": ["@azure/core-client@1.10.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0", "@azure/core-tracing": "^1.3.0", "@azure/core-util": "^1.13.0", "@azure/logger": "^1.3.0", "tslib": "^2.6.2" } }, "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w=="],
+
+    "@azure/core-http-compat": ["@azure/core-http-compat@2.4.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2" }, "peerDependencies": { "@azure/core-client": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0" } }, "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA=="],
+
+    "@azure/core-rest-pipeline": ["@azure/core-rest-pipeline@1.23.0", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-tracing": "^1.3.0", "@azure/core-util": "^1.13.0", "@azure/logger": "^1.3.0", "@typespec/ts-http-runtime": "^0.3.4", "tslib": "^2.6.2" } }, "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ=="],
+
+    "@azure/core-tracing": ["@azure/core-tracing@1.3.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ=="],
+
+    "@azure/core-util": ["@azure/core-util@1.13.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A=="],
+
+    "@azure/identity": ["@azure/identity@4.13.1", "", { "dependencies": { "@azure/abort-controller": "^2.0.0", "@azure/core-auth": "^1.9.0", "@azure/core-client": "^1.9.2", "@azure/core-rest-pipeline": "^1.17.0", "@azure/core-tracing": "^1.0.0", "@azure/core-util": "^1.11.0", "@azure/logger": "^1.0.0", "@azure/msal-browser": "^5.5.0", "@azure/msal-node": "^5.1.0", "open": "^10.1.0", "tslib": "^2.2.0" } }, "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw=="],
+
+    "@azure/logger": ["@azure/logger@1.3.0", "", { "dependencies": { "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA=="],
+
+    "@azure/msal-browser": ["@azure/msal-browser@5.11.0", "", { "dependencies": { "@azure/msal-common": "16.6.2" } }, "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg=="],
+
+    "@azure/msal-common": ["@azure/msal-common@14.16.1", "", {}, "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w=="],
+
+    "@azure/msal-node": ["@azure/msal-node@2.16.3", "", { "dependencies": { "@azure/msal-common": "14.16.1", "jsonwebtoken": "^9.0.0", "uuid": "^8.3.0" } }, "sha512-CO+SE4weOsfJf+C5LM8argzvotrXw252/ZU6SM2Tz63fEblhH1uuVaaO4ISYFuN4Q6BhTo7I3qIdi8ydUQCqhw=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
@@ -1042,6 +1077,8 @@
 
     "@forwardimpact/svcmcp": ["@forwardimpact/svcmcp@workspace:services/mcp"],
 
+    "@forwardimpact/svcmsteams": ["@forwardimpact/svcmsteams@workspace:services/msteams"],
+
     "@forwardimpact/svcpathway": ["@forwardimpact/svcpathway@workspace:services/pathway"],
 
     "@forwardimpact/svctrace": ["@forwardimpact/svctrace@workspace:services/trace"],
@@ -1186,6 +1223,8 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
+    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw=="],
+
     "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
 
     "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
@@ -1200,15 +1239,21 @@
 
     "@typescript-eslint/types": ["@typescript-eslint/types@8.59.1", "", {}, "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A=="],
 
+    "@typespec/ts-http-runtime": ["@typespec/ts-http-runtime@0.3.5", "", { "dependencies": { "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "tslib": "^2.6.2" } }, "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw=="],
+
     "@zeit/schemas": ["@zeit/schemas@2.36.0", "", {}, "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": "bin/acorn" }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "adaptivecards": ["adaptivecards@1.2.3", "", {}, "sha512-amQ5OSW3OpIkrxVKLjxVBPk/T49yuOtnqs1z5ZPfZr0+OpTovzmiHbyoAGDIsu5SNYHwOZFp/3LGOnRaALFa/g=="],
+
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -1236,15 +1281,37 @@
 
     "array-back": ["array-back@6.2.3", "", {}, "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw=="],
 
+    "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
+
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "base64url": ["base64url@3.0.1", "", {}, "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+    "body-parser": ["body-parser@1.20.5", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.15.1", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA=="],
+
+    "botbuilder": ["botbuilder@4.23.3", "", { "dependencies": { "@azure/core-rest-pipeline": "^1.18.1", "@azure/msal-node": "^2.13.1", "axios": "^1.8.2", "botbuilder-core": "4.23.3", "botbuilder-stdlib": "4.23.3-internal", "botframework-connector": "4.23.3", "botframework-schema": "4.23.3", "botframework-streaming": "4.23.3", "dayjs": "^1.11.13", "filenamify": "^6.0.0", "fs-extra": "^11.2.0", "htmlparser2": "^9.0.1", "uuid": "^10.0.0", "zod": "^3.23.8" } }, "sha512-1gDIQHHYosYBHGXMjvZEJDrcp3NGy3lzHBml5wn9PFqVuIk/cbsCDZs3KJ3g+aH/GGh4CH/ij9iQ2KbQYHAYKA=="],
+
+    "botbuilder-core": ["botbuilder-core@4.23.3", "", { "dependencies": { "botbuilder-dialogs-adaptive-runtime-core": "4.23.3-preview", "botbuilder-stdlib": "4.23.3-internal", "botframework-connector": "4.23.3", "botframework-schema": "4.23.3", "uuid": "^10.0.0", "zod": "^3.23.8" } }, "sha512-48iW739I24piBH683b/Unvlu1fSzjB69ViOwZ0PbTkN2yW5cTvHJWlW7bXntO8GSqJfssgPaVthKfyaCW457ig=="],
+
+    "botbuilder-dialogs-adaptive-runtime-core": ["botbuilder-dialogs-adaptive-runtime-core@4.23.3-preview", "", { "dependencies": { "dependency-graph": "^1.0.0" } }, "sha512-EssyvqK9MobX3gbnUe/jjhLuxpCEeyQeQsyUFMJ236U6vzSQdrAxNH7Jc5DyZw2KKelBdK1xPBdwTYQNM5S0Qw=="],
+
+    "botbuilder-stdlib": ["botbuilder-stdlib@4.23.3-internal", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.9.0", "@azure/core-client": "^1.9.2", "@azure/core-http-compat": "^2.1.2", "@azure/core-rest-pipeline": "^1.18.1", "@azure/core-tracing": "^1.2.0" } }, "sha512-fwvIHnKU8sXo1gTww+m/k8wnuM5ktVBAV/3vWJ+ou40zapy1HYjWQuu6sVCRFgMUngpKwhdmoOQsTXsp58SNtA=="],
+
+    "botframework-connector": ["botframework-connector@4.23.3", "", { "dependencies": { "@azure/core-rest-pipeline": "^1.18.1", "@azure/identity": "^4.4.1", "@azure/msal-node": "^2.13.1", "@types/jsonwebtoken": "9.0.6", "axios": "^1.8.2", "base64url": "^3.0.0", "botbuilder-stdlib": "4.23.3-internal", "botframework-schema": "4.23.3", "buffer": "^6.0.3", "cross-fetch": "^4.0.0", "https-proxy-agent": "^7.0.5", "jsonwebtoken": "^9.0.2", "node-fetch": "^2.7.0", "openssl-wrapper": "^0.3.4", "rsa-pem-from-mod-exp": "^0.8.6", "zod": "^3.23.8" } }, "sha512-sChwCFJr3xhcMCYChaOxJoE8/YgdjOPWzGwz5JAxZDwhbQonwYX5O/6Z9EA+wB3TCFNEh642SGeC/rOitaTnGQ=="],
+
+    "botframework-schema": ["botframework-schema@4.23.3", "", { "dependencies": { "adaptivecards": "1.2.3", "uuid": "^10.0.0", "zod": "^3.23.8" } }, "sha512-/W0uWxZ3fuPLAImZRLnPTbs49Z2xMpJSIzIBxSfvwO0aqv9GsM3bTk3zlNdJ1xr40SshQ7WiH2H1hgjBALwYJw=="],
+
+    "botframework-streaming": ["botframework-streaming@4.23.3", "", { "dependencies": { "@types/ws": "^6.0.3", "uuid": "^10.0.0", "ws": "^7.5.10" } }, "sha512-GMtciQGfZXtAW6syUqFpFJQ2vDyVbpxL3T1DqFzq/GmmkAu7KTZ1zvo7PTww6+IT1kMW0lmL/XZJVq3Rhg4PQA=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
@@ -1254,7 +1321,11 @@
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1290,6 +1361,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "command-line-args": ["command-line-args@6.0.2", "", { "dependencies": { "array-back": "^6.2.3", "find-replace": "^5.0.2", "lodash.camelcase": "^4.3.0", "typical": "^7.3.0" }, "peerDependencies": { "@75lb/nature": "latest" }, "optionalPeers": ["@75lb/nature"] }, "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ=="],
 
     "command-line-usage": ["command-line-usage@7.0.4", "", { "dependencies": { "array-back": "^6.2.2", "chalk-template": "^0.4.0", "table-layout": "^4.1.1", "typical": "^7.3.0" } }, "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg=="],
@@ -1302,15 +1375,17 @@
 
     "compression": ["compression@1.8.1", "", { "dependencies": { "bytes": "3.1.2", "compressible": "~2.0.18", "debug": "2.6.9", "negotiator": "~0.6.4", "on-headers": "~1.1.0", "safe-buffer": "5.2.1", "vary": "~1.1.2" } }, "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w=="],
 
-    "content-disposition": ["content-disposition@0.5.2", "", {}, "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA=="],
+    "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+    "cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-fetch": ["cross-fetch@4.1.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1330,7 +1405,19 @@
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dependency-graph": ["dependency-graph@1.0.0", "", {}, "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg=="],
+
+    "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -1345,6 +1432,8 @@
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -1363,6 +1452,8 @@
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -1404,7 +1495,7 @@
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+    "express": ["express@4.22.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.5", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.15.1", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q=="],
 
     "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
@@ -1422,7 +1513,11 @@
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+    "filename-reserved-regex": ["filename-reserved-regex@3.0.0", "", {}, "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="],
+
+    "filenamify": ["filenamify@6.0.0", "", { "dependencies": { "filename-reserved-regex": "^3.0.0" } }, "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ=="],
+
+    "finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
 
     "find-replace": ["find-replace@5.0.2", "", { "peerDependencies": { "@75lb/nature": "latest" }, "optionalPeers": ["@75lb/nature"] }, "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q=="],
 
@@ -1434,11 +1529,17 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "forwardimpact-monorepo": ["forwardimpact-monorepo@root:", {}],
 
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -1470,6 +1571,8 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
@@ -1485,6 +1588,10 @@
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
 
@@ -1515,6 +1622,8 @@
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
 
@@ -1554,6 +1663,14 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "klaw": ["klaw@3.0.0", "", { "dependencies": { "graceful-fs": "^4.1.9" } }, "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g=="],
@@ -1569,6 +1686,20 @@
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
+
+    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
+
+    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
+
+    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
+
+    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
+
+    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
+
+    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
@@ -1594,13 +1725,17 @@
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+    "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+    "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
+    "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
+
     "microdata-rdf-streaming-parser": ["microdata-rdf-streaming-parser@3.0.0", "", { "dependencies": { "htmlparser2": "^9.0.0", "rdf-data-factory": "^2.0.0", "readable-stream": "^4.1.0", "relative-to-absolute-iri": "^1.0.2" } }, "sha512-CgdDaKqKAc/4gVhzUX7b1H0dKtnydqNu7dCMcvUceCZpAxX/6EO9w/U1Po195/F9fZY/oQakEREz8U1X7yrhAQ=="],
+
+    "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -1632,6 +1767,8 @@
 
     "node-emoji": ["node-emoji@2.2.0", "", { "dependencies": { "@sindresorhus/is": "^4.6.0", "char-regex": "^1.0.2", "emojilib": "^2.4.0", "skin-tone": "^2.0.0" } }, "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
@@ -1647,6 +1784,10 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "openssl-wrapper": ["openssl-wrapper@0.3.4", "", {}, "sha512-iITsrx6Ho8V3/2OVtmZzzX8wQaKAaFXEJQdzoPUZDtyf5jWFlqo+h+OhGT4TATQ47f9ACKHua8nw7Qoy85aeKQ=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -1680,7 +1821,7 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-to-regexp": ["path-to-regexp@3.3.0", "", {}, "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="],
+    "path-to-regexp": ["path-to-regexp@0.1.13", "", {}, "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -1704,13 +1845,15 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
-    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
-    "range-parser": ["range-parser@1.2.0", "", {}, "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A=="],
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
@@ -1740,6 +1883,10 @@
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
+    "rsa-pem-from-mod-exp": ["rsa-pem-from-mod-exp@0.8.6", "", {}, "sha512-c5ouQkOvGHF1qomUUDJGFcXsomeSO2gbEs6hVhMAtlkE1CuaZase/WzoaKFG/EZQuNmq6pw/EMCeEnDvOgCJYQ=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -1752,13 +1899,13 @@
 
     "semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+    "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
     "serve": ["serve@14.2.6", "", { "dependencies": { "@zeit/schemas": "2.36.0", "ajv": "8.18.0", "arg": "5.0.2", "boxen": "7.0.0", "chalk": "5.0.1", "chalk-template": "0.4.0", "clipboardy": "3.0.0", "compression": "1.8.1", "is-port-reachable": "4.0.0", "serve-handler": "6.1.7", "update-check": "1.5.4" }, "bin": "build/main.js" }, "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q=="],
 
     "serve-handler": ["serve-handler@6.1.7", "", { "dependencies": { "bytes": "3.0.0", "content-disposition": "0.5.2", "mime-types": "2.1.18", "minimatch": "3.1.5", "path-is-inside": "1.0.2", "path-to-regexp": "3.3.0", "range-parser": "1.2.0" } }, "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg=="],
 
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+    "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
@@ -1842,7 +1989,7 @@
 
     "type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+    "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "typical": ["typical@7.3.0", "", {}, "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw=="],
 
@@ -1858,11 +2005,17 @@
 
     "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
 
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "update-check": ["update-check@1.5.4", "", { "dependencies": { "registry-auth-token": "3.3.2", "registry-url": "3.1.0" } }, "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -1887,6 +2040,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
@@ -1922,25 +2077,55 @@
 
     "@aws-crypto/util/@aws-sdk/types": ["@aws-sdk/types@3.973.6", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw=="],
 
+    "@azure/identity/@azure/msal-node": ["@azure/msal-node@5.2.2", "", { "dependencies": { "@azure/msal-common": "16.6.2", "jsonwebtoken": "^9.0.0" } }, "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q=="],
+
+    "@azure/msal-browser/@azure/msal-common": ["@azure/msal-common@16.6.2", "", {}, "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA=="],
+
+    "@azure/msal-node/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
+    "@modelcontextprotocol/sdk/express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@protobufjs/fetch/@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
 
-    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "@typespec/ts-http-runtime/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
-    "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "apache-arrow/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+
+    "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "body-parser/raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
+
+    "botbuilder/htmlparser2": ["htmlparser2@9.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.1.0", "entities": "^4.5.0" } }, "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ=="],
+
+    "botbuilder/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "botbuilder-core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "botframework-connector/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "botframework-connector/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "botframework-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "botframework-streaming/@types/ws": ["@types/ws@6.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg=="],
 
     "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -1968,11 +2153,11 @@
 
     "eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
-    "express/content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+    "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "express/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
@@ -1981,6 +2166,10 @@
     "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
     "jsdoc/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
@@ -1991,6 +2180,8 @@
     "microdata-rdf-streaming-parser/htmlparser2": ["htmlparser2@9.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.1.0", "entities": "^4.5.0" } }, "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ=="],
 
     "mime-types/mime-db": ["mime-db@1.33.0", "", {}, "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="],
+
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
@@ -2004,21 +2195,27 @@
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
-    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "send/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+    "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "serve/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "serve-handler/bytes": ["bytes@3.0.0", "", {}, "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="],
 
+    "serve-handler/content-disposition": ["content-disposition@0.5.2", "", {}, "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA=="],
+
     "serve-handler/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "serve-handler/path-to-regexp": ["path-to-regexp@3.3.0", "", {}, "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="],
+
+    "serve-handler/range-parser": ["range-parser@1.2.0", "", {}, "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
-    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2034,11 +2231,45 @@
 
     "@aws-crypto/util/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
 
+    "@azure/identity/@azure/msal-node/@azure/msal-common": ["@azure/msal-common@16.6.2", "", {}, "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA=="],
+
+    "@modelcontextprotocol/sdk/express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "@modelcontextprotocol/sdk/express/body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "@modelcontextprotocol/sdk/express/content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "@modelcontextprotocol/sdk/express/cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "@modelcontextprotocol/sdk/express/finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "@modelcontextprotocol/sdk/express/fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "@modelcontextprotocol/sdk/express/merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "@modelcontextprotocol/sdk/express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "@modelcontextprotocol/sdk/express/qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "@modelcontextprotocol/sdk/express/send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "@modelcontextprotocol/sdk/express/serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "@modelcontextprotocol/sdk/express/type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "@typespec/ts-http-runtime/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "apache-arrow/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "botframework-connector/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "cli-highlight/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
@@ -2064,11 +2295,29 @@
 
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "protobufjs-cli/espree/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@modelcontextprotocol/sdk/express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "@modelcontextprotocol/sdk/express/type-is/media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/libraries/libcoaligned/src/jtbd.js
+++ b/libraries/libcoaligned/src/jtbd.js
@@ -5,7 +5,6 @@ import * as prettier from "prettier";
 const VALID_USERS = [
   "Engineering Leaders",
   "Empowered Engineers",
-  "Teams Using Agents",
   "Platform Builders",
 ];
 

--- a/libraries/libcoaligned/src/jtbd.js
+++ b/libraries/libcoaligned/src/jtbd.js
@@ -5,6 +5,7 @@ import * as prettier from "prettier";
 const VALID_USERS = [
   "Engineering Leaders",
   "Empowered Engineers",
+  "Teams Using Agents",
   "Platform Builders",
 ];
 

--- a/libraries/libeval/bin/fit-eval.js
+++ b/libraries/libeval/bin/fit-eval.js
@@ -9,6 +9,7 @@ import { runTeeCommand } from "../src/commands/tee.js";
 import { runRunCommand } from "../src/commands/run.js";
 import { runSuperviseCommand } from "../src/commands/supervise.js";
 import { runFacilitateCommand } from "../src/commands/facilitate.js";
+import { runCallbackCommand } from "../src/commands/callback.js";
 
 // `bun build --compile` injects FIT_EVAL_VERSION via --define, eliminating
 // the readFileSync branch in the compiled binary (which would ENOENT against
@@ -198,6 +199,30 @@ const definition = {
       description:
         "Stream readable text to stdout while saving raw NDJSON to a file",
     },
+    {
+      name: "callback",
+      args: "",
+      description:
+        "Extract the facilitator summary from an NDJSON trace and POST it to a callback URL",
+      options: {
+        "trace-file": {
+          type: "string",
+          description: "Path to the NDJSON trace file",
+        },
+        "callback-url": {
+          type: "string",
+          description: "URL to POST the summary to",
+        },
+        "correlation-id": {
+          type: "string",
+          description: "Correlation ID to include in the payload",
+        },
+        "run-url": {
+          type: "string",
+          description: "GitHub Actions run URL (optional)",
+        },
+      },
+    },
   ],
   globalOptions: {
     format: { type: "string", description: "Output format (json|text)" },
@@ -248,6 +273,7 @@ const COMMANDS = {
   run: runRunCommand,
   supervise: runSuperviseCommand,
   facilitate: runFacilitateCommand,
+  callback: runCallbackCommand,
 };
 
 async function main() {

--- a/libraries/libeval/src/commands/callback.js
+++ b/libraries/libeval/src/commands/callback.js
@@ -1,6 +1,34 @@
 import { readFileSync } from "node:fs";
 
 /**
+ * Scan an NDJSON trace and return the last orchestrator summary event, or
+ * null if none is present. Skips malformed lines (a trace writer that
+ * crashed mid-flush can leave a partial trailing record).
+ *
+ * @param {string} traceFile
+ * @returns {{verdict: string, summary: string} | null}
+ */
+function findOrchestratorSummary(traceFile) {
+  let result = null;
+  for (const line of readFileSync(traceFile, "utf8").split("\n")) {
+    if (!line.trim()) continue;
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (record.source === "orchestrator" && record.event?.type === "summary") {
+      result = {
+        verdict: record.event.verdict ?? "failure",
+        summary: record.event.summary ?? "",
+      };
+    }
+  }
+  return result;
+}
+
+/**
  * Callback command — read an NDJSON trace file, extract the orchestrator's
  * summary event, and POST it to a callback URL. Used by agent-react.yml to
  * deliver the facilitator's conclusion to an external caller (e.g. the
@@ -18,27 +46,15 @@ export async function runCallbackCommand(values, _args) {
   if (!traceFile) throw new Error("--trace-file is required");
   if (!callbackUrl) throw new Error("--callback-url is required");
 
-  const lines = readFileSync(traceFile, "utf8").split("\n");
-  let verdict = null;
-  let summary = "";
-
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    const record = JSON.parse(line);
-    if (record.source === "orchestrator" && record.event?.type === "summary") {
-      verdict = record.event.verdict ?? "failure";
-      summary = record.event.summary ?? "";
-    }
-  }
-
-  if (verdict === null) {
+  const found = findOrchestratorSummary(traceFile);
+  if (found === null) {
     throw new Error("No orchestrator summary event found in trace");
   }
 
   const payload = {
     correlation_id: correlationId,
-    verdict,
-    summary,
+    verdict: found.verdict,
+    summary: found.summary,
     run_url: runUrl,
   };
   const res = await fetch(callbackUrl, {

--- a/libraries/libeval/src/commands/callback.js
+++ b/libraries/libeval/src/commands/callback.js
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Callback command — read an NDJSON trace file, extract the orchestrator's
+ * summary event, and POST it to a callback URL. Used by agent-react.yml to
+ * deliver the facilitator's conclusion to an external caller (e.g. the
+ * Microsoft Teams bridge) after the facilitate session completes.
+ *
+ * @param {object} values - Parsed option values from cli.parse()
+ * @param {string[]} _args - Positional arguments
+ */
+export async function runCallbackCommand(values, _args) {
+  const traceFile = values["trace-file"];
+  const callbackUrl = values["callback-url"];
+  const correlationId = values["correlation-id"];
+  const runUrl = values["run-url"] ?? "";
+
+  if (!traceFile) throw new Error("--trace-file is required");
+  if (!callbackUrl) throw new Error("--callback-url is required");
+
+  const lines = readFileSync(traceFile, "utf8").split("\n");
+  let verdict = null;
+  let summary = "";
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const record = JSON.parse(line);
+    if (record.source === "orchestrator" && record.event?.type === "summary") {
+      verdict = record.event.verdict ?? "failure";
+      summary = record.event.summary ?? "";
+    }
+  }
+
+  if (verdict === null) {
+    throw new Error("No orchestrator summary event found in trace");
+  }
+
+  const payload = {
+    correlation_id: correlationId,
+    verdict,
+    summary,
+    run_url: runUrl,
+  };
+  const res = await fetch(callbackUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`Callback POST failed: ${res.status}`);
+  }
+}

--- a/libraries/libeval/test/callback.test.js
+++ b/libraries/libeval/test/callback.test.js
@@ -1,0 +1,223 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:http";
+
+import { runCallbackCommand } from "../src/commands/callback.js";
+
+// Some sibling test files (libstorage-utils.test.js) mock global.fetch and
+// do not restore it. When bun runs files in the same process, the mock
+// leaks into our tests. Snapshot the real fetch at module load and pin it
+// before each describe.
+const REAL_FETCH = globalThis.fetch.bind(globalThis);
+
+/**
+ * Start a one-shot HTTP server that records the first request and returns
+ * the configured status. Returns the URL, a getter for the captured
+ * request, and a close() helper.
+ */
+function startServer(status = 200) {
+  return new Promise((resolve) => {
+    /** @type {{method: string, url: string, body: any} | null} */
+    let lastRequest = null;
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        lastRequest = {
+          method: req.method,
+          url: req.url,
+          body: body ? JSON.parse(body) : null,
+        };
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: status < 400 }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        getLastRequest: () => lastRequest,
+        close: () =>
+          new Promise((closeResolve) => server.close(() => closeResolve())),
+      });
+    });
+  });
+}
+
+function writeTrace(records) {
+  const workdir = mkdtempSync(join(tmpdir(), "callback-test-"));
+  const tracePath = join(workdir, "trace.ndjson");
+  writeFileSync(
+    tracePath,
+    `${records.map((r) => JSON.stringify(r)).join("\n")}\n`,
+  );
+  return {
+    tracePath,
+    cleanup: () => rmSync(workdir, { recursive: true, force: true }),
+  };
+}
+
+describe("fit-eval callback", () => {
+  beforeEach(() => {
+    globalThis.fetch = REAL_FETCH;
+  });
+
+  test("extracts the orchestrator summary and POSTs it to the callback URL", async () => {
+    const server = await startServer(200);
+    const { tracePath, cleanup } = writeTrace([
+      { source: "agent", seq: 0, event: { type: "start" } },
+      {
+        source: "orchestrator",
+        seq: 1,
+        event: {
+          type: "summary",
+          verdict: "success",
+          summary: "Routed to staff-engineer.",
+          turns: 7,
+        },
+      },
+    ]);
+
+    try {
+      await runCallbackCommand({
+        "trace-file": tracePath,
+        "callback-url": `${server.url}/api/callback/abc`,
+        "correlation-id": "corr-123",
+        "run-url": "https://github.com/foo/bar/actions/runs/42",
+      });
+
+      const req = server.getLastRequest();
+      assert.strictEqual(req.method, "POST");
+      assert.strictEqual(req.url, "/api/callback/abc");
+      assert.deepStrictEqual(req.body, {
+        correlation_id: "corr-123",
+        verdict: "success",
+        summary: "Routed to staff-engineer.",
+        run_url: "https://github.com/foo/bar/actions/runs/42",
+      });
+    } finally {
+      await server.close();
+      cleanup();
+    }
+  });
+
+  test("uses the most recent summary event when multiple appear", async () => {
+    const server = await startServer(200);
+    const { tracePath, cleanup } = writeTrace([
+      {
+        source: "orchestrator",
+        seq: 1,
+        event: { type: "summary", verdict: "failure", summary: "first" },
+      },
+      {
+        source: "orchestrator",
+        seq: 2,
+        event: { type: "summary", verdict: "success", summary: "final" },
+      },
+    ]);
+
+    try {
+      await runCallbackCommand({
+        "trace-file": tracePath,
+        "callback-url": `${server.url}/api/callback/multi`,
+        "correlation-id": "m",
+      });
+
+      const req = server.getLastRequest();
+      assert.strictEqual(req.body.verdict, "success");
+      assert.strictEqual(req.body.summary, "final");
+      assert.strictEqual(req.body.run_url, "");
+    } finally {
+      await server.close();
+      cleanup();
+    }
+  });
+
+  test("throws when no orchestrator summary event is present", async () => {
+    const { tracePath, cleanup } = writeTrace([
+      { source: "agent", seq: 0, event: { type: "start" } },
+    ]);
+
+    try {
+      await assert.rejects(
+        () =>
+          runCallbackCommand({
+            "trace-file": tracePath,
+            "callback-url": "http://127.0.0.1:1/unused",
+            "correlation-id": "x",
+          }),
+        /No orchestrator summary event found in trace/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("requires --trace-file and --callback-url", async () => {
+    await assert.rejects(
+      () => runCallbackCommand({ "callback-url": "http://example" }),
+      /--trace-file is required/,
+    );
+    await assert.rejects(
+      () => runCallbackCommand({ "trace-file": "/dev/null" }),
+      /--callback-url is required/,
+    );
+  });
+
+  test("treats a missing verdict as 'failure'", async () => {
+    const server = await startServer(200);
+    const { tracePath, cleanup } = writeTrace([
+      {
+        source: "orchestrator",
+        seq: 1,
+        event: { type: "summary", summary: "session aborted" },
+      },
+    ]);
+
+    try {
+      await runCallbackCommand({
+        "trace-file": tracePath,
+        "callback-url": `${server.url}/api/callback/nv`,
+        "correlation-id": "nv",
+      });
+
+      const req = server.getLastRequest();
+      assert.strictEqual(req.body.verdict, "failure");
+      assert.strictEqual(req.body.summary, "session aborted");
+    } finally {
+      await server.close();
+      cleanup();
+    }
+  });
+
+  test("throws when the callback POST returns a non-2xx status", async () => {
+    const server = await startServer(500);
+    const { tracePath, cleanup } = writeTrace([
+      {
+        source: "orchestrator",
+        seq: 1,
+        event: { type: "summary", verdict: "success", summary: "ok" },
+      },
+    ]);
+
+    try {
+      await assert.rejects(
+        () =>
+          runCallbackCommand({
+            "trace-file": tracePath,
+            "callback-url": `${server.url}/x`,
+            "correlation-id": "x",
+          }),
+        /Callback POST failed: 500/,
+      );
+    } finally {
+      await server.close();
+      cleanup();
+    }
+  });
+});

--- a/libraries/libstorage/test/libstorage-utils.test.js
+++ b/libraries/libstorage/test/libstorage-utils.test.js
@@ -1,4 +1,4 @@
-import { test, describe, beforeEach } from "node:test";
+import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
 import { spy } from "@forwardimpact/libharness";
 
@@ -63,8 +63,10 @@ describe("SupabaseStorage", () => {
   let mockClient;
   let mockCommands;
   let supabaseStorage;
+  let originalFetch;
 
   beforeEach(() => {
+    originalFetch = globalThis.fetch;
     mockClient = { send: spy(() => Promise.resolve()) };
     mockCommands = {
       PutObjectCommand: spy((params) => ({ params })),
@@ -83,6 +85,10 @@ describe("SupabaseStorage", () => {
       "service-role-key-123",
       mockCommands,
     );
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   test("constructor throws when serviceRoleKey is missing", () => {

--- a/services/README.md
+++ b/services/README.md
@@ -25,20 +25,20 @@ that let agents consume backend functionality natively.
 
 <!-- BEGIN:jobs — Do not edit. Generated from each service's package.json. -->
 
-<job user="Teams Using Agents" goal="Reach the Agent Team from Teams">
+<job user="Platform Builders" goal="Bridge Conversation Platforms to the Agent Team">
 
-## Teams Using Agents: Reach the Agent Team from Teams
+## Platform Builders: Bridge Conversation Platforms to the Agent Team
 
-**Trigger:** Discussing work in Microsoft Teams and needing to context-switch to
-GitHub to ask the agent team anything.
+**Trigger:** Engineers discuss work in Microsoft Teams and need to
+context-switch to GitHub to invoke the agent team.
 
-**Big Hire:** Help me invoke the Kata agent team from a Teams conversation
-without leaving Teams. → **msteams**
+**Big Hire:** Help me relay messages between a chat platform and the Kata agent
+team without leaving the conversation. → **msteams**
 
-**Little Hire:** Help me send a message and get the facilitator's conclusion
-back in the same thread. → **msteams**
+**Little Hire:** Help me dispatch a facilitate session from a chat message and
+return the verdict to the same thread. → **msteams**
 
-**Competes With:** manually creating GitHub issues; copy-pasting between Teams
+**Competes With:** manually creating GitHub issues; copy-pasting between chat
 and GitHub; leaving the agent team unreachable from daily conversation.
 
 </job>

--- a/services/README.md
+++ b/services/README.md
@@ -14,6 +14,7 @@ that let agents consume backend functionality natively.
 | **graph**   | RDF knowledge graph over gRPC — relationship queries without each product standing up its own store.     |
 | **map**     | Activity reads and writes over gRPC — the agent-facing gateway to Map's activity database.               |
 | **mcp**     | Unified MCP server — agents reach backend services as tools without per-service integration.             |
+| **msteams** | Microsoft Teams bridge — relay messages between Teams conversations and the Kata agent team.             |
 | **pathway** | Engineering standard queries over gRPC — career paths and agent profiles as derivable data for products. |
 | **trace**   | OpenTelemetry span ingestion and storage over gRPC — prove whether agent changes improved outcomes.      |
 | **vector**  | Vector similarity search over gRPC — semantic retrieval without a dedicated database per product.        |
@@ -23,6 +24,24 @@ that let agents consume backend functionality natively.
 ## Jobs To Be Done
 
 <!-- BEGIN:jobs — Do not edit. Generated from each service's package.json. -->
+
+<job user="Teams Using Agents" goal="Reach the Agent Team from Teams">
+
+## Teams Using Agents: Reach the Agent Team from Teams
+
+**Trigger:** Discussing work in Microsoft Teams and needing to context-switch to
+GitHub to ask the agent team anything.
+
+**Big Hire:** Help me invoke the Kata agent team from a Teams conversation
+without leaving Teams. → **msteams**
+
+**Little Hire:** Help me send a message and get the facilitator's conclusion
+back in the same thread. → **msteams**
+
+**Competes With:** manually creating GitHub issues; copy-pasting between Teams
+and GitHub; leaving the agent team unreachable from daily conversation.
+
+</job>
 
 <job user="Platform Builders" goal="Expose Activity Data to Agents">
 

--- a/services/msteams/README.md
+++ b/services/msteams/README.md
@@ -1,0 +1,60 @@
+# svcmsteams
+
+<!-- BEGIN:description — Do not edit. Generated from package.json. -->
+
+Microsoft Teams bridge — relay messages between Teams conversations and the Kata
+agent team.
+
+<!-- END:description -->
+
+## Purpose
+
+Engineers whose work happens in Microsoft Teams cannot engage the Kata agent
+team without context-switching to GitHub. This service bridges the gap: a
+message in a Teams group chat or channel dispatches a facilitate session, and
+the facilitator's conclusion is delivered back to the same thread.
+
+The bridge is a **prototype**, runs locally on a developer machine against a
+developer/test Microsoft 365 tenant, and has no production deployment story
+yet.
+
+## How it works
+
+```
+Teams → /api/messages → Bot Framework adapter
+      → workflow_dispatch (agent-react.yml) on GitHub
+      → fit-eval facilitate session
+      → fit-eval callback POST to /api/callback/:token
+      → adapter.continueConversationAsync → Teams reply
+```
+
+Conversation continuity is in-memory per process. State is lost on restart —
+acceptable for a prototype.
+
+## Setup
+
+See [`SETUP.md`](SETUP.md) for the dev environment walkthrough and
+[`../../specs/1200-teams-agent-bridge/msteams-config.md`](../../specs/1200-teams-agent-bridge/msteams-config.md)
+for the Microsoft Azure / Teams side.
+
+## Run
+
+```sh
+cd services/msteams
+bun install
+node server.js
+```
+
+Required environment variables: `MICROSOFT_APP_ID`, `MICROSOFT_APP_PASSWORD`,
+`MICROSOFT_APP_TENANT_ID`, `GH_TOKEN`, `GITHUB_REPO`, `CALLBACK_BASE_URL`.
+Optional: `PORT` (default `3978`).
+
+## Tests
+
+```sh
+bun test test/*.test.js
+```
+
+The Bot Framework adapter and live Teams API are not unit-tested — they
+require a live tenant. Tests cover the pure helpers (`buildPrompt`,
+`formatReply`) and the in-memory stores.

--- a/services/msteams/SETUP.md
+++ b/services/msteams/SETUP.md
@@ -10,9 +10,11 @@ one.
 
 ## Prerequisites
 
-- Node.js 18 or newer (Bun also works for tests). The bridge is started
-  with `node server.js` because `botbuilder` ships CommonJS only and Bun's
-  ESM/CJS interop is unreliable for the Bot Framework SDK.
+- Node.js 18 or newer. The bridge **server** is started with `node
+  server.js` — `botbuilder` ships CommonJS only and the Bot Framework
+  adapter has historically been brittle under Bun's CJS interop. Bun is
+  fine for running the test suite (`bun test`) — the tests cover pure
+  helpers and stores, not the live adapter.
 - A Microsoft 365 developer tenant with an Azure Bot resource registered
   for the Teams channel — see
   [msteams-config.md § 1–3](../../specs/1200-teams-agent-bridge/msteams-config.md).

--- a/services/msteams/SETUP.md
+++ b/services/msteams/SETUP.md
@@ -1,0 +1,114 @@
+# Setup — Microsoft Teams Bridge
+
+This guide walks through running the bridge service on a developer machine
+against a developer/test Microsoft 365 tenant. The Microsoft-side
+configuration (Azure AD app registration, Azure Bot, Teams app manifest,
+sideloading) lives in
+[`specs/1200-teams-agent-bridge/msteams-config.md`](../../specs/1200-teams-agent-bridge/msteams-config.md).
+Complete that guide first — the values it produces are the inputs to this
+one.
+
+## Prerequisites
+
+- Node.js 18 or newer (Bun also works for tests). The bridge is started
+  with `node server.js` because `botbuilder` ships CommonJS only and Bun's
+  ESM/CJS interop is unreliable for the Bot Framework SDK.
+- A Microsoft 365 developer tenant with an Azure Bot resource registered
+  for the Teams channel — see
+  [msteams-config.md § 1–3](../../specs/1200-teams-agent-bridge/msteams-config.md).
+- A dev tunnel tool (VS Code Dev Tunnels or ngrok) — see
+  [msteams-config.md § 4](../../specs/1200-teams-agent-bridge/msteams-config.md).
+- A GitHub token with `actions:write` on `forwardimpact/monorepo`
+  (fine-grained PAT or GitHub App installation token).
+
+## Environment variables
+
+| Variable | Source | Notes |
+|---|---|---|
+| `MICROSOFT_APP_ID` | Azure AD app registration → Application (client) ID | UUID |
+| `MICROSOFT_APP_PASSWORD` | Azure AD app registration → client secret value | shown once at creation |
+| `MICROSOFT_APP_TENANT_ID` | Azure AD app registration → Directory (tenant) ID | required for single-tenant validation |
+| `GH_TOKEN` | GitHub PAT or App token | `actions:write` only |
+| `GITHUB_REPO` | `owner/repo` | typically `forwardimpact/monorepo` |
+| `CALLBACK_BASE_URL` | Dev tunnel public URL | no trailing slash |
+| `PORT` | Optional | defaults to `3978` |
+
+Quick check that everything is set:
+
+```sh
+node -e "for (const v of ['MICROSOFT_APP_ID','MICROSOFT_APP_PASSWORD','MICROSOFT_APP_TENANT_ID','GH_TOKEN','GITHUB_REPO','CALLBACK_BASE_URL']) if (!process.env[v]) { console.error('Missing: ' + v); process.exit(1); }; console.log('All set')"
+```
+
+## Install and run
+
+```sh
+cd services/msteams
+bun install
+node server.js
+```
+
+The bridge logs `Teams bridge listening on port 3978` once it is ready.
+
+## Start the dev tunnel
+
+The bridge needs a publicly reachable HTTPS URL for two endpoints:
+
+1. `POST /api/messages` — Bot Framework messaging endpoint (called by Teams)
+2. `POST /api/callback/:token` — Callback webhook (called by GitHub Actions)
+
+Both endpoints live on the same port. One tunnel covers both:
+
+```sh
+# VS Code Dev Tunnels (persistent named tunnel)
+devtunnel host kata-bridge
+
+# or ngrok (URL changes on every restart)
+ngrok http 3978
+```
+
+Copy the public URL into:
+
+- `CALLBACK_BASE_URL` (and restart the bridge)
+- The Azure Bot resource's messaging endpoint:
+  `https://<tunnel-domain>/api/messages`
+- The Teams app manifest's `validDomains` (re-zip and re-upload if it
+  changed) — see
+  [msteams-config.md § 3](../../specs/1200-teams-agent-bridge/msteams-config.md).
+
+## Smoke test
+
+1. In the team or group chat where the app is installed, send
+   `@Kata Agent hello`.
+2. The bot replies `"Working on it..."` in the same thread within a few
+   seconds.
+3. Open the
+   [agent-react.yml workflow runs](https://github.com/forwardimpact/monorepo/actions/workflows/agent-react.yml)
+   and confirm a new run triggered by the bridge with the message text as
+   the prompt input.
+4. When the facilitate session completes, a reply containing
+   `**<verdict>** — <summary>` arrives in the same Teams thread.
+5. Send a follow-up message in the same thread — verify the workflow's
+   prompt input now contains both the original message and the prior
+   summary.
+
+## Troubleshooting
+
+See
+[msteams-config.md § Troubleshooting](../../specs/1200-teams-agent-bridge/msteams-config.md)
+for the most common failure modes (bot not responding, callback timing out,
+manifest upload errors). The bridge's own console output (stdout) is the
+primary diagnostic channel for the local process.
+
+## Limitations
+
+The prototype is intentionally minimal:
+
+- **Single process, single tenant.** No clustering, no multi-tenant support.
+- **In-memory state.** Conversation history is lost when the bridge
+  restarts.
+- **No rich formatting.** Plain text only — no Adaptive Cards, files, or
+  images.
+- **No streaming.** The reply arrives after the facilitate session
+  concludes, not as partial output.
+- **No retry/backoff.** A failed GitHub dispatch or callback POST is
+  surfaced as an error message; the user re-sends the request manually.

--- a/services/msteams/index.js
+++ b/services/msteams/index.js
@@ -51,15 +51,26 @@ export function formatReply(payload) {
 
 /**
  * Append a message to a bounded history, dropping the oldest entries when
- * the cap is exceeded.
+ * the cap is exceeded. Exported for unit testing.
  *
  * @param {Array<{role: "user"|"assistant", text: string}>} history
  * @param {{role: "user"|"assistant", text: string}} entry
  */
-function appendHistory(history, entry) {
+export function appendHistory(history, entry) {
   history.push(entry);
   const max = HISTORY_MAX_EXCHANGES * 2;
   while (history.length > max) history.shift();
+}
+
+/**
+ * Strip trailing slashes from a base URL so concatenation does not produce
+ * double-slashes that fail route matching on the callback endpoint.
+ *
+ * @param {string} url
+ * @returns {string}
+ */
+function normalizeBaseUrl(url) {
+  return (url ?? "").replace(/\/+$/, "");
 }
 
 /**
@@ -123,6 +134,7 @@ async function dispatchWorkflow({
  */
 export function createBridge(config) {
   const port = config.port ?? 3978;
+  const callbackBaseUrl = normalizeBaseUrl(config.callbackBaseUrl);
   const conversations = new Map();
   const pendingCallbacks = new Map();
 
@@ -163,7 +175,7 @@ export function createBridge(config) {
     const prompt = buildPrompt(text, state.history);
     const correlationId = randomUUID();
     const callbackToken = randomUUID();
-    const callbackUrl = `${config.callbackBaseUrl}/api/callback/${callbackToken}`;
+    const callbackUrl = `${callbackBaseUrl}/api/callback/${callbackToken}`;
 
     pendingCallbacks.set(callbackToken, { correlationId, threadId });
 
@@ -203,9 +215,18 @@ export function createBridge(config) {
       res.status(404).json({ error: "Unknown callback token" });
       return;
     }
-    pendingCallbacks.delete(token);
 
     const payload = req.body ?? {};
+    // Defense in depth: the token already gates trust (capability URL),
+    // but the workflow round-trips correlation_id specifically so the
+    // bridge can detect a mis-routed callback. Reject mismatches before
+    // emitting any Teams activity.
+    if (payload.correlation_id !== pending.correlationId) {
+      res.status(400).json({ error: "Correlation ID mismatch" });
+      return;
+    }
+    pendingCallbacks.delete(token);
+
     const state = conversations.get(pending.threadId);
     if (!state || !state.ref) {
       res.status(410).json({ error: "Conversation reference missing" });

--- a/services/msteams/index.js
+++ b/services/msteams/index.js
@@ -1,0 +1,261 @@
+import { randomUUID } from "node:crypto";
+
+import botbuilder from "botbuilder";
+import express from "express";
+
+const { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext } =
+  botbuilder;
+
+const HISTORY_MAX_EXCHANGES = 5;
+const PROMPT_CHAR_CAP = 4000;
+const GITHUB_WORKFLOW_FILE = "agent-react.yml";
+const GITHUB_REF = "main";
+
+/**
+ * Build a facilitator prompt from the current message text and a rolling
+ * conversation history. History is bounded to the last 5 exchanges (10
+ * entries) and the total prompt size is capped at ~4000 characters by
+ * dropping the oldest history entries until it fits.
+ *
+ * @param {string} text - The current user message
+ * @param {Array<{role: "user"|"assistant", text: string}>} history - Prior
+ *   exchanges in chronological order. Most recent last.
+ * @returns {string}
+ */
+export function buildPrompt(text, history) {
+  const trimmed = history.slice(-HISTORY_MAX_EXCHANGES * 2);
+  while (trimmed.length > 0) {
+    const block = trimmed
+      .map((h) => `${h.role === "user" ? "User" : "Agent"}: ${h.text}`)
+      .join("\n\n");
+    const composed = `Prior conversation:\n${block}\n\nCurrent message: ${text}`;
+    if (composed.length <= PROMPT_CHAR_CAP) return composed;
+    trimmed.shift();
+  }
+  return text;
+}
+
+/**
+ * Format the verdict and summary as a Teams reply.
+ *
+ * @param {{verdict: string, summary: string, run_url?: string}} payload
+ * @returns {string}
+ */
+export function formatReply(payload) {
+  const verdict = payload.verdict ?? "unknown";
+  const summary = payload.summary ?? "";
+  const runUrl = payload.run_url;
+  const head = `**${verdict}** — ${summary}`;
+  return runUrl ? `${head}\n\n[run log](${runUrl})` : head;
+}
+
+/**
+ * Append a message to a bounded history, dropping the oldest entries when
+ * the cap is exceeded.
+ *
+ * @param {Array<{role: "user"|"assistant", text: string}>} history
+ * @param {{role: "user"|"assistant", text: string}} entry
+ */
+function appendHistory(history, entry) {
+  history.push(entry);
+  const max = HISTORY_MAX_EXCHANGES * 2;
+  while (history.length > max) history.shift();
+}
+
+/**
+ * Dispatch a workflow_dispatch event on agent-react.yml with the supplied
+ * prompt and callback information.
+ *
+ * @param {object} opts
+ * @param {string} opts.githubToken
+ * @param {string} opts.githubRepo - "owner/repo"
+ * @param {string} opts.prompt
+ * @param {string} opts.callbackUrl
+ * @param {string} opts.correlationId
+ */
+async function dispatchWorkflow({
+  githubToken,
+  githubRepo,
+  prompt,
+  callbackUrl,
+  correlationId,
+}) {
+  const url = `https://api.github.com/repos/${githubRepo}/actions/workflows/${GITHUB_WORKFLOW_FILE}/dispatches`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${githubToken}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      ref: GITHUB_REF,
+      inputs: {
+        prompt,
+        callback_url: callbackUrl,
+        correlation_id: correlationId,
+      },
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `workflow_dispatch failed: ${res.status} ${res.statusText} ${body}`,
+    );
+  }
+}
+
+/**
+ * Construct the bridge service. The factory function is the composition
+ * root — adapter, stores, and Express app are created inside and exposed
+ * on the returned object for test access.
+ *
+ * @param {object} config
+ * @param {string} config.microsoftAppId
+ * @param {string} config.microsoftAppPassword
+ * @param {string} config.microsoftAppTenantId
+ * @param {string} config.githubToken
+ * @param {string} config.githubRepo - "owner/repo"
+ * @param {string} config.callbackBaseUrl - Public base URL (no trailing slash)
+ * @param {number} [config.port=3978]
+ * @returns {{ start: () => Promise<void>, conversations: Map<string, {ref: object, history: Array<{role: string, text: string}>}>, pendingCallbacks: Map<string, {correlationId: string, threadId: string}>, buildPrompt: typeof buildPrompt }}
+ */
+export function createBridge(config) {
+  const port = config.port ?? 3978;
+  const conversations = new Map();
+  const pendingCallbacks = new Map();
+
+  const auth = new ConfigurationBotFrameworkAuthentication({
+    MicrosoftAppId: config.microsoftAppId,
+    MicrosoftAppPassword: config.microsoftAppPassword,
+    MicrosoftAppTenantId: config.microsoftAppTenantId,
+    MicrosoftAppType: "SingleTenant",
+  });
+  const adapter = new CloudAdapter(auth);
+
+  adapter.onTurnError = async (context, error) => {
+    console.error("Bot Framework turn error:", error);
+    try {
+      await context.sendActivity("Sorry, something went wrong.");
+    } catch (sendError) {
+      console.error("Failed to send error notice:", sendError);
+    }
+  };
+
+  async function handleMessageActivity(context) {
+    const activity = context.activity;
+    if (activity.type !== "message") return;
+
+    const threadId = activity.conversation?.id;
+    if (!threadId) return;
+
+    const text = (activity.text ?? "").trim();
+    if (!text) return;
+
+    let state = conversations.get(threadId);
+    if (!state) {
+      state = { ref: null, history: [] };
+      conversations.set(threadId, state);
+    }
+    state.ref = TurnContext.getConversationReference(activity);
+
+    const prompt = buildPrompt(text, state.history);
+    const correlationId = randomUUID();
+    const callbackToken = randomUUID();
+    const callbackUrl = `${config.callbackBaseUrl}/api/callback/${callbackToken}`;
+
+    pendingCallbacks.set(callbackToken, { correlationId, threadId });
+
+    await context.sendActivity("Working on it...");
+
+    try {
+      await dispatchWorkflow({
+        githubToken: config.githubToken,
+        githubRepo: config.githubRepo,
+        prompt,
+        callbackUrl,
+        correlationId,
+      });
+      appendHistory(state.history, { role: "user", text });
+    } catch (err) {
+      pendingCallbacks.delete(callbackToken);
+      console.error("workflow dispatch failed:", err);
+      await context.sendActivity(
+        `Failed to reach the agent team: ${err.message}`,
+      );
+    }
+  }
+
+  const app = express();
+  app.use(express.json());
+
+  app.post("/api/messages", async (req, res) => {
+    await adapter.process(req, res, (context) =>
+      handleMessageActivity(context),
+    );
+  });
+
+  app.post("/api/callback/:token", async (req, res) => {
+    const { token } = req.params;
+    const pending = pendingCallbacks.get(token);
+    if (!pending) {
+      res.status(404).json({ error: "Unknown callback token" });
+      return;
+    }
+    pendingCallbacks.delete(token);
+
+    const payload = req.body ?? {};
+    const state = conversations.get(pending.threadId);
+    if (!state || !state.ref) {
+      res.status(410).json({ error: "Conversation reference missing" });
+      return;
+    }
+
+    const replyText = formatReply(payload);
+    try {
+      await adapter.continueConversationAsync(
+        config.microsoftAppId,
+        state.ref,
+        async (context) => {
+          await context.sendActivity(replyText);
+        },
+      );
+      appendHistory(state.history, {
+        role: "assistant",
+        text: payload.summary ?? "",
+      });
+      res.status(200).json({ ok: true });
+    } catch (err) {
+      console.error("Failed to deliver Teams reply:", err);
+      res.status(500).json({ error: "Failed to deliver reply" });
+    }
+  });
+
+  let server;
+
+  async function start() {
+    return new Promise((resolve) => {
+      server = app.listen(port, () => {
+        console.log(`Teams bridge listening on port ${port}`);
+        resolve();
+      });
+    });
+  }
+
+  async function stop() {
+    if (!server) return;
+    await new Promise((resolve) => server.close(() => resolve()));
+    server = null;
+  }
+
+  return {
+    start,
+    stop,
+    conversations,
+    pendingCallbacks,
+    buildPrompt,
+    formatReply,
+    app,
+  };
+}

--- a/services/msteams/package.json
+++ b/services/msteams/package.json
@@ -20,12 +20,12 @@
   "author": "D. Olsson <hi@senzilla.io>",
   "jobs": [
     {
-      "user": "Teams Using Agents",
-      "goal": "Reach the Agent Team from Teams",
-      "trigger": "Discussing work in Microsoft Teams and needing to context-switch to GitHub to ask the agent team anything.",
-      "bigHire": "invoke the Kata agent team from a Teams conversation without leaving Teams.",
-      "littleHire": "send a message and get the facilitator's conclusion back in the same thread.",
-      "competesWith": "manually creating GitHub issues; copy-pasting between Teams and GitHub; leaving the agent team unreachable from daily conversation"
+      "user": "Platform Builders",
+      "goal": "Bridge Conversation Platforms to the Agent Team",
+      "trigger": "Engineers discuss work in Microsoft Teams and need to context-switch to GitHub to invoke the agent team.",
+      "bigHire": "relay messages between a chat platform and the Kata agent team without leaving the conversation.",
+      "littleHire": "dispatch a facilitate session from a chat message and return the verdict to the same thread.",
+      "competesWith": "manually creating GitHub issues; copy-pasting between chat and GitHub; leaving the agent team unreachable from daily conversation"
     }
   ],
   "type": "module",

--- a/services/msteams/package.json
+++ b/services/msteams/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@forwardimpact/svcmsteams",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Microsoft Teams bridge — relay messages between Teams conversations and the Kata agent team.",
+  "keywords": [
+    "teams",
+    "bridge",
+    "bot",
+    "relay",
+    "agent"
+  ],
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "services/msteams"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Teams Using Agents",
+      "goal": "Reach the Agent Team from Teams",
+      "trigger": "Discussing work in Microsoft Teams and needing to context-switch to GitHub to ask the agent team anything.",
+      "bigHire": "invoke the Kata agent team from a Teams conversation without leaving Teams.",
+      "littleHire": "send a message and get the facilitator's conclusion back in the same thread.",
+      "competesWith": "manually creating GitHub issues; copy-pasting between Teams and GitHub; leaving the agent team unreachable from daily conversation"
+    }
+  ],
+  "type": "module",
+  "main": "./index.js",
+  "bin": {
+    "fit-svcmsteams": "./server.js"
+  },
+  "files": [
+    "index.js",
+    "server.js"
+  ],
+  "scripts": {
+    "test": "bun test test/*.test.js"
+  },
+  "dependencies": {
+    "botbuilder": "^4.23.3",
+    "express": "^4.21.0"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=18.0.0"
+  }
+}

--- a/services/msteams/server.js
+++ b/services/msteams/server.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { createBridge } from "./index.js";
+
+const bridge = createBridge({
+  microsoftAppId: process.env.MICROSOFT_APP_ID ?? "",
+  microsoftAppPassword: process.env.MICROSOFT_APP_PASSWORD ?? "",
+  microsoftAppTenantId: process.env.MICROSOFT_APP_TENANT_ID ?? "",
+  githubToken: process.env.GH_TOKEN,
+  githubRepo: process.env.GITHUB_REPO,
+  callbackBaseUrl: process.env.CALLBACK_BASE_URL,
+  port: parseInt(process.env.PORT ?? "3978", 10),
+});
+
+await bridge.start();

--- a/services/msteams/test/bridge.test.js
+++ b/services/msteams/test/bridge.test.js
@@ -1,7 +1,25 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
 
-import { buildPrompt, formatReply } from "../index.js";
+import {
+  appendHistory,
+  buildPrompt,
+  createBridge,
+  formatReply,
+} from "../index.js";
+
+function makeBridge(overrides = {}) {
+  return createBridge({
+    microsoftAppId: "test-app-id",
+    microsoftAppPassword: "test-password",
+    microsoftAppTenantId: "test-tenant",
+    githubToken: "test-gh-token",
+    githubRepo: "owner/repo",
+    callbackBaseUrl: "https://tunnel.example",
+    port: 0,
+    ...overrides,
+  });
+}
 
 describe("buildPrompt", () => {
   test("returns just the message text when history is empty", () => {
@@ -95,5 +113,104 @@ describe("formatReply", () => {
   test("falls back to 'unknown' when verdict is missing", () => {
     const out = formatReply({ summary: "no verdict" });
     assert.match(out, /\*\*unknown\*\*/);
+  });
+});
+
+describe("appendHistory", () => {
+  test("appends a single entry to an empty history", () => {
+    const history = [];
+    appendHistory(history, { role: "user", text: "hi" });
+    assert.deepStrictEqual(history, [{ role: "user", text: "hi" }]);
+  });
+
+  test("preserves chronological order across many appends", () => {
+    const history = [];
+    for (let i = 0; i < 6; i++) {
+      appendHistory(history, { role: "user", text: `u${i}` });
+      appendHistory(history, { role: "assistant", text: `a${i}` });
+    }
+    // Cap is 10 entries (5 exchanges). Oldest exchange (u0/a0) dropped.
+    assert.strictEqual(history.length, 10);
+    assert.strictEqual(history[0].text, "u1");
+    assert.strictEqual(history[history.length - 1].text, "a5");
+  });
+
+  test("never exceeds 10 entries even under sustained appends", () => {
+    const history = [];
+    for (let i = 0; i < 50; i++) {
+      appendHistory(history, { role: "user", text: `x${i}` });
+    }
+    assert.strictEqual(history.length, 10);
+    assert.strictEqual(history[0].text, "x40");
+    assert.strictEqual(history[9].text, "x49");
+  });
+});
+
+describe("createBridge — stores", () => {
+  test("constructs empty pendingCallbacks and conversations maps", () => {
+    const bridge = makeBridge();
+    assert.ok(bridge.pendingCallbacks instanceof Map);
+    assert.ok(bridge.conversations instanceof Map);
+    assert.strictEqual(bridge.pendingCallbacks.size, 0);
+    assert.strictEqual(bridge.conversations.size, 0);
+  });
+
+  test("pendingCallbacks supports token-based insert, O(1) lookup, and cleanup", () => {
+    const bridge = makeBridge();
+    bridge.pendingCallbacks.set("tok-abc", {
+      correlationId: "corr-1",
+      threadId: "thread-1",
+    });
+    bridge.pendingCallbacks.set("tok-def", {
+      correlationId: "corr-2",
+      threadId: "thread-2",
+    });
+
+    const got = bridge.pendingCallbacks.get("tok-abc");
+    assert.deepStrictEqual(got, {
+      correlationId: "corr-1",
+      threadId: "thread-1",
+    });
+    assert.strictEqual(bridge.pendingCallbacks.has("tok-def"), true);
+    assert.strictEqual(bridge.pendingCallbacks.has("tok-missing"), false);
+
+    bridge.pendingCallbacks.delete("tok-abc");
+    assert.strictEqual(bridge.pendingCallbacks.has("tok-abc"), false);
+    assert.strictEqual(bridge.pendingCallbacks.size, 1);
+  });
+
+  test("conversations store keeps a bounded history per thread", () => {
+    const bridge = makeBridge();
+    const thread = { ref: { conversation: { id: "t1" } }, history: [] };
+    bridge.conversations.set("t1", thread);
+
+    for (let i = 0; i < 12; i++) {
+      appendHistory(thread.history, { role: "user", text: `q${i}` });
+      appendHistory(thread.history, { role: "assistant", text: `a${i}` });
+    }
+
+    assert.strictEqual(thread.history.length, 10);
+    assert.strictEqual(thread.history[0].text, "q7");
+    assert.strictEqual(thread.history[9].text, "a11");
+    assert.strictEqual(bridge.conversations.size, 1);
+  });
+});
+
+describe("createBridge — config normalization", () => {
+  test("strips trailing slash from callbackBaseUrl in dispatch URL composition", async () => {
+    const bridge = makeBridge({ callbackBaseUrl: "https://tunnel.example/" });
+    // The bridge stores callbackBaseUrl internally after normalization, but
+    // it is not directly exposed. Smoke-test by exercising the callback
+    // route: a known token+correlation pair must route correctly under the
+    // normalized base URL. We verify that the express app has the route
+    // registered.
+    const routes = bridge.app._router.stack
+      .filter((layer) => layer.route)
+      .map((layer) => layer.route.path);
+    assert.ok(
+      routes.includes("/api/callback/:token"),
+      `expected /api/callback/:token in routes, got ${JSON.stringify(routes)}`,
+    );
+    assert.ok(routes.includes("/api/messages"));
   });
 });

--- a/services/msteams/test/bridge.test.js
+++ b/services/msteams/test/bridge.test.js
@@ -1,0 +1,99 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+import { buildPrompt, formatReply } from "../index.js";
+
+describe("buildPrompt", () => {
+  test("returns just the message text when history is empty", () => {
+    assert.strictEqual(buildPrompt("hello", []), "hello");
+  });
+
+  test("prepends prior exchanges in chronological order", () => {
+    const history = [
+      { role: "user", text: "first question" },
+      { role: "assistant", text: "first answer" },
+    ];
+    const result = buildPrompt("follow-up", history);
+    assert.match(result, /Prior conversation:/);
+    assert.match(result, /User: first question/);
+    assert.match(result, /Agent: first answer/);
+    assert.match(result, /Current message: follow-up/);
+    assert.ok(
+      result.indexOf("first question") < result.indexOf("first answer"),
+      "user message must precede agent reply",
+    );
+    assert.ok(
+      result.indexOf("first answer") < result.indexOf("follow-up"),
+      "history must precede current message",
+    );
+  });
+
+  test("caps history to the last 5 exchanges (10 entries)", () => {
+    const history = [];
+    for (let i = 0; i < 8; i++) {
+      history.push({ role: "user", text: `q${i}` });
+      history.push({ role: "assistant", text: `a${i}` });
+    }
+    const result = buildPrompt("now", history);
+    // Oldest 3 exchanges (entries 0..5) are dropped; q5..q7 / a5..a7 remain.
+    for (let i = 0; i < 3; i++) {
+      assert.ok(
+        !new RegExp(`User: q${i}\\b`).test(result),
+        `q${i} must be dropped`,
+      );
+      assert.ok(
+        !new RegExp(`Agent: a${i}\\b`).test(result),
+        `a${i} must be dropped`,
+      );
+    }
+    for (let i = 3; i < 8; i++) {
+      assert.match(result, new RegExp(`User: q${i}\\b`));
+      assert.match(result, new RegExp(`Agent: a${i}\\b`));
+    }
+  });
+
+  test("drops the oldest entries when the prompt exceeds the character cap", () => {
+    const big = "x".repeat(1500);
+    const history = [
+      { role: "user", text: `oldest ${big}` },
+      { role: "assistant", text: `old reply ${big}` },
+      { role: "user", text: `newer ${big}` },
+      { role: "assistant", text: `newer reply ${big}` },
+    ];
+    const result = buildPrompt("now", history);
+    assert.ok(
+      result.length <= 4000,
+      `expected <=4000 chars, got ${result.length}`,
+    );
+    // Older entries must be dropped first; newer must remain in the result.
+    assert.ok(!result.includes("oldest"), "oldest entry must be dropped");
+    assert.match(result, /Current message: now/);
+  });
+});
+
+describe("formatReply", () => {
+  test("formats verdict and summary in bold + dash form", () => {
+    assert.strictEqual(
+      formatReply({ verdict: "success", summary: "done" }),
+      "**success** — done",
+    );
+  });
+
+  test("appends a run-log link when run_url is present", () => {
+    const out = formatReply({
+      verdict: "failure",
+      summary: "diagnosed root cause",
+      run_url: "https://github.com/foo/bar/actions/runs/9",
+    });
+    assert.match(out, /\*\*failure\*\* — diagnosed root cause/);
+    assert.match(
+      out,
+      /\[run log\]\(https:\/\/github\.com\/foo\/bar\/actions\/runs\/9\)/,
+    );
+  });
+
+  test("falls back to 'unknown' when verdict is missing", () => {
+    const out = formatReply({ summary: "no verdict" });
+    assert.match(out, /\*\*unknown\*\*/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements [spec 1200](specs/1200-teams-agent-bridge/spec.md) — a prototype bridge that lets engineers invoke the Kata agent team from a Microsoft Teams group chat or channel without context-switching to GitHub. Microsoft Teams and GitHub remain parallel channels into the same agent team; the bridge does not tunnel through GitHub artifacts.

- **`libraries/libeval`** — new `fit-eval callback` subcommand reads an NDJSON trace, extracts the orchestrator summary event, and POSTs `{correlation_id, verdict, summary, run_url}` to a caller-supplied URL.
- **`services/msteams/`** — new prototype Node.js service (Bot Framework v4 + Express). Receives Teams activities via a dev tunnel, dispatches `workflow_dispatch` on `agent-react.yml`, receives the callback, and delivers the facilitator's conclusion to the originating Teams thread. Conversation continuity per thread, in-memory store (state lost on restart — prototype scope).
- **`.github/workflows/agent-react.yml`** — `workflow_dispatch` gains optional `callback_url` and `correlation_id` inputs and a new `Deliver callback` step. Uses `forwardimpact/fit-eval@v1`'s new `trace-file` composite output. Existing dispatch behavior is unchanged when `callback_url` is empty. Missing-trace fallback POSTs a `verdict:"failure"` placeholder so Teams users are never stranded.
- **`libraries/libstorage/test/libstorage-utils.test.js`** — `afterEach` restores `globalThis.fetch` after the SupabaseStorage tests, fixing a pre-existing test isolation bug that was leaking the fetch spy across files under bun's parallel runner.
- **Sibling repo:** [forwardimpact/fit-eval#1](https://github.com/forwardimpact/fit-eval/pull/1) (merged, `v1` advanced) added the `trace-dir` / `trace-file` / `case` composite outputs the workflow consumes.

Plan-a deviations and their resolutions are recorded in the wiki log entry and in the second commit message.

5-reviewer kata-review panel was run on the implementation diff; consensus and verified-minority blockers/highs/mediums were addressed before push.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test` (44 spec-1200 tests pass; pre-existing wiki-signing failures in the sandbox are unrelated)
- [ ] Manual round-trip from a developer Teams tenant per `services/msteams/SETUP.md` and `specs/1200-teams-agent-bridge/msteams-config.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_014GMSU857Sq4Yzg46SdrQFP)_