### PR TITLE
design(1230): threaded discussion bridges

### DIFF
--- a/specs/1230-threaded-discussion-bridges/design-a.md
+++ b/specs/1230-threaded-discussion-bridges/design-a.md
@@ -1,0 +1,147 @@
+# Design 1230-a — Threaded discussion bridges
+
+## Overview
+
+The agent team treats every threaded channel through a single bridge
+pattern: a per-channel adapter service receives webhooks, dispatches a
+channel-agnostic workflow, and delivers replies via a structured callback.
+libeval gains a `discuss` mode whose orchestration loop is suspendable
+across workflow runs, making long-running RFCs and the daily storyboard
+tractable.
+
+## Components
+
+| Component | Responsibility |
+|---|---|
+| `libraries/libbridge` | Webhook intake skeleton, callback registration, workflow dispatch, history capping, rate limiting, typing/progress patterns, durable state interface over libindex. Channel-agnostic. |
+| `services/ghbridge` | GitHub adapter. Verifies Kata App webhook signatures. Translates Discussion events to a prompt. Posts replies via the `addDiscussionComment` GraphQL mutation. |
+| `services/msbridge` | Microsoft Teams adapter (renamed from `services/msteams`). Verifies Bot Framework JWTs. Posts replies via `continueConversationAsync`. |
+| `kata-dispatch.yml` | Renamed `agent-react.yml`. Channel-agnostic worker. Triggers: issue/PR/review events plus `workflow_dispatch` from bridges. |
+| `kata-shift.yml` | Renamed `agent-team.yml`. Scheduled rotation. Rename only. |
+| libeval `discuss` mode | New orchestration mode: async, durable, resumable. CLI: `fit-eval discuss`. |
+| Consolidated libeval CLI | `--lead-profile` and `--lead-model` for the lead role across `supervise`, `facilitate`, and `discuss`. `--agent-*` for participants. |
+
+## Data flow
+
+```mermaid
+sequenceDiagram
+    participant Ch as Channel
+    participant Br as Adapter (gh/ms bridge)
+    participant St as libindex (discussions)
+    participant WF as kata-dispatch.yml
+    participant LE as libeval (discuss)
+
+    Ch->>Br: webhook (signature verified)
+    Br->>St: load DiscussionContext by (channel, discussion_id)
+    Br->>WF: workflow_dispatch(prompt, callback_url, correlation_id, discussion_id)
+    WF->>LE: fit-eval discuss --lead-profile … --agent-*
+    LE-->>LE: RollCall / Ask / Answer / Announce
+    alt Adjourn
+        LE->>WF: trace with final replies
+        WF->>Br: callback(verdict=adjourned, replies[])
+        Br->>Ch: post replies
+        Br->>St: persist final state
+    else Recess
+        LE->>WF: trace with resumption trigger
+        WF->>Br: callback(verdict=recessed, trigger)
+        Br->>St: persist trigger and context
+        Note over Br,Ch: bridge watches the trigger
+        Ch-->>Br: webhook fires trigger
+        Br->>WF: workflow_dispatch(resume_context, …)
+    end
+```
+
+## Interfaces
+
+### Bridge → workflow
+
+`workflow_dispatch` inputs:
+
+| Input | Purpose |
+|---|---|
+| `prompt` | Composed task text built from thread history + the new event. |
+| `callback_url` | Per-invocation URL with a token registered on the bridge. |
+| `correlation_id` | Stable id matching dispatch to callback. |
+| `discussion_id` | Stable id for the threaded conversation; carried through traces for linking. |
+| `resume_context` | Optional. Serialized prior state when resuming a recessed run. |
+
+### Workflow → bridge
+
+Callback payload, extending the existing Teams contract:
+
+```ts
+type Callback = {
+  correlation_id: string;
+  verdict: "adjourned" | "recessed" | "failed";
+  summary: string;
+  run_url?: string;
+  replies?: Array<{
+    addressee?: string;
+    body: string;
+    in_reply_to?: string;
+    thread_id?: string;
+  }>;
+  trigger?: {
+    kind: "responses" | "elapsed" | "either";
+    responses?: number;
+    elapsed?: string;
+  };
+};
+```
+
+### libeval `discuss` mode tools
+
+| Tool | Behaviour |
+|---|---|
+| `RollCall` | Enumerate / ping participants for the session. |
+| `Ask` | Directed question to a named participant. |
+| `Answer` | Reply to an Ask. |
+| `Announce` | Broadcast to current participants. |
+| `RequestForComment` | Fire-and-forget to a configured channel via the bridge; returns `{thread_url, correlation_id, channel}`. |
+| `Recess` | Suspend the run with a resumption trigger. |
+| `Adjourn` | Terminate with a final outcome record. |
+
+The lead role (Chair) defaults to `release-engineer` and is configurable
+per invocation via `--lead-profile`.
+
+## State
+
+`DiscussionContext`, keyed by `(channel, discussion_id)`, persisted via
+libindex JSONL:
+
+| Field | Notes |
+|---|---|
+| `discussion_id` | Stable identifier; flows through every workflow run on this thread. |
+| `channel` | `github-discussions` \| `msteams` \| future. |
+| `history` | Bounded ring of recent exchanges. |
+| `participants` | Roster (agent profiles + external human ids). |
+| `open_rfcs` | Active `RequestForComment` correlation ids and their triggers. |
+| `lead` | Profile name of the current Chair. |
+| `pending_callbacks` | Token → correlation_id registry. |
+
+libindex provides JSONL-backed read/write; bridge code consumes
+`IndexBase` / `BufferedIndex` rather than implementing storage.
+
+## Key decisions
+
+| Decision | Chosen | Rejected | Why |
+|---|---|---|---|
+| Where channel events enter | Per-channel adapter service | Direct webhook to the dispatch workflow (status quo for Discussions) | Symmetry with Teams; the workflow stays channel-agnostic; reply delivery is consistent across channels. |
+| Bridge structure | Shared `libbridge` + per-channel services | One unified bridge process hosting all channels | Channel SDKs (Bot Framework, Octokit) drag heavyweight dependencies; per-service deploys and scales independently; avoids god-object risk. |
+| Async orchestration home | New libeval `discuss` mode | Extend `facilitate` mode | `facilitate`'s loop assumes synchronous within-run coordination; suspend/resume is a fundamentally different control flow; conflating them confuses the system prompt and tool semantics. |
+| Resumption store | libindex JSONL | Wiki markdown files | Wiki has no concurrency guarantees and surfaces orchestration metadata humans should not edit; libindex provides typed read/write with buffered persistence. |
+| Resumption mechanism | Bridge re-dispatches the workflow on trigger | Long-running workflow with polling | GitHub Actions caps run duration; RFCs span up to 14-day horizons; in-run polling wastes minutes. |
+| Reply structure | Structured `replies[]` on the callback payload | Facilitator emits GraphQL mutation strings into the workflow | Model-produced mutation strings are unvalidated; structured replies render deterministically per channel; multi-addressee logic leaves the model prompt. |
+| Trace continuity | One NDJSON per workflow run, linked by `discussion_id` | Concatenated multi-run NDJSON | Simpler; existing TraceCollector unchanged; fit-trace gains a `by-discussion` lookup over the carried id. |
+| Lead-role CLI surface | Consolidated `--lead-profile` / `--lead-model` | Keep mode-specific flags (`--supervisor-*`, `--facilitator-*`) | Three modes × two flags = six surface area; consolidation halves the CLI footprint and clarifies that "lead" is one role concept across modes. |
+| `coordination-protocol.md` | Keep Discussions as the RFC channel | Remove Discussions from the protocol entirely | The runtime path changes, but Discussions remain the semantic home for RFCs and unsettled questions; agents still need that routing guidance. |
+
+## Out of scope (deferred to plan)
+
+- Concrete file paths and module layout inside `libbridge`.
+- Exact libindex schema, file location, and migration of the existing
+  Teams in-memory conversation map.
+- Per-channel webhook signature verification implementation details.
+- Bot Framework SDK upgrade or pinning.
+- Internal refactoring of `kata-shift.yml` beyond the rename.
+- `coordination-protocol.md` text edits beyond the runtime-mechanism note.

--- a/specs/1230-threaded-discussion-bridges/spec.md
+++ b/specs/1230-threaded-discussion-bridges/spec.md
@@ -1,0 +1,93 @@
+# Spec 1230 — Threaded discussion bridges
+
+## Persona and job
+
+Hired by **Teams Using Agents** to maintain a single agent team that engages
+humans across multiple threaded channels — GitHub Discussions, Microsoft
+Teams, and future channels — without the team owning channel-specific logic
+inside the workflow that runs it.
+
+Related JTBD: *Run an autonomous, continuously improving development team
+that plans, ships, studies its own traces, and acts on findings.*
+
+## Problem
+
+Threaded channels are first-class places where humans coordinate with the
+agent team. Today these channels are handled inconsistently.
+
+| Channel | How it reaches the workflow today |
+|---|---|
+| Microsoft Teams | Dedicated service receives Bot Framework activities, dispatches the workflow via `workflow_dispatch`, and delivers replies asynchronously via a callback contract. |
+| GitHub Discussions | Webhook events trigger `agent-react.yml` directly. The workflow composes Discussion-specific reply logic — including GraphQL mutation instructions for multi-addressee threads — inside the facilitator prompt. |
+
+This split has three concrete consequences:
+
+1. **The workflow is not channel-agnostic.** `agent-react.yml` carries
+   Discussion-shaped composition logic that other channels cannot reuse.
+   Adding a future channel duplicates the pattern in YAML.
+2. **Reply delivery semantics drift.** Teams replies are validated,
+   rate-limited, history-bounded, and rendered with typing indicators.
+   Discussion replies have none of these properties because they are
+   produced by a model prompt that synthesizes GraphQL mutation strings at
+   runtime.
+3. **Long-running coordination is impossible.** RFCs in Discussions can run
+   for days — the coordination protocol allows a 14-day ownership horizon.
+   The workflow must conclude within a single GitHub Actions run, so the
+   agent team cannot orchestrate an RFC that awaits human responses across
+   that horizon.
+
+Additionally, the existing libeval orchestration modes (`supervise`,
+`facilitate`) assume synchronous within-run coordination. Neither supports
+the suspend-and-resume pattern that RFCs and the daily storyboard
+(`kata-storyboard.yml`) need.
+
+## Scope
+
+### In scope
+
+- A single bridge pattern for every threaded channel, expressed as a
+  shared library plus per-channel adapter services.
+- GitHub Discussions moves to the bridge pattern. The Kata GitHub App
+  receives `discussion` and `discussion_comment` webhooks at the new
+  GitHub bridge instead of at the workflow.
+- Microsoft Teams moves to the bridge pattern by sharing the library,
+  preserving its current contract with the workflow.
+- The workflow becomes channel-agnostic. It accepts `workflow_dispatch`
+  from the bridges with `(prompt, callback_url, correlation_id,
+  discussion_id, resume_context?)` inputs.
+- A new libeval orchestration mode for asynchronous, durable, resumable
+  orchestration with humans-in-the-loop across threaded channels.
+- A consolidated CLI surface — a single lead profile and lead model
+  option — across `supervise`, `facilitate`, and the new mode.
+- A resumption store for in-flight discussions and pending callbacks.
+- Workflow renames that reflect the new responsibilities:
+  `agent-react.yml` → `kata-dispatch.yml`; `agent-team.yml` →
+  `kata-shift.yml`.
+
+### Excluded
+
+- Migrating issues, PRs, or PR-review handling out of the dispatch
+  workflow — those are not threaded discussion channels.
+- Changing the semantic role of GitHub Discussions in
+  `coordination-protocol.md`. The RFC channel role remains.
+- Adding any new channel beyond GitHub Discussions and Microsoft Teams.
+- Hosting the bridge services in production infrastructure (handled
+  outside this spec; tunnel-only is dev/testing).
+- Removing the `supervise` or `facilitate` modes from libeval.
+
+## Success criteria
+
+| Claim | Verifies via |
+|---|---|
+| The dispatch workflow does not reference `discussion` or `discussion_comment` events. | `grep -E 'discussion(_comment)?' .github/workflows/kata-dispatch.yml` returns empty. |
+| `kata-shift.yml` exists; `agent-team.yml` and `agent-react.yml` do not. | `ls .github/workflows/{agent-team,agent-react,kata-shift,kata-dispatch}.yml` — first two absent, last two present. |
+| The Kata GitHub App's webhook subscription includes `discussion` and `discussion_comment` events and targets the GitHub bridge endpoint. | App configuration record under `services/ghbridge/`. |
+| `services/ghbridge` and `services/msbridge` exist as siblings; `services/msteams` does not exist on `main`. | `ls services/{ghbridge,msbridge,msteams}` — first two present, last absent. |
+| Both bridges depend on the shared bridge library. | `grep "@forwardimpact/libbridge" services/{gh,ms}bridge/package.json` returns matches in both. |
+| Multi-addressee Discussion replies are posted from a structured callback payload, not from model-produced GraphQL strings. | `grep -E 'addDiscussionComment\|gh api graphql' .github/workflows/kata-dispatch.yml` returns empty. |
+| libeval exposes a new orchestration mode parallel to `run`, `supervise`, `facilitate`, invoked as `fit-eval discuss`. | `fit-eval --help` lists the mode. |
+| The new mode can suspend a run with a resumption trigger and continues correctly when the bridge re-dispatches the workflow with prior context. | An integration test posts a request-for-comment, suspends, is resumed by a follow-up webhook, and adjourns. |
+| The lead role and model are configured by a single profile flag and a single model flag across all multi-agent modes; mode-specific equivalents do not exist. | `fit-eval supervise --help`, `facilitate --help`, `discuss --help` all show the consolidated flags and none of the legacy mode-specific flags. |
+| Resumption state is persisted via libindex (not the wiki, not an external store). | `grep "@forwardimpact/libindex" libraries/libbridge` returns matches; nothing under `wiki/discussions/`. |
+| Traces from multiple workflow runs of the same conversation are queryable as one discussion. | `fit-trace by-discussion <id>` returns all linked traces. |
+| `coordination-protocol.md` still lists Discussions as the channel for RFCs and unsettled questions. | `grep -i 'discussion' .claude/agents/references/coordination-protocol.md` still returns the rows for RFCs and the "settled" routing question. |


### PR DESCRIPTION
## Summary

- Unify GitHub Discussions and Microsoft Teams under one bridge pattern: per-channel adapter services (`services/ghbridge`, `services/msbridge`) over a shared `libraries/libbridge`, dispatching a channel-agnostic workflow via the existing `workflow_dispatch` + callback contract Teams already uses.
- Add a new libeval orchestration mode (`fit-eval discuss`) for async, durable, resumable orchestration — supports `RequestForComment`, `Recess`, `Adjourn` so RFCs and the daily storyboard can span multiple workflow runs.
- Consolidate `--supervisor-*`/`--facilitator-*` CLI options into `--lead-profile`/`--lead-model` across `supervise`, `facilitate`, and `discuss`.
- Rename `agent-react.yml` → `kata-dispatch.yml` and `agent-team.yml` → `kata-shift.yml` to match the new responsibilities.
- Persist `DiscussionContext` (history, participants, open RFCs, pending callbacks) via libindex.
- This PR contains both `spec.md` and `design-a.md`, written together at the user's request after an extended design discussion. `wiki/STATUS.md` is held at `1230 design draft` — neither has been formally approved.

## Test plan

- [ ] Human review of `specs/1230-threaded-discussion-bridges/spec.md` against WHAT/WHY boundaries.
- [ ] Human review of `specs/1230-threaded-discussion-bridges/design-a.md` against the 200-line architectural-sketch boundary (147 lines).
- [ ] `bun run check` (passes locally).
- [ ] `bun run test` (17 pre-existing libwiki failures in sandbox due to commit-signing env; unrelated to this doc-only change — CI will be authoritative).
- [ ] Confirm `coordination-protocol.md` is **not** modified by this PR (runtime mechanism change only; deferred to plan).

Procedural notes:
- Spec and design written together against an unapproved spec. Normal kata-spec / kata-design flow merges the spec PR first, then opens a design PR.
- No `kata-review` sub-agent panel was run — user is reviewing directly.
- `wiki/STATUS.md` held at `design draft` rather than transitioning to `design approved` on merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_011AKsSruvoRthP4buFwEPDj)_