### PR TITLE
docs(kata-design,kata-plan): default to clean break unless spec asked

### DIFF
--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -43,17 +43,18 @@ is no commitment to implement, and a design has nothing to shape.
 - [ ] One design per spec — do not bundle multiple specs into one design.
 - [ ] Read the spec end-to-end before writing. Restate problem, scope, and
       success criteria without referring back.
+- [ ] Default to a clean break — compat only when the spec required it.
 
 </read_do_checklist>
 
 <do_confirm_checklist goal="Verify design quality before recommending approval">
 
-- [ ] Components, interfaces, and data flow stated before detail.
+- [ ] Components, interfaces, and data flow stated — Mermaid where it clarifies.
 - [ ] Each key decision names a rejected alternative and why.
-- [ ] Mermaid diagrams used where they clarify structure.
 - [ ] Stays within spec scope at the architectural level — names components,
       interfaces, and data structures but not file-level changes, execution
       ordering, or implementation steps (plan scope).
+- [ ] Clean break unless the spec explicitly required backward compatibility.
 - [ ] Under 200 lines total.
 - [ ] Clean sub-agent review panel of `design-a.md` via
       [`kata-review`](../kata-review/SKILL.md) completed (fresh context, panel
@@ -112,6 +113,8 @@ interfaces connect them — and why this architecture over alternatives.
   flow, state machines, sequence diagrams.
 - **Scope-faithful.** Stay within the spec's scope. If scope should change,
   return the spec to draft rather than expanding silently.
+- **Clean break by default.** Honor [§ Clean breaks](../../../CONTRIBUTING.md#read-do)
+  — design without compat unless the spec required it; return spec to `draft` if unsafe.
 
 **Form follows content.** Prefer tables for lists with shared structure
 (components, decisions). Prefer bullets for flat facts. Use prose only for the

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -41,16 +41,17 @@ there is no architectural direction to translate into implementation steps.
 - [ ] Read the spec and design end-to-end before writing. Restate problem,
       scope, success criteria, and architectural direction without referring
       back.
+- [ ] Default to a clean break — compat only when design (and spec) required it.
 
 </read_do_checklist>
 
 <do_confirm_checklist goal="Verify plan quality before recommending approval">
 
-- [ ] One-paragraph approach. More rationale than that belongs in the design.
+- [ ] One-paragraph approach, no per-step rationale — more belongs in the design.
 - [ ] Changes are concrete — exact file paths, functions, before/after.
 - [ ] Blast radius visible — created, modified, and deleted files clear.
 - [ ] Ordering explicit with stated dependencies.
-- [ ] No per-step rationale paragraphs.
+- [ ] Clean break unless the design (and spec) explicitly required backward compatibility.
 - [ ] Risks list only items the implementer cannot see from the plan itself.
 - [ ] Libraries used is one line (packages + exports, or `none`).
 - [ ] Execution recommendation present (which agents, sequential vs parallel).
@@ -104,6 +105,8 @@ The plan translates an approved design into concrete implementation steps.
 - **Execution recommendation.** Route parts to the most suitable agent —
   engineering agents for code, `technical-writer` for docs. For decomposed plans,
   state which parts can run in parallel vs sequentially.
+- **Clean break by default.** Honor [§ Clean breaks](../../../CONTRIBUTING.md#read-do)
+  — plan without compat unless design (and spec) required it; revise design if unsafe.
 
 **Form follows content.** Prefer tables for shared-structure lists, bullets for
 flat facts, prose only for narrative connecting them. If a paragraph could be a


### PR DESCRIPTION
## Summary

- `kata-design` and `kata-plan` now default to a clean break. Backward compatibility (compat shims, dual code paths, deprecation flags, dual writes) appears in a design or plan only when the upstream artifact explicitly required it — spec for designs, design+spec for plans.
- Integrated per `COALIGNED.md` layering: L2 reuse (links to `CONTRIBUTING.md` § Clean breaks rather than restating), new L4 directive in *Writing a Design* / *Writing a Plan*, new L6 READ-DO entry-gate item, new L6 DO-CONFIRM exit-gate item. Two cohesive existing items were merged in each DO-CONFIRM to stay under the 9-item cap.

## Test plan

- [x] `bun run check` (includes `coaligned instructions` enforcing 192-line L4 cap and 9-item L6 cap)
- [ ] `bun run test` — pre-existing libwiki/libcli signing-server failures in the cloud env reproduce on `main` and are unrelated to this diff; expected to pass in CI

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcL3MpFCvx5tnjrKJrhuYY)_