### PR TITLE
refactor(libbridge): bridge parity primitives + spec(1280) msbridge resume

### DIFF
--- a/libraries/libbridge/CLAUDE.md
+++ b/libraries/libbridge/CLAUDE.md
@@ -47,6 +47,9 @@ To add a new bridge `xbridge`, implement four things:
    applies the verdict (`adjourned` / `failed` / `recessed`). Throw
    `new CallbackHandlerError(status, message)` to short-circuit with a
    specific HTTP status (e.g. 410 if the conversation reference is gone).
+   If the bridge supports `recessed`, plug in `ResumeScheduler` (below)
+   and call `enterRecess` / `cancelRecess` from the verdict branches —
+   no hand-rolled timer code.
 
 Once those four pieces exist, the rest is composition:
 
@@ -108,6 +111,46 @@ Every bridge consumes the canonical `BridgeConfig` JSDoc typedef from
 `src/index.js`. Channel-specific fields extend it — see each bridge's
 README for the channel-specific surface.
 
+## Suspend/resume
+
+When a workflow returns `verdict: "recessed"` with a `trigger`, the
+conversation waits — either for N more responses, an elapsed duration,
+or "either". `ResumeScheduler` owns that lifecycle for both bridges:
+
+```js
+const resume = new ResumeScheduler({
+  dispatcher,
+  store,
+  logger,
+  buildCallbackMeta: (ctx) => ({ discussionId: ctx.discussion_id }),
+  buildResumeInputs: (ctx) => ({ discussionId: ctx.discussion_id }),
+});
+
+// service start:
+await resume.rearm();
+// service stop:
+resume.clear();
+
+// in the "new message in existing thread" handler:
+const { freshDispatchAllowed } = await resume.processInbound(ctx);
+if (freshDispatchAllowed) { /* rate-check + dispatcher.dispatch(...) */ }
+
+// in handleReply:
+switch (payload.verdict) {
+  case "recessed":
+    resume.enterRecess(ctx, meta.correlationId, payload.trigger);
+    break;
+  case "adjourned":
+  case "failed":
+    resume.cancelRecess(ctx, meta.correlationId);
+    break;
+}
+```
+
+The two `build*` callbacks are the only per-channel inputs. msbridge
+overrides `buildCallbackMeta` to `{ threadId: ctx.discussion_id }` to
+match its `loadDiscussionId` lens; everything else is shared.
+
 ## What lives where
 
 - `Acknowledgement` — reaction + optional typing-verb lifecycle.
@@ -116,6 +159,8 @@ README for the channel-specific surface.
 - `Dispatcher` — the dispatch dance.
 - `createCallbackHandler` — the inbound-callback skeleton.
 - `RateLimiter` — per-thread dispatch rate cap.
+- `ResumeScheduler` — suspend/resume lifecycle (channel-agnostic).
+- `ElapsedScheduler` — chunked-setTimeout primitive used by `ResumeScheduler`.
 - `createBridgeServer` — Hono + `@hono/node-server` wiring.
 - `validateCallbackPayload` — lenient kata-dispatch payload validator.
 - `newDiscussionContext` — canonical record-shape factory.

--- a/libraries/libbridge/CLAUDE.md
+++ b/libraries/libbridge/CLAUDE.md
@@ -15,3 +15,109 @@ Channel-agnostic primitives shared by `services/ghbridge` and `services/msbridge
   construction inside this package.
 - **Caller-injected clock.** `evaluateTrigger(trigger, observed, now)` takes
   `now` as a parameter; never call `Date.now()` from trigger evaluation.
+
+## Bridge contract
+
+A "bridge" is a service that relays human messages from a channel
+(GitHub Discussions, Microsoft Teams, …) to the Kata dispatch workflow
+and posts the workflow's reply back. Every bridge composes the same
+libbridge primitives in the same order.
+
+To add a new bridge `xbridge`, implement four things:
+
+1. **Channel intake** — `onWebhook: (c) => Response`. Verify the inbound
+   request is authentic (signature, OAuth, whatever the channel uses) and
+   extract `(threadId, text, ackTarget)`. For channels with an
+   SDK-driven intake (e.g. Bot Framework's `adapter.process`), wrap the
+   SDK inside `services/xbridge/src/<channel>.js` so `index.js` never
+   sees the express/HTTP shim.
+
+2. **Reaction adapter** — `{ add(target) -> reactionId | null, remove(reactionId, target) -> void }`.
+   The channel's "I received your message" reaction. The `target` shape
+   is opaque to libbridge — pick whatever your channel needs (a GraphQL
+   subject id, an activity reference, a Slack `(channel, ts)` tuple).
+
+3. **Typing adapter** *(optional)* — `{ send(target, text) -> void }`.
+   Only if your channel benefits from filler "Crafting..." messages
+   while the workflow runs. `Acknowledgement` owns the verb pool and
+   cadence; the adapter only delivers a string.
+
+4. **Reply handler** — `handleReply(ctx, payload, meta) -> void`. Posts
+   `payload.replies` to the channel, appends them to `ctx.history`, and
+   applies the verdict (`adjourned` / `failed` / `recessed`). Throw
+   `new CallbackHandlerError(status, message)` to short-circuit with a
+   specific HTTP status (e.g. 410 if the conversation reference is gone).
+
+Once those four pieces exist, the rest is composition:
+
+```js
+import {
+  Acknowledgement, CallbackRegistry, DiscussionContextStore, Dispatcher,
+  RateLimiter, createBridgeServer, createCallbackHandler,
+  newDiscussionContext, normalizeBaseUrl,
+} from "@forwardimpact/libbridge";
+
+const ack = new Acknowledgement({
+  reactionAdapter,         // your channel
+  typingAdapter,           // optional
+});
+const dispatcher = new Dispatcher({
+  callbacks: new CallbackRegistry(),
+  ack,
+  store: new DiscussionContextStore(storage),
+  callbackBaseUrl: normalizeBaseUrl(config.callback_base_url),
+  workflowFile: "kata-dispatch.yml",
+  githubRepo: config.github_repo,
+  getGithubToken: () => config.ghToken(),
+});
+const onCallback = createCallbackHandler({
+  channel: "xchannel",
+  callbacks, ack, store, logger, tracer,
+  spanName: "XBridge.HandleCallback",
+  loadDiscussionId: (meta) => meta.meta.threadId,
+  handleReply,             // your channel
+});
+const bridge = createBridgeServer({
+  config, logger, tracer,
+  webhookPath: "/api/messages",
+  onWebhook,               // your channel
+  onCallback,
+});
+```
+
+Inside your channel's intake, the only call you make for dispatch is:
+
+```js
+await dispatcher.dispatch({
+  ctx,
+  prompt: buildPrompt(text, ctx.history),
+  ackTarget,               // your channel-shaped target
+  historyText: text,
+  callbackMeta: { threadId },
+});
+```
+
+`Dispatcher.dispatch` owns the rest: register the callback token, start
+the acknowledgement, fire the workflow, append history, push the
+dispatch timestamp, flush the store, and on failure roll back the
+acknowledgement and the callback registration.
+
+## Configuration
+
+Every bridge consumes the canonical `BridgeConfig` JSDoc typedef from
+`src/index.js`. Channel-specific fields extend it — see each bridge's
+README for the channel-specific surface.
+
+## What lives where
+
+- `Acknowledgement` — reaction + optional typing-verb lifecycle.
+- `CallbackRegistry` — in-memory token → correlation map with TTL.
+- `DiscussionContextStore` — persisted `(channel, discussion_id)` state.
+- `Dispatcher` — the dispatch dance.
+- `createCallbackHandler` — the inbound-callback skeleton.
+- `RateLimiter` — per-thread dispatch rate cap.
+- `createBridgeServer` — Hono + `@hono/node-server` wiring.
+- `validateCallbackPayload` — lenient kata-dispatch payload validator.
+- `newDiscussionContext` — canonical record-shape factory.
+- `evaluateTrigger`, `parseIsoDuration` — recessed-resume trigger helpers.
+- `dispatchWorkflow` — the one channel-specific URL (`workflow_dispatch`).

--- a/libraries/libbridge/src/acknowledgement.js
+++ b/libraries/libbridge/src/acknowledgement.js
@@ -1,0 +1,122 @@
+import { ProgressTicker } from "./progress-ticker.js";
+
+const DEFAULT_TICKER_INTERVAL_MS = 25_000;
+
+/**
+ * Channel-agnostic acknowledgement lifecycle. The host service injects two
+ * adapters; libbridge owns the *when*, the adapter owns the *how*:
+ *
+ *   reactionAdapter.add(target) -> reactionId | null
+ *   reactionAdapter.remove(reactionId, target) -> void
+ *   tickerAdapter.tick(target, n) -> void          // optional
+ *
+ * `start(token, target)` immediately adds the reaction and, if a ticker
+ * adapter is supplied, starts a ProgressTicker that calls `tick(target, n)`
+ * every `tickerIntervalMs` (default 25s). `finish(token, target)` stops the
+ * ticker and removes the reaction.
+ *
+ * Errors from adapter calls are logged (via the optional logger) but never
+ * thrown — a missing reaction or a failed tick must not block the
+ * dispatch or the reply. Ticker rejections auto-stop the ticker
+ * (inherited from ProgressTicker).
+ */
+export class Acknowledgement {
+  #reactionAdapter;
+  #tickerAdapter;
+  #ticker;
+  #logger;
+  #state = new Map();
+
+  /**
+   * @param {object} options
+   * @param {{add: Function, remove: Function}} options.reactionAdapter
+   * @param {{tick: Function}} [options.tickerAdapter]
+   * @param {number} [options.tickerIntervalMs]
+   * @param {import("./progress-ticker.js").ProgressTicker} [options.progressTicker]
+   * @param {{warn?: Function, error?: Function}} [options.logger]
+   */
+  constructor({
+    reactionAdapter,
+    tickerAdapter,
+    tickerIntervalMs,
+    progressTicker,
+    logger,
+  } = {}) {
+    if (
+      !reactionAdapter ||
+      typeof reactionAdapter.add !== "function" ||
+      typeof reactionAdapter.remove !== "function"
+    ) {
+      throw new Error("reactionAdapter must implement add() and remove()");
+    }
+    if (tickerAdapter && typeof tickerAdapter.tick !== "function") {
+      throw new Error("tickerAdapter must implement tick()");
+    }
+    this.#reactionAdapter = reactionAdapter;
+    this.#tickerAdapter = tickerAdapter ?? null;
+    this.#ticker =
+      progressTicker ??
+      new ProgressTicker({
+        intervalMs: tickerIntervalMs ?? DEFAULT_TICKER_INTERVAL_MS,
+      });
+    this.#logger = logger ?? null;
+  }
+
+  /**
+   * Begin acknowledging the dispatch identified by `token`. Idempotent on the
+   * same token — a second start is a no-op (the original timer keeps
+   * running, the original reaction stays attached).
+   * @param {string} token
+   * @param {unknown} target
+   */
+  async start(token, target) {
+    if (this.#state.has(token)) return;
+    let reactionId = null;
+    try {
+      reactionId = (await this.#reactionAdapter.add(target)) ?? null;
+    } catch (err) {
+      this.#logger?.warn?.("acknowledgement.add", err);
+    }
+    this.#state.set(token, { reactionId, target });
+    if (this.#tickerAdapter) {
+      let n = 0;
+      const adapter = this.#tickerAdapter;
+      const logger = this.#logger;
+      this.#ticker.start(token, async () => {
+        n++;
+        try {
+          await adapter.tick(target, n);
+        } catch (err) {
+          logger?.warn?.("acknowledgement.tick", err);
+          throw err;
+        }
+      });
+    }
+  }
+
+  /**
+   * Stop acknowledging the dispatch identified by `token`. No-op if the
+   * token has no active acknowledgement.
+   * @param {string} token
+   * @param {unknown} [target]
+   */
+  async finish(token, target) {
+    const entry = this.#state.get(token);
+    if (!entry) return;
+    this.#ticker.stop(token);
+    this.#state.delete(token);
+    try {
+      await this.#reactionAdapter.remove(
+        entry.reactionId,
+        target ?? entry.target,
+      );
+    } catch (err) {
+      this.#logger?.warn?.("acknowledgement.remove", err);
+    }
+  }
+
+  /** @param {string} token @returns {boolean} */
+  pending(token) {
+    return this.#state.has(token);
+  }
+}

--- a/libraries/libbridge/src/acknowledgement.js
+++ b/libraries/libbridge/src/acknowledgement.js
@@ -1,28 +1,40 @@
 import { ProgressTicker } from "./progress-ticker.js";
 
-const DEFAULT_TICKER_INTERVAL_MS = 25_000;
+const DEFAULT_INTERVAL_MS = 25_000;
+
+export const DEFAULT_TYPING_VERBS = Object.freeze([
+  "Moonwalking",
+  "Unravelling",
+  "Tempering",
+  "Crafting",
+  "Simmering",
+  "Percolating",
+  "Decoding",
+]);
 
 /**
- * Channel-agnostic acknowledgement lifecycle. The host service injects two
- * adapters; libbridge owns the *when*, the adapter owns the *how*:
+ * Channel-agnostic acknowledgement lifecycle. The consumer provides a
+ * reaction adapter that knows how to add and remove the channel's
+ * "received" reaction. Optionally, the consumer may pass a typing adapter
+ * — its only job is to deliver a single string to the channel.
+ * Acknowledgement owns *when* to react, *which* typing verb to use, and
+ * *how often* to send one.
  *
  *   reactionAdapter.add(target) -> reactionId | null
  *   reactionAdapter.remove(reactionId, target) -> void
- *   tickerAdapter.tick(target, n) -> void          // optional
+ *   typingAdapter.send(target, text) -> void           // optional
  *
- * `start(token, target)` immediately adds the reaction and, if a ticker
- * adapter is supplied, starts a ProgressTicker that calls `tick(target, n)`
- * every `tickerIntervalMs` (default 25s). `finish(token, target)` stops the
- * ticker and removes the reaction.
- *
- * Errors from adapter calls are logged (via the optional logger) but never
- * thrown — a missing reaction or a failed tick must not block the
- * dispatch or the reply. Ticker rejections auto-stop the ticker
- * (inherited from ProgressTicker).
+ * `start(token, target)` adds the reaction immediately. If a typing
+ * adapter was supplied, it also begins posting a random typing verb
+ * every `intervalMs` (default 25s) — e.g. `"Crafting..."`,
+ * `"Moonwalking..."`. `finish(token, target)` stops the typing ticker
+ * and removes the reaction. Adapter errors are logged through the
+ * optional logger but never thrown.
  */
 export class Acknowledgement {
   #reactionAdapter;
-  #tickerAdapter;
+  #typingAdapter;
+  #typingVerbs;
   #ticker;
   #logger;
   #state = new Map();
@@ -30,15 +42,17 @@ export class Acknowledgement {
   /**
    * @param {object} options
    * @param {{add: Function, remove: Function}} options.reactionAdapter
-   * @param {{tick: Function}} [options.tickerAdapter]
-   * @param {number} [options.tickerIntervalMs]
+   * @param {{send: Function}} [options.typingAdapter]
+   * @param {number} [options.intervalMs] - Typing cadence (default 25s)
+   * @param {readonly string[]} [options.typingVerbs] - Override the verb pool
    * @param {import("./progress-ticker.js").ProgressTicker} [options.progressTicker]
    * @param {{warn?: Function, error?: Function}} [options.logger]
    */
   constructor({
     reactionAdapter,
-    tickerAdapter,
-    tickerIntervalMs,
+    typingAdapter,
+    intervalMs,
+    typingVerbs,
     progressTicker,
     logger,
   } = {}) {
@@ -49,23 +63,26 @@ export class Acknowledgement {
     ) {
       throw new Error("reactionAdapter must implement add() and remove()");
     }
-    if (tickerAdapter && typeof tickerAdapter.tick !== "function") {
-      throw new Error("tickerAdapter must implement tick()");
+    if (typingAdapter && typeof typingAdapter.send !== "function") {
+      throw new Error("typingAdapter must implement send()");
+    }
+    if (typingVerbs !== undefined) {
+      if (!Array.isArray(typingVerbs) || typingVerbs.length === 0) {
+        throw new Error("typingVerbs must be a non-empty array");
+      }
     }
     this.#reactionAdapter = reactionAdapter;
-    this.#tickerAdapter = tickerAdapter ?? null;
+    this.#typingAdapter = typingAdapter ?? null;
+    this.#typingVerbs = typingVerbs ?? DEFAULT_TYPING_VERBS;
     this.#ticker =
       progressTicker ??
-      new ProgressTicker({
-        intervalMs: tickerIntervalMs ?? DEFAULT_TICKER_INTERVAL_MS,
-      });
+      new ProgressTicker({ intervalMs: intervalMs ?? DEFAULT_INTERVAL_MS });
     this.#logger = logger ?? null;
   }
 
   /**
-   * Begin acknowledging the dispatch identified by `token`. Idempotent on the
-   * same token — a second start is a no-op (the original timer keeps
-   * running, the original reaction stays attached).
+   * Begin acknowledging the dispatch identified by `token`. Idempotent on
+   * the same token — a second start is a no-op.
    * @param {string} token
    * @param {unknown} target
    */
@@ -78,20 +95,7 @@ export class Acknowledgement {
       this.#logger?.warn?.("acknowledgement.add", err);
     }
     this.#state.set(token, { reactionId, target });
-    if (this.#tickerAdapter) {
-      let n = 0;
-      const adapter = this.#tickerAdapter;
-      const logger = this.#logger;
-      this.#ticker.start(token, async () => {
-        n++;
-        try {
-          await adapter.tick(target, n);
-        } catch (err) {
-          logger?.warn?.("acknowledgement.tick", err);
-          throw err;
-        }
-      });
-    }
+    if (this.#typingAdapter) this.#startTyping(token, target);
   }
 
   /**
@@ -118,5 +122,20 @@ export class Acknowledgement {
   /** @param {string} token @returns {boolean} */
   pending(token) {
     return this.#state.has(token);
+  }
+
+  #startTyping(token, target) {
+    const adapter = this.#typingAdapter;
+    const verbs = this.#typingVerbs;
+    const logger = this.#logger;
+    this.#ticker.start(token, async () => {
+      const verb = verbs[Math.floor(Math.random() * verbs.length)];
+      try {
+        await adapter.send(target, `${verb}...`);
+      } catch (err) {
+        logger?.warn?.("acknowledgement.typing", err);
+        throw err;
+      }
+    });
   }
 }

--- a/libraries/libbridge/src/callback-handler.js
+++ b/libraries/libbridge/src/callback-handler.js
@@ -1,0 +1,167 @@
+import { validateCallbackPayload } from "./callback-payload.js";
+
+/**
+ * Thrown from a `handleReply` callback to short-circuit `createCallbackHandler`
+ * with a specific HTTP status (e.g. 410 when a conversation reference is
+ * missing). The handler emits the response without logging the throw as an
+ * error.
+ */
+export class CallbackHandlerError extends Error {
+  /**
+   * @param {number} status
+   * @param {string} message
+   */
+  constructor(status, message) {
+    super(message);
+    this.name = "CallbackHandlerError";
+    this.status = status;
+  }
+}
+
+/**
+ * Build the Hono `onCallback` handler that both bridges share. The handler:
+ *
+ *   1. Consumes the callback token from `CallbackRegistry`.
+ *   2. Finishes the acknowledgement.
+ *   3. Validates the JSON body with the lenient libbridge validator.
+ *   4. Checks the `correlation_id` matches the consumed token.
+ *   5. Loads the discussion context for `(channel, discussionId)`.
+ *   6. Hands `(ctx, payload, meta)` to the caller's `handleReply` to post
+ *      replies, append history, and apply the verdict.
+ *   7. Flushes the store and emits a span.
+ *
+ * `handleReply` may throw `new CallbackHandlerError(status, message)` to
+ * short-circuit with a specific HTTP status.
+ *
+ * @param {object} options
+ * @param {string} options.channel
+ * @param {import("./callback-registry.js").CallbackRegistry} options.callbacks
+ * @param {import("./acknowledgement.js").Acknowledgement} options.ack
+ * @param {import("./discussion-context.js").DiscussionContextStore} options.store
+ * @param {{debug?: Function, error?: Function}} options.logger
+ * @param {{startSpan: Function}} options.tracer
+ * @param {string} options.spanName
+ * @param {(meta: object) => string} options.loadDiscussionId
+ * @param {(meta: object) => unknown} [options.ackFinishTarget]
+ * @param {(ctx: object, payload: object, meta: object) => Promise<void>} options.handleReply
+ * @returns {(c: object) => Promise<Response>}
+ */
+export function createCallbackHandler({
+  channel,
+  callbacks,
+  ack,
+  store,
+  logger,
+  tracer,
+  spanName,
+  loadDiscussionId,
+  ackFinishTarget,
+  handleReply,
+}) {
+  if (!channel) throw new Error("channel is required");
+  if (!callbacks) throw new Error("callbacks is required");
+  if (!ack) throw new Error("ack is required");
+  if (!store) throw new Error("store is required");
+  if (!logger) throw new Error("logger is required");
+  if (!tracer) throw new Error("tracer is required");
+  if (!spanName) throw new Error("spanName is required");
+  if (typeof loadDiscussionId !== "function") {
+    throw new Error("loadDiscussionId is required");
+  }
+  if (typeof handleReply !== "function") {
+    throw new Error("handleReply is required");
+  }
+
+  return async (c) => {
+    const prelude = await resolveContext(c, {
+      callbacks,
+      ack,
+      store,
+      channel,
+      logger,
+      loadDiscussionId,
+      ackFinishTarget,
+    });
+    if (prelude.error) return c.json({ error: prelude.error }, prelude.status);
+
+    const { token, ctx, meta, payload } = prelude;
+    delete ctx.pending_callbacks[token];
+    return runHandleReply(c, {
+      ctx,
+      meta,
+      payload,
+      handleReply,
+      store,
+      logger,
+      tracer,
+      spanName,
+    });
+  };
+}
+
+async function resolveContext(
+  c,
+  { callbacks, ack, store, channel, logger, loadDiscussionId, ackFinishTarget },
+) {
+  const token = c.req.param("token");
+  const meta = callbacks.consume(token);
+  if (!meta) {
+    logger.debug?.("callback", "unknown token");
+    return { status: 404, error: "Unknown callback token" };
+  }
+  await ack.finish(token, ackFinishTarget ? ackFinishTarget(meta) : undefined);
+
+  let body;
+  try {
+    body = await c.req.json();
+  } catch {
+    return { status: 400, error: "Invalid JSON" };
+  }
+  const payload = validateCallbackPayload(body);
+  if (!payload) return { status: 400, error: "Invalid payload" };
+  if (payload.correlation_id !== meta.correlationId) {
+    return { status: 400, error: "Correlation ID mismatch" };
+  }
+
+  const discussionId = loadDiscussionId(meta);
+  const ctx = await store.loadByChannel(channel, discussionId);
+  if (!ctx) {
+    logger.error?.("callback", "context missing", {
+      discussion_id: discussionId,
+    });
+    return { status: 410, error: "Discussion context missing" };
+  }
+  return { token, ctx, meta, payload };
+}
+
+async function runHandleReply(
+  c,
+  { ctx, meta, payload, handleReply, store, logger, tracer, spanName },
+) {
+  const span = tracer.startSpan(spanName, {
+    kind: "SERVER",
+    attributes: { correlation_id: meta.correlationId },
+  });
+  try {
+    await handleReply(ctx, payload, meta);
+    ctx.last_active_at = Date.now();
+    await store.add(ctx);
+    await store.flush();
+    span.addEvent("reply_delivered", { verdict: payload.verdict });
+    span.setOk();
+    return c.json({ ok: true }, 200);
+  } catch (err) {
+    if (err instanceof CallbackHandlerError) {
+      span.addEvent("short_circuit", { status: err.status });
+      span.setOk();
+      return c.json({ error: err.message }, err.status);
+    }
+    logger.error?.("callback", err, {
+      correlation_id: meta.correlationId,
+    });
+    span.setError(err);
+    return c.json({ error: "Failed to deliver reply" }, 500);
+  } finally {
+    await span.end();
+  }
+}

--- a/libraries/libbridge/src/callback-payload.js
+++ b/libraries/libbridge/src/callback-payload.js
@@ -1,9 +1,11 @@
-const MAX_FIELD_LENGTH = 2000;
+export const MAX_FIELD_LENGTH = 2000;
 
 /**
- * Validate and sanitize the kata-dispatch callback payload. Returns a clean
- * object or null. Accepts the channel-agnostic optional fields (`replies`,
- * `trigger`, `discussion_id`) used by the discuss-mode trace.
+ * Validate and sanitize the kata-dispatch callback payload. Lenient by
+ * design: missing `verdict`/`summary` default to safe sentinels rather
+ * than rejecting, so a host that wants to surface a degraded callback
+ * can still post something useful. Returns a clean object or `null` if
+ * `correlation_id` is missing.
  *
  * @param {unknown} body
  * @returns {object | null}
@@ -40,6 +42,8 @@ export function validateCallbackPayload(body) {
 }
 
 /**
+ * Strip trailing slashes from a base URL so callback URL composition is
+ * deterministic regardless of operator input.
  * @param {string} url
  * @returns {string}
  */
@@ -48,27 +52,24 @@ export function normalizeBaseUrl(url) {
 }
 
 /**
- * Build a fresh `DiscussionContext` record for the github-discussions channel.
- * Mirrors the canonical record shape declared in `libbridge`.
+ * Build a fresh `DiscussionContext` record for any channel. The host
+ * service supplies a `participant` (channel-shaped) and the canonical
+ * record fields (`history`, `open_rfcs`, `dispatches`, etc.) are filled
+ * in here so both bridges agree on the shape.
  *
- * @param {string} discussionId
- * @param {object} discussion - The GitHub webhook payload's discussion object
+ * @param {object} args
+ * @param {string} args.channel
+ * @param {string} args.discussionId
+ * @param {object} args.participant
  * @returns {object}
  */
-export function newDiscussionContext(discussionId, discussion) {
+export function newDiscussionContext({ channel, discussionId, participant }) {
   return {
-    id: `github-discussions:${discussionId}`,
-    channel: "github-discussions",
+    id: `${channel}:${discussionId}`,
+    channel,
     discussion_id: discussionId,
     history: [],
-    participants: [
-      {
-        name: discussion?.user?.login ?? "github-user",
-        kind: "human",
-        external_id: discussion?.user?.id?.toString(),
-        metadata: { node_id: discussion?.node_id },
-      },
-    ],
+    participants: [participant],
     open_rfcs: {},
     lead: "release-engineer",
     pending_callbacks: {},

--- a/libraries/libbridge/src/dispatcher.js
+++ b/libraries/libbridge/src/dispatcher.js
@@ -1,0 +1,128 @@
+import { randomUUID } from "node:crypto";
+
+import { dispatchWorkflow } from "./dispatch.js";
+import { appendHistory } from "./history.js";
+
+/**
+ * The standard "dispatch dance" both bridges perform: generate a
+ * correlation ID, register the callback token, start the acknowledgement
+ * (if `ackTarget` is supplied), fire the kata-dispatch workflow, append
+ * history, push the dispatch timestamp, and flush the store. On failure
+ * the acknowledgement is finished and the callback registration is rolled
+ * back before the error rethrows.
+ *
+ * The caller still owns: loading/creating the context, checking the rate
+ * limiter, and deciding the user-facing action when `dispatch()` throws.
+ *
+ * @example
+ *   const { token, correlationId } = await dispatcher.dispatch({
+ *     ctx,
+ *     prompt,
+ *     ackTarget: { subjectId: nodeId },
+ *     historyText: text,
+ *     callbackMeta: { discussionId },
+ *     workflowInputs: { discussionId },
+ *   });
+ */
+export class Dispatcher {
+  #callbacks;
+  #ack;
+  #store;
+  #callbackBaseUrl;
+  #workflowFile;
+  #githubRepo;
+  #getGithubToken;
+
+  /**
+   * @param {object} options
+   * @param {import("./callback-registry.js").CallbackRegistry} options.callbacks
+   * @param {import("./acknowledgement.js").Acknowledgement} options.ack
+   * @param {import("./discussion-context.js").DiscussionContextStore} options.store
+   * @param {string} options.callbackBaseUrl - Already normalised
+   * @param {string} options.workflowFile
+   * @param {string} options.githubRepo
+   * @param {() => Promise<string> | string} options.getGithubToken
+   */
+  constructor({
+    callbacks,
+    ack,
+    store,
+    callbackBaseUrl,
+    workflowFile,
+    githubRepo,
+    getGithubToken,
+  }) {
+    if (!callbacks) throw new Error("callbacks is required");
+    if (!ack) throw new Error("ack is required");
+    if (!store) throw new Error("store is required");
+    if (typeof callbackBaseUrl !== "string") {
+      throw new Error("callbackBaseUrl is required");
+    }
+    if (!workflowFile) throw new Error("workflowFile is required");
+    if (!githubRepo) throw new Error("githubRepo is required");
+    if (typeof getGithubToken !== "function") {
+      throw new Error("getGithubToken is required");
+    }
+    this.#callbacks = callbacks;
+    this.#ack = ack;
+    this.#store = store;
+    this.#callbackBaseUrl = callbackBaseUrl;
+    this.#workflowFile = workflowFile;
+    this.#githubRepo = githubRepo;
+    this.#getGithubToken = getGithubToken;
+  }
+
+  /**
+   * @param {object} args
+   * @param {object} args.ctx - Discussion context record (mutated)
+   * @param {string} args.prompt
+   * @param {object} args.callbackMeta - Stored on the callback token
+   * @param {unknown} [args.ackTarget] - If omitted, no acknowledgement is started
+   * @param {string} [args.historyText] - Appended to ctx.history as the user turn on success
+   * @param {object} [args.workflowInputs] - Extra fields for `dispatchWorkflow`
+   * @returns {Promise<{token: string, correlationId: string}>}
+   */
+  async dispatch({
+    ctx,
+    prompt,
+    callbackMeta,
+    ackTarget,
+    historyText,
+    workflowInputs,
+  }) {
+    if (!ctx) throw new Error("ctx is required");
+    if (typeof prompt !== "string") throw new Error("prompt is required");
+
+    const correlationId = randomUUID();
+    const token = this.#callbacks.register(correlationId, callbackMeta ?? {});
+    ctx.pending_callbacks[token] = correlationId;
+    const callbackUrl = `${this.#callbackBaseUrl}/api/callback/${token}`;
+
+    if (ackTarget !== undefined) await this.#ack.start(token, ackTarget);
+    try {
+      const ghToken = await this.#getGithubToken();
+      await dispatchWorkflow({
+        workflowFile: this.#workflowFile,
+        repo: this.#githubRepo,
+        token: ghToken,
+        prompt,
+        callbackUrl,
+        correlationId,
+        ...(workflowInputs ?? {}),
+      });
+      if (historyText !== undefined) {
+        appendHistory(ctx.history, { role: "user", text: historyText });
+      }
+      ctx.dispatches.push(Date.now());
+      ctx.last_active_at = Date.now();
+      await this.#store.add(ctx);
+      await this.#store.flush();
+      return { token, correlationId };
+    } catch (err) {
+      if (ackTarget !== undefined) await this.#ack.finish(token, ackTarget);
+      this.#callbacks.consume(token);
+      delete ctx.pending_callbacks[token];
+      throw err;
+    }
+  }
+}

--- a/libraries/libbridge/src/elapsed-scheduler.js
+++ b/libraries/libbridge/src/elapsed-scheduler.js
@@ -3,9 +3,10 @@ const CHUNK_CAP_MS = 7 * 24 * 60 * 60 * 1000;
 /**
  * In-memory scheduler for `elapsed` resume triggers. JS `setTimeout`'s
  * practical cap is ~24.8 days; this scheduler chunks longer durations
- * into <= 7-day rearm segments so future >24-day windows work, while the
- * persistent `due_at` in `open_rfcs` is the source of truth across
- * restarts.
+ * into <= 7-day rearm segments so future >24-day windows work, while
+ * the persistent `due_at` in `open_rfcs` is the source of truth across
+ * restarts. Channel-agnostic — used by `ResumeScheduler` for both
+ * bridges.
  */
 export class ElapsedScheduler {
   #timers = new Map();

--- a/libraries/libbridge/src/index.js
+++ b/libraries/libbridge/src/index.js
@@ -6,4 +6,11 @@ export { RateLimiter } from "./rate-limit.js";
 export { dispatchWorkflow } from "./dispatch.js";
 export { DiscussionContextStore } from "./discussion-context.js";
 export { ProgressTicker } from "./progress-ticker.js";
+export { Acknowledgement } from "./acknowledgement.js";
+export {
+  MAX_FIELD_LENGTH,
+  newDiscussionContext,
+  normalizeBaseUrl,
+  validateCallbackPayload,
+} from "./callback-payload.js";
 export { evaluateTrigger, parseIsoDuration } from "./triggers.js";

--- a/libraries/libbridge/src/index.js
+++ b/libraries/libbridge/src/index.js
@@ -27,6 +27,8 @@ export {
   CallbackHandlerError,
   createCallbackHandler,
 } from "./callback-handler.js";
+export { ElapsedScheduler } from "./elapsed-scheduler.js";
+export { ResumeScheduler } from "./resume-scheduler.js";
 export {
   MAX_FIELD_LENGTH,
   newDiscussionContext,

--- a/libraries/libbridge/src/index.js
+++ b/libraries/libbridge/src/index.js
@@ -1,3 +1,15 @@
+/**
+ * Canonical configuration contract every bridge consumes. Channel-specific
+ * fields (e.g. `app_webhook_secret` on ghbridge, `msAppId()` on msbridge)
+ * extend this — see each bridge's README for the channel-specific surface.
+ *
+ * @typedef {object} BridgeConfig
+ * @property {string} host - Bind host (typically "127.0.0.1" or "0.0.0.0")
+ * @property {number} port - Bind port; 0 selects a free port
+ * @property {string} callback_base_url - Public URL the dispatched workflow posts back to
+ * @property {string} github_repo - "owner/repo" hosting the kata-dispatch workflow
+ */
+
 export { createBridgeServer } from "./server.js";
 export { CallbackRegistry } from "./callback-registry.js";
 export { buildPrompt } from "./prompt.js";
@@ -10,6 +22,11 @@ export {
   Acknowledgement,
   DEFAULT_TYPING_VERBS,
 } from "./acknowledgement.js";
+export { Dispatcher } from "./dispatcher.js";
+export {
+  CallbackHandlerError,
+  createCallbackHandler,
+} from "./callback-handler.js";
 export {
   MAX_FIELD_LENGTH,
   newDiscussionContext,

--- a/libraries/libbridge/src/index.js
+++ b/libraries/libbridge/src/index.js
@@ -6,7 +6,10 @@ export { RateLimiter } from "./rate-limit.js";
 export { dispatchWorkflow } from "./dispatch.js";
 export { DiscussionContextStore } from "./discussion-context.js";
 export { ProgressTicker } from "./progress-ticker.js";
-export { Acknowledgement } from "./acknowledgement.js";
+export {
+  Acknowledgement,
+  DEFAULT_TYPING_VERBS,
+} from "./acknowledgement.js";
 export {
   MAX_FIELD_LENGTH,
   newDiscussionContext,

--- a/libraries/libbridge/src/resume-scheduler.js
+++ b/libraries/libbridge/src/resume-scheduler.js
@@ -1,0 +1,254 @@
+import { ElapsedScheduler } from "./elapsed-scheduler.js";
+import { evaluateTrigger, parseIsoDuration } from "./triggers.js";
+
+const DEFAULT_PROMPT = "Resume requested.";
+
+/**
+ * Channel-agnostic suspend/resume lifecycle for the discuss-mode trace.
+ * When the workflow returns a `"recessed"` verdict, the bridge calls
+ * `enterRecess(...)` to persist the trigger on
+ * `ctx.open_rfcs[correlationId]`. The scheduler watches inbound activity
+ * via `processInbound(ctx)` and ticking elapsed timers via the embedded
+ * `ElapsedScheduler`; when a trigger fires, it redispatches the workflow
+ * through the shared `Dispatcher` with a `resume_context` payload
+ * linking back to the original correlation id.
+ *
+ * Channel-specific extras are supplied by two small constructor
+ * callbacks:
+ *
+ *   buildCallbackMeta(ctx) -> { ... }   // matches the bridge's loadDiscussionId
+ *   buildResumeInputs(ctx) -> { ... }   // extra workflow_dispatch inputs
+ *
+ * Both default to ghbridge's convention; msbridge overrides
+ * `buildCallbackMeta` to `{ threadId: ctx.discussion_id }` when it
+ * adopts resume.
+ *
+ * @example
+ *   const scheduler = new ResumeScheduler({
+ *     dispatcher,
+ *     store,
+ *     logger,
+ *     buildCallbackMeta: (ctx) => ({ discussionId: ctx.discussion_id }),
+ *     buildResumeInputs: (ctx) => ({ discussionId: ctx.discussion_id }),
+ *   });
+ *   // service start:
+ *   await scheduler.rearm();
+ *   // inbound activity:
+ *   const { freshDispatchAllowed } = await scheduler.processInbound(ctx);
+ *   if (freshDispatchAllowed) { ... dispatch fresh ... }
+ *   // on "recessed" verdict:
+ *   scheduler.enterRecess(ctx, correlationId, payload.trigger);
+ *   // on "adjourned" / "failed":
+ *   scheduler.cancelRecess(ctx, correlationId);
+ *   // service stop:
+ *   scheduler.clear();
+ */
+export class ResumeScheduler {
+  #dispatcher;
+  #store;
+  #logger;
+  #elapsed;
+  #prompt;
+  #buildResumeInputs;
+  #buildCallbackMeta;
+
+  /**
+   * @param {object} options
+   * @param {import("./dispatcher.js").Dispatcher} options.dispatcher
+   * @param {import("./discussion-context.js").DiscussionContextStore} options.store
+   * @param {{error?: Function, info?: Function}} [options.logger]
+   * @param {string} [options.prompt] - Default "Resume requested."
+   * @param {(ctx: object) => object} [options.buildCallbackMeta]
+   * @param {(ctx: object) => object} [options.buildResumeInputs]
+   */
+  constructor({
+    dispatcher,
+    store,
+    logger,
+    prompt = DEFAULT_PROMPT,
+    buildCallbackMeta = (ctx) => ({ discussionId: ctx.discussion_id }),
+    buildResumeInputs = () => ({}),
+  }) {
+    if (!dispatcher) throw new Error("dispatcher is required");
+    if (!store) throw new Error("store is required");
+    if (typeof buildCallbackMeta !== "function") {
+      throw new Error("buildCallbackMeta must be a function");
+    }
+    if (typeof buildResumeInputs !== "function") {
+      throw new Error("buildResumeInputs must be a function");
+    }
+    this.#dispatcher = dispatcher;
+    this.#store = store;
+    this.#logger = logger ?? null;
+    this.#prompt = prompt;
+    this.#buildCallbackMeta = buildCallbackMeta;
+    this.#buildResumeInputs = buildResumeInputs;
+    this.#elapsed = new ElapsedScheduler({
+      onFire: (cid) => this.#fireElapsed(cid),
+      onError: (err, cid) =>
+        this.#logger?.error?.("resume.elapsed", err, {
+          correlation_id: cid,
+        }),
+    });
+  }
+
+  /** @returns {number} Number of armed elapsed timers */
+  get size() {
+    return this.#elapsed.size;
+  }
+
+  /**
+   * Begin watching `correlationId` for trigger resolution. Persists the
+   * trigger and the history index at recess time onto
+   * `ctx.open_rfcs[correlationId]`. If the trigger has an elapsed
+   * component, schedules an in-memory timer that will fire even when no
+   * inbound activity arrives. No-op if `trigger` is falsy.
+   *
+   * The caller is responsible for flushing the store after this call —
+   * `enterRecess` mutates ctx but does not write.
+   *
+   * @param {object} ctx
+   * @param {string} correlationId
+   * @param {import("./triggers.js").ResumeTrigger} trigger
+   */
+  enterRecess(ctx, correlationId, trigger) {
+    if (!trigger) return;
+    const openedAt = Date.now();
+    ctx.open_rfcs[correlationId] = {
+      trigger,
+      opened_at: openedAt,
+      history_index_at_open: ctx.history.length,
+    };
+    if (trigger.kind === "elapsed" || trigger.kind === "either") {
+      if (typeof trigger.elapsed === "string") {
+        const dueAt = openedAt + parseIsoDuration(trigger.elapsed);
+        ctx.open_rfcs[correlationId].due_at = dueAt;
+        this.#elapsed.schedule(correlationId, dueAt);
+      }
+    }
+  }
+
+  /**
+   * Stop watching `correlationId`. Removes the rfc from `ctx.open_rfcs`
+   * and cancels any associated elapsed timer. Idempotent — safe to call
+   * for verdicts that didn't actually recess.
+   *
+   * @param {object} ctx
+   * @param {string} correlationId
+   */
+  cancelRecess(ctx, correlationId) {
+    delete ctx.open_rfcs[correlationId];
+    this.#elapsed.cancel(correlationId);
+  }
+
+  /**
+   * Walk `ctx.open_rfcs`. For each rfc whose trigger has fired given the
+   * current history length and clock, redispatch the workflow with
+   * `resume_context` linking back to the original correlation id, then
+   * cancel the rfc. Returns a summary so the host can decide whether to
+   * additionally fire a fresh lead session on this inbound activity.
+   *
+   * If a redispatch fails the rfc remains armed — the host's failure
+   * recovery (next inbound activity, or the next elapsed tick) will
+   * retry.
+   *
+   * @param {object} ctx
+   * @returns {Promise<{
+   *   fired: number,
+   *   hasOpenRfc: boolean,
+   *   freshDispatchAllowed: boolean,
+   * }>}
+   */
+  async processInbound(ctx) {
+    const fired = this.#evaluate(ctx);
+    for (const { correlationId, rfc } of fired) {
+      const historySince = ctx.history.slice(rfc.history_index_at_open);
+      await this.#redispatch(ctx, correlationId, historySince);
+      this.cancelRecess(ctx, correlationId);
+    }
+    const hasOpenRfc = Object.keys(ctx.open_rfcs ?? {}).length > 0;
+    return {
+      fired: fired.length,
+      hasOpenRfc,
+      freshDispatchAllowed: fired.length === 0 && !hasOpenRfc,
+    };
+  }
+
+  /**
+   * Rehydrate persistent elapsed timers from the store. Call once after
+   * the bridge server starts so deadlines set before a restart still
+   * fire.
+   * @returns {Promise<void>}
+   */
+  async rearm() {
+    if (!this.#store.loaded) await this.#store.loadData();
+    for (const record of this.#store.index.values()) {
+      const open = record?.open_rfcs;
+      if (!open) continue;
+      for (const [correlationId, rfc] of Object.entries(open)) {
+        if (typeof rfc.due_at === "number") {
+          this.#elapsed.schedule(correlationId, rfc.due_at);
+        }
+      }
+    }
+  }
+
+  /** Cancel every armed elapsed timer. Safe to call on shutdown. */
+  clear() {
+    this.#elapsed.clear();
+  }
+
+  #evaluate(ctx) {
+    const fired = [];
+    for (const [correlationId, rfc] of Object.entries(ctx.open_rfcs ?? {})) {
+      const trigger = rfc.trigger;
+      if (!trigger) continue;
+      const observed = {
+        responses: ctx.history.length - rfc.history_index_at_open,
+        opened_at: rfc.opened_at,
+      };
+      if (evaluateTrigger(trigger, observed, Date.now()).fired) {
+        fired.push({ correlationId, rfc });
+      }
+    }
+    return fired;
+  }
+
+  async #redispatch(ctx, correlationId, historySince) {
+    const resumeContext = JSON.stringify({
+      correlation_id: correlationId,
+      history_since: historySince,
+    });
+    await this.#dispatcher.dispatch({
+      ctx,
+      prompt: this.#prompt,
+      callbackMeta: this.#buildCallbackMeta(ctx),
+      workflowInputs: {
+        ...this.#buildResumeInputs(ctx),
+        resumeContext,
+      },
+    });
+  }
+
+  async #fireElapsed(correlationId) {
+    const found = await this.#findContextWithRfc(correlationId);
+    if (!found) return;
+    const { ctx, rfc } = found;
+    const historySince = ctx.history.slice(rfc.history_index_at_open);
+    await this.#redispatch(ctx, correlationId, historySince);
+    this.cancelRecess(ctx, correlationId);
+    ctx.last_active_at = Date.now();
+    await this.#store.add(ctx);
+    await this.#store.flush();
+  }
+
+  async #findContextWithRfc(correlationId) {
+    if (!this.#store.loaded) await this.#store.loadData();
+    for (const record of this.#store.index.values()) {
+      if (record?.open_rfcs?.[correlationId]) {
+        return { ctx: record, rfc: record.open_rfcs[correlationId] };
+      }
+    }
+    return null;
+  }
+}

--- a/libraries/libbridge/test/acknowledgement.test.js
+++ b/libraries/libbridge/test/acknowledgement.test.js
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+
+import { Acknowledgement } from "../src/acknowledgement.js";
+import { ProgressTicker } from "../src/progress-ticker.js";
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function makeReactionAdapter({ addImpl, removeImpl } = {}) {
+  const adds = [];
+  const removes = [];
+  return {
+    adds,
+    removes,
+    add: async (target) => {
+      adds.push(target);
+      return addImpl ? addImpl(target) : "reaction-id-1";
+    },
+    remove: async (reactionId, target) => {
+      removes.push({ reactionId, target });
+      if (removeImpl) await removeImpl(reactionId, target);
+    },
+  };
+}
+
+function makeTickerAdapter({ tickImpl } = {}) {
+  const ticks = [];
+  return {
+    ticks,
+    tick: async (target, n) => {
+      ticks.push({ target, n });
+      if (tickImpl) await tickImpl(target, n);
+    },
+  };
+}
+
+describe("Acknowledgement", () => {
+  test("rejects construction without a reaction adapter", () => {
+    expect(() => new Acknowledgement({})).toThrow();
+    expect(() => new Acknowledgement({ reactionAdapter: {} })).toThrow();
+  });
+
+  test("rejects a ticker adapter that lacks tick()", () => {
+    expect(
+      () =>
+        new Acknowledgement({
+          reactionAdapter: makeReactionAdapter(),
+          tickerAdapter: {},
+        }),
+    ).toThrow();
+  });
+
+  test("start adds the reaction immediately and finish removes it", async () => {
+    const reactions = makeReactionAdapter();
+    const ack = new Acknowledgement({ reactionAdapter: reactions });
+    await ack.start("tok-1", { subjectId: "S_1" });
+    expect(reactions.adds).toEqual([{ subjectId: "S_1" }]);
+    expect(ack.pending("tok-1")).toBe(true);
+    await ack.finish("tok-1");
+    expect(reactions.removes).toHaveLength(1);
+    expect(reactions.removes[0]).toEqual({
+      reactionId: "reaction-id-1",
+      target: { subjectId: "S_1" },
+    });
+    expect(ack.pending("tok-1")).toBe(false);
+  });
+
+  test("reaction-only mode never invokes a ticker", async () => {
+    const reactions = makeReactionAdapter();
+    const ticker = new ProgressTicker({ intervalMs: 10 });
+    const ack = new Acknowledgement({
+      reactionAdapter: reactions,
+      progressTicker: ticker,
+    });
+    await ack.start("tok-2", { id: "x" });
+    await wait(35);
+    await ack.finish("tok-2");
+    expect(ticker.size).toBe(0);
+  });
+
+  test("when a ticker adapter is supplied, tick() runs on each interval", async () => {
+    const reactions = makeReactionAdapter();
+    const ticks = makeTickerAdapter();
+    const ack = new Acknowledgement({
+      reactionAdapter: reactions,
+      tickerAdapter: ticks,
+      progressTicker: new ProgressTicker({ intervalMs: 10 }),
+    });
+    await ack.start("tok-3", { ref: "abc" });
+    await wait(55);
+    await ack.finish("tok-3");
+    expect(ticks.ticks.length).toBeGreaterThanOrEqual(3);
+    expect(ticks.ticks[0]).toEqual({ target: { ref: "abc" }, n: 1 });
+    expect(ticks.ticks[1].n).toBe(2);
+  });
+
+  test("add() errors are swallowed and the lifecycle still proceeds", async () => {
+    const reactions = {
+      add: async () => {
+        throw new Error("network");
+      },
+      remove: async () => {},
+    };
+    const ack = new Acknowledgement({ reactionAdapter: reactions });
+    await expect(ack.start("tok-4", null)).resolves.toBeUndefined();
+    expect(ack.pending("tok-4")).toBe(true);
+    await ack.finish("tok-4");
+    expect(ack.pending("tok-4")).toBe(false);
+  });
+
+  test("remove() errors are swallowed so the host's reply path is not blocked", async () => {
+    const reactions = makeReactionAdapter({
+      removeImpl: () => {
+        throw new Error("offline");
+      },
+    });
+    const ack = new Acknowledgement({ reactionAdapter: reactions });
+    await ack.start("tok-5", "T");
+    await expect(ack.finish("tok-5")).resolves.toBeUndefined();
+  });
+
+  test("tick() errors auto-stop the ticker without blocking finish()", async () => {
+    const reactions = makeReactionAdapter();
+    const ticks = makeTickerAdapter({
+      tickImpl: () => {
+        throw new Error("post failed");
+      },
+    });
+    const ticker = new ProgressTicker({ intervalMs: 10 });
+    const ack = new Acknowledgement({
+      reactionAdapter: reactions,
+      tickerAdapter: ticks,
+      progressTicker: ticker,
+    });
+    await ack.start("tok-6", "T");
+    await wait(30);
+    expect(ticker.size).toBe(0);
+    await ack.finish("tok-6");
+    expect(reactions.removes).toHaveLength(1);
+  });
+
+  test("finish without start is a no-op", async () => {
+    const reactions = makeReactionAdapter();
+    const ack = new Acknowledgement({ reactionAdapter: reactions });
+    await ack.finish("never-started");
+    expect(reactions.removes).toHaveLength(0);
+  });
+
+  test("double start on the same token is idempotent", async () => {
+    const reactions = makeReactionAdapter();
+    const ack = new Acknowledgement({ reactionAdapter: reactions });
+    await ack.start("tok-7", "A");
+    await ack.start("tok-7", "B");
+    expect(reactions.adds).toEqual(["A"]);
+  });
+});

--- a/libraries/libbridge/test/acknowledgement.test.js
+++ b/libraries/libbridge/test/acknowledgement.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { Acknowledgement } from "../src/acknowledgement.js";
+import {
+  Acknowledgement,
+  DEFAULT_TYPING_VERBS,
+} from "../src/acknowledgement.js";
 import { ProgressTicker } from "../src/progress-ticker.js";
 
 const wait = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -22,13 +25,13 @@ function makeReactionAdapter({ addImpl, removeImpl } = {}) {
   };
 }
 
-function makeTickerAdapter({ tickImpl } = {}) {
-  const ticks = [];
+function makeTypingAdapter({ sendImpl } = {}) {
+  const sends = [];
   return {
-    ticks,
-    tick: async (target, n) => {
-      ticks.push({ target, n });
-      if (tickImpl) await tickImpl(target, n);
+    sends,
+    send: async (target, text) => {
+      sends.push({ target, text });
+      if (sendImpl) await sendImpl(target, text);
     },
   };
 }
@@ -39,12 +42,22 @@ describe("Acknowledgement", () => {
     expect(() => new Acknowledgement({ reactionAdapter: {} })).toThrow();
   });
 
-  test("rejects a ticker adapter that lacks tick()", () => {
+  test("rejects a typing adapter that lacks send()", () => {
     expect(
       () =>
         new Acknowledgement({
           reactionAdapter: makeReactionAdapter(),
-          tickerAdapter: {},
+          typingAdapter: {},
+        }),
+    ).toThrow();
+  });
+
+  test("rejects an empty typingVerbs list", () => {
+    expect(
+      () =>
+        new Acknowledgement({
+          reactionAdapter: makeReactionAdapter(),
+          typingVerbs: [],
         }),
     ).toThrow();
   });
@@ -64,7 +77,7 @@ describe("Acknowledgement", () => {
     expect(ack.pending("tok-1")).toBe(false);
   });
 
-  test("reaction-only mode never invokes a ticker", async () => {
+  test("reaction-only mode never starts the typing ticker", async () => {
     const reactions = makeReactionAdapter();
     const ticker = new ProgressTicker({ intervalMs: 10 });
     const ack = new Acknowledgement({
@@ -77,20 +90,41 @@ describe("Acknowledgement", () => {
     expect(ticker.size).toBe(0);
   });
 
-  test("when a ticker adapter is supplied, tick() runs on each interval", async () => {
+  test("when a typing adapter is supplied, send() runs on each interval with a verb", async () => {
     const reactions = makeReactionAdapter();
-    const ticks = makeTickerAdapter();
+    const typing = makeTypingAdapter();
     const ack = new Acknowledgement({
       reactionAdapter: reactions,
-      tickerAdapter: ticks,
+      typingAdapter: typing,
       progressTicker: new ProgressTicker({ intervalMs: 10 }),
     });
     await ack.start("tok-3", { ref: "abc" });
     await wait(55);
     await ack.finish("tok-3");
-    expect(ticks.ticks.length).toBeGreaterThanOrEqual(3);
-    expect(ticks.ticks[0]).toEqual({ target: { ref: "abc" }, n: 1 });
-    expect(ticks.ticks[1].n).toBe(2);
+    expect(typing.sends.length).toBeGreaterThanOrEqual(3);
+    for (const { target, text } of typing.sends) {
+      expect(target).toEqual({ ref: "abc" });
+      expect(text).toMatch(/^[A-Z][a-z]+\.\.\.$/);
+      const verb = text.replace(/\.\.\.$/, "");
+      expect(DEFAULT_TYPING_VERBS).toContain(verb);
+    }
+  });
+
+  test("custom typingVerbs override the default pool", async () => {
+    const typing = makeTypingAdapter();
+    const ack = new Acknowledgement({
+      reactionAdapter: makeReactionAdapter(),
+      typingAdapter: typing,
+      typingVerbs: ["Chirping"],
+      progressTicker: new ProgressTicker({ intervalMs: 10 }),
+    });
+    await ack.start("tok-custom", "T");
+    await wait(35);
+    await ack.finish("tok-custom");
+    expect(typing.sends.length).toBeGreaterThan(0);
+    for (const { text } of typing.sends) {
+      expect(text).toBe("Chirping...");
+    }
   });
 
   test("add() errors are swallowed and the lifecycle still proceeds", async () => {
@@ -118,17 +152,17 @@ describe("Acknowledgement", () => {
     await expect(ack.finish("tok-5")).resolves.toBeUndefined();
   });
 
-  test("tick() errors auto-stop the ticker without blocking finish()", async () => {
+  test("typing send() errors auto-stop the ticker without blocking finish()", async () => {
     const reactions = makeReactionAdapter();
-    const ticks = makeTickerAdapter({
-      tickImpl: () => {
+    const typing = makeTypingAdapter({
+      sendImpl: () => {
         throw new Error("post failed");
       },
     });
     const ticker = new ProgressTicker({ intervalMs: 10 });
     const ack = new Acknowledgement({
       reactionAdapter: reactions,
-      tickerAdapter: ticks,
+      typingAdapter: typing,
       progressTicker: ticker,
     });
     await ack.start("tok-6", "T");

--- a/libraries/libbridge/test/callback-handler.test.js
+++ b/libraries/libbridge/test/callback-handler.test.js
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createMockStorage } from "@forwardimpact/libharness";
+
+import { Acknowledgement } from "../src/acknowledgement.js";
+import {
+  CallbackHandlerError,
+  createCallbackHandler,
+} from "../src/callback-handler.js";
+import { CallbackRegistry } from "../src/callback-registry.js";
+import { DiscussionContextStore } from "../src/discussion-context.js";
+
+function makeLogger() {
+  const calls = [];
+  const sink = (level) => (channel, msg, fields) => {
+    calls.push({ level, channel, msg, fields });
+  };
+  return {
+    calls,
+    debug: sink("debug"),
+    info: sink("info"),
+    warn: sink("warn"),
+    error: sink("error"),
+  };
+}
+
+function makeTracer() {
+  const events = [];
+  const noop = () => {};
+  return {
+    events,
+    startSpan: (name, opts) => ({
+      addEvent: (event, attrs) => events.push({ name, event, attrs }),
+      setOk: noop,
+      setError: noop,
+      end: async () => {},
+    }),
+  };
+}
+
+function makeReactionAdapter() {
+  const removes = [];
+  return {
+    removes,
+    add: async () => "rid",
+    remove: async (rid, target) => {
+      removes.push({ rid, target });
+    },
+  };
+}
+
+function makeC({ token, body, parseFails } = {}) {
+  return {
+    req: {
+      param: () => token,
+      json: async () => {
+        if (parseFails) throw new Error("bad json");
+        return body;
+      },
+    },
+    json: (b, status) =>
+      new Response(JSON.stringify(b), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+  };
+}
+
+const channel = "test-channel";
+
+async function seed(
+  store,
+  callbacks,
+  { discussionId = "D_1", meta = {} } = {},
+) {
+  const correlationId = "corr-1";
+  const token = callbacks.register(correlationId, {
+    discussionId,
+    ...meta,
+  });
+  const ctx = {
+    id: `${channel}:${discussionId}`,
+    channel,
+    discussion_id: discussionId,
+    history: [],
+    participants: [],
+    open_rfcs: {},
+    lead: "release-engineer",
+    pending_callbacks: { [token]: correlationId },
+    dispatches: [],
+    last_active_at: Date.now(),
+  };
+  await store.add(ctx);
+  await store.flush();
+  return { token, correlationId, ctx };
+}
+
+describe("createCallbackHandler", () => {
+  let store;
+  let callbacks;
+  let ack;
+  let reactions;
+  let logger;
+  let tracer;
+  let handleReplyCalls;
+  let handler;
+
+  beforeEach(() => {
+    store = new DiscussionContextStore(createMockStorage());
+    callbacks = new CallbackRegistry();
+    reactions = makeReactionAdapter();
+    ack = new Acknowledgement({ reactionAdapter: reactions });
+    logger = makeLogger();
+    tracer = makeTracer();
+    handleReplyCalls = [];
+    handler = createCallbackHandler({
+      channel,
+      callbacks,
+      ack,
+      store,
+      logger,
+      tracer,
+      spanName: "Test.HandleCallback",
+      loadDiscussionId: (meta) => meta.meta?.discussionId,
+      handleReply: async (ctx, payload, meta) => {
+        handleReplyCalls.push({ ctx, payload, meta });
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await store.shutdown();
+  });
+
+  test("rejects construction when required options are missing", () => {
+    expect(() => createCallbackHandler({})).toThrow();
+    expect(() =>
+      createCallbackHandler({
+        channel: "c",
+        callbacks,
+        ack,
+        store,
+        logger,
+        tracer,
+        spanName: "n",
+      }),
+    ).toThrow(/loadDiscussionId/);
+  });
+
+  test("unknown token returns 404", async () => {
+    const res = await handler(makeC({ token: "none", body: {} }));
+    expect(res.status).toBe(404);
+  });
+
+  test("invalid JSON returns 400", async () => {
+    const { token } = await seed(store, callbacks);
+    const res = await handler(makeC({ token, parseFails: true }));
+    expect(res.status).toBe(400);
+  });
+
+  test("payload missing correlation_id returns 400", async () => {
+    const { token } = await seed(store, callbacks);
+    const res = await handler(makeC({ token, body: {} }));
+    expect(res.status).toBe(400);
+  });
+
+  test("correlation_id mismatch returns 400", async () => {
+    const { token } = await seed(store, callbacks);
+    const res = await handler(
+      makeC({
+        token,
+        body: { correlation_id: "wrong", verdict: "adjourned", summary: "" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("missing context returns 410", async () => {
+    const token = callbacks.register("corr-x", { discussionId: "missing" });
+    const res = await handler(
+      makeC({
+        token,
+        body: {
+          correlation_id: "corr-x",
+          verdict: "adjourned",
+          summary: "",
+        },
+      }),
+    );
+    expect(res.status).toBe(410);
+  });
+
+  test("happy path invokes handleReply and flushes the store", async () => {
+    const { token, correlationId, ctx } = await seed(store, callbacks);
+    const res = await handler(
+      makeC({
+        token,
+        body: {
+          correlation_id: correlationId,
+          verdict: "adjourned",
+          summary: "done",
+          replies: [{ body: "hi" }],
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(handleReplyCalls).toHaveLength(1);
+    expect(handleReplyCalls[0].payload.verdict).toBe("adjourned");
+    expect(handleReplyCalls[0].ctx.discussion_id).toBe(ctx.discussion_id);
+    const reloaded = await store.loadByChannel(channel, "D_1");
+    expect(reloaded.pending_callbacks[token]).toBeUndefined();
+    expect(reloaded.last_active_at).toBeGreaterThan(0);
+  });
+
+  test("ack.finish runs before handleReply", async () => {
+    const { token, correlationId } = await seed(store, callbacks);
+    let finishedFirst = false;
+    handler = createCallbackHandler({
+      channel,
+      callbacks,
+      ack,
+      store,
+      logger,
+      tracer,
+      spanName: "Test.HandleCallback",
+      loadDiscussionId: (meta) => meta.meta?.discussionId,
+      handleReply: async () => {
+        finishedFirst = reactions.removes.length === 1;
+      },
+    });
+    // Have something to remove.
+    await ack.start(token, { subjectId: "S" });
+    await handler(
+      makeC({
+        token,
+        body: {
+          correlation_id: correlationId,
+          verdict: "adjourned",
+          summary: "",
+        },
+      }),
+    );
+    expect(finishedFirst).toBe(true);
+  });
+
+  test("ackFinishTarget is forwarded when supplied", async () => {
+    const { token, correlationId } = await seed(store, callbacks);
+    handler = createCallbackHandler({
+      channel,
+      callbacks,
+      ack,
+      store,
+      logger,
+      tracer,
+      spanName: "Test.HandleCallback",
+      loadDiscussionId: (meta) => meta.meta?.discussionId,
+      ackFinishTarget: (meta) => ({ subjectId: meta.meta?.discussionId }),
+      handleReply: async () => {},
+    });
+    await ack.start(token, { subjectId: "ORIGINAL" });
+    await handler(
+      makeC({
+        token,
+        body: {
+          correlation_id: correlationId,
+          verdict: "adjourned",
+          summary: "",
+        },
+      }),
+    );
+    expect(reactions.removes[0].target).toEqual({ subjectId: "D_1" });
+  });
+
+  test("handleReply may throw CallbackHandlerError to short-circuit with a custom status", async () => {
+    const { token, correlationId } = await seed(store, callbacks);
+    handler = createCallbackHandler({
+      channel,
+      callbacks,
+      ack,
+      store,
+      logger,
+      tracer,
+      spanName: "Test.HandleCallback",
+      loadDiscussionId: (meta) => meta.meta?.discussionId,
+      handleReply: async () => {
+        throw new CallbackHandlerError(410, "Conversation reference missing");
+      },
+    });
+    const res = await handler(
+      makeC({
+        token,
+        body: {
+          correlation_id: correlationId,
+          verdict: "adjourned",
+          summary: "",
+        },
+      }),
+    );
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toBe("Conversation reference missing");
+  });
+
+  test("unexpected handleReply errors return 500", async () => {
+    const { token, correlationId } = await seed(store, callbacks);
+    handler = createCallbackHandler({
+      channel,
+      callbacks,
+      ack,
+      store,
+      logger,
+      tracer,
+      spanName: "Test.HandleCallback",
+      loadDiscussionId: (meta) => meta.meta?.discussionId,
+      handleReply: async () => {
+        throw new Error("network");
+      },
+    });
+    const res = await handler(
+      makeC({
+        token,
+        body: {
+          correlation_id: correlationId,
+          verdict: "adjourned",
+          summary: "",
+        },
+      }),
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/libraries/libbridge/test/callback-payload.test.js
+++ b/libraries/libbridge/test/callback-payload.test.js
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  MAX_FIELD_LENGTH,
+  newDiscussionContext,
+  normalizeBaseUrl,
+  validateCallbackPayload,
+} from "../src/callback-payload.js";
+
+describe("validateCallbackPayload", () => {
+  test("rejects non-object bodies", () => {
+    expect(validateCallbackPayload(null)).toBeNull();
+    expect(validateCallbackPayload(undefined)).toBeNull();
+    expect(validateCallbackPayload("string")).toBeNull();
+  });
+
+  test("rejects when correlation_id is missing or non-string", () => {
+    expect(validateCallbackPayload({})).toBeNull();
+    expect(validateCallbackPayload({ correlation_id: 42 })).toBeNull();
+    expect(validateCallbackPayload({ correlation_id: "" })).toBeNull();
+  });
+
+  test("defaults verdict to 'unknown' and summary to '' when missing", () => {
+    const payload = validateCallbackPayload({ correlation_id: "c-1" });
+    expect(payload).toEqual({
+      correlation_id: "c-1",
+      verdict: "unknown",
+      summary: "",
+      replies: [],
+    });
+  });
+
+  test("passes through verdict and summary, truncating to MAX_FIELD_LENGTH", () => {
+    const long = "x".repeat(MAX_FIELD_LENGTH + 100);
+    const payload = validateCallbackPayload({
+      correlation_id: "c-1",
+      verdict: long,
+      summary: long,
+    });
+    expect(payload.verdict).toHaveLength(MAX_FIELD_LENGTH);
+    expect(payload.summary).toHaveLength(MAX_FIELD_LENGTH);
+  });
+
+  test("preserves replies array, trigger object, discussion_id, and run_url", () => {
+    const payload = validateCallbackPayload({
+      correlation_id: "c-1",
+      verdict: "adjourned",
+      summary: "done",
+      replies: [{ body: "hi" }, { body: "follow up", in_reply_to: "C_1" }],
+      trigger: { kind: "responses", responses: 2 },
+      discussion_id: "GD_x",
+      run_url: "https://github.com/owner/repo/actions/runs/1",
+    });
+    expect(payload.replies).toHaveLength(2);
+    expect(payload.trigger).toEqual({ kind: "responses", responses: 2 });
+    expect(payload.discussion_id).toBe("GD_x");
+    expect(payload.run_url).toBe(
+      "https://github.com/owner/repo/actions/runs/1",
+    );
+  });
+
+  test("drops non-array replies and non-object triggers", () => {
+    const payload = validateCallbackPayload({
+      correlation_id: "c-1",
+      replies: "not an array",
+      trigger: "not an object",
+    });
+    expect(payload.replies).toEqual([]);
+    expect(payload.trigger).toBeUndefined();
+  });
+});
+
+describe("normalizeBaseUrl", () => {
+  test("strips trailing slashes", () => {
+    expect(normalizeBaseUrl("https://x.test/")).toBe("https://x.test");
+    expect(normalizeBaseUrl("https://x.test///")).toBe("https://x.test");
+    expect(normalizeBaseUrl("https://x.test")).toBe("https://x.test");
+  });
+
+  test("returns empty string for null/undefined", () => {
+    expect(normalizeBaseUrl(null)).toBe("");
+    expect(normalizeBaseUrl(undefined)).toBe("");
+  });
+});
+
+describe("newDiscussionContext", () => {
+  test("composes the canonical record shape from channel/discussionId/participant", () => {
+    const participant = {
+      name: "alice",
+      kind: "human",
+      external_id: "42",
+      metadata: { node_id: "U_1" },
+    };
+    const ctx = newDiscussionContext({
+      channel: "github-discussions",
+      discussionId: "D_kw1",
+      participant,
+    });
+    expect(ctx.id).toBe("github-discussions:D_kw1");
+    expect(ctx.channel).toBe("github-discussions");
+    expect(ctx.discussion_id).toBe("D_kw1");
+    expect(ctx.participants).toEqual([participant]);
+    expect(ctx.history).toEqual([]);
+    expect(ctx.open_rfcs).toEqual({});
+    expect(ctx.pending_callbacks).toEqual({});
+    expect(ctx.dispatches).toEqual([]);
+    expect(ctx.lead).toBe("release-engineer");
+    expect(typeof ctx.last_active_at).toBe("number");
+  });
+
+  test("supports the msteams channel shape", () => {
+    const ref = { conversation: { id: "thread-1" } };
+    const ctx = newDiscussionContext({
+      channel: "msteams",
+      discussionId: "thread-1",
+      participant: { name: "teams-user", kind: "human", metadata: ref },
+    });
+    expect(ctx.id).toBe("msteams:thread-1");
+    expect(ctx.participants[0].metadata).toBe(ref);
+  });
+});

--- a/libraries/libbridge/test/dispatcher.test.js
+++ b/libraries/libbridge/test/dispatcher.test.js
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createMockStorage } from "@forwardimpact/libharness";
+
+import { Acknowledgement } from "../src/acknowledgement.js";
+import { CallbackRegistry } from "../src/callback-registry.js";
+import { DiscussionContextStore } from "../src/discussion-context.js";
+import { Dispatcher } from "../src/dispatcher.js";
+
+function makeReactionAdapter() {
+  const adds = [];
+  const removes = [];
+  return {
+    adds,
+    removes,
+    add: async (target) => {
+      adds.push(target);
+      return "rid";
+    },
+    remove: async (rid, target) => {
+      removes.push({ rid, target });
+    },
+  };
+}
+
+function makeCtx(channel = "test-channel", id = "T_1") {
+  return {
+    id: `${channel}:${id}`,
+    channel,
+    discussion_id: id,
+    history: [],
+    participants: [],
+    open_rfcs: {},
+    lead: "release-engineer",
+    pending_callbacks: {},
+    dispatches: [],
+    last_active_at: 0,
+  };
+}
+
+function stubFetch({ onWorkflowDispatch } = {}) {
+  const calls = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    const target = String(url);
+    if (target.startsWith("https://api.github.com/")) {
+      calls.push({ url: target, init });
+      if (onWorkflowDispatch) return onWorkflowDispatch(url, init);
+      return new Response("{}", { status: 204 });
+    }
+    return original(url, init);
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+describe("Dispatcher", () => {
+  let store;
+  let callbacks;
+  let reactions;
+  let ack;
+  let dispatcher;
+  let fetchStub;
+
+  beforeEach(() => {
+    store = new DiscussionContextStore(createMockStorage());
+    callbacks = new CallbackRegistry();
+    reactions = makeReactionAdapter();
+    ack = new Acknowledgement({ reactionAdapter: reactions });
+    fetchStub = stubFetch();
+    dispatcher = new Dispatcher({
+      callbacks,
+      ack,
+      store,
+      callbackBaseUrl: "https://bridge.example",
+      workflowFile: "kata-dispatch.yml",
+      githubRepo: "owner/repo",
+      getGithubToken: async () => "ghs_test",
+    });
+  });
+
+  afterEach(async () => {
+    fetchStub.restore();
+    await store.shutdown();
+  });
+
+  test("rejects construction when required options are missing", () => {
+    expect(() => new Dispatcher({})).toThrow();
+    expect(
+      () =>
+        new Dispatcher({
+          callbacks,
+          ack,
+          store,
+          callbackBaseUrl: "x",
+          workflowFile: "w",
+          githubRepo: "r",
+        }),
+    ).toThrow("getGithubToken is required");
+  });
+
+  test("happy path: registers callback, starts ack, dispatches, appends history, flushes store", async () => {
+    const ctx = makeCtx();
+    const result = await dispatcher.dispatch({
+      ctx,
+      prompt: "hello",
+      ackTarget: { subjectId: "S_1" },
+      historyText: "hello",
+      callbackMeta: { discussionId: "T_1" },
+      workflowInputs: { discussionId: "T_1" },
+    });
+    expect(typeof result.token).toBe("string");
+    expect(typeof result.correlationId).toBe("string");
+    expect(ctx.pending_callbacks[result.token]).toBe(result.correlationId);
+    expect(ctx.history).toEqual([{ role: "user", text: "hello" }]);
+    expect(ctx.dispatches).toHaveLength(1);
+    expect(reactions.adds).toEqual([{ subjectId: "S_1" }]);
+    expect(callbacks.peek(result.token)?.meta).toEqual({ discussionId: "T_1" });
+    expect(fetchStub.calls).toHaveLength(1);
+    const body = JSON.parse(fetchStub.calls[0].init.body);
+    expect(body.inputs.callback_url).toBe(
+      `https://bridge.example/api/callback/${result.token}`,
+    );
+    expect(body.inputs.correlation_id).toBe(result.correlationId);
+    expect(body.inputs.discussion_id).toBe("T_1");
+    const reloaded = await store.loadByChannel("test-channel", "T_1");
+    expect(reloaded).not.toBeNull();
+  });
+
+  test("ackTarget omitted: no reaction is added", async () => {
+    const ctx = makeCtx();
+    await dispatcher.dispatch({
+      ctx,
+      prompt: "resume",
+      callbackMeta: { discussionId: "T_1" },
+      workflowInputs: { discussionId: "T_1", resumeContext: "{}" },
+    });
+    expect(reactions.adds).toHaveLength(0);
+  });
+
+  test("historyText omitted: no history is appended", async () => {
+    const ctx = makeCtx();
+    await dispatcher.dispatch({
+      ctx,
+      prompt: "p",
+      callbackMeta: {},
+      ackTarget: { subjectId: "S" },
+    });
+    expect(ctx.history).toEqual([]);
+  });
+
+  test("workflowInputs flow through to the dispatch payload", async () => {
+    const ctx = makeCtx();
+    await dispatcher.dispatch({
+      ctx,
+      prompt: "p",
+      callbackMeta: {},
+      workflowInputs: { discussionId: "D_1", resumeContext: '{"r":1}' },
+    });
+    const body = JSON.parse(fetchStub.calls[0].init.body);
+    expect(body.inputs.discussion_id).toBe("D_1");
+    expect(body.inputs.resume_context).toBe('{"r":1}');
+  });
+
+  test("on workflow_dispatch failure: ack is finished, callback consumed, pending_callbacks cleaned, error rethrown", async () => {
+    fetchStub.restore();
+    fetchStub = stubFetch({
+      onWorkflowDispatch: () =>
+        new Response("nope", { status: 422, statusText: "Unprocessable" }),
+    });
+    const ctx = makeCtx();
+    await expect(
+      dispatcher.dispatch({
+        ctx,
+        prompt: "p",
+        callbackMeta: {},
+        ackTarget: { subjectId: "S_2" },
+      }),
+    ).rejects.toThrow(/workflow_dispatch failed/);
+    expect(Object.keys(ctx.pending_callbacks)).toHaveLength(0);
+    expect(callbacks.size).toBe(0);
+    expect(reactions.adds).toHaveLength(1);
+    expect(reactions.removes).toHaveLength(1);
+    expect(ctx.history).toEqual([]);
+    expect(ctx.dispatches).toEqual([]);
+  });
+
+  test("rollback without ackTarget: skips ack.finish but still rolls back the callback", async () => {
+    fetchStub.restore();
+    fetchStub = stubFetch({
+      onWorkflowDispatch: () => new Response("", { status: 500 }),
+    });
+    const ctx = makeCtx();
+    await expect(
+      dispatcher.dispatch({ ctx, prompt: "p", callbackMeta: {} }),
+    ).rejects.toThrow();
+    expect(reactions.removes).toHaveLength(0);
+    expect(callbacks.size).toBe(0);
+    expect(Object.keys(ctx.pending_callbacks)).toHaveLength(0);
+  });
+
+  test("getGithubToken receives await — accepts sync or async values", async () => {
+    let calls = 0;
+    dispatcher = new Dispatcher({
+      callbacks,
+      ack,
+      store,
+      callbackBaseUrl: "https://bridge.example",
+      workflowFile: "kata-dispatch.yml",
+      githubRepo: "owner/repo",
+      getGithubToken: () => {
+        calls++;
+        return "sync_token";
+      },
+    });
+    const ctx = makeCtx();
+    await dispatcher.dispatch({ ctx, prompt: "p", callbackMeta: {} });
+    expect(calls).toBe(1);
+    expect(fetchStub.calls[0].init.headers.Authorization).toBe(
+      "Bearer sync_token",
+    );
+  });
+});

--- a/libraries/libbridge/test/elapsed-scheduler.test.js
+++ b/libraries/libbridge/test/elapsed-scheduler.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import { ElapsedScheduler } from "../src/elapsed-scheduler.js";
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+describe("ElapsedScheduler", () => {
+  test("rejects construction without onFire", () => {
+    expect(() => new ElapsedScheduler({})).toThrow();
+  });
+
+  test("fires at the scheduled time and forgets the timer", async () => {
+    const fired = [];
+    const scheduler = new ElapsedScheduler({
+      onFire: async (cid) => fired.push(cid),
+    });
+    scheduler.schedule("c-1", Date.now() + 15);
+    await wait(35);
+    expect(fired).toEqual(["c-1"]);
+    expect(scheduler.size).toBe(0);
+  });
+
+  test("schedule with a past dueAt fires immediately", async () => {
+    const fired = [];
+    const scheduler = new ElapsedScheduler({
+      onFire: async (cid) => fired.push(cid),
+    });
+    scheduler.schedule("c-past", Date.now() - 1000);
+    await wait(10);
+    expect(fired).toEqual(["c-past"]);
+  });
+
+  test("scheduling the same id replaces the previous timer", async () => {
+    const fired = [];
+    const scheduler = new ElapsedScheduler({
+      onFire: async (cid) => fired.push(cid),
+    });
+    scheduler.schedule("c-1", Date.now() + 50);
+    scheduler.schedule("c-1", Date.now() + 15);
+    await wait(35);
+    expect(fired).toEqual(["c-1"]);
+    expect(scheduler.size).toBe(0);
+  });
+
+  test("cancel prevents firing", async () => {
+    const fired = [];
+    const scheduler = new ElapsedScheduler({
+      onFire: async (cid) => fired.push(cid),
+    });
+    scheduler.schedule("c-1", Date.now() + 15);
+    scheduler.cancel("c-1");
+    await wait(25);
+    expect(fired).toEqual([]);
+    expect(scheduler.size).toBe(0);
+  });
+
+  test("clear cancels all timers", () => {
+    const scheduler = new ElapsedScheduler({ onFire: async () => {} });
+    scheduler.schedule("a", Date.now() + 60_000);
+    scheduler.schedule("b", Date.now() + 60_000);
+    expect(scheduler.size).toBe(2);
+    scheduler.clear();
+    expect(scheduler.size).toBe(0);
+  });
+
+  test("rejections from onFire are surfaced to onError, not unhandled", async () => {
+    const errors = [];
+    const scheduler = new ElapsedScheduler({
+      onFire: async () => {
+        throw new Error("boom");
+      },
+      onError: (err, cid) => errors.push({ message: err.message, cid }),
+    });
+    scheduler.schedule("c-err", Date.now() + 10);
+    await wait(25);
+    expect(errors).toEqual([{ message: "boom", cid: "c-err" }]);
+  });
+});

--- a/libraries/libbridge/test/resume-scheduler.test.js
+++ b/libraries/libbridge/test/resume-scheduler.test.js
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createMockStorage } from "@forwardimpact/libharness";
+
+import { Acknowledgement } from "../src/acknowledgement.js";
+import { CallbackRegistry } from "../src/callback-registry.js";
+import { DiscussionContextStore } from "../src/discussion-context.js";
+import { Dispatcher } from "../src/dispatcher.js";
+import { ResumeScheduler } from "../src/resume-scheduler.js";
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function makeCtx({ channel = "test-channel", id = "T_1", history = [] } = {}) {
+  return {
+    id: `${channel}:${id}`,
+    channel,
+    discussion_id: id,
+    history,
+    participants: [],
+    open_rfcs: {},
+    lead: "release-engineer",
+    pending_callbacks: {},
+    dispatches: [],
+    last_active_at: 0,
+  };
+}
+
+function stubFetch() {
+  const calls = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    const target = String(url);
+    if (target.startsWith("https://api.github.com/")) {
+      calls.push({ url: target, init });
+      return new Response("{}", { status: 204 });
+    }
+    return original(url, init);
+  };
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function buildEnv({ buildCallbackMeta, buildResumeInputs } = {}) {
+  const store = new DiscussionContextStore(createMockStorage());
+  const callbacks = new CallbackRegistry();
+  const ack = new Acknowledgement({
+    reactionAdapter: {
+      add: async () => null,
+      remove: async () => {},
+    },
+  });
+  const dispatcher = new Dispatcher({
+    callbacks,
+    ack,
+    store,
+    callbackBaseUrl: "https://bridge.example",
+    workflowFile: "kata-dispatch.yml",
+    githubRepo: "owner/repo",
+    getGithubToken: async () => "ghs_test",
+  });
+  const scheduler = new ResumeScheduler({
+    dispatcher,
+    store,
+    buildCallbackMeta,
+    buildResumeInputs,
+  });
+  return { store, callbacks, dispatcher, scheduler };
+}
+
+describe("ResumeScheduler", () => {
+  let env;
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = stubFetch();
+    env = buildEnv();
+  });
+
+  afterEach(async () => {
+    fetchStub.restore();
+    env.scheduler.clear();
+    await env.store.shutdown();
+  });
+
+  test("rejects construction when required options are missing", () => {
+    expect(() => new ResumeScheduler({})).toThrow();
+    expect(() => new ResumeScheduler({ dispatcher: env.dispatcher })).toThrow(
+      "store is required",
+    );
+  });
+
+  test("rejects non-function callback builders", () => {
+    expect(
+      () =>
+        new ResumeScheduler({
+          dispatcher: env.dispatcher,
+          store: env.store,
+          buildCallbackMeta: "nope",
+        }),
+    ).toThrow();
+  });
+
+  test("enterRecess stores trigger, opened_at, history_index_at_open on ctx.open_rfcs", () => {
+    const ctx = makeCtx({
+      history: [{ role: "user", text: "first" }],
+    });
+    env.scheduler.enterRecess(ctx, "corr-1", {
+      kind: "responses",
+      responses: 2,
+    });
+    const rfc = ctx.open_rfcs["corr-1"];
+    expect(rfc.trigger).toEqual({ kind: "responses", responses: 2 });
+    expect(rfc.history_index_at_open).toBe(1);
+    expect(typeof rfc.opened_at).toBe("number");
+    expect(rfc.due_at).toBeUndefined();
+  });
+
+  test("enterRecess with elapsed trigger schedules a timer and records due_at", () => {
+    const ctx = makeCtx();
+    env.scheduler.enterRecess(ctx, "corr-2", {
+      kind: "elapsed",
+      elapsed: "PT5S",
+    });
+    expect(ctx.open_rfcs["corr-2"].due_at).toBe(
+      ctx.open_rfcs["corr-2"].opened_at + 5000,
+    );
+    expect(env.scheduler.size).toBe(1);
+  });
+
+  test("enterRecess with falsy trigger is a no-op", () => {
+    const ctx = makeCtx();
+    env.scheduler.enterRecess(ctx, "corr-3", null);
+    expect(ctx.open_rfcs["corr-3"]).toBeUndefined();
+  });
+
+  test("cancelRecess removes the rfc and cancels its timer; idempotent", () => {
+    const ctx = makeCtx();
+    env.scheduler.enterRecess(ctx, "corr-4", {
+      kind: "elapsed",
+      elapsed: "PT5S",
+    });
+    expect(env.scheduler.size).toBe(1);
+    env.scheduler.cancelRecess(ctx, "corr-4");
+    expect(ctx.open_rfcs["corr-4"]).toBeUndefined();
+    expect(env.scheduler.size).toBe(0);
+    expect(() => env.scheduler.cancelRecess(ctx, "corr-4")).not.toThrow();
+  });
+
+  test("processInbound returns freshDispatchAllowed=true when there are no rfcs", async () => {
+    const ctx = makeCtx();
+    const result = await env.scheduler.processInbound(ctx);
+    expect(result).toEqual({
+      fired: 0,
+      hasOpenRfc: false,
+      freshDispatchAllowed: true,
+    });
+  });
+
+  test("processInbound returns freshDispatchAllowed=false when an rfc is open but no trigger fired", async () => {
+    const ctx = makeCtx({ history: [{ role: "user", text: "x" }] });
+    env.scheduler.enterRecess(ctx, "corr-5", {
+      kind: "responses",
+      responses: 5,
+    });
+    // Append one more so we have responses=1 since recess (one < 5).
+    ctx.history.push({ role: "user", text: "y" });
+    const result = await env.scheduler.processInbound(ctx);
+    expect(result).toEqual({
+      fired: 0,
+      hasOpenRfc: true,
+      freshDispatchAllowed: false,
+    });
+    expect(fetchStub.calls).toHaveLength(0);
+  });
+
+  test("processInbound fires a 'responses' trigger and redispatches with resume_context", async () => {
+    const ctx = makeCtx();
+    await env.store.add(ctx);
+    env.scheduler.enterRecess(ctx, "corr-fire", {
+      kind: "responses",
+      responses: 2,
+    });
+    // Two new responses since recess.
+    ctx.history.push({ role: "user", text: "one" });
+    ctx.history.push({ role: "user", text: "two" });
+
+    const result = await env.scheduler.processInbound(ctx);
+    expect(result.fired).toBe(1);
+    expect(result.hasOpenRfc).toBe(false);
+    expect(result.freshDispatchAllowed).toBe(false);
+    expect(ctx.open_rfcs["corr-fire"]).toBeUndefined();
+
+    expect(fetchStub.calls).toHaveLength(1);
+    const inputs = JSON.parse(fetchStub.calls[0].init.body).inputs;
+    expect(inputs.resume_context).toBeDefined();
+    const resume = JSON.parse(inputs.resume_context);
+    expect(resume.correlation_id).toBe("corr-fire");
+    expect(resume.history_since).toEqual([
+      { role: "user", text: "one" },
+      { role: "user", text: "two" },
+    ]);
+    // Default buildCallbackMeta keys discussionId from ctx.discussion_id.
+    expect(inputs.discussion_id).toBeUndefined(); // default buildResumeInputs returns {}
+  });
+
+  test("buildCallbackMeta override flows into the registered callback meta (msbridge convention)", async () => {
+    fetchStub.restore();
+    fetchStub = stubFetch();
+    env = buildEnv({
+      buildCallbackMeta: (ctx) => ({ threadId: ctx.discussion_id }),
+    });
+    const ctx = makeCtx({ id: "thread-99" });
+    await env.store.add(ctx);
+    env.scheduler.enterRecess(ctx, "corr-x", {
+      kind: "responses",
+      responses: 1,
+    });
+    ctx.history.push({ role: "user", text: "hello" });
+    await env.scheduler.processInbound(ctx);
+
+    const token = Object.keys(ctx.pending_callbacks)[0];
+    const stored = env.callbacks.peek(token);
+    expect(stored.meta).toEqual({ threadId: "thread-99" });
+  });
+
+  test("buildResumeInputs override flows into the workflow_dispatch inputs (ghbridge convention)", async () => {
+    fetchStub.restore();
+    fetchStub = stubFetch();
+    env = buildEnv({
+      buildResumeInputs: (ctx) => ({ discussionId: ctx.discussion_id }),
+    });
+    const ctx = makeCtx({ id: "D_99" });
+    await env.store.add(ctx);
+    env.scheduler.enterRecess(ctx, "corr-y", {
+      kind: "responses",
+      responses: 1,
+    });
+    ctx.history.push({ role: "user", text: "hi" });
+    await env.scheduler.processInbound(ctx);
+    const inputs = JSON.parse(fetchStub.calls[0].init.body).inputs;
+    expect(inputs.discussion_id).toBe("D_99");
+    expect(inputs.resume_context).toBeDefined();
+  });
+
+  test("rearm reschedules timers from persisted due_at across a fresh process", async () => {
+    // Seed via the existing store, then reopen the same storage with a
+    // fresh scheduler — that mirrors a service restart.
+    const ctx = makeCtx({ id: "D_rearm" });
+    ctx.open_rfcs["corr-z"] = {
+      trigger: { kind: "elapsed", elapsed: "PT60S" },
+      opened_at: Date.now(),
+      history_index_at_open: 0,
+      due_at: Date.now() + 60_000,
+    };
+    await env.store.add(ctx);
+    await env.store.flush();
+
+    // Tear down the original scheduler/store and reuse the same backing.
+    const sharedStorage = env.store._storage ?? null;
+    if (!sharedStorage) {
+      // DiscussionContextStore doesn't expose its storage handle; build a
+      // second store against the same underlying mock by direct add. The
+      // path that matters in production is `loadData()` reading JSONL —
+      // here we replay that by adding the record into a fresh store and
+      // calling rearm.
+      const freshStore = new DiscussionContextStore(createMockStorage());
+      await freshStore.add(ctx);
+      const callbacks = new CallbackRegistry();
+      const ack = new Acknowledgement({
+        reactionAdapter: { add: async () => null, remove: async () => {} },
+      });
+      const dispatcher = new Dispatcher({
+        callbacks,
+        ack,
+        store: freshStore,
+        callbackBaseUrl: "https://bridge.example",
+        workflowFile: "kata-dispatch.yml",
+        githubRepo: "owner/repo",
+        getGithubToken: async () => "t",
+      });
+      const fresh = new ResumeScheduler({ dispatcher, store: freshStore });
+      try {
+        expect(fresh.size).toBe(0);
+        await fresh.rearm();
+        expect(fresh.size).toBe(1);
+      } finally {
+        fresh.clear();
+        await freshStore.shutdown();
+      }
+    }
+  });
+
+  test("elapsed trigger fires the redispatch automatically on its deadline", async () => {
+    const ctx = makeCtx({ id: "D_tick" });
+    await env.store.add(ctx);
+    await env.store.flush();
+    // Directly construct an rfc with a 20ms deadline.
+    const dueAt = Date.now() + 20;
+    ctx.open_rfcs["corr-tick"] = {
+      trigger: { kind: "elapsed", elapsed: "PT60S" },
+      opened_at: Date.now(),
+      history_index_at_open: 0,
+      due_at: dueAt,
+    };
+    await env.store.add(ctx);
+    // Manually arm via rearm (mimics restart path).
+    await env.scheduler.rearm();
+    await wait(60);
+    expect(fetchStub.calls.length).toBeGreaterThanOrEqual(1);
+    const reloaded = await env.store.loadByChannel("test-channel", "D_tick");
+    expect(reloaded.open_rfcs["corr-tick"]).toBeUndefined();
+  });
+});

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -1,31 +1,50 @@
 import { randomUUID } from "node:crypto";
 
 import {
+  Acknowledgement,
   CallbackRegistry,
   DiscussionContextStore,
-  ProgressTicker,
   RateLimiter,
   appendHistory,
   buildPrompt,
   createBridgeServer,
   dispatchWorkflow,
   evaluateTrigger,
-  parseIsoDuration,
-} from "@forwardimpact/libbridge";
-
-import {
   newDiscussionContext,
   normalizeBaseUrl,
+  parseIsoDuration,
   validateCallbackPayload,
-} from "./src/callback-payload.js";
+} from "@forwardimpact/libbridge";
+
 import { ElapsedScheduler } from "./src/elapsed-scheduler.js";
 import {
   ADD_REACTION_MUTATION,
+  REMOVE_REACTION_MUTATION,
   postDiscussionReplies,
   postSingleDiscussionReply,
 } from "./src/graphql.js";
 
 export { validateCallbackPayload };
+
+const REACTION_CONTENT = "EYES";
+
+function buildReactionAdapter(graphqlClient) {
+  return {
+    add: async (target) => {
+      if (!target?.subjectId) return null;
+      await graphqlClient(ADD_REACTION_MUTATION, {
+        i: { subjectId: target.subjectId, content: REACTION_CONTENT },
+      });
+      return target.subjectId;
+    },
+    remove: async (_reactionId, target) => {
+      if (!target?.subjectId) return;
+      await graphqlClient(REMOVE_REACTION_MUTATION, {
+        i: { subjectId: target.subjectId, content: REACTION_CONTENT },
+      });
+    },
+  };
+}
 
 const CHANNEL = "github-discussions";
 const WEBHOOK_PATH = "/api/webhook";
@@ -50,7 +69,7 @@ export class GhBridgeService {
   #store;
   #callbacks;
   #rateLimiter;
-  #progressTicker;
+  #ack;
   #bridge;
   #elapsedScheduler;
 
@@ -87,7 +106,12 @@ export class GhBridgeService {
     this.#store = new DiscussionContextStore(storage);
     this.#callbacks = new CallbackRegistry();
     this.#rateLimiter = new RateLimiter();
-    this.#progressTicker = deps.progressTicker ?? new ProgressTicker();
+    this.#ack =
+      deps.acknowledgement ??
+      new Acknowledgement({
+        reactionAdapter: buildReactionAdapter(this.#graphqlClient),
+        logger,
+      });
     this.#elapsedScheduler = new ElapsedScheduler({
       onFire: (cid) => this.#fireElapsed(cid),
       onError: (err, cid) =>
@@ -202,7 +226,9 @@ export class GhBridgeService {
       const token = this.#callbacks.register(correlationId, { discussionId });
       ctx.pending_callbacks[token] = correlationId;
       const callbackUrl = `${this.#callbackBaseUrl}/api/callback/${token}`;
+      const ackTarget = { subjectId: discussion?.node_id };
 
+      await this.#ack.start(token, ackTarget);
       try {
         const ghToken = await this.#getInstallationToken();
         await dispatchWorkflow({
@@ -219,13 +245,13 @@ export class GhBridgeService {
         ctx.last_active_at = Date.now();
         await this.#store.add(ctx);
         await this.#store.flush();
-        this.#startProgressIndicator(token, discussion?.node_id, ghToken);
         span.addEvent("workflow_dispatched", {
           correlation_id: correlationId,
         });
         span.setOk();
         return c.body(null, 200);
       } catch (err) {
+        await this.#ack.finish(token, ackTarget);
         this.#callbacks.consume(token);
         delete ctx.pending_callbacks[token];
         this.#logger.error("webhook", err, {
@@ -325,7 +351,9 @@ export class GhBridgeService {
     });
     ctx.pending_callbacks[token] = correlationId;
     const callbackUrl = `${this.#callbackBaseUrl}/api/callback/${token}`;
+    const ackTarget = { subjectId: comment?.node_id };
 
+    await this.#ack.start(token, ackTarget);
     try {
       const ghToken = await this.#getInstallationToken();
       await dispatchWorkflow({
@@ -338,8 +366,8 @@ export class GhBridgeService {
         discussionId: ctx.discussion_id,
       });
       ctx.dispatches.push(Date.now());
-      this.#startProgressIndicator(token, comment?.node_id, ghToken);
     } catch (err) {
+      await this.#ack.finish(token, ackTarget);
       this.#callbacks.consume(token);
       delete ctx.pending_callbacks[token];
       throw err;
@@ -385,7 +413,7 @@ export class GhBridgeService {
       this.#logger.debug("callback", "unknown token");
       return c.json({ error: "Unknown callback token" }, 404);
     }
-    this.#progressTicker.stop(token);
+    await this.#ack.finish(token, { subjectId: meta.meta?.discussionId });
 
     let body;
     try {
@@ -513,18 +541,18 @@ export class GhBridgeService {
     }
   }
 
-  #startProgressIndicator(token, commentNodeId, _ghToken) {
-    if (!commentNodeId) return;
-    this.#progressTicker.start(token, async () => {
-      await this.#graphqlClient(ADD_REACTION_MUTATION, {
-        i: { subjectId: commentNodeId, content: "EYES" },
-      });
-    });
-  }
-
   async #loadOrCreateContext(discussionId, discussion) {
     const existing = await this.#store.loadByChannel(CHANNEL, discussionId);
     if (existing) return existing;
-    return newDiscussionContext(discussionId, discussion);
+    return newDiscussionContext({
+      channel: CHANNEL,
+      discussionId,
+      participant: {
+        name: discussion?.user?.login ?? "github-user",
+        kind: "human",
+        external_id: discussion?.user?.id?.toString(),
+        metadata: { node_id: discussion?.node_id },
+      },
+    });
   }
 }

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -4,18 +4,16 @@ import {
   DiscussionContextStore,
   Dispatcher,
   RateLimiter,
+  ResumeScheduler,
   appendHistory,
   buildPrompt,
   createBridgeServer,
   createCallbackHandler,
-  evaluateTrigger,
   newDiscussionContext,
   normalizeBaseUrl,
-  parseIsoDuration,
   validateCallbackPayload,
 } from "@forwardimpact/libbridge";
 
-import { ElapsedScheduler } from "./src/elapsed-scheduler.js";
 import {
   ADD_REACTION_MUTATION,
   REMOVE_REACTION_MUTATION,
@@ -49,12 +47,11 @@ function buildReactionAdapter(graphqlClient) {
 }
 
 /**
- * GitHub Discussions bridge service. Receives webhooks from the Kata GitHub
- * App for `discussion` and `discussion_comment` events, drives the libbridge
- * dispatch dance, and posts the lead's structured replies back to the thread
- * via the `addDiscussionComment` GraphQL mutation. Suspend/resume semantics:
- * a `recessed` verdict persists a trigger, then re-dispatches with
- * `resume_context` when the trigger fires.
+ * GitHub Discussions bridge service. Receives webhooks from the Kata
+ * GitHub App for `discussion` and `discussion_comment` events, drives
+ * the libbridge dispatch dance, posts the lead's structured replies back
+ * via the `addDiscussionComment` GraphQL mutation, and tracks the
+ * suspend/resume lifecycle through the shared `ResumeScheduler`.
  */
 export class GhBridgeService {
   #logger;
@@ -68,8 +65,8 @@ export class GhBridgeService {
   #rateLimiter;
   #ack;
   #dispatcher;
+  #resume;
   #bridge;
-  #elapsedScheduler;
   #onCallback;
 
   /**
@@ -122,10 +119,12 @@ export class GhBridgeService {
       githubRepo: config.github_repo,
       getGithubToken: () => this.#getInstallationToken(),
     });
-    this.#elapsedScheduler = new ElapsedScheduler({
-      onFire: (cid) => this.#fireElapsed(cid),
-      onError: (err, cid) =>
-        this.#logger.error("elapsed", err, { correlation_id: cid }),
+    this.#resume = new ResumeScheduler({
+      dispatcher: this.#dispatcher,
+      store: this.#store,
+      logger,
+      buildCallbackMeta: (ctx) => ({ discussionId: ctx.discussion_id }),
+      buildResumeInputs: (ctx) => ({ discussionId: ctx.discussion_id }),
     });
 
     this.#onCallback = createCallbackHandler({
@@ -175,12 +174,12 @@ export class GhBridgeService {
   /** @returns {Promise<void>} */
   async start() {
     await this.#bridge.start();
-    await this.#rearmElapsedTriggers();
+    await this.#resume.rearm();
   }
 
   /** @returns {Promise<void>} */
   async stop() {
-    this.#elapsedScheduler.clear();
+    this.#resume.clear();
     await this.#bridge.stop();
     await this.#store.shutdown();
   }
@@ -287,23 +286,9 @@ export class GhBridgeService {
       appendHistory(ctx.history, { role: "user", text });
       ctx.last_active_at = Date.now();
 
-      const fired = this.#evaluateResponseTriggers(ctx);
-      const hasOpenRfc = Object.keys(ctx.open_rfcs ?? {}).length > 0;
+      const { freshDispatchAllowed } = await this.#resume.processInbound(ctx);
 
-      if (fired.length > 0) {
-        for (const { correlationId, rfc } of fired) {
-          const historySince = ctx.history.slice(rfc.history_index_at_open);
-          await this.#redispatchForResume(ctx, correlationId, historySince);
-          delete ctx.open_rfcs[correlationId];
-          this.#elapsedScheduler.cancel(correlationId);
-        }
-      } else if (hasOpenRfc) {
-        // RFC open, trigger not yet fired — accumulate this response into
-        // history; do not spawn a parallel fresh lead session on the same
-        // thread. Responses accrue toward the trigger; the eventual
-        // re-dispatch carries the full `history_since`.
-        span.setOk();
-      } else {
+      if (freshDispatchAllowed) {
         const limit = this.#rateLimiter.check(discussionId, ctx.dispatches);
         if (!limit.allowed) {
           this.#logger.info("webhook", "rate limited", {
@@ -337,37 +322,6 @@ export class GhBridgeService {
     }
   }
 
-  #evaluateResponseTriggers(ctx) {
-    const fired = [];
-    for (const [correlationId, rfc] of Object.entries(ctx.open_rfcs ?? {})) {
-      const trigger = rfc.trigger;
-      if (!trigger) continue;
-      const observed = {
-        responses: ctx.history.length - rfc.history_index_at_open,
-        opened_at: rfc.opened_at,
-      };
-      const result = evaluateTrigger(trigger, observed, Date.now());
-      if (result.fired) fired.push({ correlationId, rfc });
-    }
-    return fired;
-  }
-
-  async #redispatchForResume(ctx, correlationId, historySince) {
-    const resumeContext = JSON.stringify({
-      correlation_id: correlationId,
-      history_since: historySince,
-    });
-    await this.#dispatcher.dispatch({
-      ctx,
-      prompt: "Resume requested.",
-      callbackMeta: { discussionId: ctx.discussion_id },
-      workflowInputs: {
-        discussionId: ctx.discussion_id,
-        resumeContext,
-      },
-    });
-  }
-
   async #handleReply(ctx, payload, meta) {
     await postDiscussionReplies(this.#graphqlClient, ctx, payload.replies);
     for (const reply of payload.replies) {
@@ -379,15 +333,13 @@ export class GhBridgeService {
 
     switch (payload.verdict) {
       case "recessed":
-        this.#enterRecess(ctx, meta.correlationId, payload.trigger);
+        this.#resume.enterRecess(ctx, meta.correlationId, payload.trigger);
         break;
       case "adjourned":
-        delete ctx.open_rfcs[meta.correlationId];
-        this.#elapsedScheduler.cancel(meta.correlationId);
+        this.#resume.cancelRecess(ctx, meta.correlationId);
         break;
       case "failed":
-        delete ctx.open_rfcs[meta.correlationId];
-        this.#elapsedScheduler.cancel(meta.correlationId);
+        this.#resume.cancelRecess(ctx, meta.correlationId);
         if (payload.summary) {
           await postSingleDiscussionReply(
             this.#graphqlClient,
@@ -398,58 +350,6 @@ export class GhBridgeService {
         break;
       default:
         break;
-    }
-  }
-
-  #enterRecess(ctx, correlationId, trigger) {
-    if (!trigger) return;
-    const openedAt = Date.now();
-    ctx.open_rfcs[correlationId] = {
-      trigger,
-      opened_at: openedAt,
-      history_index_at_open: ctx.history.length,
-    };
-    if (trigger.kind === "elapsed" || trigger.kind === "either") {
-      if (typeof trigger.elapsed === "string") {
-        const dueAt = openedAt + parseIsoDuration(trigger.elapsed);
-        ctx.open_rfcs[correlationId].due_at = dueAt;
-        this.#elapsedScheduler.schedule(correlationId, dueAt);
-      }
-    }
-  }
-
-  async #fireElapsed(correlationId) {
-    const records = await this.#findContextWithRfc(correlationId);
-    if (!records) return;
-    const { ctx, rfc } = records;
-    const historySince = ctx.history.slice(rfc.history_index_at_open);
-    await this.#redispatchForResume(ctx, correlationId, historySince);
-    delete ctx.open_rfcs[correlationId];
-    ctx.last_active_at = Date.now();
-    await this.#store.add(ctx);
-    await this.#store.flush();
-  }
-
-  async #findContextWithRfc(correlationId) {
-    if (!this.#store.loaded) await this.#store.loadData();
-    for (const record of this.#store.index.values()) {
-      if (record?.open_rfcs?.[correlationId]) {
-        return { ctx: record, rfc: record.open_rfcs[correlationId] };
-      }
-    }
-    return null;
-  }
-
-  async #rearmElapsedTriggers() {
-    if (!this.#store.loaded) await this.#store.loadData();
-    for (const record of this.#store.index.values()) {
-      const open = record?.open_rfcs;
-      if (!open) continue;
-      for (const [correlationId, rfc] of Object.entries(open)) {
-        if (typeof rfc.due_at === "number") {
-          this.#elapsedScheduler.schedule(correlationId, rfc.due_at);
-        }
-      }
     }
   }
 

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -1,14 +1,13 @@
-import { randomUUID } from "node:crypto";
-
 import {
   Acknowledgement,
   CallbackRegistry,
   DiscussionContextStore,
+  Dispatcher,
   RateLimiter,
   appendHistory,
   buildPrompt,
   createBridgeServer,
-  dispatchWorkflow,
+  createCallbackHandler,
   evaluateTrigger,
   newDiscussionContext,
   normalizeBaseUrl,
@@ -26,6 +25,9 @@ import {
 
 export { validateCallbackPayload };
 
+const CHANNEL = "github-discussions";
+const WEBHOOK_PATH = "/api/webhook";
+const WORKFLOW_FILE = "kata-dispatch.yml";
 const REACTION_CONTENT = "EYES";
 
 function buildReactionAdapter(graphqlClient) {
@@ -46,23 +48,18 @@ function buildReactionAdapter(graphqlClient) {
   };
 }
 
-const CHANNEL = "github-discussions";
-const WEBHOOK_PATH = "/api/webhook";
-const WORKFLOW_FILE = "kata-dispatch.yml";
-
 /**
  * GitHub Discussions bridge service. Receives webhooks from the Kata GitHub
- * App for `discussion` and `discussion_comment` events, dispatches the
- * channel-agnostic Kata dispatch workflow, and posts the lead's structured
- * replies back to the thread via the `addDiscussionComment` GraphQL
- * mutation. Suspend/resume semantics: a `recessed` verdict persists a
- * trigger, then re-dispatches with `resume_context` when the trigger fires.
+ * App for `discussion` and `discussion_comment` events, drives the libbridge
+ * dispatch dance, and posts the lead's structured replies back to the thread
+ * via the `addDiscussionComment` GraphQL mutation. Suspend/resume semantics:
+ * a `recessed` verdict persists a trigger, then re-dispatches with
+ * `resume_context` when the trigger fires.
  */
 export class GhBridgeService {
   #logger;
   #tracer;
   #config;
-  #callbackBaseUrl;
   #verifyWebhook;
   #getInstallationToken;
   #graphqlClient;
@@ -70,11 +67,15 @@ export class GhBridgeService {
   #callbacks;
   #rateLimiter;
   #ack;
+  #dispatcher;
   #bridge;
   #elapsedScheduler;
+  #onCallback;
 
   /**
-   * @param {import("@forwardimpact/libconfig").ServiceConfig} config
+   * @param {import("@forwardimpact/libbridge").BridgeConfig & {
+   *   app_webhook_secret: string,
+   * }} config
    * @param {object} deps
    * @param {import("@forwardimpact/libtelemetry").Logger} deps.logger
    * @param {import("@forwardimpact/libtelemetry").Tracer} deps.tracer
@@ -82,6 +83,7 @@ export class GhBridgeService {
    * @param {(secret: string, body: string, signature: string) => Promise<boolean>} deps.verifyWebhook
    * @param {() => Promise<string>} deps.getInstallationToken
    * @param {(query: string, vars: object) => Promise<unknown>} deps.graphqlClient
+   * @param {Acknowledgement} [deps.acknowledgement] - Override (tests)
    */
   constructor(config, deps) {
     const { logger, tracer, storage, verifyWebhook, getInstallationToken } =
@@ -98,7 +100,6 @@ export class GhBridgeService {
     this.#config = config;
     this.#logger = logger;
     this.#tracer = tracer;
-    this.#callbackBaseUrl = normalizeBaseUrl(config.callback_base_url);
     this.#verifyWebhook = verifyWebhook;
     this.#getInstallationToken = getInstallationToken;
     this.#graphqlClient = deps.graphqlClient;
@@ -112,10 +113,33 @@ export class GhBridgeService {
         reactionAdapter: buildReactionAdapter(this.#graphqlClient),
         logger,
       });
+    this.#dispatcher = new Dispatcher({
+      callbacks: this.#callbacks,
+      ack: this.#ack,
+      store: this.#store,
+      callbackBaseUrl: normalizeBaseUrl(config.callback_base_url),
+      workflowFile: WORKFLOW_FILE,
+      githubRepo: config.github_repo,
+      getGithubToken: () => this.#getInstallationToken(),
+    });
     this.#elapsedScheduler = new ElapsedScheduler({
       onFire: (cid) => this.#fireElapsed(cid),
       onError: (err, cid) =>
         this.#logger.error("elapsed", err, { correlation_id: cid }),
+    });
+
+    this.#onCallback = createCallbackHandler({
+      channel: CHANNEL,
+      callbacks: this.#callbacks,
+      ack: this.#ack,
+      store: this.#store,
+      logger,
+      tracer,
+      spanName: "GhBridge.HandleCallback",
+      loadDiscussionId: (meta) => meta.meta?.discussionId,
+      ackFinishTarget: (meta) => ({ subjectId: meta.meta?.discussionId }),
+      handleReply: (ctx, payload, meta) =>
+        this.#handleReply(ctx, payload, meta),
     });
 
     this.#bridge = createBridgeServer({
@@ -124,7 +148,7 @@ export class GhBridgeService {
       tracer,
       webhookPath: WEBHOOK_PATH,
       onWebhook: (c) => this.#handleWebhook(c),
-      onCallback: (c) => this.#handleCallback(c),
+      onCallback: (c) => this.#onCallback(c),
     });
   }
 
@@ -221,43 +245,22 @@ export class GhBridgeService {
         return c.body(null, 200);
       }
 
-      const prompt = buildPrompt(text, ctx.history);
-      const correlationId = randomUUID();
-      const token = this.#callbacks.register(correlationId, { discussionId });
-      ctx.pending_callbacks[token] = correlationId;
-      const callbackUrl = `${this.#callbackBaseUrl}/api/callback/${token}`;
-      const ackTarget = { subjectId: discussion?.node_id };
-
-      await this.#ack.start(token, ackTarget);
       try {
-        const ghToken = await this.#getInstallationToken();
-        await dispatchWorkflow({
-          workflowFile: WORKFLOW_FILE,
-          repo: this.#config.github_repo,
-          token: ghToken,
-          prompt,
-          callbackUrl,
-          correlationId,
-          discussionId,
+        const { correlationId } = await this.#dispatcher.dispatch({
+          ctx,
+          prompt: buildPrompt(text, ctx.history),
+          ackTarget: { subjectId: discussionId },
+          historyText: text,
+          callbackMeta: { discussionId },
+          workflowInputs: { discussionId },
         });
-        appendHistory(ctx.history, { role: "user", text });
-        ctx.dispatches.push(Date.now());
-        ctx.last_active_at = Date.now();
-        await this.#store.add(ctx);
-        await this.#store.flush();
         span.addEvent("workflow_dispatched", {
           correlation_id: correlationId,
         });
         span.setOk();
         return c.body(null, 200);
       } catch (err) {
-        await this.#ack.finish(token, ackTarget);
-        this.#callbacks.consume(token);
-        delete ctx.pending_callbacks[token];
-        this.#logger.error("webhook", err, {
-          discussion_id: discussionId,
-          correlation_id: correlationId,
-        });
+        this.#logger.error("webhook", err, { discussion_id: discussionId });
         span.setError(err);
         return c.json({ error: "Dispatch failed" }, 502);
       }
@@ -297,8 +300,8 @@ export class GhBridgeService {
       } else if (hasOpenRfc) {
         // RFC open, trigger not yet fired — accumulate this response into
         // history; do not spawn a parallel fresh lead session on the same
-        // thread. Per plan-a-05 Step 5.4, responses accrue toward the
-        // trigger; the eventual re-dispatch carries the full `history_since`.
+        // thread. Responses accrue toward the trigger; the eventual
+        // re-dispatch carries the full `history_since`.
         span.setOk();
       } else {
         const limit = this.#rateLimiter.check(discussionId, ctx.dispatches);
@@ -312,7 +315,13 @@ export class GhBridgeService {
           span.setOk();
           return c.body(null, 200);
         }
-        await this.#dispatchFreshFromComment(ctx, text, comment);
+        await this.#dispatcher.dispatch({
+          ctx,
+          prompt: buildPrompt(text, ctx.history),
+          ackTarget: { subjectId: comment?.node_id },
+          callbackMeta: { discussionId: ctx.discussion_id },
+          workflowInputs: { discussionId: ctx.discussion_id },
+        });
       }
 
       await this.#store.add(ctx);
@@ -343,149 +352,52 @@ export class GhBridgeService {
     return fired;
   }
 
-  async #dispatchFreshFromComment(ctx, text, comment) {
-    const prompt = buildPrompt(text, ctx.history);
-    const correlationId = randomUUID();
-    const token = this.#callbacks.register(correlationId, {
-      discussionId: ctx.discussion_id,
-    });
-    ctx.pending_callbacks[token] = correlationId;
-    const callbackUrl = `${this.#callbackBaseUrl}/api/callback/${token}`;
-    const ackTarget = { subjectId: comment?.node_id };
-
-    await this.#ack.start(token, ackTarget);
-    try {
-      const ghToken = await this.#getInstallationToken();
-      await dispatchWorkflow({
-        workflowFile: WORKFLOW_FILE,
-        repo: this.#config.github_repo,
-        token: ghToken,
-        prompt,
-        callbackUrl,
-        correlationId,
-        discussionId: ctx.discussion_id,
-      });
-      ctx.dispatches.push(Date.now());
-    } catch (err) {
-      await this.#ack.finish(token, ackTarget);
-      this.#callbacks.consume(token);
-      delete ctx.pending_callbacks[token];
-      throw err;
-    }
-  }
-
   async #redispatchForResume(ctx, correlationId, historySince) {
-    const newCorrelationId = randomUUID();
-    const token = this.#callbacks.register(newCorrelationId, {
-      discussionId: ctx.discussion_id,
-    });
-    ctx.pending_callbacks[token] = newCorrelationId;
-    const callbackUrl = `${this.#callbackBaseUrl}/api/callback/${token}`;
-
     const resumeContext = JSON.stringify({
       correlation_id: correlationId,
       history_since: historySince,
     });
-    try {
-      const ghToken = await this.#getInstallationToken();
-      await dispatchWorkflow({
-        workflowFile: WORKFLOW_FILE,
-        repo: this.#config.github_repo,
-        token: ghToken,
-        prompt: "Resume requested.",
-        callbackUrl,
-        correlationId: newCorrelationId,
+    await this.#dispatcher.dispatch({
+      ctx,
+      prompt: "Resume requested.",
+      callbackMeta: { discussionId: ctx.discussion_id },
+      workflowInputs: {
         discussionId: ctx.discussion_id,
         resumeContext,
-      });
-    } catch (err) {
-      this.#callbacks.consume(token);
-      delete ctx.pending_callbacks[token];
-      throw err;
-    }
-    ctx.dispatches.push(Date.now());
+      },
+    });
   }
 
-  async #handleCallback(c) {
-    const token = c.req.param("token");
-    const meta = this.#callbacks.consume(token);
-    if (!meta) {
-      this.#logger.debug("callback", "unknown token");
-      return c.json({ error: "Unknown callback token" }, 404);
-    }
-    await this.#ack.finish(token, { subjectId: meta.meta?.discussionId });
-
-    let body;
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON" }, 400);
-    }
-    const payload = validateCallbackPayload(body);
-    if (!payload) return c.json({ error: "Invalid payload" }, 400);
-    if (payload.correlation_id !== meta.correlationId) {
-      return c.json({ error: "Correlation ID mismatch" }, 400);
-    }
-
-    const discussionId = meta.meta?.discussionId;
-    const ctx = await this.#store.loadByChannel(CHANNEL, discussionId);
-    if (!ctx) {
-      this.#logger.error("callback", "context missing", { discussionId });
-      return c.json({ error: "Discussion context missing" }, 410);
-    }
-    delete ctx.pending_callbacks[token];
-
-    const span = this.#tracer.startSpan("GhBridge.HandleCallback", {
-      kind: "SERVER",
-      attributes: { correlation_id: meta.correlationId },
-    });
-    try {
-      await this.#getInstallationToken();
-      await postDiscussionReplies(this.#graphqlClient, ctx, payload.replies);
-      for (const reply of payload.replies) {
-        appendHistory(ctx.history, {
-          role: "assistant",
-          text: reply.body ?? "",
-        });
-      }
-
-      switch (payload.verdict) {
-        case "recessed":
-          this.#enterRecess(ctx, meta.correlationId, payload.trigger);
-          break;
-        case "adjourned":
-          delete ctx.open_rfcs[meta.correlationId];
-          this.#elapsedScheduler.cancel(meta.correlationId);
-          break;
-        case "failed":
-          delete ctx.open_rfcs[meta.correlationId];
-          this.#elapsedScheduler.cancel(meta.correlationId);
-          if (payload.summary) {
-            await postSingleDiscussionReply(
-              this.#graphqlClient,
-              ctx,
-              payload.summary,
-            );
-          }
-          break;
-        default:
-          break;
-      }
-
-      ctx.last_active_at = Date.now();
-      await this.#store.add(ctx);
-      await this.#store.flush();
-      span.addEvent("reply_delivered", { verdict: payload.verdict });
-      span.setOk();
-      return c.json({ ok: true }, 200);
-    } catch (err) {
-      this.#logger.error("callback", err, {
-        correlation_id: meta.correlationId,
+  async #handleReply(ctx, payload, meta) {
+    await postDiscussionReplies(this.#graphqlClient, ctx, payload.replies);
+    for (const reply of payload.replies) {
+      appendHistory(ctx.history, {
+        role: "assistant",
+        text: reply.body ?? "",
       });
-      span.setError(err);
-      return c.json({ error: "Failed to deliver reply" }, 500);
-    } finally {
-      await span.end();
+    }
+
+    switch (payload.verdict) {
+      case "recessed":
+        this.#enterRecess(ctx, meta.correlationId, payload.trigger);
+        break;
+      case "adjourned":
+        delete ctx.open_rfcs[meta.correlationId];
+        this.#elapsedScheduler.cancel(meta.correlationId);
+        break;
+      case "failed":
+        delete ctx.open_rfcs[meta.correlationId];
+        this.#elapsedScheduler.cancel(meta.correlationId);
+        if (payload.summary) {
+          await postSingleDiscussionReply(
+            this.#graphqlClient,
+            ctx,
+            payload.summary,
+          );
+        }
+        break;
+      default:
+        break;
     }
   }
 

--- a/services/ghbridge/src/graphql.js
+++ b/services/ghbridge/src/graphql.js
@@ -19,6 +19,13 @@ export const ADD_REACTION_MUTATION = `
     }
   }`;
 
+export const REMOVE_REACTION_MUTATION = `
+  mutation RemoveReaction($i: RemoveReactionInput!) {
+    removeReaction(input: $i) {
+      reaction { content }
+    }
+  }`;
+
 /**
  * Post each reply in `replies` as a separate `addDiscussionComment`
  * GraphQL mutation. Skips entries lacking a body.

--- a/services/ghbridge/test/callback.test.js
+++ b/services/ghbridge/test/callback.test.js
@@ -10,6 +10,7 @@ import { GhBridgeService } from "../index.js";
 import {
   ADD_DISCUSSION_COMMENT_MUTATION,
   ADD_REACTION_MUTATION,
+  REMOVE_REACTION_MUTATION,
 } from "../src/graphql.js";
 
 function makeTracer() {
@@ -200,9 +201,31 @@ describe("ghbridge callback handler", () => {
     );
   });
 
-  test("graphql contains exactly two mutations (the source of truth)", () => {
+  test("graphql contains the three mutations (the source of truth)", () => {
     expect(ADD_DISCUSSION_COMMENT_MUTATION).toContain("addDiscussionComment");
     expect(ADD_REACTION_MUTATION).toContain("addReaction");
+    expect(REMOVE_REACTION_MUTATION).toContain("removeReaction");
+  });
+
+  test("callback fires removeReaction(EYES) on the discussion", async () => {
+    const token = await dispatchFresh(ctx.service, baseUrl);
+    const meta = ctx.service.callbacks.peek(token);
+    const before = ctx.graphqlCalls.filter((c) =>
+      c.query.includes("removeReaction"),
+    ).length;
+    expect(before).toBe(0);
+    await postCallback(baseUrl, token, {
+      correlation_id: meta.correlationId,
+      verdict: "adjourned",
+      summary: "done",
+      replies: [],
+    });
+    const removeCalls = ctx.graphqlCalls.filter((c) =>
+      c.query.includes("removeReaction"),
+    );
+    expect(removeCalls).toHaveLength(1);
+    expect(removeCalls[0].variables.i.content).toBe("EYES");
+    expect(removeCalls[0].variables.i.subjectId).toBe("D_kw1");
   });
 
   test("addDiscussionComment is not composed inside any workflow YAML", async () => {

--- a/services/ghbridge/test/webhook.test.js
+++ b/services/ghbridge/test/webhook.test.js
@@ -166,47 +166,18 @@ describe("ghbridge webhook intake", () => {
     expect(Object.keys(ctx.pending_callbacks)).toHaveLength(1);
   });
 
-  test("addReaction (EYES) GraphQL mutation fires as progress indicator", async () => {
-    // Replace the global service with one that uses a capturing ticker so
-    // we can invoke the tick callback synchronously.
-    await service.stop();
-    harness.restore();
-
-    let capturedTick = null;
-    const captureTicker = {
-      start: (_token, tick) => {
-        capturedTick = tick;
-      },
-      stop: () => {},
-    };
-    const localHarness = buildHarness();
-    const graphqlCalls = [];
-    service = new (await import("../index.js")).GhBridgeService(makeConfig(), {
-      logger: createMockLogger(),
-      tracer: makeTracer(),
-      storage: createMockStorage(),
-      verifyWebhook: (s, b, sig) =>
-        import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),
-      getInstallationToken: async () => "ghs_test",
-      graphqlClient: async (q, v) => {
-        graphqlCalls.push({ query: q, variables: v });
-        return {};
-      },
-      progressTicker: captureTicker,
-    });
-    await service.start();
-    harness = localHarness;
-    baseUrl = `http://127.0.0.1:${service.address().port}`;
-
+  test("addReaction (EYES) fires once when the discussion is dispatched", async () => {
     await postSigned(baseUrl, "discussion", discussionEvent());
-    expect(capturedTick).not.toBeNull();
-    await capturedTick();
-    const reactionCalls = graphqlCalls.filter((c) =>
+    const reactionCalls = harness.graphqlCalls.filter((c) =>
       c.query.includes("addReaction"),
     );
     expect(reactionCalls).toHaveLength(1);
     expect(reactionCalls[0].variables.i.content).toBe("EYES");
     expect(reactionCalls[0].variables.i.subjectId).toBe("D_kw1");
+    const removeCalls = harness.graphqlCalls.filter((c) =>
+      c.query.includes("removeReaction"),
+    );
+    expect(removeCalls).toHaveLength(0);
   });
 
   test("ignores unsupported events with 204", async () => {

--- a/services/msbridge/index.js
+++ b/services/msbridge/index.js
@@ -1,100 +1,39 @@
 import { randomUUID } from "node:crypto";
 
-import botbuilder from "botbuilder";
-
 import {
+  Acknowledgement,
   CallbackRegistry,
   DiscussionContextStore,
-  ProgressTicker,
   RateLimiter,
   appendHistory,
   buildPrompt,
   createBridgeServer,
   dispatchWorkflow,
+  newDiscussionContext,
+  normalizeBaseUrl,
+  validateCallbackPayload,
 } from "@forwardimpact/libbridge";
 
-const { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext } =
-  botbuilder;
+import {
+  TurnContext,
+  buildReactionAdapter,
+  buildTickerAdapter,
+  createDefaultAdapter,
+  sendReply,
+} from "./src/teams.js";
 
 const CHANNEL = "msteams";
 const WEBHOOK_PATH = "/api/messages";
 const WORKFLOW_FILE = "kata-dispatch.yml";
-const MAX_FIELD_LENGTH = 2000;
-const TYPING_VERBS = [
-  "Moonwalking",
-  "Unravelling",
-  "Tempering",
-  "Crafting",
-  "Simmering",
-  "Percolating",
-  "Decoding",
-];
 
-export { buildPrompt, appendHistory } from "@forwardimpact/libbridge";
-
-/**
- * @param {string} url
- * @returns {boolean}
- */
-export function isValidRunUrl(url) {
-  if (typeof url !== "string") return false;
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "https:" && parsed.hostname === "github.com";
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Format the verdict and summary as a Teams reply.
- *
- * @param {{verdict: string, summary: string, run_url?: string}} payload
- * @returns {string}
- */
-export function formatReply(payload) {
-  return payload.summary ?? "";
-}
-
-/**
- * Validate and sanitize the callback payload. Returns a clean object or null.
- * Accepts (and silently ignores) the channel-agnostic optional fields
- * `replies`, `trigger`, `discussion_id` that the kata-dispatch callback
- * sometimes carries — Teams does not render those surfaces.
- *
- * @param {unknown} body
- * @returns {{correlation_id: string, verdict: string, summary: string, run_url?: string} | null}
- */
-export function validateCallbackPayload(body) {
-  if (!body || typeof body !== "object") return null;
-
-  const cid = body.correlation_id;
-  if (typeof cid !== "string" || !cid) return null;
-  if (typeof body.verdict !== "string" || !body.verdict) return null;
-  if (typeof body.summary !== "string") return null;
-  if (typeof body.run_url !== "string" || !isValidRunUrl(body.run_url)) {
-    return null;
-  }
-
-  return {
-    correlation_id: cid,
-    verdict: body.verdict.slice(0, MAX_FIELD_LENGTH),
-    summary: body.summary.slice(0, MAX_FIELD_LENGTH),
-    run_url: body.run_url,
-  };
-}
-
-function normalizeBaseUrl(url) {
-  return (url ?? "").replace(/\/+$/, "");
-}
+export { appendHistory, buildPrompt, validateCallbackPayload };
 
 /**
  * Microsoft Teams bridge service. Receives messages from Teams via the Bot
  * Framework, dispatches the channel-agnostic Kata dispatch workflow on
  * GitHub, and delivers the callback reply back into the Teams
- * conversation. Refactored onto `@forwardimpact/libbridge` so msbridge and
- * ghbridge share the same intake skeleton, callback registry, rate
- * limiter, history bound, and durable thread state.
+ * conversation. Mirrors the shape of `services/ghbridge`: shared libbridge
+ * primitives plus a small `src/teams.js` for botbuilder-bound rendering.
  */
 export class MsBridgeService {
   #logger;
@@ -105,7 +44,7 @@ export class MsBridgeService {
   #store;
   #callbacks;
   #rateLimiter;
-  #progressTicker;
+  #ack;
   #bridge;
 
   /**
@@ -114,9 +53,10 @@ export class MsBridgeService {
    * @param {import("@forwardimpact/libtelemetry").Logger} deps.logger
    * @param {import("@forwardimpact/libtelemetry").Tracer} deps.tracer
    * @param {import("@forwardimpact/libstorage").StorageInterface} deps.storage
-   * @param {object} [deps.adapter] - Override for tests
+   * @param {object} [deps.adapter] - Bot Framework adapter override (tests)
+   * @param {Acknowledgement} [deps.acknowledgement] - Override (tests)
    */
-  constructor(config, { logger, tracer, storage, adapter }) {
+  constructor(config, { logger, tracer, storage, adapter, acknowledgement }) {
     if (!logger) throw new Error("logger is required");
     if (!tracer) throw new Error("tracer is required");
     if (!storage) throw new Error("storage is required");
@@ -126,7 +66,7 @@ export class MsBridgeService {
     this.#tracer = tracer;
     this.#callbackBaseUrl = normalizeBaseUrl(config.callback_base_url);
 
-    this.#adapter = adapter ?? this.#defaultAdapter(config);
+    this.#adapter = adapter ?? createDefaultAdapter(config);
     this.#adapter.onTurnError = async (context, error) => {
       this.#logger.error("onTurnError", error);
       try {
@@ -142,26 +82,26 @@ export class MsBridgeService {
     this.#store = new DiscussionContextStore(storage);
     this.#callbacks = new CallbackRegistry();
     this.#rateLimiter = new RateLimiter();
-    this.#progressTicker = new ProgressTicker();
+    this.#ack =
+      acknowledgement ??
+      new Acknowledgement({
+        reactionAdapter: buildReactionAdapter(this.#adapter, () =>
+          this.#config.msAppId(),
+        ),
+        tickerAdapter: buildTickerAdapter(this.#adapter, () =>
+          this.#config.msAppId(),
+        ),
+        logger,
+      });
 
     this.#bridge = createBridgeServer({
       config,
       logger,
       tracer,
       webhookPath: WEBHOOK_PATH,
-      onWebhook: (c) => this.#handleMessages(c),
+      onWebhook: (c) => this.#handleWebhook(c),
       onCallback: (c) => this.#handleCallback(c),
     });
-  }
-
-  #defaultAdapter(config) {
-    const auth = new ConfigurationBotFrameworkAuthentication({
-      MicrosoftAppId: config.msAppId(),
-      MicrosoftAppPassword: config.msAppPassword(),
-      MicrosoftAppTenantId: config.msAppTenantId(),
-      MicrosoftAppType: "SingleTenant",
-    });
-    return new CloudAdapter(auth);
   }
 
   /** @returns {import("@forwardimpact/libbridge").DiscussionContextStore} */
@@ -195,7 +135,7 @@ export class MsBridgeService {
     await this.#store.shutdown();
   }
 
-  async #handleMessages(c) {
+  async #handleWebhook(c) {
     const req = c.req.raw;
     const rawBody = c.get("rawBody");
     const expressLikeReq = {
@@ -234,7 +174,7 @@ export class MsBridgeService {
     };
     try {
       await this.#adapter.process(expressLikeReq, resLike, (context) =>
-        this.#handleMessage(context),
+        this.#handleNewMessage(context),
       );
       return new Response(resLike._body ?? null, {
         status: resLike._status,
@@ -246,7 +186,7 @@ export class MsBridgeService {
     }
   }
 
-  async #handleMessage(context) {
+  async #handleNewMessage(context) {
     const activity = context.activity;
     if (activity.type !== "message") return;
 
@@ -254,7 +194,7 @@ export class MsBridgeService {
     const text = (activity.text ?? "").trim();
     if (!threadId || !text) return;
 
-    const span = this.#tracer.startSpan("MsBridge.HandleMessage", {
+    const span = this.#tracer.startSpan("MsBridge.HandleNewMessage", {
       kind: "SERVER",
       attributes: { thread_id: threadId },
     });
@@ -285,11 +225,9 @@ export class MsBridgeService {
       });
       ctx.pending_callbacks[callbackToken] = correlationId;
       const callbackUrl = `${this.#callbackBaseUrl}/api/callback/${callbackToken}`;
+      const ackTarget = { ref, activityId: activity.id };
 
-      const verb =
-        TYPING_VERBS[Math.floor(Math.random() * TYPING_VERBS.length)];
-      await context.sendActivity(`${verb}...`);
-
+      await this.#ack.start(callbackToken, ackTarget);
       try {
         await dispatchWorkflow({
           workflowFile: WORKFLOW_FILE,
@@ -303,15 +241,15 @@ export class MsBridgeService {
         ctx.dispatches.push(Date.now());
         await this.#store.add(ctx);
         await this.#store.flush();
-        this.#startTypingTicker(callbackToken, ref);
         span.addEvent("workflow_dispatched", {
           correlation_id: correlationId,
         });
         span.setOk();
       } catch (err) {
+        await this.#ack.finish(callbackToken, ackTarget);
         this.#callbacks.consume(callbackToken);
         delete ctx.pending_callbacks[callbackToken];
-        this.#logger.error("handleMessage", err, {
+        this.#logger.error("handleNewMessage", err, {
           thread_id: threadId,
           correlation_id: correlationId,
         });
@@ -331,7 +269,7 @@ export class MsBridgeService {
     if (!meta) {
       return c.json({ error: "Unknown callback token" }, 404);
     }
-    this.#progressTicker.stop(token);
+    await this.#ack.finish(token);
 
     let body;
     try {
@@ -358,15 +296,9 @@ export class MsBridgeService {
     });
     try {
       const ref = ctx.participants[0].metadata;
-      const replyText = formatReply(payload);
-      await this.#adapter.continueConversationAsync(
-        this.#config.msAppId(),
-        ref,
-        async (turnContext) => {
-          await turnContext.sendActivity(replyText);
-        },
-      );
-      appendHistory(ctx.history, { role: "assistant", text: payload.summary });
+      await this.#postReplies(ref, payload.replies, ctx);
+      await this.#applyVerdict(ref, payload, threadId, meta.correlationId);
+
       ctx.last_active_at = Date.now();
       await this.#store.add(ctx);
       await this.#store.flush();
@@ -385,41 +317,49 @@ export class MsBridgeService {
     }
   }
 
+  async #postReplies(ref, replies, ctx) {
+    const list = Array.isArray(replies) ? replies : [];
+    const msAppIdFn = () => this.#config.msAppId();
+    for (const reply of list) {
+      if (!reply || typeof reply.body !== "string" || !reply.body) continue;
+      await sendReply(this.#adapter, msAppIdFn, ref, reply.body);
+    }
+    for (const reply of list) {
+      if (!reply || typeof reply.body !== "string") continue;
+      appendHistory(ctx.history, { role: "assistant", text: reply.body });
+    }
+  }
+
+  async #applyVerdict(ref, payload, threadId, correlationId) {
+    if (payload.verdict === "recessed") {
+      this.#logger.info("callback", "resume not yet supported on msteams", {
+        thread_id: threadId,
+        correlation_id: correlationId,
+      });
+      return;
+    }
+    if (payload.verdict === "failed" && payload.summary) {
+      await sendReply(
+        this.#adapter,
+        () => this.#config.msAppId(),
+        ref,
+        payload.summary,
+      );
+    }
+  }
+
   async #loadOrCreateContext(threadId, ref) {
     const existing = await this.#store.loadByChannel(CHANNEL, threadId);
     if (existing) return existing;
-    return {
-      id: DiscussionContextStore.keyOf(CHANNEL, threadId),
+    return newDiscussionContext({
       channel: CHANNEL,
-      discussion_id: threadId,
-      history: [],
-      participants: [
-        {
-          name: "teams-user",
-          kind: "human",
-          external_id: ref?.user?.id,
-          metadata: ref,
-        },
-      ],
-      open_rfcs: {},
-      lead: "release-engineer",
-      pending_callbacks: {},
-      dispatches: [],
-      last_active_at: Date.now(),
-    };
-  }
-
-  #startTypingTicker(callbackToken, ref) {
-    this.#progressTicker.start(callbackToken, async () => {
-      const verb =
-        TYPING_VERBS[Math.floor(Math.random() * TYPING_VERBS.length)];
-      await this.#adapter.continueConversationAsync(
-        this.#config.msAppId(),
-        ref,
-        async (context) => {
-          await context.sendActivity(`${verb}...`);
-        },
-      );
+      discussionId: threadId,
+      participant: {
+        name: "teams-user",
+        kind: "human",
+        external_id: ref?.user?.id,
+        metadata: ref,
+      },
     });
   }
 }

--- a/services/msbridge/index.js
+++ b/services/msbridge/index.js
@@ -17,7 +17,7 @@ import {
 import {
   TurnContext,
   buildReactionAdapter,
-  buildTickerAdapter,
+  buildTypingAdapter,
   createDefaultAdapter,
   sendReply,
 } from "./src/teams.js";
@@ -82,15 +82,12 @@ export class MsBridgeService {
     this.#store = new DiscussionContextStore(storage);
     this.#callbacks = new CallbackRegistry();
     this.#rateLimiter = new RateLimiter();
+    const msAppIdFn = () => this.#config.msAppId();
     this.#ack =
       acknowledgement ??
       new Acknowledgement({
-        reactionAdapter: buildReactionAdapter(this.#adapter, () =>
-          this.#config.msAppId(),
-        ),
-        tickerAdapter: buildTickerAdapter(this.#adapter, () =>
-          this.#config.msAppId(),
-        ),
+        reactionAdapter: buildReactionAdapter(this.#adapter, msAppIdFn),
+        typingAdapter: buildTypingAdapter(this.#adapter, msAppIdFn),
         logger,
       });
 

--- a/services/msbridge/index.js
+++ b/services/msbridge/index.js
@@ -1,14 +1,14 @@
-import { randomUUID } from "node:crypto";
-
 import {
   Acknowledgement,
+  CallbackHandlerError,
   CallbackRegistry,
   DiscussionContextStore,
+  Dispatcher,
   RateLimiter,
   appendHistory,
   buildPrompt,
   createBridgeServer,
-  dispatchWorkflow,
+  createCallbackHandler,
   newDiscussionContext,
   normalizeBaseUrl,
   validateCallbackPayload,
@@ -16,6 +16,7 @@ import {
 
 import {
   TurnContext,
+  botFrameworkIntake,
   buildReactionAdapter,
   buildTypingAdapter,
   createDefaultAdapter,
@@ -29,26 +30,33 @@ const WORKFLOW_FILE = "kata-dispatch.yml";
 export { appendHistory, buildPrompt, validateCallbackPayload };
 
 /**
- * Microsoft Teams bridge service. Receives messages from Teams via the Bot
- * Framework, dispatches the channel-agnostic Kata dispatch workflow on
- * GitHub, and delivers the callback reply back into the Teams
- * conversation. Mirrors the shape of `services/ghbridge`: shared libbridge
- * primitives plus a small `src/teams.js` for botbuilder-bound rendering.
+ * Microsoft Teams bridge service. Receives messages from Teams via the
+ * Bot Framework, drives the libbridge dispatch dance, and delivers the
+ * callback reply back into the Teams conversation. Mirrors `ghbridge`:
+ * shared libbridge primitives (Dispatcher, callback handler,
+ * Acknowledgement) plus a small `src/teams.js` for botbuilder-bound
+ * rendering.
  */
 export class MsBridgeService {
   #logger;
   #tracer;
-  #config;
-  #callbackBaseUrl;
+  #msAppId;
   #adapter;
   #store;
   #callbacks;
   #rateLimiter;
   #ack;
+  #dispatcher;
   #bridge;
+  #onCallback;
 
   /**
-   * @param {import("@forwardimpact/libconfig").ServiceConfig} config
+   * @param {import("@forwardimpact/libbridge").BridgeConfig & {
+   *   msAppId: () => string,
+   *   msAppPassword: () => string,
+   *   msAppTenantId: () => string,
+   *   ghToken: () => string,
+   * }} config
    * @param {object} deps
    * @param {import("@forwardimpact/libtelemetry").Logger} deps.logger
    * @param {import("@forwardimpact/libtelemetry").Tracer} deps.tracer
@@ -61,10 +69,9 @@ export class MsBridgeService {
     if (!tracer) throw new Error("tracer is required");
     if (!storage) throw new Error("storage is required");
     this.config = config;
-    this.#config = config;
     this.#logger = logger;
     this.#tracer = tracer;
-    this.#callbackBaseUrl = normalizeBaseUrl(config.callback_base_url);
+    this.#msAppId = () => config.msAppId();
 
     this.#adapter = adapter ?? createDefaultAdapter(config);
     this.#adapter.onTurnError = async (context, error) => {
@@ -82,22 +89,47 @@ export class MsBridgeService {
     this.#store = new DiscussionContextStore(storage);
     this.#callbacks = new CallbackRegistry();
     this.#rateLimiter = new RateLimiter();
-    const msAppIdFn = () => this.#config.msAppId();
     this.#ack =
       acknowledgement ??
       new Acknowledgement({
-        reactionAdapter: buildReactionAdapter(this.#adapter, msAppIdFn),
-        typingAdapter: buildTypingAdapter(this.#adapter, msAppIdFn),
+        reactionAdapter: buildReactionAdapter(this.#adapter, this.#msAppId),
+        typingAdapter: buildTypingAdapter(this.#adapter, this.#msAppId),
         logger,
       });
+    this.#dispatcher = new Dispatcher({
+      callbacks: this.#callbacks,
+      ack: this.#ack,
+      store: this.#store,
+      callbackBaseUrl: normalizeBaseUrl(config.callback_base_url),
+      workflowFile: WORKFLOW_FILE,
+      githubRepo: config.github_repo,
+      getGithubToken: () => config.ghToken(),
+    });
+
+    this.#onCallback = createCallbackHandler({
+      channel: CHANNEL,
+      callbacks: this.#callbacks,
+      ack: this.#ack,
+      store: this.#store,
+      logger,
+      tracer,
+      spanName: "MsBridge.HandleCallback",
+      loadDiscussionId: (meta) => meta.meta?.threadId,
+      handleReply: (ctx, payload, meta) =>
+        this.#handleReply(ctx, payload, meta),
+    });
 
     this.#bridge = createBridgeServer({
       config,
       logger,
       tracer,
       webhookPath: WEBHOOK_PATH,
-      onWebhook: (c) => this.#handleWebhook(c),
-      onCallback: (c) => this.#handleCallback(c),
+      onWebhook: botFrameworkIntake(
+        this.#adapter,
+        (turnContext) => this.#handleNewMessage(turnContext),
+        logger,
+      ),
+      onCallback: (c) => this.#onCallback(c),
     });
   }
 
@@ -132,57 +164,6 @@ export class MsBridgeService {
     await this.#store.shutdown();
   }
 
-  async #handleWebhook(c) {
-    const req = c.req.raw;
-    const rawBody = c.get("rawBody");
-    const expressLikeReq = {
-      headers: Object.fromEntries(req.headers.entries()),
-      body: rawBody ? JSON.parse(rawBody.toString("utf8")) : {},
-      method: req.method,
-    };
-    const resLike = {
-      headersSent: false,
-      _status: 200,
-      _body: undefined,
-      _headers: {},
-      status(code) {
-        this._status = code;
-        return this;
-      },
-      json(body) {
-        this._body = JSON.stringify(body);
-        this._headers["content-type"] = "application/json";
-        this.headersSent = true;
-        return this;
-      },
-      send(body) {
-        this._body = body;
-        this.headersSent = true;
-        return this;
-      },
-      end(body) {
-        if (body !== undefined) this._body = body;
-        this.headersSent = true;
-        return this;
-      },
-      header(k, v) {
-        this._headers[k.toLowerCase()] = v;
-      },
-    };
-    try {
-      await this.#adapter.process(expressLikeReq, resLike, (context) =>
-        this.#handleNewMessage(context),
-      );
-      return new Response(resLike._body ?? null, {
-        status: resLike._status,
-        headers: resLike._headers,
-      });
-    } catch (err) {
-      this.#logger.error("messages", err);
-      return c.json({ error: "Invalid activity" }, 400);
-    }
-  }
-
   async #handleNewMessage(context) {
     const activity = context.activity;
     if (activity.type !== "message") return;
@@ -197,10 +178,9 @@ export class MsBridgeService {
     });
 
     try {
-      const now = Date.now();
       const ref = TurnContext.getConversationReference(activity);
       const ctx = await this.#loadOrCreateContext(threadId, ref);
-      ctx.last_active_at = now;
+      ctx.last_active_at = Date.now();
       ctx.participants[0].metadata = ref;
 
       const limit = this.#rateLimiter.check(threadId, ctx.dispatches);
@@ -215,41 +195,20 @@ export class MsBridgeService {
         return;
       }
 
-      const prompt = buildPrompt(text, ctx.history);
-      const correlationId = randomUUID();
-      const callbackToken = this.#callbacks.register(correlationId, {
-        threadId,
-      });
-      ctx.pending_callbacks[callbackToken] = correlationId;
-      const callbackUrl = `${this.#callbackBaseUrl}/api/callback/${callbackToken}`;
-      const ackTarget = { ref, activityId: activity.id };
-
-      await this.#ack.start(callbackToken, ackTarget);
       try {
-        await dispatchWorkflow({
-          workflowFile: WORKFLOW_FILE,
-          repo: this.#config.github_repo,
-          token: this.#config.ghToken(),
-          prompt,
-          callbackUrl,
-          correlationId,
+        const { correlationId } = await this.#dispatcher.dispatch({
+          ctx,
+          prompt: buildPrompt(text, ctx.history),
+          ackTarget: { ref, activityId: activity.id },
+          historyText: text,
+          callbackMeta: { threadId },
         });
-        appendHistory(ctx.history, { role: "user", text });
-        ctx.dispatches.push(Date.now());
-        await this.#store.add(ctx);
-        await this.#store.flush();
         span.addEvent("workflow_dispatched", {
           correlation_id: correlationId,
         });
         span.setOk();
       } catch (err) {
-        await this.#ack.finish(callbackToken, ackTarget);
-        this.#callbacks.consume(callbackToken);
-        delete ctx.pending_callbacks[callbackToken];
-        this.#logger.error("handleNewMessage", err, {
-          thread_id: threadId,
-          correlation_id: correlationId,
-        });
+        this.#logger.error("handleNewMessage", err, { thread_id: threadId });
         span.setError(err);
         await context.sendActivity(
           "Failed to reach the agent team. Please try again later.",
@@ -260,66 +219,25 @@ export class MsBridgeService {
     }
   }
 
-  async #handleCallback(c) {
-    const token = c.req.param("token");
-    const meta = this.#callbacks.consume(token);
-    if (!meta) {
-      return c.json({ error: "Unknown callback token" }, 404);
+  async #handleReply(ctx, payload, meta) {
+    if (!ctx.participants?.[0]?.metadata) {
+      throw new CallbackHandlerError(410, "Conversation reference missing");
     }
-    await this.#ack.finish(token);
-
-    let body;
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ error: "Invalid JSON" }, 400);
-    }
-    const payload = validateCallbackPayload(body);
-    if (!payload) return c.json({ error: "Invalid payload" }, 400);
-    if (payload.correlation_id !== meta.correlationId) {
-      return c.json({ error: "Correlation ID mismatch" }, 400);
-    }
-
-    const threadId = meta.meta?.threadId;
-    const ctx = await this.#store.loadByChannel(CHANNEL, threadId);
-    if (!ctx || !ctx.participants?.[0]?.metadata) {
-      return c.json({ error: "Conversation reference missing" }, 410);
-    }
-    delete ctx.pending_callbacks[token];
-
-    const span = this.#tracer.startSpan("MsBridge.HandleCallback", {
-      kind: "SERVER",
-      attributes: { correlation_id: meta.correlationId },
-    });
-    try {
-      const ref = ctx.participants[0].metadata;
-      await this.#postReplies(ref, payload.replies, ctx);
-      await this.#applyVerdict(ref, payload, threadId, meta.correlationId);
-
-      ctx.last_active_at = Date.now();
-      await this.#store.add(ctx);
-      await this.#store.flush();
-      span.addEvent("reply_delivered", { verdict: payload.verdict });
-      span.setOk();
-      return c.json({ ok: true }, 200);
-    } catch (err) {
-      this.#logger.error("callback", err, {
-        thread_id: threadId,
-        correlation_id: meta.correlationId,
-      });
-      span.setError(err);
-      return c.json({ error: "Failed to deliver reply" }, 500);
-    } finally {
-      await span.end();
-    }
+    const ref = ctx.participants[0].metadata;
+    await this.#postReplies(ref, payload.replies, ctx);
+    await this.#applyVerdict(
+      ref,
+      payload,
+      ctx.discussion_id,
+      meta.correlationId,
+    );
   }
 
   async #postReplies(ref, replies, ctx) {
     const list = Array.isArray(replies) ? replies : [];
-    const msAppIdFn = () => this.#config.msAppId();
     for (const reply of list) {
       if (!reply || typeof reply.body !== "string" || !reply.body) continue;
-      await sendReply(this.#adapter, msAppIdFn, ref, reply.body);
+      await sendReply(this.#adapter, this.#msAppId, ref, reply.body);
     }
     for (const reply of list) {
       if (!reply || typeof reply.body !== "string") continue;
@@ -336,12 +254,7 @@ export class MsBridgeService {
       return;
     }
     if (payload.verdict === "failed" && payload.summary) {
-      await sendReply(
-        this.#adapter,
-        () => this.#config.msAppId(),
-        ref,
-        payload.summary,
-      );
+      await sendReply(this.#adapter, this.#msAppId, ref, payload.summary);
     }
   }
 

--- a/services/msbridge/src/teams.js
+++ b/services/msbridge/src/teams.js
@@ -1,0 +1,123 @@
+import botbuilder from "botbuilder";
+
+const { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext } =
+  botbuilder;
+
+export { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext };
+
+export const TYPING_VERBS = [
+  "Moonwalking",
+  "Unravelling",
+  "Tempering",
+  "Crafting",
+  "Simmering",
+  "Percolating",
+  "Decoding",
+];
+
+function pickVerb() {
+  return TYPING_VERBS[Math.floor(Math.random() * TYPING_VERBS.length)];
+}
+
+/**
+ * Reaction adapter for the Bot Framework. Sends a `messageReaction` activity
+ * with `reactionsAdded: [{ type: "like" }]` on start and the matching
+ * `reactionsRemoved` on finish — Microsoft's Bot SDK does not surface a
+ * generic emoji reaction type, so `like` is the closest immediate
+ * acknowledgement we can offer.
+ *
+ * @param {object} adapter - Bot Framework CloudAdapter (or compatible stub)
+ * @param {() => string} msAppIdFn
+ * @returns {{add: Function, remove: Function}}
+ */
+export function buildReactionAdapter(adapter, msAppIdFn) {
+  return {
+    add: async (target) => {
+      if (!target?.ref || !target?.activityId) return null;
+      await adapter.continueConversationAsync(
+        msAppIdFn(),
+        target.ref,
+        async (turnContext) => {
+          await turnContext.sendActivity({
+            type: "messageReaction",
+            replyToId: target.activityId,
+            reactionsAdded: [{ type: "like" }],
+          });
+        },
+      );
+      return "like";
+    },
+    remove: async (_reactionId, target) => {
+      if (!target?.ref || !target?.activityId) return;
+      await adapter.continueConversationAsync(
+        msAppIdFn(),
+        target.ref,
+        async (turnContext) => {
+          await turnContext.sendActivity({
+            type: "messageReaction",
+            replyToId: target.activityId,
+            reactionsRemoved: [{ type: "like" }],
+          });
+        },
+      );
+    },
+  };
+}
+
+/**
+ * Ticker adapter that posts a random "Moonwalking…" verb as a fresh
+ * message activity. Teams is a more immediate medium than GitHub
+ * Discussions; the verbs give a sense of presence while the workflow
+ * dispatch is running.
+ *
+ * @param {object} adapter
+ * @param {() => string} msAppIdFn
+ * @returns {{tick: Function}}
+ */
+export function buildTickerAdapter(adapter, msAppIdFn) {
+  return {
+    tick: async (target, _n) => {
+      if (!target?.ref) return;
+      const verb = pickVerb();
+      await adapter.continueConversationAsync(
+        msAppIdFn(),
+        target.ref,
+        async (turnContext) => {
+          await turnContext.sendActivity(`${verb}...`);
+        },
+      );
+    },
+  };
+}
+
+/**
+ * Post `text` as a Teams message in the conversation identified by `ref`.
+ * @param {object} adapter
+ * @param {() => string} msAppIdFn
+ * @param {object} ref
+ * @param {string} text
+ */
+export async function sendReply(adapter, msAppIdFn, ref, text) {
+  await adapter.continueConversationAsync(
+    msAppIdFn(),
+    ref,
+    async (turnContext) => {
+      await turnContext.sendActivity(text);
+    },
+  );
+}
+
+/**
+ * Build the default Bot Framework CloudAdapter wired to the service config.
+ * @param {object} config
+ * @returns {object}
+ */
+export function createDefaultAdapter(config) {
+  const auth = new ConfigurationBotFrameworkAuthentication({
+    MicrosoftAppId: config.msAppId(),
+    MicrosoftAppPassword: config.msAppPassword(),
+    MicrosoftAppTenantId: config.msAppTenantId(),
+    MicrosoftAppType: "SingleTenant",
+  });
+  return new CloudAdapter(auth);
+}

--- a/services/msbridge/src/teams.js
+++ b/services/msbridge/src/teams.js
@@ -5,26 +5,12 @@ const { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext } =
 
 export { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext };
 
-export const TYPING_VERBS = [
-  "Moonwalking",
-  "Unravelling",
-  "Tempering",
-  "Crafting",
-  "Simmering",
-  "Percolating",
-  "Decoding",
-];
-
-function pickVerb() {
-  return TYPING_VERBS[Math.floor(Math.random() * TYPING_VERBS.length)];
-}
-
 /**
- * Reaction adapter for the Bot Framework. Sends a `messageReaction` activity
- * with `reactionsAdded: [{ type: "like" }]` on start and the matching
- * `reactionsRemoved` on finish — Microsoft's Bot SDK does not surface a
- * generic emoji reaction type, so `like` is the closest immediate
- * acknowledgement we can offer.
+ * Reaction adapter for the Bot Framework. Sends a `messageReaction`
+ * activity with `reactionsAdded: [{ type: "like" }]` on start and the
+ * matching `reactionsRemoved` on finish — Microsoft's Bot SDK does not
+ * surface a generic emoji reaction type, so `like` is the closest
+ * immediate acknowledgement we can offer.
  *
  * @param {object} adapter - Bot Framework CloudAdapter (or compatible stub)
  * @param {() => string} msAppIdFn
@@ -65,25 +51,23 @@ export function buildReactionAdapter(adapter, msAppIdFn) {
 }
 
 /**
- * Ticker adapter that posts a random "Moonwalking…" verb as a fresh
- * message activity. Teams is a more immediate medium than GitHub
- * Discussions; the verbs give a sense of presence while the workflow
- * dispatch is running.
+ * Typing adapter for the Bot Framework. Single responsibility: deliver
+ * `text` to the conversation identified by `target.ref`. Acknowledgement
+ * owns the verb pool and cadence.
  *
  * @param {object} adapter
  * @param {() => string} msAppIdFn
- * @returns {{tick: Function}}
+ * @returns {{send: Function}}
  */
-export function buildTickerAdapter(adapter, msAppIdFn) {
+export function buildTypingAdapter(adapter, msAppIdFn) {
   return {
-    tick: async (target, _n) => {
+    send: async (target, text) => {
       if (!target?.ref) return;
-      const verb = pickVerb();
       await adapter.continueConversationAsync(
         msAppIdFn(),
         target.ref,
         async (turnContext) => {
-          await turnContext.sendActivity(`${verb}...`);
+          await turnContext.sendActivity(text);
         },
       );
     },

--- a/services/msbridge/src/teams.js
+++ b/services/msbridge/src/teams.js
@@ -105,3 +105,69 @@ export function createDefaultAdapter(config) {
   });
   return new CloudAdapter(auth);
 }
+
+/**
+ * Adapt the Bot Framework's express-style `adapter.process(req, res, cb)`
+ * to a Hono request handler. The bridge service hands off the inbound
+ * activity stream to this helper and gets a normal `(c) => Response`
+ * back — `index.js` never sees the express shim.
+ *
+ * @param {object} adapter - Bot Framework CloudAdapter
+ * @param {(turnContext: object) => Promise<void>} onContext
+ * @param {{error?: Function}} [logger]
+ * @returns {(c: object) => Promise<Response>}
+ */
+export function botFrameworkIntake(adapter, onContext, logger) {
+  return async (c) => {
+    const req = c.req.raw;
+    const rawBody = c.get("rawBody");
+    const expressLikeReq = {
+      headers: Object.fromEntries(req.headers.entries()),
+      body: rawBody ? JSON.parse(rawBody.toString("utf8")) : {},
+      method: req.method,
+    };
+    const resLike = makeResLike();
+    try {
+      await adapter.process(expressLikeReq, resLike, onContext);
+      return new Response(resLike._body ?? null, {
+        status: resLike._status,
+        headers: resLike._headers,
+      });
+    } catch (err) {
+      logger?.error?.("messages", err);
+      return c.json({ error: "Invalid activity" }, 400);
+    }
+  };
+}
+
+function makeResLike() {
+  return {
+    headersSent: false,
+    _status: 200,
+    _body: undefined,
+    _headers: {},
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = JSON.stringify(body);
+      this._headers["content-type"] = "application/json";
+      this.headersSent = true;
+      return this;
+    },
+    send(body) {
+      this._body = body;
+      this.headersSent = true;
+      return this;
+    },
+    end(body) {
+      if (body !== undefined) this._body = body;
+      this.headersSent = true;
+      return this;
+    },
+    header(k, v) {
+      this._headers[k.toLowerCase()] = v;
+    },
+  };
+}

--- a/services/msbridge/test/msbridge.test.js
+++ b/services/msbridge/test/msbridge.test.js
@@ -10,8 +10,6 @@ import {
   MsBridgeService,
   appendHistory,
   buildPrompt,
-  formatReply,
-  isValidRunUrl,
   validateCallbackPayload,
 } from "../index.js";
 
@@ -42,17 +40,35 @@ function makeTracer() {
 }
 
 function makeAdapter(overrides = {}) {
+  const sent = [];
+  const reactionActivities = [];
   return {
+    sent,
+    reactionActivities,
     process: async (_req, res, callback) => {
       const turnContext = {
         activity: overrides.activity ?? { type: "message" },
-        sendActivity: async () => {},
+        sendActivity: async (activity) => {
+          sent.push(activity);
+        },
       };
       await callback(turnContext);
       if (!res.headersSent) res.status(200).end();
     },
     continueConversationAsync: async (_appId, _ref, callback) => {
-      await callback({ sendActivity: async () => {} });
+      await callback({
+        sendActivity: async (activity) => {
+          if (
+            activity &&
+            typeof activity === "object" &&
+            activity.type === "messageReaction"
+          ) {
+            reactionActivities.push(activity);
+          } else {
+            sent.push(activity);
+          }
+        },
+      });
     },
     onTurnError: null,
     ...overrides,
@@ -76,107 +92,38 @@ describe("msbridge service", () => {
       expect(MsBridgeService.prototype.stop).toBeTruthy();
     });
 
-    test("re-exports buildPrompt and appendHistory from libbridge", () => {
+    test("re-exports buildPrompt, appendHistory, validateCallbackPayload from libbridge", () => {
       expect(typeof buildPrompt).toBe("function");
       expect(typeof appendHistory).toBe("function");
+      expect(typeof validateCallbackPayload).toBe("function");
     });
   });
 
-  describe("validateCallbackPayload", () => {
-    test("rejects bodies missing required keys", () => {
-      const validRunUrl = "https://github.com/owner/repo/actions/runs/1";
+  describe("validateCallbackPayload (lenient libbridge contract)", () => {
+    test("requires only correlation_id", () => {
       expect(validateCallbackPayload(null)).toBeNull();
       expect(validateCallbackPayload({})).toBeNull();
-      expect(validateCallbackPayload({ correlation_id: 42 })).toBeNull();
-      expect(
-        validateCallbackPayload({
-          correlation_id: "c1",
-          summary: "ok",
-          run_url: validRunUrl,
-        }),
-      ).toBeNull();
-      expect(
-        validateCallbackPayload({
-          correlation_id: "c1",
-          verdict: "success",
-          run_url: validRunUrl,
-        }),
-      ).toBeNull();
-      expect(
-        validateCallbackPayload({
-          correlation_id: "c1",
-          verdict: "success",
-          summary: "ok",
-        }),
-      ).toBeNull();
-    });
-
-    test("normalises required keys", () => {
-      const payload = validateCallbackPayload({
-        correlation_id: "c1",
-        verdict: "success",
-        summary: "all good",
-        run_url: "https://github.com/owner/repo/actions/runs/1",
-      });
-      expect(payload).toEqual({
-        correlation_id: "c1",
-        verdict: "success",
-        summary: "all good",
-        run_url: "https://github.com/owner/repo/actions/runs/1",
+      const minimal = validateCallbackPayload({ correlation_id: "c-1" });
+      expect(minimal).toEqual({
+        correlation_id: "c-1",
+        verdict: "unknown",
+        summary: "",
+        replies: [],
       });
     });
 
-    test("accepts optional channel-agnostic fields without surfacing them", () => {
+    test("passes through optional channel-agnostic fields", () => {
       const payload = validateCallbackPayload({
-        correlation_id: "c1",
+        correlation_id: "c-1",
         verdict: "adjourned",
         summary: "done",
-        run_url: "https://github.com/owner/repo/actions/runs/1",
         replies: [{ body: "hi" }],
         trigger: { kind: "responses", responses: 2 },
-        discussion_id: "GD_abc",
+        discussion_id: "GD_x",
       });
-      expect(payload).toBeTruthy();
-      expect(payload.replies).toBeUndefined();
-      expect(payload.trigger).toBeUndefined();
-      expect(payload.discussion_id).toBeUndefined();
-    });
-
-    test("rejects untrusted run_url hosts", () => {
-      const payload = validateCallbackPayload({
-        correlation_id: "c1",
-        verdict: "success",
-        summary: "",
-        run_url: "https://evil.example/x",
-      });
-      expect(payload).toBeNull();
-    });
-  });
-
-  describe("isValidRunUrl", () => {
-    test("accepts https github.com URLs", () => {
-      expect(
-        isValidRunUrl("https://github.com/owner/repo/actions/runs/1"),
-      ).toBe(true);
-    });
-
-    test("rejects non-github hosts and non-https", () => {
-      expect(isValidRunUrl("https://evil.example/x")).toBe(false);
-      expect(isValidRunUrl("http://github.com/x")).toBe(false);
-      expect(isValidRunUrl(null)).toBe(false);
-      expect(isValidRunUrl(42)).toBe(false);
-    });
-  });
-
-  describe("formatReply", () => {
-    test("returns the summary verbatim", () => {
-      expect(formatReply({ verdict: "success", summary: "hello" })).toBe(
-        "hello",
-      );
-    });
-
-    test("returns empty string when summary missing", () => {
-      expect(formatReply({})).toBe("");
+      expect(payload.replies).toEqual([{ body: "hi" }]);
+      expect(payload.trigger).toEqual({ kind: "responses", responses: 2 });
+      expect(payload.discussion_id).toBe("GD_x");
     });
   });
 
@@ -224,10 +171,37 @@ describe("msbridge service", () => {
 
   describe("callback handler", () => {
     let service;
+    let adapter;
     let baseUrl;
 
+    async function seedCtx(token, threadId, correlationId) {
+      const ref = {
+        bot: { id: "b" },
+        channelId: "msteams",
+        conversation: { id: threadId },
+        serviceUrl: "https://example",
+        user: { id: "u" },
+        activityId: "a-1",
+      };
+      await service.store.add({
+        id: `msteams:${threadId}`,
+        channel: "msteams",
+        discussion_id: threadId,
+        history: [],
+        participants: [{ name: "teams-user", kind: "human", metadata: ref }],
+        open_rfcs: {},
+        lead: "release-engineer",
+        pending_callbacks: { [token]: correlationId },
+        dispatches: [],
+        last_active_at: Date.now(),
+      });
+      await service.store.flush();
+      return ref;
+    }
+
     beforeEach(async () => {
-      service = newService();
+      adapter = makeAdapter();
+      service = newService({ adapter });
       await service.start();
       baseUrl = `http://127.0.0.1:${service.address().port}`;
     });
@@ -242,87 +216,88 @@ describe("msbridge service", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           correlation_id: "x",
-          verdict: "success",
+          verdict: "adjourned",
           summary: "",
         }),
       });
       expect(res.status).toBe(404);
     });
 
-    test("accepts payloads carrying optional replies/trigger/discussion_id", async () => {
-      const token = service.callbacks.register("c-1", { threadId: "t-1" });
-      const ref = {
-        bot: { id: "b" },
-        channelId: "msteams",
-        conversation: { id: "t-1" },
-        serviceUrl: "https://example",
-        user: { id: "u" },
-        activityId: "a",
-      };
-      await service.store.add({
-        id: "msteams:t-1",
-        channel: "msteams",
-        discussion_id: "t-1",
-        history: [],
-        participants: [{ name: "teams-user", kind: "human", metadata: ref }],
-        open_rfcs: {},
-        lead: "release-engineer",
-        pending_callbacks: { [token]: "c-1" },
-        dispatches: [],
-        last_active_at: Date.now(),
-      });
-      await service.store.flush();
-
-      const res = await fetch(`${baseUrl}/api/callback/${token}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          correlation_id: "c-1",
-          verdict: "adjourned",
-          summary: "ok",
-          run_url: "https://github.com/owner/repo/actions/runs/1",
-          replies: [{ body: "ignored on teams" }],
-          trigger: { kind: "responses", responses: 2 },
-          discussion_id: "GD_x",
-        }),
-      });
-      expect(res.status).toBe(200);
-    });
-
     test("correlation_id mismatch returns 400", async () => {
       const token = service.callbacks.register("real-corr", {
-        threadId: "t-2",
+        threadId: "t-mm",
       });
-      await service.store.add({
-        id: "msteams:t-2",
-        channel: "msteams",
-        discussion_id: "t-2",
-        history: [],
-        participants: [
-          {
-            name: "teams-user",
-            kind: "human",
-            metadata: { conversation: { id: "t-2" } },
-          },
-        ],
-        open_rfcs: {},
-        lead: "release-engineer",
-        pending_callbacks: { [token]: "real-corr" },
-        dispatches: [],
-        last_active_at: Date.now(),
-      });
-      await service.store.flush();
+      await seedCtx(token, "t-mm", "real-corr");
       const res = await fetch(`${baseUrl}/api/callback/${token}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           correlation_id: "wrong-corr",
-          verdict: "success",
+          verdict: "adjourned",
           summary: "ok",
-          run_url: "https://github.com/owner/repo/actions/runs/1",
         }),
       });
       expect(res.status).toBe(400);
+    });
+
+    test("adjourned verdict posts each reply as a separate sendActivity", async () => {
+      const token = service.callbacks.register("c-adj", { threadId: "t-adj" });
+      await seedCtx(token, "t-adj", "c-adj");
+      const res = await fetch(`${baseUrl}/api/callback/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          correlation_id: "c-adj",
+          verdict: "adjourned",
+          summary: "ignored summary",
+          replies: [{ body: "first" }, { body: "follow up" }],
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(adapter.sent).toContain("first");
+      expect(adapter.sent).toContain("follow up");
+      expect(adapter.sent).not.toContain("ignored summary");
+      const stored = await service.store.loadByChannel("msteams", "t-adj");
+      expect(stored.history.map((h) => h.text)).toEqual(["first", "follow up"]);
+    });
+
+    test("failed verdict additionally posts the summary", async () => {
+      const token = service.callbacks.register("c-fail", {
+        threadId: "t-fail",
+      });
+      await seedCtx(token, "t-fail", "c-fail");
+      const res = await fetch(`${baseUrl}/api/callback/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          correlation_id: "c-fail",
+          verdict: "failed",
+          summary: "facilitator failed; see run",
+          replies: [{ body: "what we had so far" }],
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(adapter.sent).toContain("what we had so far");
+      expect(adapter.sent).toContain("facilitator failed; see run");
+    });
+
+    test("recessed verdict logs and posts only the replies (no resume yet)", async () => {
+      const token = service.callbacks.register("c-rec", { threadId: "t-rec" });
+      await seedCtx(token, "t-rec", "c-rec");
+      const res = await fetch(`${baseUrl}/api/callback/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          correlation_id: "c-rec",
+          verdict: "recessed",
+          summary: "awaiting humans",
+          replies: [{ body: "what do you think?" }],
+          trigger: { kind: "responses", responses: 2 },
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(adapter.sent).toContain("what do you think?");
+      expect(adapter.sent).not.toContain("awaiting humans");
     });
   });
 
@@ -354,6 +329,83 @@ describe("msbridge service", () => {
       await service.store.flush();
       const reloaded = await service.store.loadByChannel("msteams", "thread-1");
       expect(reloaded.participants[0].metadata).toEqual(ref);
+    });
+  });
+
+  describe("acknowledgement lifecycle", () => {
+    let service;
+    let adapter;
+    let baseUrl;
+
+    beforeEach(async () => {
+      adapter = makeAdapter({
+        activity: {
+          type: "message",
+          id: "act-1",
+          text: "hello",
+          conversation: { id: "thread-ack" },
+          channelId: "msteams",
+          serviceUrl: "https://example",
+          from: { id: "u" },
+          recipient: { id: "b" },
+        },
+      });
+      service = newService({ adapter });
+      // Stub the workflow dispatch fetch.
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = async (url, init) => {
+        const target = String(url);
+        if (target.startsWith("https://api.github.com/")) {
+          return new Response("{}", { status: 204 });
+        }
+        return originalFetch(url, init);
+      };
+      service._restoreFetch = () => {
+        globalThis.fetch = originalFetch;
+      };
+      await service.start();
+      baseUrl = `http://127.0.0.1:${service.address().port}`;
+    });
+
+    afterEach(async () => {
+      await service.stop();
+      service._restoreFetch();
+    });
+
+    test("dispatch sends a 'like' reactionsAdded activity and callback sends reactionsRemoved", async () => {
+      // Drive an inbound message through the bot adapter.
+      const res = await fetch(`${baseUrl}/api/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "message", text: "hi" }),
+      });
+      expect(res.status).toBe(200);
+      const added = adapter.reactionActivities.filter(
+        (a) => a.reactionsAdded?.[0]?.type === "like",
+      );
+      expect(added.length).toBe(1);
+      expect(added[0].replyToId).toBe("act-1");
+
+      // Now invoke the callback for the token that was just registered.
+      const stored = await service.store.loadByChannel("msteams", "thread-ack");
+      const [token] = Object.keys(stored.pending_callbacks);
+      const correlationId = stored.pending_callbacks[token];
+      const cb = await fetch(`${baseUrl}/api/callback/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          correlation_id: correlationId,
+          verdict: "adjourned",
+          summary: "",
+          replies: [{ body: "ok" }],
+        }),
+      });
+      expect(cb.status).toBe(200);
+      const removed = adapter.reactionActivities.filter(
+        (a) => a.reactionsRemoved?.[0]?.type === "like",
+      );
+      expect(removed.length).toBe(1);
+      expect(removed[0].replyToId).toBe("act-1");
     });
   });
 });

--- a/specs/1280-msbridge-suspend-resume/design-a.md
+++ b/specs/1280-msbridge-suspend-resume/design-a.md
@@ -3,16 +3,16 @@
 Architectural design for [spec 1280](spec.md). The libbridge
 `ResumeScheduler` primitive (extracted from `services/ghbridge` earlier in
 this PR) is the contract; this design wires it into `services/msbridge`
-as one new field plus three composition points and one method-call swap.
+as one new field, four call sites covering six verdict branches, and one
+correctness change to the history-append ordering on the inbound path.
 
 ## Components
 
 | Component | Role in this design |
 |---|---|
-| `services/msbridge/index.js` | Gains a `#resume` field constructed alongside `#dispatcher`. Calls into the scheduler at four points: `start`, `stop`, `#handleNewMessage`, `#handleReply`. |
+| `services/msbridge/index.js` | Gains a `#resume` field constructed alongside `#dispatcher`. Calls into the scheduler at four sites: lifecycle (`start`, `stop`), inbound path (`#handleNewMessage`), and reply path (`#handleReply`, three verdict branches). |
 | `libraries/libbridge` | Unchanged. Supplies `ResumeScheduler` already. |
-| `services/msbridge/src/teams.js` | Unchanged. No channel rendering moves; the resume re-dispatch goes through the existing `Dispatcher` and posts replies through the existing callback path. |
-| `services/msbridge/test/` | Gains an end-to-end resume test file that drives the bridge through the Bot Framework intake mock and asserts the same observable behaviour as `services/ghbridge/test/resume.test.js`. |
+| `services/msbridge/src/teams.js` | Unchanged. Resume re-dispatch reaches Teams through `Dispatcher.dispatch` → callback → the existing `handleReply` / `sendReply` chain, so no new channel rendering is required. |
 
 ## Data flow
 
@@ -50,10 +50,17 @@ bridges. The only msbridge-specific bit is what the scheduler stores under
 | Site | Change |
 |---|---|
 | Constructor | Construct `#resume = new ResumeScheduler({ dispatcher: #dispatcher, store: #store, logger, buildCallbackMeta: (ctx) => ({ threadId: ctx.discussion_id }), buildResumeInputs: () => ({}) })` alongside `#dispatcher`. |
-| `start()` | After `#bridge.start()`, call `await #resume.rearm()` — same shape as `services/ghbridge`. |
-| `stop()` | Before `#bridge.stop()`, call `#resume.clear()` — same shape as `services/ghbridge`. |
-| `#handleNewMessage` | Between loading the context and the rate-limit check, call `const { freshDispatchAllowed } = await #resume.processInbound(ctx)` and skip both the rate-limit check and the fresh dispatch when `freshDispatchAllowed` is false. |
+| `start()` | Call `#resume.rearm()` once the bridge is accepting requests, so a deadline that fires immediately can complete its re-dispatch through the live server. |
+| `stop()` | Call `#resume.clear()` while the bridge is still accepting requests, so no armed timer fires into a torn-down host. |
+| `#handleNewMessage` (inbound path) | Append the user's text to `ctx.history`, then call `const { freshDispatchAllowed } = await #resume.processInbound(ctx)`. When `freshDispatchAllowed` is false, neither the rate-limit check nor the fresh dispatch runs. When it is true, `dispatcher.dispatch` is called without `historyText` — the user turn is already in `ctx.history`. |
 | `#handleReply` verdict branches | Replace the `recessed` log-only branch with `#resume.enterRecess(ctx, meta.correlationId, payload.trigger)`. Add `#resume.cancelRecess(ctx, meta.correlationId)` to both `adjourned` and `failed` branches (the existing summary post on `failed` stays). |
+
+History append is moved out of `dispatcher.dispatch`'s `historyText` argument
+and into the inbound handler so that `processInbound` evaluates the
+responses trigger against an `ctx.history.length` that already includes
+the message that should satisfy it. Without this move the trigger would
+under-count by one on every inbound message. `services/ghbridge` already
+does it this way.
 
 The two `build*` callbacks are the only per-channel inputs. Both are pure
 functions over `ctx.discussion_id` — no Bot Framework SDK reaches the
@@ -64,9 +71,12 @@ scheduler.
 | Decision | Chosen | Rejected | Why |
 |---|---|---|---|
 | `callbackMeta` key for resume dispatches | `{ threadId: ctx.discussion_id }` | `{ discussionId: ctx.discussion_id }` (the libbridge default) | The existing msbridge `createCallbackHandler` registration reads `meta.meta?.threadId` via its `loadDiscussionId` lens; matching that key keeps callback meta consistent across fresh and resume dispatches and avoids changing the lens. |
-| `workflowInputs` for resume dispatches | `{}` (default) | `{ discussionId: ctx.discussion_id }` (ghbridge convention) | msbridge does not pass `discussion_id` on fresh dispatches today. Adding it on resume only would create asymmetry; adding it on both is a separate, broader change (trace-linkage parity for msteams) and belongs to a different spec. |
-| `processInbound` call position in `#handleNewMessage` | Before the rate-limit check, after the context load | After the rate-limit check | A resume re-dispatch is a continuation of an existing recess, not a new dispatch by the user. Rate-limiting it against the user's own message would penalise the user for the agent's own scheduling decision. ghbridge applies the rate-limit check only on the fresh-dispatch branch (`freshDispatchAllowed`); this preserves that behaviour. |
-| Cancellation on `adjourned` and `failed` | Always call `cancelRecess` | Only call when an rfc is known to exist | `cancelRecess` is idempotent and the cost of a missing key is zero. Calling unconditionally removes a branch the bridge would otherwise have to maintain. |
+| `workflowInputs` for resume dispatches | `{}` (default) | `{ discussionId: ctx.discussion_id }` (ghbridge convention) | msbridge does not pass `discussion_id` on fresh dispatches today, so passing it on resume only would create asymmetry; passing it on both is a broader trace-linkage-parity change that belongs to a different spec. The parity gap is deliberate. |
+| `processInbound` runs before the rate-limit check | Resume re-dispatches happen unconditionally | Gate resume re-dispatches behind the rate limiter | A resume is a continuation of an existing recess, not a new dispatch by the user. Rate-limiting it against the user's own message would penalise the user for the agent's scheduling decision. ghbridge applies the rate-limit check only on the fresh-dispatch branch and this design follows the same shape. |
+| History append moved into the inbound handler | Append in `#handleNewMessage` before `processInbound`; drop `historyText` from the fresh-dispatch call | Keep `historyText: text` on `dispatcher.dispatch` | Without the move, `processInbound` evaluates the responses trigger against an `ctx.history` that does not include the message that should satisfy it, under-counting by one. Keeping `historyText` AND adding the explicit append produces a duplicate user turn. ghbridge resolves this the same way. |
+| Cancellation on `adjourned` and `failed` | Always call `cancelRecess` | Guard with `if (open_rfcs[correlationId])` | `cancelRecess` is idempotent and the cost of a missing key is zero. Calling unconditionally removes a branch the bridge would otherwise have to maintain. |
+| `#resume` constructed eagerly in the constructor | Alongside `#dispatcher`, dependencies fully wired before `start()` | Lazy construction inside `start()`, or via an injected factory | Eager construction keeps the wiring in one place, matches `#dispatcher`'s pattern, and lets test overrides (`deps.acknowledgement`-style) compose at the same level. Lazy or factory shapes add a layer for a one-shot dependency the bridge always needs. |
+| Verdict-branch calls live in `#handleReply` directly | `enterRecess` / `cancelRecess` are called inline from the verdict switch | Route through `#applyVerdict` or a new `#applyRecessTransition` helper | The switch already names each verdict; adding two method calls per branch is more legible than introducing a third helper that exists only to host them. Matches ghbridge's shape. |
 | Test placement | New file `services/msbridge/test/resume.test.js` mirroring `services/ghbridge/test/resume.test.js` | Add resume scenarios to the existing `msbridge.test.js` | A separate file keeps the resume e2e shape readable side-by-side with ghbridge's. Reviewers comparing the two bridges' resume behaviour open one file per side. |
 | Inbound activity driver in tests | Reuse `botFrameworkIntake` plus the adapter mock from `msbridge.test.js` (drives `#handleNewMessage` via real HTTP) | Call `#handleNewMessage` directly via a private accessor | The HTTP path is the contract; testing through it catches intake-glue regressions and matches the level at which `services/ghbridge/test/resume.test.js` operates. |
 
@@ -77,8 +87,8 @@ scheduler.
   `services/ghbridge`. Out of scope for this spec; see spec 1280 § Scope.
 - Cross-channel resumption (a recess opened on Teams resolving via a
   comment on Discussions). Deferred per spec.
-- The exact line position of the `processInbound` call relative to
-  `ctx.last_active_at = Date.now()` and the participant metadata refresh
-  — execution ordering is a plan concern.
+- Execution ordering inside `#handleNewMessage` and `start()` / `stop()`
+  beyond the architectural before/after relationships named in
+  Composition — exact step sequencing is a plan concern.
 - The fixture shape of the Bot Framework inbound activities in the new
   resume test file — concrete fixture authoring is a plan concern.

--- a/specs/1280-msbridge-suspend-resume/design-a.md
+++ b/specs/1280-msbridge-suspend-resume/design-a.md
@@ -1,0 +1,84 @@
+# Design 1280-a — Suspend/resume support for msbridge
+
+Architectural design for [spec 1280](spec.md). The libbridge
+`ResumeScheduler` primitive (extracted from `services/ghbridge` earlier in
+this PR) is the contract; this design wires it into `services/msbridge`
+as one new field plus three composition points and one method-call swap.
+
+## Components
+
+| Component | Role in this design |
+|---|---|
+| `services/msbridge/index.js` | Gains a `#resume` field constructed alongside `#dispatcher`. Calls into the scheduler at four points: `start`, `stop`, `#handleNewMessage`, `#handleReply`. |
+| `libraries/libbridge` | Unchanged. Supplies `ResumeScheduler` already. |
+| `services/msbridge/src/teams.js` | Unchanged. No channel rendering moves; the resume re-dispatch goes through the existing `Dispatcher` and posts replies through the existing callback path. |
+| `services/msbridge/test/` | Gains an end-to-end resume test file that drives the bridge through the Bot Framework intake mock and asserts the same observable behaviour as `services/ghbridge/test/resume.test.js`. |
+
+## Data flow
+
+```mermaid
+sequenceDiagram
+    participant Te as Teams user
+    participant Br as services/msbridge
+    participant Rs as ResumeScheduler<br/>(libbridge)
+    participant Di as Dispatcher<br/>(libbridge)
+    participant Wf as kata-dispatch.yml
+
+    Te->>Br: new message
+    Br->>Rs: processInbound(ctx)
+    alt trigger fires
+        Rs->>Di: dispatch (resume_context)
+        Di->>Wf: workflow_dispatch
+    else open recess, no trigger fired
+        Rs-->>Br: freshDispatchAllowed=false
+    else no open recess
+        Rs-->>Br: freshDispatchAllowed=true
+        Br->>Di: dispatch (fresh)
+        Di->>Wf: workflow_dispatch
+    end
+    Wf-->>Br: callback (verdict=recessed)
+    Br->>Rs: enterRecess(ctx, correlationId, trigger)
+    Note over Rs: trigger persisted on ctx.open_rfcs;<br/>elapsed timer armed if applicable
+```
+
+The pre-recess and post-recess control flows are symmetric across both
+bridges. The only msbridge-specific bit is what the scheduler stores under
+`callbackMeta` when it re-dispatches (`threadId`, not `discussionId`).
+
+## Composition
+
+| Site | Change |
+|---|---|
+| Constructor | Construct `#resume = new ResumeScheduler({ dispatcher: #dispatcher, store: #store, logger, buildCallbackMeta: (ctx) => ({ threadId: ctx.discussion_id }), buildResumeInputs: () => ({}) })` alongside `#dispatcher`. |
+| `start()` | After `#bridge.start()`, call `await #resume.rearm()` — same shape as `services/ghbridge`. |
+| `stop()` | Before `#bridge.stop()`, call `#resume.clear()` — same shape as `services/ghbridge`. |
+| `#handleNewMessage` | Between loading the context and the rate-limit check, call `const { freshDispatchAllowed } = await #resume.processInbound(ctx)` and skip both the rate-limit check and the fresh dispatch when `freshDispatchAllowed` is false. |
+| `#handleReply` verdict branches | Replace the `recessed` log-only branch with `#resume.enterRecess(ctx, meta.correlationId, payload.trigger)`. Add `#resume.cancelRecess(ctx, meta.correlationId)` to both `adjourned` and `failed` branches (the existing summary post on `failed` stays). |
+
+The two `build*` callbacks are the only per-channel inputs. Both are pure
+functions over `ctx.discussion_id` — no Bot Framework SDK reaches the
+scheduler.
+
+## Key decisions
+
+| Decision | Chosen | Rejected | Why |
+|---|---|---|---|
+| `callbackMeta` key for resume dispatches | `{ threadId: ctx.discussion_id }` | `{ discussionId: ctx.discussion_id }` (the libbridge default) | The existing msbridge `createCallbackHandler` registration reads `meta.meta?.threadId` via its `loadDiscussionId` lens; matching that key keeps callback meta consistent across fresh and resume dispatches and avoids changing the lens. |
+| `workflowInputs` for resume dispatches | `{}` (default) | `{ discussionId: ctx.discussion_id }` (ghbridge convention) | msbridge does not pass `discussion_id` on fresh dispatches today. Adding it on resume only would create asymmetry; adding it on both is a separate, broader change (trace-linkage parity for msteams) and belongs to a different spec. |
+| `processInbound` call position in `#handleNewMessage` | Before the rate-limit check, after the context load | After the rate-limit check | A resume re-dispatch is a continuation of an existing recess, not a new dispatch by the user. Rate-limiting it against the user's own message would penalise the user for the agent's own scheduling decision. ghbridge applies the rate-limit check only on the fresh-dispatch branch (`freshDispatchAllowed`); this preserves that behaviour. |
+| Cancellation on `adjourned` and `failed` | Always call `cancelRecess` | Only call when an rfc is known to exist | `cancelRecess` is idempotent and the cost of a missing key is zero. Calling unconditionally removes a branch the bridge would otherwise have to maintain. |
+| Test placement | New file `services/msbridge/test/resume.test.js` mirroring `services/ghbridge/test/resume.test.js` | Add resume scenarios to the existing `msbridge.test.js` | A separate file keeps the resume e2e shape readable side-by-side with ghbridge's. Reviewers comparing the two bridges' resume behaviour open one file per side. |
+| Inbound activity driver in tests | Reuse `botFrameworkIntake` plus the adapter mock from `msbridge.test.js` (drives `#handleNewMessage` via real HTTP) | Call `#handleNewMessage` directly via a private accessor | The HTTP path is the contract; testing through it catches intake-glue regressions and matches the level at which `services/ghbridge/test/resume.test.js` operates. |
+
+## What this design does not cover
+
+- Whether `services/msbridge` should also pass `discussion_id` as a
+  workflow input on fresh dispatches for trace linkage parity with
+  `services/ghbridge`. Out of scope for this spec; see spec 1280 § Scope.
+- Cross-channel resumption (a recess opened on Teams resolving via a
+  comment on Discussions). Deferred per spec.
+- The exact line position of the `processInbound` call relative to
+  `ctx.last_active_at = Date.now()` and the participant metadata refresh
+  — execution ordering is a plan concern.
+- The fixture shape of the Bot Framework inbound activities in the new
+  resume test file — concrete fixture authoring is a plan concern.

--- a/specs/1280-msbridge-suspend-resume/spec.md
+++ b/specs/1280-msbridge-suspend-resume/spec.md
@@ -2,15 +2,12 @@
 
 ## Persona and job
 
-Hired by the **Teams Using Agents** user group named in
-[CLAUDE.md § Primary Products](../../CLAUDE.md#primary-products) — teams that
-ask their agent team a question on Microsoft Teams, expect the agent to think,
-deliberate, and come back when the answer is ready, rather than answer
-immediately every time.
-
-This persona has no `<job>` entry in [JTBD.md](../../JTBD.md) today; the user
-group exists in CLAUDE.md as one of the three primary product audiences but
-its jobs are not yet captured in the JTBD authoritative list.
+Hired by the **Teams Using Agents** user group's
+[`<job goal="Run a Continuously Improving Agent Team">`](../../JTBD.md) entry
+— specifically, the discuss-mode surface where an agent reasons before
+answering rather than answering immediately every time. This spec extends
+that surface on Microsoft Teams to match what `services/ghbridge` already
+delivers on GitHub Discussions.
 
 ## Problem
 
@@ -79,16 +76,15 @@ Three non-changes:
 
 ### In scope
 
-- Wiring `ResumeScheduler` into `services/msbridge` with msteams-shaped
-  callback meta and resume-input builders. Composition only — the names
-  used by `services/msbridge`'s callback registry (`threadId`) and the
-  fact that msteams does not pass `discussion_id` as a workflow input
-  today are inherited from existing convention.
-- Calling the scheduler's pre-dispatch and per-message hooks from the
-  intake and reply handlers so trigger evaluation happens before fresh
-  dispatch and rfc state transitions happen on the verdict.
-- Rearming persisted timers when `services/msbridge` starts; cancelling
-  them when it stops.
+- `services/msbridge` learns to suspend a recess on a `recessed` verdict,
+  watch subsequent inbound messages and elapsed time for the trigger's
+  satisfaction, and re-dispatch the workflow with `resume_context` when
+  the trigger fires. Behaviour matches `services/ghbridge`'s resume
+  surface; the design decides the exact composition.
+- Trigger evaluation occurs before any fresh dispatch on the inbound
+  path, and recess state transitions occur on receipt of the workflow
+  verdict.
+- Persisted recess deadlines survive a `services/msbridge` restart.
 - End-to-end tests at the `services/msbridge/test` layer matching the
   shape of `services/ghbridge/test/resume.test.js`: both
   `responses`-trigger and `elapsed`-trigger paths, with the same
@@ -131,8 +127,8 @@ Out of scope by inheritance:
 | A `recessed` verdict on Teams persists the trigger on `open_rfcs` rather than no-opping. | An end-to-end test that drives a Teams message → `recessed` callback returns the discussion context with one entry in `open_rfcs` carrying the trigger payload. |
 | A subsequent Teams message that satisfies a `responses` trigger re-dispatches the workflow with `resume_context`. | An end-to-end test that observes exactly two workflow dispatches (initial + resume) on the captured GitHub Actions fetch, with the second carrying a `resume_context` whose `correlation_id` matches the original dispatch and whose `history_since` contains the post-recess messages. |
 | A subsequent Teams message during an open recess that does NOT satisfy the trigger accrues into history without spawning a parallel fresh dispatch. | An end-to-end test where the dispatch fetch is observed once total and the stored context shows the user's intermediate message in `history`. |
-| An `elapsed` trigger persists `due_at` and the scheduler rearms it on bridge start. | A test that seeds an `open_rfcs` record with a future `due_at` into the same storage backing, constructs a fresh `MsBridgeService`, calls `start()`, and observes a scheduled timer (visible via the scheduler's `size` getter exposed for diagnostics) without sending any new message. |
+| An `elapsed` trigger persists `due_at` and the bridge rearms it on start. | A test that seeds an `open_rfcs` record with a future `due_at` into the same storage backing, starts a fresh bridge, and observes that a timer is armed for that deadline without any inbound message — verifiable by any read-only observable the host exposes on its scheduler. |
 | The Teams resume behaviour matches `services/ghbridge` for the same trigger shapes. | The new `services/msbridge/test` resume tests assert the same end-to-end claims that `services/ghbridge/test/resume.test.js` asserts, with the only differences being the channel name (`msteams` vs `github-discussions`), the inbound activity shape, and the absence of GraphQL reactions in the assertions. |
 | The `adjourned` and `failed` paths in `services/msbridge` continue to behave as today. | Existing tests in `services/msbridge/test/msbridge.test.js` for `adjourned` and `failed` verdicts continue to pass without modification. |
-| `services/msbridge` no longer emits the `"resume not yet supported on msteams"` log line. | `grep -F 'resume not yet supported' services/msbridge` returns no matches. |
-| Service shutdown cancels every armed elapsed timer. | A test that arms an `elapsed` trigger via the bridge, calls `stop()`, and asserts the underlying scheduler `size` is zero after the call. |
+| `services/msbridge` no longer logs a "resume not supported" notice on a `recessed` verdict. | An end-to-end test that POSTs a `recessed` callback and observes the logger captured no entry matching that phrase. |
+| Service shutdown cancels every armed elapsed timer. | A test that arms an `elapsed` trigger via the bridge, calls `stop()`, and observes — by any read-only observable the host exposes on its scheduler — that no timer remains armed. |

--- a/specs/1280-msbridge-suspend-resume/spec.md
+++ b/specs/1280-msbridge-suspend-resume/spec.md
@@ -1,0 +1,138 @@
+# Spec 1280 — Suspend/resume support for msbridge
+
+## Persona and job
+
+Hired by the **Teams Using Agents** user group named in
+[CLAUDE.md § Primary Products](../../CLAUDE.md#primary-products) — teams that
+ask their agent team a question on Microsoft Teams, expect the agent to think,
+deliberate, and come back when the answer is ready, rather than answer
+immediately every time.
+
+This persona has no `<job>` entry in [JTBD.md](../../JTBD.md) today; the user
+group exists in CLAUDE.md as one of the three primary product audiences but
+its jobs are not yet captured in the JTBD authoritative list.
+
+## Problem
+
+The Kata dispatch workflow can return any of three terminal verdicts —
+`adjourned`, `failed`, or `recessed`. The `recessed` verdict carries a
+`trigger` describing when the agent wants to be re-summoned: after N more
+responses, or after an elapsed ISO-8601 duration, or either.
+
+The `services/ghbridge` service implements this fully. When a GitHub
+Discussion thread receives a `recessed` verdict the bridge persists the
+trigger on the conversation, watches comments accrue, and on trigger
+satisfaction re-dispatches the workflow carrying `resume_context` that the
+facilitator uses to continue where it left off.
+
+The `services/msbridge` service does not. Its callback handler logs
+`"resume not yet supported on msteams"` on a `recessed` verdict and applies
+the same code path as `adjourned`. The agent's request to be re-summoned is
+silently dropped.
+
+Three consequences:
+
+1. **Teams users get different behaviour from the same workflow than
+   Discussions users.** The same `kata-dispatch.yml`, posed the same way,
+   produces a recess on Discussions and a no-op on Teams. The disparity is
+   undocumented to the user.
+
+2. **Discuss-mode work on Teams is artificially constrained.** A
+   facilitator running a quorum-style task must adjourn synchronously or fail
+   — it cannot say "ask three teammates, come back when two answer." The
+   contract that `kata-dispatch.yml` already exposes is unreachable from
+   Teams.
+
+3. **`services/ghbridge` and `services/msbridge` carry a feature delta**
+   that a contributor reading either file must hold in their head. The
+   bridge-parity work that landed `libraries/libbridge`'s `ResumeScheduler`
+   primitive closed the structural gap; only the wiring remains.
+
+## Proposal
+
+Wire `libraries/libbridge`'s `ResumeScheduler` into `services/msbridge` so
+the Teams bridge supports both response-count and elapsed-duration triggers
+end-to-end. Behaviour matches `services/ghbridge` exactly except for the
+channel-specific callback-meta convention.
+
+Three observable changes for the Teams user:
+
+- A `recessed` verdict now suspends the conversation. The acknowledgement
+  reaction is removed (existing behaviour); the facilitator's `replies` are
+  posted (existing behaviour); the trigger is persisted (new).
+- Subsequent messages from the user in the same Teams thread accrue toward
+  the trigger. When the trigger fires, the workflow re-dispatches with the
+  same `resume_context` payload `services/ghbridge` produces.
+- Elapsed triggers fire even when no further user message arrives. A
+  persisted `due_at` survives a `services/msbridge` restart.
+
+Three non-changes:
+
+- `libraries/libbridge` gains no new exports. The primitives exist.
+- The `kata-dispatch.yml` workflow contract is unchanged. The
+  `resume_context` envelope already produced by `services/ghbridge` is
+  reused byte-for-byte.
+- `services/msbridge`'s response to `adjourned` and `failed` verdicts is
+  unchanged.
+
+## Scope
+
+### In scope
+
+- Wiring `ResumeScheduler` into `services/msbridge` with msteams-shaped
+  callback meta and resume-input builders. Composition only — the names
+  used by `services/msbridge`'s callback registry (`threadId`) and the
+  fact that msteams does not pass `discussion_id` as a workflow input
+  today are inherited from existing convention.
+- Calling the scheduler's pre-dispatch and per-message hooks from the
+  intake and reply handlers so trigger evaluation happens before fresh
+  dispatch and rfc state transitions happen on the verdict.
+- Rearming persisted timers when `services/msbridge` starts; cancelling
+  them when it stops.
+- End-to-end tests at the `services/msbridge/test` layer matching the
+  shape of `services/ghbridge/test/resume.test.js`: both
+  `responses`-trigger and `elapsed`-trigger paths, with the same
+  assertions on `resume_context` content.
+
+### Excluded
+
+Permanent non-goals:
+
+- Changes to `libraries/libbridge`. The scheduler is the contract; this
+  spec is the consumer side.
+- Channel-specific resume semantics. The trigger evaluation, the
+  `resume_context` shape, and the cancellation rules are all defined by
+  `libraries/libbridge`'s primitive and inherited unchanged.
+- A user-facing notification when a recess begins. Teams will not see "the
+  agent is waiting for two more responses" — the existing reply text the
+  facilitator chose to post is the user-facing signal.
+
+Deferred:
+
+- A per-recess timeout failsafe (auto-fail a recess that never resolves
+  beyond a hard limit). The libbridge `evaluateTrigger` contract already
+  treats elapsed as the natural failsafe; adding a second one is future
+  work.
+- Cross-channel resumption (a recess opened on Teams resolving via a
+  comment on Discussions, or vice versa). Each channel resumes its own
+  recesses only.
+
+Out of scope by inheritance:
+
+- Conversation state shape (`open_rfcs`, `pending_callbacks`,
+  `discussion_id`). `services/msbridge` already writes the canonical
+  `DiscussionContextStore` record from spec 1230; the `open_rfcs` field is
+  already part of that record and survives reload.
+
+## Success criteria
+
+| Claim | Verifies via |
+|---|---|
+| A `recessed` verdict on Teams persists the trigger on `open_rfcs` rather than no-opping. | An end-to-end test that drives a Teams message → `recessed` callback returns the discussion context with one entry in `open_rfcs` carrying the trigger payload. |
+| A subsequent Teams message that satisfies a `responses` trigger re-dispatches the workflow with `resume_context`. | An end-to-end test that observes exactly two workflow dispatches (initial + resume) on the captured GitHub Actions fetch, with the second carrying a `resume_context` whose `correlation_id` matches the original dispatch and whose `history_since` contains the post-recess messages. |
+| A subsequent Teams message during an open recess that does NOT satisfy the trigger accrues into history without spawning a parallel fresh dispatch. | An end-to-end test where the dispatch fetch is observed once total and the stored context shows the user's intermediate message in `history`. |
+| An `elapsed` trigger persists `due_at` and the scheduler rearms it on bridge start. | A test that seeds an `open_rfcs` record with a future `due_at` into the same storage backing, constructs a fresh `MsBridgeService`, calls `start()`, and observes a scheduled timer (visible via the scheduler's `size` getter exposed for diagnostics) without sending any new message. |
+| The Teams resume behaviour matches `services/ghbridge` for the same trigger shapes. | The new `services/msbridge/test` resume tests assert the same end-to-end claims that `services/ghbridge/test/resume.test.js` asserts, with the only differences being the channel name (`msteams` vs `github-discussions`), the inbound activity shape, and the absence of GraphQL reactions in the assertions. |
+| The `adjourned` and `failed` paths in `services/msbridge` continue to behave as today. | Existing tests in `services/msbridge/test/msbridge.test.js` for `adjourned` and `failed` verdicts continue to pass without modification. |
+| `services/msbridge` no longer emits the `"resume not yet supported on msteams"` log line. | `grep -F 'resume not yet supported' services/msbridge` returns no matches. |
+| Service shutdown cancels every armed elapsed timer. | A test that arms an `elapsed` trigger via the bridge, calls `stop()`, and asserts the underlying scheduler `size` is zero after the call. |


### PR DESCRIPTION
## Summary

Two threads of work ship together.

**Bridge parity refactor.** Pulls the dispatch dance, the callback handler skeleton, the acknowledgement lifecycle, the typing-verb pool, the Bot Framework intake glue, and the suspend/resume scheduler out of `services/ghbridge` and `services/msbridge` into `libraries/libbridge`. The two bridges now mirror each other: imports → constants → class → constructor (validate + libbridge wiring) → lifecycle → intake → reply. New libbridge exports: `Acknowledgement`, `Dispatcher`, `createCallbackHandler` (+ `CallbackHandlerError`), `ResumeScheduler`, `ElapsedScheduler`, `validateCallbackPayload`, `newDiscussionContext`, `normalizeBaseUrl`, plus a `BridgeConfig` JSDoc typedef.

`services/ghbridge/index.js` collapses from 530 lines to 370. `services/msbridge/index.js` goes from 425 to 275 and gains the 👀 reaction + typing-verb feedback it didn't have before. `libraries/libbridge/CLAUDE.md` documents the four-piece bridge contract a new contributor would implement (intake, reaction adapter, optional typing adapter, reply handler).

**Spec 1280 — msbridge suspend/resume.** Spec + design ship alongside as a follow-up to wire the now-channel-agnostic `ResumeScheduler` into msbridge. Spec defines the WHAT/WHY (Teams users get the same `recessed` semantics as Discussions users today get); design 1280-a names the four call sites and the history-append ordering fix that's needed to make the responses trigger count correctly. Both passed a 9-reviewer panel (3 product + 3 technical on spec, 3 technical on design) — consensus findings addressed in `c56359fc`.

155 bridge tests (libbridge + ghbridge + msbridge) pass. Repo-level test failures (17) are pre-existing libwiki offline-network tests on `main`, unchanged by this PR.

## Test plan

- [x] `bun run check` — passes
- [x] `bun run test libraries/libbridge/test/ services/ghbridge/test/ services/msbridge/test/` — 155 / 155 green
- [ ] CI green on the PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ta4JEJbfdP2RsQSzkT3nGL)_