### PR TITLE
refactor(kata-dispatch): switch to fit-eval@v1 action, drop bypass and dead code

### DIFF
--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -191,46 +191,32 @@ jobs:
             echo "$delim"
           } >> "$GITHUB_OUTPUT"
 
-      # Run the libeval CLI directly so Part 02's discuss mode + lead-flag
-      # consolidation reach this workflow without a sibling-repo
-      # composite-action retag. Selects discuss mode when discussion_id is
-      # set (the bridge path), otherwise facilitate mode.
+      # Select discuss mode when a discussion_id is supplied (the bridge
+      # path resuming or starting a threaded conversation); otherwise run a
+      # one-shot facilitate. The discuss / facilitate / supervise modes all
+      # take the same lead-profile + agent-profiles pair after the libeval
+      # consolidation that landed alongside discuss mode.
       #
-      # Security: every untrusted dispatch input (DISPATCH_PROMPT,
-      # DISCUSSION_ID, RESUME_CONTEXT) reaches the shell only via env:
-      # declarations — never as ${{ }} interpolation inside the `run:`
-      # block. The args=(...) array preserves whitespace and JSON contents.
+      # Untrusted dispatch inputs (task text, discussion_id, resume_context)
+      # flow as `with:` inputs; the composite action env-wraps them before
+      # they reach any shell, so this surface preserves the same
+      # template-injection-safe contract as the previous direct-CLI form.
       - name: Assess and Act
         id: assess
+        uses: forwardimpact/fit-eval@v1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
           CLAUDE_CODE_USE_BEDROCK: "0"
-          DISPATCH_PROMPT: ${{ steps.task.outputs.task }}
-          DISCUSSION_ID: ${{ inputs.discussion_id }}
-          RESUME_CONTEXT: ${{ inputs.resume_context }}
-          TARGET_TYPE: ${{ steps.task.outputs.target-type }}
-          TARGET_NUMBER: ${{ steps.task.outputs.target-number }}
-        run: |
-          set -euo pipefail
-          trace_file="$RUNNER_TEMP/trace.ndjson"
-          args=(
-            --task-text="$DISPATCH_PROMPT"
-            --lead-profile=release-engineer
-            --agent-profiles=product-manager,security-engineer,staff-engineer,technical-writer
-            --max-turns=1500
-            --output="$trace_file"
-          )
-          if [ -n "$DISCUSSION_ID" ]; then
-            args+=( --discussion-id="$DISCUSSION_ID" )
-            if [ -n "$RESUME_CONTEXT" ]; then
-              args+=( --resume-context="$RESUME_CONTEXT" )
-            fi
-            node libraries/libeval/bin/fit-eval.js discuss "${args[@]}"
-          else
-            node libraries/libeval/bin/fit-eval.js facilitate "${args[@]}"
-          fi
-          echo "trace-file=$trace_file" >> "$GITHUB_OUTPUT"
+        with:
+          mode: ${{ inputs.discussion_id != '' && 'discuss' || 'facilitate' }}
+          task-text: ${{ steps.task.outputs.task }}
+          lead-profile: release-engineer
+          agent-profiles: product-manager,security-engineer,staff-engineer,technical-writer
+          max-turns: "1500"
+          timeout-minutes: "300"
+          discussion-id: ${{ inputs.discussion_id }}
+          resume-context: ${{ inputs.resume_context }}
 
       # Deliver the facilitator's conclusion to an external caller (e.g. the
       # MS Teams bridge or GitHub Discussions bridge) when one is specified

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -114,13 +114,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          target_type="pull_request"
           target_number="${PR_NUMBER_FROM_EVENT:-}"
 
           case "$EVENT_NAME" in
             issues)
-              target_type="issue"
-              target_number="${PR_NUMBER_FROM_EVENT:-}"
               if [ "$EVENT_ACTION" = "labeled" ]; then
                 context="Label \"$LABEL_NAME\" was added to issue \"$ISSUE_TITLE\" (#$target_number). Issue URL: $ITEM_URL."
                 action="route to the best-suited agent."
@@ -130,8 +127,6 @@ jobs:
               fi
               ;;
             pull_request_target)
-              target_type="pull_request"
-              target_number="${PR_NUMBER_FROM_EVENT:-}"
               if [ "$EVENT_ACTION" = "closed" ]; then
                 context="PR \"$PR_TITLE\" (#$target_number) has been approved and merged. PR URL: $ITEM_URL."
               else
@@ -140,18 +135,14 @@ jobs:
               action="route to the best-suited agent."
               ;;
             workflow_dispatch)
-              target_type=""
-              target_number=""
               ;;
             issue_comment)
               if [ "$IS_PR" = "true" ]; then
                 context="A new comment was posted on PR #$target_number by @$AUTHOR (user type: $AUTHOR_TYPE; event: $EVENT_NAME). Comment URL: $ITEM_URL."
-                action="route to the best-suited agent and ask them to assess the comment and act on it."
               else
-                target_type="issue"
                 context="A new comment was posted on issue \"$ISSUE_TITLE\" (#$target_number) by @$AUTHOR (user type: $AUTHOR_TYPE; event: $EVENT_NAME). Comment URL: $ITEM_URL."
-                action="route to the best-suited agent and ask them to assess the comment and act on it."
               fi
+              action="route to the best-suited agent and ask them to assess the comment and act on it."
               ;;
             pull_request_review)
               context="A review was submitted on PR \"$PR_TITLE\" (#$target_number) by @$AUTHOR (user type: $AUTHOR_TYPE; event: $EVENT_NAME). Review URL: $ITEM_URL. The review payload bundles the review body together with any inline diff comments — fetch the full set when assessing."
@@ -184,8 +175,6 @@ jobs:
           # Lab template-injection guidance.
           delim="EOF_$(openssl rand -hex 16)"
           {
-            echo "target-type=$target_type"
-            echo "target-number=$target_number"
             echo "task<<$delim"
             echo "$task"
             echo "$delim"
@@ -236,7 +225,7 @@ jobs:
           set -euo pipefail
           if [ -n "$TRACE_FILE" ] && [ -f "$TRACE_FILE" ]; then
             echo "Using trace file: $TRACE_FILE"
-            node libraries/libeval/bin/fit-eval.js callback \
+            bunx fit-eval callback \
               --trace-file="$TRACE_FILE" \
               --callback-url="$CALLBACK_URL" \
               --correlation-id="$CORRELATION_ID" \


### PR DESCRIPTION
## Summary

`kata-dispatch.yml` was bypassing `forwardimpact/fit-eval@v1` and calling
the libeval CLI directly because the composite action didn't yet expose
discuss mode or the unified `lead-*` flags. Both now ship at `@v1` (see
[forwardimpact/fit-eval#2](https://github.com/forwardimpact/fit-eval/pull/2),
already merged and retagged), so the bypass and a small cluster of dead
plumbing around it can go.

## Changes

**Assess and Act → `uses: forwardimpact/fit-eval@v1`**

The inline `node libraries/libeval/bin/fit-eval.js {discuss,facilitate}`
shell block is replaced by an action call. Mode flips on the
`discussion_id` input — discuss when set (the bridge resume / start
path), facilitate otherwise:

```yaml
mode: ${{ inputs.discussion_id != '' && 'discuss' || 'facilitate' }}
```

`task-text`, `lead-profile`, `agent-profiles`, `max-turns`, plus the
new `discussion-id` / `resume-context` inputs flow through `with:`.
`timeout-minutes: "300"` matches the original "30+ minute runs are
routine" comment in the concurrency block; the action's default of 45
would have been too short. The action env-wraps every input before it
reaches a shell, so the template-injection-safe contract the old run
block enforced manually is preserved — comment block updated to reflect
that.

**Deliver callback → `bunx fit-eval callback`**

The only remaining direct-CLI call was the post-run callback step:
`node libraries/libeval/bin/fit-eval.js callback`. Switched to `bunx
fit-eval callback`, which is the same form the composite action uses
internally (`fit-eval` → `bunx fit-eval` → `npx @forwardimpact/libeval
fit-eval`). The curl/jq failure-placeholder branch stays — there is no
trace-file to consume in that case, so it's not a callback-CLI concern.

**Dead code in Compose task text**

- `target-type` / `target-number` were echoed to `$GITHUB_OUTPUT`. Their
  only consumer was `TARGET_TYPE` / `TARGET_NUMBER` env vars on the old
  hand-rolled Assess step, which is gone now. Outputs removed.
- The `target_type` shell variable was orphaned inside the step — it
  was only ever echoed to the now-deleted output, never used in any
  context string. Removed entirely.
- `target_number` stays as an internal-only variable; the issue / PR
  number is still substituted into the context strings for the
  facilitator.
- The `issue_comment` branch had `action="route to the best-suited
  agent and ask them to assess the comment and act on it."` set in
  both arms of an inner `if/else`. Pulled out below the `fi`.

## Out of scope

`kata-storyboard.yml`, `kata-coaching.yml`, and `kata-shift.yml` route
through `forwardimpact/kata-agent@v1`, which still declares the legacy
`supervisor-*` / `facilitator-*` inputs and forwards them to
`fit-eval@v1`. Because `fit-eval@v1` no longer accepts those names
(clean break), `lead-profile` values passed to `kata-agent` are
silently dropped before they reach libeval. Fixing this needs a sibling
PR against `forwardimpact/kata-agent` plus a `v1` retag — happy to
follow up.

## Test plan

- [ ] Workflow YAML parses (verified locally with PyYAML).
- [ ] `rg '(supervisor|facilitator)-(model|profile)' .github` returns
      nothing.
- [ ] `rg 'node libraries/libeval/bin' .github` returns nothing.
- [ ] Issue / PR / review trigger fires `kata-dispatch` and the
      facilitator runs to completion.
- [ ] `workflow_dispatch` with a `discussion_id` selects discuss mode
      and forwards `--discussion-id` / `--resume-context` to libeval.
- [ ] `workflow_dispatch` with a `callback_url` and no trace file still
      posts the failure placeholder.


---
_Generated by [Claude Code](https://claude.ai/code/session_015uPYpLW8y8DEwHdpsiNcaS)_