### PR TITLE
docs(prove-changes): rename to lead-profile / lead-model in published guides

### DIFF
--- a/websites/fit/docs/libraries/prove-changes/index.md
+++ b/websites/fit/docs/libraries/prove-changes/index.md
@@ -250,7 +250,7 @@ For a **supervised evaluation** (one agent, one judge):
 ```sh
 npx fit-eval supervise \
   --task-file=evals/refactor-utils/task.md \
-  --supervisor-profile=refactor-judge \
+  --lead-profile=refactor-judge \
   --supervisor-cwd=. \
   --supervisor-allowed-tools=Read,Grep,Bash \
   --agent-cwd=/tmp/refactor-sandbox \
@@ -270,7 +270,7 @@ For a **facilitated session** (one facilitator, N participants):
 ```sh
 npx fit-eval facilitate \
   --task-file=sessions/release-review/task.md \
-  --facilitator-profile=release-facilitator \
+  --lead-profile=release-facilitator \
   --facilitator-cwd=. \
   --agent-profiles=security-engineer,release-engineer,technical-writer \
   --agent-cwd=. \

--- a/websites/fit/docs/libraries/prove-changes/run-benchmark/ci-workflow/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-benchmark/ci-workflow/index.md
@@ -68,7 +68,7 @@ CI-specific inputs that have no CLI equivalent:
 | `output` | `"benchmark-runs"` | Run-output directory |
 | `runs` | `"5"` | Runs per task |
 | `agent-model` | `"claude-sonnet-4-6"` | Claude model for the agent-under-test |
-| `supervisor-model` | `"claude-opus-4-7"` | Claude model for the supervisor |
+| `lead-model` | `"claude-opus-4-7"` | Claude model for the lead role |
 | `judge-model` | `"claude-opus-4-7"` | Claude model for the judge |
 | `agent-profile` | | Agent-under-test profile name |
 | `judge-profile` | | Judge profile name |

--- a/websites/fit/docs/libraries/prove-changes/run-eval/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-eval/index.md
@@ -69,7 +69,7 @@ mask failures.
 ```sh
 npx fit-eval supervise \
   --task-file=evals/refactor-utils/task.md \
-  --supervisor-profile=refactor-judge \
+  --lead-profile=refactor-judge \
   --supervisor-cwd=. \
   --supervisor-allowed-tools=Read,Grep,Bash \
   --agent-cwd=/tmp/refactor-sandbox \
@@ -118,7 +118,7 @@ jobs:
           cp -r . /tmp/sandbox
           npx --yes @forwardimpact/libeval fit-eval supervise \
             --task-file=evals/refactor-utils/task.md \
-            --supervisor-profile=refactor-judge \
+            --lead-profile=refactor-judge \
             --supervisor-cwd=. \
             --supervisor-allowed-tools=Read,Grep,Bash \
             --agent-cwd=/tmp/sandbox \


### PR DESCRIPTION
## Summary

Five stale CLI-flag references in `websites/fit/docs/libraries/prove-changes/`
still taught the pre-discuss libeval option names. They render at
[www.forwardimpact.team/docs/libraries/prove-changes/](https://www.forwardimpact.team/docs/libraries/prove-changes/)
and friends, so an external reader copying these snippets would hit
`unknown option` from `fit-eval` today.

Companion PR:
[forwardimpact/kata-agent#1](https://github.com/forwardimpact/kata-agent/pull/1)
finishes the same rename in the `kata-agent` composite action so
monorepo workflows that pass `lead-profile` through it actually reach
libeval after retag.

## Changes

- `run-eval/index.md` — two `fit-eval supervise --supervisor-profile=…`
  examples (the local-run snippet and the CI-workflow embed) →
  `--lead-profile=…`.
- `prove-changes/index.md` — the supervise example used
  `--supervisor-profile=refactor-judge`; the facilitate example used
  `--facilitator-profile=release-facilitator`. Both →
  `--lead-profile=…`.
- `run-benchmark/ci-workflow/index.md` — the inputs table listed
  `supervisor-model` as a `fit-benchmark` action input.
  `bin/fit-benchmark.js` exposes `lead-model`. Row renamed.

## Scope notes

`--supervisor-cwd`, `--supervisor-allowed-tools`, and `--facilitator-cwd`
were **not** renamed in libeval (only the per-role profile and model were
unified into `lead-*`). Those flags stay verbatim in the docs.

`rg '(supervisor|facilitator)-(model|profile)' websites/ .github/ .claude/`
now returns nothing under live config and docs (the only remaining
matches are inside `specs/` history, which is the immutable design
record and is intentionally left alone).

## Test plan

- [ ] `rg '(supervisor|facilitator)-(model|profile)'` outside `specs/`
      returns nothing.
- [ ] `bunx fit-doc serve --src=websites/fit --watch` renders the three
      affected pages without broken links or partials.


---
_Generated by [Claude Code](https://claude.ai/code/session_015uPYpLW8y8DEwHdpsiNcaS)_