### PR TITLE
fix(hooks): install CLI deps before bootstrap on SessionStart

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash scripts/install-deps.sh"
+          },
+          {
+            "type": "command",
             "command": "bash scripts/bootstrap.sh"
           }
         ]


### PR DESCRIPTION
scripts/bootstrap.sh calls just install, but just isn't pre-installed
in environments like Claude Code on the web. In CI the fit-bootstrap
composite action installs just/gh/apm first; session hooks have no
such wrapper, so the script failed before reaching the wiki sync.

Add scripts/install-deps.sh as a separate SessionStart hook step
before scripts/bootstrap.sh. The two scripts already separate
concerns (CLI tooling vs. workspace setup + wiki sync); the hook
config now reflects that order. Claude Code runs hooks in the same
array sequentially, and install-deps.sh's target ($HOME/.local/bin)
is already on PATH, so just resolves for bootstrap.sh without
further plumbing.