### PR TITLE
Cap subdir CLAUDE.md at 128 lines / 768 words

### DIFF
--- a/COALIGNED.md
+++ b/COALIGNED.md
@@ -210,12 +210,17 @@ enforced by `coaligned instructions` (see `libraries/libcoaligned/`):
 
 | Layer                        | Target      | Loaded           |
 | ---------------------------- | ----------- | ---------------- |
-| L1 CLAUDE.md                 | ≤ 192 lines | auto             |
+| L1 root CLAUDE.md            | ≤ 192 lines | auto             |
+| L1 subdir CLAUDE.md          | ≤ 128 lines | on demand        |
 | L2 CONTRIBUTING.md & JTBD.md | ≤ 256 lines | on demand        |
 | L3 Agent profile             | ≤ 64 lines  | auto (every run) |
 | L4 SKILL.md                  | ≤ 192 lines | auto (per skill) |
 | L5 Skill reference file      | ≤ 128 lines | on demand        |
 | L6 Checklist (per block)     | ≤ 9 items   | auto (per skill) |
 
-L6 is gated by item count, not lines — wrapped-line length is a formatting
-artifact, not cognitive load.
+The root `CLAUDE.md` carries project identity and is auto-loaded every run.
+Subdirectory `CLAUDE.md` files are read on demand when work enters that
+directory — they extend the root with directory-local conventions and must
+stay tight so they layer cleanly. L1 subdir is capped at 128 lines and 768
+words; L6 is gated by item count, not lines — wrapped-line length is a
+formatting artifact, not cognitive load.

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -1,11 +1,28 @@
 # Config
 
 Local runtime configuration. This directory is gitignored — each contributor
-maintains their own `config.json`. The file is read by `libconfig` at startup.
+maintains their own `config.json`, read by `libconfig` at startup.
+
+## Audience
+
+Internal contributors only. External users never reach `config/` — products
+and services ship constructor defaults, and `npx fit-<product> init` writes
+a starter `config.json` on first run.
+
+## Layered consumers
+
+`config.json` is the canonical source. Three layers consume it via
+[`libconfig`](../libraries/libconfig/CLAUDE.md):
+
+| Block            | Factory                     | Consumed by                                  |
+| ---------------- | --------------------------- | -------------------------------------------- |
+| `init`           | `createInitConfig()`        | [services/](../services/CLAUDE.md) (`fit-rc`) |
+| `service.<name>` | `createServiceConfig(name)` | [services/](../services/CLAUDE.md)            |
+| `product.<name>` | `createProductConfig(name)` | [products/](../products/CLAUDE.md)            |
 
 ## `config.json` structure
 
-Three top-level sections, each consumed by a different factory in `libconfig`:
+Three top-level sections, each consumed by a different factory:
 
 ```json
 {
@@ -17,8 +34,7 @@ Three top-level sections, each consumed by a different factory in `libconfig`:
 
 ### `init` — service supervision
 
-Read by `createInitConfig()` → consumed by `fit-rc`. Defines which processes
-the supervisor manages.
+Defines which processes `fit-rc` manages.
 
 ```json
 {
@@ -35,23 +51,13 @@ the supervisor manages.
 ```
 
 Each entry has a `name` and a `command` (the shell command `fit-rc` spawns).
-Non-Node commands that need `.env` variables must source them explicitly (the
-supervisor does not load `.env` — Node services use `libconfig` internally).
+Non-Node commands needing `.env` variables must source them explicitly.
 
 **Declaration order matters.** `start <name>`, `stop <name>`, and
-`restart <name>` operate on the named service and everything after it.
-Services before the target are untouched. List infrastructure (tunnels,
-databases) before the services that depend on them.
+`restart <name>` operate on the target and everything after it. List
+infrastructure (tunnels, databases) before services that depend on them.
 
-Optional entries — add when working on those features:
-
-```json
-{ "name": "mstunnel", "command": "sh -c '. ./.env && exec cloudflared tunnel --url ${SERVICE_MSBRIDGE_URL} --protocol http2'" }
-{ "name": "msbridge", "command": "node -e \"import('@forwardimpact/svcmsbridge/server.js')\"" }
-```
-
-Oneshot services use `"type": "oneshot"` with `up`/`down` instead of `command`.
-`fit-rc start <name>` runs the `up` command; `fit-rc stop <name>` runs `down`:
+Oneshot services use `"type": "oneshot"` with `up`/`down` instead of `command`:
 
 ```json
 {
@@ -62,37 +68,15 @@ Oneshot services use `"type": "oneshot"` with `up`/`down` instead of `command`.
 }
 ```
 
-### `service` — service configuration
+### `service.<name>` — service configuration
 
-Read by `createServiceConfig(name)`. Keyed by service name. Values are merged
-with the service's constructor defaults, then overridden by `SERVICE_{NAME}_{KEY}`
-environment variables from `.env` or the shell.
+Values merge with the service's constructor defaults, then overridden by
+`SERVICE_{NAME}_{KEY}` environment variables from `.env` or the shell.
 
-```json
-{
-  "service": {
-    "mcp": {
-      "systemPrompt": "...",
-      "tools": { ... }
-    }
-  }
-}
-```
+### `product.<name>` — product configuration
 
-### `product` — product configuration
-
-Read by `createProductConfig(name)`. Same merge/override pattern as services,
-with `PRODUCT_{NAME}_{KEY}` environment variables.
-
-```json
-{
-  "product": {
-    "guide": {
-      "systemPrompt": "..."
-    }
-  }
-}
-```
+Same merge/override pattern as services, with `PRODUCT_{NAME}_{KEY}`
+environment variables.
 
 ## `.env`
 
@@ -100,4 +84,3 @@ Merge order: constructor defaults → `config.json` → `.env`. The `.env` file
 is the persistent source of truth — non-credential keys overwrite
 `process.env` unconditionally on load. Credential keys (API keys, tokens) go
 to a private map; shell env wins at read time for credentials only.
-

--- a/libraries/CLAUDE.md
+++ b/libraries/CLAUDE.md
@@ -6,161 +6,86 @@ conventions a library must follow.
 
 ## Audience
 
-The primary audience for library CLIs and their matching skills is **external
-agents and engineers** who have limited context and no direct access to this
+External agents and engineers with limited context and no access to the
 monorepo. They reach a tool via `npx fit-<name>` or by loading the matching
 skill — without ever cloning the repo.
 
-Write `--help` output, skill instructions, and published guides for that reader:
-self-contained, no insider tooling references, no relative paths into
-`libraries/` or `websites/`, and every doc link a fully-qualified public URL.
+Write `--help` output, skill instructions, and published guides for that
+reader: self-contained, no insider tooling references, no relative paths
+into `libraries/` or `websites/`, and every doc link a fully-qualified
+public URL.
 
-## Mandate
+### Mandate
 
-When building a product, service, website, or script, you **must** check the
-[catalog](README.md) before writing a generic capability. If a library here
-covers it, use the library. If not, note that in the commit or plan so the next
-contributor does not re-search.
-
-This rule lives next to the other invariants in
+Before writing a generic capability under products, services, websites, or
+scripts, check the [catalog](README.md). If a library covers it, use it; if
+not, note that in the commit or plan so the next contributor does not
+re-search. This rule lives next to the other invariants in
 [CONTRIBUTING.md](../CONTRIBUTING.md#read-do).
+
+## Configuration
+
+Libraries that need runtime config layer on top of
+[`config/`](../config/CLAUDE.md) via [`libconfig`](libconfig/CLAUDE.md).
+Pick the factory that matches the consumer: `createServiceConfig`,
+`createProductConfig`, `createInitConfig`, `createExtensionConfig`, or
+`createScriptConfig`. `libconfig`, `librc`, and `libsupervise` form the
+config-to-runtime pipeline.
 
 ## `package.json` metadata
 
 Every library carries metadata the catalog generators consume. `description`
-becomes the catalog row in [README.md](README.md). `keywords` are 4–6 lowercase
-tokens; last is always `agent`. `jobs` are Little Hire entries — no `forces` or
-`firedWhen` — generating the jobs block in README.md.
-
-### Worked example: `librpc`
-
-```json
-{
-  "description": "gRPC server and client framework — how agent services talk to each other.",
-  "keywords": ["grpc", "rpc", "server", "client", "agent"],
-  "jobs": [
-    {
-      "user": "Platform Builders",
-      "goal": "Stand Up Typed Services",
-      "trigger": "Starting a new service and reaching for last project's copy-pasted transport boilerplate.",
-      "bigHire": "ship a service endpoint without reimplementing transport.",
-      "littleHire": "call a service without managing connections or retries.",
-      "competesWith": "copy-pasting boilerplate; hand-writing protobuf clients; tolerating the duplication"
-    }
-  ]
-}
-```
-
-After editing, regenerate: `bun run context:fix`.
+becomes the catalog row in [README.md](README.md). `keywords` are 4–6
+lowercase tokens; last is always `agent`. `jobs` are Little Hire entries —
+no `forces` or `firedWhen` — generating the jobs block in README.md. See
+`libraries/librpc/package.json` for a worked example. After editing,
+regenerate: `bun run context:fix`.
 
 ## Invocation context
 
 Libraries that ship a CLI can opt into `InvocationContext` — a frozen
 `{ data, args, options }` contract that libcli produces from argv. Declare
-named positionals with `args: string[]` on the subcommand definition and a
-`handler: (ctx) => …`; call `cli.dispatch(parsed, { data })` to receive a
-context with named args instead of a raw positionals array. See the
-[Every Surface guide](websites/fit/docs/libraries/every-surface/index.md) for
-the full contract and dispatch pattern.
+named positionals with `args: string[]` on the subcommand and a
+`handler: (ctx) => …`; call `cli.dispatch(parsed, { data })`. See the
+[Every Surface guide](https://www.forwardimpact.team/docs/libraries/every-surface/index.md)
+for the full contract.
 
 ## CLIs and progressive documentation
 
 If a library ships a CLI (a `bin/` entry in `package.json`), three artifacts
-must exist together so an external reader lands on the same docs from any entry
-point:
+must exist together so an external reader lands on the same docs from any
+entry point:
 
-- One or more **user guides** — markdown sources under
-  `websites/fit/docs/libraries/<task-slug>/index.md`. A CLI may carry multiple
-  task guides (e.g. `fit-eval` links to `agent-evaluations`,
-  `agent-collaboration`, and `trace-analysis`).
-- The **skill** — `.claude/skills/fit-<name>/SKILL.md`.
-- The **CLI `--help`** — `documentation` entries on the libcli definition, one
+- **User guides** under `websites/fit/docs/libraries/<task-slug>/index.md`.
+  A CLI may carry multiple task guides (e.g. `fit-eval` links to
+  `agent-evaluations`, `agent-collaboration`, `trace-analysis`).
+- **Skill** at `.claude/skills/fit-<name>/SKILL.md`.
+- **CLI `--help`** — `documentation` entries on the libcli definition, one
   per linked guide.
 
 ### Linking rule
 
-Skill and CLI both link each guide using the **fully-qualified URL of the
-markdown source**:
+Skill `## Documentation` list and CLI `documentation` array carry the same
+entries in the same order — same titles, same URLs:
 
 ```
 https://www.forwardimpact.team/docs/libraries/<task-slug>/index.md
 ```
 
-Slugs are task-shaped (e.g. `trace-analysis`, `agent-evaluations`), not
-library-name-shaped — one library may host multiple task slugs and one task slug
-may cut across multiple libraries.
-
-The skill's `## Documentation` list and the CLI's `documentation` array must
-carry the same entries in the same order. When you add, remove, or rename a
-link in one, update the other in the same commit.
-
-The `.md` extension is deliberate. Agents fetch markdown more reliably than
-rendered HTML, and the `.md` URL maps one-to-one to the source file in
-`websites/fit/docs/libraries/<task-slug>/index.md`. Use the same title and URL
-across all three artifacts. Product-task guides (the engineer/leadership
-audience) live under `/docs/products/` instead — see
-[products/CLAUDE.md](../products/CLAUDE.md) for that policy. A library CLI may
-cross-link to a product guide when the task naturally cuts across both
-audiences.
-
-### Worked example: `fit-foo` with one guide `bar`
-
-Guide source: `websites/fit/docs/libraries/bar/index.md`.
-
-Skill (`.claude/skills/fit-foo/SKILL.md`) carries this `## Documentation` block:
-
-```markdown
-## Documentation
-
-- [Bar Guide](https://www.forwardimpact.team/docs/libraries/bar/index.md) —
-  how to use `fit-foo` to do bar.
-```
-
-CLI definition (libcli) carries the same link:
-
-```js
-const cli = createCli({
-  name: "fit-foo",
-  documentation: [
-    {
-      title: "Bar Guide",
-      url: "https://www.forwardimpact.team/docs/libraries/bar/index.md",
-      description: "How to use fit-foo to do bar.",
-    },
-  ],
-});
-```
+Slugs are task-shaped (`trace-analysis`), not library-name-shaped. The `.md`
+extension is deliberate — agents fetch markdown more reliably than rendered
+HTML, and the URL maps one-to-one to the source file. Product-task guides
+(engineer/leadership audience) live under `/docs/products/` instead — see
+[products/CLAUDE.md](../products/CLAUDE.md). A library CLI may cross-link to
+a product guide when the task naturally cuts across both audiences.
 
 ## Adding a library
 
-Same shape as every other library here:
-
 - `package.json` — `@forwardimpact/lib<name>`, ESM, with `description`,
-  `keywords`, and `jobs`.
+  `keywords`, `jobs`.
 - `README.md` — purpose, key exports, one composition example.
 - `src/` — implementation (no tests in `src`).
-- `test/` — `*.test.js` files, runner-independent (`bun:test` and `node:test`
-  both work, see `libharness`).
-- Run `bun run context:fix` to regenerate the catalog and jobs tables. Update
-  any consuming product or service to import from the new library.
-
-## Configuration and supervision libraries
-
-`libconfig`, `librc`, and `libsupervise` form the config-to-runtime pipeline.
-See `libraries/libconfig/CLAUDE.md` and `config/CLAUDE.md`.
-
-## Vocabulary
-
-- **engineering-standard** — the agent-aligned engineering standard data model
-  (disciplines, levels, tracks, capabilities, skills, behaviours, drivers)
-  authored as YAML under [products/map/starter/](../products/map/starter/).
-  Defines what good engineering looks like for the organization.
-- **skill-doc** — the published markdown documentation for a skill or
-  capability, surfaced to agents via `--help` links so they can locate
-  authoritative usage docs without prior context.
-- **MCP** — [Model Context Protocol](https://modelcontextprotocol.io/),
-  Anthropic's standard for exposing tools to LLM agents. `libmcp` bridges gRPC
-  services into MCP tools.
-- **Plan-Do-Study-Act** — the Toyota-Kata improvement loop the Kata Agent Team
-  uses: agents plan, ship, study their traces, and act on findings. See
-  [KATA.md](../KATA.md).
+- `test/` — `*.test.js` files, runner-independent (`bun:test` and
+  `node:test` both work, see `libharness`).
+- Run `bun run context:fix` to regenerate the catalog and jobs tables.
+  Update any consuming product or service to import from the new library.

--- a/libraries/libbridge/CLAUDE.md
+++ b/libraries/libbridge/CLAUDE.md
@@ -7,9 +7,8 @@ Channel-agnostic primitives shared by `services/ghbridge` and `services/msbridge
 - **No channel SDKs.** Never import `botbuilder`, `@octokit/*`, or any other
   channel-specific SDK from this package. Channel adapters own the SDKs.
 - **No GraphQL or REST strings.** Never compose `addDiscussionComment` or
-  `addReaction` mutations, or any channel-specific URL beyond
-  `https://api.github.com/repos/${repo}/actions/workflows/...` (the workflow
-  dispatch endpoint, which is GitHub-Actions-shaped not channel-shaped).
+  `addReaction` mutations, or any channel-specific URL beyond the
+  workflow-dispatch endpoint (GitHub-Actions-shaped, not channel-shaped).
 - **Caller-injected storage.** `DiscussionContextStore` takes a
   `StorageInterface` from the host service — no implicit `LocalStorage`
   construction inside this package.
@@ -18,92 +17,51 @@ Channel-agnostic primitives shared by `services/ghbridge` and `services/msbridge
 
 ## Bridge contract
 
-A "bridge" is a service that relays human messages from a channel
-(GitHub Discussions, Microsoft Teams, …) to the Kata dispatch workflow
-and posts the workflow's reply back. Every bridge composes the same
-libbridge primitives in the same order.
-
-To add a new bridge `xbridge`, implement four things:
+A "bridge" relays human messages from a channel (GitHub Discussions,
+Microsoft Teams, …) to the Kata dispatch workflow and posts the workflow's
+reply back. Every bridge composes the same libbridge primitives in the same
+order. To add `xbridge`, implement four pieces:
 
 1. **Channel intake** — `onWebhook: (c) => Response`. Verify the inbound
-   request is authentic (signature, OAuth, whatever the channel uses) and
-   extract `(threadId, text, ackTarget)`. For channels with an
+   request is authentic and extract `(threadId, text, ackTarget)`. For
    SDK-driven intake (e.g. Bot Framework's `adapter.process`), wrap the
-   SDK inside `services/xbridge/src/<channel>.js` so `index.js` never
-   sees the express/HTTP shim.
+   SDK in `services/xbridge/src/<channel>.js` so `index.js` never sees the
+   express/HTTP shim.
 
-2. **Reaction adapter** — `{ add(target) -> reactionId | null, remove(reactionId, target) -> void }`.
-   The channel's "I received your message" reaction. The `target` shape
-   is opaque to libbridge — pick whatever your channel needs (a GraphQL
-   subject id, an activity reference, a Slack `(channel, ts)` tuple).
+2. **Reaction adapter** —
+   `{ add(target) -> reactionId | null, remove(reactionId, target) -> void }`.
+   The channel's "I received your message" reaction. The `target` shape is
+   opaque to libbridge.
 
-3. **Typing adapter** *(optional)* — `{ send(target, text) -> void }`.
-   Only if your channel benefits from filler "Crafting..." messages
-   while the workflow runs. `Acknowledgement` owns the verb pool and
-   cadence; the adapter only delivers a string.
+3. **Typing adapter** *(optional)* — `{ send(target, text) -> void }`. Only
+   if your channel benefits from filler "Crafting..." messages while the
+   workflow runs. `Acknowledgement` owns the verb pool and cadence.
 
 4. **Reply handler** — `handleReply(ctx, payload, meta) -> void`. Posts
-   `payload.replies` to the channel, appends them to `ctx.history`, and
-   applies the verdict (`adjourned` / `failed` / `recessed`). Throw
-   `new CallbackHandlerError(status, message)` to short-circuit with a
-   specific HTTP status (e.g. 410 if the conversation reference is gone).
-   If the bridge supports `recessed`, plug in `ResumeScheduler` (below)
-   and call `enterRecess` / `cancelRecess` from the verdict branches —
-   no hand-rolled timer code.
+   `payload.replies`, appends them to `ctx.history`, and applies the
+   verdict (`adjourned` / `failed` / `recessed`). Throw
+   `CallbackHandlerError(status, message)` to short-circuit. If the bridge
+   supports `recessed`, plug in `ResumeScheduler` and call
+   `enterRecess` / `cancelRecess` from the verdict branches.
 
-Once those four pieces exist, the rest is composition:
+Once those exist, composition is mechanical — instantiate
+`Acknowledgement` with your adapters, construct a `Dispatcher` over a
+`CallbackRegistry` and `DiscussionContextStore`, wire `createBridgeServer`
+with `onWebhook` and `createCallbackHandler({ channel, handleReply, ...})`.
+See `services/ghbridge/src/index.js` for the canonical wiring.
 
-```js
-import {
-  Acknowledgement, CallbackRegistry, DiscussionContextStore, Dispatcher,
-  RateLimiter, createBridgeServer, createCallbackHandler,
-  newDiscussionContext, normalizeBaseUrl,
-} from "@forwardimpact/libbridge";
-
-const ack = new Acknowledgement({
-  reactionAdapter,         // your channel
-  typingAdapter,           // optional
-});
-const dispatcher = new Dispatcher({
-  callbacks: new CallbackRegistry(),
-  ack,
-  store: new DiscussionContextStore(storage),
-  callbackBaseUrl: normalizeBaseUrl(config.callback_base_url),
-  workflowFile: "kata-dispatch.yml",
-  githubRepo: config.github_repo,
-  getGithubToken: () => config.ghToken(),
-});
-const onCallback = createCallbackHandler({
-  channel: "xchannel",
-  callbacks, ack, store, logger, tracer,
-  spanName: "XBridge.HandleCallback",
-  loadDiscussionId: (meta) => meta.meta.threadId,
-  handleReply,             // your channel
-});
-const bridge = createBridgeServer({
-  config, logger, tracer,
-  webhookPath: "/api/messages",
-  onWebhook,               // your channel
-  onCallback,
-});
-```
-
-Inside your channel's intake, the only call you make for dispatch is:
+Inside channel intake, the only dispatch call is:
 
 ```js
 await dispatcher.dispatch({
-  ctx,
-  prompt: buildPrompt(text, ctx.history),
-  ackTarget,               // your channel-shaped target
-  historyText: text,
-  callbackMeta: { threadId },
+  ctx, prompt: buildPrompt(text, ctx.history),
+  ackTarget, historyText: text, callbackMeta: { threadId },
 });
 ```
 
-`Dispatcher.dispatch` owns the rest: register the callback token, start
-the acknowledgement, fire the workflow, append history, push the
-dispatch timestamp, flush the store, and on failure roll back the
-acknowledgement and the callback registration.
+`Dispatcher.dispatch` owns the rest: register the callback token, start the
+acknowledgement, fire the workflow, append history, push the dispatch
+timestamp, flush the store, and on failure roll back.
 
 ## Configuration
 
@@ -114,55 +72,36 @@ README for the channel-specific surface.
 ## Suspend/resume
 
 When a workflow returns `verdict: "recessed"` with a `trigger`, the
-conversation waits — either for N more responses, an elapsed duration,
-or "either". `ResumeScheduler` owns that lifecycle for both bridges:
+conversation waits — for N more responses, an elapsed duration, or either.
+`ResumeScheduler` owns that lifecycle:
 
 ```js
 const resume = new ResumeScheduler({
-  dispatcher,
-  store,
-  logger,
+  dispatcher, store, logger,
   buildCallbackMeta: (ctx) => ({ discussionId: ctx.discussion_id }),
   buildResumeInputs: (ctx) => ({ discussionId: ctx.discussion_id }),
 });
-
-// service start:
-await resume.rearm();
-// service stop:
-resume.clear();
-
-// in the "new message in existing thread" handler:
+await resume.rearm();                         // service start
+resume.clear();                               // service stop
 const { freshDispatchAllowed } = await resume.processInbound(ctx);
-if (freshDispatchAllowed) { /* rate-check + dispatcher.dispatch(...) */ }
-
-// in handleReply:
-switch (payload.verdict) {
-  case "recessed":
-    resume.enterRecess(ctx, meta.correlationId, payload.trigger);
-    break;
-  case "adjourned":
-  case "failed":
-    resume.cancelRecess(ctx, meta.correlationId);
-    break;
-}
+resume.enterRecess(ctx, correlationId, trigger);
+resume.cancelRecess(ctx, correlationId);
 ```
 
-The two `build*` callbacks are the only per-channel inputs. msbridge
-overrides `buildCallbackMeta` to `{ threadId: ctx.discussion_id }` to
-match its `loadDiscussionId` lens; everything else is shared.
+The two `build*` callbacks are the only per-channel inputs. `msbridge`
+overrides `buildCallbackMeta` to `{ threadId: ctx.discussion_id }` to match
+its `loadDiscussionId` lens.
 
 ## What lives where
 
-- `Acknowledgement` — reaction + optional typing-verb lifecycle.
-- `CallbackRegistry` — in-memory token → correlation map with TTL.
-- `DiscussionContextStore` — persisted `(channel, discussion_id)` state.
-- `Dispatcher` — the dispatch dance.
-- `createCallbackHandler` — the inbound-callback skeleton.
-- `RateLimiter` — per-thread dispatch rate cap.
-- `ResumeScheduler` — suspend/resume lifecycle (channel-agnostic).
-- `ElapsedScheduler` — chunked-setTimeout primitive used by `ResumeScheduler`.
-- `createBridgeServer` — Hono + `@hono/node-server` wiring.
-- `validateCallbackPayload` — lenient kata-dispatch payload validator.
-- `newDiscussionContext` — canonical record-shape factory.
-- `evaluateTrigger`, `parseIsoDuration` — recessed-resume trigger helpers.
-- `dispatchWorkflow` — the one channel-specific URL (`workflow_dispatch`).
+| Export | Role |
+|---|---|
+| `Acknowledgement` | reaction + optional typing-verb lifecycle |
+| `CallbackRegistry` | token → correlation map with TTL |
+| `DiscussionContextStore` | persisted `(channel, discussion_id)` state |
+| `Dispatcher`, `dispatchWorkflow` | the dispatch dance + workflow URL |
+| `createCallbackHandler`, `validateCallbackPayload` | inbound-callback skeleton + payload validator |
+| `RateLimiter` | per-thread dispatch rate cap |
+| `ResumeScheduler`, `ElapsedScheduler` | suspend/resume lifecycle + chunked-setTimeout |
+| `createBridgeServer` | Hono + `@hono/node-server` wiring |
+| `newDiscussionContext`, `evaluateTrigger`, `parseIsoDuration` | record factory + trigger helpers |

--- a/libraries/libcoaligned/src/instructions.js
+++ b/libraries/libcoaligned/src/instructions.js
@@ -102,15 +102,25 @@ async function findSkillReferences(root, skillDirs) {
 async function buildLayers(root) {
   const claudeDirs = await findByName(root, ".claude", "dir");
   const skillDirs = await findSkillDirs(root, claudeDirs);
+  const allClaude = await findByName(root, "CLAUDE.md", "file");
+  const rootClaude = allClaude.filter((p) => p === "CLAUDE.md");
+  const subdirClaude = allClaude.filter((p) => p !== "CLAUDE.md");
   return {
     skillDirs,
     layers: [
       {
         id: "L1",
-        name: "CLAUDE.md",
+        name: "root CLAUDE.md",
         maxLines: 192,
         maxWords: 896,
-        files: await findByName(root, "CLAUDE.md", "file"),
+        files: rootClaude,
+      },
+      {
+        id: "L1",
+        name: "subdir CLAUDE.md",
+        maxLines: 128,
+        maxWords: 768,
+        files: subdirClaude,
       },
       {
         id: "L2",

--- a/libraries/libcoaligned/test/instructions.test.js
+++ b/libraries/libcoaligned/test/instructions.test.js
@@ -23,15 +23,39 @@ describe("checkInstructions", () => {
     }
   });
 
-  test("flags an oversized CLAUDE.md against L1 line cap", async () => {
+  test("flags an oversized root CLAUDE.md against L1 line cap", async () => {
     const root = await makeRepo();
     try {
       const oversize = "line\n".repeat(200);
       await writeFile(join(root, "CLAUDE.md"), oversize);
       const errors = await checkInstructions({ root });
       assert.ok(
-        errors.some((e) => e.includes("CLAUDE.md") && e.includes("L1")),
-        `expected an L1 CLAUDE.md error, got: ${JSON.stringify(errors)}`,
+        errors.some(
+          (e) => e.includes("CLAUDE.md") && e.includes("L1 root CLAUDE.md"),
+        ),
+        `expected an L1 root CLAUDE.md error, got: ${JSON.stringify(errors)}`,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("flags an oversized subdir CLAUDE.md at the tighter 128-line cap", async () => {
+    const root = await makeRepo();
+    try {
+      await mkdir(join(root, "products"), { recursive: true });
+      // 140 lines exceeds the 128-line subdir cap but stays under the 192
+      // root cap — proves the tighter rule applies to subdirectories only.
+      const oversize = "line\n".repeat(140);
+      await writeFile(join(root, "products", "CLAUDE.md"), oversize);
+      const errors = await checkInstructions({ root });
+      assert.ok(
+        errors.some(
+          (e) =>
+            e.includes("products/CLAUDE.md") &&
+            e.includes("L1 subdir CLAUDE.md"),
+        ),
+        `expected an L1 subdir CLAUDE.md error, got: ${JSON.stringify(errors)}`,
       );
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/products/CLAUDE.md
+++ b/products/CLAUDE.md
@@ -1,171 +1,103 @@
 # Products
 
-Conventions when working under `products/`. Products are the seven end-user
-applications (Map, Pathway, Guide, Landmark, Summit, Outpost, Gear) consumed
-via `npm install` and `npx fit-<product>`. Gear is a meta-package that
-re-exports all service and library CLIs as dependencies.
+Conventions when working under `products/`. The catalog and jobs live in
+[README.md](README.md); this file documents the metadata, rules, and
+conventions a product must follow. Products are the seven end-user
+applications (Map, Pathway, Guide, Landmark, Summit, Outpost, Gear)
+consumed via `npm install` and `npx fit-<product>`. Gear is a meta-package
+re-exporting all service and library CLIs.
 
 ## Audience
 
-The primary audience for product CLIs and their matching skills is **external
-engineers, leaders, and agents** who have limited context and no direct access
-to this monorepo. They reach a tool via `npx fit-<product>` or by loading the
-matching skill — without ever cloning the repo.
+External engineers, leaders, and agents with limited context and no access
+to the monorepo. They reach a tool via `npx fit-<product>` or by loading
+the matching skill — without ever cloning the repo.
 
-Write `--help` output, skill instructions, and published guides for that reader:
-self-contained, no insider tooling references, no relative paths into
-`products/` or `websites/`, and every doc link a fully-qualified public URL.
+Write `--help` output, skill instructions, and published guides for that
+reader: self-contained, no insider tooling references, no relative paths
+into `products/` or `websites/`, and every doc link a fully-qualified
+public URL.
 
 ## Configuration
 
-Products that need runtime config use `createProductConfig(name)`, which merges
-constructor defaults → `config.json` `product.<name>` block → `PRODUCT_{NAME}_*`
-env vars. See [`config/CLAUDE.md`](../config/CLAUDE.md) for the file format
-and merge order.
+Products that need runtime config use `createProductConfig(name)`, which
+merges constructor defaults → `config.json` `product.<name>` block →
+`PRODUCT_{NAME}_*` env vars. See [`config/CLAUDE.md`](../config/CLAUDE.md)
+for the file format and merge order, and
+[`libraries/libconfig/CLAUDE.md`](../libraries/libconfig/CLAUDE.md) for the
+factory.
 
 ## `package.json` metadata
 
-Every product carries metadata the catalog generators consume. `description`
-becomes the catalog row in [README.md](README.md). `jobs` are Big Hire entries —
-with `forces` and `firedWhen` — generating [JTBD.md](../JTBD.md) and the jobs
-block in README.md.
-
-### Worked example: `fit-map`
-
-```json
-{
-  "description": "Data product for agent-aligned engineering standards, consumed by AI agents and engineers",
-  "jobs": [
-    {
-      "user": "Engineering Leaders",
-      "goal": "Define the Engineering Standard",
-      "trigger": "A promotion decision stalls because two managers disagree on what 'senior' means — neither can point to a written definition.",
-      "bigHire": "turn 'good engineering' into an operational definition the organization trusts and follows.",
-      "littleHire": "update the standard knowing structural mistakes get caught before they ship.",
-      "competesWith": "tribal knowledge; borrowed frameworks; per-manager intuition; tolerating the ambiguity",
-      "forces": {
-        "push": "Inconsistent expectations produce contested promotions.",
-        "pull": "A shared definition that makes quality visible and discussable.",
-        "habit": "Each manager carries a private mental model of what 'good' means.",
-        "anxiety": "Getting definitions wrong feels worse than having none."
-      },
-      "firedWhen": "definitions drift from practice; or a reorg removes the mandate to maintain them."
-    }
-  ]
-}
-```
-
-After editing, regenerate: `bun run context:fix`.
+Every product carries metadata the catalog generators consume.
+`description` becomes the catalog row in [README.md](README.md). `jobs` are
+Big Hire entries — with `forces` and `firedWhen` — generating
+[JTBD.md](../JTBD.md) and the jobs block in README.md. See
+`products/map/package.json` for a worked example. After editing,
+regenerate: `bun run context:fix`.
 
 `products/<name>/` metadata-only (e.g., Kata) — `"private": true`,
-`description` + `jobs`, no `bin/` or CLI — exempt from § Audience's
+`description` + `jobs`, no `bin/` or CLI — is exempt from § Audience's
 `npx fit-<product>` claim.
 
 ## Invocation context
 
-Products with both a web UI and a CLI can share handler logic through
-`InvocationContext` — a frozen `{ data, args, options }` contract that libui's
-`createBoundRouter` produces from the URL and libcli's `dispatch()` produces
-from argv. Use `defineRoute` to bind a URL pattern to its CLI command and graph
-entity in one descriptor; the shared presenter receives the same context shape
-from both surfaces. See the
-[Every Surface guide](websites/fit/docs/libraries/every-surface/index.md) for
-the full contract.
+Products with both a web UI and a CLI share handler logic through
+`InvocationContext` — a frozen `{ data, args, options }` contract that
+libui's `createBoundRouter` produces from the URL and libcli's `dispatch()`
+produces from argv. Use `defineRoute` to bind a URL pattern to its CLI
+command and graph entity in one descriptor. See the
+[Every Surface guide](https://www.forwardimpact.team/docs/libraries/every-surface/index.md).
 
 ## CLIs and progressive documentation
 
-Every product ships a CLI (a `bin/` entry in `package.json`). Three artifacts
-must exist together so an external reader lands on the same docs from any entry
-point:
+Every product ships a CLI (a `bin/` entry in `package.json`). Three
+artifacts must exist together so an external reader lands on the same docs
+from any entry point:
 
-- One or more **user guides** — markdown sources under
-  `websites/fit/docs/products/<task-slug>/index.md`. A product may carry
-  multiple task guides (e.g. `fit-pathway` links to `authoring-standards`,
-  `agent-teams`, and `career-paths`).
-- The **skill** — `.claude/skills/fit-<product>/SKILL.md`.
-- The **CLI `--help`** — `documentation` entries on the libcli definition, one
+- **User guides** under `websites/fit/docs/products/<task-slug>/index.md`.
+  A product may carry multiple task guides (e.g. `fit-pathway` links to
+  `authoring-standards`, `agent-teams`, `career-paths`).
+- **Skill** at `.claude/skills/fit-<product>/SKILL.md`.
+- **CLI `--help`** — `documentation` entries on the libcli definition, one
   per linked guide.
 
 ### Linking rule
 
-Skill and CLI both link each guide using the **fully-qualified URL of the
-markdown source**:
+Skill `## Documentation` list and CLI `documentation` array carry the same
+entries in the same order — same titles, same URLs:
 
 ```
 https://www.forwardimpact.team/docs/products/<task-slug>/index.md
 ```
 
-Slugs are task-shaped (e.g. `authoring-standards`, `team-capability`), not
-product-name-shaped — one product may host multiple task slugs and one task slug
-may cut across multiple products (e.g. `authoring-standards` is linked by both
-`fit-map` and `fit-pathway`).
-
-The skill's `## Documentation` list and the CLI's `documentation` array must
-carry the same entries in the same order. When you add, remove, or rename a
-link in one, update the other in the same commit.
-
-The `.md` extension is deliberate. Agents fetch markdown more reliably than
-rendered HTML, and the `.md` URL maps one-to-one to the source file in
-`websites/fit/docs/products/<task-slug>/index.md`. Use the same title and URL
-across all three artifacts. Library-task guides (the builder/agent audience)
+Slugs are task-shaped (`authoring-standards`), not product-name-shaped —
+one product may host multiple slugs and one slug may cut across multiple
+products. The `.md` extension is deliberate — agents fetch markdown more
+reliably than rendered HTML. Library-task guides (builder/agent audience)
 live under `/docs/libraries/` instead — see
-[libraries/CLAUDE.md](../libraries/CLAUDE.md) for that policy. A product CLI may
-cross-link to a library guide when the task naturally cuts across both
-audiences.
-
-### Worked example: `fit-foo` with one guide `bar`
-
-Guide source: `websites/fit/docs/products/bar/index.md`.
-
-Skill (`.claude/skills/fit-foo/SKILL.md`) carries this `## Documentation` block:
-
-```markdown
-## Documentation
-
-- [Bar Guide](https://www.forwardimpact.team/docs/products/bar/index.md) —
-  how to use `fit-foo` to do bar.
-```
-
-CLI definition (libcli) carries the same link:
-
-```js
-const cli = createCli({
-  name: "fit-foo",
-  documentation: [
-    {
-      title: "Bar Guide",
-      url: "https://www.forwardimpact.team/docs/products/bar/index.md",
-      description: "How to use fit-foo to do bar.",
-    },
-  ],
-});
-```
+[libraries/CLAUDE.md](../libraries/CLAUDE.md). A product CLI may cross-link
+to a library guide when the task cuts across both audiences.
 
 ## Workspace dependencies
 
 Any `@forwardimpact/*` package imported by a file under `products/<name>/`
 must appear in that product's `package.json` — in `dependencies`,
-`devDependencies`, `peerDependencies`, or `optionalDependencies`. Imports
-at runtime go in `dependencies`; test-only imports may go in
-`devDependencies`.
+`devDependencies`, `peerDependencies`, or `optionalDependencies`.
 
-The monorepo's workspace hoist lets every product resolve every
-workspace package from the root `node_modules/`, masking missing
-declarations in `bun install` and `bun test`. The gap surfaces only when
-a downstream consumer runs `npx fit-<product>` against a clean machine
-and hits `Cannot find package '@forwardimpact/<name>'` before any product
-code executes (spec 1070).
+The monorepo's workspace hoist masks missing declarations in `bun install`
+and `bun test`; the gap only surfaces when a downstream consumer runs
+`npx fit-<product>` against a clean machine. The
+[`check-workspace-imports`](../scripts/check-workspace-imports.mjs) guard
+enforces the rule on every PR through `bun run context`.
 
-The `check-workspace-imports` guard
-([`scripts/check-workspace-imports.mjs`](../scripts/check-workspace-imports.mjs))
-enforces the rule on every PR through `bun run context`. If you hit a
-diagnostic of the form
+## Adding a product
 
-```
-products/<name>/<path>:<line>: imports "@forwardimpact/<pkg>" but it is not declared in products/<name>/package.json
-```
-
-add `@forwardimpact/<pkg>` to the importing product's manifest. The
-guard scans static `import`/`export` declarations and dynamic
-`await import("…")` calls; it skips self-imports (a package referencing
-its own name resolves via the package's own `exports` field).
+- `package.json` — `@forwardimpact/fit-<name>` with `description` and Big
+  Hire `jobs`.
+- `bin/fit-<name>.js` — CLI entry (`#!/usr/bin/env node`).
+- `src/` — implementation. `test/` — `*.test.js` files.
+- Add `product.<name>` block to `config/config.json` if runtime config is
+  needed.
+- Run `bun run context:fix` to regenerate the catalog, jobs tables, and
+  JTBD.md.

--- a/products/outpost/templates/CLAUDE.md
+++ b/products/outpost/templates/CLAUDE.md
@@ -36,19 +36,16 @@ destructive actions.
 
 ## Dependencies
 
-- **ripgrep** (`rg`) — fast knowledge graph searches. Install:
+- **ripgrep** (`rg`) — fast knowledge graph searches.
   `brew install ripgrep`.
 
 ## Workspace Layout
 
-Everything is relative to this root:
-
 ```
 ./
-├── knowledge/         # The knowledge graph (Obsidian-compatible)
-│   ├── People/ Organizations/ Projects/ Topics/
-│   ├── Candidates/ Goals/ Priorities/ Conditions/ Roles/
-│   └── Tasks/ Weeklies/
+├── knowledge/         # Obsidian-compatible graph: People/ Organizations/
+│   Projects/ Topics/ Candidates/ Goals/ Priorities/ Conditions/ Roles/
+│   Tasks/ Weeklies/
 ├── .claude/skills/    # Auto-discovered skill files
 ├── drafts/            # Email drafts (draft-emails skill)
 ├── USER.md            # Your identity — gitignored
@@ -77,16 +74,14 @@ Each agent writes `~/.cache/fit/outpost/state/{agent}_triage.md` per wake. The
 
 ## Cache Directory (`~/.cache/fit/outpost/`)
 
-Synced data and runtime state live outside the KB to keep it clean — only parsed
-knowledge, notes, and drafts live here. Top-level subdirs:
+Synced data and runtime state live outside the KB. Top-level subdirs:
 
 - `apple_mail/` — Mail threads as `.md` (plus `attachments/`)
 - `apple_calendar/` — Calendar events as `.json`
 - `teams_chat/` — Teams 1:1 chats as `.md`
-- `head-hunter/` — head-hunter agent memory (cursor, failures, seen, prospects,
-  log)
-- `state/` — runtime state: per-source last-sync timestamps, processed-file
-  index, and `{agent}_triage.md` per agent
+- `head-hunter/` — head-hunter agent memory
+- `state/` — per-source last-sync timestamps, processed-file index, and
+  `{agent}_triage.md` per agent
 
 ## Knowledge Graph
 
@@ -129,6 +124,5 @@ generation).
 
 ## Working Outside This Directory
 
-You have full filesystem access (macOS). For tasks outside this knowledge base
-(organizing Desktop, finding files in Downloads, etc.), use shell commands
-directly.
+You have full filesystem access (macOS). For tasks outside this KB
+(organizing Desktop, finding files in Downloads), use shell commands directly.

--- a/services/CLAUDE.md
+++ b/services/CLAUDE.md
@@ -1,60 +1,71 @@
 # Services
 
-Conventions when working under `services/`. Services are the internal
-microservices that back products — they are never consumed directly by external
-users. External access goes through product CLIs and the MCP server; individual
-gRPC services are implementation details.
+Conventions when working under `services/`. The catalog and jobs live in
+[README.md](README.md); this file documents the metadata, rules, and
+conventions a service must follow.
 
 ## Audience
 
-The primary audience is **internal contributors** working on service backends.
-Unlike products and libraries, services are not published to npm for direct
-consumption. External users reach service functionality indirectly through
-product CLIs and the MCP server.
+Internal contributors working on service backends. Services are not
+published to npm — external users reach service functionality indirectly
+through product CLIs and the MCP server.
 
-## Mandate
+### Mandate
 
 When building a product feature that requires graph queries, vector search,
 pathway derivation, trace collection, or MCP tool exposure, use the
-corresponding service. Do not embed service-level logic in products.
-
-This rule lives next to the other invariants in
+corresponding service. Do not embed service-level logic in products. This
+rule lives next to the other invariants in
 [CONTRIBUTING.md](../CONTRIBUTING.md#read-do).
-
-## Architecture
-
-Most services expose a gRPC interface defined in `proto/`. Exceptions: `mcp`
-exposes an HTTP/SSE interface using `@modelcontextprotocol/sdk` and delegates to
-the gRPC services as a client; `msbridge` and `ghbridge` expose HTTP
-interfaces using `libbridge` (Hono + `@hono/node-server`) — `msbridge`
-adds `botbuilder` for the Bot Framework, `ghbridge` adds `@octokit/*`
-for App auth, webhook verification, and GraphQL.
-
-Each service follows the same structure:
-
-- **`server.js`** — entry point. Creates config, logger, tracer, service
-  instance, and server, then calls `server.start()`.
-- **`index.js`** — service implementation. Exports the service class (gRPC) or
-  factory function (MCP).
-- **`proto/*.proto`** — gRPC service definition (all services except `mcp`).
-- **`test/`** — tests, run with `bun test test/*.test.js`.
-
-## `server.js` conventions
-
-Every `server.js` follows the same sequence:
-
-1. `createServiceConfig(name)` — load config.
-2. `createLogger(name)` and `createTracer(name)` — set up observability.
-3. Initialize domain dependencies (indexes, clients, data loaders).
-4. Construct service instance, wrap in `Server`, call `start()`.
-
-The shebang is `#!/usr/bin/env node`. The `bin` entry in `package.json` is
-`fit-svc<name>` (e.g. `fit-svcgraph`).
 
 ## Configuration
 
 `createServiceConfig(name)` merges constructor defaults → `config.json`
-`service.<name>` → `.env` `SERVICE_{NAME}_*`.
+`service.<name>` block → `.env` `SERVICE_{NAME}_*`. See
+[`config/CLAUDE.md`](../config/CLAUDE.md) for the file format and merge
+order, and [`libraries/libconfig/CLAUDE.md`](../libraries/libconfig/CLAUDE.md)
+for the factory.
+
+## Architecture
+
+Most services expose a gRPC interface defined in `proto/`. Exceptions:
+`mcp` exposes an HTTP/SSE interface using `@modelcontextprotocol/sdk` and
+delegates to gRPC services as a client; `msbridge` and `ghbridge` expose
+HTTP interfaces via `libbridge` (Hono + `@hono/node-server`) — `msbridge`
+adds `botbuilder` for the Bot Framework, `ghbridge` adds `@octokit/*` for
+App auth, webhook verification, and GraphQL.
+
+Each service follows the same structure:
+
+- **`server.js`** — entry point. Creates config, logger, tracer, service
+  instance, and server, then calls `server.start()`. Shebang is
+  `#!/usr/bin/env node`; the `bin` entry is `fit-svc<name>`.
+- **`index.js`** — service implementation. Exports the service class
+  (gRPC) or factory function (MCP).
+- **`proto/*.proto`** — gRPC service definition (all services except `mcp`).
+- **`test/`** — tests, run with `bun test test/*.test.js`.
+
+### `server.js` sequence
+
+1. `createServiceConfig(name)` — load config.
+2. `createLogger(name)` and `createTracer(name)` — observability.
+3. Initialize domain dependencies (indexes, clients, data loaders).
+4. Construct service instance, wrap in `Server`, call `start()`.
+
+## `package.json` metadata
+
+Every service carries metadata the catalog generators consume. `description`
+becomes the catalog row in [README.md](README.md). `keywords` are 4–6
+lowercase tokens; last is always `agent`. `jobs` are Little Hire entries —
+no `forces` or `firedWhen` — generating the jobs block in README.md. See
+`services/svcgraph/package.json` for a worked example. After editing,
+regenerate: `bun run context:fix`.
+
+## No external documentation
+
+Services have no published skills, no `--help` linking rules, and no
+fully-qualified documentation URLs. They are internal to the monorepo. Each
+service carries its own `README.md` for contributor context.
 
 ## Running services
 
@@ -70,59 +81,18 @@ bunx fit-rc restart <name>   # restart <name> and everything after it
 node --watch services/<name>/server.js   # single service without fit-rc
 ```
 
-## `package.json` metadata
-
-Every service carries metadata the catalog generators consume. `description`
-becomes the catalog row in [README.md](README.md). `keywords` are 4–6 lowercase
-tokens; last is always `agent`. `jobs` are Little Hire entries — no `forces` or
-`firedWhen` — generating the jobs block in README.md.
-
-### Worked example: `svcgraph`
-
-```json
-{
-  "description": "Simple RDF knowledge graph over gRPC for products.",
-  "keywords": ["graph", "rdf", "knowledge", "grpc", "agent"],
-  "jobs": [
-    {
-      "user": "Platform Builders",
-      "goal": "Ground Agents in Context",
-      "trigger": "Needing to know how two concepts relate and realizing the answer is scattered across files no one wants to join by hand.",
-      "bigHire": "traverse a knowledge graph from a product without standing up my own store.",
-      "littleHire": "answer relationship questions without writing join logic.",
-      "competesWith": "ad-hoc joins across flat files; embedding a triple store in each product; skipping the relationship question entirely"
-    }
-  ]
-}
-```
-
-After editing, regenerate: `bun run context:fix`.
-
 ## Proto definitions
 
-gRPC services define their interface in `proto/<name>.proto`. After editing a
-proto file, regenerate bindings:
-
-```sh
-just codegen
-```
+gRPC services define their interface in `proto/<name>.proto`. After editing
+a proto file, regenerate bindings with `just codegen`.
 
 ## Adding a service
 
-Same shape as every other service here:
-
 - `package.json` — `@forwardimpact/svc<name>`, ESM, with `description`,
-  `keywords`, and `jobs`.
-- `server.js` — entry point following the standard bootstrap sequence.
+  `keywords`, `jobs`.
+- `server.js` — entry point following the bootstrap sequence above.
 - `index.js` — service implementation.
 - `proto/<name>.proto` — gRPC service definition (unless MCP-only).
 - `test/` — `*.test.js` files.
 - Add an entry to `config/config.json` so `fit-rc` can manage it.
-- Run `bun run context:fix` to regenerate the catalog and jobs tables. Update
-  any consuming product to import from the new service.
-
-## No external documentation
-
-Services have no published skills, no `--help` linking rules, and no
-fully-qualified documentation URLs. They are internal to the monorepo. Each
-service carries its own `README.md` for contributor context.
+- Run `bun run context:fix` to regenerate the catalog and jobs tables.

--- a/websites/CLAUDE.md
+++ b/websites/CLAUDE.md
@@ -25,28 +25,24 @@ bunx fit-doc serve --src=websites/monorepo --watch
 Every page is a directory containing `index.md`. No other `.md` filenames.
 
 - **Frontmatter** — `title` (rendered as H1) and `description` (meta) are
-  required. Optional: `toc: false`, `layout: product|home`,
-  `hero: { image, alt, title, subtitle, cta }`.
-- **Headings** — body headings start at `##` (the build system renders H1 from
+  required. Optional: `toc: false`, `layout: product|home`, `hero: {…}`.
+- **Headings** — body headings start at `##` (the build renders H1 from
   `title`; a manual `# Title` produces a duplicate).
-- **Links** — absolute directory paths (`/docs/products/agent-teams/`, not
-  relative, not `index.md`). External links use full URLs.
-- **Code blocks** — always specify a language tag (`sh`, `yaml`, `json`,
-  `mermaid`, etc.).
-- **Card grids use content partials.** Hub page cards are
-  `<!-- part:card:relative-path -->` markers that resolve to the target page's
-  frontmatter `title` and `description` at build time. The build fails if a
-  partial references a nonexistent page. Hand-written `<a>` cards are only used
-  for external links or same-page anchors.
-- **Hand-written links are not checked.** Partials validate their targets, but
-  inline markdown links are not verified at build time.
-- **Cross-links** — every non-hub page ends with a `## What's next` section.
-  Cards use content partials only (`<!-- part:card:path -->`), never markdown
-  links. Maximum four cards. When a page has a `## Verify` section,
+- **Links** — absolute directory paths (`/docs/products/agent-teams/`),
+  never relative, never `index.md`. External links use full URLs.
+- **Code blocks** — always specify a language tag (`sh`, `yaml`, `mermaid`).
+- **Card grids use content partials.** `<!-- part:card:relative-path -->`
+  markers resolve to the target page's `title` and `description` at build
+  time; the build fails if the target is missing. Hand-written `<a>` cards
+  are only for external links or same-page anchors.
+- **Hand-written markdown links are not checked.** Only partials validate
+  their targets.
+- **Cross-links** — every non-hub page ends with `## What's next` using
+  partials only (max four cards). When a page has `## Verify`,
   `## What's next` follows it. Card targets follow JTBD structure: Big Hire
-  guides link to their Little Hire children; Little Hire guides link back to
-  the parent Big Hire and sibling Little Hires; Getting Started pages link to
-  the product page and primary guide.
+  guides link to Little Hire children; Little Hire guides link back to the
+  parent Big Hire and siblings; Getting Started pages link to the product
+  page and primary guide.
 
 ## Page Types
 
@@ -69,23 +65,9 @@ Product pages (`/map/`, `/pathway/`, etc.) follow a consistent structure:
 
 Collection pages use `toc: false` and a grid of content partials to link to
 children. Cards are organized under `##` job headings with a persona label.
-
-```html
-<div class="grid">
-<!-- part:card:agent-teams -->
-<!-- part:card:agent-teams/organizational-context -->
-</div>
-```
-
-Each `<!-- part:card:path -->` resolves to an `<a>` with the target page's
-`title` and `description` from frontmatter. Paths are relative to the current
-page's directory — `agent-teams` for a sibling, `../docs/libraries` for a
-cross-tree reference. The build fails if a target page does not exist, so stale
-card references are caught automatically.
-
-Hand-written `<a>` cards are still used for external links (GitHub URLs) and
-same-page anchors (`href="#section"`). See `gear/index.md` and
-`docs/internals/kata/index.md` for examples.
+Partial paths are relative to the page's directory — `agent-teams` for a
+sibling, `../docs/libraries` for a cross-tree reference. See `gear/index.md`
+and `docs/internals/kata/index.md` for examples.
 
 ### Getting Started Pages
 


### PR DESCRIPTION
## Summary

Subdirectory `CLAUDE.md` files were drifting toward the same length as the root identity doc. This PR splits L1 into two layers so subdir docs get a wall against further growth, and aligns the four config-layering files on a shared skeleton.

- **Split L1 caps** in `libraries/libcoaligned`:
  - Root `CLAUDE.md` keeps the 192/896 cap (unchanged).
  - Subdir `CLAUDE.md` is capped at **128 lines / 768 words** — the current median for lines, ~P75 for words.
- **Rewrote five oversized files** to fit the new cap: `libraries/`, `libraries/libbridge/`, `products/`, `products/outpost/templates/`, `websites/`.
- **Aligned `{config,libraries,services,products}/CLAUDE.md` on a shared skeleton**: Audience → Configuration → `package.json` metadata → layer-specific sections → Adding. Each file cross-references the others through its Configuration section, so the layering around `config.json` consumption is explicit.

## Sizes after rewrite

| File | Lines | Words | Cap |
|---|---:|---:|---|
| `CLAUDE.md` (root) | 183 | 819 | 192 / 896 |
| `config/CLAUDE.md` | 86 | 342 | 128 / 768 |
| `libraries/CLAUDE.md` | 91 | 496 | 128 / 768 |
| `services/CLAUDE.md` | 98 | 496 | 128 / 768 |
| `products/CLAUDE.md` | 103 | 549 | 128 / 768 |
| `libraries/libbridge/CLAUDE.md` | 107 | 572 | 128 / 768 |
| `websites/CLAUDE.md` | 121 | 710 | 128 / 768 |
| `products/outpost/templates/CLAUDE.md` | 128 | 708 | 128 / 768 |

Four other subdir `CLAUDE.md` files were already well under the new cap and were left untouched.

## Test plan

- [x] `bunx coaligned` — no errors
- [x] `bun test libraries/libcoaligned/test/` — 11/11 pass (added a test that proves the tighter cap applies only to subdirectories)
- [x] `bun run format` — clean
- [x] Root `CLAUDE.md` content unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01ESBDfcorWiGuzyRiRaodss)_