### PR TITLE
feat(agents): hoist on-boot read set above ## Assess (Option A)

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -28,13 +28,18 @@ Your calm is not indifference — it's the quiet intensity of someone who has se
 what happens when teams stop improving. Sign every GitHub comment and PR body
 with `— Improvement Coach 📊`.
 
+## Every Run
+
+Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
+`Bash: fit-wiki boot --agent improvement-coach`. Triage inbox if non-empty;
+`fit-wiki claim` before opening any PR. Contract:
+[memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
+
 ## Assess
 
-Survey domain state, then choose the highest-priority action:
+_Skip when handed a specific task._ Survey domain state, then choose the
+highest-priority action:
 
-0. **[On-boot read set](.claude/agents/references/memory-protocol.md#on-boot-read-set)**
-   — `Read wiki/MEMORY.md` then `Bash: fit-wiki boot`. Routing per
-   [On-Boot Routing](.claude/agents/references/memory-protocol.md#on-boot-routing).
 1. **Agents due for coaching?** — Check coaching log in
    `wiki/improvement-coach.md` and recent runs
    (`gh run list --workflow=kata-coaching.yml --limit=10`). Dispatch

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -30,13 +30,18 @@ management, it's matchmaking. When priorities conflict, you're transparent about
 trade-offs rather than pretending everything fits. Sign every GitHub comment and
 PR body with `— Product Manager 🌱`.
 
+## Every Run
+
+Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
+`Bash: fit-wiki boot --agent product-manager`. Triage inbox if non-empty;
+`fit-wiki claim` before opening any PR. Contract:
+[memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
+
 ## Assess
 
-Survey all open work items, then act on the highest-priority bucket:
+_Skip when handed a specific task._ Survey all open work items, then act on
+the highest-priority bucket:
 
-0. **[On-boot read set](.claude/agents/references/memory-protocol.md#on-boot-read-set)**
-   — `Read wiki/MEMORY.md` then `Bash: fit-wiki boot`. Routing per
-   [On-Boot Routing](.claude/agents/references/memory-protocol.md#on-boot-routing).
 1. **Survey.** `gh pr list --search 'spec(' --state open` +
    `gh issue list --search "-label:experiment -label:obstacle"` +
    `wiki/STATUS.md`. Buckets: **P1** open spec PRs whose STATUS row is still

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -26,13 +26,18 @@ checking the next pipeline. Reassuring to others because you've already worried
 enough for everyone. Sign every GitHub comment and PR body with
 `— Release Engineer 🚀`.
 
+## Every Run
+
+Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
+`Bash: fit-wiki boot --agent release-engineer`. Triage inbox if non-empty;
+`fit-wiki claim` before opening any PR. Contract:
+[memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
+
 ## Assess
 
-Survey domain state, then choose the highest-priority action:
+_Skip when handed a specific task._ Survey domain state, then choose the
+highest-priority action:
 
-0. **[On-boot read set](.claude/agents/references/memory-protocol.md#on-boot-read-set)**
-   — `Read wiki/MEMORY.md` then `Bash: fit-wiki boot`. Routing per
-   [On-Boot Routing](.claude/agents/references/memory-protocol.md#on-boot-routing).
 1. **Main branch CI failing from trivial issues?** -- Repair CI directly (push
    `bun run check:fix` to `main`; you are the **only** agent allowed to push to
    `main`, and only for mechanical fixes -- if failures persist after

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -28,13 +28,18 @@ security as much as you do, and you know fear doesn't teach. The occasional
 gallows humor keeps things from getting too heavy. Sign every GitHub comment and
 PR body with `— Security Engineer 🔒`.
 
+## Every Run
+
+Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
+`Bash: fit-wiki boot --agent security-engineer`. Triage inbox if non-empty;
+`fit-wiki claim` before opening any PR. Contract:
+[memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
+
 ## Assess
 
-Survey domain state, then choose the highest-priority action:
+_Skip when handed a specific task._ Survey domain state, then choose the
+highest-priority action:
 
-0. **[On-boot read set](.claude/agents/references/memory-protocol.md#on-boot-read-set)**
-   — `Read wiki/MEMORY.md` then `Bash: fit-wiki boot`. Routing per
-   [On-Boot Routing](.claude/agents/references/memory-protocol.md#on-boot-routing).
 1. **Critical vulnerabilities?** -- Patch immediately (`kata-security-update`;
    check: `npm audit`, GitHub security advisories)
 2. **Open Dependabot PRs?** -- Triage and merge or close

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -28,16 +28,21 @@ microservices and lived to tell the tale. Never harsh, but allergic to
 hand-waving — if it can't be drawn on a whiteboard, it's not a design. Sign
 every GitHub comment and PR body with `— Staff Engineer 🛠️`.
 
+## Every Run
+
+Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
+`Bash: fit-wiki boot --agent staff-engineer`. Triage inbox if non-empty;
+`fit-wiki claim` before opening any PR. Contract:
+[memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
+
 ## Assess
 
-Run `git fetch origin main` on every phase boundary, then route from
-`origin/main` only. A STATUS row at `{phase} approved` on an open PR — even
-one you just authored — does not advance routing; only merge of the prior
-phase's PR puts the artifact on `main`. Pick the highest-priority action:
+_Skip when handed a specific task._ Run `git fetch origin main` on every
+phase boundary, then route from `origin/main` only. A STATUS row at
+`{phase} approved` on an open PR — even one you just authored — does not
+advance routing; only merge of the prior phase's PR puts the artifact on
+`main`. Pick the highest-priority action:
 
-0. **[On-boot read set](.claude/agents/references/memory-protocol.md#on-boot-read-set)**
-   — `Read wiki/MEMORY.md` then `Bash: fit-wiki boot`. Routing per
-   [On-Boot Routing](.claude/agents/references/memory-protocol.md#on-boot-routing).
 1. **Merged specs without designs?** -- `kata-design` (specs/NNN/ where
    `spec.md` is on `origin/main` but `design-a.md` is not)
 2. **Merged designs without plans?** -- `kata-plan` (specs/NNN/ where

--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -29,13 +29,18 @@ Occasionally wry about the state of documentation in the industry, but never
 bitter — you're on a mission, and the mission is comprehension. Sign every
 GitHub comment and PR body with `— Technical Writer 📝`.
 
+## Every Run
+
+Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
+`Bash: fit-wiki boot --agent technical-writer`. Triage inbox if non-empty;
+`fit-wiki claim` before opening any PR. Contract:
+[memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
+
 ## Assess
 
-Survey domain state, then choose the highest-priority action:
+_Skip when handed a specific task._ Survey domain state, then choose the
+highest-priority action:
 
-0. **[On-boot read set](.claude/agents/references/memory-protocol.md#on-boot-read-set)**
-   — `Read wiki/MEMORY.md` then `Bash: fit-wiki boot`. Routing per
-   [On-Boot Routing](.claude/agents/references/memory-protocol.md#on-boot-routing).
 1. **Stale or inaccurate cross-agent observations?** -- `kata-wiki-curate`
    (check agent summaries for unacknowledged observations or stale data)
 2. **Documentation topic due for review?** -- Review one topic in depth

--- a/COALIGNED.md
+++ b/COALIGNED.md
@@ -213,7 +213,7 @@ enforced by `coaligned instructions` (see `libraries/libcoaligned/`):
 | L1 root CLAUDE.md            | ≤ 192 lines | auto             |
 | L1 subdir CLAUDE.md          | ≤ 128 lines | on demand        |
 | L2 CONTRIBUTING.md & JTBD.md | ≤ 256 lines | on demand        |
-| L3 Agent profile             | ≤ 64 lines  | auto (every run) |
+| L3 Agent profile             | ≤ 72 lines  | auto (every run) |
 | L4 SKILL.md                  | ≤ 192 lines | auto (per skill) |
 | L5 Skill reference file      | ≤ 128 lines | on demand        |
 | L6 Checklist (per block)     | ≤ 9 items   | auto (per skill) |

--- a/libraries/libcoaligned/src/instructions.js
+++ b/libraries/libcoaligned/src/instructions.js
@@ -140,8 +140,8 @@ async function buildLayers(root) {
       {
         id: "L3",
         name: "agent profile",
-        maxLines: 64,
-        maxWords: 384,
+        maxLines: 72,
+        maxWords: 448,
         files: await findAgentProfiles(root, claudeDirs),
       },
       {


### PR DESCRIPTION
## Summary

Restructure all 6 agent profiles to address the React-mode Step 0 skip
observed in the post-1060 memory-protocol traces. Each profile now opens a
new `## Every Run` section *above* `## Assess` containing the on-boot read
set, with a one-line italic scope hint on `## Assess` for the symmetric
case. L3 agent-profile cap bumps to absorb the new section.

## Why

Spec 1060 inverted the on-boot contract from "find files, read files, write
files" to "call `fit-wiki` subcommands." It cited F5 (Step 0 skipped in
React-mode: 4 of 4 traces skipped the declared Step 0 because the Ask scope
eclipsed it) and committed to closing it via clearer Step 0 wording inside
each agent's `## Assess` section.

Trace analysis of the 7 days after PR #1032 landed told a more nuanced
story. Across 40 facilitator/agent sessions in 13 runs:

| Workflow type | `fit-wiki boot` adoption | MEMORY.md read | Own summary read |
|---|---:|---:|---:|
| Pre-redesign baseline (2 runs, 6 sessions) | 0% (didn't exist) | 67% | 50% |
| Post-redesign scheduled (kata-storyboard/coaching/shift; 4 runs, 13 sessions) | **69%** | **85%** | **69%** |
| Post-redesign React-mode dispatch (7 runs, 21 sessions) | **32%** | **53%** | **32%** |

The scheduled-vs-React-mode cleavage is the load-bearing finding. Scheduled
workflows traverse `## Assess` top-down (no externally-handed task), so
Step 0 at the top of that list fires. React-mode dispatches arrive with a
specific task in the payload — the agent reads the `## Assess` header as
scope-conditional ("do this *when surveying*") and skips the whole block,
Step 0 along with it.

In the cleanest post-redesign compliant trace (`staff-engineer` on run
`26342247028`), the boot digest returned `claims: []`, and a Cross-Cutting
Priorities entry the agent read out loud says:

> "Root cause for repeat: `fit-wiki boot` digest does not surface in-flight
> open PRs by own bot identity for the target spec…"

The agent then immediately ran `gh pr list --search 'design/1220'` — the
exact workaround the priority entry documents. So even when Step 0 was
followed, the redesign's downstream primitives (`fit-wiki claim`,
`log decision`, `inbox promote`) had **0 adoption** across all 35
post-redesign sessions. The wiki itself self-reports four post-redesign
collisions in 48h on `wiki/technical-writer.md:92,94` and proposes
"`fit-wiki claim` **mandatory** at the start of each `kata-documentation`
cycle (currently optional per coverage map ownership)."

## What

**Each agent profile** (6 files in `.claude/agents/`):

```diff
 ## Voice

 [unchanged voice paragraph]

+## Every Run
+
+Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
+`Bash: fit-wiki boot --agent {agent-name}`. Triage inbox if non-empty;
+`fit-wiki claim` before opening any PR. Contract:
+[memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
+
 ## Assess

-Survey domain state, then choose the highest-priority action:
+_Skip when handed a specific task._ Survey domain state, then choose the
+highest-priority action:

-0. **[On-boot read set]** — `Read wiki/MEMORY.md` then `Bash: fit-wiki boot`.
-   Routing per [On-Boot Routing]...
 1. **[domain priority]** ...
```

### Wording and framing decisions

| Choice | Why |
|---|---|
| Section header **`## Every Run`** | Reads as universal ("every time you run, do this"). Considered and rejected: `## On Boot` (can be misread as conditional — "I'm not booting, I'm mid-task"); `## First Steps` (too generic). |
| Lead phrase **`Before any task — handed or self-picked —`** | Names both dispatch modes explicitly so React-mode agents recognize themselves in the scope. Pre-edit, the `## Assess` framing implicitly excluded the React-mode case. |
| Section position **between `## Voice` and `## Assess`** | The agent reads top-down: identity → voice → ritual → routing → constraints. Above Assess so the on-boot block is encountered before any conditional section. |
| Concrete agent name **`--agent staff-engineer`** | Copy-paste-runnable. Considered: `--agent <self>` placeholder for uniformity, rejected because one less substitution to get wrong outweighs cross-profile diff cleanliness. |
| `## Assess` header **kept unchanged** | Historical wiki references like `step 1 bun audit clean` (see `wiki/security-engineer-2026-W21.md`) reference priorities by their existing numbers. Step 0 removed, steps 1–N preserved exactly. |
| Italic scope hint **`_Skip when handed a specific task._`** | Symmetric instruction on the routing side. Italic marks it as meta-instruction, not part of the routing logic. Inlined with the existing preamble to save a line. |
| Imperative **inbox triage + `fit-wiki claim`** in profile | Trace evidence: zero adoption of write-side primitives. The redesign closes F8/F18 on the *memory side*; the *behavior side* needs the profile to name the claim imperative, since the protocol alone hasn't moved usage. |

### L3 cap bump

The redesign adds ~5–7 lines / ~24 words per profile — the first net add to
agent profiles since commit `274dcfb9` (the libcoaligned extraction in
PR #780). The old 64-line / 384-word cap had no room for a new section.

- `libraries/libcoaligned/src/instructions.js` — `maxLines: 64 → 72`, `maxWords: 384 → 448`
- `COALIGNED.md` — table row `≤ 64 lines` → `≤ 72 lines`

Ratio preserved at ~6 words/line. All 6 profiles fit under the new cap with
room to spare (62–68 lines, max 408 words).

## Test plan

- [x] `bun run check` — passes (format / lint / jsdoc / invariants / context)
- [x] `bunx coaligned instructions` — exits 0; all 6 profiles within new cap
- [x] `bun test` in `libraries/libcoaligned` — 11/11 pass
- [ ] After merge: monitor next 5–10 React-mode dispatch traces for
      `fit-wiki boot` adoption rate vs the 32% pre-change baseline
- [ ] After merge: monitor `wiki/MEMORY.md ## Active Claims` table for first
      organic `fit-wiki claim` row (currently 0 across all 35 post-1060
      sessions)

## Out of scope

- Write-side gate ("PR opened by self without an Active Claim row")
  remains documented but unenforced — separate spec for write-side
  enforcement.
- Pre-cutover weekly logs over the 500-line cap (cutover 2026-W23 / Mon
  2026-06-01) — operational migration #1031 follow-up.
- `agent-react` workflow dispatch-side enforcement (injecting `fit-wiki
  boot` output as a tool result before the agent's first turn) — would be
  the durable structural fix (Option C in the design exploration) but is a
  bigger change.

— Staff Engineer 🛠️


---
_Generated by [Claude Code](https://claude.ai/code/session_019nmM5KGCYbLxcJ9cDGbf9g)_