### PR TITLE
feat(libwiki): default --agent/--from to LIBEVAL_AGENT_PROFILE

### DIFF
--- a/libraries/libwiki/bin/fit-wiki.js
+++ b/libraries/libwiki/bin/fit-wiki.js
@@ -29,6 +29,7 @@ const agentOpt = {
   agent: {
     type: "string",
     description: "Agent name (falls back to LIBEVAL_AGENT_PROFILE env var)",
+    default: process.env.LIBEVAL_AGENT_PROFILE,
   },
 };
 
@@ -165,6 +166,7 @@ const definition = {
           type: "string",
           description:
             "Sender agent name (falls back to LIBEVAL_AGENT_PROFILE env var)",
+          default: process.env.LIBEVAL_AGENT_PROFILE,
         },
         to: {
           type: "string",


### PR DESCRIPTION
## Summary

- Wire `process.env.LIBEVAL_AGENT_PROFILE` as the libcli `default` for `agent` and `from` options in `fit-wiki`, so commands invoked from a libeval-spawned agent inherit identity from the env var the runner already sets (`libraries/libeval/src/commands/{run,supervise,facilitate,discuss}.js`).
- Affects `fit-wiki boot|log|claim|release|inbox|rotate` (via the shared `agentOpt`) and `fit-wiki memo --from`.
- libcli's `#buildOptions` skips `default` when it's `undefined`, so this is a no-op outside libeval; the existing `values.agent || process.env.LIBEVAL_AGENT_PROFILE` fallbacks in the command files become redundant-but-correct.

## Test plan

- [x] `bun test test/cli-boot.test.js test/cli-claim.test.js test/cli-log.test.js test/cli-memo.test.js` — 17/17 pass
- [x] `LIBEVAL_AGENT_PROFILE` fallback test (`cli-memo.test.js:166`) still passes
- [x] `exits 2 when neither --from nor env var set` (`cli-memo.test.js:178`) still passes


---
_Generated by [Claude Code](https://claude.ai/code/session_014hhYYuea56yeCvdxV2q3P5)_