### PR TITLE
fix(libwiki): drop stale cutover + 500-line refs from audit help and derivation comment

### DIFF
--- a/libraries/libwiki/bin/fit-wiki.js
+++ b/libraries/libwiki/bin/fit-wiki.js
@@ -143,7 +143,7 @@ const definition = {
     {
       name: "audit",
       description:
-        "Audit the wiki against the memory-protocol contract (500-line cap; cutover 2026-W23)",
+        "Audit the wiki against the memory-protocol contract (line and word budgets)",
       options: {
         ...wikiRootOpt,
         ...todayOpt,

--- a/libraries/libwiki/src/constants.js
+++ b/libraries/libwiki/src/constants.js
@@ -14,8 +14,8 @@ export const PRIORITY_INDEX_TABLE_HEADER =
 export const DECISION_HEADING = "### Decision";
 
 // Cap derivation: ≤2.5% of a 1M-token context window = 25k tokens;
-// ≈42 tokens/line empirical proxy → ~500 lines. See spec 1060
-// design-a.md § Decision area 2 for the full anchor.
+// converted via ≈42 tokens/line empirical proxy, then 64-aligned.
+// See spec 1060 design-a.md § Decision area 2 for the full anchor.
 export const WEEKLY_LOG_LINE_BUDGET = 496;
 export const SUMMARY_LINE_BUDGET = 72;
 export const WEEKLY_LOG_WORD_BUDGET = 6400;


### PR DESCRIPTION
## Summary
- `bin/fit-wiki.js` — audit `--help` still claimed a "500-line cap; cutover 2026-W23". Both were removed in #1175 when audit moved to line and word budgets with no cutover gate. Reword to `(line and word budgets)`.
- `src/constants.js` — cap-derivation comment named "~500 lines" alongside `WEEKLY_LOG_LINE_BUDGET`, requiring two places to stay in sync. Drop the hardcoded result; describe the derivation steps (token budget → tokens/line proxy → 64-aligned) and let the constant be the sole source of truth.

## Test plan
- [x] `bun test libraries/libwiki/test/cli-audit.test.js` — 7/7 pass
- [x] `fit-wiki --help` shows the updated audit description

https://claude.ai/code/session_01Md6hz1xn29AoyeKY4Uiwxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Md6hz1xn29AoyeKY4Uiwxm)_