### PR TITLE
refactor(libwiki): remove audit grace-window mechanism

### DIFF
--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -82,11 +82,8 @@ Operator escape; seals the current file even when it is under the cap.
 ### `audit` — Memory-protocol gate
 
 ```sh
-npx fit-wiki audit [--format json] [--legacy-only]
+npx fit-wiki audit [--format json]
 ```
-
-`FIT_WIKI_AUDIT_GRACE_UNTIL=<ISO date>` converts summary and decision-block
-failures to warnings until the window closes.
 
 ### `memo` — Cross-team memo
 

--- a/libraries/libwiki/README.md
+++ b/libraries/libwiki/README.md
@@ -94,8 +94,7 @@ on any failure. Text output: `WARN ...` and `FAIL ...` lines plus a
 `RESULT: ...` trailer. JSON output:
 
 ```json
-{ "result": "pass|fail", "failures": [...], "warnings": [...],
-  "grace_active": false, "grace_until": null }
+{ "result": "pass|fail", "failures": [...], "warnings": [...] }
 ```
 
 Each finding carries a stable `id` for filtering. The catalogue lives in

--- a/libraries/libwiki/src/audit/engine.js
+++ b/libraries/libwiki/src/audit/engine.js
@@ -13,11 +13,10 @@ function applyRule(rule, subject, ctx) {
   if (rule.when && !rule.when(subject, ctx)) return [];
   const result = rule.check(subject, ctx);
   if (result == null) return [];
-  const level = rule.graceDowngrade && ctx.grace ? "warn" : rule.severity;
   const items = Array.isArray(result) ? result : [result];
   return items.map((item) => ({
     id: rule.id,
-    level,
+    level: rule.severity,
     path: subject.path ?? null,
     message: rule.message(subject, item, ctx),
   }));

--- a/libraries/libwiki/src/audit/format.js
+++ b/libraries/libwiki/src/audit/format.js
@@ -22,8 +22,8 @@ export function emitText(findings) {
   return lines.join("\n") + "\n";
 }
 
-/** Render findings as a JSON document with grace-window metadata from ctx. */
-export function emitJson(findings, ctx) {
+/** Render findings as a JSON document. */
+export function emitJson(findings) {
   const { failures, warnings } = partition(findings);
   return (
     JSON.stringify(
@@ -31,8 +31,6 @@ export function emitJson(findings, ctx) {
         result: failures.length === 0 ? "pass" : "fail",
         failures,
         warnings,
-        grace_active: ctx.grace,
-        grace_until: ctx.graceUntil,
       },
       null,
       2,

--- a/libraries/libwiki/src/audit/rules.js
+++ b/libraries/libwiki/src/audit/rules.js
@@ -212,7 +212,6 @@ export const RULES = [
     id: "summary.line-budget",
     scope: "summary",
     severity: "fail",
-    graceDowngrade: true,
     check: lineBudget(SUMMARY_LINE_BUDGET),
     message: (s, r) =>
       `budget: ${s.path} has ${r.value} lines (limit ${SUMMARY_LINE_BUDGET})`,
@@ -221,7 +220,6 @@ export const RULES = [
     id: "summary.word-budget",
     scope: "summary",
     severity: "fail",
-    graceDowngrade: true,
     check: wordBudget(SUMMARY_WORD_BUDGET),
     message: (s, r) =>
       `budget: ${s.path} has ${r.value} words (limit ${SUMMARY_WORD_BUDGET})`,
@@ -272,7 +270,6 @@ export const RULES = [
     id: "decision-block.heading-within-5",
     scope: "weekly-log-main",
     severity: "fail",
-    graceDowngrade: true,
     check: decisionWithin5({
       entryRe: /^## \d{4}-\d{2}-\d{2}(?:[\s(].*)?$/,
       requiredLine: DECISION_HEADING,

--- a/libraries/libwiki/src/audit/scopes.js
+++ b/libraries/libwiki/src/audit/scopes.js
@@ -173,7 +173,7 @@ export function resolveScope(scopeKey, ctx) {
 }
 
 /** Build the audit context: classifies and loads every wiki file once. */
-export function buildContext({ wikiRoot, today, graceUntil }) {
+export function buildContext({ wikiRoot, today }) {
   const subjects = {
     summary: [],
     "weekly-log-main": [],
@@ -187,8 +187,6 @@ export function buildContext({ wikiRoot, today, graceUntil }) {
   return {
     wikiRoot,
     today,
-    grace: Boolean(graceUntil && graceUntil >= today),
-    graceUntil: graceUntil ?? null,
     subjects,
     memory: loadMemory(wikiRoot),
     storyboard: loadStoryboard(wikiRoot, today),

--- a/libraries/libwiki/src/commands/audit.js
+++ b/libraries/libwiki/src/commands/audit.js
@@ -12,13 +12,12 @@ export function runAuditCommand(values, _args, _cli) {
   const projectRoot = finder.findProjectRoot(process.cwd());
   const wikiRoot = values["wiki-root"] || path.join(projectRoot, "wiki");
   const today = values.today || new Date().toISOString().slice(0, 10);
-  const graceUntil = process.env.FIT_WIKI_AUDIT_GRACE_UNTIL || null;
 
-  const ctx = buildContext({ wikiRoot, today, graceUntil });
+  const ctx = buildContext({ wikiRoot, today });
   const findings = runAudit(RULES, ctx);
 
   process.stdout.write(
-    values.format === "json" ? emitJson(findings, ctx) : emitText(findings),
+    values.format === "json" ? emitJson(findings) : emitText(findings),
   );
 
   if (findings.some((f) => f.level === "fail")) process.exit(1);

--- a/libraries/libwiki/test/audit-cli.test.js
+++ b/libraries/libwiki/test/audit-cli.test.js
@@ -88,8 +88,6 @@ describe("fit-wiki audit CLI", () => {
     assert.equal(result.result, "pass");
     assert.deepEqual(result.failures, []);
     assert.deepEqual(result.warnings, []);
-    assert.equal(result.grace_active, false);
-    assert.equal(result.grace_until, null);
   });
 
   test("over-budget summary: JSON failure with id, path, exit 1", () => {
@@ -119,28 +117,6 @@ describe("fit-wiki audit CLI", () => {
       lineBudget.message,
       /staff-engineer\.md has \d+ lines \(limit 72\)/,
     );
-  });
-
-  test("grace window: summary line budget downgrades to warn, RESULT pass", () => {
-    seedCleanWiki(wikiRoot);
-    const big = Array(100).fill("x").join("\n");
-    writeFileSync(
-      join(wikiRoot, "staff-engineer.md"),
-      `# Staff Engineer — Summary\n\n**Last run**: nothing.\n\n## Message Inbox\n\n<!-- memo:inbox -->\n\n${big}\n`,
-    );
-    const out = run(
-      dir,
-      ["audit", "--today", "2026-05-24", "--format", "json"],
-      { FIT_WIKI_AUDIT_GRACE_UNTIL: "2099-01-01" },
-    );
-    const result = JSON.parse(out);
-    assert.equal(result.result, "pass");
-    assert.equal(result.grace_active, true);
-    assert.equal(result.grace_until, "2099-01-01");
-    const lineBudget = result.warnings.find(
-      (w) => w.id === "summary.line-budget",
-    );
-    assert.ok(lineBudget, "expected line-budget downgraded to warn");
   });
 
   test("text emitter: WARN before FAIL, RESULT trailer", () => {

--- a/libraries/libwiki/test/audit-engine.test.js
+++ b/libraries/libwiki/test/audit-engine.test.js
@@ -107,8 +107,8 @@ describe("runAudit", () => {
     );
   };
 
-  const audit = (today = "2026-05-24", graceUntil = null) =>
-    runAudit(RULES, buildContext({ wikiRoot: wiki, today, graceUntil }));
+  const audit = (today = "2026-05-24") =>
+    runAudit(RULES, buildContext({ wikiRoot: wiki, today }));
 
   const idsOf = (findings) => findings.map((f) => f.id);
 
@@ -126,19 +126,6 @@ describe("runAudit", () => {
       `# Staff Engineer — Summary\n\n**Last run**: nothing.\n\n## Message Inbox\n\n<!-- memo:inbox -->\n\n${big}\n`,
     );
     assert.ok(idsOf(audit()).includes("summary.line-budget"));
-  });
-
-  test("grace window downgrades summary.line-budget to warn", () => {
-    seedClean();
-    const big = Array(100).fill("x").join("\n");
-    writeFileSync(
-      join(wiki, "staff-engineer.md"),
-      `# Staff Engineer — Summary\n\n**Last run**: nothing.\n\n## Message Inbox\n\n<!-- memo:inbox -->\n\n${big}\n`,
-    );
-    const lineBudget = audit("2026-05-24", "2099-01-01").find(
-      (f) => f.id === "summary.line-budget",
-    );
-    assert.equal(lineBudget.level, "warn");
   });
 
   test("summary first H2 mismatch fires summary.first-h2-inbox", () => {

--- a/scripts/spec-1060-migrate-wiki.mjs
+++ b/scripts/spec-1060-migrate-wiki.mjs
@@ -177,8 +177,7 @@ function compactSummary(filePath, dryRun) {
   const lines = countLines(text);
   if (lines <= SUMMARY_LINE_BUDGET) return null;
   // Conservative compaction: do nothing automatically — print a warning so the
-  // human reviewer can decide what to trim. The audit grace window covers
-  // these until manual compaction lands. (The plan called for an automatic
+  // human reviewer can decide what to trim. (The plan called for an automatic
   // move-to-current-week pass; in a sandbox where the wiki is a separate repo
   // and we cannot guarantee the live week file, we surface the violation
   // instead and exit cleanly.)


### PR DESCRIPTION
Drop the FIT_WIKI_AUDIT_GRACE_UNTIL env var, graceDowngrade rule flag,
and grace_active/grace_until JSON fields from `fit-wiki audit`. The CI
workflow already stopped setting the env var; this removes the dead
runtime path, the three rules that opted into downgrade, the SKILL.md
and README references, and a stale comment in the spec-1060 migration
script.