### PR TITLE
design(1300): svcdiscussion — shared store for both bridges

### DIFF
--- a/libraries/libbridge/src/origin-index.js
+++ b/libraries/libbridge/src/origin-index.js
@@ -20,7 +20,10 @@ export class OriginIndex extends BufferedIndex {
    * @param {string} [options.indexKey]
    * @param {number} [options.ttlMs] - Eviction window (default 24h)
    */
-  constructor(storage, { indexKey = "origins.jsonl", ttlMs = DEFAULT_TTL_MS } = {}) {
+  constructor(
+    storage,
+    { indexKey = "origins.jsonl", ttlMs = DEFAULT_TTL_MS } = {},
+  ) {
     super(storage, indexKey, {
       flush_interval: 1_000,
       max_buffer_size: 100,

--- a/libraries/libeval/src/discusser.js
+++ b/libraries/libeval/src/discusser.js
@@ -256,7 +256,6 @@ export function createDiscusser({
     ];
   }
 
-
   let discusser;
   const leadServer = createDiscussLeadToolServer(ctx);
 
@@ -292,8 +291,13 @@ export function createDiscusser({
   });
 
   const defaultDisallowed = [
-    "Agent", "Task", "TaskOutput", "TaskStop",
-    "Bash", "Write", "Edit",
+    "Agent",
+    "Task",
+    "TaskOutput",
+    "TaskStop",
+    "Bash",
+    "Write",
+    "Edit",
   ];
   const leadRunner = createAgentRunner({
     cwd: resolvedLeadCwd,

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -158,8 +158,13 @@ export function createFacilitator({
   });
 
   const defaultDisallowed = [
-    "Agent", "Task", "TaskOutput", "TaskStop",
-    "Bash", "Write", "Edit",
+    "Agent",
+    "Task",
+    "TaskOutput",
+    "TaskStop",
+    "Bash",
+    "Write",
+    "Edit",
   ];
   const disallowedTools = facilitatorDisallowedTools
     ? [...new Set([...defaultDisallowed, ...facilitatorDisallowedTools])]

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -185,8 +185,13 @@ export function createSupervisor({
   });
 
   const defaultDisallowed = [
-    "Agent", "Task", "TaskOutput", "TaskStop",
-    "Bash", "Write", "Edit",
+    "Agent",
+    "Task",
+    "TaskOutput",
+    "TaskStop",
+    "Bash",
+    "Write",
+    "Edit",
   ];
   const disallowedTools = supervisorDisallowedTools
     ? [...new Set([...defaultDisallowed, ...supervisorDisallowedTools])]

--- a/libraries/libeval/test/discuss-tools.test.js
+++ b/libraries/libeval/test/discuss-tools.test.js
@@ -30,15 +30,16 @@ describe("DiscussTools handlers", () => {
     assert.strictEqual(ctx.rfcs[0].thread_id, "GD_kw_test");
     assert.strictEqual(ctx.rfcs[0].channel, "github-discussions");
     assert.strictEqual(ctx.rfcs[1].addressee, "bob");
-    assert.strictEqual(
-      ctx.rfcs[0].correlation_id,
-      ctx.rfcs[1].correlation_id,
-    );
+    assert.strictEqual(ctx.rfcs[0].correlation_id, ctx.rfcs[1].correlation_id);
 
     const payload = JSON.parse(result.content[0].text);
     assert.match(payload.correlation_id, /^rfc_\d+$/);
     assert.strictEqual(payload.channel, "github-discussions");
-    assert.strictEqual(ctx.replies.length, 0, "replies should not be populated by RFC");
+    assert.strictEqual(
+      ctx.replies.length,
+      0,
+      "replies should not be populated by RFC",
+    );
   });
 
   test("RequestForComment emits a single anonymous RFC when no addressees are listed", async () => {

--- a/libraries/libeval/test/facilitator-factory.test.js
+++ b/libraries/libeval/test/facilitator-factory.test.js
@@ -60,7 +60,10 @@ describe("Facilitator - createFacilitator factory", () => {
   test("facilitator lead gets plain string system prompt (no preset)", () => {
     const f = createFacilitator(baseOpts());
     assert.strictEqual(typeof f.facilitatorRunner.systemPrompt, "string");
-    assert.strictEqual(f.facilitatorRunner.systemPrompt, FACILITATOR_SYSTEM_PROMPT);
+    assert.strictEqual(
+      f.facilitatorRunner.systemPrompt,
+      FACILITATOR_SYSTEM_PROMPT,
+    );
   });
 
   test("agents get claude_code preset system prompt", () => {

--- a/libraries/libeval/test/supervisor-factory.test.js
+++ b/libraries/libeval/test/supervisor-factory.test.js
@@ -55,7 +55,10 @@ describe("Supervisor - createSupervisor factory", () => {
   test("supervisor lead gets plain string system prompt (no preset)", () => {
     const s = createSupervisor(baseOpts());
     assert.strictEqual(typeof s.supervisorRunner.systemPrompt, "string");
-    assert.strictEqual(s.supervisorRunner.systemPrompt, SUPERVISOR_SYSTEM_PROMPT);
+    assert.strictEqual(
+      s.supervisorRunner.systemPrompt,
+      SUPERVISOR_SYSTEM_PROMPT,
+    );
   });
 
   test("agent gets claude_code preset system prompt", () => {

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -343,7 +343,12 @@ export class GhBridgeService {
       });
     };
 
-    await postDiscussionReplies(this.#graphqlClient, ctx, payload.replies, recordOrigin);
+    await postDiscussionReplies(
+      this.#graphqlClient,
+      ctx,
+      payload.replies,
+      recordOrigin,
+    );
     for (const reply of payload.replies) {
       appendHistory(ctx.history, {
         role: "assistant",

--- a/services/ghbridge/src/graphql.js
+++ b/services/ghbridge/src/graphql.js
@@ -35,7 +35,12 @@ export const REMOVE_REACTION_MUTATION = `
  * @param {Array<{body: string, in_reply_to?: string}>} replies
  * @param {(comment: {id: string}) => Promise<void>} [onPosted] - Called after each mutation returns
  */
-export async function postDiscussionReplies(graphqlClient, ctx, replies, onPosted) {
+export async function postDiscussionReplies(
+  graphqlClient,
+  ctx,
+  replies,
+  onPosted,
+) {
   for (const reply of replies) {
     if (!reply || typeof reply.body !== "string") continue;
     const input = {
@@ -43,7 +48,9 @@ export async function postDiscussionReplies(graphqlClient, ctx, replies, onPoste
       body: reply.body,
       ...(reply.in_reply_to ? { replyToId: reply.in_reply_to } : {}),
     };
-    const res = await graphqlClient(ADD_DISCUSSION_COMMENT_MUTATION, { i: input });
+    const res = await graphqlClient(ADD_DISCUSSION_COMMENT_MUTATION, {
+      i: input,
+    });
     const comment = res?.addDiscussionComment?.comment;
     if (comment?.id && onPosted) await onPosted(comment);
   }
@@ -57,7 +64,12 @@ export async function postDiscussionReplies(graphqlClient, ctx, replies, onPoste
  * @param {string} text
  * @param {(comment: {id: string}) => Promise<void>} [onPosted] - Called after the mutation returns
  */
-export async function postSingleDiscussionReply(graphqlClient, ctx, text, onPosted) {
+export async function postSingleDiscussionReply(
+  graphqlClient,
+  ctx,
+  text,
+  onPosted,
+) {
   const res = await graphqlClient(ADD_DISCUSSION_COMMENT_MUTATION, {
     i: { discussionId: ctx.discussion_id, body: text },
   });

--- a/services/ghbridge/test/callback.test.js
+++ b/services/ghbridge/test/callback.test.js
@@ -60,7 +60,11 @@ async function newService() {
     graphqlClient: async (query, variables) => {
       graphqlCalls.push({ query, variables });
       if (query.includes("addDiscussionComment")) {
-        return { addDiscussionComment: { comment: { id: `C_${++commentCounter}`, url: "url" } } };
+        return {
+          addDiscussionComment: {
+            comment: { id: `C_${++commentCounter}`, url: "url" },
+          },
+        };
       }
       return {};
     },
@@ -276,7 +280,11 @@ describe("ghbridge callback handler", () => {
 
     const commentEvent = {
       action: "created",
-      discussion: { node_id: "D_kw1", body: "rfc", user: { id: 1, login: "u" } },
+      discussion: {
+        node_id: "D_kw1",
+        body: "rfc",
+        user: { id: 1, login: "u" },
+      },
       comment: { node_id: postedCommentId, body: "bot reply" },
     };
     const json = JSON.stringify(commentEvent);

--- a/specs/1300-svcdiscussion/design-a.md
+++ b/specs/1300-svcdiscussion/design-a.md
@@ -2,141 +2,146 @@
 
 Architectural design for [spec 1300](spec.md). A new gRPC service owns
 the canonical discussion and origin records; both bridges call it
-through generated clients while keeping their existing
-`libbridge`-shaped composition intact.
+through generated clients while keeping their existing libbridge
+composition. `ResumeScheduler`'s contract with its `store` parameter
+widens so the resume lifecycle still works over a remote backend.
+
+## Component boundary
+
+```mermaid
+graph LR
+    subgraph ghbridge["services/ghbridge"]
+        GBI[index.js<br/>intake + reply]
+        GCA[DiscussionAdapter<br/>in-process]
+    end
+    subgraph msbridge["services/msbridge"]
+        MBI[index.js<br/>intake + reply]
+        MCA[DiscussionAdapter<br/>in-process]
+    end
+    subgraph libbridge["@forwardimpact/libbridge"]
+        DSP[Dispatcher]
+        RS[ResumeScheduler]
+        ACK[Acknowledgement]
+        CB[createCallbackHandler]
+    end
+    subgraph svcdiscussion["services/svcdiscussion"]
+        IDX[BufferedIndex pair<br/>+ sweep timer]
+    end
+    subgraph data["data/bridges/"]
+        DF[discussions.jsonl]
+        OF[origins.jsonl]
+    end
+
+    GBI --> DSP
+    GBI --> RS
+    GBI --> ACK
+    GBI --> CB
+    GBI --> GCA
+    MBI --> DSP
+    MBI --> RS
+    MBI --> ACK
+    MBI --> CB
+    MBI --> MCA
+    DSP -.store contract.-> GCA
+    DSP -.store contract.-> MCA
+    RS -.store contract.-> GCA
+    RS -.store contract.-> MCA
+    GCA -- DiscussionClient (gRPC) --> IDX
+    MCA -- DiscussionClient (gRPC) --> IDX
+    IDX --> DF
+    IDX --> OF
+```
+
+The libbridge box ships no gRPC dependency. Each bridge's
+`DiscussionAdapter` is the only thing that imports the generated client,
+and it presents a store-shaped object to `Dispatcher` and
+`ResumeScheduler`.
 
 ## Components
 
-| Component | Role in this design |
+| Component | Role |
 |---|---|
-| `services/svcdiscussion/` | New gRPC service. Follows `services/CLAUDE.md` layout (server entry, implementation, `proto/`, `test/`). Holds the only on-disk discussion and origin state; runs the periodic sweep. |
-| `services/svcdiscussion/proto/discussion.proto` | Declares package `discussion` and service `Discussion`. Five RPCs: `LoadDiscussion`, `SaveDiscussion`, `HasOrigin`, `RecordOrigin`, `Sweep`. |
-| `services/svcdiscussion/index.js` | Implements `Discussion` over two `BufferedIndex`-backed stores constructed against one shared `StorageInterface` rooted at `data/bridges/`. |
-| `services/ghbridge/`, `services/msbridge/` | Construct a `DiscussionClient` at startup via `createClient("discussion", …)`. The local-store dependency they pass to `Dispatcher` and `ResumeScheduler` is a thin in-process adapter over that client. ghbridge calls `HasOrigin` / `RecordOrigin` directly from its webhook intake and reply paths. |
-| `libraries/libbridge` | Loses `discussion-context.js` and `origin-index.js`. Keeps `Acknowledgement`, `CallbackRegistry`, `Dispatcher`, `ResumeScheduler`, `RateLimiter`, `ElapsedScheduler`, the callback handler, the prompt/history/trigger helpers, `createBridgeServer`, `newDiscussionContext`, and the payload validator. `Dispatcher` and `ResumeScheduler` keep their store-shaped duck-typed contract (`.loadByChannel`, `.add`, `.flush`) unchanged. |
-
-## Data flow
-
-```mermaid
-sequenceDiagram
-    participant W as Webhook (channel)
-    participant B as services/{gh,ms}bridge
-    participant A as DiscussionAdapter<br/>(in-process)
-    participant C as DiscussionClient<br/>(librpc)
-    participant S as services/svcdiscussion
-    participant D as data/bridges/{discussions,origins}.jsonl
-
-    W->>B: inbound activity / webhook
-    B->>A: loadByChannel(channel, id)
-    A->>C: LoadDiscussion
-    C->>S: gRPC
-    S-->>C: Discussion or NOT_FOUND
-    C-->>A: record or null
-    A-->>B: ctx
-    Note over B: ctx.history mutated locally, dispatcher fires workflow
-    B->>A: add(ctx) + flush()
-    A->>C: SaveDiscussion(ctx)
-    C->>S: gRPC
-    S->>D: append via BufferedIndex (server-side flush)
-    Note over B,S: ghbridge intake also calls<br/>HasOrigin(comment_id) before any further work,<br/>and reply path calls RecordOrigin per posted comment.
-```
-
-The sweep loop runs entirely inside `svcdiscussion`: a 60-second
-interval evicts records whose `last_active_at` is older than the
-configured 24-hour TTL. The `Sweep` RPC exists for deterministic tests
-(callable with an explicit `now`) and is not called by either bridge in
-production.
+| `services/svcdiscussion/` | New gRPC service. Follows the `services/CLAUDE.md` layout (server entry, implementation, `proto/`, `test/`). Owns the only on-disk discussion and origin state and runs the periodic sweep. The `svc`-prefixed directory deviates from the bare names used by `services/{trace,graph,vector}` and matches the spec's explicit naming choice. |
+| `services/svcdiscussion/proto/discussion.proto` | Declares `package discussion`, `service Discussion`, message `DiscussionRecord` (deliberately not `Discussion` to avoid the codegen service/message name collision), `Origin`, `OpenRfc`, `Participant`, `ResumeTrigger`, plus a small set of request/response messages. |
+| `services/svcdiscussion/index.js` | Implements `Discussion` over two `BufferedIndex` stores constructed against one shared `StorageInterface` rooted at `data/bridges/`. The service's own config block is `service.discussion.*` (the registered name on `createServiceConfig("discussion")`). |
+| `services/{gh,ms}bridge/index.js` | Construct a `DiscussionClient` at startup via `createClient("discussion", …)`. Wrap the client in a `DiscussionAdapter` (a small in-process object) and pass that adapter wherever the old `DiscussionContextStore` instance went. ghbridge calls `client.HasOrigin` / `client.RecordOrigin` from the webhook intake and reply paths without going through the adapter. |
+| `libraries/libbridge` | Loses `discussion-context.js` and `origin-index.js`. `ResumeScheduler` is amended to stop reaching into `store.loaded`, `store.loadData()`, and `store.index.values()` (see § Key decisions). Everything else stays. |
 
 ## Discussion record on the wire
 
-`Discussion` mirrors the existing in-memory shape one-for-one so the
-record factory (`newDiscussionContext`) and the dispatcher's mutations
-do not change. Opaque payloads (Bot Framework `ConversationReference`,
-GitHub node metadata) ride as a JSON string on each participant, the
-same way they survive the existing JSONL round-trip.
+`DiscussionRecord` mirrors the existing in-memory shape one-for-one so
+the record factory and dispatcher mutations do not change. The
+persisted JSONL on disk follows the proto field names.
 
 | Field | Proto type | Notes |
 |---|---|---|
 | `id` | `string` | `<channel>:<discussion_id>` — the libindex key. |
 | `channel` | `string` | `"github-discussions"` or `"msteams"`. |
 | `discussion_id` | `string` | Channel-side thread id. |
-| `lead` | `string` | Carries the conversation lead. |
+| `lead` | `string` | Conversation lead. |
 | `last_active_at` | `int64` | Epoch ms. Sweep input. |
 | `dispatches` | `repeated int64` | Rate-limiter input. |
 | `history` | `repeated HistoryEntry` | `{ role, text }`. |
 | `participants` | `repeated Participant` | `{ name, kind, external_id, metadata_json }`. |
-| `open_rfcs` | `map<string, OpenRfc>` | Correlation id → `{ trigger_json, opened_at, history_index_at_open }`. |
+| `open_rfcs` | `map<string, OpenRfc>` | Correlation id → `{ trigger, opened_at, history_index_at_open, due_at }`. |
 | `pending_callbacks` | `map<string, string>` | Token → correlation id. Travels with the record per spec. |
 
-`Origin` is flat: `{ id, discussion_id, posted_at }`.
+`OpenRfc.trigger` is a typed `ResumeTrigger` message — `{ kind, responses, elapsed }` — so the on-disk field name remains `trigger` (preserving the spec's "persisted record shape is unchanged" requirement). `OpenRfc.due_at` is required for `ResumeScheduler` to rearm elapsed timers after a restart.
+
+`Origin` is flat: `{ id, discussion_id, posted_at }`. Opaque per-participant metadata (Bot Framework `ConversationReference`, GitHub node metadata) rides as a JSON string because it is channel-shaped and outside this service's concern.
 
 ## RPC contract
 
-| RPC | Request | Response | Bridge call site |
+| RPC | Request | Response | Caller |
 |---|---|---|---|
-| `LoadDiscussion` | `{ channel, discussion_id }` | `Discussion` (empty `id` ⇒ not found) | `loadByChannel` inside `#loadOrCreateContext` and the inbound paths in both bridges. |
-| `SaveDiscussion` | `Discussion` | `common.Empty` | The single hot-path write that today is `await store.add(ctx); await store.flush()`. |
+| `LoadDiscussion` | `{ channel, discussion_id }` | `DiscussionRecord` or gRPC `NOT_FOUND` | Adapter `loadByChannel`. |
+| `LoadDiscussionByCorrelation` | `{ correlation_id }` | `DiscussionRecord` or gRPC `NOT_FOUND` | Adapter `loadByCorrelation` — replaces `ResumeScheduler.#findContextWithRfc`'s linear scan over `store.index.values()`. |
+| `ListOpenRecesses` | `common.Empty` | `repeated OpenRecessRef { id, channel, discussion_id, correlation_id, due_at }` | Adapter `listOpenRecesses` — used by `ResumeScheduler.rearm()` to arm elapsed timers without iterating the whole map. |
+| `SaveDiscussion` | `DiscussionRecord` | `common.Empty` | Adapter `save` — the single hot-path write that today is `add+flush`. |
 | `HasOrigin` | `{ id }` | `{ exists: bool }` | ghbridge's `#handleDiscussionComment` self-echo guard. |
 | `RecordOrigin` | `Origin` | `common.Empty` | ghbridge's `recordOrigin` callback inside `#handleReply`. |
-| `Sweep` | `{ now: int64 (optional) }` | `{ evicted: int32 }` | Tests only; production uses the server-internal timer. |
+| `Sweep` | `{ now: optional int64 }` | `{ evicted_discussions: int32, evicted_origins: int32 }` | Tests only. Absent `now` ⇒ server uses `Date.now()`. Production uses the server-internal 60 s timer. |
 
-## In-process adapter (bridge side)
+## Adapter contract (bridge side)
 
-Both `Dispatcher` and `ResumeScheduler` already accept any store-shaped
-object with `.loadByChannel`, `.add`, `.flush`. Each bridge's
-`server.js` wraps its `DiscussionClient` in a four-method adapter and
-passes that wherever the old `DiscussionContextStore` instance went:
+`DiscussionAdapter` is the only new abstraction on the bridge side. It wraps the generated `DiscussionClient` and satisfies the contract `Dispatcher` and `ResumeScheduler` consume:
 
-| Adapter method | Implementation |
+| Method | Implementation |
 |---|---|
-| `loadByChannel(channel, id)` | `client.LoadDiscussion({ channel, discussion_id: id })`, returns `null` on empty id. |
+| `loadByChannel(channel, id)` | `client.LoadDiscussion`, returns `null` on gRPC `NOT_FOUND`. |
+| `loadByCorrelation(correlationId)` | `client.LoadDiscussionByCorrelation`, returns `null` on gRPC `NOT_FOUND`. |
+| `listOpenRecesses()` | `client.ListOpenRecesses` → array of `{ correlationId, due_at }`. |
 | `add(ctx)` | `client.SaveDiscussion(ctx)`. |
-| `flush()` | No-op — the service's `BufferedIndex` owns batching. |
-| `shutdown()` | No-op — the service owns its own lifecycle. |
+| `flush()` | No-op. The server-side `BufferedIndex` owns batching, so a successful `SaveDiscussion` carries the same durability promise the old in-process `add+flush` did: in-memory until the next service-side flush. Crash semantics are identical to today — `svcdiscussion` losing buffered writes is the same crash window the per-bridge buffer had. |
+| `shutdown()` | No-op on the bridge side. The service drains its own buffer through librpc's SIGTERM handler. The previous bridge-side `store.shutdown()` flush gate disappears with the in-process buffer; bridges no longer drain anything on stop. |
 
-The adapter keeps the libbridge invariant intact: `libbridge` ships no
-gRPC dependency, and the channel-agnostic primitives still talk to a
-store-shaped duck. ghbridge's origin path bypasses the adapter and
-calls the client directly because `OriginIndex` was only ever a
-two-method type and the call sites are explicit.
+`Dispatcher.dispatch` only uses `.add` and `.flush` and is satisfied by this adapter unchanged. `ResumeScheduler` is amended to consume `loadByCorrelation` and `listOpenRecesses` in place of its current reaches into `store.loaded`, `store.loadData()`, and `store.index.values()`; that change keeps the resume lifecycle working over a remote backend without leaking gRPC into libbridge.
 
 ## Storage layout
 
-The service constructs one `StorageInterface` rooted at `bridges/`
-(resolved by `libstorage` to `data/bridges/` from the monorepo root) and
-hands it to two `BufferedIndex` instances using the existing index keys
-(`discussions.jsonl`, `origins.jsonl`). The two files therefore land at
-the canonical paths the spec requires, owned by a single process. The
-discussion store keeps the current 5 s / 1000-entry buffer; the origin
-store keeps the current 1 s / 100-entry buffer. Sweep cadence and TTL
-default to today's values and are overridable via
-`service.discussion.{sweepIntervalMs,conversationTtlMs}`.
+The service constructs one `StorageInterface` rooted at `bridges/`, resolved by `libstorage` to `data/bridges/` from the monorepo root, and hands it to two `BufferedIndex` instances using the existing index keys (`discussions.jsonl`, `origins.jsonl`). Both files land at the canonical paths the spec requires, owned by a single process. The discussion store keeps the current 5 s / 1000-entry buffer; the origin store keeps the current 1 s / 100-entry buffer. Both can be overridden via `service.discussion.*`.
+
+A single 60 s sweep timer evicts records older than the TTL from both indexes. The discussion side mirrors the existing 24 h `conversationTtlMs`. The origin side gains a periodic timer it did not have before — today's `OriginIndex.sweep(now)` is caller-driven; the service moves it onto the same cadence as discussions to put both indexes under one lifecycle. The origin TTL stays at 24 h.
 
 ## Key decisions
 
 | Decision | Chosen | Rejected | Why |
 |---|---|---|---|
-| Surface shape | One `Discussion` service with five methods covering both record kinds | Two services (`Discussion` + `Origin`) | Spec mandates a single interface. Matches the `trace.Trace` and `graph.Graph` shape — one proto, one stub, one generated client — and lets the service supervise one lifecycle. |
-| Sweep ownership | Server-internal 60 s timer plus a `Sweep` RPC for tests | RPC-only sweep driven by a bridge cron, or every-call lazy eviction | Bridges should not own the TTL — both today and after this design the per-channel state is owned by the store, not the caller. A test-callable RPC keeps the integration test deterministic without exposing scheduling to production callers. |
-| Record format on the wire | Full PUT of the `Discussion` message on every save | Delta API (`AppendHistory`, `SetOpenRfc`, …) | A delta API would freeze today's mutation set into the proto; the foundation is meant to enable future tools (cross-bridge lookup, history recall), and a single getter/setter pair is easier to evolve. The hot path today is one in-memory mutation followed by `add+flush`, so PUT semantics are already what the bridges do. |
+| Surface shape | One `Discussion` service with seven RPCs covering both record kinds | Two services (`Discussion` + `Origin`) | Spec mandates a single interface. Matches `trace.Trace` and `graph.Graph` — one proto, one stub, one supervised process. |
+| Resume contract over gRPC | Widen the store contract with `loadByCorrelation` and `listOpenRecesses`; amend `ResumeScheduler` to use them in place of `store.loaded` / `store.loadData()` / `store.index.values()` | Keep the four-method adapter (`loadByChannel`, `add`, `flush`, `shutdown`) and let `ResumeScheduler.rearm` and `#findContextWithRfc` fail | The current `ResumeScheduler` reaches past `loadByChannel` to walk every record. A 4-method adapter cannot satisfy that. Either widen the contract or move resume into the service; widening keeps the dispatcher + scheduler composition on the bridge side, which is what the libbridge contract is designed around. |
+| Message name | `DiscussionRecord` | `Discussion` | proto3 allows `service Discussion` + `message Discussion` in the same package, but every peer service (`trace.Trace`/`Span`, `graph.Graph`/`PatternQuery`) keeps the names distinct; matching the convention avoids codegen-tool friction. |
+| Not-found channel | gRPC `NOT_FOUND` status from `LoadDiscussion` / `LoadDiscussionByCorrelation` | Sentinel empty `id` on a default-constructed `DiscussionRecord` | Status codes are how every other librpc service signals absence; the adapter translates `NOT_FOUND` to `null` so the bridge call sites read exactly as they do today. |
+| Resume trigger over the wire | Typed `ResumeTrigger` message; on-record field name stays `trigger` | `string trigger_json` carrying the JSON-serialised trigger | A typed message keeps the spec's "persisted record shape is unchanged" intact — the on-disk JSONL field is still `trigger`, not `trigger_json` — and gives the service introspection over recess state if a future tool wants it. |
 | Opaque participant metadata | JSON string per participant | `google.protobuf.Struct` or first-class proto fields | The Bot Framework `ConversationReference` and GitHub node metadata are channel-shaped and outside this service's concern. A JSON string keeps the contract minimal and matches how the JSONL already round-trips these blobs. |
-| Bridge-side integration | A four-method in-process adapter over the gRPC client, passed to `Dispatcher` and `ResumeScheduler` unchanged | Change `Dispatcher`/`ResumeScheduler` to take a client directly | The adapter preserves the libbridge invariant ("no channel SDKs or service SDKs in the library") and keeps the dispatcher/scheduler composable for any future store backend. The cost is twelve lines per bridge — well below the cost of widening the libbridge contract. |
-| Origin path on ghbridge | Direct `client.HasOrigin` / `client.RecordOrigin` calls | Wrap the client in an `OriginIndex`-shaped class in libbridge | `OriginIndex` exists today only because `BufferedIndex` made it cheap; the actual call surface is two methods, used at two call sites. A library wrapper would import the gRPC client (invariant violation) and add a layer that hides nothing. |
-| Storage root | `createStorage("bridges")` shared by both indexes inside the service | Per-service root (`createStorage("bridges/svcdiscussion")`) with `indexKey` overrides | The spec names the exact on-disk paths. Rooting at `bridges/` lands the two files at `data/bridges/discussions.jsonl` and `data/bridges/origins.jsonl` with no `indexKey` gymnastics. |
-| Buffering | Server keeps existing `BufferedIndex` cadences (5 s / 1000 for discussions, 1 s / 100 for origins); adapter `flush()` becomes a no-op | Per-call synchronous append on the server, or pass-through buffering on the client | Per-call append would slow the hot path under load; client-side buffering would lose state when a bridge crashes. The service is now the only writer, so its own buffering is sufficient and matches today's durability behaviour. |
-| Test seams | Bridge tests construct a fake `DiscussionClient` and the same adapter wrapper; service tests use `createMockStorage` against the real `BufferedIndex` pair | Mount the real service in-process in every bridge test | A fake client keeps bridge tests fast and focused on bridge logic; the service has its own test directory for store behaviour. Both layers can still grow integration tests later without restructuring. |
-| Service supervision | The supervised-services list in the starter configuration gains `svcdiscussion` ahead of both bridges | Lazy connection from the bridges with retries | Today's starter shape gives every gRPC service a fixed start-up order; adding `svcdiscussion` to the same list keeps the lifecycle predictable and uses the same machinery `trace`, `graph`, etc. already rely on. |
+| Sweep ownership | Server-internal 60 s timer plus a `Sweep` RPC for tests | Bridge-driven sweep | The TTL is store-owned, not caller-owned. A test-callable RPC keeps the integration test deterministic without exposing scheduling to production callers. The origin index gains a periodic timer it did not have before — intentional, so both indexes share one lifecycle. |
+| Origin path on ghbridge | Direct `client.HasOrigin` / `client.RecordOrigin` calls; no adapter wrapper | Wrap the client in an `OriginIndex`-shaped class in libbridge | The actual call sites are explicit; the previous `.flush()` after each reply and the `.shutdown()` on stop disappear because the service owns batching and its own lifecycle. |
+| Storage root | `createStorage("bridges")` inside the service, both indexes share it | Per-service root (`createStorage("svcdiscussion")`) with `indexKey` overrides | Lands the two files at the canonical paths the spec requires with no `indexKey` gymnastics. The bridges' previous `bridges/{ghbridge,msbridge}/` directories are not read or written by any code after cutover. |
+| Buffering / durability | Server keeps the existing `BufferedIndex` cadences; adapter `flush()` is a no-op | Per-call synchronous append, or pass-through buffering on the client | Per-call append would slow the hot path. Client-side buffering would lose state when the bridge crashes. Server-side buffering is the simplest viable choice; durability does not improve relative to today (the service can still lose buffered writes on crash), and the design is honest that the crash window moves rather than disappears. |
+| Service supervision | The product starter that bundles the bridges (today none of the shipped starters does) gains `svcdiscussion` in its `init.services` list before the bridge entries | Lazy connection with retries from the bridges | Today's bridges are not in any shipped starter; this design does not assume they are. When a starter does bundle them, `svcdiscussion` must come first so the bridges' `createClient("discussion", …)` resolves at startup. |
 
 ## What this design does not cover
 
-- The agent-facing tool surfaces over the new store (cross-bridge
-  lookup, history recall). Foundation only; the follow-up spec for the
-  tool catalogue will add RPCs without changing the underlying store.
-- Concrete file paths, signatures, or execution ordering inside any of
-  the components above — those are plan concerns.
-- The shape of the bridge fakes used in tests, beyond the contract the
-  adapter satisfies.
-- Removal of the per-bridge legacy files under
-  `data/bridges/{ghbridge,msbridge}/` on operator machines. The clean
-  break means no code reads or writes them; cleanup is operational, not
-  a code change.
+- The agent-facing tool surfaces over the new store (cross-bridge lookup, history recall). Foundation only; the follow-up spec for the tool catalogue will add RPCs without changing the underlying store.
+- Concrete file paths, function signatures, or execution ordering inside any of the components above — those are plan concerns.
+- The shape of the bridge fakes used in tests beyond the contract the adapter satisfies.
+- Removal of the per-bridge legacy files under `data/bridges/{ghbridge,msbridge}/` on operator machines. The clean break means no code reads or writes them; cleanup is operational, not a code change.

--- a/specs/1300-svcdiscussion/design-a.md
+++ b/specs/1300-svcdiscussion/design-a.md
@@ -1,0 +1,142 @@
+# Design 1300-a — svcdiscussion
+
+Architectural design for [spec 1300](spec.md). A new gRPC service owns
+the canonical discussion and origin records; both bridges call it
+through generated clients while keeping their existing
+`libbridge`-shaped composition intact.
+
+## Components
+
+| Component | Role in this design |
+|---|---|
+| `services/svcdiscussion/` | New gRPC service. Follows `services/CLAUDE.md` layout (server entry, implementation, `proto/`, `test/`). Holds the only on-disk discussion and origin state; runs the periodic sweep. |
+| `services/svcdiscussion/proto/discussion.proto` | Declares package `discussion` and service `Discussion`. Five RPCs: `LoadDiscussion`, `SaveDiscussion`, `HasOrigin`, `RecordOrigin`, `Sweep`. |
+| `services/svcdiscussion/index.js` | Implements `Discussion` over two `BufferedIndex`-backed stores constructed against one shared `StorageInterface` rooted at `data/bridges/`. |
+| `services/ghbridge/`, `services/msbridge/` | Construct a `DiscussionClient` at startup via `createClient("discussion", …)`. The local-store dependency they pass to `Dispatcher` and `ResumeScheduler` is a thin in-process adapter over that client. ghbridge calls `HasOrigin` / `RecordOrigin` directly from its webhook intake and reply paths. |
+| `libraries/libbridge` | Loses `discussion-context.js` and `origin-index.js`. Keeps `Acknowledgement`, `CallbackRegistry`, `Dispatcher`, `ResumeScheduler`, `RateLimiter`, `ElapsedScheduler`, the callback handler, the prompt/history/trigger helpers, `createBridgeServer`, `newDiscussionContext`, and the payload validator. `Dispatcher` and `ResumeScheduler` keep their store-shaped duck-typed contract (`.loadByChannel`, `.add`, `.flush`) unchanged. |
+
+## Data flow
+
+```mermaid
+sequenceDiagram
+    participant W as Webhook (channel)
+    participant B as services/{gh,ms}bridge
+    participant A as DiscussionAdapter<br/>(in-process)
+    participant C as DiscussionClient<br/>(librpc)
+    participant S as services/svcdiscussion
+    participant D as data/bridges/{discussions,origins}.jsonl
+
+    W->>B: inbound activity / webhook
+    B->>A: loadByChannel(channel, id)
+    A->>C: LoadDiscussion
+    C->>S: gRPC
+    S-->>C: Discussion or NOT_FOUND
+    C-->>A: record or null
+    A-->>B: ctx
+    Note over B: ctx.history mutated locally, dispatcher fires workflow
+    B->>A: add(ctx) + flush()
+    A->>C: SaveDiscussion(ctx)
+    C->>S: gRPC
+    S->>D: append via BufferedIndex (server-side flush)
+    Note over B,S: ghbridge intake also calls<br/>HasOrigin(comment_id) before any further work,<br/>and reply path calls RecordOrigin per posted comment.
+```
+
+The sweep loop runs entirely inside `svcdiscussion`: a 60-second
+interval evicts records whose `last_active_at` is older than the
+configured 24-hour TTL. The `Sweep` RPC exists for deterministic tests
+(callable with an explicit `now`) and is not called by either bridge in
+production.
+
+## Discussion record on the wire
+
+`Discussion` mirrors the existing in-memory shape one-for-one so the
+record factory (`newDiscussionContext`) and the dispatcher's mutations
+do not change. Opaque payloads (Bot Framework `ConversationReference`,
+GitHub node metadata) ride as a JSON string on each participant, the
+same way they survive the existing JSONL round-trip.
+
+| Field | Proto type | Notes |
+|---|---|---|
+| `id` | `string` | `<channel>:<discussion_id>` — the libindex key. |
+| `channel` | `string` | `"github-discussions"` or `"msteams"`. |
+| `discussion_id` | `string` | Channel-side thread id. |
+| `lead` | `string` | Carries the conversation lead. |
+| `last_active_at` | `int64` | Epoch ms. Sweep input. |
+| `dispatches` | `repeated int64` | Rate-limiter input. |
+| `history` | `repeated HistoryEntry` | `{ role, text }`. |
+| `participants` | `repeated Participant` | `{ name, kind, external_id, metadata_json }`. |
+| `open_rfcs` | `map<string, OpenRfc>` | Correlation id → `{ trigger_json, opened_at, history_index_at_open }`. |
+| `pending_callbacks` | `map<string, string>` | Token → correlation id. Travels with the record per spec. |
+
+`Origin` is flat: `{ id, discussion_id, posted_at }`.
+
+## RPC contract
+
+| RPC | Request | Response | Bridge call site |
+|---|---|---|---|
+| `LoadDiscussion` | `{ channel, discussion_id }` | `Discussion` (empty `id` ⇒ not found) | `loadByChannel` inside `#loadOrCreateContext` and the inbound paths in both bridges. |
+| `SaveDiscussion` | `Discussion` | `common.Empty` | The single hot-path write that today is `await store.add(ctx); await store.flush()`. |
+| `HasOrigin` | `{ id }` | `{ exists: bool }` | ghbridge's `#handleDiscussionComment` self-echo guard. |
+| `RecordOrigin` | `Origin` | `common.Empty` | ghbridge's `recordOrigin` callback inside `#handleReply`. |
+| `Sweep` | `{ now: int64 (optional) }` | `{ evicted: int32 }` | Tests only; production uses the server-internal timer. |
+
+## In-process adapter (bridge side)
+
+Both `Dispatcher` and `ResumeScheduler` already accept any store-shaped
+object with `.loadByChannel`, `.add`, `.flush`. Each bridge's
+`server.js` wraps its `DiscussionClient` in a four-method adapter and
+passes that wherever the old `DiscussionContextStore` instance went:
+
+| Adapter method | Implementation |
+|---|---|
+| `loadByChannel(channel, id)` | `client.LoadDiscussion({ channel, discussion_id: id })`, returns `null` on empty id. |
+| `add(ctx)` | `client.SaveDiscussion(ctx)`. |
+| `flush()` | No-op — the service's `BufferedIndex` owns batching. |
+| `shutdown()` | No-op — the service owns its own lifecycle. |
+
+The adapter keeps the libbridge invariant intact: `libbridge` ships no
+gRPC dependency, and the channel-agnostic primitives still talk to a
+store-shaped duck. ghbridge's origin path bypasses the adapter and
+calls the client directly because `OriginIndex` was only ever a
+two-method type and the call sites are explicit.
+
+## Storage layout
+
+The service constructs one `StorageInterface` rooted at `bridges/`
+(resolved by `libstorage` to `data/bridges/` from the monorepo root) and
+hands it to two `BufferedIndex` instances using the existing index keys
+(`discussions.jsonl`, `origins.jsonl`). The two files therefore land at
+the canonical paths the spec requires, owned by a single process. The
+discussion store keeps the current 5 s / 1000-entry buffer; the origin
+store keeps the current 1 s / 100-entry buffer. Sweep cadence and TTL
+default to today's values and are overridable via
+`service.discussion.{sweepIntervalMs,conversationTtlMs}`.
+
+## Key decisions
+
+| Decision | Chosen | Rejected | Why |
+|---|---|---|---|
+| Surface shape | One `Discussion` service with five methods covering both record kinds | Two services (`Discussion` + `Origin`) | Spec mandates a single interface. Matches the `trace.Trace` and `graph.Graph` shape — one proto, one stub, one generated client — and lets the service supervise one lifecycle. |
+| Sweep ownership | Server-internal 60 s timer plus a `Sweep` RPC for tests | RPC-only sweep driven by a bridge cron, or every-call lazy eviction | Bridges should not own the TTL — both today and after this design the per-channel state is owned by the store, not the caller. A test-callable RPC keeps the integration test deterministic without exposing scheduling to production callers. |
+| Record format on the wire | Full PUT of the `Discussion` message on every save | Delta API (`AppendHistory`, `SetOpenRfc`, …) | A delta API would freeze today's mutation set into the proto; the foundation is meant to enable future tools (cross-bridge lookup, history recall), and a single getter/setter pair is easier to evolve. The hot path today is one in-memory mutation followed by `add+flush`, so PUT semantics are already what the bridges do. |
+| Opaque participant metadata | JSON string per participant | `google.protobuf.Struct` or first-class proto fields | The Bot Framework `ConversationReference` and GitHub node metadata are channel-shaped and outside this service's concern. A JSON string keeps the contract minimal and matches how the JSONL already round-trips these blobs. |
+| Bridge-side integration | A four-method in-process adapter over the gRPC client, passed to `Dispatcher` and `ResumeScheduler` unchanged | Change `Dispatcher`/`ResumeScheduler` to take a client directly | The adapter preserves the libbridge invariant ("no channel SDKs or service SDKs in the library") and keeps the dispatcher/scheduler composable for any future store backend. The cost is twelve lines per bridge — well below the cost of widening the libbridge contract. |
+| Origin path on ghbridge | Direct `client.HasOrigin` / `client.RecordOrigin` calls | Wrap the client in an `OriginIndex`-shaped class in libbridge | `OriginIndex` exists today only because `BufferedIndex` made it cheap; the actual call surface is two methods, used at two call sites. A library wrapper would import the gRPC client (invariant violation) and add a layer that hides nothing. |
+| Storage root | `createStorage("bridges")` shared by both indexes inside the service | Per-service root (`createStorage("bridges/svcdiscussion")`) with `indexKey` overrides | The spec names the exact on-disk paths. Rooting at `bridges/` lands the two files at `data/bridges/discussions.jsonl` and `data/bridges/origins.jsonl` with no `indexKey` gymnastics. |
+| Buffering | Server keeps existing `BufferedIndex` cadences (5 s / 1000 for discussions, 1 s / 100 for origins); adapter `flush()` becomes a no-op | Per-call synchronous append on the server, or pass-through buffering on the client | Per-call append would slow the hot path under load; client-side buffering would lose state when a bridge crashes. The service is now the only writer, so its own buffering is sufficient and matches today's durability behaviour. |
+| Test seams | Bridge tests construct a fake `DiscussionClient` and the same adapter wrapper; service tests use `createMockStorage` against the real `BufferedIndex` pair | Mount the real service in-process in every bridge test | A fake client keeps bridge tests fast and focused on bridge logic; the service has its own test directory for store behaviour. Both layers can still grow integration tests later without restructuring. |
+| Service supervision | The supervised-services list in the starter configuration gains `svcdiscussion` ahead of both bridges | Lazy connection from the bridges with retries | Today's starter shape gives every gRPC service a fixed start-up order; adding `svcdiscussion` to the same list keeps the lifecycle predictable and uses the same machinery `trace`, `graph`, etc. already rely on. |
+
+## What this design does not cover
+
+- The agent-facing tool surfaces over the new store (cross-bridge
+  lookup, history recall). Foundation only; the follow-up spec for the
+  tool catalogue will add RPCs without changing the underlying store.
+- Concrete file paths, signatures, or execution ordering inside any of
+  the components above — those are plan concerns.
+- The shape of the bridge fakes used in tests, beyond the contract the
+  adapter satisfies.
+- Removal of the per-bridge legacy files under
+  `data/bridges/{ghbridge,msbridge}/` on operator machines. The clean
+  break means no code reads or writes them; cleanup is operational, not
+  a code change.

--- a/specs/1300-svcdiscussion/design-a.md
+++ b/specs/1300-svcdiscussion/design-a.md
@@ -61,11 +61,23 @@ and it presents a store-shaped object to `Dispatcher` and
 
 | Component | Role |
 |---|---|
-| `services/svcdiscussion/` | New gRPC service. Follows the `services/CLAUDE.md` layout (server entry, implementation, `proto/`, `test/`). Owns the only on-disk discussion and origin state and runs the periodic sweep. The `svc`-prefixed directory deviates from the bare names used by `services/{trace,graph,vector}` and matches the spec's explicit naming choice. |
+| `services/svcdiscussion/` | New gRPC service. Follows the `services/CLAUDE.md` layout (server entry, implementation, `proto/`, `test/`). Owns the only on-disk discussion and origin state and runs the periodic sweep. The spec mandates the `svc`-prefixed directory name even though peer services use bare names (`services/{trace,graph,vector}`); this design honours the spec without renaming peers in the same change. |
 | `services/svcdiscussion/proto/discussion.proto` | Declares `package discussion`, `service Discussion`, message `DiscussionRecord` (deliberately not `Discussion` to avoid the codegen service/message name collision), `Origin`, `OpenRfc`, `Participant`, `ResumeTrigger`, plus a small set of request/response messages. |
 | `services/svcdiscussion/index.js` | Implements `Discussion` over two `BufferedIndex` stores constructed against one shared `StorageInterface` rooted at `data/bridges/`. The service's own config block is `service.discussion.*` (the registered name on `createServiceConfig("discussion")`). |
 | `services/{gh,ms}bridge/index.js` | Construct a `DiscussionClient` at startup via `createClient("discussion", …)`. Wrap the client in a `DiscussionAdapter` (a small in-process object) and pass that adapter wherever the old `DiscussionContextStore` instance went. ghbridge calls `client.HasOrigin` / `client.RecordOrigin` from the webhook intake and reply paths without going through the adapter. |
-| `libraries/libbridge` | Loses `discussion-context.js` and `origin-index.js`. `ResumeScheduler` is amended to stop reaching into `store.loaded`, `store.loadData()`, and `store.index.values()` (see § Key decisions). Everything else stays. |
+| `libraries/libbridge` | Loses `discussion-context.js` and `origin-index.js`. `ResumeScheduler` widens its store contract to consume `loadByCorrelation` and `listOpenRecesses` (see § Key decisions); everything else stays. |
+
+## Naming map
+
+| Surface | Identifier |
+|---|---|
+| Service directory | `services/svcdiscussion/` (per spec) |
+| npm package | `@forwardimpact/svcdiscussion` |
+| Proto package | `discussion` |
+| gRPC service | `Discussion` |
+| Generated client | `DiscussionClient` |
+| Config block | `service.discussion.*` (registered via `createServiceConfig("discussion")`) |
+| Supervisor entry name | `discussion` (bare, matching peer entries like `trace`, `graph`) |
 
 ## Discussion record on the wire
 
@@ -86,7 +98,7 @@ persisted JSONL on disk follows the proto field names.
 | `open_rfcs` | `map<string, OpenRfc>` | Correlation id → `{ trigger, opened_at, history_index_at_open, due_at }`. |
 | `pending_callbacks` | `map<string, string>` | Token → correlation id. Travels with the record per spec. |
 
-`OpenRfc.trigger` is a typed `ResumeTrigger` message — `{ kind, responses, elapsed }` — so the on-disk field name remains `trigger` (preserving the spec's "persisted record shape is unchanged" requirement). `OpenRfc.due_at` is required for `ResumeScheduler` to rearm elapsed timers after a restart.
+`OpenRfc.trigger` is a typed `ResumeTrigger` message — `{ kind, responses, elapsed }` — so the on-disk field name remains `trigger` (preserving the spec's "persisted record shape is unchanged" requirement). `OpenRfc.due_at` is encoded as `optional int64` because `ResumeScheduler.enterRecess` only sets it for `elapsed` and `either` triggers; `ResumeScheduler.rearm` keys arming on field presence, not on the proto3 default `0`.
 
 `Origin` is flat: `{ id, discussion_id, posted_at }`. Opaque per-participant metadata (Bot Framework `ConversationReference`, GitHub node metadata) rides as a JSON string because it is channel-shaped and outside this service's concern.
 
@@ -95,8 +107,8 @@ persisted JSONL on disk follows the proto field names.
 | RPC | Request | Response | Caller |
 |---|---|---|---|
 | `LoadDiscussion` | `{ channel, discussion_id }` | `DiscussionRecord` or gRPC `NOT_FOUND` | Adapter `loadByChannel`. |
-| `LoadDiscussionByCorrelation` | `{ correlation_id }` | `DiscussionRecord` or gRPC `NOT_FOUND` | Adapter `loadByCorrelation` — replaces `ResumeScheduler.#findContextWithRfc`'s linear scan over `store.index.values()`. |
-| `ListOpenRecesses` | `common.Empty` | `repeated OpenRecessRef { id, channel, discussion_id, correlation_id, due_at }` | Adapter `listOpenRecesses` — used by `ResumeScheduler.rearm()` to arm elapsed timers without iterating the whole map. |
+| `LoadDiscussionByCorrelation` | `{ correlation_id }` | `DiscussionRecord` or gRPC `NOT_FOUND` | Adapter `loadByCorrelation`. Lets `ResumeScheduler` find the owning record when an elapsed timer fires. |
+| `ListOpenRecesses` | `common.Empty` | `repeated OpenRecessRef { correlation_id, due_at }` | Adapter `listOpenRecesses`. Server-side filter: returns one entry per open RFC that has a `due_at` set. Response-only triggers are excluded because `ResumeScheduler.rearm` only arms elapsed timers. |
 | `SaveDiscussion` | `DiscussionRecord` | `common.Empty` | Adapter `save` — the single hot-path write that today is `add+flush`. |
 | `HasOrigin` | `{ id }` | `{ exists: bool }` | ghbridge's `#handleDiscussionComment` self-echo guard. |
 | `RecordOrigin` | `Origin` | `common.Empty` | ghbridge's `recordOrigin` callback inside `#handleReply`. |
@@ -112,16 +124,16 @@ persisted JSONL on disk follows the proto field names.
 | `loadByCorrelation(correlationId)` | `client.LoadDiscussionByCorrelation`, returns `null` on gRPC `NOT_FOUND`. |
 | `listOpenRecesses()` | `client.ListOpenRecesses` → array of `{ correlationId, due_at }`. |
 | `add(ctx)` | `client.SaveDiscussion(ctx)`. |
-| `flush()` | No-op. The server-side `BufferedIndex` owns batching, so a successful `SaveDiscussion` carries the same durability promise the old in-process `add+flush` did: in-memory until the next service-side flush. Crash semantics are identical to today — `svcdiscussion` losing buffered writes is the same crash window the per-bridge buffer had. |
+| `flush()` | No-op. The server-side `BufferedIndex` owns batching, so a `SaveDiscussion` returns when the record is in the service's in-memory index but not necessarily on disk. See § Key decisions on the write-barrier shift this introduces. |
 | `shutdown()` | No-op on the bridge side. The service drains its own buffer through librpc's SIGTERM handler. The previous bridge-side `store.shutdown()` flush gate disappears with the in-process buffer; bridges no longer drain anything on stop. |
 
-`Dispatcher.dispatch` only uses `.add` and `.flush` and is satisfied by this adapter unchanged. `ResumeScheduler` is amended to consume `loadByCorrelation` and `listOpenRecesses` in place of its current reaches into `store.loaded`, `store.loadData()`, and `store.index.values()`; that change keeps the resume lifecycle working over a remote backend without leaking gRPC into libbridge.
+`Dispatcher.dispatch` only uses `.add` and `.flush` and is satisfied by this adapter unchanged. `ResumeScheduler` consumes `loadByCorrelation` and `listOpenRecesses` from the adapter to drive its rearm and elapsed-fire paths; that contract widening keeps the resume lifecycle working over a remote backend without leaking gRPC into libbridge.
 
 ## Storage layout
 
 The service constructs one `StorageInterface` rooted at `bridges/`, resolved by `libstorage` to `data/bridges/` from the monorepo root, and hands it to two `BufferedIndex` instances using the existing index keys (`discussions.jsonl`, `origins.jsonl`). Both files land at the canonical paths the spec requires, owned by a single process. The discussion store keeps the current 5 s / 1000-entry buffer; the origin store keeps the current 1 s / 100-entry buffer. Both can be overridden via `service.discussion.*`.
 
-A single 60 s sweep timer evicts records older than the TTL from both indexes. The discussion side mirrors the existing 24 h `conversationTtlMs`. The origin side gains a periodic timer it did not have before — today's `OriginIndex.sweep(now)` is caller-driven; the service moves it onto the same cadence as discussions to put both indexes under one lifecycle. The origin TTL stays at 24 h.
+A single sweep timer evicts records older than the TTL from both indexes; the cadence carries over from today's `DEFAULT_SWEEP_INTERVAL_MS` (60 s). The discussion side keeps the existing 24 h `conversationTtlMs`. The origin side gains a periodic timer it did not have before — today's `OriginIndex.sweep(now)` is caller-driven; the service moves it onto the same cadence as discussions to put both indexes under one lifecycle. The origin TTL stays at 24 h.
 
 ## Key decisions
 
@@ -129,15 +141,16 @@ A single 60 s sweep timer evicts records older than the TTL from both indexes. T
 |---|---|---|---|
 | Surface shape | One `Discussion` service with seven RPCs covering both record kinds | Two services (`Discussion` + `Origin`) | Spec mandates a single interface. Matches `trace.Trace` and `graph.Graph` — one proto, one stub, one supervised process. |
 | Resume contract over gRPC | Widen the store contract with `loadByCorrelation` and `listOpenRecesses`; amend `ResumeScheduler` to use them in place of `store.loaded` / `store.loadData()` / `store.index.values()` | Keep the four-method adapter (`loadByChannel`, `add`, `flush`, `shutdown`) and let `ResumeScheduler.rearm` and `#findContextWithRfc` fail | The current `ResumeScheduler` reaches past `loadByChannel` to walk every record. A 4-method adapter cannot satisfy that. Either widen the contract or move resume into the service; widening keeps the dispatcher + scheduler composition on the bridge side, which is what the libbridge contract is designed around. |
-| Message name | `DiscussionRecord` | `Discussion` | proto3 allows `service Discussion` + `message Discussion` in the same package, but every peer service (`trace.Trace`/`Span`, `graph.Graph`/`PatternQuery`) keeps the names distinct; matching the convention avoids codegen-tool friction. |
-| Not-found channel | gRPC `NOT_FOUND` status from `LoadDiscussion` / `LoadDiscussionByCorrelation` | Sentinel empty `id` on a default-constructed `DiscussionRecord` | Status codes are how every other librpc service signals absence; the adapter translates `NOT_FOUND` to `null` so the bridge call sites read exactly as they do today. |
+| Message name | `DiscussionRecord` | `Discussion` | proto3 allows `service Discussion` + `message Discussion` in the same package, but no peer service has a message that shares its service name; matching that convention avoids codegen-tool friction. |
+| Not-found channel | gRPC `NOT_FOUND` status from `LoadDiscussion` / `LoadDiscussionByCorrelation` | Sentinel empty `id` on a default-constructed `DiscussionRecord` | No peer service currently signals absence — every other librpc method either returns a collection or is a write that does not fail with "missing." `NOT_FOUND` is the standard gRPC status for this case, and the adapter translates it to `null` so bridge call sites read exactly as they do today. |
 | Resume trigger over the wire | Typed `ResumeTrigger` message; on-record field name stays `trigger` | `string trigger_json` carrying the JSON-serialised trigger | A typed message keeps the spec's "persisted record shape is unchanged" intact — the on-disk JSONL field is still `trigger`, not `trigger_json` — and gives the service introspection over recess state if a future tool wants it. |
 | Opaque participant metadata | JSON string per participant | `google.protobuf.Struct` or first-class proto fields | The Bot Framework `ConversationReference` and GitHub node metadata are channel-shaped and outside this service's concern. A JSON string keeps the contract minimal and matches how the JSONL already round-trips these blobs. |
 | Sweep ownership | Server-internal 60 s timer plus a `Sweep` RPC for tests | Bridge-driven sweep | The TTL is store-owned, not caller-owned. A test-callable RPC keeps the integration test deterministic without exposing scheduling to production callers. The origin index gains a periodic timer it did not have before — intentional, so both indexes share one lifecycle. |
 | Origin path on ghbridge | Direct `client.HasOrigin` / `client.RecordOrigin` calls; no adapter wrapper | Wrap the client in an `OriginIndex`-shaped class in libbridge | The actual call sites are explicit; the previous `.flush()` after each reply and the `.shutdown()` on stop disappear because the service owns batching and its own lifecycle. |
 | Storage root | `createStorage("bridges")` inside the service, both indexes share it | Per-service root (`createStorage("svcdiscussion")`) with `indexKey` overrides | Lands the two files at the canonical paths the spec requires with no `indexKey` gymnastics. The bridges' previous `bridges/{ghbridge,msbridge}/` directories are not read or written by any code after cutover. |
-| Buffering / durability | Server keeps the existing `BufferedIndex` cadences; adapter `flush()` is a no-op | Per-call synchronous append, or pass-through buffering on the client | Per-call append would slow the hot path. Client-side buffering would lose state when the bridge crashes. Server-side buffering is the simplest viable choice; durability does not improve relative to today (the service can still lose buffered writes on crash), and the design is honest that the crash window moves rather than disappears. |
-| Service supervision | The product starter that bundles the bridges (today none of the shipped starters does) gains `svcdiscussion` in its `init.services` list before the bridge entries | Lazy connection with retries from the bridges | Today's bridges are not in any shipped starter; this design does not assume they are. When a starter does bundle them, `svcdiscussion` must come first so the bridges' `createClient("discussion", …)` resolves at startup. |
+| Buffering / durability | Server keeps the existing `BufferedIndex` cadences; adapter `flush()` is a no-op | Per-call synchronous append, or pass-through buffering on the client | Per-call append would slow the hot path. Client-side buffering would lose state when the bridge crashes. Server-side buffering keeps the simplest viable shape. |
+| Write-barrier semantics | `Dispatcher.dispatch` and `ResumeScheduler.#fireElapsed` treat `add` + `flush` as a hard write barrier today; under this design `add` succeeds when the record is in the service's in-memory index but not necessarily on disk, and `flush` is a no-op | Issue a synchronous server-side flush from `flush()` on every call | Today a per-bridge crash loses that bridge's unflushed buffer. Under this design a `svcdiscussion` crash loses any unflushed buffered writes from both bridges at once — the same window, larger blast radius. The plan must accept this trade or revisit the write-barrier. |
+| Service supervision | Any starter that supervises a bridge also lists `discussion` in its `init.services` ahead of the bridge entries | Lazy connection with retries from the bridges | None of the shipped starters supervise the bridges today, so the design states the conditional rule rather than naming a concrete starter. Where a starter does bundle them, `discussion` must come first so the bridges' `createClient("discussion", …)` resolves at startup. |
 
 ## What this design does not cover
 

--- a/specs/1300-svcdiscussion/spec.md
+++ b/specs/1300-svcdiscussion/spec.md
@@ -2,12 +2,13 @@
 
 ## Persona and job
 
-Hired by **Teams Using Agents** to give the bridges a single source of truth
-for cross-channel discussion state — a foundation the agent team can later
-query to recall what was said in any thread, from any side.
+Hired by **Teams Using Agents** to give the threaded-discussion bridges
+a single source of truth for cross-channel state — a foundation the
+agent team can later query to recall what was said in any thread, from
+any side.
 
-Related JTBD: *Run an autonomous, continuously improving development team
-that plans, ships, studies its own traces, and acts on findings.*
+Related JTBD: *Teams Using Agents — Run a Continuously Improving Agent
+Team* ([JTBD.md](../../JTBD.md)).
 
 ## Problem
 
@@ -15,94 +16,108 @@ The threaded-discussion bridges (`services/ghbridge`, `services/msbridge`)
 each own a private on-disk store, and the agent team cannot reach across
 them.
 
-| Concern | Where it lives today |
+| Concern | How it is held today |
 |---|---|
-| GitHub Discussions thread state | `data/bridges/ghbridge/discussions.jsonl` written by ghbridge's in-process `DiscussionContextStore`. |
-| Microsoft Teams thread state | `data/bridges/msbridge/discussions.jsonl` written by msbridge's in-process `DiscussionContextStore`. |
-| Self-echo dedupe for GitHub replies | `data/bridges/ghbridge/origins.jsonl` written by ghbridge's in-process `OriginIndex`. |
+| GitHub Discussions thread state | A per-process discussion store inside `services/ghbridge`. |
+| Microsoft Teams thread state | A separate per-process discussion store inside `services/msbridge`. |
+| Self-echo dedupe for GitHub replies | A per-process origin index inside `services/ghbridge`. |
 
 Three concrete consequences fall out of that split:
 
-1. **Records are partitioned by channel even though the schema is uniform.**
-   `DiscussionContextStore.keyOf("github-discussions", id)` and
-   `keyOf("msteams", id)` already share a key space, but the two files live
-   under different process roots and neither bridge can read the other's
-   data. A query like "show me every open conversation across all channels"
-   has no place to land.
-2. **Future cross-bridge agent tools cannot be built.** Recalling a thread's
-   history from outside the originating bridge — for example, a Kata RFC
-   summary that cites a Teams conversation — requires a callable surface
-   over the shared store. The current `BufferedIndex` is a process-local
-   `Map`; there is no off-process reader.
-3. **`OriginIndex` is locked to one bridge.** Self-echo dedupe is the only
-   thing keeping `discussion_comment.created` from feeding ghbridge's own
-   replies back into the dispatch dance. As soon as another channel needs
-   the same protection — or as soon as the records become interesting to
-   trace queries — the index has nowhere to live except a second per-bridge
-   file.
+1. **Records are partitioned by process even though the schema is
+   uniform.** The two bridges already agree on a single key space —
+   that is what lets the channel-agnostic `kata-dispatch.yml` workflow
+   resume a conversation from either side — but the records themselves
+   live behind different process roots and neither bridge can read the
+   other's data. A query like "show me every open conversation across
+   all channels" has no place to land.
+2. **Future cross-bridge agent tools cannot be built.** Recalling a
+   thread's history from outside the originating bridge — for example,
+   a Kata RFC summary that cites a Teams conversation — requires a
+   callable surface over the shared store. Today both stores are
+   in-process state in their respective bridges; nothing outside the
+   bridge can read them.
+3. **Origin dedupe has no shared home.** Self-echo dedupe is the only
+   thing keeping `discussion_comment.created` from feeding ghbridge's
+   own replies back into the dispatch dance, and it currently runs only
+   in ghbridge (the Microsoft Teams adapter does not echo bot messages,
+   so msbridge does not need it today). The record kind is already
+   channel-agnostic in shape; placing it next to the discussion store
+   keeps both kinds of records under one lifecycle.
 
 The `libbridge` invariants forbid embedding service-level logic in the
-library, and `services/CLAUDE.md` mandates that "when building a product
-feature that requires graph queries, vector search, pathway derivation,
-trace collection, or MCP tool exposure, use the corresponding service. Do
-not embed service-level logic in products." A shared store is exactly that
-kind of service-level capability, and today no such service exists.
+library, and `services/CLAUDE.md` mandates that service-level
+capabilities be reached through services, not embedded in callers. A
+shared store is exactly that kind of service-level capability, and
+today no such service exists.
 
 ## Scope
 
 ### In scope
 
-- A new service, `services/svcdiscussion`, owning the canonical store for
-  every threaded-discussion bridge.
-- One gRPC interface that exposes both kinds of records the bridges write
-  today: thread-state CRUD keyed by `(channel, discussion_id)` and origin
-  dedupe keyed by channel-side reply id.
-- Both bridges (`services/ghbridge`, `services/msbridge`) become gRPC
-  clients of the new service. Their in-process `DiscussionContextStore`
-  and `OriginIndex` go away.
-- A single canonical on-disk location for each kind of record:
-  - `data/bridges/discussions.jsonl`
-  - `data/bridges/origins.jsonl`
-- The 24-hour conversation TTL and the periodic sweep for stale records
-  continue to apply, owned by the service instead of by each bridge.
-- `libbridge` retains only the channel-agnostic primitives that have no
-  state of their own (`Acknowledgement`, `CallbackRegistry`, `Dispatcher`,
-  `ResumeScheduler`, prompt/history/trigger helpers,
-  `createBridgeServer`). The two store classes leave the package.
-- Clean break: when the new service is in place, the per-bridge JSONL
-  files at `data/bridges/{ghbridge,msbridge}/` are no longer written or
-  read. No migration utility, no compatibility shim.
+- A new service, `services/svcdiscussion`, owning the canonical store
+  for every threaded-discussion bridge.
+- A single service interface that exposes both kinds of records the
+  bridges write today — discussion state keyed by
+  `(channel, discussion_id)` and origin dedupe keyed by channel-side
+  reply id — plus the operations the bridges actually need: load a
+  discussion by channel, upsert a discussion record, check existence by
+  origin id, record an origin id, and trigger a sweep of expired
+  records.
+- Both bridges (`services/ghbridge`, `services/msbridge`) become
+  clients of the new service. Their in-process discussion-store and
+  origin-index classes go away.
+- One canonical on-disk location for each kind of record, owned and
+  written exclusively by the service:
+  `data/bridges/discussions.jsonl` and `data/bridges/origins.jsonl`.
+- The 24-hour conversation TTL and the periodic sweep of stale records
+  move from per-bridge timers into the service.
+- `libbridge` retains only the channel-agnostic primitives that have
+  no shared state of their own — the acknowledgement and
+  callback-handling primitives, the dispatcher, the resume scheduler,
+  the rate limiter, the prompt/history/trigger helpers, and the bridge
+  HTTP wiring. The discussion-store and origin-index classes leave the
+  package. The record factory and payload validator stay because the
+  bridges still construct the record locally before sending it to the
+  service.
+- The persisted record shape is unchanged, including the per-record
+  `pending_callbacks` map that pairs callback tokens with correlation
+  ids across restarts. The in-memory callback-token registry the
+  dispatcher uses on the hot path stays process-local on each bridge.
+- Clean break: when the new service is in place, no code reads or
+  writes the per-bridge JSONL files at `data/bridges/{ghbridge,msbridge}/`.
+  No migration utility, no compatibility shim. Any conversations
+  in flight at cutover become un-resumable on the new service; the
+  legacy files expire under their existing 24-hour TTL on disk and are
+  ignored thereafter.
 
 ### Excluded
 
 - Agent-facing tool surfaces that read the store (cross-bridge lookup,
   history recall in prompts, MCP tools over `service.mcp`). Foundation
   only; the tool catalogue is a follow-up.
-- Any change to the kata-dispatch workflow contract, the callback payload
-  shape, the suspend/resume trigger model, or the
-  `(prompt, callback_url, correlation_id, discussion_id)` workflow inputs.
+- Any change to the kata-dispatch workflow contract, the callback
+  payload shape, the suspend/resume trigger model, or the
+  `(prompt, callback_url, correlation_id, discussion_id)` workflow
+  inputs.
 - Any change to channel adapters: GitHub GraphQL strings stay in
   `services/ghbridge/src/graphql.js`; Bot Framework intake stays in
   `services/msbridge/src/teams.js`.
 - Adding a third bridge or a third channel.
-- Removing the existing in-flight conversations from the two
-  per-bridge files. They expire under their own 24-hour TTL.
-- Persisting the `CallbackRegistry` token map in the service. It remains
-  process-local on each bridge.
 
 ## Success criteria
 
 | Claim | Verifies via |
 |---|---|
-| A `services/svcdiscussion` service exists with the same structural shape as the other gRPC services. | `ls services/svcdiscussion/{server.js,index.js,proto,test}` lists each entry. |
-| The service exposes both record kinds — thread state and origin dedupe — on a single gRPC surface. | The proto definition declares one service whose methods cover loading, saving, and sweeping discussions and recording and checking origin reply ids. |
-| Both bridges depend on the service through generated clients, not on the removed library classes. | `grep -E "DiscussionContextStore\|OriginIndex" services/{ghbridge,msbridge}/` returns empty; the bridges import a discussion client from the generated services. |
-| The two store classes are gone from `libbridge`. | `ls libraries/libbridge/src/{discussion-context,origin-index}.js` reports both files absent. |
-| `libbridge` still exports the channel-agnostic primitives the bridges compose. | `Acknowledgement`, `CallbackRegistry`, `Dispatcher`, `ResumeScheduler`, `createBridgeServer`, the prompt and trigger helpers, and `newDiscussionContext` are still re-exported from `libraries/libbridge/src/index.js`. |
-| Discussion state from both channels lands in one file, origins in another. | After exercising both bridges end-to-end against the service, `data/bridges/discussions.jsonl` contains records with both `github-discussions:…` and `msteams:…` ids; `data/bridges/origins.jsonl` is the only origin file on disk. |
-| The per-bridge files are no longer written. | After end-to-end exercise, `data/bridges/ghbridge/` and `data/bridges/msbridge/` contain no `discussions.jsonl` or `origins.jsonl`. |
-| The 24-hour conversation TTL is honoured by the service. | A test that seeds a record with `last_active_at` older than 24 hours and triggers a sweep observes the record removed. |
-| The service is supervised the same way as other gRPC services. | `config/config.json` (or the starter `starter/config.json` consumed by `fit-rc`) lists `svcdiscussion` under `init.services`. |
+| A `services/svcdiscussion` service exists and follows the structural conventions documented in `services/CLAUDE.md`. | The service directory contains a server entry point, an implementation module, a proto definition, and a test directory at the conventional locations for a service. |
+| The service exposes both record kinds — thread state and origin dedupe — on one service interface. | The proto definition declares a single service whose RPC methods cover loading a discussion by channel, upserting a discussion record, checking and recording origin reply ids, and triggering a sweep. |
+| Neither bridge contains a reference to the removed in-process store types. | A repository-wide search across `services/ghbridge/` and `services/msbridge/` returns no occurrences of either removed type name. |
+| The store and origin classes are gone from `libbridge`. | The `@forwardimpact/libbridge` package no longer exports the two types, and the package source no longer contains either implementation module. |
+| `libbridge` still exports every other symbol the bridges currently import from it. | Every symbol that `services/ghbridge` and `services/msbridge` import from `@forwardimpact/libbridge` today, except the two removed types, is still importable after the change. |
+| Discussion state from both channels lands in one file; origins in another. | After both bridges exchange at least one message with the agent team, `data/bridges/discussions.jsonl` contains records with both `github-discussions:…` and `msteams:…` ids, and `data/bridges/origins.jsonl` is the only origin file on disk. |
+| The per-bridge files are no longer written. | After end-to-end exercise, the directories `data/bridges/ghbridge/` and `data/bridges/msbridge/` contain no `discussions.jsonl` or `origins.jsonl`. |
+| The 24-hour conversation TTL is honoured by the service. | A test seeds a record whose last activity is older than 24 hours, lets the periodic sweep run, and observes the record removed from a subsequent load. |
+| The service is supervised the same way as peer gRPC services. | The starter configuration that ships with the products bundling these services lists `svcdiscussion` alongside the existing supervised services. |
 | ghbridge's self-echo dedupe still suppresses inbound webhooks for replies the bridge just posted. | An integration test posts a reply through ghbridge, replays the resulting `discussion_comment.created` webhook, and observes no dispatch. |
 | msbridge's resume-from-recess flow still finds the right thread state after restart. | An integration test enters a recess, restarts msbridge, fires the inbound activity that satisfies the trigger, and observes a fresh dispatch. |
-| `libbridge/CLAUDE.md` reflects the new boundary. | The "Invariants" and "What lives where" sections no longer claim that `DiscussionContextStore` belongs to the library, and they direct readers to `services/svcdiscussion` for the persisted state. |
+| `libbridge` documentation reflects the new ownership boundary. | The `libbridge` package documentation no longer claims ownership of the persisted discussion or origin state and directs readers to the new service for that state. |

--- a/specs/1300-svcdiscussion/spec.md
+++ b/specs/1300-svcdiscussion/spec.md
@@ -1,0 +1,108 @@
+# Spec 1300 — svcdiscussion
+
+## Persona and job
+
+Hired by **Teams Using Agents** to give the bridges a single source of truth
+for cross-channel discussion state — a foundation the agent team can later
+query to recall what was said in any thread, from any side.
+
+Related JTBD: *Run an autonomous, continuously improving development team
+that plans, ships, studies its own traces, and acts on findings.*
+
+## Problem
+
+The threaded-discussion bridges (`services/ghbridge`, `services/msbridge`)
+each own a private on-disk store, and the agent team cannot reach across
+them.
+
+| Concern | Where it lives today |
+|---|---|
+| GitHub Discussions thread state | `data/bridges/ghbridge/discussions.jsonl` written by ghbridge's in-process `DiscussionContextStore`. |
+| Microsoft Teams thread state | `data/bridges/msbridge/discussions.jsonl` written by msbridge's in-process `DiscussionContextStore`. |
+| Self-echo dedupe for GitHub replies | `data/bridges/ghbridge/origins.jsonl` written by ghbridge's in-process `OriginIndex`. |
+
+Three concrete consequences fall out of that split:
+
+1. **Records are partitioned by channel even though the schema is uniform.**
+   `DiscussionContextStore.keyOf("github-discussions", id)` and
+   `keyOf("msteams", id)` already share a key space, but the two files live
+   under different process roots and neither bridge can read the other's
+   data. A query like "show me every open conversation across all channels"
+   has no place to land.
+2. **Future cross-bridge agent tools cannot be built.** Recalling a thread's
+   history from outside the originating bridge — for example, a Kata RFC
+   summary that cites a Teams conversation — requires a callable surface
+   over the shared store. The current `BufferedIndex` is a process-local
+   `Map`; there is no off-process reader.
+3. **`OriginIndex` is locked to one bridge.** Self-echo dedupe is the only
+   thing keeping `discussion_comment.created` from feeding ghbridge's own
+   replies back into the dispatch dance. As soon as another channel needs
+   the same protection — or as soon as the records become interesting to
+   trace queries — the index has nowhere to live except a second per-bridge
+   file.
+
+The `libbridge` invariants forbid embedding service-level logic in the
+library, and `services/CLAUDE.md` mandates that "when building a product
+feature that requires graph queries, vector search, pathway derivation,
+trace collection, or MCP tool exposure, use the corresponding service. Do
+not embed service-level logic in products." A shared store is exactly that
+kind of service-level capability, and today no such service exists.
+
+## Scope
+
+### In scope
+
+- A new service, `services/svcdiscussion`, owning the canonical store for
+  every threaded-discussion bridge.
+- One gRPC interface that exposes both kinds of records the bridges write
+  today: thread-state CRUD keyed by `(channel, discussion_id)` and origin
+  dedupe keyed by channel-side reply id.
+- Both bridges (`services/ghbridge`, `services/msbridge`) become gRPC
+  clients of the new service. Their in-process `DiscussionContextStore`
+  and `OriginIndex` go away.
+- A single canonical on-disk location for each kind of record:
+  - `data/bridges/discussions.jsonl`
+  - `data/bridges/origins.jsonl`
+- The 24-hour conversation TTL and the periodic sweep for stale records
+  continue to apply, owned by the service instead of by each bridge.
+- `libbridge` retains only the channel-agnostic primitives that have no
+  state of their own (`Acknowledgement`, `CallbackRegistry`, `Dispatcher`,
+  `ResumeScheduler`, prompt/history/trigger helpers,
+  `createBridgeServer`). The two store classes leave the package.
+- Clean break: when the new service is in place, the per-bridge JSONL
+  files at `data/bridges/{ghbridge,msbridge}/` are no longer written or
+  read. No migration utility, no compatibility shim.
+
+### Excluded
+
+- Agent-facing tool surfaces that read the store (cross-bridge lookup,
+  history recall in prompts, MCP tools over `service.mcp`). Foundation
+  only; the tool catalogue is a follow-up.
+- Any change to the kata-dispatch workflow contract, the callback payload
+  shape, the suspend/resume trigger model, or the
+  `(prompt, callback_url, correlation_id, discussion_id)` workflow inputs.
+- Any change to channel adapters: GitHub GraphQL strings stay in
+  `services/ghbridge/src/graphql.js`; Bot Framework intake stays in
+  `services/msbridge/src/teams.js`.
+- Adding a third bridge or a third channel.
+- Removing the existing in-flight conversations from the two
+  per-bridge files. They expire under their own 24-hour TTL.
+- Persisting the `CallbackRegistry` token map in the service. It remains
+  process-local on each bridge.
+
+## Success criteria
+
+| Claim | Verifies via |
+|---|---|
+| A `services/svcdiscussion` service exists with the same structural shape as the other gRPC services. | `ls services/svcdiscussion/{server.js,index.js,proto,test}` lists each entry. |
+| The service exposes both record kinds — thread state and origin dedupe — on a single gRPC surface. | The proto definition declares one service whose methods cover loading, saving, and sweeping discussions and recording and checking origin reply ids. |
+| Both bridges depend on the service through generated clients, not on the removed library classes. | `grep -E "DiscussionContextStore\|OriginIndex" services/{ghbridge,msbridge}/` returns empty; the bridges import a discussion client from the generated services. |
+| The two store classes are gone from `libbridge`. | `ls libraries/libbridge/src/{discussion-context,origin-index}.js` reports both files absent. |
+| `libbridge` still exports the channel-agnostic primitives the bridges compose. | `Acknowledgement`, `CallbackRegistry`, `Dispatcher`, `ResumeScheduler`, `createBridgeServer`, the prompt and trigger helpers, and `newDiscussionContext` are still re-exported from `libraries/libbridge/src/index.js`. |
+| Discussion state from both channels lands in one file, origins in another. | After exercising both bridges end-to-end against the service, `data/bridges/discussions.jsonl` contains records with both `github-discussions:…` and `msteams:…` ids; `data/bridges/origins.jsonl` is the only origin file on disk. |
+| The per-bridge files are no longer written. | After end-to-end exercise, `data/bridges/ghbridge/` and `data/bridges/msbridge/` contain no `discussions.jsonl` or `origins.jsonl`. |
+| The 24-hour conversation TTL is honoured by the service. | A test that seeds a record with `last_active_at` older than 24 hours and triggers a sweep observes the record removed. |
+| The service is supervised the same way as other gRPC services. | `config/config.json` (or the starter `starter/config.json` consumed by `fit-rc`) lists `svcdiscussion` under `init.services`. |
+| ghbridge's self-echo dedupe still suppresses inbound webhooks for replies the bridge just posted. | An integration test posts a reply through ghbridge, replays the resulting `discussion_comment.created` webhook, and observes no dispatch. |
+| msbridge's resume-from-recess flow still finds the right thread state after restart. | An integration test enters a recess, restarts msbridge, fires the inbound activity that satisfies the trigger, and observes a fresh dispatch. |
+| `libbridge/CLAUDE.md` reflects the new boundary. | The "Invariants" and "What lives where" sections no longer claim that `DiscussionContextStore` belongs to the library, and they direct readers to `services/svcdiscussion` for the persisted state. |


### PR DESCRIPTION
## Summary

- Spec 1300 — a new `svcdiscussion` gRPC service owns the canonical discussion and origin records for both threaded-discussion bridges (`services/ghbridge`, `services/msbridge`). Clean break from the current per-bridge `data/bridges/{ghbridge,msbridge}/` files; data lands at `data/bridges/discussions.jsonl` and `data/bridges/origins.jsonl`.
- Design 1300-a — single `Discussion` service with seven RPCs (`LoadDiscussion`, `LoadDiscussionByCorrelation`, `ListOpenRecesses`, `SaveDiscussion`, `HasOrigin`, `RecordOrigin`, `Sweep`). Bridges wrap the generated client in a `DiscussionAdapter` that satisfies `Dispatcher` and a widened `ResumeScheduler` contract — preserving the libbridge invariant against gRPC dependencies. Two stores share one storage root under the service.
- Status: `wiki/STATUS.md` row advanced to `1300 design draft` (no approval signal).

Spec and design each passed a 3+3 / 3+3 sub-agent review panel; one substantial revision round per artifact addressed consensus findings.

Also bundles a `chore` commit that applies pre-existing biome formatter drift across 10 unrelated files (purely whitespace; flagged in its own commit for easy review).

## Test plan

- [x] Spec review panel (3 product-manager + 3 staff-engineer) clean
- [x] Design review panel (3 staff-engineer) clean after revision round 2
- [x] `bun run check` — passes for code; one pre-existing wiki-audit failure (`wiki/security-engineer.md` 74 vs 72 line budget) being fixed separately
- [x] `bun run test` — code tests pass; 17 libwiki test failures are sandbox-only (`git commit` rejects without global user config in `/tmp` fixtures), not regressions from this branch
- [ ] Human review of spec and design artifacts under `specs/1300-svcdiscussion/`

---
_Generated by [Claude Code](https://claude.ai/code/session_017KEVuGXhnhWnr7DZy3itPh)_