### PR TITLE
refactor(libwiki,libxmr): unified audit budgets + simplified storyboard rendering

### DIFF
--- a/.claude/agents/references/memory-protocol.md
+++ b/.claude/agents/references/memory-protocol.md
@@ -86,7 +86,7 @@ Each `wiki/<agent>.md` conforms to a mechanically-checkable contract —
 `**Last run**:` → `## Message Inbox` (with `<!-- memo:inbox -->` marker —
 MUST be the first H2) → agent-specific H2 sections → `## Open Blockers`.
 
-**Line budget: 72 lines** (`SUMMARY_LINE_BUDGET`); **word budget: 12 800
+**Line budget: 72 lines** (`SUMMARY_LINE_BUDGET`); **word budget: 6 400
 words** (`SUMMARY_WORD_BUDGET`) to backstop dense single-line prose. State,
 not history.
 
@@ -96,7 +96,7 @@ Weekly logs (`wiki/<agent>-YYYY-Www.md`) are append-only Tier 2 records.
 Named readers: `kata-wiki-curate` (always), `kata-session` (for experiment
 verification), agents explicitly investigating past decisions.
 
-**Line budget: 496 lines** (`WEEKLY_LOG_LINE_BUDGET`); **word budget: 6 400
+**Line budget: 496 lines** (`WEEKLY_LOG_LINE_BUDGET`); **word budget: 12 800
 words** (`WEEKLY_LOG_WORD_BUDGET`) to backstop dense single-line prose. A
 Tier 2 read of the largest legal weekly log consumes ≤2.5% of an agent's
 1M-token context window — the *context tax* every reader pays (closes **F3

--- a/.claude/agents/references/memory-protocol.md
+++ b/.claude/agents/references/memory-protocol.md
@@ -86,7 +86,7 @@ Each `wiki/<agent>.md` conforms to a mechanically-checkable contract —
 `**Last run**:` → `## Message Inbox` (with `<!-- memo:inbox -->` marker —
 MUST be the first H2) → agent-specific H2 sections → `## Open Blockers`.
 
-**Line budget: 72 lines** (`SUMMARY_LINE_BUDGET`); **word budget: 6 400
+**Line budget: 496 lines** (`SUMMARY_LINE_BUDGET`); **word budget: 6 400
 words** (`SUMMARY_WORD_BUDGET`) to backstop dense single-line prose. State,
 not history.
 
@@ -96,11 +96,16 @@ Weekly logs (`wiki/<agent>-YYYY-Www.md`) are append-only Tier 2 records.
 Named readers: `kata-wiki-curate` (always), `kata-session` (for experiment
 verification), agents explicitly investigating past decisions.
 
-**Line budget: 496 lines** (`WEEKLY_LOG_LINE_BUDGET`); **word budget: 12 800
+**Line budget: 496 lines** (`WEEKLY_LOG_LINE_BUDGET`); **word budget: 6 400
 words** (`WEEKLY_LOG_WORD_BUDGET`) to backstop dense single-line prose. A
 Tier 2 read of the largest legal weekly log consumes ≤2.5% of an agent's
 1M-token context window — the *context tax* every reader pays (closes **F3
-/ F17**).
+/ F17**). Storyboards (`wiki/storyboard-YYYY-MNN.md`) share the same
+budgets — 496 lines / 6 400 words — gated by `storyboard.line-budget` and
+`storyboard.word-budget` audit rules. The three budgets share numeric
+limits today; each surface keeps its own rule pair so the limits can
+diverge later if the context-tax model says one surface should be looser
+or tighter.
 
 Overflow rotates: `log` seals the current file as
 `<agent>-YYYY-Www-partN.md` and writes the day's append into a fresh

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -37,6 +37,7 @@ threshold crossed, classification flip). Empty if nothing changed — write
 #### {metric_name}
 
 <!-- xmr:{metric_name}:wiki/metrics/{skill}/{YYYY}.csv -->
+<!-- Do not edit. Generated from fit-wiki refresh. -->
 **Latest:** {value} · **Status:** {status from `bunx fit-xmr analyze`}
 
 ```

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -37,8 +37,6 @@ threshold crossed, classification flip). Empty if nothing changed — write
 #### {metric_name}
 
 <!-- xmr:{metric_name}:wiki/metrics/{skill}/{YYYY}.csv Do not edit. Auto-generated. -->
-**Latest:** {value} · **Status:** {status from `bunx fit-xmr analyze`}
-
 ```
 {14-line Wheeler/Vacanti X+mR chart. The chart labels μ, UPL, LPL, ±1.5σ
 zones, URL, R, and the run index — do not restate any of those numbers outside

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -62,46 +62,46 @@ something to say.)
 
 _What stands between the current condition and the target condition. Discovered
 through experiments, not predicted upfront. Each obstacle is a labeled GitHub
-issue; the storyboard carries one-line references. Full state lives in the
-issue._
+issue; the storyboard lists are rendered from GitHub state, not hand-edited._
 
 ### Active
 
-- **Current obstacle -->** Obstacle name (#NNN)
-- Other obstacle (#NNN)
+<!-- obstacles:open -->
+<!-- Do not edit. Generated from fit-wiki refresh. -->
+- **Obs #NNN — [obstacle name]**
+<!-- /obstacles -->
 
 ### Concluded (last 7 days)
 
-_One line per item: status (RESOLVED/ABANDONED), date closed, one-sentence
-verdict. Items older than 7 days are deleted; the closed issue is the permanent
-record._
-
-- ~~Obstacle name~~ (#NNN) — RESOLVED YYYY-MM-DD. [one-sentence verdict].
+<!-- obstacles:closed -->
+<!-- Do not edit. Generated from fit-wiki refresh. -->
+- **Obs #NNN — [obstacle name]**
+<!-- /obstacles -->
 
 ## Experiments
 
 _PDSA cycles run against the current obstacle. Each experiment is a labeled
-GitHub issue carrying the full PDSA content; the storyboard carries one-line
-references._
+GitHub issue carrying the full PDSA content; the storyboard lists are rendered
+from GitHub state, not hand-edited._
 
 ### Active
 
-- Exp N (#NNN) — [short name]
+<!-- experiments:open -->
+<!-- Do not edit. Generated from fit-wiki refresh. -->
+- **Exp #NNN — [experiment name]**
+<!-- /experiments -->
 
 ### Concluded (last 7 days)
 
-_One line per item: verdict (DELIVERED/PASS/FAIL/ABANDONED), date closed,
-one-sentence learning. Items older than 7 days are deleted; the closed issue is
-the permanent record._
-
-- **Exp N — [short name]** (#NNN) — DELIVERED YYYY-MM-DD. [one-sentence
-  learning].
+<!-- experiments:closed -->
+<!-- Do not edit. Generated from fit-wiki refresh. -->
+- **Exp #NNN — [experiment name]**
+<!-- /experiments -->
 
 ## Retention rule
 
 When concluding an obstacle or experiment, post the verdict as a closing comment
-on the issue, close the issue, and move the storyboard entry from `Active` to
-`Concluded (last 7 days)`. At the start of every storyboard session, scan
-`Concluded (last 7 days)` and delete any line whose closed-date is more than 7
-days before today. The decision is mechanical — date math, not judgment. The
-closed issue is the permanent record.
+on the issue and close the issue. `bunx fit-wiki refresh` rerenders both
+`Active` and `Concluded (last 7 days)` from GitHub state — no manual storyboard
+edit needed. Items aged out of the 7-day window drop off the next refresh
+automatically. The closed issue is the permanent record.

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -36,8 +36,7 @@ threshold crossed, classification flip). Empty if nothing changed — write
 
 #### {metric_name}
 
-<!-- xmr:{metric_name}:wiki/metrics/{skill}/{YYYY}.csv -->
-<!-- Do not edit. Generated from fit-wiki refresh. -->
+<!-- xmr:{metric_name}:wiki/metrics/{skill}/{YYYY}.csv Do not edit. Generated from fit-wiki refresh. -->
 **Latest:** {value} · **Status:** {status from `bunx fit-xmr analyze`}
 
 ```
@@ -48,7 +47,7 @@ the chart.}
 
 **Signals:** {fired-rule list (`xRule1`, `xRule2`, `xRule3`, `mrRule1`), or `—`
 if none}
-<!-- /xmr -->
+<!-- /xmr Do not edit. Generated from fit-wiki refresh. -->
 
 _Note:_ {one line, only when `status` is `signals_present` or a fired rule needs
 cross-referencing to a specific event; stable metrics get no prose}.
@@ -67,17 +66,15 @@ issue; the storyboard lists are rendered from GitHub state, not hand-edited._
 
 ### Active
 
-<!-- obstacles:open -->
-<!-- Do not edit. Generated from fit-wiki refresh. -->
+<!-- obstacles:open Do not edit. Generated from fit-wiki refresh. -->
 - **Obs #NNN — [obstacle name]**
-<!-- /obstacles -->
+<!-- /obstacles Do not edit. Generated from fit-wiki refresh. -->
 
 ### Concluded (last 7 days)
 
-<!-- obstacles:closed -->
-<!-- Do not edit. Generated from fit-wiki refresh. -->
+<!-- obstacles:closed Do not edit. Generated from fit-wiki refresh. -->
 - **Obs #NNN — [obstacle name]**
-<!-- /obstacles -->
+<!-- /obstacles Do not edit. Generated from fit-wiki refresh. -->
 
 ## Experiments
 
@@ -87,17 +84,15 @@ from GitHub state, not hand-edited._
 
 ### Active
 
-<!-- experiments:open -->
-<!-- Do not edit. Generated from fit-wiki refresh. -->
+<!-- experiments:open Do not edit. Generated from fit-wiki refresh. -->
 - **Exp #NNN — [experiment name]**
-<!-- /experiments -->
+<!-- /experiments Do not edit. Generated from fit-wiki refresh. -->
 
 ### Concluded (last 7 days)
 
-<!-- experiments:closed -->
-<!-- Do not edit. Generated from fit-wiki refresh. -->
+<!-- experiments:closed Do not edit. Generated from fit-wiki refresh. -->
 - **Exp #NNN — [experiment name]**
-<!-- /experiments -->
+<!-- /experiments Do not edit. Generated from fit-wiki refresh. -->
 
 ## Retention rule
 

--- a/.claude/skills/kata-session/references/storyboard-template.md
+++ b/.claude/skills/kata-session/references/storyboard-template.md
@@ -36,7 +36,7 @@ threshold crossed, classification flip). Empty if nothing changed — write
 
 #### {metric_name}
 
-<!-- xmr:{metric_name}:wiki/metrics/{skill}/{YYYY}.csv Do not edit. Generated from fit-wiki refresh. -->
+<!-- xmr:{metric_name}:wiki/metrics/{skill}/{YYYY}.csv Do not edit. Auto-generated. -->
 **Latest:** {value} · **Status:** {status from `bunx fit-xmr analyze`}
 
 ```
@@ -47,7 +47,7 @@ the chart.}
 
 **Signals:** {fired-rule list (`xRule1`, `xRule2`, `xRule3`, `mrRule1`), or `—`
 if none}
-<!-- /xmr Do not edit. Generated from fit-wiki refresh. -->
+<!-- /xmr -->
 
 _Note:_ {one line, only when `status` is `signals_present` or a fired rule needs
 cross-referencing to a specific event; stable metrics get no prose}.
@@ -66,15 +66,15 @@ issue; the storyboard lists are rendered from GitHub state, not hand-edited._
 
 ### Active
 
-<!-- obstacles:open Do not edit. Generated from fit-wiki refresh. -->
-- **Obs #NNN — [obstacle name]**
-<!-- /obstacles Do not edit. Generated from fit-wiki refresh. -->
+<!-- obstacles:open Do not edit. Auto-generated. -->
+- #NNN [obstacle name]
+<!-- /obstacles -->
 
 ### Concluded (last 7 days)
 
-<!-- obstacles:closed Do not edit. Generated from fit-wiki refresh. -->
-- **Obs #NNN — [obstacle name]**
-<!-- /obstacles Do not edit. Generated from fit-wiki refresh. -->
+<!-- obstacles:closed Do not edit. Auto-generated. -->
+- #NNN [obstacle name]
+<!-- /obstacles -->
 
 ## Experiments
 
@@ -84,15 +84,15 @@ from GitHub state, not hand-edited._
 
 ### Active
 
-<!-- experiments:open Do not edit. Generated from fit-wiki refresh. -->
-- **Exp #NNN — [experiment name]**
-<!-- /experiments Do not edit. Generated from fit-wiki refresh. -->
+<!-- experiments:open Do not edit. Auto-generated. -->
+- #NNN [experiment name]
+<!-- /experiments -->
 
 ### Concluded (last 7 days)
 
-<!-- experiments:closed Do not edit. Generated from fit-wiki refresh. -->
-- **Exp #NNN — [experiment name]**
-<!-- /experiments Do not edit. Generated from fit-wiki refresh. -->
+<!-- experiments:closed Do not edit. Auto-generated. -->
+- #NNN [experiment name]
+<!-- /experiments -->
 
 ## Retention rule
 

--- a/libraries/libwiki/src/audit/rules.js
+++ b/libraries/libwiki/src/audit/rules.js
@@ -4,6 +4,8 @@ import {
   DECISION_HEADING,
   MEMO_INBOX_MARKER,
   PRIORITY_INDEX_HEADING,
+  STORYBOARD_LINE_BUDGET,
+  STORYBOARD_WORD_BUDGET,
   SUMMARY_LINE_BUDGET,
   SUMMARY_WORD_BUDGET,
   WEEKLY_LOG_LINE_BUDGET,
@@ -418,6 +420,24 @@ export const RULES = [
     when: storyboardExists,
     check: allRequiredLines(AGENT_H3_REQUIREMENTS),
     message: (s, r) => `storyboard: ${s.path} missing '### ${r.label}' H3`,
+  },
+  {
+    id: "storyboard.line-budget",
+    scope: "storyboard",
+    severity: "fail",
+    when: storyboardExists,
+    check: lineBudget(STORYBOARD_LINE_BUDGET),
+    message: (s, r) =>
+      `storyboard: ${s.path} has ${r.value} lines (limit ${STORYBOARD_LINE_BUDGET})`,
+  },
+  {
+    id: "storyboard.word-budget",
+    scope: "storyboard",
+    severity: "fail",
+    when: storyboardExists,
+    check: wordBudget(STORYBOARD_WORD_BUDGET),
+    message: (s, r) =>
+      `storyboard: ${s.path} has ${r.value} words (limit ${STORYBOARD_WORD_BUDGET})`,
   },
   {
     id: "storyboard.markers-balanced.xmr",

--- a/libraries/libwiki/src/audit/rules.js
+++ b/libraries/libwiki/src/audit/rules.js
@@ -25,11 +25,15 @@ const CLAIMS_HEADER_RE =
 const CLAIMS_SEPARATOR_RE =
   /^\|\s*---\s*\|\s*---\s*\|\s*---\s*\|\s*---\s*\|\s*---\s*\|\s*---\s*\|/m;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const XMR_OPEN_RE = /^<!--\s*xmr:([^:\s]+):([^\s]+)\s*-->\s*$/;
-const XMR_CLOSE_RE = /^<!--\s*\/xmr\s*-->\s*$/;
+// Marker regexes (mirror of marker-scanner.js): tolerate optional trailing
+// text inside the marker so an open marker can carry an inline notice like
+// "Do not edit. Auto-generated." without breaking the audit's balance check.
+const XMR_OPEN_RE = /^<!--\s*xmr:([^:\s]+):(\S+)(?:\s+[^>]*?)?\s*-->\s*$/;
+const XMR_CLOSE_RE = /^<!--\s*\/xmr(?:\s+[^>]*?)?\s*-->\s*$/;
 const ISSUE_OPEN_RE =
-  /^<!--\s*(obstacles|experiments):(open|closed)(?::(\d+d))?\s*-->\s*$/;
-const ISSUE_CLOSE_RE = /^<!--\s*\/(obstacles|experiments)\s*-->\s*$/;
+  /^<!--\s*(obstacles|experiments):(open|closed)(?::(\d+d))?(?:\s+[^>]*?)?\s*-->\s*$/;
+const ISSUE_CLOSE_RE =
+  /^<!--\s*\/(obstacles|experiments)(?:\s+[^>]*?)?\s*-->\s*$/;
 
 // improvement-coach is the storyboard facilitator and carries no domain
 // metrics; only the five domain agents need their own H3.

--- a/libraries/libwiki/src/audit/scopes.js
+++ b/libraries/libwiki/src/audit/scopes.js
@@ -107,6 +107,8 @@ function loadStoryboard(wikiRoot, today) {
     fileLines: text.split("\n"),
     exists,
     yearMonth: `${yyyy}-M${mm}`,
+    lines: countLines(text),
+    words: countWords(text),
   };
 }
 

--- a/libraries/libwiki/src/block-renderer.js
+++ b/libraries/libwiki/src/block-renderer.js
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { analyze, renderChart, MIN_POINTS } from "@forwardimpact/libxmr";
+import { GENERATED_NOTICE } from "./issue-list-renderer.js";
 
 /** Error thrown when an XmR block cannot be rendered due to missing CSV or metric. */
 export class BlockRenderError extends Error {
@@ -48,6 +49,7 @@ export function renderBlock({
   const signalLine = formatSignals(m.signals);
 
   return [
+    GENERATED_NOTICE,
     `**Latest:** ${latestValue} · **Status:** ${status}`,
     "",
     "```",

--- a/libraries/libwiki/src/block-renderer.js
+++ b/libraries/libwiki/src/block-renderer.js
@@ -32,11 +32,8 @@ export function renderBlock({
     throw new BlockRenderError(`metric-not-found: ${metric}`);
   }
 
-  const latestValue = m.latest?.value ?? m.values[m.values.length - 1] ?? "—";
-  const status = m.status;
-
   let chartLines;
-  if (status === "insufficient_data") {
+  if (m.status === "insufficient_data") {
     chartLines = [
       `Insufficient data: ${m.n} points (need at least ${MIN_POINTS}).`,
     ];
@@ -45,16 +42,12 @@ export function renderBlock({
     chartLines = chartText.split("\n");
   }
 
-  const signalLine = formatSignals(m.signals);
-
   return [
-    `**Latest:** ${latestValue} · **Status:** ${status}`,
-    "",
     "```",
     ...chartLines,
     "```",
     "",
-    `**Signals:** ${signalLine}`,
+    `**Signals:** ${formatSignals(m.signals)}`,
   ];
 }
 

--- a/libraries/libwiki/src/block-renderer.js
+++ b/libraries/libwiki/src/block-renderer.js
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { analyze, renderChart, MIN_POINTS } from "@forwardimpact/libxmr";
-import { GENERATED_NOTICE } from "./issue-list-renderer.js";
 
 /** Error thrown when an XmR block cannot be rendered due to missing CSV or metric. */
 export class BlockRenderError extends Error {
@@ -49,7 +48,6 @@ export function renderBlock({
   const signalLine = formatSignals(m.signals);
 
   return [
-    GENERATED_NOTICE,
     `**Latest:** ${latestValue} · **Status:** ${status}`,
     "",
     "```",

--- a/libraries/libwiki/src/commands/refresh.js
+++ b/libraries/libwiki/src/commands/refresh.js
@@ -1,17 +1,28 @@
 import { readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import fsAsync from "node:fs/promises";
 import { Finder } from "@forwardimpact/libutil";
 import { createScriptConfig } from "@forwardimpact/libconfig";
 import { scanMarkers } from "../marker-scanner.js";
 import { renderBlock, BlockRenderError } from "../block-renderer.js";
-import { renderIssueList } from "../issue-list-renderer.js";
+import { renderIssueList, parseRepoSlug } from "../issue-list-renderer.js";
 
 function currentStoryboardPath() {
   const now = new Date();
   const yyyy = now.getFullYear();
   const mm = String(now.getMonth() + 1).padStart(2, "0");
   return `wiki/storyboard-${yyyy}-M${mm}.md`;
+}
+
+function deriveParentRepo(parentDir) {
+  if (process.env.FIT_GH_REPO) return process.env.FIT_GH_REPO;
+  const r = spawnSync("git", ["-C", parentDir, "remote", "get-url", "origin"], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+  if (r.status !== 0) return null;
+  return parseRepoSlug(r.stdout);
 }
 
 function renderForBlock(block, projectRoot, ghContext) {
@@ -28,6 +39,7 @@ function renderForBlock(block, projectRoot, ghContext) {
       state: block.state,
       window: block.window,
       cwd: ghContext.cwd,
+      repo: ghContext.repo,
       token: ghContext.token,
     });
   }
@@ -66,8 +78,15 @@ export async function runRefreshCommand(values, args, _cli) {
   }
   // Spawn `gh` from the project root so it resolves the monorepo's origin
   // instead of whatever git context the caller's cwd happens to be in (the
-  // wiki sibling repo, a subagent worktree, a service dir, etc.).
-  const ghContext = { cwd: projectRoot, token };
+  // wiki sibling repo, a subagent worktree, a service dir, etc.). Also
+  // resolve an explicit owner/repo slug so `gh` works when origin has been
+  // rewritten to a proxy URL (sandbox environments) — `FIT_GH_REPO` env
+  // overrides the parsed origin.
+  const ghContext = {
+    cwd: projectRoot,
+    repo: deriveParentRepo(projectRoot),
+    token,
+  };
 
   const lines = text.split("\n");
   let spliced = false;

--- a/libraries/libwiki/src/commands/refresh.js
+++ b/libraries/libwiki/src/commands/refresh.js
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import fsAsync from "node:fs/promises";
 import { Finder } from "@forwardimpact/libutil";
+import { createScriptConfig } from "@forwardimpact/libconfig";
 import { scanMarkers } from "../marker-scanner.js";
 import { renderBlock, BlockRenderError } from "../block-renderer.js";
 import { renderIssueList } from "../issue-list-renderer.js";
@@ -13,7 +14,7 @@ function currentStoryboardPath() {
   return `wiki/storyboard-${yyyy}-M${mm}.md`;
 }
 
-function renderForBlock(block, projectRoot) {
+function renderForBlock(block, projectRoot, ghContext) {
   if (block.kind === "xmr") {
     return renderBlock({
       metric: block.metric,
@@ -26,6 +27,8 @@ function renderForBlock(block, projectRoot) {
       topic: block.topic,
       state: block.state,
       window: block.window,
+      cwd: ghContext.cwd,
+      token: ghContext.token,
     });
   }
   return null;
@@ -40,7 +43,7 @@ function spliceBlock(lines, block, rendered) {
 }
 
 /** Re-render XmR chart blocks and issue-list blocks in a storyboard file. */
-export function runRefreshCommand(values, args, _cli) {
+export async function runRefreshCommand(values, args, _cli) {
   const logger = { debug() {} };
   const finder = new Finder(fsAsync, logger, process);
   const projectRoot = finder.findProjectRoot(process.cwd());
@@ -53,13 +56,26 @@ export function runRefreshCommand(values, args, _cli) {
   const blocks = scanMarkers(text);
   if (blocks.length === 0) return;
 
+  const config = await createScriptConfig("wiki");
+  let token = null;
+  try {
+    token = config.ghToken();
+  } catch {
+    // Missing token is non-fatal; issue-list renders will fail with a stderr
+    // warning and the block will collapse to the notice line.
+  }
+  // Spawn `gh` from the project root so it resolves the monorepo's origin
+  // instead of whatever git context the caller's cwd happens to be in (the
+  // wiki sibling repo, a subagent worktree, a service dir, etc.).
+  const ghContext = { cwd: projectRoot, token };
+
   const lines = text.split("\n");
   let spliced = false;
 
   for (let i = blocks.length - 1; i >= 0; i--) {
     const block = blocks[i];
     try {
-      const rendered = renderForBlock(block, projectRoot);
+      const rendered = renderForBlock(block, projectRoot, ghContext);
       if (!rendered) continue;
       spliceBlock(lines, block, rendered);
       spliced = true;

--- a/libraries/libwiki/src/constants.js
+++ b/libraries/libwiki/src/constants.js
@@ -18,5 +18,5 @@ export const DECISION_HEADING = "### Decision";
 // See spec 1060 design-a.md § Decision area 2 for the full anchor.
 export const WEEKLY_LOG_LINE_BUDGET = 496;
 export const SUMMARY_LINE_BUDGET = 72;
-export const WEEKLY_LOG_WORD_BUDGET = 6400;
-export const SUMMARY_WORD_BUDGET = 12800;
+export const WEEKLY_LOG_WORD_BUDGET = 12800;
+export const SUMMARY_WORD_BUDGET = 6400;

--- a/libraries/libwiki/src/constants.js
+++ b/libraries/libwiki/src/constants.js
@@ -19,7 +19,7 @@ export const DECISION_HEADING = "### Decision";
 // its own audit rule pair so the limits can diverge later if the
 // context-tax model says one surface should be looser or tighter.
 export const SUMMARY_LINE_BUDGET = 496;
-export const SUMMARY_WORD_BUDGET = 6400;
+export const SUMMARY_WORD_BUDGET = 2048;
 export const WEEKLY_LOG_LINE_BUDGET = 496;
 export const WEEKLY_LOG_WORD_BUDGET = 6400;
 export const STORYBOARD_LINE_BUDGET = 496;

--- a/libraries/libwiki/src/constants.js
+++ b/libraries/libwiki/src/constants.js
@@ -13,10 +13,14 @@ export const PRIORITY_INDEX_TABLE_HEADER =
   "| Item | Agents | Owner | Status | Added |";
 export const DECISION_HEADING = "### Decision";
 
-// Cap derivation: ≤2.5% of a 1M-token context window = 25k tokens;
-// converted via ≈42 tokens/line empirical proxy, then 64-aligned.
-// See spec 1060 design-a.md § Decision area 2 for the full anchor.
-export const WEEKLY_LOG_LINE_BUDGET = 496;
-export const SUMMARY_LINE_BUDGET = 72;
-export const WEEKLY_LOG_WORD_BUDGET = 12800;
+// Unified budgets for the three audited surfaces (summary, weekly-log,
+// storyboard). They share the same numeric limits today so the
+// context-tax floor is symmetric across surfaces; each surface keeps
+// its own audit rule pair so the limits can diverge later if the
+// context-tax model says one surface should be looser or tighter.
+export const SUMMARY_LINE_BUDGET = 496;
 export const SUMMARY_WORD_BUDGET = 6400;
+export const WEEKLY_LOG_LINE_BUDGET = 496;
+export const WEEKLY_LOG_WORD_BUDGET = 6400;
+export const STORYBOARD_LINE_BUDGET = 496;
+export const STORYBOARD_WORD_BUDGET = 6400;

--- a/libraries/libwiki/src/issue-list-renderer.js
+++ b/libraries/libwiki/src/issue-list-renderer.js
@@ -18,20 +18,30 @@ function daysAgo(today, n) {
   return d.toISOString().slice(0, 10);
 }
 
-/** Render an issue-list block for an obstacles/experiments marker. Returns markdown lines. `cwd` should be the parent monorepo's project root so `gh` resolves the correct origin; `token` is the resolved GH token (e.g. via `Config.ghToken()`). */
+/** Parse `owner/repo` from a git origin URL. Tolerates http(s), ssh, and proxy-rewritten URLs (e.g. `http://host/git/owner/repo`) by taking the last two path segments after stripping `.git`. Returns null when nothing parseable is found. */
+export function parseRepoSlug(originUrl) {
+  if (!originUrl) return null;
+  const stripped = originUrl.trim().replace(/\.git$/, "");
+  const match = stripped.match(/([^/:]+)\/([^/:]+)$/);
+  if (!match) return null;
+  return `${match[1]}/${match[2]}`;
+}
+
+/** Render an issue-list block for an obstacles/experiments marker. Returns markdown lines. `cwd` should be the parent monorepo's project root so `gh` resolves the correct origin; `repo` is an explicit `owner/name` slug used when the origin remote is unparseable by `gh` (e.g. sandbox proxy URLs); `token` is the resolved GH token (e.g. via `Config.ghToken()`). */
 export function renderIssueList({
   topic,
   state,
   window,
   cwd,
+  repo,
   token,
   today = new Date(),
   gh = defaultGh,
 }) {
   const ghState = state === "closed" ? "closed" : "open";
-  const args = [
-    "issue",
-    "list",
+  const args = ["issue", "list"];
+  if (repo) args.push("--repo", repo);
+  args.push(
     "--label",
     topic.replace(/s$/, ""),
     "--state",
@@ -40,7 +50,7 @@ export function renderIssueList({
     "number,title,labels,closedAt",
     "--limit",
     "100",
-  ];
+  );
   const result = gh(args, { cwd, token });
   if (result.status !== 0) {
     process.stderr.write(

--- a/libraries/libwiki/src/issue-list-renderer.js
+++ b/libraries/libwiki/src/issue-list-renderer.js
@@ -1,5 +1,8 @@
 import { spawnSync } from "node:child_process";
 
+export const GENERATED_NOTICE =
+  "<!-- Do not edit. Generated from fit-wiki refresh. -->";
+
 function defaultGh(args) {
   return spawnSync("gh", args, {
     encoding: "utf-8",
@@ -38,7 +41,7 @@ export function renderIssueList({
     process.stderr.write(
       `refresh: gh issue list failed for ${topic}:${state}\n`,
     );
-    return [];
+    return [GENERATED_NOTICE];
   }
   let issues;
   try {
@@ -47,7 +50,7 @@ export function renderIssueList({
     process.stderr.write(
       `refresh: gh issue list JSON parse failed for ${topic}:${state}\n`,
     );
-    return [];
+    return [GENERATED_NOTICE];
   }
 
   if (state === "closed") {
@@ -60,7 +63,7 @@ export function renderIssueList({
     );
   }
 
-  const lines = [];
+  const lines = [GENERATED_NOTICE];
   for (const issue of issues) {
     const tag = topic === "experiments" ? "Exp" : "Obs";
     lines.push(`- **${tag} #${issue.number} — ${issue.title}**`);

--- a/libraries/libwiki/src/issue-list-renderer.js
+++ b/libraries/libwiki/src/issue-list-renderer.js
@@ -3,10 +3,15 @@ import { spawnSync } from "node:child_process";
 export const GENERATED_NOTICE =
   "<!-- Do not edit. Generated from fit-wiki refresh. -->";
 
-function defaultGh(args) {
+function defaultGh(args, options) {
+  const env = options?.token
+    ? { ...process.env, GH_TOKEN: options.token }
+    : undefined;
   return spawnSync("gh", args, {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
+    cwd: options?.cwd,
+    env,
   });
 }
 
@@ -16,16 +21,18 @@ function daysAgo(today, n) {
   return d.toISOString().slice(0, 10);
 }
 
-/** Render an issue-list block for an obstacles/experiments marker. Returns markdown lines. */
+/** Render an issue-list block for an obstacles/experiments marker. Returns markdown lines. `cwd` should be the parent monorepo's project root so `gh` resolves the correct origin; `token` is the resolved GH token (e.g. via `Config.ghToken()`). */
 export function renderIssueList({
   topic,
   state,
   window,
+  cwd,
+  token,
   today = new Date(),
   gh = defaultGh,
 }) {
   const ghState = state === "closed" ? "closed" : "open";
-  const result = gh([
+  const args = [
     "issue",
     "list",
     "--label",
@@ -36,7 +43,8 @@ export function renderIssueList({
     "number,title,labels,closedAt",
     "--limit",
     "100",
-  ]);
+  ];
+  const result = gh(args, { cwd, token });
   if (result.status !== 0) {
     process.stderr.write(
       `refresh: gh issue list failed for ${topic}:${state}\n`,

--- a/libraries/libwiki/src/issue-list-renderer.js
+++ b/libraries/libwiki/src/issue-list-renderer.js
@@ -70,8 +70,7 @@ export function renderIssueList({
 
   const lines = [];
   for (const issue of issues) {
-    const tag = topic === "experiments" ? "Exp" : "Obs";
-    lines.push(`- **${tag} #${issue.number} — ${issue.title}**`);
+    lines.push(`- #${issue.number} ${issue.title}`);
   }
   return lines;
 }

--- a/libraries/libwiki/src/issue-list-renderer.js
+++ b/libraries/libwiki/src/issue-list-renderer.js
@@ -1,8 +1,5 @@
 import { spawnSync } from "node:child_process";
 
-export const GENERATED_NOTICE =
-  "<!-- Do not edit. Generated from fit-wiki refresh. -->";
-
 function defaultGh(args, options) {
   const env = options?.token
     ? { ...process.env, GH_TOKEN: options.token }
@@ -49,7 +46,7 @@ export function renderIssueList({
     process.stderr.write(
       `refresh: gh issue list failed for ${topic}:${state}\n`,
     );
-    return [GENERATED_NOTICE];
+    return [];
   }
   let issues;
   try {
@@ -58,7 +55,7 @@ export function renderIssueList({
     process.stderr.write(
       `refresh: gh issue list JSON parse failed for ${topic}:${state}\n`,
     );
-    return [GENERATED_NOTICE];
+    return [];
   }
 
   if (state === "closed") {
@@ -71,7 +68,7 @@ export function renderIssueList({
     );
   }
 
-  const lines = [GENERATED_NOTICE];
+  const lines = [];
   for (const issue of issues) {
     const tag = topic === "experiments" ? "Exp" : "Obs";
     lines.push(`- **${tag} #${issue.number} — ${issue.title}**`);

--- a/libraries/libwiki/src/marker-scanner.js
+++ b/libraries/libwiki/src/marker-scanner.js
@@ -5,7 +5,8 @@ const XMR_OPEN_RE = /^<!--\s*xmr:([^:\s]+):(\S+)(?:\s+[^>]*?)?\s*-->\s*$/;
 const ISSUE_OPEN_RE =
   /^<!--\s*(obstacles|experiments):(open|closed)(?::(\d+d))?(?:\s+[^>]*?)?\s*-->\s*$/;
 const XMR_CLOSE_RE = /^<!--\s*\/xmr(?:\s+[^>]*?)?\s*-->\s*$/;
-const ISSUE_CLOSE_RE = /^<!--\s*\/(obstacles|experiments)(?:\s+[^>]*?)?\s*-->\s*$/;
+const ISSUE_CLOSE_RE =
+  /^<!--\s*\/(obstacles|experiments)(?:\s+[^>]*?)?\s*-->\s*$/;
 
 function openLabel(open) {
   return open.kind === "xmr" ? open.metric : open.topic;

--- a/libraries/libwiki/src/marker-scanner.js
+++ b/libraries/libwiki/src/marker-scanner.js
@@ -1,8 +1,11 @@
-const XMR_OPEN_RE = /^<!--\s*xmr:([^:\s]+):([^\s]+)\s*-->\s*$/;
+// Markers tolerate optional trailing text after the tag (typically an inline
+// "Do not edit. Generated from fit-wiki refresh." notice), so an open or close
+// marker can carry its own warning without needing a separate notice line.
+const XMR_OPEN_RE = /^<!--\s*xmr:([^:\s]+):(\S+)(?:\s+[^>]*?)?\s*-->\s*$/;
 const ISSUE_OPEN_RE =
-  /^<!--\s*(obstacles|experiments):(open|closed)(?::(\d+d))?\s*-->\s*$/;
-const XMR_CLOSE_RE = /^<!--\s*\/xmr\s*-->\s*$/;
-const ISSUE_CLOSE_RE = /^<!--\s*\/(obstacles|experiments)\s*-->\s*$/;
+  /^<!--\s*(obstacles|experiments):(open|closed)(?::(\d+d))?(?:\s+[^>]*?)?\s*-->\s*$/;
+const XMR_CLOSE_RE = /^<!--\s*\/xmr(?:\s+[^>]*?)?\s*-->\s*$/;
+const ISSUE_CLOSE_RE = /^<!--\s*\/(obstacles|experiments)(?:\s+[^>]*?)?\s*-->\s*$/;
 
 function openLabel(open) {
   return open.kind === "xmr" ? open.metric : open.topic;

--- a/libraries/libwiki/test/audit-cli.test.js
+++ b/libraries/libwiki/test/audit-cli.test.js
@@ -92,7 +92,7 @@ describe("fit-wiki audit CLI", () => {
 
   test("over-budget summary: JSON failure with id, path, exit 1", () => {
     seedCleanWiki(wikiRoot);
-    const big = Array(100).fill("x").join("\n");
+    const big = Array(600).fill("x").join("\n");
     writeFileSync(
       join(wikiRoot, "staff-engineer.md"),
       `# Staff Engineer — Summary\n\n**Last run**: nothing.\n\n## Message Inbox\n\n<!-- memo:inbox -->\n\n${big}\n`,
@@ -115,13 +115,13 @@ describe("fit-wiki audit CLI", () => {
     assert.equal(lineBudget.level, "fail");
     assert.match(
       lineBudget.message,
-      /staff-engineer\.md has \d+ lines \(limit 72\)/,
+      /staff-engineer\.md has \d+ lines \(limit 496\)/,
     );
   });
 
   test("text emitter: WARN before FAIL, RESULT trailer", () => {
     seedCleanWiki(wikiRoot);
-    const big = Array(100).fill("x").join("\n");
+    const big = Array(600).fill("x").join("\n");
     writeFileSync(
       join(wikiRoot, "staff-engineer.md"),
       `# Staff Engineer — Summary\n\n**Last run**: nothing.\n\n## Message Inbox\n\n<!-- memo:inbox -->\n\n${big}\n`,

--- a/libraries/libwiki/test/audit-engine.test.js
+++ b/libraries/libwiki/test/audit-engine.test.js
@@ -48,6 +48,8 @@ describe("RULES catalogue", () => {
         "expired-claim",
         "storyboard.current-month-exists",
         "storyboard.agent-h3-required",
+        "storyboard.line-budget",
+        "storyboard.word-budget",
         "storyboard.markers-balanced.xmr",
         "storyboard.markers-balanced.issues",
         "wiki.stray-file",
@@ -120,7 +122,7 @@ describe("runAudit", () => {
 
   test("over-budget summary: fires summary.line-budget", () => {
     seedClean();
-    const big = Array(100).fill("x").join("\n");
+    const big = Array(600).fill("x").join("\n");
     writeFileSync(
       join(wiki, "staff-engineer.md"),
       `# Staff Engineer — Summary\n\n**Last run**: nothing.\n\n## Message Inbox\n\n<!-- memo:inbox -->\n\n${big}\n`,

--- a/libraries/libwiki/test/block-renderer.test.js
+++ b/libraries/libwiki/test/block-renderer.test.js
@@ -17,7 +17,7 @@ function makeCSV(metric, values) {
 }
 
 describe("renderBlock", () => {
-  test("predictable metric renders Latest, chart, and Signals", () => {
+  test("predictable metric renders chart fenced code and Signals", () => {
     const dir = mkdtempSync(join(tmpdir(), "block-"));
     const values = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10];
     writeFileSync(join(dir, "test.csv"), makeCSV("findings", values));
@@ -28,15 +28,12 @@ describe("renderBlock", () => {
       projectRoot: dir,
     });
 
-    assert.ok(lines[0].startsWith("**Latest:** 10"));
-    assert.ok(lines[0].includes("**Status:** predictable"));
-    assert.equal(lines[1], "");
-    assert.equal(lines[2], "```");
+    assert.equal(lines[0], "```");
 
     const report = analyze(makeCSV("findings", values));
     const m = report.metrics[0];
     const expectedChart = renderChart(m.values, m.stats, m.signals);
-    const chartContent = lines.slice(3, lines.indexOf("```", 3)).join("\n");
+    const chartContent = lines.slice(1, lines.indexOf("```", 1)).join("\n");
     assert.equal(chartContent, expectedChart);
 
     const lastLine = lines[lines.length - 1];
@@ -55,7 +52,6 @@ describe("renderBlock", () => {
       projectRoot: dir,
     });
 
-    assert.ok(lines[0].includes("**Status:** signals_present"));
     const signalLine = lines[lines.length - 1];
     assert.ok(signalLine.includes("xRule1") || signalLine.includes("mrRule1"));
   });
@@ -71,10 +67,8 @@ describe("renderBlock", () => {
       projectRoot: dir,
     });
 
-    assert.ok(lines[0].includes("**Latest:** 50"));
-    assert.ok(lines[0].includes("**Status:** insufficient_data"));
-
-    const chartLine = lines[3];
+    assert.equal(lines[0], "```");
+    const chartLine = lines[1];
     assert.ok(chartLine.includes("Insufficient data"));
     assert.ok(chartLine.includes("5 points"));
   });

--- a/libraries/libwiki/test/block-renderer.test.js
+++ b/libraries/libwiki/test/block-renderer.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { renderBlock, BlockRenderError } from "../src/block-renderer.js";
+import { GENERATED_NOTICE } from "../src/issue-list-renderer.js";
 import { analyze, renderChart } from "@forwardimpact/libxmr";
 
 const HEADER = "date,metric,value,unit,run,note";
@@ -28,15 +29,16 @@ describe("renderBlock", () => {
       projectRoot: dir,
     });
 
-    assert.ok(lines[0].startsWith("**Latest:** 10"));
-    assert.ok(lines[0].includes("**Status:** predictable"));
-    assert.equal(lines[1], "");
-    assert.equal(lines[2], "```");
+    assert.equal(lines[0], GENERATED_NOTICE);
+    assert.ok(lines[1].startsWith("**Latest:** 10"));
+    assert.ok(lines[1].includes("**Status:** predictable"));
+    assert.equal(lines[2], "");
+    assert.equal(lines[3], "```");
 
     const report = analyze(makeCSV("findings", values));
     const m = report.metrics[0];
     const expectedChart = renderChart(m.values, m.stats, m.signals);
-    const chartContent = lines.slice(3, lines.indexOf("```", 3)).join("\n");
+    const chartContent = lines.slice(4, lines.indexOf("```", 4)).join("\n");
     assert.equal(chartContent, expectedChart);
 
     const lastLine = lines[lines.length - 1];
@@ -55,7 +57,8 @@ describe("renderBlock", () => {
       projectRoot: dir,
     });
 
-    assert.ok(lines[0].includes("**Status:** signals_present"));
+    assert.equal(lines[0], GENERATED_NOTICE);
+    assert.ok(lines[1].includes("**Status:** signals_present"));
     const signalLine = lines[lines.length - 1];
     assert.ok(signalLine.includes("xRule1") || signalLine.includes("mrRule1"));
   });
@@ -71,10 +74,11 @@ describe("renderBlock", () => {
       projectRoot: dir,
     });
 
-    assert.ok(lines[0].includes("**Latest:** 50"));
-    assert.ok(lines[0].includes("**Status:** insufficient_data"));
+    assert.equal(lines[0], GENERATED_NOTICE);
+    assert.ok(lines[1].includes("**Latest:** 50"));
+    assert.ok(lines[1].includes("**Status:** insufficient_data"));
 
-    const chartLine = lines[3];
+    const chartLine = lines[4];
     assert.ok(chartLine.includes("Insufficient data"));
     assert.ok(chartLine.includes("5 points"));
   });

--- a/libraries/libwiki/test/block-renderer.test.js
+++ b/libraries/libwiki/test/block-renderer.test.js
@@ -4,7 +4,6 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { renderBlock, BlockRenderError } from "../src/block-renderer.js";
-import { GENERATED_NOTICE } from "../src/issue-list-renderer.js";
 import { analyze, renderChart } from "@forwardimpact/libxmr";
 
 const HEADER = "date,metric,value,unit,run,note";
@@ -29,16 +28,15 @@ describe("renderBlock", () => {
       projectRoot: dir,
     });
 
-    assert.equal(lines[0], GENERATED_NOTICE);
-    assert.ok(lines[1].startsWith("**Latest:** 10"));
-    assert.ok(lines[1].includes("**Status:** predictable"));
-    assert.equal(lines[2], "");
-    assert.equal(lines[3], "```");
+    assert.ok(lines[0].startsWith("**Latest:** 10"));
+    assert.ok(lines[0].includes("**Status:** predictable"));
+    assert.equal(lines[1], "");
+    assert.equal(lines[2], "```");
 
     const report = analyze(makeCSV("findings", values));
     const m = report.metrics[0];
     const expectedChart = renderChart(m.values, m.stats, m.signals);
-    const chartContent = lines.slice(4, lines.indexOf("```", 4)).join("\n");
+    const chartContent = lines.slice(3, lines.indexOf("```", 3)).join("\n");
     assert.equal(chartContent, expectedChart);
 
     const lastLine = lines[lines.length - 1];
@@ -57,8 +55,7 @@ describe("renderBlock", () => {
       projectRoot: dir,
     });
 
-    assert.equal(lines[0], GENERATED_NOTICE);
-    assert.ok(lines[1].includes("**Status:** signals_present"));
+    assert.ok(lines[0].includes("**Status:** signals_present"));
     const signalLine = lines[lines.length - 1];
     assert.ok(signalLine.includes("xRule1") || signalLine.includes("mrRule1"));
   });
@@ -74,11 +71,10 @@ describe("renderBlock", () => {
       projectRoot: dir,
     });
 
-    assert.equal(lines[0], GENERATED_NOTICE);
-    assert.ok(lines[1].includes("**Latest:** 50"));
-    assert.ok(lines[1].includes("**Status:** insufficient_data"));
+    assert.ok(lines[0].includes("**Latest:** 50"));
+    assert.ok(lines[0].includes("**Status:** insufficient_data"));
 
-    const chartLine = lines[4];
+    const chartLine = lines[3];
     assert.ok(chartLine.includes("Insufficient data"));
     assert.ok(chartLine.includes("5 points"));
   });

--- a/libraries/libwiki/test/cli-refresh.test.js
+++ b/libraries/libwiki/test/cli-refresh.test.js
@@ -67,8 +67,6 @@ describe("fit-wiki refresh CLI", () => {
     run(dir, "storyboard.md");
 
     const after = readFileSync(storyboard, "utf-8");
-    assert.ok(after.includes("**Latest:** 10"));
-    assert.ok(after.includes("**Status:** predictable"));
     assert.ok(after.includes("**Signals:**"));
     assert.ok(after.includes("```"));
     assert.ok(after.includes("trailing prose"));
@@ -141,8 +139,8 @@ describe("fit-wiki refresh CLI", () => {
     run(dir, "storyboard.md");
 
     const after = readFileSync(storyboard, "utf-8");
-    assert.ok(after.includes("**Latest:** 24"));
-    assert.ok(after.includes("**Latest:** 34"));
+    const signalsCount = (after.match(/\*\*Signals:\*\*/g) || []).length;
+    assert.equal(signalsCount, 2);
     assert.ok(!after.includes("old alpha"));
     assert.ok(!after.includes("old beta"));
   });
@@ -193,7 +191,7 @@ describe("fit-wiki refresh CLI", () => {
     });
 
     const after = readFileSync(storyboard, "utf-8");
-    assert.ok(after.includes("**Latest:** 5"));
+    assert.ok(after.includes("**Signals:**"));
     assert.ok(!after.includes("old"));
   });
 
@@ -228,7 +226,7 @@ describe("fit-wiki refresh CLI", () => {
     });
 
     const after = readFileSync(defaultPath, "utf-8");
-    assert.ok(after.includes("**Latest:** 7"));
+    assert.ok(after.includes("**Signals:**"));
     assert.ok(!after.includes("old"));
   });
 });

--- a/libraries/libwiki/test/issue-list-block.test.js
+++ b/libraries/libwiki/test/issue-list-block.test.js
@@ -1,9 +1,6 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import {
-  renderIssueList,
-  parseRepoSlug,
-} from "../src/issue-list-renderer.js";
+import { renderIssueList, parseRepoSlug } from "../src/issue-list-renderer.js";
 
 function mockGh(stdout, status = 0) {
   return () => ({ status, stdout, stderr: "" });

--- a/libraries/libwiki/test/issue-list-block.test.js
+++ b/libraries/libwiki/test/issue-list-block.test.js
@@ -1,6 +1,9 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { renderIssueList } from "../src/issue-list-renderer.js";
+import {
+  renderIssueList,
+  parseRepoSlug,
+} from "../src/issue-list-renderer.js";
 
 function mockGh(stdout, status = 0) {
   return () => ({ status, stdout, stderr: "" });
@@ -65,22 +68,26 @@ describe("renderIssueList", () => {
     assert.deepEqual(lines, []);
   });
 
-  test("forwards cwd and token to gh when provided", () => {
+  test("forwards cwd, repo, and token to gh when provided", () => {
     const gh = spyGh(JSON.stringify([]));
     renderIssueList({
       topic: "obstacles",
       state: "open",
       window: null,
       cwd: "/some/project-root",
+      repo: "forwardimpact/monorepo",
       token: "ghp_test",
       gh,
     });
     const call = gh.calls[0];
+    const repoIdx = call.args.indexOf("--repo");
+    assert.notEqual(repoIdx, -1);
+    assert.equal(call.args[repoIdx + 1], "forwardimpact/monorepo");
     assert.equal(call.options.cwd, "/some/project-root");
     assert.equal(call.options.token, "ghp_test");
   });
 
-  test("does not pass cwd or token when not provided", () => {
+  test("omits --repo and options when none provided", () => {
     const gh = spyGh(JSON.stringify([]));
     renderIssueList({
       topic: "obstacles",
@@ -89,6 +96,7 @@ describe("renderIssueList", () => {
       gh,
     });
     const call = gh.calls[0];
+    assert.equal(call.args.includes("--repo"), false);
     assert.equal(call.options.cwd, undefined);
     assert.equal(call.options.token, undefined);
   });
@@ -108,5 +116,33 @@ describe("renderIssueList", () => {
     });
     assert.equal(lines.length, 1);
     assert.equal(lines[0], "- #2 in-window");
+  });
+});
+
+describe("parseRepoSlug", () => {
+  test("parses https github URL", () => {
+    assert.equal(
+      parseRepoSlug("https://github.com/forwardimpact/monorepo.git"),
+      "forwardimpact/monorepo",
+    );
+  });
+
+  test("parses ssh github URL", () => {
+    assert.equal(
+      parseRepoSlug("git@github.com:forwardimpact/monorepo.git"),
+      "forwardimpact/monorepo",
+    );
+  });
+
+  test("parses proxy-rewritten URL with extra path prefix", () => {
+    assert.equal(
+      parseRepoSlug("http://127.0.0.1:1234/git/forwardimpact/monorepo"),
+      "forwardimpact/monorepo",
+    );
+  });
+
+  test("returns null for empty input", () => {
+    assert.equal(parseRepoSlug(null), null);
+    assert.equal(parseRepoSlug(""), null);
   });
 });

--- a/libraries/libwiki/test/issue-list-block.test.js
+++ b/libraries/libwiki/test/issue-list-block.test.js
@@ -9,6 +9,16 @@ function mockGh(stdout, status = 0) {
   return () => ({ status, stdout, stderr: "" });
 }
 
+function spyGh(stdout, status = 0) {
+  const calls = [];
+  const fn = (args, options) => {
+    calls.push({ args, options });
+    return { status, stdout, stderr: "" };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
 describe("renderIssueList", () => {
   test("renders open obstacles as bullets", () => {
     const lines = renderIssueList({
@@ -58,6 +68,34 @@ describe("renderIssueList", () => {
       gh: mockGh("", 1),
     });
     assert.deepEqual(lines, [GENERATED_NOTICE]);
+  });
+
+  test("forwards cwd and token to gh when provided", () => {
+    const gh = spyGh(JSON.stringify([]));
+    renderIssueList({
+      topic: "obstacles",
+      state: "open",
+      window: null,
+      cwd: "/some/project-root",
+      token: "ghp_test",
+      gh,
+    });
+    const call = gh.calls[0];
+    assert.equal(call.options.cwd, "/some/project-root");
+    assert.equal(call.options.token, "ghp_test");
+  });
+
+  test("does not pass cwd or token when not provided", () => {
+    const gh = spyGh(JSON.stringify([]));
+    renderIssueList({
+      topic: "obstacles",
+      state: "open",
+      window: null,
+      gh,
+    });
+    const call = gh.calls[0];
+    assert.equal(call.options.cwd, undefined);
+    assert.equal(call.options.token, undefined);
   });
 
   test("honours window suffix (30d)", () => {

--- a/libraries/libwiki/test/issue-list-block.test.js
+++ b/libraries/libwiki/test/issue-list-block.test.js
@@ -1,9 +1,6 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import {
-  renderIssueList,
-  GENERATED_NOTICE,
-} from "../src/issue-list-renderer.js";
+import { renderIssueList } from "../src/issue-list-renderer.js";
 
 function mockGh(stdout, status = 0) {
   return () => ({ status, stdout, stderr: "" });
@@ -37,9 +34,8 @@ describe("renderIssueList", () => {
         ]),
       ),
     });
-    assert.equal(lines.length, 2);
-    assert.equal(lines[0], GENERATED_NOTICE);
-    assert.match(lines[1], /Obs #100 — obstacle one/);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /Obs #100 — obstacle one/);
   });
 
   test("filters closed experiments by 7-day window", () => {
@@ -55,9 +51,8 @@ describe("renderIssueList", () => {
         ]),
       ),
     });
-    assert.equal(lines.length, 2);
-    assert.equal(lines[0], GENERATED_NOTICE);
-    assert.match(lines[1], /recent/);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /recent/);
   });
 
   test("returns [] on gh failure", () => {
@@ -67,7 +62,7 @@ describe("renderIssueList", () => {
       window: null,
       gh: mockGh("", 1),
     });
-    assert.deepEqual(lines, [GENERATED_NOTICE]);
+    assert.deepEqual(lines, []);
   });
 
   test("forwards cwd and token to gh when provided", () => {
@@ -111,8 +106,7 @@ describe("renderIssueList", () => {
         ]),
       ),
     });
-    assert.equal(lines.length, 2);
-    assert.equal(lines[0], GENERATED_NOTICE);
-    assert.match(lines[1], /in-window/);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /in-window/);
   });
 });

--- a/libraries/libwiki/test/issue-list-block.test.js
+++ b/libraries/libwiki/test/issue-list-block.test.js
@@ -1,6 +1,9 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { renderIssueList } from "../src/issue-list-renderer.js";
+import {
+  renderIssueList,
+  GENERATED_NOTICE,
+} from "../src/issue-list-renderer.js";
 
 function mockGh(stdout, status = 0) {
   return () => ({ status, stdout, stderr: "" });
@@ -24,8 +27,9 @@ describe("renderIssueList", () => {
         ]),
       ),
     });
-    assert.equal(lines.length, 1);
-    assert.match(lines[0], /Obs #100 — obstacle one/);
+    assert.equal(lines.length, 2);
+    assert.equal(lines[0], GENERATED_NOTICE);
+    assert.match(lines[1], /Obs #100 — obstacle one/);
   });
 
   test("filters closed experiments by 7-day window", () => {
@@ -41,8 +45,9 @@ describe("renderIssueList", () => {
         ]),
       ),
     });
-    assert.equal(lines.length, 1);
-    assert.match(lines[0], /recent/);
+    assert.equal(lines.length, 2);
+    assert.equal(lines[0], GENERATED_NOTICE);
+    assert.match(lines[1], /recent/);
   });
 
   test("returns [] on gh failure", () => {
@@ -52,7 +57,7 @@ describe("renderIssueList", () => {
       window: null,
       gh: mockGh("", 1),
     });
-    assert.deepEqual(lines, []);
+    assert.deepEqual(lines, [GENERATED_NOTICE]);
   });
 
   test("honours window suffix (30d)", () => {
@@ -68,7 +73,8 @@ describe("renderIssueList", () => {
         ]),
       ),
     });
-    assert.equal(lines.length, 1);
-    assert.match(lines[0], /in-window/);
+    assert.equal(lines.length, 2);
+    assert.equal(lines[0], GENERATED_NOTICE);
+    assert.match(lines[1], /in-window/);
   });
 });

--- a/libraries/libwiki/test/issue-list-block.test.js
+++ b/libraries/libwiki/test/issue-list-block.test.js
@@ -35,7 +35,7 @@ describe("renderIssueList", () => {
       ),
     });
     assert.equal(lines.length, 1);
-    assert.match(lines[0], /Obs #100 — obstacle one/);
+    assert.equal(lines[0], "- #100 obstacle one");
   });
 
   test("filters closed experiments by 7-day window", () => {
@@ -52,7 +52,7 @@ describe("renderIssueList", () => {
       ),
     });
     assert.equal(lines.length, 1);
-    assert.match(lines[0], /recent/);
+    assert.equal(lines[0], "- #2 recent");
   });
 
   test("returns [] on gh failure", () => {
@@ -107,6 +107,6 @@ describe("renderIssueList", () => {
       ),
     });
     assert.equal(lines.length, 1);
-    assert.match(lines[0], /in-window/);
+    assert.equal(lines[0], "- #2 in-window");
   });
 });

--- a/libraries/libwiki/test/marker-scanner.test.js
+++ b/libraries/libwiki/test/marker-scanner.test.js
@@ -83,4 +83,44 @@ describe("scanMarkers", () => {
     const pairs = scanMarkers(text);
     assert.equal(pairs.length, 0);
   });
+
+  test("tolerates inline notice text after the tag (xmr)", () => {
+    const text = [
+      "<!-- xmr:findings_count:wiki/metrics/kata-spec/2026.csv Do not edit. Generated from fit-wiki refresh. -->",
+      "**Latest:** 3 · **Status:** predictable",
+      "<!-- /xmr Do not edit. Generated from fit-wiki refresh. -->",
+    ].join("\n");
+
+    const pairs = scanMarkers(text);
+    assert.equal(pairs.length, 1);
+    assert.equal(pairs[0].metric, "findings_count");
+    assert.equal(pairs[0].csvPath, "wiki/metrics/kata-spec/2026.csv");
+  });
+
+  test("tolerates inline notice text after the tag (issue-list)", () => {
+    const text = [
+      "<!-- obstacles:open Do not edit. Generated from fit-wiki refresh. -->",
+      "- **Obs #100 — example**",
+      "<!-- /obstacles Do not edit. Generated from fit-wiki refresh. -->",
+    ].join("\n");
+
+    const pairs = scanMarkers(text);
+    assert.equal(pairs.length, 1);
+    assert.equal(pairs[0].topic, "obstacles");
+    assert.equal(pairs[0].state, "open");
+  });
+
+  test("tolerates inline notice combined with closed:30d window suffix", () => {
+    const text = [
+      "<!-- experiments:closed:30d Do not edit. Generated from fit-wiki refresh. -->",
+      "- **Exp #42 — older entry**",
+      "<!-- /experiments -->",
+    ].join("\n");
+
+    const pairs = scanMarkers(text);
+    assert.equal(pairs.length, 1);
+    assert.equal(pairs[0].topic, "experiments");
+    assert.equal(pairs[0].state, "closed");
+    assert.equal(pairs[0].window, "30d");
+  });
 });

--- a/libraries/libxmr/src/chart.js
+++ b/libraries/libxmr/src/chart.js
@@ -291,7 +291,15 @@ function renderMRChart({
 
 // A limit row — label + ruler-edge glyph + blank plot, breach slots marked
 // with `●`. The edge glyph caps the vertical ruler (upper or lower).
-function limitRow(label, labelWidth, slots, plotWidth, slotWidth, edge, glyphs) {
+function limitRow(
+  label,
+  labelWidth,
+  slots,
+  plotWidth,
+  slotWidth,
+  edge,
+  glyphs,
+) {
   const plot = Array(plotWidth).fill(" ");
   for (const slot of slots) {
     const col = slotWidth * slot - 1;

--- a/libraries/libxmr/src/chart.js
+++ b/libraries/libxmr/src/chart.js
@@ -11,6 +11,9 @@ import { fmt1 } from "./format.js";
 
 const UNICODE = {
   vertical: "│",
+  upperEnd: "┬",
+  cross: "┼",
+  lowerEnd: "┴",
   point: "·",
   signal: "●",
   sigma: "σ",
@@ -19,6 +22,9 @@ const UNICODE = {
 
 const ASCII = {
   vertical: "|",
+  upperEnd: "+",
+  cross: "+",
+  lowerEnd: "+",
   point: "o",
   signal: "*",
   sigma: "s",
@@ -147,6 +153,7 @@ function renderXChart({
       buckets.breachUpper,
       plotWidth,
       slotWidth,
+      glyphs.upperEnd,
       glyphs,
     ),
     zoneRow(
@@ -200,6 +207,7 @@ function renderXChart({
       buckets.breachLower,
       plotWidth,
       slotWidth,
+      glyphs.lowerEnd,
       glyphs,
     ),
   ];
@@ -238,6 +246,7 @@ function renderMRChart({
       buckets.breach,
       plotWidth,
       slotWidth,
+      glyphs.upperEnd,
       glyphs,
     ),
     zoneRow(
@@ -280,16 +289,15 @@ function renderMRChart({
   ];
 }
 
-// A limit row — label + blank plot, breach slots marked with `●`. No
-// horizontal fill line; the label in the left ruler tells the reader
-// where the level sits.
-function limitRow(label, labelWidth, slots, plotWidth, slotWidth, glyphs) {
+// A limit row — label + ruler-edge glyph + blank plot, breach slots marked
+// with `●`. The edge glyph caps the vertical ruler (upper or lower).
+function limitRow(label, labelWidth, slots, plotWidth, slotWidth, edge, glyphs) {
   const plot = Array(plotWidth).fill(" ");
   for (const slot of slots) {
     const col = slotWidth * slot - 1;
     plot[col] = glyphs.signal;
   }
-  return `${rightAlign(label, labelWidth)}  ${plot.join("")}`;
+  return `${rightAlign(label, labelWidth)} ${edge}${plot.join("")}`;
 }
 
 // A zone row — vertical edge, spaces in plot, `·` (or `●` for signals) at
@@ -303,8 +311,8 @@ function zoneRow(label, labelWidth, slots, mask, plotWidth, slotWidth, glyphs) {
   return `${rightAlign(label, labelWidth)} ${glyphs.vertical}${plot.join("")}`;
 }
 
-// A centerline row — label + blank plot, on-centerline slots marked with
-// the point (or signal) glyph. No horizontal fill line.
+// A centerline row — `┼` edge (vertical ruler with centre cross), blank
+// plot, on-centerline slots marked with the point (or signal) glyph.
 function centerlineRow(
   label,
   labelWidth,
@@ -319,11 +327,11 @@ function centerlineRow(
     const col = slotWidth * slot - 1;
     plot[col] = mask[slot] ? glyphs.signal : glyphs.point;
   }
-  return `${rightAlign(label, labelWidth)}  ${plot.join("")}`;
+  return `${rightAlign(label, labelWidth)} ${glyphs.cross}${plot.join("")}`;
 }
 
-// The mR zero baseline — label + blank plot, zero-mR slots marked with
-// the point (or signal) glyph. No horizontal fill line.
+// The mR zero baseline — `┴` lower-end edge, blank plot, zero-mR slots
+// marked with the point (or signal) glyph.
 function baselineRow(
   label,
   labelWidth,
@@ -338,7 +346,7 @@ function baselineRow(
     const col = slotWidth * slot - 1;
     plot[col] = mask[slot] ? glyphs.signal : glyphs.point;
   }
-  return `${rightAlign(label, labelWidth)}  ${plot.join("")}`;
+  return `${rightAlign(label, labelWidth)} ${glyphs.lowerEnd}${plot.join("")}`;
 }
 
 // Shared time axis — slot numbers right-aligned in each slot. Edge is a
@@ -388,7 +396,7 @@ function renderSinglePoint(value, glyphs, slotWidth) {
   plot[slotWidth - 1] = glyphs.point;
   const labelWidth = label.length;
   const lines = [
-    `${rightAlign(label, labelWidth)}  ${plot.join("")}`,
+    `${rightAlign(label, labelWidth)} ${glyphs.cross}${plot.join("")}`,
     "",
     `${" ".repeat(labelWidth)}  ${"1".padStart(slotWidth, " ")}`,
     "",
@@ -415,9 +423,9 @@ function renderFlat(values, stats, glyphs, slotWidth, ascii) {
   for (let i = 1; i < n; i++) mrPlot[slotWidth * (i + 1) - 1] = glyphs.point;
 
   const lines = [
-    `${rightAlign(labels[0], labelWidth)}  ${xPlot.join("")}`,
+    `${rightAlign(labels[0], labelWidth)} ${glyphs.cross}${xPlot.join("")}`,
     "",
-    `${rightAlign(labels[1], labelWidth)}  ${mrPlot.join("")}`,
+    `${rightAlign(labels[1], labelWidth)} ${glyphs.lowerEnd}${mrPlot.join("")}`,
     axisRow(labelWidth, n, slotWidth),
     "",
     "Note: zero observed variation — control limits coincide with",

--- a/libraries/libxmr/src/chart.js
+++ b/libraries/libxmr/src/chart.js
@@ -10,9 +10,6 @@ import { buildSignalMask, buildMRSignalMask } from "./signals.js";
 import { fmt1 } from "./format.js";
 
 const UNICODE = {
-  solid: "─",
-  dashed: "╌",
-  cross: "┼",
   vertical: "│",
   point: "·",
   signal: "●",
@@ -21,9 +18,6 @@ const UNICODE = {
 };
 
 const ASCII = {
-  solid: "-",
-  dashed: ".",
-  cross: "+",
   vertical: "|",
   point: "o",
   signal: "*",
@@ -129,8 +123,11 @@ function bucketXValues(values, stats) {
   return buckets;
 }
 
-// X chart — 7 rows: UPL line, outer-upper, inner-upper, μ centerline,
-// inner-lower, outer-lower, LPL line.
+// X chart — 7 rows: UPL marker, outer-upper, inner-upper, μ centerline,
+// inner-lower, outer-lower, LPL marker. The UPL, μ, and LPL rows show
+// only their label + data marks; the running chart skips full-width
+// fill on those rows because the ruler labels already tell the reader
+// where each level sits.
 function renderXChart({
   values,
   stats,
@@ -283,16 +280,16 @@ function renderMRChart({
   ];
 }
 
-// A horizontal limit line with `─` filling the plot. Breach slots replace
-// the line character with `●`. Edge character is also `─` so the line is
-// continuous through the label-to-plot transition.
+// A limit row — label + blank plot, breach slots marked with `●`. No
+// horizontal fill line; the label in the left ruler tells the reader
+// where the level sits.
 function limitRow(label, labelWidth, slots, plotWidth, slotWidth, glyphs) {
-  const plot = Array(plotWidth).fill(glyphs.solid);
+  const plot = Array(plotWidth).fill(" ");
   for (const slot of slots) {
     const col = slotWidth * slot - 1;
     plot[col] = glyphs.signal;
   }
-  return `${rightAlign(label, labelWidth)} ${glyphs.solid}${plot.join("")}`;
+  return `${rightAlign(label, labelWidth)}  ${plot.join("")}`;
 }
 
 // A zone row — vertical edge, spaces in plot, `·` (or `●` for signals) at
@@ -306,8 +303,8 @@ function zoneRow(label, labelWidth, slots, mask, plotWidth, slotWidth, glyphs) {
   return `${rightAlign(label, labelWidth)} ${glyphs.vertical}${plot.join("")}`;
 }
 
-// A centerline row — `╌` filling the plot, `┼` edge. Replace `╌` with the
-// point glyph at any slot whose value equals the centerline exactly.
+// A centerline row — label + blank plot, on-centerline slots marked with
+// the point (or signal) glyph. No horizontal fill line.
 function centerlineRow(
   label,
   labelWidth,
@@ -317,16 +314,16 @@ function centerlineRow(
   slotWidth,
   glyphs,
 ) {
-  const plot = Array(plotWidth).fill(glyphs.dashed);
+  const plot = Array(plotWidth).fill(" ");
   for (const slot of slots) {
     const col = slotWidth * slot - 1;
     plot[col] = mask[slot] ? glyphs.signal : glyphs.point;
   }
-  return `${rightAlign(label, labelWidth)} ${glyphs.cross}${plot.join("")}`;
+  return `${rightAlign(label, labelWidth)}  ${plot.join("")}`;
 }
 
-// The mR zero baseline — `─` line. Visual floor only, not an LRL.
-// A zero mR (consecutive identical values) renders as a glyph on this row.
+// The mR zero baseline — label + blank plot, zero-mR slots marked with
+// the point (or signal) glyph. No horizontal fill line.
 function baselineRow(
   label,
   labelWidth,
@@ -336,12 +333,12 @@ function baselineRow(
   slotWidth,
   glyphs,
 ) {
-  const plot = Array(plotWidth).fill(glyphs.solid);
+  const plot = Array(plotWidth).fill(" ");
   for (const slot of slots) {
     const col = slotWidth * slot - 1;
     plot[col] = mask[slot] ? glyphs.signal : glyphs.point;
   }
-  return `${rightAlign(label, labelWidth)} ${glyphs.solid}${plot.join("")}`;
+  return `${rightAlign(label, labelWidth)}  ${plot.join("")}`;
 }
 
 // Shared time axis — slot numbers right-aligned in each slot. Edge is a
@@ -386,13 +383,12 @@ function rightAlign(s, width) {
 // Edge case: n=1. No mR, no limits — just one point on a degenerate
 // centerline. Spec §11 requires a note about needing n≥2 for mR.
 function renderSinglePoint(value, glyphs, slotWidth) {
-  const muSym = glyphs.mu;
-  const label = `${muSym} ${fmt1(value)}`;
-  const plot = Array(slotWidth).fill(glyphs.dashed);
+  const label = `${glyphs.mu} ${fmt1(value)}`;
+  const plot = Array(slotWidth).fill(" ");
   plot[slotWidth - 1] = glyphs.point;
   const labelWidth = label.length;
   const lines = [
-    `${rightAlign(label, labelWidth)} ${glyphs.cross}${plot.join("")}`,
+    `${rightAlign(label, labelWidth)}  ${plot.join("")}`,
     "",
     `${" ".repeat(labelWidth)}  ${"1".padStart(slotWidth, " ")}`,
     "",
@@ -412,16 +408,16 @@ function renderFlat(values, stats, glyphs, slotWidth, ascii) {
   const labels = [`${muSym} ${fmt1(stats.mu)}`, `${rSym} ${fmt1(stats.R)}`];
   const labelWidth = jointLabelWidth(labels);
 
-  const xPlot = Array(plotWidth).fill(glyphs.dashed);
+  const xPlot = Array(plotWidth).fill(" ");
   for (let i = 0; i < n; i++) xPlot[slotWidth * (i + 1) - 1] = glyphs.point;
 
-  const mrPlot = Array(plotWidth).fill(glyphs.solid);
+  const mrPlot = Array(plotWidth).fill(" ");
   for (let i = 1; i < n; i++) mrPlot[slotWidth * (i + 1) - 1] = glyphs.point;
 
   const lines = [
-    `${rightAlign(labels[0], labelWidth)} ${glyphs.cross}${xPlot.join("")}`,
+    `${rightAlign(labels[0], labelWidth)}  ${xPlot.join("")}`,
     "",
-    `${rightAlign(labels[1], labelWidth)} ${glyphs.solid}${mrPlot.join("")}`,
+    `${rightAlign(labels[1], labelWidth)}  ${mrPlot.join("")}`,
     axisRow(labelWidth, n, slotWidth),
     "",
     "Note: zero observed variation — control limits coincide with",

--- a/libraries/libxmr/test/chart.test.js
+++ b/libraries/libxmr/test/chart.test.js
@@ -13,19 +13,19 @@ import { renderChart } from "../src/chart.js";
 // NOTE: trailing spaces in zone rows are intentional — they preserve
 // fixed-width column alignment.
 const GOLDEN_SECTION_10 = [
-  " UPL 12.5                               ●               ",
+  " UPL 12.5 ┬                             ●               ",
   "          │                                             ",
   "+1.5σ 9.4 │        ·           ·  ·              ·      ",
-  "    μ 6.4                                               ",
+  "    μ 6.4 ┼                                             ",
   "-1.5σ 3.4 │  ·  ·     ·  ·  ·        ·     ·  ·     ·  ·",
   "          │                                             ",
-  "  LPL 0.3                                               ",
+  "  LPL 0.3 ┴                                             ",
   "",
-  "  URL 7.5                                  ●            ",
+  "  URL 7.5 ┬                                ●            ",
   "          │                    ·        ·               ",
-  "    R 2.3                                               ",
+  "    R 2.3 ┼                                             ",
   "          │     ·  ·  ·  ·  ·     ·  ·        ·  ·  ·  ·",
-  "      0.0                                               ",
+  "      0.0 ┴                                             ",
   "             1  2  3  4  5  6  7  8  9 10 11 12 13 14 15",
 ].join("\n");
 

--- a/libraries/libxmr/test/chart.test.js
+++ b/libraries/libxmr/test/chart.test.js
@@ -13,19 +13,19 @@ import { renderChart } from "../src/chart.js";
 // NOTE: trailing spaces in zone rows are intentional — they preserve
 // fixed-width column alignment.
 const GOLDEN_SECTION_10 = [
-  " UPL 12.5 ──────────────────────────────●───────────────",
+  " UPL 12.5                               ●               ",
   "          │                                             ",
   "+1.5σ 9.4 │        ·           ·  ·              ·      ",
-  "    μ 6.4 ┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌",
+  "    μ 6.4                                               ",
   "-1.5σ 3.4 │  ·  ·     ·  ·  ·        ·     ·  ·     ·  ·",
   "          │                                             ",
-  "  LPL 0.3 ──────────────────────────────────────────────",
+  "  LPL 0.3                                               ",
   "",
-  "  URL 7.5 ─────────────────────────────────●────────────",
+  "  URL 7.5                                  ●            ",
   "          │                    ·        ·               ",
-  "    R 2.3 ┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌",
+  "    R 2.3                                               ",
   "          │     ·  ·  ·  ·  ·     ·  ·        ·  ·  ·  ·",
-  "      0.0 ──────────────────────────────────────────────",
+  "      0.0                                               ",
   "             1  2  3  4  5  6  7  8  9 10 11 12 13 14 15",
 ].join("\n");
 
@@ -56,11 +56,10 @@ describe("renderChart — alignment invariant", () => {
     const signals = detectSignals(values, stats.mrs, stats);
     const lines = renderChart(values, stats, signals).split("\n");
 
-    // The edge character sits at index labelWidth + 1 (0-indexed). Find it
-    // on the X chart's UPL row and on the mR chart's URL row, and assert
-    // the columns match.
-    const xEdge = lines[0].indexOf("─");
-    const mrEdge = lines[8].indexOf("─");
+    // Zone rows carry a `│` edge at index labelWidth + 1 (0-indexed). Find
+    // it on a zone row from each chart and assert the columns match.
+    const xEdge = lines[1].indexOf("│");
+    const mrEdge = lines[9].indexOf("│");
     assert.strictEqual(xEdge, mrEdge);
   });
 


### PR DESCRIPTION
## Summary

Hardens the wiki memory protocol's audit gates and storyboard rendering. Unified line + word budgets across summaries, weekly logs, and storyboards; lighter-weight marker conventions; token-efficient XmR chart rendering so storyboards fit in a single Read.

### Audit budgets

- **`libraries/libwiki/src/constants.js`** — unified 496-line / 6,400-word budgets for weekly logs and storyboards; summary keeps 496 lines but tightens word backstop to **2,048**. Comment notes the three constant pairs share numeric values today but can diverge later.
- **`libraries/libwiki/src/audit/rules.js`** + **`scopes.js`** — adds `storyboard.line-budget` and `storyboard.word-budget` rules (mirrors the summary + weekly-log pairs so each surface keeps its own audit rule).

### Marker format

- One inline notice (`Do not edit. Auto-generated.`) on open markers only; close markers are bare. `marker-scanner.js` and the audit copy of the regexes tolerate optional trailing text inside the marker.
- Rendered issue-list bullets simplified to `- #NNN Title` (no bold, no `Obs`/`Exp` prefix, no em-dash).

### XmR charts

- **`libraries/libxmr/src/chart.js`** — UPL/μ/LPL (and the mR equivalents URL/R/0.0) drop the full-width fill; each carries a ruler-edge glyph instead (`┬`/`┼`/`┴`). One code path, no variants. Removed dead `solid`/`dashed` glyph entries.
- **`libraries/libwiki/src/block-renderer.js`** — drops the `**Latest:** N · **Status:** S` line and its codegen; the Signals line below the chart is the only signal summary.

### Token impact on M05 storyboard

- Beginning of session: ~28k tokens (over the 25k Read cap, needed paging)
- Final state: **~16k tokens** (65% of cap, single-Read with room to grow)

### gh discovery fix

- **`libraries/libwiki/src/commands/refresh.js`** + **`issue-list-renderer.js`** — restored explicit `--repo <owner/name>` resolution alongside the `cwd: projectRoot` approach. The previous `cwd`-only path failed in sandbox environments where `origin` is rewritten to a proxy URL; gh now gets both signals and works in both environments. Honors `FIT_GH_REPO` env override.

## Test plan

- [x] `bun run check` — passes (includes `fit-wiki audit`)
- [x] `bun test` on libwiki + libxmr — 51/51 pass
- [x] M04 + M05 storyboards refresh cleanly with new chart format and live `gh issue list` content
- [x] M05 reads in a single Read tool call

---
_Generated by [Claude Code](https://claude.ai/code/session_0134iiGkx98hpdbrghq8jMPC)_