### PR TITLE
feat(coaligned): add L3 agent reference layer (192L/1280W)

### DIFF
--- a/.claude/agents/references/coordination-protocol.md
+++ b/.claude/agents/references/coordination-protocol.md
@@ -20,9 +20,8 @@ output an agent produces.
 
 ## Agent labels on experiment issues
 
-Experiment issues carry an `agent:{name}` label identifying the owning agent so
-agents can find their assigned work during
-[on-boot routing](memory-protocol.md#on-boot-routing):
+Experiment issues carry an `agent:{name}` label so agents find their work
+during [on-boot routing](memory-protocol.md#on-boot-routing):
 
 ```sh
 gh issue list --state open --label experiment --label "agent:staff-engineer"
@@ -34,41 +33,15 @@ Valid labels: `agent:staff-engineer`, `agent:product-manager`,
 ## Approval signal
 
 Phase artifacts (specs, designs, plans, implementations) are gated into `main`
-by `kata-release-merge`. Approval state is recorded in `wiki/STATUS.md` — a
-markdown page in the wiki wrapping a tab-separated body, one row per spec:
-`{id}\t{phase}\t{status}`. STATUS is the canonical approval record; see
-[`approval-signals.md`](approval-signals.md) for the full signal catalogue
-and write protocol.
-
-Signals from any source below feed STATUS:
-
-- `<phase>:approved` label applied to the PR (human or `/ship-it`)
-- `gh pr review --approve` by a trusted account
-- Approval comment ("approve", "LGTM", "ship it") from a trusted contributor
-- Direct user message in an interactive coding session (trusted user)
-- `kata-plan` panel-clean (`staff-engineer`, plans only)
-
-**Trust rule.** Spec and design approvals must originate from a trusted human.
-Agents never autonomously originate `spec approved` or `design approved`; they
-only propagate signals already expressed by a trusted human. Plans may be
-approved by `staff-engineer` after `kata-plan` review.
-
-`kata-dispatch` is the bridge from PR-side signals (labels, comments, reviews)
-to STATUS — it validates trust (using the same gate as `kata-release-merge`)
-and writes the matching STATUS row. The facilitator does **not** apply any
-approval label or submit an APPROVED review on behalf of any contributor; it
-only propagates signals already expressed by trusted humans into STATUS.
+by `kata-release-merge` against `wiki/STATUS.md`. See
+[`approval-signals.md`](approval-signals.md) for the full signal catalogue,
+trust rule, and write protocol. `kata-dispatch` is the bridge from PR-side
+signals (labels, comments, reviews) to STATUS — it never originates approvals,
+only propagates signals already expressed by a trusted human.
 
 **Approval is not phase progression.** A STATUS row at `{phase} approved`
-authorizes `kata-release-merge` to merge that PR; it does not by itself advance
-the phase. Phase progression is derived only from `main`: the next phase begins
-when the prior phase's artifact (`specs/NNN/spec.md`, `design-a.md`,
-`plan-a.md`) is on `main` — i.e. the prior phase's PR has been merged. An
-approved-but-unmerged PR does not unblock the next phase.
-
-**Labels remain as input signals**, not as gates. Humans may apply
-`<phase>:approved` labels for PR UI visibility; the label fires `kata-dispatch`
-which validates trust and writes STATUS.
+authorizes merge; it does not advance the phase. The next phase begins only
+when the prior phase's artifact is on `main`.
 
 ## Measurement-system changes
 
@@ -76,106 +49,56 @@ Changes to a canonical-11 metric — skill removal, rename, split, definition
 change, sidecar opening, denominator redefinition, rule-semantics challenge —
 follow one of eight named repair moves and ship with a redefinition file.
 
-| Move | Definition (one sentence) | Falsifier-set kind |
+| Move | One-sentence definition | Falsifier-set kind |
 |---|---|---|
-| `producer-rehoming` | Reassign a metric's producing skill when the original is removed/split/renamed; record a continuity tag on the first row under the new producer. | "structural-zero rows present after rehoming run" |
-| `mode-restriction` | Narrow recording to one activation mode of a multi-mode skill so the series is unimodal. | "post-restriction series remains bimodal under XmR" |
-| `historical-phasing` | Annotate a series with a Phase boundary; XmR analysis windows on Phase 1; no CSV backfill. | "Phase 1 cannot reach `predictable` after horizon" |
-| `sidecar-pre-flight` | Record a candidate metric to a sibling CSV while the canonical metric continues; no denominator change until ratification. | "sidecar diverges from canonical at horizon" |
-| `stock-vs-flow-recast` | Replace a flow-rate metric with a stock metric on the same axis when burst architecture trips XmR by construction. | "stock series fires `xRule1` or `mrRule1` post-recast" |
-| `event-driven-recast` | Replace per-day cadence with per-activation ("no row, no event"). | "per-activation series remains `insufficient_data` at horizon" |
-| `rule-semantics-rfc` | Challenge an XmR rule's blocking effect on `predictable` via Discussion RFC; quorum required. | "RFC quorum not reached by horizon" |
-| `habit-to-policy` | Promote an undocumented defensive habit into a `SKILL.md` check after a defect surfaces. | "post-promotion defect of the same shape recurs" |
+| `producer-rehoming` | Reassign a metric's producing skill when the original is removed/split/renamed; tag continuity on the first row under the new producer. | "structural-zero rows after rehoming" |
+| `mode-restriction` | Narrow recording to one activation mode of a multi-mode skill so the series is unimodal. | "post-restriction series remains bimodal" |
+| `historical-phasing` | Annotate a Phase boundary; XmR windows on Phase 1; no CSV backfill. | "Phase 1 cannot reach `predictable`" |
+| `sidecar-pre-flight` | Record a candidate to a sibling CSV while the canonical metric continues; no denominator change until ratification. | "sidecar diverges from canonical" |
+| `stock-vs-flow-recast` | Replace a flow-rate metric with a stock metric when burst architecture trips XmR by construction. | "stock series fires `xRule1` post-recast" |
+| `event-driven-recast` | Replace per-day cadence with per-activation ("no row, no event"). | "per-activation series stays `insufficient_data`" |
+| `rule-semantics-rfc` | Challenge an XmR rule's blocking effect via Discussion RFC; quorum required. | "RFC quorum not reached by horizon" |
+| `habit-to-policy` | Promote a defensive habit into a `SKILL.md` check after a defect surfaces. | "post-promotion defect of same shape recurs" |
 
 The list is closed; extensions land via the spec/design/plan/implement chain.
 
 ### Redefinition shape
 
-Each canonical-11 change ships a `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md`
-file in the same PR. The file is YAML front-matter plus a brief prose body:
+Each canonical-11 change ships `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md` in
+the same PR — YAML front-matter plus a one-paragraph prose body:
 
 ```yaml
 ---
-move: producer-rehoming | mode-restriction | historical-phasing |
-      sidecar-pre-flight | stock-vs-flow-recast | event-driven-recast |
-      rule-semantics-rfc | habit-to-policy
-affected_metrics:
-  - {skill: <skill>, metric: <metric>}
-falsifier_set:
-  - <predicate>
+move: <one of the eight>
+affected_metrics: [{skill: <skill>, metric: <metric>}]
+falsifier_set: [<predicate>]
 verdict_horizon: <YYYY-MM-DD>
 cohort_readout: <YYYY-MM-DD>      # >= verdict_horizon
 denominator_effect: none | sidecar | conditional-amend | amend
-links:
-  obstacle_issue: <issue-ref>?
-  experiment_issue: <issue-ref>?
-  pr: <pr-ref>?
+links: { obstacle_issue: <issue-ref>?, experiment_issue: <issue-ref>?, pr: <pr-ref>? }
 ---
-
-# Redefinition — <human-readable title>
-
-<one-paragraph context: what changed, why this move, what the cohort ratifies>
 ```
 
 `verdict_horizon ≤ cohort_readout` is the only ordering constraint.
-`denominator_effect` enum: `none` for sidecars and rule-semantics challenges
-that don't move the denominator; `sidecar` for a parallel CSV pending verdict;
-`conditional-amend` for a denominator change ratified at the cohort read-out;
-`amend` for an unconditional denominator change.
+`denominator_effect`: `none` for sidecars and rule-semantics challenges;
+`sidecar` for a parallel CSV pending verdict; `conditional-amend` for a
+denominator change ratified at the cohort read-out; `amend` for unconditional.
 
 ### No-silent-redefinition rule
 
-> No change to the canonical-11 denominator (additions, removals, conditional
-> or unconditional redefinitions) lands without a redefinition file at
-> `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md` whose `denominator_effect` is
+> No change to the canonical-11 denominator lands without a redefinition file
+> at `wiki/redefinitions/{YYYY-MM-DD}-{slug}.md` whose `denominator_effect` is
 > non-`none`, a cohort read-out date on or before the storyboard meeting at
 > which the change takes effect, and a linked storyboard headline.
->
-> This single statement lives in `coordination-protocol.md` § Measurement-system
-> changes. KATA.md § Metrics links to it; no other file restates it.
 
-### Worked example — sidecar pre-flight
-
-```yaml
----
-move: sidecar-pre-flight
-affected_metrics:
-  - {skill: kata-trace, metric: findings_count}
-falsifier_set:
-  - sidecar diverges from canonical at verdict horizon
-verdict_horizon: YYYY-MM-DD
-cohort_readout: YYYY-MM-DD
-denominator_effect: none
-links:
-  obstacle_issue: "<issue-ref>"
-  experiment_issue: "<issue-ref>"
-  pr: null
----
-
-# Redefinition — sidecar pre-flight (inline example)
-
-One paragraph context: a sidecar CSV opened to evaluate the
-`findings_count` recasting; the cohort ratifies at the next read-out.
-```
+KATA.md § Metrics links to this section; no other file restates the rule.
 
 ### Detection
 
-Any commit touching a canonical-11 metric edge must, in the same commit, add or
-modify a `wiki/redefinitions/*.md` file. The canonical-11 edges are
-`wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, and
-`coordination-protocol.md` § Measurement-system changes. Cross-repo enforcement
-between this monorepo and the wiki repo is the follow-on CI workstream.
-
-```sh
-# Commits that edit canonical-11 edges but do NOT touch wiki/redefinitions/.
-for c in $(git log --format=%H --since="<date>" -- \
-    'wiki/storyboard-*.md' \
-    '.claude/skills/*/references/metrics.md' \
-    '.claude/agents/references/coordination-protocol.md'); do
-  git diff-tree --no-commit-id --name-only -r "$c" \
-    | grep -q '^wiki/redefinitions/' || echo "$c missing redefinition"
-done
-```
+Any commit touching a canonical-11 edge must add or modify
+`wiki/redefinitions/*.md` in the same commit. Canonical-11 edges:
+`wiki/storyboard-*.md`, `.claude/skills/*/references/metrics.md`, and this
+section.
 
 ## Decision questions
 
@@ -187,107 +110,65 @@ When an output could fit multiple channels, ask in order:
    `spec/`.
 4. Otherwise → wiki.
 
-A finding can require **multiple channels in parallel** — e.g., a CVE that also
-raises a policy question lands as both a `fix/` branch (the patch) **and** a
-Discussion (the policy question). `fix/` and `spec/` branches never share a PR,
-but either may run alongside a Discussion.
+A finding can require **multiple channels in parallel** — e.g., a CVE raising
+a policy question is both a `fix/` PR and a Discussion. `fix/` and `spec/`
+branches never share a PR, but either may run alongside a Discussion.
 
 ## Cross-agent escalation
 
-To pull another agent into a thread, address them by name in plain text — e.g.
-"Hello Product Manager," or "Hey Staff Engineer, can you take a look at the
-trust check?" The `kata-dispatch` facilitator infers the addressee and routes the
-response. Do **not** use `@`-mentions for agents: agents don't have GitHub user
-accounts, so `@product-manager` would either ping an unrelated GitHub user with
-that handle or resolve to nothing. Do not write to another agent's wiki summary
-— they read their own.
+Address another agent by name in plain text — "Hello Product Manager,
+can you take a look?" `kata-dispatch` infers the addressee and routes the
+response. Do **not** use `@`-mentions: agents have no GitHub accounts, so
+`@product-manager` either pings an unrelated user or resolves to nothing.
+Do not write to another agent's wiki summary — they read their own.
 
 ## Inbound: unclear addressed comments
 
-If a comment addressed to you is ambiguous — unclear ask, missing context, or
-could be interpreted multiple ways — reply asking one specific clarifying
-question. Do not act on inferred intent.
+If a comment addressed to you is ambiguous, reply with one specific
+clarifying question. Do not act on inferred intent.
 
 ## Discussion ownership and termination
 
-The author of a Discussion owns its termination — closing it, linking to the
-resulting spec or wiki note, or reassigning ownership to another agent or human
-in a comment. A Discussion older than **14 days** without a terminal event is a
-mis-routing; the invariant audit (KATA.md § Invariants) checks for stale open
-Discussions.
-
-### Runtime mechanism
-
-Discussion events reach the agent team via `services/ghbridge`, not directly
-via the dispatch workflow. The bridge stores per-thread state (history,
-participants, open RFCs, lead) in `libindex` JSONL and re-dispatches the
-workflow when a recess trigger fires. RFC long-running coordination is
-expressed via the libeval `discuss` mode's `Recess` and `RequestForComment`
-tools — the agent team should treat a Discussion the same way regardless of
-whether it spans one workflow run or 14 days of recesses.
+The author owns termination — closing the Discussion, linking to the
+resulting spec or wiki note, or reassigning ownership. A Discussion older
+than **14 days** without a terminal event is a mis-routing; the invariant
+audit checks for stale open Discussions.
 
 ## Trust at run-time
 
-The `kata-dispatch` facilitator verifies the author is a trusted contributor
-before engaging any participant — LLM judgement, scoped per run. Untrusted
-authors receive an acknowledgement; no participant agent files a `fix/` or
-`spec/` branch on their behalf.
+`kata-dispatch` verifies the author is a trusted contributor before engaging
+any participant — LLM judgement, scoped per run. Untrusted authors get an
+acknowledgement; no participant agent files a `fix/` or `spec/` branch on
+their behalf.
 
 ## Channels this protocol does NOT cover
 
 - **Wiki reads/writes** — see [memory-protocol.md](memory-protocol.md).
-- **Storyboard inputs** — record to metrics CSV; the storyboard reads CSV via
-  `fit-xmr`.
+- **Storyboard inputs** — record to metrics CSV; `fit-xmr` reads CSV.
 - **Sub-agent invocation** — owned by individual skill procedures.
 
 ## Citation format
 
-Cite every non-wiki output back in the wiki log so the deliberation trail stays
-linked. Format: `<Channel> #<N>: <one-line topic> (<URL>)`.
-
-```
-Discussion: should fit-pathway support nested levels?
-(https://github.com/forwardimpact/monorepo/discussions/<N>)
-PR: docs(kata): document kata-dispatch workflow
-(https://github.com/forwardimpact/monorepo/pull/<N>)
-Issue: clarify proficiency scale for expert tier
-(https://github.com/forwardimpact/monorepo/issues/<N>)
-```
+Cite every non-wiki output in the wiki log so the deliberation trail stays
+linked. Format: `<Channel> <ref>: <one-line topic> (<URL>)`.
 
 ## Creating outputs (gh CLI)
 
-`gh` is the authorized tool for every non-wiki output. Capture the returned URL
-for the citation format above.
+`gh` is the authorized tool for every non-wiki output. Capture the returned
+URL for the citation format above.
 
 - **Issue comment:** `gh issue comment <N> --body "<text>"`
 - **PR comment:** `gh pr comment <N> --body "<text>"`
 - **New Discussion:**
-  `gh api graphql -f query='mutation { createDiscussion(input: { repositoryId, categoryId, title, body }) { discussion { url } } }'`
+  `gh api graphql -f query='mutation { createDiscussion(input: {...}) {...} }'`
 - **Discussion comment:**
-  `gh api graphql -f query='mutation { addDiscussionComment(input: { discussionId, body }) { comment { url } } }'`
-  — pass `replyToId` to thread the reply
+  `gh api graphql -f query='mutation { addDiscussionComment(input: {...}) {...} }'`
+  — pass `replyToId` to thread.
 
-## When skills declare a `## Coordination Channels` block
+## `## Coordination Channels` block in a skill
 
-A skill carries a `## Coordination Channels` block when its procedure produces
-**non-wiki, non-fix/spec outputs** that need cross-agent or external visibility
-— typically PR comments, issue comments, or Discussions. Skills whose only
-outputs are wiki appends and fix/spec branches don't need the block; routing for
-those is governed by this file plus `memory-protocol.md` directly.
-
-## Common mis-routings
-
-The most frequent failure modes this protocol prevents — watch for these:
-
-- **Open questions stranded as wiki TODOs.** A finding that needs input from
-  another agent or a human is not a settled note — it's a Discussion. If a wiki
-  entry contains "?", "decide whether", or "needs review", open a Discussion and
-  link from the wiki note.
-- **Cross-cutting comments lost in PR threads.** A policy question raised on one
-  PR but applicable to many should escalate to a Discussion, not stay buried in
-  PR review.
-- **Agent-to-agent memos sent via direct edits to another summary.** Use
-  `fit-wiki memo --from <you> --to <recipient> --message "<text>"` so the
-  bullet lands under the recipient's `## Message Inbox` marker. Never
-  hand-edit another agent's summary — `fit-wiki memo` is the only supported
-  write path.
+A skill carries this block when its procedure produces non-wiki, non-fix/spec
+outputs needing cross-agent or external visibility — typically PR comments,
+issue comments, or Discussions. Skills whose only outputs are wiki appends
+and fix/spec branches don't need the block; this file plus
+`memory-protocol.md` govern routing for those.

--- a/.claude/agents/references/memory-protocol.md
+++ b/.claude/agents/references/memory-protocol.md
@@ -1,8 +1,8 @@
 # Memory Protocol
 
-This file governs **agent memory and action routing** via the `fit-wiki` CLI.
-Every contract below maps to one or more `fit-wiki` subcommands — the CLI is
-the path, not an alternative. For non-wiki outputs see
+Governs **agent memory and action routing** via the `fit-wiki` CLI. Every
+contract below maps to one or more `fit-wiki` subcommands — the CLI is the
+path, not an alternative. For non-wiki outputs see
 [coordination-protocol.md](coordination-protocol.md).
 
 ## On-Boot Read Set
@@ -22,12 +22,10 @@ Three Tier 1 surfaces, all in `wiki/`:
 2. `Bash: fit-wiki boot --agent <self>` — structured digest of the other
    Tier 1 surfaces. JSON output; `--format markdown` for prose.
 
-Total cost: 2 tool calls vs the legacy 3 reads (closes F11).
-
 ## On-Boot Routing
 
-Apply this priority scheme against the `boot` digest's JSON fields — first
-level with actionable work wins:
+Apply this priority against the `boot` digest's JSON fields — first level with
+actionable work wins:
 
 1. **Owned priorities** (`owned_priorities[]`) — MEMORY.md `## Cross-Cutting
    Priorities` rows where you are `Owner`. Team commitments preempt domain
@@ -39,35 +37,33 @@ level with actionable work wins:
 4. **Cross-cutting fallback** (`cross_cutting[]`) — rows listing you under
    `Agents` (not Owner). Report clean only after checking all four.
 
-**Skip-self rule:** an agent treats its own row in `claims[]` as preempting
-routing — the work is already in flight. Other agents' claims are settled
-state for routing purposes.
+**Skip-self rule:** treat your own row in `claims[]` as preempting routing —
+the work is already in flight. Other agents' claims are settled state.
 
 The `### Decision` block records which level produced the chosen action.
 
 ## Tool-vs-Memory Habit
 
-The competing habit named by the JTBD analysis is `gh` / `git` / source
-re-derivation. When the next answer can come from either path, **prefer
-memory** — every primitive is calibrated to cost fewer tool calls than the
-alternative: one for the on-boot read set (closes **F11**), one for a
-Decision-block append (closes **F4**), one for inbox state (partial **F5**).
-The CLI is the path, not the alternative.
+The competing habit is `gh` / `git` / source re-derivation. When the next
+answer can come from either path, **prefer memory** — every primitive is
+calibrated to cost fewer tool calls than the alternative. The CLI is the
+path, not the alternative.
 
 ## During Each Run
 
 Append entries to the current weekly log via `fit-wiki log`:
 
 - `fit-wiki log decision --agent <self> --surveyed ... --chosen ...
-  --rationale ... [--alternatives ...]` — required at the **opening** of each
-  weekly-log entry. Decision-block contract closes **F6 / F13**.
+  --rationale ... [--alternatives ...]` — required at the **opening** of
+  each weekly-log entry.
 - `fit-wiki log note --agent <self> --field "Actions taken" --body "..."` —
   in-run field append.
 - `fit-wiki log done --agent <self>` — close the entry.
 
 Rotation is implicit: when the next append would push the file past the
-500-line cap, `log` seals the current file as `…-Www-partN.md` and writes the
-new entry to a fresh `…-Www.md`. `fit-wiki rotate` is the operator escape.
+500-line cap, `log` seals the current file as `…-Www-partN.md` and writes
+the new entry to a fresh `…-Www.md`. `fit-wiki rotate` is the operator
+escape.
 
 Triage the Message Inbox via `fit-wiki inbox {list|ack|promote|drop}`.
 `promote --index N` writes a row into `## Cross-Cutting Priorities` and
@@ -80,15 +76,13 @@ Blockers as needed at run end.
 ## Summary Contract
 
 Each `wiki/<agent>.md` conforms to a mechanically-checkable contract —
-`audit` gates it on Stop-hook and pre-merge CI (closes **F10**).
+`audit` gates it on Stop-hook and pre-merge CI.
 
 **Permitted sections (in order):** `# {Agent Title} — Summary` (H1) →
 `**Last run**:` → `## Message Inbox` (with `<!-- memo:inbox -->` marker —
 MUST be the first H2) → agent-specific H2 sections → `## Open Blockers`.
 
-**Line budget: 496 lines** (`SUMMARY_LINE_BUDGET`); **word budget: 6 400
-words** (`SUMMARY_WORD_BUDGET`) to backstop dense single-line prose. State,
-not history.
+**Budgets:** 496 lines, 6 400 words. State, not history.
 
 ## Weekly Log Contract
 
@@ -96,21 +90,15 @@ Weekly logs (`wiki/<agent>-YYYY-Www.md`) are append-only Tier 2 records.
 Named readers: `kata-wiki-curate` (always), `kata-session` (for experiment
 verification), agents explicitly investigating past decisions.
 
-**Line budget: 496 lines** (`WEEKLY_LOG_LINE_BUDGET`); **word budget: 6 400
-words** (`WEEKLY_LOG_WORD_BUDGET`) to backstop dense single-line prose. A
-Tier 2 read of the largest legal weekly log consumes ≤2.5% of an agent's
-1M-token context window — the *context tax* every reader pays (closes **F3
-/ F17**). Storyboards (`wiki/storyboard-YYYY-MNN.md`) share the same
-budgets — 496 lines / 6 400 words — gated by `storyboard.line-budget` and
-`storyboard.word-budget` audit rules. The three budgets share numeric
-limits today; each surface keeps its own rule pair so the limits can
-diverge later if the context-tax model says one surface should be looser
-or tighter.
+**Budgets:** 496 lines, 6 400 words. Storyboards
+(`wiki/storyboard-YYYY-MNN.md`) share the same budgets, gated by separate
+`storyboard.line-budget` / `storyboard.word-budget` audit rules so the
+limits can diverge later.
 
 Overflow rotates: `log` seals the current file as
 `<agent>-YYYY-Www-partN.md` and writes the day's append into a fresh
 `<agent>-YYYY-Www.md`. No part is ever rewritten — the append-only audit
-guarantee is preserved by rename, not by in-place edit.
+guarantee is preserved by rename, not in-place edit.
 
 Every dated `## YYYY-MM-DD` entry opens with `### Decision` (required;
 `audit` enforces).
@@ -118,16 +106,16 @@ Every dated `## YYYY-MM-DD` entry opens with `### Decision` (required;
 ## Cross-Cutting Priorities
 
 `wiki/MEMORY.md` carries the cross-cutting priority surface. Read by every
-boot (digest's `owned_priorities` + `cross_cutting` slices). Schema: `| Item
-| Agents | Owner | Status | Added |`, max 10 active. Writers: `fit-wiki
-inbox promote` (from a memo) and direct `kata-wiki-curate` edits.
+boot (digest's `owned_priorities` + `cross_cutting` slices). Schema:
+`| Item | Agents | Owner | Status | Added |`, max 10 active. Writers:
+`fit-wiki inbox promote` (from a memo) and direct `kata-wiki-curate` edits.
 
 ## Active Claims
 
-Sibling H2 to Cross-Cutting Priorities in `wiki/MEMORY.md`. A *claim* is an
-assertion that an agent is actively working on a named target (a spec, an
-open PR, a storyboard experiment) and intends to ship the next observable
-state change for it. **Row present = active; row absent = settled.**
+Sibling H2 to Cross-Cutting Priorities in `wiki/MEMORY.md`. A *claim*
+asserts that an agent is actively working on a named target and intends to
+ship the next observable state change. **Row present = active; row absent
+= settled.**
 
 Schema (header copied verbatim from `libwiki/constants.js`):
 
@@ -140,66 +128,31 @@ Lifecycle:
 - `fit-wiki claim --agent <self> --target <id> --branch <name> [--pr <id>]
   [--expires-at YYYY-MM-DD]` — defaults `expires_at = claimed_at + 7 days`.
   Refuses duplicates with exit 2.
-- `fit-wiki release --agent <self> --target <id>` — normal lifecycle removal.
+- `fit-wiki release --agent <self> --target <id>` — normal removal.
 - `fit-wiki release --expired` — operator cleanup, removes every row past
   `expires_at`.
 
 Audit history lives in git history of `MEMORY.md` — rows are settled by
-deletion, with the prior commit preserving the claim record. Closes **F8 /
-F18**.
-
-## Named Jobs This Protocol Serves
-
-- *Find the next thing to pick up without colliding* → `fit-wiki claim` /
-  `release`. Claims surface + skip-self rule keeps two agents from racing on
-  the same target.
-- *Trust another agent's reported state without re-deriving* → `fit-wiki
-  boot` digest + `Read wiki/MEMORY.md`.
-- *Receive memos without breaking my contract* → `fit-wiki inbox list / ack /
-  promote / drop`.
+deletion; the prior commit preserves the claim record.
 
 ## CLI Contract Map
 
-| Subcommand | Status | Contract(s) realized |
-| --- | --- | --- |
-| `boot` | new | On-Boot Read Set; On-Boot Routing |
-| `log decision` | new | Decision-block opening (write) |
-| `log note` / `log done` | new | Weekly log field append / close |
-| `claim` / `release` | new | Active Claims write |
-| `inbox list` | new | Message Inbox read |
-| `inbox ack` / `drop` | new | Message Inbox triage |
-| `inbox promote` | new | Cross-Cutting Priorities write (from inbox) |
-| `rotate` | new | Weekly Log Contract (explicit rotation) |
-| `audit` | absorbed (`scripts/wiki-audit.sh`) | Summary; Active Claims schema; Decision-block opening (gate); Weekly Log cap (gate); Expired claims |
-| `memo` | retained | Sibling channel (cross-agent memo writer) |
-| `push` / `pull` | retained | Sibling channel (wiki git lifecycle) |
-| `init` | modified | Active Claims scaffold; Stop-hook installation |
-| `refresh` | extended | Sibling channel (storyboard + obstacle/experiment markers) |
+| Subcommand | Contract(s) realized |
+| --- | --- |
+| `boot` | On-Boot Read Set; On-Boot Routing |
+| `log decision` | Decision-block opening (write) |
+| `log note` / `log done` | Weekly log field append / close |
+| `claim` / `release` | Active Claims write |
+| `inbox list` | Message Inbox read |
+| `inbox ack` / `drop` | Message Inbox triage |
+| `inbox promote` | Cross-Cutting Priorities write (from inbox) |
+| `rotate` | Weekly Log Contract (explicit rotation) |
+| `audit` | Summary; Active Claims schema; Decision-block gate; Weekly Log cap; Expired claims |
+| `memo` | Cross-agent memo writer |
+| `push` / `pull` | Wiki git lifecycle |
+| `init` | Active Claims scaffold; Stop-hook installation |
+| `refresh` | Storyboard + obstacle/experiment marker refresh |
 
 One-shot administrative scripts (`scripts/spec-NNN-*.mjs`) write to `wiki/`
 transiently and self-delete in the same commit; they are not part of this
-protocol's read/write contract.
-
-**Reverse map — every contract has a writer and (if gated) an auditor:**
-
-| Contract assigned to the CLI | Subcommand(s) |
-| --- | --- |
-| On-Boot Read Set / On-Boot Routing | `boot` |
-| Decision-block (write / gate) | `log decision` / `audit` |
-| Weekly log append | `log decision`, `log note`, `log done` |
-| Weekly log cap (write / gate) | `log` (seal-before-append), `rotate` / `audit` |
-| Active Claims (write / gate) | `claim`, `release`, `release --expired` / `audit` |
-| Cross-Cutting Priorities write | `inbox promote` (plus `kata-wiki-curate`) |
-| Message Inbox (read / triage) | `inbox list` / `inbox ack`, `drop`, `promote` |
-| Summary Contract (gate) | `audit` |
-| Active Claims scaffold + Stop-hook install | `init` |
-
-## Process
-
-```mermaid
-graph TD
-  A[Agent Startup] --> R[Read wiki/MEMORY.md]
-  A --> B["Bash: fit-wiki boot"]
-  B --> D["Digest { owned_priorities, claims, storyboard_items, cross_cutting }"]
-  D --> Route[Action routing per § On-Boot Routing]
-```
+protocol.

--- a/COALIGNED.md
+++ b/COALIGNED.md
@@ -102,6 +102,20 @@ scope constraints.
 3. **Minimal.** Every line loads on every run. Include scope constraints and
    skill routing; push everything else to L4 or L5.
 
+### Agent References
+
+Read on demand when a profile or procedure cites them. Co-located in
+`.claude/agents/references/<name>.md`. Same declarative role as L5 skill
+references but shared across agents — cross-cutting protocols (memory,
+coordination, approval) that no single skill owns.
+
+1. **Declarative, cross-cutting.** Protocols and tables shared by multiple
+   agents. If only one skill consults it, put it in that skill's `references/`.
+2. **Independently correct.** Stale data is a distinct defect class from a
+   wrong profile or procedure.
+3. **On-demand only.** Never auto-loaded. If a profile always needs the
+   content, fold it into the profile or the calling skill.
+
 ## L4 — Skill Procedure (SKILL.md)
 
 Auto-loaded per skill invocation. The procedure is the complete instruction set
@@ -216,6 +230,7 @@ enforced by `coaligned instructions` (see `libraries/libcoaligned/`):
 | L1 subdir CLAUDE.md          | ≤ 128 lines | on demand        |
 | L2 CONTRIBUTING.md & JTBD.md | ≤ 256 lines | on demand        |
 | L3 Agent profile             | ≤ 72 lines  | auto (every run) |
+| L3 Agent reference           | ≤ 192 lines | on demand        |
 | L4 SKILL.md                  | ≤ 192 lines | auto (per skill) |
 | L5 Skill reference file      | ≤ 128 lines | on demand        |
 | L6 Checklist (per block)     | ≤ 9 items   | auto (per skill) |

--- a/libraries/libcoaligned/src/instructions.js
+++ b/libraries/libcoaligned/src/instructions.js
@@ -78,6 +78,19 @@ async function findAgentProfiles(root, claudeDirs) {
   return out;
 }
 
+async function findAgentReferences(root, claudeDirs) {
+  const out = [];
+  for (const d of claudeDirs) {
+    const files = await listFiles(
+      root,
+      `${d}/agents/references`,
+      (e) => e.isFile() && e.name.endsWith(".md"),
+    );
+    out.push(...files);
+  }
+  return out;
+}
+
 async function findSkillDirs(root, claudeDirs) {
   const out = [];
   for (const d of claudeDirs) {
@@ -144,6 +157,13 @@ async function buildLayers(root) {
         maxLines: 72,
         maxWords: 448,
         files: await findAgentProfiles(root, claudeDirs),
+      },
+      {
+        id: "L3",
+        name: "agent reference",
+        maxLines: 192,
+        maxWords: 1280,
+        files: await findAgentReferences(root, claudeDirs),
       },
       {
         id: "L4",

--- a/libraries/libcoaligned/test/instructions.test.js
+++ b/libraries/libcoaligned/test/instructions.test.js
@@ -68,6 +68,30 @@ describe("checkInstructions", () => {
     }
   });
 
+  test("flags an oversized agent reference at the 192-line cap", async () => {
+    const root = await makeRepo();
+    try {
+      await mkdir(join(root, ".claude", "agents", "references"), {
+        recursive: true,
+      });
+      const oversize = "line\n".repeat(200);
+      await writeFile(join(root, ".claude/agents/references/big.md"), oversize);
+      const findings = await checkInstructions({ root });
+      const f = findings.find(
+        (x) =>
+          x.id === "instructions.line-budget" &&
+          x.path.endsWith(".claude/agents/references/big.md"),
+      );
+      assert.ok(
+        f,
+        `expected an agent-reference line-budget finding, got: ${JSON.stringify(findings)}`,
+      );
+      assert.match(f.message, /agent reference/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("flags a checklist that exceeds 9 items", async () => {
     const root = await makeRepo();
     try {


### PR DESCRIPTION
## Summary

- New **L3 Agent reference** layer in COALIGNED.md (≤ 192 lines / ≤ 1280 words, on-demand). Parallels L5 skill references but for cross-cutting protocols shared across agents (memory, coordination, approval).
- `libcoaligned` now scans `.claude/agents/references/*.md` against the new caps — previously these files were silently unbounded. The layer config slots into the post-#1213 ESLint-style rule catalog.
- Two oversized references (no splits) rewritten tighter to fit:
  - `coordination-protocol.md`: 293→174 lines, 1888→1099 words. Cut the approval-signal duplication (now a pointer to `approval-signals.md`), the worked redefinition example, the detection shell snippet, the Discussion runtime-mechanism section, and the "Common mis-routings" recap. Compressed the eight-move table and YAML shape.
  - `memory-protocol.md`: 204→158 lines, 1337→924 words. Cut the "Named Jobs This Protocol Serves" block, the reverse CLI map, the Mermaid process diagram, the F# obstacle-code references, and the "context tax" prose.
- Preserved every stable anchor cited from KATA.md and specs (`#measurement-system-changes`, `#detection`, `#on-boot-routing`, `#on-boot-read-set`, `#cli-contract-map`).

## Test plan

- [x] `bunx coaligned instructions` exits 0
- [x] `cd libraries/libcoaligned && bun test` — 12/12 pass (includes a new test for the L3 agent-reference cap)
- [x] `bun run check` — repo lint/format clean (3 wiki-audit errors are pre-existing in the wiki repo, not introduced by this branch)
- [ ] Confirm KATA.md cross-references still resolve in rendered docs

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSDonBiWLG6yJxznoXScsK)_