### PR TITLE
fix(libeval): block Recess misuse when Asks are pending; reshape trigger kinds around intent

### DIFF
--- a/libraries/libbridge/CLAUDE.md
+++ b/libraries/libbridge/CLAUDE.md
@@ -72,8 +72,12 @@ README for the channel-specific surface.
 ## Suspend/resume
 
 When a workflow returns `verdict: "recessed"` with a `trigger`, the
-conversation waits — for N more responses, an elapsed duration, or either.
-`ResumeScheduler` owns that lifecycle:
+conversation waits. The trigger kind names the lead's intent:
+`missing_input` (resume when N new replies have arrived on the
+dispatching thread), `elapsed` (resume after an ISO-8601 duration), or
+`escalation_needed` (reserved for future signal-based resume; the
+scheduler throws if it sees this kind today). `ResumeScheduler` owns
+that lifecycle:
 
 ```js
 const resume = new ResumeScheduler({

--- a/libraries/libbridge/src/callback-payload.js
+++ b/libraries/libbridge/src/callback-payload.js
@@ -48,7 +48,20 @@ export function validateCallbackPayload(body) {
   };
 }
 
-const ALLOWED_TRIGGER_KINDS = new Set(["responses", "elapsed", "any"]);
+const ALLOWED_TRIGGER_KINDS = new Set([
+  "missing_input",
+  "escalation_needed",
+  "elapsed",
+]);
+
+const TRIGGER_FIELD_VALIDATORS = {
+  replies: (raw) => {
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n : undefined;
+  },
+  elapsed: (raw) => (typeof raw === "string" ? raw : undefined),
+  signal: (raw) => (typeof raw === "string" && raw ? raw : undefined),
+};
 
 /**
  * Validate and sanitize a trigger object at the payload boundary.
@@ -63,14 +76,11 @@ function validateTrigger(raw) {
     return undefined;
   }
   const trigger = { kind: raw.kind };
-  if (raw.responses !== undefined) {
-    const n = Number(raw.responses);
-    if (!Number.isFinite(n) || n < 0) return undefined;
-    trigger.responses = n;
-  }
-  if (raw.elapsed !== undefined) {
-    if (typeof raw.elapsed !== "string") return undefined;
-    trigger.elapsed = raw.elapsed;
+  for (const [field, validate] of Object.entries(TRIGGER_FIELD_VALIDATORS)) {
+    if (raw[field] === undefined) continue;
+    const clean = validate(raw[field]);
+    if (clean === undefined) return undefined;
+    trigger[field] = clean;
   }
   return trigger;
 }

--- a/libraries/libbridge/src/resume-scheduler.js
+++ b/libraries/libbridge/src/resume-scheduler.js
@@ -119,12 +119,10 @@ export class ResumeScheduler {
       opened_at: openedAt,
       history_index_at_open: ctx.history.length,
     };
-    if (trigger.kind === "elapsed" || trigger.kind === "either") {
-      if (typeof trigger.elapsed === "string") {
-        const dueAt = openedAt + parseIsoDuration(trigger.elapsed);
-        ctx.open_rfcs[correlationId].due_at = dueAt;
-        this.#elapsed.schedule(correlationId, dueAt);
-      }
+    if (trigger.kind === "elapsed" && typeof trigger.elapsed === "string") {
+      const dueAt = openedAt + parseIsoDuration(trigger.elapsed);
+      ctx.open_rfcs[correlationId].due_at = dueAt;
+      this.#elapsed.schedule(correlationId, dueAt);
     }
   }
 
@@ -204,7 +202,7 @@ export class ResumeScheduler {
       const trigger = rfc.trigger;
       if (!trigger) continue;
       const observed = {
-        responses: ctx.history.length - rfc.history_index_at_open,
+        replies: ctx.history.length - rfc.history_index_at_open,
         opened_at: rfc.opened_at,
       };
       if (evaluateTrigger(trigger, observed, Date.now()).fired) {

--- a/libraries/libbridge/src/triggers.js
+++ b/libraries/libbridge/src/triggers.js
@@ -1,10 +1,13 @@
 /**
  * @typedef {object} ResumeTrigger
- * @property {"responses"|"elapsed"|"either"} kind
- * @property {number} [responses] - Number of new responses needed.
- *   For `kind: "either"`, optional alongside `elapsed`.
- * @property {string} [elapsed] - ISO-8601 duration, e.g. `"P14D"`, `"PT12H"`,
- *   `"P1DT6H"`. Required for `kind: "elapsed"`; optional for `"either"`.
+ * @property {"missing_input"|"escalation_needed"|"elapsed"} kind
+ * @property {number} [replies] - Required for `kind: "missing_input"`.
+ *   Number of new replies on the dispatching thread needed to fire.
+ * @property {string} [elapsed] - Required for `kind: "elapsed"`.
+ *   ISO-8601 duration, e.g. `"P14D"`, `"PT12H"`, `"P1DT6H"`.
+ * @property {string} [signal] - Required for `kind: "escalation_needed"`.
+ *   Reserved for future use. The bridge throws when evaluating this kind
+ *   until signal-based resume support lands.
  */
 
 const ISO_8601_DURATION =
@@ -42,7 +45,7 @@ export function parseIsoDuration(duration) {
  * Evaluate whether a resume trigger has fired.
  *
  * @param {ResumeTrigger} trigger
- * @param {{responses?: number, opened_at?: number}} observed
+ * @param {{replies?: number, opened_at?: number}} observed
  * @param {number} now - ms epoch (caller-provided for testability)
  * @returns {{fired: boolean, due_at?: number}}
  */
@@ -56,37 +59,27 @@ export function evaluateTrigger(trigger, observed, now) {
   observed ??= {};
 
   switch (trigger.kind) {
-    case "responses":
-      return evaluateResponses(trigger, observed);
+    case "missing_input":
+      return evaluateMissingInput(trigger, observed);
     case "elapsed":
       return evaluateElapsed(trigger, observed, now);
-    case "either": {
-      const r =
-        trigger.responses !== undefined
-          ? evaluateResponses(trigger, observed)
-          : { fired: false };
-      const e =
-        trigger.elapsed !== undefined
-          ? evaluateElapsed(trigger, observed, now)
-          : { fired: false };
-      if (r.fired || e.fired) return { fired: true };
-      return e.due_at !== undefined
-        ? { fired: false, due_at: e.due_at }
-        : { fired: false };
-    }
+    case "escalation_needed":
+      throw new Error(
+        "escalation_needed is reserved for future use. See the follow-up spec for signal-based resume.",
+      );
     default:
       throw new Error(`Unsupported trigger kind: ${trigger.kind}`);
   }
 }
 
-function evaluateResponses(trigger, observed) {
-  if (typeof trigger.responses !== "number" || trigger.responses < 1) {
+function evaluateMissingInput(trigger, observed) {
+  if (typeof trigger.replies !== "number" || trigger.replies < 1) {
     throw new Error(
-      'trigger.responses must be a positive number for kind "responses"',
+      'trigger.replies must be a positive number for kind "missing_input"',
     );
   }
-  const seen = observed.responses ?? 0;
-  return { fired: seen >= trigger.responses };
+  const seen = observed.replies ?? 0;
+  return { fired: seen >= trigger.replies };
 }
 
 function evaluateElapsed(trigger, observed, now) {

--- a/libraries/libbridge/test/callback-payload.test.js
+++ b/libraries/libbridge/test/callback-payload.test.js
@@ -48,12 +48,12 @@ describe("validateCallbackPayload", () => {
       verdict: "adjourned",
       summary: "done",
       replies: [{ body: "hi" }, { body: "follow up", in_reply_to: "C_1" }],
-      trigger: { kind: "responses", responses: 2 },
+      trigger: { kind: "missing_input", replies: 2 },
       discussion_id: "GD_x",
       run_url: "https://github.com/owner/repo/actions/runs/1",
     });
     expect(payload.replies).toHaveLength(2);
-    expect(payload.trigger).toEqual({ kind: "responses", responses: 2 });
+    expect(payload.trigger).toEqual({ kind: "missing_input", replies: 2 });
     expect(payload.discussion_id).toBe("GD_x");
     expect(payload.run_url).toBe(
       "https://github.com/owner/repo/actions/runs/1",
@@ -107,7 +107,7 @@ describe("validateCallbackPayload", () => {
   });
 
   test("accepts trigger with allowed kind values", () => {
-    for (const kind of ["responses", "elapsed", "any"]) {
+    for (const kind of ["missing_input", "escalation_needed", "elapsed"]) {
       const payload = validateCallbackPayload({
         correlation_id: "c-1",
         trigger: { kind },
@@ -116,18 +116,28 @@ describe("validateCallbackPayload", () => {
     }
   });
 
-  test("validates trigger responses as a finite non-negative number", () => {
+  test("rejects legacy kinds (responses, either, any) at the payload boundary", () => {
+    for (const kind of ["responses", "either", "any"]) {
+      const payload = validateCallbackPayload({
+        correlation_id: "c-1",
+        trigger: { kind },
+      });
+      expect(payload.trigger).toBeUndefined();
+    }
+  });
+
+  test("validates trigger replies as a finite non-negative number", () => {
     const bad = validateCallbackPayload({
       correlation_id: "c-1",
-      trigger: { kind: "responses", responses: -1 },
+      trigger: { kind: "missing_input", replies: -1 },
     });
     expect(bad.trigger).toBeUndefined();
 
     const good = validateCallbackPayload({
       correlation_id: "c-1",
-      trigger: { kind: "responses", responses: 3 },
+      trigger: { kind: "missing_input", replies: 3 },
     });
-    expect(good.trigger).toEqual({ kind: "responses", responses: 3 });
+    expect(good.trigger).toEqual({ kind: "missing_input", replies: 3 });
   });
 
   test("validates trigger elapsed as a string", () => {
@@ -142,6 +152,23 @@ describe("validateCallbackPayload", () => {
       trigger: { kind: "elapsed", elapsed: "PT5M" },
     });
     expect(good.trigger).toEqual({ kind: "elapsed", elapsed: "PT5M" });
+  });
+
+  test("validates trigger signal as a non-empty string for escalation_needed", () => {
+    const bad = validateCallbackPayload({
+      correlation_id: "c-1",
+      trigger: { kind: "escalation_needed", signal: "" },
+    });
+    expect(bad.trigger).toBeUndefined();
+
+    const good = validateCallbackPayload({
+      correlation_id: "c-1",
+      trigger: { kind: "escalation_needed", signal: "reviewer-ack" },
+    });
+    expect(good.trigger).toEqual({
+      kind: "escalation_needed",
+      signal: "reviewer-ack",
+    });
   });
 });
 

--- a/libraries/libbridge/test/resume-scheduler.test.js
+++ b/libraries/libbridge/test/resume-scheduler.test.js
@@ -108,11 +108,11 @@ describe("ResumeScheduler", () => {
       history: [{ role: "user", text: "first" }],
     });
     env.scheduler.enterRecess(ctx, "corr-1", {
-      kind: "responses",
-      responses: 2,
+      kind: "missing_input",
+      replies: 2,
     });
     const rfc = ctx.open_rfcs["corr-1"];
-    expect(rfc.trigger).toEqual({ kind: "responses", responses: 2 });
+    expect(rfc.trigger).toEqual({ kind: "missing_input", replies: 2 });
     expect(rfc.history_index_at_open).toBe(1);
     expect(typeof rfc.opened_at).toBe("number");
     expect(rfc.due_at).toBeUndefined();
@@ -162,10 +162,10 @@ describe("ResumeScheduler", () => {
   test("processInbound returns freshDispatchAllowed=false when an rfc is open but no trigger fired", async () => {
     const ctx = makeCtx({ history: [{ role: "user", text: "x" }] });
     env.scheduler.enterRecess(ctx, "corr-5", {
-      kind: "responses",
-      responses: 5,
+      kind: "missing_input",
+      replies: 5,
     });
-    // Append one more so we have responses=1 since recess (one < 5).
+    // Append one more so we have replies=1 since recess (one < 5).
     ctx.history.push({ role: "user", text: "y" });
     const result = await env.scheduler.processInbound(ctx);
     expect(result).toEqual({
@@ -176,14 +176,14 @@ describe("ResumeScheduler", () => {
     expect(fetchStub.calls).toHaveLength(0);
   });
 
-  test("processInbound fires a 'responses' trigger and redispatches with resume_context", async () => {
+  test("processInbound fires a 'missing_input' trigger and redispatches with resume_context", async () => {
     const ctx = makeCtx();
     await env.store.add(ctx);
     env.scheduler.enterRecess(ctx, "corr-fire", {
-      kind: "responses",
-      responses: 2,
+      kind: "missing_input",
+      replies: 2,
     });
-    // Two new responses since recess.
+    // Two new replies since recess.
     ctx.history.push({ role: "user", text: "one" });
     ctx.history.push({ role: "user", text: "two" });
 
@@ -215,8 +215,8 @@ describe("ResumeScheduler", () => {
     const ctx = makeCtx({ id: "thread-99" });
     await env.store.add(ctx);
     env.scheduler.enterRecess(ctx, "corr-x", {
-      kind: "responses",
-      responses: 1,
+      kind: "missing_input",
+      replies: 1,
     });
     ctx.history.push({ role: "user", text: "hello" });
     await env.scheduler.processInbound(ctx);
@@ -235,8 +235,8 @@ describe("ResumeScheduler", () => {
     const ctx = makeCtx({ id: "D_99" });
     await env.store.add(ctx);
     env.scheduler.enterRecess(ctx, "corr-y", {
-      kind: "responses",
-      responses: 1,
+      kind: "missing_input",
+      replies: 1,
     });
     ctx.history.push({ role: "user", text: "hi" });
     await env.scheduler.processInbound(ctx);

--- a/libraries/libbridge/test/triggers.test.js
+++ b/libraries/libbridge/test/triggers.test.js
@@ -33,17 +33,17 @@ describe("parseIsoDuration", () => {
 });
 
 describe("evaluateTrigger", () => {
-  test("kind=responses fires when observed count reaches the threshold", () => {
-    const t = { kind: "responses", responses: 3 };
-    expect(evaluateTrigger(t, { responses: 2 }, 0)).toEqual({ fired: false });
-    expect(evaluateTrigger(t, { responses: 3 }, 0)).toEqual({ fired: true });
-    expect(evaluateTrigger(t, { responses: 5 }, 0)).toEqual({ fired: true });
+  test("kind=missing_input fires when observed replies reaches the threshold", () => {
+    const t = { kind: "missing_input", replies: 3 };
+    expect(evaluateTrigger(t, { replies: 2 }, 0)).toEqual({ fired: false });
+    expect(evaluateTrigger(t, { replies: 3 }, 0)).toEqual({ fired: true });
+    expect(evaluateTrigger(t, { replies: 5 }, 0)).toEqual({ fired: true });
   });
 
-  test("kind=responses without observed.responses treats it as 0", () => {
-    expect(evaluateTrigger({ kind: "responses", responses: 1 }, {}, 0)).toEqual(
-      { fired: false },
-    );
+  test("kind=missing_input without observed.replies treats it as 0", () => {
+    expect(
+      evaluateTrigger({ kind: "missing_input", replies: 1 }, {}, 0),
+    ).toEqual({ fired: false });
   });
 
   test("kind=elapsed fires once now passes opened_at + duration", () => {
@@ -68,31 +68,10 @@ describe("evaluateTrigger", () => {
     );
   });
 
-  test("kind=either fires when either branch fires", () => {
-    const opened_at = 100;
-    const trigger = { kind: "either", responses: 2, elapsed: "PT1H" };
-    expect(
-      evaluateTrigger(trigger, { responses: 0, opened_at }, opened_at + 10),
-    ).toEqual({
-      fired: false,
-      due_at: opened_at + 60 * 60 * 1000,
-    });
-    expect(
-      evaluateTrigger(trigger, { responses: 2, opened_at }, opened_at + 10),
-    ).toEqual({ fired: true });
-    expect(
-      evaluateTrigger(
-        trigger,
-        { responses: 0, opened_at },
-        opened_at + 60 * 60 * 1000,
-      ),
-    ).toEqual({ fired: true });
-  });
-
-  test("kind=either honours single-branch triggers (only responses)", () => {
-    expect(
-      evaluateTrigger({ kind: "either", responses: 1 }, { responses: 1 }, 0),
-    ).toEqual({ fired: true });
+  test("kind=escalation_needed throws as reserved for future use", () => {
+    expect(() =>
+      evaluateTrigger({ kind: "escalation_needed", signal: "ack" }, {}, 0),
+    ).toThrow(/reserved for future use/);
   });
 
   test("now is caller-provided — function never reads Date.now()", () => {
@@ -106,7 +85,8 @@ describe("evaluateTrigger", () => {
   test("rejects invalid trigger shapes", () => {
     expect(() => evaluateTrigger(null, {}, 0)).toThrow();
     expect(() => evaluateTrigger({ kind: "ufo" }, {}, 0)).toThrow();
-    expect(() => evaluateTrigger({ kind: "responses" }, {}, 0)).toThrow();
+    expect(() => evaluateTrigger({ kind: "either" }, {}, 0)).toThrow();
+    expect(() => evaluateTrigger({ kind: "missing_input" }, {}, 0)).toThrow();
     expect(() => evaluateTrigger({ kind: "elapsed" }, {}, 0)).toThrow();
     expect(() =>
       evaluateTrigger({ kind: "elapsed", elapsed: "P14D" }, {}, "now"),

--- a/libraries/libeval/src/discuss-tools.js
+++ b/libraries/libeval/src/discuss-tools.js
@@ -20,28 +20,44 @@ import { tool } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
 
 import {
+  ADJOURN_DESC,
   baseTools,
   concludeSession,
   orchestrationServer,
+  RECESS_DESC,
   requestForCommentTool,
+  requireNoPendingAsks,
 } from "./orchestration-toolkit.js";
 
 /** System prompt for discuss-mode agent participants. L0 mechanics only per COALIGNED. */
 export const DISCUSS_AGENT_SYSTEM_PROMPT =
   "You are a participant in a discussion.\n" +
-  "Each question arrives as `[ask#N] <name>: <text>`.\n" +
+  "Each question arrives as `[ask#N] <name>: <text>` in your inbox.\n" +
   "Quote N as askId on your `Answer` to route the reply correctly.\n" +
   "Your `Answer` is posted to the discussion thread as a separate reply.\n" +
   "If the task already contains a completed response with no new human input after it, `Answer` that no further action is needed.\n" +
   "Do not redo completed work.";
 
-const RESUME_TRIGGER_SCHEMA = z
-  .object({
-    kind: z.enum(["responses", "elapsed", "either"]),
-    responses: z.number().optional(),
-    elapsed: z.string().optional(),
-  })
-  .strict();
+const RESUME_TRIGGER_SCHEMA = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("missing_input"),
+      replies: z.number().int().positive(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("escalation_needed"),
+      signal: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("elapsed"),
+      elapsed: z.string().min(1),
+    })
+    .strict(),
+]);
 
 /** Discuss-mode lead tool server. */
 export function createDiscussLeadToolServer(ctx) {
@@ -49,13 +65,13 @@ export function createDiscussLeadToolServer(ctx) {
     ...baseTools(ctx, { from: "lead", defaultTo: undefined, broadcast: true }),
     tool(
       "Recess",
-      "Suspend the run. The bridge re-dispatches the workflow when the trigger fires.",
+      RECESS_DESC,
       { reason: z.string(), trigger: RESUME_TRIGGER_SCHEMA },
       createRecessHandler(ctx),
     ),
     tool(
       "Adjourn",
-      "End the discussion with a verdict ('adjourned' / 'failed') and a summary.",
+      ADJOURN_DESC,
       {
         verdict: z.enum(["adjourned", "failed"]),
         summary: z.string(),
@@ -83,6 +99,8 @@ export function createDiscussAgentToolServer(ctx, { from }) {
  */
 export function createRecessHandler(ctx) {
   return async ({ reason, trigger }) => {
+    const guard = requireNoPendingAsks(ctx);
+    if (guard) return guard;
     ctx.recessTrigger = trigger;
     concludeSession(ctx, {
       verdict: "recessed",
@@ -96,6 +114,8 @@ export function createRecessHandler(ctx) {
 /** Adjourn handler — ends the discussion with a verdict. */
 export function createAdjournHandler(ctx) {
   return async ({ verdict, summary, outcome }) => {
+    const guard = requireNoPendingAsks(ctx);
+    if (guard) return guard;
     if (outcome !== undefined) ctx.outcome = outcome;
     concludeSession(ctx, {
       verdict,

--- a/libraries/libeval/src/discusser.js
+++ b/libraries/libeval/src/discusser.js
@@ -36,10 +36,11 @@ export const DISCUSS_SYSTEM_PROMPT =
   "Use `Ask` to delegate work to the best-suited participant.\n" +
   "Participants are domain experts; state the task, not how to do it.\n" +
   "Each participant's `Answer` is posted to the discussion thread as a separate reply.\n" +
-  "`Ask` returns {askIds:[N,…]} immediately.\n" +
-  "Answers arrive on your next turn as `[answer#N] <participant>: <text>`.\n" +
-  "Multiple `Ask` calls in one turn run participants concurrently.\n" +
-  "Wait for all participants to `Answer` before calling `Adjourn` or `Recess`.";
+  "`Ask` is async and returns {askIds:[N,…]} immediately.\n" +
+  "Answers arrive on your next turn as `[answer#N] <participant>: <text>` in your inbox.\n" +
+  "End your turn while Asks are pending. The system resumes you when answers arrive.\n" +
+  "Multiple `Ask` calls in one turn run participants in parallel.\n" +
+  "End the discussion by calling `Adjourn` with a verdict and summary, or `Recess` only to wait on an external reply or duration.";
 
 /**
  * Augment a base orchestration context with discuss-mode fields.

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -25,15 +25,16 @@ export const FACILITATOR_SYSTEM_PROMPT =
   "Use `RollCall` to list participants.\n" +
   "Use `Ask` to delegate work to the best-suited participant.\n" +
   "Participants are domain experts; state the task, not how to do it.\n" +
-  "`Ask` returns {askIds:[N,…]} immediately.\n" +
-  "Answers arrive on your next turn as `[answer#N] <participant>: <text>`.\n" +
-  "Multiple `Ask` calls in one turn run participants concurrently.\n" +
-  "Wait for all participants to `Answer` before calling `Conclude`.";
+  "`Ask` is async and returns {askIds:[N,…]} immediately.\n" +
+  "Answers arrive on your next turn as `[answer#N] <participant>: <text>` in your inbox.\n" +
+  "End your turn while Asks are pending. The system resumes you when answers arrive.\n" +
+  "Multiple `Ask` calls in one turn run participants in parallel.\n" +
+  "End every session by calling `Conclude` with a verdict and summary.";
 
 /** System prompt for facilitated agent participants. L0 mechanics only per COALIGNED. */
 export const FACILITATED_AGENT_SYSTEM_PROMPT =
   "You are a participant in a facilitated session.\n" +
-  "Each question arrives as `[ask#N] <name>: <text>`.\n" +
+  "Each question arrives as `[ask#N] <name>: <text>` in your inbox.\n" +
   "Quote N as askId on your `Answer` to route the reply correctly.\n" +
   "If the task already contains a completed response with no new human input after it, `Answer` that no further action is needed.\n" +
   "Do not redo completed work.";

--- a/libraries/libeval/src/orchestration-toolkit.js
+++ b/libraries/libeval/src/orchestration-toolkit.js
@@ -46,9 +46,24 @@ export function createOrchestrationContext() {
 
 // --- Handler factories ---
 
+/**
+ * Guard for terminal tools (`Conclude`, `Adjourn`, `Recess`). Returns an
+ * error result when the caller still has Asks in flight, telling them to
+ * end the turn and wait for the auto-resume. Returns `null` when no Asks
+ * are pending and the terminal tool is free to run.
+ */
+export function requireNoPendingAsks(ctx) {
+  if (ctx.pendingAsks.size === 0) return null;
+  return errorResult(
+    "Asks are still pending. End your turn. You will be resumed when answers arrive.",
+  );
+}
+
 /** Mark the session as concluded; cancel any open Asks so askers see the synthetic null on their next turn. */
 export function createConcludeHandler(ctx) {
   return async ({ verdict, summary }) => {
+    const guard = requireNoPendingAsks(ctx);
+    if (guard) return guard;
     concludeSession(ctx, { verdict, summary, reason: "session concluded" });
     return { content: [{ type: "text", text: "Session concluded." }] };
   };
@@ -235,8 +250,18 @@ const ANNOUNCE_DESC = "Broadcast a message with no reply expected.";
 
 const ROLLCALL_DESC = "List all participants in the session.";
 
+// Terminal-tool descriptions. Each one ends the run. Group them so the
+// contrast is visible: Conclude (success/failure), Adjourn (settled in
+// thread), Recess (paused for out-of-session input). Each description
+// leads with the cost.
 const CONCLUDE_DESC =
-  "End the session with a verdict ('success' or 'failure') and a summary.";
+  "End the session. Provide a verdict ('success' or 'failure') and a summary.";
+
+const ADJOURN_DESC =
+  "End the discussion. Provide a verdict ('adjourned' or 'failed') and a summary. Cancels any unanswered Asks.";
+
+const RECESS_DESC =
+  "End the run and schedule an out-of-session re-dispatch. Cancels any unanswered Asks. Use only when waiting on an external reply or duration. Do not use to wait on in-flight Asks.";
 
 // --- Tool builders ---
 
@@ -244,6 +269,7 @@ const CONCLUDE_DESC =
 function textResult(text) {
   return { content: [{ type: "text", text }] };
 }
+/** Build an MCP tool error result wrapping a single text message. */
 function errorResult(text) {
   return { content: [{ type: "text", text }], isError: true };
 }
@@ -391,4 +417,11 @@ function requestForCommentTool(ctx) {
 
 // Re-export the building blocks discuss-tools.js needs to assemble its
 // own lead tool surface (it has two extra terminal tools).
-export { baseTools, orchestrationServer, requestForCommentTool };
+export {
+  ADJOURN_DESC,
+  baseTools,
+  errorResult,
+  orchestrationServer,
+  RECESS_DESC,
+  requestForCommentTool,
+};

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -32,15 +32,16 @@ export const SUPERVISOR_SYSTEM_PROMPT =
   "You supervise one agent.\n" +
   "You have no tools to perform work yourself.\n" +
   "Use `Ask` to delegate work to the agent.\n" +
-  "`Ask` returns {askIds:[N]} immediately.\n" +
-  "The reply arrives on your next turn as `[answer#N] agent: <text>`.\n" +
+  "`Ask` is async and returns {askIds:[N]} immediately.\n" +
+  "The reply arrives on your next turn as `[answer#N] agent: <text>` in your inbox.\n" +
+  "End your turn while Asks are pending. The system resumes you when an answer arrives.\n" +
   "If the agent goes off-track, send a corrective `Ask`.\n" +
-  "End every session by calling `Conclude`.";
+  "End every session by calling `Conclude` with a verdict and summary.";
 
 /** System prompt for the supervised agent. L0 mechanics only per COALIGNED. */
 export const AGENT_SYSTEM_PROMPT =
   "A supervisor directs your work.\n" +
-  "Each question arrives as `[ask#N] supervisor: <text>`.\n" +
+  "Each question arrives as `[ask#N] supervisor: <text>` in your inbox.\n" +
   "Quote N as askId on your `Answer` to route the reply correctly.\n" +
   "If the task already contains a completed response with no new human input after it, `Answer` that no further action is needed.\n" +
   "Do not redo completed work.";

--- a/libraries/libeval/test/discuss-tools.test.js
+++ b/libraries/libeval/test/discuss-tools.test.js
@@ -94,4 +94,49 @@ describe("DiscussTools handlers", () => {
     assert.strictEqual(ctx.summary, "Discussion settled");
     assert.strictEqual(ctx.outcome, "approved");
   });
+
+  test("Recess refuses when Asks are still pending and leaves ctx.concluded false", async () => {
+    const ctx = makeCtx();
+    ctx.messageBus = { answer: () => {} };
+    ctx.pendingAsks.set(7, {
+      askId: 7,
+      askerName: "lead",
+      addresseeName: "agent-1",
+      reminded: false,
+    });
+    const handler = createRecessHandler(ctx);
+
+    const result = await handler({
+      reason: "premature",
+      trigger: { kind: "elapsed", elapsed: "PT1H" },
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.match(result.content[0].text, /Asks are still pending/);
+    assert.strictEqual(ctx.concluded, false);
+    assert.strictEqual(ctx.recessTrigger, null);
+    assert.strictEqual(ctx.pendingAsks.size, 1);
+  });
+
+  test("Adjourn refuses when Asks are still pending and leaves ctx.concluded false", async () => {
+    const ctx = makeCtx();
+    ctx.messageBus = { answer: () => {} };
+    ctx.pendingAsks.set(9, {
+      askId: 9,
+      askerName: "lead",
+      addresseeName: "agent-1",
+      reminded: false,
+    });
+    const handler = createAdjournHandler(ctx);
+
+    const result = await handler({
+      verdict: "adjourned",
+      summary: "early exit",
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.match(result.content[0].text, /Asks are still pending/);
+    assert.strictEqual(ctx.concluded, false);
+    assert.strictEqual(ctx.pendingAsks.size, 1);
+  });
 });

--- a/libraries/libeval/test/discusser.test.js
+++ b/libraries/libeval/test/discusser.test.js
@@ -79,7 +79,7 @@ describe("Discusser orchestration", () => {
     const redactor = createNoopRedactor();
     const ctx = augmentContextForDiscuss(createOrchestrationContext(), null);
     ctx.verdict = "recessed";
-    ctx.recessTrigger = { kind: "responses", responses: 2 };
+    ctx.recessTrigger = { kind: "missing_input", replies: 2 };
     ctx.summary = "awaiting replies";
     ctx.replies.push({ body: "outgoing reply", agent: "agent-1" });
 
@@ -102,7 +102,10 @@ describe("Discusser orchestration", () => {
 
     assert.strictEqual(result.success, false);
     assert.strictEqual(result.verdict, "recessed");
-    assert.deepStrictEqual(result.trigger, { kind: "responses", responses: 2 });
+    assert.deepStrictEqual(result.trigger, {
+      kind: "missing_input",
+      replies: 2,
+    });
     assert.strictEqual(result.replies.length, 1);
 
     // The last summary line is the discuss-augmented one; it carries replies and trigger.
@@ -111,8 +114,8 @@ describe("Discusser orchestration", () => {
     assert.strictEqual(last.event.type, "summary");
     assert.strictEqual(last.event.verdict, "recessed");
     assert.deepStrictEqual(last.event.trigger, {
-      kind: "responses",
-      responses: 2,
+      kind: "missing_input",
+      replies: 2,
     });
     assert.strictEqual(last.event.replies.length, 1);
   });

--- a/libraries/libeval/test/facilitator-redirect.test.js
+++ b/libraries/libeval/test/facilitator-redirect.test.js
@@ -65,15 +65,24 @@ describe("Facilitator - duplicate-Ask resilience (regression for run 26336965189
     // The facilitator deliberately Asks twice in a row — the broadcast-
     // then-individual pattern that previously orphaned a queue message.
     // Both Asks are issued in the same assistant turn and dispatched in
-    // parallel (the SDK fans tool_use blocks out simultaneously).
+    // parallel. Under the auto-resume model the lead ends its turn after
+    // the two Asks. The agent answers each ask in its own turn (a
+    // synthetic reminder unblocks the second), so the lead may wake twice
+    // — once per answer. Conclude only runs once both Asks are cleared;
+    // the second wake-up that has nothing pending is a no-op turn.
     const facilitatorRunner = createMockRunner(
-      [{ text: "Asking twice" }],
+      [
+        { text: "Asking twice" },
+        { text: "Waiting for the other answer" },
+        { text: "Concluding" },
+      ],
       [
         [
           askMsg("agent-1", "First question?", "1"),
           askMsg("agent-1", "Second question?", "2"),
-          concludeMsg("Both answered"),
         ],
+        [],
+        [concludeMsg("Both answered")],
       ],
       {
         toolDispatcher: {

--- a/libraries/libeval/test/facilitator.test.js
+++ b/libraries/libeval/test/facilitator.test.js
@@ -416,8 +416,15 @@ describe("Facilitator - bidirectional Ask", () => {
       from: "facilitator",
     });
 
-    // Facilitator: turn 0 Ask → turn 1 (sees agent's answer + agent's own
-    // Ask) Answer + Conclude.
+    // Sequence (each side handles one message per turn — no in-turn
+    // Answer-and-Ask collapses, so the inboxes drain deterministically
+    // under the auto-resume model):
+    //
+    //   fac.0: Ask agent ("What runtime?")            askId=1
+    //   agt.0: Ask fac  ("What version is required?")  askId=2
+    //   fac.1: Answer askId=2 (still owes askId=1)     end turn
+    //   agt.1: Answer askId=1                          end turn
+    //   fac.2: Conclude (no pending Asks)
     const facilitatorAnswerDispatcher = async () => {
       const owed = [...ctx.pendingAsks.values()].find(
         (e) => e.addresseeName === "facilitator",
@@ -428,7 +435,7 @@ describe("Facilitator - bidirectional Ask", () => {
       });
     };
     const facilitatorRunner = createMockRunner(
-      [{ text: "Asking" }, { text: "Handling back-and-forth" }],
+      [{ text: "Asking" }, { text: "Answering" }, { text: "Concluding" }],
       [
         [askMsg("agent-1", "What runtime?")],
         [
@@ -437,8 +444,8 @@ describe("Facilitator - bidirectional Ask", () => {
             { askId: 0, message: "use Bun 1.2+" },
             { id: "fac-ans-1" },
           ),
-          concludeMsg("Done"),
         ],
+        [concludeMsg("Done")],
       ],
       {
         toolDispatcher: {
@@ -449,20 +456,17 @@ describe("Facilitator - bidirectional Ask", () => {
       },
     );
 
-    // Agent: turn 0 (with facilitator's ask in inbox) → Answer + Ask back.
-    // Turn 1 (with facilitator's answer in inbox) → end turn quietly.
     const agentRunner = createMockRunner(
-      [{ text: "Replying and asking back" }, { text: "Got it" }],
+      [{ text: "Asking back" }, { text: "Replying" }],
       [
         [
-          answerMsgPlaceholder(),
           createToolUseMsg(
             "Ask",
             { question: "What version is required?" },
             { id: "agt-ask-1" },
           ),
         ],
-        [{ type: "assistant", content: "Thanks." }],
+        [answerMsgPlaceholder()],
       ],
       {
         toolDispatcher: {

--- a/libraries/libeval/test/orchestration-toolkit.test.js
+++ b/libraries/libeval/test/orchestration-toolkit.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert";
 
 import {
   cancelPendingAsks,
+  concludeSession,
   createAnnounceHandler,
   createAnswerHandler,
   createAskHandler,
@@ -47,7 +48,7 @@ describe("OrchestrationToolkit - simple handlers", () => {
     assert.ok(result.content[0].text.includes("concluded"));
   });
 
-  test("Conclude cancels every pending Ask by routing a synthetic null answer to each asker's queue", async () => {
+  test("concludeSession cancels every pending Ask with a synthetic null answer (defensive cleanup)", () => {
     const ctx = createOrchestrationContext();
     ctx.messageBus = stubBus();
     ctx.pendingAsks.set(1, {
@@ -65,7 +66,11 @@ describe("OrchestrationToolkit - simple handlers", () => {
       reminded: false,
     });
 
-    await createConcludeHandler(ctx)({ verdict: "failure", summary: "done" });
+    concludeSession(ctx, {
+      verdict: "failure",
+      summary: "done",
+      reason: "session concluded",
+    });
 
     assert.strictEqual(ctx.pendingAsks.size, 0);
     const answers = ctx.messageBus.calls.filter((c) => c.method === "answer");
@@ -74,6 +79,30 @@ describe("OrchestrationToolkit - simple handlers", () => {
       assert.strictEqual(a.from, "@orchestrator");
       assert.ok(a.text.includes("session concluded"));
     }
+  });
+
+  test("Conclude refuses when Asks are still pending and leaves ctx.concluded false", async () => {
+    const ctx = createOrchestrationContext();
+    ctx.messageBus = stubBus();
+    ctx.pendingAsks.set(1, {
+      askId: 1,
+      askerName: "facilitator",
+      addresseeName: "agent-1",
+      question: "Q1?",
+      reminded: false,
+    });
+
+    const result = await createConcludeHandler(ctx)({
+      verdict: "success",
+      summary: "done",
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.match(result.content[0].text, /Asks are still pending/);
+    assert.strictEqual(ctx.concluded, false);
+    assert.strictEqual(ctx.pendingAsks.size, 1);
+    const answers = ctx.messageBus.calls.filter((c) => c.method === "answer");
+    assert.strictEqual(answers.length, 0);
   });
 
   test("Announce publishes via the bus and never touches pendingAsks", async () => {

--- a/libraries/libeval/test/pending-ask.test.js
+++ b/libraries/libeval/test/pending-ask.test.js
@@ -107,8 +107,8 @@ describe("Pending-ask enforcement — facilitated mode", () => {
     const concludeHandler = createConcludeHandler(ctx);
 
     const facilitatorRunner = createMockRunner(
-      [{ text: "Asking" }],
-      [[askMsg("agent-1", "What?"), concludeMsg("Done")]],
+      [{ text: "Asking" }, { text: "Concluding" }],
+      [[askMsg("agent-1", "What?")], [concludeMsg("Done")]],
       {
         toolDispatcher: {
           Ask: (i) => askHandler(i),
@@ -153,8 +153,8 @@ describe("Pending-ask enforcement — facilitated mode", () => {
     const concludeHandler = createConcludeHandler(ctx);
 
     const facilitatorRunner = createMockRunner(
-      [{ text: "Asking" }],
-      [[askMsg("agent-1", "What?"), concludeMsg("Done")]],
+      [{ text: "Asking" }, { text: "Concluding" }],
+      [[askMsg("agent-1", "What?")], [concludeMsg("Done")]],
       {
         toolDispatcher: {
           Ask: (i) => askHandler(i),

--- a/libraries/libeval/test/prompts.test.js
+++ b/libraries/libeval/test/prompts.test.js
@@ -6,6 +6,8 @@ import {
   FACILITATED_AGENT_SYSTEM_PROMPT,
   SUPERVISOR_SYSTEM_PROMPT,
   AGENT_SYSTEM_PROMPT,
+  DISCUSS_SYSTEM_PROMPT,
+  DISCUSS_AGENT_SYSTEM_PROMPT,
 } from "@forwardimpact/libeval";
 
 const FACILITATED_PROMPTS = [
@@ -16,15 +18,25 @@ const SUPERVISE_PROMPTS = [
   ["SUPERVISOR_SYSTEM_PROMPT", SUPERVISOR_SYSTEM_PROMPT],
   ["AGENT_SYSTEM_PROMPT", AGENT_SYSTEM_PROMPT],
 ];
+const DISCUSS_PROMPTS = [
+  ["DISCUSS_SYSTEM_PROMPT", DISCUSS_SYSTEM_PROMPT],
+  ["DISCUSS_AGENT_SYSTEM_PROMPT", DISCUSS_AGENT_SYSTEM_PROMPT],
+];
 const LEAD_PROMPTS = [
   ["FACILITATOR_SYSTEM_PROMPT", FACILITATOR_SYSTEM_PROMPT],
   ["SUPERVISOR_SYSTEM_PROMPT", SUPERVISOR_SYSTEM_PROMPT],
+  ["DISCUSS_SYSTEM_PROMPT", DISCUSS_SYSTEM_PROMPT],
 ];
 const AGENT_PROMPTS = [
   ["FACILITATED_AGENT_SYSTEM_PROMPT", FACILITATED_AGENT_SYSTEM_PROMPT],
   ["AGENT_SYSTEM_PROMPT", AGENT_SYSTEM_PROMPT],
+  ["DISCUSS_AGENT_SYSTEM_PROMPT", DISCUSS_AGENT_SYSTEM_PROMPT],
 ];
-const ALL_PROMPTS = [...FACILITATED_PROMPTS, ...SUPERVISE_PROMPTS];
+const ALL_PROMPTS = [
+  ...FACILITATED_PROMPTS,
+  ...SUPERVISE_PROMPTS,
+  ...DISCUSS_PROMPTS,
+];
 
 describe("COALIGNED L0 — leads name Ask and their terminal tool", () => {
   test("facilitator names Ask and Conclude", () => {
@@ -35,6 +47,57 @@ describe("COALIGNED L0 — leads name Ask and their terminal tool", () => {
     assert.ok(SUPERVISOR_SYSTEM_PROMPT.includes("Ask"));
     assert.ok(SUPERVISOR_SYSTEM_PROMPT.includes("Conclude"));
   });
+  test("discuss-lead names Ask, Adjourn, and Recess", () => {
+    assert.ok(DISCUSS_SYSTEM_PROMPT.includes("Ask"));
+    assert.ok(DISCUSS_SYSTEM_PROMPT.includes("Adjourn"));
+    assert.ok(DISCUSS_SYSTEM_PROMPT.includes("Recess"));
+  });
+});
+
+describe("COALIGNED L0 — leads describe Ask as async and surface auto-resume", () => {
+  for (const [name, prompt] of LEAD_PROMPTS) {
+    test(`${name} states Ask is async`, () => {
+      assert.ok(
+        prompt.includes("`Ask` is async"),
+        `${name} must say Ask is async so the lead does not assume a sync return`,
+      );
+    });
+    test(`${name} states answers arrive in the inbox on the next turn`, () => {
+      assert.ok(
+        prompt.includes("`[answer#N]"),
+        `${name} must show the answer tag the lead will see on resume`,
+      );
+      assert.ok(
+        prompt.includes("next turn"),
+        `${name} must say answers arrive on the next turn`,
+      );
+    });
+    test(`${name} states auto-resume: end the turn while Asks are pending`, () => {
+      assert.ok(
+        prompt.includes("End your turn while Asks are pending"),
+        `${name} must direct the lead to end the turn rather than wait inline`,
+      );
+      assert.ok(
+        prompt.includes("system resumes you"),
+        `${name} must name the auto-resume mechanic`,
+      );
+    });
+  }
+});
+
+describe("COALIGNED L0 — agents describe inbox arrival of questions", () => {
+  for (const [name, prompt] of AGENT_PROMPTS) {
+    test(`${name} states questions arrive in the inbox as [ask#N]`, () => {
+      assert.ok(
+        prompt.includes("`[ask#N]"),
+        `${name} must show the ask tag agents will see`,
+      );
+      assert.ok(
+        prompt.includes("inbox"),
+        `${name} must name the inbox so the arrival channel is explicit`,
+      );
+    });
+  }
 });
 
 describe("COALIGNED L0 — leads state delegation constraint", () => {

--- a/libraries/libeval/test/supervisor-run.test.js
+++ b/libraries/libeval/test/supervisor-run.test.js
@@ -131,8 +131,8 @@ describe("Supervisor - sync session flow", () => {
     });
 
     const supervisorRunner = createMockRunner(
-      [{ text: "Delegating" }],
-      [[askMsg("Install the packages."), concludeMsg("Done")]],
+      [{ text: "Delegating" }, { text: "Concluding" }],
+      [[askMsg("Install the packages.")], [concludeMsg("Done")]],
       {
         toolDispatcher: {
           Ask: (input) => askHandler(input),
@@ -174,12 +174,10 @@ describe("Supervisor - sync session flow", () => {
     });
 
     const supervisorRunner = createMockRunner(
-      [{ text: "Reviewing" }],
+      [{ text: "Reviewing" }, { text: "Concluding" }],
       [
-        [
-          askMsg("Do the work."),
-          concludeMsg("Agent failed the task", "failure"),
-        ],
+        [askMsg("Do the work.")],
+        [concludeMsg("Agent failed the task", "failure")],
       ],
       {
         toolDispatcher: {

--- a/services/ghbridge/test/callback.test.js
+++ b/services/ghbridge/test/callback.test.js
@@ -173,10 +173,10 @@ describe("ghbridge callback handler", () => {
     const res = await postCallback(baseUrl, token, {
       correlation_id: meta.correlationId,
       verdict: "recessed",
-      summary: "awaiting responses",
+      summary: "awaiting replies",
       run_url: "https://github.com/owner/repo/actions/runs/1",
       replies: [{ body: "what do others think?" }],
-      trigger: { kind: "responses", responses: 2 },
+      trigger: { kind: "missing_input", replies: 2 },
     });
     expect(res.status).toBe(200);
     const stored = await ctx.service.store.loadByChannel(
@@ -185,7 +185,7 @@ describe("ghbridge callback handler", () => {
     );
     const rfcs = Object.values(stored.open_rfcs);
     expect(rfcs).toHaveLength(1);
-    expect(rfcs[0].trigger).toEqual({ kind: "responses", responses: 2 });
+    expect(rfcs[0].trigger).toEqual({ kind: "missing_input", replies: 2 });
     expect(typeof rfcs[0].history_index_at_open).toBe("number");
   });
 

--- a/services/ghbridge/test/resume.test.js
+++ b/services/ghbridge/test/resume.test.js
@@ -118,10 +118,10 @@ describe("ghbridge resume", () => {
     await postCallback(baseUrl, token, {
       correlation_id: meta.correlationId,
       verdict: "recessed",
-      summary: "awaiting 2 responses",
+      summary: "awaiting 2 replies",
       run_url: "https://github.com/owner/repo/actions/runs/1",
       replies: [],
-      trigger: { kind: "responses", responses: 2 },
+      trigger: { kind: "missing_input", replies: 2 },
     });
     const stored2 = await ctx.service.store.loadByChannel(
       "github-discussions",
@@ -256,14 +256,14 @@ describe("ghbridge resume", () => {
     );
     const token = Object.keys(stored1.pending_callbacks)[0];
     const meta = ctx.service.callbacks.peek(token);
-    // Recess with a 3-response trigger; one comment must not fire.
+    // Recess with a 3-reply trigger; one comment must not fire.
     await postCallback(baseUrl, token, {
       correlation_id: meta.correlationId,
       verdict: "recessed",
-      summary: "wait for 3 responses",
+      summary: "wait for 3 replies",
       run_url: "https://github.com/owner/repo/actions/runs/1",
       replies: [],
-      trigger: { kind: "responses", responses: 3 },
+      trigger: { kind: "missing_input", replies: 3 },
     });
     expect(ctx.dispatches).toHaveLength(1);
 

--- a/services/msbridge/test/msbridge.test.js
+++ b/services/msbridge/test/msbridge.test.js
@@ -118,11 +118,11 @@ describe("msbridge service", () => {
         verdict: "adjourned",
         summary: "done",
         replies: [{ body: "hi" }],
-        trigger: { kind: "responses", responses: 2 },
+        trigger: { kind: "missing_input", replies: 2 },
         discussion_id: "GD_x",
       });
       expect(payload.replies).toEqual([{ body: "hi" }]);
-      expect(payload.trigger).toEqual({ kind: "responses", responses: 2 });
+      expect(payload.trigger).toEqual({ kind: "missing_input", replies: 2 });
       expect(payload.discussion_id).toBe("GD_x");
     });
   });
@@ -294,7 +294,7 @@ describe("msbridge service", () => {
           verdict: "recessed",
           summary: "awaiting humans",
           replies: [{ body: "what do you think?" }],
-          trigger: { kind: "responses", responses: 2 },
+          trigger: { kind: "missing_input", replies: 2 },
         }),
       });
       expect(res.status).toBe(200);
@@ -303,8 +303,8 @@ describe("msbridge service", () => {
       const stored = await service.store.loadByChannel("msteams", "t-rec");
       expect(Object.keys(stored.open_rfcs)).toHaveLength(1);
       expect(Object.values(stored.open_rfcs)[0].trigger).toEqual({
-        kind: "responses",
-        responses: 2,
+        kind: "missing_input",
+        replies: 2,
       });
       const infoMessages = logger.info.mock.calls.map((call) =>
         String(call.arguments[1] ?? ""),

--- a/services/msbridge/test/resume.test.js
+++ b/services/msbridge/test/resume.test.js
@@ -155,10 +155,10 @@ describe("msbridge resume", () => {
     await postCallback(baseUrl, token, {
       correlation_id: meta.correlationId,
       verdict: "recessed",
-      summary: "awaiting 2 responses",
+      summary: "awaiting 2 replies",
       run_url: "https://github.com/owner/repo/actions/runs/1",
       replies: [],
-      trigger: { kind: "responses", responses: 2 },
+      trigger: { kind: "missing_input", replies: 2 },
     });
     const stored2 = await service.store.loadByChannel("msteams", "t-r");
     expect(Object.keys(stored2.open_rfcs)).toHaveLength(1);
@@ -219,10 +219,10 @@ describe("msbridge resume", () => {
     await postCallback(baseUrl, token, {
       correlation_id: meta.correlationId,
       verdict: "recessed",
-      summary: "wait for 3 responses",
+      summary: "wait for 3 replies",
       run_url: "https://github.com/owner/repo/actions/runs/1",
       replies: [],
-      trigger: { kind: "responses", responses: 3 },
+      trigger: { kind: "missing_input", replies: 3 },
     });
     expect(dispatches).toHaveLength(1);
 

--- a/websites/fit/docs/libraries/bridge-channels/index.md
+++ b/websites/fit/docs/libraries/bridge-channels/index.md
@@ -48,7 +48,7 @@ primitives every adapter needs:
 | `appendHistory` | Bounded message history (default cap: 10 entries; oldest dropped on overflow) |
 | `buildPrompt` | Prompt builder that prepends recent history bounded by exchange count and char cap |
 | `dispatchWorkflow` | GitHub Actions `workflow_dispatch` POST with the agreed input shape |
-| `evaluateTrigger` | Caller-clock resume-trigger evaluation (kinds: `responses`, `elapsed`, `either`) |
+| `evaluateTrigger` | Caller-clock resume-trigger evaluation (kinds: `missing_input`, `elapsed`, `escalation_needed`) |
 | `parseIsoDuration` | ISO-8601 duration parser (`P1D`, `PT12H`, `P1DT6H`) used by `evaluateTrigger` |
 
 The top four — `Acknowledgement`, `Dispatcher`, `createCallbackHandler`, and
@@ -226,14 +226,15 @@ token-and-payload mismatches.
 ## Evaluate recess triggers
 
 Long-running RFCs use the libeval `Recess` verdict to wait for an external
-signal. A trigger is one of three shapes:
+signal. A trigger is one of three shapes, named for the lead's intent:
 
-- `{ kind: "responses", responses: N }` — fire when at least `N` new responses
-  arrive since the recess opened.
+- `{ kind: "missing_input", replies: N }` — fire when at least `N` new
+  replies have arrived on the dispatching thread since the recess opened.
 - `{ kind: "elapsed", elapsed: "P1D" }` — fire after an ISO-8601 duration
   passes. Days, hours, minutes, seconds supported (`P14D`, `PT12H`, `P1DT6H`).
-- `{ kind: "either", responses?: N, elapsed?: "P1D" }` — fire on whichever
-  arm satisfies first.
+- `{ kind: "escalation_needed", signal: "<name>" }` — reserved for future
+  use. The schema accepts this shape, but the scheduler throws until
+  signal-based resume support ships.
 
 `evaluateTrigger(trigger, observed, now)` returns `{ fired: boolean, due_at?: number }`
 where `due_at` is the absolute ms-epoch when an elapsed arm will fire (useful
@@ -265,10 +266,12 @@ if (result.fired) {
 ```
 
 `evaluateTrigger` is pure: it takes a trigger, an observation
-(`{ responses?, opened_at? }`), and a clock reading, and returns whether the
+(`{ replies?, opened_at? }`), and a clock reading, and returns whether the
 observation satisfies the trigger. The host calls it whenever a candidate
-event arrives — for `responses`, on every new channel message; for `elapsed`,
-on a host-scheduled wake-up at `due_at`.
+event arrives — for `missing_input`, on every new channel message; for
+`elapsed`, on a host-scheduled wake-up at `due_at`; `escalation_needed`
+throws today and will integrate with channel signal intake once that
+spec lands.
 
 ## Verify
 
@@ -281,9 +284,11 @@ You have reached the outcome of this guide when:
   an injected `libstorage` instance and keyed by `(channel, discussion_id)`.
 - You can `register`, dispatch, and one-shot `consume` callback tokens through
   `CallbackRegistry`, with `correlation_id` echoed end-to-end.
-- You can evaluate `responses`, `elapsed`, and `either` recess triggers
+- You can evaluate `missing_input` and `elapsed` recess triggers
   against a caller-supplied clock and route the resume back through
   `dispatchWorkflow` with a JSON-encoded `resume_context`.
+  `escalation_needed` triggers parse but throw at evaluation until
+  signal-based resume ships.
 
 ## What's next
 

--- a/websites/fit/docs/services/bridge-conversations/dispatch-from-chat/index.md
+++ b/websites/fit/docs/services/bridge-conversations/dispatch-from-chat/index.md
@@ -110,7 +110,7 @@ When `kata-dispatch.yml` finishes, the workflow POSTs to
      `ResumeScheduler.enterRecess(ctx, correlationId, trigger)` to
      persist the trigger on `ctx.open_rfcs[correlationId]`. Subsequent
      inbound messages in the same Teams thread accrue toward a
-     `responses` trigger; an `elapsed` trigger arms a timer that
+     `missing_input` trigger; an `elapsed` trigger arms a timer that
      survives a service restart via `rearm()`. The replies are still
      posted (step 7) so the user sees what the team has so far.
 9. **Store flush** — the updated context (`last_active_at`, history,

--- a/websites/fit/docs/services/bridge-discussions/resume-recessed/index.md
+++ b/websites/fit/docs/services/bridge-discussions/resume-recessed/index.md
@@ -1,6 +1,6 @@
 ---
 title: Resume a Recessed RFC When a Trigger Fires
-description: Trace the suspend/resume contract — how a `recessed` verdict persists a trigger, accumulates responses, and re-dispatches with `resume_context` when the trigger condition is met.
+description: Trace the suspend/resume contract — how a `recessed` verdict persists a trigger, accumulates replies, and re-dispatches with `resume_context` when the trigger condition is met.
 ---
 
 An RFC posted as a GitHub Discussion may need to wait. The lead reads the
@@ -27,14 +27,14 @@ startup, see
 ## Trigger kinds
 
 A `recessed` callback carries a `trigger` object that `ResumeScheduler`
-evaluates via `evaluateTrigger` (from `@forwardimpact/libbridge`). Three
-kinds are supported:
+evaluates via `evaluateTrigger` (from `@forwardimpact/libbridge`). The
+kind names the lead's intent for the recess:
 
-| Kind        | Fires when                                                                              |
-| ----------- | --------------------------------------------------------------------------------------- |
-| `responses` | A configured number of new history entries have accrued since the RFC opened.           |
-| `elapsed`   | An ISO-8601 duration (`P1D`, `PT12H`, `P1DT6H`) has passed since the RFC opened.        |
-| `either`    | Whichever of a `responses` count and an `elapsed` duration fires first.                 |
+| Kind                 | Fires when                                                                                                                                            |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `missing_input`      | At least `replies` new history entries have accrued on the dispatching thread since the RFC opened.                                                   |
+| `elapsed`            | An ISO-8601 duration (`P1D`, `PT12H`, `P1DT6H`) has passed since the RFC opened.                                                                      |
+| `escalation_needed`  | Reserved for future use. The schema accepts `{ kind: "escalation_needed", signal: "<name>" }`, but the scheduler throws until signal-based resume ships. |
 
 Triggers are evaluated against the caller's clock (libbridge's
 `evaluateTrigger(trigger, observed, now)` takes `now` as a parameter), so
@@ -53,14 +53,13 @@ When the bridge receives a `recessed` callback, the libbridge
    verdict, it exists only for trace/debug purposes.
 2. **`ResumeScheduler.enterRecess(ctx, correlation_id, trigger)`**
    records `open_rfcs[correlation_id] = { trigger, opened_at, history_index_at_open }`.
-3. **For an `elapsed` or `either` trigger** with an `elapsed` field, the
-   scheduler computes `due_at = opened_at + parseIsoDuration(elapsed)`,
-   stores it on the rfc, and arms the embedded `ElapsedScheduler`. When
-   it fires the scheduler re-dispatches without further inbound
-   activity.
-4. **For a `responses` trigger** (or `either` without an `elapsed`
-   field), no timer is armed — every subsequent comment will re-evaluate
-   the trigger inside `processInbound(ctx)`.
+3. **For an `elapsed` trigger**, the scheduler computes
+   `due_at = opened_at + parseIsoDuration(elapsed)`, stores it on the
+   rfc, and arms the embedded `ElapsedScheduler`. When it fires the
+   scheduler re-dispatches without further inbound activity.
+4. **For a `missing_input` trigger**, no timer is armed — every
+   subsequent comment will re-evaluate the trigger inside
+   `processInbound(ctx)`.
 5. **The "EYES" reaction is removed** by `Acknowledgement.finish(...)`
    before the handler returns, signalling that the workflow run for this
    correlation id is complete.
@@ -74,7 +73,7 @@ A trigger fires in one of two places:
 
 - **Inbound comment path** — `#handleDiscussionComment` calls
   `resume.processInbound(ctx)` for every comment. The scheduler walks
-  `ctx.open_rfcs`, computes `observed = { responses: history.length - history_index_at_open, opened_at }`,
+  `ctx.open_rfcs`, computes `observed = { replies: history.length - history_index_at_open, opened_at }`,
   and feeds each `(trigger, observed, Date.now())` triple to
   `evaluateTrigger`. Fired RFCs are re-dispatched and cancelled.
 - **Elapsed timer path** — `ElapsedScheduler` (embedded in
@@ -100,10 +99,10 @@ Either way, re-dispatch goes through the shared `Dispatcher`:
    `adjourned` with final replies, but a second `recessed` is also valid
    — `ResumeScheduler` will track the new RFC the same way.
 
-## Accumulating responses without firing
+## Accumulating replies without firing
 
 If an RFC is open and a comment arrives but the trigger does not yet
-fire (e.g., `responses: 3` and only one comment has arrived):
+fire (e.g., `replies: 3` and only one comment has arrived):
 
 - The inbound comment is appended to `ctx.history` so the next
   evaluation sees the wider window.
@@ -122,7 +121,7 @@ because they do not consume workflow runs.
 | Symptom                                                       | Cause                                                                             |
 | ------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | Elapsed trigger never fires after bridge restart              | `ResumeScheduler.rearm()` walks `store.index.values()` and re-schedules any rfc with a persisted `due_at`; check whether the rfc on disk has `due_at` and whether `rearm()` ran (called from `service.start()`) |
-| Responses trigger never fires despite enough comments         | The `responses` count is compared against `history.length - history_index_at_open`; check that webhook delivery is reaching the bridge and that comments are appearing in `ctx.history` |
+| `missing_input` trigger never fires despite enough comments   | The `replies` count is compared against `history.length - history_index_at_open`; check that webhook delivery is reaching the bridge and that comments are appearing in `ctx.history` |
 | Re-dispatch happens but the workflow lacks prior context      | `resume_context` carries `history_since`, the slice from `history_index_at_open` onward — *not* the full history. The workflow must thread it through its prompt itself |
 | Two parallel workflow runs on the same thread                 | A fresh dispatch fired while an RFC was open; inspect logs around `processInbound` to confirm `freshDispatchAllowed` was correctly false (and that no other code path bypassed it) |
 
@@ -137,7 +136,7 @@ You have reached the outcome of this guide when:
 - Subsequent comments on the discussion accrue into the bridge's
   history without spawning new workflow runs (verify with the Actions
   tab — no new run while `hasOpenRfc` holds).
-- When the trigger condition is met (responses count reached or elapsed
+- When the trigger condition is met (replies count reached or elapsed
   duration passed), a fresh workflow run appears in the Actions tab
   with a `resume_context` input carrying the original `correlation_id`
   and the `history_since` slice.


### PR DESCRIPTION
## Summary

Fixes the four L0 surfaces that conspired to let a discuss-mode lead call `Recess` while three of five agents had not yet replied (kata-storyboard run 26445956128, 2026-05-26).

- **Tool descriptions** for `Conclude`/`Adjourn`/`Recess` now lead with the cost and live as named constants in `orchestration-toolkit.js` so the contrast is visible in source.
- **Lead system prompts** (discuss, facilitate, supervisor) standardized on a 7-step skeleton that surfaces the auto-resume mechanic explicitly: "End your turn while Asks are pending. The system resumes you when answers arrive." Participants standardized on a 4-step skeleton.
- **`requireNoPendingAsks` guard** wired into every terminal handler across discuss, facilitate, and supervisor modes. The lead can no longer end the session with Asks in flight; the guard returns an error result that directs the lead to end the turn.
- **Trigger kinds renamed** from mechanic-shaped (`responses` / `elapsed` / `either`) to intent-shaped (`missing_input` / `elapsed` / `escalation_needed`). The lead picks based on *why* it is recessing, not on a polling mechanic that reads as "in-session Answers". The `either` combinator (zero live callers) is dropped and the latent libbridge/libeval `either`/`any` boundary mismatch goes with it. `escalation_needed` ships as a forward-compatible stub — schema accepts `{ kind, signal }` but the scheduler throws "reserved for future use" until a follow-up spec wires named external signals through ghbridge/msbridge intake.

Test fixtures that scripted Ask + Conclude in a single lead turn (the misuse pattern the guard now catches) are restructured into the explicit two-turn auto-resume flow. `prompts.test.js` extended to cover all six lead and participant prompts; new positive and negative tests cover the guard and the renamed schema.

## Test plan

- [x] `bun run check`
- [x] `bun run --filter @forwardimpact/libeval test` (543 pass)
- [x] `bun run --filter @forwardimpact/libbridge test` (135 pass)
- [x] `bun run --filter @forwardimpact/svcghbridge test` (19 pass)
- [x] `bun run --filter @forwardimpact/svcmsbridge test` (19 pass)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LT9RF3pbQ9B8aumTH9nV7q)_