### PR TITLE
refactor(specs/1300): rename svcdiscussion service to svcbridge

### DIFF
--- a/specs/1300-svcbridge/design-a.md
+++ b/specs/1300-svcbridge/design-a.md
@@ -1,4 +1,4 @@
-# Design 1300-a — svcdiscussion
+# Design 1300-a — svcbridge
 
 Architectural design for [spec 1300](spec.md). A new gRPC service owns
 the canonical discussion and origin records; both bridges call it
@@ -24,7 +24,7 @@ graph LR
         ACK[Acknowledgement]
         CB[createCallbackHandler]
     end
-    subgraph svcdiscussion["services/svcdiscussion"]
+    subgraph bridge["services/bridge"]
         IDX[BufferedIndex pair<br/>+ sweep timer]
     end
     subgraph data["data/bridges/"]
@@ -46,8 +46,8 @@ graph LR
     DSP -.store contract.-> MCA
     RS -.store contract.-> GCA
     RS -.store contract.-> MCA
-    GCA -- DiscussionClient (gRPC) --> IDX
-    MCA -- DiscussionClient (gRPC) --> IDX
+    GCA -- BridgeClient (gRPC) --> IDX
+    MCA -- BridgeClient (gRPC) --> IDX
     IDX --> DF
     IDX --> OF
 ```
@@ -61,27 +61,31 @@ and it presents a store-shaped object to `Dispatcher` and
 
 | Component | Role |
 |---|---|
-| `services/svcdiscussion/` | New gRPC service. Follows the `services/CLAUDE.md` layout (server entry, implementation, `proto/`, `test/`). Owns the only on-disk discussion and origin state and runs the periodic sweep. The spec mandates the `svc`-prefixed directory name even though peer services use bare names (`services/{trace,graph,vector}`); this design honours the spec without renaming peers in the same change. |
-| `services/svcdiscussion/proto/discussion.proto` | Declares `package discussion`, `service Discussion`, message `DiscussionRecord` (deliberately not `Discussion` to avoid the codegen service/message name collision), `Origin`, `OpenRfc`, `Participant`, `ResumeTrigger`, plus a small set of request/response messages. |
-| `services/svcdiscussion/index.js` | Implements `Discussion` over two `BufferedIndex` stores constructed against one shared `StorageInterface` rooted at `data/bridges/`. The service's own config block is `service.discussion.*` (the registered name on `createServiceConfig("discussion")`). |
-| `services/{gh,ms}bridge/index.js` | Construct a `DiscussionClient` at startup via `createClient("discussion", …)`. Wrap the client in a `DiscussionAdapter` (a small in-process object) and pass that adapter wherever the old `DiscussionContextStore` instance went. ghbridge calls `client.HasOrigin` / `client.RecordOrigin` from the webhook intake and reply paths without going through the adapter. |
+| `services/bridge/` | New gRPC service. Follows the `services/CLAUDE.md` layout (server entry, implementation, `proto/`, `test/`) and the peer naming convention — a bare directory name (`bridge`, matching `services/{trace,graph,vector}`) with the `svc`-prefix carried only by the npm package (`@forwardimpact/svcbridge`). Sits beside its `ghbridge`/`msbridge` clients. Owns the only on-disk discussion and origin state and runs the periodic sweep. |
+| `services/bridge/proto/bridge.proto` | Declares `package bridge`, `service Bridge`, message `Discussion` (the persisted record the service stores; `service Bridge` leaves the bare `Discussion` name free of any service/message collision), `Origin`, `OpenRfc`, `Participant`, `ResumeTrigger`, plus a small set of request/response messages. |
+| `services/bridge/index.js` | Implements `Bridge` over two `BufferedIndex` stores constructed against one shared `StorageInterface` rooted at `data/bridges/`. The service's own config block is `service.bridge.*` (the registered name on `createServiceConfig("bridge")`). |
+| `services/{gh,ms}bridge/index.js` | Construct a `BridgeClient` at startup via `createClient("bridge", …)`. Wrap the client in a `DiscussionAdapter` (a small in-process object) and pass that adapter wherever the old `DiscussionContextStore` instance went. ghbridge calls `client.HasOrigin` / `client.RecordOrigin` from the webhook intake and reply paths without going through the adapter. |
 | `libraries/libbridge` | Loses `discussion-context.js` and `origin-index.js`. `ResumeScheduler` widens its store contract to consume `loadByCorrelation` and `listOpenRecesses` (see § Key decisions); everything else stays. |
 
 ## Naming map
 
 | Surface | Identifier |
 |---|---|
-| Service directory | `services/svcdiscussion/` (per spec) |
-| npm package | `@forwardimpact/svcdiscussion` |
-| Proto package | `discussion` |
-| gRPC service | `Discussion` |
-| Generated client | `DiscussionClient` |
-| Config block | `service.discussion.*` (registered via `createServiceConfig("discussion")`) |
-| Supervisor entry name | `discussion` (bare, matching peer entries like `trace`, `graph`) |
+| Service directory | `services/bridge/` (bare, matching peers like `services/trace`) |
+| npm package | `@forwardimpact/svcbridge` |
+| Proto file | `bridge.proto` |
+| Proto package | `bridge` |
+| gRPC service | `Bridge` |
+| Generated base / client | `BridgeBase` / `BridgeClient` |
+| Service implementation | `BridgeService` (extends `BridgeBase`) |
+| Config block | `service.bridge.*` (registered via `createServiceConfig("bridge")`) |
+| Supervisor entry name | `bridge` (bare, matching peer entries like `trace`, `graph`) |
+
+These are not free variables. `createServiceConfig(name)` sets `config.name`, and librpc resolves the gRPC service from it: `getServiceDefinition` looks up `definitions[name.toLowerCase()]` (`librpc/src/base.js`) and both `Server` and `Client` do `capitalizeFirstLetter(config.name)` to name the gRPC service. libcodegen derives the generated dir, the definitions key, and the export prefix from the **proto file basename**, and the class inside each artifact from the in-proto `service` declaration (`libcodegen/src/base.js`, `services.js`, `definitions.js`). So the invariant is: **`config.name` (lowercased) == proto-file basename == lowercased gRPC service name.** The npm package and directory names are decoupled from this chain — `svc` lives only in the package/bin, exactly as peers do it. Aligning the config identifier therefore forces the proto file, proto package, and gRPC service to move with it.
 
 ## Discussion record on the wire
 
-`DiscussionRecord` mirrors the existing in-memory shape one-for-one so
+`Discussion` mirrors the existing in-memory shape one-for-one so
 the record factory and dispatcher mutations do not change. The
 persisted JSONL on disk follows the proto field names.
 
@@ -106,17 +110,17 @@ persisted JSONL on disk follows the proto field names.
 
 | RPC | Request | Response | Caller |
 |---|---|---|---|
-| `LoadDiscussion` | `{ channel, discussion_id }` | `DiscussionRecord` or gRPC `NOT_FOUND` | Adapter `loadByChannel`. |
-| `LoadDiscussionByCorrelation` | `{ correlation_id }` | `DiscussionRecord` or gRPC `NOT_FOUND` | Adapter `loadByCorrelation`. Lets `ResumeScheduler` find the owning record when an elapsed timer fires. |
+| `LoadDiscussion` | `{ channel, discussion_id }` | `Discussion` or gRPC `NOT_FOUND` | Adapter `loadByChannel`. |
+| `LoadDiscussionByCorrelation` | `{ correlation_id }` | `Discussion` or gRPC `NOT_FOUND` | Adapter `loadByCorrelation`. Lets `ResumeScheduler` find the owning record when an elapsed timer fires. |
 | `ListOpenRecesses` | `common.Empty` | `repeated OpenRecessRef { correlation_id, due_at }` | Adapter `listOpenRecesses`. Server-side filter: returns one entry per open RFC that has a `due_at` set. Response-only triggers are excluded because `ResumeScheduler.rearm` only arms elapsed timers. |
-| `SaveDiscussion` | `DiscussionRecord` | `common.Empty` | Adapter `save` — the single hot-path write that today is `add+flush`. |
+| `SaveDiscussion` | `Discussion` | `common.Empty` | Adapter `save` — the single hot-path write that today is `add+flush`. |
 | `HasOrigin` | `{ id }` | `{ exists: bool }` | ghbridge's `#handleDiscussionComment` self-echo guard. |
 | `RecordOrigin` | `Origin` | `common.Empty` | ghbridge's `recordOrigin` callback inside `#handleReply`. |
 | `Sweep` | `{ now: optional int64 }` | `{ evicted_discussions: int32, evicted_origins: int32 }` | Tests only. Absent `now` ⇒ server uses `Date.now()`. Production uses the server-internal 60 s timer. |
 
 ## Adapter contract (bridge side)
 
-`DiscussionAdapter` is the only new abstraction on the bridge side. It wraps the generated `DiscussionClient` and satisfies the contract `Dispatcher` and `ResumeScheduler` consume:
+`DiscussionAdapter` is the only new abstraction on the bridge side. It wraps the generated `BridgeClient` and satisfies the contract `Dispatcher` and `ResumeScheduler` consume:
 
 | Method | Implementation |
 |---|---|
@@ -131,7 +135,7 @@ persisted JSONL on disk follows the proto field names.
 
 ## Storage layout
 
-The service constructs one `StorageInterface` rooted at `bridges/`, resolved by `libstorage` to `data/bridges/` from the monorepo root, and hands it to two `BufferedIndex` instances using the existing index keys (`discussions.jsonl`, `origins.jsonl`). Both files land at the canonical paths the spec requires, owned by a single process. The discussion store keeps the current 5 s / 1000-entry buffer; the origin store keeps the current 1 s / 100-entry buffer. Both can be overridden via `service.discussion.*`.
+The service constructs one `StorageInterface` rooted at `bridges/`, resolved by `libstorage` to `data/bridges/` from the monorepo root, and hands it to two `BufferedIndex` instances using the existing index keys (`discussions.jsonl`, `origins.jsonl`). Both files land at the canonical paths the spec requires, owned by a single process. The discussion store keeps the current 5 s / 1000-entry buffer; the origin store keeps the current 1 s / 100-entry buffer. Both can be overridden via `service.bridge.*`.
 
 A single sweep timer evicts records older than the TTL from both indexes; the cadence carries over from today's `DEFAULT_SWEEP_INTERVAL_MS` (60 s). The discussion side keeps the existing 24 h `conversationTtlMs`. The origin side gains a periodic timer it did not have before — today's `OriginIndex.sweep(now)` is caller-driven; the service moves it onto the same cadence as discussions to put both indexes under one lifecycle. The origin TTL stays at 24 h.
 
@@ -139,18 +143,18 @@ A single sweep timer evicts records older than the TTL from both indexes; the ca
 
 | Decision | Chosen | Rejected | Why |
 |---|---|---|---|
-| Surface shape | One `Discussion` service with seven RPCs covering both record kinds | Two services (`Discussion` + `Origin`) | Spec mandates a single interface. Matches `trace.Trace` and `graph.Graph` — one proto, one stub, one supervised process. |
+| Surface shape | One `Bridge` service with seven RPCs covering both record kinds | Two services split by record kind (discussion + origin) | Spec mandates a single interface. Matches `trace.Trace` and `graph.Graph` — one proto, one stub, one supervised process. |
 | Resume contract over gRPC | Widen the store contract with `loadByCorrelation` and `listOpenRecesses`; amend `ResumeScheduler` to use them in place of `store.loaded` / `store.loadData()` / `store.index.values()` | Keep the four-method adapter (`loadByChannel`, `add`, `flush`, `shutdown`) and let `ResumeScheduler.rearm` and `#findContextWithRfc` fail | The current `ResumeScheduler` reaches past `loadByChannel` to walk every record. A 4-method adapter cannot satisfy that. Either widen the contract or move resume into the service; widening keeps the dispatcher + scheduler composition on the bridge side, which is what the libbridge contract is designed around. |
-| Message name | `DiscussionRecord` | `Discussion` | proto3 allows `service Discussion` + `message Discussion` in the same package, but no peer service has a message that shares its service name; matching that convention avoids codegen-tool friction. |
-| Not-found channel | gRPC `NOT_FOUND` status from `LoadDiscussion` / `LoadDiscussionByCorrelation` | Sentinel empty `id` on a default-constructed `DiscussionRecord` | No peer service currently signals absence — every other librpc method either returns a collection or is a write that does not fail with "missing." `NOT_FOUND` is the standard gRPC status for this case, and the adapter translates it to `null` so bridge call sites read exactly as they do today. |
+| Message name | `Discussion` | `Discussion` | With the service named `Bridge`, the bare `Discussion` name is free — no service/message collision — and no peer service names a message after its service, which `Discussion` still honours. `Discussion` reads as the record `Bridge` stores; the `Record` suffix would be redundant. |
+| Not-found channel | gRPC `NOT_FOUND` status from `LoadDiscussion` / `LoadDiscussionByCorrelation` | Sentinel empty `id` on a default-constructed `Discussion` | No peer service currently signals absence — every other librpc method either returns a collection or is a write that does not fail with "missing." `NOT_FOUND` is the standard gRPC status for this case, and the adapter translates it to `null` so bridge call sites read exactly as they do today. |
 | Resume trigger over the wire | Typed `ResumeTrigger` message; on-record field name stays `trigger` | `string trigger_json` carrying the JSON-serialised trigger | A typed message keeps the spec's "persisted record shape is unchanged" intact — the on-disk JSONL field is still `trigger`, not `trigger_json` — and gives the service introspection over recess state if a future tool wants it. |
 | Opaque participant metadata | JSON string per participant | `google.protobuf.Struct` or first-class proto fields | The Bot Framework `ConversationReference` and GitHub node metadata are channel-shaped and outside this service's concern. A JSON string keeps the contract minimal and matches how the JSONL already round-trips these blobs. |
 | Sweep ownership | Server-internal 60 s timer plus a `Sweep` RPC for tests | Bridge-driven sweep | The TTL is store-owned, not caller-owned. A test-callable RPC keeps the integration test deterministic without exposing scheduling to production callers. The origin index gains a periodic timer it did not have before — intentional, so both indexes share one lifecycle. |
 | Origin path on ghbridge | Direct `client.HasOrigin` / `client.RecordOrigin` calls; no adapter wrapper | Wrap the client in an `OriginIndex`-shaped class in libbridge | The actual call sites are explicit; the previous `.flush()` after each reply and the `.shutdown()` on stop disappear because the service owns batching and its own lifecycle. |
-| Storage root | `createStorage("bridges")` inside the service, both indexes share it | Per-service root (`createStorage("svcdiscussion")`) with `indexKey` overrides | Lands the two files at the canonical paths the spec requires with no `indexKey` gymnastics. The bridges' previous `bridges/{ghbridge,msbridge}/` directories are not read or written by any code after cutover. |
+| Storage root | `createStorage("bridges")` inside the service, both indexes share it | Per-service root (`createStorage("bridge")`) with `indexKey` overrides | Lands the two files at the canonical paths the spec requires with no `indexKey` gymnastics. The bridges' previous `bridges/{ghbridge,msbridge}/` directories are not read or written by any code after cutover. |
 | Buffering / durability | Server keeps the existing `BufferedIndex` cadences; adapter `flush()` is a no-op | Per-call synchronous append, or pass-through buffering on the client | Per-call append would slow the hot path. Client-side buffering would lose state when the bridge crashes. Server-side buffering keeps the simplest viable shape. |
-| Write-barrier semantics | `Dispatcher.dispatch` and `ResumeScheduler.#fireElapsed` treat `add` + `flush` as a hard write barrier today; under this design `add` succeeds when the record is in the service's in-memory index but not necessarily on disk, and `flush` is a no-op | Issue a synchronous server-side flush from `flush()` on every call | Today a per-bridge crash loses that bridge's unflushed buffer. Under this design a `svcdiscussion` crash loses any unflushed buffered writes from both bridges at once — the same window, larger blast radius. The plan must accept this trade or revisit the write-barrier. |
-| Service supervision | Any starter that supervises a bridge also lists `discussion` in its `init.services` ahead of the bridge entries | Lazy connection with retries from the bridges | None of the shipped starters supervise the bridges today, so the design states the conditional rule rather than naming a concrete starter. Where a starter does bundle them, `discussion` must come first so the bridges' `createClient("discussion", …)` resolves at startup. |
+| Write-barrier semantics | `Dispatcher.dispatch` and `ResumeScheduler.#fireElapsed` treat `add` + `flush` as a hard write barrier today; under this design `add` succeeds when the record is in the service's in-memory index but not necessarily on disk, and `flush` is a no-op | Issue a synchronous server-side flush from `flush()` on every call | Today a per-bridge crash loses that bridge's unflushed buffer. Under this design a `bridge` service crash loses any unflushed buffered writes from both bridges at once — the same window, larger blast radius. The plan must accept this trade or revisit the write-barrier. |
+| Service supervision | Any starter that supervises a bridge also lists `bridge` in its `init.services` ahead of the bridge entries | Lazy connection with retries from the bridges | None of the shipped starters supervise the bridges today, so the design states the conditional rule rather than naming a concrete starter. Where a starter does bundle them, `bridge` must come first so the bridges' `createClient("bridge", …)` resolves at startup. |
 
 ## What this design does not cover
 

--- a/specs/1300-svcbridge/plan-a.md
+++ b/specs/1300-svcbridge/plan-a.md
@@ -1,9 +1,9 @@
-# Plan 1300-a — svcdiscussion
+# Plan 1300-a — svcbridge
 
 Execution plan for [design 1300-a](design-a.md). Stand up
-`services/svcdiscussion/` as the canonical store, widen
+`services/bridge/` as the canonical store, widen
 `ResumeScheduler` so the resume lifecycle survives over a remote
-backend, swap both bridges onto a `DiscussionClient` through a
+backend, swap both bridges onto a `BridgeClient` through a
 per-bridge `DiscussionAdapter`, and delete the two store classes from
 `libbridge`. Clean break: no migration, no compat shim.
 
@@ -30,10 +30,10 @@ adapter wrapper. Catalogs regenerate at the end.
 | # | Step | Touches |
 |---|---|---|
 | 1 | Propagate handler-thrown `.code` in librpc | `libraries/librpc/src/server.js`, `libraries/librpc/test/server.test.js` |
-| 2 | Service package + proto + skeleton | `services/svcdiscussion/package.json`, `services/svcdiscussion/proto/discussion.proto`, `services/svcdiscussion/server.js`, `services/svcdiscussion/index.js`, `services/svcdiscussion/README.md` |
+| 2 | Service package + proto + skeleton | `services/bridge/package.json`, `services/bridge/proto/bridge.proto`, `services/bridge/server.js`, `services/bridge/index.js`, `services/bridge/README.md` |
 | 3 | `bun install` + `bunx fit-codegen --all` | `bun.lock`, `generated/` (regenerated artifacts) |
-| 4 | Service implementation body | `services/svcdiscussion/index.js` (RPC bodies + sweep) |
-| 5 | Service tests | `services/svcdiscussion/test/discussion.test.js` |
+| 4 | Service implementation body | `services/bridge/index.js` (RPC bodies + sweep) |
+| 5 | Service tests | `services/bridge/test/bridge.test.js` |
 | 6 | `createMockDiscussionClient` in libharness | `libraries/libharness/src/mock/clients.js`, `libraries/libharness/src/mock/index.js` |
 | 7 | Widen `ResumeScheduler` store contract + rewrite affected libbridge tests | `libraries/libbridge/src/resume-scheduler.js`, `libraries/libbridge/src/index.js` (typedef), `libraries/libbridge/test/{resume-scheduler,dispatcher,callback-handler}.test.js` |
 | 8 | Delete the two store classes | `libraries/libbridge/src/{discussion-context,origin-index}.js`, `libraries/libbridge/test/{discussion-context,origin-index}.test.js`, `libraries/libbridge/src/index.js` exports |
@@ -71,14 +71,14 @@ before codegen runs. The skeleton compiles but throws "not
 implemented" on each RPC; Step 4 fills in the bodies.
 
 - **Created:**
-  - `services/svcdiscussion/package.json`
-  - `services/svcdiscussion/proto/discussion.proto`
-  - `services/svcdiscussion/server.js`
-  - `services/svcdiscussion/index.js`
-  - `services/svcdiscussion/README.md`
+  - `services/bridge/package.json`
+  - `services/bridge/proto/bridge.proto`
+  - `services/bridge/server.js`
+  - `services/bridge/index.js`
+  - `services/bridge/README.md`
 
 `package.json` mirrors `services/trace/package.json`. Name
-`@forwardimpact/svcdiscussion`, `bin.fit-svcdiscussion = ./server.js`,
+`@forwardimpact/svcbridge`, `bin.fit-svcbridge = ./server.js`,
 deps on `libconfig`, `libindex`, `libpreflight`, `librpc`,
 `libstorage`, `libtelemetry`, `libtype`; devDep on `libharness`.
 `description` ends in a noun phrase agents recognise (e.g. "Canonical
@@ -90,26 +90,26 @@ conversation state across bridges`, with `bigHire`/`littleHire`/
 `competesWith`/`trigger` strings — copy the shape from
 `services/trace/package.json:20-29`.
 
-`proto/discussion.proto`:
+`proto/bridge.proto`:
 
 ```proto
 syntax = "proto3";
 
-package discussion;
+package bridge;
 
 import "common.proto";
 
-service Discussion {
-  rpc LoadDiscussion(LoadDiscussionRequest) returns (DiscussionRecord);
-  rpc LoadDiscussionByCorrelation(LoadByCorrelationRequest) returns (DiscussionRecord);
+service Bridge {
+  rpc LoadDiscussion(LoadDiscussionRequest) returns (Discussion);
+  rpc LoadDiscussionByCorrelation(LoadByCorrelationRequest) returns (Discussion);
   rpc ListOpenRecesses(common.Empty) returns (OpenRecessList);
-  rpc SaveDiscussion(DiscussionRecord) returns (common.Empty);
+  rpc SaveDiscussion(Discussion) returns (common.Empty);
   rpc HasOrigin(OriginKey) returns (HasOriginResponse);
   rpc RecordOrigin(Origin) returns (common.Empty);
   rpc Sweep(SweepRequest) returns (SweepResponse);
 }
 
-message DiscussionRecord {
+message Discussion {
   string id = 1;
   string channel = 2;
   string discussion_id = 3;
@@ -161,9 +161,9 @@ import { createLogger } from "@forwardimpact/libtelemetry";
 import { Server, createTracer } from "@forwardimpact/librpc";
 import { createStorage } from "@forwardimpact/libstorage";
 
-import { DiscussionService } from "./index.js";
+import { BridgeService } from "./index.js";
 
-const config = await createServiceConfig("discussion", {
+const config = await createServiceConfig("bridge", {
   discussion_flush_interval_ms: 5_000,
   discussion_max_buffer_size: 1_000,
   origin_flush_interval_ms: 1_000,
@@ -172,24 +172,24 @@ const config = await createServiceConfig("discussion", {
   origin_ttl_ms: 24 * 60 * 60 * 1000,
   sweep_interval_ms: 60_000,
 });
-const logger = createLogger("discussion");
-const tracer = await createTracer("discussion");
+const logger = createLogger("bridge");
+const tracer = await createTracer("bridge");
 const storage = createStorage("bridges");
 
-const service = new DiscussionService(config, { storage, logger, tracer });
+const service = new BridgeService(config, { storage, logger, tracer });
 await new Server(service, config).start();
 ```
 
-`createServiceConfig("discussion")` roots the namespace at `service.discussion.*`; the per-key names above land at `service.discussion.conversation_ttl_ms`, etc. The `discussion_` / `origin_` prefixes on the buffer keys disambiguate the two sub-stores within one config block (one service, two `BufferedIndex` instances).
+`createServiceConfig("bridge")` roots the namespace at `service.bridge.*`; the per-key names above land at `service.bridge.conversation_ttl_ms`, etc. The `discussion_` / `origin_` prefixes on the buffer keys disambiguate the two sub-stores within one config block (one service, two `BufferedIndex` instances).
 
 `index.js` skeleton — RPC bodies stubbed to `throw new Error("not implemented")`, ready for Step 4:
 
 ```js
 import { services } from "@forwardimpact/librpc";
 
-const { DiscussionBase } = services;
+const { BridgeBase } = services;
 
-export class DiscussionService extends DiscussionBase {
+export class BridgeService extends BridgeBase {
   constructor(config, { storage, logger, tracer }) {
     super(config);
     // Stored for Step 4
@@ -222,21 +222,21 @@ bunx fit-codegen --all
 ```
 
 `bun install` materialises the workspace symlink at
-`node_modules/@forwardimpact/svcdiscussion`. `fit-codegen` then
-discovers `services/svcdiscussion/proto/discussion.proto` (via
+`node_modules/@forwardimpact/svcbridge`. `fit-codegen` then
+discovers `services/bridge/proto/bridge.proto` (via
 `libcodegen/bin/fit-codegen.js:140-147`) and emits:
 
-- `generated/proto/discussion.proto`
-- `generated/services/discussion/{service.js,client.js}`
-- `generated/types/discussion/*`
-- updated `generated/services/exports.js` (new `DiscussionBase`, `DiscussionClient` lines)
+- `generated/proto/bridge.proto`
+- `generated/services/bridge/{service.js,client.js}`
+- `generated/types/bridge/*`
+- updated `generated/services/exports.js` (new `BridgeBase`, `BridgeClient` lines)
 - updated `generated/definitions/exports.js`
 
-**Verify:** `generated/services/exports.js` lists `DiscussionBase` and `DiscussionClient`; the generated client (`generated/services/discussion/client.js`) enforces `req instanceof discussion.<Request>` per the codegen pattern (see `generated/services/trace/client.js:31-35`).
+**Verify:** `generated/services/exports.js` lists `BridgeBase` and `BridgeClient`; the generated client (`generated/services/bridge/client.js`) enforces `req instanceof bridge.<Request>` per the codegen pattern (see `generated/services/trace/client.js:31-35`).
 
 ## Step 4 — Service implementation body
 
-- **Modified:** `services/svcdiscussion/index.js`
+- **Modified:** `services/bridge/index.js`
 
 Replace the stubs. Constructor builds two `BufferedIndex` instances against the shared storage and starts the sweep timer:
 
@@ -244,11 +244,11 @@ Replace the stubs. Constructor builds two `BufferedIndex` instances against the 
 import { BufferedIndex } from "@forwardimpact/libindex";
 import { services } from "@forwardimpact/librpc";
 import grpc from "@grpc/grpc-js";
-import { discussion } from "@forwardimpact/libtype";
+import { bridge } from "@forwardimpact/libtype";
 
-const { DiscussionBase } = services;
+const { BridgeBase } = services;
 
-export class DiscussionService extends DiscussionBase {
+export class BridgeService extends BridgeBase {
   #discussions;
   #origins;
   #conversationTtlMs;
@@ -281,8 +281,8 @@ RPC bodies, one-to-one with the design's § RPC contract:
 
 | RPC | Body |
 |---|---|
-| `LoadDiscussion` | `await this.#discussions.loadData(); const rec = this.#discussions.index.get(`${req.channel}:${req.discussion_id}`); if (!rec) throw Object.assign(new Error("not found"), { code: grpc.status.NOT_FOUND }); return discussion.DiscussionRecord.fromObject(rec);` |
-| `LoadDiscussionByCorrelation` | `await this.#discussions.loadData(); for (const rec of this.#discussions.index.values()) if (rec.pending_callbacks?.[req.correlation_id] !== undefined \|\| rec.open_rfcs?.[req.correlation_id]) return discussion.DiscussionRecord.fromObject(rec); throw Object.assign(new Error("not found"), { code: grpc.status.NOT_FOUND });` |
+| `LoadDiscussion` | `await this.#discussions.loadData(); const rec = this.#discussions.index.get(`${req.channel}:${req.discussion_id}`); if (!rec) throw Object.assign(new Error("not found"), { code: grpc.status.NOT_FOUND }); return bridge.Discussion.fromObject(rec);` |
+| `LoadDiscussionByCorrelation` | `await this.#discussions.loadData(); for (const rec of this.#discussions.index.values()) if (rec.pending_callbacks?.[req.correlation_id] !== undefined \|\| rec.open_rfcs?.[req.correlation_id]) return bridge.Discussion.fromObject(rec); throw Object.assign(new Error("not found"), { code: grpc.status.NOT_FOUND });` |
 | `ListOpenRecesses` | `await this.#discussions.loadData(); const refs = []; for (const rec of this.#discussions.index.values()) for (const [cid, rfc] of Object.entries(rec.open_rfcs ?? {})) if (typeof rfc.due_at === "number") refs.push({ correlation_id: cid, due_at: rfc.due_at }); return { refs };` |
 | `SaveDiscussion` | `await this.#discussions.add(req); return {};` |
 | `HasOrigin` | `return { exists: await this.#origins.has(req.id) };` |
@@ -298,13 +298,13 @@ RPC bodies, one-to-one with the design's § RPC contract:
 
 `shutdown()` clears the sweep timer and awaits `Promise.all([this.#discussions.flush(), this.#origins.flush()])`.
 
-**Verify:** `bun test services/svcdiscussion/test/*.test.js` exits 0 (Step 5).
+**Verify:** `bun test services/bridge/test/*.test.js` exits 0 (Step 5).
 
 ## Step 5 — Service tests
 
 Mirror `services/trace/test/trace.test.js` shape.
 
-- **Created:** `services/svcdiscussion/test/discussion.test.js`
+- **Created:** `services/bridge/test/bridge.test.js`
 
 Cases (test names quoted):
 
@@ -319,7 +319,7 @@ Cases (test names quoted):
 9. `"Sweep evicts origins whose posted_at is older than origin_ttl_ms"` — covers the new per-server origin TTL behaviour the design § Storage layout introduces.
 10. `"Concurrent SaveDiscussion from two channels both land"`.
 
-Use `createMockConfig("discussion", { …Step 2 defaults })`, `createMockStorage()`, `createMockLogger()` from `libharness`. RPC bodies are called directly on the service instance (in-process), same as the trace service tests.
+Use `createMockConfig("bridge", { …Step 2 defaults })`, `createMockStorage()`, `createMockLogger()` from `libharness`. RPC bodies are called directly on the service instance (in-process), same as the trace service tests.
 
 **Verify:** all ten tests pass.
 
@@ -403,7 +403,7 @@ Drop the two export lines at `libraries/libbridge/src/index.js:19-20` (`Discussi
 
 ```js
 import grpc from "@grpc/grpc-js";
-import { common, discussion } from "@forwardimpact/libtype";
+import { common, bridge } from "@forwardimpact/libtype";
 
 const isNotFound = (err) => err?.code === grpc.status.NOT_FOUND;
 
@@ -414,14 +414,14 @@ export class DiscussionAdapter {
   async loadByChannel(channel, id) {
     try {
       return await this.#client.LoadDiscussion(
-        discussion.LoadDiscussionRequest.fromObject({ channel, discussion_id: id }),
+        bridge.LoadDiscussionRequest.fromObject({ channel, discussion_id: id }),
       );
     } catch (err) { if (isNotFound(err)) return null; throw err; }
   }
   async loadByCorrelation(correlationId) {
     try {
       return await this.#client.LoadDiscussionByCorrelation(
-        discussion.LoadByCorrelationRequest.fromObject({ correlation_id: correlationId }),
+        bridge.LoadByCorrelationRequest.fromObject({ correlation_id: correlationId }),
       );
     } catch (err) { if (isNotFound(err)) return null; throw err; }
   }
@@ -432,7 +432,7 @@ export class DiscussionAdapter {
     return refs.map((r) => ({ correlationId: r.correlation_id, dueAt: r.due_at }));
   }
   async add(ctx) {
-    await this.#client.SaveDiscussion(discussion.DiscussionRecord.fromObject(ctx));
+    await this.#client.SaveDiscussion(bridge.Discussion.fromObject(ctx));
   }
   async flush() {}
   async shutdown() {}
@@ -442,16 +442,16 @@ export class DiscussionAdapter {
 `ghbridge/index.js`:
 
 - Drop `DiscussionContextStore` and `OriginIndex` from the libbridge import.
-- Add `import { DiscussionAdapter } from "./src/discussion-adapter.js";` and `import { discussion as discussionPb } from "@forwardimpact/libtype";` — aliased because `#handleDiscussionCreated` and `#handleDiscussionComment` both declare a `const discussion = body.discussion;` local that would otherwise shadow the import.
+- Add `import { DiscussionAdapter } from "./src/discussion-adapter.js";` and `import { bridge } from "@forwardimpact/libtype";`. No alias is needed: `#handleDiscussionCreated` and `#handleDiscussionComment` declare a `const discussion = body.discussion;` local, but the libtype namespace is now `bridge`, so it no longer collides with that local.
 - Constructor signature: replace `storage` dep with `discussionClient`. Wrap once: `this.#store = new DiscussionAdapter(discussionClient); this.#client = discussionClient;`. Hand `this.#store` to `Dispatcher`, `ResumeScheduler`, `createCallbackHandler` exactly as before. Drop `#origins` field entirely.
-- In `#handleDiscussionComment`: replace `await this.#origins.has(commentId)` with `(await this.#client.HasOrigin(discussionPb.OriginKey.fromObject({ id: commentId }))).exists`.
-- In `#handleReply`: the `recordOrigin` callback becomes `async (comment) => this.#client.RecordOrigin(discussionPb.Origin.fromObject({ id: comment.id, discussion_id: ctx.discussion_id, posted_at: Date.now() }))`. Drop the trailing `await this.#origins.flush()`.
+- In `#handleDiscussionComment`: replace `await this.#origins.has(commentId)` with `(await this.#client.HasOrigin(bridge.OriginKey.fromObject({ id: commentId }))).exists`.
+- In `#handleReply`: the `recordOrigin` callback becomes `async (comment) => this.#client.RecordOrigin(bridge.Origin.fromObject({ id: comment.id, discussion_id: ctx.discussion_id, posted_at: Date.now() }))`. Drop the trailing `await this.#origins.flush()`.
 - In `stop()`: the sequence is now `this.#resume.clear(); await this.#bridge.stop();` — `await this.#origins.shutdown()` and `await this.#store.shutdown()` both go away (the adapter's `shutdown()` is a no-op; the service owns buffer draining via librpc's SIGTERM handler).
 
 `ghbridge/server.js`:
 
 - Drop `createStorage` import and the `const storage = createStorage("bridges/ghbridge");` line.
-- Add `import { createClient } from "@forwardimpact/librpc";` and `const discussionClient = await createClient("discussion", logger, tracer);`.
+- Add `import { createClient } from "@forwardimpact/librpc";` and `const discussionClient = await createClient("bridge", logger, tracer);`.
 - Replace `storage` with `discussionClient` on the deps object.
 
 `ghbridge/package.json`: drop `@forwardimpact/libstorage` dep; ensure `@forwardimpact/libtype` is added (used by `discussion-adapter.js`). Bump minor.
@@ -475,9 +475,9 @@ Mirror Step 9 minus the origin paths (msbridge has no `OriginIndex` import today
 
 `libbridge/CLAUDE.md`:
 
-- Drop the "Caller-injected storage" bullet from § Invariants — the caller-injected-storage invariant moves to `services/svcdiscussion`.
+- Drop the "Caller-injected storage" bullet from § Invariants — the caller-injected-storage invariant moves to `services/bridge`.
 - Drop the `DiscussionContextStore` and `OriginIndex` rows from the § What lives where table.
-- In § Bridge contract step 3 of the composition recipe, replace "construct a `Dispatcher` over a `CallbackRegistry` and `DiscussionContextStore`" with "construct a `Dispatcher` over a `CallbackRegistry` and a host-supplied object satisfying the `DiscussionAdapter` typedef — see `services/svcdiscussion`".
+- In § Bridge contract step 3 of the composition recipe, replace "construct a `Dispatcher` over a `CallbackRegistry` and `DiscussionContextStore`" with "construct a `Dispatcher` over a `CallbackRegistry` and a host-supplied object satisfying the `DiscussionAdapter` typedef — see `services/bridge`".
 
 `libbridge/README.md`:
 
@@ -485,12 +485,12 @@ Mirror Step 9 minus the origin paths (msbridge has no `OriginIndex` import today
 
 `services/ghbridge/README.md` and `services/msbridge/README.md`:
 
-- Replace the "Discussion context is persisted as JSONL under `data/bridges/{ghbridge,msbridge}/`" prose with: "Discussion state is owned by `services/svcdiscussion`; the bridge talks to it over gRPC. The bridge process keeps no on-disk discussion state of its own. Operators upgrading from a pre-svcdiscussion bridge can safely delete legacy `data/bridges/{ghbridge,msbridge}/` files; conversations in flight at cutover are un-resumable on the new service and the legacy files expire under their existing 24-hour TTL on disk regardless."
-- Add a § Service supervision note: "If you supervise `ghbridge`/`msbridge` via `fit-rc`, list `discussion` ahead of the bridge entries in `init.services` so `createClient('discussion', …)` resolves at startup."
+- Replace the "Discussion context is persisted as JSONL under `data/bridges/{ghbridge,msbridge}/`" prose with: "Discussion state is owned by `services/bridge`; the bridge talks to it over gRPC. The bridge process keeps no on-disk discussion state of its own. Operators upgrading from a bridge that predates this service can safely delete legacy `data/bridges/{ghbridge,msbridge}/` files; conversations in flight at cutover are un-resumable on the new service and the legacy files expire under their existing 24-hour TTL on disk regardless."
+- Add a § Service supervision note: "If you supervise `ghbridge`/`msbridge` via `fit-rc`, list `bridge` ahead of the bridge entries in `init.services` so `createClient('bridge', …)` resolves at startup."
 
 `services/CLAUDE.md`:
 
-- Drop the "Discussion index — `data/bridges/{ghbridge,msbridge}/discussions.jsonl`" example from § Runtime data; replace with: "Bridge discussion + origin state — owned by `svcdiscussion`, persisted at `data/bridges/discussions.jsonl` and `data/bridges/origins.jsonl`."
+- Drop the "Discussion index — `data/bridges/{ghbridge,msbridge}/discussions.jsonl`" example from § Runtime data; replace with: "Bridge discussion + origin state — owned by `services/bridge`, persisted at `data/bridges/discussions.jsonl` and `data/bridges/origins.jsonl`."
 
 **Verify:** `bun run context` exits 0 (no doc length / jsdoc breaks).
 
@@ -506,7 +506,7 @@ bun test
 bun run check
 ```
 
-`context:fix` regenerates the services catalog row and the JTBD entry from the new `svcdiscussion/package.json`. The full `bun test` sweep exercises the cross-package boundary (`libbridge` ResumeScheduler against in-memory FakeAdapter; bridges against `createMockDiscussionClient`; svcdiscussion against `createMockStorage`).
+`context:fix` regenerates the services catalog row and the JTBD entry from the new `services/bridge/package.json`. The full `bun test` sweep exercises the cross-package boundary (`libbridge` ResumeScheduler against in-memory FakeAdapter; bridges against `createMockDiscussionClient`; the bridge service against `createMockStorage`).
 
 The spec's "no shipped starter bundles the bridges today, so § Service supervision support is vacuously satisfied" claim is verified mechanically: `rg 'ghbridge|msbridge' products/*/starter/` returns no matches.
 
@@ -517,12 +517,12 @@ The spec's "per-bridge files are no longer written" criterion is verified mechan
 ## Risks
 
 - **Proto `int64` JSON shape.** The wire types `OpenRfc.due_at`, `Origin.posted_at`, and `OpenRfc.history_index_at_open` are `int64`. `protobuf.js` returns these as `Long` instances or strings depending on loader config; the existing protos already use `int64` (`trace.Span.start_time_unix_nano` etc.) and consumers treat them as numbers, so the prevailing loader config is `longs: Number` or equivalent — confirm by exercising case 7 in Step 5 (`ListOpenRecesses` returns `due_at` consumable as a `number` by `setTimeout`).
-- **`bun.lock` churn from new workspace member.** `bun install` after adding `services/svcdiscussion/package.json` updates the lockfile to record the new workspace. Expected.
+- **`bun.lock` churn from new workspace member.** `bun install` after adding `services/bridge/package.json` updates the lockfile to record the new workspace. Expected.
 
-Libraries used: `@forwardimpact/libindex` (`BufferedIndex`), `@forwardimpact/librpc` (`Server`, `createClient`, `createTracer`, `services.DiscussionBase`, `grpc.status`), `@forwardimpact/libstorage` (`createStorage`), `@forwardimpact/libconfig` (`createServiceConfig`), `@forwardimpact/libtelemetry` (`createLogger`), `@forwardimpact/libpreflight` (`node22`), `@forwardimpact/libtype` (`discussion.*` typed messages), `@forwardimpact/libharness` (`createMockConfig`, `createMockStorage`, `createMockLogger`, `createMockDiscussionClient` — new in Step 6).
+Libraries used: `@forwardimpact/libindex` (`BufferedIndex`), `@forwardimpact/librpc` (`Server`, `createClient`, `createTracer`, `services.BridgeBase`, `grpc.status`), `@forwardimpact/libstorage` (`createStorage`), `@forwardimpact/libconfig` (`createServiceConfig`), `@forwardimpact/libtelemetry` (`createLogger`), `@forwardimpact/libpreflight` (`node22`), `@forwardimpact/libtype` (`bridge.*` typed messages), `@forwardimpact/libharness` (`createMockConfig`, `createMockStorage`, `createMockLogger`, `createMockDiscussionClient` — new in Step 6).
 
 ## Execution
 
-Single agent, sequential. The steps share too much context for parallel execution to pay off (Step 1's librpc patch unblocks Step 4's NOT_FOUND throws; Step 2's package.json must exist before Step 3's codegen; Step 7's contract change is consumed by Step 9/10's adapter wiring). Route to `staff-engineer` via `kata-implement`. One PR titled `feat(svcdiscussion): canonical store for both bridges`.
+Single agent, sequential. The steps share too much context for parallel execution to pay off (Step 1's librpc patch unblocks Step 4's NOT_FOUND throws; Step 2's package.json must exist before Step 3's codegen; Step 7's contract change is consumed by Step 9/10's adapter wiring). Route to `staff-engineer` via `kata-implement`. One PR titled `feat(svcbridge): canonical store for both bridges`.
 
 — Staff Engineer 🛠️

--- a/specs/1300-svcbridge/spec.md
+++ b/specs/1300-svcbridge/spec.md
@@ -1,4 +1,4 @@
-# Spec 1300 — svcdiscussion
+# Spec 1300 — svcbridge
 
 ## Persona and job
 
@@ -55,7 +55,7 @@ today no such service exists.
 
 ### In scope
 
-- A new service, `services/svcdiscussion`, owning the canonical store
+- A new service, `services/bridge`, owning the canonical store
   for every threaded-discussion bridge.
 - A single service interface that exposes both kinds of records the
   bridges write today — discussion state keyed by
@@ -109,7 +109,7 @@ today no such service exists.
 
 | Claim | Verifies via |
 |---|---|
-| A `services/svcdiscussion` service exists and follows the structural conventions documented in `services/CLAUDE.md`. | The service directory contains a server entry point, an implementation module, a proto definition, and a test directory at the conventional locations for a service. |
+| A `services/bridge` service exists and follows the structural conventions documented in `services/CLAUDE.md`. | The service directory contains a server entry point, an implementation module, a proto definition, and a test directory at the conventional locations for a service. |
 | The service exposes both record kinds — thread state and origin dedupe — on one service interface. | The proto definition declares a single service whose RPC methods cover loading a discussion by channel, upserting a discussion record, checking and recording origin reply ids, and triggering a sweep. |
 | Neither bridge contains a reference to the removed in-process store types. | A repository-wide search across `services/ghbridge/` and `services/msbridge/` returns no occurrences of either removed type name. |
 | The store and origin classes are gone from `libbridge`. | The `@forwardimpact/libbridge` package no longer exports the two types, and the package source no longer contains either implementation module. |
@@ -117,7 +117,7 @@ today no such service exists.
 | Discussion state from both channels lands in one file; origins in another. | After both bridges exchange at least one message with the agent team, `data/bridges/discussions.jsonl` contains records with both `github-discussions:…` and `msteams:…` ids, and `data/bridges/origins.jsonl` is the only origin file on disk. |
 | The per-bridge files are no longer written. | After end-to-end exercise, the directories `data/bridges/ghbridge/` and `data/bridges/msbridge/` contain no `discussions.jsonl` or `origins.jsonl`. |
 | The 24-hour conversation TTL is honoured by the service. | A test seeds a record whose last activity is older than 24 hours, lets the periodic sweep run, and observes the record removed from a subsequent load. |
-| The service is supervised the same way as peer gRPC services. | The starter configuration that ships with the products bundling these services lists `svcdiscussion` alongside the existing supervised services. |
+| The service is supervised the same way as peer gRPC services. | The starter configuration that ships with the products bundling these services lists `bridge` alongside the existing supervised services. |
 | ghbridge's self-echo dedupe still suppresses inbound webhooks for replies the bridge just posted. | An integration test posts a reply through ghbridge, replays the resulting `discussion_comment.created` webhook, and observes no dispatch. |
 | msbridge's resume-from-recess flow still finds the right thread state after restart. | An integration test enters a recess, restarts msbridge, fires the inbound activity that satisfies the trigger, and observes a fresh dispatch. |
 | `libbridge` documentation reflects the new ownership boundary. | The `libbridge` package documentation no longer claims ownership of the persisted discussion or origin state and directs readers to the new service for that state. |


### PR DESCRIPTION
## Summary

Renames the service planned under spec 1300 from `svcdiscussion` to `svcbridge`, so its identity matches the `libbridge` library and the `ghbridge`/`msbridge` bridges it serves. Spec-only change — touches the spec folder and the spec, design, and plan documents.

The rename goes deeper than the package name because the service identity is **coupled to the gRPC wiring**:

- `librpc` resolves the gRPC service from `config.name` — `getServiceDefinition` looks up `definitions[name.toLowerCase()]` and both `Server`/`Client` do `capitalizeFirstLetter(config.name)` to name the service (`librpc/src/base.js`, `client.js`, `server.js`).
- `libcodegen` derives the generated dir, definitions key, and export prefix from the **proto-file basename**, and the class inside each artifact from the in-proto `service` declaration (`libcodegen/src/base.js`, `services.js`, `definitions.js`).

So `config.name` (lowercased) == proto-file basename == lowercased gRPC service name is a single locked identifier. Aligning the config block therefore forces the proto file, proto package, and gRPC service to move with it.

## What changed

- **Service identity → `svcbridge`**: spec folder `1300-svcdiscussion` → `1300-svcbridge`; package `@forwardimpact/svcbridge`; bin `fit-svcbridge`.
- **Coupled gRPC identifiers `discussion` → `bridge`**: proto file/package, `service Bridge`, config block `service.bridge.*`, `createClient`/`createLogger`/`createTracer`/`createServiceConfig("bridge")`, generated `BridgeBase`/`BridgeClient`, service impl `BridgeService`, libtype namespace `bridge.*`.
- **Directory → `services/bridge/`** (bare name, matching peers like `services/trace` → `@forwardimpact/svctrace`; `svc` stays only in the package/bin), sitting beside its `ghbridge`/`msbridge` clients.
- **Proto message `DiscussionRecord` → `Discussion`**: with the service named `Bridge` the bare name is collision-free and the `Record` suffix is redundant (`bridge.Discussion` on the wire).
- **Data-side names kept** (they describe the stored records, not the service): `discussion_id`, `discussions.jsonl`, `LoadDiscussion`/`SaveDiscussion` RPCs, `DiscussionAdapter`, `createMockDiscussionClient`.
- Documented the coupling invariant in the design's naming map so this doesn't drift again.

## Test plan

- [x] `bun run check` — `format`, `lint`, `jsdoc`, `invariants`, and `context` (instructions/metadata/jtbd/dependabot) all pass. The only failure is `bun run wiki` flagging an untracked, pre-existing `wiki/` file this branch never touches.
- [x] Verified no residual coupled identifiers remain and all data-side names are intact (grep sweep across the three docs).

https://claude.ai/code/session_016UgwzZxhvJVDkhSr4HctXj

---
_Generated by [Claude Code](https://claude.ai/code/session_016UgwzZxhvJVDkhSr4HctXj)_