### PR TITLE
design(1320,1340): per-user GitHub auth for chat-surface dispatch

### DIFF
--- a/specs/1320-user-auth-oauth-ghauth/design-a.md
+++ b/specs/1320-user-auth-oauth-ghauth/design-a.md
@@ -1,0 +1,148 @@
+# Design 1320-a: oauth + ghauth
+
+Spec 1320 asks for two services that let a chat surface dispatch under a
+**per-user** GitHub identity: `services/oauth/` (protocol-only HTTP) and
+`services/ghauth/` (GitHub-specific gRPC + state). First consumers are
+`msbridge` and `ghbridge`; the contract must satisfy their linking and
+token-resolution needs. Out of scope: `services/kata`, `services/mcp`, bridge
+adoption, the Kata Agent **Team** App, cross-surface identity unification.
+
+## Components
+
+```mermaid
+graph LR
+  CL["OAuth client<br/>(browser / future Claude Chat)"] -->|HTTP OAuth 2.1| OA["services/oauth<br/>(stateless adapter)"]
+  OA -->|gRPC AuthProvider| GH["services/ghauth<br/>(state + GitHub)"]
+  BR["msbridge / ghbridge<br/>(follow-up)"] -->|gRPC GetToken| GH
+  GH -->|HTTPS| GHUB["GitHub<br/>Kata Agent User App"]
+  GH --> ST[("BufferedIndex JSONL<br/>data/ghauth/")]
+```
+
+`oauth` holds no secrets and no state; every HTTP endpoint maps to one
+`AuthProvider` gRPC call. It selects its backend by name from config
+(`provider: "ghauth"`) and constructs that client at boot, the way
+`services/mcp/server.js` constructs its gRPC clients — so `oauth`'s source
+contains no GitHub-specific code (SC#3). `ghauth` implements the
+provider-agnostic `AuthProvider` contract; a second provider (e.g. `msauth`)
+would implement the same contract and be swapped in by config alone.
+
+## AuthProvider gRPC contract
+
+`ghauth` is internal-only (consumed by `oauth` and the bridges, never exposed
+as an MCP tool), so it returns **domain messages**, not `tool.ToolCallResult`.
+The token query is a discriminated `oneof` the bridge branches on directly.
+
+| RPC | Request | Response | Drives |
+| --- | ------- | -------- | ------ |
+| `Begin` | `surface, surface_user_id, redirect_uri, code_challenge, scopes` | `upstream_authorize_url, state` | `GET /authorize` |
+| `Complete` | `code, state` (from GitHub callback) | `downstream_code, redirect_uri, client_state` | `GET /callback` |
+| `Redeem` | `code, code_verifier` | `access_token, token_type, expires_in` | `POST /token` |
+| `GetToken` | `surface, surface_user_id` | `oneof { string token; LinkRequired{authorize_url}; ReAuthRequired }` | bridge dispatch |
+| `Revoke` | `surface, surface_user_id` | `common.Empty` | unlink |
+
+`Begin`/`Complete` are the **linking** path the bridges need (a user clicks a
+link, authorizes GitHub, `ghauth` stores the binding). `Redeem` plus the
+downstream `access_token` are the OAuth-server path an OAuth *client* (future
+Claude Chat) needs; the bridges never call `Redeem`. `GetToken` is the
+**dispatch read path**: `(channel, participant.external_id)` maps onto
+`(surface, surface_user_id)`, and the `token` arm is a `string` directly usable
+as `libbridge` `Dispatcher`'s `getGithubToken` result (whose contract is
+`() => Promise<string> | string`).
+
+## oauth HTTP surface
+
+| Endpoint | Maps to |
+| -------- | ------- |
+| `GET /.well-known/oauth-authorization-server` | static metadata from config `issuer` |
+| `GET /authorize` | `Begin` → 302 to `upstream_authorize_url` |
+| `GET /callback` | `Complete` → 302 to client `redirect_uri` (or a "linked" page when no client awaits) |
+| `POST /token` | `Redeem` → JSON token response |
+| `GET /health` | liveness (mirrors `services/mcp`) |
+
+PKCE `code_challenge`/`code_verifier` pass through `oauth` untouched into
+`Begin`/`Redeem`; `ghauth` verifies the verifier at `Redeem` against the
+`code_challenge` carried in the grant. Whether `/callback` redirects or renders a "linked" page
+is decided by the flow record: a client-initiated flow carries a `redirect_uri`
+(302 with `downstream_code`); a bridge-initiated link carries none (linked
+page).
+
+## State (ghauth)
+
+`BufferedIndex` instances over an injected `libstorage` store rooted at
+`data/ghauth/`:
+
+| Index | Key | Holds | Lifetime |
+| ----- | --- | ----- | -------- |
+| `bindings.jsonl` | `surface:surface_user_id` | `github_user_id`, access + refresh token, `expires_at`, scopes | until revoked |
+| `flows.jsonl` | outer `state` | pending authorize: `surface, surface_user_id`, plus `code_challenge`/`redirect_uri`/`client_state` (client-initiated only) | short TTL sweep |
+| `grants.jsonl` | `downstream_code` | client-initiated grant: binding ref, `code_challenge`, `redirect_uri`, `client_state` | short TTL; consumed once at `Redeem` |
+
+`Begin` writes a `flows` row; `Complete` consumes it — exchanging the GitHub
+code for a user-to-server token and writing the `bindings` row. For a
+client-initiated flow (one carrying a `redirect_uri`), `Complete` also mints a
+`downstream_code` into `grants`, carrying the `code_challenge` forward; a
+bridge-initiated link writes no grant. `Redeem` consumes the `grants` row and
+verifies `code_verifier` against the grant's `code_challenge`. This `grants`
+store is the home for the outer (Claude↔`oauth`) "issued grants" state; the
+bridges exercise only `bindings` + `flows`. Persisting an issued `access_token`
+for later introspection is deferred to the Claude Chat surface (see below).
+
+`GetToken` reads `bindings`, refreshing via the GitHub OAuth client when the
+access token is near expiry. A refresh that fails because GitHub reports the
+grant revoked yields `ReAuthRequired`; a transient refresh error surfaces as an
+error, not `ReAuthRequired`. A missing binding yields `LinkRequired` whose
+`authorize_url` **is** `oauth`'s own `/authorize` endpoint — `ghauth` composes
+it from the configured `link_base_url` (one URL shape, not a second). The TTL
+sweep mirrors `DiscussionContextStore`.
+
+## Linking sequence
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant O as oauth
+  participant G as ghauth
+  participant H as GitHub
+  U->>O: GET /authorize(surface,user_id,pkce)
+  O->>G: Begin(...)
+  G-->>O: upstream_url, state
+  O-->>U: 302 → GitHub
+  U->>H: authorize Kata Agent User App
+  H->>O: GET /callback(code,state)
+  O->>G: Complete(code,state)
+  G->>H: exchange code → user-to-server token
+  G->>G: store binding(surface,user_id)
+  G-->>O: downstream_code (or "linked")
+  O-->>U: 302 → client redirect (or linked page)
+```
+
+Dispatch read path: `bridge → GetToken(surface,user_id) → {token|LinkRequired|ReAuthRequired}`.
+
+## Key decisions
+
+| Decision | Rejected alternative | Why |
+| -------- | -------------------- | --- |
+| Two services: protocol front + provider backend | One combined service | A combined service mixes HTTP + gRPC + GitHub, can't add a second provider without editing the protocol layer, and breaks the thin-adapter precedent set by `services/mcp`. |
+| Provider-agnostic `AuthProvider` contract | GitHub-specific RPCs on `oauth` | GitHub-specific RPCs would put `octokit`/GitHub code in `oauth`, failing SC#3 and blocking a second provider. |
+| `ghauth` owns all state (flows, bindings, issued grants) | `oauth` owns outer-protocol state | Stateful `oauth` needs a datastore in every front instance, splits the token lifecycle across two services, and contradicts the user-set "ghauth owns state" principle. |
+| Domain `oneof` result | `tool.ToolCallResult` | `ghauth` isn't an MCP tool; a typed `oneof` lets the bridge branch without string-parsing a `content` blob. |
+| `BufferedIndex` JSONL via injected storage | External database | Honors the zero-runtime-dependency invariant and matches how the bridges already persist; no new infrastructure. |
+| Binding key `(surface, surface_user_id)` | Unify on `github_user_id` | Spec excludes cross-surface unification; independent bindings are simpler and map 1:1 to the bridges' `(channel, external_id)`. |
+| User-to-server token (Kata Agent User App) | Installation token | GitHub enforces the requester's own repo permissions at dispatch; user-to-server tokens are refreshable, so `ghauth` owns refresh. |
+| `ghauth` composes the `LinkRequired` URL from `link_base_url` | Each consumer composes it | Keeps the consumer dumb and the URL shape in one place; the spec requires the typed result to carry the URL. |
+
+## Configuration
+
+- `service.oauth`: `host`, `port`, `issuer`, `provider: "ghauth"` (backend
+  client name). `init.services` lists `ghauth` **before** `oauth` (dependency
+  first).
+- `service.ghauth`: `host`, `port`, `link_base_url`; secrets via env
+  (`SERVICE_GHAUTH_*` client id/secret accessors, per `libconfig` credential
+  resolution); storage under `data/ghauth/`.
+
+## Future-surface note (not designed here)
+
+The opaque `access_token` `oauth` issues maps to a `ghauth` binding, leaving
+room for a later token-introspection endpoint and Dynamic Client Registration
+when `services/kata` + `services/mcp` expose Claude Chat. Neither is built in
+this spec; the contract above does not preclude them.

--- a/specs/1320-user-auth-oauth-ghauth/spec.md
+++ b/specs/1320-user-auth-oauth-ghauth/spec.md
@@ -1,0 +1,137 @@
+# Spec 1320: Per-user GitHub authentication for chat-surface dispatch
+
+**Persona / job:** Teams Using Agents —
+[Run a continuously improving agent team](../../JTBD.md#teams-using-agents-run-a-continuously-improving-agent-team).
+(Secondary: Platform Builders gain a reusable auth capability rather than
+per-surface glue.)
+
+## Problem
+
+When a human dispatches the Kata Agent Team from a chat surface, the
+`workflow_dispatch` call runs under a **single shared GitHub token**, not the
+identity of the person who asked:
+
+- `msbridge` constructs its `Dispatcher` with `getGithubToken` closing over a
+  static configured token (`ghToken`).
+- `ghbridge` constructs its `Dispatcher` with `getGithubToken` returning the
+  **Kata Agent Team** App installation token.
+
+Two consequences follow from this evidence:
+
+- **No per-user authorization.** Anyone who can post in the channel triggers a
+  dispatch carrying the team's full privileges. GitHub never gets the chance to
+  enforce whether *that requester* may run the workflow on the repo. The trust
+  decision is re-implemented in-channel (contributor allowlists) instead of
+  delegated to GitHub's own permission model.
+- **No attribution.** The run is not traceable to the human who initiated it,
+  only to the shared identity.
+
+A third surface is planned — **Claude Chat**, the seventh entry the Kata
+surfaces model in KATA.md will gain (separate follow-up spec) — which will need
+the same per-user GitHub authority. Without a shared mechanism, each surface
+re-implements the authorization-code flow, token storage, refresh, and
+revocation handling. That duplication is both wasteful and a security hazard:
+authorization-flow and token-lifecycle handling are easy to get subtly wrong,
+and spreading secret-bearing code across three services widens the attack
+surface.
+
+There is today **no shared way** for a human on any chat surface to link their
+GitHub identity once and have subsequent agent dispatches performed under their
+own GitHub authority.
+
+## Proposal
+
+Introduce two services that, together, let any chat surface resolve a
+**per-user GitHub token** for dispatch. The split follows the same shape as the
+existing `services/mcp/` service: a thin protocol-only front service that holds
+no domain secrets and delegates to gRPC backend(s).
+
+| Service          | Interface | Responsibility                                                                                                                 |
+| ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `services/oauth/`  | HTTP      | Speaks the OAuth 2.1 authorization-server protocol only. Holds no provider secrets and no tokens. Delegates every provider-specific step to a configured gRPC provider backend. |
+| `services/ghauth/` | gRPC      | Implements all GitHub specifics: the **Kata Agent User** App (user-to-server) authorization-code exchange, refresh, and revoke; durable storage of the user↔identity↔token binding; and a query returning a usable token (or a typed "link required" / "re-auth required" result) for a given surface user. |
+
+The relationship mirrors `services/mcp/` ↔ its gRPC backends in **role**, not in
+exact wiring: `mcp` is a protocol-only HTTP adapter that translates MCP requests
+into typed gRPC calls against backend services, exposing what `config.json`
+declares; `oauth` is a protocol-only HTTP adapter that translates the OAuth
+dance into typed gRPC calls against a provider backend it is configured to use.
+Neither front service contains domain logic; both keep the protocol layer thin
+and the backend stateful. A future second identity provider drops in as a new
+gRPC service plus configuration, without changing `oauth`'s code.
+
+`ghauth` is consumed two ways: by `oauth` (driving the user-facing authorization
+dance over HTTP) and **directly over gRPC** by internal services that need a
+token for a known surface user. The first such consumers will be `msbridge` and
+`ghbridge` (separate follow-up spec); this spec's contract is designed to fully
+satisfy their needs.
+
+### Grounding consumers (in-scope requirements; consumers built later)
+
+The deliverables here are only `oauth` + `ghauth`. The `ghauth` contract is
+nonetheless a committed requirement of this spec, shaped against what the
+bridges will require:
+
+- A bridge holds a `(channel, participant.external_id)` pair for the human who
+  posted. The `ghauth` query interface must accept exactly this shape — a
+  surface identifier plus the surface's native user id — and return a token
+  consumable as `libbridge`'s `Dispatcher` `getGithubToken` result (whose
+  contract is `() => Promise<string> | string`).
+- When the surface user has not linked GitHub, the query must return a typed
+  "link required" result carrying the authorize URL the bridge can show the
+  user, **not** an opaque error.
+- When a stored token is revoked or expired and cannot be refreshed, the query
+  must return a typed "re-auth required" result, distinguishable from a
+  transient failure, so the bridge can prompt re-linking rather than retrying.
+
+These three properties are validated by `ghauth`'s own tests in this spec; the
+end-to-end exercise through a real bridge belongs to the follow-up spec.
+
+## Two GitHub Apps (clarified; only one in scope)
+
+| App                  | Auth model       | Owned by                          | This spec       |
+| -------------------- | ---------------- | --------------------------------- | --------------- |
+| **Kata Agent Team**  | server-to-server | existing config / agent workflows | unchanged       |
+| **Kata Agent User**  | user-to-server   | `services/ghauth/` (new secrets)  | introduced here |
+
+`ghauth` owns only the **Kata Agent User** App's credentials. The Team App's
+secrets and usage are untouched.
+
+## Scope
+
+**In scope:**
+
+- `services/oauth/` — new HTTP service exposing the OAuth 2.1 authorization-
+  server protocol surface (the standard authorization-server endpoints plus a
+  provider-callback endpoint), with the provider backend chosen from
+  configuration rather than hard-coded.
+- `services/ghauth/` — new gRPC service: Kata Agent User App authorization-code
+  exchange / refresh / revoke; durable, restart-surviving storage of the
+  `(surface, surface_user_id)` ↔ GitHub identity ↔ token binding; query
+  interface returning a usable token or a typed link/re-auth result.
+- Configuration and `fit-rc` `init.services` entries for both services, per the
+  `services/CLAUDE.md` convention.
+- Service `README.md` + `package.json` metadata for both, per
+  `services/CLAUDE.md`.
+
+**Out of scope (explicit):**
+
+- `services/kata/` (the Claude Chat dispatch-tool service).
+- `services/mcp/` changes and Claude Chat connector registration.
+- `msbridge` / `ghbridge` adopting the new interface (follow-up spec).
+- The **Kata Agent Team** App (recorded in the table above; not modified).
+- Cross-surface identity unification (treating the same human as one identity
+  across two surfaces). Each `(surface, surface_user_id)` binding is independent.
+
+## Success criteria
+
+| # | Criterion | Verification |
+| - | --------- | ------------ |
+| 1 | `ghauth` starts under `fit-rc` and a smoke gRPC call returns a response (not a connection error). | `bunx fit-rc start ghauth`; `services/ghauth/test/smoke.test.js` |
+| 2 | `oauth` serves a valid OAuth 2.1 authorization-server metadata document, and its authorize endpoint issues a redirect to the configured provider's authorization URL. | `services/oauth/test/metadata.test.js`, `services/oauth/test/authorize.test.js` |
+| 3 | The provider backend is chosen from configuration; `services/oauth/`'s **source** contains no GitHub-specific code. | `rg -i 'github|octokit' services/oauth/ -g '!test/' -g '!*.md'` returns nothing (incidental mentions in tests/docs allowed) |
+| 4 | For a linked surface user with a valid stored token, the query returns that token unchanged. | `services/ghauth/test/query-linked.test.js` |
+| 5 | For an unlinked surface user, the query returns a typed "link required" result carrying an authorize URL (and no token). | `services/ghauth/test/query-unlinked.test.js` |
+| 6 | For a stored token that is expired and cannot be refreshed (or has been revoked), the query returns a typed "re-auth required" result, distinct from both a valid token and a transient error. | `services/ghauth/test/query-reauth.test.js` |
+| 7 | A token binding written before a restart is readable after a fresh service start. | `services/ghauth/test/persistence.test.js` |
+| 8 | The query interface accepts a `(surface, surface_user_id)` argument pair and, for a linked user, yields a value of type `string` (directly usable as a `getGithubToken` result). | `services/ghauth/test/query-contract.test.js` |

--- a/specs/1340-bridges-per-user-dispatch-auth/design-a.md
+++ b/specs/1340-bridges-per-user-dispatch-auth/design-a.md
@@ -1,0 +1,162 @@
+# Design 1340-a: bridges dispatch under the requester's GitHub identity
+
+Spec 1340 makes `msbridge` and `ghbridge` acquire the `kata-dispatch` token
+**per requester** from `ghauth` (Spec 1320), prompting on the channel when no
+usable token exists instead of dispatching under a shared token. The bridges
+share the dispatch primitive in `libbridge`, and a resumed conversation
+redispatches through that same primitive. Out of scope: `oauth`/`ghauth`
+themselves, the linking flow, Claude Chat, and `ghbridge`'s reply/reaction
+posting (stays on the Team App installation credential).
+
+## Components
+
+```mermaid
+graph TD
+  subgraph libbridge
+    D["Dispatcher<br/>(dispatch path)"]
+    R["ResumeScheduler<br/>#redispatch"]
+    TR["TokenResolver<br/>(surface,user) → DispatchAuth"]
+    R --> D
+    D --> TR
+  end
+  MB["msbridge"] -->|dispatch + render prompt| D
+  GB["ghbridge"] -->|dispatch + render prompt| D
+  TR -->|gRPC GetToken| GH["ghauth (1320)"]
+  MB -.->|ghauth client| TR
+  GB -.->|ghauth client| TR
+```
+
+The per-requester logic lives in `libbridge` because both bridges **and** the
+resume path share one `Dispatcher`; duplicating it per bridge would leave the
+resume redispatch (which never touches bridge code) unprotected.
+
+## DispatchAuth outcome
+
+`TokenResolver` wraps a `ghauth` gRPC client and maps 1320's `GetToken` `oneof`
+plus transport state into one discriminated result the dispatch path returns:
+
+| Variant | Source | Bridge renders |
+| ------- | ------ | -------------- |
+| `token(string)` | `GetToken` token arm | nothing — dispatch proceeds |
+| `link_required(authorize_url)` | `GetToken` `LinkRequired` | post the authorize URL |
+| `reauth_required` | `GetToken` `ReAuthRequired` | post a re-link prompt |
+| `transient(error)` | any gRPC failure (`UNAVAILABLE`, deadline, and every other code) | post a transient-error notice |
+
+`reauth_required` carries no URL of its own (1320 does not attach one); the
+bridge directs the user to the same linking entrypoint as `link_required`.
+Only the two typed arms 1320 defines map to `link_required` / `reauth_required`;
+every other gRPC outcome folds into `transient`. The `transient` variant is the
+**query's** transport failure; the existing throw/catch path for a failed
+`workflow_dispatch` itself is unchanged.
+
+## Dispatch path change
+
+`Dispatcher.dispatch` today holds `getGithubToken` fixed at construction, and
+starts the acknowledgement *before* fetching the token. The change:
+
+1. Call `TokenResolver` with `(ctx.channel, requester)` — the surface is the
+   context's existing `channel` value, so `libbridge` imports no channel constant
+   (honoring its no-channel-SDK invariant), and `requester` is an explicit input
+   the caller supplies (see below), not a value `dispatch()` reads off the
+   context.
+2. On `token`: start the acknowledgement and fire `workflow_dispatch` with that
+   token — the existing dance, unchanged downstream.
+3. On `link_required` / `reauth_required` / `transient`: start **no**
+   acknowledgement, fire **no** workflow, and return the variant to the caller.
+
+`dispatch()` gains a `requester` parameter and returns a `DispatchAuth` outcome.
+The `token` variant still includes the existing `{token, correlationId}` the
+intake success-caller destructures today. The intake caller renders any
+non-`token` variant inline; the resume path (`#redispatch`), which discards the
+return today, now inspects the outcome and, on a non-`token` variant, invokes
+the declined-outcome handler (below) instead. The token is resolved *before* the
+acknowledgement starts (see Key Decisions).
+
+```mermaid
+sequenceDiagram
+  participant H as Bridge intake
+  participant D as Dispatcher
+  participant T as TokenResolver
+  participant W as workflow_dispatch
+  H->>D: dispatch(ctx, prompt, requester, ackTarget)
+  D->>T: resolve(ctx.channel, requester)
+  alt token
+    T-->>D: token
+    D->>W: fire (per-user token)
+    D-->>H: {dispatched}
+  else link/reauth/transient
+    T-->>D: variant
+    D-->>H: variant (no ack, no dispatch)
+  end
+  H->>H: render prompt for variant
+```
+
+## Recorded requester
+
+The triggering requester is the human who caused *this* dispatch — not the
+conversation originator (`participant[0]`, which stays for history/attribution).
+Each bridge derives the requester's surface user id for the current inbound
+event and passes it into the dispatch path:
+
+| Bridge | Surface (`ctx.channel`) | Requester source |
+| ------ | ----------------------- | ---------------- |
+| `msbridge` | `msteams` | the message sender (`activity.from.id`) |
+| `ghbridge` | `github-discussions` | comment author for comment events, else discussion author |
+
+Because the requester is an explicit dispatch input, fresh and resume dispatches
+differ only in who supplies it. When a dispatch enters recess, `enterRecess` —
+the sole writer of the open-rfc record (today only the trigger and timing) —
+gains the requester and records it on that rfc. A resume — including an
+`elapsed`-timer resume that has no fresh inbound — reads the requester from the
+rfc it resumes and passes it back into `dispatch()`. The resolver therefore
+always sees the `(surface, requester)` key of the dispatch being run, with no
+shared mutable field to go stale.
+
+## Bridge rendering
+
+On the **intake** path the bridge has the `DispatchAuth` outcome as
+`dispatch()`'s return value and renders it inline: `msbridge` through its Teams
+`sendReply`, `ghbridge` through its discussion-comment GraphQL reply (which stays
+on the installation credential — see Key Decisions).
+
+The **resume** path runs inside `ResumeScheduler`, which is channel-agnostic and
+holds no reply adapter, and an `elapsed`-timer resume has no live inbound to
+reply through. So `ResumeScheduler` gains a caller-injected declined-outcome
+handler in its constructor — mirroring its existing `buildCallbackMeta` /
+`buildResumeInputs` constructor callbacks (not the reply handler, which lives on
+the separate callback handler) — that each bridge wires to its reply path. When
+a resume resolves to a non-`token` variant,
+`ResumeScheduler` cancels the recess and invokes that handler, which posts the
+prompt using the channel coordinates already stored on the context (the same
+coordinates the bridges use to post recess replies today), so it works without a
+live inbound.
+
+## Configuration
+
+Each bridge's startup wiring constructs a `ghauth` gRPC client (via `librpc`
+`createClient`) from a `ghauth` client binding added to its service config, and
+injects it into the `TokenResolver` the `Dispatcher` requires. The failing
+component for SC#10 is that **bridge startup wiring**: with the binding absent
+it cannot build the `ghauth` client, so the `TokenResolver` and `Dispatcher` are
+never constructed and the service does not start — the same fail-fast posture
+`Dispatcher` already takes for a missing token source. `init.services` lists
+`ghauth` before the bridges so the dependency is up first.
+
+## Key decisions
+
+| Decision | Rejected alternative | Why |
+| -------- | -------------------- | --- |
+| Resolution in the shared `Dispatcher` (injected `TokenResolver`) | Resolve in each bridge, pass a token into `dispatch()` | The resume redispatch flows through `Dispatcher`, not bridge code; per-bridge resolution would leave resumes on the old shared token and duplicate the branch twice. |
+| `dispatch()` returns a typed `DispatchAuth` outcome | Throw on non-`token` results | Link/re-auth/transient are expected control flow, not errors; a typed return lets each bridge render the right channel message without exception-as-control-flow. |
+| Resolve the token **before** starting the acknowledgement | Keep today's order (ack, then token) | Starting the ack then declining leaves a dangling "received" reaction (SC#7); resolving first means the ack starts only when a dispatch will fire. |
+| Requester as an explicit dispatch input (recorded on the rfc for resume) | Overwrite `participant[0].external_id` | The originator remains meaningful for history/attribution; overwriting conflates "who started the thread" with "who triggered this dispatch," and an explicit input avoids a shared mutable field. |
+| Resume reuses the recorded requester | Re-derive from a fresh inbound | An `elapsed`-triggered resume has no inbound sender; the requester who entered recess is the authority to reuse. |
+| `transient` → post a notice, fire nothing | Fail open to a fallback shared token | Dispatching under a fallback reintroduces the exact shared-identity gap 1320/1340 close. |
+| `ghbridge` replies/reactions stay on the installation credential | Post replies as the per-user token | The bot's replies are the app's action, not the user's; only the dispatch is the user's authorized act. |
+
+## Clean break
+
+No compatibility shim: the static `ghToken` / installation-token dispatch
+closures are removed from both bridges, and `Dispatcher`'s construction-time
+`getGithubToken` is replaced by the injected `TokenResolver`. Nothing outside
+the bridges + `libbridge` consumes that closure.

--- a/specs/1340-bridges-per-user-dispatch-auth/spec.md
+++ b/specs/1340-bridges-per-user-dispatch-auth/spec.md
@@ -1,0 +1,113 @@
+# Spec 1340: Bridges dispatch under the requester's GitHub identity
+
+**Persona / job:** Teams Using Agents —
+[Run a continuously improving agent team](../../JTBD.md#teams-using-agents-run-a-continuously-improving-agent-team).
+When a human asks the agent team to act, the team should act with *that human's*
+authority — so they can trust it and so GitHub enforces their permissions.
+
+**Depends on:** Spec 1320 (`services/oauth` + `services/ghauth`). 1320 builds
+the per-user token capability; 1340 makes the two existing bridges consume it.
+1340 cannot be implemented until 1320 has merged.
+
+## Problem
+
+`msbridge` and `ghbridge` relay a human's chat message to the Kata Agent Team
+by firing `kata-dispatch` via `workflow_dispatch`. Today that dispatch runs
+under a **single shared GitHub token**, never the identity of the person who
+asked:
+
+- `msbridge` constructs its `Dispatcher` with `getGithubToken` returning a
+  static configured token (`ghToken`).
+- `ghbridge` constructs its `Dispatcher` with `getGithubToken` returning the
+  Kata Agent **Team** App installation token. The same installation credential
+  also backs `ghbridge`'s reply and reaction posting.
+
+Consequences (the same gap Spec 1320 describes, now on the consumer side):
+
+- **No per-user authorization.** Anyone who can post in the channel triggers a
+  dispatch carrying the team's full privileges; GitHub never enforces whether
+  *that requester* may run the workflow on the repo.
+- **No attribution.** The workflow run is traceable only to the shared
+  identity, not the human who initiated it.
+
+The bridges capture only the **conversation originator's** surface identity, set
+once when the discussion context is created. `ghbridge` records the discussion
+author and never updates it for a later comment, so a dispatch triggered by a
+*commenter* would resolve to the wrong human. `msbridge` records the first
+sender even though a later message in the thread may come from someone else.
+Neither bridge records who triggered *this* dispatch, neither resolves a
+per-user token, and the shared dispatch primitive in `libbridge` takes one
+token fixed when it is constructed.
+
+Spec 1320 delivers a per-user token query keyed by `(surface, surface_user_id)`
+that returns either a usable token (a `string`) or a typed `LinkRequired` /
+`ReAuthRequired` result, and distinguishes those from a transient failure.
+Nothing consumes it yet.
+
+## Proposal
+
+Both bridges acquire the dispatch token **per requester** from `ghauth`, keyed
+by the surface and the human who triggered the current dispatch, and handle the
+absent-token cases by prompting on the channel instead of dispatching.
+
+| Change area | What changes (WHAT, not how) |
+| ----------- | ---------------------------- |
+| Triggering-user capture | Each bridge identifies and records, on the discussion context, the human who triggered *this* dispatch — the comment author for `ghbridge` comment events, the message sender for `msbridge` — rather than only the conversation originator. |
+| `libbridge` dispatch path | The dispatch path acquires the token for the recorded triggering requester from `ghauth`; when no usable token comes back, it does not fire `workflow_dispatch` and instead yields the `LinkRequired` / `ReAuthRequired` / transient-failure outcome to the bridge. |
+| Prompt-back | On `LinkRequired`, the bridge posts the authorize URL to the channel; on `ReAuthRequired`, it posts a re-link prompt; on a transient failure, it reports a transient error — and in all three cases fires no `workflow_dispatch`. |
+| Resume redispatch | A suspended conversation that resumes redispatches under the **recorded triggering requester's** token (resumes have no fresh sender), reusing the identity captured for the dispatch that entered recess. |
+| Acknowledgement on no-dispatch | The "received" acknowledgement is not left dangling when a dispatch is declined for a link/re-auth/transient outcome. |
+| Configuration | Each bridge gains a `ghauth` client binding so the dispatch path can reach the query. |
+
+The `surface` passed to `ghauth` is each bridge's existing channel constant
+(`msbridge` → `msteams`, `ghbridge` → `github-discussions`); the
+`surface_user_id` is the triggering user's native id. The resolved per-user
+token is used **only on the dispatch path** — `ghbridge`'s reply and reaction
+posting continue to use the Team App installation credential.
+
+This supersedes the bridges' construction-time fixed-token integration: the
+token value is still a `string` as 1320 commits, but it is now acquired per
+dispatch from the triggering requester rather than held once at construction.
+
+## Scope
+
+**In scope:**
+
+- `services/msbridge/` — triggering-sender capture per message; per-user token
+  acquisition on the dispatch path; the link/re-auth/transient prompt-back.
+- `services/ghbridge/` — the same, with triggering-user capture distinguishing
+  the comment author from the discussion author; reply/reaction path unchanged.
+- `libbridge` — the shared dispatch path acquiring the token for the recorded
+  triggering requester and yielding the typed link/re-auth/transient outcome;
+  resume redispatch reusing the recorded requester; no dangling acknowledgement
+  on the no-dispatch path.
+- Configuration: a `ghauth` client binding for each bridge.
+
+**Out of scope (explicit):**
+
+- `services/oauth/` and `services/ghauth/` themselves (Spec 1320).
+- The linking flow a user follows after seeing the prompt (lives in
+  `oauth` + `ghauth`).
+- Claude Chat and `services/kata` / `services/mcp`; this spec does not
+  generalize the dispatch path for that future surface.
+- `ghbridge`'s reply and reaction posting (stays on the installation credential).
+- Rate limiting and the recess/resume *trigger* semantics, which are unchanged
+  apart from the redispatch-token reuse named above.
+
+## Success criteria
+
+Each criterion is an observable behaviour (whether the workflow-dispatch call
+fired, and what the channel received); the named test is where it is asserted.
+
+| # | Observable behaviour | Asserted in |
+| - | -------------------- | ----------- |
+| 1 | A `msbridge` message from sender S causes a `ghauth` query keyed by `(msteams, S)`; a later message from a different sender T in the same thread queries `(msteams, T)`, not S. | `services/msbridge/test/dispatch-auth.test.js` |
+| 2 | A `ghbridge` comment by author A on a discussion opened by B causes a query keyed by `(github-discussions, A)`; a top-level discussion by B queries `(github-discussions, B)`. | `services/ghbridge/test/dispatch-auth.test.js` |
+| 3 | Given a `LinkRequired` result, the channel receives a message containing the authorize URL and the workflow-dispatch call is never invoked. | both bridges' `dispatch-auth.test.js` |
+| 4 | Given a `ReAuthRequired` result, the channel receives a re-link prompt and the workflow-dispatch call is never invoked. | both bridges' `dispatch-auth.test.js` |
+| 5 | Given a transient `ghauth` failure, the channel receives a transient-error message and the workflow-dispatch call is never invoked. | both bridges' `dispatch-auth.test.js` |
+| 6 | Given a usable token, the workflow-dispatch call is invoked with that token and not with the static/installation token. | both bridges' `dispatch-auth.test.js` |
+| 7 | After a declined dispatch (criteria 3–5), no "received" acknowledgement remains pending for that message. | `libraries/libbridge/test/dispatcher.test.js` |
+| 8 | A resume redispatch invokes the `ghauth` query keyed by the requester recorded for the dispatch that entered recess, not a fresh sender. | `libraries/libbridge/test/resume-scheduler.test.js` |
+| 9 | `ghbridge` reply and reaction posting still goes through the installation credential after the change. | `services/ghbridge/test/reply-path.test.js` |
+| 10 | Each bridge fails to start when its `ghauth` client binding is absent from configuration. | `services/msbridge/test/startup.test.js`, `services/ghbridge/test/startup.test.js` |


### PR DESCRIPTION
## Summary

- **Spec + design 1320** (`oauth` + `ghauth`): two new services that let a chat surface dispatch the Kata Agent Team under a per-user GitHub identity. `services/oauth/` is a stateless OAuth 2.1 protocol adapter; `services/ghauth/` is a provider-agnostic `AuthProvider` gRPC backend owning GitHub user-to-server auth and `BufferedIndex` token state. Scoped to those two services; grounded in the bridges as first consumers.
- **Spec + design 1340** (bridge adoption): wires `msbridge` + `ghbridge` (via the shared `libbridge` dispatch path) to acquire the dispatch token per requester from `ghauth`, prompting on the channel to link/re-link when no usable token exists instead of dispatching under a shared token. Per-user resolution lives in the shared `Dispatcher` so resume redispatch is covered; `ghbridge` reply/reaction posting stays on the Team App installation credential.

Both deliverables are spec + design only (no implementation). 1340 depends on 1320 and cannot be implemented until 1320's services exist. Each spec and design passed cold sub-agent review panels.

## Test plan

- [x] `bun run check` — passes
- [ ] `bun run test` — pre-existing, unrelated failures only (libwiki git-integration and fit-map roster-integration tests needing fixtures/seeded data absent in the build container); this change is markdown-only spec/design docs and touches no test code


---
_Generated by [Claude Code](https://claude.ai/code/session_01HKvN4kwz19pYSsrc3U59Ju)_