### PR TITLE
feat(ghauth,oauth): per-user GitHub auth services (#1320)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -735,6 +735,25 @@
         "@forwardimpact/libharness": "^0.1.5",
       },
     },
+    "services/ghauth": {
+      "name": "@forwardimpact/svcghauth",
+      "version": "0.1.0",
+      "bin": {
+        "fit-svcghauth": "./server.js",
+      },
+      "dependencies": {
+        "@forwardimpact/libconfig": "^0.1.79",
+        "@forwardimpact/libindex": "^0.1.0",
+        "@forwardimpact/libpreflight": "^0.1.0",
+        "@forwardimpact/librpc": "^0.1.99",
+        "@forwardimpact/libstorage": "^0.1.78",
+        "@forwardimpact/libtelemetry": "^0.1.42",
+        "@forwardimpact/libtype": "^0.1.0",
+      },
+      "devDependencies": {
+        "@forwardimpact/libharness": "^0.1.21",
+      },
+    },
     "services/ghbridge": {
       "name": "@forwardimpact/svcghbridge",
       "version": "0.1.0",
@@ -834,6 +853,25 @@
       },
       "devDependencies": {
         "@forwardimpact/libharness": "^0.1.5",
+      },
+    },
+    "services/oauth": {
+      "name": "@forwardimpact/svcoauth",
+      "version": "0.1.0",
+      "bin": {
+        "fit-svcoauth": "./server.js",
+      },
+      "dependencies": {
+        "@forwardimpact/libconfig": "^0.1.79",
+        "@forwardimpact/libpreflight": "^0.1.0",
+        "@forwardimpact/librpc": "^0.1.99",
+        "@forwardimpact/libtelemetry": "^0.1.42",
+        "@forwardimpact/libtype": "^0.1.0",
+        "@hono/node-server": "^2.0.2",
+        "hono": "^4.12.18",
+      },
+      "devDependencies": {
+        "@forwardimpact/libharness": "^0.1.21",
       },
     },
     "services/pathway": {
@@ -1180,6 +1218,8 @@
 
     "@forwardimpact/svcembedding": ["@forwardimpact/svcembedding@workspace:services/embedding"],
 
+    "@forwardimpact/svcghauth": ["@forwardimpact/svcghauth@workspace:services/ghauth"],
+
     "@forwardimpact/svcghbridge": ["@forwardimpact/svcghbridge@workspace:services/ghbridge"],
 
     "@forwardimpact/svcgraph": ["@forwardimpact/svcgraph@workspace:services/graph"],
@@ -1189,6 +1229,8 @@
     "@forwardimpact/svcmcp": ["@forwardimpact/svcmcp@workspace:services/mcp"],
 
     "@forwardimpact/svcmsbridge": ["@forwardimpact/svcmsbridge@workspace:services/msbridge"],
+
+    "@forwardimpact/svcoauth": ["@forwardimpact/svcoauth@workspace:services/oauth"],
 
     "@forwardimpact/svcpathway": ["@forwardimpact/svcpathway@workspace:services/pathway"],
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -62,8 +62,13 @@ services that depend on them.
 Optional entries — add when working on those features:
 
 ```json
+{ "name": "oauthtunnel", "command": "sh -c '. ./.env && exec cloudflared tunnel --url ${SERVICE_OAUTH_URL} --protocol http2'" }
 { "name": "mstunnel", "command": "sh -c '. ./.env && exec cloudflared tunnel --url ${SERVICE_MSBRIDGE_URL} --protocol http2'" }
+{ "name": "ghtunnel", "command": "sh -c '. ./.env && exec cloudflared tunnel --url ${SERVICE_GHBRIDGE_URL} --protocol http2'" }
+{ "name": "ghauth", "command": "node -e \"import('@forwardimpact/svcghauth/server.js')\"" }
+{ "name": "oauth",  "command": "node -e \"import('@forwardimpact/svcoauth/server.js')\"" }
 { "name": "msbridge", "command": "node -e \"import('@forwardimpact/svcmsbridge/server.js')\"" }
+{ "name": "ghbridge", "command": "node -e \"import('@forwardimpact/svcghbridge/server.js')\"" }
 ```
 
 Oneshot services use `"type": "oneshot"` with `up`/`down` instead of `command`:

--- a/services/README.md
+++ b/services/README.md
@@ -9,17 +9,19 @@ that let agents consume backend functionality natively.
 
 <!-- BEGIN:catalog — Do not edit. Generated from each service's package.json. -->
 
-| Service       | Description                                                                                                 |
-| ------------- | ----------------------------------------------------------------------------------------------------------- |
-| **embedding** | Text embeddings over gRPC — semantic representation without each product running its own inference.         |
-| **ghbridge**  | GitHub Discussions bridge — relay messages between GitHub Discussion threads and the Kata agent team.       |
-| **graph**     | RDF knowledge graph over gRPC — relationship queries without each product standing up its own store.        |
-| **map**       | Activity reads and writes over gRPC — the agent-facing gateway to Map's activity database.                  |
-| **mcp**       | Unified MCP server — agents reach backend services as tools without per-service integration.                |
-| **msbridge**  | Microsoft Teams bridge onto libbridge — relay messages between Teams conversations and the Kata agent team. |
-| **pathway**   | Engineering standard queries over gRPC — career paths and agent profiles as derivable data for products.    |
-| **trace**     | OpenTelemetry span ingestion and storage over gRPC — prove whether agent changes improved outcomes.         |
-| **vector**    | Vector similarity search over gRPC — semantic retrieval without a dedicated database per product.           |
+| Service       | Description                                                                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **embedding** | Text embeddings over gRPC — semantic representation without each product running its own inference.                          |
+| **ghauth**    | GitHub user authentication — per-user OAuth token lifecycle for the Kata Agent User App.                                     |
+| **ghbridge**  | GitHub Discussions bridge — relay messages between GitHub Discussion threads and the Kata agent team.                        |
+| **graph**     | RDF knowledge graph over gRPC — relationship queries without each product standing up its own store.                         |
+| **map**       | Activity reads and writes over gRPC — the agent-facing gateway to Map's activity database.                                   |
+| **mcp**       | Unified MCP server — agents reach backend services as tools without per-service integration.                                 |
+| **msbridge**  | Microsoft Teams bridge onto libbridge — relay messages between Teams conversations and the Kata agent team.                  |
+| **oauth**     | OAuth 2.1 authorization server adapter — protocol-only HTTP front that delegates to a configured provider backend over gRPC. |
+| **pathway**   | Engineering standard queries over gRPC — career paths and agent profiles as derivable data for products.                     |
+| **trace**     | OpenTelemetry span ingestion and storage over gRPC — prove whether agent changes improved outcomes.                          |
+| **vector**    | Vector similarity search over gRPC — semantic retrieval without a dedicated database per product.                            |
 
 <!-- END:catalog -->
 
@@ -101,6 +103,25 @@ per-product activity endpoints; embedding query logic in the evaluation skill.
 
 </job>
 
+<job user="Platform Builders" goal="Expose an OAuth 2.1 authorization server without provider-specific code">
+
+## Platform Builders: Expose an OAuth 2.1 authorization server without provider-specific code
+
+**Trigger:** A new identity provider needs to plug into the same authorization
+flow without changing the protocol layer.
+
+**Big Hire:** Help me serve standard OAuth 2.1 endpoints that delegate every
+provider-specific step to a gRPC backend, keeping the HTTP surface
+provider-agnostic. → **oauth**
+
+**Little Hire:** Help me redirect an authorize request to the upstream provider
+and exchange a callback code for a downstream token. → **oauth**
+
+**Competes With:** per-provider HTTP services that mix OAuth protocol handling
+with provider-specific exchange logic.
+
+</job>
+
 <job user="Platform Builders" goal="Ground Agents in Context">
 
 ## Platform Builders: Ground Agents in Context
@@ -174,6 +195,27 @@ later. → **trace**
 
 **Competes With:** per-product trace files; manual log comparison; skipping
 observability entirely.
+
+</job>
+
+<job user="Platform Builders" goal="Resolve a per-user GitHub token for agent dispatch">
+
+## Platform Builders: Resolve a per-user GitHub token for agent dispatch
+
+**Trigger:** A chat surface needs to dispatch a workflow under the identity of
+the human who asked, not a shared bot token.
+
+**Big Hire:** Help me own the Kata Agent User App credential lifecycle
+end-to-end so every surface resolves a per-user GitHub token through one gRPC
+query. → **ghauth**
+
+**Little Hire:** Help me exchange an authorization code for a user-to-server
+token, store the binding, refresh on expiry, and return a typed link/re-auth
+result when the binding is missing or revoked. → **ghauth**
+
+**Competes With:** per-surface OAuth implementations duplicating the
+authorization-code flow, token storage, and refresh logic across multiple bridge
+services.
 
 </job>
 

--- a/services/ghauth/README.md
+++ b/services/ghauth/README.md
@@ -1,0 +1,98 @@
+# GitHub User Authentication
+
+<!-- BEGIN:description — Do not edit. Generated from package.json. -->
+
+GitHub user authentication — per-user OAuth token lifecycle for the Kata Agent
+User App.
+
+<!-- END:description -->
+
+## Prerequisites
+
+- A **Kata Agent User** GitHub App (user-to-server auth model) with
+  "Expire user authorization tokens" enabled and the permissions the
+  dispatch workflow requires (e.g. `actions:write`).
+- The App's **Client ID** and a generated **Client Secret**.
+
+Configuration (loaded via `createServiceConfig("ghauth")`):
+
+| Env var | Purpose |
+| --- | --- |
+| `SERVICE_GHAUTH_URL` | Listen URL (default `grpc://localhost:3006`) |
+| `SERVICE_GHAUTH_CLIENT_ID` | Kata Agent User App client ID |
+| `SERVICE_GHAUTH_CLIENT_SECRET` | Kata Agent User App client secret |
+| `SERVICE_GHAUTH_LINK_BASE_URL` | Public URL of the `oauth` service (used in `LinkRequired.authorize_url`) |
+
+## Running
+
+Add `ghauth` and `oauth` to `config/config.json` under `init.services` —
+see [`config/CLAUDE.md`](../../config/CLAUDE.md) for the entry format.
+List `oauthtunnel` with the other tunnels (before services) so that
+restarting `ghauth` does not cycle the tunnel (declaration order determines
+restart scope). List `ghauth` before `oauth` (dependency first).
+
+Start both services:
+
+```sh
+just rc-start
+```
+
+The tunnel uses a quick `trycloudflare.com` hostname that changes on
+every restart. After starting, check the tunnel log for the assigned URL:
+
+```sh
+cat data/logs/oauthtunnel/current | grep trycloudflare.com
+```
+
+### GitHub App callback configuration
+
+In the App settings (`github.com/settings/apps/<app>`):
+
+1. Set **Callback URL** to `https://<tunnel-domain>/callback`.
+2. Save changes.
+
+Set `SERVICE_GHAUTH_LINK_BASE_URL` in `.env` to the tunnel domain
+(without any path), then restart only the auth services:
+
+```sh
+bunx fit-rc restart ghauth
+```
+
+The tunnel keeps its hostname across service restarts.
+
+Token bindings are persisted as JSONL under `data/ghauth/` via
+`libstorage` (the standard `createStorage` path — no extra env var
+needed).
+
+### Corporate network considerations
+
+The service must be able to reach `github.com` to exchange authorization
+codes and refresh tokens. If you are on a corporate VPN with tenant
+restrictions, disconnect before starting.
+
+## Smoke test
+
+Visit the authorize URL in a browser:
+
+```
+https://<tunnel-domain>/authorize?surface=test&surface_user_id=you
+```
+
+The flow:
+
+1. Redirects to GitHub to authorize the Kata Agent User App.
+2. GitHub calls back to `/callback` on the `oauth` service.
+3. `ghauth` exchanges the authorization code for a user-to-server token.
+4. The binding is stored in `data/ghauth/bindings.jsonl`.
+5. The browser shows "Linked — Your account has been linked."
+
+Verify the binding via gRPC:
+
+```js
+const result = await client.GetToken({ surface: "test", surface_user_id: "you" });
+// result.token → "ghu_..."
+```
+
+For an unlinked user, `GetToken` returns `link_required` with the
+authorize URL. For a revoked or expired token that cannot be refreshed,
+it returns `re_auth_required`.

--- a/services/ghauth/index.js
+++ b/services/ghauth/index.js
@@ -1,0 +1,213 @@
+import crypto from "node:crypto";
+import { services } from "@forwardimpact/librpc";
+import { RevokedError } from "./src/github-oauth.js";
+
+const { GhauthBase } = services;
+
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+/**
+ * GitHub user authentication service — Kata Agent User App token lifecycle.
+ * @augments GhauthBase
+ */
+export class GhauthService extends GhauthBase {
+  #bindings;
+  #flows;
+  #grants;
+  #github;
+  #linkBaseUrl;
+
+  /**
+   * @param {object} config
+   * @param {object} deps
+   * @param {import("./src/stores.js").BindingStore} deps.bindings
+   * @param {import("./src/stores.js").FlowStore} deps.flows
+   * @param {import("./src/stores.js").GrantStore} deps.grants
+   * @param {ReturnType<import("./src/github-oauth.js").createGithubOAuth>} deps.github
+   */
+  constructor(config, { bindings, flows, grants, github }) {
+    super(config);
+    this.#bindings = bindings;
+    this.#flows = flows;
+    this.#grants = grants;
+    this.#github = github;
+    this.#linkBaseUrl = config.link_base_url;
+  }
+
+  /**
+   * @param {object} req
+   * @returns {Promise<object>}
+   */
+  async Begin(req) {
+    const state = crypto.randomUUID();
+    const redirectUri = `${this.#linkBaseUrl}/callback`;
+
+    await this.#flows.add({
+      id: state,
+      surface: req.surface,
+      surface_user_id: req.surface_user_id,
+      code_challenge: req.code_challenge ?? null,
+      redirect_uri: req.redirect_uri ?? null,
+      client_state: null,
+      created_at: Date.now(),
+    });
+
+    const upstreamUrl = this.#github.authorizeUrl({
+      state,
+      redirectUri,
+      scopes: req.scopes ?? [],
+    });
+
+    return { upstream_authorize_url: upstreamUrl, state };
+  }
+
+  /**
+   * @param {object} req
+   * @returns {Promise<object>}
+   */
+  async Complete(req) {
+    const flow = await this.#flows.consume(req.state);
+    if (!flow) throw new Error("Unknown or expired flow state");
+
+    const redirectUri = `${this.#linkBaseUrl}/callback`;
+    const tokens = await this.#github.exchangeCode(req.code, redirectUri);
+
+    const bindingId = this.#bindings.constructor.keyOf(
+      flow.surface,
+      flow.surface_user_id,
+    );
+    await this.#bindings.upsert({
+      id: bindingId,
+      github_user_id: null,
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token ?? null,
+      expires_at: tokens.expires_in
+        ? Date.now() + tokens.expires_in * 1000
+        : null,
+      scopes: flow.scopes ?? [],
+    });
+
+    if (flow.redirect_uri) {
+      const downstreamCode = crypto.randomUUID();
+      await this.#grants.add({
+        id: downstreamCode,
+        surface: flow.surface,
+        surface_user_id: flow.surface_user_id,
+        code_challenge: flow.code_challenge,
+        redirect_uri: flow.redirect_uri,
+        client_state: flow.client_state,
+        created_at: Date.now(),
+      });
+      return {
+        downstream_code: downstreamCode,
+        redirect_uri: flow.redirect_uri,
+        client_state: flow.client_state,
+      };
+    }
+
+    return {};
+  }
+
+  /**
+   * @param {object} req
+   * @returns {Promise<object>}
+   */
+  async Redeem(req) {
+    const grant = await this.#grants.consume(req.code);
+    if (!grant) throw new Error("Unknown or expired grant code");
+
+    if (grant.code_challenge) {
+      const expected = crypto
+        .createHash("sha256")
+        .update(req.code_verifier)
+        .digest("base64url");
+      if (expected !== grant.code_challenge) {
+        throw new Error("PKCE code_verifier mismatch");
+      }
+    }
+
+    const binding = await this.#bindings.loadBinding(
+      grant.surface,
+      grant.surface_user_id,
+    );
+    if (!binding) throw new Error("Binding not found for grant");
+
+    return {
+      access_token: binding.access_token,
+      token_type: "bearer",
+      expires_in: binding.expires_at
+        ? Math.max(0, Math.floor((binding.expires_at - Date.now()) / 1000))
+        : 0,
+    };
+  }
+
+  /**
+   * @param {object} req
+   * @returns {Promise<object>}
+   */
+  async GetToken(req) {
+    const binding = await this.#bindings.loadBinding(
+      req.surface,
+      req.surface_user_id,
+    );
+
+    if (!binding) {
+      const authorizeUrl = `${this.#linkBaseUrl}/authorize?surface=${encodeURIComponent(req.surface)}&surface_user_id=${encodeURIComponent(req.surface_user_id)}`;
+      return {
+        result: "link_required",
+        link_required: { authorize_url: authorizeUrl },
+      };
+    }
+
+    if (
+      binding.expires_at &&
+      Date.now() > binding.expires_at - EXPIRY_BUFFER_MS
+    ) {
+      if (!binding.refresh_token) {
+        return { result: "re_auth_required", re_auth_required: {} };
+      }
+      try {
+        const refreshed = await this.#github.refresh(binding.refresh_token);
+        binding.access_token = refreshed.access_token;
+        binding.refresh_token =
+          refreshed.refresh_token ?? binding.refresh_token;
+        binding.expires_at = refreshed.expires_in
+          ? Date.now() + refreshed.expires_in * 1000
+          : null;
+        await this.#bindings.upsert(binding);
+      } catch (err) {
+        if (err instanceof RevokedError) {
+          return { result: "re_auth_required", re_auth_required: {} };
+        }
+        throw err;
+      }
+    }
+
+    return { result: "token", token: binding.access_token };
+  }
+
+  /**
+   * @param {object} req
+   * @returns {Promise<object>}
+   */
+  async Revoke(req) {
+    const binding = await this.#bindings.loadBinding(
+      req.surface,
+      req.surface_user_id,
+    );
+    if (binding) {
+      await this.#github.revoke(binding.access_token);
+      await this.#bindings.delete(binding.id);
+    }
+    return {};
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async shutdown() {
+    await this.#bindings.shutdown();
+    await this.#flows.shutdown();
+    await this.#grants.shutdown();
+  }
+}

--- a/services/ghauth/package.json
+++ b/services/ghauth/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@forwardimpact/svcghauth",
+  "version": "0.1.0",
+  "description": "GitHub user authentication — per-user OAuth token lifecycle for the Kata Agent User App.",
+  "keywords": [
+    "github",
+    "oauth",
+    "authentication",
+    "token",
+    "agent"
+  ],
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "services/ghauth"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Platform Builders",
+      "goal": "Resolve a per-user GitHub token for agent dispatch",
+      "trigger": "A chat surface needs to dispatch a workflow under the identity of the human who asked, not a shared bot token.",
+      "bigHire": "own the Kata Agent User App credential lifecycle end-to-end so every surface resolves a per-user GitHub token through one gRPC query.",
+      "littleHire": "exchange an authorization code for a user-to-server token, store the binding, refresh on expiry, and return a typed link/re-auth result when the binding is missing or revoked.",
+      "competesWith": "per-surface OAuth implementations duplicating the authorization-code flow, token storage, and refresh logic across multiple bridge services"
+    }
+  ],
+  "type": "module",
+  "main": "./index.js",
+  "bin": {
+    "fit-svcghauth": "./server.js"
+  },
+  "files": [
+    "index.js",
+    "server.js",
+    "src",
+    "proto"
+  ],
+  "scripts": {
+    "test": "bun test test/*.test.js"
+  },
+  "dependencies": {
+    "@forwardimpact/libconfig": "^0.1.79",
+    "@forwardimpact/libindex": "^0.1.0",
+    "@forwardimpact/libpreflight": "^0.1.0",
+    "@forwardimpact/librpc": "^0.1.99",
+    "@forwardimpact/libstorage": "^0.1.78",
+    "@forwardimpact/libtelemetry": "^0.1.42",
+    "@forwardimpact/libtype": "^0.1.0"
+  },
+  "devDependencies": {
+    "@forwardimpact/libharness": "^0.1.21"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/services/ghauth/proto/ghauth.proto
+++ b/services/ghauth/proto/ghauth.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package ghauth;
+
+import "common.proto";
+
+service Ghauth {
+  rpc Begin(BeginRequest) returns (BeginResponse);
+  rpc Complete(CompleteRequest) returns (CompleteResponse);
+  rpc Redeem(RedeemRequest) returns (RedeemResponse);
+  rpc GetToken(GetTokenRequest) returns (GetTokenResponse);
+  rpc Revoke(RevokeRequest) returns (common.Empty);
+}
+
+message BeginRequest {
+  string surface = 1;
+  string surface_user_id = 2;
+  optional string redirect_uri = 3;
+  optional string code_challenge = 4;
+  repeated string scopes = 5;
+}
+message BeginResponse { string upstream_authorize_url = 1; string state = 2; }
+
+message CompleteRequest { string code = 1; string state = 2; }
+message CompleteResponse {
+  optional string downstream_code = 1;
+  optional string redirect_uri = 2;
+  optional string client_state = 3;
+}
+
+message RedeemRequest { string code = 1; string code_verifier = 2; }
+message RedeemResponse { string access_token = 1; string token_type = 2; int64 expires_in = 3; }
+
+message GetTokenRequest { string surface = 1; string surface_user_id = 2; }
+message LinkRequired { string authorize_url = 1; }
+message ReAuthRequired {}
+message GetTokenResponse {
+  oneof result {
+    string token = 1;
+    LinkRequired link_required = 2;
+    ReAuthRequired re_auth_required = 3;
+  }
+}
+
+message RevokeRequest { string surface = 1; string surface_user_id = 2; }

--- a/services/ghauth/server.js
+++ b/services/ghauth/server.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import "@forwardimpact/libpreflight/node22";
+
+import { Server, createTracer } from "@forwardimpact/librpc";
+import { createServiceConfig } from "@forwardimpact/libconfig";
+import { createLogger } from "@forwardimpact/libtelemetry";
+import { createStorage } from "@forwardimpact/libstorage";
+import { GhauthService } from "./index.js";
+import { BindingStore, FlowStore, GrantStore } from "./src/stores.js";
+import { createGithubOAuth } from "./src/github-oauth.js";
+
+const config = await createServiceConfig("ghauth", {
+  protocol: "grpc",
+  port: 3006,
+  link_base_url: "http://localhost:3007",
+  client_id: "",
+  client_secret: "",
+});
+
+const logger = createLogger("ghauth");
+const tracer = await createTracer("ghauth");
+const storage = createStorage("ghauth");
+
+const github = createGithubOAuth({
+  clientId: config.client_id,
+  clientSecret: config.client_secret,
+});
+
+const bindings = new BindingStore(storage);
+const flows = new FlowStore(storage);
+const grants = new GrantStore(storage);
+
+const service = new GhauthService(config, { bindings, flows, grants, github });
+const server = new Server(service, config, logger, tracer);
+
+await server.start();
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, async () => {
+    await service.shutdown();
+    process.exit(0);
+  });
+}

--- a/services/ghauth/src/github-oauth.js
+++ b/services/ghauth/src/github-oauth.js
@@ -1,0 +1,105 @@
+/**
+ * Thrown when GitHub reports a token grant as revoked.
+ */
+export class RevokedError extends Error {
+  /** @param {string} [message] */
+  constructor(message = "Token revoked") {
+    super(message);
+    this.name = "RevokedError";
+  }
+}
+
+/**
+ * Create a GitHub OAuth client for the Kata Agent User App.
+ * @param {object} options
+ * @param {string} options.clientId
+ * @param {string} options.clientSecret
+ * @param {typeof fetch} [options.fetchImpl]
+ * @returns {object}
+ */
+export function createGithubOAuth({
+  clientId,
+  clientSecret,
+  fetchImpl = fetch,
+}) {
+  const tokenUrl = "https://github.com/login/oauth/access_token";
+
+  return {
+    authorizeUrl({ state, redirectUri, scopes = [] }) {
+      const params = new URLSearchParams({
+        client_id: clientId,
+        state,
+        redirect_uri: redirectUri,
+      });
+      if (scopes.length) params.set("scope", scopes.join(" "));
+      return `https://github.com/login/oauth/authorize?${params}`;
+    },
+
+    async exchangeCode(code, redirectUri) {
+      const res = await fetchImpl(tokenUrl, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+          client_id: clientId,
+          client_secret: clientSecret,
+          code,
+          redirect_uri: redirectUri,
+        }),
+      });
+      const body = await res.json();
+      if (body.error) throw new Error(`GitHub OAuth error: ${body.error}`);
+      return {
+        access_token: body.access_token,
+        refresh_token: body.refresh_token,
+        expires_in: body.expires_in,
+      };
+    },
+
+    async refresh(refreshToken) {
+      const res = await fetchImpl(tokenUrl, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+          client_id: clientId,
+          client_secret: clientSecret,
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+        }),
+      });
+      const body = await res.json();
+      if (body.error === "bad_refresh_token" || body.error === "unauthorized") {
+        throw new RevokedError(`GitHub refresh failed: ${body.error}`);
+      }
+      if (body.error) throw new Error(`GitHub refresh error: ${body.error}`);
+      return {
+        access_token: body.access_token,
+        refresh_token: body.refresh_token,
+        expires_in: body.expires_in,
+      };
+    },
+
+    async revoke(accessToken) {
+      const res = await fetchImpl(
+        `https://api.github.com/applications/${clientId}/token`,
+        {
+          method: "DELETE",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+          },
+          body: JSON.stringify({ access_token: accessToken }),
+        },
+      );
+      if (!res.ok && res.status !== 422) {
+        throw new Error(`GitHub revoke failed: ${res.status}`);
+      }
+    },
+  };
+}

--- a/services/ghauth/src/stores.js
+++ b/services/ghauth/src/stores.js
@@ -1,0 +1,216 @@
+import { BufferedIndex } from "@forwardimpact/libindex";
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_SWEEP_INTERVAL_MS = 60_000;
+
+/**
+ * Durable store for `(surface, surface_user_id)` ↔ GitHub token bindings.
+ * @augments BufferedIndex
+ */
+export class BindingStore extends BufferedIndex {
+  /**
+   * @param {import("@forwardimpact/libstorage").StorageInterface} storage
+   * @param {object} [options]
+   * @param {string} [options.indexKey]
+   */
+  constructor(storage, { indexKey = "bindings.jsonl" } = {}) {
+    super(storage, indexKey, { flush_interval: 5_000, max_buffer_size: 100 });
+  }
+
+  /**
+   * @param {string} surface
+   * @param {string} userId
+   * @returns {string}
+   */
+  static keyOf(surface, userId) {
+    return `${surface}:${userId}`;
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async loadData() {
+    await super.loadData();
+    for (const [id, record] of this.index) {
+      if (record.deleted) this.index.delete(id);
+    }
+  }
+
+  /**
+   * @param {string} surface
+   * @param {string} userId
+   * @returns {Promise<object|null>}
+   */
+  async loadBinding(surface, userId) {
+    if (!this.loaded) await this.loadData();
+    return this.index.get(BindingStore.keyOf(surface, userId)) ?? null;
+  }
+
+  /**
+   * @param {object} record
+   * @returns {Promise<void>}
+   */
+  async upsert(record) {
+    await this.add(record);
+  }
+
+  /**
+   * @param {string} id
+   * @returns {Promise<void>}
+   */
+  async delete(id) {
+    this.index.delete(id);
+    await this.add({ id, deleted: true });
+  }
+}
+
+/**
+ * Short-TTL store with periodic sweep, mirroring DiscussionContextStore.
+ * @augments BufferedIndex
+ */
+class TtlStore extends BufferedIndex {
+  #ttlMs;
+  #sweepTimer;
+
+  /**
+   * @param {import("@forwardimpact/libstorage").StorageInterface} storage
+   * @param {string} indexKey
+   * @param {object} [options]
+   * @param {number} [options.ttlMs]
+   * @param {number} [options.sweepIntervalMs]
+   */
+  constructor(
+    storage,
+    indexKey,
+    {
+      ttlMs = DEFAULT_TTL_MS,
+      sweepIntervalMs = DEFAULT_SWEEP_INTERVAL_MS,
+    } = {},
+  ) {
+    super(storage, indexKey, { flush_interval: 1_000, max_buffer_size: 100 });
+    this.#ttlMs = ttlMs;
+    this.#sweepTimer = setInterval(
+      () => this.#sweep(Date.now()),
+      sweepIntervalMs,
+    );
+    this.#sweepTimer.unref();
+  }
+
+  /** Stop the periodic sweep timer. */
+  stopSweep() {
+    if (this.#sweepTimer) {
+      clearInterval(this.#sweepTimer);
+      this.#sweepTimer = null;
+    }
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async shutdown() {
+    this.stopSweep();
+    await super.shutdown();
+  }
+
+  /**
+   * @param {number} now
+   * @returns {number}
+   */
+  sweepNow(now) {
+    return this.#sweep(now);
+  }
+
+  #sweep(now) {
+    let evicted = 0;
+    for (const [id, record] of this.index) {
+      if (now - (record?.created_at ?? 0) > this.#ttlMs) {
+        this.index.delete(id);
+        evicted++;
+      }
+    }
+    return evicted;
+  }
+}
+
+/**
+ * Pending authorization flows keyed by outer `state`.
+ * @augments TtlStore
+ */
+export class FlowStore extends TtlStore {
+  /**
+   * @param {import("@forwardimpact/libstorage").StorageInterface} storage
+   * @param {object} [options]
+   */
+  constructor(storage, options) {
+    super(storage, "flows.jsonl", options);
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async loadData() {
+    await super.loadData();
+    for (const [id, record] of this.index) {
+      if (record.deleted) this.index.delete(id);
+    }
+  }
+
+  /**
+   * @param {string} state
+   * @returns {Promise<object|null>}
+   */
+  async loadFlow(state) {
+    if (!this.loaded) await this.loadData();
+    return this.index.get(state) ?? null;
+  }
+
+  /**
+   * @param {string} state
+   * @returns {Promise<object|null>}
+   */
+  async consume(state) {
+    if (!this.loaded) await this.loadData();
+    const flow = this.index.get(state);
+    if (!flow) return null;
+    this.index.delete(state);
+    await this.add({ id: state, deleted: true });
+    return flow;
+  }
+}
+
+/**
+ * Issued downstream codes keyed by `downstream_code`, consumed once.
+ * @augments TtlStore
+ */
+export class GrantStore extends TtlStore {
+  /**
+   * @param {import("@forwardimpact/libstorage").StorageInterface} storage
+   * @param {object} [options]
+   */
+  constructor(storage, options) {
+    super(storage, "grants.jsonl", options);
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async loadData() {
+    await super.loadData();
+    for (const [id, record] of this.index) {
+      if (record.deleted) this.index.delete(id);
+    }
+  }
+
+  /**
+   * @param {string} code
+   * @returns {Promise<object|null>}
+   */
+  async consume(code) {
+    if (!this.loaded) await this.loadData();
+    const grant = this.index.get(code);
+    if (!grant) return null;
+    this.index.delete(code);
+    await this.add({ id: code, deleted: true });
+    return grant;
+  }
+}

--- a/services/ghauth/test/persistence.test.js
+++ b/services/ghauth/test/persistence.test.js
@@ -1,0 +1,53 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { createMockStorage } from "@forwardimpact/libharness/mock";
+import { BindingStore } from "../src/stores.js";
+
+describe("ghauth persistence (SC#7)", () => {
+  test("binding written before restart is readable after fresh start", async () => {
+    const storage = createMockStorage();
+
+    const store1 = new BindingStore(storage);
+    await store1.upsert({
+      id: BindingStore.keyOf("teams", "u1"),
+      github_user_id: "ghuser-abc",
+      access_token: "ghu_persisted",
+      refresh_token: "ghr_persisted",
+      expires_at: Date.now() + 3600_000,
+      scopes: ["repo"],
+    });
+    await store1.shutdown();
+
+    const store2 = new BindingStore(storage);
+    const binding = await store2.loadBinding("teams", "u1");
+    assert.ok(binding, "binding survives restart");
+    assert.strictEqual(binding.access_token, "ghu_persisted");
+    await store2.shutdown();
+  });
+
+  test("deleted binding is not readable after restart", async () => {
+    const storage = createMockStorage();
+
+    const store1 = new BindingStore(storage);
+    const id = BindingStore.keyOf("teams", "u2");
+    await store1.upsert({
+      id,
+      github_user_id: "ghuser-def",
+      access_token: "ghu_to_delete",
+      refresh_token: null,
+      expires_at: null,
+      scopes: [],
+    });
+    await store1.delete(id);
+    await store1.shutdown();
+
+    const store2 = new BindingStore(storage);
+    const binding = await store2.loadBinding("teams", "u2");
+    assert.strictEqual(
+      binding,
+      null,
+      "deleted binding does not survive restart",
+    );
+    await store2.shutdown();
+  });
+});

--- a/services/ghauth/test/query-contract.test.js
+++ b/services/ghauth/test/query-contract.test.js
@@ -1,0 +1,44 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { createMockConfig } from "@forwardimpact/libharness";
+import { createMockStorage } from "@forwardimpact/libharness/mock";
+import { GhauthService } from "../index.js";
+import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
+
+describe("ghauth query-contract (SC#8)", () => {
+  test("GetToken accepts (surface, surface_user_id) and token arm is typeof string", async () => {
+    const storage = createMockStorage();
+    const config = createMockConfig("ghauth", {
+      link_base_url: "http://localhost:3007",
+    });
+    const bindings = new BindingStore(storage);
+    const service = new GhauthService(config, {
+      bindings,
+      flows: new FlowStore(storage),
+      grants: new GrantStore(storage),
+      github: {
+        authorizeUrl: () => "",
+        exchangeCode: async () => ({}),
+        refresh: async () => ({}),
+        revoke: async () => {},
+      },
+    });
+
+    await bindings.upsert({
+      id: BindingStore.keyOf("github-discussions", "ext-42"),
+      github_user_id: "ghuser-xyz",
+      access_token: "ghu_contract_token",
+      refresh_token: null,
+      expires_at: null,
+      scopes: [],
+    });
+
+    const result = await service.GetToken({
+      surface: "github-discussions",
+      surface_user_id: "ext-42",
+    });
+
+    assert.strictEqual(typeof result.token, "string", "token arm is a string");
+    assert.strictEqual(result.token, "ghu_contract_token");
+  });
+});

--- a/services/ghauth/test/query-linked.test.js
+++ b/services/ghauth/test/query-linked.test.js
@@ -1,0 +1,76 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { createMockConfig } from "@forwardimpact/libharness";
+import { createMockStorage } from "@forwardimpact/libharness/mock";
+import { GhauthService } from "../index.js";
+import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
+
+describe("ghauth query-linked (SC#4)", () => {
+  test("linked user with valid token returns that token unchanged", async () => {
+    const storage = createMockStorage();
+    const config = createMockConfig("ghauth", {
+      link_base_url: "http://localhost:3007",
+    });
+    const bindings = new BindingStore(storage);
+    const service = new GhauthService(config, {
+      bindings,
+      flows: new FlowStore(storage),
+      grants: new GrantStore(storage),
+      github: {
+        authorizeUrl: () => "",
+        exchangeCode: async () => ({}),
+        refresh: async () => ({}),
+        revoke: async () => {},
+      },
+    });
+
+    await bindings.upsert({
+      id: BindingStore.keyOf("teams", "u1"),
+      github_user_id: "ghuser-abc",
+      access_token: "ghu_stored_token",
+      refresh_token: "ghr_refresh",
+      expires_at: Date.now() + 3600_000,
+      scopes: ["repo"],
+    });
+
+    const result = await service.GetToken({
+      surface: "teams",
+      surface_user_id: "u1",
+    });
+    assert.strictEqual(result.token, "ghu_stored_token");
+  });
+
+  test("linked user with non-expiring token returns it", async () => {
+    const storage = createMockStorage();
+    const config = createMockConfig("ghauth", {
+      link_base_url: "http://localhost:3007",
+    });
+    const bindings = new BindingStore(storage);
+    const service = new GhauthService(config, {
+      bindings,
+      flows: new FlowStore(storage),
+      grants: new GrantStore(storage),
+      github: {
+        authorizeUrl: () => "",
+        exchangeCode: async () => ({}),
+        refresh: async () => ({}),
+        revoke: async () => {},
+      },
+    });
+
+    await bindings.upsert({
+      id: BindingStore.keyOf("teams", "u2"),
+      github_user_id: "ghuser-def",
+      access_token: "ghu_no_expiry",
+      refresh_token: null,
+      expires_at: null,
+      scopes: [],
+    });
+
+    const result = await service.GetToken({
+      surface: "teams",
+      surface_user_id: "u2",
+    });
+    assert.strictEqual(result.token, "ghu_no_expiry");
+  });
+});

--- a/services/ghauth/test/query-reauth.test.js
+++ b/services/ghauth/test/query-reauth.test.js
@@ -1,0 +1,118 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { createMockConfig } from "@forwardimpact/libharness";
+import { createMockStorage } from "@forwardimpact/libharness/mock";
+import { GhauthService } from "../index.js";
+import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
+import { RevokedError } from "../src/github-oauth.js";
+
+describe("ghauth query-reauth (SC#6)", () => {
+  test("expired token with revoked refresh returns re_auth_required", async () => {
+    const storage = createMockStorage();
+    const config = createMockConfig("ghauth", {
+      link_base_url: "http://localhost:3007",
+    });
+    const bindings = new BindingStore(storage);
+    const service = new GhauthService(config, {
+      bindings,
+      flows: new FlowStore(storage),
+      grants: new GrantStore(storage),
+      github: {
+        authorizeUrl: () => "",
+        exchangeCode: async () => ({}),
+        refresh: async () => {
+          throw new RevokedError();
+        },
+        revoke: async () => {},
+      },
+    });
+
+    await bindings.upsert({
+      id: BindingStore.keyOf("teams", "u1"),
+      github_user_id: "ghuser-abc",
+      access_token: "ghu_expired",
+      refresh_token: "ghr_revoked",
+      expires_at: Date.now() - 1000,
+      scopes: [],
+    });
+
+    const result = await service.GetToken({
+      surface: "teams",
+      surface_user_id: "u1",
+    });
+
+    assert.ok(result.re_auth_required, "result contains re_auth_required");
+    assert.strictEqual(result.token, undefined, "no token returned");
+    assert.strictEqual(result.link_required, undefined, "not link_required");
+  });
+
+  test("expired token with no refresh_token returns re_auth_required", async () => {
+    const storage = createMockStorage();
+    const config = createMockConfig("ghauth", {
+      link_base_url: "http://localhost:3007",
+    });
+    const bindings = new BindingStore(storage);
+    const service = new GhauthService(config, {
+      bindings,
+      flows: new FlowStore(storage),
+      grants: new GrantStore(storage),
+      github: {
+        authorizeUrl: () => "",
+        exchangeCode: async () => ({}),
+        refresh: async () => ({}),
+        revoke: async () => {},
+      },
+    });
+
+    await bindings.upsert({
+      id: BindingStore.keyOf("teams", "u2"),
+      github_user_id: "ghuser-def",
+      access_token: "ghu_expired_no_refresh",
+      refresh_token: null,
+      expires_at: Date.now() - 1000,
+      scopes: [],
+    });
+
+    const result = await service.GetToken({
+      surface: "teams",
+      surface_user_id: "u2",
+    });
+
+    assert.ok(result.re_auth_required, "result contains re_auth_required");
+  });
+
+  test("transient refresh error propagates as error, not re_auth_required", async () => {
+    const storage = createMockStorage();
+    const config = createMockConfig("ghauth", {
+      link_base_url: "http://localhost:3007",
+    });
+    const bindings = new BindingStore(storage);
+    const service = new GhauthService(config, {
+      bindings,
+      flows: new FlowStore(storage),
+      grants: new GrantStore(storage),
+      github: {
+        authorizeUrl: () => "",
+        exchangeCode: async () => ({}),
+        refresh: async () => {
+          throw new Error("network timeout");
+        },
+        revoke: async () => {},
+      },
+    });
+
+    await bindings.upsert({
+      id: BindingStore.keyOf("teams", "u3"),
+      github_user_id: "ghuser-ghi",
+      access_token: "ghu_expired",
+      refresh_token: "ghr_valid",
+      expires_at: Date.now() - 1000,
+      scopes: [],
+    });
+
+    await assert.rejects(
+      () => service.GetToken({ surface: "teams", surface_user_id: "u3" }),
+      { message: "network timeout" },
+    );
+  });
+});

--- a/services/ghauth/test/query-unlinked.test.js
+++ b/services/ghauth/test/query-unlinked.test.js
@@ -1,0 +1,50 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { createMockConfig } from "@forwardimpact/libharness";
+import { createMockStorage } from "@forwardimpact/libharness/mock";
+import { GhauthService } from "../index.js";
+import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
+
+describe("ghauth query-unlinked (SC#5)", () => {
+  test("unlinked user returns link_required with authorize_url", async () => {
+    const storage = createMockStorage();
+    const config = createMockConfig("ghauth", {
+      link_base_url: "http://localhost:3007",
+    });
+    const service = new GhauthService(config, {
+      bindings: new BindingStore(storage),
+      flows: new FlowStore(storage),
+      grants: new GrantStore(storage),
+      github: {
+        authorizeUrl: () => "",
+        exchangeCode: async () => ({}),
+        refresh: async () => ({}),
+        revoke: async () => {},
+      },
+    });
+
+    const result = await service.GetToken({
+      surface: "teams",
+      surface_user_id: "unknown",
+    });
+
+    assert.ok(result.link_required, "result contains link_required");
+    assert.ok(
+      result.link_required.authorize_url,
+      "link_required has authorize_url",
+    );
+    assert.ok(
+      result.link_required.authorize_url.includes("/authorize"),
+      "URL contains /authorize path",
+    );
+    assert.ok(
+      result.link_required.authorize_url.includes("surface=teams"),
+      "URL carries surface param",
+    );
+    assert.ok(
+      result.link_required.authorize_url.includes("surface_user_id=unknown"),
+      "URL carries surface_user_id param",
+    );
+    assert.strictEqual(result.token, undefined, "no token returned");
+  });
+});

--- a/services/ghauth/test/smoke.test.js
+++ b/services/ghauth/test/smoke.test.js
@@ -1,0 +1,33 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { createMockConfig } from "@forwardimpact/libharness";
+import { createMockStorage } from "@forwardimpact/libharness/mock";
+import { GhauthService } from "../index.js";
+import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
+
+describe("ghauth smoke (SC#1)", () => {
+  test("service constructs and GetToken returns a response object", async () => {
+    const storage = createMockStorage();
+    const config = createMockConfig("ghauth", {
+      link_base_url: "http://localhost:3007",
+    });
+    const service = new GhauthService(config, {
+      bindings: new BindingStore(storage),
+      flows: new FlowStore(storage),
+      grants: new GrantStore(storage),
+      github: {
+        authorizeUrl: () => "http://gh",
+        exchangeCode: async () => ({}),
+        refresh: async () => ({}),
+        revoke: async () => {},
+      },
+    });
+
+    const result = await service.GetToken({
+      surface: "teams",
+      surface_user_id: "u1",
+    });
+    assert.ok(result, "GetToken returns a response");
+    assert.strictEqual(typeof result, "object");
+  });
+});

--- a/services/msbridge/README.md
+++ b/services/msbridge/README.md
@@ -17,19 +17,25 @@ conversations and the Kata agent team.
 - A GitHub token with `actions:write` on `forwardimpact/monorepo`.
   `libconfig` falls back to `gh auth token` when `GH_TOKEN` is not set in
   `.env`, so `gh auth login` is sufficient.
-- Credentials (`MICROSOFT_APP_ID`, `MICROSOFT_APP_PASSWORD`,
-  `MICROSOFT_APP_TENANT_ID`) and service params
-  (`SERVICE_MSBRIDGE_GITHUB_REPO`, `SERVICE_MSBRIDGE_CALLBACK_BASE_URL`)
-  in `.env`. All config is loaded by `libconfig` via
-  `createServiceConfig("msbridge")`.
+
+Configuration (loaded via `createServiceConfig("msbridge")`):
+
+| Env var | Purpose |
+| --- | --- |
+| `SERVICE_MSBRIDGE_URL` | Listen URL (default `http://localhost:3978`) |
+| `SERVICE_MSBRIDGE_GITHUB_REPO` | `owner/repo` target |
+| `SERVICE_MSBRIDGE_CALLBACK_BASE_URL` | Public URL the workflow POSTs callbacks to |
+| `MICROSOFT_APP_ID` | Azure Bot application id |
+| `MICROSOFT_APP_PASSWORD` | Azure Bot client secret |
+| `MICROSOFT_APP_TENANT_ID` | Azure AD tenant id |
 
 ## Running
 
 Add `mstunnel` and `msbridge` to `config/config.json` under
 `init.services` — see [`config/CLAUDE.md`](../../config/CLAUDE.md) for the
-entry format. List the tunnel before the bridge so that restarting the
-bridge does not cycle the tunnel (declaration order determines restart
-scope).
+entry format. List the tunnel with the other tunnels (before services) so
+that restarting the bridge does not cycle the tunnel (declaration order
+determines restart scope).
 
 Start both services:
 
@@ -44,14 +50,13 @@ every restart. After starting, check the tunnel log for the assigned URL:
 cat data/logs/mstunnel/current | grep trycloudflare.com
 ```
 
-Set that URL as the Azure Bot messaging endpoint in the Azure portal
-(Settings → Configuration):
-`https://<tunnel-domain>/api/messages`.
+### Azure Bot messaging endpoint
 
-Also set `SERVICE_MSBRIDGE_CALLBACK_BASE_URL` in `.env` to the same
-tunnel domain (without the `/api/messages` path) so the bridge can
-receive workflow callbacks. Then restart only the bridge to pick up the
-new value:
+In the Azure portal (Settings → Configuration), set the messaging endpoint
+to `https://<tunnel-domain>/api/messages`.
+
+Set `SERVICE_MSBRIDGE_CALLBACK_BASE_URL` in `.env` to the tunnel domain
+(without any path), then restart only the bridge:
 
 ```sh
 bunx fit-rc restart msbridge

--- a/services/oauth/README.md
+++ b/services/oauth/README.md
@@ -1,0 +1,83 @@
+# OAuth Authorization Server
+
+<!-- BEGIN:description — Do not edit. Generated from package.json. -->
+
+OAuth 2.1 authorization server adapter — protocol-only HTTP front that delegates
+to a configured provider backend over gRPC.
+
+<!-- END:description -->
+
+## Prerequisites
+
+- A running provider backend (currently `ghauth`) that implements the
+  `Begin`, `Complete`, and `Redeem` RPCs.
+
+Configuration (loaded via `createServiceConfig("oauth")`):
+
+| Env var | Purpose |
+| --- | --- |
+| `SERVICE_OAUTH_URL` | Listen URL (default `http://localhost:3007`) |
+| `SERVICE_OAUTH_ISSUER` | Authorization server issuer URL (used in metadata document) |
+| `SERVICE_OAUTH_PROVIDER` | Backend provider service name, resolved via `createClient` (default `ghauth`) |
+
+## Running
+
+Add `oauth` to `config/config.json` under `init.services` — see
+[`config/CLAUDE.md`](../../config/CLAUDE.md) for the entry format. List
+`oauthtunnel` with the other tunnels (before services) and `ghauth`
+before `oauth` (dependency first).
+
+Start the service:
+
+```sh
+just rc-start
+```
+
+The tunnel uses a quick `trycloudflare.com` hostname that changes on
+every restart. After starting, check the tunnel log for the assigned URL:
+
+```sh
+cat data/logs/oauthtunnel/current | grep trycloudflare.com
+```
+
+Set the tunnel domain as `SERVICE_GHAUTH_LINK_BASE_URL` in `.env` (so
+`ghauth` composes the correct `LinkRequired.authorize_url`), then restart
+the auth services:
+
+```sh
+bunx fit-rc restart ghauth
+```
+
+The tunnel keeps its hostname across service restarts.
+
+## Endpoints
+
+| Route | Method | Description |
+| --- | --- | --- |
+| `/.well-known/oauth-authorization-server` | GET | AS metadata document |
+| `/authorize` | GET | Begin authorization — redirects to upstream provider |
+| `/callback` | GET | Provider callback — redirects to client or renders "linked" page |
+| `/token` | POST | Exchange authorization code for token |
+| `/health` | GET | Liveness check |
+
+## Smoke test
+
+Verify the metadata document:
+
+```sh
+curl https://<tunnel-domain>/.well-known/oauth-authorization-server
+```
+
+Returns the issuer, authorization endpoint, token endpoint, supported
+response types (`code`), grant types (`authorization_code`), and code
+challenge methods (`S256`).
+
+Verify the authorize redirect:
+
+```sh
+curl -sI 'https://<tunnel-domain>/authorize?surface=test&surface_user_id=you'
+```
+
+Returns a `302` redirect to the upstream provider's authorization URL.
+The full linking flow is described in the
+[ghauth README](../ghauth/README.md#smoke-test).

--- a/services/oauth/index.js
+++ b/services/oauth/index.js
@@ -1,0 +1,137 @@
+import { Hono } from "hono";
+import { serve } from "@hono/node-server";
+import * as types from "@forwardimpact/libtype";
+
+/**
+ * Create the OAuth 2.1 authorization server HTTP adapter.
+ * @param {object} options
+ * @param {object} options.config
+ * @param {object} options.logger
+ * @param {object} options.providerClient
+ * @returns {{ app: import("hono").Hono, address: () => object|null, start: () => Promise<void>, stop: () => Promise<void> }}
+ */
+export function createOauthService({ config, logger, providerClient }) {
+  const providerTypes = types[config.provider];
+  const typed = (name, obj) => providerTypes[name].fromObject(obj);
+  const app = new Hono();
+
+  app.onError((err, c) => {
+    logger.error("oauth.error", err.message);
+    return c.json({ error: "server_error" }, 500);
+  });
+
+  app.use("*", async (c, next) => {
+    await next();
+    c.header("X-Content-Type-Options", "nosniff");
+    c.header("X-Frame-Options", "DENY");
+    c.header("Cache-Control", "no-store");
+  });
+
+  const metadata = {
+    issuer: config.issuer,
+    authorization_endpoint: `${config.issuer}/authorize`,
+    token_endpoint: `${config.issuer}/token`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code"],
+    code_challenge_methods_supported: ["S256"],
+  };
+
+  app.get("/.well-known/oauth-authorization-server", (c) => c.json(metadata));
+
+  app.get("/authorize", async (c) => {
+    const { surface, surface_user_id, redirect_uri, code_challenge, scope } =
+      c.req.query();
+    if (!surface || !surface_user_id) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+    const scopes = scope ? scope.split(" ") : [];
+
+    const result = await providerClient.Begin(
+      typed("BeginRequest", {
+        surface,
+        surface_user_id,
+        redirect_uri: redirect_uri || undefined,
+        code_challenge: code_challenge || undefined,
+        scopes,
+      }),
+    );
+
+    return c.redirect(result.upstream_authorize_url, 302);
+  });
+
+  app.get("/callback", async (c) => {
+    const { code, state } = c.req.query();
+    if (!code || !state) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+
+    const result = await providerClient.Complete(
+      typed("CompleteRequest", { code, state }),
+    );
+
+    if (result.redirect_uri) {
+      const url = new URL(result.redirect_uri);
+      url.searchParams.set("code", result.downstream_code);
+      if (result.client_state)
+        url.searchParams.set("state", result.client_state);
+      return c.redirect(url.toString(), 302);
+    }
+
+    return c.html(
+      "<!DOCTYPE html><html><body><h1>Linked</h1><p>Your account has been linked. You can close this window.</p></body></html>",
+    );
+  });
+
+  app.post("/token", async (c) => {
+    const body = await c.req.parseBody();
+    if (body.grant_type && body.grant_type !== "authorization_code") {
+      return c.json({ error: "unsupported_grant_type" }, 400);
+    }
+    if (!body.code) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+    const result = await providerClient.Redeem(
+      typed("RedeemRequest", {
+        code: body.code,
+        code_verifier: body.code_verifier,
+      }),
+    );
+
+    return c.json({
+      access_token: result.access_token,
+      token_type: result.token_type,
+      expires_in: Number(result.expires_in),
+    });
+  });
+
+  app.get("/health", (c) => c.json({ status: "ok" }));
+
+  let server = null;
+
+  return {
+    app,
+    address() {
+      if (!server || typeof server.address !== "function") return null;
+      const addr = server.address();
+      if (!addr || typeof addr === "string") return null;
+      return { port: addr.port };
+    },
+    async start() {
+      const { host, port } = config;
+      await new Promise((resolve) => {
+        server = serve({ fetch: app.fetch, port, hostname: host }, (info) => {
+          logger.info("oauth.server", "listening", {
+            host,
+            port: info?.port ?? port,
+          });
+          resolve();
+        });
+      });
+    },
+    async stop() {
+      if (!server) return;
+      await new Promise((resolve) => server.close(() => resolve()));
+      server = null;
+    },
+  };
+}

--- a/services/oauth/package.json
+++ b/services/oauth/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@forwardimpact/svcoauth",
+  "version": "0.1.0",
+  "description": "OAuth 2.1 authorization server adapter — protocol-only HTTP front that delegates to a configured provider backend over gRPC.",
+  "keywords": [
+    "oauth",
+    "authorization",
+    "protocol",
+    "adapter",
+    "agent"
+  ],
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "services/oauth"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Platform Builders",
+      "goal": "Expose an OAuth 2.1 authorization server without provider-specific code",
+      "trigger": "A new identity provider needs to plug into the same authorization flow without changing the protocol layer.",
+      "bigHire": "serve standard OAuth 2.1 endpoints that delegate every provider-specific step to a gRPC backend, keeping the HTTP surface provider-agnostic.",
+      "littleHire": "redirect an authorize request to the upstream provider and exchange a callback code for a downstream token.",
+      "competesWith": "per-provider HTTP services that mix OAuth protocol handling with provider-specific exchange logic"
+    }
+  ],
+  "type": "module",
+  "main": "./index.js",
+  "bin": {
+    "fit-svcoauth": "./server.js"
+  },
+  "files": [
+    "index.js",
+    "server.js"
+  ],
+  "scripts": {
+    "test": "bun test test/*.test.js"
+  },
+  "dependencies": {
+    "@forwardimpact/libconfig": "^0.1.79",
+    "@forwardimpact/libpreflight": "^0.1.0",
+    "@forwardimpact/librpc": "^0.1.99",
+    "@forwardimpact/libtelemetry": "^0.1.42",
+    "@forwardimpact/libtype": "^0.1.0",
+    "@hono/node-server": "^2.0.2",
+    "hono": "^4.12.18"
+  },
+  "devDependencies": {
+    "@forwardimpact/libharness": "^0.1.21"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/services/oauth/server.js
+++ b/services/oauth/server.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import "@forwardimpact/libpreflight/node22";
+
+import { createClient } from "@forwardimpact/librpc";
+import { createServiceConfig } from "@forwardimpact/libconfig";
+import { createLogger } from "@forwardimpact/libtelemetry";
+import { createOauthService } from "./index.js";
+
+const config = await createServiceConfig("oauth", {
+  protocol: "http",
+  port: 3007,
+  issuer: "http://localhost:3007",
+  provider: "ghauth",
+});
+
+const logger = createLogger("oauth");
+const providerClient = await createClient(config.provider, logger);
+
+const service = createOauthService({ config, logger, providerClient });
+await service.start();
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => service.stop());
+}

--- a/services/oauth/test/authorize.test.js
+++ b/services/oauth/test/authorize.test.js
@@ -1,0 +1,109 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { createOauthService } from "../index.js";
+
+describe("oauth authorize (SC#2)", () => {
+  test("authorize endpoint redirects to upstream_authorize_url", async () => {
+    const upstreamUrl =
+      "https://github.com/login/oauth/authorize?client_id=cid&state=s1";
+    const { app } = createOauthService({
+      config: {
+        issuer: "http://localhost:3007",
+        host: "0.0.0.0",
+        port: 0,
+        provider: "ghauth",
+      },
+      logger: { info: () => {}, error: () => {} },
+      providerClient: {
+        Begin: async (req) => {
+          assert.strictEqual(req.surface, "teams");
+          assert.strictEqual(req.surface_user_id, "u1");
+          return { upstream_authorize_url: upstreamUrl, state: "s1" };
+        },
+        Complete: async () => ({}),
+        Redeem: async () => ({}),
+      },
+    });
+
+    const res = await app.request(
+      "/authorize?surface=teams&surface_user_id=u1",
+    );
+    assert.strictEqual(res.status, 302);
+    assert.strictEqual(res.headers.get("Location"), upstreamUrl);
+  });
+
+  test("callback with redirect_uri redirects to client with downstream_code", async () => {
+    const { app } = createOauthService({
+      config: {
+        issuer: "http://localhost:3007",
+        host: "0.0.0.0",
+        port: 0,
+        provider: "ghauth",
+      },
+      logger: { info: () => {}, error: () => {} },
+      providerClient: {
+        Begin: async () => ({}),
+        Complete: async () => ({
+          downstream_code: "dc-123",
+          redirect_uri: "http://client.example/cb",
+          client_state: "cs-1",
+        }),
+        Redeem: async () => ({}),
+      },
+    });
+
+    const res = await app.request("/callback?code=gh-code&state=s1");
+    assert.strictEqual(res.status, 302);
+    const location = new URL(res.headers.get("Location"));
+    assert.strictEqual(
+      location.origin + location.pathname,
+      "http://client.example/cb",
+    );
+    assert.strictEqual(location.searchParams.get("code"), "dc-123");
+    assert.strictEqual(location.searchParams.get("state"), "cs-1");
+  });
+
+  test("callback without redirect_uri renders linked page", async () => {
+    const { app } = createOauthService({
+      config: {
+        issuer: "http://localhost:3007",
+        host: "0.0.0.0",
+        port: 0,
+        provider: "ghauth",
+      },
+      logger: { info: () => {}, error: () => {} },
+      providerClient: {
+        Begin: async () => ({}),
+        Complete: async () => ({}),
+        Redeem: async () => ({}),
+      },
+    });
+
+    const res = await app.request("/callback?code=gh-code&state=s1");
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(html.includes("Linked"), "page contains Linked heading");
+  });
+
+  test("health endpoint returns ok", async () => {
+    const { app } = createOauthService({
+      config: {
+        issuer: "http://localhost:3007",
+        host: "0.0.0.0",
+        port: 0,
+        provider: "ghauth",
+      },
+      logger: { info: () => {}, error: () => {} },
+      providerClient: {
+        Begin: async () => ({}),
+        Complete: async () => ({}),
+        Redeem: async () => ({}),
+      },
+    });
+
+    const res = await app.request("/health");
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.strictEqual(body.status, "ok");
+  });
+});

--- a/services/oauth/test/metadata.test.js
+++ b/services/oauth/test/metadata.test.js
@@ -1,0 +1,60 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { createOauthService } from "../index.js";
+
+function stubProvider() {
+  return {
+    Begin: async () => ({
+      upstream_authorize_url: "https://github.com/login/oauth/authorize",
+      state: "s1",
+    }),
+    Complete: async () => ({}),
+    Redeem: async () => ({
+      access_token: "tok",
+      token_type: "bearer",
+      expires_in: 3600,
+    }),
+  };
+}
+
+function createTestService(overrides = {}) {
+  return createOauthService({
+    config: {
+      issuer: "http://localhost:3007",
+      host: "0.0.0.0",
+      port: 0,
+      provider: "ghauth",
+      ...overrides,
+    },
+    logger: { info: () => {}, error: () => {} },
+    providerClient: stubProvider(),
+  });
+}
+
+describe("oauth metadata (SC#2)", () => {
+  test("serves valid AS metadata document", async () => {
+    const { app } = createTestService();
+    const res = await app.request("/.well-known/oauth-authorization-server");
+
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.strictEqual(body.issuer, "http://localhost:3007");
+    assert.strictEqual(
+      body.authorization_endpoint,
+      "http://localhost:3007/authorize",
+    );
+    assert.strictEqual(body.token_endpoint, "http://localhost:3007/token");
+    assert.ok(body.response_types_supported.includes("code"));
+    assert.ok(body.grant_types_supported.includes("authorization_code"));
+    assert.ok(body.code_challenge_methods_supported.includes("S256"));
+  });
+
+  test("metadata includes security headers", async () => {
+    const { app } = createTestService();
+    const res = await app.request("/.well-known/oauth-authorization-server");
+
+    assert.strictEqual(res.headers.get("X-Content-Type-Options"), "nosniff");
+    assert.strictEqual(res.headers.get("X-Frame-Options"), "DENY");
+    assert.strictEqual(res.headers.get("Cache-Control"), "no-store");
+  });
+});

--- a/services/oauth/test/no-github.test.js
+++ b/services/oauth/test/no-github.test.js
@@ -1,0 +1,28 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { execSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serviceDir = resolve(__dirname, "..");
+
+describe("oauth no-github (SC#3)", () => {
+  test("no github or octokit references in oauth source (excluding tests and docs)", () => {
+    let output = "";
+    try {
+      output = execSync(
+        `rg -i 'github|octokit' ${serviceDir} -g '!test/' -g '!*.md' -g '!*.json' --no-filename`,
+        { encoding: "utf-8" },
+      );
+    } catch {
+      output = "";
+    }
+
+    assert.strictEqual(
+      output.trim(),
+      "",
+      `oauth source must not contain github/octokit references, found:\n${output}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces `services/ghauth/` — gRPC service owning the Kata Agent User App credential lifecycle (authorization-code exchange, token storage via BufferedIndex JSONL, refresh, revocation, and `GetToken(surface, surface_user_id)` query returning `token | link_required | re_auth_required`)
- Introduces `services/oauth/` — provider-agnostic OAuth 2.1 HTTP adapter (Hono) that delegates every provider-specific step to a configured gRPC backend (`ghauth`), keeping its source GitHub-free (SC#3)
- 17 tests covering all 8 success criteria: smoke, query-linked, query-unlinked, query-reauth, persistence, query-contract, metadata, authorize, no-github

## Test plan

- [x] `bun run check` passes (format, lint, jsdoc, invariants, context)
- [x] `bun run test` passes (3837 pass, 0 fail across 392 files including 17 new)
- [x] `rg -i 'github|octokit' services/oauth/ -g '!test/' -g '!*.md' -g '!*.json'` returns empty (SC#3)
- [x] Review panel: 2 high findings (flow tombstone, binding_id split) addressed; error handler and input validation added
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)