### PR TITLE
ci: push wiki via forwardimpact/fit-wiki after agent runs

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -5,21 +5,29 @@ actions (`actions/`) they consume.
 
 ## Third-party actions
 
-Four composite actions are published as standalone repos under
+Five composite actions are published as standalone repos under
 `forwardimpact/` and referenced by tag — sibling repos this monorepo
 maintains, not external dependencies:
 
 | Action | Repo | Purpose |
 |---|---|---|
-| `forwardimpact/fit-bootstrap@v1` | [fit-bootstrap](https://github.com/forwardimpact/fit-bootstrap) | Single source of truth for the FIT CI environment (Bun + cached deps + cached workspace + wiki sync + `./scripts/bootstrap.sh`) |
+| `forwardimpact/fit-bootstrap@v1` | [fit-bootstrap](https://github.com/forwardimpact/fit-bootstrap) | Single source of truth for the FIT CI environment (Bun + cached deps + cached workspace + wiki checkout + `./scripts/bootstrap.sh`) |
+| `forwardimpact/fit-wiki@v1` | [fit-wiki](https://github.com/forwardimpact/fit-wiki) | Run a `fit-wiki` agent-memory command (push, pull, audit), minting a fresh GitHub App token first |
 | `forwardimpact/fit-benchmark@v1` | [fit-benchmark](https://github.com/forwardimpact/fit-benchmark) | Coding-agent benchmarks via `fit-benchmark` CLI |
 | `forwardimpact/fit-eval@v1` | [fit-eval](https://github.com/forwardimpact/fit-eval) | Agent task execution via `fit-eval` CLI |
-| `forwardimpact/kata-agent@v1` | [kata-agent](https://github.com/forwardimpact/kata-agent) | Full Kata workflow (auth + checkout + `fit-bootstrap` + `fit-eval`) |
+| `forwardimpact/kata-agent@v1` | [kata-agent](https://github.com/forwardimpact/kata-agent) | Full Kata workflow (auth + checkout + `fit-bootstrap` + `fit-eval` + `fit-wiki`) |
 
-`kata-agent` delegates to `fit-bootstrap@v1` and `fit-eval@v1`
-internally; every workflow in this repo calls
-`forwardimpact/fit-bootstrap@v1` directly for the CI environment.
-When changing either interface, update and tag the sibling first.
+`kata-agent` delegates to `fit-bootstrap@v1`, `fit-eval@v1`, and
+`fit-wiki@v1` internally; every workflow in this repo calls
+`forwardimpact/fit-bootstrap@v1` directly for the CI environment, and
+the agent workflows call `forwardimpact/fit-wiki@v1` to push memory back
+after the run. When changing any interface, update and tag the sibling
+first.
+
+`fit-bootstrap` only **checks out** the wiki (when given a `token`); it no
+longer pushes. The start-of-job App token expires after one hour, so a
+cleanup-time push fails on long agent runs — push with `fit-wiki@v1` as an
+`always()` step after the agent, which mints a fresh token first.
 
 ### Editing a published action
 
@@ -61,9 +69,9 @@ action's own directory. Two consequences:
   `./.github/actions/<name>` — the path they have at the workspace root.
 - **A published composite action** cannot reach into its own subdirectory
   with `./sub` (the caller does not have it). Use the full repo form
-  `{owner}/{repo}/{path}@{ref}` instead — e.g.
-  `forwardimpact/fit-bootstrap/post-run@v1` references the action's own
-  `post-run/` subdirectory at the same tag.
+  `{owner}/{repo}/{path}@{ref}` instead — e.g. a hypothetical
+  `forwardimpact/fit-bootstrap/sub-action@v1` would reference the action's
+  own `sub-action/` subdirectory at the same tag.
 
 ## Matrix workflows and trace artifacts
 

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -169,6 +169,14 @@ jobs:
           task-amend: ${{ inputs.task-amend }}
           case: ${{ matrix.case.id }}
 
+      - name: Push wiki changes
+        if: always()
+        uses: forwardimpact/fit-wiki@v1
+        with:
+          command: push
+          app-id: ${{ secrets.KATA_APP_ID }}
+          app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+
       - name: Dump service logs
         if: failure()
         shell: bash

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -192,6 +192,16 @@ jobs:
           discussion-id: ${{ inputs.discussion_id }}
           resume-context: ${{ inputs.resume_context }}
 
+      # Push agent memory back with a freshly minted token — the token from
+      # job start expires after an hour and this run can take up to five.
+      - name: Push wiki changes
+        if: always()
+        uses: forwardimpact/fit-wiki@v1
+        with:
+          command: push
+          app-id: ${{ secrets.KATA_APP_ID }}
+          app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+
       # Deliver the facilitator's conclusion to an external caller (e.g. the
       # MS Teams bridge or GitHub Discussions bridge) when one is specified
       # via workflow_dispatch. Skipped on issue/PR events where inputs is

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -136,6 +136,14 @@ jobs:
           supervisor-allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,Skill,TodoWrite"
           task-amend: ${{ steps.amend.outputs.amend }}
 
+      - name: Push wiki changes
+        if: always()
+        uses: forwardimpact/fit-wiki@v1
+        with:
+          command: push
+          app-id: ${{ secrets.KATA_APP_ID }}
+          app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+
       - name: Scan logs for sensitive values
         if: always() && inputs.product == 'landmark'
         shell: bash


### PR DESCRIPTION
## Summary

- The post-run wiki push failed on long Kata jobs because the GitHub App installation token minted at job start expires after one hour. This rewires the wiki push to mint a **fresh** token at push time.
- `kata-dispatch`, `eval-guide`, and `kata-interview` now push the wiki via a new `forwardimpact/fit-wiki@v1` action as an `always()` step after their `fit-eval` run (replacing the removed `fit-bootstrap` post-run push).
- `.github/CLAUDE.md` updated for the new `fit-wiki` sibling action and the removed `post-run` sub-action.

Pairs with already-published sibling changes (live on `@v1`):
- **`forwardimpact/fit-wiki@v1`** (new) — runs `bunx fit-wiki <command>`, minting a fresh token when creds are supplied.
- **`forwardimpact/fit-bootstrap@v1`** — checkout-only; `post-run/`, the `Push wiki changes` step, and the `wiki-push` toggle removed.
- **`forwardimpact/kata-agent@v1`** — pushes via `fit-wiki@v1` (covers `kata-shift`/`kata-coaching`/`kata-storyboard`).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- [ ] A long-running agent run (e.g. `kata-dispatch`) pushes the wiki successfully past the 1-hour mark.