### PR TITLE
feat(bridges): dispatch under the requester's GitHub identity (#1340)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -76,6 +76,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # GitHub Discussions Bridge (Optional)
 # ==========================================
 # Required when running the Discussions ↔ Kata agent bridge (services/ghbridge).
+# Also requires SERVICE_GHAUTH_URL above (per-user dispatch tokens).
 # See services/ghbridge/README.md
 
 # Kata Agent Team GitHub App credentials
@@ -92,7 +93,8 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # ==========================================
 # MS Teams Bridge (Optional)
 # ==========================================
-# Required only when running the Teams ↔ Kata agent bridge (services/msbridge).
+# Required when running the Teams ↔ Kata agent bridge (services/msbridge).
+# Also requires SERVICE_GHAUTH_URL above (per-user dispatch tokens).
 # See services/msbridge/README.md
 
 # Azure AD app registration credentials

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
       "dependencies": {
         "@forwardimpact/libindex": "^0.1.38",
         "@forwardimpact/libstorage": "^0.1.78",
+        "@forwardimpact/libtype": "^0.1.0",
         "@hono/node-server": "^2.0.4",
         "hono": "^4.12.23",
       },
@@ -517,7 +518,7 @@
     },
     "libraries/libwiki": {
       "name": "@forwardimpact/libwiki",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "bin": {
         "fit-wiki": "./bin/fit-wiki.js",
       },

--- a/libraries/libbridge/CLAUDE.md
+++ b/libraries/libbridge/CLAUDE.md
@@ -55,7 +55,7 @@ Inside channel intake, the only dispatch call is:
 ```js
 await dispatcher.dispatch({
   ctx, prompt: buildPrompt(text, ctx.history),
-  ackTarget, historyText: text, callbackMeta: { threadId },
+  requester, ackTarget, historyText: text, callbackMeta: { threadId },
 });
 ```
 
@@ -104,6 +104,7 @@ its `loadDiscussionId` lens.
 | `CallbackRegistry` | token → correlation map with TTL |
 | `DiscussionContextStore` | persisted `(channel, discussion_id)` state |
 | `Dispatcher`, `dispatchWorkflow` | the dispatch dance + workflow URL |
+| `TokenResolver` | `(surface, user) → DispatchAuth` via ghauth gRPC |
 | `createCallbackHandler`, `validateCallbackPayload` | inbound-callback skeleton + payload validator |
 | `RateLimiter` | per-thread dispatch rate cap |
 | `ResumeScheduler`, `ElapsedScheduler` | suspend/resume lifecycle + chunked-setTimeout |

--- a/libraries/libbridge/package.json
+++ b/libraries/libbridge/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@forwardimpact/libindex": "^0.1.38",
     "@forwardimpact/libstorage": "^0.1.78",
+    "@forwardimpact/libtype": "^0.1.0",
     "@hono/node-server": "^2.0.4",
     "hono": "^4.12.23"
   },

--- a/libraries/libbridge/src/dispatcher.js
+++ b/libraries/libbridge/src/dispatcher.js
@@ -3,27 +3,7 @@ import { randomUUID } from "node:crypto";
 import { dispatchWorkflow } from "./dispatch.js";
 import { appendHistory } from "./history.js";
 
-/**
- * The standard "dispatch dance" both bridges perform: generate a
- * correlation ID, register the callback token, start the acknowledgement
- * (if `ackTarget` is supplied), fire the kata-dispatch workflow, append
- * history, push the dispatch timestamp, and flush the store. On failure
- * the acknowledgement is finished and the callback registration is rolled
- * back before the error rethrows.
- *
- * The caller still owns: loading/creating the context, checking the rate
- * limiter, and deciding the user-facing action when `dispatch()` throws.
- *
- * @example
- *   const { token, correlationId } = await dispatcher.dispatch({
- *     ctx,
- *     prompt,
- *     ackTarget: { subjectId: nodeId },
- *     historyText: text,
- *     callbackMeta: { discussionId },
- *     workflowInputs: { discussionId },
- *   });
- */
+/** Dispatch dance: resolve per-user token, register callback, ack, fire workflow, flush. */
 export class Dispatcher {
   #callbacks;
   #ack;
@@ -31,7 +11,7 @@ export class Dispatcher {
   #callbackBaseUrl;
   #workflowFile;
   #githubRepo;
-  #getGithubToken;
+  #tokenResolver;
 
   /**
    * @param {object} options
@@ -41,7 +21,7 @@ export class Dispatcher {
    * @param {string} options.callbackBaseUrl - Already normalised
    * @param {string} options.workflowFile
    * @param {string} options.githubRepo
-   * @param {() => Promise<string> | string} options.getGithubToken
+   * @param {import("./token-resolver.js").TokenResolver} options.tokenResolver
    */
   constructor({
     callbacks,
@@ -50,7 +30,7 @@ export class Dispatcher {
     callbackBaseUrl,
     workflowFile,
     githubRepo,
-    getGithubToken,
+    tokenResolver,
   }) {
     if (!callbacks) throw new Error("callbacks is required");
     if (!ack) throw new Error("ack is required");
@@ -60,31 +40,31 @@ export class Dispatcher {
     }
     if (!workflowFile) throw new Error("workflowFile is required");
     if (!githubRepo) throw new Error("githubRepo is required");
-    if (typeof getGithubToken !== "function") {
-      throw new Error("getGithubToken is required");
-    }
+    if (!tokenResolver) throw new Error("tokenResolver is required");
     this.#callbacks = callbacks;
     this.#ack = ack;
     this.#store = store;
     this.#callbackBaseUrl = callbackBaseUrl;
     this.#workflowFile = workflowFile;
     this.#githubRepo = githubRepo;
-    this.#getGithubToken = getGithubToken;
+    this.#tokenResolver = tokenResolver;
   }
 
   /**
    * @param {object} args
    * @param {object} args.ctx - Discussion context record (mutated)
    * @param {string} args.prompt
+   * @param {string} args.requester - Surface user id of the triggering human
    * @param {object} args.callbackMeta - Stored on the callback token
    * @param {unknown} [args.ackTarget] - If omitted, no acknowledgement is started
    * @param {string} [args.historyText] - Appended to ctx.history as the user turn on success
    * @param {object} [args.workflowInputs] - Extra fields for `dispatchWorkflow`
-   * @returns {Promise<{token: string, correlationId: string}>}
+   * @returns {Promise<{kind: "dispatched", token: string, correlationId: string} | {kind: "link_required", authorizeUrl: string} | {kind: "reauth_required"} | {kind: "transient", error: Error}>}
    */
   async dispatch({
     ctx,
     prompt,
+    requester,
     callbackMeta,
     ackTarget,
     historyText,
@@ -92,19 +72,23 @@ export class Dispatcher {
   }) {
     if (!ctx) throw new Error("ctx is required");
     if (typeof prompt !== "string") throw new Error("prompt is required");
+    if (typeof requester !== "string") throw new Error("requester is required");
+
+    const auth = await this.#tokenResolver.resolve(ctx.channel, requester);
+    if (auth.kind !== "token") return auth;
 
     const correlationId = randomUUID();
-    const token = this.#callbacks.register(correlationId, callbackMeta ?? {});
+    const mergedMeta = { ...(callbackMeta ?? {}), requester };
+    const token = this.#callbacks.register(correlationId, mergedMeta);
     ctx.pending_callbacks[token] = correlationId;
     const callbackUrl = `${this.#callbackBaseUrl}/api/callback/${token}`;
 
     if (ackTarget !== undefined) await this.#ack.start(token, ackTarget);
     try {
-      const ghToken = await this.#getGithubToken();
       await dispatchWorkflow({
         workflowFile: this.#workflowFile,
         repo: this.#githubRepo,
-        token: ghToken,
+        token: auth.token,
         prompt,
         callbackUrl,
         correlationId,
@@ -117,7 +101,7 @@ export class Dispatcher {
       ctx.last_active_at = Date.now();
       await this.#store.add(ctx);
       await this.#store.flush();
-      return { token, correlationId };
+      return { kind: "dispatched", token, correlationId };
     } catch (err) {
       if (ackTarget !== undefined) await this.#ack.finish(token, ackTarget);
       this.#callbacks.consume(token);

--- a/libraries/libbridge/src/index.js
+++ b/libraries/libbridge/src/index.js
@@ -24,6 +24,7 @@ export {
   DEFAULT_TYPING_VERBS,
 } from "./acknowledgement.js";
 export { Dispatcher } from "./dispatcher.js";
+export { TokenResolver } from "./token-resolver.js";
 export {
   CallbackHandlerError,
   createCallbackHandler,

--- a/libraries/libbridge/src/resume-scheduler.js
+++ b/libraries/libbridge/src/resume-scheduler.js
@@ -3,46 +3,7 @@ import { evaluateTrigger, parseIsoDuration } from "./triggers.js";
 
 const DEFAULT_PROMPT = "Resume requested.";
 
-/**
- * Channel-agnostic suspend/resume lifecycle for the discuss-mode trace.
- * When the workflow returns a `"recessed"` verdict, the bridge calls
- * `enterRecess(...)` to persist the trigger on
- * `ctx.open_rfcs[correlationId]`. The scheduler watches inbound activity
- * via `processInbound(ctx)` and ticking elapsed timers via the embedded
- * `ElapsedScheduler`; when a trigger fires, it redispatches the workflow
- * through the shared `Dispatcher` with a `resume_context` payload
- * linking back to the original correlation id.
- *
- * Channel-specific extras are supplied by two small constructor
- * callbacks:
- *
- *   buildCallbackMeta(ctx) -> { ... }   // matches the bridge's loadDiscussionId
- *   buildResumeInputs(ctx) -> { ... }   // extra workflow_dispatch inputs
- *
- * Both default to ghbridge's convention; msbridge overrides
- * `buildCallbackMeta` to `{ threadId: ctx.discussion_id }` when it
- * adopts resume.
- *
- * @example
- *   const scheduler = new ResumeScheduler({
- *     dispatcher,
- *     store,
- *     logger,
- *     buildCallbackMeta: (ctx) => ({ discussionId: ctx.discussion_id }),
- *     buildResumeInputs: (ctx) => ({ discussionId: ctx.discussion_id }),
- *   });
- *   // service start:
- *   await scheduler.rearm();
- *   // inbound activity:
- *   const { freshDispatchAllowed } = await scheduler.processInbound(ctx);
- *   if (freshDispatchAllowed) { ... dispatch fresh ... }
- *   // on "recessed" verdict:
- *   scheduler.enterRecess(ctx, correlationId, payload.trigger);
- *   // on "adjourned" / "failed":
- *   scheduler.cancelRecess(ctx, correlationId);
- *   // service stop:
- *   scheduler.clear();
- */
+/** Channel-agnostic suspend/resume lifecycle for the discuss-mode trace. */
 export class ResumeScheduler {
   #dispatcher;
   #store;
@@ -51,6 +12,7 @@ export class ResumeScheduler {
   #prompt;
   #buildResumeInputs;
   #buildCallbackMeta;
+  #onDeclined;
 
   /**
    * @param {object} options
@@ -60,6 +22,7 @@ export class ResumeScheduler {
    * @param {string} [options.prompt] - Default "Resume requested."
    * @param {(ctx: object) => object} [options.buildCallbackMeta]
    * @param {(ctx: object) => object} [options.buildResumeInputs]
+   * @param {((ctx: object, outcome: object) => Promise<void>) | null} [options.onDeclined]
    */
   constructor({
     dispatcher,
@@ -68,6 +31,7 @@ export class ResumeScheduler {
     prompt = DEFAULT_PROMPT,
     buildCallbackMeta = (ctx) => ({ discussionId: ctx.discussion_id }),
     buildResumeInputs = () => ({}),
+    onDeclined = null,
   }) {
     if (!dispatcher) throw new Error("dispatcher is required");
     if (!store) throw new Error("store is required");
@@ -77,12 +41,16 @@ export class ResumeScheduler {
     if (typeof buildResumeInputs !== "function") {
       throw new Error("buildResumeInputs must be a function");
     }
+    if (onDeclined != null && typeof onDeclined !== "function") {
+      throw new Error("onDeclined must be a function");
+    }
     this.#dispatcher = dispatcher;
     this.#store = store;
     this.#logger = logger ?? null;
     this.#prompt = prompt;
     this.#buildCallbackMeta = buildCallbackMeta;
     this.#buildResumeInputs = buildResumeInputs;
+    this.#onDeclined = onDeclined;
     this.#elapsed = new ElapsedScheduler({
       onFire: (cid) => this.#fireElapsed(cid),
       onError: (err, cid) =>
@@ -99,10 +67,9 @@ export class ResumeScheduler {
 
   /**
    * Begin watching `correlationId` for trigger resolution. Persists the
-   * trigger and the history index at recess time onto
-   * `ctx.open_rfcs[correlationId]`. If the trigger has an elapsed
-   * component, schedules an in-memory timer that will fire even when no
-   * inbound activity arrives. No-op if `trigger` is falsy.
+   * trigger, the history index at recess time, and the triggering
+   * requester onto `ctx.open_rfcs[correlationId]`. If the trigger has an
+   * elapsed component, schedules an in-memory timer.
    *
    * The caller is responsible for flushing the store after this call —
    * `enterRecess` mutates ctx but does not write.
@@ -110,14 +77,16 @@ export class ResumeScheduler {
    * @param {object} ctx
    * @param {string} correlationId
    * @param {import("./triggers.js").ResumeTrigger} trigger
+   * @param {string} [requester] - Surface user id of the triggering human
    */
-  enterRecess(ctx, correlationId, trigger) {
+  enterRecess(ctx, correlationId, trigger, requester) {
     if (!trigger) return;
     const openedAt = Date.now();
     ctx.open_rfcs[correlationId] = {
       trigger,
       opened_at: openedAt,
       history_index_at_open: ctx.history.length,
+      requester,
     };
     if (trigger.kind === "elapsed" && typeof trigger.elapsed === "string") {
       const dueAt = openedAt + parseIsoDuration(trigger.elapsed);
@@ -128,8 +97,7 @@ export class ResumeScheduler {
 
   /**
    * Stop watching `correlationId`. Removes the rfc from `ctx.open_rfcs`
-   * and cancels any associated elapsed timer. Idempotent — safe to call
-   * for verdicts that didn't actually recess.
+   * and cancels any associated elapsed timer. Idempotent.
    *
    * @param {object} ctx
    * @param {string} correlationId
@@ -140,29 +108,21 @@ export class ResumeScheduler {
   }
 
   /**
-   * Walk `ctx.open_rfcs`. For each rfc whose trigger has fired given the
-   * current history length and clock, redispatch the workflow with
-   * `resume_context` linking back to the original correlation id, then
-   * cancel the rfc. Returns a summary so the host can decide whether to
-   * additionally fire a fresh lead session on this inbound activity.
-   *
-   * If a redispatch fails the rfc remains armed — the host's failure
-   * recovery (next inbound activity, or the next elapsed tick) will
-   * retry.
+   * Walk `ctx.open_rfcs`. For each rfc whose trigger has fired,
+   * redispatch the workflow. Returns a summary so the host can decide
+   * whether to additionally fire a fresh lead session.
    *
    * @param {object} ctx
-   * @returns {Promise<{
-   *   fired: number,
-   *   hasOpenRfc: boolean,
-   *   freshDispatchAllowed: boolean,
-   * }>}
+   * @returns {Promise<{fired: number, hasOpenRfc: boolean, freshDispatchAllowed: boolean}>}
    */
   async processInbound(ctx) {
     const fired = this.#evaluate(ctx);
     for (const { correlationId, rfc } of fired) {
       const historySince = ctx.history.slice(rfc.history_index_at_open);
-      await this.#redispatch(ctx, correlationId, historySince);
-      this.cancelRecess(ctx, correlationId);
+      const result = await this.#redispatch(ctx, correlationId, historySince);
+      if (result.kind === "dispatched") {
+        this.cancelRecess(ctx, correlationId);
+      }
     }
     const hasOpenRfc = Object.keys(ctx.open_rfcs ?? {}).length > 0;
     return {
@@ -173,9 +133,7 @@ export class ResumeScheduler {
   }
 
   /**
-   * Rehydrate persistent elapsed timers from the store. Call once after
-   * the bridge server starts so deadlines set before a restart still
-   * fire.
+   * Rehydrate persistent elapsed timers from the store.
    * @returns {Promise<void>}
    */
   async rearm() {
@@ -213,19 +171,38 @@ export class ResumeScheduler {
   }
 
   async #redispatch(ctx, correlationId, historySince) {
+    const rfc = ctx.open_rfcs[correlationId];
+    if (!rfc.requester) {
+      this.cancelRecess(ctx, correlationId);
+      this.#logger?.info?.("resume.skip", "rfc missing requester", {
+        correlation_id: correlationId,
+      });
+      return {
+        kind: "transient",
+        error: new Error("rfc missing requester"),
+      };
+    }
     const resumeContext = JSON.stringify({
       correlation_id: correlationId,
       history_since: historySince,
     });
-    await this.#dispatcher.dispatch({
+    const result = await this.#dispatcher.dispatch({
       ctx,
       prompt: this.#prompt,
+      requester: rfc.requester,
       callbackMeta: this.#buildCallbackMeta(ctx),
       workflowInputs: {
         ...this.#buildResumeInputs(ctx),
         resumeContext,
       },
     });
+    if (result.kind !== "dispatched") {
+      this.cancelRecess(ctx, correlationId);
+      await this.#store.add(ctx);
+      await this.#store.flush();
+      if (this.#onDeclined) await this.#onDeclined(ctx, result);
+    }
+    return result;
   }
 
   async #fireElapsed(correlationId) {
@@ -233,11 +210,13 @@ export class ResumeScheduler {
     if (!found) return;
     const { ctx, rfc } = found;
     const historySince = ctx.history.slice(rfc.history_index_at_open);
-    await this.#redispatch(ctx, correlationId, historySince);
-    this.cancelRecess(ctx, correlationId);
-    ctx.last_active_at = Date.now();
-    await this.#store.add(ctx);
-    await this.#store.flush();
+    const result = await this.#redispatch(ctx, correlationId, historySince);
+    if (result.kind === "dispatched") {
+      this.cancelRecess(ctx, correlationId);
+      ctx.last_active_at = Date.now();
+      await this.#store.add(ctx);
+      await this.#store.flush();
+    }
   }
 
   async #findContextWithRfc(correlationId) {

--- a/libraries/libbridge/src/resume-scheduler.js
+++ b/libraries/libbridge/src/resume-scheduler.js
@@ -77,7 +77,7 @@ export class ResumeScheduler {
    * @param {object} ctx
    * @param {string} correlationId
    * @param {import("./triggers.js").ResumeTrigger} trigger
-   * @param {string} [requester] - Surface user id of the triggering human
+   * @param {string} requester - Surface user id of the triggering human
    */
   enterRecess(ctx, correlationId, trigger, requester) {
     if (!trigger) return;

--- a/libraries/libbridge/src/token-resolver.js
+++ b/libraries/libbridge/src/token-resolver.js
@@ -1,0 +1,41 @@
+import { ghauth } from "@forwardimpact/libtype";
+
+/** Maps ghauth GetToken oneof + gRPC transport into a discriminated DispatchAuth result. */
+export class TokenResolver {
+  #client;
+
+  /** @param {object} client - ghauth gRPC client */
+  constructor(client) {
+    if (!client) throw new Error("ghauth client is required");
+    this.#client = client;
+  }
+
+  /** @returns {Promise<{kind: string, token?: string, authorizeUrl?: string, error?: Error}>} */
+  async resolve(surface, surfaceUserId) {
+    try {
+      const req = new ghauth.GetTokenRequest({
+        surface,
+        surface_user_id: surfaceUserId,
+      });
+      const res = await this.#client.GetToken(req);
+      switch (res.result) {
+        case "token":
+          return { kind: "token", token: res.token };
+        case "link_required":
+          return {
+            kind: "link_required",
+            authorizeUrl: res.link_required.authorize_url,
+          };
+        case "re_auth_required":
+          return { kind: "reauth_required" };
+        default:
+          return {
+            kind: "transient",
+            error: new Error("unexpected GetToken result"),
+          };
+      }
+    } catch (err) {
+      return { kind: "transient", error: err };
+    }
+  }
+}

--- a/libraries/libbridge/test/dispatcher.test.js
+++ b/libraries/libbridge/test/dispatcher.test.js
@@ -57,6 +57,10 @@ function stubFetch({ onWorkflowDispatch } = {}) {
   };
 }
 
+function makeTokenResolver(token = "ghs_test") {
+  return { resolve: async () => ({ kind: "token", token }) };
+}
+
 describe("Dispatcher", () => {
   let store;
   let callbacks;
@@ -78,7 +82,7 @@ describe("Dispatcher", () => {
       callbackBaseUrl: "https://bridge.example",
       workflowFile: "kata-dispatch.yml",
       githubRepo: "owner/repo",
-      getGithubToken: async () => "ghs_test",
+      tokenResolver: makeTokenResolver(),
     });
   });
 
@@ -99,7 +103,7 @@ describe("Dispatcher", () => {
           workflowFile: "w",
           githubRepo: "r",
         }),
-    ).toThrow("getGithubToken is required");
+    ).toThrow("tokenResolver is required");
   });
 
   test("happy path: registers callback, starts ack, dispatches, appends history, flushes store", async () => {
@@ -107,18 +111,19 @@ describe("Dispatcher", () => {
     const result = await dispatcher.dispatch({
       ctx,
       prompt: "hello",
+      requester: "U_1",
       ackTarget: { subjectId: "S_1" },
       historyText: "hello",
       callbackMeta: { discussionId: "T_1" },
       workflowInputs: { discussionId: "T_1" },
     });
+    expect(result.kind).toBe("dispatched");
     expect(typeof result.token).toBe("string");
     expect(typeof result.correlationId).toBe("string");
     expect(ctx.pending_callbacks[result.token]).toBe(result.correlationId);
     expect(ctx.history).toEqual([{ role: "user", text: "hello" }]);
     expect(ctx.dispatches).toHaveLength(1);
     expect(reactions.adds).toEqual([{ subjectId: "S_1" }]);
-    expect(callbacks.peek(result.token)?.meta).toEqual({ discussionId: "T_1" });
     expect(fetchStub.calls).toHaveLength(1);
     const body = JSON.parse(fetchStub.calls[0].init.body);
     expect(body.inputs.callback_url).toBe(
@@ -135,6 +140,7 @@ describe("Dispatcher", () => {
     await dispatcher.dispatch({
       ctx,
       prompt: "resume",
+      requester: "U_1",
       callbackMeta: { discussionId: "T_1" },
       workflowInputs: { discussionId: "T_1", resumeContext: "{}" },
     });
@@ -146,6 +152,7 @@ describe("Dispatcher", () => {
     await dispatcher.dispatch({
       ctx,
       prompt: "p",
+      requester: "U_1",
       callbackMeta: {},
       ackTarget: { subjectId: "S" },
     });
@@ -157,6 +164,7 @@ describe("Dispatcher", () => {
     await dispatcher.dispatch({
       ctx,
       prompt: "p",
+      requester: "U_1",
       callbackMeta: {},
       workflowInputs: { discussionId: "D_1", resumeContext: '{"r":1}' },
     });
@@ -176,6 +184,7 @@ describe("Dispatcher", () => {
       dispatcher.dispatch({
         ctx,
         prompt: "p",
+        requester: "U_1",
         callbackMeta: {},
         ackTarget: { subjectId: "S_2" },
       }),
@@ -195,15 +204,19 @@ describe("Dispatcher", () => {
     });
     const ctx = makeCtx();
     await expect(
-      dispatcher.dispatch({ ctx, prompt: "p", callbackMeta: {} }),
+      dispatcher.dispatch({
+        ctx,
+        prompt: "p",
+        requester: "U_1",
+        callbackMeta: {},
+      }),
     ).rejects.toThrow();
     expect(reactions.removes).toHaveLength(0);
     expect(callbacks.size).toBe(0);
     expect(Object.keys(ctx.pending_callbacks)).toHaveLength(0);
   });
 
-  test("getGithubToken receives await — accepts sync or async values", async () => {
-    let calls = 0;
+  test("token resolver result is used as the dispatch token", async () => {
     dispatcher = new Dispatcher({
       callbacks,
       ack,
@@ -211,16 +224,128 @@ describe("Dispatcher", () => {
       callbackBaseUrl: "https://bridge.example",
       workflowFile: "kata-dispatch.yml",
       githubRepo: "owner/repo",
-      getGithubToken: () => {
-        calls++;
-        return "sync_token";
+      tokenResolver: makeTokenResolver("ghs_per_user"),
+    });
+    const ctx = makeCtx();
+    await dispatcher.dispatch({
+      ctx,
+      prompt: "p",
+      requester: "U_1",
+      callbackMeta: {},
+    });
+    expect(fetchStub.calls[0].init.headers.Authorization).toBe(
+      "Bearer ghs_per_user",
+    );
+  });
+
+  test("requester is required", () => {
+    const ctx = makeCtx();
+    expect(
+      dispatcher.dispatch({ ctx, prompt: "p", callbackMeta: {} }),
+    ).rejects.toThrow("requester is required");
+  });
+
+  test("link_required: no ack, no workflow, no callback registered", async () => {
+    dispatcher = new Dispatcher({
+      callbacks,
+      ack,
+      store,
+      callbackBaseUrl: "https://bridge.example",
+      workflowFile: "kata-dispatch.yml",
+      githubRepo: "owner/repo",
+      tokenResolver: {
+        resolve: async () => ({
+          kind: "link_required",
+          authorizeUrl: "https://example.com/authorize",
+        }),
       },
     });
     const ctx = makeCtx();
-    await dispatcher.dispatch({ ctx, prompt: "p", callbackMeta: {} });
-    expect(calls).toBe(1);
-    expect(fetchStub.calls[0].init.headers.Authorization).toBe(
-      "Bearer sync_token",
-    );
+    const result = await dispatcher.dispatch({
+      ctx,
+      prompt: "p",
+      requester: "U_1",
+      callbackMeta: {},
+      ackTarget: { subjectId: "S_1" },
+    });
+    expect(result.kind).toBe("link_required");
+    expect(result.authorizeUrl).toBe("https://example.com/authorize");
+    expect(reactions.adds).toHaveLength(0);
+    expect(fetchStub.calls).toHaveLength(0);
+    expect(callbacks.size).toBe(0);
+    expect(ctx.history).toEqual([]);
+    expect(ctx.dispatches).toEqual([]);
+  });
+
+  test("reauth_required: no ack, no workflow, no callback registered", async () => {
+    dispatcher = new Dispatcher({
+      callbacks,
+      ack,
+      store,
+      callbackBaseUrl: "https://bridge.example",
+      workflowFile: "kata-dispatch.yml",
+      githubRepo: "owner/repo",
+      tokenResolver: {
+        resolve: async () => ({ kind: "reauth_required" }),
+      },
+    });
+    const ctx = makeCtx();
+    const result = await dispatcher.dispatch({
+      ctx,
+      prompt: "p",
+      requester: "U_1",
+      callbackMeta: {},
+      ackTarget: { subjectId: "S_1" },
+    });
+    expect(result.kind).toBe("reauth_required");
+    expect(reactions.adds).toHaveLength(0);
+    expect(fetchStub.calls).toHaveLength(0);
+    expect(callbacks.size).toBe(0);
+    expect(ctx.history).toEqual([]);
+    expect(ctx.dispatches).toEqual([]);
+  });
+
+  test("transient: no ack, no workflow, no callback registered", async () => {
+    dispatcher = new Dispatcher({
+      callbacks,
+      ack,
+      store,
+      callbackBaseUrl: "https://bridge.example",
+      workflowFile: "kata-dispatch.yml",
+      githubRepo: "owner/repo",
+      tokenResolver: {
+        resolve: async () => ({
+          kind: "transient",
+          error: new Error("UNAVAILABLE"),
+        }),
+      },
+    });
+    const ctx = makeCtx();
+    const result = await dispatcher.dispatch({
+      ctx,
+      prompt: "p",
+      requester: "U_1",
+      callbackMeta: {},
+      ackTarget: { subjectId: "S_1" },
+    });
+    expect(result.kind).toBe("transient");
+    expect(reactions.adds).toHaveLength(0);
+    expect(fetchStub.calls).toHaveLength(0);
+    expect(callbacks.size).toBe(0);
+    expect(ctx.history).toEqual([]);
+    expect(ctx.dispatches).toEqual([]);
+  });
+
+  test("requester round-trips in callbackMeta", async () => {
+    const ctx = makeCtx();
+    const result = await dispatcher.dispatch({
+      ctx,
+      prompt: "p",
+      requester: "U_1",
+      callbackMeta: { discussionId: "T_1" },
+    });
+    expect(result.kind).toBe("dispatched");
+    expect(callbacks.peek(result.token).meta.requester).toBe("U_1");
+    expect(callbacks.peek(result.token).meta.discussionId).toBe("T_1");
   });
 });

--- a/libraries/libbridge/test/resume-scheduler.test.js
+++ b/libraries/libbridge/test/resume-scheduler.test.js
@@ -43,7 +43,23 @@ function stubFetch() {
   };
 }
 
-function buildEnv({ buildCallbackMeta, buildResumeInputs } = {}) {
+function makeTokenResolver(token = "ghs_test") {
+  const calls = [];
+  return {
+    calls,
+    resolve: async (surface, surfaceUserId) => {
+      calls.push({ surface, surfaceUserId });
+      return { kind: "token", token };
+    },
+  };
+}
+
+function buildEnv({
+  buildCallbackMeta,
+  buildResumeInputs,
+  onDeclined,
+  tokenResolver,
+} = {}) {
   const store = new DiscussionContextStore(createMockStorage());
   const callbacks = new CallbackRegistry();
   const ack = new Acknowledgement({
@@ -52,6 +68,7 @@ function buildEnv({ buildCallbackMeta, buildResumeInputs } = {}) {
       remove: async () => {},
     },
   });
+  const tr = tokenResolver ?? makeTokenResolver();
   const dispatcher = new Dispatcher({
     callbacks,
     ack,
@@ -59,15 +76,16 @@ function buildEnv({ buildCallbackMeta, buildResumeInputs } = {}) {
     callbackBaseUrl: "https://bridge.example",
     workflowFile: "kata-dispatch.yml",
     githubRepo: "owner/repo",
-    getGithubToken: async () => "ghs_test",
+    tokenResolver: tr,
   });
   const scheduler = new ResumeScheduler({
     dispatcher,
     store,
     buildCallbackMeta,
     buildResumeInputs,
+    onDeclined,
   });
-  return { store, callbacks, dispatcher, scheduler };
+  return { store, callbacks, dispatcher, scheduler, tokenResolver: tr };
 }
 
 describe("ResumeScheduler", () => {
@@ -103,27 +121,49 @@ describe("ResumeScheduler", () => {
     ).toThrow();
   });
 
-  test("enterRecess stores trigger, opened_at, history_index_at_open on ctx.open_rfcs", () => {
+  test("rejects non-function onDeclined", () => {
+    expect(
+      () =>
+        new ResumeScheduler({
+          dispatcher: env.dispatcher,
+          store: env.store,
+          onDeclined: "nope",
+        }),
+    ).toThrow("onDeclined must be a function");
+  });
+
+  test("enterRecess stores trigger, opened_at, history_index_at_open, and requester on ctx.open_rfcs", () => {
     const ctx = makeCtx({
       history: [{ role: "user", text: "first" }],
     });
-    env.scheduler.enterRecess(ctx, "corr-1", {
-      kind: "missing_input",
-      replies: 2,
-    });
+    env.scheduler.enterRecess(
+      ctx,
+      "corr-1",
+      {
+        kind: "missing_input",
+        replies: 2,
+      },
+      "U_1",
+    );
     const rfc = ctx.open_rfcs["corr-1"];
     expect(rfc.trigger).toEqual({ kind: "missing_input", replies: 2 });
     expect(rfc.history_index_at_open).toBe(1);
     expect(typeof rfc.opened_at).toBe("number");
     expect(rfc.due_at).toBeUndefined();
+    expect(rfc.requester).toBe("U_1");
   });
 
   test("enterRecess with elapsed trigger schedules a timer and records due_at", () => {
     const ctx = makeCtx();
-    env.scheduler.enterRecess(ctx, "corr-2", {
-      kind: "elapsed",
-      elapsed: "PT5S",
-    });
+    env.scheduler.enterRecess(
+      ctx,
+      "corr-2",
+      {
+        kind: "elapsed",
+        elapsed: "PT5S",
+      },
+      "U_1",
+    );
     expect(ctx.open_rfcs["corr-2"].due_at).toBe(
       ctx.open_rfcs["corr-2"].opened_at + 5000,
     );
@@ -132,16 +172,21 @@ describe("ResumeScheduler", () => {
 
   test("enterRecess with falsy trigger is a no-op", () => {
     const ctx = makeCtx();
-    env.scheduler.enterRecess(ctx, "corr-3", null);
+    env.scheduler.enterRecess(ctx, "corr-3", null, "U_1");
     expect(ctx.open_rfcs["corr-3"]).toBeUndefined();
   });
 
   test("cancelRecess removes the rfc and cancels its timer; idempotent", () => {
     const ctx = makeCtx();
-    env.scheduler.enterRecess(ctx, "corr-4", {
-      kind: "elapsed",
-      elapsed: "PT5S",
-    });
+    env.scheduler.enterRecess(
+      ctx,
+      "corr-4",
+      {
+        kind: "elapsed",
+        elapsed: "PT5S",
+      },
+      "U_1",
+    );
     expect(env.scheduler.size).toBe(1);
     env.scheduler.cancelRecess(ctx, "corr-4");
     expect(ctx.open_rfcs["corr-4"]).toBeUndefined();
@@ -161,11 +206,15 @@ describe("ResumeScheduler", () => {
 
   test("processInbound returns freshDispatchAllowed=false when an rfc is open but no trigger fired", async () => {
     const ctx = makeCtx({ history: [{ role: "user", text: "x" }] });
-    env.scheduler.enterRecess(ctx, "corr-5", {
-      kind: "missing_input",
-      replies: 5,
-    });
-    // Append one more so we have replies=1 since recess (one < 5).
+    env.scheduler.enterRecess(
+      ctx,
+      "corr-5",
+      {
+        kind: "missing_input",
+        replies: 5,
+      },
+      "U_1",
+    );
     ctx.history.push({ role: "user", text: "y" });
     const result = await env.scheduler.processInbound(ctx);
     expect(result).toEqual({
@@ -179,11 +228,15 @@ describe("ResumeScheduler", () => {
   test("processInbound fires a 'missing_input' trigger and redispatches with resume_context", async () => {
     const ctx = makeCtx();
     await env.store.add(ctx);
-    env.scheduler.enterRecess(ctx, "corr-fire", {
-      kind: "missing_input",
-      replies: 2,
-    });
-    // Two new replies since recess.
+    env.scheduler.enterRecess(
+      ctx,
+      "corr-fire",
+      {
+        kind: "missing_input",
+        replies: 2,
+      },
+      "U_1",
+    );
     ctx.history.push({ role: "user", text: "one" });
     ctx.history.push({ role: "user", text: "two" });
 
@@ -202,8 +255,6 @@ describe("ResumeScheduler", () => {
       { role: "user", text: "one" },
       { role: "user", text: "two" },
     ]);
-    // Default buildCallbackMeta keys discussionId from ctx.discussion_id.
-    expect(inputs.discussion_id).toBeUndefined(); // default buildResumeInputs returns {}
   });
 
   test("buildCallbackMeta override flows into the registered callback meta (msbridge convention)", async () => {
@@ -214,16 +265,22 @@ describe("ResumeScheduler", () => {
     });
     const ctx = makeCtx({ id: "thread-99" });
     await env.store.add(ctx);
-    env.scheduler.enterRecess(ctx, "corr-x", {
-      kind: "missing_input",
-      replies: 1,
-    });
+    env.scheduler.enterRecess(
+      ctx,
+      "corr-x",
+      {
+        kind: "missing_input",
+        replies: 1,
+      },
+      "U_1",
+    );
     ctx.history.push({ role: "user", text: "hello" });
     await env.scheduler.processInbound(ctx);
 
     const token = Object.keys(ctx.pending_callbacks)[0];
     const stored = env.callbacks.peek(token);
-    expect(stored.meta).toEqual({ threadId: "thread-99" });
+    expect(stored.meta.threadId).toBe("thread-99");
+    expect(stored.meta.requester).toBe("U_1");
   });
 
   test("buildResumeInputs override flows into the workflow_dispatch inputs (ghbridge convention)", async () => {
@@ -234,10 +291,15 @@ describe("ResumeScheduler", () => {
     });
     const ctx = makeCtx({ id: "D_99" });
     await env.store.add(ctx);
-    env.scheduler.enterRecess(ctx, "corr-y", {
-      kind: "missing_input",
-      replies: 1,
-    });
+    env.scheduler.enterRecess(
+      ctx,
+      "corr-y",
+      {
+        kind: "missing_input",
+        replies: 1,
+      },
+      "U_1",
+    );
     ctx.history.push({ role: "user", text: "hi" });
     await env.scheduler.processInbound(ctx);
     const inputs = JSON.parse(fetchStub.calls[0].init.body).inputs;
@@ -246,50 +308,40 @@ describe("ResumeScheduler", () => {
   });
 
   test("rearm reschedules timers from persisted due_at across a fresh process", async () => {
-    // Seed via the existing store, then reopen the same storage with a
-    // fresh scheduler — that mirrors a service restart.
     const ctx = makeCtx({ id: "D_rearm" });
     ctx.open_rfcs["corr-z"] = {
       trigger: { kind: "elapsed", elapsed: "PT60S" },
       opened_at: Date.now(),
       history_index_at_open: 0,
       due_at: Date.now() + 60_000,
+      requester: "U_1",
     };
     await env.store.add(ctx);
     await env.store.flush();
 
-    // Tear down the original scheduler/store and reuse the same backing.
-    const sharedStorage = env.store._storage ?? null;
-    if (!sharedStorage) {
-      // DiscussionContextStore doesn't expose its storage handle; build a
-      // second store against the same underlying mock by direct add. The
-      // path that matters in production is `loadData()` reading JSONL —
-      // here we replay that by adding the record into a fresh store and
-      // calling rearm.
-      const freshStore = new DiscussionContextStore(createMockStorage());
-      await freshStore.add(ctx);
-      const callbacks = new CallbackRegistry();
-      const ack = new Acknowledgement({
-        reactionAdapter: { add: async () => null, remove: async () => {} },
-      });
-      const dispatcher = new Dispatcher({
-        callbacks,
-        ack,
-        store: freshStore,
-        callbackBaseUrl: "https://bridge.example",
-        workflowFile: "kata-dispatch.yml",
-        githubRepo: "owner/repo",
-        getGithubToken: async () => "t",
-      });
-      const fresh = new ResumeScheduler({ dispatcher, store: freshStore });
-      try {
-        expect(fresh.size).toBe(0);
-        await fresh.rearm();
-        expect(fresh.size).toBe(1);
-      } finally {
-        fresh.clear();
-        await freshStore.shutdown();
-      }
+    const freshStore = new DiscussionContextStore(createMockStorage());
+    await freshStore.add(ctx);
+    const callbacks = new CallbackRegistry();
+    const ack = new Acknowledgement({
+      reactionAdapter: { add: async () => null, remove: async () => {} },
+    });
+    const dispatcher = new Dispatcher({
+      callbacks,
+      ack,
+      store: freshStore,
+      callbackBaseUrl: "https://bridge.example",
+      workflowFile: "kata-dispatch.yml",
+      githubRepo: "owner/repo",
+      tokenResolver: makeTokenResolver(),
+    });
+    const fresh = new ResumeScheduler({ dispatcher, store: freshStore });
+    try {
+      expect(fresh.size).toBe(0);
+      await fresh.rearm();
+      expect(fresh.size).toBe(1);
+    } finally {
+      fresh.clear();
+      await freshStore.shutdown();
     }
   });
 
@@ -297,20 +349,92 @@ describe("ResumeScheduler", () => {
     const ctx = makeCtx({ id: "D_tick" });
     await env.store.add(ctx);
     await env.store.flush();
-    // Directly construct an rfc with a 20ms deadline.
     const dueAt = Date.now() + 20;
     ctx.open_rfcs["corr-tick"] = {
       trigger: { kind: "elapsed", elapsed: "PT60S" },
       opened_at: Date.now(),
       history_index_at_open: 0,
       due_at: dueAt,
+      requester: "U_1",
     };
     await env.store.add(ctx);
-    // Manually arm via rearm (mimics restart path).
     await env.scheduler.rearm();
     await wait(60);
     expect(fetchStub.calls.length).toBeGreaterThanOrEqual(1);
     const reloaded = await env.store.loadByChannel("test-channel", "D_tick");
     expect(reloaded.open_rfcs["corr-tick"]).toBeUndefined();
+  });
+
+  test("resume redispatch passes recorded requester to dispatch", async () => {
+    const tr = makeTokenResolver();
+    env = buildEnv({ tokenResolver: tr });
+    const ctx = makeCtx();
+    await env.store.add(ctx);
+    env.scheduler.enterRecess(
+      ctx,
+      "corr-req",
+      {
+        kind: "missing_input",
+        replies: 1,
+      },
+      "U_42",
+    );
+    ctx.history.push({ role: "user", text: "trigger" });
+    await env.scheduler.processInbound(ctx);
+    expect(tr.calls.length).toBeGreaterThanOrEqual(1);
+    expect(tr.calls[0].surfaceUserId).toBe("U_42");
+    expect(tr.calls[0].surface).toBe("test-channel");
+  });
+
+  test("resume declined: cancelRecess + onDeclined called", async () => {
+    const declinedCalls = [];
+    const tr = {
+      resolve: async () => ({
+        kind: "link_required",
+        authorizeUrl: "https://example.com/auth",
+      }),
+    };
+    env = buildEnv({
+      tokenResolver: tr,
+      onDeclined: async (ctx, outcome) => {
+        declinedCalls.push({
+          discussion_id: ctx.discussion_id,
+          kind: outcome.kind,
+        });
+      },
+    });
+    const ctx = makeCtx();
+    await env.store.add(ctx);
+    env.scheduler.enterRecess(
+      ctx,
+      "corr-dec",
+      {
+        kind: "missing_input",
+        replies: 1,
+      },
+      "U_1",
+    );
+    ctx.history.push({ role: "user", text: "trigger" });
+    await env.scheduler.processInbound(ctx);
+    expect(ctx.open_rfcs["corr-dec"]).toBeUndefined();
+    expect(declinedCalls).toHaveLength(1);
+    expect(declinedCalls[0].kind).toBe("link_required");
+  });
+
+  test("RFC missing requester: cancel + skip, dispatch not called", async () => {
+    const tr = makeTokenResolver();
+    env = buildEnv({ tokenResolver: tr });
+    const ctx = makeCtx();
+    await env.store.add(ctx);
+    ctx.open_rfcs["corr-old"] = {
+      trigger: { kind: "missing_input", replies: 1 },
+      opened_at: Date.now(),
+      history_index_at_open: 0,
+    };
+    ctx.history.push({ role: "user", text: "trigger" });
+    await env.scheduler.processInbound(ctx);
+    expect(ctx.open_rfcs["corr-old"]).toBeUndefined();
+    expect(tr.calls).toHaveLength(0);
+    expect(fetchStub.calls).toHaveLength(0);
   });
 });

--- a/libraries/libbridge/test/token-resolver.test.js
+++ b/libraries/libbridge/test/token-resolver.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import { TokenResolver } from "../src/token-resolver.js";
+
+function mockClient(impl) {
+  return { GetToken: impl };
+}
+
+describe("TokenResolver", () => {
+  test("rejects construction without a client", () => {
+    expect(() => new TokenResolver()).toThrow("ghauth client is required");
+    expect(() => new TokenResolver(null)).toThrow("ghauth client is required");
+  });
+
+  test("token arm returns kind=token", async () => {
+    const resolver = new TokenResolver(
+      mockClient(async () => ({ result: "token", token: "ghs_x" })),
+    );
+    const auth = await resolver.resolve("msteams", "U_1");
+    expect(auth).toEqual({ kind: "token", token: "ghs_x" });
+  });
+
+  test("link_required arm returns kind=link_required with authorizeUrl", async () => {
+    const resolver = new TokenResolver(
+      mockClient(async () => ({
+        result: "link_required",
+        link_required: { authorize_url: "https://example.com/authorize" },
+      })),
+    );
+    const auth = await resolver.resolve("msteams", "U_2");
+    expect(auth).toEqual({
+      kind: "link_required",
+      authorizeUrl: "https://example.com/authorize",
+    });
+  });
+
+  test("re_auth_required arm returns kind=reauth_required", async () => {
+    const resolver = new TokenResolver(
+      mockClient(async () => ({
+        result: "re_auth_required",
+        re_auth_required: {},
+      })),
+    );
+    const auth = await resolver.resolve("msteams", "U_3");
+    expect(auth).toEqual({ kind: "reauth_required" });
+  });
+
+  test("gRPC error folds into kind=transient", async () => {
+    const resolver = new TokenResolver(
+      mockClient(async () => {
+        throw new Error("UNAVAILABLE");
+      }),
+    );
+    const auth = await resolver.resolve("msteams", "U_4");
+    expect(auth.kind).toBe("transient");
+    expect(auth.error.message).toBe("UNAVAILABLE");
+  });
+
+  test("unexpected result arm folds into kind=transient", async () => {
+    const resolver = new TokenResolver(
+      mockClient(async () => ({ result: "unknown_arm" })),
+    );
+    const auth = await resolver.resolve("msteams", "U_5");
+    expect(auth.kind).toBe("transient");
+    expect(auth.error.message).toBe("unexpected GetToken result");
+  });
+
+  test("passes surface and surfaceUserId to the client", async () => {
+    let captured;
+    const resolver = new TokenResolver(
+      mockClient(async (req) => {
+        captured = req;
+        return { result: "token", token: "t" };
+      }),
+    );
+    await resolver.resolve("github-discussions", "42");
+    expect(captured.surface).toBe("github-discussions");
+    expect(captured.surface_user_id).toBe("42");
+  });
+});

--- a/services/ghbridge/README.md
+++ b/services/ghbridge/README.md
@@ -13,17 +13,31 @@ the Kata agent team.
   webhook subscriptions for `discussion` and `discussion_comment` events
   (see the kata-setup skill for initial App creation).
 - An installation of that App on the target repository.
-- A GitHub token with `actions:write` on the target repository.
-  `libconfig` falls back to `gh auth token` when `GH_TOKEN` is not set in
-  `.env`, so `gh auth login` is sufficient.
+- The `ghauth` service running and reachable (provides per-user GitHub
+  tokens for dispatch). Each user who triggers a dispatch must have linked
+  their GitHub account through the OAuth flow — the bridge posts a link
+  prompt on the discussion when a link is missing.
 
-Configuration (loaded via `createServiceConfig("ghbridge")`):
+The App installation token is still used for posting replies, reactions,
+and declined-dispatch notices — only the `workflow_dispatch` call uses
+the per-user token.
+
+### Dependencies
+
+| Service | Why |
+| --- | --- |
+| `ghauth` | Per-user GitHub token for `workflow_dispatch` |
+
+### Configuration
+
+Loaded via `createServiceConfig("ghbridge")`):
 
 | Env var | Purpose |
 | --- | --- |
 | `SERVICE_GHBRIDGE_URL` | Listen URL (default `http://localhost:3009`) |
 | `SERVICE_GHBRIDGE_GITHUB_REPO` | `owner/repo` target |
 | `SERVICE_GHBRIDGE_CALLBACK_BASE_URL` | Public URL the workflow POSTs callbacks to |
+| `SERVICE_GHAUTH_URL` | gRPC address of the ghauth service |
 | `SERVICE_GHBRIDGE_APP_ID` | Kata App numeric id |
 | `SERVICE_GHBRIDGE_APP_PRIVATE_KEY` | PEM contents (see § Private key format) |
 | `SERVICE_GHBRIDGE_APP_INSTALLATION_ID` | Installation id for the target repo |

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -6,6 +6,7 @@ import {
   OriginIndex,
   RateLimiter,
   ResumeScheduler,
+  TokenResolver,
   appendHistory,
   buildPrompt,
   createBridgeServer,
@@ -59,7 +60,6 @@ export class GhBridgeService {
   #tracer;
   #config;
   #verifyWebhook;
-  #getInstallationToken;
   #graphqlClient;
   #store;
   #origins;
@@ -96,11 +96,11 @@ export class GhBridgeService {
     if (typeof getInstallationToken !== "function") {
       throw new Error("getInstallationToken is required");
     }
+    if (!deps.ghauthClient) throw new Error("ghauthClient is required");
     this.#config = config;
     this.#logger = logger;
     this.#tracer = tracer;
     this.#verifyWebhook = verifyWebhook;
-    this.#getInstallationToken = getInstallationToken;
     this.#graphqlClient = deps.graphqlClient;
 
     this.#store = new DiscussionContextStore(storage);
@@ -120,7 +120,7 @@ export class GhBridgeService {
       callbackBaseUrl: normalizeBaseUrl(config.callback_base_url),
       workflowFile: WORKFLOW_FILE,
       githubRepo: config.github_repo,
-      getGithubToken: () => this.#getInstallationToken(),
+      tokenResolver: new TokenResolver(deps.ghauthClient),
     });
     this.#resume = new ResumeScheduler({
       dispatcher: this.#dispatcher,
@@ -128,6 +128,7 @@ export class GhBridgeService {
       logger,
       buildCallbackMeta: (ctx) => ({ discussionId: ctx.discussion_id }),
       buildResumeInputs: (ctx) => ({ discussionId: ctx.discussion_id }),
+      onDeclined: (ctx, outcome) => this.#renderDeclined(ctx, outcome),
     });
 
     this.#onCallback = createCallbackHandler({
@@ -232,6 +233,12 @@ export class GhBridgeService {
       return c.body(null, 204);
     }
 
+    const requester = discussion?.user?.id?.toString();
+    if (!requester) {
+      this.#logger.debug("webhook", "ignoring discussion without user id");
+      return c.body(null, 204);
+    }
+
     const span = this.#tracer.startSpan("GhBridge.HandleDiscussion", {
       kind: "SERVER",
       attributes: { discussion_id: discussionId },
@@ -249,17 +256,23 @@ export class GhBridgeService {
       }
 
       try {
-        const { correlationId } = await this.#dispatcher.dispatch({
+        const result = await this.#dispatcher.dispatch({
           ctx,
           prompt: buildPrompt(text, ctx.history),
+          requester,
           ackTarget: { subjectId: discussionId },
           historyText: text,
           callbackMeta: { discussionId },
           workflowInputs: { discussionId },
         });
-        span.addEvent("workflow_dispatched", {
-          correlation_id: correlationId,
-        });
+        if (result.kind === "dispatched") {
+          span.addEvent("workflow_dispatched", {
+            correlation_id: result.correlationId,
+          });
+        } else {
+          await this.#renderDeclined(ctx, result);
+          span.addEvent("dispatch_declined", { kind: result.kind });
+        }
         span.setOk();
         return c.body(null, 200);
       } catch (err) {
@@ -282,6 +295,9 @@ export class GhBridgeService {
       });
       return c.body(null, 204);
     }
+
+    const requester = comment?.user?.id?.toString();
+    if (!requester) return c.body(null, 204);
 
     const discussionId = discussion?.node_id;
     const text = (comment?.body ?? "").trim();
@@ -312,13 +328,17 @@ export class GhBridgeService {
           span.setOk();
           return c.body(null, 200);
         }
-        await this.#dispatcher.dispatch({
+        const result = await this.#dispatcher.dispatch({
           ctx,
           prompt: buildPrompt(text, ctx.history),
+          requester,
           ackTarget: { subjectId: comment?.node_id },
           callbackMeta: { discussionId: ctx.discussion_id },
           workflowInputs: { discussionId: ctx.discussion_id },
         });
+        if (result.kind !== "dispatched") {
+          await this.#renderDeclined(ctx, result);
+        }
       }
 
       await this.#store.add(ctx);
@@ -358,7 +378,12 @@ export class GhBridgeService {
 
     switch (payload.verdict) {
       case "recessed":
-        this.#resume.enterRecess(ctx, meta.correlationId, payload.trigger);
+        this.#resume.enterRecess(
+          ctx,
+          meta.correlationId,
+          payload.trigger,
+          meta.meta?.requester,
+        );
         break;
       case "adjourned":
         this.#resume.cancelRecess(ctx, meta.correlationId);
@@ -391,6 +416,39 @@ export class GhBridgeService {
         break;
     }
 
+    await this.#origins.flush();
+  }
+
+  async #renderDeclined(ctx, outcome) {
+    let body;
+    switch (outcome.kind) {
+      case "link_required":
+        body = `To dispatch, link your GitHub account: ${outcome.authorizeUrl}`;
+        break;
+      case "reauth_required":
+        body =
+          "Your GitHub link has expired. Please re-link your account to dispatch.";
+        break;
+      case "transient":
+        body =
+          "Unable to verify your GitHub identity right now. Please try again later.";
+        break;
+      default:
+        return;
+    }
+    const recordOrigin = async (comment) => {
+      await this.#origins.add({
+        id: comment.id,
+        discussion_id: ctx.discussion_id,
+        posted_at: Date.now(),
+      });
+    };
+    await postSingleDiscussionReply(
+      this.#graphqlClient,
+      ctx,
+      body,
+      recordOrigin,
+    );
     await this.#origins.flush();
   }
 

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -80,21 +80,16 @@ export class GhBridgeService {
    * @param {import("@forwardimpact/libtelemetry").Tracer} deps.tracer
    * @param {import("@forwardimpact/libstorage").StorageInterface} deps.storage
    * @param {(secret: string, body: string, signature: string) => Promise<boolean>} deps.verifyWebhook
-   * @param {() => Promise<string>} deps.getInstallationToken
    * @param {(query: string, vars: object) => Promise<unknown>} deps.graphqlClient
    * @param {Acknowledgement} [deps.acknowledgement] - Override (tests)
    */
   constructor(config, deps) {
-    const { logger, tracer, storage, verifyWebhook, getInstallationToken } =
-      deps;
+    const { logger, tracer, storage, verifyWebhook } = deps;
     if (!logger) throw new Error("logger is required");
     if (!tracer) throw new Error("tracer is required");
     if (!storage) throw new Error("storage is required");
     if (typeof verifyWebhook !== "function") {
       throw new Error("verifyWebhook is required");
-    }
-    if (typeof getInstallationToken !== "function") {
-      throw new Error("getInstallationToken is required");
     }
     if (!deps.ghauthClient) throw new Error("ghauthClient is required");
     this.#config = config;

--- a/services/ghbridge/server.js
+++ b/services/ghbridge/server.js
@@ -7,7 +7,7 @@ import { verify } from "@octokit/webhooks-methods";
 
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createStorage } from "@forwardimpact/libstorage";
-import { createTracer } from "@forwardimpact/librpc";
+import { clients, createTracer } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
 import { GhBridgeService } from "./index.js";
@@ -36,6 +36,10 @@ const graphqlClient = async (query, variables) => {
   });
 };
 
+const { GhauthClient } = clients;
+const ghauthConfig = await createServiceConfig("ghauth");
+const ghauthClient = new GhauthClient(ghauthConfig, logger, tracer);
+
 const service = new GhBridgeService(config, {
   logger,
   tracer,
@@ -43,6 +47,7 @@ const service = new GhBridgeService(config, {
   verifyWebhook: verify,
   getInstallationToken,
   graphqlClient,
+  ghauthClient,
 });
 
 await service.start();

--- a/services/ghbridge/test/callback.test.js
+++ b/services/ghbridge/test/callback.test.js
@@ -68,6 +68,9 @@ async function newService() {
       }
       return {};
     },
+    ghauthClient: {
+      GetToken: async () => ({ result: "token", token: "ghs_per_user" }),
+    },
   });
   await service.start();
   return {

--- a/services/ghbridge/test/dispatch-auth.test.js
+++ b/services/ghbridge/test/dispatch-auth.test.js
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { sign } from "@octokit/webhooks-methods";
+import {
+  createMockConfig,
+  createMockLogger,
+  createMockStorage,
+} from "@forwardimpact/libharness";
+
+import { GhBridgeService } from "../index.js";
+
+function makeTracer() {
+  const noop = () => {};
+  return {
+    startSpan: () => ({
+      addEvent: noop,
+      setOk: noop,
+      setError: noop,
+      end: async () => {},
+    }),
+  };
+}
+
+const SECRET = "ghbridge-test-secret-long-enough";
+
+function makeConfig() {
+  return createMockConfig("ghbridge", {
+    host: "127.0.0.1",
+    port: 0,
+    github_repo: "owner/repo",
+    callback_base_url: "https://bridge.example",
+    app_webhook_secret: SECRET,
+  });
+}
+
+function makeGhauthClient(impl) {
+  const calls = [];
+  return {
+    calls,
+    GetToken: async (req) => {
+      calls.push(req);
+      return impl(req);
+    },
+  };
+}
+
+async function postSigned(baseUrl, event, body) {
+  const json = JSON.stringify(body);
+  const signature = await sign(SECRET, json);
+  return fetch(`${baseUrl}/api/webhook`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-github-event": event,
+      "x-hub-signature-256": signature,
+    },
+    body: json,
+  });
+}
+
+describe("ghbridge dispatch-auth", () => {
+  let dispatches;
+  let graphqlCalls;
+  let originalFetch;
+
+  beforeEach(() => {
+    dispatches = [];
+    graphqlCalls = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      const target = String(url);
+      if (target.startsWith("https://api.github.com/")) {
+        dispatches.push({ url: target, init });
+        return new Response("{}", { status: 204 });
+      }
+      return originalFetch(url, init);
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function buildService(ghauthClient) {
+    let commentCounter = 0;
+    return new GhBridgeService(makeConfig(), {
+      logger: createMockLogger(),
+      tracer: makeTracer(),
+      storage: createMockStorage(),
+      verifyWebhook: (s, b, sig) =>
+        import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),
+      getInstallationToken: async () => "ghs_install",
+      graphqlClient: async (query, variables) => {
+        graphqlCalls.push({ query, variables });
+        if (query.includes("addDiscussionComment")) {
+          return {
+            addDiscussionComment: {
+              comment: { id: `C_${++commentCounter}`, url: "url" },
+            },
+          };
+        }
+        return {};
+      },
+      ghauthClient,
+    });
+  }
+
+  test("comment by A on discussion by B queries (github-discussions, A)", async () => {
+    const client = makeGhauthClient(() => ({
+      result: "token",
+      token: "ghs_user",
+    }));
+    const service = buildService(client);
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await postSigned(baseUrl, "discussion", {
+      action: "created",
+      discussion: {
+        node_id: "D_1",
+        body: "opener",
+        user: { id: 100, login: "bob" },
+      },
+    });
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0].surface).toBe("github-discussions");
+    expect(client.calls[0].surface_user_id).toBe("100");
+
+    await postSigned(baseUrl, "discussion_comment", {
+      action: "created",
+      discussion: {
+        node_id: "D_1",
+        body: "opener",
+        user: { id: 100, login: "bob" },
+      },
+      comment: {
+        body: "comment by alice",
+        node_id: "C_new",
+        user: { id: 200, login: "alice" },
+      },
+    });
+    expect(client.calls).toHaveLength(2);
+    expect(client.calls[1].surface_user_id).toBe("200");
+
+    await service.stop();
+  });
+
+  test("top-level discussion by B queries (github-discussions, B)", async () => {
+    const client = makeGhauthClient(() => ({
+      result: "token",
+      token: "ghs_user",
+    }));
+    const service = buildService(client);
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await postSigned(baseUrl, "discussion", {
+      action: "created",
+      discussion: {
+        node_id: "D_2",
+        body: "top-level body",
+        user: { id: 42, login: "carol" },
+      },
+    });
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0].surface_user_id).toBe("42");
+
+    await service.stop();
+  });
+
+  test("link_required: discussion reply with authorize URL, no workflow_dispatch", async () => {
+    const client = makeGhauthClient(() => ({
+      result: "link_required",
+      link_required: { authorize_url: "https://example.com/authorize?s=ghd" },
+    }));
+    const service = buildService(client);
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    const res = await postSigned(baseUrl, "discussion", {
+      action: "created",
+      discussion: {
+        node_id: "D_link",
+        body: "hi",
+        user: { id: 1, login: "u" },
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(dispatches).toHaveLength(0);
+    const commentCalls = graphqlCalls.filter((c) =>
+      c.query.includes("addDiscussionComment"),
+    );
+    expect(commentCalls).toHaveLength(1);
+    expect(commentCalls[0].variables.i.body).toContain(
+      "https://example.com/authorize",
+    );
+
+    await service.stop();
+  });
+
+  test("reauth_required: discussion reply with re-link prompt, no workflow_dispatch", async () => {
+    const client = makeGhauthClient(() => ({
+      result: "re_auth_required",
+      re_auth_required: {},
+    }));
+    const service = buildService(client);
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await postSigned(baseUrl, "discussion", {
+      action: "created",
+      discussion: {
+        node_id: "D_reauth",
+        body: "hi",
+        user: { id: 1, login: "u" },
+      },
+    });
+    expect(dispatches).toHaveLength(0);
+    const commentCalls = graphqlCalls.filter((c) =>
+      c.query.includes("addDiscussionComment"),
+    );
+    expect(commentCalls).toHaveLength(1);
+    expect(commentCalls[0].variables.i.body).toContain("re-link");
+
+    await service.stop();
+  });
+
+  test("transient: discussion reply with transient error, no workflow_dispatch", async () => {
+    const client = makeGhauthClient(() => {
+      throw new Error("UNAVAILABLE");
+    });
+    const service = buildService(client);
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await postSigned(baseUrl, "discussion", {
+      action: "created",
+      discussion: {
+        node_id: "D_trans",
+        body: "hi",
+        user: { id: 1, login: "u" },
+      },
+    });
+    expect(dispatches).toHaveLength(0);
+    const commentCalls = graphqlCalls.filter((c) =>
+      c.query.includes("addDiscussionComment"),
+    );
+    expect(commentCalls).toHaveLength(1);
+    expect(commentCalls[0].variables.i.body).toContain("try again later");
+
+    await service.stop();
+  });
+
+  test("token: workflow_dispatch uses per-user token", async () => {
+    const client = makeGhauthClient(() => ({
+      result: "token",
+      token: "ghs_alice_personal",
+    }));
+    const service = buildService(client);
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await postSigned(baseUrl, "discussion", {
+      action: "created",
+      discussion: {
+        node_id: "D_tok",
+        body: "hi",
+        user: { id: 1, login: "u" },
+      },
+    });
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0].init.headers.Authorization).toBe(
+      "Bearer ghs_alice_personal",
+    );
+
+    await service.stop();
+  });
+});

--- a/services/ghbridge/test/reply-path.test.js
+++ b/services/ghbridge/test/reply-path.test.js
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { sign } from "@octokit/webhooks-methods";
+import {
+  createMockConfig,
+  createMockLogger,
+  createMockStorage,
+} from "@forwardimpact/libharness";
+
+import { GhBridgeService } from "../index.js";
+import { ADD_DISCUSSION_COMMENT_MUTATION } from "../src/graphql.js";
+
+function makeTracer() {
+  const noop = () => {};
+  return {
+    startSpan: () => ({
+      addEvent: noop,
+      setOk: noop,
+      setError: noop,
+      end: async () => {},
+    }),
+  };
+}
+
+const SECRET = "ghbridge-test-secret-long-enough";
+
+function makeConfig() {
+  return createMockConfig("ghbridge", {
+    host: "127.0.0.1",
+    port: 0,
+    github_repo: "owner/repo",
+    callback_base_url: "https://bridge.example",
+    app_webhook_secret: SECRET,
+  });
+}
+
+describe("ghbridge reply path", () => {
+  let dispatches;
+  let graphqlCalls;
+  let originalFetch;
+  let service;
+
+  beforeEach(async () => {
+    dispatches = [];
+    graphqlCalls = [];
+    let commentCounter = 0;
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      const target = String(url);
+      if (target.startsWith("https://api.github.com/")) {
+        dispatches.push({ url: target, init });
+        return new Response("{}", { status: 204 });
+      }
+      return originalFetch(url, init);
+    };
+
+    service = new GhBridgeService(makeConfig(), {
+      logger: createMockLogger(),
+      tracer: makeTracer(),
+      storage: createMockStorage(),
+      verifyWebhook: (s, b, sig) =>
+        import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),
+      getInstallationToken: async () => "ghs_installation_token",
+      graphqlClient: async (query, variables) => {
+        graphqlCalls.push({ query, variables });
+        if (query.includes("addDiscussionComment")) {
+          return {
+            addDiscussionComment: {
+              comment: { id: `C_${++commentCounter}`, url: "url" },
+            },
+          };
+        }
+        return {};
+      },
+      ghauthClient: {
+        GetToken: async () => ({
+          result: "token",
+          token: "ghs_per_user_token",
+        }),
+      },
+    });
+    await service.start();
+  });
+
+  afterEach(async () => {
+    await service.stop();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("reply posting uses installation credential (graphqlClient), not per-user token", async () => {
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    const discussionEvent = {
+      action: "created",
+      discussion: {
+        node_id: "D_reply",
+        body: "rfc",
+        user: { id: 1, login: "u" },
+      },
+    };
+    const json = JSON.stringify(discussionEvent);
+    const signature = await sign(SECRET, json);
+    await fetch(`${baseUrl}/api/webhook`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-github-event": "discussion",
+        "x-hub-signature-256": signature,
+      },
+      body: json,
+    });
+
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0].init.headers.Authorization).toBe(
+      "Bearer ghs_per_user_token",
+    );
+
+    const stored = await service.store.loadByChannel(
+      "github-discussions",
+      "D_reply",
+    );
+    const token = Object.keys(stored.pending_callbacks)[0];
+    const meta = service.callbacks.peek(token);
+
+    const callbackRes = await fetch(`${baseUrl}/api/callback/${token}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        correlation_id: meta.correlationId,
+        verdict: "adjourned",
+        summary: "done",
+        replies: [{ body: "bot reply" }],
+      }),
+    });
+    expect(callbackRes.status).toBe(200);
+
+    const commentCalls = graphqlCalls.filter(
+      (c) => c.query === ADD_DISCUSSION_COMMENT_MUTATION,
+    );
+    expect(commentCalls).toHaveLength(1);
+    expect(commentCalls[0].variables.i.body).toBe("bot reply");
+  });
+});

--- a/services/ghbridge/test/resume.test.js
+++ b/services/ghbridge/test/resume.test.js
@@ -51,6 +51,9 @@ async function newService() {
       import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),
     getInstallationToken: async () => "ghs_test",
     graphqlClient: async () => ({}),
+    ghauthClient: {
+      GetToken: async () => ({ result: "token", token: "ghs_per_user" }),
+    },
   });
   await service.start();
   return {
@@ -132,7 +135,7 @@ describe("ghbridge resume", () => {
     await postSigned(baseUrl, "discussion_comment", {
       action: "created",
       discussion: { node_id: "D_resume" },
-      comment: { body: "I think yes", node_id: "C_1" },
+      comment: { body: "I think yes", node_id: "C_1", user: { id: 2 } },
     });
     let stored3 = await ctx.service.store.loadByChannel(
       "github-discussions",
@@ -143,7 +146,7 @@ describe("ghbridge resume", () => {
     await postSigned(baseUrl, "discussion_comment", {
       action: "created",
       discussion: { node_id: "D_resume" },
-      comment: { body: "agreed", node_id: "C_2" },
+      comment: { body: "agreed", node_id: "C_2", user: { id: 3 } },
     });
     stored3 = await ctx.service.store.loadByChannel(
       "github-discussions",
@@ -270,7 +273,7 @@ describe("ghbridge resume", () => {
     await postSigned(baseUrl, "discussion_comment", {
       action: "created",
       discussion: { node_id: "D_accum" },
-      comment: { body: "one", node_id: "C_1" },
+      comment: { body: "one", node_id: "C_1", user: { id: 2 } },
     });
     // No fresh dispatch should fire — there's an open RFC.
     expect(ctx.dispatches).toHaveLength(1);

--- a/services/ghbridge/test/startup.test.js
+++ b/services/ghbridge/test/startup.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createMockConfig,
+  createMockLogger,
+  createMockStorage,
+} from "@forwardimpact/libharness";
+
+import { GhBridgeService } from "../index.js";
+
+function makeTracer() {
+  const noop = () => {};
+  return {
+    startSpan: () => ({
+      addEvent: noop,
+      setOk: noop,
+      setError: noop,
+      end: async () => {},
+    }),
+  };
+}
+
+function makeConfig() {
+  return createMockConfig("ghbridge", {
+    host: "127.0.0.1",
+    port: 0,
+    github_repo: "owner/repo",
+    callback_base_url: "https://bridge.example",
+    app_webhook_secret: "secret-long-enough-for-hmac",
+  });
+}
+
+describe("ghbridge startup", () => {
+  test("construction fails when ghauthClient is absent", () => {
+    expect(
+      () =>
+        new GhBridgeService(makeConfig(), {
+          logger: createMockLogger(),
+          tracer: makeTracer(),
+          storage: createMockStorage(),
+          verifyWebhook: async () => true,
+          getInstallationToken: async () => "t",
+          graphqlClient: async () => ({}),
+        }),
+    ).toThrow("ghauthClient is required");
+  });
+});

--- a/services/ghbridge/test/webhook.test.js
+++ b/services/ghbridge/test/webhook.test.js
@@ -55,6 +55,10 @@ function buildHarness({ dispatchImpl } = {}) {
   return { dispatches, graphqlCalls, restore };
 }
 
+function makeGhauthClient(token = "ghs_per_user") {
+  return { GetToken: async () => ({ result: "token", token }) };
+}
+
 async function newService({ dispatchImpl } = {}) {
   const harness = buildHarness({ dispatchImpl });
   const config = makeConfig();
@@ -70,6 +74,7 @@ async function newService({ dispatchImpl } = {}) {
       harness.graphqlCalls.push({ query, variables });
       return { addDiscussionComment: { comment: { id: "C_1", url: "url" } } };
     },
+    ghauthClient: makeGhauthClient(),
   });
   await service.start();
   return { service, harness };

--- a/services/msbridge/README.md
+++ b/services/msbridge/README.md
@@ -14,17 +14,27 @@ conversations and the Kata agent team.
   [config-msteams.md § 1–3](../../specs/1200-teams-agent-bridge/config-msteams.md).
 - The **Microsoft Teams channel** must be enabled on the Azure Bot resource
   (Settings → Channels → add Microsoft Teams).
-- A GitHub token with `actions:write` on `forwardimpact/monorepo`.
-  `libconfig` falls back to `gh auth token` when `GH_TOKEN` is not set in
-  `.env`, so `gh auth login` is sufficient.
+- The `ghauth` service running and reachable (provides per-user GitHub
+  tokens for dispatch). Each user who triggers a dispatch must have linked
+  their GitHub account through the OAuth flow — the bridge prompts on the
+  channel when a link is missing.
 
-Configuration (loaded via `createServiceConfig("msbridge")`):
+### Dependencies
+
+| Service | Why |
+| --- | --- |
+| `ghauth` | Per-user GitHub token for `workflow_dispatch` |
+
+### Configuration
+
+Loaded via `createServiceConfig("msbridge")`:
 
 | Env var | Purpose |
 | --- | --- |
 | `SERVICE_MSBRIDGE_URL` | Listen URL (default `http://localhost:3010`) |
 | `SERVICE_MSBRIDGE_GITHUB_REPO` | `owner/repo` target |
 | `SERVICE_MSBRIDGE_CALLBACK_BASE_URL` | Public URL the workflow POSTs callbacks to |
+| `SERVICE_GHAUTH_URL` | gRPC address of the ghauth service |
 | `MICROSOFT_APP_ID` | Azure Bot application id |
 | `MICROSOFT_APP_PASSWORD` | Azure Bot client secret |
 | `MICROSOFT_APP_TENANT_ID` | Azure AD tenant id |

--- a/services/msbridge/index.js
+++ b/services/msbridge/index.js
@@ -6,6 +6,7 @@ import {
   Dispatcher,
   RateLimiter,
   ResumeScheduler,
+  TokenResolver,
   appendHistory,
   buildPrompt,
   createBridgeServer,
@@ -57,19 +58,23 @@ export class MsBridgeService {
    *   msAppId: () => string,
    *   msAppPassword: () => string,
    *   msAppTenantId: () => string,
-   *   ghToken: () => string,
    * }} config
    * @param {object} deps
    * @param {import("@forwardimpact/libtelemetry").Logger} deps.logger
    * @param {import("@forwardimpact/libtelemetry").Tracer} deps.tracer
    * @param {import("@forwardimpact/libstorage").StorageInterface} deps.storage
+   * @param {object} deps.ghauthClient - ghauth gRPC client
    * @param {object} [deps.adapter] - Bot Framework adapter override (tests)
    * @param {Acknowledgement} [deps.acknowledgement] - Override (tests)
    */
-  constructor(config, { logger, tracer, storage, adapter, acknowledgement }) {
+  constructor(
+    config,
+    { logger, tracer, storage, ghauthClient, adapter, acknowledgement },
+  ) {
     if (!logger) throw new Error("logger is required");
     if (!tracer) throw new Error("tracer is required");
     if (!storage) throw new Error("storage is required");
+    if (!ghauthClient) throw new Error("ghauthClient is required");
     this.#logger = logger;
     this.#tracer = tracer;
     this.#msAppId = () => config.msAppId();
@@ -104,7 +109,7 @@ export class MsBridgeService {
       callbackBaseUrl: normalizeBaseUrl(config.callback_base_url),
       workflowFile: WORKFLOW_FILE,
       githubRepo: config.github_repo,
-      getGithubToken: () => config.ghToken(),
+      tokenResolver: new TokenResolver(ghauthClient),
     });
     this.#resume = new ResumeScheduler({
       dispatcher: this.#dispatcher,
@@ -112,6 +117,7 @@ export class MsBridgeService {
       logger,
       buildCallbackMeta: (ctx) => ({ threadId: ctx.discussion_id }),
       buildResumeInputs: () => ({}),
+      onDeclined: (ctx, outcome) => this.#renderDeclined(ctx, outcome),
     });
 
     this.#onCallback = createCallbackHandler({
@@ -189,6 +195,9 @@ export class MsBridgeService {
     const text = (activity.text ?? "").trim();
     if (!threadId || !text) return;
 
+    const requester = activity.from?.id;
+    if (!requester) return;
+
     const span = this.#tracer.startSpan("MsBridge.HandleNewMessage", {
       kind: "SERVER",
       attributes: { thread_id: threadId },
@@ -223,16 +232,22 @@ export class MsBridgeService {
       }
 
       try {
-        const { correlationId } = await this.#dispatcher.dispatch({
+        const result = await this.#dispatcher.dispatch({
           ctx,
           prompt: buildPrompt(text, ctx.history),
+          requester,
           ackTarget: { ref, activityId: activity.id },
           callbackMeta: { threadId },
           workflowInputs: { discussionId: threadId },
         });
-        span.addEvent("workflow_dispatched", {
-          correlation_id: correlationId,
-        });
+        if (result.kind === "dispatched") {
+          span.addEvent("workflow_dispatched", {
+            correlation_id: result.correlationId,
+          });
+        } else {
+          await this.#renderDeclined(ctx, result);
+          span.addEvent("dispatch_declined", { kind: result.kind });
+        }
         span.setOk();
       } catch (err) {
         this.#logger.error("handleNewMessage", err, { thread_id: threadId });
@@ -254,7 +269,12 @@ export class MsBridgeService {
     await this.#postReplies(ref, payload.replies, ctx);
     switch (payload.verdict) {
       case "recessed":
-        this.#resume.enterRecess(ctx, meta.correlationId, payload.trigger);
+        this.#resume.enterRecess(
+          ctx,
+          meta.correlationId,
+          payload.trigger,
+          meta.meta?.requester,
+        );
         break;
       case "adjourned":
         this.#resume.cancelRecess(ctx, meta.correlationId);
@@ -287,6 +307,37 @@ export class MsBridgeService {
     for (const reply of list) {
       if (!reply || typeof reply.body !== "string") continue;
       appendHistory(ctx.history, { role: "assistant", text: reply.body });
+    }
+  }
+
+  async #renderDeclined(ctx, outcome) {
+    const ref = ctx.participants?.[0]?.metadata;
+    if (!ref) return;
+    switch (outcome.kind) {
+      case "link_required":
+        await sendReply(
+          this.#adapter,
+          this.#msAppId,
+          ref,
+          `To dispatch, link your GitHub account: ${outcome.authorizeUrl}`,
+        );
+        break;
+      case "reauth_required":
+        await sendReply(
+          this.#adapter,
+          this.#msAppId,
+          ref,
+          "Your GitHub link has expired. Please re-link your account to dispatch.",
+        );
+        break;
+      case "transient":
+        await sendReply(
+          this.#adapter,
+          this.#msAppId,
+          ref,
+          "Unable to verify your GitHub identity right now. Please try again later.",
+        );
+        break;
     }
   }
 

--- a/services/msbridge/server.js
+++ b/services/msbridge/server.js
@@ -3,7 +3,7 @@ import "@forwardimpact/libpreflight/node22";
 
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createStorage } from "@forwardimpact/libstorage";
-import { createTracer } from "@forwardimpact/librpc";
+import { clients, createTracer } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
 import { MsBridgeService } from "./index.js";
@@ -14,5 +14,14 @@ const tracer = await createTracer("msbridge");
 
 const storage = createStorage("bridges/msbridge");
 
-const service = new MsBridgeService(config, { logger, tracer, storage });
+const { GhauthClient } = clients;
+const ghauthConfig = await createServiceConfig("ghauth");
+const ghauthClient = new GhauthClient(ghauthConfig, logger, tracer);
+
+const service = new MsBridgeService(config, {
+  logger,
+  tracer,
+  storage,
+  ghauthClient,
+});
 await service.start();

--- a/services/msbridge/test/dispatch-auth.test.js
+++ b/services/msbridge/test/dispatch-auth.test.js
@@ -1,0 +1,286 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  createMockConfig,
+  createMockLogger,
+  createMockStorage,
+} from "@forwardimpact/libharness";
+
+import { MsBridgeService } from "../index.js";
+
+function makeTracer() {
+  const noop = () => {};
+  return {
+    startSpan: () => ({
+      addEvent: noop,
+      setOk: noop,
+      setError: noop,
+      end: async () => {},
+    }),
+  };
+}
+
+function makeConfig(overrides = {}) {
+  return createMockConfig("msbridge", {
+    port: 0,
+    host: "127.0.0.1",
+    github_repo: "owner/repo",
+    callback_base_url: "https://tunnel.example",
+    msAppId: () => "test-app-id",
+    msAppPassword: () => "test-password",
+    msAppTenantId: () => "test-tenant",
+    ...overrides,
+  });
+}
+
+function makeAdapter(overrides = {}) {
+  const sent = [];
+  return {
+    sent,
+    reactionActivities: [],
+    process: async (_req, res, callback) => {
+      const turnContext = {
+        activity: overrides.activity ?? { type: "message" },
+        sendActivity: async (activity) => {
+          sent.push(activity);
+        },
+      };
+      await callback(turnContext);
+      if (!res.headersSent) res.status(200).end();
+    },
+    continueConversationAsync: async (_appId, _ref, callback) => {
+      await callback({
+        sendActivity: async (activity) => {
+          sent.push(activity);
+        },
+      });
+    },
+    onTurnError: null,
+    ...overrides,
+  };
+}
+
+function makeGhauthClient(impl) {
+  const calls = [];
+  return {
+    calls,
+    GetToken: async (req) => {
+      calls.push(req);
+      return impl(req);
+    },
+  };
+}
+
+function makeActivity(threadId, fromId, text) {
+  return {
+    type: "message",
+    id: "a-1",
+    text,
+    conversation: { id: threadId },
+    channelId: "msteams",
+    serviceUrl: "https://example",
+    from: { id: fromId },
+    recipient: { id: "b" },
+  };
+}
+
+describe("msbridge dispatch-auth", () => {
+  let dispatches;
+  let originalFetch;
+
+  beforeEach(() => {
+    dispatches = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      const target = String(url);
+      if (target.startsWith("https://api.github.com/")) {
+        dispatches.push({ url: target, init });
+        return new Response("{}", { status: 204 });
+      }
+      return originalFetch(url, init);
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("sender S triggers ghauth query with (msteams, S); sender T triggers (msteams, T)", async () => {
+    const client = makeGhauthClient(() => ({
+      result: "token",
+      token: "ghs_user",
+    }));
+    const overrides = {
+      activity: makeActivity("t-1", "sender-S", "hello from S"),
+    };
+    const adapter = makeAdapter(overrides);
+    const service = new MsBridgeService(makeConfig(), {
+      logger: createMockLogger(),
+      tracer: makeTracer(),
+      storage: createMockStorage(),
+      ghauthClient: client,
+      adapter,
+    });
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "message" }),
+    });
+
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0].surface).toBe("msteams");
+    expect(client.calls[0].surface_user_id).toBe("sender-S");
+
+    overrides.activity = makeActivity("t-2", "sender-T", "hello from T");
+    await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "message" }),
+    });
+
+    expect(client.calls).toHaveLength(2);
+    expect(client.calls[1].surface_user_id).toBe("sender-T");
+
+    await service.stop();
+  });
+
+  test("link_required: channel receives authorize URL, no workflow_dispatch", async () => {
+    const client = makeGhauthClient(() => ({
+      result: "link_required",
+      link_required: {
+        authorize_url: "https://example.com/authorize?s=msteams",
+      },
+    }));
+    const adapter = makeAdapter({
+      activity: makeActivity("t-link", "U_link", "hi"),
+    });
+    const service = new MsBridgeService(makeConfig(), {
+      logger: createMockLogger(),
+      tracer: makeTracer(),
+      storage: createMockStorage(),
+      ghauthClient: client,
+      adapter,
+    });
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "message" }),
+    });
+
+    expect(dispatches).toHaveLength(0);
+    expect(
+      adapter.sent.some((m) =>
+        typeof m === "string"
+          ? m.includes("https://example.com/authorize")
+          : false,
+      ),
+    ).toBe(true);
+
+    await service.stop();
+  });
+
+  test("reauth_required: channel receives re-link prompt, no workflow_dispatch", async () => {
+    const client = makeGhauthClient(() => ({
+      result: "re_auth_required",
+      re_auth_required: {},
+    }));
+    const adapter = makeAdapter({
+      activity: makeActivity("t-reauth", "U_reauth", "hi"),
+    });
+    const service = new MsBridgeService(makeConfig(), {
+      logger: createMockLogger(),
+      tracer: makeTracer(),
+      storage: createMockStorage(),
+      ghauthClient: client,
+      adapter,
+    });
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "message" }),
+    });
+
+    expect(dispatches).toHaveLength(0);
+    expect(
+      adapter.sent.some((m) =>
+        typeof m === "string" ? m.includes("re-link") : false,
+      ),
+    ).toBe(true);
+
+    await service.stop();
+  });
+
+  test("transient: channel receives transient error, no workflow_dispatch", async () => {
+    const client = makeGhauthClient(() => {
+      throw new Error("UNAVAILABLE");
+    });
+    const adapter = makeAdapter({
+      activity: makeActivity("t-transient", "U_transient", "hi"),
+    });
+    const service = new MsBridgeService(makeConfig(), {
+      logger: createMockLogger(),
+      tracer: makeTracer(),
+      storage: createMockStorage(),
+      ghauthClient: client,
+      adapter,
+    });
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "message" }),
+    });
+
+    expect(dispatches).toHaveLength(0);
+    expect(
+      adapter.sent.some((m) =>
+        typeof m === "string" ? m.includes("try again later") : false,
+      ),
+    ).toBe(true);
+
+    await service.stop();
+  });
+
+  test("token: workflow_dispatch uses per-user token", async () => {
+    const client = makeGhauthClient(() => ({
+      result: "token",
+      token: "ghs_alice_personal",
+    }));
+    const adapter = makeAdapter({
+      activity: makeActivity("t-token", "U_alice", "deploy"),
+    });
+    const service = new MsBridgeService(makeConfig(), {
+      logger: createMockLogger(),
+      tracer: makeTracer(),
+      storage: createMockStorage(),
+      ghauthClient: client,
+      adapter,
+    });
+    await service.start();
+    const baseUrl = `http://127.0.0.1:${service.address().port}`;
+
+    await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "message" }),
+    });
+
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0].init.headers.Authorization).toBe(
+      "Bearer ghs_alice_personal",
+    );
+
+    await service.stop();
+  });
+});

--- a/services/msbridge/test/msbridge.test.js
+++ b/services/msbridge/test/msbridge.test.js
@@ -22,7 +22,6 @@ function makeConfig(overrides = {}) {
     msAppId: () => "test-app-id",
     msAppPassword: () => "test-password",
     msAppTenantId: () => "test-tenant",
-    ghToken: () => "test-gh-token",
     ...overrides,
   });
 }
@@ -75,11 +74,23 @@ function makeAdapter(overrides = {}) {
   };
 }
 
-function newService({ adapter, config: configOverrides, logger } = {}) {
+function makeGhauthClient(token = "ghs_per_user") {
+  return {
+    GetToken: async () => ({ result: "token", token }),
+  };
+}
+
+function newService({
+  adapter,
+  config: configOverrides,
+  logger,
+  ghauthClient,
+} = {}) {
   return new MsBridgeService(makeConfig(configOverrides), {
     logger: logger ?? createMockLogger(),
     tracer: makeTracer(),
     storage: createMockStorage(),
+    ghauthClient: ghauthClient ?? makeGhauthClient(),
     adapter: adapter ?? makeAdapter(),
   });
 }

--- a/services/msbridge/test/resume.test.js
+++ b/services/msbridge/test/resume.test.js
@@ -29,7 +29,6 @@ function makeConfig(configOverrides = {}) {
     msAppId: () => "test-app-id",
     msAppPassword: () => "test-password",
     msAppTenantId: () => "test-tenant",
-    ghToken: () => "test-gh-token",
     ...configOverrides,
   });
 }
@@ -109,11 +108,16 @@ describe("msbridge resume", () => {
   let dispatches;
   let originalFetch;
 
+  function makeGhauthClient(token = "ghs_per_user") {
+    return { GetToken: async () => ({ result: "token", token }) };
+  }
+
   function buildService() {
     return new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
       tracer: makeTracer(),
       storage,
+      ghauthClient: makeGhauthClient(),
       adapter,
     });
   }

--- a/services/msbridge/test/startup.test.js
+++ b/services/msbridge/test/startup.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createMockConfig,
+  createMockLogger,
+  createMockStorage,
+} from "@forwardimpact/libharness";
+
+import { MsBridgeService } from "../index.js";
+
+function makeTracer() {
+  const noop = () => {};
+  return {
+    startSpan: () => ({
+      addEvent: noop,
+      setOk: noop,
+      setError: noop,
+      end: async () => {},
+    }),
+  };
+}
+
+function makeConfig() {
+  return createMockConfig("msbridge", {
+    port: 0,
+    host: "127.0.0.1",
+    github_repo: "owner/repo",
+    callback_base_url: "https://tunnel.example",
+    msAppId: () => "test-app-id",
+    msAppPassword: () => "test-password",
+    msAppTenantId: () => "test-tenant",
+  });
+}
+
+function makeAdapter() {
+  return {
+    sent: [],
+    reactionActivities: [],
+    process: async (_req, res, callback) => {
+      await callback({
+        activity: { type: "message" },
+        sendActivity: async () => {},
+      });
+      if (!res.headersSent) res.status(200).end();
+    },
+    continueConversationAsync: async () => {},
+    onTurnError: null,
+  };
+}
+
+describe("msbridge startup", () => {
+  test("construction fails when ghauthClient is absent", () => {
+    expect(
+      () =>
+        new MsBridgeService(makeConfig(), {
+          logger: createMockLogger(),
+          tracer: makeTracer(),
+          storage: createMockStorage(),
+          adapter: makeAdapter(),
+        }),
+    ).toThrow("ghauthClient is required");
+  });
+});


### PR DESCRIPTION
## Summary

- Both bridges (`msbridge`, `ghbridge`) now acquire the dispatch token **per requester** from `ghauth` (Spec 1320) instead of using a shared static/installation token
- When no usable token exists (`LinkRequired`, `ReAuthRequired`, transient failure), the bridge prompts on the channel instead of dispatching — no dangling acknowledgement
- Resume redispatches reuse the requester recorded when the dispatch entered recess
- `ghbridge` reply/reaction posting stays on the installation credential (only dispatch uses the per-user token)

## Changes

- **`libraries/libbridge`**: New `TokenResolver` class wrapping ghauth gRPC `GetToken`; `Dispatcher` gains `requester` param and `tokenResolver` injection (replacing `getGithubToken`); `ResumeScheduler` records requester on RFC and adds `onDeclined` handler
- **`services/msbridge`**: Wires ghauth client, derives requester from `activity.from.id`, handles declined outcomes via `#renderDeclined`
- **`services/ghbridge`**: Wires ghauth client, derives requester from `discussion.user.id` (top-level) or `comment.user.id` (comments), posts declined notices via `graphqlClient` (installation credential), records origin to prevent echo loops

## Test plan

- [ ] `bun test libraries/libbridge/test/` — 151 tests (token-resolver, dispatcher, resume-scheduler)
- [ ] `bun test services/msbridge/test/` — 25 tests (dispatch-auth, startup, existing)
- [ ] `bun test services/ghbridge/test/` — 27 tests (dispatch-auth, startup, reply-path, existing)
- [ ] All 10 spec success criteria covered by named test files
- [ ] `bun run check` passes (format, lint, jsdoc, invariants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)