### PR TITLE
design(1270): integrate keyless workflow identity for hosted Kata Agent Team

### DIFF
--- a/specs/1270-kata-bridges-public-hosting/design-a.md
+++ b/specs/1270-kata-bridges-public-hosting/design-a.md
@@ -1,59 +1,92 @@
-# Design 1270-a — Public hosting for Kata bridges
+# Design 1270-a — Public hosting for the Kata Agent Team
 
-Architectural design for [spec 1270](spec.md). Builds on the bridge pattern
-established by [design 1230-a](../1230-threaded-discussion-bridges/design-a.md):
-adds tenancy to `libbridge`, multi-tenant modes to `services/ghbridge` and
-`services/msbridge`, and a new `services/tenancy` service that owns the
-installation-to-repository registry. The kata-dispatch workflow contract is
-unchanged.
+Architectural design for [spec 1270](spec.md), building on
+[design 1230-a](../1230-threaded-discussion-bridges/design-a.md). Adds
+three structural pieces to the self-hosted architecture:
+`services/apptoken` (single custody point for the public App's
+private key; mints short-lived, repo-scoped installation tokens),
+`services/tenancy` (the registry), and tenancy in `libraries/libbridge`
+(channel-agnostic resolver interface). The kata-dispatch
+workflow_dispatch input shape and callback payload schema are
+unchanged; the callback URL scheme that the bridge serves gains a
+`{tenant_id}` path segment.
 
 ## Components
 
 | Component | Responsibility |
 |---|---|
-| `libraries/libbridge` | Adds a channel-agnostic `TenantResolver` interface. Callers (the bridge services) supply a resolver implementation; libbridge does not import channel SDKs. In single-tenant mode the supplied resolver returns a fixed `default` tenant; in multi-tenant mode it calls the tenancy service. |
-| `services/tenancy` | New gRPC service. Owns the registry mapping `(channel, channel_tenant_key) → Tenant`. Owns the per-tenant **callback verification material** used to authenticate inbound workflow callbacks. Distinct from the App-level credentials that each bridge holds for outbound API calls (see below). |
-| `services/ghbridge` | Gains multi-tenant mode. Holds the single Forward Impact-owned **App private key** in process (one credential, not per-tenant) and mints per-installation tokens on demand from the resolved `channel_tenant_key`. Posts replies via that installation token. |
-| `services/msbridge` | Gains multi-tenant mode. Holds the single multi-tenant **Bot Framework credential** (one credential, not per-tenant) and validates inbound JWTs against any consenting Microsoft tenant. Resolves tenant via the activity's `tenantId`. |
-| Hosted GitHub App | Registration artifact (no code). One App owned by Forward Impact, public install URL. Permissions identical to the self-hosted Kata App. |
+| `services/apptoken` | New. Holds the single Forward Impact-owned App private key in process and mints short-lived, **repo-scoped** installation tokens. Two callable surfaces: a control-plane gRPC interface for the bridges (mutual peer authentication; substrate is a plan concern), and a **public HTTPS endpoint** reached from GitHub Actions runners (authenticated via **GitHub Actions OIDC**, with the `repository` claim bounding the issued token). |
+| `services/tenancy` | New. Owns the `(channel, channel_tenant_key) → Tenant` registry. Does not hold App-credential material (that lives only in `services/apptoken`) and does not hold any new cryptographic primitive — callback verification is achieved by tenant-binding the inherited 1230 single-use callback token, not by a new signature scheme. |
+| `libraries/libbridge` | Adds a channel-agnostic `TenantResolver` interface. Bridges supply the resolver; libbridge imports no channel SDKs. Single-tenant mode returns a fixed `default` tenant; multi-tenant mode calls `services/tenancy`. |
+| `services/ghbridge` | Gains multi-tenant mode. Calls `services/apptoken` for installation tokens (replies, reactions). Resolves tenant via `installation_id` from the webhook payload. |
+| `services/msbridge` | Gains multi-tenant mode. Holds the multi-tenant **Bot Framework credential** in process — deliberately outside `services/apptoken`'s scope, which is the GitHub App private key only; Bot Framework custody hardening is a follow-on. Validates inbound JWTs against any consenting Microsoft tenant; resolves tenant via the activity's `tenantId`. Calls `services/apptoken` for the GitHub App credential used to dispatch the customer workflow. |
+| Hosted GitHub App | Registration artifact (no code). One App owned by Forward Impact, public install URL. Permissions identical to the self-hosted Kata App; webhook subscriptions extended to include `installation`. |
 | Hosted Azure AD app + Bot resource | Registration artifact (no code). Multi-tenant, consent-on-install. One Bot Framework resource shared across consenting tenants. |
-| `TRUST.md` | Repository root document. Enumerates operator access surface for both deployment paths. |
+| `kata-setup` workflow templates | Hosted-path templates carry no reference to the hosted App's private key, replacing every customer-side path that today consumes `KATA_APP_PRIVATE_KEY` with a single OIDC call to `services/apptoken`. The specific upstream actions and input names being replaced are a plan concern. Self-hosted templates unchanged. |
+| `TRUST.md` | Repository root document. Enumerates operator access surface for both deployment paths, including what `services/apptoken` can mint and on whose behalf. |
 
 ## Data flow
+
+The hosted control plane participates in event transit (webhook → dispatch),
+reply transit (callback → channel), and **token issuance** for every kata
+workflow. It does not participate in agent execution.
 
 ```mermaid
 sequenceDiagram
     participant Ch as Channel (GH Discussions / MS Teams)
     participant Br as Hosted bridge (gh / ms)
     participant Tn as services/tenancy
+    participant AT as services/apptoken
     participant GH as GitHub Actions API
-    participant WF as kata-dispatch.yml<br/>(customer repo)
+    participant WF as kata-* workflow<br/>(customer repo)
     participant An as Anthropic API
 
     Ch->>Br: webhook (signature verified)
     Br->>Tn: ResolveTenant(channel, channel_tenant_key)
-    Tn-->>Br: Tenant{repo, verify_key_id, ...}
-    Br->>GH: workflow_dispatch (using installation token)
+    Tn-->>Br: Tenant{repo, state}
+    Br->>AT: MintInstallationToken(repo) [peer auth]
+    AT-->>Br: short-lived installation token
+    Br->>GH: workflow_dispatch (installation token, dispatch inputs)
     GH->>WF: run starts in customer repo
+    WF->>AT: MintInstallationToken(repo) [OIDC]
+    AT-->>WF: short-lived installation token
+    WF->>GH: checkout / commits / PRs / wiki push (installation token)
     WF->>An: prompt + ANTHROPIC_API_KEY (customer secret)
     An-->>WF: response
     WF->>Br: signed callback (verdict, replies)
-    Br->>Tn: VerifyCallback(tenant_id, signature)
-    Br->>Ch: post replies via installation token / Bot Framework
+    Br->>Tn: ResolveTenant(by tenant_id from URL)
+    Br->>AT: MintInstallationToken(repo) [peer auth]
+    AT-->>Br: short-lived installation token
+    Br->>Ch: post replies (installation token / Bot Framework)
 ```
 
-The control plane participates in event transit (webhook → dispatch) and reply
-transit (callback → channel). It does not participate in agent execution. The
-Anthropic key, prompt processing, tool results, and conversation execution
-live entirely inside the customer's GitHub Actions runner.
+Scheduled and event-triggered kata workflows (every workflow named in
+spec § Proposal 2 other than the bridge-dispatched `kata-dispatch.yml`
+path above) start at the `GH->>WF` step with no bridge upstream and
+re-mint via the same `WF->>AT` OIDC step. Anthropic processing
+stays inside the customer's runner.
+
+## Workflow identity
+
+`services/apptoken` is the single point of App-key custody. The key never
+leaves this process; callers receive only short-lived installation tokens.
+
+| Caller | Authentication | Token scope |
+|---|---|---|
+| Customer kata workflow run | GitHub Actions OIDC. The broker validates the OIDC token and consults `services/tenancy.resolveByRepo` to confirm the claimed `repository` has an `active` Tenant row before minting. | The single repository named in the OIDC claim. |
+| Hosted bridge | Mutual peer authentication inside the control plane (concrete substrate — mTLS, signed JWT, mesh-issued credential — is a plan concern). The bridge passes the tenant's resolved `repo` from `services/tenancy`. | The single repository the tenancy registry has on the active `Tenant` row. |
+
+`services/apptoken` rejects mint requests when the claimed repo is not
+an active installation / `active` tenant row, or when the per-tenant
+issuance rate ceiling is exceeded. Token TTL is GitHub's installation-
+token maximum; the customer workflow re-mints inside a long run.
 
 ## Tenancy abstraction
 
 `libbridge` introduces a channel-agnostic resolver. Channel-specific
-extraction (parsing a webhook body or a Bot Framework activity into a
-`(channel, channel_tenant_key)` pair) lives in the calling bridge service —
-keeping libbridge free of channel SDK dependencies per its existing
-invariants.
+extraction (parsing a webhook or Bot Framework activity into a
+`(channel, channel_tenant_key)` pair) lives in the calling bridge,
+keeping libbridge free of channel SDK dependencies.
 
 ```ts
 type ChannelTenantKey = { channel: "github-discussions" | "msteams"; key: string };
@@ -61,64 +94,73 @@ type ChannelTenantKey = { channel: "github-discussions" | "msteams"; key: string
 interface Tenant {
   tenant_id: string;        // stable uuid, registry-owned
   channel: "github-discussions" | "msteams";
-  channel_tenant_key: string;   // installation_id (GH) | azure tenantId (MS)
-  repo?: { owner: string; name: string };  // populated when state === "active"
+  channel_tenant_key: string;   // GitHub: "{installation_id}:{owner}/{name}"; MS: azure tenantId
+  repo?: { owner: string; name: string };  // required when state === "active"
   state: "pending_consent" | "active" | "revoked";
-  verify_key_id: string;        // opaque id; secret material never crosses RPC
 }
 
 interface TenantResolver {
-  resolve(k: ChannelTenantKey): Promise<Tenant>;   // only returns active tenants in multi-tenant mode
+  resolve(k: ChannelTenantKey): Promise<Tenant>;     // active tenants only
+  resolveByRepo(repo: { owner: string; name: string }): Promise<Tenant>;
+  resolveByTenantId(tenant_id: string): Promise<Tenant>;     // for callback path
 }
 ```
 
-`repo` is optional because onboarding may create rows in `pending_consent`
-before the customer maps a repository (see § Onboarding).
+`resolveByRepo` exists for `services/apptoken`'s OIDC path (which has
+a `repository` claim but no `channel_tenant_key`); both methods return
+only `state === "active"` tenants. A GitHub installation may cover
+many repositories — the registry creates one row per `(installation_id,
+repo)` pair on `repositories_added`, encoded in `channel_tenant_key`.
+Teams `pending_consent` rows lack `repo` until the customer self-serves
+the mapping (see § Onboarding).
 
-`DiscussionContext` keys gain a tenant prefix: the bridge constructs every
-storage path as `tenants/{tenant_id}/discussions/{discussion_id}` before
-calling libstorage. libstorage itself is unchanged — the isolation
-invariant is enforced by the bridge's path-construction discipline, the
-same shape `DiscussionContextStore` already uses today.
+Per-tenant storage isolation. In multi-tenant mode the bridge
+instantiates one `DiscussionContextStore` per resolved tenant, each
+under storage prefix `tenants/{tenant_id}/`; existing record keys
+(`channel:discussion_id`) and libstorage are unchanged. In
+single-tenant mode the bridge uses one store with no tenant prefix —
+self-hosted data files are read in place without migration.
 
 ## Tenant registry
-
-The tenancy service persists:
 
 | Field | Notes |
 |---|---|
 | `tenant_id` | UUID. Registry-owned. |
-| `channel_tenant_key` | GitHub `installation_id` or MS Entra `tenant_id`. Unique per channel. |
+| `channel_tenant_key` | GitHub: composite `"{installation_id}:{owner}/{name}"`. MS Entra: tenant id. Unique per channel. |
 | `repo` | Customer's `owner/name`. Set during onboarding; rotatable via re-onboarding. |
-| `verify_key_id` | Opaque id for the per-tenant callback verification material. Secret material lives in the tenancy service's keystore and never crosses the gRPC boundary; the bridge calls `VerifyCallback(tenant_id, signature, body)` instead of pulling the key. |
 | `created_at` / `last_active_at` | Lifecycle bookkeeping. |
 | `state` | `pending_consent` \| `active` \| `revoked`. Only `active` tenants resolve. |
 
-The keystore uses the libindex JSONL pattern already established in this
-repo. Production hardening (managed datastore, KMS) is deferred — see § What
-this design does not cover.
+Per-tenant callback verification reuses the inherited 1230 single-use
+token. The dispatcher registers the token bound to `(correlation_id,
+tenant_id)` and the URL is `/callback/{tenant_id}/{token}`; the
+bridge consumes the token and rejects if the URL's tenant id does not
+match the token's. No new cryptographic primitive.
+
+Substrate: libindex JSONL initially. Callback verification holds no
+per-tenant key/secret material; the verification state is the
+`(correlation_id, tenant_id)` binding the bridge's existing
+`CallbackRegistry` records at token registration. Production
+hardening of the registry substrate is deferred.
 
 ## Onboarding
 
-Hosted-mode onboarding is event-driven; self-hosted mode uses configuration,
-not runtime triggers.
+Hosted-mode onboarding is event-driven; self-hosted is configuration.
 
-| Trigger | Handler role | Effect |
+| Trigger | Handler | Effect |
 |---|---|---|
-| GitHub App `installation` webhook (`created` / `repositories_added`) | GitHub install handler in `ghbridge` | Creates a `Tenant` row keyed by `installation_id`, `state = pending_consent`. The customer maps to `owner/name` via a one-shot config endpoint to advance to `active`. |
-| Bot Framework `installationUpdate` activity (`action=add`) | Teams consent handler in `msbridge` | Creates a `Tenant` row keyed by Microsoft `tenantId`, `state = pending_consent`. Customer maps to `owner/name` to advance to `active`. |
+| GitHub App `installation` webhook (`created` / `repositories_added`) | GitHub install handler in `ghbridge` | One `state = active` row per `(installation_id, repo)` pair in the event's repository set. No mapping step — the installation event already names the repos the App may act on. |
+| Bot Framework `installationUpdate` activity (`action=add`) | Teams consent handler in `msbridge` | One `state = pending_consent` row keyed by Microsoft `tenantId`. The customer self-serves the repo mapping via a hosted onboarding endpoint; the Forward Impact operator takes no action between consent and mapping. |
 
-A `Tenant` in `pending_consent` does not resolve; the bridge rejects
-inbound channel events for it until the customer completes the repo
-mapping step.
-
-**Self-hosted mode** is not an onboarding path — it is a deployment-time
-configuration. The bridge runs with `SERVICE_*_MULTI_TENANT` unset; the
-supplied `TenantResolver` returns a fixed `default` tenant unconditionally
-and the tenancy service is not started. The existing
-`MICROSOFT_APP_TENANT_ID` single-value JWT validation in `msbridge`
-remains in force in this mode and is bypassed only when multi-tenant mode
-is enabled.
+A `Tenant` in `pending_consent` does not resolve and `services/apptoken`
+does not mint tokens for it. Self-hosted mode is a deployment-time
+configuration: each bridge reads a multi-tenant flag from its config
+(name is a plan concern). Off → bridge returns the `default` tenant,
+`services/tenancy` and `services/apptoken` are not started, `msbridge`
+constructs a single-tenant Bot Framework authenticator from
+`MICROSOFT_APP_TENANT_ID`. On → the bridge resolves per request and
+`msbridge` constructs a multi-tenant authenticator that accepts JWTs
+from any `active` tenant.
 
 ## Key decisions
 
@@ -126,26 +168,33 @@ is enabled.
 |---|---|---|---|
 | GitHub App model | One Forward Impact-owned App, multi-installation | One App per customer | GitHub's App model is already multi-install. Per-customer Apps duplicate registration without changing the trust shape — the operator still holds whichever private key is in use. |
 | Azure AD app model | One multi-tenant Azure AD app | One per customer tenant | Bot Framework supports multi-tenant validation natively. Per-tenant apps would require operator action per onboard. |
-| Registry packaging | Standalone gRPC service (`services/tenancy`) | (a) library inside `libbridge` consumed by each bridge; (b) table inside `services/ghbridge` shared via direct DB access | Two bridges (and any future channel) share one authoritative registry. A library would force every bridge to embed the same persistence and keystore code and reimplement consistency on its own. A table inside ghbridge would couple msbridge to ghbridge's lifecycle and process boundary. A standalone service follows the established `services/CLAUDE.md` pattern and keeps callback-verification material on one process. |
-| Tenant resolver placement | Channel-agnostic interface in `libbridge`; channel-specific extraction in the calling bridge | Resolver lives entirely in `libbridge` and imports channel SDKs | Putting channel SDK imports in `libbridge` violates its existing "no channel SDKs" invariant (per `libraries/libbridge/CLAUDE.md`). Keeping extraction in the bridge service preserves libbridge as channel-agnostic transport. |
-| Storage isolation | Tenant prefix in the path the bridge constructs before calling libstorage | (a) modify `libstorage` to enforce prefixing; (b) one libstorage instance per tenant | libstorage stays caller-injected and unchanged (per its existing invariant). The bridge's `DiscussionContextStore` already constructs paths; gaining a `tenant_id` segment is a path-construction change, not a libstorage change. Per-tenant instances complicate process startup without adding a guarantee against a buggy bridge. |
+| App private key custody | Centralized in `services/apptoken` | (a) Each bridge holds the key in process; (b) the key lives in every customer repository's Actions secrets | (a) Duplicates the master credential across processes and forces every bridge to embed key-handling code. (b) Replicates the master credential across every customer's CI environment and is the disqualifying property the spec calls out — incompatible with public-App security. |
+| In-workflow authentication to apptoken | GitHub Actions OIDC | (a) A long-lived per-customer secret installed in repository Actions secrets; (b) bridge-issued tokens carried as `workflow_dispatch` inputs | (a) Reintroduces the customer-side long-lived credential the spec exists to eliminate. (b) Bridge-issued tokens cannot reach scheduled workflows (`kata-shift`, `kata-storyboard`) which have no upstream bridge, and a single dispatched token cannot survive a multi-hour run. OIDC reaches every workflow surface uniformly and supports mid-run re-mints. |
+| Workflow identity coverage | Every kata workflow on the hosted path uses the same `services/apptoken`-via-OIDC step | Only `kata-dispatch.yml` goes through the broker; scheduled workflows keep a customer-side secret | Mixed-model coverage leaves `KATA_APP_PRIVATE_KEY` in customer repositories and defeats the spec's master-credential criterion. One mechanism across all kata workflows is also one surface to audit. |
+| Hosted dispatch identity | `services/apptoken`-minted installation token | Per-user OAuth via `services/ghauth` | Per-user OAuth requires every dispatcher to complete a one-time link flow before they can post — incompatible with the spec's setup-floor reduction. `services/ghauth` remains the dispatch identity for self-hosted operators who want per-user attribution. |
+| Token scoping | Per-repo from OIDC claim / per-tenant `repo` row | Per-installation (broader scope) | Per-installation tokens can act on every repository the installation covers; per-repo tokens confine blast radius to the one repository named in the request and align with the OIDC claim used to authenticate the caller. |
+| Registry packaging | Standalone gRPC service (`services/tenancy`) | (a) Library inside `libbridge`; (b) table inside `services/ghbridge` shared via direct DB access | Two bridges (and the apptoken service) share one authoritative registry. A library forces every caller to embed the same persistence code. A table inside ghbridge couples msbridge and apptoken to ghbridge's lifecycle. |
+| Tenant resolver placement | Channel-agnostic interface in `libbridge`; channel-specific extraction in the calling bridge | Resolver lives entirely in `libbridge` and imports channel SDKs | Putting channel SDK imports in `libbridge` violates its existing "no channel SDKs" invariant. Keeping extraction in the bridge service preserves libbridge as channel-agnostic transport. |
+| Storage isolation | One `DiscussionContextStore` instance per resolved tenant, each with a `tenants/{tenant_id}/` storage prefix | (a) Modify `libstorage` to enforce prefixing for every caller; (b) one big shared store with tenant-keyed entries in a single JSONL | libstorage stays caller-injected and unchanged per its existing invariant. Per-tenant store instances keep the existing `channel:discussion_id` key shape and confine a bug at the bridge layer (a missing tenant-prefix tag) to that tenant only, instead of risking cross-tenant key collisions in a shared file. |
 | Anthropic key path | Stays in customer's repo secrets; control plane has no access | Proxy through control plane | Proxying would put the key in the operator's blast radius. BYOK keeps the credential, the prompt, and the response on the customer's runner. |
-| Workflow execution | Customer's GitHub Actions runner via `workflow_dispatch` | Hosted runners managed by Forward Impact | Hosted execution would expand the trust surface to include the agent's tool calls and repo writes. Dispatching into the customer's runner keeps execution in the customer's blast radius. |
-| Self-hosted code path | Same code, single-tenant mode flag | A separate self-hosted-only bridge | One code path, exercised in two configurations. Avoids drift between hosted and self-hosted behaviour. |
-| Trust model artifact | `TRUST.md` at repo root | Section in CLAUDE.md / README | A standalone document is linkable from external onboarding pages, the marketplace listing, and the Teams app submission. CLAUDE.md is internal. |
-| Callback authentication | Per-tenant secret material in the tenancy keystore; bridges verify via a `VerifyCallback(tenant_id, signature, body)` RPC that does not return the key | A single shared secret across all tenants | A shared secret means a leak in any tenant's workflow logs compromises all tenants. Per-tenant material confines blast radius. The specific cryptographic primitive (HMAC vs asymmetric) is a plan concern; the design constraint is per-tenant isolation and that the verification material never leaves the tenancy service. |
-| Callback URL routing | Per-tenant callback URL path: `/callback/{tenant_id}/{token}` | One URL with tenant inferred from body | Path-level scoping rejects mis-addressed callbacks before body parsing and aligns the tenant id with the audit and rate-limit dimensions. Exposing `tenant_id` in the URL is acceptable because it is an opaque registry-owned UUID, not a secret, and the per-tenant `token` carries the authority. |
+| Workflow execution | Customer's GitHub Actions runner via `workflow_dispatch` and scheduled triggers | Hosted runners managed by Forward Impact | Hosted execution would expand the trust surface to include every tool call and repo write the agents make. Dispatching into the customer's runner keeps execution in the customer's blast radius. |
+| Self-hosted code path | Same code, single-tenant mode flag | A separate self-hosted-only bridge | One code path, exercised in two configurations; avoids hosted/self-hosted behaviour drift. |
+| Trust model artifact | `TRUST.md` at repo root | Section in CLAUDE.md / README | A standalone document is linkable from external onboarding, the marketplace listing, and Teams app submission. |
+| Bot Framework credential custody | Held in `services/msbridge` process | Centralize in `services/apptoken` alongside the GitHub App key | The GitHub App key is consumed by every kata workflow (high-fanout); centralising it gives a uniform OIDC-mint path. The Bot Framework credential is only consumed by `msbridge` itself (no fanout), so the marginal blast-radius win from centralising it does not justify the new in-process boundary; Bot Framework custody hardening is a follow-on (see § Deferred). |
+| Callback authentication | Tenant-bind the inherited 1230 single-use token (registry stores `(correlation_id, tenant_id)` on register; bridge rejects on consume if the URL's tenant id mismatches the token's tenant id) | (a) Add a new signature primitive (HMAC or asymmetric) over the callback body per tenant; (b) shared secret across all tenants | (a) Introduces a primitive the spec did not authorize and adds new secret-management surface for no property gain — token-binding alone gives the cross-tenant rejection property the spec asks for. (b) A shared secret means a leak in any tenant's workflow logs compromises all tenants. |
+| Callback URL routing | Per-tenant URL path: `/callback/{tenant_id}/{token}` | One URL with tenant inferred from body | Path-level scoping rejects mis-addressed callbacks before body parsing and pairs cleanly with the token-bind-on-register approach above. |
+| `services/apptoken` customer-facing transport | Public HTTPS endpoint reached directly from GitHub Actions runners | Proxy OIDC mint requests through `services/ghbridge` | Scheduled runs (`kata-shift`, `kata-storyboard`) never call ghbridge; proxying their OIDC mints through it would expand ghbridge's attack surface and couple apptoken's availability to ghbridge's. A direct public endpoint keeps the mint path uniform. |
 
 ## What this design does not cover
 
-- The marketplace listing copy, App icon, screenshots, or any publish-time
-  artefact for the GitHub App and the Teams app catalog entry.
-- The concrete protobuf schema for `services/tenancy`.
-- Rate limiting, abuse prevention, and DoS posture on the hosted control
-  plane beyond per-tenant scoping.
-- KMS integration and rotation procedures for the App private key and the
-  Bot Framework secret.
+- Publish-time artefacts (marketplace listing, App icon, screenshots,
+  Teams catalog metadata).
+- Concrete protobuf schemas for `services/tenancy` and `services/apptoken`.
+- Exact GitHub Actions OIDC claim-validation rules; the design
+  constraint is that the broker scopes minted tokens to the
+  OIDC-asserted repository.
+- Rate limiting and DoS posture beyond per-tenant scoping.
+- KMS/HSM custody and rotation for the hosted App private key.
 - Replacement of libindex JSONL with a managed datastore.
-- The exact text of `TRUST.md` — content is in scope, drafting is a plan
-  concern.
+- Exact `TRUST.md` text (content is in scope, drafting is a plan concern).
 - Migration paths between self-hosted and hosted deployments.

--- a/specs/1270-kata-bridges-public-hosting/spec.md
+++ b/specs/1270-kata-bridges-public-hosting/spec.md
@@ -1,167 +1,330 @@
-# Spec 1270 — Public hosting for Kata bridges
+# Spec 1270 — Public hosting for the Kata Agent Team
 
 ## Persona and job
 
 Hired by the **Teams Using Agents** user group named in
-[CLAUDE.md § Primary Products](../../CLAUDE.md#primary-products) to lower the
-setup floor below "register your own GitHub App, register your own Azure AD
-app, expose two public tunnels, and run two services" — without removing the
-self-hosted path for teams that need the strongest privacy posture.
-
-This persona has no `<job>` entry in [JTBD.md](../../JTBD.md) today; the user
-group exists in CLAUDE.md as one of the three primary product audiences but
-its jobs have not yet been captured in the JTBD authoritative list.
+[CLAUDE.md § Primary Products](../../CLAUDE.md#primary-products), serving
+the **Little Hire** of their _Run a Continuously Improving Agent Team_
+job in [JTBD.md](../../JTBD.md): _"Help me onboard a Kata installation
+that runs the Plan-Do-Study-Act loop without per-team prompt
+engineering."_ This spec attacks the setup floor that today gates that
+onboarding — without removing the self-hosted path for teams that need
+the strongest privacy posture.
 
 ## Problem
 
 Every team that adopts the Kata Agent Team today must operate four
-infrastructure components themselves before the first agent reply lands.
+infrastructure components and replicate one master credential across
+every consuming repository before the first agent reply lands.
+
+### Infrastructure the adopter runs
 
 | Component | What the adopter must do today |
 |---|---|
-| Kata Agent Team GitHub App | Register their own App in GitHub, generate and rotate a private key, set the webhook URL to point at their tunnel, hold `KATA_APP_ID` / `KATA_APP_PRIVATE_KEY` as repository secrets. |
-| `services/ghbridge` | Run the bridge process locally, expose it over a public tunnel that re-issues a hostname on every restart, configure `SERVICE_GHBRIDGE_APP_PRIVATE_KEY` and `SERVICE_GHBRIDGE_APP_WEBHOOK_SECRET`. |
+| Kata Agent Team GitHub App | Register their own App in GitHub, generate and rotate a private key, set the webhook URL to point at their tunnel. |
+| `services/ghbridge` | Run the bridge process locally, expose it over a public tunnel whose hostname is reassigned on every tunnel restart, configure `SERVICE_GHBRIDGE_APP_PRIVATE_KEY` and `SERVICE_GHBRIDGE_APP_WEBHOOK_SECRET`. |
 | Kata Agent Team Teams bot | Register a single-tenant Azure AD app and a Bot Framework resource in Azure, package and sideload a manifest pointing at their tunnel. |
 | `services/msbridge` | Run the bridge, expose it over a tunnel, hold `MICROSOFT_APP_ID` / `MICROSOFT_APP_PASSWORD` / `MICROSOFT_APP_TENANT_ID`. |
 
-This produces three consequences:
+### The master credential the adopter holds in every repository
 
-1. **The setup floor blocks evaluation.** A team that wants to try Kata must
-   complete two cloud-platform registrations, two public-tunnel deployments,
-   four long-lived credentials, and two running services before the first
+Every kata workflow that authenticates as the GitHub App today reads
+`KATA_APP_PRIVATE_KEY` from the consuming repository's Actions secrets.
+The set covers `kata-shift.yml`, `kata-storyboard.yml`,
+`kata-dispatch.yml`, `kata-coaching.yml`, and `kata-interview.yml`. The
+webhook bridges themselves never see this secret; it lives in the
+customer's CI environment.
+
+### Consequences
+
+1. **The setup floor blocks evaluation.** A team that wants to try Kata
+   must complete two cloud-platform registrations, two public-tunnel
+   deployments, multiple long-lived credentials (see § Infrastructure
+   the adopter runs above), and two running services before the first
    message. Teams without infrastructure experience cannot evaluate.
 
-2. **Every adopter holds the same shape of secret.** GitHub App private keys,
-   Azure AD client secrets, and webhook secrets are replicated across every
-   installation with no organizational benefit — every adopter carries the
-   custody burden alone.
+2. **Every adopter holds the same shape of secret.** GitHub App private
+   keys, Azure AD client secrets, and webhook secrets are replicated
+   across every installation with no organizational benefit — every
+   adopter carries the custody burden alone.
 
 3. **There is no hosted offering to compare against.** The open-source
-   distribution today means "self-host or do not use it." Adopters cannot
-   choose convenience over custody, and Forward Impact cannot demonstrate
-   the system on its own infrastructure to prospective users.
+   distribution today means "self-host or do not use it." Adopters
+   cannot choose convenience over custody, and Forward Impact cannot
+   demonstrate the system on its own infrastructure to prospective
+   users.
 
-The Teams bot is single-tenant by construction today — the running
-`services/msbridge` requires `MICROSOFT_APP_TENANT_ID` and validates inbound
-Bot Framework JWTs against that single value. Spec 1200 introduced this with
-"Multi-tenant support or organizational bot publishing" explicitly excluded,
-and design 1200-a recorded the choice as "prototype uses a single-tenant dev
-registration." Both have shipped and the constraint is unresolved since.
+4. **The customer-secret App-identity model is incompatible with a
+   public App.** A public, multi-installation App's private key is the
+   master credential for every installation. The current model
+   replicates that credential into every customer repository's Actions
+   secrets, where every kata workflow reads it on every run. No
+   custody arrangement at the operator layer can resolve this — a
+   hosted offering needs an identity model in which the App private
+   key never lives in any customer repository.
+
+The Teams bot is single-tenant by construction today: the running
+`services/msbridge` is configured with a single `MICROSOFT_APP_TENANT_ID`
+and rejects inbound Bot Framework activities that do not originate from
+that one tenant id. This constraint shipped with
+[spec 1200](../1200-teams-agent-bridge/spec.md) and has not been
+revisited since.
+
+Two scope boundaries that this Problem section deliberately does not
+attack are listed in § Excluded.
 
 ## Proposal
 
-Offer two deployment paths in parallel — a Forward Impact-operated hosted
-control plane, and the existing self-hosted code path.
+Offer two deployment paths in parallel — a Forward Impact-operated
+hosted control plane plus a hosted workflow-identity capability, and
+the existing self-hosted code path.
 
 ### 1. Hosted control plane
 
-Forward Impact operates a single multi-tenant deployment of the bridges:
+Forward Impact operates a single hosted control plane comprising the
+bridges and their supporting registry:
 
-- One Kata Agent Team GitHub App registration, public on GitHub, installable
-  to any organization or repository.
-- One multi-tenant Azure AD app and Bot Framework registration, addable to
-  any Microsoft Entra tenant from the Teams app catalog.
-- Multi-tenant variants of `services/ghbridge` and `services/msbridge` that
-  route between incoming channel events and each tenant's GitHub repository.
-- A tenant registry mapping GitHub installation ids and Microsoft tenant ids
-  to the customer's configured target repository.
+- One Kata Agent Team GitHub App registration, public on GitHub,
+  installable to any organization or repository.
+- One multi-tenant Azure AD app and Bot Framework registration,
+  addable to any Microsoft Entra tenant from the Teams app catalog.
+- Multi-tenant variants of `services/ghbridge` and `services/msbridge`
+  that route between incoming channel events and each tenant's GitHub
+  repository.
+- A tenant registry mapping each channel's tenant key to the customer's
+  configured target repository.
 - Per-tenant isolation in storage, signature verification, and outbound
   workflow dispatch.
 
-### 2. Self-hosted path (preserved)
+### 2. Keyless workflow identity
 
-A team that needs the strongest privacy posture continues to register their
-own GitHub App, their own Azure AD app, and runs `services/ghbridge` and
-`services/msbridge` as they do today. The `kata-setup` skill produces a
-self-hosted deployment by default; the hosted path is opt-in.
+The hosted offering replaces the customer-secret App-identity model
+with a property: the App private key never leaves Forward Impact's
+control plane, and every kata workflow running on the hosted path
+obtains short-lived, **repo-scoped GitHub App credentials** at run
+time (distinct from the per-invocation callback token model
+inherited from spec 1230, which is a separate primitive flowing in
+the opposite direction). The hosted path never requires any
+long-lived credential on the customer side.
 
-### 3. Anthropic key never leaves the customer
+- Covers `kata-shift.yml`, `kata-storyboard.yml`, `kata-dispatch.yml`,
+  `kata-coaching.yml`, and `kata-interview.yml` — the kata workflows
+  that authenticate as the hosted App today. Future kata workflows that
+  need this identity opt in via this same path through future specs.
+- Token lifetime does not bound run lifetime: a multi-hour agent run
+  succeeds end-to-end on the hosted path without operator intervention.
 
-The kata-dispatch workflow continues to run in the customer's GitHub Actions
-runner against the customer's `ANTHROPIC_API_KEY` repository secret. The
-control plane process has no Anthropic SDK dependency, no Anthropic
-environment variables, and no code path that handles an Anthropic credential.
+The mechanism, transport, packaging, and authentication shape used to
+deliver this property are design concerns.
 
-### 4. Published trust model
+### 3. Self-hosted path (preserved)
 
-A `TRUST.md` document at the repository root enumerates — for both hosted
-and self-hosted paths — which secrets the operator holds, which message
-content the operator sees, and which surfaces the operator cannot reach.
-Linked from `kata-setup`, the ghbridge README, and the msbridge README.
+A team that needs the strongest privacy posture continues to register
+their own GitHub App, their own Azure AD app, and runs
+`services/ghbridge` and `services/msbridge` as they do today, with
+`KATA_APP_PRIVATE_KEY` in their own Actions secrets. The `kata-setup`
+skill produces a self-hosted deployment when the operator does not
+opt into the hosted path.
+
+### 4. Anthropic key never leaves the customer
+
+Every kata workflow continues to run in the customer's GitHub Actions
+runner against the customer's `ANTHROPIC_API_KEY` repository secret.
+The control plane has no Anthropic SDK dependency, no Anthropic
+environment variables, and no code path that handles an Anthropic
+credential.
+
+### 5. Published trust model
+
+A `TRUST.md` document at the repository root enumerates six aspects of
+the hosted operator surface, with a per-aspect hosted-vs-self-hosted
+comparison column for each:
+
+1. Secrets the hosted operator holds.
+2. Message content the hosted operator sees.
+3. Workflow runs the hosted operator can observe.
+4. The BYOK Anthropic boundary (the customer's `ANTHROPIC_API_KEY`,
+   prompts, and Anthropic responses never reach the control plane).
+5. What the hosted workflow-identity capability can mint and on whose
+   behalf.
+6. Surfaces the hosted operator cannot reach.
+
+`TRUST.md` is linked from `.claude/skills/kata-setup/SKILL.md`, the
+ghbridge README, and the msbridge README.
 
 ## Scope
 
 ### In scope
 
-Build deliverables — engineering work that produces code or docs in this
-repository:
+Build deliverables — engineering work that produces code or docs in
+this repository:
 
-- Multi-tenancy capability in `libraries/libbridge` — tenant resolution from
-  incoming events, per-tenant credential isolation, and per-tenant storage
-  isolation. Names of the libbridge exports that gain tenant-awareness are a
-  design concern.
-- Multi-tenant modes for `services/ghbridge` and `services/msbridge`. Single-
-  tenant remains the default for self-hosted operators.
-- A tenant registry that owns the mapping from `(channel, channel tenant
-  key)` to the customer's GitHub repository and from each tenant to its
-  isolated credential material. Whether the registry is packaged as a
-  service, a library, or a table inside another service is a design concern.
-- Onboarding handlers that populate the registry without operator
-  intervention. The triggers are the GitHub App `installation` event and the
-  Bot Framework `installationUpdate` activity.
-- Extension of the hosted Kata GitHub App's webhook subscription set to
-  include `installation` (today's subscriptions are `discussion` and
-  `discussion_comment`, per `services/ghbridge/README.md`).
+- Multi-tenancy in the shared bridge primitives currently in
+  `libraries/libbridge` (whether the multi-tenancy code lives in
+  libbridge or in a new library is a design concern).
+- Multi-tenant capability in `services/ghbridge` and `services/msbridge`.
+  Single-tenant operation remains the default for self-hosted
+  operators; the shape of the toggle (build flag, mode flag, separate
+  binary, separate deployment) is a design concern.
+- A tenant registry that owns the mapping from each channel's tenant
+  key to the customer's GitHub repository, plus whatever per-tenant
+  state the bridges need to reject callbacks addressed to the wrong
+  tenant. Whether the registry is packaged as a service, a library,
+  or a table inside another service, and the form of the per-tenant
+  state that backs cross-tenant rejection, are design concerns.
+- A workflow-identity capability that issues short-lived, repo-scoped
+  credentials to (a) every kata workflow named in § Proposal 2 and
+  (b) the hosted bridges, without any customer-side long-lived
+  credential. The capability is the single logical custody point for
+  the hosted App's signing material; the substrate that physically
+  stores that material (filesystem, KMS, HSM) is deferred — see
+  § Deferred. Mechanism, transport, packaging, and authentication
+  shape are design concerns.
+- Updated workflow templates emitted by `kata-setup` for the hosted
+  path, covering every kata workflow named in § Proposal 2, with no
+  `KATA_APP_PRIVATE_KEY` secret reference in any kata workflow file
+  and no input on any action the workflow calls that carries
+  App-private-key material.
+- Automated tenant onboarding: each channel platform's installation /
+  consent signal reaches the registry without operator intervention.
+  Specific channel events consumed and the hosted App's webhook
+  subscription set are design concerns.
 - A `TRUST.md` document at the repository root.
-
-Operator commitments — registrations and infrastructure Forward Impact owns
-outside the repository:
-
-- A single hosted Kata GitHub App registration, public on GitHub, with the
-  same permissions as the self-hosted App plus the `installation` event
-  subscription above.
-- A multi-tenant Azure AD app registration and Bot Framework resource,
-  configured so consenting tenants are isolated from each other.
 
 ### Excluded
 
 Permanent non-goals — architectural constraints, not deferred work:
 
-- Hosting the kata-dispatch workflow itself. Execution stays on the
+- Hosting any kata workflow itself. Execution of every kata workflow
+  named in § Proposal 2 (and any future kata workflow) stays on the
   customer's GitHub Actions runner.
-- Proxying or holding the customer's Anthropic API key. BYOK is a constraint.
-- New channel bridges. The two existing channels in spec 1230
-  (`services/ghbridge`, `services/msbridge`) are the full set; this spec
-  does not introduce a third.
-- Federated or community-operated control planes. The hosted control plane
-  is operated by Forward Impact only; self-hosted users do not run it.
+- Proxying or holding the customer's Anthropic API key. BYOK is a
+  constraint.
+- New channel bridges. The two existing bridge services
+  (`services/ghbridge`, `services/msbridge`) are the full set; this
+  spec does not introduce a third channel. Multi-tenancy work on the
+  two existing bridges is in scope, see § In scope.
+- Federated or community-operated control planes. The hosted control
+  plane is operated by Forward Impact only; self-hosted users do not
+  run it.
+- The Forward Impact monorepo's own use of `KATA_APP_PRIVATE_KEY` in
+  its CI for release, publishing, and website workflows. That is
+  Forward Impact's own master credential for its own publishing
+  pipeline, not a secret an adopter ever holds. The hosted-path
+  identity model in this spec applies to kata workflows running in
+  **a consuming repository**.
+- The bridge-side dispatch identity provided by `services/ghauth`
+  (per-user GitHub OAuth tokens used to fire `workflow_dispatch`,
+  distinct from the App installation token used for replies and
+  reactions). `services/ghauth`'s domain is unaffected by this spec,
+  which addresses only the **customer-repository** side of the App
+  identity surface.
 
-Deferred — out of scope here but tractable for follow-on work:
+### Deferred
 
-- Confidential computing, hardware enclaves, customer-managed encryption
-  keys for at-rest storage, or attestation.
+Out of scope here but tractable as follow-on work:
+
+- Confidential computing, hardware enclaves, customer-managed
+  encryption keys for at-rest storage, or attestation.
+- Substrate hardening for custody of the hosted App's signing
+  material (KMS, HSM, secret-manager integration) and the rotation
+  procedure. The initial delivery establishes the workflow-identity
+  capability as the single logical custody point; the substrate that
+  physically backs that custody point is a design concern, and
+  production hardening of that substrate is a follow-on.
 - Migration tooling between self-hosted and hosted deployments. A team
   selects one path at setup time; switching later is a future concern.
-- Billing, quota, account management, or any commercial layer over the
-  hosted control plane. Coarse-grained per-tenant rate limits for abuse
-  prevention are in scope only insofar as they protect availability.
+- Billing, quota, account management, or any commercial layer over
+  the hosted control plane.
 
-Out of scope by inheritance from prior specs:
+### Inherited from prior specs
 
-- Changes to the kata-dispatch workflow contract (inputs, outputs, callback
-  payload). The existing contract from [spec 1230](../1230-threaded-discussion-bridges/spec.md)
-  is reused unchanged.
+**Contracts reused unchanged.**
+
+- The `workflow_dispatch` input shape for `kata-dispatch.yml`:
+  `prompt`, `callback_url`, and `correlation_id` (established by
+  [spec 1200](../1200-teams-agent-bridge/spec.md)), plus
+  `discussion_id` and `resume_context` (layered on by
+  [spec 1230](../1230-threaded-discussion-bridges/spec.md)).
+- The bridge-bound callback **payload schema** (the
+  `correlation_id` / `verdict` / `summary` / `run_url` base from
+  [spec 1200](../1200-teams-agent-bridge/spec.md) plus the `replies[]`
+  array layered on by
+  [spec 1230](../1230-threaded-discussion-bridges/spec.md)).
+- The **per-invocation callback-token-in-URL primitive** introduced by
+  [spec 1200](../1200-teams-agent-bridge/spec.md) (the dispatch
+  inserts a per-call token into `callback_url`) together with the
+  **single-use register/consume token registry** that
+  [spec 1230](../1230-threaded-discussion-bridges/spec.md)'s
+  implementation formalised (the bridge registers the token before
+  dispatch and consumes it on the inbound callback). This spec
+  extends that combined model with per-tenant scoping — it does not
+  replace either piece.
+
+**Exclusions explicitly lifted.**
+
+- [Spec 1200](../1200-teams-agent-bridge/spec.md) listed both
+  *multi-tenant Teams support* and *organizational bot publishing*
+  as Excluded. The running `services/msbridge` is wired single-tenant
+  under those exclusions. This spec lifts both — see § Operator
+  commitments (a multi-tenant Azure AD app and a Bot Framework
+  resource published to the Teams app catalog so any consenting Entra
+  tenant can install it).
+
+**What this spec adds on top of the inherited contracts (called out so
+the inheritance above is not misread as covering everything).**
+
+- **Per-tenant scoping of callback verification.** The 1230 model
+  already authenticates callbacks via the single-use token in the
+  URL. This spec adds tenant-scoping on top so that a token-bearing
+  callback addressed to tenant B cannot mutate state, post replies,
+  or otherwise act on tenant A's resources — even before the token
+  itself is evaluated. The token model is reused; the new property is
+  cross-tenant rejection.
+- **A new customer-side step that obtains GitHub App credentials at
+  run time without a long-lived secret.** Today's kata workflows
+  derive an installation token from `KATA_APP_PRIVATE_KEY` in repo
+  secrets — directly via `actions/create-github-app-token`
+  (kata-dispatch.yml, kata-interview.yml) or indirectly by passing
+  `app-private-key` to `forwardimpact/kata-agent@v1` (kata-shift.yml,
+  kata-storyboard.yml, kata-coaching.yml). The hosted path replaces
+  that step with a call into the workflow-identity capability;
+  mechanism is a design concern. This is internal to the customer's
+  workflow file and does not alter either of the two inherited
+  contracts at the top of this section.
+
+## Operator commitments (out of repo)
+
+Registrations and infrastructure Forward Impact owns outside this
+repository — captured here so reviewers know which deliverables produce
+no PR:
+
+- A single hosted Kata GitHub App registration, public on GitHub, with
+  the same permissions as the self-hosted App.
+- A multi-tenant Azure AD app registration and Bot Framework resource,
+  published to the Microsoft Teams app catalog so any consenting
+  Microsoft Entra tenant can install it without a per-customer Azure
+  AD app registration. Tenants are isolated from each other.
+- A custody arrangement for the hosted App's private key that keeps it
+  inside the control plane and accessible only to the workflow-identity
+  capability. The specific custody substrate (filesystem, KMS, HSM) is
+  deferred — see § Deferred.
 
 ## Success criteria
 
 | Claim | Verifies via |
 |---|---|
-| A team can install the hosted Kata GitHub App on a repository without registering their own GitHub App. | The customer's GitHub App settings list the Forward Impact-owned App by slug (no per-customer App registration); a first `kata-dispatch.yml` run on the customer's repository completes green with no `KATA_APP_*` secret present in the repository's Actions secrets. |
-| A team can add the hosted Teams bot to a Microsoft tenant without registering their own Azure AD app. | The Teams app catalog entry resolves to the Forward Impact-owned Azure AD app id; a first activity from a newly consented tenant dispatches `kata-dispatch.yml` in the configured customer repository. |
-| The hosted control plane does not read the customer's Anthropic API key. | `grep -rE 'ANTHROPIC_API_KEY' services/ghbridge services/msbridge libraries/libbridge` and any tenant-registry implementation returns no matches; `grep -rE '@anthropic-ai/sdk\|require.*anthropic' services/ghbridge services/msbridge libraries/libbridge` returns no matches; the `package.json` `dependencies` of `services/ghbridge` and `services/msbridge` contain no `anthropic` entries. |
-| Per-tenant state isolation in storage. | A bridge request authenticated for tenant A that targets a storage key belonging to tenant B returns the same response shape as if the key did not exist, with no field in the response containing tenant B's record content. |
-| Per-tenant signature verification end-to-end. | A bridge request signed with tenant A's key but addressed (via routing path or payload tenant id) to tenant B's resource returns HTTP 401/403 and does not dispatch a workflow. |
-| Self-hosted setup still works. | Following the [`kata-setup`](../../.claude/skills/kata-setup/SKILL.md) skill end-to-end against a fresh repository produces a functional self-hosted deployment; no step in that skill assumes the hosted control plane. |
+| A team can install the hosted Kata GitHub App on a repository without registering their own GitHub App. | The Forward Impact-owned Kata Agent Team App is publicly installable on GitHub; a hosted-path adopter completes onboarding without creating any GitHub App registration in their own organization or user account. |
+| A team can add the hosted Teams bot to a Microsoft tenant without registering their own Azure AD app. | The Teams app catalog entry for the hosted bot resolves to the Forward Impact-owned Azure AD app id; a hosted-path adopter completes Teams onboarding without creating any Azure AD app registration in their own Entra tenant. |
+| No GitHub App private key is required in a hosted-path consuming repository. | The hosted-path setup flow does not ask the adopter to set `KATA_APP_PRIVATE_KEY` or any equivalent renaming; a hosted-path consuming repository's Actions-secrets listing contains no `KATA_APP_PRIVATE_KEY` entry. (Public identifiers like the App id are not credentials and are not constrained by this criterion. Microsoft App credentials are scoped to the hosted Teams operator, never to a consuming repository — see the hosted Teams onboarding criterion below.) |
+| The hosted App's signing material does not appear, by reference or by value, in customer workflow files or templates. | No hosted-path workflow template emitted by `kata-setup` carries the hosted App's private key by any path: no template references the secret by any name, and no template passes a private-key-bearing input (under any input name) to any action it invokes. The criterion holds against any renaming of the secret. |
+| Long-running kata workflows are not bounded by a single credential lifetime. | A `kata-dispatch.yml` run on the hosted path lasting at least 90 minutes — exceeding the 60-minute GitHub App installation-token cap, so the run necessarily crosses at least one credential boundary — completes end-to-end without operator intervention. |
+| The hosted control plane does not read the customer's Anthropic API key. | For every directory listed in § In scope as part of the hosted control plane (the bridges, the tenant registry, the workflow-identity capability, and the multi-tenancy code in `libraries/libbridge`), plus any sibling control-plane directory the design names: no `package.json` declares any `@anthropic-ai/*` package as a runtime dependency; no source file imports a module under `@anthropic-ai/*`; no source file reads an environment variable whose name matches `ANTHROPIC_*`. The same patterns pass against the hosted-path workflow templates emitted by `kata-setup` so the BYOK boundary is end-to-end. |
+| Per-tenant state isolation across the hosted control plane. | On any control-plane surface that returns persisted state to a caller authenticated as tenant A — for both per-id reads and any aggregate/list endpoints — the response (HTTP status code plus body) carries no field, count, or other content derived from a record persisted on behalf of tenant B. The criterion is bounded to the wire-visible response (status + body); timing-side-channel indistinguishability is not in scope here. |
+| Per-tenant verification of callbacks from workflow runs. | A callback from a workflow run authenticated with material bound to tenant A but addressed to tenant B's resource is rejected: no reply is posted to any tenant B channel, and no state attributed to a tenant B thread changes as a result of the callback. |
+| Workflow-identity is scoped to the requesting repository. | An attempt by a customer workflow run on repository X to obtain credentials usable against repository Y is rejected by the workflow-identity capability and no credential for Y is produced. |
+| Self-hosted setup still works. | Following the [`kata-setup`](../../.claude/skills/kata-setup/SKILL.md) skill end-to-end against a fresh repository in self-hosted mode produces a deployment that successfully delivers an agent-authored reply to a Discussion thread on the operator's own repository; no step in the skill assumes the hosted control plane. |
 | `TRUST.md` is discoverable from operator-facing documentation. | `TRUST.md` exists at the repository root and is linked from `.claude/skills/kata-setup/SKILL.md`, `services/ghbridge/README.md`, and `services/msbridge/README.md`. |
-| `TRUST.md` enumerates the trust model for both deployment paths. | `TRUST.md` contains a top-level heading for each of: secrets the hosted operator holds; message content the hosted operator sees; the BYOK Anthropic boundary; the differences between hosted and self-hosted access. |
-| Onboarding writes a tenant-registry record without operator intervention. | A test install of the hosted GitHub App on a fresh repository, and a test consent of the hosted Teams app in a fresh Microsoft tenant, each produce one new tenant-registry record observable via the registry's read API within 60 seconds — without any operator-side console action or API call. |
+| `TRUST.md` enumerates the trust model for both deployment paths. | `TRUST.md` contains one top-level heading for each of the six aspects listed in § Proposal 5, and each section includes a per-aspect comparison between hosted and self-hosted access. |
+| GitHub-side onboarding requires no operator intervention. | A test install of the hosted GitHub App on a fresh repository, followed by a user-authored event of a kind the bridge already supports today on that repository, results in a successful `workflow_dispatch` of `kata-dispatch.yml` on the configured customer repository — with no action taken by the hosted operator between the install and the dispatch. |
+| Teams-side onboarding requires no operator intervention. | A test consent of the hosted Teams app in a fresh Microsoft tenant, followed by a user-authored event of a kind the bridge already supports today in that tenant, results in a successful `workflow_dispatch` of `kata-dispatch.yml` on the configured customer repository — with no action taken by the hosted operator between the consent and the dispatch. |


### PR DESCRIPTION
## Summary

Structurally integrates keyless workflow identity into spec 1270 and its design, so the hosted Kata Agent Team can serve every kata workflow — not just the bridge-mediated `kata-dispatch.yml` — without the public App's private key ever living in a customer repository.

- **Spec 1270** widens from "Public hosting for Kata bridges" to "Public hosting for the Kata Agent Team". A new proposal pillar (Keyless workflow identity) covers `kata-shift.yml`, `kata-storyboard.yml`, `kata-dispatch.yml`, `kata-coaching.yml`, and `kata-interview.yml` — every kata workflow that authenticates as the hosted App today. The inherited-scope section accurately attributes spec 1200's contributions (workflow_dispatch input shape, base callback payload, callback-token-in-URL primitive, single-tenant Teams exclusion) and spec 1230's contributions (`discussion_id`/`resume_context`, `replies[]`, register/consume token registry). The persona/job now cites the actual JTBD entry.
- **Design 1270-a** adds three components: `services/apptoken` (single custody point for the App private key, with a control-plane gRPC face for bridges and a public HTTPS face for runner OIDC), `services/tenancy` (registry mapping `(channel, channel_tenant_key) → Tenant`), and tenancy in `libraries/libbridge` (channel-agnostic `TenantResolver` interface). Per-tenant cross-tenant rejection is achieved by tenant-binding the inherited 1230 single-use token (`/callback/{tenant_id}/{token}`) — no new cryptographic primitive. Per-tenant storage isolation via one `DiscussionContextStore` instance per resolved tenant under `tenants/{tenant_id}/`, with single-tenant mode unchanged so self-hosted data files are read in place without migration.

`wiki/STATUS.md` set to `1270 design approved`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- [ ] kata-spec / kata-design review panels were run during preparation (spec: 8 rounds × 6 reviewers; design: 4 rounds × 3 reviewers). Final design panel returned no blockers and no highs; remaining individual-reviewer wording preferences are recorded as verified-and-dismissed per the kata-review caller protocol.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158sr7X9bccqJt2Dxjh1oHz)_