### PR TITLE
perf(tests): cut suite to 49s via DI; spec 1370 charters monorepo rollout

### DIFF
--- a/libraries/libeval/test/benchmark-e2e.test.js
+++ b/libraries/libeval/test/benchmark-e2e.test.js
@@ -9,7 +9,7 @@
  * `supervisor-run.test.js`.
  */
 
-import { describe, test } from "node:test";
+import { describe, test, before } from "node:test";
 import assert from "node:assert";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -141,7 +141,23 @@ async function collectRecords(runner) {
 }
 
 describe("BenchmarkRunner E2E (fixture family)", () => {
-  test("produces one record per (task, runIndex), including pre-flight failures", async () => {
+  // Tests 1, 2, 4, 5, 6 share the runs:1 / mockRunAgent configuration and
+  // only differ in what they assert against the resulting records — set up
+  // once instead of paying the runner.run() cost five times.
+  let sharedRecords;
+  // Shared setup does a full runner.run() with 4 tasks; on slower CI hardware
+  // the default 5s test timeout is tight, so explicitly budget headroom.
+  before(
+    async () => {
+      const { runner } = await setupRunner({ runs: 1 });
+      sharedRecords = await collectRecords(runner);
+    },
+    { timeout: 30_000 },
+  );
+
+  test("produces one record per (task, runIndex), including pre-flight failures", {
+    timeout: 30_000,
+  }, async () => {
     const { runner, out } = await setupRunner({ runs: 2 });
     const records = await collectRecords(runner);
     // 4 tasks × 2 runs = 8 records (preflight-broken records included).
@@ -171,10 +187,8 @@ describe("BenchmarkRunner E2E (fixture family)", () => {
     }
   });
 
-  test("pass: running-service grading via HTTP probe yields verdict='pass'", async () => {
-    const { runner } = await setupRunner({ runs: 1 });
-    const records = await collectRecords(runner);
-    const passRec = records.find((r) => r.taskId === "pass");
+  test("pass: running-service grading via HTTP probe yields verdict='pass'", () => {
+    const passRec = sharedRecords.find((r) => r.taskId === "pass");
     assert.ok(passRec, "pass record missing");
     assert.strictEqual(passRec.scoring.verdict, "pass");
     assert.strictEqual(passRec.scoring.exitCode, 0);
@@ -182,19 +196,15 @@ describe("BenchmarkRunner E2E (fixture family)", () => {
     assert.strictEqual(passRec.scoring.details[0].test, "probe");
   });
 
-  test("repo-state: repository-state grading via SHA-256 yields verdict='pass'", async () => {
-    const { runner } = await setupRunner({ runs: 1 });
-    const records = await collectRecords(runner);
-    const rs = records.find((r) => r.taskId === "repo-state");
+  test("repo-state: repository-state grading via SHA-256 yields verdict='pass'", () => {
+    const rs = sharedRecords.find((r) => r.taskId === "repo-state");
     assert.ok(rs);
     assert.strictEqual(rs.scoring.verdict, "pass");
     assert.strictEqual(rs.verdict, "pass");
   });
 
   test("scoring sentinel filename never appears in the agent trace", async () => {
-    const { runner } = await setupRunner({ runs: 1 });
-    const records = await collectRecords(runner);
-    for (const r of records) {
+    for (const r of sharedRecords) {
       if (!r.agentTracePath) continue;
       const body = await readFile(r.agentTracePath, "utf8").catch(() => "");
       assert.ok(
@@ -204,10 +214,8 @@ describe("BenchmarkRunner E2E (fixture family)", () => {
     }
   });
 
-  test("judge prompt has {{SCORING_RESULT}} substituted (verdict tracks scoring)", async () => {
-    const { runner } = await setupRunner({ runs: 1 });
-    const records = await collectRecords(runner);
-    for (const r of records) {
+  test("judge prompt has {{SCORING_RESULT}} substituted (verdict tracks scoring)", () => {
+    for (const r of sharedRecords) {
       if (r.preflightError) continue;
       assert.strictEqual(
         r.scoring.verdict === "pass" ? "pass" : "fail",
@@ -218,9 +226,7 @@ describe("BenchmarkRunner E2E (fixture family)", () => {
   });
 
   test("traces are consumable by fit-trace overview", async () => {
-    const { runner } = await setupRunner({ runs: 1 });
-    const records = await collectRecords(runner);
-    for (const r of records) {
+    for (const r of sharedRecords) {
       if (!r.agentTracePath) continue;
       const ndjson = await readFile(r.agentTracePath, "utf8").catch(() => "");
       if (!ndjson) continue;
@@ -234,7 +240,9 @@ describe("BenchmarkRunner E2E (fixture family)", () => {
     }
   });
 
-  test("report aggregator computes pass@k over the JSONL file", async () => {
+  test("report aggregator computes pass@k over the JSONL file", {
+    timeout: 30_000,
+  }, async () => {
     const { runner, out } = await setupRunner({ runs: 2 });
     await collectRecords(runner);
     const report = await aggregate({ inputDir: out, kValues: [1] });

--- a/libraries/libmock/src/mock/clock.js
+++ b/libraries/libmock/src/mock/clock.js
@@ -1,0 +1,45 @@
+import { spy } from "./spy.js";
+
+/**
+ * Creates a mock clock with controllable time and a no-wait sleep.
+ *
+ * `now()` returns the current virtual time in ms. `sleep(ms)` advances
+ * virtual time by `ms` and resolves on the next microtask — no real
+ * timers are scheduled. `advance(ms)` lets a test move time forward
+ * without going through `sleep` (e.g. to expire a token).
+ *
+ * Pass `{ sleep, now }` from a returned clock to any constructor that
+ * accepts those collaborators to make its tests deterministic.
+ *
+ * @param {object} [options]
+ * @param {number} [options.start=0] - Initial virtual time in ms.
+ * @returns {{
+ *   now: () => number,
+ *   sleep: (ms: number) => Promise<void>,
+ *   advance: (ms: number) => void,
+ *   set: (ms: number) => void,
+ *   sleeps: Array<number>,
+ * }}
+ */
+export function createMockClock({ start = 0 } = {}) {
+  let current = start;
+  const sleeps = [];
+
+  const now = spy(() => current);
+  const sleep = spy(async (ms) => {
+    sleeps.push(ms);
+    current += ms;
+  });
+
+  return {
+    now,
+    sleep,
+    advance(ms) {
+      current += ms;
+    },
+    set(ms) {
+      current = ms;
+    },
+    sleeps,
+  };
+}

--- a/libraries/libmock/src/mock/index.js
+++ b/libraries/libmock/src/mock/index.js
@@ -25,6 +25,7 @@ export {
 } from "./clients.js";
 export { createMockServiceCallbacks } from "./service-callbacks.js";
 export { createMockFs } from "./fs.js";
+export { createMockClock } from "./clock.js";
 export { spy } from "./spy.js";
 export {
   createMockSupabaseClient,

--- a/libraries/libmock/src/mock/observer.js
+++ b/libraries/libmock/src/mock/observer.js
@@ -37,6 +37,10 @@ export function createMockTracer(overrides = {}) {
       trace_id: `trace-${Date.now()}`,
       name,
       ...options,
+      addEvent: spy(),
+      setOk: spy(),
+      setError: spy(),
+      end: spy(async () => {}),
     })),
     startClientSpan: spy((_service, _method) => ({
       span: {

--- a/libraries/librpc/src/auth.js
+++ b/libraries/librpc/src/auth.js
@@ -8,14 +8,17 @@ import grpc from "@grpc/grpc-js";
 export class HmacAuth {
   #secret;
   #tokenLifetimeMs;
+  #now;
 
   /**
    * Creates a new HMAC authenticator instance
    * @param {string} secret - Shared secret key for HMAC generation (minimum 32 characters)
    * @param {number} tokenLifetimeSeconds - Token lifetime in seconds (default: 60)
+   * @param {object} [options] - Optional collaborators
+   * @param {() => number} [options.now] - Injectable clock (default: Date.now)
    * @throws {Error} When secret is too short or invalid
    */
-  constructor(secret, tokenLifetimeSeconds = 60) {
+  constructor(secret, tokenLifetimeSeconds = 60, { now = Date.now } = {}) {
     if (!secret || typeof secret !== "string") {
       throw new Error("Secret must be a non-empty string");
     }
@@ -28,6 +31,7 @@ export class HmacAuth {
 
     this.#secret = secret;
     this.#tokenLifetimeMs = tokenLifetimeSeconds * 1000;
+    this.#now = now;
   }
 
   /**
@@ -41,7 +45,7 @@ export class HmacAuth {
       throw new Error("Service ID must be a non-empty string");
     }
 
-    const timestamp = Date.now();
+    const timestamp = this.#now();
     const payload = `${serviceId}:${timestamp}`;
     const signature = crypto
       .createHmac("sha256", this.#secret)
@@ -92,7 +96,7 @@ export class HmacAuth {
       }
 
       // Check token expiration
-      const now = Date.now();
+      const now = this.#now();
       if (now - timestamp > this.#tokenLifetimeMs) {
         return {
           isValid: false,

--- a/libraries/librpc/test/auth.test.js
+++ b/libraries/librpc/test/auth.test.js
@@ -2,7 +2,7 @@ import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert";
 
 import { createAuth, HmacAuth } from "../src/index.js";
-import { assertThrowsMessage } from "@forwardimpact/libmock";
+import { assertThrowsMessage, createMockClock } from "@forwardimpact/libmock";
 
 describe("Auth", () => {
   describe("HmacAuth", () => {
@@ -30,16 +30,18 @@ describe("Auth", () => {
       assert.strictEqual(result.serviceId, serviceId);
     });
 
-    test("should reject expired tokens", async () => {
+    test("should reject expired tokens", () => {
       const secret = "test-secret-that-is-at-least-32-characters-long";
-      // 1 second lifetime
-      const auth = new HmacAuth(secret, 1);
+      // 1 second lifetime, with an injected clock so the test doesn't
+      // have to sleep through real time.
+      const clock = createMockClock({ start: 1_000_000 });
+      const auth = new HmacAuth(secret, 1, { now: clock.now });
       const serviceId = "test-service";
 
       const token = auth.generateToken(serviceId);
 
-      // Wait for token to expire (1.1 seconds)
-      await new Promise((resolve) => setTimeout(resolve, 1100));
+      // Move past the 1-second lifetime.
+      clock.advance(1100);
 
       const result = auth.verifyToken(token);
       assert.strictEqual(result.isValid, false);

--- a/libraries/libsyntheticgen/test/faker.test.js
+++ b/libraries/libsyntheticgen/test/faker.test.js
@@ -4,12 +4,10 @@ import { FakerTool } from "../src/tools/faker.js";
 import {
   assertRejectsMessage,
   assertThrowsMessage,
+  createSilentLogger,
 } from "@forwardimpact/libmock";
 
-const logger = {
-  info() {},
-  error() {},
-};
+const logger = createSilentLogger();
 
 describe("FakerTool", () => {
   test("requires logger", () => {

--- a/libraries/libsyntheticgen/test/sdv.test.js
+++ b/libraries/libsyntheticgen/test/sdv.test.js
@@ -4,9 +4,10 @@ import { SdvTool } from "../src/tools/sdv.js";
 import {
   assertRejectsMessage,
   assertThrowsMessage,
+  createSilentLogger,
 } from "@forwardimpact/libmock";
 
-const logger = { info() {}, error() {} };
+const logger = createSilentLogger();
 
 describe("SdvTool", () => {
   test("requires all dependencies", () => {

--- a/libraries/libsyntheticgen/test/synthea.test.js
+++ b/libraries/libsyntheticgen/test/synthea.test.js
@@ -4,9 +4,10 @@ import { SyntheaTool } from "../src/tools/synthea.js";
 import {
   assertRejectsMessage,
   assertThrowsMessage,
+  createSilentLogger,
 } from "@forwardimpact/libmock";
 
-const logger = { info() {}, error() {} };
+const logger = createSilentLogger();
 
 describe("SyntheaTool", () => {
   test("requires all dependencies", () => {

--- a/libraries/libsyntheticrender/test/validate.test.js
+++ b/libraries/libsyntheticrender/test/validate.test.js
@@ -1,7 +1,10 @@
 import { describe, test } from "node:test";
 import assert from "node:assert";
 import { validateCrossContent, ContentValidator } from "../src/validate.js";
-import { assertThrowsMessage } from "@forwardimpact/libmock";
+import {
+  assertThrowsMessage,
+  createSilentLogger,
+} from "@forwardimpact/libmock";
 
 /**
  * Build minimal valid entities for testing.
@@ -401,7 +404,7 @@ describe("ContentValidator", () => {
   });
 
   test("validates entities using validate method", () => {
-    const logger = { info() {}, error() {} };
+    const logger = createSilentLogger();
     const validator = new ContentValidator(logger);
     const result = validator.validate(buildEntities());
     assert.strictEqual(result.passed, true);

--- a/libraries/libutil/src/retry.js
+++ b/libraries/libutil/src/retry.js
@@ -1,19 +1,25 @@
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * Retry class for handling transient errors with exponential backoff
  */
 export class Retry {
   #retries;
   #delay;
+  #sleep;
 
   /**
    * Creates a new Retry instance
    * @param {object} [config] - Optional configuration object
    * @param {number} [config.retries] - Maximum number of retry attempts (default: 10)
    * @param {number} [config.delay] - Initial delay in milliseconds (default: 1000)
+   * @param {(ms: number) => Promise<void>} [config.sleep] - Injectable sleep
+   *   for deterministic tests (default: real setTimeout-based wait).
    */
   constructor(config = {}) {
     this.#retries = config.retries ?? 10;
     this.#delay = config.delay ?? 1000;
+    this.#sleep = config.sleep ?? defaultSleep;
   }
 
   /**
@@ -87,7 +93,7 @@ export class Retry {
           const exponentialDelay = this.#delay * Math.pow(2, attempt);
           const jitter = Math.random() * 0.3 * exponentialDelay;
           const wait = exponentialDelay + jitter;
-          await new Promise((resolve) => setTimeout(resolve, wait));
+          await this.#sleep(wait);
           continue;
         }
 
@@ -100,7 +106,7 @@ export class Retry {
           const exponentialDelay = this.#delay * Math.pow(2, attempt);
           const jitter = Math.random() * 0.3 * exponentialDelay;
           const wait = exponentialDelay + jitter;
-          await new Promise((resolve) => setTimeout(resolve, wait));
+          await this.#sleep(wait);
           continue;
         }
 

--- a/libraries/libutil/test/retry.test.js
+++ b/libraries/libutil/test/retry.test.js
@@ -1,16 +1,18 @@
 import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert";
-import { spy } from "@forwardimpact/libmock";
+import { createMockClock, spy } from "@forwardimpact/libmock";
 
 // Module under test
 import { Retry } from "../src/retry.js";
 
 describe("Retry", () => {
   let retry;
+  let clock;
 
   beforeEach(() => {
-    // Use very short delay for testing to speed up retry tests
-    retry = new Retry({ delay: 1 });
+    // Mock clock collapses every backoff sleep to a microtask.
+    clock = createMockClock();
+    retry = new Retry({ delay: 1, sleep: clock.sleep });
   });
 
   test("creates retry instance with default config", () => {

--- a/libraries/libwiki/src/commands/claim.js
+++ b/libraries/libwiki/src/commands/claim.js
@@ -8,15 +8,16 @@ import {
   parseClaims,
   filterExpired,
 } from "../active-claims.js";
+import { createDefaultIo } from "../io.js";
 
-function projectRoot() {
+function projectRoot(io) {
   const logger = { debug() {} };
-  const finder = new Finder(fsAsync, logger, process);
-  return finder.findProjectRoot(process.cwd());
+  const finder = new Finder(fsAsync, logger, { cwd: io.cwd });
+  return finder.findProjectRoot(io.cwd());
 }
 
-function memoryPath(values) {
-  const root = projectRoot();
+function memoryPath(values, io) {
+  const root = projectRoot(io);
   const wikiRoot = values["wiki-root"] || path.join(root, "wiki");
   return path.join(wikiRoot, "MEMORY.md");
 }
@@ -33,19 +34,19 @@ function addDays(today, n) {
 }
 
 /** Insert a row into MEMORY.md `## Active Claims`. Refuses if (agent, target) already present. */
-export function runClaimCommand(values, _args, cli) {
-  const agent = values.agent || process.env.LIBEVAL_AGENT_PROFILE;
+export function runClaimCommand(values, _args, cli, io = createDefaultIo()) {
+  const agent = values.agent || io.env.LIBEVAL_AGENT_PROFILE;
   if (!agent) {
     cli.usageError("claim requires --agent or LIBEVAL_AGENT_PROFILE");
-    process.exit(2);
+    return io.exit(2);
   }
   if (!values.target || !values.branch) {
     cli.usageError("claim requires --target and --branch");
-    process.exit(2);
+    return io.exit(2);
   }
-  const today = values.today || new Date().toISOString().slice(0, 10);
+  const today = values.today || io.today();
   const expires = values["expires-at"] || addDays(today, 7);
-  const memPath = memoryPath(values);
+  const memPath = memoryPath(values, io);
   const text = readMemory(memPath);
   const result = appendClaim(text, {
     agent,
@@ -56,22 +57,20 @@ export function runClaimCommand(values, _args, cli) {
     expires_at: expires,
   });
   if (!result.inserted) {
-    process.stderr.write(
-      `claim already exists for ${agent}/${values.target}\n`,
-    );
-    process.exit(2);
+    io.stderr(`claim already exists for ${agent}/${values.target}\n`);
+    return io.exit(2);
   }
   writeFileSync(memPath, result.text);
-  process.stdout.write(`claimed ${values.target} (expires ${expires})\n`);
+  io.stdout(`claimed ${values.target} (expires ${expires})\n`);
 }
 
 /** Remove a claim row. `--expired` cleans every row past expires_at. */
-export function runReleaseCommand(values, _args, cli) {
-  const memPath = memoryPath(values);
+export function runReleaseCommand(values, _args, cli, io = createDefaultIo()) {
+  const memPath = memoryPath(values, io);
   const text = readMemory(memPath);
 
   if (values.expired) {
-    const today = values.today || new Date().toISOString().slice(0, 10);
+    const today = values.today || io.today();
     const claims = parseClaims(text);
     const { expired } = filterExpired(claims, today);
     let current = text;
@@ -84,24 +83,24 @@ export function runReleaseCommand(values, _args, cli) {
       }
     }
     writeFileSync(memPath, current);
-    process.stdout.write(`released ${count} expired claim(s)\n`);
+    io.stdout(`released ${count} expired claim(s)\n`);
     return;
   }
 
-  const agent = values.agent || process.env.LIBEVAL_AGENT_PROFILE;
+  const agent = values.agent || io.env.LIBEVAL_AGENT_PROFILE;
   if (!agent) {
     cli.usageError("release requires --agent or --expired");
-    process.exit(2);
+    return io.exit(2);
   }
   if (!values.target) {
     cli.usageError("release requires --target (or --expired)");
-    process.exit(2);
+    return io.exit(2);
   }
   const result = removeClaim(text, { agent, target: values.target });
   writeFileSync(memPath, result.text);
   if (!result.removed) {
-    process.stdout.write(`no matching claim for ${agent}/${values.target}\n`);
+    io.stdout(`no matching claim for ${agent}/${values.target}\n`);
   } else {
-    process.stdout.write(`released ${values.target}\n`);
+    io.stdout(`released ${values.target}\n`);
   }
 }

--- a/libraries/libwiki/src/commands/init.js
+++ b/libraries/libwiki/src/commands/init.js
@@ -6,6 +6,7 @@ import { Finder } from "@forwardimpact/libutil";
 import { createScriptConfig } from "@forwardimpact/libconfig";
 import { WikiRepo } from "../wiki-repo.js";
 import { listSkills } from "../skill-roster.js";
+import { createDefaultIo } from "../io.js";
 import {
   ACTIVE_CLAIMS_HEADING,
   ACTIVE_CLAIMS_TABLE_HEADER,
@@ -13,8 +14,8 @@ import {
 } from "../constants.js";
 
 /** Resolve the wiki clone URL. Honors the FIT_WIKI_URL env var as an explicit override (for sandboxed environments where `origin` is rewritten to a local proxy that does not serve wiki repos); otherwise derives the URL by appending `.wiki.git` to the parent repo's `origin` remote. */
-export function deriveWikiUrl(parentDir) {
-  if (process.env.FIT_WIKI_URL) return process.env.FIT_WIKI_URL;
+export function deriveWikiUrl(parentDir, env = process.env) {
+  if (env.FIT_WIKI_URL) return env.FIT_WIKI_URL;
 
   const r = spawnSync("git", ["-C", parentDir, "remote", "get-url", "origin"], {
     encoding: "utf-8",
@@ -55,12 +56,10 @@ function scaffoldActiveClaims(memoryPath) {
   return true;
 }
 
-async function maybeCloneWiki(projectRoot, wikiDir) {
-  const wikiUrl = deriveWikiUrl(projectRoot);
+async function maybeCloneWiki(projectRoot, wikiDir, io) {
+  const wikiUrl = deriveWikiUrl(projectRoot, io.env);
   if (!wikiUrl) {
-    process.stderr.write(
-      "init: could not determine wiki URL from origin remote\n",
-    );
+    io.stderr("init: could not determine wiki URL from origin remote\n");
     return;
   }
   const config = await createScriptConfig("wiki");
@@ -73,17 +72,20 @@ async function maybeCloneWiki(projectRoot, wikiDir) {
   if (cloneResult.cloned) {
     repo.inheritIdentity();
   } else {
-    process.stderr.write(
-      "init: could not clone wiki, continuing with local-only steps\n",
-    );
+    io.stderr("init: could not clone wiki, continuing with local-only steps\n");
   }
 }
 
 /** Clone the wiki if not already present, scaffold Active Claims in MEMORY.md, and create per-skill metric directories. */
-export async function runInitCommand(values, _args, _cli) {
+export async function runInitCommand(
+  values,
+  _args,
+  _cli,
+  io = createDefaultIo(),
+) {
   const logger = { debug() {} };
-  const finder = new Finder(fsAsync, logger, process);
-  const projectRoot = finder.findProjectRoot(process.cwd());
+  const finder = new Finder(fsAsync, logger, { cwd: io.cwd });
+  const projectRoot = finder.findProjectRoot(io.cwd());
 
   const wikiDir = path.resolve(projectRoot, values["wiki-root"] ?? "wiki");
   const skillsDir = path.resolve(
@@ -91,7 +93,7 @@ export async function runInitCommand(values, _args, _cli) {
     values["skills-dir"] ?? path.join(".claude", "skills"),
   );
 
-  await maybeCloneWiki(projectRoot, wikiDir);
+  await maybeCloneWiki(projectRoot, wikiDir, io);
 
   if (existsSync(skillsDir)) {
     for (const slug of listSkills({ skillsDir })) {
@@ -102,11 +104,9 @@ export async function runInitCommand(values, _args, _cli) {
   if (existsSync(wikiDir)) {
     const memoryPath = path.join(wikiDir, "MEMORY.md");
     if (scaffoldActiveClaims(memoryPath)) {
-      process.stdout.write(
-        `init: scaffolded ${ACTIVE_CLAIMS_HEADING} in ${memoryPath}\n`,
-      );
+      io.stdout(`init: scaffolded ${ACTIVE_CLAIMS_HEADING} in ${memoryPath}\n`);
     }
   }
 
-  process.stdout.write(`init: wiki ready at ${wikiDir}\n`);
+  io.stdout(`init: wiki ready at ${wikiDir}\n`);
 }

--- a/libraries/libwiki/src/commands/log.js
+++ b/libraries/libwiki/src/commands/log.js
@@ -8,24 +8,24 @@ import {
   appendEntry,
 } from "../weekly-log.js";
 import { DECISION_HEADING } from "../constants.js";
+import { createDefaultIo } from "../io.js";
 
-function projectRootForCommand() {
+function projectRootForCommand(io) {
   const logger = { debug() {} };
-  const finder = new Finder(fsAsync, logger, process);
-  return finder.findProjectRoot(process.cwd());
+  const finder = new Finder(fsAsync, logger, { cwd: io.cwd });
+  return finder.findProjectRoot(io.cwd());
 }
 
-function commonContext(values) {
-  const agent = values.agent || process.env.LIBEVAL_AGENT_PROFILE;
+function commonContext(values, io) {
+  const agent = values.agent || io.env.LIBEVAL_AGENT_PROFILE;
   if (!agent) {
-    process.stderr.write(
-      "log requires --agent <name> or LIBEVAL_AGENT_PROFILE env var\n",
-    );
-    process.exit(2);
+    io.stderr("log requires --agent <name> or LIBEVAL_AGENT_PROFILE env var\n");
+    io.exit(2);
+    return null;
   }
-  const projectRoot = projectRootForCommand();
+  const projectRoot = projectRootForCommand(io);
   const wikiRoot = values["wiki-root"] || path.join(projectRoot, "wiki");
-  const today = values.today || new Date().toISOString().slice(0, 10);
+  const today = values.today || io.today();
   return { agent, wikiRoot, today };
 }
 
@@ -39,8 +39,10 @@ function lastDateHeading(text) {
   return last;
 }
 
-function runDecision(values) {
-  const { agent, wikiRoot, today } = commonContext(values);
+function runDecision(values, io) {
+  const ctx = commonContext(values, io);
+  if (!ctx) return;
+  const { agent, wikiRoot, today } = ctx;
   const surveyed = values.surveyed || "—";
   const chosen = values.chosen || "—";
   const rationale = values.rationale || "—";
@@ -63,14 +65,17 @@ function runDecision(values) {
   rotateIfOverBudget(wikiRoot, agent, today, lineCount);
   const target = weeklyLogPath(wikiRoot, agent, today);
   appendEntry(target, body, agent, today);
-  process.stdout.write(`logged decision to ${target}\n`);
+  io.stdout(`logged decision to ${target}\n`);
 }
 
-function runNote(values) {
-  const { agent, wikiRoot, today } = commonContext(values);
+function runNote(values, io) {
+  const ctx = commonContext(values, io);
+  if (!ctx) return;
+  const { agent, wikiRoot, today } = ctx;
   if (!values.field || !values.body) {
-    process.stderr.write("log note requires --field and --body\n");
-    process.exit(2);
+    io.stderr("log note requires --field and --body\n");
+    io.exit(2);
+    return;
   }
   const fieldBlock = `### ${values.field}\n\n${values.body}\n`;
   // Conservative line budget: assume we'll prepend a date heading.
@@ -82,28 +87,30 @@ function runNote(values) {
   const existing = existsSync(target) ? readFileSync(target, "utf-8") : "";
   const body = lastDateHeading(existing) === today ? fieldBlock : withHeading;
   appendEntry(target, body, agent, today);
-  process.stdout.write(`logged note to ${target}\n`);
+  io.stdout(`logged note to ${target}\n`);
 }
 
-function runDone(values) {
-  const { agent, wikiRoot, today } = commonContext(values);
+function runDone(values, io) {
+  const ctx = commonContext(values, io);
+  if (!ctx) return;
+  const { agent, wikiRoot, today } = ctx;
   const body = `### Closed\n\nRun closed ${today}.\n`;
   const lineCount = body.split("\n").length;
   rotateIfOverBudget(wikiRoot, agent, today, lineCount);
   const target = weeklyLogPath(wikiRoot, agent, today);
   appendEntry(target, body, agent, today);
-  process.stdout.write(`closed entry in ${target}\n`);
+  io.stdout(`closed entry in ${target}\n`);
 }
 
 const SUBS = { decision: runDecision, note: runNote, done: runDone };
 
 /** Dispatch `log {decision|note|done}` to the matching sub-handler. */
-export function runLogCommand(values, args, cli) {
+export function runLogCommand(values, args, cli, io = createDefaultIo()) {
   const sub = args[0];
   const handler = SUBS[sub];
   if (!handler) {
     cli.usageError("log requires subcommand: decision | note | done");
-    process.exit(2);
+    return io.exit(2);
   }
-  handler(values);
+  handler(values, io);
 }

--- a/libraries/libwiki/src/commands/refresh.js
+++ b/libraries/libwiki/src/commands/refresh.js
@@ -7,16 +7,16 @@ import { createScriptConfig } from "@forwardimpact/libconfig";
 import { scanMarkers } from "../marker-scanner.js";
 import { renderBlock, BlockRenderError } from "../block-renderer.js";
 import { renderIssueList, parseRepoSlug } from "../issue-list-renderer.js";
+import { createDefaultIo } from "../io.js";
 
-function currentStoryboardPath() {
-  const now = new Date();
+function currentStoryboardPath(now = new Date()) {
   const yyyy = now.getFullYear();
   const mm = String(now.getMonth() + 1).padStart(2, "0");
   return `wiki/storyboard-${yyyy}-M${mm}.md`;
 }
 
-function deriveParentRepo(parentDir) {
-  if (process.env.FIT_GH_REPO) return process.env.FIT_GH_REPO;
+function deriveParentRepo(parentDir, env) {
+  if (env.FIT_GH_REPO) return env.FIT_GH_REPO;
   const r = spawnSync("git", ["-C", parentDir, "remote", "get-url", "origin"], {
     encoding: "utf-8",
     stdio: "pipe",
@@ -55,10 +55,15 @@ function spliceBlock(lines, block, rendered) {
 }
 
 /** Re-render XmR chart blocks and issue-list blocks in a storyboard file. */
-export async function runRefreshCommand(values, args, _cli) {
+export async function runRefreshCommand(
+  values,
+  args,
+  _cli,
+  io = createDefaultIo(),
+) {
   const logger = { debug() {} };
-  const finder = new Finder(fsAsync, logger, process);
-  const projectRoot = finder.findProjectRoot(process.cwd());
+  const finder = new Finder(fsAsync, logger, { cwd: io.cwd });
+  const projectRoot = finder.findProjectRoot(io.cwd());
 
   const storyboardPath = path.resolve(
     projectRoot,
@@ -84,7 +89,7 @@ export async function runRefreshCommand(values, args, _cli) {
   // overrides the parsed origin.
   const ghContext = {
     cwd: projectRoot,
-    repo: deriveParentRepo(projectRoot),
+    repo: deriveParentRepo(projectRoot, io.env),
     token,
   };
 
@@ -100,7 +105,7 @@ export async function runRefreshCommand(values, args, _cli) {
       spliced = true;
     } catch (err) {
       if (!(err instanceof BlockRenderError)) throw err;
-      process.stderr.write(
+      io.stderr(
         `refresh-error ${storyboardPath}:${block.openLine + 1} ${err.message}\n`,
       );
     }
@@ -108,8 +113,6 @@ export async function runRefreshCommand(values, args, _cli) {
 
   if (spliced) writeFileSync(storyboardPath, lines.join("\n"));
   if (values && values.format === "json") {
-    process.stdout.write(
-      JSON.stringify({ blocks: blocks.length, spliced }) + "\n",
-    );
+    io.stdout(JSON.stringify({ blocks: blocks.length, spliced }) + "\n");
   }
 }

--- a/libraries/libwiki/src/io.js
+++ b/libraries/libwiki/src/io.js
@@ -1,0 +1,77 @@
+/**
+ * Process-bound I/O collaborators shared across libwiki commands.
+ *
+ * Each command accepts an optional `io` argument; when omitted, the
+ * bound `process.*` defaults run. Tests construct a synthetic `io`
+ * (e.g. capturing stdout into a string and recording exit codes
+ * instead of terminating the runner) and call command handlers
+ * directly, avoiding `execFileSync("node", [...])`.
+ */
+export function createDefaultIo() {
+  return {
+    stdout: (s) => process.stdout.write(s),
+    stderr: (s) => process.stderr.write(s),
+    exit: (code) => process.exit(code),
+    cwd: () => process.cwd(),
+    env: process.env,
+    today: () => new Date().toISOString().slice(0, 10),
+  };
+}
+
+/**
+ * Test helper: synthetic `io` that captures stdout/stderr into strings
+ * and records exit codes instead of terminating the process. After a
+ * handler returns, inspect `out`/`err`/`exitCode` to assert behavior.
+ *
+ * @param {object} overrides - Per-test overrides (cwd, env, today).
+ * @returns {object} `{ stdout, stderr, exit, cwd, env, today, out, err, exitCode }`
+ */
+export function createTestIo(overrides = {}) {
+  const io = {
+    out: "",
+    err: "",
+    exitCode: null,
+    stdout(s) {
+      io.out += s;
+    },
+    stderr(s) {
+      io.err += s;
+    },
+    exit(code) {
+      io.exitCode = code;
+      throw new IoExit(code);
+    },
+    cwd: overrides.cwd ?? (() => process.cwd()),
+    env: overrides.env ?? process.env,
+    today: overrides.today ?? (() => new Date().toISOString().slice(0, 10)),
+  };
+  return io;
+}
+
+/**
+ * Thrown by `createTestIo`'s `exit` so handlers stop unwinding the way
+ * `process.exit` would. Tests can catch it or wrap calls in
+ * `runWithIo(() => handler(...), io)`.
+ */
+export class IoExit extends Error {
+  /** @param {number} code - Exit code the handler asked the process to exit with. */
+  constructor(code) {
+    super(`IoExit(${code})`);
+    this.name = "IoExit";
+    this.code = code;
+  }
+}
+
+/**
+ * Run a handler that may call `io.exit()`; swallow the synthetic
+ * IoExit so callers can inspect `io.exitCode` linearly without
+ * try/catch boilerplate.
+ */
+export async function runWithIo(fn) {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof IoExit) return undefined;
+    throw err;
+  }
+}

--- a/libraries/libwiki/test/cli-claim.test.js
+++ b/libraries/libwiki/test/cli-claim.test.js
@@ -9,14 +9,25 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
 
-const CLI_PATH = new URL("../bin/fit-wiki.js", import.meta.url).pathname;
+import { runClaimCommand, runReleaseCommand } from "../src/commands/claim.js";
+import { createTestIo, runWithIo } from "../src/io.js";
+
+function makeCli() {
+  return {
+    errors: [],
+    usageError(message) {
+      this.errors.push(message);
+    },
+  };
+}
 
 describe("fit-wiki claim/release CLI", () => {
   let dir;
   let wikiRoot;
   let memoryPath;
+  let cli;
+  let io;
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "claim-cli-"));
     wikiRoot = join(dir, "wiki");
@@ -27,122 +38,78 @@ describe("fit-wiki claim/release CLI", () => {
       memoryPath,
       "## Active Claims\n\n| agent | target | branch | pr | claimed_at | expires_at |\n| --- | --- | --- | --- | --- | --- |\n| *None* | — | — | — | — | — |\n",
     );
+    cli = makeCli();
+    io = createTestIo({ cwd: () => dir });
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
-  test("claim inserts a row", () => {
-    execFileSync(
-      "node",
-      [
-        CLI_PATH,
-        "claim",
-        "--agent",
-        "staff-engineer",
-        "--target",
-        "spec-NNNN",
-        "--branch",
-        "feat/x",
-        "--today",
-        "2026-05-19",
-      ],
-      { cwd: dir, encoding: "utf-8" },
+  test("claim inserts a row", async () => {
+    await runWithIo(() =>
+      runClaimCommand(
+        {
+          agent: "staff-engineer",
+          target: "spec-NNNN",
+          branch: "feat/x",
+          today: "2026-05-19",
+        },
+        [],
+        cli,
+        io,
+      ),
     );
     const text = readFileSync(memoryPath, "utf-8");
     assert.match(text, /staff-engineer \| spec-NNNN \| feat\/x/);
+    assert.equal(io.exitCode, null);
   });
 
-  test("claim refuses duplicates with exit 2", () => {
-    execFileSync(
-      "node",
-      [
-        CLI_PATH,
-        "claim",
-        "--agent",
-        "staff-engineer",
-        "--target",
-        "spec-NNNN",
-        "--branch",
-        "feat/x",
-      ],
-      {
-        cwd: dir,
-        encoding: "utf-8",
-      },
+  test("claim refuses duplicates with exit 2", async () => {
+    await runWithIo(() =>
+      runClaimCommand(
+        { agent: "staff-engineer", target: "spec-NNNN", branch: "feat/x" },
+        [],
+        cli,
+        io,
+      ),
     );
-    try {
-      execFileSync(
-        "node",
-        [
-          CLI_PATH,
-          "claim",
-          "--agent",
-          "staff-engineer",
-          "--target",
-          "spec-NNNN",
-          "--branch",
-          "feat/y",
-        ],
-        {
-          cwd: dir,
-          encoding: "utf-8",
-          stdio: "pipe",
-        },
-      );
-      assert.fail("expected non-zero exit");
-    } catch (err) {
-      assert.equal(err.status, 2);
-    }
+    await runWithIo(() =>
+      runClaimCommand(
+        { agent: "staff-engineer", target: "spec-NNNN", branch: "feat/y" },
+        [],
+        cli,
+        io,
+      ),
+    );
+    assert.equal(io.exitCode, 2);
   });
 
-  test("release removes a row", () => {
-    execFileSync(
-      "node",
-      [
-        CLI_PATH,
-        "claim",
-        "--agent",
-        "staff-engineer",
-        "--target",
-        "spec-NNNN",
-        "--branch",
-        "feat/x",
-      ],
-      {
-        cwd: dir,
-        encoding: "utf-8",
-      },
+  test("release removes a row", async () => {
+    await runWithIo(() =>
+      runClaimCommand(
+        { agent: "staff-engineer", target: "spec-NNNN", branch: "feat/x" },
+        [],
+        cli,
+        io,
+      ),
     );
-    execFileSync(
-      "node",
-      [
-        CLI_PATH,
-        "release",
-        "--agent",
-        "staff-engineer",
-        "--target",
-        "spec-NNNN",
-      ],
-      {
-        cwd: dir,
-        encoding: "utf-8",
-      },
+    await runWithIo(() =>
+      runReleaseCommand(
+        { agent: "staff-engineer", target: "spec-NNNN" },
+        [],
+        cli,
+        io,
+      ),
     );
     const text = readFileSync(memoryPath, "utf-8");
     assert.doesNotMatch(text, /staff-engineer \| spec-NNNN/);
   });
 
-  test("release --expired clears expired rows", () => {
+  test("release --expired clears expired rows", async () => {
     writeFileSync(
       memoryPath,
       "## Active Claims\n\n| agent | target | branch | pr | claimed_at | expires_at |\n| --- | --- | --- | --- | --- | --- |\n| staff-engineer | old | feat/o | — | 2026-04-01 | 2026-04-08 |\n| staff-engineer | new | feat/n | — | 2026-05-19 | 2026-05-26 |\n",
     );
-    execFileSync(
-      "node",
-      [CLI_PATH, "release", "--expired", "--today", "2026-05-19"],
-      {
-        cwd: dir,
-        encoding: "utf-8",
-      },
+    await runWithIo(() =>
+      runReleaseCommand({ expired: true, today: "2026-05-19" }, [], cli, io),
     );
     const text = readFileSync(memoryPath, "utf-8");
     assert.doesNotMatch(text, /\| old \|/);

--- a/libraries/libwiki/test/cli-init.test.js
+++ b/libraries/libwiki/test/cli-init.test.js
@@ -1,4 +1,4 @@
-import { describe, test, beforeEach } from "node:test";
+import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import {
   mkdtempSync,
@@ -6,17 +6,14 @@ import {
   existsSync,
   writeFileSync,
   readFileSync,
-  rmSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
 import { WikiRepo } from "../src/wiki-repo.js";
 import { listSkills } from "../src/skill-roster.js";
-import { deriveWikiUrl } from "../src/commands/init.js";
+import { deriveWikiUrl, runInitCommand } from "../src/commands/init.js";
+import { createTestIo, runWithIo } from "../src/io.js";
 import { git, createBareRepo, seedBareRepo } from "./helpers.js";
-
-const CLI_PATH = new URL("../bin/fit-wiki.js", import.meta.url).pathname;
 
 describe("init command", () => {
   let projectDir;
@@ -158,36 +155,43 @@ describe("deriveWikiUrl", () => {
 describe("init Active Claims scaffolding", () => {
   let dir;
   let wikiRoot;
+  let io;
+  // runInitCommand calls createScriptConfig("wiki") which reads
+  // process.env.GH_TOKEN directly (it predates io.env injection), so the
+  // global needs a value for the test to reach the scaffolding step.
+  let priorGhToken;
   beforeEach(() => {
+    priorGhToken = process.env.GH_TOKEN;
+    if (!process.env.GH_TOKEN) process.env.GH_TOKEN = "test-token";
     dir = mkdtempSync(join(tmpdir(), "init-active-"));
     wikiRoot = join(dir, "wiki");
     mkdirSync(wikiRoot, { recursive: true });
     writeFileSync(join(dir, "package.json"), '{"name":"root"}');
-  });
-
-  function runInit(env = {}) {
-    return execFileSync("node", [CLI_PATH, "init"], {
-      cwd: dir,
-      encoding: "utf-8",
-      // GH_TOKEN: ensure config.ghToken() resolves without invoking `gh auth`
-      // — clone of /nonexistent/repo.git fails by design, and init falls
-      // through to the local-only Active Claims scaffolding.
+    io = createTestIo({
+      cwd: () => dir,
+      // FIT_WIKI_URL points at a non-existent path so the clone fails
+      // cleanly; the handler falls through to the local-only scaffolding.
       env: {
         ...process.env,
-        ...env,
         FIT_WIKI_URL: "/nonexistent/repo.git",
-        GH_TOKEN: process.env.GH_TOKEN || "test-token",
       },
-      stdio: "pipe",
     });
+  });
+  afterEach(() => {
+    if (priorGhToken === undefined) delete process.env.GH_TOKEN;
+    else process.env.GH_TOKEN = priorGhToken;
+  });
+
+  async function runInit() {
+    return runWithIo(() => runInitCommand({}, [], null, io));
   }
 
-  test("scaffolds ## Active Claims in MEMORY.md when absent", () => {
+  test("scaffolds ## Active Claims in MEMORY.md when absent", async () => {
     writeFileSync(
       join(wikiRoot, "MEMORY.md"),
       "## Cross-Cutting Priorities\n\n| Item | Agents | Owner | Status | Added |\n| --- | --- | --- | --- | --- |\n| *None* | — | — | — | — |\n",
     );
-    runInit();
+    await runInit();
     const text = readFileSync(join(wikiRoot, "MEMORY.md"), "utf-8");
     assert.match(text, /## Active Claims/);
     assert.match(
@@ -196,13 +200,13 @@ describe("init Active Claims scaffolding", () => {
     );
   });
 
-  test("idempotent — second init does not duplicate Active Claims", () => {
+  test("idempotent — second init does not duplicate Active Claims", async () => {
     writeFileSync(
       join(wikiRoot, "MEMORY.md"),
       "## Cross-Cutting Priorities\n\n| Item | Agents | Owner | Status | Added |\n| --- | --- | --- | --- | --- |\n| *None* | — | — | — | — |\n",
     );
-    runInit();
-    runInit();
+    await runInit();
+    await runInit();
     const text = readFileSync(join(wikiRoot, "MEMORY.md"), "utf-8");
     const matches = text.match(/## Active Claims/g) || [];
     assert.equal(matches.length, 1);

--- a/libraries/libwiki/test/cli-log.test.js
+++ b/libraries/libwiki/test/cli-log.test.js
@@ -10,40 +10,48 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
 
-const CLI_PATH = new URL("../bin/fit-wiki.js", import.meta.url).pathname;
+import { runLogCommand } from "../src/commands/log.js";
+import { createTestIo, runWithIo } from "../src/io.js";
+
+function makeCli() {
+  return {
+    errors: [],
+    usageError(message) {
+      this.errors.push(message);
+    },
+  };
+}
 
 describe("fit-wiki log CLI", () => {
   let dir;
   let wikiRoot;
+  let cli;
+  let io;
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "log-cli-"));
     wikiRoot = join(dir, "wiki");
     mkdirSync(wikiRoot, { recursive: true });
     writeFileSync(join(dir, "package.json"), '{"name":"root"}');
+    cli = makeCli();
+    io = createTestIo({ cwd: () => dir });
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
-  test("log decision writes leading ### Decision block", () => {
-    execFileSync(
-      "node",
-      [
-        CLI_PATH,
-        "log",
-        "decision",
-        "--agent",
-        "staff-engineer",
-        "--surveyed",
-        "owned",
-        "--chosen",
-        "implement spec NNNN",
-        "--rationale",
-        "merged plan",
-        "--today",
-        "2026-05-19",
-      ],
-      { cwd: dir, encoding: "utf-8" },
+  test("log decision writes leading ### Decision block", async () => {
+    await runWithIo(() =>
+      runLogCommand(
+        {
+          agent: "staff-engineer",
+          surveyed: "owned",
+          chosen: "implement spec NNNN",
+          rationale: "merged plan",
+          today: "2026-05-19",
+        },
+        ["decision"],
+        cli,
+        io,
+      ),
     );
     const expected = join(wikiRoot, "staff-engineer-2026-W21.md");
     assert.equal(existsSync(expected), true);
@@ -54,53 +62,40 @@ describe("fit-wiki log CLI", () => {
     assert.match(text, /\*\*Chosen:\*\* implement spec NNNN/);
   });
 
-  test("missing subcommand exits 2", () => {
-    try {
-      execFileSync("node", [CLI_PATH, "log", "--agent", "staff-engineer"], {
-        cwd: dir,
-        encoding: "utf-8",
-        stdio: "pipe",
-      });
-      assert.fail("expected exit 2");
-    } catch (err) {
-      assert.equal(err.status, 2);
-    }
+  test("missing subcommand exits 2", async () => {
+    await runWithIo(() =>
+      runLogCommand({ agent: "staff-engineer" }, [], cli, io),
+    );
+    assert.equal(io.exitCode, 2);
   });
 
-  test("log note appends under the open decision's date heading", () => {
-    const args = (sub, extra) => [
-      CLI_PATH,
-      "log",
-      sub,
-      "--agent",
-      "staff-engineer",
-      "--today",
-      "2026-05-19",
-      ...extra,
-    ];
-    execFileSync(
-      "node",
-      args("decision", [
-        "--surveyed",
-        "owned",
-        "--chosen",
-        "x",
-        "--rationale",
-        "y",
-      ]),
-      { cwd: dir, encoding: "utf-8" },
+  test("log note appends under the open decision's date heading", async () => {
+    const base = { agent: "staff-engineer", today: "2026-05-19" };
+    await runWithIo(() =>
+      runLogCommand(
+        { ...base, surveyed: "owned", chosen: "x", rationale: "y" },
+        ["decision"],
+        cli,
+        io,
+      ),
     );
-    execFileSync(
-      "node",
-      args("note", ["--field", "Actions taken", "--body", "Did stuff"]),
-      { cwd: dir, encoding: "utf-8" },
+    await runWithIo(() =>
+      runLogCommand(
+        { ...base, field: "Actions taken", body: "Did stuff" },
+        ["note"],
+        cli,
+        io,
+      ),
     );
-    execFileSync(
-      "node",
-      args("note", ["--field", "Findings", "--body", "All clean"]),
-      { cwd: dir, encoding: "utf-8" },
+    await runWithIo(() =>
+      runLogCommand(
+        { ...base, field: "Findings", body: "All clean" },
+        ["note"],
+        cli,
+        io,
+      ),
     );
-    execFileSync("node", args("done", []), { cwd: dir, encoding: "utf-8" });
+    await runWithIo(() => runLogCommand(base, ["done"], cli, io));
 
     const text = readFileSync(
       join(wikiRoot, "staff-engineer-2026-W21.md"),
@@ -118,41 +113,34 @@ describe("fit-wiki log CLI", () => {
     );
   });
 
-  test("log note for a new day opens its own entry", () => {
-    const base = ["--agent", "staff-engineer", "--wiki-root", wikiRoot];
-    execFileSync(
-      "node",
-      [
-        CLI_PATH,
-        "log",
-        "decision",
-        ...base,
-        "--today",
-        "2026-05-19",
-        "--surveyed",
-        "s",
-        "--chosen",
-        "c",
-        "--rationale",
-        "r",
-      ],
-      { cwd: dir, encoding: "utf-8" },
+  test("log note for a new day opens its own entry", async () => {
+    const base = { agent: "staff-engineer", "wiki-root": wikiRoot };
+    await runWithIo(() =>
+      runLogCommand(
+        {
+          ...base,
+          today: "2026-05-19",
+          surveyed: "s",
+          chosen: "c",
+          rationale: "r",
+        },
+        ["decision"],
+        cli,
+        io,
+      ),
     );
-    execFileSync(
-      "node",
-      [
-        CLI_PATH,
-        "log",
-        "note",
-        ...base,
-        "--today",
-        "2026-05-20",
-        "--field",
-        "Followup",
-        "--body",
-        "Next day",
-      ],
-      { cwd: dir, encoding: "utf-8" },
+    await runWithIo(() =>
+      runLogCommand(
+        {
+          ...base,
+          today: "2026-05-20",
+          field: "Followup",
+          body: "Next day",
+        },
+        ["note"],
+        cli,
+        io,
+      ),
     );
     const text = readFileSync(
       join(wikiRoot, "staff-engineer-2026-W21.md"),

--- a/libraries/libwiki/test/cli-refresh.test.js
+++ b/libraries/libwiki/test/cli-refresh.test.js
@@ -5,7 +5,9 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 
-const CLI_PATH = new URL("../bin/fit-wiki.js", import.meta.url).pathname;
+import { runRefreshCommand } from "../src/commands/refresh.js";
+import { createTestIo, runWithIo } from "../src/io.js";
+
 const HEADER = "date,metric,value,unit,run,note";
 
 function makeCSV(metric, values) {
@@ -23,29 +25,26 @@ function createProject() {
   return dir;
 }
 
-function run(cwd, storyboardPath) {
-  return execFileSync("node", [CLI_PATH, "refresh", storyboardPath], {
-    cwd,
-    encoding: "utf-8",
-    env: { ...process.env, PATH: process.env.PATH },
-    stdio: "pipe",
-  });
+async function refresh(cwd, storyboardPath) {
+  const io = createTestIo({ cwd: () => cwd });
+  await runWithIo(() => runRefreshCommand({}, [storyboardPath], null, io));
+  return io;
 }
 
 describe("fit-wiki refresh CLI", () => {
-  test("no markers — file unchanged", () => {
+  test("no markers — file unchanged", async () => {
     const dir = createProject();
     const storyboard = join(dir, "storyboard.md");
     const original = "# Storyboard\n\nSome prose.\n";
     writeFileSync(storyboard, original);
 
-    run(dir, "storyboard.md");
+    await refresh(dir, "storyboard.md");
 
     const after = readFileSync(storyboard, "utf-8");
     assert.equal(after, original);
   });
 
-  test("one marker — block regenerated with chart", () => {
+  test("one marker — block regenerated with chart", async () => {
     const dir = createProject();
     const csvDir = join(dir, "wiki", "metrics", "kata-spec");
     mkdirSync(csvDir, { recursive: true });
@@ -64,7 +63,7 @@ describe("fit-wiki refresh CLI", () => {
       ].join("\n"),
     );
 
-    run(dir, "storyboard.md");
+    await refresh(dir, "storyboard.md");
 
     const after = readFileSync(storyboard, "utf-8");
     assert.ok(after.includes("**Signals:**"));
@@ -73,7 +72,7 @@ describe("fit-wiki refresh CLI", () => {
     assert.ok(!after.includes("old content here"));
   });
 
-  test("idempotent — second refresh produces same output", () => {
+  test("idempotent — second refresh produces same output", async () => {
     const dir = createProject();
     const csvDir = join(dir, "wiki", "metrics", "kata-spec");
     mkdirSync(csvDir, { recursive: true });
@@ -90,16 +89,16 @@ describe("fit-wiki refresh CLI", () => {
       ].join("\n"),
     );
 
-    run(dir, "storyboard.md");
+    await refresh(dir, "storyboard.md");
     const after1 = readFileSync(storyboard, "utf-8");
 
-    run(dir, "storyboard.md");
+    await refresh(dir, "storyboard.md");
     const after2 = readFileSync(storyboard, "utf-8");
 
     assert.equal(after1, after2);
   });
 
-  test("two markers — both blocks regenerated", () => {
+  test("two markers — both blocks regenerated", async () => {
     const dir = createProject();
     const csvDir = join(dir, "wiki", "metrics", "kata-spec");
     mkdirSync(csvDir, { recursive: true });
@@ -136,7 +135,7 @@ describe("fit-wiki refresh CLI", () => {
       ].join("\n"),
     );
 
-    run(dir, "storyboard.md");
+    await refresh(dir, "storyboard.md");
 
     const after = readFileSync(storyboard, "utf-8");
     const signalsCount = (after.match(/\*\*Signals:\*\*/g) || []).length;
@@ -145,7 +144,7 @@ describe("fit-wiki refresh CLI", () => {
     assert.ok(!after.includes("old beta"));
   });
 
-  test("missing CSV — block unchanged, exit 0", () => {
+  test("missing CSV — block unchanged, exit 0", async () => {
     const dir = createProject();
     const storyboard = join(dir, "storyboard.md");
     const original = [
@@ -155,13 +154,13 @@ describe("fit-wiki refresh CLI", () => {
     ].join("\n");
     writeFileSync(storyboard, original);
 
-    run(dir, "storyboard.md");
+    await refresh(dir, "storyboard.md");
 
     const after = readFileSync(storyboard, "utf-8");
     assert.ok(after.includes("preserved content"));
   });
 
-  test("working-directory independence", () => {
+  test("working-directory independence", async () => {
     const dir = createProject();
     const csvDir = join(dir, "wiki", "metrics", "kata-spec");
     mkdirSync(csvDir, { recursive: true });
@@ -183,19 +182,15 @@ describe("fit-wiki refresh CLI", () => {
     const subdir = join(dir, "deep", "nested");
     mkdirSync(subdir, { recursive: true });
 
-    execFileSync("node", [CLI_PATH, "refresh", "storyboard.md"], {
-      cwd: subdir,
-      encoding: "utf-8",
-      env: { ...process.env, PATH: process.env.PATH },
-      stdio: "pipe",
-    });
+    // Run from a deep subdir; project-root resolution must climb to dir.
+    await refresh(subdir, "storyboard.md");
 
     const after = readFileSync(storyboard, "utf-8");
     assert.ok(after.includes("**Signals:**"));
     assert.ok(!after.includes("old"));
   });
 
-  test("defaults to current month storyboard when no path given", () => {
+  test("defaults to current month storyboard when no path given", async () => {
     const dir = createProject();
     const csvDir = join(dir, "wiki", "metrics", "kata-spec");
     mkdirSync(csvDir, { recursive: true });
@@ -218,12 +213,8 @@ describe("fit-wiki refresh CLI", () => {
       ].join("\n"),
     );
 
-    execFileSync("node", [CLI_PATH, "refresh"], {
-      cwd: dir,
-      encoding: "utf-8",
-      env: { ...process.env, PATH: process.env.PATH },
-      stdio: "pipe",
-    });
+    const io = createTestIo({ cwd: () => dir });
+    await runWithIo(() => runRefreshCommand({}, [], null, io));
 
     const after = readFileSync(defaultPath, "utf-8");
     assert.ok(after.includes("**Signals:**"));

--- a/libraries/libwiki/test/helpers.js
+++ b/libraries/libwiki/test/helpers.js
@@ -24,6 +24,9 @@ export function seedBareRepo(bare) {
   execFileSync("git", ["clone", bare, tmp], { stdio: "pipe" });
   git(tmp, "config", "user.name", "Seed");
   git(tmp, "config", "user.email", "seed@example.com");
+  // Test repos must not depend on the host's commit-signing config.
+  git(tmp, "config", "commit.gpgsign", "false");
+  git(tmp, "config", "tag.gpgsign", "false");
   git(tmp, "checkout", "-b", "master");
   writeFileSync(join(tmp, "README.md"), "# Wiki\n");
   git(tmp, "add", "-A");
@@ -41,5 +44,7 @@ export function cloneRepo(bare, name) {
   const wikiDir = join(parent, "wiki");
   git(wikiDir, "config", "user.name", "Test User");
   git(wikiDir, "config", "user.email", "test@example.com");
+  git(wikiDir, "config", "commit.gpgsign", "false");
+  git(wikiDir, "config", "tag.gpgsign", "false");
   return { parent, wikiDir };
 }

--- a/products/guide/package.json
+++ b/products/guide/package.json
@@ -86,6 +86,9 @@
     "@forwardimpact/svctrace": "^0.1.34",
     "@forwardimpact/svcvector": "^0.1.111"
   },
+  "devDependencies": {
+    "@forwardimpact/libmock": "^0.1.0"
+  },
   "engines": {
     "bun": ">=1.2.0",
     "node": ">=22.0.0"

--- a/products/guide/test/status.test.js
+++ b/products/guide/test/status.test.js
@@ -1,5 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
+import { createMockFs } from "@forwardimpact/libmock";
 import { runStatus } from "../src/lib/status.js";
 
 /**
@@ -91,12 +92,6 @@ function createMockHealthDefinition() {
       requestStream: false,
       responseStream: false,
     },
-  };
-}
-
-function createMockFs() {
-  return {
-    readdir: async () => [],
   };
 }
 

--- a/services/ghbridge/test/callback.test.js
+++ b/services/ghbridge/test/callback.test.js
@@ -4,6 +4,7 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
@@ -12,18 +13,6 @@ import {
   ADD_REACTION_MUTATION,
   REMOVE_REACTION_MUTATION,
 } from "../src/graphql.js";
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
-}
 
 const SECRET = "ghbridge-test-secret-long-enough";
 
@@ -52,7 +41,7 @@ async function newService() {
   };
   const service = new GhBridgeService(makeConfig(), {
     logger: createMockLogger(),
-    tracer: makeTracer(),
+    tracer: createMockTracer(),
     storage: createMockStorage(),
     verifyWebhook: (s, b, sig) =>
       import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/ghbridge/test/dispatch-auth.test.js
+++ b/services/ghbridge/test/dispatch-auth.test.js
@@ -4,21 +4,10 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
-}
 
 const SECRET = "ghbridge-test-secret-long-enough";
 
@@ -84,7 +73,7 @@ describe("ghbridge dispatch-auth", () => {
     let commentCounter = 0;
     return new GhBridgeService(makeConfig(), {
       logger: createMockLogger(),
-      tracer: makeTracer(),
+      tracer: createMockTracer(),
       storage: createMockStorage(),
       verifyWebhook: (s, b, sig) =>
         import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/ghbridge/test/reply-path.test.js
+++ b/services/ghbridge/test/reply-path.test.js
@@ -4,22 +4,11 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
 import { ADD_DISCUSSION_COMMENT_MUTATION } from "../src/graphql.js";
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
-}
 
 const SECRET = "ghbridge-test-secret-long-enough";
 
@@ -55,7 +44,7 @@ describe("ghbridge reply path", () => {
 
     service = new GhBridgeService(makeConfig(), {
       logger: createMockLogger(),
-      tracer: makeTracer(),
+      tracer: createMockTracer(),
       storage: createMockStorage(),
       verifyWebhook: (s, b, sig) =>
         import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/ghbridge/test/resume.test.js
+++ b/services/ghbridge/test/resume.test.js
@@ -4,21 +4,10 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
-}
 
 const SECRET = "ghbridge-test-secret-long-enough";
 
@@ -45,7 +34,7 @@ async function newService() {
   };
   const service = new GhBridgeService(makeConfig(), {
     logger: createMockLogger(),
-    tracer: makeTracer(),
+    tracer: createMockTracer(),
     storage: createMockStorage(),
     verifyWebhook: (s, b, sig) =>
       import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/ghbridge/test/startup.test.js
+++ b/services/ghbridge/test/startup.test.js
@@ -4,21 +4,10 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
-}
 
 function makeConfig() {
   return createMockConfig("ghbridge", {
@@ -36,7 +25,7 @@ describe("ghbridge startup", () => {
       () =>
         new GhBridgeService(makeConfig(), {
           logger: createMockLogger(),
-          tracer: makeTracer(),
+          tracer: createMockTracer(),
           storage: createMockStorage(),
           verifyWebhook: async () => true,
           getInstallationToken: async () => "t",

--- a/services/ghbridge/test/webhook.test.js
+++ b/services/ghbridge/test/webhook.test.js
@@ -4,21 +4,10 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
-}
 
 const SECRET = "ghbridge-test-secret-long-enough";
 
@@ -65,7 +54,7 @@ async function newService({ dispatchImpl } = {}) {
   const storage = createMockStorage();
   const service = new GhBridgeService(config, {
     logger: createMockLogger(),
-    tracer: makeTracer(),
+    tracer: createMockTracer(),
     storage,
     verifyWebhook: (s, b, sig) =>
       import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/msbridge/test/dispatch-auth.test.js
+++ b/services/msbridge/test/dispatch-auth.test.js
@@ -4,21 +4,10 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import { MsBridgeService } from "../index.js";
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
-}
 
 function makeConfig(overrides = {}) {
   return createMockConfig("msbridge", {
@@ -116,7 +105,7 @@ describe("msbridge dispatch-auth", () => {
     const adapter = makeAdapter(overrides);
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
-      tracer: makeTracer(),
+      tracer: createMockTracer(),
       storage: createMockStorage(),
       ghauthClient: client,
       adapter,
@@ -159,7 +148,7 @@ describe("msbridge dispatch-auth", () => {
     });
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
-      tracer: makeTracer(),
+      tracer: createMockTracer(),
       storage: createMockStorage(),
       ghauthClient: client,
       adapter,
@@ -195,7 +184,7 @@ describe("msbridge dispatch-auth", () => {
     });
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
-      tracer: makeTracer(),
+      tracer: createMockTracer(),
       storage: createMockStorage(),
       ghauthClient: client,
       adapter,
@@ -228,7 +217,7 @@ describe("msbridge dispatch-auth", () => {
     });
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
-      tracer: makeTracer(),
+      tracer: createMockTracer(),
       storage: createMockStorage(),
       ghauthClient: client,
       adapter,
@@ -262,7 +251,7 @@ describe("msbridge dispatch-auth", () => {
     });
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
-      tracer: makeTracer(),
+      tracer: createMockTracer(),
       storage: createMockStorage(),
       ghauthClient: client,
       adapter,

--- a/services/msbridge/test/msbridge.test.js
+++ b/services/msbridge/test/msbridge.test.js
@@ -4,6 +4,7 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import {
@@ -24,18 +25,6 @@ function makeConfig(overrides = {}) {
     msAppTenantId: () => "test-tenant",
     ...overrides,
   });
-}
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
 }
 
 function makeAdapter(overrides = {}) {
@@ -88,7 +77,7 @@ function newService({
 } = {}) {
   return new MsBridgeService(makeConfig(configOverrides), {
     logger: logger ?? createMockLogger(),
-    tracer: makeTracer(),
+    tracer: createMockTracer(),
     storage: createMockStorage(),
     ghauthClient: ghauthClient ?? makeGhauthClient(),
     adapter: adapter ?? makeAdapter(),
@@ -150,7 +139,7 @@ describe("msbridge service", () => {
       expect(
         () =>
           new MsBridgeService(makeConfig(), {
-            tracer: makeTracer(),
+            tracer: createMockTracer(),
             storage: createMockStorage(),
             adapter: makeAdapter(),
           }),
@@ -173,7 +162,7 @@ describe("msbridge service", () => {
         () =>
           new MsBridgeService(makeConfig(), {
             logger: createMockLogger(),
-            tracer: makeTracer(),
+            tracer: createMockTracer(),
             adapter: makeAdapter(),
           }),
       ).toThrow("storage is required");

--- a/services/msbridge/test/resume.test.js
+++ b/services/msbridge/test/resume.test.js
@@ -4,21 +4,10 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import { MsBridgeService } from "../index.js";
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
-}
 
 function makeConfig(configOverrides = {}) {
   return createMockConfig("msbridge", {
@@ -115,7 +104,7 @@ describe("msbridge resume", () => {
   function buildService() {
     return new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
-      tracer: makeTracer(),
+      tracer: createMockTracer(),
       storage,
       ghauthClient: makeGhauthClient(),
       adapter,

--- a/services/msbridge/test/startup.test.js
+++ b/services/msbridge/test/startup.test.js
@@ -4,21 +4,10 @@ import {
   createMockConfig,
   createMockLogger,
   createMockStorage,
+  createMockTracer,
 } from "@forwardimpact/libmock";
 
 import { MsBridgeService } from "../index.js";
-
-function makeTracer() {
-  const noop = () => {};
-  return {
-    startSpan: () => ({
-      addEvent: noop,
-      setOk: noop,
-      setError: noop,
-      end: async () => {},
-    }),
-  };
-}
 
 function makeConfig() {
   return createMockConfig("msbridge", {
@@ -54,7 +43,7 @@ describe("msbridge startup", () => {
       () =>
         new MsBridgeService(makeConfig(), {
           logger: createMockLogger(),
-          tracer: makeTracer(),
+          tracer: createMockTracer(),
           storage: createMockStorage(),
           adapter: makeAdapter(),
         }),

--- a/specs/1370-ambient-dependencies-to-injected-collaborators/spec.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/spec.md
@@ -1,0 +1,210 @@
+# Spec 1370 — Ambient Dependencies to Injected Collaborators
+
+## Problem
+
+The monorepo treats `node:fs`, `node:child_process`, `Date.now()`,
+`setTimeout`, and the `process` global as ambient dependencies imported at
+the top of every module that needs them. As a result, the test suite has
+no seam to substitute fakes at — so test files reach for the real
+filesystem, spawn real subprocesses, sleep real wall-clock time, and
+mutate the global `process.env`. Each test pays the cost of a tiny
+integration test even when it only exercises pure logic, and the seams
+that do exist (Finder's `process` parameter, libconfig's optional
+`process` arg, WikiRepo's `resolveToken` callback) are inconsistent
+shapes that each caller has to reinvent.
+
+The full-suite wall time was 60 s before recent test-side patches; the
+slowest individual tests were `setTimeout`-based waits inside `Retry`
+backoff and `HmacAuth` token expiry that could not be skipped because
+the production code had no clock seam. The four libwiki CLI test files
+(`cli-claim`, `cli-log`, `cli-refresh`, `cli-init`) each spawned `node
+bin/fit-wiki.js` once per case because the command handlers called
+`process.exit`, `process.stdout.write`, and `process.cwd()` directly —
+in-process invocation would have terminated the test runner. Across the
+monorepo, the ambient-dependency footprint is large enough that the
+problem is structural, not incidental:
+
+| Smell | Files affected (src) |
+|---|---|
+| Direct `node:fs` import (sync or `fs/promises`) | 91 |
+| Direct `node:child_process` import | 24 |
+| `Date.now()` or `new Date()` call in module body | 60 |
+| `process.exit()` as control flow | 34 |
+| `process.cwd()` read at call site | 18 |
+| `process.env.X` read inside functions | 45 |
+| `setTimeout(...)` used as a wait primitive | 21 |
+
+Test-side consequences:
+
+| Test smell | Test files affected |
+|---|---|
+| `mkdtempSync` + real `writeFileSync`/`mkdirSync` per case | 58 |
+| Spawned subprocess (`execFileSync`/`spawnSync`/`spawn`) | 19 |
+| Mutate `process.env.*` globally with manual restore | 23 |
+| Real `setTimeout`-based sleep to advance state | 4 |
+
+Three concrete failure modes follow from this shape:
+
+- **Tests can't fake what production hardcodes.** `Retry`'s exponential
+  backoff and `HmacAuth`'s expiry were untestable in microseconds until
+  a `sleep`/`now` collaborator was added; the same untestable shape
+  recurs in any future class that does backoff, retry, expiry, or rate
+  limiting unless the pattern is established and enforced.
+- **CLI handlers cannot be unit tested in process.** Free functions
+  like `runClaimCommand(values, args, cli)` reach into `process.exit`,
+  `process.stdout.write`, and `process.cwd()` mid-body. The only way to
+  exercise them is to spawn `node bin/fit-wiki.js`, which adds
+  60–100 ms of fork + module-load to every test case and forces real
+  filesystem setup in a tmpdir.
+- **`Finder` already accepts DI but every caller wires it by hand, and
+  the injected `fs` parameter is dead code.** 23 separate
+  `new Finder(...)` call sites exist across `libraries/`, `products/`,
+  and `services/`. Some pass `process`, some pass `{ cwd: io.cwd }`,
+  some pass `console` as the logger, some pass a custom no-op logger.
+  Each module rebuilds the same boilerplate, and the inconsistency
+  hides bugs: Finder declares an `fs` constructor parameter but never
+  references it anywhere in the class — `findUpward` and `findData`
+  call `fs.existsSync(...)` against the top-level
+  `import fs from "fs"`. Every consumer that passes a `node:fs/promises`
+  module thinks it's injecting fs; in reality, only `process.cwd()`
+  flows through, and only because `findProjectRoot` happens to read it.
+
+The pattern is reachable from any module under `libraries/`,
+`products/`, and `services/`. Recent fixes on the
+`claude/test-suite-performance-uRYQj` branch added clock injection to
+`Retry` and `HmacAuth`, I/O injection to four libwiki commands, and
+extended `createMockTracer` so bridge tests could stop reinventing it.
+Those landings prove the seam works and trimmed ~11 s off wall time,
+but they touched the four hottest test files only. The 87 other src
+files that import `node:fs` directly and the 30 other src files that
+call `Date.now()` carry the same shape and will surface the same test
+smells the moment their tests become hot.
+
+## Personas and Jobs
+
+| Persona | Job | How the gap blocks progress |
+|---|---|---|
+| Teams Using Agents | Run a continuously improving agent team ([JTBD.md](../../JTBD.md)) | Agents iterate against the test suite. A 60 s suite where most tests are integration-shaped against real fs/process/clock means every Plan-Do-Study-Act cycle waits on tests that test the wrong thing, and feedback that should arrive in milliseconds arrives in seconds. |
+| Empowered Engineers | Trust agent output ([JTBD.md](../../JTBD.md)) | A reviewer assessing agent-authored code reads the module's signatures to learn what it touches. Today the signatures lie — a class declares no fs parameter yet imports `node:fs` directly inside its body. Explicit collaborator parameters make the dependency surface a property of the signature, so a reviewer can assess scope from the function header. (This benefit is qualitative; the spec does not commit to a measurable reviewer-confidence target.) |
+
+## Scope
+
+This spec is a **whole-monorepo charter** that establishes a single
+DI contract every src module follows. It supersedes the inconsistent
+seams that already exist (Finder's `process` arg, libconfig's `process`
+arg, WikiRepo's `resolveToken`, libwiki's `io`) by converging them on
+one shape and applies that shape across `libraries/`, `products/`, and
+`services/`.
+
+### In scope
+
+| Component class | What changes |
+|---|---|
+| **Clock collaborator** | Every class doing time-based work — backoff, expiry, cooldown, rate limit, debounce, schedule, `Date.now()` ID generation — accepts a `clock` collaborator with `now()` and `sleep(ms)` methods. `Date.now()`, `new Date()`, and `setTimeout(...)` in module bodies of `libraries/*/src`, `products/*/src`, and `services/*/src` are eliminated. The single legitimate exception is the default-clock factory itself. libmock's `createMockClock` is the canonical fake. |
+| **Filesystem collaborator** | Every src module that touches files accepts an `fs` collaborator with the methods it actually uses; the module does not also import `node:fs` directly. The async/sync split is consolidated to one fs surface per module (sync-only or async-only), not mixed. libmock's `createMockFs` is the canonical fake; production wires `node:fs`. |
+| **Process collaborator** | Every src module that reads `process.cwd()`, `process.env`, `process.argv`, writes to `process.stdout`/`process.stderr`, or calls `process.exit` accepts a `proc` collaborator with the methods it actually uses. Termination is not control flow: handlers return a typed result (`{ ok: true, ... }` / `{ ok: false, code, error }`) and the bin shim translates results to exit codes. `process.exit` survives only in `bin/*.js` entry points and at top-level CLI dispatch in libcli. |
+| **Subprocess collaborator** | Every src module that shells out to `git`, `gh`, `node`, or any other tool accepts a `subprocess` collaborator (or a domain-specific abstraction over it, such as `GitClient`). `spawnSync`/`execFileSync`/`spawn` calls survive only inside dedicated subprocess-collaborator implementations. |
+| **libwiki: command handlers receive collaborators explicitly** | The twelve `runXxxCommand` free functions (`runBootCommand`, `runLogCommand`, `runAuditCommand`, `runInitCommand`, `runPushCommand`, `runPullCommand`, `runRefreshCommand`, `runMemoCommand`, `runInboxCommand`, `runClaimCommand`, `runReleaseCommand`, `runRotateCommand`) accept `fs`, `proc`, `clock`, `subprocess`, and any libwiki-internal collaborators (the git repo, the wiki config) as explicit parameters. The four handlers already migrated to the `io` pattern on `claude/test-suite-performance-uRYQj` set the precedent; the remaining eight follow the same contract. Whether the handlers stay free functions, get bundled into classes, or compose through some other structure is a **design decision**, not a spec decision — what matters is that no command handler reaches into `process.exit`, `process.cwd`, `process.stdout/stderr`, `process.env`, `Date.now`, or imports `node:fs`/`node:child_process` directly. `bin/fit-wiki.js` remains the only place that constructs production collaborators. |
+| **libwiki: git access is mediated by an injected collaborator** | The git operations in `wiki-repo.js` (5 `spawnSync("git", ...)` call sites, currently consolidated behind two private helpers) and the git operations in the `commands/init.js` `deriveWikiUrl` flow stop spawning git directly. They consume a git-access collaborator provided at construction time. The shape of that collaborator (raw subprocess fan-out vs. a typed `GitClient` API), and where it lives (libutil, a new libgit, or inline in libwiki), is a **design decision**. The existing integration tests for `WikiRepo` (rebase conflicts, `-X ours` recovery) keep real git through the production collaborator; logic-only tests use a fake. |
+| **libwiki: wiki sync flow consolidates** | The git pull/push/conflict resolution logic currently spread across `wiki-repo.js`, `commands/sync.js`, and the wiki-related code paths inside the bridges, collapses into one cohesive surface that command handlers call instead of orchestrating git themselves. The exact API shape (method names, parameter style, error type) is a **design decision**. |
+| **libutil: `Finder` collaborator pass-through and call-site collapse** | The `fs` constructor parameter on `Finder` actually flows through to `findUpward` and `findData` instead of being ignored as it is today. The 23 hand-rolled `new Finder(fsAsync, logger, process)` call sites across the monorepo collapse to consumers receiving a Finder collaborator constructed by a single canonical site. Whether that canonical site is a factory function, a static method on Finder, a libutil-managed singleton, or something else is a **design decision**. |
+| **libutil: `Retry`, downloader, finder, etc. accept the clock collaborator** | Already done for `Retry`. Apply the same to any other util class with time-dependent behavior surfaced by the audit; `Date.now()` and `setTimeout` survive only inside default-clock factories. |
+| **librpc: `HmacAuth` clock injection** | Already done. Audit the rest of librpc for the same shape (token issuance, retry, deadline) and apply the contract uniformly. |
+| **libeval: `BenchmarkRunner` accepts `fs`, `proc`, `subprocess`, `clock`** | `runner.js`, `workdir.js`, `task-family.js`, `judge.js`, and the `commands/*.js` family stop importing `node:fs`, `node:os`, and `node:child_process` directly. Workdir creation (`mkdtemp`, `cp`, `mkdir`) and process orchestration (`spawn`) route through injected collaborators. The benchmark-e2e tests stop paying the cost of real tmpdir setup for assertions that only inspect record shape. |
+| **libeval: typed-result control flow** | The `runner` and `commands/*` modules return `{ records, errors }` instead of writing to `process.stdout` and exiting; the bin shim renders them. |
+| **products and services** | landmark/dispatcher, map/activity, outpost/scheduler, summit, pathway, guide, and every service under `services/*/src` that currently calls `process.exit`, `process.cwd()`, or reads `process.env.X` mid-function moves to the same constructor-injected `proc`/`fs`/`clock` contract. The CLI entry points stay where they are. |
+| **libcli contract** | libcli stops reading the global `process` when it dispatches a handler, and provides handlers a path to receive the same collaborators the rest of the monorepo uses. Whether the existing `InvocationContext` extends with a `collaborators` slot, a sibling `runtime` context is added, or libcli takes a different shape is a **design decision** — what matters is that no handler dispatched through libcli has to reach into globals to find fs, clock, or process. |
+| **libmock additions** | libmock grows a canonical fake for every collaborator surface this spec introduces — at minimum: clock (already shipped), fs (already shipped), process/proc, subprocess, and the git-access collaborator from the libwiki row. Every test that needs a fake imports it from libmock. The exact factory names, parameter shapes, and capture semantics (record calls vs. configurable responses vs. both) are a **design decision**. |
+| **Lint-level enforcement** | A new invariant under `scripts/check-ambient-deps.mjs` (wired into `bun run invariants`) flags any new src file that imports `node:fs`, `node:child_process`, calls `Date.now()` / `new Date()` / `setTimeout` / `process.*` outside the allow-list (default-collaborator factories, bin shims, libcli internals). Existing violations are catalogued in a deny-list file; the deny-list shrinks as modules migrate. |
+
+### Out of scope
+
+- **The CLI binary contract for external users.** `npx fit-wiki claim --target …` and every other published CLI continues to accept the same argv, write the same stdout/stderr, and return the same exit codes. Changes are internal to how handlers are wired.
+- **Replacing tests that legitimately exercise real integration.** `libwiki/wiki-repo.test.js` legitimately tests real git behavior (rebase conflicts, `-X ours` recovery), `landmark/dispatcher.test.js` tests the bin's exit-code contract end-to-end, `libeval/benchmark-workdir.test.js`'s listener-cleanup test legitimately spawns a node subprocess. These keep real collaborators. The design phase establishes a naming convention or marker that the lint check (Success Criterion 5) can use to distinguish integration tests from unit tests on the deny-list — the convention itself is a design decision, but the spec requires that one exists so the lint check is mechanically verifiable.
+- **Performance work unrelated to the DI pattern.** Algorithmic speedups, parallelization, dependency upgrades, build-system changes.
+- **A new test runner or assertion library.** node:test and bun:test both continue to work; the contract here is about source structure, not test mechanics.
+- **The migration to TypeScript.** Constructor signatures and collaborator shapes are documented in JSDoc; a future migration can read those without re-deriving them.
+- **External SDK abstractions.** `@grpc/grpc-js`, `@anthropic-ai/claude-agent-sdk`, `botbuilder`, `@octokit/*` and similar third-party SDKs are not wrapped in this spec. The DI contract is for node-runtime primitives and project-internal subprocess targets.
+
+## Success Criteria
+
+| # | Criterion | How to verify |
+|---|---|---|
+| 1 | No src module under `libraries/*/src`, `products/*/src`, or `services/*/src` imports `node:fs`, `node:fs/promises`, or `node:child_process` directly outside the allow-listed default-collaborator factories. | `bun run invariants` exits non-zero if a non-allow-listed src file imports those modules. |
+| 2 | No src module calls `Date.now()`, `new Date()`, or `setTimeout(...)` outside the allow-listed default-clock factory and the bin shims. | Same invariant check, same exit semantics. |
+| 3 | No src module calls `process.exit(...)`, `process.cwd()`, `process.stdout.write`, `process.stderr.write`, or reads `process.env.X` outside the allow-listed bin shims, default-collaborator factories, and libcli internals. | Same invariant check. |
+| 4 | Every libwiki command is reachable as a method on a class constructed with explicit collaborators. The CLI surface (`fit-wiki claim`, `fit-wiki log`, ...) produces byte-identical output to the current implementation for the existing test corpus. | `bun test libraries/libwiki/test/` passes; a golden-output test asserts the CLI's stdout/stderr/exitCode for a representative set of invocations matches the pre-refactor baseline. |
+| 5 | Every command-handler test in libwiki, libeval, products/landmark, products/map, products/outpost, products/summit, products/pathway, and products/guide that previously spawned a subprocess via `execFileSync`/`spawnSync` now runs in-process against injected fakes, with one explicit smoke test per binary that spawns the bin to verify the wiring. | A new `scripts/check-subprocess-in-tests.mjs` invariant enumerates `execFileSync`/`spawnSync` call sites in `test/` and flags any that match `node`/the project's own bins, with an allow-list of one entry per binary for the smoke test. |
+| 6 | The full test suite (`bun run test`) hits a sequence of milestones rather than a single target, so progress is visible and a missed milestone surfaces problems early. **M1**: under 45 s after libwiki migration completes. **M2**: under 35 s after libeval and librpc migration completes. **M3**: under 25 s after products and services migration completes. Every milestone reports zero failures and zero environmental-flake errors. | At each milestone, `time bun run test` reports `real` under the target on the same hardware class three consecutive runs apart (warmup excluded); `bun run test 2>&1` reports `0 fail` and `0 errors`. The 49 s state already on `claude/test-suite-performance-uRYQj` is the pre-M1 baseline. |
+| 7 | libmock exports canonical fakes for **every** collaborator surface the spec introduces (clock, fs, proc/process, subprocess, git-client, and any other surface introduced during design). Each fake is documented in `libraries/libmock/README.md` under a single "Collaborators" section that names the surface, the production shape it fakes, and an example. The exact factory names and parameter shapes are settled in the design phase. | `libraries/libmock/src/index.js` re-exports a factory for every collaborator surface declared in the design doc; the README's Collaborators section lists every export with a one-line example; a test in libmock asserts that every declared collaborator surface has a corresponding export. |
+| 8 | `scripts/check-libmock.mjs` (the existing inline-mock guard) catches the common-shape reimplementations of every collaborator fake libmock introduces — at minimum, the exact patterns the panel review flagged plus any patterns the design phase enumerates. The guard is not expected to catch every conceivable inline duplicate (a fully obfuscated reimplementation will slip through), but it must catch the same kinds of shapes the existing guard catches for tracer/logger/storage today, applied to the new collaborator surfaces. | A regression test in `scripts/` exercises the guard against a corpus of representative inline shapes (one positive case per collaborator surface) and verifies each is flagged. |
+| 9 | The `Finder` class accepts the same `{ fs, proc, logger }` shape as every other collaborator-aware util; the 17 hand-rolled `new Finder(...)` call sites collapse to consumers receiving a `finder` collaborator. The `fs` parameter actually flows through to internal calls instead of `findUpward` using the top-level import. | `rg "new Finder\(" libraries/ products/ services/` returns zero matches outside `libutil` itself; a unit test injects a `createMockFs` and verifies `findUpward` uses it. |
+| 10 | A contributor doc at `MONOREPO.md` (or a new sibling) names the four collaborator surfaces, the canonical libmock fakes, and the invariants that enforce them, so a future contributor lands on the pattern from any starting point. | The doc exists, links to libmock's collaborator README section, and is referenced from `CONTRIBUTING.md` § READ-DO. |
+
+## Risks and Mitigations
+
+- **Refactor blast radius and half-migrated chaos.** This touches more
+  than 150 src files across three top-level directories. A pure
+  deny-list lets the invariants pass but doesn't tell a contributor
+  whether a module's direct fs import is "temporarily allowed" or
+  "forgotten". Mitigation: the design phase produces an explicit
+  library-by-library migration order (libutil → libmock → libwiki →
+  libeval → librpc/services → products), and `wiki/STATUS.md` carries
+  one design+plan row per library so progress is visible and parallel
+  sessions don't collide. The deny-list shrinks in lockstep with each
+  library's migration PR — a library does not exit migration with any
+  of its files still on the deny-list.
+- **External CLI contract drift.** Mitigation: a golden-output test per
+  CLI binary, captured **before any refactor PR opens**, asserts
+  byte-identical stdout/stderr/exit for the existing test corpus.
+  Golden capture is a prerequisite of the first migration PR, not a
+  test added during it. The release-merge gate refuses to merge any
+  refactor PR that changes a golden output without an explicit
+  approval signal.
+- **OO-vs-DI conflation.** The user's request named "OO+DI" but the
+  problem this spec solves is dependency injection, not class-vs-function
+  representation. The libwiki `io` pattern already on
+  `claude/test-suite-performance-uRYQj` shows DI via function
+  parameters works fine. Mitigation: the spec deliberately does not
+  require classes — every "command handlers receive collaborators
+  explicitly" row leaves the function-vs-class choice to design. The
+  test for whether this spec succeeds is "can the test inject fakes
+  without spawning subprocesses or touching the real fs/clock", not
+  "is everything a class".
+- **Constructor-shape fragmentation.** If different libraries choose
+  different parameter styles (single `runtime` bag in one library,
+  four separate args in another), the pattern fractures immediately.
+  Mitigation: the design phase **must** lock in one collaborator-passing
+  style before any library's plan is approved. The design-approval row
+  in STATUS records which style was chosen; subsequent library plans
+  reference it.
+- **Slow migration overshadows the speed win.** Mitigation: Success
+  Criterion 6's staged milestones (M1/M2/M3) gate the spec — if M1
+  passes but M2 misses, we re-investigate before pushing further. The
+  49 s state already achieved on `claude/test-suite-performance-uRYQj`
+  is the pre-M1 baseline, not the proof point for the final target.
+- **Migration cost itself is unbudgeted.** Capturing golden outputs,
+  writing fakes, threading collaborators through call sites, and
+  updating tests is non-trivial work across 150+ files. Mitigation: the
+  design phase produces an effort estimate per library; the plan phase
+  decides which libraries are in the first wave and which can wait
+  until the pattern is proven. The spec is approved as a charter; not
+  every library must migrate in the same quarter.
+
+## Open Questions for Design
+
+- Should the four collaborators be passed as a single `runtime` parameter
+  (`{ fs, proc, clock, subprocess }`) or as four separate constructor
+  arguments? Trade-off: cohesion vs. constructor noise.
+- Should libcli own the collaborator-construction step, or should each
+  bin shim construct collaborators inline? Trade-off: shared idiom vs.
+  CLI variations (e.g., a CLI that needs a custom logger).
+- Where do `GitClient`, `GhClient`, and other domain-specific
+  subprocess abstractions live? Candidates: a new `libgit`/`libgh`, or
+  inside `libutil`, or inline in each consumer. Trade-off: surface area
+  vs. discoverability.
+- Should `Result` types be introduced as a shared type from libtype, or
+  remain inline plain objects? Trade-off: ceremony vs. consistency.
+
+These questions are for the design phase. They are listed here so the
+design author has a starting agenda, not so this spec answers them.


### PR DESCRIPTION
## Summary

- Inject clock/I/O collaborators into `Retry`, `HmacAuth`, and four libwiki commands so their tests stop sleeping through real time and stop spawning `node bin/fit-wiki.js`. `createMockClock` added to libmock; `createDefaultIo`/`createTestIo` added to libwiki. Production defaults preserved; bin shims unchanged.
- Consolidate 15 inline mock factories across bridge, synthetic-lib, and guide tests onto existing libmock primitives (`createMockTracer` extended to expose span lifecycle spies; `createSilentLogger`; `createMockFs`).
- Hoist shared `BenchmarkRunner` setup to `before()` so five libeval tests reuse one record set instead of running the runner five times.
- Test repo helper disables `commit.gpgsign`/`tag.gpgsign` so suite no longer depends on the host's signing config (fixed an environmental flake hitting `wiki-repo.test.js` too).
- Spec 1370 charters the monorepo-wide rollout of the same pattern: 91 src files still import `node:fs` directly, 60 still call `Date.now()`, 23 hand-roll `new Finder(...)`, and the `fs` parameter on `Finder` is dead code. The spec stages migration behind M1/M2/M3 wall-time milestones (45s → 35s → 25s) and was reviewed by a three-agent panel for HOW-leak, factual grounding, and architectural soundness before approval.

Full suite: **60.05s → 49.11s wall time, 3,871 tests, 0 fail, 0 errors**.

## Test plan

- [x] `bun run test` — completes in 49.11s with 0 failures (was 60.05s with 17 fail / 25 errors from environmental flake)
- [ ] `bun run check` — CI
- [ ] `bun run test` — CI
- [ ] Spec 1370 approved in `wiki/STATUS.md` (set to `spec approved` as part of /ship-it)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rm5deEvR6j2LNVBcpcvZ2t)_