### PR TITLE
chore: replace just rc-* with bunx fit-rc, fix bridge server logging

### DIFF
--- a/services/CLAUDE.md
+++ b/services/CLAUDE.md
@@ -99,9 +99,9 @@ Services are managed by `fit-rc`. The service list lives in
 `config/config.json` under `init.services`.
 
 ```sh
-just rc-start                # start all services
-just rc-stop                 # stop all services
-just rc-status               # show service status
+bunx fit-rc start                # start all services
+bunx fit-rc stop                 # stop all services
+bunx fit-rc status               # show service status
 bunx fit-rc start <name>     # start everything up through <name>
 bunx fit-rc restart <name>   # restart <name> and everything after it
 ```

--- a/services/bridge/server.js
+++ b/services/bridge/server.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import "@forwardimpact/libpreflight/node22";
 
+import { Server, createTracer } from "@forwardimpact/librpc";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
-import { Server, createTracer } from "@forwardimpact/librpc";
 import { createStorage } from "@forwardimpact/libstorage";
 
 import { BridgeService } from "./index.js";
@@ -17,9 +17,14 @@ const config = await createServiceConfig("bridge", {
   origin_ttl_ms: 24 * 60 * 60 * 1000,
   sweep_interval_ms: 60_000,
 });
+
+// Initialize observability
 const logger = createLogger("bridge");
 const tracer = await createTracer("bridge");
+
 const storage = createStorage("bridges");
 
 const service = new BridgeService(config, { storage, logger, tracer });
-await new Server(service, config).start();
+const server = new Server(service, config, logger, tracer);
+
+await server.start();

--- a/services/ghauth/README.md
+++ b/services/ghauth/README.md
@@ -34,7 +34,7 @@ restart scope). List `ghauth` before `oauth` (dependency first).
 Start both services:
 
 ```sh
-just rc-start
+bunx fit-rc start
 ```
 
 The tunnel uses a quick `trycloudflare.com` hostname that changes on

--- a/services/ghbridge/README.md
+++ b/services/ghbridge/README.md
@@ -83,7 +83,7 @@ scope).
 Start both services:
 
 ```sh
-just rc-start
+bunx fit-rc start
 ```
 
 The tunnel uses a quick `trycloudflare.com` hostname that changes on

--- a/services/msbridge/README.md
+++ b/services/msbridge/README.md
@@ -57,7 +57,7 @@ determines restart scope).
 Start both services:
 
 ```sh
-just rc-start
+bunx fit-rc start
 ```
 
 The tunnel uses a quick `trycloudflare.com` hostname that changes on

--- a/services/oauth/README.md
+++ b/services/oauth/README.md
@@ -30,7 +30,7 @@ before `oauth` (dependency first).
 Start the service:
 
 ```sh
-just rc-start
+bunx fit-rc start
 ```
 
 The tunnel uses a quick `trycloudflare.com` hostname that changes on

--- a/websites/fit/docs/getting-started/contributors/index.md
+++ b/websites/fit/docs/getting-started/contributors/index.md
@@ -91,7 +91,7 @@ dependencies through constructors, factory functions wire real implementations,
 tests inject mocks directly.
 
 **Services** are gRPC microservices supervised by `fit-rc`. Start them with
-`just rc-start`.
+`bunx fit-rc start`.
 
 ## Development workflow
 

--- a/websites/fit/docs/internals/operations/index.md
+++ b/websites/fit/docs/internals/operations/index.md
@@ -29,8 +29,8 @@ Environment is configured via profile-based `.env` files, managed by
 load `.env` via `set dotenv-load`. Configure profiles via `just env-reset`:
 
 ```sh
-just rc-start                              # local env, local storage, no auth
-just env-reset docker-native && just rc-start  # docker networking, MinIO storage
+bunx fit-rc start                          # local env, local storage, no auth
+just env-reset docker-native && bunx fit-rc start  # docker networking, MinIO storage
 ```
 
 ### Environment Setup
@@ -64,10 +64,10 @@ Services are supervised by `fit-rc` (via `libraries/librc/`). The service list
 is defined in `config/config.json` under `init.services`.
 
 ```sh
-bunx fit-rc start              # Start all services (or: just rc-start)
-bunx fit-rc stop               # Graceful shutdown    (or: just rc-stop)
-bunx fit-rc restart            # Restart all          (or: just rc-restart)
-bunx fit-rc status             # Show service status  (or: just rc-status)
+bunx fit-rc start              # Start all services
+bunx fit-rc stop               # Graceful shutdown
+bunx fit-rc restart            # Restart all
+bunx fit-rc status             # Show service status
 bunx fit-rc start embedding    # Start a single service
 ```
 
@@ -90,7 +90,7 @@ just tei-start                # Start TEI service (downloads model on first run)
 ```sh
 bun install                   # Install all workspace dependencies
 just quickstart               # Full bootstrap: env, generate, data, codegen, process
-just rc-start                 # Start services (supabase/tei skipped if not installed)
+bunx fit-rc start             # Start services (supabase/tei skipped if not installed)
 ```
 
 ### Generation
@@ -139,9 +139,9 @@ bunx fit-outpost daemon      # Run scheduler
 ```sh
 just process                  # Process all resources (agents, tools, vectors, graphs)
 just process-fast             # Process without vectors (no TEI required)
-just rc-start                 # Start all services
-just rc-stop                  # Stop all services
-just rc-status                # Service health check
+bunx fit-rc start             # Start all services
+bunx fit-rc stop              # Stop all services
+bunx fit-rc status            # Service health check
 ```
 
 ### Infrastructure

--- a/websites/fit/docs/services/bridge-conversations/index.md
+++ b/websites/fit/docs/services/bridge-conversations/index.md
@@ -86,7 +86,7 @@ in that order, so restarting the bridge does not cycle the tunnel
 Start both services:
 
 ```sh
-just rc-start
+bunx fit-rc start
 ```
 
 The tunnel publishes a fresh `trycloudflare.com` hostname on every restart.

--- a/websites/fit/docs/services/bridge-discussions/index.md
+++ b/websites/fit/docs/services/bridge-discussions/index.md
@@ -98,7 +98,7 @@ the tunnel.
 Start both services:
 
 ```sh
-just rc-start
+bunx fit-rc start
 ```
 
 The tunnel publishes a fresh `trycloudflare.com` hostname on every


### PR DESCRIPTION
## Summary

- Replace `just rc-start`/`stop`/`status` with `bunx fit-rc start`/`stop`/`status` across all service READMEs, website guides, and `services/CLAUDE.md`
- Fix `services/bridge/server.js` to pass `logger` and `tracer` to the `Server` constructor (was silently dropping all log output)
- Restructure `server.js` to match the `graph/server.js` layout

## Test plan

- [x] `bunx fit-rc start` — bridge service now logs `Listening` and RPC traffic to `data/logs/bridge/current`
- [x] `rg "just rc-(start|stop|status)" --type-not json | grep -v justfile | grep -v specs/` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)