### PR TITLE
design(1380): GitHub account-link binding integrity and auth-completion resume

### DIFF
--- a/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
@@ -1,0 +1,124 @@
+# Design 1380-a — link binding integrity and auth-completion resume
+
+Spec 1380 closes two coupled defects on the `github-discussions` linking flow:
+the completion step binds a token without checking who authorized, and the
+message that triggered linking is dropped. The integrity fix lands in `ghauth`
+(`Complete`); the resume flow is composed in `ghbridge` over a new
+`services/bridge` store, the existing `libbridge` `Dispatcher`, and the
+`oauth` round-trip already used for OAuth-client redirects. Out of scope:
+the Teams surface, alternative token-minting methods, and the clickable-link
+UX (retained).
+
+## Components and flow
+
+```mermaid
+graph LR
+  U[Discussion participant] -->|webhook| GB[ghbridge intake]
+  GB -->|dispatch| DSP[libbridge Dispatcher]
+  DSP -->|GetToken| GH[ghauth]
+  GB -.->|link_required / reauth_required:<br/>mint link_token, stash target,<br/>augment authorize URL| PD[(PendingDispatchStore<br/>services/bridge)]
+  GB -->|post link| TH[discussion thread]
+  U -->|click| OA[oauth /authorize]
+  OA -->|Begin client_state=link_token| GH
+  GH --> GHUB[GitHub User App]
+  GHUB -->|callback| OC[oauth /callback]
+  OC -->|Complete: verify authorizer == surface id,<br/>record github_user_id| GH
+  OC -->|302 to redirect_uri, state=link_token| LC[ghbridge /api/link-complete]
+  LC -->|lookup link_token| PD
+  LC -->|re-dispatch ctx| DSP
+  LC -->|confirmation page| U
+```
+
+| Component | Role in this design |
+|---|---|
+| `ghauth.Complete` | Verifies the authorizing GitHub account against the flow's `surface_user_id`; records the verified id on the binding. |
+| `PendingDispatchStore` (`services/bridge`) | Canonical, TTL'd map `link_token → replay target`; sibling to the discussion/origin stores so it survives `ghbridge` restarts. |
+| `ghbridge` link-prompt path | Mints `link_token`, stashes the target, augments the authorize URL with its completion redirect + token. |
+| `ghbridge` `/api/link-complete` | Post-auth landing endpoint: resolves `link_token`, re-dispatches, renders confirmation. |
+| `oauth /authorize` | Forwards `client_state` (carrying `link_token`) into `Begin` — the one new pass-through. |
+| `libbridge.Dispatcher` | Unchanged dispatch primitive; the replay calls it exactly as intake does. |
+
+## Identity verification (Defect 1)
+
+`Complete` today binds `tokens.access_token` to `flow.surface_user_id` and
+writes `github_user_id: null` with no authorizer check. The fix: after the code
+exchange, resolve the authorizing account's GitHub id from the freshly minted
+token, then bind **only** when that id equals the flow's `surface_user_id`,
+recording it as the binding's `github_user_id`. A mismatch performs no upsert —
+no create, no overwrite — and returns a typed `identity_mismatch` outcome the
+`oauth /callback` renders as a refusal page.
+
+The equality rule applies to surfaces whose identity namespace **is** GitHub
+accounts, which `github-discussions` is (its `surface_user_id` is the GitHub
+numeric id, per Spec 1340). This is expressed as a per-surface identity policy
+on the provider so a future surface with a non-GitHub namespace records the
+verified id without asserting equality. Teams is explicitly deferred.
+
+## Resume flow (Defect 2)
+
+When `Dispatcher.dispatch` returns `link_required` or `reauth_required`,
+`ghbridge` (not `libbridge`, keeping it channel-agnostic) mints an opaque
+`link_token`, writes a `PendingDispatch` target keyed by it, and augments the
+`authorize_url` with `redirect_uri=<callback_base>/api/link-complete` and
+`client_state=<link_token>` before posting. `transient` stashes nothing (no
+link is shown).
+
+`oauth /callback` already redirects to a downstream `redirect_uri` with the
+echoed `client_state`; `/api/link-complete` receives `state=link_token`,
+resolves the `PendingDispatch` target, reloads the discussion context, and
+re-dispatches through `Dispatcher.dispatch`. The pending record is deleted on
+re-dispatch (idempotent against a page refresh) and renders a "processing your
+message" page in place of today's terminal notice.
+
+**Safety property:** the replay re-runs the same `GetToken` gate, which returns
+a token only if a binding now exists for `target.surface_user_id` — and after
+the Defect 1 fix, that binding exists only if the legitimate user authorized.
+So a forged or stale `link_token` hit cannot dispatch; it re-posts the link
+harmlessly. No separate proof-of-completion is needed.
+
+## Canonical store as the single source of truth
+
+The replay reconstructs the prompt from the discussion store, so the inbound
+turn must be persisted **before** the pending pointer on every intake path.
+Today only the comment path persists on decline; the discussion-created path
+relies on `Dispatcher` appending `historyText` on success only. This design
+unifies both: intake appends the inbound turn to the context and flushes it
+through the `DiscussionAdapter` before calling `dispatch`, and the success-only
+`historyText` append inside `Dispatcher` is removed (clean break). The pending
+record therefore carries **no message body**.
+
+History entries gain an `author` field (the participant's `external_id`;
+assistant turns carry none) so the replay selects the latest turn authored by
+`target.surface_user_id` as the message to re-dispatch — correct even when
+several humans have posted in the thread.
+
+## Data structures
+
+| Structure | Shape |
+|---|---|
+| `PendingDispatch` record | `{ link_token, surface, surface_user_id, discussion_id, created_at }` — target only, TTL-swept like the flow/grant stores. |
+| Binding (`ghauth`) | `github_user_id` populated with the verified authorizer id (was always `null`). |
+| History entry | `{ role, text, author? }` (was `{ role, text }`). |
+
+## Key Decisions
+
+| Decision | Choice | Rejected alternative |
+|---|---|---|
+| How `Complete` learns who authorized | Resolve the account id from the minted token, compare to the flow's `surface_user_id` | Trust the OAuth callback / the request parameter — that is the current vulnerability |
+| Where the replay target lives | Server-held `PendingDispatch` keyed by an opaque token | Encode `(user, thread)` in `client_state` — the completer could edit it to redirect the replay to another user/thread |
+| Where the pending store lives | `services/bridge` alongside discussion/origin state | In-memory in `ghbridge` — lost on restart between link-post and completion; violates "ghbridge holds no own disk state" |
+| Proof that completion was genuine | The `GetToken` gate during replay (binding exists ⇒ verified user linked) | `ghbridge` redeeming the downstream OAuth code — pulls the bridge into the OAuth-client role and hands it a user token it never uses |
+| How resume is modeled | Dedicated pending store + completion endpoint | A new `ResumeScheduler` trigger kind — its triggers fire off inbound replies / elapsed time, not an external OAuth callback; overloading muddies the abstraction |
+| How the message is re-sent | Replay through `Dispatcher.dispatch` | A bespoke dispatch path — would duplicate rate-limiting, callback registration, and the `GetToken` safety gate |
+| Which message a multi-party thread replays | Latest history turn authored by the linking user | Latest turn regardless of author — could re-dispatch another participant's message |
+| Where link augmentation happens | `ghbridge` (channel-specific completion endpoint) | `libbridge` `TokenResolver` — would import a channel-specific callback path, breaking its no-channel invariant |
+
+## Notes for the planner
+
+- The only `oauth` change is forwarding `client_state` through `/authorize`
+  into `Begin`; `Complete` already echoes `flow.client_state`.
+- `Begin`/the flow record must persist `client_state` (today set `null` on the
+  GetToken-originated path).
+- Removing `historyText` touches both bridges' intake and the `Dispatcher`
+  contract; `msbridge` must adopt the same intake-persists-first ordering.
+- The confirmation page is a `ghbridge` HTTP response; no channel SDK involved.

--- a/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
@@ -102,9 +102,10 @@ several humans have posted in the thread.
 
 | Structure | Shape |
 |---|---|
-| `PendingDispatch` record | `{ link_token, surface, surface_user_id, discussion_id, created_at }` — target only, TTL-swept like the flow/grant stores. |
+| `PendingDispatch` record | New `services/bridge` message `{ link_token, surface, surface_user_id, discussion_id, created_at }` — target only, TTL-swept like the flow/grant stores. `surface` is the channel value the replay feeds to `loadByChannel` (i.e. `ctx.channel`), not a second identifier. |
+| `BeginRequest` (`ghauth`) | Gains a `client_state` field; `Begin` persists it on the flow instead of hard-coding `null`. This is the upstream half of the `client_state` round-trip. |
 | Binding (`ghauth`) | `github_user_id` populated with the verified authorizer id (was always `null`). |
-| History entry | `{ role, text, author? }` (was `{ role, text }`). |
+| History entry (`bridge` proto `HistoryEntry`) | `{ role, text, author? }` (was `{ role, text }`); the shared canonical schema, not just an in-memory shape. |
 
 ## Key Decisions
 
@@ -121,14 +122,20 @@ several humans have posted in the thread.
 
 ## Constraints the plan must honor
 
-- **`client_state` round-trips end to end.** It must enter at `/authorize`,
-  persist on the flow record (the `GetToken`-originated path fixes it to `null`
-  today), and survive to `Complete`, which already echoes it. No other `oauth`
-  contract changes.
-- **The history `author` field is the shared cross-bridge change.** Both
-  `ghbridge` and `msbridge` read the same history entries, so the schema
-  addition is common. Removing the `Dispatcher` `historyText` append is
-  `ghbridge`-only: `msbridge` already appends its turn at intake and does not
-  use `historyText`, so its dispatch path is unaffected.
+- **`client_state` round-trips end to end across two contracts.** It must enter
+  at `oauth /authorize` (a new query pass-through), cross the `ghauth.Begin`
+  gRPC boundary (a new `BeginRequest.client_state` field, persisted on the flow
+  instead of the current hard-coded `null`), and survive to `Complete`, which
+  already echoes `flow.client_state`. `oauth`'s own HTTP surface needs no other
+  change.
+- **Two cross-bridge changes, different blast radius.** The `HistoryEntry`
+  `author` field is a shared canonical-schema addition both bridges read.
+  Removing the success-only `historyText` append is a change to the shared
+  `libbridge.Dispatcher` contract — but only `ghbridge` is behaviourally
+  affected: `msbridge` already appends its turn at intake and passes no
+  `historyText`, so its dispatch path does not change.
+- **`reauth_required` is the `libbridge` outcome name** (`TokenResolver` maps
+  the `ghauth` gRPC `re_auth_required` arm onto it); the plan should grep the
+  resolver-level spelling, not the wire spelling.
 - **The confirmation page is a `ghbridge` HTTP response** — no channel SDK,
   preserving the libbridge no-channel invariant.

--- a/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
@@ -16,7 +16,7 @@ graph LR
   U[Discussion participant] -->|webhook| GB[ghbridge intake]
   GB -->|dispatch| DSP[libbridge Dispatcher]
   DSP -->|GetToken| GH[ghauth]
-  GB -.->|link_required / reauth_required:<br/>mint link_token, stash target,<br/>augment authorize URL| PD[(PendingDispatchStore<br/>services/bridge)]
+  GB -.->|link_required:<br/>mint link_token, stash target,<br/>augment authorize URL| PD[(PendingDispatchStore<br/>services/bridge)]
   GB -->|post link| TH[discussion thread]
   U -->|click| OA[oauth /authorize]
   OA -->|Begin client_state=link_token| GH
@@ -32,10 +32,10 @@ graph LR
 | Component | Role in this design |
 |---|---|
 | `ghauth.Complete` | Verifies the authorizing GitHub account against the flow's `surface_user_id`; records the verified id on the binding. |
-| `PendingDispatchStore` (`services/bridge`) | Canonical, TTL'd map `link_token → replay target`; sibling to the discussion/origin stores so it survives `ghbridge` restarts. |
-| `ghbridge` link-prompt path | Mints `link_token`, stashes the target, augments the authorize URL with its completion redirect + token. |
+| `PendingDispatchStore` (`services/bridge`) | Canonical, TTL'd map `link_token → replay target`; sibling to the discussion/origin stores so it survives `ghbridge` restarts. Like those stores it is reached over the bridge gRPC client, behind new RPCs (put / resolve-and-consume / sweep), not a local in-process object. |
+| `ghbridge` link-prompt path | On a `link_required` decline, mints `link_token`, stashes the target, augments the authorize URL with its completion redirect + token. |
 | `ghbridge` `/api/link-complete` | Post-auth landing endpoint: resolves `link_token`, re-dispatches, renders confirmation. |
-| `oauth /authorize` | Forwards `client_state` (carrying `link_token`) into `Begin` — the one new pass-through. |
+| `oauth /authorize` | Gains one new pass-through: forwards `client_state` (carrying `link_token`) into `Begin` (today it forwards `redirect_uri`/`code_challenge`/`scope` but not `client_state`). |
 | `libbridge.Dispatcher` | Unchanged dispatch primitive; the replay calls it exactly as intake does. |
 
 ## Identity verification (Defect 1)
@@ -56,12 +56,14 @@ verified id without asserting equality. Teams is explicitly deferred.
 
 ## Resume flow (Defect 2)
 
-When `Dispatcher.dispatch` returns `link_required` or `reauth_required`,
-`ghbridge` (not `libbridge`, keeping it channel-agnostic) mints an opaque
-`link_token`, writes a `PendingDispatch` target keyed by it, and augments the
-`authorize_url` with `redirect_uri=<callback_base>/api/link-complete` and
-`client_state=<link_token>` before posting. `transient` stashes nothing (no
-link is shown).
+When `Dispatcher.dispatch` returns `link_required`, `ghbridge` (not `libbridge`,
+keeping it channel-agnostic) mints an opaque `link_token`, writes a
+`PendingDispatch` target keyed by it, and augments the `authorize_url` with
+`redirect_uri=<callback_base>/api/link-complete` and `client_state=<link_token>`
+before posting. The other declined outcomes stash nothing: `reauth_required`
+carries no `authorize_url` to augment and `transient` shows no link. Resume for
+expired bindings (`reauth_required`) is out of scope per the spec — it would
+first need `GetToken` to surface a re-link URL, which it does not today.
 
 `oauth /callback` already redirects to a downstream `redirect_uri` with the
 echoed `client_state`; `/api/link-complete` receives `state=link_token`,
@@ -79,13 +81,17 @@ harmlessly. No separate proof-of-completion is needed.
 ## Canonical store as the single source of truth
 
 The replay reconstructs the prompt from the discussion store, so the inbound
-turn must be persisted **before** the pending pointer on every intake path.
-Today only the comment path persists on decline; the discussion-created path
-relies on `Dispatcher` appending `historyText` on success only. This design
-unifies both: intake appends the inbound turn to the context and flushes it
-through the `DiscussionAdapter` before calling `dispatch`, and the success-only
-`historyText` append inside `Dispatcher` is removed (clean break). The pending
-record therefore carries **no message body**.
+turn must reach the canonical store **before** the pending pointer is written.
+The two intake paths are asymmetric today: the comment path appends the turn
+and persists the context regardless of dispatch outcome, while the
+discussion-created path never persists the turn on a declined dispatch — it
+relies on `Dispatcher` appending `historyText` only when dispatch succeeds.
+
+This design makes turn persistence the **intake's** responsibility on both
+paths and removes the success-only append from the `Dispatcher` contract (a
+clean break: the dispatch primitive no longer mutates history). The resulting
+invariant — inbound turn persisted before resume bookkeeping — is what lets the
+pending record carry **no message body**.
 
 History entries gain an `author` field (the participant's `external_id`;
 assistant turns carry none) so the replay selects the latest turn authored by
@@ -113,12 +119,16 @@ several humans have posted in the thread.
 | Which message a multi-party thread replays | Latest history turn authored by the linking user | Latest turn regardless of author — could re-dispatch another participant's message |
 | Where link augmentation happens | `ghbridge` (channel-specific completion endpoint) | `libbridge` `TokenResolver` — would import a channel-specific callback path, breaking its no-channel invariant |
 
-## Notes for the planner
+## Constraints the plan must honor
 
-- The only `oauth` change is forwarding `client_state` through `/authorize`
-  into `Begin`; `Complete` already echoes `flow.client_state`.
-- `Begin`/the flow record must persist `client_state` (today set `null` on the
-  GetToken-originated path).
-- Removing `historyText` touches both bridges' intake and the `Dispatcher`
-  contract; `msbridge` must adopt the same intake-persists-first ordering.
-- The confirmation page is a `ghbridge` HTTP response; no channel SDK involved.
+- **`client_state` round-trips end to end.** It must enter at `/authorize`,
+  persist on the flow record (the `GetToken`-originated path fixes it to `null`
+  today), and survive to `Complete`, which already echoes it. No other `oauth`
+  contract changes.
+- **The history `author` field is the shared cross-bridge change.** Both
+  `ghbridge` and `msbridge` read the same history entries, so the schema
+  addition is common. Removing the `Dispatcher` `historyText` append is
+  `ghbridge`-only: `msbridge` already appends its turn at intake and does not
+  use `historyText`, so its dispatch path is unaffected.
+- **The confirmation page is a `ghbridge` HTTP response** — no channel SDK,
+  preserving the libbridge no-channel invariant.

--- a/specs/1380-ghbridge-link-binding-integrity-resume/spec.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/spec.md
@@ -1,0 +1,104 @@
+# Spec 1380 — GitHub account-link binding integrity and auth-completion resume
+
+## Problem
+
+The per-user GitHub authentication flow that bridges use to dispatch workflows
+under the requester's own identity (spec 1320, spec 1340) has two coupled
+defects: the account-linking step can bind a token to the wrong person, and the
+message that triggers linking is silently dropped. Both surface on the
+`github-discussions` channel served by `ghbridge` over the shared `ghauth` /
+`oauth` services.
+
+### Defect 1 — The link binds a token to an unverified identity (security, HIGH)
+
+When a user with no binding triggers a dispatch, the bridge posts an
+authorization link into the discussion thread. The link carries the intended
+user's surface identity as a request parameter. When the linking flow
+completes, the minted GitHub user token is bound to **that requested identity**,
+never to the GitHub account that actually authorized. The completion step
+records no GitHub account id for the binding and performs no check that the
+authorizer is the intended user.
+
+Because the link lives in the discussion thread — which may be fully public —
+anyone who can see it (or who simply edits the surface-identity parameter)
+can complete the flow on the intended user's behalf:
+
+| Timing | Effect |
+|---|---|
+| A different person clicks **before** the intended user | Their token is bound under the intended user's identity. The intended user is never re-prompted, because a binding now exists, and silently dispatches workflows under someone else's GitHub account. |
+| A different person clicks **after** the intended user | The correct binding is overwritten (last-writer-wins), redirecting the victim's future dispatches onto the other account. |
+
+No secret leaks in the URL. The defect is that the link is an
+**unauthenticated capability to write a token binding for an arbitrary
+identity**. This breaks the attribution guarantee — "dispatch runs as the
+requesting human" — that the per-user dispatch design exists to provide, and it
+realizes the Teams-Using-Agents anxiety force directly: a single shared link
+lets one participant act under another's GitHub identity.
+
+### Defect 2 — The first message is dropped at the link prompt (UX, blocking)
+
+The dispatch path resolves the per-user token first and returns a
+"link required" outcome before doing any other work, so the triggering message
+is discarded. The bridge posts the link and the user completes it, but the flow
+ends on a terminal "you can close this window" page. The binding now exists, yet
+the message that prompted linking was never dispatched — the user must send it
+again to get any result. On a brand-new discussion the triggering message is
+not persisted at all on the declined path, so nothing records what the user
+asked for.
+
+### Why they are coupled
+
+Automatically re-dispatching the pending message on link completion is only
+safe once Defect 1 is fixed. With the identity check absent, completing a
+victim's pending link would both plant the completer's token under the victim's
+identity **and** auto-fire the victim's queued message under it — turning the
+binding hijack into an unsolicited dispatch. The integrity fix is therefore a
+precondition for the resume feature, and the two ship together.
+
+## Personas and Jobs
+
+| Persona | Job | How the gap blocks progress |
+|---|---|---|
+| Teams Using Agents | [Run a Continuously Improving Agent Team](../../JTBD.md) | A dispatch identity that another participant can silently assume amplifies bad patterns faster than humans can intervene (the job's named anxiety), and a first interaction that dead-ends at a link prompt is friction at the very moment a team is onboarding the bridge. |
+
+## Scope
+
+### In scope
+
+| Component | What changes |
+|---|---|
+| Account-link completion | The token is bound only when the GitHub account that authorized matches the intended surface identity; a mismatch writes and overwrites nothing. The binding records which GitHub account it represents. |
+| Auth-completion resume | A message dropped because the requester had no binding is re-dispatched automatically once that same user completes linking — no resend. The user sees a confirmation that the message is being processed, not a dead-end page. |
+| Single source of truth for message content | The dropped message is recorded in the canonical discussion store before any resume bookkeeping, on every intake path including a new discussion's first message, so resume reconstructs the prompt from the canonical store. Resume bookkeeping stores no copy of the message body. |
+| Turn attribution in discussion history | Stored discussion-history turns identify their authoring user, so resume re-dispatches the turn belonging to the user who linked rather than whatever turn happens to be most recent in a multi-participant thread. |
+| Tamper-resistance of the resume target | The linking round-trip cannot let whoever completes it choose which user or which thread is re-dispatched; the replay target is fixed by server-held state, not by data the completer can edit. |
+
+### Out of scope
+
+- Alternative token-minting methods (device flow, personal access tokens, or
+  dispatching under the App installation token instead of a user token) — a
+  separate decision.
+- Identity verification for the Microsoft Teams surface — its identity model
+  differs; this spec covers `github-discussions` only. Shared bridge
+  primitives must not preclude a later Teams equivalent.
+- Changing the linking UX away from a clickable link (the click-through flow
+  is retained deliberately).
+- Resilience when the user abandons the browser after authorizing but before
+  the confirmation lands — completion still records the binding, and the
+  existing resend remains the fallback; a server-to-server completion signal
+  is a possible later hardening, not part of this spec.
+- The bounded-history retention limit — if a thread accumulates more turns than
+  history retains before the user links, reconstruction may miss the triggering
+  turn; tuning that limit is a separate concern.
+
+## Success Criteria
+
+| Claim | Verification |
+|---|---|
+| A completion whose authorizing GitHub account differs from the requested surface identity neither writes a new binding nor overwrites an existing one. | Drive a completion where the authorizer's account id differs from the requested surface identity; observe no binding is created or modified. |
+| Every binding records the GitHub account id of the user who authorized it. | Complete a flow and inspect the resulting binding; observe it carries the authorizer's GitHub account id, not a null value. |
+| A message arriving from a user with no binding is recorded in the canonical discussion store before any resume bookkeeping, on the first-message-of-a-new-discussion path. | Send a first message on a new discussion from an unlinked user; observe the message is present in the canonical discussion store after the link is posted, before linking completes. |
+| Completing the link causes the originally-intended message to be dispatched without the user sending it again. | Drive first message → posted link → verified completion with no second inbound message; observe exactly one workflow dispatch occurs and it carries the original prompt. |
+| Resume bookkeeping holds no copy of the message body. | Inspect the persisted resume record; observe it carries identifiers and timestamps only, no message text. |
+| Whoever completes the link cannot redirect the re-dispatch to a different user or thread than the one recorded when the link was issued. | Attempt to alter the completer-visible round-trip data to name a different user/thread; observe the re-dispatch targets only the server-recorded (user, thread) or does not fire. |
+| In a thread where several humans have posted, resume re-dispatches the turn authored by the user who linked. | Interleave turns from two users before linking, then complete linking as one of them; observe the re-dispatched prompt is that user's turn. |

--- a/specs/1380-ghbridge-link-binding-integrity-resume/spec.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/spec.md
@@ -48,18 +48,20 @@ asked for.
 
 ### Why they are coupled
 
-Automatically re-dispatching the pending message on link completion is only
-safe once Defect 1 is fixed. With the identity check absent, completing a
-victim's pending link would both plant the completer's token under the victim's
-identity **and** auto-fire the victim's queued message under it — turning the
-binding hijack into an unsolicited dispatch. The integrity fix is therefore a
+The auto-completion resume this spec introduces (Defect 2) is only safe once
+Defect 1 is fixed. Today no auto-resume exists, so the hijack stops at the
+binding. Once resume ships, completing a victim's pending link with the
+identity check still absent would both plant the completer's token under the
+victim's identity **and** auto-fire the victim's queued message under it —
+turning the binding hijack into an unsolicited dispatch. The integrity fix is
+therefore a
 precondition for the resume feature, and the two ship together.
 
 ## Personas and Jobs
 
 | Persona | Job | How the gap blocks progress |
 |---|---|---|
-| Teams Using Agents | [Run a Continuously Improving Agent Team](../../JTBD.md) | A dispatch identity that another participant can silently assume amplifies bad patterns faster than humans can intervene (the job's named anxiety), and a first interaction that dead-ends at a link prompt is friction at the very moment a team is onboarding the bridge. |
+| Teams Using Agents | [Run a Continuously Improving Agent Team](../../JTBD.md#teams-using-agents-run-a-continuously-improving-agent-team) | A dispatch identity that another participant can silently assume amplifies bad patterns faster than humans can intervene (the job's named anxiety), and a first interaction that dead-ends at a link prompt is friction at the very moment a team is onboarding the bridge. |
 
 ## Scope
 
@@ -96,9 +98,10 @@ precondition for the resume feature, and the two ship together.
 | Claim | Verification |
 |---|---|
 | A completion whose authorizing GitHub account differs from the requested surface identity neither writes a new binding nor overwrites an existing one. | Drive a completion where the authorizer's account id differs from the requested surface identity; observe no binding is created or modified. |
-| Every binding records the GitHub account id of the user who authorized it. | Complete a flow and inspect the resulting binding; observe it carries the authorizer's GitHub account id, not a null value. |
+| Every binding records the GitHub account id of the user who authorized it. | Complete a flow and inspect the resulting binding; observe it carries the authorizer's GitHub account id. |
 | A message arriving from a user with no binding is recorded in the canonical discussion store before any resume bookkeeping, on the first-message-of-a-new-discussion path. | Send a first message on a new discussion from an unlinked user; observe the message is present in the canonical discussion store after the link is posted, before linking completes. |
+| The same record-before-bookkeeping ordering holds on the existing-thread comment path, so the property is uniform across intake paths. | Post a comment from an unlinked user on an existing discussion; observe the message is in the canonical discussion store before any resume bookkeeping. |
 | Completing the link causes the originally-intended message to be dispatched without the user sending it again. | Drive first message → posted link → verified completion with no second inbound message; observe exactly one workflow dispatch occurs and it carries the original prompt. |
 | Resume bookkeeping holds no copy of the message body. | Inspect the persisted resume record; observe it carries identifiers and timestamps only, no message text. |
-| Whoever completes the link cannot redirect the re-dispatch to a different user or thread than the one recorded when the link was issued. | Attempt to alter the completer-visible round-trip data to name a different user/thread; observe the re-dispatch targets only the server-recorded (user, thread) or does not fire. |
+| Whoever completes the link cannot redirect the re-dispatch to a different user or thread than the one recorded when the link was issued. | Attempt to alter the completer-visible round-trip data to name a different user/thread; observe the re-dispatch targets the server-recorded (user, thread) and ignores the altered data. |
 | In a thread where several humans have posted, resume re-dispatches the turn authored by the user who linked. | Interleave turns from two users before linking, then complete linking as one of them; observe the re-dispatched prompt is that user's turn. |


### PR DESCRIPTION
## Summary

- Adds **spec 1380** and **design-a** for two coupled defects on the `github-discussions` account-linking flow:
  1. **Binding integrity (security):** `ghauth.Complete` binds a minted GitHub token to the requested surface identity without verifying the GitHub account that actually authorized, so a discussion participant can complete a link posted in a (possibly public) thread and act under another user's identity (before/after-click hijack).
  2. **Dead-end UX:** the message that triggers linking is dropped, so after linking the user must resend it.
- The design adds: authorizer-identity verification in `ghauth.Complete`; a `PendingDispatchStore` in `services/bridge`; a `client_state` round-trip (new `oauth /authorize` pass-through + new `ghauth.BeginRequest.client_state` field); a `ghbridge /api/link-complete` endpoint that replays the dropped message through the existing `Dispatcher`; intake-owned turn persistence; and a `HistoryEntry.author` field for correct multi-participant replay.

## Status

- **`wiki/STATUS.md`: `1380 design draft`** — this PR lands the spec and design on `main` but **does not signal design approval**. Approval remains a separate human decision; the plan phase still gates on `design approved`.

## Review

- Spec reviewed by a product panel (3×) and a technical panel (3×) — no blockers/highs; consensus mediums addressed.
- Design reviewed by a technical panel (3×) over two rounds — all consensus findings addressed (resume scoped to `link_required`; `BeginRequest.client_state` contract named; cross-bridge scope corrected).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

Docs-only change (markdown under `specs/`); CI `check`/`test` should be unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_018UypcGNV5VMmQmJRiGRfPp)_