### PR TITLE
design(1390): realtime bridge conversations

### DIFF
--- a/specs/1390-realtime-bridge-conversations/design-a.md
+++ b/specs/1390-realtime-bridge-conversations/design-a.md
@@ -1,0 +1,143 @@
+# Design 1390 — Realtime Bridge Conversations
+
+Turns the bridge↔run contract from one terminal callback into a **streaming
+session**: `correlation_id` stops being a one-shot callback nonce and becomes a
+session id. The run streams events out as they happen and pulls injected
+messages in while it is live.
+
+## The constraint that shapes everything
+
+The run executes inside an **ephemeral CI runner** that is not addressable —
+nothing can POST *into* it — but it has full outbound network (it already calls
+the GitHub API and the callback URL). So the run **dials home and holds both
+channels itself**: it POSTs events out as they occur, and it long-polls the
+bridge for injected messages. The bridge becomes a **broker** keyed by
+`correlation_id`, never a pusher. Realtime therefore lives only inside the
+active run window; gaps between runs fall back to the existing recess/resume
+path (spec boundary, accepted).
+
+```mermaid
+flowchart LR
+  H[Human / Discussion] -->|webhook| B(Bridge service)
+  B -->|workflow_dispatch + callback_url + inbox_url| W[CI run / libeval discuss]
+  W -->|POST events: reply / ack / terminal| B
+  W -.->|long-poll GET inbox?since=seq| B
+  B -->|addDiscussionComment per event| H
+```
+
+## Components
+
+| Component | Layer | Role change |
+| --- | --- | --- |
+| `CallbackRegistry` token lifetime | libbridge | The host stops calling `consume` (and clearing the pending-callback binding) on every callback; it defers that to the terminal verdict, so one token serves many in-progress deliveries |
+| `Dispatcher` | libbridge | On dispatch, also passes the run an inbox URL; the existing pending-callback binding (token → correlation) now persists for the run's lifetime and becomes the "run is live" signal |
+| `createCallbackHandler` | libbridge | Adds an `in_progress` verdict branch that posts replies without consuming the token or touching recess; the EYES `ack.finish` call moves out of the per-callback path onto the terminal branch |
+| Inbox broker (new) | state in `services/bridge` store + proto; HTTP endpoint in `ghbridge`/`msbridge` | Per-`correlation_id` queue of injected messages: `enqueue` on channel intake, `drainSince(seq)` served by a long-poll route in each bridge's `createBridgeServer` wiring (where the callback route already lives) |
+| Live-run record | `services/bridge` store + proto | Reuses the persisted pending-callback binding plus the already-stored `requester` (today on callback `meta` / `OpenRfc`) as the dispatch-vs-inject discriminator and the injection-authorization key — not a new parallel record |
+| Reply emitter (new) | libeval `Discusser` | Outbound client that POSTs each reply/ack as produced; `ctx.replies` entries are extended to carry both a `kind` (`reply`/`ack`) and the emitted envelope `seq` |
+| Inbound poller (new) | libeval, alongside the agent loops | A concurrent task that long-polls the inbox and lands each injected message on the **lead's** bus queue via `messageBus.synthetic`; the lead's existing `#drainOrWait` wakes on it — the shared drain is not modified |
+| `Acknowledge` tool (new) | libeval `discuss-tools` | Agent-surface tool; emits an `ack`-kind reply, does not discharge the pending Ask |
+
+## Session wire contract
+
+One POST shape, discriminated by `kind`; `seq` is the existing `SequenceCounter`
+value, making every event idempotent.
+
+| `kind` | When | Bridge action |
+| --- | --- | --- |
+| `reply` | Answer routed to lead | `addDiscussionComment`; append history; dedupe by `seq` |
+| `ack` | `Acknowledge` called | `addDiscussionComment` (own comment); **not** counted as a reply |
+| `terminal` | Adjourn / Recess / Fail | Apply verdict (existing switch); close session token |
+
+The post-hoc `fit-eval callback` workflow step is retained **only** as the
+crash safety net: if the process dies without a `terminal` event, the trace
+scan still POSTs a `failed` conclusion, exactly as today's placeholder branch.
+
+## Egress: streaming replies and acks
+
+The `Discusser` already intercepts `messageBus.answer` to push lead-routed
+answers onto `ctx.replies`. That same interception point fires
+`emitter.post({kind:"reply", seq, agent, body})`. `Acknowledge` posts
+`{kind:"ack", …}` directly. `ctx.replies` entries — today `{body, agent,
+thread_id}` — are extended with `kind` (so the terminal trace summary and the
+bridge can tell ack from answer) and `seq`. The `seq` is the existing
+per-run monotonic envelope counter (`SequenceCounter`), unique within a run,
+which the bridge uses as the egress dedupe key. The **EYES** acknowledgement
+reaction now spans the whole session and is finished only on the `terminal`
+event, which is why `ack.finish` moves off the per-callback path.
+
+## Ingress: message injection
+
+The lead loop already idles in `#drainOrWait`, racing `waitForMessages(lead)`
+against `donePromise`. The inbound poller runs as a **concurrent task beside the
+agent loops** (not a change to the shared `#drainOrWait`): when the bridge's
+inbox yields a new message, it calls `messageBus.synthetic(lead, text)`, which
+lands only on the lead's queue; the lead's existing wait wakes, it sees the
+human input, and may delegate with fresh `Ask` calls. **No change to the turn
+model** — injection is just another source of bus traffic, scoped to the lead.
+
+### Dispatch-vs-inject state machine (bridge, on inbound message)
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Dispatched: message, no active run
+  Dispatched --> InProgress: first event received
+  InProgress --> InProgress: requester msg → enqueue inbox
+  InProgress --> Notice: non-requester msg → static notice (run untouched)
+  InProgress --> Recessed: terminal=recessed
+  InProgress --> Idle: terminal=adjourned/failed
+  Recessed --> Dispatched: resume trigger fires (existing path)
+```
+
+Authorization: only the `requester` recorded on the `active_run` may inject;
+a different user's message yields a brief static notice and leaves the run
+untouched (spec §3). This reuses the `requester` already stored on dispatch.
+
+## Key decisions
+
+| Decision | Chosen | Rejected — why |
+| --- | --- | --- |
+| Ingress transport | Run **pulls** via long-poll | Bridge **pushes** to run — impossible; CI runner is not addressable |
+| Execution substrate | Keep **ephemeral CI** | **Persistent addressable service** — would need per-conversation checkout/token/worktree sandbox; out of scope, separate effort |
+| Callback token lifetime | **Session** (multi-delivery, closes on terminal) | Single-use `consume` — cannot carry many in-progress posts |
+| Reply idempotency | **`seq`-tagged events**, bridge dedupes last-posted seq | Trust-once delivery — retries would double-post comments |
+| Injection into loop | **Third racer** in `#drainOrWait` → `messageBus.synthetic` | Rework turn loop — breaks mode symmetry (spec §4) |
+| `Acknowledge` surface | **Own comment**, `ack`-kind, does not discharge Ask | Status-edit / reaction — spec §3 wants it interactive and noisy |
+| Conversation length | **Raise default turn budget**, semantics unchanged | Elastic/per-injection budget — adds a discuss-only branch, breaks symmetry |
+| Adjourn/inject race | Bridge **reconciles**: unconsumed inbox at terminal → re-dispatch with that message | Drop the message — silent data loss; the human's steer vanishes |
+
+## Edge cases
+
+- **Adjourn/inject race.** Two sub-cases: a message arrives after the lead
+  Adjourns (never fetched), or it is fetched onto the bus but the lead Adjourns
+  before acting on it. To catch both, the inbox advances a high-water mark only
+  when the lead *acts on* an injected message (produces output after it), not
+  when the poller fetches it. On the `terminal` event, any injected message past
+  that mark is unreconciled, and the bridge re-dispatches it as a fresh run
+  carrying that message. This is a **dedicated reconciliation path**: the
+  recess/resume machinery cannot be reused because `open_rfcs` is populated only
+  on the `recessed` verdict, and an adjourned/failed run leaves none.
+- **At-most-once posts.** Egress `seq` dedupe on the bridge plus the existing
+  `Origin` record (which suppresses webhook echoes of the bridge's own
+  comments) give at-most-once thread posting under retry.
+- **Crash safety.** Process death without a `terminal` event → the retained
+  workflow callback step posts a `failed` conclusion and closes the session.
+- **Channel symmetry.** The streaming/injection contract lives at the libbridge
+  layer; `services/msbridge` inherits it. Two things remain per-channel: the
+  `handleReply` reply-posting (per-reply now, shifting how each channel uses its
+  own post-one / post-many helpers), and a long-poll inbox route added to each
+  bridge's `createBridgeServer` wiring next to the existing callback route.
+  Neither is channel-specific *streaming* logic — the streaming/session logic
+  itself stays shared.
+
+## What stays identical
+
+The `OrchestrationLoop` turn model, the Ask/Answer/Announce protocol, the
+`{source, seq, event}` envelope **shape**, and the resumption-trigger set
+(`missing_input` / `elapsed` / `escalation_needed`) are unchanged. Discuss mode
+gains additive events (streamed reply/ack) and one additive agent tool
+(`Acknowledge`); the only turn-model change is a larger default budget. Symmetry
+means a shared envelope shape and turn model across `run`, `supervise`,
+`facilitate`, and `discuss` — not an identical event set (discuss is already
+richer via its `meta`/summary events).

--- a/specs/1390-realtime-bridge-conversations/spec.md
+++ b/specs/1390-realtime-bridge-conversations/spec.md
@@ -1,0 +1,184 @@
+# 1390 — Realtime Bridge Conversations
+
+Serves **Teams Using Agents — Run a Continuously Improving Agent Team**
+([JTBD](../../JTBD.md#teams-using-agents-run-a-continuously-improving-agent-team)).
+A team talks to the Kata agent team through a GitHub Discussion (or, via the
+sibling Teams bridge, a Teams thread). Today that conversation feels like batch
+email; this spec makes it feel like a chat.
+
+## Problem
+
+A bridge conversation is the primary way a human interacts with the agent team
+in natural language. The current dispatch contract is a batch request/response:
+the bridge fires one workflow run, the agent team works in silence, and the
+human sees nothing on the thread until the lead **Adjourns** and the single
+terminal callback is delivered. Three concrete failures follow.
+
+### 1. No feedback until the whole team is done
+
+The only reply the human receives arrives after the lead concludes the entire
+session. A run is budgeted for up to five hours, and a realistic
+multi-participant discussion (lead delegates to several domain agents, each does
+substantial work) routinely runs for many minutes before anything is posted.
+During that window the only progress signal on the thread is a single **EYES**
+reaction. From the human's seat the team looks idle, then a wall of replies
+appears at once. Partial answers that already exist mid-run — one agent has
+finished while others are still working — are withheld until the end even though
+they are ready to read.
+
+### 2. Agents go silent between accepting work and finishing it
+
+When the lead delegates with **Ask**, the addressed agent may pick up a
+long-running task (a security audit, an implementation pass). There is no way
+for that agent to say "I've got this, here's what I'm about to do" before it
+disappears into the work. The human cannot tell whether the question was even
+received, let alone what the agent intends. The first and only sign that the
+Ask landed is the eventual **Answer**.
+
+### 3. A new message during a run cannot reach the run
+
+If the human thinks of a clarification, correction, or follow-up while a run is
+in progress, there is no path for that message to reach the live session. The
+bridge holds no binding from a discussion to its in-progress run, so a mid-run
+comment is simply treated as a new request: it dispatches a **second,
+independent run** with no shared context (it is the in-task recursion guard,
+not any per-thread serialization, that keeps that second run from blindly
+redoing the first run's work). The human's only options are to wait for the
+run to finish or to accept a competing dispatch. The conversation cannot adapt
+while it is happening — the defining property of a chat.
+
+### Why this matters
+
+These are not three independent bugs; together they make the bridge a
+fire-and-forget RPC wearing a chat interface. The experience the team wants is a
+live conversation: work-in-progress is visible as it happens, agents
+acknowledge before they dig in, and the human can steer mid-flight. The
+machinery to run multi-agent discussions already exists (discuss mode, the
+Ask/Answer message bus, the callback path); what is missing is a *streaming*,
+*steerable* contract between the bridge and the running session.
+
+## Solution
+
+Turn the bridge↔run contract from a single terminal callback into a live
+session that streams events out as they happen and accepts messages in while the
+run is live. Four capabilities, layered.
+
+### 1. Stream replies as they are produced
+
+Each agent answer that is routed to the lead is posted to the thread at the
+moment it is produced, rather than being accumulated and delivered only when the
+session ends. A run that produces five answers over ten minutes posts five
+comments over ten minutes. The terminal conclusion remains the close of the
+session, but it is no longer the first thing the human sees.
+
+### 2. `Acknowledge` — early, interactive feedback
+
+Add an **Acknowledge** capability to the agent participant surface. An agent can
+acknowledge an Ask it has received — "picking this up, here's my plan" — before
+it begins the work. (This agent-facing capability is named for the act of
+acknowledging an Ask; it is distinct from the bridge's existing internal
+`Acknowledgement` reaction/typing-indicator lifecycle, which it neither uses nor
+replaces.) An acknowledgement:
+
+- is posted to the thread as its **own comment**, so progress feels interactive
+  and live (a separate visible message, not a status edit);
+- does **not** discharge the Ask — the agent still owes a real Answer, and the
+  acknowledgement does not count as one for any resumption or completion
+  accounting;
+- is distinguishable on the thread and in the trace from a final Answer.
+
+### 3. Inject new messages into a live run
+
+The bridge tracks which discussion is bound to which in-progress run. When a new
+message arrives on a discussion that already has a live run:
+
+- **From the original requester** (the human who triggered the run): the message
+  is injected into the running session and delivered to the lead, who may
+  delegate it with further Asks. No second run is started.
+- **From anyone else:** the bridge posts a brief, static notice on the thread
+  explaining that a run is in progress and their message was not injected. The
+  live run is not disturbed and no new run is dispatched on their behalf.
+
+When no run is live, a new message dispatches a fresh run exactly as it does
+today. When the run has recessed, the existing suspend/resume path continues to
+apply.
+
+### 4. Longer conversations, unchanged mode semantics
+
+Injected continuations make a single run legitimately span many more turns than
+a one-shot dispatch. This is accommodated by **raising the default
+conversation-length budget** so an injected conversation is not cut off
+mid-flight — not by reworking the turn model. The requirement is *symmetry*: the
+`run`, `supervise`, and `facilitate` modes are not behaviourally changed by this
+spec, and within `discuss` mode the orchestration loop and the Ask/Answer
+protocol are unchanged apart from the additive `Acknowledge` tool and the
+streaming emission of events. (The streamed reply/ack events and `discuss`
+mode's existing `meta`/summary events make its trace richer than the one-shot
+`run` mode's; "symmetry" means a shared envelope *shape* and a shared turn
+model, not an identical event *set*.) The concrete budget value is a plan
+decision.
+
+### Boundaries that hold
+
+- **No addressable runtime required.** Realtime is achieved within the existing
+  ephemeral run substrate; the run is never made addressable from the outside.
+  The streaming and injection channels are established by the run reaching out,
+  not by anything reaching in. The exact mechanism is a design concern; what the
+  spec commits to is that this works without the persistent runtime listed in
+  Out of scope.
+- **Realtime is bounded to the active run window.** Streaming and injection only
+  apply while a run is live (within its execution-time budget). Across the gaps
+  between runs, the conversation falls back to the existing recess/resume
+  behaviour. This bound is accepted, not worked around.
+- **Channel-agnostic.** The streaming/injection contract lives at the shared
+  bridge library (`libbridge`) so both the GitHub Discussions bridge
+  (`services/ghbridge`) and the Microsoft Teams bridge (`services/msbridge`)
+  inherit it; only the channel-specific reply-posting differs.
+- **At-most-once thread posts.** A streamed reply or acknowledgement is posted to
+  the thread at most once even if the underlying delivery is retried or the
+  conversation later resumes, and the bridge continues to suppress webhook
+  echoes of its own posts.
+
+## Scope
+
+### In scope
+
+| Area | Change |
+| --- | --- |
+| Reply delivery | Replies stream to the thread as produced, not only at session end |
+| Agent tools | New `Acknowledge` capability on the discuss-mode agent surface |
+| Acknowledgement semantics | Own comment; does not discharge the Ask; distinct from Answer in thread and trace |
+| Message injection | Original requester's mid-run messages reach the live lead; no new run spawned |
+| Non-requester messages | Brief static notice; live run untouched |
+| Bridge session state | Bridge tracks discussion ↔ in-progress run binding and the pending inbound messages for a run |
+| Callback contract | Supports many in-progress deliveries per run plus one terminal conclusion, with at-most-once thread posting |
+| Conversation budget | Default conversation-length budget raised so injected continuations are not cut off (concrete value deferred to the plan) |
+| Both bridges | Behaviour delivered at the shared `libbridge` layer so `services/ghbridge` and `services/msbridge` both inherit it |
+| Crash safety | The existing terminal-verdict-on-failure guarantee is preserved once replies stream inline — a run that dies without concluding still yields a failure verdict on the thread |
+
+### Out of scope
+
+- **Persistent / addressable run runtime.** Keeping the run on the existing
+  ephemeral CI substrate is assumed; moving runs onto a long-lived service to
+  get push-based delivery is a separate effort.
+- **Cross-run realtime.** Steering a conversation between runs (after a run has
+  ended or recessed) beyond the existing resume behaviour.
+- **Multi-requester authority.** Allowing participants other than the original
+  requester to steer a live run, or transferring run ownership.
+- **New resumption trigger kinds.** The `missing_input` / `elapsed` /
+  `escalation_needed` trigger set is unchanged.
+- **Per-channel UX beyond comment posting** (reactions as progress bars, typing
+  indicators, etc.).
+
+## Success Criteria
+
+| # | Criterion | Verified by |
+| --- | --- | --- |
+| 1 | An agent answer is posted to the thread before the session concludes, not only at Adjourn | Observe a discuss run with multiple answers: comments appear on the thread as each answer is produced, ahead of the terminal conclusion |
+| 2 | `Acknowledge` posts a distinct comment that does not discharge the Ask | A run where an agent acknowledges then later answers produces two thread comments; the acknowledgement is not counted as the Answer and the agent is still expected to answer |
+| 3 | The original requester's mid-run message reaches the live lead without starting a second run | Post a follow-up as the requester during a live run; the lead receives it and may delegate it, and no new workflow run is dispatched |
+| 4 | A non-requester's mid-run message yields a static notice and leaves the run undisturbed | Post as a different user during a live run; a brief notice is posted and the live run continues unaffected |
+| 5 | A streamed reply or acknowledgement is posted at most once under delivery retry | Re-delivery of the same reply event produces no duplicate thread comment |
+| 6 | Other modes are not behaviourally changed, and an injected conversation is not cut off by the default budget | `run` / `supervise` / `facilitate` mode behaviour is unchanged (their existing tests pass unmodified); a multi-round injected `discuss` conversation runs to a natural conclusion without hitting the default turn cap |
+| 7 | Both bridges inherit streaming and injection | The shared `libbridge` layer carries the contract; `services/msbridge` gains the behaviour without channel-specific streaming logic |
+| 8 | A run that ends without concluding (crash, timeout, runner eviction) still delivers a terminal verdict to the thread | Terminate a live run before it concludes; the thread receives a failure conclusion |


### PR DESCRIPTION
## Summary

- Adds `specs/1390-realtime-bridge-conversations/spec.md` (WHAT/WHY) and
  `design-a.md` (WHICH/WHERE) for making bridge conversations realtime and
  dynamic: stream agent replies to the thread as they are produced, an
  `Acknowledge` agent tool for early feedback before long work, and injection
  of the original requester's mid-run messages into a live run.
- Design keeps runs on the existing ephemeral CI substrate — the run dials
  home (streams events out, long-polls for injected messages in); the bridge
  becomes a `correlation_id`-keyed broker. Realtime is bounded to the active
  run window, with recess/resume as the cross-run fallback.

## Status

- **`wiki/STATUS.md` records `1390 design draft` — NOT approved.** This PR
  lands the spec and design as drafts; approval is a separate human-only
  signal and is intentionally not applied here.
- Both drafts passed their `kata-review` panels (spec: product + technical;
  design: technical) and consensus findings were addressed before this PR.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01BE2rG35vW23fiGCvHLd57D

---
_Generated by [Claude Code](https://claude.ai/code/session_01BE2rG35vW23fiGCvHLd57D)_