### PR TITLE
feat(libwiki): push claims and releases to remote immediately

### DIFF
--- a/libraries/libwiki/src/build-repo.js
+++ b/libraries/libwiki/src/build-repo.js
@@ -1,0 +1,20 @@
+import path from "node:path";
+import fsAsync from "node:fs/promises";
+import { Finder } from "@forwardimpact/libutil";
+import { createScriptConfig } from "@forwardimpact/libconfig";
+import { WikiRepo } from "./wiki-repo.js";
+
+/** Construct a WikiRepo from CLI values and the working directory. */
+export async function buildRepo(values, cwd = process.cwd()) {
+  const logger = { debug() {} };
+  const finder = new Finder(fsAsync, logger, { cwd: () => cwd });
+  const projectRoot = finder.findProjectRoot(cwd);
+  const wikiDir = path.resolve(projectRoot, values["wiki-root"] ?? "wiki");
+
+  const config = await createScriptConfig("wiki");
+  return new WikiRepo({
+    wikiDir,
+    parentDir: projectRoot,
+    resolveToken: () => config.ghToken(),
+  });
+}

--- a/libraries/libwiki/src/commands/claim.js
+++ b/libraries/libwiki/src/commands/claim.js
@@ -9,6 +9,7 @@ import {
   filterExpired,
 } from "../active-claims.js";
 import { createDefaultIo } from "../io.js";
+import { buildRepo } from "../build-repo.js";
 
 function projectRoot(io) {
   const logger = { debug() {} };
@@ -33,8 +34,26 @@ function addDays(today, n) {
   return d.toISOString().slice(0, 10);
 }
 
+async function pushWiki(repoFactory, values, io, message) {
+  if (!repoFactory) return;
+  try {
+    const repo = await repoFactory(values, io.cwd());
+    repo.inheritIdentity();
+    const result = repo.commitAndPush(message);
+    if (result.pushed) io.stdout("push: committed and pushed\n");
+  } catch (err) {
+    io.stderr(`push failed (saved locally): ${err.message}\n`);
+  }
+}
+
 /** Insert a row into MEMORY.md `## Active Claims`. Refuses if (agent, target) already present. */
-export function runClaimCommand(values, _args, cli, io = createDefaultIo()) {
+export async function runClaimCommand(
+  values,
+  _args,
+  cli,
+  io = createDefaultIo(),
+  repoFactory = buildRepo,
+) {
   const agent = values.agent || io.env.LIBEVAL_AGENT_PROFILE;
   if (!agent) {
     cli.usageError("claim requires --agent or LIBEVAL_AGENT_PROFILE");
@@ -62,10 +81,17 @@ export function runClaimCommand(values, _args, cli, io = createDefaultIo()) {
   }
   writeFileSync(memPath, result.text);
   io.stdout(`claimed ${values.target} (expires ${expires})\n`);
+  await pushWiki(repoFactory, values, io, `wiki: claim ${values.target}`);
 }
 
 /** Remove a claim row. `--expired` cleans every row past expires_at. */
-export function runReleaseCommand(values, _args, cli, io = createDefaultIo()) {
+export async function runReleaseCommand(
+  values,
+  _args,
+  cli,
+  io = createDefaultIo(),
+  repoFactory = buildRepo,
+) {
   const memPath = memoryPath(values, io);
   const text = readMemory(memPath);
 
@@ -84,6 +110,7 @@ export function runReleaseCommand(values, _args, cli, io = createDefaultIo()) {
     }
     writeFileSync(memPath, current);
     io.stdout(`released ${count} expired claim(s)\n`);
+    await pushWiki(repoFactory, values, io, "wiki: release expired claims");
     return;
   }
 
@@ -102,5 +129,6 @@ export function runReleaseCommand(values, _args, cli, io = createDefaultIo()) {
     io.stdout(`no matching claim for ${agent}/${values.target}\n`);
   } else {
     io.stdout(`released ${values.target}\n`);
+    await pushWiki(repoFactory, values, io, `wiki: release ${values.target}`);
   }
 }

--- a/libraries/libwiki/src/commands/sync.js
+++ b/libraries/libwiki/src/commands/sync.js
@@ -1,22 +1,5 @@
-import path from "node:path";
-import fsAsync from "node:fs/promises";
-import { Finder } from "@forwardimpact/libutil";
-import { createScriptConfig } from "@forwardimpact/libconfig";
-import { WikiRepo, WikiPullConflict } from "../wiki-repo.js";
-
-async function buildRepo(values) {
-  const logger = { debug() {} };
-  const finder = new Finder(fsAsync, logger, process);
-  const projectRoot = finder.findProjectRoot(process.cwd());
-  const wikiDir = path.resolve(projectRoot, values["wiki-root"] ?? "wiki");
-
-  const config = await createScriptConfig("wiki");
-  return new WikiRepo({
-    wikiDir,
-    parentDir: projectRoot,
-    resolveToken: () => config.ghToken(),
-  });
-}
+import { WikiPullConflict } from "../wiki-repo.js";
+import { buildRepo } from "../build-repo.js";
 
 /** Commit all wiki changes and push them to the remote wiki repository. */
 export async function runPushCommand(values, _args, cli) {

--- a/libraries/libwiki/test/cli-claim.test.js
+++ b/libraries/libwiki/test/cli-claim.test.js
@@ -12,6 +12,8 @@ import { tmpdir } from "node:os";
 
 import { runClaimCommand, runReleaseCommand } from "../src/commands/claim.js";
 import { createTestIo, runWithIo } from "../src/io.js";
+import { WikiRepo } from "../src/wiki-repo.js";
+import { git, createBareRepo, seedBareRepo, cloneRepo } from "./helpers.js";
 
 function makeCli() {
   return {
@@ -55,6 +57,7 @@ describe("fit-wiki claim/release CLI", () => {
         [],
         cli,
         io,
+        null,
       ),
     );
     const text = readFileSync(memoryPath, "utf-8");
@@ -69,6 +72,7 @@ describe("fit-wiki claim/release CLI", () => {
         [],
         cli,
         io,
+        null,
       ),
     );
     await runWithIo(() =>
@@ -77,6 +81,7 @@ describe("fit-wiki claim/release CLI", () => {
         [],
         cli,
         io,
+        null,
       ),
     );
     assert.equal(io.exitCode, 2);
@@ -89,6 +94,7 @@ describe("fit-wiki claim/release CLI", () => {
         [],
         cli,
         io,
+        null,
       ),
     );
     await runWithIo(() =>
@@ -97,6 +103,7 @@ describe("fit-wiki claim/release CLI", () => {
         [],
         cli,
         io,
+        null,
       ),
     );
     const text = readFileSync(memoryPath, "utf-8");
@@ -109,10 +116,114 @@ describe("fit-wiki claim/release CLI", () => {
       "## Active Claims\n\n| agent | target | branch | pr | claimed_at | expires_at |\n| --- | --- | --- | --- | --- | --- |\n| staff-engineer | old | feat/o | — | 2026-04-01 | 2026-04-08 |\n| staff-engineer | new | feat/n | — | 2026-05-19 | 2026-05-26 |\n",
     );
     await runWithIo(() =>
-      runReleaseCommand({ expired: true, today: "2026-05-19" }, [], cli, io),
+      runReleaseCommand(
+        { expired: true, today: "2026-05-19" },
+        [],
+        cli,
+        io,
+        null,
+      ),
     );
     const text = readFileSync(memoryPath, "utf-8");
     assert.doesNotMatch(text, /\| old \|/);
     assert.match(text, /\| new \|/);
+  });
+});
+
+describe("claim/release push integration", () => {
+  let bare;
+  let parent;
+  let wikiDir;
+  let memPath;
+  let cli;
+  let io;
+
+  beforeEach(() => {
+    bare = createBareRepo();
+    seedBareRepo(bare);
+    ({ parent, wikiDir } = cloneRepo(bare, "claim-push"));
+    git(wikiDir, "checkout", "master");
+    memPath = join(wikiDir, "MEMORY.md");
+    writeFileSync(
+      memPath,
+      "## Active Claims\n\n| agent | target | branch | pr | claimed_at | expires_at |\n| --- | --- | --- | --- | --- | --- |\n| *None* | — | — | — | — | — |\n",
+    );
+    writeFileSync(join(parent, "package.json"), '{"name":"root"}');
+    cli = makeCli();
+    io = createTestIo({ cwd: () => parent });
+  });
+
+  function repoFactory(_values, _cwd) {
+    return new WikiRepo({
+      wikiDir,
+      parentDir: parent,
+      resolveToken: () => null,
+    });
+  }
+
+  test("claim pushes to remote", async () => {
+    await runWithIo(() =>
+      runClaimCommand(
+        {
+          agent: "staff-engineer",
+          target: "spec-NNNN",
+          branch: "feat/x",
+          today: "2099-01-01",
+        },
+        [],
+        cli,
+        io,
+        repoFactory,
+      ),
+    );
+
+    assert.match(io.out, /push: committed and pushed/);
+    const log = git(bare, "log", "--oneline", "-1", "master");
+    assert.match(log, /wiki: claim spec-NNNN/);
+  });
+
+  test("claim succeeds locally when push fails", async () => {
+    const failingFactory = async () => {
+      throw new Error("network down");
+    };
+    await runWithIo(() =>
+      runClaimCommand(
+        {
+          agent: "staff-engineer",
+          target: "spec-NNNN",
+          branch: "feat/x",
+          today: "2099-01-01",
+        },
+        [],
+        cli,
+        io,
+        failingFactory,
+      ),
+    );
+
+    assert.equal(io.exitCode, null);
+    const text = readFileSync(memPath, "utf-8");
+    assert.match(text, /staff-engineer \| spec-NNNN/);
+    assert.match(io.err, /push failed.*network down/);
+  });
+
+  test("release pushes to remote", async () => {
+    writeFileSync(
+      memPath,
+      "## Active Claims\n\n| agent | target | branch | pr | claimed_at | expires_at |\n| --- | --- | --- | --- | --- | --- |\n| staff-engineer | spec-NNNN | feat/x | — | 2099-01-01 | 2099-01-08 |\n",
+    );
+    await runWithIo(() =>
+      runReleaseCommand(
+        { agent: "staff-engineer", target: "spec-NNNN" },
+        [],
+        cli,
+        io,
+        repoFactory,
+      ),
+    );
+
+    assert.match(io.out, /push: committed and pushed/);
+    const log = git(bare, "log", "--oneline", "-1", "master");
+    assert.match(log, /wiki: release spec-NNNN/);
   });
 });


### PR DESCRIPTION
## Summary

- Claims and releases now call `commitAndPush` right after writing MEMORY.md, giving parallel agents real-time visibility into what's already taken.
- Extract `buildRepo` to `src/build-repo.js` so `claim`, `release`, `push`, and `pull` share one repo-construction code path.
- Push is best-effort — local write always succeeds even if the push fails (no token, offline).

## Test plan

- [x] `bun test test/cli-claim.test.js` — 7 tests (4 existing + 3 new integration tests)
- [ ] `bun run check`
- [ ] `bun run test`