### PR TITLE
plan(1380): link binding integrity and auth-completion resume with bridge parity

### DIFF
--- a/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
@@ -37,8 +37,10 @@ graph LR
 |---|---|
 | `ghauth.Complete` | Verifies the authorizing GitHub account against the flow's `surface_user_id` (equality check on `github-discussions`; record-only on `msteams`); records the verified id on the binding. |
 | `PendingDispatchStore` (`services/bridge`) | Canonical, TTL'd map `link_token → replay target`; sibling to the discussion/origin stores so it survives bridge restarts. Like those stores it is reached over the bridge gRPC client, behind new RPCs (put / resolve-and-consume / sweep), not a local in-process object. |
-| `ghbridge` / `msbridge` link-prompt path | On a `link_required` decline, mints `link_token`, stashes the target, augments the authorize URL with its completion redirect + token. Each bridge posts the link through its own channel SDK (GraphQL comment / Bot Framework reply). |
-| `ghbridge` / `msbridge` `/api/link-complete` | Post-auth landing endpoint on each bridge: resolves `link_token`, re-dispatches, renders confirmation. Identical handler logic; the channel SDK is not involved (the user is on the browser). |
+| `libbridge.prepareLinkResume` | Mints an opaque `link_token` and augments the authorize URL with `redirect_uri` and `client_state`. Pure function — no channel SDK, no store access. |
+| `libbridge.createLinkCompleteHandler` | Factory returning the Hono GET handler for `/api/link-complete`. Resolves the `PendingDispatch`, loads the discussion context, finds the latest user turn by author, re-dispatches, and renders the confirmation page. Entirely channel-agnostic (parallel to `createCallbackHandler`). |
+| `libbridge.createBridgeServer` | Gains an optional `onLinkComplete` handler; when provided, mounts `GET /api/link-complete` alongside the existing webhook and callback routes. |
+| Bridge `#stashAndPostLink` | The only channel-specific resume code in each bridge: calls `prepareLinkResume` (libbridge), writes the `PendingDispatch` via the store, and posts the augmented link through its channel SDK (GraphQL comment / Bot Framework reply). |
 | `oauth /authorize` | Gains one new pass-through: forwards `client_state` (carrying `link_token`) into `Begin` (today it forwards `redirect_uri`/`code_challenge`/`scope` but not `client_state`). |
 | `libbridge.Dispatcher` | Unchanged dispatch primitive; the replay calls it exactly as intake does. |
 
@@ -62,24 +64,28 @@ expressed as a per-surface identity policy on the provider
 
 ## Resume flow (Defect 2)
 
-When `Dispatcher.dispatch` returns `link_required`, each bridge (not
-`libbridge`, keeping it channel-agnostic) mints an opaque `link_token`,
-writes a `PendingDispatch` target keyed by it, and augments the
-`authorize_url` with `redirect_uri=<callback_base>/api/link-complete` and
-`client_state=<link_token>` before posting the link through its channel SDK.
-The other declined outcomes stash nothing: `reauth_required` carries no
-`authorize_url` to augment and `transient` shows no link. Resume for
-expired bindings (`reauth_required`) is out of scope per the spec — it would
-first need `GetToken` to surface a re-link URL, which it does not today.
+When `Dispatcher.dispatch` returns `link_required`, each bridge calls
+`prepareLinkResume` (a libbridge pure function that mints an opaque
+`link_token` and augments the `authorize_url` with
+`redirect_uri=<callback_base>/api/link-complete` and
+`client_state=<link_token>`), writes the `PendingDispatch` target via the
+store, and posts the augmented link through its channel SDK — the only
+channel-specific line. The other declined outcomes stash nothing:
+`reauth_required` carries no `authorize_url` to augment and `transient`
+shows no link. Resume for expired bindings (`reauth_required`) is out of
+scope per the spec — it would first need `GetToken` to surface a re-link
+URL, which it does not today.
 
 `oauth /callback` already redirects to a downstream `redirect_uri` with the
-echoed `client_state`; `/api/link-complete` on each bridge receives
-`state=link_token`, resolves the `PendingDispatch` target, reloads the
-discussion context, and re-dispatches through `Dispatcher.dispatch`. The
-pending record is deleted on re-dispatch (idempotent against a page refresh)
-and renders a "processing your message" page in place of today's terminal
-notice. The `/api/link-complete` handler is identical across bridges — it
-uses no channel SDK since the user is on the browser, not in the channel.
+echoed `client_state`; `/api/link-complete` receives `state=link_token`,
+resolves the `PendingDispatch` target, reloads the discussion context, and
+re-dispatches through `Dispatcher.dispatch`. The pending record is deleted
+on re-dispatch (idempotent against a page refresh) and renders a "processing
+your message" page in place of today's terminal notice. The handler is
+`createLinkCompleteHandler` — a libbridge factory parallel to
+`createCallbackHandler`. It uses no channel SDK (the user is on the browser)
+and is wired into `createBridgeServer` via the new optional `onLinkComplete`
+parameter.
 
 **Safety property:** the replay re-runs the same `GetToken` gate, which returns
 a token only if a binding now exists for `target.surface_user_id` — and after
@@ -129,7 +135,8 @@ several humans have posted in the thread.
 | How resume is modeled | Dedicated pending store + completion endpoint | A new `ResumeScheduler` trigger kind — its triggers fire off inbound replies / elapsed time, not an external OAuth callback; overloading muddies the abstraction |
 | How the message is re-sent | Replay through `Dispatcher.dispatch` | A bespoke dispatch path — would duplicate rate-limiting, callback registration, and the `GetToken` safety gate |
 | Which message a multi-party thread replays | Latest history turn authored by the linking user | Latest turn regardless of author — could re-dispatch another participant's message |
-| Where link augmentation happens | Each bridge (channel-specific completion endpoint) | `libbridge` `TokenResolver` — would import a channel-specific callback path, breaking its no-channel invariant |
+| Where link augmentation lives | `libbridge.prepareLinkResume` (pure function) + `createLinkCompleteHandler` (factory) | Per-bridge duplication — identical logic in both bridges with no channel SDK dependency, violating the "push shared logic into libbridge" principle |
+| Where link posting happens | Each bridge's `#stashAndPostLink` (thin: one channel-SDK call) | `libbridge` — would import channel SDKs, breaking the no-channel invariant |
 
 ## Constraints the plan must honor
 
@@ -149,8 +156,9 @@ several humans have posted in the thread.
 - **`reauth_required` is the `libbridge` outcome name** (`TokenResolver` maps
   the `ghauth` gRPC `re_auth_required` arm onto it); the plan should grep the
   resolver-level spelling, not the wire spelling.
-- **The confirmation page is a bridge HTTP response** — no channel SDK on
-  either bridge, preserving the libbridge no-channel invariant.
+- **The confirmation page is a libbridge HTTP response** — rendered by
+  `createLinkCompleteHandler`, no channel SDK, preserving the no-channel
+  invariant. Both bridges share the same handler via `createBridgeServer`.
 - **msbridge's single intake path** simplifies the turn-persistence change:
   `#handleNewMessage` is the only entry point (no discussion-created /
   comment split), so the invariant requires one code path, not two.

--- a/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/design-a.md
@@ -1,29 +1,33 @@
 # Design 1380-a — link binding integrity and auth-completion resume
 
-Spec 1380 closes two coupled defects on the `github-discussions` linking flow:
-the completion step binds a token without checking who authorized, and the
-message that triggered linking is dropped. The integrity fix lands in `ghauth`
-(`Complete`); the resume flow is composed in `ghbridge` over a new
+Spec 1380 closes two coupled defects on the bridge linking flow: the
+completion step binds a token without checking who authorized, and the
+message that triggered linking is dropped. Both defects affect every bridge
+channel (`github-discussions` via `ghbridge`, `msteams` via `msbridge`)
+because they originate in the shared `ghauth` completion step and the
+shared `libbridge` dispatch contract. The integrity fix lands in `ghauth`
+(`Complete`); the resume flow is composed in each bridge over a new
 `services/bridge` store, the existing `libbridge` `Dispatcher`, and the
-`oauth` round-trip already used for OAuth-client redirects. Out of scope:
-the Teams surface, alternative token-minting methods, and the clickable-link
-UX (retained).
+`oauth` round-trip. Both bridges implement the same resume pattern — the
+only per-channel difference is how the link is posted (GraphQL comment vs
+Bot Framework reply). Out of scope: alternative token-minting methods and
+the clickable-link UX (retained).
 
 ## Components and flow
 
 ```mermaid
 graph LR
-  U[Discussion participant] -->|webhook| GB[ghbridge intake]
-  GB -->|dispatch| DSP[libbridge Dispatcher]
+  U[Channel participant] -->|webhook / activity| BR[ghbridge or msbridge intake]
+  BR -->|dispatch| DSP[libbridge Dispatcher]
   DSP -->|GetToken| GH[ghauth]
-  GB -.->|link_required:<br/>mint link_token, stash target,<br/>augment authorize URL| PD[(PendingDispatchStore<br/>services/bridge)]
-  GB -->|post link| TH[discussion thread]
+  BR -.->|link_required:<br/>mint link_token, stash target,<br/>augment authorize URL| PD[(PendingDispatchStore<br/>services/bridge)]
+  BR -->|post link| TH[channel thread]
   U -->|click| OA[oauth /authorize]
   OA -->|Begin client_state=link_token| GH
   GH --> GHUB[GitHub User App]
   GHUB -->|callback| OC[oauth /callback]
-  OC -->|Complete: verify authorizer == surface id,<br/>record github_user_id| GH
-  OC -->|302 to redirect_uri, state=link_token| LC[ghbridge /api/link-complete]
+  OC -->|Complete: verify authorizer,<br/>record github_user_id| GH
+  OC -->|302 to redirect_uri, state=link_token| LC[bridge /api/link-complete]
   LC -->|lookup link_token| PD
   LC -->|re-dispatch ctx| DSP
   LC -->|confirmation page| U
@@ -31,10 +35,10 @@ graph LR
 
 | Component | Role in this design |
 |---|---|
-| `ghauth.Complete` | Verifies the authorizing GitHub account against the flow's `surface_user_id`; records the verified id on the binding. |
-| `PendingDispatchStore` (`services/bridge`) | Canonical, TTL'd map `link_token → replay target`; sibling to the discussion/origin stores so it survives `ghbridge` restarts. Like those stores it is reached over the bridge gRPC client, behind new RPCs (put / resolve-and-consume / sweep), not a local in-process object. |
-| `ghbridge` link-prompt path | On a `link_required` decline, mints `link_token`, stashes the target, augments the authorize URL with its completion redirect + token. |
-| `ghbridge` `/api/link-complete` | Post-auth landing endpoint: resolves `link_token`, re-dispatches, renders confirmation. |
+| `ghauth.Complete` | Verifies the authorizing GitHub account against the flow's `surface_user_id` (equality check on `github-discussions`; record-only on `msteams`); records the verified id on the binding. |
+| `PendingDispatchStore` (`services/bridge`) | Canonical, TTL'd map `link_token → replay target`; sibling to the discussion/origin stores so it survives bridge restarts. Like those stores it is reached over the bridge gRPC client, behind new RPCs (put / resolve-and-consume / sweep), not a local in-process object. |
+| `ghbridge` / `msbridge` link-prompt path | On a `link_required` decline, mints `link_token`, stashes the target, augments the authorize URL with its completion redirect + token. Each bridge posts the link through its own channel SDK (GraphQL comment / Bot Framework reply). |
+| `ghbridge` / `msbridge` `/api/link-complete` | Post-auth landing endpoint on each bridge: resolves `link_token`, re-dispatches, renders confirmation. Identical handler logic; the channel SDK is not involved (the user is on the browser). |
 | `oauth /authorize` | Gains one new pass-through: forwards `client_state` (carrying `link_token`) into `Begin` (today it forwards `redirect_uri`/`code_challenge`/`scope` but not `client_state`). |
 | `libbridge.Dispatcher` | Unchanged dispatch primitive; the replay calls it exactly as intake does. |
 
@@ -50,27 +54,32 @@ no create, no overwrite — and returns a typed `identity_mismatch` outcome the
 
 The equality rule applies to surfaces whose identity namespace **is** GitHub
 accounts, which `github-discussions` is (its `surface_user_id` is the GitHub
-numeric id, per Spec 1340). This is expressed as a per-surface identity policy
-on the provider so a future surface with a non-GitHub namespace records the
-verified id without asserting equality. Teams is explicitly deferred.
+numeric id, per Spec 1340). For `msteams`, the `surface_user_id` is a
+Teams/AAD object id — a different namespace — so the equality check does not
+fire, but the verified GitHub id is still recorded on the binding. This is
+expressed as a per-surface identity policy on the provider
+(`GITHUB_ID_SURFACES`) so the same `Complete` code path serves both channels.
 
 ## Resume flow (Defect 2)
 
-When `Dispatcher.dispatch` returns `link_required`, `ghbridge` (not `libbridge`,
-keeping it channel-agnostic) mints an opaque `link_token`, writes a
-`PendingDispatch` target keyed by it, and augments the `authorize_url` with
-`redirect_uri=<callback_base>/api/link-complete` and `client_state=<link_token>`
-before posting. The other declined outcomes stash nothing: `reauth_required`
-carries no `authorize_url` to augment and `transient` shows no link. Resume for
+When `Dispatcher.dispatch` returns `link_required`, each bridge (not
+`libbridge`, keeping it channel-agnostic) mints an opaque `link_token`,
+writes a `PendingDispatch` target keyed by it, and augments the
+`authorize_url` with `redirect_uri=<callback_base>/api/link-complete` and
+`client_state=<link_token>` before posting the link through its channel SDK.
+The other declined outcomes stash nothing: `reauth_required` carries no
+`authorize_url` to augment and `transient` shows no link. Resume for
 expired bindings (`reauth_required`) is out of scope per the spec — it would
 first need `GetToken` to surface a re-link URL, which it does not today.
 
 `oauth /callback` already redirects to a downstream `redirect_uri` with the
-echoed `client_state`; `/api/link-complete` receives `state=link_token`,
-resolves the `PendingDispatch` target, reloads the discussion context, and
-re-dispatches through `Dispatcher.dispatch`. The pending record is deleted on
-re-dispatch (idempotent against a page refresh) and renders a "processing your
-message" page in place of today's terminal notice.
+echoed `client_state`; `/api/link-complete` on each bridge receives
+`state=link_token`, resolves the `PendingDispatch` target, reloads the
+discussion context, and re-dispatches through `Dispatcher.dispatch`. The
+pending record is deleted on re-dispatch (idempotent against a page refresh)
+and renders a "processing your message" page in place of today's terminal
+notice. The `/api/link-complete` handler is identical across bridges — it
+uses no channel SDK since the user is on the browser, not in the channel.
 
 **Safety property:** the replay re-runs the same `GetToken` gate, which returns
 a token only if a binding now exists for `target.surface_user_id` — and after
@@ -82,16 +91,18 @@ harmlessly. No separate proof-of-completion is needed.
 
 The replay reconstructs the prompt from the discussion store, so the inbound
 turn must reach the canonical store **before** the pending pointer is written.
-The two intake paths are asymmetric today: the comment path appends the turn
-and persists the context regardless of dispatch outcome, while the
+The intake paths are asymmetric today: ghbridge's comment path appends the
+turn and persists the context regardless of dispatch outcome, while its
 discussion-created path never persists the turn on a declined dispatch — it
 relies on `Dispatcher` appending `historyText` only when dispatch succeeds.
+msbridge already appends at intake but does not persist before dispatch on all
+code paths.
 
-This design makes turn persistence the **intake's** responsibility on both
-paths and removes the success-only append from the `Dispatcher` contract (a
-clean break: the dispatch primitive no longer mutates history). The resulting
-invariant — inbound turn persisted before resume bookkeeping — is what lets the
-pending record carry **no message body**.
+This design makes turn persistence the **intake's** responsibility on all
+paths across both bridges and removes the success-only append from the
+`Dispatcher` contract (a clean break: the dispatch primitive no longer mutates
+history). The resulting invariant — inbound turn persisted before resume
+bookkeeping — is what lets the pending record carry **no message body**.
 
 History entries gain an `author` field (the participant's `external_id`;
 assistant turns carry none) so the replay selects the latest turn authored by
@@ -118,7 +129,7 @@ several humans have posted in the thread.
 | How resume is modeled | Dedicated pending store + completion endpoint | A new `ResumeScheduler` trigger kind — its triggers fire off inbound replies / elapsed time, not an external OAuth callback; overloading muddies the abstraction |
 | How the message is re-sent | Replay through `Dispatcher.dispatch` | A bespoke dispatch path — would duplicate rate-limiting, callback registration, and the `GetToken` safety gate |
 | Which message a multi-party thread replays | Latest history turn authored by the linking user | Latest turn regardless of author — could re-dispatch another participant's message |
-| Where link augmentation happens | `ghbridge` (channel-specific completion endpoint) | `libbridge` `TokenResolver` — would import a channel-specific callback path, breaking its no-channel invariant |
+| Where link augmentation happens | Each bridge (channel-specific completion endpoint) | `libbridge` `TokenResolver` — would import a channel-specific callback path, breaking its no-channel invariant |
 
 ## Constraints the plan must honor
 
@@ -133,9 +144,13 @@ several humans have posted in the thread.
   Removing the success-only `historyText` append is a change to the shared
   `libbridge.Dispatcher` contract — but only `ghbridge` is behaviourally
   affected: `msbridge` already appends its turn at intake and passes no
-  `historyText`, so its dispatch path does not change.
+  `historyText`, so its dispatch path does not change. Both bridges gain
+  the resume flow (stash + link-complete endpoint).
 - **`reauth_required` is the `libbridge` outcome name** (`TokenResolver` maps
   the `ghauth` gRPC `re_auth_required` arm onto it); the plan should grep the
   resolver-level spelling, not the wire spelling.
-- **The confirmation page is a `ghbridge` HTTP response** — no channel SDK,
-  preserving the libbridge no-channel invariant.
+- **The confirmation page is a bridge HTTP response** — no channel SDK on
+  either bridge, preserving the libbridge no-channel invariant.
+- **msbridge's single intake path** simplifies the turn-persistence change:
+  `#handleNewMessage` is the only entry point (no discussion-created /
+  comment split), so the invariant requires one code path, not two.

--- a/specs/1380-ghbridge-link-binding-integrity-resume/plan-a.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/plan-a.md
@@ -300,21 +300,37 @@ Verify: add tests to `services/bridge/test/bridge.test.js`:
 - sweep evicts records older than TTL
 - resolve after restart still sees NOT_FOUND (delete marker survives)
 
-## Step 6 — libbridge: remove historyText from Dispatcher, add author to appendHistory
+## Step 6 — libbridge: clean break, author support, and link-resume primitives
 
 Intent: the dispatch primitive no longer mutates history (clean break);
-author attribution added to history entries.
+author attribution added to history entries; new link-resume primitives
+(`prepareLinkResume`, `createLinkCompleteHandler`) keep bridges thin.
 
 | File | Action |
 |---|---|
 | `libraries/libbridge/src/dispatcher.js` | Modified |
 | `libraries/libbridge/src/history.js` | Modified |
+| `libraries/libbridge/src/link-resume.js` | Created |
+| `libraries/libbridge/src/server.js` | Modified |
+| `libraries/libbridge/src/index.js` | Modified (new exports) |
 | `libraries/libbridge/test/dispatcher.test.js` | Modified |
-| `libraries/libbridge/CLAUDE.md` | Modified (remove stale `historyText` from dispatch example) |
+| `libraries/libbridge/test/link-resume.test.js` | Created |
+| `libraries/libbridge/CLAUDE.md` | Modified (remove stale `historyText`, add link-resume exports) |
+
+### 6a — Dispatcher clean break
 
 **dispatcher.js** — remove `historyText` from the `dispatch()` parameter
 list, the JSDoc, and the conditional `appendHistory` call (lines 97–99).
 Remove the `appendHistory` import.
+
+**dispatcher.test.js** — remove `historyText: "hello"` from the happy-path
+test; update the assertion that checks `ctx.history` — it should now be
+empty after dispatch (history is the intake's responsibility). Remove the
+`"historyText omitted: no history is appended"` test (parameter no longer
+exists). `msbridge` already appends at intake and never passes
+`historyText`, so it is unaffected.
+
+### 6b — Author support in appendHistory
 
 **history.js** — accept optional `author` on entries:
 
@@ -327,32 +343,171 @@ export function appendHistory(history, entry, { maxEntries = 10 } = {}) {
 }
 ```
 
-**dispatcher.test.js** — remove `historyText: "hello"` from the happy-path
-test; update the assertion that checks `ctx.history` — it should now be
-empty after dispatch (history is the intake's responsibility). Remove the
-`"historyText omitted: no history is appended"` test (parameter no longer
-exists). `msbridge` already appends at intake and never passes
-`historyText`, so it is unaffected.
+### 6c — Link-resume primitives (new file)
 
-Verify: `bun test libraries/libbridge/test/dispatcher.test.js` — all
-remaining tests pass.
+**link-resume.js** — two exports, both channel-agnostic:
 
-## Step 7 — ghbridge: turn persistence, link augmentation, /api/link-complete
+`prepareLinkResume(authorizeUrl, callbackBaseUrl)` — mints an opaque
+`link_token`, augments the authorize URL with `redirect_uri` and
+`client_state`, returns `{ linkToken, augmentedUrl }`:
+
+```js
+import { randomUUID } from "node:crypto";
+import { normalizeBaseUrl } from "./callback-payload.js";
+
+export function prepareLinkResume(authorizeUrl, callbackBaseUrl) {
+  const linkToken = randomUUID();
+  const url = new URL(authorizeUrl);
+  url.searchParams.set(
+    "redirect_uri",
+    `${normalizeBaseUrl(callbackBaseUrl)}/api/link-complete`,
+  );
+  url.searchParams.set("client_state", linkToken);
+  return { linkToken, augmentedUrl: url.toString() };
+}
+```
+
+`createLinkCompleteHandler({ channel, store, dispatcher,
+buildCallbackMeta })` — factory returning a Hono GET handler, parallel to
+`createCallbackHandler`. Resolves the `PendingDispatch`, loads the
+discussion context, finds the latest user turn by the linking user's
+`author` field, re-dispatches, and renders a confirmation or error page.
+No `ackTarget` — the user is on the browser, not the channel:
+
+```js
+import { buildPrompt } from "./prompt.js";
+
+export function createLinkCompleteHandler({
+  channel,
+  store,
+  dispatcher,
+  buildCallbackMeta,
+}) {
+  return async (c) => {
+    const linkToken = c.req.query("state");
+    if (!linkToken) {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Error</h1>" +
+          "<p>Missing state parameter.</p></body></html>",
+        400,
+      );
+    }
+
+    const target = await store.resolvePendingDispatch(linkToken);
+    if (!target) {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Already processed</h1>" +
+          "<p>This link has already been used or has expired." +
+          "</p></body></html>",
+      );
+    }
+
+    const ctx = await store.loadByChannel(channel, target.discussion_id);
+    if (!ctx) {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Error</h1>" +
+          "<p>Discussion not found.</p></body></html>",
+        404,
+      );
+    }
+
+    const userTurn = [...ctx.history]
+      .reverse()
+      .find(
+        (e) => e.role === "user" && e.author === target.surface_user_id,
+      );
+    if (!userTurn) {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Error</h1>" +
+          "<p>No message found to re-dispatch.</p></body></html>",
+        404,
+      );
+    }
+
+    const result = await dispatcher.dispatch({
+      ctx,
+      prompt: buildPrompt(userTurn.text, ctx.history),
+      requester: target.surface_user_id,
+      callbackMeta: buildCallbackMeta(ctx),
+      workflowInputs: { discussionId: target.discussion_id },
+    });
+
+    if (result.kind === "dispatched") {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Processing</h1>" +
+          "<p>Your message is being processed. " +
+          "You can close this window.</p></body></html>",
+      );
+    }
+
+    return c.html(
+      "<!DOCTYPE html><html><body><h1>Unable to dispatch</h1>" +
+        "<p>Your account could not be verified. Please try " +
+        "linking again from the conversation.</p></body></html>",
+    );
+  };
+}
+```
+
+### 6d — createBridgeServer: mount link-complete route
+
+**server.js** — add optional `onLinkComplete` parameter. When provided,
+mount `GET /api/link-complete` with the same error-wrapping pattern as the
+existing webhook and callback routes:
+
+```js
+if (onLinkComplete) {
+  app.get("/api/link-complete", async (c) => {
+    try {
+      return await onLinkComplete(c);
+    } catch (err) {
+      logger.error("bridge.link-complete", err);
+      return c.json({ error: "Link completion failure" }, 500);
+    }
+  });
+}
+```
+
+### 6e — DiscussionAdapter typedef and exports
+
+**index.js** — extend the `DiscussionAdapter` typedef with two optional
+methods:
+
+```js
+ * @property {(target: object) => Promise<void>} [putPendingDispatch]
+ * @property {(linkToken: string) => Promise<object|null>} [resolvePendingDispatch]
+```
+
+Add new exports:
+
+```js
+export { prepareLinkResume, createLinkCompleteHandler } from "./link-resume.js";
+```
+
+**CLAUDE.md** — remove `historyText` from the dispatch example; add
+`prepareLinkResume` and `createLinkCompleteHandler` to the "What lives
+where" table.
+
+Verify: `bun test libraries/libbridge/test/` — all tests pass, including
+new `link-resume.test.js` covering `prepareLinkResume` (URL augmentation,
+unique token) and `createLinkCompleteHandler` (dispatched → "Processing",
+no binding → "Unable to dispatch", consumed token → "Already processed",
+multi-party → correct turn, missing state → 400).
+
+## Step 7 — ghbridge: turn persistence and thin link-resume wiring
 
 Intent: both intake paths persist the user turn (with author) before
-dispatch; `link_required` outcomes stash a `PendingDispatch` and augment
-the authorize URL; a new endpoint completes the resume. Depends on Step 4
-(oauth forwards `client_state` extracted from the augmented authorize URL),
-Step 5 (bridge stores pending dispatches), and Step 6 (Dispatcher no
-longer accepts `historyText`).
+dispatch; `link_required` outcomes delegate to `prepareLinkResume`
+(libbridge) and a thin channel-specific post. The `/api/link-complete`
+endpoint is wired via `createLinkCompleteHandler` + `createBridgeServer`.
+Depends on Steps 4, 5, and 6.
 
 | File | Action |
 |---|---|
 | `services/ghbridge/index.js` | Modified |
 | `services/ghbridge/src/discussion-adapter.js` | Modified |
-| `services/ghbridge/test/helpers.js` | Modified (add `PutPendingDispatch`/`ResolvePendingDispatch` stubs to `createStatefulDiscussionClient`) |
+| `services/ghbridge/test/helpers.js` | Modified (add `PutPendingDispatch`/`ResolvePendingDispatch` stubs) |
 | `services/ghbridge/test/dispatch-auth.test.js` | Modified |
-| `services/ghbridge/test/link-complete.test.js` | Created |
 
 ### 7a — DiscussionAdapter: add pending-dispatch methods
 
@@ -403,21 +558,23 @@ existing `appendHistory` call. Move `await this.#store.add(ctx)` before the
 any bookkeeping. Keep the final `store.add(ctx)` at line 344 (captures
 dispatch-result state).
 
-### 7c — Link augmentation on link_required
+### 7c — Thin #stashAndPostLink
 
-Add a new `#stashAndPostLink` method. Both intake paths call it when
-dispatch returns `link_required` (instead of calling `#renderDeclined`).
+Both intake paths call `#stashAndPostLink` when dispatch returns
+`link_required` (instead of calling `#renderDeclined`).
 
 The `link_required` case stays in `#renderDeclined` — it is still needed by
 the `ResumeScheduler.onDeclined` callback (`index.js:127`), which fires
 when a resumed dispatch returns `link_required` (e.g., binding revoked
 between recess and elapsed-timer fire). That path posts the bare authorize
-URL without augmentation, since there is no specific user turn to stash for
-a resume-initiated re-dispatch.
+URL without augmentation.
 
 ```js
 async #stashAndPostLink(ctx, result, requester) {
-  const linkToken = crypto.randomUUID();
+  const { linkToken, augmentedUrl } = prepareLinkResume(
+    result.authorizeUrl,
+    this.#config.callback_base_url,
+  );
 
   await this.#store.putPendingDispatch({
     link_token: linkToken,
@@ -427,12 +584,7 @@ async #stashAndPostLink(ctx, result, requester) {
     created_at: Date.now(),
   });
 
-  const url = new URL(result.authorizeUrl);
-  const callbackBase = normalizeBaseUrl(this.#config.callback_base_url);
-  url.searchParams.set("redirect_uri", `${callbackBase}/api/link-complete`);
-  url.searchParams.set("client_state", linkToken);
-
-  const body = `To dispatch, link your GitHub account: ${url}`;
+  const body = `To dispatch, link your GitHub account: ${augmentedUrl}`;
   const recordOrigin = async (comment) => {
     await this.#client.RecordOrigin(
       bridge.Origin.fromObject({
@@ -448,134 +600,63 @@ async #stashAndPostLink(ctx, result, requester) {
 }
 ```
 
-Add `import crypto from "node:crypto";` at the top of the file.
+Add `import { prepareLinkResume, createLinkCompleteHandler } from
+"@forwardimpact/libbridge";` to the imports.
 
-The augmented authorize URL includes `redirect_uri` and `client_state` as
-query params. When the user completes OAuth, `ghauth.Complete` creates a
-downstream grant (because `flow.redirect_uri` is set) whose code is
-included in the redirect to `/api/link-complete`. The link-complete handler
-does not redeem this code — the `GetToken` gate during re-dispatch is the
-proof of completion. The orphaned grant expires via the grants store TTL;
-this is acceptable overhead from reusing the existing redirect plumbing.
+### 7d — Wire createBridgeServer with onLinkComplete
 
-### 7d — `/api/link-complete` endpoint
-
-Mount a GET route on the bridge app in the constructor, after
-`createBridgeServer`:
+In the constructor, create the handler and pass it to `createBridgeServer`:
 
 ```js
-this.#bridge.app.get("/api/link-complete", (c) =>
-  this.#handleLinkComplete(c),
-);
+const onLinkComplete = createLinkCompleteHandler({
+  channel: CHANNEL,
+  store: this.#store,
+  dispatcher: this.#dispatcher,
+  buildCallbackMeta: (ctx) => ({ discussionId: ctx.discussion_id }),
+});
+
+this.#bridge = createBridgeServer({
+  config, logger, tracer,
+  webhookPath: WEBHOOK_PATH,
+  onWebhook: (c) => this.#handleWebhook(c),
+  onCallback: (c) => this.#onCallback(c),
+  onLinkComplete,
+});
 ```
 
-Handler. No `ackTarget` is passed on re-dispatch — the user is on the
-browser confirmation page, not watching the discussion thread for a
-reaction:
-
-```js
-async #handleLinkComplete(c) {
-  const linkToken = c.req.query("state");
-  if (!linkToken) {
-    return c.html(
-      "<!DOCTYPE html><html><body><h1>Error</h1>" +
-        "<p>Missing state parameter.</p></body></html>",
-      400,
-    );
-  }
-
-  const target = await this.#store.resolvePendingDispatch(linkToken);
-  if (!target) {
-    return c.html(
-      "<!DOCTYPE html><html><body><h1>Already processed</h1>" +
-        "<p>This link has already been used or has expired." +
-        "</p></body></html>",
-    );
-  }
-
-  const ctx = await this.#store.loadByChannel(CHANNEL, target.discussion_id);
-  if (!ctx) {
-    return c.html(
-      "<!DOCTYPE html><html><body><h1>Error</h1>" +
-        "<p>Discussion not found.</p></body></html>",
-      404,
-    );
-  }
-
-  const userTurn = [...ctx.history]
-    .reverse()
-    .find(
-      (e) => e.role === "user" && e.author === target.surface_user_id,
-    );
-  if (!userTurn) {
-    return c.html(
-      "<!DOCTYPE html><html><body><h1>Error</h1>" +
-        "<p>No message found to re-dispatch.</p></body></html>",
-      404,
-    );
-  }
-
-  const result = await this.#dispatcher.dispatch({
-    ctx,
-    prompt: buildPrompt(userTurn.text, ctx.history),
-    requester: target.surface_user_id,
-    callbackMeta: { discussionId: target.discussion_id },
-    workflowInputs: { discussionId: target.discussion_id },
-  });
-
-  if (result.kind === "dispatched") {
-    return c.html(
-      "<!DOCTYPE html><html><body><h1>Processing</h1>" +
-        "<p>Your message is being processed. " +
-        "You can close this window.</p></body></html>",
-    );
-  }
-
-  return c.html(
-    "<!DOCTYPE html><html><body><h1>Unable to dispatch</h1>" +
-      "<p>Your account could not be verified. Please try " +
-      "linking again from the discussion.</p></body></html>",
-  );
-}
-```
+The orphaned downstream grant (created by `Complete` because
+`flow.redirect_uri` is set) expires via the grants store TTL; this is
+acceptable overhead from reusing the existing redirect plumbing.
 
 ### 7e — Tests
 
 **helpers.js** — extend `createStatefulDiscussionClient` with
-`PutPendingDispatch` (stores in a local map) and
-`ResolvePendingDispatch` (consume-and-return from the map, throw NOT_FOUND
-if absent). Both tests (`dispatch-auth.test.js` and `link-complete.test.js`)
-share this fixture.
+`PutPendingDispatch` / `ResolvePendingDispatch` stubs.
 
 **dispatch-auth.test.js** — update the `link_required` test: the posted
 comment now contains augmented URL params (`redirect_uri`, `client_state`),
 not the bare authorize URL.
 
-**link-complete.test.js** (new) — exercises the full resume round-trip:
+Integration tests for the link-complete handler live in
+`libraries/libbridge/test/link-resume.test.js` (Step 6). Bridge-level
+tests verify that the ghbridge intake paths persist turns before stashing
+and post the augmented URL:
 
 | Case | Spec criterion | Assertion |
 |---|---|---|
-| Valid link_token, binding exists | SC 5 (completing link causes dispatch) | dispatch fires, renders "Processing" page |
-| Valid link_token, no binding | — | dispatch returns link_required, renders "Unable to dispatch" |
-| Unknown/consumed link_token | SC 7 (tamper-resistance) | renders "Already processed" |
-| Missing `state` param | SC 7 (tamper-resistance) | 400 |
-| Multi-party thread: two users posted | SC 8 (correct turn attribution) | re-dispatches the linking user's turn, not the other's |
-| Altered `state` param (wrong token) | SC 7 (tamper-resistance) | renders "Already processed" (server-held target wins) |
-| Discussion-created then link_required | SC 3 (first-message canonical store) | after link is posted, the user turn is present in the discussion store |
-| Comment then link_required | SC 4 (comment-path canonical store) | after link is posted, the user turn is present in the discussion store |
-| Inspect PendingDispatch record | SC 6 (no message body) | record contains `link_token`, `surface`, `surface_user_id`, `discussion_id`, `created_at` only — no `text` or `body` field |
+| Discussion-created then link_required | SC 3 (canonical store) | user turn in store before pending stash |
+| Comment then link_required | SC 4 (canonical store) | user turn in store before pending stash |
+| Inspect PendingDispatch record | SC 6 (no message body) | record has no `text` or `body` field |
 
 Verify: `bun test services/ghbridge/test/` — all tests pass.
 
-## Step 8 — msbridge: resume parity
+## Step 8 — msbridge: resume parity (symmetric with Step 7)
 
-Intent: msbridge gets the same resume flow as ghbridge — turn persistence
-with author, pending-dispatch stash on `link_required`, and a
-`/api/link-complete` endpoint. The handler logic is identical to ghbridge's;
-the only channel-specific difference is that `#stashAndPostLink` uses
-`sendReply` (Bot Framework) instead of `postSingleDiscussionReply`
-(GraphQL). Depends on Steps 5 (PendingDispatch store) and 6 (Dispatcher
-clean break).
+Intent: msbridge gets the same resume flow as ghbridge. The structure
+mirrors Step 7 exactly — identical DiscussionAdapter methods, same
+`prepareLinkResume` + `createLinkCompleteHandler` wiring from libbridge.
+The only channel-specific code is in `#stashAndPostLink` (one `sendReply`
+call). Depends on Steps 5 and 6.
 
 | File | Action |
 |---|---|
@@ -583,62 +664,46 @@ clean break).
 | `services/msbridge/src/discussion-adapter.js` | Modified |
 | `services/msbridge/test/helpers.js` | Modified |
 | `services/msbridge/test/dispatch-auth.test.js` | Modified |
-| `services/msbridge/test/link-complete.test.js` | Created |
 
 ### 8a — DiscussionAdapter: add pending-dispatch methods
 
-Add `putPendingDispatch(target)` and `resolvePendingDispatch(linkToken)` to
-msbridge's `DiscussionAdapter`. Identical to ghbridge's (Step 7a) — same
-`isNotFound` pattern, same bridge RPC wrappers.
+Identical to ghbridge (Step 7a) — same two methods, same `isNotFound`
+pattern, same bridge RPC wrappers. The code is the same because both
+adapters wrap the same `BridgeClient`.
 
 ### 8b — Turn persistence with author
 
 **`#handleNewMessage` (line 219)** — add `author: requester` to the
-existing `appendHistory` call:
+existing `appendHistory` call. Add `await this.#store.add(ctx)` before the
+dispatch attempt to ensure the turn reaches the canonical store before any
+pending-dispatch bookkeeping on the `link_required` path. msbridge has a
+single intake path (no discussion-created / comment split), so one
+insertion point satisfies the invariant:
 
 ```js
 appendHistory(ctx.history, { role: "user", text, author: requester });
-```
-
-Move `await this.#store.add(ctx)` before the `processInbound` call
-(currently at lines 223–224 inside the `!freshDispatchAllowed` branch) to
-ensure the turn reaches the canonical store before any bookkeeping on
-every code path, not just the non-dispatch path:
-
-```js
-appendHistory(ctx.history, { role: "user", text, author: requester });
-
-const { freshDispatchAllowed } = await this.#resume.processInbound(ctx);
-if (!freshDispatchAllowed) {
-  await this.#store.add(ctx);
-  await this.#store.flush();
-  span.setOk();
-  return;
-}
-```
-
-Wait — msbridge currently persists only on the `!freshDispatchAllowed`
-early return. On the dispatch path, the dispatcher itself calls
-`store.add(ctx)` + `store.flush()` on success. For the resume invariant,
-the turn must be persisted **before** the pending-dispatch stash
-(link_required path). Add `await this.#store.add(ctx)` before the dispatch
-call:
-
-```js
+ctx.last_active_at = Date.now();
 await this.#store.add(ctx);
 
-const limit = this.#rateLimiter.check(threadId, ctx.dispatches);
-// ... rate limit, dispatch, etc.
+const { freshDispatchAllowed } = await this.#resume.processInbound(ctx);
 ```
 
-### 8c — Link augmentation on link_required
+Keep the existing `store.add(ctx)` + `store.flush()` in the
+`!freshDispatchAllowed` early return and after dispatch (captures
+dispatch-result state).
 
-Add a `#stashAndPostLink` method mirroring ghbridge's (Step 7c), using
-`sendReply` instead of `postSingleDiscussionReply`:
+### 8c — Thin #stashAndPostLink
+
+Same pattern as ghbridge (Step 7c) — `prepareLinkResume` from libbridge
+handles token minting and URL augmentation. The only channel-specific line
+is the `sendReply` call:
 
 ```js
 async #stashAndPostLink(ctx, result, requester) {
-  const linkToken = crypto.randomUUID();
+  const { linkToken, augmentedUrl } = prepareLinkResume(
+    result.authorizeUrl,
+    this.#config.callback_base_url,
+  );
 
   await this.#store.putPendingDispatch({
     link_token: linkToken,
@@ -648,78 +713,73 @@ async #stashAndPostLink(ctx, result, requester) {
     created_at: Date.now(),
   });
 
-  const url = new URL(result.authorizeUrl);
-  const callbackBase = normalizeBaseUrl(this.#config.callback_base_url);
-  url.searchParams.set("redirect_uri", `${callbackBase}/api/link-complete`);
-  url.searchParams.set("client_state", linkToken);
-
   const ref = ctx.participants?.[0]?.metadata;
   if (ref) {
     await sendReply(
       this.#adapter,
       this.#msAppId,
       ref,
-      `To dispatch, link your GitHub account: ${url}`,
+      `To dispatch, link your GitHub account: ${augmentedUrl}`,
     );
   }
 }
 ```
 
-Add `import crypto from "node:crypto";` at the top of the file.
+Add `import { prepareLinkResume, createLinkCompleteHandler } from
+"@forwardimpact/libbridge";` to the imports. Store `this.#config = config`
+in the constructor (`callback_base_url` is needed by `prepareLinkResume`).
 
-In `#handleNewMessage`, when dispatch returns `link_required`, call
-`#stashAndPostLink` instead of `#renderDeclined`. Keep `link_required`
-in `#renderDeclined` for the `ResumeScheduler.onDeclined` callback (same
-reasoning as ghbridge Step 7c).
+In `#handleNewMessage`, call `#stashAndPostLink` on `link_required` instead
+of `#renderDeclined`. Keep `link_required` in `#renderDeclined` for the
+`ResumeScheduler.onDeclined` callback (same reasoning as Step 7c).
 
-### 8d — `/api/link-complete` endpoint
+### 8d — Wire createBridgeServer with onLinkComplete
 
-Mount a GET route on the bridge app in the constructor, after
-`createBridgeServer`:
+Identical wiring to ghbridge (Step 7d), with `buildCallbackMeta` using
+`threadId` (msbridge's convention):
 
 ```js
-this.#bridge.app.get("/api/link-complete", (c) =>
-  this.#handleLinkComplete(c),
-);
+const onLinkComplete = createLinkCompleteHandler({
+  channel: CHANNEL,
+  store: this.#store,
+  dispatcher: this.#dispatcher,
+  buildCallbackMeta: (ctx) => ({ threadId: ctx.discussion_id }),
+});
+
+this.#bridge = createBridgeServer({
+  config, logger, tracer,
+  webhookPath: WEBHOOK_PATH,
+  onWebhook: botFrameworkIntake(...),
+  onCallback: (c) => this.#onCallback(c),
+  onLinkComplete,
+});
 ```
-
-The handler is identical to ghbridge's (Step 7d) — resolve
-`PendingDispatch` by link token, load discussion context, find latest user
-turn by author, re-dispatch, render confirmation page. No `ackTarget` (user
-is on the browser). No channel SDK involved.
-
-Store the `config` reference as `this.#config = config` in the constructor
-(currently only `this.#msAppId` is stored from config; `callback_base_url`
-is needed for `normalizeBaseUrl` in `#stashAndPostLink`).
 
 ### 8e — Tests
 
-**helpers.js** — extend msbridge's `createStatefulDiscussionClient` with
-`PutPendingDispatch` / `ResolvePendingDispatch` stubs (same pattern as
-ghbridge Step 7e).
+**helpers.js** — extend `createStatefulDiscussionClient` with
+`PutPendingDispatch` / `ResolvePendingDispatch` stubs.
 
 **dispatch-auth.test.js** — update the `link_required` test: the reply
 now contains the augmented URL.
 
-**link-complete.test.js** (new) — same test matrix as ghbridge's
-(Step 7e), adapted for Bot Framework mocks instead of GraphQL:
+Bridge-level tests verify turn persistence and URL augmentation; the
+link-complete handler is tested in `libbridge/test/link-resume.test.js`
+(Step 6):
 
-| Case | Assertion |
-|---|---|
-| Valid link_token, binding exists | dispatch fires, renders "Processing" page |
-| Valid link_token, no binding | renders "Unable to dispatch" |
-| Unknown/consumed link_token | renders "Already processed" |
-| Missing `state` param | 400 |
-| New message then link_required | user turn present in discussion store before pending stash |
-| Inspect PendingDispatch record | no message body in record |
+| Case | Spec criterion | Assertion |
+|---|---|---|
+| New message then link_required | SC 3 (canonical store) | user turn in store before pending stash |
+| Inspect PendingDispatch record | SC 6 (no message body) | record has no `text` or `body` field |
 
 Verify: `bun test services/msbridge/test/` — all tests pass.
 
 ## Libraries used
 
 `@forwardimpact/libbridge` (appendHistory, Dispatcher, buildPrompt,
-normalizeBaseUrl, createBridgeServer), `@forwardimpact/libtype` (bridge,
-ghauth typed message constructors).
+normalizeBaseUrl, createBridgeServer, prepareLinkResume,
+createLinkCompleteHandler), `@forwardimpact/libtype` (bridge, ghauth typed
+message constructors).
 
 ## Risks
 

--- a/specs/1380-ghbridge-link-binding-integrity-resume/plan-a.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/plan-a.md
@@ -7,10 +7,11 @@
 The implementation sequences changes bottom-up: proto definitions first
 (shared schema), then the identity-verification and client-state plumbing
 in `ghauth` / `oauth`, the `PendingDispatch` store in `services/bridge`,
-the `Dispatcher` clean break in `libbridge`, and finally the `ghbridge`
-integration that ties the resume flow together. Each step is independently
-testable and the ordering avoids forward references — later steps depend
-on earlier ones but never the reverse.
+the `Dispatcher` clean break in `libbridge`, then the `ghbridge`
+integration, and finally the parallel `msbridge` integration for full
+bridge parity. Each step is independently testable and the ordering avoids
+forward references — later steps depend on earlier ones but never the
+reverse.
 
 ## Step 1 — Proto changes and codegen
 
@@ -566,6 +567,154 @@ not the bare authorize URL.
 
 Verify: `bun test services/ghbridge/test/` — all tests pass.
 
+## Step 8 — msbridge: resume parity
+
+Intent: msbridge gets the same resume flow as ghbridge — turn persistence
+with author, pending-dispatch stash on `link_required`, and a
+`/api/link-complete` endpoint. The handler logic is identical to ghbridge's;
+the only channel-specific difference is that `#stashAndPostLink` uses
+`sendReply` (Bot Framework) instead of `postSingleDiscussionReply`
+(GraphQL). Depends on Steps 5 (PendingDispatch store) and 6 (Dispatcher
+clean break).
+
+| File | Action |
+|---|---|
+| `services/msbridge/index.js` | Modified |
+| `services/msbridge/src/discussion-adapter.js` | Modified |
+| `services/msbridge/test/helpers.js` | Modified |
+| `services/msbridge/test/dispatch-auth.test.js` | Modified |
+| `services/msbridge/test/link-complete.test.js` | Created |
+
+### 8a — DiscussionAdapter: add pending-dispatch methods
+
+Add `putPendingDispatch(target)` and `resolvePendingDispatch(linkToken)` to
+msbridge's `DiscussionAdapter`. Identical to ghbridge's (Step 7a) — same
+`isNotFound` pattern, same bridge RPC wrappers.
+
+### 8b — Turn persistence with author
+
+**`#handleNewMessage` (line 219)** — add `author: requester` to the
+existing `appendHistory` call:
+
+```js
+appendHistory(ctx.history, { role: "user", text, author: requester });
+```
+
+Move `await this.#store.add(ctx)` before the `processInbound` call
+(currently at lines 223–224 inside the `!freshDispatchAllowed` branch) to
+ensure the turn reaches the canonical store before any bookkeeping on
+every code path, not just the non-dispatch path:
+
+```js
+appendHistory(ctx.history, { role: "user", text, author: requester });
+
+const { freshDispatchAllowed } = await this.#resume.processInbound(ctx);
+if (!freshDispatchAllowed) {
+  await this.#store.add(ctx);
+  await this.#store.flush();
+  span.setOk();
+  return;
+}
+```
+
+Wait — msbridge currently persists only on the `!freshDispatchAllowed`
+early return. On the dispatch path, the dispatcher itself calls
+`store.add(ctx)` + `store.flush()` on success. For the resume invariant,
+the turn must be persisted **before** the pending-dispatch stash
+(link_required path). Add `await this.#store.add(ctx)` before the dispatch
+call:
+
+```js
+await this.#store.add(ctx);
+
+const limit = this.#rateLimiter.check(threadId, ctx.dispatches);
+// ... rate limit, dispatch, etc.
+```
+
+### 8c — Link augmentation on link_required
+
+Add a `#stashAndPostLink` method mirroring ghbridge's (Step 7c), using
+`sendReply` instead of `postSingleDiscussionReply`:
+
+```js
+async #stashAndPostLink(ctx, result, requester) {
+  const linkToken = crypto.randomUUID();
+
+  await this.#store.putPendingDispatch({
+    link_token: linkToken,
+    surface: CHANNEL,
+    surface_user_id: requester,
+    discussion_id: ctx.discussion_id,
+    created_at: Date.now(),
+  });
+
+  const url = new URL(result.authorizeUrl);
+  const callbackBase = normalizeBaseUrl(this.#config.callback_base_url);
+  url.searchParams.set("redirect_uri", `${callbackBase}/api/link-complete`);
+  url.searchParams.set("client_state", linkToken);
+
+  const ref = ctx.participants?.[0]?.metadata;
+  if (ref) {
+    await sendReply(
+      this.#adapter,
+      this.#msAppId,
+      ref,
+      `To dispatch, link your GitHub account: ${url}`,
+    );
+  }
+}
+```
+
+Add `import crypto from "node:crypto";` at the top of the file.
+
+In `#handleNewMessage`, when dispatch returns `link_required`, call
+`#stashAndPostLink` instead of `#renderDeclined`. Keep `link_required`
+in `#renderDeclined` for the `ResumeScheduler.onDeclined` callback (same
+reasoning as ghbridge Step 7c).
+
+### 8d — `/api/link-complete` endpoint
+
+Mount a GET route on the bridge app in the constructor, after
+`createBridgeServer`:
+
+```js
+this.#bridge.app.get("/api/link-complete", (c) =>
+  this.#handleLinkComplete(c),
+);
+```
+
+The handler is identical to ghbridge's (Step 7d) — resolve
+`PendingDispatch` by link token, load discussion context, find latest user
+turn by author, re-dispatch, render confirmation page. No `ackTarget` (user
+is on the browser). No channel SDK involved.
+
+Store the `config` reference as `this.#config = config` in the constructor
+(currently only `this.#msAppId` is stored from config; `callback_base_url`
+is needed for `normalizeBaseUrl` in `#stashAndPostLink`).
+
+### 8e — Tests
+
+**helpers.js** — extend msbridge's `createStatefulDiscussionClient` with
+`PutPendingDispatch` / `ResolvePendingDispatch` stubs (same pattern as
+ghbridge Step 7e).
+
+**dispatch-auth.test.js** — update the `link_required` test: the reply
+now contains the augmented URL.
+
+**link-complete.test.js** (new) — same test matrix as ghbridge's
+(Step 7e), adapted for Bot Framework mocks instead of GraphQL:
+
+| Case | Assertion |
+|---|---|
+| Valid link_token, binding exists | dispatch fires, renders "Processing" page |
+| Valid link_token, no binding | renders "Unable to dispatch" |
+| Unknown/consumed link_token | renders "Already processed" |
+| Missing `state` param | 400 |
+| New message then link_required | user turn present in discussion store before pending stash |
+| Inspect PendingDispatch record | no message body in record |
+
+Verify: `bun test services/msbridge/test/` — all tests pass.
+
 ## Libraries used
 
 `@forwardimpact/libbridge` (appendHistory, Dispatcher, buildPrompt,
@@ -581,7 +730,9 @@ ghauth typed message constructors).
 
 ## Execution
 
-All steps are sequential (each depends on the prior step's outputs).
+Steps 1–7 are sequential (each depends on the prior step's outputs).
+Step 8 (msbridge parity) depends on Steps 5 and 6 but is independent of
+Step 7 — Steps 7 and 8 can run in parallel if two agents are available.
 Route to `staff-engineer` for implementation. `technical-writer` is not
 needed — changes are internal service code with no published documentation
 impact.

--- a/specs/1380-ghbridge-link-binding-integrity-resume/plan-a.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/plan-a.md
@@ -1,0 +1,587 @@
+# Plan 1380-a — link binding integrity and auth-completion resume
+
+[Spec](spec.md) · [Design](design-a.md)
+
+## Approach
+
+The implementation sequences changes bottom-up: proto definitions first
+(shared schema), then the identity-verification and client-state plumbing
+in `ghauth` / `oauth`, the `PendingDispatch` store in `services/bridge`,
+the `Dispatcher` clean break in `libbridge`, and finally the `ghbridge`
+integration that ties the resume flow together. Each step is independently
+testable and the ordering avoids forward references — later steps depend
+on earlier ones but never the reverse.
+
+## Step 1 — Proto changes and codegen
+
+Intent: extend the shared schema to carry identity verification outcomes,
+client-state passthrough, history authorship, and pending-dispatch records.
+
+| File | Action |
+|---|---|
+| `services/ghauth/proto/ghauth.proto` | Modified |
+| `services/bridge/proto/bridge.proto` | Modified |
+| `generated/` | Regenerated |
+
+**ghauth.proto** — add `client_state` to `BeginRequest`, add `outcome` to
+`CompleteResponse`:
+
+```protobuf
+message BeginRequest {
+  string surface = 1;
+  string surface_user_id = 2;
+  optional string redirect_uri = 3;
+  optional string code_challenge = 4;
+  repeated string scopes = 5;
+  optional string client_state = 6;       // NEW
+}
+
+message CompleteResponse {
+  optional string downstream_code = 1;
+  optional string redirect_uri = 2;
+  optional string client_state = 3;
+  optional string outcome = 4;            // NEW — "identity_mismatch" or absent
+}
+```
+
+**bridge.proto** — add `author` to `HistoryEntry`, add `PendingDispatch`
+message, two RPCs, and extend `SweepResponse`:
+
+```protobuf
+message HistoryEntry {
+  string role = 1;
+  string text = 2;
+  optional string author = 3;             // NEW — surface_user_id of the participant
+}
+
+message PendingDispatch {
+  string link_token = 1;
+  string surface = 2;
+  string surface_user_id = 3;
+  string discussion_id = 4;
+  int64 created_at = 5;
+}
+
+message PutPendingDispatchRequest { PendingDispatch pending = 1; }
+message ResolvePendingDispatchRequest { string link_token = 1; }
+
+message SweepResponse {
+  int32 evicted_discussions = 1;
+  int32 evicted_origins = 2;
+  int32 evicted_pending = 3;              // NEW
+}
+```
+
+Add to the `Bridge` service block:
+
+```protobuf
+rpc PutPendingDispatch(PutPendingDispatchRequest) returns (common.Empty);
+rpc ResolvePendingDispatch(ResolvePendingDispatchRequest) returns (PendingDispatch);
+```
+
+Run `just codegen`.
+
+Verify: `bun test services/ghauth/test services/bridge/test` — existing
+tests pass with the new optional fields.
+
+## Step 2 — github-oauth.js: add getUser
+
+Intent: resolve the authenticated GitHub account id from a freshly minted
+token so `Complete` can verify the authorizer's identity.
+
+| File | Action |
+|---|---|
+| `services/ghauth/src/github-oauth.js` | Modified |
+
+Add `getUser` to the object returned by `createGithubOAuth`, after `revoke`:
+
+```js
+async getUser(accessToken) {
+  const res = await fetchImpl("https://api.github.com/user", {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  if (!res.ok) throw new Error(`GitHub user lookup failed: ${res.status}`);
+  const body = await res.json();
+  return body.id;
+},
+```
+
+Returns the numeric GitHub user id.
+
+Verify: unit test in `services/ghauth/test/` confirming `getUser` calls the
+correct endpoint and returns the id.
+
+## Step 3 — ghauth: identity verification and client_state passthrough
+
+Intent: `Complete` verifies the authorizer matches the intended surface
+identity; `Begin` stores the caller's `client_state` instead of `null`.
+
+| File | Action |
+|---|---|
+| `services/ghauth/index.js` | Modified |
+
+**Begin (line 51)** — replace `client_state: null` with
+`client_state: req.client_state ?? null`.
+
+**Complete (lines 68–108)** — after the `exchangeCode` call (line 73),
+before the binding upsert. The flow is already consumed (line 69) at this
+point, so even on mismatch the flow cannot be replayed — an important
+single-use property. On identity mismatch, the early return also skips the
+`if (flow.redirect_uri)` branch, so no downstream grant is created and no
+redirect occurs; the caller (`oauth /callback`) renders a terminal refusal
+page instead:
+
+```js
+const GITHUB_ID_SURFACES = new Set(["github-discussions"]);
+
+// Resolve the authorizing GitHub account
+const authorizedGithubId = String(
+  await this.#github.getUser(tokens.access_token),
+);
+
+// Identity policy: surfaces whose namespace IS GitHub accounts require equality
+if (
+  GITHUB_ID_SURFACES.has(flow.surface) &&
+  authorizedGithubId !== flow.surface_user_id
+) {
+  return { outcome: "identity_mismatch" };
+}
+```
+
+Replace the `github_user_id: null` binding (line 81) with
+`github_user_id: authorizedGithubId`.
+
+The constant `GITHUB_ID_SURFACES` is module-level, placed below
+`EXPIRY_BUFFER_MS`.
+
+Verify: new test `services/ghauth/test/identity-verification.test.js`:
+- matching id → binding created with `github_user_id` populated, no
+  `outcome` on the response
+- mismatching id → no binding created/modified, response has
+  `outcome: "identity_mismatch"`
+- non-github-discussions surface → binding created regardless of id
+  difference, `github_user_id` populated with the verified id
+- `client_state` round-trip: `Begin({ ..., client_state: "tok" })` →
+  `Complete` response carries `client_state: "tok"`
+
+## Step 4 — oauth: client_state passthrough and identity_mismatch refusal
+
+Intent: the OAuth HTTP surface forwards `client_state` into `Begin` and
+renders a refusal page when `Complete` returns an identity mismatch.
+Depends on Step 3 (ghauth accepts `client_state` and returns `outcome`).
+
+| File | Action |
+|---|---|
+| `services/oauth/index.js` | Modified |
+
+**/authorize (lines 41–60)** — extract `client_state` from query alongside
+the existing params; pass it to `BeginRequest`:
+
+```js
+const {
+  surface, surface_user_id, redirect_uri, code_challenge, scope, client_state,
+} = c.req.query();
+// ...
+const result = await providerClient.Begin(
+  typed("BeginRequest", {
+    surface,
+    surface_user_id,
+    redirect_uri: redirect_uri || undefined,
+    code_challenge: code_challenge || undefined,
+    scopes,
+    client_state: client_state || undefined,
+  }),
+);
+```
+
+**/callback (lines 62–83)** — before the `result.redirect_uri` check, add
+an identity-mismatch guard:
+
+```js
+if (result.outcome === "identity_mismatch") {
+  return c.html(
+    '<!DOCTYPE html><html><body><h1>Account mismatch</h1>' +
+      '<p>The GitHub account that authorized does not match the ' +
+      'account that requested linking. No binding was created. ' +
+      'Please try again from the correct account.</p></body></html>',
+  );
+}
+```
+
+Verify: update `services/oauth/test/authorize.test.js`:
+- `/authorize` with `client_state` passes it to `Begin`
+- `/callback` receiving `outcome: "identity_mismatch"` renders the refusal
+  page (200, HTML contains "mismatch")
+
+## Step 5 — bridge: PendingDispatch store and RPCs
+
+Intent: add a TTL-swept store for pending re-dispatch targets, keyed by
+link token, consumed atomically on resolution.
+
+| File | Action |
+|---|---|
+| `services/bridge/index.js` | Modified |
+| `services/bridge/proto/bridge.proto` | (Already modified in Step 1) |
+
+Add a third `BufferedIndex` for `pending_dispatches.jsonl` alongside
+discussions and origins. Wire `PutPendingDispatch` and
+`ResolvePendingDispatch` RPCs:
+
+```js
+constructor(config, { storage, logger, tracer }) {
+  // ... existing discussions and origins ...
+  this.#pendingDispatches = new BufferedIndex(
+    storage, "pending_dispatches.jsonl",
+    { flush_interval: config.pending_flush_interval_ms ?? 1_000,
+      max_buffer_size: 100 },
+  );
+  this.#pendingTtlMs = config.pending_ttl_ms ?? 10 * 60 * 1000;
+}
+```
+
+**PutPendingDispatch** — store with `id: link_token`:
+
+```js
+async PutPendingDispatch(req) {
+  const p = req.pending;
+  await this.#pendingDispatches.add({
+    id: p.link_token,
+    surface: p.surface,
+    surface_user_id: p.surface_user_id,
+    discussion_id: p.discussion_id,
+    created_at: Number(p.created_at) || Date.now(),
+  });
+  return {};
+}
+```
+
+**ResolvePendingDispatch** — consume (return + soft-delete). Follow the
+`BindingStore` pattern: `index.delete` removes the record from memory,
+then `add({ id, deleted: true })` writes a delete marker to the JSONL.
+Filter `deleted` records in `loadData` so they do not reappear after
+restart:
+
+```js
+async ResolvePendingDispatch(req) {
+  await this.#pendingDispatches.loadData();
+  for (const [id, rec] of this.#pendingDispatches.index) {
+    if (rec.deleted) this.#pendingDispatches.index.delete(id);
+  }
+  const rec = this.#pendingDispatches.index.get(req.link_token);
+  if (!rec)
+    throw Object.assign(new Error("not found"), {
+      code: grpc.status.NOT_FOUND,
+    });
+  this.#pendingDispatches.index.delete(req.link_token);
+  await this.#pendingDispatches.add({ id: req.link_token, deleted: true });
+  return bridge.PendingDispatch.fromObject({
+    link_token: rec.id,
+    surface: rec.surface,
+    surface_user_id: rec.surface_user_id,
+    discussion_id: rec.discussion_id,
+    created_at: rec.created_at,
+  });
+}
+```
+
+**Sweep** — extend `#sweep` to evict stale pending dispatches using
+`this.#pendingTtlMs` (same pattern as discussions/origins). Include the
+count in `SweepResponse.evicted_pending`.
+
+**shutdown** — flush pending dispatches alongside discussions and origins.
+
+Verify: add tests to `services/bridge/test/bridge.test.js`:
+- put → resolve returns the record and consumes it (second resolve →
+  NOT_FOUND)
+- sweep evicts records older than TTL
+- resolve after restart still sees NOT_FOUND (delete marker survives)
+
+## Step 6 — libbridge: remove historyText from Dispatcher, add author to appendHistory
+
+Intent: the dispatch primitive no longer mutates history (clean break);
+author attribution added to history entries.
+
+| File | Action |
+|---|---|
+| `libraries/libbridge/src/dispatcher.js` | Modified |
+| `libraries/libbridge/src/history.js` | Modified |
+| `libraries/libbridge/test/dispatcher.test.js` | Modified |
+| `libraries/libbridge/CLAUDE.md` | Modified (remove stale `historyText` from dispatch example) |
+
+**dispatcher.js** — remove `historyText` from the `dispatch()` parameter
+list, the JSDoc, and the conditional `appendHistory` call (lines 97–99).
+Remove the `appendHistory` import.
+
+**history.js** — accept optional `author` on entries:
+
+```js
+export function appendHistory(history, entry, { maxEntries = 10 } = {}) {
+  const record = { role: entry.role, text: entry.text };
+  if (entry.author !== undefined) record.author = entry.author;
+  history.push(record);
+  while (history.length > maxEntries) history.shift();
+}
+```
+
+**dispatcher.test.js** — remove `historyText: "hello"` from the happy-path
+test; update the assertion that checks `ctx.history` — it should now be
+empty after dispatch (history is the intake's responsibility). Remove the
+`"historyText omitted: no history is appended"` test (parameter no longer
+exists). `msbridge` already appends at intake and never passes
+`historyText`, so it is unaffected.
+
+Verify: `bun test libraries/libbridge/test/dispatcher.test.js` — all
+remaining tests pass.
+
+## Step 7 — ghbridge: turn persistence, link augmentation, /api/link-complete
+
+Intent: both intake paths persist the user turn (with author) before
+dispatch; `link_required` outcomes stash a `PendingDispatch` and augment
+the authorize URL; a new endpoint completes the resume. Depends on Step 4
+(oauth forwards `client_state` extracted from the augmented authorize URL),
+Step 5 (bridge stores pending dispatches), and Step 6 (Dispatcher no
+longer accepts `historyText`).
+
+| File | Action |
+|---|---|
+| `services/ghbridge/index.js` | Modified |
+| `services/ghbridge/src/discussion-adapter.js` | Modified |
+| `services/ghbridge/test/helpers.js` | Modified (add `PutPendingDispatch`/`ResolvePendingDispatch` stubs to `createStatefulDiscussionClient`) |
+| `services/ghbridge/test/dispatch-auth.test.js` | Modified |
+| `services/ghbridge/test/link-complete.test.js` | Created |
+
+### 7a — DiscussionAdapter: add pending-dispatch methods
+
+Add `putPendingDispatch(target)` and `resolvePendingDispatch(linkToken)` to
+`DiscussionAdapter`, wrapping the new bridge RPCs. Same `isNotFound` pattern
+as `loadByChannel`:
+
+```js
+async putPendingDispatch(target) {
+  await this.#client.PutPendingDispatch(
+    bridge.PutPendingDispatchRequest.fromObject({ pending: target }),
+  );
+}
+
+async resolvePendingDispatch(linkToken) {
+  try {
+    return await this.#client.ResolvePendingDispatch(
+      bridge.ResolvePendingDispatchRequest.fromObject({
+        link_token: linkToken,
+      }),
+    );
+  } catch (err) {
+    if (isNotFound(err)) return null;
+    throw err;
+  }
+}
+```
+
+### 7b — Turn persistence with author
+
+**`#handleDiscussionCreated`** — before the rate-limit check, append the
+user turn and persist the context. This is a behavioral change: the context
+is now persisted on every discussion-created event (including rate-limited
+and declined outcomes), which is required for resume — the turn must be in
+the canonical store before any pending-dispatch bookkeeping:
+
+```js
+appendHistory(ctx.history, { role: "user", text, author: requester });
+ctx.last_active_at = Date.now();
+await this.#store.add(ctx);
+```
+
+Remove `historyText: text` from the `dispatch()` call.
+
+**`#handleDiscussionComment` (line 314)** — add `author: requester` to the
+existing `appendHistory` call. Move `await this.#store.add(ctx)` before the
+`processInbound` call to ensure the turn reaches the canonical store before
+any bookkeeping. Keep the final `store.add(ctx)` at line 344 (captures
+dispatch-result state).
+
+### 7c — Link augmentation on link_required
+
+Add a new `#stashAndPostLink` method. Both intake paths call it when
+dispatch returns `link_required` (instead of calling `#renderDeclined`).
+
+The `link_required` case stays in `#renderDeclined` — it is still needed by
+the `ResumeScheduler.onDeclined` callback (`index.js:127`), which fires
+when a resumed dispatch returns `link_required` (e.g., binding revoked
+between recess and elapsed-timer fire). That path posts the bare authorize
+URL without augmentation, since there is no specific user turn to stash for
+a resume-initiated re-dispatch.
+
+```js
+async #stashAndPostLink(ctx, result, requester) {
+  const linkToken = crypto.randomUUID();
+
+  await this.#store.putPendingDispatch({
+    link_token: linkToken,
+    surface: CHANNEL,
+    surface_user_id: requester,
+    discussion_id: ctx.discussion_id,
+    created_at: Date.now(),
+  });
+
+  const url = new URL(result.authorizeUrl);
+  const callbackBase = normalizeBaseUrl(this.#config.callback_base_url);
+  url.searchParams.set("redirect_uri", `${callbackBase}/api/link-complete`);
+  url.searchParams.set("client_state", linkToken);
+
+  const body = `To dispatch, link your GitHub account: ${url}`;
+  const recordOrigin = async (comment) => {
+    await this.#client.RecordOrigin(
+      bridge.Origin.fromObject({
+        id: comment.id,
+        discussion_id: ctx.discussion_id,
+        posted_at: Date.now(),
+      }),
+    );
+  };
+  await postSingleDiscussionReply(
+    this.#graphqlClient, ctx, body, recordOrigin,
+  );
+}
+```
+
+Add `import crypto from "node:crypto";` at the top of the file.
+
+The augmented authorize URL includes `redirect_uri` and `client_state` as
+query params. When the user completes OAuth, `ghauth.Complete` creates a
+downstream grant (because `flow.redirect_uri` is set) whose code is
+included in the redirect to `/api/link-complete`. The link-complete handler
+does not redeem this code — the `GetToken` gate during re-dispatch is the
+proof of completion. The orphaned grant expires via the grants store TTL;
+this is acceptable overhead from reusing the existing redirect plumbing.
+
+### 7d — `/api/link-complete` endpoint
+
+Mount a GET route on the bridge app in the constructor, after
+`createBridgeServer`:
+
+```js
+this.#bridge.app.get("/api/link-complete", (c) =>
+  this.#handleLinkComplete(c),
+);
+```
+
+Handler. No `ackTarget` is passed on re-dispatch — the user is on the
+browser confirmation page, not watching the discussion thread for a
+reaction:
+
+```js
+async #handleLinkComplete(c) {
+  const linkToken = c.req.query("state");
+  if (!linkToken) {
+    return c.html(
+      "<!DOCTYPE html><html><body><h1>Error</h1>" +
+        "<p>Missing state parameter.</p></body></html>",
+      400,
+    );
+  }
+
+  const target = await this.#store.resolvePendingDispatch(linkToken);
+  if (!target) {
+    return c.html(
+      "<!DOCTYPE html><html><body><h1>Already processed</h1>" +
+        "<p>This link has already been used or has expired." +
+        "</p></body></html>",
+    );
+  }
+
+  const ctx = await this.#store.loadByChannel(CHANNEL, target.discussion_id);
+  if (!ctx) {
+    return c.html(
+      "<!DOCTYPE html><html><body><h1>Error</h1>" +
+        "<p>Discussion not found.</p></body></html>",
+      404,
+    );
+  }
+
+  const userTurn = [...ctx.history]
+    .reverse()
+    .find(
+      (e) => e.role === "user" && e.author === target.surface_user_id,
+    );
+  if (!userTurn) {
+    return c.html(
+      "<!DOCTYPE html><html><body><h1>Error</h1>" +
+        "<p>No message found to re-dispatch.</p></body></html>",
+      404,
+    );
+  }
+
+  const result = await this.#dispatcher.dispatch({
+    ctx,
+    prompt: buildPrompt(userTurn.text, ctx.history),
+    requester: target.surface_user_id,
+    callbackMeta: { discussionId: target.discussion_id },
+    workflowInputs: { discussionId: target.discussion_id },
+  });
+
+  if (result.kind === "dispatched") {
+    return c.html(
+      "<!DOCTYPE html><html><body><h1>Processing</h1>" +
+        "<p>Your message is being processed. " +
+        "You can close this window.</p></body></html>",
+    );
+  }
+
+  return c.html(
+    "<!DOCTYPE html><html><body><h1>Unable to dispatch</h1>" +
+      "<p>Your account could not be verified. Please try " +
+      "linking again from the discussion.</p></body></html>",
+  );
+}
+```
+
+### 7e — Tests
+
+**helpers.js** — extend `createStatefulDiscussionClient` with
+`PutPendingDispatch` (stores in a local map) and
+`ResolvePendingDispatch` (consume-and-return from the map, throw NOT_FOUND
+if absent). Both tests (`dispatch-auth.test.js` and `link-complete.test.js`)
+share this fixture.
+
+**dispatch-auth.test.js** — update the `link_required` test: the posted
+comment now contains augmented URL params (`redirect_uri`, `client_state`),
+not the bare authorize URL.
+
+**link-complete.test.js** (new) — exercises the full resume round-trip:
+
+| Case | Spec criterion | Assertion |
+|---|---|---|
+| Valid link_token, binding exists | SC 5 (completing link causes dispatch) | dispatch fires, renders "Processing" page |
+| Valid link_token, no binding | — | dispatch returns link_required, renders "Unable to dispatch" |
+| Unknown/consumed link_token | SC 7 (tamper-resistance) | renders "Already processed" |
+| Missing `state` param | SC 7 (tamper-resistance) | 400 |
+| Multi-party thread: two users posted | SC 8 (correct turn attribution) | re-dispatches the linking user's turn, not the other's |
+| Altered `state` param (wrong token) | SC 7 (tamper-resistance) | renders "Already processed" (server-held target wins) |
+| Discussion-created then link_required | SC 3 (first-message canonical store) | after link is posted, the user turn is present in the discussion store |
+| Comment then link_required | SC 4 (comment-path canonical store) | after link is posted, the user turn is present in the discussion store |
+| Inspect PendingDispatch record | SC 6 (no message body) | record contains `link_token`, `surface`, `surface_user_id`, `discussion_id`, `created_at` only — no `text` or `body` field |
+
+Verify: `bun test services/ghbridge/test/` — all tests pass.
+
+## Libraries used
+
+`@forwardimpact/libbridge` (appendHistory, Dispatcher, buildPrompt,
+normalizeBaseUrl, createBridgeServer), `@forwardimpact/libtype` (bridge,
+ghauth typed message constructors).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `GET /user` rate limit during high-throughput linking | The call happens once per link completion, not per dispatch. GitHub's 5000 req/hr per-token limit is well above the expected linking rate. |
+| Pending dispatch sweep races with completion callback | `ResolvePendingDispatch` is a consume (get-and-delete) operation on the bridge service — at most one caller wins; the second sees NOT_FOUND and renders "Already processed". |
+
+## Execution
+
+All steps are sequential (each depends on the prior step's outputs).
+Route to `staff-engineer` for implementation. `technical-writer` is not
+needed — changes are internal service code with no published documentation
+impact.

--- a/specs/1380-ghbridge-link-binding-integrity-resume/spec.md
+++ b/specs/1380-ghbridge-link-binding-integrity-resume/spec.md
@@ -5,9 +5,11 @@
 The per-user GitHub authentication flow that bridges use to dispatch workflows
 under the requester's own identity (spec 1320, spec 1340) has two coupled
 defects: the account-linking step can bind a token to the wrong person, and the
-message that triggers linking is silently dropped. Both surface on the
-`github-discussions` channel served by `ghbridge` over the shared `ghauth` /
-`oauth` services.
+message that triggers linking is silently dropped. Both defects affect every
+bridge channel (`github-discussions` via `ghbridge`, `msteams` via `msbridge`)
+because the linking flow runs through the shared `ghauth` / `oauth` services
+and the vulnerability is in the shared completion step, not in channel-specific
+code.
 
 ### Defect 1 — The link binds a token to an unverified identity (security, HIGH)
 
@@ -19,9 +21,10 @@ never to the GitHub account that actually authorized. The completion step
 records no GitHub account id for the binding and performs no check that the
 authorizer is the intended user.
 
-Because the link lives in the discussion thread — which may be fully public —
-anyone who can see it (or who simply edits the surface-identity parameter)
-can complete the flow on the intended user's behalf:
+Because the link lives in the channel thread — a public GitHub Discussion or a
+Teams conversation visible to all participants — anyone who can see it (or who
+simply edits the surface-identity parameter) can complete the flow on the
+intended user's behalf:
 
 | Timing | Effect |
 |---|---|
@@ -69,20 +72,18 @@ precondition for the resume feature, and the two ship together.
 
 | Component | What changes |
 |---|---|
-| Account-link completion | The token is bound only when the GitHub account that authorized matches the intended surface identity; a mismatch writes and overwrites nothing. The binding records which GitHub account it represents. |
-| Auth-completion resume | A message dropped because the requester had no binding is re-dispatched automatically once that same user completes linking — no resend. The user sees a confirmation that the message is being processed, not a dead-end page. |
-| Single source of truth for message content | The dropped message is recorded in the canonical discussion store before any resume bookkeeping, on every intake path including a new discussion's first message, so resume reconstructs the prompt from the canonical store. Resume bookkeeping stores no copy of the message body. |
+| Account-link completion | The token is bound only after verifying the authorizing GitHub account; the binding records which GitHub account it represents. On surfaces whose identity namespace is GitHub accounts (`github-discussions`), a mismatch between the authorizer and the intended surface identity writes and overwrites nothing. On surfaces with a different namespace (`msteams`), the verified GitHub id is recorded without asserting equality — the binding still cannot be created silently by a third party, because the completion step now requires a verified identity. |
+| Auth-completion resume | A message dropped because the requester had no binding is re-dispatched automatically once that same user completes linking — no resend. The user sees a confirmation that the message is being processed, not a dead-end page. This applies to both `ghbridge` and `msbridge`. |
+| Single source of truth for message content | The dropped message is recorded in the canonical discussion store before any resume bookkeeping, on every intake path (ghbridge: discussion-created, discussion-comment; msbridge: new message), so resume reconstructs the prompt from the canonical store. Resume bookkeeping stores no copy of the message body. |
 | Turn attribution in discussion history | Stored discussion-history turns identify their authoring user, so resume re-dispatches the turn belonging to the user who linked rather than whatever turn happens to be most recent in a multi-participant thread. |
 | Tamper-resistance of the resume target | The linking round-trip cannot let whoever completes it choose which user or which thread is re-dispatched; the replay target is fixed by server-held state, not by data the completer can edit. |
+| Bridge parity | Both `ghbridge` and `msbridge` implement the same resume flow: pending-dispatch stash, augmented authorize URL, and a `/api/link-complete` endpoint. The identity verification, `PendingDispatch` store, `Dispatcher` clean break, and history `author` field are shared infrastructure used by both. |
 
 ### Out of scope
 
 - Alternative token-minting methods (device flow, personal access tokens, or
   dispatching under the App installation token instead of a user token) — a
   separate decision.
-- Identity verification for the Microsoft Teams surface — its identity model
-  differs; this spec covers `github-discussions` only. Shared bridge
-  primitives must not preclude a later Teams equivalent.
 - Changing the linking UX away from a clickable link (the click-through flow
   is retained deliberately).
 - Resilience when the user abandons the browser after authorizing but before
@@ -99,9 +100,8 @@ precondition for the resume feature, and the two ship together.
 |---|---|
 | A completion whose authorizing GitHub account differs from the requested surface identity neither writes a new binding nor overwrites an existing one. | Drive a completion where the authorizer's account id differs from the requested surface identity; observe no binding is created or modified. |
 | Every binding records the GitHub account id of the user who authorized it. | Complete a flow and inspect the resulting binding; observe it carries the authorizer's GitHub account id. |
-| A message arriving from a user with no binding is recorded in the canonical discussion store before any resume bookkeeping, on the first-message-of-a-new-discussion path. | Send a first message on a new discussion from an unlinked user; observe the message is present in the canonical discussion store after the link is posted, before linking completes. |
-| The same record-before-bookkeeping ordering holds on the existing-thread comment path, so the property is uniform across intake paths. | Post a comment from an unlinked user on an existing discussion; observe the message is in the canonical discussion store before any resume bookkeeping. |
-| Completing the link causes the originally-intended message to be dispatched without the user sending it again. | Drive first message → posted link → verified completion with no second inbound message; observe exactly one workflow dispatch occurs and it carries the original prompt. |
+| A message arriving from a user with no binding is recorded in the canonical discussion store before any resume bookkeeping, on every intake path (ghbridge: discussion-created, discussion-comment; msbridge: new message). | Send a first message from an unlinked user on each intake path; observe the message is present in the canonical discussion store after the link is posted, before linking completes. |
+| Completing the link causes the originally-intended message to be dispatched without the user sending it again, on both `ghbridge` and `msbridge`. | Drive first message → posted link → verified completion with no second inbound message; observe exactly one workflow dispatch occurs and it carries the original prompt. Repeat on each bridge. |
 | Resume bookkeeping holds no copy of the message body. | Inspect the persisted resume record; observe it carries identifiers and timestamps only, no message text. |
 | Whoever completes the link cannot redirect the re-dispatch to a different user or thread than the one recorded when the link was issued. | Attempt to alter the completer-visible round-trip data to name a different user/thread; observe the re-dispatch targets the server-recorded (user, thread) and ignores the altered data. |
 | In a thread where several humans have posted, resume re-dispatches the turn authored by the user who linked. | Interleave turns from two users before linking, then complete linking as one of them; observe the re-dispatched prompt is that user's turn. |


### PR DESCRIPTION
## Summary

- Eight-step plan for spec 1380: fixes two coupled defects on the account-linking flow (binding integrity + message-drop resume) across both ghbridge and msbridge
- Pushes createLinkCompleteHandler and prepareLinkResume into libbridge as channel-agnostic primitives — both bridges wire them identically with one channel-SDK call each
- Identity verification in ghauth.Complete records verified GitHub id on every binding; equality check fires on github-discussions (same namespace), record-only on msteams (different namespace)

## Test plan

- [ ] bun run check
- [ ] bun run test

Generated with Claude Code