### PR TITLE
plan(1390): realtime bridge conversations

### DIFF
--- a/specs/1390-realtime-bridge-conversations/plan-a-01.md
+++ b/specs/1390-realtime-bridge-conversations/plan-a-01.md
@@ -1,0 +1,379 @@
+# Plan 1390-a Part 1 — Bridge-side streaming contract
+
+[overview](plan-a.md) · [part 2](plan-a-02.md)
+
+## Step 1: Extend Discussion proto with session fields
+
+Add `active_requester` and `last_posted_seq` to the Discussion message so
+the dispatch-vs-inject state machine and seq-based dedupe survive bridge
+restarts.
+
+**Modified:** `services/bridge/proto/bridge.proto`
+
+```diff
+ message Discussion {
+   ...
+   map<string, string> pending_callbacks = 10;
++  optional string active_requester = 11;
++  int64 last_posted_seq = 12;  // init to -1 at creation site
+ }
+```
+
+The `last_posted_seq` proto default is `0`, but `SequenceCounter` also
+starts at `0`, so the factory function (`newDiscussionContext` in libbridge)
+must initialize `last_posted_seq` to `-1` to avoid deduping the first
+event.
+
+**Verify:** `bunx fit-codegen --all` succeeds; existing bridge tests pass.
+
+## Step 2: Add inbox broker to services/bridge
+
+Create a per-`correlation_id` message queue stored alongside discussions and
+origins.
+
+**Modified:** `services/bridge/proto/bridge.proto`, `services/bridge/index.js`
+
+Proto additions:
+
+```proto
+message InboxMessage {
+  string correlation_id = 1;
+  int64 seq = 2;
+  string text = 3;
+  string author = 4;
+  int64 enqueued_at = 5;
+}
+
+message EnqueueInboxRequest { InboxMessage message = 1; }
+message DrainInboxRequest { string correlation_id = 1; int64 since_seq = 2; }
+message InboxMessages { repeated InboxMessage messages = 1; }
+```
+
+RPCs added to the `Bridge` service:
+
+```proto
+rpc EnqueueInbox(EnqueueInboxRequest) returns (common.Empty);
+rpc DrainInbox(DrainInboxRequest) returns (InboxMessages);
+```
+
+Store implementation: add a third `BufferedIndex` (`inbox.jsonl`) to
+`services/bridge/index.js`. `EnqueueInbox` assigns a monotonic `seq` per
+`correlation_id` (in-memory counter map, reset on restart — the seq is
+meaningful only within one session). `DrainInbox` returns messages with
+`seq > since_seq`. `Sweep` evicts inbox entries whose `enqueued_at` exceeds
+the discussion TTL.
+
+**Verify:** `bunx fit-codegen --all` succeeds; unit test: enqueue 3
+messages, drain since seq 1, get 2 back.
+
+## Step 3: Extend callback payload validation
+
+Add `kind`, `seq`, `body`, and `agent` fields to the lenient callback
+payload validator.
+
+**Modified:** `libraries/libbridge/src/callback-payload.js`
+
+```javascript
+kind: typeof raw.kind === "string" ? raw.kind : "terminal",
+seq: typeof raw.seq === "number" ? raw.seq : -1,
+body: typeof raw.body === "string" ? truncate(raw.body) : "",
+agent: typeof raw.agent === "string" ? truncate(raw.agent) : "",
+```
+
+`kind` defaults to `"terminal"` for backward compatibility with the
+existing crash-safety callback step which sends no `kind`. Valid kinds:
+`"reply"`, `"ack"`, `"terminal"`.
+
+**Verify:** Existing callback-payload tests pass; new tests: payload with
+`kind: "reply"` validates; payload without `kind` defaults to `"terminal"`.
+
+## Step 4: Restructure createCallbackHandler for session semantics
+
+Branch on `kind` to implement peek-vs-consume, ack lifecycle, and seq
+dedupe. This is the largest change in the plan.
+
+**Modified:** `libraries/libbridge/src/callback-handler.js`
+
+The current handler calls `resolveContext` (which consumes the token,
+finishes ack, parses JSON, and loads context) then `runHandleReply`.
+Restructure to:
+
+1. Parse JSON and validate payload up front (before token lookup).
+2. Determine `isTerminal` from `payload.kind`.
+3. Token lookup: `callbacks.consume(token)` for terminal,
+   `callbacks.peek(token)` for reply/ack.
+4. Ack: `ack.finish` only on terminal.
+5. Seq dedupe: if `!isTerminal && payload.seq <= ctx.last_posted_seq`,
+   return `200 {ok: true, dedupe: true}`.
+6. Normalize payload for `handleReply`: for reply/ack, set
+   `payload.replies = [{body: payload.body, agent: payload.agent}]` and
+   `payload.verdict = null`.
+7. Call `handleReply(ctx, payload, meta)`.
+8. Post-reply state update: terminal clears `pending_callbacks[token]` and
+   `active_requester`; reply/ack updates `last_posted_seq`.
+9. Save and flush.
+
+```javascript
+return async (c) => {
+  let body;
+  try { body = await c.req.json(); } catch { return c.json({ error: "Invalid JSON" }, 400); }
+  const payload = validateCallbackPayload(body);
+  if (!payload) return c.json({ error: "Invalid payload" }, 400);
+
+  const token = c.req.param("token");
+  const isTerminal = payload.kind === "terminal";
+  const meta = isTerminal ? callbacks.consume(token) : callbacks.peek(token);
+  if (!meta) return c.json({ error: "Unknown callback token" }, 404);
+
+  if (isTerminal) {
+    await ack.finish(token, ackFinishTarget?.(meta));
+  }
+  if (payload.correlation_id !== meta.correlationId) {
+    return c.json({ error: "Correlation ID mismatch" }, 400);
+  }
+
+  const discussionId = loadDiscussionId(meta);
+  const ctx = await store.loadByChannel(channel, discussionId);
+  if (!ctx) return c.json({ error: "Discussion context missing" }, 410);
+
+  if (!isTerminal && payload.seq >= 0 && payload.seq <= ctx.last_posted_seq) {
+    return c.json({ ok: true, dedupe: true }, 200);
+  }
+
+  if (!isTerminal) {
+    payload.replies = payload.body ? [{ body: payload.body, agent: payload.agent }] : [];
+    payload.verdict = null;
+  }
+
+  return runHandleReply(c, {
+    ctx, meta, payload, handleReply, store, logger, tracer, spanName,
+    postReply() {
+      if (isTerminal) {
+        delete ctx.pending_callbacks[token];
+        ctx.active_requester = null;
+      } else {
+        ctx.last_posted_seq = payload.seq;
+      }
+    },
+  });
+};
+```
+
+`runHandleReply` is retained unchanged — it owns span lifecycle, error
+handling, `ctx.last_active_at`, store save/flush, and the
+`CallbackHandlerError` catch. Its only addition is calling the `postReply`
+hook (when provided) after `handleReply` succeeds but before the store
+flush, so session state updates are atomic with the reply delivery.
+
+The `handleReply` callbacks in ghbridge and msbridge post replies and
+append history *before* the verdict switch. A `null` verdict (streaming
+events) must skip only the verdict routing, not the reply posting. Place
+the guard **inside** the `switch` block as a `default` early return, not
+before `postDiscussionReplies`:
+
+**Modified:** `services/ghbridge/index.js` `#handleReply`,
+`services/msbridge/index.js` `#handleReply`
+
+```javascript
+// After postDiscussionReplies + appendHistory (unchanged)...
+switch (payload.verdict) {
+  case "recessed": /* ... existing ... */ break;
+  case "adjourned": /* ... existing ... */ break;
+  case "failed": /* ... existing ... */ break;
+  default:
+    if (!payload.verdict) return; // streaming event — replies already posted
+    /* ... existing default (posts summary if no replies) ... */
+}
+```
+
+**Verify:** (1) `kind=reply` uses peek, does not consume token, posts one
+reply, appends history, updates `last_posted_seq`. (2) `kind=terminal`
+consumes token, finishes ack, clears `pending_callbacks` and
+`active_requester`, routes verdict. (3) Duplicate seq returns dedupe
+response. (4) Legacy payload (no kind) treated as terminal.
+
+## Step 5: Extend Dispatcher — set active_requester, pass inbox_url
+
+Set `active_requester` on the discussion context and construct an inbox URL
+alongside the callback URL.
+
+**Modified:** `libraries/libbridge/src/dispatcher.js`,
+`libraries/libbridge/src/dispatch.js`
+
+In `Dispatcher.dispatch()`, after
+`ctx.pending_callbacks[token] = correlationId`:
+
+```javascript
+ctx.active_requester = requester;
+const inboxUrl = `${this.#callbackBaseUrl}/api/inbox/${correlationId}`;
+```
+
+Pass `inboxUrl` to `dispatchWorkflow()`.
+
+In `dispatchWorkflow()` (`dispatch.js`), add `inboxUrl` parameter and
+include in workflow inputs:
+
+```diff
+ inputs: {
+   prompt,
+   callback_url: callbackUrl,
+   correlation_id: correlationId,
++  inbox_url: inboxUrl,
+   ...(discussionId && { discussion_id: discussionId }),
+   ...(resumeContext && { resume_context: resumeContext }),
+ }
+```
+
+In the dispatch failure catch block (which already deletes
+`ctx.pending_callbacks[token]`), also clear:
+
+```javascript
+ctx.active_requester = null;
+```
+
+**Verify:** After dispatch, `ctx.active_requester` equals `requester`;
+workflow inputs include `inbox_url`; on failure rollback,
+`active_requester` is null.
+
+## Step 6: Add inbox long-poll route to createBridgeServer
+
+Mount `GET /api/inbox/:correlationId` as a long-poll endpoint.
+
+**Modified:** `libraries/libbridge/src/server.js`,
+`libraries/libbridge/src/index.js`
+
+Add optional `onInbox` handler parameter to `createBridgeServer`:
+
+```javascript
+if (onInbox) {
+  app.get("/api/inbox/:correlationId", async (c) => {
+    try { return await onInbox(c); }
+    catch (err) { logger.error("bridge.inbox", err); return c.json({ error: "Inbox failure" }, 500); }
+  });
+}
+```
+
+**Created:** `libraries/libbridge/src/inbox-handler.js`
+
+```javascript
+export function createInboxHandler({ client, logger, pollTimeoutMs = 30_000, pollIntervalMs = 1_000 }) {
+  return async (c) => {
+    const correlationId = c.req.param("correlationId");
+    const sinceSeq = parseInt(c.req.query("since") ?? "0", 10);
+    const deadline = Date.now() + pollTimeoutMs;
+
+    while (Date.now() < deadline) {
+      const result = await client.DrainInbox({ correlation_id: correlationId, since_seq: sinceSeq });
+      if (result.messages?.length > 0) return c.json({ messages: result.messages });
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+    }
+    return c.json({ messages: [] });
+  };
+}
+```
+
+Export from `libraries/libbridge/src/index.js`.
+
+**Verify:** Enqueue a message, long-poll returns it within 2s; long-poll
+with no messages returns empty after timeout.
+
+## Step 7: Add dispatch-vs-inject logic to ghbridge and msbridge intake
+
+When a message arrives on a discussion with an active run, inject into the
+inbox or post a static notice instead of dispatching.
+
+**Modified:** `services/ghbridge/index.js`, `services/msbridge/index.js`
+
+In `#handleDiscussionComment` (ghbridge) / `#handleNewMessage` (msbridge),
+the existing flow is: load context → append history → `processInbound(ctx)`
+→ check `freshDispatchAllowed` → dispatch. The inject guard goes **after**
+`processInbound` returns `{ freshDispatchAllowed: true }` (so recess
+accounting is honoured) and **before** `dispatcher.dispatch()`. History is
+already appended by the existing intake code above the guard, so the inject
+path must not append it again:
+
+```javascript
+// After processInbound + freshDispatchAllowed check, before dispatch:
+if (Object.keys(ctx.pending_callbacks).length > 0 && ctx.active_requester) {
+  if (String(requester) === String(ctx.active_requester)) {
+    const correlationId = Object.values(ctx.pending_callbacks)[0];
+    await this.#client.EnqueueInbox(bridge.EnqueueInboxRequest.fromObject({
+      message: { correlation_id: correlationId, text, author: String(requester), enqueued_at: Date.now() },
+    }));
+    // History already appended by intake above — do not duplicate
+    ctx.last_active_at = Date.now();
+    await this.#store.add(ctx);
+    await this.#store.flush();
+    return c.json({ ok: true, injected: true });
+  }
+  await postStaticNotice(ctx, /* channel-specific posting */);
+  return c.json({ ok: true, noticed: true });
+}
+```
+
+For `#handleDiscussionCreated` (new discussion, first message), the inject
+guard is unreachable — `pending_callbacks` is empty on a fresh context.
+
+Add a `postStaticNotice` helper to each bridge that posts a brief comment:
+"A session is in progress on this thread. Your message was not forwarded to
+the active run."
+
+Wire `createInboxHandler` in both bridges' `createBridgeServer` call:
+
+```javascript
+this.#bridge = createBridgeServer({
+  ...existing,
+  onInbox: createInboxHandler({ client: this.#client, logger }),
+});
+```
+
+**Verify:** Two messages to the same discussion — first dispatches, second
+(while run is active, from same requester) returns `injected: true` and
+enqueues. Non-requester message returns `noticed: true` and posts the static
+notice.
+
+## Step 8: Handle terminal reconciliation
+
+When a terminal event arrives, check for unconsumed inbox messages past the
+run's high-water mark and re-dispatch if any remain.
+
+**Modified:** `libraries/libbridge/src/callback-payload.js`,
+`services/ghbridge/index.js` `#handleReply`,
+`services/msbridge/index.js` `#handleReply`
+
+Add `last_acted_seq` to the callback payload validator (same lenient
+pattern as `seq`):
+
+```javascript
+last_acted_seq: typeof raw.last_acted_seq === "number" ? raw.last_acted_seq : -1,
+```
+
+The run's `InboxPoller` tracks which messages the lead acted on (see Part
+2, Step 5) and reports `last_acted_seq` in the terminal payload. The bridge
+drains only messages past that mark — messages the run already processed
+are not re-dispatched:
+
+```javascript
+// In handleReply, after verdict routing completes on the terminal branch:
+const lastActed = payload.last_acted_seq ?? -1;
+const remaining = await this.#client.DrainInbox({
+  correlation_id: meta.correlationId, since_seq: lastActed,
+});
+if (remaining.messages?.length > 0) {
+  // Coalesce all unconsumed messages into one prompt
+  const coalesced = remaining.messages.map((m) => m.text).join("\n\n");
+  await this.#dispatcher.dispatch({
+    ctx, prompt: buildPrompt(coalesced, ctx.history),
+    requester: remaining.messages[0].author, ackTarget, callbackMeta,
+  });
+}
+```
+
+This catches both sub-cases from the design: a message enqueued after the
+lead Adjourned (never fetched) and a message fetched but not acted on
+before Adjourn. Multiple unconsumed messages are coalesced into a single
+re-dispatch prompt.
+
+**Verify:** Inject a message, then send terminal (adjourned) before the run
+fetches it; observe re-dispatch fires with the injected message. Inject two
+messages, observe both are coalesced in the re-dispatch prompt.

--- a/specs/1390-realtime-bridge-conversations/plan-a-02.md
+++ b/specs/1390-realtime-bridge-conversations/plan-a-02.md
@@ -1,0 +1,346 @@
+# Plan 1390-a Part 2 — Run-side streaming and injection
+
+[overview](plan-a.md) · [part 1](plan-a-01.md)
+
+## Step 1: Add streaming environment to discuss command
+
+Read `CALLBACK_URL`, `INBOX_URL`, and `CORRELATION_ID` from environment and
+thread them to `createDiscusser`.
+
+**Modified:** `libraries/libeval/src/commands/discuss.js`,
+`libraries/libeval/src/discusser.js`
+
+In `parseDiscussOptions`, add:
+
+```javascript
+callbackUrl: process.env.CALLBACK_URL ?? null,
+inboxUrl: process.env.INBOX_URL ?? null,
+correlationId: process.env.CORRELATION_ID ?? null,
+```
+
+In `runDiscussCommand`, pass them to `createDiscusser`. In
+`createDiscusser`, accept `callbackUrl`, `inboxUrl`, `correlationId` and
+thread to the `Discusser` constructor and the `OrchestrationLoop`.
+
+**Verify:** Set env vars, call `parseDiscussOptions`; values propagate
+through to the Discusser instance.
+
+## Step 2: Add reply emitter
+
+POST `{kind, seq, body, agent, correlation_id}` to the callback URL each
+time an answer is routed to the lead.
+
+**Created:** `libraries/libeval/src/reply-emitter.js`
+
+```javascript
+export class ReplyEmitter {
+  #callbackUrl;
+  #correlationId;
+  #counter;
+
+  constructor({ callbackUrl, correlationId, counter }) {
+    this.#callbackUrl = callbackUrl;
+    this.#correlationId = correlationId;
+    this.#counter = counter;
+  }
+
+  emit({ kind, body, agent }) {
+    const seq = this.#counter.next();
+    if (this.#callbackUrl) {
+      // Fire-and-forget — do not block the message bus
+      fetch(this.#callbackUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          correlation_id: this.#correlationId,
+          kind, seq, body, agent,
+        }),
+      }).catch(() => {});
+    }
+    return seq;
+  }
+}
+```
+
+`emit` is synchronous — it assigns `seq` from the counter and returns it
+immediately. The HTTP POST is fire-and-forget so the message bus is never
+blocked on network I/O. Delivery failures are absorbed; the bridge's
+seq-based dedupe handles retries at the terminal summary level (the crash
+safety callback carries all replies).
+
+**Modified:** `libraries/libeval/src/discusser.js`
+
+In `createDiscusser`, create the emitter and **replace** the existing
+answer interception block (the `messageBus.answer` monkey-patch that today
+pushes to `ctx.replies`) with a version that also emits:
+
+```javascript
+const emitter = new ReplyEmitter({ callbackUrl, correlationId, counter });
+ctx.emitter = emitter;
+
+const originalAnswer = messageBus.answer.bind(messageBus);
+messageBus.answer = (from, to, text, askId) => {
+  if (to === "lead" && from !== "@orchestrator") {
+    const seq = emitter.emit({ kind: "reply", body: text, agent: from });
+    ctx.replies.push({
+      body: text, agent: from, kind: "reply", seq,
+      ...(ctx.discussionId && { thread_id: ctx.discussionId }),
+    });
+  }
+  originalAnswer(from, to, text, askId);
+};
+```
+
+`ctx.emitter` is set so the Acknowledge tool (Step 3) can reach it.
+
+The `ctx.replies` shape is extended from `{body, agent, thread_id?}` to
+`{body, agent, kind, seq, thread_id?}`. The terminal summary emission
+(`Discusser.#emitDiscussSummary`) already serializes `ctx.replies` into the
+trace — the extra fields are additive and pass through harmlessly to the
+bridge's `handleReply`, which iterates `replies[].body`.
+
+**Verify:** Create discusser with `callbackUrl`; answer routed to lead →
+fetch called with `kind: "reply"`, `seq` is a number. Without
+`callbackUrl` → seq returned, no fetch.
+
+## Step 3: Add Acknowledge tool
+
+Add an agent-surface tool that emits an ack event without discharging the
+pending Ask.
+
+**Modified:** `libraries/libeval/src/discuss-tools.js`
+
+Add `Acknowledge` to `createDiscussAgentToolServer` (alongside
+`RequestForComment`):
+
+```javascript
+const AcknowledgeSchema = z.object({
+  message: z.string().describe("Brief acknowledgement to post on the thread"),
+  askId: z.number().optional().describe("The ask being acknowledged"),
+});
+
+server.addTool("Acknowledge", AcknowledgeSchema, async ({ message }) => {
+  const seq = ctx.emitter?.emit({ kind: "ack", body: message, agent: from }) ?? -1;
+  ctx.replies.push({
+    body: message, agent: from, kind: "ack", seq,
+    ...(ctx.discussionId && { thread_id: ctx.discussionId }),
+  });
+  return { success: true };
+});
+```
+
+The tool pushes to `ctx.replies` (for the terminal trace summary) and emits
+via `ReplyEmitter` (for the streaming bridge post), but does **not** call
+`messageBus.answer` — the Ask remains pending and the agent still owes an
+Answer.
+
+**Verify:** Agent calls Acknowledge → ack emitted, pushed to
+`ctx.replies`; the original Ask remains in `ctx.pendingAsks`.
+
+## Step 4: Add inbound poller
+
+A concurrent task that long-polls the inbox URL and lands injected messages
+on the lead's bus queue via `messageBus.synthetic`.
+
+**Created:** `libraries/libeval/src/inbox-poller.js`
+
+```javascript
+export class InboxPoller {
+  #inboxUrl;
+  #messageBus;
+  #leadName;
+  #signal;
+  #lastSeq = 0;
+  lastActedSeq = -1;
+
+  constructor({ inboxUrl, messageBus, leadName, signal }) {
+    this.#inboxUrl = inboxUrl;
+    this.#messageBus = messageBus;
+    this.#leadName = leadName;
+    this.#signal = signal;
+  }
+
+  async run() {
+    if (!this.#inboxUrl) return;
+    while (!this.#signal.aborted) {
+      try {
+        const res = await fetch(
+          `${this.#inboxUrl}?since=${this.#lastSeq}`,
+          { signal: this.#signal },
+        );
+        if (!res.ok) { await delay(5_000, this.#signal); continue; }
+        const { messages } = await res.json();
+        for (const msg of messages) {
+          this.#messageBus.synthetic(this.#leadName, msg.text);
+          this.#lastSeq = Math.max(this.#lastSeq, msg.seq);
+        }
+      } catch (err) {
+        if (err.name === "AbortError") return;
+        await delay(5_000, this.#signal);
+      }
+    }
+  }
+}
+
+function delay(ms, signal) {
+  return new Promise((resolve) => {
+    const id = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => { clearTimeout(id); resolve(); }, { once: true });
+  });
+}
+```
+
+**Modified:** `libraries/libeval/src/orchestration-loop.js`
+
+Accept an optional `inboxPoller` in the constructor. In `run()`, start it
+alongside agent loops and shut it down on stop:
+
+```javascript
+const pollerPromise = this.inboxPoller?.run().catch(() => {});
+
+// ... existing lead + agent loop code ...
+
+this.#stop();  // AbortController signals the poller
+await Promise.allSettled([...agentPromises, pollerPromise].filter(Boolean));
+```
+
+The poller receives the `OrchestrationLoop`'s `AbortController.signal`, so
+it shuts down when the session concludes. The lead's `#drainOrWait` wakes
+naturally on the synthetic message — no change to the drain loop.
+
+The poller exposes `lastActedSeq` (public) — set by the Discusser after
+the lead produces output following an injected message. The terminal
+summary includes `last_acted_seq` so the bridge's reconciliation (Part 1,
+Step 8) drains only unacted-on messages. The Discusser updates
+`inboxPoller.lastActedSeq = inboxPoller.#lastSeq` after each lead turn
+that follows a synthetic message.
+
+**Modified:** `libraries/libeval/src/discusser.js`
+
+In `createDiscusser`, create the poller and pass it to the
+`OrchestrationLoop`:
+
+```javascript
+const abortController = new AbortController();
+const inboxPoller = inboxUrl
+  ? new InboxPoller({ inboxUrl, messageBus, leadName: "lead", signal: abortController.signal })
+  : null;
+
+const loop = new OrchestrationLoop({
+  ...existing,
+  inboxPoller,
+  abortController,
+});
+```
+
+**Verify:** Start poller with mock inbox URL serving one message → message
+lands on lead's queue. Abort signal stops poller cleanly.
+
+## Step 5: Raise default conversation budget
+
+Increase `DEFAULT_MAX_LEAD_TURNS` so injected continuations are not cut off.
+
+**Modified:** `libraries/libeval/src/orchestration-loop.js`
+
+```diff
+-const DEFAULT_MAX_LEAD_TURNS = 40;
++const DEFAULT_MAX_LEAD_TURNS = 200;
+```
+
+The `maxLeadTurns` parameter remains overridable via the constructor. The
+kata-dispatch.yml workflow passes `max-turns: "1500"` (per-SDK-call budget),
+which is separate from `maxLeadTurns` (session-level lead-resume cap). The
+raise applies to sessions where no override is provided.
+
+Also expose `maxLeadTurns` as a CLI option on the discuss command so the
+workflow can override it if needed:
+
+**Modified:** `libraries/libeval/src/commands/discuss.js`
+
+```javascript
+const maxLeadTurnsRaw = values["max-lead-turns"] ?? "200";
+const maxLeadTurns = parseInt(maxLeadTurnsRaw, 10);
+```
+
+Thread through `createDiscusser` → `OrchestrationLoop`.
+
+**Verify:** A discuss session with 50+ injected messages does not hit the
+turn cap. Existing tests that reference `DEFAULT_MAX_LEAD_TURNS` updated.
+
+## Step 6: Wire streaming inputs through kata-dispatch.yml
+
+Pass streaming URLs as environment variables to the "Assess and Act" step
+so the discuss command can read them.
+
+**Modified:** `.github/workflows/kata-dispatch.yml`
+
+Add `inbox_url` workflow_dispatch input:
+
+```yaml
+inbox_url:
+  description: "Long-poll URL for injecting messages into a live run (optional)"
+  required: false
+  type: string
+```
+
+Add env vars to the "Assess and Act" step (alongside the existing
+`ANTHROPIC_API_KEY` and `GH_TOKEN`):
+
+```diff
+ - name: Assess and Act
+   uses: forwardimpact/fit-eval@v1
+   env:
+     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+     GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+     CLAUDE_CODE_USE_BEDROCK: "0"
++    CALLBACK_URL: ${{ inputs.callback_url }}
++    CORRELATION_ID: ${{ inputs.correlation_id }}
++    INBOX_URL: ${{ inputs.inbox_url }}
+```
+
+The env vars are inherited by the composite action's inner steps. The
+`fit-eval discuss` command reads them from `process.env` (Step 1 of this
+part).
+
+**Verify:** Workflow syntax validates. Env vars visible to the composite
+action's inner shell steps.
+
+## Step 7: Emit `kind: "terminal"` from crash safety callback
+
+Tag the existing callback command's output with `kind: "terminal"` so the
+session-aware bridge handler routes it correctly.
+
+**Modified:** `libraries/libeval/src/commands/callback.js`
+
+In the `readTraceSummary` payload construction:
+
+```diff
+ const payload = {
+   correlation_id: correlationId,
++  kind: "terminal",
+   verdict: found.verdict,
+   summary: found.summary,
++  last_acted_seq: found.lastActedSeq ?? -1,
+   ...
+ };
+```
+
+The `lastActedSeq` is read from the trace summary event (emitted by the
+Discusser from `inboxPoller.lastActedSeq`) so the bridge's terminal
+reconciliation (Part 1, Step 8) can drain only unacted-on inbox messages.
+
+**Modified:** `.github/workflows/kata-dispatch.yml`
+
+The curl fallback (no trace file) also needs `kind`:
+
+```diff
+-  '{correlation_id: $cid, verdict: "failed", ...'
++  '{correlation_id: $cid, kind: "terminal", verdict: "failed", ...'
+```
+
+Backward compatibility: the bridge handler defaults `kind` to `"terminal"`
+when absent (Part 1, Step 3), so this change is safe to deploy before or
+after the bridge update.
+
+**Verify:** Callback command output includes `kind: "terminal"`. Curl
+fallback includes `kind: "terminal"`.

--- a/specs/1390-realtime-bridge-conversations/plan-a.md
+++ b/specs/1390-realtime-bridge-conversations/plan-a.md
@@ -1,0 +1,75 @@
+# Plan 1390-a — Realtime Bridge Conversations
+
+[spec](spec.md) · [design](design-a.md)
+
+## Approach
+
+The bridge becomes a session broker keyed by `correlation_id`. Session
+lifetime is bounded by one active run: dispatch opens the session (callback
+token persists across deliveries, EYES reaction spans the whole run),
+`reply` and `ack` events stream out through the existing callback endpoint
+discriminated by a new `kind` field, injected messages queue into a
+per-correlation inbox served by a new long-poll GET route, and a `terminal`
+event closes everything. On the run side, the Discusser gains a
+`ReplyEmitter` that POSTs events as they happen and a concurrent
+`InboxPoller` task that long-polls the inbox and lands messages on the
+lead's bus queue via `messageBus.synthetic`; a new `Acknowledge` tool
+completes the agent surface. The existing post-hoc callback workflow step is
+retained unchanged as the crash safety net — `kind` defaults to `"terminal"`
+when absent, so the bridge handles it identically to today's payload. The
+default `maxLeadTurns` is raised from 40 to 200 — five one-shot sessions
+worth of headroom — so injected continuations are not cut off mid-flight;
+sessions without injection are unaffected in practice because they conclude
+well within 40 turns and the cap is a safety bound, not a target.
+
+**Coordination with spec 1380.** Both specs modify the Dispatcher and the
+bridge proto but touch non-overlapping concerns. Spec 1380 removes the
+success-only `historyText` append from `Dispatcher`, adds
+`PendingDispatchStore` and `HistoryEntry.author`, and adds a
+`/api/link-complete` endpoint. This plan adds `inboxUrl` to the Dispatcher,
+`active_requester` and `last_posted_seq` to the Discussion proto, inbox
+broker RPCs, and a `/api/inbox/:correlationId` endpoint. If 1380 lands
+first the `historyText` parameter is already gone — this plan does not
+depend on or modify it. The two specs' `createBridgeServer` routes
+(`/api/link-complete` vs `/api/inbox/:correlationId`) are distinct paths.
+
+**Neither the spec nor the design requires changes given 1380.** The 1390
+dispatch-vs-inject state machine operates on `active_requester` +
+`pending_callbacks`, set only after `Dispatcher.dispatch` returns `kind:
+"dispatched"`. The 1380 linking flow returns `kind: "link_required"` — no
+run starts, no session opens, so the 1390 state machine is never entered.
+The two flows compose: linking completes → resumed dispatch → session opens
+→ injection becomes possible.
+
+Libraries used: none.
+
+## Parts
+
+| Part | Scope | Dependencies |
+| --- | --- | --- |
+| [plan-a-01](plan-a-01.md) | Bridge-side streaming contract (libbridge, services/bridge, ghbridge, msbridge) | None |
+| [plan-a-02](plan-a-02.md) | Run-side streaming and injection (libeval, kata-dispatch.yml) | Part 1 endpoints must exist |
+
+## Risks
+
+- **Inbox long-poll under bridge restart.** If the bridge restarts while a
+  run is active, the in-memory `CallbackRegistry` is lost but the persisted
+  `pending_callbacks` and `active_requester` remain. The poller's next
+  long-poll gets no results (registry entry gone, inbox store survives in
+  the bridge gRPC service). The run continues without injection; the crash
+  safety net closes the session when the run ends. This is the same
+  limitation as today's single-shot callbacks — a bridge restart during an
+  active run already loses the callback registration.
+- **Sibling action unchanged.** The `forwardimpact/fit-eval@v1` composite
+  action does not need modification; `CALLBACK_URL`, `CORRELATION_ID`
+  (existing workflow inputs) and `INBOX_URL` (new) are set as environment
+  variables at the calling workflow step level and inherited by the
+  composite action's inner steps. The `fit-eval discuss` command reads them
+  from `process.env`.
+
+## Execution
+
+Both parts are sequential — Part 2 depends on Part 1's new endpoints. Route
+both to `staff-engineer`. Part 1 is the larger effort (callback handler
+restructuring, new proto/RPCs, intake state machine); Part 2 is additive
+wiring on the run side.


### PR DESCRIPTION
## Summary

- Two-part plan for spec 1390 (Realtime Bridge Conversations) turning the bridge↔run contract from a single terminal callback into a streaming session
- Part 1: Bridge-side streaming contract — session-aware callback handler (peek vs consume), inbox broker (new proto/RPCs), dispatch-vs-inject state machine, inbox long-poll endpoint
- Part 2: Run-side streaming and injection — reply emitter (fire-and-forget POST), inbox poller (concurrent long-poll task), Acknowledge tool (agent surface), conversation budget raise (40→200)
- Coordinates with spec 1380 (under way) — orthogonal changes to Dispatcher and bridge proto, no spec/design changes needed

## Test plan

- [ ] Verify `bunx fit-codegen --all` succeeds with new proto messages
- [ ] Callback handler: `kind=reply` uses peek (not consume), `kind=terminal` consumes and finishes ack
- [ ] Seq dedupe: duplicate seq returns 200 without double-posting
- [ ] Dispatch-vs-inject: second message from requester during active run enqueues to inbox
- [ ] Non-requester message during active run posts static notice
- [ ] ReplyEmitter fire-and-forget does not block message bus
- [ ] InboxPoller lands synthetic messages on lead's queue
- [ ] Acknowledge tool does not discharge pending Ask
- [ ] Terminal reconciliation re-dispatches unconsumed inbox messages past high-water mark
- [ ] Crash safety callback includes `kind: "terminal"` and `last_acted_seq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)