### PR TITLE
feat(ghauth,libbridge,ghbridge,msbridge): link binding integrity and auth-completion resume (#1380)

### DIFF
--- a/libraries/libbridge/CLAUDE.md
+++ b/libraries/libbridge/CLAUDE.md
@@ -53,7 +53,7 @@ Inside channel intake, the only dispatch call is:
 ```js
 await dispatcher.dispatch({
   ctx, prompt: buildPrompt(text, ctx.history),
-  requester, ackTarget, historyText: text, callbackMeta: { threadId },
+  requester, ackTarget, callbackMeta: { threadId },
 });
 ```
 
@@ -107,3 +107,5 @@ its `loadDiscussionId` lens.
 | `ResumeScheduler`, `ElapsedScheduler` | suspend/resume lifecycle + chunked-setTimeout |
 | `createBridgeServer` | Hono + `@hono/node-server` wiring |
 | `newDiscussionContext`, `evaluateTrigger`, `parseIsoDuration` | record factory + trigger helpers |
+| `prepareLinkResume` | mints link token, augments authorize URL for resume |
+| `createLinkCompleteHandler` | factory for the `/api/link-complete` GET handler |

--- a/libraries/libbridge/src/dispatcher.js
+++ b/libraries/libbridge/src/dispatcher.js
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 
 import { dispatchWorkflow } from "./dispatch.js";
-import { appendHistory } from "./history.js";
 
 /** Dispatch dance: resolve per-user token, register callback, ack, fire workflow, flush. */
 export class Dispatcher {
@@ -57,7 +56,6 @@ export class Dispatcher {
    * @param {string} args.requester - Surface user id of the triggering human
    * @param {object} args.callbackMeta - Stored on the callback token
    * @param {unknown} [args.ackTarget] - If omitted, no acknowledgement is started
-   * @param {string} [args.historyText] - Appended to ctx.history as the user turn on success
    * @param {object} [args.workflowInputs] - Extra fields for `dispatchWorkflow`
    * @returns {Promise<{kind: "dispatched", token: string, correlationId: string} | {kind: "link_required", authorizeUrl: string} | {kind: "reauth_required"} | {kind: "transient", error: Error}>}
    */
@@ -67,7 +65,6 @@ export class Dispatcher {
     requester,
     callbackMeta,
     ackTarget,
-    historyText,
     workflowInputs,
   }) {
     if (!ctx) throw new Error("ctx is required");
@@ -94,9 +91,6 @@ export class Dispatcher {
         correlationId,
         ...(workflowInputs ?? {}),
       });
-      if (historyText !== undefined) {
-        appendHistory(ctx.history, { role: "user", text: historyText });
-      }
       ctx.dispatches.push(Date.now());
       ctx.last_active_at = Date.now();
       await this.#store.add(ctx);

--- a/libraries/libbridge/src/history.js
+++ b/libraries/libbridge/src/history.js
@@ -9,6 +9,8 @@
  * @param {number} [options.maxEntries] - Default 10
  */
 export function appendHistory(history, entry, { maxEntries = 10 } = {}) {
-  history.push(entry);
+  const record = { role: entry.role, text: entry.text };
+  if (entry.author !== undefined) record.author = entry.author;
+  history.push(record);
   while (history.length > maxEntries) history.shift();
 }

--- a/libraries/libbridge/src/index.js
+++ b/libraries/libbridge/src/index.js
@@ -18,6 +18,8 @@
  * @property {(ctx: object) => Promise<void>} add
  * @property {() => Promise<void>} flush
  * @property {() => Promise<void>} shutdown
+ * @property {(target: object) => Promise<void>} [putPendingDispatch]
+ * @property {(linkToken: string) => Promise<object|null>} [resolvePendingDispatch]
  */
 
 export { createBridgeServer } from "./server.js";
@@ -47,3 +49,4 @@ export {
   validateCallbackPayload,
 } from "./callback-payload.js";
 export { evaluateTrigger, parseIsoDuration } from "./triggers.js";
+export { prepareLinkResume, createLinkCompleteHandler } from "./link-resume.js";

--- a/libraries/libbridge/src/link-resume.js
+++ b/libraries/libbridge/src/link-resume.js
@@ -1,0 +1,92 @@
+import { randomUUID } from "node:crypto";
+import { normalizeBaseUrl } from "./callback-payload.js";
+import { buildPrompt } from "./prompt.js";
+
+/**
+ * @param {string} authorizeUrl
+ * @param {string} callbackBaseUrl
+ * @returns {{ linkToken: string, augmentedUrl: string }}
+ */
+export function prepareLinkResume(authorizeUrl, callbackBaseUrl) {
+  const linkToken = randomUUID();
+  const url = new URL(authorizeUrl);
+  url.searchParams.set(
+    "redirect_uri",
+    `${normalizeBaseUrl(callbackBaseUrl)}/api/link-complete`,
+  );
+  url.searchParams.set("client_state", linkToken);
+  return { linkToken, augmentedUrl: url.toString() };
+}
+
+/**
+ * @param {object} options
+ * @returns {(c: import("hono").Context) => Promise<Response>}
+ */
+export function createLinkCompleteHandler({
+  channel,
+  store,
+  dispatcher,
+  buildCallbackMeta,
+}) {
+  return async (c) => {
+    const linkToken = c.req.query("state");
+    if (!linkToken) {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Error</h1>" +
+          "<p>Missing state parameter.</p></body></html>",
+        400,
+      );
+    }
+
+    const target = await store.resolvePendingDispatch(linkToken);
+    if (!target) {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Already processed</h1>" +
+          "<p>This link has already been used or has expired." +
+          "</p></body></html>",
+      );
+    }
+
+    const ctx = await store.loadByChannel(channel, target.discussion_id);
+    if (!ctx) {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Error</h1>" +
+          "<p>Discussion not found.</p></body></html>",
+        404,
+      );
+    }
+
+    const userTurn = [...ctx.history]
+      .reverse()
+      .find((e) => e.role === "user" && e.author === target.surface_user_id);
+    if (!userTurn) {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Error</h1>" +
+          "<p>No message found to re-dispatch.</p></body></html>",
+        404,
+      );
+    }
+
+    const result = await dispatcher.dispatch({
+      ctx,
+      prompt: buildPrompt(userTurn.text, ctx.history),
+      requester: target.surface_user_id,
+      callbackMeta: buildCallbackMeta(ctx),
+      workflowInputs: { discussionId: target.discussion_id },
+    });
+
+    if (result.kind === "dispatched") {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Processing</h1>" +
+          "<p>Your message is being processed. " +
+          "You can close this window.</p></body></html>",
+      );
+    }
+
+    return c.html(
+      "<!DOCTYPE html><html><body><h1>Unable to dispatch</h1>" +
+        "<p>Your account could not be verified. Please try " +
+        "linking again from the conversation.</p></body></html>",
+    );
+  };
+}

--- a/libraries/libbridge/src/server.js
+++ b/libraries/libbridge/src/server.js
@@ -23,6 +23,7 @@ import { serve } from "@hono/node-server";
  * @param {string} options.webhookPath - e.g. `/api/messages` or `/api/webhooks/github`
  * @param {(c: import("hono").Context) => Promise<Response> | Response} options.onWebhook
  * @param {(c: import("hono").Context) => Promise<Response> | Response} options.onCallback
+ * @param {((c: import("hono").Context) => Promise<Response> | Response)} [options.onLinkComplete]
  * @returns {{ start: () => Promise<void>, stop: () => Promise<void>, app: import("hono").Hono, address: () => ({port: number} | null) }}
  */
 export function createBridgeServer({
@@ -32,6 +33,7 @@ export function createBridgeServer({
   webhookPath,
   onWebhook,
   onCallback,
+  onLinkComplete,
 }) {
   if (!config) throw new Error("config is required");
   if (!logger) throw new Error("logger is required");
@@ -85,6 +87,17 @@ export function createBridgeServer({
       return c.json({ error: "Callback failure" }, 500);
     }
   });
+
+  if (onLinkComplete) {
+    app.get("/api/link-complete", async (c) => {
+      try {
+        return await onLinkComplete(c);
+      } catch (err) {
+        logger.error("bridge.link-complete", err);
+        return c.json({ error: "Link completion failure" }, 500);
+      }
+    });
+  }
 
   let server = null;
 

--- a/libraries/libbridge/test/dispatcher.test.js
+++ b/libraries/libbridge/test/dispatcher.test.js
@@ -139,7 +139,6 @@ describe("Dispatcher", () => {
       prompt: "hello",
       requester: "U_1",
       ackTarget: { subjectId: "S_1" },
-      historyText: "hello",
       callbackMeta: { discussionId: "T_1" },
       workflowInputs: { discussionId: "T_1" },
     });
@@ -147,7 +146,7 @@ describe("Dispatcher", () => {
     expect(typeof result.token).toBe("string");
     expect(typeof result.correlationId).toBe("string");
     expect(ctx.pending_callbacks[result.token]).toBe(result.correlationId);
-    expect(ctx.history).toEqual([{ role: "user", text: "hello" }]);
+    expect(ctx.history).toEqual([]);
     expect(ctx.dispatches).toHaveLength(1);
     expect(reactions.adds).toEqual([{ subjectId: "S_1" }]);
     expect(fetchStub.calls).toHaveLength(1);
@@ -171,18 +170,6 @@ describe("Dispatcher", () => {
       workflowInputs: { discussionId: "T_1", resumeContext: "{}" },
     });
     expect(reactions.adds).toHaveLength(0);
-  });
-
-  test("historyText omitted: no history is appended", async () => {
-    const ctx = makeCtx();
-    await dispatcher.dispatch({
-      ctx,
-      prompt: "p",
-      requester: "U_1",
-      callbackMeta: {},
-      ackTarget: { subjectId: "S" },
-    });
-    expect(ctx.history).toEqual([]);
   });
 
   test("workflowInputs flow through to the dispatch payload", async () => {

--- a/libraries/libbridge/test/link-resume.test.js
+++ b/libraries/libbridge/test/link-resume.test.js
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+
+import {
+  prepareLinkResume,
+  createLinkCompleteHandler,
+} from "../src/link-resume.js";
+
+describe("prepareLinkResume", () => {
+  test("augments URL with redirect_uri and client_state, returns unique token", () => {
+    const { linkToken, augmentedUrl } = prepareLinkResume(
+      "https://oauth.example/authorize?surface=github-discussions&surface_user_id=42",
+      "https://bridge.example/",
+    );
+    const url = new URL(augmentedUrl);
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://bridge.example/api/link-complete",
+    );
+    expect(url.searchParams.get("client_state")).toBe(linkToken);
+    expect(typeof linkToken).toBe("string");
+    expect(linkToken.length).toBeGreaterThan(0);
+  });
+
+  test("produces unique tokens on successive calls", () => {
+    const a = prepareLinkResume("https://x/a", "https://b");
+    const b = prepareLinkResume("https://x/a", "https://b");
+    expect(a.linkToken).not.toBe(b.linkToken);
+  });
+
+  test("strips trailing slash from callbackBaseUrl", () => {
+    const { augmentedUrl } = prepareLinkResume(
+      "https://x/authorize",
+      "https://bridge.example///",
+    );
+    const url = new URL(augmentedUrl);
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://bridge.example/api/link-complete",
+    );
+  });
+});
+
+describe("createLinkCompleteHandler", () => {
+  function makeApp(handler) {
+    const app = new Hono();
+    app.get("/api/link-complete", handler);
+    return app;
+  }
+
+  function makeStore({ pending = null, ctx = null } = {}) {
+    return {
+      resolvePendingDispatch: async () => pending,
+      loadByChannel: async () => ctx,
+    };
+  }
+
+  test("missing state returns 400", async () => {
+    const handler = createLinkCompleteHandler({
+      channel: "github-discussions",
+      store: makeStore(),
+      dispatcher: { dispatch: async () => ({}) },
+      buildCallbackMeta: () => ({}),
+    });
+    const app = makeApp(handler);
+    const res = await app.request("/api/link-complete");
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("Missing state");
+  });
+
+  test("consumed token returns 'Already processed'", async () => {
+    const handler = createLinkCompleteHandler({
+      channel: "github-discussions",
+      store: makeStore({ pending: null }),
+      dispatcher: { dispatch: async () => ({}) },
+      buildCallbackMeta: () => ({}),
+    });
+    const app = makeApp(handler);
+    const res = await app.request("/api/link-complete?state=expired-tok");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Already processed");
+  });
+
+  test("discussion not found returns 404", async () => {
+    const handler = createLinkCompleteHandler({
+      channel: "github-discussions",
+      store: makeStore({
+        pending: { discussion_id: "d-1", surface_user_id: "42" },
+        ctx: null,
+      }),
+      dispatcher: { dispatch: async () => ({}) },
+      buildCallbackMeta: () => ({}),
+    });
+    const app = makeApp(handler);
+    const res = await app.request("/api/link-complete?state=tok");
+    expect(res.status).toBe(404);
+    const html = await res.text();
+    expect(html).toContain("Discussion not found");
+  });
+
+  test("dispatched returns 'Processing'", async () => {
+    const handler = createLinkCompleteHandler({
+      channel: "github-discussions",
+      store: makeStore({
+        pending: { discussion_id: "d-1", surface_user_id: "42" },
+        ctx: {
+          discussion_id: "d-1",
+          history: [{ role: "user", text: "deploy please", author: "42" }],
+        },
+      }),
+      dispatcher: {
+        dispatch: async () => ({
+          kind: "dispatched",
+          token: "t",
+          correlationId: "c",
+        }),
+      },
+      buildCallbackMeta: (ctx) => ({ discussionId: ctx.discussion_id }),
+    });
+    const app = makeApp(handler);
+    const res = await app.request("/api/link-complete?state=tok");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Processing");
+  });
+
+  test("dispatch failure renders 'Unable to dispatch'", async () => {
+    const handler = createLinkCompleteHandler({
+      channel: "github-discussions",
+      store: makeStore({
+        pending: { discussion_id: "d-1", surface_user_id: "42" },
+        ctx: {
+          discussion_id: "d-1",
+          history: [{ role: "user", text: "hello", author: "42" }],
+        },
+      }),
+      dispatcher: {
+        dispatch: async () => ({
+          kind: "link_required",
+          authorizeUrl: "http://x",
+        }),
+      },
+      buildCallbackMeta: () => ({}),
+    });
+    const app = makeApp(handler);
+    const res = await app.request("/api/link-complete?state=tok");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Unable to dispatch");
+  });
+
+  test("multi-party thread: selects the turn authored by the linking user", async () => {
+    let capturedPrompt;
+    const handler = createLinkCompleteHandler({
+      channel: "github-discussions",
+      store: makeStore({
+        pending: { discussion_id: "d-1", surface_user_id: "42" },
+        ctx: {
+          discussion_id: "d-1",
+          history: [
+            { role: "user", text: "msg from 99", author: "99" },
+            { role: "user", text: "msg from 42", author: "42" },
+            { role: "user", text: "another from 99", author: "99" },
+          ],
+        },
+      }),
+      dispatcher: {
+        dispatch: async ({ prompt }) => {
+          capturedPrompt = prompt;
+          return { kind: "dispatched", token: "t", correlationId: "c" };
+        },
+      },
+      buildCallbackMeta: () => ({}),
+    });
+    const app = makeApp(handler);
+    await app.request("/api/link-complete?state=tok");
+    expect(capturedPrompt).toContain("Current message: msg from 42");
+  });
+
+  test("no user turn found returns 404", async () => {
+    const handler = createLinkCompleteHandler({
+      channel: "github-discussions",
+      store: makeStore({
+        pending: { discussion_id: "d-1", surface_user_id: "42" },
+        ctx: {
+          discussion_id: "d-1",
+          history: [{ role: "assistant", text: "hi there" }],
+        },
+      }),
+      dispatcher: { dispatch: async () => ({}) },
+      buildCallbackMeta: () => ({}),
+    });
+    const app = makeApp(handler);
+    const res = await app.request("/api/link-complete?state=tok");
+    expect(res.status).toBe(404);
+    const html = await res.text();
+    expect(html).toContain("No message found");
+  });
+});

--- a/libraries/libmock/src/mock/clients.js
+++ b/libraries/libmock/src/mock/clients.js
@@ -155,8 +155,14 @@ export function createMockDiscussionClient(overrides = {}) {
     HasOrigin: spy(() => Promise.resolve({ exists: false })),
     RecordOrigin: spy(() => Promise.resolve({})),
     Sweep: spy(() =>
-      Promise.resolve({ evicted_discussions: 0, evicted_origins: 0 }),
+      Promise.resolve({
+        evicted_discussions: 0,
+        evicted_origins: 0,
+        evicted_pending: 0,
+      }),
     ),
+    PutPendingDispatch: spy(() => Promise.resolve({})),
+    ResolvePendingDispatch: spy(() => Promise.reject(notFound())),
     ...overrides,
   };
 }
@@ -187,6 +193,7 @@ function coerceInt64Fields(obj) {
 export function createStatefulDiscussionClient() {
   const records = new Map();
   const origins = new Map();
+  const pending = new Map();
 
   return {
     SaveDiscussion: spy(async (req) => {
@@ -235,6 +242,21 @@ export function createStatefulDiscussionClient() {
     Sweep: spy(async () => ({
       evicted_discussions: 0,
       evicted_origins: 0,
+      evicted_pending: 0,
     })),
+    PutPendingDispatch: spy(async (req) => {
+      const obj = req?.toJSON?.() ?? req;
+      const p = obj.pending ?? obj;
+      pending.set(p.link_token, p);
+      return {};
+    }),
+    ResolvePendingDispatch: spy(async (req) => {
+      const obj = req?.toJSON?.() ?? req;
+      const token = obj.link_token;
+      const rec = pending.get(token);
+      if (!rec) throw notFound();
+      pending.delete(token);
+      return rec;
+    }),
   };
 }

--- a/services/bridge/index.js
+++ b/services/bridge/index.js
@@ -11,8 +11,10 @@ const { BridgeBase } = services;
 export class BridgeService extends BridgeBase {
   #discussions;
   #origins;
+  #pendingDispatches;
   #conversationTtlMs;
   #originTtlMs;
+  #pendingTtlMs;
   #sweepTimer;
 
   /**
@@ -28,8 +30,17 @@ export class BridgeService extends BridgeBase {
       flush_interval: config.origin_flush_interval_ms,
       max_buffer_size: config.origin_max_buffer_size,
     });
+    this.#pendingDispatches = new BufferedIndex(
+      storage,
+      "pending_dispatches.jsonl",
+      {
+        flush_interval: config.pending_flush_interval_ms ?? 1_000,
+        max_buffer_size: 100,
+      },
+    );
     this.#conversationTtlMs = config.conversation_ttl_ms;
     this.#originTtlMs = config.origin_ttl_ms;
+    this.#pendingTtlMs = config.pending_ttl_ms ?? 10 * 60 * 1000;
     this.#sweepTimer = setInterval(() => {
       this.#sweep(Date.now()).catch((e) => logger.error?.("sweep", e));
     }, config.sweep_interval_ms);
@@ -113,36 +124,89 @@ export class BridgeService extends BridgeBase {
   /**
    *
    */
+  async PutPendingDispatch(req) {
+    const p = req.pending;
+    await this.#pendingDispatches.add({
+      id: p.link_token,
+      surface: p.surface,
+      surface_user_id: p.surface_user_id,
+      discussion_id: p.discussion_id,
+      created_at: Number(p.created_at) || Date.now(),
+    });
+    return {};
+  }
+
+  /**
+   *
+   */
+  async ResolvePendingDispatch(req) {
+    await this.#pendingDispatches.loadData();
+    for (const [id, rec] of this.#pendingDispatches.index) {
+      if (rec.deleted) this.#pendingDispatches.index.delete(id);
+    }
+    const rec = this.#pendingDispatches.index.get(req.link_token);
+    if (!rec)
+      throw Object.assign(new Error("not found"), {
+        code: grpc.status.NOT_FOUND,
+      });
+    this.#pendingDispatches.index.delete(req.link_token);
+    await this.#pendingDispatches.add({ id: req.link_token, deleted: true });
+    return bridge.PendingDispatch.fromObject({
+      link_token: rec.id,
+      surface: rec.surface,
+      surface_user_id: rec.surface_user_id,
+      discussion_id: rec.discussion_id,
+      created_at: rec.created_at,
+    });
+  }
+
+  /**
+   *
+   */
   async Sweep(req) {
     const now = req.now ?? Date.now();
-    const { evicted_discussions, evicted_origins } = await this.#sweep(now);
-    return { evicted_discussions, evicted_origins };
+    const { evicted_discussions, evicted_origins, evicted_pending } =
+      await this.#sweep(now);
+    return { evicted_discussions, evicted_origins, evicted_pending };
+  }
+
+  #sweepIndex(index, now, isStale) {
+    let evicted = 0;
+    for (const [key, rec] of index) {
+      if (isStale(rec, now)) {
+        index.delete(key);
+        evicted++;
+      }
+    }
+    return evicted;
   }
 
   async #sweep(now) {
     await this.#discussions.loadData();
     await this.#origins.loadData();
+    await this.#pendingDispatches.loadData();
 
-    let evicted_discussions = 0;
-    for (const [key, rec] of this.#discussions.index) {
-      if (now - (rec.last_active_at ?? 0) > this.#conversationTtlMs) {
-        this.#discussions.index.delete(key);
-        evicted_discussions++;
-      }
-    }
-
-    let evicted_origins = 0;
-    for (const [key, rec] of this.#origins.index) {
-      if (now - (rec.posted_at ?? 0) > this.#originTtlMs) {
-        this.#origins.index.delete(key);
-        evicted_origins++;
-      }
-    }
+    const evicted_discussions = this.#sweepIndex(
+      this.#discussions.index,
+      now,
+      (rec) => now - (rec.last_active_at ?? 0) > this.#conversationTtlMs,
+    );
+    const evicted_origins = this.#sweepIndex(
+      this.#origins.index,
+      now,
+      (rec) => now - (rec.posted_at ?? 0) > this.#originTtlMs,
+    );
+    const evicted_pending = this.#sweepIndex(
+      this.#pendingDispatches.index,
+      now,
+      (rec) => rec.deleted || now - (rec.created_at ?? 0) > this.#pendingTtlMs,
+    );
 
     if (evicted_discussions > 0) await this.#discussions.flush();
     if (evicted_origins > 0) await this.#origins.flush();
+    if (evicted_pending > 0) await this.#pendingDispatches.flush();
 
-    return { evicted_discussions, evicted_origins };
+    return { evicted_discussions, evicted_origins, evicted_pending };
   }
 
   /**
@@ -150,6 +214,10 @@ export class BridgeService extends BridgeBase {
    */
   async shutdown() {
     clearInterval(this.#sweepTimer);
-    await Promise.all([this.#discussions.flush(), this.#origins.flush()]);
+    await Promise.all([
+      this.#discussions.flush(),
+      this.#origins.flush(),
+      this.#pendingDispatches.flush(),
+    ]);
   }
 }

--- a/services/bridge/index.js
+++ b/services/bridge/index.js
@@ -141,9 +141,11 @@ export class BridgeService extends BridgeBase {
    */
   async ResolvePendingDispatch(req) {
     await this.#pendingDispatches.loadData();
+    const stale = [];
     for (const [id, rec] of this.#pendingDispatches.index) {
-      if (rec.deleted) this.#pendingDispatches.index.delete(id);
+      if (rec.deleted) stale.push(id);
     }
+    for (const id of stale) this.#pendingDispatches.index.delete(id);
     const rec = this.#pendingDispatches.index.get(req.link_token);
     if (!rec)
       throw Object.assign(new Error("not found"), {

--- a/services/bridge/proto/bridge.proto
+++ b/services/bridge/proto/bridge.proto
@@ -12,6 +12,8 @@ service Bridge {
   rpc HasOrigin(OriginKey) returns (HasOriginResponse);
   rpc RecordOrigin(Origin) returns (common.Empty);
   rpc Sweep(SweepRequest) returns (SweepResponse);
+  rpc PutPendingDispatch(PutPendingDispatchRequest) returns (common.Empty);
+  rpc ResolvePendingDispatch(ResolvePendingDispatchRequest) returns (PendingDispatch);
 }
 
 message Discussion {
@@ -27,7 +29,7 @@ message Discussion {
   map<string, string> pending_callbacks = 10;
 }
 
-message HistoryEntry { string role = 1; string text = 2; }
+message HistoryEntry { string role = 1; string text = 2; optional string author = 3; }
 message Participant {
   string name = 1; string kind = 2;
   optional string external_id = 3; string metadata_json = 4;
@@ -52,5 +54,16 @@ message OriginKey { string id = 1; }
 message HasOriginResponse { bool exists = 1; }
 message OpenRecessRef { string correlation_id = 1; int64 due_at = 2; }
 message OpenRecessList { repeated OpenRecessRef refs = 1; }
+message PendingDispatch {
+  string link_token = 1;
+  string surface = 2;
+  string surface_user_id = 3;
+  string discussion_id = 4;
+  int64 created_at = 5;
+}
+
+message PutPendingDispatchRequest { PendingDispatch pending = 1; }
+message ResolvePendingDispatchRequest { string link_token = 1; }
+
 message SweepRequest { optional int64 now = 1; }
-message SweepResponse { int32 evicted_discussions = 1; int32 evicted_origins = 2; }
+message SweepResponse { int32 evicted_discussions = 1; int32 evicted_origins = 2; int32 evicted_pending = 3; }

--- a/services/bridge/test/bridge.test.js
+++ b/services/bridge/test/bridge.test.js
@@ -246,6 +246,54 @@ describe("bridge service", () => {
     assert.strictEqual(freshCheck.exists, true);
   });
 
+  test("PutPendingDispatch then ResolvePendingDispatch returns and consumes the record", async () => {
+    await service.PutPendingDispatch({
+      pending: {
+        link_token: "lt-1",
+        surface: "github-discussions",
+        surface_user_id: "42",
+        discussion_id: "d-100",
+        created_at: Date.now(),
+      },
+    });
+
+    const resolved = await service.ResolvePendingDispatch({
+      link_token: "lt-1",
+    });
+    assert.strictEqual(resolved.link_token, "lt-1");
+    assert.strictEqual(resolved.surface, "github-discussions");
+    assert.strictEqual(resolved.surface_user_id, "42");
+    assert.strictEqual(resolved.discussion_id, "d-100");
+
+    await assert.rejects(
+      () => service.ResolvePendingDispatch({ link_token: "lt-1" }),
+      (err) => err.code === grpc.status.NOT_FOUND,
+    );
+  });
+
+  test("Sweep evicts pending dispatches older than TTL", async () => {
+    const now = Date.now();
+    const stale = now - 11 * 60 * 1000;
+
+    await service.PutPendingDispatch({
+      pending: {
+        link_token: "lt-old",
+        surface: "github-discussions",
+        surface_user_id: "42",
+        discussion_id: "d-1",
+        created_at: stale,
+      },
+    });
+
+    const result = await service.Sweep({ now });
+    assert.ok(result.evicted_pending >= 1);
+
+    await assert.rejects(
+      () => service.ResolvePendingDispatch({ link_token: "lt-old" }),
+      (err) => err.code === grpc.status.NOT_FOUND,
+    );
+  });
+
   test("Concurrent SaveDiscussion from two channels both land", async () => {
     await Promise.all([
       service.SaveDiscussion({

--- a/services/ghauth/index.js
+++ b/services/ghauth/index.js
@@ -5,6 +5,7 @@ import { RevokedError } from "./src/github-oauth.js";
 const { GhauthBase } = services;
 
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+const GITHUB_ID_SURFACES = new Set(["github-discussions"]);
 
 /**
  * GitHub user authentication service — Kata Agent User App token lifecycle.
@@ -48,7 +49,7 @@ export class GhauthService extends GhauthBase {
       surface_user_id: req.surface_user_id,
       code_challenge: req.code_challenge ?? null,
       redirect_uri: req.redirect_uri ?? null,
-      client_state: null,
+      client_state: req.client_state ?? null,
       created_at: Date.now(),
     });
 
@@ -72,13 +73,24 @@ export class GhauthService extends GhauthBase {
     const redirectUri = `${this.#linkBaseUrl}/callback`;
     const tokens = await this.#github.exchangeCode(req.code, redirectUri);
 
+    const authorizedGithubId = String(
+      await this.#github.getUser(tokens.access_token),
+    );
+
+    if (
+      GITHUB_ID_SURFACES.has(flow.surface) &&
+      authorizedGithubId !== flow.surface_user_id
+    ) {
+      return { outcome: "identity_mismatch" };
+    }
+
     const bindingId = this.#bindings.constructor.keyOf(
       flow.surface,
       flow.surface_user_id,
     );
     await this.#bindings.upsert({
       id: bindingId,
-      github_user_id: null,
+      github_user_id: authorizedGithubId,
       access_token: tokens.access_token,
       refresh_token: tokens.refresh_token ?? null,
       expires_at: tokens.expires_in

--- a/services/ghauth/proto/ghauth.proto
+++ b/services/ghauth/proto/ghauth.proto
@@ -18,6 +18,7 @@ message BeginRequest {
   optional string redirect_uri = 3;
   optional string code_challenge = 4;
   repeated string scopes = 5;
+  optional string client_state = 6;
 }
 message BeginResponse { string upstream_authorize_url = 1; string state = 2; }
 
@@ -26,6 +27,7 @@ message CompleteResponse {
   optional string downstream_code = 1;
   optional string redirect_uri = 2;
   optional string client_state = 3;
+  optional string outcome = 4;
 }
 
 message RedeemRequest { string code = 1; string code_verifier = 2; }

--- a/services/ghauth/src/github-oauth.js
+++ b/services/ghauth/src/github-oauth.js
@@ -84,6 +84,18 @@ export function createGithubOAuth({
       };
     },
 
+    async getUser(accessToken) {
+      const res = await fetchImpl("https://api.github.com/user", {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+      if (!res.ok) throw new Error(`GitHub user lookup failed: ${res.status}`);
+      const body = await res.json();
+      return body.id;
+    },
+
     async revoke(accessToken) {
       const res = await fetchImpl(
         `https://api.github.com/applications/${clientId}/token`,

--- a/services/ghauth/test/identity-verification.test.js
+++ b/services/ghauth/test/identity-verification.test.js
@@ -1,0 +1,102 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { createMockConfig } from "@forwardimpact/libmock";
+import { createMockStorage } from "@forwardimpact/libmock/mock";
+import { GhauthService } from "../index.js";
+import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
+
+function createService(storage, { getUserId = "12345" } = {}) {
+  const config = createMockConfig("ghauth", {
+    link_base_url: "http://localhost:3007",
+  });
+  const bindings = new BindingStore(storage);
+  return {
+    service: new GhauthService(config, {
+      bindings,
+      flows: new FlowStore(storage),
+      grants: new GrantStore(storage),
+      github: {
+        authorizeUrl: () => "http://gh/authorize",
+        exchangeCode: async () => ({
+          access_token: "ghu_test",
+          refresh_token: "ghr_test",
+          expires_in: 3600,
+        }),
+        getUser: async () => getUserId,
+        refresh: async () => ({}),
+        revoke: async () => {},
+      },
+    }),
+    bindings,
+  };
+}
+
+describe("ghauth identity verification", () => {
+  test("matching id creates binding with github_user_id", async () => {
+    const storage = createMockStorage();
+    const { service, bindings } = createService(storage, {
+      getUserId: "42",
+    });
+
+    const { state } = await service.Begin({
+      surface: "github-discussions",
+      surface_user_id: "42",
+    });
+    const result = await service.Complete({ code: "code1", state });
+
+    assert.strictEqual(result.outcome, undefined);
+    const binding = await bindings.loadBinding("github-discussions", "42");
+    assert.ok(binding, "binding was created");
+    assert.strictEqual(binding.github_user_id, "42");
+  });
+
+  test("mismatching id returns identity_mismatch and creates no binding", async () => {
+    const storage = createMockStorage();
+    const { service, bindings } = createService(storage, {
+      getUserId: "999",
+    });
+
+    const { state } = await service.Begin({
+      surface: "github-discussions",
+      surface_user_id: "42",
+    });
+    const result = await service.Complete({ code: "code1", state });
+
+    assert.strictEqual(result.outcome, "identity_mismatch");
+    const binding = await bindings.loadBinding("github-discussions", "42");
+    assert.strictEqual(binding, null, "no binding created");
+  });
+
+  test("non-github-discussions surface creates binding regardless of id difference", async () => {
+    const storage = createMockStorage();
+    const { service, bindings } = createService(storage, {
+      getUserId: "999",
+    });
+
+    const { state } = await service.Begin({
+      surface: "msteams",
+      surface_user_id: "aad-obj-id",
+    });
+    const result = await service.Complete({ code: "code1", state });
+
+    assert.strictEqual(result.outcome, undefined);
+    const binding = await bindings.loadBinding("msteams", "aad-obj-id");
+    assert.ok(binding, "binding was created");
+    assert.strictEqual(binding.github_user_id, "999");
+  });
+
+  test("client_state round-trip: Begin stores it, Complete returns it", async () => {
+    const storage = createMockStorage();
+    const { service } = createService(storage, { getUserId: "42" });
+
+    const { state } = await service.Begin({
+      surface: "github-discussions",
+      surface_user_id: "42",
+      client_state: "tok-abc",
+      redirect_uri: "http://bridge/api/link-complete",
+    });
+    const result = await service.Complete({ code: "code1", state });
+
+    assert.strictEqual(result.client_state, "tok-abc");
+  });
+});

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -9,8 +9,10 @@ import {
   buildPrompt,
   createBridgeServer,
   createCallbackHandler,
+  createLinkCompleteHandler,
   newDiscussionContext,
   normalizeBaseUrl,
+  prepareLinkResume,
   validateCallbackPayload,
 } from "@forwardimpact/libbridge";
 import { bridge } from "@forwardimpact/libtype";
@@ -140,6 +142,13 @@ export class GhBridgeService {
         this.#handleReply(ctx, payload, meta),
     });
 
+    const onLinkComplete = createLinkCompleteHandler({
+      channel: CHANNEL,
+      store: this.#store,
+      dispatcher: this.#dispatcher,
+      buildCallbackMeta: (ctx) => ({ discussionId: ctx.discussion_id }),
+    });
+
     this.#bridge = createBridgeServer({
       config,
       logger,
@@ -147,6 +156,7 @@ export class GhBridgeService {
       webhookPath: WEBHOOK_PATH,
       onWebhook: (c) => this.#handleWebhook(c),
       onCallback: (c) => this.#onCallback(c),
+      onLinkComplete,
     });
   }
 
@@ -238,6 +248,11 @@ export class GhBridgeService {
     });
     try {
       const ctx = await this.#loadOrCreateContext(discussionId, discussion);
+
+      appendHistory(ctx.history, { role: "user", text, author: requester });
+      ctx.last_active_at = Date.now();
+      await this.#store.add(ctx);
+
       const limit = this.#rateLimiter.check(discussionId, ctx.dispatches);
       if (!limit.allowed) {
         this.#logger.info("webhook", "rate limited", {
@@ -254,7 +269,6 @@ export class GhBridgeService {
           prompt: buildPrompt(text, ctx.history),
           requester,
           ackTarget: { subjectId: discussionId },
-          historyText: text,
           callbackMeta: { discussionId },
           workflowInputs: { discussionId },
         });
@@ -263,7 +277,7 @@ export class GhBridgeService {
             correlation_id: result.correlationId,
           });
         } else {
-          await this.#renderDeclined(ctx, result);
+          await this.#handleDispatchResult(ctx, result, requester);
           span.addEvent("dispatch_declined", { kind: result.kind });
         }
         span.setOk();
@@ -311,8 +325,9 @@ export class GhBridgeService {
       let ctx = await this.#store.loadByChannel(CHANNEL, discussionId);
       if (!ctx) ctx = await this.#loadOrCreateContext(discussionId, discussion);
 
-      appendHistory(ctx.history, { role: "user", text });
+      appendHistory(ctx.history, { role: "user", text, author: requester });
       ctx.last_active_at = Date.now();
+      await this.#store.add(ctx);
 
       const { freshDispatchAllowed } = await this.#resume.processInbound(ctx);
 
@@ -337,7 +352,7 @@ export class GhBridgeService {
           workflowInputs: { discussionId: ctx.discussion_id },
         });
         if (result.kind !== "dispatched") {
-          await this.#renderDeclined(ctx, result);
+          await this.#handleDispatchResult(ctx, result, requester);
         }
       }
 
@@ -417,6 +432,46 @@ export class GhBridgeService {
         }
         break;
     }
+  }
+
+  async #handleDispatchResult(ctx, result, requester) {
+    if (result.kind === "link_required") {
+      await this.#stashAndPostLink(ctx, result, requester);
+    } else if (result.kind !== "dispatched") {
+      await this.#renderDeclined(ctx, result);
+    }
+  }
+
+  async #stashAndPostLink(ctx, result, requester) {
+    const { linkToken, augmentedUrl } = prepareLinkResume(
+      result.authorizeUrl,
+      this.#config.callback_base_url,
+    );
+
+    await this.#store.putPendingDispatch({
+      link_token: linkToken,
+      surface: CHANNEL,
+      surface_user_id: requester,
+      discussion_id: ctx.discussion_id,
+      created_at: Date.now(),
+    });
+
+    const body = `To dispatch, link your GitHub account: ${augmentedUrl}`;
+    const recordOrigin = async (comment) => {
+      await this.#client.RecordOrigin(
+        bridge.Origin.fromObject({
+          id: comment.id,
+          discussion_id: ctx.discussion_id,
+          posted_at: Date.now(),
+        }),
+      );
+    };
+    await postSingleDiscussionReply(
+      this.#graphqlClient,
+      ctx,
+      body,
+      recordOrigin,
+    );
   }
 
   async #renderDeclined(ctx, outcome) {

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -437,7 +437,7 @@ export class GhBridgeService {
   async #handleDispatchResult(ctx, result, requester) {
     if (result.kind === "link_required") {
       await this.#stashAndPostLink(ctx, result, requester);
-    } else if (result.kind !== "dispatched") {
+    } else {
       await this.#renderDeclined(ctx, result);
     }
   }

--- a/services/ghbridge/src/discussion-adapter.js
+++ b/services/ghbridge/src/discussion-adapter.js
@@ -102,6 +102,31 @@ export class DiscussionAdapter {
   /**
    *
    */
+  async putPendingDispatch(target) {
+    await this.#client.PutPendingDispatch(
+      bridge.PutPendingDispatchRequest.fromObject({ pending: target }),
+    );
+  }
+
+  /**
+   *
+   */
+  async resolvePendingDispatch(linkToken) {
+    try {
+      return await this.#client.ResolvePendingDispatch(
+        bridge.ResolvePendingDispatchRequest.fromObject({
+          link_token: linkToken,
+        }),
+      );
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  }
+
+  /**
+   *
+   */
   async flush() {}
   /**
    *

--- a/services/ghbridge/test/dispatch-auth.test.js
+++ b/services/ghbridge/test/dispatch-auth.test.js
@@ -179,9 +179,10 @@ describe("ghbridge dispatch-auth", () => {
       c.query.includes("addDiscussionComment"),
     );
     expect(commentCalls).toHaveLength(1);
-    expect(commentCalls[0].variables.i.body).toContain(
-      "https://example.com/authorize",
-    );
+    const linkBody = commentCalls[0].variables.i.body;
+    expect(linkBody).toContain("redirect_uri=");
+    expect(linkBody).toContain("client_state=");
+    expect(linkBody).toContain("link-complete");
 
     await service.stop();
   });

--- a/services/ghbridge/test/resume.test.js
+++ b/services/ghbridge/test/resume.test.js
@@ -153,8 +153,8 @@ describe("ghbridge resume", () => {
     const resumeCtx = JSON.parse(resumeInputs.resume_context);
     expect(resumeCtx.correlation_id).toBe(meta.correlationId);
     expect(resumeCtx.history_since).toEqual([
-      { role: "user", text: "I think yes" },
-      { role: "user", text: "agreed" },
+      { role: "user", text: "I think yes", author: "2" },
+      { role: "user", text: "agreed", author: "3" },
     ]);
   });
 

--- a/services/msbridge/index.js
+++ b/services/msbridge/index.js
@@ -10,8 +10,10 @@ import {
   buildPrompt,
   createBridgeServer,
   createCallbackHandler,
+  createLinkCompleteHandler,
   newDiscussionContext,
   normalizeBaseUrl,
+  prepareLinkResume,
   validateCallbackPayload,
 } from "@forwardimpact/libbridge";
 
@@ -43,6 +45,7 @@ export { appendHistory, buildPrompt, validateCallbackPayload };
 export class MsBridgeService {
   #logger;
   #tracer;
+  #config;
   #msAppId;
   #adapter;
   #store;
@@ -85,6 +88,7 @@ export class MsBridgeService {
     if (!ghauthClient) throw new Error("ghauthClient is required");
     this.#logger = logger;
     this.#tracer = tracer;
+    this.#config = config;
     this.#msAppId = () => config.msAppId();
 
     this.#adapter = adapter ?? createDefaultAdapter(config);
@@ -141,6 +145,13 @@ export class MsBridgeService {
         this.#handleReply(ctx, payload, meta),
     });
 
+    const onLinkComplete = createLinkCompleteHandler({
+      channel: CHANNEL,
+      store: this.#store,
+      dispatcher: this.#dispatcher,
+      buildCallbackMeta: (ctx) => ({ threadId: ctx.discussion_id }),
+    });
+
     this.#bridge = createBridgeServer({
       config,
       logger,
@@ -152,6 +163,7 @@ export class MsBridgeService {
         logger,
       ),
       onCallback: (c) => this.#onCallback(c),
+      onLinkComplete,
     });
   }
 
@@ -213,10 +225,11 @@ export class MsBridgeService {
     try {
       const ref = TurnContext.getConversationReference(activity);
       const ctx = await this.#loadOrCreateContext(threadId, ref);
-      ctx.last_active_at = Date.now();
       ctx.participants[0].metadata = ref;
 
-      appendHistory(ctx.history, { role: "user", text });
+      appendHistory(ctx.history, { role: "user", text, author: requester });
+      ctx.last_active_at = Date.now();
+      await this.#store.add(ctx);
 
       const { freshDispatchAllowed } = await this.#resume.processInbound(ctx);
       if (!freshDispatchAllowed) {
@@ -251,6 +264,9 @@ export class MsBridgeService {
           span.addEvent("workflow_dispatched", {
             correlation_id: result.correlationId,
           });
+        } else if (result.kind === "link_required") {
+          await this.#stashAndPostLink(ctx, result, requester);
+          span.addEvent("dispatch_declined", { kind: result.kind });
         } else {
           await this.#renderDeclined(ctx, result);
           span.addEvent("dispatch_declined", { kind: result.kind });
@@ -314,6 +330,31 @@ export class MsBridgeService {
     for (const reply of list) {
       if (!reply || typeof reply.body !== "string") continue;
       appendHistory(ctx.history, { role: "assistant", text: reply.body });
+    }
+  }
+
+  async #stashAndPostLink(ctx, result, requester) {
+    const { linkToken, augmentedUrl } = prepareLinkResume(
+      result.authorizeUrl,
+      this.#config.callback_base_url,
+    );
+
+    await this.#store.putPendingDispatch({
+      link_token: linkToken,
+      surface: CHANNEL,
+      surface_user_id: requester,
+      discussion_id: ctx.discussion_id,
+      created_at: Date.now(),
+    });
+
+    const ref = ctx.participants?.[0]?.metadata;
+    if (ref) {
+      await sendReply(
+        this.#adapter,
+        this.#msAppId,
+        ref,
+        `To dispatch, link your GitHub account: ${augmentedUrl}`,
+      );
     }
   }
 

--- a/services/msbridge/src/discussion-adapter.js
+++ b/services/msbridge/src/discussion-adapter.js
@@ -105,6 +105,31 @@ export class DiscussionAdapter {
   /**
    *
    */
+  async putPendingDispatch(target) {
+    await this.#client.PutPendingDispatch(
+      bridge.PutPendingDispatchRequest.fromObject({ pending: target }),
+    );
+  }
+
+  /**
+   *
+   */
+  async resolvePendingDispatch(linkToken) {
+    try {
+      return await this.#client.ResolvePendingDispatch(
+        bridge.ResolvePendingDispatchRequest.fromObject({
+          link_token: linkToken,
+        }),
+      );
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  }
+
+  /**
+   *
+   */
   async flush() {}
   /**
    *

--- a/services/msbridge/test/dispatch-auth.test.js
+++ b/services/msbridge/test/dispatch-auth.test.js
@@ -166,7 +166,7 @@ describe("msbridge dispatch-auth", () => {
     expect(
       adapter.sent.some((m) =>
         typeof m === "string"
-          ? m.includes("https://example.com/authorize")
+          ? m.includes("link-complete") && m.includes("client_state")
           : false,
       ),
     ).toBe(true);

--- a/services/msbridge/test/resume.test.js
+++ b/services/msbridge/test/resume.test.js
@@ -174,8 +174,8 @@ describe("msbridge resume", () => {
     const resumeCtx = JSON.parse(resumeInputs.resume_context);
     expect(resumeCtx.correlation_id).toBe(meta.correlationId);
     expect(resumeCtx.history_since).toEqual([
-      { role: "user", text: "I think yes" },
-      { role: "user", text: "agreed" },
+      { role: "user", text: "I think yes", author: "u" },
+      { role: "user", text: "agreed", author: "u" },
     ]);
   });
 

--- a/services/oauth/index.js
+++ b/services/oauth/index.js
@@ -39,8 +39,14 @@ export function createOauthService({ config, logger, providerClient }) {
   app.get("/.well-known/oauth-authorization-server", (c) => c.json(metadata));
 
   app.get("/authorize", async (c) => {
-    const { surface, surface_user_id, redirect_uri, code_challenge, scope } =
-      c.req.query();
+    const {
+      surface,
+      surface_user_id,
+      redirect_uri,
+      code_challenge,
+      scope,
+      client_state,
+    } = c.req.query();
     if (!surface || !surface_user_id) {
       return c.json({ error: "invalid_request" }, 400);
     }
@@ -53,6 +59,7 @@ export function createOauthService({ config, logger, providerClient }) {
         redirect_uri: redirect_uri || undefined,
         code_challenge: code_challenge || undefined,
         scopes,
+        client_state: client_state || undefined,
       }),
     );
 
@@ -68,6 +75,15 @@ export function createOauthService({ config, logger, providerClient }) {
     const result = await providerClient.Complete(
       typed("CompleteRequest", { code, state }),
     );
+
+    if (result.outcome === "identity_mismatch") {
+      return c.html(
+        "<!DOCTYPE html><html><body><h1>Account mismatch</h1>" +
+          "<p>The account that authorized does not match the " +
+          "account that requested linking. No binding was created. " +
+          "Please try again from the correct account.</p></body></html>",
+      );
+    }
 
     if (result.redirect_uri) {
       const url = new URL(result.redirect_uri);

--- a/services/oauth/test/authorize.test.js
+++ b/services/oauth/test/authorize.test.js
@@ -85,6 +85,54 @@ describe("oauth authorize (SC#2)", () => {
     assert.ok(html.includes("Linked"), "page contains Linked heading");
   });
 
+  test("/authorize with client_state passes it to Begin", async () => {
+    let capturedClientState;
+    const { app } = createOauthService({
+      config: {
+        issuer: "http://localhost:3007",
+        host: "0.0.0.0",
+        port: 0,
+        provider: "ghauth",
+      },
+      logger: { info: () => {}, error: () => {} },
+      providerClient: {
+        Begin: async (req) => {
+          capturedClientState = req.client_state;
+          return { upstream_authorize_url: "http://gh", state: "s1" };
+        },
+        Complete: async () => ({}),
+        Redeem: async () => ({}),
+      },
+    });
+
+    await app.request(
+      "/authorize?surface=teams&surface_user_id=u1&client_state=link-tok-99",
+    );
+    assert.strictEqual(capturedClientState, "link-tok-99");
+  });
+
+  test("/callback with identity_mismatch renders refusal page", async () => {
+    const { app } = createOauthService({
+      config: {
+        issuer: "http://localhost:3007",
+        host: "0.0.0.0",
+        port: 0,
+        provider: "ghauth",
+      },
+      logger: { info: () => {}, error: () => {} },
+      providerClient: {
+        Begin: async () => ({}),
+        Complete: async () => ({ outcome: "identity_mismatch" }),
+        Redeem: async () => ({}),
+      },
+    });
+
+    const res = await app.request("/callback?code=gh-code&state=s1");
+    assert.strictEqual(res.status, 200);
+    const html = await res.text();
+    assert.ok(html.includes("mismatch"), "page contains mismatch text");
+  });
+
   test("health endpoint returns ok", async () => {
     const { app } = createOauthService({
       config: {


### PR DESCRIPTION
## Summary

- **Identity verification**: `ghauth.Complete` now resolves the authorizing GitHub account and verifies it matches the intended surface identity. Mismatches write no binding and render a refusal page.
- **Auth-completion resume**: When a user with no binding triggers dispatch, the bridge stashes a `PendingDispatch` target, augments the authorize URL, and on link completion the `/api/link-complete` endpoint re-dispatches the original message automatically — no resend needed.
- **Bridge parity**: Both `ghbridge` and `msbridge` implement the same pattern via shared `libbridge` primitives (`prepareLinkResume`, `createLinkCompleteHandler`).
- **Dispatcher clean break**: `historyText` removed from `Dispatcher.dispatch()` — turn persistence is now the intake's responsibility.

## Test plan

- [x] `bun run check` passes (format, lint, jsdoc, invariants)
- [x] `bun run test` passes (3920 tests, 0 failures)
- [x] Identity verification: matching id creates binding, mismatching id returns identity_mismatch with no binding
- [x] Non-github-discussions surface creates binding regardless of id difference
- [x] client_state round-trips through Begin → Complete
- [x] PendingDispatch put → resolve → consumed (second resolve → NOT_FOUND)
- [x] Sweep evicts stale pending dispatches
- [x] Link-complete handler: dispatched → "Processing", no binding → "Unable to dispatch", consumed → "Already processed", multi-party → correct author turn
- [x] ghbridge and msbridge post augmented URL with redirect_uri and client_state
- [x] Clean sub-agent review panel: no blockers, no high findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)