### PR TITLE
design(1270): public hosting — split token broker into services/oidc + services/ghserver

### DIFF
--- a/specs/1270-kata-bridges-public-hosting/design-a.md
+++ b/specs/1270-kata-bridges-public-hosting/design-a.md
@@ -2,40 +2,43 @@
 
 Architectural design for [spec 1270](spec.md), building on
 [design 1230-a](../1230-threaded-discussion-bridges/design-a.md). Adds
-three structural pieces to the self-hosted architecture:
-`services/ghserver` (single custody point for the public App's
-private key; mints short-lived, repo-scoped installation tokens),
-`services/tenancy` (the registry), and tenancy in `libraries/libbridge`
-(channel-agnostic resolver interface). The kata-dispatch
-workflow_dispatch input shape and callback payload schema are
-unchanged; the callback URL scheme that the bridge serves gains a
-`{tenant_id}` path segment.
+to the self-hosted architecture (detailed in § Components): two
+control-plane services — `services/ghserver` (pure-gRPC custody point that
+mints repo-scoped installation tokens) and `services/oidc` (stateless HTTP
+front validating GitHub Actions OIDC, delegating minting over gRPC — the
+`services/oauth`→`services/ghauth` pattern) — a `services/tenancy` registry,
+a `TenantResolver` in `libraries/libbridge`, and multi-tenant behaviour in
+the existing `ghbridge`/`msbridge`/`bridge` services. The kata-dispatch
+input shape and callback payload schema are unchanged; the callback URL
+gains a `{tenant_id}` segment.
 
 ## Components
 
 | Component | Responsibility |
 |---|---|
-| `services/ghserver` | New. Holds the single Forward Impact-owned App private key in process and mints short-lived, **repo-scoped** installation tokens. Two callable surfaces: a control-plane gRPC interface for the bridges (mutual peer authentication; substrate is a plan concern), and a **public HTTPS endpoint** reached from GitHub Actions runners (authenticated via **GitHub Actions OIDC**, with the `repository` claim bounding the issued token). |
-| `services/tenancy` | New. Owns the `(channel, channel_tenant_key) → Tenant` registry. Does not hold App-credential material (that lives only in `services/ghserver`) and does not hold any new cryptographic primitive — callback verification is achieved by tenant-binding the inherited 1230 single-use callback token, not by a new signature scheme. |
+| `services/ghserver` | New. Pure gRPC service — the single point of App-key custody. Holds the Forward Impact-owned App private key in process and mints short-lived, **repo-scoped** installation tokens. Consults `services/tenancy.resolveByRepo` and enforces the per-tenant issuance ceiling before minting. Exposes one transport (gRPC), matching the one-transport-per-service convention in `services/CLAUDE.md` § Architecture. Two classes of control-plane caller, both peer-authenticated (substrate is a plan concern): the hosted bridges (replies, reactions, dispatch) and `services/oidc`. |
+| `services/oidc` | New. Stateless HTTP front reached from GitHub Actions runners. Validates the inbound **GitHub Actions OIDC** token (issuer, audience, JWKS), extracts the `repository` claim, and calls its configured provider (`services/ghserver`) over gRPC to mint the `repository`-scoped token. Holds **no** key material. Provider is swappable via config, mirroring `services/oauth`→`services/ghauth`; exposed publicly via its own tunnel. |
+| `services/tenancy` | New. Owns the `(channel, channel_tenant_key) → Tenant` registry. Does not hold App-credential material (that lives only in `services/ghserver`) and holds no new cryptographic primitive — callback verification tenant-binds the inherited 1230 single-use token, not a new signature scheme. |
 | `libraries/libbridge` | Adds a channel-agnostic `TenantResolver` interface. Bridges supply the resolver; libbridge imports no channel SDKs. Single-tenant mode returns a fixed `default` tenant; multi-tenant mode calls `services/tenancy`. |
-| `services/ghbridge` | Gains multi-tenant mode. Calls `services/ghserver` for installation tokens (replies, reactions). Resolves tenant via `installation_id` from the webhook payload. |
-| `services/msbridge` | Gains multi-tenant mode. Holds the multi-tenant **Bot Framework credential** in process — deliberately outside `services/ghserver`'s scope, which is the GitHub App private key only; Bot Framework custody hardening is a follow-on. Validates inbound JWTs against any consenting Microsoft tenant; resolves tenant via the activity's `tenantId`. Calls `services/ghserver` for the GitHub App credential used to dispatch the customer workflow. |
+| `services/ghbridge` | Gains multi-tenant mode. Replaces its in-process `createAppAuth` installation-token derivation with a `services/ghserver` mint for the GraphQL reply/reaction path. Resolves tenant by newly parsing `installation.id` (carried in App webhook deliveries, not read today). |
+| `services/msbridge` | Gains multi-tenant mode. Holds the multi-tenant **Bot Framework credential** in process — outside `services/ghserver`'s scope (the GitHub App key only); Bot Framework custody hardening is a follow-on. Builds a multi-tenant authenticator that accepts JWTs from any consenting Microsoft tenant (single-tenant today) and resolves the tenant from the activity's Entra id (`channelData.tenant.id`). Calls `services/ghserver` for the GitHub App credential used to dispatch the customer workflow. |
+| `services/bridge` | Existing canonical threaded-discussion store — the single source of truth both bridges reach via the `DiscussionAdapter` over gRPC (owns `data/bridges/*.jsonl`). Gains per-tenant record scoping by `tenant_id`; single-tenant mode adds no prefix, so existing keys are unchanged. |
 | Hosted GitHub App | Registration artifact (no code). One App owned by Forward Impact, public install URL. Permissions identical to the self-hosted Kata App; webhook subscriptions extended to include `installation`. |
 | Hosted Azure AD app + Bot resource | Registration artifact (no code). Multi-tenant, consent-on-install. One Bot Framework resource shared across consenting tenants. |
-| `kata-setup` workflow templates | Hosted-path templates carry no reference to the hosted App's private key, replacing every customer-side path that today consumes `KATA_APP_PRIVATE_KEY` with a single OIDC call to `services/ghserver`. The specific upstream actions and input names being replaced are a plan concern. Self-hosted templates unchanged. |
-| `TRUST.md` | Repository root document. Enumerates operator access surface for both deployment paths, including what `services/ghserver` can mint and on whose behalf. |
+| `kata-setup` workflow templates | Hosted-path templates carry no reference to the hosted App's private key, replacing every customer-side path that today consumes `KATA_APP_PRIVATE_KEY` with a single OIDC call to `services/oidc`. The upstream actions and input names being replaced are a plan concern. Self-hosted templates unchanged. |
+| `TRUST.md` | Repository root document, structured as the six aspects in spec § Proposal 5, each with a hosted-vs-self-hosted comparison column — including what `services/ghserver` can mint and on whose behalf, and that the only publicly-reachable control-plane process (`services/oidc`) holds no signing material. Drafting the prose is a plan concern. |
 
 ## Data flow
 
-The hosted control plane participates in event transit (webhook → dispatch),
-reply transit (callback → channel), and **token issuance** for every kata
-workflow. It does not participate in agent execution.
+The hosted control plane participates in event transit, reply transit,
+and **token issuance** for every kata workflow — never in agent execution.
 
 ```mermaid
 sequenceDiagram
     participant Ch as Channel (GH Discussions / MS Teams)
     participant Br as Hosted bridge (gh / ms)
     participant Tn as services/tenancy
+    participant OI as services/oidc
     participant AT as services/ghserver
     participant GH as GitHub Actions API
     participant WF as kata-* workflow<br/>(customer repo)
@@ -48,8 +51,10 @@ sequenceDiagram
     AT-->>Br: short-lived installation token
     Br->>GH: workflow_dispatch (installation token, dispatch inputs)
     GH->>WF: run starts in customer repo
-    WF->>AT: MintInstallationToken(repo) [OIDC]
-    AT-->>WF: short-lived installation token
+    WF->>OI: exchange OIDC token (audience-scoped)
+    OI->>AT: MintInstallationToken(repo) [peer auth]
+    AT-->>OI: short-lived installation token
+    OI-->>WF: short-lived installation token
     WF->>GH: checkout / commits / PRs / wiki push (installation token)
     WF->>An: prompt + ANTHROPIC_API_KEY (customer secret)
     An-->>WF: response
@@ -60,26 +65,26 @@ sequenceDiagram
     Br->>Ch: post replies (installation token / Bot Framework)
 ```
 
-Scheduled and event-triggered kata workflows (every workflow named in
-spec § Proposal 2 other than the bridge-dispatched `kata-dispatch.yml`
-path above) start at the `GH->>WF` step with no bridge upstream and
-re-mint via the same `WF->>AT` OIDC step. Anthropic processing
-stays inside the customer's runner.
+Scheduled and event-triggered kata workflows (every workflow in spec
+§ Proposal 2 other than the bridge-dispatched `kata-dispatch.yml` above)
+start at `GH->>WF` with no bridge upstream and re-mint via the same
+`WF->>OI->>AT` OIDC step. Anthropic processing stays on the runner.
 
 ## Workflow identity
 
-`services/ghserver` is the single point of App-key custody. The key never
-leaves this process; callers receive only short-lived installation tokens.
+`services/ghserver` is the single point of App-key custody: the key never
+leaves this gRPC process and callers receive only short-lived tokens.
+`services/oidc` performs OIDC validation; `services/ghserver` performs
+custody policy — tenancy check, per-repo scoping, rate ceiling.
 
-| Caller | Authentication | Token scope |
-|---|---|---|
-| Customer kata workflow run | GitHub Actions OIDC. The broker validates the OIDC token and consults `services/tenancy.resolveByRepo` to confirm the claimed `repository` has an `active` Tenant row before minting. | The single repository named in the OIDC claim. |
-| Hosted bridge | Mutual peer authentication inside the control plane (concrete substrate — mTLS, signed JWT, mesh-issued credential — is a plan concern). The bridge passes the tenant's resolved `repo` from `services/tenancy`. | The single repository the tenancy registry has on the active `Tenant` row. |
+| Caller | Reaches | Authentication | Token scope |
+|---|---|---|---|
+| Customer kata workflow run | `services/oidc` → `services/ghserver` | GitHub Actions OIDC, terminated at `services/oidc`, which validates the token (issuer, audience, JWKS) and passes the asserted `repository`. `services/ghserver` consults `services/tenancy.resolveByRepo` to confirm that `repository` has an `active` Tenant row before minting. | The single repository named in the OIDC claim. |
+| Hosted bridge | `services/ghserver` directly | Mutual peer authentication inside the control plane (substrate — mTLS, signed JWT, mesh-issued credential — is a plan concern). The bridge passes the tenant's resolved `repo` from `services/tenancy`. | The single repository on the active `Tenant` row. |
 
-`services/ghserver` rejects mint requests when the claimed repo is not
-an active installation / `active` tenant row, or when the per-tenant
-issuance rate ceiling is exceeded. Token TTL is GitHub's installation-
-token maximum; the customer workflow re-mints inside a long run.
+`services/ghserver` rejects mints when the repo is not an `active` tenant
+row or the per-tenant rate ceiling is exceeded. Token TTL is GitHub's
+installation-token maximum; long runs re-mint.
 
 ## Tenancy abstraction
 
@@ -106,20 +111,19 @@ interface TenantResolver {
 }
 ```
 
-`resolveByRepo` exists for `services/ghserver`'s OIDC path (which has
-a `repository` claim but no `channel_tenant_key`); both methods return
-only `state === "active"` tenants. A GitHub installation may cover
-many repositories — the registry creates one row per `(installation_id,
-repo)` pair on `repositories_added`, encoded in `channel_tenant_key`.
-Teams `pending_consent` rows lack `repo` until the customer self-serves
-the mapping (see § Onboarding).
+`resolveByRepo` serves `services/ghserver`'s mint path, driven by the
+OIDC-asserted `repository` that `services/oidc` forwards (no
+`channel_tenant_key`); both methods return only `active` tenants. A
+GitHub installation may cover many repos — the registry creates one row
+per `(installation_id, repo)` pair on `repositories_added`. Teams
+`pending_consent` rows lack `repo` until the customer self-serves it.
 
-Per-tenant storage isolation. In multi-tenant mode the bridge
-instantiates one `DiscussionContextStore` per resolved tenant, each
-under storage prefix `tenants/{tenant_id}/`; existing record keys
-(`channel:discussion_id`) and libstorage are unchanged. In
-single-tenant mode the bridge uses one store with no tenant prefix —
-self-hosted data files are read in place without migration.
+Per-tenant storage isolation lands in `services/bridge` (reached via the
+`DiscussionAdapter` over gRPC). Multi-tenant mode scopes every record by
+the resolved `tenant_id` — per-id keys gain a `{tenant_id}:` prefix and the
+cross-record RPCs (correlation lookup, recess list, inbox drain, sweep)
+filter by tenant, so no list/aggregate response crosses tenants. Single-
+tenant mode adds no prefix or filter, leaving keys and JSONL unchanged.
 
 ## Tenant registry
 
@@ -132,16 +136,11 @@ self-hosted data files are read in place without migration.
 | `state` | `pending_consent` \| `active` \| `revoked`. Only `active` tenants resolve. |
 
 Per-tenant callback verification reuses the inherited 1230 single-use
-token. The dispatcher registers the token bound to `(correlation_id,
-tenant_id)` and the URL is `/callback/{tenant_id}/{token}`; the
-bridge consumes the token and rejects if the URL's tenant id does not
-match the token's. No new cryptographic primitive.
-
-Substrate: libindex JSONL initially. Callback verification holds no
-per-tenant key/secret material; the verification state is the
-`(correlation_id, tenant_id)` binding the bridge's existing
-`CallbackRegistry` records at token registration. Production
-hardening of the registry substrate is deferred.
+token: the dispatcher registers it bound to `(correlation_id,
+tenant_id)`, the URL is `/callback/{tenant_id}/{token}`, and the bridge
+rejects on consume if the URL's tenant id mismatches — the verification
+state is the existing `CallbackRegistry` binding. Production hardening of
+the registry substrate is deferred.
 
 ## Onboarding
 
@@ -150,17 +149,15 @@ Hosted-mode onboarding is event-driven; self-hosted is configuration.
 | Trigger | Handler | Effect |
 |---|---|---|
 | GitHub App `installation` webhook (`created` / `repositories_added`) | GitHub install handler in `ghbridge` | One `state = active` row per `(installation_id, repo)` pair in the event's repository set. No mapping step — the installation event already names the repos the App may act on. |
-| Bot Framework `installationUpdate` activity (`action=add`) | Teams consent handler in `msbridge` | One `state = pending_consent` row keyed by Microsoft `tenantId`. The customer self-serves the repo mapping via a hosted onboarding endpoint; the Forward Impact operator takes no action between consent and mapping. |
+| Bot Framework `installationUpdate` activity (`action=add`) | Teams consent handler in `msbridge` | One `state = pending_consent` row keyed by Microsoft `tenantId`. The customer self-serves the repo mapping via a hosted onboarding endpoint; the operator takes no action between consent and mapping. |
 
 A `Tenant` in `pending_consent` does not resolve and `services/ghserver`
-does not mint tokens for it. Self-hosted mode is a deployment-time
-configuration: each bridge reads a multi-tenant flag from its config
-(name is a plan concern). Off → bridge returns the `default` tenant,
-`services/tenancy` and `services/ghserver` are not started, `msbridge`
-constructs a single-tenant Bot Framework authenticator from
-`MICROSOFT_APP_TENANT_ID`. On → the bridge resolves per request and
-`msbridge` constructs a multi-tenant authenticator that accepts JWTs
-from any `active` tenant.
+does not mint for it. Self-hosted mode is a deploy-time flag (name is a
+plan concern): off → bridge returns the `default` tenant; `tenancy`,
+`ghserver`, and `oidc` are not started (self-hosted workflows use
+`KATA_APP_PRIVATE_KEY` directly); `msbridge` builds a single-tenant Bot
+Framework authenticator from `MICROSOFT_APP_TENANT_ID`. On → the bridge
+resolves per request and `msbridge` accepts JWTs from any `active` tenant.
 
 ## Key decisions
 
@@ -169,32 +166,33 @@ from any `active` tenant.
 | GitHub App model | One Forward Impact-owned App, multi-installation | One App per customer | GitHub's App model is already multi-install. Per-customer Apps duplicate registration without changing the trust shape — the operator still holds whichever private key is in use. |
 | Azure AD app model | One multi-tenant Azure AD app | One per customer tenant | Bot Framework supports multi-tenant validation natively. Per-tenant apps would require operator action per onboard. |
 | App private key custody | Centralized in `services/ghserver` | (a) Each bridge holds the key in process; (b) the key lives in every customer repository's Actions secrets | (a) Duplicates the master credential across processes and forces every bridge to embed key-handling code. (b) Replicates the master credential across every customer's CI environment and is the disqualifying property the spec calls out — incompatible with public-App security. |
-| In-workflow authentication to ghserver | GitHub Actions OIDC | (a) A long-lived per-customer secret installed in repository Actions secrets; (b) bridge-issued tokens carried as `workflow_dispatch` inputs | (a) Reintroduces the customer-side long-lived credential the spec exists to eliminate. (b) Bridge-issued tokens cannot reach scheduled workflows (`kata-shift`, `kata-storyboard`) which have no upstream bridge, and a single dispatched token cannot survive a multi-hour run. OIDC reaches every workflow surface uniformly and supports mid-run re-mints. |
-| Workflow identity coverage | Every kata workflow on the hosted path uses the same `services/ghserver`-via-OIDC step | Only `kata-dispatch.yml` goes through the broker; scheduled workflows keep a customer-side secret | Mixed-model coverage leaves `KATA_APP_PRIVATE_KEY` in customer repositories and defeats the spec's master-credential criterion. One mechanism across all kata workflows is also one surface to audit. |
+| In-workflow authentication to the control plane | GitHub Actions OIDC (terminated at `services/oidc`) | (a) A long-lived per-customer secret installed in repository Actions secrets; (b) bridge-issued tokens carried as `workflow_dispatch` inputs | (a) Reintroduces the customer-side long-lived credential the spec exists to eliminate. (b) Bridge-issued tokens cannot reach scheduled workflows (`kata-shift`, `kata-storyboard`) which have no upstream bridge, and a single dispatched token cannot survive a multi-hour run. OIDC reaches every workflow surface uniformly and supports mid-run re-mints. |
+| Workflow identity coverage | Every kata workflow on the hosted path uses the same OIDC-to-`services/oidc` mint step | Only `kata-dispatch.yml` goes through the broker; scheduled workflows keep a customer-side secret | Mixed-model coverage leaves `KATA_APP_PRIVATE_KEY` in customer repositories and defeats the spec's master-credential criterion. One mechanism across all kata workflows is also one surface to audit. |
 | Hosted dispatch identity | `services/ghserver`-minted installation token | Per-user OAuth via `services/ghauth` | Per-user OAuth requires every dispatcher to complete a one-time link flow before they can post — incompatible with the spec's setup-floor reduction. `services/ghauth` remains the dispatch identity for self-hosted operators who want per-user attribution. |
 | Token scoping | Per-repo from OIDC claim / per-tenant `repo` row | Per-installation (broader scope) | Per-installation tokens can act on every repository the installation covers; per-repo tokens confine blast radius to the one repository named in the request and align with the OIDC claim used to authenticate the caller. |
 | Registry packaging | Standalone gRPC service (`services/tenancy`) | (a) Library inside `libbridge`; (b) table inside `services/ghbridge` shared via direct DB access | Two bridges (and the ghserver service) share one authoritative registry. A library forces every caller to embed the same persistence code. A table inside ghbridge couples msbridge and ghserver to ghbridge's lifecycle. |
 | Tenant resolver placement | Channel-agnostic interface in `libbridge`; channel-specific extraction in the calling bridge | Resolver lives entirely in `libbridge` and imports channel SDKs | Putting channel SDK imports in `libbridge` violates its existing "no channel SDKs" invariant. Keeping extraction in the bridge service preserves libbridge as channel-agnostic transport. |
-| Storage isolation | One `DiscussionContextStore` instance per resolved tenant, each with a `tenants/{tenant_id}/` storage prefix | (a) Modify `libstorage` to enforce prefixing for every caller; (b) one big shared store with tenant-keyed entries in a single JSONL | libstorage stays caller-injected and unchanged per its existing invariant. Per-tenant store instances keep the existing `channel:discussion_id` key shape and confine a bug at the bridge layer (a missing tenant-prefix tag) to that tenant only, instead of risking cross-tenant key collisions in a shared file. |
+| Storage isolation | Tenant-scope records inside `services/bridge` (the shared canonical store) by `tenant_id`, passed through the `DiscussionAdapter` over gRPC | (a) Per-tenant store instances inside each bridge process; (b) one shared unscoped store with tenant-keyed entries | (a) misplaces isolation in a process that holds no store — the bridges own only a gRPC client to `services/bridge`. Scoping at the store keeps one authoritative isolation point and leaves `libindex`/`libstorage` (used by `services/bridge`, not by the bridge processes) caller-injected and unchanged; (b) risks cross-tenant key collisions in a single file. |
 | Anthropic key path | Stays in customer's repo secrets; control plane has no access | Proxy through control plane | Proxying would put the key in the operator's blast radius. BYOK keeps the credential, the prompt, and the response on the customer's runner. |
 | Workflow execution | Customer's GitHub Actions runner via `workflow_dispatch` and scheduled triggers | Hosted runners managed by Forward Impact | Hosted execution would expand the trust surface to include every tool call and repo write the agents make. Dispatching into the customer's runner keeps execution in the customer's blast radius. |
 | Self-hosted code path | Same code, single-tenant mode flag | A separate self-hosted-only bridge | One code path, exercised in two configurations; avoids hosted/self-hosted behaviour drift. |
 | Trust model artifact | `TRUST.md` at repo root | Section in CLAUDE.md / README | A standalone document is linkable from external onboarding, the marketplace listing, and Teams app submission. |
-| Bot Framework credential custody | Held in `services/msbridge` process | Centralize in `services/ghserver` alongside the GitHub App key | The GitHub App key is consumed by every kata workflow (high-fanout); centralising it gives a uniform OIDC-mint path. The Bot Framework credential is only consumed by `msbridge` itself (no fanout), so the marginal blast-radius win from centralising it does not justify the new in-process boundary; Bot Framework custody hardening is a follow-on (see § Deferred). |
-| Callback authentication | Tenant-bind the inherited 1230 single-use token (registry stores `(correlation_id, tenant_id)` on register; bridge rejects on consume if the URL's tenant id mismatches the token's tenant id) | (a) Add a new signature primitive (HMAC or asymmetric) over the callback body per tenant; (b) shared secret across all tenants | (a) Introduces a primitive the spec did not authorize and adds new secret-management surface for no property gain — token-binding alone gives the cross-tenant rejection property the spec asks for. (b) A shared secret means a leak in any tenant's workflow logs compromises all tenants. |
-| Callback URL routing | Per-tenant URL path: `/callback/{tenant_id}/{token}` | One URL with tenant inferred from body | Path-level scoping rejects mis-addressed callbacks before body parsing and pairs cleanly with the token-bind-on-register approach above. |
-| `services/ghserver` customer-facing transport | Public HTTPS endpoint reached directly from GitHub Actions runners | Proxy OIDC mint requests through `services/ghbridge` | Scheduled runs (`kata-shift`, `kata-storyboard`) never call ghbridge; proxying their OIDC mints through it would expand ghbridge's attack surface and couple ghserver's availability to ghbridge's. A direct public endpoint keeps the mint path uniform. |
+| Bot Framework credential custody | Held in `services/msbridge` process | Centralize in `services/ghserver` alongside the GitHub App key | The GitHub App key is consumed by every kata workflow (high-fanout); centralising it gives a uniform OIDC-mint path. The Bot Framework credential is consumed only by `msbridge` (no fanout), so centralising it does not justify the new in-process boundary; its custody hardening is deferred (§ What this design does not cover). |
+| Callback authentication | Tenant-bind the inherited 1230 single-use token (registry stores `(correlation_id, tenant_id)` on register; bridge rejects on consume if the URL's tenant id mismatches the token's) | (a) Add a new signature primitive (HMAC or asymmetric) over the callback body per tenant; (b) shared secret across all tenants | (a) Introduces a primitive the spec did not authorize and adds new secret-management surface for no property gain — token-binding alone gives the cross-tenant rejection property. (b) A shared secret means a leak in any tenant's workflow logs compromises all tenants. |
+| Callback URL routing | Per-tenant URL path: `/callback/{tenant_id}/{token}` | One URL with tenant inferred from body | Path-level scoping rejects mis-addressed callbacks before body parsing and pairs cleanly with the token-bind-on-register approach. |
+| Public ingress for OIDC mint | Dedicated stateless front `services/oidc` that validates the OIDC token and delegates to `services/ghserver` over gRPC | (a) A public HTTPS endpoint on `services/ghserver` itself, alongside its control-plane gRPC; (b) proxy OIDC mint requests through `services/ghbridge` | (a) Would make one service expose two transports, against the one-transport-per-service convention every existing service follows (`services/CLAUDE.md` § Architecture), and put the key-custody process on the public internet. The protocol-front pattern (`services/oauth`→`services/ghauth`, `services/mcp`→backend gRPC) keeps the only publicly-listening process key-free and lets internal callers reach the provider directly over gRPC. (b) Scheduled runs never call ghbridge; proxying their mints through it would expand ghbridge's attack surface and couple ghserver's availability to ghbridge's. |
 
 ## What this design does not cover
 
 - Publish-time artefacts (marketplace listing, App icon, screenshots,
   Teams catalog metadata).
-- Concrete protobuf schemas for `services/tenancy` and `services/ghserver`.
-- Exact GitHub Actions OIDC claim-validation rules; the design
-  constraint is that the broker scopes minted tokens to the
-  OIDC-asserted repository.
+- Concrete protobuf schemas for `services/tenancy` and `services/ghserver`,
+  the `services/oidc` HTTP request/response shape, and its provider config.
+- Exact GitHub Actions OIDC claim-validation rules — `services/oidc` must
+  scope the minted token to the OIDC-asserted `repository`.
 - Rate limiting and DoS posture beyond per-tenant scoping.
 - KMS/HSM custody and rotation for the hosted App private key.
+- Custody hardening for the Bot Framework credential held in `services/msbridge`.
 - Replacement of libindex JSONL with a managed datastore.
 - Exact `TRUST.md` text (content is in scope, drafting is a plan concern).
 - Migration paths between self-hosted and hosted deployments.

--- a/specs/1270-kata-bridges-public-hosting/spec.md
+++ b/specs/1270-kata-bridges-public-hosting/spec.md
@@ -176,10 +176,11 @@ this repository:
   credentials to (a) every kata workflow named in § Proposal 2 and
   (b) the hosted bridges, without any customer-side long-lived
   credential. The capability is the single logical custody point for
-  the hosted App's signing material; the substrate that physically
-  stores that material (filesystem, KMS, HSM) is deferred — see
-  § Deferred. Mechanism, transport, packaging, and authentication
-  shape are design concerns.
+  the hosted App's signing material — even when realized as a custody
+  backend sitting behind a separate stateless protocol front; the
+  substrate that physically stores that material (filesystem, KMS, HSM)
+  is deferred — see § Deferred. Mechanism, transport, packaging, and
+  authentication shape are design concerns.
 - Updated workflow templates emitted by `kata-setup` for the hosted
   path, covering every kata workflow named in § Proposal 2, with no
   `KATA_APP_PRIVATE_KEY` secret reference in any kata workflow file
@@ -319,7 +320,7 @@ no PR:
 | No GitHub App private key is required in a hosted-path consuming repository. | The hosted-path setup flow does not ask the adopter to set `KATA_APP_PRIVATE_KEY` or any equivalent renaming; a hosted-path consuming repository's Actions-secrets listing contains no `KATA_APP_PRIVATE_KEY` entry. (Public identifiers like the App id are not credentials and are not constrained by this criterion. Microsoft App credentials are scoped to the hosted Teams operator, never to a consuming repository — see the hosted Teams onboarding criterion below.) |
 | The hosted App's signing material does not appear, by reference or by value, in customer workflow files or templates. | No hosted-path workflow template emitted by `kata-setup` carries the hosted App's private key by any path: no template references the secret by any name, and no template passes a private-key-bearing input (under any input name) to any action it invokes. The criterion holds against any renaming of the secret. |
 | Long-running kata workflows are not bounded by a single credential lifetime. | A `kata-dispatch.yml` run on the hosted path lasting at least 90 minutes — exceeding the 60-minute GitHub App installation-token cap, so the run necessarily crosses at least one credential boundary — completes end-to-end without operator intervention. |
-| The hosted control plane does not read the customer's Anthropic API key. | For every directory listed in § In scope as part of the hosted control plane (the bridges, the tenant registry, the workflow-identity capability, and the multi-tenancy code in `libraries/libbridge`), plus any sibling control-plane directory the design names: no `package.json` declares any `@anthropic-ai/*` package as a runtime dependency; no source file imports a module under `@anthropic-ai/*`; no source file reads an environment variable whose name matches `ANTHROPIC_*`. The same patterns pass against the hosted-path workflow templates emitted by `kata-setup` so the BYOK boundary is end-to-end. |
+| The hosted control plane does not read the customer's Anthropic API key. | For every directory listed in § In scope as part of the hosted control plane (the bridges, the tenant registry, the workflow-identity capability — both its credential-custody backend and any stateless protocol front it sits behind — and the multi-tenancy code in `libraries/libbridge`), plus any sibling control-plane directory the design names: no `package.json` declares any `@anthropic-ai/*` package as a runtime dependency; no source file imports a module under `@anthropic-ai/*`; no source file reads an environment variable whose name matches `ANTHROPIC_*`. The same patterns pass against the hosted-path workflow templates emitted by `kata-setup` so the BYOK boundary is end-to-end. |
 | Per-tenant state isolation across the hosted control plane. | On any control-plane surface that returns persisted state to a caller authenticated as tenant A — for both per-id reads and any aggregate/list endpoints — the response (HTTP status code plus body) carries no field, count, or other content derived from a record persisted on behalf of tenant B. The criterion is bounded to the wire-visible response (status + body); timing-side-channel indistinguishability is not in scope here. |
 | Per-tenant verification of callbacks from workflow runs. | A callback from a workflow run authenticated with material bound to tenant A but addressed to tenant B's resource is rejected: no reply is posted to any tenant B channel, and no state attributed to a tenant B thread changes as a result of the callback. |
 | Workflow-identity is scoped to the requesting repository. | An attempt by a customer workflow run on repository X to obtain credentials usable against repository Y is rejected by the workflow-identity capability and no credential for Y is produced. |


### PR DESCRIPTION
## Summary

Revises `design-a.md` for [spec 1270](specs/1270-kata-bridges-public-hosting/spec.md) (public hosting for the Kata Agent Team) and applies light, transport-agnostic polish to `spec.md`.

- **One-transport-per-service fix.** The prior design had a single `services/ghserver` listening on *two* transports (control-plane gRPC + a public HTTPS/OIDC endpoint), against the convention in `services/CLAUDE.md` § Architecture. Split into:
  - `services/ghserver` — pure-gRPC custody point for the public GitHub App private key; mints repo-scoped installation tokens.
  - `services/oidc` — stateless HTTP front that validates GitHub Actions OIDC and delegates minting to a provider over gRPC.
  - Mirrors the established `services/oauth`→`services/ghauth` and `services/mcp`→backend-gRPC protocol-front pattern, and keeps the key-custody process off the public internet.
- **Per-tenant storage isolation** relocated to `services/bridge` (the canonical store both bridges reach via the `DiscussionAdapter` over gRPC): per-id key prefixing **plus** tenant-filtered cross-record RPCs, so list/aggregate responses don't cross tenants (spec criterion).
- **spec.md** kept service-name-free: the workflow-identity capability is described as "single logical custody point … even when realized as a custody backend behind a stateless protocol front."

Scope: only the two 1270 files. The design passed a 3-reviewer kata-review panel (iterated to clean: zero Blocker/High; all consensus Medium findings addressed); 198 lines, under the 200-line limit.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_0111zx9tr8tsCNwXf64PfAdS

---
_Generated by [Claude Code](https://claude.ai/code/session_0111zx9tr8tsCNwXf64PfAdS)_