### PR TITLE
fix(libutil): authenticate git over HTTPS with Basic x-access-token

### DIFF
--- a/libraries/libutil/src/git-client.js
+++ b/libraries/libutil/src/git-client.js
@@ -144,11 +144,18 @@ export class GitClient {
   }
 
   async #runRaw(args, { cwd, allowFailure = false } = {}) {
-    // Authenticate over HTTPS by injecting a per-invocation bearer header via
-    // git's `-c` config (the standard token mechanism; `git -c http.extraHeader`
-    // must precede the subcommand). No-op when the client carries no token.
+    // Authenticate over HTTPS by injecting a per-invocation Basic auth header
+    // via git's `-c` config (the `-c http.extraHeader` must precede the
+    // subcommand). GitHub's git-over-HTTPS expects the token as the password in
+    // HTTP Basic auth (username `x-access-token`); a `bearer` scheme is rejected
+    // for PAT/OAuth tokens and only works for App installation tokens, so Basic
+    // is the broadly-compatible choice. No-op when the client carries no token.
     const fullArgs = this.#token
-      ? ["-c", `http.extraHeader=AUTHORIZATION: bearer ${this.#token}`, ...args]
+      ? [
+          "-c",
+          `http.extraHeader=Authorization: Basic ${Buffer.from(`x-access-token:${this.#token}`).toString("base64")}`,
+          ...args,
+        ]
       : args;
     const result = await this.#runtime.subprocess.run("git", fullArgs, {
       cwd,

--- a/libraries/libutil/test/git-client.test.js
+++ b/libraries/libutil/test/git-client.test.js
@@ -71,13 +71,14 @@ describe("GitClient", () => {
     );
   });
 
-  test("withAuth injects a bearer http.extraHeader before the subcommand", async () => {
+  test("withAuth injects a Basic x-access-token http.extraHeader before the subcommand", async () => {
     const { client, subprocess } = clientWith();
     await client.withAuth("secret").fetch("origin", undefined, { cwd: "/r" });
     const args = subprocess.calls.at(-1).args;
+    const expected = Buffer.from("x-access-token:secret").toString("base64");
     assert.deepStrictEqual(args.slice(0, 3), [
       "-c",
-      "http.extraHeader=AUTHORIZATION: bearer secret",
+      `http.extraHeader=Authorization: Basic ${expected}`,
       "fetch",
     ]);
   });


### PR DESCRIPTION
## Summary

- `GitClient` injected the auth token as `http.extraHeader=AUTHORIZATION: bearer <token>`. GitHub's git-over-HTTPS rejects the `bearer` scheme for PAT/OAuth tokens (only App installation tokens accept `bearer`), so authenticated `clone`/`fetch`/`push` fell through to a username prompt and failed with `could not read Username for 'https://github.com'`. This broke `fit-wiki init`/`pull` whenever the token resolves to a PAT/OAuth token.
- Switch to HTTP Basic auth with username `x-access-token` and the token as the password — GitHub's documented mechanism, compatible with PAT, OAuth, and App tokens alike. Since every `fit-*` CLI's authenticated git ops flow through this one method, the fix lands at the source.
- Verified end-to-end: a real wiki clone that failed under `bearer` now succeeds via `bunx fit-wiki init`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_018as3TUGyZgQcvkAVGUkxCj

---
_Generated by [Claude Code](https://claude.ai/code/session_018as3TUGyZgQcvkAVGUkxCj)_