### PR TITLE
docs(1271): reconcile spec/design with shipped clean-break storage

### DIFF
--- a/specs/1271-rename-ghauth-to-ghuser/design-a.md
+++ b/specs/1271-rename-ghauth-to-ghuser/design-a.md
@@ -41,31 +41,35 @@ flowchart TD
 | `scripts/check-ambient-deps.deny.json`, `bun.lock` | source/derived | deny key `services/ghauth/src/stores.js` → `services/ghuser/src/stores.js`; lockfile workspace entry regenerates on `bun install` |
 | Docs | source | `services/README.md` (regenerated via `bun run context:fix`), `services/ghuser/README.md`, and the three pages from spec criterion 9 — `getting-started/contributors`, `services/bridge-conversations`, `services/bridge-discussions` |
 
-## Storage-namespace migration
+## Storage-namespace clean break
 
-`server.js` calls `createStorage("ghauth")`, rooting durable state at
-`data/ghauth/`: `bindings.jsonl` (the `(surface, surface_user_id)` ↔ token
+> **Superseded during planning/implementation.** This section originally
+> specified a one-shot boot migration to preserve pre-rename bindings. The
+> shipped implementation ([PR #1296](https://github.com/forwardimpact/monorepo/pull/1296))
+> deliberately chose a **clean break** instead; this section now records what
+> shipped, and spec criterion 8 was reversed to match.
+
+`server.js` calls `createStorage("ghuser")`, rooting durable state at
+`data/ghuser/`: `bindings.jsonl` (the `(surface, surface_user_id)` ↔ token
 binding — durable), plus `flows.jsonl` and `grants.jsonl` (10-minute-TTL
-ephemera). Renaming the namespace to `data/ghuser/` would orphan existing
-bindings and force every linked user to re-link — which spec criterion 8
-forbids.
+ephemera). **Nothing reads the legacy `data/ghauth/` path** — there is no
+boot migration, no migration module, and no `migration.test.js`.
 
-**Mechanism: a one-shot, idempotent boot migration.** On start, if the
-`ghuser` binding store is empty/absent and a legacy `data/ghauth/bindings.jsonl`
-exists, the service relocates the binding records into the `ghuser` namespace
-before serving, then proceeds normally. The migration is guarded so a second
-boot is a no-op. `flows`/`grants` are **not** migrated: they self-expire within
-10 minutes, so at worst an auth dance in flight across the single deploy is
-restarted — never a re-link of an established binding. This keeps the
-fallback path bounded and removable, rather than a permanent dual-path read.
+**Consequence.** Bindings written under the pre-rename `data/ghauth/`
+namespace are abandoned; any deployment carrying live bindings loses them at
+cutover and those users must re-link. The ephemeral `flows`/`grants` records
+self-expire within 10 minutes, so at worst an auth dance in flight across the
+cutover is restarted. The clean break was preferred over a migration because
+it leaves no dual-path or fallback code to carry and remove later — the
+post-rename tree reads exactly one namespace.
 
 ## Key decisions
 
 | Decision | Chosen | Rejected | Why |
 |---|---|---|---|
 | Migration extent | One coordinated change: proto+name+package sources edited, codegen regenerated, all consumers updated together | Stage the rename (land an alias, migrate consumers later) | The libtype `ghauth` namespace and `GhauthClient` are generated; once the proto package renames they cease to exist, so there is no intermediate tree state that both builds and is half-renamed. A clean break in one change is the only consistent state. |
-| Binding continuity | One-shot boot migration of `bindings.jsonl` into the new namespace | (a) Permanent read-through fallback to `data/ghauth/`; (b) external ops `mv` only | (a) leaves dual-path code forever — violates clean-break. (b) is untestable from the repo, yet criterion 8 names a migration test; a boot migration is self-contained and verifiable. |
-| Ephemeral stores | Drop `flows`/`grants` at the rename (no migration) | Migrate all three stores | They carry 10-minute TTL records; migrating in-flight auth flows adds code for state that expires within one deploy window. Established bindings are the only continuity the spec requires. |
+| Binding continuity | **Clean break — abandon `data/ghauth/`, no migration** (decided during planning; reverses spec criterion 8) | (a) One-shot boot migration of `bindings.jsonl`; (b) permanent read-through fallback to `data/ghauth/` | Both (a) and (b) add storage-relocation code to carry and later remove for a one-time cutover. The clean break keeps the post-rename tree reading exactly one namespace; affected users re-link, which is acceptable for the current deployment footprint. |
+| Ephemeral stores | Not migrated — `flows`/`grants` left under the old namespace, abandoned with `bindings` | (moot once binding continuity is a clean break) | They carry 10-minute TTL records that self-expire; at worst an in-flight auth dance across cutover is restarted. |
 | Generated artifacts | Regenerate via `just codegen`; never hand-edit `generated/**` | Hand-patch generated files to the new names | Generated files are outputs of the proto + definitions pipeline; hand edits drift from the source and break the next regeneration. |
 | `oauth` provider binding | Move the `provider` default and `SERVICE_OAUTH_PROVIDER` value to `"ghuser"`; `oauth` keeps its name | Treat the `provider` string as a doc reference only | `createClient(config.provider)` resolves the backend definition **by that name**; leaving it `"ghauth"` would resolve a definition that no longer exists. It is a behaviour-bearing value, not prose. |
 | Config acceptance surface | Assert against tracked `.env.*.example` + `config/CLAUDE.md` | Assert against `config/config.json` | The runtime `config/config.json` is gitignored and regenerated at setup; only the documented entry and env examples are tracked and reviewable. |

--- a/specs/1271-rename-ghauth-to-ghuser/spec.md
+++ b/specs/1271-rename-ghauth-to-ghuser/spec.md
@@ -39,10 +39,20 @@ identifiers change. The rename touches the service itself, its published
 package identity, its configuration surface, its generated codegen artifacts,
 its live consumers, and its documentation.
 
-The rename is purely nominal: the OAuth authorization-code exchange, refresh,
-revoke, durable binding storage, and the `GetToken` link/re-auth result
-semantics established by spec 1320 are unchanged. A user who linked their
-GitHub identity before the rename is not forced to re-link after it.
+The rename is purely nominal in **behaviour**: the OAuth authorization-code
+exchange, refresh, revoke, durable binding storage mechanics, and the
+`GetToken` link/re-auth result semantics established by spec 1320 are
+unchanged.
+
+> **Storage is a clean break (decided during planning).** The durable
+> storage namespace moves from `data/ghauth/` to `data/ghuser/` with **no
+> read-back of the old path** — no boot migration. Bindings written under the
+> pre-rename namespace are abandoned, so a user who linked their GitHub
+> identity before the rename **must re-link** after it. Any deployment
+> carrying live `data/ghauth/` bindings loses them at cutover. This reverses
+> the originally-specified continuity guarantee (see § Success criteria #8)
+> and is recorded here to match what shipped in
+> [PR #1296](https://github.com/forwardimpact/monorepo/pull/1296).
 
 ## Scope
 
@@ -56,7 +66,7 @@ GitHub identity before the rename is not forced to re-link after it.
 | gRPC contract names | proto `package ghauth` → `ghuser`, `service Ghauth` → `Ghuser`, file `proto/ghauth.proto` → `proto/ghuser.proto` (RPCs and message shapes unchanged) |
 | Generated codegen | `generated/` artifacts for the service regenerate under the `ghuser` name; no `ghauth` codegen artifact remains |
 | Configuration | env vars `SERVICE_GHAUTH_*` → `SERVICE_GHUSER_*` (`_URL`, `_CLIENT_ID`, `_CLIENT_SECRET`, `_LINK_BASE_URL`) in `.env.*.example`, and the documented `init.services` entry in `config/CLAUDE.md` (service name + `svcghuser` package). The generated runtime `config/config.json` is gitignored and refreshed at setup time — not a tracked acceptance surface. |
-| Persisted storage path | the service storage namespace moves from `data/ghauth/` to `data/ghuser/`; bindings written before the rename must remain resolvable afterward — a real data move, not a nominal change (the migration mechanism is a design/plan concern) |
+| Persisted storage path | the service storage namespace moves from `data/ghauth/` to `data/ghuser/` as a **clean break** — `createStorage("ghuser")` roots state at `data/ghuser/` and nothing reads `data/ghauth/`. Pre-rename bindings are abandoned and affected users re-link; there is no migration (see Proposal and § Success criteria #8) |
 | Live consumers | `services/ghbridge`, `services/msbridge`, and `libraries/libbridge` (token-resolver) reference the renamed service/package/contract; `services/oauth`'s provider binding (its `provider` default value and `SERVICE_OAUTH_PROVIDER`, which resolve the backend client **by name**) moves from `ghauth` to `ghuser`. Consumer-side identifiers move with it — the generated client class (`GhauthClient` → `GhuserClient`) and local symbols (`ghauthClient`). |
 | Policy + lockfile | `scripts/check-ambient-deps.deny.json` (keyed on the service source path) and `bun.lock` (keyed on the package name) move to the renamed values |
 | Documentation | `services/README.md`, `services/ghuser/README.md`, and the `websites/fit/docs/` pages that name the service |
@@ -84,5 +94,5 @@ GitHub identity before the rename is not forced to re-link after it.
 | 5 | Configuration moved on tracked surfaces. | No `SERVICE_GHAUTH_*` key appears in any `.env.*.example` and the corresponding `SERVICE_GHUSER_*` keys are present; the documented `init.services` entry in `config/CLAUDE.md` names `ghuser` and `@forwardimpact/svcghuser` (the gitignored runtime `config/config.json` is refreshed at setup time and is not part of this check) |
 | 6 | Live consumers resolve the renamed service and stay green. | `services/ghbridge`, `services/msbridge`, `services/oauth`, and `libraries/libbridge` reference `ghuser`; `bun run check` and `bun run test` pass |
 | 7 | Behaviour is unchanged. | The migrated spec-1320 acceptance tests pass unchanged under `services/ghuser/test/` — `query-linked`, `query-unlinked`, `query-reauth`, `query-contract`, `persistence`, `identity-verification`, and `smoke` |
-| 8 | A pre-rename link survives. | A binding seeded under the pre-rename storage namespace (`data/ghauth/`) is resolvable via `GetToken` through the renamed service after a fresh start, with no re-link required — `services/ghuser/test/migration.test.js` |
+| 8 | Storage is a clean break — no migration. | `services/ghuser/server.js` calls `createStorage("ghuser")` and never reads `data/ghauth/`; there is no boot migration, no migration module, and no `services/ghuser/test/migration.test.js`. Pre-rename bindings are abandoned and affected users re-link. **(Reverses the original "a pre-rename link survives" criterion — see Proposal.)** |
 | 9 | Documentation names the renamed service. | `services/README.md`, `websites/fit/docs/getting-started/contributors/index.md`, `websites/fit/docs/services/bridge-conversations/index.md`, and `websites/fit/docs/services/bridge-discussions/index.md` reference `ghuser`; none reference `ghauth` |


### PR DESCRIPTION
Follow-up to [#1296](https://github.com/forwardimpact/monorepo/pull/1296) (spec 1271, `ghauth` → `ghuser` rename).

## Why

The rename shipped with a **clean-break** storage move — `createStorage("ghuser")` roots state at `data/ghuser/` with no read-back of `data/ghauth/`, no boot migration, and no `migration.test.js`. Pre-rename bindings are abandoned and affected users re-link.

But spec 1271 and design 1271-a still described the **originally-planned boot migration** that preserved pre-rename links. The merged records therefore contradicted the shipped behaviour — a reader would expect link continuity and a `migration.test.js` that don't exist. This reconciles the documents with reality (the gap the plan's "Reconciliation required" note flagged as out-of-lane).

## Changes (documentation only)

**`spec.md`**
- Proposal: states the clean break and its cutover consequence (any deployment with live `data/ghauth/` bindings loses them; users re-link).
- "Persisted storage path" scope row: rewritten to the clean break.
- Success criterion 8: reversed from *"a pre-rename link survives"* to *"storage is a clean break — no migration"*, with a verification that matches the shipped `server.js`.

**`design-a.md`**
- "Storage-namespace migration" → "Storage-namespace clean break", recording what shipped and why a migration was rejected.
- "Binding continuity" and "Ephemeral stores" decision rows updated to reflect the clean break as the chosen option.

No code or behaviour change. The `ghauth` strings that remain in these files are historical references inside the spec/design narrative and are excluded from the criterion-2 sweep by design (`-g '!specs/**'`).

https://claude.ai/code/session_015XKV6fbQgBDdoLapB1yHi4

---
_Generated by [Claude Code](https://claude.ai/code/session_015XKV6fbQgBDdoLapB1yHi4)_