### PR TITLE
docs(kata): clarify clean-break guidance, remove softening qualifiers

### DIFF
--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -43,7 +43,6 @@ is no commitment to implement, and a design has nothing to shape.
 - [ ] One design per spec — do not bundle multiple specs into one design.
 - [ ] Read the spec end-to-end before writing. Restate problem, scope, and
       success criteria without referring back.
-- [ ] Default to a clean break — compat only when the spec required it.
 
 </read_do_checklist>
 
@@ -102,8 +101,10 @@ interfaces connect them — and why this architecture over alternatives.
   flow, state machines, sequence diagrams.
 - **Scope-faithful.** Stay within the spec's scope. If scope should change,
   return the spec to draft rather than expanding silently.
-- **Clean break by default.** Honor [§ Clean breaks](../../../CONTRIBUTING.md#read-do)
-  — design without compat unless the spec required it; return spec to `draft` if unsafe.
+- **Clean break.** Follow [§ Clean breaks](../../../CONTRIBUTING.md#read-do): the
+  design replaces the old path, never wraps it in shims or fallbacks. Compat
+  belongs in the design only when the spec names it as a requirement; if a clean
+  break can't meet the spec, return the spec to `draft` rather than designing around it.
 
 **Form follows content.** Prefer tables for lists with shared structure
 (components, decisions). Prefer bullets for flat facts. Use prose only for the

--- a/.claude/skills/kata-plan/SKILL.md
+++ b/.claude/skills/kata-plan/SKILL.md
@@ -41,7 +41,6 @@ there is no architectural direction to translate into implementation steps.
 - [ ] Read the spec and design end-to-end before writing. Restate problem,
       scope, success criteria, and architectural direction without referring
       back.
-- [ ] Default to a clean break — compat only when design (and spec) required it.
 
 </read_do_checklist>
 
@@ -98,8 +97,10 @@ The plan translates an approved design into concrete implementation steps.
 - **Execution recommendation.** Route parts to the most suitable agent —
   engineering agents for code, `technical-writer` for docs. For decomposed plans,
   state which parts can run in parallel vs sequentially.
-- **Clean break by default.** Honor [§ Clean breaks](../../../CONTRIBUTING.md#read-do)
-  — plan without compat unless design (and spec) required it; revise design if unsafe.
+- **Clean break.** Follow [§ Clean breaks](../../../CONTRIBUTING.md#read-do): the
+  plan replaces the old path, never wraps it in shims or fallbacks. Compat
+  belongs in the plan only when the design names it as a requirement; if a clean
+  break can't meet the design, revise the design rather than planning around it.
 
 **Form follows content.** Prefer tables for shared-structure lists, bullets for
 flat facts, prose only for narrative connecting them. If a paragraph could be a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ Entry gate — read every item before starting.
       try/catch "just to be safe," no optional chaining on data that isn't
       optional.
 - [ ] **Clean breaks.** Delete old code as you write new — in one commit. No
-      shims, aliases, or flags for the old path. With no consumers yet, remove
-      the old interface entirely.
+      shims, aliases, fallbacks, or flags for the old path; update every call
+      site and remove the old interface.
 
 </read_do_checklist>
 


### PR DESCRIPTION
## Summary

The clean-break policy was stated three ways: an absolute rule in `CONTRIBUTING.md` and softened restatements in `kata-design` and `kata-plan` (*"default to a clean break"*, *"compat only when … required it"*). The *default* / *unless required* framing read as a weighable preference, inviting the very compat layers, fallbacks, and shims it was meant to forbid — and restating it per skill let the wordings drift, violating "one home per policy."

- **CONTRIBUTING.md** — name *fallbacks* explicitly; replace the misreadable *"with no consumers yet"* conditional with an unconditional action.
- **kata-design / kata-plan** — drop the duplicated read-do restatement (the only doubly-stated checklist item), keeping one § Writing statement that defers to the canonical rule and gates compat on the spec/design *explicitly naming it a requirement*.

Net: fewer instructions, one home per policy, no softening qualifiers.

## Test plan

- [x] `bun run check` — instructions word-budget and per-item caps pass for all three edited files (one unrelated pre-existing `wiki/staff-engineer.md` summary-budget failure, untouched by this change)
- [ ] `bun run test`

https://claude.ai/code/session_0186AjXikSRoNhz4NuZXsTX3

---
_Generated by [Claude Code](https://claude.ai/code/session_0186AjXikSRoNhz4NuZXsTX3)_