### PR TITLE
feat(libwiki): make `fit-wiki fix` verify the audit and converge

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -45,6 +45,28 @@ git push origin main && git push origin v1 --force
 `GITHUB_TOKEN` in this environment has push rights to every sibling repo
 under `forwardimpact/*`; no extra auth setup is needed.
 
+### `IS_SANDBOX` for headless agents
+
+Every published action that drives the Claude Agent SDK runs it in
+**bypass-permissions** mode (`--dangerously-skip-permissions`), which Claude
+Code refuses under `uid 0` unless the process is marked sandboxed. CI runners
+and agent containers may run as root, so each such action sets `IS_SANDBOX=1`
+on the step that spawns the agent:
+
+- `fit-eval` — the `Run fit-eval` step (all modes).
+- `fit-benchmark` — the `Run benchmark` step (the agent-under-test).
+- `fit-wiki` — the `Run fit-wiki command` step (`fit-wiki fix` is an agent run).
+- `kata-agent` — the `Assess and Act` step, explicit alongside the `fit-eval@v1`
+  it wraps.
+
+(`fit-bootstrap` spawns no agent and needs nothing.) The SDK forwards the
+parent process environment to the spawned Claude Code process, so setting it on
+the action's environment is sufficient; this is deliberately **not** hard-coded
+in `libeval` so the value stays an environment decision. Without it the agent
+exits 1 with no NDJSON output before its first turn — the same failure mode any
+`fit-eval`-derived command (e.g. `fit-wiki fix`) hits when run as root in an
+environment that has not set the flag.
+
 ## Local composite actions
 
 Live under `actions/`. Workflows reference them via the full workspace path

--- a/libraries/libwiki/src/commands/fix.js
+++ b/libraries/libwiki/src/commands/fix.js
@@ -11,56 +11,133 @@ import { buildContext, resolveScope } from "../audit/scopes.js";
 import { currentDayIso } from "../util/clock.js";
 import { resolveProjectRoot } from "../util/wiki-dir.js";
 
+// The agent edits, we re-audit, and resume on whatever still fails. Cap the
+// rounds so a finding the agent cannot resolve (e.g. a budget needing
+// `fit-wiki rotate`, which it has no Bash to run) fails loudly, not forever.
+const MAX_ROUNDS = 3;
+
+/**
+ * Every rule governing a scope with an open finding, as `id — hint` lines.
+ * Handing the agent the full contract for the files it edits — not just the
+ * failing rules — stops it fixing one finding by breaking another (dropping
+ * the `**Last run**:` line, appending a section after `## Open Blockers`, …).
+ */
+function invariantContract(findings) {
+  const scopes = new Set(
+    findings.map((f) => RULES.find((r) => r.id === f.id)?.scope),
+  );
+  return RULES.filter((r) => scopes.has(r.scope) && r.hint).map(
+    (r) => `- ${r.id} — ${r.hint}`,
+  );
+}
+
+/**
+ * The opening task: the findings, the invariant contract, and the two things
+ * the rule hints don't cover — where trimmed history goes, and to prefer a
+ * single Write.
+ */
+function composeTask(findings, wikiRoot, projectRoot) {
+  return [
+    `Fix these wiki audit findings by editing files under ${wikiRoot}.`,
+    ``,
+    emitFindingsText(findings, { cwd: projectRoot }),
+    ``,
+    `All of these invariants must hold when you finish — never fix one finding`,
+    `by breaking another:`,
+    ...invariantContract(findings),
+    ``,
+    `Move history out of an over-budget summary into the agent's weekly-log`,
+    `file (wiki/<agent>-YYYY-Www.md), never a new summary section. Prefer a`,
+    `single Write over many Edits.`,
+  ].join("\n");
+}
+
+/** The resume task: the findings that survived the last edit. */
+function composeFollowup(findings, projectRoot) {
+  return [
+    `The wiki still fails the audit. Remaining findings:`,
+    ``,
+    emitFindingsText(findings, { cwd: projectRoot }),
+    ``,
+    `Fix every one without breaking any invariant listed earlier.`,
+  ].join("\n");
+}
+
+/**
+ * Surface a round's agent error, if any. Returns true when it is fatal: a
+ * missing sessionId means the process never started (e.g. the SDK refused
+ * bypass-permissions as root), so there is nothing to resume. A turn-limit or
+ * transient error keeps its session and may have made partial progress, so it
+ * is noted but not fatal — the re-audit decides.
+ */
+function isFatalError(result, round, err) {
+  if (!result.error) return false;
+  if (!result.sessionId) {
+    err(`fit-wiki fix: agent run failed: ${result.error.message}\n`);
+    return true;
+  }
+  err(`fit-wiki fix: round ${round} agent error: ${result.error.message}\n`);
+  return false;
+}
+
 /** Run the wiki audit and auto-fix findings via a Haiku-powered AgentRunner. */
 export async function runFixCommand(ctx) {
   const { runtime } = ctx.deps;
-  const options = ctx.options;
   const projectRoot = resolveProjectRoot(runtime);
-  const wikiRoot = options["wiki-root"] || path.join(projectRoot, "wiki");
-  const today = options.today || currentDayIso(runtime);
+  const wikiRoot = ctx.options["wiki-root"] || path.join(projectRoot, "wiki");
+  const today = ctx.options.today || currentDayIso(runtime);
+  const out = (s) => runtime.proc.stdout.write(s);
+  const err = (s) => runtime.proc.stderr.write(s);
 
-  const auditCtx = buildContext({ wikiRoot, today, fs: runtime.fsSync });
-  const findings = runRules(RULES, auditCtx, { resolveScope });
+  // The agent's edits change the result, so re-read and re-audit each round.
+  const audit = () =>
+    runRules(RULES, buildContext({ wikiRoot, today, fs: runtime.fsSync }), {
+      resolveScope,
+    });
 
+  let findings = audit();
   if (findings.length === 0) {
-    runtime.proc.stdout.write("nothing to fix\n");
+    out("nothing to fix\n");
     return { ok: true };
   }
 
-  const auditText = emitFindingsText(findings, { cwd: projectRoot });
-  const redactor = createRedactor();
-  const devNull = new Writable({
-    write(_c, _e, cb) {
-      cb();
-    },
-  });
-
-  const systemPrompt = composeProfilePrompt("technical-writer", {
-    profilesDir: path.resolve(projectRoot, ".claude/agents"),
-  });
-
-  const { query } = await import("@anthropic-ai/claude-agent-sdk");
-
+  const query =
+    ctx.deps.query ?? (await import("@anthropic-ai/claude-agent-sdk")).query;
   const runner = createAgentRunner({
     cwd: projectRoot,
     query,
-    output: devNull,
+    output: new Writable({ write: (_c, _e, cb) => cb() }),
     model: "claude-haiku-4-5-20251001",
-    maxTurns: 15,
+    maxTurns: 30,
     allowedTools: ["Read", "Write", "Edit"],
     settingSources: ["project"],
-    systemPrompt,
-    redactor,
+    systemPrompt: composeProfilePrompt("technical-writer", {
+      profilesDir: path.resolve(projectRoot, ".claude/agents"),
+    }),
+    redactor: createRedactor(),
   });
 
-  const task = [
-    `Fix these wiki audit findings.`,
-    `The wiki root is ${wikiRoot}.`,
-    ``,
-    auditText,
-  ].join("\n");
+  // The audit is the verdict, not the agent's self-report: run, re-audit, and
+  // resume the session on whatever still fails until clean or out of rounds.
+  // Resuming also extends the turn budget for a trim too large for one round.
+  let task = composeTask(findings, wikiRoot, projectRoot);
+  for (let round = 0; round < MAX_ROUNDS; round++) {
+    const result =
+      round === 0 ? await runner.run(task) : await runner.resume(task);
+    if (result.text) out(result.text + "\n");
+    if (isFatalError(result, round, err)) return { ok: false, code: 1 };
 
-  const result = await runner.run(task);
-  if (result.text) runtime.proc.stdout.write(result.text + "\n");
-  return { ok: result.success, code: result.success ? 0 : 1 };
+    findings = audit();
+    if (findings.length === 0) {
+      out("fixed: wiki audit is clean\n");
+      return { ok: true, code: 0 };
+    }
+    task = composeFollowup(findings, projectRoot);
+  }
+
+  err(
+    `fit-wiki fix: ${findings.length} finding(s) remain after ${MAX_ROUNDS} round(s):\n` +
+      emitFindingsText(findings, { cwd: projectRoot }),
+  );
+  return { ok: false, code: 1 };
 }

--- a/libraries/libwiki/test/cli-fix.test.js
+++ b/libraries/libwiki/test/cli-fix.test.js
@@ -1,6 +1,12 @@
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -38,6 +44,85 @@ function seedCleanWiki(wikiRoot) {
   );
 }
 
+// Minimal technical-writer profile so composeProfilePrompt can read it.
+function seedAgentProfile(projectRoot) {
+  const agentsDir = join(projectRoot, ".claude", "agents");
+  mkdirSync(agentsDir, { recursive: true });
+  writeFileSync(
+    join(agentsDir, "technical-writer.md"),
+    "---\nname: technical-writer\n---\nYou are the technical writer.\n",
+  );
+}
+
+const summary = (lines) => lines.join("\n") + "\n";
+
+// A summary missing the **Last run** line fails exactly summary.last-run-marker.
+const MISSING_LAST_RUN = summary([
+  "# Staff Engineer — Summary",
+  "",
+  "## Message Inbox",
+  "",
+  "<!-- memo:inbox -->",
+  "",
+  "## Open Blockers",
+  "",
+  "- none",
+]);
+
+// Adds the Last run line but appends a section after Open Blockers — trades the
+// first violation for summary.open-blockers-last.
+const SECTION_AFTER_BLOCKERS = summary([
+  "# Staff Engineer — Summary",
+  "",
+  "**Last run**: 2026-05-24 — settled.",
+  "",
+  "## Message Inbox",
+  "",
+  "<!-- memo:inbox -->",
+  "",
+  "## Open Blockers",
+  "",
+  "- none",
+  "",
+  "## History",
+  "",
+  "- old",
+]);
+
+// Satisfies every summary invariant.
+const VALID_SUMMARY = summary([
+  "# Staff Engineer — Summary",
+  "",
+  "**Last run**: 2026-05-24 — settled state only.",
+  "",
+  "## Message Inbox",
+  "",
+  "<!-- memo:inbox -->",
+  "",
+  "## Open Blockers",
+  "",
+  "- none",
+]);
+
+/**
+ * A mock SDK `query` that writes `versions[n]` to the summary on its n-th call
+ * (clamped to the last version) and reports success. Records each call's
+ * `resume` option so tests can assert run-vs-resume.
+ */
+function scriptedQuery(summaryPath, versions, calls) {
+  return async function* ({ options }) {
+    calls.push({ resume: options.resume ?? null });
+    const v = versions[Math.min(calls.length - 1, versions.length - 1)];
+    writeFileSync(summaryPath, v);
+    yield { type: "system", subtype: "init", session_id: "sess-fix" };
+    yield {
+      type: "result",
+      subtype: "success",
+      result: `round ${calls.length}`,
+    };
+  };
+}
+
 describe("fit-wiki fix CLI (in-process)", () => {
   let dir;
   let wikiRoot;
@@ -58,5 +143,108 @@ describe("fit-wiki fix CLI (in-process)", () => {
     );
     assert.deepEqual(result, { ok: true });
     assert.match(harness.stdout, /nothing to fix/);
+  });
+
+  test("re-audits and resumes the agent until the audit is clean", async () => {
+    seedCleanWiki(wikiRoot);
+    seedAgentProfile(dir);
+    const summaryPath = join(wikiRoot, "staff-engineer.md");
+    writeFileSync(summaryPath, MISSING_LAST_RUN);
+
+    // First edit only trades one violation for another; the resume fixes it.
+    const calls = [];
+    const query = scriptedQuery(
+      summaryPath,
+      [SECTION_AFTER_BLOCKERS, VALID_SUMMARY],
+      calls,
+    );
+    const harness = makeRuntime({ cwd: dir });
+
+    const result = await runFixCommand(
+      ctxFor({
+        runtime: harness.runtime,
+        query,
+        options: { today: "2026-05-24" },
+      }),
+    );
+
+    assert.equal(result.ok, true);
+    assert.match(harness.stdout, /fixed: wiki audit is clean/);
+    assert.equal(calls.length, 2, "should run once then resume once");
+    assert.equal(calls[0].resume, null, "first call is a fresh run");
+    assert.equal(
+      calls[1].resume,
+      "sess-fix",
+      "second call resumes the session",
+    );
+    assert.equal(readFileSync(summaryPath, "utf8"), VALID_SUMMARY);
+  });
+
+  test("fails with the remaining findings when the agent cannot converge", async () => {
+    seedCleanWiki(wikiRoot);
+    seedAgentProfile(dir);
+    const summaryPath = join(wikiRoot, "staff-engineer.md");
+    writeFileSync(summaryPath, MISSING_LAST_RUN);
+
+    // The agent never fixes the file, so the audit keeps failing.
+    const calls = [];
+    const query = scriptedQuery(summaryPath, [MISSING_LAST_RUN], calls);
+    const harness = makeRuntime({ cwd: dir });
+
+    const result = await runFixCommand(
+      ctxFor({
+        runtime: harness.runtime,
+        query,
+        options: { today: "2026-05-24" },
+      }),
+    );
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 1);
+    assert.match(harness.stderr, /finding\(s\) remain after 3 round\(s\)/);
+    assert.match(harness.stderr, /summary\.last-run-marker/);
+    assert.equal(
+      calls.length,
+      3,
+      "one run plus two resumes, capped at MAX_ROUNDS",
+    );
+  });
+
+  test("surfaces the error and bails when the agent process never starts", async () => {
+    seedCleanWiki(wikiRoot);
+    seedAgentProfile(dir);
+    const summaryPath = join(wikiRoot, "staff-engineer.md");
+    writeFileSync(summaryPath, MISSING_LAST_RUN);
+
+    // An iterator that rejects on the first step with no prior event → no
+    // sessionId, mimicking the SDK failing to launch (e.g. the root guard
+    // rejecting --dangerously-skip-permissions: it exits before any NDJSON).
+    const calls = [];
+    const query = () => {
+      calls.push(1);
+      return {
+        [Symbol.asyncIterator]: () => ({
+          next: () =>
+            Promise.reject(new Error("Claude Code process exited with code 1")),
+        }),
+      };
+    };
+    const harness = makeRuntime({ cwd: dir });
+
+    const result = await runFixCommand(
+      ctxFor({
+        runtime: harness.runtime,
+        query,
+        options: { today: "2026-05-24" },
+      }),
+    );
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 1);
+    assert.match(
+      harness.stderr,
+      /agent run failed: Claude Code process exited with code 1/,
+    );
+    assert.equal(calls.length, 1, "no resume after a launch failure");
   });
 });

--- a/libraries/libwiki/test/helpers.js
+++ b/libraries/libwiki/test/helpers.js
@@ -65,17 +65,18 @@ export function makeRuntime({ cwd = process.cwd(), env = {}, now } = {}) {
 /**
  * Assemble an `InvocationContext`-shaped object for invoking a command handler
  * directly in-process (without going through `cli.dispatch`).
- * @param {{runtime: object, wikiSync?: object, gitClient?: object, options?: object, args?: object}} parts
+ * @param {{runtime: object, wikiSync?: object, gitClient?: object, query?: function, options?: object, args?: object}} parts
  * @returns {object}
  */
 export function ctxFor({
   runtime,
   wikiSync,
   gitClient,
+  query,
   options = {},
   args = {},
 }) {
-  return { deps: { runtime, wikiSync, gitClient }, options, args };
+  return { deps: { runtime, wikiSync, gitClient, query }, options, args };
 }
 
 /** Run a git command in the given directory and return its trimmed stdout. */


### PR DESCRIPTION
## Summary

- `fit-wiki fix` reported success from the agent's self-declared completion, so it could trade one audit violation for another (drop the `**Last run**:` line, append a section after `## Open Blockers`) and still exit 0 — and it swallowed agent errors, exiting 1 with no output when the run failed to launch.
- The **audit is now the verdict**: run the technical-writer agent, re-audit, and resume the session on whatever still fails until clean or out of rounds (capped at 3, which also extends the turn budget for a large trim).
- The agent is handed the **full invariant contract** for the files it edits, so it stops fixing one finding by breaking another; a launch failure (no session) is surfaced instead of swallowed; `query` is injectable for tests.
- The orchestration is a single run/resume loop with small prompt/error helpers.
- The agent runs in bypass-permissions mode, which Claude Code refuses under `uid 0` unless `IS_SANDBOX=1`; that stays an **environment decision** — set on the published fit-eval/kata-agent/fit-benchmark/fit-wiki actions and documented in `.github/CLAUDE.md` — not hard-coded in libeval.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPE4GGs1cCPLVQqxZ7JnTZ)_