### PR TITLE
refactor(services): standardize HTTP services on new libhttp library

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,12 +20,11 @@
     },
     "libraries/libbridge": {
       "name": "@forwardimpact/libbridge",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
+        "@forwardimpact/libhttp": "^0.1.0",
         "@forwardimpact/libtype": "^0.1.0",
         "@forwardimpact/libutil": "^0.1.84",
-        "@hono/node-server": "^2.0.4",
-        "hono": "^4.12.23",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -33,14 +32,14 @@
     },
     "libraries/libcli": {
       "name": "@forwardimpact/libcli",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
       },
     },
     "libraries/libcoaligned": {
       "name": "@forwardimpact/libcoaligned",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "bin": {
         "coaligned": "./bin/coaligned.js",
       },
@@ -53,7 +52,7 @@
     },
     "libraries/libcodegen": {
       "name": "@forwardimpact/libcodegen",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "bin": {
         "fit-codegen": "./bin/fit-codegen.js",
       },
@@ -74,7 +73,7 @@
     },
     "libraries/libconfig": {
       "name": "@forwardimpact/libconfig",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "dependencies": {
         "@forwardimpact/libsecret": "^0.1.15",
         "@forwardimpact/libstorage": "^0.1.53",
@@ -86,7 +85,7 @@
     },
     "libraries/libdoc": {
       "name": "@forwardimpact/libdoc",
-      "version": "0.2.33",
+      "version": "0.2.34",
       "bin": {
         "fit-doc": "./bin/fit-doc.js",
       },
@@ -112,7 +111,7 @@
     },
     "libraries/libeval": {
       "name": "@forwardimpact/libeval",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "bin": {
         "fit-eval": "./bin/fit-eval.js",
         "fit-trace": "./bin/fit-trace.js",
@@ -169,9 +168,20 @@
         "@forwardimpact/libutil": "^0.1.60",
       },
     },
+    "libraries/libhttp": {
+      "name": "@forwardimpact/libhttp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@hono/node-server": "^2.0.4",
+        "hono": "^4.12.23",
+      },
+      "devDependencies": {
+        "@forwardimpact/libmock": "^0.1.0",
+      },
+    },
     "libraries/libindex": {
       "name": "@forwardimpact/libindex",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
         "@forwardimpact/libtype": "^0.1.63",
         "@forwardimpact/libutil": "^0.1.84",
@@ -182,7 +192,7 @@
     },
     "libraries/libmacos": {
       "name": "@forwardimpact/libmacos",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.60",
       },
@@ -210,7 +220,7 @@
     },
     "libraries/libpack": {
       "name": "@forwardimpact/libpack",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.84",
       },
@@ -234,7 +244,7 @@
     },
     "libraries/libprompt": {
       "name": "@forwardimpact/libprompt",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.84",
         "mustache": "^4.2.0",
@@ -246,7 +256,7 @@
     },
     "libraries/librc": {
       "name": "@forwardimpact/librc",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "bin": {
         "fit-rc": "./bin/fit-rc.js",
       },
@@ -300,7 +310,7 @@
     },
     "libraries/librpc": {
       "name": "@forwardimpact/librpc",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "bin": {
         "fit-unary": "./bin/fit-unary.js",
       },
@@ -318,7 +328,7 @@
     },
     "libraries/libsecret": {
       "name": "@forwardimpact/libsecret",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.60",
       },
@@ -338,7 +348,7 @@
     },
     "libraries/libstorage": {
       "name": "@forwardimpact/libstorage",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "bin": {
         "fit-storage": "./bin/fit-storage.js",
       },
@@ -367,6 +377,7 @@
         "@forwardimpact/libcli": "^0.1.0",
         "@forwardimpact/libpreflight": "^0.1.0",
         "@forwardimpact/libtelemetry": "^0.1.22",
+        "@forwardimpact/libutil": "^0.1.0",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -374,7 +385,7 @@
     },
     "libraries/libsyntheticgen": {
       "name": "@forwardimpact/libsyntheticgen",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.61",
         "seedrandom": "^3.0.5",
@@ -390,7 +401,7 @@
     },
     "libraries/libsyntheticprose": {
       "name": "@forwardimpact/libsyntheticprose",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
         "@forwardimpact/libprompt": "^0.1.0",
         "@forwardimpact/libsyntheticgen": "^0.1.21",
@@ -406,7 +417,7 @@
     },
     "libraries/libsyntheticrender": {
       "name": "@forwardimpact/libsyntheticrender",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
         "@forwardimpact/libsyntheticgen": "^0.1.0",
         "@forwardimpact/libtemplate": "^0.2.0",
@@ -426,7 +437,7 @@
     },
     "libraries/libtelemetry": {
       "name": "@forwardimpact/libtelemetry",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "bin": {
         "fit-visualize": "./bin/fit-visualize.js",
       },
@@ -446,7 +457,7 @@
     },
     "libraries/libtemplate": {
       "name": "@forwardimpact/libtemplate",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.84",
         "mustache": "^4.2.0",
@@ -454,7 +465,7 @@
     },
     "libraries/libterrain": {
       "name": "@forwardimpact/libterrain",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "bin": {
         "fit-terrain": "./bin/fit-terrain.js",
       },
@@ -497,14 +508,14 @@
     },
     "libraries/libui": {
       "name": "@forwardimpact/libui",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "devDependencies": {
         "happy-dom": "^20.9.0",
       },
     },
     "libraries/libutil": {
       "name": "@forwardimpact/libutil",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "bin": {
         "fit-download-bundle": "./bin/fit-download-bundle.js",
         "fit-tiktoken": "./bin/fit-tiktoken.js",
@@ -545,7 +556,7 @@
     },
     "libraries/libwiki": {
       "name": "@forwardimpact/libwiki",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "bin": {
         "fit-wiki": "./bin/fit-wiki.js",
       },
@@ -563,7 +574,7 @@
     },
     "libraries/libxmr": {
       "name": "@forwardimpact/libxmr",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "bin": {
         "fit-xmr": "./bin/fit-xmr.js",
       },
@@ -604,7 +615,7 @@
     },
     "products/guide": {
       "name": "@forwardimpact/guide",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "bin": {
         "fit-guide": "./bin/fit-guide.js",
       },
@@ -698,6 +709,7 @@
         "@forwardimpact/libmacos": "^0.1.0",
         "@forwardimpact/libpreflight": "^0.1.0",
         "@forwardimpact/libtelemetry": "^0.1.33",
+        "@forwardimpact/libutil": "^0.1.0",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -705,7 +717,7 @@
     },
     "products/pathway": {
       "name": "@forwardimpact/pathway",
-      "version": "0.25.66",
+      "version": "0.26.0",
       "bin": {
         "fit-pathway": "./bin/fit-pathway.js",
       },
@@ -731,7 +743,7 @@
     },
     "products/summit": {
       "name": "@forwardimpact/summit",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "bin": {
         "fit-summit": "./bin/fit-summit.js",
       },
@@ -875,6 +887,7 @@
       },
       "dependencies": {
         "@forwardimpact/libconfig": "^0.1.67",
+        "@forwardimpact/libhttp": "^0.1.0",
         "@forwardimpact/libmcp": "^0.1.0",
         "@forwardimpact/libpreflight": "^0.1.0",
         "@forwardimpact/libresource": "^0.1.0",
@@ -882,6 +895,7 @@
         "@forwardimpact/libtelemetry": "^0.1.35",
         "@forwardimpact/libtype": "^0.1.68",
         "@forwardimpact/svcmap": "^0.1.0",
+        "@hono/node-server": "^2.0.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
       },
       "devDependencies": {
@@ -915,12 +929,11 @@
       },
       "dependencies": {
         "@forwardimpact/libconfig": "^0.1.79",
+        "@forwardimpact/libhttp": "^0.1.0",
         "@forwardimpact/libpreflight": "^0.1.0",
         "@forwardimpact/librpc": "^0.1.99",
         "@forwardimpact/libtelemetry": "^0.1.42",
         "@forwardimpact/libtype": "^0.1.0",
-        "@hono/node-server": "^2.0.4",
-        "hono": "^4.12.23",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -1201,6 +1214,8 @@
     "@forwardimpact/libformat": ["@forwardimpact/libformat@workspace:libraries/libformat"],
 
     "@forwardimpact/libgraph": ["@forwardimpact/libgraph@workspace:libraries/libgraph"],
+
+    "@forwardimpact/libhttp": ["@forwardimpact/libhttp@workspace:libraries/libhttp"],
 
     "@forwardimpact/libindex": ["@forwardimpact/libindex@workspace:libraries/libindex"],
 

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -226,28 +226,24 @@ drift in the instruction architecture.
 
 **Trigger:** Adding a proto definition and realizing the JavaScript types are
 already stale; registering a gRPC service as MCP tools and realizing the tool
-schema is just the proto definition rewritten by hand; starting a new service
-and reaching for last project's copy-pasted transport boilerplate; importing
-service types in a product and finding three different hand-maintained copies of
-the same definition.
+schema is just the proto definition rewritten by hand; importing service types
+in a product and finding three different hand-maintained copies of the same
+definition.
 
 **Big Hire:** Help me keep types in sync with proto definitions without
 hand-writing; register gRPC services as MCP tools from config instead of writing
-glue code; ship a service endpoint without reimplementing transport; import
-service types from one generated source instead of maintaining copies. →
-**libcodegen, libmcp, librpc, libtype**
+glue code; import service types from one generated source instead of maintaining
+copies. → **libcodegen, libmcp, libtype**
 
 **Little Hire:** Help me change a proto definition and trust the JavaScript
 types follow; expose a new proto method as an agent tool without touching tool
-registration; call a service without managing connections or retries; reference
-a service type and trust it matches the proto definition. → **libcodegen,
-libmcp, librpc, libtype**
+registration; reference a service type and trust it matches the proto
+definition. → **libcodegen, libmcp, libtype**
 
 **Competes With:** manual type definitions; hoping hand-written types match;
 skipping types entirely; hand-written tool schemas; per-service MCP adapters;
-leaving services invisible to agents; copy-pasting boilerplate; hand-writing
-protobuf clients; tolerating the duplication; hand-maintained type copies;
-inferring types from runtime responses.
+leaving services invisible to agents; hand-maintained type copies; inferring
+types from runtime responses.
 
 </job>
 
@@ -317,21 +313,24 @@ hooks.
 
 </job>
 
-<job user="Platform Builders" goal="Stand Up an HTTP Service Without Boilerplate">
+<job user="Platform Builders" goal="Ship Service Endpoints Without Boilerplate">
 
-## Platform Builders: Stand Up an HTTP Service Without Boilerplate
+## Platform Builders: Ship Service Endpoints Without Boilerplate
 
 **Trigger:** Starting a new HTTP service and reaching for last service's
-copy-pasted Hono wiring.
+copy-pasted Hono wiring; starting a new service and reaching for last project's
+copy-pasted transport boilerplate.
 
 **Big Hire:** Help me ship an HTTP endpoint without reimplementing server
-lifecycle, security headers, or health checks. → **libhttp**
+lifecycle, security headers, or health checks; ship a gRPC service endpoint
+without reimplementing transport. → **libhttp, librpc**
 
-**Little Hire:** Help me mount routes on a configured app and call start(). →
-**libhttp**
+**Little Hire:** Help me mount routes on a configured app and call start(); call
+a service without managing connections or retries. → **libhttp, librpc**
 
 **Competes With:** copy-pasting Hono setup; hand-rolling node:http servers;
-tolerating the duplication.
+tolerating the duplication; copy-pasting boilerplate; hand-writing protobuf
+clients.
 
 </job>
 

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -21,6 +21,7 @@ can read and tune via JSON.
 | **libeval**            | Agent evaluation framework — prove whether agent changes improved outcomes with reproducible evidence.                                    |
 | **libformat**          | Render markdown to ANSI or HTML — formatted output in any surface without losing structure.                                               |
 | **libgraph**           | RDF triple store with named ontologies — answer relationship questions without writing join logic.                                        |
+| **libhttp**            | HTTP service framework — ship a Hono service endpoint without reimplementing lifecycle, security headers, or health checks.               |
 | **libindex**           | JSONL-backed indexes with filtering and buffered writes — fast context lookup without an external search engine.                          |
 | **libmacos**           | macOS bundle assembly, code signing, and OS permission helpers — desktop delivery without platform ceremony.                              |
 | **libmcp**             | Config-driven gRPC-to-MCP tool registration — expose protobuf services as agent tools without glue code.                                  |
@@ -313,6 +314,24 @@ of an upstream library's. → **libpreflight**
 
 **Competes With:** inline checks in each bin; engines-strict; install-time
 hooks.
+
+</job>
+
+<job user="Platform Builders" goal="Stand Up an HTTP Service Without Boilerplate">
+
+## Platform Builders: Stand Up an HTTP Service Without Boilerplate
+
+**Trigger:** Starting a new HTTP service and reaching for last service's
+copy-pasted Hono wiring.
+
+**Big Hire:** Help me ship an HTTP endpoint without reimplementing server
+lifecycle, security headers, or health checks. → **libhttp**
+
+**Little Hire:** Help me mount routes on a configured app and call start(). →
+**libhttp**
+
+**Competes With:** copy-pasting Hono setup; hand-rolling node:http servers;
+tolerating the duplication.
 
 </job>
 

--- a/libraries/libbridge/CLAUDE.md
+++ b/libraries/libbridge/CLAUDE.md
@@ -105,7 +105,7 @@ its `loadDiscussionId` lens.
 | `createCallbackHandler`, `validateCallbackPayload` | inbound-callback skeleton + payload validator |
 | `RateLimiter` | per-thread dispatch rate cap |
 | `ResumeScheduler`, `ElapsedScheduler` | suspend/resume lifecycle + chunked-setTimeout |
-| `createBridgeServer` | Hono + `@hono/node-server` wiring |
+| `createBridgeServer` | bridge routes mounted on `@forwardimpact/libhttp` |
 | `newDiscussionContext`, `evaluateTrigger`, `parseIsoDuration` | record factory + trigger helpers |
 | `prepareLinkResume` | mints link token, augments authorize URL for resume |
 | `createLinkCompleteHandler` | factory for the `/api/link-complete` GET handler |

--- a/libraries/libbridge/package.json
+++ b/libraries/libbridge/package.json
@@ -40,10 +40,9 @@
     "test": "bun test test/*.test.js"
   },
   "dependencies": {
+    "@forwardimpact/libhttp": "^0.1.0",
     "@forwardimpact/libtype": "^0.1.0",
-    "@forwardimpact/libutil": "^0.1.84",
-    "@hono/node-server": "^2.0.4",
-    "hono": "^4.12.23"
+    "@forwardimpact/libutil": "^0.1.84"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/libraries/libbridge/src/server.js
+++ b/libraries/libbridge/src/server.js
@@ -1,6 +1,4 @@
-import { Hono } from "hono";
-import { bodyLimit } from "hono/body-limit";
-import { serve } from "@hono/node-server";
+import { createHttpService } from "@forwardimpact/libhttp";
 
 /**
  * Create the channel-agnostic HTTP server that bridges (ghbridge, msbridge)
@@ -47,97 +45,66 @@ export function createBridgeServer({
     throw new Error("onCallback is required");
   }
 
-  const app = new Hono();
-
-  // Security headers — standard hardening for a backend service.
-  app.use("*", async (c, next) => {
-    await next();
-    c.header("X-Content-Type-Options", "nosniff");
-    c.header("X-Frame-Options", "DENY");
-    c.header("Cache-Control", "no-store");
-  });
-
-  // Request body size limit — 1 MB is generous for JSON callback payloads.
-  app.use("*", bodyLimit({ maxSize: 1024 * 1024 }));
-
-  // Capture the raw POST body once, before downstream handlers parse it.
-  // Channel adapters use this buffer to verify HMAC signatures.
-  app.use("*", async (c, next) => {
-    if (c.req.method === "POST") {
-      const buf = Buffer.from(await c.req.raw.clone().arrayBuffer());
-      c.set("rawBody", buf);
-    }
-    await next();
-  });
-
-  app.options(webhookPath, (c) => c.body(null, 200));
-
-  app.post(webhookPath, async (c) => {
-    try {
-      return await onWebhook(c);
-    } catch (err) {
-      logger.error("bridge.webhook", err);
-      return c.json({ error: "Webhook failure" }, 500);
-    }
-  });
-
-  app.post("/api/callback/:token", async (c) => {
-    try {
-      return await onCallback(c);
-    } catch (err) {
-      logger.error("bridge.callback", err);
-      return c.json({ error: "Callback failure" }, 500);
-    }
-  });
-
-  if (onLinkComplete) {
-    app.get("/api/link-complete", async (c) => {
-      try {
-        return await onLinkComplete(c);
-      } catch (err) {
-        logger.error("bridge.link-complete", err);
-        return c.json({ error: "Link completion failure" }, 500);
-      }
-    });
-  }
-
-  if (onInbox) {
-    app.get("/api/inbox/:correlationId", async (c) => {
-      try {
-        return await onInbox(c);
-      } catch (err) {
-        logger.error("bridge.inbox", err);
-        return c.json({ error: "Inbox failure" }, 500);
-      }
-    });
-  }
-
-  let server = null;
-
-  return {
-    app,
-    address() {
-      if (!server || typeof server.address !== "function") return null;
-      const addr = server.address();
-      if (!addr || typeof addr === "string") return null;
-      return { port: addr.port };
-    },
-    async start() {
-      const { host, port } = config;
-      await new Promise((resolve) => {
-        server = serve({ fetch: app.fetch, port, hostname: host }, (info) => {
-          logger.info("bridge.server", "listening", {
-            host,
-            port: info?.port ?? port,
-          });
-          resolve();
-        });
+  // Lifecycle, security headers, body limit, and the health route are owned by
+  // `@forwardimpact/libhttp`. This factory only mounts the bridge routes (and
+  // the raw-body capture they depend on) through the `configure` callback.
+  return createHttpService({
+    name: "bridge",
+    config,
+    logger,
+    tracer: _tracer,
+    configure(app) {
+      // Capture the raw POST body once, before downstream handlers parse it.
+      // Channel adapters use this buffer to verify HMAC signatures.
+      app.use("*", async (c, next) => {
+        if (c.req.method === "POST") {
+          const buf = Buffer.from(await c.req.raw.clone().arrayBuffer());
+          c.set("rawBody", buf);
+        }
+        await next();
       });
+
+      app.options(webhookPath, (c) => c.body(null, 200));
+
+      app.post(webhookPath, async (c) => {
+        try {
+          return await onWebhook(c);
+        } catch (err) {
+          logger.error("bridge.webhook", err);
+          return c.json({ error: "Webhook failure" }, 500);
+        }
+      });
+
+      app.post("/api/callback/:token", async (c) => {
+        try {
+          return await onCallback(c);
+        } catch (err) {
+          logger.error("bridge.callback", err);
+          return c.json({ error: "Callback failure" }, 500);
+        }
+      });
+
+      if (onLinkComplete) {
+        app.get("/api/link-complete", async (c) => {
+          try {
+            return await onLinkComplete(c);
+          } catch (err) {
+            logger.error("bridge.link-complete", err);
+            return c.json({ error: "Link completion failure" }, 500);
+          }
+        });
+      }
+
+      if (onInbox) {
+        app.get("/api/inbox/:correlationId", async (c) => {
+          try {
+            return await onInbox(c);
+          } catch (err) {
+            logger.error("bridge.inbox", err);
+            return c.json({ error: "Inbox failure" }, 500);
+          }
+        });
+      }
     },
-    async stop() {
-      if (!server) return;
-      await new Promise((resolve) => server.close(() => resolve()));
-      server = null;
-    },
-  };
+  });
 }

--- a/libraries/libbridge/src/server.js
+++ b/libraries/libbridge/src/server.js
@@ -28,7 +28,7 @@ import { createHttpService } from "@forwardimpact/libhttp";
 export function createBridgeServer({
   config,
   logger,
-  tracer: _tracer,
+  tracer,
   webhookPath,
   onWebhook,
   onCallback,
@@ -52,7 +52,7 @@ export function createBridgeServer({
     name: "bridge",
     config,
     logger,
-    tracer: _tracer,
+    tracer,
     configure(app) {
       // Capture the raw POST body once, before downstream handlers parse it.
       // Channel adapters use this buffer to verify HMAC signatures.

--- a/libraries/libhttp/README.md
+++ b/libraries/libhttp/README.md
@@ -1,0 +1,39 @@
+# libhttp
+
+<!-- BEGIN:description — Do not edit. Generated from package.json. -->
+
+HTTP service framework — ship a Hono service endpoint without reimplementing
+lifecycle, security headers, or health checks.
+
+<!-- END:description -->
+
+## Getting Started
+
+`createHttpService` owns the transport boilerplate (security headers, body
+limit, error envelope, `/health`, port binding, graceful `stop()`). The service
+mounts its routes through the `configure` callback:
+
+```js
+import { createHttpService } from "@forwardimpact/libhttp";
+
+const service = createHttpService({
+  name: "example",
+  config, // { host, port }
+  logger,
+  configure(app) {
+    app.get("/hello", (c) => c.json({ hello: "world" }));
+  },
+});
+
+await service.start();
+// service.address() -> { port }
+// service.stop()    -> graceful shutdown (runs optional onStop first)
+```
+
+Signal handling stays in the entry point (`server.js`), not the library:
+
+```js
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => service.stop());
+}
+```

--- a/libraries/libhttp/package.json
+++ b/libraries/libhttp/package.json
@@ -20,7 +20,7 @@
   "jobs": [
     {
       "user": "Platform Builders",
-      "goal": "Stand Up an HTTP Service Without Boilerplate",
+      "goal": "Ship Service Endpoints Without Boilerplate",
       "trigger": "Starting a new HTTP service and reaching for last service's copy-pasted Hono wiring.",
       "bigHire": "ship an HTTP endpoint without reimplementing server lifecycle, security headers, or health checks.",
       "littleHire": "mount routes on a configured app and call start().",

--- a/libraries/libhttp/package.json
+++ b/libraries/libhttp/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@forwardimpact/libhttp",
+  "version": "0.1.0",
+  "description": "HTTP service framework — ship a Hono service endpoint without reimplementing lifecycle, security headers, or health checks.",
+  "keywords": [
+    "http",
+    "hono",
+    "server",
+    "service",
+    "agent"
+  ],
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "libraries/libhttp"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Platform Builders",
+      "goal": "Stand Up an HTTP Service Without Boilerplate",
+      "trigger": "Starting a new HTTP service and reaching for last service's copy-pasted Hono wiring.",
+      "bigHire": "ship an HTTP endpoint without reimplementing server lifecycle, security headers, or health checks.",
+      "littleHire": "mount routes on a configured app and call start().",
+      "competesWith": "copy-pasting Hono setup; hand-rolling node:http servers; tolerating the duplication"
+    }
+  ],
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src/**/*.js",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "bun test test/*.test.js"
+  },
+  "dependencies": {
+    "@hono/node-server": "^2.0.4",
+    "hono": "^4.12.23"
+  },
+  "devDependencies": {
+    "@forwardimpact/libmock": "^0.1.0"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libraries/libhttp/src/index.js
+++ b/libraries/libhttp/src/index.js
@@ -1,0 +1,1 @@
+export { createHttpService } from "./server.js";

--- a/libraries/libhttp/src/server.js
+++ b/libraries/libhttp/src/server.js
@@ -1,0 +1,124 @@
+import { Hono } from "hono";
+import { bodyLimit as honoBodyLimit } from "hono/body-limit";
+import { HTTPException } from "hono/http-exception";
+import { serve } from "@hono/node-server";
+
+const DEFAULT_BODY_LIMIT = 1024 * 1024; // 1 MB — generous for JSON payloads.
+
+/**
+ * Create a standard HTTP service backed by Hono + `@hono/node-server`.
+ *
+ * This is the HTTP counterpart to `librpc`'s `Server`: it owns the transport
+ * boilerplate (security headers, body-size limit, a global error envelope, a
+ * health endpoint, port binding, `address()`, graceful `stop()`) so a service
+ * only writes its routes. Routes are mounted by the caller through the
+ * `configure` callback — the "app callback" — keeping the developer experience
+ * a thin factory over Hono.
+ *
+ * Signal handling is intentionally NOT registered here. The entry point
+ * (`server.js`, the bin shim) owns wiring `SIGINT`/`SIGTERM` to `stop()`,
+ * keeping process-exit decisions at the composition root rather than buried in
+ * a shared library.
+ *
+ * @param {object} options
+ * @param {string} options.name - Service name, used for log tags (e.g. `"oauth"`).
+ * @param {{host?: string, port: number}} options.config - Bind host/port.
+ * @param {object} options.logger - Logger with `.info()` / `.error()`.
+ * @param {object} [options.tracer] - Optional tracer, forwarded to `configure`.
+ * @param {object} [options.runtime] - Optional ambient-collaborator bag. Unused
+ *   by the core wiring (network I/O only); accepted and forwarded to
+ *   `configure` so a host can inject runtime collaborators without changing the
+ *   factory signature.
+ * @param {(app: import("hono").Hono, ctx: {config: object, logger: object, tracer?: object, runtime?: object}) => void} options.configure
+ *   Mounts the service's routes/middleware on `app`. Runs after the standard
+ *   middleware so service routes inherit security headers and the body limit.
+ * @param {number|false} [options.bodyLimit] - Max request body in bytes. Pass
+ *   `0`/`false` to disable (required when a handler reads the raw request
+ *   stream itself, e.g. an SDK transport). Defaults to 1 MB.
+ * @param {string|false} [options.health] - Path for the auto-mounted health
+ *   route, or `false` to disable. Defaults to `"/health"`.
+ * @param {() => (void | Promise<void>)} [options.onStop] - Optional cleanup run
+ *   during `stop()` before the socket closes (e.g. close sessions, clear timers).
+ * @returns {{ app: import("hono").Hono, address: () => ({port: number} | null), start: () => Promise<void>, stop: () => Promise<void> }}
+ */
+export function createHttpService({
+  name,
+  config,
+  logger,
+  tracer,
+  runtime,
+  configure,
+  bodyLimit = DEFAULT_BODY_LIMIT,
+  health = "/health",
+  onStop,
+}) {
+  if (!name) throw new Error("name is required");
+  if (!config) throw new Error("config is required");
+  if (!logger) throw new Error("logger is required");
+  if (typeof configure !== "function") {
+    throw new Error("configure is required");
+  }
+
+  const app = new Hono();
+
+  // Global error envelope — any uncaught handler error becomes a 500.
+  // `HTTPException`s (e.g. the body-limit 413, or an explicit `throw`) carry
+  // their own status/response and render it directly.
+  app.onError((err, c) => {
+    if (err instanceof HTTPException) return err.getResponse();
+    logger.error(`${name}.error`, err.message);
+    return c.json({ error: "server_error" }, 500);
+  });
+
+  // Security headers — standard hardening for a backend service.
+  app.use("*", async (c, next) => {
+    await next();
+    c.header("X-Content-Type-Options", "nosniff");
+    c.header("X-Frame-Options", "DENY");
+    c.header("Cache-Control", "no-store");
+  });
+
+  // Request body size limit. Disabled when falsy so handlers that consume the
+  // raw request stream themselves keep an untouched body.
+  if (bodyLimit) {
+    app.use("*", honoBodyLimit({ maxSize: bodyLimit }));
+  }
+
+  // Health endpoint — mounted before service routes so it always resolves
+  // ahead of any catch-all the service registers in `configure`.
+  if (health) {
+    app.get(health, (c) => c.json({ status: "ok" }));
+  }
+
+  configure(app, { config, logger, tracer, runtime });
+
+  let server = null;
+
+  return {
+    app,
+    address() {
+      if (!server || typeof server.address !== "function") return null;
+      const addr = server.address();
+      if (!addr || typeof addr === "string") return null;
+      return { port: addr.port };
+    },
+    async start() {
+      const { host, port } = config;
+      await new Promise((resolve) => {
+        server = serve({ fetch: app.fetch, port, hostname: host }, (info) => {
+          logger.info(`${name}.server`, "listening", {
+            host,
+            port: info?.port ?? port,
+          });
+          resolve();
+        });
+      });
+    },
+    async stop() {
+      if (!server) return;
+      if (onStop) await onStop();
+      await new Promise((resolve) => server.close(() => resolve()));
+      server = null;
+    },
+  };
+}

--- a/libraries/libhttp/src/server.js
+++ b/libraries/libhttp/src/server.js
@@ -10,8 +10,8 @@ const DEFAULT_BODY_LIMIT = 1024 * 1024; // 1 MB — generous for JSON payloads.
  *
  * This is the HTTP counterpart to `librpc`'s `Server`: it owns the transport
  * boilerplate (security headers, body-size limit, a global error envelope, a
- * health endpoint, port binding, `address()`, graceful `stop()`) so a service
- * only writes its routes. Routes are mounted by the caller through the
+ * `/health` endpoint, port binding, `address()`, graceful `stop()`) so a
+ * service only writes its routes. Routes are mounted by the caller through the
  * `configure` callback — the "app callback" — keeping the developer experience
  * a thin factory over Hono.
  *
@@ -22,21 +22,16 @@ const DEFAULT_BODY_LIMIT = 1024 * 1024; // 1 MB — generous for JSON payloads.
  *
  * @param {object} options
  * @param {string} options.name - Service name, used for log tags (e.g. `"oauth"`).
- * @param {{host?: string, port: number}} options.config - Bind host/port.
+ * @param {{host: string, port: number}} options.config - Bind host/port.
  * @param {object} options.logger - Logger with `.info()` / `.error()`.
- * @param {object} [options.tracer] - Optional tracer, forwarded to `configure`.
- * @param {object} [options.runtime] - Optional ambient-collaborator bag. Unused
- *   by the core wiring (network I/O only); accepted and forwarded to
- *   `configure` so a host can inject runtime collaborators without changing the
- *   factory signature.
- * @param {(app: import("hono").Hono, ctx: {config: object, logger: object, tracer?: object, runtime?: object}) => void} options.configure
+ * @param {object} [options.tracer] - Tracer, injected alongside `logger` and
+ *   forwarded to `configure` so route handlers can open spans.
+ * @param {(app: import("hono").Hono, deps: {logger: object, tracer?: object}) => void} options.configure
  *   Mounts the service's routes/middleware on `app`. Runs after the standard
  *   middleware so service routes inherit security headers and the body limit.
- * @param {number|false} [options.bodyLimit] - Max request body in bytes. Pass
- *   `0`/`false` to disable (required when a handler reads the raw request
- *   stream itself, e.g. an SDK transport). Defaults to 1 MB.
- * @param {string|false} [options.health] - Path for the auto-mounted health
- *   route, or `false` to disable. Defaults to `"/health"`.
+ * @param {number} [options.bodyLimit] - Max request body in bytes. Pass `0` to
+ *   disable (required when a handler reads the raw request stream itself, e.g.
+ *   an SDK transport). Defaults to 1 MB.
  * @param {() => (void | Promise<void>)} [options.onStop] - Optional cleanup run
  *   during `stop()` before the socket closes (e.g. close sessions, clear timers).
  * @returns {{ app: import("hono").Hono, address: () => ({port: number} | null), start: () => Promise<void>, stop: () => Promise<void> }}
@@ -46,10 +41,8 @@ export function createHttpService({
   config,
   logger,
   tracer,
-  runtime,
   configure,
   bodyLimit = DEFAULT_BODY_LIMIT,
-  health = "/health",
   onStop,
 }) {
   if (!name) throw new Error("name is required");
@@ -78,38 +71,31 @@ export function createHttpService({
     c.header("Cache-Control", "no-store");
   });
 
-  // Request body size limit. Disabled when falsy so handlers that consume the
-  // raw request stream themselves keep an untouched body.
+  // Request body size limit. Disabled when 0 so handlers that consume the raw
+  // request stream themselves keep an untouched body.
   if (bodyLimit) {
     app.use("*", honoBodyLimit({ maxSize: bodyLimit }));
   }
 
-  // Health endpoint — mounted before service routes so it always resolves
-  // ahead of any catch-all the service registers in `configure`.
-  if (health) {
-    app.get(health, (c) => c.json({ status: "ok" }));
-  }
+  // Health endpoint — mounted before service routes so it resolves ahead of any
+  // catch-all the service registers in `configure`.
+  app.get("/health", (c) => c.json({ status: "ok" }));
 
-  configure(app, { config, logger, tracer, runtime });
+  configure(app, { logger, tracer });
 
   let server = null;
 
   return {
     app,
     address() {
-      if (!server || typeof server.address !== "function") return null;
-      const addr = server.address();
-      if (!addr || typeof addr === "string") return null;
-      return { port: addr.port };
+      const addr = server?.address();
+      return addr ? { port: addr.port } : null;
     },
     async start() {
       const { host, port } = config;
       await new Promise((resolve) => {
         server = serve({ fetch: app.fetch, port, hostname: host }, (info) => {
-          logger.info(`${name}.server`, "listening", {
-            host,
-            port: info?.port ?? port,
-          });
+          logger.info(`${name}.server`, "listening", { host, port: info.port });
           resolve();
         });
       });

--- a/libraries/libhttp/test/server.test.js
+++ b/libraries/libhttp/test/server.test.js
@@ -119,19 +119,6 @@ describe("createHttpService", () => {
     });
   });
 
-  describe("health disabled", () => {
-    test("health: false omits the route", async () => {
-      await startWith({
-        health: false,
-        configure(app) {
-          app.get("/health", (c) => c.text("custom"));
-        },
-      });
-      const res = await fetch(`${baseUrl}/health`);
-      expect(await res.text()).toBe("custom");
-    });
-  });
-
   describe("lifecycle", () => {
     test("onStop runs during stop() and stop() is idempotent", async () => {
       let stopped = 0;
@@ -147,20 +134,16 @@ describe("createHttpService", () => {
       expect(stopped).toBe(1); // stop() is idempotent — onStop fires once
     });
 
-    test("forwards config/logger/tracer/runtime to configure", async () => {
+    test("forwards logger and tracer to configure", async () => {
       let received;
       const tracer = { tag: "tracer" };
-      const runtime = { tag: "runtime" };
       await startWith({
         tracer,
-        runtime,
-        configure(_app, ctx) {
-          received = ctx;
+        configure(_app, deps) {
+          received = deps;
         },
       });
       expect(received.tracer).toBe(tracer);
-      expect(received.runtime).toBe(runtime);
-      expect(received.config).toBeDefined();
       expect(received.logger).toBeDefined();
     });
   });

--- a/libraries/libhttp/test/server.test.js
+++ b/libraries/libhttp/test/server.test.js
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createMockLogger } from "@forwardimpact/libmock/mock";
+
+import { createHttpService } from "../src/server.js";
+
+describe("createHttpService", () => {
+  let service;
+  let baseUrl;
+
+  async function startWith(options) {
+    service = createHttpService({
+      name: "test",
+      config: { host: "127.0.0.1", port: 0 },
+      logger: createMockLogger(),
+      ...options,
+    });
+    await service.start();
+    baseUrl = `http://127.0.0.1:${service.address().port}`;
+    return service;
+  }
+
+  afterEach(async () => {
+    if (service) await service.stop();
+    service = null;
+  });
+
+  describe("required options", () => {
+    test("throws without name, config, logger, or configure", () => {
+      expect(() => createHttpService({})).toThrow("name is required");
+      expect(() => createHttpService({ name: "x" })).toThrow(
+        "config is required",
+      );
+      expect(() =>
+        createHttpService({ name: "x", config: { port: 0 } }),
+      ).toThrow("logger is required");
+      expect(() =>
+        createHttpService({
+          name: "x",
+          config: { port: 0 },
+          logger: createMockLogger(),
+        }),
+      ).toThrow("configure is required");
+    });
+  });
+
+  describe("standard wiring", () => {
+    beforeEach(async () => {
+      await startWith({
+        configure(app) {
+          app.get("/hello", (c) => c.json({ hello: "world" }));
+          app.get("/boom", () => {
+            throw new Error("kaboom");
+          });
+        },
+      });
+    });
+
+    test("auto-mounts /health", async () => {
+      const res = await fetch(`${baseUrl}/health`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ status: "ok" });
+    });
+
+    test("configure routes are reachable", async () => {
+      const res = await fetch(`${baseUrl}/hello`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ hello: "world" });
+    });
+
+    test("applies security headers", async () => {
+      const res = await fetch(`${baseUrl}/health`);
+      expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+      expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+    });
+
+    test("uncaught handler errors become a 500 envelope", async () => {
+      const res = await fetch(`${baseUrl}/boom`);
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: "server_error" });
+    });
+
+    test("address() returns the bound port", () => {
+      expect(service.address().port).toBeGreaterThan(0);
+    });
+  });
+
+  describe("body limit", () => {
+    test("rejects bodies over the configured limit", async () => {
+      await startWith({
+        bodyLimit: 16,
+        configure(app) {
+          app.post("/echo", async (c) => c.json(await c.req.json()));
+        },
+      });
+      const res = await fetch(`${baseUrl}/echo`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ value: "x".repeat(100) }),
+      });
+      expect(res.status).toBe(413);
+    });
+
+    test("bodyLimit: 0 leaves the body untouched", async () => {
+      await startWith({
+        bodyLimit: 0,
+        configure(app) {
+          app.post("/echo", async (c) => c.json(await c.req.json()));
+        },
+      });
+      const big = { value: "x".repeat(100) };
+      const res = await fetch(`${baseUrl}/echo`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(big),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(big);
+    });
+  });
+
+  describe("health disabled", () => {
+    test("health: false omits the route", async () => {
+      await startWith({
+        health: false,
+        configure(app) {
+          app.get("/health", (c) => c.text("custom"));
+        },
+      });
+      const res = await fetch(`${baseUrl}/health`);
+      expect(await res.text()).toBe("custom");
+    });
+  });
+
+  describe("lifecycle", () => {
+    test("onStop runs during stop() and stop() is idempotent", async () => {
+      let stopped = 0;
+      await startWith({
+        onStop: () => {
+          stopped += 1;
+        },
+        configure() {},
+      });
+      await service.stop();
+      await service.stop();
+      service = null; // prevent afterEach double-stop
+      expect(stopped).toBe(1); // stop() is idempotent — onStop fires once
+    });
+
+    test("forwards config/logger/tracer/runtime to configure", async () => {
+      let received;
+      const tracer = { tag: "tracer" };
+      const runtime = { tag: "runtime" };
+      await startWith({
+        tracer,
+        runtime,
+        configure(_app, ctx) {
+          received = ctx;
+        },
+      });
+      expect(received.tracer).toBe(tracer);
+      expect(received.runtime).toBe(runtime);
+      expect(received.config).toBeDefined();
+      expect(received.logger).toBeDefined();
+    });
+  });
+});

--- a/libraries/librpc/package.json
+++ b/libraries/librpc/package.json
@@ -20,9 +20,9 @@
   "jobs": [
     {
       "user": "Platform Builders",
-      "goal": "Keep Service Contracts Typed",
+      "goal": "Ship Service Endpoints Without Boilerplate",
       "trigger": "Starting a new service and reaching for last project's copy-pasted transport boilerplate.",
-      "bigHire": "ship a service endpoint without reimplementing transport.",
+      "bigHire": "ship a gRPC service endpoint without reimplementing transport.",
       "littleHire": "call a service without managing connections or retries.",
       "competesWith": "copy-pasting boilerplate; hand-writing protobuf clients; tolerating the duplication"
     }

--- a/services/CLAUDE.md
+++ b/services/CLAUDE.md
@@ -60,9 +60,9 @@ See [`config/CLAUDE.md`](../config/CLAUDE.md) and
 
 ## Architecture
 
-Most services expose gRPC (`proto/`). Exceptions: `mcp` exposes HTTP/SSE
-via `@modelcontextprotocol/sdk`; `msbridge` and `ghbridge` expose HTTP
-via `libbridge` (Hono + `@hono/node-server`).
+Most services expose gRPC (`proto/`). HTTP services standardize on `libhttp`'s
+`createHttpService` (Hono + `@hono/node-server`): `oauth` directly,
+`ghbridge`/`msbridge` via `libbridge`, `mcp` via a raw req/res escape hatch.
 
 Each service follows the same structure:
 

--- a/services/mcp/index.js
+++ b/services/mcp/index.js
@@ -1,14 +1,17 @@
 import crypto from "node:crypto";
-import { createServer } from "node:http";
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+import { createHttpService } from "@forwardimpact/libhttp";
+import { RESPONSE_ALREADY_SENT } from "@hono/node-server/utils/response";
 
 import { registerToolsFromConfig } from "@forwardimpact/libmcp";
 
 const SESSION_IDLE_MS = 30 * 60 * 1000;
 const SESSION_SWEEP_MS = 60_000;
-const SHUTDOWN_TIMEOUT_MS = 5000;
+const DEFAULT_HOST = "0.0.0.0";
+const DEFAULT_PORT = 3005;
 
 /**
  * Builds the MCP prompt by appending one routing line per (tool, statement)
@@ -43,12 +46,6 @@ function sendInternalError(res, logger, err) {
     error: { code: -32603, message: "Internal server error" },
     id: null,
   });
-}
-
-function tryServeHealth(req, res) {
-  if (req.url !== "/health" || req.method !== "GET") return false;
-  sendJson(res, 200, { status: "ok" });
-  return true;
 }
 
 /**
@@ -107,8 +104,14 @@ async function dispatchNewSession(req, res, ctx) {
  * MCP SDK's Protocol only supports one transport at a time. The system prompt
  * is read from config.system_prompt and served via the guide-default MCP prompt.
  *
+ * Transport boilerplate (security headers, `/health`, lifecycle) is owned by
+ * `@forwardimpact/libhttp`. The MCP SDK's `StreamableHTTPServerTransport` drives
+ * the raw Node request/response, so the catch-all route reaches them via
+ * `c.env.incoming`/`c.env.outgoing` and returns the `RESPONSE_ALREADY_SENT`
+ * sentinel; libhttp's body limit is disabled so the SDK reads an untouched body.
+ *
  * @param {{ config: object, logger: object, graphClient: object, vectorClient: object, pathwayClient: object, mapClient: object, resourceIndex: object }} deps
- * @returns {{ start: () => Promise<void> }}
+ * @returns {{ app: import("hono").Hono, address: () => object|null, start: () => Promise<void>, stop: () => Promise<void> }}
  */
 export function createMcpService({
   config,
@@ -147,70 +150,67 @@ export function createMcpService({
     return server;
   }
 
-  async function start() {
-    const promptText = buildPromptText(config.system_prompt, config.tools);
-    const host = config.host || "0.0.0.0";
-    const port = config.port || 3005;
-    const expectedToken = config.mcpToken();
-    const sessions = new Map();
-    const ctx = { sessions, makeServer, promptText, logger };
+  const promptText = buildPromptText(config.system_prompt, config.tools);
+  const expectedToken = config.mcpToken();
+  const sessions = new Map();
+  const ctx = { sessions, makeServer, promptText, logger };
+  let sweepTimer = null;
 
-    const httpServer = createServer(async (req, res) => {
-      if (tryServeHealth(req, res)) return;
-      if (!isAuthorized(req, expectedToken)) {
-        res.writeHead(401);
-        res.end("Unauthorized");
-        return;
-      }
-      const sessionId = req.headers["mcp-session-id"];
-      const existing = sessionId && sessions.get(sessionId);
-      if (existing) {
-        await dispatchExistingSession(req, res, existing, logger);
-        return;
-      }
-      await dispatchNewSession(req, res, ctx);
-    });
-
-    httpServer.on("error", (err) => {
-      logger.error(`HTTP server error: ${err.message}`);
-      if (err.code === "EADDRINUSE") process.exit(1);
-    });
-
-    httpServer.listen(port, host, () => {
-      logger.info(`MCP server listening on ${host}:${port}`);
-    });
-
-    const sweepTimer = setInterval(() => {
-      const now = Date.now();
-      for (const [sid, session] of sessions) {
-        if (now - session.lastActivity > SESSION_IDLE_MS) {
-          logger.info(`Reaping idle session ${sid}`);
-          session.server.close();
+  const httpService = createHttpService({
+    name: "mcp",
+    config: {
+      host: config.host || DEFAULT_HOST,
+      port: config.port || DEFAULT_PORT,
+    },
+    logger,
+    // The MCP SDK transport reads the raw request stream itself, so the body
+    // limit must stay off to leave the body untouched.
+    bodyLimit: 0,
+    configure(app) {
+      app.all("*", async (c) => {
+        const req = c.env.incoming;
+        const res = c.env.outgoing;
+        if (!isAuthorized(req, expectedToken)) {
+          res.writeHead(401);
+          res.end("Unauthorized");
+          return RESPONSE_ALREADY_SENT;
         }
-      }
-    }, SESSION_SWEEP_MS);
-    sweepTimer.unref();
-
-    const shutdown = async () => {
+        const sessionId = req.headers["mcp-session-id"];
+        const existing = sessionId && sessions.get(sessionId);
+        if (existing) {
+          await dispatchExistingSession(req, res, existing, logger);
+        } else {
+          await dispatchNewSession(req, res, ctx);
+        }
+        return RESPONSE_ALREADY_SENT;
+      });
+    },
+    async onStop() {
       logger.info("Shutting down MCP server");
-      clearInterval(sweepTimer);
-
-      const forceExit = setTimeout(() => {
-        logger.error("Shutdown timed out, forcing exit");
-        process.exit(1);
-      }, SHUTDOWN_TIMEOUT_MS);
-      forceExit.unref();
-
+      if (sweepTimer) clearInterval(sweepTimer);
       await Promise.allSettled(
         [...sessions.values()].map((s) => s.server.close()),
       );
       sessions.clear();
-      httpServer.close();
-    };
+    },
+  });
 
-    process.on("SIGINT", shutdown);
-    process.on("SIGTERM", shutdown);
-  }
-
-  return { start };
+  return {
+    app: httpService.app,
+    address: httpService.address,
+    async start() {
+      sweepTimer = setInterval(() => {
+        const now = Date.now();
+        for (const [sid, session] of sessions) {
+          if (now - session.lastActivity > SESSION_IDLE_MS) {
+            logger.info(`Reaping idle session ${sid}`);
+            session.server.close();
+          }
+        }
+      }, SESSION_SWEEP_MS);
+      sweepTimer.unref();
+      await httpService.start();
+    },
+    stop: httpService.stop,
+  };
 }

--- a/services/mcp/index.js
+++ b/services/mcp/index.js
@@ -10,8 +10,6 @@ import { registerToolsFromConfig } from "@forwardimpact/libmcp";
 
 const SESSION_IDLE_MS = 30 * 60 * 1000;
 const SESSION_SWEEP_MS = 60_000;
-const DEFAULT_HOST = "0.0.0.0";
-const DEFAULT_PORT = 3005;
 
 /**
  * Builds the MCP prompt by appending one routing line per (tool, statement)
@@ -110,12 +108,13 @@ async function dispatchNewSession(req, res, ctx) {
  * `c.env.incoming`/`c.env.outgoing` and returns the `RESPONSE_ALREADY_SENT`
  * sentinel; libhttp's body limit is disabled so the SDK reads an untouched body.
  *
- * @param {{ config: object, logger: object, graphClient: object, vectorClient: object, pathwayClient: object, mapClient: object, resourceIndex: object }} deps
+ * @param {{ config: object, logger: object, tracer?: object, graphClient: object, vectorClient: object, pathwayClient: object, mapClient: object, resourceIndex: object }} deps
  * @returns {{ app: import("hono").Hono, address: () => object|null, start: () => Promise<void>, stop: () => Promise<void> }}
  */
 export function createMcpService({
   config,
   logger,
+  tracer,
   graphClient,
   vectorClient,
   pathwayClient,
@@ -158,11 +157,9 @@ export function createMcpService({
 
   const httpService = createHttpService({
     name: "mcp",
-    config: {
-      host: config.host || DEFAULT_HOST,
-      port: config.port || DEFAULT_PORT,
-    },
+    config,
     logger,
+    tracer,
     // The MCP SDK transport reads the raw request stream itself, so the body
     // limit must stay off to leave the body untouched.
     bodyLimit: 0,

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@forwardimpact/libconfig": "^0.1.67",
+    "@forwardimpact/libhttp": "^0.1.0",
     "@forwardimpact/libmcp": "^0.1.0",
     "@forwardimpact/libpreflight": "^0.1.0",
     "@forwardimpact/libresource": "^0.1.0",
@@ -48,6 +49,7 @@
     "@forwardimpact/libtelemetry": "^0.1.35",
     "@forwardimpact/libtype": "^0.1.68",
     "@forwardimpact/svcmap": "^0.1.0",
+    "@hono/node-server": "^2.0.4",
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {

--- a/services/mcp/server.js
+++ b/services/mcp/server.js
@@ -32,3 +32,7 @@ const service = createMcpService({
 });
 
 await service.start();
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => service.stop());
+}

--- a/services/mcp/server.js
+++ b/services/mcp/server.js
@@ -24,6 +24,7 @@ const resourceIndex = createResourceIndex("resources");
 const service = createMcpService({
   config,
   logger,
+  tracer,
   graphClient,
   vectorClient,
   pathwayClient,

--- a/services/mcp/test/http.test.js
+++ b/services/mcp/test/http.test.js
@@ -1,0 +1,83 @@
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert";
+import { spy } from "@forwardimpact/libmock";
+
+import { createMcpService } from "../index.js";
+
+/**
+ * Integration coverage for the libhttp + MCP-SDK escape hatch: the service
+ * mounts on `@forwardimpact/libhttp`, but the StreamableHTTP transport drives
+ * the raw Node request/response via `c.env.incoming`/`c.env.outgoing`. These
+ * tests start a real server on an ephemeral port and exercise it over HTTP.
+ */
+function createMockConfig() {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    mcpToken: () => "test-bearer-token",
+    system_prompt: "You are Guide, a test agent.",
+    tools: {},
+  };
+}
+
+describe("MCP HTTP transport", () => {
+  let service;
+  let baseUrl;
+
+  before(async () => {
+    service = createMcpService({
+      config: createMockConfig(),
+      logger: { info: spy(), error: spy() },
+      graphClient: {},
+      vectorClient: {},
+      pathwayClient: {},
+    });
+    await service.start();
+    baseUrl = `http://127.0.0.1:${service.address().port}`;
+  });
+
+  after(async () => {
+    await service.stop();
+  });
+
+  test("GET /health is served by libhttp without auth", async () => {
+    const res = await fetch(`${baseUrl}/health`);
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(await res.json(), { status: "ok" });
+  });
+
+  test("requests without a bearer token are rejected with 401", async () => {
+    const res = await fetch(`${baseUrl}/`, { method: "POST" });
+    assert.strictEqual(res.status, 401);
+  });
+
+  test("an authorized initialize handshake establishes a session", async () => {
+    const res = await fetch(`${baseUrl}/`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-bearer-token",
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "0.0.0" },
+        },
+      }),
+    });
+    // The SDK transport drove the raw response: a session id is minted and the
+    // status is a non-error 2xx (proving the escape hatch wiring works).
+    assert.ok(res.status >= 200 && res.status < 300, `status ${res.status}`);
+    assert.ok(
+      res.headers.get("mcp-session-id"),
+      "expected an mcp-session-id header",
+    );
+    // Drain the body so the connection can close cleanly.
+    await res.text();
+  });
+});

--- a/services/oauth/index.js
+++ b/services/oauth/index.js
@@ -1,9 +1,13 @@
-import { Hono } from "hono";
-import { serve } from "@hono/node-server";
+import { createHttpService } from "@forwardimpact/libhttp";
 import * as types from "@forwardimpact/libtype";
 
 /**
  * Create the OAuth 2.1 authorization server HTTP adapter.
+ *
+ * Transport boilerplate (security headers, error envelope, `/health`, lifecycle)
+ * is owned by `@forwardimpact/libhttp`; this factory only declares the OAuth
+ * routes inside the `configure` callback.
+ *
  * @param {object} options
  * @param {object} options.config
  * @param {object} options.logger
@@ -13,19 +17,6 @@ import * as types from "@forwardimpact/libtype";
 export function createOauthService({ config, logger, providerClient }) {
   const providerTypes = types[config.provider];
   const typed = (name, obj) => providerTypes[name].fromObject(obj);
-  const app = new Hono();
-
-  app.onError((err, c) => {
-    logger.error("oauth.error", err.message);
-    return c.json({ error: "server_error" }, 500);
-  });
-
-  app.use("*", async (c, next) => {
-    await next();
-    c.header("X-Content-Type-Options", "nosniff");
-    c.header("X-Frame-Options", "DENY");
-    c.header("Cache-Control", "no-store");
-  });
 
   const metadata = {
     issuer: config.issuer,
@@ -36,118 +27,96 @@ export function createOauthService({ config, logger, providerClient }) {
     code_challenge_methods_supported: ["S256"],
   };
 
-  app.get("/.well-known/oauth-authorization-server", (c) => c.json(metadata));
-
-  app.get("/authorize", async (c) => {
-    const {
-      surface,
-      surface_user_id,
-      redirect_uri,
-      code_challenge,
-      scope,
-      client_state,
-    } = c.req.query();
-    if (!surface || !surface_user_id) {
-      return c.json({ error: "invalid_request" }, 400);
-    }
-    const scopes = scope ? scope.split(" ") : [];
-
-    const result = await providerClient.Begin(
-      typed("BeginRequest", {
-        surface,
-        surface_user_id,
-        redirect_uri: redirect_uri || undefined,
-        code_challenge: code_challenge || undefined,
-        scopes,
-        client_state: client_state || undefined,
-      }),
-    );
-
-    return c.redirect(result.upstream_authorize_url, 302);
-  });
-
-  app.get("/callback", async (c) => {
-    const { code, state } = c.req.query();
-    if (!code || !state) {
-      return c.json({ error: "invalid_request" }, 400);
-    }
-
-    const result = await providerClient.Complete(
-      typed("CompleteRequest", { code, state }),
-    );
-
-    if (result.outcome === "identity_mismatch") {
-      return c.html(
-        "<!DOCTYPE html><html><body><h1>Account mismatch</h1>" +
-          "<p>The account that authorized does not match the " +
-          "account that requested linking. No binding was created. " +
-          "Please try again from the correct account.</p></body></html>",
+  return createHttpService({
+    name: "oauth",
+    config,
+    logger,
+    configure(app) {
+      app.get("/.well-known/oauth-authorization-server", (c) =>
+        c.json(metadata),
       );
-    }
 
-    if (result.redirect_uri) {
-      const url = new URL(result.redirect_uri);
-      url.searchParams.set("code", result.downstream_code);
-      if (result.client_state)
-        url.searchParams.set("state", result.client_state);
-      return c.redirect(url.toString(), 302);
-    }
+      app.get("/authorize", async (c) => {
+        const {
+          surface,
+          surface_user_id,
+          redirect_uri,
+          code_challenge,
+          scope,
+          client_state,
+        } = c.req.query();
+        if (!surface || !surface_user_id) {
+          return c.json({ error: "invalid_request" }, 400);
+        }
+        const scopes = scope ? scope.split(" ") : [];
 
-    return c.html(
-      "<!DOCTYPE html><html><body><h1>Linked</h1><p>Your account has been linked. You can close this window.</p></body></html>",
-    );
-  });
+        const result = await providerClient.Begin(
+          typed("BeginRequest", {
+            surface,
+            surface_user_id,
+            redirect_uri: redirect_uri || undefined,
+            code_challenge: code_challenge || undefined,
+            scopes,
+            client_state: client_state || undefined,
+          }),
+        );
 
-  app.post("/token", async (c) => {
-    const body = await c.req.parseBody();
-    if (body.grant_type && body.grant_type !== "authorization_code") {
-      return c.json({ error: "unsupported_grant_type" }, 400);
-    }
-    if (!body.code) {
-      return c.json({ error: "invalid_request" }, 400);
-    }
-    const result = await providerClient.Redeem(
-      typed("RedeemRequest", {
-        code: body.code,
-        code_verifier: body.code_verifier,
-      }),
-    );
+        return c.redirect(result.upstream_authorize_url, 302);
+      });
 
-    return c.json({
-      access_token: result.access_token,
-      token_type: result.token_type,
-      expires_in: Number(result.expires_in),
-    });
-  });
+      app.get("/callback", async (c) => {
+        const { code, state } = c.req.query();
+        if (!code || !state) {
+          return c.json({ error: "invalid_request" }, 400);
+        }
 
-  app.get("/health", (c) => c.json({ status: "ok" }));
+        const result = await providerClient.Complete(
+          typed("CompleteRequest", { code, state }),
+        );
 
-  let server = null;
+        if (result.outcome === "identity_mismatch") {
+          return c.html(
+            "<!DOCTYPE html><html><body><h1>Account mismatch</h1>" +
+              "<p>The account that authorized does not match the " +
+              "account that requested linking. No binding was created. " +
+              "Please try again from the correct account.</p></body></html>",
+          );
+        }
 
-  return {
-    app,
-    address() {
-      if (!server || typeof server.address !== "function") return null;
-      const addr = server.address();
-      if (!addr || typeof addr === "string") return null;
-      return { port: addr.port };
-    },
-    async start() {
-      const { host, port } = config;
-      await new Promise((resolve) => {
-        server = serve({ fetch: app.fetch, port, hostname: host }, (info) => {
-          logger.info("oauth.server", "listening", {
-            host,
-            port: info?.port ?? port,
-          });
-          resolve();
+        if (result.redirect_uri) {
+          const url = new URL(result.redirect_uri);
+          url.searchParams.set("code", result.downstream_code);
+          if (result.client_state)
+            url.searchParams.set("state", result.client_state);
+          return c.redirect(url.toString(), 302);
+        }
+
+        return c.html(
+          "<!DOCTYPE html><html><body><h1>Linked</h1><p>Your account has been linked. You can close this window.</p></body></html>",
+        );
+      });
+
+      app.post("/token", async (c) => {
+        const body = await c.req.parseBody();
+        if (body.grant_type && body.grant_type !== "authorization_code") {
+          return c.json({ error: "unsupported_grant_type" }, 400);
+        }
+        if (!body.code) {
+          return c.json({ error: "invalid_request" }, 400);
+        }
+        const result = await providerClient.Redeem(
+          typed("RedeemRequest", {
+            code: body.code,
+            code_verifier: body.code_verifier,
+          }),
+        );
+
+        return c.json({
+          access_token: result.access_token,
+          token_type: result.token_type,
+          expires_in: Number(result.expires_in),
         });
       });
     },
-    async stop() {
-      if (!server) return;
-      await new Promise((resolve) => server.close(() => resolve()));
-      server = null;
-    },
-  };
+  });
 }

--- a/services/oauth/package.json
+++ b/services/oauth/package.json
@@ -41,12 +41,11 @@
   },
   "dependencies": {
     "@forwardimpact/libconfig": "^0.1.79",
+    "@forwardimpact/libhttp": "^0.1.0",
     "@forwardimpact/libpreflight": "^0.1.0",
     "@forwardimpact/librpc": "^0.1.99",
     "@forwardimpact/libtelemetry": "^0.1.42",
-    "@forwardimpact/libtype": "^0.1.0",
-    "@hono/node-server": "^2.0.4",
-    "hono": "^4.12.23"
+    "@forwardimpact/libtype": "^0.1.0"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/specs/1370-ambient-dependencies-to-injected-collaborators/plan-a-06-services.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/plan-a-06-services.md
@@ -25,7 +25,7 @@ substitutions:
 |---|---|
 | Step 2 (golden capture) | Snapshot the service's RPC contract via `bun test services/<name>/test/contract.test.js` (creating the file if not present — per-service Step 2 substep). Contract tests assert request/response shapes against a stubbed dependency layer. No bytes-comparison golden. |
 | Step 7 (golden replay) | Re-run the contract test after refactor; pass/fail is the verdict. |
-| `runtime.proc.exit` allow-list | Services call `runtime.proc.exit(code)` from the entry point on SIGTERM / fatal startup error; the migration preserves this. |
+| `runtime.proc.exit` allow-list | Services call `runtime.proc.exit(code)` from the entry point on a fatal startup error; the migration preserves this. HTTP services (oauth, mcp) instead wire `SIGINT`/`SIGTERM` to `service.stop()` in `server.js` for graceful shutdown — `libhttp` owns the socket teardown, so the entry point never calls `runtime.proc.exit` on a signal. |
 
 ## Service file layout
 
@@ -36,6 +36,27 @@ have a `src/` subtree. Per-section "Files (src)" lists below reflect
 the actual layout; sections for services without `src/` list
 `services/<name>/index.js`, `services/<name>/server.js`, and any other
 top-level `.js` file.
+
+## HTTP transport standardization (libhttp)
+
+Since 2026-05-30 the four HTTP services standardize on
+`@forwardimpact/libhttp`'s `createHttpService` factory — a non-bin library
+added **after** this plan was first drafted: `oauth` mounts its routes
+directly, `ghbridge` / `msbridge` go through `libbridge`'s
+`createBridgeServer`, and `mcp` reaches the MCP SDK transport through a
+raw-Node escape hatch (`c.env.incoming` / `c.env.outgoing` +
+`RESPONSE_ALREADY_SENT`). `libhttp/src` is **ambient-clean** — it does only
+network I/O (Hono + `@hono/node-server`) and touches no `process` / `node:fs`
+/ clock / timer surface, so `check-ambient-deps` passes on it. It therefore
+carries **no** 1370 sub-row, and the HTTP services migrate **no** transport
+internals: serve/bind, security headers, body limit, `/health`, and graceful
+`stop()` already live behind the library. `libhttp` already accepts injected
+`logger` and `tracer`; the runtime construction site and `SIGINT`/`SIGTERM` →
+`service.stop()` wiring live in each `server.js`. The clock/timer surface for
+the bridge HTTP path (`ProgressTicker`, `ElapsedScheduler`) lives in
+`libbridge` and migrates in its plan-a-04 sub-row. The per-service bullets
+below describe only the **domain** ambient usage that remains after transport
+moved into the libraries.
 
 ## bridge
 
@@ -72,12 +93,12 @@ Files (src): `services/ghauth/index.js`, `services/ghauth/server.js` (no `src/` 
 
 Sub-row: `1370/services-ghbridge\tplan\timplemented`.
 
-Blocking: plan-a-01; plan-a-02 (libwiki — wiki-flow consumes WikiSync).
+Blocking: plan-a-01; plan-a-02 (libwiki — wiki-flow consumes WikiSync); plan-a-04 (libbridge — HTTP transport + ProgressTicker/ElapsedScheduler clock).
 
-Files (src): `services/ghbridge/index.js`, `services/ghbridge/server.js`, `services/ghbridge/src/discussion-adapter.js`, `services/ghbridge/src/graphql.js`.
+Files (src): `services/ghbridge/index.js`, `services/ghbridge/server.js`, `services/ghbridge/src/discussion-adapter.js`, `services/ghbridge/src/graphql.js`, `services/ghbridge/src/injection.js`.
 
-- The pre-PR `rg "WikiRepo|wiki-repo"` audit (per plan-a-02 Step 2) currently shows zero ghbridge importers of `WikiRepo`; if the audit at PR time uncovers wiki-flow code that the 2026-05-30 snapshot missed, it's rewired here (or in plan-a-02 if the migration interlock pulls it forward). Service's own ambient-dep migration covers `process.env`, `node:fs`, `Date.now()`, and any `node:child_process` usage in `graphql.js` / `discussion-adapter.js`.
-- Bridge hardening already in place (MAX_REPLY_COUNT, bodyLimit, sanitization) is untouched.
+- The pre-PR `rg "WikiRepo|wiki-repo"` audit (per plan-a-02 Step 2) currently shows zero ghbridge importers of `WikiRepo`; if the audit at PR time uncovers wiki-flow code that the 2026-05-30 snapshot missed, it's rewired here (or in plan-a-02 if the migration interlock pulls it forward). The service's own ambient-dep migration now centers on `Date.now()` for discussion-context timestamps (`index.js`, `src/injection.js`) → `runtime.clock.now`, plus any `process.env` / `node:fs` / `node:child_process` usage in `graphql.js` / `discussion-adapter.js`. HTTP lifecycle, body limit, and security headers moved into `libbridge` → `libhttp`, so they are no longer migrated here.
+- Bridge hardening already in place (MAX_REPLY_COUNT, sanitization) is untouched; `bodyLimit` now lives in `libhttp`.
 
 ## graph
 
@@ -105,20 +126,21 @@ Sub-row: `1370/services-mcp\tplan\timplemented`.
 
 Blocking: plan-a-01.
 
-Files (src): `services/mcp/index.js`, `services/mcp/server.js` (no `src/` subtree). MCP transport service.
+Files (src): `services/mcp/index.js`, `services/mcp/server.js` (no `src/` subtree; `test/http.test.js` is the transport contract test from Step 2 — it exercises `/health`, the 401 path, and a real `initialize` handshake over the escape hatch). MCP transport service.
 
-- libmcp boundary already excluded from SDK wrapping; service-level migration covers project-internal ambient-dep usage only.
+- No longer runs its own `node:http` server: `mcp` mounts on `libhttp` and hands the raw Node req/res to the MCP SDK's `StreamableHTTPServerTransport` through the escape hatch (`c.env.incoming` / `c.env.outgoing`, returning `RESPONSE_ALREADY_SENT`), with `libhttp`'s body limit disabled so the SDK reads an untouched body. libmcp / the SDK stay excluded from wrapping.
+- Remaining ambient surface is the **clock** only: `Date.now()` for per-session `lastActivity` stamps and `setInterval` for the idle-session sweep → `runtime.clock.now` and `runtime.clock.setInterval`. The former `EADDRINUSE` and shutdown-timeout `process.exit` calls were removed in the libhttp migration; signal handling now lives in `server.js` (`SIGINT`/`SIGTERM` → `service.stop()`), which clears the sweep timer and closes sessions through `libhttp`'s `onStop` hook.
 
 ## msbridge
 
 Sub-row: `1370/services-msbridge\tplan\timplemented`.
 
-Blocking: plan-a-01; plan-a-02 (libwiki).
+Blocking: plan-a-01; plan-a-02 (libwiki); plan-a-04 (libbridge — HTTP transport + ProgressTicker/ElapsedScheduler clock).
 
 Files (src): `services/msbridge/index.js`, `services/msbridge/server.js`, `services/msbridge/src/discussion-adapter.js`, `services/msbridge/src/teams.js`.
 
 - The pre-PR `rg "WikiRepo|wiki-repo"` audit currently shows zero msbridge importers of `WikiRepo`; same conditional rewire as ghbridge. Recent fixes — `e9b9e5a6` HMAC refactor, `5624831f` cascade auth cleanup, `d6b43163` hardening, `0df0d073` format auto-fix — are preserved untouched.
-- Migration covers `process.env.SERVICE_SECRET` / similar (already removed; verify), `Date.now()` for typing-ticker cadence (`runtime.clock.now`), `setTimeout` for typing ticker (`runtime.clock.setTimeout`).
+- Migration now centers on `Date.now()` for discussion-context timestamps in `index.js` → `runtime.clock.now`. The typing-ticker cadence (`setInterval` in `ProgressTicker`) and the `elapsed`-resume `setTimeout` (`ElapsedScheduler`, already on an injected `#clock`) live in `libbridge`, not the service — they migrate in libbridge's plan-a-04 row. HTTP lifecycle / body limit moved into `libbridge` → `libhttp`.
 
 ## oauth
 
@@ -128,7 +150,7 @@ Blocking: plan-a-01.
 
 Files (src): `services/oauth/index.js`, `services/oauth/server.js` (no `src/` subtree). OAuth dance handler.
 
-- `process.env` for OAuth client secrets; `Date.now()` for token expiry; `node:fs` for state persistence (if any).
+- Thinnest HTTP service: `index.js` delegates entirely to `libhttp` and the gRPC `providerClient`, so it carries **no** ambient deps — no `process.env`, `Date.now()`, or `node:fs` (client secrets and host/port arrive through `createServiceConfig` in `server.js`; there is no token-expiry or state-persistence logic in the adapter). Migration is the standard `{ runtime }` construction in `server.js`, which already wires `SIGINT`/`SIGTERM` → `service.stop()`.
 
 ## pathway (service)
 
@@ -173,7 +195,9 @@ After every service's PR merges:
 Libraries used: libutil (Runtime), libmock (createTestRuntime + fakes —
 especially createMockSubprocess for shell-out tests), libcli where the
 service ships an admin CLI, each service's library dependencies (libwiki,
-libgraph, libvector per section), libmcp for mcp / others as needed.
+libgraph, libvector per section), libhttp (ambient-clean HTTP transport
+composed by oauth / mcp / bridges — no 1370 row of its own), libbridge (HTTP
++ scheduling clock for the bridges), libmcp for mcp / others as needed.
 
 ## Master row advance
 
@@ -186,6 +210,6 @@ This is the only condition that flips the master row.
 - **Service migration without consumer awareness.** A service whose RPC contract evolves during migration (even if the contract test still passes) may surprise the gateway. Mitigation: contract tests must include canary cases the gateway also runs; release-merge gates service PRs on both the local contract test and the gateway's contract verification (where available).
 - **Bridge service async-cascade collides with existing hardening.** msbridge / ghbridge's hardening commits introduced precise error-path semantics. Migration must preserve them exactly. Mitigation: each bridge PR's diff shows hardening lines untouched; release-merge inspects.
 - **services that read `process.env` lazily during request handling.** A `runtime.proc.env` Proxy preserves late-binding token rotation ([design § Collaborator Surfaces](design-a.md#collaborator-surfaces)). Tests must specifically exercise the rotation path against `createMockProcess({ env })` mutation between requests.
-- **services/mcp and external SDK boundary.** MCP's SDK is out of scope; if a service module re-implements MCP transport semantics inline (rather than calling the SDK), migrating that module surfaces the inline reimplementation. Mitigation: per-service audit lists every `node:net` / `node:http` direct use and the PR rewrites them through the SDK or `runtime` collaborators, not both.
+- **services/mcp and external SDK boundary.** Resolved by the 2026-05-30 libhttp migration: mcp no longer runs its own `node:http` server — it mounts on `libhttp` and hands the raw Node req/res to the MCP SDK transport via the documented escape hatch (`c.env.incoming` / `c.env.outgoing` + `RESPONSE_ALREADY_SENT`). The `node:net` / `node:http` direct-use audit now returns clean for mcp, so the remaining migration is purely the clock surface (`Date.now()` / `setInterval`); there is no inline transport reimplementation left to surface.
 
 — Staff Engineer 🛠️


### PR DESCRIPTION
## Summary

- Add `@forwardimpact/libhttp` — a `createHttpService` factory that owns the shared HTTP transport boilerplate (security headers, body limit, error envelope, `/health`, port binding, `address()`, graceful `stop()`), the HTTP counterpart to `librpc`'s `Server`. Services mount routes via a `configure(app)` callback; `libhttp/src` is ambient-clean (network I/O only).
- Migrate all four HTTP services onto it: `oauth` mounts routes directly; `ghbridge`/`msbridge` via `libbridge`'s `createBridgeServer` (refactored to compose `libhttp`); `mcp` mounts on it too, reaching the MCP SDK transport through a raw-Node escape hatch (`c.env.incoming`/`c.env.outgoing` + `RESPONSE_ALREADY_SENT`, body limit disabled). Signal handling lives in each `server.js`.
- `tracer` is injected alongside `logger` and forwarded to `configure` for upcoming route-level spans.
- Share one JTBD between `librpc` and `libhttp` ("Ship Service Endpoints Without Boilerplate") so the catalog stays compact; `librpc` leaves the type-themed group.
- Ground spec 1370 plan part 06 in the new codebase (libhttp is ambient-clean → no 1370 sub-row; mcp no longer uses `node:http`; bridges' HTTP lifecycle/bodyLimit moved into libbridge→libhttp).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai8PvGnwS6vwpTYEce4j73)_