### PR TITLE
refactor(services): migrate to injected clock collaborator (#1370 part-06)

### DIFF
--- a/libraries/libmock/src/mock/clock.js
+++ b/libraries/libmock/src/mock/clock.js
@@ -11,11 +11,14 @@ import { spy } from "./spy.js";
  * Pass `{ sleep, now }` from a returned clock to any constructor that
  * accepts those collaborators to make its tests deterministic.
  *
- * `setTimeout(fn, ms)` / `clearTimeout(handle)` delegate to the host's real
- * timers (matching `createDefaultClock`), so a migrated module that schedules
- * work through the injected clock keeps its real-timer test behaviour. Virtual
- * `now()` and real `setTimeout` are intentionally independent — a test that
- * needs a fired timer waits on real time as it did before migration.
+ * `setTimeout(fn, ms)` / `clearTimeout(handle)` / `setInterval(fn, ms)` /
+ * `clearInterval(handle)` delegate to the host's real timers (matching
+ * `createDefaultClock`), so a migrated module that schedules work through the
+ * injected clock keeps its real-timer test behaviour. Virtual `now()` and the
+ * real timers are intentionally independent — a test that needs a fired timer
+ * waits on real time as it did before migration; a periodic sweep timer is
+ * typically `.unref()`'d and never fires during a unit test, which exercises
+ * its eviction path through an explicit `now` argument instead.
  *
  * @param {object} [options]
  * @param {number} [options.start=0] - Initial virtual time in ms.
@@ -24,6 +27,8 @@ import { spy } from "./spy.js";
  *   sleep: (ms: number) => Promise<void>,
  *   setTimeout: (fn: Function, ms: number) => *,
  *   clearTimeout: (handle: *) => void,
+ *   setInterval: (fn: Function, ms: number) => *,
+ *   clearInterval: (handle: *) => void,
  *   advance: (ms: number) => void,
  *   set: (ms: number) => void,
  *   sleeps: Array<number>,
@@ -44,6 +49,8 @@ export function createMockClock({ start = 0 } = {}) {
     sleep,
     setTimeout: (fn, ms) => setTimeout(fn, ms),
     clearTimeout: (handle) => clearTimeout(handle),
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (handle) => clearInterval(handle),
     advance(ms) {
       current += ms;
     },

--- a/libraries/libutil/src/runtime.js
+++ b/libraries/libutil/src/runtime.js
@@ -40,7 +40,8 @@ import { Finder } from "./finder.js";
  *   `exitCode` accessor.
  * @property {Object} clock
  *   Time surface: `now()`, `sleep(ms)`, `setTimeout(fn, ms)`,
- *   `clearTimeout(handle)`.
+ *   `clearTimeout(handle)`, `setInterval(fn, ms)`, `clearInterval(handle)`.
+ *   The interval handle mirrors the host timer (so callers may `.unref()` it).
  * @property {Object} subprocess
  *   Subprocess surface: `run(cmd, args, opts) -> Promise<{stdout, stderr,
  *   exitCode}>` (async, buffered), `runSync(cmd, args, opts) -> {stdout,
@@ -134,7 +135,7 @@ function lineIterator(stream) {
 
 /**
  * Build the clock surface backed by real timers.
- * @returns {{now: () => number, sleep: (ms: number) => Promise<void>, setTimeout: Function, clearTimeout: Function}}
+ * @returns {{now: () => number, sleep: (ms: number) => Promise<void>, setTimeout: Function, clearTimeout: Function, setInterval: Function, clearInterval: Function}}
  */
 export function createDefaultClock() {
   return {
@@ -142,6 +143,8 @@ export function createDefaultClock() {
     sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
     setTimeout: (fn, ms) => setTimeout(fn, ms),
     clearTimeout: (handle) => clearTimeout(handle),
+    setInterval: (fn, ms) => setInterval(fn, ms),
+    clearInterval: (handle) => clearInterval(handle),
   };
 }
 

--- a/libraries/libutil/test/runtime.test.js
+++ b/libraries/libutil/test/runtime.test.js
@@ -1,7 +1,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
 
-import { createTestRuntime } from "@forwardimpact/libmock";
+import { createTestRuntime, createMockClock } from "@forwardimpact/libmock";
 
 import {
   createDefaultRuntime,
@@ -104,6 +104,20 @@ describe("createDefaultClock / createDefaultSubprocess", () => {
     await clock.sleep(1);
   });
 
+  test("clock.setInterval returns an unref-able host handle; clearInterval stops it", () => {
+    const clock = createDefaultClock();
+    let fired = 0;
+    // 1h period guarantees the callback never fires within the test.
+    const handle = clock.setInterval(() => fired++, 3_600_000);
+    // The handle must mirror the host timer so periodic sweepers can `.unref()`
+    // it (design § Collaborator Surfaces — a load-bearing contract for the
+    // service idle-session/TTL reapers).
+    assert.strictEqual(typeof handle.unref, "function");
+    handle.unref();
+    clock.clearInterval(handle);
+    assert.strictEqual(fired, 0);
+  });
+
   test("subprocess.run echoes via a real binary", async () => {
     const sub = createDefaultSubprocess();
     const result = await sub.run("node", ["-e", "process.stdout.write('hi')"]);
@@ -155,6 +169,20 @@ describe("createDefaultClock / createDefaultSubprocess", () => {
     assert.strictEqual(child.pid, undefined);
     assert.strictEqual(await child.exitCode, 127);
     assert.strictEqual(await child.signal, null);
+  });
+});
+
+describe("createMockClock interval surface", () => {
+  test("setInterval returns an unref-able handle; clearInterval stops it", () => {
+    const clock = createMockClock();
+    let fired = 0;
+    const handle = clock.setInterval(() => fired++, 3_600_000);
+    // The fake delegates to the host timer (matching createDefaultClock), so a
+    // migrated sweeper injected with createMockClock keeps the `.unref()` seam.
+    assert.strictEqual(typeof handle.unref, "function");
+    handle.unref();
+    clock.clearInterval(handle);
+    assert.strictEqual(fired, 0);
   });
 });
 

--- a/scripts/check-ambient-deps.deny.yml
+++ b/scripts/check-ambient-deps.deny.yml
@@ -20,7 +20,3 @@ libraries/libutil/src/retry.js:
   - set-timeout
 libraries/libutil/src/wait.js:
   - date-now
-services/ghuser/src/stores.js:
-  - date-now
-services/ghbridge/src/injection.js:
-  - date-now

--- a/services/bridge/index.js
+++ b/services/bridge/index.js
@@ -18,12 +18,21 @@ export class BridgeService extends BridgeBase {
   #originTtlMs;
   #pendingTtlMs;
   #sweepTimer;
+  #clock;
 
   /**
-   *
+   * @param {object} config
+   * @param {object} deps
+   * @param {object} deps.storage
+   * @param {object} deps.logger
+   * @param {object} [deps.tracer]
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} deps.clock
+   *   Injected clock collaborator (`now`/`setInterval`/`clearInterval`).
    */
-  constructor(config, { storage, logger, tracer }) {
+  constructor(config, { storage, logger, tracer, clock }) {
     super(config);
+    if (!clock) throw new Error("clock is required");
+    this.#clock = clock;
     this.#discussions = new BufferedIndex(storage, "discussions.jsonl", {
       flush_interval: config.discussion_flush_interval_ms,
       max_buffer_size: config.discussion_max_buffer_size,
@@ -48,8 +57,8 @@ export class BridgeService extends BridgeBase {
     this.#conversationTtlMs = config.conversation_ttl_ms;
     this.#originTtlMs = config.origin_ttl_ms;
     this.#pendingTtlMs = config.pending_ttl_ms ?? 10 * 60 * 1000;
-    this.#sweepTimer = setInterval(() => {
-      this.#sweep(Date.now()).catch((e) => logger.error?.("sweep", e));
+    this.#sweepTimer = this.#clock.setInterval(() => {
+      this.#sweep(this.#clock.now()).catch((e) => logger.error?.("sweep", e));
     }, config.sweep_interval_ms);
     this.#sweepTimer.unref();
   }
@@ -144,7 +153,7 @@ export class BridgeService extends BridgeBase {
       seq,
       text: msg.text ?? "",
       author: msg.author ?? "",
-      enqueued_at: msg.enqueued_at ?? Date.now(),
+      enqueued_at: msg.enqueued_at ?? this.#clock.now(),
     };
     await this.#inbox.add(entry);
     await this.#inbox.flush();
@@ -177,7 +186,7 @@ export class BridgeService extends BridgeBase {
       surface: p.surface,
       surface_user_id: p.surface_user_id,
       discussion_id: p.discussion_id,
-      created_at: Number(p.created_at) || Date.now(),
+      created_at: Number(p.created_at) || this.#clock.now(),
     });
     return {};
   }
@@ -212,7 +221,7 @@ export class BridgeService extends BridgeBase {
    *
    */
   async Sweep(req) {
-    const now = req.now ?? Date.now();
+    const now = req.now ?? this.#clock.now();
     const { evicted_discussions, evicted_origins, evicted_pending } =
       await this.#sweep(now);
     return { evicted_discussions, evicted_origins, evicted_pending };
@@ -272,7 +281,7 @@ export class BridgeService extends BridgeBase {
    *
    */
   async shutdown() {
-    clearInterval(this.#sweepTimer);
+    this.#clock.clearInterval(this.#sweepTimer);
     await Promise.all([
       this.#discussions.flush(),
       this.#origins.flush(),

--- a/services/bridge/package.json
+++ b/services/bridge/package.json
@@ -48,7 +48,8 @@
     "@forwardimpact/librpc": "^0.1.77",
     "@forwardimpact/libstorage": "^0.1.53",
     "@forwardimpact/libtelemetry": "^0.1.41",
-    "@forwardimpact/libtype": "^0.1.63"
+    "@forwardimpact/libtype": "^0.1.63",
+    "@forwardimpact/libutil": "^0.1.85"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/services/bridge/server.js
+++ b/services/bridge/server.js
@@ -5,6 +5,7 @@ import { Server, createTracer } from "@forwardimpact/librpc";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { createStorage } from "@forwardimpact/libstorage";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { BridgeService } from "./index.js";
 
@@ -23,8 +24,9 @@ const logger = createLogger("bridge");
 const tracer = await createTracer("bridge");
 
 const storage = createStorage("bridges");
+const { clock } = createDefaultRuntime();
 
-const service = new BridgeService(config, { storage, logger, tracer });
+const service = new BridgeService(config, { storage, logger, tracer, clock });
 const server = new Server(service, config, logger, tracer);
 
 await server.start();

--- a/services/bridge/test/bridge.test.js
+++ b/services/bridge/test/bridge.test.js
@@ -7,6 +7,7 @@ import {
   createMockConfig,
   createMockStorage,
   createMockLogger,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 const DEFAULTS = {
@@ -32,6 +33,7 @@ describe("bridge service", () => {
       storage,
       logger,
       tracer: null,
+      clock: createMockClock({ start: Date.now() }),
     });
   });
 

--- a/services/embedding/test/contract.test.js
+++ b/services/embedding/test/contract.test.js
@@ -1,0 +1,67 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+
+import { EmbeddingService } from "../index.js";
+
+// RPC-contract snapshot (plan-a-06 Step 2 substitution for services): the
+// embedding adapter is a thin translator over the TEI HTTP backend, so the
+// contract is the request it issues and the proto-shaped response it returns.
+// The backend is stubbed via a fake `fetch`, so no real subprocess or network
+// is touched — the test exercises only the adapter's record shape.
+
+describe("embedding service contract", () => {
+  const config = { backend_port: 8090, model: "test-model" };
+  const backendUrl = "http://127.0.0.1:8090";
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("construction requires a backendUrl", () => {
+    assert.throws(() => new EmbeddingService(config, ""), /backendUrl/);
+  });
+
+  test("CreateEmbeddings posts to the TEI endpoint and maps embeddings to values", async () => {
+    const calls = [];
+    globalThis.fetch = async (url, init) => {
+      calls.push({ url, init });
+      return {
+        ok: true,
+        json: async () => ({
+          data: [{ embedding: [0.1, 0.2] }, { embedding: [0.3, 0.4] }],
+        }),
+      };
+    };
+
+    const service = new EmbeddingService(config, backendUrl);
+    const res = await service.CreateEmbeddings({ input: ["a", "b"] });
+
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].url, `${backendUrl}/v1/embeddings`);
+    assert.strictEqual(calls[0].init.method, "POST");
+    // The adapter intentionally sends a fixed `model: "default"` (TEI is
+    // single-model per process; the model is selected at spawn via
+    // `--model-id`), so `config.model` does not flow into the request body.
+    assert.deepStrictEqual(JSON.parse(calls[0].init.body), {
+      input: ["a", "b"],
+      model: "default",
+    });
+    assert.deepStrictEqual(res, {
+      data: [{ values: [0.1, 0.2] }, { values: [0.3, 0.4] }],
+    });
+  });
+
+  test("CreateEmbeddings throws on a non-2xx backend response", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 503 });
+    const service = new EmbeddingService(config, backendUrl);
+    await assert.rejects(
+      () => service.CreateEmbeddings({ input: ["a"] }),
+      /503/,
+    );
+  });
+});

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -82,6 +82,7 @@ export class GhBridgeService {
   #resume;
   #bridge;
   #onCallback;
+  #clock;
 
   /**
    * @param {import("@forwardimpact/libbridge").BridgeConfig & {
@@ -93,10 +94,12 @@ export class GhBridgeService {
    * @param {object} deps.discussionClient - BridgeClient instance
    * @param {(secret: string, body: string, signature: string) => Promise<boolean>} deps.verifyWebhook
    * @param {(query: string, vars: object) => Promise<unknown>} deps.graphqlClient
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} deps.clock
+   *   Injected clock collaborator (`now()` for discussion-context timestamps).
    * @param {Acknowledgement} [deps.acknowledgement] - Override (tests)
    */
   constructor(config, deps) {
-    const { logger, tracer, discussionClient, verifyWebhook } = deps;
+    const { logger, tracer, discussionClient, verifyWebhook, clock } = deps;
     if (!logger) throw new Error("logger is required");
     if (!tracer) throw new Error("tracer is required");
     if (!discussionClient) throw new Error("discussionClient is required");
@@ -104,11 +107,13 @@ export class GhBridgeService {
       throw new Error("verifyWebhook is required");
     }
     if (!deps.ghuserClient) throw new Error("ghuserClient is required");
+    if (!clock) throw new Error("clock is required");
     this.#config = config;
     this.#logger = logger;
     this.#tracer = tracer;
     this.#verifyWebhook = verifyWebhook;
     this.#graphqlClient = deps.graphqlClient;
+    this.#clock = clock;
 
     this.#store = new DiscussionAdapter(discussionClient);
     this.#client = discussionClient;
@@ -265,7 +270,7 @@ export class GhBridgeService {
       const ctx = await this.#loadOrCreateContext(discussionId, discussion);
 
       appendHistory(ctx.history, { role: "user", text, author: requester });
-      ctx.last_active_at = Date.now();
+      ctx.last_active_at = this.#clock.now();
       await this.#store.add(ctx);
 
       const limit = this.#rateLimiter.check(discussionId, ctx.dispatches);
@@ -342,7 +347,7 @@ export class GhBridgeService {
       if (!ctx) ctx = await this.#loadOrCreateContext(discussionId, discussion);
 
       appendHistory(ctx.history, { role: "user", text, author: requester });
-      ctx.last_active_at = Date.now();
+      ctx.last_active_at = this.#clock.now();
       await this.#store.add(ctx);
 
       const { freshDispatchAllowed } = await this.#resume.processInbound(ctx);
@@ -352,6 +357,7 @@ export class GhBridgeService {
           client: this.#client,
           graphqlClient: this.#graphqlClient,
           recordOrigin: this.#recordOrigin(ctx),
+          clock: this.#clock,
         });
         if (inject) {
           await this.#store.add(ctx);
@@ -484,7 +490,7 @@ export class GhBridgeService {
       surface: CHANNEL,
       surface_user_id: requester,
       discussion_id: ctx.discussion_id,
-      created_at: Date.now(),
+      created_at: this.#clock.now(),
     });
 
     await postSingleDiscussionReply(
@@ -526,7 +532,7 @@ export class GhBridgeService {
         bridge.Origin.fromObject({
           id: comment.id,
           discussion_id: ctx.discussion_id,
-          posted_at: Date.now(),
+          posted_at: this.#clock.now(),
         }),
       );
     };

--- a/services/ghbridge/package.json
+++ b/services/ghbridge/package.json
@@ -47,6 +47,7 @@
     "@forwardimpact/librpc": "^0.1.99",
     "@forwardimpact/libtelemetry": "^0.1.42",
     "@forwardimpact/libtype": "^0.1.63",
+    "@forwardimpact/libutil": "^0.1.85",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/graphql": "^9.0.3",
     "@octokit/webhooks-methods": "^6.0.0"

--- a/services/ghbridge/server.js
+++ b/services/ghbridge/server.js
@@ -8,6 +8,7 @@ import { verify } from "@octokit/webhooks-methods";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { clients, createTracer } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { GhBridgeService } from "./index.js";
 
@@ -46,6 +47,8 @@ const ghuserClient = new GhuserClient(ghuserConfig, logger, tracer);
 const bridgeConfig = await createServiceConfig("bridge");
 const discussionClient = new BridgeClient(bridgeConfig, logger, tracer);
 
+const { clock } = createDefaultRuntime();
+
 const service = new GhBridgeService(config, {
   logger,
   tracer,
@@ -54,6 +57,7 @@ const service = new GhBridgeService(config, {
   getInstallationToken,
   graphqlClient,
   ghuserClient,
+  clock,
 });
 
 await service.start();

--- a/services/ghbridge/src/injection.js
+++ b/services/ghbridge/src/injection.js
@@ -7,13 +7,21 @@ import { postSingleDiscussionReply } from "./graphql.js";
  * Try to inject a message into an active run's inbox, or post a static
  * notice if the requester is not the session owner.
  *
+ * @param {object} ctx
+ * @param {string} requester
+ * @param {string} text
+ * @param {object} deps
+ * @param {object} deps.client
+ * @param {Function} deps.graphqlClient
+ * @param {Function} deps.recordOrigin
+ * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} deps.clock
  * @returns {{ kind: "injected"|"noticed" } | null}
  */
 export async function tryInject(
   ctx,
   requester,
   text,
-  { client, graphqlClient, recordOrigin },
+  { client, graphqlClient, recordOrigin, clock },
 ) {
   if (
     Object.keys(ctx.pending_callbacks).length === 0 ||
@@ -29,11 +37,11 @@ export async function tryInject(
           correlation_id: correlationId,
           text,
           author: String(requester),
-          enqueued_at: Date.now(),
+          enqueued_at: clock.now(),
         },
       }),
     );
-    ctx.last_active_at = Date.now();
+    ctx.last_active_at = clock.now();
     return { kind: "injected" };
   }
   await postSingleDiscussionReply(

--- a/services/ghbridge/test/callback.test.js
+++ b/services/ghbridge/test/callback.test.js
@@ -4,6 +4,7 @@ import {
   createMockConfig,
   createMockLogger,
   createMockTracer,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
@@ -42,6 +43,7 @@ async function newService() {
   const service = new GhBridgeService(makeConfig(), {
     logger: createMockLogger(),
     tracer: createMockTracer(),
+    clock: createMockClock(),
     discussionClient: createStatefulDiscussionClient(),
     verifyWebhook: (s, b, sig) =>
       import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/ghbridge/test/dispatch-auth.test.js
+++ b/services/ghbridge/test/dispatch-auth.test.js
@@ -4,6 +4,7 @@ import {
   createMockConfig,
   createMockLogger,
   createMockTracer,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
@@ -74,6 +75,7 @@ describe("ghbridge dispatch-auth", () => {
     return new GhBridgeService(makeConfig(), {
       logger: createMockLogger(),
       tracer: createMockTracer(),
+      clock: createMockClock(),
       discussionClient: createStatefulDiscussionClient(),
       verifyWebhook: (s, b, sig) =>
         import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/ghbridge/test/reply-path.test.js
+++ b/services/ghbridge/test/reply-path.test.js
@@ -4,6 +4,7 @@ import {
   createMockConfig,
   createMockLogger,
   createMockTracer,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
@@ -45,6 +46,7 @@ describe("ghbridge reply path", () => {
     service = new GhBridgeService(makeConfig(), {
       logger: createMockLogger(),
       tracer: createMockTracer(),
+      clock: createMockClock(),
       discussionClient: createStatefulDiscussionClient(),
       verifyWebhook: (s, b, sig) =>
         import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/ghbridge/test/resume.test.js
+++ b/services/ghbridge/test/resume.test.js
@@ -4,6 +4,7 @@ import {
   createMockConfig,
   createMockLogger,
   createMockTracer,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
@@ -35,6 +36,7 @@ async function newService() {
   const service = new GhBridgeService(makeConfig(), {
     logger: createMockLogger(),
     tracer: createMockTracer(),
+    clock: createMockClock(),
     discussionClient: createStatefulDiscussionClient(),
     verifyWebhook: (s, b, sig) =>
       import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/ghbridge/test/webhook.test.js
+++ b/services/ghbridge/test/webhook.test.js
@@ -4,6 +4,7 @@ import {
   createMockConfig,
   createMockLogger,
   createMockTracer,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 import { GhBridgeService } from "../index.js";
@@ -55,6 +56,7 @@ async function newService({ dispatchImpl } = {}) {
   const service = new GhBridgeService(config, {
     logger: createMockLogger(),
     tracer: createMockTracer(),
+    clock: createMockClock(),
     discussionClient,
     verifyWebhook: (s, b, sig) =>
       import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),

--- a/services/ghuser/index.js
+++ b/services/ghuser/index.js
@@ -17,6 +17,7 @@ export class GhuserService extends GhuserBase {
   #grants;
   #github;
   #linkBaseUrl;
+  #clock;
 
   /**
    * @param {object} config
@@ -25,14 +26,19 @@ export class GhuserService extends GhuserBase {
    * @param {import("./src/stores.js").FlowStore} deps.flows
    * @param {import("./src/stores.js").GrantStore} deps.grants
    * @param {ReturnType<import("./src/github-oauth.js").createGithubOAuth>} deps.github
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} deps.clock
+   *   Injected clock collaborator; drives flow/grant timestamps and token
+   *   expiry comparisons (`now()`).
    */
-  constructor(config, { bindings, flows, grants, github }) {
+  constructor(config, { bindings, flows, grants, github, clock }) {
     super(config);
+    if (!clock) throw new Error("clock is required");
     this.#bindings = bindings;
     this.#flows = flows;
     this.#grants = grants;
     this.#github = github;
     this.#linkBaseUrl = config.link_base_url;
+    this.#clock = clock;
   }
 
   /**
@@ -50,7 +56,7 @@ export class GhuserService extends GhuserBase {
       code_challenge: req.code_challenge ?? null,
       redirect_uri: req.redirect_uri ?? null,
       client_state: req.client_state ?? null,
-      created_at: Date.now(),
+      created_at: this.#clock.now(),
     });
 
     const upstreamUrl = this.#github.authorizeUrl({
@@ -94,7 +100,7 @@ export class GhuserService extends GhuserBase {
       access_token: tokens.access_token,
       refresh_token: tokens.refresh_token ?? null,
       expires_at: tokens.expires_in
-        ? Date.now() + tokens.expires_in * 1000
+        ? this.#clock.now() + tokens.expires_in * 1000
         : null,
       scopes: flow.scopes ?? [],
     });
@@ -108,7 +114,7 @@ export class GhuserService extends GhuserBase {
         code_challenge: flow.code_challenge,
         redirect_uri: flow.redirect_uri,
         client_state: flow.client_state,
-        created_at: Date.now(),
+        created_at: this.#clock.now(),
       });
       return {
         downstream_code: downstreamCode,
@@ -148,7 +154,10 @@ export class GhuserService extends GhuserBase {
       access_token: binding.access_token,
       token_type: "bearer",
       expires_in: binding.expires_at
-        ? Math.max(0, Math.floor((binding.expires_at - Date.now()) / 1000))
+        ? Math.max(
+            0,
+            Math.floor((binding.expires_at - this.#clock.now()) / 1000),
+          )
         : 0,
     };
   }
@@ -173,7 +182,7 @@ export class GhuserService extends GhuserBase {
 
     if (
       binding.expires_at &&
-      Date.now() > binding.expires_at - EXPIRY_BUFFER_MS
+      this.#clock.now() > binding.expires_at - EXPIRY_BUFFER_MS
     ) {
       if (!binding.refresh_token) {
         return { result: "re_auth_required", re_auth_required: {} };
@@ -184,7 +193,7 @@ export class GhuserService extends GhuserBase {
         binding.refresh_token =
           refreshed.refresh_token ?? binding.refresh_token;
         binding.expires_at = refreshed.expires_in
-          ? Date.now() + refreshed.expires_in * 1000
+          ? this.#clock.now() + refreshed.expires_in * 1000
           : null;
         await this.#bindings.upsert(binding);
       } catch (err) {

--- a/services/ghuser/package.json
+++ b/services/ghuser/package.json
@@ -48,7 +48,8 @@
     "@forwardimpact/librpc": "^0.1.99",
     "@forwardimpact/libstorage": "^0.1.78",
     "@forwardimpact/libtelemetry": "^0.1.42",
-    "@forwardimpact/libtype": "^0.1.0"
+    "@forwardimpact/libtype": "^0.1.0",
+    "@forwardimpact/libutil": "^0.1.85"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/services/ghuser/server.js
+++ b/services/ghuser/server.js
@@ -5,6 +5,7 @@ import { Server, createTracer } from "@forwardimpact/librpc";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { createStorage } from "@forwardimpact/libstorage";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { GhuserService } from "./index.js";
 import { BindingStore, FlowStore, GrantStore } from "./src/stores.js";
 import { createGithubOAuth } from "./src/github-oauth.js";
@@ -24,11 +25,18 @@ const github = createGithubOAuth({
   clientSecret: config.client_secret,
 });
 
+const { clock } = createDefaultRuntime();
 const bindings = new BindingStore(storage);
-const flows = new FlowStore(storage);
-const grants = new GrantStore(storage);
+const flows = new FlowStore(storage, { clock });
+const grants = new GrantStore(storage, { clock });
 
-const service = new GhuserService(config, { bindings, flows, grants, github });
+const service = new GhuserService(config, {
+  bindings,
+  flows,
+  grants,
+  github,
+  clock,
+});
 const server = new Server(service, config, logger, tracer);
 
 await server.start();

--- a/services/ghuser/src/stores.js
+++ b/services/ghuser/src/stores.js
@@ -71,6 +71,7 @@ export class BindingStore extends BufferedIndex {
 class TtlStore extends BufferedIndex {
   #ttlMs;
   #sweepTimer;
+  #clock;
 
   /**
    * @param {import("@forwardimpact/libstorage").StorageInterface} storage
@@ -78,6 +79,8 @@ class TtlStore extends BufferedIndex {
    * @param {object} [options]
    * @param {number} [options.ttlMs]
    * @param {number} [options.sweepIntervalMs]
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} options.clock
+   *   Injected clock collaborator (`now`/`setInterval`/`clearInterval`).
    */
   constructor(
     storage,
@@ -85,12 +88,15 @@ class TtlStore extends BufferedIndex {
     {
       ttlMs = DEFAULT_TTL_MS,
       sweepIntervalMs = DEFAULT_SWEEP_INTERVAL_MS,
+      clock,
     } = {},
   ) {
     super(storage, indexKey, { flush_interval: 1_000, max_buffer_size: 100 });
+    if (!clock) throw new Error("clock is required");
+    this.#clock = clock;
     this.#ttlMs = ttlMs;
-    this.#sweepTimer = setInterval(
-      () => this.#sweep(Date.now()),
+    this.#sweepTimer = this.#clock.setInterval(
+      () => this.#sweep(this.#clock.now()),
       sweepIntervalMs,
     );
     this.#sweepTimer.unref();
@@ -99,7 +105,7 @@ class TtlStore extends BufferedIndex {
   /** Stop the periodic sweep timer. */
   stopSweep() {
     if (this.#sweepTimer) {
-      clearInterval(this.#sweepTimer);
+      this.#clock.clearInterval(this.#sweepTimer);
       this.#sweepTimer = null;
     }
   }

--- a/services/ghuser/test/identity-verification.test.js
+++ b/services/ghuser/test/identity-verification.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { createMockConfig } from "@forwardimpact/libmock";
+import { createMockConfig, createMockClock } from "@forwardimpact/libmock";
 import { createMockStorage } from "@forwardimpact/libmock/mock";
 import { GhuserService } from "../index.js";
 import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
@@ -9,12 +9,14 @@ function createService(storage, { getUserId = "12345" } = {}) {
   const config = createMockConfig("ghuser", {
     link_base_url: "http://localhost:3007",
   });
+  const clock = createMockClock({ start: Date.now() });
   const bindings = new BindingStore(storage);
   return {
     service: new GhuserService(config, {
       bindings,
-      flows: new FlowStore(storage),
-      grants: new GrantStore(storage),
+      flows: new FlowStore(storage, { clock }),
+      grants: new GrantStore(storage, { clock }),
+      clock,
       github: {
         authorizeUrl: () => "http://gh/authorize",
         exchangeCode: async () => ({

--- a/services/ghuser/test/query-contract.test.js
+++ b/services/ghuser/test/query-contract.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { createMockConfig } from "@forwardimpact/libmock";
+import { createMockConfig, createMockClock } from "@forwardimpact/libmock";
 import { createMockStorage } from "@forwardimpact/libmock/mock";
 import { GhuserService } from "../index.js";
 import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
@@ -11,11 +11,13 @@ describe("ghuser query-contract (SC#8)", () => {
     const config = createMockConfig("ghuser", {
       link_base_url: "http://localhost:3007",
     });
+    const clock = createMockClock({ start: Date.now() });
     const bindings = new BindingStore(storage);
     const service = new GhuserService(config, {
       bindings,
-      flows: new FlowStore(storage),
-      grants: new GrantStore(storage),
+      flows: new FlowStore(storage, { clock }),
+      grants: new GrantStore(storage, { clock }),
+      clock,
       github: {
         authorizeUrl: () => "",
         exchangeCode: async () => ({}),

--- a/services/ghuser/test/query-linked.test.js
+++ b/services/ghuser/test/query-linked.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { createMockConfig } from "@forwardimpact/libmock";
+import { createMockConfig, createMockClock } from "@forwardimpact/libmock";
 import { createMockStorage } from "@forwardimpact/libmock/mock";
 import { GhuserService } from "../index.js";
 import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
@@ -11,11 +11,13 @@ describe("ghuser query-linked (SC#4)", () => {
     const config = createMockConfig("ghuser", {
       link_base_url: "http://localhost:3007",
     });
+    const clock = createMockClock({ start: Date.now() });
     const bindings = new BindingStore(storage);
     const service = new GhuserService(config, {
       bindings,
-      flows: new FlowStore(storage),
-      grants: new GrantStore(storage),
+      flows: new FlowStore(storage, { clock }),
+      grants: new GrantStore(storage, { clock }),
+      clock,
       github: {
         authorizeUrl: () => "",
         exchangeCode: async () => ({}),
@@ -45,11 +47,13 @@ describe("ghuser query-linked (SC#4)", () => {
     const config = createMockConfig("ghuser", {
       link_base_url: "http://localhost:3007",
     });
+    const clock = createMockClock({ start: Date.now() });
     const bindings = new BindingStore(storage);
     const service = new GhuserService(config, {
       bindings,
-      flows: new FlowStore(storage),
-      grants: new GrantStore(storage),
+      flows: new FlowStore(storage, { clock }),
+      grants: new GrantStore(storage, { clock }),
+      clock,
       github: {
         authorizeUrl: () => "",
         exchangeCode: async () => ({}),

--- a/services/ghuser/test/query-reauth.test.js
+++ b/services/ghuser/test/query-reauth.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { createMockConfig } from "@forwardimpact/libmock";
+import { createMockConfig, createMockClock } from "@forwardimpact/libmock";
 import { createMockStorage } from "@forwardimpact/libmock/mock";
 import { GhuserService } from "../index.js";
 import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
@@ -12,11 +12,13 @@ describe("ghuser query-reauth (SC#6)", () => {
     const config = createMockConfig("ghuser", {
       link_base_url: "http://localhost:3007",
     });
+    const clock = createMockClock({ start: Date.now() });
     const bindings = new BindingStore(storage);
     const service = new GhuserService(config, {
       bindings,
-      flows: new FlowStore(storage),
-      grants: new GrantStore(storage),
+      flows: new FlowStore(storage, { clock }),
+      grants: new GrantStore(storage, { clock }),
+      clock,
       github: {
         authorizeUrl: () => "",
         exchangeCode: async () => ({}),
@@ -51,11 +53,13 @@ describe("ghuser query-reauth (SC#6)", () => {
     const config = createMockConfig("ghuser", {
       link_base_url: "http://localhost:3007",
     });
+    const clock = createMockClock({ start: Date.now() });
     const bindings = new BindingStore(storage);
     const service = new GhuserService(config, {
       bindings,
-      flows: new FlowStore(storage),
-      grants: new GrantStore(storage),
+      flows: new FlowStore(storage, { clock }),
+      grants: new GrantStore(storage, { clock }),
+      clock,
       github: {
         authorizeUrl: () => "",
         exchangeCode: async () => ({}),
@@ -86,11 +90,13 @@ describe("ghuser query-reauth (SC#6)", () => {
     const config = createMockConfig("ghuser", {
       link_base_url: "http://localhost:3007",
     });
+    const clock = createMockClock({ start: Date.now() });
     const bindings = new BindingStore(storage);
     const service = new GhuserService(config, {
       bindings,
-      flows: new FlowStore(storage),
-      grants: new GrantStore(storage),
+      flows: new FlowStore(storage, { clock }),
+      grants: new GrantStore(storage, { clock }),
+      clock,
       github: {
         authorizeUrl: () => "",
         exchangeCode: async () => ({}),

--- a/services/ghuser/test/query-unlinked.test.js
+++ b/services/ghuser/test/query-unlinked.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { createMockConfig } from "@forwardimpact/libmock";
+import { createMockConfig, createMockClock } from "@forwardimpact/libmock";
 import { createMockStorage } from "@forwardimpact/libmock/mock";
 import { GhuserService } from "../index.js";
 import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
@@ -11,10 +11,12 @@ describe("ghuser query-unlinked (SC#5)", () => {
     const config = createMockConfig("ghuser", {
       link_base_url: "http://localhost:3007",
     });
+    const clock = createMockClock({ start: Date.now() });
     const service = new GhuserService(config, {
       bindings: new BindingStore(storage),
-      flows: new FlowStore(storage),
-      grants: new GrantStore(storage),
+      flows: new FlowStore(storage, { clock }),
+      grants: new GrantStore(storage, { clock }),
+      clock,
       github: {
         authorizeUrl: () => "",
         exchangeCode: async () => ({}),

--- a/services/ghuser/test/smoke.test.js
+++ b/services/ghuser/test/smoke.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { createMockConfig } from "@forwardimpact/libmock";
+import { createMockConfig, createMockClock } from "@forwardimpact/libmock";
 import { createMockStorage } from "@forwardimpact/libmock/mock";
 import { GhuserService } from "../index.js";
 import { BindingStore, FlowStore, GrantStore } from "../src/stores.js";
@@ -11,10 +11,12 @@ describe("ghuser smoke (SC#1)", () => {
     const config = createMockConfig("ghuser", {
       link_base_url: "http://localhost:3007",
     });
+    const clock = createMockClock({ start: Date.now() });
     const service = new GhuserService(config, {
       bindings: new BindingStore(storage),
-      flows: new FlowStore(storage),
-      grants: new GrantStore(storage),
+      flows: new FlowStore(storage, { clock }),
+      grants: new GrantStore(storage, { clock }),
+      clock,
       github: {
         authorizeUrl: () => "http://gh",
         exchangeCode: async () => ({}),

--- a/services/mcp/index.js
+++ b/services/mcp/index.js
@@ -64,8 +64,8 @@ export function isAuthorized(req, expectedToken) {
   return crypto.timingSafeEqual(Buffer.from(auth), Buffer.from(expected));
 }
 
-async function dispatchExistingSession(req, res, session, logger) {
-  session.lastActivity = Date.now();
+async function dispatchExistingSession(req, res, session, logger, clock) {
+  session.lastActivity = clock.now();
   try {
     await session.transport.handleRequest(req, res);
   } catch (err) {
@@ -74,7 +74,7 @@ async function dispatchExistingSession(req, res, session, logger) {
 }
 
 async function dispatchNewSession(req, res, ctx) {
-  const { sessions, makeServer, promptText, logger } = ctx;
+  const { sessions, makeServer, promptText, logger, clock } = ctx;
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => crypto.randomUUID(),
   });
@@ -91,7 +91,7 @@ async function dispatchNewSession(req, res, ctx) {
 
   const sid = transport.sessionId;
   if (sid) {
-    sessions.set(sid, { transport, server, lastActivity: Date.now() });
+    sessions.set(sid, { transport, server, lastActivity: clock.now() });
   }
 }
 
@@ -108,7 +108,7 @@ async function dispatchNewSession(req, res, ctx) {
  * `c.env.incoming`/`c.env.outgoing` and returns the `RESPONSE_ALREADY_SENT`
  * sentinel; libhttp's body limit is disabled so the SDK reads an untouched body.
  *
- * @param {{ config: object, logger: object, tracer?: object, graphClient: object, vectorClient: object, pathwayClient: object, mapClient: object, resourceIndex: object }} deps
+ * @param {{ config: object, logger: object, tracer?: object, graphClient: object, vectorClient: object, pathwayClient: object, mapClient: object, resourceIndex: object, clock: import("@forwardimpact/libutil/runtime").Runtime["clock"] }} deps
  * @returns {{ app: import("hono").Hono, address: () => object|null, start: () => Promise<void>, stop: () => Promise<void> }}
  */
 export function createMcpService({
@@ -120,7 +120,9 @@ export function createMcpService({
   pathwayClient,
   mapClient,
   resourceIndex,
+  clock,
 }) {
+  if (!clock) throw new Error("clock is required");
   function makeServer(promptText) {
     const server = new McpServer(
       { name: "guide", version: "0.1.0" },
@@ -152,7 +154,7 @@ export function createMcpService({
   const promptText = buildPromptText(config.system_prompt, config.tools);
   const expectedToken = config.mcpToken();
   const sessions = new Map();
-  const ctx = { sessions, makeServer, promptText, logger };
+  const ctx = { sessions, makeServer, promptText, logger, clock };
   let sweepTimer = null;
 
   const httpService = createHttpService({
@@ -175,7 +177,7 @@ export function createMcpService({
         const sessionId = req.headers["mcp-session-id"];
         const existing = sessionId && sessions.get(sessionId);
         if (existing) {
-          await dispatchExistingSession(req, res, existing, logger);
+          await dispatchExistingSession(req, res, existing, logger, clock);
         } else {
           await dispatchNewSession(req, res, ctx);
         }
@@ -184,7 +186,7 @@ export function createMcpService({
     },
     async onStop() {
       logger.info("Shutting down MCP server");
-      if (sweepTimer) clearInterval(sweepTimer);
+      if (sweepTimer) clock.clearInterval(sweepTimer);
       await Promise.allSettled(
         [...sessions.values()].map((s) => s.server.close()),
       );
@@ -196,8 +198,8 @@ export function createMcpService({
     app: httpService.app,
     address: httpService.address,
     async start() {
-      sweepTimer = setInterval(() => {
-        const now = Date.now();
+      sweepTimer = clock.setInterval(() => {
+        const now = clock.now();
         for (const [sid, session] of sessions) {
           if (now - session.lastActivity > SESSION_IDLE_MS) {
             logger.info(`Reaping idle session ${sid}`);

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -48,6 +48,7 @@
     "@forwardimpact/librpc": "^0.1.92",
     "@forwardimpact/libtelemetry": "^0.1.35",
     "@forwardimpact/libtype": "^0.1.68",
+    "@forwardimpact/libutil": "^0.1.85",
     "@forwardimpact/svcmap": "^0.1.0",
     "@hono/node-server": "^2.0.4",
     "@modelcontextprotocol/sdk": "^1.29.0"

--- a/services/mcp/server.js
+++ b/services/mcp/server.js
@@ -5,6 +5,7 @@ import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createResourceIndex } from "@forwardimpact/libresource";
 import { createClient, createTracer } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { createMcpService } from "./index.js";
 
@@ -20,6 +21,7 @@ const vectorClient = await createClient("vector", logger, tracer);
 const pathwayClient = await createClient("pathway", logger, tracer);
 const mapClient = await createClient("map", logger, tracer);
 const resourceIndex = createResourceIndex("resources");
+const { clock } = createDefaultRuntime();
 
 const service = createMcpService({
   config,
@@ -30,6 +32,7 @@ const service = createMcpService({
   pathwayClient,
   mapClient,
   resourceIndex,
+  clock,
 });
 
 await service.start();

--- a/services/mcp/test/http.test.js
+++ b/services/mcp/test/http.test.js
@@ -1,6 +1,6 @@
 import { test, describe, before, after } from "node:test";
 import assert from "node:assert";
-import { spy } from "@forwardimpact/libmock";
+import { spy, createMockClock } from "@forwardimpact/libmock";
 
 import { createMcpService } from "../index.js";
 
@@ -31,6 +31,7 @@ describe("MCP HTTP transport", () => {
       graphClient: {},
       vectorClient: {},
       pathwayClient: {},
+      clock: createMockClock({ start: Date.now() }),
     });
     await service.start();
     baseUrl = `http://127.0.0.1:${service.address().port}`;

--- a/services/mcp/test/mcp.test.js
+++ b/services/mcp/test/mcp.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { spy } from "@forwardimpact/libmock";
+import { spy, createMockClock } from "@forwardimpact/libmock";
 
 import { buildPromptText, createMcpService, isAuthorized } from "../index.js";
 import { registerToolsFromConfig } from "@forwardimpact/libmcp";
@@ -182,6 +182,7 @@ describe("MCP service", () => {
         graphClient: clients.graph,
         vectorClient: clients.vector,
         pathwayClient: clients.pathway,
+        clock: createMockClock({ start: Date.now() }),
       });
       assert.strictEqual(typeof start, "function");
     });

--- a/services/msbridge/index.js
+++ b/services/msbridge/index.js
@@ -67,6 +67,7 @@ export class MsBridgeService {
   #resume;
   #bridge;
   #onCallback;
+  #clock;
 
   /**
    * @param {import("@forwardimpact/libbridge").BridgeConfig & {
@@ -79,6 +80,8 @@ export class MsBridgeService {
    * @param {import("@forwardimpact/libtelemetry").Tracer} deps.tracer
    * @param {object} deps.discussionClient - BridgeClient instance
    * @param {object} deps.ghuserClient - ghuser gRPC client
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} deps.clock
+   *   Injected clock collaborator (`now()` for discussion-context timestamps).
    * @param {object} [deps.adapter] - Bot Framework adapter override (tests)
    * @param {Acknowledgement} [deps.acknowledgement] - Override (tests)
    */
@@ -91,14 +94,17 @@ export class MsBridgeService {
       ghuserClient,
       adapter,
       acknowledgement,
+      clock,
     },
   ) {
     if (!logger) throw new Error("logger is required");
     if (!tracer) throw new Error("tracer is required");
     if (!discussionClient) throw new Error("discussionClient is required");
     if (!ghuserClient) throw new Error("ghuserClient is required");
+    if (!clock) throw new Error("clock is required");
     this.#logger = logger;
     this.#tracer = tracer;
+    this.#clock = clock;
     this.#config = config;
     this.#msAppId = () => config.msAppId();
 
@@ -245,7 +251,7 @@ export class MsBridgeService {
       ctx.participants[0].metadata = ref;
 
       appendHistory(ctx.history, { role: "user", text, author: requester });
-      ctx.last_active_at = Date.now();
+      ctx.last_active_at = this.#clock.now();
       await this.#store.add(ctx);
 
       const { freshDispatchAllowed } = await this.#resume.processInbound(ctx);
@@ -370,11 +376,11 @@ export class MsBridgeService {
             correlation_id: correlationId,
             text,
             author: String(requester),
-            enqueued_at: Date.now(),
+            enqueued_at: this.#clock.now(),
           },
         }),
       );
-      ctx.last_active_at = Date.now();
+      ctx.last_active_at = this.#clock.now();
       return { kind: "injected" };
     }
     await sendReply(
@@ -430,7 +436,7 @@ export class MsBridgeService {
       surface: CHANNEL,
       surface_user_id: requester,
       discussion_id: ctx.discussion_id,
-      created_at: Date.now(),
+      created_at: this.#clock.now(),
     });
 
     const ref = ctx.participants?.[0]?.metadata;

--- a/services/msbridge/package.json
+++ b/services/msbridge/package.json
@@ -46,6 +46,7 @@
     "@forwardimpact/librpc": "^0.1.99",
     "@forwardimpact/libtelemetry": "^0.1.42",
     "@forwardimpact/libtype": "^0.1.63",
+    "@forwardimpact/libutil": "^0.1.85",
     "botbuilder": "^4.23.3"
   },
   "devDependencies": {

--- a/services/msbridge/server.js
+++ b/services/msbridge/server.js
@@ -4,6 +4,7 @@ import "@forwardimpact/libpreflight/node22";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { clients, createTracer } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { MsBridgeService } from "./index.js";
 
@@ -20,10 +21,13 @@ const ghuserClient = new GhuserClient(ghuserConfig, logger, tracer);
 const bridgeConfig = await createServiceConfig("bridge");
 const discussionClient = new BridgeClient(bridgeConfig, logger, tracer);
 
+const { clock } = createDefaultRuntime();
+
 const service = new MsBridgeService(config, {
   logger,
   tracer,
   discussionClient,
   ghuserClient,
+  clock,
 });
 await service.start();

--- a/services/msbridge/test/dispatch-auth.test.js
+++ b/services/msbridge/test/dispatch-auth.test.js
@@ -5,6 +5,7 @@ import {
   createMockDiscussionClient,
   createMockLogger,
   createMockTracer,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 import { MsBridgeService } from "../index.js";
@@ -106,6 +107,7 @@ describe("msbridge dispatch-auth", () => {
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
       tracer: createMockTracer(),
+      clock: createMockClock(),
       discussionClient: createMockDiscussionClient(),
       ghuserClient: client,
       adapter,
@@ -149,6 +151,7 @@ describe("msbridge dispatch-auth", () => {
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
       tracer: createMockTracer(),
+      clock: createMockClock(),
       discussionClient: createMockDiscussionClient(),
       ghuserClient: client,
       adapter,
@@ -185,6 +188,7 @@ describe("msbridge dispatch-auth", () => {
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
       tracer: createMockTracer(),
+      clock: createMockClock(),
       discussionClient: createMockDiscussionClient(),
       ghuserClient: client,
       adapter,
@@ -218,6 +222,7 @@ describe("msbridge dispatch-auth", () => {
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
       tracer: createMockTracer(),
+      clock: createMockClock(),
       discussionClient: createMockDiscussionClient(),
       ghuserClient: client,
       adapter,
@@ -252,6 +257,7 @@ describe("msbridge dispatch-auth", () => {
     const service = new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
       tracer: createMockTracer(),
+      clock: createMockClock(),
       discussionClient: createMockDiscussionClient(),
       ghuserClient: client,
       adapter,

--- a/services/msbridge/test/msbridge.test.js
+++ b/services/msbridge/test/msbridge.test.js
@@ -5,6 +5,7 @@ import {
   createMockDiscussionClient,
   createMockLogger,
   createMockTracer,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 import {
@@ -79,6 +80,7 @@ function newService({
   return new MsBridgeService(makeConfig(configOverrides), {
     logger: logger ?? createMockLogger(),
     tracer: createMockTracer(),
+    clock: createMockClock(),
     discussionClient: createStatefulDiscussionClient(),
     ghuserClient: ghuserClient ?? makeGhuserClient(),
     adapter: adapter ?? makeAdapter(),
@@ -146,6 +148,7 @@ describe("msbridge service", () => {
         () =>
           new MsBridgeService(makeConfig(), {
             tracer: createMockTracer(),
+            clock: createMockClock(),
             discussionClient: createMockDiscussionClient(),
             adapter: makeAdapter(),
           }),
@@ -169,6 +172,7 @@ describe("msbridge service", () => {
           new MsBridgeService(makeConfig(), {
             logger: createMockLogger(),
             tracer: createMockTracer(),
+            clock: createMockClock(),
             adapter: makeAdapter(),
           }),
       ).toThrow("discussionClient is required");

--- a/services/msbridge/test/resume.test.js
+++ b/services/msbridge/test/resume.test.js
@@ -4,6 +4,7 @@ import {
   createMockConfig,
   createMockLogger,
   createMockTracer,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 import { MsBridgeService } from "../index.js";
@@ -105,6 +106,7 @@ describe("msbridge resume", () => {
     return new MsBridgeService(makeConfig(), {
       logger: createMockLogger(),
       tracer: createMockTracer(),
+      clock: createMockClock(),
       discussionClient,
       ghuserClient: makeGhuserClient(),
       adapter,

--- a/services/msbridge/test/startup.test.js
+++ b/services/msbridge/test/startup.test.js
@@ -5,6 +5,7 @@ import {
   createMockLogger,
   createMockDiscussionClient,
   createMockTracer,
+  createMockClock,
 } from "@forwardimpact/libmock";
 
 import { MsBridgeService } from "../index.js";
@@ -44,6 +45,7 @@ describe("msbridge startup", () => {
         new MsBridgeService(makeConfig(), {
           logger: createMockLogger(),
           tracer: createMockTracer(),
+          clock: createMockClock(),
           discussionClient: createMockDiscussionClient(),
           adapter: makeAdapter(),
         }),

--- a/specs/1370-ambient-dependencies-to-injected-collaborators/design-a.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/design-a.md
@@ -115,7 +115,10 @@ bin shim along with the src modules it drives.
   `exitCode` so libcli's existing pattern survives without a rewrite).
 - `runtime.clock` — `now()` (ms); `sleep(ms)` is the primary wait
   primitive (Promise); `setTimeout(fn, ms)` / `clearTimeout(h)` for
-  fire-and-forget scheduling (debounce, watchdog) only.
+  fire-and-forget scheduling (debounce, watchdog) only;
+  `setInterval(fn, ms)` / `clearInterval(h)` for periodic sweepers
+  (added in plan-a-06 for the service idle-session/TTL reapers — the
+  returned handle mirrors the host timer so callers may `.unref()` it).
 - `runtime.subprocess` — `run(cmd, args, opts) → Promise<{ stdout,
   stderr, exitCode }>` for one-shot commands (replaces every current
   `spawnSync` / `execFileSync`); `runSync(cmd, args, opts) → { stdout,


### PR DESCRIPTION
## Summary

Part 06 (services) of spec 1370 — ambient dependencies → injected collaborators. Threads an injected `clock` collaborator through the services so periodic timers and timestamps no longer reach for the global `Date.now()`/`setInterval`.

**Foundation** (`feat(libutil,libmock)`):
- Adds `setInterval`/`clearInterval` to the Runtime clock surface (`createDefaultClock` + `createMockClock`), returning the real host handle so sweepers stay `.unref()`-able. Syncs the design's Collaborator Surfaces and adds direct unit coverage.

**Services** (`refactor(services)`):
- Migrates the five services with residual domain time usage — `bridge`, `ghuser`, `ghbridge`, `msbridge`, `mcp` — to `clock.now()` / `clock.setInterval` / `clock.clearInterval`; `server.js` wires the production clock via `createDefaultRuntime()`, tests inject `createMockClock`.
- Drains the ambient-deps deny-list of its two remaining service entries (`ghuser/src/stores.js`, `ghbridge/src/injection.js`).
- Records the seven services already ambient-clean after the libhttp transport migration; `embedding` gains a contract test (it had none).
- Declares the `@forwardimpact/libutil` dependency on the five migrated services.

Bridge hardening (rate limiting, sanitization, HMAC/cascade auth) is untouched — diffs are limited to clock substitutions and constructor wiring. Verified locally: `bun run check`, `bun run invariants`, and the full suite (4117 pass / 0 fail). Two independent 5-reviewer panels returned 0 blocker / 0 high / 0 medium.

**STATUS note:** spec 1370 is multi-part and its `teardown` unit is still pending, so the consolidated `1370` row stays at `plan approved` rather than advancing to `plan implemented`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_016jw3x8HiGaLo24GJzxNfiy

---
_Generated by [Claude Code](https://claude.ai/code/session_016jw3x8HiGaLo24GJzxNfiy)_