### PR TITLE
refactor(1370): tear down ambient-dependency bridges (require injected runtime)

### DIFF
--- a/libraries/libbridge/src/callback-handler.js
+++ b/libraries/libbridge/src/callback-handler.js
@@ -1,5 +1,3 @@
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
-
 import { validateCallbackPayload } from "./callback-payload.js";
 
 /**
@@ -60,8 +58,9 @@ export function createCallbackHandler({
   loadDiscussionId,
   ackFinishTarget,
   handleReply,
-  clock = createDefaultClock(),
+  clock,
 }) {
+  if (!clock) throw new Error("clock is required");
   if (!channel) throw new Error("channel is required");
   if (!callbacks) throw new Error("callbacks is required");
   if (!ack) throw new Error("ack is required");

--- a/libraries/libbridge/src/callback-payload.js
+++ b/libraries/libbridge/src/callback-payload.js
@@ -1,5 +1,3 @@
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
-
 export const MAX_FIELD_LENGTH = 2000;
 export const MAX_REPLY_COUNT = 50;
 
@@ -129,8 +127,9 @@ export function newDiscussionContext({
   channel,
   discussionId,
   participant,
-  clock = createDefaultClock(),
+  clock,
 }) {
+  if (!clock) throw new Error("clock is required");
   return {
     id: `${channel}:${discussionId}`,
     channel,

--- a/libraries/libbridge/src/callback-registry.js
+++ b/libraries/libbridge/src/callback-registry.js
@@ -1,7 +1,5 @@
 import { randomUUID } from "node:crypto";
 
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
-
 const DEFAULT_TTL_MS = 2 * 60 * 60 * 1000;
 
 /**
@@ -25,7 +23,8 @@ export class CallbackRegistry {
    * @param {number} [options.ttlMs] - Time-to-live in ms (default: 2h)
    * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} [options.clock]
    */
-  constructor({ ttlMs = DEFAULT_TTL_MS, clock = createDefaultClock() } = {}) {
+  constructor({ ttlMs = DEFAULT_TTL_MS, clock } = {}) {
+    if (!clock) throw new Error("clock is required");
     this.#ttlMs = ttlMs;
     this.#clock = clock;
   }

--- a/libraries/libbridge/src/dispatcher.js
+++ b/libraries/libbridge/src/dispatcher.js
@@ -1,7 +1,5 @@
 import { randomUUID } from "node:crypto";
 
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
-
 import { dispatchWorkflow } from "./dispatch.js";
 
 /** Dispatch dance: resolve per-user token, register callback, ack, fire workflow, flush. */
@@ -37,7 +35,7 @@ export class Dispatcher {
     githubRepo,
     tokenResolver,
     tenantResolver,
-    clock = createDefaultClock(),
+    clock,
   }) {
     if (!callbacks) throw new Error("callbacks is required");
     if (!ack) throw new Error("ack is required");
@@ -49,6 +47,7 @@ export class Dispatcher {
     if (!githubRepo) throw new Error("githubRepo is required");
     if (!tokenResolver) throw new Error("tokenResolver is required");
     if (!tenantResolver) throw new Error("tenantResolver is required");
+    if (!clock) throw new Error("clock is required");
     this.#callbacks = callbacks;
     this.#ack = ack;
     this.#store = store;

--- a/libraries/libbridge/src/elapsed-scheduler.js
+++ b/libraries/libbridge/src/elapsed-scheduler.js
@@ -1,5 +1,3 @@
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
-
 const CHUNK_CAP_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
@@ -22,8 +20,9 @@ export class ElapsedScheduler {
    * @param {(err: Error, correlationId: string) => void} [options.onError] - Invoked when `onFire` rejects.
    * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} [options.clock]
    */
-  constructor({ onFire, onError = () => {}, clock = createDefaultClock() }) {
+  constructor({ onFire, onError = () => {}, clock }) {
     if (typeof onFire !== "function") throw new Error("onFire is required");
+    if (!clock) throw new Error("clock is required");
     this.#onFire = onFire;
     this.#onError = onError;
     this.#clock = clock;

--- a/libraries/libbridge/src/inbox-handler.js
+++ b/libraries/libbridge/src/inbox-handler.js
@@ -1,5 +1,4 @@
 import { bridge } from "@forwardimpact/libtype";
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
 
 /**
  * Long-poll handler for the per-correlation inbox. The run's InboxPoller
@@ -18,8 +17,9 @@ export function createInboxHandler({
   logger,
   pollTimeoutMs = 30_000,
   pollIntervalMs = 1_000,
-  clock = createDefaultClock(),
+  clock,
 }) {
+  if (!clock) throw new Error("clock is required");
   return async (c) => {
     const correlationId = c.req.param("correlationId");
     const sinceSeq = parseInt(c.req.query("since") ?? "0", 10);

--- a/libraries/libbridge/src/index.js
+++ b/libraries/libbridge/src/index.js
@@ -29,10 +29,7 @@ export { appendHistory } from "./history.js";
 export { RateLimiter } from "./rate-limit.js";
 export { dispatchWorkflow } from "./dispatch.js";
 export { ProgressTicker } from "./progress-ticker.js";
-export {
-  Acknowledgement,
-  DEFAULT_TYPING_VERBS,
-} from "./acknowledgement.js";
+export { Acknowledgement, DEFAULT_TYPING_VERBS } from "./acknowledgement.js";
 export { Dispatcher } from "./dispatcher.js";
 export {
   DefaultTenantResolver,

--- a/libraries/libbridge/src/rate-limit.js
+++ b/libraries/libbridge/src/rate-limit.js
@@ -1,5 +1,3 @@
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
-
 /**
  * Sliding-window rate limiter. Operates on a caller-owned `dispatches: number[]`
  * array of timestamps and returns a structured result so callers can both
@@ -16,11 +14,8 @@ export class RateLimiter {
    * @param {number} [options.max] - Max dispatches allowed in the window (default: 5)
    * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} [options.clock]
    */
-  constructor({
-    windowMs = 60_000,
-    max = 5,
-    clock = createDefaultClock(),
-  } = {}) {
+  constructor({ windowMs = 60_000, max = 5, clock } = {}) {
+    if (!clock) throw new Error("clock is required");
     this.#windowMs = windowMs;
     this.#max = max;
     this.#clock = clock;

--- a/libraries/libbridge/src/resume-scheduler.js
+++ b/libraries/libbridge/src/resume-scheduler.js
@@ -1,5 +1,3 @@
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
-
 import { ElapsedScheduler } from "./elapsed-scheduler.js";
 import { evaluateTrigger, parseIsoDuration } from "./triggers.js";
 
@@ -36,7 +34,7 @@ export class ResumeScheduler {
     buildCallbackMeta = (ctx) => ({ discussionId: ctx.discussion_id }),
     buildResumeInputs = () => ({}),
     onDeclined = null,
-    clock = createDefaultClock(),
+    clock,
   }) {
     if (!dispatcher) throw new Error("dispatcher is required");
     if (!store) throw new Error("store is required");
@@ -49,6 +47,7 @@ export class ResumeScheduler {
     if (onDeclined != null && typeof onDeclined !== "function") {
       throw new Error("onDeclined must be a function");
     }
+    if (!clock) throw new Error("clock is required");
     this.#dispatcher = dispatcher;
     this.#store = store;
     this.#logger = logger ?? null;

--- a/libraries/libbridge/test/callback-handler.test.js
+++ b/libraries/libbridge/test/callback-handler.test.js
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createDefaultClock } from "@forwardimpact/libutil/runtime";
 
 import { Acknowledgement } from "../src/acknowledgement.js";
 import {
@@ -119,6 +120,8 @@ async function seed(
   return { token, correlationId, ctx };
 }
 
+const clock = createDefaultClock();
+
 describe("createCallbackHandler", () => {
   let store;
   let callbacks;
@@ -131,13 +134,14 @@ describe("createCallbackHandler", () => {
 
   beforeEach(() => {
     store = createFakeAdapter();
-    callbacks = new CallbackRegistry();
+    callbacks = new CallbackRegistry({ clock });
     reactions = makeReactionAdapter();
     ack = new Acknowledgement({ reactionAdapter: reactions });
     logger = makeLogger();
     tracer = makeTracer();
     handleReplyCalls = [];
     handler = createCallbackHandler({
+      clock,
       channel,
       callbacks,
       ack,
@@ -153,9 +157,10 @@ describe("createCallbackHandler", () => {
   });
 
   test("rejects construction when required options are missing", () => {
-    expect(() => createCallbackHandler({})).toThrow();
+    expect(() => createCallbackHandler({ clock })).toThrow();
     expect(() =>
       createCallbackHandler({
+        clock,
         channel: "c",
         callbacks,
         ack,
@@ -266,6 +271,7 @@ describe("createCallbackHandler", () => {
     const { token, correlationId } = await seed(store, callbacks);
     let finishedFirst = false;
     handler = createCallbackHandler({
+      clock,
       channel,
       callbacks,
       ack,
@@ -296,6 +302,7 @@ describe("createCallbackHandler", () => {
   test("ackFinishTarget is forwarded when supplied", async () => {
     const { token, correlationId } = await seed(store, callbacks);
     handler = createCallbackHandler({
+      clock,
       channel,
       callbacks,
       ack,
@@ -324,6 +331,7 @@ describe("createCallbackHandler", () => {
   test("handleReply may throw CallbackHandlerError to short-circuit with a custom status", async () => {
     const { token, correlationId } = await seed(store, callbacks);
     handler = createCallbackHandler({
+      clock,
       channel,
       callbacks,
       ack,
@@ -426,6 +434,7 @@ describe("createCallbackHandler", () => {
   test("unexpected handleReply errors return 500", async () => {
     const { token, correlationId } = await seed(store, callbacks);
     handler = createCallbackHandler({
+      clock,
       channel,
       callbacks,
       ack,

--- a/libraries/libbridge/test/callback-payload.test.js
+++ b/libraries/libbridge/test/callback-payload.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createDefaultClock } from "@forwardimpact/libutil/runtime";
 
 import {
   MAX_FIELD_LENGTH,
@@ -7,6 +8,8 @@ import {
   normalizeBaseUrl,
   validateCallbackPayload,
 } from "../src/callback-payload.js";
+
+const clock = createDefaultClock();
 
 describe("validateCallbackPayload", () => {
   test("rejects non-object bodies", () => {
@@ -235,6 +238,7 @@ describe("newDiscussionContext", () => {
       metadata: { node_id: "U_1" },
     };
     const ctx = newDiscussionContext({
+      clock,
       channel: "github-discussions",
       discussionId: "D_kw1",
       participant,
@@ -256,6 +260,7 @@ describe("newDiscussionContext", () => {
   test("supports the msteams channel shape", () => {
     const ref = { conversation: { id: "thread-1" } };
     const ctx = newDiscussionContext({
+      clock,
       channel: "msteams",
       discussionId: "thread-1",
       participant: { name: "teams-user", kind: "human", metadata: ref },

--- a/libraries/libbridge/test/callback-registry.test.js
+++ b/libraries/libbridge/test/callback-registry.test.js
@@ -1,12 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { createDefaultClock } from "@forwardimpact/libutil/runtime";
 
 import { CallbackRegistry } from "../src/callback-registry.js";
 
 const DEFAULT = { tenant_id: "default" };
 
+const clock = createDefaultClock();
+
 describe("CallbackRegistry", () => {
   test("register returns a token and consume returns the metadata once", () => {
-    const reg = new CallbackRegistry();
+    const reg = new CallbackRegistry({ clock });
     const token = reg.register("corr-1", {
       threadId: "T1",
       tenant_id: "default",
@@ -26,7 +29,7 @@ describe("CallbackRegistry", () => {
   });
 
   test("peek returns metadata without consuming and clones the entry", () => {
-    const reg = new CallbackRegistry();
+    const reg = new CallbackRegistry({ clock });
     const token = reg.register("corr-2", { tenant_id: "default" });
     const peeked = reg.peek(token, DEFAULT);
     expect(peeked.correlationId).toBe("corr-2");
@@ -39,20 +42,20 @@ describe("CallbackRegistry", () => {
   });
 
   test("register rejects empty correlationId", () => {
-    const reg = new CallbackRegistry();
+    const reg = new CallbackRegistry({ clock });
     expect(() => reg.register("", { tenant_id: "default" })).toThrow();
     expect(() => reg.register(undefined, { tenant_id: "default" })).toThrow();
   });
 
   test("register requires meta.tenant_id", () => {
-    const reg = new CallbackRegistry();
+    const reg = new CallbackRegistry({ clock });
     expect(() => reg.register("corr", {})).toThrow(/tenant_id/);
     expect(() => reg.register("corr")).toThrow(/tenant_id/);
     expect(() => reg.register("corr", { tenant_id: "" })).toThrow(/tenant_id/);
   });
 
   test("consume returns null when tenant_id does not match the stored binding", () => {
-    const reg = new CallbackRegistry();
+    const reg = new CallbackRegistry({ clock });
     const token = reg.register("corr-mismatch", { tenant_id: "tenant-a" });
     expect(reg.consume(token, { tenant_id: "tenant-b" })).toBeNull();
     // Mismatched consume leaves the entry intact for the rightful caller.
@@ -63,14 +66,14 @@ describe("CallbackRegistry", () => {
   });
 
   test("peek returns null when tenant_id does not match the stored binding", () => {
-    const reg = new CallbackRegistry();
+    const reg = new CallbackRegistry({ clock });
     const token = reg.register("corr-peek", { tenant_id: "tenant-a" });
     expect(reg.peek(token, { tenant_id: "tenant-b" })).toBeNull();
     expect(reg.peek(token, { tenant_id: "tenant-a" })).not.toBeNull();
   });
 
   test("consume and peek require a tenant_id argument", () => {
-    const reg = new CallbackRegistry();
+    const reg = new CallbackRegistry({ clock });
     const token = reg.register("corr-required", { tenant_id: "default" });
     expect(() => reg.consume(token)).toThrow(/tenant_id/);
     expect(() => reg.consume(token, {})).toThrow(/tenant_id/);
@@ -79,7 +82,7 @@ describe("CallbackRegistry", () => {
   });
 
   test("sweep evicts entries older than ttlMs (caller-provided clock)", () => {
-    const reg = new CallbackRegistry({ ttlMs: 1000 });
+    const reg = new CallbackRegistry({ clock, ttlMs: 1000 });
     const before = Date.now();
     const a = reg.register("corr-a", { tenant_id: "default" });
     const b = reg.register("corr-b", { tenant_id: "default" });
@@ -95,7 +98,7 @@ describe("CallbackRegistry", () => {
   });
 
   test("default ttlMs matches the legacy 2h constant", () => {
-    const reg = new CallbackRegistry();
+    const reg = new CallbackRegistry({ clock });
     const before = Date.now();
     reg.register("corr-default-ttl", { tenant_id: "default" });
     const twoHours = 2 * 60 * 60 * 1000;
@@ -104,7 +107,7 @@ describe("CallbackRegistry", () => {
   });
 
   test("issues unique tokens for distinct correlationIds", () => {
-    const reg = new CallbackRegistry();
+    const reg = new CallbackRegistry({ clock });
     const t1 = reg.register("a", { tenant_id: "default" });
     const t2 = reg.register("b", { tenant_id: "default" });
     expect(t1).not.toBe(t2);

--- a/libraries/libbridge/test/dispatcher.test.js
+++ b/libraries/libbridge/test/dispatcher.test.js
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createDefaultClock } from "@forwardimpact/libutil/runtime";
 
 import { Acknowledgement } from "../src/acknowledgement.js";
 import { CallbackRegistry } from "../src/callback-registry.js";
@@ -96,6 +97,8 @@ function makeDefaultTenantResolver(channel = "test-channel") {
   return new DefaultTenantResolver({ channel });
 }
 
+const clock = createDefaultClock();
+
 describe("Dispatcher", () => {
   let store;
   let callbacks;
@@ -106,11 +109,12 @@ describe("Dispatcher", () => {
 
   beforeEach(() => {
     store = createFakeAdapter();
-    callbacks = new CallbackRegistry();
+    callbacks = new CallbackRegistry({ clock });
     reactions = makeReactionAdapter();
     ack = new Acknowledgement({ reactionAdapter: reactions });
     fetchStub = stubFetch();
     dispatcher = new Dispatcher({
+      clock,
       callbacks,
       ack,
       store,
@@ -127,10 +131,11 @@ describe("Dispatcher", () => {
   });
 
   test("rejects construction when required options are missing", () => {
-    expect(() => new Dispatcher({})).toThrow();
+    expect(() => new Dispatcher({ clock })).toThrow();
     expect(
       () =>
         new Dispatcher({
+          clock,
           callbacks,
           ack,
           store,
@@ -142,6 +147,7 @@ describe("Dispatcher", () => {
     expect(
       () =>
         new Dispatcher({
+          clock,
           callbacks,
           ack,
           store,
@@ -252,6 +258,7 @@ describe("Dispatcher", () => {
 
   test("token resolver result is used as the dispatch token", async () => {
     dispatcher = new Dispatcher({
+      clock,
       callbacks,
       ack,
       store,
@@ -282,6 +289,7 @@ describe("Dispatcher", () => {
 
   test("link_required: no ack, no workflow, no callback registered", async () => {
     dispatcher = new Dispatcher({
+      clock,
       callbacks,
       ack,
       store,
@@ -315,6 +323,7 @@ describe("Dispatcher", () => {
 
   test("reauth_required: no ack, no workflow, no callback registered", async () => {
     dispatcher = new Dispatcher({
+      clock,
       callbacks,
       ack,
       store,
@@ -344,6 +353,7 @@ describe("Dispatcher", () => {
 
   test("transient: no ack, no workflow, no callback registered", async () => {
     dispatcher = new Dispatcher({
+      clock,
       callbacks,
       ack,
       store,
@@ -401,6 +411,7 @@ describe("Dispatcher", () => {
       ResolveByTenantId: async () => null,
     };
     dispatcher = new Dispatcher({
+      clock,
       callbacks,
       ack,
       store,
@@ -434,6 +445,7 @@ describe("Dispatcher", () => {
       resolveByTenantId: async () => null,
     };
     dispatcher = new Dispatcher({
+      clock,
       callbacks,
       ack,
       store,

--- a/libraries/libbridge/test/elapsed-scheduler.test.js
+++ b/libraries/libbridge/test/elapsed-scheduler.test.js
@@ -1,17 +1,21 @@
 import { describe, expect, test } from "bun:test";
+import { createDefaultClock } from "@forwardimpact/libutil/runtime";
 
 import { ElapsedScheduler } from "../src/elapsed-scheduler.js";
 
 const wait = (ms) => new Promise((r) => setTimeout(r, ms));
 
+const clock = createDefaultClock();
+
 describe("ElapsedScheduler", () => {
   test("rejects construction without onFire", () => {
-    expect(() => new ElapsedScheduler({})).toThrow();
+    expect(() => new ElapsedScheduler({ clock })).toThrow();
   });
 
   test("fires at the scheduled time and forgets the timer", async () => {
     const fired = [];
     const scheduler = new ElapsedScheduler({
+      clock,
       onFire: async (cid) => fired.push(cid),
     });
     scheduler.schedule("c-1", Date.now() + 15);
@@ -23,6 +27,7 @@ describe("ElapsedScheduler", () => {
   test("schedule with a past dueAt fires immediately", async () => {
     const fired = [];
     const scheduler = new ElapsedScheduler({
+      clock,
       onFire: async (cid) => fired.push(cid),
     });
     scheduler.schedule("c-past", Date.now() - 1000);
@@ -33,6 +38,7 @@ describe("ElapsedScheduler", () => {
   test("scheduling the same id replaces the previous timer", async () => {
     const fired = [];
     const scheduler = new ElapsedScheduler({
+      clock,
       onFire: async (cid) => fired.push(cid),
     });
     scheduler.schedule("c-1", Date.now() + 50);
@@ -45,6 +51,7 @@ describe("ElapsedScheduler", () => {
   test("cancel prevents firing", async () => {
     const fired = [];
     const scheduler = new ElapsedScheduler({
+      clock,
       onFire: async (cid) => fired.push(cid),
     });
     scheduler.schedule("c-1", Date.now() + 15);
@@ -55,7 +62,7 @@ describe("ElapsedScheduler", () => {
   });
 
   test("clear cancels all timers", () => {
-    const scheduler = new ElapsedScheduler({ onFire: async () => {} });
+    const scheduler = new ElapsedScheduler({ clock, onFire: async () => {} });
     scheduler.schedule("a", Date.now() + 60_000);
     scheduler.schedule("b", Date.now() + 60_000);
     expect(scheduler.size).toBe(2);
@@ -66,6 +73,7 @@ describe("ElapsedScheduler", () => {
   test("rejections from onFire are surfaced to onError, not unhandled", async () => {
     const errors = [];
     const scheduler = new ElapsedScheduler({
+      clock,
       onFire: async () => {
         throw new Error("boom");
       },

--- a/libraries/libbridge/test/rate-limit.test.js
+++ b/libraries/libbridge/test/rate-limit.test.js
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import { createDefaultClock } from "@forwardimpact/libutil/runtime";
 
 import { RateLimiter } from "../src/rate-limit.js";
 
+const clock = createDefaultClock();
+
 describe("RateLimiter", () => {
   test("allows up to max dispatches per window", () => {
-    const limiter = new RateLimiter({ windowMs: 60_000, max: 3 });
+    const limiter = new RateLimiter({ clock, windowMs: 60_000, max: 3 });
     const dispatches = [];
     const now = Date.now();
     for (let i = 0; i < 3; i++) {
@@ -19,7 +22,7 @@ describe("RateLimiter", () => {
   });
 
   test("evicts timestamps outside the window before measuring", () => {
-    const limiter = new RateLimiter({ windowMs: 1000, max: 5 });
+    const limiter = new RateLimiter({ clock, windowMs: 1000, max: 5 });
     const now = Date.now();
     const dispatches = [now - 5000, now - 3000, now - 2000];
     const result = limiter.check("t1", dispatches);
@@ -28,7 +31,7 @@ describe("RateLimiter", () => {
   });
 
   test("retryAfterMs predicts when the oldest entry exits the window", () => {
-    const limiter = new RateLimiter({ windowMs: 60_000, max: 2 });
+    const limiter = new RateLimiter({ clock, windowMs: 60_000, max: 2 });
     const now = Date.now();
     const dispatches = [now - 10_000, now - 5_000];
     const result = limiter.check("t1", dispatches);
@@ -38,7 +41,7 @@ describe("RateLimiter", () => {
   });
 
   test("default windowMs and max match legacy values", () => {
-    const limiter = new RateLimiter();
+    const limiter = new RateLimiter({ clock });
     const now = Date.now();
     const dispatches = [now, now, now, now, now];
     const result = limiter.check("t1", dispatches);
@@ -46,7 +49,7 @@ describe("RateLimiter", () => {
   });
 
   test("rejects non-array dispatches", () => {
-    const limiter = new RateLimiter();
+    const limiter = new RateLimiter({ clock });
     expect(() => limiter.check("t1", null)).toThrow();
     expect(() => limiter.check("t1", undefined)).toThrow();
   });

--- a/libraries/libbridge/test/resume-scheduler.test.js
+++ b/libraries/libbridge/test/resume-scheduler.test.js
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createDefaultClock } from "@forwardimpact/libutil/runtime";
 
 import { Acknowledgement } from "../src/acknowledgement.js";
 import { CallbackRegistry } from "../src/callback-registry.js";
@@ -89,7 +90,7 @@ function buildEnv({
   tokenResolver,
 } = {}) {
   const store = createFakeAdapter();
-  const callbacks = new CallbackRegistry();
+  const callbacks = new CallbackRegistry({ clock });
   const ack = new Acknowledgement({
     reactionAdapter: {
       add: async () => null,
@@ -98,6 +99,7 @@ function buildEnv({
   });
   const tr = tokenResolver ?? makeTokenResolver();
   const dispatcher = new Dispatcher({
+    clock,
     callbacks,
     ack,
     store,
@@ -108,6 +110,7 @@ function buildEnv({
     tenantResolver: new DefaultTenantResolver({ channel: "test-channel" }),
   });
   const scheduler = new ResumeScheduler({
+    clock,
     dispatcher,
     store,
     buildCallbackMeta,
@@ -116,6 +119,8 @@ function buildEnv({
   });
   return { store, callbacks, dispatcher, scheduler, tokenResolver: tr };
 }
+
+const clock = createDefaultClock();
 
 describe("ResumeScheduler", () => {
   let env;
@@ -132,16 +137,17 @@ describe("ResumeScheduler", () => {
   });
 
   test("rejects construction when required options are missing", () => {
-    expect(() => new ResumeScheduler({})).toThrow();
-    expect(() => new ResumeScheduler({ dispatcher: env.dispatcher })).toThrow(
-      "store is required",
-    );
+    expect(() => new ResumeScheduler({ clock })).toThrow();
+    expect(
+      () => new ResumeScheduler({ clock, dispatcher: env.dispatcher }),
+    ).toThrow("store is required");
   });
 
   test("rejects non-function callback builders", () => {
     expect(
       () =>
         new ResumeScheduler({
+          clock,
           dispatcher: env.dispatcher,
           store: env.store,
           buildCallbackMeta: "nope",
@@ -153,6 +159,7 @@ describe("ResumeScheduler", () => {
     expect(
       () =>
         new ResumeScheduler({
+          clock,
           dispatcher: env.dispatcher,
           store: env.store,
           onDeclined: "nope",
@@ -347,11 +354,12 @@ describe("ResumeScheduler", () => {
 
     const freshStore = createFakeAdapter();
     await freshStore.add(ctx);
-    const callbacks = new CallbackRegistry();
+    const callbacks = new CallbackRegistry({ clock });
     const ack = new Acknowledgement({
       reactionAdapter: { add: async () => null, remove: async () => {} },
     });
     const dispatcher = new Dispatcher({
+      clock,
       callbacks,
       ack,
       store: freshStore,
@@ -361,7 +369,7 @@ describe("ResumeScheduler", () => {
       tokenResolver: makeTokenResolver(),
       tenantResolver: new DefaultTenantResolver({ channel: "test-channel" }),
     });
-    const fresh = new ResumeScheduler({ dispatcher, store: freshStore });
+    const fresh = new ResumeScheduler({ clock, dispatcher, store: freshStore });
     try {
       expect(fresh.size).toBe(0);
       await fresh.rearm();

--- a/libraries/libcli/src/cli.js
+++ b/libraries/libcli/src/cli.js
@@ -180,17 +180,16 @@ export class Cli {
 }
 
 /**
- * Create a Cli instance. When `runtime` is provided, error,
- * usage-error, and help output route through `runtime.proc` instead of the
- * global `process`. The zero-arg form keeps reading the global `process` as a
- * deprecated alias for one migration cycle.
+ * Create a Cli instance. Error, usage-error, and help output route through the
+ * injected `runtime.proc`.
  * @param {object} definition - The CLI definition.
- * @param {object} [options]
- * @param {import('@forwardimpact/libutil/runtime').Runtime} [options.runtime]
+ * @param {object} options
+ * @param {import('@forwardimpact/libutil/runtime').Runtime} options.runtime
  * @returns {Cli}
  */
 export function createCli(definition, { runtime } = {}) {
-  const proc = runtime ? runtime.proc : process;
+  if (!runtime) throw new Error("runtime is required");
+  const proc = runtime.proc;
   const helpRenderer = new HelpRenderer({ process: proc });
   return new Cli(definition, { process: proc, helpRenderer });
 }

--- a/libraries/libcoaligned/bin/coaligned.js
+++ b/libraries/libcoaligned/bin/coaligned.js
@@ -51,7 +51,7 @@ const definition = {
   examples: ["coaligned", "coaligned instructions", "coaligned jtbd --fix"],
 };
 
-const cli = createCli(definition);
+const cli = createCli(definition, { runtime });
 
 function writeFindings(findings, passMessage, jsonOutput, cwd, rt) {
   if (jsonOutput) {

--- a/libraries/libcoaligned/src/instructions.js
+++ b/libraries/libcoaligned/src/instructions.js
@@ -1,5 +1,4 @@
 import { resolve } from "node:path";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { runRules } from "@forwardimpact/libutil";
 
 const SKIP_DIRS = new Set([
@@ -322,7 +321,8 @@ export const INSTRUCTION_RULES = [
  *   with `emitFindingsText` / `emitFindingsJson` from libutil.
  */
 export async function checkInstructions({ root, runtime }) {
-  const { fs } = runtime ?? createDefaultRuntime();
+  if (!runtime) throw new Error("runtime is required");
+  const { fs } = runtime;
   const { layers, skillDirs } = await buildLayers(root, fs);
   const fileSubjects = await buildFileSubjects(root, layers, fs);
   const checklistSubjects = await buildChecklistSubjects(

--- a/libraries/libcoaligned/src/jtbd.js
+++ b/libraries/libcoaligned/src/jtbd.js
@@ -1,7 +1,6 @@
 import { join } from "node:path";
 import * as prettier from "prettier";
 import { runRules } from "@forwardimpact/libutil";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 const VALID_USERS = [
   "Engineering Leaders",
@@ -503,7 +502,8 @@ async function processJtbdMd(root, fix, formatMarkdown, result, fsSync) {
  *   that were rewritten in place.
  */
 export async function checkJtbd({ root, fix = false, runtime }) {
-  const { fsSync } = runtime ?? createDefaultRuntime();
+  if (!runtime) throw new Error("runtime is required");
+  const { fsSync } = runtime;
   const result = { findings: [], stale: [], fixed: [] };
   const prettierConfig = await prettier.resolveConfig(join(root, "JTBD.md"));
   const formatMarkdown = makeFormatter(prettierConfig);

--- a/libraries/libcoaligned/test/instructions.test.js
+++ b/libraries/libcoaligned/test/instructions.test.js
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { checkInstructions } from "../src/index.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const runtime = createDefaultRuntime();
 
 async function makeRepo() {
   const root = await mkdtemp(join(tmpdir(), "libcoaligned-instr-"));
@@ -16,7 +18,7 @@ describe("checkInstructions", () => {
   test("returns no findings for an empty repo", async () => {
     const root = await makeRepo();
     try {
-      const findings = await checkInstructions({ root });
+      const findings = await checkInstructions({ root, runtime });
       assert.deepStrictEqual(findings, []);
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -28,7 +30,7 @@ describe("checkInstructions", () => {
     try {
       const oversize = "line\n".repeat(200);
       await writeFile(join(root, "CLAUDE.md"), oversize);
-      const findings = await checkInstructions({ root });
+      const findings = await checkInstructions({ root, runtime });
       const f = findings.find(
         (x) =>
           x.id === "instructions.line-budget" && x.path.endsWith("CLAUDE.md"),
@@ -52,7 +54,7 @@ describe("checkInstructions", () => {
       // root cap — proves the tighter rule applies to subdirectories only.
       const oversize = "line\n".repeat(140);
       await writeFile(join(root, "products", "CLAUDE.md"), oversize);
-      const findings = await checkInstructions({ root });
+      const findings = await checkInstructions({ root, runtime });
       const f = findings.find(
         (x) =>
           x.id === "instructions.line-budget" &&
@@ -76,7 +78,7 @@ describe("checkInstructions", () => {
       });
       const oversize = "line\n".repeat(200);
       await writeFile(join(root, ".claude/agents/references/big.md"), oversize);
-      const findings = await checkInstructions({ root });
+      const findings = await checkInstructions({ root, runtime });
       const f = findings.find(
         (x) =>
           x.id === "instructions.line-budget" &&
@@ -110,7 +112,7 @@ describe("checkInstructions", () => {
         "",
       ].join("\n");
       await writeFile(join(root, ".claude/skills/demo/SKILL.md"), skill);
-      const findings = await checkInstructions({ root });
+      const findings = await checkInstructions({ root, runtime });
       const f = findings.find((x) => x.id === "L7.too-many-items");
       assert.ok(
         f,

--- a/libraries/libcoaligned/test/jtbd.test.js
+++ b/libraries/libcoaligned/test/jtbd.test.js
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { checkJtbd } from "../src/index.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const runtime = createDefaultRuntime();
 
 async function makeRepo() {
   const root = await mkdtemp(join(tmpdir(), "libcoaligned-jtbd-"));
@@ -49,7 +51,7 @@ describe("checkJtbd", () => {
   test("passes on an empty repo with no packages", async () => {
     const root = await makeRepo();
     try {
-      const result = await checkJtbd({ root });
+      const result = await checkJtbd({ root, runtime });
       assert.deepStrictEqual(result.findings, []);
       assert.deepStrictEqual(result.stale, []);
     } finally {
@@ -70,7 +72,7 @@ describe("checkJtbd", () => {
         join(root, "libraries", "libfoo", "package.json"),
         JSON.stringify(pkg),
       );
-      const result = await checkJtbd({ root });
+      const result = await checkJtbd({ root, runtime });
       const f = result.findings.find(
         (x) => x.id === "jtbd.hire-missing-period",
       );
@@ -107,10 +109,10 @@ describe("checkJtbd", () => {
       const readmePath = join(root, "libraries", "libfoo", "README.md");
       await writeFile(readmePath, readme);
 
-      const dryRun = await checkJtbd({ root, fix: false });
+      const dryRun = await checkJtbd({ root, fix: false, runtime });
       assert.ok(dryRun.stale.length > 0, "expected stale entries");
 
-      const fixed = await checkJtbd({ root, fix: true });
+      const fixed = await checkJtbd({ root, fix: true, runtime });
       assert.ok(fixed.fixed.length > 0, "expected fix to apply");
 
       const updated = await readFile(readmePath, "utf8");
@@ -140,7 +142,7 @@ describe("checkJtbd", () => {
         "<!-- BEGIN:jobs -->\n<!-- END:jobs -->\n",
       );
 
-      const result = await checkJtbd({ root });
+      const result = await checkJtbd({ root, runtime });
       assert.deepStrictEqual(result.findings, []);
       assert.ok(result.stale.includes("JTBD.md"));
     } finally {
@@ -162,7 +164,7 @@ describe("checkJtbd", () => {
         JSON.stringify(pkg),
       );
 
-      const result = await checkJtbd({ root });
+      const result = await checkJtbd({ root, runtime });
       const f = result.findings.find((x) => x.id === "jtbd.invalid-user");
       assert.ok(
         f,
@@ -194,7 +196,7 @@ describe("checkJtbd", () => {
         "<!-- BEGIN:jobs -->\n<!-- END:jobs -->\n",
       );
 
-      await checkJtbd({ root, fix: true });
+      await checkJtbd({ root, fix: true, runtime });
 
       const jtbd = await readFile(join(root, "JTBD.md"), "utf8");
       const start = jtbd.indexOf("**Big Hire:**");
@@ -237,8 +239,8 @@ describe("checkJtbd", () => {
         "<!-- BEGIN:jobs -->\n<!-- END:jobs -->\n",
       );
 
-      await checkJtbd({ root, fix: true });
-      const second = await checkJtbd({ root, fix: true });
+      await checkJtbd({ root, fix: true, runtime });
+      const second = await checkJtbd({ root, fix: true, runtime });
 
       assert.deepStrictEqual(second.fixed, []);
       assert.deepStrictEqual(second.stale, []);

--- a/libraries/libcodegen/bin/fit-codegen.js
+++ b/libraries/libcodegen/bin/fit-codegen.js
@@ -11,6 +11,7 @@ import protoLoader from "@grpc/proto-loader";
 import mustache from "mustache";
 
 import { createCli, SummaryRenderer } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { Finder } from "@forwardimpact/libutil";
 import { Logger } from "@forwardimpact/libtelemetry";
 import {
@@ -62,7 +63,8 @@ const definition = {
   ],
 };
 
-const cli = createCli(definition);
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
 
 /**
  * Create tar.gz bundle of all directories inside sourcePath
@@ -179,6 +181,7 @@ function createCodegen(
   mustache,
   protoLoader,
   fs,
+  runtime,
 ) {
   const base = new CodegenBase(
     protoDirs,
@@ -187,6 +190,7 @@ function createCodegen(
     mustache,
     protoLoader,
     fs,
+    runtime,
   );
   return {
     types: new CodegenTypes(base),
@@ -356,6 +360,7 @@ async function runCodegen(protoDirs, projectRoot, finder) {
     mustache,
     protoLoader,
     fs,
+    runtime,
   );
   await executeGeneration(codegens, sourcePath, parsedFlags);
 
@@ -370,8 +375,13 @@ async function runCodegen(protoDirs, projectRoot, finder) {
  */
 async function main() {
   try {
-    const logger = new Logger("codegen");
-    const finder = new Finder(fsAsync, logger, process);
+    const logger = new Logger("codegen", runtime);
+    const finder = new Finder({
+      fs: fsAsync,
+      fsSync: fs,
+      proc: process,
+      logger,
+    });
     const projectRoot = finder.findProjectRoot(process.cwd());
 
     const protoDirs = discoverProtoDirs(projectRoot);
@@ -385,7 +395,7 @@ async function main() {
 
     await runCodegen(protoDirs, projectRoot, finder);
   } catch (err) {
-    const logger = new Logger("codegen");
+    const logger = new Logger("codegen", runtime);
     logger.exception("main", err);
     cli.error(err.message);
     process.exit(1);

--- a/libraries/libcodegen/src/base.js
+++ b/libraries/libcodegen/src/base.js
@@ -1,6 +1,5 @@
 import { fileURLToPath } from "node:url";
 import protobuf from "protobufjs";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /** Convert camelCase to snake_case (protobufjs normalizes field names) */
 function camelToSnake(str) {
@@ -71,7 +70,7 @@ export class CodegenBase {
    * @param {object} mustache - Mustache template rendering module
    * @param {object} protoLoader - Protocol buffer loader module
    * @param {object} fs - File system module (sync operations only)
-   * @param {object} [runtime] - Optional runtime bag; falls back to createDefaultRuntime()
+   * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected runtime bag
    */
   constructor(
     protoDirs,
@@ -90,6 +89,7 @@ export class CodegenBase {
     if (!mustache) throw new Error("mustache module is required");
     if (!protoLoader) throw new Error("protoLoader module is required");
     if (!fs) throw new Error("fs module is required");
+    if (!runtime) throw new Error("runtime is required");
 
     this.#protoDirs = protoDirs;
     this.#projectRoot = projectRoot;
@@ -97,7 +97,7 @@ export class CodegenBase {
     this.#mustache = mustache;
     this.#protoLoader = protoLoader;
     this.#fs = fs;
-    this.#subprocess = (runtime ?? createDefaultRuntime()).subprocess;
+    this.#subprocess = runtime.subprocess;
   }
 
   /**

--- a/libraries/libcodegen/test/metadata.test.js
+++ b/libraries/libcodegen/test/metadata.test.js
@@ -7,6 +7,7 @@ import protoLoader from "@grpc/proto-loader";
 import mustache from "mustache";
 
 import { CodegenBase, CodegenMetadata } from "@forwardimpact/libcodegen";
+import { createTestRuntime } from "@forwardimpact/libmock";
 
 const projectRoot = path.resolve(
   path.dirname(new URL(import.meta.url).pathname),
@@ -38,6 +39,7 @@ function createBase() {
     mustache,
     protoLoader,
     fs,
+    createTestRuntime(),
   );
 }
 

--- a/libraries/libconfig/src/bootstrap.js
+++ b/libraries/libconfig/src/bootstrap.js
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { readEnvFile, updateEnvFile } from "@forwardimpact/libsecret";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { mergeConfigFragment, mergeEnvEntries } from "./merge.js";
 import { bootstrapRefusal } from "./errors.js";
@@ -41,7 +40,9 @@ export async function bootstrapProject({
   overwrites = {},
   deps,
 } = {}) {
-  const { fs, proc } = deps?.runtime ?? createDefaultRuntime();
+  const runtime = deps?.runtime;
+  if (!runtime) throw new Error("deps.runtime is required");
+  const { fs, proc } = runtime;
   const resolvedTarget = target ?? proc.cwd();
 
   const configDir = path.join(resolvedTarget, "config");
@@ -49,7 +50,7 @@ export async function bootstrapProject({
   const envPath = path.join(resolvedTarget, ".env");
 
   const existingConfig = await readJsonOrEmpty(fs, configPath);
-  const existingEnv = await readEnvSubset(Object.keys(env), envPath);
+  const existingEnv = await readEnvSubset(Object.keys(env), envPath, runtime);
 
   const cfg = mergeConfigFragment({
     existing: existingConfig,
@@ -76,7 +77,7 @@ export async function bootstrapProject({
   // criterion to survive a pre-existing .env with mode 0o644. The merged
   // `ev.result` is computed for classification only.
   for (const [key, value] of Object.entries(env)) {
-    await updateEnvFile(key, value, envPath);
+    await updateEnvFile(key, value, envPath, runtime);
   }
 }
 
@@ -90,10 +91,10 @@ async function readJsonOrEmpty(fs, filePath) {
   }
 }
 
-async function readEnvSubset(keys, envPath) {
+async function readEnvSubset(keys, envPath, runtime) {
   const out = {};
   for (const key of keys) {
-    const value = await readEnvFile(key, envPath);
+    const value = await readEnvFile(key, envPath, runtime);
     if (value !== undefined) out[key] = value;
   }
   return out;

--- a/libraries/libconfig/src/config.js
+++ b/libraries/libconfig/src/config.js
@@ -1,9 +1,6 @@
 import path from "node:path";
 import { createStorage } from "@forwardimpact/libstorage";
-import {
-  createDefaultProc,
-  createDefaultRuntime,
-} from "@forwardimpact/libutil/runtime";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /** @typedef {import("@forwardimpact/libstorage").StorageInterface} StorageInterface */
 /** @typedef {import("@forwardimpact/libutil/runtime").Runtime} Runtime */
@@ -53,39 +50,6 @@ function parseEnvLine(line) {
 }
 
 /**
- * Resolve a runtime collaborator from the new or legacy call shapes.
- *
- * New shape  — callers pass `{ runtime }` as the third positional arg; the
- *   runtime bag carries `{ proc, fs, clock, subprocess }`.
- * Legacy shape — callers pass a bare `process`-like object (with `.env` and
- *   `.cwd()`). This is mapped onto a minimal runtime for one deprecation cycle.
- * Absent      — falls back to `createDefaultRuntime()`.
- *
- * @param {object|undefined} runtimeOrProcess
- * @returns {{ proc: object, fs: object, clock: object }}
- */
-function resolveRuntime(runtimeOrProcess) {
-  if (!runtimeOrProcess) {
-    return createDefaultRuntime();
-  }
-  // New shape: { runtime: <bag> }
-  if (runtimeOrProcess.runtime) {
-    return runtimeOrProcess.runtime;
-  }
-  // Legacy shape: bare process-like object ({ env, cwd })
-  // Map onto a minimal runtime, preserving the original proc surface.
-  const legacyProc =
-    typeof runtimeOrProcess.cwd === "function"
-      ? runtimeOrProcess
-      : createDefaultProc({ source: runtimeOrProcess });
-  const defaultRt = createDefaultRuntime();
-  return {
-    ...defaultRt,
-    proc: legacyProc,
-  };
-}
-
-/**
  * Centralized configuration management class
  */
 export class Config {
@@ -120,34 +84,37 @@ export class Config {
   #clock;
   #storageFn;
   #subprocess;
+  #runtime;
 
   /**
    * Creates a new Config instance.
    *
-   * Preferred call shape (new):
+   * Call shape:
    *   `new Config(namespace, name, defaults, { runtime }, storageFn)`
    *   where `runtime` is a runtime bag from `createDefaultRuntime()` or
-   *   `createTestRuntime()`.
-   *
-   * Legacy call shape (one-cycle deprecation alias — still supported):
-   *   `new Config(namespace, name, defaults, process, storageFn)`
-   *   where `process` is a bare process-like object with `.env` and `.cwd()`.
+   *   `createTestRuntime()`. The runtime arg is optional — when omitted the
+   *   default production runtime is built (a composition-root convenience).
    *
    * @param {string} namespace - Namespace for the configuration
    * @param {string} name - Name of the configuration
    * @param {object} [defaults] - Default configuration values
-   * @param {{ runtime: Runtime }|object} [runtimeOrProcess] - Runtime bag wrapper
-   *   or legacy bare process object
-   * @param {(bucket: string, type?: string, process?: object) => StorageInterface} [storageFn]
+   * @param {{ runtime: Runtime }|Runtime} [runtimeOption] - Runtime bag wrapper
+   *   (or a bare runtime bag)
+   * @param {(bucket: string, type?: string, runtime?: object) => StorageInterface} [storageFn]
    */
   constructor(
     namespace,
     name,
     defaults = {},
-    runtimeOrProcess = undefined,
+    runtimeOption = undefined,
     storageFn = createStorage,
   ) {
-    const rt = resolveRuntime(runtimeOrProcess);
+    // Injected `{ runtime }` (or a bare runtime bag); absent → the default
+    // production runtime (a composition-root convenience for config factories).
+    const rt = runtimeOption
+      ? (runtimeOption.runtime ?? runtimeOption)
+      : createDefaultRuntime();
+    this.#runtime = rt;
     this.#proc = rt.proc;
     this.#fs = rt.fs;
     this.#clock = rt.clock;
@@ -164,7 +131,7 @@ export class Config {
    * @returns {Promise<void>}
    */
   async load() {
-    this.#storage = this.#storageFn("config", null, this.#proc);
+    this.#storage = this.#storageFn("config", null, this.#runtime);
 
     // 1. Load .env — credentials go to #envOverrides, everything else
     //    goes to proc.env (so SERVICE_*_URL etc. are available below)

--- a/libraries/libconfig/src/index.js
+++ b/libraries/libconfig/src/index.js
@@ -10,29 +10,26 @@ import { Config } from "./config.js";
  * Preferred call shape (new):
  *   `createConfig(namespace, name, defaults, { runtime }, storageFn)`
  *
- * Legacy call shape (one-cycle deprecation alias — still supported):
- *   `createConfig(namespace, name, defaults, process, storageFn)`
- *
  * @param {string} namespace - Namespace for the configuration
  * @param {string} name - Name of the configuration
  * @param {object} [defaults] - Default configuration values
- * @param {{ runtime: Runtime }|object} [runtimeOrProcess] - Runtime bag wrapper or
- *   legacy bare process object. Defaults to the production runtime when omitted.
- * @param {(bucket: string, type?: string, process?: object) => StorageInterface} [storageFn]
+ * @param@param {{ runtime: Runtime }|Runtime} [runtimeOption] - Runtime bag wrapper.
+ *   Defaults to the production runtime when omitted.
+ * @param {(bucket: string, type?: string, runtime?: object) => StorageInterface} [storageFn]
  * @returns {Promise<Config>} Initialized Config instance
  */
 export async function createConfig(
   namespace,
   name,
   defaults = {},
-  runtimeOrProcess = undefined,
+  runtimeOption = undefined,
   storageFn = createStorage,
 ) {
   const instance = new Config(
     namespace,
     name,
     defaults,
-    runtimeOrProcess,
+    runtimeOption,
     storageFn,
   );
   await instance.load();
@@ -45,27 +42,23 @@ export async function createConfig(
  * Preferred call shape (new):
  *   `createServiceConfig(name, defaults, { runtime }, storageFn)`
  *
- * Legacy call shape (one-cycle deprecation alias — still supported):
- *   `createServiceConfig(name, defaults, process, storageFn)`
- *
  * @param {string} name - Name of the service configuration
  * @param {object} [defaults] - Default configuration values
- * @param {{ runtime: Runtime }|object} [runtimeOrProcess] - Runtime bag wrapper or
- *   legacy bare process object
- * @param {(bucket: string, type?: string, process?: object) => StorageInterface} [storageFn]
+ * @param@param {{ runtime: Runtime }|Runtime} [runtimeOption] - Runtime bag wrapper
+ * @param {(bucket: string, type?: string, runtime?: object) => StorageInterface} [storageFn]
  * @returns {Promise<Config>} Initialized Config instance for service namespace
  */
 export async function createServiceConfig(
   name,
   defaults = {},
-  runtimeOrProcess = undefined,
+  runtimeOption = undefined,
   storageFn = createStorage,
 ) {
   const instance = new Config(
     "service",
     name,
     defaults,
-    runtimeOrProcess,
+    runtimeOption,
     storageFn,
   );
   await instance.load();
@@ -78,27 +71,23 @@ export async function createServiceConfig(
  * Preferred call shape (new):
  *   `createExtensionConfig(name, defaults, { runtime }, storageFn)`
  *
- * Legacy call shape (one-cycle deprecation alias — still supported):
- *   `createExtensionConfig(name, defaults, process, storageFn)`
- *
  * @param {string} name - Name of the extension configuration
  * @param {object} [defaults] - Default configuration values
- * @param {{ runtime: Runtime }|object} [runtimeOrProcess] - Runtime bag wrapper or
- *   legacy bare process object
- * @param {(bucket: string, type?: string, process?: object) => StorageInterface} [storageFn]
+ * @param@param {{ runtime: Runtime }|Runtime} [runtimeOption] - Runtime bag wrapper
+ * @param {(bucket: string, type?: string, runtime?: object) => StorageInterface} [storageFn]
  * @returns {Promise<Config>} Initialized Config instance for extension namespace
  */
 export async function createExtensionConfig(
   name,
   defaults = {},
-  runtimeOrProcess = undefined,
+  runtimeOption = undefined,
   storageFn = createStorage,
 ) {
   const instance = new Config(
     "extension",
     name,
     defaults,
-    runtimeOrProcess,
+    runtimeOption,
     storageFn,
   );
   await instance.load();
@@ -111,27 +100,23 @@ export async function createExtensionConfig(
  * Preferred call shape (new):
  *   `createScriptConfig(name, defaults, { runtime }, storageFn)`
  *
- * Legacy call shape (one-cycle deprecation alias — still supported):
- *   `createScriptConfig(name, defaults, process, storageFn)`
- *
  * @param {string} name - Name of the script configuration
  * @param {object} [defaults] - Default configuration values
- * @param {{ runtime: Runtime }|object} [runtimeOrProcess] - Runtime bag wrapper or
- *   legacy bare process object
- * @param {(bucket: string, type?: string, process?: object) => StorageInterface} [storageFn]
+ * @param@param {{ runtime: Runtime }|Runtime} [runtimeOption] - Runtime bag wrapper
+ * @param {(bucket: string, type?: string, runtime?: object) => StorageInterface} [storageFn]
  * @returns {Promise<Config>} Initialized Config instance for script namespace
  */
 export async function createScriptConfig(
   name,
   defaults = {},
-  runtimeOrProcess = undefined,
+  runtimeOption = undefined,
   storageFn = createStorage,
 ) {
   const instance = new Config(
     "script",
     name,
     defaults,
-    runtimeOrProcess,
+    runtimeOption,
     storageFn,
   );
   await instance.load();
@@ -144,27 +129,23 @@ export async function createScriptConfig(
  * Preferred call shape (new):
  *   `createProductConfig(name, defaults, { runtime }, storageFn)`
  *
- * Legacy call shape (one-cycle deprecation alias — still supported):
- *   `createProductConfig(name, defaults, process, storageFn)`
- *
  * @param {string} name - Name of the product configuration
  * @param {object} [defaults] - Default configuration values
- * @param {{ runtime: Runtime }|object} [runtimeOrProcess] - Runtime bag wrapper or
- *   legacy bare process object
- * @param {(bucket: string, type?: string, process?: object) => StorageInterface} [storageFn]
+ * @param@param {{ runtime: Runtime }|Runtime} [runtimeOption] - Runtime bag wrapper
+ * @param {(bucket: string, type?: string, runtime?: object) => StorageInterface} [storageFn]
  * @returns {Promise<Config>} Initialized Config instance for product namespace
  */
 export async function createProductConfig(
   name,
   defaults = {},
-  runtimeOrProcess = undefined,
+  runtimeOption = undefined,
   storageFn = createStorage,
 ) {
   const instance = new Config(
     "product",
     name,
     defaults,
-    runtimeOrProcess,
+    runtimeOption,
     storageFn,
   );
   await instance.load();
@@ -178,19 +159,15 @@ export async function createProductConfig(
  * Preferred call shape (new):
  *   `createInitConfig({ runtime }, storageFn)`
  *
- * Legacy call shape (one-cycle deprecation alias — still supported):
- *   `createInitConfig(process, storageFn)`
- *
- * @param {{ runtime: Runtime }|object} [runtimeOrProcess] - Runtime bag wrapper or
- *   legacy bare process object
- * @param {(bucket: string, type?: string, process?: object) => StorageInterface} [storageFn]
+ * @param@param {{ runtime: Runtime }|Runtime} [runtimeOption] - Runtime bag wrapper
+ * @param {(bucket: string, type?: string, runtime?: object) => StorageInterface} [storageFn]
  * @returns {Promise<Config>} Initialized Config instance with init() and rootDir()
  */
 export async function createInitConfig(
-  runtimeOrProcess = undefined,
+  runtimeOption = undefined,
   storageFn = createStorage,
 ) {
-  const instance = new Config("init", "rc", {}, runtimeOrProcess, storageFn);
+  const instance = new Config("init", "rc", {}, runtimeOption, storageFn);
   await instance.load();
   return instance;
 }

--- a/libraries/libconfig/test/bootstrap.test.js
+++ b/libraries/libconfig/test/bootstrap.test.js
@@ -4,7 +4,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { tmpdir } from "node:os";
 
-import { bootstrapProject } from "../src/bootstrap.js";
+import { bootstrapProject as _bootstrapProject } from "../src/bootstrap.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+// bootstrapProject requires an injected runtime; the tests exercise real fs,
+// so thread the production runtime through a thin wrapper.
+const _runtime = createDefaultRuntime();
+const bootstrapProject = (opts = {}) =>
+  _bootstrapProject({ ...opts, deps: { runtime: _runtime } });
 
 let testDir;
 

--- a/libraries/libconfig/test/credential-env-override.test.js
+++ b/libraries/libconfig/test/credential-env-override.test.js
@@ -4,6 +4,10 @@ import { mkdtemp, writeFile, rm } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { createProductConfig } from "../src/index.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+// Real fs (to read the .env written to tmpdir) with a test-controlled proc.
+const runtimeWith = (proc) => ({ ...createDefaultRuntime(), proc });
 
 // Mocked storage that always returns no config file (no findUpward walk).
 function mockStorageFn() {
@@ -29,7 +33,11 @@ describe("PRODUCT_LANDMARK_TOKEN credential override", () => {
     const config = await createProductConfig(
       "landmark",
       { token: undefined },
-      { ...process, cwd: () => tmpdir, env: { PATH: process.env.PATH } },
+      runtimeWith({
+        ...process,
+        cwd: () => tmpdir,
+        env: { PATH: process.env.PATH },
+      }),
       mockStorageFn,
     );
     assert.equal(config.token, "test-jwt-value");
@@ -41,11 +49,11 @@ describe("PRODUCT_LANDMARK_TOKEN credential override", () => {
     const config = await createProductConfig(
       "landmark",
       { token: undefined },
-      {
+      runtimeWith({
         ...process,
         cwd: () => tmpdir,
         env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "shell-jwt" },
-      },
+      }),
       mockStorageFn,
     );
     assert.equal(config.token, "shell-jwt");
@@ -57,11 +65,11 @@ describe("PRODUCT_LANDMARK_TOKEN credential override", () => {
     const config = await createProductConfig(
       "landmark",
       { token: undefined },
-      {
+      runtimeWith({
         ...process,
         cwd: () => tmpdir,
         env: { PATH: process.env.PATH, PRODUCT_LANDMARK_TOKEN: "" },
-      },
+      }),
       mockStorageFn,
     );
     // .env wins, not ""

--- a/libraries/libconfig/test/libconfig-core.test.js
+++ b/libraries/libconfig/test/libconfig-core.test.js
@@ -12,6 +12,11 @@ import {
   createMockStorage,
   spy,
 } from "@forwardimpact/libmock";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+// Wrap a test proc as a runtime bag (real fs + test-controlled proc). The proc
+// object is shared so Config's env mutations remain observable on it.
+const rt = (proc) => ({ ...createDefaultRuntime(), proc });
 
 describe("libconfig - Config", () => {
   let mockProcess;
@@ -37,7 +42,7 @@ describe("libconfig - Config", () => {
       "test",
       "myservice",
       { defaultValue: 42 },
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -60,7 +65,7 @@ describe("libconfig - Config", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -80,7 +85,7 @@ describe("libconfig - Config", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -101,7 +106,7 @@ describe("libconfig - Config", () => {
       "test",
       "myservice",
       { numbers: [], boolean: false },
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -119,7 +124,7 @@ describe("libconfig - Config", () => {
       "test",
       "myservice",
       { invalid: "" },
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -132,7 +137,7 @@ describe("libconfig - Config", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -145,7 +150,7 @@ describe("libconfig - Config", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -162,7 +167,7 @@ describe("libconfig - Config", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -171,7 +176,7 @@ describe("libconfig - Config", () => {
 
   test("uses default storageFactory when storageFn not provided", async () => {
     mockProcess.env.STORAGE_ROOT = "/tmp";
-    const config = await createConfig("test", "myservice", {}, mockProcess);
+    const config = await createConfig("test", "myservice", {}, rt(mockProcess));
 
     assert.strictEqual(config.name, "myservice");
   });
@@ -184,7 +189,7 @@ describe("libconfig - Environment-driven storage integration", () => {
       cwd: () => "/test/dir",
     };
 
-    const config = await createConfig("test", "myservice", {}, mockProcess);
+    const config = await createConfig("test", "myservice", {}, rt(mockProcess));
 
     assert.strictEqual(config.name, "myservice");
   });
@@ -213,7 +218,7 @@ describe("libconfig - Environment-driven storage integration", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -226,7 +231,7 @@ describe("libconfig - Environment-driven storage integration", () => {
       cwd: () => "/test/dir",
     };
 
-    const config = await createConfig("test", "myservice", {}, mockProcess);
+    const config = await createConfig("test", "myservice", {}, rt(mockProcess));
 
     assert.strictEqual(config.name, "myservice");
     assert.strictEqual(config.namespace, "test");
@@ -250,7 +255,7 @@ describe("libconfig - Config methods", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
 
@@ -271,7 +276,7 @@ describe("libconfig - Config methods", () => {
     const config = await createServiceConfig(
       "testservice",
       { custom: "value" },
-      proc,
+      rt(proc),
       storageFn,
     );
 
@@ -290,7 +295,7 @@ describe("libconfig - Config methods", () => {
     const config = await createExtensionConfig(
       "testextension",
       { custom: "value" },
-      proc,
+      rt(proc),
       storageFn,
     );
 
@@ -309,7 +314,7 @@ describe("libconfig - Config methods", () => {
     const config = await createProductConfig(
       "testproduct",
       { custom: "value" },
-      proc,
+      rt(proc),
       storageFn,
     );
 

--- a/libraries/libconfig/test/libconfig-credentials.test.js
+++ b/libraries/libconfig/test/libconfig-credentials.test.js
@@ -3,6 +3,10 @@ import assert from "node:assert";
 
 import { createConfig } from "../src/index.js";
 import { createMockStorage, spy } from "@forwardimpact/libmock";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+// Wrap a test proc as a runtime bag (real fs + test-controlled proc).
+const rt = (proc) => ({ ...createDefaultRuntime(), proc });
 
 describe("libconfig - Anthropic and MCP credentials", () => {
   const baseMockProcess = () => ({
@@ -37,7 +41,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
       "test",
       "myservice",
       {},
-      proc,
+      rt(proc),
       mockStorageFn(storage),
     );
     assert.strictEqual(config.mcpToken(), "mcp-secret-123");
@@ -51,7 +55,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
       "test",
       "myservice",
       {},
-      baseMockProcess(),
+      rt(baseMockProcess()),
       mockStorageFn(storage),
     );
     assert.throws(() => config.mcpToken(), {
@@ -80,7 +84,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
       "test",
       "myservice",
       {},
-      proc,
+      rt(proc),
       mockStorageFn(storage),
     );
     const token = await config.anthropicToken();
@@ -102,7 +106,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
       "test",
       "myservice",
       {},
-      baseMockProcess(),
+      rt(baseMockProcess()),
       mockStorageFn(storage),
     );
     const token = await config.anthropicToken();
@@ -141,7 +145,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
         "test",
         "myservice",
         {},
-        proc,
+        rt(proc),
         mockStorageFn(storage),
       );
       const token = await config.anthropicToken();
@@ -178,7 +182,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
         "test",
         "myservice",
         {},
-        proc,
+        rt(proc),
         mockStorageFn(storage),
       );
       await assert.rejects(() => config.anthropicToken(), {
@@ -197,7 +201,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
       "test",
       "myservice",
       {},
-      baseMockProcess(),
+      rt(baseMockProcess()),
       mockStorageFn(storage),
     );
     await assert.rejects(() => config.anthropicToken(), {
@@ -214,7 +218,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
       "test",
       "myservice",
       {},
-      baseMockProcess(),
+      rt(baseMockProcess()),
       mockStorageFn(storage),
     );
 
@@ -243,7 +247,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
       "test",
       "myservice",
       {},
-      baseMockProcess(),
+      rt(baseMockProcess()),
       mockStorageFn(storage),
     );
     await config.clearOAuthCredential();
@@ -257,7 +261,7 @@ describe("libconfig - Anthropic and MCP credentials", () => {
       "test",
       "myservice",
       {},
-      baseMockProcess(),
+      rt(baseMockProcess()),
       mockStorageFn(storage),
     );
     // Should not throw

--- a/libraries/libconfig/test/libconfig-env-file.test.js
+++ b/libraries/libconfig/test/libconfig-env-file.test.js
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 
 import { createConfig } from "../src/index.js";
 import { createMockStorage, spy } from "@forwardimpact/libmock";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 describe("libconfig - .env file loading", () => {
   const testDir = path.join(tmpdir(), `libconfig-env-test-${process.pid}`);
@@ -16,9 +17,11 @@ describe("libconfig - .env file loading", () => {
       get: spy(() => Promise.resolve("")),
     });
 
-  const createProcess = (env = {}) => ({
-    cwd: () => testDir,
-    env,
+  // Real fs (to read the .env written to testDir) with a test-controlled proc.
+  // Config mutates `runtime.proc.env`, so tests inspect `.proc.env` afterward.
+  const createRuntime = (env = {}) => ({
+    ...createDefaultRuntime(),
+    proc: { cwd: () => testDir, env },
   });
 
   afterEach(() => {
@@ -41,7 +44,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -57,7 +60,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess({ GITHUB_TOKEN: "env-value" }),
+      createRuntime({ GITHUB_TOKEN: "env-value" }),
       mockStorageFn,
     );
 
@@ -67,11 +70,17 @@ describe("libconfig - .env file loading", () => {
   test("GH_TOKEN from .env file is treated as a credential", async () => {
     writeEnvFile("GH_TOKEN=gh-cli-value\n");
 
-    const proc = createProcess();
-    const config = await createConfig("test", "svc", {}, proc, mockStorageFn);
+    const runtime = createRuntime();
+    const config = await createConfig(
+      "test",
+      "svc",
+      {},
+      runtime,
+      mockStorageFn,
+    );
 
     assert.strictEqual(config.ghToken(), "gh-cli-value");
-    assert.strictEqual(proc.env.GH_TOKEN, undefined);
+    assert.strictEqual(runtime.proc.env.GH_TOKEN, undefined);
   });
 
   test("loads non-allowed keys into process.env", async () => {
@@ -79,19 +88,19 @@ describe("libconfig - .env file loading", () => {
       "SERVICE_SECRET=my-secret\nSERVICE_MCP_URL=http://localhost:3005\nGITHUB_TOKEN=allowed\n",
     );
 
-    const mockProcess = createProcess();
+    const runtime = createRuntime();
     const config = await createConfig(
       "test",
       "svc",
       {},
-      mockProcess,
+      runtime,
       mockStorageFn,
     );
 
     assert.strictEqual(config.ghToken(), "allowed");
-    assert.strictEqual(mockProcess.env.SERVICE_SECRET, "my-secret");
+    assert.strictEqual(runtime.proc.env.SERVICE_SECRET, "my-secret");
     assert.strictEqual(
-      mockProcess.env.SERVICE_MCP_URL,
+      runtime.proc.env.SERVICE_MCP_URL,
       "http://localhost:3005",
     );
   });
@@ -99,13 +108,13 @@ describe("libconfig - .env file loading", () => {
   test(".env file overwrites inherited process.env for non-credential keys", async () => {
     writeEnvFile("SERVICE_SECRET=from-file\n");
 
-    const mockProcess = createProcess({ SERVICE_SECRET: "from-env" });
-    await createConfig("test", "svc", {}, mockProcess, mockStorageFn);
+    const runtime = createRuntime({ SERVICE_SECRET: "from-env" });
+    await createConfig("test", "svc", {}, runtime, mockStorageFn);
 
     // .env is the persistent source of truth. Supervised child processes
     // inherit stale values from svscan — always applying the .env value
     // ensures edits take effect on restart.
-    assert.strictEqual(mockProcess.env.SERVICE_SECRET, "from-file");
+    assert.strictEqual(runtime.proc.env.SERVICE_SECRET, "from-file");
   });
 
   test("skips comments and blank lines", async () => {
@@ -117,7 +126,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -133,7 +142,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -149,7 +158,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -164,7 +173,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -179,7 +188,7 @@ describe("libconfig - .env file loading", () => {
     chmodSync(envPath, 0o000);
 
     await assert.rejects(
-      () => createConfig("test", "svc", {}, createProcess(), mockStorageFn),
+      () => createConfig("test", "svc", {}, createRuntime(), mockStorageFn),
       (error) => error.code === "EACCES",
     );
 
@@ -194,7 +203,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -210,7 +219,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -234,7 +243,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -250,7 +259,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -271,8 +280,14 @@ describe("libconfig - .env file loading", () => {
       ].join("\n"),
     );
 
-    const proc = createProcess();
-    const config = await createConfig("test", "svc", {}, proc, mockStorageFn);
+    const runtime = createRuntime();
+    const config = await createConfig(
+      "test",
+      "svc",
+      {},
+      runtime,
+      mockStorageFn,
+    );
 
     assert.strictEqual(config.supabaseAnonKey(), "anon-jwt");
     assert.strictEqual(config.supabaseServiceRoleKey(), "service-role-jwt");
@@ -281,13 +296,13 @@ describe("libconfig - .env file loading", () => {
     // SUPABASE_URL is non-credential; it must remain on process.env so
     // docker-compose's ${SUPABASE_URL} interpolation works at the shell
     // level (design § Key Decisions row 7).
-    assert.strictEqual(proc.env.SUPABASE_URL, "http://127.0.0.1:54321");
+    assert.strictEqual(runtime.proc.env.SUPABASE_URL, "http://127.0.0.1:54321");
     assert.strictEqual(config.supabaseUrl(), "http://127.0.0.1:54321");
 
     // Three secret values must NOT leak onto process.env.
-    assert.strictEqual(proc.env.SUPABASE_ANON_KEY, undefined);
-    assert.strictEqual(proc.env.SUPABASE_SERVICE_ROLE_KEY, undefined);
-    assert.strictEqual(proc.env.SUPABASE_JWT_SECRET, undefined);
+    assert.strictEqual(runtime.proc.env.SUPABASE_ANON_KEY, undefined);
+    assert.strictEqual(runtime.proc.env.SUPABASE_SERVICE_ROLE_KEY, undefined);
+    assert.strictEqual(runtime.proc.env.SUPABASE_JWT_SECRET, undefined);
   });
 
   test("strips export prefix on keys", async () => {
@@ -297,7 +312,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 
@@ -316,7 +331,7 @@ describe("libconfig - .env file loading", () => {
       "test",
       "svc",
       {},
-      createProcess(),
+      createRuntime(),
       mockStorageFn,
     );
 

--- a/libraries/libconfig/test/libconfig-getters.test.js
+++ b/libraries/libconfig/test/libconfig-getters.test.js
@@ -8,6 +8,10 @@ import {
   createTestRuntime,
   spy,
 } from "@forwardimpact/libmock";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+// Wrap a test proc as a runtime bag (real fs + test-controlled proc).
+const rt = (proc) => ({ ...createDefaultRuntime(), proc });
 
 describe("libconfig - Config getters", () => {
   const mockStorageFn = () =>
@@ -37,7 +41,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       () => mockStorage,
     );
 
@@ -60,7 +64,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       () => mockStorage,
     );
 
@@ -82,7 +86,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       () => mockStorage,
     );
 
@@ -114,7 +118,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(config.ghToken(), "gh-cli-token");
@@ -130,7 +134,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(config.ghToken(), "actions-token");
@@ -146,7 +150,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(config.ghToken(), "gh-token");
@@ -196,7 +200,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(config.supabaseUrl(), "http://127.0.0.1:54321");
@@ -212,7 +216,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.throws(() => config.supabaseUrl(), {
@@ -230,7 +234,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(config.supabaseAnonKey(), "anon-key-value");
@@ -246,7 +250,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.throws(() => config.supabaseAnonKey(), {
@@ -264,7 +268,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(
@@ -283,7 +287,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.throws(() => config.supabaseServiceRoleKey(), {
@@ -301,7 +305,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(config.supabaseJwtSecret(), "jwt-secret-value");
@@ -317,7 +321,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.throws(() => config.supabaseJwtSecret(), {
@@ -335,7 +339,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(config.msAppPassword(), "test-client-secret");
@@ -351,7 +355,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.throws(() => config.msAppPassword(), {
@@ -369,7 +373,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(config.msAppId(), "test-app-id");
@@ -385,7 +389,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.throws(() => config.msAppId(), {
@@ -403,7 +407,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.strictEqual(config.msAppTenantId(), "test-tenant-id");
@@ -419,7 +423,7 @@ describe("libconfig - Config getters", () => {
       "test",
       "myservice",
       {},
-      mockProcess,
+      rt(mockProcess),
       mockStorageFn,
     );
     assert.throws(() => config.msAppTenantId(), {

--- a/libraries/libconfig/test/stderr.integration.test.js
+++ b/libraries/libconfig/test/stderr.integration.test.js
@@ -36,10 +36,14 @@ describe("bootstrapProject — refusal stderr greppability", () => {
       import { bootstrapProject } from "${pathToFileUrl(
         path.join(repoRoot, "libraries", "libconfig", "src", "bootstrap.js"),
       )}";
+      import { createDefaultRuntime } from "${pathToFileUrl(
+        path.join(repoRoot, "libraries", "libutil", "src", "runtime.js"),
+      )}";
       try {
         await bootstrapProject({
           target: ${JSON.stringify(testDir)},
           fragment: { product: { x: { foo: "b" } } },
+          deps: { runtime: createDefaultRuntime() },
         });
         process.exit(0);
       } catch (err) {

--- a/libraries/libdoc/bin/fit-doc.js
+++ b/libraries/libdoc/bin/fit-doc.js
@@ -79,8 +79,9 @@ const definition = {
   examples: ["fit-doc build", "fit-doc serve --watch --port 8080"],
 };
 
-const cli = createCli(definition);
-const logger = createLogger("doc");
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
+const logger = createLogger("doc", runtime);
 
 /**
  * @param {import("../builder.js").PagesBuilder} builder
@@ -144,8 +145,6 @@ async function runServe(builder, server, pagesDir, distDir, options) {
 }
 
 async function main() {
-  const runtime = createDefaultRuntime();
-
   const parsed = cli.parse(process.argv.slice(2));
   if (!parsed) process.exit(0);
 
@@ -174,6 +173,7 @@ async function main() {
     parseFrontMatter,
     mustache.render,
     prettier,
+    runtime,
   );
 
   try {

--- a/libraries/libdoc/src/builder.js
+++ b/libraries/libdoc/src/builder.js
@@ -14,8 +14,6 @@ import {
 import { scanPages } from "./page-tree.js";
 import { resolvePartials, defaultRegistry } from "./partials.js";
 
-const logger = createLogger("libdoc");
-
 /**
  * Pages builder for converting Markdown files to HTML
  */
@@ -26,6 +24,7 @@ export class PagesBuilder {
   #matter;
   #mustacheRender;
   #prettier;
+  #logger;
 
   /**
    * Creates a new PagesBuilder instance
@@ -35,14 +34,24 @@ export class PagesBuilder {
    * @param {Function} matterParser - Front matter parser function
    * @param {Function} mustacheRender - Mustache render function
    * @param {object} prettier - Prettier module for HTML formatting
+   * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected runtime bag
    */
-  constructor(fs, path, markedParser, matterParser, mustacheRender, prettier) {
+  constructor(
+    fs,
+    path,
+    markedParser,
+    matterParser,
+    mustacheRender,
+    prettier,
+    runtime,
+  ) {
     if (!fs) throw new Error("fs is required");
     if (!path) throw new Error("path is required");
     if (!markedParser) throw new Error("markedParser is required");
     if (!matterParser) throw new Error("matterParser is required");
     if (!mustacheRender) throw new Error("mustacheRender is required");
     if (!prettier) throw new Error("prettier is required");
+    if (!runtime) throw new Error("runtime is required");
 
     this.#fs = fs;
     this.#path = path;
@@ -50,6 +59,7 @@ export class PagesBuilder {
     this.#matter = matterParser;
     this.#mustacheRender = mustacheRender;
     this.#prettier = prettier;
+    this.#logger = createLogger("libdoc", runtime);
 
     // Configure marked with extensions
     this.#marked.use(
@@ -103,7 +113,7 @@ export class PagesBuilder {
         this.#path.join(distDir, "assets"),
       )
     ) {
-      logger.info("  ✓ assets/");
+      this.#logger.info("  ✓ assets/");
     }
 
     const skipFiles = new Set(["index.template.html", "CNAME", "justfile"]);
@@ -120,7 +130,7 @@ export class PagesBuilder {
           this.#path.join(pagesDir, entry.name),
           this.#path.join(distDir, entry.name),
         );
-        logger.info(`  ✓ ${entry.name}`);
+        this.#logger.info(`  ✓ ${entry.name}`);
       });
   }
 
@@ -146,7 +156,7 @@ export class PagesBuilder {
       xml,
       "utf-8",
     );
-    logger.info("  ✓ sitemap.xml");
+    this.#logger.info("  ✓ sitemap.xml");
   }
 
   /**
@@ -174,7 +184,7 @@ export class PagesBuilder {
     const output = insertSectionLinks(content.split("\n"), sections, linkLine);
 
     this.#fs.writeFileSync(llmsPath, output.join("\n"), "utf-8");
-    logger.info("  ✓ llms.txt (augmented)");
+    this.#logger.info("  ✓ llms.txt (augmented)");
   }
 
   /**
@@ -240,7 +250,7 @@ export class PagesBuilder {
       finalHtml,
       "utf-8",
     );
-    logger.info(`  ✓ ${outputPath}.html`);
+    this.#logger.info(`  ✓ ${outputPath}.html`);
 
     this.#fs.writeFileSync(
       this.#path.join(distDir, outputPath + ".md"),
@@ -330,7 +340,7 @@ export class PagesBuilder {
    * @returns {Promise<void>}
    */
   async build(pagesDir, distDir, baseUrl) {
-    logger.info("Building documentation...");
+    this.#logger.info("Building documentation...");
 
     baseUrl = this.#resolveBaseUrl(baseUrl, pagesDir);
 
@@ -377,6 +387,6 @@ export class PagesBuilder {
       this.#augmentLlmsTxt(sortedPages, baseUrl, distDir);
     }
 
-    logger.info("Documentation build complete!");
+    this.#logger.info("Documentation build complete!");
   }
 }

--- a/libraries/libdoc/src/server.js
+++ b/libraries/libdoc/src/server.js
@@ -1,12 +1,11 @@
 import { createLogger } from "@forwardimpact/libtelemetry";
 
-const logger = createLogger("libdoc");
-
 /**
  * Documentation server for serving built documentation and watching for changes
  */
 export class PagesServer {
   #fs;
+  #logger;
   #Hono;
   #serve;
   #builder;
@@ -19,19 +18,20 @@ export class PagesServer {
    * @param {Function} HonoConstructor - Hono constructor (optional, required for serve())
    * @param {Function} serveFn - Hono serve function from @hono/node-server (optional, required for serve())
    * @param {import("./builder.js").PagesBuilder} builder - PagesBuilder instance
-   * @param {{ runtime?: import("@forwardimpact/libutil/runtime").Runtime }} [opts] - Optional injected runtime bag
+   * @param {{ runtime: import("@forwardimpact/libutil/runtime").Runtime }} opts - Injected runtime bag
    */
   constructor(fs, HonoConstructor, serveFn, builder, opts) {
     if (!fs) throw new Error("fs is required");
     if (!builder) throw new Error("builder is required");
+    if (!opts?.runtime) throw new Error("runtime is required");
 
     this.#fs = fs;
     this.#Hono = HonoConstructor;
     this.#serve = serveFn;
     this.#builder = builder;
     this.#watcher = null;
-    // Fall back to the ambient process when no runtime is injected (BC shim).
-    this.#proc = opts?.runtime?.proc ?? process;
+    this.#proc = opts.runtime.proc;
+    this.#logger = createLogger("libdoc", opts.runtime);
   }
 
   /**
@@ -41,7 +41,7 @@ export class PagesServer {
    * @returns {void}
    */
   watch(pagesDir, distDir) {
-    logger.info(`Watching for changes in ${pagesDir}...`);
+    this.#logger.info(`Watching for changes in ${pagesDir}...`);
 
     this.#watcher = this.#fs.watch(
       pagesDir,
@@ -53,7 +53,7 @@ export class PagesServer {
             filename.endsWith(".mustache") ||
             filename.startsWith("assets/"))
         ) {
-          logger.info(`\nRebuilding due to change in ${filename}...`);
+          this.#logger.info(`\nRebuilding due to change in ${filename}...`);
           this.#builder.build(pagesDir, distDir).catch((error) => {
             console.error("Build error:", error);
           });
@@ -159,7 +159,7 @@ export class PagesServer {
       });
     });
 
-    logger.info(`Serving documentation at http://${hostname}:${port}`);
+    this.#logger.info(`Serving documentation at http://${hostname}:${port}`);
 
     return this.#serve({ fetch: app.fetch, port, hostname });
   }

--- a/libraries/libdoc/test/libdoc-builder.test.js
+++ b/libraries/libdoc/test/libdoc-builder.test.js
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { PagesBuilder, PagesServer } from "../src/index.js";
+import { createTestRuntime } from "@forwardimpact/libmock";
 import { assertThrowsMessage } from "@forwardimpact/libmock";
 
 test("PagesBuilder constructor validates dependencies", () => {
@@ -56,6 +57,7 @@ test("PagesBuilder constructor validates dependencies", () => {
     mockMatter,
     mockMustache,
     mockPrettier,
+    createTestRuntime(),
   );
   assert.ok(builder instanceof PagesBuilder);
 });
@@ -73,7 +75,9 @@ test("PagesServer constructor validates dependencies", () => {
   );
 
   const mockBuilder = {};
-  const server = new PagesServer(mockFs, null, null, mockBuilder);
+  const server = new PagesServer(mockFs, null, null, mockBuilder, {
+    runtime: createTestRuntime(),
+  });
   assert.ok(server instanceof PagesServer);
 
   const mockHono = function () {};
@@ -83,6 +87,7 @@ test("PagesServer constructor validates dependencies", () => {
     mockHono,
     mockServe,
     mockBuilder,
+    { runtime: createTestRuntime() },
   );
   assert.ok(serverWithHono instanceof PagesServer);
 });
@@ -93,7 +98,9 @@ test("PagesServer stopWatch handles null watcher", () => {
   const mockServe = () => {};
   const mockBuilder = {};
 
-  const server = new PagesServer(mockFs, mockHono, mockServe, mockBuilder);
+  const server = new PagesServer(mockFs, mockHono, mockServe, mockBuilder, {
+    runtime: createTestRuntime(),
+  });
 
   assert.doesNotThrow(() => server.stopWatch());
 });
@@ -185,6 +192,7 @@ test("PagesBuilder generates correct output paths", async () => {
     mockMatter,
     mockMustache,
     mockPrettier,
+    createTestRuntime(),
   );
 
   await builder.build("docs", "dist");
@@ -293,6 +301,7 @@ test("PagesBuilder handles multiple markdown files correctly", async () => {
     mockMatter,
     mockMustache,
     mockPrettier,
+    createTestRuntime(),
   );
 
   await builder.build("docs", "dist");
@@ -378,6 +387,7 @@ test("PagesBuilder skips CLAUDE.md and SKILL.md files", async () => {
     mockMatter,
     mockMustache,
     mockPrettier,
+    createTestRuntime(),
   );
 
   await builder.build("docs", "dist");
@@ -436,7 +446,9 @@ test("PagesServer handles directory requests correctly", async () => {
   const mockServe = () => ({});
   const mockBuilder = {};
 
-  const server = new PagesServer(mockFs, mockHono, mockServe, mockBuilder);
+  const server = new PagesServer(mockFs, mockHono, mockServe, mockBuilder, {
+    runtime: createTestRuntime(),
+  });
   server.serve("dist", { port: 3000, hostname: "0.0.0.0" });
 
   const handler = mockApp.routes.get("*");

--- a/libraries/libdoc/test/libdoc-companion.test.js
+++ b/libraries/libdoc/test/libdoc-companion.test.js
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { PagesBuilder } from "../src/index.js";
+import { createTestRuntime } from "@forwardimpact/libmock";
 
 function createTestHarness({
   sourceFiles,
@@ -100,6 +101,7 @@ function createTestHarness({
     mockMatter,
     mockMustache,
     mockPrettier,
+    createTestRuntime(),
   );
 
   return { files, dirs, copied, builder };

--- a/libraries/libdoc/test/libdoc-llms.test.js
+++ b/libraries/libdoc/test/libdoc-llms.test.js
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { PagesBuilder } from "../src/index.js";
+import { createTestRuntime } from "@forwardimpact/libmock";
 
 function createTestHarness({
   sourceFiles,
@@ -100,6 +101,7 @@ function createTestHarness({
     mockMatter,
     mockMustache,
     mockPrettier,
+    createTestRuntime(),
   );
 
   return { files, dirs, copied, builder };
@@ -306,6 +308,7 @@ test("PagesBuilder copies root-level static files and skips .md, template, CNAME
     mockMatter,
     mockMustache,
     mockPrettier,
+    createTestRuntime(),
   );
 
   await builder.build("src", "dist");
@@ -420,6 +423,7 @@ test("PagesBuilder classifies docs pages under Documentation in llms.txt", async
     mockMatter,
     mockMustache,
     mockPrettier,
+    createTestRuntime(),
   );
 
   await builder.build("src", "dist", "https://example.com");

--- a/libraries/libeval/bin/fit-benchmark.js
+++ b/libraries/libeval/bin/fit-benchmark.js
@@ -156,10 +156,10 @@ export const definition = {
   ],
 };
 
-const logger = createLogger("benchmark");
+const runtime = createDefaultRuntime();
+const logger = createLogger("benchmark", runtime);
 
 async function main() {
-  const runtime = createDefaultRuntime();
   const cli = createCli(definition, { runtime });
   const parsed = cli.parse(runtime.proc.argv.slice(2));
   if (!parsed) return runtime.proc.exit(0);
@@ -187,7 +187,7 @@ async function main() {
 if (import.meta.url === `file://${realpathSync(process.argv[1])}`) {
   main().catch((error) => {
     logger.exception("main", error);
-    createCli(definition).error(error.message);
+    createCli(definition, { runtime }).error(error.message);
     process.exit(1);
   });
 }

--- a/libraries/libeval/bin/fit-eval.js
+++ b/libraries/libeval/bin/fit-eval.js
@@ -313,10 +313,10 @@ const definition = {
   ],
 };
 
-const logger = createLogger("eval");
+const runtime = createDefaultRuntime();
+const logger = createLogger("eval", runtime);
 
 async function main() {
-  const runtime = createDefaultRuntime();
   const cli = createCli(definition, { runtime });
   const parsed = cli.parse(runtime.proc.argv.slice(2));
   if (!parsed) return runtime.proc.exit(0);
@@ -341,6 +341,6 @@ async function main() {
 
 main().catch((error) => {
   logger.exception("main", error);
-  createCli(definition).error(error.message);
+  createCli(definition, { runtime }).error(error.message);
   process.exit(1);
 });

--- a/libraries/libeval/bin/fit-selfedit.js
+++ b/libraries/libeval/bin/fit-selfedit.js
@@ -72,11 +72,11 @@ if (extra.length > 0) fail(`unexpected extra arguments: ${extra.join(" ")}`);
 const absoluteTarget = resolve(process.cwd(), targetArg);
 
 // Safeguard 1: settings.json must grant Edit() on this path.
-const settingsPath = new Finder(fsPromises, { debug() {} }).findUpward(
-  dirname(absoluteTarget),
-  ".claude/settings.json",
-  20,
-);
+const settingsPath = new Finder({
+  fs: fsPromises,
+  fsSync: { existsSync },
+  proc: process,
+}).findUpward(dirname(absoluteTarget), ".claude/settings.json", 20);
 if (!settingsPath) {
   fail(
     `no .claude/settings.json found walking upward from ${dirname(absoluteTarget)}`,

--- a/libraries/libeval/bin/fit-trace.js
+++ b/libraries/libeval/bin/fit-trace.js
@@ -340,14 +340,14 @@ const definition = {
   ],
 };
 
-const logger = createLogger("trace");
+const runtime = createDefaultRuntime();
+const logger = createLogger("trace", runtime);
 
 // Commands that talk to the GitHub API need a config-backed token resolver;
 // the rest only read local trace files through the runtime.
 const NEEDS_CONFIG = new Set(["runs", "download"]);
 
 async function main() {
-  const runtime = createDefaultRuntime();
   const cli = createCli(definition, { runtime });
   const parsed = cli.parse(runtime.proc.argv.slice(2));
   if (!parsed) return runtime.proc.exit(0);
@@ -376,6 +376,6 @@ async function main() {
 
 main().catch((error) => {
   logger.exception("main", error);
-  createCli(definition).error(error.message);
+  createCli(definition, { runtime }).error(error.message);
   process.exit(1);
 });

--- a/libraries/libeval/src/discusser.js
+++ b/libraries/libeval/src/discusser.js
@@ -274,6 +274,7 @@ export function createDiscusser({
         messageBus,
         leadName: "lead",
         signal: abortController.signal,
+        runtime,
       })
     : null;
 

--- a/libraries/libeval/src/inbox-poller.js
+++ b/libraries/libeval/src/inbox-poller.js
@@ -18,20 +18,17 @@ export class InboxPoller {
    * @param {import("./message-bus.js").MessageBus} deps.messageBus
    * @param {string} deps.leadName
    * @param {AbortSignal} deps.signal
-   * @param {import("@forwardimpact/libutil/runtime").Runtime} [deps.runtime] -
-   *   Ambient collaborators; only `clock.setTimeout`/`clock.clearTimeout` are
-   *   used for the inter-poll backoff. Falls back to the global timers when
-   *   absent so existing callers keep working.
+   * @param {import("@forwardimpact/libutil/runtime").Runtime} deps.runtime -
+   *   Injected collaborators; `clock.setTimeout`/`clock.clearTimeout` drive the
+   *   inter-poll backoff.
    */
   constructor({ inboxUrl, messageBus, leadName, signal, runtime }) {
+    if (!runtime) throw new Error("runtime is required");
     this.#inboxUrl = inboxUrl;
     this.#messageBus = messageBus;
     this.#leadName = leadName;
     this.#signal = signal;
-    this.#clock = runtime?.clock ?? {
-      setTimeout: (fn, ms) => globalThis.setTimeout(fn, ms),
-      clearTimeout: (h) => globalThis.clearTimeout(h),
-    };
+    this.#clock = runtime.clock;
   }
 
   /** Long-poll the inbox until the abort signal fires. */

--- a/libraries/libeval/src/redaction.js
+++ b/libraries/libeval/src/redaction.js
@@ -135,7 +135,8 @@ export function createRedactor({
   patterns = DEFAULT_PATTERNS,
   enabled,
 } = {}) {
-  const proc = runtime?.proc ?? defaultProc();
+  if (!runtime) throw new Error("runtime is required");
+  const proc = runtime.proc;
   const resolvedEnv = env ?? proc.env;
   const envDisabled = resolvedEnv.LIBEVAL_REDACTION_DISABLED === "1";
   const resolvedEnabled = enabled ?? !envDisabled;
@@ -149,20 +150,6 @@ export function createRedactor({
     );
   }
   return new Redactor({ envSnapshot, patterns, enabled: resolvedEnabled });
-}
-
-/**
- * Lazily build the production proc surface so callers that don't inject a
- * runtime keep working. Imported indirectly to avoid pulling the whole
- * runtime bag (and its `node:fs`/`node:child_process` imports) into modules
- * that only ever receive an injected runtime.
- * @returns {{env: Record<string, string|undefined>, stderr: {write: (s: string) => void}}}
- */
-function defaultProc() {
-  return {
-    env: globalThis.process?.env ?? {},
-    stderr: { write: (s) => globalThis.process?.stderr?.write(s) },
-  };
 }
 
 /**

--- a/libraries/libeval/test/inbox-poller.test.js
+++ b/libraries/libeval/test/inbox-poller.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, test, afterEach, beforeEach } from "bun:test";
+import { createTestRuntime } from "@forwardimpact/libmock";
+const _rt = createTestRuntime();
 
 import { InboxPoller } from "../src/inbox-poller.js";
 import { createMessageBus } from "../src/message-bus.js";
@@ -33,6 +35,7 @@ describe("InboxPoller", () => {
 
     const bus = createMessageBus({ participants: ["lead"] });
     const poller = new InboxPoller({
+      runtime: _rt,
       inboxUrl: "https://bridge.test/api/inbox/corr-1",
       messageBus: bus,
       leadName: "lead",
@@ -64,6 +67,7 @@ describe("InboxPoller", () => {
 
     const bus = createMessageBus({ participants: ["lead"] });
     const poller = new InboxPoller({
+      runtime: _rt,
       inboxUrl: "https://bridge.test/api/inbox/corr-1",
       messageBus: bus,
       leadName: "lead",
@@ -80,6 +84,7 @@ describe("InboxPoller", () => {
     const bus = createMessageBus({ participants: ["lead"] });
     const ac = new AbortController();
     const poller = new InboxPoller({
+      runtime: _rt,
       inboxUrl: null,
       messageBus: bus,
       leadName: "lead",

--- a/libraries/libeval/test/redaction-pipeline.test.js
+++ b/libraries/libeval/test/redaction-pipeline.test.js
@@ -1,4 +1,6 @@
 import { describe, test } from "node:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const _rt = createDefaultRuntime();
 import assert from "node:assert";
 import { PassThrough, Writable } from "node:stream";
 
@@ -57,6 +59,7 @@ describe("Producer pipeline — sentinel sweep (criterion 1)", () => {
     const sink = captureSink();
 
     const redactor = createRedactor({
+      runtime: _rt,
       env: {
         ANTHROPIC_API_KEY: ANTH_SENT,
         GH_TOKEN: GH_SENT,
@@ -146,7 +149,7 @@ describe("Producer pipeline — sentinel sweep (criterion 1)", () => {
 describe("Producer pipeline — patterns (criterion 2)", () => {
   test("pattern hits redact when no env vars are configured", async () => {
     const sink = captureSink();
-    const redactor = createRedactor({ env: {} });
+    const redactor = createRedactor({ runtime: _rt, env: {} });
 
     const anth = "sk-ant-" + "a".repeat(95);
     const ghp = "ghp_" + "A".repeat(36);
@@ -211,6 +214,7 @@ describe("Producer pipeline — opt-out warning (criterion 4)", () => {
     };
     try {
       redactor = createRedactor({
+        runtime: _rt,
         env: {
           LIBEVAL_REDACTION_DISABLED: "1",
           ANTHROPIC_API_KEY: ANTH_SENT,
@@ -257,6 +261,7 @@ describe("Producer pipeline — toText() byte-for-byte placeholder fidelity (cri
   test("captured NDJSON replays placeholders identically through TraceCollector.toText()", async () => {
     const sink = captureSink();
     const redactor = createRedactor({
+      runtime: _rt,
       env: { ANTHROPIC_API_KEY: ANTH_SENT, GH_TOKEN: GH_SENT },
     });
 
@@ -323,6 +328,7 @@ describe("Producer pipeline — toText() byte-for-byte placeholder fidelity (cri
     });
 
     const redactor = createRedactor({
+      runtime: _rt,
       env: { GH_TOKEN: GH_SENT },
     });
 
@@ -397,7 +403,10 @@ describe("Producer pipeline — Supervisor.emitSummary covers Conclude-handler t
     const agentRunner = createMockRunner([]);
 
     const sink = captureSink();
-    const redactor = createRedactor({ env: { GH_TOKEN: GH_SENT } });
+    const redactor = createRedactor({
+      runtime: _rt,
+      env: { GH_TOKEN: GH_SENT },
+    });
 
     const supervisor = new Supervisor({
       agentRunner,
@@ -460,7 +469,10 @@ describe("Producer pipeline — Facilitator.emitSummary covers Conclude-handler 
     const agentRunner = createMockRunner([]);
 
     const sink = captureSink();
-    const redactor = createRedactor({ env: { GH_TOKEN: GH_SENT } });
+    const redactor = createRedactor({
+      runtime: _rt,
+      env: { GH_TOKEN: GH_SENT },
+    });
 
     const facilitator = new Facilitator({
       facilitatorRunner,

--- a/libraries/libeval/test/redaction.test.js
+++ b/libraries/libeval/test/redaction.test.js
@@ -1,5 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const _rt = createDefaultRuntime();
 
 import {
   Redactor,
@@ -75,6 +77,7 @@ describe("Redactor — env-var allowlist (criterion 1)", () => {
     }
 
     const r = createRedactor({
+      runtime: _rt,
       env: {
         ANTHROPIC_API_KEY: ANTHROPIC,
         AWS_ACCESS_KEY_ID: AWS_KEY,
@@ -172,7 +175,7 @@ describe("Redactor — env-var allowlist (criterion 1)", () => {
 
   test("multiple occurrences of the same sentinel in a single string all redacted", () => {
     const SENT = "MULTI_HIT_SENTINEL";
-    const r = createRedactor({ env: { GH_TOKEN: SENT } });
+    const r = createRedactor({ runtime: _rt, env: { GH_TOKEN: SENT } });
     const out = r.redactValue(`${SENT} and ${SENT} again ${SENT}`);
     assert.strictEqual(
       out,
@@ -182,6 +185,7 @@ describe("Redactor — env-var allowlist (criterion 1)", () => {
 
   test("empty-string env values do not poison redaction", () => {
     const r = createRedactor({
+      runtime: _rt,
       env: { GH_TOKEN: "", GITHUB_TOKEN: "", ANTHROPIC_API_KEY: "" },
     });
     // Empty string input must come through identically; redactor must
@@ -195,6 +199,7 @@ describe("Redactor — env-var allowlist (criterion 1)", () => {
 
   test("LIBEVAL_REDACTION_ENV_VARS replaces (not extends) the default allowlist", () => {
     const r = createRedactor({
+      runtime: _rt,
       env: {
         LIBEVAL_REDACTION_ENV_VARS: "FOO,BAR",
         FOO: "foo-secret",
@@ -210,6 +215,7 @@ describe("Redactor — env-var allowlist (criterion 1)", () => {
 
   test("LIBEVAL_REDACTION_ENV_VARS trims whitespace and ignores empty entries", () => {
     const r = createRedactor({
+      runtime: _rt,
       env: {
         LIBEVAL_REDACTION_ENV_VARS: "  FOO , , BAR  ",
         FOO: "foo-secret",
@@ -223,7 +229,7 @@ describe("Redactor — env-var allowlist (criterion 1)", () => {
 
 describe("Redactor — credential patterns (criterion 2)", () => {
   test("each default pattern at canonical length yields [REDACTED:pattern:KIND]", () => {
-    const r = createRedactor({ env: {} });
+    const r = createRedactor({ runtime: _rt, env: {} });
 
     // Anthropic prefix + 80 url-safe chars.
     const anth = "sk-ant-" + "a".repeat(80);
@@ -253,7 +259,7 @@ describe("Redactor — credential patterns (criterion 2)", () => {
   });
 
   test("anthropic pattern hit inside tool_result.content JSON-string", () => {
-    const r = createRedactor({ env: {} });
+    const r = createRedactor({ runtime: _rt, env: {} });
     const anth = "sk-ant-" + "z".repeat(95);
     const message = {
       type: "user",
@@ -273,7 +279,7 @@ describe("Redactor — credential patterns (criterion 2)", () => {
 });
 
 describe("Redactor — benign content unchanged (criterion 3)", () => {
-  const r = createRedactor({ env: {} });
+  const r = createRedactor({ runtime: _rt, env: {} });
   const benign = [
     "Hello world — this is plain prose.",
     "# Markdown header\n\n- item 1\n- item 2",
@@ -302,6 +308,7 @@ describe("Redactor — opt-out (criterion 4, design § Opt-out surface)", () => 
     let r;
     const stderr = captureStderr(() => {
       r = createRedactor({
+        runtime: _rt,
         env: {
           LIBEVAL_REDACTION_DISABLED: "1",
           GH_TOKEN: "would-have-redacted",
@@ -323,6 +330,7 @@ describe("Redactor — opt-out (criterion 4, design § Opt-out surface)", () => 
     let r;
     const stderr = captureStderr(() => {
       r = createRedactor({
+        runtime: _rt,
         env: { LIBEVAL_REDACTION_DISABLED: "true", GH_TOKEN: "secret-value" },
       });
     });
@@ -338,6 +346,7 @@ describe("Redactor — opt-out (criterion 4, design § Opt-out surface)", () => 
     let r;
     const stderr = captureStderr(() => {
       r = createRedactor({
+        runtime: _rt,
         env: { LIBEVAL_REDACTION_DISABLED: "yes", GH_TOKEN: "secret-value" },
       });
     });
@@ -352,7 +361,7 @@ describe("Redactor — opt-out (criterion 4, design § Opt-out surface)", () => 
   test("createRedactor({ enabled: false }) fires the stderr warning regardless of env state", () => {
     let r;
     const stderr = captureStderr(() => {
-      r = createRedactor({ env: {}, enabled: false });
+      r = createRedactor({ runtime: _rt, env: {}, enabled: false });
     });
     assert.strictEqual(r.enabled, false);
     assert.match(stderr, /libeval: trace redaction DISABLED/);
@@ -389,7 +398,7 @@ describe("createNoopRedactor", () => {
 });
 
 describe("Redactor — word boundary adversarial cases (Risks table)", () => {
-  const r = createRedactor({ env: {} });
+  const r = createRedactor({ runtime: _rt, env: {} });
   const body = "A".repeat(36);
   const token = `ghp_${body}`;
 
@@ -464,9 +473,9 @@ describe("Redactor — exports and defaults", () => {
     ]);
   });
 
-  test("createRedactor() with no options falls back to process.env", () => {
+  test("createRedactor({ runtime: _rt }) with no options falls back to process.env", () => {
     // Smoke check — must not throw, and must produce a Redactor.
-    const r = createRedactor();
+    const r = createRedactor({ runtime: _rt });
     assert.ok(r instanceof Redactor);
   });
 });

--- a/libraries/libgraph/bin/fit-process-graphs.js
+++ b/libraries/libgraph/bin/fit-process-graphs.js
@@ -3,6 +3,7 @@ import "@forwardimpact/libpreflight/node22";
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createResourceIndex } from "@forwardimpact/libresource";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
@@ -28,8 +29,9 @@ const definition = {
   },
 };
 
-const cli = createCli(definition);
-const logger = createLogger("graphs");
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
+const logger = createLogger("graphs", runtime);
 
 /**
  * Processes resources into RDF graphs
@@ -40,7 +42,7 @@ async function main() {
   if (!parsed) process.exit(0);
 
   const resourceIndex = createResourceIndex("resources");
-  const graphIndex = createGraphIndex("graphs");
+  const graphIndex = createGraphIndex("graphs", runtime.clock);
 
   const processor = new GraphProcessor(graphIndex, resourceIndex, logger);
 

--- a/libraries/libgraph/bin/fit-query.js
+++ b/libraries/libgraph/bin/fit-query.js
@@ -3,6 +3,7 @@ import "@forwardimpact/libpreflight/node22";
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { createGraphIndex, parseGraphQuery } from "@forwardimpact/libgraph";
 
@@ -27,8 +28,9 @@ const definition = {
   examples: ['fit-query "?" rdf:type schema:Person'],
 };
 
-const cli = createCli(definition);
-const logger = createLogger("query");
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
+const logger = createLogger("query", runtime);
 
 /**
  * Queries the graph index with a triple pattern
@@ -44,7 +46,7 @@ async function main() {
   }
 
   const pattern = parseGraphQuery(parsed.positionals.join(" "));
-  const graphIndex = createGraphIndex("graphs");
+  const graphIndex = createGraphIndex("graphs", runtime.clock);
 
   const identifiers = await graphIndex.queryItems(pattern);
 

--- a/libraries/libgraph/bin/fit-subjects.js
+++ b/libraries/libgraph/bin/fit-subjects.js
@@ -3,6 +3,7 @@ import "@forwardimpact/libpreflight/node22";
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { createGraphIndex } from "@forwardimpact/libgraph";
 
@@ -27,8 +28,9 @@ const definition = {
   examples: ["fit-subjects", "fit-subjects schema:Person"],
 };
 
-const cli = createCli(definition);
-const logger = createLogger("subjects");
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
+const logger = createLogger("subjects", runtime);
 
 /**
  * Lists graph subjects, optionally filtered by type
@@ -39,7 +41,7 @@ async function main() {
   if (!parsed) process.exit(0);
 
   const type = parsed.positionals[0] || null;
-  const graphIndex = createGraphIndex("graphs");
+  const graphIndex = createGraphIndex("graphs", runtime.clock);
 
   const subjects = await graphIndex.getSubjects(type);
 

--- a/libraries/libgraph/src/index.js
+++ b/libraries/libgraph/src/index.js
@@ -65,14 +65,17 @@ export function parseGraphQuery(line) {
 /**
  * Creates a `GraphIndex` with the provided storage prefix and default index key.
  * @param {string} prefix - Storage prefix (directory name or S3 key prefix) for graph data
+ * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} clock - Injected clock
  * @returns {GraphIndex} Graph index instance
  */
-export function createGraphIndex(prefix) {
+export function createGraphIndex(prefix, clock) {
   if (!prefix) throw new Error("prefix is required");
   const storage = createStorage(prefix);
   const n3Store = new Store({ prefixes: RDF_PREFIXES });
   // New constructor order: storage, store, prefixes, indexKey
-  return new GraphIndex(storage, n3Store, RDF_PREFIXES, "index.jsonl");
+  return new GraphIndex(storage, n3Store, RDF_PREFIXES, "index.jsonl", {
+    clock,
+  });
 }
 
 // GraphIndex is NOT exported to avoid circular dependency - import from ./index/graph.js

--- a/libraries/libgraph/src/index/graph.js
+++ b/libraries/libgraph/src/index/graph.js
@@ -19,13 +19,21 @@ export class GraphIndex extends IndexBase {
    * @param {Store} store - N3 Store instance for graph operations
    * @param {{[key: string]: string}} [prefixes] - Optional RDF prefix map
    * @param {string} [indexKey] - The index file name to use for storage (default: "index.jsonl")
+   * @param {object} [deps]
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} deps.clock
    */
-  constructor(storage, store, prefixes = {}, indexKey = "index.jsonl") {
+  constructor(
+    storage,
+    store,
+    prefixes = {},
+    indexKey = "index.jsonl",
+    { clock } = {},
+  ) {
     if (!storage) throw new Error("storage is required");
     if (!store || !(store instanceof Store))
       throw new Error("store must be an N3 Store instance");
 
-    super(storage, indexKey);
+    super(storage, indexKey, {}, { clock });
 
     this.#graph = store;
     this.#prefixes = prefixes;

--- a/libraries/libindex/src/buffered.js
+++ b/libraries/libindex/src/buffered.js
@@ -1,5 +1,4 @@
 import { IndexBase } from "./base.js";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /**
  * Buffered index for high-volume writes with periodic flushing
@@ -20,19 +19,16 @@ export class BufferedIndex extends IndexBase {
    * @param {object} config - Buffer configuration
    * @param {number} [config.flush_interval] - Flush interval in milliseconds (default: 5000)
    * @param {number} [config.max_buffer_size] - Max items before forced flush (default: 1000)
-   * @param {object} [deps] - Injected collaborators
-   * @param {import("@forwardimpact/libutil/runtime").Runtime} [deps.runtime]
+   * @param {object} deps - Injected collaborators
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} deps.clock -
+   *   Injected clock collaborator (the only runtime surface BufferedIndex uses).
    */
-  constructor(
-    storage,
-    indexKey,
-    config = {},
-    { runtime = createDefaultRuntime() } = {},
-  ) {
+  constructor(storage, indexKey, config = {}, { clock } = {}) {
     super(storage, indexKey);
+    if (!clock) throw new Error("clock is required");
     this.#flushInterval = config.flush_interval || 5000;
     this.#maxBufferSize = config.max_buffer_size || 1000;
-    this.#clock = runtime.clock;
+    this.#clock = clock;
   }
 
   /**

--- a/libraries/libindex/test/buffered.test.js
+++ b/libraries/libindex/test/buffered.test.js
@@ -4,6 +4,9 @@ import assert from "node:assert";
 // Module under test
 import { BufferedIndex } from "../src/index.js";
 import { createMockStorage } from "@forwardimpact/libmock";
+import { createDefaultClock } from "@forwardimpact/libutil/runtime";
+
+const clock = createDefaultClock();
 
 describe("BufferedIndex - Buffered Write Operations", () => {
   let bufferedIndex;
@@ -21,19 +24,28 @@ describe("BufferedIndex - Buffered Write Operations", () => {
 
   describe("Constructor Configuration", () => {
     test("uses default config values when not provided", () => {
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl");
+      bufferedIndex = new BufferedIndex(
+        mockStorage,
+        "test.jsonl",
+        {},
+        { clock },
+      );
       assert.ok(bufferedIndex, "Should create instance with defaults");
     });
 
     test("accepts config with flush_interval", () => {
       const config = { flush_interval: 1000 };
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config);
+      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config, {
+        clock,
+      });
       assert.ok(bufferedIndex, "Should create instance with custom config");
     });
 
     test("accepts config with max_buffer_size", () => {
       const config = { max_buffer_size: 500 };
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config);
+      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config, {
+        clock,
+      });
       assert.ok(bufferedIndex, "Should create instance with custom config");
     });
   });
@@ -41,7 +53,9 @@ describe("BufferedIndex - Buffered Write Operations", () => {
   describe("Buffered Add Operations", () => {
     test("add buffers items without immediate write", async () => {
       const config = { flush_interval: 10000 };
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config);
+      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config, {
+        clock,
+      });
 
       await bufferedIndex.add({ id: "item1", data: "test" });
 
@@ -54,7 +68,9 @@ describe("BufferedIndex - Buffered Write Operations", () => {
 
     test("add makes items immediately queryable", async () => {
       const config = { flush_interval: 10000 };
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config);
+      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config, {
+        clock,
+      });
 
       await bufferedIndex.add({ id: "item1", data: "test" });
       const exists = await bufferedIndex.has("item1");
@@ -68,7 +84,9 @@ describe("BufferedIndex - Buffered Write Operations", () => {
 
     test("flush writes buffered items to storage", async () => {
       const config = { flush_interval: 10000 };
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config);
+      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config, {
+        clock,
+      });
 
       await bufferedIndex.add({ id: "item1", data: "test1" });
       await bufferedIndex.add({ id: "item2", data: "test2" });
@@ -84,7 +102,12 @@ describe("BufferedIndex - Buffered Write Operations", () => {
     });
 
     test("flush returns zero when buffer is empty", async () => {
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl");
+      bufferedIndex = new BufferedIndex(
+        mockStorage,
+        "test.jsonl",
+        {},
+        { clock },
+      );
 
       const flushed = await bufferedIndex.flush();
 
@@ -100,7 +123,9 @@ describe("BufferedIndex - Buffered Write Operations", () => {
   describe("Automatic Flush Behavior", () => {
     test("forces flush when max_buffer_size is reached", async () => {
       const config = { flush_interval: 10000, max_buffer_size: 2 };
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config);
+      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config, {
+        clock,
+      });
 
       await bufferedIndex.add({ id: "item1", data: "test1" });
       await bufferedIndex.add({ id: "item2", data: "test2" });
@@ -116,7 +141,9 @@ describe("BufferedIndex - Buffered Write Operations", () => {
   describe("Shutdown", () => {
     test("shutdown flushes remaining buffered items", async () => {
       const config = { flush_interval: 10000 };
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config);
+      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl", config, {
+        clock,
+      });
 
       await bufferedIndex.add({ id: "item1", data: "test" });
       await bufferedIndex.shutdown();
@@ -129,7 +156,12 @@ describe("BufferedIndex - Buffered Write Operations", () => {
     });
 
     test("shutdown succeeds with empty buffer", async () => {
-      bufferedIndex = new BufferedIndex(mockStorage, "test.jsonl");
+      bufferedIndex = new BufferedIndex(
+        mockStorage,
+        "test.jsonl",
+        {},
+        { clock },
+      );
       await bufferedIndex.shutdown();
 
       assert.strictEqual(

--- a/libraries/libmacos/src/posix-spawn.js
+++ b/libraries/libmacos/src/posix-spawn.js
@@ -10,8 +10,6 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
-
 // responsibility_spawnattrs_setdisclaim makes the spawned child disclaim
 // TCC "responsible process" status, so macOS checks the parent's responsible
 // process (Outpost.app) instead.
@@ -101,7 +99,7 @@ function buildStringArray(strings) {
  * @param {object} [runtime] - Runtime collaborator bag
  * @returns {string}
  */
-export function readOutput(filePath, runtime = createDefaultRuntime()) {
+export function readOutput(filePath, runtime) {
   const { fsSync } = runtime;
   try {
     return fsSync.readFileSync(filePath, "utf-8");
@@ -130,13 +128,7 @@ export function readOutput(filePath, runtime = createDefaultRuntime()) {
  * @param {object} [runtime] - Runtime collaborator bag
  * @returns {{ pid: number, stdoutFile: string, stderrFile: string }}
  */
-export function spawn(
-  executable,
-  args,
-  env,
-  cwd,
-  runtime = createDefaultRuntime(),
-) {
+export function spawn(executable, args, env, cwd, runtime) {
   const { proc, clock, fsSync } = runtime;
   const argv = buildStringArray([executable, ...args]);
   const envObj = env ?? { ...proc.env };
@@ -221,11 +213,7 @@ export function spawn(
  * @param {object} [runtime] - Runtime collaborator bag
  * @returns {Promise<number>} Exit status
  */
-export async function waitForExit(
-  pid,
-  pollIntervalMs = 100,
-  runtime = createDefaultRuntime(),
-) {
+export async function waitForExit(pid, pollIntervalMs = 100, runtime) {
   const { clock } = runtime;
   const status = new Int32Array(1);
   while (true) {

--- a/libraries/libmacos/src/tcc-responsibility.js
+++ b/libraries/libmacos/src/tcc-responsibility.js
@@ -7,16 +7,23 @@
  * @returns {(executable: string, args: string[], env?: Record<string, string>, cwd?: string) => Promise<{ exitCode: number, stdout: string, stderr: string }>}
  */
 export function createTccSpawn(deps) {
-  return async function spawnWithTccDisclaim(executable, args, env, cwd) {
+  return async function spawnWithTccDisclaim(
+    executable,
+    args,
+    env,
+    cwd,
+    runtime,
+  ) {
     const { pid, stdoutFile, stderrFile } = deps.spawn(
       executable,
       args,
       env,
       cwd,
+      runtime,
     );
-    const exitCode = await deps.waitForExit(pid);
-    const stdout = deps.readOutput(stdoutFile);
-    const stderr = deps.readOutput(stderrFile);
+    const exitCode = await deps.waitForExit(pid, undefined, runtime);
+    const stdout = deps.readOutput(stdoutFile, runtime);
+    const stderr = deps.readOutput(stderrFile, runtime);
     return { exitCode, stdout, stderr };
   };
 }

--- a/libraries/libpack/src/builder.js
+++ b/libraries/libpack/src/builder.js
@@ -1,7 +1,5 @@
 import { join } from "path";
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
-
 /** Orchestrate pack generation across stager and emitters. */
 export class PackBuilder {
   #stager;
@@ -10,7 +8,8 @@ export class PackBuilder {
 
   /** @param {{stager: PackStager, emitters: {tar: TarEmitter, git: GitEmitter, disc: DiscEmitter}, runtime?: object}} deps */
   constructor({ stager, emitters, runtime }) {
-    const rt = runtime ?? createDefaultRuntime();
+    if (!runtime) throw new Error("runtime is required");
+    const rt = runtime;
     this.#stager = stager;
     this.#emitters = emitters;
     this.#fs = rt.fs;

--- a/libraries/libpack/src/disc-emitter.js
+++ b/libraries/libpack/src/disc-emitter.js
@@ -1,7 +1,5 @@
 import { join } from "path";
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
-
 import { buildSkillEntry, stringifySorted } from "./util.js";
 
 const SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
@@ -12,7 +10,8 @@ export class DiscEmitter {
 
   /** @param {{runtime?: object}} [opts] */
   constructor({ runtime } = {}) {
-    const rt = runtime ?? createDefaultRuntime();
+    if (!runtime) throw new Error("runtime is required");
+    const rt = runtime;
     this.#fs = rt.fs;
   }
 

--- a/libraries/libpack/src/git-emitter.js
+++ b/libraries/libpack/src/git-emitter.js
@@ -1,7 +1,5 @@
 import { join } from "path";
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
-
 const AUTHOR = "Forward Impact Pathway";
 const EMAIL = "pathway@forwardimpact.team";
 const EPOCH = "1970-01-01T00:00:00Z";
@@ -28,7 +26,8 @@ export class GitEmitter {
 
   /** @param {{runtime?: object}} [opts] */
   constructor({ runtime } = {}) {
-    const rt = runtime ?? createDefaultRuntime();
+    if (!runtime) throw new Error("runtime is required");
+    const rt = runtime;
     this.#subprocess = rt.subprocess;
     this.#fs = rt.fs;
     this.#proc = rt.proc;

--- a/libraries/libpack/src/stager.js
+++ b/libraries/libpack/src/stager.js
@@ -1,7 +1,5 @@
 import { join } from "path";
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
-
 import { collectFiles } from "./util.js";
 
 /** Stage directory trees per layout (full, APM, skills). */
@@ -10,7 +8,8 @@ export class PackStager {
 
   /** @param {{runtime?: object}} [opts] */
   constructor({ runtime } = {}) {
-    const rt = runtime ?? createDefaultRuntime();
+    if (!runtime) throw new Error("runtime is required");
+    const rt = runtime;
     this.#fs = rt.fs;
   }
 

--- a/libraries/libpack/src/tar-emitter.js
+++ b/libraries/libpack/src/tar-emitter.js
@@ -1,5 +1,3 @@
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
-
 import { collectPaths, resetTimestamps } from "./util.js";
 
 /** Deterministic tarball emitter. */
@@ -9,7 +7,8 @@ export class TarEmitter {
 
   /** @param {{runtime?: object}} [opts] */
   constructor({ runtime } = {}) {
-    const rt = runtime ?? createDefaultRuntime();
+    if (!runtime) throw new Error("runtime is required");
+    const rt = runtime;
     this.#subprocess = rt.subprocess;
     this.#fs = rt.fs;
   }

--- a/libraries/libpack/test/builder.integration.test.js
+++ b/libraries/libpack/test/builder.integration.test.js
@@ -1,4 +1,6 @@
 import { describe, test, expect } from "bun:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const runtime = createDefaultRuntime();
 import { mkdtemp } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -85,8 +87,9 @@ describe("PackBuilder", () => {
     const disc = createRecordingDiscEmitter();
 
     const builder = new PackBuilder({
-      stager: new PackStager(),
+      stager: new PackStager({ runtime }),
       emitters: { tar, git, disc },
+      runtime,
     });
 
     const result = await builder.build({

--- a/libraries/libpack/test/disc-emitter.integration.test.js
+++ b/libraries/libpack/test/disc-emitter.integration.test.js
@@ -1,4 +1,6 @@
 import { describe, test, expect } from "bun:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const runtime = createDefaultRuntime();
 import { mkdtemp, mkdir, writeFile, readFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -31,7 +33,7 @@ describe("DiscEmitter", () => {
     const skillsDir = await createSkillsDir();
     const outputDir = await makeTempDir();
 
-    const emitter = new DiscEmitter();
+    const emitter = new DiscEmitter({ runtime });
     const entries = await emitter.emit(skillsDir, outputDir);
 
     expect(entries).toHaveLength(2);
@@ -55,7 +57,7 @@ describe("DiscEmitter", () => {
 
   test("emitAggregate deduplicates skills across packs", async () => {
     const packsDir = await makeTempDir();
-    const emitter = new DiscEmitter();
+    const emitter = new DiscEmitter({ runtime });
 
     // Create two per-pack skill repos with overlapping skills
     const skills1 = await createSkillsDir();

--- a/libraries/libpack/test/git-emitter.integration.test.js
+++ b/libraries/libpack/test/git-emitter.integration.test.js
@@ -1,4 +1,6 @@
 import { describe, test, expect } from "bun:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const runtime = createDefaultRuntime();
 import {
   mkdtemp,
   mkdir,
@@ -59,7 +61,7 @@ describe("GitEmitter", () => {
     const repoPath = join(outDir, "test.git");
     const cloneDir = join(outDir, "clone");
 
-    const emitter = new GitEmitter();
+    const emitter = new GitEmitter({ runtime });
     await emitter.emit(stagedDir, repoPath, {
       version: "1.0.0",
       name: "test-pack",
@@ -79,7 +81,7 @@ describe("GitEmitter", () => {
     const outDir = await makeTempDir();
     const repoPath = join(outDir, "test.git");
 
-    const emitter = new GitEmitter();
+    const emitter = new GitEmitter({ runtime });
     await emitter.emit(stagedDir, repoPath, {
       version: "2.5.0",
       name: "tagged",
@@ -94,7 +96,7 @@ describe("GitEmitter", () => {
     const outDir = await makeTempDir();
     const repoPath = join(outDir, "test.git");
 
-    const emitter = new GitEmitter();
+    const emitter = new GitEmitter({ runtime });
     await emitter.emit(stagedDir, repoPath, {
       version: "1.0.0",
       name: "clean",
@@ -118,7 +120,7 @@ describe("GitEmitter", () => {
     const repo1 = join(outDir, "a.git");
     const repo2 = join(outDir, "b.git");
 
-    const emitter = new GitEmitter();
+    const emitter = new GitEmitter({ runtime });
     await emitter.emit(stagedDir, repo1, { version: "1.0.0", name: "det" });
     await emitter.emit(stagedDir, repo2, { version: "1.0.0", name: "det" });
 
@@ -140,7 +142,7 @@ describe("GitEmitter", () => {
     const repoPath = join(outDir, "test.git");
     const cloneDir = join(outDir, "http-clone");
 
-    const emitter = new GitEmitter();
+    const emitter = new GitEmitter({ runtime });
     await emitter.emit(stagedDir, repoPath, {
       version: "1.0.0",
       name: "http-test",
@@ -187,7 +189,7 @@ describe("GitEmitter", () => {
     const repoPath = join(outDir, "test.git");
     const cloneDir = join(outDir, "shallow-clone");
 
-    const emitter = new GitEmitter();
+    const emitter = new GitEmitter({ runtime });
     await emitter.emit(stagedDir, repoPath, {
       version: "1.0.0",
       name: "smart-http-test",

--- a/libraries/libpack/test/stager.integration.test.js
+++ b/libraries/libpack/test/stager.integration.test.js
@@ -1,4 +1,6 @@
 import { describe, test, expect } from "bun:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const runtime = createDefaultRuntime();
 import { mkdtemp, readFile, readdir, stat } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -39,7 +41,7 @@ const CONTENT = {
 describe("PackStager", () => {
   test("stageFull creates expected file tree", async () => {
     const dir = await makeTempDir();
-    const stager = new PackStager();
+    const stager = new PackStager({ runtime });
     await stager.stageFull(dir, CONTENT);
 
     expect(
@@ -78,7 +80,7 @@ describe("PackStager", () => {
   test("stageApm produces APM layout with lock file", async () => {
     const fullDir = await makeTempDir();
     const apmDir = await makeTempDir();
-    const stager = new PackStager();
+    const stager = new PackStager({ runtime });
     await stager.stageFull(fullDir, CONTENT);
     await stager.stageApm(fullDir, apmDir, "se-platform", "1.0.0");
 
@@ -102,7 +104,7 @@ describe("PackStager", () => {
   });
 
   test("skillsDir returns .claude/skills path", () => {
-    const stager = new PackStager();
+    const stager = new PackStager({ runtime });
     expect(stager.skillsDir("/tmp/pack")).toBe("/tmp/pack/.claude/skills");
   });
 });

--- a/libraries/libpack/test/tar-emitter.integration.test.js
+++ b/libraries/libpack/test/tar-emitter.integration.test.js
@@ -1,4 +1,6 @@
 import { describe, test, expect } from "bun:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const runtime = createDefaultRuntime();
 import { mkdtemp, mkdir, writeFile, readFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -23,7 +25,7 @@ describe("TarEmitter", () => {
     const outDir = await makeTempDir();
     const outputPath = join(outDir, "test.tar.gz");
 
-    const emitter = new TarEmitter();
+    const emitter = new TarEmitter({ runtime });
     await emitter.emit(stagedDir, outputPath);
 
     const listing = execFileSync("tar", ["tzf", outputPath]).toString();
@@ -37,7 +39,7 @@ describe("TarEmitter", () => {
     const path1 = join(outDir, "a.tar.gz");
     const path2 = join(outDir, "b.tar.gz");
 
-    const emitter = new TarEmitter();
+    const emitter = new TarEmitter({ runtime });
     await emitter.emit(stagedDir, path1);
     await emitter.emit(stagedDir, path2);
 

--- a/libraries/libprompt/src/loader.js
+++ b/libraries/libprompt/src/loader.js
@@ -1,6 +1,5 @@
 import { join } from "node:path";
 import Mustache from "mustache";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /**
  * Prompt loader with Mustache templating.
@@ -12,10 +11,11 @@ export class PromptLoader {
 
   /**
    * @param {string} promptDir - Directory containing .prompt.md files
-   * @param {import("@forwardimpact/libutil/runtime").Runtime} [runtime]
+   * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
    */
-  constructor(promptDir, runtime = createDefaultRuntime()) {
+  constructor(promptDir, runtime) {
     if (!promptDir) throw new Error("promptDir is required");
+    if (!runtime) throw new Error("runtime is required");
     this.#promptDir = promptDir;
     this.#fsSync = runtime.fsSync;
   }

--- a/libraries/libprompt/test/loader.test.js
+++ b/libraries/libprompt/test/loader.test.js
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { PromptLoader, createPromptLoader } from "../src/index.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 describe("PromptLoader", () => {
   let tempDir;
@@ -26,27 +27,27 @@ describe("PromptLoader", () => {
   });
 
   test("constructor accepts valid promptDir", () => {
-    const loader = new PromptLoader(tempDir);
+    const loader = new PromptLoader(tempDir, createDefaultRuntime());
     assert.ok(loader instanceof PromptLoader);
   });
 
   describe("load", () => {
     test("throws when promptName is not provided", () => {
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       assert.throws(() => loader.load(), {
         message: "promptName is required",
       });
     });
 
     test("throws when promptName is empty string", () => {
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       assert.throws(() => loader.load(""), {
         message: "promptName is required",
       });
     });
 
     test("throws when prompt file does not exist", () => {
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       assert.throws(() => loader.load("nonexistent"), {
         message: /Prompt file not found/,
       });
@@ -56,7 +57,7 @@ describe("PromptLoader", () => {
       const content = "# Test Prompt\n\nThis is a test prompt.";
       writeFileSync(join(tempDir, "test.prompt.md"), content);
 
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       const result = loader.load("test");
 
       assert.strictEqual(result, content);
@@ -66,7 +67,7 @@ describe("PromptLoader", () => {
       const content = "# Prompt with umlauts and accents";
       writeFileSync(join(tempDir, "unicode.prompt.md"), content);
 
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       const result = loader.load("unicode");
 
       assert.strictEqual(result, content);
@@ -78,7 +79,7 @@ describe("PromptLoader", () => {
       const template = "Hello, {{name}}!";
       writeFileSync(join(tempDir, "greeting.prompt.md"), template);
 
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       const result = loader.render("greeting", { name: "World" });
 
       assert.strictEqual(result, "Hello, World!");
@@ -88,7 +89,7 @@ describe("PromptLoader", () => {
       const template = "Hello, {{name}}!";
       writeFileSync(join(tempDir, "greeting.prompt.md"), template);
 
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       const result = loader.render("greeting", {});
 
       assert.strictEqual(result, "Hello, !");
@@ -98,7 +99,7 @@ describe("PromptLoader", () => {
       const template = "Static content";
       writeFileSync(join(tempDir, "static.prompt.md"), template);
 
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       const result = loader.render("static");
 
       assert.strictEqual(result, "Static content");
@@ -108,7 +109,7 @@ describe("PromptLoader", () => {
       const template = "Content: {{{html}}}";
       writeFileSync(join(tempDir, "html.prompt.md"), template);
 
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       const result = loader.render("html", { html: "<strong>bold</strong>" });
 
       assert.strictEqual(result, "Content: <strong>bold</strong>");
@@ -119,7 +120,7 @@ describe("PromptLoader", () => {
         "Items:{{#items}}\n- {{name}}{{/items}}\nTotal: {{total}}";
       writeFileSync(join(tempDir, "list.prompt.md"), template);
 
-      const loader = new PromptLoader(tempDir);
+      const loader = new PromptLoader(tempDir, createDefaultRuntime());
       const result = loader.render("list", {
         items: [{ name: "First" }, { name: "Second" }],
         total: 2,
@@ -141,7 +142,7 @@ describe("PromptLoader", () => {
 describe("createPromptLoader", () => {
   test("returns a PromptLoader instance", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "libprompt-factory-"));
-    const loader = createPromptLoader(tempDir);
+    const loader = createPromptLoader(tempDir, createDefaultRuntime());
     assert.ok(loader instanceof PromptLoader);
     rmSync(tempDir, { recursive: true, force: true });
   });

--- a/libraries/librc/bin/fit-rc.js
+++ b/libraries/librc/bin/fit-rc.js
@@ -60,14 +60,14 @@ const definition = {
   ],
 };
 
-const cli = createCli(definition);
+const cli = createCli(definition, { runtime });
 const parsed = cli.parse(runtime.proc.argv.slice(2));
 if (!parsed) runtime.proc.exit(0);
 
 const { values, positionals } = parsed;
 const [command, serviceName] = positionals;
 
-const baseLogger = createLogger("rc");
+const baseLogger = createLogger("rc", runtime);
 const isSilent = values.silent;
 const logger = {
   debug: (...a) => !isSilent && baseLogger.debug(...a),

--- a/libraries/librc/src/index.js
+++ b/libraries/librc/src/index.js
@@ -2,7 +2,6 @@
  * Unix socket client utilities for communicating with svscan daemon.
  */
 import net from "node:net";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 export { ServiceManager } from "./manager.js";
 
@@ -41,13 +40,13 @@ export function sendCommand(socketPath, cmd) {
  * Waits for socket to become available
  * @param {string} socketPath - Path to Unix socket
  * @param {number} timeout - Timeout in ms
- * @param {import("@forwardimpact/libutil/runtime").Runtime} [runtime] - Runtime
- *   bag. Falls back to `createDefaultRuntime()` so existing callers keep
- *   working without change.
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected
+ *   runtime bag (supplies the clock).
  * @returns {Promise<boolean>} True if socket available
  */
 export async function waitForSocket(socketPath, timeout, runtime) {
-  const { clock } = runtime ?? createDefaultRuntime();
+  if (!runtime) throw new Error("runtime is required");
+  const { clock } = runtime;
   const start = clock.now();
   while (clock.now() - start < timeout) {
     try {

--- a/libraries/librc/src/manager.js
+++ b/libraries/librc/src/manager.js
@@ -19,20 +19,11 @@
 import path from "node:path";
 import { createRequire } from "node:module";
 import { pipeline } from "node:stream/promises";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 const require = createRequire(import.meta.url);
 const SVSCAN_BIN = require.resolve(
   "@forwardimpact/libsupervise/bin/fit-svscan.js",
 );
-
-// Lazily constructed so that test code importing this module does not
-// trigger the real-fs side-effects of createDefaultRuntime at import time.
-let _defaultRuntime;
-function getDefaultRuntime() {
-  if (!_defaultRuntime) _defaultRuntime = createDefaultRuntime();
-  return _defaultRuntime;
-}
 
 /**
  * @typedef {object} RuntimePaths
@@ -69,7 +60,9 @@ function getDefaultRuntime() {
 /**
  * @typedef {object} Dependencies
  * @property {typeof import("node:fs")} [fs] - File system module (sync surface).
- *   BC shim: superseded by `runtime.fsSync` when a `runtime` bag is injected.
+ *   Foundation-gap override for `logs()`'s `createReadStream`, which the
+ *   ratified `runtime.fsSync` surface does not express; defaults to
+ *   `runtime.fsSync` otherwise (see teardown ledger § foundation surface gaps).
  * @property {typeof import("node:child_process").spawn} [spawn] - Spawn function.
  *   In production wire from the bin (which is allowed to import child_process).
  * @property {typeof import("node:child_process").execSync} [execSync] - ExecSync function.
@@ -82,7 +75,7 @@ function getDefaultRuntime() {
  *   `Writable` (see MONOREPO teardown § foundation surface gaps).
  * @property {import("@forwardimpact/libutil/runtime").Runtime} [runtime] - Runtime bag.
  *   Supplies the sync-fs (`fsSync`) and process (`proc`, including `kill` and
- *   `env`) surfaces; `deps.fs` overrides `fsSync` when present.
+ *   `env`) surfaces; `deps.fs` overrides `fsSync` for stream reads when present.
  */
 
 /**
@@ -109,11 +102,13 @@ export class ServiceManager {
     if (!config) throw new Error("config is required");
     if (!logger) throw new Error("logger is required");
 
-    const runtime = deps.runtime ?? getDefaultRuntime();
+    const runtime = deps.runtime;
+    if (!runtime) throw new Error("deps.runtime is required");
 
     this.#config = config;
     this.#logger = logger;
-    // deps.fs (legacy sync-fs override) > runtime.fsSync
+    // deps.fs is the foundation-gap override for logs() stream reads
+    // (createReadStream); otherwise the injected runtime's sync-fs is used.
     this.#fs = deps.fs ?? runtime.fsSync;
     // spawn and execSync must be provided by the caller (bin or test); there
     // is no runtime-level equivalent that covers detached stdio-redirect

--- a/libraries/libresource/bin/fit-process-resources.js
+++ b/libraries/libresource/bin/fit-process-resources.js
@@ -3,6 +3,7 @@ import "@forwardimpact/libpreflight/node22";
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createScriptConfig } from "@forwardimpact/libconfig";
 import { createResourceIndex } from "@forwardimpact/libresource";
 import { createStorage } from "@forwardimpact/libstorage";
@@ -37,8 +38,9 @@ const definition = {
   },
 };
 
-const cli = createCli(definition);
-const logger = createLogger("resources");
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
+const logger = createLogger("resources", runtime);
 
 /**
  * Process all HTML files in the knowledge base directory and generate resources

--- a/libraries/librpc/bin/fit-unary.js
+++ b/libraries/librpc/bin/fit-unary.js
@@ -34,7 +34,7 @@ const definition = {
 };
 
 const cli = createCli(definition, { runtime });
-const logger = createLogger("cli");
+const logger = createLogger("cli", runtime);
 
 /**
  * Makes a unary gRPC call to a service

--- a/libraries/librpc/src/index.js
+++ b/libraries/librpc/src/index.js
@@ -2,6 +2,7 @@ import grpc from "@grpc/grpc-js";
 
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { Tracer } from "@forwardimpact/libtelemetry/tracer.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { capitalizeFirstLetter } from "./base.js";
 import * as exports from "./generated/services/exports.js";
@@ -31,10 +32,14 @@ export async function createTracer(serviceName) {
   const traceConfig = await createServiceConfig("trace");
   const { TraceClient } = clients;
   const traceClient = new TraceClient(traceConfig);
+  // createTracer is a composition-root factory; it builds the production clock
+  // as its DI root and threads it into the Tracer (and thus every Span).
+  const { clock } = createDefaultRuntime();
   return new Tracer({
     serviceName,
     traceClient,
     grpcMetadata: grpc.Metadata,
+    clock,
   });
 }
 

--- a/libraries/librpc/src/server.js
+++ b/libraries/librpc/src/server.js
@@ -6,7 +6,6 @@ import {
   capitalizeFirstLetter,
 } from "./base.js";
 import { healthDefinition, createHealthHandlers } from "./health.js";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /**
  * gRPC Server class using pre-compiled service definitions
@@ -21,29 +20,29 @@ export class Server extends Rpc {
    * Creates a gRPC server for a service
    * @param {object} service - Service instance with business logic
    * @param {object} config - Server configuration
-   * @param {object} [logger] - Optional logger instance
-   * @param {import("@forwardimpact/libtelemetry").Tracer} [tracer] - Optional tracer for distributed tracing
-   * @param {(serviceName: string, logger: object, tracer: object) => object} observerFn - Observer factory
-   * @param {() => {grpc: object}} grpcFn - gRPC factory
-   * @param {(serviceName: string) => object} authFn - Auth factory
-   * @param {import("@forwardimpact/libutil/runtime").Runtime} [runtime] - Optional runtime bag;
-   *   falls back to `createDefaultRuntime()` so existing service callers keep working.
+   * @param {object} options - Injected collaborators and optional factory overrides
+   * @param {object} [options.logger] - Optional logger instance
+   * @param {import("@forwardimpact/libtelemetry").Tracer} [options.tracer] - Optional tracer for distributed tracing
+   * @param {import("@forwardimpact/libutil/runtime").Runtime} options.runtime - Injected runtime bag
+   * @param {(serviceName: string, logger: object, tracer: object) => object} [options.observerFn] - Observer factory
+   * @param {() => {grpc: object}} [options.grpcFn] - gRPC factory
+   * @param {(serviceName: string) => object} [options.authFn] - Auth factory
    */
-  constructor(
-    service,
-    config,
-    logger = null,
-    tracer = null,
-    observerFn = createObserver,
-    grpcFn = createGrpc,
-    authFn = createAuth,
-    runtime = null,
-  ) {
+  constructor(service, config, options = {}) {
     if (!service) throw new Error("service is required");
+    const {
+      logger = null,
+      tracer = null,
+      runtime,
+      observerFn = createObserver,
+      grpcFn = createGrpc,
+      authFn = createAuth,
+    } = options;
+    if (!runtime) throw new Error("runtime is required");
 
     super(config, logger, tracer, observerFn, grpcFn, authFn);
     this.#service = service;
-    this.#runtime = runtime ?? createDefaultRuntime();
+    this.#runtime = runtime;
   }
 
   /** Starts the gRPC server */

--- a/libraries/librpc/test/health.test.js
+++ b/libraries/librpc/test/health.test.js
@@ -7,6 +7,7 @@ import {
   ServingStatus,
   Server,
 } from "../src/index.js";
+import { createTestRuntime } from "@forwardimpact/libmock";
 import {
   createMockConfig,
   createMockGrpcFn,
@@ -14,6 +15,8 @@ import {
   createMockAuthFn,
   createMockLogger,
 } from "@forwardimpact/libmock";
+
+const runtime = createTestRuntime();
 
 describe("healthDefinition", () => {
   test("Check has the required service definition fields", () => {
@@ -109,15 +112,14 @@ describe("Server health registration", () => {
     const mockLogFn = createMockLogger();
     const mockObserverFn = createMockObserverFn(mockLogFn);
 
-    const server = new Server(
-      mockService,
-      mockConfig,
-      mockLogFn,
-      null,
-      mockObserverFn,
-      mockGrpcFn,
-      mockAuthFn,
-    );
+    const server = new Server(mockService, mockConfig, {
+      logger: mockLogFn,
+      tracer: null,
+      observerFn: mockObserverFn,
+      grpcFn: mockGrpcFn,
+      authFn: mockAuthFn,
+      runtime,
+    });
 
     await server.start();
     assert.ok(server);
@@ -147,15 +149,14 @@ describe("Server health registration", () => {
     const mockLogFn = createMockLogger();
     const mockObserverFn = createMockObserverFn(mockLogFn);
 
-    const server = new Server(
-      mockService,
-      mockConfig,
-      mockLogFn,
-      null,
-      mockObserverFn,
-      mockGrpcFn,
-      trackingAuthFn,
-    );
+    const server = new Server(mockService, mockConfig, {
+      logger: mockLogFn,
+      tracer: null,
+      observerFn: mockObserverFn,
+      grpcFn: mockGrpcFn,
+      authFn: trackingAuthFn,
+      runtime,
+    });
 
     await server.start();
 

--- a/libraries/librpc/test/server.test.js
+++ b/libraries/librpc/test/server.test.js
@@ -2,6 +2,7 @@ import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert";
 
 import { Server } from "../src/index.js";
+import { createTestRuntime } from "@forwardimpact/libmock";
 import {
   assertThrowsMessage,
   createMockAuthFn,
@@ -12,6 +13,8 @@ import {
   createMockTracer,
   spy,
 } from "@forwardimpact/libmock";
+
+const runtime = createTestRuntime();
 
 describe("Server", () => {
   let mockService;
@@ -38,15 +41,14 @@ describe("Server", () => {
   test("should require service parameter", () => {
     assertThrowsMessage(
       () =>
-        new Server(
-          null,
-          mockConfig,
-          mockLogFn,
-          null,
-          mockObserverFn,
-          mockGrpcFn,
-          mockAuthFn,
-        ),
+        new Server(null, mockConfig, {
+          logger: mockLogFn,
+          tracer: null,
+          observerFn: mockObserverFn,
+          grpcFn: mockGrpcFn,
+          authFn: mockAuthFn,
+          runtime,
+        }),
       /service is required/,
     );
   });
@@ -54,29 +56,27 @@ describe("Server", () => {
   test("should require config parameter", () => {
     assertThrowsMessage(
       () =>
-        new Server(
-          mockService,
-          null,
-          mockLogFn,
-          null,
-          mockObserverFn,
-          mockGrpcFn,
-          mockAuthFn,
-        ),
+        new Server(mockService, null, {
+          logger: mockLogFn,
+          tracer: null,
+          observerFn: mockObserverFn,
+          grpcFn: mockGrpcFn,
+          authFn: mockAuthFn,
+          runtime,
+        }),
       /config is required/,
     );
   });
 
   test("should accept valid parameters", () => {
-    const server = new Server(
-      mockService,
-      mockConfig,
-      mockLogFn,
-      null,
-      mockObserverFn,
-      mockGrpcFn,
-      mockAuthFn,
-    );
+    const server = new Server(mockService, mockConfig, {
+      logger: mockLogFn,
+      tracer: null,
+      observerFn: mockObserverFn,
+      grpcFn: mockGrpcFn,
+      authFn: mockAuthFn,
+      runtime,
+    });
 
     assert.ok(server);
     assert.strictEqual(server.config, mockConfig);
@@ -91,15 +91,14 @@ describe("Server", () => {
       getHandlers: getHandlersSpy,
     };
 
-    const server = new Server(
-      spiedService,
-      mockConfig,
-      mockLogFn,
-      null,
-      mockObserverFn,
-      mockGrpcFn,
-      mockAuthFn,
-    );
+    const server = new Server(spiedService, mockConfig, {
+      logger: mockLogFn,
+      tracer: null,
+      observerFn: mockObserverFn,
+      grpcFn: mockGrpcFn,
+      authFn: mockAuthFn,
+      runtime,
+    });
 
     // Start the server to trigger setup
     await server.start();
@@ -132,15 +131,14 @@ describe("Server", () => {
       logger: () => mockLogFn,
     });
 
-    const server = new Server(
-      throwingService,
-      mockConfig,
-      mockLogFn,
-      null,
-      customObserverFn,
-      customGrpcFn,
-      mockAuthFn,
-    );
+    const server = new Server(throwingService, mockConfig, {
+      logger: mockLogFn,
+      tracer: null,
+      observerFn: customObserverFn,
+      grpcFn: customGrpcFn,
+      authFn: mockAuthFn,
+      runtime,
+    });
 
     await server.start();
 
@@ -155,15 +153,14 @@ describe("Server", () => {
   test("should accept tracer parameter", () => {
     const mockTracer = createMockTracer();
 
-    const server = new Server(
-      mockService,
-      mockConfig,
-      mockLogFn,
-      mockTracer,
-      mockObserverFn,
-      mockGrpcFn,
-      mockAuthFn,
-    );
+    const server = new Server(mockService, mockConfig, {
+      logger: mockLogFn,
+      tracer: mockTracer,
+      observerFn: mockObserverFn,
+      grpcFn: mockGrpcFn,
+      authFn: mockAuthFn,
+      runtime,
+    });
 
     assert.ok(server);
   });

--- a/libraries/libsecret/src/index.js
+++ b/libraries/libsecret/src/index.js
@@ -1,8 +1,6 @@
 import crypto from "crypto";
 import path from "path";
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
-
 /**
  * Reads an environment variable value from an env file
  * @param {string} key - Environment variable name
@@ -10,11 +8,7 @@ import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
  * @param {object} [runtime] - Runtime collaborator bag
  * @returns {Promise<string|undefined>} The value if found, undefined otherwise
  */
-export async function readEnvFile(
-  key,
-  envPath = ".env",
-  runtime = createDefaultRuntime(),
-) {
+export async function readEnvFile(key, envPath = ".env", runtime) {
   const { fs } = runtime;
   const fullPath = path.resolve(envPath);
 
@@ -47,7 +41,7 @@ export async function getOrGenerateSecret(
   key,
   generator,
   envPath = ".env",
-  runtime = createDefaultRuntime(),
+  runtime,
 ) {
   if (typeof generator !== "function") {
     throw new Error("generator is required");
@@ -68,12 +62,7 @@ export async function getOrGenerateSecret(
  * @param {string} [envPath] - Path to .env file (defaults to .env in current directory)
  * @param {object} [runtime] - Runtime collaborator bag
  */
-export async function updateEnvFile(
-  key,
-  value,
-  envPath = ".env",
-  runtime = createDefaultRuntime(),
-) {
+export async function updateEnvFile(key, value, envPath = ".env", runtime) {
   const { fs } = runtime;
   const fullPath = path.resolve(envPath);
   let content = "";
@@ -187,7 +176,7 @@ export function generateJWT(payload, secret) {
  */
 export function mintSupabaseJwt(
   { email, secret, ttlSeconds = 3600, claims = {} },
-  runtime = createDefaultRuntime(),
+  runtime,
 ) {
   const { clock } = runtime;
   if (!secret) throw new Error("mintSupabaseJwt: secret required");
@@ -210,10 +199,7 @@ export function mintSupabaseJwt(
 
 const SUPABASE_ROLE_EXP_SECONDS = 10 * 365 * 24 * 60 * 60;
 
-function mintSupabaseRoleKey(
-  { role, secret },
-  runtime = createDefaultRuntime(),
-) {
+function mintSupabaseRoleKey({ role, secret }, runtime) {
   const { clock } = runtime;
   if (!secret) {
     throw new Error(
@@ -236,10 +222,7 @@ function mintSupabaseRoleKey(
  * @param {object} [runtime] - Runtime collaborator bag
  * @returns {string} Signed JWT
  */
-export function mintSupabaseAnonKey(
-  { secret },
-  runtime = createDefaultRuntime(),
-) {
+export function mintSupabaseAnonKey({ secret }, runtime) {
   return mintSupabaseRoleKey({ role: "anon", secret }, runtime);
 }
 
@@ -252,10 +235,7 @@ export function mintSupabaseAnonKey(
  * @param {object} [runtime] - Runtime collaborator bag
  * @returns {string} Signed JWT
  */
-export function mintSupabaseServiceRoleKey(
-  { secret },
-  runtime = createDefaultRuntime(),
-) {
+export function mintSupabaseServiceRoleKey({ secret }, runtime) {
   return mintSupabaseRoleKey({ role: "service_role", secret }, runtime);
 }
 

--- a/libraries/libsecret/test/libsecret.test.js
+++ b/libraries/libsecret/test/libsecret.test.js
@@ -189,7 +189,10 @@ describe("libsecret", () => {
     const secret = "supabase-test-secret";
 
     test("mints a 3-part JWT with HS256 header and Supabase claims", () => {
-      const jwt = mintSupabaseJwt({ email: "alice@example.com", secret });
+      const jwt = mintSupabaseJwt(
+        { email: "alice@example.com", secret },
+        makeRuntime(),
+      );
       const [headerB64, payloadB64, sig] = jwt.split(".");
       assert.ok(sig);
 
@@ -209,11 +212,14 @@ describe("libsecret", () => {
     });
 
     test("honours ttlSeconds", () => {
-      const jwt = mintSupabaseJwt({
-        email: "alice@example.com",
-        secret,
-        ttlSeconds: 60,
-      });
+      const jwt = mintSupabaseJwt(
+        {
+          email: "alice@example.com",
+          secret,
+          ttlSeconds: 60,
+        },
+        makeRuntime(),
+      );
       const payload = JSON.parse(
         Buffer.from(jwt.split(".")[1], "base64url").toString(),
       );
@@ -221,11 +227,14 @@ describe("libsecret", () => {
     });
 
     test("merges extra claims", () => {
-      const jwt = mintSupabaseJwt({
-        email: "alice@example.com",
-        secret,
-        claims: { custom: "x" },
-      });
+      const jwt = mintSupabaseJwt(
+        {
+          email: "alice@example.com",
+          secret,
+          claims: { custom: "x" },
+        },
+        makeRuntime(),
+      );
       const payload = JSON.parse(
         Buffer.from(jwt.split(".")[1], "base64url").toString(),
       );
@@ -233,7 +242,10 @@ describe("libsecret", () => {
     });
 
     test("signature verifies under the same secret", () => {
-      const jwt = mintSupabaseJwt({ email: "alice@example.com", secret });
+      const jwt = mintSupabaseJwt(
+        { email: "alice@example.com", secret },
+        makeRuntime(),
+      );
       const [h, p, s] = jwt.split(".");
       const expected = createHmac("sha256", secret)
         .update(`${h}.${p}`)
@@ -243,14 +255,14 @@ describe("libsecret", () => {
 
     test("throws when secret missing", () => {
       assert.throws(
-        () => mintSupabaseJwt({ email: "x@y", secret: "" }),
+        () => mintSupabaseJwt({ email: "x@y", secret: "" }, makeRuntime()),
         /secret required/,
       );
     });
 
     test("throws when email missing", () => {
       assert.throws(
-        () => mintSupabaseJwt({ email: "", secret }),
+        () => mintSupabaseJwt({ email: "", secret }, makeRuntime()),
         /email required/,
       );
     });
@@ -273,7 +285,7 @@ describe("libsecret", () => {
     const TEN_YEARS_SECONDS = 10 * 365 * 24 * 60 * 60;
 
     test("returns a 3-segment HS256 JWT", () => {
-      const jwt = mintSupabaseAnonKey({ secret });
+      const jwt = mintSupabaseAnonKey({ secret }, makeRuntime());
       const parts = jwt.split(".");
       assert.strictEqual(parts.length, 3);
       const header = JSON.parse(Buffer.from(parts[0], "base64url").toString());
@@ -281,7 +293,7 @@ describe("libsecret", () => {
     });
 
     test("payload contains role: anon and iss: supabase", () => {
-      const jwt = mintSupabaseAnonKey({ secret });
+      const jwt = mintSupabaseAnonKey({ secret }, makeRuntime());
       const payload = JSON.parse(
         Buffer.from(jwt.split(".")[1], "base64url").toString(),
       );
@@ -292,7 +304,7 @@ describe("libsecret", () => {
     });
 
     test("exp - iat equals the 10-year constant", () => {
-      const jwt = mintSupabaseAnonKey({ secret });
+      const jwt = mintSupabaseAnonKey({ secret }, makeRuntime());
       const payload = JSON.parse(
         Buffer.from(jwt.split(".")[1], "base64url").toString(),
       );
@@ -300,7 +312,7 @@ describe("libsecret", () => {
     });
 
     test("signature verifies under the same secret", () => {
-      const jwt = mintSupabaseAnonKey({ secret });
+      const jwt = mintSupabaseAnonKey({ secret }, makeRuntime());
       const [h, p, s] = jwt.split(".");
       const expected = createHmac("sha256", secret)
         .update(`${h}.${p}`)
@@ -310,7 +322,7 @@ describe("libsecret", () => {
 
     test("throws when secret missing", () => {
       assert.throws(
-        () => mintSupabaseAnonKey({ secret: "" }),
+        () => mintSupabaseAnonKey({ secret: "" }, makeRuntime()),
         /mintSupabaseAnonKey: secret required/,
       );
     });
@@ -321,7 +333,7 @@ describe("libsecret", () => {
     const TEN_YEARS_SECONDS = 10 * 365 * 24 * 60 * 60;
 
     test("returns a 3-segment HS256 JWT", () => {
-      const jwt = mintSupabaseServiceRoleKey({ secret });
+      const jwt = mintSupabaseServiceRoleKey({ secret }, makeRuntime());
       const parts = jwt.split(".");
       assert.strictEqual(parts.length, 3);
       const header = JSON.parse(Buffer.from(parts[0], "base64url").toString());
@@ -329,7 +341,7 @@ describe("libsecret", () => {
     });
 
     test("payload contains role: service_role and iss: supabase", () => {
-      const jwt = mintSupabaseServiceRoleKey({ secret });
+      const jwt = mintSupabaseServiceRoleKey({ secret }, makeRuntime());
       const payload = JSON.parse(
         Buffer.from(jwt.split(".")[1], "base64url").toString(),
       );
@@ -338,7 +350,7 @@ describe("libsecret", () => {
     });
 
     test("exp - iat equals the 10-year constant", () => {
-      const jwt = mintSupabaseServiceRoleKey({ secret });
+      const jwt = mintSupabaseServiceRoleKey({ secret }, makeRuntime());
       const payload = JSON.parse(
         Buffer.from(jwt.split(".")[1], "base64url").toString(),
       );
@@ -346,7 +358,7 @@ describe("libsecret", () => {
     });
 
     test("signature verifies under the same secret", () => {
-      const jwt = mintSupabaseServiceRoleKey({ secret });
+      const jwt = mintSupabaseServiceRoleKey({ secret }, makeRuntime());
       const [h, p, s] = jwt.split(".");
       const expected = createHmac("sha256", secret)
         .update(`${h}.${p}`)
@@ -356,7 +368,7 @@ describe("libsecret", () => {
 
     test("throws when secret missing", () => {
       assert.throws(
-        () => mintSupabaseServiceRoleKey({ secret: "" }),
+        () => mintSupabaseServiceRoleKey({ secret: "" }, makeRuntime()),
         /mintSupabaseServiceRoleKey: secret required/,
       );
     });

--- a/libraries/libstorage/bin/fit-storage.js
+++ b/libraries/libstorage/bin/fit-storage.js
@@ -2,7 +2,7 @@
 
 import "@forwardimpact/libpreflight/node22";
 
-import { readFileSync } from "node:fs";
+import nodeFs, { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import {
   createCli,
@@ -10,6 +10,7 @@ import {
   formatSuccess,
   formatBullet,
 } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createScriptConfig } from "@forwardimpact/libconfig";
 import { createStorage } from "@forwardimpact/libstorage";
 import { Logger } from "@forwardimpact/libtelemetry";
@@ -89,7 +90,8 @@ const definition = {
   ],
 };
 
-const cli = createCli(definition);
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
 const parsed = cli.parse(process.argv.slice(2));
 if (!parsed) process.exit(0);
 
@@ -102,8 +104,8 @@ const [command] = positionals;
  * @returns {Promise<string[]>} Array of discovered prefixes
  */
 async function discoverLocalPrefixes() {
-  const logger = new Logger("storage");
-  const finder = new Finder(fs, logger);
+  const logger = new Logger("storage", runtime);
+  const finder = new Finder({ fs, fsSync: nodeFs, proc: process, logger });
   const root = finder.findUpward(process.cwd(), "data");
   if (!root) return [];
 
@@ -157,7 +159,7 @@ const commands = {
 
   async upload() {
     await createScriptConfig("storage");
-    const logger = new Logger("storage");
+    const logger = new Logger("storage", runtime);
     const prefixes = prefixList.length
       ? prefixList
       : await discoverLocalPrefixes();
@@ -195,7 +197,7 @@ const commands = {
 
   async download() {
     await createScriptConfig("storage");
-    const logger = new Logger("storage");
+    const logger = new Logger("storage", runtime);
     const prefixes = prefixList.length
       ? prefixList
       : await discoverRemotePrefixes();

--- a/libraries/libstorage/src/index.js
+++ b/libraries/libstorage/src/index.js
@@ -98,19 +98,6 @@ export function isJson(key, data) {
 }
 
 /**
- * Adapt an old-style `process`-shaped object `{ env, cwd? }` into a minimal
- * `runtime.proc`-shaped collaborator so BC callers keep working.
- * @param {object} proc - Old-style process-like object.
- * @returns {object} Runtime-proc-shaped object.
- */
-function _procFromLegacy(proc) {
-  return {
-    env: proc.env ?? {},
-    cwd: typeof proc.cwd === "function" ? () => proc.cwd() : () => "",
-  };
-}
-
-/**
  * Creates a local storage instance
  * @param {string} prefix - Bucket/directory name for local storage
  * @param {object} runtime - Runtime collaborator bag
@@ -247,56 +234,36 @@ function _createSupabaseStorage(prefix, runtime) {
  *
  * @param {string} prefix - Prefix for the storage operations (for S3) or bucket/directory name (for local)
  * @param {string} [type] - Storage type ("local", "s3", or "supabase")
- * @param {object|null} [processOrRuntime] - Legacy process-shaped object `{ env, cwd? }` OR a
- *   runtime bag `{ fs, proc, … }` — either is accepted for backward compatibility.
- *   When omitted, a default runtime is constructed automatically.
+ * @param {import("@forwardimpact/libutil/runtime").Runtime|null} [runtime] - Runtime
+ *   bag `{ fs, proc, … }`. When omitted — a composition-root convenience — the
+ *   default production runtime is constructed automatically.
  * @param {string|null} [rootDir] - Explicit root directory for local storage
  * @returns {object} Storage instance
  * @throws {Error} When unsupported storage type is provided
  */
-export function createStorage(
-  prefix,
-  type,
-  processOrRuntime = null,
-  rootDir = null,
-) {
-  // Build the runtime collaborator. Accept three shapes:
-  //   (a) a full runtime bag (has `.proc`),
-  //   (b) a legacy process-like object (has `.env` but no `.proc`),
-  //   (c) null/undefined — construct the default runtime.
-  let runtime;
-  if (processOrRuntime && typeof processOrRuntime === "object") {
-    if ("proc" in processOrRuntime && "fs" in processOrRuntime) {
-      // Full runtime bag — use as-is.
-      runtime = processOrRuntime;
-    } else {
-      // Legacy process-like object: adapt it into a minimal runtime.
-      const legacyProc = _procFromLegacy(processOrRuntime);
-      const defaultRuntime = createDefaultRuntime();
-      runtime = { ...defaultRuntime, proc: legacyProc };
-    }
-  } else {
-    runtime = createDefaultRuntime();
-  }
+export function createStorage(prefix, type, runtime = null, rootDir = null) {
+  // Consumers inject a runtime bag; when absent the default production runtime
+  // is built here (createStorage is a composition-root factory).
+  const rt = runtime ?? createDefaultRuntime();
 
   // Always use local storage for config and generated directories
   // These are part of the codebase and should never be stored in S3
   if (prefix === "config" || prefix === "generated") {
-    return _createLocalStorage(prefix, runtime, rootDir);
+    return _createLocalStorage(prefix, rt, rootDir);
   }
 
-  const finalType = type || runtime.proc.env.STORAGE_TYPE || "local";
+  const finalType = type || rt.proc.env.STORAGE_TYPE || "local";
 
   switch (finalType) {
     case "local":
     case undefined:
-      return _createLocalStorage(prefix, runtime, rootDir);
+      return _createLocalStorage(prefix, rt, rootDir);
 
     case "s3":
-      return _createS3Storage(prefix, runtime);
+      return _createS3Storage(prefix, rt);
 
     case "supabase":
-      return _createSupabaseStorage(prefix, runtime);
+      return _createSupabaseStorage(prefix, rt);
 
     default:
       throw new Error(`Unsupported storage type: ${finalType}`);

--- a/libraries/libstorage/test/libstorage-utils.test.js
+++ b/libraries/libstorage/test/libstorage-utils.test.js
@@ -1,6 +1,10 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { spy } from "@forwardimpact/libmock";
+import {
+  spy,
+  createTestRuntime,
+  createMockProcess,
+} from "@forwardimpact/libmock";
 
 import {
   LocalStorage,
@@ -16,46 +20,38 @@ import {
 } from "../src/index.js";
 
 describe("storageFactory", () => {
-  let mockProcess;
-
-  beforeEach(() => {
-    mockProcess = {
-      env: {},
-    };
-  });
+  const runtimeWithEnv = (env) =>
+    createTestRuntime({ proc: createMockProcess({ env }) });
 
   test("creates LocalStorage for local type", () => {
-    mockProcess.env.STORAGE_ROOT = "/tmp";
+    const runtime = runtimeWithEnv({ STORAGE_ROOT: "/tmp" });
 
-    const storage = createStorage("config", "local", mockProcess);
+    const storage = createStorage("config", "local", runtime);
 
     assert(storage instanceof LocalStorage);
   });
 
   test("creates S3Storage for s3 type", () => {
-    mockProcess.env = {
+    const runtime = runtimeWithEnv({
       STORAGE_TYPE: "s3",
       S3_REGION: "us-east-1",
       S3_ENDPOINT: "https://s3.amazonaws.com",
       AWS_ACCESS_KEY_ID: "test-key",
       AWS_SECRET_ACCESS_KEY: "test-secret",
       S3_DATA_BUCKET: "test-bucket",
-    };
+    });
 
-    const storage = createStorage("/test/path", "s3", mockProcess);
+    const storage = createStorage("/test/path", "s3", runtime);
 
     assert(storage instanceof S3Storage);
   });
 
   test("throws error for unsupported storage type", () => {
-    mockProcess.env.STORAGE_TYPE = "unsupported";
+    const runtime = runtimeWithEnv({ STORAGE_TYPE: "unsupported" });
 
-    assert.throws(
-      () => createStorage("/test/path", "unsupported", mockProcess),
-      {
-        message: /Unsupported storage type: unsupported/,
-      },
-    );
+    assert.throws(() => createStorage("/test/path", "unsupported", runtime), {
+      message: /Unsupported storage type: unsupported/,
+    });
   });
 });
 

--- a/libraries/libsupervise/bin/fit-logger.js
+++ b/libraries/libsupervise/bin/fit-logger.js
@@ -49,7 +49,7 @@ const definition = {
   ],
 };
 
-const cli = createCli(definition);
+const cli = createCli(definition, { runtime });
 
 const parsed = cli.parse(process.argv.slice(2));
 if (!parsed) runtime.proc.exit(0);

--- a/libraries/libsupervise/bin/fit-svscan.js
+++ b/libraries/libsupervise/bin/fit-svscan.js
@@ -57,8 +57,8 @@ const definition = {
   ],
 };
 
-const cli = createCli(definition);
-const logger = createLogger("svscan");
+const cli = createCli(definition, { runtime });
+const logger = createLogger("svscan", runtime);
 
 const parsed = cli.parse(process.argv.slice(2));
 if (!parsed) runtime.proc.exit(0);

--- a/libraries/libsupervise/src/index.js
+++ b/libraries/libsupervise/src/index.js
@@ -20,6 +20,6 @@ import { SupervisionTree } from "./tree.js";
 export function createSupervisionTree(logDir, options = {}) {
   const { runtime, ...config } = options;
   if (!runtime) throw new Error("runtime is required");
-  const logger = createLogger("tree");
+  const logger = createLogger("tree", runtime);
   return new SupervisionTree(logDir, { ...config, runtime, logger });
 }

--- a/libraries/libsyntheticgen/src/engine/activity-initiatives.js
+++ b/libraries/libsyntheticgen/src/engine/activity-initiatives.js
@@ -4,8 +4,6 @@
  * @module libterrain/engine/activity-initiatives
  */
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
-
 /**
  * Compute initiative priority from magnitude and direction.
  * @param {boolean} isDeclining
@@ -231,7 +229,7 @@ function processAffect(params) {
  * @param {object[]} people
  * @param {object[]} teams
  * @param {object[]} _snapshots
- * @param {object} [runtime] - Runtime collaborator bag (default: createDefaultRuntime())
+ * @param {object} [runtime] - Runtime collaborator bag
  * @returns {{ scorecards: object[], initiatives: object[] }}
  */
 export function deriveInitiatives(
@@ -240,7 +238,7 @@ export function deriveInitiatives(
   people,
   teams,
   _snapshots,
-  runtime = createDefaultRuntime(),
+  runtime,
 ) {
   const driverMap = new Map(
     (ast.standard?.drivers || []).map((d) => [d.id, d]),

--- a/libraries/libsyntheticgen/src/engine/activity.js
+++ b/libraries/libsyntheticgen/src/engine/activity.js
@@ -6,7 +6,6 @@
  * @module libterrain/engine/activity
  */
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { PROSE_ACTIVITIES } from "../activity/index.js";
 import { deriveInitiatives } from "./activity-initiatives.js";
 import { generateRosterSnapshots } from "./activity-roster.js";
@@ -54,16 +53,10 @@ const PROFICIENCY_ORDER = [
  * @param {import('./rng.js').SeededRNG} rng
  * @param {object[]} people
  * @param {object[]} teams
- * @param {object} [runtime] - Runtime collaborator bag (default: createDefaultRuntime())
+ * @param {object} [runtime] - Runtime collaborator bag
  * @returns {object}
  */
-export function generateActivity(
-  ast,
-  rng,
-  people,
-  teams,
-  runtime = createDefaultRuntime(),
-) {
+export function generateActivity(ast, rng, people, teams, runtime) {
   const roster = people.map((p) => ({
     email: p.email,
     name: p.name,

--- a/libraries/libsyntheticgen/src/engine/tier0.js
+++ b/libraries/libsyntheticgen/src/engine/tier0.js
@@ -16,12 +16,15 @@ export class EntityGenerator {
   /**
    * @param {Function} rngFactory - Factory function that creates a seeded RNG
    * @param {object} logger - Logger instance
+   * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected runtime bag
    */
-  constructor(rngFactory, logger) {
+  constructor(rngFactory, logger, runtime) {
     if (!rngFactory) throw new Error("rngFactory is required");
     if (!logger) throw new Error("logger is required");
+    if (!runtime) throw new Error("runtime is required");
     this.rngFactory = rngFactory;
     this.logger = logger;
+    this.runtime = runtime;
   }
 
   /**
@@ -36,7 +39,7 @@ export class EntityGenerator {
       rng,
       this.logger,
     );
-    const activity = generateActivity(ast, rng, people, teams);
+    const activity = generateActivity(ast, rng, people, teams, this.runtime);
 
     const clinical = ast.clinical
       ? buildClinicalEntities(
@@ -70,8 +73,9 @@ export class EntityGenerator {
 /**
  * Creates an EntityGenerator with the built-in seeded RNG factory.
  * @param {object} logger - Logger instance
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected runtime bag
  * @returns {EntityGenerator}
  */
-export function createEntityGenerator(logger) {
-  return new EntityGenerator(createSeededRNG, logger);
+export function createEntityGenerator(logger, runtime) {
+  return new EntityGenerator(createSeededRNG, logger, runtime);
 }

--- a/libraries/libsyntheticgen/test/activity.test.js
+++ b/libraries/libsyntheticgen/test/activity.test.js
@@ -202,7 +202,13 @@ describe("activity generation", () => {
       const rng = createSeededRNG(ast.seed);
       const { teams, people } = buildEntities(ast, rng);
       for (let i = 0; i < 17; i++) rng.random();
-      const drifted = generateActivity(ast, rng, people, teams).comment.keys;
+      const drifted = generateActivity(
+        ast,
+        rng,
+        people,
+        teams,
+        createTestRuntime(),
+      ).comment.keys;
 
       assert.deepStrictEqual(
         drifted.map((c) => `${c.snapshot_id}|${c.email}`),

--- a/libraries/libsyntheticgen/test/clinical-entities.test.js
+++ b/libraries/libsyntheticgen/test/clinical-entities.test.js
@@ -1,4 +1,5 @@
 import { describe, test } from "node:test";
+import { createTestRuntime } from "@forwardimpact/libmock";
 import assert from "node:assert";
 import { buildClinicalEntities } from "../src/engine/clinical-entities.js";
 import { createSeededRNG } from "../src/engine/rng.js";
@@ -264,7 +265,7 @@ describe("clinical entity generation", () => {
     const { parse } = await import("../src/dsl/parser.js");
     const { MINI_TERRAIN } = await import("./fixtures/mini-terrain.fixture.js");
     const logger = { warn: () => {} };
-    const gen = createEntityGenerator(logger);
+    const gen = createEntityGenerator(logger, createTestRuntime());
     const ast = parse(tokenize(MINI_TERRAIN));
     const result = gen.generate(ast);
     assert.strictEqual(result.clinical, null);

--- a/libraries/libsyntheticgen/test/clinical-prose-keys.test.js
+++ b/libraries/libsyntheticgen/test/clinical-prose-keys.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert";
 import { clinicalProseKeys } from "../src/engine/clinical-prose-keys.js";
 import { collectProseKeys } from "../src/engine/prose-keys.js";
 import { PromptLoader } from "@forwardimpact/libprompt";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,7 +18,7 @@ const promptDir = join(
 );
 
 function makePromptLoader() {
-  return new PromptLoader(promptDir);
+  return new PromptLoader(promptDir, createDefaultRuntime());
 }
 
 function makeClinicalEntities() {

--- a/libraries/libsyntheticgen/test/file-path-parity.test.js
+++ b/libraries/libsyntheticgen/test/file-path-parity.test.js
@@ -11,6 +11,7 @@
  * (see `fixtures/README.md` for the regeneration command).
  */
 import { describe, test } from "node:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import assert from "node:assert";
 import fs from "node:fs";
 import path from "node:path";
@@ -41,6 +42,7 @@ describe("file-path parity against pre-refactor baseline", () => {
       rng,
       entities.people,
       entities.teams,
+      createDefaultRuntime(),
     );
     const files = renderRawDocuments(entities, undefined);
     const actual = Array.from(files.keys()).sort();

--- a/libraries/libsyntheticgen/test/prose-activity.test.js
+++ b/libraries/libsyntheticgen/test/prose-activity.test.js
@@ -6,6 +6,7 @@
  * and per-output unit coverage including multi-driver-declining input.
  */
 import { describe, test } from "node:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import assert from "node:assert";
 import fs from "node:fs";
 import path from "node:path";
@@ -28,7 +29,13 @@ function loadFromDsl() {
   const rng = createSeededRNG(ast.seed);
   const built = buildEntities(ast, rng);
   const entities = { ...built, content: [], domain: "test.example" };
-  entities.activity = generateActivity(ast, rng, built.people, built.teams);
+  entities.activity = generateActivity(
+    ast,
+    rng,
+    built.people,
+    built.teams,
+    createDefaultRuntime(),
+  );
   return { ast, entities, rng };
 }
 

--- a/libraries/libsyntheticprose/src/engine/cache.js
+++ b/libraries/libsyntheticprose/src/engine/cache.js
@@ -11,8 +11,6 @@
  * @module libsyntheticprose/engine/cache
  */
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
-
 const SCHEMA_VERSION = 1;
 const SCHEMA_FIELD = "_schema";
 
@@ -24,9 +22,9 @@ export class ProseCache {
    * @param {object} options
    * @param {string} options.cachePath - Path to prose cache JSON file
    * @param {object} options.logger - Logger instance
-   * @param {object} [options.runtime] - Runtime collaborator bag (default: createDefaultRuntime())
+   * @param {object} [options.runtime] - Runtime collaborator bag
    */
-  constructor({ cachePath, logger, runtime = createDefaultRuntime() }) {
+  constructor({ cachePath, logger, runtime }) {
     if (!cachePath) throw new Error("cachePath is required");
     if (!logger) throw new Error("logger is required");
     const { fsSync } = runtime;

--- a/libraries/libsyntheticprose/src/engine/generator.js
+++ b/libraries/libsyntheticprose/src/engine/generator.js
@@ -14,7 +14,6 @@
  */
 
 import { generateHash } from "@forwardimpact/libutil";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /** Async LLM-backed prose generator that writes through to a ProseCache on every miss. */
 export class ProseGenerator {
@@ -29,7 +28,7 @@ export class ProseGenerator {
    *        Pre-configured LLM client — required when mode is "generate"
    * @param {import('@forwardimpact/libprompt').PromptLoader} options.promptLoader
    * @param {object} options.logger
-   * @param {object} [options.runtime]             Runtime collaborator bag (default: createDefaultRuntime())
+   * @param {object} [options.runtime]             Runtime collaborator bag
    */
   constructor({
     cache,
@@ -38,7 +37,7 @@ export class ProseGenerator {
     llmApi,
     promptLoader,
     logger,
-    runtime = createDefaultRuntime(),
+    runtime,
   }) {
     if (!cache) throw new Error("cache is required");
     if (!mode) throw new Error("mode is required");

--- a/libraries/libsyntheticprose/src/engine/pathway.js
+++ b/libraries/libsyntheticprose/src/engine/pathway.js
@@ -8,7 +8,6 @@
  * @module libterrain/engine/pathway
  */
 
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { join } from "path";
 import { buildStandardPrompt } from "../prompts/pathway/standard.js";
 import { buildLevelPrompt } from "../prompts/pathway/level.js";
@@ -25,10 +24,10 @@ import {
 /**
  * Load JSON schemas from the schema directory.
  * @param {string} schemaDir - Path to products/map/schema/json/
- * @param {object} [runtime] - Runtime collaborator bag (default: createDefaultRuntime())
+ * @param {object} [runtime] - Runtime collaborator bag
  * @returns {object} schemas keyed by entity type
  */
-export function loadSchemas(schemaDir, runtime = createDefaultRuntime()) {
+export function loadSchemas(schemaDir, runtime) {
   const { fsSync } = runtime;
   const names = [
     "standard",

--- a/libraries/libsyntheticprose/test/build-prompt.test.js
+++ b/libraries/libsyntheticprose/test/build-prompt.test.js
@@ -12,6 +12,9 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { ProseCache } from "../src/engine/cache.js";
 import { ProseGenerator } from "../src/engine/generator.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+const _runtime = createDefaultRuntime();
 
 function makeLogger() {
   return {
@@ -42,9 +45,11 @@ function makeFixture() {
   const cache = new ProseCache({
     cachePath: join(tmpDir, "cache.json"),
     logger: makeLogger(),
+    runtime: _runtime,
   });
   const generator = new ProseGenerator({
     cache,
+    runtime: _runtime,
     mode: "generate",
     promptLoader: makeEchoPromptLoader(),
     logger: makeLogger(),

--- a/libraries/libsyntheticrender/src/render/dataset-renderers.js
+++ b/libraries/libsyntheticrender/src/render/dataset-renderers.js
@@ -10,7 +10,6 @@
  */
 
 import YAML from "yaml";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 // ── JSON ────────────────────────────────────────────────────────────────────
 
@@ -108,14 +107,10 @@ function renderMarkdown(dataset, config) {
 /**
  * @param {Dataset} dataset
  * @param {object} config - { path }
- * @param {object} [runtime] - Runtime collaborator bag (default: createDefaultRuntime())
+ * @param {object} [runtime] - Runtime collaborator bag
  * @returns {Promise<Map<string, Buffer>>}
  */
-async function renderParquet(
-  dataset,
-  config,
-  runtime = createDefaultRuntime(),
-) {
+async function renderParquet(dataset, config, runtime) {
   const { fsSync } = runtime;
   let arrow, parquetModule;
   try {
@@ -192,15 +187,10 @@ const RENDERERS = {
  * @param {Dataset} dataset
  * @param {string} format
  * @param {object} config
- * @param {object} [runtime] - Runtime collaborator bag (default: createDefaultRuntime())
+ * @param {object} [runtime] - Runtime collaborator bag
  * @returns {Promise<Map<string, string|Buffer>>}
  */
-export async function renderDataset(
-  dataset,
-  format,
-  config,
-  runtime = createDefaultRuntime(),
-) {
+export async function renderDataset(dataset, format, config, runtime) {
   const renderer = RENDERERS[format];
   if (!renderer) throw new Error(`Unknown format: ${format}`);
   if (format === "parquet") return renderer(dataset, config, runtime);

--- a/libraries/libsyntheticrender/src/render/fhir-microdata.js
+++ b/libraries/libsyntheticrender/src/render/fhir-microdata.js
@@ -15,7 +15,6 @@ import { normalizePatientRef } from "@forwardimpact/libsyntheticgen/tools/synthe
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_DIR = join(__dirname, "..", "..", "templates");
-const templates = new TemplateLoader(TEMPLATE_DIR);
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -237,8 +236,9 @@ function validateFhirInput(input, config) {
  * @param {string} config.path - Output directory (required, non-empty)
  * @returns {Map<string, string>}
  */
-export function renderFhirMicrodataHtml(input, config) {
+export function renderFhirMicrodataHtml(input, config, runtime) {
   validateFhirInput(input, config);
+  const templates = new TemplateLoader(TEMPLATE_DIR, runtime);
   const { patients, conditions, procedures, medRequests, crossRef, domain } =
     input;
 

--- a/libraries/libsyntheticrender/src/render/html.js
+++ b/libraries/libsyntheticrender/src/render/html.js
@@ -352,7 +352,7 @@ function extractGuideConfig(gc) {
   };
 }
 
-function buildLinkedEntities(entities, domain) {
+function buildLinkedEntities(entities, domain, runtime) {
   const gc = entities.content.find((c) => c.id === "guide_html");
   const { startYear, endYear } = extractDateRange(entities);
   const seed = entities.activity?.seed || 42;
@@ -371,6 +371,7 @@ function buildLinkedEntities(entities, domain) {
     orgName,
     startYear,
     endYear,
+    runtime,
   });
 
   return { linked, gc };
@@ -385,15 +386,16 @@ function buildLinkedEntities(entities, domain) {
  * @param {object} [options.fhirCrossRef] - Optional FHIR cross-ref index;
  *   when non-null, clinical pages emit reverse links to matched patients.
  *   Absent or `null` → byte-identical output with no reverse links.
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected runtime bag
  * @returns {{ files: Map<string,string>, linked: import('./link-assigner.js').LinkedEntities }}
  */
-export function renderHTML(entities, prose, templates, options = {}) {
+export function renderHTML(entities, prose, templates, options = {}, runtime) {
   if (!templates) throw new Error("templates is required");
   const { fhirCrossRef = null } = options;
   const files = new Map();
   const domain = entities.domain;
 
-  const { linked, gc } = buildLinkedEntities(entities, domain);
+  const { linked, gc } = buildLinkedEntities(entities, domain, runtime);
   const enrichedPlatforms = enrichPlatformsWithLinks(linked);
   const enrichedDrugs = enrichDrugsWithLinks(linked);
 

--- a/libraries/libsyntheticrender/src/render/link-assigner.js
+++ b/libraries/libsyntheticrender/src/render/link-assigner.js
@@ -10,7 +10,6 @@
 
 import { createSeededRNG } from "@forwardimpact/libsyntheticgen/rng";
 import { isoDate } from "@forwardimpact/libutil";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /**
  * @typedef {object} LinkedEntities
@@ -37,7 +36,7 @@ import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
  * @param {number} params.blogCount
  * @param {string[]} [params.articleTopics=[]]
  * @param {number} [params.seed=42]
- * @param {object} [params.runtime] - Runtime collaborator bag (default: createDefaultRuntime())
+ * @param {object} [params.runtime] - Runtime collaborator bag
  * @returns {LinkedEntities}
  */
 export function assignLinks({
@@ -57,7 +56,7 @@ export function assignLinks({
   startYear = null,
   endYear = null,
   blogTopics = null,
-  runtime = createDefaultRuntime(),
+  runtime,
 }) {
   const { clock } = runtime;
   const rng = createSeededRNG(seed + 1000);

--- a/libraries/libsyntheticrender/src/render/markdown.js
+++ b/libraries/libsyntheticrender/src/render/markdown.js
@@ -6,7 +6,6 @@
  */
 
 import { isoDate } from "@forwardimpact/libutil";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 const SKILL_NAMES = [
   "version_control",
@@ -134,15 +133,10 @@ function renderPersona(files, person, entities, prose, templates, date) {
  * @param {object} entities
  * @param {Map<string,string>} prose
  * @param {import('@forwardimpact/libtemplate/loader').TemplateLoader} templates - Template loader
- * @param {object} [runtime] - Runtime collaborator bag (default: createDefaultRuntime())
+ * @param {object} [runtime] - Runtime collaborator bag
  * @returns {Map<string,string>} path → Markdown content
  */
-export function renderMarkdown(
-  entities,
-  prose,
-  templates,
-  runtime = createDefaultRuntime(),
-) {
+export function renderMarkdown(entities, prose, templates, runtime) {
   if (!templates) throw new Error("templates is required");
   const { clock } = runtime;
   const files = new Map();

--- a/libraries/libsyntheticrender/src/render/renderer.js
+++ b/libraries/libsyntheticrender/src/render/renderer.js
@@ -22,12 +22,15 @@ export class Renderer {
   /**
    * @param {import('@forwardimpact/libtemplate/loader').TemplateLoader} templateLoader - Template loader
    * @param {object} logger - Logger instance
+   * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected runtime bag
    */
-  constructor(templateLoader, logger) {
+  constructor(templateLoader, logger, runtime) {
     if (!templateLoader) throw new Error("templateLoader is required");
     if (!logger) throw new Error("logger is required");
+    if (!runtime) throw new Error("runtime is required");
     this.templateLoader = templateLoader;
     this.logger = logger;
+    this.runtime = runtime;
   }
 
   /**
@@ -43,7 +46,13 @@ export class Renderer {
    * @returns {{ files: Map<string,string>, linked: object }}
    */
   renderSkeleton(entities, prose, options = {}) {
-    return renderHTML(entities, prose, this.templateLoader, options);
+    return renderHTML(
+      entities,
+      prose,
+      this.templateLoader,
+      options,
+      this.runtime,
+    );
   }
 
   /**
@@ -72,7 +81,7 @@ export class Renderer {
    * @returns {Map<string,string>}
    */
   renderMarkdown(entities, prose) {
-    return renderMarkdown(entities, prose, this.templateLoader);
+    return renderMarkdown(entities, prose, this.templateLoader, this.runtime);
   }
 
   /**
@@ -127,10 +136,11 @@ export class Renderer {
 /**
  * Creates a Renderer with real dependencies wired.
  * @param {object} logger - Logger instance
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected runtime bag
  * @returns {Renderer}
  */
-export function createRenderer(logger) {
+export function createRenderer(logger, runtime) {
   const templateDir = join(__dirname, "..", "..", "templates");
-  const templateLoader = new TemplateLoader(templateDir);
-  return new Renderer(templateLoader, logger);
+  const templateLoader = new TemplateLoader(templateDir, runtime);
+  return new Renderer(templateLoader, logger, runtime);
 }

--- a/libraries/libsyntheticrender/test/dataset-renderers.test.js
+++ b/libraries/libsyntheticrender/test/dataset-renderers.test.js
@@ -1,6 +1,8 @@
 import { describe, test } from "node:test";
 import assert from "node:assert";
 import { renderDataset } from "../src/render/dataset-renderers.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const _rt = createDefaultRuntime();
 import { assertRejectsMessage } from "@forwardimpact/libmock";
 
 const FIXTURE = {
@@ -24,9 +26,14 @@ const EMPTY = {
 describe("dataset renderers", () => {
   describe("JSON", () => {
     test("renders valid JSON", async () => {
-      const result = await renderDataset(FIXTURE, "json", {
-        path: "out/test.json",
-      });
+      const result = await renderDataset(
+        FIXTURE,
+        "json",
+        {
+          path: "out/test.json",
+        },
+        _rt,
+      );
       assert.strictEqual(result.size, 1);
       const content = result.get("out/test.json");
       const parsed = JSON.parse(content);
@@ -35,22 +42,37 @@ describe("dataset renderers", () => {
     });
 
     test("round-trips records", async () => {
-      const result = await renderDataset(FIXTURE, "json", { path: "x.json" });
+      const result = await renderDataset(
+        FIXTURE,
+        "json",
+        { path: "x.json" },
+        _rt,
+      );
       const parsed = JSON.parse(result.get("x.json"));
       assert.deepStrictEqual(parsed, FIXTURE.records);
     });
 
     test("handles empty dataset", async () => {
-      const result = await renderDataset(EMPTY, "json", { path: "e.json" });
+      const result = await renderDataset(
+        EMPTY,
+        "json",
+        { path: "e.json" },
+        _rt,
+      );
       assert.deepStrictEqual(JSON.parse(result.get("e.json")), []);
     });
   });
 
   describe("YAML", () => {
     test("renders YAML content", async () => {
-      const result = await renderDataset(FIXTURE, "yaml", {
-        path: "out/test.yaml",
-      });
+      const result = await renderDataset(
+        FIXTURE,
+        "yaml",
+        {
+          path: "out/test.yaml",
+        },
+        _rt,
+      );
       const content = result.get("out/test.yaml");
       assert.ok(content.includes("Alice"));
       assert.ok(content.includes("Bob"));
@@ -59,9 +81,14 @@ describe("dataset renderers", () => {
 
   describe("CSV", () => {
     test("renders header and rows", async () => {
-      const result = await renderDataset(FIXTURE, "csv", {
-        path: "out/test.csv",
-      });
+      const result = await renderDataset(
+        FIXTURE,
+        "csv",
+        {
+          path: "out/test.csv",
+        },
+        _rt,
+      );
       const lines = result.get("out/test.csv").split("\n");
       assert.strictEqual(lines[0], "id,name,active,score,tags");
       assert.ok(lines[1].startsWith("1,Alice,true,9.5,"));
@@ -74,13 +101,13 @@ describe("dataset renderers", () => {
         records: [{ val: "hello, world" }],
         metadata: {},
       };
-      const result = await renderDataset(ds, "csv", { path: "c.csv" });
+      const result = await renderDataset(ds, "csv", { path: "c.csv" }, _rt);
       const lines = result.get("c.csv").split("\n");
       assert.ok(lines[1].includes('"hello, world"'));
     });
 
     test("handles empty dataset", async () => {
-      const result = await renderDataset(EMPTY, "csv", { path: "e.csv" });
+      const result = await renderDataset(EMPTY, "csv", { path: "e.csv" }, _rt);
       assert.strictEqual(result.get("e.csv"), "");
     });
 
@@ -91,7 +118,7 @@ describe("dataset renderers", () => {
         records: [{ data: { key: "val" } }],
         metadata: {},
       };
-      const result = await renderDataset(ds, "csv", { path: "n.csv" });
+      const result = await renderDataset(ds, "csv", { path: "n.csv" }, _rt);
       const content = result.get("n.csv");
       // Nested object is serialized as JSON, then CSV-escaped (quotes doubled)
       assert.ok(content.includes('{""key"":""val""}'));
@@ -100,9 +127,14 @@ describe("dataset renderers", () => {
 
   describe("Markdown", () => {
     test("renders table with header", async () => {
-      const result = await renderDataset(FIXTURE, "markdown", {
-        path: "out/test.md",
-      });
+      const result = await renderDataset(
+        FIXTURE,
+        "markdown",
+        {
+          path: "out/test.md",
+        },
+        _rt,
+      );
       const content = result.get("out/test.md");
       assert.ok(content.startsWith("# test_records"));
       assert.ok(content.includes("| id | name |"));
@@ -111,7 +143,12 @@ describe("dataset renderers", () => {
     });
 
     test("handles empty dataset", async () => {
-      const result = await renderDataset(EMPTY, "markdown", { path: "e.md" });
+      const result = await renderDataset(
+        EMPTY,
+        "markdown",
+        { path: "e.md" },
+        _rt,
+      );
       const content = result.get("e.md");
       assert.ok(content.includes("No records."));
     });
@@ -123,17 +160,22 @@ describe("dataset renderers", () => {
         records: [{ val: "a|b" }],
         metadata: {},
       };
-      const result = await renderDataset(ds, "markdown", { path: "p.md" });
+      const result = await renderDataset(ds, "markdown", { path: "p.md" }, _rt);
       assert.ok(result.get("p.md").includes("a\\|b"));
     });
   });
 
   describe("SQL INSERT", () => {
     test("renders INSERT statement", async () => {
-      const result = await renderDataset(FIXTURE, "sql", {
-        path: "out/test.sql",
-        table: "my_table",
-      });
+      const result = await renderDataset(
+        FIXTURE,
+        "sql",
+        {
+          path: "out/test.sql",
+          table: "my_table",
+        },
+        _rt,
+      );
       const content = result.get("out/test.sql");
       assert.ok(content.startsWith('INSERT INTO "my_table"'));
       assert.ok(content.includes('"id"'));
@@ -144,9 +186,14 @@ describe("dataset renderers", () => {
     });
 
     test("uses dataset name as default table", async () => {
-      const result = await renderDataset(FIXTURE, "sql", {
-        path: "out/test.sql",
-      });
+      const result = await renderDataset(
+        FIXTURE,
+        "sql",
+        {
+          path: "out/test.sql",
+        },
+        _rt,
+      );
       const content = result.get("out/test.sql");
       assert.ok(content.includes('"test_records"'));
     });
@@ -158,26 +205,41 @@ describe("dataset renderers", () => {
         records: [{ val: "it's" }],
         metadata: {},
       };
-      const result = await renderDataset(ds, "sql", {
-        path: "e.sql",
-        table: "t",
-      });
+      const result = await renderDataset(
+        ds,
+        "sql",
+        {
+          path: "e.sql",
+          table: "t",
+        },
+        _rt,
+      );
       assert.ok(result.get("e.sql").includes("'it''s'"));
     });
 
     test("renders NULL for null values", async () => {
-      const result = await renderDataset(FIXTURE, "sql", {
-        path: "n.sql",
-        table: "t",
-      });
+      const result = await renderDataset(
+        FIXTURE,
+        "sql",
+        {
+          path: "n.sql",
+          table: "t",
+        },
+        _rt,
+      );
       assert.ok(result.get("n.sql").includes("NULL"));
     });
 
     test("handles empty dataset", async () => {
-      const result = await renderDataset(EMPTY, "sql", {
-        path: "e.sql",
-        table: "t",
-      });
+      const result = await renderDataset(
+        EMPTY,
+        "sql",
+        {
+          path: "e.sql",
+          table: "t",
+        },
+        _rt,
+      );
       assert.ok(result.get("e.sql").includes("No records"));
     });
   });
@@ -193,9 +255,12 @@ describe("dataset renderers", () => {
         ],
         metadata: {},
       };
-      const result = await renderDataset(simpleDs, "parquet", {
-        path: "out/test.parquet",
-      });
+      const result = await renderDataset(
+        simpleDs,
+        "parquet",
+        { path: "out/test.parquet" },
+        _rt,
+      );
       const buf = result.get("out/test.parquet");
       assert.ok(Buffer.isBuffer(buf));
       assert.ok(buf.length > 0);
@@ -207,7 +272,7 @@ describe("dataset renderers", () => {
   describe("dispatch", () => {
     test("throws on unknown format", async () => {
       await assertRejectsMessage(
-        () => renderDataset(FIXTURE, "xlsx", { path: "x" }),
+        () => renderDataset(FIXTURE, "xlsx", { path: "x" }, _rt),
         /Unknown format: xlsx/,
       );
     });

--- a/libraries/libsyntheticrender/test/fhir-microdata.test.js
+++ b/libraries/libsyntheticrender/test/fhir-microdata.test.js
@@ -1,9 +1,15 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import {
-  renderFhirMicrodataHtml,
+  renderFhirMicrodataHtml as _renderFhirMicrodataHtml,
   buildFhirCrossRef,
 } from "../src/render/fhir-microdata.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+// Thread a real runtime (the renderer reads bundled templates via fsSync).
+const _fhirRuntime = createDefaultRuntime();
+const renderFhirMicrodataHtml = (input, config) =>
+  _renderFhirMicrodataHtml(input, config, _fhirRuntime);
 
 const PATIENT_A = "11111111-1111-4111-8111-111111111111";
 const PATIENT_B = "22222222-2222-4222-8222-222222222222";

--- a/libraries/libsyntheticrender/test/render-clinical-html.test.js
+++ b/libraries/libsyntheticrender/test/render-clinical-html.test.js
@@ -3,13 +3,15 @@ import assert from "node:assert";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { TemplateLoader } from "@forwardimpact/libtemplate/loader";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+const _rt = createDefaultRuntime();
 import { renderHTML } from "../src/render/html.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_DIR = join(__dirname, "..", "templates");
 
 function makeTemplates() {
-  return new TemplateLoader(TEMPLATE_DIR);
+  return new TemplateLoader(TEMPLATE_DIR, createDefaultRuntime());
 }
 
 function makeMinimalEntities(overrides = {}) {
@@ -101,7 +103,7 @@ function makeClinicalFixture() {
 describe("renderClinicalPages", () => {
   test("produces 7 clinical HTML files", () => {
     const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
-    const { files } = renderHTML(entities, new Map(), makeTemplates());
+    const { files } = renderHTML(entities, new Map(), makeTemplates(), {}, _rt);
 
     const clinicalFiles = [
       "condition-explainers.html",
@@ -119,7 +121,7 @@ describe("renderClinicalPages", () => {
 
   test("Schema.org microdata uses correct itemtype URLs", () => {
     const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
-    const { files } = renderHTML(entities, new Map(), makeTemplates());
+    const { files } = renderHTML(entities, new Map(), makeTemplates(), {}, _rt);
 
     assert.match(
       files.get("condition-explainers.html"),
@@ -153,7 +155,7 @@ describe("renderClinicalPages", () => {
 
   test("data-enrich keys follow clinical_ prefix pattern", () => {
     const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
-    const { files } = renderHTML(entities, new Map(), makeTemplates());
+    const { files } = renderHTML(entities, new Map(), makeTemplates(), {}, _rt);
 
     assert.match(
       files.get("condition-explainers.html"),
@@ -183,7 +185,7 @@ describe("renderClinicalPages", () => {
 
   test("empty prose cache falls back to placeholder strings", () => {
     const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
-    const { files } = renderHTML(entities, new Map(), makeTemplates());
+    const { files } = renderHTML(entities, new Map(), makeTemplates(), {}, _rt);
 
     assert.match(
       files.get("condition-explainers.html"),
@@ -201,7 +203,7 @@ describe("renderClinicalPages", () => {
       ],
       ["clinical_trial_faq_oncora_p3", "Common questions about ONCORA-301."],
     ]);
-    const { files } = renderHTML(entities, prose, makeTemplates());
+    const { files } = renderHTML(entities, prose, makeTemplates(), {}, _rt);
 
     assert.match(
       files.get("condition-explainers.html"),
@@ -215,14 +217,14 @@ describe("renderClinicalPages", () => {
 
   test("trial-cards has no data-enrich attribute", () => {
     const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
-    const { files } = renderHTML(entities, new Map(), makeTemplates());
+    const { files } = renderHTML(entities, new Map(), makeTemplates(), {}, _rt);
 
     assert.doesNotMatch(files.get("trial-cards.html"), /data-enrich/);
   });
 
   test("no clinical block produces zero clinical files, leaves others unaffected", () => {
     const entities = makeMinimalEntities({ clinical: null });
-    const { files } = renderHTML(entities, new Map(), makeTemplates());
+    const { files } = renderHTML(entities, new Map(), makeTemplates(), {}, _rt);
 
     const clinicalFiles = [
       "condition-explainers.html",
@@ -242,7 +244,7 @@ describe("renderClinicalPages", () => {
 
   test("condition study link points to trial IRIs", () => {
     const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
-    const { files } = renderHTML(entities, new Map(), makeTemplates());
+    const { files } = renderHTML(entities, new Map(), makeTemplates(), {}, _rt);
 
     assert.match(
       files.get("condition-explainers.html"),
@@ -262,9 +264,13 @@ describe("renderClinicalPages", () => {
       siteIdToPatientIris: new Map([["cambridge", new Set([patientIri])]]),
       trialIriToPatientIris: new Map([[trialIri, new Set([patientIri])]]),
     };
-    const { files } = renderHTML(entities, new Map(), makeTemplates(), {
-      fhirCrossRef,
-    });
+    const { files } = renderHTML(
+      entities,
+      new Map(),
+      makeTemplates(),
+      { fhirCrossRef },
+      _rt,
+    );
     assert.match(
       files.get("trial-cards.html"),
       /itemprop="https:\/\/www\.forwardimpact\.team\/schema\/rdf\/enrolledPatient"/,
@@ -281,7 +287,7 @@ describe("renderClinicalPages", () => {
 
   test("no fhirCrossRef option: reverse-link strings absent from output", () => {
     const entities = makeMinimalEntities({ clinical: makeClinicalFixture() });
-    const { files } = renderHTML(entities, new Map(), makeTemplates());
+    const { files } = renderHTML(entities, new Map(), makeTemplates(), {}, _rt);
 
     for (const page of [
       "trial-cards.html",
@@ -324,7 +330,7 @@ describe("renderClinicalPages", () => {
     clinical.sites[0].trials.push("completed_trial");
 
     const entities = makeMinimalEntities({ clinical });
-    const { files } = renderHTML(entities, new Map(), makeTemplates());
+    const { files } = renderHTML(entities, new Map(), makeTemplates(), {}, _rt);
 
     const siteHtml = files.get("site-descriptions.html");
     assert.match(

--- a/libraries/libtelemetry/bin/fit-visualize.js
+++ b/libraries/libtelemetry/bin/fit-visualize.js
@@ -43,7 +43,7 @@ const definition = {
   ],
 };
 
-const cli = createCli(definition);
+const cli = createCli(definition, { runtime });
 
 const parsed = cli.parse(runtime.proc.argv.slice(2));
 if (!parsed) runtime.proc.exit(0);
@@ -99,7 +99,9 @@ const repl = new Repl({
 
   setup: async (state) => {
     const traceStorage = createStorage("traces");
-    state.traceIndex = new TraceIndex(traceStorage, "index.jsonl");
+    state.traceIndex = new TraceIndex(traceStorage, "index.jsonl", {
+      clock: runtime.clock,
+    });
     state.visualizer = new TraceVisualizer(state.traceIndex, runtime);
   },
 

--- a/libraries/libtelemetry/src/index/trace.js
+++ b/libraries/libtelemetry/src/index/trace.js
@@ -9,6 +9,16 @@ import { trace } from "@forwardimpact/libtype";
  */
 export class TraceIndex extends BufferedIndex {
   /**
+   * @param {import("@forwardimpact/libstorage").StorageInterface} storage
+   * @param {string} [indexKey]
+   * @param {object} [deps]
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} deps.clock
+   */
+  constructor(storage, indexKey = "index.jsonl", { clock } = {}) {
+    super(storage, indexKey, {}, { clock });
+  }
+
+  /**
    * Loads data from storage and reconstructs Span objects
    * Overrides parent to ensure proper protobuf enum deserialization
    * @returns {Promise<void>}

--- a/libraries/libtelemetry/src/logger.js
+++ b/libraries/libtelemetry/src/logger.js
@@ -1,5 +1,3 @@
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
-
 import { msToIso } from "./time.js";
 
 /**
@@ -25,17 +23,17 @@ export class Logger {
   /**
    * Creates a new Logger instance
    * @param {string} domain - Domain or service area for this logger instance
-   * @param {object} [proc] - Process object for environment access (defaults to global.process)
-   * @param {import("@forwardimpact/libutil/runtime").Runtime} [runtime] - Optional runtime bag;
-   *   falls back to `createDefaultClock()` so existing callers keep working unchanged.
+   * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected
+   *   runtime bag; supplies the `proc` (env access) and `clock` collaborators.
    */
-  constructor(domain, proc = global.process, runtime = null) {
+  constructor(domain, runtime) {
     if (!domain || typeof domain !== "string") {
       throw new Error("domain must be a non-empty string");
     }
+    if (!runtime) throw new Error("runtime is required");
     this.#domain = domain;
-    this.#process = proc;
-    this.#clock = runtime?.clock ?? createDefaultClock();
+    this.#process = runtime.proc;
+    this.#clock = runtime.clock;
     this.#level = this.#resolveLevel();
     this.#enabled = this.#isEnabled();
   }
@@ -245,9 +243,9 @@ export class Logger {
 /**
  * Factory function to create a Logger instance
  * @param {string} domain - Domain or service area for the logger
- * @param {import("@forwardimpact/libutil/runtime").Runtime} [runtime] - Optional runtime bag
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected runtime bag
  * @returns {Logger} Configured logger instance
  */
-export function createLogger(domain, runtime = null) {
-  return new Logger(domain, global.process, runtime);
+export function createLogger(domain, runtime) {
+  return new Logger(domain, runtime);
 }

--- a/libraries/libtelemetry/src/span.js
+++ b/libraries/libtelemetry/src/span.js
@@ -1,5 +1,4 @@
 import { trace } from "@forwardimpact/libtype";
-import { createDefaultClock } from "@forwardimpact/libutil/runtime";
 
 /**
  * Compute the wall-clock offset (ns) relative to hrtime.bigint() using the
@@ -45,8 +44,8 @@ export class Span {
    * @param {string} [options.traceId] - Trace ID from parent context
    * @param {string} [options.parentSpanId] - Parent span ID from parent context
    * @param {object} options.traceClient - Trace service client
-   * @param {import("@forwardimpact/libutil/runtime").Runtime} [options.runtime] - Optional runtime bag;
-   *   falls back to `createDefaultClock()` so existing callers keep working unchanged.
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} options.clock -
+   *   Injected clock collaborator (drives the wall-clock offset).
    */
   constructor({
     name,
@@ -56,9 +55,9 @@ export class Span {
     traceId,
     parentSpanId,
     traceClient,
-    runtime = null,
+    clock,
   }) {
-    const clock = runtime?.clock ?? createDefaultClock();
+    if (!clock) throw new Error("clock is required");
     this.#wallClockOffsetNs = computeWallClockOffset(clock);
     this.#object = {
       trace_id: traceId || this.#generateId(),

--- a/libraries/libtelemetry/src/tracer.js
+++ b/libraries/libtelemetry/src/tracer.js
@@ -11,6 +11,7 @@ export class Tracer {
   #traceClient;
   #spanContext;
   #grpcMetadata;
+  #clock;
 
   /**
    * Creates a new tracer instance
@@ -18,15 +19,19 @@ export class Tracer {
    * @param {string} options.serviceName - Name of the service
    * @param {object} options.traceClient - Trace service client
    * @param {Function} options.grpcMetadata - gRPC Metadata constructor for creating metadata instances
+   * @param {import("@forwardimpact/libutil/runtime").Runtime["clock"]} options.clock -
+   *   Injected clock collaborator, threaded into every Span.
    */
-  constructor({ serviceName, traceClient, grpcMetadata }) {
+  constructor({ serviceName, traceClient, grpcMetadata, clock }) {
     if (!serviceName) throw new Error("serviceName is required");
     if (!traceClient) throw new Error("traceClient is required");
     if (!grpcMetadata) throw new Error("grpcMetadata is required");
+    if (!clock) throw new Error("clock is required");
 
     this.#serviceName = serviceName;
     this.#traceClient = traceClient;
     this.#grpcMetadata = grpcMetadata;
+    this.#clock = clock;
     this.#spanContext = new AsyncLocalStorage();
   }
 
@@ -58,6 +63,7 @@ export class Tracer {
       traceId: options.traceId,
       parentSpanId: options.parentSpanId,
       traceClient: this.#traceClient,
+      clock: this.#clock,
     });
 
     return span;

--- a/libraries/libtelemetry/test/error.test.js
+++ b/libraries/libtelemetry/test/error.test.js
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import { strict as assert } from "node:assert";
 
 import { Tracer } from "../src/tracer.js";
+import { createMockClock } from "@forwardimpact/libmock";
 
 test("Tracer enriches errors with trace context in observeClientUnaryCall", async () => {
   const mockTraceClient = {
@@ -36,6 +37,7 @@ test("Tracer enriches errors with trace context in observeClientUnaryCall", asyn
     serviceName: "test-service",
     traceClient: mockTraceClient,
     grpcMetadata: mockGrpcMetadata,
+    clock: createMockClock(),
   });
 
   const request = { test: "data" };
@@ -100,6 +102,7 @@ test("Tracer enriches errors with trace context in observeServerUnaryCall", asyn
     serviceName: "test-service",
     traceClient: mockTraceClient,
     grpcMetadata: mockGrpcMetadata,
+    clock: createMockClock(),
   });
 
   const call = {
@@ -167,6 +170,7 @@ test("Logger extracts trace context from error", async () => {
     serviceName: "test-service",
     traceClient: mockTraceClient,
     grpcMetadata: mockGrpcMetadata,
+    clock: createMockClock(),
   });
 
   const request = { test: "data" };
@@ -223,6 +227,7 @@ test("Tracer handles non-Error objects gracefully", async () => {
     serviceName: "test-service",
     traceClient: mockTraceClient,
     grpcMetadata: mockGrpcMetadata,
+    clock: createMockClock(),
   });
 
   const request = { test: "data" };

--- a/libraries/libtelemetry/test/index-core.test.js
+++ b/libraries/libtelemetry/test/index-core.test.js
@@ -4,6 +4,8 @@ import assert from "node:assert";
 import { TraceIndex } from "../src/index/trace.js";
 import { trace } from "@forwardimpact/libtype";
 import { assertThrowsMessage, createMockStorage } from "@forwardimpact/libmock";
+import { createMockClock } from "@forwardimpact/libmock";
+const _clock = createMockClock();
 
 describe("TraceIndex - Core", () => {
   let traceIndex;
@@ -11,20 +13,24 @@ describe("TraceIndex - Core", () => {
 
   beforeEach(() => {
     mockStorage = createMockStorage();
-    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl");
+    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl", {
+      clock: _clock,
+    });
   });
 
   describe("Constructor and Inheritance", () => {
     test("constructor validates storage parameter", () => {
       assertThrowsMessage(
-        () => new TraceIndex(null),
+        () => new TraceIndex(null, undefined, { clock: _clock }),
         /storage is required/,
         "Should throw for missing storage",
       );
     });
 
     test("constructor sets properties correctly", () => {
-      const index = new TraceIndex(mockStorage, "custom.jsonl");
+      const index = new TraceIndex(mockStorage, "custom.jsonl", {
+        clock: _clock,
+      });
       assert.strictEqual(index.storage(), mockStorage, "Should set storage");
       assert.strictEqual(index.indexKey, "custom.jsonl", "Should set indexKey");
       assert.strictEqual(
@@ -35,7 +41,7 @@ describe("TraceIndex - Core", () => {
     });
 
     test("constructor uses default indexKey when not provided", () => {
-      const index = new TraceIndex(mockStorage);
+      const index = new TraceIndex(mockStorage, undefined, { clock: _clock });
       assert.strictEqual(
         index.indexKey,
         "index.jsonl",

--- a/libraries/libtelemetry/test/index-resource.test.js
+++ b/libraries/libtelemetry/test/index-resource.test.js
@@ -4,6 +4,8 @@ import assert from "node:assert";
 import { TraceIndex } from "../src/index/trace.js";
 import { trace } from "@forwardimpact/libtype";
 import { createMockStorage } from "@forwardimpact/libmock";
+import { createMockClock } from "@forwardimpact/libmock";
+const _clock = createMockClock();
 
 describe("TraceIndex - Resource ID Filtering", () => {
   let traceIndex;
@@ -11,7 +13,9 @@ describe("TraceIndex - Resource ID Filtering", () => {
 
   beforeEach(() => {
     mockStorage = createMockStorage();
-    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl");
+    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl", {
+      clock: _clock,
+    });
   });
 
   describe("queryItems() - Resource ID Filtering with Complete Traces", () => {

--- a/libraries/libtelemetry/test/tracer.test.js
+++ b/libraries/libtelemetry/test/tracer.test.js
@@ -2,6 +2,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert";
 
 import { Tracer } from "../src/tracer.js";
+import { createMockClock } from "@forwardimpact/libmock";
 
 /**
  * Mock gRPC Metadata class for testing
@@ -40,6 +41,7 @@ describe("Tracer", () => {
         serviceName: "test-service",
         traceClient: mockTraceClient,
         grpcMetadata: MockMetadata,
+        clock: createMockClock(),
       });
 
       // Simulate two concurrent operations
@@ -93,6 +95,7 @@ describe("Tracer", () => {
         serviceName: "test-service",
         traceClient: mockTraceClient,
         grpcMetadata: MockMetadata,
+        clock: createMockClock(),
       });
       const context = tracer.getSpanContext();
 
@@ -125,6 +128,7 @@ describe("Tracer", () => {
         serviceName: "test-service",
         traceClient: mockTraceClient,
         grpcMetadata: MockMetadata,
+        clock: createMockClock(),
       });
 
       // Mock gRPC metadata with trace context

--- a/libraries/libtelemetry/test/visualizer-attributes.test.js
+++ b/libraries/libtelemetry/test/visualizer-attributes.test.js
@@ -5,6 +5,8 @@ import { TraceVisualizer } from "../src/visualizer.js";
 import { TraceIndex } from "../src/index/trace.js";
 import { trace } from "@forwardimpact/libtype";
 import { createMockStorage } from "@forwardimpact/libmock";
+import { createMockClock } from "@forwardimpact/libmock";
+const _clock = createMockClock();
 
 describe("TraceVisualizer - attributes and errors", () => {
   let traceIndex;
@@ -14,7 +16,9 @@ describe("TraceVisualizer - attributes and errors", () => {
   beforeEach(() => {
     mockStorage = createMockStorage();
 
-    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl");
+    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl", {
+      clock: _clock,
+    });
     visualizer = new TraceVisualizer(traceIndex);
   });
 

--- a/libraries/libtelemetry/test/visualizer-basics.test.js
+++ b/libraries/libtelemetry/test/visualizer-basics.test.js
@@ -5,6 +5,8 @@ import { TraceVisualizer } from "../src/visualizer.js";
 import { TraceIndex } from "../src/index/trace.js";
 import { trace } from "@forwardimpact/libtype";
 import { assertThrowsMessage, createMockStorage } from "@forwardimpact/libmock";
+import { createMockClock } from "@forwardimpact/libmock";
+const _clock = createMockClock();
 
 describe("TraceVisualizer - basics", () => {
   let traceIndex;
@@ -14,7 +16,9 @@ describe("TraceVisualizer - basics", () => {
   beforeEach(() => {
     mockStorage = createMockStorage();
 
-    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl");
+    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl", {
+      clock: _clock,
+    });
     visualizer = new TraceVisualizer(traceIndex);
   });
 

--- a/libraries/libtelemetry/test/visualizer-edge-cases.test.js
+++ b/libraries/libtelemetry/test/visualizer-edge-cases.test.js
@@ -5,6 +5,8 @@ import { TraceVisualizer } from "../src/visualizer.js";
 import { TraceIndex } from "../src/index/trace.js";
 import { trace } from "@forwardimpact/libtype";
 import { createMockStorage } from "@forwardimpact/libmock";
+import { createMockClock } from "@forwardimpact/libmock";
+const _clock = createMockClock();
 
 describe("TraceVisualizer - edge cases and complex scenarios", () => {
   let traceIndex;
@@ -14,7 +16,9 @@ describe("TraceVisualizer - edge cases and complex scenarios", () => {
   beforeEach(() => {
     mockStorage = createMockStorage();
 
-    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl");
+    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl", {
+      clock: _clock,
+    });
     visualizer = new TraceVisualizer(traceIndex);
   });
 

--- a/libraries/libtelemetry/test/visualizer-timeline.test.js
+++ b/libraries/libtelemetry/test/visualizer-timeline.test.js
@@ -5,6 +5,8 @@ import { TraceVisualizer } from "../src/visualizer.js";
 import { TraceIndex } from "../src/index/trace.js";
 import { trace } from "@forwardimpact/libtype";
 import { createMockStorage } from "@forwardimpact/libmock";
+import { createMockClock } from "@forwardimpact/libmock";
+const _clock = createMockClock();
 
 describe("TraceVisualizer - multiple traces and timeline", () => {
   let traceIndex;
@@ -14,7 +16,9 @@ describe("TraceVisualizer - multiple traces and timeline", () => {
   beforeEach(() => {
     mockStorage = createMockStorage();
 
-    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl");
+    traceIndex = new TraceIndex(mockStorage, "test-traces.jsonl", {
+      clock: _clock,
+    });
     visualizer = new TraceVisualizer(traceIndex);
   });
 

--- a/libraries/libtemplate/src/loader.js
+++ b/libraries/libtemplate/src/loader.js
@@ -1,6 +1,5 @@
 import { join } from "node:path";
 import Mustache from "mustache";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /**
  * Template loader with two-tier resolution and Mustache rendering.
@@ -16,10 +15,11 @@ export class TemplateLoader {
 
   /**
    * @param {string} defaultsDir - Absolute path to the package's templates/ folder
-   * @param {import("@forwardimpact/libutil/runtime").Runtime} [runtime]
+   * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
    */
-  constructor(defaultsDir, runtime = createDefaultRuntime()) {
+  constructor(defaultsDir, runtime) {
     if (!defaultsDir) throw new Error("defaultsDir is required");
+    if (!runtime) throw new Error("runtime is required");
     this.#defaultsDir = defaultsDir;
     this.#fsSync = runtime.fsSync;
   }

--- a/libraries/libtemplate/test/loader.test.js
+++ b/libraries/libtemplate/test/loader.test.js
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { TemplateLoader, createTemplateLoader } from "../src/index.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 describe("TemplateLoader", () => {
   let defaultsDir;
@@ -26,27 +27,27 @@ describe("TemplateLoader", () => {
   });
 
   test("constructor accepts valid defaultsDir", () => {
-    const loader = new TemplateLoader(defaultsDir);
+    const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
     assert.ok(loader instanceof TemplateLoader);
   });
 
   describe("load", () => {
     test("throws when name is not provided", () => {
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       assert.throws(() => loader.load(), {
         message: "name is required",
       });
     });
 
     test("throws when name is empty string", () => {
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       assert.throws(() => loader.load(""), {
         message: "name is required",
       });
     });
 
     test("throws when template file does not exist", () => {
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       assert.throws(() => loader.load("nonexistent.html"), {
         message: /Template 'nonexistent.html' not found/,
       });
@@ -56,7 +57,7 @@ describe("TemplateLoader", () => {
       const content = "<h1>{{title}}</h1>";
       writeFileSync(join(defaultsDir, "page.html"), content);
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.load("page.html");
 
       assert.strictEqual(result, content);
@@ -69,7 +70,7 @@ describe("TemplateLoader", () => {
       writeFileSync(join(defaultsDir, "page.html"), "default");
       writeFileSync(join(dataDir, "templates", "page.html"), "override");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.load("page.html", dataDir);
 
       assert.strictEqual(result, "override");
@@ -82,7 +83,7 @@ describe("TemplateLoader", () => {
 
       writeFileSync(join(defaultsDir, "page.html"), "default");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.load("page.html", dataDir);
 
       assert.strictEqual(result, "default");
@@ -94,7 +95,7 @@ describe("TemplateLoader", () => {
     test("renders template with data", () => {
       writeFileSync(join(defaultsDir, "greeting.html"), "Hello, {{name}}!");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.render("greeting.html", { name: "World" });
 
       assert.strictEqual(result, "Hello, World!");
@@ -103,7 +104,7 @@ describe("TemplateLoader", () => {
     test("renders template with empty data", () => {
       writeFileSync(join(defaultsDir, "greeting.html"), "Hello, {{name}}!");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.render("greeting.html", {});
 
       assert.strictEqual(result, "Hello, !");
@@ -112,7 +113,7 @@ describe("TemplateLoader", () => {
     test("renders template without data argument", () => {
       writeFileSync(join(defaultsDir, "static.html"), "Static content");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.render("static.html");
 
       assert.strictEqual(result, "Static content");
@@ -122,7 +123,7 @@ describe("TemplateLoader", () => {
       const template = "<ul>{{#items}}<li>{{.}}</li>{{/items}}</ul>";
       writeFileSync(join(defaultsDir, "list.html"), template);
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.render("list.html", { items: ["a", "b"] });
 
       assert.strictEqual(result, "<ul><li>a</li><li>b</li></ul>");
@@ -135,7 +136,7 @@ describe("TemplateLoader", () => {
       writeFileSync(join(defaultsDir, "page.html"), "default {{v}}");
       writeFileSync(join(dataDir, "templates", "page.html"), "custom {{v}}");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.render("page.html", { v: "!" }, dataDir);
 
       assert.strictEqual(result, "custom !");
@@ -151,7 +152,7 @@ describe("TemplateLoader", () => {
       );
       writeFileSync(join(defaultsDir, "item.html"), "<li>{{label}}</li>");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.renderWithPartials(
         "page.html",
         { items: [{ label: "a" }, { label: "b" }] },
@@ -169,7 +170,7 @@ describe("TemplateLoader", () => {
       writeFileSync(join(defaultsDir, "partial.html"), "default");
       writeFileSync(join(dataDir, "templates", "partial.html"), "overridden");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.renderWithPartials(
         "page.html",
         {},
@@ -184,7 +185,7 @@ describe("TemplateLoader", () => {
     test("missing partial raises a Template not found error", () => {
       writeFileSync(join(defaultsDir, "page.html"), "{{> missing.html}}");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       assert.throws(
         () => loader.renderWithPartials("page.html", {}, ["missing.html"]),
         {
@@ -196,7 +197,7 @@ describe("TemplateLoader", () => {
     test("renders without any partials when partialNames is empty", () => {
       writeFileSync(join(defaultsDir, "page.html"), "Hello, {{name}}!");
 
-      const loader = new TemplateLoader(defaultsDir);
+      const loader = new TemplateLoader(defaultsDir, createDefaultRuntime());
       const result = loader.renderWithPartials(
         "page.html",
         { name: "World" },
@@ -219,7 +220,7 @@ describe("TemplateLoader", () => {
 describe("createTemplateLoader", () => {
   test("returns a TemplateLoader instance", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "libtemplate-factory-"));
-    const loader = createTemplateLoader(tempDir);
+    const loader = createTemplateLoader(tempDir, createDefaultRuntime());
     assert.ok(loader instanceof TemplateLoader);
     rmSync(tempDir, { recursive: true, force: true });
   });

--- a/libraries/libterrain/bin/fit-terrain.js
+++ b/libraries/libterrain/bin/fit-terrain.js
@@ -140,8 +140,8 @@ const definition = {
   documentation,
 };
 
-const cli = createCli(definition);
-const logger = createLogger("terrain");
+const cli = createCli(definition, { runtime });
+const logger = createLogger("terrain", runtime);
 
 /**
  * Build an Anthropic-backed LLM client adapted to the OpenAI choices shape

--- a/libraries/libterrain/src/cli-helpers.js
+++ b/libraries/libterrain/src/cli-helpers.js
@@ -86,13 +86,14 @@ export function createPipeline(opts) {
     templateDir,
     persistCache,
   } = opts;
-  const promptLoader = new PromptLoader(promptDir);
-  const templateLoader = new TemplateLoader(templateDir);
+  const promptLoader = new PromptLoader(promptDir, runtime);
+  const templateLoader = new TemplateLoader(templateDir, runtime);
 
   const dslParser = createDslParser();
-  const entityGenerator = createEntityGenerator(logger);
-  const proseCache = new ProseCache({ cachePath, logger });
+  const entityGenerator = createEntityGenerator(logger, runtime);
+  const proseCache = new ProseCache({ cachePath, logger, runtime });
   const proseGenerator = new ProseGenerator({
+    runtime,
     cache: proseCache,
     mode,
     strict: opts.strict,
@@ -101,7 +102,7 @@ export function createPipeline(opts) {
     logger,
   });
   const pathwayGenerator = new PathwayGenerator(proseGenerator, logger);
-  const renderer = new Renderer(templateLoader, logger);
+  const renderer = new Renderer(templateLoader, logger, runtime);
   const validator = new ContentValidator(logger);
 
   // Build an execFileFn compatible with SyntheaTool / SdvTool from the

--- a/libraries/libterrain/src/nodes.js
+++ b/libraries/libterrain/src/nodes.js
@@ -184,7 +184,7 @@ export function buildNodes(ctx) {
         if (!hasPathwayStandard || !options.schemaDir) return { files };
 
         logger.info("render", "Rendering pathway");
-        const schemas = loadSchemas(options.schemaDir);
+        const schemas = loadSchemas(options.schemaDir, runtime);
         const pathwayData = await pathwayGenerator.generate({
           standard: entities.standard,
           domain: entities.domain,
@@ -215,7 +215,8 @@ export function buildNodes(ctx) {
           logger,
           parse.clinical,
         );
-        await renderDatasetOutputs(parse.outputs, datasets, files, logger);
+        const outs = parse.outputs;
+        await renderDatasetOutputs(outs, datasets, files, logger, runtime);
         return { files, datasetsMap: datasets };
       },
     },
@@ -290,7 +291,7 @@ export function buildNodes(ctx) {
             );
             continue;
           }
-          const rendered = renderFhirMicrodataHtml(input, out.config);
+          const rendered = renderFhirMicrodataHtml(input, out.config, runtime);
           for (const [path, content] of rendered) files.set(path, content);
         }
         return { files };
@@ -463,22 +464,18 @@ function resolveDatasetConfig(ds, clinical, logger) {
 }
 
 /** Render dataset outputs and merge into the files map. */
-async function renderDatasetOutputs(outputs, datasets, files, logger) {
+async function renderDatasetOutputs(outputs, datasets, files, logger, runtime) {
   logger.info("pipeline", `Rendering ${outputs.length} dataset output(s)`);
   for (const out of outputs) {
     if (out.format === "fhir_microdata_html") continue;
     const dataset = datasets.get(out.dataset);
     if (!dataset) {
-      logger.info(
-        "pipeline",
-        `Skipping output '${out.dataset}': dataset not generated`,
-      );
+      logger.info("pipeline", `Skipping '${out.dataset}': not generated`);
       continue;
     }
-    const rendered = await renderDataset(dataset, out.format, out.config);
-    for (const [path, content] of rendered) {
-      files.set(path, content);
-    }
+    const { format, config } = out;
+    const rendered = await renderDataset(dataset, format, config, runtime);
+    for (const [path, content] of rendered) files.set(path, content);
   }
 }
 

--- a/libraries/libterrain/src/pipeline.js
+++ b/libraries/libterrain/src/pipeline.js
@@ -39,7 +39,6 @@
 
 import { buildNodes } from "./nodes.js";
 import { NullProseCacheSink } from "./sinks.js";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /** Names of the nodes the DAG knows about. Inspect verb takes one of these. */
 export const STAGES = [
@@ -144,10 +143,8 @@ export class Pipeline {
     this.proseCacheSink = proseCacheSink || new NullProseCacheSink();
     this.toolFactory = toolFactory || null;
     this.logger = logger;
-    // Fall back to the production runtime when callers do not inject one.
-    // This preserves backward compatibility for external consumers that
-    // construct Pipeline without a runtime bag.
-    this.runtime = runtime ?? createDefaultRuntime();
+    if (!runtime) throw new Error("runtime is required");
+    this.runtime = runtime;
   }
 
   /**

--- a/libraries/libterrain/src/sinks.js
+++ b/libraries/libterrain/src/sinks.js
@@ -15,7 +15,6 @@ import {
   ContentFormatter,
   formatContent,
 } from "@forwardimpact/libsyntheticrender";
-import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 const ZERO_STATS = {
   filesWritten: 0,
@@ -42,11 +41,11 @@ export class WriteSink {
     if (!monorepoRoot) throw new Error("monorepoRoot is required");
     if (!prettierFn) throw new Error("prettierFn is required");
     if (!logger) throw new Error("logger is required");
+    if (!runtime) throw new Error("runtime is required");
     this.monorepoRoot = monorepoRoot;
     this.formatter = new ContentFormatter(prettierFn, logger);
     this.logger = logger;
-    // Fall back to the production runtime for BC when no runtime is injected.
-    this._fs = (runtime ?? createDefaultRuntime()).fs;
+    this._fs = runtime.fs;
   }
 
   /** Format and write generated files, raw documents, and evidence to disk. */

--- a/libraries/libterrain/test/datasets.test.js
+++ b/libraries/libterrain/test/datasets.test.js
@@ -1,6 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { buildNodes } from "../src/nodes.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 function makeLogger() {
   return { info: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
@@ -36,6 +37,7 @@ function runDatasetsNode(parse, { clinical, factory }) {
     proseCacheSink: { flush: () => {} },
     toolFactory: factory,
     logger: makeLogger(),
+    runtime: createDefaultRuntime(),
     options: {},
   });
   return nodes.datasets.run({ parse: { ...parse, clinical } });
@@ -225,6 +227,7 @@ describe("datasets node — condition resolution", () => {
       proseCacheSink: { flush: () => {} },
       toolFactory: factory,
       logger,
+      runtime: createDefaultRuntime(),
       options: {},
     });
 
@@ -324,6 +327,7 @@ async function runFhirNodes(parse, ctx = {}) {
     proseCacheSink: { flush: () => {} },
     toolFactory: ctx.factory ?? null,
     logger: ctx.logger ?? makeLogger(),
+    runtime: createDefaultRuntime(),
     options: {},
   });
   const datasets = await nodes.datasets.run({

--- a/libraries/libterrain/test/fhir-microdata-rdf.test.js
+++ b/libraries/libterrain/test/fhir-microdata-rdf.test.js
@@ -16,6 +16,7 @@ import {
   PathwayGenerator,
 } from "@forwardimpact/libsyntheticprose";
 import { TemplateLoader } from "@forwardimpact/libtemplate/loader";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { Parser } from "@forwardimpact/libresource/parser.js";
 import { Skolemizer } from "@forwardimpact/libresource/skolemizer.js";
 import { Pipeline } from "../src/pipeline.js";
@@ -116,11 +117,14 @@ function makeFhirToolFactory() {
 function makePipeline() {
   const tmpDir = mkdtempSync(join(tmpdir(), "fhir-rdf-"));
   const logger = makeLogger();
+  const runtime = createDefaultRuntime();
   const proseCache = new ProseCache({
+    runtime,
     cachePath: join(tmpDir, "cache.json"),
     logger,
   });
   const proseGenerator = new ProseGenerator({
+    runtime,
     cache: proseCache,
     mode: "no-prose",
     promptLoader: { load: () => "system", render: () => "user" },
@@ -128,14 +132,19 @@ function makePipeline() {
   });
   const deps = {
     dslParser: createDslParser(),
-    entityGenerator: createEntityGenerator(logger),
+    entityGenerator: createEntityGenerator(logger, runtime),
     proseCache,
     proseGenerator,
     pathwayGenerator: new PathwayGenerator(proseGenerator, logger),
-    renderer: new Renderer(new TemplateLoader(TEMPLATE_DIR), logger),
+    renderer: new Renderer(
+      new TemplateLoader(TEMPLATE_DIR, createDefaultRuntime()),
+      logger,
+      runtime,
+    ),
     validator: new ContentValidator(logger),
     proseCacheSink: new NullProseCacheSink(),
     toolFactory: makeFhirToolFactory(),
+    runtime,
     logger,
   };
   return { tmpDir, pipeline: new Pipeline(deps) };

--- a/libraries/libterrain/test/pipeline.test.js
+++ b/libraries/libterrain/test/pipeline.test.js
@@ -19,6 +19,7 @@ import {
   PathwayGenerator,
 } from "@forwardimpact/libsyntheticprose";
 import { TemplateLoader } from "@forwardimpact/libtemplate/loader";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { Pipeline } from "../src/pipeline.js";
 import { NullProseCacheSink } from "../src/sinks.js";
 
@@ -92,11 +93,14 @@ function makePipelineDeps({
 } = {}) {
   const tmpDir = mkdtempSync(join(tmpdir(), "pipeline-deps-"));
   const logger = makeLogger();
+  const runtime = createDefaultRuntime();
   const proseCache = new ProseCache({
+    runtime,
     cachePath: join(tmpDir, "cache.json"),
     logger,
   });
   const proseGenerator = new ProseGenerator({
+    runtime,
     cache: proseCache,
     mode,
     strict,
@@ -107,14 +111,19 @@ function makePipelineDeps({
     tmpDir,
     deps: {
       dslParser: createDslParser(),
-      entityGenerator: createEntityGenerator(logger),
+      entityGenerator: createEntityGenerator(logger, runtime),
       proseCache,
       proseGenerator,
       pathwayGenerator: new PathwayGenerator(proseGenerator, logger),
-      renderer: new Renderer(new TemplateLoader(TEMPLATE_DIR), logger),
+      renderer: new Renderer(
+        new TemplateLoader(TEMPLATE_DIR, createDefaultRuntime()),
+        logger,
+        runtime,
+      ),
       validator: new ContentValidator(logger),
       proseCacheSink: new NullProseCacheSink(),
       toolFactory,
+      runtime,
       logger,
     },
   };
@@ -137,7 +146,10 @@ describe("Pipeline integration", () => {
     const source = readFileSync(FIXTURE_PATH, "utf-8");
     const parser = createDslParser();
     const ast = parser.parse(source);
-    const generator = createEntityGenerator(makeLogger());
+    const generator = createEntityGenerator(
+      makeLogger(),
+      createDefaultRuntime(),
+    );
     const entities = generator.generate(ast);
 
     assert.ok(entities.orgs.length > 0);
@@ -152,7 +164,10 @@ describe("Pipeline integration", () => {
     const source = readFileSync(FIXTURE_PATH, "utf-8");
     const parser = createDslParser();
     const ast = parser.parse(source);
-    const generator = createEntityGenerator(makeLogger());
+    const generator = createEntityGenerator(
+      makeLogger(),
+      createDefaultRuntime(),
+    );
     const entities = generator.generate(ast);
 
     for (const org of entities.orgs) {
@@ -373,7 +388,10 @@ describe("Pipeline integration", () => {
     const source = readFileSync(FIXTURE_PATH, "utf-8");
     const parser = createDslParser();
     const ast = parser.parse(source);
-    const generator = createEntityGenerator(makeLogger());
+    const generator = createEntityGenerator(
+      makeLogger(),
+      createDefaultRuntime(),
+    );
     const entities = generator.generate(ast);
     const result = validateCrossContent(entities);
 

--- a/libraries/libterrain/test/sinks.test.js
+++ b/libraries/libterrain/test/sinks.test.js
@@ -1,5 +1,6 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { join } from "path";
 import { mkdtempSync, rmSync, readFileSync, existsSync, readdirSync } from "fs";
 import { tmpdir } from "os";
@@ -81,6 +82,7 @@ describe("WriteSink", () => {
       const sink = new WriteSink({
         monorepoRoot: tmpDir,
         prettierFn: format,
+        runtime: createDefaultRuntime(),
         logger: makeLogger(),
       });
       const stats = await sink.accept(result);
@@ -128,6 +130,7 @@ describe("WriteSink", () => {
       const sink = new WriteSink({
         monorepoRoot: tmpDir,
         prettierFn: format,
+        runtime: createDefaultRuntime(),
         logger: makeLogger(),
       });
       await sink.accept(result);
@@ -151,6 +154,7 @@ describe("WriteSink", () => {
       const sink = new WriteSink({
         monorepoRoot: tmpDir,
         prettierFn: format,
+        runtime: createDefaultRuntime(),
         logger: makeLogger(),
       });
       await sink.accept(result);
@@ -183,6 +187,7 @@ describe("LoadSink", () => {
 
       const sink = new LoadSink({
         prettierFn: format,
+        runtime: createDefaultRuntime(),
         supabase: { id: "stub" },
         loadToSupabase,
         logger: makeLogger(),
@@ -260,10 +265,12 @@ describe("CompositeSink", () => {
       const writeSink = new WriteSink({
         monorepoRoot: tmpDir,
         prettierFn: format,
+        runtime: createDefaultRuntime(),
         logger: makeLogger(),
       });
       const loadSink = new LoadSink({
         prettierFn: format,
+        runtime: createDefaultRuntime(),
         supabase: { id: "stub" },
         loadToSupabase: async (_s, raw) => ({ loaded: raw.size, errors: [] }),
         logger: makeLogger(),

--- a/libraries/libutil/bin/fit-download-bundle.js
+++ b/libraries/libutil/bin/fit-download-bundle.js
@@ -9,6 +9,7 @@ import { createScriptConfig } from "@forwardimpact/libconfig";
 import { createStorage } from "@forwardimpact/libstorage";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { createBundleDownloader, execLine } from "@forwardimpact/libutil";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 // `bun build --compile` injects FIT_DOWNLOAD_BUNDLE_VERSION via --define,
 // eliminating the readFileSync branch in the compiled binary (which would
@@ -29,8 +30,9 @@ const definition = {
   },
 };
 
-const cli = createCli(definition);
-const logger = createLogger("generated");
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
+const logger = createLogger("generated", runtime);
 
 /**
  * Downloads generated code bundle from remote storage.
@@ -42,7 +44,7 @@ async function main() {
   if (!parsed) process.exit(0);
 
   await createScriptConfig("download-bundle");
-  const downloader = createBundleDownloader(createStorage, logger);
+  const downloader = createBundleDownloader(createStorage, logger, runtime);
   await downloader.download();
 
   // If additional arguments provided, execute them after download

--- a/libraries/libutil/bin/fit-tiktoken.js
+++ b/libraries/libutil/bin/fit-tiktoken.js
@@ -3,6 +3,7 @@ import "@forwardimpact/libpreflight/node22";
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { countTokens } from "@forwardimpact/libutil";
 
@@ -27,8 +28,9 @@ const definition = {
   examples: ['fit-tiktoken "hello world"', "echo 'hello world' | fit-tiktoken"],
 };
 
-const cli = createCli(definition);
-const logger = createLogger("tiktoken");
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
+const logger = createLogger("tiktoken", runtime);
 
 /**
  * Counts tokens in the provided text

--- a/libraries/libutil/src/finder.js
+++ b/libraries/libutil/src/finder.js
@@ -1,40 +1,15 @@
-import nodeFsSync from "node:fs";
-import nodeFsPromises from "node:fs/promises";
 import path from "path";
 import { createRequire } from "node:module";
 
 const NOOP_LOGGER = { debug() {} };
 
 /**
- * Detect the new collaborator-config constructor form. The legacy positional
- * form passes an fs module as the first argument (which carries `readFile`);
- * the new form passes `{ fs, fsSync?, proc, logger? }`.
- * @param {*} arg - The first constructor argument.
- * @returns {boolean}
- */
-function isRuntimeConfig(arg) {
-  return (
-    arg != null &&
-    typeof arg === "object" &&
-    !Array.isArray(arg) &&
-    (arg.proc !== undefined ||
-      arg.fsSync !== undefined ||
-      (arg.fs !== undefined && typeof arg.readFile !== "function"))
-  );
-}
-
-/**
  * Finder class for project path resolution and symlink management.
  * Handles filesystem operations for linking generated code to packages.
  *
- * Two constructor forms are supported during the ambient-to-injected migration:
- *
- * - Collaborator config (canonical): `new Finder({ fs, fsSync?, proc, logger? })`.
- *   The injected `fs` (async) and `fsSync` (sync, for existence checks) flow
- *   through to every internal call — the spec-flagged dead-`fs` bug is fixed.
- * - Legacy positional (deprecated, one migration cycle):
- *   `new Finder(fs, logger, process)`. Preserved byte-for-byte so existing
- *   call sites stay green until their per-unit migration PRs convert them.
+ * Constructed with injected collaborators: `new Finder({ fs, fsSync?, proc,
+ * logger? })`. The injected `fs` (async) and `fsSync` (sync, for existence
+ * checks) flow through to every internal call.
  */
 export class Finder {
   #fs;
@@ -43,39 +18,28 @@ export class Finder {
   #proc;
 
   /**
-   * @param {object} fsOrConfig - Either `{ fs, fsSync?, proc, logger? }` (new)
-   *   or the async fs module (legacy positional first argument).
-   * @param {object} [logger] - Legacy positional logger.
-   * @param {object} [proc] - Legacy positional process (cwd provider).
+   * @param {object} config - Injected collaborators.
+   * @param {object} config.fs - Async fs surface (mkdir, lstat, symlink, …).
+   * @param {object} [config.fsSync] - Sync fs surface for existence checks;
+   *   falls back to `fs` when omitted.
+   * @param {object} config.proc - Process collaborator (cwd provider).
+   * @param {object} [config.logger] - Optional logger; defaults to a no-op.
    */
-  constructor(fsOrConfig, logger, proc = global.process) {
-    if (isRuntimeConfig(fsOrConfig)) {
-      // Finder is the one module that legitimately bridges the sync and async
-      // fs surfaces (existence checks vs. symlink ops), so it reads both fields
-      // by property access rather than a single `{ fs, fsSync }` destructure
-      // (which design Decision 7 reserves for consumer modules).
-      const fs = fsOrConfig.fs;
-      const fsSync = fsOrConfig.fsSync;
-      const procArg = fsOrConfig.proc;
-      if (!fs) throw new Error("fs is required");
-      if (!procArg) throw new Error("proc is required");
-      this.#fs = fs;
-      const existsTarget = fsSync ?? fs;
-      this.#existsSync = existsTarget.existsSync.bind(existsTarget);
-      this.#proc = procArg;
-      this.#logger = fsOrConfig.logger ?? NOOP_LOGGER;
-      return;
-    }
-    // Legacy positional form: behavior identical to the pre-1370 Finder —
-    // every fs operation routes through the module-level node:fs imports
-    // (the historical dead-`fs` behavior callers depend on).
-    if (!fsOrConfig) throw new Error("fs is required");
-    if (!logger) throw new Error("logger is required");
-    if (!proc) throw new Error("process is required");
-    this.#fs = nodeFsPromises;
-    this.#existsSync = (p) => nodeFsSync.existsSync(p);
-    this.#logger = logger;
+  constructor(config = {}) {
+    // Finder is the one module that legitimately bridges the sync and async
+    // fs surfaces (existence checks vs. symlink ops), so it reads both fields
+    // by property access rather than a single `{ fs, fsSync }` destructure
+    // (which design Decision 7 reserves for consumer modules).
+    const fs = config.fs;
+    const fsSync = config.fsSync;
+    const proc = config.proc;
+    if (!fs) throw new Error("fs is required");
+    if (!proc) throw new Error("proc is required");
+    this.#fs = fs;
+    const existsTarget = fsSync ?? fs;
+    this.#existsSync = existsTarget.existsSync.bind(existsTarget);
     this.#proc = proc;
+    this.#logger = config.logger ?? NOOP_LOGGER;
   }
 
   /**

--- a/libraries/libutil/src/index.js
+++ b/libraries/libutil/src/index.js
@@ -101,13 +101,16 @@ export function createTokenizer() {
  * Used in containerized deployments to download pre-generated code bundles.
  * @param {Function} createStorage - Storage factory function from libstorage
  * @param {object} logger - Logger instance
+ * @param {import("./runtime.js").Runtime} runtime - Injected runtime bag; supplies
+ *   the `fs`/`fsSync`/`proc` collaborators the Finder reads.
  * @returns {BundleDownloader} Configured BundleDownloader instance
  */
-export function createBundleDownloader(createStorage, logger) {
+export function createBundleDownloader(createStorage, logger, runtime) {
   if (!createStorage) throw new Error("createStorage is required");
   if (!logger) throw new Error("logger is required");
+  if (!runtime) throw new Error("runtime is required");
 
-  const finder = new Finder(fs, logger);
+  const finder = new Finder({ ...runtime, logger });
   const extractor = new TarExtractor(fs, path);
 
   return new BundleDownloader(createStorage, finder, logger, extractor);

--- a/libraries/libutil/test/finder.test.js
+++ b/libraries/libutil/test/finder.test.js
@@ -23,7 +23,12 @@ describe("Finder", () => {
       cwd: () => "/test/project",
     };
 
-    finder = new Finder(fsPromises, mockLogger, mockProcess);
+    finder = new Finder({
+      fs: fsPromises,
+      fsSync: fs,
+      proc: mockProcess,
+      logger: mockLogger,
+    });
 
     // Create a temporary directory for testing
     const __filename = fileURLToPath(import.meta.url);
@@ -45,8 +50,13 @@ describe("Finder", () => {
   });
 
   describe("constructor", () => {
-    test("creates Finder with fs, logger and process", () => {
-      const finder = new Finder(fsPromises, mockLogger, mockProcess);
+    test("creates Finder with injected collaborators", () => {
+      const finder = new Finder({
+        fs: fsPromises,
+        fsSync: fs,
+        proc: mockProcess,
+        logger: mockLogger,
+      });
 
       assert.ok(finder instanceof Finder);
     });
@@ -55,28 +65,23 @@ describe("Finder", () => {
       assert.throws(() => new Finder(), {
         message: /fs is required/,
       });
-      assert.throws(() => new Finder(null), {
+      assert.throws(() => new Finder({ proc: mockProcess }), {
         message: /fs is required/,
       });
     });
 
-    test("validates logger parameter", () => {
-      assert.throws(() => new Finder(fsPromises), {
-        message: /logger is required/,
-      });
-      assert.throws(() => new Finder(fsPromises, null), {
-        message: /logger is required/,
+    test("validates proc parameter", () => {
+      assert.throws(() => new Finder({ fs: fsPromises }), {
+        message: /proc is required/,
       });
     });
 
-    test("validates process parameter", () => {
-      assert.throws(() => new Finder(fsPromises, mockLogger, null), {
-        message: /process is required/,
+    test("defaults logger to a no-op when omitted", () => {
+      const finder = new Finder({
+        fs: fsPromises,
+        fsSync: fs,
+        proc: mockProcess,
       });
-    });
-
-    test("uses global process when not provided", () => {
-      const finder = new Finder(fsPromises, mockLogger);
       assert.ok(finder instanceof Finder);
     });
   });
@@ -267,8 +272,11 @@ describe("Finder", () => {
       const dataDir = path.join(tempDir, "data");
       fs.mkdirSync(dataDir);
 
-      const cwdFinder = new Finder(fsPromises, mockLogger, {
-        cwd: () => tempDir,
+      const cwdFinder = new Finder({
+        fs: fsPromises,
+        fsSync: fs,
+        proc: { cwd: () => tempDir },
+        logger: mockLogger,
       });
       const result = cwdFinder.findData("data", "/nonexistent-home");
 
@@ -281,8 +289,11 @@ describe("Finder", () => {
       const subDir = path.join(tempDir, "products", "pathway");
       fs.mkdirSync(subDir, { recursive: true });
 
-      const cwdFinder = new Finder(fsPromises, mockLogger, {
-        cwd: () => subDir,
+      const cwdFinder = new Finder({
+        fs: fsPromises,
+        fsSync: fs,
+        proc: { cwd: () => subDir },
+        logger: mockLogger,
       });
       const result = cwdFinder.findData("data", "/nonexistent-home");
 
@@ -297,8 +308,11 @@ describe("Finder", () => {
       const isolatedDir = path.join(tempDir, "isolated");
       fs.mkdirSync(isolatedDir);
 
-      const cwdFinder = new Finder(fsPromises, mockLogger, {
-        cwd: () => isolatedDir,
+      const cwdFinder = new Finder({
+        fs: fsPromises,
+        fsSync: fs,
+        proc: { cwd: () => isolatedDir },
+        logger: mockLogger,
       });
       const result = cwdFinder.findData("data", fakeHome);
 
@@ -309,8 +323,11 @@ describe("Finder", () => {
       const isolatedDir = path.join(tempDir, "isolated");
       fs.mkdirSync(isolatedDir);
 
-      const cwdFinder = new Finder(fsPromises, mockLogger, {
-        cwd: () => isolatedDir,
+      const cwdFinder = new Finder({
+        fs: fsPromises,
+        fsSync: fs,
+        proc: { cwd: () => isolatedDir },
+        logger: mockLogger,
       });
 
       assert.throws(() => cwdFinder.findData("data", "/nonexistent-home"), {
@@ -326,8 +343,11 @@ describe("Finder", () => {
       const homeFitData = path.join(fakeHome, ".fit", "data");
       fs.mkdirSync(homeFitData, { recursive: true });
 
-      const cwdFinder = new Finder(fsPromises, mockLogger, {
-        cwd: () => tempDir,
+      const cwdFinder = new Finder({
+        fs: fsPromises,
+        fsSync: fs,
+        proc: { cwd: () => tempDir },
+        logger: mockLogger,
       });
       const result = cwdFinder.findData("data", fakeHome);
 

--- a/libraries/libutil/test/libutil.test.js
+++ b/libraries/libutil/test/libutil.test.js
@@ -3,7 +3,11 @@ import assert from "node:assert";
 
 // Module under test
 import { createBundleDownloader } from "../src/index.js";
-import { createSilentLogger, spy } from "@forwardimpact/libmock";
+import {
+  createSilentLogger,
+  createTestRuntime,
+  spy,
+} from "@forwardimpact/libmock";
 
 const mockLogger = createSilentLogger();
 
@@ -12,7 +16,11 @@ describe("libutil", () => {
     test("creates BundleDownloader instance with correct dependencies", () => {
       const mockStorageFactory = spy();
 
-      const downloader = createBundleDownloader(mockStorageFactory, mockLogger);
+      const downloader = createBundleDownloader(
+        mockStorageFactory,
+        mockLogger,
+        createTestRuntime(),
+      );
 
       assert.ok(downloader);
       assert.ok(typeof downloader.initialize === "function");
@@ -20,16 +28,33 @@ describe("libutil", () => {
     });
 
     test("validates storageFactory parameter", () => {
-      assert.throws(() => createBundleDownloader(null, mockLogger), {
-        message: /createStorage is required/,
-      });
+      assert.throws(
+        () => createBundleDownloader(null, mockLogger, createTestRuntime()),
+        {
+          message: /createStorage is required/,
+        },
+      );
     });
 
     test("validates logger parameter", () => {
       const mockStorageFactory = spy();
-      assert.throws(() => createBundleDownloader(mockStorageFactory, null), {
-        message: /logger is required/,
-      });
+      assert.throws(
+        () =>
+          createBundleDownloader(mockStorageFactory, null, createTestRuntime()),
+        {
+          message: /logger is required/,
+        },
+      );
+    });
+
+    test("validates runtime parameter", () => {
+      const mockStorageFactory = spy();
+      assert.throws(
+        () => createBundleDownloader(mockStorageFactory, mockLogger),
+        {
+          message: /runtime is required/,
+        },
+      );
     });
   });
 });

--- a/libraries/libutil/test/logger.test.js
+++ b/libraries/libutil/test/logger.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert";
 
 // Module under test
 import { Logger, createLogger } from "@forwardimpact/libtelemetry";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 describe("Logger", () => {
   let originalDebug;
@@ -22,7 +23,7 @@ describe("Logger", () => {
   });
 
   test("creates Logger with domain", () => {
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     assert.ok(logger instanceof Logger);
     assert.strictEqual(logger.domain, "test");
@@ -32,7 +33,7 @@ describe("Logger", () => {
     assert.throws(() => new Logger(), {
       message: /domain must be a non-empty string/,
     });
-    assert.throws(() => new Logger(""), {
+    assert.throws(() => new Logger("", createDefaultRuntime()), {
       message: /domain must be a non-empty string/,
     });
     assert.throws(() => new Logger(null), {
@@ -42,42 +43,42 @@ describe("Logger", () => {
 
   test("enables logging when DEBUG=*", () => {
     process.env.DEBUG = "*";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     assert.strictEqual(logger.enabled, true);
   });
 
   test("disables logging when DEBUG is empty", () => {
     process.env.DEBUG = "";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     assert.strictEqual(logger.enabled, false);
   });
 
   test("enables logging for exact domain match", () => {
     process.env.DEBUG = "test,other";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     assert.strictEqual(logger.enabled, true);
   });
 
   test("enables logging for wildcard pattern match", () => {
     process.env.DEBUG = "test*";
-    const logger = new Logger("test:service");
+    const logger = new Logger("test:service", createDefaultRuntime());
 
     assert.strictEqual(logger.enabled, true);
   });
 
   test("disables logging for non-matching domain", () => {
     process.env.DEBUG = "other";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     assert.strictEqual(logger.enabled, false);
   });
 
   test("logs debug message when enabled", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     logger.debug("TestApp", "Test message");
 
@@ -90,7 +91,7 @@ describe("Logger", () => {
 
   test("does not log when disabled", () => {
     process.env.DEBUG = "other";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     logger.debug("TestApp", "Test message");
 
@@ -99,7 +100,7 @@ describe("Logger", () => {
 
   test("handles empty data object", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     logger.debug("TestApp", "Test message", {});
 
@@ -110,7 +111,7 @@ describe("Logger", () => {
 
   test("includes timestamp in log output", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     logger.debug("TestApp", "Test message");
 
@@ -120,7 +121,7 @@ describe("Logger", () => {
 
   test("merges trace context with provided attributes", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     const error = new Error("Test error");
     Object.defineProperty(error, "trace_id", {
@@ -139,7 +140,7 @@ describe("Logger", () => {
 
   test("exception logs message when disabled", () => {
     process.env.DEBUG = "other";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     const error = new Error("Test error");
 
@@ -156,7 +157,7 @@ describe("Logger", () => {
 
   test("exception logs message with stack trace when enabled", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     const error = new Error("Test error");
 
@@ -173,7 +174,7 @@ describe("Logger", () => {
 
   test("exception extracts trace context from error", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     const error = new Error("Test error");
     error.trace_id = "trace456";
@@ -190,7 +191,7 @@ describe("Logger", () => {
 
   test("exception merges trace context with provided attributes", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test");
+    const logger = new Logger("test", createDefaultRuntime());
 
     const error = new Error("Test error");
     error.trace_id = "trace123";
@@ -205,14 +206,14 @@ describe("Logger", () => {
 
 describe("createLogger", () => {
   test("creates Logger instance", () => {
-    const logger = createLogger("test");
+    const logger = createLogger("test", createDefaultRuntime());
 
     assert.ok(logger instanceof Logger);
     assert.strictEqual(logger.domain, "test");
   });
 
   test("passes through domain validation", () => {
-    assert.throws(() => createLogger(""), {
+    assert.throws(() => createLogger("", createDefaultRuntime()), {
       message: /domain must be a non-empty string/,
     });
   });

--- a/libraries/libvector/bin/fit-process-vectors.js
+++ b/libraries/libvector/bin/fit-process-vectors.js
@@ -3,6 +3,7 @@ import "@forwardimpact/libpreflight/node22";
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createResourceIndex } from "@forwardimpact/libresource";
 import { createStorage } from "@forwardimpact/libstorage";
@@ -31,8 +32,9 @@ const definition = {
   },
 };
 
-const cli = createCli(definition);
-const logger = createLogger("vectors");
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
+const logger = createLogger("vectors", runtime);
 
 /**
  * Processes resources into vector embeddings

--- a/libraries/libvector/bin/fit-search.js
+++ b/libraries/libvector/bin/fit-search.js
@@ -3,6 +3,7 @@ import "@forwardimpact/libpreflight/node22";
 
 import { readFileSync } from "node:fs";
 import { createCli } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { clients } from "@forwardimpact/librpc";
@@ -31,8 +32,9 @@ const definition = {
   examples: ["fit-search 'career progression'"],
 };
 
-const cli = createCli(definition);
-const logger = createLogger("search");
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, { runtime });
+const logger = createLogger("search", runtime);
 
 /**
  * Searches vector index by embedding a query string

--- a/libraries/libwiki/src/commands/fix.js
+++ b/libraries/libwiki/src/commands/fix.js
@@ -115,7 +115,7 @@ export async function runFixCommand(ctx) {
       profilesDir: path.resolve(projectRoot, ".claude/agents"),
       runtime,
     }),
-    redactor: createRedactor(),
+    redactor: createRedactor({ runtime }),
   });
 
   // The audit is the verdict, not the agent's self-report: run, re-audit, and

--- a/products/guide/src/commands/init.js
+++ b/products/guide/src/commands/init.js
@@ -17,11 +17,17 @@ import {
  */
 export async function runInitCommand(runtime) {
   const { fs, proc } = runtime;
-  const serviceSecret = await getOrGenerateSecret("SERVICE_SECRET", () =>
-    generateSecret(),
+  const serviceSecret = await getOrGenerateSecret(
+    "SERVICE_SECRET",
+    () => generateSecret(),
+    ".env",
+    runtime,
   );
-  const mcpToken = await getOrGenerateSecret("MCP_TOKEN", () =>
-    generateSecret(),
+  const mcpToken = await getOrGenerateSecret(
+    "MCP_TOKEN",
+    () => generateSecret(),
+    ".env",
+    runtime,
   );
 
   const starterDir = new URL("../../starter", import.meta.url).pathname;
@@ -39,6 +45,7 @@ export async function runInitCommand(runtime) {
   );
 
   await bootstrapProject({
+    deps: { runtime },
     fragment: starterConfig,
     env: {
       SERVICE_SECRET: serviceSecret,

--- a/products/landmark/bin/fit-landmark.js
+++ b/products/landmark/bin/fit-landmark.js
@@ -265,7 +265,8 @@ const definition = {
 };
 
 async function main() {
-  const cli = createCli(definition);
+  const runtime = createDefaultRuntime();
+  const cli = createCli(definition, { runtime });
   const parsed = cli.parse(process.argv.slice(2));
   if (!parsed) process.exit(0);
 
@@ -282,8 +283,6 @@ async function main() {
     cli.usageError(`unknown command "${command}"`);
     process.exit(2);
   }
-
-  const runtime = createDefaultRuntime();
 
   try {
     const dataDir = resolveDataDir(values, runtime);

--- a/products/landmark/test/lib/sign-test-token.js
+++ b/products/landmark/test/lib/sign-test-token.js
@@ -1,4 +1,5 @@
 import { mintSupabaseJwt } from "@forwardimpact/libsecret";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /**
  * HMAC-sign a Supabase-shaped JWT for use in tests and local fixtures.
@@ -15,5 +16,5 @@ export function signTestToken({
   ttlSeconds = 900,
 }) {
   if (!secret) throw new Error("signTestToken: SUPABASE_JWT_SECRET not set");
-  return mintSupabaseJwt({ email, secret, ttlSeconds });
+  return mintSupabaseJwt({ email, secret, ttlSeconds }, createDefaultRuntime());
 }

--- a/products/map/bin/fit-map.js
+++ b/products/map/bin/fit-map.js
@@ -212,7 +212,7 @@ const definition = {
   ],
 };
 
-const cli = createCli(definition);
+const cli = createCli(definition, { runtime });
 
 /**
  * Format validation results for display using libcli helpers.
@@ -316,7 +316,7 @@ async function runExport(dataDir, outputDir) {
 
   const exporter = await createExporter({
     runtime,
-    renderer: createRenderer(),
+    renderer: createRenderer(runtime),
   });
   const result = await exporter.exportAll({ data, outputDir });
 

--- a/products/map/src/commands/auth-issue.js
+++ b/products/map/src/commands/auth-issue.js
@@ -73,7 +73,7 @@ export async function runAuthIssueCommand({
     );
   }
 
-  const jwt = mintSupabaseJwt({ email, secret, ttlSeconds });
+  const jwt = mintSupabaseJwt({ email, secret, ttlSeconds }, runtime);
   runtime.proc.stdout.write(
     formatHeader(`Issued JWT for ${email} (${row.kind}, ttl=${ttlString})`) +
       "\n\n",

--- a/products/map/src/commands/init.js
+++ b/products/map/src/commands/init.js
@@ -60,7 +60,7 @@ export async function runInit(targetPath, runtime) {
   // Materialise target/config/config.json so subsequent fit-map invocations
   // anchor at the init target rather than upward-walking into an ancestor
   // config/. No product.map starter fragment is shipped this spec.
-  await bootstrapProject({ target, fragment: {} });
+  await bootstrapProject({ target, fragment: {}, deps: { runtime } });
 
   runtime.proc.stdout.write(
     formatSuccess("Created ./data/pathway/ with starter data.") + "\n\n",

--- a/products/map/src/commands/substrate-issue.js
+++ b/products/map/src/commands/substrate-issue.js
@@ -68,7 +68,7 @@ export async function runSubstrateIssueCommand({
   }
 
   const secret = config.supabaseJwtSecret();
-  const jwt = mintSupabaseJwt({ email, secret, ttlSeconds });
+  const jwt = mintSupabaseJwt({ email, secret, ttlSeconds }, runtime);
 
   const { snapshot_id, item_id } = await resolveDiscoveryVector(supabase);
 

--- a/products/map/src/commands/substrate-smoke.js
+++ b/products/map/src/commands/substrate-smoke.js
@@ -106,11 +106,14 @@ export async function runSelfSmoke({ supabase, config, runtime }) {
   const persona = personas[0];
 
   const secret = config.supabaseJwtSecret();
-  const jwt = mintSupabaseJwt({
-    email: persona.email,
-    secret,
-    ttlSeconds: parseDuration("1h"),
-  });
+  const jwt = mintSupabaseJwt(
+    {
+      email: persona.email,
+      secret,
+      ttlSeconds: parseDuration("1h"),
+    },
+    runtime,
+  );
 
   // Spec § Success Criteria rows 1–4: explicit shape check.
   assertJwtShape(jwt, persona.email, runtime.clock.now());

--- a/products/map/src/exporter.js
+++ b/products/map/src/exporter.js
@@ -113,7 +113,7 @@ export async function createExporter({ runtime, renderer } = {}) {
   let r = renderer;
   if (!r) {
     const { createRenderer } = await import("./renderer.js");
-    r = createRenderer();
+    r = createRenderer(runtime);
   }
   return new Exporter(runtime.fs, r);
 }

--- a/products/map/src/renderer.js
+++ b/products/map/src/renderer.js
@@ -99,9 +99,10 @@ export class Renderer {
 
 /**
  * Wire a Renderer with the package's bundled templates directory.
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected runtime bag
  * @returns {Renderer}
  */
-export function createRenderer() {
+export function createRenderer(runtime) {
   const templateDir = join(__dirname, "..", "templates");
-  return new Renderer(new TemplateLoader(templateDir));
+  return new Renderer(new TemplateLoader(templateDir, runtime));
 }

--- a/products/map/test/exporter.test.js
+++ b/products/map/test/exporter.test.js
@@ -5,6 +5,7 @@
  */
 
 import { test, describe, beforeEach, afterEach } from "node:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import assert from "node:assert";
 import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import * as fsp from "node:fs/promises";
@@ -45,7 +46,7 @@ async function parseQuads(html) {
 
 describe("Exporter", () => {
   test("writes one file per base entity into <outputDir>/pathway/<type>/<id>.html", async () => {
-    const exporter = new Exporter(fsp, createRenderer());
+    const exporter = new Exporter(fsp, createRenderer(createDefaultRuntime()));
     const result = await exporter.exportAll({ data: DATA, outputDir });
 
     assert.strictEqual(result.errors.length, 0);
@@ -68,7 +69,7 @@ describe("Exporter", () => {
   });
 
   test("rendered files parse with fit: vocabulary subjects", async () => {
-    const exporter = new Exporter(fsp, createRenderer());
+    const exporter = new Exporter(fsp, createRenderer(createDefaultRuntime()));
     await exporter.exportAll({ data: DATA, outputDir });
 
     const html = await fsp.readFile(
@@ -86,7 +87,7 @@ describe("Exporter", () => {
   });
 
   test("running twice yields byte-identical output", async () => {
-    const exporter = new Exporter(fsp, createRenderer());
+    const exporter = new Exporter(fsp, createRenderer(createDefaultRuntime()));
     await exporter.exportAll({ data: DATA, outputDir });
 
     const path = join(outputDir, "pathway", "skill", "planning.html");
@@ -103,7 +104,7 @@ describe("Exporter", () => {
     await fsp.mkdir(ghostDir, { recursive: true });
     await fsp.writeFile(join(ghostDir, "ghost.html"), "ghost");
 
-    const exporter = new Exporter(fsp, createRenderer());
+    const exporter = new Exporter(fsp, createRenderer(createDefaultRuntime()));
     await exporter.exportAll({ data: DATA, outputDir });
 
     assert.strictEqual(existsSync(join(ghostDir, "ghost.html")), false);

--- a/products/map/test/pipeline.test.js
+++ b/products/map/test/pipeline.test.js
@@ -20,6 +20,7 @@
  */
 
 import { test, describe, beforeEach, afterEach } from "node:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import assert from "node:assert";
 import { mkdtempSync, rmSync } from "node:fs";
 import * as fsp from "node:fs/promises";
@@ -89,7 +90,7 @@ afterEach(() => {
 describe("end-to-end export → resource → graph pipeline", () => {
   test("fit-map export → ResourceProcessor → GraphProcessor → getSubjects('fit:Skill') returns the fixture skill", async () => {
     // 1. Export to a temp knowledge dir
-    const exporter = new Exporter(fsp, createRenderer());
+    const exporter = new Exporter(fsp, createRenderer(createDefaultRuntime()));
     const { errors } = await exporter.exportAll({ data: DATA, outputDir });
     assert.strictEqual(errors.length, 0, "export should produce no errors");
 

--- a/products/map/test/renderer.test.js
+++ b/products/map/test/renderer.test.js
@@ -9,6 +9,7 @@
  */
 
 import { test, describe } from "node:test";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import assert from "node:assert";
 import { MicrodataRdfParser } from "microdata-rdf-streaming-parser";
 
@@ -104,7 +105,7 @@ const CTX = {
 };
 
 describe("Renderer", () => {
-  const renderer = createRenderer();
+  const renderer = createRenderer(createDefaultRuntime());
 
   test("renderSkill emits a complete HTML document with fit:Skill quads", async () => {
     const html = renderer.renderSkill(SKILL, CTX);

--- a/products/outpost/src/agent-runner.js
+++ b/products/outpost/src/agent-runner.js
@@ -16,6 +16,7 @@ export class AgentRunner {
   #fs;
   #proc;
   #clock;
+  #runtime;
 
   /**
    * @param {Object | (() => Object | Promise<{default?: Object}>)} spawn -
@@ -43,6 +44,7 @@ export class AgentRunner {
     this.#fs = runtime.fs;
     this.#proc = runtime.proc;
     this.#clock = runtime.clock;
+    this.#runtime = runtime;
     this.#activeChildren = new Set();
   }
 
@@ -181,14 +183,19 @@ export class AgentRunner {
         spawnArgs,
         env,
         kbPath,
+        this.#runtime,
       );
       this.#activeChildren.add(pid);
 
-      const exitCode = await spawnMod.waitForExit(pid);
+      const exitCode = await spawnMod.waitForExit(
+        pid,
+        undefined,
+        this.#runtime,
+      );
       this.#activeChildren.delete(pid);
 
-      const stdout = spawnMod.readOutput(stdoutFile);
-      const stderr = spawnMod.readOutput(stderrFile);
+      const stdout = spawnMod.readOutput(stdoutFile, this.#runtime);
+      const stderr = spawnMod.readOutput(stderrFile, this.#runtime);
 
       if (exitCode === 0) {
         this.#log(

--- a/products/outpost/src/kb-manager.js
+++ b/products/outpost/src/kb-manager.js
@@ -6,11 +6,10 @@ import { join, dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
-const logger = createLogger("outpost");
-
 /** Manage knowledge base lifecycle including initialization, updates, and settings merging. */
 export class KBManager {
   #fs;
+  #logger;
 
   /**
    * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
@@ -21,6 +20,7 @@ export class KBManager {
     if (!runtime?.fs) throw new Error("runtime.fs is required");
     if (!logFn) throw new Error("logFn is required");
     this.#fs = runtime.fs;
+    this.#logger = createLogger("outpost", runtime);
   }
 
   /**
@@ -74,12 +74,12 @@ export class KBManager {
    */
   async copyBundledFiles(tpl, dest) {
     await this.#fs.copyFile(join(tpl, "CLAUDE.md"), join(dest, "CLAUDE.md"));
-    logger.info(`  Updated CLAUDE.md`);
+    this.#logger.info(`  Updated CLAUDE.md`);
 
     const apmSrc = join(tpl, "apm.yml");
     if (await this.#exists(apmSrc)) {
       await this.#fs.copyFile(apmSrc, join(dest, "apm.yml"));
-      logger.info(`  Updated apm.yml`);
+      this.#logger.info(`  Updated apm.yml`);
     }
 
     await this.mergeSettings(tpl, dest);
@@ -96,7 +96,9 @@ export class KBManager {
       const names = entries.map((d) =>
         sub === "agents" ? d.name.replace(".md", "") : d.name,
       );
-      logger.info(`  Updated ${names.length} ${sub}: ${names.join(", ")}`);
+      this.#logger.info(
+        `  Updated ${names.length} ${sub}: ${names.join(", ")}`,
+      );
     }
   }
 
@@ -141,7 +143,7 @@ export class KBManager {
     if (!(await this.#exists(destPath))) {
       await this.#ensureDir(join(dest, ".claude"));
       await this.#fs.copyFile(src, destPath);
-      logger.info(`  Created settings.json`);
+      this.#logger.info(`  Created settings.json`);
       return;
     }
 
@@ -154,9 +156,9 @@ export class KBManager {
 
     if (added > 0) {
       await this.#writeJSON(destPath, existing);
-      logger.info(`  Updated settings.json (${added} new entries)`);
+      this.#logger.info(`  Updated settings.json (${added} new entries)`);
     } else {
-      logger.info(`  Settings up to date`);
+      this.#logger.info(`  Settings up to date`);
     }
   }
 
@@ -193,7 +195,7 @@ export class KBManager {
 
     await this.copyBundledFiles(templateDir, dest);
 
-    logger.info(
+    this.#logger.info(
       `Knowledge base initialized at ${dest}\n\nNext steps:\n  1. Edit ${dest}/USER.md with your name, email, and domain\n  2. cd ${dest} && npx apm install\n  3. claude`,
     );
     return { ok: true, value: { dest } };
@@ -215,7 +217,7 @@ export class KBManager {
       };
     }
     await this.copyBundledFiles(templateDir, dest);
-    logger.info(`\nKnowledge base updated: ${dest}`);
+    this.#logger.info(`\nKnowledge base updated: ${dest}`);
     return { ok: true, value: { dest } };
   }
 

--- a/products/outpost/src/outpost.js
+++ b/products/outpost/src/outpost.js
@@ -22,8 +22,6 @@ import { createCli } from "@forwardimpact/libcli";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { isoTimestamp } from "@forwardimpact/libutil";
 
-const logger = createLogger("outpost");
-
 import { StateManager } from "./state-manager.js";
 import { AgentRunner } from "./agent-runner.js";
 import { Scheduler, formatLocalTime } from "./scheduler.js";
@@ -131,6 +129,7 @@ function renderAgentStatus(name, agent, s, kbMissing) {
  */
 export async function run(runtime, version) {
   const { fs, proc, clock } = runtime;
+  const logger = createLogger("outpost", runtime);
 
   /**
    * Async existence check via the one fs surface this module uses.
@@ -401,7 +400,7 @@ export async function run(runtime, version) {
   }
 
   // --- CLI entry point -------------------------------------------------------
-  const cli = createCli(buildDefinition(version));
+  const cli = createCli(buildDefinition(version), { runtime });
   const parsed = cli.parse(proc.argv.slice(2));
   if (!parsed) return 0;
 

--- a/products/outpost/src/socket-server.js
+++ b/products/outpost/src/socket-server.js
@@ -5,8 +5,6 @@
 import { createServer } from "node:net";
 import { createConnection } from "node:net";
 import { createLogger } from "@forwardimpact/libtelemetry";
-
-const logger = createLogger("outpost");
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { computeNextWakeAt, nowFromClock } from "./scheduler.js";
@@ -326,6 +324,7 @@ export class SocketServer {
 export async function requestShutdown(socketPath, runtime) {
   if (!runtime?.fsSync) throw new Error("runtime.fsSync is required");
   if (!runtime?.clock) throw new Error("runtime.clock is required");
+  const logger = createLogger("outpost", runtime);
   if (!runtime.fsSync.existsSync(socketPath)) {
     logger.info("Daemon not running (no socket).");
     return false;

--- a/products/pathway/bin/fit-pathway.js
+++ b/products/pathway/bin/fit-pathway.js
@@ -264,7 +264,8 @@ const definition = {
  * Main CLI entry point
  */
 async function main() {
-  const cli = createCli(definition);
+  const runtime = createDefaultRuntime();
+  const cli = createCli(definition, { runtime });
   const parsed = cli.parse(process.argv.slice(2));
   if (!parsed) process.exit(0);
 
@@ -275,8 +276,6 @@ async function main() {
     cli.showHelp();
     process.exit(0);
   }
-
-  const runtime = createDefaultRuntime();
 
   let dataDir;
   if (values.data) {
@@ -322,7 +321,7 @@ async function main() {
 
   try {
     const loader = createDataLoader(runtime);
-    const templateLoader = createTemplateLoader(TEMPLATE_DIR);
+    const templateLoader = createTemplateLoader(TEMPLATE_DIR, runtime);
 
     const data = await loader.loadAndValidate(dataDir);
 

--- a/products/pathway/src/commands/agent-io.js
+++ b/products/pathway/src/commands/agent-io.js
@@ -16,8 +16,6 @@ import { formatTeamInstructions } from "../formatters/agent/team-instructions.js
 import { formatSuccess } from "@forwardimpact/libcli";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
-const logger = createLogger("pathway");
-
 /**
  * Async file-existence check over the injected async fs surface. Keeps this
  * module on a single fs surface (async only) per spec § Scope / design
@@ -51,6 +49,7 @@ async function ensureDir(filePath, runtime) {
  * @param {Object} claudeSettings - Settings loaded from data
  */
 export async function generateClaudeSettings(baseDir, claudeSettings, runtime) {
+  const logger = createLogger("pathway", runtime);
   const settingsPath = join(baseDir, ".claude", "settings.json");
 
   let settings = {};
@@ -77,6 +76,7 @@ export async function generateClaudeSettings(baseDir, claudeSettings, runtime) {
  * @param {Object} vscodeSettings - Settings loaded from data
  */
 export async function generateVscodeSettings(baseDir, vscodeSettings, runtime) {
+  const logger = createLogger("pathway", runtime);
   if (!vscodeSettings || Object.keys(vscodeSettings).length === 0) return;
 
   const settingsPath = join(baseDir, ".vscode", "settings.json");
@@ -105,6 +105,7 @@ export async function generateVscodeSettings(baseDir, vscodeSettings, runtime) {
  * @param {string} template - Mustache template for agent profile
  */
 export async function writeProfile(profile, baseDir, template, runtime) {
+  const logger = createLogger("pathway", runtime);
   const profilePath = join(baseDir, ".claude", "agents", profile.filename);
   const profileContent = formatAgentProfile(profile, template);
   await ensureDir(profilePath, runtime);
@@ -128,6 +129,7 @@ export async function writeTeamInstructions(
   template,
   runtime,
 ) {
+  const logger = createLogger("pathway", runtime);
   const content = formatTeamInstructions(
     teamInstructions,
     orgSection,
@@ -160,6 +162,7 @@ export async function writeSkillReferences(
   template,
   runtime,
 ) {
+  const logger = createLogger("pathway", runtime);
   const refDir = join(skillDir, "references");
   await runtime.fs.rm(refDir, { recursive: true, force: true });
   if (!references || references.length === 0) return 0;
@@ -184,6 +187,7 @@ export async function writeSkillReferences(
  * @param {import('@forwardimpact/libutil/runtime').Runtime} runtime - Injected collaborators
  */
 export async function writeSkills(skills, baseDir, templates, runtime) {
+  const logger = createLogger("pathway", runtime);
   let fileCount = 0;
   for (const skill of skills) {
     const skillDir = join(baseDir, ".claude", "skills", skill.dirname);

--- a/products/pathway/src/commands/build-bundle.js
+++ b/products/pathway/src/commands/build-bundle.js
@@ -11,8 +11,6 @@ import { join } from "path";
 import Mustache from "mustache";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
-const logger = createLogger("pathway");
-
 /**
  * Generate distribution bundle (bundle.tar.gz + install.sh)
  * @param {Object} params
@@ -33,6 +31,7 @@ export async function generateBundle({
   templatesDir,
   runtime,
 }) {
+  const logger = createLogger("pathway", runtime);
   logger.info("📦 Generating distribution bundle...");
 
   const standardTitle = standard.title || "Engineering Pathway";

--- a/products/pathway/src/commands/build-packs.js
+++ b/products/pathway/src/commands/build-packs.js
@@ -19,7 +19,6 @@ import { join } from "path";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { createDataLoader } from "@forwardimpact/map/loader";
 
-const logger = createLogger("pathway");
 import { createTemplateLoader } from "@forwardimpact/libtemplate";
 import {
   generateAgentProfile,
@@ -222,13 +221,14 @@ export async function generatePacks({
   templatesDir,
   runtime,
 }) {
+  const logger = createLogger("pathway", runtime);
   logger.info("📦 Generating agent/skill packs...");
 
   const normalizedSiteUrl = siteUrl.replace(/\/$/, "");
   const standardTitle = standard.title || "Engineering Pathway";
 
   const loader = createDataLoader(runtime);
-  const templateLoader = createTemplateLoader(templatesDir);
+  const templateLoader = createTemplateLoader(templatesDir, runtime);
 
   const data = await loader.loadAndValidate(dataDir);
   const agentData = await loader.loadAgentData(dataDir);
@@ -280,12 +280,13 @@ export async function generatePacks({
   });
 
   const builder = new PackBuilder({
-    stager: new PackStager(),
+    stager: new PackStager({ runtime }),
     emitters: {
-      tar: new TarEmitter(),
-      git: new GitEmitter(),
-      disc: new DiscEmitter(),
+      tar: new TarEmitter({ runtime }),
+      git: new GitEmitter({ runtime }),
+      disc: new DiscEmitter({ runtime }),
     },
+    runtime,
   });
 
   const { packs } = await builder.build({ combinations, outputDir, version });

--- a/products/pathway/src/commands/build.js
+++ b/products/pathway/src/commands/build.js
@@ -15,7 +15,6 @@ import { createLogger } from "@forwardimpact/libtelemetry";
 import { createIndexGenerator } from "@forwardimpact/map/index-generator";
 import { createDataLoader } from "@forwardimpact/map/loader";
 
-const logger = createLogger("pathway");
 import { generateBundle } from "./build-bundle.js";
 import { generatePacks } from "./build-packs.js";
 
@@ -66,6 +65,7 @@ const PUBLIC_ASSETS = [
 const ROOT_ASSETS = ["templates"];
 
 async function copyAssets(srcDir, assetNames, outputDir, runtime) {
+  const logger = createLogger("pathway", runtime);
   for (const asset of assetNames) {
     const src = join(srcDir, asset);
     const dest = join(outputDir, asset);
@@ -86,6 +86,7 @@ async function copyAssets(srcDir, assetNames, outputDir, runtime) {
  * @param {Object} params.options - Command options
  */
 export async function runBuildCommand({ dataDir, options, runtime }) {
+  const logger = createLogger("pathway", runtime);
   const outputDir = options.output || join(runtime.proc.cwd(), "public");
   const clean = options.clean !== false;
 

--- a/products/pathway/src/commands/dev.js
+++ b/products/pathway/src/commands/dev.js
@@ -12,8 +12,6 @@ import { createLogger } from "@forwardimpact/libtelemetry";
 import { createIndexGenerator } from "@forwardimpact/map/index-generator";
 import { createDataLoader } from "@forwardimpact/map/loader";
 
-const logger = createLogger("pathway");
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const publicDir = join(__dirname, "..");
@@ -176,6 +174,7 @@ function resolveRoute(pathname, routes) {
  * @param {Object} params.options - Command options
  */
 export async function runDevCommand({ dataDir, options, runtime }) {
+  const logger = createLogger("pathway", runtime);
   const port = options.port || 3000;
   const version = await resolveVersion(runtime);
 

--- a/products/pathway/src/commands/serve.js
+++ b/products/pathway/src/commands/serve.js
@@ -15,8 +15,6 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import { createLogger } from "@forwardimpact/libtelemetry";
 
-const logger = createLogger("pathway");
-
 /**
  * Run the serve command.
  * @param {Object} params
@@ -24,6 +22,7 @@ const logger = createLogger("pathway");
  * @param {Object} params.options - CLI options (port, host)
  */
 export async function runServeCommand({ dir, options, runtime }) {
+  const logger = createLogger("pathway", runtime);
   const port = Number(options.port) || 3000;
   const host = options.host || "0.0.0.0";
 

--- a/products/pathway/src/commands/update.js
+++ b/products/pathway/src/commands/update.js
@@ -12,8 +12,6 @@ import { tmpdir } from "os";
 import { createLogger } from "@forwardimpact/libtelemetry";
 import { createDataLoader } from "@forwardimpact/map/loader";
 
-const logger = createLogger("pathway");
-
 const BASE_DIR = join(homedir(), ".fit", "data");
 const INSTALL_DIR = join(BASE_DIR, "pathway");
 
@@ -31,6 +29,7 @@ export async function runUpdateCommand({
   options,
   runtime,
 }) {
+  const logger = createLogger("pathway", runtime);
   // Verify we have a home-directory installation
   try {
     await runtime.fs.access(INSTALL_DIR);

--- a/products/pathway/test/agent-baseline.integration.test.js
+++ b/products/pathway/test/agent-baseline.integration.test.js
@@ -46,7 +46,10 @@ function silent(fn) {
 async function runAgent(dataDir) {
   const outputDir = mkdtempSync(join(tmpdir(), "agent-baseline-out-"));
   const loader = createDataLoader(createDefaultRuntime());
-  const templateLoader = createTemplateLoader(templatesDir);
+  const templateLoader = createTemplateLoader(
+    templatesDir,
+    createDefaultRuntime(),
+  );
   const data = await loader.loadAllData(dataDir);
   await silent(() =>
     runAgentCommand({

--- a/products/pathway/test/agent-command.integration.test.js
+++ b/products/pathway/test/agent-command.integration.test.js
@@ -108,7 +108,10 @@ async function runAgent(work) {
   const dataDir = join(work, "data");
   const outputDir = join(work, "out");
   const loader = createDataLoader(createDefaultRuntime());
-  const templateLoader = createTemplateLoader(templatesDir);
+  const templateLoader = createTemplateLoader(
+    templatesDir,
+    createDefaultRuntime(),
+  );
   const data = await loader.loadAllData(dataDir);
   await silent(() =>
     runAgentCommand({

--- a/products/pathway/test/agent-level.integration.test.js
+++ b/products/pathway/test/agent-level.integration.test.js
@@ -48,7 +48,10 @@ function stageDataDir({ stripOrgContext = true } = {}) {
 
 async function runAgent({ dataDir, args, options, outputDir = null }) {
   const loader = createDataLoader(createDefaultRuntime());
-  const templateLoader = createTemplateLoader(templatesDir);
+  const templateLoader = createTemplateLoader(
+    templatesDir,
+    createDefaultRuntime(),
+  );
   const data = await loader.loadAllData(dataDir);
   const opts = { ...options };
   if (outputDir) opts.output = outputDir;

--- a/products/pathway/test/build-packs.integration.test.js
+++ b/products/pathway/test/build-packs.integration.test.js
@@ -360,6 +360,7 @@ describe("generatePacks", () => {
     const loader = createDataLoader(createDefaultRuntime());
     const templateLoader = createTemplateLoader(
       join(__dirname, "..", "templates"),
+      createDefaultRuntime(),
     );
     const data = await loader.loadAllData(starterDir);
 

--- a/products/pathway/test/serve.integration.test.js
+++ b/products/pathway/test/serve.integration.test.js
@@ -5,6 +5,9 @@ import { tmpdir } from "os";
 import { execFileSync, spawn } from "child_process";
 import { existsSync } from "fs";
 import { GitEmitter, PackStager } from "@forwardimpact/libpack";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+const _packRuntime = createDefaultRuntime();
 
 const CLEAN_ENV = Object.fromEntries(
   Object.entries(process.env).filter(([k]) => !k.startsWith("GIT_")),
@@ -17,8 +20,8 @@ async function makeTempDir() {
 async function buildMinimalSite() {
   const siteDir = await makeTempDir();
 
-  const stager = new PackStager();
-  const emitter = new GitEmitter();
+  const stager = new PackStager({ runtime: _packRuntime });
+  const emitter = new GitEmitter({ runtime: _packRuntime });
 
   const fullDir = join(siteDir, "_staging");
   const apmDir = join(siteDir, "_staging-apm");

--- a/products/summit/bin/fit-summit.js
+++ b/products/summit/bin/fit-summit.js
@@ -268,7 +268,8 @@ const definition = {
 };
 
 async function main() {
-  const cli = createCli(definition);
+  const runtime = createDefaultRuntime();
+  const cli = createCli(definition, { runtime });
   const parsed = cli.parse(process.argv.slice(2));
   if (!parsed) process.exit(0);
 
@@ -287,7 +288,6 @@ async function main() {
   }
 
   try {
-    const runtime = createDefaultRuntime();
     const dataDir = resolveDataDir(values, runtime);
     const data = await loadMapData(dataDir, runtime);
     await handler({ data, args, options: values, dataDir, config, runtime });

--- a/scripts/check-ambient-deps.deny.yml
+++ b/scripts/check-ambient-deps.deny.yml
@@ -12,8 +12,6 @@
 # outlive 1370 are catalogued in the spec teardown ledger).
 libraries/libutil/src/extractor.js:
   - import:fs
-libraries/libutil/src/finder.js:
-  - import:fs
 libraries/libutil/src/index.js:
   - import:fs
 libraries/libutil/src/retry.js:

--- a/scripts/env-setup.js
+++ b/scripts/env-setup.js
@@ -9,6 +9,7 @@ import {
 } from "@forwardimpact/libsecret";
 import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 /**
  * Unified bootstrap script.
@@ -35,7 +36,8 @@ async function main() {
     },
   });
 
-  const get = (key, gen) => getOrGenerateSecret(key, gen);
+  const runtime = createDefaultRuntime();
+  const get = (key, gen) => getOrGenerateSecret(key, gen, ".env", runtime);
 
   // Generate / read the Supabase JWT secret first; the anon and
   // service-role keys are HMAC-signed against it.
@@ -54,13 +56,13 @@ async function main() {
     [
       "SUPABASE_ANON_KEY",
       await get("SUPABASE_ANON_KEY", () =>
-        mintSupabaseAnonKey({ secret: supabaseJwtSecret }),
+        mintSupabaseAnonKey({ secret: supabaseJwtSecret }, runtime),
       ),
     ],
     [
       "SUPABASE_SERVICE_ROLE_KEY",
       await get("SUPABASE_SERVICE_ROLE_KEY", () =>
-        mintSupabaseServiceRoleKey({ secret: supabaseJwtSecret }),
+        mintSupabaseServiceRoleKey({ secret: supabaseJwtSecret }, runtime),
       ),
     ],
     [
@@ -83,7 +85,7 @@ async function main() {
     return;
   }
 
-  for (const [k, v] of entries) await updateEnvFile(k, v);
+  for (const [k, v] of entries) await updateEnvFile(k, v, ".env", runtime);
   for (const [k] of entries) console.log(`${k} is set in .env`);
 }
 

--- a/services/bridge/index.js
+++ b/services/bridge/index.js
@@ -33,14 +33,24 @@ export class BridgeService extends BridgeBase {
     super(config);
     if (!clock) throw new Error("clock is required");
     this.#clock = clock;
-    this.#discussions = new BufferedIndex(storage, "discussions.jsonl", {
-      flush_interval: config.discussion_flush_interval_ms,
-      max_buffer_size: config.discussion_max_buffer_size,
-    });
-    this.#origins = new BufferedIndex(storage, "origins.jsonl", {
-      flush_interval: config.origin_flush_interval_ms,
-      max_buffer_size: config.origin_max_buffer_size,
-    });
+    this.#discussions = new BufferedIndex(
+      storage,
+      "discussions.jsonl",
+      {
+        flush_interval: config.discussion_flush_interval_ms,
+        max_buffer_size: config.discussion_max_buffer_size,
+      },
+      { clock: this.#clock },
+    );
+    this.#origins = new BufferedIndex(
+      storage,
+      "origins.jsonl",
+      {
+        flush_interval: config.origin_flush_interval_ms,
+        max_buffer_size: config.origin_max_buffer_size,
+      },
+      { clock: this.#clock },
+    );
     this.#pendingDispatches = new BufferedIndex(
       storage,
       "pending_dispatches.jsonl",
@@ -48,11 +58,17 @@ export class BridgeService extends BridgeBase {
         flush_interval: config.pending_flush_interval_ms ?? 1_000,
         max_buffer_size: 100,
       },
+      { clock: this.#clock },
     );
-    this.#inbox = new BufferedIndex(storage, "inbox.jsonl", {
-      flush_interval: config.discussion_flush_interval_ms,
-      max_buffer_size: config.discussion_max_buffer_size,
-    });
+    this.#inbox = new BufferedIndex(
+      storage,
+      "inbox.jsonl",
+      {
+        flush_interval: config.discussion_flush_interval_ms,
+        max_buffer_size: config.discussion_max_buffer_size,
+      },
+      { clock: this.#clock },
+    );
     this.#inboxSeqs = new Map();
     this.#conversationTtlMs = config.conversation_ttl_ms;
     this.#originTtlMs = config.origin_ttl_ms;
@@ -238,7 +254,6 @@ export class BridgeService extends BridgeBase {
     return evicted;
   }
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: three-index sweep with eviction and flush
   async #sweep(now) {
     await this.#discussions.loadData();
     await this.#origins.loadData();

--- a/services/bridge/server.js
+++ b/services/bridge/server.js
@@ -20,13 +20,14 @@ const config = await createServiceConfig("bridge", {
 });
 
 // Initialize observability
-const logger = createLogger("bridge");
+const runtime = createDefaultRuntime();
+const logger = createLogger("bridge", runtime);
 const tracer = await createTracer("bridge");
 
 const storage = createStorage("bridges");
-const { clock } = createDefaultRuntime();
+const { clock } = runtime;
 
 const service = new BridgeService(config, { storage, logger, tracer, clock });
-const server = new Server(service, config, logger, tracer);
+const server = new Server(service, config, { logger, tracer, runtime });
 
 await server.start();

--- a/services/embedding/package.json
+++ b/services/embedding/package.json
@@ -45,7 +45,8 @@
     "@forwardimpact/libconfig": "^0.1.58",
     "@forwardimpact/libpreflight": "^0.1.0",
     "@forwardimpact/librpc": "^0.1.77",
-    "@forwardimpact/libtelemetry": "^0.1.41"
+    "@forwardimpact/libtelemetry": "^0.1.41",
+    "@forwardimpact/libutil": "^0.1.85"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/services/embedding/server.js
+++ b/services/embedding/server.js
@@ -6,6 +6,7 @@ import { Server } from "@forwardimpact/librpc";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createTracer } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { EmbeddingService } from "./index.js";
 
@@ -14,7 +15,8 @@ const config = await createServiceConfig("embedding", {
   model: "BAAI/bge-small-en-v1.5",
 });
 
-const logger = createLogger("embedding");
+const runtime = createDefaultRuntime();
+const logger = createLogger("embedding", runtime);
 const tracer = await createTracer("embedding");
 
 const backend_port = config.backend_port;
@@ -38,6 +40,6 @@ tei.on("exit", (code, signal) => {
 });
 
 const service = new EmbeddingService(config, backendUrl);
-const server = new Server(service, config, logger, tracer);
+const server = new Server(service, config, { logger, tracer, runtime });
 
 await server.start();

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -117,8 +117,8 @@ export class GhBridgeService {
 
     this.#store = new DiscussionAdapter(discussionClient);
     this.#client = discussionClient;
-    this.#callbacks = new CallbackRegistry();
-    this.#rateLimiter = new RateLimiter();
+    this.#callbacks = new CallbackRegistry({ clock: this.#clock });
+    this.#rateLimiter = new RateLimiter({ clock: this.#clock });
     this.#ack =
       deps.acknowledgement ??
       new Acknowledgement({
@@ -126,6 +126,7 @@ export class GhBridgeService {
         logger,
       });
     this.#dispatcher = new Dispatcher({
+      clock: this.#clock,
       callbacks: this.#callbacks,
       ack: this.#ack,
       store: this.#store,
@@ -139,6 +140,7 @@ export class GhBridgeService {
       }),
     });
     this.#resume = new ResumeScheduler({
+      clock: this.#clock,
       dispatcher: this.#dispatcher,
       store: this.#store,
       logger,
@@ -148,6 +150,7 @@ export class GhBridgeService {
     });
 
     this.#onCallback = createCallbackHandler({
+      clock: this.#clock,
       channel: CHANNEL,
       callbacks: this.#callbacks,
       ack: this.#ack,
@@ -176,7 +179,11 @@ export class GhBridgeService {
       onWebhook: (c) => this.#handleWebhook(c),
       onCallback: (c) => this.#onCallback(c),
       onLinkComplete,
-      onInbox: createInboxHandler({ client: discussionClient, logger }),
+      onInbox: createInboxHandler({
+        client: discussionClient,
+        logger,
+        clock: this.#clock,
+      }),
     });
   }
 
@@ -542,6 +549,7 @@ export class GhBridgeService {
     const existing = await this.#store.loadByChannel(CHANNEL, discussionId);
     if (existing) return existing;
     return newDiscussionContext({
+      clock: this.#clock,
       channel: CHANNEL,
       discussionId,
       participant: {

--- a/services/ghbridge/server.js
+++ b/services/ghbridge/server.js
@@ -20,7 +20,8 @@ const config = await createServiceConfig("ghbridge", {
   app_installation_id: "",
   app_webhook_secret: "",
 });
-const logger = createLogger("ghbridge");
+const runtime = createDefaultRuntime();
+const logger = createLogger("ghbridge", runtime);
 const tracer = await createTracer("ghbridge");
 
 const appAuth = createAppAuth({
@@ -47,7 +48,7 @@ const ghuserClient = new GhuserClient(ghuserConfig, logger, tracer);
 const bridgeConfig = await createServiceConfig("bridge");
 const discussionClient = new BridgeClient(bridgeConfig, logger, tracer);
 
-const { clock } = createDefaultRuntime();
+const { clock } = runtime;
 
 const service = new GhBridgeService(config, {
   logger,

--- a/services/ghbridge/test/resume.test.js
+++ b/services/ghbridge/test/resume.test.js
@@ -24,6 +24,7 @@ function makeConfig() {
 
 async function newService() {
   const dispatches = [];
+  const clock = createMockClock();
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (url, init) => {
     const target = String(url);
@@ -36,7 +37,7 @@ async function newService() {
   const service = new GhBridgeService(makeConfig(), {
     logger: createMockLogger(),
     tracer: createMockTracer(),
-    clock: createMockClock(),
+    clock,
     discussionClient: createStatefulDiscussionClient(),
     verifyWebhook: (s, b, sig) =>
       import("@octokit/webhooks-methods").then((m) => m.verify(s, b, sig)),
@@ -50,6 +51,7 @@ async function newService() {
   return {
     service,
     dispatches,
+    clock,
     restore: () => {
       globalThis.fetch = originalFetch;
     },
@@ -176,7 +178,7 @@ describe("ghbridge resume", () => {
     const token = Object.keys(stored1.pending_callbacks)[0];
     const meta = ctx.service.callbacks.peek(token, { tenant_id: "default" });
 
-    const before = Date.now();
+    const before = ctx.clock.now();
     await postCallback(baseUrl, token, {
       correlation_id: meta.correlationId,
       verdict: "recessed",

--- a/services/ghuser/server.js
+++ b/services/ghuser/server.js
@@ -16,7 +16,8 @@ const config = await createServiceConfig("ghuser", {
   link_base_url: "",
 });
 
-const logger = createLogger("ghuser");
+const runtime = createDefaultRuntime();
+const logger = createLogger("ghuser", runtime);
 const tracer = await createTracer("ghuser");
 const storage = createStorage("ghuser");
 
@@ -25,8 +26,8 @@ const github = createGithubOAuth({
   clientSecret: config.client_secret,
 });
 
-const { clock } = createDefaultRuntime();
-const bindings = new BindingStore(storage);
+const { clock } = runtime;
+const bindings = new BindingStore(storage, { clock });
 const flows = new FlowStore(storage, { clock });
 const grants = new GrantStore(storage, { clock });
 
@@ -37,7 +38,7 @@ const service = new GhuserService(config, {
   github,
   clock,
 });
-const server = new Server(service, config, logger, tracer);
+const server = new Server(service, config, { logger, tracer, runtime });
 
 await server.start();
 

--- a/services/ghuser/src/stores.js
+++ b/services/ghuser/src/stores.js
@@ -13,8 +13,13 @@ export class BindingStore extends BufferedIndex {
    * @param {object} [options]
    * @param {string} [options.indexKey]
    */
-  constructor(storage, { indexKey = "bindings.jsonl" } = {}) {
-    super(storage, indexKey, { flush_interval: 5_000, max_buffer_size: 100 });
+  constructor(storage, { indexKey = "bindings.jsonl", clock } = {}) {
+    super(
+      storage,
+      indexKey,
+      { flush_interval: 5_000, max_buffer_size: 100 },
+      { clock },
+    );
   }
 
   /**
@@ -91,8 +96,13 @@ class TtlStore extends BufferedIndex {
       clock,
     } = {},
   ) {
-    super(storage, indexKey, { flush_interval: 1_000, max_buffer_size: 100 });
     if (!clock) throw new Error("clock is required");
+    super(
+      storage,
+      indexKey,
+      { flush_interval: 1_000, max_buffer_size: 100 },
+      { clock },
+    );
     this.#clock = clock;
     this.#ttlMs = ttlMs;
     this.#sweepTimer = this.#clock.setInterval(

--- a/services/ghuser/test/identity-verification.test.js
+++ b/services/ghuser/test/identity-verification.test.js
@@ -10,7 +10,7 @@ function createService(storage, { getUserId = "12345" } = {}) {
     link_base_url: "http://localhost:3007",
   });
   const clock = createMockClock({ start: Date.now() });
-  const bindings = new BindingStore(storage);
+  const bindings = new BindingStore(storage, { clock });
   return {
     service: new GhuserService(config, {
       bindings,

--- a/services/ghuser/test/persistence.test.js
+++ b/services/ghuser/test/persistence.test.js
@@ -1,4 +1,5 @@
 import { test, describe } from "node:test";
+import { createMockClock } from "@forwardimpact/libmock";
 import assert from "node:assert";
 import { createMockStorage } from "@forwardimpact/libmock/mock";
 import { BindingStore } from "../src/stores.js";
@@ -7,7 +8,7 @@ describe("ghuser persistence (SC#7)", () => {
   test("binding written before restart is readable after fresh start", async () => {
     const storage = createMockStorage();
 
-    const store1 = new BindingStore(storage);
+    const store1 = new BindingStore(storage, { clock: createMockClock() });
     await store1.upsert({
       id: BindingStore.keyOf("teams", "u1"),
       github_user_id: "ghuser-abc",
@@ -18,7 +19,7 @@ describe("ghuser persistence (SC#7)", () => {
     });
     await store1.shutdown();
 
-    const store2 = new BindingStore(storage);
+    const store2 = new BindingStore(storage, { clock: createMockClock() });
     const binding = await store2.loadBinding("teams", "u1");
     assert.ok(binding, "binding survives restart");
     assert.strictEqual(binding.access_token, "ghu_persisted");
@@ -28,7 +29,7 @@ describe("ghuser persistence (SC#7)", () => {
   test("deleted binding is not readable after restart", async () => {
     const storage = createMockStorage();
 
-    const store1 = new BindingStore(storage);
+    const store1 = new BindingStore(storage, { clock: createMockClock() });
     const id = BindingStore.keyOf("teams", "u2");
     await store1.upsert({
       id,
@@ -41,7 +42,7 @@ describe("ghuser persistence (SC#7)", () => {
     await store1.delete(id);
     await store1.shutdown();
 
-    const store2 = new BindingStore(storage);
+    const store2 = new BindingStore(storage, { clock: createMockClock() });
     const binding = await store2.loadBinding("teams", "u2");
     assert.strictEqual(
       binding,

--- a/services/ghuser/test/query-contract.test.js
+++ b/services/ghuser/test/query-contract.test.js
@@ -12,7 +12,7 @@ describe("ghuser query-contract (SC#8)", () => {
       link_base_url: "http://localhost:3007",
     });
     const clock = createMockClock({ start: Date.now() });
-    const bindings = new BindingStore(storage);
+    const bindings = new BindingStore(storage, { clock });
     const service = new GhuserService(config, {
       bindings,
       flows: new FlowStore(storage, { clock }),

--- a/services/ghuser/test/query-linked.test.js
+++ b/services/ghuser/test/query-linked.test.js
@@ -12,7 +12,7 @@ describe("ghuser query-linked (SC#4)", () => {
       link_base_url: "http://localhost:3007",
     });
     const clock = createMockClock({ start: Date.now() });
-    const bindings = new BindingStore(storage);
+    const bindings = new BindingStore(storage, { clock });
     const service = new GhuserService(config, {
       bindings,
       flows: new FlowStore(storage, { clock }),
@@ -48,7 +48,7 @@ describe("ghuser query-linked (SC#4)", () => {
       link_base_url: "http://localhost:3007",
     });
     const clock = createMockClock({ start: Date.now() });
-    const bindings = new BindingStore(storage);
+    const bindings = new BindingStore(storage, { clock });
     const service = new GhuserService(config, {
       bindings,
       flows: new FlowStore(storage, { clock }),

--- a/services/ghuser/test/query-reauth.test.js
+++ b/services/ghuser/test/query-reauth.test.js
@@ -13,7 +13,7 @@ describe("ghuser query-reauth (SC#6)", () => {
       link_base_url: "http://localhost:3007",
     });
     const clock = createMockClock({ start: Date.now() });
-    const bindings = new BindingStore(storage);
+    const bindings = new BindingStore(storage, { clock });
     const service = new GhuserService(config, {
       bindings,
       flows: new FlowStore(storage, { clock }),
@@ -54,7 +54,7 @@ describe("ghuser query-reauth (SC#6)", () => {
       link_base_url: "http://localhost:3007",
     });
     const clock = createMockClock({ start: Date.now() });
-    const bindings = new BindingStore(storage);
+    const bindings = new BindingStore(storage, { clock });
     const service = new GhuserService(config, {
       bindings,
       flows: new FlowStore(storage, { clock }),
@@ -91,7 +91,7 @@ describe("ghuser query-reauth (SC#6)", () => {
       link_base_url: "http://localhost:3007",
     });
     const clock = createMockClock({ start: Date.now() });
-    const bindings = new BindingStore(storage);
+    const bindings = new BindingStore(storage, { clock });
     const service = new GhuserService(config, {
       bindings,
       flows: new FlowStore(storage, { clock }),

--- a/services/ghuser/test/query-unlinked.test.js
+++ b/services/ghuser/test/query-unlinked.test.js
@@ -13,7 +13,7 @@ describe("ghuser query-unlinked (SC#5)", () => {
     });
     const clock = createMockClock({ start: Date.now() });
     const service = new GhuserService(config, {
-      bindings: new BindingStore(storage),
+      bindings: new BindingStore(storage, { clock }),
       flows: new FlowStore(storage, { clock }),
       grants: new GrantStore(storage, { clock }),
       clock,

--- a/services/ghuser/test/smoke.test.js
+++ b/services/ghuser/test/smoke.test.js
@@ -13,7 +13,7 @@ describe("ghuser smoke (SC#1)", () => {
     });
     const clock = createMockClock({ start: Date.now() });
     const service = new GhuserService(config, {
-      bindings: new BindingStore(storage),
+      bindings: new BindingStore(storage, { clock }),
       flows: new FlowStore(storage, { clock }),
       grants: new GrantStore(storage, { clock }),
       clock,

--- a/services/graph/package.json
+++ b/services/graph/package.json
@@ -49,6 +49,7 @@
     "@forwardimpact/libresource": "^0.1.89",
     "@forwardimpact/librpc": "^0.1.77",
     "@forwardimpact/libtelemetry": "^0.1.41",
+    "@forwardimpact/libutil": "^0.1.85",
     "n3": "^2.0.3"
   },
   "devDependencies": {

--- a/services/graph/server.js
+++ b/services/graph/server.js
@@ -6,18 +6,20 @@ import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createGraphIndex } from "@forwardimpact/libgraph";
 import { createTracer } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { GraphService } from "./index.js";
 
 const config = await createServiceConfig("graph");
 
 // Initialize observability
-const logger = createLogger("graph");
+const runtime = createDefaultRuntime();
+const logger = createLogger("graph", runtime);
 const tracer = await createTracer("graph");
 
-const graphIndex = createGraphIndex("graphs");
+const graphIndex = createGraphIndex("graphs", runtime.clock);
 
 const service = new GraphService(config, graphIndex);
-const server = new Server(service, config, logger, tracer);
+const server = new Server(service, config, { logger, tracer, runtime });
 
 await server.start();

--- a/services/map/package.json
+++ b/services/map/package.json
@@ -48,6 +48,7 @@
     "@forwardimpact/librpc": "^0.1.77",
     "@forwardimpact/libtelemetry": "^0.1.30",
     "@forwardimpact/libtype": "^0.1.67",
+    "@forwardimpact/libutil": "^0.1.85",
     "@forwardimpact/map": "^0.15.12",
     "@supabase/supabase-js": "^2.106.2"
   },

--- a/services/map/server.js
+++ b/services/map/server.js
@@ -4,12 +4,14 @@ import "@forwardimpact/libpreflight/node22";
 import { Server, createClient, createTracer } from "@forwardimpact/librpc";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 
 import { MapService } from "./index.js";
 
 const config = await createServiceConfig("map");
-const logger = createLogger("map");
+const runtime = createDefaultRuntime();
+const logger = createLogger("map", runtime);
 const tracer = await createTracer("map");
 
 const supabaseUrl = config.supabaseUrl();
@@ -21,6 +23,6 @@ const supabase = createSupabaseClient(supabaseUrl, supabaseKey, {
 const pathwayClient = await createClient("pathway", logger, tracer);
 
 const service = new MapService(config, { supabase, pathwayClient });
-const server = new Server(service, config, logger, tracer);
+const server = new Server(service, config, { logger, tracer, runtime });
 
 await server.start();

--- a/services/mcp/server.js
+++ b/services/mcp/server.js
@@ -13,7 +13,8 @@ const config = await createServiceConfig("mcp", {
   system_prompt: "",
   tools: "",
 });
-const logger = createLogger("mcp");
+const runtime = createDefaultRuntime();
+const logger = createLogger("mcp", runtime);
 const tracer = await createTracer("mcp");
 
 const graphClient = await createClient("graph", logger, tracer);
@@ -21,7 +22,7 @@ const vectorClient = await createClient("vector", logger, tracer);
 const pathwayClient = await createClient("pathway", logger, tracer);
 const mapClient = await createClient("map", logger, tracer);
 const resourceIndex = createResourceIndex("resources");
-const { clock } = createDefaultRuntime();
+const { clock } = runtime;
 
 const service = createMcpService({
   config,

--- a/services/msbridge/index.js
+++ b/services/msbridge/index.js
@@ -123,8 +123,8 @@ export class MsBridgeService {
     };
 
     this.#store = new DiscussionAdapter(discussionClient);
-    this.#callbacks = new CallbackRegistry();
-    this.#rateLimiter = new RateLimiter();
+    this.#callbacks = new CallbackRegistry({ clock: this.#clock });
+    this.#rateLimiter = new RateLimiter({ clock: this.#clock });
     this.#ack =
       acknowledgement ??
       new Acknowledgement({
@@ -133,6 +133,7 @@ export class MsBridgeService {
         logger,
       });
     this.#dispatcher = new Dispatcher({
+      clock: this.#clock,
       callbacks: this.#callbacks,
       ack: this.#ack,
       store: this.#store,
@@ -146,6 +147,7 @@ export class MsBridgeService {
       }),
     });
     this.#resume = new ResumeScheduler({
+      clock: this.#clock,
       dispatcher: this.#dispatcher,
       store: this.#store,
       logger,
@@ -155,6 +157,7 @@ export class MsBridgeService {
     });
 
     this.#onCallback = createCallbackHandler({
+      clock: this.#clock,
       channel: CHANNEL,
       callbacks: this.#callbacks,
       ack: this.#ack,
@@ -186,7 +189,11 @@ export class MsBridgeService {
       ),
       onCallback: (c) => this.#onCallback(c),
       onLinkComplete,
-      onInbox: createInboxHandler({ client: discussionClient, logger }),
+      onInbox: createInboxHandler({
+        client: discussionClient,
+        logger,
+        clock: this.#clock,
+      }),
     });
   }
 
@@ -485,6 +492,7 @@ export class MsBridgeService {
     const existing = await this.#store.loadByChannel(CHANNEL, threadId);
     if (existing) return existing;
     return newDiscussionContext({
+      clock: this.#clock,
       channel: CHANNEL,
       discussionId: threadId,
       participant: {

--- a/services/msbridge/server.js
+++ b/services/msbridge/server.js
@@ -12,7 +12,8 @@ const config = await createServiceConfig("msbridge", {
   github_repo: "",
   callback_base_url: "",
 });
-const logger = createLogger("msbridge");
+const runtime = createDefaultRuntime();
+const logger = createLogger("msbridge", runtime);
 const tracer = await createTracer("msbridge");
 
 const { GhuserClient, BridgeClient } = clients;
@@ -21,7 +22,7 @@ const ghuserClient = new GhuserClient(ghuserConfig, logger, tracer);
 const bridgeConfig = await createServiceConfig("bridge");
 const discussionClient = new BridgeClient(bridgeConfig, logger, tracer);
 
-const { clock } = createDefaultRuntime();
+const { clock } = runtime;
 
 const service = new MsBridgeService(config, {
   logger,

--- a/services/oauth/package.json
+++ b/services/oauth/package.json
@@ -45,7 +45,8 @@
     "@forwardimpact/libpreflight": "^0.1.0",
     "@forwardimpact/librpc": "^0.1.99",
     "@forwardimpact/libtelemetry": "^0.1.42",
-    "@forwardimpact/libtype": "^0.1.0"
+    "@forwardimpact/libtype": "^0.1.0",
+    "@forwardimpact/libutil": "^0.1.85"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/services/oauth/server.js
+++ b/services/oauth/server.js
@@ -4,6 +4,7 @@ import "@forwardimpact/libpreflight/node22";
 import { createClient } from "@forwardimpact/librpc";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createLogger } from "@forwardimpact/libtelemetry";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { createOauthService } from "./index.js";
 
 const config = await createServiceConfig("oauth", {
@@ -11,7 +12,8 @@ const config = await createServiceConfig("oauth", {
   issuer: "",
 });
 
-const logger = createLogger("oauth");
+const runtime = createDefaultRuntime();
+const logger = createLogger("oauth", runtime);
 const providerClient = await createClient(config.provider, logger);
 
 const service = createOauthService({ config, logger, providerClient });

--- a/services/pathway/server.js
+++ b/services/pathway/server.js
@@ -9,7 +9,6 @@ import { Finder } from "@forwardimpact/libutil";
 import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { homedir } from "os";
 import { join } from "path";
-import fs from "fs/promises";
 
 import { PathwayService } from "./index.js";
 
@@ -17,14 +16,18 @@ const config = await createServiceConfig("pathway", {
   data_dir: "",
 });
 
+// The service entry point is a legitimate construction site for the
+// production runtime; it threads the bag to every collaborator below.
+const runtime = createDefaultRuntime();
+
 // Initialize observability
-const logger = createLogger("pathway");
+const logger = createLogger("pathway", runtime);
 const tracer = await createTracer("pathway");
 
 // Resolve the pathway data directory using the same upward-walk + HOME
 // fallback rules as fit-pathway. SERVICE_PATHWAY_DATA_DIR (picked up by
 // libconfig and exposed as config.data_dir) overrides the discovery.
-const finder = new Finder(fs, logger, process);
+const finder = new Finder({ ...runtime, logger });
 const data_dir = config.data_dir
   ? String(config.data_dir)
   : join(finder.findData("data", homedir()), "pathway");
@@ -33,9 +36,8 @@ const data_dir = config.data_dir
 // loadAllData drops `human` from each skill (loader.js:102-127) while
 // loadSkillsWithAgentData spreads the full raw skill, which is the shape
 // generateAgentProfile walks. Both are required.
-// createDataLoader requires an injected runtime; the service entry point is a
-// legitimate construction site for the production runtime.
-const loader = createDataLoader(createDefaultRuntime());
+// createDataLoader requires an injected runtime; reuse the bag built above.
+const loader = createDataLoader(runtime);
 const data = await loader.loadAllData(data_dir);
 const agentData = await loader.loadAgentData(data_dir);
 const skillsWithAgent = await loader.loadSkillsWithAgentData(data_dir);
@@ -45,6 +47,6 @@ const service = new PathwayService(config, {
   agentData,
   skillsWithAgent,
 });
-const server = new Server(service, config, logger, tracer);
+const server = new Server(service, config, { logger, tracer, runtime });
 
 await server.start();

--- a/services/tenancy/server.js
+++ b/services/tenancy/server.js
@@ -15,11 +15,12 @@ const logger = createLogger("tenancy");
 const tracer = await createTracer("tenancy");
 const storage = createStorage("tenancy");
 
-const { clock } = createDefaultRuntime();
+const runtime = createDefaultRuntime();
+const { clock } = runtime;
 const tenants = new TenantStore(storage, { clock });
 
 const service = new TenancyService(config, { tenants });
-const server = new Server(service, config, logger, tracer);
+const server = new Server(service, config, { logger, tracer, runtime });
 
 await server.start();
 

--- a/services/tenancy/src/tenant-store.js
+++ b/services/tenancy/src/tenant-store.js
@@ -35,8 +35,13 @@ export class TenantStore extends BufferedIndex {
    *   `last_active_at` timestamps so tests can use a virtual clock.
    */
   constructor(storage, { indexKey = "tenants.jsonl", clock } = {}) {
-    super(storage, indexKey, { flush_interval: 5_000, max_buffer_size: 100 });
     if (!clock) throw new Error("clock is required");
+    super(
+      storage,
+      indexKey,
+      { flush_interval: 5_000, max_buffer_size: 100 },
+      { clock },
+    );
     this.#clock = clock;
   }
 

--- a/services/trace/package.json
+++ b/services/trace/package.json
@@ -48,7 +48,8 @@
     "@forwardimpact/librpc": "^0.1.77",
     "@forwardimpact/libstorage": "^0.1.53",
     "@forwardimpact/libtelemetry": "^0.1.41",
-    "@forwardimpact/libtype": "^0.1.63"
+    "@forwardimpact/libtype": "^0.1.63",
+    "@forwardimpact/libutil": "^0.1.85"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/services/trace/server.js
+++ b/services/trace/server.js
@@ -5,17 +5,20 @@ import { Server } from "@forwardimpact/librpc";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { createStorage } from "@forwardimpact/libstorage";
 import { TraceIndex } from "@forwardimpact/libtelemetry/index/trace.js";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { TraceService } from "./index.js";
 
 const config = await createServiceConfig("trace");
+const runtime = createDefaultRuntime();
+const { clock } = runtime;
 
 // Initialize storage for traces
 const traceStorage = createStorage("traces");
 
 // Create trace index
-const traceIndex = new TraceIndex(traceStorage);
+const traceIndex = new TraceIndex(traceStorage, "index.jsonl", { clock });
 
 const service = new TraceService(config, traceIndex);
-const server = new Server(service, config);
+const server = new Server(service, config, { runtime });
 await server.start();

--- a/services/trace/test/trace.test.js
+++ b/services/trace/test/trace.test.js
@@ -6,6 +6,8 @@ import { TraceService } from "../index.js";
 import { TraceIndex } from "@forwardimpact/libtelemetry/index/trace.js";
 import { trace } from "@forwardimpact/libtype";
 import { createMockConfig, createMockStorage } from "@forwardimpact/libmock";
+import { createMockClock } from "@forwardimpact/libmock";
+const _clock = createMockClock();
 
 describe("trace service", () => {
   describe("TraceService", () => {
@@ -52,7 +54,9 @@ describe("trace service", () => {
       mockStorage = createMockStorage();
 
       // Use real TraceIndex with mock storage for more realistic testing
-      mockTraceIndex = new TraceIndex(mockStorage, "test-traces.jsonl");
+      mockTraceIndex = new TraceIndex(mockStorage, "test-traces.jsonl", {
+        clock: _clock,
+      });
     });
 
     test("creates service instance with trace index", () => {

--- a/services/vector/package.json
+++ b/services/vector/package.json
@@ -50,6 +50,7 @@
     "@forwardimpact/libstorage": "^0.1.53",
     "@forwardimpact/libtelemetry": "^0.1.41",
     "@forwardimpact/libtype": "^0.1.63",
+    "@forwardimpact/libutil": "^0.1.85",
     "@forwardimpact/libvector": "^0.1.68"
   },
   "devDependencies": {

--- a/services/vector/server.js
+++ b/services/vector/server.js
@@ -9,13 +9,15 @@ import { VectorIndex } from "@forwardimpact/libvector/index/vector.js";
 import { createStorage } from "@forwardimpact/libstorage";
 import { createTracer } from "@forwardimpact/librpc";
 import { createLogger } from "@forwardimpact/libtelemetry";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
 import { VectorService } from "./index.js";
 
 const config = await createServiceConfig("vector");
 
 // Initialize observability
-const logger = createLogger("vector");
+const runtime = createDefaultRuntime();
+const logger = createLogger("vector", runtime);
 const tracer = await createTracer("vector");
 
 // gRPC embedding client
@@ -39,6 +41,6 @@ const vectorStorage = createStorage("vectors");
 const vectorIndex = new VectorIndex(vectorStorage);
 
 const service = new VectorService(config, vectorIndex, createEmbeddings);
-const server = new Server(service, config, logger, tracer);
+const server = new Server(service, config, { logger, tracer, runtime });
 
 await server.start();

--- a/specs/1370-ambient-dependencies-to-injected-collaborators/teardown.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/teardown.md
@@ -183,29 +183,58 @@ A future "runtime surface extension" spec should add: a writable
 now-shipped `proc.kill`, closes the libsupervise group-kill). When it lands,
 the items above migrate and this section shrinks to empty.
 
+## Retained composition-root defaults (DX-first decision)
+
+The teardown removes every backward-compat **bridge** and forces consumers to
+inject. It deliberately **retains** `createDefaultRuntime()` at a small set of
+**composition-root factories** — the DI roots where building the production
+runtime is the factory's job, not a fallback a consumer failed to supply.
+These are not BC bridges (no legacy call shape, no per-consumer fallback);
+they are the single place a root constructs the runtime. Retaining them keeps
+the external/idiomatic call sites clean (the alternative threads a runtime
+through dozens of `createServiceConfig("x")` / `createStorage("y")` call sites):
+
+- `libstorage/src/index.js` — `createStorage(prefix, type, runtime?)` builds a
+  default runtime when `runtime` is absent. The legacy bare-process branch
+  (`_procFromLegacy`) **is** removed.
+- `libconfig/src/{config.js,index.js}` — `Config` / `createServiceConfig` etc.
+  build a default runtime when no `{ runtime }` is passed. The legacy
+  bare-process `resolveRuntime` branch **is** removed (and the helper inlined).
+- `librpc/src/index.js` — `createTracer(name)` builds the clock for the Tracer
+  (and thence every Span).
+
+`librpc/src/server.js` — `Server` was **fully injected** rather than retained:
+its trailing positional params (`logger`, `tracer`, `observerFn`, `grpcFn`,
+`authFn`, `runtime`) were collapsed into a single options bag
+(`new Server(service, config, { logger, tracer, runtime, … })`), making
+`runtime` required and dropping the `createDefaultRuntime()` default. Every
+service `server.js` and the librpc tests inject a runtime through the bag.
+
+Service `server.js` entry points and library `bin/` entry points are likewise
+roots: they call `createDefaultRuntime()` once and thread the bag onward. The
+checklist greps below therefore still match these root sites — that is expected
+and correct; the spec's "remaining hits are the live root, not a fallback."
+
 ## Checklist for the `1370/teardown` PR
 
-- [ ] `rg "new Finder\([^{]" libraries/ products/ services/` → 0 outside
-      `libraries/libutil/` (Bridge 1).
-- [ ] `rg "createCli\(" libraries/ products/ services/ | grep -v runtime |
+- [x] `rg "new Finder\([^{]" libraries/ products/ services/` → 0 outside
+      `libraries/libutil/` (Bridge 1). *(One comment reference remains in
+      `libwiki/src/util/wiki-dir.js`; no live call.)*
+- [x] `rg "createCli\(" libraries/ products/ services/ | grep -v runtime |
       grep -v /test/` → 0 (Bridge 2).
-- [ ] `rg "(\?\?|=) *createDefaultRuntime\(\)|(\?\?|=) *createDefaultClock\(\)"
-      libraries/ products/ services/ -g '!**/libutil/src/runtime.js'` → every
-      hit dead (Bridge 3; the `=` alternative catches the `runtime =
-      createDefaultRuntime()` / `clock = createDefaultClock()`
-      default-parameter form that parts 03+ use, which the old `??`-only grep
-      missed. The excluded `libutil/src/runtime.js` is the factory itself —
-      its internal `createDefaultClock()` build step is permanent, not a
-      consumer fallback).
-- [ ] `rg "\?\? process\b|globalThis\.(process|setTimeout|clearTimeout)|getDefaultRuntime"
-      libraries/ products/ services/` → only the foundation-gap residue in
-      `librc/manager.js` remains (Bridge 3 + the NOT-BC section).
-- [ ] `rg "resolveRuntime|_procFromLegacy" libraries/` → 0; the `Logger`
+- [x] `rg "(\?\?|=) *createDefaultRuntime\(\)|(\?\?|=) *createDefaultClock\(\)"
+      libraries/ products/ services/ -g '!**/libutil/src/runtime.js'` → the
+      only remaining hits are the retained composition-root defaults above
+      (libstorage `createStorage`, librpc `createTracer`) plus bin/`server.js`
+      roots; every per-consumer fallback is removed (Bridge 3).
+- [x] `rg "\?\? process\b|globalThis\.(process|setTimeout|clearTimeout)|getDefaultRuntime"
+      libraries/ products/ services/` → only the foundation-gap residue
+      `librc/manager.js` `deps.stdout ?? process.stdout` remains (NOT-BC).
+- [x] `rg "resolveRuntime|_procFromLegacy" libraries/` → 0; the `Logger`
       positional `proc` parameter removed (Bridge 4).
-- [ ] `finder.js` removed from `check-ambient-deps.deny.yml`; `bun run
+- [x] `finder.js` removed from `check-ambient-deps.deny.yml`; `bun run
       invariants` green.
-- [ ] All four bridges' code paths deleted; the NOT-BC residue either migrated
-      (if the runtime-surface-extension spec has landed) or explicitly retained
-      with a tracking reference; `bun run test` green.
+- [x] All four bridges' code paths deleted; the NOT-BC residue explicitly
+      retained with the tracking reference above; `bun run test` green.
 - [ ] STATUS `1370/teardown` → `plan implemented`; master `1370` → `plan
       implemented` once every sub-row reads `plan implemented`.


### PR DESCRIPTION
## Summary

Completes the `1370/teardown` migration unit — removes the one-cycle
backward-compatibility bridges shipped in part 01 now that every consumer has
migrated onto the injected `runtime` bag.

- **Bridge 1 — `Finder`:** collapsed to `new Finder({ fs, fsSync?, proc, logger? })`; deleted the legacy `(fs, logger, process)` positional path and its `node:fs` imports; dropped `finder.js` from the ambient-deps deny-list.
- **Bridge 2 — `createCli`:** `runtime` is now required; removed the global-`process` fallback.
- **Bridge 3 — per-unit defaults:** made the injected `runtime` (or its narrow `clock`/`fs` projection) a required parameter across libbridge, libtelemetry (Logger/Span), libprompt/libtemplate, the synthetic gen/prose/render engines (incl. removing the `fhir-microdata` module-level loader singleton), libterrain, libpack, libindex (+ subclasses), libsecret, libcodegen, libcoaligned, libmacos, librc (dropped the `getDefaultRuntime` singleton), libeval (`globalThis` timers/proc), libconfig bootstrap, and **librpc `Server`** — whose trailing positional params were collapsed into an options bag so `runtime` could be injected required.
- **Bridge 4 — legacy call-shape adapters:** removed libconfig `resolveRuntime`'s bare-process branch (helper inlined), libstorage `_procFromLegacy`, and the libtelemetry `Logger` positional `proc`.
- **Consumers:** every service `server.js` and product CLI/command threads a single root-built `createDefaultRuntime()` onward.

**Retained by design** (documented in `teardown.md`): `createDefaultRuntime()` at composition-root factories (`createStorage`, the libconfig factories, `createTracer`'s clock) — these are DI roots, not consumer fallbacks. The `librc logs()` `deps.fs`/`deps.stdout` streaming path stays as the NOT-BC foundation-gap until a runtime-surface-extension spec lands.

Codegen is unaffected (Server is not templated); `just codegen` produces no diff. Full suite green (3841 pass, 0 fail), `bun run invariants` green.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUkL65DFdV89zaznPGHiVJ)_