### PR TITLE
plan(1370): part-07 gap closure + artifact grounding

### DIFF
--- a/specs/1370-ambient-dependencies-to-injected-collaborators/design-a.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/design-a.md
@@ -29,7 +29,7 @@ one row per library/product (spec § Risks mitigation).
 | `GhClient` | libutil (`src/gh-client.js`) | Typed async methods over `runtime.subprocess`: `prCreate`, `prMerge`, `apiGet`, `apiPost`. |
 | `WikiSync` | libwiki (`src/wiki-sync.js`) | Consolidates pull/rebase/conflict-resolve/push currently spread across `wiki-repo.js`, `commands/sync.js`, and bridge call sites. Consumes `{ runtime, gitClient }`. Constructed once inside `bin/fit-wiki.js` (the same layer that builds `runtime`) and passed to handlers via `cli.dispatch(parsed, { deps: { runtime, wikiSync } })`. |
 | libwiki command handlers | libwiki (`src/commands/<name>.js`) | Per-command files keep today's layout. Each handler signature changes from `(values, args, cli)` to `(ctx)` and reads `ctx.deps.runtime` plus `ctx.deps.wikiSync` (and any other host-injected collaborator the bin chooses to thread). No `LibwikiCommands` class wrapper — the shape matches every other multi-subcommand CLI's dispatched handlers. Handlers return the result envelope below. Spec § Scope enumerated 12 handlers; the implementation covers 13 to match the bin's shipped command set (`fix` post-dates the spec). |
-| `Finder` (refactored) | libutil | Constructor `{ fs, proc }` — logger is **removed** from the constructor. `findUpward` / `findData` use the injected `fs` (the current dead-`fs` bug is fixed). Methods take an optional `{ logger }` per call; default logger is a `runtime.proc`-based stderr logger built inside `createDefaultRuntime`. Only `libutil` ever calls `new Finder(...)`; SC9 holds without escape hatches. |
+| `Finder` (refactored) | libutil | Constructor `{ fs, fsSync?, proc, logger? }` — the injected `fs`/`fsSync` flow through to `findUpward` / `findData` (the dead-`fs` bug is fixed). **Implementation note (2026-06-01):** the logger is a **constructor** field, not the per-call parameter this row first described; the default is a no-op. A site needing a custom logger on the shared `runtime.finder` uses `finder.withLogger(logger)` (added in [plan-a-07.md](plan-a-07.md)), which returns a logger-bound view sharing the same collaborators. Only `libutil` constructs `Finder`; enforced by `scripts/check-collaborator-construction.mjs` ([plan-a-07.md](plan-a-07.md)), which generalises SC9 to the whole DI pattern — no leaf collaborator constructor (`new Finder`, `createDefaultProc/Clock/Subprocess`) outside libutil in production code. The original waves left 6 escape-hatch sites that part-07 collapses. |
 | Entry points (`bin/*.js` **and** `services/*/server.js`) | unchanged paths | Sole construction site for `createDefaultRuntime()`. Sole callers of `runtime.proc.exit`. Bin shims translate handler results to exit codes; service entries call `runtime.proc.exit` only on shutdown signals. **Spec interpretation:** SC3 allow-lists "bin/*.js entry points"; spec § Scope row "products and services" puts services in scope alongside CLIs, so the design reads "bin shims" as "entry points (bin shims + service server.js)" — services are entry points by another name. If reviewers disagree, the spec returns to draft to widen SC3 explicitly. |
 | `scripts/check-ambient-deps.mjs` | scripts/ | Invariant under `bun run invariants`. Reads two JSON files (schemas in Decision 9). Detection is AST-based on constructor parameter destructuring (catches `fs` xor `fsSync` violations) and on direct imports of `node:fs`, `node:child_process`. |
 | `scripts/check-subprocess-in-tests.mjs` | scripts/ | Sibling invariant. Exempts `*.integration.test.js` files (whole-file granularity — mixed files split during their library's migration) and the one-entry-per-binary smoke allow-list. |
@@ -110,9 +110,16 @@ bin shim along with the src modules it drives.
   property reads pass through on every access so token rotation and
   late-binding config work; tests override the fake's backing object),
   `argv` (read-only array — entry-point bins parse it; domain modules
-  should not), `stdout.write`, `stderr.write`, `exit(code)`, `exitCode`
+  should not), `stdout`/`stderr` (**pipeline-grade `Writable`s** as of
+  [plan-a-07.md](plan-a-07.md) — they support `.write(str)` and also serve as
+  `pipeline()` sinks; the original implementation shipped a narrower
+  `{ write }` shim, which blocked `librc logs()`), `exit(code)`, `exitCode`
   setter (libcli sets this directly — the contract carries both `exit` and
-  `exitCode` so libcli's existing pattern survives without a rewrite).
+  `exitCode` so libcli's existing pattern survives without a rewrite). The
+  implementation also grew `kill(pid, signal)` (negative pid = process
+  group), `pid`, `platform`, and `on(event, handler)` during the waves —
+  surfaces the design did not enumerate but the services/supervise migrations
+  required.
 - `runtime.clock` — `now()` (ms); `sleep(ms)` is the primary wait
   primitive (Promise); `setTimeout(fn, ms)` / `clearTimeout(h)` for
   fire-and-forget scheduling (debounce, watchdog) only;
@@ -131,9 +138,12 @@ bin shim along with the src modules it drives.
   for `runSync` only when the call site is a synchronous accessor whose
   caller chain cannot be made async without an unbounded cascade.
 - `runtime.finder` — pre-constructed `Finder` built inside
-  `createDefaultRuntime` (phase 2). Methods accept `{ logger }` per call
-  for sites that want a custom logger; default is a stderr logger built
-  from `runtime.proc.stderr`.
+  `createDefaultRuntime` (phase 2). A site that wants a custom logger calls
+  `runtime.finder.withLogger(logger)` ([plan-a-07.md](plan-a-07.md)) rather
+  than constructing its own `Finder`; the default logger is a no-op. (This
+  row originally described a per-call `{ logger }` parameter that was never
+  implemented — the logger is a constructor field; `withLogger` is the
+  grounded seam.)
 
 ## libmock README and Drift Detection
 
@@ -157,8 +167,10 @@ library's deny-list entries or unrenamed integration tests remain.
 - File-level migration order inside a library — that's the plan's
   per-library section.
 - Third-party SDK wrapping (`@grpc/grpc-js`, `botbuilder`, `@octokit/*`).
-- A `runtime.logger` slot — logger is a per-call concern on Finder
-  methods; other domains pass loggers as domain dependencies.
-- Performance milestones M1/M2/M3 — covered by spec Success Criterion 6.
+- A `runtime.logger` slot — logger is a Finder constructor field, attached to
+  the shared `runtime.finder` via `finder.withLogger(logger)` ([plan-a-07.md](plan-a-07.md));
+  other domains pass loggers as domain dependencies.
+- Performance milestones M1/M2/M3 — **retired** (see [spec § Outcome](spec.md#outcome-post-implementation-reconciliation-2026-06-01));
+  the original framing gated on spec Success Criterion 6.
 
 — Staff Engineer 🛠️

--- a/specs/1370-ambient-dependencies-to-injected-collaborators/plan-a-05-products.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/plan-a-05-products.md
@@ -101,7 +101,10 @@ After every product's PR merges:
 - The product's library blockers (per the per-section table above) are at `plan implemented`.
 - The product's sub-row is at `plan implemented`.
 
-The M3 milestone ([spec § SC6](spec.md#success-criteria)) gates on every products + services sub-row landing.
+The M3 wall-time milestone (spec § SC6) originally gated on every products +
+services sub-row landing. **SC6 is retired** — see
+[spec § Outcome](spec.md#outcome-post-implementation-reconciliation-2026-06-01);
+no sub-row gates on wall time.
 
 ## Libraries used
 

--- a/specs/1370-ambient-dependencies-to-injected-collaborators/plan-a-07.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/plan-a-07.md
@@ -1,0 +1,290 @@
+# Plan 1370 — Part 07: Gap Closure and Accounting Reconciliation
+
+Post-implementation remediation unit. Parts 01–06 + teardown shipped the
+charter, but a post-merge audit surfaced four open items the master `1370`
+row papered over when it advanced to `plan implemented`. This part closes
+them and makes the spec's own artifacts match what shipped. It is the new
+**last** unit; the master `1370` row re-advances to `plan implemented` only
+when `1370/part-07-reconciliation` does (the `kata-release-merge` sub-row
+gate counts it like every other `1370/<unit>` row).
+
+The four items, and how this part disposes of each (dispositions chosen by
+the spec owner, 2026-06-01):
+
+| Gap | Disposition | Steps |
+|---|---|---|
+| **SC9 (+ the general DI pattern)** — `new Finder(` exists outside libutil (2 bins, 1 service entry, 1 pre-runtime bin, 2 test helpers) and the teardown checklist quietly narrowed the check to `new Finder\([^{]` to pass; the same anti-pattern (constructing a collaborator instead of receiving it from the `runtime` bag) also appears as `createDefaultProc().env` in `librpc/src/base.js` | Route every production site through the injected runtime (Finder + the librpc proc read), then enforce the **general** rule — no direct construction of a leaf collaborator (`new Finder`, `createDefaultProc/Clock/Subprocess`) outside libutil — with a real invariant | 1, 2 |
+| **librc `logs()`** — the sole genuine runtime-surface gap left (`runtime.proc.stdout` is a `{ write }` shim, not a pipeline-grade `Writable`; `manager.js` keeps `deps.stdout ?? process.stdout` + a `deps.fs` override) | Extend `runtime.proc.stdout`/`stderr` to pipeline-grade `Writable`s and migrate `logs()` onto the runtime | 3 |
+| **SC6** — the M1/M2/M3 wall-time milestones were never met (`38.5 s` recorded at part-06 in `wiki/staff-engineer-2026-W22.md` vs the `25 s` M3 target; a post-merge audit re-ran the suite at `4144` tests / ~55 s on a 4-core container) yet the master row advanced anyway | Retire the absolute wall-time milestones with a grounded outcome note (retroactive `spec.md` edit, carried in this PR); verify nothing in plan/CI/docs still asserts a 25 s gate | 4 |
+| **Accounting** — `teardown.md` describes libeval/libsupervise as deferred/grandfathered when both fully migrated, and names a "future runtime-surface-extension spec" for capabilities that already shipped | Correct the durable ledger and other artifacts (retroactive edits, carried in this PR); reconcile STATUS | 4, 5 |
+
+This part follows the [§ Migration Recipe](plan-a.md#migration-recipe)
+except Step 2 (golden capture) — it touches no CLI argv/stdout contract (the
+collaborator-construction edits are internal). The `logs()` change is
+covered by a new behavioural test, not by the `fit-rc` golden — that golden
+captures only `help` and `no-command`, so it never exercises `logs`; the
+golden replay in Step 3 only confirms those two cases stay byte-identical.
+
+## Approach
+
+Three small code changes plus a documentation reconciliation. The
+collaborator collapse leans on the fact that
+`findData`/`findUpward`/`findProjectRoot` never read the logger (only
+`createSymlink`/`createPackageSymlinks` do, via `finder.js:163`), so the
+sites that only resolve paths lose nothing by switching to bare
+`runtime.finder`; the one site that logs (codegen's symlink creation) gets a
+`Finder.withLogger(logger)` seam — which also grounds the [design's
+per-call-logger claim](design-a.md#components) to a mechanism that actually
+exists. The librc change implements the exact `proc.stdout` surface extension
+the [teardown ledger](teardown.md) named as required. No
+backward-compat shim: every `new Finder(` and the `logs()` `deps.fs` /
+`deps.stdout` fallbacks are deleted, not wrapped ([§ Clean
+breaks](../../CONTRIBUTING.md#read-do)). librc's `deps.spawn` / `deps.execSync`
+are **not** touched — they are a deliberate DI seam for the svscan fd-redirect
+spawn (see [teardown.md § Residual](teardown.md), not a `logs()` fallback).
+
+## Steps
+
+### Step 1 — Collapse every direct collaborator construction to the injected runtime
+
+The anti-pattern is broader than Finder: a consumer that invokes any of
+libutil's leaf collaborator constructors (`new Finder`, `createDefaultProc`,
+`createDefaultClock`, `createDefaultSubprocess`) hand-rolls a collaborator it
+should destructure off the `runtime` bag. This step fixes the **production**
+instances — the six `new Finder(` sites plus librpc's `createDefaultProc()`
+read — and adds the logger seam the one logging Finder site needs.
+(`createDefaultRuntime()` is the sanctioned composition-root factory and is
+left in place at its 116 root call sites.)
+
+- **Modified:**
+  - `libraries/libutil/src/finder.js` — add `withLogger(logger)` returning a
+    Finder over the same collaborators with the given logger. Because the
+    constructor derives `#existsSync` from `fsSync ?? fs`, the method cannot
+    just copy private fields onto a bare object — store the raw `fs`/`fsSync`
+    on the instance and rebuild via `new Finder({ fs, fsSync, proc, logger })`
+    (identical existence binding, swapped logger).
+  - `services/pathway/server.js:30` — delete `new Finder({ ...runtime, logger })`;
+    call `runtime.finder.findData("data", homedir())` directly (findData does
+    not log, so `logger` was dead).
+  - `libraries/libstorage/bin/fit-storage.js:108` — delete `new Finder(...)`;
+    use `runtime.finder.findUpward(process.cwd(), "data")` (findUpward does
+    not log).
+  - `libraries/libcodegen/bin/fit-codegen.js:379` — there is a **single**
+    `new Finder({ …, logger })` here, constructed in `main()` and threaded
+    into `runCodegen` where it serves both `findProjectRoot` (`:385`) and
+    `createPackageSymlinks` (`:367`). Because that one instance is the only
+    logger consumer in the file, replace it with
+    `runtime.finder.withLogger(logger)` (not bare `runtime.finder`, or the
+    symlink debug logs go silent).
+  - `libraries/libeval/bin/fit-selfedit.js:75` — construct
+    `createDefaultRuntime()` at the top of the security pre-check and use
+    `runtime.finder.findUpward(dirname(absoluteTarget), ".claude/settings.json", 20)`
+    (no ordering constraint forces the lookup before runtime construction).
+  - `libraries/libxmr/test/helpers.js:58`,
+    `libraries/libwiki/test/helpers.js:52` — replace `new Finder(...)` with a
+    finder obtained from a factory: `createDefaultRuntime().finder` when the
+    helper needs real-fs traversal of fixtures, else
+    `createTestRuntime().finder` from libmock.
+  - `libraries/librpc/src/base.js:34-35` — `createAuth(serviceName)` reads
+    `createDefaultProc().env.SERVICE_SECRET`, hand-rolling a throwaway `proc`
+    (the "no ambient-dep smell" comment notwithstanding — it *is* the DI
+    bypass, laundered through the factory). Thread the runtime in:
+    `createAuth(serviceName, runtime)` reading `runtime.proc.env.SERVICE_SECRET`;
+    update its call site (the `Server`/base wiring already carries a `runtime`
+    in its options bag per [teardown.md](teardown.md)), and delete the
+    `createDefaultProc` import.
+  - `libraries/libwiki/src/util/wiki-dir.js:6` — the comment is accurate
+    ("SC9 keeps Finder construction inside libutil") but contains the literal
+    token `new Finder(`, which the SC9 verify grep (and a reader) trips over;
+    reword it to drop the literal call form so the literal-grep verification
+    is unambiguous.
+- **Verify:** `rg "new Finder\(" libraries/ products/ services/` returns
+  matches only under `libraries/libutil/` (spec Success Criterion 9, literal
+  form); `rg "createDefaultProc\(" libraries/ products/ services/ -g '!**/libutil/**'`
+  returns matches only in `test/` files; `bun run test` green for
+  libcodegen/libstorage/libwiki/libxmr/librpc, products/pathway,
+  services/pathway.
+
+### Step 2 — Enforce "no direct collaborator construction" as an invariant
+
+Make the broader DI pattern (not just SC9) mechanically verifiable so it
+cannot regress. The check is deliberately **separate** from
+`check-ambient-deps.mjs`: that checker scans `src/` only and skips `bin/`,
+`test/`, and package-root entry files (they are *allowed* ambient deps),
+whereas every collaborator-construction violation lives in exactly those
+excluded locations — and the rule is a hard no-grandfathering rule, not the
+ambient-deps monotone deny-list model. Reimplementing the small AST walk here
+keeps the two checks' opposing scopes and policies cleanly decoupled.
+
+- **Created:**
+  - `scripts/check-collaborator-construction.mjs` — its own acorn parse + AST
+    walk over `*.js` under `libraries/`, `products/`, `services/`
+    (recursively: `src/`, `bin/`, `test/`, and package-root files; skips
+    `node_modules`/`dist`/`generated`/`tmp`). Flags the four leaf
+    collaborator constructors outside `libraries/libutil/`:
+    - `new Finder(...)` (`NewExpression`, callee `Finder`),
+    - `createDefaultProc(...)`, `createDefaultClock(...)`,
+      `createDefaultSubprocess(...)` (`CallExpression`, callee an `Identifier`
+      of that name).
+
+    `createDefaultRuntime(...)` is **not** flagged (sanctioned
+    composition-root factory). **Prod-strict / test-lenient policy:** for a
+    file under a `test/` directory, only `new Finder(` is flagged (SC9 wants
+    Finder gone everywhere); `createDefaultProc/Clock/Subprocess` are permitted
+    in tests (a test may wire a real collaborator deliberately). For all other
+    files (`src/`, `bin/`, package roots) all four are flagged. No allow-list:
+    the tree is clean after Step 1, so any future hit is a real regression.
+  - `scripts/check-collaborator-construction.test.mjs` — fixtures: `new Finder(`
+    in a non-libutil src path is flagged; the same under `libutil/` is not;
+    `createDefaultClock()` in a `*.test.js` path is **not** flagged but in a
+    `src` path **is**; `createDefaultRuntime()` is never flagged.
+- **Modified:**
+  - `package.json` — two edits so the check runs under `bun run invariants`,
+    matching the existing pattern: (1) add a sub-script
+    `"invariants:check-collaborator-construction": "node scripts/check-collaborator-construction.mjs"`
+    (the `.mjs` checks use the `node` runner, like
+    `invariants:check-ambient-deps`); (2) append
+    `&& bun run invariants:check-collaborator-construction` to the end of the
+    `"invariants"` aggregate `&&`-chain. Without edit (2) the check exists but
+    never runs in CI.
+  - `MONOREPO.md` § Enforcement — describe the check (the pattern: receive
+    collaborators from the `runtime` bag, never construct them outside
+    libutil) and update the closing sentence "All three run under `bun run
+    invariants`" (`MONOREPO.md:231`) to "All four".
+- **Verify:** `bun run invariants` exits 0 on the tree; the regression test
+  passes; a `new Finder(` or a `createDefaultClock()` added under `src/`
+  outside libutil fails CI, while the same `createDefaultClock()` under
+  `test/` does not.
+
+### Step 3 — Make `runtime.proc.stdout`/`stderr` pipeline-grade and migrate `librc logs()`
+
+Implement the writable-stdout surface extension the teardown ledger named,
+then drop librc's two foundation-gap fallbacks.
+
+- **Modified:**
+  - `libraries/libutil/src/runtime.js` — in `createDefaultProc`, replace the
+    `{ write }` shims with `Writable`s that forward chunks to
+    `source.stdout`/`source.stderr` (a `new Writable({ write(c,e,cb){
+    source.stdout.write(c); cb(); } })` wrapper — pipeline-grade as a sink,
+    `.write(str)` still works, `.end()` does not close the real stream).
+    Update the `proc` typedef: `stdout`/`stderr` are pipeline-grade
+    `Writable`s. Import `Writable` from `node:stream` (libutil/src/runtime.js
+    is the allow-listed default-collaborator factory).
+  - `libraries/libmock/src/mock/infra.js` (createMockProcess — note: it lives
+    in `infra.js`, not a `process.js`) — make the `stdout`/`stderr` recorders
+    `Writable` subclasses that retain the existing capture accessor (so current
+    assertions keep working) and accept piped input.
+  - `libraries/libmock/src/mock/fs.js` (createMockFs) — `createReadStream`
+    **already exists** (`:274`, returns a `Readable` over stored content) and
+    so does `createWriteStream` (`:288`); no addition needed. Confirm the
+    existing `createReadStream` yields the configured content for the `logs()`
+    test; extend only if a gap surfaces.
+  - `libraries/librc/src/manager.js` — delete `this.#fs = deps.fs ?? runtime.fsSync`
+    (use `runtime.fsSync.createReadStream`, which the sync surface already
+    exposes — `runtime.fsSync` is the full `node:fs` module, so the old
+    comment claiming it lacks `createReadStream` was always inaccurate); delete
+    `this.#stdout = deps.stdout ?? process.stdout` (use `runtime.proc.stdout`);
+    drop `fs`/`stdout` from the `Dependencies` typedef and the foundation-gap
+    comments at `:62-78`, `:110-112`, `:129-132`. Leave `deps.spawn` /
+    `deps.execSync` untouched.
+  - `libraries/librc/test/{manager-logs,manager-start,manager-stop}.test.js` —
+    all three currently pass an `fs` override through `deps`; once `deps.fs` is
+    gone, route their sync-fs through `createTestRuntime({ fsSync })` instead.
+    The `logs()` test additionally asserts captured `proc.stdout` from the mock
+    `Writable`.
+- **Verify:** `rg "deps\.fs|deps\.stdout|process\.stdout" libraries/librc/src/manager.js`
+  returns zero; `logs()` test runs in-process with no real `process.stdout`;
+  `bun run scripts/capture-cli-golden.mjs --verify fit-rc` exits 0;
+  `bun run test` green across all `runtime.proc.stdout` consumers (full
+  suite — the proc surface is monorepo-wide).
+
+### Step 4 — Land the retroactive artifact corrections and verify no stale references
+
+The artifact edits (SC6 retirement, SC9 reframe, teardown de-staling,
+design grounding, plan index) ship in this PR's non-code commits. This step
+verifies they are internally consistent and that no machine-checked surface
+still asserts a retired gate.
+
+- **Modified (carried in this PR):** `spec.md` (SC6, SC9, Risks, § Outcome),
+  `design-a.md` (Finder logger seam; surface-extensions-shipped note; retire
+  the `M1/M2/M3` Out-of-Scope line and the per-call-logger Out-of-Scope line),
+  `teardown.md` (libeval/libsupervise corrected; residue shrunk to the
+  plan-closed `logs()` item; svscan-spawn noted as DI-clean-but-not-unified),
+  `plan-a.md` (Migration Order index + master-row re-advance note; **retire
+  the § Performance milestone tracking M1/M2/M3 gate**; reconcile the
+  `check-ambient-deps.deny.json` → `.deny.yml` filename), `plan-a-05-products.md`
+  (the "M3 milestone gates …" line). All SC6-milestone language across the
+  spec dir must read as **retired**, not live.
+- **Verify:** searching the spec dir, `scripts/`, and `package.json` for a
+  live `25 s` / `M3` wall-time gate surfaces only the retired-with-rationale
+  prose in `spec.md`/`plan-a.md` (no CI assertion, no skill grep on the
+  narrowed `new Finder` form); the teardown checklist greps all return their
+  stated counts.
+
+### Step 5 — STATUS reconciliation
+
+Reflect the honest state: the spec has approved-but-unimplemented remediation
+work again.
+
+- **Modified:** `wiki/STATUS.md` — add `1370/part-07-reconciliation\tplan\tapproved`;
+  set master `1370` back to `plan approved` (a sub-row is no longer
+  implemented, so per the file header the master cannot read `implemented`).
+  On this part's implementation, both rows advance to `plan implemented`.
+- **Verify:** `wiki/STATUS.md` parses against `^\d{4}(/[a-z0-9-]+)?$`;
+  `1370/teardown` stays `plan implemented`.
+
+## Per-unit verification
+
+| Check | Command | Pass condition |
+|---|---|---|
+| Finder singleton | `rg "new Finder\(" libraries/ products/ services/` | matches only under `libraries/libutil/` |
+| Prod proc construction | `rg "createDefaultProc\(" libraries/ products/ services/ -g '!**/libutil/**'` | matches only in `test/` files |
+| Invariants | `bun run invariants` | exit 0; `check-collaborator-construction` green (and fails on a planted `src/` violation) |
+| librc residue | `rg "deps\.fs\|deps\.stdout\|process\.stdout" libraries/librc/src/manager.js` | zero matches |
+| Golden replay | `bun run scripts/capture-cli-golden.mjs --verify fit-rc` | exit 0 (bytes match) |
+| Full suite | `bun run test` | `0 fail`, `0 errors` (proc + collaborator changes are monorepo-wide) |
+
+## Libraries used
+
+Libraries used: libutil (Finder.withLogger, runtime proc Writable), libmock
+(createMockProcess Writable, createMockFs createReadStream), librc
+(ServiceManager.logs migration), librpc (createAuth runtime injection).
+
+## Risks
+
+- **`runtime.proc.stdout` widening is monorepo-wide.** Every consumer of
+  `proc.stdout`/`stderr` now receives a `Writable` instead of a `{ write }`
+  object. The change is backward-compatible (a `Writable` has `.write`), but
+  a test asserting the exact shape of `proc.stdout`, or code reading
+  `.write()`'s boolean return for backpressure, can shift. Mitigation: the
+  Step 3 verification runs the full suite, not just librc.
+- **Mock capture-accessor drift.** Making `createMockProcess` stdout a
+  `Writable` must preserve whatever accessor existing tests read (`.calls`,
+  `.written`, etc.). The implementer reads the current mock and keeps the
+  accessor name; the runtime-completeness test does not cover capture shape,
+  so a silent break would only surface in consumer tests — run them.
+- **codegen symlink logger.** Whether `fit-codegen:367`'s finder consumes a
+  live logger determines if `withLogger` is needed there or the site collapses
+  to bare `runtime.finder`. The implementer confirms by reading the call site
+  before choosing; getting it wrong silently drops symlink debug logs (not a
+  test failure). Mitigation: grep `createSymlink`/`createPackageSymlinks`
+  logger usage before editing.
+- **librpc `createAuth` call-site threading.** Adding a `runtime` parameter to
+  `createAuth(serviceName)` only works cleanly if every caller already has a
+  runtime in scope. The teardown ledger says `Server` was fully injected with
+  a runtime options bag, so the expected single caller is covered — but the
+  implementer must confirm there is no other `createAuth(` caller (and no
+  default-factory invocation) lacking a runtime before changing the signature.
+  If one exists, thread the runtime to it rather than re-introducing
+  `createDefaultProc()`.
+
+## Execution
+
+Single engineering-agent PR; steps are sequential within it (Step 2 depends
+on Step 1; Step 4 verifies Steps 1–3 plus the carried doc edits). The
+retroactive `spec.md`/`design-a.md`/`teardown.md`/`plan-a.md` edits are
+authored by the planning session and carried into the same PR so the
+artifacts and the code land together. No part of this unit runs in parallel
+with another — it is the terminal 1370 unit.
+
+— Plan author, spec 1370 part-07

--- a/specs/1370-ambient-dependencies-to-injected-collaborators/plan-a.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/plan-a.md
@@ -70,7 +70,7 @@ so the plan parts can stay short. Variations are called out per section.
      (e.g. WikiSync rebase recovery, libeval workdir listener cleanup)
      rename to `*.integration.test.js`.
 6. **Deny-list shrink.** Remove every entry for the unit from
-   `scripts/check-ambient-deps.deny.json` and
+   `scripts/check-ambient-deps.deny.yml` and
    `scripts/check-subprocess-in-tests.deny.json`. The PR may not exit
    migration with any entry for the unit remaining
    ([spec § Risks](spec.md#risks-and-mitigations)).
@@ -138,7 +138,7 @@ contract drift).
 
 ### Deny-list seeding
 
-Foundations PR seeds `scripts/check-ambient-deps.deny.json` with every
+Foundations PR seeds `scripts/check-ambient-deps.deny.yml` with every
 existing src violation across the monorepo, grouped by library/product/
 service. Each migration PR removes its unit's entries (Step 6). The
 deny-list is monotone — entries are removed only, never added — and CI
@@ -153,21 +153,17 @@ has a corresponding `createMock*` factory export
 Adding a field to `Runtime` without adding a fake fails CI. This
 catches the "spec extension drifts ahead of fakes" failure mode.
 
-### Performance milestone tracking
+### Performance milestone tracking (RETIRED)
 
-[Spec § SC6](spec.md#success-criteria) gates the spec on M1/M2/M3 wall
-times. The plan tracks them as part of release-merge's per-wave
-acceptance:
-
-| Milestone | Trigger | Target |
-|---|---|---|
-| Pre-M1 baseline | foundations PR merges | record current `time bun run test` in plan-a-01 final note |
-| M1 | every library in plan-a-02/03/04 sub-row at `plan implemented` | `real` under 45 s, three consecutive runs |
-| M2 | every libeval + librpc sub-row at `plan implemented` | `real` under 35 s |
-| M3 | every products + services sub-row at `plan implemented` | `real` under 25 s |
-
-A missed milestone halts further wave PRs until reinvestigated
-([spec § Risks](spec.md#risks-and-mitigations) — Slow migration).
+This section originally gated the spec on M1/M2/M3 wall times (45 s / 35 s /
+25 s) tracked as part of release-merge's per-wave acceptance, with a missed
+milestone halting further wave PRs. **The wall-time gate is retired** — it
+was missed (~38.5 s at part-06 vs the 25 s M3 target) because the migration
+traded coarse integration tests for many fine-grained unit tests and total
+wall time tracked scope, not per-test speed. See
+[spec § Outcome](spec.md#outcome-post-implementation-reconciliation-2026-06-01)
+for the grounded close-out; wall time is now a recorded trend, not a gate, and
+no wave PR is halted on it.
 
 ## Migration Order and Part Index
 
@@ -182,15 +178,22 @@ libraries) so every src module gets covered.
 | 03 | [plan-a-03-bin-libraries.md](plan-a-03-bin-libraries.md) | libconfig (no bin), libstorage, libcoaligned, libeval, librpc, libdoc, libcodegen, libterrain, libxmr, librc, libgraph, libvector, libresource, libsupervise, libtelemetry | 01 |
 | 04 | [plan-a-04-non-bin-libraries.md](plan-a-04-non-bin-libraries.md) | libbridge, libformat, libindex, libmacos, libmcp, libpack, libpolicy, libpreflight, libprompt, libproto, librepl, libsecret, libskill, libsyntheticgen, libsyntheticprose, libsyntheticrender, libtemplate, libtype, libui | 01 |
 | 05 | [plan-a-05-products.md](plan-a-05-products.md) | products/{map, pathway, summit, landmark, guide, outpost} | 01, 03 (libeval), 02 (libwiki) |
+| 05-b | [plan-a-05-b.md](plan-a-05-b.md) | follow-up wave for the remaining products + libeval/libsupervise (landmark, map, outpost) after the first products wave | 05 |
 | 06 | [plan-a-06-services.md](plan-a-06-services.md) | services/{bridge, embedding, ghauth, ghbridge, graph, map, mcp, msbridge, oauth, pathway, trace, vector} | 01, 03 |
 | teardown | [teardown.md](teardown.md) | remove the one-cycle BC bridges foundations shipped (`Finder` legacy positional constructor + `node:fs` deny-list entry; `createCli` zero-arg fallback) | 02, 03, 04, 05, 06 |
+| 07 | [plan-a-07.md](plan-a-07.md) | post-implementation gap closure: collapse the residual `new Finder(` sites + enforce SC9 with an invariant; make `runtime.proc.stdout` pipeline-grade and migrate `librc logs()`; retire SC6's wall-time milestones with a grounded outcome; reconcile `teardown.md`/`spec.md`/`design-a.md` to what shipped | 01–06, teardown |
 
-The `teardown` unit is the **last** to land: it deletes the backward-compat
-bridges part 01 introduced so consumers could migrate incrementally. The master
-`1370` row reaches `plan implemented` only once `1370/teardown` does (the
-`kata-release-merge` sub-row gate enforces it). See
+Part 07 is a **post-merge remediation unit** authored after the master row
+had already advanced. It is now the terminal unit: the master `1370` row,
+having been set back to `plan approved` to reflect the outstanding work,
+re-advances to `plan implemented` only once `1370/part-07-reconciliation`
+does. The `teardown` unit was the last of the original migration waves: it
+deletes the backward-compat bridges part 01 introduced so consumers could
+migrate incrementally. The master `1370` row reaches `plan implemented` only
+once every sub-row — `1370/teardown` and `1370/part-07-reconciliation` — does
+(the `kata-release-merge` sub-row gate enforces it). See
 [teardown.md](teardown.md) for the bridges, their forcing functions, and the
-removal checklist — `finder.js`'s `check-ambient-deps.deny.json` entry
+removal checklist — `finder.js`'s `check-ambient-deps.deny.yml` entry
 mechanically blocks the Finder bridge from being forgotten; the `createCli`
 fallback is tracked by teardown.md plus a runnable zero-count check.
 
@@ -234,11 +237,13 @@ audit — plan-a-03), libconfig (process arg → runtime.proc — plan-a-03).
   to async forces every caller path async. Mitigation: plan-a-02 carries
   the bridge call-site updates inside the libwiki PR (the bridges
   themselves remain on their existing bin contracts).
-- **M2/M3 milestone slippage stalls the program.** A missed milestone
-  halts further wave PRs ([§ Performance milestone tracking](#performance-milestone-tracking)).
-  Mitigation: plan-a-03 and plan-a-04 are ordered so the smallest
-  libraries migrate first, building per-unit time savings into M1
-  before the larger libraries land.
+- **M2/M3 milestone slippage stalls the program.** ~~A missed milestone
+  halts further wave PRs.~~ **Retired** — the wall-time gate no longer halts
+  any wave ([§ Performance milestone tracking](#performance-milestone-tracking),
+  [spec § Outcome](spec.md#outcome-post-implementation-reconciliation-2026-06-01)).
+  The milestones were missed and the program completed anyway; ordering
+  plan-a-03/04 smallest-first still helped per-unit feedback latency, which
+  remains the real benefit.
 - **products PR opens before its library consumer migrates.** If a
   product is migrated while still constructing collaborators against a
   pre-1370 library shape, the product carries an in-flight compatibility

--- a/specs/1370-ambient-dependencies-to-injected-collaborators/spec.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/spec.md
@@ -135,11 +135,45 @@ one shape and applies that shape across `libraries/`, `products/`, and
 | 3 | No src module calls `process.exit(...)`, `process.cwd()`, `process.stdout.write`, `process.stderr.write`, or reads `process.env.X` outside the allow-listed bin shims, default-collaborator factories, and libcli internals. | Same invariant check. |
 | 4 | Every libwiki command handler is dispatched through `cli.dispatch(parsed, { deps: { runtime, wikiSync } })` and reads its collaborators from `ctx.deps` — no command handler imports `node:fs`/`node:child_process` or reads `process.*` directly. The same DI contract applies uniformly to every multi-subcommand CLI in the monorepo; libwiki does not introduce a per-CLI facade class. The CLI surface (`fit-wiki claim`, `fit-wiki log`, ...) produces byte-identical output to the current implementation for the existing test corpus. | `bun test libraries/libwiki/test/` passes; a golden-output test asserts the CLI's stdout/stderr/exitCode for a representative set of invocations matches the pre-refactor baseline. |
 | 5 | Every command-handler test in libwiki, libeval, products/landmark, products/map, products/outpost, products/summit, products/pathway, and products/guide that previously spawned a subprocess via `execFileSync`/`spawnSync` now runs in-process against injected fakes, with one explicit smoke test per binary that spawns the bin to verify the wiring. | A new `scripts/check-subprocess-in-tests.mjs` invariant enumerates `execFileSync`/`spawnSync` call sites in `test/` and flags any that match `node`/the project's own bins, with an allow-list of one entry per binary for the smoke test. |
-| 6 | The full test suite (`bun run test`) hits a sequence of milestones rather than a single target, so progress is visible and a missed milestone surfaces problems early. **M1**: under 45 s after libwiki migration completes. **M2**: under 35 s after libeval and librpc migration completes. **M3**: under 25 s after products and services migration completes. Every milestone reports zero failures and zero environmental-flake errors. | At each milestone, `time bun run test` reports `real` under the target on the same hardware class three consecutive runs apart (warmup excluded); `bun run test 2>&1` reports `0 fail` and `0 errors`. The 49 s state already on `claude/test-suite-performance-uRYQj` is the pre-M1 baseline. |
+| 6 | **(Retired 2026-06-01 — see § Outcome.)** The testability transformation (SC1–5, 7–9) is complete and CI-enforced. The absolute wall-time milestones originally specified here (M1 45 s / M2 35 s / M3 25 s) are **not** a pass/fail gate: the migration roughly doubled the test count (more, finer-grained unit tests), so wall time tracks scope, not per-test speed. Suites must still report zero failures and zero environmental-flake errors. | `bun run test 2>&1` reports `0 fail` and `0 errors`. Wall time is recorded as a trend signal (see § Outcome), not gated against a fixed target. |
 | 7 | libmock exports canonical fakes for **every** collaborator surface the spec introduces (clock, fs, proc/process, subprocess, git-client, and any other surface introduced during design). Each fake is documented in `libraries/libmock/README.md` under a single "Collaborators" section that names the surface, the production shape it fakes, and an example. The exact factory names and parameter shapes are settled in the design phase. | `libraries/libmock/src/index.js` re-exports a factory for every collaborator surface declared in the design doc; the README's Collaborators section lists every export with a one-line example; a test in libmock asserts that every declared collaborator surface has a corresponding export. |
 | 8 | `scripts/check-libmock.mjs` (the existing inline-mock guard) catches the common-shape reimplementations of every collaborator fake libmock introduces — at minimum, the exact patterns the panel review flagged plus any patterns the design phase enumerates. The guard is not expected to catch every conceivable inline duplicate (a fully obfuscated reimplementation will slip through), but it must catch the same kinds of shapes the existing guard catches for tracer/logger/storage today, applied to the new collaborator surfaces. | A regression test in `scripts/` exercises the guard against a corpus of representative inline shapes (one positive case per collaborator surface) and verifies each is flagged. |
-| 9 | The `Finder` class accepts the same `{ fs, proc, logger }` shape as every other collaborator-aware util; the 17 hand-rolled `new Finder(...)` call sites collapse to consumers receiving a `finder` collaborator. The `fs` parameter actually flows through to internal calls instead of `findUpward` using the top-level import. | `rg "new Finder\(" libraries/ products/ services/` returns zero matches outside `libutil` itself; a unit test injects a `createMockFs` and verifies `findUpward` uses it. |
+| 9 | The `Finder` class accepts the same `{ fs, proc, logger }` shape as every other collaborator-aware util; the 17 hand-rolled `new Finder(...)` call sites collapse to consumers receiving a `finder` collaborator. The `fs` parameter actually flows through to internal calls instead of `findUpward` using the top-level import. **(Enforcement grounded in [plan-a-07.md](plan-a-07.md): the original waves left 6 construction sites and narrowed the verification grep to the legacy positional form `new Finder\([^{]`; part-07 collapses every site and restores the literal check below as a CI invariant.)** | `rg "new Finder\(" libraries/ products/ services/` returns zero matches outside `libutil` itself, enforced by `scripts/check-collaborator-construction.mjs` (which also enforces the broader rule — no `createDefaultProc/Clock/Subprocess` outside libutil in production code); a unit test injects a `createMockFs` and verifies `findUpward` uses it. |
 | 10 | A contributor doc at `MONOREPO.md` (or a new sibling) names the four collaborator surfaces, the canonical libmock fakes, and the invariants that enforce them, so a future contributor lands on the pattern from any starting point. | The doc exists, links to libmock's collaborator README section, and is referenced from `CONTRIBUTING.md` § READ-DO. |
+
+## Outcome (post-implementation reconciliation, 2026-06-01)
+
+Parts 01–06 + teardown shipped the charter; SC1–5 and SC7–8 are met and
+CI-enforced. SC9 and SC10 are **not yet** met on `main` — six `new Finder(`
+sites remain and the enforcing invariant does not exist; [plan-a-07.md](plan-a-07.md)
+(approved, pending implementation) closes them. A post-merge audit recorded
+the following honest results so the artifacts match what shipped:
+
+- **The structural goal succeeded.** Ambient `node:fs`/`node:child_process`/
+  `Date.now`/`setTimeout`/`process.*` are gone from src outside the
+  allow-listed factories and bin shims; the deny-list shrank to four residual
+  libutil-foundation entries; dependency surfaces are explicit and fakes are
+  canonical. This is a durable reviewing- and unit-testing improvement.
+- **The wall-time goal (SC6) was not met and is retired, not silently
+  dropped.** The implementing agent recorded `38.5 s` at the part-06
+  milestone against the `25 s` M3 target (`wiki/staff-engineer-2026-W22.md`,
+  run for part-06: *"SC6 M3 (<25s) … not met at 38.5s — flagged"*); a
+  post-merge audit re-ran the suite at `4144` passing tests / ~55 s on a
+  4-core container — i.e. above target on every hardware class measured. The
+  cause is qualitative and grounded: the migration replaced coarse
+  subprocess-spawning integration tests with many fine-grained in-process unit
+  tests, so per-test cost fell while total wall time did not. The speed win
+  (milliseconds, not subprocess forks, per unit test) is real; the absolute
+  wall-time milestone was the wrong gate for a scope that grew underneath it.
+  Wall time is now a recorded trend, not a gate.
+- **The only genuine runtime-surface gap left** is `librc logs()` (it cannot
+  pipe to `runtime.proc.stdout`, a `{ write }` shim). [plan-a-07.md](plan-a-07.md)
+  closes it by making `proc.stdout`/`stderr` pipeline-grade `Writable`s. The
+  libeval and libsupervise residue the teardown ledger once named as needing
+  "a future runtime-surface-extension spec" had already shipped during the
+  waves (`runtime.fs.createReadStream`/`createWriteStream`, `proc.kill` group
+  signalling, `subprocess.spawn` `detached`/`pid`/`stdin`); [teardown.md](teardown.md)
+  is corrected to match.
 
 ## Risks and Mitigations
 
@@ -178,11 +212,14 @@ one shape and applies that shape across `libraries/`, `products/`, and
   style before any library's plan is approved. The design-approval row
   in STATUS records which style was chosen; subsequent library plans
   reference it.
-- **Slow migration overshadows the speed win.** Mitigation: Success
-  Criterion 6's staged milestones (M1/M2/M3) gate the spec — if M1
-  passes but M2 misses, we re-investigate before pushing further. The
-  49 s state already achieved on `claude/test-suite-performance-uRYQj`
-  is the pre-M1 baseline, not the proof point for the final target.
+- **Slow migration overshadows the speed win.** Mitigation as originally
+  written: Success Criterion 6's staged milestones (M1/M2/M3) gate the spec.
+  **Outcome (see § Outcome):** the milestones were missed and the risk
+  materialised — wall time stayed flat as the test count doubled. The
+  response was to retire the wall-time gate with a grounded rationale rather
+  than to keep chasing an absolute target against a moving scope; the
+  testability win the spec actually exists for (SC1–5, 7–9) landed and is
+  enforced.
 - **Migration cost itself is unbudgeted.** Capturing golden outputs,
   writing fakes, threading collaborators through call sites, and
   updating tests is non-trivial work across 150+ files. Mitigation: the

--- a/specs/1370-ambient-dependencies-to-injected-collaborators/teardown.md
+++ b/specs/1370-ambient-dependencies-to-injected-collaborators/teardown.md
@@ -140,48 +140,45 @@ callers that passed the old shape keep working for one cycle.
 
 ## Residual global reads that are NOT backward-compat (foundation surface gaps)
 
-These are **not** BC bridges and teardown does **not** remove them — they exist
-because the ratified `runtime` surface does not (yet) express the capability.
-Closing them needs a **foundation follow-up** that extends the runtime contract
-(a separate spec/design amendment), not the `1370/teardown` unit. They are
-listed here so "no fallbacks left after teardown" has an explicit, honest
-exception set:
+**Corrected 2026-06-01 (post-merge audit + [plan-a-07.md](plan-a-07.md)).**
+An earlier revision of this section listed libeval, libsupervise, and a
+`librc logs()` pair as grandfathered gaps awaiting "a future runtime
+surface-extension spec." That description did **not** match what shipped:
+most of the surface those items needed was added, backward-compatibly,
+during the migration waves, and the rest is closed by part-07. The honest
+current state:
 
-- **`librc/src/manager.js` `logs()` — streaming read piped to a `Writable`
-  stdout.** `logs()` does `pipeline(fs.createReadStream(logPath), this.#stdout)`.
-  Two surface gaps keep it grandfathered together (they are co-required — fixing
-  one without the other does not migrate `logs()`):
-  - `fs.createReadStream` is not on the `fsSync`/`fs` surface, so `librc` keeps
-    its legacy `deps.fs` for the read stream.
-  - `runtime.proc.stdout` is a `{ write }` shim, not a pipeline-grade
-    `Writable`, so `librc` keeps `deps.stdout ?? process.stdout` for the sink.
-
-  **Resolved this wave:** `runtime.proc` now exposes `kill(pid, signal)`
-  (negative pid = group), so `librc`'s liveness probe and env reads route
-  through `runtime.proc` and the `deps.process` fallback was deleted. Only the
-  `logs()` streaming pair above remains.
-- **`libsupervise` detached, process-group spawning** (`spawn(...,
-  { detached: true })` + `process.kill(-pid, ...)`) and **log stdin piping** —
-  `runtime.subprocess` exposes no detached option, no child **pid** (needed for
-  `proc.kill(-pid, ...)` group-kill), and no writable child stdin. This is why
-  libsupervise was deferred this wave. (`proc.kill` now exists, but the spawn
-  surface must also return the pid and accept `detached` before the group-kill
-  can route through it.)
-- **`libeval` streaming-fs / `node:net` / fd-passing files**
-  (`benchmark/{runner,workdir,task-family,scorer,judge,report,*-installer}.js`,
-  `commands/{tee,run,supervise,discuss,facilitate}.js`, `trace-github.js`,
-  `profile-prompt.js`) — kept grandfathered in `check-ambient-deps.deny.yml`;
-  they need `createReadStream`/`createWriteStream`, `node:net`, and fd-3
-  passing, none of which the runtime surface covers.
+- **Closed during the waves.** `runtime.fs` gained `createReadStream` /
+  `createWriteStream`; `runtime.fsSync` is the full `node:fs` module (so it
+  too exposes `createReadStream`); `runtime.proc` gained `kill(pid, signal)`
+  (negative pid = group), `pid`, `platform`, and `on(event, handler)`;
+  `runtime.subprocess.spawn` gained `detached`, `pid`, and writable `stdin`.
+  With those, **libeval** migrated fully (no `node:fs` imports;
+  `createWriteStream` via `runtime.fs`; **off** the deny-list) and
+  **libsupervise** migrated fully (`this.#proc.kill(-pid, …)` group teardown,
+  `detached: true` spawns, and `logProcess.stdin` piping all route through
+  injected collaborators). Neither is deferred; neither is on the deny-list.
+- **To be closed by [plan-a-07.md](plan-a-07.md) (approved, pending
+  implementation).** The one genuine remaining surface gap **is**
+  `librc/src/manager.js` `logs()`: it pipes a read stream into
+  `runtime.proc.stdout`, which is still a `{ write }` shim rather than a
+  pipeline-grade `Writable`, so `manager.js` still carries the
+  `deps.fs ?? runtime.fsSync` and `deps.stdout ?? process.stdout` fallbacks on
+  `main`. Part-07 **will** make `proc.stdout`/`stderr` pipeline-grade
+  `Writable`s and migrate `logs()` onto `runtime.fsSync.createReadStream` +
+  `runtime.proc.stdout`.
+- **Genuinely remaining (DI-clean, not a fallback).** `librc` still injects
+  `deps.spawn` / `deps.execSync` (from the bin) to launch the `fit-svscan`
+  daemon, because that spawn needs `detached` **plus** fd-redirect-to-logfile
+  stdio (`stdio: [..., fd, fd]`), which `runtime.subprocess.spawn` does not
+  yet express. This is dependency-injected (the bin supplies it; src reads no
+  ambient `process`/`child_process`), so it is **not** a backward-compat
+  fallback — it is a deliberate injected seam. Unifying it onto
+  `runtime.subprocess` (an fd-redirect `stdio` option) is the only surface
+  extension still open; it is small, and no separate spec is required unless a
+  second consumer needs the same shape.
 - **Already-closed notes:** `Config.ghToken()` uses
-  `runtime.subprocess.runSync`, and `runtime.proc.kill` is now in the contract
-  — both were foundation seams added during the wave, so neither appears above.
-
-A future "runtime surface extension" spec should add: a writable
-`proc.stdout` stream, streaming `fs.createReadStream`/`createWriteStream`, and
-`subprocess.spawn` detached + pid + writable-stdin (which, combined with the
-now-shipped `proc.kill`, closes the libsupervise group-kill). When it lands,
-the items above migrate and this section shrinks to empty.
+  `runtime.subprocess.runSync` — a foundation seam added during the wave.
 
 ## Retained composition-root defaults (DX-first decision)
 
@@ -229,12 +226,17 @@ and correct; the spec's "remaining hits are the live root, not a fallback."
       roots; every per-consumer fallback is removed (Bridge 3).
 - [x] `rg "\?\? process\b|globalThis\.(process|setTimeout|clearTimeout)|getDefaultRuntime"
       libraries/ products/ services/` → only the foundation-gap residue
-      `librc/manager.js` `deps.stdout ?? process.stdout` remains (NOT-BC).
+      `librc/manager.js` `deps.stdout ?? process.stdout` remains (NOT-BC) on
+      `main`; **scheduled for removal in [plan-a-07.md](plan-a-07.md)**
+      (approved, pending) once `runtime.proc.stdout` becomes pipeline-grade.
 - [x] `rg "resolveRuntime|_procFromLegacy" libraries/` → 0; the `Logger`
       positional `proc` parameter removed (Bridge 4).
 - [x] `finder.js` removed from `check-ambient-deps.deny.yml`; `bun run
       invariants` green.
 - [x] All four bridges' code paths deleted; the NOT-BC residue explicitly
       retained with the tracking reference above; `bun run test` green.
-- [ ] STATUS `1370/teardown` → `plan implemented`; master `1370` → `plan
-      implemented` once every sub-row reads `plan implemented`.
+- [x] STATUS `1370/teardown` → `plan implemented`. **Note (2026-06-01):** the
+      master `1370` row advanced to `plan implemented` after teardown, but a
+      post-merge audit reopened it — see [plan-a-07.md](plan-a-07.md). Master
+      `1370` re-advances to `plan implemented` only once
+      `1370/part-07-reconciliation` is also implemented.


### PR DESCRIPTION
## Summary

A post-merge audit of spec 1370 (ambient dependencies → injected collaborators) found four items the master row papered over when it advanced to `plan implemented`. This branch adds a remediation plan and grounds the existing artifacts to what actually shipped. Two logical commits:

- **`plan(1370): add part-07 gap-closure unit`** — new `plan-a-07.md`:
  - **SC9 + general DI pattern** — collapse every direct collaborator construction to the injected runtime (the six `new Finder(` sites plus `librpc/base.js`'s `createDefaultProc().env` read), then enforce the *broader* rule with a new `scripts/check-collaborator-construction.mjs` invariant: no `new Finder` / `createDefaultProc`/`Clock`/`Subprocess` outside libutil (`createDefaultRuntime` exempt). Prod-strict / test-lenient; wired into `bun run invariants`.
  - **librc `logs()`** — make `runtime.proc.stdout`/`stderr` pipeline-grade `Writable`s and migrate off the `deps.fs`/`deps.stdout` fallbacks (the last genuine runtime-surface gap).
  - **SC6** — retire the unmet wall-time milestones with a grounded outcome.
  - **Accounting** — STATUS reconciliation (master `1370` reopened to `plan approved` for the new `1370/part-07-reconciliation` sub-row).

- **`docs(1370): ground existing artifacts to what shipped`** — corrects stale/aspirational claims across `spec.md` (SC6 retired + § Outcome; SC9 reframed; SC9/SC10 stated not-yet-met on main), `design-a.md` (Finder logger is a constructor field via `withLogger`, not the never-implemented per-call param; shipped surface extensions noted), `teardown.md` (libeval/libsupervise migrated, not deferred; residue shrunk), and `plan-a.md`/`plan-a-05-products.md` (wall-time gates retired; index + `deny.yml` fixes).

This branch carries **documentation only** (the spec dir). The code described in `plan-a-07.md` is left for `kata-implement`; SC9/SC10 remain unmet on `main` until that lands, which the artifacts now state plainly.

Reviewed via a clean 3-reviewer `kata-review` panel (no blockers; all consensus + verified-singleton findings addressed).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sc6cGsaPQdcBGeUr42yWUH)_