### PR TITLE
chore(invariants): catch spec-artifact and kata-team label references

### DIFF
--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -47,8 +47,7 @@ advance routing; only merge of the prior phase's PR puts the artifact on
 0. **48h Staff deliverable with no artifact?** Scan
    `wiki/storyboard-{YYYY}-M{MM}.md` (Next review, Active Experiments
    horizons, Q5 pre-commits). Action before routes 1–4. On slip, post a
-   slip-as-data Announce. (Staff Exp 45, P1 2026-06-01; close if RE Exp 43
-   verdict 2026-05-27 lands F1.)
+   slip-as-data Announce.
 1. **Merged specs without designs?** -- `kata-design` (specs/NNN/ where
    `spec.md` is on `origin/main` but `design-a.md` is not)
 2. **Merged designs without plans?** -- `kata-plan` (specs/NNN/ where

--- a/.github/workflows/publish-brew.yml
+++ b/.github/workflows/publish-brew.yml
@@ -75,8 +75,8 @@ jobs:
             gear)     "$BUNDLE/Contents/MacOS/fit-svcgraph" --help ;;
           esac
 
-      - name: Verify cdhash stability (plan §1b CI gate)
-        # Spec SC8 / plan Risk 9: rebuild the bundle from the same tree and
+      - name: Verify cdhash stability
+        # Rebuild the bundle from the same tree and
         # confirm the signed cdhash is identical. A drifting cdhash wipes TCC
         # grants on `brew upgrade`, so a non-deterministic build must fail
         # release rather than ship.

--- a/libraries/libeval/src/benchmark/result.js
+++ b/libraries/libeval/src/benchmark/result.js
@@ -5,8 +5,8 @@
  *   - RESULT_RECORD_SCHEMA — one record per (task, runIndex) from a full
  *     benchmark run. Has a happy branch (invariants + judge present) and a
  *     pre-flight-failure branch (invariants/judgeVerdict/submission absent).
- *   - INVARIANTS_RECORD_SCHEMA — narrower output of `benchmark-invariants`
- *     (P7): ad-hoc grading without a full lifecycle.
+ *   - INVARIANTS_RECORD_SCHEMA — narrower output of `benchmark-invariants`:
+ *     ad-hoc grading without a full lifecycle.
  *
  * Validation is throw-on-mismatch so the runner can wrap every JSONL append
  * in a guard and reject schema drift at write time.

--- a/libraries/libeval/src/benchmark/task-family.js
+++ b/libraries/libeval/src/benchmark/task-family.js
@@ -2,7 +2,7 @@
  * Task-family loader. A task family is a directory under
  *   <root>/
  *     apm.lock.yaml
- *     .claude/                # pre-staged skills + agents (P1)
+ *     .claude/                # pre-staged skills + agents
  *     tasks/<task_name>/
  *       agent.task.md
  *       supervisor.task.md    # optional; appended to the task as supervisor context

--- a/libraries/libeval/src/commands/benchmark-invariants.js
+++ b/libraries/libeval/src/commands/benchmark-invariants.js
@@ -1,6 +1,6 @@
 /**
  * `fit-benchmark invariants` — check a single task's invariants against a
- * post-run workdir directory without invoking an agent (P6/P7). Useful for
+ * post-run workdir directory without invoking an agent. Useful for
  * re-checking an agent's output against revised grading material.
  */
 

--- a/libraries/libeval/test/bin-smoke.integration.test.js
+++ b/libraries/libeval/test/bin-smoke.integration.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-// Per-bin smoke tests (spec SC5): spawn each libeval bin with `--version`
+// Per-bin smoke tests: spawn each libeval bin with `--version`
 // and assert it exits 0 and prints a semver-shaped line. This is the one
 // legitimate subprocess test per binary, so it lives in an
 // `*.integration.test.js` file (exempt from check-subprocess-in-tests).

--- a/libraries/libmock/test/runtime-completeness.test.js
+++ b/libraries/libmock/test/runtime-completeness.test.js
@@ -68,7 +68,7 @@ describe("Runtime completeness", () => {
     assert.strictEqual(rt.clock, sentinel);
   });
 
-  // SC7 covers every declared collaborator surface, not only the runtime-bag
+  // This covers every declared collaborator surface, not only the runtime-bag
   // fields — the typed clients (GitClient/GhClient) documented in the README
   // Collaborators section must also have exported fakes.
   test("declared non-bag collaborator surfaces have exported fakes", () => {

--- a/libraries/libstorage/src/index.js
+++ b/libraries/libstorage/src/index.js
@@ -131,7 +131,7 @@ function _createLocalStorage(prefix, runtime, rootDir = null) {
   }
 
   // 3. Filesystem discovery (fallback) via the injected finder collaborator,
-  //    so the runtime's fs flows through path discovery (SC9).
+  //    so the runtime's fs flows through path discovery.
   const root = proc.cwd();
   const basePath = runtime.finder.findUpward(root, relative);
 

--- a/libraries/libsupervise/test/bin-smoke.integration.test.js
+++ b/libraries/libsupervise/test/bin-smoke.integration.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-// Per-bin smoke tests (spec SC5): spawn each libsupervise bin with `--version`
+// Per-bin smoke tests: spawn each libsupervise bin with `--version`
 // and assert it exits 0 and prints a semver-shaped line. This is the one
 // legitimate subprocess test per binary, so it lives in an
 // `*.integration.test.js` file (exempt from check-subprocess-in-tests).

--- a/libraries/libutil/test/git-client.integration.test.js
+++ b/libraries/libutil/test/git-client.integration.test.js
@@ -7,7 +7,7 @@ import path from "node:path";
 import { createDefaultRuntime } from "../src/runtime.js";
 import { GitClient } from "../src/git-client.js";
 
-// SC5 "one explicit smoke test per binary" for GitClient: exercises the real
+// One explicit smoke test per binary for GitClient: exercises the real
 // `git` binary through the default runtime in a tmpdir.
 describe("GitClient (integration)", () => {
   let dir;

--- a/libraries/libwiki/src/util/wiki-dir.js
+++ b/libraries/libwiki/src/util/wiki-dir.js
@@ -3,7 +3,7 @@ import path from "node:path";
 /**
  * Find the project root by upward `package.json` discovery from the current
  * working directory, using the injected `runtime.finder` (the one canonical
- * Finder — SC9 keeps `new Finder(...)` inside libutil).
+ * Finder — `new Finder(...)` lives only inside libutil).
  * @param {import('@forwardimpact/libutil/runtime').Runtime} runtime
  * @returns {string}
  */

--- a/libraries/libwiki/test/fit-wiki-smoke.integration.test.js
+++ b/libraries/libwiki/test/fit-wiki-smoke.integration.test.js
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 
-// The one allow-listed smoke test per binary (SC5): it spawns the real bin to
+// The one allow-listed smoke test per binary: it spawns the real bin to
 // prove the runtime/dispatch wiring end-to-end. Every other libwiki command is
 // covered in-process against injected collaborators.
 const CLI_PATH = new URL("../bin/fit-wiki.js", import.meta.url).pathname;

--- a/libraries/libwiki/test/golden-functional.integration.test.js
+++ b/libraries/libwiki/test/golden-functional.integration.test.js
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 
-// Real-bin functional CLI-surface guard (spec SC4): spawns the actual
+// Real-bin functional CLI-surface guard: spawns the actual
 // `fit-wiki` bin against a committed audit-clean fixture wiki and asserts the
 // read-only command output (which the capture harness can replay
 // idempotently) is byte-identical to the committed golden. Mutating commands

--- a/libraries/libwiki/test/golden.test.js
+++ b/libraries/libwiki/test/golden.test.js
@@ -7,7 +7,7 @@ import { createCli } from "@forwardimpact/libcli";
 import { createDefinition } from "../src/cli-definition.js";
 import { makeRuntime } from "./helpers.js";
 
-// Byte-for-byte CLI-contract guard (spec SC4): the definition + libcli help
+// Byte-for-byte CLI-contract guard: the definition + libcli help
 // renderer must keep producing the snapshots captured in golden/fit-wiki/. The
 // committed `*.txt` were captured from the bin with the version normalised to
 // `X.Y.Z`; rendering in-process with that version reproduces them without a

--- a/products/guide/test/bin-smoke.integration.test.js
+++ b/products/guide/test/bin-smoke.integration.test.js
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// SC5 smoke test: spawn the real fit-guide bin to verify the runtime wiring
+// Smoke test: spawn the real fit-guide bin to verify the runtime wiring
 // (createDefaultRuntime + the librepl one-shot command path) end to end. The
 // `--version` flag runs before any network setup, so it is deterministic.
 const binPath = join(

--- a/products/landmark/test/bin-smoke.integration.test.js
+++ b/products/landmark/test/bin-smoke.integration.test.js
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// SC5 smoke test: spawn the real fit-landmark bin to verify the runtime
+// Smoke test: spawn the real fit-landmark bin to verify the runtime
 // wiring (createDefaultRuntime threaded from the bin into the dispatcher) end
 // to end. The `--version` flag runs before any data load or Supabase setup,
 // so it is deterministic and network-free.

--- a/products/map/test/bin-smoke.integration.test.js
+++ b/products/map/test/bin-smoke.integration.test.js
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// SC5 smoke tests: spawn each real bin to verify the runtime wiring
+// Smoke tests: spawn each real bin to verify the runtime wiring
 // (createDefaultRuntime threaded from the bin) end to end. `--version` runs
 // before any data load or Supabase setup, so it is deterministic and
 // network-free.

--- a/products/map/test/pipeline.test.js
+++ b/products/map/test/pipeline.test.js
@@ -5,13 +5,12 @@
  * and libgraph GraphProcessor, then asserts that
  * `GraphIndex.getSubjects("fit:Skill")` returns the fixture skill's IRI.
  *
- * This is the only test that exercises foundation F2's `RDF_PREFIXES`
- * registration: the `fit:Skill` short form must expand via the N3 Store's
- * prefix table or the query degrades to a literal and misses all
- * subjects. It is also the only test that proves ResourceProcessor's
- * `ALLOWED_TYPE_PREFIXES` (foundation F1) accepts the fit: vocabulary —
- * if F1 regresses, the parser rejects every main item and no subjects are
- * loaded into the graph.
+ * This is the only test that exercises the `RDF_PREFIXES` registration: the
+ * `fit:Skill` short form must expand via the N3 Store's prefix table or the
+ * query degrades to a literal and misses all subjects. It is also the only
+ * test that proves ResourceProcessor's `ALLOWED_TYPE_PREFIXES` accepts the
+ * fit: vocabulary — if that widening regresses, the parser rejects every main
+ * item and no subjects are loaded into the graph.
  *
  * The test uses real filesystem LocalStorage instances for both the
  * knowledge directory (from the exporter) and the graph index directory,
@@ -114,8 +113,8 @@ describe("end-to-end export → resource → graph pipeline", () => {
     await resourceProcessor.process(".html");
 
     // Sanity check: resource index has at least one resource whose Turtle
-    // content mentions the fit: skill subject. Foundation F1 — if the
-    // parser widening regressed, zero main items would be produced.
+    // content mentions the fit: skill subject. If the parser widening
+    // regressed, zero main items would be produced.
     const ids = await resourceIndex.findAll();
     assert.ok(ids.length > 0, "ResourceProcessor should have stored resources");
     const stored = await resourceIndex.get(ids);
@@ -140,7 +139,7 @@ describe("end-to-end export → resource → graph pipeline", () => {
     );
     await graphProcessor.process("test-actor");
 
-    // 7. Foundation F2 check — the fit: prefix must be registered so
+    // 7. RDF prefix check — the fit: prefix must be registered so
     //    `fit:Skill` expands to the full IRI. If this regresses, the
     //    subjects map comes back empty.
     const subjects = await graphIndex.getSubjects("fit:Skill");

--- a/products/outpost/test/bin-smoke.integration.test.js
+++ b/products/outpost/test/bin-smoke.integration.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-// Per-bin smoke test (spec SC5): spawn the fit-outpost bin with `--version`
+// Per-bin smoke test: spawn the fit-outpost bin with `--version`
 // and assert it exits 0 and prints a semver-shaped line. This is the one
 // legitimate subprocess test for the binary, so it lives in an
 // `*.integration.test.js` file (exempt from check-subprocess-in-tests).

--- a/products/pathway/test/agent-level.integration.test.js
+++ b/products/pathway/test/agent-level.integration.test.js
@@ -4,8 +4,8 @@
  * Stages a copy of products/map/starter into a temp data dir, removes the
  * organizational-context slot so byte-comparisons are scoped to the
  * teamInstructions / level-expectations layer, then invokes runAgentCommand
- * with various combinations of `--level`. Covers SC1 (level changes output),
- * SC3 (unknown-level error shape), and the `--list` short-circuit (C-5).
+ * with various combinations of `--level`. Covers level-driven output changes,
+ * the unknown-level error shape, and the `--list` short-circuit.
  */
 
 import { test, describe } from "node:test";
@@ -95,7 +95,7 @@ function stubProcessExit() {
 }
 
 describe("agent --level integration", () => {
-  test("SC1-file — two levels produce different CLAUDE.md outputs", async () => {
+  test("two levels produce different CLAUDE.md outputs (file)", async () => {
     const { work, dataDir } = stageDataDir();
     try {
       const outJ040 = join(work, "out-j040");
@@ -166,7 +166,7 @@ describe("agent --level integration", () => {
     }
   });
 
-  test("SC1-stdout — populated level expectations appear on stdout with Team Instructions umbrella label", async () => {
+  test("populated level expectations appear on stdout with Team Instructions umbrella label", async () => {
     const { work, dataDir } = stageDataDir();
     const stdout = captureWrite(process.stdout);
     try {

--- a/products/summit/test/bin-smoke.integration.test.js
+++ b/products/summit/test/bin-smoke.integration.test.js
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// SC5 smoke test: spawn the real fit-summit bin to verify the runtime wiring
+// Smoke test: spawn the real fit-summit bin to verify the runtime wiring
 // (createDefaultRuntime threaded through cli.parse) end to end. `--version` and
 // `--help` run before any data load, so they are deterministic.
 const binPath = join(

--- a/scripts/check-temporal.mjs
+++ b/scripts/check-temporal.mjs
@@ -32,6 +32,36 @@ const rules = [
   { pattern: "\\bGH-[0-9]{2,5}\\b" },
   { pattern: "\\(#[0-9]{2,5}\\)", globs: ["!**/test/**"] },
   { pattern: "[[:space:]]#[0-9]{2,5}\\b", globs: ["!**/test/**"] },
+  // Spec-artefact labels: solution criteria (SC), priorities (P), and
+  // findings (F) are numbered inside a spec's spec.md / plan / review. Once
+  // the spec closes, "SC5" or "Foundation F1" in a comment points at nothing.
+  // Match the uppercase label forms only (caseSensitive) so the lowercase
+  // tokens that collide — patient fixture IDs (`p1`), latency percentiles
+  // (`p50`/`p90`), CSS hex (`#f87171`), cert extensions (`.p12`) — never trip
+  // the check.
+  { pattern: "\\bSC[0-9]+\\b", caseSensitive: true },
+  // P (priority) and F (finding) also serve as a legitimate, self-defined
+  // triage vocabulary in the agent operating docs under .claude/ (the product
+  // manager's P1/P2/P3 buckets, the storyboard P1/F4 placeholders) — those are
+  // not references into a spec, so scope these two rules to everything else.
+  { pattern: "\\bP[0-9]+\\b", caseSensitive: true, globs: ["!.claude/**"] },
+  { pattern: "\\bF[0-9]+\\b", caseSensitive: true, globs: ["!.claude/**"] },
+  // Kata experiments and obstacles are tracked as labeled GitHub issues that
+  // close when the PDSA cycle ends, so "Exp 45" / "RE Exp 43" / "Obstacle 12"
+  // rot the same way a raw issue number does. caseSensitive so prose like
+  // "active experiments" or an "exp"-prefixed identifier never matches — only
+  // the capitalised label-plus-number form does.
+  {
+    pattern: "\\b(Exp|Experiment|Obstacle)[- ]?[0-9]+\\b",
+    caseSensitive: true,
+  },
+  // Agent-role initialisms used as a numbered shorthand for that agent's
+  // experiments or findings (SE = staff/security engineer, RE = release
+  // engineer, TW = technical writer, PM = product manager, IC = improvement
+  // coach). None occur today; this guards against the shorthand creeping in.
+  // Single-letter role forms (S#, T#) are deliberately omitted — they collide
+  // with `S3`, `SHA-256`, type parameters, and similar legitimate tokens.
+  { pattern: "\\b(SE|RE|TW|PM|IC)[0-9]+\\b", caseSensitive: true },
   {
     pattern:
       "\\b(introduced|added|landed|shipped|removed) in (spec|design|plan|PR|issue)\\b",
@@ -76,8 +106,11 @@ for (const rule of rules) {
     "--line-number",
     "--color",
     "never",
-    "-i",
   ];
+  // Most rules match prose case-insensitively ("PR", "GH-", "spec"); the
+  // spec-artefact label rules opt into case-sensitivity to dodge lowercase
+  // homographs.
+  if (!rule.caseSensitive) args.push("-i");
   for (const g of baseGlobs) args.push("--glob", g);
   if (rule.globs) {
     for (const g of rule.globs) args.push("--glob", g);


### PR DESCRIPTION
## Summary

- Extend the temporal-reference invariant (`scripts/check-temporal.mjs`) to the numbered labels that specs and the kata team use internally, which rot the same way spec/issue numbers do once the artifact closes.
- Add rules (all **case-sensitive**, so lowercase homographs never trip the check):
  - `SC[0-9]+` repo-wide — solution criteria
  - `P[0-9]+` / `F[0-9]+` excluding `.claude/**` — priorities/findings (the PM `P1/P2/P3` triage buckets and storyboard `P1/F4` placeholders there are a legitimate self-defined vocabulary, not spec references)
  - `(Exp|Experiment|Obstacle)[- ]?[0-9]+` repo-wide — kata PDSA issues that close
  - `(SE|RE|TW|PM|IC)[0-9]+` — agent-role initialism shorthand (none today; preventive guard)
- New per-rule `caseSensitive` flag drives matching so labels are caught while collisions are left alone — patient fixture IDs (`p1`), latency percentiles (`p50`/`p90`), CSS hex (`#f87171`), cert extensions (`.p12`).
- Deliberately **not** matched: single-letter role forms (`S#`/`T#` — collide with `S3`, `SHA-256`, type params), `Phase N` (clinical-trial phase / pipeline stages), `Stream A`, and `Q1`–`Q5` (Toyota Kata coaching questions) — domain/framework terms, not rotting references.
- Scrub the references the new rules surfaced across libeval, libmock, libstorage, libsupervise, libutil, libwiki, the map/pathway/guide/landmark/summit/outpost tests, the brew workflow, and the transient parenthetical in `staff-engineer.md` — each replaced with a self-contained description of why the code is there.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01VjbVQEyf28htByCudPsLXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjbVQEyf28htByCudPsLXc)_