### PR TITLE
perf(bootstrap): skip codegen on warm CI cache via relative symlinks

### DIFF
--- a/libraries/libutil/src/finder.js
+++ b/libraries/libutil/src/finder.js
@@ -158,10 +158,15 @@ export class Finder {
     // Ensure the target's parent directory exists before symlinking
     await this.#fs.mkdir(path.dirname(targetPath), { recursive: true });
 
-    // Create the symlink
-    await this.#fs.symlink(sourcePath, targetPath, "dir");
+    // Link relative to the symlink's own directory, not absolute. A relative
+    // target survives being moved or restored at a different path — e.g. the
+    // CI workspace cache restoring libraries/*/src/generated on a runner whose
+    // checkout root differs from where codegen first ran. An absolute target
+    // would dangle, forcing a full codegen re-run on every warm cache.
+    const relativeSource = path.relative(path.dirname(targetPath), sourcePath);
+    await this.#fs.symlink(relativeSource, targetPath, "dir");
     this.#logger.debug("Finder", "Created symlink", {
-      source_path: sourcePath,
+      source_path: relativeSource,
       target_path: targetPath,
     });
   }

--- a/libraries/libutil/test/finder.test.js
+++ b/libraries/libutil/test/finder.test.js
@@ -198,8 +198,12 @@ describe("Finder", () => {
 
       assert.ok(fs.existsSync(targetPath));
       assert.ok(fs.lstatSync(targetPath).isSymbolicLink());
-      // Should point to new source
-      assert.strictEqual(fs.readlinkSync(targetPath), sourceDir);
+      // Should point to new source, via a relative target so the link
+      // survives being restored at a different absolute path.
+      assert.strictEqual(
+        fs.readlinkSync(targetPath),
+        path.relative(path.dirname(targetPath), sourceDir),
+      );
     });
   });
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,37 +2,55 @@
 set -euo pipefail
 
 # ── Sync with origin/main ────────────────────────────────────────
-# Shallow clones lack enough history for rebase to find a merge base.
-# Unshallow first so rebase works reliably.
-if [ -f .git/shallow ]; then
-  git fetch --unshallow origin
-fi
+# The fit-bootstrap action already rebases onto origin/main (it must, to key
+# the workspace cache off the post-rebase tree) and sets BOOTSTRAP_SKIP_SYNC
+# so we don't pay for a second fetch+rebase round-trip here. Local runs and
+# the SessionStart hook leave it unset and still sync.
+if [ "${BOOTSTRAP_SKIP_SYNC:-}" != "true" ]; then
+  # Shallow clones lack enough history for rebase to find a merge base.
+  # Unshallow first so rebase works reliably.
+  if [ -f .git/shallow ]; then
+    git fetch --unshallow origin
+  fi
 
-git fetch origin main
+  git fetch origin main
 
-current_branch=$(git branch --show-current)
+  current_branch=$(git branch --show-current)
 
-if [ "$current_branch" = "main" ]; then
-  git merge --ff-only origin/main
-else
-  # Update local main ref without checkout
-  git branch -f main origin/main
-  # Rebase feature branch onto main; on conflict abort and warn (never reset)
-  if git rebase main 2>/dev/null; then
-    echo "Rebased '$current_branch' onto main."
+  if [ "$current_branch" = "main" ]; then
+    git merge --ff-only origin/main
   else
-    git rebase --abort
-    echo "Branch '$current_branch' has conflicts with main. Rebase manually when ready."
+    # Update local main ref without checkout
+    git branch -f main origin/main
+    # Rebase feature branch onto main; on conflict abort and warn (never reset)
+    if git rebase main 2>/dev/null; then
+      echo "Rebased '$current_branch' onto main."
+    else
+      git rebase --abort
+      echo "Branch '$current_branch' has conflicts with main. Rebase manually when ready."
+    fi
   fi
 fi
 
 # ── Install workspace ───────────────────────────────────────────
-# Codegen creates symlinks at libraries/*/src/generated → ./generated that
-# the workspace cache does not restore, so always run codegen even on a
-# warm cache; bun install is what we actually save time on.
+# fit-codegen now writes RELATIVE symlinks (libraries/*/src/generated ->
+# ../../../generated), so the workspace cache restores both generated/ and its
+# symlinks intact — a warm cache needs neither bun install nor codegen. Guard
+# against a stale cache (e.g. one saved before relative symlinks, whose links
+# dangle once restored at a different path) by verifying the generated tree
+# resolves, and fall back to codegen only when it does not.
 if [ "${BOOTSTRAP_WORKSPACE_CACHE_HIT:-}" = "true" ]; then
-  echo "Workspace cache hit — skipping bun install, running codegen"
-  just codegen
+  needs_codegen=0
+  [ -d generated/types ] || needs_codegen=1
+  for link in libraries/*/src/generated; do
+    [ -e "$link" ] || needs_codegen=1
+  done
+  if [ "$needs_codegen" = "0" ]; then
+    echo "Workspace cache hit — generated restored; skipping bun install and codegen"
+  else
+    echo "Workspace cache hit — generated tree incomplete; running codegen"
+    just codegen
+  fi
 else
   just install
 fi


### PR DESCRIPTION
## Summary

- Cuts `fit-bootstrap` wall time on the cached CI path it runs for every workflow, including the Kata agent team.
- `libutil` `Finder.createSymlink` now writes **relative** generated symlinks (`libraries/*/src/generated -> ../../../generated`) instead of absolute. Absolute links dangle once a cache is restored at a different path, which is why the workspace cache could never carry them and codegen re-ran on every warm cache.
- `scripts/bootstrap.sh` skips `bun install` **and** codegen on a workspace cache hit (the relative symlinks now restore intact), guarded by a check that re-runs codegen only if the restored `generated/` tree fails to resolve. It also skips its fetch+rebase when `BOOTSTRAP_SKIP_SYNC=true`, since the `fit-bootstrap` action already rebased onto `origin/main` to key the cache.

Pairs with `forwardimpact/fit-bootstrap@v1` (retagged to `397b1a1`: `env-v2` consolidated cache + `BOOTSTRAP_SKIP_SYNC`). The speedup only activates once this lands on `main`, since the action runs `bootstrap.sh`/`libutil` from the caller's checkout.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- [x] `libutil` finder tests pass locally (26/26), including the updated relative-symlink assertion
- [x] Verified `just codegen` produces resolving relative symlinks and the warm-cache guard self-heals on a dangling link

https://claude.ai/code/session_01W1YYweH9JM242CzzAefkJy

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1YYweH9JM242CzzAefkJy)_