### PR TITLE
refactor(bootstrap): drop branch sync; rebase is the action's job

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,36 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ── Sync with origin/main ────────────────────────────────────────
-# The fit-bootstrap action already rebases onto origin/main (it must, to key
-# the workspace cache off the post-rebase tree) and sets BOOTSTRAP_SKIP_SYNC
-# so we don't pay for a second fetch+rebase round-trip here. Local runs and
-# the SessionStart hook leave it unset and still sync.
-if [ "${BOOTSTRAP_SKIP_SYNC:-}" != "true" ]; then
-  # Shallow clones lack enough history for rebase to find a merge base.
-  # Unshallow first so rebase works reliably.
-  if [ -f .git/shallow ]; then
-    git fetch --unshallow origin
-  fi
-
-  git fetch origin main
-
-  current_branch=$(git branch --show-current)
-
-  if [ "$current_branch" = "main" ]; then
-    git merge --ff-only origin/main
-  else
-    # Update local main ref without checkout
-    git branch -f main origin/main
-    # Rebase feature branch onto main; on conflict abort and warn (never reset)
-    if git rebase main 2>/dev/null; then
-      echo "Rebased '$current_branch' onto main."
-    else
-      git rebase --abort
-      echo "Branch '$current_branch' has conflicts with main. Rebase manually when ready."
-    fi
-  fi
-fi
+# Environment setup only — install the workspace and sync the wiki. Keeping the
+# branch current with origin/main is a separate concern owned by whoever needs
+# it: the fit-bootstrap action rebases before computing its cache key, and CI
+# is the only context that requires it. Local runs and resumed sessions operate
+# on the branch as-is; rebase yourself when you want to.
 
 # ── Install workspace ───────────────────────────────────────────
 # fit-codegen now writes RELATIVE symlinks (libraries/*/src/generated ->


### PR DESCRIPTION
## Summary

- `scripts/bootstrap.sh` no longer fetches and rebases onto `origin/main`. That sync logic was duplicated with the `fit-bootstrap` action — which **must** rebase before computing its workspace cache key — and was only suppressed there by the `BOOTSTRAP_SKIP_SYNC` flag.
- Removing it deletes the duplication and the flag, and stops a plain "set up the environment" script from rewriting the caller's branch as a side effect.
- Currency with `main` is now owned solely by the context that needs it: the action rebases in CI. Local runs and resumed sessions operate on the branch as-is (resumed sessions no longer auto-rebase).

Pairs with `forwardimpact/fit-bootstrap@main` (`22e7a8a`, dead flag removed). The action's `v1` tag will be moved to that commit once this lands, completing the cutover.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- [x] `bash -n scripts/bootstrap.sh` passes; no `git rebase`/`fetch origin main` remains in the script
- [x] SessionStart resume hook ran the new `bootstrap.sh` cleanly (install + codegen + wiki), with no rebase step

https://claude.ai/code/session_01W1YYweH9JM242CzzAefkJy

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1YYweH9JM242CzzAefkJy)_