### PR TITLE
chore(check-temporal): flag spelled-out 'Success Criteria' spec references

### DIFF
--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -182,7 +182,7 @@ jobs:
           fi
 
           fail=0
-          # Spec § Success Criteria row 8: scan for all three literals.
+          # Scan the run logs for all three secret literals.
           # GH Actions auto-masks the two repo secrets, so grepping for
           # them is normally a no-op — but the scan still performs the
           # grep so the criterion is satisfied literally and to catch the

--- a/products/map/src/commands/substrate-smoke.js
+++ b/products/map/src/commands/substrate-smoke.js
@@ -115,7 +115,8 @@ export async function runSelfSmoke({ supabase, config, runtime }) {
     runtime,
   );
 
-  // Spec § Success Criteria rows 1–4: explicit shape check.
+  // Explicit shape checks: the JWT is well-formed, the persona resolves to
+  // a human, and discovery resolves.
   assertJwtShape(jwt, persona.email, runtime.clock.now());
   await assertPersonaIsHuman(supabase, persona.email);
   assertDiscoveryResolves(persona, discovery);

--- a/scripts/check-temporal.mjs
+++ b/scripts/check-temporal.mjs
@@ -32,7 +32,7 @@ const rules = [
   { pattern: "\\bGH-[0-9]{2,5}\\b" },
   { pattern: "\\(#[0-9]{2,5}\\)", globs: ["!**/test/**"] },
   { pattern: "[[:space:]]#[0-9]{2,5}\\b", globs: ["!**/test/**"] },
-  // Spec-artefact labels: solution criteria (SC), priorities (P), and
+  // Spec-artefact labels: success criteria (SC), priorities (P), and
   // findings (F) are numbered inside a spec's spec.md / plan / review. Once
   // the spec closes, "SC5" or "Foundation F1" in a comment points at nothing.
   // Match the uppercase label forms only (caseSensitive) so the lowercase

--- a/scripts/check-temporal.mjs
+++ b/scripts/check-temporal.mjs
@@ -40,6 +40,13 @@ const rules = [
   // (`p50`/`p90`), CSS hex (`#f87171`), cert extensions (`.p12`) — never trip
   // the check.
   { pattern: "\\bSC[0-9]+\\b", caseSensitive: true },
+  // The same label spelled out as a spec-section reference ("Spec § Success
+  // Criteria row 8") rots when the spec closes, exactly like "SC8". Require
+  // the capitalised "Success" (caseSensitive) so the generic prose noun in
+  // the agent docs — "a spec with verifiable success criteria" — never trips;
+  // only the section-label form does. Allow either case on the second word so
+  // "Success criteria" is caught too.
+  { pattern: "\\bSuccess [Cc]riteria\\b", caseSensitive: true },
   // P (priority) and F (finding) also serve as a legitimate, self-defined
   // triage vocabulary in the agent operating docs under .claude/ (the product
   // manager's P1/P2/P3 buckets, the storyboard P1/F4 placeholders) — those are

--- a/services/ghbridge/test/callback.test.js
+++ b/services/ghbridge/test/callback.test.js
@@ -231,7 +231,7 @@ describe("ghbridge callback handler", () => {
   });
 
   test("addDiscussionComment is not composed inside any workflow YAML", async () => {
-    // Spec § Success criteria row 6: GraphQL mutation strings are owned by
+    // GraphQL mutation strings are owned by
     // src/graphql.js, never composed inside facilitator prompts or workflow
     // YAML. This guard catches a regression where the Discussion handling
     // sneaks back into kata-dispatch.yml.


### PR DESCRIPTION
## Summary

- Correct the SC abbreviation in `scripts/check-temporal.mjs` — `SC` stands for **success criteria**, not "solution criteria". "Success Criteria" is the term used consistently across all specs and wiki memory.
- Add a temporal-reference rule for the **spelled-out** label: `\bSuccess [Cc]riteria\b` (case-sensitive). A `Spec § Success Criteria row N` reference rots when the spec closes, exactly like the abbreviated `SC8` form the adjacent rule already catches.
  - Case-sensitive on the capitalised `Success` so generic lowercase prose — e.g. `.claude/skills/*.md`'s "a spec with verifiable success criteria" — is left alone; only the section-label form is flagged.
  - Allows either case on the second word so `Success criteria` is caught too.
- Scrub the three in-scope references the new rule surfaced, each rewritten to explain *why* the code is there with no spec-section pointer:
  - `products/map/src/commands/substrate-smoke.js`
  - `.github/workflows/kata-interview.yml`
  - `services/ghbridge/test/callback.test.js`

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01VjbVQEyf28htByCudPsLXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjbVQEyf28htByCudPsLXc)_