### PR TITLE
plan(0640): test-side hygiene

### DIFF
--- a/specs/0640-refactor-test-suite/plan-a-01.md
+++ b/specs/0640-refactor-test-suite/plan-a-01.md
@@ -125,11 +125,15 @@ triple/definition/bundle in a file that does not import the new fixture
 ```js
 // new RULES entries
 {
-  // inline `new GraphIndex(mockStorage, n3Store, …)` triple
+  // inline mock triple: createMockStorage + new GraphIndex co-occurring
+  // without the fixture import. Keyed on createMockStorage (the *mock* triple),
+  // NOT a bare `new GraphIndex` — products/map/test/pipeline.test.js builds a
+  // *real* GraphIndex over LocalStorage (integration) and must not trip.
   test: (t) =>
+    /createMockStorage\s*\(/.test(t) &&
     /new\s+GraphIndex\s*\(/.test(t) &&
     !t.includes("createGraphIndexFixture"),
-  message: "inline GraphIndex triple — use createGraphIndexFixture",
+  message: "inline GraphIndex mock triple — use createGraphIndexFixture",
 },
 {
   // inline mock object literal `{ Check: { path: "…", requestStream: … } }`.
@@ -159,7 +163,10 @@ detection + a negative when the file imports the fixture), mirroring the
 existing `createMockSubprocess` cases. For the gRPC rule, add a second negative
 asserting that a real-definition assertion (`assert.strictEqual(check.path,
 "/grpc.health.v1.Health/Check")` with no `Check: {` mock literal) does **not**
-trip — pinning the librpc/health.test.js exemption.
+trip — pinning the librpc/health.test.js exemption. For the GraphIndex rule, add
+a second negative asserting that a `new GraphIndex(new LocalStorage(…), …)`
+construction with no `createMockStorage` does **not** trip — pinning the
+products/map/test/pipeline.test.js (real-GraphIndex integration) exemption.
 
 Verify: `bun test tests/check-libmock-rules.test.js`.
 
@@ -214,7 +221,7 @@ Verify: `bun test libraries/librepl` and `bun run invariants:check-libmock`.
 
 ## Step 7 — Part verification
 
-Run `bun run check` and
+Run `bun run check`, `bun run invariants:check-libmock` (SC2's own command), and
 `bun test libraries/libmock libraries/libgraph libraries/librpc products/guide libraries/librepl tests/check-libmock-rules.test.js`.
 Confirms SC1 (exports resolve + README), SC2 (each new rule flags its inline
-shape).
+shape; `check-libmock` stays green across the repo).

--- a/specs/0640-refactor-test-suite/plan-a-01.md
+++ b/specs/0640-refactor-test-suite/plan-a-01.md
@@ -15,6 +15,10 @@ dependency.
 - Created: `libraries/libmock/src/mock/environments.js`
 - Modified: `libraries/libmock/src/mock/index.js` (export the three)
 
+`src/index.js` already does `export * from "./mock/index.js"`, so the three
+resolve from the package root transitively — no top-level `src/index.js` edit is
+needed, and SC1's "exported from `src/index.js`" is satisfied.
+
 ```js
 // environments.js
 /**
@@ -128,10 +132,15 @@ triple/definition/bundle in a file that does not import the new fixture
   message: "inline GraphIndex triple — use createGraphIndexFixture",
 },
 {
-  // inline { Check: { path: "/grpc.health.v1.Health/Check" … } }
+  // inline mock object literal `{ Check: { path: "…", requestStream: … } }`.
+  // Keyed on the requestStream/responseStream literal keys inside a Check
+  // object, NOT the bare path string — librpc/health.test.js asserts on the
+  // real definition's `check.path` (no `Check: {` mock literal) and must not
+  // trip this rule.
   test: (t) =>
-    /Check\s*:\s*\{[\s\S]{0,120}?\/grpc\.health\.v1\.Health\/Check/.test(t) &&
-    !t.includes("createMockGrpcHealthDefinition"),
+    /Check\s*:\s*\{[\s\S]{0,160}?requestStream\s*:[\s\S]{0,80}?responseStream\s*:/.test(
+      t,
+    ) && !t.includes("createMockGrpcHealthDefinition"),
   message:
     "inline gRPC health definition — use createMockGrpcHealthDefinition",
 },
@@ -147,7 +156,10 @@ triple/definition/bundle in a file that does not import the new fixture
 
 Add a `has(...)` assertion per rule to `check-libmock-rules.test.js` (positive
 detection + a negative when the file imports the fixture), mirroring the
-existing `createMockSubprocess` cases.
+existing `createMockSubprocess` cases. For the gRPC rule, add a second negative
+asserting that a real-definition assertion (`assert.strictEqual(check.path,
+"/grpc.health.v1.Health/Check")` with no `Check: {` mock literal) does **not**
+trip — pinning the librpc/health.test.js exemption.
 
 Verify: `bun test tests/check-libmock-rules.test.js`.
 

--- a/specs/0640-refactor-test-suite/plan-a-01.md
+++ b/specs/0640-refactor-test-suite/plan-a-01.md
@@ -1,0 +1,208 @@
+# Plan 0640-a Part 01 — libmock fixtures, lint rules, consumer collapse
+
+Implements spec § A and design Components/Decisions 1–3, 8. Independently
+executable; no dependency on other parts.
+
+Libraries used: libmock (new fixtures), libgraph (`GraphIndex`, n3 `Store` —
+injected by consumers, not imported into libmock).
+
+## Step 1 — Add the three fixtures to libmock
+
+Add the three additive exports following the injected-collaborator pattern
+(Decision 1): graph constructors arrive as parameters; libmock gains no
+dependency.
+
+- Created: `libraries/libmock/src/mock/environments.js`
+- Modified: `libraries/libmock/src/mock/index.js` (export the three)
+
+```js
+// environments.js
+/**
+ * Graph-index test triple: a mock storage, an n3 Store, and a GraphIndex wired
+ * to both. GraphIndex and Store are injected so libmock stays dependency-free.
+ * @param {object} opts
+ * @param {Function} opts.GraphIndex - libgraph GraphIndex constructor.
+ * @param {Function} opts.Store - n3 Store constructor.
+ * @param {object} [opts.storageOverrides] - passed to createMockStorage.
+ * @param {*} [opts.prefixes] - prefixes arg for GraphIndex (default {}).
+ * @param {string} [opts.indexKey="test-graph.jsonl"] - jsonl key.
+ * @returns {{ n3Store: object, graphIndex: object, mockStorage: object }}
+ */
+export function createGraphIndexFixture({
+  GraphIndex,
+  Store,
+  storageOverrides,
+  prefixes = {},
+  indexKey = "test-graph.jsonl",
+}) {
+  const mockStorage = createMockStorage(storageOverrides);
+  const n3Store = new Store();
+  const graphIndex = new GraphIndex(mockStorage, n3Store, prefixes, indexKey);
+  return { n3Store, graphIndex, mockStorage };
+}
+
+/**
+ * The stripped gRPC health service definition guide's status check fakes — the
+ * { Check: { path, requestStream, responseStream } } shape, not librpc's real
+ * healthDefinition.
+ * @returns {{ Check: { path: string, requestStream: boolean, responseStream: boolean } }}
+ */
+export function createMockGrpcHealthDefinition() {
+  return {
+    Check: {
+      path: "/grpc.health.v1.Health/Check",
+      requestStream: false,
+      responseStream: false,
+    },
+  };
+}
+
+/**
+ * The readline/process/os/formatter/storage bundle librepl's tests inject.
+ * Reproduces libraries/librepl/test/librepl.test.js:13-58 exactly.
+ * @returns {{ readline, process, os, formatter, storage }}
+ */
+export function createReplEnvironment() {
+  const process = {
+    argv: ["node", "script.js"],
+    stdin: {
+      isTTY: true,
+      setEncoding: () => {},
+      async *[Symbol.asyncIterator]() {
+        yield "test input";
+      },
+    },
+    stdout: { write: () => {} },
+    stderr: { write: () => {} },
+    exit: (code) => {
+      process._exitCalled = true;
+      process._exitCode = code;
+    },
+    _exitCalled: false,
+    _exitCode: null,
+  };
+  return {
+    readline: { createInterface: () => ({ on: () => {}, prompt: () => {}, close: () => {} }) },
+    process,
+    os: { userInfo: () => ({ uid: 1000 }) },
+    formatter: () => ({ format: (text) => `formatted: ${text}` }),
+    storage: createMockStorage(),
+  };
+}
+```
+
+Import `createMockStorage` from `./storage.js`.
+
+Verify: `bun test libraries/libmock`.
+
+## Step 2 — Document the fixtures in the README
+
+Add one row per fixture to the Collaborators section with a one-line example.
+
+- Modified: `libraries/libmock/README.md`
+
+| Surface | Factory | Example |
+| --- | --- | --- |
+| graph-index | `createGraphIndexFixture` | `const { graphIndex } = createGraphIndexFixture({ GraphIndex, Store });` |
+| grpc health def | `createMockGrpcHealthDefinition` | `const def = createMockGrpcHealthDefinition();` |
+| repl env | `createReplEnvironment` | `const { readline, process } = createReplEnvironment();` |
+
+Verify: README lists all three under § Collaborators.
+
+## Step 3 — Add inline-shape lint rules
+
+Add one shape detector per fixture to the rules array, flagging the inline
+triple/definition/bundle in a file that does not import the new fixture
+(Decision 3 — shape match, not name match).
+
+- Modified: `scripts/check-libmock-rules.mjs`
+- Modified: `tests/check-libmock-rules.test.js`
+
+```js
+// new RULES entries
+{
+  // inline `new GraphIndex(mockStorage, n3Store, …)` triple
+  test: (t) =>
+    /new\s+GraphIndex\s*\(/.test(t) &&
+    !t.includes("createGraphIndexFixture"),
+  message: "inline GraphIndex triple — use createGraphIndexFixture",
+},
+{
+  // inline { Check: { path: "/grpc.health.v1.Health/Check" … } }
+  test: (t) =>
+    /Check\s*:\s*\{[\s\S]{0,120}?\/grpc\.health\.v1\.Health\/Check/.test(t) &&
+    !t.includes("createMockGrpcHealthDefinition"),
+  message:
+    "inline gRPC health definition — use createMockGrpcHealthDefinition",
+},
+{
+  // inline readline.createInterface bundle paired with a mock process exit flag
+  test: (t) =>
+    /createInterface\s*:/.test(t) &&
+    /_exitCalled/.test(t) &&
+    !t.includes("createReplEnvironment"),
+  message: "inline repl environment bundle — use createReplEnvironment",
+},
+```
+
+Add a `has(...)` assertion per rule to `check-libmock-rules.test.js` (positive
+detection + a negative when the file imports the fixture), mirroring the
+existing `createMockSubprocess` cases.
+
+Verify: `bun test tests/check-libmock-rules.test.js`.
+
+## Step 4 — Collapse the five libgraph consumers
+
+Replace the inline `{ mockStorage, n3Store, graphIndex }` setup with
+`createGraphIndexFixture`, passing `GraphIndex` and `Store` by direct injection
+(Open Q3 default).
+
+- Modified: `libraries/libgraph/test/{index-items,prefixes,index-loading,libgraph-filters,libgraph-query}.test.js`
+
+Each `beforeEach` becomes
+`({ mockStorage, n3Store, graphIndex } = createGraphIndexFixture({ GraphIndex, Store, … }))`,
+carrying that file's existing `storageOverrides` (e.g. prefixes.test.js's
+`ontology.ttl` getter), `prefixes` (e.g. `RDF_PREFIXES`), and `indexKey`. Tests
+that construct extra `new GraphIndex(...)` for ctor-validation
+(`index-loading.test.js`, `libgraph-query.test.js`) keep those direct
+constructions — the rule fires only on the rebuilt triple, and these files now
+import the fixture so the rule is satisfied. Add `createGraphIndexFixture` to
+the existing libmock import.
+
+Verify: `bun test libraries/libgraph` and `bun run invariants:check-libmock`.
+
+## Step 5 — Collapse the two grpc-health consumers
+
+Replace the inline health definition with `createMockGrpcHealthDefinition`.
+
+- Modified: `products/guide/test/status.test.js` (drop local
+  `createMockHealthDefinition`, import the fixture, call it in `createMockDeps`)
+- Modified: `libraries/librpc/test/health.test.js` — **audit first**: this file
+  exercises librpc's **real** `healthDefinition` (serialization round-trips),
+  which the design leaves untouched. If it contains no inline *mock* definition,
+  it is not a consumer; leave it unchanged and note so. Only collapse a genuine
+  inline mock shape if present.
+
+Verify: `bun test products/guide libraries/librpc` and
+`bun run invariants:check-libmock`.
+
+## Step 6 — Collapse the librepl consumer
+
+Replace the inline readline/process/os/formatter/storage bundle with
+`createReplEnvironment`.
+
+- Modified: `libraries/librepl/test/librepl.test.js`
+
+The `beforeEach` becomes
+`({ readline: mockReadline, process: mockProcess, os: mockOs, formatter: mockFormatter, storage: mockStorage } = createReplEnvironment())`,
+or destructure to the names the tests already use. Tests that mutate
+`mockProcess.argv` (line 108+) keep doing so on the returned object.
+
+Verify: `bun test libraries/librepl` and `bun run invariants:check-libmock`.
+
+## Step 7 — Part verification
+
+Run `bun run check` and
+`bun test libraries/libmock libraries/libgraph libraries/librpc products/guide libraries/librepl tests/check-libmock-rules.test.js`.
+Confirms SC1 (exports resolve + README), SC2 (each new rule flags its inline
+shape).

--- a/specs/0640-refactor-test-suite/plan-a-02.md
+++ b/specs/0640-refactor-test-suite/plan-a-02.md
@@ -42,8 +42,11 @@ Verify: `bun test libraries/libtemplate` (no `mkdtemp`).
 
 ## Step 3 — Sweep the remaining non-`integration` real-I/O files
 
-For each candidate below, apply the decision rule, then act. The rule (Open Q1
-default): **migrate** when the code under test accepts a `runtime` (or `fs`)
+The candidate lists below are the seed enumeration as of this plan; Step 4's
+`rg -l mkdtemp` gate is the authoritative closing check, so treat any
+non-`integration` `mkdtemp`/subprocess file the gate surfaces — listed here or
+not — as in-scope for the rule. For each candidate, apply the decision rule,
+then act. The rule (Open Q1 default): **migrate** when the code under test accepts a `runtime` (or `fs`)
 parameter and the assertions inspect pure logic/returned values; **rename** to
 `*.integration.test.js` when the real filesystem/subprocess behaviour is itself
 under test or no injection seam exists; **allow-list** only a genuine residual

--- a/specs/0640-refactor-test-suite/plan-a-02.md
+++ b/specs/0640-refactor-test-suite/plan-a-02.md
@@ -1,0 +1,105 @@
+# Plan 0640-a Part 02 — migrate real-I/O unit tests onto the seam
+
+Implements spec § B and design Component "Unit / integration boundary",
+Decision 4, Open Q1. Independently executable; no dependency on other parts.
+
+Libraries used: libmock (`createMockFs`, `createTestRuntime`).
+
+## Migration shape (applies to every step)
+
+A unit test that builds `createDefaultRuntime()` + a real `mkdtemp` and seeds it
+with `writeFileSync` becomes: a `createMockFs(seed)` whose `seed` is the file
+map the test previously wrote to disk, injected through
+`createTestRuntime({ fs: createMockFs(seed) })` (which sets `fsSync = fs`, the
+sync surface the loaders read). Drop the `mkdtempSync`/`writeFileSync`/`rmSync`
+and `tmpdir` imports. Use a fixed in-memory dir path (e.g. `/prompts`) for the
+loader's `promptDir`.
+
+## Step 1 — Migrate the libprompt loader test
+
+- Modified: `libraries/libprompt/test/loader.test.js`
+
+Replace the `beforeEach` tempdir with a per-test `createMockFs` seed. Each test
+that did `writeFileSync(join(tempDir, "x.prompt.md"), content)` seeds
+`createMockFs({ "/prompts/x.prompt.md": content })` and constructs
+`new PromptLoader("/prompts", createTestRuntime({ fs }))`. Constructor-validation
+tests (`promptDir is required`, etc.) need no fs at all. Drop the `node:fs` /
+`node:os` / `createDefaultRuntime` imports; import `createMockFs`,
+`createTestRuntime` from `@forwardimpact/libmock`.
+
+Verify: `bun test libraries/libprompt` (same pass count, no `mkdtemp`).
+
+## Step 2 — Migrate the libtemplate loader test
+
+- Modified: `libraries/libtemplate/test/loader.test.js`
+
+Same shape. The override-dir tests (`dataDir` second tmpdir, lines 67–90) seed
+both layers into one `createMockFs` map (`/defaults/page.html`,
+`/data/templates/page.html`) and pass the data dir through the loader's existing
+parameter. Drop `mkdirSync`/`mkdtempSync`/`rmSync`/`tmpdir`.
+
+Verify: `bun test libraries/libtemplate` (no `mkdtemp`).
+
+## Step 3 — Sweep the remaining non-`integration` real-I/O files
+
+For each candidate below, apply the decision rule, then act. The rule (Open Q1
+default): **migrate** when the code under test accepts a `runtime` (or `fs`)
+parameter and the assertions inspect pure logic/returned values; **rename** to
+`*.integration.test.js` when the real filesystem/subprocess behaviour is itself
+under test or no injection seam exists; **allow-list** only a genuine residual
+(record it for SC3).
+
+- Modified / renamed: the files in the candidate list.
+
+**Candidate list — `mkdtemp` (non-integration `*.test.js`):**
+
+`libraries/libcoaligned/test/{instructions,jtbd}.test.js`,
+`libraries/libconfig/test/{bootstrap,credential-env-override}.test.js`,
+`libraries/libeval/test/{assert,benchmark-apm-installer,benchmark-env-loader,benchmark-judge,benchmark-npm-installer,benchmark-report,benchmark-task-family,by-discussion,callback,lead-flags,task-input,trace-split}.test.js`,
+`libraries/libsyntheticgen/test/synthea.test.js`,
+`libraries/libsyntheticprose/test/build-prompt.test.js`,
+`libraries/libterrain/test/{fhir-microdata-rdf,pipeline,sinks}.test.js`,
+`libraries/libwiki/test/{agent-roster,audit-cli,audit-engine,audit-status-row,block-renderer,boot,cli-boot,cli-claim,cli-fix,cli-init,cli-log,cli-memo,cli-refresh,marker-migrator,skill-roster,weekly-log}.test.js`,
+`libraries/libxmr/test/summarize.test.js`,
+`products/landmark/test/{dispatcher,lib/commands-verb}.test.js`,
+`products/map/test/{activity/substrate-stage,exporter,pipeline}.test.js`,
+`products/outpost/test/sync-helpers-copy.test.js`,
+`tests/{capture-cli-golden,env-setup}.test.js`.
+
+**Candidate list — subprocess (`execFileSync`/`spawnSync`/`execSync`,
+non-integration):**
+
+`libraries/librc/test/{manager-logs,manager-start,manager-stop}.test.js`,
+`libraries/libwiki/test/cli-refresh.test.js`,
+`products/landmark/test/{dispatcher,lib/commands-verb}.test.js`,
+`services/oauth/test/no-github.test.js`,
+`tests/{check-ambient-deps,check-subprocess-in-tests,env-setup}.test.js`.
+
+**Classification hints from sampling (confirm per file, do not assume):**
+
+| Cluster | Likely disposition | Why |
+| --- | --- | --- |
+| Files passing `createDefaultRuntime()` into a runtime-accepting fn (`benchmark-report`, `jtbd`, `boot`, `exporter`) | migrate | seam exists; swap to `createTestRuntime({ fs })` |
+| `libwiki/test/cli-*.test.js` exercising a CLI command end-to-end against a real wiki dir | likely rename | the on-disk wiki round-trip is the behaviour under test |
+| `librc/test/manager-*.test.js`, `check-ambient-deps`/`check-subprocess-in-tests` self-tests | likely rename or already-exempt | spawn real processes / scan the real tree |
+| Guard self-tests (`tests/check-*.test.js`) | leave / allow-list | they intentionally exercise real I/O against the repo |
+
+**Skip:** files already named `*.integration.test.js` (e.g.
+`products/pathway/test/build-packs.integration.test.js`) and any entry already in
+`scripts/check-subprocess-in-tests.allow.json`.
+
+Verify per file: `bun test <file>`; `bun run invariants:check-subprocess-in-tests`.
+
+## Step 4 — Establish the SC3 allow-list and verify
+
+- Verify only: no source file change beyond Step 3.
+
+After the sweep, `rg -l mkdtemp` over non-`integration` `*.test.js` under
+`libraries/`, `products/`, `services/`, `tests/` must return only the
+deliberately-allow-listed residual (the guard self-tests). Record that residual
+set in the PR description so the reviewer can confirm it against SC3.
+
+Verify: `bun run invariants:check-ambient-deps`,
+`bun run invariants:check-subprocess-in-tests`, and
+`bun test libraries products services tests` for the touched directories green.
+Confirms SC3.

--- a/specs/0640-refactor-test-suite/plan-a-02.md
+++ b/specs/0640-refactor-test-suite/plan-a-02.md
@@ -17,7 +17,8 @@ loader's `promptDir`.
 
 ## Step 1 — Migrate the libprompt loader test
 
-- Modified: `libraries/libprompt/test/loader.test.js`
+- Modified: `libraries/libprompt/test/loader.test.js`,
+  `libraries/libprompt/package.json`
 
 Replace the `beforeEach` tempdir with a per-test `createMockFs` seed. Each test
 that did `writeFileSync(join(tempDir, "x.prompt.md"), content)` seeds
@@ -25,20 +26,28 @@ that did `writeFileSync(join(tempDir, "x.prompt.md"), content)` seeds
 `new PromptLoader("/prompts", createTestRuntime({ fs }))`. Constructor-validation
 tests (`promptDir is required`, etc.) need no fs at all. Drop the `node:fs` /
 `node:os` / `createDefaultRuntime` imports; import `createMockFs`,
-`createTestRuntime` from `@forwardimpact/libmock`.
+`createTestRuntime` from `@forwardimpact/libmock`. libprompt does **not** yet
+declare libmock — add `"@forwardimpact/libmock"` to `package.json`
+`devDependencies` (matching the version other libs pin) so
+`check-workspace-imports` stays green.
 
-Verify: `bun test libraries/libprompt` (same pass count, no `mkdtemp`).
+Verify: `bun test libraries/libprompt` (same pass count, no `mkdtemp`);
+`bun run invariants:check-workspace-imports`.
 
 ## Step 2 — Migrate the libtemplate loader test
 
-- Modified: `libraries/libtemplate/test/loader.test.js`
+- Modified: `libraries/libtemplate/test/loader.test.js`,
+  `libraries/libtemplate/package.json`
 
 Same shape. The override-dir tests (`dataDir` second tmpdir, lines 67–90) seed
 both layers into one `createMockFs` map (`/defaults/page.html`,
 `/data/templates/page.html`) and pass the data dir through the loader's existing
-parameter. Drop `mkdirSync`/`mkdtempSync`/`rmSync`/`tmpdir`.
+parameter. Drop `mkdirSync`/`mkdtempSync`/`rmSync`/`tmpdir`. libtemplate does
+**not** yet declare libmock — add `"@forwardimpact/libmock"` to `package.json`
+`devDependencies` so `check-workspace-imports` stays green.
 
-Verify: `bun test libraries/libtemplate` (no `mkdtemp`).
+Verify: `bun test libraries/libtemplate` (no `mkdtemp`);
+`bun run invariants:check-workspace-imports`.
 
 ## Step 3 — Sweep the remaining non-`integration` real-I/O files
 
@@ -50,9 +59,13 @@ then act. The rule (Open Q1 default): **migrate** when the code under test accep
 parameter and the assertions inspect pure logic/returned values; **rename** to
 `*.integration.test.js` when the real filesystem/subprocess behaviour is itself
 under test or no injection seam exists; **allow-list** only a genuine residual
-(record it for SC3).
+(record it for SC3). When a **migrate** disposition makes a test file the first
+in its package to import `@forwardimpact/libmock`, add libmock to that package's
+`package.json` `devDependencies` in the same change (per plan-a.md § Cross-cutting
+"Workspace-import declarations").
 
-- Modified / renamed: the files in the candidate list.
+- Modified / renamed: the files in the candidate list (plus any newly-importing
+  `package.json`).
 
 **Candidate list — `mkdtemp` (non-integration `*.test.js`):**
 

--- a/specs/0640-refactor-test-suite/plan-a-02.md
+++ b/specs/0640-refactor-test-suite/plan-a-02.md
@@ -91,7 +91,17 @@ non-integration):**
 `products/pathway/test/build-packs.integration.test.js`) and any entry already in
 `scripts/check-subprocess-in-tests.allow.json`.
 
-Verify per file: `bun test <file>`; `bun run invariants:check-subprocess-in-tests`.
+**Owned end-to-end here (also > 400 LOC, excluded from Part 03):** after
+applying the migrate/rename rule to `libraries/libterrain/test/pipeline.test.js`
+(411) and `libraries/libwiki/test/audit-engine.test.js` (421), bring each result
+under the 400-LOC ceiling — split by behaviour family (Part 03's rule) or
+allow-list if cohesive. `products/map/test/pipeline.test.js` is a **rename** to
+`*.integration.test.js` (real `GraphIndex` over `LocalStorage`); the Part 01
+GraphIndex rule is scoped to the `createMockStorage` triple, so it does not trip
+here.
+
+Verify per file: `bun test <file>`; `bun run invariants:check-subprocess-in-tests`;
+for the two dual-concern files, also confirm ≤400 LOC (or allow-listed).
 
 ## Step 4 — Establish the SC3 allow-list and verify
 

--- a/specs/0640-refactor-test-suite/plan-a-03.md
+++ b/specs/0640-refactor-test-suite/plan-a-03.md
@@ -1,0 +1,83 @@
+# Plan 0640-a Part 03 — split files over 400 LOC + shape policy
+
+Implements spec § C (large files) and design Decision 5 / Component "Test-file
+shape policy". Independently executable; no dependency on other parts.
+
+Libraries used: none (test-file restructuring only).
+
+## Split rule (applies to every file step)
+
+Split **by behaviour family** along existing top-level `describe` boundaries —
+each new file owns one cohesive family and stays ≤400 LOC. Name siblings
+`<original>-<family>.test.js` (e.g. `trace-collector-tojson.test.js`). Lift
+setup shared across the new siblings into a `test/helpers.js` or the relevant
+libmock fixture rather than copy-pasting. Do not change assertions, rename
+`src`, or alter coverage — this is a maintainability move with **no wall-time
+target** (Decision 7). Files whose only over-ceiling cause is a single
+indivisible behaviour (no clean family seam) go on the allow-list (Step 3)
+instead of being force-split.
+
+## Step 1 — Split the named priority cluster
+
+- Created/modified: split siblings under `libraries/libeval/test/` and
+  `libraries/libcli/test/`.
+
+| File (LOC) | Split along |
+| --- | --- |
+| `libeval/test/tee-writer.test.js` (559) | single `TeeWriter` describe — split by method/behaviour group inside it (e.g. write/flush vs error/teardown) |
+| `libeval/test/trace-collector.test.js` (518) | the four inner describes: `addLine`, `toJSON`, `toText`, `createTraceCollector` |
+| `libeval/test/redaction-pipeline.test.js` (506) | the six per-criterion describes (sentinel sweep / patterns / opt-out / toText fidelity / Supervisor / Facilitator) |
+| `libcli/test/cli.test.js` (539) | `parse`-family vs help-family vs error-family describes |
+
+Verify: `bun test libraries/libeval libraries/libcli`; each new file ≤400 LOC.
+
+## Step 2 — Split the remaining over-ceiling files
+
+Apply the split rule to the rest of the > 400 LOC set (model-types excluded —
+Part 04 owns it). Audit each for a clean behaviour-family seam; allow-list any
+without one (Step 3).
+
+- Created/modified: split siblings for —
+
+`libraries/libsecret/test/libsecret.test.js` (630),
+`libraries/libeval/test/{orchestration-toolkit,facilitator,redaction,agent-runner,trace-query}.test.js`,
+`libraries/libutil/test/finder.test.js` (481),
+`libraries/libdoc/test/{libdoc-builder,libdoc-llms}.test.js`,
+`libraries/libbridge/test/{resume-scheduler,dispatcher,callback-handler}.test.js`,
+`libraries/libindex/test/base-filters.test.js` (454),
+`services/msbridge/test/msbridge.test.js` (436),
+`libraries/libterrain/test/{datasets,pipeline}.test.js`,
+`libraries/libconfig/test/libconfig-getters.test.js` (433),
+`libraries/libsyntheticgen/test/parser.test.js` (425),
+`libraries/libwiki/test/audit-engine.test.js` (421),
+`tests/{model-matching-core,model-validation-data}.test.js`,
+`libraries/libtelemetry/test/visualizer-edge-cases.test.js` (415),
+`libraries/libsyntheticrender/test/{validate,fhir-microdata}.test.js`.
+
+Note: `products/pathway/test/build-packs.integration.test.js` (560) is an
+integration file — apply the same family split or allow-list it; the ceiling
+applies to all `*.test.js`.
+
+Verify: `bun test` for each touched library/product/service directory; each new
+file ≤400 LOC.
+
+## Step 3 — Record the shape policy and allow-list
+
+Add one CONTRIBUTING line stating the ceiling and the allow-list, and enumerate
+the deliberately-larger files.
+
+- Modified: `CONTRIBUTING.md`
+
+Add under the READ-DO "Simple over easy" area (judgement-shaped, **no lint** per
+Decision 5): a single line — "Target ≤400 LOC per `*.test.js`, split by
+behaviour family; files that are one cohesive behaviour may exceed it — keep the
+exception list here." — followed by the bulleted allow-list of files retained
+over 400 LOC with a half-line reason each.
+
+Verify: a size scan (`find … -name '*.test.js' | xargs wc -l | awk '$1>400'`)
+returns only the files named in the CONTRIBUTING allow-list. Confirms SC5.
+
+## Step 4 — Part verification
+
+Run `bun run check` and `bun test` across every touched directory. Confirms SC5
+and that splits preserved `0 fail` (SC6 contribution).

--- a/specs/0640-refactor-test-suite/plan-a-03.md
+++ b/specs/0640-refactor-test-suite/plan-a-03.md
@@ -46,10 +46,9 @@ without one (Step 3).
 `libraries/libbridge/test/{resume-scheduler,dispatcher,callback-handler}.test.js`,
 `libraries/libindex/test/base-filters.test.js` (454),
 `services/msbridge/test/msbridge.test.js` (436),
-`libraries/libterrain/test/{datasets,pipeline}.test.js`,
+`libraries/libterrain/test/datasets.test.js` (433),
 `libraries/libconfig/test/libconfig-getters.test.js` (433),
 `libraries/libsyntheticgen/test/parser.test.js` (425),
-`libraries/libwiki/test/audit-engine.test.js` (421),
 `tests/{model-matching-core,model-validation-data}.test.js`,
 `libraries/libtelemetry/test/visualizer-edge-cases.test.js` (415),
 `libraries/libsyntheticrender/test/{validate,fhir-microdata}.test.js`.
@@ -57,6 +56,11 @@ without one (Step 3).
 Note: `products/pathway/test/build-packs.integration.test.js` (560) is an
 integration file — apply the same family split or allow-list it; the ceiling
 applies to all `*.test.js`.
+
+Excluded (owned elsewhere, per plan-a.md cross-cutting):
+`libraries/libterrain/test/pipeline.test.js` and
+`libraries/libwiki/test/audit-engine.test.js` (Part 02, which brings them under
+the ceiling after the I/O migration); `tests/model-types.test.js` (Part 04).
 
 Verify: `bun test` for each touched library/product/service directory; each new
 file ≤400 LOC.

--- a/specs/0640-refactor-test-suite/plan-a-04.md
+++ b/specs/0640-refactor-test-suite/plan-a-04.md
@@ -1,0 +1,73 @@
+# Plan 0640-a Part 04 — collapse combinatorial matrices
+
+Implements spec § C (parametrization) and design Decision 6, Open Q2.
+Independently executable; **owns `tests/model-types.test.js`** (resolves the
+Part 03 overlap).
+
+Libraries used: none (hand-rolled property loops per Open Q2 default; do not
+admit `fast-check`).
+
+## Audit-then-collapse rule (applies to every step)
+
+Before collapsing, confirm the matrix exercises a **single implementation path**
+(Decision 6). Where it does, replace the cross-multiplied cases with: the
+boundary cases (min/max/just-over/just-under of each ordered axis) plus **one**
+hand-rolled property loop asserting the invariant across the full axis. Where an
+axis is a genuine branch (distinct code path per value), keep those as discrete
+cases — do not fold a real branch into the property loop. No coverage loss: the
+targeted functions' branch coverage is unchanged.
+
+## Step 1 — `libskill/test/modifiers.test.js`
+
+- Modified: `libraries/libskill/test/modifiers.test.js`
+
+Audit the `for (const cap of Object.values(Capability))` enumerations
+(lines 35, 124, 147, 156) and the capability × modifier expansion tests. Each
+loop that asserts one invariant over every capability is the property check —
+keep one such loop per invariant and add explicit boundary cases (a capability
+with skills, one with none, an unrecognized key). Collapse repeated per-value
+`test(...)` blocks that assert the same shape into the property loop.
+
+Verify: `bun test libraries/libskill/test/modifiers.test.js`; case count drops,
+suite green.
+
+## Step 2 — `libskill/test/policies-predicates.test.js`
+
+- Modified: `libraries/libskill/test/policies-predicates.test.js`
+
+Audit the level-ordered predicates (`hasMinLevel`, `hasLevel`,
+`hasBelowLevel` — lines 159–250) where each cross-multiplies a level against the
+ordered level set. Collapse each to boundary cases (at-threshold, one-below,
+one-above, the `below awareness` floor already present at line 242) plus one
+property loop asserting monotonicity across the level order. Leave the discrete
+predicate describes (`isAny`/`isNone`/`isCore`/… ) as-is — they test distinct
+branches, not a matrix.
+
+Verify: `bun test libraries/libskill/test/policies-predicates.test.js`.
+
+## Step 3 — `tests/model-types.test.js` (audit decides disposition)
+
+- Modified: `tests/model-types.test.js`
+
+Audit first. Inspection shows this file is broad **per-helper** coverage
+(`getSkillProficiencyIndex`, `clampSkillProficiency`,
+`skillProficiencyMeetsRequirement`, capability/emoji helpers, `deriveJob`, …),
+not a single cross-multiply. Two dispositions:
+
+- If the per-helper tests are discrete (no cross-multiplied matrix), this is a
+  **large-file split**, not a matrix collapse: split by behaviour family under
+  the 400-LOC ceiling (Type Helpers / Capability Functions / emoji / derive*)
+  per Part 03's split rule, since the file is 448 LOC.
+- Collapse only the genuinely cross-multiplied sections (e.g. the
+  proficiency/maturity `MeetsRequirement` ordered comparisons) to boundary +
+  one property loop, the same as Steps 1–2.
+
+Verify: `bun test tests/model-types.test.js`; resulting file(s) ≤400 LOC; suite
+green.
+
+## Step 4 — Part verification
+
+Run `bun run check` and
+`bun test libraries/libskill tests/model-types.test.js`. Confirms SC4 (matrices
+replaced by boundary + property with unchanged covered paths) and, for Step 3's
+split disposition, contributes to SC5.

--- a/specs/0640-refactor-test-suite/plan-a.md
+++ b/specs/0640-refactor-test-suite/plan-a.md
@@ -1,0 +1,69 @@
+# Plan 0640-a — Test-Side Hygiene
+
+Implements [spec.md](spec.md) per [design-a.md](design-a.md). Read both before
+executing; this plan does not restate them.
+
+## Approach
+
+Decomposed into four independently-executable parts that touch disjoint file
+sets: Part 01 adds the three libmock fixtures with their inline-shape lint rules
+and README lines, then collapses the eight named inline consumers onto them;
+Part 02 migrates the residual real-I/O **unit** tests onto the existing
+`runtime` seam (`createTestRuntime` + `createMockFs`) and renames genuine
+integration tests to `*.integration.test.js`; Part 03 splits the 30 over-400-LOC
+test files by behaviour family and records the shape policy plus its allow-list;
+Part 04 collapses the combinatorial matrices to boundary + property cases after
+auditing each for single-path. The three design Open Questions resolve to their
+stated defaults: graph fixtures take `GraphIndex`/`Store` by direct injection
+(Q3), property checks are hand-rolled loops (Q2), and the § B sweep migrates only
+assertions over pure logic — everything else is renamed (Q1).
+
+## Part Index
+
+| Part | Scope (spec §) | Primary paths | Depends on |
+| --- | --- | --- | --- |
+| [01](plan-a-01.md) | § A — three libmock fixtures + lint rules + consumer collapse | `libraries/libmock/`, `libraries/libgraph/test/`, `libraries/librpc/test/`, `products/guide/test/`, `libraries/librepl/test/`, `scripts/check-libmock-rules.mjs`, `tests/check-libmock-rules.test.js` | none |
+| [02](plan-a-02.md) | § B — migrate real-I/O unit tests onto the seam | `libraries/libprompt/test/`, `libraries/libtemplate/test/`, swept unit tests under `libraries/`, `products/`, `services/`, `tests/` | none |
+| [03](plan-a-03.md) | § C.1 — split files > 400 LOC + shape policy | the 29 over-ceiling files (model-types excluded — Part 04), `CONTRIBUTING.md` | none |
+| [04](plan-a-04.md) | § C.2 — collapse combinatorial matrices | `libraries/libskill/test/modifiers.test.js`, `policies-predicates.test.js`, `tests/model-types.test.js` | none |
+
+## Cross-cutting
+
+- **Runner.** All test files run under `bun test` (0650). `node:test`-style
+  imports remain bun-compatible; do not rewrite import style as part of this
+  work.
+- **Seam re-use.** Parts 02 consumes the injected `runtime` parameter 1370
+  shipped; no `src/` file changes in any part except where a fixture's injected
+  constructor is read from an existing export.
+- **model-types overlap.** `tests/model-types.test.js` (448 LOC) appears on both
+  the > 400 list and the matrix list. **Part 04 owns it** (audit then collapse);
+  Part 03's split set excludes it. If Part 04's audit finds it is broad
+  per-helper coverage rather than a single-path cross-multiply, Part 04 splits it
+  by behaviour family under the Part 03 ceiling instead of collapsing.
+- **Three-artifact rule.** Every new shared fixture lands with its export, its
+  `check-libmock-rules.mjs` shape rule, and its README line in the same commit
+  (Decision 2). Part 01 is the only part that adds fixtures.
+
+## Execution
+
+Route all four parts to an engineering agent. Parts 01, 02, 03, and 04 are
+mutually independent (disjoint file sets after the model-types assignment above)
+and may run in parallel. Each part ends green on `bun run check` and
+`bun test` for the directories it touched; the final integrating run verifies
+the full suite and the spec's six success criteria.
+
+## Risks
+
+- **`createMockFs` sync surface coverage (Part 02).** The loaders read
+  `runtime.fsSync` (`existsSync`/`readFileSync`); `createMockFs` provides those,
+  but a swept file may call a sync method the fake lacks. Verify each migrated
+  file's exact `fsSync` calls resolve against `createMockFs` before assuming the
+  swap is mechanical; extend the fake (Part 01-style, with rule + README) only
+  if a genuine gap appears.
+- **Matrix single-path assumption (Part 04).** Collapsing a matrix that actually
+  exercises distinct branches would drop coverage. Each matrix is audited for
+  single-path **before** collapse (Decision 6); if an axis is a real branch, keep
+  it as discrete cases rather than folding it into the property check.
+- **Behaviour-family split coupling (Part 03).** Splitting a file with shared
+  top-level setup can duplicate fixtures across the new files; lift shared setup
+  into a sibling helper or the relevant libmock fixture rather than copy-pasting.

--- a/specs/0640-refactor-test-suite/plan-a.md
+++ b/specs/0640-refactor-test-suite/plan-a.md
@@ -56,6 +56,30 @@ assertions over pure logic — everything else is renamed (Q1).
 - **Three-artifact rule.** Every new shared fixture lands with its export, its
   `check-libmock-rules.mjs` shape rule, and its README line in the same commit
   (Decision 2). Part 01 is the only part that adds fixtures.
+- **Workspace-import declarations.** `scripts/check-workspace-imports.mjs` fails
+  any `@forwardimpact/*` import not declared in the importing package's
+  `package.json`. Any file that **newly** imports `@forwardimpact/libmock` (or
+  any other workspace package) requires that package added to the importing
+  package's `devDependencies` in the same commit. Part 01's consumers
+  (libgraph, guide, map, librepl, librpc) already declare libmock; the new
+  importers are in Part 02 (libprompt, libtemplate, and any lib the sweep
+  newly migrates) — see Part 02.
+
+## STATUS sub-rows
+
+Each part is tracked as a `wiki/STATUS.md` sub-row under the master `0640` row,
+mirroring the 1370/1270 precedent (`1370/teardown`, `1270/protos-and-tenancy`):
+
+| Sub-row | Part |
+| --- | --- |
+| `0640/libmock-fixtures` | 01 |
+| `0640/io-migration` | 02 |
+| `0640/file-splits` | 03 |
+| `0640/matrix-collapse` | 04 |
+
+All four sub-rows enter at `plan approved` alongside the master row. Each
+advances to `plan implemented` when its part merges. The master `0640` row
+advances to `plan implemented` only when **every** sub-row is implemented.
 
 ## Execution
 

--- a/specs/0640-refactor-test-suite/plan-a.md
+++ b/specs/0640-refactor-test-suite/plan-a.md
@@ -40,6 +40,19 @@ assertions over pure logic — everything else is renamed (Q1).
   Part 03's split set excludes it. If Part 04's audit finds it is broad
   per-helper coverage rather than a single-path cross-multiply, Part 04 splits it
   by behaviour family under the Part 03 ceiling instead of collapsing.
+- **Part 02 ∩ Part 03 overlap.** `libraries/libterrain/test/pipeline.test.js`
+  (411 LOC, `mkdtemp`) and `libraries/libwiki/test/audit-engine.test.js` (421
+  LOC, `mkdtemp`) appear on both Part 02's sweep list and Part 03's split list.
+  **Part 02 owns both end-to-end**: migrate/rename the I/O first, then bring the
+  result under the 400-LOC ceiling (split by family, or allow-list per Part 03's
+  rule if cohesive). Part 03's split set excludes both. This keeps the two parts
+  file-disjoint and parallel-safe.
+- **map pipeline GraphIndex.** `products/map/test/pipeline.test.js` builds a
+  *real* `GraphIndex` over `LocalStorage` (an integration construction, not the
+  `createMockStorage` unit triple) and also uses `mkdtemp`. **Part 02 owns it**
+  as a rename to `*.integration.test.js`; Part 01's GraphIndex rule is scoped to
+  the `createMockStorage` triple so it does not trip on this file (or on the
+  rename).
 - **Three-artifact rule.** Every new shared fixture lands with its export, its
   `check-libmock-rules.mjs` shape rule, and its README line in the same commit
   (Decision 2). Part 01 is the only part that adds fixtures.


### PR DESCRIPTION
## Summary

- Implementation plan for [spec 0640](../tree/main/specs/0640-refactor-test-suite/spec.md) per the approved [design-a](../tree/main/specs/0640-refactor-test-suite/design-a.md): lift libmock fake reuse and cut maintenance surface (no wall-clock target, per design Decision 7).
- Decomposed into `plan-a.md` + four independently-executable, file-disjoint parts:
  - **01** § A — add `createGraphIndexFixture` / `createMockGrpcHealthDefinition` / `createReplEnvironment` to libmock with inline-shape lint rules + README lines; collapse the 8 named inline consumers.
  - **02** § B — migrate residual real-I/O **unit** tests onto the existing `runtime`/`createMockFs` seam; rename genuine integration tests to `*.integration.test.js`; declare the libmock devDep where newly imported.
  - **03** § C.1 — split the over-400-LOC test files by behaviour family; record the shape policy + allow-list in CONTRIBUTING (judgement, no new guard — per spec Non-goals + design Decision 5).
  - **04** § C.2 — collapse the combinatorial matrices to boundary + property cases after auditing each for single-path.
- Tracked via per-part STATUS sub-rows (`0640/libmock-fixtures|io-migration|file-splits|matrix-collapse`) mirroring the 1370/1270 precedent.
- Clean `kata-review` panel of 3; all blocker/high/medium findings addressed. Supersedes #1335 (closed) — two improvements from it (libmock devDep declarations, per-part STATUS sub-rows) grafted here.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

Planning artifacts only; the four parts execute on follow-on branches via `kata-implement`. Per-part verification is enumerated in each `plan-a-NN.md` § verification block.

https://claude.ai/code/session_01DDWeVZGVUUSAXF2jjjLC5H