### PR TITLE
plan(1420): single-source native binary builds

### DIFF
--- a/specs/1420-single-source-native-binaries/plan-a-01.md
+++ b/specs/1420-single-source-native-binaries/plan-a-01.md
@@ -1,0 +1,110 @@
+# Plan 1420-a-01 — Compile-readiness fixes
+
+Part 1 of [plan 1420-a](plan-a.md). Makes the shared `just build-binary` emit a
+working, versioned binary for the three CLIs that cannot join the build today.
+Independently executable on a branch off `origin/main`.
+
+Libraries used: none (uses libcodegen's existing `protobufjs` + `long` deps).
+
+## Step 1 — Bind `util.Long` for `fit-codegen`'s own proto loading
+
+Add a side-effecting module that binds protobufjs's `util.Long` to the `long`
+implementation, and import it at the top of the runtime proto-loading module so
+the binding runs before any 64-bit field default is resolved.
+
+- Created: `libraries/libcodegen/src/long-init.js`
+- Modified: `libraries/libcodegen/src/base.js`
+
+`libraries/libcodegen/src/long-init.js`:
+
+```js
+// protobufjs populates `util.Long` through a dynamic `inquire("long")` that
+// `bun build --compile` cannot resolve, leaving it undefined when a 64-bit
+// field default is computed — crashing the compiled fit-codegen binary at
+// startup. Bind it explicitly. Imported for its side effect by the proto-
+// loading module (base.js), not by the bin shim, because ES imports are
+// hoisted above shim-body statements and would bind too late.
+import protobuf from "protobufjs";
+import Long from "long";
+
+protobuf.util.Long = Long;
+protobuf.configure();
+```
+
+The `protobuf.util.Long = Long; protobuf.configure();` pair is the exact binding
+`libcodegen/src/types.js` (lines 62–69) already injects into *generated*
+downstream code; this module applies the same proven, idempotent pattern to
+`fit-codegen`'s **own** binary. In `libraries/libcodegen/src/base.js`, add the
+side-effect import immediately after the existing `import protobuf from "protobufjs";`
+(line 2):
+
+```js
+import protobuf from "protobufjs";
+import "./long-init.js";
+```
+
+Verify: `just build-binary fit-codegen bun-linux-x64`, then run the compiled
+binary against the repo's protos — `./dist/binaries/fit-codegen --all` completes
+and `./dist/binaries/fit-codegen --version` prints the version and exits 0. The
+`--all` run is the load-bearing check: it forces `base.js#loadProtobufRoot →
+resolveAll()`, the 64-bit-default resolution that throws today, so a regressed or
+absent `Long` binding fails here even if `--version`/`--help` pass.
+
+## Step 2 — Read `FIT_WIKI_VERSION` in the `fit-wiki` bin
+
+Give `fit-wiki` the env-injected version read with a source-execution
+`readFileSync` fallback, matching the `fit-codegen` pattern, so the compiled
+binary stops ENOENT-ing on its own `package.json`.
+
+- Modified: `libraries/libwiki/bin/fit-wiki.js`
+
+Replace the version resolution in `main()` (lines 19–24):
+
+```js
+  const version =
+    runtime.proc.env.FIT_WIKI_VERSION ||
+    JSON.parse(
+      runtime.fsSync.readFileSync(
+        new URL("../package.json", import.meta.url),
+        "utf8",
+      ),
+    ).version;
+```
+
+(`just build-binary` upper-cases the bin name to `FIT_WIKI_VERSION` and injects
+it via `--define`, so the `readFileSync` branch tree-shakes away in the binary.)
+
+Verify: `just build-binary fit-wiki bun-linux-x64 && ./dist/binaries/fit-wiki --version` prints the version and exits 0 (today it exits ENOENT).
+
+## Step 3 — Rename `fit-outpost`'s build-time version read
+
+Rename the bin entry's version env read from `OUTPOST_VERSION` to
+`FIT_OUTPOST_VERSION` — the name `just build-binary fit-outpost` injects (bin
+name upper-cased, `-`→`_`) — so a shared build of `fit-outpost` carries its
+version.
+
+- Modified: `products/outpost/bin/fit-outpost.js`
+
+Change the version read (lines 19–22):
+
+```js
+const VERSION =
+  process.env.FIT_OUTPOST_VERSION ||
+  JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"))
+    .version;
+```
+
+The comment above it referencing `bun build --define` stays accurate. `pkg/build.js`'s
+own scheduler compile (which injects `OUTPOST_VERSION` against `src/outpost.js`)
+is retired in [Part 03](plan-a-03.md) together with the `publish-macos.yml`
+rewire; leaving it until then keeps `just pkg` runnable on `main` between merges.
+
+Verify: `just build-binary fit-outpost bun-linux-x64 && ./dist/binaries/fit-outpost --version && ./dist/binaries/fit-outpost --help` — version prints, help lists the commands (today the installer's `src/outpost.js` binary prints nothing; this builds the real bin entry instead).
+
+## Risks
+
+- The `long-init.js` binding must execute before `base.js`'s `#loadProtobufRoot`
+  resolves any type. Placing the import directly under `base.js`'s own
+  `protobufjs` import guarantees module-init order; do not move it into
+  `bin/fit-codegen.js` (hoisting defeats it — see the design's rejected
+  alternative).

--- a/specs/1420-single-source-native-binaries/plan-a-02.md
+++ b/specs/1420-single-source-native-binaries/plan-a-02.md
@@ -1,0 +1,196 @@
+# Plan 1420-a-02 — CLI manifest + justfile + docs
+
+Part 2 of [plan 1420-a](plan-a.md). Introduces the single-source-of-truth build
+set and collapses the bespoke 0600 enumeration recipes onto it. Branch off
+`origin/main`; depends on [Part 01](plan-a-01.md) for the shared
+`fit-outpost` binary's version.
+
+Libraries used: libmacos (`scripts/build-app.sh`, consumed unchanged).
+
+## Step 1 — Create the CLI-set manifest
+
+Add the one authoritative list of the distributable build set: 6 product CLIs +
+25 gear CLIs + `fit-wiki`, each with its targets and a bundle tag (`.app`
+membership; `null` = native channel only).
+
+- Created: `build/cli-manifest.json`
+
+```json
+{
+  "clis": [
+    { "name": "fit-map",                "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "map" },
+    { "name": "fit-pathway",            "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "pathway" },
+    { "name": "fit-guide",              "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "guide" },
+    { "name": "fit-landmark",           "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "landmark" },
+    { "name": "fit-summit",             "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "summit" },
+    { "name": "fit-outpost",            "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "outpost" },
+    { "name": "fit-svcgraph",           "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-svcmcp",             "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-svcpathway",         "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-svctrace",           "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-svcvector",          "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-codegen",            "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-terrain",            "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-eval",               "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-doc",                "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-rc",                 "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-xmr",                "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-storage",            "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-logger",             "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-svscan",             "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-trace",              "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-visualize",          "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-query",              "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-subjects",           "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-process-graphs",     "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-process-resources",  "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-process-vectors",    "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-search",             "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-unary",              "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-tiktoken",           "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-download-bundle",    "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": "gear" },
+    { "name": "fit-wiki",               "targets": ["bun-linux-x64", "bun-darwin-arm64"], "bundle": null }
+  ]
+}
+```
+
+`fit-svcgraph` is first among `gear` entries so it remains the gear bundle's
+`--primary-exec` (the CLI `publish-brew.yml`'s gear smoke test invokes).
+
+Verify: `jq -e '.clis | length == 32' build/cli-manifest.json` exits 0, and every `.name` resolves: `jq -r '.clis[].name' build/cli-manifest.json | while read c; do just build-binary "$c" bun-linux-x64 >/dev/null; done` exits 0. (Run this on the integrated 01→02 branch — on a 02-only branch the `fit-outpost` binary still compiles but carries no version until Part 01's `FIT_OUTPOST_VERSION` rename lands.)
+
+## Step 2 — Replace the enumeration recipes with a manifest-driven `build-all`
+
+Delete `build-binaries`, `build-product-binaries`, `build-gear-binaries`, and
+`build-apps`; add a single `build-all` recipe that derives its CLI set from the
+manifest. No surviving recipe references a removed one or carries a build
+enumeration.
+
+- Modified: `justfile`
+
+Remove justfile lines 225–264 (`build-binaries` + `build-product-binaries` +
+`build-gear-binaries`) and 327–335 (`build-apps`). Add:
+
+```makefile
+# Build every distributable binary for TARGET, driven by build/cli-manifest.json
+build-all TARGET="bun-darwin-arm64": codegen
+    #!/usr/bin/env bash
+    set -euo pipefail
+    jq -r --arg t "{{TARGET}}" \
+      '.clis[] | select(.targets | index($t)) | .name' build/cli-manifest.json \
+      | while read -r CLI; do just build-binary "$CLI" "{{TARGET}}"; done
+```
+
+`build-binary` (lines 192–223) is unchanged — it stays the sole compile
+primitive and sole binary-build entry point.
+
+Verify: `rg -n 'build-binaries|build-product-binaries|build-gear-binaries|build-apps' justfile` returns nothing; `just build-all bun-linux-x64` compiles all 32 binaries into `dist/binaries/`.
+
+## Step 3 — Drive `build-app-gear` from the manifest
+
+Replace `build-app-gear`'s inline 25-CLI `--extra-exec` list with the gear
+subset of the manifest, keeping its irreducible packaging config (plist,
+entitlements, version, out-dir).
+
+- Modified: `justfile`
+
+Replace `build-app-gear` including its preceding comment (lines 293–325) with:
+
+```makefile
+# Assemble dist/apps/fit-gear.app — bundles the manifest's gear CLI subset
+build-app-gear:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mapfile -t GEAR < <(jq -r '.clis[] | select(.bundle == "gear") | .name' build/cli-manifest.json)
+    ARGS=(--bundle-name "fit-gear" --primary-exec "dist/binaries/${GEAR[0]}")
+    for CLI in "${GEAR[@]:1}"; do ARGS+=(--extra-exec "dist/binaries/$CLI"); done
+    ARGS+=(
+      --info-plist "macos/gear/Info.plist"
+      --entitlements "macos/gear/entitlements.plist"
+      --version "$(jq -r .version package.json)"
+      --out-dir dist/apps
+    )
+    bash libraries/libmacos/scripts/build-app.sh "${ARGS[@]}"
+```
+
+Verify (macOS): `jq '[.clis[]|select(.bundle=="gear")]|length' build/cli-manifest.json` is exactly 25; `just build-all bun-darwin-arm64 && just build-app-gear` produces `dist/apps/fit-gear.app` whose `Contents/MacOS/` holds those 25 gear binaries with `fit-svcgraph` as the primary exec.
+
+## Step 4 — Make `build-app-product` outpost consume the shared binary
+
+Stop `build-app-product`'s outpost path from compiling the scheduler; build only
+the Swift launcher and bundle the shared `dist/binaries/fit-outpost` as the
+extra exec. The non-outpost branch is unchanged.
+
+- Modified: `justfile`
+
+Replace the outpost branch of `build-app-product` (lines 270–282) so it reads:
+
+```makefile
+    if [ "{{NAME}}" = "outpost" ]; then
+      (cd products/outpost && bun pkg/build.js --launcher)
+      bash libraries/libmacos/scripts/build-app.sh \
+        --bundle-name "fit-outpost" \
+        --primary-exec "products/outpost/dist/Outpost" \
+        --extra-exec "dist/binaries/fit-outpost" \
+        --info-plist "products/outpost/macos/Info.plist" \
+        --entitlements "products/outpost/macos/Outpost.entitlements" \
+        --resource "products/outpost/config" \
+        --resource "products/outpost/templates" \
+        --resource "design/fit/assets/icon-outpost.svg" \
+        --version "$(jq -r .version products/outpost/package.json)" \
+        --out-dir dist/apps
+    else
+```
+
+Only the launcher invocation (`bun pkg/build.js --launcher` instead of
+`just build`) and the `--extra-exec` source (`dist/binaries/fit-outpost`
+instead of `products/outpost/dist/fit-outpost`) change; the launcher remains the
+bundle's primary exec.
+
+This recipe is `outpost-determinism-probe.yml`'s build path, but that probe's
+`paths:` filter (lines 6–9) only watches `products/outpost/**`,
+`libraries/libmacos/**`, and the probe file — **not** `justfile` — so it would
+not auto-run on this justfile-only change. Add `justfile` to that filter in the
+same step so the cdhash gate fires on PRs that touch the outpost-app recipe:
+
+```yaml
+    paths:
+      - "products/outpost/**"
+      - "libraries/libmacos/**"
+      - "justfile"
+      - ".github/workflows/outpost-determinism-probe.yml"
+```
+
+- Also modified: `.github/workflows/outpost-determinism-probe.yml`
+
+Verify (macOS): `just build-binary fit-outpost bun-darwin-arm64 && just build-app-product outpost` produces `dist/apps/fit-outpost.app`; the probe now triggers on this PR and its two-build cdhash comparison passes.
+
+## Step 5 — Update the release-internals doc
+
+Point the gear-CLI maintenance note at the manifest, since both
+`build-gear-binaries` and `build-app-gear`'s inline list no longer enumerate the
+set.
+
+- Modified: `websites/fit/docs/internals/release/index.md`
+
+Replace lines 68–70:
+
+```md
+When a library or service CLI is added or removed, update `build/cli-manifest.json`
+(the single source of truth for the build set, from which `build-app-gear` now
+derives the gear bundle's membership) and the `binary` stanzas in
+`Casks/fit-gear.rb` in the tap repo.
+```
+
+The cask→PATH mapping table (lines 58–66) stays as-is: it is human-facing
+documentation mirroring the tap repo's human-edited cask `binary` stanzas, not a
+build input, so it is not a second build-set enumeration in the spec's sense.
+
+Verify: `rg -n 'build-gear-binaries|build-product-binaries|build-binaries\b' websites/fit/docs/internals/release/index.md` returns nothing, and the surviving `build-app-gear` mention reads as manifest-derived (no inline CLI list beside it).
+
+## Risks
+
+- `build-app-gear`'s primary exec is positional (`GEAR[0]`); if the manifest's
+  gear order is edited so `fit-svcgraph` is no longer first, `publish-brew.yml`'s
+  gear smoke test (`fit-svcgraph --help`) and the cask's primary binary diverge.
+  Keep `fit-svcgraph` first.

--- a/specs/1420-single-source-native-binaries/plan-a-03.md
+++ b/specs/1420-single-source-native-binaries/plan-a-03.md
@@ -1,0 +1,379 @@
+# Plan 1420-a-03 — Native channel + workflow rewire
+
+Part 3 of [plan 1420-a](plan-a.md). Adds the reusable build workflow and the
+public native channel, rewires both macOS publish workflows onto shared
+artifacts, and retires Outpost's duplicate scheduler compile. Branch off
+`origin/main`; depends on [Part 01](plan-a-01.md) (smoke gate passes) and
+[Part 02](plan-a-02.md) (matrix reads the manifest).
+
+Libraries used: none.
+
+Pin every action to a full commit SHA per repo convention. SHAs already in use:
+`actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`,
+`actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4`,
+`forwardimpact/fit-bootstrap@v1`. The snippets below use the literal token
+`PIN_DOWNLOAD_ARTIFACT_V4` everywhere `actions/download-artifact` appears —
+**resolve it once** and pin all three occurrences identically before applying.
+Get the v4 SHA with:
+
+```sh
+gh api repos/actions/download-artifact/git/ref/tags/v4 --jq .object.sha
+```
+
+(Dereference to the commit if it returns a tag object.) The YAML will not run
+until every `PIN_DOWNLOAD_ARTIFACT_V4` is replaced with that SHA + ` # v4`.
+
+## Step 1 — Add `build-binaries.yml` reusable workflow
+
+Single source of build logic: a `workflow_call` matrix over (CLI × requested
+target) that compiles, gates by executing the binary, and uploads each binary +
+checksum keyed `{cli}-{target}`.
+
+- Created: `.github/workflows/build-binaries.yml`
+
+```yaml
+name: "Build: Binaries"
+
+on:
+  workflow_call:
+    inputs:
+      targets:
+        description: "JSON array of bun targets to build (subset of the manifest's)."
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      cells: ${{ steps.gen.outputs.cells }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - id: gen
+        env:
+          TARGETS: ${{ inputs.targets }}
+        run: |
+          CELLS=$(jq -c --argjson req "$TARGETS" '
+            [ .clis[] as $c | $c.targets[]
+              | select(. as $t | $req | index($t))
+              | { cli: $c.name, target: .,
+                  os: (if . == "bun-linux-x64" then "ubuntu-latest" else "macos-14" end) } ]
+          ' build/cli-manifest.json)
+          # Fail loudly on a bad `targets` input rather than emit an empty
+          # matrix that silently skips every build.
+          test "$(jq 'length' <<<"$CELLS")" -gt 0 \
+            || { echo "::error::no manifest CLI matches targets ${TARGETS}"; exit 1; }
+          echo "cells={\"include\":${CELLS}}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.cells) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: forwardimpact/fit-bootstrap@v1
+      - name: Ensure codegen is current
+        run: just codegen
+      - name: Compile
+        run: just build-binary "${{ matrix.cli }}" "${{ matrix.target }}"
+      - name: Smoke gate
+        run: |
+          BIN="dist/binaries/${{ matrix.cli }}"
+          # Capture stdout+stderr: a CLI that prints --help to stderr must still
+          # count as non-empty output (the gate is "starts and writes output").
+          OUT="$("$BIN" --help 2>&1)"
+          test -n "$OUT" || { echo "::error::${{ matrix.cli }} produced no output"; exit 1; }
+      - name: Checksum
+        run: shasum -a 256 "dist/binaries/${{ matrix.cli }}" | awk '{print $1}' > "dist/binaries/${{ matrix.cli }}.sha256"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: "${{ matrix.cli }}-${{ matrix.target }}"
+          path: |
+            dist/binaries/${{ matrix.cli }}
+            dist/binaries/${{ matrix.cli }}.sha256
+          if-no-files-found: error
+```
+
+The `--help` gate is the universal "starts and produces output" check (spec
+criterion #2). It catches the `fit-codegen` and `fit-outpost` failures because
+both manifest today as **startup** failures — the binary exits before arg
+parsing, so any invocation including `--help` reproduces them. `--help` is a
+pure print-and-exit for every CLI in the manifest because all are libcli
+`createCli` binaries (libcli short-circuits `--help`/`--version` before any
+dispatch or server start, so the five `fit-svc*` CLIs do not bind a port); a
+hypothetical hanging `--help` would time the cell out and surface, not mask, the
+problem. The deeper `fit-codegen` proto-resolution path is additionally proven by
+Part 01's `--all` verify before it ever reaches this gate.
+
+Verify: a PR carrying this file plus a temporary caller (or `publish-native.yml` from Step 2) runs the matrix; the `fit-codegen` and `fit-outpost` cells pass the smoke gate (they would fail before Part 01).
+
+## Step 2 — Add `publish-native.yml`
+
+Public raw-binary channel: build all targets through the reusable workflow, then
+attach every binary + checksum to the release.
+
+- Created: `.github/workflows/publish-native.yml`
+
+```yaml
+name: "Publish: Native"
+
+on:
+  push:
+    tags: ["native@v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  binaries:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      targets: '["bun-linux-x64", "bun-darwin-arm64"]'
+
+  release:
+    needs: binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@PIN_DOWNLOAD_ARTIFACT_V4 # v4
+        with:
+          path: dist/binaries
+          merge-multiple: true
+      - name: Create or reuse GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" --generate-notes 2>/dev/null \
+            || echo "Release $GITHUB_REF_NAME already exists"
+      - name: Restore executable bit and upload binaries + checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # actions/upload-artifact does not preserve the POSIX executable bit;
+          # restore it so downstream consumers receive runnable binaries (the
+          # `.sha256` siblings stay non-executable text).
+          find dist/binaries -type f ! -name '*.sha256' -exec chmod +x {} +
+          gh release upload "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --clobber dist/binaries/*
+```
+
+`native@v*` does not collide with `publish-brew.yml`'s tag allowlist (it lists
+only `gear@v*` and the six product tags).
+
+Verify: pushing a `native@v*` tag produces a release carrying one binary per
+CLI-per-target (32 × 2 = 64) plus a `.sha256` beside each.
+
+## Step 3 — Rewire `publish-brew.yml` onto shared artifacts
+
+Source macOS binaries from `build-binaries.yml` instead of compiling in-workflow;
+keep the `.app` wrap, codesign, cdhash-stability check, and cask PR.
+
+- Modified: `.github/workflows/publish-brew.yml`
+
+Add a leading reusable-workflow job and make `build` consume its artifacts.
+Replace **only the compile** in the `build` job — the **Ensure codegen** step
+(lines 51–52, now done inside `build-binaries.yml`) and the **Build bundle**
+step (lines 54–65) — with an artifact download and an assembly step. The
+`./.github/actions/audit` gate (line 49) is **kept**; it is a release gate, not
+part of the compile:
+
+```yaml
+jobs:
+  binaries:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      targets: '["bun-darwin-arm64"]'
+
+  build:
+    needs: binaries
+    runs-on: macos-14
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # ... existing "Extract bundle and version from tag" step (unchanged) ...
+      - uses: forwardimpact/fit-bootstrap@v1   # for `just` + the .app recipes
+      - uses: ./.github/actions/audit          # kept — release gate, unchanged
+      - uses: actions/download-artifact@PIN_DOWNLOAD_ARTIFACT_V4 # v4
+        with:
+          pattern: "*-bun-darwin-arm64"
+          path: dist/binaries
+          merge-multiple: true
+      - name: Assemble bundle
+        run: |
+          # upload-artifact drops the executable bit; restore it before wrapping.
+          find dist/binaries -type f ! -name '*.sha256' -exec chmod +x {} +
+          case "${{ steps.meta.outputs.kind }}" in
+            gear)     just build-app-gear ;;
+            product)  just build-app-product "${{ steps.meta.outputs.name }}" ;;
+          esac
+```
+
+The **Build bundle** step's `just build-gear-binaries` / `just build-binary`
+calls are gone (binaries arrive as artifacts; `build-app-*` consume
+`dist/binaries/*` after Part 02). In **Verify cdhash stability** (lines 78–104),
+keep the step but make its rebuild re-assemble the `.app` from the **same**
+downloaded binaries rather than recompiling. The rebuild block (lines 86–96)
+becomes:
+
+```yaml
+          rm -rf dist/apps products/outpost/dist   # keep dist/binaries (artifacts)
+          case "${{ steps.meta.outputs.kind }}" in
+            gear)     just build-app-gear ;;
+            product)  just build-app-product "${{ steps.meta.outputs.name }}" ;;
+          esac
+```
+
+`dist/binaries` is no longer deleted, so the downloaded binaries survive for the
+second assembly; for the outpost product tag, `build-app-product outpost`
+re-creates `products/outpost/dist` by re-running `bun pkg/build.js --launcher`
+(deterministic per spec 1170) and re-consumes the preserved
+`dist/binaries/fit-outpost`. The `BASELINE`/`AFTER` capture and comparison around
+this block are unchanged. The **Smoke test**, **Zip bundle and hash**, release,
+and **tap-pr** steps are unchanged.
+
+Routing every brew tag through `build-binaries.yml` compiles the **full**
+darwin-arm64 set (all 32 CLIs), not just the tag's CLI; the consuming job then
+assembles only its own bundle. This is the design's single-build-path
+consequence (design § publish-brew / publish-macos both download a subset of the
+same matrix) — it is intended, not a defect, but see the Risks note on its
+release-coupling cost.
+
+Verify: a `gear@v*` build downloads the 25 gear artifacts, assembles
+`fit-gear.app`, passes the codesign + cdhash-stability gate, and opens the cask
+PR; a product tag does the same for its single CLI.
+
+## Step 4 — Retire Outpost's scheduler compile in `pkg/build.js`
+
+Remove the scheduler compile so `pkg/build.js` builds only the launcher and
+assembles the `.app`/`.pkg` from a pre-supplied `dist/fit-outpost` (the shared
+binary), with a guard if it is missing.
+
+- Modified: `products/outpost/pkg/build.js`
+
+Delete `compileScheduler()` (lines 44–62) and its `--define 'process.env.OUTPOST_VERSION'`.
+Change the CLI flag logic (lines 167–186) so `scheduler` is gone and
+`app`/`pkg` imply only `launcher`, and guard `buildApp()` on the binary's
+presence:
+
+```js
+const all = args.length === 0;
+const want = {
+  launcher: all || args.includes("--launcher"),
+  app: args.includes("--app") || args.includes("--pkg"),
+  pkg: args.includes("--pkg"),
+};
+if (want.app || want.pkg) want.launcher = true;
+
+console.log(`Outpost Build (v${VERSION})`);
+console.log("==========================");
+if (want.launcher) compileLauncher();
+if (want.app) buildApp();
+if (want.pkg) buildPKG();
+```
+
+At the top of `buildApp()`, fail fast if the shared binary is absent:
+
+```js
+  if (!existsSync(join(DIST_DIR, APP_NAME))) {
+    throw new Error(
+      `${APP_NAME} binary not found in dist/ — build it with \`just build-binary fit-outpost\` or supply it from the native build before assembling the app.`,
+    );
+  }
+```
+
+The `--scheduler` flag and the `OUTPOST_VERSION` define no longer exist; the
+shared `just build-binary fit-outpost` (Part 01) is the only `fit-outpost`
+compile. Update the usage comment block (lines 5–10) to drop `--scheduler`.
+
+Verify: `bun pkg/build.js --launcher` builds only `dist/Outpost`; `bun pkg/build.js --app` errors clearly when `dist/fit-outpost` is absent and succeeds once it is present.
+
+## Step 5 — Rewire `publish-macos.yml` onto the shared `fit-outpost`
+
+Source the single `fit-outpost` binary from `build-binaries.yml`, place it where
+`pkg/build.js` expects it, then build the launcher and `.pkg`/`.app`.
+
+- Modified: `.github/workflows/publish-macos.yml`
+
+Add the reusable-workflow job and rewire the build job's compile step:
+
+```yaml
+jobs:
+  binaries:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      targets: '["bun-darwin-arm64"]'
+
+  build:
+    needs: binaries
+    runs-on: macos-14
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # ... existing "Extract version from tag" step (unchanged) ...
+      - uses: forwardimpact/fit-bootstrap@v1
+      - uses: ./.github/actions/audit
+      - name: Run tests
+        run: bun run test
+      - uses: actions/download-artifact@PIN_DOWNLOAD_ARTIFACT_V4 # v4
+        with:
+          name: fit-outpost-bun-darwin-arm64
+          path: products/outpost/dist   # workspace-root-relative → products/outpost/dist/fit-outpost
+      - name: Build .pkg installer
+        working-directory: products/outpost   # cwd here, so `dist/fit-outpost` == products/outpost/dist/fit-outpost
+        run: |
+          chmod +x dist/fit-outpost   # upload-artifact dropped the +x bit
+          bun pkg/build.js --pkg      # launcher + .app + .pkg; consumes dist/fit-outpost, no scheduler compile
+      # ... existing "Verify .pkg exists" + release + upload steps (unchanged) ...
+```
+
+`runs-on` moves from `macos-latest` to `macos-14` to match the build job's
+runner (cdhash-determinism parity with the other workflows). This aligns the
+Swift toolchain too: `outpost-determinism-probe.yml` and `publish-brew.yml`
+already build on `macos-14`, so the launcher's determinism profile is exercised
+there — moving `publish-macos.yml` onto the same image removes the only
+`outpost@v*` build still on `macos-latest`. The `just pkg` step is replaced; the
+scheduler is no longer compiled here.
+
+Verify: an `outpost@v*` build downloads the `fit-outpost` artifact, builds the
+launcher and `.pkg`, and uploads the installer; the `.pkg`'s bundled scheduler
+reports its version (`FIT_OUTPOST_VERSION` from Part 01). After applying all
+steps, `rg -n PIN_DOWNLOAD_ARTIFACT_V4 .github/workflows/` returns nothing — no
+unresolved pin token remains in any of the three workflows.
+
+## Risks
+
+- **`download-artifact` directory layout.** `merge-multiple: true` flattens all
+  artifacts into one directory; without it each artifact lands under its own
+  `name/` subdir and `dist/binaries/<cli>` paths break. The native and brew jobs
+  rely on the flattened layout; the macOS job downloads a single named artifact
+  so needs only `path`.
+- **Release coupling: every publish builds the full set.** Each `gear@v*`/
+  product/`outpost@v*` tag now compiles all 32 darwin-arm64 binaries through the
+  shared matrix and gates each on its smoke test, so an unrelated CLI's
+  compile/smoke failure blocks an otherwise-healthy cask release. This is the
+  design's single-build-path trade (byte-equality without cross-workflow races);
+  narrowing the matrix per tag would be a design change, not a plan tweak — flag
+  it if a release is ever blocked by an unrelated CLI.
+- **Codegen runs per matrix cell.** Each cell runs `just codegen` before its
+  compile (design § Interfaces requires the build set be codegen-current), so a
+  64-cell native build runs codegen 64×. Correct but not free; do not "optimize"
+  by hoisting codegen out of the matrix, as cross-target cells run on different
+  runners that each need their own generated tree.
+- **cdhash parity across runners.** `publish-brew.yml` and `publish-macos.yml`
+  must build on the same macOS runner image the binaries were compiled on
+  (`macos-14`); a runner-image mismatch between the `binaries` job and the
+  consuming job can perturb the codesign cdhash. Keep both pinned to `macos-14`.

--- a/specs/1420-single-source-native-binaries/plan-a.md
+++ b/specs/1420-single-source-native-binaries/plan-a.md
@@ -1,0 +1,49 @@
+# Plan 1420-a — Single-Source Native Binary Builds
+
+Implements [design 1420-a](design-a.md) for [spec 1420](spec.md).
+
+## Approach
+
+Land the three compile-readiness fixes first so the shared `just build-binary`
+emits correct binaries for `fit-codegen`, `fit-wiki`, and `fit-outpost`; then
+introduce the single-source-of-truth CLI manifest and collapse the bespoke
+`just` recipes onto it; then add the `build-binaries.yml` reusable workflow plus
+`publish-native.yml` and rewire `publish-brew.yml`/`publish-macos.yml` to consume
+its artifacts and retire the duplicate `fit-outpost` compile. Each part is its
+own branch off `origin/main` and verifiable on its own.
+
+## Parts
+
+| Part | Title | Scope | Depends on |
+|---|---|---|---|
+| [01](plan-a-01.md) | Compile-readiness fixes | `fit-codegen` `Long` binding, `fit-wiki` version env read, `fit-outpost` bin version-name rename | — |
+| [02](plan-a-02.md) | CLI manifest + justfile + docs | `build/cli-manifest.json`; delete the 0600 enumeration recipes; manifest-driven `build-all`, `build-app-gear`, `build-app-product` outpost path; release-doc update | 01 |
+| [03](plan-a-03.md) | Native channel + workflow rewire | `build-binaries.yml` reusable matrix, `publish-native.yml`, `publish-brew.yml`/`publish-macos.yml` rewire, `pkg/build.js` scheduler retirement | 01, 02 |
+
+## Execution
+
+Sequential: **01 → 02 → 03**. Part 02's `build-app-product outpost` path bundles
+the shared `dist/binaries/fit-outpost`, which only carries a version once 01's
+bin rename lands; Part 03's smoke gate only passes once 01's fixes are on `main`
+and its matrix reads the manifest 02 creates. Route all three to an engineering
+agent — there is no docs-only part (the release-doc edit in 02 is one table
+footnote adjacent to the recipe change). `outpost-determinism-probe.yml` is the
+local guard that 02's outpost-app rewrite preserves the spec-1170 cdhash
+contract; no part edits it.
+
+## Risks
+
+- **cdhash determinism (spec 1170).** Part 02 changes how `fit-outpost.app` is
+  assembled (Swift launcher built standalone via `pkg/build.js --launcher`,
+  scheduler sourced from the shared `dist/binaries/fit-outpost`). The launcher's
+  determinism profile is untouched and the bun compile is already deterministic,
+  but the `outpost-determinism-probe.yml` PR check is the gate that proves it —
+  treat a probe failure as a blocker, not flake.
+- **Smoke gate forces same-OS runners.** Each `bun-darwin-arm64` matrix cell
+  must run on `macos-14` and each `bun-linux-x64` cell on `ubuntu-latest`; a cell
+  scheduled on the wrong OS cannot execute its binary and will fail confusingly.
+  The matrix-generation job must attach the runner label per target.
+- **`fit-codegen` startup crash reproduces only when bundled.** The `Long` bug is
+  invisible under `bun run`/`bunx` (source execution resolves `long`); it appears
+  only in the `--compile` artifact. Verify every 01 fix against the *compiled*
+  binary, never the source CLI.


### PR DESCRIPTION
Implementation plan for [spec 1420](https://github.com/forwardimpact/monorepo/blob/main/specs/1420-single-source-native-binaries/spec.md), translating the approved [design 1420-a](https://github.com/forwardimpact/monorepo/blob/main/specs/1420-single-source-native-binaries/design-a.md) into execution-ready steps.

## What this plans

Native binaries become single-source: one `just build-binary` primitive driven by one checked-in CLI manifest, one `build-binaries.yml` reusable matrix that compiles + smoke-gates + uploads, a new `publish-native.yml` channel, and `publish-brew.yml`/`publish-macos.yml` rewired to consume the shared artifacts instead of compiling their own. Plus the three compile-readiness fixes (`fit-codegen` `Long` binding, `fit-wiki` version env read, `fit-outpost` version-name rename + retired scheduler compile).

## Decomposition (sequential 01 → 02 → 03)

| Part | Scope |
|---|---|
| `plan-a-01.md` | Compile-readiness fixes (libcodegen `long-init`, libwiki version, outpost bin rename) |
| `plan-a-02.md` | `build/cli-manifest.json`; delete the 0600 enumeration recipes; manifest-driven `build-all` / `build-app-gear` / outpost `build-app-product`; release-doc + determinism-probe path filter |
| `plan-a-03.md` | `build-binaries.yml` matrix, `publish-native.yml`, brew/macOS rewire, `pkg/build.js` scheduler retirement |

`plan-a.md` carries the approach, the part index, execution routing, and cross-cutting risks (spec-1170 cdhash determinism, same-OS smoke runners, full-set-per-tag release coupling).

## Review

Two clean `kata-review` panels (3 cold reviewers each). Round 1 surfaced a smoke-gate-adequacy concern, the dropped `audit` gate, missing `chmod +x` restores, and an under-specified cdhash edit; round 2 surfaced the determinism-probe path-filter gap and the full-set-per-tag coupling. No blockers remained; every blocker/high/medium finding was addressed before this PR opened.

https://claude.ai/code/session_01DMxSUzeygG8sV862Nsy6Pv

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMxSUzeygG8sV862Nsy6Pv)_