### PR TITLE
fix(kata-session): delegate Q3 obstacle routing, no session-side coaching dispatch

### DIFF
--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -128,23 +128,23 @@ Mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    Use `Announce` for between-question transitions. In solo mode, read files
    directly.
 6. **Collect, don't write.** The facilitator writes no files — participants own
-   every write (CSVs, weekly-log memory, issues) and the storyboard renders via
-   `fit-wiki refresh`. Collect the reported `#NNN`s and numbers via `Answer` for
-   the summary.
+   every write (CSVs, weekly-log memory, issues). Collect reported `#NNN`s and
+   numbers via `Answer` for the summary.
 7. **Route Q3 obstacles (team meetings only; skip for 1-on-1).** For each
-   obstacle pick one route (they can run in parallel) and log the choice.
-   Triggers and worked example:
+   obstacle the facilitator picks one route (parallel allowed) and logs it; it
+   runs no `gh` itself. Triggers and worked example:
    [`team-storyboard.md`](references/team-storyboard.md#q3-obstacle-routing).
    - **Discussion** — shared-artifact change (metric, rule, boundary, policy) or
-     same question in ≥2 agents' Q3 answers. RFC per
+     same question in ≥2 agents' Q3 answers. The owning agent opens an RFC per
      [coordination-protocol.md](../../agents/references/coordination-protocol.md):
      `gh discussion create --category <category> --title "RFC: <q>"`.
    - **Coaching** — participant-scoped blocker / unanalyzed trace / stalled
-     experiment: `gh workflow run kata-coaching.yml -f agent=<name>`.
+     experiment: not dispatched here. The obstacle issue stands; the coach
+     dispatches `kata-coaching.yml` in its Assess run.
 8. **Conclude (facilitated mode only).** Call `Conclude` with a session summary
    covering meeting type, key metrics, obstacles addressed, experiments planned,
-   and any coaching session triggered. (Wiki memory pushes automatically; the
-   facilitator does not commit.)
+   and any obstacle handed off for coaching. (Wiki pushes automatically; do not
+   commit.)
 
 ## Participant Protocol
 

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -85,7 +85,9 @@ permanent record.
 
 ## Q3 obstacle routing
 
-Per SKILL.md Step 7, pick a route per obstacle (parallel allowed):
+Per SKILL.md Step 7, the facilitator picks a route per obstacle (parallel
+allowed) and logs it — Discussion is delegated to the owning agent, Coaching is
+left to the coach's Assess run:
 
 | Trigger                                                                          | Route      |
 | -------------------------------------------------------------------------------- | ---------- |
@@ -96,11 +98,10 @@ Per SKILL.md Step 7, pick a route per obstacle (parallel allowed):
 **Worked example — multi-agent canonical-metric flag.** SE/RE/TW/PM each flagged a
 canonical-11 metric (`prs_actioned`, `releases_cut`, `errors_found`,
 `issues_created`). All four mapped to one shared artifact — right route: one
-Discussion, not four parallel coaching dispatches. Each headline bullet for the
-four metrics carries the new `Redefinition:` slot per
-[`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes);
-for this date the value is `—` on all four. Example:
-`- kata-security-update / prs_actioned — … — Redefinition: —`.
+Discussion, not four parallel coaching dispatches. Each of the four headline
+bullets carries the `Redefinition:` slot per
+[`coordination-protocol.md` § Measurement-system changes](../../../agents/references/coordination-protocol.md#measurement-system-changes)
+(here `—`).
 
 ## Participant briefing template
 


### PR DESCRIPTION
## Summary

Two follow-ups to the coach-as-pure-facilitator work (the facilitator has no Bash, so it can't run `gh`):

- **Deterministic storyboard render** — the `forwardimpact/kata-agent@v1` action now runs `fit-wiki refresh` **before** the agent (so the facilitator/participants read up-to-date Current Condition + Active/Concluded lists) and **after** the run under `always()` before the push (so obstacles/experiments the agent created/closed and any metric rows render into the pushed storyboard). That change lives in the `kata-agent` sibling repo (already tagged `v1`); this PR carries the matching protocol docs.
- **Q3 obstacle routing delegation** (this PR's code) — step 7 no longer asks the facilitator to run `gh`. The two routes split by ownership:
  - **Discussion** (shared-artifact RFC): the facilitator picks the route and logs it, then `Ask`s the owning agent to open the RFC and report the link.
  - **Coaching**: **not dispatched from the session.** Dispatching `kata-coaching.yml` is the improvement-coach's own self-directed Assess-run job (it picks the agent due for a 1-on-1 from the coaching log + run history). The storyboard obstacle issue is the handoff.

Touches `kata-session` SKILL + `team-storyboard.md`. Instruction-length budgets pass.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01BMHWyaREoPekSRBn5Lk5Fq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMHWyaREoPekSRBn5Lk5Fq)_