### PR TITLE
feat: single-source native binary builds (#1420)

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,75 @@
+name: "Build: Binaries"
+
+on:
+  workflow_call:
+    inputs:
+      targets:
+        description: "JSON array of bun targets to build (subset of the manifest's)."
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      cells: ${{ steps.gen.outputs.cells }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - id: gen
+        env:
+          TARGETS: ${{ inputs.targets }}
+        run: |
+          # `server: true` entries (long-running gRPC services) are still built,
+          # checksummed, uploaded, and bundled — the flag only tells the smoke
+          # step below to skip executing them, since their bin starts a server
+          # rather than honouring --help. Defaults to false for every other CLI.
+          CELLS=$(jq -c --argjson req "$TARGETS" '
+            [ .clis[] as $c | $c.targets[]
+              | select(. as $t | $req | index($t))
+              | { cli: $c.name, target: .,
+                  os: (if . == "bun-linux-x64" then "ubuntu-latest" else "macos-14" end),
+                  server: ($c.server // false) } ]
+          ' build/cli-manifest.json)
+          # Fail loudly on a bad `targets` input rather than emit an empty
+          # matrix that silently skips every build.
+          test "$(jq 'length' <<<"$CELLS")" -gt 0 \
+            || { echo "::error::no manifest CLI matches targets ${TARGETS}"; exit 1; }
+          echo "cells={\"include\":${CELLS}}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.cells) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: forwardimpact/fit-bootstrap@v1
+      - name: Ensure codegen is current
+        run: just codegen
+      - name: Compile
+        run: just build-binary "${{ matrix.cli }}" "${{ matrix.target }}"
+      - name: Smoke gate
+        # Servers boot on any invocation and never exit, so --help would hang
+        # the cell; they are excluded until they support a print-and-exit flag.
+        if: ${{ matrix.server != true }}
+        run: |
+          BIN="dist/binaries/${{ matrix.cli }}"
+          # Capture stdout+stderr: a CLI that prints --help to stderr must still
+          # count as non-empty output (the gate is "starts and writes output").
+          # `set -e` (the default shell) fails the gate when the binary exits
+          # non-zero — the fit-codegen / fit-outpost startup-crash failure mode.
+          OUT="$("$BIN" --help 2>&1)"
+          test -n "$OUT" || { echo "::error::${{ matrix.cli }} produced no output"; exit 1; }
+      - name: Checksum
+        run: shasum -a 256 "dist/binaries/${{ matrix.cli }}" | awk '{print $1}' > "dist/binaries/${{ matrix.cli }}.sha256"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: "${{ matrix.cli }}-${{ matrix.target }}"
+          path: |
+            dist/binaries/${{ matrix.cli }}
+            dist/binaries/${{ matrix.cli }}.sha256
+          if-no-files-found: error

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -45,6 +45,10 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.matrix.outputs.cells) }}
     runs-on: ${{ matrix.os }}
+    # Bound the cell: bootstrap + codegen + compile + smoke is a few minutes, so
+    # a stuck cell (e.g. a future non-server CLI that hangs on --help) fails fast
+    # instead of burning the default job budget.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: forwardimpact/fit-bootstrap@v1

--- a/.github/workflows/outpost-determinism-probe.yml
+++ b/.github/workflows/outpost-determinism-probe.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "products/outpost/**"
       - "libraries/libmacos/**"
+      - "justfile"
       - ".github/workflows/outpost-determinism-probe.yml"
 
 permissions:

--- a/.github/workflows/publish-brew.yml
+++ b/.github/workflows/publish-brew.yml
@@ -84,6 +84,8 @@ jobs:
             product)  "$BUNDLE/Contents/MacOS/fit-${{ steps.meta.outputs.name }}" --help ;;
             gear)
               SMOKE_CLI=$(jq -r '[.clis[] | select(.bundle == "gear" and (.server != true)) | .name][0]' build/cli-manifest.json)
+              test -n "$SMOKE_CLI" && [ "$SMOKE_CLI" != "null" ] \
+                || { echo "::error::no non-server gear CLI in manifest to smoke"; exit 1; }
               "$BUNDLE/Contents/MacOS/$SMOKE_CLI" --help
               ;;
           esac

--- a/.github/workflows/publish-brew.yml
+++ b/.github/workflows/publish-brew.yml
@@ -18,7 +18,15 @@ permissions:
   contents: read
 
 jobs:
+  binaries:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      targets: '["bun-darwin-arm64"]'
+
   build:
+    needs: binaries
     runs-on: macos-14
 
     permissions:
@@ -48,20 +56,19 @@ jobs:
 
       - uses: ./.github/actions/audit
 
-      - name: Ensure codegen is current
-        run: just codegen
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: "*-bun-darwin-arm64"
+          path: dist/binaries
+          merge-multiple: true
 
-      - name: Build bundle
+      - name: Assemble bundle
         run: |
+          # upload-artifact drops the executable bit; restore it before wrapping.
+          find dist/binaries -type f ! -name '*.sha256' -exec chmod +x {} +
           case "${{ steps.meta.outputs.kind }}" in
-            gear)
-              just build-gear-binaries
-              just build-app-gear
-              ;;
-            product)
-              just build-binary "fit-${{ steps.meta.outputs.name }}"
-              just build-app-product "${{ steps.meta.outputs.name }}"
-              ;;
+            gear)     just build-app-gear ;;
+            product)  just build-app-product "${{ steps.meta.outputs.name }}" ;;
           esac
 
       - name: Smoke test
@@ -83,16 +90,10 @@ jobs:
         run: |
           BUNDLE="dist/apps/${{ steps.meta.outputs.bundle }}"
           BASELINE=$(codesign -dvvv "$BUNDLE" 2>&1 | grep -i CDHash || true)
-          rm -rf dist/apps dist/binaries products/outpost/dist
+          rm -rf dist/apps products/outpost/dist   # keep dist/binaries (artifacts)
           case "${{ steps.meta.outputs.kind }}" in
-            gear)
-              just build-gear-binaries
-              just build-app-gear
-              ;;
-            product)
-              just build-binary "fit-${{ steps.meta.outputs.name }}"
-              just build-app-product "${{ steps.meta.outputs.name }}"
-              ;;
+            gear)     just build-app-gear ;;
+            product)  just build-app-product "${{ steps.meta.outputs.name }}" ;;
           esac
           AFTER=$(codesign -dvvv "$BUNDLE" 2>&1 | grep -i CDHash || true)
           if [ "$BASELINE" != "$AFTER" ]; then

--- a/.github/workflows/publish-brew.yml
+++ b/.github/workflows/publish-brew.yml
@@ -76,10 +76,16 @@ jobs:
           BUNDLE="dist/apps/${{ steps.meta.outputs.bundle }}"
           codesign --verify --deep --strict "$BUNDLE"
           # Product bundles run their own CLI's --help. Shared bundles exercise
-          # one primary CLI per bundle (others are reachable via cask binary stanzas).
+          # one CLI per bundle (others are reachable via cask binary stanzas).
+          # The gear primary-exec (fit-svcgraph) is a long-running server with no
+          # --help short-circuit, so smoke the first non-server gear CLI instead;
+          # teaching the server entries to honour --help is tracked separately.
           case "${{ steps.meta.outputs.kind }}" in
             product)  "$BUNDLE/Contents/MacOS/fit-${{ steps.meta.outputs.name }}" --help ;;
-            gear)     "$BUNDLE/Contents/MacOS/fit-svcgraph" --help ;;
+            gear)
+              SMOKE_CLI=$(jq -r '[.clis[] | select(.bundle == "gear" and (.server != true)) | .name][0]' build/cli-manifest.json)
+              "$BUNDLE/Contents/MacOS/$SMOKE_CLI" --help
+              ;;
           esac
 
       - name: Verify cdhash stability

--- a/.github/workflows/publish-macos.yml
+++ b/.github/workflows/publish-macos.yml
@@ -8,8 +8,16 @@ permissions:
   contents: read
 
 jobs:
+  binaries:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      targets: '["bun-darwin-arm64"]'
+
   build:
-    runs-on: macos-latest
+    needs: binaries
+    runs-on: macos-14
 
     permissions:
       contents: write
@@ -32,9 +40,16 @@ jobs:
       - name: Run tests
         run: bun run test
 
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: fit-outpost-bun-darwin-arm64
+          path: products/outpost/dist   # workspace-root-relative → products/outpost/dist/fit-outpost
+
       - name: Build .pkg installer
         working-directory: products/outpost
-        run: just pkg
+        run: |
+          chmod +x dist/fit-outpost   # upload-artifact dropped the +x bit
+          bun pkg/build.js --pkg      # launcher + .app + .pkg; consumes dist/fit-outpost, no scheduler compile
 
       - name: Verify .pkg exists
         working-directory: products/outpost

--- a/.github/workflows/publish-native.yml
+++ b/.github/workflows/publish-native.yml
@@ -23,8 +23,25 @@ jobs:
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          path: dist/binaries
-          merge-multiple: true
+          path: dist/artifacts
+      - name: Stage per-target release assets
+        run: |
+          # Each artifact is named {cli}-{target} but, rooted at the upload's
+          # common ancestor (dist/binaries), holds a bare {cli} + {cli}.sha256.
+          # `merge-multiple` would flatten both targets' identically-named files
+          # into one path (last-write-wins), so download per-artifact and re-emit
+          # each with the target in the asset filename — one addressable binary
+          # plus checksum per CLI-per-target. upload-artifact drops the POSIX
+          # executable bit, so `install -m 0755` restores it (the `.sha256`
+          # siblings stay non-executable text).
+          mkdir -p dist/release
+          for dir in dist/artifacts/*/; do
+            key=$(basename "$dir")   # {cli}-{target}, the addressable asset name
+            bin=$(find "$dir" -maxdepth 1 -type f ! -name '*.sha256')
+            test -n "$bin" || { echo "::error::artifact $key has no binary"; exit 1; }
+            install -m 0755 "$bin" "dist/release/$key"
+            cp "$bin.sha256" "dist/release/$key.sha256"
+          done
       - name: Create or reuse GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -32,12 +49,7 @@ jobs:
           gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" --generate-notes 2>/dev/null \
             || echo "Release $GITHUB_REF_NAME already exists"
-      - name: Restore executable bit and upload binaries + checksums
+      - name: Upload binaries + checksums
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          # actions/upload-artifact does not preserve the POSIX executable bit;
-          # restore it so downstream consumers receive runnable binaries (the
-          # `.sha256` siblings stay non-executable text).
-          find dist/binaries -type f ! -name '*.sha256' -exec chmod +x {} +
-          gh release upload "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --clobber dist/binaries/*
+        run: gh release upload "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --clobber dist/release/*

--- a/.github/workflows/publish-native.yml
+++ b/.github/workflows/publish-native.yml
@@ -1,0 +1,43 @@
+name: "Publish: Native"
+
+on:
+  push:
+    tags: ["native@v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  binaries:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-binaries.yml
+    with:
+      targets: '["bun-linux-x64", "bun-darwin-arm64"]'
+
+  release:
+    needs: binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist/binaries
+          merge-multiple: true
+      - name: Create or reuse GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" --generate-notes 2>/dev/null \
+            || echo "Release $GITHUB_REF_NAME already exists"
+      - name: Restore executable bit and upload binaries + checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # actions/upload-artifact does not preserve the POSIX executable bit;
+          # restore it so downstream consumers receive runnable binaries (the
+          # `.sha256` siblings stay non-executable text).
+          find dist/binaries -type f ! -name '*.sha256' -exec chmod +x {} +
+          gh release upload "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --clobber dist/binaries/*

--- a/build/cli-manifest.json
+++ b/build/cli-manifest.json
@@ -33,27 +33,32 @@
     {
       "name": "fit-svcgraph",
       "targets": ["bun-linux-x64", "bun-darwin-arm64"],
-      "bundle": "gear"
+      "bundle": "gear",
+      "server": true
     },
     {
       "name": "fit-svcmcp",
       "targets": ["bun-linux-x64", "bun-darwin-arm64"],
-      "bundle": "gear"
+      "bundle": "gear",
+      "server": true
     },
     {
       "name": "fit-svcpathway",
       "targets": ["bun-linux-x64", "bun-darwin-arm64"],
-      "bundle": "gear"
+      "bundle": "gear",
+      "server": true
     },
     {
       "name": "fit-svctrace",
       "targets": ["bun-linux-x64", "bun-darwin-arm64"],
-      "bundle": "gear"
+      "bundle": "gear",
+      "server": true
     },
     {
       "name": "fit-svcvector",
       "targets": ["bun-linux-x64", "bun-darwin-arm64"],
-      "bundle": "gear"
+      "bundle": "gear",
+      "server": true
     },
     {
       "name": "fit-codegen",

--- a/build/cli-manifest.json
+++ b/build/cli-manifest.json
@@ -1,0 +1,164 @@
+{
+  "clis": [
+    {
+      "name": "fit-map",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "map"
+    },
+    {
+      "name": "fit-pathway",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "pathway"
+    },
+    {
+      "name": "fit-guide",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "guide"
+    },
+    {
+      "name": "fit-landmark",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "landmark"
+    },
+    {
+      "name": "fit-summit",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "summit"
+    },
+    {
+      "name": "fit-outpost",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "outpost"
+    },
+    {
+      "name": "fit-svcgraph",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-svcmcp",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-svcpathway",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-svctrace",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-svcvector",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-codegen",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-terrain",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-eval",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-doc",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-rc",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-xmr",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-storage",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-logger",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-svscan",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-trace",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-visualize",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-query",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-subjects",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-process-graphs",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-process-resources",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-process-vectors",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-search",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-unary",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-tiktoken",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-download-bundle",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": "gear"
+    },
+    {
+      "name": "fit-wiki",
+      "targets": ["bun-linux-x64", "bun-darwin-arm64"],
+      "bundle": null
+    }
+  ]
+}

--- a/justfile
+++ b/justfile
@@ -223,57 +223,24 @@ build-binary NAME TARGET="bun-darwin-arm64":
       --outfile "dist/binaries/{{NAME}}" \
       "$ENTRY"
 
-# Build every Mach-O for the default target (codegen + product + gear)
-build-binaries: codegen build-product-binaries build-gear-binaries
-
-# Compile every fit-<product> CLI
-build-product-binaries:
-    just build-binary fit-outpost
-    just build-binary fit-guide
-    just build-binary fit-landmark
-    just build-binary fit-map
-    just build-binary fit-pathway
-    just build-binary fit-summit
-
-# Compile every gear CLI (services + library binaries; must stay in sync with
-# Casks/fit-gear.rb in the forwardimpact/homebrew-tap repo)
-build-gear-binaries:
-    just build-binary fit-svcgraph
-    just build-binary fit-svcmcp
-    just build-binary fit-svcpathway
-    just build-binary fit-svctrace
-    just build-binary fit-svcvector
-    just build-binary fit-codegen
-    just build-binary fit-terrain
-    just build-binary fit-eval
-    just build-binary fit-doc
-    just build-binary fit-rc
-    just build-binary fit-xmr
-    just build-binary fit-storage
-    just build-binary fit-logger
-    just build-binary fit-svscan
-    just build-binary fit-trace
-    just build-binary fit-visualize
-    just build-binary fit-query
-    just build-binary fit-subjects
-    just build-binary fit-process-graphs
-    just build-binary fit-process-resources
-    just build-binary fit-process-vectors
-    just build-binary fit-search
-    just build-binary fit-unary
-    just build-binary fit-tiktoken
-    just build-binary fit-download-bundle
+# Build every distributable binary for TARGET, driven by build/cli-manifest.json
+build-all TARGET="bun-darwin-arm64": codegen
+    #!/usr/bin/env bash
+    set -euo pipefail
+    jq -r --arg t "{{TARGET}}" \
+      '.clis[] | select(.targets | index($t)) | .name' build/cli-manifest.json \
+      | while read -r CLI; do just build-binary "$CLI" "{{TARGET}}"; done
 
 # Assemble dist/apps/fit-<NAME>.app for a product (outpost is special-cased)
 build-app-product NAME:
     #!/usr/bin/env bash
     set -euo pipefail
     if [ "{{NAME}}" = "outpost" ]; then
-      (cd products/outpost && just build)
+      (cd products/outpost && bun pkg/build.js --launcher)
       bash libraries/libmacos/scripts/build-app.sh \
         --bundle-name "fit-outpost" \
         --primary-exec "products/outpost/dist/Outpost" \
-        --extra-exec "products/outpost/dist/fit-outpost" \
+        --extra-exec "dist/binaries/fit-outpost" \
         --info-plist "products/outpost/macos/Info.plist" \
         --entitlements "products/outpost/macos/Outpost.entitlements" \
         --resource "products/outpost/config" \
@@ -291,49 +258,20 @@ build-app-product NAME:
         --out-dir dist/apps
     fi
 
-# Assemble dist/apps/fit-gear.app — bundles all 25 service + library CLIs
+# Assemble dist/apps/fit-gear.app — bundles the manifest's gear CLI subset
 build-app-gear:
-    bash libraries/libmacos/scripts/build-app.sh \
-      --bundle-name "fit-gear" \
-      --primary-exec "dist/binaries/fit-svcgraph" \
-      --extra-exec "dist/binaries/fit-svcmcp" \
-      --extra-exec "dist/binaries/fit-svcpathway" \
-      --extra-exec "dist/binaries/fit-svctrace" \
-      --extra-exec "dist/binaries/fit-svcvector" \
-      --extra-exec "dist/binaries/fit-codegen" \
-      --extra-exec "dist/binaries/fit-terrain" \
-      --extra-exec "dist/binaries/fit-eval" \
-      --extra-exec "dist/binaries/fit-doc" \
-      --extra-exec "dist/binaries/fit-rc" \
-      --extra-exec "dist/binaries/fit-xmr" \
-      --extra-exec "dist/binaries/fit-storage" \
-      --extra-exec "dist/binaries/fit-logger" \
-      --extra-exec "dist/binaries/fit-svscan" \
-      --extra-exec "dist/binaries/fit-trace" \
-      --extra-exec "dist/binaries/fit-visualize" \
-      --extra-exec "dist/binaries/fit-query" \
-      --extra-exec "dist/binaries/fit-subjects" \
-      --extra-exec "dist/binaries/fit-process-graphs" \
-      --extra-exec "dist/binaries/fit-process-resources" \
-      --extra-exec "dist/binaries/fit-process-vectors" \
-      --extra-exec "dist/binaries/fit-search" \
-      --extra-exec "dist/binaries/fit-unary" \
-      --extra-exec "dist/binaries/fit-tiktoken" \
-      --extra-exec "dist/binaries/fit-download-bundle" \
-      --info-plist "macos/gear/Info.plist" \
-      --entitlements "macos/gear/entitlements.plist" \
-      --version "$(jq -r .version package.json)" \
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mapfile -t GEAR < <(jq -r '.clis[] | select(.bundle == "gear") | .name' build/cli-manifest.json)
+    ARGS=(--bundle-name "fit-gear" --primary-exec "dist/binaries/${GEAR[0]}")
+    for CLI in "${GEAR[@]:1}"; do ARGS+=(--extra-exec "dist/binaries/$CLI"); done
+    ARGS+=(
+      --info-plist "macos/gear/Info.plist"
+      --entitlements "macos/gear/entitlements.plist"
+      --version "$(jq -r .version package.json)"
       --out-dir dist/apps
-
-# Fan-out: build every Mach-O, then every bundle
-build-apps: build-binaries
-    just build-app-product outpost
-    just build-app-product guide
-    just build-app-product landmark
-    just build-app-product map
-    just build-app-product pathway
-    just build-app-product summit
-    just build-app-gear
+    )
+    bash libraries/libmacos/scripts/build-app.sh "${ARGS[@]}"
 
 # ── Quality ───────────────────────────────────────────────────────
 

--- a/libraries/libcodegen/bin/fit-codegen.js
+++ b/libraries/libcodegen/bin/fit-codegen.js
@@ -2,6 +2,14 @@
 
 import "@forwardimpact/libpreflight/node22";
 
+// Bind protobufjs's `util.Long` before any other import evaluates. The
+// `@grpc/proto-loader` import below pulls in protobufjs's descriptor extension,
+// which calls `Root.fromJSON(...).resolveAll()` at module-evaluation time —
+// resolving a 64-bit field default needs `util.Long`, which `bun --compile`
+// leaves undefined (see long-init.js). This side-effect import must precede the
+// proto-loader import so the binding is in place before that resolveAll runs.
+import "../src/long-init.js";
+
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";

--- a/libraries/libcodegen/src/base.js
+++ b/libraries/libcodegen/src/base.js
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 import protobuf from "protobufjs";
+import "./long-init.js";
 
 /** Convert camelCase to snake_case (protobufjs normalizes field names) */
 function camelToSnake(str) {

--- a/libraries/libcodegen/src/long-init.js
+++ b/libraries/libcodegen/src/long-init.js
@@ -1,0 +1,17 @@
+// protobufjs populates `util.Long` through a dynamic `inquire("long")` that
+// `bun build --compile` cannot resolve, leaving it undefined when a 64-bit
+// field default is computed — crashing the compiled fit-codegen binary at
+// startup (`util.Long.fromNumber is not a function`). Bind it explicitly.
+//
+// Imported for its side effect both by `bin/fit-codegen.js` (ahead of the
+// `@grpc/proto-loader` import, whose descriptor extension runs `resolveAll()`
+// at module-evaluation time) and by base.js (ahead of its own runtime
+// `Root.resolveAll()`). ES module imports evaluate in source order, so an
+// ordered side-effect import binds before the proto-loading code runs —
+// inline binding statements in an entry body would not, since imports hoist
+// above them.
+import protobuf from "protobufjs";
+import Long from "long";
+
+protobuf.util.Long = Long;
+protobuf.configure();

--- a/products/outpost/justfile
+++ b/products/outpost/justfile
@@ -15,15 +15,12 @@ default:
 prepare-template:
     bun pkg/build.js --prepare-template
 
-# Compile standalone scheduler binary
-build-scheduler:
-    bun pkg/build.js --scheduler
-
 # Compile Swift app launcher (includes status menu UI)
 build-launcher:
     bun pkg/build.js --launcher
 
-# Prepare templates + compile scheduler + compile launcher
+# Compile the Swift launcher. The fit-outpost scheduler binary now comes from
+# the shared `just build-binary fit-outpost`, not this recipe.
 build:
     bun pkg/build.js
 

--- a/products/outpost/pkg/build.js
+++ b/products/outpost/pkg/build.js
@@ -3,11 +3,13 @@
 // Build script for Outpost (arm64 macOS).
 //
 // Usage:
-//   bun pkg/build.js                    Compile scheduler + launcher
+//   bun pkg/build.js                    Compile launcher
 //   bun pkg/build.js --app              Above + assemble Outpost.app
 //   bun pkg/build.js --pkg              Above + .pkg installer
-//   bun pkg/build.js --scheduler        Compile scheduler binary only
 //   bun pkg/build.js --launcher         Compile Swift launcher only
+//
+// The fit-outpost scheduler binary is produced by the shared
+// `just build-binary fit-outpost` and must be present in dist/ before --app/--pkg.
 
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -35,29 +37,6 @@ function ensureDir(dir) {
 function run(cmd, opts = {}) {
   console.log(`  $ ${cmd}`);
   return execSync(cmd, { encoding: "utf8", stdio: "inherit", ...opts });
-}
-
-// ---------------------------------------------------------------------------
-// Compile scheduler binary
-// ---------------------------------------------------------------------------
-
-function compileScheduler() {
-  const outputPath = join(DIST_DIR, APP_NAME);
-
-  console.log(`\nCompiling ${APP_NAME}...`);
-  ensureDir(DIST_DIR);
-
-  const cmd = [
-    "bun build",
-    "--compile",
-    `--outfile "${outputPath}"`,
-    "src/outpost.js",
-  ].join(" ");
-
-  run(cmd, { cwd: PROJECT_DIR });
-
-  console.log(`  -> ${outputPath}`);
-  return outputPath;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,6 +89,12 @@ function compileLauncher() {
 
 function buildApp() {
   console.log("\nAssembling Outpost.app...");
+
+  if (!existsSync(join(DIST_DIR, APP_NAME))) {
+    throw new Error(
+      `${APP_NAME} binary not found in dist/ — build it with \`just build-binary fit-outpost\` or supply it from the native build before assembling the app.`,
+    );
+  }
 
   const LIBMACOS = join(PROJECT_DIR, "..", "..", "libraries", "libmacos");
   const script = join(LIBMACOS, "scripts", "build-app.sh");
@@ -165,21 +150,14 @@ const args = process.argv.slice(2);
 // Explicit flags → run only those steps; --app/--pkg imply the earlier steps.
 const all = args.length === 0;
 const want = {
-  scheduler: all || args.includes("--scheduler"),
   launcher: all || args.includes("--launcher"),
   app: args.includes("--app") || args.includes("--pkg"),
   pkg: args.includes("--pkg"),
 };
-if (want.app || want.pkg) {
-  want.scheduler = true;
-  want.launcher = true;
-}
+if (want.app || want.pkg) want.launcher = true;
 
 console.log(`Outpost Build (v${VERSION})`);
 console.log("==========================");
-// Scheduler first (before launcher exists in dist/) so the launcher binary
-// is not embedded in the compiled binary.
-if (want.scheduler) compileScheduler();
 if (want.launcher) compileLauncher();
 if (want.app) buildApp();
 if (want.pkg) buildPKG();

--- a/products/outpost/pkg/build.js
+++ b/products/outpost/pkg/build.js
@@ -146,8 +146,9 @@ function buildPKG() {
 
 const args = process.argv.slice(2);
 
-// No flags → full default build (scheduler + launcher).
-// Explicit flags → run only those steps; --app/--pkg imply the earlier steps.
+// No flags → default build (launcher only; the fit-outpost scheduler binary
+// comes from the shared `just build-binary fit-outpost`, not this script).
+// Explicit flags → run only those steps; --app/--pkg imply the launcher.
 const all = args.length === 0;
 const want = {
   launcher: all || args.includes("--launcher"),

--- a/websites/fit/docs/internals/release/index.md
+++ b/websites/fit/docs/internals/release/index.md
@@ -65,9 +65,10 @@ the authoritative mapping between casks and the CLIs they place on `PATH`.
 | `fit-outpost` | `fit-outpost` | 1 |
 | `fit-gear` | `fit-svcgraph`, `fit-svcmcp`, `fit-svcpathway`, `fit-svctrace`, `fit-svcvector`, `fit-codegen`, `fit-terrain`, `fit-eval`, `fit-doc`, `fit-rc`, `fit-xmr`, `fit-storage`, `fit-logger`, `fit-svscan`, `fit-trace`, `fit-visualize`, `fit-query`, `fit-subjects`, `fit-process-graphs`, `fit-process-resources`, `fit-process-vectors`, `fit-search`, `fit-unary`, `fit-tiktoken`, `fit-download-bundle` | 25 |
 
-When a library or service CLI is added or removed, update both the
-`build-gear-binaries` / `build-app-gear` recipes in the monorepo justfile and
-the `binary` stanzas in `Casks/fit-gear.rb` in the tap repo.
+When a library or service CLI is added or removed, update `build/cli-manifest.json`
+(the single source of truth for the build set, from which `build-app-gear` now
+derives the gear bundle's membership) and the `binary` stanzas in
+`Casks/fit-gear.rb` in the tap repo.
 
 ## Livecheck regex pattern
 

--- a/websites/fit/docs/internals/release/index.md
+++ b/websites/fit/docs/internals/release/index.md
@@ -68,7 +68,10 @@ the authoritative mapping between casks and the CLIs they place on `PATH`.
 When a library or service CLI is added or removed, update `build/cli-manifest.json`
 (the single source of truth for the build set, from which `build-app-gear` now
 derives the gear bundle's membership) and the `binary` stanzas in
-`Casks/fit-gear.rb` in the tap repo.
+`Casks/fit-gear.rb` in the tap repo. Mark a long-running service CLI — one whose
+`bin` starts a server rather than printing `--help` and exiting — with
+`"server": true` so the native build still compiles, checksums, uploads, and
+bundles it but its per-binary smoke gate skips execution (running it would hang).
 
 ## Livecheck regex pattern
 


### PR DESCRIPTION
## Summary

Implements [spec 1420](specs/1420-single-source-native-binaries/spec.md): native `fit-*` binaries are now produced in exactly one place, gated by a per-binary smoke test, published as a raw release channel, and consumed by both macOS publish workflows — plus compile-readiness fixes.

- **`fit-codegen` compile-readiness** — bind protobufjs's `util.Long` (`libcodegen/src/long-init.js`) so the `--compile` binary no longer crashes at startup. The binding is imported in `bin/fit-codegen.js` ahead of `@grpc/proto-loader` (whose descriptor extension runs `resolveAll()` at module-eval time) and in `base.js`.
- **Single-source manifest** — `build/cli-manifest.json` is the sole enumeration of the distributable build set (6 product + 25 gear + `fit-wiki`). The bespoke `build-binaries`/`build-product-binaries`/`build-gear-binaries`/`build-apps` recipes are deleted; `build-binary` is the only compile primitive, and `build-all`/`build-app-gear`/`build-app-product` derive from the manifest.
- **`build-binaries.yml`** — reusable `workflow_call` matrix (CLI × target) that compiles, smoke-gates, checksums, and uploads each binary. `publish-native.yml` (new) publishes per-CLI-per-target binaries + checksums on `native@v*`; `publish-brew.yml` and `publish-macos.yml` now consume shared artifacts instead of compiling their own.
- **Outpost** — the `.app` consumes the shared `dist/binaries/fit-outpost`; `pkg/build.js` retires the scheduler compile and builds only the Swift launcher.

### Maintainer-sanctioned deviations (documented in commits)

- The five `fit-svc*` service CLIs are long-running gRPC servers that boot on any invocation (no `--help` short-circuit), so they are flagged `"server": true` and **excluded from smoke execution** — still compiled, checksummed, uploaded, and bundled. Teaching them to honour `--help` is tracked as follow-up.
- The compiled `fit-codegen --all` still can't bundle its `.mustache` templates; spec criterion #3 requires only `--version` (met), and codegen always runs from source via `bunx`. Tracked as follow-up.

### Review

Two independent 5-reviewer panels (`kata-review`); every consensus blocker/high/medium addressed, including a native-channel artifact-collision blocker (per-target asset names) and the gear smoke-test server-hang.

## Test plan

- [x] `bun run check`
- [x] `bun run test` (4159 pass, 0 fail)
- [x] Compiled binaries verified: `fit-codegen --version` → 0.1.60, `fit-wiki --version` → 0.2.13, `fit-outpost --version` → 3.1.4 (all three failed before); `just build-all bun-linux-x64` compiles all 32

https://claude.ai/code/session_017xyoDTyeuGB4W8QfJgbcmv

---
_Generated by [Claude Code](https://claude.ai/code/session_017xyoDTyeuGB4W8QfJgbcmv)_