### PR TITLE
build(deps): trim default install (~57 MB) and provision synthetic-data tools on demand

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -394,9 +394,12 @@
         "@forwardimpact/libprompt": "^0.1.9",
         "@forwardimpact/libsyntheticrender": "^0.1.25",
       },
-      "optionalDependencies": {
+      "peerDependencies": {
         "@faker-js/faker": "^10.4.0",
       },
+      "optionalPeers": [
+        "@faker-js/faker",
+      ],
     },
     "libraries/libsyntheticprose": {
       "name": "@forwardimpact/libsyntheticprose",
@@ -1217,8 +1220,6 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
-
-    "@faker-js/faker": ["@faker-js/faker@10.4.0", "", {}, "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw=="],
 
     "@forwardimpact/gear": ["@forwardimpact/gear@workspace:products/gear"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -302,7 +302,6 @@
         "jsdom": "^29.1.1",
         "microdata-rdf-streaming-parser": "^3.0.0",
         "n3": "^2.0.3",
-        "rdf-canonize": "^5.0.0",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -407,9 +406,6 @@
         "@forwardimpact/libsyntheticgen": "^0.1.21",
         "@forwardimpact/libtelemetry": "^0.1.23",
         "@forwardimpact/libutil": "^0.1.61",
-        "ajv": "^8.20.0",
-        "ajv-formats": "^3.0.1",
-        "yaml": "^2.9.0",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -427,13 +423,15 @@
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
       },
-      "optionalDependencies": {
+      "peerDependencies": {
         "apache-arrow": "^21.1.0",
         "parquet-wasm": "^0.7.1",
-      },
-      "peerDependencies": {
         "prettier": "^3.0.0",
       },
+      "optionalPeers": [
+        "apache-arrow",
+        "parquet-wasm",
+      ],
     },
     "libraries/libtelemetry": {
       "name": "@forwardimpact/libtelemetry",
@@ -510,12 +508,12 @@
       "name": "@forwardimpact/libui",
       "version": "1.3.0",
       "devDependencies": {
-        "happy-dom": "^20.9.0",
+        "jsdom": "^29.1.1",
       },
     },
     "libraries/libutil": {
       "name": "@forwardimpact/libutil",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "bin": {
         "fit-download-bundle": "./bin/fit-download-bundle.js",
         "fit-tiktoken": "./bin/fit-tiktoken.js",
@@ -738,7 +736,7 @@
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
-        "happy-dom": "^20.9.0",
+        "jsdom": "^29.1.1",
       },
     },
     "products/summit": {
@@ -795,6 +793,7 @@
         "@forwardimpact/libpreflight": "^0.1.0",
         "@forwardimpact/librpc": "^0.1.77",
         "@forwardimpact/libtelemetry": "^0.1.41",
+        "@forwardimpact/libutil": "^0.1.85",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -860,7 +859,7 @@
         "@forwardimpact/libresource": "^0.1.89",
         "@forwardimpact/librpc": "^0.1.77",
         "@forwardimpact/libtelemetry": "^0.1.41",
-        "n3": "^2.0.3",
+        "@forwardimpact/libutil": "^0.1.85",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -879,6 +878,7 @@
         "@forwardimpact/librpc": "^0.1.77",
         "@forwardimpact/libtelemetry": "^0.1.30",
         "@forwardimpact/libtype": "^0.1.67",
+        "@forwardimpact/libutil": "^0.1.85",
         "@forwardimpact/map": "^0.15.12",
         "@supabase/supabase-js": "^2.106.2",
       },
@@ -888,7 +888,7 @@
     },
     "services/mcp": {
       "name": "@forwardimpact/svcmcp",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "bin": {
         "fit-svcmcp": "./server.js",
       },
@@ -943,6 +943,7 @@
         "@forwardimpact/librpc": "^0.1.99",
         "@forwardimpact/libtelemetry": "^0.1.42",
         "@forwardimpact/libtype": "^0.1.0",
+        "@forwardimpact/libutil": "^0.1.85",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -983,7 +984,6 @@
         "@forwardimpact/librpc": "^0.1.99",
         "@forwardimpact/libstorage": "^0.1.78",
         "@forwardimpact/libtelemetry": "^0.1.42",
-        "@forwardimpact/libtype": "^0.1.0",
         "@forwardimpact/libutil": "^0.1.85",
       },
       "devDependencies": {
@@ -1004,6 +1004,7 @@
         "@forwardimpact/libstorage": "^0.1.53",
         "@forwardimpact/libtelemetry": "^0.1.41",
         "@forwardimpact/libtype": "^0.1.63",
+        "@forwardimpact/libutil": "^0.1.85",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -1024,6 +1025,7 @@
         "@forwardimpact/libstorage": "^0.1.53",
         "@forwardimpact/libtelemetry": "^0.1.41",
         "@forwardimpact/libtype": "^0.1.63",
+        "@forwardimpact/libutil": "^0.1.85",
         "@forwardimpact/libvector": "^0.1.68",
       },
       "devDependencies": {
@@ -1492,12 +1494,6 @@
 
     "@supabase/supabase-js": ["@supabase/supabase-js@2.106.2", "", { "dependencies": { "@supabase/auth-js": "2.106.2", "@supabase/functions-js": "2.106.2", "@supabase/postgrest-js": "2.106.2", "@supabase/realtime-js": "2.106.2", "@supabase/storage-js": "2.106.2" } }, "sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA=="],
 
-    "@swc/helpers": ["@swc/helpers@0.5.19", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA=="],
-
-    "@types/command-line-args": ["@types/command-line-args@5.2.3", "", {}, "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw=="],
-
-    "@types/command-line-usage": ["@types/command-line-usage@5.0.4", "", {}, "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="],
-
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -1514,9 +1510,7 @@
 
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
-    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
-
-    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+    "@types/ws": ["@types/ws@6.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg=="],
 
     "@typescript-eslint/types": ["@typescript-eslint/types@8.59.1", "", {}, "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A=="],
 
@@ -1550,8 +1544,6 @@
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
-    "apache-arrow": ["apache-arrow@21.1.0", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^24.0.3", "command-line-args": "^6.0.1", "command-line-usage": "^7.0.1", "flatbuffers": "^25.1.24", "json-bignum": "^0.0.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.js" } }, "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA=="],
-
     "arch": ["arch@2.2.0", "", {}, "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="],
 
     "are-docs-informative": ["are-docs-informative@0.0.2", "", {}, "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig=="],
@@ -1559,8 +1551,6 @@
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
-    "array-back": ["array-back@6.2.3", "", {}, "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -1641,10 +1631,6 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
-    "command-line-args": ["command-line-args@6.0.2", "", { "dependencies": { "array-back": "^6.2.3", "find-replace": "^5.0.2", "lodash.camelcase": "^4.3.0", "typical": "^7.3.0" }, "peerDependencies": { "@75lb/nature": "latest" }, "optionalPeers": ["@75lb/nature"] }, "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ=="],
-
-    "command-line-usage": ["command-line-usage@7.0.4", "", { "dependencies": { "array-back": "^6.2.2", "chalk-template": "^0.4.0", "table-layout": "^4.1.1", "typical": "^7.3.0" } }, "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg=="],
 
     "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
@@ -1798,13 +1784,9 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
-    "find-replace": ["find-replace@5.0.2", "", { "peerDependencies": { "@75lb/nature": "latest" }, "optionalPeers": ["@75lb/nature"] }, "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q=="],
-
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
-
-    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
@@ -1843,8 +1825,6 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
-
-    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1929,8 +1909,6 @@
     "jsdoc-type-pratt-parser": ["jsdoc-type-pratt-parser@7.2.0", "", {}, "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
-
-    "json-bignum": ["json-bignum@0.0.3", "", {}, "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -2074,8 +2052,6 @@
 
     "param-case": ["param-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A=="],
 
-    "parquet-wasm": ["parquet-wasm@0.7.1", "", {}, "sha512-fjEGpMApzt3mpI2pUxdRgQGu5G+s4nr0vm5xn43JO7jxdYzzu2fHrVrTHtfeEhtB6vfvTzJBz0WydDYzLWvszQ=="],
-
     "parse-imports-exports": ["parse-imports-exports@0.2.4", "", { "dependencies": { "parse-statements": "1.0.11" } }, "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ=="],
 
     "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
@@ -2136,8 +2112,6 @@
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": "cli.js" }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
-    "rdf-canonize": ["rdf-canonize@5.0.0", "", { "dependencies": { "setimmediate": "^1.0.5" } }, "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w=="],
-
     "rdf-data-factory": ["rdf-data-factory@2.0.2", "", { "dependencies": { "@rdfjs/types": "^2.0.0" } }, "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg=="],
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
@@ -2183,8 +2157,6 @@
     "serve-handler": ["serve-handler@6.1.7", "", { "dependencies": { "bytes": "3.0.0", "content-disposition": "0.5.2", "mime-types": "2.1.18", "minimatch": "3.1.5", "path-is-inside": "1.0.2", "path-to-regexp": "3.3.0", "range-parser": "1.2.0" } }, "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -2236,8 +2208,6 @@
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
-    "table-layout": ["table-layout@4.1.1", "", { "dependencies": { "array-back": "^6.2.2", "wordwrapjs": "^5.1.0" } }, "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA=="],
-
     "terser": ["terser@5.46.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": "bin/terser" }, "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
@@ -2269,8 +2239,6 @@
     "type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
-
-    "typical": ["typical@7.3.0", "", {}, "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -2313,8 +2281,6 @@
     "widest-line": ["widest-line@4.0.1", "", { "dependencies": { "string-width": "^5.0.1" } }, "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
-
-    "wordwrapjs": ["wordwrapjs@5.1.1", "", {}, "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg=="],
 
     "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
@@ -2382,8 +2348,6 @@
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "apache-arrow/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
-
     "botbuilder/htmlparser2": ["htmlparser2@9.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.1.0", "entities": "^4.5.0" } }, "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ=="],
 
     "botbuilder/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -2395,8 +2359,6 @@
     "botframework-connector/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "botframework-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "botframework-streaming/@types/ws": ["@types/ws@6.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg=="],
 
     "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -2433,10 +2395,6 @@
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
-
-    "happy-dom/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
-
-    "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
@@ -2511,8 +2469,6 @@
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "apache-arrow/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "botframework-connector/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/justfile
+++ b/justfile
@@ -420,35 +420,12 @@ tei-install:
 tei-start:
     bunx fit-rc start embedding
 
-# ── Synthea ───────────────────────────────────────────────────────
+# ── Synthetic data dependencies ───────────────────────────────────
 
-synthea_version := "3.3.0"
-synthea_jar := "vendor/synthea/synthea-with-dependencies.jar"
+# Install synthetic-data generation deps (Synthea JAR, SDV, faker) on demand
+synthetic-deps:
+    bash scripts/synthetic-deps.sh
 
-# Download the Synthea JAR into vendor/synthea/ if not already present
-synthea-install:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ -f "{{synthea_jar}}" ]; then
-        echo "synthea: already installed at {{synthea_jar}}"
-        exit 0
-    fi
-    mkdir -p vendor/synthea
-    echo "Downloading Synthea v{{synthea_version}}..."
-    curl -fSL -o "{{synthea_jar}}" \
-        "https://github.com/synthetichealth/synthea/releases/download/v{{synthea_version}}/synthea-with-dependencies.jar"
-    echo "synthea: installed at {{synthea_jar}}"
-
-# Report Synthea install status and Java availability
-synthea-status:
-    #!/usr/bin/env bash
-    if [ ! -f "{{synthea_jar}}" ]; then
-        echo "synthea: not installed (run 'just synthea-install')"
-        exit 1
-    fi
-    if ! command -v java &>/dev/null; then
-        echo "synthea: Java not found (install Java 11+)"
-        exit 1
-    fi
-    java_version=$(java -version 2>&1 | head -1)
-    echo "synthea: ok (${java_version})"
+# Report synthetic-data dependency status without installing
+synthetic-deps-check:
+    bash scripts/synthetic-deps.sh --check

--- a/libraries/libresource/package.json
+++ b/libraries/libresource/package.json
@@ -59,8 +59,7 @@
     "html-minifier-terser": "^7.2.0",
     "jsdom": "^29.1.1",
     "microdata-rdf-streaming-parser": "^3.0.0",
-    "n3": "^2.0.3",
-    "rdf-canonize": "^5.0.0"
+    "n3": "^2.0.3"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/libraries/libsyntheticgen/package.json
+++ b/libraries/libsyntheticgen/package.json
@@ -46,7 +46,7 @@
     "@forwardimpact/libprompt": "^0.1.9",
     "@forwardimpact/libsyntheticrender": "^0.1.25"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@faker-js/faker": "^10.4.0"
   },
   "engines": {
@@ -55,5 +55,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "@faker-js/faker": {
+      "optional": true
+    }
   }
 }

--- a/libraries/libsyntheticgen/src/tools/synthea.js
+++ b/libraries/libsyntheticgen/src/tools/synthea.js
@@ -36,7 +36,7 @@ export class SyntheaTool {
     } catch {
       throw new Error(
         `Synthea requires Java and ${this.syntheaJar}. ` +
-          "Run 'just synthea-install' to download the JAR, " +
+          "Run 'just synthetic-deps' to download the JAR, " +
           "or set SYNTHEA_JAR to a custom path.",
       );
     }

--- a/libraries/libsyntheticgen/test/faker.test.js
+++ b/libraries/libsyntheticgen/test/faker.test.js
@@ -9,10 +9,26 @@ import {
 
 const logger = createSilentLogger();
 
+// @faker-js/faker is an optional peer dependency, provisioned on demand by
+// `just synthetic-deps` rather than installed by default. Detect it once so the
+// tests that need the real package self-skip when it is absent (conditional
+// registration, since bun's node:test ignores the `{ skip }` option).
+const FAKER_AVAILABLE = await (async () => {
+  try {
+    await import("@faker-js/faker");
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
 describe("FakerTool", () => {
   test("requires logger", () => {
     assertThrowsMessage(() => new FakerTool({}), /requires logger/);
   });
+
+  // Everything below exercises the real faker provider paths.
+  if (!FAKER_AVAILABLE) return;
 
   test("checkAvailability returns true", async () => {
     const tool = new FakerTool({ logger });

--- a/libraries/libsyntheticgen/test/synthea.test.js
+++ b/libraries/libsyntheticgen/test/synthea.test.js
@@ -46,7 +46,7 @@ describe("SyntheaTool", () => {
     );
   });
 
-  test("checkAvailability error message references 'just synthea-install'", async () => {
+  test("checkAvailability error message references 'just synthetic-deps'", async () => {
     const tool = new SyntheaTool({
       logger,
       syntheaJar: "/missing.jar",
@@ -57,7 +57,7 @@ describe("SyntheaTool", () => {
     });
     await assertRejectsMessage(
       () => tool.checkAvailability(),
-      /just synthea-install/,
+      /just synthetic-deps/,
     );
   });
 

--- a/libraries/libsyntheticprose/package.json
+++ b/libraries/libsyntheticprose/package.json
@@ -34,10 +34,7 @@
     "@forwardimpact/libutil": "^0.1.61",
     "@forwardimpact/libsyntheticgen": "^0.1.21",
     "@forwardimpact/libtelemetry": "^0.1.23",
-    "@forwardimpact/libprompt": "^0.1.0",
-    "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1",
-    "yaml": "^2.9.0"
+    "@forwardimpact/libprompt": "^0.1.0"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/libraries/libsyntheticrender/package.json
+++ b/libraries/libsyntheticrender/package.json
@@ -47,9 +47,7 @@
     "@forwardimpact/libmock": "^0.1.0"
   },
   "peerDependencies": {
-    "prettier": "^3.0.0"
-  },
-  "optionalDependencies": {
+    "prettier": "^3.0.0",
     "apache-arrow": "^21.1.0",
     "parquet-wasm": "^0.7.1"
   },
@@ -59,5 +57,13 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependenciesMeta": {
+    "apache-arrow": {
+      "optional": true
+    },
+    "parquet-wasm": {
+      "optional": true
+    }
   }
 }

--- a/libraries/libsyntheticrender/test/dataset-renderers.test.js
+++ b/libraries/libsyntheticrender/test/dataset-renderers.test.js
@@ -5,6 +5,19 @@ import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 const _rt = createDefaultRuntime();
 import { assertRejectsMessage } from "@forwardimpact/libmock";
 
+// apache-arrow and parquet-wasm are optional peer dependencies — the parquet
+// renderer degrades gracefully when they are absent. Detect availability once
+// so the parquet test self-skips on installs that opted out of the ~31 MB pair.
+const PARQUET_AVAILABLE = await (async () => {
+  try {
+    await import("apache-arrow");
+    await import("parquet-wasm/esm/parquet_wasm.js");
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
 const FIXTURE = {
   name: "test_records",
   schema: null,
@@ -245,6 +258,9 @@ describe("dataset renderers", () => {
   });
 
   describe("Parquet", () => {
+    // Conditional registration (not `{ skip }`, which bun's node:test ignores):
+    // when the optional deps are not installed, the parquet test is omitted.
+    if (!PARQUET_AVAILABLE) return;
     test("renders parquet buffer", async () => {
       const simpleDs = {
         name: "parq",

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -61,7 +61,7 @@
     "test": "bun test test/*.test.js"
   },
   "devDependencies": {
-    "happy-dom": "^20.9.0"
+    "jsdom": "^29.1.1"
   },
   "engines": {
     "bun": ">=1.2.0",

--- a/libraries/libui/test/bound-router.test.js
+++ b/libraries/libui/test/bound-router.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { Window } from "happy-dom";
+import { JSDOM } from "jsdom";
 
 import { createBoundRouter } from "../src/bound-router.js";
 import { defineRoute } from "../src/route-descriptor.js";
@@ -11,7 +11,10 @@ const savedHistory = globalThis.history;
 const savedDocument = globalThis.document;
 
 beforeEach(() => {
-  win = new Window({ url: "http://localhost" });
+  win = new JSDOM("", { url: "http://localhost/" }).window;
+  // jsdom emits a "Not implemented" notice for scrollTo; the router calls it on
+  // every route match, so stub it to a no-op (happy-dom implemented it silently).
+  win.scrollTo = () => {};
   globalThis.window = win;
   globalThis.history = win.history;
   globalThis.document = win.document;

--- a/libraries/libui/test/command-bar.test.js
+++ b/libraries/libui/test/command-bar.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { Window } from "happy-dom";
+import { JSDOM } from "jsdom";
 
 import { createCommandBar } from "../src/command-bar.js";
 import { createReactive } from "../src/reactive.js";
@@ -11,7 +11,7 @@ const savedDocument = globalThis.document;
 const savedNavigator = globalThis.navigator;
 
 beforeEach(() => {
-  win = new Window({ url: "http://localhost" });
+  win = new JSDOM("", { url: "http://localhost/" }).window;
   globalThis.window = win;
   globalThis.document = win.document;
   globalThis.navigator = win.navigator;

--- a/libraries/libui/test/json-ld-script.test.js
+++ b/libraries/libui/test/json-ld-script.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { Window } from "happy-dom";
+import { JSDOM } from "jsdom";
 
 import { createJsonLdScript } from "../src/json-ld-script.js";
 import { freezeInvocationContext } from "../src/invocation-context.js";
@@ -9,7 +9,7 @@ let win;
 const savedDocument = globalThis.document;
 
 beforeEach(() => {
-  win = new Window({ url: "http://localhost" });
+  win = new JSDOM("", { url: "http://localhost/" }).window;
   globalThis.document = win.document;
 });
 

--- a/products/pathway/package.json
+++ b/products/pathway/package.json
@@ -134,7 +134,7 @@
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0",
-    "happy-dom": "^20.9.0"
+    "jsdom": "^29.1.1"
   },
   "engines": {
     "bun": ">=1.2.0",

--- a/products/pathway/test/first-visit-banner.test.js
+++ b/products/pathway/test/first-visit-banner.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { Window } from "happy-dom";
+import { JSDOM } from "jsdom";
 
 import { createFirstVisitBanner } from "../src/components/first-visit-banner.js";
 
@@ -11,7 +11,7 @@ const savedNavigator = globalThis.navigator;
 const savedHTMLElement = globalThis.HTMLElement;
 
 beforeEach(() => {
-  win = new Window({ url: "http://localhost" });
+  win = new JSDOM("", { url: "http://localhost/" }).window;
   globalThis.window = win;
   globalThis.document = win.document;
   globalThis.navigator = win.navigator;

--- a/products/pathway/test/first-visit-dismissal.test.js
+++ b/products/pathway/test/first-visit-dismissal.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { Window } from "happy-dom";
+import { JSDOM } from "jsdom";
 
 const MODULE_PATH = "../src/lib/first-visit-dismissal.js";
 const STORAGE_KEY = "pathway:first-visit-banner:dismissed";
@@ -11,7 +11,7 @@ const savedDocument = globalThis.document;
 const savedNavigator = globalThis.navigator;
 
 beforeEach(() => {
-  win = new Window({ url: "http://localhost" });
+  win = new JSDOM("", { url: "http://localhost/" }).window;
   globalThis.window = win;
   globalThis.document = win.document;
   globalThis.navigator = win.navigator;
@@ -34,15 +34,28 @@ async function loadModule() {
 }
 
 /**
- * Override a Storage method using defineProperty. Reassigning directly on the
- * instance is a no-op in happy-dom because the methods live on the Storage
- * prototype; defineProperty installs an own property that shadows the
- * prototype method.
+ * Replace `window.localStorage` with an in-memory fake whose `name` method
+ * throws. Stubbing a method on the real Storage instance is unreliable — the
+ * DOM exposes Storage as a proxy that treats `storage.setItem = …` as writing
+ * a *key* named "setItem" rather than shadowing the method. The module reads
+ * `window.localStorage` lazily per call, so swapping the whole object on the
+ * window is the dependable way to inject a failing method.
  */
-function stubStorageMethod(storage, name, impl) {
-  Object.defineProperty(storage, name, {
-    value: impl,
-    writable: true,
+function stubStorageMethod(win, name, impl) {
+  const store = new Map();
+  const fake = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+  };
+  fake[name] = impl;
+  Object.defineProperty(win, "localStorage", {
+    value: fake,
     configurable: true,
   });
 }
@@ -62,7 +75,7 @@ describe("first-visit-dismissal", () => {
 
   test("getItem throws — isDismissed returns false and does not throw", async () => {
     const { isDismissed } = await loadModule();
-    stubStorageMethod(win.localStorage, "getItem", () => {
+    stubStorageMethod(win, "getItem", () => {
       throw new Error("storage disabled");
     });
     assert.strictEqual(isDismissed(), false);
@@ -70,7 +83,7 @@ describe("first-visit-dismissal", () => {
 
   test("setItem throws — markDismissed returns without throwing", async () => {
     const { isDismissed, markDismissed } = await loadModule();
-    stubStorageMethod(win.localStorage, "setItem", () => {
+    stubStorageMethod(win, "setItem", () => {
       throw new Error("quota");
     });
     assert.doesNotThrow(() => markDismissed());

--- a/scripts/synthetic-deps.sh
+++ b/scripts/synthetic-deps.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Install the dependencies needed for synthetic data generation
+# (`just synthetic` / `just synthetic-update`).
+#
+# These three tools — the Synthea JAR (Java), the SDV package (Python), and
+# @faker-js/faker (npm) — are heterogeneous and heavy, and synthetic generation
+# is a rare, deliberate action. They are intentionally kept OUT of package.json
+# and the default `bun install`, so routine workflow runs and agent dispatches
+# stay lean. Provision them on demand with `just synthetic-deps`; report status
+# with `just synthetic-deps --check`.
+#
+# All version strings live here — bump them in one place.
+set -euo pipefail
+
+SYNTHEA_VERSION="3.3.0"
+SDV_VERSION="1.37.0"
+FAKER_VERSION="10.4.0"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SYNTHEA_DIR="$ROOT/vendor/synthea"
+# Runtime resolves the JAR from $SYNTHEA_JAR or this default path
+# (see libraries/libterrain/src/cli-helpers.js).
+SYNTHEA_JAR="$SYNTHEA_DIR/synthea-with-dependencies.jar"
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+# Provision the Synthea fat JAR into vendor/synthea/ (gitignored). Idempotent:
+# an existing JAR is left in place. Java is required to *run* Synthea, not to
+# download it, so a missing JVM is a warning here, surfaced fully by --check.
+install_synthea() {
+  if [ -f "$SYNTHEA_JAR" ]; then
+    echo "synthea already installed at $SYNTHEA_JAR"
+    return 0
+  fi
+  mkdir -p "$SYNTHEA_DIR"
+  echo "Downloading Synthea v$SYNTHEA_VERSION..."
+  curl -fSL -o "$SYNTHEA_JAR" \
+    "https://github.com/synthetichealth/synthea/releases/download/v${SYNTHEA_VERSION}/synthea-with-dependencies.jar"
+  echo "Installed synthea v$SYNTHEA_VERSION at $SYNTHEA_JAR"
+  command -v java >/dev/null 2>&1 ||
+    echo "::warning::synthea: Java not found on PATH — install Java 11+ to run it"
+}
+
+# Install SDV so the system `python3` can `import sdv` (the contract SdvTool
+# relies on). Prefer uv when present for speed; fall back to pip --user. Both
+# land where the python3 on PATH can import them.
+install_sdv() {
+  if python3 -c "import sdv" >/dev/null 2>&1; then
+    echo "sdv already installed ($(python3 -c 'import sdv; print(sdv.__version__)' 2>/dev/null))"
+    return 0
+  fi
+  echo "Installing sdv==$SDV_VERSION..."
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install --python "$(command -v python3)" "sdv==$SDV_VERSION" ||
+      python3 -m pip install --user "sdv==$SDV_VERSION"
+  else
+    python3 -m pip install --user "sdv==$SDV_VERSION"
+  fi
+  if ! python3 -c "import sdv" >/dev/null 2>&1; then
+    echo "::error::sdv: install completed but 'python3 -c \"import sdv\"' still fails" >&2
+    exit 1
+  fi
+  echo "Installed sdv $(python3 -c 'import sdv; print(sdv.__version__)' 2>/dev/null)"
+}
+
+# Install @faker-js/faker into the workspace without touching package.json or
+# the lockfile (--no-save). Pinned to an exact version so seeded faker output
+# stays reproducible despite not being locked. faker is declared as an optional
+# peerDependency of libsyntheticgen, so bun does not auto-install it otherwise.
+install_faker() {
+  if [ -d "$ROOT/node_modules/@faker-js/faker" ]; then
+    echo "faker already installed"
+    return 0
+  fi
+  echo "Installing @faker-js/faker@$FAKER_VERSION (--no-save)..."
+  ( cd "$ROOT" && bun add --no-save "@faker-js/faker@$FAKER_VERSION" )
+  echo "Installed @faker-js/faker@$FAKER_VERSION"
+}
+
+# ── Status ───────────────────────────────────────────────────────
+#
+# `--check` reports availability of each tool without installing, and exits
+# non-zero if anything is missing so callers can gate on it.
+synthetic_check() {
+  local missing=0
+
+  if [ -f "$SYNTHEA_JAR" ] && command -v java >/dev/null 2>&1; then
+    echo "synthea: ok ($(java -version 2>&1 | head -1))"
+  elif [ -f "$SYNTHEA_JAR" ]; then
+    echo "synthea: JAR present but Java not found (install Java 11+)"; missing=1
+  else
+    echo "synthea: not installed"; missing=1
+  fi
+
+  if python3 -c "import sdv" >/dev/null 2>&1; then
+    echo "sdv: ok ($(python3 -c 'import sdv; print(sdv.__version__)' 2>/dev/null))"
+  else
+    echo "sdv: not installed"; missing=1
+  fi
+
+  if [ -d "$ROOT/node_modules/@faker-js/faker" ]; then
+    echo "faker: ok"
+  else
+    echo "faker: not installed"; missing=1
+  fi
+
+  [ "$missing" -eq 0 ] || {
+    echo "synthetic-deps: incomplete (run 'just synthetic-deps')" >&2
+    return 1
+  }
+  echo "synthetic-deps: all present"
+}
+
+# ── Entry ────────────────────────────────────────────────────────
+
+if [ "${1:-}" = "--check" ]; then
+  synthetic_check || exit 1
+  exit 0
+fi
+
+install_synthea
+install_sdv
+install_faker
+echo "synthetic-deps: done"

--- a/services/graph/package.json
+++ b/services/graph/package.json
@@ -49,8 +49,7 @@
     "@forwardimpact/libresource": "^0.1.89",
     "@forwardimpact/librpc": "^0.1.77",
     "@forwardimpact/libtelemetry": "^0.1.41",
-    "@forwardimpact/libutil": "^0.1.85",
-    "n3": "^2.0.3"
+    "@forwardimpact/libutil": "^0.1.85"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/websites/fit/docs/internals/operations/index.md
+++ b/websites/fit/docs/internals/operations/index.md
@@ -96,12 +96,19 @@ bunx fit-rc start             # Start services (supabase/tei skipped if not inst
 ### Generation
 
 ```sh
+just synthetic-deps           # Provision generation tools (Synthea, SDV, faker)
 just synthetic                # Cached prose (default, no LLM needed)
 just synthetic-update         # Generate new prose via LLM and update cache
 ```
 
 Generation uses cached prose by default from `data/synthetic/prose-cache.json`.
 Use `just synthetic-update` to call the LLM and refresh the cache.
+
+The dataset tools (the Synthea JAR, the SDV Python package, and faker) are
+heavy and rarely needed, so they live outside `package.json` and the default
+`bun install`. Provision them on demand with `just synthetic-deps`
+(`just synthetic-deps-check` reports status); the pipeline gracefully skips any
+dataset whose tool is unavailable.
 
 ### Activity Seed (synthetic data)
 


### PR DESCRIPTION
## Summary

Shrinks a default `bun install` by **~57 MB (24 packages, 0 added)** without dropping any functionality, and consolidates the heterogeneous synthetic-data tooling behind one on-demand provisioner.

**Lighter default install:**
- `apache-arrow` + `parquet-wasm` (~31 MB): `optionalDependencies` → optional `peerDependencies` in `libsyntheticrender`. The parquet renderer already degrades gracefully; its test self-registers only when the deps are present.
- `happy-dom` (~19 MB): test-only and redundant with `jsdom` (already a prod dep of `libresource`). Migrated the 5 libui/pathway DOM tests to jsdom and dropped `happy-dom`.
- `@faker-js/faker` (~4.8 MB): → optional `peerDependency` in `libsyntheticgen`; `faker.test.js` self-skips the real-faker cases when absent.
- Removed genuinely unused declarations: `rdf-canonize` (libresource, sole consumer — left the tree), plus `n3`/`ajv`/`ajv-formats`/`yaml` declarations that no longer matched imports (still in tree via other consumers — correctness, not weight).

**Structured synthetic-data provisioning:**
- New `scripts/synthetic-deps.sh` (mirrors `install-deps.sh`) installs the Synthea JAR (Java), SDV (Python, via uv with `pip --user` fallback), and faker (pinned, via `bun add --no-save` so it never enters the lockfile). `--check` reports status.
- `justfile`: replaced `synthea-install`/`synthea-status` with `synthetic-deps` / `synthetic-deps-check`.
- Updated the `SyntheaTool` error message + test to point at `just synthetic-deps`; documented the flow in the operations reference.

The dataset pipeline already skips any dataset whose tool is unavailable, so default generation output is unchanged — the tools simply aren't installed by default anymore.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- [x] libui (31), libsyntheticgen + libterrain (260), and synthetic/resource/graph suites pass locally
- [x] faker & parquet test gates verified both ways (deps present vs absent)
- [x] `bun add --no-save` confirmed to leave the lockfile untouched; faker dropped from lockfile (761 → 737 packages)
- [x] biome, `check-workspace-imports`, `check-ambient-deps`, `check-metadata` clean

https://claude.ai/code/session_01PHZHA9EzZGbA4DSQEgamcE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHZHA9EzZGbA4DSQEgamcE)_