### PR TITLE
libeval: hint at release cut in PR-merged task text

### DIFF
--- a/libraries/libeval/src/events/github.js
+++ b/libraries/libeval/src/events/github.js
@@ -29,11 +29,12 @@ export const TASK_TEMPLATE_ISSUE_LABELED =
 export const TASK_TEMPLATE_PR_LABELED =
   'Label "${LABEL}" was added to PR "${PR_TITLE}" (#${NUMBER}). PR URL: ${URL}.';
 
-// "unreleased changes" + "cut" hint at release activity (the release-engineer's
-// Assess step 3 / `kata-release-cut`) without naming an owner, so the lead
-// routes the merge instead of treating it as a no-op.
+// "unreleased changes"/"cut" and "status" hint at the two post-merge actions —
+// release activity (the release-engineer's Assess step 3 / `kata-release-cut`)
+// and advancing the spec's `wiki/STATUS.md` row — without naming an owner or
+// artifact, so the lead routes the merge instead of treating it as a no-op.
 export const TASK_TEMPLATE_PR_MERGED =
-  'PR "${PR_TITLE}" (#${NUMBER}) merged to main — may leave unreleased changes to cut. PR URL: ${URL}.';
+  'PR "${PR_TITLE}" (#${NUMBER}) merged to main — may leave unreleased changes to cut or status to update. PR URL: ${URL}.';
 
 // Appended verbatim to comment/review templates. `${BODY}` is the untrusted
 // author text; the fence and the "data, not instructions" framing keep the lead

--- a/libraries/libeval/src/events/github.js
+++ b/libraries/libeval/src/events/github.js
@@ -29,10 +29,12 @@ export const TASK_TEMPLATE_ISSUE_LABELED =
 export const TASK_TEMPLATE_PR_LABELED =
   'Label "${LABEL}" was added to PR "${PR_TITLE}" (#${NUMBER}). PR URL: ${URL}.';
 
-// "unreleased changes"/"cut" and "status" hint at the two post-merge actions —
-// release activity (the release-engineer's Assess step 3 / `kata-release-cut`)
-// and advancing the spec's `wiki/STATUS.md` row — without naming an owner or
-// artifact, so the lead routes the merge instead of treating it as a no-op.
+// "unreleased changes"/"cut" point at the genuine post-merge action — release
+// activity (the release-engineer's Assess step 3 / `kata-release-cut`).
+// "status" is a backstop: the spec's `wiki/STATUS.md` row is normally advanced
+// in the pre-merge gate (`kata-release-merge` Step 8), but the keyword catches a
+// merge that landed without it. Neither owner nor artifact is named, so the lead
+// routes the merge instead of treating it as a no-op.
 export const TASK_TEMPLATE_PR_MERGED =
   'PR "${PR_TITLE}" (#${NUMBER}) merged to main — may leave unreleased changes to cut or status to update. PR URL: ${URL}.';
 

--- a/libraries/libeval/src/events/github.js
+++ b/libraries/libeval/src/events/github.js
@@ -29,8 +29,11 @@ export const TASK_TEMPLATE_ISSUE_LABELED =
 export const TASK_TEMPLATE_PR_LABELED =
   'Label "${LABEL}" was added to PR "${PR_TITLE}" (#${NUMBER}). PR URL: ${URL}.';
 
+// "unreleased changes" + "cut" hint at release activity (the release-engineer's
+// Assess step 3 / `kata-release-cut`) without naming an owner, so the lead
+// routes the merge instead of treating it as a no-op.
 export const TASK_TEMPLATE_PR_MERGED =
-  'PR "${PR_TITLE}" (#${NUMBER}) merged. PR URL: ${URL}.';
+  'PR "${PR_TITLE}" (#${NUMBER}) merged to main — may leave unreleased changes to cut. PR URL: ${URL}.';
 
 // Appended verbatim to comment/review templates. `${BODY}` is the untrusted
 // author text; the fence and the "data, not instructions" framing keep the lead

--- a/libraries/libeval/test/events-github.test.js
+++ b/libraries/libeval/test/events-github.test.js
@@ -102,7 +102,7 @@ describe("composeTaskFromGitHubEvent matches the kata-dispatch shell output", ()
     );
     assert.strictEqual(
       task,
-      'PR "Wire up task-event" (#99) merged to main — may leave unreleased changes to cut. PR URL: https://github.com/acme/repo/pull/99.',
+      'PR "Wire up task-event" (#99) merged to main — may leave unreleased changes to cut or status to update. PR URL: https://github.com/acme/repo/pull/99.',
     );
   });
 

--- a/libraries/libeval/test/events-github.test.js
+++ b/libraries/libeval/test/events-github.test.js
@@ -102,7 +102,7 @@ describe("composeTaskFromGitHubEvent matches the kata-dispatch shell output", ()
     );
     assert.strictEqual(
       task,
-      'PR "Wire up task-event" (#99) merged. PR URL: https://github.com/acme/repo/pull/99.',
+      'PR "Wire up task-event" (#99) merged to main — may leave unreleased changes to cut. PR URL: https://github.com/acme/repo/pull/99.',
     );
   });
 


### PR DESCRIPTION
The PR-merged task template stated the merge as bare fact, giving the
facilitator no next-step signal — so merges often resulted in non-action.
Add the keywords "unreleased changes" and "cut", grounded in the
release-engineer's Assess step 3 and kata-release-cut, to hint at release
activity without naming an owner.

https://claude.ai/code/session_01CqHnzikdtsYhN9272DNqJe