### PR TITLE
feat(libeval): wrap composed prompts in parallel section tags

### DIFF
--- a/COALIGNED.md
+++ b/COALIGNED.md
@@ -81,6 +81,26 @@ interactive runs or `libeval` prompt for agent workflows.
 4. **Invisible downstream.** The most specific layer overrides. A system prompt
    should never compete with a skill procedure.
 
+### Section Tags
+
+When a harness composes a system prompt from more than one layer, it wraps each
+layer in a parallel, sibling-tagged section so the boundary between persona (L3)
+and orchestration mechanics (L0) stays explicit:
+
+```text
+<agent_profile>
+…L3 profile body…
+</agent_profile>
+
+<session_protocol>
+…L0 orchestration mechanics…
+</session_protocol>
+```
+
+The tags are siblings joined by a blank line — neither nests inside the other,
+and `<agent_profile>` precedes `<session_protocol>`. Profile and protocol source
+text carry no tags; the harness applies them at composition time.
+
 ## L1 — Project Identity (CLAUDE.md)
 
 Auto-loaded via `settingSources: ["project"]`. Orients every contributor on

--- a/libraries/libeval/src/discusser.js
+++ b/libraries/libeval/src/discusser.js
@@ -310,10 +310,6 @@ export function createDiscusser({
       from: config.name,
     });
 
-    const agentTrailer = config.systemPromptAmend
-      ? `${DISCUSS_AGENT_SYSTEM_PROMPT}\n\n${config.systemPromptAmend}`
-      : DISCUSS_AGENT_SYSTEM_PROMPT;
-
     const runner = createAgentRunner({
       cwd: config.cwd ?? resolvedLeadCwd,
       query,
@@ -328,7 +324,8 @@ export function createDiscusser({
         role: "agent",
         profile: config.agentProfile,
         profilesDir: resolvedProfilesDir,
-        trailer: agentTrailer,
+        trailer: DISCUSS_AGENT_SYSTEM_PROMPT,
+        amend: config.systemPromptAmend,
         runtime,
       }),
       redactor,

--- a/libraries/libeval/src/facilitator.js
+++ b/libraries/libeval/src/facilitator.js
@@ -134,10 +134,6 @@ export function createFacilitator({
       from: config.name,
     });
 
-    const agentTrailer = config.systemPromptAmend
-      ? `${FACILITATED_AGENT_SYSTEM_PROMPT}\n\n${config.systemPromptAmend}`
-      : FACILITATED_AGENT_SYSTEM_PROMPT;
-
     const runner = createAgentRunner({
       cwd: config.cwd ?? facilitatorCwd,
       query,
@@ -152,7 +148,8 @@ export function createFacilitator({
         role: "agent",
         profile: config.agentProfile,
         profilesDir: resolvedProfilesDir,
-        trailer: agentTrailer,
+        trailer: FACILITATED_AGENT_SYSTEM_PROMPT,
+        amend: config.systemPromptAmend,
         runtime,
       }),
       redactor,

--- a/libraries/libeval/src/judge.js
+++ b/libraries/libeval/src/judge.js
@@ -17,7 +17,7 @@ import { resolve } from "node:path";
 import { Writable } from "node:stream";
 
 import { createAgentRunner } from "./agent-runner.js";
-import { composeProfilePrompt } from "./profile-prompt.js";
+import { composeSystemPrompt } from "./profile-prompt.js";
 import { SequenceCounter } from "./sequence-counter.js";
 import {
   createJudgeToolServer,
@@ -140,7 +140,7 @@ export class Judge {
 /**
  * Factory function — wires the AgentRunner with the judge orchestration server
  * and the JUDGE_SYSTEM_PROMPT trailer. A `judgeProfile` (when supplied) layers
- * on top of the trailer via `composeProfilePrompt`, matching the
+ * on top of the trailer via `composeSystemPrompt`, matching the
  * supervisor/facilitator pattern.
  *
  * @param {object} deps
@@ -151,7 +151,7 @@ export class Judge {
  * @param {string} [deps.model]
  * @param {number} [deps.maxTurns] - Default 5 (the judge is expected to act in turn 1; 5 leaves headroom for tool inspection).
  * @param {string[]} [deps.allowedTools] - Default `["Read","Glob","Grep","Bash"]` — read-only inspection.
- * @param {string} [deps.judgeProfile] - Profile name; resolved into the system prompt via `composeProfilePrompt`.
+ * @param {string} [deps.judgeProfile] - Profile name; resolved into the system prompt via `composeSystemPrompt`.
  * @param {string} [deps.profilesDir] - Defaults to `<cwd>/.claude/agents`.
  * @param {string} [deps.taskAmend]
  * @returns {Judge}
@@ -176,17 +176,13 @@ export function createJudge({
   if (!runtime) throw new Error("runtime is required");
 
   const resolvedProfilesDir = profilesDir ?? resolve(cwd, ".claude/agents");
-  const systemPrompt = judgeProfile
-    ? composeProfilePrompt(judgeProfile, {
-        profilesDir: resolvedProfilesDir,
-        trailer: JUDGE_SYSTEM_PROMPT,
-        runtime,
-      })
-    : {
-        type: "preset",
-        preset: "claude_code",
-        append: JUDGE_SYSTEM_PROMPT,
-      };
+  const systemPrompt = composeSystemPrompt({
+    role: "agent",
+    profile: judgeProfile,
+    profilesDir: resolvedProfilesDir,
+    trailer: JUDGE_SYSTEM_PROMPT,
+    runtime,
+  });
 
   const ctx = createOrchestrationContext();
   ctx.participants = [{ name: "judge", role: "judge" }];

--- a/libraries/libeval/src/profile-prompt.js
+++ b/libraries/libeval/src/profile-prompt.js
@@ -1,7 +1,25 @@
 /**
  * System prompt composition for agent runners.
  *
- * Two helpers:
+ * libeval assembles every agent system prompt from up to two parallel,
+ * sibling-tagged sections (see COALIGNED.md § L0):
+ *
+ *     <agent_profile>
+ *     …persona body…
+ *     </agent_profile>
+ *
+ *     <session_protocol>
+ *     …orchestration mechanics, then any amendment…
+ *     </session_protocol>
+ *
+ * The two tags are siblings joined by a blank line — neither nests inside
+ * the other. A section appears only when its content is present. A
+ * system-prompt amendment is folded into the protocol trailer before
+ * wrapping, so it lands transparently inside `<session_protocol>`. The tag
+ * convention lives entirely here: profile `.md` files and trailer constants
+ * carry no tags.
+ *
+ * Helpers:
  *
  * - `composeProfilePrompt(name, opts)` — profile + `claude_code` preset.
  *   Used by agent participants that need the full Claude Code tool surface.
@@ -10,61 +28,113 @@
  *   roles (supervisor, facilitator, discuss lead) that should only see
  *   the orchestration instructions and optionally a profile body.
  *
- * - `composeSystemPrompt(opts)` — unified entry point. Delegates to one
- *   of the above based on `opts.role`.
+ * - `composeSystemPrompt(opts)` — unified entry point. Folds `amend` into
+ *   the protocol section, then delegates to one of the above based on
+ *   `opts.role`.
  */
 
 import { join } from "node:path";
 
+/** Sibling section tags. Neither nests inside the other. */
+const AGENT_PROFILE_TAG = "agent_profile";
+const SESSION_PROTOCOL_TAG = "session_protocol";
+
+/** Wrap content in a semantic section tag, each on its own line. */
+function wrapSection(tag, content) {
+  return `<${tag}>\n${content}\n</${tag}>`;
+}
+
 /**
- * Compose a `claude_code`-preset system prompt from a profile file. The
- * profile is read synchronously off the injected `runtime.fsSync` surface —
- * this composer runs inside the synchronous SDK-option builders of the
+ * Assemble the parallel `<agent_profile>` / `<session_protocol>` sections.
+ * Each section is emitted only when its content is non-empty; the two tags
+ * are siblings joined by a blank line and never nest.
+ *
+ * @param {object} parts
+ * @param {string} [parts.body] - Profile body, already frontmatter-stripped.
+ * @param {string} [parts.protocol] - Session protocol trailer, with any
+ *   amendment already folded in.
+ * @returns {string}
+ */
+function assembleSections({ body, protocol }) {
+  const sections = [];
+  if (body) sections.push(wrapSection(AGENT_PROFILE_TAG, body));
+  if (protocol) sections.push(wrapSection(SESSION_PROTOCOL_TAG, protocol));
+  return sections.join("\n\n");
+}
+
+/**
+ * Read a profile `.md`, strip its frontmatter, and return the trimmed body.
+ * Reads synchronously off the injected `runtime.fsSync` surface — this
+ * composer runs inside the synchronous SDK-option builders of the
  * supervisor / facilitator / discusser / judge factories, so it cannot go
  * async without an unbounded cascade.
  *
  * @param {string} name - Profile basename (no `.md` suffix)
+ * @param {string} profilesDir - Directory containing `<name>.md`
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
+ * @returns {string}
+ */
+function readProfileBody(name, profilesDir, runtime) {
+  const path = join(profilesDir, `${name}.md`);
+  const raw = runtime.fsSync.readFileSync(path, "utf8");
+  return stripFrontmatter(raw).trim();
+}
+
+/**
+ * Compose a `claude_code`-preset system prompt from a profile file. The
+ * profile body is wrapped in `<agent_profile>`; an optional protocol trailer
+ * is wrapped in a sibling `<session_protocol>`.
+ *
+ * @param {string} name - Profile basename (no `.md` suffix)
  * @param {object} opts
  * @param {string} opts.profilesDir - Directory containing `<name>.md`
- * @param {string} [opts.trailer] - Mode-specific trailer appended after a blank line
+ * @param {string} [opts.trailer] - Session protocol, wrapped as a sibling
+ *   `<session_protocol>` section after a blank line
  * @param {import("@forwardimpact/libutil/runtime").Runtime} opts.runtime - Ambient collaborators; uses `fsSync.readFileSync`.
  * @returns {{type: "preset", preset: "claude_code", append: string}}
  */
 export function composeProfilePrompt(name, { profilesDir, trailer, runtime }) {
-  const path = join(profilesDir, `${name}.md`);
-  const raw = runtime.fsSync.readFileSync(path, "utf8");
-  const body = stripFrontmatter(raw).trim();
-  const append = trailer && trailer.length > 0 ? `${body}\n\n${trailer}` : body;
-  return { type: "preset", preset: "claude_code", append };
+  const body = readProfileBody(name, profilesDir, runtime);
+  return {
+    type: "preset",
+    preset: "claude_code",
+    append: assembleSections({ body, protocol: trailer }),
+  };
 }
 
 /**
- * Compose a plain-string system prompt for a lead role (no Claude Code preset).
+ * Compose a plain-string system prompt for a lead role (no Claude Code
+ * preset). The protocol trailer is wrapped in `<session_protocol>`; an
+ * optional profile body is wrapped in a sibling `<agent_profile>` before it.
+ *
  * @param {object} opts
  * @param {string} [opts.profile] - Profile basename (no `.md` suffix)
  * @param {string} [opts.profilesDir] - Directory containing profile files
- * @param {string} opts.trailer - Mode-specific orchestration instructions
+ * @param {string} opts.trailer - Session protocol (orchestration instructions)
  * @param {import("@forwardimpact/libutil/runtime").Runtime} opts.runtime - Ambient collaborators; uses `fsSync.readFileSync`.
  * @returns {string}
  */
 export function composeLeadPrompt({ profile, profilesDir, trailer, runtime }) {
   if (!trailer) throw new Error("trailer is required");
-  if (!profile) return trailer;
-  const path = join(profilesDir, `${profile}.md`);
-  const raw = runtime.fsSync.readFileSync(path, "utf8");
-  const body = stripFrontmatter(raw).trim();
-  return `${body}\n\n${trailer}`;
+  const body = profile
+    ? readProfileBody(profile, profilesDir, runtime)
+    : undefined;
+  return assembleSections({ body, protocol: trailer });
 }
 
 /**
- * Unified entry point for composing system prompts.
+ * Unified entry point for composing system prompts. Folds an optional
+ * amendment into the protocol trailer — so it lands inside
+ * `<session_protocol>` — then delegates by role.
  *
  * @param {object} opts
  * @param {"lead"|"agent"} opts.role - `"lead"` produces a plain string;
  *   `"agent"` produces a `claude_code` preset object.
  * @param {string} [opts.profile] - Profile basename
  * @param {string} [opts.profilesDir]
- * @param {string} opts.trailer - Mode-specific instructions
+ * @param {string} opts.trailer - Session protocol (orchestration instructions)
+ * @param {string} [opts.amend] - Caller-supplied amendment, appended inside
+ *   `<session_protocol>` after the trailer with a blank-line separator.
  * @param {import("@forwardimpact/libutil/runtime").Runtime} opts.runtime - Ambient collaborators; uses `fsSync.readFileSync`.
  * @returns {string | {type: "preset", preset: "claude_code", append: string}}
  */
@@ -73,16 +143,31 @@ export function composeSystemPrompt({
   profile,
   profilesDir,
   trailer,
+  amend,
   runtime,
 }) {
   if (!trailer) throw new Error("trailer is required");
+  const protocol = amend ? `${trailer}\n\n${amend}` : trailer;
   if (role === "lead") {
-    return composeLeadPrompt({ profile, profilesDir, trailer, runtime });
+    return composeLeadPrompt({
+      profile,
+      profilesDir,
+      trailer: protocol,
+      runtime,
+    });
   }
   if (profile) {
-    return composeProfilePrompt(profile, { profilesDir, trailer, runtime });
+    return composeProfilePrompt(profile, {
+      profilesDir,
+      trailer: protocol,
+      runtime,
+    });
   }
-  return { type: "preset", preset: "claude_code", append: trailer };
+  return {
+    type: "preset",
+    preset: "claude_code",
+    append: assembleSections({ protocol }),
+  };
 }
 
 /**

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -122,6 +122,7 @@ const devNull = new Writable({
  * @param {string[]} [deps.supervisorDisallowedTools]
  * @param {string} [deps.supervisorProfile]
  * @param {string} [deps.agentProfile]
+ * @param {string} [deps.agentSystemPromptAmend] - Amendment folded into the agent's `<session_protocol>` section, after the protocol trailer.
  * @param {string} [deps.profilesDir]
  * @param {string} [deps.taskAmend]
  * @param {Record<string, object>} [deps.agentMcpServers]
@@ -141,6 +142,7 @@ export function createSupervisor({
   supervisorDisallowedTools,
   supervisorProfile,
   agentProfile,
+  agentSystemPromptAmend,
   profilesDir,
   taskAmend,
   agentMcpServers,
@@ -182,6 +184,7 @@ export function createSupervisor({
       profile: agentProfile,
       profilesDir: resolvedProfilesDir,
       trailer: AGENT_SYSTEM_PROMPT,
+      amend: agentSystemPromptAmend,
       runtime,
     }),
     mcpServers: { orchestration: agentServer, ...agentMcpServers },

--- a/libraries/libeval/test/amend.test.js
+++ b/libraries/libeval/test/amend.test.js
@@ -50,14 +50,20 @@ describe("systemPromptAmend delivery (SC 7 a)", () => {
     });
     const append = facilitator.agents[0].runner.systemPrompt.append;
     assert.ok(append.includes(FACILITATED_AGENT_SYSTEM_PROMPT));
-    assert.ok(append.endsWith("<TEST_MARKER>"));
+    // The amendment is folded transparently into the <session_protocol>
+    // section — after the protocol trailer, before the closing tag.
+    const amendAt = append.indexOf("<TEST_MARKER>");
     assert.ok(
-      append.indexOf(FACILITATED_AGENT_SYSTEM_PROMPT) <
-        append.indexOf("<TEST_MARKER>"),
+      append.indexOf(FACILITATED_AGENT_SYSTEM_PROMPT) < amendAt,
+      "amendment follows the protocol trailer",
+    );
+    assert.ok(
+      amendAt < append.indexOf("</session_protocol>"),
+      "amendment lands inside the <session_protocol> section",
     );
   });
 
-  test("Facilitator without systemPromptAmend leaves the prompt purely generic", () => {
+  test("Facilitator without systemPromptAmend wraps just the protocol", () => {
     const facilitator = createFacilitator({
       facilitatorCwd: "/tmp/fac",
       agentConfigs: [{ name: "agent-1", role: "worker", cwd: "/tmp/agent" }],
@@ -68,7 +74,7 @@ describe("systemPromptAmend delivery (SC 7 a)", () => {
     });
     assert.strictEqual(
       facilitator.agents[0].runner.systemPrompt.append,
-      FACILITATED_AGENT_SYSTEM_PROMPT,
+      `<session_protocol>\n${FACILITATED_AGENT_SYSTEM_PROMPT}\n</session_protocol>`,
     );
   });
 });

--- a/libraries/libeval/test/facilitator-factory.test.js
+++ b/libraries/libeval/test/facilitator-factory.test.js
@@ -64,7 +64,7 @@ describe("Facilitator - createFacilitator factory", () => {
     assert.strictEqual(typeof f.facilitatorRunner.systemPrompt, "string");
     assert.strictEqual(
       f.facilitatorRunner.systemPrompt,
-      FACILITATOR_SYSTEM_PROMPT,
+      `<session_protocol>\n${FACILITATOR_SYSTEM_PROMPT}\n</session_protocol>`,
     );
   });
 
@@ -74,7 +74,7 @@ describe("Facilitator - createFacilitator factory", () => {
       assert.deepStrictEqual(agent.runner.systemPrompt, {
         type: "preset",
         preset: "claude_code",
-        append: FACILITATED_AGENT_SYSTEM_PROMPT,
+        append: `<session_protocol>\n${FACILITATED_AGENT_SYSTEM_PROMPT}\n</session_protocol>`,
       });
     }
   });

--- a/libraries/libeval/test/judge.test.js
+++ b/libraries/libeval/test/judge.test.js
@@ -178,7 +178,10 @@ describe("createJudge", () => {
       assert.ok(sp, "systemPrompt must be set");
       assert.strictEqual(sp.type, "preset");
       assert.strictEqual(sp.preset, "claude_code");
-      assert.strictEqual(sp.append, JUDGE_SYSTEM_PROMPT);
+      assert.strictEqual(
+        sp.append,
+        `<session_protocol>\n${JUDGE_SYSTEM_PROMPT}\n</session_protocol>`,
+      );
     });
   });
 

--- a/libraries/libeval/test/profile-prompt.test.js
+++ b/libraries/libeval/test/profile-prompt.test.js
@@ -5,7 +5,11 @@ import { fileURLToPath } from "node:url";
 
 import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
-import { composeProfilePrompt } from "@forwardimpact/libeval";
+import {
+  composeProfilePrompt,
+  composeLeadPrompt,
+  composeSystemPrompt,
+} from "@forwardimpact/libeval";
 
 const RT = createDefaultRuntime();
 
@@ -45,9 +49,18 @@ describe("composeProfilePrompt", () => {
       "append should not leak the skills list",
     );
     assert.ok(
-      result.append.startsWith("You are the fixture agent."),
-      "append should start with the body content",
+      result.append.startsWith("<agent_profile>\nYou are the fixture agent."),
+      "body content should open the <agent_profile> section",
     );
+  });
+
+  test("wraps the profile body in <agent_profile>", () => {
+    const result = composeProfilePrompt("with-frontmatter", {
+      profilesDir: FIXTURES,
+      runtime: RT,
+    });
+    assert.ok(result.append.startsWith("<agent_profile>\n"));
+    assert.ok(result.append.endsWith("\n</agent_profile>"));
   });
 
   test("uses entire body when frontmatter is absent", () => {
@@ -55,28 +68,51 @@ describe("composeProfilePrompt", () => {
       profilesDir: FIXTURES,
       runtime: RT,
     });
-    assert.ok(result.append.startsWith("You are the frontmatter-less"));
+    assert.ok(
+      result.append.startsWith("<agent_profile>\nYou are the frontmatter-less"),
+    );
   });
 
-  test("concatenates trailer with blank-line separator", () => {
+  test("wraps the trailer in a sibling <session_protocol> section", () => {
     const result = composeProfilePrompt("with-frontmatter", {
       profilesDir: FIXTURES,
       runtime: RT,
       trailer: "TRAILER_TEXT",
     });
-    assert.ok(result.append.endsWith("\n\nTRAILER_TEXT"));
     assert.ok(result.append.includes("You are the fixture agent."));
+    assert.ok(
+      result.append.includes(
+        "</agent_profile>\n\n<session_protocol>\nTRAILER_TEXT\n</session_protocol>",
+      ),
+      "sections are siblings joined by a blank line",
+    );
+    assert.ok(
+      result.append.indexOf("<agent_profile>") <
+        result.append.indexOf("<session_protocol>"),
+      "profile precedes protocol",
+    );
   });
 
-  test("omits trailer cleanly when not provided", () => {
+  test("the two sections are siblings — neither nests in the other", () => {
+    const result = composeProfilePrompt("with-frontmatter", {
+      profilesDir: FIXTURES,
+      runtime: RT,
+      trailer: "TRAILER_TEXT",
+    });
+    assert.ok(
+      result.append.indexOf("</agent_profile>") <
+        result.append.indexOf("<session_protocol>"),
+      "<agent_profile> closes before <session_protocol> opens",
+    );
+  });
+
+  test("omits the <session_protocol> section when no trailer is provided", () => {
     const result = composeProfilePrompt("with-frontmatter", {
       profilesDir: FIXTURES,
       runtime: RT,
     });
-    assert.ok(
-      !result.append.endsWith("\n\n"),
-      "append should not have trailing blank lines when no trailer",
-    );
+    assert.ok(!result.append.includes("<session_protocol>"));
+    assert.ok(result.append.endsWith("</agent_profile>"));
   });
 
   test("treats empty trailer as omitted", () => {
@@ -85,7 +121,7 @@ describe("composeProfilePrompt", () => {
       runtime: RT,
       trailer: "",
     });
-    assert.ok(!result.append.endsWith("\n\n"));
+    assert.ok(!result.append.includes("<session_protocol>"));
   });
 
   test("throws ENOENT for missing profile", () => {
@@ -131,5 +167,95 @@ describe("composeProfilePrompt", () => {
         `expected composed prompt for ${name} to include body substring "${probe}"`,
       );
     }
+  });
+});
+
+describe("composeSystemPrompt", () => {
+  test("folds amend into the <session_protocol> section", () => {
+    const result = composeSystemPrompt({
+      role: "agent",
+      profile: "with-frontmatter",
+      profilesDir: FIXTURES,
+      trailer: "PROTOCOL",
+      amend: "<AMENDMENT>",
+      runtime: RT,
+    });
+    const open = result.append.indexOf("<session_protocol>");
+    const close = result.append.indexOf("</session_protocol>");
+    const amendAt = result.append.indexOf("<AMENDMENT>");
+    assert.ok(
+      open < amendAt && amendAt < close,
+      "amendment lands inside the <session_protocol> section",
+    );
+    assert.ok(
+      result.append.includes("PROTOCOL\n\n<AMENDMENT>"),
+      "amendment follows the trailer with a blank-line separator",
+    );
+  });
+
+  test("wraps the protocol even when no profile is supplied", () => {
+    const result = composeSystemPrompt({
+      role: "agent",
+      profilesDir: FIXTURES,
+      trailer: "PROTOCOL",
+      amend: "<AMENDMENT>",
+      runtime: RT,
+    });
+    assert.strictEqual(result.type, "preset");
+    assert.ok(!result.append.includes("<agent_profile>"));
+    assert.strictEqual(
+      result.append,
+      "<session_protocol>\nPROTOCOL\n\n<AMENDMENT>\n</session_protocol>",
+    );
+  });
+
+  test("lead role returns a wrapped plain string", () => {
+    const result = composeSystemPrompt({
+      role: "lead",
+      profilesDir: FIXTURES,
+      trailer: "LEAD_PROTOCOL",
+      runtime: RT,
+    });
+    assert.strictEqual(typeof result, "string");
+    assert.strictEqual(
+      result,
+      "<session_protocol>\nLEAD_PROTOCOL\n</session_protocol>",
+    );
+  });
+});
+
+describe("composeLeadPrompt", () => {
+  test("wraps profile and trailer as parallel sections", () => {
+    const result = composeLeadPrompt({
+      profile: "with-frontmatter",
+      profilesDir: FIXTURES,
+      trailer: "LEAD_PROTOCOL",
+      runtime: RT,
+    });
+    assert.ok(result.startsWith("<agent_profile>\n"));
+    assert.ok(
+      result.includes(
+        "</agent_profile>\n\n<session_protocol>\nLEAD_PROTOCOL\n</session_protocol>",
+      ),
+    );
+  });
+
+  test("emits only <session_protocol> when no profile is supplied", () => {
+    const result = composeLeadPrompt({
+      profilesDir: FIXTURES,
+      trailer: "LEAD_PROTOCOL",
+      runtime: RT,
+    });
+    assert.strictEqual(
+      result,
+      "<session_protocol>\nLEAD_PROTOCOL\n</session_protocol>",
+    );
+  });
+
+  test("throws when trailer is missing", () => {
+    assert.throws(
+      () => composeLeadPrompt({ profilesDir: FIXTURES, runtime: RT }),
+      /trailer is required/,
+    );
   });
 });

--- a/libraries/libeval/test/supervisor-factory.test.js
+++ b/libraries/libeval/test/supervisor-factory.test.js
@@ -59,7 +59,7 @@ describe("Supervisor - createSupervisor factory", () => {
     assert.strictEqual(typeof s.supervisorRunner.systemPrompt, "string");
     assert.strictEqual(
       s.supervisorRunner.systemPrompt,
-      SUPERVISOR_SYSTEM_PROMPT,
+      `<session_protocol>\n${SUPERVISOR_SYSTEM_PROMPT}\n</session_protocol>`,
     );
   });
 
@@ -68,8 +68,19 @@ describe("Supervisor - createSupervisor factory", () => {
     assert.deepStrictEqual(s.agentRunner.systemPrompt, {
       type: "preset",
       preset: "claude_code",
-      append: AGENT_SYSTEM_PROMPT,
+      append: `<session_protocol>\n${AGENT_SYSTEM_PROMPT}\n</session_protocol>`,
     });
+  });
+
+  test("folds agentSystemPromptAmend into the agent <session_protocol>", () => {
+    const s = createSupervisor({
+      ...baseOpts(),
+      agentSystemPromptAmend: "<TEST_MARKER>",
+    });
+    assert.strictEqual(
+      s.agentRunner.systemPrompt.append,
+      `<session_protocol>\n${AGENT_SYSTEM_PROMPT}\n\n<TEST_MARKER>\n</session_protocol>`,
+    );
   });
 
   test("blocks sub-agent spawn and write tools on supervisor by default", () => {


### PR DESCRIPTION
## Summary

- Assemble every agent system prompt from two parallel, sibling-tagged sections owned entirely by the prompt composer (`profile-prompt.js`): the profile body in `<agent_profile>` and the orchestration protocol in `<session_protocol>`.
- The tags never nest, `<agent_profile>` precedes `<session_protocol>`, and each section appears only when its content exists.
- Fold the system-prompt amendment into `<session_protocol>` (after the trailer, no tag of its own), applied symmetrically across all modes: facilitate, discuss, and supervise agents fold their amendment; judge and the standalone run route through the same composer. Adds `agentSystemPromptAmend` to supervise for parity.
- The **task** amendment stays on the task prompt and never enters `<session_protocol>`.
- Document the convention at a high level under COALIGNED.md L0.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TFA7MX1QZgQtzApkLe7i9L)_