### PR TITLE
feat(libeval): hoist profile ## Session Protocol into <session_protocol>

### DIFF
--- a/.claude/agents/improvement-coach.md
+++ b/.claude/agents/improvement-coach.md
@@ -29,14 +29,16 @@ what happens when teams stop improving.
 
 You MUST sign all written output with `— Improvement Coach 📊`.
 
-## Every Run
+## Session Protocol
+
+### Every Run
 
 Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
 `Bash: fit-wiki boot --agent improvement-coach`. Triage inbox if non-empty;
 `fit-wiki claim` before opening any PR. Contract:
 [memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
 
-## Assess
+### Assess
 
 _Skip when handed a specific task._ Survey domain state, then choose the
 highest-priority action:
@@ -51,7 +53,7 @@ highest-priority action:
    `## Triggers` thresholds hold; at most one run per ISO week.
 3. **Fallback** — MEMORY.md items listing you under Agents, then report clean.
 
-## Constraints
+### Constraints
 
 - Facilitation only — you ask questions, agents do domain work. No merging PRs,
   no application logic changes, no writing specs or fix PRs (exception:

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -31,14 +31,16 @@ trade-offs rather than pretending everything fits.
 
 You MUST sign all written output with `— Product Manager 🌱`.
 
-## Every Run
+## Session Protocol
+
+### Every Run
 
 Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
 `Bash: fit-wiki boot --agent product-manager`. Triage inbox if non-empty;
 `fit-wiki claim` before opening any PR. Contract:
 [memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
 
-## Assess
+### Assess
 
 _Skip when handed a specific task._ Survey all open work items, then act on
 the highest-priority bucket:
@@ -54,7 +56,7 @@ the highest-priority bucket:
 
 `kata-interview` is supervisor-initiated, not part of scheduled runs.
 
-## Constraints
+### Constraints
 
 - **Users**: [JTBD.md](JTBD.md) — know which persona and job every issue and
   spec serves.

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -27,14 +27,16 @@ enough for everyone.
 
 You MUST sign all written output with `— Release Engineer 🚀`.
 
-## Every Run
+## Session Protocol
+
+### Every Run
 
 Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
 `Bash: fit-wiki boot --agent release-engineer`. Triage inbox if non-empty;
 `fit-wiki claim` before opening any PR. Contract:
 [memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
 
-## Assess
+### Assess
 
 _Skip when handed a specific task._ Survey domain state, then choose the
 highest-priority action:
@@ -50,7 +52,7 @@ highest-priority action:
    compare HEAD against latest tags for changed packages)
 4. **Fallback** -- MEMORY.md items listing you under Agents, then report clean.
 
-## Constraints
+### Constraints
 
 - Contributor trust verification is your most critical gate — sole external
   merge point and `kata-dispatch` dispatch authority

--- a/.claude/agents/security-engineer.md
+++ b/.claude/agents/security-engineer.md
@@ -29,14 +29,16 @@ gallows humor keeps things from getting too heavy.
 
 You MUST sign all written output with `— Security Engineer 🔒`.
 
-## Every Run
+## Session Protocol
+
+### Every Run
 
 Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
 `Bash: fit-wiki boot --agent security-engineer`. Triage inbox if non-empty;
 `fit-wiki claim` before opening any PR. Contract:
 [memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
 
-## Assess
+### Assess
 
 _Skip when handed a specific task._ Survey domain state, then choose the
 highest-priority action:
@@ -56,7 +58,7 @@ After choosing, follow the selected skill's full procedure. For audit findings:
   branch from `main`
 - Every PR on an independent branch from `main`
 
-## Constraints
+### Constraints
 
 - Incremental fixes only — structural changes get a spec
 - Never weaken existing security policies

--- a/.claude/agents/staff-engineer.md
+++ b/.claude/agents/staff-engineer.md
@@ -29,14 +29,16 @@ hand-waving — if it can't be drawn on a whiteboard, it's not a design.
 
 You MUST sign all written output with `— Staff Engineer 🛠️`.
 
-## Every Run
+## Session Protocol
+
+### Every Run
 
 Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
 `Bash: fit-wiki boot --agent staff-engineer`. Triage inbox if non-empty;
 `fit-wiki claim` before opening any PR. Contract:
 [memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
 
-## Assess
+### Assess
 
 _Skip when handed a specific task._ Run `git fetch origin main` on every
 phase boundary, then route from `origin/main` only. A STATUS row at
@@ -57,7 +59,7 @@ advance routing; only merge of the prior phase's PR puts the artifact on
    and `wiki/STATUS.md` does not yet show `plan implemented` for the spec)
 4. **Fallback** -- MEMORY.md items listing you under Agents, then report clean.
 
-## Constraints
+### Constraints
 
 - Design, planning, and implementation only — never write specs or cut releases
 - Scope discipline: follow the plan, do not refactor adjacent code or add

--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -30,14 +30,16 @@ bitter — you're on a mission, and the mission is comprehension.
 
 You MUST sign all written output with `— Technical Writer 📝`.
 
-## Every Run
+## Session Protocol
+
+### Every Run
 
 Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
 `Bash: fit-wiki boot --agent technical-writer`. Triage inbox if non-empty;
 `fit-wiki claim` before opening any PR. Contract:
 [memory-protocol § On-Boot Read Set](.claude/agents/references/memory-protocol.md#on-boot-read-set).
 
-## Assess
+### Assess
 
 _Skip when handed a specific task._ Survey domain state, then choose the
 highest-priority action:
@@ -56,7 +58,7 @@ findings:
   from `main`
 - Every PR on an independent branch from `main`
 
-## Constraints
+### Constraints
 
 - Incremental fixes only — structural changes get a spec
 - Never weaken documentation accuracy or audience separation

--- a/libraries/libeval/src/profile-prompt.js
+++ b/libraries/libeval/src/profile-prompt.js
@@ -13,11 +13,25 @@
  *     </session_protocol>
  *
  * The two tags are siblings joined by a blank line — neither nests inside
- * the other. A section appears only when its content is present. A
- * system-prompt amendment is folded into the protocol trailer before
- * wrapping, so it lands transparently inside `<session_protocol>`. The tag
+ * the other. A section appears only when its content is present. The tag
  * convention lives entirely here: profile `.md` files and trailer constants
  * carry no tags.
+ *
+ * The `<session_protocol>` body is assembled from up to three fragments, in
+ * order of decreasing generality:
+ *
+ *   1. the role-invariant orchestration trailer (libeval-owned);
+ *   2. the profile's own hoisted `## Session Protocol` section, if present;
+ *   3. a run-specific amendment, if supplied.
+ *
+ * Fragment 2 is the convention-based hoist: a profile may carry a level-2
+ * `## Session Protocol` markdown heading whose body is the role's work
+ * routine. When present, that section is lifted out of `<agent_profile>` and
+ * folded into `<session_protocol>` next to the orchestration mechanics, so
+ * the harness comms protocol and the role's work routine read as one
+ * coherent block. The heading line itself is dropped — the tag already names
+ * the section. Profiles with no such heading are unaffected (the entire body
+ * stays in `<agent_profile>`).
  *
  * Helpers:
  *
@@ -28,9 +42,9 @@
  *   roles (supervisor, facilitator, discuss lead) that should only see
  *   the orchestration instructions and optionally a profile body.
  *
- * - `composeSystemPrompt(opts)` — unified entry point. Folds `amend` into
- *   the protocol section, then delegates to one of the above based on
- *   `opts.role`.
+ * - `composeSystemPrompt(opts)` — unified entry point. Threads `amend` into
+ *   the protocol section as the run-specific fragment, then delegates to one
+ *   of the above based on `opts.role`.
  */
 
 import { join } from "node:path";
@@ -39,6 +53,17 @@ import { join } from "node:path";
 const AGENT_PROFILE_TAG = "agent_profile";
 const SESSION_PROTOCOL_TAG = "session_protocol";
 
+/**
+ * A level-2 heading that names the profile's hoisted session-protocol
+ * section. Case-insensitive, tolerant of trailing whitespace, but the level
+ * is fixed at two `#` so a `### Session Protocol` subsection does not trip
+ * the hoist.
+ */
+const SESSION_PROTOCOL_HEADING = /^##[ \t]+session protocol[ \t]*$/i;
+
+/** A level-1 or level-2 heading — the boundary that ends a hoisted section. */
+const SECTION_BOUNDARY = /^#{1,2}[ \t]+\S/;
+
 /** Wrap content in a semantic section tag, each on its own line. */
 function wrapSection(tag, content) {
   return `<${tag}>\n${content}\n</${tag}>`;
@@ -46,86 +71,148 @@ function wrapSection(tag, content) {
 
 /**
  * Assemble the parallel `<agent_profile>` / `<session_protocol>` sections.
- * Each section is emitted only when its content is non-empty; the two tags
- * are siblings joined by a blank line and never nest.
+ * The profile section is emitted only when `body` is non-empty. The protocol
+ * section is built by joining its fragments (in the order given) with a
+ * blank-line separator, dropping any that are empty, and is emitted only
+ * when at least one fragment survives. The two tags are siblings joined by a
+ * blank line and never nest.
  *
  * @param {object} parts
- * @param {string} [parts.body] - Profile body, already frontmatter-stripped.
- * @param {string} [parts.protocol] - Session protocol trailer, with any
- *   amendment already folded in.
+ * @param {string} [parts.body] - Profile body, frontmatter-stripped and with
+ *   any `## Session Protocol` section already hoisted out.
+ * @param {Array<string | undefined>} [parts.protocolParts] - Ordered session
+ *   protocol fragments: trailer, hoisted profile section, run amendment.
  * @returns {string}
  */
-function assembleSections({ body, protocol }) {
+function assembleSections({ body, protocolParts = [] }) {
   const sections = [];
   if (body) sections.push(wrapSection(AGENT_PROFILE_TAG, body));
+  const protocol = protocolParts.filter(Boolean).join("\n\n");
   if (protocol) sections.push(wrapSection(SESSION_PROTOCOL_TAG, protocol));
   return sections.join("\n\n");
 }
 
 /**
- * Read a profile `.md`, strip its frontmatter, and return the trimmed body.
- * Reads synchronously off the injected `runtime.fsSync` surface — this
- * composer runs inside the synchronous SDK-option builders of the
- * supervisor / facilitator / discusser / judge factories, so it cannot go
- * async without an unbounded cascade.
+ * Split a frontmatter-stripped profile body into its persona and an optional
+ * hoisted `## Session Protocol` section. The section runs from its heading to
+ * the next level-1/level-2 heading (or end of body); the heading line is
+ * dropped. Anything before and after the section is rejoined into `persona`.
+ * When the body carries no `## Session Protocol` heading, the whole body is
+ * returned as `persona` and `protocol` is `undefined`.
+ *
+ * @param {string} body - Frontmatter-stripped, trimmed profile body.
+ * @returns {{ persona: string, protocol: string | undefined }}
+ */
+function splitSessionProtocol(body) {
+  const lines = body.split("\n");
+  const start = lines.findIndex((line) => SESSION_PROTOCOL_HEADING.test(line));
+  if (start === -1) return { persona: body, protocol: undefined };
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (SECTION_BOUNDARY.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+
+  const protocol = lines
+    .slice(start + 1, end)
+    .join("\n")
+    .trim();
+  const before = lines.slice(0, start).join("\n").trim();
+  const after = lines.slice(end).join("\n").trim();
+  const persona = [before, after].filter(Boolean).join("\n\n");
+  return { persona, protocol: protocol || undefined };
+}
+
+/**
+ * Read a profile `.md`, strip its frontmatter, and split off any hoisted
+ * `## Session Protocol` section. Reads synchronously off the injected
+ * `runtime.fsSync` surface — this composer runs inside the synchronous
+ * SDK-option builders of the supervisor / facilitator / discusser / judge
+ * factories, so it cannot go async without an unbounded cascade.
  *
  * @param {string} name - Profile basename (no `.md` suffix)
  * @param {string} profilesDir - Directory containing `<name>.md`
  * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
- * @returns {string}
+ * @returns {{ persona: string, protocol: string | undefined }}
  */
-function readProfileBody(name, profilesDir, runtime) {
+function readProfileSections(name, profilesDir, runtime) {
   const path = join(profilesDir, `${name}.md`);
   const raw = runtime.fsSync.readFileSync(path, "utf8");
-  return stripFrontmatter(raw).trim();
+  return splitSessionProtocol(stripFrontmatter(raw).trim());
 }
 
 /**
  * Compose a `claude_code`-preset system prompt from a profile file. The
- * profile body is wrapped in `<agent_profile>`; an optional protocol trailer
- * is wrapped in a sibling `<session_protocol>`.
+ * persona is wrapped in `<agent_profile>`; the protocol trailer, the
+ * profile's hoisted `## Session Protocol` section, and any amendment are
+ * joined (in that order) into a sibling `<session_protocol>`.
  *
  * @param {string} name - Profile basename (no `.md` suffix)
  * @param {object} opts
  * @param {string} opts.profilesDir - Directory containing `<name>.md`
- * @param {string} [opts.trailer] - Session protocol, wrapped as a sibling
- *   `<session_protocol>` section after a blank line
+ * @param {string} [opts.trailer] - Session protocol orchestration mechanics,
+ *   the first fragment of the `<session_protocol>` section.
+ * @param {string} [opts.amend] - Run-specific amendment, the last fragment of
+ *   the `<session_protocol>` section.
  * @param {import("@forwardimpact/libutil/runtime").Runtime} opts.runtime - Ambient collaborators; uses `fsSync.readFileSync`.
  * @returns {{type: "preset", preset: "claude_code", append: string}}
  */
-export function composeProfilePrompt(name, { profilesDir, trailer, runtime }) {
-  const body = readProfileBody(name, profilesDir, runtime);
+export function composeProfilePrompt(
+  name,
+  { profilesDir, trailer, amend, runtime },
+) {
+  const { persona, protocol } = readProfileSections(name, profilesDir, runtime);
   return {
     type: "preset",
     preset: "claude_code",
-    append: assembleSections({ body, protocol: trailer }),
+    append: assembleSections({
+      body: persona,
+      protocolParts: [trailer, protocol, amend],
+    }),
   };
 }
 
 /**
  * Compose a plain-string system prompt for a lead role (no Claude Code
- * preset). The protocol trailer is wrapped in `<session_protocol>`; an
- * optional profile body is wrapped in a sibling `<agent_profile>` before it.
+ * preset). The protocol trailer, an optional profile's hoisted
+ * `## Session Protocol` section, and any amendment are joined into
+ * `<session_protocol>`; an optional persona is wrapped in a sibling
+ * `<agent_profile>` before it.
  *
  * @param {object} opts
  * @param {string} [opts.profile] - Profile basename (no `.md` suffix)
  * @param {string} [opts.profilesDir] - Directory containing profile files
  * @param {string} opts.trailer - Session protocol (orchestration instructions)
+ * @param {string} [opts.amend] - Run-specific amendment, the last fragment of
+ *   the `<session_protocol>` section.
  * @param {import("@forwardimpact/libutil/runtime").Runtime} opts.runtime - Ambient collaborators; uses `fsSync.readFileSync`.
  * @returns {string}
  */
-export function composeLeadPrompt({ profile, profilesDir, trailer, runtime }) {
+export function composeLeadPrompt({
+  profile,
+  profilesDir,
+  trailer,
+  amend,
+  runtime,
+}) {
   if (!trailer) throw new Error("trailer is required");
-  const body = profile
-    ? readProfileBody(profile, profilesDir, runtime)
-    : undefined;
-  return assembleSections({ body, protocol: trailer });
+  const { persona, protocol } = profile
+    ? readProfileSections(profile, profilesDir, runtime)
+    : { persona: undefined, protocol: undefined };
+  return assembleSections({
+    body: persona,
+    protocolParts: [trailer, protocol, amend],
+  });
 }
 
 /**
- * Unified entry point for composing system prompts. Folds an optional
- * amendment into the protocol trailer — so it lands inside
- * `<session_protocol>` — then delegates by role.
+ * Unified entry point for composing system prompts. Threads an optional
+ * amendment through as the run-specific fragment of `<session_protocol>`
+ * (after the trailer and any hoisted profile section), then delegates by
+ * role.
  *
  * @param {object} opts
  * @param {"lead"|"agent"} opts.role - `"lead"` produces a plain string;
@@ -133,8 +220,8 @@ export function composeLeadPrompt({ profile, profilesDir, trailer, runtime }) {
  * @param {string} [opts.profile] - Profile basename
  * @param {string} [opts.profilesDir]
  * @param {string} opts.trailer - Session protocol (orchestration instructions)
- * @param {string} [opts.amend] - Caller-supplied amendment, appended inside
- *   `<session_protocol>` after the trailer with a blank-line separator.
+ * @param {string} [opts.amend] - Caller-supplied amendment, the last fragment
+ *   inside `<session_protocol>`, joined with a blank-line separator.
  * @param {import("@forwardimpact/libutil/runtime").Runtime} opts.runtime - Ambient collaborators; uses `fsSync.readFileSync`.
  * @returns {string | {type: "preset", preset: "claude_code", append: string}}
  */
@@ -147,26 +234,21 @@ export function composeSystemPrompt({
   runtime,
 }) {
   if (!trailer) throw new Error("trailer is required");
-  const protocol = amend ? `${trailer}\n\n${amend}` : trailer;
   if (role === "lead") {
-    return composeLeadPrompt({
-      profile,
-      profilesDir,
-      trailer: protocol,
-      runtime,
-    });
+    return composeLeadPrompt({ profile, profilesDir, trailer, amend, runtime });
   }
   if (profile) {
     return composeProfilePrompt(profile, {
       profilesDir,
-      trailer: protocol,
+      trailer,
+      amend,
       runtime,
     });
   }
   return {
     type: "preset",
     preset: "claude_code",
-    append: assembleSections({ protocol }),
+    append: assembleSections({ protocolParts: [trailer, amend] }),
   };
 }
 

--- a/libraries/libeval/test/fixtures/profile-prompt/with-session-protocol.md
+++ b/libraries/libeval/test/fixtures/profile-prompt/with-session-protocol.md
@@ -1,0 +1,29 @@
+---
+name: with-session-protocol
+description: A fixture profile that carries a hoisted ## Session Protocol section.
+skills:
+  - kata-spec
+---
+
+You are the hoist fixture agent. You exist so `composeProfilePrompt` tests can
+verify that the hoisted work-routine section is lifted out of the persona and
+folded into the protocol tag.
+
+## Voice
+
+Terse. You speak only to prove the persona text survives the hoist.
+
+## Session Protocol
+
+Before any task, boot the work routine fixture step.
+
+### Routing
+
+Pick the highest-priority fixture action. This level-3 heading must stay inside
+the hoisted section.
+
+## Constraints
+
+This trailing persona section must remain in `<agent_profile>` after the hoist.
+
+— Hoist Fixture 🪝

--- a/libraries/libeval/test/profile-prompt.test.js
+++ b/libraries/libeval/test/profile-prompt.test.js
@@ -170,6 +170,110 @@ describe("composeProfilePrompt", () => {
   });
 });
 
+describe("composeProfilePrompt — hoisted ## Session Protocol", () => {
+  test("lifts the section out of <agent_profile> into <session_protocol>", () => {
+    const result = composeProfilePrompt("with-session-protocol", {
+      profilesDir: FIXTURES,
+      runtime: RT,
+      trailer: "TRAILER_TEXT",
+    });
+    const profileEnd = result.append.indexOf("</agent_profile>");
+    const protocolStart = result.append.indexOf("<session_protocol>");
+    const hoistedAt = result.append.indexOf(
+      "Before any task, boot the work routine fixture step.",
+    );
+    assert.ok(profileEnd !== -1 && protocolStart > profileEnd);
+    assert.ok(
+      hoistedAt > protocolStart,
+      "hoisted work routine lands inside <session_protocol>",
+    );
+  });
+
+  test("drops the heading line itself", () => {
+    const result = composeProfilePrompt("with-session-protocol", {
+      profilesDir: FIXTURES,
+      runtime: RT,
+      trailer: "TRAILER_TEXT",
+    });
+    assert.ok(
+      !result.append.includes("## Session Protocol"),
+      "the <session_protocol> tag replaces the heading",
+    );
+  });
+
+  test("keeps persona sections on both sides of the hoist in <agent_profile>", () => {
+    const result = composeProfilePrompt("with-session-protocol", {
+      profilesDir: FIXTURES,
+      runtime: RT,
+      trailer: "TRAILER_TEXT",
+    });
+    const profileBody = result.append.slice(
+      result.append.indexOf("<agent_profile>"),
+      result.append.indexOf("</agent_profile>"),
+    );
+    assert.ok(
+      profileBody.includes("## Voice"),
+      "section before the hoist stays",
+    );
+    assert.ok(
+      profileBody.includes("## Constraints"),
+      "section after the hoist stays",
+    );
+    assert.ok(profileBody.includes("— Hoist Fixture 🪝"));
+    assert.ok(
+      !profileBody.includes("Before any task"),
+      "hoisted content does not remain in the persona",
+    );
+  });
+
+  test("keeps a level-3 subsection inside the hoisted section", () => {
+    const result = composeProfilePrompt("with-session-protocol", {
+      profilesDir: FIXTURES,
+      runtime: RT,
+      trailer: "TRAILER_TEXT",
+    });
+    const protocolBody = result.append.slice(
+      result.append.indexOf("<session_protocol>"),
+      result.append.indexOf("</session_protocol>"),
+    );
+    assert.ok(
+      protocolBody.includes("### Routing"),
+      "a ### subsection does not terminate the hoist",
+    );
+  });
+
+  test("orders trailer, then hoisted section, within <session_protocol>", () => {
+    const result = composeProfilePrompt("with-session-protocol", {
+      profilesDir: FIXTURES,
+      runtime: RT,
+      trailer: "TRAILER_TEXT",
+    });
+    assert.ok(
+      result.append.indexOf("TRAILER_TEXT") <
+        result.append.indexOf("Before any task"),
+      "the orchestration trailer precedes the hoisted work routine",
+    );
+  });
+
+  test("emits <session_protocol> from the hoist even with no trailer", () => {
+    const result = composeProfilePrompt("with-session-protocol", {
+      profilesDir: FIXTURES,
+      runtime: RT,
+    });
+    assert.ok(result.append.includes("<session_protocol>"));
+    assert.ok(result.append.includes("Before any task"));
+    assert.ok(!result.append.includes("## Session Protocol"));
+  });
+
+  test("a profile with no such heading keeps its whole body in <agent_profile>", () => {
+    const result = composeProfilePrompt("with-frontmatter", {
+      profilesDir: FIXTURES,
+      runtime: RT,
+    });
+    assert.ok(!result.append.includes("<session_protocol>"));
+  });
+});
+
 describe("composeSystemPrompt", () => {
   test("folds amend into the <session_protocol> section", () => {
     const result = composeSystemPrompt({
@@ -190,6 +294,25 @@ describe("composeSystemPrompt", () => {
     assert.ok(
       result.append.includes("PROTOCOL\n\n<AMENDMENT>"),
       "amendment follows the trailer with a blank-line separator",
+    );
+  });
+
+  test("orders trailer, hoisted section, then amend inside <session_protocol>", () => {
+    const result = composeSystemPrompt({
+      role: "agent",
+      profile: "with-session-protocol",
+      profilesDir: FIXTURES,
+      trailer: "PROTOCOL",
+      amend: "<AMENDMENT>",
+      runtime: RT,
+    });
+    const trailerAt = result.append.indexOf("PROTOCOL");
+    const hoistedAt = result.append.indexOf("Before any task");
+    const amendAt = result.append.indexOf("<AMENDMENT>");
+    const close = result.append.indexOf("</session_protocol>");
+    assert.ok(
+      trailerAt < hoistedAt && hoistedAt < amendAt && amendAt < close,
+      "fragments run trailer → hoisted → amend, all inside the section",
     );
   });
 
@@ -249,6 +372,25 @@ describe("composeLeadPrompt", () => {
     assert.strictEqual(
       result,
       "<session_protocol>\nLEAD_PROTOCOL\n</session_protocol>",
+    );
+  });
+
+  test("hoists a profile's ## Session Protocol section alongside the trailer", () => {
+    const result = composeLeadPrompt({
+      profile: "with-session-protocol",
+      profilesDir: FIXTURES,
+      trailer: "LEAD_PROTOCOL",
+      runtime: RT,
+    });
+    const protocolBody = result.slice(
+      result.indexOf("<session_protocol>"),
+      result.indexOf("</session_protocol>"),
+    );
+    assert.ok(protocolBody.includes("LEAD_PROTOCOL"));
+    assert.ok(protocolBody.includes("Before any task"));
+    assert.ok(!result.includes("## Session Protocol"));
+    assert.ok(
+      result.indexOf("LEAD_PROTOCOL") < result.indexOf("Before any task"),
     );
   });
 


### PR DESCRIPTION
## Summary

- `composeProfilePrompt` / `composeLeadPrompt` / `composeSystemPrompt` now hoist a profile's `## Session Protocol` section out of `<agent_profile>` and into the sibling `<session_protocol>` tag, next to the orchestration trailer. The `<session_protocol>` body is assembled from three ordered fragments: the role-invariant trailer, the profile's hoisted section, then any run-specific amendment.
- The hoist runs from the `## Session Protocol` heading to the next level-1/level-2 heading; the heading line itself is dropped (the tag already names the section), `###` subsections stay inside, and persona text on both sides of the section is rejoined. Profiles without the heading are unaffected — the whole body stays in `<agent_profile>`.
- Migrated the six kata agent profiles (`staff-engineer`, `improvement-coach`, `product-manager`, `release-engineer`, `security-engineer`, `technical-writer`) to the convention: their `Every Run` / `Assess` / `Constraints` sections are now `###` subsections under a single `## Session Protocol` heading. Pure restructure — no content changes; intro and `## Voice` stay in the persona.
- Live consumers (`fit-wiki fix`, and libeval's run/discusser/facilitator/supervisor/judge) compose these profiles, so the work routine now reads as one coherent block with the harness comms protocol.

## Test plan

- [x] `bun test libraries/libeval/` — 605 pass, 0 fail (includes a new fixture + 9 hoist/ordering tests across `composeProfilePrompt`, `composeSystemPrompt`, `composeLeadPrompt`)
- [x] Composed all six migrated profiles through `composeProfilePrompt`: heading dropped, `## Voice` retained in persona, `Every Run`/`Assess`/`Constraints` hoisted, trailer precedes the routine, nothing stranded
- [ ] `bun run check`
- [ ] `bun run test`