### PR TITLE
Remove libwiki stray-file audit rule

### DIFF
--- a/libraries/libwiki/src/audit/rules.js
+++ b/libraries/libwiki/src/audit/rules.js
@@ -77,7 +77,6 @@ const columnCount = (expected) => (s) =>
 
 const exists = (s) => (s.exists ? null : {});
 const expired = (s, ctx) => (s.expires_at < ctx.today ? {} : null);
-const always = () => ({});
 
 function entryHasDecision(lines, startIdx, requiredLine, stopRe) {
   let seen = 0;
@@ -492,15 +491,4 @@ export const RULES = [
   // -- STATUS.md rows (per-migration-unit sub-row schema) --
 
   ...STATUS_ROW_RULES,
-
-  // -- Stray files --
-
-  {
-    id: "wiki.stray-file",
-    scope: "stray-file",
-    severity: "fail",
-    check: always,
-    message: () => "Does not match any known scope",
-    hint: "rename to a recognized scope (summary, weekly log, weekly-log part) or remove the file",
-  },
 ];

--- a/libraries/libwiki/src/audit/scopes.js
+++ b/libraries/libwiki/src/audit/scopes.js
@@ -74,8 +74,7 @@ function classifyFile(filePath, fs) {
   const base = path.basename(filePath);
   if (EXCLUDED_BASES.has(base)) return null;
   // STATUS.md is loaded separately (loadStatus) and audited via the dedicated
-  // `status-row` scope — skip the per-file classification so it is not treated
-  // as a stray file.
+  // `status-row` scope — skip the per-file classification.
   if (base === "STATUS.md") return null;
   if (NON_SUMMARY_PREFIXES.some((p) => base.startsWith(p))) return null;
   if (WEEKLY_LOG_NAME_RE.test(base)) {
@@ -85,8 +84,10 @@ function classifyFile(filePath, fs) {
     return { kind: "weekly-log-part", subject: loadFile(filePath, fs) };
   }
   const subject = loadFile(filePath, fs);
-  const kind = SUMMARY_H1_RE.test(subject.firstLine) ? "summary" : "stray";
-  return { kind, subject };
+  // Files that do not match a summary or weekly-log shape are left
+  // unclassified: stray files are not audited.
+  if (!SUMMARY_H1_RE.test(subject.firstLine)) return null;
+  return { kind: "summary", subject };
 }
 
 function loadMemory(wikiRoot, fs) {
@@ -216,7 +217,6 @@ const SCOPE_RESOLVERS = {
       ...r,
       path: ctx.status.path,
     })),
-  "stray-file": (ctx) => ctx.subjects.stray,
 };
 
 /** Resolve a scope key into the list of subjects the engine should iterate. */
@@ -236,7 +236,6 @@ export function buildContext({ wikiRoot, today, fs }) {
     summary: [],
     "weekly-log-main": [],
     "weekly-log-part": [],
-    stray: [],
   };
   for (const file of listMdFiles(wikiRoot, fs)) {
     const classified = classifyFile(file, fs);

--- a/libraries/libwiki/test/audit-engine.test.js
+++ b/libraries/libwiki/test/audit-engine.test.js
@@ -272,11 +272,11 @@ describe("runRules", () => {
     assert.ok(idsOf(audit(seed)).includes("memory.priority-separator-row"));
   });
 
-  test("stray file fires wiki.stray-file", () => {
+  test("stray file is not audited", () => {
     const seed = cleanSeed("2026-05-24", {
       [`${WIKI}/weird.md`]: "# Whatever\n",
     });
-    assert.ok(idsOf(audit(seed)).includes("wiki.stray-file"));
+    assert.ok(!idsOf(audit(seed)).includes("wiki.stray-file"));
   });
 
   test("when predicate skips rule when subject does not qualify", () => {

--- a/libraries/libwiki/test/audit-rules.test.js
+++ b/libraries/libwiki/test/audit-rules.test.js
@@ -43,7 +43,6 @@ describe("RULES catalogue", () => {
         "status-row.id-format",
         "status-row.phase",
         "status-row.status",
-        "wiki.stray-file",
       ],
     );
   });


### PR DESCRIPTION
Stray files in the wiki are now permitted. Drop the wiki.stray-file
rule and the supporting classification: files that don't match a
summary or weekly-log shape are left unclassified rather than flagged.

https://claude.ai/code/session_01WhkWkaRuvTEfyi1GyJ7csh