### PR TITLE
docs(app-config): GitHub &amp; Azure app configuration scenarios (+ config-driven bridge tenancy mode)

### DIFF
--- a/.env.docker-native.example
+++ b/.env.docker-native.example
@@ -52,17 +52,48 @@ SERVICE_MAP_URL=grpc://localhost:3004
 SERVICE_PATHWAY_URL=grpc://localhost:3005
 
 # ==========================================
+# Hosted Control Plane — Tenant Registry (Optional)
+# ==========================================
+# Hosted, multi-tenant deployments only (services/tenancy). Internal gRPC
+# registry; not started in single-tenant self-hosted mode.
+# See services/tenancy/README.md
+
+# SERVICE_TENANCY_URL=grpc://localhost:3006
+
+# ==========================================
+# Hosted Control Plane — GitHub App Custody (Optional)
+# ==========================================
+# Hosted, multi-tenant deployments only (services/ghserver). Holds the GitHub
+# server App key and mints repo-scoped installation tokens; internal gRPC
+# (loopback). App config: services/ghserver/github-app.md.
+# See services/ghserver/README.md
+
+# SERVICE_GHSERVER_URL=grpc://localhost:3007
+# SERVICE_GHSERVER_APP_ID=
+# SERVICE_GHSERVER_PRIVATE_KEY=
+
+# ==========================================
+# Hosted Control Plane — OIDC Exchange (Optional)
+# ==========================================
+# Hosted, multi-tenant deployments only (services/oidc). Public HTTP front that
+# validates a GitHub Actions OIDC token and delegates minting to ghserver.
+# See services/oidc/README.md
+
+# SERVICE_OIDC_URL=http://localhost:3008
+# SERVICE_OIDC_PROVIDER=ghserver
+
+# ==========================================
 # GitHub User Auth (Optional)
 # ==========================================
 # Required when running per-user GitHub auth (services/ghuser).
-# See services/ghuser/README.md
+# See services/ghuser/README.md and services/ghuser/github-app.md
 
 # Kata Agent User GitHub App credentials
 # SERVICE_GHUSER_CLIENT_ID=
 # SERVICE_GHUSER_CLIENT_SECRET=
 
 # Service configuration (no trailing slashes on URLs)
-# SERVICE_GHUSER_URL=grpc://localhost:3006
+# SERVICE_GHUSER_URL=grpc://localhost:3009
 # SERVICE_GHUSER_LINK_BASE_URL=
 
 # ==========================================
@@ -71,7 +102,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # Required when running the OAuth authorization server (services/oauth).
 # See services/oauth/README.md
 
-# SERVICE_OAUTH_URL=http://localhost:3007
+# SERVICE_OAUTH_URL=http://localhost:3010
 # SERVICE_OAUTH_PROVIDER=ghuser
 
 # ==========================================
@@ -79,7 +110,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # ==========================================
 # Required when running the MCP tool server (services/mcp).
 
-# SERVICE_MCP_URL=http://localhost:3008
+# SERVICE_MCP_URL=http://localhost:3011
 
 # ==========================================
 # Bridge Store Service (Optional)
@@ -88,14 +119,14 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # Canonical discussion and origin store for both bridges.
 # See services/bridge/README.md
 
-# SERVICE_BRIDGE_URL=grpc://localhost:3009
+# SERVICE_BRIDGE_URL=grpc://localhost:3012
 
 # ==========================================
 # GitHub Discussions Bridge (Optional)
 # ==========================================
 # Required when running the Discussions ↔ Kata agent bridge (services/ghbridge).
 # Also requires SERVICE_GHUSER_URL and SERVICE_BRIDGE_URL above.
-# See services/ghbridge/README.md
+# See services/ghbridge/README.md and services/ghserver/github-app.md (self-hosted vs hosted)
 
 # Kata Agent Team GitHub App credentials
 # SERVICE_GHBRIDGE_APP_ID=
@@ -104,16 +135,18 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # SERVICE_GHBRIDGE_APP_WEBHOOK_SECRET=
 
 # Bridge configuration (no trailing slashes on URLs)
-# SERVICE_GHBRIDGE_URL=http://localhost:3010
+# SERVICE_GHBRIDGE_URL=http://localhost:3013
 # SERVICE_GHBRIDGE_GITHUB_REPO=
 # SERVICE_GHBRIDGE_CALLBACK_BASE_URL=
+# Deployment mode: single (self-hosted) or multi (hosted; needs tenancy + ghserver)
+# SERVICE_GHBRIDGE_TENANCY_MODE=single
 
 # ==========================================
 # MS Teams Bridge (Optional)
 # ==========================================
 # Required only when running the Teams ↔ Kata agent bridge (services/msbridge).
 # Also requires SERVICE_GHUSER_URL and SERVICE_BRIDGE_URL above.
-# See services/msbridge/README.md
+# See services/msbridge/README.md and services/msbridge/azure-app.md (self-hosted vs hosted)
 
 # Azure AD app registration credentials
 # MICROSOFT_APP_ID=
@@ -121,9 +154,11 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # MICROSOFT_APP_PASSWORD=
 
 # Bridge configuration (no trailing slashes on URLs)
-# SERVICE_MSBRIDGE_URL=http://localhost:3011
+# SERVICE_MSBRIDGE_URL=http://localhost:3014
 # SERVICE_MSBRIDGE_GITHUB_REPO=
 # SERVICE_MSBRIDGE_CALLBACK_BASE_URL=
+# Deployment mode: single (self-hosted) or multi (hosted; needs tenancy + ghserver)
+# SERVICE_MSBRIDGE_TENANCY_MODE=single
 
 # ==========================================
 # Embedding Service (Optional)
@@ -131,7 +166,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # gRPC endpoint for the embedding service (wraps TEI internally).
 # Start with: just tei-start
 
-# SERVICE_EMBEDDING_URL=grpc://embedding.local:3012
+# SERVICE_EMBEDDING_URL=grpc://embedding.local:3015
 
 # ==========================================
 # Supabase (single instance — all products)

--- a/.env.docker-supabase.example
+++ b/.env.docker-supabase.example
@@ -52,17 +52,48 @@ SERVICE_MAP_URL=grpc://localhost:3004
 SERVICE_PATHWAY_URL=grpc://localhost:3005
 
 # ==========================================
+# Hosted Control Plane — Tenant Registry (Optional)
+# ==========================================
+# Hosted, multi-tenant deployments only (services/tenancy). Internal gRPC
+# registry; not started in single-tenant self-hosted mode.
+# See services/tenancy/README.md
+
+# SERVICE_TENANCY_URL=grpc://localhost:3006
+
+# ==========================================
+# Hosted Control Plane — GitHub App Custody (Optional)
+# ==========================================
+# Hosted, multi-tenant deployments only (services/ghserver). Holds the GitHub
+# server App key and mints repo-scoped installation tokens; internal gRPC
+# (loopback). App config: services/ghserver/github-app.md.
+# See services/ghserver/README.md
+
+# SERVICE_GHSERVER_URL=grpc://localhost:3007
+# SERVICE_GHSERVER_APP_ID=
+# SERVICE_GHSERVER_PRIVATE_KEY=
+
+# ==========================================
+# Hosted Control Plane — OIDC Exchange (Optional)
+# ==========================================
+# Hosted, multi-tenant deployments only (services/oidc). Public HTTP front that
+# validates a GitHub Actions OIDC token and delegates minting to ghserver.
+# See services/oidc/README.md
+
+# SERVICE_OIDC_URL=http://localhost:3008
+# SERVICE_OIDC_PROVIDER=ghserver
+
+# ==========================================
 # GitHub User Auth (Optional)
 # ==========================================
 # Required when running per-user GitHub auth (services/ghuser).
-# See services/ghuser/README.md
+# See services/ghuser/README.md and services/ghuser/github-app.md
 
 # Kata Agent User GitHub App credentials
 # SERVICE_GHUSER_CLIENT_ID=
 # SERVICE_GHUSER_CLIENT_SECRET=
 
 # Service configuration (no trailing slashes on URLs)
-# SERVICE_GHUSER_URL=grpc://localhost:3006
+# SERVICE_GHUSER_URL=grpc://localhost:3009
 # SERVICE_GHUSER_LINK_BASE_URL=
 
 # ==========================================
@@ -71,7 +102,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # Required when running the OAuth authorization server (services/oauth).
 # See services/oauth/README.md
 
-# SERVICE_OAUTH_URL=http://localhost:3007
+# SERVICE_OAUTH_URL=http://localhost:3010
 # SERVICE_OAUTH_PROVIDER=ghuser
 
 # ==========================================
@@ -79,7 +110,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # ==========================================
 # Required when running the MCP tool server (services/mcp).
 
-# SERVICE_MCP_URL=http://localhost:3008
+# SERVICE_MCP_URL=http://localhost:3011
 
 # ==========================================
 # Bridge Store Service (Optional)
@@ -88,14 +119,14 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # Canonical discussion and origin store for both bridges.
 # See services/bridge/README.md
 
-# SERVICE_BRIDGE_URL=grpc://localhost:3009
+# SERVICE_BRIDGE_URL=grpc://localhost:3012
 
 # ==========================================
 # GitHub Discussions Bridge (Optional)
 # ==========================================
 # Required when running the Discussions ↔ Kata agent bridge (services/ghbridge).
 # Also requires SERVICE_GHUSER_URL and SERVICE_BRIDGE_URL above.
-# See services/ghbridge/README.md
+# See services/ghbridge/README.md and services/ghserver/github-app.md (self-hosted vs hosted)
 
 # Kata Agent Team GitHub App credentials
 # SERVICE_GHBRIDGE_APP_ID=
@@ -104,16 +135,18 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # SERVICE_GHBRIDGE_APP_WEBHOOK_SECRET=
 
 # Bridge configuration (no trailing slashes on URLs)
-# SERVICE_GHBRIDGE_URL=http://localhost:3010
+# SERVICE_GHBRIDGE_URL=http://localhost:3013
 # SERVICE_GHBRIDGE_GITHUB_REPO=
 # SERVICE_GHBRIDGE_CALLBACK_BASE_URL=
+# Deployment mode: single (self-hosted) or multi (hosted; needs tenancy + ghserver)
+# SERVICE_GHBRIDGE_TENANCY_MODE=single
 
 # ==========================================
 # MS Teams Bridge (Optional)
 # ==========================================
 # Required only when running the Teams ↔ Kata agent bridge (services/msbridge).
 # Also requires SERVICE_GHUSER_URL and SERVICE_BRIDGE_URL above.
-# See services/msbridge/README.md
+# See services/msbridge/README.md and services/msbridge/azure-app.md (self-hosted vs hosted)
 
 # Azure AD app registration credentials
 # MICROSOFT_APP_ID=
@@ -121,9 +154,11 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # MICROSOFT_APP_PASSWORD=
 
 # Bridge configuration (no trailing slashes on URLs)
-# SERVICE_MSBRIDGE_URL=http://localhost:3011
+# SERVICE_MSBRIDGE_URL=http://localhost:3014
 # SERVICE_MSBRIDGE_GITHUB_REPO=
 # SERVICE_MSBRIDGE_CALLBACK_BASE_URL=
+# Deployment mode: single (self-hosted) or multi (hosted; needs tenancy + ghserver)
+# SERVICE_MSBRIDGE_TENANCY_MODE=single
 
 # ==========================================
 # Embedding Service (Optional)
@@ -131,7 +166,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # gRPC endpoint for the embedding service (wraps TEI internally).
 # Start with: just tei-start
 
-# SERVICE_EMBEDDING_URL=grpc://embedding.local:3012
+# SERVICE_EMBEDDING_URL=grpc://embedding.local:3015
 
 # ==========================================
 # Supabase (single instance — all products)

--- a/.env.local.example
+++ b/.env.local.example
@@ -44,17 +44,48 @@ SERVICE_MAP_URL=grpc://localhost:3004
 SERVICE_PATHWAY_URL=grpc://localhost:3005
 
 # ==========================================
+# Hosted Control Plane — Tenant Registry (Optional)
+# ==========================================
+# Hosted, multi-tenant deployments only (services/tenancy). Internal gRPC
+# registry; not started in single-tenant self-hosted mode.
+# See services/tenancy/README.md
+
+# SERVICE_TENANCY_URL=grpc://localhost:3006
+
+# ==========================================
+# Hosted Control Plane — GitHub App Custody (Optional)
+# ==========================================
+# Hosted, multi-tenant deployments only (services/ghserver). Holds the GitHub
+# server App key and mints repo-scoped installation tokens; internal gRPC
+# (loopback). App config: services/ghserver/github-app.md.
+# See services/ghserver/README.md
+
+# SERVICE_GHSERVER_URL=grpc://localhost:3007
+# SERVICE_GHSERVER_APP_ID=
+# SERVICE_GHSERVER_PRIVATE_KEY=
+
+# ==========================================
+# Hosted Control Plane — OIDC Exchange (Optional)
+# ==========================================
+# Hosted, multi-tenant deployments only (services/oidc). Public HTTP front that
+# validates a GitHub Actions OIDC token and delegates minting to ghserver.
+# See services/oidc/README.md
+
+# SERVICE_OIDC_URL=http://localhost:3008
+# SERVICE_OIDC_PROVIDER=ghserver
+
+# ==========================================
 # GitHub User Auth (Optional)
 # ==========================================
 # Required when running per-user GitHub auth (services/ghuser).
-# See services/ghuser/README.md
+# See services/ghuser/README.md and services/ghuser/github-app.md
 
 # Kata Agent User GitHub App credentials
 # SERVICE_GHUSER_CLIENT_ID=
 # SERVICE_GHUSER_CLIENT_SECRET=
 
 # Service configuration (no trailing slashes on URLs)
-# SERVICE_GHUSER_URL=grpc://localhost:3006
+# SERVICE_GHUSER_URL=grpc://localhost:3009
 # SERVICE_GHUSER_LINK_BASE_URL=
 
 # ==========================================
@@ -63,7 +94,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # Required when running the OAuth authorization server (services/oauth).
 # See services/oauth/README.md
 
-# SERVICE_OAUTH_URL=http://localhost:3007
+# SERVICE_OAUTH_URL=http://localhost:3010
 # SERVICE_OAUTH_PROVIDER=ghuser
 
 # ==========================================
@@ -71,7 +102,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # ==========================================
 # Required when running the MCP tool server (services/mcp).
 
-# SERVICE_MCP_URL=http://localhost:3008
+# SERVICE_MCP_URL=http://localhost:3011
 
 # ==========================================
 # Bridge Store Service (Optional)
@@ -80,14 +111,14 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # Canonical discussion and origin store for both bridges.
 # See services/bridge/README.md
 
-# SERVICE_BRIDGE_URL=grpc://localhost:3009
+# SERVICE_BRIDGE_URL=grpc://localhost:3012
 
 # ==========================================
 # GitHub Discussions Bridge (Optional)
 # ==========================================
 # Required when running the Discussions ↔ Kata agent bridge (services/ghbridge).
 # Also requires SERVICE_GHUSER_URL and SERVICE_BRIDGE_URL above.
-# See services/ghbridge/README.md
+# See services/ghbridge/README.md and services/ghserver/github-app.md (self-hosted vs hosted)
 
 # Kata Agent Team GitHub App credentials
 # SERVICE_GHBRIDGE_APP_ID=
@@ -96,16 +127,18 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # SERVICE_GHBRIDGE_APP_WEBHOOK_SECRET=
 
 # Bridge configuration (no trailing slashes on URLs)
-# SERVICE_GHBRIDGE_URL=http://localhost:3010
+# SERVICE_GHBRIDGE_URL=http://localhost:3013
 # SERVICE_GHBRIDGE_GITHUB_REPO=
 # SERVICE_GHBRIDGE_CALLBACK_BASE_URL=
+# Deployment mode: single (self-hosted) or multi (hosted; needs tenancy + ghserver)
+# SERVICE_GHBRIDGE_TENANCY_MODE=single
 
 # ==========================================
 # MS Teams Bridge (Optional)
 # ==========================================
 # Required when running the Teams ↔ Kata agent bridge (services/msbridge).
 # Also requires SERVICE_GHUSER_URL and SERVICE_BRIDGE_URL above.
-# See services/msbridge/README.md
+# See services/msbridge/README.md and services/msbridge/azure-app.md (self-hosted vs hosted)
 
 # Azure AD app registration credentials
 # MICROSOFT_APP_ID=
@@ -113,9 +146,11 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # MICROSOFT_APP_PASSWORD=
 
 # Bridge configuration (no trailing slashes on URLs)
-# SERVICE_MSBRIDGE_URL=http://localhost:3011
+# SERVICE_MSBRIDGE_URL=http://localhost:3014
 # SERVICE_MSBRIDGE_GITHUB_REPO=
 # SERVICE_MSBRIDGE_CALLBACK_BASE_URL=
+# Deployment mode: single (self-hosted) or multi (hosted; needs tenancy + ghserver)
+# SERVICE_MSBRIDGE_TENANCY_MODE=single
 
 # ==========================================
 # Embedding Service (Optional)
@@ -123,7 +158,7 @@ SERVICE_PATHWAY_URL=grpc://localhost:3005
 # gRPC endpoint for the embedding service (wraps TEI internally).
 # Start with: just tei-start
 
-SERVICE_EMBEDDING_URL=grpc://localhost:3012
+SERVICE_EMBEDDING_URL=grpc://localhost:3015
 
 # ==========================================
 # Supabase (single instance — all products)

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -65,16 +65,26 @@ Optional services — add when working on those features:
 
 ```json
 { "name": "oauthtunnel", "command": "sh -c '. ./.env && exec cloudflared tunnel --url ${SERVICE_OAUTH_URL} --protocol http2'" }
-{ "name": "mstunnel",    "command": "sh -c '. ./.env && exec cloudflared tunnel --url ${SERVICE_MSBRIDGE_URL} --protocol http2'" }
+{ "name": "oidctunnel",  "command": "sh -c '. ./.env && exec cloudflared tunnel --url ${SERVICE_OIDC_URL} --protocol http2'" }
 { "name": "ghtunnel",    "command": "sh -c '. ./.env && exec cloudflared tunnel --url ${SERVICE_GHBRIDGE_URL} --protocol http2'" }
+{ "name": "mstunnel",    "command": "sh -c '. ./.env && exec cloudflared tunnel --url ${SERVICE_MSBRIDGE_URL} --protocol http2'" }
+{ "name": "tenancy",     "command": "node -e \"import('@forwardimpact/svctenancy/server.js')\"" }
+{ "name": "ghserver",    "command": "node -e \"import('@forwardimpact/svcghserver/server.js')\"" }
+{ "name": "oidc",        "command": "node -e \"import('@forwardimpact/svcoidc/server.js')\"" }
 { "name": "ghuser",      "command": "node -e \"import('@forwardimpact/svcghuser/server.js')\"" }
 { "name": "oauth",       "command": "node -e \"import('@forwardimpact/svcoauth/server.js')\"" }
 { "name": "mcp",         "command": "node -e \"import('@forwardimpact/svcmcp/server.js')\"" }
 { "name": "bridge",      "command": "node -e \"import('@forwardimpact/svcbridge/server.js')\"" }
-{ "name": "msbridge",    "command": "node -e \"import('@forwardimpact/svcmsbridge/server.js')\"" }
 { "name": "ghbridge",    "command": "node -e \"import('@forwardimpact/svcghbridge/server.js')\"" }
+{ "name": "msbridge",    "command": "node -e \"import('@forwardimpact/svcmsbridge/server.js')\"" }
 { "name": "embedding",   "command": "node -e \"import('@forwardimpact/svcembedding/server.js')\"" }
 ```
+
+This order mirrors the `.env.*.example` profiles (ports `3006`–`3015`) and
+lists each service after what it depends on: `tenancy` → `ghserver` → `oidc`,
+ahead of the multi-tenant `ghbridge`/`msbridge` that consume them. Only `oidc`
+is public-facing (its `oidctunnel` mirrors `oauthtunnel`); `tenancy` and
+`ghserver` are internal gRPC (loopback) and need no tunnel.
 
 Oneshot services use `"type": "oneshot"` with `up`/`down` instead of `command`:
 
@@ -91,6 +101,16 @@ Oneshot services use `"type": "oneshot"` with `up`/`down` instead of `command`:
 
 Values merge with the service's constructor defaults, then overridden by
 `SERVICE_{NAME}_{KEY}` environment variables from `.env` or the shell.
+
+For configuring the platform apps whose credentials feed these blocks and
+`.env` — self-hosted (single-tenant) vs hosted (multi-tenant) — see the
+per-app guides:
+
+- [GitHub server App](../services/ghserver/github-app.md) — installation-token
+  App (`ghbridge` / `ghserver`).
+- [GitHub user App](../services/ghuser/github-app.md) — per-user OAuth
+  (`ghuser`).
+- [Azure AD app](../services/msbridge/azure-app.md) — Teams bot (`msbridge`).
 
 ### `product.<name>` — product configuration
 

--- a/libraries/libbridge/src/index.js
+++ b/libraries/libbridge/src/index.js
@@ -34,6 +34,7 @@ export { Dispatcher } from "./dispatcher.js";
 export {
   DefaultTenantResolver,
   RegistryTenantResolver,
+  assertMultiTenantDeps,
 } from "./tenant-resolver.js";
 export { TokenResolver } from "./token-resolver.js";
 export { GhServerTokenResolver } from "./ghserver-token-resolver.js";

--- a/libraries/libbridge/src/tenant-resolver.js
+++ b/libraries/libbridge/src/tenant-resolver.js
@@ -100,3 +100,18 @@ export class RegistryTenantResolver {
     return this.#client.ResolveByTenantId({ tenant_id });
   }
 }
+
+/**
+ * Fail fast when a bridge is in multi-tenant mode but the tenancy client that
+ * mode requires was not injected. The bridge's `tenancy_mode` config is the
+ * single source of truth; a multi config missing its collaborators is a wiring
+ * error, not single-tenant mode.
+ *
+ * @param {boolean} multiTenant
+ * @param {object} [tenancyClient]
+ * @returns {void}
+ */
+export function assertMultiTenantDeps(multiTenant, tenancyClient) {
+  if (multiTenant && !tenancyClient)
+    throw new Error("tenancyClient is required in multi-tenant mode");
+}

--- a/libraries/libbridge/test/tenant-resolver.test.js
+++ b/libraries/libbridge/test/tenant-resolver.test.js
@@ -3,7 +3,21 @@ import { describe, expect, test } from "bun:test";
 import {
   DefaultTenantResolver,
   RegistryTenantResolver,
+  assertMultiTenantDeps,
 } from "../src/tenant-resolver.js";
+
+describe("assertMultiTenantDeps", () => {
+  test("throws when multi-tenant but no tenancy client", () => {
+    expect(() => assertMultiTenantDeps(true, undefined)).toThrow(
+      /tenancyClient is required/,
+    );
+  });
+
+  test("passes when multi-tenant with a client, or single-tenant", () => {
+    expect(() => assertMultiTenantDeps(true, {})).not.toThrow();
+    expect(() => assertMultiTenantDeps(false, undefined)).not.toThrow();
+  });
+});
 
 describe("DefaultTenantResolver", () => {
   test("requires channel", () => {

--- a/services/ghbridge/README.md
+++ b/services/ghbridge/README.md
@@ -11,6 +11,10 @@ For the trust model when this bridge runs as the hosted Forward Impact
 service vs the customer's self-hosted deployment, see
 [TRUST.md](../../TRUST.md).
 
+For configuring the GitHub **server App** this bridge uses (self-hosted holds
+the key here; hosted custodies it in `services/ghserver`), see
+[`services/ghserver` § github-app.md](https://github.com/forwardimpact/monorepo/blob/main/services/ghserver/github-app.md).
+
 ## Prerequisites
 
 - The Kata Agent Team GitHub App with `discussions: write` permission and

--- a/services/ghbridge/index.js
+++ b/services/ghbridge/index.js
@@ -8,6 +8,7 @@ import {
   ResumeScheduler,
   TokenResolver,
   appendHistory,
+  assertMultiTenantDeps,
   buildPrompt,
   createBridgeServer,
   createCallbackHandler,
@@ -112,7 +113,11 @@ export class GhBridgeService {
     // per-request resolved tenant repo; `makeGraphqlClient(repo)` returns a
     // client bound to that repo. Single-tenant uses the static `graphqlClient`.
     this.#makeGraphqlClient = deps.makeGraphqlClient;
-    this.#multiTenant = Boolean(deps.tenancyClient);
+    // Deployment mode is config-driven — `tenancy_mode` is the single source of
+    // truth. server.js injects the tenancy/ghserver clients only in "multi";
+    // guard against a multi config that is missing them.
+    this.#multiTenant = config.tenancy_mode === "multi";
+    assertMultiTenantDeps(this.#multiTenant, deps.tenancyClient);
     this.#clock = clock;
     this.#trustedOrigins = trustedOrigins;
     // Multi-tenant onboarding upserts repositories into the registry. The
@@ -300,7 +305,7 @@ export class GhBridgeService {
     // Multi-tenant onboarding: register repositories named by an
     // install-class delivery. Single-tenant deployments have no tenancy
     // client and skip this branch.
-    if (this.#tenancyClient && isInstallEvent(event, body)) {
+    if (this.#multiTenant && isInstallEvent(event, body)) {
       await handleInstall(body, {
         tenancyClient: this.#tenancyClient,
         logger: this.#logger,
@@ -315,7 +320,7 @@ export class GhBridgeService {
     // is dropped (204). Single-tenant deployments skip this branch and rely on
     // the DefaultTenantResolver (`tenant_id = "default"`).
     let tenant;
-    if (this.#tenancyClient) {
+    if (this.#multiTenant) {
       tenant = await extractTenant(body, this.#tenantResolver);
       if (!tenant) {
         this.#logger.debug("webhook", "no active tenant for delivery");

--- a/services/ghbridge/test/multi-tenant.test.js
+++ b/services/ghbridge/test/multi-tenant.test.js
@@ -149,7 +149,11 @@ async function newService({ multi } = {}) {
     deps.tenancyClient = tenancy;
   }
   const service = new GhBridgeService(
-    makeConfig(multi ? { github_repo: "" } : {}),
+    makeConfig(
+      multi
+        ? { tenancy_mode: "multi", github_repo: "" }
+        : { tenancy_mode: "single" },
+    ),
     deps,
   );
   await service.start();

--- a/services/ghbridge/test/startup.test.js
+++ b/services/ghbridge/test/startup.test.js
@@ -25,13 +25,14 @@ const BASE_DEPS = () => ({
   ticketSecret: "ghbridge-test-secret",
 });
 
-function makeConfig() {
+function makeConfig(overrides = {}) {
   return createMockConfig("ghbridge", {
     host: "127.0.0.1",
     port: 0,
     github_repo: "owner/repo",
     callback_base_url: "https://bridge.example",
     app_webhook_secret: "secret-long-enough-for-hmac",
+    ...overrides,
   });
 }
 
@@ -75,7 +76,7 @@ describe("ghbridge startup", () => {
         expires_at: 0,
       }),
     };
-    const service = new GhBridgeService(makeConfig(), {
+    const service = new GhBridgeService(makeConfig({ tenancy_mode: "multi" }), {
       ...BASE_DEPS(),
       ghuserClient: {},
       tenantResolver: new RegistryTenantResolver({ client: tenancyClient }),

--- a/services/ghserver/README.md
+++ b/services/ghserver/README.md
@@ -7,6 +7,10 @@ the hosted control plane.
 
 <!-- END:description -->
 
+For configuring the GitHub **server App** (self-hosted vs hosted), see
+[github-app.md](github-app.md). The separate per-user OAuth app is documented
+in `services/ghuser`.
+
 ## What this service owns
 
 `services/ghserver` is the only process in the hosted control plane that

--- a/services/ghserver/github-app.md
+++ b/services/ghserver/github-app.md
@@ -1,0 +1,109 @@
+# GitHub server App configuration
+
+How to configure the **GitHub server App** — the installation App whose private
+key mints repo-scoped, server-to-server installation tokens — for each
+deployment model. `services/ghserver` is the App's key-custody service in the
+hosted model; `services/ghbridge` holds the same key in the self-hosted model.
+
+> **Two GitHub apps, do not conflate them.** This guide covers the **server
+> App** (installation tokens). The separate **user App** — per-user OAuth, used
+> for dispatch identity in self-hosted deployments — is documented in
+> [`services/ghuser` § GitHub user App configuration](https://github.com/forwardimpact/monorepo/blob/main/services/ghuser/github-app.md).
+
+This is the GitHub counterpart of
+[`services/msbridge` § Azure AD app configuration](https://github.com/forwardimpact/monorepo/blob/main/services/msbridge/azure-app.md);
+the two guides share a structure. See
+[TRUST.md](https://github.com/forwardimpact/monorepo/blob/main/TRUST.md) for the
+trust model.
+
+## At a glance
+
+| Aspect | Self-hosted (single-tenant) | Hosted (multi-tenant) |
+| --- | --- | --- |
+| Who registers / owns the App | the adopting team | Forward Impact (one shared App) |
+| App scope toggle | "Where can this GitHub App be installed?" → **Only on this account** | → **Any account** |
+| Tenant binding | static installation id (`SERVICE_GHBRIDGE_APP_INSTALLATION_ID`) | resolved per inbound webhook from the delivery's repository (`resolveByRepo`) |
+| Signing credential | App private key (PEM) | App private key (PEM) |
+| Where the key lives | in the `ghbridge` process | in `services/ghserver` **only** — no bridge or workflow holds it |
+| Workflow credential | `KATA_APP_ID` + `KATA_APP_PRIVATE_KEY` repo secrets | installation token minted at run time from `services/oidc` (repo sets the `FIT_OIDC_URL` variable; no App-key secret) |
+| Discussion-reply credential | installation token from the static installation id | per-repo installation token minted by `services/ghserver` |
+| Bridge mode flag | `SERVICE_GHBRIDGE_TENANCY_MODE=single` (default) | `SERVICE_GHBRIDGE_TENANCY_MODE=multi` |
+| Onboarding | install the App on your own account, by hand | install the shared App from its public URL; `installation` webhooks onboard repos into `services/tenancy` |
+| Services required | `ghbridge`, `bridge`, `ghuser` | `ghbridge`, `bridge`, `ghserver`, `oidc`, `tenancy` |
+
+## Self-hosted (single-tenant)
+
+You own and run one GitHub App for your account/organization; the bridge holds
+its key directly (`services/ghserver` is not deployed).
+
+**Register the App** following
+[`kata-setup` § GitHub App Setup](https://github.com/forwardimpact/monorepo/blob/main/.claude/skills/kata-setup/references/github-app.md):
+
+- **Where can this GitHub App be installed?** → **Only on this account.**
+- Enable the webhook → `${GHBRIDGE_PUBLIC_URL}/api/webhook` with a 32-byte hex
+  secret (also set as `SERVICE_GHBRIDGE_APP_WEBHOOK_SECRET`).
+- Install the App on the target repository and note the **installation id**.
+
+**Configure** `services/ghbridge` (`createServiceConfig("ghbridge")`):
+
+| Env var | Value |
+| --- | --- |
+| `SERVICE_GHBRIDGE_TENANCY_MODE` | `single` (default) |
+| `SERVICE_GHBRIDGE_APP_ID` | the App's numeric id |
+| `SERVICE_GHBRIDGE_APP_PRIVATE_KEY` | PEM contents (single-line — see the ghbridge README § Private key format) |
+| `SERVICE_GHBRIDGE_APP_INSTALLATION_ID` | installation id for the target repo |
+| `SERVICE_GHBRIDGE_APP_WEBHOOK_SECRET` | the webhook secret |
+
+**Workflows** authenticate with the App via repo secrets `KATA_APP_ID` and
+`KATA_APP_PRIVATE_KEY` (the `kata-setup` self-hosted workflow templates). The
+bridge threads the literal tenant id `default` through `services/bridge`;
+per-user OAuth via the **user App** (`services/ghuser`) supplies the
+`workflow_dispatch` credential.
+
+**Onboarding** is manual: one account, one App, one installation. No tenant
+registry is involved.
+
+## Hosted (multi-tenant)
+
+Forward Impact registers and runs one shared GitHub App plus the hosted control
+plane. Adopters install the App and never register their own.
+
+**App registration (Forward Impact operator):**
+
+- **Where can this GitHub App be installed?** → **Any account.**
+- Webhook → the hosted `ghbridge` ingress; the App private key is provisioned
+  **only** into `services/ghserver`.
+
+**Configure the hosted services:**
+
+| Service | Key configuration |
+| --- | --- |
+| `services/ghserver` | `SERVICE_GHSERVER_APP_ID`, `SERVICE_GHSERVER_PRIVATE_KEY` — the only process that holds the App key; mints repo-scoped installation tokens |
+| `services/oidc` | validates a workflow's GitHub Actions OIDC token and delegates minting to `ghserver` |
+| `services/ghbridge` | `SERVICE_GHBRIDGE_TENANCY_MODE=multi` — holds no App key; resolves the tenant per webhook and mints per-repo tokens via `ghserver` |
+| `services/tenancy` | tenant registry — onboarding upserts and repo → tenant resolution |
+
+**Adopter setup** carries **no** `KATA_APP_PRIVATE_KEY`: the repo sets the
+`FIT_OIDC_URL` repository **variable** (and `ANTHROPIC_API_KEY`), and the
+hosted workflow templates mint a short-lived installation token from
+`services/oidc` at run time.
+
+**Onboarding** is self-service: installing the shared App fires
+`installation.created` / `installation.repositories_added`, which onboard each
+repository into `services/tenancy` with `state = active`. Thereafter every
+inbound webhook resolves to its tenant by repository.
+
+> The `installation.repositories_removed` / full-uninstall **revoke** path and
+> KMS/HSM custody of the App key are deferred hardening, tracked in the
+> [hosted control-plane hardening spec](https://github.com/forwardimpact/monorepo/blob/main/specs/1272-hosted-control-plane-hardening/spec.md).
+
+## See also
+
+- [GitHub **user** App configuration](https://github.com/forwardimpact/monorepo/blob/main/services/ghuser/github-app.md)
+  — the other GitHub app (per-user OAuth dispatch identity).
+- [Azure AD app configuration](https://github.com/forwardimpact/monorepo/blob/main/services/msbridge/azure-app.md)
+  — the symmetric Teams guide.
+- [`services/ghbridge` README](https://github.com/forwardimpact/monorepo/blob/main/services/ghbridge/README.md)
+  § Tenancy mode — runtime configuration and the private-key format.
+- [TRUST.md](https://github.com/forwardimpact/monorepo/blob/main/TRUST.md)
+  — trust model for both paths.

--- a/services/ghserver/package.json
+++ b/services/ghserver/package.json
@@ -36,7 +36,8 @@
     "index.js",
     "server.js",
     "src",
-    "proto"
+    "proto",
+    "github-app.md"
   ],
   "scripts": {
     "test": "bun test test/*.test.js"

--- a/services/ghuser/README.md
+++ b/services/ghuser/README.md
@@ -7,6 +7,10 @@ User App.
 
 <!-- END:description -->
 
+For configuring this GitHub **user App** (self-hosted vs hosted), see
+[github-app.md](github-app.md). The separate server/installation app
+is documented in `services/ghserver`.
+
 ## Prerequisites
 
 - A **Kata Agent User** GitHub App (user-to-server auth model) with

--- a/services/ghuser/github-app.md
+++ b/services/ghuser/github-app.md
@@ -1,0 +1,70 @@
+# GitHub user App configuration
+
+How to configure the **GitHub user App** — the Kata Agent **User** App that
+issues per-user OAuth (user-to-server) tokens through `services/ghuser`. Both
+bridges share it: in self-hosted deployments it supplies the GitHub identity a
+`workflow_dispatch` runs under, so commits are authored as the human who asked
+rather than a shared bot.
+
+> **Two GitHub apps, do not conflate them.** This guide covers the **user App**
+> (per-user OAuth). The separate **server App** — the installation App whose key
+> mints server-to-server tokens — is documented in
+> [`services/ghserver` § GitHub server App configuration](https://github.com/forwardimpact/monorepo/blob/main/services/ghserver/github-app.md).
+
+See [TRUST.md](https://github.com/forwardimpact/monorepo/blob/main/TRUST.md) for
+the trust model.
+
+## At a glance
+
+| Aspect | Self-hosted (single-tenant) | Hosted (multi-tenant) |
+| --- | --- | --- |
+| Who registers / owns the App | the adopting team | Forward Impact (one shared App) |
+| App type | a GitHub App (or OAuth App) issuing **user-to-server** tokens | same |
+| Role in dispatch | **the** `workflow_dispatch` identity — each dispatch runs as the linked user | **not on the dispatch path** — hosted `workflow_dispatch` uses the server App's installation token (`services/ghserver`) instead |
+| Credential | OAuth `client_id` + `client_secret` | OAuth `client_id` + `client_secret` |
+| Per-user linking | users link once via the OAuth flow; the bridge prompts on the channel when a link is missing | same flow where per-user identity is still wanted (e.g. attribution), but not required for dispatch |
+| Services required | `ghuser` (+ the bridge that consumes it) | optional — `ghuser` need not run if only App-token dispatch is used |
+
+## Self-hosted (single-tenant)
+
+The user App is the dispatch identity. Register one GitHub App (or OAuth App)
+that issues user-to-server tokens, set its **Authorization callback URL** to
+`${GHUSER_LINK_BASE_URL}/callback`, and run `services/ghuser`.
+
+**Configure** `services/ghuser` (`createServiceConfig("ghuser")`):
+
+| Env var | Value |
+| --- | --- |
+| `SERVICE_GHUSER_CLIENT_ID` | the user App's OAuth client id |
+| `SERVICE_GHUSER_CLIENT_SECRET` | the user App's OAuth client secret |
+| `SERVICE_GHUSER_LINK_BASE_URL` | public base URL the bridge links users to for authorization |
+| `SERVICE_GHUSER_IDP_ORIGIN` / `SERVICE_GHUSER_TRUSTED_IDP_ORIGINS` | identity-provider origin and the trusted-origin allowlist |
+| `SERVICE_GHUSER_LINK_COMPLETION_TICKET_SECRET` | shared HMAC secret across `ghuser`, `ghbridge`, and `msbridge` |
+
+Each user who triggers a dispatch links their GitHub account once; the bridge
+(`ghbridge` or `msbridge`) prompts on the channel when a link is missing and
+resolves the per-user token through `ghuser` at dispatch time.
+
+## Hosted (multi-tenant)
+
+Hosted `workflow_dispatch` does **not** use the user App. The dispatch
+credential shifts to the **server App** installation token minted by
+`services/ghserver` for the resolved tenant repo (so hosted workflow commits
+are authored as the App, not the human dispatcher — the design's explicit
+trade-off to avoid requiring every dispatcher to complete a per-user link
+flow). `services/ghuser` therefore need not run on the hosted dispatch path.
+
+Where per-user attribution is still desired on a hosted surface, the same OAuth
+flow and configuration above apply; it simply no longer gates dispatch.
+
+## See also
+
+- [GitHub **server** App configuration](https://github.com/forwardimpact/monorepo/blob/main/services/ghserver/github-app.md)
+  — the other GitHub app (installation tokens), with the self-hosted vs hosted
+  scenarios.
+- [Azure AD app configuration](https://github.com/forwardimpact/monorepo/blob/main/services/msbridge/azure-app.md)
+  — the Teams app; it shares this user App for self-hosted dispatch identity.
+- [`services/ghuser` README](README.md) — the service's RPC surface and runtime
+  configuration.
+- [TRUST.md](https://github.com/forwardimpact/monorepo/blob/main/TRUST.md)
+  — trust model for both paths.

--- a/services/ghuser/package.json
+++ b/services/ghuser/package.json
@@ -36,7 +36,8 @@
     "index.js",
     "server.js",
     "src",
-    "proto"
+    "proto",
+    "github-app.md"
   ],
   "scripts": {
     "test": "bun test test/*.test.js"

--- a/services/msbridge/README.md
+++ b/services/msbridge/README.md
@@ -11,6 +11,9 @@ For the trust model when this bridge runs as the hosted Forward Impact
 service vs the customer's self-hosted deployment, see
 [TRUST.md](../../TRUST.md).
 
+For configuring the Azure AD (Entra) app behind this bridge (self-hosted
+single-tenant vs hosted multi-tenant), see [azure-app.md](azure-app.md).
+
 ## Prerequisites
 
 - A Microsoft 365 developer tenant with an Azure Bot resource registered

--- a/services/msbridge/azure-app.md
+++ b/services/msbridge/azure-app.md
@@ -1,0 +1,110 @@
+# Azure AD app configuration
+
+How to configure the **Azure AD (Entra) app** — registered as an Azure Bot —
+behind `services/msbridge` for each deployment model. This is the Teams
+counterpart of
+[`services/ghserver` § GitHub server App configuration](https://github.com/forwardimpact/monorepo/blob/main/services/ghserver/github-app.md);
+the two guides share a structure. See
+[TRUST.md](https://github.com/forwardimpact/monorepo/blob/main/TRUST.md) for the
+trust model.
+
+> Teams has **one** app (the Azure Bot). For the GitHub `workflow_dispatch`
+> credential it triggers, the self-hosted path reuses the GitHub **user App**
+> (`services/ghuser`), exactly as `ghbridge` does — see
+> [GitHub user App configuration](https://github.com/forwardimpact/monorepo/blob/main/services/ghuser/github-app.md).
+
+## At a glance
+
+| Aspect | Self-hosted (single-tenant) | Hosted (multi-tenant) |
+| --- | --- | --- |
+| Who registers / owns the app | the adopting team | Forward Impact (one shared app) |
+| App scope toggle | "Supported account types" → **Accounts in this organizational directory only**; `MicrosoftAppType` = **SingleTenant** | → **Accounts in any organizational directory**; `MicrosoftAppType` = **MultiTenant** |
+| Tenant binding | `MICROSOFT_APP_TENANT_ID` set | `MICROSOFT_APP_TENANT_ID` **omitted**; resolved per activity from `channelData.tenant.id` |
+| Auth credential | client secret (`MICROSOFT_APP_PASSWORD`) | client secret (`MICROSOFT_APP_PASSWORD`) |
+| Where the credential lives | in the `msbridge` process | in the `msbridge` process — the Bot Framework credential is **not** centralized the way the GitHub App key is (no cross-workflow fanout); custody hardening is deferred (see below) |
+| Workflow credential | GitHub `workflow_dispatch` runs under per-user OAuth via the GitHub user App (`services/ghuser`) | GitHub `workflow_dispatch` runs under a repo-scoped GitHub server-App installation token minted by `services/ghserver` (Teams is not a GitHub Actions runner, so there is no `services/oidc` exchange on this path) |
+| Chat-reply credential | in-process Bot Framework credential | in-process Bot Framework credential |
+| Bridge mode flag | `SERVICE_MSBRIDGE_TENANCY_MODE=single` (default) | `SERVICE_MSBRIDGE_TENANCY_MODE=multi` |
+| Onboarding | register the Azure app and sideload the Teams app by hand | install the shared Teams app; `installationUpdate` consent + `POST /onboard` map the repo into `services/tenancy` |
+| Services required | `msbridge`, `bridge`, `ghuser` | `msbridge`, `bridge`, `ghserver`, `tenancy` |
+
+## Self-hosted (single-tenant)
+
+You own and run one Azure AD app, bound to your own Entra tenant.
+
+**Register the app** following
+[Teams configuration § Azure AD App Registration](https://github.com/forwardimpact/monorepo/blob/main/specs/1200-teams-agent-bridge/config-msteams.md):
+
+- **Supported account types** → **Accounts in this organizational directory
+  only** (single tenant).
+- Create a **client secret** and copy its value.
+- Register an Azure Bot for the app and enable the **Microsoft Teams** channel;
+  point the messaging endpoint at your bridge's public URL.
+
+**Configure** `services/msbridge` (`createServiceConfig("msbridge")`):
+
+| Env var | Value |
+| --- | --- |
+| `SERVICE_MSBRIDGE_TENANCY_MODE` | `single` (default) |
+| `MICROSOFT_APP_ID` | the app's Application (client) id |
+| `MICROSOFT_APP_PASSWORD` | the client secret value |
+| `MICROSOFT_APP_TENANT_ID` | the Directory (tenant) id |
+
+> `MICROSOFT_APP_TENANT_ID` is **required** here:
+> `ConfigurationBotFrameworkAuthentication` defaults to multi-tenant
+> validation when it is absent, so every inbound activity fails with 401.
+
+The bridge runs the Bot Framework authenticator in `SingleTenant` mode and
+threads the literal tenant id `default` through `services/bridge`; per-user
+OAuth via the GitHub user App (`services/ghuser`) supplies the
+`workflow_dispatch` credential.
+
+**Onboarding** is manual: one Entra tenant, one app, one repo. No tenant
+registry is involved.
+
+## Hosted (multi-tenant)
+
+Forward Impact registers and runs one shared Azure AD app plus the hosted
+control plane. Adopters install the shared Teams app and never register their
+own Azure app.
+
+**App registration (Forward Impact operator):**
+
+- **Supported account types** → **Accounts in any organizational directory**
+  (multitenant); the bridge runs with `MicrosoftAppType` = **MultiTenant** and
+  `MICROSOFT_APP_TENANT_ID` **omitted**, so the Bot Framework SDK accepts JWTs
+  issued by any consenting Entra tenant.
+
+**Configure the hosted services:**
+
+| Service | Key configuration |
+| --- | --- |
+| `services/msbridge` | `SERVICE_MSBRIDGE_TENANCY_MODE=multi`; `MICROSOFT_APP_ID` / `MICROSOFT_APP_PASSWORD` set, `MICROSOFT_APP_TENANT_ID` omitted |
+| `services/ghserver` | mints the repo-scoped GitHub server-App installation token used for hosted `workflow_dispatch` |
+| `services/tenancy` | tenant registry — consent registration, Entra-tid → tenant resolution, repo mapping |
+
+**Onboarding** is self-service:
+
+1. A tenant adds the shared Teams app → Bot Framework fires `installationUpdate`
+   (`action = add`) → the tenant is registered `pending_consent` in
+   `services/tenancy`, keyed by its Entra tenant id.
+2. The customer calls `POST /onboard` with `{ repo: { owner, name } }`; the
+   handler verifies the caller's Entra `tid`, transitions that tenant to
+   `active`, and binds the repo. Activities from non-active tenants are
+   rejected.
+
+> Full Bot Framework JWT signature validation for `/onboard` and custody
+> hardening of the Bot Framework credential are deferred; until the verifier
+> lands, `/onboard` is **default-deny** in production. Both are tracked in the
+> [hosted control-plane hardening spec](https://github.com/forwardimpact/monorepo/blob/main/specs/1272-hosted-control-plane-hardening/spec.md).
+
+## See also
+
+- [GitHub server App configuration](https://github.com/forwardimpact/monorepo/blob/main/services/ghserver/github-app.md)
+  — the symmetric GitHub guide.
+- [GitHub user App configuration](https://github.com/forwardimpact/monorepo/blob/main/services/ghuser/github-app.md)
+  — the shared per-user dispatch identity for self-hosted.
+- [`services/msbridge` README](README.md) § Tenancy mode — runtime
+  configuration and multi-tenant onboarding detail.
+- [TRUST.md](https://github.com/forwardimpact/monorepo/blob/main/TRUST.md)
+  — trust model for both paths.

--- a/services/msbridge/index.js
+++ b/services/msbridge/index.js
@@ -9,6 +9,7 @@ import {
   ResumeScheduler,
   TokenResolver,
   appendHistory,
+  assertMultiTenantDeps,
   buildPrompt,
   createBridgeServer,
   createCallbackHandler,
@@ -74,6 +75,7 @@ export class MsBridgeService {
   #clock;
   #trustedOrigins;
   #tenancyClient;
+  #multiTenant;
   #tenantResolver;
 
   /**
@@ -128,6 +130,10 @@ export class MsBridgeService {
     // Present only in multi-tenant mode; drives consent registration and the
     // /onboard repo mapping. Single-tenant deployments never reach tenancy.
     this.#tenancyClient = tenancyClient;
+    // Deployment mode is config-driven — `tenancy_mode` is the single source of
+    // truth; server.js injects the tenancy/ghserver clients only in "multi".
+    this.#multiTenant = config.tenancy_mode === "multi";
+    assertMultiTenantDeps(this.#multiTenant, tenancyClient);
 
     // One resolver instance is shared by the store adapter (tenant_id on
     // every gRPC) and the dispatcher (tenant_id in the callback URL). The
@@ -171,7 +177,7 @@ export class MsBridgeService {
     // Bot Framework reply credential stays in-process. Single-tenant keeps the
     // per-user OAuth token via services/ghuser.
     const dispatchTokenResolver =
-      this.#tenancyClient && ghserverClient
+      this.#multiTenant && ghserverClient
         ? new GhServerTokenResolver(ghserverClient, { requestedBy: "msbridge" })
         : new TokenResolver(ghuserClient);
     this.#dispatcher = new Dispatcher({
@@ -239,7 +245,7 @@ export class MsBridgeService {
     });
 
     // Hosted repo-mapping endpoint, mounted only in multi-tenant mode.
-    if (this.#tenancyClient) {
+    if (this.#multiTenant) {
       this.#mountOnboard(authenticateTenant, logger);
     }
   }
@@ -316,7 +322,7 @@ export class MsBridgeService {
    * @returns {Promise<boolean>} true when the activity was a consent signal
    */
   async #maybeHandleConsent(activity) {
-    if (!this.#tenancyClient || !isConsentActivity(activity)) return false;
+    if (!this.#multiTenant || !isConsentActivity(activity)) return false;
     await handleConsent(activity, {
       tenancyClient: this.#tenancyClient,
       logger: this.#logger,
@@ -348,7 +354,7 @@ export class MsBridgeService {
     // (pending_consent) tenants are dropped. Single-tenant deployments skip
     // this branch and rely on the DefaultTenantResolver (`tenant_id = "default"`).
     let tenant;
-    if (this.#tenancyClient) {
+    if (this.#multiTenant) {
       tenant = await extractTenant(activity, this.#tenantResolver);
       if (!tenant) {
         this.#logger.debug("intake", "no active tenant for activity");

--- a/services/msbridge/package.json
+++ b/services/msbridge/package.json
@@ -34,7 +34,8 @@
   },
   "files": [
     "index.js",
-    "server.js"
+    "server.js",
+    "azure-app.md"
   ],
   "scripts": {
     "test": "bun test test/*.test.js"

--- a/services/msbridge/test/multi-tenant.test.js
+++ b/services/msbridge/test/multi-tenant.test.js
@@ -140,7 +140,11 @@ for (const mode of ["single", "multi"]) {
         };
       }
       service = new MsBridgeService(
-        makeConfig(multi ? { github_repo: "" } : {}),
+        makeConfig(
+          multi
+            ? { tenancy_mode: "multi", github_repo: "" }
+            : { tenancy_mode: "single" },
+        ),
         deps,
       );
       await service.start();


### PR DESCRIPTION
## Summary

Two logical changes, both centered on how the bridges are configured:

**Docs — app configuration scenarios** (per package, shipped in `files[]`):
- `services/ghserver/github-app.md` — GitHub **server** (installation) App; `services/ghuser/github-app.md` — GitHub **user** (OAuth) App; `services/msbridge/azure-app.md` — Azure AD (Entra)/Bot app. Each documents self-hosted (single-tenant) vs hosted (multi-tenant); the server-App and Azure guides are structurally symmetric, with genuine channel differences called out in the same slots.
- `config/CLAUDE.md` + the three `.env.*.example` profiles add the hosted control-plane services (`tenancy`, `ghserver`, `oidc` + an `oidctunnel`) in dependency order, a single monotonic example-port run (`3001–3015`), a `SERVICE_*_TENANCY_MODE` example, and links to the per-app guides.

**Fix — `tenancy_mode` is the single source of truth:**
- Both bridges previously inferred multi-tenant mode from whether a tenancy client was injected. They now derive it from `config.tenancy_mode` (the documented source of truth that `server.js` already branches on) and fail fast when a `multi` config is missing its client.
- The guard (`assertMultiTenantDeps`) lives in `libbridge` (both bridges import it; no duplication) with a unit test; bridge tests set `tenancy_mode` so the config flag — not client injection — selects the mode.

Docs-only changes plus a contained bridge refactor; no behavioral change to the single-tenant (default) path.

## Test plan

- [x] `bun run check` (exit 0)
- [x] `bun test libraries/libbridge services/ghbridge services/msbridge` (285 pass)