### PR TITLE
feat(libwiki): bisecting seal for the rotation primitive (#1450)

### DIFF
--- a/libraries/libwiki/src/audit/rules.js
+++ b/libraries/libwiki/src/audit/rules.js
@@ -310,7 +310,7 @@ export const RULES = [
     remediation: "flag",
     check: lineBudget(WEEKLY_LOG_LINE_BUDGET),
     message: (_s, r) => `${r.value} lines (limit ${WEEKLY_LOG_LINE_BUDGET})`,
-    hint: "sealed parts should already be at-or-under the cap; if not, the rotation that produced this part needs investigation",
+    hint: "the bisecting seal produces conforming parts, so an over-budget part means a hand-edited part or an irreducible single-day section — bisect it at a finer seam by hand",
   },
   {
     id: "weekly-log-part.word-budget",
@@ -319,7 +319,7 @@ export const RULES = [
     remediation: "flag",
     check: wordBudget(WEEKLY_LOG_WORD_BUDGET),
     message: (_s, r) => `${r.value} words (limit ${WEEKLY_LOG_WORD_BUDGET})`,
-    hint: "sealed parts should already be at-or-under the cap; if not, the rotation that produced this part needs investigation",
+    hint: "the bisecting seal produces conforming parts, so an over-budget part means a hand-edited part or an irreducible single-day section — bisect it at a finer seam by hand",
   },
   {
     id: "weekly-log-part.h1-agent-matches-filename",

--- a/libraries/libwiki/src/audit/scopes.js
+++ b/libraries/libwiki/src/audit/scopes.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { yearMonth } from "@forwardimpact/libutil";
 import { parseClaims } from "../active-claims.js";
+import { countLines, countWords } from "../budget.js";
 import { PRIORITY_INDEX_HEADING } from "../constants.js";
 
 const SUMMARY_H1_RE = /^# [A-Z].* — Summary$/;
@@ -26,25 +27,6 @@ function listMdFiles(wikiRoot, fs) {
     .readdirSync(wikiRoot)
     .filter((e) => e.endsWith(".md"))
     .map((e) => path.join(wikiRoot, e));
-}
-
-function countLines(text) {
-  return text.split("\n").length - (text.endsWith("\n") ? 1 : 0);
-}
-
-function countWords(text) {
-  let count = 0;
-  let inWord = false;
-  for (let i = 0; i < text.length; i++) {
-    const c = text.charCodeAt(i);
-    const isWs = c === 32 || c === 9 || c === 10 || c === 13;
-    if (isWs) inWord = false;
-    else if (!inWord) {
-      inWord = true;
-      count++;
-    }
-  }
-  return count;
 }
 
 function loadFile(filePath, fs) {

--- a/libraries/libwiki/src/budget.js
+++ b/libraries/libwiki/src/budget.js
@@ -1,0 +1,25 @@
+// Canonical line- and word-counters for the budgeted wiki surfaces. The audit
+// (`audit/scopes.js`) and the rotation primitive's bisecting seal
+// (`weekly-log.js`) both import this one pair so a part the seal calls
+// conforming cannot later be flagged by an audit counting differently.
+
+/** Count lines, not counting a trailing newline as an empty final line. */
+export function countLines(text) {
+  return text.split("\n").length - (text.endsWith("\n") ? 1 : 0);
+}
+
+/** Count whitespace-delimited words. */
+export function countWords(text) {
+  let count = 0;
+  let inWord = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text.charCodeAt(i);
+    const isWs = c === 32 || c === 9 || c === 10 || c === 13;
+    if (isWs) inWord = false;
+    else if (!inWord) {
+      inWord = true;
+      count++;
+    }
+  }
+  return count;
+}

--- a/libraries/libwiki/src/commands/fix.js
+++ b/libraries/libwiki/src/commands/fix.js
@@ -87,30 +87,44 @@ function composeFollowup(findings, projectRoot) {
  */
 function rotateOverBudgetMainLogs(
   findings,
-  { wikiRoot, today, projectRoot, fs, out },
+  { wikiRoot, today, projectRoot, fs, out, err },
 ) {
   const subjects = buildContext({ wikiRoot, today, fs }).subjects[
     "weekly-log-main"
   ];
   const agentByPath = new Map(subjects.map((s) => [s.path, s.agentPrefix]));
+  // A log over BOTH budgets yields two `rotate` findings with the same path
+  // (different rule ids); seal each path once, or the second force call would
+  // bisect the freshly-written fresh-main into a spurious near-empty part.
+  const sealed = new Set();
   for (const f of findings) {
     if (classOf(f) !== "rotate") continue;
     const agent = agentByPath.get(f.path);
     if (!agent) continue;
     if (weeklyLogPath(wikiRoot, agent, today) !== f.path) continue;
-    const res = rotateIfOverBudget(
-      wikiRoot,
-      agent,
-      today,
-      0,
-      { force: true },
-      fs,
-    );
-    if (res.rotated) {
-      out(
-        `rotated ${path.relative(projectRoot, res.fromPath)} -> ` +
-          `${path.relative(projectRoot, res.toPath)}\n`,
+    if (sealed.has(f.path)) continue;
+    sealed.add(f.path);
+    try {
+      const res = rotateIfOverBudget(
+        wikiRoot,
+        agent,
+        today,
+        0,
+        { force: true },
+        fs,
       );
+      if (res.status === "sealed" || res.status === "incomplete") {
+        for (const part of res.parts) {
+          out(
+            `rotated ${path.relative(projectRoot, res.fromPath)} -> ` +
+              `${path.relative(projectRoot, part)}\n`,
+          );
+        }
+      }
+    } catch (e) {
+      // A failed seal leaves the source intact (the writer rolled back); report
+      // it and let the re-audit re-flag the still-over-budget log for a human.
+      err(`fit-wiki fix: rotate failed for ${agent}: ${e.message}\n`);
     }
   }
 }
@@ -234,6 +248,7 @@ export async function runFixCommand(ctx) {
       projectRoot,
       fs,
       out,
+      err,
     });
     findings = audit();
     if (findings.length === 0) {

--- a/libraries/libwiki/src/commands/fix.js
+++ b/libraries/libwiki/src/commands/fix.js
@@ -85,10 +85,34 @@ function composeFollowup(findings, projectRoot) {
  * untouched (rotating it would force-seal a healthy current-week log instead);
  * it survives the re-audit and is flagged for a human.
  */
-function rotateOverBudgetMainLogs(
-  findings,
-  { wikiRoot, today, projectRoot, fs, out, err },
-) {
+/**
+ * Seal one over-budget current-week main log. A failed seal leaves the source
+ * intact (the writer rolled back), so the re-audit re-flags it for a human.
+ */
+function sealMainLog(agent, { wikiRoot, today, projectRoot, fs, out, err }) {
+  try {
+    const res = rotateIfOverBudget(
+      wikiRoot,
+      agent,
+      today,
+      0,
+      { force: true },
+      fs,
+    );
+    if (res.status !== "sealed" && res.status !== "incomplete") return;
+    for (const part of res.parts) {
+      out(
+        `rotated ${path.relative(projectRoot, res.fromPath)} -> ` +
+          `${path.relative(projectRoot, part)}\n`,
+      );
+    }
+  } catch (e) {
+    err(`fit-wiki fix: rotate failed for ${agent}: ${e.message}\n`);
+  }
+}
+
+function rotateOverBudgetMainLogs(findings, deps) {
+  const { wikiRoot, today, fs } = deps;
   const subjects = buildContext({ wikiRoot, today, fs }).subjects[
     "weekly-log-main"
   ];
@@ -100,32 +124,10 @@ function rotateOverBudgetMainLogs(
   for (const f of findings) {
     if (classOf(f) !== "rotate") continue;
     const agent = agentByPath.get(f.path);
-    if (!agent) continue;
-    if (weeklyLogPath(wikiRoot, agent, today) !== f.path) continue;
+    if (!agent || weeklyLogPath(wikiRoot, agent, today) !== f.path) continue;
     if (sealed.has(f.path)) continue;
     sealed.add(f.path);
-    try {
-      const res = rotateIfOverBudget(
-        wikiRoot,
-        agent,
-        today,
-        0,
-        { force: true },
-        fs,
-      );
-      if (res.status === "sealed" || res.status === "incomplete") {
-        for (const part of res.parts) {
-          out(
-            `rotated ${path.relative(projectRoot, res.fromPath)} -> ` +
-              `${path.relative(projectRoot, part)}\n`,
-          );
-        }
-      }
-    } catch (e) {
-      // A failed seal leaves the source intact (the writer rolled back); report
-      // it and let the re-audit re-flag the still-over-budget log for a human.
-      err(`fit-wiki fix: rotate failed for ${agent}: ${e.message}\n`);
-    }
+    sealMainLog(agent, deps);
   }
 }
 

--- a/libraries/libwiki/src/commands/log.js
+++ b/libraries/libwiki/src/commands/log.js
@@ -30,6 +30,36 @@ function lastDateHeading(text) {
   return last;
 }
 
+/**
+ * Rotate before an append, never blocking it. A bisecting seal may now produce
+ * multiple parts; the append still proceeds against the fresh current file. An
+ * `incomplete` residue (a lone over-cap day-section sealed as its own part —
+ * never the live file) is surfaced to stderr but does not block the append. A
+ * thrown fs error is reported and swallowed: the writer rolled back, so the
+ * (intact) current file still receives the new entry.
+ */
+function rotateBeforeAppend(wikiRoot, agent, today, appendLines, runtime) {
+  try {
+    const res = rotateIfOverBudget(
+      wikiRoot,
+      agent,
+      today,
+      appendLines,
+      {},
+      runtime.fsSync,
+    );
+    if (res.status === "incomplete") {
+      runtime.proc.stderr.write(
+        `note: day-section ${res.residue.section} alone exceeds the budget ` +
+          `(${res.residue.lines} lines, ${res.residue.words} words); ` +
+          `sealed as ${res.residue.path} for manual recovery\n`,
+      );
+    }
+  } catch (e) {
+    runtime.proc.stderr.write(`note: rotation failed: ${e.message}\n`);
+  }
+}
+
 function runDecision(runtime, options) {
   const ctx = commonContext(runtime, options);
   if (ctx.error) return ctx.error;
@@ -53,7 +83,7 @@ function runDecision(runtime, options) {
     "",
   ].join("\n");
   const lineCount = body.split("\n").length;
-  rotateIfOverBudget(wikiRoot, agent, today, lineCount, {}, runtime.fsSync);
+  rotateBeforeAppend(wikiRoot, agent, today, lineCount, runtime);
   const target = weeklyLogPath(wikiRoot, agent, today);
   appendEntry(target, body, agent, today, runtime.fsSync);
   runtime.proc.stdout.write(`logged decision to ${target}\n`);
@@ -71,13 +101,12 @@ function runNote(runtime, options) {
   const fieldBlock = `### ${options.field}\n\n${options.body}\n`;
   // Conservative line budget: assume we'll prepend a date heading.
   const withHeading = `## ${today}\n\n${fieldBlock}`;
-  rotateIfOverBudget(
+  rotateBeforeAppend(
     wikiRoot,
     agent,
     today,
     withHeading.split("\n").length,
-    {},
-    runtime.fsSync,
+    runtime,
   );
   const target = weeklyLogPath(wikiRoot, agent, today);
   // Append under the open entry if the file's last `## YYYY-MM-DD` is today;
@@ -97,7 +126,7 @@ function runDone(runtime, options) {
   const { agent, wikiRoot, today } = ctx;
   const body = `### Closed\n\nRun closed ${today}.\n`;
   const lineCount = body.split("\n").length;
-  rotateIfOverBudget(wikiRoot, agent, today, lineCount, {}, runtime.fsSync);
+  rotateBeforeAppend(wikiRoot, agent, today, lineCount, runtime);
   const target = weeklyLogPath(wikiRoot, agent, today);
   appendEntry(target, body, agent, today, runtime.fsSync);
   runtime.proc.stdout.write(`closed entry in ${target}\n`);

--- a/libraries/libwiki/src/commands/rotate.js
+++ b/libraries/libwiki/src/commands/rotate.js
@@ -17,20 +17,44 @@ export function runRotateCommand(ctx) {
   const wikiRoot = resolveWikiRoot(runtime, options);
   const today = options.today || currentDayIso(runtime);
 
-  const result = rotateIfOverBudget(
-    wikiRoot,
-    agent,
-    today,
-    0,
-    { force: true },
-    runtime.fsSync,
-  );
-  if (result.rotated) {
-    runtime.proc.stdout.write(
-      `rotated ${result.fromPath} → ${result.toPath}\n`,
+  let result;
+  try {
+    result = rotateIfOverBudget(
+      wikiRoot,
+      agent,
+      today,
+      0,
+      { force: true },
+      runtime.fsSync,
     );
-  } else {
-    runtime.proc.stdout.write(`no rotation needed for ${agent}\n`);
+  } catch (e) {
+    runtime.proc.stderr.write(`rotate failed: ${e.message}\n`);
+    return { ok: false, code: 1 };
   }
-  return { ok: true };
+  switch (result.status) {
+    case "noop":
+      runtime.proc.stdout.write(`no rotation needed for ${agent}\n`);
+      return { ok: true };
+    case "sealed":
+      for (const part of result.parts) {
+        runtime.proc.stdout.write(`sealed → ${part}\n`);
+      }
+      return { ok: true };
+    case "incomplete": {
+      for (const part of result.parts) {
+        runtime.proc.stdout.write(`sealed → ${part}\n`);
+      }
+      const { section, lines, words, path: residuePath } = result.residue;
+      runtime.proc.stderr.write(
+        `day-section ${section} alone exceeds the budget ` +
+          `(${lines} lines, ${words} words) and cannot be split at a day ` +
+          `seam: ${residuePath}\n` +
+          `recover it by hand — bisect the section at a finer seam ` +
+          `(see the memory protocol's manual-recovery convention)\n`,
+      );
+      return { ok: false, code: 1 };
+    }
+    default:
+      return { ok: true };
+  }
 }

--- a/libraries/libwiki/src/commands/rotate.js
+++ b/libraries/libwiki/src/commands/rotate.js
@@ -55,6 +55,8 @@ export function runRotateCommand(ctx) {
       return { ok: false, code: 1 };
     }
     default:
+      // Defensive: the tagged union is exhaustive above, so this is
+      // unreachable; kept so a future status can't fall through to no return.
       return { ok: true };
   }
 }

--- a/libraries/libwiki/src/index.js
+++ b/libraries/libwiki/src/index.js
@@ -32,6 +32,7 @@ export {
   isoWeek,
   weeklyLogPath,
   rotateIfOverBudget,
+  bisectWeeklyLog,
   appendEntry,
 } from "./weekly-log.js";
 export { buildDigest } from "./boot.js";

--- a/libraries/libwiki/src/index.js
+++ b/libraries/libwiki/src/index.js
@@ -35,5 +35,6 @@ export {
   appendEntry,
 } from "./weekly-log.js";
 export { buildDigest } from "./boot.js";
+export { countLines, countWords } from "./budget.js";
 export { RULES } from "./audit/rules.js";
 export { resolveScope as resolveAuditScope } from "./audit/scopes.js";

--- a/libraries/libwiki/src/weekly-log.js
+++ b/libraries/libwiki/src/weekly-log.js
@@ -1,10 +1,7 @@
 import path from "node:path";
 import { isoWeekString } from "@forwardimpact/libutil";
 import { countLines, countWords } from "./budget.js";
-import {
-  WEEKLY_LOG_LINE_BUDGET,
-  WEEKLY_LOG_WORD_BUDGET,
-} from "./constants.js";
+import { WEEKLY_LOG_LINE_BUDGET, WEEKLY_LOG_WORD_BUDGET } from "./constants.js";
 
 // ISO week computation lives in libutil's calendar util (the one place a
 // `new Date` is allowed); re-exported here for the existing public surface.
@@ -38,6 +35,53 @@ function agentTitle(agent) {
 
 function defaultH1(agent, isoWeekStr) {
   return `# ${agentTitle(agent)} — ${isoWeekStr}\n`;
+}
+
+/** Describe a lone over-cap day-section as a residue at its part index. */
+function residueOf(sec, partIndex, measure) {
+  const { lines, words } = measure(sec.text);
+  return { section: sec.date, lines, words, partIndex };
+}
+
+/**
+ * Greedily pack day-sections into part bodies under both budgets, the prologue
+ * riding with part 1. A lone section that alone exceeds a budget is sealed as
+ * its own part and recorded as the (first) residue.
+ * @param {Array<{date: string, text: string}>} sections
+ * @param {string} prologue - Content above the first seam; rides with part 1.
+ * @param {{overBudget: (s: string) => boolean, measure: (s: string) => {lines: number, words: number}}} budget
+ * @returns {{partBodies: string[], residue: null | {section: string, lines: number, words: number, partIndex: number}}}
+ */
+function packSections(sections, prologue, { overBudget, measure }) {
+  const partBodies = [];
+  let residue = null;
+  let open = prologue; // body of the part currently being filled
+  let opened = prologue.length > 0;
+  const flush = () => {
+    if (opened) {
+      partBodies.push(open);
+      open = "";
+      opened = false;
+    }
+  };
+  for (const sec of sections) {
+    if (overBudget(sec.text)) {
+      // Irreducible lone day-section: flush the open part, then seal it alone.
+      flush();
+      residue ??= residueOf(sec, partBodies.length, measure);
+      partBodies.push(sec.text);
+    } else if (!opened) {
+      open = sec.text;
+      opened = true;
+    } else if (overBudget(open + sec.text)) {
+      partBodies.push(open);
+      open = sec.text;
+    } else {
+      open += sec.text;
+    }
+  }
+  flush();
+  return { partBodies, residue };
 }
 
 /**
@@ -120,44 +164,10 @@ export function bisectWeeklyLog(text, agent, isoWeekStr) {
     ),
   }));
 
-  const partBodies = [];
-  let residue = null;
-  let current = prologue;
-  let currentEmpty = prologue.length === 0;
-
-  for (const sec of sections) {
-    if (overBudget(sec.text)) {
-      // Irreducible lone day-section: flush the open part, then seal it alone.
-      if (!currentEmpty) {
-        partBodies.push(current);
-        current = "";
-        currentEmpty = true;
-      }
-      const partIndex = partBodies.length;
-      partBodies.push(sec.text);
-      if (residue === null) {
-        const measured = measure(sec.text);
-        residue = {
-          section: sec.date,
-          lines: measured.lines,
-          words: measured.words,
-          partIndex,
-        };
-      }
-      continue;
-    }
-    if (currentEmpty) {
-      current = sec.text;
-      currentEmpty = false;
-    } else if (overBudget(current + sec.text)) {
-      partBodies.push(current);
-      current = sec.text;
-    } else {
-      current += sec.text;
-    }
-  }
-  if (!currentEmpty) partBodies.push(current);
-
+  const { partBodies, residue } = packSections(sections, prologue, {
+    overBudget,
+    measure,
+  });
   return finish(partBodies, residue);
 }
 

--- a/libraries/libwiki/src/weekly-log.js
+++ b/libraries/libwiki/src/weekly-log.js
@@ -15,11 +15,17 @@ export function weeklyLogPath(wikiRoot, agent, today) {
   return path.join(wikiRoot, `${agent}-${isoWeekString(today)}.md`);
 }
 
-function nextPartPath(filePath, fs) {
+function nextPartIndex(filePath, fs) {
   const dir = path.dirname(filePath);
   const base = path.basename(filePath, ".md");
   let n = 1;
   while (fs.existsSync(path.join(dir, `${base}-part${n}.md`))) n++;
+  return n;
+}
+
+function partPathAt(filePath, n) {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath, ".md");
   return path.join(dir, `${base}-part${n}.md`);
 }
 
@@ -156,8 +162,67 @@ export function bisectWeeklyLog(text, agent, isoWeekStr) {
 }
 
 /**
- * Rotate the current weekly log if next append would exceed the budget.
- * @returns {{rotated: boolean, fromPath: string, toPath?: string}}
+ * Stage every part at its slot and the fresh-main body at temps, then commit
+ * by renaming each part onto its `-partN.md` slot and the fresh main over
+ * `filePath` as the single final step. On any failure before that last rename,
+ * unlink every committed slot and remaining temp this seal wrote and re-throw,
+ * so the source's path/contents/inode are untouched. Returns the produced slot
+ * paths in part order.
+ *
+ * @param {string} filePath - The current weekly-log path.
+ * @param {Array<{h1: string, body: string}>} parts - Ordered parts to seal.
+ * @param {string} agent
+ * @param {string} isoWeekStr
+ * @param {object} fs - Sync filesystem surface.
+ * @returns {string[]} The `-partN.md` slot paths, in part order.
+ */
+function atomicSeal(filePath, parts, agent, isoWeekStr, fs) {
+  const start = nextPartIndex(filePath, fs);
+  const slots = parts.map((_, i) => partPathAt(filePath, start + i));
+  const mainTemp = `${filePath}.tmp`;
+  const temps = []; // temp paths this seal wrote, for rollback
+  const committed = []; // slots already renamed into place, for rollback
+  try {
+    // Stage every part and the fresh main at temp files.
+    slots.forEach((slot, i) => {
+      const tmp = `${slot}.tmp`;
+      fs.writeFileSync(tmp, `${parts[i].h1}\n${parts[i].body}`);
+      temps.push(tmp);
+    });
+    fs.writeFileSync(mainTemp, defaultH1(agent, isoWeekStr));
+    temps.push(mainTemp);
+    // Commit: parts onto their slots, then the fresh main as the final step.
+    slots.forEach((slot, i) => {
+      fs.renameSync(`${slot}.tmp`, slot);
+      committed.push(slot);
+      // The part temp is consumed by its rename; drop it from the rollback set.
+      temps.splice(temps.indexOf(`${slot}.tmp`), 1);
+    });
+    fs.renameSync(mainTemp, filePath);
+    return slots;
+  } catch (e) {
+    for (const slot of committed) {
+      try {
+        fs.unlinkSync(slot);
+      } catch {}
+    }
+    for (const tmp of temps) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {}
+    }
+    throw e;
+  }
+}
+
+/**
+ * Rotate the current weekly log, sealing an over-budget source into
+ * budget-conforming parts via a bisecting seal. Returns a tagged union:
+ * `{status:"noop"}` (no rotation needed), `{status:"sealed",parts}` (sealed
+ * into one-or-more conforming parts), or `{status:"incomplete",parts,residue}`
+ * (a lone day-section exceeds a budget and is named).
+ *
+ * @returns {{status: "noop"|"sealed"|"incomplete", fromPath: string, parts?: string[], residue?: {path: string, section: string, lines: number, words: number}}}
  * @param {string} wikiRoot
  * @param {string} agent
  * @param {string} today - ISO date string.
@@ -175,16 +240,29 @@ export function rotateIfOverBudget(
 ) {
   const filePath = weeklyLogPath(wikiRoot, agent, today);
   const { force = false } = options;
-  if (!fs.existsSync(filePath)) return { rotated: false, fromPath: filePath };
+  if (!fs.existsSync(filePath)) return { status: "noop", fromPath: filePath };
   const text = fs.readFileSync(filePath, "utf-8");
   const current = countLines(text);
   if (!force && current + appendLines <= WEEKLY_LOG_LINE_BUDGET) {
-    return { rotated: false, fromPath: filePath };
+    return { status: "noop", fromPath: filePath };
   }
-  const toPath = nextPartPath(filePath, fs);
-  fs.renameSync(filePath, toPath);
-  fs.writeFileSync(filePath, defaultH1(agent, isoWeekString(today)));
-  return { rotated: true, fromPath: filePath, toPath };
+  const isoWeekStr = isoWeekString(today);
+  const { parts, residue } = bisectWeeklyLog(text, agent, isoWeekStr);
+  const slots = atomicSeal(filePath, parts, agent, isoWeekStr, fs);
+  if (residue === null) {
+    return { status: "sealed", fromPath: filePath, parts: slots };
+  }
+  return {
+    status: "incomplete",
+    fromPath: filePath,
+    parts: slots,
+    residue: {
+      path: slots[residue.partIndex],
+      section: residue.section,
+      lines: residue.lines,
+      words: residue.words,
+    },
+  };
 }
 
 /**

--- a/libraries/libwiki/src/weekly-log.js
+++ b/libraries/libwiki/src/weekly-log.js
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { isoWeekString } from "@forwardimpact/libutil";
-import { WEEKLY_LOG_LINE_BUDGET } from "./constants.js";
+import { countLines, countWords } from "./budget.js";
+import {
+  WEEKLY_LOG_LINE_BUDGET,
+  WEEKLY_LOG_WORD_BUDGET,
+} from "./constants.js";
 
 // ISO week computation lives in libutil's calendar util (the one place a
 // `new Date` is allowed); re-exported here for the existing public surface.
@@ -9,14 +13,6 @@ export { isoWeek } from "@forwardimpact/libutil";
 /** Return the path of the current weekly log file for an agent. */
 export function weeklyLogPath(wikiRoot, agent, today) {
   return path.join(wikiRoot, `${agent}-${isoWeekString(today)}.md`);
-}
-
-function countLines(text) {
-  if (text.length === 0) return 0;
-  let n = 0;
-  for (const ch of text) if (ch === "\n") n++;
-  if (!text.endsWith("\n")) n++;
-  return n;
 }
 
 function nextPartPath(filePath, fs) {
@@ -36,6 +32,127 @@ function agentTitle(agent) {
 
 function defaultH1(agent, isoWeekStr) {
   return `# ${agentTitle(agent)} — ${isoWeekStr}\n`;
+}
+
+/**
+ * Split an over-budget weekly-log source at its `## YYYY-MM-DD` day-section
+ * seams into an ordered list of conforming parts. Pure — no I/O.
+ *
+ * The first line of `text` is the original H1; it is consumed and replaced by
+ * per-part H1s, never appearing in a part body. Everything after that first
+ * line is the body, sliced at the day-section seam byte offsets so that
+ * concatenating the parts' bodies reproduces the original body byte-for-byte.
+ * The prologue (any content above the first seam) rides with part 1. Sections
+ * are greedily packed left-to-right under both the line- and word-budget, with
+ * each candidate part measured H1-included so its own H1 is charged.
+ *
+ * When a single chunk alone exceeds a budget — a lone day-section, or the
+ * whole prologue when the source has no day-sections — it is sealed as its own
+ * (over-budget) part and named in `residue`; the rest still packs normally.
+ *
+ * @param {string} text - The full weekly-log source (H1 + body).
+ * @param {string} agent - Agent profile id (e.g. "staff-engineer").
+ * @param {string} isoWeekStr - ISO week label (e.g. "2026-W21").
+ * @returns {{parts: Array<{h1: string, body: string}>, residue: null | {section: string, lines: number, words: number, partIndex: number}}}
+ */
+export function bisectWeeklyLog(text, agent, isoWeekStr) {
+  const nl = text.indexOf("\n");
+  const body = nl === -1 ? "" : text.slice(nl + 1);
+  const title = agentTitle(agent);
+  // `(part N of M)` costs the same 1 line and 4 word-tokens regardless of the
+  // digits in N/M, so a fixed template measures every part exactly without
+  // needing to know M before packing finishes.
+  const h1Template = `# ${title} — ${isoWeekStr} (part 1 of 1)`;
+  const measure = (chunk) => {
+    const rendered = `${h1Template}\n${chunk}`;
+    return { lines: countLines(rendered), words: countWords(rendered) };
+  };
+  const overBudget = (chunk) => {
+    const { lines, words } = measure(chunk);
+    return lines > WEEKLY_LOG_LINE_BUDGET || words > WEEKLY_LOG_WORD_BUDGET;
+  };
+  const partH1 = (n, m) => `# ${title} — ${isoWeekStr} (part ${n} of ${m})`;
+  const finish = (partBodies, residue) => {
+    const m = partBodies.length;
+    return {
+      parts: partBodies.map((b, i) => ({ h1: partH1(i + 1, m), body: b })),
+      residue,
+    };
+  };
+
+  // Locate the day-section seams (date at line-start, trailing suffix
+  // tolerated, e.g. `## 2026-05-19 (third activation)`).
+  const seamRe = /^## (\d{4}-\d{2}-\d{2})/gm;
+  const seams = [];
+  let match;
+  while ((match = seamRe.exec(body)) !== null) {
+    seams.push({ offset: match.index, date: match[1] });
+  }
+
+  // Zero day-sections: the whole body is the prologue and its own single part.
+  if (seams.length === 0) {
+    const measured = measure(body);
+    const residue =
+      measured.lines > WEEKLY_LOG_LINE_BUDGET ||
+      measured.words > WEEKLY_LOG_WORD_BUDGET
+        ? {
+            section: "prologue",
+            lines: measured.lines,
+            words: measured.words,
+            partIndex: 0,
+          }
+        : null;
+    return finish([body], residue);
+  }
+
+  const prologue = body.slice(0, seams[0].offset);
+  const sections = seams.map((s, i) => ({
+    date: s.date,
+    text: body.slice(
+      s.offset,
+      i + 1 < seams.length ? seams[i + 1].offset : body.length,
+    ),
+  }));
+
+  const partBodies = [];
+  let residue = null;
+  let current = prologue;
+  let currentEmpty = prologue.length === 0;
+
+  for (const sec of sections) {
+    if (overBudget(sec.text)) {
+      // Irreducible lone day-section: flush the open part, then seal it alone.
+      if (!currentEmpty) {
+        partBodies.push(current);
+        current = "";
+        currentEmpty = true;
+      }
+      const partIndex = partBodies.length;
+      partBodies.push(sec.text);
+      if (residue === null) {
+        const measured = measure(sec.text);
+        residue = {
+          section: sec.date,
+          lines: measured.lines,
+          words: measured.words,
+          partIndex,
+        };
+      }
+      continue;
+    }
+    if (currentEmpty) {
+      current = sec.text;
+      currentEmpty = false;
+    } else if (overBudget(current + sec.text)) {
+      partBodies.push(current);
+      current = sec.text;
+    } else {
+      current += sec.text;
+    }
+  }
+  if (!currentEmpty) partBodies.push(current);
+
+  return finish(partBodies, residue);
 }
 
 /**

--- a/libraries/libwiki/src/weekly-log.js
+++ b/libraries/libwiki/src/weekly-log.js
@@ -12,18 +12,25 @@ export function weeklyLogPath(wikiRoot, agent, today) {
   return path.join(wikiRoot, `${agent}-${isoWeekString(today)}.md`);
 }
 
-function nextPartIndex(filePath, fs) {
-  const dir = path.dirname(filePath);
-  const base = path.basename(filePath, ".md");
-  let n = 1;
-  while (fs.existsSync(path.join(dir, `${base}-part${n}.md`))) n++;
-  return n;
-}
-
 function partPathAt(filePath, n) {
   const dir = path.dirname(filePath);
   const base = path.basename(filePath, ".md");
   return path.join(dir, `${base}-part${n}.md`);
+}
+
+// Find `count` part slots that are each verified free, skipping any occupied
+// `-partN.md` (e.g. a numbering gap left by a manually deleted middle part).
+// Every returned slot is unoccupied, so the seal never overwrites a pre-existing
+// part on commit nor unlinks one on rollback.
+function nextFreeSlots(filePath, count, fs) {
+  const slots = [];
+  let n = 1;
+  while (slots.length < count) {
+    const p = partPathAt(filePath, n);
+    if (!fs.existsSync(p)) slots.push(p);
+    n++;
+  }
+  return slots;
 }
 
 function agentTitle(agent) {
@@ -44,17 +51,33 @@ function residueOf(sec, partIndex, measure) {
 }
 
 /**
+ * An over-cap prologue cannot merge with any day-section (adding content only
+ * grows it), so it always seals as its own part 0. Flag it up front as the
+ * first residue so it is never shipped silently over budget.
+ */
+function prologueResidue(prologue, { overBudget, measure }) {
+  if (prologue.length === 0 || !overBudget(prologue)) return null;
+  const { lines, words } = measure(prologue);
+  return { section: "prologue", lines, words, partIndex: 0 };
+}
+
+/**
  * Greedily pack day-sections into part bodies under both budgets, the prologue
- * riding with part 1. A lone section that alone exceeds a budget is sealed as
- * its own part and recorded as the (first) residue.
+ * riding with part 1. A chunk that alone exceeds a budget — a lone day-section
+ * or an over-cap prologue — is sealed as its own part and recorded as the
+ * (first) residue; packed runs and single sections are kept under both budgets,
+ * so the only over-cap part bodies are the ones `residue` accounts for.
  * @param {Array<{date: string, text: string}>} sections
  * @param {string} prologue - Content above the first seam; rides with part 1.
  * @param {{overBudget: (s: string) => boolean, measure: (s: string) => {lines: number, words: number}}} budget
  * @returns {{partBodies: string[], residue: null | {section: string, lines: number, words: number, partIndex: number}}}
  */
-function packSections(sections, prologue, { overBudget, measure }) {
+function packSections(sections, prologue, budget) {
+  const { overBudget, measure } = budget;
   const partBodies = [];
-  let residue = null;
+  // The prologue, when over budget, is always pushed first (part 0) — record it
+  // before packing so a later lone-section residue cannot displace it.
+  let residue = prologueResidue(prologue, budget);
   let open = prologue; // body of the part currently being filled
   let opened = prologue.length > 0;
   const flush = () => {
@@ -139,20 +162,10 @@ export function bisectWeeklyLog(text, agent, isoWeekStr) {
     seams.push({ offset: match.index, date: match[1] });
   }
 
-  // Zero day-sections: the whole body is the prologue and its own single part.
+  // Zero day-sections: the whole body is the prologue and its own single part,
+  // flagged as a residue when it alone exceeds a budget.
   if (seams.length === 0) {
-    const measured = measure(body);
-    const residue =
-      measured.lines > WEEKLY_LOG_LINE_BUDGET ||
-      measured.words > WEEKLY_LOG_WORD_BUDGET
-        ? {
-            section: "prologue",
-            lines: measured.lines,
-            words: measured.words,
-            partIndex: 0,
-          }
-        : null;
-    return finish([body], residue);
+    return finish([body], prologueResidue(body, { overBudget, measure }));
   }
 
   const prologue = body.slice(0, seams[0].offset);
@@ -187,8 +200,7 @@ export function bisectWeeklyLog(text, agent, isoWeekStr) {
  * @returns {string[]} The `-partN.md` slot paths, in part order.
  */
 function atomicSeal(filePath, parts, agent, isoWeekStr, fs) {
-  const start = nextPartIndex(filePath, fs);
-  const slots = parts.map((_, i) => partPathAt(filePath, start + i));
+  const slots = nextFreeSlots(filePath, parts.length, fs);
   const mainTemp = `${filePath}.tmp`;
   const temps = []; // temp paths this seal wrote, for rollback
   const committed = []; // slots already renamed into place, for rollback

--- a/libraries/libwiki/test/cli-fix.integration.test.js
+++ b/libraries/libwiki/test/cli-fix.integration.test.js
@@ -250,17 +250,19 @@ describe("fit-wiki fix CLI (in-process)", () => {
     assert.equal(calls.length, 1, "no resume after a launch failure");
   });
 
-  test("rotates an over-budget weekly log deterministically, without the agent", async () => {
+  test("bisects a multi-day over-cap log into conforming parts; audit clean, no agent", async () => {
     seedCleanWiki(wikiRoot);
     seedAgentProfile(dir);
-    // Valid H1 + 600 filler lines → over the line budget, well under words.
+    // Valid H1 + 4 day-sections @ 150 lines: each section is under both
+    // budgets, jointly they overflow the line budget. The bisecting seal splits
+    // them into conforming parts and the re-audit is clean.
     const logPath = weeklyLogPath(wikiRoot, "staff-engineer", "2026-05-24");
-    writeFileSync(
-      logPath,
-      ["# Staff Engineer — 2026-W21", ""]
-        .concat(Array(600).fill("- filler"))
-        .join("\n") + "\n",
-    );
+    let text = "# Staff Engineer — 2026-W21\n";
+    for (let s = 0; s < 4; s++) {
+      text += `## 2026-05-${String(18 + s).padStart(2, "0")}\n`;
+      for (let i = 1; i < 150; i++) text += "- filler\n";
+    }
+    writeFileSync(logPath, text);
 
     // The agent must never be constructed for a deterministic rotation.
     const calls = [];
@@ -277,13 +279,43 @@ describe("fit-wiki fix CLI (in-process)", () => {
 
     assert.equal(calls.length, 0, "rotation does not invoke the agent");
     assert.match(harness.stdout, /rotated/);
+    assert.match(harness.stdout, /fixed: wiki audit is clean/);
     assert.ok(
-      existsSync(join(wikiRoot, "staff-engineer-2026-W21-part1.md")),
-      "the bloated log is sealed as a part",
+      existsSync(join(wikiRoot, "staff-engineer-2026-W21-part1.md")) &&
+        existsSync(join(wikiRoot, "staff-engineer-2026-W21-part2.md")),
+      "the over-cap log is sealed into ≥2 conforming parts",
     );
     assert.ok(existsSync(logPath), "a fresh main log is started");
-    // Sealing relabels the overflow onto the part — flagged for a human, not
-    // silently failed and not handed to the agent.
+    // The over-cap multi-day log now resolves clean — no human flag.
+    assert.deepEqual(result, { ok: true, code: 0 });
+    assert.doesNotMatch(harness.stderr, /weekly-log-part\.line-budget/);
+  });
+
+  test("flags only the irreducible single-day section that cannot be split", async () => {
+    seedCleanWiki(wikiRoot);
+    seedAgentProfile(dir);
+    // One day-section alone exceeds the line budget — it cannot be split at a
+    // day seam, so it seals as an over-cap part the audit still flags.
+    const logPath = weeklyLogPath(wikiRoot, "staff-engineer", "2026-05-24");
+    let text = "# Staff Engineer — 2026-W21\n## 2026-05-19\n";
+    for (let i = 0; i < 600; i++) text += "- filler\n";
+    writeFileSync(logPath, text);
+
+    const calls = [];
+    const query = scriptedQuery(join(wikiRoot, "unused.md"), [""], calls);
+    const harness = makeRuntime({ cwd: dir });
+
+    const result = await runFixCommand(
+      ctxFor({
+        runtime: harness.runtime,
+        query,
+        options: { today: "2026-05-24" },
+      }),
+    );
+
+    assert.equal(calls.length, 0, "rotation does not invoke the agent");
+    assert.ok(existsSync(logPath), "a fresh main log is started");
+    // Only the irreducible residue flags for a human.
     assert.equal(result.ok, false);
     assert.equal(result.code, 2);
     assert.match(harness.stderr, /need human judgment/);

--- a/libraries/libwiki/test/cli-log.integration.test.js
+++ b/libraries/libwiki/test/cli-log.integration.test.js
@@ -85,4 +85,40 @@ describe("fit-wiki log CLI seal-on-append (in-process)", () => {
       "the fresh current log is well under budget",
     );
   });
+
+  test("note shares the seal-then-append path and lands in a fresh current log", () => {
+    const today = "2026-05-24";
+    const logPath = weeklyLogPath(wikiRoot, "staff-engineer", today);
+    let text = "# Staff Engineer — 2026-W21\n";
+    for (let s = 0; s < 4; s++) {
+      text += `## 2026-05-${String(18 + s).padStart(2, "0")}\n`;
+      for (let i = 1; i < 150; i++) text += "- filler\n";
+    }
+    writeFileSync(logPath, text);
+
+    const harness = makeRuntime({ cwd: dir });
+    const result = runLogCommand(
+      ctxFor({
+        runtime: harness.runtime,
+        options: {
+          agent: "staff-engineer",
+          "wiki-root": wikiRoot,
+          today,
+          field: "Findings",
+          body: "all clean",
+        },
+        args: { subcommand: "note" },
+      }),
+    );
+
+    assert.deepEqual(result, { ok: true });
+    assert.ok(
+      existsSync(join(wikiRoot, "staff-engineer-2026-W21-part1.md")),
+      "the over-cap log is sealed before the note appends",
+    );
+    const fresh = readFileSync(logPath, "utf-8");
+    assert.match(fresh, /^# Staff Engineer — 2026-W21\n/);
+    assert.match(fresh, /### Findings/);
+    assert.ok(fresh.split("\n").length - 1 <= WEEKLY_LOG_LINE_BUDGET);
+  });
 });

--- a/libraries/libwiki/test/cli-log.integration.test.js
+++ b/libraries/libwiki/test/cli-log.integration.test.js
@@ -1,0 +1,88 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { runLogCommand } from "../src/commands/log.js";
+import { weeklyLogPath } from "../src/weekly-log.js";
+import { WEEKLY_LOG_LINE_BUDGET } from "../src/constants.js";
+import { makeRuntime, ctxFor } from "./helpers.js";
+
+// The append path seals via fs.renameSync (no createMockFs renameSync), so the
+// rotate-then-append behaviour is exercised against the real fs here; the
+// mock-backed cli-log.test.js covers the under-budget (no-seal) cases.
+describe("fit-wiki log CLI seal-on-append (in-process)", () => {
+  let dir;
+  let wikiRoot;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "log-cli-"));
+    wikiRoot = join(dir, "wiki");
+    mkdirSync(wikiRoot, { recursive: true });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("decision against an over-line-budget multi-day log bisects, then appends fresh", () => {
+    const today = "2026-05-24"; // ISO 2026-W21
+    const logPath = weeklyLogPath(wikiRoot, "staff-engineer", today);
+    // 4 day-sections @ 150 lines: each under budget, jointly over the line
+    // budget so the append path's non-force short-circuit triggers a seal.
+    let text = "# Staff Engineer — 2026-W21\n";
+    for (let s = 0; s < 4; s++) {
+      text += `## 2026-05-${String(18 + s).padStart(2, "0")}\n`;
+      for (let i = 1; i < 150; i++) text += "- filler\n";
+    }
+    writeFileSync(logPath, text);
+
+    const harness = makeRuntime({ cwd: dir });
+    const result = runLogCommand(
+      ctxFor({
+        runtime: harness.runtime,
+        options: {
+          agent: "staff-engineer",
+          "wiki-root": wikiRoot,
+          today,
+          surveyed: "owned",
+          chosen: "ship it",
+          rationale: "merged plan",
+        },
+        args: { subcommand: "decision" },
+      }),
+    );
+
+    assert.deepEqual(result, { ok: true });
+    // The prior content is sealed into ≥2 conforming parts.
+    assert.ok(
+      existsSync(join(wikiRoot, "staff-engineer-2026-W21-part1.md")) &&
+        existsSync(join(wikiRoot, "staff-engineer-2026-W21-part2.md")),
+      "sealed into ≥2 parts",
+    );
+    for (const n of [1, 2]) {
+      const part = readFileSync(
+        join(wikiRoot, `staff-engineer-2026-W21-part${n}.md`),
+        "utf-8",
+      );
+      assert.ok(
+        part.split("\n").length - 1 <= WEEKLY_LOG_LINE_BUDGET,
+        `part${n} conforms to the line budget`,
+      );
+    }
+    // The new dated entry opens in a fresh, small current file.
+    const fresh = readFileSync(logPath, "utf-8");
+    assert.match(fresh, /^# Staff Engineer — 2026-W21\n/);
+    assert.match(fresh, /## 2026-05-24/);
+    assert.match(fresh, /### Decision/);
+    assert.ok(
+      fresh.split("\n").length - 1 <= WEEKLY_LOG_LINE_BUDGET,
+      "the fresh current log is well under budget",
+    );
+  });
+});

--- a/libraries/libwiki/test/cli-rotate.integration.test.js
+++ b/libraries/libwiki/test/cli-rotate.integration.test.js
@@ -1,6 +1,12 @@
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -67,11 +73,17 @@ describe("fit-wiki rotate CLI (in-process)", () => {
   test("an irreducible single-day section exits 1 and names the section", () => {
     let text = "# Staff Engineer — 2026-W21\n## 2026-05-18\nx\n## 2026-05-19\n";
     for (let i = 0; i < 600; i++) text += "filler\n";
-    writeFileSync(weeklyLogPath(wikiRoot, "staff-engineer", "2026-05-24"), text);
+    writeFileSync(
+      weeklyLogPath(wikiRoot, "staff-engineer", "2026-05-24"),
+      text,
+    );
     const { result, harness } = run();
     assert.equal(result.ok, false);
     assert.equal(result.code, 1);
-    assert.match(harness.stderr, /day-section 2026-05-19 alone exceeds the budget/);
+    assert.match(
+      harness.stderr,
+      /day-section 2026-05-19 alone exceeds the budget/,
+    );
     assert.match(harness.stderr, /recover it by hand/);
   });
 });

--- a/libraries/libwiki/test/cli-rotate.integration.test.js
+++ b/libraries/libwiki/test/cli-rotate.integration.test.js
@@ -1,0 +1,77 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { runRotateCommand } from "../src/commands/rotate.js";
+import { weeklyLogPath } from "../src/weekly-log.js";
+import { makeRuntime, ctxFor } from "./helpers.js";
+
+// rotateIfOverBudget seals via fs.renameSync, which createMockFs does not
+// model — so this drives the real fs under a temp dir, like cli-fix.
+describe("fit-wiki rotate CLI (in-process)", () => {
+  let dir;
+  let wikiRoot;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rotate-cli-"));
+    wikiRoot = join(dir, "wiki");
+    mkdirSync(wikiRoot, { recursive: true });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const run = (today = "2026-05-24") => {
+    const harness = makeRuntime({ cwd: dir });
+    const result = runRotateCommand(
+      ctxFor({
+        runtime: harness.runtime,
+        options: { agent: "staff-engineer", "wiki-root": wikiRoot, today },
+      }),
+    );
+    return { result, harness };
+  };
+
+  function multiDayLog(sections = 4, linesPerSection = 150) {
+    let text = "# Staff Engineer — 2026-W21\n";
+    for (let s = 0; s < sections; s++) {
+      const day = String(18 + s).padStart(2, "0");
+      text += `## 2026-05-${day}\n`;
+      for (let i = 1; i < linesPerSection; i++) text += "filler\n";
+    }
+    return text;
+  }
+
+  test("seals a multi-day over-cap log into parts, prints each, exits 0", () => {
+    const logPath = weeklyLogPath(wikiRoot, "staff-engineer", "2026-05-24");
+    writeFileSync(logPath, multiDayLog());
+    const { result, harness } = run();
+    assert.deepEqual(result, { ok: true });
+    const printed = harness.stdout.match(/^sealed → .*-part\d+\.md$/gm) || [];
+    assert.ok(printed.length >= 2, "prints each sealed part");
+    assert.ok(
+      existsSync(join(wikiRoot, "staff-engineer-2026-W21-part1.md")),
+      "part1 sealed",
+    );
+    assert.ok(existsSync(logPath), "fresh main created");
+  });
+
+  test("no rotation needed (missing file) prints a message and exits 0", () => {
+    // The CLI forces, so an existing file always seals; the genuine noop is the
+    // missing-file path.
+    const { result, harness } = run();
+    assert.deepEqual(result, { ok: true });
+    assert.match(harness.stdout, /no rotation needed for staff-engineer/);
+  });
+
+  test("an irreducible single-day section exits 1 and names the section", () => {
+    let text = "# Staff Engineer — 2026-W21\n## 2026-05-18\nx\n## 2026-05-19\n";
+    for (let i = 0; i < 600; i++) text += "filler\n";
+    writeFileSync(weeklyLogPath(wikiRoot, "staff-engineer", "2026-05-24"), text);
+    const { result, harness } = run();
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 1);
+    assert.match(harness.stderr, /day-section 2026-05-19 alone exceeds the budget/);
+    assert.match(harness.stderr, /recover it by hand/);
+  });
+});

--- a/libraries/libwiki/test/weekly-log.integration.test.js
+++ b/libraries/libwiki/test/weekly-log.integration.test.js
@@ -6,6 +6,8 @@ import {
   writeFileSync,
   readFileSync,
   existsSync,
+  statSync,
+  readdirSync,
   rmSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -13,9 +15,9 @@ import { tmpdir } from "node:os";
 import { weeklyLogPath, rotateIfOverBudget } from "../src/weekly-log.js";
 import { WEEKLY_LOG_LINE_BUDGET } from "../src/constants.js";
 
-// rotateIfOverBudget seals the over-budget file via fs.renameSync, which the
-// in-memory libmock fs does not model (it ships async `rename` only). Until that
-// sync surface exists this stays an integration test against the real fs.
+// rotateIfOverBudget seals via fs.renameSync, which the in-memory libmock fs
+// does not model (it ships async `rename` only). Until that sync surface
+// exists this stays an integration test against the real fs.
 describe("rotateIfOverBudget", () => {
   let wikiRoot;
   beforeEach(() => {
@@ -23,70 +25,111 @@ describe("rotateIfOverBudget", () => {
   });
   afterEach(() => rmSync(wikiRoot, { recursive: true, force: true }));
 
-  test("no-op when file does not exist", () => {
-    const r = rotateIfOverBudget(
-      wikiRoot,
-      "staff-engineer",
-      "2026-05-19",
-      0,
-      {},
-      nodeFs,
-    );
-    assert.equal(r.rotated, false);
+  const AGENT = "staff-engineer";
+  const WEEK = "2026-05-19"; // ISO 2026-W21
+
+  // A multi-day source over the line budget: each section is under the cap but
+  // jointly they overflow, so a bisecting seal yields ≥2 conforming parts.
+  function multiDaySource(sections = 4, linesPerSection = 150) {
+    let text = `# Staff Engineer — 2026-W21\n`;
+    for (let s = 0; s < sections; s++) {
+      const day = String(18 + s).padStart(2, "0");
+      text += `## 2026-05-${day}\n`;
+      for (let i = 1; i < linesPerSection; i++) text += `filler\n`;
+    }
+    return text;
+  }
+
+  test("noop when file does not exist", () => {
+    const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 0, {}, nodeFs);
+    assert.equal(r.status, "noop");
   });
 
-  test("rotates when over budget", () => {
-    const filePath = weeklyLogPath(wikiRoot, "staff-engineer", "2026-05-19");
-    const big = "x\n".repeat(WEEKLY_LOG_LINE_BUDGET + 5);
-    writeFileSync(filePath, big);
-    const r = rotateIfOverBudget(
-      wikiRoot,
-      "staff-engineer",
-      "2026-05-19",
-      1,
-      {},
-      nodeFs,
-    );
-    assert.equal(r.rotated, true);
-    assert.match(r.toPath, /-part1\.md$/);
-    assert.equal(existsSync(filePath), true, "fresh file created");
-    assert.equal(existsSync(r.toPath), true, "sealed part exists");
-    assert.equal(
-      readFileSync(r.toPath, "utf-8"),
-      big,
-      "sealed part preserves prior content byte-for-byte",
-    );
+  test("noop when under budget on the non-force append path", () => {
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    writeFileSync(filePath, "# Staff Engineer — 2026-W21\n\nsmall\n");
+    const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 1, {}, nodeFs);
+    assert.equal(r.status, "noop");
   });
 
-  test("part numbering increments", () => {
-    const filePath = weeklyLogPath(wikiRoot, "staff-engineer", "2026-05-19");
-    writeFileSync(filePath, "x\n".repeat(WEEKLY_LOG_LINE_BUDGET + 5));
-    rotateIfOverBudget(wikiRoot, "staff-engineer", "2026-05-19", 1, {}, nodeFs);
-    writeFileSync(filePath, "x\n".repeat(WEEKLY_LOG_LINE_BUDGET + 5));
-    const r2 = rotateIfOverBudget(
-      wikiRoot,
-      "staff-engineer",
-      "2026-05-19",
-      1,
-      {},
-      nodeFs,
-    );
-    assert.match(r2.toPath, /-part2\.md$/);
+  test("seals an over-budget multi-day source into ≥2 conforming parts", () => {
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    writeFileSync(filePath, multiDaySource());
+    const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 1, {}, nodeFs);
+    assert.equal(r.status, "sealed");
+    assert.ok(r.parts.length >= 2, "splits into multiple parts");
+    for (const p of r.parts) {
+      assert.match(p, /-part\d+\.md$/);
+      assert.ok(
+        readFileSync(p, "utf-8").split("\n").length - 1 <=
+          WEEKLY_LOG_LINE_BUDGET,
+        "each part is at-or-under the line budget",
+      );
+    }
+    assert.equal(existsSync(filePath), true, "fresh main created");
+    assert.match(readFileSync(filePath, "utf-8"), /^# Staff Engineer — 2026-W21\n$/);
   });
 
-  test("force rotates even when under budget", () => {
-    const filePath = weeklyLogPath(wikiRoot, "staff-engineer", "2026-05-19");
-    writeFileSync(filePath, "small\n");
-    const r = rotateIfOverBudget(
-      wikiRoot,
-      "staff-engineer",
-      "2026-05-19",
-      0,
-      {
-        force: true,
+  test("force seals into conforming parts without a born-over-cap part", () => {
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    writeFileSync(filePath, multiDaySource());
+    const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 0, { force: true }, nodeFs);
+    assert.equal(r.status, "sealed");
+    assert.ok(r.parts.length >= 2);
+  });
+
+  test("part slots continue past existing parts", () => {
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    writeFileSync(join(wikiRoot, "staff-engineer-2026-W21-part1.md"), "# old\n");
+    writeFileSync(filePath, multiDaySource());
+    const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 1, {}, nodeFs);
+    assert.equal(r.status, "sealed");
+    assert.match(r.parts[0], /-part2\.md$/, "new parts start at the next free slot");
+  });
+
+  test("incomplete when a lone day-section exceeds the budget", () => {
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    let text = "# Staff Engineer — 2026-W21\n## 2026-05-18\nx\n## 2026-05-19\n";
+    for (let i = 0; i < 600; i++) text += "filler\n";
+    text += "## 2026-05-20\nx\n";
+    writeFileSync(filePath, text);
+    const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 0, { force: true }, nodeFs);
+    assert.equal(r.status, "incomplete");
+    assert.equal(r.residue.section, "2026-05-19");
+    assert.ok(r.parts.includes(r.residue.path), "residue path is among the parts");
+    assert.ok(r.residue.lines > WEEKLY_LOG_LINE_BUDGET);
+  });
+
+  test("atomic: a mid-commit rename failure leaves the source intact", () => {
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    const original = multiDaySource();
+    writeFileSync(filePath, original);
+    const inodeBefore = statSync(filePath).ino;
+
+    // Wrap real fs but make the SECOND renameSync throw, so ≥1 slot is already
+    // committed when the failure hits — exercising the slot-unlink rollback.
+    let renames = 0;
+    const flakyFs = {
+      existsSync: nodeFs.existsSync,
+      readFileSync: nodeFs.readFileSync,
+      writeFileSync: nodeFs.writeFileSync,
+      unlinkSync: nodeFs.unlinkSync,
+      renameSync: (from, to) => {
+        renames++;
+        if (renames === 2) throw new Error("disk full");
+        return nodeFs.renameSync(from, to);
       },
-      nodeFs,
+    };
+
+    assert.throws(
+      () => rotateIfOverBudget(wikiRoot, AGENT, WEEK, 1, {}, flakyFs),
+      /disk full/,
     );
-    assert.equal(r.rotated, true);
+    assert.equal(readFileSync(filePath, "utf-8"), original, "source contents intact");
+    assert.equal(statSync(filePath).ino, inodeBefore, "source inode unchanged");
+    const leftover = readdirSync(wikiRoot).filter(
+      (f) => f.includes("-part") || f.endsWith(".tmp"),
+    );
+    assert.deepEqual(leftover, [], "no part or temp files survive the rollback");
   });
 });

--- a/libraries/libwiki/test/weekly-log.integration.test.js
+++ b/libraries/libwiki/test/weekly-log.integration.test.js
@@ -67,24 +67,41 @@ describe("rotateIfOverBudget", () => {
       );
     }
     assert.equal(existsSync(filePath), true, "fresh main created");
-    assert.match(readFileSync(filePath, "utf-8"), /^# Staff Engineer — 2026-W21\n$/);
+    assert.match(
+      readFileSync(filePath, "utf-8"),
+      /^# Staff Engineer — 2026-W21\n$/,
+    );
   });
 
   test("force seals into conforming parts without a born-over-cap part", () => {
     const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
     writeFileSync(filePath, multiDaySource());
-    const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 0, { force: true }, nodeFs);
+    const r = rotateIfOverBudget(
+      wikiRoot,
+      AGENT,
+      WEEK,
+      0,
+      { force: true },
+      nodeFs,
+    );
     assert.equal(r.status, "sealed");
     assert.ok(r.parts.length >= 2);
   });
 
   test("part slots continue past existing parts", () => {
     const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
-    writeFileSync(join(wikiRoot, "staff-engineer-2026-W21-part1.md"), "# old\n");
+    writeFileSync(
+      join(wikiRoot, "staff-engineer-2026-W21-part1.md"),
+      "# old\n",
+    );
     writeFileSync(filePath, multiDaySource());
     const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 1, {}, nodeFs);
     assert.equal(r.status, "sealed");
-    assert.match(r.parts[0], /-part2\.md$/, "new parts start at the next free slot");
+    assert.match(
+      r.parts[0],
+      /-part2\.md$/,
+      "new parts start at the next free slot",
+    );
   });
 
   test("incomplete when a lone day-section exceeds the budget", () => {
@@ -93,10 +110,20 @@ describe("rotateIfOverBudget", () => {
     for (let i = 0; i < 600; i++) text += "filler\n";
     text += "## 2026-05-20\nx\n";
     writeFileSync(filePath, text);
-    const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 0, { force: true }, nodeFs);
+    const r = rotateIfOverBudget(
+      wikiRoot,
+      AGENT,
+      WEEK,
+      0,
+      { force: true },
+      nodeFs,
+    );
     assert.equal(r.status, "incomplete");
     assert.equal(r.residue.section, "2026-05-19");
-    assert.ok(r.parts.includes(r.residue.path), "residue path is among the parts");
+    assert.ok(
+      r.parts.includes(r.residue.path),
+      "residue path is among the parts",
+    );
     assert.ok(r.residue.lines > WEEKLY_LOG_LINE_BUDGET);
   });
 
@@ -125,11 +152,19 @@ describe("rotateIfOverBudget", () => {
       () => rotateIfOverBudget(wikiRoot, AGENT, WEEK, 1, {}, flakyFs),
       /disk full/,
     );
-    assert.equal(readFileSync(filePath, "utf-8"), original, "source contents intact");
+    assert.equal(
+      readFileSync(filePath, "utf-8"),
+      original,
+      "source contents intact",
+    );
     assert.equal(statSync(filePath).ino, inodeBefore, "source inode unchanged");
     const leftover = readdirSync(wikiRoot).filter(
       (f) => f.includes("-part") || f.endsWith(".tmp"),
     );
-    assert.deepEqual(leftover, [], "no part or temp files survive the rollback");
+    assert.deepEqual(
+      leftover,
+      [],
+      "no part or temp files survive the rollback",
+    );
   });
 });

--- a/libraries/libwiki/test/weekly-log.integration.test.js
+++ b/libraries/libwiki/test/weekly-log.integration.test.js
@@ -167,4 +167,103 @@ describe("rotateIfOverBudget", () => {
       "no part or temp files survive the rollback",
     );
   });
+
+  test("atomic: a staging-phase write failure (before any rename) rolls back", () => {
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    const original = multiDaySource();
+    writeFileSync(filePath, original);
+    const inodeBefore = statSync(filePath).ino;
+
+    // Fail on the SECOND part temp write — before any rename has run — so only
+    // the temp-cleanup rollback branch (no committed slots) is exercised.
+    let writes = 0;
+    const flakyFs = {
+      existsSync: nodeFs.existsSync,
+      readFileSync: nodeFs.readFileSync,
+      renameSync: nodeFs.renameSync,
+      unlinkSync: nodeFs.unlinkSync,
+      writeFileSync: (p, data) => {
+        writes++;
+        if (writes === 2) throw new Error("disk full");
+        return nodeFs.writeFileSync(p, data);
+      },
+    };
+
+    assert.throws(
+      () => rotateIfOverBudget(wikiRoot, AGENT, WEEK, 1, {}, flakyFs),
+      /disk full/,
+    );
+    assert.equal(readFileSync(filePath, "utf-8"), original, "source intact");
+    assert.equal(statSync(filePath).ino, inodeBefore, "source inode unchanged");
+    const leftover = readdirSync(wikiRoot).filter(
+      (f) => f.includes("-part") || f.endsWith(".tmp"),
+    );
+    assert.deepEqual(leftover, [], "no staged temps survive the rollback");
+  });
+
+  test("never overwrites a pre-existing part when slot numbering has a gap", () => {
+    // A manually deleted middle part leaves part1 + part3; a multi-part seal
+    // must claim only free slots (part2, part4, …), never clobbering part3.
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    writeFileSync(join(wikiRoot, "staff-engineer-2026-W21-part1.md"), "# p1\n");
+    const part3 = join(wikiRoot, "staff-engineer-2026-W21-part3.md");
+    writeFileSync(part3, "# preexisting part 3\n");
+    writeFileSync(filePath, multiDaySource());
+
+    const r = rotateIfOverBudget(wikiRoot, AGENT, WEEK, 1, {}, nodeFs);
+    assert.equal(r.status, "sealed");
+    assert.ok(r.parts.length >= 2);
+    assert.ok(
+      !r.parts.includes(part3),
+      "the seal does not claim the occupied part3 slot",
+    );
+    assert.equal(
+      readFileSync(part3, "utf-8"),
+      "# preexisting part 3\n",
+      "the pre-existing part3 is untouched",
+    );
+  });
+
+  test("force seals a word-only-over multi-day source into conforming parts", () => {
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    // 2 day-sections @ 200 lines × 20 words ≈ 8000 words > 6400, ~400 lines
+    // < 496 — only the word budget is breached. Drives the seal end-to-end
+    // through the primitive's atomic writer.
+    let text = "# Staff Engineer — 2026-W21\n";
+    for (let s = 0; s < 2; s++) {
+      text += `## 2026-05-${String(19 + s).padStart(2, "0")}\n`;
+      for (let i = 1; i < 200; i++)
+        text += `${Array(20).fill("word").join(" ")}\n`;
+    }
+    writeFileSync(filePath, text);
+    const r = rotateIfOverBudget(
+      wikiRoot,
+      AGENT,
+      WEEK,
+      0,
+      { force: true },
+      nodeFs,
+    );
+    assert.equal(r.status, "sealed");
+    assert.ok(r.parts.length >= 2, "word overflow splits into ≥2 parts");
+  });
+
+  test("incomplete when the prologue alone exceeds the budget above day-sections", () => {
+    const filePath = weeklyLogPath(wikiRoot, AGENT, WEEK);
+    let text = "# Staff Engineer — 2026-W21\n";
+    for (let i = 0; i < 600; i++) text += "preamble\n";
+    text += "## 2026-05-19\nx\n## 2026-05-20\ny\n";
+    writeFileSync(filePath, text);
+    const r = rotateIfOverBudget(
+      wikiRoot,
+      AGENT,
+      WEEK,
+      0,
+      { force: true },
+      nodeFs,
+    );
+    assert.equal(r.status, "incomplete");
+    assert.equal(r.residue.section, "prologue");
+    assert.ok(r.parts.includes(r.residue.path));
+  });
 });

--- a/libraries/libwiki/test/weekly-log.test.js
+++ b/libraries/libwiki/test/weekly-log.test.js
@@ -1,9 +1,37 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { createMockFs } from "@forwardimpact/libmock";
-import { isoWeek, weeklyLogPath, appendEntry } from "../src/weekly-log.js";
+import {
+  isoWeek,
+  weeklyLogPath,
+  appendEntry,
+  bisectWeeklyLog,
+} from "../src/weekly-log.js";
+import { countLines, countWords } from "../src/budget.js";
+import {
+  WEEKLY_LOG_LINE_BUDGET,
+  WEEKLY_LOG_WORD_BUDGET,
+} from "../src/constants.js";
 
 const WIKI_ROOT = "/wiki";
+
+// Build a `## YYYY-MM-DD` day-section of `lines` lines, each carrying
+// `wordsPerLine` words, so a fixture can target the line- or word-budget
+// independently.
+function daySection(date, lines, wordsPerLine = 1) {
+  const word = "word";
+  const rows = [`## ${date}`];
+  for (let i = 1; i < lines; i++) {
+    rows.push(Array(wordsPerLine).fill(word).join(" "));
+  }
+  return rows.join("\n") + "\n";
+}
+
+function source(h1, ...sections) {
+  return `${h1}\n${sections.join("")}`;
+}
+
+const H1 = "# Staff Engineer — 2026-W21";
 
 describe("isoWeek", () => {
   test("2026-01-04 is W01", () => {
@@ -35,6 +63,123 @@ describe("isoWeek", () => {
     const { year, week } = isoWeek(new Date("2026-12-31T00:00:00Z"));
     assert.equal(year, 2026);
     assert.equal(week, 53);
+  });
+});
+
+describe("bisectWeeklyLog", () => {
+  // Every part's rendered text (H1 + body) is at-or-under both budgets.
+  const partConforms = (p) => {
+    const rendered = `${p.h1}\n${p.body}`;
+    return (
+      countLines(rendered) <= WEEKLY_LOG_LINE_BUDGET &&
+      countWords(rendered) <= WEEKLY_LOG_WORD_BUDGET
+    );
+  };
+  const bodyBelowH1 = (text) => text.slice(text.indexOf("\n") + 1);
+
+  test("over the line budget across days → ≥2 conforming parts", () => {
+    // 4 × 150-line sections = 600 body lines > 496; each section < 496.
+    const text = source(
+      H1,
+      daySection("2026-05-18", 150),
+      daySection("2026-05-19", 150),
+      daySection("2026-05-20", 150),
+      daySection("2026-05-21", 150),
+    );
+    const { parts, residue } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    assert.equal(residue, null);
+    assert.ok(parts.length >= 2, "splits into multiple parts");
+    for (const p of parts) assert.ok(partConforms(p), "every part conforms");
+  });
+
+  test("over only the word budget across days → ≥2 conforming parts", () => {
+    // 2 × 200-line sections @ 20 words/line ≈ 4000 words each > 6400 jointly,
+    // ~400 lines total < 496 — only the word budget is breached.
+    const text = source(
+      H1,
+      daySection("2026-05-19", 200, 20),
+      daySection("2026-05-20", 200, 20),
+    );
+    assert.ok(countLines(text) <= WEEKLY_LOG_LINE_BUDGET, "under the line cap");
+    assert.ok(countWords(text) > WEEKLY_LOG_WORD_BUDGET, "over the word cap");
+    const { parts, residue } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    assert.equal(residue, null);
+    assert.ok(parts.length >= 2);
+    for (const p of parts) assert.ok(partConforms(p));
+  });
+
+  test("loses and duplicates no content; cuts only at day seams", () => {
+    const text = source(
+      H1,
+      "preamble line\n",
+      daySection("2026-05-18", 150),
+      daySection("2026-05-19", 150),
+      daySection("2026-05-20", 150),
+      daySection("2026-05-21", 150),
+    );
+    const { parts } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    // Concatenated part bodies equal the original body below its H1.
+    assert.equal(parts.map((p) => p.body).join(""), bodyBelowH1(text));
+    // The prologue rides with part 1; every other part starts at a day seam,
+    // and no day-section's count is lost or duplicated across parts.
+    assert.match(parts[0].body, /^preamble line\n## 2026-05-18/);
+    for (const p of parts.slice(1)) {
+      assert.match(p.body, /^## \d{4}-\d{2}-\d{2}/);
+    }
+    const seamCount = (s) => (s.match(/^## \d{4}-\d{2}-\d{2}/gm) || []).length;
+    assert.equal(
+      parts.reduce((n, p) => n + seamCount(p.body), 0),
+      seamCount(bodyBelowH1(text)),
+    );
+  });
+
+  test("H1s number (part 1 of M) … (part M of M)", () => {
+    const text = source(
+      H1,
+      daySection("2026-05-18", 150),
+      daySection("2026-05-19", 150),
+      daySection("2026-05-20", 150),
+      daySection("2026-05-21", 150),
+    );
+    const { parts } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    const m = parts.length;
+    parts.forEach((p, i) => {
+      assert.equal(p.h1, `# Staff Engineer — 2026-W21 (part ${i + 1} of ${m})`);
+    });
+  });
+
+  test("irreducible lone day-section → residue named with its date", () => {
+    // One 600-line section alone exceeds the line budget; the rest packs.
+    const text = source(
+      H1,
+      daySection("2026-05-18", 50),
+      daySection("2026-05-19", 600),
+      daySection("2026-05-20", 50),
+    );
+    const { parts, residue } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    assert.ok(residue, "an irreducible residue is reported");
+    assert.equal(residue.section, "2026-05-19");
+    assert.ok(residue.lines > WEEKLY_LOG_LINE_BUDGET);
+    // The residue's part carries that section; the rest conforms.
+    assert.match(parts[residue.partIndex].body, /^## 2026-05-19/);
+    parts.forEach((p, i) => {
+      if (i !== residue.partIndex) {
+        const rendered = `${p.h1}\n${p.body}`;
+        assert.ok(countLines(rendered) <= WEEKLY_LOG_LINE_BUDGET);
+      }
+    });
+    // Content is still fully preserved.
+    assert.equal(parts.map((p) => p.body).join(""), bodyBelowH1(text));
+  });
+
+  test("zero-day-section over-cap source → residue 'prologue'", () => {
+    const text = `${H1}\n${Array(600).fill("filler").join("\n")}\n`;
+    const { parts, residue } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    assert.equal(parts.length, 1);
+    assert.ok(residue);
+    assert.equal(residue.section, "prologue");
+    assert.equal(residue.partIndex, 0);
+    assert.equal(parts.map((p) => p.body).join(""), bodyBelowH1(text));
   });
 });
 

--- a/libraries/libwiki/test/weekly-log.test.js
+++ b/libraries/libwiki/test/weekly-log.test.js
@@ -184,6 +184,56 @@ describe("bisectWeeklyLog", () => {
     assert.equal(parts.map((p) => p.body).join(""), bodyBelowH1(text));
   });
 
+  test("over-cap prologue above day-sections → residue 'prologue', never silent", () => {
+    // A preamble that alone busts the line budget, then normal day-sections.
+    const prologue = `${Array(600).fill("preamble").join("\n")}\n`;
+    const text = source(
+      H1,
+      prologue,
+      daySection("2026-05-19", 50),
+      daySection("2026-05-20", 50),
+    );
+    const { parts, residue } = bisectWeeklyLog(
+      text,
+      "staff-engineer",
+      "2026-W21",
+    );
+    assert.ok(
+      residue,
+      "the over-cap prologue is flagged, not shipped silently",
+    );
+    assert.equal(residue.section, "prologue");
+    assert.equal(residue.partIndex, 0);
+    assert.ok(residue.lines > WEEKLY_LOG_LINE_BUDGET);
+    // The prologue is part 0; content is still fully preserved.
+    assert.match(parts[0].body, /^preamble/);
+    assert.equal(parts.map((p) => p.body).join(""), bodyBelowH1(text));
+  });
+
+  test("multiple irreducible sections → first named, every over-cap part present", () => {
+    const text = source(
+      H1,
+      daySection("2026-05-18", 600),
+      daySection("2026-05-19", 50),
+      daySection("2026-05-20", 600),
+    );
+    const { parts, residue } = bisectWeeklyLog(
+      text,
+      "staff-engineer",
+      "2026-W21",
+    );
+    // residue names the FIRST irreducible chunk (plan: "names the first such
+    // chunk"); the second over-cap section is still its own part in the list,
+    // so the caller's status is incomplete and the audit flags every over-cap
+    // part — none ships silently.
+    assert.equal(residue.section, "2026-05-18");
+    const overCap = parts.filter(
+      (p) => countLines(`${p.h1}\n${p.body}`) > WEEKLY_LOG_LINE_BUDGET,
+    );
+    assert.equal(overCap.length, 2, "both irreducible parts are present");
+    assert.equal(parts.map((p) => p.body).join(""), bodyBelowH1(text));
+  });
+
   test("zero-day-section over-cap source → residue 'prologue'", () => {
     const text = `${H1}\n${Array(600).fill("filler").join("\n")}\n`;
     const { parts, residue } = bisectWeeklyLog(

--- a/libraries/libwiki/test/weekly-log.test.js
+++ b/libraries/libwiki/test/weekly-log.test.js
@@ -86,7 +86,11 @@ describe("bisectWeeklyLog", () => {
       daySection("2026-05-20", 150),
       daySection("2026-05-21", 150),
     );
-    const { parts, residue } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    const { parts, residue } = bisectWeeklyLog(
+      text,
+      "staff-engineer",
+      "2026-W21",
+    );
     assert.equal(residue, null);
     assert.ok(parts.length >= 2, "splits into multiple parts");
     for (const p of parts) assert.ok(partConforms(p), "every part conforms");
@@ -102,7 +106,11 @@ describe("bisectWeeklyLog", () => {
     );
     assert.ok(countLines(text) <= WEEKLY_LOG_LINE_BUDGET, "under the line cap");
     assert.ok(countWords(text) > WEEKLY_LOG_WORD_BUDGET, "over the word cap");
-    const { parts, residue } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    const { parts, residue } = bisectWeeklyLog(
+      text,
+      "staff-engineer",
+      "2026-W21",
+    );
     assert.equal(residue, null);
     assert.ok(parts.length >= 2);
     for (const p of parts) assert.ok(partConforms(p));
@@ -156,7 +164,11 @@ describe("bisectWeeklyLog", () => {
       daySection("2026-05-19", 600),
       daySection("2026-05-20", 50),
     );
-    const { parts, residue } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    const { parts, residue } = bisectWeeklyLog(
+      text,
+      "staff-engineer",
+      "2026-W21",
+    );
     assert.ok(residue, "an irreducible residue is reported");
     assert.equal(residue.section, "2026-05-19");
     assert.ok(residue.lines > WEEKLY_LOG_LINE_BUDGET);
@@ -174,7 +186,11 @@ describe("bisectWeeklyLog", () => {
 
   test("zero-day-section over-cap source → residue 'prologue'", () => {
     const text = `${H1}\n${Array(600).fill("filler").join("\n")}\n`;
-    const { parts, residue } = bisectWeeklyLog(text, "staff-engineer", "2026-W21");
+    const { parts, residue } = bisectWeeklyLog(
+      text,
+      "staff-engineer",
+      "2026-W21",
+    );
     assert.equal(parts.length, 1);
     assert.ok(residue);
     assert.equal(residue.section, "prologue");


### PR DESCRIPTION
## Summary

Implements spec 1450 — the libwiki rotation primitive's seal stops being a plain
rename and becomes a **bisecting seal**: an over-budget weekly log is split at
its `## YYYY-MM-DD` day-section seams into one-or-more sealed parts, each
at-or-under both the line- and word-budget. Refuse-and-error survives only as the
irreducible-residue floor (a lone day-section that alone exceeds a budget).

- **Shared counters** — `countLines`/`countWords` extracted into `src/budget.js`,
  imported by both the seal and the audit so a part the seal calls conforming
  cannot later be flagged by an audit counting differently.
- **Pure splitter** — `bisectWeeklyLog` slices the body at seam byte offsets
  (content-preserving byte-for-byte), greedy-packs day-sections under both
  budgets charging each part's own H1, and flags an over-cap lone section or
  prologue as the residue.
- **Atomic writer** — parts are staged at temps then committed slot-by-slot with
  the fresh-main rename as the single commit point; any failure rolls back
  (unlinks committed slots + temps) leaving the source path/contents/inode
  intact. `nextFreeSlots` claims only individually-free `-partN.md` slots, so a
  numbering gap never clobbers a pre-existing part.
- **Tagged result** — `rotateIfOverBudget` returns `noop` / `sealed` /
  `incomplete`; the three callers (`rotate`, `fix`, append paths) branch on
  `status`. An over-cap multi-day current log now resolves clean through
  `fit-wiki fix`; only a genuine irreducible residue still flags for a human.
- Sealed-part audit hint text reworded for the new behaviour.

Reviewed by two rounds of a 5-agent cold review panel; the second round found no
blocker/high/medium after the first round's prologue-overflow and slot-gap
findings were fixed.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01SjNGaP74xDBcgiPkKiuxjn)_