### PR TITLE
fix(binaries): unblock bun --compile — drop jsdom, compiled-aware svscan logger

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -4,14 +4,14 @@ on:
   workflow_call:
     inputs:
       targets:
-        description: "JSON array of bun targets to build (subset of the manifest's). Omit to build every target in the manifest."
+        description: "JSON array of bun targets to build. Defaults to the standard release set (bun-linux-x64, bun-darwin-arm64)."
         type: string
         required: false
         default: '["bun-linux-x64", "bun-darwin-arm64"]'
   workflow_dispatch:
     inputs:
       targets:
-        description: "JSON array of bun targets to build (subset of the manifest's). Defaults to the full build manifest."
+        description: "JSON array of bun targets to build. Defaults to the standard release set (bun-linux-x64, bun-darwin-arm64)."
         type: string
         required: false
         default: '["bun-linux-x64", "bun-darwin-arm64"]'

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -4,9 +4,17 @@ on:
   workflow_call:
     inputs:
       targets:
-        description: "JSON array of bun targets to build (subset of the manifest's)."
+        description: "JSON array of bun targets to build (subset of the manifest's). Omit to build every target in the manifest."
         type: string
-        required: true
+        required: false
+        default: '["bun-linux-x64", "bun-darwin-arm64"]'
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: "JSON array of bun targets to build (subset of the manifest's). Defaults to the full build manifest."
+        type: string
+        required: false
+        default: '["bun-linux-x64", "bun-darwin-arm64"]'
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,8 +223,8 @@ Security policies apply to all contributors — human and agent.
   `invalid` markers; close the PR if dependents lack compatible ranges.
 - **Audit after changes.** Run `just audit-vulnerabilities` after adding or
   updating deps.
-- **No `jsdom`** (its `css-tree` dep breaks `bun --compile`) — use `linkedom`
-  for HTML parsing, `happy-dom` for browser-env tests.
+- **No `jsdom`** (its `css-tree` breaks `bun --compile`) — use `linkedom` for
+  parsing, `happy-dom` for browser-env tests.
 
 ### Classification
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,17 +215,16 @@ Security policies apply to all contributors — human and agent.
 ## Dependency Policy
 
 - **Prefer built-ins.** Use Node built-ins over npm (`fetch` not `undici`,
-  `crypto.randomUUID()` not `uuid`); consolidate overlapping packages — one YAML
-  parser, one markdown renderer.
+  `crypto.randomUUID()` not `uuid`); consolidate overlapping packages.
 - **Align versions.** Declare the same range across workspaces. Bun hoists
-  matched versions to a single copy — don't remove a runtime dep just because it
-  deduplicates.
-- **No nested duplicates.** Same package at two major versions (e.g.
-  `protobufjs@8` next to `@grpc/proto-loader/protobufjs@7`) is forbidden. Before
-  merging a major bump, run `bun pm ls` and inspect `bun.lock` for `invalid`
-  markers; close the PR if dependents lack compatible ranges.
+  matched versions; don't drop a runtime dep just because it deduplicates.
+- **No nested duplicates.** The same package at two major versions is
+  forbidden. Before a major bump, run `bun pm ls` and inspect `bun.lock` for
+  `invalid` markers; close the PR if dependents lack compatible ranges.
 - **Audit after changes.** Run `just audit-vulnerabilities` after adding or
   updating deps.
+- **No `jsdom`** (its `css-tree` dep breaks `bun --compile`) — use `linkedom`
+  for HTML parsing, `happy-dom` for browser-env tests.
 
 ### Classification
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "libraries/libbridge": {
       "name": "@forwardimpact/libbridge",
-      "version": "0.1.10",
+      "version": "0.1.12",
       "dependencies": {
         "@forwardimpact/libhttp": "^0.1.0",
         "@forwardimpact/libtype": "^0.1.0",
@@ -33,7 +33,7 @@
     },
     "libraries/libcli": {
       "name": "@forwardimpact/libcli",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
       },
@@ -218,7 +218,7 @@
     },
     "libraries/libmock": {
       "name": "@forwardimpact/libmock",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "peerDependencies": {
         "@forwardimpact/libtype": "*",
       },
@@ -307,7 +307,7 @@
         "@forwardimpact/libtype": "^0.1.63",
         "@forwardimpact/libutil": "^0.1.60",
         "html-minifier-terser": "^7.2.0",
-        "jsdom": "^29.1.1",
+        "linkedom": "^0.18.12",
         "microdata-rdf-streaming-parser": "^3.0.0",
         "n3": "^2.0.3",
       },
@@ -424,7 +424,7 @@
     },
     "libraries/libsyntheticrender": {
       "name": "@forwardimpact/libsyntheticrender",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "dependencies": {
         "@forwardimpact/libsyntheticgen": "^0.1.0",
         "@forwardimpact/libtemplate": "^0.2.0",
@@ -477,7 +477,7 @@
     },
     "libraries/libterrain": {
       "name": "@forwardimpact/libterrain",
-      "version": "0.1.33",
+      "version": "0.1.35",
       "bin": {
         "fit-terrain": "./bin/fit-terrain.js",
       },
@@ -527,7 +527,7 @@
     },
     "libraries/libutil": {
       "name": "@forwardimpact/libutil",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "bin": {
         "fit-download-bundle": "./bin/fit-download-bundle.js",
         "fit-tiktoken": "./bin/fit-tiktoken.js",
@@ -815,7 +815,7 @@
     },
     "services/ghbridge": {
       "name": "@forwardimpact/svcghbridge",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "fit-svcghbridge": "./server.js",
       },
@@ -837,7 +837,7 @@
     },
     "services/ghserver": {
       "name": "@forwardimpact/svcghserver",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "fit-svcghserver": "./server.js",
       },
@@ -940,7 +940,7 @@
     },
     "services/msbridge": {
       "name": "@forwardimpact/svcmsbridge",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "fit-svcmsbridge": "./server.js",
       },
@@ -1617,6 +1617,8 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
     "botbuilder": ["botbuilder@4.23.3", "", { "dependencies": { "@azure/core-rest-pipeline": "^1.18.1", "@azure/msal-node": "^2.13.1", "axios": "^1.8.2", "botbuilder-core": "4.23.3", "botbuilder-stdlib": "4.23.3-internal", "botframework-connector": "4.23.3", "botframework-schema": "4.23.3", "botframework-streaming": "4.23.3", "dayjs": "^1.11.13", "filenamify": "^6.0.0", "fs-extra": "^11.2.0", "htmlparser2": "^9.0.1", "uuid": "^10.0.0", "zod": "^3.23.8" } }, "sha512-1gDIQHHYosYBHGXMjvZEJDrcp3NGy3lzHBml5wn9PFqVuIk/cbsCDZs3KJ3g+aH/GGh4CH/ij9iQ2KbQYHAYKA=="],
 
     "botbuilder-core": ["botbuilder-core@4.23.3", "", { "dependencies": { "botbuilder-dialogs-adaptive-runtime-core": "4.23.3-preview", "botbuilder-stdlib": "4.23.3-internal", "botframework-connector": "4.23.3", "botframework-schema": "4.23.3", "uuid": "^10.0.0", "zod": "^3.23.8" } }, "sha512-48iW739I24piBH683b/Unvlu1fSzjB69ViOwZ0PbTkN2yW5cTvHJWlW7bXntO8GSqJfssgPaVthKfyaCW457ig=="],
@@ -1703,7 +1705,13 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
@@ -1891,6 +1899,8 @@
 
     "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
 
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
     "html-minifier-terser": ["html-minifier-terser@7.2.0", "", { "dependencies": { "camel-case": "^4.1.2", "clean-css": "~5.3.2", "commander": "^10.0.0", "entities": "^4.4.0", "param-case": "^3.0.4", "relateurl": "^0.2.7", "terser": "^5.15.1" }, "bin": "cli.js" }, "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
@@ -1987,6 +1997,8 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
+
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
@@ -2074,6 +2086,8 @@
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -2292,6 +2306,8 @@
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
 
     "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -496,7 +496,7 @@
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
         "@forwardimpact/libresource": "^0.1.111",
-        "jsdom": "^29.1.1",
+        "linkedom": "^0.18.12",
       },
       "optionalDependencies": {
         "@supabase/supabase-js": "^2.106.2",
@@ -522,7 +522,7 @@
       "name": "@forwardimpact/libui",
       "version": "1.3.0",
       "devDependencies": {
-        "jsdom": "^29.1.1",
+        "happy-dom": "^20.10.1",
       },
     },
     "libraries/libutil": {
@@ -750,7 +750,7 @@
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
-        "jsdom": "^29.1.1",
+        "happy-dom": "^20.10.1",
       },
     },
     "products/summit": {
@@ -1103,14 +1103,6 @@
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
-    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
-
-    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
-
-    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
-
-    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
-
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
 
     "@aws-crypto/crc32c": ["@aws-crypto/crc32c@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag=="],
@@ -1231,21 +1223,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
-    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
-
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
-
-    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
-
-    "@csstools/css-calc": ["@csstools/css-calc@3.2.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w=="],
-
-    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.0", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ=="],
-
-    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
-
-    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
-
-    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@es-joy/jsdoccomment": ["@es-joy/jsdoccomment@0.86.0", "", { "dependencies": { "@types/estree": "^1.0.8", "@typescript-eslint/types": "^8.58.0", "comment-parser": "1.4.6", "esquery": "^1.7.0", "jsdoc-type-pratt-parser": "~7.2.0" } }, "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw=="],
 
@@ -1264,8 +1242,6 @@
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
-
-    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@forwardimpact/gear": ["@forwardimpact/gear@workspace:products/gear"],
 
@@ -1559,7 +1535,9 @@
 
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
-    "@types/ws": ["@types/ws@6.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg=="],
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/types": ["@typescript-eslint/types@8.59.1", "", {}, "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A=="],
 
@@ -1611,8 +1589,6 @@
 
     "base64url": ["base64url@3.0.1", "", {}, "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="],
 
-    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
-
     "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
@@ -1644,6 +1620,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -1707,19 +1685,13 @@
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
-    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
-
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
     "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
 
-    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
-
     "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
@@ -1883,6 +1855,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "happy-dom": ["happy-dom@20.10.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-awPoqPjx8CgjapJllyDlgzgVHjBExcitKK5ZJkxwhQJyQpHFkyS2bEcqCm7IeW20cQvuCI0cz2Ifq79CJKqtiw=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
@@ -1894,8 +1868,6 @@
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
     "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
-
-    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
 
@@ -1947,8 +1919,6 @@
 
     "is-port-reachable": ["is-port-reachable@4.0.0", "", {}, "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig=="],
 
-    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
-
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
@@ -1966,8 +1936,6 @@
     "jsdoc": ["jsdoc@4.0.5", "", { "dependencies": { "@babel/parser": "^7.20.15", "@jsdoc/salty": "^0.2.1", "@types/markdown-it": "^14.1.1", "bluebird": "^3.7.2", "catharsis": "^0.9.0", "escape-string-regexp": "^2.0.0", "js2xmlparser": "^4.0.2", "klaw": "^3.0.0", "markdown-it": "^14.1.0", "markdown-it-anchor": "^8.6.7", "marked": "^4.0.10", "mkdirp": "^1.0.4", "requizzle": "^0.2.3", "strip-json-comments": "^3.1.0", "underscore": "~1.13.2" }, "bin": "jsdoc.js" }, "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g=="],
 
     "jsdoc-type-pratt-parser": ["jsdoc-type-pratt-parser@7.2.0", "", {}, "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw=="],
-
-    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -2025,8 +1993,6 @@
 
     "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="],
 
-    "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
-
     "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": "bin/markdown-it.mjs" }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
 
     "markdown-it-anchor": ["markdown-it-anchor@8.6.7", "", { "peerDependencies": { "@types/markdown-it": "*", "markdown-it": "*" } }, "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA=="],
@@ -2040,8 +2006,6 @@
     "marked-terminal": ["marked-terminal@7.3.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "ansi-regex": "^6.1.0", "chalk": "^5.4.1", "cli-highlight": "^2.1.11", "cli-table3": "^0.6.5", "node-emoji": "^2.2.0", "supports-hyperlinks": "^3.1.0" }, "peerDependencies": { "marked": ">=1 <16" } }, "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
@@ -2121,7 +2085,7 @@
 
     "parse-statements": ["parse-statements@1.0.11", "", {}, "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA=="],
 
-    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
@@ -2207,8 +2171,6 @@
 
     "sanitize-html": ["sanitize-html@2.17.4", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "launder": "^1.7.1", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ=="],
 
-    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
-
     "seedrandom": ["seedrandom@3.0.5", "", {}, "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="],
 
     "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
@@ -2269,17 +2231,11 @@
 
     "supports-hyperlinks": ["supports-hyperlinks@3.2.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig=="],
 
-    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
-
     "terser": ["terser@5.46.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": "bin/terser" }, "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
-
-    "tldts": ["tldts@7.0.23", "", { "dependencies": { "tldts-core": "^7.0.23" }, "bin": "bin/cli.js" }, "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw=="],
-
-    "tldts-core": ["tldts-core@7.0.23", "", {}, "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ=="],
 
     "tmp": ["tmp@0.2.6", "", {}, "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="],
 
@@ -2289,9 +2245,7 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
-
-    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
@@ -2310,8 +2264,6 @@
     "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
 
     "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
-
-    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -2333,13 +2285,11 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
-    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
-    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
-
-    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -2355,11 +2305,7 @@
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
-    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
-
     "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
-
-    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "xmlcreate": ["xmlcreate@2.0.4", "", {}, "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="],
 
@@ -2425,13 +2371,13 @@
 
     "botframework-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "botframework-streaming/@types/ws": ["@types/ws@6.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg=="],
+
     "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "chalk-template/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
     "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
@@ -2461,6 +2407,8 @@
 
     "glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
+    "happy-dom/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
@@ -2478,10 +2426,6 @@
     "microdata-rdf-streaming-parser/htmlparser2": ["htmlparser2@9.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.1.0", "entities": "^4.5.0" } }, "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ=="],
 
     "mime-types/mime-db": ["mime-db@1.33.0", "", {}, "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="],
-
-    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
-
-    "parse5/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
@@ -2562,10 +2506,6 @@
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
-    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "protobufjs-cli/espree/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/libraries/libmock/src/mock/subprocess.js
+++ b/libraries/libmock/src/mock/subprocess.js
@@ -1,3 +1,5 @@
+import { Writable } from "node:stream";
+
 import { spy } from "./spy.js";
 
 function asyncIterableOf(str) {
@@ -9,27 +11,21 @@ function asyncIterableOf(str) {
 }
 
 /**
- * A captured-chunks stub for a spawned child's writable stdin. Records every
- * `write(chunk)` on `chunks`; `end()`/`destroy()` are no-ops. Mirrors the
- * shape `createDefaultSubprocess().spawn` exposes (the child's `node:stream`
- * Writable) closely enough for a supervisor that pipes into it.
+ * A captured-chunks sink for a spawned child's writable stdin. A real
+ * `node:stream` Writable (so it is a valid `pipe()` destination, the way a
+ * supervisor pipes a service's output into its logger) that records every
+ * written chunk on `chunks` instead of forwarding it anywhere. Mirrors the
+ * `stdin` the production `createDefaultSubprocess().spawn` exposes.
  */
 function createMockStdinSink() {
-  const sink = {
-    chunks: [],
-    write(chunk) {
-      sink.chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
-      return true;
+  const chunks = [];
+  const sink = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      callback();
     },
-    end() {},
-    destroy() {},
-    on() {
-      return sink;
-    },
-    once() {
-      return sink;
-    },
-  };
+  });
+  sink.chunks = chunks;
   return sink;
 }
 

--- a/libraries/libresource/package.json
+++ b/libraries/libresource/package.json
@@ -57,7 +57,7 @@
     "@forwardimpact/libtype": "^0.1.63",
     "@forwardimpact/libutil": "^0.1.60",
     "html-minifier-terser": "^7.2.0",
-    "jsdom": "^29.1.1",
+    "linkedom": "^0.18.12",
     "microdata-rdf-streaming-parser": "^3.0.0",
     "n3": "^2.0.3"
   },

--- a/libraries/libresource/src/parser.js
+++ b/libraries/libresource/src/parser.js
@@ -34,13 +34,13 @@ export class Parser {
   }
 
   /**
-   * Parses HTML DOM and extracts structured items
-   * @param {object} dom - JSDOM instance
+   * Parses an HTML document and extracts structured items
+   * @param {object} document - Parsed document (linkedom)
    * @param {string} baseIri - Base IRI for parsing
    * @returns {Promise<Array>} Array of extracted items with RDF quads
    */
-  async parseHTML(dom, baseIri) {
-    const minifiedHtml = await this.#minifyHTML(dom.serialize());
+  async parseHTML(document, baseIri) {
+    const minifiedHtml = await this.#minifyHTML(document.toString());
     const allQuads = await this.#extractQuads(minifiedHtml, baseIri);
 
     if (!allQuads || allQuads.length === 0) {

--- a/libraries/libresource/src/processor/resource.js
+++ b/libraries/libresource/src/processor/resource.js
@@ -1,4 +1,4 @@
-import { JSDOM } from "jsdom";
+import { parseHTML } from "linkedom";
 import { sanitizeDom } from "../sanitizer.js";
 
 import { generateHash } from "@forwardimpact/libsecret";
@@ -52,24 +52,24 @@ export class ResourceProcessor extends ProcessorBase {
         ? htmlContent.toString("utf8")
         : String(htmlContent);
 
-      const dom = new JSDOM(html);
-      sanitizeDom(dom);
+      const { document } = parseHTML(html);
+      sanitizeDom(document);
 
-      const baseIri = this.#extractBaseIri(dom, key);
-      const items = await this.#parseHTML(dom, baseIri);
+      const baseIri = this.#extractBaseIri(document, key);
+      const items = await this.#parseHTML(document, baseIri);
 
       await super.process(items, key);
     }
   }
 
   /**
-   * Extracts base IRI from DOM's base element or uses fallback
-   * @param {object} dom - JSDOM instance with parsed HTML
+   * Extracts base IRI from the document's base element or uses fallback
+   * @param {object} document - Parsed document with HTML (linkedom)
    * @param {string} key - Storage key (filename) for fallback IRI generation
    * @returns {string} Base IRI to use for this document
    */
-  #extractBaseIri(dom, key) {
-    const baseElement = dom.window.document.querySelector("base[href]");
+  #extractBaseIri(document, key) {
+    const baseElement = document.querySelector("base[href]");
     return (
       baseElement?.getAttribute("href") ||
       this.#baseIri ||
@@ -103,12 +103,12 @@ export class ResourceProcessor extends ProcessorBase {
   /**
    * Parses HTML DOM and extracts structured items with RDF union merging.
    * Implements entity merging across files using stable IRI-based identifiers.
-   * @param {object} dom - JSDOM instance with parsed and sanitized HTML
+   * @param {object} document - Parsed and sanitized document (linkedom)
    * @param {string} baseIri - Base IRI for resolving relative references
    * @returns {Promise<Array>} Array of item objects ready for processItem()
    */
-  async #parseHTML(dom, baseIri) {
-    const parsedItems = await this.#parser.parseHTML(dom, baseIri);
+  async #parseHTML(document, baseIri) {
+    const parsedItems = await this.#parser.parseHTML(document, baseIri);
     if (!parsedItems || parsedItems.length === 0) return [];
 
     const items = [];

--- a/libraries/libresource/src/sanitizer.js
+++ b/libraries/libresource/src/sanitizer.js
@@ -1,3 +1,5 @@
+import { NodeFilter } from "linkedom";
+
 /**
  * Pattern definitions for text-node sanitation.
  */
@@ -60,19 +62,15 @@ function applyPatterns(value, patterns) {
 }
 
 /**
- * Sanitize an existing JSDOM instance in-place.
- * @param {import('jsdom').JSDOM} dom - DOM to mutate
+ * Sanitize a parsed document in-place.
+ * @param {import('linkedom').Document} document - Document to mutate
  * @param {Array} patterns - Pattern definitions (defaults to SANITIZE_PATTERNS)
- * @returns {import('jsdom').JSDOM} The mutated DOM instance
+ * @returns {import('linkedom').Document} The mutated document
  */
-export function sanitizeDom(dom, patterns = SANITIZE_PATTERNS) {
+export function sanitizeDom(document, patterns = SANITIZE_PATTERNS) {
   try {
-    const { document } = dom.window;
     const root = document.body || document;
-    const walker = document.createTreeWalker(
-      root,
-      dom.window.NodeFilter.SHOW_TEXT,
-    );
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
     while (walker.nextNode()) {
       const node = walker.currentNode;
       const original = node.nodeValue;
@@ -83,5 +81,5 @@ export function sanitizeDom(dom, patterns = SANITIZE_PATTERNS) {
   } catch {
     // Ignore sanitizer errors to avoid disrupting processing
   }
-  return dom;
+  return document;
 }

--- a/libraries/libresource/test/libresource.test.js
+++ b/libraries/libresource/test/libresource.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert";
-import { JSDOM } from "jsdom";
+import { parseHTML } from "linkedom";
 
 import { toType, toIdentifier, ResourceIndex } from "../src/index.js";
 import { sanitizeDom } from "../src/sanitizer.js";
@@ -300,20 +300,20 @@ describe("toType helper function", () => {
 
 describe("sanitizeDom patterns", () => {
   test("encodes angle-number and stray ampersand; preserves existing &amp; entity and unknown entity", () => {
-    const html = `<!DOCTYPE html><div>Value <5 and >10 plus R&D &amp; already encoded &unknown; end</div>`;
-    const dom = new JSDOM(html);
-    sanitizeDom(dom);
-    const text = dom.window.document.querySelector("div").textContent;
+    const html = `<!DOCTYPE html><html><body><div>Value <5 and >10 plus R&D &amp; already encoded &unknown; end</div></body></html>`;
+    const { document } = parseHTML(html);
+    sanitizeDom(document);
+    const text = document.querySelector("div").textContent;
     const expected =
       "Value &lt;5 and &gt;10 plus R&amp;D &amp; already encoded &unknown; end";
     assert.strictEqual(text, expected);
   });
 
   test("normalizes smart quotes and nbsp characters", () => {
-    const html = `<!DOCTYPE html><p>“Quoted” ‘text’ and&nbsp;space</p>`;
-    const dom = new JSDOM(html.replace(/&nbsp;/g, "\u00A0"));
-    sanitizeDom(dom);
-    const text = dom.window.document.querySelector("p").textContent;
+    const html = `<!DOCTYPE html><html><body><p>“Quoted” ‘text’ and&nbsp;space</p></body></html>`;
+    const { document } = parseHTML(html.replace(/&nbsp;/g, "\u00A0"));
+    sanitizeDom(document);
+    const text = document.querySelector("p").textContent;
     assert.strictEqual(text, '"Quoted" \u0027text\u0027 and space');
     // Ensure no smart quotes remain
     assert.doesNotMatch(text, /[“”‘’]/);

--- a/libraries/libresource/test/parser.test.js
+++ b/libraries/libresource/test/parser.test.js
@@ -1,9 +1,17 @@
 import { test, describe, beforeEach } from "node:test";
 import assert from "node:assert";
-import { JSDOM } from "jsdom";
+import { parseHTML } from "linkedom";
 
 import { Parser } from "../src/parser.js";
 import { Skolemizer } from "../src/skolemizer.js";
+
+/** Wraps fragment markup in a full HTML document and returns its parsed DOM. */
+function domOf(bodyHtml) {
+  const { document } = parseHTML(
+    `<!DOCTYPE html><html><head></head><body>${bodyHtml}</body></html>`,
+  );
+  return document;
+}
 
 describe("Parser", () => {
   let parser;
@@ -37,7 +45,7 @@ describe("Parser", () => {
         <h1 itemprop="headline">Test Article</h1>
       </div>
     `;
-    const dom = new JSDOM(html);
+    const dom = domOf(html);
     const baseIri = "https://example.com/";
 
     const items = await parser.parseHTML(dom, baseIri);
@@ -52,7 +60,7 @@ describe("Parser", () => {
         <span itemprop="https://www.forwardimpact.team/schema/rdf/name">Test Skill</span>
       </div>
     `;
-    const dom = new JSDOM(html);
+    const dom = domOf(html);
     const baseIri = "https://example.com/";
 
     const items = await parser.parseHTML(dom, baseIri);
@@ -73,7 +81,7 @@ describe("Parser", () => {
 
   test("returns empty array for HTML without microdata", async () => {
     const html = "<div><h1>No Microdata Here</h1></div>";
-    const dom = new JSDOM(html);
+    const dom = domOf(html);
     const baseIri = "https://example.com/";
 
     const items = await parser.parseHTML(dom, baseIri);

--- a/libraries/libsupervise/src/tree.js
+++ b/libraries/libsupervise/src/tree.js
@@ -3,10 +3,9 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 import { EventEmitter } from "node:events";
 
-import { LongrunProcess } from "./longrun.js";
+import { LIBCLI_IS_COMPILED } from "@forwardimpact/libcli";
 
-const require = createRequire(import.meta.url);
-const LOG_BIN = require.resolve("../bin/fit-logger.js");
+import { LongrunProcess } from "./longrun.js";
 
 /**
  * @typedef {object} TreeConfig
@@ -27,6 +26,8 @@ export class SupervisionTree extends EventEmitter {
   #logProcesses;
   #running;
   #logger;
+  #isCompiled;
+  #loggerCmd;
 
   /**
    * Creates a new SupervisionTree
@@ -36,6 +37,10 @@ export class SupervisionTree extends EventEmitter {
    *   Injected runtime bag (uses `subprocess`, `clock`; threaded into children).
    * @param {number} [config.shutdownTimeout] - Timeout for graceful shutdown in ms (default: 3000)
    * @param {import('@forwardimpact/libtelemetry').Logger} config.logger - Logger instance
+   * @param {boolean} [config.isCompiled] - Whether the host is a
+   *   `bun build --compile` binary; defaults to libcli's `LIBCLI_IS_COMPILED`.
+   *   Selects how the `fit-logger` child is launched (see {@link #loggerCommand});
+   *   injectable so tests can exercise both branches without a real binary.
    */
   constructor(logDir, config) {
     super();
@@ -53,6 +58,34 @@ export class SupervisionTree extends EventEmitter {
     this.#longruns = new Map();
     this.#logProcesses = new Map();
     this.#running = false;
+    this.#isCompiled = config.isCompiled ?? LIBCLI_IS_COMPILED;
+  }
+
+  /**
+   * Resolve the command + base args used to launch the `fit-logger` child,
+   * daemontools-style: svscan execs a separate logger program per supervised
+   * service (like s6-svscan exec'ing s6-log) and pipes the service's output
+   * into its stdin.
+   *
+   * A compiled install ships `fit-logger` alongside `fit-svscan` on PATH, so it
+   * is launched by bare name and resolved by the OS — the same way s6 run
+   * scripts invoke their logger. In source/npx execution there is no installed
+   * binary, so the entry module is run under `node`; the `require.resolve` stays
+   * inside this branch (and lazy) so it never runs in a compiled binary, where
+   * the `../bin/fit-logger.js` path does not exist on the `$bunfs`.
+   * @returns {{command: string, baseArgs: string[]}}
+   */
+  #loggerCommand() {
+    if (this.#loggerCmd) return this.#loggerCmd;
+    this.#loggerCmd = this.#isCompiled
+      ? { command: "fit-logger", baseArgs: [] }
+      : {
+          command: "node",
+          baseArgs: [
+            createRequire(import.meta.url).resolve("../bin/fit-logger.js"),
+          ],
+        };
+    return this.#loggerCmd;
   }
 
   /**
@@ -129,9 +162,10 @@ export class SupervisionTree extends EventEmitter {
    * @param {PassThrough} stderr - Stderr stream to pipe from
    */
   #spawnLogProcess(name, logDir, stdout, stderr) {
+    const { command, baseArgs } = this.#loggerCommand();
     const logProcess = this.#subprocess.spawn(
-      "node",
-      [LOG_BIN, "--dir", logDir],
+      command,
+      [...baseArgs, "--dir", logDir],
       {
         stdio: ["pipe", "inherit", "inherit"],
       },

--- a/libraries/libsupervise/test/tree.test.js
+++ b/libraries/libsupervise/test/tree.test.js
@@ -3,7 +3,11 @@ import assert from "node:assert";
 import { EventEmitter } from "node:events";
 
 import { SupervisionTree } from "../src/tree.js";
-import { createSilentLogger, createTestRuntime } from "@forwardimpact/libmock";
+import {
+  createMockSubprocess,
+  createSilentLogger,
+  createTestRuntime,
+} from "@forwardimpact/libmock";
 
 const mockLogger = createSilentLogger();
 const cfg = (extra = {}) => ({
@@ -106,6 +110,55 @@ describe("SupervisionTree", () => {
       await tree.stop();
 
       assert.deepStrictEqual(events, ["start", "stop"]);
+    });
+  });
+
+  // Each supervised service gets its own fit-logger child (daemontools s6-log
+  // model): the service's stdout/stderr are piped into the logger's stdin,
+  // which writes one rotated log per service. How that child is launched
+  // depends on whether svscan is a compiled binary.
+  describe("log process", () => {
+    /** Run `add` against a capturing subprocess and return the logger spawn. */
+    async function logSpawnFor({ isCompiled }) {
+      const subprocess = createMockSubprocess();
+      const tree = new SupervisionTree(
+        "/tmp/logs",
+        cfg({ runtime: createTestRuntime({ subprocess }), isCompiled }),
+      );
+      await tree.start();
+      await tree.add("web", "run-web");
+      // The logger is the spawn carrying the --dir flag; the service itself
+      // goes through `bash -c`.
+      const logCall = subprocess.calls.find((c) => c.args.includes("--dir"));
+      // The mock child "exits" immediately and the mock clock's setTimeout uses
+      // real timers, so leaving the tree running would respawn the logger every
+      // 100ms forever; stop() flips the guard that gates the restart.
+      await tree.stop();
+      return logCall;
+    }
+
+    test("source mode runs fit-logger under node with the per-service log dir", async () => {
+      const logCall = await logSpawnFor({ isCompiled: false });
+      assert.ok(logCall, "a logger process is spawned");
+      assert.strictEqual(logCall.cmd, "node");
+      assert.match(logCall.args[0], /bin\/fit-logger\.js$/);
+      assert.deepStrictEqual(logCall.args.slice(1), ["--dir", "/tmp/logs/web"]);
+    });
+
+    test("compiled mode execs the sibling fit-logger resolved from PATH", async () => {
+      const logCall = await logSpawnFor({ isCompiled: true });
+      assert.ok(logCall, "a logger process is spawned");
+      assert.strictEqual(logCall.cmd, "fit-logger");
+      assert.deepStrictEqual(logCall.args, ["--dir", "/tmp/logs/web"]);
+    });
+
+    test("pipes the service streams into the logger via a stdin pipe", async () => {
+      const logCall = await logSpawnFor({ isCompiled: false });
+      assert.deepStrictEqual(logCall.opts.stdio, [
+        "pipe",
+        "inherit",
+        "inherit",
+      ]);
     });
   });
 });

--- a/libraries/libterrain/package.json
+++ b/libraries/libterrain/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0",
     "@forwardimpact/libresource": "^0.1.111",
-    "jsdom": "^29.1.1"
+    "linkedom": "^0.18.12"
   },
   "peerDependencies": {
     "prettier": "^3.0.0"

--- a/libraries/libterrain/test/fhir-microdata-rdf.test.js
+++ b/libraries/libterrain/test/fhir-microdata-rdf.test.js
@@ -2,7 +2,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { JSDOM } from "jsdom";
+import { parseHTML } from "linkedom";
 import { createMockFs, createTestRuntime } from "@forwardimpact/libmock";
 import {
   createDslParser,
@@ -152,8 +152,8 @@ function makePipeline() {
 }
 
 async function parseFile(parser, content, baseIri) {
-  const dom = new JSDOM(content);
-  return parser.parseHTML(dom, baseIri);
+  const { document } = parseHTML(content);
+  return parser.parseHTML(document, baseIri);
 }
 
 function hasQuad(items, { subject, predicate, object }) {

--- a/libraries/libui/package.json
+++ b/libraries/libui/package.json
@@ -61,7 +61,7 @@
     "test": "bun test test/*.test.js"
   },
   "devDependencies": {
-    "jsdom": "^29.1.1"
+    "happy-dom": "^20.10.1"
   },
   "engines": {
     "bun": ">=1.2.0",

--- a/libraries/libui/test/bound-router.test.js
+++ b/libraries/libui/test/bound-router.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { JSDOM } from "jsdom";
+import { Window } from "happy-dom";
 
 import { createBoundRouter } from "../src/bound-router.js";
 import { defineRoute } from "../src/route-descriptor.js";
@@ -11,10 +11,7 @@ const savedHistory = globalThis.history;
 const savedDocument = globalThis.document;
 
 beforeEach(() => {
-  win = new JSDOM("", { url: "http://localhost/" }).window;
-  // jsdom emits a "Not implemented" notice for scrollTo; the router calls it on
-  // every route match, so stub it to a no-op (happy-dom implemented it silently).
-  win.scrollTo = () => {};
+  win = new Window({ url: "http://localhost/" });
   globalThis.window = win;
   globalThis.history = win.history;
   globalThis.document = win.document;

--- a/libraries/libui/test/command-bar.test.js
+++ b/libraries/libui/test/command-bar.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { JSDOM } from "jsdom";
+import { Window } from "happy-dom";
 
 import { createCommandBar } from "../src/command-bar.js";
 import { createReactive } from "../src/reactive.js";
@@ -11,7 +11,7 @@ const savedDocument = globalThis.document;
 const savedNavigator = globalThis.navigator;
 
 beforeEach(() => {
-  win = new JSDOM("", { url: "http://localhost/" }).window;
+  win = new Window({ url: "http://localhost/" });
   globalThis.window = win;
   globalThis.document = win.document;
   globalThis.navigator = win.navigator;

--- a/libraries/libui/test/json-ld-script.test.js
+++ b/libraries/libui/test/json-ld-script.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { JSDOM } from "jsdom";
+import { Window } from "happy-dom";
 
 import { createJsonLdScript } from "../src/json-ld-script.js";
 import { freezeInvocationContext } from "../src/invocation-context.js";
@@ -9,7 +9,7 @@ let win;
 const savedDocument = globalThis.document;
 
 beforeEach(() => {
-  win = new JSDOM("", { url: "http://localhost/" }).window;
+  win = new Window({ url: "http://localhost/" });
   globalThis.document = win.document;
 });
 

--- a/products/pathway/package.json
+++ b/products/pathway/package.json
@@ -134,7 +134,7 @@
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0",
-    "jsdom": "^29.1.1"
+    "happy-dom": "^20.10.1"
   },
   "engines": {
     "bun": ">=1.2.0",

--- a/products/pathway/test/first-visit-banner.test.js
+++ b/products/pathway/test/first-visit-banner.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { JSDOM } from "jsdom";
+import { Window } from "happy-dom";
 
 import { createFirstVisitBanner } from "../src/components/first-visit-banner.js";
 
@@ -11,7 +11,7 @@ const savedNavigator = globalThis.navigator;
 const savedHTMLElement = globalThis.HTMLElement;
 
 beforeEach(() => {
-  win = new JSDOM("", { url: "http://localhost/" }).window;
+  win = new Window({ url: "http://localhost/" });
   globalThis.window = win;
   globalThis.document = win.document;
   globalThis.navigator = win.navigator;

--- a/products/pathway/test/first-visit-dismissal.test.js
+++ b/products/pathway/test/first-visit-dismissal.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { JSDOM } from "jsdom";
+import { Window } from "happy-dom";
 
 const MODULE_PATH = "../src/lib/first-visit-dismissal.js";
 const STORAGE_KEY = "pathway:first-visit-banner:dismissed";
@@ -11,7 +11,7 @@ const savedDocument = globalThis.document;
 const savedNavigator = globalThis.navigator;
 
 beforeEach(() => {
-  win = new JSDOM("", { url: "http://localhost/" }).window;
+  win = new Window({ url: "http://localhost/" });
   globalThis.window = win;
   globalThis.document = win.document;
   globalThis.navigator = win.navigator;


### PR DESCRIPTION
## Summary

Unblocks the `bun build --compile` native-binary pipeline and removes the
last obstacle to it — `jsdom`, whose transitive `css-tree` loads data via
`createRequire` and cannot be embedded into a compiled binary (the binary
crashes on startup).

- **CI** — `build-binaries` is now manually dispatchable (`workflow_dispatch`)
  with an optional `targets` input, in addition to `workflow_call`; both
  inputs default to the standard release set.
- **libsupervise / `fit-svscan`** — the supervisor launches its per-service
  `fit-logger` child compiled-aware: a compiled install execs the sibling
  `fit-logger` binary by name off `PATH` (both ship in the same `gear`
  bundle), while source/npx runs `node <resolved fit-logger.js>`. The
  `require.resolve` is lazy and gated to the non-compiled branch so it never
  touches `$bunfs`. `isCompiled` is injectable for testing both paths.
- **libresource** — replaced `jsdom` with `linkedom` for HTML
  parsing/serialization and sanitization (matches the rest of the pipeline).
- **Full `jsdom` removal** — migrated the remaining test-only consumers
  (`libterrain` parsing → `linkedom`; `pathway` + `libui` browser-env tests →
  `happy-dom`) and dropped `jsdom` **and** `css-tree` from `bun.lock` entirely.
  Recorded the no-`jsdom` policy in `CONTRIBUTING.md`.
- **libmock** — the mock subprocess `stdin` is now a real `node:stream`
  Writable so it is a valid `pipe()` destination (the supervisor pipes a
  service's output into its logger).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- [ ] Manual `workflow_dispatch` of Build: Binaries (smoke gate per CLI/target)

https://claude.ai/code/session_01KXn4JpHxNPcj7tLnFoLdyh

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXn4JpHxNPcj7tLnFoLdyh)_