### PR TITLE
design(1660): fit-benchmark pass@k threshold gate

### DIFF
--- a/specs/1660-fit-benchmark-pass-k-threshold/design-a.md
+++ b/specs/1660-fit-benchmark-pass-k-threshold/design-a.md
@@ -1,0 +1,109 @@
+# Design 1660-a — fit-benchmark pass@k Threshold Gate
+
+Restates [spec 1660](spec.md): decide the benchmark's pass/fail with a per-task
+pass@k gate (every task must satisfy pass@`k` ≥ `t`), configured by
+`--pass-k`/`--pass-threshold` on both `run` and `report`; drop `--k` and always
+report pass@1/3/5; mirror the flags as `pass-k`/`pass-threshold` action inputs
+and drop the `k` input; attribute failures per task. The gate replaces today's
+"any run not `pass` ⇒ fail" rule. With no flags, only a harness-level failure
+(no records produced) exits non-zero.
+
+## Components
+
+| Component | Location | Role |
+|---|---|---|
+| Gate module | `libeval/src/benchmark/gate.js` (new) | `parsePassGate(values)` validates and returns `{passK, passThreshold}` or `null`; `evaluateGate(report, gate)` recomputes pass@`passK` per task and returns the per-task gate result. Pure, no I/O. |
+| Aggregator split | `libeval/src/benchmark/report.js` (edit) | New `aggregateRecords(records, {kValues})` holds the grouping/estimator core and validates each record through the same `validateResultRecord` filter the loader uses, so the in-memory (`run`) and persisted (`report`) sets agree; `aggregate({inputDir,...})` becomes a thin loader that reads `results.jsonl` then delegates. Display set fixed to `[1,3,5]` (caller `kValues` removed). `passAtKValue(n,c,k)` — currently module-private — is **newly exported** for the gate module. `renderTextReport()` renders gate markers when a gate result is attached. |
+| Run command | `libeval/src/commands/benchmark-run.js` (edit) | Parses the gate; drops the per-record `anyFail` rule; collects the records it streams and feeds **that in-memory set** to `aggregateRecords` + `evaluateGate`; exits on the gate. No file read-back. |
+| Report command | `libeval/src/commands/benchmark-report.js` (edit) | Drops `--k` parsing; parses the gate; aggregates from `results.jsonl`; attaches the gate result; exits on the gate. |
+| CLI definition | `libeval/bin/fit-benchmark.js` (edit) | Adds `pass-k`/`pass-threshold` options to `run` and `report`; removes `k` from `report`; updates descriptions/examples. |
+| Composite action | sibling `forwardimpact/fit-benchmark` `action.yml` | Adds `pass-k`/`pass-threshold` inputs, removes `k`, forwards to `fit-benchmark run`. Edit delivered per [`.github/CLAUDE.md`](../../.github/CLAUDE.md) § Editing a published action. |
+| Docs & skill | `fit-benchmark` SKILL.md + `references/cli.md`; `run-benchmark` guides | Reflect new flags/inputs, removed `--k`/`k`, fixed 1/3/5 columns, new exit contract. |
+
+## Interfaces
+
+```
+parsePassGate(values) -> { passK: number, passThreshold: number } | null
+  null            when neither --pass-k nor --pass-threshold present
+  throws          when exactly one present, passK < 1, or threshold ∉ [0,1]
+
+evaluateGate(report, gate) -> {
+  passK, passThreshold,
+  tasks: [{ taskId, passAtK, passed, insufficientRuns }],
+  passed: boolean                          // false if any task failed
+}
+```
+
+`TaskReport` already carries `n` and `c`, so the evaluator recomputes
+pass@`passK` from each task independently of the materialized display columns —
+the gated k need not be 1, 3, or 5. `passAtKValue` returns a `{error: "k > n"}`
+sentinel when `n < passK`, so the evaluator branches on `n < passK` directly,
+marking the task `insufficientRuns` and `passed: false`.
+
+## Data flow
+
+```mermaid
+flowchart TD
+  optsR[run opts + parsePassGate] --> runner[runner.run streams records]
+  runner --> recs[in-memory record set]
+  runner --> jsonl[(results.jsonl)]
+  recs --> aggR[aggregateRecords k=1,3,5]
+  aggR --> gateR{gate set?}
+  gateR -- yes --> evalR[evaluateGate] --> exitR[exit 0/1]
+  gateR -- no --> exitR
+
+  optsP[report opts + parsePassGate] --> loadP[aggregate reads results.jsonl]
+  loadP --> aggP[aggregateRecords k=1,3,5]
+  aggP --> gateP{gate set?}
+  gateP -- yes --> evalP[evaluateGate] --> render[renderTextReport / JSON] --> exitP[exit 0/1]
+  gateP -- no --> render
+```
+
+`run` gates over the **records it just produced** (the streamed set); `report`
+loads them back from `results.jsonl`. Both route the same records through the
+same `aggregateRecords` + `evaluateGate`, so a `run` verdict and a later
+`report` verdict over those records agree by construction (the rejected
+file-read-back alternative is in § Key Decisions).
+
+## Exit-code contract
+
+| Condition | run | report |
+|---|---|---|
+| Gate set, every task ≥ threshold | 0 | 0 |
+| Gate set, any task < threshold (incl. insufficient runs) | 1 | 1 |
+| No gate, records produced | 0 | 0 |
+| Invalid/partial gate flags | 1 (handler error envelope) | 1 |
+| `report --k=…` (removed option) | — | 1 (arg-parse error → top-level catch) |
+| Harness cannot produce records (malformed/unreadable family) | non-zero (throws) | non-zero (throws) |
+
+Gate-validation and removed-flag errors surface as non-zero through the existing
+error paths (handler envelope `code: 1`; `cli.parse` unknown-option throw caught
+by the top-level `main().catch` handler → exit 1), not as the `usageError`
+exit 2 reserved for unknown commands. No
+per-record operational special-case remains: a `preflightError` lowers a task's
+pass@k like any other failing run, so a configured gate catches it and the
+no-gate path leaves it informational.
+
+## Key Decisions
+
+| Decision | Choice | Rejected alternative |
+|---|---|---|
+| Where the gate runs | Shared `evaluateGate`, consumed by both `run` and `report` | Gate only in `report` (a bare `run`, and the action that calls it, lose a meaningful exit code); gate only in `run` (cannot re-gate an uploaded `results.jsonl` artifact without re-spending agent cost) |
+| What `run` gates over | The in-memory record set it just streamed | Re-reading `results.jsonl` (runner appends, so a reused `--output` dir pools prior-run records into the verdict) |
+| Gated k vs report columns | Evaluator recomputes pass@`passK` from each task's `(n,c)`; display fixed at 1/3/5 | Add `passK` to the materialized column set (couples the display surface to the gate; the spec fixes the columns) |
+| `n < passK` (insufficient runs) | Fail the task, mark `insufficientRuns` | Skip the task (a task with too few runs would silently pass the benchmark); hard error (one short task should fail, not abort the report) |
+| No-gate exit semantics | Non-zero only when no records are produced (harness throw); per-task outcomes are informational | Keep "any run not `pass` ⇒ fail" (the brittleness the spec removes); a per-record `preflightError` exit (indistinguishable from a task verdict fail in the record shape, and needs `includeRuns` detail the default path omits) |
+| Partial config | `parsePassGate` rejects exactly-one-flag and out-of-range values | Default the missing flag (an arbitrary default threshold silently changes the gate; hides intent) |
+| `--k` handling | Remove the flag; fixed `[1,3,5]` in `aggregateRecords` | Keep `--k` as a deprecated alias (the spec mandates a clean removal) |
+| Action change delivery | Issue-with-diff against the sibling repo, then SHA-pin bump | Direct push (agent tokens lack rights on `forwardimpact/fit-benchmark`) |
+
+## Risks
+
+- **Cross-repo drift.** The action and CLI must ship the flag rename together,
+  or a workflow passing `k` breaks — a coupling constraint the plan must honor
+  when sequencing the CLI change and the sibling action edit + SHA bump.
+- **Silent looser gate.** A user who relied on all-runs-must-pass and sets no
+  threshold now gets a green build on agent failures. The guides call out the
+  changed default explicitly so the looser semantics are not a surprise.
+
+— Claude (kata-design)

--- a/specs/1660-fit-benchmark-pass-k-threshold/spec.md
+++ b/specs/1660-fit-benchmark-pass-k-threshold/spec.md
@@ -1,0 +1,103 @@
+# Spec 1660 — fit-benchmark pass@k Threshold Gate
+
+## Problem
+
+`fit-benchmark` exists to answer one question with reproducible evidence: did a
+skill-pack change make agents better at writing code? It runs each task N times
+and reports pass@k via the OpenAI HumanEval unbiased estimator precisely because
+a single agent run is a coin flip. Yet the only automated pass/fail signal the
+tool emits ignores pass@k entirely.
+
+Today `fit-benchmark run` fails (exit 1) when **any single run of any task** is
+not `pass`, and `fit-benchmark report` always exits 0 — pass@k is computed and
+printed but never gates anything. The composite action inherits the `run` exit
+code. Three consequences follow:
+
+1. **The gate contradicts the tool's own premise.** With five runs across five
+   tasks, one flaky failure out of twenty-five fails the whole benchmark. The
+   estimator that was built to absorb non-determinism is decorative; the gate
+   demands determinism the tool assumes it cannot have.
+
+2. **Intent cannot be expressed.** A team cannot say "this skill set should let
+   the agent solve the TODO-API task at least four runs out of five." There is
+   no knob for "pass@3 ≥ 0.8 per task." The pass@k table is read by eye.
+
+3. **CI cannot gate on the evidence.** Because the only machine signal is
+   all-runs-must-pass, PR and scheduled workflows either tolerate a near-useless
+   gate or ignore the exit code and treat benchmarks as advisory.
+
+The brittleness is structural, not a bug: the per-run exit rule predates any
+notion of an aggregate target. Specs 0870, 0890, and 0980 each explicitly
+deferred threshold-based gating to a later spec. This is that spec.
+
+## Personas and Job
+
+The gate serves **Platform Builders**. Their Big Hire is to "Help me prove
+whether agent changes improved outcomes with reproducible evidence"
+([JTBD.md](../../JTBD.md) § Platform Builders: Evaluate and Improve Agents),
+hired against **Gear**. Proof that cannot fail a build is not proof a team can
+act on. A configurable per-task pass@k target turns the reported number into an
+enforceable contract — the difference between a benchmark a workflow can gate on
+and a table someone has to remember to read. Teams Using Agents inherit the
+benefit downstream when their CI gates skill PRs; they are not the direct hire.
+
+## Scope
+
+The gate is configured by two settings: `--pass-k` names an integer *k*, and
+`--pass-threshold` names a fraction *t* in `[0,1]`. The gate passes only when
+**every task** satisfies pass@*k* ≥ *t*; one task short fails the benchmark.
+
+### In scope
+
+| Component | What changes |
+|---|---|
+| Pass/fail verdict | A **per-task** pass@k gate decides the benchmark's pass/fail, **replacing** the current "any run not `pass` ⇒ fail" rule. **Both** `fit-benchmark run` (over the records it just produced) and `fit-benchmark report` (over an existing result set) apply the gate and exit non-zero when any task fails it; the two commands produce the same verdict for the same records. |
+| Gate configuration | `--pass-k` (positive integer) and `--pass-threshold` (fraction in `[0,1]`) on both `run` and `report`. Both must be supplied together; supplying one alone is a configuration error. |
+| No-gate default | When neither flag is set, the benchmark applies **no per-task gate** and does not fail on any per-task outcome (informational). It exits non-zero only when there are no result records to evaluate at all — an unreadable or malformed family that produces no records, or a result set with zero valid records. This is the clean break from all-runs-must-pass. |
+| Insufficient runs | When a gated task has fewer completed runs than *k* (`n < k`, so pass@*k* is undefined), that task **fails** the gate and the report marks it as insufficient runs. |
+| `--k` removal | The `--k` reporting flag is **removed**; the report always renders pass@1, pass@3, and pass@5. `--pass-k` (which k gates) may name any positive integer, independent of which k the report displays. |
+| Composite action | `forwardimpact/fit-benchmark@v1` gains `pass-k` and `pass-threshold` inputs, **drops** the `k` input, and forwards the new inputs to the gated `run` command so the job's exit status reflects the per-task gate. The action edit lands in the sibling repo per [`.github/CLAUDE.md`](../../.github/CLAUDE.md) § Editing a published action; this spec covers the interface, the design/plan covers the cross-repo mechanics. |
+| Report attribution | The report surface exposes, per task, the gated k, the observed pass@k, and a pass/fail-against-gate indicator, in both `--format=text` and `--format=json` output, so a reader sees why the benchmark failed without recomputing. |
+| Documentation & parity | The `fit-benchmark` skill, its CLI reference, and the run-benchmark guides reflect the new flags, the removed `--k`/`k`, the fixed report columns, and the new exit-code contract — keeping skill–CLI parity per `.claude/skills/CLAUDE.md`. |
+
+### Out of scope, deferred
+
+- **Family-aggregate threshold.** Only a per-task gate ships; a single pooled
+  pass@k across all tasks is a possible later amendment.
+- **Per-k threshold maps.** One `(--pass-k, --pass-threshold)` pair gates all
+  tasks; a different target per task or per k is deferred.
+- **Before/after delta gating.** Failing on a regression relative to a baseline
+  `results.jsonl` is separate from an absolute threshold.
+- **PR merge-gate wiring.** This spec makes the exit code meaningful; wiring
+  benchmark runs into branch-protection required checks remains workflow-author
+  territory.
+- **Backward-compatible `--k` alias.** The removal is a clean break; workflows
+  passing `--k` or the action `k` input must migrate. No deprecation shim ships.
+- **Per-task threshold overrides in the family manifest.** v1 configures the
+  gate only through the flag / action input.
+
+## Success Criteria
+
+Pass@k uses the HumanEval estimator `1 − C(n−c, k) / C(n, k)`; the fixture
+verdicts below are constructible at `n = 5` (e.g. `c = 1 ⇒ pass@3 = 0.6`,
+`c = 2 ⇒ pass@3 = 0.9`, `c = 1 ⇒ pass@4 = 0.8`, `c = 1 ⇒ pass@5 = 1.0`).
+
+| Claim | Verification |
+|---|---|
+| With both flags set, the benchmark passes only when every task's pass@`k` ≥ `t`. | Test: a `report` over a fixture `results.jsonl` with task A at pass@3 = 0.9 and task B at pass@3 = 0.6, under `--pass-k=3 --pass-threshold=0.8`, exits non-zero; raising task B to pass@3 = 0.9 makes the same command exit 0. |
+| The gate is per-task, not pooled — one failing task fails the benchmark. | Test: a fixture with three tasks at pass@3 = 0.9 and one at pass@3 = 0.6, under `--pass-k=3 --pass-threshold=0.8`, exits non-zero; removing the one failing task makes it exit 0. |
+| `run` and `report` produce the same gate verdict for the same result records. | Test: the same record set, gated through the `run` path (over just-produced records) and the `report` path (over the persisted `results.jsonl`), yields the same pass/fail. |
+| With neither flag set, no per-task gate is applied. | Test: a `report` over a fixture where every task has at least one failing run, with no `--pass-k`/`--pass-threshold`, exits 0. |
+| The old "any run not `pass` ⇒ fail" behavior no longer applies. | Test: a fixture with a single failing run among otherwise-passing runs, no flags, exits 0 (would have exited 1 before). |
+| With no gate, the absence of any evaluable record still exits non-zero. | Test: `run` against an unreadable/malformed family that produces no records exits non-zero; `report` over a results set with zero valid records exits non-zero; a results set with at least one valid record and failing runs exits 0. |
+| Supplying only one of the two flags is a configuration error. | Test: `--pass-k=3` with no `--pass-threshold` (and vice versa) exits non-zero with a message naming the missing flag, before any run or aggregation. |
+| `--pass-threshold` rejects values outside `[0,1]` and `--pass-k` rejects non-positive integers. | Test: `--pass-threshold=1.5` and `--pass-k=0` each exit non-zero with a message, before any run. |
+| A gated task with fewer runs than `k` fails the gate as insufficient runs. | Test: a fixture task with n = 3 under `--pass-k=4 --pass-threshold=0.5` fails and the report marks it insufficient runs; a task with n = 5 meeting the threshold passes. |
+| `--k` is removed and the report always renders pass@1, pass@3, pass@5 in both formats. | Test: `report --k=1,3` exits non-zero as an unknown option; both the text and JSON reports expose exactly the pass@1, pass@3, and pass@5 figures per task and no other display k. |
+| `--pass-k` is independent of the fixed report columns and gates on the named k. | Test: a fixture task at pass@4 = 0.8 (and pass@5 = 1.0) gated on `--pass-k=4 --pass-threshold=0.9` **fails** while the report still shows the 1/3/5 columns — proving the verdict tracks pass@4, not pass@5; lowering the threshold to 0.8 makes it pass. |
+| The report attributes a benchmark failure to the offending task(s) in both formats. | Test: a failing-gate report exposes, per task, the gated k (which may differ from the displayed 1/3/5), the observed pass@k at that k, and a pass/fail-against-gate indicator in both `--format=text` and `--format=json`; the failing task is distinguishable from passing ones. |
+| The composite action exposes `pass-k`/`pass-threshold`, drops `k`, and wires them to the gated command. | Test (interface-level): the action's documented inputs list `pass-k` and `pass-threshold` and no `k`, and the action forwards them to `fit-benchmark run` so the job exit status reflects the per-task gate. The sibling-repo job run itself is out of this repo's test scope. |
+| Skill, CLI reference, and guides reflect the new contract with no stale `--k`/`k`. | Test: a scan finds the new flags/inputs and the fixed pass@1/3/5 report description, and finds no remaining `--k` flag or action `k` input references in the `fit-benchmark` skill, CLI reference, or run-benchmark guides. |
+| Skill and CLI carry parity per `.claude/skills/CLAUDE.md`. | Test: the skill's documentation list and the CLI's published documentation entries carry the same entries in the same order. |
+
+— Claude (kata-spec)


### PR DESCRIPTION
## Summary

- Adds **spec 1660** (WHAT/WHY) and **design-a** (WHICH/WHERE) for a configurable per-task pass@k gate on the `fit-benchmark` CLI and composite action.
- **Gate:** every task must satisfy pass@*k* ≥ *t*, configured by `--pass-k` / `--pass-threshold` on both `run` and `report` (and as `pass-k` / `pass-threshold` action inputs).
- **Replaces** the brittle "any single run not `pass` ⇒ fail" exit rule. With no flags set the benchmark is informational and fails only when there are no records to evaluate.
- **Drops `--k`** entirely; the report always renders pass@1/3/5. The action's `k` input is dropped too.
- `wiki/STATUS.md` row for 1660 set to `design approved`.

Both artifacts passed clean `kata-review` panels (spec: 3× product + 3× technical; design: 3× technical) across two rounds — round-one consensus highs (gate not bound to a command, operational-error class collision, undefined `k > n`, an arithmetically impossible pass@k fixture) and round-two refinements (non-discriminating independence criterion, empty-`results.jsonl` semantics, design one-home/export notes) are all resolved.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01GAiTQNh7WrExxktLbXM4j5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAiTQNh7WrExxktLbXM4j5)_