### PR TITLE
fix(benchmarks): make fit-wiki cli-fix integrity invariants check content

### DIFF
--- a/benchmarks/fit-wiki/tasks/cli-fix/hooks/invariants.sh
+++ b/benchmarks/fit-wiki/tasks/cli-fix/hooks/invariants.sh
@@ -11,8 +11,13 @@ assert() {
   fi
 }
 
+# The fix must resolve the audit findings AND leave the seeded content
+# standing. `test -f` only proves the file still exists — a fix that guts
+# the body (or truncates it to satisfy the audit markers) would still pass.
+# Assert the seeded sections survive so the "intact" invariants actually
+# measure integrity instead of mere existence.
 assert audit-passes   sh -c 'cd "$1" && npx fit-wiki audit --today 2026-05-24' _ "$WORKDIR"
-assert summary-intact  test -f "$WORKDIR/wiki/staff-engineer.md"
-assert memory-intact   test -f "$WORKDIR/wiki/MEMORY.md"
+assert summary-intact  sh -c 'f="$1/wiki/staff-engineer.md"; grep -q "## Current Focus" "$f" && grep -q "## Open Blockers" "$f"' _ "$WORKDIR"
+assert memory-intact   grep -q "## Cross-Cutting Priorities" "$WORKDIR/wiki/MEMORY.md"
 
 [ "$FAIL" = 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- The `summary-intact` and `memory-intact` invariants in the `fit-wiki/cli-fix`
  benchmark task only ran `test -f` — asserting the wiki files still *existed*,
  not that their seeded content survived.
- Because `fit-wiki audit` passes on a gutted `staff-engineer.md` (required
  markers present, body deleted), a destructive fix could delete the
  `## Current Focus` and `## Open Blockers` sections and still report all three
  invariants green — leaving the "didn't destroy content" check entirely to the
  LLM judge, which defeats the purpose of a deterministic invariant gate.
- Repaired the invariants to assert the seeded content survives: `summary-intact`
  now requires both `## Current Focus` and `## Open Blockers`, and
  `memory-intact` requires `## Cross-Cutting Priorities`.

Verified through the real `fit-benchmark invariants` harness:

- **Legitimate fix** (markers added, sections preserved) → `verdict: pass`
- **Destructive fix** (markers added, sections deleted) → `verdict: fail`
  (`audit-passes` still passes — proving audit alone can't catch it — while
  `summary-intact` now correctly fails)

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01FReDZXo8U99NK6u7NGcJGy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FReDZXo8U99NK6u7NGcJGy)_