### PR TITLE
feat(libeval): give supervisor lead Bash to own post-interview wrap-up

### DIFF
--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -184,9 +184,8 @@ forces materialised; table of findings and issues created or updated.
 
 ## Memory: what to record
 
-Append yourself (your own Bash) to the current week's log: product
-interviewed; job (`<user>: <goal>`); outcome (done / abandoned / partial);
-forces observed
+Using your own Bash, append to the current week's log: product interviewed;
+job (`<user>: <goal>`); outcome (done / abandoned / partial); forces observed
 (Push/Pull/Habit/Anxiety/Competes/Fired); issue numbers + categories.
 Append one metrics row per run to `wiki/metrics/{skill}/` per
 `references/metrics.md`. See KATA.md § Metrics for recording eligibility.

--- a/.claude/skills/kata-interview/SKILL.md
+++ b/.claude/skills/kata-interview/SKILL.md
@@ -151,8 +151,9 @@ back to the agent.
 
 ### Step 7: Transition to Post-Interview
 
-Once done or abandoned, stop sending work and proceed to Steps 8–9 in
-the same turn. Conclude only after filing issues and writing the report.
+Once done or abandoned, stop Asking and do Steps 8–9 yourself with your own
+Bash and monorepo checkout — never delegate wrap-up to the agent (it breaks
+isolation). Conclude only after filing issues and writing the report.
 
 ### Step 8: Capture Findings
 
@@ -170,8 +171,8 @@ Classify each for action:
 | **Documentation**   | Unclear, missing, or outdated docs    | Create docs issue     |
 | **Out of scope**    | Not actionable or outside the product | Skip — note in report |
 
-For each actionable finding: extract; search for duplicates; create a new
-issue or comment on a matching one (templates in
+For each actionable finding, with your own `gh`: extract; search for
+duplicates; create a new issue or comment on a matching one (templates in
 `../kata-product-issue/references/templates.md` § New Issues from User
 Testing) naming the JTBD job (`<user>: <goal>`) in the body; add the
 finding to the report table with its issue number.
@@ -183,8 +184,9 @@ forces materialised; table of findings and issues created or updated.
 
 ## Memory: what to record
 
-Append to the current week's log: product interviewed; job (`<user>: <goal>`);
-outcome (done / abandoned / partial); forces observed
+Append yourself (your own Bash) to the current week's log: product
+interviewed; job (`<user>: <goal>`); outcome (done / abandoned / partial);
+forces observed
 (Push/Pull/Habit/Anxiety/Competes/Fired); issue numbers + categories.
 Append one metrics row per run to `wiki/metrics/{skill}/` per
 `references/metrics.md`. See KATA.md § Metrics for recording eligibility.

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -31,7 +31,6 @@ import { OrchestrationLoop } from "./orchestration-loop.js";
 export const SUPERVISOR_SYSTEM_PROMPT =
   "You supervise one agent.\n" +
   "Use `Ask` to delegate the agent's task to the agent.\n" +
-  "Do your own work with your own tools.\n" +
   "`Ask` is async and returns {askIds:[N]} immediately.\n" +
   "The reply arrives on your next turn as `[answer#N] agent: <text>` in your inbox.\n" +
   "End your turn while Asks are pending. The system resumes you when an answer arrives.\n" +

--- a/libraries/libeval/src/supervisor.js
+++ b/libraries/libeval/src/supervisor.js
@@ -30,8 +30,8 @@ import { OrchestrationLoop } from "./orchestration-loop.js";
 /** System prompt for the supervisor lead. L0 mechanics only per COALIGNED. */
 export const SUPERVISOR_SYSTEM_PROMPT =
   "You supervise one agent.\n" +
-  "You have no tools to perform work yourself.\n" +
-  "Use `Ask` to delegate work to the agent.\n" +
+  "Use `Ask` to delegate the agent's task to the agent.\n" +
+  "Do your own work with your own tools.\n" +
   "`Ask` is async and returns {askIds:[N]} immediately.\n" +
   "The reply arrives on your next turn as `[answer#N] agent: <text>` in your inbox.\n" +
   "End your turn while Asks are pending. The system resumes you when an answer arrives.\n" +
@@ -196,7 +196,6 @@ export function createSupervisor({
     "Task",
     "TaskOutput",
     "TaskStop",
-    "Bash",
     "Write",
     "Edit",
   ];
@@ -210,7 +209,7 @@ export function createSupervisor({
     output: devNull,
     model: supervisorModel ?? model,
     maxTurns: perRunBudget,
-    allowedTools: supervisorAllowedTools ?? ["Read", "Glob", "Grep"],
+    allowedTools: supervisorAllowedTools ?? ["Read", "Glob", "Grep", "Bash"],
     disallowedTools,
     onLine: (line) => supervisor.emitLine("supervisor", line),
     settingSources: ["project"],

--- a/libraries/libeval/test/prompts.test.js
+++ b/libraries/libeval/test/prompts.test.js
@@ -101,7 +101,13 @@ describe("COALIGNED L0 — agents describe inbox arrival of questions", () => {
 });
 
 describe("COALIGNED L0 — leads state delegation constraint", () => {
-  for (const [name, prompt] of LEAD_PROMPTS) {
+  // Supervisor is excluded: it has its own tools (incl. Bash) to do its own
+  // work, so it delegates only the agent's task — not all work — via Ask.
+  const NO_TOOL_LEADS = [
+    ["FACILITATOR_SYSTEM_PROMPT", FACILITATOR_SYSTEM_PROMPT],
+    ["DISCUSS_SYSTEM_PROMPT", DISCUSS_SYSTEM_PROMPT],
+  ];
+  for (const [name, prompt] of NO_TOOL_LEADS) {
     test(`${name} contains delegation constraint`, () => {
       assert.ok(
         prompt.includes("no tools to perform work yourself"),

--- a/libraries/libeval/test/supervisor-factory.test.js
+++ b/libraries/libeval/test/supervisor-factory.test.js
@@ -39,6 +39,7 @@ describe("Supervisor - createSupervisor factory", () => {
       "Read",
       "Glob",
       "Grep",
+      "Bash",
     ]);
   });
 
@@ -90,7 +91,6 @@ describe("Supervisor - createSupervisor factory", () => {
       "Task",
       "TaskOutput",
       "TaskStop",
-      "Bash",
       "Write",
       "Edit",
     ]);


### PR DESCRIPTION
## Summary

A `fit-trace` analysis of a `kata-interview` run showed the supervisor lead — which had no `Bash` — delegating all post-interview wrap-up (filing issues, wiki memory/metrics, commit/push) to the **isolated interviewee agent** via `Ask`. That breached the interview-isolation invariant and cost failed round-trips. The supervisor authored all the content anyway and outsourced only the keystrokes.

- **`libeval/src/supervisor.js`** — grant the supervisor lead `Bash`: drop it from the deny list and add it to the default allow list (`Write`/`Edit`/`Agent`/`Task*` stay blocked). Drop the now-false "no tools to perform work yourself" line from `SUPERVISOR_SYSTEM_PROMPT`; the lead delegates the agent's task via `Ask` but does its own work with its own tools (L0 mechanics only, no cross-layer duplication).
- **`kata-interview/SKILL.md`** — name the supervisor as the actor for Steps 8–9 and the memory log, and forbid delegating wrap-up to the agent (it breaks isolation).
- **Tests** — update the supervisor tool-set assertions; exclude the supervisor from the "no tools" delegation-constraint check (facilitator and discuss leads, which remain pure-conversation leads, still carry it).

Facilitator and discuss modes are unchanged.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01CKYmfm7zGzCFej335vfRNA)_