### PR TITLE
ci(eval-kata): raise fit-benchmark timeout to 120m

### DIFF
--- a/.github/workflows/eval-kata.yml
+++ b/.github/workflows/eval-kata.yml
@@ -24,3 +24,6 @@ jobs:
           runs: "5"
           max-turns: "25"
           judge-profile: judge
+          # runs:5 × 4 tasks ≈ 90+ min of sequential agent+judge sessions;
+          # the default 60 timed out mid-run (see run 23).
+          timeout-minutes: "120"


### PR DESCRIPTION
## Summary

- Raise the `forwardimpact/fit-benchmark` action's `timeout-minutes` to `120` in `eval-kata.yml`.

`runs:5 × 4 tasks` is ~90+ minutes of sequential agent+judge sessions, so the action's default 60-minute timeout killed the run mid-way. Run 23 completed **13/13 passing sessions** (`design-feature` 5/5, `implement-feature` 5/5, `plan-feature` 3/3) before `exit 124`, confirming the benchmark and the released `libeval@v0.1.60` family-fixtures support both work — it simply ran out of clock. 120 minutes gives a full `runs:5` dispatch room to finish.

## Test plan

- [ ] `bun run check`
- [ ] Manual `eval-kata` dispatch completes without timeout (separate, on demand).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CkzGx3Hv5gRtp1rMdEqJje)_