### PR TITLE
fix(benchmarks): accept Acceptance Criteria heading in spec-feature invariant

### DIFF
--- a/benchmarks/kata-skills/tasks/spec-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/spec-feature/hooks/invariants.sh
@@ -10,7 +10,7 @@ assert file-present --exists "$SPEC"
 
 assert has-problem        --grep '^## Problem' "$SPEC"
 assert has-scope          --grep '^##+ (In )?Scope|^##+ Non.?Goals' "$SPEC"
-assert verifiable-success --grep '^## Success' "$SPEC"
+assert verifiable-success --grep '^## (Success|Acceptance Criteria)' "$SPEC"
 assert no-how-leak        --not --grep '[A-Za-z0-9_/.-]+\.(js|ts|sh|py|yml|yaml):[0-9]+' "$SPEC" \
                           --message "file:line reference detected"
 assert cites-jtbd --cites-job "$JTBD" "$SPEC"


### PR DESCRIPTION
## Summary

- Eval: Kata run 24 ([27371457102](https://github.com/forwardimpact/monorepo/actions/runs/27371457102)) failed 2/5 `spec-feature` runs solely on the `verifiable-success` invariant: the agent titled the section `## Acceptance Criteria` instead of `## Success`, a heading the kata-spec skill does not mandate. The judge graded both specs substantively complete.
- Widen the `verifiable-success` grep to `^## (Success|Acceptance Criteria)`, mirroring how `has-scope` already accepts `Scope` or `Non-Goals`. Verified with `fit-trace assert`: both headings pass, unrelated headings still fail.

## Test plan

- [x] `fit-trace assert verifiable-success --grep '^## (Success|Acceptance Criteria)'` passes for `## Success` and `## Acceptance Criteria`, fails for other headings
- [ ] `bun run check`
- [ ] `bun run test`

https://claude.ai/code/session_01NMp2rrPRQTTxzhzxYTeGq5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMp2rrPRQTTxzhzxYTeGq5)_