### PR TITLE
fix(libeval,libutil): default agents to Opus 4.8 1M and stop masking init failures

### DIFF
--- a/.claude/skills/fit-benchmark/references/cli.md
+++ b/.claude/skills/fit-benchmark/references/cli.md
@@ -22,8 +22,8 @@ npx fit-benchmark <command> [options]
 | `--output`         | no       | Run-output directory (created if missing, default `benchmark-runs`)                              |
 | `--runs`           | no       | Runs per task (default `5`)                                                                      |
 | `--agent-model`    | no       | Claude model for the agent-under-test (default `claude-sonnet-4-6`)                              |
-| `--lead-model`       | no     | Claude model for the lead role (default `claude-fable-5[1m]`)                                       |
-| `--judge-model`    | no       | Claude model for the judge (default `claude-fable-5[1m]`)                                           |
+| `--lead-model`       | no     | Claude model for the lead role (default `claude-opus-4-8[1m]`)                                       |
+| `--judge-model`    | no       | Claude model for the judge (default `claude-opus-4-8[1m]`)                                           |
 | `--agent-profile`  | no       | Agent-under-test profile name                                                                    |
 | `--judge-profile`  | no       | Judge profile name                                                                               |
 | `--max-turns`      | no       | Agent turn budget (default `50`; `0` = unlimited)                                                |

--- a/.claude/skills/fit-eval/references/cli.md
+++ b/.claude/skills/fit-eval/references/cli.md
@@ -22,7 +22,7 @@ npx fit-eval <command> [options]
 | `--task-file`   | Path to a markdown task file                                                |
 | `--task-text`   | Inline task text (alternative to `--task-file`)                             |
 | `--task-amend`  | Additional text appended to the task                                        |
-| `--agent-model` | Claude model for agents (default: `claude-fable-5[1m]`)                    |
+| `--agent-model` | Claude model for agents (default: `claude-opus-4-8[1m]`)                    |
 | `--max-turns`   | Max agentic turns per runner invocation (default: 50 run, 200 supervise, 20 facilitate, 40 discuss; 0 = unlimited) |
 | `--output`      | Write the NDJSON trace to a file                                            |
 
@@ -39,7 +39,7 @@ npx fit-eval <command> [options]
 | Flag             | Purpose                                                          |
 | ---------------- | ---------------------------------------------------------------- |
 | `--lead-profile` | Lead role profile name (supervisor / facilitator / chair)        |
-| `--lead-model`   | Claude model for the lead role (default: `claude-fable-5[1m]`)  |
+| `--lead-model`   | Claude model for the lead role (default: `claude-opus-4-8[1m]`)  |
 
 ## Supervise-Only Options
 

--- a/.claude/skills/kata-setup/SKILL.md
+++ b/.claude/skills/kata-setup/SKILL.md
@@ -87,7 +87,7 @@ Ask these questions. Skip any already answered in the task prompt.
 5. **Wiki** — "Do you want agents to share persistent memory via a GitHub
    wiki?" Default: yes. If no, set `wiki: "false"` in generated workflows.
 
-6. **Model** — "Which Claude model?" Default: `claude-fable-5[1m]`.
+6. **Model** — "Which Claude model?" Default: `claude-opus-4-8[1m]`.
 
 7. **Agent profiles** — "Do you have custom agent profiles, or should I use the
    defaults from kata-skills?" If defaults, confirm

--- a/.claude/skills/kata-setup/references/workflow-agent.md
+++ b/.claude/skills/kata-setup/references/workflow-agent.md
@@ -10,7 +10,7 @@ the user's configuration.
 | `{{AGENT_TITLE}}`    | `Product Manager`                                        |
 | `{{AGENT_NAME}}`     | `product-manager`                                        |
 | `{{CRON_ENTRIES}}`   | Three `- cron:` lines from `schedules.md`                |
-| `{{MODEL}}`          | `claude-fable-5[1m]`                                    |
+| `{{MODEL}}`          | `claude-opus-4-8[1m]`                                    |
 | `{{WIKI}}`           | `"true"` or `"false"`                                    |
 | `{{KATA_AGENT_REF}}` | `b4a5b262f3d7acaee2da63f8b2a09bcf4730d804 # v1.0.0`      |
 
@@ -118,7 +118,7 @@ from `SKILL.md` Step 2 so they receive bump PRs instead of rotting.
   token carries all other permissions via its installation settings.
 - If wiki is disabled, set `wiki: "false"` -- the action skips wiki checkout and
   sync.
-- If model is the default (`claude-fable-5[1m]`), the `agent-model:` line
+- If model is the default (`claude-opus-4-8[1m]`), the `agent-model:` line
   can be omitted since the action defaults to it.
 - **Hosted variant** requires the `FIT_OIDC_URL` repository variable and
   depends on `kata-agent` accepting an `installation-token` input

--- a/.claude/skills/kata-setup/references/workflow-facilitate.md
+++ b/.claude/skills/kata-setup/references/workflow-facilitate.md
@@ -10,7 +10,7 @@ only when `improvement-coach` is selected.
 | --------------------- | ------------------------------------------------------------------------------------ |
 | `{{STORYBOARD_CRON}}` | `0 6 * * *` (from `schedules.md`)                                                    |
 | `{{AGENT_LIST}}`      | `security-engineer,technical-writer,product-manager,staff-engineer,release-engineer` |
-| `{{MODEL}}`           | `claude-fable-5[1m]`                                                                |
+| `{{MODEL}}`           | `claude-opus-4-8[1m]`                                                                |
 | `{{WIKI}}`            | `"true"` or `"false"`                                                                |
 | `{{KATA_AGENT_REF}}`  | `b4a5b262f3d7acaee2da63f8b2a09bcf4730d804 # v1.0.0`                                  |
 

--- a/libraries/libeval/src/agent-runner.js
+++ b/libraries/libeval/src/agent-runner.js
@@ -10,6 +10,32 @@ import { AGENT_MODEL } from "@forwardimpact/libutil/models";
 
 const DEFAULT_ALLOWED_TOOLS = ["Bash", "Read", "Glob", "Grep", "Write", "Edit"];
 
+/**
+ * Did the session actually invoke the model? A genuine run always bills
+ * tokens (the system prompt alone is thousands of input tokens) and costs
+ * more than zero. A `result` message with `subtype: "success"` but zero
+ * token usage and zero cost means the model was never reached — the
+ * canonical signature of a Claude Code init/auth failure (e.g. an invalid
+ * `ANTHROPIC_API_KEY`), which the SDK otherwise reports as a clean success.
+ *
+ * If the SDK gave us neither a `usage` object nor `total_cost_usd`, don't
+ * second-guess the subtype — trust the reported success.
+ * @param {object|null} result - The SDK `result` message, or null.
+ * @returns {boolean}
+ */
+function modelDidWork(result) {
+  if (!result) return false;
+  const { usage, total_cost_usd: cost } = result;
+  if (usage == null && cost == null) return true;
+  const tokens = usage
+    ? (usage.input_tokens ?? 0) +
+      (usage.output_tokens ?? 0) +
+      (usage.cache_creation_input_tokens ?? 0) +
+      (usage.cache_read_input_tokens ?? 0)
+    : 0;
+  return tokens > 0 || (cost ?? 0) > 0;
+}
+
 // fit-eval and kata-action run headless in CI/CD with no human to answer
 // permission prompts. The SDK is always launched in bypass mode — not
 // overridable — so a future caller can't accidentally reduce permissions.
@@ -148,6 +174,7 @@ export class AgentRunner {
   async #consumeQuery(iterator) {
     let text = "";
     let stopReason = null;
+    let resultMessage = null;
     let error = null;
     let aborted = false;
 
@@ -157,6 +184,7 @@ export class AgentRunner {
         if (message.type === "result") {
           text = message.result ?? "";
           stopReason = message.subtype;
+          resultMessage = message;
         }
       }
     } catch (err) {
@@ -167,8 +195,23 @@ export class AgentRunner {
       }
     }
 
+    // A "success" subtype is necessary but not sufficient: the SDK reports a
+    // failed init (e.g. an invalid API key) as success with zero model work.
+    // Require evidence the model actually ran, and surface a clear error when
+    // it didn't, so the masked failure can't be reported as a green run.
+    const reportedSuccess = stopReason === "success";
+    const success =
+      reportedSuccess &&
+      resultMessage?.is_error !== true &&
+      modelDidWork(resultMessage);
+    if (reportedSuccess && !success && !error) {
+      error = new Error(
+        "agent reported success but performed no model work (zero token usage) — likely a Claude Code init or authentication failure",
+      );
+    }
+
     return {
-      success: stopReason === "success",
+      success,
       text,
       sessionId: this.sessionId,
       error,

--- a/libraries/libeval/src/commands/run.js
+++ b/libraries/libeval/src/commands/run.js
@@ -140,5 +140,7 @@ export async function runRunCommand(ctx) {
     await new Promise((r) => fileStream.end(r));
   }
 
-  return result.success ? { ok: true } : { ok: false, code: 1, error: "" };
+  return result.success
+    ? { ok: true }
+    : { ok: false, code: 1, error: result.error?.message ?? "" };
 }

--- a/libraries/libeval/test/agent-runner.test.js
+++ b/libraries/libeval/test/agent-runner.test.js
@@ -204,6 +204,86 @@ describe("AgentRunner", () => {
     assert.strictEqual(result.text, "Stopped");
   });
 
+  test("run() returns success=false when result reports success but did no model work", async () => {
+    // The SDK reports a failed init (e.g. invalid API key) as a clean
+    // "success" with zero turns, zero cost, and zero token usage. That must
+    // not pass as a green run — require evidence the model actually ran.
+    const messages = [
+      { type: "system", subtype: "init", session_id: "sess-noauth" },
+      {
+        type: "result",
+        subtype: "success",
+        result: "",
+        num_turns: 1,
+        total_cost_usd: 0,
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+    ];
+
+    const output = new PassThrough();
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: mockQuery(messages),
+      output,
+      redactor: noop(),
+    });
+
+    const result = await runner.run("Task");
+    assert.strictEqual(result.success, false);
+    assert.ok(result.error);
+    assert.match(result.error.message, /no model work|authentication/i);
+  });
+
+  test("run() returns success=true when result reports success with real token usage", async () => {
+    const messages = [
+      { type: "system", subtype: "init", session_id: "sess-ok" },
+      {
+        type: "result",
+        subtype: "success",
+        result: "Done.",
+        num_turns: 5,
+        total_cost_usd: 0.0523,
+        usage: { input_tokens: 350, output_tokens: 42 },
+      },
+    ];
+
+    const output = new PassThrough();
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: mockQuery(messages),
+      output,
+      redactor: noop(),
+    });
+
+    const result = await runner.run("Task");
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.error, null);
+  });
+
+  test("run() returns success=false when result is flagged is_error despite success subtype", async () => {
+    const messages = [
+      {
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        result: "",
+        total_cost_usd: 0.01,
+        usage: { input_tokens: 100, output_tokens: 5 },
+      },
+    ];
+
+    const output = new PassThrough();
+    const runner = new AgentRunner({
+      cwd: "/tmp",
+      query: mockQuery(messages),
+      output,
+      redactor: noop(),
+    });
+
+    const result = await runner.run("Task");
+    assert.strictEqual(result.success, false);
+  });
+
   test("resume() passes sessionId via options.resume", async () => {
     let resumeCapture = null;
 

--- a/libraries/libutil/src/models.js
+++ b/libraries/libutil/src/models.js
@@ -13,7 +13,7 @@
  * Long-horizon agents under direct evaluation (eval sessions) — most
  * capable model with the 1M-context suffix.
  */
-export const AGENT_MODEL = "claude-fable-5[1m]";
+export const AGENT_MODEL = "claude-opus-4-8[1m]";
 
 /**
  * Lead roles — supervisor, facilitator, discussion lead, benchmark
@@ -22,7 +22,7 @@ export const AGENT_MODEL = "claude-fable-5[1m]";
  * suffix is an Agent SDK identifier; use CHAT_MODEL or FAST_MODEL for
  * direct Messages API calls.
  */
-export const LEAD_MODEL = "claude-fable-5[1m]";
+export const LEAD_MODEL = "claude-opus-4-8[1m]";
 
 /**
  * Benchmark agent-under-test — a pinned reference model so pass@k


### PR DESCRIPTION
## Summary

The Kata: Shift workflow drove every agent on `claude-fable-5[1m]`, which is no longer reachable with the CI `ANTHROPIC_API_KEY`. Claude Code failed at init (`Invalid API key`) and did zero work, but the eval runner reported that as a clean success (subtype `success`, 1 turn, `$0.00`), so CI stayed green while the agent team silently no-op'd.

- Switch `AGENT_MODEL` and `LEAD_MODEL` defaults from `claude-fable-5[1m]` to `claude-opus-4-8[1m]`, and update the five skill docs the `model-defaults` invariant cross-checks.
- `AgentRunner` now treats a `success` result as a failure when no model work occurred (zero token usage **and** zero cost) or the result is flagged `is_error`, and surfaces a clear error. `fit-eval run` propagates that message so the run exits non-zero instead of passing as green. The guard returns "did work" when the SDK provides neither `usage` nor `total_cost_usd`, so the existing credit-exhausted test stays correct. Because the fix is in the shared `AgentRunner`, it also protects `supervise` / `facilitate` / `discuss`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJLVsztnHnKepQ8MDrqt6p)_