### PR TITLE
fix(deps): resolve 4 high-severity audit advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "libraries/libbridge": {
       "name": "@forwardimpact/libbridge",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@forwardimpact/libhttp": "^0.1.0",
         "@forwardimpact/libtype": "^0.1.0",
@@ -40,7 +40,7 @@
     },
     "libraries/libcoaligned": {
       "name": "@forwardimpact/libcoaligned",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "bin": {
         "coaligned": "./bin/coaligned.js",
       },
@@ -56,7 +56,7 @@
     },
     "libraries/libcodegen": {
       "name": "@forwardimpact/libcodegen",
-      "version": "0.1.62",
+      "version": "0.1.64",
       "bin": {
         "fit-codegen": "./bin/fit-codegen.js",
       },
@@ -69,7 +69,7 @@
         "@grpc/proto-loader": "^0.8.1",
         "mustache": "^4.2.0",
         "protobufjs": "^7.6.3",
-        "protobufjs-cli": "1.2.2",
+        "protobufjs-cli": "1.3.3",
       },
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
@@ -89,7 +89,7 @@
     },
     "libraries/libdoc": {
       "name": "@forwardimpact/libdoc",
-      "version": "0.2.35",
+      "version": "0.2.36",
       "bin": {
         "fit-doc": "./bin/fit-doc.js",
       },
@@ -115,7 +115,7 @@
     },
     "libraries/libeval": {
       "name": "@forwardimpact/libeval",
-      "version": "0.1.60",
+      "version": "0.1.63",
       "bin": {
         "fit-eval": "./bin/fit-eval.js",
         "fit-trace": "./bin/fit-trace.js",
@@ -139,7 +139,7 @@
     },
     "libraries/libformat": {
       "name": "@forwardimpact/libformat",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "marked": "^18.0.5",
         "marked-terminal": "^7.3.0",
@@ -151,7 +151,7 @@
     },
     "libraries/libgraph": {
       "name": "@forwardimpact/libgraph",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "bin": {
         "fit-process-graphs": "./bin/fit-process-graphs.js",
         "fit-subjects": "./bin/fit-subjects.js",
@@ -174,7 +174,7 @@
     },
     "libraries/libhttp": {
       "name": "@forwardimpact/libhttp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@hono/node-server": "^2.0.4",
         "hono": "^4.12.25",
@@ -264,7 +264,7 @@
     },
     "libraries/librc": {
       "name": "@forwardimpact/librc",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "bin": {
         "fit-rc": "./bin/fit-rc.js",
       },
@@ -292,7 +292,7 @@
     },
     "libraries/libresource": {
       "name": "@forwardimpact/libresource",
-      "version": "0.1.115",
+      "version": "0.1.116",
       "bin": {
         "fit-process-resources": "./bin/fit-process-resources.js",
       },
@@ -317,7 +317,7 @@
     },
     "libraries/librpc": {
       "name": "@forwardimpact/librpc",
-      "version": "0.1.106",
+      "version": "0.1.108",
       "bin": {
         "fit-unary": "./bin/fit-unary.js",
       },
@@ -355,7 +355,7 @@
     },
     "libraries/libstorage": {
       "name": "@forwardimpact/libstorage",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "bin": {
         "fit-storage": "./bin/fit-storage.js",
       },
@@ -375,7 +375,7 @@
     },
     "libraries/libsupervise": {
       "name": "@forwardimpact/libsupervise",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "bin": {
         "fit-logger": "./bin/fit-logger.js",
         "fit-svscan": "./bin/fit-svscan.js",
@@ -477,7 +477,7 @@
     },
     "libraries/libterrain": {
       "name": "@forwardimpact/libterrain",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "bin": {
         "fit-terrain": "./bin/fit-terrain.js",
       },
@@ -507,7 +507,7 @@
     },
     "libraries/libtype": {
       "name": "@forwardimpact/libtype",
-      "version": "0.1.79",
+      "version": "0.1.82",
       "dependencies": {
         "@forwardimpact/libsecret": "^0.1.3",
         "@forwardimpact/libutil": "^0.1.60",
@@ -520,14 +520,14 @@
     },
     "libraries/libui": {
       "name": "@forwardimpact/libui",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "devDependencies": {
         "happy-dom": "^20.10.2",
       },
     },
     "libraries/libutil": {
       "name": "@forwardimpact/libutil",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "bin": {
         "fit-download-bundle": "./bin/fit-download-bundle.js",
         "fit-tiktoken": "./bin/fit-tiktoken.js",
@@ -545,7 +545,7 @@
     },
     "libraries/libvector": {
       "name": "@forwardimpact/libvector",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "bin": {
         "fit-process-vectors": "./bin/fit-process-vectors.js",
         "fit-search": "./bin/fit-search.js",
@@ -568,7 +568,7 @@
     },
     "libraries/libwiki": {
       "name": "@forwardimpact/libwiki",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "bin": {
         "fit-wiki": "./bin/fit-wiki.js",
       },
@@ -586,7 +586,7 @@
     },
     "libraries/libxmr": {
       "name": "@forwardimpact/libxmr",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "bin": {
         "fit-xmr": "./bin/fit-xmr.js",
       },
@@ -627,7 +627,7 @@
     },
     "products/guide": {
       "name": "@forwardimpact/guide",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "bin": {
         "fit-guide": "./bin/fit-guide.js",
       },
@@ -661,7 +661,7 @@
     },
     "products/landmark": {
       "name": "@forwardimpact/landmark",
-      "version": "0.1.25",
+      "version": "0.1.27",
       "bin": {
         "fit-landmark": "./bin/fit-landmark.js",
       },
@@ -683,7 +683,7 @@
     },
     "products/map": {
       "name": "@forwardimpact/map",
-      "version": "0.15.57",
+      "version": "0.15.59",
       "bin": {
         "fit-map": "./bin/fit-map.js",
       },
@@ -714,7 +714,7 @@
     },
     "products/outpost": {
       "name": "@forwardimpact/outpost",
-      "version": "3.2.2",
+      "version": "3.3.0",
       "bin": {
         "fit-outpost": "./bin/fit-outpost.js",
       },
@@ -733,7 +733,7 @@
     },
     "products/pathway": {
       "name": "@forwardimpact/pathway",
-      "version": "0.26.2",
+      "version": "0.26.4",
       "bin": {
         "fit-pathway": "./bin/fit-pathway.js",
       },
@@ -759,7 +759,7 @@
     },
     "products/summit": {
       "name": "@forwardimpact/summit",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "bin": {
         "fit-summit": "./bin/fit-summit.js",
       },
@@ -899,10 +899,7 @@
     },
     "services/map": {
       "name": "@forwardimpact/svcmap",
-      "version": "0.1.7",
-      "bin": {
-        "fit-svcmap": "./server.js",
-      },
+      "version": "0.1.9",
       "dependencies": {
         "@forwardimpact/libconfig": "^0.1.58",
         "@forwardimpact/libpreflight": "^0.1.0",
@@ -983,10 +980,7 @@
     },
     "services/oidc": {
       "name": "@forwardimpact/svcoidc",
-      "version": "0.1.2",
-      "bin": {
-        "fit-svcoidc": "./server.js",
-      },
+      "version": "0.1.4",
       "dependencies": {
         "@forwardimpact/libconfig": "^0.1.79",
         "@forwardimpact/libhttp": "^0.1.0",
@@ -1092,15 +1086,16 @@
     "brace-expansion": "^5.0.6",
     "fast-uri": "^3.1.2",
     "fast-xml-builder": "^1.1.7",
+    "form-data": "^4.0.6",
     "hono": "^4.12.25",
     "ip-address": "^10.2.0",
     "lodash": "^4.18.0",
     "postcss": "^8.5.10",
     "protobufjs": "^7.6.3",
     "qs": "^6.15.2",
-    "tmp": "^0.2.6",
+    "tmp": "^0.2.7",
     "uuid": "^11.1.1",
-    "ws": "^8.20.1",
+    "ws": "^8.21.0",
   },
   "packages": {
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.170", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.170", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.170", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.170", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.170", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.170" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-pAvhfk+iTodXZ6RF18Kz7BEUWFjL7EcR3tKuhUNdPpE1NAYCR3mSHGbafi72JsrNwKEDIs7FU31z3fqhwy8QzA=="],
@@ -1801,7 +1796,7 @@
 
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -1843,7 +1838,7 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
@@ -2101,7 +2096,7 @@
 
     "protobufjs": ["protobufjs@7.6.3", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw=="],
 
-    "protobufjs-cli": ["protobufjs-cli@1.2.2", "", { "dependencies": { "chalk": "^4.0.0", "escodegen": "^1.13.0", "espree": "^9.0.0", "estraverse": "^5.1.0", "glob": "^8.0.0", "jsdoc": "^4.0.0", "minimist": "^1.2.0", "semver": "^7.1.2", "tmp": "^0.2.1", "uglify-js": "^3.7.7" }, "peerDependencies": { "protobufjs": ">=7.5.6 <8" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-gc27fy6Om+92g4UxqOs9ECTc3Xy7zXsnBSFR0dCSEvIRG8cn3eU8x+CcN8ouBB3EjIBVnEOeQb0iVKC4lnBoKA=="],
+    "protobufjs-cli": ["protobufjs-cli@1.3.3", "", { "dependencies": { "chalk": "^4.0.0", "escodegen": "^1.13.0", "espree": "^9.0.0", "estraverse": "^5.1.0", "glob": "^8.0.0", "jsdoc": "^4.0.0", "minimist": "^1.2.0", "semver": "^7.1.2", "tmp": "^0.2.1", "uglify-js": "^3.7.7" }, "peerDependencies": { "protobufjs": "^7.6.2" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-zwmt6JeStPjeofZbl+QADexAVzP1EgsIAsO7mCfKkW/8oBxHwgTqJ1aD7zDrcCC0Nb+SLWSvCR3RDaKgIO3P8w=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -2217,7 +2212,7 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
-    "tmp": ["tmp@0.2.6", "", {}, "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="],
+    "tmp": ["tmp@0.2.7", "", {}, "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="],
 
     "to-valid-identifier": ["to-valid-identifier@1.0.0", "", { "dependencies": { "@sindresorhus/base62": "^1.0.0", "reserved-identifiers": "^1.0.0" } }, "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw=="],
 
@@ -2281,7 +2276,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
@@ -2373,6 +2368,8 @@
 
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "es-set-tostringtag/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
     "escodegen/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
     "escodegen/optionator": ["optionator@0.8.3", "", { "dependencies": { "deep-is": "~0.1.3", "fast-levenshtein": "~2.0.6", "levn": "~0.3.0", "prelude-ls": "~1.1.2", "type-check": "~0.3.2", "word-wrap": "~1.2.3" } }, "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA=="],
@@ -2390,6 +2387,8 @@
     "express/range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "get-intrinsic/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
@@ -2418,8 +2417,6 @@
     "protobufjs-cli/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "protobufjs-cli/espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
-
-    "protobufjs-cli/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 

--- a/libraries/libcodegen/package.json
+++ b/libraries/libcodegen/package.json
@@ -53,7 +53,7 @@
     "@grpc/proto-loader": "^0.8.1",
     "mustache": "^4.2.0",
     "protobufjs": "^7.6.3",
-    "protobufjs-cli": "1.2.2"
+    "protobufjs-cli": "1.3.3"
   },
   "devDependencies": {
     "@forwardimpact/libmock": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -63,15 +63,16 @@
     "brace-expansion": "^5.0.6",
     "fast-uri": "^3.1.2",
     "fast-xml-builder": "^1.1.7",
+    "form-data": "^4.0.6",
     "hono": "^4.12.25",
     "ip-address": "^10.2.0",
     "lodash": "^4.18.0",
     "postcss": "^8.5.10",
     "protobufjs": "^7.6.3",
     "qs": "^6.15.2",
-    "tmp": "^0.2.6",
+    "tmp": "^0.2.7",
     "uuid": "^11.1.1",
-    "ws": "^8.20.1"
+    "ws": "^8.21.0"
   },
   "engines": {
     "bun": ">=1.2.0",


### PR DESCRIPTION
## Summary

Clears all 4 high-severity findings from `bun audit --audit-level=high`:

- **form-data** 4.0.5 → 4.0.6 (root override added) — CRLF injection [GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx), transitive via `svcmsbridge → botbuilder`.
- **tmp** 0.2.6 → 0.2.7 (override floor raised) — path traversal [GHSA-7c78-jf6q-g5cm](https://github.com/advisories/GHSA-7c78-jf6q-g5cm), transitive via `libcodegen → protobufjs-cli`.
- **ws** 8.20.1 → 8.21.0 (override floor raised) — memory-exhaustion DoS [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p), transitive via `libui → happy-dom` and `svcmsbridge → botbuilder`.
- **protobufjs-cli** 1.2.2 → 1.3.3 (libcodegen direct dep) — pbjs code injection [GHSA-pr59-h9ph-3fr8](https://github.com/advisories/GHSA-pr59-h9ph-3fr8).

Held protobufjs-cli at **1.3.3** (peers `protobufjs ^7.6.2`, satisfied by the existing `^7.6.3` override) rather than 2.x, which peers `protobufjs ^8` and would force a protobufjs 7→8 migration; 2.0.0/2.0.1 are themselves vulnerable. `protobufjs` stays 7.6.3.

Remaining: `markdown-it` [GHSA-6v5v-wf23-fmfq](https://github.com/advisories/GHSA-6v5v-wf23-fmfq) (moderate, below the `--audit-level=high` gate) left untouched.

## Test plan

- [x] `bun audit --audit-level=high` clean
- [x] `bun run test` — 4530 pass, 0 fail
- [x] `fit-codegen --all` output byte-identical (no diff in `generated/`)
- [x] All bumped packages resolve to a single version (no duplicates)
- [ ] `bun run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)