### PR TITLE
fix(libtelemetry,libwiki): inject-aware logging and graceful no-wiki

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,12 +35,22 @@
         ]
       }
     ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/bootstrap.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "just wiki-push"
+            "command": "bunx fit-wiki push"
           }
         ]
       }

--- a/bun.lock
+++ b/bun.lock
@@ -577,6 +577,7 @@
         "@forwardimpact/libconfig": "^0.1.77",
         "@forwardimpact/libeval": "^0.1.49",
         "@forwardimpact/libpreflight": "^0.1.0",
+        "@forwardimpact/libtelemetry": "^0.1.47",
         "@forwardimpact/libutil": "^0.1.0",
         "@forwardimpact/libxmr": "^2.0.0",
       },

--- a/libraries/libbridge/test/link-resume-log-redaction.test.js
+++ b/libraries/libbridge/test/link-resume-log-redaction.test.js
@@ -23,12 +23,12 @@
  *       handler invocation under a real logger must not produce any
  *       captured log line carrying the link_token.
  *
- * Pattern: `@forwardimpact/libtelemetry` `Logger` writes via `console.error`
- * (see `libraries/libtelemetry/src/logger.js:94,108,130,159`), not
- * `process.stdout`. Rebind `console.error` for the duration of the test
- * matching the existing pattern at `libraries/libutil/test/logger.test.js:16-22`
- * (`originalConsoleError = console.error; console.error = (m) =>
- * consoleOutput.push(m);` with restore in `afterEach`).
+ * Pattern: `@forwardimpact/libtelemetry` `Logger` writes through its injected
+ * `runtime.proc.stderr` (see `libraries/libtelemetry/src/logger.js` `#emit`).
+ * The loggers under test are therefore built on a `captureRuntime` whose
+ * `proc.stderr` pushes into `captured`. The global `console.error`/`console.log`
+ * are also captured as a defensive secondary net, so a future leak via either
+ * sink still trips the assertion.
  *
  * Future ghuser (b) and services/bridge (d) integration with full logger
  * wiring would extend this fixture to assert the same invariant across the
@@ -57,6 +57,29 @@ const TRUSTED = loadTrustedIdpOrigins("https://github.com");
 const NOW = 1_700_000_000_000;
 const clock = { now: () => NOW };
 
+/**
+ * Runtime whose `proc.stderr` captures each line into `sink`, so logger output
+ * lands where the test can assert on it. The Logger writes through the injected
+ * `runtime.proc.stderr`, never the global `console`.
+ * @param {string[]} sink - Array that receives each written line.
+ * @returns {import("@forwardimpact/libutil/runtime").Runtime}
+ */
+function captureRuntime(sink) {
+  const base = createDefaultRuntime();
+  return {
+    ...base,
+    proc: {
+      ...base.proc,
+      stderr: {
+        write: (s) => {
+          sink.push(String(s));
+          return true;
+        },
+      },
+    },
+  };
+}
+
 describe("link-resume log redaction (O4 (a))", () => {
   let originalConsoleError;
   let originalConsoleLog;
@@ -81,7 +104,7 @@ describe("link-resume log redaction (O4 (a))", () => {
   }
 
   test("loader (a): refused entries log a warn but never the link token", () => {
-    const runtime = createDefaultRuntime();
+    const runtime = captureRuntime(captured);
     const bridgeLogger = createLogger("ghbridge", runtime);
     loadTrustedIdpOrigins(`not-a-url, http://github.com, https://github.com`, {
       logger: bridgeLogger,
@@ -144,7 +167,7 @@ describe("link-resume log redaction (O4 (a))", () => {
   });
 
   test("end-to-end mint→prepare→consume drives every libbridge primitive with a real logger and leaks no token", async () => {
-    const runtime = createDefaultRuntime();
+    const runtime = captureRuntime(captured);
     const bridgeLogger = createLogger("ghbridge", runtime);
 
     const trusted = loadTrustedIdpOrigins("https://github.com", {

--- a/libraries/libtelemetry/src/logger.js
+++ b/libraries/libtelemetry/src/logger.js
@@ -24,7 +24,9 @@ export class Logger {
    * Creates a new Logger instance
    * @param {string} domain - Domain or service area for this logger instance
    * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime - Injected
-   *   runtime bag; supplies the `proc` (env access) and `clock` collaborators.
+   *   runtime bag; supplies the `proc` (env access plus the `stderr` sink) and
+   *   `clock` collaborators. All output goes to `runtime.proc.stderr` so logs
+   *   follow the injected runtime and are captured wherever it is.
    */
   constructor(domain, runtime) {
     if (!domain || typeof domain !== "string") {
@@ -91,7 +93,7 @@ export class Logger {
       return;
     }
 
-    console.error(this.#formatLine("DEBUG", appId, message, attributes));
+    this.#emit(this.#formatLine("DEBUG", appId, message, attributes));
   }
 
   /**
@@ -105,7 +107,21 @@ export class Logger {
       return;
     }
 
-    console.error(this.#formatLine("INFO", appId, message, attributes));
+    this.#emit(this.#formatLine("INFO", appId, message, attributes));
+  }
+
+  /**
+   * Logs a warning message unless LOG_LEVEL is set below warn (i.e. error).
+   * @param {string} [appId] - Application identifier or method name
+   * @param {string} [message] - The log message
+   * @param {object} [attributes] - Optional key-value pairs to append to the message
+   */
+  warn(appId, message, attributes = {}) {
+    if (this.#level < LEVELS.warn) {
+      return;
+    }
+
+    this.#emit(this.#formatLine("WARN", appId, message, attributes));
   }
 
   /**
@@ -127,7 +143,7 @@ export class Logger {
     // Merge trace context with provided attributes
     const enrichedAttributes = { ...traceContext, ...attributes };
 
-    console.error(
+    this.#emit(
       this.#formatLine("ERROR", appId, errorMessage, enrichedAttributes),
     );
   }
@@ -156,9 +172,18 @@ export class Logger {
     // Merge trace context with provided attributes
     const enrichedAttributes = { ...traceContext, ...attributes };
 
-    console.error(
-      this.#formatLine("ERROR", appId, message, enrichedAttributes),
-    );
+    this.#emit(this.#formatLine("ERROR", appId, message, enrichedAttributes));
+  }
+
+  /**
+   * Write a formatted line to the injected process's stderr. The Logger emits
+   * to `runtime.proc.stderr` — never the global `console` — so output follows
+   * the injected runtime and is captured wherever that runtime is.
+   * @param {string} line - The formatted log line (no trailing newline).
+   * @private
+   */
+  #emit(line) {
+    this.#process.stderr.write(line + "\n");
   }
 
   /**

--- a/libraries/libutil/test/logger.test.js
+++ b/libraries/libutil/test/logger.test.js
@@ -5,25 +5,51 @@ import assert from "node:assert";
 import { Logger, createLogger } from "@forwardimpact/libtelemetry";
 import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 
+/**
+ * A runtime whose `proc.stderr` captures every line into `sink`, with the live
+ * `proc.env` (so `process.env.DEBUG`/`LOG_LEVEL` changes are visible) and real
+ * clock preserved. The Logger writes through `runtime.proc.stderr`, so tests
+ * inject this rather than patching the global `console`.
+ * @param {string[]} sink - Array that receives each written line.
+ * @returns {import("@forwardimpact/libutil/runtime").Runtime}
+ */
+function captureRuntime(sink) {
+  const base = createDefaultRuntime();
+  return {
+    ...base,
+    proc: {
+      ...base.proc,
+      stderr: {
+        write: (s) => {
+          sink.push(String(s));
+          return true;
+        },
+      },
+    },
+  };
+}
+
 describe("Logger", () => {
   let originalDebug;
-  let consoleOutput;
-  let originalConsoleError;
+  let originalLogLevel;
+  let output;
+  let runtime;
 
   beforeEach(() => {
     originalDebug = process.env.DEBUG;
-    consoleOutput = [];
-    originalConsoleError = console.error;
-    console.error = (message) => consoleOutput.push(message);
+    originalLogLevel = process.env.LOG_LEVEL;
+    output = [];
+    runtime = captureRuntime(output);
   });
 
   afterEach(() => {
     process.env.DEBUG = originalDebug;
-    console.error = originalConsoleError;
+    if (originalLogLevel === undefined) delete process.env.LOG_LEVEL;
+    else process.env.LOG_LEVEL = originalLogLevel;
   });
 
   test("creates Logger with domain", () => {
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     assert.ok(logger instanceof Logger);
     assert.strictEqual(logger.domain, "test");
@@ -33,7 +59,7 @@ describe("Logger", () => {
     assert.throws(() => new Logger(), {
       message: /domain must be a non-empty string/,
     });
-    assert.throws(() => new Logger("", createDefaultRuntime()), {
+    assert.throws(() => new Logger("", runtime), {
       message: /domain must be a non-empty string/,
     });
     assert.throws(() => new Logger(null), {
@@ -43,85 +69,115 @@ describe("Logger", () => {
 
   test("enables logging when DEBUG=*", () => {
     process.env.DEBUG = "*";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     assert.strictEqual(logger.enabled, true);
   });
 
   test("disables logging when DEBUG is empty", () => {
     process.env.DEBUG = "";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     assert.strictEqual(logger.enabled, false);
   });
 
   test("enables logging for exact domain match", () => {
     process.env.DEBUG = "test,other";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     assert.strictEqual(logger.enabled, true);
   });
 
   test("enables logging for wildcard pattern match", () => {
     process.env.DEBUG = "test*";
-    const logger = new Logger("test:service", createDefaultRuntime());
+    const logger = new Logger("test:service", runtime);
 
     assert.strictEqual(logger.enabled, true);
   });
 
   test("disables logging for non-matching domain", () => {
     process.env.DEBUG = "other";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     assert.strictEqual(logger.enabled, false);
   });
 
   test("logs debug message when enabled", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     logger.debug("TestApp", "Test message");
 
-    assert.strictEqual(consoleOutput.length, 1);
-    assert.ok(consoleOutput[0].includes("DEBUG"));
-    assert.ok(consoleOutput[0].includes("test"));
-    assert.ok(consoleOutput[0].includes("TestApp"));
-    assert.ok(consoleOutput[0].includes("Test message"));
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].includes("DEBUG"));
+    assert.ok(output[0].includes("test"));
+    assert.ok(output[0].includes("TestApp"));
+    assert.ok(output[0].includes("Test message"));
   });
 
   test("does not log when disabled", () => {
     process.env.DEBUG = "other";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     logger.debug("TestApp", "Test message");
 
-    assert.strictEqual(consoleOutput.length, 0);
+    assert.strictEqual(output.length, 0);
+  });
+
+  test("warn logs at the default level", () => {
+    const logger = new Logger("test", runtime);
+
+    logger.warn("TestApp", "Heads up");
+
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].includes("WARN"));
+    assert.ok(output[0].includes("Heads up"));
+  });
+
+  test("warn is suppressed when LOG_LEVEL=error", () => {
+    process.env.LOG_LEVEL = "error";
+    const logger = new Logger("test", runtime);
+
+    logger.warn("TestApp", "Heads up");
+
+    assert.strictEqual(output.length, 0);
+  });
+
+  test("error always logs regardless of LOG_LEVEL", () => {
+    process.env.LOG_LEVEL = "error";
+    const logger = new Logger("test", runtime);
+
+    logger.error("TestMethod", "boom");
+
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].includes("ERROR"));
+    assert.ok(output[0].includes("boom"));
   });
 
   test("handles empty data object", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     logger.debug("TestApp", "Test message", {});
 
-    assert.strictEqual(consoleOutput.length, 1);
-    assert.ok(consoleOutput[0].includes("DEBUG"));
-    assert.ok(consoleOutput[0].includes("Test message"));
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].includes("DEBUG"));
+    assert.ok(output[0].includes("Test message"));
   });
 
   test("includes timestamp in log output", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     logger.debug("TestApp", "Test message");
 
-    assert.strictEqual(consoleOutput.length, 1);
-    assert.ok(consoleOutput[0].match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/));
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/));
   });
 
   test("merges trace context with provided attributes", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     const error = new Error("Test error");
     Object.defineProperty(error, "trace_id", {
@@ -132,49 +188,49 @@ describe("Logger", () => {
 
     logger.error("TestMethod", error, { retry: "1/3", status: "500" });
 
-    assert.strictEqual(consoleOutput.length, 1);
-    assert.ok(consoleOutput[0].includes('trace_id="trace123"'));
-    assert.ok(consoleOutput[0].includes('retry="1/3"'));
-    assert.ok(consoleOutput[0].includes('status="500"'));
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].includes('trace_id="trace123"'));
+    assert.ok(output[0].includes('retry="1/3"'));
+    assert.ok(output[0].includes('status="500"'));
   });
 
   test("exception logs message when disabled", () => {
     process.env.DEBUG = "other";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     const error = new Error("Test error");
 
     logger.exception("TestMethod", error);
 
-    assert.strictEqual(consoleOutput.length, 1);
-    assert.ok(consoleOutput[0].includes("ERROR"));
-    assert.ok(consoleOutput[0].includes("Test error"));
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].includes("ERROR"));
+    assert.ok(output[0].includes("Test error"));
     assert.ok(
-      !consoleOutput[0].includes("at "),
+      !output[0].includes("at "),
       "Should not include stack trace when disabled",
     );
   });
 
   test("exception logs message with stack trace when enabled", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     const error = new Error("Test error");
 
     logger.exception("TestMethod", error);
 
-    assert.strictEqual(consoleOutput.length, 1);
-    assert.ok(consoleOutput[0].includes("ERROR"));
-    assert.ok(consoleOutput[0].includes("Test error"));
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].includes("ERROR"));
+    assert.ok(output[0].includes("Test error"));
     assert.ok(
-      consoleOutput[0].includes("at "),
+      output[0].includes("at "),
       "Should include stack trace when enabled",
     );
   });
 
   test("exception extracts trace context from error", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     const error = new Error("Test error");
     error.trace_id = "trace456";
@@ -183,24 +239,24 @@ describe("Logger", () => {
 
     logger.exception("TestMethod", error);
 
-    assert.strictEqual(consoleOutput.length, 1);
-    assert.ok(consoleOutput[0].includes('trace_id="trace456"'));
-    assert.ok(consoleOutput[0].includes('span_id="span789"'));
-    assert.ok(consoleOutput[0].includes('service_name="my-service"'));
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].includes('trace_id="trace456"'));
+    assert.ok(output[0].includes('span_id="span789"'));
+    assert.ok(output[0].includes('service_name="my-service"'));
   });
 
   test("exception merges trace context with provided attributes", () => {
     process.env.DEBUG = "test";
-    const logger = new Logger("test", createDefaultRuntime());
+    const logger = new Logger("test", runtime);
 
     const error = new Error("Test error");
     error.trace_id = "trace123";
 
     logger.exception("TestMethod", error, { retry: "2/3" });
 
-    assert.strictEqual(consoleOutput.length, 1);
-    assert.ok(consoleOutput[0].includes('trace_id="trace123"'));
-    assert.ok(consoleOutput[0].includes('retry="2/3"'));
+    assert.strictEqual(output.length, 1);
+    assert.ok(output[0].includes('trace_id="trace123"'));
+    assert.ok(output[0].includes('retry="2/3"'));
   });
 });
 

--- a/libraries/libwiki/bin/fit-wiki.js
+++ b/libraries/libwiki/bin/fit-wiki.js
@@ -6,8 +6,13 @@ import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
 import { GitClient } from "@forwardimpact/libutil/git-client";
 import { createScriptConfig } from "@forwardimpact/libconfig";
 import { createCli } from "@forwardimpact/libcli";
+import { createLogger } from "@forwardimpact/libtelemetry";
 import { WikiSync } from "../src/wiki-sync.js";
-import { resolveProjectRoot, resolveWikiRoot } from "../src/util/wiki-dir.js";
+import {
+  resolveProjectRoot,
+  resolveWikiRoot,
+  wikiExists,
+} from "../src/util/wiki-dir.js";
 import { createDefinition } from "../src/cli-definition.js";
 
 // Commands that mutate or sync the remote wiki need a constructed WikiSync
@@ -35,6 +40,21 @@ async function main() {
   if (!definition.commands.some((c) => c.name === command)) {
     cli.usageError(`unknown command "${command}"`);
     return runtime.proc.exit(2);
+  }
+
+  // Every command except `init` operates on an existing wiki tree. When it is
+  // absent (e.g. a fresh worktree where bootstrap.sh never ran), degrade
+  // gracefully: warn and exit 0 so the session Stop hook and other callers do
+  // not fail loudly. `init` is exempt — it creates the tree.
+  if (command !== "init") {
+    const wikiDir = resolveWikiRoot(runtime, parsed.values);
+    if (!wikiExists(runtime, wikiDir)) {
+      createLogger("wiki", runtime).warn(
+        command,
+        `no wiki at ${wikiDir}; skipping (run \`fit-wiki init\` to create one)`,
+      );
+      return runtime.proc.exit(0);
+    }
   }
 
   const gitClient = new GitClient({ runtime });

--- a/libraries/libwiki/package.json
+++ b/libraries/libwiki/package.json
@@ -49,6 +49,7 @@
     "@forwardimpact/libconfig": "^0.1.77",
     "@forwardimpact/libeval": "^0.1.49",
     "@forwardimpact/libpreflight": "^0.1.0",
+    "@forwardimpact/libtelemetry": "^0.1.47",
     "@forwardimpact/libutil": "^0.1.0",
     "@forwardimpact/libxmr": "^2.0.0"
   },

--- a/libraries/libwiki/src/commands/claim.js
+++ b/libraries/libwiki/src/commands/claim.js
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { addDays } from "@forwardimpact/libutil";
+import { createLogger } from "@forwardimpact/libtelemetry";
 import {
   appendClaim,
   removeClaim,
@@ -28,7 +29,10 @@ async function pushWiki(wikiSync, runtime, message) {
     if (result.pushed)
       runtime.proc.stdout.write("push: committed and pushed\n");
   } catch (err) {
-    runtime.proc.stderr.write(`push failed (saved locally): ${err.message}\n`);
+    createLogger("wiki", runtime).warn(
+      "claim",
+      `push failed (saved locally): ${err.message}`,
+    );
   }
 }
 
@@ -64,8 +68,9 @@ export async function runClaimCommand(ctx) {
     expires_at: expires,
   });
   if (!result.inserted) {
-    runtime.proc.stderr.write(
-      `claim already exists for ${agent}/${options.target}\n`,
+    createLogger("wiki", runtime).warn(
+      "claim",
+      `claim already exists for ${agent}/${options.target}`,
     );
     return { ok: false, code: 2 };
   }

--- a/libraries/libwiki/src/commands/fix.js
+++ b/libraries/libwiki/src/commands/fix.js
@@ -16,6 +16,7 @@ import {
 import { currentDayIso } from "../util/clock.js";
 import { resolveProjectRoot } from "../util/wiki-dir.js";
 import { FAST_MODEL } from "@forwardimpact/libutil/models";
+import { createLogger } from "@forwardimpact/libtelemetry";
 
 // Pipeline: audit → deterministic rotation (the one fix needing a file seal the
 // agent can't do) → re-audit → Haiku agent on the prose-judgment residual →
@@ -276,7 +277,8 @@ export async function runFixCommand(ctx) {
   const wikiRoot = ctx.options["wiki-root"] || path.join(projectRoot, "wiki");
   const today = ctx.options.today || currentDayIso(runtime);
   const out = (s) => runtime.proc.stdout.write(s);
-  const err = (s) => runtime.proc.stderr.write(s);
+  const logger = createLogger("wiki", runtime);
+  const err = (s) => logger.warn("fix", String(s).replace(/\n+$/, ""));
 
   // The agent's edits change the result, so re-read and re-audit each round.
   const audit = () =>

--- a/libraries/libwiki/src/commands/inbox.js
+++ b/libraries/libwiki/src/commands/inbox.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { createLogger } from "@forwardimpact/libtelemetry";
 import {
   MEMO_INBOX_MARKER,
   PRIORITY_INDEX_HEADING,
@@ -11,8 +12,9 @@ function paths(runtime, options) {
   const wikiRoot = resolveWikiRoot(runtime, options);
   const agent = options.agent || runtime.proc.env.LIBEVAL_AGENT_PROFILE;
   if (!agent) {
-    runtime.proc.stderr.write(
-      "inbox requires --agent or LIBEVAL_AGENT_PROFILE\n",
+    createLogger("wiki", runtime).warn(
+      "inbox",
+      "inbox requires --agent or LIBEVAL_AGENT_PROFILE",
     );
     return { error: { ok: false, code: 2 } };
   }
@@ -67,13 +69,13 @@ function ackOrDropCmd(runtime, options) {
   const { summaryPath } = p;
   const idx = Number.parseInt(options.index ?? "", 10);
   if (!Number.isInteger(idx) || idx < 0) {
-    runtime.proc.stderr.write("inbox requires --index <n>\n");
+    createLogger("wiki", runtime).warn("inbox", "inbox requires --index <n>");
     return { ok: false, code: 2 };
   }
   const text = runtime.fsSync.readFileSync(summaryPath, "utf-8");
   const { lines, bulletIdxs } = readInboxBullets(text);
   if (idx >= bulletIdxs.length) {
-    runtime.proc.stderr.write(`no bullet at index ${idx}\n`);
+    createLogger("wiki", runtime).warn("inbox", `no bullet at index ${idx}`);
     return { ok: false, code: 2 };
   }
   removeBulletAt(lines, bulletIdxs[idx]);
@@ -134,13 +136,16 @@ function promoteCmd(runtime, options) {
   const { summaryPath, memoryPath, agent } = p;
   const idx = Number.parseInt(options.index ?? "", 10);
   if (!Number.isInteger(idx) || idx < 0) {
-    runtime.proc.stderr.write("inbox promote requires --index <n>\n");
+    createLogger("wiki", runtime).warn(
+      "inbox",
+      "inbox promote requires --index <n>",
+    );
     return { ok: false, code: 2 };
   }
   const text = runtime.fsSync.readFileSync(summaryPath, "utf-8");
   const { lines, bullets, bulletIdxs } = readInboxBullets(text);
   if (idx >= bullets.length) {
-    runtime.proc.stderr.write(`no bullet at index ${idx}\n`);
+    createLogger("wiki", runtime).warn("inbox", `no bullet at index ${idx}`);
     return { ok: false, code: 2 };
   }
   const bulletText = bullets[idx].replace(/^[-*]\s+/, "");

--- a/libraries/libwiki/src/commands/init.js
+++ b/libraries/libwiki/src/commands/init.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { createLogger } from "@forwardimpact/libtelemetry";
 import { listSkills } from "../skill-roster.js";
 import { resolveProjectRoot, resolveWikiRoot } from "../util/wiki-dir.js";
 import {
@@ -53,19 +54,19 @@ function scaffoldActiveClaims(runtime, memoryPath) {
 }
 
 async function maybeCloneWiki(wikiSync, gitClient, projectRoot, runtime) {
+  const logger = createLogger("wiki", runtime);
   const wikiUrl = await deriveWikiUrl(gitClient, projectRoot, runtime.proc.env);
   if (!wikiUrl) {
-    runtime.proc.stderr.write(
-      "init: could not determine wiki URL from origin remote\n",
-    );
+    logger.warn("init", "could not determine wiki URL from origin remote");
     return;
   }
   const cloneResult = await wikiSync.ensureCloned(wikiUrl);
   if (cloneResult.cloned) {
     await wikiSync.inheritIdentity();
   } else {
-    runtime.proc.stderr.write(
-      "init: could not clone wiki, continuing with local-only steps\n",
+    logger.warn(
+      "init",
+      "could not clone wiki, continuing with local-only steps",
     );
   }
 }

--- a/libraries/libwiki/src/commands/log.js
+++ b/libraries/libwiki/src/commands/log.js
@@ -1,3 +1,4 @@
+import { createLogger } from "@forwardimpact/libtelemetry";
 import {
   weeklyLogPath,
   rotateIfOverBudget,
@@ -10,8 +11,9 @@ import { resolveWikiRoot } from "../util/wiki-dir.js";
 function commonContext(runtime, options) {
   const agent = options.agent || runtime.proc.env.LIBEVAL_AGENT_PROFILE;
   if (!agent) {
-    runtime.proc.stderr.write(
-      "log requires --agent <name> or LIBEVAL_AGENT_PROFILE env var\n",
+    createLogger("wiki", runtime).warn(
+      "log",
+      "log requires --agent <name> or LIBEVAL_AGENT_PROFILE env var",
     );
     return { error: { ok: false, code: 2 } };
   }
@@ -49,14 +51,15 @@ function rotateBeforeAppend(wikiRoot, agent, today, appendLines, runtime) {
       runtime.fsSync,
     );
     if (res.status === "incomplete") {
-      runtime.proc.stderr.write(
-        `note: day-section ${res.residue.section} alone exceeds the budget ` +
+      createLogger("wiki", runtime).warn(
+        "log",
+        `day-section ${res.residue.section} alone exceeds the budget ` +
           `(${res.residue.lines} lines, ${res.residue.words} words); ` +
-          `sealed as ${res.residue.path} for manual recovery\n`,
+          `sealed as ${res.residue.path} for manual recovery`,
       );
     }
   } catch (e) {
-    runtime.proc.stderr.write(`note: rotation failed: ${e.message}\n`);
+    createLogger("wiki", runtime).warn("log", `rotation failed: ${e.message}`);
   }
 }
 
@@ -95,7 +98,10 @@ function runNote(runtime, options) {
   if (ctx.error) return ctx.error;
   const { agent, wikiRoot, today } = ctx;
   if (!options.field || !options.body) {
-    runtime.proc.stderr.write("log note requires --field and --body\n");
+    createLogger("wiki", runtime).warn(
+      "log",
+      "log note requires --field and --body",
+    );
     return { ok: false, code: 2 };
   }
   const fieldBlock = `### ${options.field}\n\n${options.body}\n`;

--- a/libraries/libwiki/src/commands/memo.js
+++ b/libraries/libwiki/src/commands/memo.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { createLogger } from "@forwardimpact/libtelemetry";
 import { writeMemo } from "../memo-writer.js";
 import { listAgents } from "../agent-roster.js";
 import { BROADCAST_TARGET } from "../constants.js";
@@ -11,8 +12,9 @@ function writeAndCheck(runtime, summaryPath, sender, message, today) {
     runtime.fsSync,
   );
   if (!result.written) {
-    runtime.proc.stderr.write(
-      `summary lacks memo:inbox marker: ${result.path}\n`,
+    createLogger("wiki", runtime).warn(
+      "memo",
+      `summary lacks memo:inbox marker: ${result.path}`,
     );
     return { ok: false, code: 2 };
   }

--- a/libraries/libwiki/src/commands/refresh.js
+++ b/libraries/libwiki/src/commands/refresh.js
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { yearMonth } from "@forwardimpact/libutil";
+import { createLogger } from "@forwardimpact/libtelemetry";
 import { createScriptConfig } from "@forwardimpact/libconfig";
 import { scanMarkers } from "../marker-scanner.js";
 import { renderBlock, BlockRenderError } from "../block-renderer.js";
@@ -69,6 +70,7 @@ function readStoryboardOrNull(runtime, storyboardPath) {
 export async function runRefreshCommand(ctx) {
   const { runtime, gitClient } = ctx.deps;
   const options = ctx.options;
+  const logger = createLogger("wiki", runtime);
   const projectRoot = resolveProjectRoot(runtime);
 
   const storyboardPath = path.resolve(
@@ -77,11 +79,11 @@ export async function runRefreshCommand(ctx) {
   );
   const text = readStoryboardOrNull(runtime, storyboardPath);
   if (text === null) {
-    runtime.proc.stderr.write(`refresh: no storyboard at ${storyboardPath}\n`);
+    logger.warn("refresh", `no storyboard at ${storyboardPath}`);
     return { ok: true };
   }
   const blocks = scanMarkers(text, {
-    warn: (message) => runtime.proc.stderr.write(message),
+    warn: (message) => logger.warn("refresh", message),
   });
   if (blocks.length === 0) return { ok: true };
 
@@ -122,8 +124,9 @@ export async function runRefreshCommand(ctx) {
       spliced = true;
     } catch (err) {
       if (!(err instanceof BlockRenderError)) throw err;
-      runtime.proc.stderr.write(
-        `refresh-error ${storyboardPath}:${block.openLine + 1} ${err.message}\n`,
+      logger.error(
+        "refresh",
+        `refresh-error ${storyboardPath}:${block.openLine + 1} ${err.message}`,
       );
     }
   }

--- a/libraries/libwiki/src/commands/rotate.js
+++ b/libraries/libwiki/src/commands/rotate.js
@@ -1,3 +1,4 @@
+import { createLogger } from "@forwardimpact/libtelemetry";
 import { rotateIfOverBudget, weeklyLogPath } from "../weekly-log.js";
 import { currentDayIso } from "../util/clock.js";
 import { resolveWikiRoot } from "../util/wiki-dir.js";
@@ -5,6 +6,7 @@ import { resolveWikiRoot } from "../util/wiki-dir.js";
 /** Force-rotate the current weekly log to a sealed part file. */
 export function runRotateCommand(ctx) {
   const { runtime } = ctx.deps;
+  const logger = createLogger("wiki", runtime);
   const options = ctx.options;
   const agent = options.agent || runtime.proc.env.LIBEVAL_AGENT_PROFILE;
   if (!agent) {
@@ -34,7 +36,7 @@ export function runRotateCommand(ctx) {
       runtime.fsSync,
     );
   } catch (e) {
-    runtime.proc.stderr.write(`rotate failed: ${e.message}\n`);
+    logger.error("rotate", `rotate failed: ${e.message}`);
     return { ok: false, code: 1 };
   }
   switch (result.status) {
@@ -51,12 +53,13 @@ export function runRotateCommand(ctx) {
         runtime.proc.stdout.write(`sealed → ${part}\n`);
       }
       const { section, lines, words, path: residuePath } = result.residue;
-      runtime.proc.stderr.write(
+      logger.error(
+        "rotate",
         `day-section ${section} alone exceeds the budget ` +
           `(${lines} lines, ${words} words) and cannot be split at a day ` +
           `seam: ${residuePath}\n` +
           `recover it by hand — bisect the section at a finer seam ` +
-          `(see the memory protocol's manual-recovery convention)\n`,
+          `(see the memory protocol's manual-recovery convention)`,
       );
       return { ok: false, code: 1 };
     }

--- a/libraries/libwiki/src/commands/sync.js
+++ b/libraries/libwiki/src/commands/sync.js
@@ -1,3 +1,4 @@
+import { createLogger } from "@forwardimpact/libtelemetry";
 import { WikiPullConflict } from "../wiki-sync.js";
 
 /** Commit all wiki changes and push them to the remote wiki repository. */
@@ -25,8 +26,9 @@ export async function runPullCommand(ctx) {
     return { ok: true };
   } catch (err) {
     if (err instanceof WikiPullConflict) {
-      runtime.proc.stderr.write(
-        "fit-wiki pull: rebase conflict — local divergence detected; resolve manually or push first\n",
+      createLogger("wiki", runtime).error(
+        "pull",
+        "rebase conflict — local divergence detected; resolve manually or push first",
       );
       return { ok: false, code: 1 };
     }

--- a/libraries/libwiki/src/issue-list-renderer.js
+++ b/libraries/libwiki/src/issue-list-renderer.js
@@ -1,4 +1,5 @@
 import { addDays } from "@forwardimpact/libutil";
+import { createLogger } from "@forwardimpact/libtelemetry";
 
 /** Parse `owner/repo` from a git origin URL. Tolerates http(s), ssh, and proxy-rewritten URLs (e.g. `http://host/git/owner/repo`) by taking the last two path segments after stripping `.git`. Returns null when nothing parseable is found. */
 export function parseRepoSlug(originUrl) {
@@ -54,8 +55,9 @@ export async function renderIssueList({
   const env = token ? { ...runtime.proc.env, GH_TOKEN: token } : undefined;
   const result = await runtime.subprocess.run("gh", args, { cwd, env });
   if (result.exitCode !== 0) {
-    runtime.proc.stderr.write(
-      `refresh: gh issue list failed for ${topic}:${state}\n`,
+    createLogger("wiki", runtime).warn(
+      "refresh",
+      `gh issue list failed for ${topic}:${state}`,
     );
     return [];
   }
@@ -63,8 +65,9 @@ export async function renderIssueList({
   try {
     issues = JSON.parse(result.stdout || "[]");
   } catch {
-    runtime.proc.stderr.write(
-      `refresh: gh issue list JSON parse failed for ${topic}:${state}\n`,
+    createLogger("wiki", runtime).warn(
+      "refresh",
+      `gh issue list JSON parse failed for ${topic}:${state}`,
     );
     return [];
   }

--- a/libraries/libwiki/src/util/wiki-dir.js
+++ b/libraries/libwiki/src/util/wiki-dir.js
@@ -22,3 +22,16 @@ export function resolveProjectRoot(runtime) {
 export function resolveWikiRoot(runtime, options = {}) {
   return options["wiki-root"] || path.join(resolveProjectRoot(runtime), "wiki");
 }
+
+/**
+ * Report whether the resolved wiki root exists on disk. Commands that read or
+ * sync an existing wiki use this to degrade gracefully (warn and exit 0) when
+ * the tree was never bootstrapped — e.g. a fresh worktree where
+ * `scripts/bootstrap.sh` did not run.
+ * @param {import('@forwardimpact/libutil/runtime').Runtime} runtime
+ * @param {string} wikiDir - The resolved wiki root.
+ * @returns {boolean}
+ */
+export function wikiExists(runtime, wikiDir) {
+  return runtime.fsSync.existsSync(wikiDir);
+}

--- a/libraries/libwiki/test/fit-wiki-smoke.integration.test.js
+++ b/libraries/libwiki/test/fit-wiki-smoke.integration.test.js
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 
 // The one allow-listed smoke test per binary: it spawns the real bin to
 // prove the runtime/dispatch wiring end-to-end. Every other libwiki command is
@@ -55,5 +55,22 @@ describe("fit-wiki bin smoke", () => {
       readFileSync(memoryPath, "utf-8"),
       /staff-engineer \| test-smoke \| test/,
     );
+  });
+
+  test("warns and exits 0 when the wiki tree is missing", () => {
+    // A project root with no wiki/ — e.g. a fresh worktree where bootstrap.sh
+    // never ran. The session Stop hook (`fit-wiki push`) must not fail loudly.
+    const bare = mkdtempSync(join(tmpdir(), "fit-wiki-nowiki-"));
+    writeFileSync(join(bare, "package.json"), '{"name":"root"}');
+    try {
+      const result = spawnSync("node", [CLI_PATH, "push"], {
+        cwd: bare,
+        encoding: "utf-8",
+      });
+      assert.equal(result.status, 0, "missing wiki exits 0");
+      assert.match(result.stderr, /no wiki at/);
+    } finally {
+      rmSync(bare, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **libtelemetry**: the `Logger` now emits through the injected `runtime.proc.stderr` (single `#emit` helper) instead of global `console.error`, restoring dependency injection. Adds the missing `warn()` method (`LEVELS.warn` existed with no method, yet `libdoc`/`libsyntheticgen` already called it).
- **libwiki**: commands other than `init` now warn and exit 0 when `wiki/` is missing (e.g. a fresh worktree where `bootstrap.sh` never ran) instead of failing the session Stop hook. All diagnostics route through the libtelemetry `Logger`; command results stay on stdout.
- **hooks**: the Stop hook runs `bunx fit-wiki push` directly (not `just wiki-push`); a new `WorktreeCreate` hook runs `scripts/bootstrap.sh`. In-session `EnterWorktree` bypasses that hook today, which the graceful no-wiki behavior makes harmless.
- Migrated the two consumer tests that captured `console.error` (libutil logger, libbridge link-resume redaction) to inject a capturing `proc.stderr`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`