### PR TITLE
feat(libeval): track cost across all agent participants

### DIFF
--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -23,7 +23,8 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
-      - uses: forwardimpact/kata-agent@b4a5b262f3d7acaee2da63f8b2a09bcf4730d804 # v1
+      - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
+        id: agent
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
@@ -34,3 +35,18 @@ jobs:
           lead-profile: "improvement-coach"
           agent-profiles: "${{ inputs.agent }}"
           task-amend: ${{ inputs.task-amend }}
+
+      # Sum spend across every participant from the trace kata-agent exposes.
+      # Cost logic lives in the `fit-trace` CLI; this step only reads the
+      # path and redirects the markdown summary.
+      - name: Report run cost
+        if: always()
+        shell: bash
+        env:
+          TRACE_FILE: ${{ steps.agent.outputs.trace-file }}
+        run: |
+          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
+            bunx fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No trace file produced — cost not reported."
+          fi

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -134,6 +134,18 @@ jobs:
           discussion-id: ${{ inputs.discussion_id }}
           resume-context: ${{ inputs.resume_context }}
 
+      - name: Report run cost
+        if: always()
+        shell: bash
+        env:
+          TRACE_FILE: ${{ steps.assess.outputs.trace-file }}
+        run: |
+          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
+            bunx fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No trace file produced — cost not reported."
+          fi
+
       # Push agent memory back with a freshly minted token — the token from
       # job start expires after an hour and this run can take up to five.
       - name: Push wiki changes

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -112,6 +112,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run interview
+        id: interview
         uses: forwardimpact/fit-eval@c616487598df0840ce237ee375ad7a9837213714 # v1
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -135,6 +136,18 @@ jobs:
           allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,WebFetch,WebSearch"
           supervisor-allowed-tools: "Bash,Read,Glob,Grep,Write,Edit,Skill,TodoWrite"
           task-amend: ${{ steps.amend.outputs.amend }}
+
+      - name: Report run cost
+        if: always()
+        shell: bash
+        env:
+          TRACE_FILE: ${{ steps.interview.outputs.trace-file }}
+        run: |
+          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
+            bunx fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No trace file produced — cost not reported."
+          fi
 
       - name: Push wiki changes
         if: always()

--- a/.github/workflows/kata-shift.yml
+++ b/.github/workflows/kata-shift.yml
@@ -36,7 +36,8 @@ jobs:
           - { name: release-engineer }
           - { name: improvement-coach }
     steps:
-      - uses: forwardimpact/kata-agent@b4a5b262f3d7acaee2da63f8b2a09bcf4730d804 # v1
+      - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
+        id: agent
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
@@ -48,3 +49,18 @@ jobs:
           task-text: >-
             Assess the current state of your domain and act on the highest-priority finding.
           task-amend: ${{ inputs.task-amend }}
+
+      # Sum spend across every participant from the trace kata-agent exposes.
+      # Each matrix cell reports its own cost. Cost logic lives in the
+      # `fit-trace` CLI; this step only reads the path and redirects the summary.
+      - name: Report run cost
+        if: always()
+        shell: bash
+        env:
+          TRACE_FILE: ${{ steps.agent.outputs.trace-file }}
+        run: |
+          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
+            bunx fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No trace file produced — cost not reported."
+          fi

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -22,7 +22,8 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
-      - uses: forwardimpact/kata-agent@b4a5b262f3d7acaee2da63f8b2a09bcf4730d804 # v1
+      - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
+        id: agent
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           app-private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
@@ -33,3 +34,18 @@ jobs:
           lead-profile: "improvement-coach"
           agent-profiles: "security-engineer,technical-writer,product-manager,staff-engineer,release-engineer"
           task-amend: ${{ inputs.task-amend }}
+
+      # Sum spend across every participant from the trace kata-agent exposes.
+      # Cost logic lives in the `fit-trace` CLI; this step only reads the
+      # path and redirects the markdown summary.
+      - name: Report run cost
+        if: always()
+        shell: bash
+        env:
+          TRACE_FILE: ${{ steps.agent.outputs.trace-file }}
+        run: |
+          if [ -n "${TRACE_FILE:-}" ] && [ -f "$TRACE_FILE" ]; then
+            bunx fit-trace cost "$TRACE_FILE" --markdown >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No trace file produced — cost not reported."
+          fi

--- a/libraries/libeval/bin/fit-trace.js
+++ b/libraries/libeval/bin/fit-trace.js
@@ -22,6 +22,7 @@ import {
   runReasoningCommand,
   runTimelineCommand,
   runStatsCommand,
+  runCostCommand,
   runInitCommand,
   runTurnCommand,
   runFilterCommand,
@@ -174,6 +175,21 @@ const definition = {
       description: "Token usage and cost breakdown",
     },
     {
+      name: "cost",
+      args: ["file"],
+      argsUsage: "<file>",
+      handler: runCostCommand,
+      description:
+        "Total run cost across every participant (agent, supervisor, judge, named profiles), with a per-source breakdown",
+      options: {
+        markdown: {
+          type: "boolean",
+          description:
+            "Emit a GitHub-flavored markdown block (redirect into $GITHUB_STEP_SUMMARY)",
+        },
+      },
+    },
+    {
       name: "init",
       args: ["file"],
       argsUsage: "<file>",
@@ -299,6 +315,8 @@ const definition = {
     "fit-trace overview structured.json",
     "fit-trace timeline structured.json",
     "fit-trace stats structured.json",
+    "fit-trace cost trace.ndjson",
+    "fit-trace cost trace.ndjson --markdown",
     "fit-trace tool structured.json Conclude",
     "fit-trace search structured.json 'error|fail' --context 1",
     "fit-trace filter structured.json --tool Bash --error",

--- a/libraries/libeval/src/benchmark/judge.js
+++ b/libraries/libeval/src/benchmark/judge.js
@@ -23,11 +23,13 @@
 
 import { createJudge } from "../judge.js";
 import { createRedactor } from "../redaction.js";
+import { sumTraceCost } from "../cost.js";
 
 /**
  * @typedef {object} JudgeVerdict
  * @property {"pass" | "fail"} verdict
  * @property {string} summary
+ * @property {number} costUsd - Cost of the judge's own SDK session.
  */
 
 /**
@@ -81,12 +83,25 @@ export async function runJudge(task, workdir, invariants, deps, context) {
     await new Promise((r) => output.end(r));
   }
 
+  // The judge is its own SDK session; its spend lands in the judge trace we
+  // just wrote, not in the supervisor's combined trace. Read it back so the
+  // benchmark record's cost includes the judge.
+  const judgeTrace = await fs
+    .readFile(workdir.judgeTracePath, "utf8")
+    .catch(() => "");
+  const { totalCostUsd } = sumTraceCost(judgeTrace.split("\n"));
+
   if (outcome.verdict === null) {
-    return { verdict: "fail", summary: "judge did not conclude" };
+    return {
+      verdict: "fail",
+      summary: "judge did not conclude",
+      costUsd: totalCostUsd,
+    };
   }
   return {
     verdict: outcome.verdict === "success" ? "pass" : "fail",
     summary: outcome.summary ?? "",
+    costUsd: totalCostUsd,
   };
 }
 

--- a/libraries/libeval/src/benchmark/result.js
+++ b/libraries/libeval/src/benchmark/result.js
@@ -27,6 +27,17 @@ const JUDGE_VERDICT_SHAPE = z.object({
   summary: z.string(),
 });
 
+/**
+ * Per-participant cost attribution. `costUsd` is the sum of these; the
+ * breakdown lets reports show where the spend went. The judge runs as its
+ * own SDK session, so its cost is tracked separately from agent/supervisor.
+ */
+const COST_BREAKDOWN_SHAPE = z.object({
+  agent: z.number(),
+  supervisor: z.number(),
+  judge: z.number(),
+});
+
 const PROFILES_SHAPE = z.object({
   agent: z.union([z.string(), z.null()]),
   supervisor: z.union([z.string(), z.null()]),
@@ -44,6 +55,7 @@ const COMMON_FIELDS = {
   runIndex: z.number().int().min(0),
   verdict: VERDICT_ENUM,
   costUsd: z.number(),
+  costBreakdown: COST_BREAKDOWN_SHAPE.optional(),
   turns: z.number().int().min(0),
   profiles: PROFILES_SHAPE,
   model: z.object({

--- a/libraries/libeval/src/benchmark/runner.js
+++ b/libraries/libeval/src/benchmark/runner.js
@@ -18,6 +18,7 @@ import { createInterface } from "node:readline";
 import { join, resolve as resolvePath } from "node:path";
 
 import { DEFAULT_ENV_ALLOWLIST, createRedactor } from "../redaction.js";
+import { sumTraceCost } from "../cost.js";
 import { createSupervisor } from "../supervisor.js";
 import { installApm as defaultInstallApm } from "./apm-installer.js";
 import { installNpm as defaultInstallNpm } from "./npm-installer.js";
@@ -193,8 +194,9 @@ export class BenchmarkRunner {
           resultsRecordKey(task, runIndex),
         );
       }
-      const { costUsd, turns, submission, agentError } =
-        await this.#runAgentSafe(task, workdir);
+      const agentRun = await this.#runAgentSafe(task, workdir);
+      const { costUsd, turns, submission, agentError } = agentRun;
+      const breakdown = agentRun.costBreakdown ?? { agent: 0, supervisor: 0 };
       const invariants = await this._runInvariantsHook(
         task,
         {
@@ -206,13 +208,14 @@ export class BenchmarkRunner {
         this.runtime,
       );
       let judgeVerdict = null;
+      let judgeCost = 0;
       if (task.paths.judge) {
         const judgeContext = await this.#buildJudgeContext(
           task,
           workdir,
           skillSetHash,
         );
-        judgeVerdict = await this._runJudgeHook(
+        const judgeResult = await this._runJudgeHook(
           task,
           workdir,
           invariants,
@@ -225,6 +228,13 @@ export class BenchmarkRunner {
           },
           judgeContext,
         );
+        judgeCost = judgeResult.costUsd ?? 0;
+        // The record's judgeVerdict carries only the verdict + summary; the
+        // judge's cost is folded into costUsd / costBreakdown instead.
+        judgeVerdict = {
+          verdict: judgeResult.verdict,
+          summary: judgeResult.summary,
+        };
       }
       const verdict =
         invariants.verdict === "pass" &&
@@ -238,7 +248,12 @@ export class BenchmarkRunner {
         invariants,
         submission,
         ...(judgeVerdict && { judgeVerdict }),
-        costUsd,
+        costUsd: costUsd + judgeCost,
+        costBreakdown: {
+          agent: breakdown.agent ?? 0,
+          supervisor: breakdown.supervisor ?? 0,
+          judge: judgeCost,
+        },
         turns,
         agentTracePath: workdir.agentTracePath,
         supervisorTracePath: workdir.supervisorTracePath,
@@ -280,6 +295,7 @@ export class BenchmarkRunner {
     } catch (e) {
       return {
         costUsd: 0,
+        costBreakdown: { agent: 0, supervisor: 0 },
         turns: 0,
         submission: "",
         agentError: { message: e.message ?? String(e), aborted: false },
@@ -334,8 +350,20 @@ export class BenchmarkRunner {
       workdir.agentTracePath,
       workdir.supervisorTracePath,
     );
+    // Cost is summed across every participant's result events from the one
+    // combined trace, attributed per source. Read before unlinking.
+    const combined = await fs.readFile(combinedPath, "utf8");
+    const { totalCostUsd, bySource } = sumTraceCost(combined.split("\n"));
     await fs.unlink(combinedPath).catch(() => {});
-    return { ...summary, agentError };
+    return {
+      ...summary,
+      costUsd: totalCostUsd,
+      costBreakdown: {
+        agent: bySource.agent ?? 0,
+        supervisor: bySource.supervisor ?? 0,
+      },
+      agentError,
+    };
   }
 
   async #buildJudgeContext(task, workdir, skillSetHash) {
@@ -441,10 +469,13 @@ async function writeRecord(stream, record) {
 }
 
 /**
- * Split the combined supervisor trace into agent and supervisor files, and
- * extract cost, turn count, and submission in a single pass. Agent-source
- * events go to `agentPath`; supervisor and orchestrator events go to
- * `supervisorPath`.
+ * Split the combined supervisor trace into agent and supervisor files and
+ * extract turn count and submission in a single pass. Agent-source events go
+ * to `agentPath`; supervisor and orchestrator events go to `supervisorPath`.
+ *
+ * Cost is deliberately not summed here — the caller derives it from the same
+ * combined trace via `sumTraceCost`, so there is one cost path across the
+ * benchmark, callback, and `fit-trace cost` consumers.
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: stream-splitting state machine
 async function splitAndSummarize(
@@ -460,8 +491,6 @@ async function splitAndSummarize(
     input: fs.createReadStream(combinedPath),
     crlfDelay: Infinity,
   });
-  let agentCost = 0;
-  let supervisorCost = 0;
   let turns = 0;
   let submission = "";
   for await (const line of rl) {
@@ -476,19 +505,9 @@ async function splitAndSummarize(
     target.write(line + "\n");
     const inner = event.event;
     if (!inner) continue;
-    if (event.source === "agent") {
-      if (inner.type === "result" && typeof inner.total_cost_usd === "number") {
-        agentCost = inner.total_cost_usd;
-      }
-      if (inner.type === "assistant") {
-        const text = extractText(inner);
-        if (text) submission = text;
-      }
-    }
-    if (event.source === "supervisor") {
-      if (inner.type === "result" && typeof inner.total_cost_usd === "number") {
-        supervisorCost = inner.total_cost_usd;
-      }
+    if (event.source === "agent" && inner.type === "assistant") {
+      const text = extractText(inner);
+      if (text) submission = text;
     }
     if (event.source === "orchestrator" && inner.type === "summary") {
       turns = inner.turns ?? 0;
@@ -498,7 +517,7 @@ async function splitAndSummarize(
     new Promise((r) => agentStream.end(r)),
     new Promise((r) => supStream.end(r)),
   ]);
-  return { costUsd: agentCost + supervisorCost, turns, submission };
+  return { turns, submission };
 }
 
 function extractText(inner) {

--- a/libraries/libeval/src/commands/callback.js
+++ b/libraries/libeval/src/commands/callback.js
@@ -1,3 +1,5 @@
+import { sumTraceCost } from "../cost.js";
+
 /**
  * Scan an NDJSON trace and return the last orchestrator summary event,
  * the first `meta` event's `discussion_id`, and any structured replies
@@ -8,15 +10,14 @@
  * "adjourned"/"recessed"/"failed" from discuss). The bridge layer maps to
  * its channel semantics.
  *
- * @param {string} traceFile
- * @param {object} fsSync - Sync filesystem surface (`runtime.fsSync`).
+ * @param {string} content - Raw NDJSON trace content.
  * @returns {{verdict: string, summary: string, replies: object[], trigger?: object, discussionId?: string} | null}
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: NDJSON scan with malformed-line tolerance + meta/summary dual extraction
-function readTraceSummary(traceFile, fsSync) {
+function readTraceSummary(content) {
   let summary = null;
   let metaDiscussionId = null;
-  for (const line of fsSync.readFileSync(traceFile, "utf8").split("\n")) {
+  for (const line of content.split("\n")) {
     if (!line.trim()) continue;
     let record;
     try {
@@ -83,11 +84,15 @@ export async function runCallbackCommand(ctx) {
   if (!callbackUrl)
     return { ok: false, code: 1, error: "--callback-url is required" };
 
-  const found = readTraceSummary(traceFile, runtime.fsSync) ?? {
+  const content = runtime.fsSync.readFileSync(traceFile, "utf8");
+  const found = readTraceSummary(content) ?? {
     verdict: "failed",
     summary: "Run ended without producing a summary.",
     replies: [],
   };
+  // Total spend across every participant in the trace — the bridge surfaces
+  // it alongside the verdict so a dispatched run reports what it cost.
+  const { totalCostUsd } = sumTraceCost(content.split("\n"));
 
   const discussionId = found.discussionId ?? discussionIdOverride ?? null;
   const payload = {
@@ -96,6 +101,7 @@ export async function runCallbackCommand(ctx) {
     verdict: found.verdict,
     summary: found.summary,
     run_url: runUrl,
+    cost_usd: totalCostUsd,
     replies: found.replies,
     last_acted_seq: found.lastActedSeq ?? -1,
     ...(discussionId && { discussion_id: discussionId }),

--- a/libraries/libeval/src/commands/trace.js
+++ b/libraries/libeval/src/commands/trace.js
@@ -1,6 +1,6 @@
 import { join, dirname } from "node:path";
 import { isoTimestamp } from "@forwardimpact/libutil";
-import { createTraceCollector } from "@forwardimpact/libeval";
+import { createTraceCollector, sumTraceCost } from "@forwardimpact/libeval";
 import { createTraceQuery } from "../trace-query.js";
 import { createTraceGitHub } from "../trace-github.js";
 import { stripSignatures } from "../signature-filter.js";
@@ -193,6 +193,51 @@ export async function runStatsCommand(ctx) {
   return { ok: true };
 }
 
+/**
+ * Total run cost across every participant (agent, supervisor, judge, and any
+ * named profile), summed from each `result` event in the trace and attributed
+ * per source. The combined trace from a supervised, facilitated, or discuss
+ * session already interleaves all participants, so one file yields the whole
+ * run's spend. Default output is `{totalCostUsd, bySource}` JSON; `--markdown`
+ * emits a GitHub-flavored block to redirect into `$GITHUB_STEP_SUMMARY`.
+ *
+ * @param {import("@forwardimpact/libcli").InvocationContext} ctx
+ */
+export async function runCostCommand(ctx) {
+  const { runtime } = ctx.deps;
+  const cost = computeTraceCost(
+    runtime.fsSync.readFileSync(ctx.args.file, "utf8"),
+  );
+  if (ctx.options.markdown) {
+    runtime.proc.stdout.write(renderCostMarkdown(cost));
+  } else {
+    writeJSON(runtime, cost, ctx.options);
+  }
+  return { ok: true };
+}
+
+/**
+ * Render a cost summary as a GitHub-flavored markdown block for a CI step
+ * summary: a headline total plus a per-participant table (descending).
+ * @param {{totalCostUsd: number, bySource: Record<string, number>}} cost
+ * @returns {string}
+ */
+function renderCostMarkdown(cost) {
+  const lines = [
+    `### 💰 Run cost: $${cost.totalCostUsd.toFixed(4)}`,
+    "",
+    "Summed across every participant (agent, supervisor, judge, named profiles).",
+  ];
+  const sources = Object.entries(cost.bySource).sort((a, b) => b[1] - a[1]);
+  if (sources.length > 0) {
+    lines.push("", "| Participant | Cost (USD) |", "| --- | --- |");
+    for (const [source, usd] of sources) {
+      lines.push(`| ${source} | ${usd.toFixed(4)} |`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
 /** @param {import("@forwardimpact/libcli").InvocationContext} ctx */
 export async function runInitCommand(ctx) {
   const { runtime } = ctx.deps;
@@ -308,6 +353,25 @@ function parseBuckets(content) {
 }
 
 // --- Shared helpers ---
+
+/**
+ * Compute total + per-source cost from raw file content. A structured JSON
+ * trace (from `fit-trace download`) carries its total in `summary.totalCostUsd`
+ * but no per-source split; raw NDJSON is summed via `sumTraceCost`.
+ * @param {string} content - Raw file content (structured JSON or NDJSON).
+ * @returns {{totalCostUsd: number, bySource: Record<string, number>}}
+ */
+function computeTraceCost(content) {
+  try {
+    const parsed = JSON.parse(content);
+    if (parsed && typeof parsed.summary?.totalCostUsd === "number") {
+      return { totalCostUsd: parsed.summary.totalCostUsd, bySource: {} };
+    }
+  } catch {
+    // Not a single JSON object — treat as NDJSON below.
+  }
+  return sumTraceCost(content.split("\n"));
+}
 
 /**
  * Load a trace file. Supports structured JSON and raw NDJSON.

--- a/libraries/libeval/src/cost.js
+++ b/libraries/libeval/src/cost.js
@@ -1,0 +1,79 @@
+/**
+ * Cost aggregation over Claude Code NDJSON traces — the single source of
+ * truth for "how much did this run cost, across every participant?".
+ *
+ * The SDK reports the cumulative session cost on each `result` event as
+ * `total_cost_usd`. Supervised, facilitated, and discuss sessions interleave
+ * one runner's events with another's in a single combined trace, wrapping
+ * each in a `{source, seq, event}` envelope; a plain `run` trace carries bare
+ * events with no envelope. A judge runs as its own session in a separate
+ * trace. In every case the rule is the same: sum the `total_cost_usd` of each
+ * `result` event, and keep a per-source breakdown so callers can attribute
+ * spend to the agent, supervisor, judge, or any named participant.
+ *
+ * This mirrors `TraceCollector.handleResult`, which accumulates the same
+ * figure for its summary footer — kept as a standalone pure helper so the
+ * benchmark runner, the callback command, and `fit-trace cost` share one
+ * implementation rather than each re-deriving it (and drifting).
+ */
+
+/** Bucket key for bare (un-enveloped) `run`-mode events: a lone agent session. */
+export const UNSOURCED = "agent";
+
+/**
+ * Sum `total_cost_usd` across every `result` event in an NDJSON trace.
+ *
+ * @param {Iterable<string>} lines - NDJSON lines (e.g. `content.split("\n")`).
+ *   Blank and malformed lines are skipped.
+ * @returns {{totalCostUsd: number, bySource: Record<string, number>}}
+ *   `totalCostUsd` is the sum across all participants; `bySource` maps each
+ *   envelope `source` (or {@link UNSOURCED} for bare events) to its subtotal.
+ */
+export function sumTraceCost(lines) {
+  let totalCostUsd = 0;
+  /** @type {Record<string, number>} */
+  const bySource = {};
+
+  for (const line of lines) {
+    const parsed = parseCostLine(line);
+    if (!parsed) continue;
+    const { source, cost } = parsed;
+    totalCostUsd += cost;
+    bySource[source] = (bySource[source] ?? 0) + cost;
+  }
+
+  return { totalCostUsd, bySource };
+}
+
+/**
+ * Parse a single NDJSON line and return its `result`-event cost contribution,
+ * or null when the line is blank, malformed, not a result event, or carries
+ * no numeric `total_cost_usd`.
+ *
+ * @param {string} line
+ * @returns {{source: string, cost: number} | null}
+ */
+function parseCostLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  let event;
+  try {
+    event = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  // Unwrap the combined-trace envelope {source, seq, event}; bare events
+  // (plain `run` traces) have a `type` and no `source`.
+  let source = UNSOURCED;
+  if (event.event && !event.type && typeof event.source === "string") {
+    source = event.source;
+    event = event.event;
+  }
+
+  if (event.type !== "result") return null;
+  if (typeof event.total_cost_usd !== "number") return null;
+
+  return { source, cost: event.total_cost_usd };
+}

--- a/libraries/libeval/src/index.js
+++ b/libraries/libeval/src/index.js
@@ -1,5 +1,6 @@
 export { TraceCollector, createTraceCollector } from "./trace-collector.js";
 export { TraceQuery, createTraceQuery } from "./trace-query.js";
+export { sumTraceCost, UNSOURCED } from "./cost.js";
 export { stripSignatures } from "./signature-filter.js";
 export {
   TraceGitHub,

--- a/libraries/libeval/test/benchmark-result.test.js
+++ b/libraries/libeval/test/benchmark-result.test.js
@@ -86,6 +86,22 @@ describe("validateResultRecord", () => {
     };
     assert.doesNotThrow(() => validateResultRecord(withSupervisor));
   });
+
+  test("accepts a costBreakdown of agent/supervisor/judge", () => {
+    const withBreakdown = {
+      ...happy,
+      costBreakdown: { agent: 0.08, supervisor: 0.03, judge: 0.013 },
+    };
+    assert.doesNotThrow(() => validateResultRecord(withBreakdown));
+  });
+
+  test("rejects a costBreakdown missing the judge field", () => {
+    const broken = {
+      ...happy,
+      costBreakdown: { agent: 0.08, supervisor: 0.03 },
+    };
+    assert.throws(() => validateResultRecord(broken));
+  });
 });
 
 describe("validateInvariantsRecord", () => {

--- a/libraries/libeval/test/callback.test.js
+++ b/libraries/libeval/test/callback.test.js
@@ -110,6 +110,7 @@ describe("fit-eval callback", () => {
         verdict: "success",
         summary: "Routed to staff-engineer.",
         run_url: "https://github.com/foo/bar/actions/runs/42",
+        cost_usd: 0,
         replies: [],
         last_acted_seq: -1,
       });
@@ -173,6 +174,43 @@ describe("fit-eval callback", () => {
       assert.ok(req.body.summary.length > 0);
       assert.strictEqual(req.body.correlation_id, "x");
       assert.deepStrictEqual(req.body.replies, []);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("sums cost_usd across every participant's result events", async () => {
+    const server = await startServer(200);
+    const { tracePath, fsSync } = writeTrace([
+      {
+        source: "agent",
+        seq: 0,
+        event: { type: "result", total_cost_usd: 0.02 },
+      },
+      {
+        source: "supervisor",
+        seq: 1,
+        event: { type: "result", total_cost_usd: 0.05 },
+      },
+      {
+        source: "orchestrator",
+        seq: 2,
+        event: { type: "summary", verdict: "success", summary: "done" },
+      },
+    ]);
+
+    try {
+      await callback(
+        {
+          "trace-file": tracePath,
+          "callback-url": `${server.url}/api/callback/cost`,
+          "correlation-id": "c",
+        },
+        fsSync,
+      );
+
+      const req = server.getLastRequest();
+      assert.ok(Math.abs(req.body.cost_usd - 0.07) < 1e-9);
     } finally {
       await server.close();
     }

--- a/libraries/libeval/test/cost.test.js
+++ b/libraries/libeval/test/cost.test.js
@@ -1,0 +1,82 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+import { sumTraceCost, UNSOURCED } from "../src/cost.js";
+
+/** Build NDJSON lines from an array of records. */
+function lines(records) {
+  return records.map((r) => JSON.stringify(r));
+}
+
+describe("sumTraceCost", () => {
+  test("sums total_cost_usd across all sources in a combined trace", () => {
+    const { totalCostUsd, bySource } = sumTraceCost(
+      lines([
+        {
+          source: "agent",
+          seq: 0,
+          event: { type: "result", total_cost_usd: 0.02 },
+        },
+        {
+          source: "supervisor",
+          seq: 1,
+          event: { type: "result", total_cost_usd: 0.05 },
+        },
+        {
+          source: "judge",
+          seq: 2,
+          event: { type: "result", total_cost_usd: 0.01 },
+        },
+      ]),
+    );
+    assert.ok(Math.abs(totalCostUsd - 0.08) < 1e-9);
+    assert.deepStrictEqual(bySource, {
+      agent: 0.02,
+      supervisor: 0.05,
+      judge: 0.01,
+    });
+  });
+
+  test("accumulates multiple result events from the same source", () => {
+    const { totalCostUsd, bySource } = sumTraceCost(
+      lines([
+        {
+          source: "agent",
+          seq: 0,
+          event: { type: "result", total_cost_usd: 0.02 },
+        },
+        {
+          source: "agent",
+          seq: 1,
+          event: { type: "result", total_cost_usd: 0.03 },
+        },
+      ]),
+    );
+    assert.ok(Math.abs(totalCostUsd - 0.05) < 1e-9);
+    assert.ok(Math.abs(bySource.agent - 0.05) < 1e-9);
+  });
+
+  test("buckets bare (un-enveloped) result events under the agent source", () => {
+    const { totalCostUsd, bySource } = sumTraceCost(
+      lines([{ type: "result", total_cost_usd: 0.04 }]),
+    );
+    assert.ok(Math.abs(totalCostUsd - 0.04) < 1e-9);
+    assert.ok(Math.abs(bySource[UNSOURCED] - 0.04) < 1e-9);
+  });
+
+  test("ignores non-result events, blank lines, and malformed JSON", () => {
+    const { totalCostUsd, bySource } = sumTraceCost([
+      "",
+      "{not json",
+      JSON.stringify({ source: "agent", seq: 0, event: { type: "assistant" } }),
+      JSON.stringify({
+        source: "orchestrator",
+        seq: 1,
+        event: { type: "summary", verdict: "success" },
+      }),
+      JSON.stringify({ source: "agent", seq: 2, event: { type: "result" } }),
+    ]);
+    assert.strictEqual(totalCostUsd, 0);
+    assert.deepStrictEqual(bySource, {});
+  });
+});

--- a/libraries/libeval/test/trace-cost.test.js
+++ b/libraries/libeval/test/trace-cost.test.js
@@ -1,0 +1,53 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+
+import { createMockFs } from "@forwardimpact/libmock";
+
+import { runCostCommand } from "../src/commands/trace.js";
+
+const FILE = "/traces/trace--demo.raw.ndjson";
+
+/**
+ * Invoke the cost handler over a seeded NDJSON file, capturing stdout.
+ * @param {object} options - Parsed flags (e.g. { markdown: true }).
+ * @param {object[]} records - Trace records written as NDJSON.
+ * @returns {Promise<string>} Captured stdout.
+ */
+async function cost(options, records) {
+  const body = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+  const fsSync = createMockFs({ [FILE]: body });
+  let out = "";
+  await runCostCommand({
+    options,
+    args: { file: FILE },
+    deps: {
+      runtime: { fsSync, proc: { stdout: { write: (s) => (out += s) } } },
+    },
+  });
+  return out;
+}
+
+const COMBINED = [
+  { source: "agent", seq: 0, event: { type: "result", total_cost_usd: 0.02 } },
+  {
+    source: "supervisor",
+    seq: 1,
+    event: { type: "result", total_cost_usd: 0.05 },
+  },
+];
+
+describe("fit-trace cost", () => {
+  test("default JSON output reports total and per-source breakdown", async () => {
+    const out = await cost({}, COMBINED);
+    const parsed = JSON.parse(out);
+    assert.ok(Math.abs(parsed.totalCostUsd - 0.07) < 1e-9);
+    assert.deepStrictEqual(parsed.bySource, { agent: 0.02, supervisor: 0.05 });
+  });
+
+  test("--markdown emits a headline total and a per-participant table", async () => {
+    const out = await cost({ markdown: true }, COMBINED);
+    assert.match(out, /### 💰 Run cost: \$0\.0700/);
+    assert.match(out, /\| supervisor \| 0\.0500 \|/);
+    assert.match(out, /\| agent \| 0\.0200 \|/);
+  });
+});


### PR DESCRIPTION
## Summary

- Cost was under-reported. The benchmark dropped the judge's own SDK session entirely and summed only agent+supervisor by *replacing* (not accumulating) per-source result events; no kata workflow surfaced spend at all.
- Add `sumTraceCost` — one aggregator over every `result` event in a trace, with a per-source breakdown (handles the `{source,seq,event}` envelope). Single source of truth, mirroring `TraceCollector.handleResult`.
- Benchmark runner: include the judge's cost; sum across all sources; record `costBreakdown {agent, supervisor, judge}` alongside a now-correct `costUsd` total.
- `fit-trace cost <file>` — new command: total + per-source breakdown, with `--markdown` for a CI step summary.
- `fit-eval callback` payload gains `cost_usd`, so dispatched runs report spend to the bridge.
- All five `kata-*.yml` workflows report run cost to `$GITHUB_STEP_SUMMARY`, reading the trace path that `kata-agent@v1.0.1` now exposes as an output (sibling change: re-exposes `fit-eval`'s `trace-file`/`trace-dir`/`case`).

The monorepo workflows stay SHA-pinned per `.github/CLAUDE.md`; `kata-agent`'s `v1` floating tag is moved to `v1.0.1` for external consumers.

## Test plan

- [ ] \`bun run check\`
- [ ] \`bun run test\`