### PR TITLE
feat(msbridge): 1272 Move B, hosted-path fixes, and 1273 dispatch-identity spec

### DIFF
--- a/libraries/libcodegen/templates/client.js.mustache
+++ b/libraries/libcodegen/templates/client.js.mustache
@@ -30,15 +30,12 @@ export class {{className}} extends Client {
    * @returns { import("@grpc/grpc-js").ClientReadableStream<{{responseTypeNamespace}}.{{responseType}}> } Response stream emitting typed messages.
    */
   {{name}}({{paramName}}) {
-    // Type validation
-    if (!({{paramName}} instanceof {{requestTypeNamespace}}.{{requestType}})) {
-      throw new TypeError(
-        `{{name}}: Expected parameter to be instanceof {{requestTypeNamespace}}.{{requestType}}`,
-      );
-    }
-    
-    // Convert to plain object
-    const request = {{requestTypeNamespace}}.{{requestType}}.toObject({{paramName}});
+    // Accept a typed message or a plain init object (coerced to the typed type).
+    const message =
+      {{paramName}} instanceof {{requestTypeNamespace}}.{{requestType}}
+        ? {{paramName}}
+        : new {{requestTypeNamespace}}.{{requestType}}({{paramName}});
+    const request = {{requestTypeNamespace}}.{{requestType}}.toObject(message);
     
     // Make gRPC call
     return this.callStream("{{name}}", request, (res) => {{responseTypeNamespace}}.{{responseType}}.fromObject(res));
@@ -51,15 +48,12 @@ export class {{className}} extends Client {
    * @returns { Promise<{{responseTypeNamespace}}.{{responseType}}> } Typed response message.
    */
   async {{name}}({{paramName}}) {
-    // Type validation
-    if (!({{paramName}} instanceof {{requestTypeNamespace}}.{{requestType}})) {
-      throw new TypeError(
-        `{{name}}: Expected parameter to be instanceof {{requestTypeNamespace}}.{{requestType}}`,
-      );
-    }
-    
-    // Convert to plain object
-    const request = {{requestTypeNamespace}}.{{requestType}}.toObject({{paramName}});
+    // Accept a typed message or a plain init object (coerced to the typed type).
+    const message =
+      {{paramName}} instanceof {{requestTypeNamespace}}.{{requestType}}
+        ? {{paramName}}
+        : new {{requestTypeNamespace}}.{{requestType}}({{paramName}});
+    const request = {{requestTypeNamespace}}.{{requestType}}.toObject(message);
     
     // Make gRPC call (tracing handled by base Client class)
     return this.callUnary("{{name}}", request, (res) => {{responseTypeNamespace}}.{{responseType}}.fromObject(res));

--- a/scripts/seed-tenancy.mjs
+++ b/scripts/seed-tenancy.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// Seed services/tenancy for hosted (multi-tenant) manual testing.
+//
+// The hosted Teams path needs TWO active tenant rows for one repo, and the
+// order they are created matters:
+//
+//   1. A `github-discussions` row keyed `"{installation_id}:{owner}/{name}"`
+//      (via UpsertByPair). services/ghserver mints the workflow_dispatch token
+//      by splitting this key for the installation id, so this row MUST exist
+//      and MUST be the one ResolveByRepo returns. resolveByRepo returns the
+//      first active row matching the repo in index-insertion order, so we
+//      create it FIRST — before the msteams row that carries the same repo.
+//   2. An `msteams` row keyed by the Entra tenant id (via UpsertByChannelKey +
+//      SetRepo). msbridge resolves the dispatch target from this row's repo on
+//      every inbound Teams activity.
+//
+// This bypasses POST /onboard, which requires a Bot Framework-issued bearer
+// token (audience = the bot's app id) and never writes the github row anyway.
+// Run it against a running tenancy service.
+//
+// Usage (values fall back to .env, loaded by libconfig):
+//   bun scripts/seed-tenancy.mjs \
+//     --repo <owner/name> \            # default: SERVICE_MSBRIDGE_GITHUB_REPO
+//     --installation-id <id> \         # default: SERVICE_GHSERVER_INSTALLATION_ID
+//                                       #   then SERVICE_GHBRIDGE_APP_INSTALLATION_ID
+//     --tid <entra-tenant-id>          # default: SEED_ENTRA_TENANT_ID or MICROSOFT_APP_TENANT_ID
+//
+//   bun scripts/seed-tenancy.mjs --verify-only   # read-back without writing
+
+import { createServiceConfig } from "@forwardimpact/libconfig";
+import { clients } from "@forwardimpact/librpc";
+import { createLogger } from "@forwardimpact/libtelemetry";
+import { tenancy } from "@forwardimpact/libtype";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+function parseArgs(argv) {
+  const args = { verifyOnly: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--verify-only") args.verifyOnly = true;
+    else if (a === "--repo") args.repo = argv[++i];
+    else if (a === "--installation-id") args.installationId = argv[++i];
+    else if (a === "--tid") args.tid = argv[++i];
+    else {
+      console.error(`Unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function parseRepo(spec) {
+  if (typeof spec !== "string") return undefined;
+  const [owner, name] = spec.split("/");
+  if (!owner || !name) return undefined;
+  return { owner, name };
+}
+
+function summarize(label, t) {
+  if (!t?.tenant_id) {
+    console.log(`  ${label}: <none>`);
+    return;
+  }
+  const repo = t.repo ? `${t.repo.owner}/${t.repo.name}` : "—";
+  console.log(
+    `  ${label}: id=${t.tenant_id} channel=${t.channel} key=${t.channel_tenant_key} state=${t.state} repo=${repo}`,
+  );
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+// createServiceConfig loads .env (non-credential keys land in process.env),
+// so the fallbacks below see SERVICE_*/MICROSOFT_* values without sourcing.
+const tenancyConfig = await createServiceConfig("tenancy");
+const runtime = createDefaultRuntime();
+const logger = createLogger("seed-tenancy", runtime);
+const { TenancyClient } = clients;
+const client = new TenancyClient(tenancyConfig, runtime, logger, null);
+
+const repo = parseRepo(args.repo ?? process.env.SERVICE_MSBRIDGE_GITHUB_REPO);
+const installationId =
+  args.installationId ??
+  process.env.SERVICE_GHSERVER_INSTALLATION_ID ??
+  process.env.SERVICE_GHBRIDGE_APP_INSTALLATION_ID;
+const tid =
+  args.tid ??
+  process.env.SEED_ENTRA_TENANT_ID ??
+  process.env.MICROSOFT_APP_TENANT_ID;
+
+const missing = [];
+if (!repo) missing.push("--repo / SERVICE_MSBRIDGE_GITHUB_REPO (owner/name)");
+if (!installationId)
+  missing.push(
+    "--installation-id / SERVICE_GHSERVER_INSTALLATION_ID / SERVICE_GHBRIDGE_APP_INSTALLATION_ID",
+  );
+if (!tid)
+  missing.push("--tid / SEED_ENTRA_TENANT_ID / MICROSOFT_APP_TENANT_ID");
+if (missing.length) {
+  console.error("Missing required inputs:\n  - " + missing.join("\n  - "));
+  process.exit(2);
+}
+
+console.log(
+  `tenancy=${tenancyConfig.url ?? "(default)"} repo=${repo.owner}/${repo.name} installation=${installationId} tid=${tid}`,
+);
+
+if (!args.verifyOnly) {
+  // 1. github-discussions row FIRST (installation id is parseable for minting).
+  const gh = await client.UpsertByPair(
+    new tenancy.UpsertPairRequest({
+      installation_id: String(installationId),
+      owner: repo.owner,
+      name: repo.name,
+    }),
+  );
+  // 2. msteams row, then bind the repo onto it.
+  const ms = await client.UpsertByChannelKey(
+    new tenancy.UpsertChannelKeyRequest({
+      channel: "msteams",
+      channel_tenant_key: tid,
+      state: "active",
+    }),
+  );
+  await client.SetRepo(
+    new tenancy.SetRepoRequest({
+      tenant_id: ms.tenant_id,
+      repo: new tenancy.Repo({ owner: repo.owner, name: repo.name }),
+    }),
+  );
+  console.log("seeded:");
+  summarize("github", gh);
+  summarize("msteams", ms);
+}
+
+// Read back the exact resolutions the bridges and ghserver will perform.
+const byChannel = await client.ResolveByChannelKey(
+  new tenancy.ChannelTenantKey({ channel: "msteams", key: tid }),
+);
+const byRepo = await client.ResolveByRepo(
+  new tenancy.RepoKey({ owner: repo.owner, name: repo.name }),
+);
+console.log("resolution check:");
+summarize(
+  "ResolveByChannelKey(msteams,tid) [msbridge dispatch target]",
+  byChannel,
+);
+summarize("ResolveByRepo(repo)              [ghserver mint source]   ", byRepo);
+
+// ghserver splits channel_tenant_key as "{installation_id}:{owner}/{name}";
+// an msteams key (bare Entra tid) would throw INTERNAL at mint time.
+const mintable = /^[^:]+:[^/]+\/.+$/.test(byRepo?.channel_tenant_key ?? "");
+if (!byChannel?.tenant_id || byChannel.state !== "active") {
+  console.error("FAIL: msteams tenant not active — dispatch will be rejected.");
+  process.exit(1);
+}
+if (!mintable) {
+  console.error(
+    `FAIL: ResolveByRepo returned key "${byRepo?.channel_tenant_key}" which ghserver cannot split for an installation id. The github-discussions row must win ResolveByRepo.`,
+  );
+  process.exit(1);
+}
+console.log("OK: msteams active + ResolveByRepo yields a mintable github row.");
+process.exit(0);

--- a/services/ghserver/server.js
+++ b/services/ghserver/server.js
@@ -19,11 +19,16 @@ const config = await createServiceConfig("ghserver", {
   rate_ceiling_per_tenant_per_minute: 10,
 });
 
+// GitHub App ids are all-digits, so libconfig coerces SERVICE_GHSERVER_APP_ID
+// to a number; normalise to a string for the (string-only) assert and for
+// @octokit/auth-app downstream.
+const appId = String(config.app_id ?? "");
+
 // The App private key is the only signing material in the control plane.
 // It resolves from SERVICE_GHSERVER_PRIVATE_KEY at runtime; substrate
 // hardening (KMS/HSM custody) is the deferred follow-on per
 // design § "What this design does not cover".
-assertNonEmpty(config.app_id, "app_id");
+assertNonEmpty(appId, "app_id");
 assertNonEmpty(config.private_key, "private_key");
 
 // Refuse a public bind unless explicitly opted in (see src/bind-guard.js).
@@ -39,7 +44,7 @@ const tenancyConfig = await createServiceConfig("tenancy");
 const tenancy = new TenancyClient(tenancyConfig, runtime, logger, tracer);
 
 const appAuth = createAppAuthCustody({
-  app_id: config.app_id,
+  app_id: appId,
   private_key: config.private_key,
 });
 const rateCeiling = new RateCeiling({

--- a/services/msbridge/README.md
+++ b/services/msbridge/README.md
@@ -80,12 +80,15 @@ legacy `data/bridges/msbridge/` files; they expire under their existing
    `active`, since the `tid` is signature-bound (the caller provably owns that
    Entra tenant).
 
-Full Bot Framework JWT signature validation (fetching Microsoft's OpenID
-metadata and signing keys) is a peer-authentication substrate tracked as a
-plan concern. Until it lands, no production verifier is injected and
-`POST /onboard` is **default-deny** (every request returns 401); the
+The injected `authenticateTenant` verifier validates the inbound Bot Framework
+bearer JWT through the same `ConfigurationBotFrameworkAuthentication` the
+`/api/messages` path uses (one SDK validation path), so the caller's `tid` is
+cryptographically proven. A request whose `tid` is proven onboards as above; an
+absent or forged proof returns 401 before any registry read. The caller must
+present a Bot Framework-issued bearer token whose audience is the bot's
+`MICROSOFT_APP_ID` — a Graph or Entra user token is rejected. The
 resolved-`tid` → registry-row → `SetRepo` contract is exercised by
-`test/onboard-handler.test.js` with an injected verifier.
+`test/onboard-handler.test.js` and the verifier by `test/onboard-verifier.test.js`.
 
 ### Documented limitation: multi-tenant elapsed-recess re-arm on restart
 

--- a/services/msbridge/azure-app.md
+++ b/services/msbridge/azure-app.md
@@ -89,14 +89,59 @@ own Azure app.
    (`action = add`) → the tenant is registered `pending_consent` in
    `services/tenancy`, keyed by its Entra tenant id.
 2. The customer calls `POST /onboard` with `{ repo: { owner, name } }`; the
-   handler verifies the caller's Entra `tid`, transitions that tenant to
-   `active`, and binds the repo. Activities from non-active tenants are
-   rejected.
+   handler verifies the caller's Entra `tid` by validating the inbound Bot
+   Framework bearer JWT (same `ConfigurationBotFrameworkAuthentication` as the
+   `/api/messages` path), transitions that tenant to `active`, and binds the
+   repo. An absent or forged proof returns 401; activities from non-active
+   tenants are rejected.
 
-> Full Bot Framework JWT signature validation for `/onboard` and custody
-> hardening of the Bot Framework credential are deferred; until the verifier
-> lands, `/onboard` is **default-deny** in production. Both are tracked in the
-> [hosted control-plane hardening spec](https://github.com/forwardimpact/monorepo/blob/main/specs/1272-hosted-control-plane-hardening/spec.md).
+> Custody hardening of the Bot Framework credential remains deferred — it has no
+> cross-workflow fanout, unlike the GitHub App key — and is tracked in the
+> [hosted control-plane hardening spec](https://github.com/forwardimpact/monorepo/blob/main/specs/1272-hosted-control-plane-hardening/spec.md)
+> § Out of scope.
+
+## Manual testing of the tenancy path (local)
+
+Exercise the `tenancy` → `ghserver` mint → dispatch path on one developer
+machine, reusing one GitHub App.
+
+> Microsoft does not permit creating multi-tenant Azure Bot resources, so the
+> bot resource here is **Single Tenant**. The bridge's `multi` tenancy mode
+> still drives the registry resolver + `ghserver` minting; only the Bot
+> Framework app type follows `MICROSOFT_APP_TENANT_ID` (SingleTenant when set).
+> A true multi-tenant offering uses a single-tenant bot + a multi-tenant Entra
+> app distributed through the Teams Store, built on the Microsoft 365 Agents SDK.
+
+1. **Azure** — register an Entra app (a multi-tenant audience is fine and also
+   serves Store distribution), then create an **Azure Bot resource as Single
+   Tenant** bound to your home tenant, App ID = that app. Enable the Microsoft
+   Teams channel.
+2. **`.env`** — set `SERVICE_MSBRIDGE_TENANCY_MODE=multi`; **keep
+   `MICROSOFT_APP_TENANT_ID`** set to your home tenant (the bridge runs
+   SingleTenant Bot Framework auth to match the bot, and the seed script uses it
+   as the Entra tenant id); point `ghserver` at a GitHub App installed on the
+   test repo with **`actions: write`** (the self-hosted `ghbridge` App works if
+   it carries that permission) via `SERVICE_GHSERVER_APP_ID` /
+   `SERVICE_GHSERVER_PRIVATE_KEY`.
+3. **`config/config.json`** — add `tenancy` and `ghserver` ahead of `msbridge`
+   (see [`config/CLAUDE.md`](../../config/CLAUDE.md) § `init`).
+4. **Start** the stack (`bunx fit-rc start`) and set the Azure Bot messaging
+   endpoint to the fresh tunnel (`README.md` § Azure Bot messaging endpoint).
+5. **Seed the registry** against the running `tenancy` service:
+   ```sh
+   bun scripts/seed-tenancy.mjs        # values default from .env
+   ```
+   It creates the `github-discussions` row first (so `services/ghserver` can
+   split the installation id) then the `msteams` row, and fails loudly if
+   `ResolveByRepo` would return an unmintable row.
+6. **Smoke test** — send `@Kata Agent hello` from the test tenant; watch
+   `data/logs/msbridge/current` and `data/logs/ghserver/current` for the resolve
+   → mint → dispatch chain.
+
+> Seeding is the practical path because `POST /onboard` requires a **Bot
+> Framework-issued** bearer token (audience = the bot's `MICROSOFT_APP_ID`); an
+> Entra user or Graph token is rejected. The seed step also creates the
+> `github-discussions` row that `/onboard` never writes.
 
 ## See also
 

--- a/services/msbridge/index.js
+++ b/services/msbridge/index.js
@@ -256,17 +256,19 @@ export class MsBridgeService {
   /**
    * Mount the multi-tenant `POST /onboard` endpoint. The caller's Microsoft
    * Entra tenant id is verified by `authenticateTenant` (injectable for
-   * tests) and resolved to its registry row before any write. Default-deny:
-   * a missing verifier never authenticates a caller — production injects a
-   * verifier that validates the Bot Framework bearer JWT and returns its
-   * `tid` claim (deferred substrate tracked in services/msbridge/README.md).
+   * tests) and resolved to its registry row before any write. Multi-tenant
+   * mode injects a real Bot Framework JWT verifier (`server.js` builds it from
+   * the same authenticator the `/api/messages` path uses); a forged or absent
+   * proof is rejected with 401. Single-tenant deployments never reach here, so
+   * the endpoint is unrouted rather than default-denied. A missing verifier in
+   * multi mode is a wiring error and fails fast in `createOnboardHandler`.
    *
-   * @param {((c: object) => Promise<string | null> | (string | null)) | undefined} authenticateTenant
+   * @param {(c: object) => Promise<string | null> | (string | null)} authenticateTenant
    * @param {object} logger
    */
   #mountOnboard(authenticateTenant, logger) {
     const onboard = createOnboardHandler({
-      authenticateTenant: authenticateTenant ?? (() => null),
+      authenticateTenant,
       tenancyClient: this.#tenancyClient,
       logger,
     });

--- a/services/msbridge/server.js
+++ b/services/msbridge/server.js
@@ -14,6 +14,8 @@ import {
 } from "@forwardimpact/libbridge";
 
 import { MsBridgeService } from "./index.js";
+import { createOnboardVerifier } from "./src/onboard-verifier.js";
+import { createBotFrameworkAuthentication } from "./src/teams.js";
 
 const config = await createServiceConfig("msbridge", {
   github_repo: "",
@@ -81,17 +83,18 @@ const discussionClient = new BridgeClient(
 
 const { clock } = runtime;
 
-// `authenticateTenant` verifies the inbound Bot Framework bearer JWT and
-// returns its Entra `tid` claim (or null). Full Bot Framework JWT signature
-// validation — fetching Microsoft's OpenID metadata and signing keys via
-// botframework-connector's JwtTokenValidation — is a peer-authentication
-// substrate tracked as a plan concern (design § services/ghserver). Until that
-// substrate lands, no production verifier is injected: the onboarding endpoint
-// stays default-deny (every /onboard returns 401) rather than trusting an
-// unvalidated claim. A verifier injected here makes the happy path reachable;
-// the resolved-tid → registry-row → SetRepo contract is exercised by
-// services/msbridge/test/onboard-handler.test.js.
-const authenticateTenant = undefined;
+// Multi-tenant `/onboard` accepts only a cryptographically proven Entra `tid`.
+// The verifier wraps the same Bot Framework authenticator the `/api/messages`
+// path uses (one SDK validation path), so a forged or absent proof is rejected
+// with 401 and a proven `tid` transitions the tenant `active` and maps its
+// repo. Single-tenant deployments never mount `/onboard`, so no verifier is
+// built.
+let authenticateTenant;
+if (config.tenancy_mode === "multi") {
+  authenticateTenant = createOnboardVerifier(
+    createBotFrameworkAuthentication(config),
+  );
+}
 
 const service = new MsBridgeService(config, {
   logger,

--- a/services/msbridge/src/onboard-verifier.js
+++ b/services/msbridge/src/onboard-verifier.js
@@ -1,0 +1,49 @@
+/**
+ * Bot Framework JWT verifier for the multi-tenant `POST /onboard` endpoint.
+ *
+ * Wraps the same Bot Framework authenticator
+ * (`ConfigurationBotFrameworkAuthentication`) that the `/api/messages` path
+ * uses, so onboarding and message intake validate inbound JWTs through one SDK
+ * path — there is no parallel Microsoft signing-key fetch to maintain. The
+ * SDK's `authenticateChannelRequest` performs full validation (signature
+ * against Microsoft's published keys, audience = the bot's `MicrosoftAppId`,
+ * issuer) and returns a `ClaimsIdentity`; the verified Entra tenant id is the
+ * `tid` claim.
+ *
+ * A forged, expired, or wrong-audience token makes `authenticateChannelRequest`
+ * throw, and an absent header is rejected before the SDK is reached — both map
+ * to `null`, which the onboard handler turns into a 401.
+ */
+
+const TENANT_ID_CLAIM = "tid";
+
+/**
+ * Build the `authenticateTenant(c)` verifier the onboard handler depends on.
+ *
+ * @param {{ authenticateChannelRequest: (authHeader: string) => Promise<{
+ *   isAuthenticated: boolean,
+ *   getClaimValue: (claim: string) => string | null,
+ * }> }} auth
+ *   A Bot Framework authenticator (multi-mode
+ *   `ConfigurationBotFrameworkAuthentication`).
+ * @returns {(c: object) => Promise<string | null>} Resolves the caller's proven
+ *   Entra tenant id (`tid`), or `null` when the request is unauthenticated.
+ */
+export function createOnboardVerifier(auth) {
+  if (!auth || typeof auth.authenticateChannelRequest !== "function") {
+    throw new Error("auth with authenticateChannelRequest is required");
+  }
+  return async (c) => {
+    const authHeader = c.req.header("authorization") ?? "";
+    if (!authHeader) return null;
+    try {
+      const identity = await auth.authenticateChannelRequest(authHeader);
+      if (!identity?.isAuthenticated) return null;
+      const tid = identity.getClaimValue(TENANT_ID_CLAIM);
+      return tid || null;
+    } catch {
+      // Forged / expired / wrong-audience token: unauthenticated.
+      return null;
+    }
+  };
+}

--- a/services/msbridge/src/teams.js
+++ b/services/msbridge/src/teams.js
@@ -62,30 +62,43 @@ export async function sendReply(adapter, msAppIdFn, ref, text) {
 }
 
 /**
+ * Build the Bot Framework authenticator for the configured app type. The app
+ * type follows whether `MICROSOFT_APP_TENANT_ID` is set, independent of
+ * `tenancy_mode`: when present the authenticator runs SingleTenant bound to
+ * that tenant (the supported shape — Microsoft deprecated multi-tenant Azure
+ * Bot resources, so a hosted bot is a single-tenant resource in the operator's
+ * home tenant); when absent it runs MultiTenant for a grandfathered
+ * multi-tenant resource. The same authenticator validates both the
+ * `/api/messages` activity stream and the `/onboard` JWT, so there is one SDK
+ * validation path to maintain.
+ *
+ * @param {object} config
+ * @returns {object} ConfigurationBotFrameworkAuthentication
+ */
+export function createBotFrameworkAuthentication(config) {
+  const tenantId = config.msAppTenantId();
+  if (tenantId) {
+    return new ConfigurationBotFrameworkAuthentication({
+      MicrosoftAppId: config.msAppId(),
+      MicrosoftAppPassword: config.msAppPassword(),
+      MicrosoftAppTenantId: tenantId,
+      MicrosoftAppType: "SingleTenant",
+    });
+  }
+  return new ConfigurationBotFrameworkAuthentication({
+    MicrosoftAppId: config.msAppId(),
+    MicrosoftAppPassword: config.msAppPassword(),
+    MicrosoftAppType: "MultiTenant",
+  });
+}
+
+/**
  * Build the default Bot Framework CloudAdapter wired to the service config.
  * @param {object} config
  * @returns {object}
  */
 export function createDefaultAdapter(config) {
-  // Multi-tenant (hosted) uses Microsoft's documented MultiTenant mode: the
-  // app type is "MultiTenant" and the tenant id is omitted, so the Bot
-  // Framework SDK accepts JWTs issued by any consenting Entra tenant.
-  // Single-tenant (self-hosted) keeps the static tenant id binding.
-  if (config.tenancy_mode === "multi") {
-    const auth = new ConfigurationBotFrameworkAuthentication({
-      MicrosoftAppId: config.msAppId(),
-      MicrosoftAppPassword: config.msAppPassword(),
-      MicrosoftAppType: "MultiTenant",
-    });
-    return new CloudAdapter(auth);
-  }
-  const auth = new ConfigurationBotFrameworkAuthentication({
-    MicrosoftAppId: config.msAppId(),
-    MicrosoftAppPassword: config.msAppPassword(),
-    MicrosoftAppTenantId: config.msAppTenantId(),
-    MicrosoftAppType: "SingleTenant",
-  });
-  return new CloudAdapter(auth);
+  return new CloudAdapter(createBotFrameworkAuthentication(config));
 }
 
 /**

--- a/services/msbridge/test/multi-tenant.test.js
+++ b/services/msbridge/test/multi-tenant.test.js
@@ -138,6 +138,10 @@ for (const mode of ["single", "multi"]) {
             return { installation_token: "ghs_minted" };
           },
         };
+        // Multi-tenant mounts /onboard, which now requires a real verifier
+        // (no default-deny fallback). These tests exercise dispatch/inbox, not
+        // onboarding, so a stub verifier suffices.
+        deps.authenticateTenant = () => "entra-test";
       }
       service = new MsBridgeService(
         makeConfig(

--- a/services/msbridge/test/onboard-handler.test.js
+++ b/services/msbridge/test/onboard-handler.test.js
@@ -1,15 +1,34 @@
 import { describe, expect, test } from "bun:test";
 
 import { createOnboardHandler } from "../src/onboard-handler.js";
+import { createOnboardVerifier } from "../src/onboard-verifier.js";
 import { handleConsent } from "../src/consent-handler.js";
 
-function fakeContext(body) {
+function fakeContext(body, authHeader) {
   return {
     req: {
       json: async () => body,
-      header: () => undefined,
+      header: (name) =>
+        name?.toLowerCase() === "authorization" ? authHeader : undefined,
     },
     json: (payload, status) => ({ payload, status: status ?? 200 }),
+  };
+}
+
+/**
+ * Bot Framework authenticator stub for the end-to-end verifier integration:
+ * returns a `ClaimsIdentity`-shaped object carrying `tid`, or throws to model
+ * a forged token.
+ */
+function fakeAuth({ tid, throws = false } = {}) {
+  return {
+    authenticateChannelRequest() {
+      if (throws) throw new Error("token validation failed");
+      return Promise.resolve({
+        isAuthenticated: true,
+        getClaimValue: (claim) => (claim === "tid" ? tid : null),
+      });
+    },
   };
 }
 
@@ -235,5 +254,82 @@ describe("msbridge onboard handler", () => {
     expect(tenancyClient.rows[0].state).toBe("active");
     expect(tenancyClient.rows[0].tenant_id).toBe(uuid);
     expect(tenancyClient.rows[0].repo).toEqual({ owner: "acme", name: "web" });
+  });
+});
+
+// End-to-end through the real Bot Framework verifier (over a fake authenticator):
+// proves criterion 5's trio — a cryptographically proven tid onboards; a forged
+// or absent proof returns 401 with no registry write.
+describe("msbridge onboard handler with the Bot Framework verifier", () => {
+  test("a proven tid transitions the tenant active and maps its repo", async () => {
+    const tenancyClient = fakeTenancyClient([
+      {
+        channel_tenant_key: "entra-acme",
+        tenant_id: "uuid-acme",
+        state: "pending_consent",
+      },
+    ]);
+    const onboard = createOnboardHandler({
+      authenticateTenant: createOnboardVerifier(
+        fakeAuth({ tid: "entra-acme" }),
+      ),
+      tenancyClient,
+    });
+    const res = await onboard(
+      fakeContext(
+        { repo: { owner: "acme", name: "web" } },
+        "Bearer proven.jwt",
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(tenancyClient.rows[0].state).toBe("active");
+    expect(tenancyClient.calls.setRepo).toEqual([
+      { tenant_id: "uuid-acme", repo: { owner: "acme", name: "web" } },
+    ]);
+  });
+
+  test("a forged proof returns 401 and writes nothing", async () => {
+    const tenancyClient = fakeTenancyClient([
+      {
+        channel_tenant_key: "entra-acme",
+        tenant_id: "uuid-acme",
+        state: "pending_consent",
+      },
+    ]);
+    const onboard = createOnboardHandler({
+      authenticateTenant: createOnboardVerifier(fakeAuth({ throws: true })),
+      tenancyClient,
+    });
+    const res = await onboard(
+      fakeContext(
+        { repo: { owner: "acme", name: "web" } },
+        "Bearer forged.jwt",
+      ),
+    );
+    expect(res.status).toBe(401);
+    expect(tenancyClient.calls.upsert.length).toBe(0);
+    expect(tenancyClient.calls.setRepo.length).toBe(0);
+  });
+
+  test("an absent proof returns 401 and writes nothing", async () => {
+    const tenancyClient = fakeTenancyClient([
+      {
+        channel_tenant_key: "entra-acme",
+        tenant_id: "uuid-acme",
+        state: "pending_consent",
+      },
+    ]);
+    const onboard = createOnboardHandler({
+      authenticateTenant: createOnboardVerifier(
+        fakeAuth({ tid: "entra-acme" }),
+      ),
+      tenancyClient,
+    });
+    const res = await onboard(
+      fakeContext({ repo: { owner: "acme", name: "web" } }, undefined),
+    );
+    expect(res.status).toBe(401);
+    expect(tenancyClient.calls.upsert.length).toBe(0);
+    expect(tenancyClient.calls.setRepo.length).toBe(0);
   });
 });

--- a/services/msbridge/test/onboard-verifier.test.js
+++ b/services/msbridge/test/onboard-verifier.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import { createOnboardVerifier } from "../src/onboard-verifier.js";
+
+/**
+ * Context stub mirroring the Hono request surface the verifier reads:
+ * a case-insensitive `req.header(name)` returning the Authorization value.
+ */
+function fakeContext(authHeader) {
+  return {
+    req: {
+      header: (name) =>
+        name.toLowerCase() === "authorization" ? authHeader : undefined,
+    },
+  };
+}
+
+/**
+ * Bot Framework authenticator stub. `authenticateChannelRequest` returns a
+ * `ClaimsIdentity`-shaped object on success, or throws to model a forged /
+ * expired / wrong-audience token.
+ */
+function fakeAuth({ tid, isAuthenticated = true, throws = false } = {}) {
+  return {
+    calls: [],
+    authenticateChannelRequest(authHeader) {
+      this.calls.push(authHeader);
+      if (throws) throw new Error("token validation failed");
+      return Promise.resolve({
+        isAuthenticated,
+        getClaimValue: (claim) => (claim === "tid" ? tid : null),
+      });
+    },
+  };
+}
+
+describe("msbridge onboard verifier", () => {
+  test("constructor requires a Bot Framework authenticator", () => {
+    expect(() => createOnboardVerifier(undefined)).toThrow(
+      "authenticateChannelRequest is required",
+    );
+    expect(() => createOnboardVerifier({})).toThrow(
+      "authenticateChannelRequest is required",
+    );
+  });
+
+  test("a proven token resolves to its Entra tid", async () => {
+    const auth = fakeAuth({ tid: "entra-acme" });
+    const verify = createOnboardVerifier(auth);
+    const tid = await verify(fakeContext("Bearer proven.jwt"));
+    expect(tid).toBe("entra-acme");
+    expect(auth.calls).toEqual(["Bearer proven.jwt"]);
+  });
+
+  test("a forged token (validation throws) resolves to null", async () => {
+    const verify = createOnboardVerifier(fakeAuth({ throws: true }));
+    expect(await verify(fakeContext("Bearer forged.jwt"))).toBeNull();
+  });
+
+  test("an unauthenticated identity resolves to null", async () => {
+    const verify = createOnboardVerifier(
+      fakeAuth({ tid: "entra-acme", isAuthenticated: false }),
+    );
+    expect(await verify(fakeContext("Bearer weak.jwt"))).toBeNull();
+  });
+
+  test("an identity with no tid claim resolves to null", async () => {
+    const verify = createOnboardVerifier(fakeAuth({ tid: null }));
+    expect(await verify(fakeContext("Bearer notid.jwt"))).toBeNull();
+  });
+
+  test("an absent Authorization header resolves to null without calling the SDK", async () => {
+    const auth = fakeAuth({ tid: "entra-acme" });
+    const verify = createOnboardVerifier(auth);
+    expect(await verify(fakeContext(undefined))).toBeNull();
+    expect(await verify(fakeContext(""))).toBeNull();
+    expect(auth.calls).toEqual([]);
+  });
+});

--- a/services/tenancy/server.js
+++ b/services/tenancy/server.js
@@ -11,12 +11,12 @@ import { TenantStore } from "./src/tenant-store.js";
 
 const config = await createServiceConfig("tenancy", {});
 
-const logger = createLogger("tenancy");
+const runtime = createDefaultRuntime();
+const { clock } = runtime;
+const logger = createLogger("tenancy", runtime);
 const tracer = await createTracer("tenancy");
 const storage = createStorage("tenancy");
 
-const runtime = createDefaultRuntime();
-const { clock } = runtime;
 const tenants = new TenantStore(storage, { clock });
 
 const service = new TenancyService(config, { tenants });

--- a/specs/1272-hosted-control-plane-hardening/design-a.md
+++ b/specs/1272-hosted-control-plane-hardening/design-a.md
@@ -1,0 +1,144 @@
+# Design 1272 — Hosted control-plane hardening
+
+Spec [1272](spec.md) names six hosted-only gaps inherited from spec 1270's
+"what this design does not cover" list. This design groups them into four
+architectural moves so each lands independently:
+
+- **A** — ghserver substrate (criteria 1–4): peer-authenticated mint surface
+  + externalized App-key custody with in-place rotation.
+- **B** — verified Teams onboarding (criterion 5): inject a Bot Framework JWT
+  verifier so `/onboard` accepts a cryptographically proven `tid`.
+- **C** — tenant lifecycle correctness (criteria 6–7): webhook-driven revoke
+  that also cancels in-flight resume work, and cross-tenant enumeration so
+  `ResumeScheduler.rearm()` covers every active tenant on restart.
+- **D** — hosted templates run end-to-end (criterion 8): kata-setup hosted
+  templates pin the sibling-action minimum versions that accept the
+  `installation-token` input.
+
+Single-tenant deployments (`*_TENANCY_MODE=single`) are untouched
+(criterion 9); every new collaborator is conditioned on `multi` mode.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  subgraph hosted_control_plane
+    OIDC[oidc] -- signed peer token --> GHS[ghserver]
+    GHB[ghbridge/multi] -- signed peer token --> GHS
+    MSB[msbridge/multi] -- signed peer token --> GHS
+    GHS -- fetch + cache --> KMS[(external custody)]
+    GHB <-- ResolveByRepo / SetState --> TEN[tenancy]
+    MSB <-- ResolveByChannelKey / SetState --> TEN
+    GHB -- ListAllOpenRecesses / MarkTenantRevoked --> BR[bridge]
+    MSB -- ListAllOpenRecesses / MarkTenantRevoked --> BR
+  end
+  GH[GitHub webhook] -. installation.* .-> GHB
+  T[Teams /onboard] -. signed JWT .-> MSB
+```
+
+## Components
+
+| Component | Move | Adds |
+| --- | --- | --- |
+| `services/ghserver` peer interceptor | A | gRPC interceptor that requires a signed peer token in metadata, rejects calls without it, and surfaces `peer_identity` to handlers. The existing bind-guard stays as defense-in-depth. |
+| `services/ghserver` key resolver | A | Collaborator that fetches App PEM from external custody at startup, caches it, and re-fetches on a signed-request failure so rotation lands without process restart. |
+| `services/msbridge` onboard verifier | B | `tenantAuthenticator(req) → { tid, verified }` collaborator; the handler depends on it directly. The default-deny fallback is removed — when no verifier is wired (single-tenant path), `/onboard` is unrouted, not 401. |
+| `services/ghbridge` uninstall handler | C | New `src/uninstall-handler.js` that dispatches on `installation.deleted`, `installation.suspend`, and `installation.repositories_removed` to `tenancy.SetState(active→revoked)` then `bridge.MarkTenantRevoked`. |
+| `services/bridge` `ListAllOpenRecesses` | C | New sibling RPC with no `tenant_id` field. Server-side filters to recesses whose tenant is `active` by joining against `tenancy.ResolveByTenantId`. The existing per-tenant `ListOpenRecesses` is unchanged. |
+| `services/bridge` revoke sweep | C | New `MarkTenantRevoked` write RPC that walks the tenant's recess + callback records and applies per-record libstorage writes (each atomic via the rename primitive spec 1480 lands). Cross-record consistency is not required — callback delivery refuses any post-sweep callback via the existing tenancy-state check on `ResolveByTenantId`. |
+| Bridge-side store adapter in `multi` | C | The bridge process's store adapter constructed at boot binds the `multi`-mode choice: `Store.listOpenRecesses()` (already no-args at libbridge/src/index.js:17) is implemented by calling `ListAllOpenRecesses` instead of `ListOpenRecesses(tenant_id)`. The libbridge typedef does not widen; `libbridge`'s `ResumeScheduler` stays mode-agnostic. |
+| kata-setup hosted templates | D | Hosted `workflow-facilitate` / `workflow-react` / `workflow-agent` templates pin a minimum `kata-action-agent` / `kata-action-eval` version that accepts `installation-token`. |
+
+## Onboarding (B)
+
+```mermaid
+sequenceDiagram
+  participant C as Customer
+  participant MSB as msbridge /onboard
+  participant V as tenantAuthenticator
+  participant T as tenancy
+  C->>MSB: POST /onboard { repo }
+  MSB->>V: verify Authorization JWT
+  V-->>MSB: { tid, verified }
+  alt absent or forged
+    MSB-->>C: 401
+  else verified
+    MSB->>T: UpsertByChannelKey(msteams, tid, active)
+    T-->>MSB: tenant_id
+    MSB->>T: SetRepo(tenant_id, repo)
+    MSB-->>C: 200
+  end
+```
+
+## Revoke (C)
+
+```mermaid
+sequenceDiagram
+  participant GH as GitHub webhook
+  participant GHB as ghbridge
+  participant T as tenancy
+  participant BR as bridge
+  GH->>GHB: installation.repositories_removed
+  GHB->>T: SetState(tenant_id, revoked)
+  GHB->>BR: MarkTenantRevoked(tenant_id)
+  BR-->>GHB: { recesses_cancelled, callbacks_refused }
+  Note over T,BR: subsequent Mint/Dispatch/Resume<br/>for those repos returns NOT_FOUND
+```
+
+## Restart re-arm (C)
+
+```mermaid
+sequenceDiagram
+  participant SCH as ResumeScheduler
+  participant BR as bridge
+  SCH->>BR: ListAllOpenRecesses [multi adapter only]
+  BR-->>SCH: recesses across active tenants (server-filtered)
+  loop each recess
+    SCH->>SCH: schedule(recess)
+  end
+```
+
+## Key Decisions
+
+| # | Decision | Rejected alternative |
+| --- | --- | --- |
+| 1 | Peer auth surfaces `peer_identity` to handlers via a gRPC interceptor; transport is a **short-lived JWT** in `authorization` metadata signed with a per-caller asymmetric key (`aud=ghserver`, `exp` minutes). Public keys live in the same external custody as the App key — one trust root, not two. | **mTLS** — adds a second substrate (cert rotation, trust roots) on top of Decision 2's custody. **Shared HMAC secret across all callers** — a single leaked key compromises every peer and offers no per-caller revocation. |
+| 2 | App private key lives in an **external secret manager** (KMS/Secrets Manager); a key-resolver collaborator fetches on startup, caches, and re-fetches on a signed-request failure so rotation lands without process restart. | **Read-once env or file** — even with operator tooling, rotation requires a redeploy; criterion 3 rules this out. |
+| 3 | The `/onboard` JWT verifier wraps the Bot Framework SDK's **`ConfigurationBotFrameworkAuthentication`** — the same authenticator `services/msbridge/src/teams.js:75` already uses on the `/api/messages` path — and is injected into the handler as a collaborator. One verification path, one SDK upgrade surface. | **Verify directly against Entra JWKS** (skip the SDK) — the bridge would maintain its own Microsoft signing-key fetch + audience/issuer checks parallel to the SDK's; doubles the surface that has to track Microsoft's metadata changes. |
+| 4 | Revoke is **webhook-driven** off `installation.repositories_removed` and full uninstall, mirroring `install-handler.js`. | **Reconciliation poll** — silent on missed events and contradicts the bridge's event-sourced model. |
+| 5 | Cross-tenant enumeration is a **new sibling RPC `ListAllOpenRecesses`** on `services/bridge` (no `tenant_id` field). Bridge owns the recess store and the new RPC server-side joins against `tenancy.ResolveByTenantId` so the result excludes revoked tenants. The existing per-tenant `ListOpenRecesses` is untouched. | **Overload existing `ListOpenRecesses`** by allowing empty `tenant_id` — splits one RPC across two trust modes and breaks single-tenant tests that assert `INVALID_ARGUMENT` on missing tenant. **`services/tenancy.ListActive` + per-tenant fan-out** — N+1 round-trips at every restart and splits the recess query across two services. |
+| 6 | Revoke cancels in-flight resume work via a new **`MarkTenantRevoked`** write RPC on `services/bridge` that walks the tenant's recess + callback records under the existing **libindex writer-lock**, drops pending recesses, and marks queued callbacks refused. | **In-process scheduler cancel only** — racy across multiple bridge replicas; a callback delivered after revoke but before in-process notice would still execute. |
+| 7 | Hosted templates pin a **minimum sibling version** of `kata-action-agent` / `kata-action-eval` that accepts `installation-token`; the sibling release ships the input acceptance. The monorepo side is the pin alone (criterion 8, first clause). | **Operator-managed version** — invisible to kata-setup and re-opens the documented gap on every kata-setup re-run. |
+| 8 | Decomposed into **four independently-shippable moves** (A/B/C/D) that may land in any order. Bind-address isolation is the permanent transport-level access boundary for every control-plane RPC; Move A adds peer-auth identity *on top* of it (additive, not replacement), so C's new RPCs ship behind the same isolation as today's ghserver mint surface whenever they land. D blocks externally on the sibling release. | **One serialized plan** — couples the adopter unblock (3, 5) to the heavier substrate (1, 2). **C-after-A** — keeps C unshippable until external custody is provisioned, with no security benefit because bind isolation already covers in-control-plane RPCs. |
+
+## Suggested move ordering
+
+A planner may sequence the four moves in any order. Smallest-first (B → C → A → D)
+unblocks adopter capability earliest; substrate-first (A → C → B → D) hardens
+the mint surface before extending it. D blocks externally on the sibling
+release accepting `installation-token`.
+
+## State invariants
+
+- A `revoked` tenant row never returns from `ResolveByRepo` or `ResolveByChannelKey` (existing tenancy invariant) and is observable only via `ResolveByTenantId` so callback verification can reject mismatched-state callbacks.
+- Every `MintInstallationToken` call traverses the peer-auth interceptor; an unauthenticated caller returns gRPC `UNAUTHENTICATED` before any `ResolveByRepo`.
+- After `MarkTenantRevoked(t)` returns, every pending recess for `t` has been excised from the bridge store via individually-atomic libstorage writes; any later-arriving callback for `t` is refused by the callback handler's existing tenancy-state check on `ResolveByTenantId`. Cross-record atomicity is not required.
+- `ListAllOpenRecesses` server-side filters its result against the current tenancy state, so a recess record for a revoked tenant cannot be re-armed even if `MarkTenantRevoked` raced with a restart.
+
+## Mapping to success criteria
+
+| Crit. | Move | Component touched |
+| --- | --- | --- |
+| 1 | A | ghserver peer-auth interceptor (reject path) |
+| 2 | A | ghserver peer-auth interceptor (accept path) |
+| 3 | A | ghserver key resolver + external custody |
+| 4 | A | `services/ghserver/README.md` rotation section |
+| 5 | B | msbridge onboard verifier |
+| 6 | C | ghbridge uninstall handler + tenancy revoke + bridge MarkTenantRevoked |
+| 7 | C | bridge `ListAllOpenRecesses` + libbridge `ResumeScheduler.rearm` |
+| 8 | D | kata-setup hosted templates (sibling-version pin block) |
+| 9 | all | single-tenant path unchanged (mode guards on every new collaborator) |
+
+## Out of scope
+
+Reaffirms spec § Out of scope: hosted discovery artefacts, `FIT_OIDC_URL` auto-set, libindex replacement, self-hosted↔hosted migration, msbridge Bot Framework custody hardening, broader rate-limiting, computed-key BYOK scanner.

--- a/specs/1272-hosted-control-plane-hardening/plan-a-01.md
+++ b/specs/1272-hosted-control-plane-hardening/plan-a-01.md
@@ -1,0 +1,107 @@
+# Plan 1272 Part 01 — Move A: ghserver peer-auth + key custody
+
+Implements design [Move A](design-a.md#components) (criteria 1–4): a
+peer-authenticated `MintInstallationToken` surface and externalized App-key
+custody with in-place rotation. Read [spec § criteria 1–4](spec.md) and design
+Key Decisions 1–2 before executing. Bind-address isolation (`src/bind-guard.js`)
+stays as defense-in-depth; this move adds per-caller identity on top of it.
+
+Libraries used: librpc (server interceptor, `Server`), libconfig (config keys),
+libtype (no proto change — metadata only).
+
+## Step A1 — Peer-token verifier collaborator
+
+One sentence: add an asymmetric per-caller peer-token verifier that validates a
+short-lived JWT (`aud=ghserver`, `exp` minutes) and returns the caller identity.
+
+- Created: `services/ghserver/src/peer-auth.js`
+- Modified: `services/ghserver/index.js` (export `createPeerVerifier`)
+
+Concrete change — `createPeerVerifier({ publicKeys, clock })` returns
+`{ verify(authorizationHeader) → { peer_identity } | null }`:
+
+- Parse `Bearer <jwt>` from the `authorization` metadata value; absent/malformed
+  → return `null`.
+- Verify the JWT signature against the public key registered for the token's
+  `iss` (caller id), check `aud === "ghserver"` and `exp > clock.now()`.
+- On success return `{ peer_identity: iss }`; on any failure return `null`.
+- `publicKeys` is a `Map<callerId, pem>` supplied by the key resolver (Step A3),
+  not embedded — one trust root shared with the App key custody.
+
+Verification: `bun test test/peer-auth.test.js` (valid token → identity; expired,
+wrong-aud, unknown-issuer, absent → null).
+
+## Step A2 — Server interceptor wiring + reject path
+
+One sentence: require a verified peer token on every `MintInstallationToken`
+call, returning gRPC `UNAUTHENTICATED` before any `ResolveByRepo`.
+
+- Modified: `services/ghserver/server.js` (build verifier, pass as a server
+  interceptor), `services/ghserver/src/service.js` (read `peer_identity` from
+  call context; reject when absent)
+
+Concrete change:
+
+- In `server.js`, construct the verifier (Step A1) from resolver-supplied public
+  keys and register it as a `Server` interceptor that reads the `authorization`
+  metadata, calls `verify`, and either attaches `peer_identity` to the call
+  context or fails the call with `grpc.status.UNAUTHENTICATED`.
+- `MintInstallationToken` asserts `peer_identity` is present (defense-in-depth;
+  the interceptor already rejected the call) before resolving the repo.
+
+Verification: `bun test test/ghserver.test.js` (unauthenticated caller →
+`UNAUTHENTICATED`; valid peer → mint proceeds).
+
+## Step A3 — Externalized key resolver with in-place rotation
+
+One sentence: fetch the App PEM (and peer public keys) from external custody at
+startup, cache, and re-fetch on a signed-request failure so rotation lands
+without a process restart.
+
+- Created: `services/ghserver/src/key-resolver.js`
+- Modified: `services/ghserver/server.js` (replace `assertNonEmpty(private_key)`
+  + literal `createAppAuthCustody({ private_key })` with the resolver),
+  `services/ghserver/src/app-auth.js` (accept a `privateKeyProvider` instead of
+  a literal `private_key`)
+
+Concrete change — `createKeyResolver({ custodyClient, clock })` exposes:
+
+- `appPrivateKey()` → cached PEM; on a mint that fails signature, the resolver
+  re-fetches once and retries, so a rotated key lands without redeploy.
+- `peerPublicKeys()` → the `Map` consumed by Step A1.
+- `custodyClient` is an injectable adapter (KMS / Secrets Manager); `server.js`
+  binds the concrete one, the test injects a fake.
+- Remove the `private_key` config key and its `assertNonEmpty` so no plaintext
+  key path survives in the merged config (criterion 3).
+
+Verification: `bun test test/key-resolver.test.js` (sign-after-rotate: first
+fetch returns key1, signed-request failure triggers re-fetch returning key2,
+retry succeeds) and `node scripts/check-byok-boundary.mjs` stays green
+(parent agent owns `scripts/`; coordinate the run, do not edit the script).
+
+## Step A4 — Rotation operator section
+
+One sentence: document the key-rotation procedure for operators.
+
+- Modified: `services/ghserver/README.md`
+
+Concrete change: replace the "Credential custody and the deferred substrate"
+section with an operator "Key rotation" section: where the key lives (external
+custody), how to rotate (write the new key to custody; the resolver re-fetches
+on the next signed-request failure, no redeploy), and the peer-token trust root
+(per-caller public keys in the same custody). Drop the "deferred substrate" and
+"unauthenticated at the peer level" language.
+
+Verification: `services/ghserver/README.md` rotation section present; no
+"deferred substrate" / "unauthenticated at the peer level" strings remain.
+
+## Risks
+
+- The custody client API is operator-environment-specific; keep it behind the
+  injectable `custodyClient` adapter so the production binding in `server.js` is
+  the only environment-coupled code and the resolver itself is testable.
+- Rejected alternatives (mTLS; shared HMAC across callers — the existing
+  `librpc/src/auth.js` `HmacAuth`) are recorded in design Key Decision 1; do not
+  re-introduce a shared secret here.
+
+— Staff Engineer 🛠️

--- a/specs/1272-hosted-control-plane-hardening/plan-a-02.md
+++ b/specs/1272-hosted-control-plane-hardening/plan-a-02.md
@@ -1,0 +1,185 @@
+# Plan 1272 Part 02 — Move B: verified Teams /onboard
+
+Implements design [Move B](design-a.md#onboarding-b) (criterion 5): inject a Bot
+Framework JWT verifier so `POST /onboard` accepts only a cryptographically
+proven Entra `tid`. Read [spec § criterion 5](spec.md) and design Key Decision 3
+before executing. Single-tenant deployments never mount `/onboard`; the verifier
+is a `multi`-mode-only collaborator.
+
+Libraries used: botbuilder (`ConfigurationBotFrameworkAuthentication`,
+`ClaimsIdentity`), librpc/libconfig (unchanged — no new keys).
+
+## Step B1 — Bot Framework onboard verifier collaborator
+
+One sentence: add a verifier that wraps the same
+`ConfigurationBotFrameworkAuthentication` the `/api/messages` path uses and
+returns the request's proven Entra `tid`.
+
+- Created: `services/msbridge/src/onboard-verifier.js`
+- Modified: `services/msbridge/src/teams.js` (export `AuthenticationConstants`
+  or the literal `tid` claim name only if needed — prefer the literal `"tid"`,
+  which `ClaimsIdentity.getClaimValue("tid")` already returns)
+
+Concrete change — `createOnboardVerifier(auth)` returns an
+`authenticateTenant(c)` function:
+
+```js
+// auth is the multi-mode ConfigurationBotFrameworkAuthentication
+// instance (same SDK object used on /api/messages).
+export function createOnboardVerifier(auth) {
+  return async (c) => {
+    const authHeader = c.req.header("authorization") ?? "";
+    if (!authHeader) return null;
+    try {
+      const identity = await auth.authenticateChannelRequest(authHeader);
+      if (!identity?.isAuthenticated) return null;
+      const tid = identity.getClaimValue("tid");
+      return tid || null;
+    } catch {
+      return null; // forged / expired / wrong-audience → unauthenticated
+    }
+  };
+}
+```
+
+- `authenticateChannelRequest(authHeader)` performs full Bot Framework JWT
+  validation (signature against Microsoft's signing keys, `aud === MicrosoftAppId`,
+  issuer) — the SDK owns the JWKS fetch, so the bridge maintains no parallel
+  signing-key path (design Key Decision 3 rejected the direct-JWKS alternative).
+- A forged, expired, or absent token yields `null`; the handler maps `null` → 401.
+
+Verification: `bun test test/onboard-verifier.test.js` (authenticated identity
+with `tid` → tid; `isAuthenticated=false` → null; `authenticateChannelRequest`
+throws → null; absent header → null).
+
+## Step B2 — Build the verifier from the multi-mode authenticator
+
+One sentence: expose the multi-mode `ConfigurationBotFrameworkAuthentication`
+instance so `server.js` can build the verifier from it.
+
+- Modified: `services/msbridge/src/teams.js`
+
+Concrete change: factor the multi-mode authenticator construction out of
+`createDefaultAdapter` into a reused factory. Add
+`createMultiTenantAuthentication(config)` returning
+`new ConfigurationBotFrameworkAuthentication({ MicrosoftAppId, MicrosoftAppPassword,
+MicrosoftAppType: "MultiTenant" })`; `createDefaultAdapter`'s `multi` branch
+calls it and wraps the result in a `CloudAdapter`. The onboard verifier
+(built in `server.js`, Step B3) constructs its own instance via the same
+factory — design Key Decision 3's "one verification path, one SDK upgrade
+surface" is satisfied by sharing the *factory and SDK class*, not a single live
+object (the adapter is built inside the `MsBridgeService` constructor at
+index.js:153, the verifier in `server.js`, so they cannot share one instance
+without a larger wiring change out of scope here). Single-tenant branch
+unchanged.
+
+Verification: `bun test test/*.test.js` (existing adapter/runtime tests green —
+the multi-mode adapter still constructs).
+
+## Step B3 — Wire the verifier in server.js (remove default-deny)
+
+One sentence: build the real verifier in `multi` mode and inject it; in `single`
+mode inject nothing (the endpoint is never mounted).
+
+- Modified: `services/msbridge/server.js`
+
+Concrete change: replace `const authenticateTenant = undefined;` (server.js:94)
+and its deferred-substrate comment with:
+
+```js
+// Multi-tenant /onboard requires a cryptographically proven Entra tid. The
+// verifier wraps the same Bot Framework authenticator the /api/messages path
+// uses (design Key Decision 3), so one SDK path validates both. Single-tenant
+// never mounts /onboard, so no verifier is built.
+let authenticateTenant;
+if (config.tenancy_mode === "multi") {
+  authenticateTenant = createOnboardVerifier(
+    createMultiTenantAuthentication(config),
+  );
+}
+```
+
+Add the imports for `createOnboardVerifier` and `createMultiTenantAuthentication`.
+
+Verification: `bun test test/startup.test.js` plus a multi-mode construction
+test (service builds with a real verifier wired).
+
+## Step B4 — Remove the default-deny fallback in the handler mount
+
+One sentence: drop the `authenticateTenant ?? (() => null)` default-deny shim so
+that wiring is explicit — multi requires a verifier, single never mounts.
+
+- Modified: `services/msbridge/index.js`
+
+Concrete change in `#mountOnboard` (index.js:267–272): pass `authenticateTenant`
+straight through (no `?? (() => null)`). The constructor already only calls
+`#mountOnboard` inside `if (this.#multiTenant)` (index.js:251), so a multi-mode
+service with no verifier now fails fast at `createOnboardHandler`
+(`authenticateTenant is required`) instead of silently default-denying. Rewrite
+the `#mountOnboard` doc comment: drop "Default-deny: a missing verifier never
+authenticates" and "deferred substrate"; state that multi-mode injects a real
+Bot Framework verifier and single-tenant never mounts the endpoint.
+
+Verification: `bun test test/onboard-handler.test.js` (constructor-required test
+still green) and the multi-mode construction test from B3.
+
+## Step B5 — Test suite: proven / forged / absent
+
+One sentence: assert the three criterion-5 outcomes against the verifier and
+handler.
+
+- Created: `services/msbridge/test/onboard-verifier.test.js`
+- Modified: `services/msbridge/test/onboard-handler.test.js`
+
+Concrete change:
+
+- `onboard-verifier.test.js` covers Step B1's four cases with a fake `auth`
+  whose `authenticateChannelRequest` returns a `ClaimsIdentity`-shaped stub
+  (`{ isAuthenticated, getClaimValue }`), throws for a forged token, and is
+  never reached for an absent header.
+- `onboard-handler.test.js`: keep the existing direct-handler cases; the
+  `fakeContext` already stubs `req.header`. Add a small integration test that
+  feeds a verifier built over a fake `auth` through `createOnboardHandler` to
+  prove the criterion-5 trio end to end: proven `tid` → 200 + `active` + repo;
+  forged proof (auth throws) → 401, no writes; absent header → 401, no writes.
+
+Verification: `bun test test/onboard-verifier.test.js test/onboard-handler.test.js`
+(proven → active + SetRepo; forged → 401, zero upsert/setRepo; absent → 401,
+zero upsert/setRepo).
+
+## Step B6 — Drop default-deny / no-verifier docs
+
+One sentence: remove the "default-deny / no verifier injected" language now that
+the verifier ships.
+
+- Modified: `services/msbridge/README.md`, `services/msbridge/azure-app.md`
+
+Concrete change:
+
+- README § Multi-tenant onboarding: replace the paragraph beginning "Full Bot
+  Framework JWT signature validation … is a peer-authentication substrate …
+  default-deny (every request returns 401)" with one stating the verifier ships:
+  the handler validates the inbound Bot Framework bearer JWT via the same
+  `ConfigurationBotFrameworkAuthentication` used on `/api/messages` and accepts
+  only a proven `tid`; an absent or forged proof returns 401.
+- `azure-app.md` § Hosted: replace the blockquote "Full Bot Framework JWT
+  signature validation for `/onboard` … is deferred; until the verifier lands,
+  `/onboard` is **default-deny**" with a statement that `/onboard` validates the
+  caller's Bot Framework JWT (proven `tid` required). Leave the Bot Framework
+  **credential custody** deferral note intact — that is out of scope per spec.
+
+Verification: no "default-deny" / "no production verifier" / "until the verifier
+lands" strings remain in either doc; `rg -n "default-deny|until the verifier"
+services/msbridge` returns nothing.
+
+## Risks
+
+- `authenticateChannelRequest` is the channel-service token path
+  (`aud === MicrosoftAppId`); confirm the SDK accepts the Teams/Entra token the
+  customer presents to `/onboard`. If the customer presents a Graph/Entra user
+  token rather than a Bot Framework channel token, the verifier rejects it — the
+  tester must drive `/onboard` with a Bot Framework-issued bearer for the bot's
+  `MicrosoftAppId` audience. Documented in Step B6's README note.
+- `c.req.header` is case-insensitive in Hono; read `"authorization"`.
+
+— Staff Engineer 🛠️

--- a/specs/1272-hosted-control-plane-hardening/plan-a-03.md
+++ b/specs/1272-hosted-control-plane-hardening/plan-a-03.md
@@ -1,0 +1,146 @@
+# Plan 1272 Part 03 — Move C: revoke + cross-tenant recess re-arm
+
+Implements design [Move C](design-a.md#revoke-c) (criteria 6–7): webhook-driven
+tenant revoke that also cancels in-flight resume work, plus cross-tenant
+enumeration so a hosted bridge re-arms every active tenant's pending `elapsed`
+recess on restart. Read [spec § criteria 6–7](spec.md) and design Key Decisions
+4–6 + § State invariants before executing. All new behaviour is `multi`-mode
+only; single-tenant `ListOpenRecesses(tenant_id)` and `rearm()` are untouched.
+
+Libraries used: librpc (clients), libtype (new proto messages), libbridge
+(`ResumeScheduler`, store adapter typedef at `src/index.js:17`), libstorage
+(per-record atomic writes for the revoke sweep).
+
+## Step C1 — Proto: ListAllOpenRecesses + MarkTenantRevoked
+
+One sentence: add the two cross-tenant RPCs to the bridge proto; leave the
+per-tenant `ListOpenRecesses` untouched.
+
+- Modified: `services/bridge/proto/bridge.proto`
+
+Concrete change — add to the `Bridge` service:
+
+```proto
+rpc ListAllOpenRecesses(ListAllOpenRecessesRequest) returns (OpenRecessList);
+rpc MarkTenantRevoked(MarkTenantRevokedRequest) returns (MarkTenantRevokedResponse);
+```
+
+plus messages: `ListAllOpenRecessesRequest {}` (no `tenant_id` — design Key
+Decision 5 rejects overloading `ListOpenRecesses` with an empty id);
+`MarkTenantRevokedRequest { string tenant_id = 1; }`;
+`MarkTenantRevokedResponse { int32 recesses_cancelled = 1; int32 callbacks_refused = 2; }`.
+`OpenRecessList`/`OpenRecessRef` already carry `tenant_id` (proto:66–67).
+
+Verification: `just codegen` regenerates libtype bindings; `bun test` in
+`services/bridge` still compiles the service.
+
+## Step C2 — Bridge server: ListAllOpenRecesses (active-tenant filter)
+
+One sentence: implement `ListAllOpenRecesses` to enumerate open recesses across
+all tenants, server-side filtered to tenants whose tenancy state is `active`.
+
+- Modified: `services/bridge/index.js`
+
+Concrete change: new handler walks every recess record in the store (the same
+records `ListOpenRecesses` reads per-tenant) and, for each distinct `tenant_id`,
+joins against `tenancy.ResolveByTenantId`; drop refs whose tenant is not
+`active` (so a revoked tenant's recess can never be re-armed even if revoke
+raced a restart — design § State invariants). Inject the tenancy client the same
+way the existing handlers receive their collaborators.
+
+Verification: `bun test test/*.test.js` in `services/bridge`
+(`ListAllOpenRecesses` returns refs for active tenants across multiple tenants;
+excludes a `revoked` tenant's refs).
+
+## Step C3 — Bridge server: MarkTenantRevoked sweep
+
+One sentence: walk the tenant's recess + callback records under the existing
+libindex writer-lock, drop pending recesses, mark queued callbacks refused, and
+return the counts.
+
+- Modified: `services/bridge/index.js`
+
+Concrete change: new handler acquires the libindex writer-lock, enumerates the
+tenant's recess records and queued callbacks, applies a per-record atomic
+libstorage write (rename primitive) to remove each recess and mark each callback
+refused, and returns `{ recesses_cancelled, callbacks_refused }`. Cross-record
+atomicity is **not** required — a callback that arrives after the sweep is
+refused by the callback handler's existing `ResolveByTenantId` state check
+(design Key Decision 6, § State invariants).
+
+Verification: `bun test test/*.test.js` in `services/bridge`
+(`MarkTenantRevoked` removes the tenant's open recesses, marks its callbacks
+refused, returns matching counts, leaves other tenants' records intact).
+
+## Step C4 — ghbridge uninstall→revoke handler
+
+One sentence: dispatch the uninstall-class webhooks to `tenancy.SetState
+(active→revoked)` then `bridge.MarkTenantRevoked`, mirroring `install-handler.js`.
+
+- Created: `services/ghbridge/src/uninstall-handler.js`
+- Modified: `services/ghbridge/index.js` (route uninstall-class events in
+  `#handleWebhook`, near install dispatch at index.js:311)
+
+Concrete change — `handleUninstall(body, { tenancyClient, discussionClient, logger })`
+fires on `installation.deleted`, `installation.suspend`, and
+`installation.repositories_removed` (an `isUninstallEvent(event, body)` guard
+mirroring `isInstallEvent`). It resolves each affected installation/repo to its
+`tenant_id`, calls `tenancyClient.SetState({ tenant_id, state: "revoked" })`,
+then `discussionClient.MarkTenantRevoked({ tenant_id })`. Guarded by
+`this.#multiTenant` exactly like the install path. Update `install-handler.js`'s
+"The uninstall / `repositories_removed` revoke path is not handled here" note to
+point at the new handler.
+
+Verification: `bun test test/*.test.js` in `services/ghbridge` (uninstall event
+→ `SetState(revoked)` + `MarkTenantRevoked`; subsequent `ResolveByRepo` for the
+revoked repo returns nothing).
+
+## Step C5 — Multi-tenant store adapter binds ListAllOpenRecesses
+
+One sentence: in `multi` mode the bridge process's store adapter implements the
+no-arg `Store.listOpenRecesses()` by calling `ListAllOpenRecesses`; single-tenant
+keeps calling `ListOpenRecesses(tenant_id)`.
+
+- Modified: `services/ghbridge/src/discussion-adapter.js` and
+  `services/msbridge/src/discussion-adapter.js` (whichever owns
+  `listOpenRecesses` — the adapter constructed at boot)
+
+Concrete change: the adapter's `listOpenRecesses()` branches on the deployment
+mode chosen in `server.js`: `multi` → `client.ListAllOpenRecesses({})`; `single`
+→ `client.ListOpenRecesses({ tenant_id })` as today. The libbridge typedef
+(`src/index.js:17`) does not widen and `ResumeScheduler` stays mode-agnostic —
+it calls `store.listOpenRecesses()` (resume-scheduler.js:146) regardless.
+
+Verification: `bun test test/resume.test.js` in both bridges
+(`rearm()` in multi mode schedules recesses across multiple active tenants; none
+dropped; single-tenant `rearm` unchanged).
+
+## Step C6 — Docs: drop the deferred revoke + rearm limitations
+
+One sentence: remove the "Deferred: revoke" and "multi-tenant elapsed-recess
+re-arm on restart" limitation language now that both ship.
+
+- Modified: `services/ghbridge/README.md`, `services/msbridge/README.md`
+
+Concrete change: replace the ghbridge "Deferred: `installation.repositories_removed`
+revoke" section with a statement that uninstall-class webhooks transition the
+tenant `active→revoked` and cancel in-flight recesses/callbacks. Replace the
+"Documented limitation: multi-tenant elapsed-recess re-arm on restart" sections
+in both READMEs with a statement that a hosted restart re-arms every active
+tenant's pending `elapsed` recess via `ListAllOpenRecesses`.
+
+Verification: `rg -n "Deferred: .*revoke|elapsed-recess re-arm on restart"
+services/ghbridge services/msbridge` returns nothing.
+
+## Risks
+
+- The revoke sweep and a concurrent restart can race; correctness depends on
+  `ListAllOpenRecesses`'s active-tenant filter (Step C2) and the callback
+  handler's `ResolveByTenantId` check refusing post-sweep callbacks — neither is
+  visible from the sweep code alone (design § State invariants).
+- `installation.suspend` is treated as a revoke; confirm against the install
+  handler's event set that suspend/unsuspend symmetry is acceptable for this
+  scope (spec criterion 6 names uninstall + `repositories_removed`; suspend is
+  the conservative superset).
+
+— Staff Engineer 🛠️

--- a/specs/1272-hosted-control-plane-hardening/plan-a-04.md
+++ b/specs/1272-hosted-control-plane-hardening/plan-a-04.md
@@ -1,0 +1,76 @@
+# Plan 1272 Part 04 — Move D: kata-setup hosted template version pins
+
+Implements design [Move D](design-a.md) (criterion 8, first clause): the
+kata-setup hosted templates pin the **minimum** sibling-action versions of
+`forwardimpact/kata-agent` (and the `fit-eval` action used by `workflow-react`)
+that accept the `installation-token` input. Read [spec § criterion 8 + Risks](spec.md)
+and design Key Decision 7 before executing.
+
+The hosted templates already emit `installation-token:
+${{ steps.mint.outputs.token }}` (`workflow-agent.md` § Template (Hosted), step
+3); no template body rewrite is needed. The monorepo-side work is the pin alone.
+
+Libraries used: none (skill-markdown + version-pin guidance edit).
+
+## Blocked-on (external)
+
+This part lands only after the sibling repos tag the versions that accept
+`installation-token`:
+
+- `forwardimpact/kata-agent` — `installation-token` input acceptance.
+- `forwardimpact/fit-eval` — `installation-token` input acceptance (the
+  `workflow-react.md` hosted delta passes it; see workflow-react.md:116).
+
+Token acceptance is verified in the sibling repos' own CI (criterion 8, second
+clause), outside this repo. Do **not** gate this part's local verification on a
+cross-repo run.
+
+## Step D1 — Pin the minimum token-accepting sibling versions
+
+One sentence: record, in the hosted "Resolving Action Refs" guidance, the
+minimum sibling release that accepts `installation-token` so the generated pin
+can never resolve below it.
+
+- Modified: `.claude/skills/kata-setup/references/workflow-agent.md`
+  (canonical hosted recipe — § Resolving Action Refs)
+
+Concrete change: in § Resolving Action Refs, add a hosted floor: when generating
+a **hosted** workflow, the picked `vX.Y.Z` tag for `kata-agent` (and `fit-eval`
+for `workflow-react`) must be **≥ the minimum version that accepts
+`installation-token`**; name that minimum explicitly (e.g.
+`kata-agent ≥ v1.M.P`, `fit-eval ≥ v1.M.P`). If the highest available tag is
+below the floor, stop and tell the operator the sibling release has not shipped
+yet — never emit a pin below the floor and never fall back to a mutable tag.
+Keep the existing self-hosted resolution rule unchanged.
+
+Verification: `rg -n "installation-token" .claude/skills/kata-setup/references`
+shows the hosted floor recorded alongside the emit line; the self-hosted
+resolution rule is unchanged.
+
+## Step D2 — Cross-reference the floor from the dependent templates
+
+One sentence: point `workflow-facilitate.md` and `workflow-react.md` at the
+canonical floor so all three hosted recipes pin consistently.
+
+- Modified: `.claude/skills/kata-setup/references/workflow-facilitate.md`
+  (the § Hosted variant note at workflow-facilitate.md:110–126),
+  `.claude/skills/kata-setup/references/workflow-react.md`
+  (the § Hosted variant note at workflow-react.md:116–122)
+
+Concrete change: update each "depends on `kata-agent`/`fit-eval` accepting an
+`installation-token` input" note to read "pin the minimum sibling version that
+does — see [`workflow-agent.md` § Resolving Action Refs]". No template YAML
+changes.
+
+Verification: both files reference the canonical floor in § Resolving Action
+Refs; no duplicated floor numbers (one home — workflow-agent.md).
+
+## Risks
+
+- The floor version numbers are only known once the siblings tag; until then,
+  Step D1 must stop-and-ask rather than guess a number. Do not land a placeholder
+  pin — an under-floor pin silently re-opens the gap on every kata-setup re-run
+  (design Key Decision 7 rejected operator-managed versions for exactly this
+  reason).
+
+— Staff Engineer 🛠️

--- a/specs/1272-hosted-control-plane-hardening/plan-a.md
+++ b/specs/1272-hosted-control-plane-hardening/plan-a.md
@@ -1,0 +1,71 @@
+# Plan 1272 — Hosted control-plane hardening
+
+Implements [design-a.md](design-a.md) for spec [1272](spec.md). The design
+groups the six hosted-path gaps into four independently-shippable moves
+(A/B/C/D). This plan decomposes along that boundary: one part per move, each
+independently executable. No part restates the spec or design — read both
+before executing any part.
+
+## Approach
+
+One part per design move, in the part index below. Each part is gated entirely
+on `*_TENANCY_MODE === "multi"` (or, for Move D, on the hosted template set), so
+the self-hosted / single-tenant path is untouched (criterion 9) — every new
+collaborator is conditioned on `multi` mode and single-tenant test fixtures stay
+unmodified. Each move follows § Clean breaks: it replaces the deferred behaviour
+named in the service README rather than wrapping it, and removes the
+"deferred"/"default-deny" documentation language as it ships.
+
+## Part index
+
+| Part | Move | Scope | Criteria |
+| --- | --- | --- | --- |
+| [plan-a-01.md](plan-a-01.md) | A | `services/ghserver` peer-auth interceptor + externalized App-key custody with in-place rotation | 1–4 |
+| [plan-a-02.md](plan-a-02.md) | B | `services/msbridge` `/onboard` Bot Framework JWT verifier; remove default-deny | 5 |
+| [plan-a-03.md](plan-a-03.md) | C | `services/ghbridge` uninstall→revoke handler, `services/bridge` `ListAllOpenRecesses` + `MarkTenantRevoked`, multi-tenant `rearm` | 6–7 |
+| [plan-a-04.md](plan-a-04.md) | D | `.claude/skills/kata-setup` hosted-template sibling-version pins | 8 |
+
+## Inter-part dependencies
+
+None hard. The four parts share no code and may land in any order, matching
+design Key Decision 8. Two soft notes:
+
+- Part 01 (Move A) provisions external custody and the per-caller peer-token
+  trust root; Part 03's new bridge RPCs ship behind the same bind-address
+  isolation that covers ghserver today, so Part 03 does **not** wait on Part 01.
+- Part 04 (Move D) blocks **externally** on the sibling repos
+  (`forwardimpact/kata-action-agent`, `kata-action-eval`) shipping
+  `installation-token` input acceptance; the monorepo-side work is the version
+  pin alone and is unblocked once the siblings tag.
+
+## Execution recommendation
+
+- Parts 01, 02, 03 → an engineering agent (code + service tests). They are
+  independent and may run in parallel across separate worktrees.
+- Part 04 → `technical-writer` or an engineering agent; it is a
+  template/version-pin edit plus a README note, not service code. Land only
+  after the siblings tag the token-accepting versions.
+- Smallest-first ordering (02 → 03 → 01 → 04) unblocks adopter capability
+  earliest; substrate-first (01 → 03 → 02 → 04) hardens the mint surface before
+  extending it. Either is valid per design § Suggested move ordering.
+
+## Risks
+
+- **Part 01 external custody is environment-shaped.** The key resolver depends
+  on a secret-manager client whose exact API is operator-environment-specific;
+  the plan keeps the resolver behind an injectable collaborator so the test
+  fakes it and the production binding is a thin adapter chosen in `server.js`.
+- **Part 03 cross-record consistency.** `MarkTenantRevoked` applies per-record
+  atomic writes, not a cross-record transaction; correctness relies on the
+  callback handler's existing `ResolveByTenantId` state check refusing any
+  post-sweep callback. A reviewer cannot see this from the RPC alone — it is a
+  design invariant (design § State invariants).
+- **Part 04 is not verifiable in this repo's CI.** Only the version-pin clause
+  of criterion 8 is monorepo-checkable; token acceptance is verified in the
+  sibling repos. Do not block Part 04's local verification on a cross-repo run.
+
+Libraries used: librpc (peer interceptor, clients), libconfig (config keys),
+libbridge (ResumeScheduler, store adapter, handlers), libstorage (atomic
+record writes), libtype (proto messages), botbuilder (onboard verifier).
+
+— Staff Engineer 🛠️

--- a/specs/1272-hosted-control-plane-hardening/spec.md
+++ b/specs/1272-hosted-control-plane-hardening/spec.md
@@ -126,3 +126,25 @@ deployment and must not regress (criterion 9).
 - **Revoke and resume interact (items 4 and 5).** Revoke must also dispose of a
   tenant's in-flight recesses and queued callbacks, not only flip the row state;
   criterion 6 covers the "no longer resume" property explicitly.
+
+## Field findings (post-approval)
+
+- **2026-06-16 — multi-tenant Azure Bot resources are deprecated.** Manual e2e
+  testing hit a hard wall: Microsoft no longer permits creating a multi-tenant
+  Azure Bot resource, in the portal **or** the CLI
+  (`az bot create --app-type MultiTenant` → `InvalidBotCreationData: Multitenant
+  bot creation is deprecated. Please use SingleTenant or UserAssignedMSI`).
+  Existing multi-tenant bots are grandfathered; multi-tenant Entra **app**
+  registrations are still allowed — only the Bot *resource* type is gone. This
+  invalidates the spec 1270 operator commitment of "a multi-tenant Azure AD app
+  and Bot Framework resource… installable by any consenting Entra tenant"; the
+  hosted Teams path as designed cannot be stood up fresh. The supported
+  replacement (researched 2026-06-16) is a **single-tenant Azure Bot resource +
+  multi-tenant Entra app (`signInAudience = AzureADMultipleOrgs`) + Teams Store /
+  AppSource distribution** — one shared app reaches every tenant, not a
+  per-customer bot and not Graph change-notifications. Relatedly the **Bot
+  Framework SDK is end-of-life** (support ends 2025-12-31); the conversational
+  bot evolves into a Teams **custom engine agent** on the **Microsoft 365 Agents
+  SDK**. This transport re-architecture is a new spec, not a tweak here. The
+  `services/tenancy` mapping and the Move B `/onboard` repo-mapping verifier are
+  transport-agnostic and survive.

--- a/specs/1273-unified-per-user-dispatch-identity/design-a.md
+++ b/specs/1273-unified-per-user-dispatch-identity/design-a.md
@@ -1,0 +1,189 @@
+# Design 1273 — Unified per-user dispatch identity
+
+## Problem restated
+
+[Spec 1270](../1270-kata-bridges-public-hosting/spec.md) split the
+`workflow_dispatch` credential by deployment mode: self-hosted dispatches under
+a per-user OAuth token from `services/ghuser`; hosted dispatches under a
+repo-scoped App installation token from `services/ghserver`. The split lives as
+a `tenancy_mode` branch in both bridges and attributes hosted runs to the App
+bot, not the human. Spec 1273 unifies dispatch identity on the per-user token in
+both modes, and threads the resolved tenant id through `services/ghuser` so the
+per-user path actually works multi-tenant.
+
+## Scope (from the spec)
+
+- **In:** unify the `workflow_dispatch` credential on the `ghuser`-backed
+  per-user token in `services/msbridge` and `services/ghbridge`; thread the
+  resolved tenant id from the bridge's `PutPendingDispatch` write through
+  `services/oauth` `/authorize` → `ghuser` `Begin` → its pending-dispatch proof,
+  replacing `SINGLE_TENANT_ID`; make `services/ghuser` required in both
+  deployment models; update affected guides including `TRUST.md`.
+- **Out:** tenant → repository resolution (registry vs static — that _is_ the
+  mode definition); keyless workflow identity (`services/ghserver`, fronted by
+  `services/oidc`) for a workflow's own operations; self-hosted dispatch
+  (already per-user); reply/reaction credentials. This design removes
+  `services/ghserver` from the dispatch path only and takes no position on its
+  fate elsewhere.
+
+## Two axes, only one mode-selected
+
+The bridges compose two independent resolvers. Today both branch on
+`tenancy_mode`. This design collapses the **dispatch-identity** branch to a
+single path and leaves the **repository-resolution** branch untouched.
+
+| Axis                                  | Today                                                                                                                        | After 1273                                                |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Dispatch identity (WHO fires the run) | `tenancy_mode` selects `TokenResolver` (single) vs `GhServerTokenResolver` (multi, gated on `multiTenant && ghserverClient`) | Always `TokenResolver` (`ghuser` per-user), unconditional |
+| Repository resolution (WHICH repo)    | `tenancy_mode` selects `DefaultTenantResolver` (single) vs `RegistryTenantResolver` (multi)                                  | Unchanged — still mode-selected                           |
+
+After this change `tenancy_mode` governs repository resolution and the
+reply-token path, never dispatch identity.
+
+## Components and interfaces
+
+- **`libbridge` `TokenResolver`** (`token-resolver.js`) — the single dispatch
+  credential resolver. Wraps the `ghuser` `GetToken` oneof into a `DispatchAuth`
+  (`token` / `link_required` / `reauth_required` / `transient`). Becomes the
+  only `tokenResolver` the `Dispatcher` sees in both bridges.
+- **`libbridge` `GhServerTokenResolver`** (`ghserver-token-resolver.js`) — the
+  App-token dispatch path. **Removed** (clean break). It minted a repo-scoped
+  installation token from `services/ghserver` and attributed the run to the App,
+  which is exactly the attribution loss 1273 reverses.
+- **`libbridge` tenant resolvers** (`tenant-resolver.js`) —
+  `RegistryTenantResolver` (multi) vs `DefaultTenantResolver` (single).
+  **Unchanged.** They remain the sole `tenancy_mode` branch, and produce the
+  `tenant_id` that the dispatch path now carries into `ghuser`.
+- **`services/ghuser` `Ghuser.GetToken`** — the **dispatch-time** credential
+  fetch, keyed by `(surface, surface_user_id)`; it carries **no** tenant. On an
+  unlinked user returns `link_required` with an authorize URL; on
+  revoked/expired returns `re_auth_required` (the proto field; the resolver maps
+  it to the `reauth_required` kind). Unchanged. Required in both deployment
+  models.
+- **`services/oauth` `/authorize` → `ghuser` `Begin`** — the **link-time**
+  authorize path. `services/oauth` owns the `/authorize` HTTP endpoint
+  (`index.js`) and calls `ghuser`'s `Begin` with a `BeginRequest`. **New tenant
+  carrier:** `services/oauth`'s `/authorize` query gains a `tenant_id`
+  parameter, and `ghuser`'s `BeginRequest` proto gains a `tenant_id` field (it
+  has none today). This is the load-bearing interface addition — see Key
+  Decisions.
+- **`services/ghuser` identity contract** (`src/identity-contracts.js`) — the
+  `bridgePendingDispatchProof` contract (evaluated at `Begin`) calls
+  `bridgeClient.VerifyPendingDispatch` with a hard-coded
+  `tenant_id: SINGLE_TENANT_ID` (`"default"`). This design replaces that literal
+  with the **resolved tenant id** carried in on `BeginRequest`, so the proof is
+  keyed per tenant.
+- **`services/bridge` `PutPendingDispatch` / `VerifyPendingDispatch`** — already
+  tenant-scope their keyspace (`${tenant_id}:${link_token}`). **Unchanged**: the
+  keyspace is correct. The bridge writes the proof via `PutPendingDispatch`
+  (called from `services/msbridge` / `services/ghbridge`
+  `discussion-adapter.js`, threading the resolved tenant); only `ghuser` must
+  stop passing the hard-coded tenant on the verify side so its lookups land in
+  the right per-tenant slot.
+- **Bridge composition roots** — `services/msbridge` and `services/ghbridge`
+  (`index.js` constructors + `server.js` wiring) stop selecting the dispatch
+  resolver by mode and stop passing a ghserver client _for dispatch_.
+
+### Where ghserver still lives (and why that is in scope)
+
+`services/msbridge` constructed `ghserverClient` **only** for dispatch, so it
+stops constructing it entirely. `services/ghbridge` also uses `ghserverClient`
+on the multi-tenant **reply/reaction** path (`makeGraphqlClient` /
+`getInstallationToken`, per-tenant GraphQL installation tokens) — that path is
+out of scope, so ghbridge **retains** the client for replies and removes it only
+from the dispatch wiring.
+
+## Tenant threading (the multi-tenant addition)
+
+Multi-tenant dispatch breaks unless the per-user proof is scoped to the
+dispatching user's tenant. `services/bridge` already keys pending dispatches by
+`(tenant_id, link_token)`; the single hard-coded `"default"` in `ghuser` means
+its `VerifyPendingDispatch` only ever probes the default slot, so a second
+tenant's proof cannot be found. This design routes the **resolved tenant id**
+two ways: the bridge writes the proof via `services/bridge`
+`PutPendingDispatch`, keyed by the resolved tenant; and the same tenant id is
+carried through `services/oauth`'s `/authorize` into `ghuser`'s `Begin`
+(`BeginRequest.tenant_id`), where the `bridgePendingDispatchProof` contract's
+`VerifyPendingDispatch` call reads it, replacing `SINGLE_TENANT_ID`. Single
+tenant supplies the literal `"default"`; multi-tenant supplies the
+registry-resolved tenant id. One keyspace, correct per tenant. The dispatch-time
+`GetToken` is untouched — it never carried a tenant.
+
+## Authorization: delegated to GitHub
+
+There is no separate authz layer. The per-user token grants exactly the
+dispatcher's GitHub repo access, so GitHub adjudicates every dispatch:
+
+- **Unlinked user** → `GetToken` returns `link_required`; the bridge has no
+  token to fire with and emits the existing link prompt. The link prompt **is**
+  the denial path.
+- **Linked but unauthorized user** → a token exists, but `workflow_dispatch`
+  against the resolved repo is refused by GitHub (403). No bridge-side
+  allowlist.
+- **Linked and authorized user** → the run executes under their identity; GitHub
+  records the human as actor.
+
+## Data flow
+
+Two flows share the resolved `tenant_id`: the **link/authorize** flow (where the
+tenant is threaded, one-time per user) and the **dispatch** flow (where
+`GetToken` fetches the already-bound credential, keyed by
+`(surface, surface_user_id)` only).
+
+```mermaid
+flowchart TD
+  msg[Channel message<br/>surface + surface_user_id] --> bridge[Bridge intake]
+  bridge --> tr{tenancy_mode}
+  tr -->|single| dft[DefaultTenantResolver<br/>static repo + tenant=default]
+  tr -->|multi| reg[RegistryTenantResolver<br/>registry lookup + tenant id]
+  dft --> tid[(resolved repo + tenant_id)]
+  reg --> tid
+
+  subgraph link[Link / authorize flow — tenant_id threaded]
+    tid -.tenant_id.-> put[Bridge putPendingDispatch<br/>services/bridge PutPendingDispatch<br/>key = tenant_id:link_token]
+    tid -.tenant_id.-> auth[services/oauth /authorize<br/>carries tenant_id]
+    auth --> begin[ghuser Begin<br/>BeginRequest + tenant_id]
+    begin --> vpd[ghuser VerifyPendingDispatch<br/>tenant_id = resolved, not SINGLE_TENANT_ID]
+  end
+
+  tid --> tok[TokenResolver<br/>ghuser GetToken surface,surface_user_id<br/>UNCONDITIONAL — no tenant_id]
+  tok --> ghuser[(services/ghuser)]
+  ghuser -->|token| disp[Dispatcher.dispatch<br/>workflow_dispatch as user]
+  ghuser -->|link_required| prompt[Emit link prompt<br/>= denial]
+  tid --> disp
+  disp --> gh{GitHub authorizes}
+  gh -->|access ok| run[Run actor = human]
+  gh -->|403| refused[Dispatch refused]
+```
+
+The mode branch is on repository/tenant resolution only; the dispatch token path
+no longer forks. The resolved `tenant_id` is carried on the link/authorize path
+— into `services/bridge`'s `PutPendingDispatch` write and through
+`services/oauth` `/authorize` → `ghuser` `Begin` → `VerifyPendingDispatch` — not
+through `GetToken`, which is keyed by `(surface, surface_user_id)` alone.
+
+## Key Decisions
+
+| Decision                        | Choice                                                                                                                                                                         | Rejected alternative                                                                                                                                                                                                                |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dispatch credential             | One per-user `ghuser` token in both modes                                                                                                                                      | Keep the App token + a separate attribution layer — rejected: an attribution layer relabels logs but does not change the GitHub run _actor_, so audit fidelity stays bot-level.                                                     |
+| Tenant scoping of the proof     | Thread the real resolved `tenant_id` end-to-end through the bridge's `PutPendingDispatch` write and `services/oauth` `/authorize` → `ghuser` `Begin` → `VerifyPendingDispatch` | Keep the hard-coded `"default"` tenant — rejected: a single-tenant proof keyspace cannot distinguish tenants, so cross-tenant per-user dispatch proofs would collide or fail.                                                       |
+| Tenant carrier on the link path | Add a `tenant_id` query param to `services/oauth` `/authorize` and a `tenant_id` field to `ghuser`'s `BeginRequest` (neither exists today)                                     | Reuse `GetToken` to carry the tenant — rejected: `GetToken` is the dispatch-time fetch keyed by `(surface, surface_user_id)`; the binding is established once at link time, so the tenant belongs on the authorize/`Begin` path.    |
+| Authorization model             | GitHub repo access via the per-user token                                                                                                                                      | A bridge-side allowlist of who may dispatch — rejected: a parallel authz surface that drifts from GitHub's own grants and duplicates state GitHub already owns.                                                                     |
+| App-token dispatch path         | Clean removal of `GhServerTokenResolver` and dispatch-only `ghserverClient` wiring                                                                                             | Keep it as a fallback — rejected: a fallback _is_ the `tenancy_mode` dispatch branch this spec deletes, and it reintroduces bot-vs-human attribution; clean break per [CONTRIBUTING § Clean breaks](../../CONTRIBUTING.md#read-do). |
+| `services/ghuser` dependency    | Required in both deployment models                                                                                                                                             | Optional in hosted (1270's onboarding-floor reduction) — rejected: optionality is exactly what forced the per-mode dispatch split 1273 removes.                                                                                     |
+
+## Mapping to success criteria
+
+| #   | Criterion                                                 | How this design satisfies it                                                                                                                   |
+| --- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Dispatch runs as the user in both modes                   | `TokenResolver` (per-user) is the unconditional dispatch credential; GitHub records the linked human as actor.                                 |
+| 2   | No `tenancy_mode` branch selects the dispatch credential  | The dispatch resolver is constructed unconditionally; the only surviving mode branch selects the tenant resolver (repo).                       |
+| 3   | Proof keyed by resolved tenant id, not `SINGLE_TENANT_ID` | The identity contract passes the threaded tenant id to `VerifyPendingDispatch`; `services/bridge`'s existing per-tenant keyspace then matches. |
+| 4   | Unlinked/expired-link: no dispatch + link prompt          | `GetToken` → `link_required` / `reauth_required` yields no token, so the bridge fires nothing and emits the existing prompt.                   |
+| 5   | Linked-but-unauthorized: GitHub-refused dispatch          | A token exists, so a dispatch is attempted; GitHub refuses `workflow_dispatch` (403). No bridge-side check (integration/manual).               |
+| 6   | `ghuser` required in both models                          | `GhuserClient` is a contractual dependency of both bridges in single and multi.                                                                |
+| 7   | Self-hosted dispatch unchanged                            | Single-tenant already used `TokenResolver` with `tenant_id = "default"`; its path and tests are untouched.                                     |
+| 8   | Multi-tenant repo resolution unchanged                    | `RegistryTenantResolver` / `resolveByRepo` are not in scope; the repo axis is preserved verbatim.                                              |
+
+— Staff Engineer 🛠️

--- a/specs/1273-unified-per-user-dispatch-identity/spec.md
+++ b/specs/1273-unified-per-user-dispatch-identity/spec.md
@@ -1,0 +1,169 @@
+# Spec 1273 — Unified per-user dispatch identity
+
+## Persona and job
+
+Serves **Teams Using Agents** —
+[run a continuously improving agent team](../../JTBD.md#teams-using-agents-run-a-continuously-improving-agent-team).
+A team chats with the Kata Team "as themselves"; the runs and commits the team
+triggers should be attributed to the human who asked, in every deployment mode.
+
+This spec sits in tension with that job's **Little Hire** — "onboard a Kata
+installation that runs the Plan-Do-Study-Act loop without per-team prompt
+engineering." Unifying dispatch identity raises the hosted onboarding floor:
+every hosted dispatcher must now link a GitHub account before they can trigger a
+run. The WHY below weighs that cost against the attribution and audit gain.
+
+## Problem
+
+[Spec 1270](../1270-kata-bridges-public-hosting/spec.md) split the
+`workflow_dispatch` credential by deployment mode. Self-hosted (single-tenant)
+fires `workflow_dispatch` under a **per-user OAuth token** resolved through
+`services/ghuser`. Hosted (multi-tenant) fires it under a **repo-scoped App
+installation token** minted by `services/ghserver`. The two GitHub apps and the
+per-mode split are documented in
+[`services/ghuser/github-app.md`](../../services/ghuser/github-app.md) and
+[`services/ghserver/github-app.md`](../../services/ghserver/github-app.md).
+
+> Note: 1270 § Excluded names the per-user OAuth service `services/ghauth`; it
+> was renamed to `services/ghuser` in
+> [spec 1271](../1271-rename-ghauth-to-ghuser/spec.md). A reader
+> cross-referencing 1270 should treat `services/ghauth` and `services/ghuser` as
+> the same surface.
+
+This split has two consequences:
+
+1. **Dispatch identity diverges by deployment mode.** The bridges select the
+   dispatch credential on `tenancy_mode` — a mode-specific branch that is a
+   recurring source of gotchas and asymmetric behaviour between the two paths.
+2. **Hosted runs and commits are attributed to a bot, not the human.** On the
+   hosted path the run executes under the server App installation token, so
+   GitHub records the App as the actor. Field-observed 2026-06-16: a
+   multi-tenant Teams dispatch ran as "kata-agent-team [Bot]" rather than the
+   dispatching user. This loses attribution and audit fidelity and contradicts
+   the product intent of chatting with the Kata Team "as yourself."
+
+### Why this reverses a 1270 decision
+
+1270 did not "accept lower attribution fidelity" as a goal. It **chose** the
+repo-scoped App installation token for hosted dispatch and left per-user
+dispatch identity out of scope and unchanged on the hosted path (1270 §
+Excluded). That choice served 1270's own Little Hire: a hosted adopter could
+onboard and dispatch with **no per-user link** and no operator intervention
+(1270's onboarding success criteria). Lowering the hosted onboarding floor was
+the point.
+
+This spec makes the opposite trade. It accepts a higher onboarding floor — every
+hosted dispatcher must link a GitHub account — in exchange for two gains:
+uniform dispatch behaviour across modes (one credential path, no `tenancy_mode`
+fork on identity) and real per-user attribution and audit fidelity on the hosted
+path. The cost lands on the Teams-Using-Agents Little Hire above; the gain lands
+on the Big Hire's promise of chatting with the team "as yourself." The
+reintroduced onboarding cost is a one-time per-user link — each hosted
+dispatcher links once, then dispatches without further intervention.
+
+## Proposal
+
+Unify dispatch identity across both deployment modes. The bridges always resolve
+the `workflow_dispatch` credential through `services/ghuser` (per-user OAuth),
+in single-tenant and multi-tenant deployments alike. There is one
+dispatch-credential path; the `tenancy_mode` branch that selects the dispatch
+credential is removed.
+
+For multi-tenant deployments, the per-user dispatch identity must be scoped to
+the resolved tenant. `services/ghuser` is currently hard-wired to a single
+`"default"` tenant (the `SINGLE_TENANT_ID` behaviour in its identity contracts),
+and explicitly defers the multi-tenant case to "a future multi-tenant spec."
+This spec is that spec, naming the full threading path by behaviour:
+
+1. The bridge writes the pending-dispatch proof keyed by the resolved tenant —
+   `PutPendingDispatch` via `services/bridge`, which already keys its keyspace
+   by the resolved tenant id.
+2. The resolved tenant id is carried through `services/oauth`'s `/authorize`
+   request into `ghuser`'s `Begin`.
+3. `ghuser`'s `bridgePendingDispatchProof` reads that resolved tenant when it
+   calls `VerifyPendingDispatch`, instead of the hard-coded single tenant.
+
+The outcome (contract level): per-user dispatch is correctly tenant-scoped in
+multi-tenant mode, replacing the single hard-coded tenant. Without this, the
+unification cannot actually work multi-tenant.
+
+GitHub repository access becomes the authorization model for dispatch:
+authorization is delegated to GitHub, with no bridge-side access check. There
+are two distinct cases. An **unlinked or expired-link** user produces no token,
+so the bridge fires no dispatch and emits the existing link/reauth prompt — this
+is unchanged bridge behaviour. A **linked-but-unauthorized-on-repo** user does
+have a token, so a dispatch is attempted; GitHub then refuses the
+`workflow_dispatch` (403) at dispatch time. `services/ghuser` runs in every
+deployment.
+
+This reverses two spec 1270 decisions:
+
+- Hosted `workflow_dispatch` uses the server App installation token.
+- The hosted path requires no per-user link (the deliberate onboarding-floor
+  reduction).
+
+## Scope
+
+### In scope
+
+- Remove the deployment-mode-conditional selection of the **dispatch
+  credential** in `services/msbridge` and `services/ghbridge`, so the per-user
+  token resolved through `services/ghuser` is the single source of the
+  `workflow_dispatch` identity in both modes.
+- Thread the resolved tenant id along the linking path: the bridge writes the
+  proof via `services/bridge` `PutPendingDispatch` (keyed by the resolved
+  tenant); the tenant is carried through `services/oauth`'s `/authorize` into
+  `ghuser`'s `Begin`; and `ghuser`'s `VerifyPendingDispatch` call reads the
+  resolved tenant instead of the hard-coded single tenant (`SINGLE_TENANT_ID`),
+  so per-user dispatch is correctly tenant-scoped in multi-tenant mode.
+- Remove the now-orphaned dispatch-only credential path as a clean break: the
+  App-token dispatch resolver and its dispatch-only `ghserverClient` wiring in
+  `services/msbridge` and `services/ghbridge`, whose only consumers are the
+  deleted dispatch branches. `services/ghbridge` **retains** its
+  `ghserverClient` for the out-of-scope reply/reaction path (per-tenant GraphQL
+  installation tokens), which is unchanged.
+- `services/ghuser` is a required service in both the self-hosted and hosted
+  deployment models.
+- Update the GitHub-app guides and any deployment documentation that describe
+  the per-mode dispatch-credential split, **including `TRUST.md`** (its
+  "Workflow runs the hosted operator can observe" section asserts hosted
+  `workflow_dispatch` uses the `services/ghserver` installation token — this
+  spec reverses that), to reflect the unified model.
+
+### Excluded
+
+- **Tenant → repository resolution is unchanged.** Multi-tenant resolves the
+  target repository by registry lookup; single-tenant uses static configuration.
+  That resolution _is_ the definition of the tenancy modes; only the dispatch
+  **identity** is unified, not the repository resolution. The `tenancy_mode`
+  branch legitimately remains for tenant → repo resolution and for the
+  reply-token path.
+- **Keyless workflow identity** (`services/ghserver`, fronted by
+  `services/oidc`) — the credential a kata workflow uses for its **own** GitHub
+  operations once it is running. `services/oidc` is the public front for
+  `services/ghserver`'s keyless workflow-identity exchange (GitHub Actions
+  OIDC), not for per-user linking. That concerns what a workflow does after it
+  starts, not who triggers it, and is a separate future decision. This spec
+  removes `services/ghserver` from the **dispatch** path but does not decide
+  `services/ghserver`'s fate, and does not touch `services/oidc`. The per-user
+  linking front in scope here is `services/oauth` (see Proposal), not
+  `services/oidc`.
+- **The discussion-reply and reaction credentials** (the App installation token
+  used for replies, minted via `services/ghserver`), which are outside the
+  dispatch path. `services/ghserver` therefore stays a **required** service for
+  this reply/reaction path — it is not deprecated wholesale by this spec.
+- Self-hosted dispatch behaviour, which already uses the per-user token and is
+  not changed.
+
+## Success criteria
+
+| #   | Claim                                                                                                                    | Verified by                                                                                                                                                                                                                                                         |
+| --- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | A `workflow_dispatch` runs under the dispatching user's GitHub identity in both single-tenant and multi-tenant modes.    | Integration / manual check (no in-repo unit hook): a dispatch in each mode produces a workflow run whose actor is the linked dispatching user, not the server App. The observed run actor (the linked user login) is recorded on the implementing PR for each mode. |
+| 2   | The bridges contain no `tenancy_mode` branch that selects the **dispatch credential**.                                   | Inspection of `services/msbridge` and `services/ghbridge` shows a single dispatch-credential path with no mode-conditional credential selection (the `tenancy_mode` branch may still appear for tenant → repo resolution and the reply-token path).                 |
+| 3   | The multi-tenant pending-dispatch proof is keyed by the resolved tenant id, not the hard-coded single tenant.            | `services/ghuser` tests (`identity-verification.test.js`) show `PutPendingDispatch` / `VerifyPendingDispatch` proof scoped to the resolved tenant id, replacing `SINGLE_TENANT_ID`.                                                                                 |
+| 4   | A dispatch by an unlinked or expired-link user fires no `workflow_dispatch` and returns the existing link/reauth prompt. | The bridge `dispatch-auth` tests (`services/ghbridge/test/dispatch-auth.test.js`) show the `link_required` / `reauth_required` path fires no `workflow_dispatch` and returns the existing link prompt to the user.                                                  |
+| 5   | A linked-but-unauthorized-on-repo user has the `workflow_dispatch` refused by GitHub.                                    | Integration / manual check: a dispatch by a linked user lacking access to the resolved repo is rejected by GitHub (403) at dispatch time; there is no bridge-side access check.                                                                                     |
+| 6   | `services/ghuser` is required in both deployment models.                                                                 | The self-hosted and hosted deployment documentation and configuration both list `services/ghuser` as a required service.                                                                                                                                            |
+| 7   | Self-hosted dispatch behaviour is unchanged.                                                                             | The existing bridge `dispatch-auth` tests (single-tenant dispatch + link-prompt behaviour) pass unmodified.                                                                                                                                                         |
+| 8   | Multi-tenant tenant → repository resolution is unchanged.                                                                | The existing `resolveByRepo` resolution tests (libbridge/tenancy resolver tests, e.g. `tenant-resolver.test.js`) pass unmodified.                                                                                                                                   |


### PR DESCRIPTION
## Summary

Lands three related threads from a hosted-path manual-testing session (kept together per request):

- **Spec 1272 Move B** — real Bot Framework JWT verifier on `POST /onboard` (default-deny removed); the Bot Framework app type now follows `MICROSOFT_APP_TENANT_ID` (SingleTenant when set) independent of `tenancy_mode`, so a single-tenant Azure bot drives multi-tenant registry resolution + `ghserver` minting.
- **Hosted-path integration fixes** — the 1270 multi-tenant control plane had never run end-to-end; three never-run-live bugs fixed: `tenancy` built its logger before the runtime; generated gRPC clients rejected plain request objects (now coerced); `ghserver` rejected its numeric GitHub App id.
- **`scripts/seed-tenancy.mjs`** — reusable tenancy seeding for local multi-tenant testing.
- **Spec 1272 artifacts** — recovered reviewed `design-a`, added the decomposed plan (moves A–D), recorded post-approval field findings (multi-tenant Azure bot deprecation; never-ran-live path).
- **Spec 1273** — unified per-user dispatch identity (+ `design-a`), reviewed across two cold panels.

**Scope note:** only **Move B** of plan 1272 (A–D) is implemented; A/C/D remain. STATUS set to `1272 plan approved`, `1273 design approved` (not `plan implemented`).

## Test plan

- [x] `bun test` — msbridge 56 pass; 327 across affected packages
- [x] `bun run check` — green except the pre-existing wiki audit (unrelated)
- [ ] CI `check` + `test`