### PR TITLE
ci(kata): gate kata-* workflows on KATA_KILLSWITCH variable

### DIFF
--- a/.claude/skills/kata-setup/SKILL.md
+++ b/.claude/skills/kata-setup/SKILL.md
@@ -52,6 +52,8 @@ facilitated sessions, and event-driven responses.
 - [ ] Secrets reference names match what was configured.
 - [ ] Agent profiles match the names the user confirmed.
 - [ ] kata-dispatch workflow includes the recursion guard.
+- [ ] Every generated workflow's first step is the `Kata killswitch` gate
+      (before any token mint or checkout).
 
 </do_confirm_checklist>
 
@@ -136,6 +138,13 @@ the first workflow run." The hosted blocks carry no `KATA_APP_PRIVATE_KEY`.
 Generate one workflow per agent. Storyboard and coaching workflows are generated
 only when `improvement-coach` is selected.
 
+Every template's first step is a `Kata killswitch` gate that reads the
+`KATA_KILLSWITCH` repository (or org) Actions variable and fails the run when it
+holds a truthy value (anything other than empty, `0`, `false`, `no`, or `off`).
+Keep it first so an engaged switch halts the run before any token mint, checkout,
+or agent work. It is unset by default, so it has no effect until an operator sets
+it.
+
 ### Step 3: Generate kata-dispatch
 
 If `product-manager` is selected, ask: "Do you want agents to respond to PR
@@ -165,5 +174,8 @@ Summarize what was created and suggest next steps:
 
 - Customize agent profiles if using defaults
 - Adjust schedules after observing initial runs
+- To halt all kata workflows at once (an emergency stop), set the
+  `KATA_KILLSWITCH` repository variable to a truthy value (e.g. `1`); clear or
+  unset it to resume
 - Read the [Kata internals](https://www.forwardimpact.team/docs/internals/kata/)
   for architecture details

--- a/.claude/skills/kata-setup/references/workflow-agent.md
+++ b/.claude/skills/kata-setup/references/workflow-agent.md
@@ -45,6 +45,20 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
+      # Killswitch: fail fast when the KATA_KILLSWITCH variable holds a truthy
+      # value, so an operator can halt every kata workflow from one place
+      # without disabling each one. Keep it the first step so the run fails
+      # before any token minting, checkout, or agent work.
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off) echo "Kata killswitch not engaged; proceeding." ;;
+            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2; exit 1 ;;
+          esac
+
       - uses: forwardimpact/kata-agent@{{KATA_AGENT_REF}}
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
@@ -66,7 +80,9 @@ the **canonical** hosted recipe — `workflow-facilitate.md` and
 `workflow-react.md` reference the mint step below.
 
 1. Add `id-token: write` to `permissions` (keep `contents: write`).
-2. Insert this OIDC mint step as the first entry under `steps:`:
+2. Insert this OIDC mint step directly **after** the `Kata killswitch` step
+   (the killswitch stays first so an engaged switch fails before any token
+   mint):
 
    ```yaml
          - name: Mint installation token via Forward Impact OIDC

--- a/.claude/skills/kata-setup/references/workflow-agent.md
+++ b/.claude/skills/kata-setup/references/workflow-agent.md
@@ -14,14 +14,14 @@ the user's configuration.
 | `{{WIKI}}`           | `"true"` or `"false"`                                    |
 | `{{KATA_AGENT_REF}}` | `b4a5b262f3d7acaee2da63f8b2a09bcf4730d804 # v1.0.0`      |
 
-`{{KATA_AGENT_REF}}` is resolved at generation time — see
-[§ Resolving action refs](#resolving-action-refs).
+`{{KATA_AGENT_REF}}` is resolved at generation time (see [§ Resolving action
+refs](#resolving-action-refs)). The `Kata killswitch` step below is the canonical
+copy `workflow-facilitate.md` and `workflow-react.md` reference.
 
-Emit `## Template (self-hosted)` when the team runs its own GitHub App (the
-default), or apply `## Template (hosted)` when the team uses the Forward
-Impact-hosted control plane (see [`SKILL.md`](../SKILL.md) `--hosted`). The
-hosted variant carries no `KATA_APP_PRIVATE_KEY`; it mints a short-lived
-installation token from `services/oidc` at run time.
+Emit `## Template (self-hosted)` for a team's own GitHub App (default), or
+`## Template (hosted)` for the Forward Impact-hosted control plane (see
+[`SKILL.md`](../SKILL.md) `--hosted`) — no `KATA_APP_PRIVATE_KEY`, mints a
+short-lived `services/oidc` token at run time.
 
 ## Template (Self-Hosted)
 
@@ -45,10 +45,8 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
-      # Killswitch: fail fast when the KATA_KILLSWITCH variable holds a truthy
-      # value, so an operator can halt every kata workflow from one place
-      # without disabling each one. Keep it the first step so the run fails
-      # before any token minting, checkout, or agent work.
+      # Killswitch: halt every kata workflow by setting KATA_KILLSWITCH truthy.
+      # Keep it first so it fails before any token mint, checkout, or agent work.
       - name: Kata killswitch
         shell: bash
         env:
@@ -75,14 +73,12 @@ jobs:
 
 ## Template (Hosted)
 
-The hosted variant is the self-hosted template with three changes. This is
-the **canonical** hosted recipe — `workflow-facilitate.md` and
-`workflow-react.md` reference the mint step below.
+The hosted variant is the self-hosted template with three changes (the
+**canonical** hosted recipe the other workflow files reference):
 
 1. Add `id-token: write` to `permissions` (keep `contents: write`).
 2. Insert this OIDC mint step directly **after** the `Kata killswitch` step
-   (the killswitch stays first so an engaged switch fails before any token
-   mint):
+   (the killswitch stays first):
 
    ```yaml
          - name: Mint installation token via Forward Impact OIDC
@@ -103,39 +99,30 @@ the **canonical** hosted recipe — `workflow-facilitate.md` and
              printf 'token=%s\n' "$INSTALL_TOKEN" >> "$GITHUB_OUTPUT"
    ```
 
-3. In the `kata-agent` step, drop the `app-id` and
-   `app-private-key` inputs and add
+3. In the `kata-agent` step, drop `app-id`/`app-private-key` and add
    `installation-token: ${{ steps.mint.outputs.token }}`.
 
-`FIT_OIDC_URL` is a repository **variable** (not a secret) — the Forward
-Impact-operated `services/oidc` URL. `::add-mask::` keeps the minted token
-out of logs.
+`FIT_OIDC_URL` is a repository **variable** (not a secret): the Forward Impact
+`services/oidc` URL. `::add-mask::` keeps the minted token out of logs.
 
 ## Resolving Action Refs
 
-Generated workflows pin the published action to an immutable commit SHA,
-never the mutable `v1` tag. At generation time, list release tags with
-`gh api repos/forwardimpact/kata-agent/tags`
+Pin the published action to an immutable SHA, never the mutable `v1` tag. At
+generation time list release tags with `gh api repos/forwardimpact/kata-agent/tags`
 (`repos/forwardimpact/fit-eval/tags` for `{{FIT_EVAL_REF}}` in
-`workflow-react.md`), pick the highest `vX.Y.Z` tag (ignore the bare `v1`
-marker), and emit `<full-40-char-sha> # <tag>` so the `uses:` line reads
-`forwardimpact/kata-agent@b4a5b262f3d7acaee2da63f8b2a09bcf4730d804 # v1.0.0`.
-If resolution fails, stop and ask the operator — never fall back to a
-mutable tag. Pair the pins with the `github-actions` Dependabot config
-from `SKILL.md` Step 2 so they receive bump PRs instead of rotting.
+`workflow-react.md`), pick the highest `vX.Y.Z` tag, and emit
+`<full-40-char-sha> # <tag>`. If resolution fails, stop and ask the operator —
+never fall back to a mutable tag. Pair the pins with the `github-actions`
+Dependabot config from `SKILL.md` Step 2.
 
 ## Notes
 
-- **Cron entries** come from `schedules.md`. Agents with only a night shift
-  (security-engineer, technical-writer) get one cron line; agents with all three
-  shifts get three.
-- **File name** follows `agent-{name}.yml` (e.g., `agent-product-manager.yml`).
-- The `permissions: contents: write` block restricts `GITHUB_TOKEN`. The App
-  token carries all other permissions via its installation settings.
-- If wiki is disabled, set `wiki: "false"` -- the action skips wiki checkout and
-  sync.
-- If model is the default (`claude-opus-4-8[1m]`), the `agent-model:` line
-  can be omitted since the action defaults to it.
-- **Hosted variant** requires the `FIT_OIDC_URL` repository variable and
-  depends on `kata-agent` accepting an `installation-token` input
-  (pin the minimum sibling SHA that does).
+- **Cron** comes from `schedules.md` — one line for night-only agents
+  (security-engineer, technical-writer), three for the rest.
+- **File name** is `agent-{name}.yml`.
+- `permissions: contents: write` scopes `GITHUB_TOKEN`; the App token carries the
+  rest via its installation.
+- Set `wiki: "false"` to skip wiki checkout/sync; omit `agent-model:` when it is
+  the default (`claude-opus-4-8[1m]`).
+- **Hosted variant** needs the `FIT_OIDC_URL` variable and a `kata-agent` SHA
+  that accepts `installation-token`.

--- a/.claude/skills/kata-setup/references/workflow-facilitate.md
+++ b/.claude/skills/kata-setup/references/workflow-facilitate.md
@@ -46,20 +46,7 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
-      # Killswitch: fail fast when the KATA_KILLSWITCH variable holds a truthy
-      # value, so an operator can halt every kata workflow from one place
-      # without disabling each one. Keep it the first step so the run fails
-      # before any token minting, checkout, or agent work.
-      - name: Kata killswitch
-        shell: bash
-        env:
-          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
-        run: |
-          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off) echo "Kata killswitch not engaged; proceeding." ;;
-            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2; exit 1 ;;
-          esac
-
+      # First step: copy the `Kata killswitch` step verbatim from workflow-agent.md.
       - uses: forwardimpact/kata-agent@{{KATA_AGENT_REF}}
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
@@ -102,20 +89,7 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
-      # Killswitch: fail fast when the KATA_KILLSWITCH variable holds a truthy
-      # value, so an operator can halt every kata workflow from one place
-      # without disabling each one. Keep it the first step so the run fails
-      # before any token minting, checkout, or agent work.
-      - name: Kata killswitch
-        shell: bash
-        env:
-          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
-        run: |
-          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off) echo "Kata killswitch not engaged; proceeding." ;;
-            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2; exit 1 ;;
-          esac
-
+      # First step: copy the `Kata killswitch` step verbatim from workflow-agent.md.
       - uses: forwardimpact/kata-agent@{{KATA_AGENT_REF}}
         with:
           app-id: ${{ secrets.KATA_APP_ID }}

--- a/.claude/skills/kata-setup/references/workflow-facilitate.md
+++ b/.claude/skills/kata-setup/references/workflow-facilitate.md
@@ -46,6 +46,20 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
+      # Killswitch: fail fast when the KATA_KILLSWITCH variable holds a truthy
+      # value, so an operator can halt every kata workflow from one place
+      # without disabling each one. Keep it the first step so the run fails
+      # before any token minting, checkout, or agent work.
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off) echo "Kata killswitch not engaged; proceeding." ;;
+            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2; exit 1 ;;
+          esac
+
       - uses: forwardimpact/kata-agent@{{KATA_AGENT_REF}}
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
@@ -88,6 +102,20 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
+      # Killswitch: fail fast when the KATA_KILLSWITCH variable holds a truthy
+      # value, so an operator can halt every kata workflow from one place
+      # without disabling each one. Keep it the first step so the run fails
+      # before any token minting, checkout, or agent work.
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off) echo "Kata killswitch not engaged; proceeding." ;;
+            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2; exit 1 ;;
+          esac
+
       - uses: forwardimpact/kata-agent@{{KATA_AGENT_REF}}
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
@@ -110,9 +138,9 @@ jobs:
 Both templates above are `kata-agent` workflows, so the hosted
 delta is identical to
 [`workflow-agent.md` § Template (hosted)](workflow-agent.md): add
-`id-token: write` to `permissions`, insert the OIDC mint step as the first
-step, and replace the `app-id` / `app-private-key` inputs with
-`installation-token: ${{ steps.mint.outputs.token }}`.
+`id-token: write` to `permissions`, insert the OIDC mint step directly after
+the `Kata killswitch` step, and replace the `app-id` / `app-private-key`
+inputs with `installation-token: ${{ steps.mint.outputs.token }}`.
 
 ## Notes
 

--- a/.claude/skills/kata-setup/references/workflow-react.md
+++ b/.claude/skills/kata-setup/references/workflow-react.md
@@ -49,6 +49,19 @@ jobs:
       github.event_name == 'discussion_comment'
     runs-on: ubuntu-latest
     steps:
+      # Killswitch: fail fast when the KATA_KILLSWITCH variable holds a truthy
+      # value, so an operator can halt every kata workflow from one place
+      # without disabling each one. Keep it the first step so the run fails
+      # before any token minting, checkout, or agent work.
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off) echo "Kata killswitch not engaged; proceeding." ;;
+            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2; exit 1 ;;
+          esac
       - name: Generate token
         id: ci-app
         uses: actions/create-github-app-token@v3

--- a/.claude/skills/kata-setup/references/workflow-react.md
+++ b/.claude/skills/kata-setup/references/workflow-react.md
@@ -49,19 +49,7 @@ jobs:
       github.event_name == 'discussion_comment'
     runs-on: ubuntu-latest
     steps:
-      # Killswitch: fail fast when the KATA_KILLSWITCH variable holds a truthy
-      # value, so an operator can halt every kata workflow from one place
-      # without disabling each one. Keep it the first step so the run fails
-      # before any token minting, checkout, or agent work.
-      - name: Kata killswitch
-        shell: bash
-        env:
-          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
-        run: |
-          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
-            ""|0|false|no|off) echo "Kata killswitch not engaged; proceeding." ;;
-            *) echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2; exit 1 ;;
-          esac
+      # First step: copy the `Kata killswitch` step verbatim from workflow-agent.md.
       - name: Generate token
         id: ci-app
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -23,6 +23,23 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
+      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
+      # truthy value. Lets an operator halt every kata-* workflow from one
+      # place without disabling each one individually. Kept as the first step
+      # so the run fails before any token minting, checkout, or agent work.
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off)
+              echo "Kata killswitch not engaged — proceeding." ;;
+            *)
+              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              exit 1 ;;
+          esac
+
       - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
         id: agent
         with:

--- a/.github/workflows/kata-coaching.yml
+++ b/.github/workflows/kata-coaching.yml
@@ -34,9 +34,9 @@ jobs:
         run: |
           case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
             ""|0|false|no|off)
-              echo "Kata killswitch not engaged — proceeding." ;;
+              echo "Kata killswitch not engaged; proceeding." ;;
             *)
-              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
               exit 1 ;;
           esac
 

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -83,6 +83,23 @@ jobs:
       github.event_name == 'workflow_dispatch' || (github.event_name == 'issues' && (github.event.action == 'opened' || (github.event.action == 'labeled' && (startsWith(github.event.label.name, 'agent:') || endsWith(github.event.label.name, ':approved'))))) || github.event_name == 'issue_comment' || (github.event_name == 'pull_request_target' && ((github.event.action == 'labeled' && (startsWith(github.event.label.name, 'agent:') || endsWith(github.event.label.name, ':approved'))) || (github.event.action == 'closed' && github.event.pull_request.merged == true))) || github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     steps:
+      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
+      # truthy value. Lets an operator halt every kata-* workflow from one
+      # place without disabling each one individually. Kept as the first step
+      # so the run fails before any token minting, checkout, or agent work.
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off)
+              echo "Kata killswitch not engaged — proceeding." ;;
+            *)
+              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              exit 1 ;;
+          esac
+
       - name: Generate installation token
         id: ci-app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -94,9 +94,9 @@ jobs:
         run: |
           case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
             ""|0|false|no|off)
-              echo "Kata killswitch not engaged — proceeding." ;;
+              echo "Kata killswitch not engaged; proceeding." ;;
             *)
-              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
               exit 1 ;;
           esac
 

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
             ""|0|false|no|off)
-              echo "Kata killswitch not engaged — proceeding." ;;
+              echo "Kata killswitch not engaged; proceeding." ;;
             *)
-              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
               exit 1 ;;
           esac
 

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -33,6 +33,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 50
     steps:
+      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
+      # truthy value. Lets an operator halt every kata-* workflow from one
+      # place without disabling each one individually. Kept as the first step
+      # so the run fails before any token minting, checkout, or agent work.
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off)
+              echo "Kata killswitch not engaged — proceeding." ;;
+            *)
+              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              exit 1 ;;
+          esac
+
       - name: Generate installation token
         id: ci-app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3

--- a/.github/workflows/kata-shift.yml
+++ b/.github/workflows/kata-shift.yml
@@ -47,9 +47,9 @@ jobs:
         run: |
           case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
             ""|0|false|no|off)
-              echo "Kata killswitch not engaged — proceeding." ;;
+              echo "Kata killswitch not engaged; proceeding." ;;
             *)
-              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
               exit 1 ;;
           esac
 

--- a/.github/workflows/kata-shift.yml
+++ b/.github/workflows/kata-shift.yml
@@ -36,6 +36,23 @@ jobs:
           - { name: release-engineer }
           - { name: improvement-coach }
     steps:
+      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
+      # truthy value. Lets an operator halt every kata-* workflow from one
+      # place without disabling each one individually. Kept as the first step
+      # so the run fails before any token minting, checkout, or agent work.
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off)
+              echo "Kata killswitch not engaged — proceeding." ;;
+            *)
+              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              exit 1 ;;
+          esac
+
       - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
         id: agent
         with:

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -33,9 +33,9 @@ jobs:
         run: |
           case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
             ""|0|false|no|off)
-              echo "Kata killswitch not engaged — proceeding." ;;
+              echo "Kata killswitch not engaged; proceeding." ;;
             *)
-              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              echo "::error::KATA_KILLSWITCH engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
               exit 1 ;;
           esac
 

--- a/.github/workflows/kata-storyboard.yml
+++ b/.github/workflows/kata-storyboard.yml
@@ -22,6 +22,23 @@ jobs:
   kata:
     runs-on: ubuntu-latest
     steps:
+      # Killswitch: abort early when the KATA_KILLSWITCH variable is set to a
+      # truthy value. Lets an operator halt every kata-* workflow from one
+      # place without disabling each one individually. Kept as the first step
+      # so the run fails before any token minting, checkout, or agent work.
+      - name: Kata killswitch
+        shell: bash
+        env:
+          KATA_KILLSWITCH: ${{ vars.KATA_KILLSWITCH }}
+        run: |
+          case "$(printf '%s' "${KATA_KILLSWITCH:-}" | tr '[:upper:]' '[:lower:]')" in
+            ""|0|false|no|off)
+              echo "Kata killswitch not engaged — proceeding." ;;
+            *)
+              echo "::error::KATA_KILLSWITCH is engaged (value: ${KATA_KILLSWITCH}). Failing fast." >&2
+              exit 1 ;;
+          esac
+
       - uses: forwardimpact/kata-agent@159e107c83fbfffaced24f126fdc3c3bff4cb81a # v1
         id: agent
         with:

--- a/KATA.md
+++ b/KATA.md
@@ -151,6 +151,14 @@ artifact (issue/PR) with `cancel-in-progress: false` so cascaded events stack;
 storyboard, coaching, and interview each use a single global group. All
 workflows support `workflow_dispatch`.
 
+**Killswitch** — every `kata-*` workflow checks the `KATA_KILLSWITCH`
+repository (or org) Actions variable as its first step and fails fast when it
+holds a truthy value (anything other than empty, `0`, `false`, `no`, or `off`).
+Set it from the repository's Settings → Secrets and variables → Actions →
+Variables to halt all kata automation at once — scheduled shifts, the
+event-driven dispatcher, and manual dispatches — without disabling each workflow
+individually. Clear or unset it to resume.
+
 ## Skills
 
 All Kata skills use the `kata-` prefix and own exactly one PDSA phase (or none


### PR DESCRIPTION
## Summary

- Add a `Kata killswitch` first step to every `kata-*` workflow (coaching, dispatch, interview, shift, storyboard) that reads the `KATA_KILLSWITCH` repository/org Actions variable and fails fast when it holds a truthy value (anything other than empty, `0`, `false`, `no`, `off`). Lets an operator halt all kata automation from one place without disabling each workflow.
- Kept as the first step so an engaged switch fails before any token minting, checkout, or agent work.
- Updated the `kata-setup` skill so every generated workflow template (scheduled agent, storyboard, coaching, dispatch) emits the same gate, and reconciled the hosted OIDC mint delta to sit after the killswitch so it stays first.
- Documented the variable in `KATA.md` and in `kata-setup/SKILL.md` (Step 2 note, do-confirm checklist item, report bullet).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- [ ] `bun run invariants` (skill genericity gate) — passes locally


---
_Generated by [Claude Code](https://claude.ai/code/session_01K29BXY6MgMF8PBrRQUagua)_