### PR TITLE
feat(invariants,kata-session): shared-workspace staging + serialization (#1564)

### DIFF
--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -58,6 +58,11 @@ skill only for the full Participant Protocol below.
 - [ ] Comments closing a thread or routing a decision to a named owner name
       what is in flight (owner + artifact) or the explicit negative; routed
       owners reminded to announce at PR-open.
+- [ ] Shared-workspace discipline held (see
+      [`dispatch-discipline.md`](references/dispatch-discipline.md) §
+      Shared-workspace commit discipline): wiki-touching asks were serialized on
+      their surface, each work-producing ask carried edit-intent, and
+      single-owner directives routed to exactly one acting lane.
 - [ ] Weekly log updated under `## YYYY-MM-DD` with meeting type, metrics,
       obstacle, experiment, and Step 7 routing (1-on-1: the coached agent writes
       its own).
@@ -128,7 +133,10 @@ mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    advancing. After Q3/Q4, `Ask` each participant to record its
    obstacle and experiment as labeled issues per
    [`issue-lifecycle.md`](references/issue-lifecycle.md) and return the `#NNN`s.
-   Use `Announce` for between-question transitions.
+   Use `Announce` for between-question transitions. When an `Ask` has a receiver
+   commit in the shared checkout, carry edit-intent and serialize same-surface
+   asks per [`dispatch-discipline.md`](references/dispatch-discipline.md) §
+   Shared-workspace commit discipline.
 6. **Collect, don't write.** The facilitator writes no files — participants own
    every write (CSVs, weekly-log memory, issues). Collect reported `#NNN`s and
    numbers via `Answer` for the summary.

--- a/.claude/skills/kata-session/SKILL.md
+++ b/.claude/skills/kata-session/SKILL.md
@@ -12,15 +12,15 @@ description: >
 
 Shared entry-point skill for Toyota Kata coaching sessions. The improvement
 coach facilitates (Facilitator Process); domain agents participate (Participant
-Protocol). The mode-specific artifact surface lives in two overlays:
+Protocol). The mode-specific artifact surface lives in two overlays,
 [`team-storyboard.md`](references/team-storyboard.md) and
 [`one-on-one.md`](references/one-on-one.md).
 
 ## When to Use
 
-**Facilitator**: Entry-point skill for the improvement coach's two facilitation
-contexts — team storyboard meetings (`kata-storyboard.yml` workflow) and 1-on-1
-coaching sessions (`kata-coaching.yml` workflow).
+**Facilitator**: Entry point for the improvement coach's two contexts — team
+storyboard meetings (`kata-storyboard.yml`) and 1-on-1 coaching sessions
+(`kata-coaching.yml`).
 
 **Participant**: The coach's session-open briefing covers most runs; load this
 skill only for the full Participant Protocol below.
@@ -58,11 +58,10 @@ skill only for the full Participant Protocol below.
 - [ ] Comments closing a thread or routing a decision to a named owner name
       what is in flight (owner + artifact) or the explicit negative; routed
       owners reminded to announce at PR-open.
-- [ ] Shared-workspace discipline held (see
+- [ ] Shared-workspace discipline held per
       [`dispatch-discipline.md`](references/dispatch-discipline.md) §
-      Shared-workspace commit discipline): wiki-touching asks were serialized on
-      their surface, each work-producing ask carried edit-intent, and
-      single-owner directives routed to exactly one acting lane.
+      Shared-workspace commit discipline: same-surface asks serialized,
+      each work-producing ask carried edit-intent, single-owner routing.
 - [ ] Weekly log updated under `## YYYY-MM-DD` with meeting type, metrics,
       obstacle, experiment, and Step 7 routing (1-on-1: the coached agent writes
       its own).
@@ -91,19 +90,18 @@ skill only for the full Participant Protocol below.
 
 ## The Five Kata Questions
 
-These questions structure every coaching interaction — team meetings and 1-on-1
-sessions. The coach asks via `Ask`; the participant replies via `Answer`.
+These questions structure every coaching interaction. The coach asks via
+`Ask`; the participant replies via `Answer`.
 
-1. **What is the target condition?** Ground the conversation in where the team
-   (or the agent) is headed.
+1. **What is the target condition?** Where the team (or the agent) is headed.
 2. **What is the actual condition now?** Measured, not narrative — counts and
    durations from live data, recorded in CSV.
 3. **What obstacles prevent us from reaching the target?** Each participant
    names the obstacles in their domain.
 4. **What is the next step? What do you expect?** Propose the next experiment
    and its expected outcome.
-5. **When can we see what we learned from that step?** Establish the feedback
-   loop — the next meeting opens by reviewing what was learned.
+5. **When can we see what we learned?** The next meeting opens by reviewing
+   what was learned.
 
 What an obstacle and an experiment *are* is defined in
 [work-definition.md § Classification tests](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/work-definition.md#classification-tests);
@@ -121,28 +119,27 @@ mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    The overlay owns the mode-specific artifact surface, the question wording,
    and the participant briefing template.
 3. **Brief participants.** Deliver the overlay's briefing template before Q1.
-   Team mode: broadcast once via `Announce` at session open. 1-on-1 mode:
-   prepend it to the Q1 `Ask` body.
+   Team mode: broadcast once via `Announce` at session open. 1-on-1: prepend
+   it to the Q1 `Ask` body.
 4. **Collect XmR analysis from participants.** Participants run
    `npx fit-xmr analyze` on their own CSVs (Participant Protocol step 2) and
    report `status`, fired-rule `signals`, and `latest` in their Q2 `Answer`. The
-   facilitator has no `Bash` — it relays what they report, noting any
+   facilitator has no `Bash` — it relays what they report, flagging any
    `insufficient_data` metric.
 5. **Run the five questions.** Follow the overlay's wording. In facilitated
    mode, pose each question via `Ask` and collect `Answer` replies before
-   advancing. After Q3/Q4, `Ask` each participant to record its
-   obstacle and experiment as labeled issues per
+   advancing. After Q3/Q4, `Ask` each participant to record its obstacle and
+   experiment as labeled issues per
    [`issue-lifecycle.md`](references/issue-lifecycle.md) and return the `#NNN`s.
-   Use `Announce` for between-question transitions. When an `Ask` has a receiver
-   commit in the shared checkout, carry edit-intent and serialize same-surface
-   asks per [`dispatch-discipline.md`](references/dispatch-discipline.md) §
-   Shared-workspace commit discipline.
+   Use `Announce` between questions. When an `Ask`'s receiver commits in the
+   shared checkout, carry edit-intent and serialize same-surface asks
+   ([`dispatch-discipline.md`](references/dispatch-discipline.md)).
 6. **Collect, don't write.** The facilitator writes no files — participants own
    every write (CSVs, weekly-log memory, issues). Collect reported `#NNN`s and
    numbers via `Answer` for the summary.
-7. **Route Q3 obstacles (team meetings only; skip for 1-on-1).** For each
-   obstacle the facilitator picks one route (parallel allowed) and logs it; it
-   runs no `gh` itself. Triggers and worked example:
+7. **Route Q3 obstacles (team meetings only; skip 1-on-1).** For each obstacle
+   the facilitator picks one route (parallel allowed) and logs it; it runs no
+   `gh` itself. Triggers and worked example:
    [`team-storyboard.md`](references/team-storyboard.md#q3-obstacle-routing).
    - **Discussion** — shared-artifact change (metric, rule, boundary, policy) or
      same question in ≥2 agents' Q3 answers. The owning agent opens an RFC per
@@ -156,20 +153,18 @@ mode-specific question wording (team vs. 1-on-1) lives in the overlays.
    unexpired same-run continuation announcement means do not re-dispatch.
 9. **Conclude (facilitated mode only).** Call `Conclude` with a session summary
    covering meeting type, key metrics, obstacles addressed, experiments planned,
-   and any obstacle handed off for coaching. (Wiki pushes automatically; do not
-   commit.)
+   and any obstacle handed off for coaching. (Wiki pushes automatically.)
 
 ## Participant Protocol
 
-The pattern below applies in both modes and expands the coach's session-open
-briefing.
+Applies in both modes; expands the coach's session-open briefing.
 
 1. **Prepare for Q2.** Gather your domain's current measured state from live
    data (`gh`, `bun`, repo files) — not memory or narrative.
 2. **Record metrics to CSV and analyze them.** Before answering, append one row
    per metric to `wiki/metrics/{skill}/{YYYY}.csv` per the skill's
    `references/metrics.md`, creating the directory and header if needed. Then run
-   `npx fit-xmr analyze <csv> --format json` on your own CSV(s). The CSV is
+   `npx fit-xmr analyze <csv> --format json` on your CSV(s). The CSV is
    authoritative; your `Answer` summarizes it.
 3. **Answer with measured data.** Report numbers via
    `Answer(askId=N, message=…)`, quoting the `askId` from the `[ask#N]` header
@@ -189,9 +184,9 @@ briefing.
 
 Append to the current week's log (see agent profile for the file path):
 
-- **Session type** — Team storyboard, review, or 1-on-1 (with which agent)
+- **Session type** — Team storyboard, review, or 1-on-1 (which agent)
 - **Current condition** — Key numbers from metrics CSVs reviewed
 - **Obstacle addressed** — Which obstacle was the focus
-- **Experiment status** — Outcome of prior experiment, next experiment planned
+- **Experiment status** — Outcome of prior experiment, next one planned
 
 Participants record their own domain metrics per Participant Protocol step 2.

--- a/.claude/skills/kata-session/references/dispatch-discipline.md
+++ b/.claude/skills/kata-session/references/dispatch-discipline.md
@@ -37,3 +37,72 @@ orchestration `Ask` plus a protocol-internal continuation plus a queued memo —
 produces duplicate intent even when every individual route is plausible. If
 two routes could both plausibly carry an obligation, the coordinating
 artifact's tail decides which one holds it; the other route stands down.
+
+## Shared-workspace commit discipline
+
+When concurrent activations share one checkout, committed loss (a teammate's
+in-flight edit shipped under the wrong author) requires two conditions at once:
+two writers in one workspace, and a commit that stages by sweep. Removing either
+prevents it. These rules remove both — without a lock. **No lock, lease, or
+mutex over the workspace or any claim:** an advisory hold whose liveness signal
+is the `Answer` is the only serializer here; a real lock's dominant failure is a
+lock held by a crashed activation with no lease, a failure this protocol does
+not introduce.
+
+### Edit-intent on a work-producing ask
+
+Every ask that asks a receiver to *commit* in the shared checkout carries an
+**edit-intent** with two structurally distinct classes:
+
+| Class | Declared by | Receiver stages it? | Dispatch orders on it? |
+| --- | --- | --- | --- |
+| `staged_paths` — the own-artifact paths the receiver will commit | facilitator | yes | yes |
+| `output_surfaces` — non-staged shared targets (a shared reconciliation thread, a session summary doc, an Announce) the directive writes but no activation stages | facilitator | **no** | yes |
+
+The split is a hard boundary, not a flag: a receiver stages **only**
+`staged_paths`, and **never** an `output_surface`. Both classes name the
+specific target (a concrete file path, a specific thread) — never a coarse key
+like "the wiki" — so unrelated work does not serialize. A worked example:
+
+```
+Ask(to: agent-x, edit-intent: {
+  staged_paths: ["wiki/<own-weekly-log>.md", "wiki/metrics/<skill>/<year>.csv"],
+  output_surfaces: ["<coordinating-issue> thread"]
+})
+```
+
+### Path-scoped staging (receiver side)
+
+The receiver commits its own artifacts by explicit path — exactly the
+`staged_paths` it was given — never a whole-tree sweep. This mirrors the
+tool-side discipline: a commit stages what its author named, not whatever the
+shared tree happens to hold.
+
+### Same-surface serialization (facilitator side)
+
+Route a wiki-touching (or otherwise same-mutable-surface) ask only after the
+prior ask whose edit-intent union (`staged_paths` ∪ `output_surfaces`)
+intersects this ask's surface has returned its `Answer` or explicitly released.
+Key the hold on the **specific surface**, not the whole session — two asks
+touching unrelated targets run concurrently. The hold is advisory facilitator
+discipline; if an `Answer` never arrives the facilitator releases on its own
+judgment (no automated lease).
+
+### Single-owner routing
+
+A **single-owner** directive routes to exactly one acting lane; co-recipients
+receive a no-staging FYI that carries no edit-intent and requires no action.
+With one acting lane there is no fan-out to serialize.
+
+Classify at dispatch: a directive is **multi-owner iff it explicitly names two
+or more distinct acting recipients, each given a work-producing instruction.**
+Everything else — one named owner, an unaddressed "someone should…", a
+close-out or decision directive — is **single-owner**. **Ambiguous directives
+default to single-owner.** The fan-out of a misclassified directive ships
+duplicate records (committed-loss-adjacent), while a starved FYI lane is
+recoverable by re-dispatch on the next turn; bias toward the recoverable error.
+A genuinely multi-owner directive misread as single-owner only delays its other
+lanes by one dispatch cycle — the facilitator re-routes them once the owner
+answers.
+
+Single-owner routing is cardinality only — no lock, lease, or mutual exclusion.

--- a/.claude/skills/kata-session/references/dispatch-discipline.md
+++ b/.claude/skills/kata-session/references/dispatch-discipline.md
@@ -41,28 +41,27 @@ artifact's tail decides which one holds it; the other route stands down.
 ## Shared-workspace commit discipline
 
 When concurrent activations share one checkout, committed loss (a teammate's
-in-flight edit shipped under the wrong author) requires two conditions at once:
-two writers in one workspace, and a commit that stages by sweep. Removing either
-prevents it. These rules remove both — without a lock. **No lock, lease, or
-mutex over the workspace or any claim:** an advisory hold whose liveness signal
-is the `Answer` is the only serializer here; a real lock's dominant failure is a
-lock held by a crashed activation with no lease, a failure this protocol does
-not introduce.
+in-flight edit shipped under the wrong author) needs two conditions at once: two
+writers in one workspace, and a commit that stages by sweep. These rules remove
+both — without a lock. **No lock, lease, or mutex over the workspace or any
+claim:** the only serializer is an advisory hold whose liveness signal is the
+`Answer`. The dominant failure of a real lock — held by a crashed activation
+with no lease — this protocol avoids.
 
 ### Edit-intent on a work-producing ask
 
-Every ask that asks a receiver to *commit* in the shared checkout carries an
+Every ask that has a receiver *commit* in the shared checkout carries an
 **edit-intent** with two structurally distinct classes:
 
-| Class | Declared by | Receiver stages it? | Dispatch orders on it? |
-| --- | --- | --- | --- |
-| `staged_paths` — the own-artifact paths the receiver will commit | facilitator | yes | yes |
-| `output_surfaces` — non-staged shared targets (a shared reconciliation thread, a session summary doc, an Announce) the directive writes but no activation stages | facilitator | **no** | yes |
+| Class | Receiver stages it? | Dispatch orders on it? |
+| --- | --- | --- |
+| `staged_paths` — the own-artifact paths the receiver will commit | yes | yes |
+| `output_surfaces` — non-staged shared targets (a reconciliation thread, a session summary, an Announce) the directive writes but no one stages | **no** | yes |
 
-The split is a hard boundary, not a flag: a receiver stages **only**
-`staged_paths`, and **never** an `output_surface`. Both classes name the
-specific target (a concrete file path, a specific thread) — never a coarse key
-like "the wiki" — so unrelated work does not serialize. A worked example:
+The split is a hard boundary: a receiver stages **only** `staged_paths`, never
+an `output_surface`. Both classes name the specific target (a concrete path, a
+thread) — never a coarse key like "the wiki" — so unrelated work does not
+serialize. Example:
 
 ```
 Ask(to: agent-x, edit-intent: {
@@ -74,35 +73,31 @@ Ask(to: agent-x, edit-intent: {
 ### Path-scoped staging (receiver side)
 
 The receiver commits its own artifacts by explicit path — exactly the
-`staged_paths` it was given — never a whole-tree sweep. This mirrors the
-tool-side discipline: a commit stages what its author named, not whatever the
-shared tree happens to hold.
+`staged_paths` it was given — never a whole-tree sweep. A commit stages what its
+author named, not whatever the shared tree holds.
 
 ### Same-surface serialization (facilitator side)
 
-Route a wiki-touching (or otherwise same-mutable-surface) ask only after the
-prior ask whose edit-intent union (`staged_paths` ∪ `output_surfaces`)
-intersects this ask's surface has returned its `Answer` or explicitly released.
-Key the hold on the **specific surface**, not the whole session — two asks
-touching unrelated targets run concurrently. The hold is advisory facilitator
-discipline; if an `Answer` never arrives the facilitator releases on its own
-judgment (no automated lease).
+Route a same-mutable-surface ask only after the prior ask whose edit-intent
+union (`staged_paths` ∪ `output_surfaces`) intersects this surface has returned
+its `Answer` or released. Key the hold on the **specific surface**, not the
+session — asks touching unrelated targets run concurrently. The hold is
+advisory; if no `Answer` arrives the facilitator releases on its own judgment
+(no automated lease).
 
 ### Single-owner routing
 
 A **single-owner** directive routes to exactly one acting lane; co-recipients
-receive a no-staging FYI that carries no edit-intent and requires no action.
-With one acting lane there is no fan-out to serialize.
+get a no-staging FYI that carries no edit-intent and needs no action. With one
+acting lane there is no fan-out to serialize.
 
 Classify at dispatch: a directive is **multi-owner iff it explicitly names two
 or more distinct acting recipients, each given a work-producing instruction.**
 Everything else — one named owner, an unaddressed "someone should…", a
 close-out or decision directive — is **single-owner**. **Ambiguous directives
-default to single-owner.** The fan-out of a misclassified directive ships
-duplicate records (committed-loss-adjacent), while a starved FYI lane is
-recoverable by re-dispatch on the next turn; bias toward the recoverable error.
-A genuinely multi-owner directive misread as single-owner only delays its other
-lanes by one dispatch cycle — the facilitator re-routes them once the owner
-answers.
+default to single-owner.** A misclassified fan-out ships duplicate records
+(committed-loss-adjacent); a starved FYI lane is recoverable by re-dispatch.
+Bias toward the recoverable error: a true multi-owner directive misread as
+single-owner only delays its other lanes one cycle.
 
 Single-owner routing is cardinality only — no lock, lease, or mutual exclusion.

--- a/.coaligned/invariants/shared-workspace-staging.allow.json
+++ b/.coaligned/invariants/shared-workspace-staging.allow.json
@@ -1,6 +1,6 @@
 [
   {
     "file": "libraries/libwiki/src/wiki-sync.js",
-    "reason": "fit-wiki push/sync sweep — scoping it to own-authored paths coordinates with spec 1850 D3 (commit-scoped landings) and is tracked as #1583 item 3; lift this entry when that landing scopes the sweep. Its shell twin scripts/wiki-sync.sh shares this exemption"
+    "reason": "fit-wiki push/sync sweep is the only whole-tree committer on the tree; scoping it to own-authored paths depends on the wiki push-primitive landing design and is a tracked follow-up. Its shell twin scripts/wiki-sync.sh shares this exemption"
   }
 ]

--- a/.coaligned/invariants/shared-workspace-staging.allow.json
+++ b/.coaligned/invariants/shared-workspace-staging.allow.json
@@ -1,0 +1,6 @@
+[
+  {
+    "file": "libraries/libwiki/src/wiki-sync.js",
+    "reason": "fit-wiki push/sync sweep — scoping it to own-authored paths coordinates with the wiki push-primitive landing design and is tracked as a separate follow-up; its shell twin scripts/wiki-sync.sh shares this exemption"
+  }
+]

--- a/.coaligned/invariants/shared-workspace-staging.allow.json
+++ b/.coaligned/invariants/shared-workspace-staging.allow.json
@@ -1,6 +1,6 @@
 [
   {
     "file": "libraries/libwiki/src/wiki-sync.js",
-    "reason": "fit-wiki push/sync sweep — scoping it to own-authored paths coordinates with the wiki push-primitive landing design and is tracked as a separate follow-up; its shell twin scripts/wiki-sync.sh shares this exemption"
+    "reason": "fit-wiki push/sync sweep — scoping it to own-authored paths coordinates with spec 1850 D3 (commit-scoped landings) and is tracked as #1583 item 3; lift this entry when that landing scopes the sweep. Its shell twin scripts/wiki-sync.sh shares this exemption"
   }
 ]

--- a/.coaligned/invariants/shared-workspace-staging.rules.mjs
+++ b/.coaligned/invariants/shared-workspace-staging.rules.mjs
@@ -1,0 +1,152 @@
+// Invariant: shared-checkout commit paths must stage their own artifacts by
+// explicit path, never by a whole-tree sweep. The one whole-tree staging method
+// on the shared GitClient is `commitAll` (`git add -A`); `commitPaths` is the
+// scoped path. This rule flags every *caller* of `commitAll` in non-test
+// commit-path source, deny-by-default: a caller not in
+// shared-workspace-staging.allow.json fails, so a newly-added or overlooked
+// sweep surfaces as a violation rather than silently escaping the closed set.
+//
+// Scope is JS/MJS source only — the AST scan cannot parse shell or YAML, so
+// shell commit paths (e.g. a `fit-wiki push` shell wrapper) are governed by the
+// same allow-listed deferral their JS twin carries, not by this rule. CI sweeps
+// that run in a separate checkout (not the shared session checkout) are out of
+// scope by construction.
+//
+// The `commitAll` *definition* (the GitClient itself) and its mock are excluded:
+// they define/mock the primitive, they are not commit paths.
+//
+// Completeness boundary: the rule keys on the `commitAll` callee. A future
+// commit path that sweeps via a raw subprocess argv (e.g.
+// `run("git", ["add", "-A"])`) built from fragments is a different shape and
+// would escape this rule. The corpus has no such caller today; if one appears,
+// extend SWEEP_METHOD coverage with a JS-scoped argv-literal scan rather than
+// loosening the allowlist.
+//
+// Refresh the violator list:
+//   bunx coaligned invariants --seed shared-workspace-staging
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { parseModule, walkAst } from "./lib/ast.mjs";
+import { collectFiles, readJsonOrNull } from "./lib/walk.mjs";
+
+const SCOPE_DIRS = ["libraries", "products", "services"];
+const SKIP_DIRS = new Set(["node_modules", "dist", "generated", "tmp", "test"]);
+const SWEEP_METHOD = "commitAll";
+
+// Files that define or mock the primitive — not commit paths.
+const EXCLUDE_RELS = new Set(["libraries/libutil/src/git-client.js"]);
+const EXCLUDE_PREFIXES = ["libraries/libmock/"];
+
+function loadAllow() {
+  const entries =
+    readJsonOrNull(
+      join(import.meta.dirname, "shared-workspace-staging.allow.json"),
+    ) ?? [];
+  return new Set(entries.map((e) => e.file));
+}
+
+function calleeName(callee) {
+  if (callee?.type === "Identifier") return callee.name;
+  if (
+    callee?.type === "MemberExpression" &&
+    callee.property?.type === "Identifier"
+  ) {
+    return callee.property.name;
+  }
+  return null;
+}
+
+function sourceFiles(root) {
+  const out = [];
+  for (const scope of SCOPE_DIRS) {
+    const scopeDir = join(root, scope);
+    if (!existsSync(scopeDir)) continue;
+    for (const pkg of readdirSync(scopeDir)) {
+      const pkgDir = join(scopeDir, pkg);
+      if (!statSync(pkgDir).isDirectory()) continue;
+      out.push(
+        ...collectFiles(pkgDir, {
+          skip: SKIP_DIRS,
+          match: (name) =>
+            (name.endsWith(".js") || name.endsWith(".mjs")) &&
+            !name.endsWith(".test.js") &&
+            !name.endsWith(".test.mjs"),
+        }),
+      );
+    }
+  }
+  return out;
+}
+
+function isExcluded(rel) {
+  return (
+    EXCLUDE_RELS.has(rel) || EXCLUDE_PREFIXES.some((p) => rel.startsWith(p))
+  );
+}
+
+function sweepsWholeTree(source, filePath) {
+  let hit = false;
+  walkAst(parseModule(source, filePath), (node) => {
+    if (node.type !== "CallExpression") return;
+    if (calleeName(node.callee) === SWEEP_METHOD) hit = true;
+  });
+  return hit;
+}
+
+function buildSubjects(root) {
+  const subjects = [];
+  for (const file of sourceFiles(root)) {
+    const rel = relative(root, file);
+    if (isExcluded(rel)) continue;
+    const subject = { path: file, rel };
+    try {
+      subject.sweeps = sweepsWholeTree(readFileSync(file, "utf8"), rel);
+    } catch (err) {
+      subject.parseError = err.message;
+    }
+    subjects.push(subject);
+  }
+  return subjects;
+}
+
+export default {
+  name: "shared-workspace-staging",
+
+  build({ root }) {
+    return {
+      subjects: { "commit-path": buildSubjects(root) },
+      ctx: { allow: loadAllow() },
+    };
+  },
+
+  // Print the current violators, for seeding shared-workspace-staging.allow.json.
+  seed({ root }) {
+    const violators = buildSubjects(root)
+      .filter((s) => s.sweeps)
+      .map((s) => s.rel)
+      .sort();
+    return `${JSON.stringify(violators, null, 2)}\n`;
+  },
+
+  rules: [
+    {
+      id: "staging.parse-error",
+      scope: "commit-path",
+      severity: "fail",
+      check: (s) => (s.parseError ? { msg: s.parseError } : null),
+      message: (s, r) => r.msg,
+      hint: "fix the syntax error so the staging scan can parse the file",
+    },
+    {
+      id: "staging.whole-tree-sweep",
+      scope: "commit-path",
+      severity: "fail",
+      when: (s) => !s.parseError,
+      check: (s, c) => (s.sweeps && !c.allow.has(s.rel) ? {} : null),
+      message: (s) =>
+        `shared-checkout commit path stages by whole-tree sweep (${SWEEP_METHOD}): ${s.rel}`,
+      hint: "stage own artifacts by explicit path (commitPaths), or add the path to shared-workspace-staging.allow.json with a reason",
+    },
+  ],
+};

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/user/monorepo/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/user/monorepo/node_modules

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/design-a.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/design-a.md
@@ -15,20 +15,24 @@ Two attachment points, one per lever, plus the data that connects them:
    │  the same mutable surface         │  (no whole-tree sweep)
    │                                   │
    └──── ask + edit-intent ───────────►┘
-         (surface, own-artifact paths)
+         (staged paths + output surfaces)
 ```
 
 The edit-intent field is the seam: the facilitator declares it when routing
-(L2); the receiver consumes it to scope its commit (L1). One artifact carries
-both levers' contract, so they cannot drift apart.
+(L2); the receiver consumes the staged-path half to scope its commit (L1). The
+field carries two surface classes (D5): staged paths the receiver commits, and
+output surfaces L2 orders on but L1 never stages. The staged half is
+co-verified — L1 stages it and the S1 audit catches drift; the output half is
+order-only, so the classes must stay structurally distinct. The single-routing
+cardinality rule (D6) rides the same dispatch gate.
 
 ## Components
 
 | Component | Role | Lever |
 |---|---|---|
 | Commit paths (shared-checkout committers) | The closed set of skills/tools that commit inside the shared checkout — agent feature commits, activation sweep-commits, and tool commits (`fit-wiki claim`/`release`, already scoped by PR #1571). | L1 |
-| Edit-intent field | A structured field on a facilitated ask: the mutable surface and the own-artifact path list the receiver will stage. | L1↔L2 seam |
-| Facilitator dispatch gate | The routing step that holds a same-surface ask until the prior one Answers or releases. | L2 |
+| Edit-intent field | A structured field on a facilitated ask with two distinct classes (D5): the own-artifact **staged paths** the receiver will commit (L1), and the **output surfaces** — non-staged shared targets such as the #1702 reconciliation thread — that L2 orders on but L1 never stages. | L1↔L2 seam |
+| Facilitator dispatch gate | The routing step that holds a same-surface ask until the prior one Answers or releases (L2), and that routes a single-owner directive to exactly one acting lane with co-recipients getting a no-staging FYI (D6/S6). | L2 |
 | `fit-wiki` push primitive | Unchanged here; its landing discipline is Spec 1850 D3. L1 only governs what a commit stages, upstream of the push. | (boundary) |
 
 ## Key decisions
@@ -71,13 +75,51 @@ editing unrelated files), reintroducing the cost the autonomy investment was
 meant to remove. Keying on the surface serializes only the asks that would
 actually collide.
 
+### D5 — Edit-intent declares two surface classes; D4's order-key is their union
+
+Genuinely multi-owner directives can legitimately target one shared output that
+no activation stages — the #1702 reconciliation thread, a session summary doc, an
+Announce. Edit-intent therefore carries two structurally distinct classes:
+**staged paths** (L1 stages; D4 also orders on them) and **output surfaces** (D4
+orders on them; L1 never stages). D4's serialization order-key is the **union** of
+both; L1's stage-set is the staged subset only. **Rejected:** a flat surface list
+with a `staged` flag. A consumer that misreads the flag would let L1 stage a
+surface the activation does not own — reintroducing the exact committed-loss L1
+exists to remove — so the split must be a hard type boundary the L1 consumer
+cannot cross, not a convention. Output surfaces inherit D4's granularity rule (the
+specific thread, never "the wiki"), or the coarser key collapses throughput. This
+serializes on a non-staged surface but adds no lock: it is the same advisory
+dispatch hold as D3, keyed on a wider value set, with the Answer as liveness — S5
+holds. D6/S6 closes #1725's single-owner case; D5 covers only the residual case
+where one output surface is legitimately shared across owners.
+
+### D6 — Anchor single-routing cardinality (S6) at the L2 dispatch gate
+
+The facilitator routes a single-owner directive to exactly one acting lane;
+co-recipients receive a no-staging FYI that carries no edit-intent and requires
+no action. This mirrors how D1 anchors the L1 staging discipline at each commit
+path: S6's cardinality control attaches at L2's existing dispatch gate, the same
+component D3/D4 govern. It bounds **how many** lanes act on a directive, where
+D3/D4 bound **when** same-surface asks run — with one correctly-classified acting
+lane there is no fan-out to serialize. S6's guarantee is exactly as strong as the
+single-owner classifier at the gate (spec.md S6): a directive *misclassified as
+multi-owner* falls through to L2's temporal ordering, which caps asks in time but
+not in lane count, so the fan-out can still occur. The classifier predicate and
+its conservative-default direction are therefore load-bearing design surface, not
+an implementation detail — see open questions. **Rejected:** deduplicating the
+duplicate records after fan-out — that is the coordination-comment floor's job
+(#1667 / #1647 / #1732); S6 prevents the fan-out, upstream of it. Cardinality is
+routing only — no lock, lease, or mutual exclusion — so S5 holds.
+
 ## Data flow
 
-1. Facilitator forms an ask; if its surface matches an in-flight same-surface
-   ask, the dispatch gate (D3/D4) holds it until the prior Answer/release.
-2. The ask carries edit-intent (D2): surface + own-artifact path list.
-3. The receiver does its work and commits, staging exactly the declared paths
-   (D1) — never a whole-tree sweep.
+1. Facilitator forms an ask. A single-owner directive routes to exactly one
+   acting lane (D6); co-recipients get a no-staging FYI. If the ask's surface —
+   any staged path or output surface — matches an in-flight ask, the dispatch
+   gate (D3/D4) holds it until the prior Answer/release.
+2. The ask carries edit-intent (D2/D5): staged paths + output surfaces.
+3. The receiver does its work and commits, staging exactly the declared staged
+   paths (D1) — never a whole-tree sweep, never an output surface.
 4. The commit lands through the `fit-wiki` push primitive unchanged (Spec 1850
    D3 boundary); L1 has already ensured the commit carries only own artifacts.
 
@@ -89,13 +131,33 @@ actually collide.
   push — it scopes the commit's contents; D3 scopes how that commit lands.
 - **No lock/mutex/lease** (S5): D3 is the load-bearing rejection. Any later
   design that reintroduces lock-based mutual exclusion violates the spec.
+- **Coordination-comment floor** (#1667 / #1647 / #1732): untouched. D6/S6 keeps
+  a single-owner directive from fanning out; D5 only orders the *asks* when a
+  multi-owner fan-out is legitimate. Deduplicating or serializing the comment
+  *writes* once a fan-out has happened stays the floor's job. They compose; D5/D6
+  do not reach into the comment-write path.
 
 ## Open questions for the plan
 
 - The exact enumeration mechanism for "the closed set of commit paths" (S1's
   audit scope) — which registry or convention bounds it.
-- Where the edit-intent field lives in the ask schema and how a receiver that
-  ignores it is detected.
+- Where the edit-intent field lives in the ask schema, and how receiver
+  compliance is detected — split by class (D5): staged-path drift surfaces in
+  the S1 commit audit, but an output surface is never committed, so its
+  compliance has no commit to audit and falls to a dispatch-gate compare of
+  declared output surfaces plus the post-hoc Mode-A ≤1-record falsifier.
+- The closed set of **output surfaces** a directive can collide on (sibling to
+  the commit-path enumeration above, but on the L2 side). Unlike committers it is
+  open-ended (any API write target) and has no forcing function: a receiver must
+  name its staged paths or its own work won't land, but nothing comparable
+  compels it to declare an output surface — so an undeclared one defeats D4.
+- The single-owner classifier predicate D6/S6 keys on, and which way its
+  conservative default leans for ambiguous directives (spec.md S6 requires the
+  protocol name a classifier and declare a default; the predicate internals and
+  default direction are this design's to choose, grounded in the corpus).
+  Defaulting ambiguous directives to single-owner risks starving real
+  multi-owner work in the FYI'd lanes; defaulting to multi-owner reopens the
+  fan-out S6 exists to remove.
 - Whether the dispatch gate is advisory guidance to the facilitator or a
   mechanized hold — and the liveness fallback if an Answer never arrives
   (without reintroducing a lease, per S5).

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/design-a.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/design-a.md
@@ -30,9 +30,9 @@ cardinality rule (D6) rides the same dispatch gate.
 
 | Component | Role | Lever |
 |---|---|---|
-| Commit paths (shared-checkout committers) | The closed set of skills/tools that commit inside the shared checkout — agent feature commits, activation sweep-commits, and tool commits (`fit-wiki claim`/`release`, already scoped by PR #1571). | L1 |
-| Edit-intent field | A structured field on a facilitated ask with two distinct classes (D5): the own-artifact **staged paths** the receiver will commit (L1), and the **output surfaces** — non-staged shared targets such as the #1702 reconciliation thread — that L2 orders on but L1 never stages. | L1↔L2 seam |
-| Facilitator dispatch gate | The routing step that holds a same-surface ask until the prior one Answers or releases (L2), and that routes a single-owner directive to exactly one acting lane with co-recipients getting a no-staging FYI (D6/S6). | L2 |
+| Commit paths (shared-checkout committers) | The set of skills/tools that commit inside the shared checkout — agent feature commits, activation sweep-commits, and tool commits (`fit-wiki claim`/`release`, already scoped by PR #1571). The deny-by-default lint (S1) holds this set closed continuously: a commit path not on the own-artifact allowlist fails, so closedness is enforced, not assumed once. | L1 |
+| Edit-intent field | A structured field on a facilitated ask with two distinct classes (D5): the own-artifact **staged paths** the receiver will commit (L1), and the **output surfaces** — non-staged shared targets such as a shared reconciliation thread or session summary doc — that L2 orders on but L1 never stages. | L1↔L2 seam |
+| Facilitator dispatch gate | The routing step that holds a same-surface ask until the prior one Answers or releases (L2). The single-routing cardinality rule (D6) and the classifier that drives it (D7) attach here too. | L2 |
 | `fit-wiki` push primitive | Unchanged here; its landing discipline is Spec 1850 D3. L1 only governs what a commit stages, upstream of the push. | (boundary) |
 
 ## Key decisions
@@ -78,7 +78,7 @@ actually collide.
 ### D5 — Edit-intent declares two surface classes; D4's order-key is their union
 
 Genuinely multi-owner directives can legitimately target one shared output that
-no activation stages — the #1702 reconciliation thread, a session summary doc, an
+no activation stages — a shared reconciliation thread, a session summary doc, an
 Announce. Edit-intent therefore carries two structurally distinct classes:
 **staged paths** (L1 stages; D4 also orders on them) and **output surfaces** (D4
 orders on them; L1 never stages). D4's serialization order-key is the **union** of
@@ -104,12 +104,42 @@ D3/D4 bound **when** same-surface asks run — with one correctly-classified act
 lane there is no fan-out to serialize. S6's guarantee is exactly as strong as the
 single-owner classifier at the gate (spec.md S6): a directive *misclassified as
 multi-owner* falls through to L2's temporal ordering, which caps asks in time but
-not in lane count, so the fan-out can still occur. The classifier predicate and
-its conservative-default direction are therefore load-bearing design surface, not
-an implementation detail — see open questions. **Rejected:** deduplicating the
+not in lane count, so the fan-out can still occur. This design therefore fixes
+the predicate and its default (D7), per spec.md S6's assignment of that choice to
+design surface. **Rejected:** deduplicating the
 duplicate records after fan-out — that is the coordination-comment floor's job
 (#1667 / #1647 / #1732); S6 prevents the fan-out, upstream of it. Cardinality is
 routing only — no lock, lease, or mutual exclusion — so S5 holds.
+
+### D7 — Single-owner classifier: a directive is single-owner unless it names ≥2 distinct acting lanes; ambiguous defaults to single-owner
+
+The classifier predicate is structural, not semantic: a directive is **multi-owner
+iff it explicitly names two or more distinct acting recipients each given a
+work-producing instruction**; everything else — one named owner, an unaddressed
+"someone should…", a close-out/decision directive — is **single-owner**. The
+conservative default for ambiguity is therefore **single-owner** (one acting
+lane, the rest FYI). **Rejected:** defaulting ambiguous directives to
+multi-owner. The corpus shows the failure that *ships* is the fan-out (#1725
+Mode A, committed-loss-adjacent duplicate records); a starved FYI lane is
+recoverable by re-dispatch on the next turn, while a fanned-out duplicate-write
+collision is committed loss the repair economy must clean up. Biasing toward the
+recoverable error is the conservative choice the spec's S6 trade-off calls for.
+The cost — a genuinely multi-owner directive misread as single-owner delays its
+other lanes by one dispatch cycle — is bounded and self-correcting; the
+facilitator re-routes the held lanes once the owner Answers.
+
+### D8 — Output surfaces are declared by the facilitator at dispatch, not the receiver
+
+The forcing function D4 needs comes from *where* output surfaces are declared.
+Staged paths self-force (a receiver that omits its own path loses its work), but
+an output surface has no such pressure on the receiver. So the **facilitator**
+names the output surfaces when it forms a multi-owner ask (it already knows the
+shared target it is fanning work toward — that is why it is fanning), and the
+dispatch gate orders on the facilitator-declared set. **Rejected:** relying on
+each receiver to declare output surfaces — an undeclared one silently defeats D4,
+and the receiver has no incentive to declare a surface it merely writes to. Moving
+the declaration to the party with both the knowledge and the ordering
+responsibility closes the gap without a new enforcement mechanism.
 
 ## Data flow
 
@@ -144,20 +174,15 @@ routing only — no lock, lease, or mutual exclusion — so S5 holds.
 - Where the edit-intent field lives in the ask schema, and how receiver
   compliance is detected — split by class (D5): staged-path drift surfaces in
   the S1 commit audit, but an output surface is never committed, so its
-  compliance has no commit to audit and falls to a dispatch-gate compare of
-  declared output surfaces plus the post-hoc Mode-A ≤1-record falsifier.
-- The closed set of **output surfaces** a directive can collide on (sibling to
-  the commit-path enumeration above, but on the L2 side). Unlike committers it is
-  open-ended (any API write target) and has no forcing function: a receiver must
-  name its staged paths or its own work won't land, but nothing comparable
-  compels it to declare an output surface — so an undeclared one defeats D4.
-- The single-owner classifier predicate D6/S6 keys on, and which way its
-  conservative default leans for ambiguous directives (spec.md S6 requires the
-  protocol name a classifier and declare a default; the predicate internals and
-  default direction are this design's to choose, grounded in the corpus).
-  Defaulting ambiguous directives to single-owner risks starving real
-  multi-owner work in the FYI'd lanes; defaulting to multi-owner reopens the
-  fan-out S6 exists to remove.
+  compliance has no commit to audit and is checked at the dispatch gate by
+  comparing the facilitator-declared output surfaces against in-flight asks
+  (D8). (The Mode-A ≤1-record measure is a post-deployment validation target,
+  not an acceptance gate — spec.md treats it as a meter, not a check.)
 - Whether the dispatch gate is advisory guidance to the facilitator or a
   mechanized hold — and the liveness fallback if an Answer never arrives
   (without reintroducing a lease, per S5).
+
+(The classifier predicate and default are now fixed in D7; output-surface
+declaration in D8. The open-ended output-surface *closed set* is no longer a gap:
+D8 moves declaration to the facilitator, so there is no undeclared-by-receiver
+case to enumerate.)

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/design-a.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/design-a.md
@@ -1,0 +1,101 @@
+# Design 2010-a — path-scoped staging and facilitator serialization
+
+Architectural sketch for Spec 2010. WHICH components change and WHERE the two
+levers attach. HOW and sequencing belong in the plan.
+
+## Shape
+
+Two attachment points, one per lever, plus the data that connects them:
+
+```
+  facilitator dispatch                receiver activation
+  ─────────────────────               ────────────────────
+  [L2] same-surface gate              [L1] path-scoped staging
+   │  serialize asks that touch        │  stage own-artifact paths only
+   │  the same mutable surface         │  (no whole-tree sweep)
+   │                                   │
+   └──── ask + edit-intent ───────────►┘
+         (surface, own-artifact paths)
+```
+
+The edit-intent field is the seam: the facilitator declares it when routing
+(L2); the receiver consumes it to scope its commit (L1). One artifact carries
+both levers' contract, so they cannot drift apart.
+
+## Components
+
+| Component | Role | Lever |
+|---|---|---|
+| Commit paths (shared-checkout committers) | The closed set of skills/tools that commit inside the shared checkout — agent feature commits, activation sweep-commits, and tool commits (`fit-wiki claim`/`release`, already scoped by PR #1571). | L1 |
+| Edit-intent field | A structured field on a facilitated ask: the mutable surface and the own-artifact path list the receiver will stage. | L1↔L2 seam |
+| Facilitator dispatch gate | The routing step that holds a same-surface ask until the prior one Answers or releases. | L2 |
+| `fit-wiki` push primitive | Unchanged here; its landing discipline is Spec 1850 D3. L1 only governs what a commit stages, upstream of the push. | (boundary) |
+
+## Key decisions
+
+### D1 — Enforce path-scoped staging at each commit path, not by a global hook
+
+Each shared-checkout commit path stages an explicit own-artifact path list.
+**Rejected:** a single global pre-commit hook that rejects broad staging. A hook
+cannot tell an activation's own artifacts from a teammate's working-tree residue
+— that authorship is exactly what is unknown at commit time — so it would either
+block legitimate multi-file commits or pass the foreign content it was meant to
+stop. The path list must come from the actor that knows its own intent.
+
+### D2 — Source own-artifact paths from declared edit-intent, not from diff inspection
+
+The receiver stages the paths named in the ask's edit-intent field.
+**Rejected:** inferring own artifacts from `git diff`/blame authorship.
+Uncommitted working-tree changes carry no author, and the contaminating content
+is precisely the uncommitted residue a concurrent activation left — so inference
+reads the collision as if it were the actor's own work. Declared intent is the
+only pre-commit source of truth for "mine."
+
+### D3 — Serialize at the facilitator dispatch, not by an agent-side lock
+
+The facilitator holds a same-surface ask until the prior one returns.
+**Rejected:** an agent-side or claim-based mutex over the surface. #1539
+established the claim handshake is advisory, and a real lock's dominant failure —
+held by a dead activation with no lease — is a failure mode the family does not
+have today (S5, Non-Goals). The facilitator already owns dispatch ordering and
+has liveness signal (the Answer); serialization there needs no lock and no
+lease. **Also rejected:** a gate-time collision check — that is RFC #873's
+gate-side surface, composable with but distinct from L2's protocol-side ordering.
+
+### D4 — Key serialization on the touched surface, not the whole workspace
+
+"Same surface" is the specific mutable target (a wiki file path, a PR branch),
+not the checkout as a whole. **Rejected:** serializing every ask in a session.
+That collapses throughput by ordering asks that never conflict (two agents
+editing unrelated files), reintroducing the cost the autonomy investment was
+meant to remove. Keying on the surface serializes only the asks that would
+actually collide.
+
+## Data flow
+
+1. Facilitator forms an ask; if its surface matches an in-flight same-surface
+   ask, the dispatch gate (D3/D4) holds it until the prior Answer/release.
+2. The ask carries edit-intent (D2): surface + own-artifact path list.
+3. The receiver does its work and commits, staging exactly the declared paths
+   (D1) — never a whole-tree sweep.
+4. The commit lands through the `fit-wiki` push primitive unchanged (Spec 1850
+   D3 boundary); L1 has already ensured the commit carries only own artifacts.
+
+## Boundaries
+
+- **Allocation identity** (1840/1850 D1/D2): untouched. No identifier minting
+  changes.
+- **Push primitive** (1850 D3, 1750/1780): untouched. L1 is upstream of the
+  push — it scopes the commit's contents; D3 scopes how that commit lands.
+- **No lock/mutex/lease** (S5): D3 is the load-bearing rejection. Any later
+  design that reintroduces lock-based mutual exclusion violates the spec.
+
+## Open questions for the plan
+
+- The exact enumeration mechanism for "the closed set of commit paths" (S1's
+  audit scope) — which registry or convention bounds it.
+- Where the edit-intent field lives in the ask schema and how a receiver that
+  ignores it is detected.
+- Whether the dispatch gate is advisory guidance to the facilitator or a
+  mechanized hold — and the liveness fallback if an Answer never arrives
+  (without reintroducing a lease, per S5).

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/plan-a.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/plan-a.md
@@ -1,0 +1,210 @@
+# Plan 2010-a — path-scoped staging and facilitator serialization
+
+Executes [design-a.md](design-a.md) for [spec.md](spec.md).
+
+## Approach
+
+Ship the two levers as their controllable artifacts. **L1** is a deny-by-default
+JS-AST lint (S1): a new `.coaligned/invariants` rule keyed on the one whole-tree
+staging method the shared-checkout commit paths use — `GitClient.commitAll` (the
+`commitPaths` path is the compliant one PR #1571 established) — flagging every
+*caller* of it in commit-path source, with an explicit own-artifact allowlist.
+**L2/S2/S3/S6** are protocol requirements in the `kata-session` skill: the
+same-surface serialization rule, the edit-intent ask field (D5 two classes), the
+single-owner classifier (D7), and facilitator-declared output surfaces (D8).
+
+**Closed-set scoping (verified against the tree).** The only `commitAll` *caller*
+in JS commit-path source is `wiki-sync.js:145` (the `fit-wiki push`/sync sweep) —
+L1's sole un-scoped application site, whose code change is blocked on spec 1850
+D3 (does not yet exist), so it is **allowlisted as a named exception pointing at
+#1583 item 3**, not changed here. Its shell twin `scripts/wiki-sync.sh` runs the
+same `fit-wiki push` sweep and is part of the *same* deferral — named here, not
+linted (the JS-AST rule cannot parse shell, and it is the identical blocked
+site). The `commitAll` *definition* (`libutil/src/git-client.js`) and its mock
+(`libmock`) are the primitive, not commit paths — the caller-keyed rule never
+flags them. `.github/workflows/publish-skills.yml`'s `git add -A` runs in a
+**separate skills-repo checkout, not the shared session checkout**, so it is
+outside S1's scope (S1 governs the shared checkout). This keeps the rule
+deny-by-default, JS-only (matching the framework's AST capability), and passing
+on the current tree with exactly one allowlist entry.
+
+Libraries used: none. (Step 1 reuses the in-repo invariant helpers
+`.coaligned/invariants/lib/ast.mjs` and `lib/walk.mjs`, not workspace packages.)
+
+## Steps
+
+### 1. L1 deny-by-default staging lint (S1)
+
+Forbid whole-tree staging in commit-path source outside an own-artifact
+allowlist; gate continuously.
+
+- Created: `.coaligned/invariants/shared-workspace-staging.rules.mjs`
+- Created: `.coaligned/invariants/shared-workspace-staging.allow.json`
+
+Model on `subprocess-in-tests.rules.mjs`: `parseModule`/`walkAst` from
+`lib/ast.mjs`, `collectFiles`/`readJsonOrNull` from `lib/walk.mjs`. `build()`
+iterates each package under `libraries`/`products`/`services` and calls
+`collectFiles(pkgRoot, { skip, match })` where `skip` is a name-set including
+`"test"`, `"node_modules"`, `"dist"`, `"generated"` and `match` accepts a path
+iff it ends `.js`/`.mjs` and **not** `.test.js`/`.test.mjs`. (`collectFiles`
+filters by directory *name* in `skip` and by the `match` predicate — not by glob
+path, so the exclusions are expressed as a skip-name + a predicate, not as
+`*/test/*` strings.) Then drop two explicit paths from the collected set:
+`libraries/libutil/src/git-client.js` (the `commitAll` definition) and any file
+under `libraries/libmock`. The rule walks each remaining file's AST and flags any
+`CallExpression` whose `calleeName` resolves to `commitAll` (covers
+`this.#git.commitAll`, `git.commitAll`), unless the file is in the allow list.
+Severity `fail` (deny-by-default).
+
+Keying on the `commitAll` callee is the precise discipline: `commitPaths` is the
+scoped path (PR #1571), `commitAll` is the one whole-tree method. The
+git-client.js exclusion removes the primitive's own definition (whose `git add
+-A` argv is not a `commitAll` *call* and so would not match anyway — the
+exclusion is belt-and-suspenders). The libmock exclusion is likewise defensive:
+its `"commitAll"` is a string in a method-name array, not a `CallExpression`, so
+`calleeName` never flags it. The allow list keys on `file` only (one entry,
+mirroring `subprocess-in-tests.allow.json`'s flat `[{...}]` shape), loaded via
+`readJsonOrNull(join(import.meta.dirname, "shared-workspace-staging.allow.json"))
+?? []` (resolved relative to the rule dir, empty-fallback so an absent file does
+not crash the rule) into a `Set` of `file` values:
+
+```json
+// shared-workspace-staging.allow.json
+[
+  { "file": "libraries/libwiki/src/wiki-sync.js",
+    "reason": "fit-wiki push sweep — L1 application site blocked on spec 1850 D3 (#1583 item 3); shell twin scripts/wiki-sync.sh shares this deferral" }
+]
+```
+
+`claim`/`release` reach `commitPaths` (via `commitAndPush(msg, ["MEMORY.md"])`,
+PR #1571), never `commitAll`, so they pass without an entry. The sole flagged
+caller on the current tree is `wiki-sync.js:145`, covered by the one entry.
+
+Verify: `bunx coaligned invariants` passes on the current tree with the
+allowlist; removing the `wiki-sync.js` entry makes it fail (proves the rule
+fires on the real sweep); adding a throwaway `this.#git.commitAll(...)` call in
+any non-test commit-path `.js` file under the scoped dirs fails.
+
+### 2. Edit-intent ask field — two surface classes (S3, D5)
+
+Define the field the facilitator populates and the receiver consumes.
+
+- Modified: `.claude/skills/kata-session/references/dispatch-discipline.md`
+
+Add an **Edit-intent** section defining the field on a facilitated ask:
+
+| Class | Declared by | L1 stages it? | L2 orders on it? |
+| --- | --- | --- | --- |
+| `staged_paths` | facilitator (receiver's own artifacts) | yes | yes |
+| `output_surfaces` | facilitator (D8) | no | yes |
+
+State the hard split (D5): a receiver stages **only** `staged_paths`, never an
+`output_surface`. Both classes use the granular target (a specific file path or
+a specific thread), never a coarse key like "the wiki" (D4).
+
+Verify: the section states the field, its two classes, the per-class declarer,
+and the stage-only-staged_paths rule as a requirement (S3 pass/fail).
+
+### 3. L2 same-surface serialization rule (S2)
+
+- Modified: `.claude/skills/kata-session/references/dispatch-discipline.md`
+
+Add a **Same-surface serialization** rule to the facilitator protocol: route a
+wiki-touching (or otherwise same-mutable-surface) ask only after the prior ask
+whose edit-intent union (staged_paths ∪ output_surfaces, D4/D5) intersects this
+ask's surface has returned its Answer or explicitly released. Keying is on the
+specific surface, not the whole session (D4). State the liveness posture: the
+hold is advisory facilitator discipline (no lock/lease, S5); if an Answer never
+arrives the facilitator may release on its own judgment — there is no automated
+lease (open question resolved toward advisory, per S5).
+
+Verify: the protocol states the ordering rule as a requirement naming the
+surface-intersection key and the Answer/release release-condition (S2 pass/fail).
+
+### 4. Single-owner cardinality + classifier (S6, D6, D7)
+
+- Modified: `.claude/skills/kata-session/references/dispatch-discipline.md`
+
+Add a **Single-owner routing** rule: a single-owner directive routes to exactly
+one acting lane; co-recipients get a no-staging FYI carrying no edit-intent and
+requiring no action (D6). Define the **classifier** (D7): a directive is
+multi-owner *iff* it explicitly names ≥2 distinct acting recipients each given a
+work-producing instruction; everything else — one named owner, an unaddressed
+"someone should…", a close-out/decision directive — is single-owner. State the
+**conservative default**: ambiguous directives are single-owner (D7 rationale:
+the fan-out ships committed loss; a starved FYI lane is recoverable by
+re-dispatch). Note S5 holds — cardinality is routing only, no lock.
+
+Verify: the protocol states the one-acting-lane rule, names the classifier
+predicate, and declares the conservative default as requirements (S6 pass/fail).
+
+### 5. Wire the protocol into the facilitator skill surface (S4)
+
+- Modified: `.claude/skills/kata-session/SKILL.md`
+
+In the Facilitator Process and the facilitator DO-CONFIRM checklist, reference
+the dispatch-discipline rules so a session exercises them: checklist items that
+same-surface asks were serialized, that each work-producing ask carried
+edit-intent, and that single-owner directives routed to one lane. Include in
+`dispatch-discipline.md` one worked example ask showing edit-intent
+(`staged_paths` + `output_surfaces`) driving scoped staging — the concrete
+artifact S4's "at least one ask shows edit-intent driving scoped staging" half
+points at, present in the protocol independent of any live session. The example
+must be generic (placeholder paths like `wiki/<file>`, no repo issue/PR numbers,
+no dated snapshots) so it passes the `skill-genericity` gate.
+
+Verify (S4, both halves, at implementation time per spec.md S4): (a) the
+SKILL.md facilitator checklist names the serialization rule and the edit-intent
+requirement — protocol active; (b) `dispatch-discipline.md` carries the worked
+edit-intent example ask — the ask exercised. The post-deployment zero-collision
+result is a separate meter, not this gate.
+
+### 6. S5 review-gate note
+
+- Modified: `.claude/skills/kata-session/references/dispatch-discipline.md`
+
+One line stating the no-lock/lease/mutex boundary (S5) as a standing constraint
+on this protocol, so a future edit that adds a lock is visibly out of bounds.
+
+Verify: the no-lock constraint is stated; the diff contains no lock/lease/mutex
+primitive (S5 review gate).
+
+After Steps 2–6, `bun run invariants` (skill-genericity rule, which globs
+`.claude/skills/kata-*/**`) must pass on the edited `dispatch-discipline.md` and
+`SKILL.md`: the new protocol text uses generic field names (`staged_paths`,
+`output_surfaces`) and must carry no repo package names, file paths, or
+issue/PR links.
+
+## Risks
+
+- **A sweep via an un-modeled API.** The rule keys on the `commitAll` callee,
+  the one whole-tree-staging method the GitClient exposes. A future commit path
+  that sweeps via a raw `runtime.subprocess.run(["git","add","-A"])` built from
+  fragments would not be a `commitAll` call and would escape the rule. The
+  framework's AST keys on the callee, so the completeness boundary is "uses
+  `commitAll`"; a raw-argv sweep is a separate shape. Document this inline so a
+  future maintainer extends the callee set (or adds an argv-literal check scoped
+  to JS only) if such a path appears; the corpus has none today (the only raw
+  `add -A` argv lives in the GitClient definition the rule excludes). The
+  deny-by-default posture means a newly-introduced sweep API surfaces as an
+  un-allowlisted caller only if the rule recognizes it — so the rule's API set is
+  the completeness boundary, documented inline for future extension.
+- **`.claude/**` write gating.** Editing `dispatch-discipline.md` / `SKILL.md`
+  may be blocked by the Edit() settings rules; use the `bunx fit-selfedit`
+  path per CLAUDE.md when blocked on a non-`main` branch.
+- **Skill genericity.** `dispatch-discipline.md` is a published `kata-*` skill
+  reference; the new rules must not name this monorepo's packages/paths. Write
+  the serialization/classifier rules generically (no `libwiki`, no repo issue
+  numbers) per `.claude/skills/CLAUDE.md`; `bun run invariants`
+  (skill-genericity rule) gates this.
+
+## Execution
+
+Single agent or split: **Step 1 (lint)** is code and independent — route to an
+engineering agent. **Steps 2–6 (protocol docs)** are documentation in one skill
+and share `dispatch-discipline.md` — route to `technical-writer`, executed as one
+unit (they edit the same file). Steps 1 and 2–6 can run in parallel; no ordering
+dependency between the lint and the protocol docs. Within 2–6, do 2 (field)
+before 3/4 (rules that reference the field).
+
+— Staff Engineer 🛠️

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
@@ -90,7 +90,7 @@ separately as post-deployment validation targets below.
 
 | # | Criterion | Verified by |
 |---|---|---|
-| S1 | Every commit produced in the shared checkout contains only the committing activation's own artifacts — no path a concurrent activation authored. | An audit enumerates the closed set of commit paths (every skill or tool that commits inside the shared checkout) and confirms each stages an explicit own-artifact path list rather than a whole-tree sweep. The check is automatable as a static lint over commit-path source — forbidding whole-tree staging APIs (`git add -A`, `commit -am`, `commitAll`) outside an allowlisted path — so it gates continuously, not as a one-time audit; this is distinct from the runtime authorship hook design D1 rejects (the lint reads source, not working-tree authorship). Exact lint form is a plan concern. |
+| S1 | Every commit produced in the shared checkout contains only the committing activation's own artifacts — no path a concurrent activation authored. | An audit enumerates the closed set of commit paths (every skill or tool that commits inside the shared checkout) and confirms each stages an explicit own-artifact path list rather than a whole-tree sweep. The check is automatable as a static lint over commit-path source — forbidding whole-tree staging APIs (`git add -A`, `commit -am`, `commitAll`) outside an allowlisted path — so it gates continuously, not as a one-time audit; this is distinct from the runtime authorship hook design D1 rejects (the lint reads source, not working-tree authorship). The guarantee is only as strong as the enumeration is complete, so the lint is **deny-by-default**: any commit path not on the explicit own-artifact allowlist fails the check, so a newly-added or overlooked commit path surfaces as a violation rather than silently escaping the closed set. Keeping the set closed is therefore a property the lint enforces continuously, not a one-time completeness assumption the audit makes once. Exact lint form is a plan concern. |
 | S2 | The facilitated-session protocol mandates that a wiki-touching ask is routed only after the prior same-surface ask returns its Answer or explicitly releases. | The facilitator protocol document states the rule as a requirement — the controllable artifact and the pass/fail; a session transcript is illustrative, not the gate. |
 | S3 | The facilitated-ask format requires an edit-intent field naming the surface and the own-artifact paths the receiver will stage. | The ask-format definition mandates the field — the controllable artifact and the pass/fail; a routed ask is illustrative. |
 | S4 | A deployed facilitated session carries both levers and exercises them: the serialization rule is active and at least one ask shows edit-intent driving scoped staging. | A structural check on one session: protocol active, ask exercised — verifiable at implementation, independent of any accrual window. |
@@ -167,18 +167,25 @@ two levers held in the field; they do not gate spec approval or merge.
   landing. L1 is upstream — it scopes what enters a commit; D3 governs how a
   scoped commit lands. Where they meet, the primitive's landing behavior is
   1850 D3's; L1 adds only the staging-breadth contract. They compose; they do
-  not contest.
+  not contest. One sequencing consequence follows for the application site: the
+  #1583 item-3 scoping carries a **dual dependency** — on this spec's
+  staging-breadth contract *and* on 1850 D3's landing design — so it cannot be
+  planned until both exist. 1850 is still at `spec draft` (PR #1655 at the human
+  gate, in adjudication conflict with 1840 / PR #1654), so its D3 landing design
+  does not yet exist; item 3 therefore stays un-plannable until 1850's spec
+  merges and is designed. The block is item 3's alone — #1583 items 1–2 carry no
+  design question and can proceed independently if triage splits them.
 - **1750 / 1780 (landing honesty).** Out of scope; L1 reduces the surface those
   specs harden by ensuring a commit carries only its author's artifacts in the
   first place.
 - **#1583 (libwiki sync path) — L1's sole remaining application site.** #1583
   item 3 ("pathspec-scope the sweep") is the one shared-workspace commit path L1
   names that PR #1571 did not yet scope: the `fit-wiki push`/sync sweep. #1583's
-  body frames item 3 as *reversing* the settled "whole-tree is its contract"
-  decision (#1576 § Out of scope, #1568 lineage). This spec supplies the
-  rationale that makes it an *application* of a named discipline instead — so the
-  discipline and its sole application site do not graduate as two specs in
-  tension. The sync's design intent (publish this session's own memory) is
+  body frames item 3 as *reversing* a "whole-tree is its contract" decision that
+  its lineage (#1576 § Out of scope, #1568) had read as settled. This spec
+  supplies the rationale that makes it an *application* of a named discipline
+  instead — so the discipline and its sole application site do not graduate as
+  two specs in tension. The sync's design intent (publish this session's own memory) is
   preserved by staging the session's own-authored paths; what L1 removes is only
   the capture of a concurrent activation's in-flight residue from the shared
   checkout. Scoping the sweep is therefore L1, not a contract reversal. The

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
@@ -68,7 +68,7 @@ adding that one.
 
 | Lever | What changes |
 |---|---|
-| **L1 — path-scoped staging discipline** | Every shared-workspace commit path stages only the artifacts it owns, named by explicit path, never by `git add -A` / `commit -am` breadth. The discipline covers agent feature commits, activation sweep-commits, and tool commits. PR #1571 is the cited precedent for one path. |
+| **L1 — path-scoped staging discipline** | Every shared-workspace commit path stages only the artifacts it owns, named by explicit path, never by `git add -A` / `commit -am` breadth. The discipline covers agent feature commits, activation sweep-commits, and tool commits. PR #1571 is the cited precedent for one path; the `fit-wiki push`/sync sweep (#1583 item 3) is the **sole remaining un-scoped application site** — see § Relationship. L1 is also a security control: a whole-tree sweep into the wiki repo, which carries no gitleaks / push-protection, is a latent credential-leak surface, so scoping the staging shrinks that surface as well as preventing committed loss. (Gating the wiki repo itself is a separate, complementary control — see § Non-Goals.) |
 | **L2 — facilitator-side serialization of wiki-touching asks** | A facilitator routes a wiki-touching (or otherwise same-mutable-surface) ask only after the prior ask on that surface has returned its Answer or explicitly released. Each such ask names its edit-intent (surface + own-artifact paths) so a receiver can scope its staging under L1. |
 
 **Out of scope** (named so they are not reopened here):
@@ -77,7 +77,7 @@ adding that one.
 |---|---|
 | Allocation identity — how occurrence ordinals, fold indexes, and meta numbers are minted | The competing WHAT of specs 1840 (PR #1654) and 1850 (PR #1655); approval of either supersedes the other. This spec touches neither. |
 | The `fit-wiki` push primitive's landing discipline — stale-tree refusal, whole-tree landing semantics | Spec 1850 D3 (with 1750/1780). See § Relationship for the L1↔D3 seam. |
-| Push-rejection honesty, `-X ours` clobber, conflict-marker publication | Specs 1780 / #1668, and #1583 items 1–2 — the landing primitive, not the staging boundary. (#1583 item 3, scoping the push/sync sweep, is the one part adjacent to L1; its push-primitive specifics defer to 1850 D3, while its evidence that the sweep exists motivates L1.) |
+| Push-rejection honesty, `-X ours` clobber, conflict-marker publication | Specs 1780 / #1668, and #1583 items **1–2** — the landing primitive, not the staging boundary. (#1583 **item 3** — scoping the push/sync sweep — is *in scope as an L1 application site*, not excluded; only its push-primitive landing specifics coordinate with 1850 D3. See § Relationship.) |
 | Post-merge budget revalidation; coordination-comment and summary-surface floors | #1667; #1647 / #1732 (spec-1890/1900 attachment points). |
 | Shallow-clone forensic artifacts | Observation-layer cross-cutting item (#1577); #1575 resolved. |
 | A distributed lock, mutex, or lock service over the workspace or claim | **Non-goal** — see below. |
@@ -90,7 +90,7 @@ separately as a post-deployment validation target below.
 
 | # | Criterion | Verified by |
 |---|---|---|
-| S1 | Every commit produced in the shared checkout contains only the committing activation's own artifacts — no path a concurrent activation authored. | An audit enumerates the closed set of commit paths (every skill or tool that commits inside the shared checkout) and confirms each stages an explicit own-artifact path list rather than a whole-tree sweep; repeatable as a check. |
+| S1 | Every commit produced in the shared checkout contains only the committing activation's own artifacts — no path a concurrent activation authored. | An audit enumerates the closed set of commit paths (every skill or tool that commits inside the shared checkout) and confirms each stages an explicit own-artifact path list rather than a whole-tree sweep. The check is automatable as a static lint over commit-path source — forbidding whole-tree staging APIs (`git add -A`, `commit -am`, `commitAll`) outside an allowlisted path — so it gates continuously, not as a one-time audit; this is distinct from the runtime authorship hook design D1 rejects (the lint reads source, not working-tree authorship). Exact lint form is a plan concern. |
 | S2 | The facilitated-session protocol mandates that a wiki-touching ask is routed only after the prior same-surface ask returns its Answer or explicitly releases. | The facilitator protocol document states the rule as a requirement — the controllable artifact and the pass/fail; a session transcript is illustrative, not the gate. |
 | S3 | The facilitated-ask format requires an edit-intent field naming the surface and the own-artifact paths the receiver will stage. | The ask-format definition mandates the field — the controllable artifact and the pass/fail; a routed ask is illustrative. |
 | S4 | A deployed facilitated session carries both levers and exercises them: the serialization rule is active and at least one ask shows edit-intent driving scoped staging. | A structural check on one session: protocol active, ask exercised — verifiable at implementation, independent of any accrual window. |
@@ -116,6 +116,13 @@ gate spec approval or merge.
   S5.
 - **No allocation-contract change.** This spec does not alter how identifiers
   are minted; that is the 1840/1850 adjudication.
+- **No wiki-repo destination gating.** Standing up gitleaks / push-protection on
+  the separate wiki repository is a complementary security control that gates the
+  *destination* repo, orthogonal to L1's staging *scope* — a perfectly scoped
+  commit can still carry a secret into an ungated repo. That gap is a standing
+  known issue tracked on its own line (security-engineer), not folded into this
+  spec's two levers. L1 shrinks the leak surface; closing the destination gap is
+  separate work.
 
 ## Relationship to in-flight siblings
 
@@ -131,6 +138,20 @@ gate spec approval or merge.
 - **1750 / 1780 (landing honesty).** Out of scope; L1 reduces the surface those
   specs harden by ensuring a commit carries only its author's artifacts in the
   first place.
+- **#1583 (libwiki sync path) — L1's sole remaining application site.** #1583
+  item 3 ("pathspec-scope the sweep") is the one shared-workspace commit path L1
+  names that PR #1571 did not yet scope: the `fit-wiki push`/sync sweep. #1583's
+  body frames item 3 as *reversing* the settled "whole-tree is its contract"
+  decision (#1576 § Out of scope, #1568 lineage). This spec supplies the
+  rationale that makes it an *application* of a named discipline instead — so the
+  discipline and its sole application site do not graduate as two specs in
+  tension. The sync's design intent (publish this session's own memory) is
+  preserved by staging the session's own-authored paths; what L1 removes is only
+  the capture of a concurrent activation's in-flight residue from the shared
+  checkout. Scoping the sweep is therefore L1, not a contract reversal. The
+  push-primitive landing specifics (stale-tree refusal, fast-forward honesty)
+  remain 1850 D3's; #1583 stays the tracking item for the implementation, citing
+  this spec as its authority.
 
 This spec does not pre-empt the 6/24 Exp #1565 read or the 7/02 RFC #873
 verdict; it gives both a proposed structure to evaluate instead of an unbounded

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
@@ -173,8 +173,13 @@ two levers held in the field; they do not gate spec approval or merge.
   planned until both exist. 1850 is still at `spec draft` (PR #1655 at the human
   gate, in adjudication conflict with 1840 / PR #1654), so its D3 landing design
   does not yet exist; item 3 therefore stays un-plannable until 1850's spec
-  merges and is designed. The block is item 3's alone — #1583 items 1–2 carry no
-  design question and can proceed independently if triage splits them.
+  merges and is designed. The dependency runs deeper than sequencing: item 3's
+  *shape* forks on 1850's mechanism choice — a worktree-per-session design makes
+  item 3 a defense-in-depth lint, while a shared-tree + explicit-paths design
+  makes it a staging refactor that must itself produce the per-session path list
+  — so the item-3 plan must read 1850's design, not merely wait for it. The
+  block is item 3's alone — #1583 items 1–2 carry no design question and can
+  proceed independently if triage splits them.
 - **1750 / 1780 (landing honesty).** Out of scope; L1 reduces the surface those
   specs harden by ensuring a commit carries only its author's artifacts in the
   first place.

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
@@ -95,7 +95,7 @@ separately as post-deployment validation targets below.
 | S3 | The facilitated-ask format requires an edit-intent field naming the surface and the own-artifact paths the receiver will stage. | The ask-format definition mandates the field — the controllable artifact and the pass/fail; a routed ask is illustrative. |
 | S4 | A deployed facilitated session carries both levers and exercises them: the serialization rule is active and at least one ask shows edit-intent driving scoped staging. | A structural check on one session: protocol active, ask exercised — verifiable at implementation, independent of any accrual window. |
 | S5 | The fix introduces no lock, mutex, lease, or lock service over the workspace or the claim handshake. | The design and implementation contain no such component; the non-goal stands as a review gate. |
-| S6 | A single-owner directive routes to exactly one lane; co-recipients receive a no-staging FYI that carries no edit-intent and requires no action. | The facilitator protocol states the single-routing cardinality rule as a requirement — the controllable artifact and the pass/fail; a session transcript is illustrative, not the gate. |
+| S6 | A single-owner directive routes to exactly one lane; co-recipients receive a no-staging FYI that carries no edit-intent and requires no action. The protocol names the single-owner classifier that makes this determination at dispatch time and declares its conservative default for ambiguous directives. | The facilitator protocol states the single-routing cardinality rule **and** names a classifier with a declared conservative default as requirements — the controllable artifact and the pass/fail; a session transcript is illustrative, not the gate. |
 
 S6 is the cardinality complement to L2's temporal serialization, attached at
 L2's existing facilitator-dispatch gate: it bounds **how many** lanes act on one
@@ -104,6 +104,24 @@ single acting lane there is no fan-out to serialize, so S6 alone closes #1725's
 Mode A (the single-owner directive "fanned to six agents"). S6 introduces no
 lock, lease, or mutual exclusion — it constrains routing cardinality only — so S5
 still holds.
+
+**S6's guarantee is exactly as strong as the single-owner classifier at dispatch
+time.** The cardinality cap binds only on directives the classifier labels
+single-owner. A single-owner directive *misclassified as multi-owner* never
+reaches S6's one-lane rule: it falls through to L2, which caps the asks
+**temporally** (same-surface ordering) but not **cardinally** (count of acting
+lanes), so the fan-out — and the Mode-A falsifier failure — can still occur. The
+classifier is therefore load-bearing surface, not an implementation detail, and
+its conservative default is a genuine trade-off: defaulting an ambiguous
+directive to single-owner risks starving real multi-owner work in the FYI'd
+lanes, while defaulting to multi-owner reopens the exact fan-out S6 exists to
+remove. This spec **requires** that the protocol name such a classifier and
+declare its default; it does **not** fix the predicate's internals or which way
+the default leans — that is design surface (kata-design open question on the
+classifier predicate and conservative-default choice), where the choice can be
+grounded in the corpus. Pinning the requirement here without pinning the
+mechanism keeps S6 honest about where its guarantee lives while leaving the
+load-bearing decision to be made with evidence.
 
 **Post-deployment validation targets (not acceptance gates):** two falsifiers
 run over the window, one per failure mode.

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
@@ -69,7 +69,7 @@ adding that one.
 | Lever | What changes |
 |---|---|
 | **L1 — path-scoped staging discipline** | Every shared-workspace commit path stages only the artifacts it owns, named by explicit path, never by `git add -A` / `commit -am` breadth. The discipline covers agent feature commits, activation sweep-commits, and tool commits. PR #1571 is the cited precedent for one path; the `fit-wiki push`/sync sweep (#1583 item 3) is the **sole remaining un-scoped application site** — see § Relationship. L1 is also a security control: a whole-tree sweep into the wiki repo, which carries no gitleaks / push-protection, is a latent credential-leak surface, so scoping the staging shrinks that surface as well as preventing committed loss. (Gating the wiki repo itself is a separate, complementary control — see § Non-Goals.) |
-| **L2 — facilitator-side serialization of wiki-touching asks** | A facilitator routes a wiki-touching (or otherwise same-mutable-surface) ask only after the prior ask on that surface has returned its Answer or explicitly released. Each such ask names its edit-intent (surface + own-artifact paths) so a receiver can scope its staging under L1. |
+| **L2 — facilitator-side serialization of wiki-touching asks** | A facilitator routes a wiki-touching (or otherwise same-mutable-surface) ask only after the prior ask on that surface has returned its Answer or explicitly released. Each such ask names its edit-intent (surface + own-artifact paths) so a receiver can scope its staging under L1. A single-owner directive routes to exactly one acting lane; co-recipients get a no-staging FYI that carries no edit-intent and requires no action. This single-routing cardinality is the complement to the temporal ordering above — with one acting lane there is no fan-out to serialize. |
 
 **Out of scope** (named so they are not reopened here):
 
@@ -84,9 +84,9 @@ adding that one.
 
 ## Success Criteria
 
-All five are checkable at implementation time, without waiting on a future
-session-accrual window. The longitudinal zero-collision result is stated
-separately as a post-deployment validation target below.
+All six are checkable at implementation time, without waiting on a future
+session-accrual window. The longitudinal zero-collision results are stated
+separately as post-deployment validation targets below.
 
 | # | Criterion | Verified by |
 |---|---|---|
@@ -95,15 +95,30 @@ separately as a post-deployment validation target below.
 | S3 | The facilitated-ask format requires an edit-intent field naming the surface and the own-artifact paths the receiver will stage. | The ask-format definition mandates the field — the controllable artifact and the pass/fail; a routed ask is illustrative. |
 | S4 | A deployed facilitated session carries both levers and exercises them: the serialization rule is active and at least one ask shows edit-intent driving scoped staging. | A structural check on one session: protocol active, ask exercised — verifiable at implementation, independent of any accrual window. |
 | S5 | The fix introduces no lock, mutex, lease, or lock service over the workspace or the claim handshake. | The design and implementation contain no such component; the non-goal stands as a review gate. |
+| S6 | A single-owner directive routes to exactly one lane; co-recipients receive a no-staging FYI that carries no edit-intent and requires no action. | The facilitator protocol states the single-routing cardinality rule as a requirement — the controllable artifact and the pass/fail; a session transcript is illustrative, not the gate. |
 
-**Post-deployment validation target (not an acceptance gate):** across ≥5
-facilitated sessions with both levers applied, new committed-loss occurrences in
-the #1564 facilitated-session sub-family are zero (the parallel-collision ledger
-over the window). This measures the **committed-loss sub-shape only**; Exp
-#1565's broader predicate P1 ("0 shared-workspace collisions of any sub-shape")
-is unchanged and owned by #1565 — this spec does not narrow it. The target is
-the standing meter for whether the two levers held in the field; it does not
-gate spec approval or merge.
+S6 is the cardinality complement to L2's temporal serialization, attached at
+L2's existing facilitator-dispatch gate: it bounds **how many** lanes act on one
+directive, where L2's ordering rule bounds **when** same-surface asks run. With a
+single acting lane there is no fan-out to serialize, so S6 alone closes #1725's
+Mode A (the single-owner directive "fanned to six agents"). S6 introduces no
+lock, lease, or mutual exclusion — it constrains routing cardinality only — so S5
+still holds.
+
+**Post-deployment validation targets (not acceptance gates):** two falsifiers
+run over the window, one per failure mode.
+
+- **Mode B — committed loss.** Across ≥5 facilitated sessions with both levers
+  applied, new committed-loss occurrences in the #1564 facilitated-session
+  sub-family are zero (the parallel-collision ledger over the window).
+- **Mode A — single-owner fan-out** (#1725's falsifier). The next ≥5
+  single-owner close-out directives each produce ≤1 reconciliation record and 0
+  duplicate-leg wiki collisions attributable to this directive class.
+
+Each measures its own sub-shape only; Exp #1565's broader predicate P1 ("0
+shared-workspace collisions of any sub-shape") is unchanged and owned by #1565 —
+this spec does not narrow it. The targets are the standing meters for whether the
+two levers held in the field; they do not gate spec approval or merge.
 
 ## Non-Goals
 

--- a/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
+++ b/specs/2010-shared-workspace-commit-scoping-and-serialization/spec.md
@@ -1,0 +1,139 @@
+# Spec 2010 — shared-workspace committed loss: path-scoped staging and facilitator serialization
+
+Graduates the facilitated-session/shared-workspace sub-family of Obstacle
+[#1564](https://github.com/forwardimpact/monorepo/issues/1564) from interim
+floors to a structural fix. The family stands at 92 real occurrences plus 34
+near-misses in four-plus weeks (`wiki/parallel-collision-ledger.md`, per Exp 51
+[#1585](https://github.com/forwardimpact/monorepo/issues/1585)). This spec
+addresses the one sub-shape that ships **committed loss or wrong-author
+content** — not the allocation-identity question that specs
+[1840](https://github.com/forwardimpact/monorepo/pull/1654) /
+[1850](https://github.com/forwardimpact/monorepo/pull/1655) contest, and not a
+lock. The invariant in one sentence: **committed loss requires two conditions
+at once — two writers in one workspace and a commit that stages by sweep — so
+removing either condition prevents it.**
+
+## Personas and Jobs
+
+| Persona | Job | How the gap blocks progress |
+|---|---|---|
+| Teams Using Agents | [Run a Continuously Improving Agent Team](../../JTBD.md#teams-using-agents-run-a-continuously-improving-agent-team) | The team's anxiety force is that "autonomy might amplify bad patterns faster than humans can intervene." This sub-family is that force realized: facilitated sessions route overlapping work into one shared checkout, and broad-staging commits then publish a teammate's in-flight edits under the wrong author. Repair (verbatim re-lands, renumber maps, forensic bisects) now consumes a dominant share of coach, release-engineer, and product-manager capacity — the improvement loop spends its budget cleaning up its own coordination. |
+| Platform Builders | [Build Agent-Capable Systems](../../JTBD.md#platform-builders-build-agent-capable-systems) | The shared-workspace commit path and the facilitated-dispatch path are primitives every Kata installation runs. A scoping discipline at the commit boundary and a serialization rule at the dispatch boundary protect every installation that runs an agent team in a shared checkout, independent of which skill is executing. |
+
+## Problem
+
+Vocabulary: a **shared workspace** is the single checkout a facilitated session's
+concurrent agent activations share; a **commit path** is any code that stages
+and commits inside that checkout (an agent's feature commit, an activation
+sweep-commit, or a tool commit such as `fit-wiki claim`/`release`); a **sweep**
+stages by breadth (`git add -A`, `git commit -am`) rather than by explicit path;
+**committed loss** is foreign or wrong-author content reaching a commit — the
+only sub-shape in the family that ships, as opposed to being caught at
+push-reject, rebase, or pre-commit diff.
+
+The family's facilitated-session catches have all been accidents of tooling —
+push-reject, rebase, scope partition — never a designed control (#1564). The
+committed-loss instances are the ones no accident caught. Two conditions
+co-produce them, and the corpus shows each is independently removable.
+
+| Condition | Behavior today | Evidence |
+|---|---|---|
+| **Concurrent dispatch into one workspace** | The facilitator routes asks that touch the same mutable surface (a wiki file, a PR branch, the shared tree) to multiple activations at once, with no ordering. Both are mid-session before either sees the other's intent. In #1725 a single-owner directive was "fanned to six agents," producing three duplicate comments of "pure redundancy." | #1564 (mechanics), #1725 (routing cause) |
+| **Commit paths stage by sweep** | Commit paths stage the whole dirty tree rather than their own artifacts, so a commit captures whatever a concurrent activation left in the tree. The team named this "the sweep is upstream of both levers" and "agent-side discipline cannot scope a commit the tool makes on the agent's behalf." | #1564, #1568, #1583 |
+
+When both conditions hold, a sweep-commit picks up a teammate's just-appended
+content and ships it under the wrong author before any repair (#1564 collision
+"sweep-commit cross-contamination," **not caught pre-landing**). Each condition
+has a validated single-condition fix:
+
+- **Serialize same-surface asks.** The falsifier experiment #1565 recorded that
+  after the facilitator "serialized all wiki-touching asks, zero further
+  collisions occurred (n=1 session)." Its standing target is "0 collisions
+  across ≥5 facilitated sessions with the discipline applied."
+- **Scope the staging.** PR #1571 pathspec-limited the `fit-wiki
+  claim`/`release` commits to their one-line contract — the team's first
+  codification of the move, applied to one commit path. The discipline
+  generalizes: every shared-workspace commit path stages its own artifacts by
+  explicit path.
+
+A lock is the wrong third option. The claim handshake "is therefore an advisory
+marker, not a single-writer mutex" (#1539); making it a real mutex introduces a
+dominant new failure — a lock held by a dead activation with no lease — that the
+family does not have today. The two levers above remove the failure without
+adding that one.
+
+## Scope
+
+**In scope:**
+
+| Lever | What changes |
+|---|---|
+| **L1 — path-scoped staging discipline** | Every shared-workspace commit path stages only the artifacts it owns, named by explicit path, never by `git add -A` / `commit -am` breadth. The discipline covers agent feature commits, activation sweep-commits, and tool commits. PR #1571 is the cited precedent for one path. |
+| **L2 — facilitator-side serialization of wiki-touching asks** | A facilitator routes a wiki-touching (or otherwise same-mutable-surface) ask only after the prior ask on that surface has returned its Answer or explicitly released. Each such ask names its edit-intent (surface + own-artifact paths) so a receiver can scope its staging under L1. |
+
+**Out of scope** (named so they are not reopened here):
+
+| Excluded | Why, and where it lives |
+|---|---|
+| Allocation identity — how occurrence ordinals, fold indexes, and meta numbers are minted | The competing WHAT of specs 1840 (PR #1654) and 1850 (PR #1655); approval of either supersedes the other. This spec touches neither. |
+| The `fit-wiki` push primitive's landing discipline — stale-tree refusal, whole-tree landing semantics | Spec 1850 D3 (with 1750/1780). See § Relationship for the L1↔D3 seam. |
+| Push-rejection honesty, `-X ours` clobber, conflict-marker publication | Specs 1780 / #1668, and #1583 items 1–2 — the landing primitive, not the staging boundary. (#1583 item 3, scoping the push/sync sweep, is the one part adjacent to L1; its push-primitive specifics defer to 1850 D3, while its evidence that the sweep exists motivates L1.) |
+| Post-merge budget revalidation; coordination-comment and summary-surface floors | #1667; #1647 / #1732 (spec-1890/1900 attachment points). |
+| Shallow-clone forensic artifacts | Observation-layer cross-cutting item (#1577); #1575 resolved. |
+| A distributed lock, mutex, or lock service over the workspace or claim | **Non-goal** — see below. |
+
+## Success Criteria
+
+All five are checkable at implementation time, without waiting on a future
+session-accrual window. The longitudinal zero-collision result is stated
+separately as a post-deployment validation target below.
+
+| # | Criterion | Verified by |
+|---|---|---|
+| S1 | Every commit produced in the shared checkout contains only the committing activation's own artifacts — no path a concurrent activation authored. | An audit enumerates the closed set of commit paths (every skill or tool that commits inside the shared checkout) and confirms each stages an explicit own-artifact path list rather than a whole-tree sweep; repeatable as a check. |
+| S2 | The facilitated-session protocol mandates that a wiki-touching ask is routed only after the prior same-surface ask returns its Answer or explicitly releases. | The facilitator protocol document states the rule as a requirement — the controllable artifact and the pass/fail; a session transcript is illustrative, not the gate. |
+| S3 | The facilitated-ask format requires an edit-intent field naming the surface and the own-artifact paths the receiver will stage. | The ask-format definition mandates the field — the controllable artifact and the pass/fail; a routed ask is illustrative. |
+| S4 | A deployed facilitated session carries both levers and exercises them: the serialization rule is active and at least one ask shows edit-intent driving scoped staging. | A structural check on one session: protocol active, ask exercised — verifiable at implementation, independent of any accrual window. |
+| S5 | The fix introduces no lock, mutex, lease, or lock service over the workspace or the claim handshake. | The design and implementation contain no such component; the non-goal stands as a review gate. |
+
+**Post-deployment validation target (not an acceptance gate):** across ≥5
+facilitated sessions with both levers applied, new committed-loss occurrences in
+the #1564 facilitated-session sub-family are zero (the parallel-collision ledger
+over the window). This measures the **committed-loss sub-shape only**; Exp
+#1565's broader predicate P1 ("0 shared-workspace collisions of any sub-shape")
+is unchanged and owned by #1565 — this spec does not narrow it. The target is
+the standing meter for whether the two levers held in the field; it does not
+gate spec approval or merge.
+
+## Non-Goals
+
+- **No distributed lock, mutex, or lock service.** #1539 established that the
+  claim handshake is advisory, not a single-writer mutex, and that a real lock's
+  dominant failure mode is a lock held by a dead activation with no lease — a
+  failure the family does not have today. Per-activation distinguishers (#1539)
+  and the two levers here remove collisions without that failure mode. Any
+  design that reintroduces mutual-exclusion-by-lock is out of scope and fails
+  S5.
+- **No allocation-contract change.** This spec does not alter how identifiers
+  are minted; that is the 1840/1850 adjudication.
+
+## Relationship to in-flight siblings
+
+- **1840 / 1850 (allocation identity).** Disjoint. Those specs decide where
+  identity is minted; this one decides how commit paths stage and how the
+  facilitator orders asks. Neither lever here depends on their outcome.
+- **1850 D3 (push primitive).** Adjacent at one seam: L1 governs staging breadth
+  at every commit path, while 1850 D3 governs the `fit-wiki` push primitive's
+  landing. L1 is upstream — it scopes what enters a commit; D3 governs how a
+  scoped commit lands. Where they meet, the primitive's landing behavior is
+  1850 D3's; L1 adds only the staging-breadth contract. They compose; they do
+  not contest.
+- **1750 / 1780 (landing honesty).** Out of scope; L1 reduces the surface those
+  specs harden by ensuring a commit carries only its author's artifacts in the
+  first place.
+
+This spec does not pre-empt the 6/24 Exp #1565 read or the 7/02 RFC #873
+verdict; it gives both a proposed structure to evaluate instead of an unbounded
+repair economy. L2 is **protocol-side** (the facilitator's routing order),
+distinct from RFC #873's **gate-side** routing-time collision check; the two
+compose, and L2 does not decide the RFC.


### PR DESCRIPTION
## What

Implements spec 2010 — the two levers that prevent shared-workspace committed loss (a teammate's in-flight edit shipped under the wrong author) **without a lock**. This branch carries the full lifecycle: `spec(2010)` + `design(2010)` (pattern-synthesis PR #1736) → `plan(2010)` → this implementation. Refs #1564.

## L1 — path-scoped staging (S1)

A new deny-by-default coaligned invariant, `shared-workspace-staging`, flags every caller of the GitClient whole-tree `commitAll` sweep in non-test commit-path JS source. `commitPaths` (the scoped path) is compliant.

- Keyed on the `commitAll` callee via the existing AST framework (`subprocess-in-tests` template). Scoped to `.js`/`.mjs` under `libraries`/`products`/`services`, excluding test files, the `commitAll` definition (`git-client.js`), and the libmock mock.
- The sole caller on the tree is the `fit-wiki` push/sync sweep (`libwiki/src/wiki-sync.js`), allow-listed as the tracked follow-up whose scoping coordinates with the wiki push-primitive landing design (its shell twin shares the exemption). Implementing that scoping is out of scope here — it has a dual dependency on landing-design work not yet on main.
- `--seed` returns exactly `["libraries/libwiki/src/wiki-sync.js"]`; emptying the allowlist fires the rule on that file (deny-by-default proven). Completeness boundary (raw-argv sweeps) documented inline for future maintainers.

## L2 — facilitator serialization (S2/S3/S6)

`kata-session/references/dispatch-discipline.md` gains a **Shared-workspace commit discipline** section:

- **Edit-intent** field with two hard-split classes: `staged_paths` (the receiver commits these by explicit path) and `output_surfaces` (the facilitator declares and orders on these; no one stages them) — D5/D8.
- **Same-surface serialization** keyed on the specific surface, released on `Answer`/release — D4.
- **Single-owner routing** with a structural classifier (multi-owner iff ≥2 named acting lanes; **ambiguous defaults to single-owner**) — D6/D7.
- The **no lock/lease/mutex** constraint — S5.

`SKILL.md` wires the facilitator DO-CONFIRM checklist and the Q-loop reference, and `dispatch-discipline.md` carries a generic worked example ask (S4). All text is generic (no repo packages/issue numbers) and passes the skill-genericity invariant.

## Verification

`bunx coaligned invariants` passes (including `shared-workspace-staging`, `skill-genericity`, and `temporal`). Five-reviewer kata-implement panel: **0 blocker / 0 high / 0 medium**; the one acted-on Low added the inline completeness-boundary comment.

All six success criteria met: S1 (lint green, one allowlisted caller), S2 (serialization rule), S3 (edit-intent two classes), S4 (checklist + worked example), S5 (no lock primitive), S6 (classifier + conservative default).

Refs #1564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Staff Engineer 🛠️

---
_Generated by [Claude Code](https://claude.ai/code/session_016Arze7DHR26TqcrvEwdi8t)_