### PR TITLE
chore(libcoaligned): size kata-release-merge L5 budget for consolidated merge-gate rules (#1758)

### DIFF
--- a/libraries/libcoaligned/src/instructions.js
+++ b/libraries/libcoaligned/src/instructions.js
@@ -184,7 +184,24 @@ async function buildLayers(root, fs) {
         name: "skill procedure",
         maxLines: 192,
         maxWords: 1280,
-        files: skillDirs.map((d) => `${d}/SKILL.md`),
+        files: skillDirs
+          .map((d) => `${d}/SKILL.md`)
+          .filter((p) => !p.endsWith("/kata-release-merge/SKILL.md")),
+      },
+      {
+        id: "L5",
+        name: "kata-release-merge skill procedure",
+        // Larger than the L5 default to absorb four consolidated merge-gate
+        // rule sets that govern adjacent corners of one gate: phase-PR review
+        // transfer (pin-based head coverage), post-panel coverage (folded into
+        // the pin mechanism rather than duplicated), the spec-less
+        // experiment-PR approval path, and the block-comment re-ping cadence.
+        // Sized to the consolidated content, not open-ended.
+        maxLines: 320,
+        maxWords: 2304,
+        files: skillDirs
+          .map((d) => `${d}/SKILL.md`)
+          .filter((p) => p.endsWith("/kata-release-merge/SKILL.md")),
       },
       {
         id: "L6",

--- a/libraries/libcoaligned/test/instructions.test.js
+++ b/libraries/libcoaligned/test/instructions.test.js
@@ -81,6 +81,48 @@ describe("checkInstructions", () => {
     assert.match(f.message, /agent reference/);
   });
 
+  test("admits kata-release-merge SKILL.md above the default L5 cap", async () => {
+    // 250 lines exceeds the 192-line default skill cap but stays under the
+    // kata-release-merge override (320) — proves the per-skill budget applies.
+    const oversize = "line\n".repeat(250);
+    const findings = await checkInstructions({
+      root: ROOT,
+      runtime: runtimeWith({
+        [`${ROOT}/.claude/skills/kata-release-merge/SKILL.md`]: oversize,
+      }),
+    });
+    const f = findings.find(
+      (x) =>
+        x.id === "instructions.line-budget" &&
+        x.path.endsWith("kata-release-merge/SKILL.md"),
+    );
+    assert.equal(
+      f,
+      undefined,
+      `expected no line-budget finding under the override, got: ${JSON.stringify(findings)}`,
+    );
+  });
+
+  test("flags kata-release-merge SKILL.md above its override cap", async () => {
+    const oversize = "line\n".repeat(330);
+    const findings = await checkInstructions({
+      root: ROOT,
+      runtime: runtimeWith({
+        [`${ROOT}/.claude/skills/kata-release-merge/SKILL.md`]: oversize,
+      }),
+    });
+    const f = findings.find(
+      (x) =>
+        x.id === "instructions.line-budget" &&
+        x.path.endsWith("kata-release-merge/SKILL.md"),
+    );
+    assert.ok(
+      f,
+      `expected a line-budget finding above the override, got: ${JSON.stringify(findings)}`,
+    );
+    assert.match(f.message, /kata-release-merge skill procedure/);
+  });
+
   test("flags a checklist that exceeds 9 items", async () => {
     const items = Array.from({ length: 12 }, (_, i) => `- [ ] item ${i + 1}.`);
     const skill = [


### PR DESCRIPTION
## Why

`kata-release-merge/SKILL.md` sits at the L5 instruction cap (192 lines / 1189
words). Four approved Cluster F specs under master plan #1758 each add
governance to that one merge gate and breach the cap:

- **1790** / #1603 — fail-closed review transfer across force-pushes (pin-based
  head coverage)
- **1810** / #1641 — interim post-panel coverage (consolidated: its gate-side
  half folds into the existing spec-1635 sentence + 1790's pin mechanism, so it
  adds **no** kata-release-merge lines)
- **1830** / #1653 — merge-gate approval path for spec-less experiment PRs
- **1440** / #1368 — block-comment re-ping cadence

## What

Peel `kata-release-merge/SKILL.md` out of the default L5 glob into its own
named L5 entry with a budget sized to the consolidated content
(**320 lines / 2304 words**), mirroring the existing `JTBD.md` per-file
exception in the same file. Measured consolidated union of all four specs:
**316 lines / 2288 words**. Sized to that content, not open-ended.

Two tests lock the override: content above the default cap but under the
override passes; content above the override fails.

## Sequencing

This is the keystone the four Cluster F PRs rebase onto during the Merge
phase. Merge this first; the four then pick up the override on rebase and
their `instructions` checks go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)