### PR TITLE
design(2070): a product-vs-internal work axis that biases routing toward product

### DIFF
--- a/specs/2070-product-vs-internal-work-axis/design-a.md
+++ b/specs/2070-product-vs-internal-work-axis/design-a.md
@@ -25,7 +25,7 @@ graph TD
     M -->|tie-break + Decision block| W["Work selected"]
     W -->|direct-fix author labels| PR
     PR -->|label present?| G["kata-release-merge<br/>gate check"]
-    G -->|merged + labeled| C["New fit-wiki mix emitter →<br/>wiki/metrics/product-mix/{YYYY}.csv"]
+    G -->|merged + labeled| C["fit-wiki mix emitter →<br/>wiki/metrics/product-mix/{YYYY}.csv"]
     C -->|existing xmr marker| SB["Storyboard product_share<br/>(product-manager section)"]
 ```
 
@@ -43,9 +43,9 @@ mechanical-vs-structural fork.
 | **Spec authoring** — `kata-spec`                     | A required stated product-vs-internal classification in `spec.md`; the spec PR carries the matching label per the rubric.                                                                                                                                                                                                                                            | `spec.md` classification field; PR label.                                                                    |
 | **Issue triage** — `kata-product-issue`              | Triage assigns each issue's value from the shared rubric; the resulting spec or fix carries the matching label.                                                                                                                                                                                                                                                      | Issue/PR label, derived from the rubric.                                                                     |
 | **Classification label** — `product` / `internal`    | A durable per-item repository label, created once and applied at PR open by the agent authoring the work — spec PR, issue-sourced fix, and direct fix alike.                                                                                                                                                                                                         | The aggregation surface for the metric.                                                                      |
-| **Merge-gate check** — `kata-release-merge`          | Verifies the classification label is present before merge (the gate already classifies PR type and reads PR labels), so no PR enters `main` unlabeled.                                                                                                                                                                                                               | Blocks merge on a missing label; makes the merged-PR population complete.                                    |
-| **Mix emitter** — new `fit-wiki` subcommand          | Counts the period's merged PRs by classification label and appends one standard metric row (`date,metric,value,unit,run,note,event_type`) for `product_share`. Deterministic, not authored by an agent; invoked in the product-manager scheduled run.                                                                                                                | Reads merged-PR labels via `gh`; writes `wiki/metrics/product-mix/{YYYY}.csv`.                               |
-| **Storyboard metric** — storyboard file              | A `#### product_share` block under the existing `### product-manager` section, carrying an `xmr:product_share` marker over the product-mix CSV.                                                                                                                                                                                                                      | Rendered by the existing `fit-wiki refresh` xmr path via `fit-xmr`; never hand-edited.                       |
+| **Merge-gate check** — `kata-release-merge`          | Verifies the classification label is present before merge (the gate already classifies PR type and reads PR labels), so no PR enters `main` unlabeled. This is the design's mechanism for the spec's "computed from recorded data, not asserted" completeness criterion.                                                                                             | Blocks merge on a missing label; makes the merged-PR population complete.                                    |
+| **Mix emitter** — new `fit-wiki` subcommand          | Counts the period's merged PRs by classification label and appends a standard metric row for `product_share`. Deterministic, not authored by an agent; invoked in the product-manager scheduled run.                                                                                                                                                                 | Reads merged-PR labels via `gh`; writes `wiki/metrics/product-mix/{YYYY}.csv`.                               |
+| **Storyboard metric** — storyboard file              | A `#### product_share` block under the existing `### product-manager` section, carrying an `xmr:product_share:wiki/metrics/product-mix/{YYYY}.csv` marker.                                                                                                                                                                                                           | Rendered by the existing `fit-wiki refresh` xmr path via `fit-xmr`; never hand-edited.                       |
 
 ## Key Decisions
 
@@ -69,20 +69,19 @@ The ratio is never typed into the storyboard. The emitter computes
 `product_share` as product-labeled merged PRs over all merged PRs in the period,
 and appends it as one time-series row; re-running it over the same merged PRs
 yields the same value. The series begins at the first period after the gate
-check lands — earlier PRs are out of scope and never enter the denominator.
-`fit-xmr` charts the series, so a sustained drift fires a signal the team
-reviews.
+check lands; earlier PRs never enter the denominator, per the spec's
+no-retroactive-reclassification exclusion. `fit-xmr` charts the series, so a
+sustained drift fires a signal the team reviews.
 
 ## Routing bias
 
-The bias is a tie-break inside the existing strictly-ordered levels (an owned
-priority still preempts everything below it). Two details the spec requires live
-here. The exception: internal work that lifts a constraint currently blocking
-product delivery keeps its place over a tied product candidate, because it buys
-product throughput. The record: whichever case applies, the agent names the
-chosen axis value in its weekly-log `### Decision` entry, and when it picks
-internal over a tied product candidate it names the constraint that work lifts —
-that entry is the verification surface for the spec's sample-run criterion.
+Two details the spec requires live here, beyond the placement decided above. The
+exception: internal work that lifts a constraint currently blocking product
+delivery keeps its place over a tied product candidate, because it buys product
+throughput. The record: whichever case applies, the agent names the chosen axis
+value in its weekly-log `### Decision` entry, and when it picks internal over a
+tied product candidate it names the constraint that work lifts — that entry is
+the verification surface for the spec's sample-run criterion.
 
 ## Out of scope
 

--- a/specs/2070-product-vs-internal-work-axis/design-a.md
+++ b/specs/2070-product-vs-internal-work-axis/design-a.md
@@ -24,65 +24,62 @@ graph TD
     M -->|tie-break + Decision block| W["Work selected"]
     W --> PR
 
-    PR -->|gh pr list --state merged --label| E["New fit-wiki<br/>mix emitter"]
+    PR -->|merged PRs by label| E["New fit-wiki<br/>mix emitter"]
     E -->|append row| C["wiki/metrics/product-mix/{YYYY}.csv"]
     C -->|existing xmr marker| SB["Storyboard<br/>product_share series"]
 ```
 
 The label on the merged PR is the single durable carrier of completed-work
-classification: every completed item is a merged PR, so one label per PR spans
-both branches of the existing mechanical-vs-structural fork.
+classification. Because every completed item is a merged PR, one label per PR
+covers the whole population, across both branches of the existing
+mechanical-vs-structural fork.
 
 ## Components
 
-| Component                                            | What it gains                                                                                                                                                                                        | Interface                                                                                                                                                          |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Rubric** — `work-definition.md`                    | A new `### Product-aligned vs internal` section: the definition of each value, a decision test for sorting a finding, and a note that this axis is independent of the mechanical-vs-structural fork. | Cited by the two skills and the routing reference via fully-qualified URL; the only home for the definition.                                                       |
-| **Routing** — `memory-protocol.md` § On-Boot Routing | An intra-level product-priority rule, its constraint-lifting exception, and an instruction to record the case in `### Decision`.                                                                     | Operates within an existing routing level's tied-candidate set; writes the `### Decision` block.                                                                   |
-| **Spec authoring** — `kata-spec`                     | A required stated product-vs-internal classification in `spec.md`, plus the matching label on the spec PR.                                                                                           | `spec.md` classification field; PR label.                                                                                                                          |
-| **Issue triage** — `kata-product-issue`              | Triage assigns each issue's product-vs-internal value from the shared rubric; the resulting work (spec or fix) carries the matching label.                                                           | Issue/PR label, derived from the rubric, not a private definition.                                                                                                 |
-| **Classification label** — `product` / `internal`    | A durable per-item repository label, created once and applied to every completed work item, spec PR and fix PR alike.                                                                                | The aggregation surface for the metric.                                                                                                                            |
-| **Mix emitter** — new `fit-wiki` subcommand          | Queries the period's merged PRs grouped by the classification label and appends one `product_share` row to a dedicated metric CSV.                                                                   | `gh pr list --state merged --label …`; writes `wiki/metrics/product-mix/{YYYY}.csv`. Run in the workflow's deterministic pre-push step, beside `fit-wiki refresh`. |
-| **Storyboard metric** — storyboard file              | A `#### product_share` block under a team-level headline, carrying an `xmr:product_share` marker over the product-mix CSV.                                                                           | Rendered by the existing `fit-wiki refresh` xmr path via `fit-xmr`; never hand-edited.                                                                             |
+| Component                                            | What it gains                                                                                                                                                                                                                                                                                 | Interface                                                                                                    |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Rubric** — `work-definition.md`                    | A new `### Product-aligned vs internal` section: the definition of each value, a decision test for sorting a finding, a note that this axis is independent of the mechanical-vs-structural fork, and the requirement to apply the matching label to the PR that delivers any classified work. | Cited by the two skills and the routing reference via fully-qualified URL; the only home for the definition. |
+| **Routing** — `memory-protocol.md` § On-Boot Routing | An intra-level product-priority rule, its constraint-lifting exception, and an instruction to record the case in `### Decision`.                                                                                                                                                              | Operates within an existing routing level's tied-candidate set; writes the `### Decision` block.             |
+| **Spec authoring** — `kata-spec`                     | A required stated product-vs-internal classification in `spec.md`; the spec PR carries the matching label per the rubric.                                                                                                                                                                     | `spec.md` classification field; PR label.                                                                    |
+| **Issue triage** — `kata-product-issue`              | Triage assigns each issue's value from the shared rubric; the resulting spec or fix carries the matching label.                                                                                                                                                                               | Issue/PR label, derived from the rubric, not a private definition.                                           |
+| **Classification label** — `product` / `internal`    | A durable per-item repository label, created once and applied to every completed work item — spec PR, issue-sourced fix, and direct fix alike — at PR open per the rubric.                                                                                                                    | The aggregation surface for the metric.                                                                      |
+| **Mix emitter** — new `fit-wiki` subcommand          | Queries the period's merged PRs grouped by the classification label and appends one standard metric row (`date,metric,value,unit,run,note,event_type`) for `product_share` to a dedicated CSV. Invoked deterministically by the team's scheduled workflow, not authored by an agent.          | Reads merged-PR labels via `gh`; writes `wiki/metrics/product-mix/{YYYY}.csv`.                               |
+| **Storyboard metric** — storyboard file              | A `#### product_share` block under the improvement-coach storyboard section, carrying an `xmr:product_share` marker over the product-mix CSV; seeded like any metric block.                                                                                                                   | Rendered by the existing `fit-wiki refresh` xmr path via `fit-xmr`; never hand-edited.                       |
 
 ## Key Decisions
 
-| Decision                                 | Choice                                                                                                                                   | Rejected alternative                                                                                                                                                                                                                                                                                                     |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Carrier of completed-work classification | A repository PR label (`product` / `internal`) on every merged work item.                                                                | A column in `wiki/STATUS.md` — STATUS tracks specs only, so it cannot represent fix PRs, which are part of the completed-work population.                                                                                                                                                                                |
-| The metric emitter                       | A new deterministic `fit-wiki` subcommand that derives `product_share` from merged-PR labels, run in the pre-push step beside `refresh`. | (a) An agent hand-appends the row like legacy metrics — non-deterministic, and the single-metric-per-skill storyboard plus the facilitator's no-write role leave no natural writer; (b) extending `refresh` itself — its contract is render-only, and folding a data-derivation write into the renderer couples the two. |
-| Where the metric series lives            | Its own `wiki/metrics/product-mix/{YYYY}.csv`, rendered under a team-level storyboard headline.                                          | Adding `product_share` to an existing skill's CSV — violates the ratified single-metric-per-skill protocol.                                                                                                                                                                                                              |
-| Where the axis is defined                | One `### Product-aligned vs internal` section in `work-definition.md`, cited by every consumer.                                          | A definition inside each skill — the success criteria require triage to use the _shared_ rubric, and duplicate definitions drift.                                                                                                                                                                                        |
-| Routing-bias placement                   | A tie-break _within_ an existing routing level, applied only when candidates are otherwise equal.                                        | A new fifth routing level — that would reorder the strictly-ordered priority and let product work preempt an owned internal priority, which the spec forbids.                                                                                                                                                            |
+| Decision                                 | Choice                                                                                                   | Rejected alternative                                                                                                                                                                                                                                                                               |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Carrier of completed-work classification | A repository PR label (`product` / `internal`) on every merged work item.                                | A column in `wiki/STATUS.md` — STATUS tracks specs only, so it cannot represent fix PRs, which are part of the completed-work population.                                                                                                                                                          |
+| The metric emitter                       | A new deterministic `fit-wiki` subcommand that derives `product_share` from merged-PR labels.            | (a) An agent hand-appends the row like a recorded metric — the value is a cross-skill aggregate no single skill owns, and a human-entered ratio is not reproducible; (b) extending `refresh` — its contract is render-only, and folding a data-derivation write into the renderer couples the two. |
+| Where the metric series lives            | Its own `wiki/metrics/product-mix/{YYYY}.csv`, stewarded under the improvement-coach storyboard section. | Folding `product_share` into an existing skill's CSV — the series is a team aggregate, not a skill's per-run output; dedicated non-skill metric directories already exist for cross-cutting series.                                                                                                |
+| Where the axis is defined                | One `### Product-aligned vs internal` section in `work-definition.md`, cited by every consumer.          | A definition inside each skill — the success criteria require triage to use the _shared_ rubric, and duplicate definitions drift.                                                                                                                                                                  |
+| Routing-bias placement                   | A tie-break _within_ an existing routing level, applied only when candidates are otherwise equal.        | A new fifth routing level — that would reorder the strictly-ordered priority and let product work preempt an owned internal priority, which the spec forbids.                                                                                                                                      |
 
 ## Classification carrier and reproducibility
 
 The `spec.md` classification field is the authored statement of intent a reader
 sees without leaving the spec; the PR label is the machine-readable record the
 metric reads. The two are set together at authoring time so they cannot diverge.
-A fix PR that has no spec still carries the label, so the label — not the spec
-field — is what the emitter aggregates.
+A fix PR has no spec, so the label — required by the rubric on any PR that
+delivers classified work — is the uniform carrier the emitter aggregates.
 
-The ratio is reproducible because no human writes it into the storyboard. The
-mix emitter recomputes the period's `product_share` from the labels on merged
-PRs and appends it as a normal time-series row, the same class of GitHub-state
-query `refresh` already runs for the obstacle and experiment lists, except it
-writes a CSV row rather than rendering a list. `fit-xmr` then charts the series,
-so a sustained drift in the mix fires a signal the team reviews. Re-running the
-emitter over the same merged PRs yields the same row.
+The ratio value is never typed into the storyboard by hand. The mix emitter
+recomputes `product_share` from the labels on the period's merged PRs and
+appends it as a normal time-series row; re-running it over the same merged PRs
+yields the same value. `fit-xmr` then charts the series, so a sustained drift in
+the mix fires a signal the team reviews. The classification labels upstream are
+applied by agents per the rubric; only the aggregation is mechanical.
 
 ## Routing bias
 
-On-Boot Routing keeps its four strictly-ordered levels unchanged. The new rule
-fires only when two or more candidates sit at the **same** level after that
-ordering — an owned priority still preempts everything below it, and an active
-claim still means the work is in flight. Among tied candidates, product-aligned
-outranks internal. The single exception is theory-of-constraints discipline:
-internal work that lifts a constraint currently blocking product delivery keeps
-its place, because it buys product throughput. Whichever case applies, the agent
-names the chosen axis value in its `### Decision` block, and when it picks
-internal over a product candidate it names the constraint that internal work
-lifts.
+Beyond placing the bias inside the existing levels, two details the spec
+requires live here. The exception: internal work that lifts a constraint
+currently blocking product delivery keeps its place over a tied product
+candidate, because it buys product throughput. The record: whichever case
+applies, the agent names the chosen axis value in its `### Decision` block, and
+when it picks internal over a tied product candidate it names the constraint
+that internal work lifts.
 
 ## Out of scope
 

--- a/specs/2070-product-vs-internal-work-axis/design-a.md
+++ b/specs/2070-product-vs-internal-work-axis/design-a.md
@@ -1,0 +1,94 @@
+# Design 2070 — A product-vs-internal work axis that biases agent routing toward product
+
+Spec [2070](spec.md) introduces **product-aligned vs internal** as a second,
+independent classification axis and applies it in two places: the routing path
+agents use to select work, and the storyboard the team studies. This design
+names the components that carry the axis, where the classification is recorded
+so the metric is reproducible, and how routing consumes it.
+
+## Architecture
+
+The axis is defined once and consumed in three independent flows: spec/issue
+authoring records it, routing reads it to break ties, and a deterministic
+emitter aggregates the recorded labels into a storyboard metric.
+
+```mermaid
+graph TD
+    R["work-definition.md<br/>§ Product vs internal rubric"]
+    R -.cited by.-> S["kata-spec"]
+    R -.cited by.-> T["kata-product-issue"]
+    R -.cited by.-> M["memory-protocol.md<br/>§ On-Boot Routing"]
+
+    S -->|Classification field + label| PR["Merged PR<br/>(product|internal label)"]
+    T -->|label on resulting work| PR
+    M -->|tie-break + Decision block| W["Work selected"]
+    W --> PR
+
+    PR -->|labels in period| E["fit-wiki refresh<br/>ratio emitter"]
+    E -->|append row| C["wiki/metrics/improvement-coach/{YYYY}.csv"]
+    C -->|xmr marker| SB["Storyboard<br/>product_share series"]
+```
+
+The label on the merged PR is the single durable carrier of completed-work
+classification. Everything downstream of merge reads it; nothing re-derives the
+class by hand.
+
+## Components
+
+| Component                                            | What it gains                                                                                                                                                                                        | Interface                                                                                                                           |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Rubric** — `work-definition.md`                    | A new `### Product-aligned vs internal` section: the definition of each value, a decision test for sorting a finding, and a note that this axis is independent of the mechanical-vs-structural fork. | Cited by the two skills and the routing reference via fully-qualified URL; it is the only home for the definition.                  |
+| **Routing** — `memory-protocol.md` § On-Boot Routing | An intra-level product-priority rule, its constraint-lifting exception, and an instruction to record the case in `### Decision`.                                                                     | Reads the `boot` digest fields already used; writes the `### Decision` block.                                                       |
+| **Spec authoring** — `kata-spec`                     | A required `**Classification:** product-aligned \| internal` line in `spec.md`, and application of the matching PR label.                                                                            | `spec.md` field (human-readable statement); PR label (machine carrier).                                                             |
+| **Issue triage** — `kata-product-issue`              | Triage records the product-vs-internal value for each issue using the shared rubric, and the resulting work (spec or fix) carries the matching label.                                                | Issue/PR label, set from the rubric, not a private definition.                                                                      |
+| **Classification label** — `product` / `internal`    | A durable per-item GitHub label applied to every completed work item, spec PR and fix PR alike.                                                                                                      | The aggregation surface for the metric.                                                                                             |
+| **Ratio emitter** — `fit-wiki refresh`               | Counts merged PRs in the storyboard period grouped by the classification label and appends one `product_share` row to the coach metric CSV.                                                          | Reads GitHub PR state (refresh already reads issue state for Active/Concluded); writes `wiki/metrics/improvement-coach/{YYYY}.csv`. |
+| **Storyboard metric** — `storyboard-{YYYY}-MNN.md`   | A `#### product_share` block under the coach section with an `<!-- xmr:product_share:wiki/metrics/improvement-coach/{YYYY}.csv -->` marker.                                                          | Rendered by `fit-wiki refresh` via `fit-xmr`; never hand-edited.                                                                    |
+
+## Key Decisions
+
+| Decision                                 | Choice                                                                                            | Rejected alternative                                                                                                                                          |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Carrier of completed-work classification | A GitHub PR label (`product` / `internal`) on every merged work item.                             | A column in `wiki/STATUS.md` — STATUS tracks specs only, so it cannot represent fix PRs, which are part of the completed-work population.                     |
+| Where the metric is computed             | A deterministic aggregation in `fit-wiki refresh` over the period's merged-PR labels.             | Per-skill metric rows written at run time — fragmented across skills and blind to direct fix PRs that run no skill, so the ratio would be incomplete.         |
+| Where the axis is defined                | One `### Product-aligned vs internal` section in `work-definition.md`, cited by every consumer.   | A definition inside each skill — the spec's success criteria require triage to use the _shared_ rubric, and duplicate definitions drift.                      |
+| Routing-bias placement                   | A tie-break _within_ an existing routing level, applied only when candidates are otherwise equal. | A new fifth routing level — that would reorder the strictly-ordered priority and let product work preempt an owned internal priority, which the spec forbids. |
+| Spec's stated classification             | An inline `Classification` field in `spec.md` **and** a mirrored PR label.                        | Label only — a success criterion requires the spec itself to state its value, so a reader of `spec.md` sees the classification without leaving the file.      |
+
+## Classification carrier and reproducibility
+
+Completed work is exactly the set of merged PRs. Recording the class as a PR
+label gives one uniform surface that spans both branches of the existing
+mechanical-vs-structural fork: a `spec(NNN)` PR and a `fix` PR each carry one
+label. The `spec.md` `Classification` field is the authored statement of intent;
+the label is the durable record the metric reads. The two are set together at
+authoring time so they cannot diverge.
+
+The ratio is reproducible because it is never written by a human into the
+storyboard. `fit-wiki refresh` recomputes it each run from the labels on PRs
+merged in the period — the same way it already recomputes the Active/Concluded
+obstacle and experiment lists from live GitHub state — and appends the period's
+`product_share` value as a normal time-series row. `fit-xmr` then renders the
+series, so a sustained drift in the mix fires an XmR signal the team reviews.
+
+## Routing bias
+
+On-Boot Routing keeps its four strictly-ordered levels unchanged. The new rule
+fires only when two or more candidates sit at the **same** level after that
+ordering — an owned priority still preempts everything below it, and an active
+claim still means the work is in flight. Among tied candidates, product-aligned
+outranks internal. The single exception is theory-of-constraints discipline:
+internal work that lifts a constraint currently blocking product delivery keeps
+its place, because it buys product throughput. Whichever case applies, the agent
+names the chosen axis value in its `### Decision` block, and when it picks
+internal over a product candidate it names the constraint that internal work
+lifts. This makes the success criterion's "sample run shows the recorded value"
+verifiable from the weekly log.
+
+## Out of scope
+
+Carried unchanged from the spec: no weighting of the human approval gate, no
+`kata-interview` cron, no change to the four Study streams or to the
+mechanical-vs-structural fork, and no retroactive reclassification of work
+already merged. The label and metric apply only to work selected and authored
+after this design's plan lands.

--- a/specs/2070-product-vs-internal-work-axis/design-a.md
+++ b/specs/2070-product-vs-internal-work-axis/design-a.md
@@ -10,7 +10,8 @@ so the metric is reproducible, and how routing consumes it.
 
 The axis is defined once and consumed in four flows: spec authoring and issue
 triage each record it, routing reads it to break ties, and a new deterministic
-emitter derives the storyboard metric from the recorded labels.
+emitter derives the storyboard metric from the recorded labels. A merge-gate
+check keeps the recorded population complete.
 
 ```mermaid
 graph TD
@@ -19,73 +20,75 @@ graph TD
     R -.cited by.-> T["kata-product-issue"]
     R -.cited by.-> M["memory-protocol.md<br/>§ On-Boot Routing"]
 
-    S -->|classification field + label| PR["Merged PR<br/>(product|internal label)"]
+    S -->|classification field + label| PR["Open PR<br/>(product|internal label)"]
     T -->|label on resulting work| PR
     M -->|tie-break + Decision block| W["Work selected"]
-    W --> PR
-
-    PR -->|merged PRs by label| E["New fit-wiki<br/>mix emitter"]
-    E -->|append row| C["wiki/metrics/product-mix/{YYYY}.csv"]
-    C -->|existing xmr marker| SB["Storyboard<br/>product_share series"]
+    W -->|direct-fix author labels| PR
+    PR -->|label present?| G["kata-release-merge<br/>gate check"]
+    G -->|merged + labeled| C["New fit-wiki mix emitter →<br/>wiki/metrics/product-mix/{YYYY}.csv"]
+    C -->|existing xmr marker| SB["Storyboard product_share<br/>(product-manager section)"]
 ```
 
-The label on the merged PR is the single durable carrier of completed-work
+The label on the PR is the single durable carrier of completed-work
 classification. Because every completed item is a merged PR, one label per PR
 covers the whole population, across both branches of the existing
 mechanical-vs-structural fork.
 
 ## Components
 
-| Component                                            | What it gains                                                                                                                                                                                                                                                                                 | Interface                                                                                                    |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Rubric** — `work-definition.md`                    | A new `### Product-aligned vs internal` section: the definition of each value, a decision test for sorting a finding, a note that this axis is independent of the mechanical-vs-structural fork, and the requirement to apply the matching label to the PR that delivers any classified work. | Cited by the two skills and the routing reference via fully-qualified URL; the only home for the definition. |
-| **Routing** — `memory-protocol.md` § On-Boot Routing | An intra-level product-priority rule, its constraint-lifting exception, and an instruction to record the case in `### Decision`.                                                                                                                                                              | Operates within an existing routing level's tied-candidate set; writes the `### Decision` block.             |
-| **Spec authoring** — `kata-spec`                     | A required stated product-vs-internal classification in `spec.md`; the spec PR carries the matching label per the rubric.                                                                                                                                                                     | `spec.md` classification field; PR label.                                                                    |
-| **Issue triage** — `kata-product-issue`              | Triage assigns each issue's value from the shared rubric; the resulting spec or fix carries the matching label.                                                                                                                                                                               | Issue/PR label, derived from the rubric, not a private definition.                                           |
-| **Classification label** — `product` / `internal`    | A durable per-item repository label, created once and applied to every completed work item — spec PR, issue-sourced fix, and direct fix alike — at PR open per the rubric.                                                                                                                    | The aggregation surface for the metric.                                                                      |
-| **Mix emitter** — new `fit-wiki` subcommand          | Queries the period's merged PRs grouped by the classification label and appends one standard metric row (`date,metric,value,unit,run,note,event_type`) for `product_share` to a dedicated CSV. Invoked deterministically by the team's scheduled workflow, not authored by an agent.          | Reads merged-PR labels via `gh`; writes `wiki/metrics/product-mix/{YYYY}.csv`.                               |
-| **Storyboard metric** — storyboard file              | A `#### product_share` block under the improvement-coach storyboard section, carrying an `xmr:product_share` marker over the product-mix CSV; seeded like any metric block.                                                                                                                   | Rendered by the existing `fit-wiki refresh` xmr path via `fit-xmr`; never hand-edited.                       |
+| Component                                            | What it gains                                                                                                                                                                                                                                                                                                                                                        | Interface                                                                                                    |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Rubric** — `work-definition.md`                    | A new `### Product-aligned vs internal` section: each value's definition, a decision test for sorting a finding, a note that the axis is independent of the mechanical-vs-structural fork, and the requirement that the agent opening any work PR applies the matching label. The existing issue-intake "product-aligned" line links here rather than redefining it. | Cited by the two skills and the routing reference via fully-qualified URL; the only home for the definition. |
+| **Routing** — `memory-protocol.md` § On-Boot Routing | A product-priority tie-break rule (detailed in § Routing bias below).                                                                                                                                                                                                                                                                                                | Operates within an existing routing level's tied-candidate set; writes the `### Decision` block.             |
+| **Spec authoring** — `kata-spec`                     | A required stated product-vs-internal classification in `spec.md`; the spec PR carries the matching label per the rubric.                                                                                                                                                                                                                                            | `spec.md` classification field; PR label.                                                                    |
+| **Issue triage** — `kata-product-issue`              | Triage assigns each issue's value from the shared rubric; the resulting spec or fix carries the matching label.                                                                                                                                                                                                                                                      | Issue/PR label, derived from the rubric.                                                                     |
+| **Classification label** — `product` / `internal`    | A durable per-item repository label, created once and applied at PR open by the agent authoring the work — spec PR, issue-sourced fix, and direct fix alike.                                                                                                                                                                                                         | The aggregation surface for the metric.                                                                      |
+| **Merge-gate check** — `kata-release-merge`          | Verifies the classification label is present before merge (the gate already classifies PR type and reads PR labels), so no PR enters `main` unlabeled.                                                                                                                                                                                                               | Blocks merge on a missing label; makes the merged-PR population complete.                                    |
+| **Mix emitter** — new `fit-wiki` subcommand          | Counts the period's merged PRs by classification label and appends one standard metric row (`date,metric,value,unit,run,note,event_type`) for `product_share`. Deterministic, not authored by an agent; invoked in the product-manager scheduled run.                                                                                                                | Reads merged-PR labels via `gh`; writes `wiki/metrics/product-mix/{YYYY}.csv`.                               |
+| **Storyboard metric** — storyboard file              | A `#### product_share` block under the existing `### product-manager` section, carrying an `xmr:product_share` marker over the product-mix CSV.                                                                                                                                                                                                                      | Rendered by the existing `fit-wiki refresh` xmr path via `fit-xmr`; never hand-edited.                       |
 
 ## Key Decisions
 
-| Decision                                 | Choice                                                                                                   | Rejected alternative                                                                                                                                                                                                                                                                               |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Carrier of completed-work classification | A repository PR label (`product` / `internal`) on every merged work item.                                | A column in `wiki/STATUS.md` — STATUS tracks specs only, so it cannot represent fix PRs, which are part of the completed-work population.                                                                                                                                                          |
-| The metric emitter                       | A new deterministic `fit-wiki` subcommand that derives `product_share` from merged-PR labels.            | (a) An agent hand-appends the row like a recorded metric — the value is a cross-skill aggregate no single skill owns, and a human-entered ratio is not reproducible; (b) extending `refresh` — its contract is render-only, and folding a data-derivation write into the renderer couples the two. |
-| Where the metric series lives            | Its own `wiki/metrics/product-mix/{YYYY}.csv`, stewarded under the improvement-coach storyboard section. | Folding `product_share` into an existing skill's CSV — the series is a team aggregate, not a skill's per-run output; dedicated non-skill metric directories already exist for cross-cutting series.                                                                                                |
-| Where the axis is defined                | One `### Product-aligned vs internal` section in `work-definition.md`, cited by every consumer.          | A definition inside each skill — the success criteria require triage to use the _shared_ rubric, and duplicate definitions drift.                                                                                                                                                                  |
-| Routing-bias placement                   | A tie-break _within_ an existing routing level, applied only when candidates are otherwise equal.        | A new fifth routing level — that would reorder the strictly-ordered priority and let product work preempt an owned internal priority, which the spec forbids.                                                                                                                                      |
+| Decision                                 | Choice                                                                                                                                          | Rejected alternative                                                                                                                                                                                    |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Carrier of completed-work classification | A repository PR label (`product` / `internal`) on every merged work item.                                                                       | A column in `wiki/STATUS.md` — STATUS tracks specs only, so it cannot represent fix PRs, which are part of the completed-work population.                                                               |
+| Keeping the population complete          | The merge gate refuses an unlabeled PR, so the denominator is every merged PR in the period.                                                    | Trusting author discipline alone — a missed label silently drops a PR from the denominator and biases `product_share`.                                                                                  |
+| The metric emitter                       | A new deterministic `fit-wiki` subcommand deriving `product_share` from merged-PR labels.                                                       | (a) An agent hand-appends the row — a human-entered ratio is not reproducible; (b) extending `refresh` — its contract is render-only, and folding a derive-and-write into the renderer couples the two. |
+| Metric owner and home                    | A dedicated `wiki/metrics/product-mix/{YYYY}.csv`, owned by the product-manager and rendered under that agent's storyboard section.             | Folding `product_share` into the product-manager's per-run CSV — it is a team aggregate, not a per-run output; dedicated non-skill metric directories already exist for cross-cutting series.           |
+| Where the axis is defined                | One `### Product-aligned vs internal` section in `work-definition.md`, cited by every consumer and subsuming the existing issue-intake mention. | A definition inside each skill — the success criteria require triage to use the _shared_ rubric, and duplicate definitions drift.                                                                       |
+| Routing-bias placement                   | A tie-break _within_ an existing routing level, applied only when candidates are otherwise equal.                                               | A new fifth routing level — that would reorder the strictly-ordered priority and let product work preempt an owned internal priority, which the spec forbids.                                           |
 
 ## Classification carrier and reproducibility
 
 The `spec.md` classification field is the authored statement of intent a reader
 sees without leaving the spec; the PR label is the machine-readable record the
-metric reads. The two are set together at authoring time so they cannot diverge.
-A fix PR has no spec, so the label — required by the rubric on any PR that
-delivers classified work — is the uniform carrier the emitter aggregates.
+metric reads. A fix PR has no spec, so the label is the uniform carrier the
+emitter aggregates, and the merge gate guarantees it is present.
 
-The ratio value is never typed into the storyboard by hand. The mix emitter
-recomputes `product_share` from the labels on the period's merged PRs and
-appends it as a normal time-series row; re-running it over the same merged PRs
-yields the same value. `fit-xmr` then charts the series, so a sustained drift in
-the mix fires a signal the team reviews. The classification labels upstream are
-applied by agents per the rubric; only the aggregation is mechanical.
+The ratio is never typed into the storyboard. The emitter computes
+`product_share` as product-labeled merged PRs over all merged PRs in the period,
+and appends it as one time-series row; re-running it over the same merged PRs
+yields the same value. The series begins at the first period after the gate
+check lands — earlier PRs are out of scope and never enter the denominator.
+`fit-xmr` charts the series, so a sustained drift fires a signal the team
+reviews.
 
 ## Routing bias
 
-Beyond placing the bias inside the existing levels, two details the spec
-requires live here. The exception: internal work that lifts a constraint
-currently blocking product delivery keeps its place over a tied product
-candidate, because it buys product throughput. The record: whichever case
-applies, the agent names the chosen axis value in its `### Decision` block, and
-when it picks internal over a tied product candidate it names the constraint
-that internal work lifts.
+The bias is a tie-break inside the existing strictly-ordered levels (an owned
+priority still preempts everything below it). Two details the spec requires live
+here. The exception: internal work that lifts a constraint currently blocking
+product delivery keeps its place over a tied product candidate, because it buys
+product throughput. The record: whichever case applies, the agent names the
+chosen axis value in its weekly-log `### Decision` entry, and when it picks
+internal over a tied product candidate it names the constraint that work lifts —
+that entry is the verification surface for the spec's sample-run criterion.
 
 ## Out of scope
 
-The emitter, label, and metric placement are the design choices the spec
-delegated; everything else is carried unchanged from the spec's exclusions: no
-weighting of the human approval gate, no `kata-interview` cron, no change to the
-four Study streams or to the mechanical-vs-structural fork, and no retroactive
-reclassification of work already merged. The label and metric apply only to work
-selected and authored after this design's plan lands.
+The emitter, label, gate check, and metric placement are the design choices the
+spec delegated; everything else is carried unchanged from the spec's exclusions:
+no weighting of the human approval gate, no `kata-interview` cron, no change to
+the four Study streams or to the mechanical-vs-structural fork, and no
+retroactive reclassification of work already merged. The axis applies only to
+work selected and authored after this design's plan lands.

--- a/specs/2070-product-vs-internal-work-axis/design-a.md
+++ b/specs/2070-product-vs-internal-work-axis/design-a.md
@@ -8,9 +8,9 @@ so the metric is reproducible, and how routing consumes it.
 
 ## Architecture
 
-The axis is defined once and consumed in three independent flows: spec/issue
-authoring records it, routing reads it to break ties, and a deterministic
-emitter aggregates the recorded labels into a storyboard metric.
+The axis is defined once and consumed in four flows: spec authoring and issue
+triage each record it, routing reads it to break ties, and a new deterministic
+emitter derives the storyboard metric from the recorded labels.
 
 ```mermaid
 graph TD
@@ -19,57 +19,57 @@ graph TD
     R -.cited by.-> T["kata-product-issue"]
     R -.cited by.-> M["memory-protocol.md<br/>§ On-Boot Routing"]
 
-    S -->|Classification field + label| PR["Merged PR<br/>(product|internal label)"]
+    S -->|classification field + label| PR["Merged PR<br/>(product|internal label)"]
     T -->|label on resulting work| PR
     M -->|tie-break + Decision block| W["Work selected"]
     W --> PR
 
-    PR -->|labels in period| E["fit-wiki refresh<br/>ratio emitter"]
-    E -->|append row| C["wiki/metrics/improvement-coach/{YYYY}.csv"]
-    C -->|xmr marker| SB["Storyboard<br/>product_share series"]
+    PR -->|gh pr list --state merged --label| E["New fit-wiki<br/>mix emitter"]
+    E -->|append row| C["wiki/metrics/product-mix/{YYYY}.csv"]
+    C -->|existing xmr marker| SB["Storyboard<br/>product_share series"]
 ```
 
 The label on the merged PR is the single durable carrier of completed-work
-classification. Everything downstream of merge reads it; nothing re-derives the
-class by hand.
+classification: every completed item is a merged PR, so one label per PR spans
+both branches of the existing mechanical-vs-structural fork.
 
 ## Components
 
-| Component                                            | What it gains                                                                                                                                                                                        | Interface                                                                                                                           |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **Rubric** — `work-definition.md`                    | A new `### Product-aligned vs internal` section: the definition of each value, a decision test for sorting a finding, and a note that this axis is independent of the mechanical-vs-structural fork. | Cited by the two skills and the routing reference via fully-qualified URL; it is the only home for the definition.                  |
-| **Routing** — `memory-protocol.md` § On-Boot Routing | An intra-level product-priority rule, its constraint-lifting exception, and an instruction to record the case in `### Decision`.                                                                     | Reads the `boot` digest fields already used; writes the `### Decision` block.                                                       |
-| **Spec authoring** — `kata-spec`                     | A required `**Classification:** product-aligned \| internal` line in `spec.md`, and application of the matching PR label.                                                                            | `spec.md` field (human-readable statement); PR label (machine carrier).                                                             |
-| **Issue triage** — `kata-product-issue`              | Triage records the product-vs-internal value for each issue using the shared rubric, and the resulting work (spec or fix) carries the matching label.                                                | Issue/PR label, set from the rubric, not a private definition.                                                                      |
-| **Classification label** — `product` / `internal`    | A durable per-item GitHub label applied to every completed work item, spec PR and fix PR alike.                                                                                                      | The aggregation surface for the metric.                                                                                             |
-| **Ratio emitter** — `fit-wiki refresh`               | Counts merged PRs in the storyboard period grouped by the classification label and appends one `product_share` row to the coach metric CSV.                                                          | Reads GitHub PR state (refresh already reads issue state for Active/Concluded); writes `wiki/metrics/improvement-coach/{YYYY}.csv`. |
-| **Storyboard metric** — `storyboard-{YYYY}-MNN.md`   | A `#### product_share` block under the coach section with an `<!-- xmr:product_share:wiki/metrics/improvement-coach/{YYYY}.csv -->` marker.                                                          | Rendered by `fit-wiki refresh` via `fit-xmr`; never hand-edited.                                                                    |
+| Component                                            | What it gains                                                                                                                                                                                        | Interface                                                                                                                                                          |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Rubric** — `work-definition.md`                    | A new `### Product-aligned vs internal` section: the definition of each value, a decision test for sorting a finding, and a note that this axis is independent of the mechanical-vs-structural fork. | Cited by the two skills and the routing reference via fully-qualified URL; the only home for the definition.                                                       |
+| **Routing** — `memory-protocol.md` § On-Boot Routing | An intra-level product-priority rule, its constraint-lifting exception, and an instruction to record the case in `### Decision`.                                                                     | Operates within an existing routing level's tied-candidate set; writes the `### Decision` block.                                                                   |
+| **Spec authoring** — `kata-spec`                     | A required stated product-vs-internal classification in `spec.md`, plus the matching label on the spec PR.                                                                                           | `spec.md` classification field; PR label.                                                                                                                          |
+| **Issue triage** — `kata-product-issue`              | Triage assigns each issue's product-vs-internal value from the shared rubric; the resulting work (spec or fix) carries the matching label.                                                           | Issue/PR label, derived from the rubric, not a private definition.                                                                                                 |
+| **Classification label** — `product` / `internal`    | A durable per-item repository label, created once and applied to every completed work item, spec PR and fix PR alike.                                                                                | The aggregation surface for the metric.                                                                                                                            |
+| **Mix emitter** — new `fit-wiki` subcommand          | Queries the period's merged PRs grouped by the classification label and appends one `product_share` row to a dedicated metric CSV.                                                                   | `gh pr list --state merged --label …`; writes `wiki/metrics/product-mix/{YYYY}.csv`. Run in the workflow's deterministic pre-push step, beside `fit-wiki refresh`. |
+| **Storyboard metric** — storyboard file              | A `#### product_share` block under a team-level headline, carrying an `xmr:product_share` marker over the product-mix CSV.                                                                           | Rendered by the existing `fit-wiki refresh` xmr path via `fit-xmr`; never hand-edited.                                                                             |
 
 ## Key Decisions
 
-| Decision                                 | Choice                                                                                            | Rejected alternative                                                                                                                                          |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Carrier of completed-work classification | A GitHub PR label (`product` / `internal`) on every merged work item.                             | A column in `wiki/STATUS.md` — STATUS tracks specs only, so it cannot represent fix PRs, which are part of the completed-work population.                     |
-| Where the metric is computed             | A deterministic aggregation in `fit-wiki refresh` over the period's merged-PR labels.             | Per-skill metric rows written at run time — fragmented across skills and blind to direct fix PRs that run no skill, so the ratio would be incomplete.         |
-| Where the axis is defined                | One `### Product-aligned vs internal` section in `work-definition.md`, cited by every consumer.   | A definition inside each skill — the spec's success criteria require triage to use the _shared_ rubric, and duplicate definitions drift.                      |
-| Routing-bias placement                   | A tie-break _within_ an existing routing level, applied only when candidates are otherwise equal. | A new fifth routing level — that would reorder the strictly-ordered priority and let product work preempt an owned internal priority, which the spec forbids. |
-| Spec's stated classification             | An inline `Classification` field in `spec.md` **and** a mirrored PR label.                        | Label only — a success criterion requires the spec itself to state its value, so a reader of `spec.md` sees the classification without leaving the file.      |
+| Decision                                 | Choice                                                                                                                                   | Rejected alternative                                                                                                                                                                                                                                                                                                     |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Carrier of completed-work classification | A repository PR label (`product` / `internal`) on every merged work item.                                                                | A column in `wiki/STATUS.md` — STATUS tracks specs only, so it cannot represent fix PRs, which are part of the completed-work population.                                                                                                                                                                                |
+| The metric emitter                       | A new deterministic `fit-wiki` subcommand that derives `product_share` from merged-PR labels, run in the pre-push step beside `refresh`. | (a) An agent hand-appends the row like legacy metrics — non-deterministic, and the single-metric-per-skill storyboard plus the facilitator's no-write role leave no natural writer; (b) extending `refresh` itself — its contract is render-only, and folding a data-derivation write into the renderer couples the two. |
+| Where the metric series lives            | Its own `wiki/metrics/product-mix/{YYYY}.csv`, rendered under a team-level storyboard headline.                                          | Adding `product_share` to an existing skill's CSV — violates the ratified single-metric-per-skill protocol.                                                                                                                                                                                                              |
+| Where the axis is defined                | One `### Product-aligned vs internal` section in `work-definition.md`, cited by every consumer.                                          | A definition inside each skill — the success criteria require triage to use the _shared_ rubric, and duplicate definitions drift.                                                                                                                                                                                        |
+| Routing-bias placement                   | A tie-break _within_ an existing routing level, applied only when candidates are otherwise equal.                                        | A new fifth routing level — that would reorder the strictly-ordered priority and let product work preempt an owned internal priority, which the spec forbids.                                                                                                                                                            |
 
 ## Classification carrier and reproducibility
 
-Completed work is exactly the set of merged PRs. Recording the class as a PR
-label gives one uniform surface that spans both branches of the existing
-mechanical-vs-structural fork: a `spec(NNN)` PR and a `fix` PR each carry one
-label. The `spec.md` `Classification` field is the authored statement of intent;
-the label is the durable record the metric reads. The two are set together at
-authoring time so they cannot diverge.
+The `spec.md` classification field is the authored statement of intent a reader
+sees without leaving the spec; the PR label is the machine-readable record the
+metric reads. The two are set together at authoring time so they cannot diverge.
+A fix PR that has no spec still carries the label, so the label — not the spec
+field — is what the emitter aggregates.
 
-The ratio is reproducible because it is never written by a human into the
-storyboard. `fit-wiki refresh` recomputes it each run from the labels on PRs
-merged in the period — the same way it already recomputes the Active/Concluded
-obstacle and experiment lists from live GitHub state — and appends the period's
-`product_share` value as a normal time-series row. `fit-xmr` then renders the
-series, so a sustained drift in the mix fires an XmR signal the team reviews.
+The ratio is reproducible because no human writes it into the storyboard. The
+mix emitter recomputes the period's `product_share` from the labels on merged
+PRs and appends it as a normal time-series row, the same class of GitHub-state
+query `refresh` already runs for the obstacle and experiment lists, except it
+writes a CSV row rather than rendering a list. `fit-xmr` then charts the series,
+so a sustained drift in the mix fires a signal the team reviews. Re-running the
+emitter over the same merged PRs yields the same row.
 
 ## Routing bias
 
@@ -82,13 +82,13 @@ internal work that lifts a constraint currently blocking product delivery keeps
 its place, because it buys product throughput. Whichever case applies, the agent
 names the chosen axis value in its `### Decision` block, and when it picks
 internal over a product candidate it names the constraint that internal work
-lifts. This makes the success criterion's "sample run shows the recorded value"
-verifiable from the weekly log.
+lifts.
 
 ## Out of scope
 
-Carried unchanged from the spec: no weighting of the human approval gate, no
-`kata-interview` cron, no change to the four Study streams or to the
-mechanical-vs-structural fork, and no retroactive reclassification of work
-already merged. The label and metric apply only to work selected and authored
-after this design's plan lands.
+The emitter, label, and metric placement are the design choices the spec
+delegated; everything else is carried unchanged from the spec's exclusions: no
+weighting of the human approval gate, no `kata-interview` cron, no change to the
+four Study streams or to the mechanical-vs-structural fork, and no retroactive
+reclassification of work already merged. The label and metric apply only to work
+selected and authored after this design's plan lands.


### PR DESCRIPTION
## Design for spec 2070

Architectural design for [spec 2070](https://github.com/forwardimpact/monorepo/blob/main/specs/2070-product-vs-internal-work-axis/spec.md), which introduces **product-aligned vs internal** as a second, independent classification axis and applies it to routing and the storyboard.

`specs/2070-product-vs-internal-work-axis/design-a.md` (93 lines).

### What it decides

The axis is defined once in the rubric and consumed in four flows; a merge-gate check keeps the recorded population complete.

| Component | Role |
|---|---|
| **Rubric** (`work-definition.md`) | The single home for the axis definition, decision test, and the requirement to label any work PR. Subsumes the existing issue-intake "product-aligned" mention. |
| **Routing** (`memory-protocol.md` § On-Boot Routing) | An intra-level tie-break (product outranks internal among tied candidates) with the constraint-lifting exception, recorded in the `### Decision` block. |
| **kata-spec / kata-product-issue** | Carry the classification on specs and triaged issues via the shared rubric. |
| **Classification label** (`product` / `internal`) | The durable per-item carrier on every merged PR — spec, issue-fix, and direct fix alike. |
| **Merge-gate check** (`kata-release-merge`) | Refuses an unlabeled PR, so the metric's denominator is the full merged-PR population. |
| **Mix emitter** (new `fit-wiki` subcommand) | Deterministically derives `product_share` from merged-PR labels into a dedicated metric CSV. |
| **Storyboard metric** | A `product_share` xmr block under the product-manager section. |

### Key decisions (with rejected alternatives)

- **PR label as carrier** over a STATUS column (STATUS tracks specs only, misses fix PRs).
- **New deterministic `fit-wiki` emitter** over a hand-appended row (not reproducible) or extending render-only `refresh` (couples derive-and-write).
- **Merge-gate enforcement** of label presence over trusting author discipline (a missed label silently biases the ratio).
- **Intra-level routing tie-break** over a new fifth routing level (which would reorder the strict priority and preempt owned internal priorities — forbidden by the spec).

### Review

Ran three clean sub-agent review panels (cold context, panel of 3 each) per the `kata-review` caller protocol. The first surfaced a blocker — the original design ascribed a fabricated PR-aggregation capability to `fit-wiki refresh` (which is render-only). The redesign replaced it with a real new emitter, named the labeler and metric owner, and added the merge-gate completeness check. The final panel returned no blocker and no high findings, with all scope additions confirmed as justified design choices the spec delegated.

Approval is human-only — this PR does not request the `design:approved` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SXDL32iJ3KRGtEKHL4kks

---
_Generated by [Claude Code](https://claude.ai/code/session_014SXDL32iJ3KRGtEKHL4kks)_