### PR TITLE
design(2090): work-item provider abstraction (spec + design)

### DIFF
--- a/specs/2090-work-item-provider-abstraction/design-a.md
+++ b/specs/2090-work-item-provider-abstraction/design-a.md
@@ -1,0 +1,167 @@
+# Design 2090: Work-Item Provider Abstraction
+
+Generalizes the GitHub coupling in kata coordination behind a **provider
+matrix** and adds a **filesystem** provider, so the coordination half of the
+kata loop (file → open change → gate → merge) becomes benchmarkable offline.
+Scope, success criteria, and exclusions are in [spec.md](spec.md). This design
+fixes the three decisions the spec deferred: the matrix's published home, the
+filesystem storage format, and how approval signals generalize.
+
+## Architecture
+
+```mermaid
+flowchart TD
+  S[kata-* skill / agent reference<br/>names an abstract operation] --> SEL{active provider<br/>KATA_WORK_PROVIDER}
+  SEL -->|github default| GH[github column<br/>gh CLI shapes]
+  SEL -->|filesystem| FS[filesystem column<br/>file-write recipes]
+  GH --> FORGE[(GitHub forge<br/>issues, PRs, discussions)]
+  FS --> TREE[(working tree<br/>.kata/ files)]
+  MATRIX[provider matrix<br/>operations × providers] -.realizes.-> GH
+  MATRIX -.realizes.-> FS
+  BENCH[coordinate-finding benchmark task] -->|sets filesystem, no network| FS
+  TREE -->|invariants.sh reads| VERDICT[pass/fail verdict]
+```
+
+A skill names a provider-independent operation. The active provider, chosen by
+one environment variable, selects which matrix column realizes it: the `github`
+column (existing `gh` shapes) or the `filesystem` column (file-write recipes
+against `.kata/`). The matrix is the single home for any forge-specific command.
+
+## Components
+
+| Component | Home | Role |
+| --- | --- | --- |
+| **Work-item model** | new `kata-coordinate` skill | Defines ticket, change, and the shared envelope plus the abstract operation vocabulary. |
+| **Provider matrix** | a reference in `kata-coordinate` | Maps each operation to its `github` and `filesystem` realization; states per-provider degradation and the selection rule. The only place forge commands appear. |
+| **github column** | matrix | Absorbs every forge command now outside it — the `gh` shapes in `coordination-protocol.md`, `issue-lifecycle.md`, `approval-signals.md`, and the kata-* skills, plus the remote-git operations (branch, push) the spec names — into one column (the spec's § Problem grep set bounds the file set). |
+| **filesystem column** | matrix | New. File-write recipes over the `.kata/` layout below. |
+| **Re-pointed references** | `work-definition.md`, `coordination-protocol.md`, `approval-signals.md` | Re-expressed over operations: `work-definition.md`'s "Created via" and `coordination-protocol.md`'s routing name operations and move their `gh` shapes to the matrix; `approval-signals.md` generalizes its signal vocabulary, its one `gh` shape (`gh pr review --approve`) moving to the matrix github column. |
+| **Re-pointed skills** | the kata-* skills that call `gh` | Call sites replaced by an operation name + matrix link. |
+| **Benchmark task** | `benchmarks/kata-skills/tasks/coordinate-finding/` | End-to-end coordination graded by `invariants.sh` against `.kata/` files. |
+
+## Delivery and linkage
+
+The spec requires the resource to reach installations via the published skill
+pack but leaves its surface to the design. It lives in a new `kata-coordinate`
+skill, so the existing publish manifest (which syncs `.claude/skills/kata-*/**`)
+carries it with no CI change. A dedicated skill is chosen over two lighter
+alternatives: attaching the matrix as a reference under an existing kata-* skill
+was rejected because no existing skill owns cross-cutting coordination, which
+would leave the vocabulary without a clear owner or stable citation target;
+adding `.claude/agents/references/` to the publish manifest was rejected for a
+larger blast radius that forces genericizing all four references and couples
+delivery to a CI change. Skills cite the matrix as a pack sibling; the three
+references under `.claude/agents/references/` — which do not ship — cite it by
+fully-qualified monorepo URL, the pattern published skills already use for that
+directory. The vocabulary lives in the published matrix, so an installation
+resolves every operation name without needing the unpublished references.
+
+## Work-item model
+
+Two kinds share one **envelope** carried as YAML front-matter:
+
+| Field | Meaning | github | filesystem |
+| --- | --- | --- | --- |
+| `id` | stable identity | issue/PR number + URL | caller-supplied slug = repo-relative path |
+| `kind` | `ticket` \| `change` | issue \| pull request | file under `tickets/` \| `changes/` |
+| `state` | `open` \| `closed` \| `merged` | issue/PR state | front-matter value |
+| `labels` | classification incl. `agent:*` | issue/PR labels | front-matter list |
+| `links` | related work-item ids | issue refs | front-matter list |
+| `approval` | change-only trusted gate | PR label/review by trusted human | front-matter value |
+
+Discussion is an appended `## Comments` section for filesystem and the native
+thread for github; the matrix records how each capability degrades per provider.
+Front-matter is the envelope carrier, chosen over a sidecar manifest or a JSON
+store so one human-readable file holds both metadata and body and an agent edits
+it without a tool.
+
+## Abstract operations
+
+`create-ticket`, `list-tickets`, `comment`, `label`, `link`, `open-change`,
+`gate`, `merge-change`, `close`, and the discussion pair `create-discussion` /
+`comment-discussion`. The vocabulary is kept to these primitives plus
+compositions rather than a larger flat verb set, so each provider implements a
+small fixed surface: the spec's `triage` and `patch` are compositions
+(label / comment / close, and open-change / merge-change), not first-class
+operations. Obstacle and experiment are tickets distinguished by label, so
+`issue-lifecycle.md` becomes operation recipes (`create-ticket` + `comment` +
+`close`) that point at the matrix rather than carrying `gh`.
+
+## Filesystem storage format
+
+A coordination root `.kata/` in the working tree, provider-owned and disjoint
+from app files:
+
+```
+.kata/
+  tickets/{id}.md      # envelope front-matter + body; ## Comments appended
+  changes/{id}.md      # envelope (kind: change) + links to its ticket(s)
+  discussions/{id}.md  # RFC threads
+```
+
+`create-*` writes a file from the envelope template; `list-tickets` globs and
+filters on front-matter; `comment` appends; `gate` sets `approval`;
+`merge-change` sets `state: merged`. No network, no remote, no git required —
+plain file writes the agent already performs, which is why the flow runs in the
+benchmark sandbox.
+
+One file per item is chosen over a single append-only log or JSON store, which
+an agent authors and `invariants.sh` asserts on less directly. Ids are
+caller-supplied slugs (so a `{id}.md` path is the identity) rather than
+provider-minted monotonic ids, which would be non-deterministic and defeat
+path-based assertions. A change file carries only its envelope; the diff is the
+working tree at merge time, rather than a materialized patch object that
+duplicates the tree and adds an apply step the benchmark does not need.
+
+## Provider selection
+
+One input: environment variable `KATA_WORK_PROVIDER`, defaulting to `github`.
+The matrix documents it; skills never branch on it. The benchmark task exports
+`filesystem`; production leaves the default. An env var is chosen over a config
+file or per-skill flag, which add surface and one more thing the sandbox must
+seed.
+
+## Approval-signal generalization
+
+`approval-signals.md` keeps STATUS.md as the canonical record and keeps the
+trust rule (human-originated for spec/design). Its signal table is re-expressed
+as work-item signals — "a trusted approval marker on a change" and "a change
+reaches `merged`" — and the matrix maps each to its realization: github reads
+the PR label/review/merge event (the `kata-dispatch` bridge, unchanged);
+filesystem reads the change file's `approval` field and `state: merged`. The
+benchmark exercises the filesystem realization directly, without webhooks. On
+filesystem the `approval` field records the granting signal (an approval marker,
+optionally the approver); trust that the setter is authorized is out-of-band —
+the actor that runs `gate` is trusted by construction (the benchmark harness or
+a human). Emulating contributor-list trust offline is rejected as unverifiable
+without the forge.
+
+## Benchmark coordination task
+
+`coordinate-finding/` follows the existing task structure — the agent, judge,
+and supervisor task files, a workdir overlay, and the preflight and invariants
+hooks. The agent is given a finding and runs the loop: `create-ticket`,
+`open-change` linking it, `gate` with a trusted signal, `merge-change`, all under
+the filesystem provider with networking unavailable. The invariants hook asserts
+on the resulting `.kata/` files — ticket exists and is linked, change reached
+`state: merged`, `approval` recorded — using the same `assert` harness the other
+tasks use.
+
+## Criteria coverage
+
+| Spec criterion | Satisfied by |
+| --- | --- |
+| 1 model + matrix + selection | Work-item model, provider matrix, env-var selection |
+| 2 forge commands only in github column | Matrix is the single command home; skills/references re-pointed |
+| 3 three references over operations | Re-pointed references component |
+| 4 benchmark runs offline | Filesystem provider needs no network; task exports it |
+| 5 provider-independent wording | Skills name operations; branching lives only in the matrix |
+| 6 coordination task asserts on files | `coordinate-finding` `invariants.sh` |
+| 7 resource reaches installations | `kata-coordinate` ships in the published pack |
+| 8 no leakage, clean install | New skill obeys the skill-genericity invariant |
+
+## Out of scope
+
+Per spec: no CLI or library (the matrix is the seam a later `fit-work` CLI
+adopts), no Jira/GitLab provider, GitHub stays the production default, and
+`wiki/STATUS.md` / `kata-dispatch` mechanics are unchanged.

--- a/specs/2090-work-item-provider-abstraction/spec.md
+++ b/specs/2090-work-item-provider-abstraction/spec.md
@@ -90,8 +90,11 @@ Affected entities:
 
 Excluded:
 
-- **No new library or CLI.** The abstraction is a shared resource plus skill
-  wording; agents run provider-specific commands directly.
+- **No CLI or library in this spec.** The abstraction ships as a shared
+  resource plus skill wording, and agents run provider-specific commands
+  directly. A `fit-work`-style CLI that wraps the same provider matrix behind
+  one verb set is a planned follow-up spec; the matrix here is designed as the
+  seam that CLI will adopt, not a throwaway.
 - **No Jira or GitLab implementation.** This spec establishes the seam only.
 - **No change to GitHub as the production default.**
 - **No storage-format decision.** How the filesystem provider lays out its files
@@ -108,7 +111,8 @@ genericization of the references and `gh`-invoking skills is the necessary means
 to it — a coordination task cannot be benchmarked offline unless the skills it
 exercises stop calling `gh` directly. Multi-forge portability (Jira, GitLab) is
 an enabled consequence of the same seam; building those providers is future
-work.
+work. A `fit-work` CLI over the matrix is a sequenced follow-up — the matrix is
+specified now so that CLI inherits a stable seam rather than reinventing one.
 
 ## Success Criteria
 

--- a/specs/2090-work-item-provider-abstraction/spec.md
+++ b/specs/2090-work-item-provider-abstraction/spec.md
@@ -1,0 +1,124 @@
+# Spec 2090: Work-Item Provider Abstraction
+
+## Problem
+
+The kata-* skills coordinate work through GitHub primitives — issues, pull
+requests, labels, reviews — invoked via the `gh` CLI. The coupling does not live
+in the spec/design/plan skill bodies, which defer coordination to shared
+resources; it lives in those shared resources and in the operational skills that
+invoke `gh` directly. `work-definition.md` lists each work-type's "Created via"
+as a GitHub action (labeled issue, `gh` Discussion, direct git ops);
+`coordination-protocol.md` routes outputs to GitHub channels and carries a `gh`
+CLI section; `approval-signals.md` reads approval from PR labels, comments, and
+reviews. The skills and references that file, gate, merge, triage, and patch
+then call `gh` — the precise set is discoverable by grepping for `gh ` across
+the kata-* skills and the shared references, and is broader than any short list.
+
+This binds the engineering standard's coordination model to one vendor and
+blocks two outcomes:
+
+1. **The coordination half of each skill goes unmeasured.** `fit-benchmark` runs
+   each task in an ephemeral working directory seeded only with the family's
+   fixtures, with no forge credentials and no remote configured; a coordination
+   step that calls a remote forge cannot run there, and a benchmark must stay
+   reproducible and offline regardless. The `kata-skills` benchmark family is
+   four independent tasks — three grade a single produced artifact each (spec,
+   design, plan) by rubric and judge, and the fourth grades the implementation
+   against a hidden test suite. None of the four exercises a coordination step:
+   filing a finding, opening a change, gating it on a trusted signal, merging
+   it. Coordination is half of what the kata skills do, so a change to filing,
+   gating, or merging ships with no evidence it improved anything.
+
+2. **There is no seam for other forges.** A team running the standard against
+   Jira or GitLab has nowhere to fit those systems, because the skills and
+   references name `gh` rather than an operation.
+
+This blocks the job Teams Using Agents hire Kata to do — *"Help me run an
+autonomous, continuously improving development team that plans, ships, studies
+its own traces, and acts on findings"* (JTBD.md § Teams Using Agents: Run a
+Continuously Improving Agent Team) — whose Trigger is precisely that "nobody can
+tell whether the team is getting better." A team cannot tell whether the half of
+the loop it cannot benchmark is improving. The instrument that would measure it,
+`fit-benchmark` (the eval tooling within Gear), cannot reach the coordination
+half while it is GitHub-bound.
+
+## What Changes
+
+Generalize the two GitHub nouns into one substrate-neutral concept, the **work
+item**, with two kinds and a shared envelope, then describe the GitHub binding
+as one of several interchangeable **providers** in a shared resource the kata-*
+skills read. Skills and references name the abstract operation and point to the
+matrix; the matrix records the concrete commands per provider.
+
+Work-item model:
+
+| Concept | Generalizes | What it is |
+| --- | --- | --- |
+| **ticket** | GitHub issue | A tracked unit of work or finding (bug, feature, obstacle, experiment, RFC). |
+| **change** | GitHub pull request | A proposed diff carrying an approval gate. |
+| **envelope** | both | The capabilities every work item shares: stable identity, state, discussion, labels, and linkage to other items. Where a provider cannot express a capability, the matrix states how that capability degrades for it. |
+
+Provider matrix — the shared resource mapping each abstract operation (create
+ticket, list, comment, open change, gate, merge) to the concrete commands per
+provider, plus how an installation selects its active provider:
+
+| Provider | Role |
+| --- | --- |
+| **github** | The current behaviour. Remains the default and production binding. |
+| **filesystem** | New. Tickets and changes live as files in the working tree, so coordination needs no network or remote forge. |
+| **jira**, **gitlab** | Future. Enabled by the seam; not built in this spec. |
+
+## Scope
+
+Affected entities:
+
+- A new shared resource defining the work-item model, the provider matrix, and
+  how the active provider is selected. It must ship to every installation that
+  consumes the kata-* skills, so a consuming team can add a provider (outcome 2);
+  which published surface hosts it is a design decision.
+- The work-type catalogue and routing in `work-definition.md` and
+  `coordination-protocol.md`, re-expressed over work items rather than GitHub
+  nouns.
+- The approval-signal vocabulary in `approval-signals.md`, generalized so a
+  "trusted signal" is expressible by any provider.
+- Every kata-* skill and shared reference that invokes `gh` for coordination
+  (the full set is the grep result from § Problem, and includes the
+  obstacle/experiment recipes in `kata-session`'s `issue-lifecycle.md`),
+  re-pointed at the abstract operations.
+- The `kata-skills` benchmark family, which gains at least one end-to-end
+  coordination task graded against the filesystem provider.
+
+Excluded:
+
+- **No new library or CLI.** The abstraction is a shared resource plus skill
+  wording; agents run provider-specific commands directly.
+- **No Jira or GitLab implementation.** This spec establishes the seam only.
+- **No change to GitHub as the production default.**
+- **No storage-format decision.** How the filesystem provider lays out its files
+  is left to the design.
+- `wiki/STATUS.md` and `kata-dispatch` keep their mechanics; only the
+  provider-specific signals they read (PR labels, comments, reviews, merge
+  events) are re-expressed as work-item signals.
+
+## Delivered Outcome
+
+The primary, accountable outcome is the **measurement seam**: end-to-end kata
+coordination becomes benchmarkable offline via the filesystem provider. The
+genericization of the references and `gh`-invoking skills is the necessary means
+to it — a coordination task cannot be benchmarked offline unless the skills it
+exercises stop calling `gh` directly. Multi-forge portability (Jira, GitLab) is
+an enabled consequence of the same seam; building those providers is future
+work.
+
+## Success Criteria
+
+| # | Criterion | Verified by |
+| --- | --- | --- |
+| 1 | A shared resource defines the work-item model (ticket, change, envelope) and a provider matrix listing the abstract operations with at least `github` and `filesystem` columns and a provider-selection rule. | The resource exists; it contains both columns, every listed operation, and the selection rule. |
+| 2 | Commands that act on a forge's work items (issue, pull-request, discussion, review, label, and remote-git operations) appear in the kata-* skills and shared references only within the github column of the matrix. | Grep for those commands across the kata-* skills and shared references returns hits only inside the matrix. |
+| 3 | `work-definition.md`, `coordination-protocol.md`, and `approval-signals.md` express work-types, routing, and approval signals over work-item operations, with no GitHub-noun routing outside the matrix. | Review of the three references finds zero coordination instructions naming a GitHub primitive directly. |
+| 4 | The end-to-end coordination benchmark task completes under the filesystem provider with no network access and no remote forge. | The task runs to a verdict in the sandbox with networking unavailable. |
+| 5 | The abstract operation names the skills use are provider-independent; any provider-specific behaviour appears only in the matrix (including stated degradations per the envelope). | Skill and reference wording outside the matrix contains no provider-specific branching. |
+| 6 | The `kata-skills` benchmark family includes an end-to-end coordination task graded by invariants asserting on the resulting work-item files. | The task directory exists; its `invariants.sh` asserts on the work-item files. |
+| 7 | The shared resource reaches consuming installations along with the skills that cite it. | The resource resides on the surface that syncs to installations (the published skill pack), not a tree that stays in-repo. |
+| 8 | The new resource and skill edits introduce no monorepo leakage, and published skills still install cleanly into a fresh repository. | The skill-genericity invariant check passes. |


### PR DESCRIPTION
## Summary

- **Spec 2090** — generalizes the GitHub coupling in kata coordination behind a substrate-neutral **work item** (ticket + change + envelope) and a **provider matrix**, adding a **filesystem** provider so the coordination half of the kata loop becomes benchmarkable offline. CLI is framed as a sequenced follow-up over the matrix.
- **Design 2090** — architecture resolving the three deferred decisions: matrix home (a new published `kata-coordinate` skill), filesystem storage format (one `.kata/` file per work item, envelope as front-matter), and approval-signal generalization (work-item signals over STATUS.md). Three `staff-engineer` review panels; all consensus and verifiable findings addressed.

`wiki/STATUS.md` row for 2090 set to `design approved` (human approval signal: `/ship-it` invoked by a trusted user).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UM18UwNLVPV49RVvBNeH4D

---
_Generated by [Claude Code](https://claude.ai/code/session_01UM18UwNLVPV49RVvBNeH4D)_