### PR TITLE
design(2090): work-item tracker abstraction (design-b + spec amendment)

### DIFF
--- a/.claude/agents/references/self-improvement.md
+++ b/.claude/agents/references/self-improvement.md
@@ -7,7 +7,7 @@ resolved, agents use the `fit-selfedit` CLI described below.
 
 ## Rule
 
-Every agent edit under `.claude/**` goes through `bunx fit-selfedit`. No other
+Every agent edit under `.claude/**` goes through `npx fit-selfedit`. No other
 mechanism is supported. Do not use `Edit`, `Write`, or sandboxed `Bash` on
 `.claude/**` paths — they will be denied.
 
@@ -16,11 +16,11 @@ mechanism is supported. Do not use `Edit`, `Write`, or sandboxed `Bash` on
 Use the `Bash` tool. Pipe content on stdin; the target path is the only
 positional argument:
 
-    echo "<content>" | bunx fit-selfedit <path>
+    echo "<content>" | npx fit-selfedit <path>
 
 For multi-line content, use a heredoc:
 
-    bunx fit-selfedit .claude/path/to/file <<'FIT_SELFEDIT_EOF'
+    npx fit-selfedit .claude/path/to/file <<'FIT_SELFEDIT_EOF'
     file content here
     FIT_SELFEDIT_EOF
 
@@ -62,7 +62,7 @@ re-run. If a parent directory is missing, create it with `mkdir -p` first.
 ## Trace invariant
 
 The cross-cutting invariant table (KATA.md § Invariants) enforces that every
-write under `.claude/**` is performed via `bunx fit-selfedit`. Any other
+write under `.claude/**` is performed via `npx fit-selfedit`. Any other
 mechanism — direct `Edit`/`Write` on `.claude/**`, or a sandbox-disabled
 `Bash` call writing to those paths — is a **high-severity** trace finding.
 

--- a/.coaligned/invariants/skill-genericity.rules.mjs
+++ b/.coaligned/invariants/skill-genericity.rules.mjs
@@ -1,6 +1,7 @@
-// Flag monorepo-specific content in the published kata-* skills. The kata-*
-// skill pack syncs unchanged into consuming repositories, so every line must
-// hold in a repo that installed the pack yesterday (.claude/skills/CLAUDE.md
+// Flag monorepo-specific content in the published pack. The pack syncs
+// unchanged into consuming repositories — APM installs the kata-* skills and
+// the agent profiles plus their references together — so every line must hold
+// in a repo that installed the pack yesterday (.claude/skills/CLAUDE.md
 // § Generic by design). Three rule groups guard the classes that creep back:
 //
 // 1. Internal-only tooling — bun, bunx, and just are internal contributor
@@ -79,17 +80,13 @@ const PATTERNS = [
     reason: "hardcoded date — derive the data live or use YYYY-MM-DD",
   },
   // --- Group 3: links broken in the published pack ---
-  // The pack ships only skills/kata-*/ and renamed top-level agent profiles;
-  // .claude/agents/references/, root TRUST.md, and the fit-* skills (a
-  // separate pack) are not synced, so relative links to them dangle in every
-  // consuming installation. Guaranteed surfaces (CONTRIBUTING.md, JTBD.md,
-  // KATA.md) stay relative — the consuming repo carries its own. Links to
-  // this monorepo's issues and PRs are provenance that rots — the skill must
-  // stand on its own.
-  {
-    pattern: "\\]\\((\\.\\./)+agents/",
-    reason: "agents/ is not shipped with the pack — use the full GitHub URL",
-  },
+  // The pack ships skills/kata-*/ and the agent profiles plus their
+  // references, so relative links among them resolve in a consuming install.
+  // Root TRUST.md and the fit-* skills (a separate pack) are not synced, so
+  // relative links to them dangle. Guaranteed surfaces (CONTRIBUTING.md,
+  // JTBD.md, KATA.md) stay relative — the consuming repo carries its own.
+  // Links to this monorepo's issues and PRs are provenance that rots — the
+  // skill must stand on its own.
   {
     pattern: "\\]\\((\\.\\./)+TRUST\\.md",
     reason: "TRUST.md is not shipped with the pack — use the full GitHub URL",
@@ -112,8 +109,8 @@ export default {
       subjects: {
         "skill-match": grep({
           patterns: PATTERNS,
-          paths: [".claude/skills/"],
-          globs: [".claude/skills/kata-*/**"],
+          paths: [".claude/skills/", ".claude/agents/references/"],
+          globs: [".claude/skills/kata-*/**", ".claude/agents/references/**"],
           caseSensitive: true,
           dedupe: (m) => `${m.raw}|${m.reason}`,
         }),
@@ -125,7 +122,7 @@ export default {
     failAll("skill-match", {
       id: "skills.monorepo-specific",
       message: (s) => `${s.text.trim()} — ${s.reason}`,
-      hint: "kata-* skills must hold in a repo that installed the pack yesterday (.claude/skills/CLAUDE.md § Generic by design); narrow the rule in .coaligned/invariants/skill-genericity.rules.mjs only for a legitimate generic usage",
+      hint: "published pack content (kata-* skills and agent references) must hold in a repo that installed the pack yesterday (.claude/skills/CLAUDE.md § Generic by design); narrow the rule in .coaligned/invariants/skill-genericity.rules.mjs only for a legitimate generic usage",
     }),
   ],
 };

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -7,6 +7,7 @@ on:
       - ".claude/skills/fit-*/**"
       - ".claude/skills/kata-*/**"
       - ".claude/agents/*.md"
+      - ".claude/agents/references/**"
       - "products/gear/package.json"
       - ".github/workflows/publish-skills.yml"
   workflow_dispatch:
@@ -240,6 +241,11 @@ jobs:
             agent_name=$(basename "$agent_file" .md)
             cp "$agent_file" "skills-repo/agents/${agent_name}.agent.md"
           done
+          # Ship the agent references the profiles and skills cite (e.g. the
+          # work-item tracker matrix); APM installs them alongside the skills.
+          if [ -d .claude/agents/references ]; then
+            cp -r .claude/agents/references skills-repo/agents/references
+          fi
 
       - name: Generate apm.yml
         run: |

--- a/specs/2090-work-item-provider-abstraction/design-a.md
+++ b/specs/2090-work-item-provider-abstraction/design-a.md
@@ -1,7 +1,7 @@
-# Design 2090: Work-Item Provider Abstraction
+# Design 2090: Work-Item Tracker Abstraction
 
-Generalizes the GitHub coupling in kata coordination behind a **provider
-matrix** and adds a **filesystem** provider, so the coordination half of the
+Generalizes the GitHub coupling in kata coordination behind a **tracker
+matrix** and adds a **filesystem** tracker, so the coordination half of the
 kata loop (file → open change → gate → merge) becomes benchmarkable offline.
 Scope, success criteria, and exclusions are in [spec.md](spec.md). This design
 fixes the three decisions the spec deferred: the matrix's published home, the
@@ -11,18 +11,18 @@ filesystem storage format, and how approval signals generalize.
 
 ```mermaid
 flowchart TD
-  S[kata-* skill / agent reference<br/>names an abstract operation] --> SEL{active provider<br/>KATA_WORK_PROVIDER}
+  S[kata-* skill / agent reference<br/>names an abstract operation] --> SEL{active tracker<br/>KATA_WORK_TRACKER}
   SEL -->|github default| GH[github column<br/>gh CLI shapes]
   SEL -->|filesystem| FS[filesystem column<br/>file-write recipes]
   GH --> FORGE[(GitHub forge<br/>issues, PRs, discussions)]
   FS --> TREE[(working tree<br/>.kata/ files)]
-  MATRIX[provider matrix<br/>operations × providers] -.realizes.-> GH
+  MATRIX[tracker matrix<br/>operations × trackers] -.realizes.-> GH
   MATRIX -.realizes.-> FS
   BENCH[coordinate-finding benchmark task] -->|sets filesystem, no network| FS
   TREE -->|invariants.sh reads| VERDICT[pass/fail verdict]
 ```
 
-A skill names a provider-independent operation. The active provider, chosen by
+A skill names a tracker-independent operation. The active tracker, chosen by
 one environment variable, selects which matrix column realizes it: the `github`
 column (existing `gh` shapes) or the `filesystem` column (file-write recipes
 against `.kata/`). The matrix is the single home for any forge-specific command.
@@ -31,8 +31,8 @@ against `.kata/`). The matrix is the single home for any forge-specific command.
 
 | Component | Home | Role |
 | --- | --- | --- |
-| **Work-item model** | new `kata-coordinate` skill | Defines ticket, change, and the shared envelope plus the abstract operation vocabulary. |
-| **Provider matrix** | a reference in `kata-coordinate` | Maps each operation to its `github` and `filesystem` realization; states per-provider degradation and the selection rule. The only place forge commands appear. |
+| **Work-item model** | new `kata-coordinate` skill | Defines issue, change, and the shared envelope plus the abstract operation vocabulary. |
+| **Tracker matrix** | a reference in `kata-coordinate` | Maps each operation to its `github` and `filesystem` realization; states per-tracker degradation and the selection rule. The only place forge commands appear. |
 | **github column** | matrix | Absorbs every forge command now outside it — the `gh` shapes in `coordination-protocol.md`, `issue-lifecycle.md`, `approval-signals.md`, and the kata-* skills, plus the remote-git operations (branch, push) the spec names — into one column (the spec's § Problem grep set bounds the file set). |
 | **filesystem column** | matrix | New. File-write recipes over the `.kata/` layout below. |
 | **Re-pointed references** | `work-definition.md`, `coordination-protocol.md`, `approval-signals.md` | Re-expressed over operations: `work-definition.md`'s "Created via" and `coordination-protocol.md`'s routing name operations and move their `gh` shapes to the matrix; `approval-signals.md` generalizes its signal vocabulary, its one `gh` shape (`gh pr review --approve`) moving to the matrix github column. |
@@ -63,43 +63,43 @@ Two kinds share one **envelope** carried as YAML front-matter:
 | Field | Meaning | github | filesystem |
 | --- | --- | --- | --- |
 | `id` | stable identity | issue/PR number + URL | caller-supplied slug = repo-relative path |
-| `kind` | `ticket` \| `change` | issue \| pull request | file under `tickets/` \| `changes/` |
+| `kind` | `issue` \| `change` | issue \| pull request | file under `issues/` \| `changes/` |
 | `state` | `open` \| `closed` \| `merged` | issue/PR state | front-matter value |
 | `labels` | classification incl. `agent:*` | issue/PR labels | front-matter list |
 | `links` | related work-item ids | issue refs | front-matter list |
 | `approval` | change-only trusted gate | PR label/review by trusted human | front-matter value |
 
 Discussion is an appended `## Comments` section for filesystem and the native
-thread for github; the matrix records how each capability degrades per provider.
+thread for github; the matrix records how each capability degrades per tracker.
 Front-matter is the envelope carrier, chosen over a sidecar manifest or a JSON
 store so one human-readable file holds both metadata and body and an agent edits
 it without a tool.
 
 ## Abstract operations
 
-`create-ticket`, `list-tickets`, `comment`, `label`, `link`, `open-change`,
+`create-issue`, `list-issues`, `comment`, `label`, `link`, `open-change`,
 `gate`, `merge-change`, `close`, and the discussion pair `create-discussion` /
 `comment-discussion`. The vocabulary is kept to these primitives plus
-compositions rather than a larger flat verb set, so each provider implements a
+compositions rather than a larger flat verb set, so each tracker implements a
 small fixed surface: the spec's `triage` and `patch` are compositions
 (label / comment / close, and open-change / merge-change), not first-class
-operations. Obstacle and experiment are tickets distinguished by label, so
-`issue-lifecycle.md` becomes operation recipes (`create-ticket` + `comment` +
+operations. Obstacle and experiment are issues distinguished by label, so
+`issue-lifecycle.md` becomes operation recipes (`create-issue` + `comment` +
 `close`) that point at the matrix rather than carrying `gh`.
 
 ## Filesystem storage format
 
-A coordination root `.kata/` in the working tree, provider-owned and disjoint
+A coordination root `.kata/` in the working tree, tracker-owned and disjoint
 from app files:
 
 ```
 .kata/
-  tickets/{id}.md      # envelope front-matter + body; ## Comments appended
-  changes/{id}.md      # envelope (kind: change) + links to its ticket(s)
+  issues/{id}.md      # envelope front-matter + body; ## Comments appended
+  changes/{id}.md      # envelope (kind: change) + links to its issue(s)
   discussions/{id}.md  # RFC threads
 ```
 
-`create-*` writes a file from the envelope template; `list-tickets` globs and
+`create-*` writes a file from the envelope template; `list-issues` globs and
 filters on front-matter; `comment` appends; `gate` sets `approval`;
 `merge-change` sets `state: merged`. No network, no remote, no git required —
 plain file writes the agent already performs, which is why the flow runs in the
@@ -108,14 +108,14 @@ benchmark sandbox.
 One file per item is chosen over a single append-only log or JSON store, which
 an agent authors and `invariants.sh` asserts on less directly. Ids are
 caller-supplied slugs (so a `{id}.md` path is the identity) rather than
-provider-minted monotonic ids, which would be non-deterministic and defeat
+tracker-minted monotonic ids, which would be non-deterministic and defeat
 path-based assertions. A change file carries only its envelope; the diff is the
 working tree at merge time, rather than a materialized patch object that
 duplicates the tree and adds an apply step the benchmark does not need.
 
-## Provider selection
+## Tracker selection
 
-One input: environment variable `KATA_WORK_PROVIDER`, defaulting to `github`.
+One input: environment variable `KATA_WORK_TRACKER`, defaulting to `github`.
 The matrix documents it; skills never branch on it. The benchmark task exports
 `filesystem`; production leaves the default. An env var is chosen over a config
 file or per-skill flag, which add surface and one more thing the sandbox must
@@ -140,10 +140,10 @@ without the forge.
 
 `coordinate-finding/` follows the existing task structure — the agent, judge,
 and supervisor task files, a workdir overlay, and the preflight and invariants
-hooks. The agent is given a finding and runs the loop: `create-ticket`,
+hooks. The agent is given a finding and runs the loop: `create-issue`,
 `open-change` linking it, `gate` with a trusted signal, `merge-change`, all under
-the filesystem provider with networking unavailable. The invariants hook asserts
-on the resulting `.kata/` files — ticket exists and is linked, change reached
+the filesystem tracker with networking unavailable. The invariants hook asserts
+on the resulting `.kata/` files — issue exists and is linked, change reached
 `state: merged`, `approval` recorded — using the same `assert` harness the other
 tasks use.
 
@@ -151,11 +151,11 @@ tasks use.
 
 | Spec criterion | Satisfied by |
 | --- | --- |
-| 1 model + matrix + selection | Work-item model, provider matrix, env-var selection |
+| 1 model + matrix + selection | Work-item model, tracker matrix, env-var selection |
 | 2 forge commands only in github column | Matrix is the single command home; skills/references re-pointed |
 | 3 three references over operations | Re-pointed references component |
-| 4 benchmark runs offline | Filesystem provider needs no network; task exports it |
-| 5 provider-independent wording | Skills name operations; branching lives only in the matrix |
+| 4 benchmark runs offline | Filesystem tracker needs no network; task exports it |
+| 5 tracker-independent wording | Skills name operations; branching lives only in the matrix |
 | 6 coordination task asserts on files | `coordinate-finding` `invariants.sh` |
 | 7 resource reaches installations | `kata-coordinate` ships in the published pack |
 | 8 no leakage, clean install | New skill obeys the skill-genericity invariant |
@@ -163,5 +163,5 @@ tasks use.
 ## Out of scope
 
 Per spec: no CLI or library (the matrix is the seam a later `fit-work` CLI
-adopts), no Jira/GitLab provider, GitHub stays the production default, and
+adopts), no Jira/GitLab tracker, GitHub stays the production default, and
 `wiki/STATUS.md` / `kata-dispatch` mechanics are unchanged.

--- a/specs/2090-work-item-provider-abstraction/design-b.md
+++ b/specs/2090-work-item-provider-abstraction/design-b.md
@@ -1,0 +1,196 @@
+# Design 2090-b: Work-Item Tracker Abstraction (no new skill)
+
+Alternative to [design-a.md](design-a.md). Same goal — generalize the GitHub
+coupling behind a **tracker matrix** plus a **filesystem** tracker so the
+coordination half of the kata loop (file → open change → gate → merge) becomes
+benchmarkable offline. Scope, criteria, and exclusions are in
+[spec.md](spec.md).
+
+This variant fixes three decisions: the model and matrix live as one reference
+on the surface that already owns cross-cutting coordination
+(`.claude/agents/references/`), the publish workflow and genericity gate are
+corrected so that surface ships and stays clean, and tracker selection is wired
+into the libeval harness the way agent profiles already are. It introduces **no
+new skill**.
+
+## Matrix home: the agent-references surface
+
+The matrix is needed *whenever an agent coordinates*, independent of which skill
+is active. A skill's `references/` file is only context when something links to
+it, so hosting the matrix under a domain skill buries a cross-cutting primitive
+in one skill's scope and makes every coordinating skill depend on that skill's
+presence. The surface already in scope for every agent is
+`.claude/agents/references/` — `coordination-protocol.md`, `work-definition.md`,
+`approval-signals.md` are cited from the agent profiles themselves. The matrix
+belongs there as a peer (`work-trackers.md`), giving it a clear owner and a
+stable citation target.
+
+Rejected: a dedicated `kata-coordinate` skill (design-a) adds a skill scaffold
+and README entry for a unit that only hosts a table; a reference under an
+existing kata-* skill ships with no workflow change but couples the matrix to
+that skill's domain and presence (the activation problem above).
+
+## Reaching installations
+
+APM installs the agent profiles and the skills from one pack together, so agent
+references already reach installations in principle — but the publish workflow's
+agent step copied only the top-level `*.md` profiles, never the `references/`
+subtree. This design ships that subtree too, symmetric with skill references, so
+all agent references (not just the three the spec re-expresses) become published
+content. That is the right surface for the matrix and ends the skill/agent
+asymmetry; leaving it unpublished is rejected because it fails criterion 7.
+
+Two assumptions that pre-dated APM are corrected to make this sound. The
+**genericity invariant** was scoped to the skill tree only and even banned
+skills from relative-linking into `agents/` ("not shipped"); its scope now
+covers `.claude/agents/references/` and that stale link ban is removed, so
+cross-pack relative links resolve and every shipped reference is gate-checked on
+each run (criterion 8 holds standingly, not by a one-time scan). Bringing the
+tree to green required genericizing one internal invocation (a `bunx fit-*` call
+in `self-improvement.md` → `npx`); the gate keeps it clean. Agent *profiles*
+also ship and still carry monorepo-specific operational detail; bringing them
+under the same gate is a separate follow-up, not part of this spec.
+
+## Architecture
+
+```mermaid
+flowchart TD
+  CLI["fit-eval / fit-benchmark<br/>--work-tracker"] -->|sets LIBEVAL_WORK_TRACKER| HARNESS[libeval harness]
+  HARNESS -->|forwards env to agent| S[kata-* skill / agent reference<br/>names an abstract operation]
+  S --> SEL{active tracker<br/>LIBEVAL_WORK_TRACKER}
+  SEL -->|github default| GH[github column<br/>gh CLI shapes]
+  SEL -->|filesystem| FS[filesystem column<br/>file-write recipes]
+  GH --> FORGE[(GitHub forge)]
+  FS --> TREE[(working tree<br/>.kata/ files)]
+  MATRIX[work-trackers.md<br/>agents/references] -.realizes.-> GH
+  MATRIX -.realizes.-> FS
+  TREE -->|invariants.sh reads| VERDICT[pass/fail verdict]
+```
+
+The active tracker, chosen by the harness-set env var, selects which matrix
+column realizes each operation. The matrix is the single home for forge
+commands.
+
+## Components
+
+| Component | Home | Role |
+| --- | --- | --- |
+| **Work-item model + matrix** | new `.claude/agents/references/work-trackers.md` | One reference defining issue, change, the shared envelope, the abstract operation vocabulary, the `github`/`filesystem` columns, per-tracker degradation, and the selection rule. The only place forge commands appear. |
+| **github column** | inside `work-trackers.md` | Absorbs every forge command now outside it — the `gh` shapes in the coordination references, `issue-lifecycle.md`, and the kata-* skills, plus the remote-git operations (branch, push) the spec names. The § Problem grep set bounds the file set. |
+| **filesystem column** | inside `work-trackers.md` | New. File-write recipes over the `.kata/` layout below. |
+| **Re-pointed references** | `work-definition.md`, `coordination-protocol.md`, `approval-signals.md` | Re-expressed over operations; their `gh` shapes move to the matrix; they cite it by directory-relative path. |
+| **Re-pointed skills** | the kata-* skills that call `gh` | Call sites replaced by an operation name + a relative matrix link, valid now that agents ship in the same pack. |
+| **Tracker selection** | libeval command layer + `fit-eval`/`fit-benchmark` | `--work-tracker` sets `LIBEVAL_WORK_TRACKER`; the harness forwards it to the agent, mirroring the existing `--agent-profile` → `LIBEVAL_AGENT_PROFILE` path. |
+| **Published surface + gate** | the publish workflow + the genericity invariant | Ship and gate the references tree (rationale in § Reaching installations). |
+| **Benchmark task** | `benchmarks/kata-skills/tasks/coordinate-finding/` | End-to-end coordination graded by `invariants.sh` against `.kata/` files. |
+
+## Work-item model
+
+Two kinds share one **envelope** carried as YAML front-matter:
+
+| Field | Meaning | github | filesystem |
+| --- | --- | --- | --- |
+| `id` | stable identity | issue/PR number + URL | caller-supplied slug = repo-relative path |
+| `kind` | `issue` \| `change` | issue \| pull request | file under `issues/` \| `changes/` |
+| `state` | `open` \| `closed` \| `merged` | issue/PR state | front-matter value |
+| `labels` | classification incl. `agent:*` | issue/PR labels | front-matter list |
+| `links` | related work-item ids | issue refs | front-matter list |
+| `discussion` | comment thread | native issue/PR thread | appended `## Comments` section |
+| `approval` | change-only trusted gate | PR label/review by trusted human | front-matter value |
+
+The matrix records how each capability degrades per tracker. Front-matter is the
+envelope carrier, chosen over a sidecar manifest or JSON store so one
+human-readable file holds metadata and body and an agent edits it without a tool.
+
+## Abstract operations
+
+`create-issue`, `list-issues`, `comment`, `label`, `link`, `open-change`,
+`gate`, `merge-change`, `close`, and the discussion pair `create-discussion` /
+`comment-discussion`. The spec's `triage` and `patch` are compositions
+(label / comment / close, and open-change / merge-change), not first-class
+operations, keeping each tracker's surface small and fixed. Obstacle and
+experiment are issues distinguished by label, so `issue-lifecycle.md` becomes
+operation recipes (`create-issue` + `comment` + `close`) that point at the
+matrix rather than carrying `gh`.
+
+## Filesystem storage format
+
+A coordination root `.kata/` in the working tree, tracker-owned and disjoint
+from app files:
+
+```
+.kata/
+  issues/{id}.md       # envelope front-matter + body; ## Comments appended
+  changes/{id}.md      # envelope (kind: change) + links to its issue(s)
+  discussions/{id}.md  # RFC threads
+```
+
+`create-*` writes a file from the envelope template; `list-issues` globs and
+filters on front-matter; `comment` appends; `gate` sets `approval`;
+`merge-change` sets `state: merged`. The remote-git operations branch and push
+have no remote to target, so they degrade to no-ops per the envelope rule: a
+change's diff is simply the working tree at merge time. No network, no remote,
+no git required — plain file writes the agent already performs, which is why the
+flow runs in the benchmark sandbox.
+
+One file per item is chosen over a single append-only log or JSON store, which
+an agent authors and `invariants.sh` asserts on less directly. Ids are
+caller-supplied slugs (so a `{id}.md` path is the identity) rather than
+tracker-minted monotonic ids, which would be non-deterministic and defeat
+path-based assertions. A change file carries only its envelope; the changeset is
+the working tree, not a materialized patch that duplicates it.
+
+## Tracker selection
+
+One input: environment variable `LIBEVAL_WORK_TRACKER`, defaulting to `github`.
+The libeval command layer sets it on the agent environment exactly where it
+already sets `LIBEVAL_AGENT_PROFILE`; `fit-eval` and `fit-benchmark` declare a
+`--work-tracker` option that feeds it, with matching golden help. The matrix
+documents the variable; skills never branch on it. The benchmark task runs
+`--work-tracker filesystem`; production leaves the default. A harness-set env var
+is chosen over a per-skill flag or a config file, which add surface the sandbox
+must seed and would let skill wording branch on the tracker — the one thing
+criterion 5 forbids.
+
+## Approval-signal generalization
+
+`approval-signals.md` keeps STATUS.md as the canonical record and keeps the
+trust rule (human-originated for spec/design). Its signal table is re-expressed
+as work-item signals — "a trusted approval marker on a change" and "a change
+reaches `merged`" — and the matrix maps each to its realization: github reads
+the PR label/review/merge event (the `kata-dispatch` bridge, unchanged);
+filesystem reads the change file's `approval` field and `state: merged`. The
+benchmark exercises the filesystem realization directly, without webhooks. On
+filesystem the `approval` field records the granting signal; trust that the
+setter is authorized is out-of-band — the actor that runs `gate` is trusted by
+construction (the benchmark harness or a human). Emulating contributor-list
+trust offline is rejected as unverifiable without the forge.
+
+## Benchmark coordination task
+
+`coordinate-finding/` (named for its object, a finding, rather than the
+`-feature` suffix the rubric tasks use) follows the existing task structure —
+agent, judge, and supervisor task files, a workdir overlay, and the preflight
+and invariants hooks. Invoked with `--work-tracker filesystem`, the agent is given a finding
+and runs the loop: `create-issue`, `open-change` linking it, `gate` with a
+trusted signal, `merge-change`, networking unavailable. The invariants hook
+asserts on the resulting `.kata/` files — issue exists and is linked, change
+reached `state: merged`, `approval` recorded — using the same `assert` harness
+the rubric tasks (spec/design/plan) use.
+
+## Criteria coverage
+
+| Spec criterion | Satisfied by |
+| --- | --- |
+| 1 model + matrix + selection | `work-trackers.md`: model, matrix, env-var selection rule |
+| 2 forge commands only in github column | Matrix is the single command home; skills/references re-pointed |
+| 3 three references over operations | Re-pointed references component |
+| 4 `--work-tracker` flag + offline benchmark | libeval selection wiring; `coordinate-finding` runs `--work-tracker filesystem` |
+| 5 tracker-independent wording | Skills name operations; branching lives only in the matrix |
+| 6 coordination task asserts on files | `coordinate-finding` `invariants.sh` |
+| 7 resource reaches installations | Agent-references tree published with the pack |
+| 8 no leakage, clean install | Genericity invariant extended to the published references tree |
+
+Out of scope follows the spec unchanged: no work-item operations CLI (the matrix
+is the seam a later `fit-work` CLI adopts), no Jira/GitLab tracker, GitHub stays
+the default, `wiki/STATUS.md` and `kata-dispatch` mechanics untouched.

--- a/specs/2090-work-item-provider-abstraction/spec.md
+++ b/specs/2090-work-item-provider-abstraction/spec.md
@@ -1,4 +1,4 @@
-# Spec 2090: Work-Item Provider Abstraction
+# Spec 2090: Work-Item Tracker Abstraction
 
 ## Problem
 
@@ -46,83 +46,103 @@ half while it is GitHub-bound.
 
 Generalize the two GitHub nouns into one substrate-neutral concept, the **work
 item**, with two kinds and a shared envelope, then describe the GitHub binding
-as one of several interchangeable **providers** in a shared resource the kata-*
+as one of several interchangeable **trackers** in a shared resource the kata-*
 skills read. Skills and references name the abstract operation and point to the
-matrix; the matrix records the concrete commands per provider.
+matrix; the matrix records the concrete commands per tracker.
 
 Work-item model:
 
 | Concept | Generalizes | What it is |
 | --- | --- | --- |
-| **ticket** | GitHub issue | A tracked unit of work or finding (bug, feature, obstacle, experiment, RFC). |
-| **change** | GitHub pull request | A proposed diff carrying an approval gate. |
-| **envelope** | both | The capabilities every work item shares: stable identity, state, discussion, labels, and linkage to other items. Where a provider cannot express a capability, the matrix states how that capability degrades for it. |
+| **issue** | GitHub issue | A tracked unit of work or finding (bug, feature, obstacle, experiment, RFC). The noun is shared across GitHub, GitLab, and Jira. |
+| **change** | GitHub pull request | A proposed diff carrying an approval gate (GitHub pull request, GitLab merge request, Gerrit change). |
+| **envelope** | both | The capabilities every work item shares: stable identity, state, discussion, labels, and linkage to other items. Where a tracker cannot express a capability, the matrix states how that capability degrades for it. |
 
-Provider matrix — the shared resource mapping each abstract operation (create
-ticket, list, comment, open change, gate, merge) to the concrete commands per
-provider, plus how an installation selects its active provider:
+Tracker matrix — the shared resource mapping each abstract operation (create
+issue, list, comment, open change, gate, merge) to the concrete commands per
+tracker, plus how an installation selects its active tracker:
 
-| Provider | Role |
+| Tracker | Role |
 | --- | --- |
 | **github** | The current behaviour. Remains the default and production binding. |
-| **filesystem** | New. Tickets and changes live as files in the working tree, so coordination needs no network or remote forge. |
+| **filesystem** | New. Issues and changes live as files in the working tree, so coordination needs no network or remote forge. |
 | **jira**, **gitlab** | Future. Enabled by the seam; not built in this spec. |
+
+Active-tracker selection is a libeval harness concern. The harness reads one
+environment variable, `LIBEVAL_WORK_TRACKER` (default `github`), and
+`fit-eval` and `fit-benchmark` expose a `--work-tracker` option that sets it for
+the running harness — exactly as `--agent-profile` sets `LIBEVAL_AGENT_PROFILE`
+today. This selects which matrix column is live; it runs no work-item operation
+itself.
 
 ## Scope
 
 Affected entities:
 
-- A new shared resource defining the work-item model, the provider matrix, and
-  how the active provider is selected. It must ship to every installation that
-  consumes the kata-* skills, so a consuming team can add a provider (outcome 2);
+- A new shared resource defining the work-item model, the tracker matrix, and
+  how the active tracker is selected. It must ship to every installation that
+  consumes the kata-* skills, so a consuming team can add a tracker (outcome 2);
   which published surface hosts it is a design decision.
 - The work-type catalogue and routing in `work-definition.md` and
   `coordination-protocol.md`, re-expressed over work items rather than GitHub
   nouns.
 - The approval-signal vocabulary in `approval-signals.md`, generalized so a
-  "trusted signal" is expressible by any provider.
+  "trusted signal" is expressible by any tracker.
 - Every kata-* skill and shared reference that invokes `gh` for coordination
   (the full set is the grep result from § Problem, and includes the
   obstacle/experiment recipes in `kata-session`'s `issue-lifecycle.md`),
   re-pointed at the abstract operations.
+- **libeval** — the harness reads `LIBEVAL_WORK_TRACKER` and sets it on the
+  agent environment, mirroring its existing `LIBEVAL_AGENT_PROFILE` handling.
+- **`fit-eval` and `fit-benchmark`** — each gains a `--work-tracker` option that
+  sets `LIBEVAL_WORK_TRACKER` for the harness, with matching golden help.
 - The `kata-skills` benchmark family, which gains at least one end-to-end
-  coordination task graded against the filesystem provider.
+  coordination task graded against the filesystem tracker, selected via
+  `--work-tracker filesystem`.
+- The publishing surface and its genericity gate, so the shared resource and
+  the references reach installations: the publish workflow ships the agent
+  references, and the genericity invariant's scope covers them. Any reference
+  content this newly exposes is genericized to keep the gate green.
 
 Excluded:
 
-- **No CLI or library in this spec.** The abstraction ships as a shared
-  resource plus skill wording, and agents run provider-specific commands
-  directly. A `fit-work`-style CLI that wraps the same provider matrix behind
-  one verb set is a planned follow-up spec; the matrix here is designed as the
-  seam that CLI will adopt, not a throwaway.
+- **No work-item operations CLI or library.** The abstraction ships as a shared
+  resource plus skill wording, and agents run tracker-specific commands
+  directly. A `fit-work`-style CLI that wraps the matrix behind one verb set
+  (create / gate / merge) is a planned follow-up spec; the matrix here is
+  designed as the seam that CLI will adopt, not a throwaway. The
+  `--work-tracker` selection flag and `LIBEVAL_WORK_TRACKER` are **in** scope —
+  they select the active tracker (like `--agent-profile`) and perform no
+  work-item operation.
 - **No Jira or GitLab implementation.** This spec establishes the seam only.
 - **No change to GitHub as the production default.**
-- **No storage-format decision.** How the filesystem provider lays out its files
+- **No storage-format decision.** How the filesystem tracker lays out its files
   is left to the design.
 - `wiki/STATUS.md` and `kata-dispatch` keep their mechanics; only the
-  provider-specific signals they read (PR labels, comments, reviews, merge
+  tracker-specific signals they read (PR labels, comments, reviews, merge
   events) are re-expressed as work-item signals.
 
 ## Delivered Outcome
 
 The primary, accountable outcome is the **measurement seam**: end-to-end kata
-coordination becomes benchmarkable offline via the filesystem provider. The
+coordination becomes benchmarkable offline via the filesystem tracker. The
 genericization of the references and `gh`-invoking skills is the necessary means
 to it — a coordination task cannot be benchmarked offline unless the skills it
-exercises stop calling `gh` directly. Multi-forge portability (Jira, GitLab) is
-an enabled consequence of the same seam; building those providers is future
-work. A `fit-work` CLI over the matrix is a sequenced follow-up — the matrix is
-specified now so that CLI inherits a stable seam rather than reinventing one.
+exercises stop calling `gh` directly, and the harness can select the offline
+tracker. Multi-forge portability (Jira, GitLab) is an enabled consequence of the
+same seam; building those trackers is future work. A `fit-work` operations CLI
+over the matrix is a sequenced follow-up — the matrix is specified now so that
+CLI inherits a stable seam rather than reinventing one.
 
 ## Success Criteria
 
 | # | Criterion | Verified by |
 | --- | --- | --- |
-| 1 | A shared resource defines the work-item model (ticket, change, envelope) and a provider matrix listing the abstract operations with at least `github` and `filesystem` columns and a provider-selection rule. | The resource exists; it contains both columns, every listed operation, and the selection rule. |
+| 1 | A shared resource defines the work-item model (issue, change, envelope) and a tracker matrix listing the abstract operations with at least `github` and `filesystem` columns and a tracker-selection rule. | The resource exists; it contains both columns, every listed operation, and the selection rule. |
 | 2 | Commands that act on a forge's work items (issue, pull-request, discussion, review, label, and remote-git operations) appear in the kata-* skills and shared references only within the github column of the matrix. | Grep for those commands across the kata-* skills and shared references returns hits only inside the matrix. |
 | 3 | `work-definition.md`, `coordination-protocol.md`, and `approval-signals.md` express work-types, routing, and approval signals over work-item operations, with no GitHub-noun routing outside the matrix. | Review of the three references finds zero coordination instructions naming a GitHub primitive directly. |
-| 4 | The end-to-end coordination benchmark task completes under the filesystem provider with no network access and no remote forge. | The task runs to a verdict in the sandbox with networking unavailable. |
-| 5 | The abstract operation names the skills use are provider-independent; any provider-specific behaviour appears only in the matrix (including stated degradations per the envelope). | Skill and reference wording outside the matrix contains no provider-specific branching. |
+| 4 | `fit-eval` and `fit-benchmark` accept `--work-tracker`, which sets `LIBEVAL_WORK_TRACKER` on the harness; the end-to-end coordination benchmark task completes under `--work-tracker filesystem` with no network access and no remote forge. | The flag appears in each CLI's golden help; the task runs to a verdict in the sandbox with networking unavailable. |
+| 5 | The abstract operation names the skills use are tracker-independent; any tracker-specific behaviour appears only in the matrix (including stated degradations per the envelope). | Skill and reference wording outside the matrix contains no tracker-specific branching. |
 | 6 | The `kata-skills` benchmark family includes an end-to-end coordination task graded by invariants asserting on the resulting work-item files. | The task directory exists; its `invariants.sh` asserts on the work-item files. |
-| 7 | The shared resource reaches consuming installations along with the skills that cite it. | The resource resides on the surface that syncs to installations (the published skill pack), not a tree that stays in-repo. |
+| 7 | The shared resource reaches consuming installations along with the skills that cite it. | The resource resides on the surface that syncs to installations (the published pack), not a tree that stays in-repo. |
 | 8 | The new resource and skill edits introduce no monorepo leakage, and published skills still install cleanly into a fresh repository. | The skill-genericity invariant check passes. |


### PR DESCRIPTION
## Summary

- **design-b.md** — a simpler alternative to design-a that introduces **no new skill**. The work-item model and tracker matrix live as one reference on the agent-references surface (beside `coordination-protocol.md`), and tracker selection is wired into the libeval harness via `--work-tracker` / `LIBEVAL_WORK_TRACKER` (mirroring `--agent-profile`).
- **spec.md amended** — `provider`→`tracker`, `ticket`→`issue`; the `--work-tracker` selection flag and `LIBEVAL_WORK_TRACKER` brought into scope; the exclusion narrowed to the work-item *operations* CLI only.
- **design-a.md** — terminology aligned (`tracker`/`issue`, `KATA_WORK_TRACKER`); its fundamental design (the `kata-coordinate` skill, env-var selection) is unchanged.
- **Infra fixes** so the agent-references surface ships cleanly (APM installs agents + skills together): the genericity invariant now covers `.claude/agents/references/` and drops the stale "agents/ not shipped" link ban; `publish-skills.yml` ships the references subtree; `self-improvement.md` genericized (`bunx`→`npx`).

**Approved variant: design-b** is the selected design to be planned. `wiki/STATUS.md` records `2090 design approved`.

Reviewed by a clean 3-agent design panel (no blocker/high findings).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5bR42YaGsuBv7qYDUQPP1

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5bR42YaGsuBv7qYDUQPP1)_