### PR TITLE
plan(2090): work-item tracker abstraction (plan-b for design-b)

### DIFF
--- a/specs/2090-work-item-provider-abstraction/design-a.md
+++ b/specs/2090-work-item-provider-abstraction/design-a.md
@@ -15,7 +15,7 @@ flowchart TD
   SEL -->|github default| GH[github column<br/>gh CLI shapes]
   SEL -->|filesystem| FS[filesystem column<br/>file-write recipes]
   GH --> FORGE[(GitHub forge<br/>issues, PRs, discussions)]
-  FS --> TREE[(working tree<br/>.kata/ files)]
+  FS --> TREE[(working tree<br/>.tracker/ files)]
   MATRIX[tracker matrix<br/>operations × trackers] -.realizes.-> GH
   MATRIX -.realizes.-> FS
   BENCH[coordinate-finding benchmark task] -->|sets filesystem, no network| FS
@@ -25,7 +25,7 @@ flowchart TD
 A skill names a tracker-independent operation. The active tracker, chosen by
 one environment variable, selects which matrix column realizes it: the `github`
 column (existing `gh` shapes) or the `filesystem` column (file-write recipes
-against `.kata/`). The matrix is the single home for any forge-specific command.
+against `.tracker/`). The matrix is the single home for any forge-specific command.
 
 ## Components
 
@@ -34,10 +34,10 @@ against `.kata/`). The matrix is the single home for any forge-specific command.
 | **Work-item model** | new `kata-coordinate` skill | Defines issue, change, and the shared envelope plus the abstract operation vocabulary. |
 | **Tracker matrix** | a reference in `kata-coordinate` | Maps each operation to its `github` and `filesystem` realization; states per-tracker degradation and the selection rule. The only place forge commands appear. |
 | **github column** | matrix | Absorbs every forge command now outside it — the `gh` shapes in `coordination-protocol.md`, `issue-lifecycle.md`, `approval-signals.md`, and the kata-* skills, plus the remote-git operations (branch, push) the spec names — into one column (the spec's § Problem grep set bounds the file set). |
-| **filesystem column** | matrix | New. File-write recipes over the `.kata/` layout below. |
+| **filesystem column** | matrix | New. File-write recipes over the `.tracker/` layout below. |
 | **Re-pointed references** | `work-definition.md`, `coordination-protocol.md`, `approval-signals.md` | Re-expressed over operations: `work-definition.md`'s "Created via" and `coordination-protocol.md`'s routing name operations and move their `gh` shapes to the matrix; `approval-signals.md` generalizes its signal vocabulary, its one `gh` shape (`gh pr review --approve`) moving to the matrix github column. |
 | **Re-pointed skills** | the kata-* skills that call `gh` | Call sites replaced by an operation name + matrix link. |
-| **Benchmark task** | `benchmarks/kata-skills/tasks/coordinate-finding/` | End-to-end coordination graded by `invariants.sh` against `.kata/` files. |
+| **Benchmark task** | `benchmarks/kata-skills/tasks/coordinate-finding/` | End-to-end coordination graded by `invariants.sh` against `.tracker/` files. |
 
 ## Delivery and linkage
 
@@ -89,11 +89,11 @@ operations. Obstacle and experiment are issues distinguished by label, so
 
 ## Filesystem storage format
 
-A coordination root `.kata/` in the working tree, tracker-owned and disjoint
+A coordination root `.tracker/` in the working tree, tracker-owned and disjoint
 from app files:
 
 ```
-.kata/
+.tracker/
   issues/{id}.md      # envelope front-matter + body; ## Comments appended
   changes/{id}.md      # envelope (kind: change) + links to its issue(s)
   discussions/{id}.md  # RFC threads
@@ -112,6 +112,10 @@ tracker-minted monotonic ids, which would be non-deterministic and defeat
 path-based assertions. A change file carries only its envelope; the diff is the
 working tree at merge time, rather than a materialized patch object that
 duplicates the tree and adds an apply step the benchmark does not need.
+
+The root is named `.tracker/` — not a product- or methodology-specific name — so
+an agent reading the working tree infers it is the active tracker's store
+directly, without consulting the matrix.
 
 ## Tracker selection
 
@@ -143,7 +147,7 @@ and supervisor task files, a workdir overlay, and the preflight and invariants
 hooks. The agent is given a finding and runs the loop: `create-issue`,
 `open-change` linking it, `gate` with a trusted signal, `merge-change`, all under
 the filesystem tracker with networking unavailable. The invariants hook asserts
-on the resulting `.kata/` files — issue exists and is linked, change reached
+on the resulting `.tracker/` files — issue exists and is linked, change reached
 `state: merged`, `approval` recorded — using the same `assert` harness the other
 tasks use.
 

--- a/specs/2090-work-item-provider-abstraction/design-b.md
+++ b/specs/2090-work-item-provider-abstraction/design-b.md
@@ -61,7 +61,7 @@ flowchart TD
   SEL -->|github default| GH[github column<br/>gh CLI shapes]
   SEL -->|filesystem| FS[filesystem column<br/>file-write recipes]
   GH --> FORGE[(GitHub forge)]
-  FS --> TREE[(working tree<br/>.kata/ files)]
+  FS --> TREE[(working tree<br/>.tracker/ files)]
   MATRIX[work-trackers.md<br/>agents/references] -.realizes.-> GH
   MATRIX -.realizes.-> FS
   TREE -->|invariants.sh reads| VERDICT[pass/fail verdict]
@@ -77,12 +77,12 @@ commands.
 | --- | --- | --- |
 | **Work-item model + matrix** | new `.claude/agents/references/work-trackers.md` | One reference defining issue, change, the shared envelope, the abstract operation vocabulary, the `github`/`filesystem` columns, per-tracker degradation, and the selection rule. The only place forge commands appear. |
 | **github column** | inside `work-trackers.md` | Absorbs every forge command now outside it — the `gh` shapes in the coordination references, `issue-lifecycle.md`, and the kata-* skills, plus the remote-git operations (branch, push) the spec names. The § Problem grep set bounds the file set. |
-| **filesystem column** | inside `work-trackers.md` | New. File-write recipes over the `.kata/` layout below. |
+| **filesystem column** | inside `work-trackers.md` | New. File-write recipes over the `.tracker/` layout below. |
 | **Re-pointed references** | `work-definition.md`, `coordination-protocol.md`, `approval-signals.md` | Re-expressed over operations; their `gh` shapes move to the matrix; they cite it by directory-relative path. |
 | **Re-pointed skills** | the kata-* skills that call `gh` | Call sites replaced by an operation name + a relative matrix link, valid now that agents ship in the same pack. |
 | **Tracker selection** | libeval command layer + `fit-eval`/`fit-benchmark` | `--work-tracker` sets `LIBEVAL_WORK_TRACKER`; the harness forwards it to the agent, mirroring the existing `--agent-profile` → `LIBEVAL_AGENT_PROFILE` path. |
 | **Published surface + gate** | the publish workflow + the genericity invariant | Ship and gate the references tree (rationale in § Reaching installations). |
-| **Benchmark task** | `benchmarks/kata-skills/tasks/coordinate-finding/` | End-to-end coordination graded by `invariants.sh` against `.kata/` files. |
+| **Benchmark task** | `benchmarks/kata-skills/tasks/coordinate-finding/` | End-to-end coordination graded by `invariants.sh` against `.tracker/` files. |
 
 ## Work-item model
 
@@ -115,11 +115,11 @@ matrix rather than carrying `gh`.
 
 ## Filesystem storage format
 
-A coordination root `.kata/` in the working tree, tracker-owned and disjoint
+A coordination root `.tracker/` in the working tree, tracker-owned and disjoint
 from app files:
 
 ```
-.kata/
+.tracker/
   issues/{id}.md       # envelope front-matter + body; ## Comments appended
   changes/{id}.md      # envelope (kind: change) + links to its issue(s)
   discussions/{id}.md  # RFC threads
@@ -139,6 +139,10 @@ caller-supplied slugs (so a `{id}.md` path is the identity) rather than
 tracker-minted monotonic ids, which would be non-deterministic and defeat
 path-based assertions. A change file carries only its envelope; the changeset is
 the working tree, not a materialized patch that duplicates it.
+
+The root is named `.tracker/` — not a product- or methodology-specific name — so
+an agent reading the working tree infers it is the active tracker's store
+directly, without consulting the matrix.
 
 ## Tracker selection
 
@@ -174,7 +178,7 @@ agent, judge, and supervisor task files, a workdir overlay, and the preflight
 and invariants hooks. Invoked with `--work-tracker filesystem`, the agent is given a finding
 and runs the loop: `create-issue`, `open-change` linking it, `gate` with a
 trusted signal, `merge-change`, networking unavailable. The invariants hook
-asserts on the resulting `.kata/` files — issue exists and is linked, change
+asserts on the resulting `.tracker/` files — issue exists and is linked, change
 reached `state: merged`, `approval` recorded — using the same `assert` harness
 the rubric tasks (spec/design/plan) use.
 

--- a/specs/2090-work-item-provider-abstraction/plan-b-01.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-01.md
@@ -81,17 +81,17 @@ boundary.
 
 Verification: each shape uses placeholder repo forms; no `repos/forwardimpact/monorepo`.
 
-## Step 4 — The filesystem column, `.kata/` format, degradation
+## Step 4 — The filesystem column, `.tracker/` format, degradation
 
 Intent: give every operation an offline file-write realization and state where
 capabilities degrade.
 
 Files: modify `work-trackers.md`.
 
-Change: the `.kata/` layout —
+Change: the `.tracker/` layout —
 
 ```
-.kata/
+.tracker/
   issues/{id}.md       # envelope front-matter + body; ## Comments appended
   changes/{id}.md      # envelope (kind: change) + links to its issue(s)
   discussions/{id}.md  # RFC threads

--- a/specs/2090-work-item-provider-abstraction/plan-b-01.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-01.md
@@ -1,0 +1,112 @@
+# Plan 2090-b, Part 01: The tracker matrix reference
+
+Create `.claude/agents/references/work-trackers.md` — the single home for the
+work-item model and every forge command. This part has no dependencies and is
+the citation target for Parts 02, 03, and 05. Conventions and the scope boundary
+are in [plan-b.md](plan-b.md).
+
+Libraries used: none.
+
+## Step 1 — Skeleton, model, and selection rule
+
+Intent: stand up the file with the work-item model and how a tracker is chosen.
+
+Files: create `.claude/agents/references/work-trackers.md`.
+
+Change: front-matter (`# Work Trackers`) and an intro stating the file is the
+only place forge-specific commands appear; agents read the active column from
+`$LIBEVAL_WORK_TRACKER` (default `github`) and never branch on it elsewhere. Then
+the envelope table (carried as YAML front-matter on each item):
+
+| Field | Meaning | github | filesystem |
+| --- | --- | --- | --- |
+| `id` | stable identity | issue/PR number + URL | caller-supplied slug = repo-relative path |
+| `kind` | `issue` \| `change` | issue \| pull request | file under `issues/` \| `changes/` |
+| `state` | `open` \| `closed` \| `merged` | issue/PR state | front-matter value |
+| `labels` | classification incl. `agent:*` | issue/PR labels | front-matter list |
+| `links` | related work-item ids | issue refs | front-matter list |
+| `discussion` | comment thread | native issue/PR thread | appended `## Comments` section |
+| `approval` | change-only trusted gate | PR label/review by trusted human | front-matter value |
+
+Then the selection rule: one input, `LIBEVAL_WORK_TRACKER`, default `github`; set
+by the harness (`--work-tracker`), documented here, read by the agent to pick the
+column.
+
+Verification: file exists; contains the envelope table and the selection rule.
+
+## Step 2 — Abstract operation vocabulary
+
+Intent: enumerate the fixed operation set every tracker realizes.
+
+Files: modify `work-trackers.md`.
+
+Change: a list defining `create-issue`, `list`, `read`, `comment`, `label`,
+`link`, `open-change`, `update-change`, `gate`, `merge-change`, `close`,
+`create-discussion`, `comment-discussion`. State that `triage` (label + comment +
+close) and `patch` (open-change + merge-change) are compositions, not operations.
+One line each on intent, so a skill citing the name needs no other doc.
+
+Verification: every operation Parts 02/03 cite (per plan-b.md § Operation
+vocabulary) is present.
+
+## Step 3 — The github column
+
+Intent: absorb every in-scope forge command now living outside the matrix.
+
+Files: modify `work-trackers.md`.
+
+Change: an operation × `github` table whose cells carry the concrete `gh` /
+remote-git shapes relocated from the source files. Populate from the criterion-2
+in-scope set (plan-b.md § Scope boundary) across the coordination references,
+`issue-lifecycle.md`, and the kata-* skills. Cover at least:
+
+| Operation | github realization (shape, genericized to `repos/{owner}/{repo}`) |
+| --- | --- |
+| `create-issue` | `gh issue create …` |
+| `list` | `gh issue list …` / `gh pr list …` (incl. `--json` metric fields) |
+| `read` | `gh issue view …` / `gh pr view …` / `gh pr diff …` / `gh pr checks …` |
+| `comment` | `gh issue comment …` / `gh pr comment …` |
+| `label` | `gh issue edit --add-label …` / `gh label …` |
+| `link` | issue/PR cross-references |
+| `open-change` | `git switch -c <branch>` + `git push -u origin <branch>` + `gh pr create …` |
+| `update-change` | `git push --force-with-lease origin <branch>` |
+| `gate` | `gh pr review --approve` / approval label read |
+| `merge-change` | `gh pr merge …` |
+| `close` | `gh issue close …` / `gh pr close …` |
+| `create-discussion` / `comment-discussion` | `gh api graphql … addDiscussion* …` |
+
+Name (do not inline) the `kata-dispatch` reactor bridge that `kata-setup`
+generates as the github realization of discussion-event handling, per the scope
+boundary.
+
+Verification: each shape uses placeholder repo forms; no `repos/forwardimpact/monorepo`.
+
+## Step 4 — The filesystem column, `.kata/` format, degradation
+
+Intent: give every operation an offline file-write realization and state where
+capabilities degrade.
+
+Files: modify `work-trackers.md`.
+
+Change: the `.kata/` layout —
+
+```
+.kata/
+  issues/{id}.md       # envelope front-matter + body; ## Comments appended
+  changes/{id}.md      # envelope (kind: change) + links to its issue(s)
+  discussions/{id}.md  # RFC threads
+```
+
+— plus the operation × `filesystem` column: `create-*` writes the file from an
+envelope template; `list` globs + filters front-matter; `read` returns the file
+(reduced field set vs github `--json`); `comment` appends to `## Comments`;
+`label`/`link` edit front-matter; `gate` sets `approval`; `merge-change` sets
+`state: merged`; `open-change`/`update-change` remote-git steps degrade to no-ops
+(the changeset is the working tree at merge time). Include the issue and change
+envelope templates. End with a degradation note: filesystem `read`/`list` return
+a reduced field set; CI-status reads (`gh pr checks`) are github-only; trust that
+a `gate` setter is authorized is out-of-band (the actor is trusted by
+construction).
+
+Verification: every operation from Step 2 has both a github and a filesystem
+cell; `bun run check` (genericity gate) and `bun run check-skill-refs` pass.

--- a/specs/2090-work-item-provider-abstraction/plan-b-02.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-02.md
@@ -1,0 +1,67 @@
+# Plan 2090-b, Part 02: Re-point the coordination references
+
+Re-express the three shared coordination references and the session
+issue-lifecycle recipes over the abstract operations, moving their forge shapes
+into the matrix. Depends on Part 01. Conventions: [plan-b.md](plan-b.md).
+
+Libraries used: none.
+
+## Step 1 — `work-definition.md`
+
+Intent: name operations instead of GitHub actions in each work-type's "Created
+via".
+
+Files: modify `.claude/agents/references/work-definition.md`.
+
+Change: replace each "Created via" GitHub action (labeled issue, `gh` Discussion,
+direct git ops) with the operation that creates it (`create-issue` +
+label / `create-discussion` / `open-change`) and a link to `work-trackers.md`.
+No `gh` shape remains.
+
+Verification: no GitHub-noun routing in the file; the matrix link resolves.
+
+## Step 2 — `coordination-protocol.md`
+
+Intent: route outputs to operations and delete the inline `gh` CLI section.
+
+Files: modify `.claude/agents/references/coordination-protocol.md`.
+
+Change: re-express the routing (Issue, PR/issue comment, Discussion) as
+operations (`create-issue`, `comment`, `create-discussion`/`comment-discussion`,
+`open-change`); remove the `gh` CLI section, replacing it with one pointer to
+`work-trackers.md` as the home for concrete commands. Keep the named-receiver +
+addressable-artifact rule, expressed over work items.
+
+Verification: no `gh` shape remains in the file; criterion-3 grep finds zero
+GitHub primitives named directly.
+
+## Step 3 — `approval-signals.md`
+
+Intent: generalize the approval vocabulary; keep STATUS.md canonical and the
+human-trust rule.
+
+Files: modify `.claude/agents/references/approval-signals.md`.
+
+Change: re-express the signal table as work-item signals — "a trusted approval
+marker on a change" (`gate`) and "a change reaches `merged`" (`merge-change`) —
+and point each realization to the matrix (github: PR label/review/merge event,
+the `kata-dispatch` bridge unchanged; filesystem: `approval` field + `state:
+merged`). Move the one `gh pr review --approve` shape to the matrix github
+column. Keep STATUS.md as the canonical record and the human-originated trust
+rule for spec/design.
+
+Verification: no `gh` shape remains; STATUS.md mechanics and the trust rule are
+unchanged in substance.
+
+## Step 4 — `issue-lifecycle.md`
+
+Intent: turn the obstacle/experiment recipes into operation recipes.
+
+Files: modify `.claude/skills/kata-session/references/issue-lifecycle.md`.
+
+Change: replace the six `gh issue` shapes (list/create/comment/close) with
+`list` / `create-issue` (label `obstacle`/`experiment`) / `comment` / `close`
+recipes that point at `work-trackers.md`. Obstacle and experiment stay issues
+distinguished by label.
+
+Verification: no `gh` shape remains; the recipes name only matrix operations.

--- a/specs/2090-work-item-provider-abstraction/plan-b-03.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-03.md
@@ -1,0 +1,101 @@
+# Plan 2090-b, Part 03: Re-point the kata-* skills
+
+Replace every in-scope forge call-site in the kata-* skills and their references
+with an operation name plus a link to `work-trackers.md`. Depends on Part 01.
+Scope boundary (what counts, and the `kata-setup` exclusion) is in
+[plan-b.md](plan-b.md) § Scope boundary. Conventions: [plan-b.md](plan-b.md).
+
+Libraries used: none.
+
+Each step replaces the file's in-scope `gh`/remote-git shapes with operation
+names + `../../agents/references/work-trackers.md`, leaving out-of-scope commands
+(`gh secret`, `gh run`, `git fetch origin main`, tag/wiki pushes, commit-SHA
+verification) untouched. The github realization of each removed shape must
+already exist in the matrix github column (Part 01, Step 3); add any missing
+shape there.
+
+## Step 1 — `kata-release-merge`
+
+Files: modify `SKILL.md`, `references/templates.md`, `references/reping-rule.md`,
+`references/comment-gate.md`, `references/announcement-backstop.md`.
+
+Change: `gh pr comment/view/merge/checks/close`, `gh issue comment/view`,
+`gh api repos/.../pulls` → `comment` / `read` / `merge-change` / `close` / `list`;
+`git push --force-with-lease origin <pr-branch>` (rebase) → `update-change`. Keep
+`gh api repos/.../actions` and `gh run list` (CI introspection) and
+`git fetch origin main`.
+
+Verification: criterion-2 grep over these files returns zero hits.
+
+## Step 2 — `kata-security-update`
+
+Files: modify `SKILL.md` (and `references/metrics.md` via Step 6).
+
+Change: `gh pr create/merge/close/comment`, `gh pr view/diff/list` →
+`open-change` / `merge-change` / `close` / `comment` / `read` / `list`;
+`git checkout -b … origin/<branch>` + `git push -u origin …` → `open-change`;
+route `gh api .../pulls|issues` reads through `list`/`read`. Leave security
+advisory / Dependabot-alert `gh api` reads and CI-run reads in place — they are
+outside the criterion-2 set.
+
+Verification: criterion-2 grep over `SKILL.md` returns zero hits.
+
+## Step 3 — `kata-product-issue`
+
+Files: modify `SKILL.md`, `references/templates.md`, `references/trace-discovery.md`.
+
+Change: `gh issue *` → `create-issue` / `comment` / `label` / `close` / `read`;
+`git checkout -b <fix|spec>/issue-… && git push -u origin …` → `open-change`.
+
+Verification: criterion-2 grep over these files returns zero hits.
+
+## Step 4 — `kata-implement`, `kata-backlog-synthesis`, `kata-documentation`, `kata-wiki-curate`
+
+Files: modify each skill's `SKILL.md`.
+
+Change: `gh pr/issue *` → the matching operation; `git push -u origin <branch>`
+(documentation) → `open-change`. Leave `kata-wiki-curate`'s
+`git push origin HEAD:master` (wiki memory) in place per the boundary.
+
+Verification: criterion-2 grep over these files returns hits only for the
+retained wiki/tag pushes (out of scope).
+
+## Step 5 — `kata-release-cut`
+
+Files: modify `SKILL.md`, `references/procedure.md`.
+
+Change: keep all release-tag pushes (`git push origin <prefix>@v<version>`, the
+`--tags` prohibition), `gh api .../tags`, and `gh release list` — release tags
+and releases are not work items. These files carry no in-scope `gh pr/issue`
+shape today, so this step is a confirm-and-retain pass; relocate any that a grep
+surfaces.
+
+Verification: only release-tag/release pushes and reads remain; no `gh pr/issue`
+shape outside the matrix.
+
+## Step 6 — Metric-grade forge reads
+
+Files: modify the `references/metrics.md` of `kata-spec`, `kata-design`,
+`kata-plan`, `kata-implement`, `kata-interview`, `kata-product-issue`,
+`kata-security-update`, `kata-release-merge`. These are the eight whose
+`metrics.md` carry an in-scope read (`gh pr list`, `gh issue list`, or
+`gh api .../{pulls,issues}`). Skip `kata-security-audit` (only `gh alerts`) and
+`kata-release-cut` (only `gh run`/tag reads) — confirm per file with the
+criterion-2 grep before editing; a file with no in-scope hit needs no change.
+
+Change: `gh pr list`, `gh issue list`, `gh api repos/.../pulls|issues` (metric
+queries) → `list` / `read` operations + matrix link; the rich `gh … --json …`
+field shapes move to the matrix github column under `list`/`read` (added in
+Part 01 Step 3, which is a hard precondition for this step). Keep `gh run list`
+and `gh api .../actions` (CI runs, not work items).
+
+Verification: criterion-2 grep over all `metrics.md` returns zero `gh pr`/`gh
+issue`/`gh api .../{pulls,issues}` hits.
+
+## Final verification
+
+`bun run check`, `bun run test`, and `bun run check-skill-refs` pass; the
+criterion-2 grep (issue/pr/discussion/review/label/change-materialization)
+across the kata-* skills and shared references — excluding `kata-setup/` and
+`citation-integrity.md` per the boundary — returns hits only inside
+`work-trackers.md`.

--- a/specs/2090-work-item-provider-abstraction/plan-b-04.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-04.md
@@ -1,0 +1,84 @@
+# Plan 2090-b, Part 04: Harness tracker selection
+
+Add `--work-tracker` to `fit-eval` and `fit-benchmark`, setting
+`LIBEVAL_WORK_TRACKER` on the agent environment, mirroring the existing
+`--agent-profile` → `LIBEVAL_AGENT_PROFILE` path. No dependency on Parts 01–03.
+Conventions: [plan-b.md](plan-b.md).
+
+Libraries used: libeval (run, supervise, benchmark-run, benchmark-definition),
+libcli (option definitions), libutil (runtime). Tests use libmock.
+
+## Step 1 — Set the env var on the `fit-eval` agent-running commands
+
+Intent: realize the selection at every site that already sets
+`LIBEVAL_AGENT_PROFILE` on the harness env.
+
+Files: modify `libraries/libeval/src/commands/run.js`,
+`libraries/libeval/src/commands/supervise.js`,
+`libraries/libeval/src/commands/discuss.js`,
+`libraries/libeval/src/commands/facilitate.js`.
+
+Change: parse `--work-tracker` (resolving to `"github"` when absent) in each
+option parser, then **unconditionally** set `runtime.proc.env.LIBEVAL_WORK_TRACKER
+= workTracker` **after the closing `}` of** the `if (…Profile)` block that holds
+the existing `LIBEVAL_AGENT_PROFILE` write (run.js:108-110, supervise.js:100-102,
+discuss.js:95-97, facilitate.js:91-93). Do **not** place it inside that block or
+copy the conditional guard — the write must always land so the default `"github"`
+is observable. The redaction env snapshot already freezes
+before these writes (run.js:64-67); keep the new write after it.
+
+Verification: a unit test sets `--work-tracker filesystem` and asserts
+`runtime.proc.env.LIBEVAL_WORK_TRACKER === "filesystem"`; with the flag absent
+the same env var reads `"github"`.
+
+## Step 2 — Set the env var on the `fit-benchmark` run path
+
+Intent: the benchmark agent never goes through `runSuperviseCommand` — it runs
+via `createBenchmarkRunner` — so the Step 1 writes do not cover it; the write
+must land in the benchmark command itself.
+
+Files: modify `libraries/libeval/src/commands/benchmark-run.js`.
+
+Change: add `workTracker` (default `"github"`) to `parseRunOptions`'s return
+(benchmark-run.js:50-76), then in `runBenchmarkRunCommand` set
+`runtime.proc.env.LIBEVAL_WORK_TRACKER = opts.workTracker` alongside the existing
+`runtime.proc.env.ANTHROPIC_API_KEY` write (benchmark-run.js:30-37), **before**
+`createBenchmarkRunner` so the spawned agent subprocess inherits it. This is the
+write criterion 4's offline filesystem run depends on.
+
+Verification: a unit test asserts `LIBEVAL_WORK_TRACKER` is set from
+`--work-tracker` before the runner starts.
+
+## Step 3 — Declare the option on both CLIs
+
+Intent: expose `--work-tracker` on every command whose handler now reads it.
+
+Files: modify `libraries/libeval/bin/fit-eval.js`,
+`libraries/libeval/src/commands/benchmark-definition.js`.
+
+Change: add `"work-tracker": { type: "string", description: "Active work-item
+tracker (github|filesystem, default: github)" }` to the `run`, `supervise`,
+`discuss`, and `facilitate` command `options` in `fit-eval.js`, and to the `run`
+command `options` in `benchmark-definition.js` (the declarer; benchmark-run.js
+Step 2 is the consumer). Add one `examples` entry per CLI using
+`--work-tracker=filesystem` so it renders in the captured top-level help.
+
+Verification: `node libraries/libeval/bin/fit-eval.js run --help` and
+`node libraries/libeval/bin/fit-benchmark.js run --help` each show the option.
+
+## Step 4 — Golden help and tests
+
+Intent: lock the flag into golden help (criterion 4) and cover the env wiring.
+
+Files: modify `libraries/libeval/test/golden/fit-eval/help.stdout.txt`,
+`libraries/libeval/test/golden/fit-benchmark/help.stdout.txt`, and the
+respective `cases.json`; add/extend unit tests under `libraries/libeval/test/`
+for the env writes (Steps 1-2).
+
+Change: regenerate the two `help.stdout.txt` to include the new example lines;
+add a `run --help` golden case to each `cases.json` (capturing the `--work-tracker`
+option text), since current cases cover only top-level `--help`. Add the env
+assertions from Steps 1-2.
+
+Verification: `bun run test` (golden + unit) passes; `--work-tracker` appears in
+each CLI's golden help output.

--- a/specs/2090-work-item-provider-abstraction/plan-b-05.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-05.md
@@ -1,7 +1,7 @@
 # Plan 2090-b, Part 05: The coordination benchmark task
 
 Add `coordinate-finding/` to the `kata-skills` benchmark family: an end-to-end
-file → open-change → gate → merge loop graded offline against `.kata/` files.
+file → open-change → gate → merge loop graded offline against `.tracker/` files.
 Depends on Part 01 (operation names) and Part 04 (`--work-tracker`). Conventions:
 [plan-b.md](plan-b.md).
 
@@ -34,7 +34,7 @@ Intent: seed the finding input and a clean coordination root.
 Files: create `benchmarks/kata-skills/tasks/coordinate-finding/workdir/finding.md`
 (and any seed the agent reads).
 
-Change: a short finding brief the agent files. No pre-existing `.kata/` (the
+Change: a short finding brief the agent files. No pre-existing `.tracker/` (the
 agent creates it); no app/network seed required.
 
 Verification: `workdir/` materializes; no remote or network dependency.
@@ -45,9 +45,9 @@ Intent: smoke-check preconditions and assert on the resulting files.
 
 Files: create `hooks/preflight.sh` and `hooks/invariants.sh`.
 
-Change: `preflight.sh` confirms the workdir is sane and `.kata/` is absent at
+Change: `preflight.sh` confirms the workdir is sane and `.tracker/` is absent at
 start. `invariants.sh` uses the `fit-trace assert` harness (as
-`spec-feature/hooks/invariants.sh` does) against `$WORKDIR/cwd/.kata/`:
+`spec-feature/hooks/invariants.sh` does) against `$WORKDIR/cwd/.tracker/`:
 
 - `file-present` — an `issues/*.md` exists,
 - the change `links` back to that issue,
@@ -55,7 +55,7 @@ start. `invariants.sh` uses the `fit-trace assert` harness (as
 - `approval` is recorded on the change.
 
 Verification:
-`fit-benchmark invariants --family=benchmarks/kata-skills --task=coordinate-finding --workdir=<hand-authored .kata fixture>`
+`fit-benchmark invariants --family=benchmarks/kata-skills --task=coordinate-finding --workdir=<hand-authored .tracker fixture>`
 passes on a correct fixture and fails on one missing `state: merged`.
 
 ## Step 4 — Family wiring and offline run

--- a/specs/2090-work-item-provider-abstraction/plan-b-05.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-05.md
@@ -1,0 +1,76 @@
+# Plan 2090-b, Part 05: The coordination benchmark task
+
+Add `coordinate-finding/` to the `kata-skills` benchmark family: an end-to-end
+file → open-change → gate → merge loop graded offline against `.kata/` files.
+Depends on Part 01 (operation names) and Part 04 (`--work-tracker`). Conventions:
+[plan-b.md](plan-b.md).
+
+Libraries used: fit-trace (the `assert` harness in `invariants.sh`).
+
+Model the structure on `benchmarks/kata-skills/tasks/spec-feature/` (agent /
+judge / supervisor task files, a `workdir/` overlay, `hooks/preflight.sh`,
+`hooks/invariants.sh`).
+
+## Step 1 — Task files
+
+Intent: give the agent a finding and the coordination loop to run.
+
+Files: create `benchmarks/kata-skills/tasks/coordinate-finding/agent.task.md`,
+`judge.task.md`, `supervisor.task.md`.
+
+Change: `agent.task.md` hands the agent a finding and instructs it to run the
+loop using the abstract operations — `create-issue` (the finding),
+`open-change` (linking the issue), `gate` (trusted signal), `merge-change` —
+resolving each through `work-trackers.md` under the active tracker, with
+networking unavailable. `supervisor.task.md` and `judge.task.md` mirror the
+rubric tasks' relay/grade shape.
+
+Verification: the three files exist and name only matrix operations (no `gh`).
+
+## Step 2 — Workdir overlay
+
+Intent: seed the finding input and a clean coordination root.
+
+Files: create `benchmarks/kata-skills/tasks/coordinate-finding/workdir/finding.md`
+(and any seed the agent reads).
+
+Change: a short finding brief the agent files. No pre-existing `.kata/` (the
+agent creates it); no app/network seed required.
+
+Verification: `workdir/` materializes; no remote or network dependency.
+
+## Step 3 — Hooks
+
+Intent: smoke-check preconditions and assert on the resulting files.
+
+Files: create `hooks/preflight.sh` and `hooks/invariants.sh`.
+
+Change: `preflight.sh` confirms the workdir is sane and `.kata/` is absent at
+start. `invariants.sh` uses the `fit-trace assert` harness (as
+`spec-feature/hooks/invariants.sh` does) against `$WORKDIR/cwd/.kata/`:
+
+- `file-present` — an `issues/*.md` exists,
+- the change `links` back to that issue,
+- `changes/*.md` has `state: merged`,
+- `approval` is recorded on the change.
+
+Verification:
+`fit-benchmark invariants --family=benchmarks/kata-skills --task=coordinate-finding --workdir=<hand-authored .kata fixture>`
+passes on a correct fixture and fails on one missing `state: merged`.
+
+## Step 4 — Family wiring and offline run
+
+Intent: confirm the task is discovered and runs offline under the filesystem
+tracker.
+
+Files: none expected — tasks are auto-discovered under `tasks/`;
+`benchmarks/kata-skills/apm.yml` is unchanged. Confirm no rubric task or hook
+reads `LIBEVAL_WORK_TRACKER` (plan-b.md Risks).
+
+Change: document the invocation —
+`fit-benchmark run --family=benchmarks/kata-skills --work-tracker=filesystem` —
+and that production runs leave the default `github`.
+
+Verification (criterion 4): the full loop — not just the `invariants` subcommand
+of Step 3 — runs to a pass/fail verdict in the sandbox with networking
+unavailable under `--work-tracker=filesystem`; the rubric tasks are unaffected.

--- a/specs/2090-work-item-provider-abstraction/plan-b.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b.md
@@ -1,0 +1,122 @@
+# Plan 2090-b: Work-Item Tracker Abstraction
+
+Implements [design-b.md](design-b.md), the variant selected for planning when
+that design merged ([PR #1785](https://github.com/forwardimpact/monorepo/pull/1785)).
+It is lettered **b** to mirror its design; it is the plan to implement for spec
+2090. [design-a.md](design-a.md) (the `kata-coordinate` skill) stays on record as
+the rejected alternative. Spec, criteria, and exclusions: [spec.md](spec.md).
+
+## Approach
+
+Build the tracker matrix as one new agent reference, re-point every in-scope
+forge call-site at the abstract operation it now names, wire `--work-tracker`
+into the libeval harness the way `--agent-profile` is already wired, and add an
+offline coordination benchmark task that the harness drives under the filesystem
+tracker. The publish workflow, genericity gate, and `self-improvement.md`
+genericization that design-b also names are **already on `main`** (they merged
+inside the design PR — `git show 9dfd22a --stat`); this plan builds on them and
+verifies they stay green rather than reapplying them.
+
+## Already landed (do not redo; verify)
+
+| Surface | State on `main` | This plan's obligation |
+| --- | --- | --- |
+| `.github/workflows/publish-skills.yml` | Ships `.claude/agents/references/**` in the kata pack's *Sync agents* step | New `work-trackers.md` lands under that tree, so it publishes automatically — no workflow edit |
+| `.coaligned/invariants/skill-genericity.rules.mjs` | Scope covers `.claude/agents/references/**`; stale `agents/` link ban removed | All new/edited reference + skill content must pass this gate (Cross-cutting § Genericity) |
+| `.claude/agents/references/self-improvement.md` | `bunx`→`npx` | None |
+
+## Cross-cutting
+
+### Scope boundary (the criterion-2 set)
+
+Criterion 2 is a mechanical grep. Parts 01–03 are correct only against one fixed
+definition of "commands that act on a forge's work item". This table is that
+definition; every part references it rather than re-deriving it.
+
+| Class | In scope — relocate to matrix github column | Out of scope — stays in place |
+| --- | --- | --- |
+| `gh issue *` | all (create, list, view, comment, close, edit/label) | — |
+| `gh pr *` | all (create, view, list, comment, merge, close, checks, diff, review) | — |
+| `gh api` | `.../issues*`, `.../pulls*`, `graphql` discussion mutations (`addDiscussion*`) | `.../commits*` (SHA verification), `.../tags`, `.../actions`, secrets |
+| `gh` other | `gh label *`, `gh ... review` | `gh secret *`, `gh workflow run`, `gh run *` (CI-run introspection) |
+| remote git | change materialization: `git switch -c` / `git checkout -b` of a change branch + `git push`/`--force-with-lease` of that branch | `git fetch origin main` (canonical-state/STATUS read), `git push origin <tag>` (release), `git push … HEAD:master` (wiki memory) |
+
+**Excluded surface — `kata-setup`.** `kata-setup` provisions the GitHub tracker
+itself (App, secrets, dispatch reactor, workflow files); its embedded `gh api`
+calls — including the `addDiscussionComment` graphql in generated reactor YAML —
+are the github tracker's own wiring, not portable coordination an agent performs.
+There is no filesystem-tracker equivalent to provision. The matrix's github
+column **names** the dispatch bridge (citing `kata-setup`) rather than relocating
+the generated YAML into the matrix. The criterion-2 verification grep therefore
+runs over the kata-* skills and shared references **excluding `kata-setup/`** and
+`citation-integrity.md` (commit verification). This boundary is the plan's main
+judgment call — see Risks.
+
+### Operation vocabulary
+
+The matrix (Part 01) defines these; every other part may only use these names.
+`create-issue`, `list` (issues or changes), `read` (one item), `comment`,
+`label`, `link`, `open-change`, `update-change`, `gate`, `merge-change`, `close`,
+`create-discussion`, `comment-discussion`. `triage` = label + comment + close;
+`patch` = open-change + merge-change (compositions, not operations). `read` and
+`list` cover the metric-grade forge queries (`gh pr list`, `gh pr view/diff`,
+`gh issue view`); their rich github realizations live in the matrix and degrade
+on filesystem to front-matter globs.
+
+### Active-tracker resolution
+
+Skills never branch on the tracker. The matrix instructs the agent to read the
+active column from `$LIBEVAL_WORK_TRACKER` (default `github`) and realize each
+operation through that column. The harness (Part 04) sets that env var; the agent
+resolves the column.
+
+### Genericity
+
+New and edited pack content (`work-trackers.md`, the three references,
+`issue-lifecycle.md`, the kata-* skills) must pass
+`.coaligned/invariants/skill-genericity.rules.mjs`: no `bunx`/`bun run`/`just`,
+no `@forwardimpact/…`, no hardcoded dates or `repos/forwardimpact/monorepo`, no
+monorepo issue/PR links. Use placeholder forms (`repos/{owner}/{repo}`,
+`{YYYY}`). Cross-pack links use `../../agents/references/work-trackers.md` from a
+skill (resolves identically in monorepo and pack) and `work-trackers.md` from a
+sibling reference.
+
+## Parts
+
+| Part | Scope | Depends on |
+| --- | --- | --- |
+| [01](plan-b-01.md) | New `work-trackers.md`: model, operations, github + filesystem columns, selection, degradation | — |
+| [02](plan-b-02.md) | Re-point `work-definition.md`, `coordination-protocol.md`, `approval-signals.md`, `issue-lifecycle.md` | 01 |
+| [03](plan-b-03.md) | Re-point the kata-* skills and their references (incl. metrics reads) | 01 |
+| [04](plan-b-04.md) | libeval `--work-tracker` / `LIBEVAL_WORK_TRACKER` on `fit-eval` + `fit-benchmark` | — |
+| [05](plan-b-05.md) | `coordinate-finding` benchmark task | 01, 04 |
+
+## Execution
+
+Route every part to an engineering agent (`staff-engineer`); the re-pointing is
+coordination-semantics work, not docs-site prose, so not `technical-writer`.
+Part 01 runs first and alone — it is the citation target for 02, 03, 05. Once 01
+lands, **02, 03, and 04 run in parallel** (disjoint files). **05 runs last**, after
+01 (operation names) and 04 (the `--work-tracker` flag it is invoked with). Run
+`bun run check` and `bun run test` after each part; run `bun run check-skill-refs`
+after 01–03.
+
+## Risks
+
+- **Criterion-2 boundary is a judgment call.** The Scope-boundary table excludes
+  `kata-setup` and `citation-integrity.md`. If the approver wants the
+  `kata-setup` discussion-reply relocated, Part 03 and the matrix grow and the
+  generated-reactor YAML needs a github-only carve-out. Confirm the boundary at
+  approval.
+- **Benchmark runs the whole family under `--work-tracker filesystem`.** The
+  rubric tasks (spec/design/plan/implement) must be inert under it. They never
+  read `LIBEVAL_WORK_TRACKER`, so they are — verify no rubric task or its hooks
+  reference the var (Part 05).
+- **Matrix link resolution under `check-skill-refs`.** The lint runs in the
+  publish workflow against the pack layout. `../../agents/references/…` resolves
+  there, but verify with `bun run check-skill-refs` before push (Parts 01, 03).
+- **Read/metric operations carry github-only richness.** `gh pr list --json …`
+  field sets have no filesystem analogue; the matrix must state the degradation
+  (front-matter globs return a reduced field set) so criterion 5 holds.
+
+Libraries used: none (this overview).


### PR DESCRIPTION
## Summary

Execution-ready plan implementing **[design-b](https://github.com/forwardimpact/monorepo/blob/main/specs/2090-work-item-provider-abstraction/design-b.md)** — the variant selected for planning when that design merged (#1785). Lettered **b** to mirror its design; design-a (the `kata-coordinate` skill) stays on record as the rejected alternative.

Decomposed into an overview + 5 independently executable parts:

| Part | Scope | Depends on |
| --- | --- | --- |
| `plan-b.md` | Overview: approach, the criterion-2 scope boundary, operation vocabulary, part index, execution, risks | — |
| `plan-b-01.md` | New `.claude/agents/references/work-trackers.md` — model, operations, github + filesystem columns, selection, degradation | — |
| `plan-b-02.md` | Re-point `work-definition.md`, `coordination-protocol.md`, `approval-signals.md`, `issue-lifecycle.md` | 01 |
| `plan-b-03.md` | Re-point the kata-* skills and their references (incl. metric reads) | 01 |
| `plan-b-04.md` | libeval `--work-tracker` / `LIBEVAL_WORK_TRACKER` on `fit-eval` + `fit-benchmark` | — |
| `plan-b-05.md` | `coordinate-finding` offline benchmark task | 01, 04 |

## Notes for the approver

- **Builds on already-merged infra.** design-b's publish-workflow, genericity-invariant, and `self-improvement.md` changes landed inside the design PR (commit `9dfd22a`); the plan verifies rather than re-applies them.
- **Main judgment call — the criterion-2 boundary.** The plan fixes one mechanical definition of "commands that act on a forge's work item" (issue/pr/discussion/review/label/change-materialization), includes metric-grade forge reads, and **excludes `kata-setup`** (it provisions the GitHub tracker itself) and `citation-integrity.md` (commit-SHA verification). This is flagged in Risks and warrants an explicit approver nod.
- **Execution:** route every part to an engineering agent. 01 first (citation target); then 02/03/04 in parallel (disjoint files); 05 last.

## Review

Clean 3-agent technical panel (no blocker/high/medium on consensus). Verified findings addressed in the same session: Part 03's metrics list narrowed to the eight files with in-scope reads; Part 04's libeval wiring corrected to cover `run`/`supervise`/`discuss`/`facilitate` plus the separate `benchmark-run` path with an unconditional env write. A focused re-panel confirmed both fixes against the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgFMdfP8KfcVrHCaN7Gunw)_