### PR TITLE
feat(kata): product-vs-internal work axis with routing bias and mix metric (#2070)

### DIFF
--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -45,6 +45,8 @@ Before any task — handed or self-picked — `Read wiki/MEMORY.md`, then
 _Skip when handed a specific task._ Survey all open work items, then act on
 the highest-priority bucket:
 
+Emit the product mix: `npx fit-wiki product-mix` (the next `fit-wiki refresh` renders its storyboard block).
+
 1. **Survey.** `gh pr list --search 'spec(' --state open` +
    `gh issue list --search "-label:experiment -label:obstacle"` +
    `wiki/STATUS.md`. Buckets: **P1** open spec PRs whose STATUS row is still
@@ -58,15 +60,13 @@ the highest-priority bucket:
 
 ### Constraints
 
-- **Users**: [JTBD.md](JTBD.md) — know which persona and job every issue and
-  spec serves.
+- **Users**: [JTBD.md](JTBD.md) — know which persona/job each issue and spec serves.
 - Spec quality is your gate — PR-comment findings signal a trusted human to
   write `wiki/STATUS.md`. Never apply `spec:approved`; never write STATUS.
-- Never make code changes on PR branches (release-engineer scope) — only on your
-  own `fix/` branches from issues.
+- Never change code on PR branches (release-engineer scope) — only your own `fix/` branches.
 - **Memory**: [memory-protocol.md](.claude/agents/references/memory-protocol.md)
   — files: `wiki/product-manager.md`, `wiki/product-manager-$(date +%G-W%V).md`
 - **Coordination**: [coordination-protocol.md](.claude/agents/references/coordination-protocol.md)
   — channels: Issues, Discussions, PR/issue comments, `kata-dispatch`
-- **Citation integrity**: in Assess/memory writes, every cited SHA must resolve on its referenced repo or the body is not published — [§ Citation integrity](.claude/agents/references/citation-integrity.md).
+- **Citation integrity**: every cited SHA must resolve on its repo or the body is not published — [§ Citation integrity](.claude/agents/references/citation-integrity.md).
 - **Auth anomalies**: [auth-anomaly.md](.claude/agents/references/auth-anomaly.md)

--- a/.claude/agents/references/memory-protocol.md
+++ b/.claude/agents/references/memory-protocol.md
@@ -1,8 +1,7 @@
 # Memory Protocol
 
 Governs **agent memory and action routing** via the `fit-wiki` CLI. Every
-contract below maps to `fit-wiki` subcommands — the CLI is the path, not an
-alternative. For non-wiki outputs see
+contract below maps to a `fit-wiki` subcommand. For non-wiki outputs see
 [coordination-protocol.md](coordination-protocol.md).
 
 ## On-Boot Read Set
@@ -15,15 +14,14 @@ Three Tier 1 surfaces, all in `wiki/`:
 | Cross-cutting memory | `wiki/MEMORY.md` | direct `Read` + `fit-wiki boot` |
 | Current storyboard | `wiki/storyboard-YYYY-MNN.md` | `fit-wiki boot` (slice) |
 
-Every agent-scoped `fit-wiki` invocation requires explicit `--agent <self>`
+Every agent-scoped `fit-wiki` call requires explicit `--agent <self>`
 (`--from <self>` for `memo`), no environment fallback; `release --expired` is
 the lone agent-less form.
 
 **Step 0 contract — two tool calls within the first ten:**
 
 1. `Read wiki/MEMORY.md` — the priority surface and `## Active Claims`.
-2. `Bash: fit-wiki boot --agent <self>` — JSON digest of the other Tier 1
-   surfaces (`--format markdown` for prose).
+2. `Bash: fit-wiki boot --agent <self>` — JSON digest of the other Tier 1 surfaces (`--format markdown` for prose).
 
 ## On-Boot Routing
 
@@ -38,15 +36,24 @@ actionable work wins:
 4. **Cross-cutting fallback** (`cross_cutting[]`) — rows listing you under
    `Agents` (not Owner). Report clean only after checking all four.
 
-**Skip-self rule:** treat your own `claims[]` row as preempting routing — the
-work is in flight. Other agents' claims are settled state. The `### Decision`
-block records which level produced the chosen action.
+**Skip-self rule:** treat your own `claims[]` row as preempting routing — work
+in flight; other agents' claims are settled state. The `### Decision` block
+records which level produced the chosen action.
+
+**Product-priority tie-break:** among candidates tying *within* a level (levels
+stay strictly ordered — an owned priority still preempts all below),
+product-aligned work outranks internal. **Exception:** internal work lifting a
+constraint that currently blocks product delivery keeps its place, buying
+product throughput. The bias is a default, not a quota — it never overrides an
+owned priority or active claim, nor forbids internal work. When the tie was
+product-vs-internal, the `### Decision` entry names the chosen
+[axis value](work-definition.md#product-aligned-vs-internal) and, if internal
+won, the constraint it lifts.
 
 ## Tool-vs-Memory Habit
 
-When the next answer can come from either memory or `gh`/`git`/source
-re-derivation, **prefer memory** — every primitive is calibrated to cost fewer
-tool calls than the alternative.
+Prefer memory over re-deriving from `gh`/`git`/source — primitives cost fewer
+tool calls.
 
 ## During Each Run
 
@@ -63,31 +70,28 @@ seals the current file as `…-Www-partN.md` and opens a fresh `…-Www.md`
 (`fit-wiki rotate` is the operator escape).
 
 Triage the Message Inbox via `fit-wiki inbox {list|ack|promote|drop}`; `promote
---index N` writes a `## Cross-Cutting Priorities` row and drops the bullet.
-Cross-agent memos use `fit-wiki memo` (writer-side), triaged via `inbox`. Update
-`wiki/{agent}.md` directly at run end.
+--index N` writes a `## Cross-Cutting Priorities` row. Cross-agent memos use
+`fit-wiki memo`, triaged via `inbox`. Update `wiki/{agent}.md` at run end.
 
 Keep your own summary and weekly log passing `audit` before run end — it gates
 the Stop-hook: trim settled state, `rotate` a full weekly log. Whole-wiki
-`fit-wiki fix` is the curator's tool (`kata-wiki-curate`), not a per-run step.
+`fit-wiki fix` is the curator's tool, not a per-run step.
 
 ## Summary Contract
 
-Each `wiki/<agent>.md` conforms to a mechanically-checkable contract —
-`audit` gates it on Stop-hook and pre-merge CI.
+Each `wiki/<agent>.md` conforms to a mechanically-checkable contract `audit` gates on Stop-hook and pre-merge CI.
 
 **Permitted sections (in order):** `# {Agent Title} — Summary` (H1) →
 `**Last run**:` → `## Message Inbox` (with `<!-- memo:inbox -->` marker —
 MUST be the first H2) → agent-specific H2 sections → `## Open Blockers`.
 
-**Budgets:** 496 lines, 6 400 words. State, not history. Shapes:
-§ Wiki Filename Grammar.
+**Budgets:** 496 lines, 6 400 words. State, not history. Shapes: § Wiki Filename Grammar.
 
 ## Weekly Log Contract
 
 Weekly logs (`wiki/<agent>-YYYY-Www.md`) are append-only Tier 2 records. Named
-readers: `kata-wiki-curate` (always), `kata-session` (experiment verification),
-agents investigating past decisions. Shapes: § Wiki Filename Grammar.
+readers: `kata-wiki-curate` (always), `kata-session` (experiment verification).
+Shapes: § Wiki Filename Grammar.
 
 **Budgets:** 496 lines, 6 400 words. Storyboards (`wiki/storyboard-YYYY-MNN.md`)
 share these under separate `storyboard.*-budget` rules, so limits can diverge.
@@ -96,16 +100,16 @@ Overflow rotates by rename (see § During Each Run); no part is ever rewritten.
 New entries always go through `fit-wiki log`, which emits a conforming
 `## YYYY-MM-DD` heading and `### Decision` block by construction (`audit`
 enforces both). Reserve direct edits for **repair** — a hand-composed entry
-skips the append-time checks, so drift and breaches go unnoticed until CI reds.
+skips the append-time checks.
 
 ## Wiki Filename Grammar
 
 Which files may exist under `wiki/`. The `audit` `admission` rule
 (`audit/grammar.js`) enforces it; this section and that classifier are one home,
-extended together. **Universe:** git-tracked files under `wiki/` (no git state →
-every file is governed). **Calendar tokens** are hyphen-anchored segments — week
-`YYYY-Www`, month `YYYY-MNN`, date `YYYY-MM-DD`, bare year `YYYY` (digits inside
-a longer segment are not a token). Admitted **root-file** classes:
+extended together. **Universe:** git-tracked files under `wiki/`. **Calendar
+tokens** are hyphen-anchored segments — week `YYYY-Www`, month `YYYY-MNN`, date
+`YYYY-MM-DD`, bare year `YYYY` (digits inside a longer segment are not a token).
+Admitted **root-file** classes:
 
 | Class | Shape |
 |---|---|
@@ -123,8 +127,7 @@ membership.
 
 **Remediation is flag-for-human** — never auto-fixed; a wrong move destroys
 memory. To admit a new convention, extend this section and `audit/grammar.js`
-together in one reviewed change — the single admission path. This section also
-hosts the sealed-part heading grammar.
+together in one reviewed change — the single admission path.
 
 ## Cross-Cutting Priorities
 
@@ -136,8 +139,8 @@ hosts the sealed-part heading grammar.
 ## Active Claims
 
 Sibling H2 to Cross-Cutting Priorities in `wiki/MEMORY.md`. A *claim* asserts an
-agent is actively working a named target and will ship the next observable state
-change. **Row present = active; row absent = settled.**
+agent is working a named target and will ship the next state change. **Row
+present = active; row absent = settled.**
 
 Schema (header copied verbatim from `libwiki/constants.js`):
 
@@ -147,8 +150,7 @@ Schema (header copied verbatim from `libwiki/constants.js`):
 
 Lifecycle:
 
-- `fit-wiki claim --agent <self> --target <id> --branch <name> [--pr <id>]
-  [--expires-at YYYY-MM-DD]` — defaults `expires_at = +7 days`; exit 2 on dupes.
+- `fit-wiki claim --agent <self> --target <id> --branch <name> [--pr <id>] [--expires-at YYYY-MM-DD]` — defaults `expires_at = +7 days`; exit 2 on dupes.
 - `fit-wiki release --agent <self> --target <id>` — normal removal.
 - `fit-wiki release --expired` — operator cleanup; removes every expired row.
 
@@ -161,13 +163,10 @@ entry, whichever first. The claim is atomic with its push — **the push is the
 serialization point**:
 
 1. `fit-wiki pull`
-2. Read `## Active Claims` for foreign rows on the same target. Slug equality is
-   **not** the test — compare on the coordinating artifact (issue/spec number),
-   then read any overlapping branch or PR.
+2. Read `## Active Claims` for foreign rows on the same target. Compare on the coordinating artifact (issue/spec number), not slug equality; then read any overlapping branch or PR.
 3. `fit-wiki claim --agent <self> --target <id> --branch <name>`
 4. `fit-wiki push`
-5. If the push rebases in a foreign row for the same deliverable, abort:
-   `release` your row, push, and re-route.
+5. If the push rebases in a foreign row for the same deliverable, abort: `release` your row, push, and re-route.
 
 Pair the gate with the pre-PR freshness probe —
 [coordination-protocol.md § Claim → probe → create](coordination-protocol.md#claim--probe--create).

--- a/.claude/agents/references/work-definition.md
+++ b/.claude/agents/references/work-definition.md
@@ -46,6 +46,22 @@ type](coordination-protocol.md#channel-by-output-type); gating is in
 - **Tie-breaker** — if you cannot state the change as a single verifiable diff
   *without* first making a design decision, it is structural.
 
+### Product-aligned vs internal
+
+A second axis, independent of the mechanical-vs-structural fork — a fix or a
+spec can be either value.
+
+- **Product-aligned** — changes a product or service surface a JTBD persona
+  hires (CLAUDE.md § Products, [JTBD.md](../../../JTBD.md)).
+- **Internal** — changes the agent team's own machinery, infrastructure, or
+  process.
+- **Decision test** — does the change alter a surface a JTBD persona hires? If
+  yes, it is product-aligned; if it touches only the team's own machinery,
+  infrastructure, or process, it is internal.
+
+The agent opening any work PR — spec PR, issue-sourced fix, or direct fix —
+applies the matching `product` / `internal` label.
+
 ### Unsettled → Discussion
 
 Open a Discussion/RFC — **before** any dependent fix or spec — when any holds:
@@ -68,8 +84,8 @@ the product vision, a duplicate, unclear, or already addressed.
 ### Bug vs feature vs documentation — issue intake
 
 - **Bug** — a crash, error, or output that contradicts documented behaviour.
-- **Feature / product-aligned** — a missing capability that serves a JTBD
-  persona and job (CLAUDE.md § Products, [JTBD.md](../../../JTBD.md)).
+- **Feature / product-aligned** — a missing capability that is
+  [product-aligned](#product-aligned-vs-internal) rather than internal.
 - **Documentation** — the behaviour is correct, but the docs are unclear,
   missing, or stale.
 

--- a/.claude/agents/references/work-definition.md
+++ b/.claude/agents/references/work-definition.md
@@ -49,15 +49,18 @@ type](coordination-protocol.md#channel-by-output-type); gating is in
 ### Product-aligned vs internal
 
 A second axis, independent of the mechanical-vs-structural fork — a fix or a
-spec can be either value.
+spec can be either value. The test is the surface the change lands on, by
+MONOREPO.md tree:
 
-- **Product-aligned** — changes a product or service surface a JTBD persona
-  hires (CLAUDE.md § Products, [JTBD.md](../../../JTBD.md)).
-- **Internal** — changes the agent team's own machinery, infrastructure, or
-  process.
-- **Decision test** — does the change alter a surface a JTBD persona hires? If
-  yes, it is product-aligned; if it touches only the team's own machinery,
-  infrastructure, or process, it is internal.
+- **Product-aligned** — the change is a shipped product or service surface a
+  persona hires: the `products/` or `services/` trees, or the documentation of
+  those surfaces.
+- **Internal** — everything else: shared libraries (`libraries/`), agent
+  configuration (`.claude/`), CI and automation (`.github/`), build, release,
+  and repository tooling.
+- **Decision test** — does the change land under `products/` or `services/` (or
+  document one of those surfaces)? If yes, it is product-aligned; otherwise it
+  is internal.
 
 The agent opening any work PR — spec PR, issue-sourced fix, or direct fix —
 applies the matching `product` / `internal` label.

--- a/.claude/skills/kata-product-issue/SKILL.md
+++ b/.claude/skills/kata-product-issue/SKILL.md
@@ -53,6 +53,13 @@ this table maps those work-types to the triage-specific action and labels.
 Product alignment (the **Product-aligned** row) is this skill's own criterion —
 see § Product Vision Alignment below.
 
+Triage also assigns each issue's product-vs-internal value from the shared
+rubric in
+[work-definition.md § Product-aligned vs internal](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/work-definition.md#product-aligned-vs-internal),
+and the resulting spec or fix carries the matching `product` / `internal`
+label. The § Product Vision Alignment judgement decides whether an issue is in
+scope; the axis value itself comes from the rubric, not a private definition.
+
 | Category                 | Recommended action                                                                                                  |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
 | **Mechanical fix/bug**   | Fix PR (direct git ops, no spec)                                                                                    |

--- a/.claude/skills/kata-release-merge/SKILL.md
+++ b/.claude/skills/kata-release-merge/SKILL.md
@@ -8,10 +8,9 @@ description: >
 
 # Release Merge
 
-Verify every open non-Dependabot PR — external contributions and kata-agent-team
-PRs alike — against six gates (trust, type, CI, mechanical readiness, approval,
-open comments) and merge those that pass. Contributor trust is the most critical
-gate — record each advanced PR's trust check in memory.
+Verify every open non-Dependabot PR against seven gates — trust, type, CI,
+mechanical readiness, approval, open comments, classification label — and merge
+those that pass. Trust is the most critical — record each PR's trust check.
 
 ## When to Use
 
@@ -29,11 +28,12 @@ gate — record each advanced PR's trust check in memory.
       `approved` (or `implemented` for the terminal plan row).
 - [ ] For implementation PRs: parent spec's `plan-a.md` exists on `main`.
 - [ ] No unresolved trusted-human concern in the PR comment thread.
+- [ ] Classification label (`product` / `internal`) is present on the PR.
 - [ ] Coordinating issue (if any) names the PR — self-healed when missing.
 
 </do_confirm_checklist>
 
-A PR that fails any gate is **blocked** with reason; passing PRs merge in Step 10.
+A PR that fails any gate is **blocked** with reason; passing PRs merge in Step 11.
 
 ## Process
 
@@ -61,8 +61,8 @@ gh api repos/{owner}/{repo}/contributors \
   --jq '[.[] | select(.type == "User")] | .[0:7] | .[].login'
 ```
 
-The PR author must appear in this list. If not, mark **blocked** (this lookup
-must run on every classified PR).
+The PR author must appear, or mark **blocked**; run this lookup on every
+classified PR.
 
 ### Step 3: Classify PR Type
 
@@ -83,10 +83,7 @@ gh pr view <number> --json mergeable,mergeStateStatus
 gh pr checks <number>
 ```
 
-Clean (mergeable, CI green, up-to-date) → continue to Step 6. Behind, stale, or
-conflicting → rebase (Step 5). CI failing → fix (Step 5) or block. An
-approved-and-pinned experiment PR never rebases — skip Step 5 and let Step 6
-re-block ([`experiment-path.md`](references/experiment-path.md)).
+Clean (mergeable, CI green, up-to-date) → continue to Step 6. Behind, stale, or conflicting → rebase (Step 5). CI failing → fix (Step 5) or block. An approved-and-pinned experiment PR never rebases — skip to Step 6 re-block ([`experiment-path.md`](references/experiment-path.md)).
 
 ### Step 5: Rebase + Mechanical Fixes
 
@@ -98,8 +95,7 @@ git checkout <pr-branch> && git rebase origin/main
 **Mechanical conflicts only** (lock file, generated files, formatting):
 
 ```sh
-# Lock file: take theirs, then re-run the install. Generated: re-run the
-# repository's codegen. Formatting: run the repository's formatter.
+# Lock file: take theirs, re-run install. Generated: re-run codegen. Formatting: run the formatter.
 git add <files> && git rebase --continue
 ```
 
@@ -107,7 +103,7 @@ git add <files> && git rebase --continue
 deleted-vs-modified) — `git rebase --abort` and comment the conflicting files.
 
 After rebase, run auto-fix then check; if checks still fail, mark **blocked**
-and skip to Step 11. Push with `git push --force-with-lease origin <pr-branch>`.
+and skip to Step 12. Push with `git push --force-with-lease origin <pr-branch>`.
 
 ### Step 6: Approval Gate
 
@@ -123,18 +119,14 @@ discriminator, `exp:{issue}` STATUS read, head-pin re-block:
 
 ### Step 7: Open Comment Gate
 
-If any top-7 human contributor's most-recent PR comment is an unresolved concern
-not accepted by a **later** same-human comment, mark **blocked**
-(`awaiting trusted-contributor reply`). See
-[`comment-gate.md`](references/comment-gate.md) for the resolution model.
+If a top-7 contributor's most-recent PR comment is an unresolved concern not accepted by a **later** same-human comment, mark **blocked** (`awaiting trusted-contributor reply`); see [`comment-gate.md`](references/comment-gate.md).
 
 ### Step 8: Coordinating Issue Announcement (self-heal)
 
 If no comment on the PR's coordinating issue (`Fixes #N` and variants) names the
-PR, post the cross-link yourself and log the adherence miss — **self-heal, never
-block** — so a parallel run sees the fix in flight. Probe sibling PRs on the same
-issue (`--state all`, paired with the issue-comment scan — index search alone
-lags) and resolve duplicates there before merging any. Details:
+PR, post the cross-link and log the miss — **self-heal, never
+block**. Probe sibling PRs on the same issue (`--state all`, paired with the
+issue-comment scan) and resolve duplicates before merging any. Details:
 [`announcement-backstop.md`](references/announcement-backstop.md); no coordinating
 issue → skip.
 
@@ -148,20 +140,28 @@ spec id (e.g. `feat(...): … (#NNN)` or "implements spec NNN"):
 - Update `wiki/STATUS.md` before merging — set the spec's row to
   `{NNN}\tplan\timplemented`. Commit the wiki change; the Stop hook pushes it.
 
-An **experiment PR** that passed Step 6 runs the diff-scope check in place of
-this check, not advancing the row
-([`experiment-path.md`](references/experiment-path.md)). Other PRs not referencing
-a spec (one-off fixes, doc patches) skip this step.
+An **experiment PR** that passed Step 6 runs the diff-scope check here instead,
+not advancing the row
+([`experiment-path.md`](references/experiment-path.md)). PRs not referencing a
+spec skip this step.
 
-### Step 10: Merge Mergeable PRs
+### Step 10: Classification Label Gate
+
+Read the PR's labels (fetched in Step 1). If neither `product` nor `internal`
+is present, mark **blocked** (`awaiting classification label`). No fast-path
+exemption: a `.md`/`.mdx` PR skips only the Step 6 approval gate, not this one —
+docs PRs are completed work in the denominator and must carry the label
+per [work-definition.md § Product-aligned vs internal](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/work-definition.md#product-aligned-vs-internal).
+
+### Step 11: Merge Mergeable PRs
 
 1. Post the merge comment from `references/templates.md` § Merge Comment.
 2. `gh pr merge <number> --merge --delete-branch`
 3. Verify state is `MERGED`. On race or branch-protection failure, record and
-   move on — do **not** retry without re-running Steps 1–9.
+   move on — do **not** retry without re-running Steps 1–10.
 4. **Re-ping Rule** — re-comment on any still-blocked PR past its 3-day silence window ([`reping-rule.md`](references/reping-rule.md)).
 
-### Step 11: Produce the Classification Report
+### Step 12: Produce the Classification Report
 
 Per PR record: number, title, type, author, trust check, CI, approval source
 (label / review / blocked), verdict — `merged`, `blocked`, or `re-pinged`.

--- a/.claude/skills/kata-session/references/team-storyboard.md
+++ b/.claude/skills/kata-session/references/team-storyboard.md
@@ -16,7 +16,9 @@ Experiments. Full template, with per-section word budgets, at
 Create the storyboard from [`storyboard-template.md`](storyboard-template.md):
 for every `wiki/metrics/{skill}/{YYYY}.csv`, instantiate one
 `#### {metric_name}` block under `### {skill}` with its
-`<!-- xmr:{metric}:{csv} -->` / `<!-- /xmr -->` marker pair. Then lead the
+`<!-- xmr:{metric}:{csv} -->` / `<!-- /xmr -->` marker pair. Besides the
+per-skill blocks, instantiate a `#### product_share` block under
+`### product-manager` from `wiki/metrics/product-mix/{YYYY}.csv`. Then lead the
 team through: the Challenge, the Target Condition (measurable, by month end),
 the Current Condition from metrics CSVs, initial Obstacles, and the first
 Experiment.
@@ -67,8 +69,7 @@ If a metric is missing its marker pair, a participant seeds it from
 Markers are the contract — never paste charts or issue lists by hand.
 
 Above the agent-domain sections, write a tight `### Headlines` list naming only
-metrics whose status changed since the last meeting. Agents add cross-reference
-notes only where they help.
+metrics whose status changed since the last meeting.
 
 ## Active / Concluded Partition
 

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -82,6 +82,9 @@ Identify which persona and job from [JTBD.md](../../../JTBD.md) the spec serves.
 - **No HOW.** Name what each component does, not which mechanism implements it.
   Tool selection and sequencing belong in the design and plan. Cite evidence
   by entity or behaviour name, not by `file:line` pointer.
+- **State the classification.** The spec carries a one-line
+  product-vs-internal classification per the shared rubric in
+  [work-definition.md § Product-aligned vs internal](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/work-definition.md#product-aligned-vs-internal).
 
 **Form follows content.** Prefer tables for lists with shared structure (files,
 criteria, alternatives). Prefer bullets for flat facts. Use prose only for the
@@ -161,8 +164,9 @@ panel is clean.
 ### Step 6: Open a spec PR
 
 The PR title carries the spec id: `spec(NNN): …`. Merge of that PR is what
-advances the phase. Do not apply the `spec:approved` label and do not
-recommend approval — those are human-only actions; see § Approval.
+advances the phase. Apply the matching `product` / `internal` label per the
+shared rubric when opening the PR. Do not apply the `spec:approved` label and
+do not recommend approval — those are human-only actions; see § Approval.
 
 [Citation integrity](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/citation-integrity.md): every cited SHA must resolve on its referenced repo, or the body is not published.
 

--- a/libraries/libwiki/src/cli-definition.js
+++ b/libraries/libwiki/src/cli-definition.js
@@ -1,5 +1,6 @@
 import { runMemoCommand } from "./commands/memo.js";
 import { runRefreshCommand } from "./commands/refresh.js";
+import { runProductMixCommand } from "./commands/product-mix.js";
 import { runInitCommand } from "./commands/init.js";
 import { runPushCommand, runPullCommand } from "./commands/sync.js";
 import { runBootCommand } from "./commands/boot.js";
@@ -219,6 +220,31 @@ export function createDefinition() {
         },
       },
       {
+        name: "product-mix",
+        description:
+          "Emit the product-vs-internal mix of merged PRs as a `product_share` metric row",
+        handler: runProductMixCommand,
+        options: {
+          until: {
+            type: "string",
+            description: "Window end ISO date (default: today)",
+          },
+          since: {
+            type: "string",
+            description: "Window start ISO date (default: until − 7 days)",
+          },
+          run: {
+            type: "string",
+            description: "Run id recorded on the metric row (default: gh-live)",
+          },
+          repo: {
+            type: "string",
+            description: "owner/repo slug (default: origin remote)",
+          },
+          ...wikiRootOpt,
+        },
+      },
+      {
         name: "init",
         description: "Bootstrap a wiki working tree and scaffold Active Claims",
         handler: runInitCommand,
@@ -262,6 +288,7 @@ export function createDefinition() {
       "fit-wiki fix",
       'fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"',
       "fit-wiki refresh",
+      "fit-wiki product-mix",
       "fit-wiki init",
       "fit-wiki push",
       "fit-wiki pull",

--- a/libraries/libwiki/src/commands/product-mix.js
+++ b/libraries/libwiki/src/commands/product-mix.js
@@ -1,0 +1,148 @@
+import { addDays } from "@forwardimpact/libutil";
+import { createLogger } from "@forwardimpact/libtelemetry";
+import { createScriptConfig } from "@forwardimpact/libconfig";
+import { parseRepoSlug } from "../issue-list-renderer.js";
+import { currentDayIso } from "../util/clock.js";
+import { resolveProjectRoot } from "../util/wiki-dir.js";
+
+// Resolve the monorepo's `owner/repo` slug the way `refresh.js` does: an
+// explicit `FIT_GH_REPO` env override (sandbox proxy URLs), else the origin
+// remote parsed via the injected git client. Returns null when nothing
+// parseable is found, in which case `gh` falls back to its own cwd resolution.
+async function deriveRepo(gitClient, cwd, env) {
+  if (env.FIT_GH_REPO) return env.FIT_GH_REPO;
+  if (!gitClient) return null;
+  try {
+    const url = await gitClient.remoteGetUrl("origin", { cwd });
+    return parseRepoSlug(url);
+  } catch {
+    return null;
+  }
+}
+
+// A missing token is non-fatal: `gh` may still resolve ambient auth, and a
+// hard fetch failure downstream collapses to a logged warning and no row.
+async function resolveToken() {
+  try {
+    return (await createScriptConfig("wiki")).ghToken();
+  } catch {
+    return null;
+  }
+}
+
+// `gh pr list` returns at most this many PRs; a window that hits the cap is
+// truncated, so the caller warns rather than silently undercounting.
+const FETCH_LIMIT = 200;
+
+// Fetch merged PRs in `[since, until]` and return their parsed JSON, or null on
+// any failure (non-zero exit or unparseable stdout) so the caller emits no row.
+async function fetchMergedPrs({ runtime, cwd, repo, since, until, token }) {
+  const args = ["pr", "list", "--base", "main"];
+  if (repo) args.push("--repo", repo);
+  args.push(
+    "--json",
+    "number,labels,mergedAt",
+    "--search",
+    `merged:${since}..${until}`,
+    "--limit",
+    String(FETCH_LIMIT),
+  );
+  const env = token
+    ? { ...runtime.proc.env, GH_TOKEN: token }
+    : runtime.proc.env;
+  const result = await runtime.subprocess.run("gh", args, { cwd, env });
+  if (result.exitCode !== 0) return null;
+  try {
+    return JSON.parse(result.stdout || "[]");
+  } catch {
+    return null;
+  }
+}
+
+// Tally merged PRs by their classification label. A PR with neither label is
+// unlabeled; `product` wins if both are somehow present.
+function countByLabel(prs) {
+  const counts = { product: 0, internal: 0, unlabeled: 0 };
+  for (const pr of prs) {
+    const names = (pr.labels || []).map((l) => l.name);
+    if (names.includes("product")) counts.product++;
+    else if (names.includes("internal")) counts.internal++;
+    else counts.unlabeled++;
+  }
+  return counts;
+}
+
+/**
+ * Emit the product-vs-internal mix of merged PRs as a `product_share` metric
+ * row. Counts PRs merged in `[since, until]` by their `product` / `internal`
+ * label and appends `product_share = round(product / (product + internal) *
+ * 100)` to `wiki/metrics/product-mix/<YYYY>.csv` via the `fit-xmr record` write
+ * path. Deterministic — re-running over the same merged PRs yields the same
+ * value. A window with no labeled merged PRs emits no row (avoids a 0/0 ratio).
+ */
+export async function runProductMixCommand(ctx) {
+  const { runtime, gitClient } = ctx.deps;
+  const options = ctx.options;
+  const logger = createLogger("wiki", runtime);
+  const cwd = resolveProjectRoot(runtime);
+
+  const until = options.until || currentDayIso(runtime);
+  const since = options.since || addDays(until, -7);
+  const run = options.run || "gh-live";
+  const repo =
+    options.repo || (await deriveRepo(gitClient, cwd, runtime.proc.env));
+  const token = await resolveToken();
+
+  const prs = await fetchMergedPrs({ runtime, cwd, repo, since, until, token });
+  if (prs === null) {
+    logger.warn("product-mix", `gh pr list failed for ${since}..${until}`);
+    return { ok: true };
+  }
+  if (prs.length >= FETCH_LIMIT) {
+    logger.warn(
+      "product-mix",
+      `window ${since}..${until} hit the ${FETCH_LIMIT}-PR fetch cap; product_share may undercount`,
+    );
+  }
+
+  const { product, internal, unlabeled } = countByLabel(prs);
+  const total = product + internal;
+  if (total === 0) {
+    logger.info(
+      "product-mix",
+      `no labeled merged PRs in ${since}..${until}; emitting no row`,
+    );
+    return { ok: true };
+  }
+
+  const share = Math.round((product / total) * 100);
+  const recordArgs = [
+    "fit-xmr",
+    "record",
+    "--skill",
+    "product-mix",
+    "--metric",
+    "product_share",
+    "--value",
+    String(share),
+    "--unit",
+    "pct",
+    "--date",
+    until,
+    "--run",
+    run,
+    "--note",
+    `product=${product} internal=${internal} unlabeled=${unlabeled} window=${since}..${until}`,
+    "--event-type",
+    "kata-shift",
+  ];
+  if (options["wiki-root"]) {
+    recordArgs.push("--wiki-root", options["wiki-root"]);
+  }
+
+  const recordResult = await runtime.subprocess.run("npx", recordArgs, { cwd });
+  if (recordResult.exitCode !== 0) {
+    logger.warn("product-mix", "fit-xmr record failed");
+  }
+  return { ok: true };
+}

--- a/libraries/libwiki/test/cli-product-mix.test.js
+++ b/libraries/libwiki/test/cli-product-mix.test.js
@@ -1,0 +1,128 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createTestRuntime,
+  createMockSubprocess,
+} from "@forwardimpact/libmock";
+
+import { runProductMixCommand } from "../src/commands/product-mix.js";
+
+const WINDOW = { until: "2026-06-08", since: "2026-06-01" };
+
+function prsPayload(...specs) {
+  // Each spec is a label name (or null for unlabeled). Returns the JSON shape
+  // `gh pr list --json number,labels,mergedAt` emits.
+  return JSON.stringify(
+    specs.map((label, i) => ({
+      number: i + 1,
+      labels: label ? [{ name: label }] : [],
+      mergedAt: "2026-06-05T00:00:00Z",
+    })),
+  );
+}
+
+function runWith(stdout, { options, gitClient, clock } = {}) {
+  const subprocess = createMockSubprocess({
+    responses: { gh: { stdout }, npx: { stdout: "" } },
+  });
+  const runtime = createTestRuntime({
+    subprocess,
+    finder: { findProjectRoot: () => "/repo" },
+    ...(clock ? { clock } : {}),
+  });
+  const ctx = {
+    deps: { runtime, gitClient },
+    options: options ?? { ...WINDOW, repo: "owner/repo" },
+    args: {},
+  };
+  return { ctx, subprocess, runtime, run: runProductMixCommand(ctx) };
+}
+
+describe("fit-wiki product-mix", () => {
+  test("records product_share from labeled merged PRs", async () => {
+    // 3 product + 1 internal of 4 classified → round(3/4*100) = 75.
+    const { subprocess, run } = runWith(
+      prsPayload("product", "product", "product", "internal", null),
+    );
+    const result = await run;
+    assert.equal(result.ok, true);
+
+    const recordCall = subprocess.calls.find((c) => c.cmd === "npx");
+    assert.ok(recordCall, "fit-xmr record must be invoked");
+    assert.equal(recordCall.args[0], "fit-xmr");
+    assert.ok(recordCall.args.includes("record"));
+    const pair = (flag) => recordCall.args[recordCall.args.indexOf(flag) + 1];
+    assert.equal(pair("--skill"), "product-mix");
+    assert.equal(pair("--metric"), "product_share");
+    assert.equal(pair("--value"), "75");
+    assert.equal(pair("--unit"), "pct");
+    assert.equal(pair("--date"), "2026-06-08");
+  });
+
+  test("emits no row when no PRs carry a classification label", async () => {
+    const { subprocess, run } = runWith(prsPayload(null, null));
+    const result = await run;
+    assert.equal(result.ok, true);
+    assert.ok(
+      !subprocess.calls.some((c) => c.cmd === "npx"),
+      "no fit-xmr record call for a 0/0 window",
+    );
+  });
+
+  test("emits no row for an empty merged-PR set", async () => {
+    const { subprocess, run } = runWith("[]");
+    await run;
+    assert.ok(!subprocess.calls.some((c) => c.cmd === "npx"));
+  });
+
+  test("derives the repo slug from the git origin when --repo is absent", async () => {
+    const gitClient = {
+      remoteGetUrl: async () => "https://github.com/forwardimpact/monorepo.git",
+    };
+    const { subprocess, run } = runWith(prsPayload("product"), {
+      options: { ...WINDOW },
+      gitClient,
+    });
+    await run;
+    const ghCall = subprocess.calls.find((c) => c.cmd === "gh");
+    assert.ok(ghCall.args.includes("--repo"));
+    assert.equal(
+      ghCall.args[ghCall.args.indexOf("--repo") + 1],
+      "forwardimpact/monorepo",
+    );
+  });
+
+  test("defaults the window to the trailing 7 days from the clock", async () => {
+    // currentDayIso reads runtime.clock.now(); addDays(-7) sets the start.
+    const clock = { now: () => Date.UTC(2026, 5, 8), sleep: async () => {} };
+    const { subprocess, run } = runWith(prsPayload("product"), {
+      options: { repo: "owner/repo" },
+      clock,
+    });
+    await run;
+    const ghCall = subprocess.calls.find((c) => c.cmd === "gh");
+    assert.equal(
+      ghCall.args[ghCall.args.indexOf("--search") + 1],
+      "merged:2026-06-01..2026-06-08",
+    );
+    const recordCall = subprocess.calls.find((c) => c.cmd === "npx");
+    assert.equal(
+      recordCall.args[recordCall.args.indexOf("--date") + 1],
+      "2026-06-08",
+    );
+  });
+
+  test("queries gh with the merged: search window", async () => {
+    const { subprocess, run } = runWith(prsPayload("product"));
+    await run;
+    const ghCall = subprocess.calls.find((c) => c.cmd === "gh");
+    assert.ok(ghCall, "gh pr list must be invoked");
+    assert.ok(ghCall.args.includes("--search"));
+    assert.equal(
+      ghCall.args[ghCall.args.indexOf("--search") + 1],
+      "merged:2026-06-01..2026-06-08",
+    );
+    assert.ok(ghCall.args.includes("--repo"));
+    assert.ok(ghCall.args.includes("owner/repo"));
+  });
+});

--- a/libraries/libwiki/test/golden.test.js
+++ b/libraries/libwiki/test/golden.test.js
@@ -45,6 +45,7 @@ const HELP_CASES = [
   [["fix", "--help"], "fix-help.stdout.txt"],
   [["memo", "--help"], "memo-help.stdout.txt"],
   [["refresh", "--help"], "refresh-help.stdout.txt"],
+  [["product-mix", "--help"], "product-mix-help.stdout.txt"],
   [["init", "--help"], "init-help.stdout.txt"],
   [["push", "--help"], "push-help.stdout.txt"],
   [["pull", "--help"], "pull-help.stdout.txt"],

--- a/libraries/libwiki/test/golden/fit-wiki/cases.json
+++ b/libraries/libwiki/test/golden/fit-wiki/cases.json
@@ -117,6 +117,15 @@
     "transform": []
   },
   {
+    "name": "product-mix help",
+    "args": ["product-mix", "--help"],
+    "env": {},
+    "exitCode": 0,
+    "stdoutFile": "product-mix-help.stdout.txt",
+    "stderrFile": "product-mix-help.stderr.txt",
+    "transform": []
+  },
+  {
     "name": "init help",
     "args": ["init", "--help"],
     "env": {},

--- a/libraries/libwiki/test/golden/fit-wiki/help-flag.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/help-flag.stdout.txt
@@ -13,6 +13,7 @@ Commands:
   fix                        Auto-fix wiki audit findings: rotate weekly logs, fix the rest with an AI agent (technical-writer, Haiku), flag the unresolvable
   memo                       Send a cross-team memo into a teammate's Message Inbox
   refresh [storyboard-path]  Regenerate XmR and obstacle/experiment marker blocks in a storyboard
+  product-mix                Emit the product-vs-internal mix of merged PRs as a `product_share` metric row
   init                       Bootstrap a wiki working tree and scaffold Active Claims
   push                       Commit and push local wiki changes to the remote
   pull                       Pull remote wiki changes into the local working tree
@@ -33,6 +34,7 @@ Examples:
   fit-wiki fix
   fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"
   fit-wiki refresh
+  fit-wiki product-mix
   fit-wiki init
   fit-wiki push
   fit-wiki pull

--- a/libraries/libwiki/test/golden/fit-wiki/help.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/help.stdout.txt
@@ -13,6 +13,7 @@ Commands:
   fix                        Auto-fix wiki audit findings: rotate weekly logs, fix the rest with an AI agent (technical-writer, Haiku), flag the unresolvable
   memo                       Send a cross-team memo into a teammate's Message Inbox
   refresh [storyboard-path]  Regenerate XmR and obstacle/experiment marker blocks in a storyboard
+  product-mix                Emit the product-vs-internal mix of merged PRs as a `product_share` metric row
   init                       Bootstrap a wiki working tree and scaffold Active Claims
   push                       Commit and push local wiki changes to the remote
   pull                       Pull remote wiki changes into the local working tree
@@ -33,6 +34,7 @@ Examples:
   fit-wiki fix
   fit-wiki memo --from staff-engineer --to security-engineer --message "audit d642ff0c"
   fit-wiki refresh
+  fit-wiki product-mix
   fit-wiki init
   fit-wiki push
   fit-wiki pull

--- a/libraries/libwiki/test/golden/fit-wiki/product-mix-help.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/product-mix-help.stdout.txt
@@ -1,0 +1,14 @@
+fit-wiki product-mix — Emit the product-vs-internal mix of merged PRs as a `product_share` metric row
+
+Usage: fit-wiki product-mix [options]
+
+Options:
+  --until=<string>      Window end ISO date (default: today)
+  --since=<string>      Window start ISO date (default: until − 7 days)
+  --run=<string>        Run id recorded on the metric row (default: gh-live)
+  --repo=<string>       owner/repo slug (default: origin remote)
+  --wiki-root=<string>  Override wiki root directory (default: wiki)
+
+Global options:
+  --help, -h  Show this help
+  --json      Render --help output as JSON


### PR DESCRIPTION
Implements [spec 2070](specs/2070-product-vs-internal-work-axis/spec.md) per [plan-a](specs/2070-product-vs-internal-work-axis/plan-a.md).

## What

Introduces **product-aligned vs internal** as a second, independent classification axis and applies it in routing and the storyboard.

| Step | Change |
|---|---|
| 1 | `work-definition.md` gains the canonical `### Product-aligned vs internal` section: definitions, a decision test, the independence note, and the PR-label requirement; the intake line links to it. |
| 2 | `memory-protocol.md` § On-Boot Routing gains a product-priority tie-break with the constraint-lifting exception, the not-a-quota clause, and the Decision-block recording rule. |
| 3 | `kata-spec` requires a stated product-vs-internal classification and applies the matching PR label. |
| 4 | `kata-product-issue` assigns the axis from the shared rubric. |
| 5 | `kata-release-merge` gains a DO-CONFIRM item and a new Step 10 Classification Label Gate (no docs fast-path exemption); downstream steps renumbered. |
| 7 | New deterministic `fit-wiki product-mix` emitter derives `product_share` from merged-PR labels via the `fit-xmr record` write path (+ unit test, golden help snapshot). |
| 8–9 | Storyboard `product_share` block (on the wiki surface), team-storyboard planning rule, and product-manager scheduled-run wiring. |

## Verification

- `bun run check` green (format, lint, jsdoc, genericity invariants, instruction budgets).
- New `product-mix` tests 6/6; golden CLI-contract test 18/18.
- Clean 5-reviewer panel ([`kata-review`](.claude/skills/kata-review/SKILL.md)) — no blockers/highs; consensus-medium test-coverage gap addressed; over-trimmed reference clauses restored.

## Follow-ups needed

- **Plan Step 6 — repository labels.** The `product` / `internal` labels still need creating via an authenticated GitHub session; the merge gate and emitter depend on them. They could not be created from the implementation environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UXvNuGp6idsFaPVV9evck4)_