### PR TITLE
docs(spec-2090): unify tracker terminology and improve matrix tables

### DIFF
--- a/specs/2090-work-item-provider-abstraction/design-a.md
+++ b/specs/2090-work-item-provider-abstraction/design-a.md
@@ -14,7 +14,7 @@ flowchart TD
   S[kata-* skill / agent reference<br/>names an abstract operation] --> SEL{active tracker<br/>KATA_WORK_TRACKER}
   SEL -->|github default| GH[github column<br/>gh CLI shapes]
   SEL -->|filesystem| FS[filesystem column<br/>file-write recipes]
-  GH --> FORGE[(GitHub forge<br/>issues, PRs, discussions)]
+  GH --> REMOTE[(GitHub<br/>issues, PRs, discussions)]
   FS --> TREE[(working tree<br/>.tracker/ files)]
   MATRIX[tracker matrix<br/>operations × trackers] -.realizes.-> GH
   MATRIX -.realizes.-> FS
@@ -25,15 +25,15 @@ flowchart TD
 A skill names a tracker-independent operation. The active tracker, chosen by
 one environment variable, selects which matrix column realizes it: the `github`
 column (existing `gh` shapes) or the `filesystem` column (file-write recipes
-against `.tracker/`). The matrix is the single home for any forge-specific command.
+against `.tracker/`). The matrix is the single home for any tracker-specific command.
 
 ## Components
 
 | Component | Home | Role |
 | --- | --- | --- |
 | **Work-item model** | new `kata-coordinate` skill | Defines issue, change, and the shared envelope plus the abstract operation vocabulary. |
-| **Tracker matrix** | a reference in `kata-coordinate` | Maps each operation to its `github` and `filesystem` realization; states per-tracker degradation and the selection rule. The only place forge commands appear. |
-| **github column** | matrix | Absorbs every forge command now outside it — the `gh` shapes in `coordination-protocol.md`, `issue-lifecycle.md`, `approval-signals.md`, and the kata-* skills, plus the remote-git operations (branch, push) the spec names — into one column (the spec's § Problem grep set bounds the file set). |
+| **Tracker matrix** | a reference in `kata-coordinate` | Maps each operation to its `github` and `filesystem` realization; states per-tracker degradation and the selection rule. The only place tracker commands appear. |
+| **github column** | matrix | Absorbs every tracker command now outside it — the `gh` shapes in `coordination-protocol.md`, `issue-lifecycle.md`, `approval-signals.md`, and the kata-* skills, plus the remote-git operations (branch, push) the spec names — into one column (the spec's § Problem grep set bounds the file set). |
 | **filesystem column** | matrix | New. File-write recipes over the `.tracker/` layout below. |
 | **Re-pointed references** | `work-definition.md`, `coordination-protocol.md`, `approval-signals.md` | Re-expressed over operations: `work-definition.md`'s "Created via" and `coordination-protocol.md`'s routing name operations and move their `gh` shapes to the matrix; `approval-signals.md` generalizes its signal vocabulary, its one `gh` shape (`gh pr review --approve`) moving to the matrix github column. |
 | **Re-pointed skills** | the kata-* skills that call `gh` | Call sites replaced by an operation name + matrix link. |
@@ -138,7 +138,7 @@ filesystem the `approval` field records the granting signal (an approval marker,
 optionally the approver); trust that the setter is authorized is out-of-band —
 the actor that runs `gate` is trusted by construction (the benchmark harness or
 a human). Emulating contributor-list trust offline is rejected as unverifiable
-without the forge.
+without the tracker.
 
 ## Benchmark coordination task
 
@@ -156,7 +156,7 @@ tasks use.
 | Spec criterion | Satisfied by |
 | --- | --- |
 | 1 model + matrix + selection | Work-item model, tracker matrix, env-var selection |
-| 2 forge commands only in github column | Matrix is the single command home; skills/references re-pointed |
+| 2 tracker commands only in github column | Matrix is the single command home; skills/references re-pointed |
 | 3 three references over operations | Re-pointed references component |
 | 4 benchmark runs offline | Filesystem tracker needs no network; task exports it |
 | 5 tracker-independent wording | Skills name operations; branching lives only in the matrix |

--- a/specs/2090-work-item-provider-abstraction/design-b.md
+++ b/specs/2090-work-item-provider-abstraction/design-b.md
@@ -60,7 +60,7 @@ flowchart TD
   S --> SEL{active tracker<br/>LIBEVAL_WORK_TRACKER}
   SEL -->|github default| GH[github column<br/>gh CLI shapes]
   SEL -->|filesystem| FS[filesystem column<br/>file-write recipes]
-  GH --> FORGE[(GitHub forge)]
+  GH --> FORGE[(GitHub tracker)]
   FS --> TREE[(working tree<br/>.tracker/ files)]
   MATRIX[work-trackers.md<br/>agents/references] -.realizes.-> GH
   MATRIX -.realizes.-> FS
@@ -68,15 +68,15 @@ flowchart TD
 ```
 
 The active tracker, chosen by the harness-set env var, selects which matrix
-column realizes each operation. The matrix is the single home for forge
+column realizes each operation. The matrix is the single home for tracker
 commands.
 
 ## Components
 
 | Component | Home | Role |
 | --- | --- | --- |
-| **Work-item model + matrix** | new `.claude/agents/references/work-trackers.md` | One reference defining issue, change, the shared envelope, the abstract operation vocabulary, the `github`/`filesystem` columns, per-tracker degradation, and the selection rule. The only place forge commands appear. |
-| **github column** | inside `work-trackers.md` | Absorbs every forge command now outside it — the `gh` shapes in the coordination references, `issue-lifecycle.md`, and the kata-* skills, plus the remote-git operations (branch, push) the spec names. The § Problem grep set bounds the file set. |
+| **Work-item model + matrix** | new `.claude/agents/references/work-trackers.md` | One reference defining issue, change, the shared envelope, the abstract operation vocabulary, the `github`/`filesystem` columns, per-tracker degradation, and the selection rule. The only place tracker commands appear. |
+| **github column** | inside `work-trackers.md` | Absorbs every tracker command now outside it — the `gh` shapes in the coordination references, `issue-lifecycle.md`, and the kata-* skills, plus the remote-git operations (branch, push) the spec names. The § Problem grep set bounds the file set. |
 | **filesystem column** | inside `work-trackers.md` | New. File-write recipes over the `.tracker/` layout below. |
 | **Re-pointed references** | `work-definition.md`, `coordination-protocol.md`, `approval-signals.md` | Re-expressed over operations; their `gh` shapes move to the matrix; they cite it by directory-relative path. |
 | **Re-pointed skills** | the kata-* skills that call `gh` | Call sites replaced by an operation name + a relative matrix link, valid now that agents ship in the same pack. |
@@ -90,13 +90,13 @@ Two kinds share one **envelope** carried as YAML front-matter:
 
 | Field | Meaning | github | filesystem |
 | --- | --- | --- | --- |
-| `id` | stable identity | issue/PR number + URL | caller-supplied slug = repo-relative path |
-| `kind` | `issue` \| `change` | issue \| pull request | file under `issues/` \| `changes/` |
-| `state` | `open` \| `closed` \| `merged` | issue/PR state | front-matter value |
-| `labels` | classification incl. `agent:*` | issue/PR labels | front-matter list |
-| `links` | related work-item ids | issue refs | front-matter list |
+| `id` | stable identity | issue/PR number + URL | caller-supplied slug; the file path is the id |
+| `kind` | issue or change | issue or pull request | file under `issues/` or `changes/` |
+| `state` | lifecycle: open, closed, or merged | issue/PR state | front-matter value |
+| `labels` | classification, including `agent:*` | issue/PR labels | front-matter list |
+| `links` | related work-item ids | issue references | front-matter list |
 | `discussion` | comment thread | native issue/PR thread | appended `## Comments` section |
-| `approval` | change-only trusted gate | PR label/review by trusted human | front-matter value |
+| `approval` | change-only trusted gate | PR label or review by a trusted human | front-matter value |
 
 The matrix records how each capability degrades per tracker. Front-matter is the
 envelope carrier, chosen over a sidecar manifest or JSON store so one
@@ -104,9 +104,23 @@ human-readable file holds metadata and body and an agent edits it without a tool
 
 ## Abstract operations
 
-`create-issue`, `list-issues`, `comment`, `label`, `link`, `open-change`,
-`gate`, `merge-change`, `close`, and the discussion pair `create-discussion` /
-`comment-discussion`. The spec's `triage` and `patch` are compositions
+Each operation has one realization per tracker. The matrix maps them:
+
+| Operation | github | filesystem |
+| --- | --- | --- |
+| `create-issue` | `gh issue create` | write `issues/{id}.md` from the envelope template |
+| `list-issues` | `gh issue list` | glob `issues/` and filter on front-matter |
+| `comment` | `gh issue comment` / `gh pr comment` | append to the item's `## Comments` |
+| `label` | `gh issue edit --add-label` | edit the `labels` front-matter |
+| `link` | issue/PR cross-reference | edit the `links` front-matter |
+| `open-change` | push a branch + `gh pr create` | write `changes/{id}.md`; remote-git steps are no-ops |
+| `gate` | PR review or label by a trusted human | set the `approval` field |
+| `merge-change` | `gh pr merge` | set `state: merged` |
+| `close` | `gh issue close` / `gh pr close` | set `state: closed` |
+| `create-discussion` / `comment-discussion` | `gh api graphql addDiscussion*` | write or append `discussions/{id}.md` |
+
+The shapes above are illustrative; `work-trackers.md` carries the full,
+genericized commands. The spec's `triage` and `patch` are compositions
 (label / comment / close, and open-change / merge-change), not first-class
 operations, keeping each tracker's surface small and fixed. Obstacle and
 experiment are issues distinguished by label, so `issue-lifecycle.md` becomes
@@ -168,7 +182,7 @@ benchmark exercises the filesystem realization directly, without webhooks. On
 filesystem the `approval` field records the granting signal; trust that the
 setter is authorized is out-of-band — the actor that runs `gate` is trusted by
 construction (the benchmark harness or a human). Emulating contributor-list
-trust offline is rejected as unverifiable without the forge.
+trust offline is rejected as unverifiable without the tracker.
 
 ## Benchmark coordination task
 
@@ -187,7 +201,7 @@ the rubric tasks (spec/design/plan) use.
 | Spec criterion | Satisfied by |
 | --- | --- |
 | 1 model + matrix + selection | `work-trackers.md`: model, matrix, env-var selection rule |
-| 2 forge commands only in github column | Matrix is the single command home; skills/references re-pointed |
+| 2 tracker commands only in github column | Matrix is the single command home; skills/references re-pointed |
 | 3 three references over operations | Re-pointed references component |
 | 4 `--work-tracker` flag + offline benchmark | libeval selection wiring; `coordinate-finding` runs `--work-tracker filesystem` |
 | 5 tracker-independent wording | Skills name operations; branching lives only in the matrix |

--- a/specs/2090-work-item-provider-abstraction/design-b.md
+++ b/specs/2090-work-item-provider-abstraction/design-b.md
@@ -60,7 +60,7 @@ flowchart TD
   S --> SEL{active tracker<br/>LIBEVAL_WORK_TRACKER}
   SEL -->|github default| GH[github column<br/>gh CLI shapes]
   SEL -->|filesystem| FS[filesystem column<br/>file-write recipes]
-  GH --> FORGE[(GitHub tracker)]
+  GH --> REMOTE[(GitHub)]
   FS --> TREE[(working tree<br/>.tracker/ files)]
   MATRIX[work-trackers.md<br/>agents/references] -.realizes.-> GH
   MATRIX -.realizes.-> FS

--- a/specs/2090-work-item-provider-abstraction/plan-b-01.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-01.md
@@ -1,7 +1,7 @@
 # Plan 2090-b, Part 01: The tracker matrix reference
 
 Create `.claude/agents/references/work-trackers.md` — the single home for the
-work-item model and every forge command. This part has no dependencies and is
+work-item model and every tracker command. This part has no dependencies and is
 the citation target for Parts 02, 03, and 05. Conventions and the scope boundary
 are in [plan-b.md](plan-b.md).
 
@@ -14,19 +14,19 @@ Intent: stand up the file with the work-item model and how a tracker is chosen.
 Files: create `.claude/agents/references/work-trackers.md`.
 
 Change: front-matter (`# Work Trackers`) and an intro stating the file is the
-only place forge-specific commands appear; agents read the active column from
+only place tracker-specific commands appear; agents read the active column from
 `$LIBEVAL_WORK_TRACKER` (default `github`) and never branch on it elsewhere. Then
 the envelope table (carried as YAML front-matter on each item):
 
 | Field | Meaning | github | filesystem |
 | --- | --- | --- | --- |
-| `id` | stable identity | issue/PR number + URL | caller-supplied slug = repo-relative path |
-| `kind` | `issue` \| `change` | issue \| pull request | file under `issues/` \| `changes/` |
-| `state` | `open` \| `closed` \| `merged` | issue/PR state | front-matter value |
-| `labels` | classification incl. `agent:*` | issue/PR labels | front-matter list |
-| `links` | related work-item ids | issue refs | front-matter list |
+| `id` | stable identity | issue/PR number + URL | caller-supplied slug; the file path is the id |
+| `kind` | issue or change | issue or pull request | file under `issues/` or `changes/` |
+| `state` | lifecycle: open, closed, or merged | issue/PR state | front-matter value |
+| `labels` | classification, including `agent:*` | issue/PR labels | front-matter list |
+| `links` | related work-item ids | issue references | front-matter list |
 | `discussion` | comment thread | native issue/PR thread | appended `## Comments` section |
-| `approval` | change-only trusted gate | PR label/review by trusted human | front-matter value |
+| `approval` | change-only trusted gate | PR label or review by a trusted human | front-matter value |
 
 Then the selection rule: one input, `LIBEVAL_WORK_TRACKER`, default `github`; set
 by the harness (`--work-tracker`), documented here, read by the agent to pick the
@@ -49,42 +49,48 @@ One line each on intent, so a skill citing the name needs no other doc.
 Verification: every operation Parts 02/03 cite (per plan-b.md § Operation
 vocabulary) is present.
 
-## Step 3 — The github column
+## Step 3 — The operations matrix (both columns)
 
-Intent: absorb every in-scope forge command now living outside the matrix.
+Intent: give every operation its concrete `github` shape and its `filesystem`
+realization in one table, so a reader compares the two side by side. This is the
+matrix proper.
 
 Files: modify `work-trackers.md`.
 
-Change: an operation × `github` table whose cells carry the concrete `gh` /
-remote-git shapes relocated from the source files. Populate from the criterion-2
-in-scope set (plan-b.md § Scope boundary) across the coordination references,
-`issue-lifecycle.md`, and the kata-* skills. Cover at least:
+Change: one operation × `{github, filesystem}` table. The github cells carry the
+concrete `gh` / remote-git shapes relocated from the source files (populate from
+the criterion-2 in-scope set in plan-b.md § Scope boundary across the
+coordination references, `issue-lifecycle.md`, and the kata-* skills); the
+filesystem cells carry the file-write realization over the `.tracker/` layout
+(Step 4). Cover at least:
 
-| Operation | github realization (shape, genericized to `repos/{owner}/{repo}`) |
-| --- | --- |
-| `create-issue` | `gh issue create …` |
-| `list` | `gh issue list …` / `gh pr list …` (incl. `--json` metric fields) |
-| `read` | `gh issue view …` / `gh pr view …` / `gh pr diff …` / `gh pr checks …` |
-| `comment` | `gh issue comment …` / `gh pr comment …` |
-| `label` | `gh issue edit --add-label …` / `gh label …` |
-| `link` | issue/PR cross-references |
-| `open-change` | `git switch -c <branch>` + `git push -u origin <branch>` + `gh pr create …` |
-| `update-change` | `git push --force-with-lease origin <branch>` |
-| `gate` | `gh pr review --approve` / approval label read |
-| `merge-change` | `gh pr merge …` |
-| `close` | `gh issue close …` / `gh pr close …` |
-| `create-discussion` / `comment-discussion` | `gh api graphql … addDiscussion* …` |
+| Operation | github (genericized to `repos/{owner}/{repo}`) | filesystem |
+| --- | --- | --- |
+| `create-issue` | `gh issue create …` | write `issues/{id}.md` from the envelope template |
+| `list` | `gh issue list …` / `gh pr list …` (incl. `--json` metric fields) | glob `issues/` or `changes/` and filter front-matter (reduced field set) |
+| `read` | `gh issue view …` / `gh pr view …` / `gh pr diff …` / `gh pr checks …` | return the file (CI-status reads are github-only) |
+| `comment` | `gh issue comment …` / `gh pr comment …` | append to `## Comments` |
+| `label` | `gh issue edit --add-label …` / `gh label …` | edit the `labels` front-matter |
+| `link` | issue/PR cross-references | edit the `links` front-matter |
+| `open-change` | `git switch -c <branch>` + `git push -u origin <branch>` + `gh pr create …` | write `changes/{id}.md`; remote-git steps are no-ops |
+| `update-change` | `git push --force-with-lease origin <branch>` | re-write `changes/{id}.md`; push is a no-op |
+| `gate` | `gh pr review --approve` / approval label read | set the `approval` field |
+| `merge-change` | `gh pr merge …` | set `state: merged` |
+| `close` | `gh issue close …` / `gh pr close …` | set `state: closed` |
+| `create-discussion` / `comment-discussion` | `gh api graphql … addDiscussion* …` | write or append `discussions/{id}.md` |
 
 Name (do not inline) the `kata-dispatch` reactor bridge that `kata-setup`
 generates as the github realization of discussion-event handling, per the scope
 boundary.
 
-Verification: each shape uses placeholder repo forms; no `repos/forwardimpact/monorepo`.
+Verification: every operation from Step 2 has both a github and a filesystem
+cell; each github shape uses placeholder repo forms; no
+`repos/forwardimpact/monorepo`.
 
-## Step 4 — The filesystem column, `.tracker/` format, degradation
+## Step 4 — `.tracker/` layout, envelope templates, degradation note
 
-Intent: give every operation an offline file-write realization and state where
-capabilities degrade.
+Intent: define the on-disk layout the filesystem column writes to, the templates
+`create-*` writes from, and where capabilities degrade.
 
 Files: modify `work-trackers.md`.
 
@@ -97,16 +103,13 @@ Change: the `.tracker/` layout —
   discussions/{id}.md  # RFC threads
 ```
 
-— plus the operation × `filesystem` column: `create-*` writes the file from an
-envelope template; `list` globs + filters front-matter; `read` returns the file
-(reduced field set vs github `--json`); `comment` appends to `## Comments`;
-`label`/`link` edit front-matter; `gate` sets `approval`; `merge-change` sets
-`state: merged`; `open-change`/`update-change` remote-git steps degrade to no-ops
-(the changeset is the working tree at merge time). Include the issue and change
-envelope templates. End with a degradation note: filesystem `read`/`list` return
-a reduced field set; CI-status reads (`gh pr checks`) are github-only; trust that
-a `gate` setter is authorized is out-of-band (the actor is trusted by
-construction).
+— plus the issue and change envelope templates the `create-*` cells write from,
+and a degradation note collecting what the filesystem column's cells abbreviate:
+filesystem `read`/`list` return a reduced field set; CI-status reads
+(`gh pr checks`) are github-only; the `open-change` / `update-change` remote-git
+steps have no remote and are no-ops (the changeset is the working tree at merge
+time); trust that a `gate` setter is authorized is out-of-band (the actor is
+trusted by construction).
 
-Verification: every operation from Step 2 has both a github and a filesystem
-cell; `bun run check` (genericity gate) and `bun run check-skill-refs` pass.
+Verification: the layout, both envelope templates, and the degradation note are
+present; `bun run check` (genericity gate) and `bun run check-skill-refs` pass.

--- a/specs/2090-work-item-provider-abstraction/plan-b-02.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-02.md
@@ -1,7 +1,7 @@
 # Plan 2090-b, Part 02: Re-point the coordination references
 
 Re-express the three shared coordination references and the session
-issue-lifecycle recipes over the abstract operations, moving their forge shapes
+issue-lifecycle recipes over the abstract operations, moving their tracker shapes
 into the matrix. Depends on Part 01. Conventions: [plan-b.md](plan-b.md).
 
 Libraries used: none.

--- a/specs/2090-work-item-provider-abstraction/plan-b-03.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b-03.md
@@ -1,6 +1,6 @@
 # Plan 2090-b, Part 03: Re-point the kata-* skills
 
-Replace every in-scope forge call-site in the kata-* skills and their references
+Replace every in-scope tracker call-site in the kata-* skills and their references
 with an operation name plus a link to `work-trackers.md`. Depends on Part 01.
 Scope boundary (what counts, and the `kata-setup` exclusion) is in
 [plan-b.md](plan-b.md) § Scope boundary. Conventions: [plan-b.md](plan-b.md).
@@ -73,7 +73,7 @@ surfaces.
 Verification: only release-tag/release pushes and reads remain; no `gh pr/issue`
 shape outside the matrix.
 
-## Step 6 — Metric-grade forge reads
+## Step 6 — Metric-grade tracker reads
 
 Files: modify the `references/metrics.md` of `kata-spec`, `kata-design`,
 `kata-plan`, `kata-implement`, `kata-interview`, `kata-product-issue`,

--- a/specs/2090-work-item-provider-abstraction/plan-b.md
+++ b/specs/2090-work-item-provider-abstraction/plan-b.md
@@ -9,7 +9,7 @@ the rejected alternative. Spec, criteria, and exclusions: [spec.md](spec.md).
 ## Approach
 
 Build the tracker matrix as one new agent reference, re-point every in-scope
-forge call-site at the abstract operation it now names, wire `--work-tracker`
+tracker call-site at the abstract operation it now names, wire `--work-tracker`
 into the libeval harness the way `--agent-profile` is already wired, and add an
 offline coordination benchmark task that the harness drives under the filesystem
 tracker. The publish workflow, genericity gate, and `self-improvement.md`
@@ -30,7 +30,7 @@ verifies they stay green rather than reapplying them.
 ### Scope boundary (the criterion-2 set)
 
 Criterion 2 is a mechanical grep. Parts 01–03 are correct only against one fixed
-definition of "commands that act on a forge's work item". This table is that
+definition of "commands that act on a tracker's work item". This table is that
 definition; every part references it rather than re-deriving it.
 
 | Class | In scope — relocate to matrix github column | Out of scope — stays in place |
@@ -59,7 +59,7 @@ The matrix (Part 01) defines these; every other part may only use these names.
 `label`, `link`, `open-change`, `update-change`, `gate`, `merge-change`, `close`,
 `create-discussion`, `comment-discussion`. `triage` = label + comment + close;
 `patch` = open-change + merge-change (compositions, not operations). `read` and
-`list` cover the metric-grade forge queries (`gh pr list`, `gh pr view/diff`,
+`list` cover the metric-grade tracker queries (`gh pr list`, `gh pr view/diff`,
 `gh issue view`); their rich github realizations live in the matrix and degrade
 on filesystem to front-matter globs.
 

--- a/specs/2090-work-item-provider-abstraction/spec.md
+++ b/specs/2090-work-item-provider-abstraction/spec.md
@@ -19,8 +19,8 @@ blocks two outcomes:
 
 1. **The coordination half of each skill goes unmeasured.** `fit-benchmark` runs
    each task in an ephemeral working directory seeded only with the family's
-   fixtures, with no forge credentials and no remote configured; a coordination
-   step that calls a remote forge cannot run there, and a benchmark must stay
+   fixtures, with no tracker credentials and no remote configured; a coordination
+   step that calls a remote tracker cannot run there, and a benchmark must stay
    reproducible and offline regardless. The `kata-skills` benchmark family is
    four independent tasks — three grade a single produced artifact each (spec,
    design, plan) by rubric and judge, and the fourth grades the implementation
@@ -29,7 +29,7 @@ blocks two outcomes:
    it. Coordination is half of what the kata skills do, so a change to filing,
    gating, or merging ships with no evidence it improved anything.
 
-2. **There is no seam for other forges.** A team running the standard against
+2. **There is no seam for other trackers.** A team running the standard against
    Jira or GitLab has nowhere to fit those systems, because the skills and
    references name `gh` rather than an operation.
 
@@ -65,7 +65,7 @@ tracker, plus how an installation selects its active tracker:
 | Tracker | Role |
 | --- | --- |
 | **github** | The current behaviour. Remains the default and production binding. |
-| **filesystem** | New. Issues and changes live as files in the working tree, so coordination needs no network or remote forge. |
+| **filesystem** | New. Issues and changes live as files in the working tree, so coordination needs no network or remote tracker. |
 | **jira**, **gitlab** | Future. Enabled by the seam; not built in this spec. |
 
 Active-tracker selection is a libeval harness concern. The harness reads one
@@ -129,7 +129,7 @@ coordination becomes benchmarkable offline via the filesystem tracker. The
 genericization of the references and `gh`-invoking skills is the necessary means
 to it — a coordination task cannot be benchmarked offline unless the skills it
 exercises stop calling `gh` directly, and the harness can select the offline
-tracker. Multi-forge portability (Jira, GitLab) is an enabled consequence of the
+tracker. Multi-tracker portability (Jira, GitLab) is an enabled consequence of the
 same seam; building those trackers is future work. A `fit-work` operations CLI
 over the matrix is a sequenced follow-up — the matrix is specified now so that
 CLI inherits a stable seam rather than reinventing one.
@@ -139,9 +139,9 @@ CLI inherits a stable seam rather than reinventing one.
 | # | Criterion | Verified by |
 | --- | --- | --- |
 | 1 | A shared resource defines the work-item model (issue, change, envelope) and a tracker matrix listing the abstract operations with at least `github` and `filesystem` columns and a tracker-selection rule. | The resource exists; it contains both columns, every listed operation, and the selection rule. |
-| 2 | Commands that act on a forge's work items (issue, pull-request, discussion, review, label, and remote-git operations) appear in the kata-* skills and shared references only within the github column of the matrix. | Grep for those commands across the kata-* skills and shared references returns hits only inside the matrix. |
+| 2 | Commands that act on a tracker's work items (issue, pull-request, discussion, review, label, and remote-git operations) appear in the kata-* skills and shared references only within the github column of the matrix. | Grep for those commands across the kata-* skills and shared references returns hits only inside the matrix. |
 | 3 | `work-definition.md`, `coordination-protocol.md`, and `approval-signals.md` express work-types, routing, and approval signals over work-item operations, with no GitHub-noun routing outside the matrix. | Review of the three references finds zero coordination instructions naming a GitHub primitive directly. |
-| 4 | `fit-eval` and `fit-benchmark` accept `--work-tracker`, which sets `LIBEVAL_WORK_TRACKER` on the harness; the end-to-end coordination benchmark task completes under `--work-tracker filesystem` with no network access and no remote forge. | The flag appears in each CLI's golden help; the task runs to a verdict in the sandbox with networking unavailable. |
+| 4 | `fit-eval` and `fit-benchmark` accept `--work-tracker`, which sets `LIBEVAL_WORK_TRACKER` on the harness; the end-to-end coordination benchmark task completes under `--work-tracker filesystem` with no network access and no remote tracker. | The flag appears in each CLI's golden help; the task runs to a verdict in the sandbox with networking unavailable. |
 | 5 | The abstract operation names the skills use are tracker-independent; any tracker-specific behaviour appears only in the matrix (including stated degradations per the envelope). | Skill and reference wording outside the matrix contains no tracker-specific branching. |
 | 6 | The `kata-skills` benchmark family includes an end-to-end coordination task graded by invariants asserting on the resulting work-item files. | The task directory exists; its `invariants.sh` asserts on the work-item files. |
 | 7 | The shared resource reaches consuming installations along with the skills that cite it. | The resource resides on the surface that syncs to installations (the published pack), not a tree that stays in-repo. |


### PR DESCRIPTION
## Summary

- Replace "forge" with "tracker" across spec 2090's `spec.md`, both designs, and the `plan-b*` files, so the artifacts read on one vocabulary and can be compared on architecture rather than terminology.
- Render the abstract operations in `design-b.md` as an explicit operation × {github, filesystem} matrix table instead of a prose list, and tighten the work-item envelope table (drop bundled `\|` alternatives, make the Meaning column consistently descriptive, remove the `=` shorthand).
- In `plan-b-01.md`, merge the github-only operations table with the filesystem prose into one side-by-side matrix; Step 4 now owns the `.tracker/` layout, templates, and degradation note.
- Clean the GitHub-backend mermaid node in both designs (`FORGE[(GitHub forge…)]` → `REMOTE[(GitHub…)]`).

These are editorial/readability changes to existing spec-tracked documents; no code behaviour changes.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhMrLhcLVBTjzbCq88uVsJ)_