### PR TITLE
feat(libwiki): MEMORY.md budget, +1d claim expiry, refresh clears expired claims

### DIFF
--- a/.claude/agents/references/memory-protocol.md
+++ b/.claude/agents/references/memory-protocol.md
@@ -175,7 +175,7 @@ Schema (header copied verbatim from `libwiki/constants.js`):
 
 Lifecycle:
 
-- `fit-wiki claim --agent <self> --target <id> --branch <name> [--pr <id>] [--expires-at YYYY-MM-DD]` — defaults `expires_at = +7 days`; exit 2 on dupes.
+- `fit-wiki claim --agent <self> --target <id> --branch <name> [--pr <id>] [--expires-at YYYY-MM-DD]` — defaults `expires_at = +1 day`; exit 2 on dupes.
 - `fit-wiki release --agent <self> --target <id>` — normal removal.
 - `fit-wiki release --expired` — operator cleanup; removes every expired row.
 
@@ -213,4 +213,4 @@ Pair the gate with the pre-PR freshness probe —
 | `memo` | Cross-agent memo writer |
 | `push` / `pull` | Wiki git lifecycle |
 | `init` | Active Claims scaffold; Stop-hook installation |
-| `refresh` | Storyboard + obstacle/experiment marker refresh |
+| `refresh` | Storyboard marker refresh; expired-claim sweep |

--- a/.claude/skills/fit-wiki/SKILL.md
+++ b/.claude/skills/fit-wiki/SKILL.md
@@ -61,8 +61,10 @@ npx fit-wiki log done --agent staff-engineer
 
 ### `claim` / `release` — Active Claims
 
-`claim` refuses duplicates with exit 2. `release --expired` clears every
-row past `expires_at`.
+`claim` refuses duplicates with exit 2 and defaults `expires_at` to
+`claimed_at + 1 day` — a claim is a short-lived "shipping this now" assertion,
+not a lease; override with `--expires-at`. `release --expired` clears every row
+past `expires_at` (so does `refresh`).
 
 ```sh
 npx fit-wiki claim --agent staff-engineer --target spec-NNNN --branch feat/x [--pr NNNN] [--expires-at YYYY-MM-DD]
@@ -115,10 +117,11 @@ npx fit-wiki memo --from technical-writer --to all --message "new XmR baseline"
 | `--to` | Agent name, or `all` to broadcast |
 | `--message` | Memo text |
 
-### `refresh` — Regenerate storyboard charts
+### `refresh` — Regenerate storyboard charts, clear expired claims
 
-Scans for marker pairs and regenerates each. Defaults to the current
-month's storyboard. Idempotent.
+Scans for marker pairs and regenerates each, and sweeps every expired row from
+`MEMORY.md ## Active Claims`. Defaults to the current month's storyboard.
+Idempotent.
 
 ```sh
 npx fit-wiki refresh [storyboard-path]

--- a/.claude/skills/kata-wiki-curate/SKILL.md
+++ b/.claude/skills/kata-wiki-curate/SKILL.md
@@ -27,7 +27,7 @@ with audited surfaces. `fit-wiki fix` auto-clears findings; run it first, then
 | Area               | What to check                                            | Tool                         |
 | ------------------ | -------------------------------------------------------- | ---------------------------- |
 | `contract-audit`   | Every mechanical contract rule passes                    | `fit-wiki fix`, then `audit` |
-| `claims-hygiene`   | Expired or settled claims cleared                        | `fit-wiki release --expired` |
+| `claims-hygiene`   | Expired or settled claims cleared                        | `fit-wiki refresh` |
 | `summary-accuracy` | Each summary _means_ what the agent's latest logs say    | manual (audit can't read it) |
 | `inbox-follow-up`  | `## Message Inbox` entries are acknowledged and acted on | `fit-wiki inbox`             |
 | `memory-index`     | MEMORY.md / Home.md agent descriptions and links current | manual                       |
@@ -89,7 +89,7 @@ invariant above.
 ### Step 2: Claims hygiene
 
 Audit warns (`expired-claim`) on every `## Active Claims` row past its
-`expires_at`; clear them with `npx fit-wiki release --expired` — a stale claim
+`expires_at`; clear them with `npx fit-wiki refresh` — a stale claim
 falsely signals work in flight. For rows not yet expired but naming a PR/Issue
 that has since merged or closed, verify state per the write-time invariant and
 release each via `npx fit-wiki release --agent <agent> --target <id>`.

--- a/libraries/libwiki/README.md
+++ b/libraries/libwiki/README.md
@@ -61,7 +61,8 @@ npx fit-wiki release --expired
 ```
 
 Maintains the `## Active Claims` table in `MEMORY.md`. Duplicates refused;
-row absent means settled.
+row absent means settled. `expires_at` defaults to `claimed_at + 1 day` — a
+claim is a short-lived "shipping this now" assertion, not a lease.
 
 ### `inbox` — triage memos
 
@@ -119,7 +120,9 @@ npx fit-wiki refresh [storyboard-path]
 
 Re-renders `<!-- xmr:metric:csv-path -->` and `<!-- obstacles:open[:Nd] -->`
 marker blocks inside a storyboard from their backing CSV / GitHub state.
-Default path: `wiki/storyboard-YYYY-MMM.md` for the current month.
+Default path: `wiki/storyboard-YYYY-MMM.md` for the current month. Also sweeps
+every expired row from `MEMORY.md ## Active Claims` as part of the same
+deterministic refresh.
 
 ### `init` / `push` / `pull` — wiki working tree
 

--- a/libraries/libwiki/src/audit/rules.js
+++ b/libraries/libwiki/src/audit/rules.js
@@ -8,6 +8,8 @@ import {
   ISSUE_CLOSE_RE,
   ISSUE_OPEN_RE,
   MEMO_INBOX_MARKER,
+  MEMORY_LINE_BUDGET,
+  MEMORY_WORD_BUDGET,
   PRIORITY_INDEX_HEADING,
   STORYBOARD_LINE_BUDGET,
   STORYBOARD_WORD_BUDGET,
@@ -261,6 +263,24 @@ export const RULES = [
     hint: "run `bunx fit-wiki init` to scaffold the canonical sections",
   },
   {
+    id: "memory.line-budget",
+    scope: "memory",
+    severity: "fail",
+    when: memoryExists,
+    check: lineBudget(MEMORY_LINE_BUDGET),
+    message: (_s, r) => `${r.value} lines (limit ${MEMORY_LINE_BUDGET})`,
+    hint: "MEMORY.md holds settled cross-cutting state, not history; release settled claims, prune stale priority rows, and move event-by-event detail to the relevant ledger page or weekly log",
+  },
+  {
+    id: "memory.word-budget",
+    scope: "memory",
+    severity: "fail",
+    when: memoryExists,
+    check: wordBudget(MEMORY_WORD_BUDGET),
+    message: (_s, r) => `${r.value} words (limit ${MEMORY_WORD_BUDGET})`,
+    hint: "MEMORY.md holds settled cross-cutting state, not history; release settled claims, prune stale priority rows, and move event-by-event detail to the relevant ledger page or weekly log",
+  },
+  {
     id: "memory.priority-heading",
     scope: "memory",
     severity: "fail",
@@ -338,7 +358,7 @@ export const RULES = [
     severity: "warn",
     check: expired,
     message: (s) => `${s.agent}/${s.target} expired ${s.expires_at}`,
-    hint: "run `bunx fit-wiki release --expired` to clear expired claims",
+    hint: "run `bunx fit-wiki refresh` (or `release --expired`) to clear expired claims",
   },
 
   // -- Storyboards --

--- a/libraries/libwiki/src/audit/scopes.js
+++ b/libraries/libwiki/src/audit/scopes.js
@@ -137,6 +137,18 @@ function readOptional(filePath, fs) {
   };
 }
 
+// MEMORY.md carries the same line/word budget rules as the prose surfaces, so
+// its subject needs the `lines`/`words` counters those check builders read.
+// Counted off the canonical budget.js pair, like every other budgeted surface.
+function loadMemory(filePath, fs) {
+  const base = readOptional(filePath, fs);
+  return {
+    ...base,
+    lines: countLines(base.text),
+    words: countWords(base.text),
+  };
+}
+
 /**
  * Parse the rows inside STATUS.md's fenced block into audit subjects. Lines
  * outside the ``` fence (header prose) and blank lines are skipped. Each row
@@ -354,7 +366,7 @@ export function buildContext({ wikiRoot, today, fs, subprocess }) {
     wikiRoot,
     today,
     subjects,
-    memory: readOptional(path.join(wikiRoot, "MEMORY.md"), fs),
+    memory: loadMemory(path.join(wikiRoot, "MEMORY.md"), fs),
     status: readOptional(path.join(wikiRoot, "STATUS.md"), fs),
     storyboard: loadStoryboard(wikiRoot, today, fs),
     admission: buildAdmission(wikiRoot, fs, subprocess),

--- a/libraries/libwiki/src/cli-definition.js
+++ b/libraries/libwiki/src/cli-definition.js
@@ -105,7 +105,7 @@ export function createDefinition() {
           pr: { type: "string", description: "Optional PR id" },
           "expires-at": {
             type: "string",
-            description: "Override expiry ISO date (default claim+7d)",
+            description: "Override expiry ISO date (default claim+1d)",
           },
         },
       },
@@ -208,7 +208,7 @@ export function createDefinition() {
       {
         name: "refresh",
         description:
-          "Regenerate XmR and obstacle/experiment marker blocks in a storyboard",
+          "Regenerate storyboard XmR/marker blocks and clear expired MEMORY.md claims",
         args: ["storyboard-path"],
         argsUsage: "[storyboard-path]",
         handler: runRefreshCommand,

--- a/libraries/libwiki/src/commands/claim.js
+++ b/libraries/libwiki/src/commands/claim.js
@@ -162,7 +162,9 @@ export async function runClaimCommand(ctx) {
     };
   }
   const today = options.today || currentDayIso(runtime);
-  const expires = options["expires-at"] || addDays(today, 7);
+  // Default expiry is claim+1 day: a claim is a short-lived "actively shipping
+  // this now" assertion, not a long lease. A run that outlives one day re-claims.
+  const expires = options["expires-at"] || addDays(today, 1);
   const memPath = memoryPath(runtime, options);
   const text = readMemory(runtime, memPath);
   const claim = {

--- a/libraries/libwiki/src/commands/refresh.js
+++ b/libraries/libwiki/src/commands/refresh.js
@@ -10,8 +10,9 @@ import {
   TrackerQueryError,
   parseRepoSlug,
 } from "../issue-list-renderer.js";
+import { parseClaims, filterExpired, removeClaim } from "../active-claims.js";
 import { currentDayIso } from "../util/clock.js";
-import { resolveProjectRoot } from "../util/wiki-dir.js";
+import { resolveProjectRoot, resolveWikiRoot } from "../util/wiki-dir.js";
 
 function currentStoryboardRelPath(runtime) {
   return `wiki/storyboard-${yearMonth(currentDayIso(runtime))}.md`;
@@ -101,12 +102,41 @@ function readStoryboardOrNull(runtime, storyboardPath) {
   }
 }
 
-/** Re-render XmR chart blocks and issue-list blocks in a storyboard file. */
+// Drop every MEMORY.md `## Active Claims` row past its `expires_at`, writing the
+// trimmed table back in place. Refresh is the deterministic "freshen the wiki"
+// step, so clearing lapsed claims belongs here alongside the storyboard render;
+// it runs whether or not the storyboard has marker blocks to regenerate. The
+// write is local, mirroring the storyboard splice — the caller's push publishes
+// it. A missing wiki or claims table is a clean no-op.
+function clearExpiredClaims(runtime, options, today, logger) {
+  const memPath = path.join(resolveWikiRoot(runtime, options), "MEMORY.md");
+  if (!runtime.fsSync.existsSync(memPath)) return;
+  const text = runtime.fsSync.readFileSync(memPath, "utf-8");
+  const { expired } = filterExpired(parseClaims(text), today);
+  if (expired.length === 0) return;
+  let current = text;
+  for (const c of expired) {
+    const result = removeClaim(current, { agent: c.agent, target: c.target });
+    if (result.removed) current = result.text;
+  }
+  if (current !== text) {
+    runtime.fsSync.writeFileSync(memPath, current);
+    logger.info("refresh", `cleared ${expired.length} expired claim(s)`);
+  }
+}
+
+/**
+ * Re-render storyboard XmR/issue-list blocks and clear expired MEMORY.md claims.
+ */
 export async function runRefreshCommand(ctx) {
   const { runtime, gitClient } = ctx.deps;
   const options = ctx.options;
   const logger = createLogger("wiki", runtime);
   const projectRoot = resolveProjectRoot(runtime);
+
+  // Independent of the storyboard render below (and its early returns), so a
+  // wiki with no storyboard or no marker blocks still gets its claims swept.
+  clearExpiredClaims(runtime, options, currentDayIso(runtime), logger);
 
   const storyboardPath = path.resolve(
     projectRoot,

--- a/libraries/libwiki/src/constants.js
+++ b/libraries/libwiki/src/constants.js
@@ -48,17 +48,19 @@ export const PRIORITY_INDEX_TABLE_HEADER =
   "| Item | Agents | Owner | Status | Added |";
 export const DECISION_HEADING = "### Decision";
 
-// Unified budgets for the three audited surfaces (summary, weekly-log,
-// storyboard). They share the same numeric limits today so the
-// context-tax floor is symmetric across surfaces; each surface keeps
-// its own audit rule pair so the limits can diverge later if the
-// context-tax model says one surface should be looser or tighter.
+// Unified budgets for the audited surfaces (summary, weekly-log, storyboard,
+// memory). They keep per-surface rule pairs so the limits can diverge as the
+// context-tax model says one surface should be looser or tighter. MEMORY.md is
+// the tightest: it is read on every boot and holds settled cross-cutting state,
+// not history, so its budget is sized to keep the on-boot read cheap.
 export const SUMMARY_LINE_BUDGET = 496;
 export const SUMMARY_WORD_BUDGET = 2048;
 export const WEEKLY_LOG_LINE_BUDGET = 496;
 export const WEEKLY_LOG_WORD_BUDGET = 6400;
 export const STORYBOARD_LINE_BUDGET = 496;
 export const STORYBOARD_WORD_BUDGET = 6400;
+export const MEMORY_LINE_BUDGET = 128;
+export const MEMORY_WORD_BUDGET = 2048;
 
 // Weekly-log filename convention: `<agent>-YYYY-Www.md` for the live main log
 // and `<agent>-YYYY-Www-partN.md` for a sealed part. Capture groups are

--- a/libraries/libwiki/test/audit-engine.test.js
+++ b/libraries/libwiki/test/audit-engine.test.js
@@ -418,6 +418,29 @@ describe("runRules", () => {
     assert.equal(finding.level, "warn");
   });
 
+  test("over-budget MEMORY.md fires line and word budget rules", () => {
+    // 200 lines × 13 words = 2600 words: over both the 128-line and 2048-word
+    // MEMORY budgets. The canonical sections stay valid so only the budgets fire.
+    const filler = Array.from(
+      { length: 200 },
+      (_, i) =>
+        `word ${i} lorem ipsum dolor sit amet consectetur adipiscing elit sed do`,
+    ).join("\n");
+    const seed = {
+      [`${WIKI}/MEMORY.md`]: `${MEMORY_NONE}\n${filler}\n`,
+      [`${WIKI}/storyboard-2026-M05.md`]: storyboard("2026", "05"),
+    };
+    const ids = idsOf(audit(seed));
+    assert.ok(ids.includes("memory.line-budget"));
+    assert.ok(ids.includes("memory.word-budget"));
+  });
+
+  test("clean MEMORY.md does not fire the budget rules", () => {
+    const ids = idsOf(audit(cleanSeed()));
+    assert.ok(!ids.includes("memory.line-budget"));
+    assert.ok(!ids.includes("memory.word-budget"));
+  });
+
   test("priority separator row missing", () => {
     const seed = {
       [`${WIKI}/MEMORY.md`]: [

--- a/libraries/libwiki/test/audit-rules.test.js
+++ b/libraries/libwiki/test/audit-rules.test.js
@@ -28,6 +28,8 @@ describe("RULES catalogue", () => {
         "carry-surface.h1-agent-matches-filename",
         "carry-surface.entry-has-clearance",
         "memory.file-exists",
+        "memory.line-budget",
+        "memory.word-budget",
         "memory.priority-heading",
         "memory.priority-table-header",
         "memory.priority-separator-row",

--- a/libraries/libwiki/test/cli-claim.test.js
+++ b/libraries/libwiki/test/cli-claim.test.js
@@ -46,6 +46,23 @@ describe("fit-wiki claim/release CLI (in-process)", () => {
     );
   });
 
+  test("claim defaults expiry to claimed_at + 1 day", async () => {
+    const { fsSync, make } = makeWiki();
+    const result = await runClaimCommand(
+      make({
+        agent: "staff-engineer",
+        target: "spec-NNNN",
+        branch: "feat/x",
+        today: "2026-05-19",
+      }).ctx,
+    );
+    assert.equal(result.ok, true);
+    assert.match(
+      fsSync.readFileSync(MEMORY_PATH, "utf-8"),
+      /\| 2026-05-19 \| 2026-05-20 \|/,
+    );
+  });
+
   test("claim refuses duplicates with exit 2", async () => {
     const { make } = makeWiki();
     await runClaimCommand(

--- a/libraries/libwiki/test/cli-refresh.integration.test.js
+++ b/libraries/libwiki/test/cli-refresh.integration.test.js
@@ -125,6 +125,29 @@ describe("fit-wiki refresh CLI (in-process)", () => {
     await assert.doesNotReject(() => refresh(dir, "storyboard.md"));
   });
 
+  test("clears expired MEMORY.md claims even with no storyboard", async () => {
+    const dir = createProject();
+    const wikiDir = join(dir, "wiki");
+    mkdirSync(wikiDir, { recursive: true });
+    // FIXED_NOW is 2026-05-15: the first row is past its expiry, the second is not.
+    writeFileSync(
+      join(wikiDir, "MEMORY.md"),
+      [
+        "## Active Claims",
+        "",
+        "| agent | target | branch | pr | claimed_at | expires_at |",
+        "| --- | --- | --- | --- | --- | --- |",
+        "| staff-engineer | old | feat/o | — | 2026-04-01 | 2026-05-01 |",
+        "| staff-engineer | new | feat/n | — | 2026-05-10 | 2026-06-01 |",
+        "",
+      ].join("\n"),
+    );
+    await refresh(dir, "storyboard.md"); // no storyboard file on disk
+    const after = readFileSync(join(wikiDir, "MEMORY.md"), "utf-8");
+    assert.ok(!after.includes("| old |"), "expired row removed");
+    assert.ok(after.includes("| new |"), "unexpired row kept");
+  });
+
   test("working-directory independence", async () => {
     const dir = createProject();
     const csvDir = join(dir, "wiki", "metrics", "kata-spec");

--- a/libraries/libwiki/test/golden/fit-wiki/claim-help.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/claim-help.stdout.txt
@@ -9,7 +9,7 @@ Options:
   --target=<string>      What is being claimed (spec id, PR id, etc.)
   --branch=<string>      Branch carrying the work
   --pr=<string>          Optional PR id
-  --expires-at=<string>  Override expiry ISO date (default claim+7d)
+  --expires-at=<string>  Override expiry ISO date (default claim+1d)
 
 Global options:
   --help, -h  Show this help

--- a/libraries/libwiki/test/golden/fit-wiki/help-flag.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/help-flag.stdout.txt
@@ -12,7 +12,7 @@ Commands:
   audit                      Audit the wiki against the declarative rule catalogue (line and word budgets, headings, decision blocks, storyboards, claims)
   fix                        Auto-fix wiki audit findings: rotate weekly logs, fix the rest with an AI agent (technical-writer, Haiku), flag the unresolvable
   memo                       Send a cross-team memo into a teammate's Message Inbox
-  refresh [storyboard-path]  Regenerate XmR and obstacle/experiment marker blocks in a storyboard
+  refresh [storyboard-path]  Regenerate storyboard XmR/marker blocks and clear expired MEMORY.md claims
   product-mix                Emit the product-vs-internal mix of merged PRs as a `product_share` metric row
   init                       Bootstrap a wiki working tree and scaffold Active Claims
   push                       Commit and push local wiki changes to the remote

--- a/libraries/libwiki/test/golden/fit-wiki/help.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/help.stdout.txt
@@ -12,7 +12,7 @@ Commands:
   audit                      Audit the wiki against the declarative rule catalogue (line and word budgets, headings, decision blocks, storyboards, claims)
   fix                        Auto-fix wiki audit findings: rotate weekly logs, fix the rest with an AI agent (technical-writer, Haiku), flag the unresolvable
   memo                       Send a cross-team memo into a teammate's Message Inbox
-  refresh [storyboard-path]  Regenerate XmR and obstacle/experiment marker blocks in a storyboard
+  refresh [storyboard-path]  Regenerate storyboard XmR/marker blocks and clear expired MEMORY.md claims
   product-mix                Emit the product-vs-internal mix of merged PRs as a `product_share` metric row
   init                       Bootstrap a wiki working tree and scaffold Active Claims
   push                       Commit and push local wiki changes to the remote

--- a/libraries/libwiki/test/golden/fit-wiki/refresh-help.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/refresh-help.stdout.txt
@@ -1,4 +1,4 @@
-fit-wiki refresh [storyboard-path] — Regenerate XmR and obstacle/experiment marker blocks in a storyboard
+fit-wiki refresh [storyboard-path] — Regenerate storyboard XmR/marker blocks and clear expired MEMORY.md claims
 
 Usage: fit-wiki refresh [storyboard-path] [options]
 

--- a/websites/fit/docs/libraries/predictable-team/wiki-operations/index.md
+++ b/websites/fit/docs/libraries/predictable-team/wiki-operations/index.md
@@ -118,6 +118,11 @@ the metric has fewer than 15 points the block carries an "Insufficient data"
 line instead. Files without markers are left unchanged. The operation is
 idempotent -- running it twice produces the same output.
 
+`refresh` also sweeps expired rows from `MEMORY.md`'s `## Active Claims` table
+as part of the same pass, so a stale claim no longer falsely signals work in
+flight. A claim's expiry defaults to one day after it was made, so this keeps
+the table to genuinely active work.
+
 ## Syncing wiki state
 
 The wiki is a separate git repository cloned into `wiki/` within your project.


### PR DESCRIPTION
## Summary

- Add a **128-line / 2048-word audit budget for `MEMORY.md`** — new `memory.line-budget` and `memory.word-budget` rules, counted off the canonical `budget.js` pair like every other budgeted surface. They default to the `agent` remediation class, so `fit-wiki fix` trims an over-budget MEMORY.md alongside the structural rules.
- **Reduce the default claim expiry from claim+7d to claim+1d** — a claim is a short-lived "shipping this now" assertion, not a lease; a run that outlives a day re-claims.
- **`fit-wiki refresh` now sweeps expired `## Active Claims` rows** as part of its deterministic pass, independent of whether the storyboard has marker blocks. Previously expired-claim cleanup was `release --expired`-only.
- Update `memory-protocol`, the `fit-wiki` / `kata-wiki-curate` skills, the libwiki README, the predictable-team guide, the CLI option/description text, and the golden help fixtures.

New tests cover the budget rules firing (and not firing on a clean file), the +1d default, and refresh clearing an expired row.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8MFwDddvdtp4dU6zdES3Z)_