### PR TITLE
feat(coordinate): work-item tracker abstraction + fit-benchmark improvements (#2090)

### DIFF
--- a/.claude/agents/references/approval-signals.md
+++ b/.claude/agents/references/approval-signals.md
@@ -8,12 +8,19 @@ writes the row.
 
 ## The signals
 
+Each signal is a work-item event — a trusted approval marker on a change
+(`gate`) or a change reaching `merged` (`merge-change`). The concrete shape that
+realizes each on the active tracker lives in the
+[matrix](work-trackers.md#the-matrix) (github: PR label, review, or merge event,
+relayed by the `kata-dispatch` bridge; filesystem: the `approval` field and
+`state: merged`).
+
 | Signal | Source | Captured by |
 |---|---|---|
-| `<phase>:approved` label on PR | Human or `/ship-it` | `kata-dispatch` (label event) |
-| `gh pr review --approve` | Trusted-account approver | `kata-dispatch` (review event) |
-| Approval comment ("approve", "LGTM", "ship it") | Trusted contributor on PR | `kata-dispatch` (comment event) |
-| Merged phase PR | Trusted merger (`kata-release-merge` or human) | `kata-dispatch` (PR close event with `merged: true`) |
+| `<phase>:approved` label on a change | Human or `/ship-it` | `kata-dispatch` (label event) |
+| `gate` — trusted approval marker on a change | Trusted-account approver | `kata-dispatch` (review event) |
+| Approval comment ("approve", "LGTM", "ship it") | Trusted contributor on the change | `kata-dispatch` (comment event) |
+| `merge-change` — a change reaches `merged` | Trusted merger (`kata-release-merge` or human) | `kata-dispatch` (close event with `merged: true`) |
 | Direct user message in interactive session | Trusted user | Active agent (in-session) |
 | `kata-plan` panel-clean | `staff-engineer` (plans only) | `kata-plan` skill |
 | Implementation merge | `kata-release-merge` | Skill (writes `plan implemented`) |
@@ -113,7 +120,7 @@ is stricter than the pin-less spec-row approvals because no spec, design, or
 plan artifact bounds what the approved commits contain.
 
 The signal types feeding `approved` are the trusted-human PR-side signals in
-§ The signals (label, `--approve` review, approval comment, in-session
+§ The signals (label, a `gate` approval marker, approval comment, in-session
 message); an agent verdict is never one of them.
 
 ## Labels remain as input signals

--- a/.claude/agents/references/coordination-protocol.md
+++ b/.claude/agents/references/coordination-protocol.md
@@ -8,32 +8,33 @@ this protocol covers every other output an agent produces.
 
 ## Channel by output type
 
-| Output                                          | Channel           |
-| ----------------------------------------------- | ----------------- |
-| Settled decision; weekly progress; agent state  | Wiki              |
-| Time-series measurement                         | Metrics CSV       |
-| Open question, RFC, cross-product policy debate | Discussion        |
-| Reply tied to one PR or one issue               | PR / issue thread |
-| Experiment or obstacle PDSA state               | Labeled issue     |
-| Mechanical fix or vulnerability patch           | `fix/` branch PR  |
-| Structural finding requiring design             | `spec/` branch PR |
-| Specialized work needed mid-run                 | Sub-agent         |
+Each channel names an [abstract
+operation](work-trackers.md#abstract-operations) (or a non-tracker surface); its
+concrete per-tracker shape lives in the [matrix](work-trackers.md#the-matrix).
+
+| Output                                          | Channel                                  |
+| ----------------------------------------------- | ---------------------------------------- |
+| Settled decision; weekly progress; agent state  | Wiki                                     |
+| Time-series measurement                         | Metrics CSV                              |
+| Open question, RFC, cross-product policy debate | `create-discussion` / `comment-discussion` |
+| Reply tied to one change or one issue           | `comment`                                |
+| Experiment or obstacle PDSA state               | `create-issue` + `label`                 |
+| Mechanical fix or vulnerability patch           | `open-change` (`fix/` branch)            |
+| Structural finding requiring design             | `open-change` (`spec/` branch)           |
+| Specialized work needed mid-run                 | Sub-agent                                |
 
 ## Agent labels on experiment issues
 
 Experiment issues carry an `agent:{name}` label so agents find their work
-during [on-boot routing](memory-protocol.md#on-boot-routing):
-
-```sh
-gh issue list --state open --label experiment --label "agent:staff-engineer"
-```
+during [on-boot routing](memory-protocol.md#on-boot-routing): `list` open issues
+filtered to the `experiment` and `agent:{self}` labels.
 
 Valid labels: `agent:staff-engineer`, `agent:product-manager`,
 `agent:release-engineer`, `agent:security-engineer`, `agent:technical-writer`.
 
 ## Approval signal
 
-Phase artifacts (specs, designs, plans, implementations) are gated into `main`
+Phase artifacts are gated into `main`
 by `kata-release-merge` against `wiki/STATUS.md`. See
 [`approval-signals.md`](approval-signals.md) for the full signal catalogue,
 trust rule, and write protocol. `kata-dispatch` is the bridge from PR-side
@@ -67,32 +68,32 @@ When an output could fit multiple channels, ask in order:
 4. Otherwise → wiki.
 
 A finding can require **multiple channels in parallel** — e.g., a CVE raising
-a policy question is both a `fix/` PR and a Discussion. `fix/` and `spec/`
-branches never share a PR, but either may run alongside a Discussion.
+a policy question is both a `fix/` change and a Discussion. `fix/` and `spec/`
+branches never share a change, but either may run alongside a Discussion.
 
 ## Fix-in-flight marker
 
-A PR body records a change; the coordinating issue coordinates it. An in-run
+A change carries the diff; the coordinating issue coordinates it. An in-run
 decision is not coordinated until it lands where the next reader looks — a
-route decision that lives only in a PR body is invisible to a parallel run
+route decision that lives only in a change body is invisible to a parallel run
 reading the issue, which re-implements the rejected route:
 
-1. **Announce at PR-open.** The implementing run comments on the coordinating
-   issue at or before PR-open: PR link, branch, and any route decision made
-   in-run.
+1. **Announce at `open-change`.** The implementing run comments on the
+   coordinating issue at or before `open-change`: the change link, branch, and
+   any route decision made in-run.
 2. **Close alternatives where they were opened.** When an issue thread poses
    routes A/B, the selection lands on that thread naming the rejected route
    ("took A, not B") — so a later reader knows B is rejected, not unexplored.
 3. **Rescopes name in-flight state.** A comment that redefines an issue's
-   actionable scope states what is in flight (claim, branch, or PR) — or the
+   actionable scope states what is in flight (claim, branch, or change) — or the
    explicit negative: "no fix in flight as of this comment." Closure and
    routing comments are rescopes: a comment that closes a thread or routes a
    decision or disposition to a named owner redefines actionable scope even
    though it reads as terminal, so it carries the same marker and reminds the
-   routed owner to announce at PR-open. A rescope is a
+   routed owner to announce at `open-change`. A rescope is a
    latest-state beacon; silence reads as an open invitation.
 
-A PR body may repeat a decision, never replace it.
+A change body may repeat a decision, never replace it.
 
 ## Cross-agent escalation
 
@@ -117,19 +118,23 @@ lands where the next reader looks.
    point-in-time and can false-negative against a moving origin — none is
    sufficient absence evidence alone, and a false "nothing exists" mints
    duplicate work with no concurrency required:
+   The change-existence probes are the `list` operation (concrete shape per
+   tracker in the [matrix](work-trackers.md#the-matrix)); branch existence is a
+   canonical-state read, not a tracker operation:
    - **Branch existence:** `git ls-remote origin "refs/heads/<branch>"` —
      exact ref only; glob refspecs fail silent on a miss.
-   - **PR existence:** `gh pr list --head <branch> --state all` — catches
-     a branch pushed before its PR opens, the costliest duplicate window.
-   - **Topic search:** `gh pr list --search "<issue#>" --state all`.
-     `--state all` is load-bearing — a merged or closed PR on the target
-     changes the route as much as an open one does.
+   - **Change existence:** `list` changes by head branch, across **all**
+     states — catches a branch pushed before its change opens, the costliest
+     duplicate window.
+   - **Topic search:** `list` changes searching the `<issue#>`, across **all**
+     states. All-states is load-bearing — a merged or closed change on the
+     target changes the route as much as an open one does.
    Run the probes twice: at implementation start, and again immediately
-   before `gh pr create` — the search index lags by minutes, and minutes
+   before `open-change` — the search index lags by minutes, and minutes
    are exactly the collision window. The probe complements the claim
    handshake; it never replaces it.
-3. **Create** the PR, then announce it on the coordinating issue per the
-   fix-in-flight marker rule.
+3. **Create** the change (`open-change`), then announce it on the coordinating
+   issue per the fix-in-flight marker rule.
 
 ## Inbound: unclear addressed comments
 
@@ -161,23 +166,18 @@ their behalf.
 Cite every non-wiki output in the wiki log so the deliberation trail stays
 linked. Format: `<Channel> <ref>: <one-line topic> (<URL>)`.
 
-## Creating outputs (gh CLI)
+## Creating outputs
 
-`gh` is the authorized tool for every non-wiki output. Capture the returned
-URL for the citation format above.
-
-- **Issue comment:** `gh issue comment <N> --body "<text>"`
-- **PR comment:** `gh pr comment <N> --body "<text>"`
-- **New Discussion:**
-  `gh api graphql -f query='mutation { createDiscussion(input: {...}) {...} }'`
-- **Discussion comment:**
-  `gh api graphql -f query='mutation { addDiscussionComment(input: {...}) {...} }'`
-  — pass `replyToId` to thread.
+Each non-wiki output names an operation — `comment`,
+`create-discussion` / `comment-discussion`, `create-issue`, `open-change`. The
+shape realizing each on the active tracker lives in
+[`work-trackers.md`](work-trackers.md); capture the returned id/URL for the
+citation above.
 
 ## `## Coordination Channels` block in a skill
 
 A skill carries this block when its procedure produces non-wiki, non-fix/spec
-outputs needing cross-agent or external visibility — typically PR comments,
-issue comments, or Discussions. Skills whose only outputs are wiki appends
+outputs needing cross-agent visibility — typically `comment` on a
+change or issue, or Discussions. Skills whose only outputs are wiki appends
 and fix/spec branches don't need the block; this file plus
 `memory-protocol.md` govern routing for those.

--- a/.claude/agents/references/work-definition.md
+++ b/.claude/agents/references/work-definition.md
@@ -10,7 +10,9 @@ rubric; the sibling references own the rest.
   [`coordination-protocol.md`](coordination-protocol.md).
 - **Gating** — how phase artifacts enter `main` — lives in
   [`approval-signals.md`](approval-signals.md).
-- **Commands** — the `gh` shapes for obstacle/experiment issues — live in
+- **Commands** — the concrete shapes for each operation live in
+  [`work-trackers.md`](work-trackers.md); the obstacle/experiment recipes that
+  compose them are in
   [`issue-lifecycle.md`](../../skills/kata-session/references/issue-lifecycle.md)
   and the agent profiles (branch names).
 
@@ -18,16 +20,21 @@ rubric; the sibling references own the rest.
 
 Cross-references only — see the owning reference for routing/gate detail.
 
-| Work-type          | What it is                                                   | Created via          |
-| ------------------ | ----------------------------------------------------------- | -------------------- |
-| **fix / bug**      | A mechanical, bounded correction with an obvious resolution | Direct git ops       |
-| **spec**           | The WHAT/WHY of a structural change                         | `kata-spec`          |
-| **design**         | The WHICH/WHERE — an architectural sketch for a spec        | `kata-design`        |
-| **plan**           | The HOW/WHEN — executable steps for a design                | `kata-plan`          |
-| **implementation** | The diff that executes an approved plan                     | `kata-implement`     |
-| **obstacle**       | A measured gap blocking a target condition                  | labeled issue        |
-| **experiment**     | The next testable step against an obstacle                  | labeled issue        |
-| **Discussion/RFC** | An unsettled cross-cutting question                         | `gh` Discussion      |
+Each "Created via" names an [abstract
+operation](work-trackers.md#abstract-operations) or the skill that drives it;
+the operation's concrete shape lives in the
+[matrix](work-trackers.md#the-matrix).
+
+| Work-type          | What it is                                                   | Created via                       |
+| ------------------ | ----------------------------------------------------------- | --------------------------------- |
+| **fix / bug**      | A mechanical, bounded correction with an obvious resolution | `open-change`                     |
+| **spec**           | The WHAT/WHY of a structural change                         | `kata-spec`                       |
+| **design**         | The WHICH/WHERE — an architectural sketch for a spec        | `kata-design`                     |
+| **plan**           | The HOW/WHEN — executable steps for a design                | `kata-plan`                       |
+| **implementation** | The diff that executes an approved plan                     | `kata-implement`                  |
+| **obstacle**       | A measured gap blocking a target condition                  | `create-issue` + `obstacle` label |
+| **experiment**     | The next testable step against an obstacle                  | `create-issue` + `experiment` label |
+| **Discussion/RFC** | An unsettled cross-cutting question                         | `create-discussion`               |
 
 Routing per work-type is in [`coordination-protocol.md` § Channel by output
 type](coordination-protocol.md#channel-by-output-type); gating is in
@@ -39,7 +46,7 @@ type](coordination-protocol.md#channel-by-output-type); gating is in
 
 - **Mechanical (fix)** — the resolution is clear and bounded; it replaces no
   architecture, introduces no component or contract, and crosses no scope
-  boundary. → `fix/` branch, direct git ops.
+  boundary. → `fix/` branch via `open-change`.
 - **Structural (spec)** — it needs a design decision, introduces or changes a
   component or contract, or exceeds the finder's scope. → `spec/` via
   `kata-spec`.
@@ -113,8 +120,10 @@ branches from mixing (`KATA.md` § Agents, § Design Principles).
   carries each work-type, and the decision-question order.
 - [`approval-signals.md`](approval-signals.md) — how phase artifacts are gated
   into `main`.
+- [`work-trackers.md`](work-trackers.md) — the concrete shape for each abstract
+  operation, per tracker.
 - [`issue-lifecycle.md`](../../skills/kata-session/references/issue-lifecycle.md)
-  — the `gh` recipes for obstacle and experiment issues.
+  — the operation recipes for obstacle and experiment issues.
 - `kata-pattern-synthesis` (corpus mapping) and `kata-session`
   [team-storyboard](../../skills/kata-session/references/team-storyboard.md)
   Q3 routing are **specializations** that build on this rubric.

--- a/.claude/agents/references/work-trackers.md
+++ b/.claude/agents/references/work-trackers.md
@@ -1,0 +1,170 @@
+# Work Trackers
+
+This file is the **single place** tracker-specific commands appear. Every kata-*
+skill and shared reference names an **abstract operation** (below) and links
+here; the concrete command for that operation lives in this matrix, one cell per
+tracker. A skill never branches on the tracker — it names the operation and lets
+the active column realize it.
+
+The active tracker is one input: the environment variable
+`LIBEVAL_WORK_TRACKER`, default `github`. The harness sets it (`fit-eval` /
+`fit-benchmark` `--work-tracker`); the agent reads it and realizes each
+operation through that column. Production leaves the default `github`; the
+offline coordination benchmark runs `--work-tracker filesystem`.
+
+A **work item** is a tracked unit of coordination. It has two **kinds** — an
+**issue** (a tracked unit of work or finding: bug, feature, obstacle,
+experiment, RFC) and a **change** (a proposed diff carrying an approval gate, a
+GitHub pull request) — that share one **envelope**.
+
+## Envelope
+
+Every work item carries the same capabilities, the envelope, as YAML
+front-matter on the filesystem tracker and as native fields on github:
+
+| Field | Meaning | github | filesystem |
+| --- | --- | --- | --- |
+| `id` | stable identity | issue/PR number + URL | caller-supplied slug; the file path is the id |
+| `kind` | issue or change | issue or pull request | file under `issues/` or `changes/` |
+| `state` | lifecycle: open, closed, or merged | issue/PR state | front-matter value |
+| `labels` | classification, including `agent:*` | issue/PR labels | front-matter list |
+| `links` | related work-item ids | issue references | front-matter list |
+| `discussion` | comment thread | native issue/PR thread | appended `## Comments` section |
+| `approval` | change-only trusted gate | PR label or review by a trusted human | front-matter value |
+
+Where a tracker cannot express a capability, the matrix states how it degrades
+(§ Degradation).
+
+## Abstract operations
+
+Every tracker realizes the same fixed set. A skill may use only these names:
+
+- `create-issue` — open a tracked unit of work or finding.
+- `list` — enumerate issues or changes, filtered.
+- `read` — fetch one item (body, state, metadata; CI status on github).
+- `comment` — append to an item's discussion.
+- `label` — add or change classification labels.
+- `link` — relate one item to another.
+- `open-change` — propose a diff carrying an approval gate.
+- `update-change` — revise an open change's diff.
+- `gate` — record a trusted approval on a change.
+- `merge-change` — accept a change into the trunk.
+- `close` — close an issue or change without merging.
+- `create-discussion` / `comment-discussion` — open or append an RFC thread.
+
+`triage` is a composition (`label` + `comment` + `close`); `patch` is a
+composition (`open-change` + `merge-change`). Neither is a first-class
+operation.
+
+## The matrix
+
+github cells use the placeholder repo form `repos/{owner}/{repo}`; substitute
+the live repo. The shapes are canonical — pass the flags each call site needs.
+
+| Operation | github | filesystem |
+| --- | --- | --- |
+| `create-issue` | `gh issue create --title "<t>" --body "<b>" [--label <l>]` | write `issues/{id}.md` from the issue template |
+| `list` | `gh issue list --state <s> [--label <l>] [--json <fields>]` / `gh pr list --state <s> [--base main] [--head <branch>] [--search "<q>"] [--author <a>] [--json <fields>]` | glob `issues/` or `changes/` and filter on front-matter (reduced field set) |
+| `read` | `gh issue view <n> --json <fields>` / `gh pr view <n> --json <fields>` / `gh pr diff <n>` / `gh pr checks <n>` / `gh api repos/{owner}/{repo}/issues/<n>/comments` / approval-event reads `gh api repos/{owner}/{repo}/issues/<n>/timeline` (label-add events) and `gh api repos/{owner}/{repo}/pulls/<n>/reviews` (APPROVED reviews) | return the item file; CI-status and approval-event history are github-only — the filesystem item carries `labels` and `approval` in front-matter, with no separate event log |
+| `comment` | `gh issue comment <n> --body "<b>"` / `gh pr comment <n> --body "<b>"` | append to the item's `## Comments` |
+| `label` | `gh issue edit <n> --add-label "<l>"` / `gh label <…>` | edit the `labels` front-matter |
+| `link` | name the related `#<n>` in the body (github renders a bidirectional cross-reference) | edit the `links` front-matter |
+| `open-change` | `git switch -c <branch>` + `git push -u origin <branch>` + `gh pr create --title "<t>" --body "<b>"` | write `changes/{id}.md`; the remote-git steps are no-ops |
+| `update-change` | `git push --force-with-lease origin <branch>` | re-write `changes/{id}.md`; the push is a no-op |
+| `gate` | `gh pr review <n> --approve`, or a trusted `<phase>:approved` label / approval comment read by `kata-dispatch` | set the `approval` field |
+| `merge-change` | `gh pr merge <n> --merge --delete-branch` (or `--squash --auto`) | set `state: merged` |
+| `close` | `gh issue close <n> [--reason "not planned"]` / `gh pr close <n> --comment "<b>"` | set `state: closed` |
+| `create-discussion` | `gh api graphql -f query='mutation { createDiscussion(input: {…}) { … } }'` | write `discussions/{id}.md` |
+| `comment-discussion` | `gh api graphql -f query='mutation { addDiscussionComment(input: {…}) { … } }'` (pass `replyToId` to thread) | append to `discussions/{id}.md` |
+
+**Dispatch bridge (github).** Discussion-event and PR-side approval handling on
+github runs through the `kata-dispatch` reactor that `kata-setup` generates and
+wires (App, secrets, reactor workflow). That generated wiring is the github
+tracker's own provisioning, not portable coordination — see
+[`kata-setup`](../../skills/kata-setup/SKILL.md). The matrix names it here; it
+does not relocate the generated YAML.
+
+## Filesystem layout
+
+The filesystem tracker keeps one file per item under a coordination root
+`.tracker/` in the working tree, tracker-owned and disjoint from app files. The
+root is named generically so an agent reading the tree infers the active store
+without consulting this file:
+
+```
+.tracker/
+  issues/{id}.md       # envelope front-matter + body; ## Comments appended
+  changes/{id}.md      # envelope (kind: change) + links to its issue(s)
+  discussions/{id}.md  # RFC threads
+```
+
+`id` is a caller-supplied slug, so the `{id}.md` path is the identity (no
+tracker-minted monotonic id, which would be non-deterministic). `create-*`
+writes a file from the template below; `list` globs and filters on front-matter;
+`read` returns the file; `comment` appends to `## Comments`; `gate` sets
+`approval`; `merge-change` sets `state: merged`; `close` sets `state: closed`. A
+change file carries only its envelope — the changeset is the working tree at
+merge time, not a materialized patch.
+
+### Issue template
+
+```markdown
+---
+id: <slug>
+kind: issue
+state: open
+labels: []
+links: []
+---
+
+# <title>
+
+<body>
+
+## Comments
+```
+
+### Change template
+
+```markdown
+---
+id: <slug>
+kind: change
+state: open
+labels: []
+links: [<issue-id>]
+approval:
+---
+
+# <title>
+
+<body>
+
+## Comments
+```
+
+## Degradation
+
+Where a tracker cannot express a capability, it degrades as follows:
+
+- **Reduced field set (filesystem).** `read` and `list` return only what the
+  front-matter and body carry; rich github `--json` field sets have no
+  filesystem analogue.
+- **CI status is github-only.** `gh pr checks` / `gh pr diff` have no filesystem
+  equivalent; the filesystem `read` returns the file alone.
+- **Remote-git steps are no-ops (filesystem).** `open-change` and
+  `update-change` have no remote to target; the changeset is the working tree at
+  merge time. No network, remote, or git is required — plain file writes.
+- **Out-of-band trust (filesystem).** The `approval` field records the granting
+  signal; trust that the setter is authorized is out-of-band — the actor that
+  runs `gate` is trusted by construction (the benchmark harness or a human).
+  Emulating contributor-list trust offline is not attempted.
+
+## See also
+
+- [`work-definition.md`](work-definition.md) — what each work-type is, and how
+  to classify a finding into one.
+- [`coordination-protocol.md`](coordination-protocol.md) — which operation
+  carries each output type.
+- [`approval-signals.md`](approval-signals.md) — how a `gate` and a
+  `merge-change` feed `wiki/STATUS.md`.

--- a/.claude/skills/fit-benchmark/SKILL.md
+++ b/.claude/skills/fit-benchmark/SKILL.md
@@ -91,7 +91,7 @@ paths instead of reconstructing them from `$0`):
 
 | Var | Value |
 | --- | --- |
-| `WORKDIR` | Agent CWD (the per-task copy). |
+| `AGENT_CWD` | Agent CWD (the per-task copy) — reference emitted files as `$AGENT_CWD/<path>`. |
 | `PORT` | Allocated free TCP port. |
 | `TASK_ID` | Task name (directory under `tasks/`). |
 | `TASK_DIR` | Task directory on the host. |
@@ -107,7 +107,7 @@ Install and run via npm:
 npx fit-benchmark <command> [options]
 ```
 
-The full flag surface lives in [references/cli.md](references/cli.md).
+The full flag surface lives in [references/cli.md](references/cli.md); task-authoring guidance (local skills, invariants, fast iteration, file-grading) in [references/authoring.md](references/authoring.md).
 
 ## GitHub Action
 
@@ -165,8 +165,8 @@ The `judge.task.md` template supports these variables:
 | Surface | Example |
 | --- | --- |
 | **Running service** | HTTP-probe `http://127.0.0.1:$PORT/` and assert the response shape. |
-| **Repository state** | Assert the SHA-256 of `$WORKDIR/result.txt`. |
-| **Process exit** | Run a command in `$WORKDIR` and treat exit-zero as pass. |
+| **Repository state** | Assert the SHA-256 of `$AGENT_CWD/result.txt`. |
+| **Process exit** | Run a command in `$AGENT_CWD` and treat exit-zero as pass. |
 
 ## Result Records
 

--- a/.claude/skills/fit-benchmark/references/authoring.md
+++ b/.claude/skills/fit-benchmark/references/authoring.md
@@ -1,0 +1,88 @@
+# Authoring task families
+
+Guidance for writing and iterating on tasks, beyond the format in the skill.
+
+## Test local, unpublished skills
+
+A benchmark normally `apm install`s the published skill pack named in
+`apm.yml`, so by default it grades the *published* skills. To benchmark skills
+you have changed but not yet published, point `--skills-from` at a directory
+that contains a `.claude/` tree (for example your working tree's root):
+
+```sh
+npx fit-benchmark run --family=./families/coding --skills-from=. --task=todo-api
+```
+
+The harness stages that `.claude/` instead of running `apm install`, so the
+agent runs against your local skills. Omit `--skills-from` to grade the
+published pack. This is how you prove a skill change before publishing it.
+
+## The invariants authoring contract
+
+`hooks/invariants.sh` decides the verdict by exit code (`0` = pass) and writes
+optional per-check rows as NDJSON to `$RESULTS_FD`. Grade with the
+`fit-trace assert` harness — make sure it resolves (it ships with the eval
+tooling; invoke it through your package runner if it is not on `PATH`):
+
+```sh
+#!/bin/sh
+set -u
+FAIL=0
+assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+```
+
+Two things that bite authors:
+
+- **`--grep` is JavaScript-regex, not POSIX.** Use `\s` / `\S`, not
+  `[[:space:]]` / `[[:graph:]]` (those silently fail to match).
+- **`assert` takes one file, not a glob.** Resolve the path in shell first,
+  then assert on it:
+
+  ```sh
+  ITEM=$(ls "$AGENT_CWD"/items/*.md 2>/dev/null | head -1)
+  assert item-present --exists "$ITEM"
+  ```
+
+Reference the agent's emitted files as `$AGENT_CWD/<path>` — `AGENT_CWD` is the
+agent CWD itself, not a parent containing `cwd/`.
+
+## Fast iteration
+
+Two LLM sessions per run (agent + judge) cost real money, so confirm the
+mechanics before paying for full runs:
+
+- **Validate hooks with no agent.** Hand-author a post-run directory (a
+  `cwd/` holding the files a correct agent would emit) and run the invariants
+  alone:
+
+  ```sh
+  npx fit-benchmark invariants --family=./fam --task=mytask --run-dir=./fixture
+  ```
+
+  Confirm it passes on a correct fixture and fails on a broken one before
+  wiring an agent run.
+- **Scope agent runs while authoring.** `--task=<id>` runs one task instead of
+  the whole family; `--runs=1` runs it once.
+
+## Grading emitted files (non-coding tasks)
+
+Tasks need not grade a coding diff. A task can ask the agent to *produce files*
+and grade their content — useful for coordination, document, or data-shaping
+work. The agent writes under `$AGENT_CWD`; `invariants.sh` asserts on the
+result:
+
+```sh
+#!/bin/sh
+set -u
+OUT="$AGENT_CWD/out/record.md"
+FAIL=0
+assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+
+assert produced  --exists "$OUT"
+assert has-state --grep 'state:\s*done' "$OUT" --message "record not marked done"
+[ "$FAIL" = 0 ] && exit 0 || exit 1
+```
+
+Seed any inputs the agent reads under the task's `workdir/` (copied into
+`$AGENT_CWD` before the run); a `hooks/preflight.sh` can confirm the seed and
+that no output exists yet.

--- a/.claude/skills/fit-benchmark/references/cli.md
+++ b/.claude/skills/fit-benchmark/references/cli.md
@@ -19,6 +19,9 @@ npx fit-benchmark <command> [options]
 | Flag               | Required | Purpose                                                                                          |
 | ------------------ | -------- | ------------------------------------------------------------------------------------------------ |
 | `--family`         | yes      | Path or git URL of the task family                                                               |
+| `--task`           | no       | Run only this task id (directory under `tasks/`); default runs every task                        |
+| `--skills-from`    | no       | Stage `.claude/` from this directory (a root containing `.claude/`) instead of running apm install — benchmark local, unpublished skills |
+| `--work-tracker`   | no       | Active work-item tracker the agent coordinates through: `github` or `filesystem` (default `github`) |
 | `--output`         | no       | Run-output directory (created if missing, default `benchmark-runs`)                              |
 | `--runs`           | no       | Runs per task (default `5`)                                                                      |
 | `--agent-model`    | no       | Claude model for the agent-under-test (default `claude-sonnet-4-6`)                              |
@@ -40,7 +43,7 @@ subcommand. Exit code is `0` if every record's combined verdict is
 | ------------ | -------- | ---------------------------------------------------------------------------------------- |
 | `--family`   | yes      | Path or git URL of the task family                                                       |
 | `--task`     | yes      | Task id (directory name under `tasks/`)                                        |
-| `--workdir`  | yes      | Post-run directory. `<workdir>/cwd/` is the agent CWD; invariants run against it.        |
+| `--run-dir`  | yes      | Post-run directory whose `cwd/` subdir is the agent CWD; invariants run against that cwd (the path hooks see as `$AGENT_CWD`). |
 | `--output`   | no       | Output file path (defaults to stdout; one JSONL line)                                    |
 
 `invariants` emits an `InvariantsRecord` (narrower than the full `ResultRecord` —

--- a/.claude/skills/kata-backlog-synthesis/SKILL.md
+++ b/.claude/skills/kata-backlog-synthesis/SKILL.md
@@ -33,13 +33,11 @@ patterns from noise.
 
 ## Triggers
 
-```sh
-# Eligibility — at least one threshold must hold. Comma-separated `--label` ANDs;
-# query each label separately, raise `--limit` past 30, and dedupe for the OR-union.
-{ gh issue list --label obstacle --state open --json number --limit 1000;
-  gh issue list --label experiment --state open --json number --limit 1000; } \
-  | jq -s 'add | unique_by(.number) | length'   # ≥10 → eligible
-```
+Eligibility — at least one threshold must hold. `list` open issues for the
+`obstacle` and `experiment` labels separately, then dedupe by number for the
+OR-union (a label filter ANDs, so a single combined query would miss items
+carrying only one label); ≥10 unique items → eligible
+([work-trackers.md](../../agents/references/work-trackers.md)).
 
 A sweep processes every eligible cluster, at most once per ISO week, unless a
 producer-orphaning event forces it.

--- a/.claude/skills/kata-design/references/metrics.md
+++ b/.claude/skills/kata-design/references/metrics.md
@@ -4,7 +4,7 @@ Record per KATA.md § Metrics. Append one row per run.
 
 | Metric          | Unit  | Description                          | Data source |
 | --------------- | ----- | ------------------------------------ | ----------- |
-| designs_drafted | count | Design PRs opened or merged this run | gh pr list  |
+| designs_drafted | count | Design PRs opened or merged this run | `list` changes ([work-trackers.md](../../../agents/references/work-trackers.md)) |
 
 Design backlog (`specs/` with `spec.md` but no `design-a.md`) is queried,
 not recorded.

--- a/.claude/skills/kata-documentation/SKILL.md
+++ b/.claude/skills/kata-documentation/SKILL.md
@@ -153,11 +153,10 @@ Verbs: `add` for new pages, `update` for changes, `fix` for corrections.
 
 ### Publishing changes
 
-Commits are not visible until pushed. After committing on a branch:
-
-1. **Push the branch** — `git push -u origin <branch>`
-2. **Open a PR** — `gh pr create --title "<title>" --body "<body>"`, holding the
-   PR body to [Citation integrity](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/citation-integrity.md).
+Commits are not visible until pushed. After committing on a branch, `open-change`
+([work-trackers.md](../../agents/references/work-trackers.md)) with the title and
+body, holding the PR body to
+[Citation integrity](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/citation-integrity.md).
 
 Each branch gets its own PR. Fix and spec branches are independent — push and PR
 each one separately. Wiki changes follow the wiki curation skill's publishing

--- a/.claude/skills/kata-implement/SKILL.md
+++ b/.claude/skills/kata-implement/SKILL.md
@@ -38,9 +38,9 @@ alongside the skill-specific ones below.
       `push` per
       [memory-protocol § Active Claims](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/memory-protocol.md#active-claims).
 - [ ] Probe the remote of record: `git ls-remote origin
-      "refs/heads/<branch>"`, `gh pr list --head <branch> --state all`,
-      and `--search "<spec #>" --state all`
-      ([§ Claim → probe → create](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/coordination-protocol.md#claim--probe--create)).
+      "refs/heads/<branch>"` and `list` changes by head branch and by spec
+      number, any state ([work-trackers.md](../../agents/references/work-trackers.md);
+      [§ Claim → probe → create](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/coordination-protocol.md#claim--probe--create)).
 - [ ] Read the full spec and all plan files before writing any code.
 - [ ] Implement plan-a unless explicitly directed to a different variant.
 - [ ] Implement only what the plan describes — no unrequested refactors,
@@ -159,7 +159,7 @@ before advancing.
 ### Step 8: Open an implementation PR
 
 Push commits only after the panel is clean; re-run the READ-DO freshness probe
-before `gh pr create`. Title the PR with the spec id: `feat(scope): ... (#NNN)`.
+before the `open-change`. Title the PR with the spec id: `feat(scope): ... (#NNN)`.
 After opening, announce and route on the coordinating issue per
 [coordination-protocol § Claim → probe → create](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/coordination-protocol.md#claim--probe--create),
 and hold the PR body to [Citation integrity](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/citation-integrity.md).

--- a/.claude/skills/kata-implement/references/metrics.md
+++ b/.claude/skills/kata-implement/references/metrics.md
@@ -5,7 +5,7 @@ one row per run.
 
 | Metric                  | Unit  | Description                                  | Data source |
 | ----------------------- | ----- | -------------------------------------------- | ----------- |
-| implementations_shipped | count | Implementation PRs opened or merged this run | gh pr list  |
+| implementations_shipped | count | Implementation PRs opened or merged this run | `list` changes ([work-trackers.md](../../../agents/references/work-trackers.md)) |
 
 `implementations_shipped` is route-bearing: every row records which route
 the activation took and which were eligible-but-not-taken. See

--- a/.claude/skills/kata-interview/references/metrics.md
+++ b/.claude/skills/kata-interview/references/metrics.md
@@ -4,4 +4,4 @@ Record per KATA.md § Metrics. Append one row per session.
 
 | Metric         | Unit  | Description                              | Data source   |
 | -------------- | ----- | ---------------------------------------- | ------------- |
-| issues_created | count | GitHub issues filed from this interview  | gh issue list |
+| issues_created | count | GitHub issues filed from this interview  | `list` issues ([work-trackers.md](../../../agents/references/work-trackers.md)) |

--- a/.claude/skills/kata-plan/references/metrics.md
+++ b/.claude/skills/kata-plan/references/metrics.md
@@ -4,7 +4,7 @@ Record per KATA.md § Metrics. Append one row per run.
 
 | Metric        | Unit  | Description                        | Data source |
 | ------------- | ----- | ---------------------------------- | ----------- |
-| plans_drafted | count | Plan PRs opened or merged this run | gh pr list  |
+| plans_drafted | count | Plan PRs opened or merged this run | `list` changes ([work-trackers.md](../../../agents/references/work-trackers.md)) |
 
 Plan backlog (`specs/` with `design-a.md` but no `plan-a.md`) is queried,
 not recorded.

--- a/.claude/skills/kata-product-issue/SKILL.md
+++ b/.claude/skills/kata-product-issue/SKILL.md
@@ -83,20 +83,16 @@ from prior entries.
 
 ### Step 1: List Open Issues
 
-```sh
-gh issue list --state open --limit 50 \
-  --search "-label:experiment -label:obstacle" \
-  --json number,title,body,author,labels,createdAt,updatedAt \
-  --jq '.[] | {number, title, author: .author.login, labels: [.labels[].name], created: .createdAt}'
-```
+`list` open issues (cap ~50), excluding `experiment` and `obstacle` labels,
+reading number, title, body, author, labels, and timestamps
+([work-trackers.md](../../agents/references/work-trackers.md)).
 
 Skip issues with `triaged` or `wontfix` labels.
 
 ### Step 2: Read and Classify Each Issue
 
-```sh
-gh issue view <number> --json title,body,comments,labels,author
-```
+`read` the issue's title, body, comments, labels, and author
+([work-trackers.md](../../agents/references/work-trackers.md)).
 
 Classify against the table above. Record reasoning briefly so a future run can
 audit the decision.

--- a/.claude/skills/kata-product-issue/references/metrics.md
+++ b/.claude/skills/kata-product-issue/references/metrics.md
@@ -21,5 +21,6 @@ Suppressing zero-rows on clean assesses contaminates the XmR signal with
 selection bias — runs get dropped precisely when no work happened, which is
 the data point.
 
-Backlog (`gh issue list`) is queried, not recorded — it's a stock, not process
-data.
+Backlog (`list` issues —
+[work-trackers.md](../../../agents/references/work-trackers.md)) is queried, not
+recorded — it's a stock, not process data.

--- a/.claude/skills/kata-product-issue/references/templates.md
+++ b/.claude/skills/kata-product-issue/references/templates.md
@@ -5,32 +5,29 @@ comment and PR body is signed `— Product Manager 🌱`.
 
 ## Issue Comments
 
-Use `gh issue comment <number> --body "<text>"` with the text below, selecting
-the variant that matches the triage decision. For `wontfix` and duplicate
-outcomes, chain `gh issue edit --add-label` and/or `gh issue close` after the
+`comment` on the issue with the text below, selecting the variant that matches
+the triage decision ([work-trackers.md](../../../agents/references/work-trackers.md)).
+For `wontfix` and duplicate outcomes, chain `label` and/or `close` after the
 comment.
 
 | Outcome             | Body text                                                                                                                                 | Follow-up                                   |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
 | **Mechanical fix**  | Thanks for reporting this! I can see the problem — I'll put together a fix now.                                                           | —                                           |
 | **Product-aligned** | Thanks for this suggestion! This aligns with our product direction. I'm going to write up a spec so we can plan the implementation.       | —                                           |
-| **Out of scope**    | Thanks for taking the time to open this! After reviewing it against our product direction, this falls outside our current scope. _<why>_. | `--add-label wontfix`; `gh issue close`     |
-| **Duplicate**       | Thanks for reporting this! This is already tracked in #<original>, so I'll close this one as a duplicate.                                 | `gh issue close --reason "not planned"`     |
-| **Needs info**      | Thanks for opening this! I'd like to help, but I need a bit more context: _<specific questions>_.                                         | `--add-label needs-info` (do **not** close) |
+| **Out of scope**    | Thanks for taking the time to open this! After reviewing it against our product direction, this falls outside our current scope. _<why>_. | `label` wontfix; `close`                    |
+| **Duplicate**       | Thanks for reporting this! This is already tracked in #<original>, so I'll close this one as a duplicate.                                 | `close` (reason "not planned")              |
+| **Needs info**      | Thanks for opening this! I'd like to help, but I need a bit more context: _<specific questions>_.                                         | `label` needs-info (do **not** close)       |
 
 ### Adding Feedback to Existing Issues
 
-```sh
-gh issue comment <number> --body "$(cat <<'EOF'
-Additional feedback observed during user testing of **<product>** in the
-`<scenario>` evaluation scenario:
+`comment` on the issue ([work-trackers.md](../../../agents/references/work-trackers.md)):
 
-<description>
-
-— Product Manager 🌱
-EOF
-)"
-```
+> Additional feedback observed during user testing of **<product>** in the
+> `<scenario>` evaluation scenario:
+>
+> <description>
+>
+> — Product Manager 🌱
 
 ## Fix and Spec PRs
 
@@ -40,24 +37,16 @@ commit type (`fix(<scope>)` vs `spec(<scope>)`), closing keyword (`Closes` vs
 
 ### Branch and Commit
 
-```sh
-git checkout main && git pull origin main
-git checkout -b <fix|spec>/issue-<number>-<short-description>
-# ... implement fix or write spec ...
-# Run the repository's check and test commands
-git add <paths>
-git commit -m "<fix|spec>(<scope>): <description>
-
-<Closes|Addresses> #<number>"
-git push -u origin <fix|spec>/issue-<number>-<short-description>
-```
+Implement the fix or write the spec on a `<fix|spec>/issue-<number>-…` branch,
+run the repository's check and test commands, and commit with subject
+`<fix|spec>(<scope>): <description>` and a `<Closes|Addresses> #<number>` trailer.
 
 ### PR Body
 
-```sh
-gh pr create \
-  --title "<fix|spec>(<scope>): <description>" \
-  --body "$(cat <<'EOF'
+`open-change` ([work-trackers.md](../../../agents/references/work-trackers.md))
+titled `<fix|spec>(<scope>): <description>` with this body:
+
+```markdown
 ## Summary
 
 <description>
@@ -68,8 +57,6 @@ gh pr create \
 
 - [ ] Repository check command passes
 - [ ] <specific verification>
-EOF
-)"
 ```
 
 Spec PRs replace the Test plan with a Review section:
@@ -83,11 +70,11 @@ Spec for issue #<number>. Needs review before implementation — see the
 
 ## New Issues from User Testing
 
-```sh
-gh issue create \
-  --title "<bug|docs|feat>(<product>): <concise description>" \
-  --label "user-testing" \
-  --body "$(cat <<'EOF'
+`create-issue` ([work-trackers.md](../../../agents/references/work-trackers.md))
+titled `<bug|docs|feat>(<product>): <concise description>`, labeled
+`user-testing`, with this body:
+
+```markdown
 ## Context
 Observed during user testing of **<product>** in the `<scenario>` scenario.
 
@@ -99,8 +86,6 @@ Expected: <what the user expected>
 Actual: <what happened>
 
 — Product Manager 🌱
-EOF
-)"
 ```
 
 ## Report Summary Tables

--- a/.claude/skills/kata-release-merge/SKILL.md
+++ b/.claude/skills/kata-release-merge/SKILL.md
@@ -45,16 +45,15 @@ Read `wiki/MEMORY.md` then run `Bash: fit-wiki boot --agent <self>` (per [Memory
 
 ### Step 1: List Open PRs
 
-```sh
-gh pr list --state open --base main \
-  --json number,title,headRefName,author,updatedAt,mergeable,mergeStateStatus,labels,reviews
-```
+`list` open changes against `main` ([work-trackers.md](../../agents/references/work-trackers.md)),
+reading number, title, head branch, author, update time, mergeability, labels,
+and reviews.
 
 Skip PRs authored by `app/dependabot` — handled by `kata-security-update`.
 
 ### Step 2: Verify Contributor Trust
 
-Check the author: `gh pr view <number> --json author --jq '.author.login'`. If
+`read` the change's author ([work-trackers.md](../../agents/references/work-trackers.md)). If
 `app/kata-agent-team`, the PR is **trusted by definition**. Otherwise, look up
 the top 7 human contributors:
 
@@ -80,10 +79,8 @@ Parse the title using `type(scope): subject`. Each type maps to a phase:
 
 ### Step 4: Assess Merge State
 
-```sh
-gh pr view <number> --json mergeable,mergeStateStatus
-gh pr checks <number>
-```
+`read` the change's mergeability and CI checks
+([work-trackers.md](../../agents/references/work-trackers.md)).
 
 Clean (mergeable, CI green, up-to-date) → continue to Step 6. Behind, stale, or conflicting → rebase (Step 5). CI failing → fix (Step 5) or block. An approved-and-pinned experiment PR never rebases — skip to Step 6 re-block ([`experiment-path.md`](references/experiment-path.md)).
 
@@ -105,7 +102,8 @@ git add <files> && git rebase --continue
 deleted-vs-modified) — `git rebase --abort` and comment the conflicting files.
 
 After rebase, run auto-fix then check; if checks still fail, mark **blocked**
-and skip to Step 12. Push with `git push --force-with-lease origin <pr-branch>`.
+and skip to Step 12. `update-change` to publish the rebased branch
+([work-trackers.md](../../agents/references/work-trackers.md)).
 
 **Phase-PR review transfer.** Before force-pushing a `spec`/`design`/`plan` PR,
 if the current head carries an approval signal, apply
@@ -173,7 +171,7 @@ per [work-definition.md § Product-aligned vs internal](https://github.com/forwa
 ### Step 11: Merge Mergeable PRs
 
 1. Post the merge comment from `references/templates.md` § Merge Comment.
-2. `gh pr merge <number> --merge --delete-branch`
+2. `merge-change` ([work-trackers.md](../../agents/references/work-trackers.md)).
 3. Verify state is `MERGED`. On race or branch-protection failure, record and
    move on — do **not** retry without re-running Steps 1–10.
 4. **Re-ping Rule** — re-comment on any still-blocked PR past its 3-day silence window ([`reping-rule.md`](references/reping-rule.md)).

--- a/.claude/skills/kata-release-merge/references/announcement-backstop.md
+++ b/.claude/skills/kata-release-merge/references/announcement-backstop.md
@@ -27,10 +27,9 @@ STATUS, not on issues).
 
 ## Check for an Existing Announcement
 
-```sh
-gh issue view <N> --json comments \
-  --jq '[.comments[].body | select(test("#<pr-number>([^0-9]|$)"))] | length'
-```
+`read` the coordinating issue's comments
+([work-trackers.md](../../../agents/references/work-trackers.md)) and count those
+whose body matches the PR number with a boundary pattern (`#<pr-number>([^0-9]|$)`).
 
 The boundary pattern matters: a plain substring match lets `#15981` satisfy a
 check for `#1598`, so the gate would skip the heal and the miss would go
@@ -46,9 +45,8 @@ running.
 
 ## Probe for Sibling PRs
 
-```sh
-gh pr list --search "<N>" --state all --json number,title,state
-```
+`list` all changes (any state) searching for the issue number `<N>`, reading
+number, title, and state ([work-trackers.md](../../../agents/references/work-trackers.md)).
 
 A second PR referencing the same issue is a potential duplicate. Comment on
 the issue naming both PRs and assess which route stands — the Step 7 comment

--- a/.claude/skills/kata-release-merge/references/comment-gate.md
+++ b/.claude/skills/kata-release-merge/references/comment-gate.md
@@ -6,7 +6,8 @@ close a thread on behalf of a human who has not yet reacted.
 
 ## Procedure
 
-Use `gh api repos/{owner}/{repo}/issues/<number>/comments` to read the thread.
+`read` the change's discussion thread
+([work-trackers.md](../../../agents/references/work-trackers.md)).
 For each top-7 human contributor (kata-release-merge Step 2 lookup) who has
 commented on the PR, read their **most recent** comment. If it raises a
 concern, question, or objection that has not been resolved by a **later**

--- a/.claude/skills/kata-release-merge/references/metrics.md
+++ b/.claude/skills/kata-release-merge/references/metrics.md
@@ -6,9 +6,11 @@ Record per KATA.md § Metrics. Append one row per metric per run to
 | Metric                     | Unit  | Description                                                                                                    | Data source                                                                |
 | -------------------------- | ----- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | prs_merged                 | count | PRs merged this run                                                                                            | Run actions                                                                |
-| approvals_recorded_per_run | count | Inbound human approval signals — `<phase>:approved` label-add events + APPROVED review events — observed in `[prev_run_start, current_run_start)`. These signals feed `wiki/STATUS.md` via `kata-dispatch`. | `gh api repos/{owner}/{repo}/issues/<n>/timeline` + `.../pulls/<n>/reviews` |
+| approvals_recorded_per_run | count | Inbound human approval signals — `<phase>:approved` label-add events + APPROVED review events — observed in `[prev_run_start, current_run_start)`. These signals feed `wiki/STATUS.md` via `kata-dispatch`. | `read` each item's label-add and review events ([work-trackers.md](../../../agents/references/work-trackers.md)) |
 
-Backlog (`gh pr list`) is queried, not recorded.
+Backlog (`list` changes —
+[work-trackers.md](../../../agents/references/work-trackers.md)) is queried, not
+recorded.
 
 ## Collection
 
@@ -32,15 +34,10 @@ merged this run (Step 8). The cohort undercounts approvals on PRs merged in a
 prior run still within the window — accepted at boundaries; the storyboard
 meeting reads run-over-run, not per-PR.
 
-For each cohort PR, fetch label-add events and APPROVED reviews:
-
-```sh
-gh api repos/{owner}/{repo}/issues/<n>/timeline --paginate \
-  --jq '.[] | select(.event=="labeled" and (.label.name|test("^(spec|design|plan):approved$"))) | {ts: .created_at}'
-
-gh api repos/{owner}/{repo}/pulls/<n>/reviews --paginate \
-  --jq '.[] | select(.state=="APPROVED") | {ts: .submitted_at}'
-```
+For each cohort PR, `read` its label-add events (filtering
+`event=="labeled"` with `label.name` matching `^(spec|design|plan):approved$`,
+keyed by `created_at`) and its APPROVED reviews (filtering `state=="APPROVED"`,
+keyed by `submitted_at`) — [work-trackers.md](../../../agents/references/work-trackers.md).
 
 Filter events to `ts ∈ [prev_run_start, current_run_start)` and sum across all
 cohort PRs to `approvals_recorded_per_run` (no per-event de-dup — record the

--- a/.claude/skills/kata-release-merge/references/reping-rule.md
+++ b/.claude/skills/kata-release-merge/references/reping-rule.md
@@ -22,17 +22,13 @@ Open PRs still **blocked** after this run's merges (Step 10 items 1–3). PRs
 that passed all gates merged and are gone. There is no prior-run-membership
 check — the silence window test below filters out PRs first blocked this run.
 
-For each candidate, read the most-recent bot comment timestamp on the PR
-thread:
-
-```sh
-gh api repos/{owner}/{repo}/issues/<number>/comments \
-  --jq '[.[] | select(.user.login == "kata-agent-team[bot]")] | last | .created_at'
-```
+For each candidate, `read` the change's discussion
+([work-trackers.md](../../../agents/references/work-trackers.md)) and take the
+most-recent bot comment timestamp (`user.login == "kata-agent-team[bot]"`).
 
 This is the same conversation thread the open-comment gate reads
 ([`comment-gate.md`](comment-gate.md)); every block, re-ping, and merge comment
-this skill posts goes through `gh pr comment` and lands here, so the
+this skill posts is a `comment` on the change and lands here, so the
 most-recent bot comment is the true silence anchor. The login on this endpoint
 is `kata-agent-team[bot]` — pin that, not the `app/kata-agent-team` identity
 slug.
@@ -53,8 +49,9 @@ table state — a maintained column is per-run state that drifts silently.
 When due, post the matching re-ping variant from
 [`templates.md`](templates.md) § Re-ping Comments for the PR's block reason
 **already computed in this run's Steps 2–8** — do not re-run the gates or
-re-query `gh pr checks`; the failing checks and reason carry from the run's own
-classification.
+re-`read` the change's CI checks
+([work-trackers.md](../../../agents/references/work-trackers.md)); the failing
+checks and reason carry from the run's own classification.
 
 ## Owner taxonomy
 

--- a/.claude/skills/kata-release-merge/references/templates.md
+++ b/.claude/skills/kata-release-merge/references/templates.md
@@ -2,44 +2,39 @@
 
 Comment templates and report formats for the merge gate.
 
+Each template is a `comment` on a change or issue
+([work-trackers.md](../../../agents/references/work-trackers.md)); fill the body
+shown and post it.
+
 ## Skip Comments
 
 ### Untrusted Author
 
-```sh
-gh pr comment <number> --body "Release merge: skipping — author \`<login>\` is not in the top 7 contributors. Requires human review."
-```
+> Release merge: skipping — author `<login>` is not in the top 7 contributors. Requires human review.
 
 ### Unsupported PR Type
 
-```sh
-gh pr comment <number> --body "Release merge: skipping — PR type \`<type>\` requires human review."
-```
+> Release merge: skipping — PR type `<type>` requires human review.
 
 ### Awaiting Approval Signal
 
-```sh
-gh pr comment <number> --body "Release merge: blocked — \`wiki/STATUS.md\` row for the spec does not yet show \`<phase>\tapproved\`. Apply \`<phase>:approved\` label, submit an APPROVED review, or post an approval comment from a trusted account; \`kata-dispatch\` will propagate it into STATUS."
-```
+> Release merge: blocked — `wiki/STATUS.md` row for the spec does not yet show `<phase>\tapproved`. Apply `<phase>:approved` label, submit an APPROVED review, or post an approval comment from a trusted account; `kata-dispatch` will propagate it into STATUS.
 
 ### CI Failing
 
-Comment with the specific failing checks from `gh pr checks`.
+Comment with the specific failing checks from the change's CI `read`.
 
 ### Substantive Conflict
 
-```sh
-gh pr comment <number> --body "Release merge: blocked — substantive conflicts in <files>. Author judgement needed; aborting rebase."
-```
+> Release merge: blocked — substantive conflicts in <files>. Author judgement needed; aborting rebase.
 
 ## Announcement Cross-Link
 
-Posted on the **coordinating issue** (not the PR) when Step 8 finds no comment
-naming the PR. Adapt the verb to the PR's state at gate time:
+`comment` on the **coordinating issue** (not the change) when Step 8 finds no
+comment naming the PR ([work-trackers.md](../../../agents/references/work-trackers.md)).
+Adapt the verb to the PR's state at gate time:
 
-```sh
-gh issue comment <issue-number> --body "Release merge (announcement backstop): PR #<pr-number> — \`<title>\` — is in flight for this issue and has reached the merge gate. Cross-link posted by the gate because no prior comment here named the PR; recorded as an adherence miss per coordination-protocol.md fix-in-flight markers."
-```
+> Release merge (announcement backstop): PR #<pr-number> — `<title>` — is in flight for this issue and has reached the merge gate. Cross-link posted by the gate because no prior comment here named the PR; recorded as an adherence miss per coordination-protocol.md fix-in-flight markers.
 
 ## Re-ping Comments
 
@@ -47,16 +42,12 @@ Posted by the **Re-ping Rule** (SKILL.md Step 10, item 4) when a blocked PR's
 silence window has expired. Post the one template below, filling `<state>`,
 `<owner>`, and `<next-action>` from the row matching the PR's block reason —
 already computed in this run's Steps 2–8; the Re-ping Rule does not re-run the gates.
+Post it as a `comment` on the change ([work-trackers.md](../../../agents/references/work-trackers.md)):
 
-```sh
-gh pr comment <number> --body "$(cat <<'BODY'
-Release merge Re-ping Rule — gate still open after 3 calendar days:
-- state: <state>
-- owner: <owner>
-- next_action: <next-action>
-BODY
-)"
-```
+> Release merge Re-ping Rule — gate still open after 3 calendar days:
+> - state: <state>
+> - owner: <owner>
+> - next_action: <next-action>
 
 | Block reason | `<state>` | `<owner>` | `<next-action>` |
 | --- | --- | --- | --- |
@@ -69,18 +60,13 @@ BODY
 
 ## Merge Comment
 
-```sh
-gh pr comment <number> --body "Release merge: all gates pass — type \`<type>\`, CI green, author trusted, STATUS row \`<phase>\tapproved\`. Merging."
-gh pr merge <number> --merge --delete-branch
-```
+`comment` then `merge-change`
+([work-trackers.md](../../../agents/references/work-trackers.md)):
 
-After merging, verify state:
+> Release merge: all gates pass — type `<type>`, CI green, author trusted, STATUS row `<phase>\tapproved`. Merging.
 
-```sh
-gh pr view <number> --json state --jq '.state'
-```
-
-If still `OPEN`, note in the summary rather than reporting as merged.
+After merging, `read` the change's state. If still `OPEN`, note in the summary
+rather than reporting as merged.
 
 ## Report Summary
 

--- a/.claude/skills/kata-security-update/SKILL.md
+++ b/.claude/skills/kata-security-update/SKILL.md
@@ -71,17 +71,15 @@ Extract previous triage outcomes and packages that repeatedly fail Check 8.
 
 ### Step 1: List Open Dependabot PRs
 
-```sh
-gh pr list --author 'app/dependabot' --state open \
-  --json number,title,headRefName,labels,createdAt
-```
+`list` open changes authored by `app/dependabot`, reading number, title, head
+branch, labels, and creation time
+([work-trackers.md](../../agents/references/work-trackers.md)).
 
 ### Step 2: Evaluate Each PR
 
-```sh
-gh pr view <number> --json title,body,headRefName,files,commits,statusCheckRollup,mergeable,mergeStateStatus
-gh pr diff <number>
-```
+`read` the change's title, body, head branch, files, commits, CI status,
+mergeability, and diff
+([work-trackers.md](../../agents/references/work-trackers.md)).
 
 Determine update type from title: **patch** (low risk), **minor** (low risk),
 **major** (check changelogs for breaking changes and transitive deps).
@@ -122,26 +120,18 @@ session with verification still in the background — it dies at turn end, and t
 PR's CI is the verification of record. Hold every PR or comment body to
 [Citation integrity](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/citation-integrity.md).
 
-**Merge** — all policies pass, CI green:
+Each disposition uses tracker operations from
+[work-trackers.md](../../agents/references/work-trackers.md).
 
-```sh
-gh pr comment <number> --body "Dependabot triage: all policies pass, CI green. Merging."
-gh pr merge <number> --squash --auto
-```
+**Merge** — all policies pass, CI green: `comment` "Dependabot triage: all
+policies pass, CI green. Merging.", then `merge-change` (squash).
 
 **Fix on new branch** — minor policy violations fixable (Claude Code cannot push
-to Dependabot branches):
-
-```sh
-git fetch origin <dependabot-branch>
-git checkout -b fix/dependabot-<number> origin/<dependabot-branch>
-# Make fixes; run the repository's check, test, and audit commands
-git commit -m "fix(deps): <description for PR #number>"
-git push -u origin fix/dependabot-<number>
-gh pr create --title "chore(deps): <description> (fixed)" \
-  --body "Fixes policy violations in Dependabot PR #<number>."
-gh pr close <number> --comment "Superseded by #<new-pr> with policy fixes."
-```
+to Dependabot branches). Branch off the Dependabot branch, make the fixes, run
+the repository's check/test/audit commands, then `open-change` titled
+`chore(deps): <description> (fixed)` with body "Fixes policy violations in
+Dependabot PR #<number>." Finally `close` the original change with comment
+"Superseded by #<new-pr> with policy fixes."
 
 **Rebase on new branch** — only CI failure is `vulnerability-scanning` and the
 fix is already on `main` (stale audit base, not a PR-caused issue):
@@ -149,28 +139,24 @@ fix is already on `main` (stale audit base, not a PR-caused issue):
 ```sh
 # Confirm: only vuln-scan fails and main has security fixes the PR base lacks
 git log --oneline origin/main ^<pr-merge-base> -- '**/package.json' <lockfile>
-
-# If commits exist, rebase will fix the scan — create a superseding branch
-git fetch origin <dependabot-branch>
-git checkout -b chore/rebase-dependabot-<number> origin/<dependabot-branch>
-git rebase origin/main
-# Run the repository's check, test, and audit commands
-git push -u origin chore/rebase-dependabot-<number>
-gh pr create --title "chore(deps): <original-title> (rebased)" \
-  --body "Rebases Dependabot PR #<number> on current main to pick up security fixes."
-gh pr close <number> --comment "Superseded by #<new-pr> — rebased on main to resolve stale vulnerability-scanning base."
 ```
+
+If commits exist, rebasing the Dependabot branch on `origin/main` will fix the
+scan. Run the repository's check/test/audit commands, then `open-change` titled
+`chore(deps): <original-title> (rebased)` with body "Rebases Dependabot PR
+#<number> on current main to pick up security fixes." Then `close` the original
+change with comment "Superseded by #<new-pr> — rebased on main to resolve stale
+vulnerability-scanning base." (`open-change` and `close`:
+[work-trackers.md](../../agents/references/work-trackers.md).)
 
 > **Do not use `@dependabot rebase`.** GitHub Apps cannot trigger Dependabot
 > comment commands; the command always fails with "only users with push access."
 > If a prior run posted `@dependabot rebase` and got this reply, use the "Rebase
 > on new branch" flow above instead of retrying the comment.
 
-**Close** — policy violation cannot be fixed:
-
-```sh
-gh pr close <number> --comment "Dependabot triage: closing because <reason>. Policy: <which>."
-```
+**Close** — policy violation cannot be fixed: `close` the change with comment
+"Dependabot triage: closing because <reason>. Policy: <which>."
+([work-trackers.md](../../agents/references/work-trackers.md)).
 
 ### Step 4: Summary
 

--- a/.claude/skills/kata-security-update/references/metrics.md
+++ b/.claude/skills/kata-security-update/references/metrics.md
@@ -7,4 +7,6 @@ one row per run.
 | ------------ | ----- | ---------------------------------------- | ----------- |
 | prs_actioned | count | Dependabot PRs merged or closed this run | Run actions |
 
-Backlog (`gh pr list --author app/dependabot`) is queried, not recorded.
+Backlog (`list` changes authored by `app/dependabot` —
+[work-trackers.md](../../../agents/references/work-trackers.md)) is queried, not
+recorded.

--- a/.claude/skills/kata-session/references/issue-lifecycle.md
+++ b/.claude/skills/kata-session/references/issue-lifecycle.md
@@ -3,27 +3,33 @@
 What an obstacle and an experiment *are* — and the obstacle-vs-experiment test —
 is defined in
 [work-definition.md](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/work-definition.md); this file is
-the `gh` command shapes for filing and closing them.
+the operation recipes for filing and closing them. Each recipe names an
+[abstract operation](../../agents/references/work-trackers.md#abstract-operations);
+its concrete shape per tracker lives in the
+[matrix](../../agents/references/work-trackers.md#the-matrix). Obstacle and
+experiment are both issues, distinguished only by label.
 
 The agent being coached — not the facilitator — creates, comments on, and closes
-**its own** obstacle and experiment issues with `gh`, in both team storyboard and
+**its own** obstacle and experiment issues, in both team storyboard and
 1-on-1 sessions. The facilitator has no `Bash`: it `Ask`s the agent to record
 each one, and the agent **reports the `#NNN` back via `Answer`** (the facilitator
-can't `gh issue list` to find it) for the storyboard headlines and `Conclude`
-summary.
+can't `list` to find it) for the storyboard headlines and `Conclude` summary.
 
 The storyboard's Active and Concluded lists render from issue state via the
 deterministic `fit-wiki refresh` step — never hand-edit them.
 
 ## New Obstacle
 
-```sh
-gh issue create --label obstacle \
-  --title "Obstacle name" \
-  --body "Description.
+`create-issue` with the `obstacle` label:
 
-Blocking dimension: [which gap this blocks]"
-```
+- **Title:** `Obstacle name`
+- **Body:**
+
+  ```text
+  Description.
+
+  Blocking dimension: [which gap this blocks]
+  ```
 
 ## New Experiment
 
@@ -38,16 +44,19 @@ cannot resolve in one run — split into one prediction per skill / run type.
 The `agent:` label and `Owner:` name the **coached agent itself** (the one
 running this command):
 
-```sh
-gh issue create --label experiment --label "agent:[your-agent-name]" \
-  --title "Exp N — short name" \
-  --body "Obstacle: #NNN
-Owner: [your agent name]
+`create-issue` with the `experiment` and `agent:[your-agent-name]` labels:
 
-**What:** description
-**Expected outcome:** prediction
-**Execution plan:** [omit, or a list of repo-root-anchored path globs]"
-```
+- **Title:** `Exp N — short name`
+- **Body:**
+
+  ```text
+  Obstacle: #NNN
+  Owner: [your agent name]
+
+  **What:** description
+  **Expected outcome:** prediction
+  **Execution plan:** [omit, or a list of repo-root-anchored path globs]
+  ```
 
 The `**Execution plan:**` line is required when the experiment will **ship
 code**. It names the intended change surface as a list of repo-root-anchored
@@ -66,19 +75,22 @@ This is bookkeeping, written by the owning agent (never the facilitator). The
 row's `approved` state is human-originated and written elsewhere; see
 [approval-signals.md § Experiment rows](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/approval-signals.md).
 
-## At PR-open (code-shipping experiments)
+## At open-change (code-shipping experiments)
 
-When the owning agent opens the experiment's Act PR, it requests the trusted
-human's approval signal on the PR, naming the experiment issue and flagging any
-time-sensitive evidence (e.g. retention-bounded trace artifacts). The agent
-owns this ask; nobody else requests the signal on its behalf.
+When the owning agent runs `open-change` for the experiment's Act change, it
+requests the trusted human's `gate` signal on the change, naming the experiment
+issue and flagging any time-sensitive evidence (e.g. retention-bounded trace
+artifacts). The agent owns this ask; nobody else requests the signal on its
+behalf.
 
 ## Progress Update
 
-```sh
-gh issue comment #NNN --body "**Actual outcome:** what happened
+`comment` on the experiment issue:
+
+```text
+**Actual outcome:** what happened
 **Learning:** what we learned
-**Next step:** continue / pivot / new"
+**Next step:** continue / pivot / new
 ```
 
 ## Conclusion
@@ -90,9 +102,10 @@ Every experiment concludes with one of three verdicts:
 - **VOID** — the experiment could not be evaluated (e.g. evidence lost, scope
   changed out from under it); no learning either way.
 
-```sh
-gh issue comment #NNN --body "**Verdict:** PASS|FAIL|VOID — one-sentence learning"
-gh issue close #NNN
+`comment` the verdict, then `close` the issue:
+
+```text
+**Verdict:** PASS|FAIL|VOID — one-sentence learning
 ```
 
 When a code-shipping experiment concludes **FAIL** or **VOID**, the owning

--- a/.claude/skills/kata-spec/references/metrics.md
+++ b/.claude/skills/kata-spec/references/metrics.md
@@ -5,6 +5,8 @@ one row per run.
 
 | Metric        | Unit  | Description                        | Data source |
 | ------------- | ----- | ---------------------------------- | ----------- |
-| specs_drafted | count | Spec PRs opened or pushed this run | gh pr list  |
+| specs_drafted | count | Spec PRs opened or pushed this run | `list` changes |
 
-Open spec PRs and draft age (`gh pr list`, `git log`) are queried, not recorded.
+Open spec PRs and draft age (`list` changes —
+[work-trackers.md](../../../agents/references/work-trackers.md) — plus `git log`)
+are queried, not recorded.

--- a/.claude/skills/kata-wiki-curate/SKILL.md
+++ b/.claude/skills/kata-wiki-curate/SKILL.md
@@ -39,8 +39,8 @@ If time-constrained, run `contract-audit` to completion, then prioritize
 
 **Verify state before writing.** When adding or editing any agent-summary entry
 that names a PR or Issue (Watching-list, "Recently merged", Open Blockers,
-Observations to Teammates), query state at write time via
-`gh pr view <num> --json state,mergedAt` or `gh issue view <num> --json state` —
+Observations to Teammates), `read` the work item's state at write time
+([work-trackers.md](../../agents/references/work-trackers.md)) —
 never infer it from teammate summaries, memos, or prior curation entries, which
 may be stale by hours. The same applies to edits triggered by cross-agent
 corrections: re-verify the named artifact rather than transcribing it verbatim.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -39,7 +39,7 @@ automatically. Task IDs are directory names under `tasks/`.
 A family-level `workdir/` or `specs/` (if present) is copied into every task's
 agent CWD as a shared base; the per-task `workdir/`/`specs/` overlay on top.
 Use it to maintain one fixture (e.g. an app under test) across many tasks
-rather than duplicating it per task. Hooks receive `$WORKDIR`, `$PORT`,
+rather than duplicating it per task. Hooks receive `$AGENT_CWD`, `$PORT`,
 `$TASK_ID`, `$TASK_DIR`, `$HOOKS_DIR`, `$FAMILY_DIR` (and `invariants.sh` also
 `$RESULTS_FD`).
 

--- a/benchmarks/fit-wiki/tasks/cli-fix/hooks/invariants.sh
+++ b/benchmarks/fit-wiki/tasks/cli-fix/hooks/invariants.sh
@@ -16,8 +16,8 @@ assert() {
 # the body (or truncates it to satisfy the audit markers) would still pass.
 # Assert the seeded sections survive so the "intact" invariants actually
 # measure integrity instead of mere existence.
-assert audit-passes   sh -c 'cd "$1" && npx fit-wiki audit --today 2026-05-24' _ "$WORKDIR"
-assert summary-intact  sh -c 'f="$1/wiki/staff-engineer.md"; grep -q "## Current Focus" "$f" && grep -q "## Open Blockers" "$f"' _ "$WORKDIR"
-assert memory-intact   grep -q "## Cross-Cutting Priorities" "$WORKDIR/wiki/MEMORY.md"
+assert audit-passes   sh -c 'cd "$1" && npx fit-wiki audit --today 2026-05-24' _ "$AGENT_CWD"
+assert summary-intact  sh -c 'f="$1/wiki/staff-engineer.md"; grep -q "## Current Focus" "$f" && grep -q "## Open Blockers" "$f"' _ "$AGENT_CWD"
+assert memory-intact   grep -q "## Cross-Cutting Priorities" "$AGENT_CWD/wiki/MEMORY.md"
 
 [ "$FAIL" = 0 ] && exit 0 || exit 1

--- a/benchmarks/fit-wiki/tasks/cli-fix/hooks/preflight.sh
+++ b/benchmarks/fit-wiki/tasks/cli-fix/hooks/preflight.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Verify the fixture: audit must FAIL on the seeded wiki.
-cd "$WORKDIR" && npx fit-wiki audit --today 2026-05-24 >/dev/null 2>&1 && exit 1
+cd "$AGENT_CWD" && npx fit-wiki audit --today 2026-05-24 >/dev/null 2>&1 && exit 1
 exit 0

--- a/benchmarks/kata-skills/README.md
+++ b/benchmarks/kata-skills/README.md
@@ -3,11 +3,13 @@
 Task family for `fit-benchmark` targeting the `forwardimpact/kata-skills`
 skill pack. Runs on manual dispatch via `eval-kata.yml`.
 
-The four tasks exercise the Plan→Do artifact spine — spec → design → plan →
+Four tasks exercise the Plan→Do artifact spine — spec → design → plan →
 implement — against **one shared mock app and one feature** (`todo list
 --filter`, spec 042). The app is maintained once at the family level; each task
 is seeded with its own *frozen* upstream artifacts, so it runs independently
-while sharing a single coherent narrative.
+while sharing a single coherent narrative. A fifth task, `coordinate-finding`,
+exercises the **coordination half** of the loop — file → open change → gate →
+merge — offline under the filesystem work tracker.
 
 ## Tasks
 
@@ -17,6 +19,19 @@ while sharing a single coherent narrative.
 | `design-feature` | `kata-design` | `design-a.md` | Rubric (exists, <200 lines, decisions, named trade-off) + judge |
 | `plan-feature` | `kata-plan` | `plan-a.md` | Rubric (Libraries-used line, Risks, design ref, verification) + judge |
 | `implement-feature` | `kata-implement` | edits under `app/` | Hidden test suite (baseline regression + feature) + judge (scope discipline) |
+| `coordinate-finding` | work-tracker operations | `.tracker/` work items | Invariants (issue filed, change links it, `state: merged`, approval recorded) + judge |
+| `product-issue-triage` | `kata-product-issue` | triaged `.tracker/` issue | Invariants (out-of-scope issue closed, `wontfix`-labelled, rationale comment) + judge |
+
+The work-tracking tasks are offline — run them under the filesystem tracker.
+Run a single task with `--task`:
+
+```
+fit-benchmark run --family=benchmarks/kata-skills --task=product-issue-triage --work-tracker=filesystem
+```
+
+Omit `--task` to run every task. The default tracker is `github`; production
+leaves it. The artifact-spine tasks never read `LIBEVAL_WORK_TRACKER`, so they
+are inert under `--work-tracker`.
 
 ## The shared app — family-level `workdir/`
 

--- a/benchmarks/kata-skills/tasks/coordinate-finding/agent.task.md
+++ b/benchmarks/kata-skills/tasks/coordinate-finding/agent.task.md
@@ -1,0 +1,21 @@
+Read `finding.md` — a study finding that must re-enter the work loop as tracked
+coordination.
+
+Run the coordination loop end to end using the **abstract work-item operations**,
+resolving each through the active tracker described in
+`.claude/agents/references/work-trackers.md`. This run sets
+`LIBEVAL_WORK_TRACKER=filesystem`, so each operation realizes as a file write
+under the `.tracker/` layout that reference defines. **Networking is
+unavailable** — do not call any remote tracker; the filesystem column needs none.
+
+Carry out, in order:
+
+1. `create-issue` — file the finding as an issue under `.tracker/issues/`.
+2. `open-change` — open a change under `.tracker/changes/` that `links` back to
+   that issue.
+3. `gate` — record a trusted approval on the change (set its `approval`).
+4. `merge-change` — accept the change (set its `state: merged`).
+
+Use only the operation names from `work-trackers.md`; do not invoke `gh` or any
+remote command. Follow the envelope templates in that reference for the
+front-matter each file carries.

--- a/benchmarks/kata-skills/tasks/coordinate-finding/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/coordinate-finding/hooks/invariants.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -u
+TRACKER="$AGENT_CWD/.tracker"
+FAIL=0
+assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+
+# Resolve the single issue and change the loop should have produced. The ids are
+# caller-supplied slugs, so glob the tracker store rather than assume a name.
+ISSUE=$(ls "$TRACKER"/issues/*.md 2>/dev/null | head -1)
+CHANGE=$(ls "$TRACKER"/changes/*.md 2>/dev/null | head -1)
+
+# An issue file must exist; without it nothing downstream can be asserted.
+assert issue-present --exists "$ISSUE"
+# A change file must exist before its envelope can be checked.
+assert change-present --exists "$CHANGE"
+[ "$FAIL" = 1 ] && exit 1
+
+# The change links back to the issue (by its slug id, the filename stem).
+ISSUE_ID=$(basename "$ISSUE" .md)
+assert change-links-issue --grep "$ISSUE_ID" "$CHANGE" \
+  --message "change does not link back to the issue"
+# The change reached merged state.
+assert change-merged --grep 'state:\s*merged' "$CHANGE" \
+  --message "change is not state: merged"
+# A trusted approval was recorded on the change (non-empty approval field).
+assert change-approved --grep 'approval:\s*\S' "$CHANGE" \
+  --message "no approval recorded on the change"
+
+[ "$FAIL" = 0 ] && exit 0 || exit 1

--- a/benchmarks/kata-skills/tasks/coordinate-finding/hooks/preflight.sh
+++ b/benchmarks/kata-skills/tasks/coordinate-finding/hooks/preflight.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Smoke-check the coordination workdir is sane and the tracker store is clean
+# before the agent starts: the finding is present and no .tracker/ exists yet
+# (the agent creates it).
+set -eu
+test -f "$AGENT_CWD/finding.md"
+test ! -e "$AGENT_CWD/.tracker"

--- a/benchmarks/kata-skills/tasks/coordinate-finding/judge.task.md
+++ b/benchmarks/kata-skills/tasks/coordinate-finding/judge.task.md
@@ -1,0 +1,23 @@
+Invariants result:
+
+```json
+{{INVARIANTS_RESULT}}
+```
+
+The agent was given these instructions:
+
+> {{AGENT_INSTRUCTIONS}}
+
+Agent trace at `{{AGENT_TRACE_PATH}}`. Read the finding at
+`{{TASK_DIR}}/finding.md` and the work items the agent produced under
+`{{TASK_DIR}}/.tracker/` (`issues/`, `changes/`).
+
+Decide whether the agent **ran the coordination loop** for the finding — not just
+whether the files clear the structural invariants. Cross-reference the agent's
+instructions above: did it use the abstract operations (no `gh`, no network),
+file the finding as an issue, open a change that links back to it, gate the
+change with a recorded approval, and merge it (`state: merged`)?
+
+Call `Conclude` with `verdict="success"` if the loop was carried out faithfully
+through the filesystem tracker, or `verdict="failure"` if it was not. Include a
+one-sentence `summary` naming the deciding evidence.

--- a/benchmarks/kata-skills/tasks/coordinate-finding/supervisor.task.md
+++ b/benchmarks/kata-skills/tasks/coordinate-finding/supervisor.task.md
@@ -1,0 +1,1 @@
+<!-- Reserved per spec #870 design Decision 14; unread in v1. -->

--- a/benchmarks/kata-skills/tasks/coordinate-finding/workdir/finding.md
+++ b/benchmarks/kata-skills/tasks/coordinate-finding/workdir/finding.md
@@ -1,0 +1,9 @@
+# Finding — `todo list` exit code on empty store
+
+While studying traces of the `todo` CLI, a recurring defect surfaced: running
+`todo list` against an empty store prints nothing but exits with status `1`,
+which reads as an error to any script that checks the exit code. An empty list
+is a normal state, not a failure, so the command should exit `0`.
+
+This finding needs to re-enter the work loop: filed as an issue, carried by a
+change that links back to it, gated by a trusted signal, and merged.

--- a/benchmarks/kata-skills/tasks/design-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/design-feature/hooks/invariants.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -u
-DESIGN="$WORKDIR/specs/042-todo-filter/design-a.md"
+DESIGN="$AGENT_CWD/specs/042-todo-filter/design-a.md"
 FAIL=0
-assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 
 assert file-present --exists "$DESIGN"
 [ "$FAIL" = 1 ] && exit 1

--- a/benchmarks/kata-skills/tasks/design-feature/hooks/preflight.sh
+++ b/benchmarks/kata-skills/tasks/design-feature/hooks/preflight.sh
@@ -2,4 +2,4 @@
 # Smoke-check the shared app (materialized by the harness from the family-level
 # workdir/) is sane before the agent starts.
 set -eu
-cd "$WORKDIR/app" && node --test >/dev/null 2>&1
+cd "$AGENT_CWD/app" && node --test >/dev/null 2>&1

--- a/benchmarks/kata-skills/tasks/implement-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/implement-feature/hooks/invariants.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -u
-APP="$WORKDIR/app"
+APP="$AGENT_CWD/app"
 FAIL=0
 
 if [ ! -d "$APP" ]; then

--- a/benchmarks/kata-skills/tasks/implement-feature/hooks/preflight.sh
+++ b/benchmarks/kata-skills/tasks/implement-feature/hooks/preflight.sh
@@ -2,4 +2,4 @@
 # Smoke-check the shared app (materialized by the harness from the family-level
 # workdir/) is sane before the agent starts.
 set -eu
-cd "$WORKDIR/app" && node --test >/dev/null 2>&1
+cd "$AGENT_CWD/app" && node --test >/dev/null 2>&1

--- a/benchmarks/kata-skills/tasks/plan-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/plan-feature/hooks/invariants.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -u
-PLAN="$WORKDIR/specs/042-todo-filter/plan-a.md"
+PLAN="$AGENT_CWD/specs/042-todo-filter/plan-a.md"
 FAIL=0
-assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 
 assert file-present --exists "$PLAN"
 [ "$FAIL" = 1 ] && exit 1

--- a/benchmarks/kata-skills/tasks/plan-feature/hooks/preflight.sh
+++ b/benchmarks/kata-skills/tasks/plan-feature/hooks/preflight.sh
@@ -2,4 +2,4 @@
 # Smoke-check the shared app (materialized by the harness from the family-level
 # workdir/) is sane before the agent starts.
 set -eu
-cd "$WORKDIR/app" && node --test >/dev/null 2>&1
+cd "$AGENT_CWD/app" && node --test >/dev/null 2>&1

--- a/benchmarks/kata-skills/tasks/product-issue-triage/agent.task.md
+++ b/benchmarks/kata-skills/tasks/product-issue-triage/agent.task.md
@@ -1,0 +1,15 @@
+Read `product-brief.md` — what this product is and is not — then triage the open
+issues in the tracker, following the `kata-product-issue` skill (staged under
+`.claude/skills/kata-product-issue/`).
+
+This run sets `LIBEVAL_WORK_TRACKER=filesystem`, so the tracker's issues live as
+files under `.tracker/issues/` per the model in
+`.claude/agents/references/work-trackers.md`. **Networking is unavailable** — do
+not call `gh` or any remote command; resolve every work-item operation through
+the filesystem column.
+
+For each open issue: `read` it, classify it against the product brief
+(mechanical fix / product-aligned spec / out of scope), and act through the
+work-item operations. When an issue is **out of scope**, `comment` a brief
+rationale grounded in the brief, `label` it `wontfix`, and `close` it. Do not
+open a change or spec for an out-of-scope issue.

--- a/benchmarks/kata-skills/tasks/product-issue-triage/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/product-issue-triage/hooks/invariants.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -u
+ISSUE="$AGENT_CWD/.tracker/issues/req-emoji-social.md"
+FAIL=0
+assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+
+# The issue must still exist; the triage edits it in place.
+assert issue-present --exists "$ISSUE"
+[ "$FAIL" = 1 ] && exit 1
+
+# Triaged out of scope: closed, labelled wontfix, and carrying a rationale
+# comment. Together these evidence the read -> comment -> label -> close loop
+# the filesystem tracker realizes.
+assert issue-closed --grep 'state:\s*closed' "$ISSUE" \
+  --message "issue not closed"
+assert issue-wontfix --grep 'wontfix' "$ISSUE" \
+  --message "no wontfix label applied"
+assert issue-commented --grep '##\s*Comments\s+\S' "$ISSUE" \
+  --message "no rationale comment appended"
+
+[ "$FAIL" = 0 ] && exit 0 || exit 1

--- a/benchmarks/kata-skills/tasks/product-issue-triage/hooks/preflight.sh
+++ b/benchmarks/kata-skills/tasks/product-issue-triage/hooks/preflight.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Smoke-check the triage scaffold: the product brief and the seeded open issue
+# are present before the agent starts.
+set -eu
+test -f "$AGENT_CWD/product-brief.md"
+test -f "$AGENT_CWD/.tracker/issues/req-emoji-social.md"
+grep -q 'state: open' "$AGENT_CWD/.tracker/issues/req-emoji-social.md"

--- a/benchmarks/kata-skills/tasks/product-issue-triage/judge.task.md
+++ b/benchmarks/kata-skills/tasks/product-issue-triage/judge.task.md
@@ -1,0 +1,26 @@
+Invariants result:
+
+```json
+{{INVARIANTS_RESULT}}
+```
+
+The agent was given these instructions:
+
+> {{AGENT_INSTRUCTIONS}}
+
+Agent trace at `{{AGENT_TRACE_PATH}}`. Read the product brief at
+`{{TASK_DIR}}/product-brief.md` and the triaged issue at
+`{{TASK_DIR}}/.tracker/issues/req-emoji-social.md`.
+
+Decide whether the agent **triaged the issue correctly** — not just whether the
+files clear the structural invariants. The request (animated emoji themes + a
+social activity feed) is out of scope for a minimal local single-user CLI.
+Cross-reference the agent's instructions: did it classify the issue as out of
+scope, append a rationale grounded in the brief, label it `wontfix`, close it,
+and refrain from opening a change or spec — all through the work-item operations
+rather than `gh`?
+
+Call `Conclude` with `verdict="success"` if the triage is correct and grounded,
+or `verdict="failure"` if it misclassified, acted through the wrong channel, or
+left the issue open. Include a one-sentence `summary` naming the deciding
+evidence.

--- a/benchmarks/kata-skills/tasks/product-issue-triage/supervisor.task.md
+++ b/benchmarks/kata-skills/tasks/product-issue-triage/supervisor.task.md
@@ -1,0 +1,1 @@
+<!-- Reserved per spec #870 design Decision 14; unread in v1. -->

--- a/benchmarks/kata-skills/tasks/product-issue-triage/workdir/.tracker/issues/req-emoji-social.md
+++ b/benchmarks/kata-skills/tasks/product-issue-triage/workdir/.tracker/issues/req-emoji-social.md
@@ -1,0 +1,15 @@
+---
+id: req-emoji-social
+kind: issue
+state: open
+labels: []
+links: []
+---
+
+# Add animated emoji themes and a social activity feed
+
+Please add animated emoji themes for the task list and a social activity feed so
+users can follow each other's todos and react to them with emojis. It would make
+the tool more fun and engaging.
+
+## Comments

--- a/benchmarks/kata-skills/tasks/product-issue-triage/workdir/product-brief.md
+++ b/benchmarks/kata-skills/tasks/product-issue-triage/workdir/product-brief.md
@@ -1,0 +1,12 @@
+# Product brief — `todo` CLI
+
+`todo` is a minimal, local, single-user command-line task tracker — `add`,
+`list`, `done`, backed by a local JSON store. It is deliberately small and
+stays fast and dependency-free.
+
+**In scope:** local task capture and retrieval that keeps the CLI simple and
+quick — flags and output that help one person manage their own list.
+
+**Out of scope:** multi-user or social features, networked sync, accounts, and
+visual theming or animation. These contradict the "minimal local single-user
+CLI" direction and are not planned.

--- a/benchmarks/kata-skills/tasks/spec-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/spec-feature/hooks/invariants.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -u
-SPEC="$WORKDIR/specs/042-todo-filter/spec.md"
-JTBD="$WORKDIR/jtbd-excerpt.md"
+SPEC="$AGENT_CWD/specs/042-todo-filter/spec.md"
+JTBD="$AGENT_CWD/jtbd-excerpt.md"
 FAIL=0
-assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 
 assert file-present --exists "$SPEC"
 [ "$FAIL" = 1 ] && exit 1

--- a/benchmarks/kata-skills/tasks/spec-feature/hooks/preflight.sh
+++ b/benchmarks/kata-skills/tasks/spec-feature/hooks/preflight.sh
@@ -2,4 +2,4 @@
 # Smoke-check the shared app (materialized by the harness from the family-level
 # workdir/) is sane before the agent starts.
 set -eu
-cd "$WORKDIR/app" && node --test >/dev/null 2>&1
+cd "$AGENT_CWD/app" && node --test >/dev/null 2>&1

--- a/libraries/libeval/bin/fit-eval.js
+++ b/libraries/libeval/bin/fit-eval.js
@@ -79,6 +79,11 @@ const definition = {
           type: "string",
           description: "Agent profile name to load",
         },
+        "work-tracker": {
+          type: "string",
+          description:
+            "Active work-item tracker (github|filesystem, default: github)",
+        },
         "allowed-tools": {
           type: "string",
           description: "Comma-separated tool allowlist",
@@ -114,6 +119,11 @@ const definition = {
           description: "Write the NDJSON trace to a file",
         },
         "agent-profile": { type: "string", description: "Agent profile name" },
+        "work-tracker": {
+          type: "string",
+          description:
+            "Active work-item tracker (github|filesystem, default: github)",
+        },
         "allowed-tools": {
           type: "string",
           description: "Agent tool allowlist",
@@ -169,6 +179,11 @@ const definition = {
           type: "string",
           description: "Working directory shared by participants (default: .)",
         },
+        "work-tracker": {
+          type: "string",
+          description:
+            "Active work-item tracker (github|filesystem, default: github)",
+        },
       },
     },
     {
@@ -209,6 +224,11 @@ const definition = {
         "resume-context": {
           type: "string",
           description: "JSON-serialized prior state for a resumed run",
+        },
+        "work-tracker": {
+          type: "string",
+          description:
+            "Active work-item tracker (github|filesystem, default: github)",
         },
       },
     },
@@ -268,6 +288,7 @@ const definition = {
   },
   examples: [
     "fit-eval run --task-file=task.md --output=trace.ndjson",
+    "fit-eval run --task-file=task.md --work-tracker=filesystem --output=trace.ndjson",
     "fit-eval supervise --task-file=task.md --lead-profile=judge --agent-profile=coder --output=trace.ndjson",
     'fit-eval facilitate --task-file=task.md --lead-profile=lead --agent-profiles="security-engineer,technical-writer" --output=trace.ndjson',
     'fit-eval discuss --task-file=task.md --lead-profile=release-engineer --agent-profiles="staff-engineer,security-engineer" --discussion-id=GD_kw...',

--- a/libraries/libeval/src/benchmark/apm-installer.js
+++ b/libraries/libeval/src/benchmark/apm-installer.js
@@ -11,7 +11,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 /** Installs apm and stages `.claude/` for a task family. */
 export class ApmInstaller {
@@ -28,19 +28,30 @@ export class ApmInstaller {
   /**
    * @param {import("./task-family.js").TaskFamily} family
    * @param {string} outputDir - The benchmark run's output directory.
+   * @param {object} [options]
+   * @param {string|null} [options.skillsFrom] - Stage `.claude/` from this
+   *   directory instead of running apm install. The path is a root containing
+   *   a `.claude/` tree (e.g. a working tree), letting a run exercise local,
+   *   unpublished skills.
    * @returns {Promise<{stagingDir: string, skillSetHash: string, judgeProfilesDir: string}>}
    */
-  async install(family, outputDir) {
+  async install(family, outputDir, { skillsFrom } = {}) {
     const fs = this.runtime.fs;
     const stagingDir = join(outputDir, ".apm-staging");
     const stagedClaude = join(stagingDir, ".claude");
-    const sourceClaude = join(family.rootPath, ".claude");
+    const sourceClaude = skillsFrom
+      ? join(resolve(skillsFrom), ".claude")
+      : join(family.rootPath, ".claude");
     const apmYml = join(family.rootPath, "apm.yml");
 
-    const hasApm = await fs
-      .access(apmYml)
-      .then(() => true)
-      .catch(() => false);
+    // --skills-from takes precedence over apm install: the caller is supplying
+    // the skill tree explicitly, so no remote fetch runs.
+    const hasApm =
+      !skillsFrom &&
+      (await fs
+        .access(apmYml)
+        .then(() => true)
+        .catch(() => false));
 
     if (hasApm) {
       await this.#runApmInstall(family.rootPath);
@@ -58,6 +69,9 @@ export class ApmInstaller {
       .access(sourceClaude)
       .then(() => true)
       .catch(() => false);
+    if (skillsFrom && !hasClaudeDir) {
+      throw new Error(`--skills-from has no .claude/ tree at ${sourceClaude}`);
+    }
     if (hasClaudeDir) {
       await fs.cp(sourceClaude, stagedClaude, { recursive: true });
     } else {
@@ -134,7 +148,9 @@ export function createApmInstaller(deps) {
  * @param {import("./task-family.js").TaskFamily} family
  * @param {string} outputDir
  * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
+ * @param {object} [options] - Forwarded to `ApmInstaller.install` (e.g.
+ *   `{ skillsFrom }`).
  */
-export function installApm(family, outputDir, runtime) {
-  return new ApmInstaller({ runtime }).install(family, outputDir);
+export function installApm(family, outputDir, runtime, options = {}) {
+  return new ApmInstaller({ runtime }).install(family, outputDir, options);
 }

--- a/libraries/libeval/src/benchmark/hook-env.js
+++ b/libraries/libeval/src/benchmark/hook-env.js
@@ -12,7 +12,7 @@
 /**
  * @param {Record<string, string>} baseEnv - Inherited env (`runtime.proc.env`).
  * @param {object} vars
- * @param {string} vars.cwd - Agent CWD → `$WORKDIR`.
+ * @param {string} vars.cwd - Agent CWD → `$AGENT_CWD`.
  * @param {number} vars.port - Allocated TCP port → `$PORT`.
  * @param {string} vars.taskId - Task id → `$TASK_ID`.
  * @param {string} vars.taskDir - Task directory on host → `$TASK_DIR`.
@@ -27,7 +27,10 @@ export function buildHookEnv(
 ) {
   return {
     ...baseEnv,
-    WORKDIR: cwd,
+    // The agent CWD itself — hooks reference emitted files as `$AGENT_CWD/<path>`.
+    // Distinct from the `invariants` CLI's `--run-dir` (the parent that
+    // *contains* `cwd/`), so the two are never confused.
+    AGENT_CWD: cwd,
     PORT: String(port),
     TASK_ID: taskId,
     TASK_DIR: taskDir,

--- a/libraries/libeval/src/benchmark/invariants.js
+++ b/libraries/libeval/src/benchmark/invariants.js
@@ -17,6 +17,9 @@ import { buildHookEnv } from "./hook-env.js";
  * @property {"pass" | "fail"} verdict
  * @property {Array<object>} details
  * @property {number} exitCode
+ * @property {string} [stderr] - Trimmed script stderr, present only when the
+ *   script wrote to stderr. Surfaces hook failures (e.g. a missing tool) that
+ *   leave `details` empty, so they read distinctly from a real invariant miss.
  */
 
 /**
@@ -81,11 +84,14 @@ export async function runInvariants(task, ctx, runtime) {
   const details = [];
   parseFd3Buffer(raw, details);
   const exitCode = typeof code === "number" ? code : -1;
-  return {
+  const result = {
     verdict: exitCode === 0 ? "pass" : "fail",
     details,
     exitCode,
   };
+  const trimmedStderr = stderr.trim();
+  if (trimmedStderr) result.stderr = trimmedStderr;
+  return result;
 }
 
 function pushRow(line, details) {

--- a/libraries/libeval/src/benchmark/result.js
+++ b/libraries/libeval/src/benchmark/result.js
@@ -20,6 +20,7 @@ const INVARIANTS_SHAPE = z.object({
   verdict: VERDICT_ENUM,
   details: z.array(z.unknown()),
   exitCode: z.number().int(),
+  stderr: z.string().optional(),
 });
 
 const JUDGE_VERDICT_SHAPE = z.object({

--- a/libraries/libeval/src/benchmark/runner.js
+++ b/libraries/libeval/src/benchmark/runner.js
@@ -86,6 +86,8 @@ export class BenchmarkRunner {
     query,
     allowedTools,
     maxTurns,
+    task,
+    skillsFrom,
     termGraceMs,
     runtime,
     // Test seams — default to the real implementations.
@@ -110,6 +112,8 @@ export class BenchmarkRunner {
     };
     this.query = query;
     this.maxTurns = maxTurns;
+    this.taskFilter = task ?? null;
+    this.skillsFrom = skillsFrom ?? null;
     this.termGraceMs = termGraceMs;
     this._runAgentHook = runAgent ?? null;
     this._runInvariantsHook = runInvariantsHook ?? runInvariants;
@@ -131,10 +135,22 @@ export class BenchmarkRunner {
 
     await runtime.fs.mkdir(this.output, { recursive: true });
     const { stagingDir, skillSetHash, judgeProfilesDir } =
-      await this._installApmHook(family, this.output, runtime);
+      await this._installApmHook(family, this.output, runtime, {
+        skillsFrom: this.skillsFrom,
+      });
     await this._installNpmHook(family, stagingDir, runtime);
 
-    const tasks = family.tasks();
+    let tasks = family.tasks();
+    if (this.taskFilter) {
+      const matched = tasks.filter((t) => t.id === this.taskFilter);
+      if (matched.length === 0) {
+        const available = tasks.map((t) => t.id).join(", ");
+        throw new Error(
+          `no task '${this.taskFilter}' in family; available: ${available}`,
+        );
+      }
+      tasks = matched;
+    }
     if (this.profiles.judge) {
       await assertJudgeProfileStaged(
         family,

--- a/libraries/libeval/src/benchmark/workdir.js
+++ b/libraries/libeval/src/benchmark/workdir.js
@@ -185,7 +185,7 @@ export class WorkdirManager {
  * Spawn preflight. Stays detached so we can SIGTERM the whole process group.
  * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
  * @param {string} script
- * @param {string} cwd - Agent CWD passed via $WORKDIR.
+ * @param {string} cwd - Agent CWD passed via $AGENT_CWD.
  * @param {number} port - Free TCP port passed via $PORT.
  * @param {{taskId: string, taskDir: string, hooksDir: string, familyDir: string|null}} vars - Extra hook env vars.
  * @returns {Promise<{pgid: number, error?: {phase: string, message: string, exitCode: number}}>}

--- a/libraries/libeval/src/commands/benchmark-definition.js
+++ b/libraries/libeval/src/commands/benchmark-definition.js
@@ -28,6 +28,16 @@ export const definition = {
           type: "string",
           description: "Path or git URL to a task family",
         },
+        task: {
+          type: "string",
+          description:
+            "Run only this task id (directory name under tasks/, default: every task)",
+        },
+        "skills-from": {
+          type: "string",
+          description:
+            "Stage .claude/ from this directory (a root containing .claude/) instead of running apm install — exercise local, unpublished skills",
+        },
         output: {
           type: "string",
           description:
@@ -57,6 +67,11 @@ export const definition = {
           type: "string",
           description: "Judge profile name",
         },
+        "work-tracker": {
+          type: "string",
+          description:
+            "Active work-item tracker (github|filesystem, default: github)",
+        },
         "max-turns": {
           type: "string",
           description:
@@ -84,10 +99,10 @@ export const definition = {
           type: "string",
           description: "Task id (directory name under tasks/)",
         },
-        workdir: {
+        "run-dir": {
           type: "string",
           description:
-            "Post-run directory; <workdir>/cwd/ is the agent CWD invariants run against",
+            "Post-run directory whose cwd/ subdir is the agent CWD; invariants run against that cwd — the path hooks receive as $AGENT_CWD",
         },
         output: {
           type: "string",
@@ -125,8 +140,11 @@ export const definition = {
   },
   examples: [
     "fit-benchmark run --family=./families/coding",
+    "fit-benchmark run --family=./families/coding --task=todo-api --runs=1",
+    "fit-benchmark run --family=./families/coding --work-tracker=filesystem",
+    "fit-benchmark run --family=./families/coding --skills-from=. --task=todo-api",
     `fit-benchmark run --family=./families/coding --runs=10 --agent-model=${BENCHMARK_AGENT_MODEL}`,
-    "fit-benchmark invariants --family=./families/coding --task=todo-api --workdir=./benchmark-runs/runs/todo-api/0",
+    "fit-benchmark invariants --family=./families/coding --task=todo-api --run-dir=./benchmark-runs/runs/todo-api/0",
     "fit-benchmark report --format=text",
     "fit-benchmark report --input=./runs/today --k=1,3,5 --format=text",
   ],

--- a/libraries/libeval/src/commands/benchmark-invariants.js
+++ b/libraries/libeval/src/commands/benchmark-invariants.js
@@ -23,16 +23,15 @@ export async function runBenchmarkInvariantsCommand(ctx) {
     return { ok: false, code: 1, error: "--family is required" };
   const taskId = values.task;
   if (!taskId) return { ok: false, code: 1, error: "--task is required" };
-  const workdirArg = values.workdir;
-  if (!workdirArg)
-    return { ok: false, code: 1, error: "--workdir is required" };
+  const runDirArg = values["run-dir"];
+  if (!runDirArg) return { ok: false, code: 1, error: "--run-dir is required" };
 
   const family = await loadTaskFamily(familyInput, runtime);
   const task = family.tasks().find((t) => t.id === taskId);
   if (!task)
     return { ok: false, code: 1, error: `task not found in family: ${taskId}` };
 
-  const runDir = resolve(workdirArg);
+  const runDir = resolve(runDirArg);
   const cwd = join(runDir, "cwd");
   const port = await allocatePort();
 

--- a/libraries/libeval/src/commands/benchmark-run.js
+++ b/libraries/libeval/src/commands/benchmark-run.js
@@ -8,6 +8,7 @@ import { resolve } from "node:path";
 
 import { createConfig } from "@forwardimpact/libconfig";
 import { createBenchmarkRunner } from "../benchmark/runner.js";
+import { resolveWorkTracker } from "./work-tracker.js";
 import {
   BENCHMARK_AGENT_MODEL,
   LEAD_MODEL,
@@ -28,6 +29,10 @@ export async function runBenchmarkRunCommand(ctx) {
   }
   const config = await createConfig("script", "benchmark");
   runtime.proc.env.ANTHROPIC_API_KEY = await config.anthropicToken();
+  // The benchmark agent runs via createBenchmarkRunner, not the supervise
+  // command, so the active-tracker env must land here before the runner
+  // spawns the subprocess that inherits process.env.
+  runtime.proc.env.LIBEVAL_WORK_TRACKER = opts.workTracker;
 
   // The Claude Agent SDK spawns a `claude` subprocess that inherits
   // process.env. NODE_EXTRA_CA_CERTS causes undici (the HTTP client
@@ -47,7 +52,13 @@ export async function runBenchmarkRunCommand(ctx) {
   return anyFail ? { ok: false, code: 1, error: "" } : { ok: true };
 }
 
-function parseRunOptions(values) {
+/**
+ * Parse and validate benchmark run options. Exported so tests can verify
+ * defaults, including the resolved work tracker.
+ * @param {Record<string, string|undefined>} values - Parsed option values
+ * @returns {object}
+ */
+export function parseRunOptions(values) {
   const family = values.family;
   if (!family) throw new Error("--family is required");
   const output = values.output ?? "benchmark-runs";
@@ -57,10 +68,13 @@ function parseRunOptions(values) {
   return {
     family,
     runs,
+    task: values.task ?? null,
+    skillsFrom: values["skills-from"] ?? null,
     output: resolve(output),
     agentModel: values["agent-model"] || BENCHMARK_AGENT_MODEL,
     supervisorModel: values["lead-model"] || LEAD_MODEL,
     judgeModel: values["judge-model"] || LEAD_MODEL,
+    workTracker: resolveWorkTracker(values),
     profiles: {
       agent: values["agent-profile"] ?? null,
       judge: values["judge-profile"] ?? null,

--- a/libraries/libeval/src/commands/discuss.js
+++ b/libraries/libeval/src/commands/discuss.js
@@ -4,6 +4,7 @@ import { createDiscusser } from "../discusser.js";
 import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
 import { resolveTaskContent } from "./task-input.js";
+import { resolveWorkTracker } from "./work-tracker.js";
 import { AGENT_MODEL, LEAD_MODEL } from "@forwardimpact/libutil/models";
 
 function parseAgentProfiles(raw, cwd, maxTurns) {
@@ -58,6 +59,7 @@ export function parseDiscussOptions(values, runtime) {
     maxTurns,
     maxLeadTurns,
     outputPath: values.output,
+    workTracker: resolveWorkTracker(values),
     discussionId: values["discussion-id"] ?? null,
     resumeContext,
     callbackUrl: runtime.proc.env.CALLBACK_URL ?? null,
@@ -95,6 +97,9 @@ export async function runDiscussCommand(ctx) {
   if (opts.leadProfile) {
     runtime.proc.env.LIBEVAL_AGENT_PROFILE = opts.leadProfile;
   }
+  // Unconditional so the default "github" is observable to the agent's
+  // active-tracker resolution, mirroring --agent-profile's env write above.
+  runtime.proc.env.LIBEVAL_WORK_TRACKER = opts.workTracker;
 
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
   const discusser = createDiscusser({

--- a/libraries/libeval/src/commands/facilitate.js
+++ b/libraries/libeval/src/commands/facilitate.js
@@ -4,6 +4,7 @@ import { createFacilitator } from "../facilitator.js";
 import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
 import { resolveTaskContent } from "./task-input.js";
+import { resolveWorkTracker } from "./work-tracker.js";
 import { AGENT_MODEL, LEAD_MODEL } from "@forwardimpact/libutil/models";
 
 /**
@@ -56,6 +57,7 @@ export function parseFacilitateOptions(values, runtime) {
     maxTurns,
     outputPath: values.output,
     facilitatorProfile: values["lead-profile"] ?? undefined,
+    workTracker: resolveWorkTracker(values),
   };
 }
 
@@ -91,6 +93,9 @@ export async function runFacilitateCommand(ctx) {
   if (opts.facilitatorProfile) {
     runtime.proc.env.LIBEVAL_AGENT_PROFILE = opts.facilitatorProfile;
   }
+  // Unconditional so the default "github" is observable to the agent's
+  // active-tracker resolution, mirroring --agent-profile's env write above.
+  runtime.proc.env.LIBEVAL_WORK_TRACKER = opts.workTracker;
 
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
   const facilitator = createFacilitator({

--- a/libraries/libeval/src/commands/run.js
+++ b/libraries/libeval/src/commands/run.js
@@ -6,6 +6,7 @@ import { composeProfilePrompt } from "../profile-prompt.js";
 import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
 import { SequenceCounter } from "../sequence-counter.js";
+import { resolveWorkTracker } from "./work-tracker.js";
 import { resolveTaskContent } from "./task-input.js";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { AGENT_MODEL } from "@forwardimpact/libutil/models";
@@ -14,9 +15,9 @@ import { AGENT_MODEL } from "@forwardimpact/libutil/models";
  * Parse and validate run command options from parsed values.
  * @param {object} values - Parsed option values from cli.parse()
  * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
- * @returns {{ taskContent: string, cwd: string, model: string, maxTurns: number, outputPath: string|undefined, agentProfile: string|undefined, allowedTools: string[] }}
+ * @returns {{ taskContent: string, cwd: string, model: string, maxTurns: number, outputPath: string|undefined, agentProfile: string|undefined, workTracker: string, allowedTools: string[] }}
  */
-function parseRunOptions(values, runtime) {
+export function parseRunOptions(values, runtime) {
   const { task: taskContent, amend: taskAmend } = resolveTaskContent(
     values,
     runtime,
@@ -31,6 +32,7 @@ function parseRunOptions(values, runtime) {
     maxTurns: maxTurnsRaw === "0" ? 0 : parseInt(maxTurnsRaw, 10),
     outputPath: values.output,
     agentProfile: values["agent-profile"] ?? undefined,
+    workTracker: resolveWorkTracker(values),
     allowedTools: (
       values["allowed-tools"] ??
       "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"
@@ -57,6 +59,7 @@ export async function runRunCommand(ctx) {
     maxTurns,
     outputPath,
     agentProfile,
+    workTracker,
     allowedTools,
     mcpServer,
   } = parseRunOptions(ctx.options, runtime);
@@ -108,6 +111,9 @@ export async function runRunCommand(ctx) {
   if (agentProfile) {
     runtime.proc.env.LIBEVAL_AGENT_PROFILE = agentProfile;
   }
+  // Unconditional so the default "github" is observable to the agent's
+  // active-tracker resolution, mirroring --agent-profile's env write above.
+  runtime.proc.env.LIBEVAL_WORK_TRACKER = workTracker;
 
   const systemPrompt = agentProfile
     ? composeProfilePrompt(agentProfile, {

--- a/libraries/libeval/src/commands/supervise.js
+++ b/libraries/libeval/src/commands/supervise.js
@@ -4,6 +4,7 @@ import { createSupervisor } from "../supervisor.js";
 import { createRedactor } from "../redaction.js";
 import { createTeeWriter } from "../tee-writer.js";
 import { resolveTaskContent } from "./task-input.js";
+import { resolveWorkTracker } from "./work-tracker.js";
 import { createServiceConfig } from "@forwardimpact/libconfig";
 import { AGENT_MODEL, LEAD_MODEL } from "@forwardimpact/libutil/models";
 
@@ -40,6 +41,7 @@ export async function parseSuperviseOptions(values, runtime) {
     outputPath: values.output,
     supervisorProfile: values["lead-profile"] ?? undefined,
     agentProfile: values["agent-profile"] ?? undefined,
+    workTracker: resolveWorkTracker(values),
     allowedTools: (
       values["allowed-tools"] ??
       "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"
@@ -100,6 +102,9 @@ export async function runSuperviseCommand(ctx) {
   if (opts.agentProfile) {
     runtime.proc.env.LIBEVAL_AGENT_PROFILE = opts.agentProfile;
   }
+  // Unconditional so the default "github" is observable to the agent's
+  // active-tracker resolution, mirroring --agent-profile's env write above.
+  runtime.proc.env.LIBEVAL_WORK_TRACKER = opts.workTracker;
 
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
   const supervisor = createSupervisor({

--- a/libraries/libeval/src/commands/work-tracker.js
+++ b/libraries/libeval/src/commands/work-tracker.js
@@ -1,0 +1,29 @@
+/**
+ * The active work-item tracker selects which column of the work-trackers
+ * matrix realizes each coordination operation (see the agent reference
+ * `work-trackers.md`). `github` is the production binding; the offline
+ * coordination benchmark runs under `filesystem`.
+ */
+export const DEFAULT_WORK_TRACKER = "github";
+
+/** Trackers the harness knows how to select. */
+export const KNOWN_WORK_TRACKERS = ["github", "filesystem"];
+
+/**
+ * Resolve the active work tracker from parsed CLI option values, falling back
+ * to the default when `--work-tracker` is absent or blank. The harness writes
+ * the result to `LIBEVAL_WORK_TRACKER` on the agent environment, mirroring
+ * `--agent-profile` → `LIBEVAL_AGENT_PROFILE`.
+ * @param {Record<string, string|undefined>} values - Parsed option values
+ * @returns {string}
+ * @throws {Error} if `--work-tracker` is set to an unknown tracker
+ */
+export function resolveWorkTracker(values) {
+  const tracker = values["work-tracker"] || DEFAULT_WORK_TRACKER;
+  if (!KNOWN_WORK_TRACKERS.includes(tracker)) {
+    throw new Error(
+      `unknown work tracker '${tracker}'; expected one of: ${KNOWN_WORK_TRACKERS.join(", ")}`,
+    );
+  }
+  return tracker;
+}

--- a/libraries/libeval/test/benchmark-apm-installer.integration.test.js
+++ b/libraries/libeval/test/benchmark-apm-installer.integration.test.js
@@ -42,6 +42,41 @@ describe("ApmInstaller.install", () => {
     assert.strictEqual(apmCalls[0].options.cwd, family.rootPath);
   });
 
+  test("--skills-from stages the given .claude/ and skips apm install", async () => {
+    const runtime = rt();
+    const family = await loadTaskFamily(FIXTURE, runtime);
+    // A local skills root containing a .claude/ tree, standing in for a
+    // working tree with unpublished skills.
+    const skillsRoot = await mkdtemp(join(tmpdir(), "benchmark-skills-"));
+    await cp(join(FIXTURE, ".claude"), join(skillsRoot, ".claude"), {
+      recursive: true,
+    });
+    const out = await mkdtemp(join(tmpdir(), "benchmark-apm-sf-"));
+    const { stagingDir } = await createApmInstaller({ runtime }).install(
+      family,
+      out,
+      { skillsFrom: skillsRoot },
+    );
+    await access(join(stagingDir, ".claude", "skills", "noop", "SKILL.md"));
+    const apmCalls = runtime.subprocess.calls.filter((c) => c.cmd === "apm");
+    assert.strictEqual(apmCalls.length, 0, "apm install must be skipped");
+    await rm(skillsRoot, { recursive: true, force: true });
+  });
+
+  test("--skills-from with no .claude/ tree throws", async () => {
+    const runtime = rt();
+    const family = await loadTaskFamily(FIXTURE, runtime);
+    const emptyRoot = await mkdtemp(join(tmpdir(), "benchmark-skills-empty-"));
+    const out = await mkdtemp(join(tmpdir(), "benchmark-apm-sf-empty-"));
+    await assert.rejects(
+      () =>
+        createApmInstaller({ runtime }).install(family, out, {
+          skillsFrom: emptyRoot,
+        }),
+      /--skills-from has no \.claude\/ tree/,
+    );
+  });
+
   test("two consecutive runs on the same family produce the same skillSetHash", async () => {
     const family = await loadTaskFamily(FIXTURE, rt());
     const a = await newInstaller().install(

--- a/libraries/libeval/test/benchmark-e2e.integration.test.js
+++ b/libraries/libeval/test/benchmark-e2e.integration.test.js
@@ -125,7 +125,7 @@ async function mockRunJudge(_task, workdir, invariants) {
   };
 }
 
-async function setupRunner({ runs = 2, runAgent = mockRunAgent } = {}) {
+async function setupRunner({ runs = 2, runAgent = mockRunAgent, task } = {}) {
   const out = await mkdtemp(join(tmpdir(), "benchmark-e2e-"));
   const noopQuery = async function* () {};
   const runner = new BenchmarkRunner({
@@ -142,6 +142,7 @@ async function setupRunner({ runs = 2, runAgent = mockRunAgent } = {}) {
     runJudge: mockRunJudge,
     installApm: mockInstallApm,
     installNpm: async () => {},
+    task,
     termGraceMs: 100,
   });
   return { runner, out };
@@ -295,5 +296,24 @@ describe("BenchmarkRunner E2E (fixture family)", () => {
     assert.strictEqual(passRec.agentError.aborted, false);
     assert.strictEqual(passRec.costUsd, 0);
     assert.strictEqual(passRec.submission, "");
+  });
+
+  test("--task runs only the named task", { timeout: 30_000 }, async () => {
+    const { runner } = await setupRunner({ runs: 2, task: "pass" });
+    const records = await collectRecords(runner);
+    // 1 task × 2 runs, and only the filtered task appears.
+    assert.strictEqual(records.length, 2);
+    assert.ok(
+      records.every((r) => r.taskId === "pass"),
+      "task filter leaked other tasks",
+    );
+  });
+
+  test("--task with an unknown id throws, listing available tasks", async () => {
+    const { runner } = await setupRunner({ runs: 1, task: "nope" });
+    await assert.rejects(
+      () => collectRecords(runner),
+      /no task 'nope' in family; available:.*\bpass\b/,
+    );
   });
 });

--- a/libraries/libeval/test/benchmark-hook-env.test.js
+++ b/libraries/libeval/test/benchmark-hook-env.test.js
@@ -16,7 +16,8 @@ describe("buildHookEnv", () => {
         familyDir: "/fam",
       },
     );
-    assert.equal(env.WORKDIR, "/run/cwd");
+    assert.equal(env.AGENT_CWD, "/run/cwd");
+    assert.equal(env.WORKDIR, undefined, "no legacy WORKDIR alias");
     assert.equal(env.PORT, "4242");
     assert.equal(env.TASK_ID, "spec-feature");
     assert.equal(env.TASK_DIR, "/fam/tasks/spec-feature");

--- a/libraries/libeval/test/benchmark-invariants.integration.test.js
+++ b/libraries/libeval/test/benchmark-invariants.integration.test.js
@@ -65,6 +65,34 @@ exit 3
     assert.strictEqual(out.details.length, 0);
   });
 
+  test("script stderr is surfaced so a hook failure reads distinctly", async () => {
+    // A failing hook tool (here a command that does not exist) writes to
+    // stderr and exits non-zero while emitting no fd-3 rows — the signature of
+    // a harness problem, not a real invariant miss. The stderr must survive.
+    const { task, ctx } = await buildStubTask(
+      `#!/bin/sh
+this-tool-does-not-exist assert --exists /nope
+exit 1
+`,
+    );
+    const out = await runInvariants(task, ctx, RT);
+    assert.strictEqual(out.verdict, "fail");
+    assert.strictEqual(out.details.length, 0);
+    assert.match(out.stderr, /not found/i);
+  });
+
+  test("a clean run carries no stderr field", async () => {
+    const { task, ctx } = await buildStubTask(
+      `#!/bin/sh
+printf '%s\\n' '{"test":"t","pass":true}' >&"$RESULTS_FD"
+exit 0
+`,
+    );
+    const out = await runInvariants(task, ctx, RT);
+    assert.strictEqual(out.verdict, "pass");
+    assert.ok(!("stderr" in out), "clean run should omit stderr");
+  });
+
   test("malformed fd-3 lines survive as raw rows with parseError", async () => {
     const { task, ctx } = await buildStubTask(
       `#!/bin/sh
@@ -83,17 +111,17 @@ exit 0
     assert.deepStrictEqual(out.details[1], { test: "t1", pass: true });
   });
 
-  test("WORKDIR, PORT, RESULTS_FD env vars reach the script", async () => {
+  test("AGENT_CWD, PORT, RESULTS_FD env vars reach the script", async () => {
     const { task, ctx } = await buildStubTask(
       `#!/bin/sh
-printf '%s\n' "{\\"workdir\\":\\"$WORKDIR\\",\\"port\\":$PORT,\\"fd\\":$RESULTS_FD,\\"pass\\":true}" >&"$RESULTS_FD"
+printf '%s\n' "{\\"cwd\\":\\"$AGENT_CWD\\",\\"port\\":$PORT,\\"fd\\":$RESULTS_FD,\\"pass\\":true}" >&"$RESULTS_FD"
 exit 0
 `,
     );
     ctx.port = 12345;
     const out = await runInvariants(task, ctx, RT);
     assert.strictEqual(out.verdict, "pass");
-    assert.strictEqual(out.details[0].workdir, ctx.cwd);
+    assert.strictEqual(out.details[0].cwd, ctx.cwd);
     assert.strictEqual(out.details[0].port, 12345);
     assert.strictEqual(out.details[0].fd, 3);
   });

--- a/libraries/libeval/test/benchmark-workdir.integration.test.js
+++ b/libraries/libeval/test/benchmark-workdir.integration.test.js
@@ -57,7 +57,7 @@ setInterval(() => {}, 1000);
 `;
     await writeFile(join(taskRoot, "workdir", "listener.js"), listener);
     const preflight = `#!/bin/sh
-node "$WORKDIR/listener.js" >/dev/null 2>&1 &
+node "$AGENT_CWD/listener.js" >/dev/null 2>&1 &
 # Give the listener a moment to bind before we exit.
 sleep 0.2
 exit 0

--- a/libraries/libeval/test/fixtures/benchmark-family/tasks/pass/hooks/invariants.sh
+++ b/libraries/libeval/test/fixtures/benchmark-family/tasks/pass/hooks/invariants.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Running-service probe: HTTP-GET / on $PORT, expect `{"ok":true}`.
 RESP="$(curl -sf --max-time 2 "http://127.0.0.1:$PORT/" 2>/dev/null)"
-SENTINEL="$WORKDIR/sentinel-pass-file"
+SENTINEL="$AGENT_CWD/sentinel-pass-file"
 # The sentinel file's name is part of the invariants-isolation property —
 # its content should never appear in the agent trace because hooks/
 # is never copied to the agent CWD.

--- a/libraries/libeval/test/fixtures/benchmark-family/tasks/pass/hooks/preflight.sh
+++ b/libraries/libeval/test/fixtures/benchmark-family/tasks/pass/hooks/preflight.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 # Start the service in the background. teardown reaps it.
-node "$WORKDIR/app.js" >/dev/null 2>&1 &
+node "$AGENT_CWD/app.js" >/dev/null 2>&1 &
 sleep 0.2
 exit 0

--- a/libraries/libeval/test/fixtures/benchmark-family/tasks/repo-state/hooks/invariants.sh
+++ b/libraries/libeval/test/fixtures/benchmark-family/tasks/repo-state/hooks/invariants.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-# Repo-state invariants: asserts SHA-256 of `$WORKDIR/result.txt` matches the
+# Repo-state invariants: asserts SHA-256 of `$AGENT_CWD/result.txt` matches the
 # digest of "hello\n".
 EXPECTED="5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
-F="$WORKDIR/result.txt"
+F="$AGENT_CWD/result.txt"
 if [ ! -f "$F" ]; then
   printf '%s\n' '{"test":"file","pass":false,"message":"result.txt missing"}' >&"$RESULTS_FD"
   exit 1

--- a/libraries/libeval/test/golden/fit-benchmark/cases.json
+++ b/libraries/libeval/test/golden/fit-benchmark/cases.json
@@ -7,6 +7,13 @@
     "stderrFile": "help.stderr.txt"
   },
   {
+    "name": "run-help",
+    "args": ["run", "--help"],
+    "exitCode": 0,
+    "stdoutFile": "run-help.stdout.txt",
+    "stderrFile": "run-help.stderr.txt"
+  },
+  {
     "name": "version",
     "args": ["--version"],
     "exitCode": 0,

--- a/libraries/libeval/test/golden/fit-benchmark/help.stdout.txt
+++ b/libraries/libeval/test/golden/fit-benchmark/help.stdout.txt
@@ -1,4 +1,4 @@
-fit-benchmark 0.1.50 — Run coding-agent task families, grade hidden tests, and aggregate pass@k across runs.
+fit-benchmark 0.1.64 — Run coding-agent task families, grade hidden tests, and aggregate pass@k across runs.
 
 Usage: fit-benchmark <command> [options]
 
@@ -14,8 +14,11 @@ Options:
 
 Examples:
   fit-benchmark run --family=./families/coding
+  fit-benchmark run --family=./families/coding --task=todo-api --runs=1
+  fit-benchmark run --family=./families/coding --work-tracker=filesystem
+  fit-benchmark run --family=./families/coding --skills-from=. --task=todo-api
   fit-benchmark run --family=./families/coding --runs=10 --agent-model=claude-sonnet-4-6
-  fit-benchmark invariants --family=./families/coding --task=todo-api --workdir=./benchmark-runs/runs/todo-api/0
+  fit-benchmark invariants --family=./families/coding --task=todo-api --run-dir=./benchmark-runs/runs/todo-api/0
   fit-benchmark report --format=text
   fit-benchmark report --input=./runs/today --k=1,3,5 --format=text
 

--- a/libraries/libeval/test/golden/fit-benchmark/run-help.stdout.txt
+++ b/libraries/libeval/test/golden/fit-benchmark/run-help.stdout.txt
@@ -1,0 +1,22 @@
+fit-benchmark run — Run every task in a family for N runs and emit one result record per (task, runIndex).
+
+Usage: fit-benchmark run [options]
+
+Options:
+  --family=<string>         Path or git URL to a task family
+  --task=<string>           Run only this task id (directory name under tasks/, default: every task)
+  --skills-from=<string>    Stage .claude/ from this directory (a root containing .claude/) instead of running apm install — exercise local, unpublished skills
+  --output=<string>         Run-output directory (created if missing, default: benchmark-runs)
+  --runs=<string>           Runs per task (integer ≥ 1, default: 5)
+  --agent-model=<string>    Claude model for the agent-under-test (default: claude-sonnet-4-6)
+  --lead-model=<string>     Claude model for the lead role (default: claude-opus-4-8[1m])
+  --judge-model=<string>    Claude model for the judge (default: claude-opus-4-8[1m])
+  --agent-profile=<string>  Agent-under-test profile name
+  --judge-profile=<string>  Judge profile name
+  --work-tracker=<string>   Active work-item tracker (github|filesystem, default: github)
+  --max-turns=<string>      Agent-under-test turn budget (default: 50, 0 = unlimited)
+  --allowed-tools=<string>  Comma-separated tool allowlist for the agent-under-test (default: Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite)
+
+Global options:
+  --help, -h  Show this help
+  --json      Output help as JSON

--- a/libraries/libeval/test/golden/fit-eval/cases.json
+++ b/libraries/libeval/test/golden/fit-eval/cases.json
@@ -7,6 +7,13 @@
     "stderrFile": "help.stderr.txt"
   },
   {
+    "name": "run-help",
+    "args": ["run", "--help"],
+    "exitCode": 0,
+    "stdoutFile": "run-help.stdout.txt",
+    "stderrFile": "run-help.stderr.txt"
+  },
+  {
     "name": "version",
     "args": ["--version"],
     "exitCode": 0,

--- a/libraries/libeval/test/golden/fit-eval/help.stdout.txt
+++ b/libraries/libeval/test/golden/fit-eval/help.stdout.txt
@@ -1,4 +1,4 @@
-fit-eval 0.1.50 — Run agents and capture NDJSON traces — for agent evaluations or multi-agent collaboration
+fit-eval 0.1.64 — Run agents and capture NDJSON traces — for agent evaluations or multi-agent collaboration
 
 Usage: fit-eval <command> [options]
 
@@ -19,6 +19,7 @@ Options:
 
 Examples:
   fit-eval run --task-file=task.md --output=trace.ndjson
+  fit-eval run --task-file=task.md --work-tracker=filesystem --output=trace.ndjson
   fit-eval supervise --task-file=task.md --lead-profile=judge --agent-profile=coder --output=trace.ndjson
   fit-eval facilitate --task-file=task.md --lead-profile=lead --agent-profiles="security-engineer,technical-writer" --output=trace.ndjson
   fit-eval discuss --task-file=task.md --lead-profile=release-engineer --agent-profiles="staff-engineer,security-engineer" --discussion-id=GD_kw...

--- a/libraries/libeval/test/golden/fit-eval/run-help.stdout.txt
+++ b/libraries/libeval/test/golden/fit-eval/run-help.stdout.txt
@@ -1,0 +1,22 @@
+fit-eval run — Run a single agent autonomously on a defined task
+
+Usage: fit-eval run [options]
+
+Options:
+  --task-file=<string>      Path to a markdown task file
+  --task-text=<string>      Inline task text (alternative to --task-file)
+  --task-event=<string>     Path to a native GitHub event payload JSON, composed into the task via libeval/src/events/github.js (reads $GITHUB_EVENT_NAME)
+  --task-amend=<string>     Additional text appended to the task
+  --agent-model=<string>    Claude model for the agent (default: claude-opus-4-8[1m])
+  --max-turns=<string>      Max agentic turns (default: 50, 0 = unlimited)
+  --output=<string>         Write the NDJSON trace to a file
+  --cwd=<string>            Working directory for the agent
+  --agent-profile=<string>  Agent profile name to load
+  --work-tracker=<string>   Active work-item tracker (github|filesystem, default: github)
+  --allowed-tools=<string>  Comma-separated tool allowlist
+  --mcp-server=<string>     Connect to the MCP service (e.g. --mcp-server=guide); adds mcp__<name>__* to allowed tools
+
+Global options:
+  --format=<string>  Output format (json|text)
+  --help, -h         Show this help
+  --json             Output help as JSON

--- a/libraries/libeval/test/work-tracker.test.js
+++ b/libraries/libeval/test/work-tracker.test.js
@@ -1,0 +1,167 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+import { createMockFs } from "@forwardimpact/libmock";
+
+import { parseRunOptions as parseRunOptionsEval } from "../src/commands/run.js";
+import { parseSuperviseOptions } from "../src/commands/supervise.js";
+import { parseDiscussOptions } from "../src/commands/discuss.js";
+import { parseFacilitateOptions } from "../src/commands/facilitate.js";
+import { parseRunOptions as parseBenchmarkRunOptions } from "../src/commands/benchmark-run.js";
+
+// Every agent-running entry point resolves --work-tracker (default "github")
+// so the handler can write it unconditionally to
+// runtime.proc.env.LIBEVAL_WORK_TRACKER, mirroring --agent-profile.
+// All cases use --task-text so the runtime's fs is never read; an in-memory fs
+// suffices. The env map is isolated for discuss's CALLBACK_URL/INBOX_URL reads.
+function makeRuntime(env = {}) {
+  return { fs: createMockFs(), proc: { env: { ...env } } };
+}
+
+describe("--work-tracker resolution across fit-eval agent commands", () => {
+  test("run resolves --work-tracker filesystem", () => {
+    const opts = parseRunOptionsEval(
+      { "task-text": "do a thing", "work-tracker": "filesystem" },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.workTracker, "filesystem");
+  });
+
+  test("run defaults to github when --work-tracker is absent", () => {
+    const opts = parseRunOptionsEval(
+      { "task-text": "do a thing" },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.workTracker, "github");
+  });
+
+  test("run treats an empty --work-tracker as the github default", () => {
+    const opts = parseRunOptionsEval(
+      { "task-text": "do a thing", "work-tracker": "" },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.workTracker, "github");
+  });
+
+  test("an unknown --work-tracker throws, listing the known trackers", () => {
+    assert.throws(
+      () =>
+        parseRunOptionsEval(
+          { "task-text": "do a thing", "work-tracker": "fs" },
+          makeRuntime(),
+        ),
+      /unknown work tracker 'fs'; expected one of: github, filesystem/,
+    );
+  });
+
+  test("supervise resolves --work-tracker filesystem", async () => {
+    const opts = await parseSuperviseOptions(
+      {
+        "task-text": "do a thing",
+        "agent-cwd": ".",
+        "work-tracker": "filesystem",
+      },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.workTracker, "filesystem");
+  });
+
+  test("supervise defaults to github when --work-tracker is absent", async () => {
+    const opts = await parseSuperviseOptions(
+      { "task-text": "do a thing", "agent-cwd": "." },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.workTracker, "github");
+  });
+
+  test("discuss resolves --work-tracker filesystem", () => {
+    const opts = parseDiscussOptions(
+      { "task-text": "do a thing", "work-tracker": "filesystem" },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.workTracker, "filesystem");
+  });
+
+  test("discuss defaults to github when --work-tracker is absent", () => {
+    const opts = parseDiscussOptions(
+      { "task-text": "do a thing" },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.workTracker, "github");
+  });
+
+  test("facilitate resolves --work-tracker filesystem", () => {
+    const opts = parseFacilitateOptions(
+      {
+        "task-text": "do a thing",
+        "agent-profiles": "alice,bob",
+        "work-tracker": "filesystem",
+      },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.workTracker, "filesystem");
+  });
+
+  test("facilitate defaults to github when --work-tracker is absent", () => {
+    const opts = parseFacilitateOptions(
+      { "task-text": "do a thing", "agent-profiles": "alice,bob" },
+      makeRuntime(),
+    );
+    assert.strictEqual(opts.workTracker, "github");
+  });
+});
+
+describe("fit-eval handlers write LIBEVAL_WORK_TRACKER unconditionally", () => {
+  // The handler writes runtime.proc.env.LIBEVAL_WORK_TRACKER = workTracker
+  // immediately after the --agent-profile block. Replay that one-line write
+  // against the parsed value to assert the env var lands with the right
+  // string, including the default, without spawning the agent SDK.
+  function writeEnv(runtime, workTracker) {
+    runtime.proc.env.LIBEVAL_WORK_TRACKER = workTracker;
+  }
+
+  test("filesystem flag lands as LIBEVAL_WORK_TRACKER", () => {
+    const runtime = makeRuntime();
+    const opts = parseRunOptionsEval(
+      { "task-text": "do a thing", "work-tracker": "filesystem" },
+      runtime,
+    );
+    writeEnv(runtime, opts.workTracker);
+    assert.strictEqual(runtime.proc.env.LIBEVAL_WORK_TRACKER, "filesystem");
+  });
+
+  test("absent flag lands as the github default", () => {
+    const runtime = makeRuntime();
+    const opts = parseRunOptionsEval({ "task-text": "do a thing" }, runtime);
+    writeEnv(runtime, opts.workTracker);
+    assert.strictEqual(runtime.proc.env.LIBEVAL_WORK_TRACKER, "github");
+  });
+});
+
+describe("fit-benchmark run resolves --work-tracker", () => {
+  test("resolves --work-tracker filesystem", () => {
+    const opts = parseBenchmarkRunOptions({
+      family: "./families/coding",
+      "work-tracker": "filesystem",
+    });
+    assert.strictEqual(opts.workTracker, "filesystem");
+  });
+
+  test("defaults to github when --work-tracker is absent", () => {
+    const opts = parseBenchmarkRunOptions({ family: "./families/coding" });
+    assert.strictEqual(opts.workTracker, "github");
+  });
+
+  test("the env var is set from opts.workTracker before the runner starts", () => {
+    // Mirror benchmark-run.js: the handler writes the env var right after the
+    // ANTHROPIC_API_KEY write and before createBenchmarkRunner, so the spawned
+    // subprocess inherits it. Replay that write against parsed opts.
+    const runtime = makeRuntime();
+    const opts = parseBenchmarkRunOptions({
+      family: "./families/coding",
+      "work-tracker": "filesystem",
+    });
+    runtime.proc.env.LIBEVAL_WORK_TRACKER = opts.workTracker;
+    assert.strictEqual(runtime.proc.env.LIBEVAL_WORK_TRACKER, "filesystem");
+  });
+});

--- a/websites/fit/docs/libraries/prove-changes/run-benchmark/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-benchmark/index.md
@@ -86,7 +86,7 @@ neither script is ever copied to the agent's working directory:
 
 | Var | Value |
 | --- | --- |
-| `$WORKDIR` | The per-task agent CWD. |
+| `$AGENT_CWD` | The per-task agent CWD. |
 | `$PORT` | A pre-allocated free TCP port. |
 | `$TASK_ID` | The task name. |
 | `$TASK_DIR` | The task directory on the host. |
@@ -108,7 +108,7 @@ test against:
 
 ```sh
 #!/bin/sh
-node "$WORKDIR/app.js" >/dev/null 2>&1 &
+node "$AGENT_CWD/app.js" >/dev/null 2>&1 &
 sleep 0.2
 exit 0
 ```
@@ -137,13 +137,13 @@ test "$RESP" = '[]' && exit 0 || exit 1
 
 ```sh
 # Repository state
-sha256sum "$WORKDIR/dist/build.tar.gz" \
+sha256sum "$AGENT_CWD/dist/build.tar.gz" \
   | grep -q '^expected-sha256-prefix' && exit 0 || exit 1
 ```
 
 ```sh
 # Process exit
-( cd "$WORKDIR" && bun test ) && exit 0 || exit 1
+( cd "$AGENT_CWD" && bun test ) && exit 0 || exit 1
 ```
 
 #### Writing to fd 3 from non-bash interpreters
@@ -279,7 +279,7 @@ For ad-hoc grading without an agent run:
 npx fit-benchmark invariants \
   --family=./my-coding-family \
   --task=todo-api \
-  --workdir=./runs/2026-05-11/runs/todo-api/0 \
+  --run-dir=./runs/2026-05-11/runs/todo-api/0 \
   --output=invariants.jsonl
 ```
 


### PR DESCRIPTION
## Summary

Implements spec 2090 (plan-b) and the fit-benchmark experience improvements that surfaced while testing it. Three logical commits:

1. **Work-item tracker abstraction (#2090).** Generalize the GitHub coupling in kata coordination behind a substrate-neutral work-item model and a tracker matrix (`.claude/agents/references/work-trackers.md`), with a **filesystem** tracker so the coordination half of the kata loop is benchmarkable offline. Re-points the coordination references and every in-scope `gh`/remote-git call-site across the kata-* skills at the matrix. libeval gains `--work-tracker` selection on `fit-eval`. Adds the `coordinate-finding` offline benchmark.

2. **fit-benchmark framework improvements + workdir clean break.** `--task=<id>` (run one task), `--skills-from=<dir>` (stage local unpublished skills instead of apm install), invariants now surface hook **stderr** (so a harness failure reads distinctly from a real miss), and `--work-tracker` is validated. Clean break on the workdir naming: the hook env var is **`AGENT_CWD`** and the invariants flag is **`--run-dir`** — `WORKDIR`/`--workdir` removed entirely, every task hook + fixture migrated. Adds the `product-issue-triage` primary-skill benchmark (verified end-to-end against the filesystem tracker).

3. **fit-benchmark skill docs** — authoring guide (local skills, invariants contract, fast iteration, file-grading) + flag references.

**BREAKING:** benchmark task families using `$WORKDIR` or `invariants --workdir` must switch to `$AGENT_CWD` / `--run-dir`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXMVcj3AprFVKt4zzJLAJg)_