### PR TITLE
fix(libeval): kata benchmark ran nothing — stage agent refs, fail loud on empty (#2090)

### DIFF
--- a/.github/workflows/eval-kata.yml
+++ b/.github/workflows/eval-kata.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # The kata-skills family's work-tracking tasks (coordinate-finding,
+      # product-issue-triage) coordinate through the filesystem tracker; the
+      # artifact-spine tasks ignore it. The agent SDK inherits this from the
+      # job env, and fit-benchmark resolves it (flag > env > github default).
+      LIBEVAL_WORK_TRACKER: filesystem
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: forwardimpact/fit-bootstrap@a007a6b9a1fa0db8527b7e29c158db3cf2c96c92 # v1

--- a/benchmarks/kata-skills/tasks/coordinate-finding/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/coordinate-finding/hooks/invariants.sh
@@ -2,7 +2,7 @@
 set -u
 TRACKER="$AGENT_CWD/.tracker"
 FAIL=0
-assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 
 # Resolve the single issue and change the loop should have produced. The ids are
 # caller-supplied slugs, so glob the tracker store rather than assume a name.

--- a/benchmarks/kata-skills/tasks/design-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/design-feature/hooks/invariants.sh
@@ -2,7 +2,7 @@
 set -u
 DESIGN="$AGENT_CWD/specs/042-todo-filter/design-a.md"
 FAIL=0
-assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 
 assert file-present --exists "$DESIGN"
 [ "$FAIL" = 1 ] && exit 1

--- a/benchmarks/kata-skills/tasks/plan-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/plan-feature/hooks/invariants.sh
@@ -2,7 +2,7 @@
 set -u
 PLAN="$AGENT_CWD/specs/042-todo-filter/plan-a.md"
 FAIL=0
-assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 
 assert file-present --exists "$PLAN"
 [ "$FAIL" = 1 ] && exit 1

--- a/benchmarks/kata-skills/tasks/product-issue-triage/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/product-issue-triage/hooks/invariants.sh
@@ -2,7 +2,7 @@
 set -u
 ISSUE="$AGENT_CWD/.tracker/issues/req-emoji-social.md"
 FAIL=0
-assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 
 # The issue must still exist; the triage edits it in place.
 assert issue-present --exists "$ISSUE"

--- a/benchmarks/kata-skills/tasks/spec-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/spec-feature/hooks/invariants.sh
@@ -3,7 +3,7 @@ set -u
 SPEC="$AGENT_CWD/specs/042-todo-filter/spec.md"
 JTBD="$AGENT_CWD/jtbd-excerpt.md"
 FAIL=0
-assert() { bunx fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
+assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 
 assert file-present --exists "$SPEC"
 [ "$FAIL" = 1 ] && exit 1

--- a/libraries/libeval/src/benchmark/apm-installer.js
+++ b/libraries/libeval/src/benchmark/apm-installer.js
@@ -78,6 +78,16 @@ export class ApmInstaller {
       await fs.mkdir(stagedClaude, { recursive: true });
     }
 
+    // apm's claude target deploys a pack's skills/ into .claude/skills/ but
+    // never its agents/ subtree (agent profiles + references). Stage that from
+    // the installed apm_modules into .claude/agents/ so a skill that cites an
+    // agent reference (e.g. the work-item tracker matrix) resolves in the
+    // agent CWD. No-op when --skills-from supplied a tree or no apm_modules
+    // exist.
+    if (!skillsFrom) {
+      await this.#stageApmAgents(family.rootPath, stagedClaude);
+    }
+
     // Stage the family-local judge profile outside .claude/ so it is available
     // to the judge but never copied into the agent-under-test's CWD.
     const judgeSource = join(family.rootPath, "judge.md");
@@ -100,6 +110,47 @@ export class ApmInstaller {
     }
 
     return { stagingDir, skillSetHash, judgeProfilesDir };
+  }
+
+  /**
+   * Merge each installed pack's `agents/` subtree (profiles + references) from
+   * `apm_modules/<owner>/<pack>/agents/` into the staged `.claude/agents/`.
+   * apm's claude target deploys `skills/` only, so without this an agent
+   * reference a skill cites is absent from the agent CWD.
+   * @param {string} familyRoot
+   * @param {string} stagedClaude
+   */
+  async #stageApmAgents(familyRoot, stagedClaude) {
+    const fs = this.runtime.fs;
+    const modulesRoot = join(familyRoot, "apm_modules");
+    let owners;
+    try {
+      owners = await fs.readdir(modulesRoot, { withFileTypes: true });
+    } catch {
+      return; // no apm_modules — nothing to stage
+    }
+    const stagedAgents = join(stagedClaude, "agents");
+    for (const owner of owners) {
+      if (!owner.isDirectory()) continue;
+      const ownerDir = join(modulesRoot, owner.name);
+      let packs;
+      try {
+        packs = await fs.readdir(ownerDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const pack of packs) {
+        if (!pack.isDirectory()) continue;
+        const agentsDir = join(ownerDir, pack.name, "agents");
+        const hasAgents = await fs
+          .access(agentsDir)
+          .then(() => true)
+          .catch(() => false);
+        if (hasAgents) {
+          await fs.cp(agentsDir, stagedAgents, { recursive: true });
+        }
+      }
+    }
   }
 
   async #runApmInstall(cwd) {

--- a/libraries/libeval/src/benchmark/runner.js
+++ b/libraries/libeval/src/benchmark/runner.js
@@ -39,6 +39,11 @@ const BASE_TOOLS = [
   "TodoWrite",
 ];
 
+// Upper bound on a single supervised agent run. A run that produces no terminal
+// message within this window is treated as a stall and recorded as an
+// agentError, so the benchmark never hangs the event loop into a silent exit.
+const AGENT_WATCHDOG_MS = 20 * 60 * 1000;
+
 /** Sole orchestrator for a task-family benchmark run. */
 export class BenchmarkRunner {
   /**
@@ -350,14 +355,34 @@ export class BenchmarkRunner {
     });
     const instructions = await fs.readFile(task.paths.instructions, "utf8");
     let agentError = null;
+    // Watchdog: a supervised session can hang without settling (e.g. the agent
+    // SDK subprocess exits without a terminal message), which would empty the
+    // event loop and exit the process mid-run with zero records. Race the run
+    // against a bounded timer so a stall becomes an `agentError` record instead
+    // of a silent exit; the timer also keeps the loop alive until it fires.
+    let watchdog;
     try {
-      const result = await supervisor.run(instructions);
+      const result = await Promise.race([
+        supervisor.run(instructions),
+        new Promise((_, reject) => {
+          watchdog = this.runtime.clock.setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `agent run produced no result within ${AGENT_WATCHDOG_MS}ms (possible stall)`,
+                ),
+              ),
+            AGENT_WATCHDOG_MS,
+          );
+        }),
+      ]);
       if (!result.success && !result.concluded) {
         agentError = { message: "supervisor did not succeed", aborted: false };
       }
     } catch (e) {
       agentError = { message: e.message ?? String(e), aborted: false };
     } finally {
+      this.runtime.clock.clearTimeout(watchdog);
       await new Promise((r) => combinedStream.end(r));
     }
     const summary = await splitAndSummarize(

--- a/libraries/libeval/src/commands/benchmark-run.js
+++ b/libraries/libeval/src/commands/benchmark-run.js
@@ -45,9 +45,22 @@ export async function runBenchmarkRunCommand(ctx) {
   const runner = createBenchmarkRunner({ ...opts, query, runtime });
 
   let anyFail = false;
+  let count = 0;
   for await (const record of runner.run()) {
+    count++;
     runtime.proc.stdout.write(JSON.stringify(record) + "\n");
     if (record.verdict !== "pass") anyFail = true;
+  }
+  // A run that emits zero records did nothing (no tasks discovered, or the
+  // agent never produced output). That is a failure, not a silent success —
+  // surface it loudly so CI does not go green on an empty benchmark.
+  if (count === 0) {
+    return {
+      ok: false,
+      code: 1,
+      error:
+        "benchmark produced no result records — no task ran to completion; check the family's tasks/, apm install, and agent availability (ANTHROPIC_API_KEY / claude CLI / IS_SANDBOX)",
+    };
   }
   return anyFail ? { ok: false, code: 1, error: "" } : { ok: true };
 }

--- a/libraries/libeval/src/commands/benchmark-run.js
+++ b/libraries/libeval/src/commands/benchmark-run.js
@@ -23,7 +23,7 @@ export async function runBenchmarkRunCommand(ctx) {
   const runtime = ctx.deps.runtime;
   let opts;
   try {
-    opts = parseRunOptions(values);
+    opts = parseRunOptions(values, runtime.proc.env);
   } catch (err) {
     return { ok: false, code: 1, error: err.message };
   }
@@ -69,9 +69,11 @@ export async function runBenchmarkRunCommand(ctx) {
  * Parse and validate benchmark run options. Exported so tests can verify
  * defaults, including the resolved work tracker.
  * @param {Record<string, string|undefined>} values - Parsed option values
+ * @param {Record<string, string|undefined>} [env] - Process environment, read
+ *   for the `LIBEVAL_WORK_TRACKER` fallback when `--work-tracker` is absent.
  * @returns {object}
  */
-export function parseRunOptions(values) {
+export function parseRunOptions(values, env = {}) {
   const family = values.family;
   if (!family) throw new Error("--family is required");
   const output = values.output ?? "benchmark-runs";
@@ -87,7 +89,7 @@ export function parseRunOptions(values) {
     agentModel: values["agent-model"] || BENCHMARK_AGENT_MODEL,
     supervisorModel: values["lead-model"] || LEAD_MODEL,
     judgeModel: values["judge-model"] || LEAD_MODEL,
-    workTracker: resolveWorkTracker(values),
+    workTracker: resolveWorkTracker(values, env),
     profiles: {
       agent: values["agent-profile"] ?? null,
       judge: values["judge-profile"] ?? null,

--- a/libraries/libeval/src/commands/discuss.js
+++ b/libraries/libeval/src/commands/discuss.js
@@ -59,7 +59,7 @@ export function parseDiscussOptions(values, runtime) {
     maxTurns,
     maxLeadTurns,
     outputPath: values.output,
-    workTracker: resolveWorkTracker(values),
+    workTracker: resolveWorkTracker(values, runtime?.proc?.env),
     discussionId: values["discussion-id"] ?? null,
     resumeContext,
     callbackUrl: runtime.proc.env.CALLBACK_URL ?? null,

--- a/libraries/libeval/src/commands/facilitate.js
+++ b/libraries/libeval/src/commands/facilitate.js
@@ -57,7 +57,7 @@ export function parseFacilitateOptions(values, runtime) {
     maxTurns,
     outputPath: values.output,
     facilitatorProfile: values["lead-profile"] ?? undefined,
-    workTracker: resolveWorkTracker(values),
+    workTracker: resolveWorkTracker(values, runtime?.proc?.env),
   };
 }
 

--- a/libraries/libeval/src/commands/run.js
+++ b/libraries/libeval/src/commands/run.js
@@ -32,7 +32,7 @@ export function parseRunOptions(values, runtime) {
     maxTurns: maxTurnsRaw === "0" ? 0 : parseInt(maxTurnsRaw, 10),
     outputPath: values.output,
     agentProfile: values["agent-profile"] ?? undefined,
-    workTracker: resolveWorkTracker(values),
+    workTracker: resolveWorkTracker(values, runtime?.proc?.env),
     allowedTools: (
       values["allowed-tools"] ??
       "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"

--- a/libraries/libeval/src/commands/supervise.js
+++ b/libraries/libeval/src/commands/supervise.js
@@ -41,7 +41,7 @@ export async function parseSuperviseOptions(values, runtime) {
     outputPath: values.output,
     supervisorProfile: values["lead-profile"] ?? undefined,
     agentProfile: values["agent-profile"] ?? undefined,
-    workTracker: resolveWorkTracker(values),
+    workTracker: resolveWorkTracker(values, runtime?.proc?.env),
     allowedTools: (
       values["allowed-tools"] ??
       "Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"

--- a/libraries/libeval/src/commands/work-tracker.js
+++ b/libraries/libeval/src/commands/work-tracker.js
@@ -10,16 +10,20 @@ export const DEFAULT_WORK_TRACKER = "github";
 export const KNOWN_WORK_TRACKERS = ["github", "filesystem"];
 
 /**
- * Resolve the active work tracker from parsed CLI option values, falling back
- * to the default when `--work-tracker` is absent or blank. The harness writes
- * the result to `LIBEVAL_WORK_TRACKER` on the agent environment, mirroring
- * `--agent-profile` → `LIBEVAL_AGENT_PROFILE`.
+ * Resolve the active work tracker. Precedence: the explicit `--work-tracker`
+ * flag, then an inherited `LIBEVAL_WORK_TRACKER` on the environment (so a CI
+ * job or harness can select it without the flag), then the `github` default.
+ * The harness writes the result to `LIBEVAL_WORK_TRACKER` on the agent
+ * environment, mirroring `--agent-profile` → `LIBEVAL_AGENT_PROFILE`.
  * @param {Record<string, string|undefined>} values - Parsed option values
+ * @param {Record<string, string|undefined>} [env] - Process environment
+ *   (e.g. `runtime.proc.env`); read for the `LIBEVAL_WORK_TRACKER` fallback.
  * @returns {string}
- * @throws {Error} if `--work-tracker` is set to an unknown tracker
+ * @throws {Error} if the resolved tracker is unknown
  */
-export function resolveWorkTracker(values) {
-  const tracker = values["work-tracker"] || DEFAULT_WORK_TRACKER;
+export function resolveWorkTracker(values, env = {}) {
+  const tracker =
+    values["work-tracker"] || env.LIBEVAL_WORK_TRACKER || DEFAULT_WORK_TRACKER;
   if (!KNOWN_WORK_TRACKERS.includes(tracker)) {
     throw new Error(
       `unknown work tracker '${tracker}'; expected one of: ${KNOWN_WORK_TRACKERS.join(", ")}`,

--- a/libraries/libeval/test/benchmark-apm-installer.integration.test.js
+++ b/libraries/libeval/test/benchmark-apm-installer.integration.test.js
@@ -1,6 +1,6 @@
 import { describe, test } from "node:test";
 import assert from "node:assert";
-import { access, cp, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -61,6 +61,34 @@ describe("ApmInstaller.install", () => {
     const apmCalls = runtime.subprocess.calls.filter((c) => c.cmd === "apm");
     assert.strictEqual(apmCalls.length, 0, "apm install must be skipped");
     await rm(skillsRoot, { recursive: true, force: true });
+  });
+
+  test("stages a pack's agents/ subtree from apm_modules into .claude/agents/", async () => {
+    // apm's claude target deploys skills/ only; the installer must still carry
+    // a pack's agents/ (profiles + references) so a skill that cites an agent
+    // reference (e.g. the work-tracker matrix) resolves in the agent CWD.
+    const runtime = rt();
+    const root = await mkdtemp(join(tmpdir(), "benchmark-agents-"));
+    const refDir = join(
+      root,
+      "apm_modules",
+      "acme",
+      "pack",
+      "agents",
+      "references",
+    );
+    await mkdir(refDir, { recursive: true });
+    await writeFile(join(refDir, "work-trackers.md"), "# matrix\n");
+    const out = await mkdtemp(join(tmpdir(), "benchmark-agents-out-"));
+    // No apm.yml at root → apm install is skipped; staging still pulls agents.
+    const { stagingDir } = await createApmInstaller({ runtime }).install(
+      { rootPath: root },
+      out,
+    );
+    await access(
+      join(stagingDir, ".claude", "agents", "references", "work-trackers.md"),
+    );
+    await rm(root, { recursive: true, force: true });
   });
 
   test("--skills-from with no .claude/ tree throws", async () => {

--- a/libraries/libeval/test/golden/fit-benchmark/help.stdout.txt
+++ b/libraries/libeval/test/golden/fit-benchmark/help.stdout.txt
@@ -1,4 +1,4 @@
-fit-benchmark 0.1.64 — Run coding-agent task families, grade hidden tests, and aggregate pass@k across runs.
+fit-benchmark 0.1.65 — Run coding-agent task families, grade hidden tests, and aggregate pass@k across runs.
 
 Usage: fit-benchmark <command> [options]
 

--- a/libraries/libeval/test/work-tracker.test.js
+++ b/libraries/libeval/test/work-tracker.test.js
@@ -54,6 +54,22 @@ describe("--work-tracker resolution across fit-eval agent commands", () => {
     );
   });
 
+  test("falls back to LIBEVAL_WORK_TRACKER env when the flag is absent", () => {
+    const opts = parseRunOptionsEval(
+      { "task-text": "do a thing" },
+      makeRuntime({ LIBEVAL_WORK_TRACKER: "filesystem" }),
+    );
+    assert.strictEqual(opts.workTracker, "filesystem");
+  });
+
+  test("the --work-tracker flag overrides the env fallback", () => {
+    const opts = parseRunOptionsEval(
+      { "task-text": "do a thing", "work-tracker": "github" },
+      makeRuntime({ LIBEVAL_WORK_TRACKER: "filesystem" }),
+    );
+    assert.strictEqual(opts.workTracker, "github");
+  });
+
   test("supervise resolves --work-tracker filesystem", async () => {
     const opts = await parseSuperviseOptions(
       {
@@ -150,6 +166,14 @@ describe("fit-benchmark run resolves --work-tracker", () => {
   test("defaults to github when --work-tracker is absent", () => {
     const opts = parseBenchmarkRunOptions({ family: "./families/coding" });
     assert.strictEqual(opts.workTracker, "github");
+  });
+
+  test("falls back to LIBEVAL_WORK_TRACKER env (CI selects without a flag)", () => {
+    const opts = parseBenchmarkRunOptions(
+      { family: "./families/coding" },
+      { LIBEVAL_WORK_TRACKER: "filesystem" },
+    );
+    assert.strictEqual(opts.workTracker, "filesystem");
   });
 
   test("the env var is set from opts.workTracker before the runner starts", () => {


### PR DESCRIPTION
## Summary

The `Eval: Kata` benchmark (run #25) finished in **28s, green, with an empty `results.jsonl`** — "nothing happened," yet CI passed. Root-caused and fixed:

- **Agent env lacked `work-trackers.md`.** `apm install --target claude` deploys a pack's `skills/` into `.claude/skills/` but **never its `agents/` subtree**, so the work-item tracker matrix that the re-pointed kata skills and the new work-tracking tasks cite was absent from the agent CWD (the agent's trace shows it failing to read it, then `find /`-ing). The benchmark apm-installer now stages each installed pack's `agents/` (profiles + references) from `apm_modules/` into `.claude/agents/`. (The publish workflow already ships the references to the pack — confirmed.)
- **Silent zero-record exit.** A supervised agent that never settles empties the event loop and the process exits mid-run with zero records and exit 0. Added a watchdog (via `runtime.clock`) so a stalled agent becomes an `agentError` record, and **`fit-benchmark run` now exits non-zero when it produces zero records** — CI can no longer go green on an empty benchmark.
- **Work tracker selectable from the environment.** The two work-tracking tasks (`coordinate-finding`, `product-issue-triage`) coordinate through the filesystem tracker, but the pinned `fit-benchmark@v1` action exposes no `--work-tracker` flag. `resolveWorkTracker` now reads `LIBEVAL_WORK_TRACKER` from the environment (precedence: `--work-tracker` flag > `LIBEVAL_WORK_TRACKER` env > `github` default), and `eval-kata.yml` sets `LIBEVAL_WORK_TRACKER: filesystem` at the job level so the agent SDK and `fit-benchmark` both inherit it — no sibling-edit required.
- **Hook consistency.** Reverted all kata-skills task hooks to bare `fit-trace` (`bunx fit-trace` can't resolve in the isolated agent workdir; bare is the family convention).
- Refreshed the `fit-benchmark` help golden to the current version (also fixes a pre-existing staleness on main).

Verified locally: `work-trackers.md` now stages into the agent CWD; new apm-installer test covers it; 803 libeval tests pass; `bun run check` green.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXMVcj3AprFVKt4zzJLAJg)_