### PR TITLE
fix(outpost): unfreeze macOS quit/stop, quit on first click, launch on macOS 26

### DIFF
--- a/products/outpost/macos/Outpost/Sources/AppDelegate.swift
+++ b/products/outpost/macos/Outpost/Sources/AppDelegate.swift
@@ -21,7 +21,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         statusMenu = StatusMenu(processManager: processManager)
     }
 
-    func applicationWillTerminate(_: Notification) {
-        processManager.stopScheduler()
+    func applicationShouldTerminate(
+        _: NSApplication
+    ) -> NSApplication.TerminateReply {
+        // Reap the scheduler off the main thread, then let the app exit.
+        // Returning .terminateLater keeps the run loop spinning so the UI
+        // stays responsive (no beachball) while the daemon shuts down.
+        processManager.stopScheduler {
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
     }
 }

--- a/products/outpost/macos/Outpost/Sources/ProcessManager.swift
+++ b/products/outpost/macos/Outpost/Sources/ProcessManager.swift
@@ -114,17 +114,14 @@ class ProcessManager {
     }
 
     /// Send SIGTERM to the scheduler and wait for it to exit.
-    /// Called on app quit — stops everything.
-    func stopScheduler() {
+    /// Called on app quit — stops everything. `completion` runs on the
+    /// main queue once the scheduler is reaped.
+    func stopScheduler(completion: @escaping () -> Void = {}) {
         isRunning = false
-        monitorTimer?.invalidate()
-        monitorTimer = nil
-        guard schedulerPID > 0 else { return }
-        kill(schedulerPID, SIGTERM)
-        var status: Int32 = 0
-        waitpid(schedulerPID, &status, 0)
-        schedulerPID = 0
-        NSLog("Scheduler stopped")
+        terminateScheduler(gracePeriod: 5) {
+            NSLog("Scheduler stopped")
+            completion()
+        }
     }
 
     /// Pause the scheduler without quitting the app.
@@ -132,14 +129,91 @@ class ProcessManager {
     /// prevents auto-restart until `resumeScheduler()` is called.
     func pauseScheduler() {
         isRunning = false
+        terminateScheduler(gracePeriod: 5) {
+            NSLog("Scheduler paused")
+        }
+    }
+
+    /// Terminate the scheduler without blocking the main thread.
+    ///
+    /// SIGTERM lets the daemon shut its children down gracefully. The
+    /// reap is a blocking `waitpid`, so it runs on a background queue —
+    /// doing it on the main thread is what froze the UI (the beachball)
+    /// while the daemon tore down its `claude` children. If the daemon
+    /// has not exited within `gracePeriod`, escalate to SIGKILL so the
+    /// wait is always bounded. `completion` is delivered on the main
+    /// queue after the process is reaped.
+    private func terminateScheduler(
+        gracePeriod: TimeInterval, completion: @escaping () -> Void
+    ) {
         monitorTimer?.invalidate()
         monitorTimer = nil
-        guard schedulerPID > 0 else { return }
-        kill(schedulerPID, SIGTERM)
-        var status: Int32 = 0
-        waitpid(schedulerPID, &status, 0)
+
+        // Capture and clear the PID on the main thread so the monitor
+        // timer can never race the background reap for the same child.
+        let pid = schedulerPID
         schedulerPID = 0
-        NSLog("Scheduler paused")
+        guard pid > 0 else {
+            completion()
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            kill(pid, SIGTERM)
+
+            let deadline = Date().addingTimeInterval(gracePeriod)
+            var reaped = false
+            while Date() < deadline {
+                var status: Int32 = 0
+                let result = waitpid(pid, &status, WNOHANG)
+                if result == pid || (result == -1 && errno == ECHILD) {
+                    reaped = true
+                    break
+                }
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+
+            if !reaped {
+                // Graceful shutdown timed out; force-kill and reap.
+                NSLog("Scheduler did not exit in %.0fs, sending SIGKILL", gracePeriod)
+                kill(pid, SIGKILL)
+                var status: Int32 = 0
+                waitpid(pid, &status, 0)
+            }
+
+            Self.deliverOnMain(completion)
+        }
+    }
+
+    /// Run `block` on the main thread, even while the main run loop is
+    /// parked in a non-default mode.
+    ///
+    /// On app quit `applicationShouldTerminate` returns `.terminateLater`,
+    /// which parks the main run loop in `NSModalPanelRunLoopMode` until the
+    /// termination reply arrives. The libdispatch main queue is only drained
+    /// in the common modes, so `DispatchQueue.main.async` would stall there —
+    /// the reply never fired and "Quit Outpost" took two clicks. Scheduling
+    /// the block in every termination-relevant mode (and waking the loop)
+    /// delivers it on the first pass instead. A latch keeps it to one run no
+    /// matter which mode fires first; all calls run serially on the main
+    /// thread, so the latch needs no locking.
+    private static func deliverOnMain(_ block: @escaping () -> Void) {
+        var fired = false
+        let once = {
+            if fired { return }
+            fired = true
+            block()
+        }
+        let mainLoop = CFRunLoopGetMain()
+        let modes: [CFString] = [
+            CFRunLoopMode.commonModes.rawValue,
+            "NSModalPanelRunLoopMode" as CFString,
+            "NSEventTrackingRunLoopMode" as CFString,
+        ]
+        for mode in modes {
+            CFRunLoopPerformBlock(mainLoop, mode, once)
+        }
+        CFRunLoopWakeUp(mainLoop)
     }
 
     /// Resume a paused scheduler by spawning it again.

--- a/products/outpost/pkg/build.js
+++ b/products/outpost/pkg/build.js
@@ -58,15 +58,19 @@ function compileLauncher() {
   //     -gnone — last-resort drop of DWARF debug info entirely;
   //     without it, timestamp-shaped 4-byte writes leak into
   //     Contents/MacOS/Outpost.
-  // (c) -Xlinker -no_uuid — suppress LC_UUID which ld64 derives from
-  //     content + build-time entropy; pairs with (a)/(b) to leave
-  //     the Mach-O byte-identical across rebuilds.
+  //
+  // LC_UUID is intentionally left in place. dyld on macOS 26+ aborts a
+  // main executable that has no LC_UUID ("missing LC_UUID load command"),
+  // so stripping it with `-Xlinker -no_uuid` makes the app fail to launch.
+  // ld-prime derives LC_UUID from a content hash, so with (a)/(b) holding
+  // the linked content byte-stable the UUID is already deterministic — two
+  // builds of the same tree yield a byte-identical Mach-O (verified). The
+  // cdhash-determinism gate (spec 1170) stays green without the flag.
   const swiftCmd = [
     "swift build -c release",
     "-Xswiftc -no-clang-module-breadcrumbs",
     `-Xswiftc -file-prefix-map -Xswiftc "${LAUNCHER_DIR}=."`,
     "-Xswiftc -gnone",
-    "-Xlinker -no_uuid",
   ].join(" ");
   run(swiftCmd, {
     cwd: LAUNCHER_DIR,


### PR DESCRIPTION
## Summary

Three independent bugs in the Outpost macOS menu-bar launcher (`products/outpost/macos`):

- **Beachball on quit / stop.** "Quit Outpost" and "Stop Agent Team" called a blocking `waitpid(pid, &status, 0)` on the main thread while the daemon tore down its `claude` children, hanging the UI. The scheduler is now reaped off the main thread with a bounded `SIGTERM`→`SIGKILL` escalation.
- **Quit needed two clicks.** `applicationShouldTerminate` returns `.terminateLater`, which parks the main run loop in `NSModalPanelRunLoopMode`; the `DispatchQueue.main.async` reply was never serviced there, so the first click did nothing. The termination reply is now delivered via `CFRunLoopPerformBlock` across the termination-relevant modes (with a one-shot latch), so quit lands on the first click.
- **Release build wouldn't launch on macOS 26.** The launcher was linked with `-Xlinker -no_uuid`, stripping `LC_UUID`; recent dyld aborts a main executable with no `LC_UUID` ("missing LC_UUID load command"). Dropped the flag — `ld-prime` derives `LC_UUID` from a content hash, so two builds of the same tree remain byte-identical (verified) and the cdhash-determinism gate (spec 1170) stays green.

## Test plan

- [x] `swift build` (debug) and `just build-app-product outpost` (release) both succeed
- [x] Built bundle carries `LC_UUID`, passes `codesign --verify --deep --strict`, and launches (spawns the scheduler)
- [x] Verified determinism: two `-no_uuid`-free release builds produce an identical SHA-256
- [ ] `bun run check`
- [ ] `bun run test`