### PR TITLE
feat(coaligned-skills): pack for maintaining co-alignment in a repo

### DIFF
--- a/.claude/skills/coaligned-audit/SKILL.md
+++ b/.claude/skills/coaligned-audit/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: coaligned-audit
+description: >
+  Run the full Co-Aligned check suite and act on what it finds. Use for a
+  periodic co-alignment health check, when CI reports a `coaligned` failure, or
+  before a release — to triage every finding and route it to the fix that owns
+  it.
+---
+
+# coaligned-audit
+
+The maintenance loop for the Co-Aligned architecture. `npx coaligned` runs three
+checks; this skill turns their findings into fixes by routing each to the skill
+that owns the layer.
+
+```sh
+npx coaligned                # instructions + jtbd (and invariants if present)
+npx coaligned --json         # machine-readable findings
+```
+
+Run the bare command first. It reports across subcommands at once, so a single
+run shows the whole picture.
+
+## Procedure
+
+### Step 1 — Run the suite and read the findings
+
+Run `npx coaligned`. Each finding names a subcommand, a location, and a
+one-line reason. Group findings by subcommand before fixing anything — the fix
+path differs by kind, and a length breach is a different problem from a stale
+job block.
+
+### Step 2 — Route each finding
+
+| Finding from | What it means | Route to |
+| --- | --- | --- |
+| `instructions` | A layer exceeds its line or word cap | [coaligned-layer](../coaligned-layer/SKILL.md) |
+| `jtbd` (schema) | An entry violates the JTBD structure | [coaligned-jtbd](../coaligned-jtbd/SKILL.md) |
+| `jtbd` (stale block) | A generated block is out of date | `npx coaligned jtbd --fix` |
+| `invariants` | A repo rule module flagged code | the module's hint |
+
+Fix the cause, not the symptom:
+
+- **Length breach** — do not just cut words. Move content to the layer that owns
+  it (templates and tables to an L6 reference, procedure out of an L3 profile).
+- **Stale job block** — never hand-edit a generated block. Edit the owning
+  `package.json` and run `npx coaligned jtbd --fix`.
+- **Invariant violation** — fix the code the rule objects to. Grandfather only
+  during a real migration, and only by the module's documented `--seed` path —
+  never widen an allow-list to silence a finding.
+
+### Step 3 — Re-run until clean
+
+Run `npx coaligned` again after each fix. Any finding fails the run; a clean
+run is the bar. Re-running also catches the case where one fix exposed another —
+trimming a layer can reveal a checklist that now needs its own block.
+
+### Step 4 — Record what recurred
+
+If the same class of finding keeps returning, the layer that owns it is
+incomplete, not the contributor. Note the recurring class so the procedure,
+reference, or invariant that should prevent it can be strengthened — a check
+that fires every week is training people to ignore it.
+
+## Done When
+
+<do_confirm_checklist goal="Verify co-alignment holds before signing off">
+
+- [ ] Every finding was routed to its owning fix, not silenced in place.
+- [ ] Stale job blocks were regenerated, not hand-edited.
+- [ ] Any grandfathering went through a module's `--seed` path during a real
+      migration.
+- [ ] `npx coaligned` passes with no findings.
+
+</do_confirm_checklist>
+
+## Documentation
+
+- [Co-Aligned Instruction Architecture Standard](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md) —
+  the layered model the checks enforce.
+- [libcoaligned README](https://github.com/forwardimpact/monorepo/blob/main/libraries/libcoaligned/README.md) —
+  what each subcommand checks and how findings render.

--- a/.claude/skills/coaligned-invariant/SKILL.md
+++ b/.claude/skills/coaligned-invariant/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: coaligned-invariant
+description: >
+  Author a declarative invariant rule module for `npx coaligned invariants`.
+  Use when a repository needs to enforce its own architectural rule — a
+  forbidden import, a value that must agree across files, a directory shape —
+  as a `.coaligned/invariants/*.rules.mjs` module the CLI discovers and runs.
+---
+
+# coaligned-invariant
+
+`npx coaligned invariants` is a generic host. It finds every `*.rules.mjs`
+under `.coaligned/invariants/`, runs each module's declarative rules through a
+shared engine, and reports findings. The policy lives in the repository; the
+CLI ships only the engine.
+
+Write one module per invariant. A module never imports the engine — it loads
+into the consuming repo via npx, where the package is not resolvable. It
+declares only policy; the injected kits own all mechanism.
+
+## Procedure
+
+### Step 1 — State the invariant in one sentence
+
+Write the rule as a single claim the code must satisfy ("src files must not
+import `node:child_process`", "the version literal must agree across the
+manifest and the docs page"). If you cannot state it in one sentence, it is two
+invariants — write two modules. Capture the sentence as the module's top
+comment.
+
+### Step 2 — Choose the subjects
+
+Subjects are the things the rule judges, grouped by **scope** (a label you
+pick). Decide what one subject is — a file, a manifest, a matched line, a
+cross-file agreement — and which scope name holds it. A module may declare
+several scopes.
+
+### Step 3 — Write `build(kit)`
+
+`build` receives the build kit and returns `{ subjects, ctx? }`. Use the kit to
+collect subjects; never reach for `fs` or a subprocess directly. Return one
+array per scope, plus optional `ctx` the rules read.
+
+See [references/build-kit.md](references/build-kit.md) for the full kit, and
+[references/example.md](references/example.md) for a `build` worked end to end.
+
+### Step 4 — Declare the rules
+
+`rules` is a static array, or a `(ruleKit) => array` factory. Each rule names a
+`scope`, a `severity`, an optional `when` guard, a `check` that returns a truthy
+report on violation (else `null`), and a `message`/`hint`. The build step finds
+candidates; the rules decide pass or fail.
+
+See [references/rule-kit.md](references/rule-kit.md) for the rule shape and the
+`parseError`/`failAll` helpers. A worked module is in
+[references/example.md](references/example.md).
+
+### Step 5 — Add a `seed` only for migrations
+
+When an invariant lands on a codebase with existing violations, grandfather
+them: add an optional `seed(kit)` that prints a deny-list, store it as
+co-located YAML, and have `build` read it via `kit.config`. Each migration PR
+removes entries; the list is monotone, never added to. Refresh with
+`npx coaligned invariants --seed <module-name>`.
+
+### Step 6 — Run it
+
+Drop the module in `.coaligned/invariants/` and run:
+
+```sh
+npx coaligned invariants            # run every module
+npx coaligned invariants --json     # machine output
+npx coaligned invariants --seed <name>   # print a module's seed text
+```
+
+Any finding fails the run. Confirm the rule fires on a known violation and
+passes on clean code before committing.
+
+## Done When
+
+<do_confirm_checklist goal="Verify the rule module is sound before committing">
+
+- [ ] The module's top comment states the invariant in one sentence.
+- [ ] `build` collects subjects through the kit only — no direct `fs` or
+      subprocess access.
+- [ ] Each rule reports on violation and returns `null` when clean.
+- [ ] A grandfather `seed` exists only if the invariant landed on existing
+      violations, and its deny-list is monotone.
+- [ ] `npx coaligned invariants` fails on a planted violation and passes on
+      clean code.
+
+</do_confirm_checklist>
+
+## Documentation
+
+- [Co-Aligned Instruction Architecture Standard](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md) —
+  where invariants sit in the layered architecture.
+- [libcoaligned README](https://github.com/forwardimpact/monorepo/blob/main/libraries/libcoaligned/README.md) —
+  the build kit, the rule kit, and the module contract in full.

--- a/.claude/skills/coaligned-invariant/references/build-kit.md
+++ b/.claude/skills/coaligned-invariant/references/build-kit.md
@@ -1,0 +1,50 @@
+# The build kit
+
+The engine binds a kit per run to the repo `root`, the module's own `dir` (for
+co-located config), and the `runtime` bag. The module declares policy; the kit
+owns the mechanism. Destructure what you need:
+
+```js
+build({ scan, scanAst, grep, config, root }) { … }
+```
+
+## File collection
+
+- `scan({ dirs, match, skip?, under?, read? })` — collect files as
+  `{ path, rel, text? }`. `match(name)` selects by filename; `skip` prunes
+  directories; `under: "src"` restricts to the per-package `src`/`test` shape;
+  `read: false` skips reading file text when you only need paths.
+- `scanAst({ dirs, match, extract, locations?, … })` — read and parse each
+  file, merging `extract(ast)` into the subject. A parse failure yields
+  `{ path, rel, parseError }` — pair with the `parseError` rule helper.
+- `parse(src, path, opts?)`, `walk(ast, visit)` — the lower-level AST seam when
+  you need to traverse yourself.
+
+## Search and agreement
+
+- `grep({ pattern | patterns, paths?, globs?, caseSensitive?, onlyMatching?,
+  dedupe? })` — ripgrep matches as `{ path, lineNo, text, reason? }`, with
+  per-entry `exclude` and built-in de-duplication.
+- `restatementDrift({ entries, equal })` — the shared "single source restated
+  across consumers" scan and compare (a URL, a version, any scalar that must
+  agree in many places).
+
+## Reading and listing
+
+- `readText(path)`, `readJson(path)` — read a file; `readJson` returns the
+  parsed object or a falsy value on failure.
+- `config(name, fallback?)` — read co-located JSON or YAML next to the module
+  (deny-lists, allow-lists). Returns `fallback` when absent.
+- `listDir(path, { dirsOnly? })` — list a directory's entries.
+- `lineAt(text, offset)` — line number for a character offset.
+- `glob(pattern)` — compile a glob to a `RegExp` for matching `rel` paths.
+
+## Rules
+
+- Never import `fs`, `node:child_process`, or any ambient runtime dependency.
+  Everything routes through the kit so the module stays portable across repos.
+- Return plain data from `build`. Decisions belong in the rules, not here —
+  except where the build step is the natural place to compute a violation set
+  (then pair with `failAll`).
+- Keep co-located config (`*.yml`, `*.json`) beside the module so the rule and
+  its data version together.

--- a/.claude/skills/coaligned-invariant/references/example.md
+++ b/.claude/skills/coaligned-invariant/references/example.md
@@ -1,0 +1,96 @@
+# Worked example
+
+A complete module enforcing one invariant: source files must not import a
+forbidden package. It shows the three required parts (top comment, `build`,
+`rules`) and the optional `seed` for grandfathering.
+
+`.coaligned/invariants/no-legacy-client.rules.mjs`:
+
+```js
+// Invariant: src files must not import the legacy "old-client" package.
+// New code uses "new-client". A monotone deny-list grandfathers files that
+// still import the old one during migration; each PR removes its entries.
+// Refresh the deny-list: npx coaligned invariants --seed no-legacy-client
+
+import { stringify as stringifyYaml } from "yaml";
+
+const DIRS = ["src", "packages"];
+const SKIP = ["node_modules", "dist", "generated", "tmp", "test"];
+
+function importsLegacy(ast, walk) {
+  let found = false;
+  walk(ast, (node) => {
+    if (
+      node.type === "ImportDeclaration" &&
+      node.source?.value === "old-client"
+    ) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+function subjects({ scan, parse, walk }) {
+  const out = [];
+  for (const { path, rel, text } of scan({
+    dirs: DIRS,
+    skip: SKIP,
+    match: (name) => name.endsWith(".js"),
+  })) {
+    const s = { path, rel };
+    try {
+      s.legacy = importsLegacy(parse(text, rel), walk);
+    } catch (err) {
+      s.parseError = err.message;
+    }
+    out.push(s);
+  }
+  return out;
+}
+
+export default {
+  name: "no-legacy-client",
+
+  build(kit) {
+    return {
+      subjects: { "src-file": subjects(kit) },
+      ctx: { deny: kit.config("no-legacy-client.deny.yml", { files: [] }) },
+    };
+  },
+
+  // Print the current violators as a deny-list to seed the YAML.
+  seed(kit) {
+    const files = subjects(kit)
+      .filter((s) => s.legacy)
+      .map((s) => s.rel);
+    return stringifyYaml({ files });
+  },
+
+  rules: ({ parseError }) => [
+    parseError("src-file", {
+      id: "no-legacy-client.parse-error",
+      hint: "fix the syntax error so the import scan can parse the file",
+    }),
+    {
+      id: "no-legacy-client.import",
+      scope: "src-file",
+      severity: "fail",
+      when: (s) => !s.parseError,
+      check: (s, ctx) =>
+        s.legacy && !ctx.deny.files.includes(s.rel) ? {} : null,
+      message: () => 'imports "old-client"',
+      hint: 'import "new-client", or grandfather the file in no-legacy-client.deny.yml during migration',
+    },
+  ],
+};
+```
+
+## What to copy
+
+- The **top comment** states the invariant and documents the `--seed` refresh.
+- `subjects` collects through the kit and records `parseError` instead of
+  throwing — the `parseError` rule turns that into a finding.
+- The `check` returns `{}` (truthy) on violation and `null` when clean, and
+  consults `ctx.deny` so grandfathered files pass until migrated.
+- `seed` reuses the same `subjects` function so the deny-list and the live
+  check can never diverge.

--- a/.claude/skills/coaligned-invariant/references/rule-kit.md
+++ b/.claude/skills/coaligned-invariant/references/rule-kit.md
@@ -1,0 +1,48 @@
+# The rule kit
+
+`rules` is either a static array of rule objects, or a `(ruleKit) => array`
+factory that builds them from the helpers below.
+
+## Rule object
+
+```js
+{
+  id: "my-rule.no-foo",          // stable identifier, shows in findings
+  scope: "src-file",             // which subject group this rule judges
+  severity: "fail",              // any finding fails the run
+  when: (s) => !s.parseError,    // optional guard; skip subjects that fail it
+  check: (s, ctx) =>             // return a truthy report on violation, else null
+    s.usesFoo ? { detail: s.foo } : null,
+  message: (s, report) =>        // one-line finding text
+    `imports foo [${report.detail}]`,
+  hint: "import bar instead",    // optional remediation line
+}
+```
+
+- `check` receives the subject and the shared `ctx` returned from `build`. A
+  non-null return is a violation; the returned value is passed to `message` as
+  the report.
+- `message` and `hint` may be strings or `(subject, report) => string`.
+- Keep one concern per rule. Two failure modes on one scope are two rules with
+  two ids — that is what makes a finding attributable.
+
+## Helpers (when `rules` is a factory)
+
+```js
+rules: ({ parseError, failAll }) => [ … ]
+```
+
+- `parseError(scope, { id?, hint? })` — fails any subject carrying a
+  `parseError`. Pair with `scanAst`, which sets `parseError` on unparseable
+  files. Always include this when a scope is AST-derived, so a syntax error
+  surfaces as a finding instead of silently dropping the file.
+- `failAll(scope, { id, message, hint?, when? })` — fails every subject in the
+  scope. Use when the build step already decided each subject is a violation
+  (for example, every `grep` match is a finding).
+
+## Output
+
+Findings render in the same ESLint-style format as the other subcommands; pass
+`--json` for machine output. Severity `fail` is the norm — any finding fails
+the run. There is no "warn that passes"; if it should not block, it is not an
+invariant.

--- a/.claude/skills/coaligned-jtbd/SKILL.md
+++ b/.claude/skills/coaligned-jtbd/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: coaligned-jtbd
+description: >
+  Author and maintain Jobs To Be Done entries for the Co-Aligned standard.
+  Use when writing a Big Hire or Little Hire, when adding a `<job>` tag, when
+  `package.json .jobs` blocks are stale, or when `npx coaligned jtbd` reports a
+  schema or freshness failure.
+---
+
+# coaligned-jtbd
+
+Jobs To Be Done is what agents align to: the progress each persona seeks in a
+specific circumstance, not a feature list. This skill authors job entries to
+spec and keeps the generated blocks fresh.
+
+`npx coaligned jtbd` validates entries against the schema and checks that
+generated blocks are current. `npx coaligned jtbd --fix` regenerates them.
+
+## Two kinds of job
+
+- **Big Hire** — the adoption decision, one per persona-outcome pair. Lives in
+  the root `JTBD.md` with the full entry structure.
+- **Little Hire** — a narrower, repeated daily job. Lives wherever it fits:
+  package READMEs, design docs, near the code that serves it.
+
+## Procedure
+
+### Step 1 — Reconstruct the job from a real moment
+
+Start from a struggle story, not a template. Answer: who is the persona, what
+just happened that created the job, what progress do they want, and what do they
+hire today instead? A job invented at a desk tends to confirm assumptions; a job
+reconstructed from a real decision tends to surprise.
+
+### Step 2 — Write the entry to structure
+
+The first five elements are required for every entry. **Forces** and **Fired
+When** are required for products and omitted for services and libraries.
+
+See [references/entry-template.md](references/entry-template.md) for the full
+structure and [references/example.md](references/example.md) for a worked
+entry. Hold each entry to the seven quality properties — the load-bearing ones:
+
+- **Progress, not features.** If removing the product name makes the statement
+  meaningless, the job is solution-shaped. Rewrite it.
+- **Trigger is a moment, not a role.** It answers "what just happened?", not
+  "who is this person?".
+- **Competing hires include nonconsumption.** "Hire nothing" is usually the
+  real incumbent; name it.
+- **Forces are asymmetric.** If all four feel equal, it was filled from a
+  template, not reconstructed.
+
+### Step 3 — Tag the job
+
+Wrap every job — Big or Little — in a `<job>` tag so it is discoverable without
+knowing where it lives:
+
+```markdown
+<job user="<persona>" goal="<outcome>">
+
+**Trigger:** <the moment that creates the job>.
+
+**Big Hire:** <progress sought>. → **<product>**
+
+**Little Hire:** <repeated daily progress>. → **<product>**
+
+</job>
+```
+
+Keep the full opening tag on one line within 74 characters. Discover jobs with
+`rg '<job '`.
+
+### Step 4 — Regenerate or validate
+
+- **Static `JTBD.md`** — run `npx coaligned jtbd` to validate entry structure.
+- **Generated `.jobs` blocks** — edit the `jobs` array in the owning
+  `package.json`, then run `npx coaligned jtbd --fix` to regenerate the catalog
+  and job blocks. Commit the regenerated files.
+
+```sh
+npx coaligned jtbd          # validate entries and check freshness
+npx coaligned jtbd --fix    # regenerate stale catalog and job blocks
+```
+
+A stale generated block fails the check; never hand-edit generated blocks —
+edit the manifest and regenerate.
+
+## Done When
+
+<do_confirm_checklist goal="Verify the jobs are sound before committing">
+
+- [ ] Each entry states progress, not a feature wearing job syntax.
+- [ ] Every trigger is a moment, and every Competes With names nonconsumption.
+- [ ] Every job is wrapped in a `<job>` tag on a single ≤74-char opening line.
+- [ ] Generated blocks were regenerated from manifests, not hand-edited.
+- [ ] `npx coaligned jtbd` passes with no schema or freshness findings.
+
+</do_confirm_checklist>
+
+## Documentation
+
+- [Co-Aligned Instruction Architecture Standard](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md) —
+  where jobs sit in the layered architecture.
+- [libcoaligned README](https://github.com/forwardimpact/monorepo/blob/main/libraries/libcoaligned/README.md) —
+  what `coaligned jtbd` validates and regenerates.

--- a/.claude/skills/coaligned-jtbd/references/entry-template.md
+++ b/.claude/skills/coaligned-jtbd/references/entry-template.md
@@ -1,0 +1,59 @@
+# JTBD entry structure
+
+A Big Hire entry follows a fixed structure. The first five elements are
+required for every entry. **Forces** and **Fired When** are required for
+products and omitted for services and libraries.
+
+- **User** — the persona hiring the product (`##` heading).
+- **Goal** — the high-level progress sought (`###` heading).
+- **Trigger** — the specific moment that creates the job, not a role
+  description.
+- **Big Hire** — "{progress}." — the adoption decision: why this gets hired
+  over the alternatives.
+- **Little Hire** — "{progress}." — the repeated daily use that brings the user
+  back.
+- **Competes With** — what gets hired instead; semicolon-delimited; must
+  include a "hire nothing" (nonconsumption) option.
+- **Forces** *(products only)* — four forces: **Push** (status-quo pain),
+  **Pull** (desired future state, not features), **Habit** (current behavior
+  resisting change), **Anxiety** (fear blocking adoption).
+- **Fired When** *(products only)* — conditions under which the product gets
+  abandoned; include at least one environmental shift beyond product failure.
+
+## Manifest form (generated `.jobs` blocks)
+
+When jobs are generated from `package.json`, the same fields appear as a `jobs`
+array. Services and libraries carry Little Hire entries — no `forces` or
+`firedWhen`:
+
+```json
+{
+  "jobs": [
+    {
+      "user": "<persona>",
+      "goal": "<high-level progress sought>",
+      "trigger": "<the moment that creates the job>",
+      "bigHire": "<the adoption decision>.",
+      "littleHire": "<the repeated daily use>.",
+      "competesWith": "<alt>; <alt>; hire nothing and <status quo>"
+    }
+  ]
+}
+```
+
+`npx coaligned jtbd --fix` reads these and regenerates the README catalog rows
+and the marker-delimited job blocks. Edit the manifest, never the generated
+block.
+
+## The seven quality properties
+
+1. **Progress, not features.** Remove the product name; if the statement goes
+   meaningless, it was solution-shaped.
+2. **Trigger is a moment, not a role.** It answers "what just happened?".
+3. **Competing hires include nonconsumption.** Name the "hire nothing" option.
+4. **Pull describes a desired future, not a feature list.**
+5. **Forces are asymmetric.** One force usually dominates.
+6. **Fired When includes the world, not just the product.** A reorg, a budget
+   cut, a tool ban.
+7. **Field-validated, not desk-authored.** Entries are hypotheses until a
+   customer struggle story confirms them.

--- a/.claude/skills/coaligned-jtbd/references/example.md
+++ b/.claude/skills/coaligned-jtbd/references/example.md
@@ -1,0 +1,64 @@
+# Worked entry
+
+A product Big Hire entry with all elements, then the same job as a discoverable
+tag. Replace the persona, product, and circumstances with your own — copy the
+shape, not the content.
+
+## Full entry (root JTBD.md)
+
+```markdown
+## Engineering Leaders
+
+### Staff Teams to Succeed
+
+**Trigger:** A post-mortem surfaces the same skill gap that caused the last
+incident.
+
+**Big Hire:** Help me make staffing decisions I can defend with evidence, not
+intuition.
+
+**Little Hire:** Help me spot capability gaps before someone gets set up to
+fail.
+
+**Competes With:** Gut-feel reorgs; spreadsheets of headcount; hiring a
+consultant; hire nothing and hope the gap closes on its own.
+
+**Forces:**
+
+- **Push:** The same gap keeps causing incidents and nobody can point to why.
+- **Pull:** Confidence that a staffing change strengthens the team as a system.
+- **Habit:** Staffing by who is available, not by what the team is missing.
+- **Anxiety:** Fear that a model oversimplifies people into cells in a grid.
+
+**Fired When:** A reorg dissolves the team being modeled; a budget freeze ends
+hiring; leadership mandates a different planning tool.
+```
+
+## As a discoverable tag
+
+A Big or Little Hire anywhere in the repo is wrapped so `rg '<job '` finds it:
+
+```markdown
+<job user="Engineering Leaders" goal="Staff Teams to Succeed">
+
+**Trigger:** A post-mortem surfaces the same skill gap that caused the last
+incident.
+
+**Big Hire:** Help me make staffing decisions I can defend with evidence, not
+intuition. → **Summit**
+
+**Little Hire:** Help me spot capability gaps before someone gets set up to
+fail. → **Summit**
+
+</job>
+```
+
+## Why this passes the properties
+
+- The Big Hire survives removing the product name — it is progress, not a
+  feature.
+- The trigger is a moment ("a post-mortem surfaces…"), not "leaders who staff
+  teams".
+- Competes With names nonconsumption ("hope the gap closes on its own").
+- The forces are asymmetric — Push dominates — and Fired When names the world
+  (a reorg, a freeze), not only product failure.

--- a/.claude/skills/coaligned-layer/SKILL.md
+++ b/.claude/skills/coaligned-layer/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: coaligned-layer
+description: >
+  Author or repair an instruction layer to the Co-Aligned standard — an agent
+  profile, agent reference, SKILL.md, skill reference, or checklist. Use when
+  adding an agent or skill, when `npx coaligned instructions` flags a length
+  breach, or when one layer has started restating another.
+---
+
+# coaligned-layer
+
+The Co-Aligned architecture splits instructions across eight layers, each with
+one job. A defect in one layer is a different class of problem from a defect in
+another, and that separation is what makes a failed run attributable. This
+skill authors and repairs the layers a contributor edits: L3–L7.
+
+`npx coaligned instructions` enforces a line cap and a word cap on every layer.
+Either breach fails. See [references/layer-reference.md](references/layer-reference.md)
+for the layers, their properties, and their caps.
+
+## Procedure
+
+### Step 1 — Identify the layer
+
+Name which layer you are writing — each owns one job:
+
+- **L3 agent profile** — persona, voice, skill routing, scope.
+- **L4 agent reference** — a protocol shared across agents (memory,
+  coordination, approval).
+- **L5 SKILL.md** — the complete procedure for one domain.
+- **L6 skill reference** — data the procedure consults: templates, examples,
+  lookup tables.
+- **L7 checklist** — binary verification at one pause point.
+
+Each layer's defining property and cap live in
+[references/layer-reference.md](references/layer-reference.md).
+
+If you are unsure which layer owns the content, that is the signal two layers
+are about to blur. Resolve it before writing.
+
+### Step 2 — Write to the layer's job, and only its job
+
+Apply the one rule that governs every layer: **no layer restates another.**
+
+- A profile (L3) defines boundaries; the steps go in the skill (L5).
+- A procedure (L5) makes decisions and sequences work; templates, examples, and
+  tables go in a reference (L6).
+- A reference (L6) is declarative; if it prescribes steps, it belongs in L5.
+- A checklist (L7) verifies a known step; if an item teaches, the procedure
+  above it is incomplete — move the teaching up.
+
+When two layers must mention the same tool, separate them by voice: the lower
+layer describes ("ToolX sends a message"), the higher layer directs ("Use ToolX
+to deliver the report").
+
+### Step 3 — Write checklists as gates, not prose
+
+A checklist is binary verification at a natural pause point. Use the right type:
+
+- **READ-DO** — entry gate. Read each item, then do it. Before work begins.
+- **DO-CONFIRM** — exit gate. Do from memory, then confirm. Before a commit,
+  merge, or release.
+
+Tag every checklist so it is discoverable. See
+[references/checklist-tagging.md](references/checklist-tagging.md) for the tags
+and the seven properties of a good checklist.
+
+### Step 4 — Fit the cap
+
+Run `npx coaligned instructions`. On a length breach, do not just delete words —
+move them to the layer that owns them:
+
+- L5 over cap → push templates, examples, and tables down to an L6 reference.
+- L3 over cap → push procedure to the skill it routes to.
+- L4/L6 over cap → split into two references, each independently correct.
+
+Trimming that loses meaning means the content is in the wrong layer, not that it
+is too long.
+
+### Step 5 — Verify
+
+`npx coaligned instructions` passes. Re-read the edited layer against its
+single job: a reader following only this layer should get exactly what the layer
+promises and nothing another layer owns.
+
+## Done When
+
+<do_confirm_checklist goal="Verify the layer holds before committing">
+
+- [ ] The layer carries only its own job — no content another layer owns.
+- [ ] Shared tools are separated by voice, not duplicated.
+- [ ] Every checklist is tagged and uses the correct READ-DO / DO-CONFIRM type.
+- [ ] `npx coaligned instructions` passes with no length findings.
+
+</do_confirm_checklist>
+
+## Documentation
+
+- [Co-Aligned Instruction Architecture Standard](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md) —
+  every layer, its properties, and the rules that separate them.
+- [libcoaligned README](https://github.com/forwardimpact/monorepo/blob/main/libraries/libcoaligned/README.md) —
+  what `coaligned instructions` enforces.

--- a/.claude/skills/coaligned-layer/references/checklist-tagging.md
+++ b/.claude/skills/coaligned-layer/references/checklist-tagging.md
@@ -1,0 +1,62 @@
+# Checklists: tags, types, and properties
+
+A checklist is binary verification at one pause point. It never teaches — if an
+item needs explanation, the procedure above it is incomplete.
+
+## Two types
+
+| Moment | Type | How it is used |
+| --- | --- | --- |
+| Before starting work | READ-DO | Read each item, then do it |
+| Before crossing a boundary | DO-CONFIRM | Do from memory, then confirm each item |
+
+Use READ-DO when the contributor must load constraints before the first line.
+Use DO-CONFIRM before a commit, merge, or release — skilled contributors work
+fluidly, then pause to confirm nothing was missed. Using the wrong type at the
+wrong moment defeats the checklist.
+
+## Tags
+
+Wrap each checklist in a semantic tag encoding its type and goal:
+
+```markdown
+<read_do_checklist goal="Internalize constraints before writing code">
+
+- [ ] First constraint to internalize before starting.
+- [ ] Second constraint.
+
+</read_do_checklist>
+```
+
+```markdown
+<do_confirm_checklist goal="Verify completeness before committing">
+
+- [ ] First verification to confirm before proceeding.
+- [ ] Second verification.
+
+</do_confirm_checklist>
+```
+
+Keep the full opening tag on one line within 74 characters so search output
+stays coherent. Discover checklists from anywhere:
+
+```sh
+rg '<read_do_checklist'     # entry gates
+rg '<do_confirm_checklist'  # exit gates
+```
+
+## Seven properties of a good checklist
+
+1. **Goal statement.** Every checklist states the outcome it protects.
+2. **5–7 items.** Beyond working-memory limits, contributors skip entries.
+3. **Precise.** Each item is one unambiguous action or verification.
+4. **Killer items only.** Every item addresses a failure that has actually
+   occurred or is highly likely.
+5. **Action or verification, never explanation.** A verb phrase, not a
+   paragraph.
+6. **One checklist, one moment.** Tied to a single, natural pause point.
+7. **Tested and revised.** Use it, observe what still goes wrong, revise.
+
+The cap is on item count (≤ 9 per block), not lines — a wrapped line is
+formatting, not cognitive load. If a block needs more than seven items, the
+pause point is probably two pause points.

--- a/.claude/skills/coaligned-layer/references/layer-reference.md
+++ b/.claude/skills/coaligned-layer/references/layer-reference.md
@@ -1,0 +1,59 @@
+# The layers, caps, and properties
+
+Eight layers, ascending from most general (every contributor, every run) to
+most specific (one pause point). Each has one job.
+
+| Layer | What it is | Cap | Loaded |
+| --- | --- | --- | --- |
+| L0 system prompt | Harness mechanics: turns, tool calls, completion | (harness-owned) | once per session |
+| L1 root CLAUDE.md | Project identity | ≤ 192 lines | auto, every run |
+| L1 subdir CLAUDE.md | Directory-local conventions | ≤ 128 lines | on demand |
+| L2 CONTRIBUTING.md / JTBD.md | Standards and jobs | ≤ 320 lines | on demand |
+| L3 agent profile | Persona, voice, routing, scope | ≤ 72 lines | auto, every run |
+| L4 agent reference | Cross-cutting protocol | ≤ 192 lines | on demand |
+| L5 SKILL.md | One domain's procedure | ≤ 192 lines | auto, per skill |
+| L6 skill reference | Templates, examples, lookup data | ≤ 128 lines | on demand |
+| L7 checklist block | Binary verification | ≤ 9 items | auto, per skill |
+
+L1/L2 properties are defined by the repository's own identity conventions. The
+layers a contributor edits day to day are L3–L7.
+
+## L3 — agent profile
+
+1. **Boundaries, not steps.** Defines scope and persona; procedures live in L5.
+2. **One persona per profile.** Mixing personas blurs voice and accountability.
+3. **Minimal.** Every line loads on every run. Scope and routing only; push the
+   rest to L5 or L6.
+
+## L4 — agent reference
+
+1. **Declarative, cross-cutting.** Protocols shared by several agents. If only
+   one skill needs it, it belongs in that skill's `references/`.
+2. **Independently correct.** Stale data is a distinct defect from a wrong
+   profile.
+3. **On-demand only.** Never auto-loaded. If a profile always needs it, fold it
+   into the profile.
+
+## L5 — skill procedure
+
+1. **Complete for its domain.** A contributor following only the procedure
+   produces correct output.
+2. **Imperative voice.** "Use X to do Y", not "X can be used to do Y".
+3. **Decision-making, not data.** Sequencing, rationale, judgment calls. Push
+   templates and tables to L6.
+4. **Self-contained at invocation.** No external reads required to begin;
+   references are consulted mid-procedure, not as prerequisites.
+
+## L6 — skill reference
+
+1. **Declarative, not procedural.** Templates, worked examples, lookup data.
+2. **Independently correct.** A stale reference is a different defect from a
+   wrong procedure.
+3. **On-demand only.** If a reference is always needed, move it into the
+   procedure.
+
+## The boundary that matters most
+
+L5 is procedural, L6 is declarative, L7 is verificational. "Wrong procedure",
+"stale data", and "missing verification" are three different defects. Keeping
+them in three layers is what lets a failed run point at one of them.

--- a/.claude/skills/coaligned-setup/SKILL.md
+++ b/.claude/skills/coaligned-setup/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: coaligned-setup
+description: >
+  Bootstrap the Co-Aligned instruction architecture in a repository. Use
+  when a repo has no layered agent instructions yet, when adopting the
+  COALIGNED.md standard, or when wiring `npx coaligned` into the checks so
+  instruction layers, jobs, and invariants stay enforced.
+---
+
+# coaligned-setup
+
+Stand up the [Co-Aligned](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
+instruction architecture in a repository: the root identity and jobs files,
+the invariant directory, and the `npx coaligned` checks that keep them honest.
+
+Run this once per repository. For ongoing work use the sibling skills:
+[coaligned-layer](../coaligned-layer/SKILL.md) for instruction layers,
+[coaligned-jtbd](../coaligned-jtbd/SKILL.md) for jobs,
+[coaligned-invariant](../coaligned-invariant/SKILL.md) for custom rules, and
+[coaligned-audit](../coaligned-audit/SKILL.md) for the maintenance loop.
+
+## Procedure
+
+<read_do_checklist goal="Internalize the architecture before scaffolding">
+
+- [ ] Confirm the eight layers and their one-job-each separation are clear.
+- [ ] Confirm no instruction layers exist yet; if some do, repair them with
+      coaligned-layer instead of overwriting.
+- [ ] Decide the jobs structure (see Step 1) before creating JTBD.md.
+
+</read_do_checklist>
+
+### Step 1 — Decide the jobs structure
+
+The jobs layer (L2) has two shapes. Pick by how the repo is packaged, not by
+preference.
+
+- **Single static `JTBD.md`** — the repo is one unit (one deployable, one
+  library, a monolith). Author Big Hire entries directly in `JTBD.md`. No
+  generation.
+- **Generated `.jobs` blocks** — the repo is genuinely many packages, each
+  with its own `package.json`. Each package declares `jobs` in its manifest;
+  `npx coaligned jtbd --fix` generates the catalog and job blocks into the
+  README and root `JTBD.md`.
+
+When in doubt, choose the static file — fewer moving parts. See
+[references/structure-decision.md](references/structure-decision.md).
+
+### Step 2 — Create the root layers (L1, L2)
+
+Create the auto-loaded identity and on-demand standards files. Keep each within
+its cap (L1 ≤ 192 lines; L2 ≤ 320 lines).
+
+- **`CLAUDE.md`** (L1) — project identity: what the repo is, who it serves,
+  where things live, and how to route to skills. Orientation, not procedure.
+- **`CONTRIBUTING.md`** (L2) — contribution standards: invariants, the quality
+  commands, security policy, and the universal checklists.
+- **`JTBD.md`** (L2) — the jobs, per Step 1. Use coaligned-jtbd to author
+  entries to spec.
+
+Do not restate one file in another. CLAUDE.md orients; CONTRIBUTING.md governs.
+
+### Step 3 — Create the invariant directory
+
+Create `.coaligned/invariants/`. Leave it empty for now, or add a first rule
+module with coaligned-invariant. The directory is where the repo's own
+declarative checks live; `npx coaligned invariants` discovers every
+`*.rules.mjs` under it.
+
+### Step 4 — Wire the checks into the repository
+
+Add `npx coaligned` to the repository's check command so every layer, job, and
+invariant is enforced before merge.
+
+```sh
+npx coaligned                # instructions + jtbd (and invariants if present)
+npx coaligned instructions   # layer length and checklist caps only
+npx coaligned jtbd --fix     # regenerate stale catalog and job blocks
+npx coaligned invariants     # the repo's own rule modules
+```
+
+Run the bare `npx coaligned` in the repository's lint/check task and in CI.
+
+### Step 5 — Verify the bootstrap
+
+Run `npx coaligned`. A clean run means the layers fit their caps and the jobs
+validate. Fix any finding before committing — route by subcommand the same way
+[coaligned-audit](../coaligned-audit/SKILL.md) does.
+
+## Done When
+
+<do_confirm_checklist goal="Verify the architecture stands before committing">
+
+- [ ] `CLAUDE.md`, `CONTRIBUTING.md`, and `JTBD.md` exist and stay within
+      their caps.
+- [ ] `.coaligned/invariants/` exists.
+- [ ] `npx coaligned` is wired into the repository's check command and CI.
+- [ ] `npx coaligned` passes with no findings.
+
+</do_confirm_checklist>
+
+## Documentation
+
+- [Co-Aligned Instruction Architecture Standard](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md) —
+  the eight layers, their caps, and the rules that separate them.
+- [libcoaligned README](https://github.com/forwardimpact/monorepo/blob/main/libraries/libcoaligned/README.md) —
+  what each `coaligned` subcommand checks.

--- a/.claude/skills/coaligned-setup/references/structure-decision.md
+++ b/.claude/skills/coaligned-setup/references/structure-decision.md
@@ -1,0 +1,56 @@
+# Jobs structure decision
+
+The jobs layer (L2) has two shapes. The choice is structural — it follows how
+the repository is packaged, not taste.
+
+## Decision
+
+| Signal | Structure |
+| --- | --- |
+| One `package.json` at the root, or no per-package manifests | Single static `JTBD.md` |
+| Many packages, each with its own `package.json` | Generated `.jobs` blocks |
+| Unsure | Single static `JTBD.md` (fewer moving parts) |
+
+A repository can start static and migrate later. Going the other way — folding
+generated blocks back into a static file — is rarely worth it.
+
+## Single static JTBD.md
+
+Author Big Hire entries directly in `JTBD.md`. Nothing generates them; the file
+is the source of truth. `npx coaligned jtbd` validates entry structure but has
+nothing to regenerate.
+
+Best for a repository that ships as one unit: a single library, one service,
+or a monolith.
+
+## Generated .jobs blocks
+
+Each package declares its jobs in `package.json`:
+
+```json
+{
+  "jobs": [
+    {
+      "user": "<persona>",
+      "goal": "<high-level progress sought>",
+      "trigger": "<the specific moment that creates the job>",
+      "bigHire": "<the adoption decision>.",
+      "littleHire": "<the repeated daily use>.",
+      "competesWith": "<what gets hired instead; include hire-nothing>"
+    }
+  ]
+}
+```
+
+`npx coaligned jtbd --fix` reads every package's `jobs`, validates them against
+the JTBD schema, and regenerates the marker-delimited catalog and job blocks in
+the directory READMEs and the root `JTBD.md`. Run it whenever a manifest's
+`jobs` change; CI fails if a generated block is stale.
+
+Best for a repository that is genuinely many packages with distinct personas.
+
+## Either way
+
+Entry quality is the same problem in both shapes — Big Hire vs Little Hire,
+trigger as a moment not a role, competing hires that include nonconsumption.
+Author entries with [coaligned-jtbd](../../coaligned-jtbd/SKILL.md).

--- a/.coaligned/invariants/skill-genericity.rules.mjs
+++ b/.coaligned/invariants/skill-genericity.rules.mjs
@@ -19,9 +19,10 @@
 //
 // Fully-qualified https://github.com/forwardimpact/monorepo/blob/main/...
 // links are sanctioned (canonical-protocol references) and do not match
-// these rules. fit-* skills are out of scope: they document their own
-// published CLIs and legitimately name @forwardimpact packages and tool
-// integrations.
+// these rules. fit-* and coaligned-* skills are out of scope: they document
+// their own published CLIs and legitimately name @forwardimpact packages and
+// tool integrations. Only kata-* skills (plus the agent references) are
+// scanned — see the glob in build().
 
 const PATTERNS = [
   // --- Group 1: internal-only tooling ---

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -6,9 +6,11 @@ on:
     paths:
       - ".claude/skills/fit-*/**"
       - ".claude/skills/kata-*/**"
+      - ".claude/skills/coaligned-*/**"
       - ".claude/agents/*.md"
       - ".claude/agents/references/**"
       - "products/gear/package.json"
+      - "libraries/libcoaligned/package.json"
       - ".github/workflows/publish-skills.yml"
   workflow_dispatch:
 
@@ -112,6 +114,160 @@ jobs:
 
           ```bash
           npx skills add forwardimpact/fit-skills
+          ```
+
+          ## Available Skills
+
+          | Skill | Description |
+          | --- | --- |
+          EOF
+
+          sed -i 's/^          //' skills-repo/README.md
+
+          extract_desc() {
+            awk '
+              /^description:/ {
+                sub(/^description: *>? */, "")
+                if ($0 != "") { desc = $0 }
+                while (getline > 0) {
+                  if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
+                  else { break }
+                }
+                gsub(/^ +/, "", desc)
+                gsub(/ +$/, "", desc)
+                print desc
+                exit
+              }
+            ' "$1"
+          }
+
+          for skill_dir in skills-repo/skills/*/; do
+            skill_md="$skill_dir/SKILL.md"
+            if [ -f "$skill_md" ]; then
+              name=$(sed -n 's/^name: *//p' "$skill_md" | head -1)
+              desc=$(extract_desc "$skill_md")
+              echo "| **${name}** | ${desc} |" >> skills-repo/README.md
+            fi
+          done
+
+      - name: Commit, push, tag
+        working-directory: skills-repo
+        run: |
+          git config user.name "kata-agent-team[bot]"
+          git config user.email "${{ secrets.KATA_APP_ID }}+kata-agent-team[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to publish"
+          else
+            git commit -m "chore: sync skills from monorepo @ v${VERSION}"
+            git push
+          fi
+
+          if git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists upstream"
+          else
+            git tag "v${VERSION}"
+            git push origin "v${VERSION}"
+          fi
+
+  publish-coaligned-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+          repositories: coaligned-skills
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: forwardimpact/coaligned-skills
+          token: ${{ steps.ci-app.outputs.token }}
+          path: skills-repo
+          fetch-depth: 0
+
+      - uses: ./.github/actions/audit
+        with:
+          vulnerability-scanning: "false"
+          secret-scanning: "true"
+
+      - uses: forwardimpact/fit-bootstrap@22e7a8a053c22cf56d6f4efb95fcf0b3d42267c8 # v1
+
+      - name: Skill ref lint
+        run: bun run check-skill-refs
+        env:
+          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
+
+      - name: Read version
+        run: |
+          VERSION=$(jq -r '.version' libraries/libcoaligned/package.json)
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Sync skills
+        run: |
+          inject_skill_frontmatter() {
+            local file="$1" version="$2"
+            awk -v ver="$version" '
+              NR == 1 && $0 == "---" { print; in_fm = 1; next }
+              in_fm && $0 == "---" {
+                print "license: Apache-2.0"
+                print "metadata:"
+                print "  version: \"" ver "\""
+                print "  author: forwardimpact"
+                print
+                in_fm = 0
+                next
+              }
+              { print }
+            ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+          }
+
+          rm -rf skills-repo/skills
+          mkdir -p skills-repo/skills
+          for skill_dir in .claude/skills/coaligned-*/; do
+            skill_name=$(basename "$skill_dir")
+            cp -r "$skill_dir" "skills-repo/skills/$skill_name"
+            inject_skill_frontmatter "skills-repo/skills/$skill_name/SKILL.md" "$VERSION"
+          done
+
+      - name: Generate apm.yml
+        run: |
+          cat > skills-repo/apm.yml <<EOF
+          name: coaligned-skills
+          version: ${VERSION}
+          description: >-
+            Skills for maintaining the Co-Aligned instruction architecture —
+            setup, instruction layers, jobs, invariants, and the check suite.
+          author: forwardimpact
+          license: Apache-2.0
+          includes: auto
+          EOF
+
+      - name: Generate README
+        run: |
+          cat > skills-repo/README.md << 'EOF'
+          # Co-Aligned Skills
+
+          Skills for maintaining the
+          [Co-Aligned](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
+          instruction architecture with the `coaligned` CLI.
+
+          ## Install
+
+          With [APM](https://microsoft.github.io/apm/):
+
+          ```bash
+          apm install forwardimpact/coaligned-skills
+          ```
+
+          With [npx skills](https://github.com/vercel-labs/skills):
+
+          ```bash
+          npx skills add forwardimpact/coaligned-skills
           ```
 
           ## Available Skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,10 +89,10 @@ npm. It is the source of truth for `forwardimpact/*` sibling repos:
   `#!/usr/bin/env node`, no Bun. gRPC
   products need `npx fit-codegen --all` — see
   [Typed Contracts](websites/fit/docs/libraries/typed-contracts/index.md).
-- **Skill packs** — `forwardimpact/fit-skills` and `forwardimpact/kata-skills`
+- **Skill packs** — `forwardimpact/{fit-skills,kata-skills,coaligned-skills}`
   sync on push to `main`. Install: `npx skills add forwardimpact/fit-skills`
-  (or `kata-skills`). Internal skills (`libs-*`, product internals) never
-  publish.
+  (or `kata-skills`, `coaligned-skills`). Internal skills (`libs-*`, product
+  internals) never publish.
 - **Composite actions** —
   <!-- enum:sibling-composite-actions:list -->`forwardimpact/{fit-benchmark,fit-bootstrap,fit-eval,fit-wiki,kata-agent}`<!-- /enum -->
   released via append-only `v1.0.x` tags. Edit procedure in


### PR DESCRIPTION
## Summary

- New published skill family documenting the `coaligned` CLI so external consumers can adopt and maintain the COALIGNED.md layered instruction architecture.
  - **coaligned-setup** — bootstrap L1/L2 files + `.coaligned/` + wire `npx coaligned` into the checks; decide static `JTBD.md` vs generated `.jobs`.
  - **coaligned-layer** — author/repair instruction layers L3–L7 within caps, no restatement.
  - **coaligned-jtbd** — author Big/Little Hire jobs, `<job>` tags, `.jobs` blocks; `coaligned jtbd --fix`.
  - **coaligned-invariant** — author `.coaligned/invariants/*.rules.mjs` modules (build kit / rule kit).
  - **coaligned-audit** — run the full suite, triage findings, route each to its owning fix.
- Wire the pack into publishing: new `publish-coaligned-skills` job syncing `.claude/skills/coaligned-*/` to `forwardimpact/coaligned-skills`, versioned from `libcoaligned`.
- Note `coaligned-*` as out of scope for the `skill-genericity` invariant (it documents its own CLI, like `fit-*`); add the pack to the root CLAUDE.md Distribution Model.

Each skill holds to the standard it teaches — verified against the L5/L6/L7 caps and properties (`coaligned instructions` passes, no monorepo leakage).

## Follow-up before publish can run green

- Create the `forwardimpact/coaligned-skills` sibling repo.
- Scope the `KATA_APP` installation to include `coaligned-skills`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)