### PR TITLE
refactor(ci): collapse publish-skills into matrix + composite action

### DIFF
--- a/.github/actions/publish-skill-pack/action.yml
+++ b/.github/actions/publish-skill-pack/action.yml
@@ -1,0 +1,213 @@
+name: Publish skill pack
+description: >
+  Sync one skill pack (and, for kata, its agents) from the monorepo into the
+  checked-out sibling repo, regenerate apm.yml and README.md, then commit, push,
+  and tag at the pack's package version. All pack-specific values arrive via
+  inputs so the three packs share one implementation. Prose and repo names reach
+  the scripts through the environment, never by interpolation into source text.
+
+inputs:
+  pack-prefix:
+    description: Skill directory prefix under .claude/skills (e.g. fit, coaligned, kata).
+    required: true
+  sibling-repo:
+    description: >
+      Sibling repo short name (e.g. fit-skills). Names the apm package and the
+      `forwardimpact/<repo>` install commands.
+    required: true
+  version-file:
+    description: package.json whose `.version` stamps the apm package and release tag.
+    required: true
+  apm-description:
+    description: Description block written into apm.yml.
+    required: true
+  readme-title:
+    description: README H1 title.
+    required: true
+  readme-intro:
+    description: README intro paragraph rendered under the title.
+    required: true
+  sync-agents:
+    description: When "true", also sync .claude/agents into the pack and list them in the README.
+    default: "false"
+  app-id:
+    description: GitHub App id used to form the committer email.
+    required: true
+  target-dir:
+    description: Path of the checked-out sibling repo.
+    default: skills-repo
+
+runs:
+  using: composite
+  steps:
+    - name: Read version
+      shell: bash
+      env:
+        VERSION_FILE: ${{ inputs.version-file }}
+      run: |
+        VERSION=$(jq -r '.version' "$VERSION_FILE")
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+    - name: Sync skills
+      shell: bash
+      env:
+        PACK_PREFIX: ${{ inputs.pack-prefix }}
+        TARGET_DIR: ${{ inputs.target-dir }}
+      run: |
+        inject_skill_frontmatter() {
+          local file="$1" version="$2"
+          awk -v ver="$version" '
+            NR == 1 && $0 == "---" { print; in_fm = 1; next }
+            in_fm && $0 == "---" {
+              print "license: Apache-2.0"
+              print "metadata:"
+              print "  version: \"" ver "\""
+              print "  author: forwardimpact"
+              print
+              in_fm = 0
+              next
+            }
+            { print }
+          ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+        }
+
+        rm -rf "$TARGET_DIR/skills"
+        mkdir -p "$TARGET_DIR/skills"
+        for skill_dir in ".claude/skills/${PACK_PREFIX}-"*/; do
+          skill_name=$(basename "$skill_dir")
+          cp -r "$skill_dir" "$TARGET_DIR/skills/$skill_name"
+          inject_skill_frontmatter "$TARGET_DIR/skills/$skill_name/SKILL.md" "$VERSION"
+        done
+
+    - name: Sync agents
+      if: inputs.sync-agents == 'true'
+      shell: bash
+      env:
+        TARGET_DIR: ${{ inputs.target-dir }}
+      run: |
+        rm -rf "$TARGET_DIR/agents"
+        mkdir -p "$TARGET_DIR/agents"
+        for agent_file in .claude/agents/*.md; do
+          [ -f "$agent_file" ] || continue
+          agent_name=$(basename "$agent_file" .md)
+          cp "$agent_file" "$TARGET_DIR/agents/${agent_name}.agent.md"
+        done
+        # Ship the agent references the profiles and skills cite (e.g. the
+        # work-item tracker matrix); APM installs them alongside the skills.
+        if [ -d .claude/agents/references ]; then
+          cp -r .claude/agents/references "$TARGET_DIR/agents/references"
+        fi
+
+    - name: Generate apm.yml
+      shell: bash
+      env:
+        TARGET_DIR: ${{ inputs.target-dir }}
+        APM_NAME: ${{ inputs.sibling-repo }}
+        APM_DESCRIPTION: ${{ inputs.apm-description }}
+      run: |
+        cat > "$TARGET_DIR/apm.yml" <<EOF
+        name: ${APM_NAME}
+        version: ${VERSION}
+        description: >-
+          ${APM_DESCRIPTION}
+        author: forwardimpact
+        license: Apache-2.0
+        includes: auto
+        EOF
+
+    - name: Generate README
+      shell: bash
+      env:
+        TARGET_DIR: ${{ inputs.target-dir }}
+        SIBLING_REPO: ${{ inputs.sibling-repo }}
+        README_TITLE: ${{ inputs.readme-title }}
+        README_INTRO: ${{ inputs.readme-intro }}
+        SYNC_AGENTS: ${{ inputs.sync-agents }}
+      run: |
+        extract_desc() {
+          awk '
+            /^description:/ {
+              sub(/^description: *>? */, "")
+              if ($0 != "") { desc = $0 }
+              while (getline > 0) {
+                if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
+                else { break }
+              }
+              gsub(/^ +/, "", desc)
+              gsub(/ +$/, "", desc)
+              print desc
+              exit
+            }
+          ' "$1"
+        }
+
+        readme="$TARGET_DIR/README.md"
+        printf '# %s\n\n%s\n\n' "$README_TITLE" "$README_INTRO" > "$readme"
+        cat >> "$readme" <<EOF
+        ## Install
+
+        With [APM](https://microsoft.github.io/apm/):
+
+        \`\`\`bash
+        apm install forwardimpact/${SIBLING_REPO}
+        \`\`\`
+
+        With [npx skills](https://github.com/vercel-labs/skills):
+
+        \`\`\`bash
+        npx skills add forwardimpact/${SIBLING_REPO}
+        \`\`\`
+
+        ## Available Skills
+
+        | Skill | Description |
+        | --- | --- |
+        EOF
+
+        for skill_dir in "$TARGET_DIR"/skills/*/; do
+          skill_md="$skill_dir/SKILL.md"
+          if [ -f "$skill_md" ]; then
+            name=$(sed -n 's/^name: *//p' "$skill_md" | head -1)
+            desc=$(extract_desc "$skill_md")
+            echo "| **${name}** | ${desc} |" >> "$readme"
+          fi
+        done
+
+        if [ "$SYNC_AGENTS" = "true" ]; then
+          cat >> "$readme" <<'EOF'
+
+        ## Available Agents
+
+        | Agent | Description |
+        | --- | --- |
+        EOF
+          for agent_file in "$TARGET_DIR"/agents/*.agent.md; do
+            [ -f "$agent_file" ] || continue
+            name=$(sed -n 's/^name: *//p' "$agent_file" | head -1)
+            desc=$(extract_desc "$agent_file")
+            echo "| **${name}** | ${desc} |" >> "$readme"
+          done
+        fi
+
+    - name: Commit, push, tag
+      shell: bash
+      working-directory: ${{ inputs.target-dir }}
+      env:
+        APP_ID: ${{ inputs.app-id }}
+      run: |
+        git config user.name "kata-agent-team[bot]"
+        git config user.email "${APP_ID}+kata-agent-team[bot]@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "No changes to publish"
+        else
+          git commit -m "chore: sync skills from monorepo @ v${VERSION}"
+          git push
+        fi
+
+        if git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
+          echo "Tag v${VERSION} already exists upstream"
+        else
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+        fi

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -11,6 +11,7 @@ on:
       - ".claude/agents/references/**"
       - "products/gear/package.json"
       - "libraries/libcoaligned/package.json"
+      - ".github/actions/publish-skill-pack/**"
       - ".github/workflows/publish-skills.yml"
   workflow_dispatch:
 
@@ -18,8 +19,51 @@ permissions:
   contents: read
 
 jobs:
-  publish-fit-skills:
+  # One job body, three packs. Each pack syncs its skills (kata also its agents)
+  # into the matching sibling repo, regenerates apm.yml + README.md, and tags at
+  # the pack's package version. Add or retire a pack by editing one matrix entry;
+  # the shared mechanics live in ./.github/actions/publish-skill-pack.
+  publish:
+    name: ${{ matrix.pack.repo }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pack:
+          - prefix: fit
+            repo: fit-skills
+            version-file: products/gear/package.json
+            sync-agents: "false"
+            readme-title: Forward Impact Skills
+            readme-intro: >-
+              Agent skills for the [Forward Impact](https://forwardimpact.team)
+              engineering standard.
+            apm-description: >-
+              Agent skills for the Forward Impact engineering standard.
+          - prefix: coaligned
+            repo: coaligned-skills
+            version-file: libraries/libcoaligned/package.json
+            sync-agents: "false"
+            readme-title: Co-Aligned Skills
+            readme-intro: >-
+              Skills for maintaining the
+              [Co-Aligned](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
+              instruction architecture with the `coaligned` CLI.
+            apm-description: >-
+              Skills for maintaining the Co-Aligned instruction architecture —
+              setup, instruction layers, jobs, invariants, and the check suite.
+          - prefix: kata
+            repo: kata-skills
+            version-file: products/gear/package.json
+            sync-agents: "true"
+            readme-title: Kata Skills
+            readme-intro: >-
+              Agents and skills for the [Forward Impact](https://forwardimpact.team)
+              Kata Agent Team.
+            apm-description: >-
+              Forward Impact Kata Agent Team — domain agents and skills for the
+              spec → design → plan → implement workflow, releases, security, and
+              product-issue triage.
     steps:
       - name: Generate installation token
         id: ci-app
@@ -27,13 +71,13 @@ jobs:
         with:
           app-id: ${{ secrets.KATA_APP_ID }}
           private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-          repositories: fit-skills
+          repositories: ${{ matrix.pack.repo }}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          repository: forwardimpact/fit-skills
+          repository: forwardimpact/${{ matrix.pack.repo }}
           token: ${{ steps.ci-app.outputs.token }}
           path: skills-repo
           fetch-depth: 0
@@ -50,460 +94,14 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
 
-      - name: Read version
-        run: |
-          VERSION=$(jq -r '.version' products/gear/package.json)
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-
-      - name: Sync skills
-        run: |
-          inject_skill_frontmatter() {
-            local file="$1" version="$2"
-            awk -v ver="$version" '
-              NR == 1 && $0 == "---" { print; in_fm = 1; next }
-              in_fm && $0 == "---" {
-                print "license: Apache-2.0"
-                print "metadata:"
-                print "  version: \"" ver "\""
-                print "  author: forwardimpact"
-                print
-                in_fm = 0
-                next
-              }
-              { print }
-            ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
-          }
-
-          rm -rf skills-repo/skills
-          mkdir -p skills-repo/skills
-          for skill_dir in .claude/skills/fit-*/; do
-            skill_name=$(basename "$skill_dir")
-            cp -r "$skill_dir" "skills-repo/skills/$skill_name"
-            inject_skill_frontmatter "skills-repo/skills/$skill_name/SKILL.md" "$VERSION"
-          done
-
-      - name: Generate apm.yml
-        run: |
-          cat > skills-repo/apm.yml <<EOF
-          name: fit-skills
-          version: ${VERSION}
-          description: >-
-            Agent skills for the Forward Impact engineering standard.
-          author: forwardimpact
-          license: Apache-2.0
-          includes: auto
-          EOF
-
-      - name: Generate README
-        run: |
-          cat > skills-repo/README.md << 'EOF'
-          # Forward Impact Skills
-
-          Agent skills for the [Forward Impact](https://forwardimpact.team)
-          engineering standard.
-
-          ## Install
-
-          With [APM](https://microsoft.github.io/apm/):
-
-          ```bash
-          apm install forwardimpact/fit-skills
-          ```
-
-          With [npx skills](https://github.com/vercel-labs/skills):
-
-          ```bash
-          npx skills add forwardimpact/fit-skills
-          ```
-
-          ## Available Skills
-
-          | Skill | Description |
-          | --- | --- |
-          EOF
-
-          sed -i 's/^          //' skills-repo/README.md
-
-          extract_desc() {
-            awk '
-              /^description:/ {
-                sub(/^description: *>? */, "")
-                if ($0 != "") { desc = $0 }
-                while (getline > 0) {
-                  if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
-                  else { break }
-                }
-                gsub(/^ +/, "", desc)
-                gsub(/ +$/, "", desc)
-                print desc
-                exit
-              }
-            ' "$1"
-          }
-
-          for skill_dir in skills-repo/skills/*/; do
-            skill_md="$skill_dir/SKILL.md"
-            if [ -f "$skill_md" ]; then
-              name=$(sed -n 's/^name: *//p' "$skill_md" | head -1)
-              desc=$(extract_desc "$skill_md")
-              echo "| **${name}** | ${desc} |" >> skills-repo/README.md
-            fi
-          done
-
-      - name: Commit, push, tag
-        working-directory: skills-repo
-        run: |
-          git config user.name "kata-agent-team[bot]"
-          git config user.email "${{ secrets.KATA_APP_ID }}+kata-agent-team[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No changes to publish"
-          else
-            git commit -m "chore: sync skills from monorepo @ v${VERSION}"
-            git push
-          fi
-
-          if git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
-            echo "Tag v${VERSION} already exists upstream"
-          else
-            git tag "v${VERSION}"
-            git push origin "v${VERSION}"
-          fi
-
-  publish-coaligned-skills:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate installation token
-        id: ci-app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+      - name: Publish skill pack
+        uses: ./.github/actions/publish-skill-pack
         with:
+          pack-prefix: ${{ matrix.pack.prefix }}
+          sibling-repo: ${{ matrix.pack.repo }}
+          version-file: ${{ matrix.pack.version-file }}
+          apm-description: ${{ matrix.pack.apm-description }}
+          readme-title: ${{ matrix.pack.readme-title }}
+          readme-intro: ${{ matrix.pack.readme-intro }}
+          sync-agents: ${{ matrix.pack.sync-agents }}
           app-id: ${{ secrets.KATA_APP_ID }}
-          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-          repositories: coaligned-skills
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          repository: forwardimpact/coaligned-skills
-          token: ${{ steps.ci-app.outputs.token }}
-          path: skills-repo
-          fetch-depth: 0
-
-      - uses: ./.github/actions/audit
-        with:
-          vulnerability-scanning: "false"
-          secret-scanning: "true"
-
-      - uses: forwardimpact/fit-bootstrap@22e7a8a053c22cf56d6f4efb95fcf0b3d42267c8 # v1
-
-      - name: Skill ref lint
-        run: bun run check-skill-refs
-        env:
-          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-
-      - name: Read version
-        run: |
-          VERSION=$(jq -r '.version' libraries/libcoaligned/package.json)
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-
-      - name: Sync skills
-        run: |
-          inject_skill_frontmatter() {
-            local file="$1" version="$2"
-            awk -v ver="$version" '
-              NR == 1 && $0 == "---" { print; in_fm = 1; next }
-              in_fm && $0 == "---" {
-                print "license: Apache-2.0"
-                print "metadata:"
-                print "  version: \"" ver "\""
-                print "  author: forwardimpact"
-                print
-                in_fm = 0
-                next
-              }
-              { print }
-            ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
-          }
-
-          rm -rf skills-repo/skills
-          mkdir -p skills-repo/skills
-          for skill_dir in .claude/skills/coaligned-*/; do
-            skill_name=$(basename "$skill_dir")
-            cp -r "$skill_dir" "skills-repo/skills/$skill_name"
-            inject_skill_frontmatter "skills-repo/skills/$skill_name/SKILL.md" "$VERSION"
-          done
-
-      - name: Generate apm.yml
-        run: |
-          cat > skills-repo/apm.yml <<EOF
-          name: coaligned-skills
-          version: ${VERSION}
-          description: >-
-            Skills for maintaining the Co-Aligned instruction architecture —
-            setup, instruction layers, jobs, invariants, and the check suite.
-          author: forwardimpact
-          license: Apache-2.0
-          includes: auto
-          EOF
-
-      - name: Generate README
-        run: |
-          cat > skills-repo/README.md << 'EOF'
-          # Co-Aligned Skills
-
-          Skills for maintaining the
-          [Co-Aligned](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md)
-          instruction architecture with the `coaligned` CLI.
-
-          ## Install
-
-          With [APM](https://microsoft.github.io/apm/):
-
-          ```bash
-          apm install forwardimpact/coaligned-skills
-          ```
-
-          With [npx skills](https://github.com/vercel-labs/skills):
-
-          ```bash
-          npx skills add forwardimpact/coaligned-skills
-          ```
-
-          ## Available Skills
-
-          | Skill | Description |
-          | --- | --- |
-          EOF
-
-          sed -i 's/^          //' skills-repo/README.md
-
-          extract_desc() {
-            awk '
-              /^description:/ {
-                sub(/^description: *>? */, "")
-                if ($0 != "") { desc = $0 }
-                while (getline > 0) {
-                  if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
-                  else { break }
-                }
-                gsub(/^ +/, "", desc)
-                gsub(/ +$/, "", desc)
-                print desc
-                exit
-              }
-            ' "$1"
-          }
-
-          for skill_dir in skills-repo/skills/*/; do
-            skill_md="$skill_dir/SKILL.md"
-            if [ -f "$skill_md" ]; then
-              name=$(sed -n 's/^name: *//p' "$skill_md" | head -1)
-              desc=$(extract_desc "$skill_md")
-              echo "| **${name}** | ${desc} |" >> skills-repo/README.md
-            fi
-          done
-
-      - name: Commit, push, tag
-        working-directory: skills-repo
-        run: |
-          git config user.name "kata-agent-team[bot]"
-          git config user.email "${{ secrets.KATA_APP_ID }}+kata-agent-team[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No changes to publish"
-          else
-            git commit -m "chore: sync skills from monorepo @ v${VERSION}"
-            git push
-          fi
-
-          if git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
-            echo "Tag v${VERSION} already exists upstream"
-          else
-            git tag "v${VERSION}"
-            git push origin "v${VERSION}"
-          fi
-
-  publish-kata-skills:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate installation token
-        id: ci-app
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.KATA_APP_ID }}
-          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
-          repositories: kata-skills
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          repository: forwardimpact/kata-skills
-          token: ${{ steps.ci-app.outputs.token }}
-          path: skills-repo
-          fetch-depth: 0
-
-      - uses: ./.github/actions/audit
-        with:
-          vulnerability-scanning: "false"
-          secret-scanning: "true"
-
-      - uses: forwardimpact/fit-bootstrap@22e7a8a053c22cf56d6f4efb95fcf0b3d42267c8 # v1
-
-      - name: Skill ref lint
-        run: bun run check-skill-refs
-        env:
-          GH_TOKEN: ${{ steps.ci-app.outputs.token }}
-
-      - name: Read version
-        run: |
-          VERSION=$(jq -r '.version' products/gear/package.json)
-          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
-
-      - name: Sync skills
-        run: |
-          inject_skill_frontmatter() {
-            local file="$1" version="$2"
-            awk -v ver="$version" '
-              NR == 1 && $0 == "---" { print; in_fm = 1; next }
-              in_fm && $0 == "---" {
-                print "license: Apache-2.0"
-                print "metadata:"
-                print "  version: \"" ver "\""
-                print "  author: forwardimpact"
-                print
-                in_fm = 0
-                next
-              }
-              { print }
-            ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
-          }
-
-          rm -rf skills-repo/skills
-          mkdir -p skills-repo/skills
-          for skill_dir in .claude/skills/kata-*/; do
-            skill_name=$(basename "$skill_dir")
-            cp -r "$skill_dir" "skills-repo/skills/$skill_name"
-            inject_skill_frontmatter "skills-repo/skills/$skill_name/SKILL.md" "$VERSION"
-          done
-
-      - name: Sync agents
-        run: |
-          rm -rf skills-repo/agents
-          mkdir -p skills-repo/agents
-          for agent_file in .claude/agents/*.md; do
-            [ -f "$agent_file" ] || continue
-            agent_name=$(basename "$agent_file" .md)
-            cp "$agent_file" "skills-repo/agents/${agent_name}.agent.md"
-          done
-          # Ship the agent references the profiles and skills cite (e.g. the
-          # work-item tracker matrix); APM installs them alongside the skills.
-          if [ -d .claude/agents/references ]; then
-            cp -r .claude/agents/references skills-repo/agents/references
-          fi
-
-      - name: Generate apm.yml
-        run: |
-          cat > skills-repo/apm.yml <<EOF
-          name: kata-skills
-          version: ${VERSION}
-          description: >-
-            Forward Impact Kata Agent Team — domain agents and skills for the
-            spec → design → plan → implement workflow, releases, security, and
-            product-issue triage.
-          author: forwardimpact
-          license: Apache-2.0
-          includes: auto
-          EOF
-
-      - name: Generate README
-        run: |
-          cat > skills-repo/README.md << 'EOF'
-          # Kata Skills
-
-          Agents and skills for the [Forward Impact](https://forwardimpact.team)
-          Kata Agent Team.
-
-          ## Install
-
-          With [APM](https://microsoft.github.io/apm/):
-
-          ```bash
-          apm install forwardimpact/kata-skills
-          ```
-
-          With [npx skills](https://github.com/vercel-labs/skills):
-
-          ```bash
-          npx skills add forwardimpact/kata-skills
-          ```
-
-          ## Available Skills
-
-          | Skill | Description |
-          | --- | --- |
-          EOF
-
-          sed -i 's/^          //' skills-repo/README.md
-
-          extract_desc() {
-            awk '
-              /^description:/ {
-                sub(/^description: *>? */, "")
-                if ($0 != "") { desc = $0 }
-                while (getline > 0) {
-                  if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
-                  else { break }
-                }
-                gsub(/^ +/, "", desc)
-                gsub(/ +$/, "", desc)
-                print desc
-                exit
-              }
-            ' "$1"
-          }
-
-          for skill_dir in skills-repo/skills/*/; do
-            skill_md="$skill_dir/SKILL.md"
-            if [ -f "$skill_md" ]; then
-              name=$(sed -n 's/^name: *//p' "$skill_md" | head -1)
-              desc=$(extract_desc "$skill_md")
-              echo "| **${name}** | ${desc} |" >> skills-repo/README.md
-            fi
-          done
-
-          cat >> skills-repo/README.md << 'EOF'
-
-          ## Available Agents
-
-          | Agent | Description |
-          | --- | --- |
-          EOF
-
-          for agent_file in skills-repo/agents/*.agent.md; do
-            [ -f "$agent_file" ] || continue
-            name=$(sed -n 's/^name: *//p' "$agent_file" | head -1)
-            desc=$(extract_desc "$agent_file")
-            echo "| **${name}** | ${desc} |" >> skills-repo/README.md
-          done
-
-      - name: Commit, push, tag
-        working-directory: skills-repo
-        run: |
-          git config user.name "kata-agent-team[bot]"
-          git config user.email "${{ secrets.KATA_APP_ID }}+kata-agent-team[bot]@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No changes to publish"
-          else
-            git commit -m "chore: sync skills from monorepo @ v${VERSION}"
-            git push
-          fi
-
-          if git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
-            echo "Tag v${VERSION} already exists upstream"
-          else
-            git tag "v${VERSION}"
-            git push origin "v${VERSION}"
-          fi


### PR DESCRIPTION
## Summary

- The three `publish-skills.yml` jobs (`fit`/`coaligned`/`kata`) were near-identical 150-line walls of inline bash sharing byte-for-byte blocks — a violation of the `.github/CLAUDE.md` policy that workflows orchestrate and composite actions implement.
- Extracted the shared mechanics into a new `./.github/actions/publish-skill-pack` composite action: read version, sync skills + inject frontmatter, optional agent sync (kata only), generate `apm.yml` + `README.md`, commit/push/tag.
- Drive all three packs from one matrix job. Pack differences — sibling repo, version file, README/apm prose, and `sync-agents` — are now one matrix entry each. Adding or retiring a pack is a one-entry edit.
- Workflow drops **510 → 107 lines**. Behavior is unchanged. Pack-specific values reach the scripts via the environment, never interpolated into source text (matches the `resolve-package` injection-safe pattern).
- Extended the `push` path trigger to include `.github/actions/publish-skill-pack/**` so action edits republish.

## Verification

Extracted each step's YAML-dedented `run:` script and executed it under a CI-faithful shell (`bash -eo pipefail`, `GITHUB_ENV` propagation emulated) against the real repo for all three packs:

- **fit-skills** — no agents section/dir, frontmatter injected, valid `apm.yml`.
- **coaligned-skills** — confirms per-pack `version-file` routing (libcoaligned 0.1.14 vs gear 0.1.6).
- **kata-skills** — agents synced + listed, both README tables present.

Each `apm.yml` round-trips through a YAML parser; README titles, install links, and sections all correct.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`