### PR TITLE
fix(pathway): keep generated agent profiles within their layer cap

### DIFF
--- a/products/pathway/src/commands/agent-io.js
+++ b/products/pathway/src/commands/agent-io.js
@@ -137,6 +137,20 @@ export async function writeTeamInstructions(
   );
   if (!content) return null;
   const filePath = join(baseDir, ".claude", "CLAUDE.md");
+  // Exporting several agents into one --output directory makes them share this
+  // single CLAUDE.md. That is fine when their team instructions match, but a
+  // silent overwrite would lose differing content (e.g. per-track teams). Warn
+  // rather than clobber quietly.
+  if (await pathExists(runtime.fs, filePath)) {
+    const existing = await runtime.fs.readFile(filePath, "utf-8");
+    if (existing !== content) {
+      logger.warn(
+        `Overwriting ${filePath} with different team instructions — ` +
+          `exporting agents with distinct team content into one directory ` +
+          `loses all but the last. Use separate --output directories.`,
+      );
+    }
+  }
   await ensureDir(filePath, runtime);
   await runtime.fs.writeFile(filePath, content, "utf-8");
   logger.info(formatSuccess(`Created: ${filePath}`));

--- a/products/pathway/src/formatters/agent/profile.js
+++ b/products/pathway/src/formatters/agent/profile.js
@@ -20,6 +20,29 @@ import { flattenToLine } from "../template-preprocess.js";
  */
 
 /**
+ * Compact a working-style body into a single inline clause for bullet rendering.
+ * Drops a short leading label ("Before taking action:") and collapses an
+ * enumerated checklist ("1. a 2. b 3. c") into one semicolon-joined phrase, so
+ * the style reads as a trait rather than a multi-line procedure.
+ * @param {string} content - Authored working-style markdown
+ * @returns {string} Single-line compact clause
+ */
+function compactWorkingStyle(content) {
+  const flat = flattenToLine(content);
+  const unlabelled = flat.replace(/^[^.:]{1,40}:\s*/, "");
+  const items = unlabelled
+    .split(/\s*\d+\.\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (items.length <= 1) return unlabelled;
+  const [first, ...rest] = items;
+  return [
+    first,
+    ...rest.map((s) => s.charAt(0).toLowerCase() + s.slice(1)),
+  ].join("; ");
+}
+
+/**
  * Prepare agent profile data for template rendering
  * Normalizes string values by trimming trailing newlines for consistent template output.
  * @param {Object} params
@@ -40,21 +63,40 @@ import { flattenToLine } from "../template-preprocess.js";
  * @returns {Object} Data object ready for Mustache template
  */
 function prepareAgentProfileData({ frontmatter, bodyData }) {
-  const disciplineConstraints = (bodyData.disciplineConstraints || []).map(
-    (c) => trimRequired(c),
+  // Discipline and track constraint lists are concatenated in the profile.
+  // De-duplicate so a constraint declared by both the discipline and the track
+  // (or repeated within either) renders only once.
+  const seenConstraints = new Set();
+  const dedupeConstraints = (list) =>
+    (list || [])
+      .map((c) => trimRequired(c))
+      .filter((c) => {
+        const key = c.toLowerCase();
+        if (seenConstraints.has(key)) return false;
+        seenConstraints.add(key);
+        return true;
+      });
+  const disciplineConstraints = dedupeConstraints(
+    bodyData.disciplineConstraints,
   );
-  const trackConstraints = (bodyData.trackConstraints || []).map((c) =>
-    trimRequired(c),
-  );
+  const trackConstraints = dedupeConstraints(bodyData.trackConstraints);
+  // Flatten the "Use when" cell so each skill renders on a single physical
+  // table row — multi-line cells break the markdown table and inflate the
+  // profile's line count against its layer cap.
   const skillIndex = trimFields(bodyData.skillIndex, {
     name: "required",
     dirname: "required",
     useWhen: "required",
-  });
+  }).map((entry) => ({ ...entry, useWhen: flattenToLine(entry.useWhen) }));
+  // Render each working style as a single compact bullet rather than a titled
+  // multi-paragraph block, keeping the profile within its layer cap.
   const workingStyles = trimFields(bodyData.workingStyles, {
     title: "required",
     content: "required",
-  });
+  }).map((entry) => ({
+    ...entry,
+    content: compactWorkingStyle(entry.content),
+  }));
 
   const hasConstraints =
     disciplineConstraints.length > 0 || trackConstraints.length > 0;

--- a/products/pathway/templates/agent.template.md
+++ b/products/pathway/templates/agent.template.md
@@ -32,10 +32,7 @@ skills:
 ## Working style
 
 {{#workingStyles}}
-**{{title}}**
-
-{{{content}}}
-
+- **{{title}}** — {{{content}}}
 {{/workingStyles}}
 {{/hasWorkingStyles}}
 {{#hasSkills}}

--- a/products/pathway/test/agent-profile.test.js
+++ b/products/pathway/test/agent-profile.test.js
@@ -1,0 +1,82 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { formatAgentProfile } from "../src/formatters/agent/profile.js";
+
+const template = readFileSync(
+  fileURLToPath(new URL("../templates/agent.template.md", import.meta.url)),
+  "utf-8",
+);
+
+/**
+ * Build a minimal profile input as produced by buildProfileBodyData.
+ * @param {Object} bodyOverrides - Fields to override on bodyData
+ * @returns {Object}
+ */
+function makeProfile(bodyOverrides = {}) {
+  return {
+    frontmatter: {
+      name: "software-engineer--forward-deployed",
+      description: "Software Engineering (Forward Deployed).",
+      model: "opus",
+      skills: ["full-stack-development"],
+    },
+    bodyData: {
+      title: "Software Engineering - Forward Deployed",
+      identity: "You are a Forward Deployed Software Engineer.",
+      priority: null,
+      skillIndex: [
+        {
+          name: "Full-Stack Development",
+          dirname: "full-stack-development",
+          useWhen:
+            "asked to implement features spanning frontend, backend,\nand infrastructure layers.",
+        },
+      ],
+      roleContext: "",
+      workingStyles: [
+        {
+          title: "Investigate before acting",
+          content:
+            "Before taking action:\n1. Confirm the goal\n2. Identify unknowns\n3. Research unfamiliar areas",
+        },
+      ],
+      disciplineConstraints: ["Document trade-offs explicitly"],
+      trackConstraints: ["document trade-offs explicitly", "Own the outcome"],
+      ...bodyOverrides,
+    },
+  };
+}
+
+describe("formatAgentProfile", () => {
+  test("renders each working style as a single-line bullet without numbered scaffolding", () => {
+    const out = formatAgentProfile(makeProfile(), template);
+    assert.ok(
+      out.includes(
+        "- **Investigate before acting** — Confirm the goal; identify unknowns; research unfamiliar areas",
+      ),
+      out,
+    );
+    assert.ok(!out.includes("Before taking action:"));
+    assert.ok(!/\n1\. /.test(out));
+  });
+
+  test("renders each skill on a single physical table row", () => {
+    const out = formatAgentProfile(makeProfile(), template);
+    assert.ok(
+      out.includes(
+        "| Full-Stack Development | asked to implement features spanning frontend, backend, and infrastructure layers. |",
+      ),
+      out,
+    );
+  });
+
+  test("de-duplicates a constraint shared by discipline and track", () => {
+    const out = formatAgentProfile(makeProfile(), template);
+    const occurrences = out.split("Document trade-offs explicitly").length - 1;
+    assert.strictEqual(occurrences, 1);
+    assert.ok(out.includes("- Own the outcome"));
+  });
+});


### PR DESCRIPTION
## Why

Running `/coaligned-audit` on a generated forward-deployed agent team
(`npx fit-pathway agent <discipline> --track=forward_deployed`) surfaced
length-budget breaches that trace to the generator, not to the downstream
data. Every generated `*.agent.md` exceeded the Co-Aligned **L3 agent-profile
line cap** (89–91 lines vs 72) regardless of content, because fixed template
structure consumed the budget before any prose.

This PR fixes the template/formatter so generated profiles fit, and hardens
the multi-agent export path.

## What changed

**`templates/agent.template.md` + `formatters/agent/profile.js`**
- **Working style** — render each behaviour as a single compact bullet instead
  of a titled multi-paragraph block. New `compactWorkingStyle()` drops a short
  leading label (`Before taking action:`) and collapses an enumerated checklist
  (`1. … 2. … 3. …`) into one semicolon-joined clause.
- **Required skills** — flatten the `Use when` cell so each skill is one
  physical table row. Multi-line cells also *broke* the markdown table.
- **Constraints** — de-duplicate the concatenated discipline + track lists so a
  constraint declared by both renders once.

**`commands/agent-io.js`**
- Warn instead of silently overwriting `CLAUDE.md` with different team
  instructions when several agents export into one `--output` directory
  (`settings.json` already merges; `CLAUDE.md` did not).

**`test/agent-profile.test.js`** — new unit test covering the three rendering
changes.

## Result

For the forward-deployed team (3 disciplines):

| Profile | Before | After | Cap |
|---|---|---|---|
| software-engineer | 89 ln / 485 wd | **61 ln** / 473 wd | 72 / 448 |
| data-engineer | 89 ln / 485 wd | **61 ln** / 471 wd | 72 / 448 |
| data-scientist | 87 ln / 494 wd | **61 ln** / 451 wd | 72 / 448 |

The **line cap is now satisfied** and the markdown-table bug is gone. The
residual **word** pressure is the required-skills matrix — load-bearing routing
content sized by the number of skills, not by prose verbosity. Per the
audit principle *"don't silence by widening the cap"*, reconciling the L3 word
cap for skill-dense **generated** profiles (vs lean hand-written ones) is left
to the COALIGNED standard owners rather than bumped here. Open question:
the word budget counts the whole file including the skill matrix
(`libcoaligned/src/instructions.js`), so a 7-skill index inherently costs
~150 words.

## Deferred (documented, not in this PR)

A further audit note proposed moving a skill's **tool table into an L6
reference when its SKILL.md exceeds the procedure cap**. After trimming the
authored skill bodies downstream, no skill currently breaches, so this would
be speculative structure with cross-module length-awareness and its own tests.
Tracking it as a follow-up rather than gold-plating here.

## Testing

- `bun test products/pathway/test/*.test.js` → 140 pass (+3 new). The 1
  pre-existing fail/error is an un-run `libtype` codegen step in a fresh clone,
  unrelated to this change (identical with the change reverted).
- `biome format` + `biome lint` clean on changed files.
- Verified by regenerating the forward-deployed team against real data and
  re-running `npx coaligned`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)