### PR TITLE
fix(pathway): show top two skill levels in management job descriptions

### DIFF
--- a/products/pathway/src/formatters/job/description.js
+++ b/products/pathway/src/formatters/job/description.js
@@ -65,22 +65,46 @@ function buildExpectationsParagraph(expectations) {
 }
 
 /**
- * Build capability skill sections at the highest proficiency
+ * Build capability skill sections at the job's top proficiency level(s).
+ *
+ * Each derived responsibility sits at its capability's own highest proficiency,
+ * and the list is sorted by proficiency descending. Individual-contributor jobs
+ * show only the single highest proficiency. Management jobs concentrate fewer
+ * skills at the very top, so showing one level leaves their descriptions sparse;
+ * they include the top two proficiency levels instead.
  * @param {Object} job
+ * @param {Object} [options]
+ * @param {boolean} [options.isManagement] - Whether the role is a management role
  * @returns {Array}
  */
-function buildCapabilitySkills(job) {
+function buildCapabilitySkills(job, { isManagement = false } = {}) {
   const derivedResponsibilities = job.derivedResponsibilities || [];
   if (derivedResponsibilities.length === 0) return [];
 
-  const highestProficiency = derivedResponsibilities[0].proficiency;
-  const topResponsibilities = derivedResponsibilities.filter(
-    (r) => r.proficiency === highestProficiency,
+  // Collect the top N distinct proficiency levels present in the job.
+  const levelsToShow = isManagement ? 2 : 1;
+  const allowedProficiencies = new Set();
+  for (const r of derivedResponsibilities) {
+    if (!allowedProficiencies.has(r.proficiency)) {
+      if (allowedProficiencies.size >= levelsToShow) break;
+      allowedProficiencies.add(r.proficiency);
+    }
+  }
+
+  const topResponsibilities = derivedResponsibilities.filter((r) =>
+    allowedProficiencies.has(r.proficiency),
   );
 
+  // Each capability lists the skills at its own responsibility proficiency, so
+  // a capability shown at the second level keeps its second-level skills.
+  const proficiencyByCapability = new Map(
+    topResponsibilities.map((r) => [r.capability, r.proficiency]),
+  );
   const skillsByCapability = {};
   for (const skill of job.skillMatrix) {
-    if (skill.proficiency !== highestProficiency) continue;
+    if (proficiencyByCapability.get(skill.capability) !== skill.proficiency) {
+      continue;
+    }
     if (!skillsByCapability[skill.capability]) {
       skillsByCapability[skill.capability] = [];
     }
@@ -132,7 +156,9 @@ function prepareJobDescriptionData({ job, discipline, level, track }) {
     return indexB - indexA;
   });
 
-  const capabilitySkills = buildCapabilitySkills(job);
+  const capabilitySkills = buildCapabilitySkills(job, {
+    isManagement: !!discipline?.isManagement,
+  });
 
   // Build qualification summary with placeholder replacement
   const qualificationSummary =

--- a/products/pathway/test/job-description.test.js
+++ b/products/pathway/test/job-description.test.js
@@ -1,0 +1,88 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+
+import { formatJobDescription } from "../src/formatters/job/description.js";
+
+// Minimal template that renders only the capability skill sections, enough to
+// assert which proficiency levels reach the job description.
+const TEMPLATE = [
+  "{{#capabilitySkills}}",
+  "## {{capabilityHeading}}",
+  "{{#skills}}- {{skillName}}",
+  "{{/skills}}",
+  "{{/capabilitySkills}}",
+].join("\n");
+
+const LEVEL = { id: "J070", typicalExperienceRange: "8+ years" };
+
+/**
+ * Build a job with capabilities spread across three descending proficiencies.
+ * @returns {Object}
+ */
+function makeJob() {
+  return {
+    title: "Test Role",
+    expectations: {},
+    behaviourProfile: [],
+    derivedResponsibilities: [
+      {
+        capability: "lead",
+        capabilityName: "Leadership",
+        responsibility: "Lead",
+        proficiency: "expert",
+      },
+      {
+        capability: "people",
+        capabilityName: "People",
+        responsibility: "Grow people",
+        proficiency: "practitioner",
+      },
+      {
+        capability: "delivery",
+        capabilityName: "Delivery",
+        responsibility: "Deliver",
+        proficiency: "working",
+      },
+    ],
+    skillMatrix: [
+      { capability: "lead", proficiency: "expert", skillName: "Vision Setting" },
+      { capability: "people", proficiency: "practitioner", skillName: "Coaching" },
+      { capability: "delivery", proficiency: "working", skillName: "Planning" },
+    ],
+  };
+}
+
+/**
+ * Render a job description for a discipline.
+ * @param {Object} discipline
+ * @returns {string}
+ */
+function render(discipline) {
+  return formatJobDescription(
+    { job: makeJob(), discipline, level: LEVEL, track: null },
+    TEMPLATE,
+  );
+}
+
+describe("formatJobDescription capability skills", () => {
+  const baseDiscipline = {
+    roleTitle: "Engineer",
+    specialization: "Software",
+    description: "Builds software.",
+  };
+
+  test("individual-contributor jobs show only the top proficiency level", () => {
+    const output = render({ ...baseDiscipline, isManagement: false });
+    assert.ok(output.includes("Vision Setting"));
+    assert.ok(!output.includes("Coaching"));
+    assert.ok(!output.includes("Planning"));
+  });
+
+  test("management jobs show the top two proficiency levels", () => {
+    const output = render({ ...baseDiscipline, isManagement: true });
+    assert.ok(output.includes("Vision Setting"));
+    assert.ok(output.includes("Coaching"));
+    // The third level stays out so descriptions do not run long.
+    assert.ok(!output.includes("Planning"));
+  });
+});


### PR DESCRIPTION
## Summary

- Management job descriptions only rendered skills from the single highest proficiency level, which left them sparse because management roles concentrate fewer skills at the top.
- `buildCapabilitySkills` now includes the top **two** distinct proficiency levels for management disciplines (`isManagement`), while individual-contributor jobs keep the top level only.
- Skills are filtered per capability at that capability's own responsibility proficiency, so a capability shown at the second level keeps its second-level skills.

## Test plan

- [x] `bun test` — new `products/pathway/test/job-description.test.js` covers IC (one level) and management (two levels) rendering; existing pathway + libskill suites pass.
- [ ] `bun run check`
- [ ] `bun run test`