### PR TITLE
fix(map): allow "Senior Staff"/"Senior Principal" professional titles

### DIFF
--- a/libraries/libsyntheticprose/src/prompts/pathway/level.js
+++ b/libraries/libsyntheticprose/src/prompts/pathway/level.js
@@ -46,7 +46,7 @@ export function buildLevelPrompt(levels, ctx, schema) {
       "- Output a JSON array of level objects.",
       "- For each level, generate:",
       "  - id: Use the provided ID (uppercase, e.g., J040).",
-      '  - professionalTitle: A single capitalised rank word (e.g. "Associate", "Senior", "Staff", "Principal") OR "Level <roman>" / "Level <digit>".',
+      '  - professionalTitle: A single capitalised rank word (e.g. "Associate", "Senior", "Staff", "Principal"), a seniority-qualified rank ("Senior Staff" / "Senior Principal"), OR "Level <roman>" / "Level <digit>".',
       "    When the level skeleton supplies professionalTitle, pass it through verbatim.",
       '    Otherwise emit "Level <roman>" derived from the supplied rank (1→I, 2→II, …).',
       '    NEVER emit a multi-word role-complete title (e.g. "Senior Engineer") — the discipline supplies the role.',

--- a/products/map/src/validation/level.js
+++ b/products/map/src/validation/level.js
@@ -223,14 +223,15 @@ export function validateCapability(capability, index) {
 export const CONTRACT_URL =
   "https://www.forwardimpact.team/docs/products/authoring-standards/index.md#level-field-conventions";
 
-const PROFESSIONAL_TITLE_SHAPE = /^(?:Level [IVX]+|Level \d+|[A-Z][a-z]+)$/;
+const PROFESSIONAL_TITLE_SHAPE =
+  /^(?:Level [IVX]+|Level \d+|Senior (?:Staff|Principal)|[A-Z][a-z]+)$/;
 
 /** @param {string} value */
 export function checkProfessionalTitleShape(value) {
   if (typeof value !== "string" || !PROFESSIONAL_TITLE_SHAPE.test(value)) {
     return {
       ok: false,
-      reason: `professionalTitle must be a single capitalised rank word or "Level <numeral>"; got ${JSON.stringify(value)}`,
+      reason: `professionalTitle must be a single capitalised rank word, a "Senior Staff"/"Senior Principal" seniority-qualified rank, or "Level <numeral>"; got ${JSON.stringify(value)}`,
     };
   }
   return { ok: true };

--- a/products/map/test/validation-level.test.js
+++ b/products/map/test/validation-level.test.js
@@ -18,12 +18,15 @@ describe("checkProfessionalTitleShape", () => {
     "Staff",
     "Principal",
     "Distinguished",
+    "Senior Staff",
+    "Senior Principal",
   ]) {
     test(`accepts ${JSON.stringify(ok)}`, () =>
       assert.equal(checkProfessionalTitleShape(ok).ok, true));
   }
   for (const bad of [
     "Senior Engineer",
+    "Senior Manager",
     "Engineer I",
     "engineer",
     "",


### PR DESCRIPTION
## Problem

`professionalTitle` validation (`products/map/src/validation/level.js`) only
accepted a single capitalised rank word or `Level <numeral>`. Downstream
installations that use seniority-qualified ranks — e.g. **Senior Principal**
stacked above **Principal** — fail validation:

```
INVALID_VALUE: professionalTitle must be a single capitalised rank word or
"Level <numeral>"; got "Senior Principal"
```

Surfaced by the Pfizer FIT installation renaming level J110 from
`Distinguished` to `Senior Principal`.

## Change

Extend the shape regex with a **closed allowlist** of recognised
seniority-qualified ranks:

```js
/^(?:Level [IVX]+|Level \d+|Senior (?:Staff|Principal)|[A-Z][a-z]+)$/
```

This deliberately does **not** open the door to arbitrary `Senior <Word>`
titles. The existing guardrail stays intact — role-complete titles like
`Senior Engineer` / `Senior Manager` are still rejected, so the discipline
remains the sole source of the role word (per the prose-prompt convention).

Also updates the `libsyntheticprose` level prompt to document the same
allowance, and adds unit coverage for both the accepted and rejected forms.

## Tests

- `products/map/test/validation-level.test.js` — 39 pass (adds `Senior Staff`,
  `Senior Principal` to accepts; `Senior Manager` to rejects)
- `products/map/test/validation-all-data.test.js` — pass (message-shape assertion
  preserved)
- `libraries/libsyntheticprose/test/prompts-pathway-level.test.js` — 2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)