### PR TITLE
feat(monorepo-setup): add bootstrap skill + monorepo-skills pack

### DIFF
--- a/.claude/skills/monorepo-setup/SKILL.md
+++ b/.claude/skills/monorepo-setup/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: monorepo-setup
+description: >
+  Stand up a new MONOREPO.md-compliant repository end to end — bootstrap the
+  skeleton, install the skill packs, run coaligned-setup then kata-setup, and
+  fill the seams neither owns (root package.json, directory tree, agent
+  profiles, CI, remote creation). Use when creating a Forward Impact-style repo
+  from nothing, or when one exists but the cross-cutting wiring is missing.
+---
+
+# monorepo-setup
+
+Orchestrate a full repository bootstrap to the three standards: structure
+([MONOREPO.md](https://github.com/forwardimpact/monorepo/blob/main/MONOREPO.md)),
+instruction architecture (via the `coaligned-setup` skill), and the agent team
+(via the `kata-setup` skill).
+
+This skill owns only the **seams** — the order of operations and the artifacts
+the two setup skills assume but never create. It does not restate their
+procedures: when a sub-skill changes, follow it; this skill stays put. Run it
+once per repository.
+
+## Procedure
+
+<read_do_checklist goal="Confirm the ground before touching the repo">
+
+- [ ] `gh auth status` shows access to the target owner; `apm` is on PATH.
+- [ ] The target repo does not exist yet (`gh repo view <owner>/<name>`).
+- [ ] Decide name, visibility, and timezone before generating anything.
+
+</read_do_checklist>
+
+### Step 1 — Bootstrap the skeleton
+
+`git init`, default branch `main`, then the seam files from
+[references/repo-skeleton.md](references/repo-skeleton.md): `.gitignore` and the
+MONOREPO.md top-level directories, each with a `README.md` naming its jobs.
+See [MONOREPO.md] for what each directory is for — do not invent structure.
+Commit.
+
+### Step 2 — Add the root package.json
+
+Create the root manifest from [references/repo-skeleton.md]. This is the seam
+`coaligned-setup` assumes: it wires `npx coaligned` into the check task but
+never creates the manifest. The `coaligned` bin ships only inside
+`@forwardimpact/libcoaligned` (no bare launcher), so add it as a devDependency,
+pinned to a release whose budgets exempt YAML frontmatter (0.1.15+) — otherwise
+the published skill packs breach the instruction caps.
+
+### Step 3 — Install the skill packs
+
+```sh
+apm install forwardimpact/coaligned-skills forwardimpact/kata-skills --target claude
+```
+
+Both sub-skills assume their packs sit in `.claude/skills/`. APM integrates
+skills only — confirm the kata **agent profiles** also landed in
+`.claude/agents/`. If missing, copy them from the kata-skills repo
+(`agents/*.agent.md` → `.claude/agents/<name>.md`, with `agents/references/`).
+
+### Step 4 — Run coaligned-setup, then kata-setup
+
+Run the `coaligned-setup` skill to completion, then the `kata-setup` skill.
+Order matters: the root identity files exist before the agent team references
+them. Each skill owns its domain end to end — follow them, do not duplicate
+their steps here. Answer their configuration prompts with the choices from the
+entry checklist.
+
+### Step 5 — Add the check CI
+
+`coaligned-setup` wires `coaligned` into the check task; add a CI workflow that
+runs it on push and pull request — separate from the agent workflows
+`kata-setup` generates. SHA-pin every action. Template in
+[references/repo-skeleton.md].
+
+### Step 6 — Create and seed the remote
+
+`gh repo create <owner>/<name> --source=. --push` at the chosen visibility, then
+enable the wiki and **pre-engage the killswitch** (`gh variable set
+KATA_KILLSWITCH --body 1`) so the agent workflows stay dormant until the
+operator finishes `kata-setup`'s App and secret steps. Those credential-bound
+steps cannot run from here — record them in an operator runbook (`SETUP.md`).
+
+### Step 7 — Verify the composition
+
+Run the check task: `coaligned` passes clean with the vendored packs and agent
+profiles present. Confirm `gh workflow list` shows the generated workflows.
+
+## Done When
+
+<do_confirm_checklist goal="Verify the repo stands before handing off">
+
+- [ ] Git, the root `package.json`, and the MONOREPO.md directory tree exist.
+- [ ] Both skill packs and the kata agent profiles are under `.claude/`.
+- [ ] `coaligned-setup` and `kata-setup` both completed.
+- [ ] The check task and CI run `coaligned` clean.
+- [ ] The remote exists, the wiki is on, and `KATA_KILLSWITCH` is engaged.
+- [ ] `SETUP.md` lists the operator's remaining credential steps.
+
+</do_confirm_checklist>
+
+## Documentation
+
+- [MONOREPO.md] — repository structure and the JTBD convention.
+- [COALIGNED.md](https://github.com/forwardimpact/monorepo/blob/main/COALIGNED.md) —
+  the layered instruction architecture (owned by `coaligned-setup`).
+- [KATA.md](https://github.com/forwardimpact/monorepo/blob/main/KATA.md) — the
+  agent team and its PDSA loop (owned by `kata-setup`).
+- [APM](https://microsoft.github.io/apm/) — the package manager that installs
+  the skill packs.
+
+[MONOREPO.md]: https://github.com/forwardimpact/monorepo/blob/main/MONOREPO.md

--- a/.claude/skills/monorepo-setup/references/repo-skeleton.md
+++ b/.claude/skills/monorepo-setup/references/repo-skeleton.md
@@ -1,0 +1,73 @@
+# Repo skeleton
+
+Copy-paste seam artifacts for [monorepo-setup](../SKILL.md) Steps 1, 2, and 5 —
+the files neither `coaligned-setup` nor `kata-setup` creates. Rename to the
+repo; do not commit the lockfile until the pinned `@forwardimpact/*` versions
+are published.
+
+## Directory layout
+
+Per MONOREPO.md. Create only what the repo will use; each shippable directory
+carries a `README.md` naming its jobs.
+
+- `products/` `services/` `libraries/` — shippable code (README each).
+- `websites/` — docs hub. `infrastructure/` — deployment assets.
+- `wiki/` — Kata memory, a separate checkout; gitignored, never created here.
+
+## .gitignore
+
+```gitignore
+node_modules/
+.env
+*.log
+wiki/             # Kata memory: separate checkout, cloned on demand
+dist/
+build/
+generated/
+apm_modules/      # APM writes this on first install
+```
+
+## package.json
+
+```json
+{
+  "name": "<repo>",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": [
+    "products/*/cli",
+    "products/*/site",
+    "products/*/handlers",
+    "libraries/*"
+  ],
+  "scripts": { "check": "coaligned" },
+  "devDependencies": { "@forwardimpact/libcoaligned": "^0.1.15" }
+}
+```
+
+`coaligned` resolves from this devDependency — there is no bare npm launcher.
+Pin a version whose budgets exempt YAML frontmatter (0.1.15+); published skill
+packs carry publish-injected frontmatter that otherwise breaches the caps.
+
+## .github/workflows/check.yml
+
+```yaml
+name: check
+on:
+  push: { branches: [main] }
+  pull_request:
+permissions: { contents: read }
+jobs:
+  coaligned:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha> # v4
+      - uses: actions/setup-node@<sha> # v4
+        with: { node-version: "22" }
+      - run: npm ci
+      - run: npx coaligned
+```
+
+Resolve `<sha>` for each action at generation time (`gh api
+repos/<action>/git/ref/tags/<tag>`) and pin it. The `github-actions` Dependabot
+entry that `kata-setup` adds keeps these pins fresh.

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -7,6 +7,7 @@ on:
       - ".claude/skills/fit-*/**"
       - ".claude/skills/kata-*/**"
       - ".claude/skills/coaligned-*/**"
+      - ".claude/skills/monorepo-*/**"
       - ".claude/agents/*.md"
       - ".claude/agents/references/**"
       - "products/gear/package.json"
@@ -64,6 +65,19 @@ jobs:
               Forward Impact Kata Agent Team — domain agents and skills for the
               spec → design → plan → implement workflow, releases, security, and
               product-issue triage.
+          - prefix: monorepo
+            repo: monorepo-skills
+            version-file: products/gear/package.json
+            sync-agents: "false"
+            readme-title: Monorepo Skills
+            readme-intro: >-
+              Skills for standing up and maintaining a
+              [Forward Impact](https://forwardimpact.team)-style monorepo — the
+              cross-cutting setup that composes the Co-Aligned and Kata packs.
+            apm-description: >-
+              Skills for bootstrapping a Forward Impact-style monorepo end to
+              end — repository structure, instruction architecture, and the Kata
+              Agent Team — composing the Co-Aligned and Kata packs.
     steps:
       - name: Generate installation token
         id: ci-app


### PR DESCRIPTION
## Summary

- Add the `monorepo-setup` skill (`.claude/skills/monorepo-setup/`) — orchestrates an end-to-end MONOREPO.md-compliant repo bootstrap (skeleton → `apm install` packs → `coaligned-setup` → `kata-setup`), filling only the seams neither sub-skill owns: root `package.json` + the `coaligned` devDependency, the directory tree, agent profiles, the check CI, and remote creation with the killswitch pre-engaged. It delegates to `coaligned-setup`/`kata-setup` so those evolve independently.
- Add a `monorepo` pack to `publish-skills.yml` (matrix entry + `.claude/skills/monorepo-*/**` path trigger) that syncs into the new `forwardimpact/monorepo-skills` sibling repo, mirroring fit/coaligned/kata. Future `monorepo-*` skills are picked up by the prefix glob.

Distilled from a live `forwardimpact/bionova-apps` bootstrap — the seam list is exactly the gaps hit there.

## Operator follow-up

- Install the `kata-agent-team` GitHub App on `forwardimpact/monorepo-skills`, or the publish job 403s when minting its sibling-scoped token (others still publish — `fail-fast: false`). The pack syncs on merge to `main` (or manual `workflow_dispatch`).
- `monorepo-setup` references `@forwardimpact/libcoaligned` >= 0.1.15 (the frontmatter-exempt budget fix), a separate pending change — not in this PR.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
