### PR TITLE
fix(libcoaligned): exclude YAML frontmatter from instruction budgets

### DIFF
--- a/libraries/libcoaligned/src/instructions.js
+++ b/libraries/libcoaligned/src/instructions.js
@@ -23,6 +23,15 @@ const ITEM_SPLIT_RE = /^\s*-\s*\[[ xX]\]\s*/m;
 const lineCount = (text) => (text.match(/\n/g) || []).length;
 const wordCount = (text) => (text.match(/\S+/g) || []).length;
 
+// A leading YAML frontmatter block carries metadata, not instruction prose:
+// a skill's `name`/`description`, plus the `license` and `metadata` fields the
+// publish pipeline injects. Exclude it from the line/word budget so a published
+// copy of a layer counts the same as its in-repo source. Only a fenced block
+// that opens on the first line is stripped; the closing fence is the first
+// `---` line that follows.
+const FRONTMATTER_RE = /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n?/;
+const stripFrontmatter = (text) => text.replace(FRONTMATTER_RE, "");
+
 async function walk(root, dir, visit, fs) {
   let entries;
   try {
@@ -250,11 +259,13 @@ async function buildFileSubjects(root, layers, fs) {
     for (const relPath of layer.files) {
       const text = await readText(root, relPath, fs);
       if (text == null) continue;
+      // Budget the instruction prose only — metadata frontmatter is exempt.
+      const body = stripFrontmatter(text);
       subjects.push({
         path: resolve(root, relPath),
         layer: { id: layer.id, name: layer.name },
-        lines: lineCount(text),
-        words: wordCount(text),
+        lines: lineCount(body),
+        words: wordCount(body),
         maxLines: layer.maxLines,
         maxWords: layer.maxWords,
       });

--- a/libraries/libcoaligned/test/instructions.test.js
+++ b/libraries/libcoaligned/test/instructions.test.js
@@ -193,4 +193,50 @@ describe("checkInstructions", () => {
     assert.ok(f.path.endsWith(".claude/skills/demo/SKILL.md"));
     assert.ok(typeof f.lineNo === "number" && f.lineNo > 0);
   });
+
+  test("excludes YAML frontmatter from the line budget", async () => {
+    // 8 frontmatter lines + a 190-line body = 198 raw lines, but only the
+    // body counts against the 192-line L1 cap. Mirrors a published skill whose
+    // source body fits but whose injected `license`/`metadata` push it over.
+    const frontmatter = [
+      "---",
+      "name: demo",
+      "description: >",
+      "  a skill",
+      "license: Apache-2.0",
+      "metadata:",
+      '  version: "0.1.0"',
+      "---",
+    ].join("\n");
+    const body = `\n${"line\n".repeat(190)}`;
+    const findings = await checkInstructions({
+      root: ROOT,
+      runtime: runtimeWith({ [`${ROOT}/CLAUDE.md`]: frontmatter + body }),
+    });
+    const f = findings.find(
+      (x) =>
+        x.id === "instructions.line-budget" && x.path.endsWith("CLAUDE.md"),
+    );
+    assert.equal(
+      f,
+      undefined,
+      `frontmatter must not count toward the budget, got: ${JSON.stringify(findings)}`,
+    );
+  });
+
+  test("flags body overage and reports the body line count, not raw", async () => {
+    const frontmatter = ["---", "name: demo", "---"].join("\n");
+    const body = `\n${"line\n".repeat(200)}`;
+    const findings = await checkInstructions({
+      root: ROOT,
+      runtime: runtimeWith({ [`${ROOT}/CLAUDE.md`]: frontmatter + body }),
+    });
+    const f = findings.find(
+      (x) =>
+        x.id === "instructions.line-budget" && x.path.endsWith("CLAUDE.md"),
+    );
+    assert.ok(f, `expected a line-budget finding, got: ${JSON.stringify(findings)}`);
+    // The body is 200 lines; the 3 frontmatter lines are excluded.
+    assert.match(f.message, /200 lines/);
+  });
 });


### PR DESCRIPTION
## Summary

- The L1–L6 line/word caps are meant to budget instruction **prose**, but published skill packs carry publish-injected frontmatter (`license` + `metadata`) absent from the source. Counting it pushes conformant skills over the cap in any repo that vendors the packs (e.g. the 21 packs installed into a fresh consumer all tripped the line cap by ~4 lines).
- Strip a leading YAML frontmatter block before counting lines and words, so a published copy budgets the same as its in-repo source. Body overage is still flagged and still reported at the body line count.
- Adds two tests; the monorepo's own `instructions` check stays green (only gains headroom).

The version bump to 0.1.15 + npm publish is intentionally left to `kata-release-cut`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)