### PR TITLE
chore(monorepo-setup): split CI into per-concern checks and seed the wiki

### DIFF
--- a/.claude/skills/monorepo-setup/SKILL.md
+++ b/.claude/skills/monorepo-setup/SKILL.md
@@ -68,12 +68,13 @@ entry checklist.
 
 ### Step 5 — Add the check CI
 
-`coaligned-setup` wires `coaligned` into the check task; add a CI workflow that
-runs it on push and pull request — separate from the agent workflows
-`kata-setup` generates. SHA-pin every action. Template in
-[references/repo-skeleton.md].
+`coaligned-setup` wires `coaligned` into the check task; add the check workflows
+that run on push and pull request — separate from the agent workflows
+`kata-setup` generates. One workflow per concern, never a single `check.yml`: at
+minimum `check-quality.yml`, `check-test.yml`, and `check-context.yml`. SHA-pin
+every action. Templates in [references/check-workflows.md].
 
-### Step 6 — Create and seed the remote
+### Step 6 — Create the remote, then seed and initialize the wiki
 
 `gh repo create <owner>/<name> --source=. --push` at the chosen visibility, then
 enable the wiki and **pre-engage the killswitch** (`gh variable set
@@ -81,10 +82,16 @@ KATA_KILLSWITCH --body 1`) so the agent workflows stay dormant until the
 operator finishes `kata-setup`'s App and secret steps. Those credential-bound
 steps cannot run from here — record them in an operator runbook (`SETUP.md`).
 
+Then stand up the agent team's memory: add the `.claude/settings.json` wiki
+hooks, `fit-wiki init` the wiki, seed the three named ledgers (`Home.md`,
+`MEMORY.md`, `STATUS.md`) empty-but-scaffolded, and `fit-wiki push`. Full
+sequence in [references/wiki-init.md].
+
 ### Step 7 — Verify the composition
 
 Run the check task: `coaligned` passes clean with the vendored packs and agent
-profiles present. Confirm `gh workflow list` shows the generated workflows.
+profiles present. Confirm `gh workflow list` shows the generated workflows, and
+that the wiki clones with its three ledgers via `fit-wiki pull`.
 
 ## Done When
 
@@ -93,8 +100,11 @@ profiles present. Confirm `gh workflow list` shows the generated workflows.
 - [ ] Git, the root `package.json`, and the MONOREPO.md directory tree exist.
 - [ ] Both skill packs and the kata agent profiles are under `.claude/`.
 - [ ] `coaligned-setup` and `kata-setup` both completed.
-- [ ] The check task and CI run `coaligned` clean.
+- [ ] The check workflows exist (`check-quality`, `check-test`, `check-context`)
+      and `coaligned` runs clean.
 - [ ] The remote exists, the wiki is on, and `KATA_KILLSWITCH` is engaged.
+- [ ] `.claude/settings.json` drives the wiki lifecycle, and the wiki holds
+      `Home.md`, `MEMORY.md`, and `STATUS.md`.
 - [ ] `SETUP.md` lists the operator's remaining credential steps.
 
 </do_confirm_checklist>

--- a/.claude/skills/monorepo-setup/references/check-workflows.md
+++ b/.claude/skills/monorepo-setup/references/check-workflows.md
@@ -1,0 +1,128 @@
+# Check workflows
+
+Copy-paste CI for [monorepo-setup](../SKILL.md) Step 5 — the check workflows
+that run on push and pull request. One workflow per concern, never a single
+`check.yml`: a failing format run and a failing test run must read as two
+distinct red checks. Add concerns (build, data, security) as the repo grows.
+
+All share the same trigger and least-privilege permission, and pin every action
+by SHA — resolve `<sha>` at generation time (`gh api
+repos/<action>/git/ref/tags/<tag>`); the `github-actions` Dependabot entry
+`kata-setup` adds keeps the pins fresh. Commands are the repo's own scripts
+(`npm run format`, `npm test`, …); adjust names to the root `package.json`.
+
+## .github/workflows/check-quality.yml
+
+```yaml
+name: Quality
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha> # v4
+      - uses: actions/setup-node@<sha> # v4
+        with: { node-version: "22" }
+      - run: npm ci
+      - run: npm run format
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha> # v4
+      - uses: actions/setup-node@<sha> # v4
+        with: { node-version: "22" }
+      - run: npm ci
+      - run: npm run lint
+```
+
+## .github/workflows/check-test.yml
+
+```yaml
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha> # v4
+      - uses: actions/setup-node@<sha> # v4
+        with: { node-version: "22" }
+      - run: npm ci
+      - run: npm test
+```
+
+## .github/workflows/check-context.yml
+
+This is the workflow `coaligned-setup` assumes: it wires `coaligned` into the
+check task but never adds CI. One job per `coaligned` subcommand so a layered
+instruction breach, a stale JTBD block, and an invariant violation each surface
+as their own red check.
+
+```yaml
+name: Context
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  instructions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha> # v4
+      - uses: actions/setup-node@<sha> # v4
+        with: { node-version: "22" }
+      - run: npm ci
+      - run: npx coaligned instructions
+
+  jtbd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha> # v4
+      - uses: actions/setup-node@<sha> # v4
+        with: { node-version: "22" }
+      - run: npm ci
+      - run: npx coaligned jtbd
+
+  invariants:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha> # v4
+      - uses: actions/setup-node@<sha> # v4
+        with: { node-version: "22" }
+      - run: npm ci
+      - run: npx coaligned invariants
+```
+
+## Why the wiki audit is not a check here
+
+`fit-wiki audit` reads the live, shared wiki, so its verdict is a function of
+the current wiki state, not the PR head — it would redden a clean commit
+whenever the shared wiki happens to be dirty, and flip on re-run with no code
+change. Keep it out of the per-PR gate. A scheduled curation run owns live-wiki
+findings and routes them to a single curation issue (see `kata-setup`). A
+commit-status check may verify only surfaces the PR's diff fully determines.

--- a/.claude/skills/monorepo-setup/references/repo-skeleton.md
+++ b/.claude/skills/monorepo-setup/references/repo-skeleton.md
@@ -1,9 +1,10 @@
 # Repo skeleton
 
-Copy-paste seam artifacts for [monorepo-setup](../SKILL.md) Steps 1, 2, and 5 —
-the files neither `coaligned-setup` nor `kata-setup` creates. Rename to the
-repo; do not commit the lockfile until the pinned `@forwardimpact/*` versions
-are published.
+Copy-paste seam artifacts for [monorepo-setup](../SKILL.md) Steps 1 and 2 — the
+skeleton files neither `coaligned-setup` nor `kata-setup` creates. CI templates
+live in [check-workflows.md](check-workflows.md) (Step 5); the wiki lifecycle
+and ledgers in [wiki-init.md](wiki-init.md) (Step 6). Rename to the repo; do not
+commit the lockfile until the pinned `@forwardimpact/*` versions are published.
 
 ## Directory layout
 
@@ -49,25 +50,14 @@ apm_modules/      # APM writes this on first install
 Pin a version whose budgets exempt YAML frontmatter (0.1.15+); published skill
 packs carry publish-injected frontmatter that otherwise breaches the caps.
 
-## .github/workflows/check.yml
+## Check workflows
 
-```yaml
-name: check
-on:
-  push: { branches: [main] }
-  pull_request:
-permissions: { contents: read }
-jobs:
-  coaligned:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@<sha> # v4
-      - uses: actions/setup-node@<sha> # v4
-        with: { node-version: "22" }
-      - run: npm ci
-      - run: npx coaligned
-```
+Never a single `check.yml`. Generate one workflow per concern — at minimum
+`check-quality.yml`, `check-test.yml`, and `check-context.yml`. Templates and
+the SHA-pinning rule are in [check-workflows.md](check-workflows.md).
 
-Resolve `<sha>` for each action at generation time (`gh api
-repos/<action>/git/ref/tags/<tag>`) and pin it. The `github-actions` Dependabot
-entry that `kata-setup` adds keeps these pins fresh.
+## Wiki lifecycle and ledgers
+
+The `.claude/settings.json` hooks that drive the wiki and the three named
+ledgers (`Home.md`, `MEMORY.md`, `STATUS.md`) are in
+[wiki-init.md](wiki-init.md).

--- a/.claude/skills/monorepo-setup/references/wiki-init.md
+++ b/.claude/skills/monorepo-setup/references/wiki-init.md
@@ -1,0 +1,116 @@
+# Wiki init
+
+Copy-paste seam artifacts for [monorepo-setup](../SKILL.md) Step 6 — standing up
+the agent team's persistent memory. The wiki is a separate git repository (the
+GitHub Wiki of the repo, `<repo>.wiki.git`) cloned into `wiki/` and gitignored,
+so it is never created by the bootstrap commit. Neither `coaligned-setup` nor
+`kata-setup` seeds it; this skill does.
+
+Two pieces: a minimal `.claude/settings.json` that drives the wiki lifecycle
+through Claude Code hooks, and the three named-ledger files (`Home.md`,
+`MEMORY.md`, `STATUS.md`) scaffolded empty so the first agent run reads a valid
+wiki instead of an empty clone.
+
+## .claude/settings.json
+
+The lifecycle is two moves: pull the shared wiki down before a session reads
+it, push local changes back when the session stops. `init` clones the wiki on
+first run and is idempotent after.
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx fit-wiki init" },
+          { "type": "command", "command": "npx fit-wiki pull" }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [{ "type": "command", "command": "npx fit-wiki init" }]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [{ "type": "command", "command": "npx fit-wiki push" }]
+      }
+    ]
+  }
+}
+```
+
+If `coaligned-setup` or `kata-setup` already wrote `.claude/settings.json`,
+merge these hook arrays into it rather than overwriting — do not drop their
+keys. `fit-wiki init` may install the `Stop` push hook itself; if it is already
+present, leave the single copy in place.
+
+## Seed the named ledgers
+
+The wiki needs its three named ledgers before the first agent boots. Create
+them under `wiki/`, then let `init` finish the scaffold and `push` publish it:
+
+1. Enable the wiki on the remote and create its first page (any content) so the
+   `<repo>.wiki.git` repository exists — an empty wiki has no git repo to clone.
+2. `npx fit-wiki init` — clones the wiki into `wiki/`, creates
+   `wiki/metrics/<skill>/` directories for each installed skill, and appends the
+   `## Active Claims` table to `MEMORY.md`.
+3. Write the three files below into `wiki/` (Step 2 leaves `MEMORY.md` with only
+   the Active Claims block if it did not exist; write the full template, then
+   re-run `init` to re-append Active Claims if needed).
+4. `npx fit-wiki push` — publishes the seeded ledgers.
+
+Each file is empty apart from scaffolding: a heading, a one-line description of
+what the surface is for, and an empty table or fence. Agents and `fit-wiki`
+fill them; do not hand-write state.
+
+### wiki/Home.md
+
+The wiki landing page. Names the surfaces an agent will read.
+
+```markdown
+# <repo> — Wiki
+
+Persistent memory for the agent team. Managed by `fit-wiki`; do not hand-edit a
+ledger a command owns.
+
+- **MEMORY.md** — cross-cutting priorities and active claims.
+- **STATUS.md** — canonical approval record, one row per spec.
+- `<agent>.md` — per-agent summary and message inbox.
+- `storyboard-<YYYY>-M<NN>.md` — monthly storyboard.
+- `metrics/<skill>/<YYYY>.csv` — per-skill run metrics.
+```
+
+### wiki/MEMORY.md
+
+Cross-cutting priorities the whole team reads on boot. `fit-wiki init` appends
+the `## Active Claims` table after this block; leave room for it.
+
+```markdown
+## Cross-Cutting Priorities
+
+| Item | Agents | Owner | Status | Added |
+| --- | --- | --- | --- | --- |
+| *None* | — | — | — | — |
+```
+
+### wiki/STATUS.md
+
+The canonical approval record. One row per spec inside the fence, tab-separated:
+`<id><TAB><phase><TAB><status>`. Phase is one of `spec`, `design`, `plan`;
+status is one of `draft`, `approved`, `implemented`, `cancelled`. Scaffold it
+with an empty fence — the first spec adds the first row.
+
+````markdown
+# Approval Record
+
+Canonical approval state for every spec, read by the release gate at merge time.
+One row per spec inside the fence: `<id><TAB><phase><TAB><status>`. Phase is
+`spec` | `design` | `plan`; status is `draft` | `approved` | `implemented` |
+`cancelled`.
+
+```
+```
+````


### PR DESCRIPTION
## Summary

- Replace the single `check.yml` template with one workflow per concern: a new `references/check-workflows.md` carries `check-quality.yml` (format, lint), `check-test.yml` (test), and `check-context.yml` (one job per `coaligned` subcommand — instructions, jtbd, invariants). Generalized from the monorepo's `check-*` workflows onto the portable npm/npx toolchain, with a note on why a live-wiki audit is not a per-PR gate.
- Add wiki setup + initialization: a new `references/wiki-init.md` carries a minimal `.claude/settings.json` that drives the wiki lifecycle (init+pull on SessionStart/WorktreeCreate, push on Stop) and scaffolds the three named ledgers empty-but-valid — `Home.md`, the `MEMORY.md` Cross-Cutting Priorities table, and the `STATUS.md` approval-record fence.
- Wire the two new references into `SKILL.md` (Step 5 = check workflows; Step 6 = create remote, then seed and initialize the wiki) and `repo-skeleton.md`; update the Done-When checklist.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8kq7qds21hVLXTsQLn7Do

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8kq7qds21hVLXTsQLn7Do)_