### PR TITLE
fix(skill-packs): publish under .apm/ so APM installs agents, via a fit-pack CLI

### DIFF
--- a/.claude/skills/fit-pack/SKILL.md
+++ b/.claude/skills/fit-pack/SKILL.md
@@ -26,10 +26,10 @@ agents together.
 
 ## Layout it produces
 
-Run `npx fit-pack sync` against a checked-out target repository:
+Run `npx fit-pack stage` against a checked-out target repository:
 
 ```sh
-npx fit-pack sync \
+npx fit-pack stage \
   --from .claude \
   --prefix <pack> \
   --into <target-repo> \
@@ -56,13 +56,13 @@ It writes into `<target-repo>`:
 
 1. **Check out the target repository** you publish the pack from. `fit-pack`
    writes into its working tree; it does not commit or push.
-2. **Stage** with `npx fit-pack sync`. Pass `--prefix` to select which skills
+2. **Stage** with `npx fit-pack stage`. Pass `--prefix` to select which skills
    ship (`--prefix kata` selects `skills/kata-*`). Omit `--with-agents` for a
    skills-only pack; references still ship.
 3. **Review** the generated `.apm/` tree, `apm.yml`, and `README.md`.
 4. **Commit and push** the target repository, then tag the release.
 
-A re-sync retires any earlier flat `skills/` or `agents/` layout, so migrating
+Re-staging retires any earlier flat `skills/` or `agents/` layout, so migrating
 an existing pack repository is a single run.
 
 ## Documentation

--- a/.claude/skills/fit-pack/SKILL.md
+++ b/.claude/skills/fit-pack/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: fit-pack
+description: >
+  Distribute a skill pack so agents and engineers can install it through their
+  package manager. Use when publishing skills and agents to a shared repository,
+  when a bare install pulls skills but silently drops agents, or when you need
+  the install to land in APM's conventional layout. Stages skills, agents, and
+  references into one repository tree with a generated manifest and README.
+---
+
+# Distribute Skill Packs
+
+`fit-pack` stages a set of skills and agent profiles into a repository in the
+layout package managers expect, then you commit and push that repository as the
+installable pack. It exists so one tested code path owns the layout — the same
+shape an installer reads, every time.
+
+## When this matters
+
+A pack repository whose skills sit in a root `skills/` directory installs its
+skills fine, but agents placed in a sibling `agents/` directory install for
+nobody: the installer never scans there. Agents must live under `.apm/agents/`
+with an `.agent.md` suffix, and skills under `.apm/skills/`. `fit-pack` writes
+exactly that layout so a bare `apm install <owner>/<repo>` pulls skills and
+agents together.
+
+## Layout it produces
+
+Run `npx fit-pack sync` against a checked-out target repository:
+
+```sh
+npx fit-pack sync \
+  --from .claude \
+  --prefix <pack> \
+  --into <target-repo> \
+  --name <package-name> \
+  --pack-version <version> \
+  --with-agents \
+  --description "<one line>" \
+  --readme-title "<title>" \
+  --readme-intro "<intro>"
+```
+
+It writes into `<target-repo>`:
+
+- `.apm/skills/<name>/` — every `skills/<pack>-*` directory from `--from`, with
+  `license` and a `metadata` version block injected into each `SKILL.md`.
+- `.apm/agents/<name>.agent.md` — each `agents/*.md` profile, renamed to the
+  `.agent.md` suffix the installer discovers (only with `--with-agents`).
+- `.apm/agents/references/` — shared reference files that skills and profiles
+  cite, shipped for every pack.
+- `apm.yml` — the package manifest (`name`, `version`, `description`).
+- `README.md` — install command and a table of the staged skills and agents.
+
+## Sequence
+
+1. **Check out the target repository** you publish the pack from. `fit-pack`
+   writes into its working tree; it does not commit or push.
+2. **Stage** with `npx fit-pack sync`. Pass `--prefix` to select which skills
+   ship (`--prefix kata` selects `skills/kata-*`). Omit `--with-agents` for a
+   skills-only pack; references still ship.
+3. **Review** the generated `.apm/` tree, `apm.yml`, and `README.md`.
+4. **Commit and push** the target repository, then tag the release.
+
+A re-sync retires any earlier flat `skills/` or `agents/` layout, so migrating
+an existing pack repository is a single run.
+
+## Documentation
+
+- [Distribute Skill Packs](https://www.forwardimpact.team/docs/libraries/distribute-skill-packs/index.md)
+  — Stage a skill pack into APM's .apm/ layout so a bare install pulls skills
+  and agents together

--- a/.claude/skills/kata-setup/SKILL.md
+++ b/.claude/skills/kata-setup/SKILL.md
@@ -25,7 +25,7 @@ facilitated sessions, and event-driven responses.
 - Node.js 18+
 - GitHub repository with Actions enabled
 - Anthropic API key
-- `npx skills add forwardimpact/kata-skills`
+- `apm install forwardimpact/kata-skills`
 
 ## Checklists
 
@@ -97,7 +97,7 @@ Ask these questions. Skip any already answered in the task prompt.
 
 7. **Agent profiles** — "Do you have custom agent profiles, or should I use the
    defaults from kata-skills?" If defaults, confirm
-   `npx skills add forwardimpact/kata-skills` is installed.
+   `apm install forwardimpact/kata-skills` is installed.
 
 8. **Control plane** — "Are you using the Forward Impact-hosted control
    plane, or self-hosting your own GitHub App?" Default: self-hosted. See

--- a/.github/actions/publish-skill-pack/action.yml
+++ b/.github/actions/publish-skill-pack/action.yml
@@ -55,154 +55,36 @@ runs:
         VERSION=$(jq -r '.version' "$VERSION_FILE")
         echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-    - name: Sync skills
+    # Stage the sibling repo's `.apm/` tree, apm.yml, and README in one tested
+    # code path. `fit-pack` (libpack) owns the APM layout — skills under
+    # `.apm/skills/`, agents under `.apm/agents/<name>.agent.md` — shared with
+    # the Pathway git packs so the two cannot drift. Workflows orchestrate;
+    # the staging logic lives in the library, not in walls of inline bash.
+    - name: Stage pack
       shell: bash
       env:
         PACK_PREFIX: ${{ inputs.pack-prefix }}
         TARGET_DIR: ${{ inputs.target-dir }}
-      run: |
-        inject_skill_frontmatter() {
-          local file="$1" version="$2"
-          awk -v ver="$version" '
-            NR == 1 && $0 == "---" { print; in_fm = 1; next }
-            in_fm && $0 == "---" {
-              print "license: Apache-2.0"
-              print "metadata:"
-              print "  version: \"" ver "\""
-              print "  author: forwardimpact"
-              print
-              in_fm = 0
-              next
-            }
-            { print }
-          ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
-        }
-
-        # Retire the pre-.apm/ flat layout so the migration leaves no stragglers.
-        rm -rf "$TARGET_DIR/skills" "$TARGET_DIR/agents"
-        rm -rf "$TARGET_DIR/.apm/skills"
-        mkdir -p "$TARGET_DIR/.apm/skills"
-        for skill_dir in ".claude/skills/${PACK_PREFIX}-"*/; do
-          skill_name=$(basename "$skill_dir")
-          cp -r "$skill_dir" "$TARGET_DIR/.apm/skills/$skill_name"
-          inject_skill_frontmatter "$TARGET_DIR/.apm/skills/$skill_name/SKILL.md" "$VERSION"
-        done
-
-    - name: Sync agents
-      if: inputs.sync-agents == 'true'
-      shell: bash
-      env:
-        TARGET_DIR: ${{ inputs.target-dir }}
-      run: |
-        rm -rf "$TARGET_DIR/.apm/agents"
-        mkdir -p "$TARGET_DIR/.apm/agents"
-        for agent_file in .claude/agents/*.md; do
-          [ -f "$agent_file" ] || continue
-          agent_name=$(basename "$agent_file" .md)
-          cp "$agent_file" "$TARGET_DIR/.apm/agents/${agent_name}.agent.md"
-        done
-
-    # Always ship the agent references that profiles and skills cite (e.g. the
-    # work-item tracker matrix). Every pack gets them, not only the
-    # agent-syncing ones. Skills in any pack may resolve a
-    # `.claude/agents/references/*` path, and benchmark task CWDs need them
-    # present. APM installs them alongside the skills. Runs after Sync agents
-    # so kata's `rm -rf .apm/agents` cannot wipe the references dir.
-    - name: Sync agent references
-      shell: bash
-      env:
-        TARGET_DIR: ${{ inputs.target-dir }}
-      run: |
-        rm -rf "$TARGET_DIR/.apm/agents/references"
-        if [ -d .claude/agents/references ]; then
-          mkdir -p "$TARGET_DIR/.apm/agents"
-          cp -r .claude/agents/references "$TARGET_DIR/.apm/agents/references"
-        fi
-
-    - name: Generate apm.yml
-      shell: bash
-      env:
-        TARGET_DIR: ${{ inputs.target-dir }}
         APM_NAME: ${{ inputs.sibling-repo }}
         APM_DESCRIPTION: ${{ inputs.apm-description }}
-      run: |
-        cat > "$TARGET_DIR/apm.yml" <<EOF
-        name: ${APM_NAME}
-        version: ${VERSION}
-        description: >-
-          ${APM_DESCRIPTION}
-        author: forwardimpact
-        license: Apache-2.0
-        includes: auto
-        EOF
-
-    - name: Generate README
-      shell: bash
-      env:
-        TARGET_DIR: ${{ inputs.target-dir }}
-        SIBLING_REPO: ${{ inputs.sibling-repo }}
         README_TITLE: ${{ inputs.readme-title }}
         README_INTRO: ${{ inputs.readme-intro }}
         SYNC_AGENTS: ${{ inputs.sync-agents }}
       run: |
-        extract_desc() {
-          awk '
-            /^description:/ {
-              sub(/^description: *>? */, "")
-              if ($0 != "") { desc = $0 }
-              while (getline > 0) {
-                if (/^  /) { gsub(/^  /, ""); desc = desc " " $0 }
-                else { break }
-              }
-              gsub(/^ +/, "", desc)
-              gsub(/ +$/, "", desc)
-              print desc
-              exit
-            }
-          ' "$1"
-        }
-
-        readme="$TARGET_DIR/README.md"
-        printf '# %s\n\n%s\n\n' "$README_TITLE" "$README_INTRO" > "$readme"
-        cat >> "$readme" <<EOF
-        ## Install
-
-        With [APM](https://microsoft.github.io/apm/):
-
-        \`\`\`bash
-        apm install forwardimpact/${SIBLING_REPO}
-        \`\`\`
-
-        ## Available Skills
-
-        | Skill | Description |
-        | --- | --- |
-        EOF
-
-        for skill_dir in "$TARGET_DIR"/.apm/skills/*/; do
-          skill_md="$skill_dir/SKILL.md"
-          if [ -f "$skill_md" ]; then
-            name=$(sed -n 's/^name: *//p' "$skill_md" | head -1)
-            desc=$(extract_desc "$skill_md")
-            echo "| **${name}** | ${desc} |" >> "$readme"
-          fi
-        done
-
+        agents_flag=""
         if [ "$SYNC_AGENTS" = "true" ]; then
-          cat >> "$readme" <<'EOF'
-
-        ## Available Agents
-
-        | Agent | Description |
-        | --- | --- |
-        EOF
-          for agent_file in "$TARGET_DIR"/.apm/agents/*.agent.md; do
-            [ -f "$agent_file" ] || continue
-            name=$(sed -n 's/^name: *//p' "$agent_file" | head -1)
-            desc=$(extract_desc "$agent_file")
-            echo "| **${name}** | ${desc} |" >> "$readme"
-          done
+          agents_flag="--with-agents"
         fi
+        bunx fit-pack sync \
+          --from .claude \
+          --prefix "$PACK_PREFIX" \
+          --into "$TARGET_DIR" \
+          --name "$APM_NAME" \
+          --pack-version "$VERSION" \
+          --description "$APM_DESCRIPTION" \
+          --readme-title "$README_TITLE" \
+          --readme-intro "$README_INTRO" \
+          $agents_flag
 
     - name: Commit, push, tag
       shell: bash

--- a/.github/actions/publish-skill-pack/action.yml
+++ b/.github/actions/publish-skill-pack/action.yml
@@ -7,6 +7,12 @@ description: >
   inputs so the three packs share one implementation. Prose and repo names reach
   the scripts through the environment, never by interpolation into source text.
 
+  Primitives are laid out under APM's conventional `.apm/` source root
+  (`.apm/skills/<name>/`, `.apm/agents/<name>.agent.md`) so that a bare
+  `apm install forwardimpact/<repo>` discovers and installs every primitive,
+  agents included. A root-level `agents/` directory is not an APM-recognized
+  package form, so agents placed there install for nobody.
+
 inputs:
   pack-prefix:
     description: Skill directory prefix under .claude/skills (e.g. fit, coaligned, kata).
@@ -72,12 +78,14 @@ runs:
           ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
         }
 
-        rm -rf "$TARGET_DIR/skills"
-        mkdir -p "$TARGET_DIR/skills"
+        # Retire the pre-.apm/ flat layout so the migration leaves no stragglers.
+        rm -rf "$TARGET_DIR/skills" "$TARGET_DIR/agents"
+        rm -rf "$TARGET_DIR/.apm/skills"
+        mkdir -p "$TARGET_DIR/.apm/skills"
         for skill_dir in ".claude/skills/${PACK_PREFIX}-"*/; do
           skill_name=$(basename "$skill_dir")
-          cp -r "$skill_dir" "$TARGET_DIR/skills/$skill_name"
-          inject_skill_frontmatter "$TARGET_DIR/skills/$skill_name/SKILL.md" "$VERSION"
+          cp -r "$skill_dir" "$TARGET_DIR/.apm/skills/$skill_name"
+          inject_skill_frontmatter "$TARGET_DIR/.apm/skills/$skill_name/SKILL.md" "$VERSION"
         done
 
     - name: Sync agents
@@ -86,12 +94,12 @@ runs:
       env:
         TARGET_DIR: ${{ inputs.target-dir }}
       run: |
-        rm -rf "$TARGET_DIR/agents"
-        mkdir -p "$TARGET_DIR/agents"
+        rm -rf "$TARGET_DIR/.apm/agents"
+        mkdir -p "$TARGET_DIR/.apm/agents"
         for agent_file in .claude/agents/*.md; do
           [ -f "$agent_file" ] || continue
           agent_name=$(basename "$agent_file" .md)
-          cp "$agent_file" "$TARGET_DIR/agents/${agent_name}.agent.md"
+          cp "$agent_file" "$TARGET_DIR/.apm/agents/${agent_name}.agent.md"
         done
 
     # Always ship the agent references that profiles and skills cite (e.g. the
@@ -99,16 +107,16 @@ runs:
     # agent-syncing ones. Skills in any pack may resolve a
     # `.claude/agents/references/*` path, and benchmark task CWDs need them
     # present. APM installs them alongside the skills. Runs after Sync agents
-    # so kata's `rm -rf agents` cannot wipe the references dir.
+    # so kata's `rm -rf .apm/agents` cannot wipe the references dir.
     - name: Sync agent references
       shell: bash
       env:
         TARGET_DIR: ${{ inputs.target-dir }}
       run: |
-        rm -rf "$TARGET_DIR/agents/references"
+        rm -rf "$TARGET_DIR/.apm/agents/references"
         if [ -d .claude/agents/references ]; then
-          mkdir -p "$TARGET_DIR/agents"
-          cp -r .claude/agents/references "$TARGET_DIR/agents/references"
+          mkdir -p "$TARGET_DIR/.apm/agents"
+          cp -r .claude/agents/references "$TARGET_DIR/.apm/agents/references"
         fi
 
     - name: Generate apm.yml
@@ -165,19 +173,13 @@ runs:
         apm install forwardimpact/${SIBLING_REPO}
         \`\`\`
 
-        With [npx skills](https://github.com/vercel-labs/skills):
-
-        \`\`\`bash
-        npx skills add forwardimpact/${SIBLING_REPO}
-        \`\`\`
-
         ## Available Skills
 
         | Skill | Description |
         | --- | --- |
         EOF
 
-        for skill_dir in "$TARGET_DIR"/skills/*/; do
+        for skill_dir in "$TARGET_DIR"/.apm/skills/*/; do
           skill_md="$skill_dir/SKILL.md"
           if [ -f "$skill_md" ]; then
             name=$(sed -n 's/^name: *//p' "$skill_md" | head -1)
@@ -194,7 +196,7 @@ runs:
         | Agent | Description |
         | --- | --- |
         EOF
-          for agent_file in "$TARGET_DIR"/agents/*.agent.md; do
+          for agent_file in "$TARGET_DIR"/.apm/agents/*.agent.md; do
             [ -f "$agent_file" ] || continue
             name=$(sed -n 's/^name: *//p' "$agent_file" | head -1)
             desc=$(extract_desc "$agent_file")

--- a/.github/actions/publish-skill-pack/action.yml
+++ b/.github/actions/publish-skill-pack/action.yml
@@ -75,7 +75,7 @@ runs:
         if [ "$SYNC_AGENTS" = "true" ]; then
           agents_flag="--with-agents"
         fi
-        bunx fit-pack sync \
+        bunx fit-pack stage \
           --from .claude \
           --prefix "$PACK_PREFIX" \
           --into "$TARGET_DIR" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,11 @@ npm. It is the source of truth for `forwardimpact/*` sibling repos:
   products need `npx fit-codegen --all` — see
   [Typed Contracts](websites/fit/docs/libraries/typed-contracts/index.md).
 - **Skill packs** — `forwardimpact/{fit-skills,kata-skills,coaligned-skills}`
-  sync on push to `main`. Install: `npx skills add forwardimpact/fit-skills`
-  (or `kata-skills`, `coaligned-skills`). Internal skills (`libs-*`, product
-  internals) never publish.
+  sync on push to `main`. Install: `apm install forwardimpact/fit-skills`
+  (or `kata-skills`, `coaligned-skills`). Packs ship under APM's `.apm/`
+  convention (`.apm/skills/`, `.apm/agents/`), so a bare install pulls skills
+  and agents together. Internal skills (`libs-*`, product internals) never
+  publish.
 - **Composite actions** —
   <!-- enum:sibling-composite-actions:list -->`forwardimpact/{fit-benchmark,fit-bootstrap,fit-eval,fit-wiki,kata-agent}`<!-- /enum -->
   released via append-only `v1.0.x` tags. Edit procedure in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,10 +91,8 @@ npm. It is the source of truth for `forwardimpact/*` sibling repos:
   [Typed Contracts](websites/fit/docs/libraries/typed-contracts/index.md).
 - **Skill packs** — `forwardimpact/{fit-skills,kata-skills,coaligned-skills}`
   sync on push to `main`. Install: `apm install forwardimpact/fit-skills`
-  (or `kata-skills`, `coaligned-skills`). Packs ship under APM's `.apm/`
-  convention (`.apm/skills/`, `.apm/agents/`), so a bare install pulls skills
-  and agents together. Internal skills (`libs-*`, product internals) never
-  publish.
+  (or `kata-skills`, `coaligned-skills`). Internal skills (`libs-*`, product
+  internals) never publish.
 - **Composite actions** —
   <!-- enum:sibling-composite-actions:list -->`forwardimpact/{fit-benchmark,fit-bootstrap,fit-eval,fit-wiki,kata-agent}`<!-- /enum -->
   released via append-only `v1.0.x` tags. Edit procedure in

--- a/bun.lock
+++ b/bun.lock
@@ -33,14 +33,14 @@
     },
     "libraries/libcli": {
       "name": "@forwardimpact/libcli",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "devDependencies": {
         "@forwardimpact/libmock": "^0.1.0",
       },
     },
     "libraries/libcoaligned": {
       "name": "@forwardimpact/libcoaligned",
-      "version": "0.1.11",
+      "version": "0.1.14",
       "bin": {
         "coaligned": "./bin/coaligned.js",
       },
@@ -58,7 +58,7 @@
     },
     "libraries/libcodegen": {
       "name": "@forwardimpact/libcodegen",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "bin": {
         "fit-codegen": "./bin/fit-codegen.js",
       },
@@ -117,7 +117,7 @@
     },
     "libraries/libeval": {
       "name": "@forwardimpact/libeval",
-      "version": "0.1.64",
+      "version": "0.1.66",
       "bin": {
         "fit-eval": "./bin/fit-eval.js",
         "fit-trace": "./bin/fit-trace.js",
@@ -220,7 +220,7 @@
     },
     "libraries/libmock": {
       "name": "@forwardimpact/libmock",
-      "version": "0.1.8",
+      "version": "0.1.11",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",
       },
@@ -231,7 +231,12 @@
     "libraries/libpack": {
       "name": "@forwardimpact/libpack",
       "version": "0.1.7",
+      "bin": {
+        "fit-pack": "./bin/fit-pack.js",
+      },
       "dependencies": {
+        "@forwardimpact/libcli": "^0.1.0",
+        "@forwardimpact/libpreflight": "^0.1.0",
         "@forwardimpact/libutil": "^0.1.84",
       },
       "devDependencies": {
@@ -397,7 +402,7 @@
     },
     "libraries/libsyntheticgen": {
       "name": "@forwardimpact/libsyntheticgen",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "dependencies": {
         "@forwardimpact/libutil": "^0.1.61",
         "seedrandom": "^3.0.5",
@@ -429,7 +434,7 @@
     },
     "libraries/libsyntheticrender": {
       "name": "@forwardimpact/libsyntheticrender",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
         "@forwardimpact/libsyntheticgen": "^0.1.0",
         "@forwardimpact/libtemplate": "^0.2.0",
@@ -532,7 +537,7 @@
     },
     "libraries/libutil": {
       "name": "@forwardimpact/libutil",
-      "version": "0.1.95",
+      "version": "0.1.97",
       "bin": {
         "fit-download-bundle": "./bin/fit-download-bundle.js",
         "fit-tiktoken": "./bin/fit-tiktoken.js",
@@ -573,7 +578,7 @@
     },
     "libraries/libwiki": {
       "name": "@forwardimpact/libwiki",
-      "version": "0.2.26",
+      "version": "0.2.30",
       "bin": {
         "fit-wiki": "./bin/fit-wiki.js",
       },
@@ -667,7 +672,7 @@
     },
     "products/landmark": {
       "name": "@forwardimpact/landmark",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "bin": {
         "fit-landmark": "./bin/fit-landmark.js",
       },
@@ -720,7 +725,7 @@
     },
     "products/outpost": {
       "name": "@forwardimpact/outpost",
-      "version": "3.4.0",
+      "version": "3.5.1",
       "bin": {
         "fit-outpost": "./bin/fit-outpost.js",
       },
@@ -739,7 +744,7 @@
     },
     "products/pathway": {
       "name": "@forwardimpact/pathway",
-      "version": "0.26.5",
+      "version": "0.26.6",
       "bin": {
         "fit-pathway": "./bin/fit-pathway.js",
       },
@@ -788,7 +793,7 @@
     },
     "services/bridge": {
       "name": "@forwardimpact/svcbridge",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "fit-svcbridge": "./server.js",
       },
@@ -809,7 +814,7 @@
     },
     "services/embedding": {
       "name": "@forwardimpact/svcembedding",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "fit-svcembedding": "./server.js",
       },
@@ -827,7 +832,7 @@
     },
     "services/ghbridge": {
       "name": "@forwardimpact/svcghbridge",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "bin": {
         "fit-svcghbridge": "./server.js",
       },
@@ -850,7 +855,7 @@
     },
     "services/ghserver": {
       "name": "@forwardimpact/svcghserver",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "bin": {
         "fit-svcghserver": "./server.js",
       },
@@ -869,7 +874,7 @@
     },
     "services/ghuser": {
       "name": "@forwardimpact/svcghuser",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "fit-svcghuser": "./server.js",
       },
@@ -954,7 +959,7 @@
     },
     "services/msbridge": {
       "name": "@forwardimpact/svcmsbridge",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "bin": {
         "fit-svcmsbridge": "./server.js",
       },
@@ -975,7 +980,7 @@
     },
     "services/oauth": {
       "name": "@forwardimpact/svcoauth",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "fit-svcoauth": "./server.js",
       },
@@ -1013,7 +1018,7 @@
     },
     "services/pathway": {
       "name": "@forwardimpact/svcpathway",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "bin": {
         "fit-svcpathway": "./server.js",
       },
@@ -1036,7 +1041,7 @@
     },
     "services/tenancy": {
       "name": "@forwardimpact/svctenancy",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "fit-svctenancy": "./server.js",
       },

--- a/launchers/fit-pack/bin/fit-pack.js
+++ b/launchers/fit-pack/bin/fit-pack.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "@forwardimpact/libpack/bin/fit-pack.js";

--- a/launchers/fit-pack/package.json
+++ b/launchers/fit-pack/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "fit-pack",
+  "version": "0.0.0",
+  "description": "Run fit-pack from the npm registry — launcher for @forwardimpact/libpack",
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "launchers/fit-pack"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "type": "module",
+  "bin": {
+    "fit-pack": "./bin/fit-pack.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "dependencies": {
+    "@forwardimpact/libpack": "0.0.0"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libraries/libpack/README.md
+++ b/libraries/libpack/README.md
@@ -13,6 +13,23 @@ Pack distribution — tarballs, bare git repos, and skill discovery indices
 - `TarEmitter` — deterministic `.tar.gz` from a staged directory
 - `GitEmitter` — static bare git repo from a staged directory
 - `DiscEmitter` — `.well-known/skills/` discovery index
+- `SkillPackPublisher` — sync a skill pack into a sibling repo working tree in
+  APM's canonical `.apm/` layout (drives the `fit-pack` CLI)
+- `APM_SKILLS_DIR` / `APM_AGENTS_DIR` / `apmAgentFilename` — the one definition
+  of APM's source layout, shared by every staging path
+
+## CLI
+
+`fit-pack sync` stages a skill pack into a checked-out sibling repository:
+
+```bash
+fit-pack sync --prefix kata --with-agents \
+  --into skills-repo --name kata-skills --pack-version 1.2.3 \
+  --description "…" --readme-title "Kata Skills" --readme-intro "…"
+```
+
+It writes `<into>/.apm/skills/<name>/`, `<into>/.apm/agents/<name>.agent.md`,
+`<into>/apm.yml`, and `<into>/README.md` deterministically.
 
 ## Composition
 

--- a/libraries/libpack/README.md
+++ b/libraries/libpack/README.md
@@ -13,17 +13,17 @@ Pack distribution — tarballs, bare git repos, and skill discovery indices
 - `TarEmitter` — deterministic `.tar.gz` from a staged directory
 - `GitEmitter` — static bare git repo from a staged directory
 - `DiscEmitter` — `.well-known/skills/` discovery index
-- `SkillPackPublisher` — sync a skill pack into a sibling repo working tree in
+- `SkillPackPublisher` — stage a skill pack into a sibling repo working tree in
   APM's canonical `.apm/` layout (drives the `fit-pack` CLI)
 - `APM_SKILLS_DIR` / `APM_AGENTS_DIR` / `apmAgentFilename` — the one definition
   of APM's source layout, shared by every staging path
 
 ## CLI
 
-`fit-pack sync` stages a skill pack into a checked-out sibling repository:
+`fit-pack stage` writes a skill pack into a checked-out sibling repository:
 
 ```bash
-fit-pack sync --prefix kata --with-agents \
+fit-pack stage --prefix kata --with-agents \
   --into skills-repo --name kata-skills --pack-version 1.2.3 \
   --description "…" --readme-title "Kata Skills" --readme-intro "…"
 ```

--- a/libraries/libpack/bin/fit-pack.js
+++ b/libraries/libpack/bin/fit-pack.js
@@ -12,9 +12,9 @@ const definition = {
   description: "Stage skill packs into APM's .apm/ source layout",
   commands: [
     {
-      name: "sync",
+      name: "stage",
       description:
-        "Sync a skill pack into a sibling repo working tree (APM .apm/ layout)",
+        "Stage a skill pack into a sibling repo working tree (APM .apm/ layout)",
       options: {
         from: {
           type: "string",
@@ -48,7 +48,7 @@ const definition = {
         },
         "with-agents": {
           type: "boolean",
-          description: "Also sync agent profiles into .apm/agents/",
+          description: "Also stage agent profiles into .apm/agents/",
         },
       },
     },
@@ -59,7 +59,7 @@ const definition = {
     json: { type: "boolean", description: "Output help as JSON" },
   },
   examples: [
-    "fit-pack sync --prefix kata --with-agents --into skills-repo --name kata-skills --pack-version 1.2.3",
+    "fit-pack stage --prefix kata --with-agents --into skills-repo --name kata-skills --pack-version 1.2.3",
   ],
   documentation: [
     {
@@ -83,7 +83,7 @@ const { values, positionals } = parsed;
 const [command] = positionals;
 
 const commands = {
-  async sync() {
+  async stage() {
     for (const required of ["prefix", "into", "name", "pack-version"]) {
       if (!values[required]) {
         cli.usageError(`--${required} is required`);

--- a/libraries/libpack/bin/fit-pack.js
+++ b/libraries/libpack/bin/fit-pack.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import "@forwardimpact/libpreflight/node22";
+
+import { createCli, formatSuccess } from "@forwardimpact/libcli";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+import { SkillPackPublisher } from "../src/index.js";
+
+const definition = {
+  name: "fit-pack",
+  description: "Stage skill packs into APM's .apm/ source layout",
+  commands: [
+    {
+      name: "sync",
+      description:
+        "Sync a skill pack into a sibling repo working tree (APM .apm/ layout)",
+      options: {
+        from: {
+          type: "string",
+          description:
+            "Source dir holding skills/ and agents/ (default: .claude)",
+        },
+        prefix: {
+          type: "string",
+          description: "Skill directory prefix to select (e.g. kata)",
+        },
+        into: {
+          type: "string",
+          description: "Target sibling repo working tree",
+        },
+        name: {
+          type: "string",
+          description: "APM package name (sibling repo short name)",
+        },
+        "pack-version": {
+          type: "string",
+          description: "Version stamped into apm.yml and SKILL.md metadata",
+        },
+        description: {
+          type: "string",
+          description: "apm.yml description",
+        },
+        "readme-title": { type: "string", description: "README H1 title" },
+        "readme-intro": {
+          type: "string",
+          description: "README intro paragraph",
+        },
+        "with-agents": {
+          type: "boolean",
+          description: "Also sync agent profiles into .apm/agents/",
+        },
+      },
+    },
+  ],
+  globalOptions: {
+    help: { type: "boolean", short: "h", description: "Show this help" },
+    version: { type: "boolean", description: "Show version" },
+    json: { type: "boolean", description: "Output help as JSON" },
+  },
+  examples: [
+    "fit-pack sync --prefix kata --with-agents --into skills-repo --name kata-skills --pack-version 1.2.3",
+  ],
+  documentation: [
+    {
+      title: "Distribute Skill Packs",
+      url: "https://www.forwardimpact.team/docs/libraries/distribute-skill-packs/index.md",
+      description:
+        "Stage a skill pack into APM's .apm/ layout so a bare install pulls skills and agents together.",
+    },
+  ],
+};
+
+const runtime = createDefaultRuntime();
+const cli = createCli(definition, {
+  runtime,
+  packageJsonUrl: new URL("../package.json", import.meta.url),
+});
+const parsed = cli.parse(process.argv.slice(2));
+if (!parsed) process.exit(0);
+
+const { values, positionals } = parsed;
+const [command] = positionals;
+
+const commands = {
+  async sync() {
+    for (const required of ["prefix", "into", "name", "pack-version"]) {
+      if (!values[required]) {
+        cli.usageError(`--${required} is required`);
+        process.exit(2);
+      }
+    }
+    const publisher = new SkillPackPublisher({ runtime });
+    const { skills, agents } = await publisher.publish({
+      sourceDir: values.from || ".claude",
+      prefix: values.prefix,
+      targetDir: values.into,
+      name: values.name,
+      version: values["pack-version"],
+      description: values.description || "",
+      readmeTitle: values["readme-title"] || values.name,
+      readmeIntro: values["readme-intro"] || "",
+      withAgents: Boolean(values["with-agents"]),
+    });
+    process.stdout.write(
+      formatSuccess(
+        `Staged ${skills.length} skill(s) and ${agents.length} agent(s) into ${values.into}`,
+      ) + "\n",
+    );
+  },
+};
+
+if (!command) {
+  cli.usageError("no command specified");
+  process.exit(2);
+} else if (commands[command]) {
+  await commands[command]();
+} else {
+  cli.usageError(`unknown command "${command}"`);
+  process.exit(2);
+}

--- a/libraries/libpack/package.json
+++ b/libraries/libpack/package.json
@@ -30,15 +30,22 @@
   "type": "module",
   "main": "./src/index.js",
   "exports": {
-    ".": "./src/index.js"
+    ".": "./src/index.js",
+    "./bin/fit-pack.js": "./bin/fit-pack.js"
+  },
+  "bin": {
+    "fit-pack": "./bin/fit-pack.js"
   },
   "files": [
-    "src/**/*.js"
+    "src/**/*.js",
+    "bin/**/*.js"
   ],
   "scripts": {
     "test": "bun test test/*.test.js"
   },
   "dependencies": {
+    "@forwardimpact/libcli": "^0.1.0",
+    "@forwardimpact/libpreflight": "^0.1.0",
     "@forwardimpact/libutil": "^0.1.84"
   },
   "devDependencies": {

--- a/libraries/libpack/src/index.js
+++ b/libraries/libpack/src/index.js
@@ -3,3 +3,5 @@ export { PackStager } from "./stager.js";
 export { TarEmitter } from "./tar-emitter.js";
 export { GitEmitter } from "./git-emitter.js";
 export { DiscEmitter } from "./disc-emitter.js";
+export { SkillPackPublisher } from "./skill-pack.js";
+export { APM_SKILLS_DIR, APM_AGENTS_DIR, apmAgentFilename } from "./layout.js";

--- a/libraries/libpack/src/layout.js
+++ b/libraries/libpack/src/layout.js
@@ -1,0 +1,25 @@
+/**
+ * Canonical APM source layout.
+ *
+ * APM discovers a package's primitives by directory convention: skills under
+ * `.apm/skills/<name>/` and agents under `.apm/agents/<name>.agent.md`. The
+ * `.agent.md` suffix is load-bearing — APM's agent discovery keys on it; a
+ * plain `.md` file under `.apm/agents/` is not recognized as an agent, and a
+ * root-level `agents/` directory is not a recognized package form at all.
+ *
+ * Defining the layout once keeps every staging path from drifting: the
+ * sibling-repo publisher and the Pathway git packs both build the same shape,
+ * so agents can never silently fail to install in one path but not the other.
+ */
+export const APM_SKILLS_DIR = ".apm/skills";
+export const APM_AGENTS_DIR = ".apm/agents";
+
+/**
+ * Canonical APM agent filename for an agent whose stem (basename without
+ * extension) is `stem`.
+ * @param {string} stem
+ * @returns {string}
+ */
+export function apmAgentFilename(stem) {
+  return `${stem}.agent.md`;
+}

--- a/libraries/libpack/src/skill-pack.js
+++ b/libraries/libpack/src/skill-pack.js
@@ -1,0 +1,265 @@
+import { basename, join } from "path";
+
+import { APM_AGENTS_DIR, APM_SKILLS_DIR, apmAgentFilename } from "./layout.js";
+
+const LICENSE = "Apache-2.0";
+const AUTHOR = "forwardimpact";
+
+/**
+ * Publish a monorepo skill pack into a sibling repository's working tree using
+ * APM's canonical `.apm/` source layout, so a bare `apm install <owner>/<repo>`
+ * discovers and installs skills and agents together.
+ *
+ * This is the single code path for the sibling-pack layout: the publish
+ * workflow drives it through the `fit-pack` CLI, and the same layout constants
+ * back the Pathway git packs (see `PackStager.stageApmGit`).
+ */
+export class SkillPackPublisher {
+  #fs;
+
+  /** @param {{runtime?: object}} [opts] */
+  constructor({ runtime } = {}) {
+    if (!runtime) throw new Error("runtime is required");
+    this.#fs = runtime.fs;
+  }
+
+  /** Return true if a path exists. */
+  async #exists(path) {
+    try {
+      await this.#fs.access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Stage the pack into `targetDir`.
+   *
+   * @param {object} opts
+   * @param {string} opts.sourceDir - Directory holding `skills/` and `agents/`
+   *   (the monorepo's `.claude` directory).
+   * @param {string} opts.prefix - Skill directory prefix to select (e.g. `kata`
+   *   selects `skills/kata-*`).
+   * @param {string} opts.targetDir - Sibling repo working tree to write into.
+   * @param {string} opts.name - APM package name (sibling repo short name).
+   * @param {string} opts.version - Stamped into apm.yml and SKILL.md metadata.
+   * @param {boolean} [opts.withAgents] - Also sync agent profiles.
+   * @param {string} [opts.description] - apm.yml description.
+   * @param {string} [opts.readmeTitle] - README H1.
+   * @param {string} [opts.readmeIntro] - README intro paragraph.
+   * @returns {Promise<{skills: object[], agents: object[]}>}
+   */
+  async publish(opts) {
+    await this.#clean(opts.targetDir);
+    const skills = await this.#stageSkills(opts);
+    const agents = opts.withAgents ? await this.#stageAgents(opts) : [];
+    await this.#stageAgentReferences(opts);
+    await this.#writeManifest(opts);
+    await this.#writeReadme(opts, skills, agents);
+    return { skills, agents };
+  }
+
+  /** Remove the pre-`.apm/` flat layout and any prior `.apm/` tree. */
+  async #clean(targetDir) {
+    const { rm } = this.#fs;
+    const stale = [
+      join(targetDir, "skills"),
+      join(targetDir, "agents"),
+      join(targetDir, APM_SKILLS_DIR),
+      join(targetDir, APM_AGENTS_DIR),
+    ];
+    for (const path of stale) {
+      await rm(path, { recursive: true, force: true });
+    }
+  }
+
+  /** Copy `skills/<prefix>-*` into `.apm/skills/`, injecting frontmatter. */
+  async #stageSkills({ sourceDir, prefix, targetDir, version }) {
+    const { mkdir, readdir, cp, readFile, writeFile } = this.#fs;
+    const srcDir = join(sourceDir, "skills");
+    const destDir = join(targetDir, APM_SKILLS_DIR);
+    await mkdir(destDir, { recursive: true });
+
+    const dirs = (await readdir(srcDir, { withFileTypes: true }))
+      .filter((e) => e.isDirectory() && e.name.startsWith(`${prefix}-`))
+      .map((e) => e.name)
+      .sort();
+
+    const staged = [];
+    for (const name of dirs) {
+      const skillDest = join(destDir, name);
+      await cp(join(srcDir, name), skillDest, { recursive: true });
+
+      const skillMd = join(skillDest, "SKILL.md");
+      const original = await readFile(skillMd, "utf-8");
+      await writeFile(skillMd, injectFrontmatter(original, version), "utf-8");
+
+      staged.push({
+        name: frontmatterField(original, "name") || name,
+        description: foldedField(original, "description"),
+      });
+    }
+    return staged;
+  }
+
+  /** Copy `agents/*.md` into `.apm/agents/<stem>.agent.md`. */
+  async #stageAgents({ sourceDir, targetDir }) {
+    const { mkdir, readdir, readFile, writeFile } = this.#fs;
+    const srcDir = join(sourceDir, "agents");
+    const destDir = join(targetDir, APM_AGENTS_DIR);
+    await mkdir(destDir, { recursive: true });
+
+    const files = (await readdir(srcDir, { withFileTypes: true }))
+      .filter((e) => e.isFile() && e.name.endsWith(".md"))
+      .map((e) => e.name)
+      .sort();
+
+    const staged = [];
+    for (const file of files) {
+      const content = await readFile(join(srcDir, file), "utf-8");
+      const stem = basename(file, ".md");
+      await writeFile(join(destDir, apmAgentFilename(stem)), content, "utf-8");
+      staged.push({
+        name: frontmatterField(content, "name") || stem,
+        description: foldedField(content, "description"),
+      });
+    }
+    return staged;
+  }
+
+  /**
+   * Copy `agents/references/` into `.apm/agents/references/`. Every pack ships
+   * the references that skills and profiles cite, not only agent-syncing ones.
+   * Runs after agent staging so the references dir is never wiped.
+   */
+  async #stageAgentReferences({ sourceDir, targetDir }) {
+    const { mkdir, cp } = this.#fs;
+    const src = join(sourceDir, "agents", "references");
+    if (!(await this.#exists(src))) return;
+    const destAgents = join(targetDir, APM_AGENTS_DIR);
+    await mkdir(destAgents, { recursive: true });
+    await cp(src, join(destAgents, "references"), { recursive: true });
+  }
+
+  /** Write the APM package manifest. */
+  async #writeManifest({ targetDir, name, version, description }) {
+    const lines = [
+      `name: ${name}`,
+      `version: ${version}`,
+      `description: >-`,
+      `  ${description || ""}`,
+      `author: ${AUTHOR}`,
+      `license: ${LICENSE}`,
+      `includes: auto`,
+      ``,
+    ];
+    await this.#fs.writeFile(
+      join(targetDir, "apm.yml"),
+      lines.join("\n"),
+      "utf-8",
+    );
+  }
+
+  /** Write the README with install command and skill/agent tables. */
+  async #writeReadme(opts, skills, agents) {
+    const { targetDir, name, readmeTitle, readmeIntro, withAgents } = opts;
+    const lines = [
+      `# ${readmeTitle || name}`,
+      ``,
+      readmeIntro || "",
+      ``,
+      `## Install`,
+      ``,
+      `With [APM](https://microsoft.github.io/apm/):`,
+      ``,
+      "```bash",
+      `apm install forwardimpact/${name}`,
+      "```",
+      ``,
+      `## Available Skills`,
+      ``,
+      `| Skill | Description |`,
+      `| --- | --- |`,
+      ...skills.map((s) => `| **${s.name}** | ${s.description} |`),
+    ];
+
+    if (withAgents) {
+      lines.push(
+        ``,
+        `## Available Agents`,
+        ``,
+        `| Agent | Description |`,
+        `| --- | --- |`,
+        ...agents.map((a) => `| **${a.name}** | ${a.description} |`),
+      );
+    }
+    lines.push(``);
+    await this.#fs.writeFile(
+      join(targetDir, "README.md"),
+      lines.join("\n"),
+      "utf-8",
+    );
+  }
+}
+
+/**
+ * Insert `license` and a `metadata` block (version + author) just before the
+ * closing `---` of a SKILL.md's YAML frontmatter. Content without frontmatter
+ * is returned unchanged.
+ * @param {string} content
+ * @param {string} version
+ * @returns {string}
+ */
+export function injectFrontmatter(content, version) {
+  const lines = content.split("\n");
+  if (lines[0] !== "---") return content;
+  let close = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === "---") {
+      close = i;
+      break;
+    }
+  }
+  if (close === -1) return content;
+  lines.splice(
+    close,
+    0,
+    `license: ${LICENSE}`,
+    `metadata:`,
+    `  version: "${version}"`,
+    `  author: ${AUTHOR}`,
+  );
+  return lines.join("\n");
+}
+
+/** Read a single-line frontmatter field value (first match), or "". */
+function frontmatterField(content, key) {
+  const match = content.match(new RegExp(`^${key}:\\s*(.*)$`, "m"));
+  return match ? match[1].trim() : "";
+}
+
+/**
+ * Read a frontmatter field that may be a folded block scalar (`>-`), joining
+ * 2-space-indented continuation lines into one space-separated string.
+ * @param {string} content
+ * @param {string} key
+ * @returns {string}
+ */
+function foldedField(content, key) {
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(new RegExp(`^${key}:\\s*>?-?\\s*(.*)$`));
+    if (!match) continue;
+    let value = match[1];
+    for (let j = i + 1; j < lines.length; j++) {
+      if (/^\s{2}\S/.test(lines[j])) {
+        value += (value ? " " : "") + lines[j].trim();
+      } else {
+        break;
+      }
+    }
+    return value.trim();
+  }
+  return "";
+}

--- a/libraries/libpack/src/stager.js
+++ b/libraries/libpack/src/stager.js
@@ -1,5 +1,6 @@
 import { join } from "path";
 
+import { APM_AGENTS_DIR, APM_SKILLS_DIR, apmAgentFilename } from "./layout.js";
 import { collectFiles } from "./util.js";
 
 /** Stage directory trees per layout (full, APM, skills). */
@@ -152,15 +153,18 @@ export class PackStager {
   }
 
   /** Stage the APM git repo layout from a full staging dir.
-   *  Skills live at root; agents live under .apm/agents/ (APM's
-   *  canonical source layout for agent discovery and integration).
+   *  Skills and agents both live under APM's canonical `.apm/` source root
+   *  (`.apm/skills/<name>/`, `.apm/agents/<name>.agent.md`) so `apm install`
+   *  discovers and installs both. The `.agent.md` suffix is required — APM's
+   *  agent discovery keys on it. Shared with the sibling-repo publisher via
+   *  `./layout.js` so the two staging paths cannot drift.
    */
   async stageApmGit(fullDir, gitDir, packName, version) {
     const { mkdir, readdir, cp, writeFile, copyFile } = this.#fs;
     const srcSkillsDir = join(fullDir, ".claude", "skills");
     const srcAgentsDir = join(fullDir, ".claude", "agents");
-    const destSkillsDir = join(gitDir, "skills");
-    const destAgentsDir = join(gitDir, ".apm", "agents");
+    const destSkillsDir = join(gitDir, APM_SKILLS_DIR);
+    const destAgentsDir = join(gitDir, APM_AGENTS_DIR);
 
     await mkdir(destSkillsDir, { recursive: true });
     await mkdir(destAgentsDir, { recursive: true });
@@ -178,7 +182,11 @@ export class PackStager {
       f.endsWith(".md"),
     );
     for (const file of agentFiles) {
-      await cp(join(srcAgentsDir, file), join(destAgentsDir, file));
+      const stem = file.slice(0, -".md".length);
+      await cp(
+        join(srcAgentsDir, file),
+        join(destAgentsDir, apmAgentFilename(stem)),
+      );
     }
 
     const srcClaudeMd = join(fullDir, ".claude", "CLAUDE.md");

--- a/libraries/libpack/test/skill-pack.integration.test.js
+++ b/libraries/libpack/test/skill-pack.integration.test.js
@@ -1,0 +1,213 @@
+import { describe, test } from "node:test";
+import { expect } from "@forwardimpact/libmock/expect";
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+import { mkdtemp, mkdir, writeFile, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { SkillPackPublisher, injectFrontmatter } from "../src/skill-pack.js";
+
+const runtime = createDefaultRuntime();
+
+async function makeTempDir() {
+  return mkdtemp(join(tmpdir(), "libpack-skillpack-"));
+}
+
+/** Build a `.claude`-shaped source tree under a fresh temp dir. */
+async function makeSource() {
+  const source = join(await makeTempDir(), ".claude");
+  await mkdir(join(source, "skills", "kata-review"), { recursive: true });
+  await writeFile(
+    join(source, "skills", "kata-review", "SKILL.md"),
+    "---\nname: kata-review\ndescription: Review an artifact\n---\n# Review\n",
+  );
+  // A different prefix that must NOT be selected.
+  await mkdir(join(source, "skills", "fit-map"), { recursive: true });
+  await writeFile(
+    join(source, "skills", "fit-map", "SKILL.md"),
+    "---\nname: fit-map\ndescription: Map\n---\n# Map\n",
+  );
+  await mkdir(join(source, "agents", "references"), { recursive: true });
+  await writeFile(
+    join(source, "agents", "staff-engineer.md"),
+    "---\nname: staff-engineer\ndescription: Staff engineer profile\n---\n# Staff\n",
+  );
+  await writeFile(
+    join(source, "agents", "references", "memory.md"),
+    "# Memory protocol\n",
+  );
+  return source;
+}
+
+describe("injectFrontmatter", () => {
+  test("inserts license and metadata before the closing fence", () => {
+    const out = injectFrontmatter("---\nname: x\n---\n# Body\n", "1.2.3");
+    expect(out).toContain("license: Apache-2.0");
+    expect(out).toContain("metadata:");
+    expect(out).toContain('  version: "1.2.3"');
+    expect(out).toContain("  author: forwardimpact");
+    // Body and name survive.
+    expect(out).toContain("name: x");
+    expect(out).toContain("# Body");
+  });
+
+  test("returns content without frontmatter unchanged", () => {
+    const input = "# No frontmatter\n";
+    expect(injectFrontmatter(input, "1.0.0")).toBe(input);
+  });
+});
+
+describe("SkillPackPublisher", () => {
+  test("requires a runtime", () => {
+    expect(() => new SkillPackPublisher({})).toThrow("runtime is required");
+  });
+
+  test("stages skills and agents under .apm/ with prefix filtering", async () => {
+    const source = await makeSource();
+    const target = await makeTempDir();
+    const publisher = new SkillPackPublisher({ runtime });
+
+    const result = await publisher.publish({
+      sourceDir: source,
+      prefix: "kata",
+      targetDir: target,
+      name: "kata-skills",
+      version: "1.2.3",
+      withAgents: true,
+      description: "Kata agent team",
+      readmeTitle: "Kata Skills",
+      readmeIntro: "Agents and skills.",
+    });
+
+    // Selected skill staged at the canonical path.
+    expect(
+      existsSync(join(target, ".apm", "skills", "kata-review", "SKILL.md")),
+    ).toBe(true);
+    // Other-prefix skill excluded.
+    expect(existsSync(join(target, ".apm", "skills", "fit-map"))).toBe(false);
+    // Agent uses the .agent.md suffix.
+    expect(
+      existsSync(join(target, ".apm", "agents", "staff-engineer.agent.md")),
+    ).toBe(true);
+    // References ship alongside agents.
+    expect(
+      existsSync(join(target, ".apm", "agents", "references", "memory.md")),
+    ).toBe(true);
+
+    expect(result.skills).toEqual([
+      { name: "kata-review", description: "Review an artifact" },
+    ]);
+    expect(result.agents).toEqual([
+      { name: "staff-engineer", description: "Staff engineer profile" },
+    ]);
+  });
+
+  test("injects version metadata into staged SKILL.md", async () => {
+    const source = await makeSource();
+    const target = await makeTempDir();
+    await new SkillPackPublisher({ runtime }).publish({
+      sourceDir: source,
+      prefix: "kata",
+      targetDir: target,
+      name: "kata-skills",
+      version: "9.9.9",
+      withAgents: true,
+    });
+    const skillMd = await readFile(
+      join(target, ".apm", "skills", "kata-review", "SKILL.md"),
+      "utf-8",
+    );
+    expect(skillMd).toContain('  version: "9.9.9"');
+    expect(skillMd).toContain("license: Apache-2.0");
+  });
+
+  test("writes a valid apm.yml manifest", async () => {
+    const source = await makeSource();
+    const target = await makeTempDir();
+    await new SkillPackPublisher({ runtime }).publish({
+      sourceDir: source,
+      prefix: "kata",
+      targetDir: target,
+      name: "kata-skills",
+      version: "1.2.3",
+      withAgents: true,
+      description: "Kata agent team",
+    });
+    const apm = await readFile(join(target, "apm.yml"), "utf-8");
+    expect(apm).toContain("name: kata-skills");
+    expect(apm).toContain("version: 1.2.3");
+    expect(apm).toContain("includes: auto");
+    expect(apm).toContain("Kata agent team");
+  });
+
+  test("README has the APM install command and tables, never npx skills", async () => {
+    const source = await makeSource();
+    const target = await makeTempDir();
+    await new SkillPackPublisher({ runtime }).publish({
+      sourceDir: source,
+      prefix: "kata",
+      targetDir: target,
+      name: "kata-skills",
+      version: "1.2.3",
+      withAgents: true,
+      readmeTitle: "Kata Skills",
+      readmeIntro: "Agents and skills.",
+    });
+    const readme = await readFile(join(target, "README.md"), "utf-8");
+    expect(readme).toContain("# Kata Skills");
+    expect(readme).toContain("apm install forwardimpact/kata-skills");
+    expect(readme).toContain("## Available Skills");
+    expect(readme).toContain("| **kata-review** | Review an artifact |");
+    expect(readme).toContain("## Available Agents");
+    expect(readme).toContain("| **staff-engineer** | Staff engineer profile |");
+    expect(readme).not.toContain("npx skills");
+  });
+
+  test("without agents: references still ship, no Available Agents section", async () => {
+    const source = await makeSource();
+    const target = await makeTempDir();
+    const { agents } = await new SkillPackPublisher({ runtime }).publish({
+      sourceDir: source,
+      prefix: "kata",
+      targetDir: target,
+      name: "fit-skills",
+      version: "1.0.0",
+      withAgents: false,
+    });
+    expect(agents).toEqual([]);
+    expect(
+      existsSync(join(target, ".apm", "agents", "staff-engineer.agent.md")),
+    ).toBe(false);
+    expect(
+      existsSync(join(target, ".apm", "agents", "references", "memory.md")),
+    ).toBe(true);
+    const readme = await readFile(join(target, "README.md"), "utf-8");
+    expect(readme).not.toContain("## Available Agents");
+  });
+
+  test("retires a pre-existing flat layout", async () => {
+    const source = await makeSource();
+    const target = await makeTempDir();
+    // Simulate the old flat layout left over from a prior publish.
+    await mkdir(join(target, "skills", "kata-stale"), { recursive: true });
+    await writeFile(join(target, "skills", "kata-stale", "SKILL.md"), "old");
+    await mkdir(join(target, "agents"), { recursive: true });
+    await writeFile(join(target, "agents", "old.agent.md"), "old");
+
+    await new SkillPackPublisher({ runtime }).publish({
+      sourceDir: source,
+      prefix: "kata",
+      targetDir: target,
+      name: "kata-skills",
+      version: "1.2.3",
+      withAgents: true,
+    });
+
+    expect(existsSync(join(target, "skills"))).toBe(false);
+    expect(existsSync(join(target, "agents"))).toBe(false);
+    expect(existsSync(join(target, ".apm", "skills", "kata-review"))).toBe(
+      true,
+    );
+  });
+});

--- a/products/pathway/test/build-packs.integration.test.js
+++ b/products/pathway/test/build-packs.integration.test.js
@@ -423,7 +423,7 @@ describe("generatePacks", () => {
 
     try {
       execFileSync("git", ["clone", repoPath, cloneDir], { env: cleanEnv });
-      assert.ok(existsSync(join(cloneDir, "skills")));
+      assert.ok(existsSync(join(cloneDir, ".apm", "skills")));
       assert.ok(existsSync(join(cloneDir, ".apm", "agents")));
       assert.ok(existsSync(join(cloneDir, "apm.yml")));
     } finally {

--- a/websites/fit/docs/libraries/distribute-skill-packs/index.md
+++ b/websites/fit/docs/libraries/distribute-skill-packs/index.md
@@ -1,0 +1,190 @@
+---
+title: Distribute Skill Packs
+description: Stage a skill pack into APM's .apm/ layout so a bare install pulls skills and agents together — one command from a source tree to an installable repository.
+---
+
+You have a set of skills and agent profiles you want a team to install, and you
+have picked a package manager — APM — to distribute them. The trap is the
+layout: put your skills in a root `skills/` directory and the installer finds
+them, but put your agents next to them in `agents/` and they install for
+nobody. The installer never scans that path. Agents have to live under
+`.apm/agents/` with an `.agent.md` suffix, and skills under `.apm/skills/`, or a
+bare install silently drops half the pack. `fit-pack` writes that layout for
+you. Point it at a source tree, and it stages skills, agents, and their shared
+references into a target repository, generates the manifest and a README, and
+leaves you a clean tree to commit and push.
+
+## Prerequisites
+
+- Node.js 18+
+- A **source tree** holding the content to ship: a `skills/` directory with one
+  subdirectory per skill (each containing a `SKILL.md`) and, optionally, an
+  `agents/` directory of `*.md` agent profiles.
+- A **target repository** checked out locally — the repository you publish the
+  pack from. `fit-pack` writes into its working tree; it never commits or
+  pushes.
+
+No global install is needed; run the CLI through `npx`:
+
+```sh
+npx fit-pack --help
+```
+
+## Understand the layout it produces
+
+APM discovers a package's primitives by directory convention. `fit-pack` writes
+the canonical form into your target repository:
+
+```text
+<target>/
+  apm.yml                          # package manifest
+  README.md                        # install command + skill/agent tables
+  .apm/
+    skills/
+      <skill-name>/SKILL.md        # one directory per skill
+    agents/
+      <agent-name>.agent.md        # one file per agent profile
+      references/                  # shared files skills and agents cite
+```
+
+Two rules are load-bearing, and getting either wrong is the failure this guide
+exists to prevent:
+
+- **Skills live under `.apm/skills/`.** A bare `apm install <owner>/<repo>`
+  walks that directory for `SKILL.md` files.
+- **Agents live under `.apm/agents/` with the `.agent.md` suffix.** APM's agent
+  discovery keys on that suffix. A plain `.md` file, or an agent placed in a
+  root `agents/` directory, is invisible to the installer.
+
+## Stage the pack
+
+Run `fit-pack sync` against your checked-out target repository:
+
+```sh
+npx fit-pack sync \
+  --from .claude \
+  --prefix kata \
+  --into ./skills-repo \
+  --name kata-skills \
+  --pack-version 1.2.3 \
+  --with-agents \
+  --description "Agents and skills for the Kata workflow" \
+  --readme-title "Kata Skills" \
+  --readme-intro "Agents and skills for the Kata workflow."
+```
+
+The options:
+
+| Option           | Meaning                                                        |
+| ---------------- | -------------------------------------------------------------- |
+| `--from`         | Source dir holding `skills/` and `agents/` (default `.claude`) |
+| `--prefix`       | Select which skills ship — `kata` selects `skills/kata-*`      |
+| `--into`         | Target repository working tree to write into                   |
+| `--name`         | APM package name (the installed repository's short name)       |
+| `--pack-version` | Version stamped into `apm.yml` and each `SKILL.md`             |
+| `--with-agents`  | Also stage agent profiles into `.apm/agents/`                  |
+| `--description`  | One-line description written into `apm.yml`                    |
+| `--readme-title` | README H1                                                      |
+| `--readme-intro` | README intro paragraph                                         |
+
+On success it reports what it staged:
+
+```text
+✓ Staged 12 skill(s) and 6 agent(s) into ./skills-repo
+```
+
+`--prefix` is how one source tree feeds several packs. With
+`--prefix kata` only `skills/kata-*` directories ship; a `skills/fit-map`
+directory in the same source is left out. Omit `--with-agents` for a
+skills-only pack — the shared `references/` still ship, because skills cite them
+too.
+
+## Review what was written
+
+`fit-pack` injects a `license` field and a `metadata` version block into every
+staged `SKILL.md`, so the installed skill records the version it came from
+without you editing source files:
+
+```sh
+head -8 ./skills-repo/.apm/skills/kata-review/SKILL.md
+```
+
+```text
+---
+name: kata-review
+description: Grade a single artifact against quality criteria
+license: Apache-2.0
+metadata:
+  version: "1.2.3"
+  author: forwardimpact
+---
+```
+
+The generated `apm.yml` is a minimal, valid package manifest:
+
+```yaml
+name: kata-skills
+version: 1.2.3
+description: >-
+  Agents and skills for the Kata workflow
+author: forwardimpact
+license: Apache-2.0
+includes: auto
+```
+
+And `README.md` carries the install command and a table of everything in the
+pack, so a visitor to the repository sees how to install it and what they get.
+
+## Publish the repository
+
+`fit-pack` stops at the working tree. You own the commit:
+
+```sh
+cd ./skills-repo
+git add -A
+git commit -m "Publish pack v1.2.3"
+git push
+git tag v1.2.3 && git push origin v1.2.3
+```
+
+Consumers then install the whole pack — skills and agents together — with a
+single command:
+
+```sh
+apm install <owner>/skills-repo
+```
+
+## Re-sync to update or migrate
+
+Running `fit-pack sync` again is the update path. It rewrites `.apm/`, the
+manifest, and the README from the current source, and it **retires any earlier
+flat layout** — a root `skills/` or `agents/` directory left over from a hand-built
+pack is removed in the same run. Migrating an existing pack repository to the
+correct layout is therefore a single `sync` followed by a commit.
+
+Because the output is deterministic, an unchanged source produces an unchanged
+tree: re-running when nothing changed leaves `git status` clean, so you only
+ever commit real differences.
+
+## Verify
+
+You have reached the outcome of this guide when:
+
+- `npx fit-pack sync` writes `.apm/skills/<name>/`, `.apm/agents/<name>.agent.md`,
+  `.apm/agents/references/`, `apm.yml`, and `README.md` into your target
+  repository.
+- Each staged `SKILL.md` carries the injected `license` and `metadata.version`.
+- `--prefix` selects only the matching skills, and `--with-agents` controls
+  whether agent profiles are staged.
+- After you commit and push, `apm install <owner>/<repo>` installs both the
+  skills and the agents.
+
+## What's next
+
+<div class="grid">
+
+<!-- part:card:../integrate-standard -->
+
+<!-- part:card:../prove-changes -->
+
+</div>

--- a/websites/fit/docs/libraries/distribute-skill-packs/index.md
+++ b/websites/fit/docs/libraries/distribute-skill-packs/index.md
@@ -58,10 +58,10 @@ exists to prevent:
 
 ## Stage the pack
 
-Run `fit-pack sync` against your checked-out target repository:
+Run `fit-pack stage` against your checked-out target repository:
 
 ```sh
-npx fit-pack sync \
+npx fit-pack stage \
   --from .claude \
   --prefix kata \
   --into ./skills-repo \
@@ -154,13 +154,13 @@ single command:
 apm install <owner>/skills-repo
 ```
 
-## Re-sync to update or migrate
+## Re-stage to update or migrate
 
-Running `fit-pack sync` again is the update path. It rewrites `.apm/`, the
+Running `fit-pack stage` again is the update path. It rewrites `.apm/`, the
 manifest, and the README from the current source, and it **retires any earlier
 flat layout** — a root `skills/` or `agents/` directory left over from a hand-built
 pack is removed in the same run. Migrating an existing pack repository to the
-correct layout is therefore a single `sync` followed by a commit.
+correct layout is therefore a single `stage` followed by a commit.
 
 Because the output is deterministic, an unchanged source produces an unchanged
 tree: re-running when nothing changed leaves `git status` clean, so you only
@@ -170,7 +170,7 @@ ever commit real differences.
 
 You have reached the outcome of this guide when:
 
-- `npx fit-pack sync` writes `.apm/skills/<name>/`, `.apm/agents/<name>.agent.md`,
+- `npx fit-pack stage` writes `.apm/skills/<name>/`, `.apm/agents/<name>.agent.md`,
   `.apm/agents/references/`, `apm.yml`, and `README.md` into your target
   repository.
 - Each staged `SKILL.md` carries the injected `license` and `metadata.version`.

--- a/websites/fit/docs/libraries/index.md
+++ b/websites/fit/docs/libraries/index.md
@@ -103,5 +103,13 @@ toc: false
 
 </div>
 
+## Distribute Skill Packs (Builders)
+
+<div class="grid">
+
+<!-- part:card:distribute-skill-packs -->
+
+</div>
+
 Looking for product workflows? See [Product Guides](/docs/products/). For shared
 gRPC service integration, see [Service Guides](/docs/services/).

--- a/websites/fit/gear/index.md
+++ b/websites/fit/gear/index.md
@@ -172,7 +172,7 @@ whether its latest move is a real change or just expected variation.
 
 ```sh
 npm install @forwardimpact/libcli @forwardimpact/libstorage  # any subset
-npx skills add forwardimpact/fit-skills
+apm install forwardimpact/fit-skills
 ```
 
 <div class="grid">

--- a/websites/fit/index.md
+++ b/websites/fit/index.md
@@ -167,7 +167,7 @@ npx fit-pathway agent software_engineering --track=platform
 Install the shared skill pack and browse the library catalog:
 
 ```sh
-npx skills add forwardimpact/fit-skills
+apm install forwardimpact/fit-skills
 ```
 
   </div>

--- a/websites/kata/index.md
+++ b/websites/kata/index.md
@@ -229,7 +229,7 @@ layout: home
       </div>
       <div class="terminal-lines">
         <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">cd my-repo/</span></div>
-        <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">npx skills add forwardimpact/kata-skills</span></div>
+        <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">apm install forwardimpact/kata-skills</span></div>
         <div class="terminal-line"><span class="terminal-prompt">&#10095; </span><span class="terminal-cmd">echo </span><span class="terminal-string">"Setup the Kata Team"</span><span class="terminal-cmd"> | claude</span></div>
       </div>
     </div>

--- a/websites/kata/llms.txt
+++ b/websites/kata/llms.txt
@@ -18,7 +18,7 @@ The team runs on plain
 JavaScript with no databases, no queues, and no third-party dependencies;
 shared state lives as markdown in a Git repository.
 
-Install via `npx skills add forwardimpact/kata-skills`, then ask Claude to set
+Install via `apm install forwardimpact/kata-skills`, then ask Claude to set
 up the team.
 
 ## Optional


### PR DESCRIPTION
## Summary

- **Fix the root cause:** sibling skill packs published a root-level `agents/` directory, which APM never scans, so `apm install forwardimpact/<repo>` pulled skills but silently dropped agents. Packs now publish under APM's canonical `.apm/` layout (`.apm/skills/`, `.apm/agents/<name>.agent.md`), so a bare install pulls skills and agents together.
- **Single code path in libpack:** a new `src/layout.js` is the one definition of the APM source layout, shared by the new `SkillPackPublisher` (staging, frontmatter injection, `apm.yml` + README generation, all unit-tested) and by `stageApmGit` — whose reconciliation also fixed the same latent agent-discovery bug in Pathway's git packs.
- **`fit-pack` public CLI:** `fit-pack stage` wraps the publisher; the `publish-skill-pack` action drops ~150 lines of inline bash for one `fit-pack stage` call. Ships with a launcher, a published skill, a `--help` `documentation` entry, and a Library Guides page (Distribute Skill Packs) linked from the hub.
- **Dropped `npx skills` install instructions** for these packs (generated README, CLAUDE.md, kata-setup, FIT/Kata sites); APM is the single documented install path.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeSD5gGGsUvZumANKcc7iP)_