### PR TITLE
docs(outpost): spec 2100 — one TCC grant for spawned agents (plan + verification runbook)

### DIFF
--- a/products/outpost/macos/TCC-VERIFICATION.md
+++ b/products/outpost/macos/TCC-VERIFICATION.md
@@ -7,11 +7,6 @@ equivalent — TCC state cannot be exercised on Linux or in a headless runner �
 this runbook is the durable guard, run once to diagnose and once per release to
 re-check.
 
-It implements
-[spec 2100](../../../specs/2100-outpost-tcc-grant-inheritance/spec.md) via
-[design-a](../../../specs/2100-outpost-tcc-grant-inheritance/design-a.md) and
-[plan-a](../../../specs/2100-outpost-tcc-grant-inheritance/plan-a.md).
-
 ## What this measures
 
 macOS attributes a TCC-gated access to the accessing process's **responsible
@@ -146,11 +141,11 @@ ad-hoc build with a deterministic cdhash survives a `brew upgrade`).
   work is internal.
 - **Axis 1 fails (a hop resolves to its child)** → the disclaim setting at that
   hop misattributes; apply the recorded attribution-preserving setting to both
-  hops (plan Step 3) and re-run.
+  hops and re-run.
 - **A service fails (Axis 2)** → document the single direct grant for that
-  service on `Outpost.app` (plan Step 4 / Step 6).
+  service on `Outpost.app`.
 - **Grant lost on upgrade (Axis 3)** → ship a Developer ID-signed bundle so the
-  grant pins to the designated requirement (plan Step 5).
+  grant pins to the designated requirement.
 
 ## Results
 

--- a/products/outpost/macos/TCC-VERIFICATION.md
+++ b/products/outpost/macos/TCC-VERIFICATION.md
@@ -1,0 +1,181 @@
+# Outpost TCC Verification Runbook
+
+A manual macOS hardware procedure that both **diagnoses** whether Outpost's
+spawned agents need more than one TCC grant and **re-checks** that a single
+grant to `Outpost.app` still covers them after any change. There is no CI
+equivalent — TCC state cannot be exercised on Linux or in a headless runner — so
+this runbook is the durable guard, run once to diagnose and once per release to
+re-check.
+
+It implements
+[spec 2100](../../../specs/2100-outpost-tcc-grant-inheritance/spec.md) via
+[design-a](../../../specs/2100-outpost-tcc-grant-inheritance/design-a.md) and
+[plan-a](../../../specs/2100-outpost-tcc-grant-inheritance/plan-a.md).
+
+## What this measures
+
+macOS attributes a TCC-gated access to the accessing process's **responsible
+process**, walking the spawn chain. Outpost's chain has two `posix_spawn` hops,
+each carrying a `responsibility_spawnattrs_setdisclaim` call:
+
+```
+Outpost.app  --hop 1-->  fit-outpost daemon  --hop 2-->  claude (node)
+   (signed bundle)        ProcessManager.swift            posix-spawn.js
+```
+
+The goal is that a single grant to `Outpost.app` covers the whole subtree. This
+runbook does **not** assume which disclaim setting achieves that — it measures
+the responsible-process lookup at **each hop** and records the setting that
+keeps `Outpost.app` responsible.
+
+## TCC services and their `tccutil` identifiers
+
+| Resource             | Path                              | TCC service                 | `tccutil` identifier          |
+| -------------------- | --------------------------------- | --------------------------- | ----------------------------- |
+| Mail store read      | `~/Library/Mail/…/Envelope Index` | Full Disk Access            | `SystemPolicyAllFiles`        |
+| Calendar store read  | `~/Library/Calendars/`            | Full Disk Access            | `SystemPolicyAllFiles`        |
+| Knowledge base       | `~/Documents/<kb>`                | Files & Folders (Documents) | `SystemPolicyDocumentsFolder` |
+| Draft-side Mail send | Mail via AppleScript              | Automation (AppleEvents)    | `AppleEvents`                 |
+
+The Calendar store is read **as files** (Full Disk Access); this runbook does
+**not** exercise the distinct EventKit Calendar service, so a green file-access
+result here does not prove Calendar-API coverage.
+
+## Preconditions
+
+- macOS 14 or later.
+- A built, installed `Outpost.app` (note its signing identity — Developer ID or
+  ad-hoc — for the results block).
+- `claude` installed and resolvable by the daemon. The daemon searches
+  `/usr/local/bin`, `~/.claude/bin`, `~/.local/bin`, `/opt/homebrew/bin` in that
+  order — confirm which binary it will spawn.
+- At least one agent configured in `~/.fit/outpost/scheduler.json` with a `kb`
+  that exists.
+- Root access (`sudo`): the Axis 1 reads (`log stream`, `launchctl procinfo`)
+  require it.
+
+## Procedure
+
+Run each step in order. Record outcomes in the **Results** block at the bottom.
+
+**(a) Reset TCC state.** Clear prior grants so the run starts clean:
+
+```sh
+tccutil reset SystemPolicyAllFiles
+tccutil reset SystemPolicyDocumentsFolder
+tccutil reset AppleEvents
+```
+
+Then in **System Settings → Privacy & Security**, remove any existing `node` or
+Claude-CLI (version-string) entries under Full Disk Access, Files & Folders, and
+Automation.
+
+**(b) Grant only `Outpost.app`.** Grant `Outpost.app` Full Disk Access and, if
+prompted, Files & Folders (Documents) and Automation for Mail. Grant **nothing**
+to `node` or the Claude CLI.
+
+**(c) Start the attribution stream, then wake an agent.** The spawned `claude`
+is short-lived, so begin capturing before the wake. In a second terminal, the
+TCC subsystem logs the responsible process for each access decision — this is
+the **authoritative** attribution signal:
+
+```sh
+sudo log stream --predicate 'subsystem == "com.apple.TCC"' --debug
+```
+
+Then wake:
+
+```sh
+fit-outpost wake <agent-name>
+```
+
+**(d) Assert per-hop attribution (Axis 1).** The daemon and its spawned `claude`
+child must both be attributed to `Outpost.app`. While the wake runs, capture
+both hop pids — the `claude` agent is a **direct child** of the daemon, which
+avoids matching the operator's own interactive `claude` session — and read each
+one's responsible process:
+
+```sh
+DAEMON_PID=$(pgrep -f 'Contents/MacOS/fit-outpost daemon' | head -1)  # hop 1 child
+CLAUDE_PID=$(pgrep -P "$DAEMON_PID" | head -1)                        # hop 2 child
+sudo launchctl procinfo "$DAEMON_PID" | grep -i 'responsible'
+sudo launchctl procinfo "$CLAUDE_PID" | grep -i 'responsible'
+```
+
+Read the responsible process from the TCC stream's access lines (authoritative)
+and corroborate with `launchctl procinfo`'s responsible-pid field. Record, **per
+hop**, whether it is `Outpost.app` — a leaf-only check is not sufficient, one
+correct hop can mask an inverted one. If the child exits before you sample it,
+re-wake and capture promptly (or pick an agent whose turn runs longer).
+
+**(e) Assert file-access succeeds under one grant (Axis 1+2, file-access).**
+Confirm the agent read the Mail/Calendar stores and wrote its briefing:
+
+```sh
+ls -t ~/.cache/fit/outpost/state/*_last_output.md | head -1
+```
+
+Confirm no `node` or Claude-CLI entry is **required** in the privacy panes for
+the read to succeed.
+
+**(f) Exercise Automation (Axis 2, AppleEvents).** Trigger a draft-side skill
+(one that drives Mail via AppleScript) and confirm it sends/drafts under the
+single `Outpost.app` Automation grant, with no separate `node`/CLI Automation
+entry.
+
+**(g) Fix C — conditional direct grant.** If any single service still fails
+under the `Outpost.app`-only grant, grant **that one service** (per the table
+above) to `Outpost.app` directly, re-run (c)–(f), and record which service
+needed it. The remedy is still one process — never a grant to `node` or the CLI.
+
+**(h) Persistence across upgrade (Axis 3).** Rebuild and re-sign `Outpost.app`,
+reinstall it over the existing grant, and re-wake:
+
+```sh
+fit-outpost wake <agent-name>
+```
+
+Confirm the grant is still in force with **no** re-prompt. Record the signing
+identity used (Developer ID pins to the bundle's designated requirement; an
+ad-hoc build with a deterministic cdhash survives a `brew upgrade`).
+
+## Interpreting the result
+
+- **All axes pass with one grant, no change made** → the three-grant
+  documentation was stale; only the docs and spawn-site comments change, and the
+  work is internal.
+- **Axis 1 fails (a hop resolves to its child)** → the disclaim setting at that
+  hop misattributes; apply the recorded attribution-preserving setting to both
+  hops (plan Step 3) and re-run.
+- **A service fails (Axis 2)** → document the single direct grant for that
+  service on `Outpost.app` (plan Step 4 / Step 6).
+- **Grant lost on upgrade (Axis 3)** → ship a Developer ID-signed bundle so the
+  grant pins to the designated requirement (plan Step 5).
+
+## Results
+
+Fill in on every run; this block is the durable, tracked record of the
+diagnosis.
+
+```
+Date:                    <YYYY-MM-DD>
+macOS version:           <e.g. 14.5>
+Outpost.app identity:    <Developer ID | ad-hoc>
+
+Axis 1 — per-hop attribution
+  hop 1 (daemon)  responsible process:  <Outpost.app | other>   PASS/FAIL
+  hop 2 (claude)  responsible process:  <Outpost.app | other>   PASS/FAIL
+  attribution-preserving disclaim value (if a change was needed):  <0 | 1 | n/a>
+
+Axis 2 — per-service honoring (under one Outpost.app grant)
+  Full Disk Access (Mail/Calendar read):   PASS/FAIL
+  Files & Folders (Documents KB):           PASS/FAIL
+  Automation (draft-side Mail):             PASS/FAIL
+  service(s) needing a direct grant:        <none | service name(s)>
+
+Axis 3 — persistence across re-signed upgrade
+  grant survived, no re-prompt:             PASS/FAIL
+
+Diagnosed root cause:    <stale docs | disclaim setting | non-inherited service | persistence | combination>
+Fixes applied:           <none | Step 3 | Step 4 | Step 5 | combination>
+```

--- a/specs/2100-outpost-tcc-grant-inheritance/design-a.md
+++ b/specs/2100-outpost-tcc-grant-inheritance/design-a.md
@@ -1,0 +1,143 @@
+# Design 2100-a — One TCC grant for Outpost's spawned agents
+
+Spec 2100 asks that an Outpost user grant macOS access to a single process —
+`Outpost.app` — instead of three (`Outpost.app`, `node`, the Claude Code CLI).
+The spec leaves the root cause open: the three-grant instruction may be a live
+runtime defect or stale documentation, and the effect of
+`responsibility_spawnattrs_setdisclaim` must be confirmed on hardware before any
+change. This design is therefore **diagnosis-gated**. It does not pick a fix up
+front; it defines a diagnostic that measures three independent axes, maps each
+failing axis to a fix that composes with the others, and records the implicated
+axes in the implementation (spec criterion 4).
+
+## Attribution model
+
+macOS attributes a TCC-gated access to the accessing process's **responsible
+process**, found by walking the spawn chain — provided each hop is created with
+`posix_spawn` (not `fork`+`exec`) so the spawn attributes apply. A single grant
+to the responsible process covers the subtree it spawns. Outpost's chain has two
+such hops, each carrying a `responsibility_spawnattrs_setdisclaim(attr, d)` call
+where `d` is a **binary** disclaim flag — not a tunable range — set to `1` at
+both hops today. The repo's comments and spec 0600 read `1` as "child disclaims,
+responsibility flows up to `Outpost.app`"; the first spec panel split on whether
+that reading is correct. Which of the two flag settings actually keeps
+`Outpost.app` responsible is what the harness measures — it is not assumed here.
+These two calls are the only knob that steers attribution along the chain:
+
+```mermaid
+flowchart LR
+  A["Outpost.app<br/>(signed bundle)"] -->|"hop 1: posix_spawn + disclaim<br/>ProcessManager.swift (silgen)"| B["fit-outpost daemon"]
+  B -->|"hop 2: posix_spawn + disclaim<br/>posix-spawn.js (Bun FFI)"| C["claude (node)"]
+  C --> R[("~/Library Mail/Calendar · ~/Documents KB · AppleEvents")]
+  A -. "intended responsible process for the whole subtree" .-> R
+```
+
+The two hops are independent call sites in different languages, but they
+implement one primitive and must agree: if **either** hop attributes its child
+to itself, that child needs its own grant. The design governs them by one
+contract — "both hops keep `Outpost.app` the responsible process" — not two
+independent toggles, and the harness asserts attribution **per hop**, not only
+at the leaf, so one correct hop cannot mask an inverted one.
+
+## TCC services per resource (spec obligation, line 18)
+
+The spec requires the design to pin which TCC service each resource needs; the
+harness confirms these on hardware:
+
+| Resource             | Path                              | TCC service                 |
+| -------------------- | --------------------------------- | --------------------------- |
+| Mail store read      | `~/Library/Mail/…/Envelope Index` | Full Disk Access            |
+| Calendar store read  | `~/Library/Calendars/`            | Full Disk Access            |
+| Knowledge base       | `~/Documents/<kb>`                | Files & Folders (Documents) |
+| Draft-side Mail send | Mail via AppleScript              | Automation (AppleEvents)    |
+
+The product page's "Files & Folders" framing covers the `~/Documents` knowledge
+base; the Mail/Calendar reads under `~/Library` are Full Disk Access. They are
+different resources, not a contradiction — the docs rewrite states both. The
+harness reads the Calendar store as files (Full Disk Access); it does **not**
+exercise the distinct EventKit Calendar service, so a green result here is not
+read as covering the Calendar API path.
+
+## Diagnostic: three composable axes
+
+One hardware procedure (the runbook below) resets TCC, grants **only**
+`Outpost.app`, wakes an agent, and measures three axes. Axes are independent —
+zero, one, or several may fail, and their fixes stack:
+
+```mermaid
+flowchart TD
+  H["Harness: reset TCC, grant ONLY Outpost.app, wake agent"] --> X1{"Axis 1 — per-hop attribution:<br/>does each hop's child resolve<br/>to Outpost.app?"}
+  H --> X2{"Axis 2 — per-service honoring:<br/>under correct attribution, does each<br/>service (FDA / Files&Folders / Automation)<br/>succeed with one grant?"}
+  H --> X3{"Axis 3 — persistence:<br/>does the grant survive a<br/>rebuilt, re-signed bundle?"}
+  X1 -->|hop misattributes| FA["Fix A — flip the offending hop to the<br/>other (binary) disclaim setting; if both<br/>are already correct, Axis 1 passes, no change"]
+  X2 -->|a service not inherited| FC["Fix C — that service is granted/<br/>documented on Outpost.app directly<br/>(still one process)"]
+  X3 -->|grant lost on rebuild| FB["Fix B — consume Developer ID identity<br/>so the grant pins to the bundle DR"]
+  X1 -->|all pass| D["All axes pass → docs were stale →<br/>docs-only, classification drops to internal"]
+  X2 -->|all pass| D
+  X3 -->|all pass| D
+```
+
+If every axis already passes, the three-grant instruction was stale: the only
+change is docs and comments, and the spec's classification drops to internal.
+
+## Components
+
+| Component                         | Where                                                                                           | Role                                                                                                                 |
+| --------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Diagnostic / verification runbook | Owned by the Outpost macOS package (path is a plan decision)                                    | The single hardware procedure detailed in § Verification harness; run once to diagnose, once per release to re-check |
+| Spawn attribution control         | `ProcessManager.swift` (hop 1), `libraries/libmacos/src/posix-spawn.js` (hop 2)                 | The two `setdisclaim` calls; Fix A flips the implicated hop(s) to the attribution-preserving setting                 |
+| Signed bundle identity            | `sign-app.sh` (`MACOS_SIGN_IDENTITY`), `macos-signing` action — already wired                   | Consumed, not built; Fix B's persistence dimension, supplied by the cert rollout                                     |
+| TCC docs                          | `websites/fit/outpost/index.md`, `websites/fit/docs/getting-started/engineers/outpost/index.md` | Rewritten to one grant + a one-time migration note, after a green harness run                                        |
+| Spawn-site comments               | both hops                                                                                       | Reconciled to the verified semantics, so the next contributor cannot silently invert the knob                        |
+
+## On the signing identity (Fix B's real role)
+
+Developer ID signing is **not** an in-session fix for misattribution: if Axis 1
+already resolves to `Outpost.app`, the grant on `Outpost.app` is what TCC
+consults, and identity does not change that. Identity governs Axis 3 only — what
+the grant pins to and whether it survives a rebuilt bundle — plus the
+trustworthy name the user authorizes. So 2100 is **not blocked on the
+certificate rollout**: the spec's in-session three-grant gap is closed by Fix A
+and/or Fix C, and Axis 3 already has a fallback in spec 1170's deterministic
+ad-hoc cdhash (a single ad-hoc grant survives a `brew upgrade`). Developer ID is
+the occasion and the stronger persistence guarantee, owned by the cert rollout,
+not a 2100 dependency.
+
+## Verification harness (single home for the procedure)
+
+One tracked runbook encodes spec criteria 1–3 as a checklist: `tccutil reset`
+the services in § TCC services → grant only `Outpost.app` → wake an agent →
+assert each hop's responsible-process lookup (`launchctl procinfo` / a
+`log stream` TCC predicate) resolves to `Outpost.app`, the Mail/Calendar read
+succeeds, and no `node`/CLI entry is required (criterion 1); a draft-side action
+exercises Automation (criterion 2); a re-signed-bundle reinstall checks
+persistence (criterion 3). This is the only durable guard — TCC state is not
+exercisable in CI or on Linux — so it doubles as the per-release re-check.
+
+## Key decisions
+
+| Decision                                                        | Why                                                                                                        | Rejected alternative                                                                     |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Diagnose on hardware before changing code                       | The repo's comments and spec 0600 may be wrong about the knob; an inverted flip silently preserves the gap | Trust the comments and flip the flag — the failure mode the spec exists to avoid         |
+| Three composable axes, not one exclusive branch tree            | Failures can co-occur (a wrong hop value and a non-inherited service); their fixes stack                   | A mutually-exclusive 4-way decision tree — forces one exit when several causes may hold  |
+| Treat both spawn hops as one governed control, assert per hop   | Either hop disclaiming to its child reopens the gap; a leaf-only check hides it                            | Fix/observe only the daemon→`claude` hop — leaves hop 1 able to break attribution unseen |
+| Pin TCC services in the design                                  | The spec assigns this to the design (line 18)                                                              | Defer service identification to the harness — leaves the docs rewrite ungrounded         |
+| One runbook for diagnosis and per-release re-check              | TCC behavior is not exercisable in CI/Linux; a manual re-check is the only durable guard                   | Build a CI assertion — impossible without macOS TCC state                                |
+| Docs rewrite gated on a green harness run; clean break, no shim | Writing one-grant instructions before the behavior is confirmed would mislead users                        | Rewrite docs speculatively, or keep three-grant docs as a fallback                       |
+
+## Recording the diagnosed outcome (satisfies criterion 4)
+
+Because the harness runs after this design is written, the diagnosed outcome —
+which axes were implicated and which fixes were applied — is recorded as part of
+the implementation, in the implementation PR alongside the code/doc changes, not
+as a re-approved design. The plan sequences the diagnostic run first, so its
+result is known before the fix and docs steps; that recorded outcome in the
+implementation is what spec criterion 4 verifies. The runbook itself is a
+tracked file the implementation creates (so the per-release re-check has a
+home); its path is a plan decision.
+
+## Out of scope (unchanged from spec)
+
+Terminal-invoked CLI attribution (deferred in spec 0600), the signing-pipeline
+mechanics themselves, the config trust boundary / spawn-env allow-set (spec
+1360), and OS-sandboxing the spawned agent.

--- a/specs/2100-outpost-tcc-grant-inheritance/plan-a.md
+++ b/specs/2100-outpost-tcc-grant-inheritance/plan-a.md
@@ -1,0 +1,177 @@
+# Plan 2100-a — One TCC grant for Outpost's spawned agents
+
+Implements [design-a.md](design-a.md) for [spec.md](spec.md).
+
+## Approach
+
+The design is diagnosis-gated, so the plan is too: author the verification
+runbook, run it once on macOS hardware to measure the three axes, apply only the
+fix(es) the run implicates, then re-run the runbook green before rewriting the
+docs and reconciling the spawn-site comments. The disclaim flag is treated as a
+binary setting the run identifies — never flipped blind. Steps 1, 6, 7 are
+unconditional; steps 3–5 fire only on their axis. The diagnosed outcome lands in
+the runbook's tracked results block (Step 2), discharging spec criterion 4.
+Steps 2–5 require a Mac; the rest do not.
+
+Libraries used: none.
+
+## Step 1 — Author the TCC verification runbook
+
+Create the single hardware procedure that both diagnoses and re-checks.
+
+- Created: `products/outpost/macos/TCC-VERIFICATION.md`
+
+Contents: a checklist that (a) `tccutil reset SystemPolicyAllFiles`,
+`tccutil reset SystemPolicyDocumentsFolder`, and `tccutil reset AppleEvents`
+(the identifiers for the design's Full Disk Access / Files & Folders /
+Automation services), and clears any `node`/CLI privacy entries; (b) grants
+**only** `Outpost.app`; (c) wakes an agent (`fit-outpost wake`); (d) for **each
+hop** resolves the live child's responsible process (`launchctl procinfo <pid>`
+and a `log stream --predicate 'subsystem == "com.apple.TCC"'` capture) and
+asserts it is `Outpost.app`; (e) confirms the Mail/Calendar read succeeds and
+the agent writes its briefing under `~/.cache/fit/outpost/state/` with no
+`node`/CLI entry required (Axis 1+2, file-access; reads the Calendar store as
+files only — not the EventKit Calendar service, per design § "TCC services");
+(f) triggers a draft-side skill to exercise Automation (Axis 2, AppleEvents);
+(g) for any service that still fails under the single grant, grants **that one
+service** to `Outpost.app` and re-checks (the Fix C path); (h) reinstalls a
+re-signed bundle over the grant and re-wakes (Axis 3). The file ends with a
+**results block** of fixed fields — per-axis pass/fail, the Axis 1
+attribution-preserving disclaim value, any service requiring a direct grant, and
+the signing identity in force — which Step 2 fills in as the durable, tracked
+record of the diagnosis (and the criterion-4 record).
+
+Verification: the file exists, maps each design service to its `tccutil`
+identifier, enumerates the conditional Fix C grant, and carries an empty results
+block with the fields above.
+
+## Step 2 — Run the diagnostic on hardware (manual gate)
+
+Execute Step 1's runbook on macOS 14+ against an installed, signed
+`Outpost.app`; record which axes fail.
+
+- Modified: `products/outpost/macos/TCC-VERIFICATION.md` (fill in the results
+  block)
+
+Change: fill every field of the runbook's results block — per-axis pass/fail,
+the Axis 1 attribution-preserving disclaim value, any service needing a direct
+grant, the signing identity. This committed block is the input to Steps 3–5 and
+the durable record of the diagnosed root cause (spec criterion 4); the
+implementation PR body restates it for reviewers.
+
+Verification: the results block names the implicated axes (or "all pass"), the
+Axis 1 value, and — if all axes passed — that the change is docs-only and the
+classification drops to internal.
+
+## Step 3 — Fix A: correct the disclaim setting (only if Axis 1 fails)
+
+Set the implicated hop(s) to the attribution-preserving setting recorded in Step
+2's results block; if the recorded value equals the current setting, make no
+change here.
+
+- Modified: `products/outpost/macos/Outpost/Sources/ProcessManager.swift` (the
+  `responsibility_spawnattrs_setdisclaim` call, ~line 88)
+- Modified: `libraries/libmacos/src/posix-spawn.js` (the `setDisclaim` call,
+  ~line 160)
+
+Change: at each implicated hop, set the `responsibility_spawnattrs_setdisclaim`
+flag to the value Step 2 recorded (the binary alternative to the current `1`).
+Anchor on the symbol name, not the line number, since Step 7 edits adjacent
+comments. Both hops carry the same value per the design's single-contract rule.
+
+Verification: re-running the runbook shows each hop's child resolving to
+`Outpost.app`.
+
+## Step 4 — Fix C: pin a non-inherited service to Outpost.app (only if Axis 2 fails)
+
+Record which service is not covered by the single grant; its remedy is the
+conditional direct-grant sub-step the runbook already performs (Step 1g), and
+the docs (Step 6) instruct that single direct grant. Its remedy is still one
+process.
+
+- Modified: `products/outpost/macos/TCC-VERIFICATION.md` (name the non-inherited
+  service in the results block)
+
+Change: name the affected service (per design § "TCC services per resource") in
+the results block. No spawn-code change.
+
+Verification: re-running the runbook's Step 1g sub-step (that service granted to
+`Outpost.app`) shows the affected resource succeeding under one process.
+
+## Step 5 — Fix B: ensure Developer ID persistence (only if Axis 3 fails)
+
+A release-configuration dependency, not a code change here: confirm the release
+build sets `MACOS_SIGN_IDENTITY` (Developer ID) via the `macos-signing` action
+so the grant pins to the bundle's designated requirement. If certs are
+unavailable, spec 1170's deterministic ad-hoc cdhash is the interim persistence
+path and this step defers without blocking 2100.
+
+- Modified: `products/outpost/macos/TCC-VERIFICATION.md` (record the signing
+  identity in force during the Axis 3 reinstall)
+
+Change: none in 2100's code; record whether the Axis 3 run used a Developer ID
+or ad-hoc identity. Step 6's docs state the persistence story for whichever
+identity ships (re-grant once on the Developer ID cutover; ad-hoc survives
+`brew upgrade` in the interim).
+
+Verification: re-running the runbook's Axis 3 reinstall preserves the grant with
+no re-prompt under the identity in force.
+
+## Step 6 — Rewrite the macOS Privacy & Security docs (gated on a green run)
+
+Replace the three-process instruction with one process plus the pinned services
+and a one-time migration note. Only after steps 2–5 leave the runbook green.
+
+- Modified: `websites/fit/outpost/index.md` (§ macOS Privacy & Security)
+- Modified: `websites/fit/docs/getting-started/engineers/outpost/index.md` (§
+  macOS Privacy & Security, lines 73–83)
+
+Change: drop the `node` and CLI-version bullets; instruct a single grant to
+`Outpost.app`, mapped to the resources from the design's service table (Full
+Disk Access for Mail/Calendar, Files & Folders for the `~/Documents` knowledge
+base, Automation for draft-side Mail); add a short migration note (a user aid,
+not a retained three-grant path) that users upgrading from a three-grant install
+re-grant `Outpost.app` once and may remove the stale `node`/CLI grants; state
+the persistence story for the identity in force (Developer ID survives upgrades;
+the interim ad-hoc build survives `brew upgrade`).
+
+Verification: both pages name only `Outpost.app` and carry the migration note;
+`fit-doc` build passes.
+
+## Step 7 — Reconcile the spawn-site comments
+
+Rewrite the responsibility-call comments to match the verified semantics. Runs
+after Step 3 so it describes the committed flag value.
+
+- Modified: `products/outpost/macos/Outpost/Sources/ProcessManager.swift`
+  (comments, lines 3–8 and 86–87)
+- Modified: `libraries/libmacos/src/posix-spawn.js` (comments, lines 13–15 and
+  158–159)
+- Modified: `libraries/libmacos/src/tcc-responsibility.js` (if its comments
+  carry any attribution-direction claim — survey and reconcile or confirm none)
+
+Change: state what the run confirmed the disclaim flag does and that both hops
+must hold the attribution-preserving value; remove the unverified "inherit
+Outpost.app" wording wherever the run contradicted it, across all three files.
+
+Verification: the three files describe the same, run-confirmed behavior; no
+comment still asserts an unverified direction (spec criterion 6).
+
+## Risks
+
+- **Hardware-only diagnosis.** Steps 2–5 cannot run in CI or on Linux; an
+  implementer without a Mac can author steps 1, 6, 7 but cannot close the loop.
+- **Misread diagnostic inverts Fix A.** Flipping the disclaim flag the wrong way
+  silently worsens the gap; the per-hop runbook assertion (Step 1d) is the guard
+  and must pass before Step 6.
+- **Cert availability.** If Axis 3 is implicated but Developer ID certs are not
+  yet issued, Step 5 defers to the rollout; do not block the other fixes or the
+  docs on it.
+
+## Execution recommendation
+
+Sequential: Step 1 → Step 2 → (Steps 3/4/5 as implicated) → green runbook re-run
+→ Steps 6/7. An engineering agent authors Step 1 and applies Step 3; a
+macOS-hardware operator runs Steps 2, 4, 5 (the hardware run and its
+results-block records); `technical-writer` authors Step 6; an engineering agent
+does Step 7. Steps 6 and 7 may run in parallel once the runbook is green.

--- a/specs/2100-outpost-tcc-grant-inheritance/spec.md
+++ b/specs/2100-outpost-tcc-grant-inheritance/spec.md
@@ -1,0 +1,161 @@
+# Spec 2100 — One TCC grant for Outpost's spawned agents
+
+**Classification:** Product-aligned. The deliverable is the macOS permission
+experience of an Outpost end user ([JTBD.md](../../JTBD.md) — Outpost, Empowered
+Engineers: keep track of people, projects, and threads without continuous
+effort). If diagnosis (below) shows the runtime already needs only one grant and
+the three-grant instruction is stale documentation, the work narrows to a
+documentation correction and the classification drops to internal — the design
+records which case holds.
+
+## Problem
+
+Outpost runs a daemon, launched by `Outpost.app`, that spawns `claude` agents on
+a schedule to read content the user chose to sync — Apple Mail and Calendar.
+Those reads cross macOS TCC boundaries: reading the Mail and Calendar stores
+needs a macOS file-access grant (the sync skills name Full Disk Access; the
+product page documents per-folder Files & Folders grants — the design must pin
+which TCC service each resource actually requires), and the draft-side skills
+drive Mail through AppleEvents (Automation).
+
+Today the Outpost documentation instructs the user to grant TCC access to
+**three** separate processes:
+
+- **Outpost.app** — the launcher
+- **node** — runs skill scripts (Homebrew's `claude` is a node-shebang script,
+  so `node` is the executable macOS sees)
+- a version string (e.g. the CLI's version) — the Claude Code CLI, which macOS
+  shows by version instead of by name
+
+Evidence: `websites/fit/outpost/index.md` § macOS Privacy & Security, and
+`websites/fit/docs/getting-started/engineers/outpost/index.md`.
+
+That three-grant instruction sits in unexplained tension with the project's own
+record. Spec 0600 (written for `fit-basecamp`, Outpost's prior name) set as a
+success criterion that the bundle-launched scheduler disclaims TCC
+responsibility when spawning `claude`, with a hardware test that "observes no TCC
+prompt plus a responsible-process lookup that resolves to the basecamp bundle."
+In other words, the design intends — and 0600 claimed to verify — that a single
+grant to the launching app covers the spawned subtree through the macOS
+responsible-process model. Both spawn sites
+(`products/outpost/macos/Outpost/Sources/ProcessManager.swift`,
+`libraries/libmacos/src/posix-spawn.js`) carry that disclaim call for exactly
+this purpose.
+
+So the project record says single-grant coverage should work, while the
+user-facing docs tell users to grant three processes. One of them is wrong, and
+which one is unknown:
+
+- The runtime may genuinely require three grants (the responsible-process
+  attribution is not actually collapsing to `Outpost.app` for these resources,
+  or behaves differently for file-access grants than for the Calendar/Contacts
+  case 0600 tested), and the docs are correct.
+- Or the runtime already needs only one grant and the three-grant instruction is
+  stale or over-cautious documentation.
+
+This spec exists to settle that and leave the user needing a single grant. It is
+explicitly **not** committing to a direction for the disclaim call: the
+documented effect of `responsibility_spawnattrs_setdisclaim` and whether the
+current call value produces single-bundle attribution for Mail/Calendar file
+access is the central question the design must resolve empirically on macOS
+hardware — the project's own code comments and the verification a future change
+would rest on cannot both be assumed correct.
+
+A new input motivates revisiting this now: per the triggering request, the team
+has obtained Apple Developer signing certificates for the Outpost binaries (an
+assumption this spec takes from that request — the repository carries the
+signing infrastructure gated on a secret, but cannot prove a certificate was
+issued). Today the bundles are **ad-hoc** signed (spec 1290 explicitly excludes
+Developer ID signing and notes "the current ad-hoc signature is what … TCC
+grants attach to"), with a deterministic cdhash so an ad-hoc grant survives a
+`brew upgrade` rebuild on the brew lane (spec 1170). Moving to a stable, named
+Developer ID identity changes what TCC pins a grant to and is the natural moment
+to close the three-grant gap rather than carry it onto the signed builds. The
+identity switch itself is owned by the certificate rollout, not this spec.
+
+## Why it matters
+
+- **First-run friction.** A new Outpost user faces three permission prompts
+  before the product does anything, and must reason about which folders each of
+  three processes needs.
+- **Confusing, low-trust prompts.** Authorizing a bare `node` and a numeric
+  version string gives the user no way to tell what they are granting. One named,
+  signed application is a clear authorization decision — and Developer ID signing
+  makes that name trustworthy.
+- **Recurring re-prompts.** A `node` upgrade or a `claude` version bump presents
+  a new process identity, re-triggering prompts the user already answered.
+
+## Scope
+
+Affected:
+
+| Area | What changes |
+|---|---|
+| TCC attribution for the `Outpost.app` → daemon → `claude` (`node`) spawn chain | Whichever layer the diagnosis finds responsible — within a bounded search space of the spawn-site disclaim call, the signing identity the grant pins to, and the documentation — is corrected so a single grant to `Outpost.app` covers the chain; if attribution already works, no code change |
+| Outpost macOS Privacy & Security docs | `websites/fit/outpost/index.md` and `websites/fit/docs/getting-started/engineers/outpost/index.md` describe granting one process, with a one-time re-grant note for existing users |
+| Spawn-site comments | The comments describing the responsibility call are reconciled with the behavior the design verifies on hardware |
+
+Excluded:
+
+- **Terminal-invoked CLI path.** Running the CLI directly (a `PATH` symlink
+  invoked from a terminal) makes the terminal the responsible process. That path
+  was deferred in spec 0600 and is unchanged; the single-grant outcome here
+  applies to `Outpost.app` launched as an app / login item.
+- **The signing pipeline mechanics** (introducing Developer ID signing, cdhash
+  determinism) — specs 1170/1290 and the certificate rollout own that; this spec
+  consumes a stable signed identity, it does not build one.
+- **Config trust boundary and the spawn-env allow-set** (spec 1360) — unchanged.
+- **OS-sandboxing the spawned agent** — the residual tracked in
+  `products/outpost/CLAUDE.md`; out of scope.
+
+## Success criteria
+
+1. With a macOS file-access grant given to **only** `Outpost.app` — no separate
+   grant to `node` or the Claude Code CLI — a scheduled agent wake reads the
+   Apple Mail and Calendar stores and completes a sync, and the relevant macOS
+   privacy pane shows no required entry for `node` or the CLI version string.
+   Verified by a macOS hardware test: `tccutil reset` the relevant services,
+   grant only `Outpost.app`, trigger a wake, confirm sync output under the cache
+   directory and inspect the privacy panes.
+2. The same single-grant coverage holds for a draft-side action that drives Mail
+   through AppleEvents (Automation), confirming the outcome is not specific to one
+   TCC service. Verified on the same hardware test by triggering a draft-side
+   skill after granting only `Outpost.app`.
+3. After the one-time migration grant, a subsequent app upgrade — replacing
+   `Outpost.app` with a rebuilt, re-signed Developer ID bundle — keeps the grant
+   in force with no re-prompt. Verified by reinstalling a freshly built signed
+   bundle over an existing grant and running a wake with no new prompt.
+4. The design document records the diagnosed root cause: whether the three-grant
+   requirement was live runtime behavior (and which layer fixed it) or stale
+   documentation. Verified by reading the design.
+5. The Outpost macOS Privacy & Security documentation describes granting one
+   process and notes the one-time re-grant on migration. Verified by reading the
+   two pages named in Scope.
+6. The repository carries one consistent description of how Outpost's spawned
+   agents obtain TCC access. Verified by reading the spawn-site comments against
+   the documented behavior.
+
+## Constraints and risks
+
+- **Requires hardware verification; no CI guard.** The responsible-process model
+  and `responsibility_spawnattrs_setdisclaim` cannot be exercised in CI or on
+  Linux, so every behavioral criterion terminates in a manual macOS hardware test
+  (consistent with spec 0600's verification). There is no durable CI regression
+  guard that single-grant behavior stays fixed across future builds; the design
+  should propose the lightest-weight manual re-check that fits the release.
+- **Direction of the disclaim call is unsettled.** The project's own comments and
+  spec 0600 read the call one way; that reading must be confirmed against actual
+  hardware behavior before any change, because an inverted change would silently
+  preserve or worsen the gap rather than fail loudly.
+- **Cross-signer children.** `node` (Homebrew) and `claude` (Anthropic-signed)
+  carry signing identities distinct from a Developer-ID-signed `Outpost.app`
+  (and an ad-hoc bundle carries no Team ID at all). Whether the
+  responsible-process model attributes the grant to `Outpost.app` regardless of a
+  child's own signature must be confirmed on hardware (criteria 1–2 exercise this
+  directly), not assumed.
+- **One-time migration for existing users.** If closing the gap changes
+  attribution, existing users re-grant `Outpost.app` once on migration, after
+  which the stale `node` and Claude-CLI grants are unnecessary. This is a real
+  cost for the persona — a re-prompt after an update they did not initiate — and
+  must be weighed against the first-run friction removed and called out in the
+  docs, not left to surprise.


### PR DESCRIPTION
## Summary

Lands spec 2100 — collapsing the three macOS TCC grants an Outpost user must give today (`Outpost.app`, `node`, the Claude Code CLI) down to one grant on `Outpost.app` — through the spec → design → plan pipeline, plus the first implementation artifact.

- `specs/2100-outpost-tcc-grant-inheritance/spec.md` — WHAT/WHY. Root cause held open (live runtime defect vs. stale docs); the disclaim-call direction is treated as unverified.
- `…/design-a.md` — WHICH/WHERE. Diagnosis-gated, three composable axes (per-hop responsible-process attribution / per-service honoring / grant persistence), TCC services pinned per resource, signing scoped to persistence only.
- `…/plan-a.md` — HOW/WHEN. Author the runbook → run it → apply only the implicated fix → re-run green → rewrite docs + reconcile spawn-site comments.
- `products/outpost/macos/TCC-VERIFICATION.md` — plan Step 1. The hardware runbook that diagnoses and (per release) re-checks single-grant coverage, with a fixed-field results block that is the durable record.

Each artifact passed two independent review panels (technical + product for the spec).

### Scope / what this does NOT do

This is **not** the behavioral fix. Plan Steps 2–7 — running the diagnostic on a Mac, applying whichever fix it implicates (the disclaim setting, a direct service grant, or Developer ID signing), and rewriting the user-facing docs/comments — all require macOS hardware and are a follow-up. No spawn code, no user-facing docs, and no spawn-site comments change in this PR. STATUS for 2100 is `plan approved`, not `plan implemented`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFTke9hMBWxMj1ZTNPDuBb

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFTke9hMBWxMj1ZTNPDuBb)_