### PR TITLE
fix(outpost): inherit fit-outpost.app as TCC responsible process

### DIFF
--- a/libraries/libmacos/scripts/build-app.sh
+++ b/libraries/libmacos/scripts/build-app.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Assemble a macOS .app bundle from compiled binaries and resources.
 #
 # Usage: build-app.sh [options]
-#   --bundle-name NAME        Bundle directory name (e.g. "Outpost" → Outpost.app)
+#   --bundle-name NAME        Bundle directory name (e.g. "fit-outpost" → fit-outpost.app)
 #   --primary-exec PATH       Path to the primary executable (becomes CFBundleExecutable)
 #   --extra-exec PATH         Additional executable to place in Contents/MacOS/ (repeatable)
 #   --info-plist PATH         Path to Info.plist to embed

--- a/libraries/libmacos/src/posix-spawn.js
+++ b/libraries/libmacos/src/posix-spawn.js
@@ -2,7 +2,7 @@
 
 // Bun FFI wrapper for posix_spawn (macOS only).
 //
-// Used by the scheduler when running inside Outpost.app so that child
+// Used by the scheduler when running inside fit-outpost.app so that child
 // processes (claude) inherit TCC attributes from the responsible binary.
 
 import { dlopen, ptr } from "bun:ffi";
@@ -10,9 +10,11 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// responsibility_spawnattrs_setdisclaim makes the spawned child disclaim
-// TCC "responsible process" status, so macOS checks the parent's responsible
-// process (Outpost.app) instead.
+// responsibility_spawnattrs_setdisclaim controls the spawned child's TCC
+// "responsible process". With disclaim = 1 the child becomes responsible for
+// itself; with disclaim = 0 (what we pass below) it keeps the parent chain's
+// responsible process, so macOS attributes the child's access to
+// fit-outpost.app.
 const {
   symbols: { responsibility_spawnattrs_setdisclaim: setDisclaim },
 } = dlopen("/usr/lib/system/libquarantine.dylib", {
@@ -155,9 +157,12 @@ export function spawn(executable, args, env, cwd, runtime) {
 
   libc.symbols.posix_spawnattr_init(attr);
 
-  // Disclaim TCC responsibility so the child inherits the responsible
-  // process from the parent chain (ultimately Outpost.app).
-  setDisclaim(attr, 1);
+  // Do NOT disclaim TCC responsibility: with disclaim = 0 the child keeps the
+  // parent chain's responsible process, so its access is attributed to
+  // fit-outpost.app and a single grant to the app covers the whole subtree.
+  // (disclaim = 1 makes the child responsible for itself, defeating the
+  // single-grant model — see products/outpost/macos/TCC-VERIFICATION.md.)
+  setDisclaim(attr, 0);
 
   libc.symbols.posix_spawn_file_actions_init(fa);
 

--- a/products/outpost/CLAUDE.md
+++ b/products/outpost/CLAUDE.md
@@ -44,11 +44,14 @@ environment is a user-only trust assumption, the same as the two roots above. A
 spawned agent cannot influence it, so the injection chain runs through
 `config.env`, which the allow-set closes.
 
-All three wake paths (scheduler tick `src/scheduler.js`, socket-mediated wake
-`src/socket-server.js`, direct-CLI `fit-outpost wake` in `src/outpost.js`)
-forward `config.env` into the one `buildSpawnEnv` function, so they produce an
-identical filtered env from identical config. Do not re-introduce a per-path env
-merge.
+Both spawn paths (scheduler tick `src/scheduler.js`, socket-mediated wake
+`src/socket-server.js`) forward `config.env` into the one `buildSpawnEnv`
+function, so they produce an identical filtered env from identical config. The
+`fit-outpost wake` CLI (`src/outpost.js`) does **not** spawn itself — it
+forwards the wake over the daemon socket (so the spawn descends from
+`fit-outpost.app` for TCC attribution), which routes it through the
+socket-mediated path. Do not re-introduce a per-path env merge, and do not
+re-introduce a local CLI spawn that would bypass `buildSpawnEnv`.
 
 ## State-File Naming (load-bearing)
 

--- a/products/outpost/macos/Outpost/Sources/AppDelegate.swift
+++ b/products/outpost/macos/Outpost/Sources/AppDelegate.swift
@@ -1,6 +1,6 @@
 import AppKit
 
-/// App delegate for Outpost.app.
+/// App delegate for fit-outpost.app.
 ///
 /// Manages the process tree: spawns the scheduler as a child process
 /// via posix_spawn and hosts the status menu bar UI in-process.

--- a/products/outpost/macos/Outpost/Sources/ProcessManager.swift
+++ b/products/outpost/macos/Outpost/Sources/ProcessManager.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-// Private API: makes the spawned child disclaim TCC "responsible process"
-// status so macOS checks the parent app (Outpost.app) for TCC grants.
+// Private API controlling the spawned child's TCC "responsible process".
+// Passing 0 (below) keeps the parent chain's responsible process so macOS
+// checks fit-outpost.app for TCC grants; passing 1 would make the child
+// responsible for itself.
 @_silgen_name("responsibility_spawnattrs_setdisclaim")
 func responsibility_spawnattrs_setdisclaim(
     _ attr: UnsafeMutablePointer<posix_spawnattr_t?>, _ disclaim: Int32
@@ -10,9 +12,9 @@ func responsibility_spawnattrs_setdisclaim(
 /// Manages the scheduler as a child process using posix_spawn.
 ///
 /// posix_spawn is required (instead of fork+exec) so that TCC attributes
-/// inherit from the responsible binary (Outpost.app). This lets child
+/// inherit from the responsible binary (fit-outpost.app). This lets child
 /// processes (the scheduler, and claude spawned by the scheduler) access
-/// Calendar, Contacts, and other protected resources under Outpost's
+/// Calendar, Contacts, and other protected resources under fit-outpost.app's
 /// TCC grants.
 class ProcessManager {
     private var schedulerPID: pid_t = 0
@@ -83,9 +85,11 @@ class ProcessManager {
         var attr: posix_spawnattr_t?
         posix_spawnattr_init(&attr)
 
-        // Disclaim TCC responsibility so fit-outpost (and its children)
-        // inherit Outpost.app as the responsible process.
-        _ = responsibility_spawnattrs_setdisclaim(&attr, 1)
+        // Keep TCC responsibility with the parent chain (disclaim = 0) so
+        // fit-outpost (and its children, including claude) inherit
+        // fit-outpost.app as the responsible process. A single TCC grant to
+        // the app then covers the whole spawned subtree.
+        _ = responsibility_spawnattrs_setdisclaim(&attr, 0)
 
         var pid: pid_t = 0
         let result = posix_spawn(

--- a/products/outpost/macos/TCC-VERIFICATION.md
+++ b/products/outpost/macos/TCC-VERIFICATION.md
@@ -2,7 +2,7 @@
 
 A manual macOS hardware procedure that both **diagnoses** whether Outpost's
 spawned agents need more than one TCC grant and **re-checks** that a single
-grant to `Outpost.app` still covers them after any change. There is no CI
+grant to `fit-outpost.app` still covers them after any change. There is no CI
 equivalent — TCC state cannot be exercised on Linux or in a headless runner — so
 this runbook is the durable guard, run once to diagnose and once per release to
 re-check.
@@ -14,14 +14,18 @@ process**, walking the spawn chain. Outpost's chain has two `posix_spawn` hops,
 each carrying a `responsibility_spawnattrs_setdisclaim` call:
 
 ```
-Outpost.app  --hop 1-->  fit-outpost daemon  --hop 2-->  claude (node)
+fit-outpost.app  --hop 1-->  fit-outpost daemon  --hop 2-->  claude (node)
    (signed bundle)        ProcessManager.swift            posix-spawn.js
 ```
 
-The goal is that a single grant to `Outpost.app` covers the whole subtree. This
-runbook does **not** assume which disclaim setting achieves that — it measures
-the responsible-process lookup at **each hop** and records the setting that
-keeps `Outpost.app` responsible.
+The goal is that a single grant to `fit-outpost.app` covers the whole subtree.
+Both spawn sites achieve this by passing `disclaim = 0`
+(`ProcessManager.swift`, `posix-spawn.js`): the child keeps the parent chain's
+responsible process rather than becoming responsible for itself, so attribution
+flows up to `fit-outpost.app`. This runbook re-measures the responsible-process
+lookup at **each hop** per release to confirm that setting still holds — an
+inverted `disclaim = 1` would make each child responsible for itself and
+silently break the single-grant model.
 
 ## TCC services and their `tccutil` identifiers
 
@@ -39,13 +43,20 @@ result here does not prove Calendar-API coverage.
 ## Preconditions
 
 - macOS 14 or later.
-- A built, installed `Outpost.app` (note its signing identity — Developer ID or
+- A built, installed `fit-outpost.app` (note its signing identity — Developer ID or
   ad-hoc — for the results block).
 - `claude` installed and resolvable by the daemon. The daemon searches
   `/usr/local/bin`, `~/.claude/bin`, `~/.local/bin`, `/opt/homebrew/bin` in that
   order — confirm which binary it will spawn.
 - At least one agent configured in `~/.fit/outpost/scheduler.json` with a `kb`
   that exists.
+- **The daemon must be running and must have been launched by
+  `fit-outpost.app`** (open the app or enable it as a login item) — not started
+  with `fit-outpost daemon` from a terminal. `fit-outpost wake` forwards the
+  request to this running daemon, so only a daemon descended from the app
+  produces the responsible-process chain this runbook verifies; a
+  terminal-launched daemon attributes to the terminal instead. If no daemon is
+  running, `fit-outpost wake` errors rather than spawning locally.
 - Root access (`sudo`): the Axis 1 reads (`log stream`, `launchctl procinfo`)
   require it.
 
@@ -65,7 +76,7 @@ Then in **System Settings → Privacy & Security**, remove any existing `node` o
 Claude-CLI (version-string) entries under Full Disk Access, Files & Folders, and
 Automation.
 
-**(b) Grant only `Outpost.app`.** Grant `Outpost.app` Full Disk Access and, if
+**(b) Grant only `fit-outpost.app`.** Grant `fit-outpost.app` Full Disk Access and, if
 prompted, Files & Folders (Documents) and Automation for Mail. Grant **nothing**
 to `node` or the Claude CLI.
 
@@ -84,8 +95,15 @@ Then wake:
 fit-outpost wake <agent-name>
 ```
 
+This does not spawn `claude` itself — it forwards the wake over the daemon
+socket, and the daemon (a child of `fit-outpost.app`) does the spawning. That is
+what places `claude` in the `fit-outpost.app` → daemon → `claude` chain this
+runbook measures. The wake runs asynchronously in the daemon, so the command
+returns as soon as the daemon accepts it; sample the pids (step (d)) and the
+briefing file (step (e)) against the daemon's work, not this command's exit.
+
 **(d) Assert per-hop attribution (Axis 1).** The daemon and its spawned `claude`
-child must both be attributed to `Outpost.app`. While the wake runs, capture
+child must both be attributed to `fit-outpost.app`. While the wake runs, capture
 both hop pids — the `claude` agent is a **direct child** of the daemon, which
 avoids matching the operator's own interactive `claude` session — and read each
 one's responsible process:
@@ -99,7 +117,7 @@ sudo launchctl procinfo "$CLAUDE_PID" | grep -i 'responsible'
 
 Read the responsible process from the TCC stream's access lines (authoritative)
 and corroborate with `launchctl procinfo`'s responsible-pid field. Record, **per
-hop**, whether it is `Outpost.app` — a leaf-only check is not sufficient, one
+hop**, whether it is `fit-outpost.app` — a leaf-only check is not sufficient, one
 correct hop can mask an inverted one. If the child exits before you sample it,
 re-wake and capture promptly (or pick an agent whose turn runs longer).
 
@@ -115,15 +133,15 @@ the read to succeed.
 
 **(f) Exercise Automation (Axis 2, AppleEvents).** Trigger a draft-side skill
 (one that drives Mail via AppleScript) and confirm it sends/drafts under the
-single `Outpost.app` Automation grant, with no separate `node`/CLI Automation
+single `fit-outpost.app` Automation grant, with no separate `node`/CLI Automation
 entry.
 
 **(g) Fix C — conditional direct grant.** If any single service still fails
-under the `Outpost.app`-only grant, grant **that one service** (per the table
-above) to `Outpost.app` directly, re-run (c)–(f), and record which service
+under the `fit-outpost.app`-only grant, grant **that one service** (per the table
+above) to `fit-outpost.app` directly, re-run (c)–(f), and record which service
 needed it. The remedy is still one process — never a grant to `node` or the CLI.
 
-**(h) Persistence across upgrade (Axis 3).** Rebuild and re-sign `Outpost.app`,
+**(h) Persistence across upgrade (Axis 3).** Rebuild and re-sign `fit-outpost.app`,
 reinstall it over the existing grant, and re-wake:
 
 ```sh
@@ -143,7 +161,7 @@ ad-hoc build with a deterministic cdhash survives a `brew upgrade`).
   hop misattributes; apply the recorded attribution-preserving setting to both
   hops and re-run.
 - **A service fails (Axis 2)** → document the single direct grant for that
-  service on `Outpost.app`.
+  service on `fit-outpost.app`.
 - **Grant lost on upgrade (Axis 3)** → ship a Developer ID-signed bundle so the
   grant pins to the designated requirement.
 
@@ -155,14 +173,14 @@ diagnosis.
 ```
 Date:                    <YYYY-MM-DD>
 macOS version:           <e.g. 14.5>
-Outpost.app identity:    <Developer ID | ad-hoc>
+fit-outpost.app identity:    <Developer ID | ad-hoc>
 
 Axis 1 — per-hop attribution
-  hop 1 (daemon)  responsible process:  <Outpost.app | other>   PASS/FAIL
-  hop 2 (claude)  responsible process:  <Outpost.app | other>   PASS/FAIL
+  hop 1 (daemon)  responsible process:  <fit-outpost.app | other>   PASS/FAIL
+  hop 2 (claude)  responsible process:  <fit-outpost.app | other>   PASS/FAIL
   attribution-preserving disclaim value (if a change was needed):  <0 | 1 | n/a>
 
-Axis 2 — per-service honoring (under one Outpost.app grant)
+Axis 2 — per-service honoring (under one fit-outpost.app grant)
   Full Disk Access (Mail/Calendar read):   PASS/FAIL
   Files & Folders (Documents KB):           PASS/FAIL
   Automation (draft-side Mail):             PASS/FAIL

--- a/products/outpost/src/outpost.js
+++ b/products/outpost/src/outpost.js
@@ -26,7 +26,7 @@ import { StateManager } from "./state-manager.js";
 import { AgentRunner } from "./agent-runner.js";
 import { Scheduler, formatLocalTime } from "./scheduler.js";
 import { KBManager } from "./kb-manager.js";
-import { SocketServer, requestShutdown } from "./socket-server.js";
+import { SocketServer, requestShutdown, requestWake } from "./socket-server.js";
 import {
   readPosture,
   writePosture,
@@ -436,17 +436,28 @@ export async function run(runtime, version) {
         cli.usageError("missing required argument <agent>");
         return 2;
       }
-      const config = await loadConfig();
-      const state = await stateManager.load();
-      const agent = config.agents[args[0]];
-      if (!agent) {
-        cli.error(
-          `agent "${args[0]}" not found. Available: ${Object.keys(config.agents).join(", ") || "(none)"}`,
-        );
-        return 1;
+      // Always route the wake through the running daemon. The daemon is the
+      // only spawn site that descends from fit-outpost.app, so a `claude`
+      // spawned there inherits the app as its TCC responsible process and a
+      // single grant to the app covers it. Spawning from this CLI process
+      // would attribute the access to the terminal instead, breaking the
+      // single-grant model. If no daemon is running there is nowhere to wake
+      // with correct attribution, so this errors rather than spawning locally.
+      const result = await requestWake(SOCKET_PATH, args[0], runtime);
+      if (result.ok) {
+        log(`Wake dispatched to daemon for "${args[0]}".`);
+        return 0;
       }
-      await agentRunner.wake(args[0], agent, state, config.env);
-      return 0;
+      if (result.reason === "not-running") {
+        cli.error(
+          "daemon not running. Start fit-outpost.app (or run `fit-outpost daemon`) before waking an agent.",
+        );
+      } else if (result.reason === "timeout") {
+        cli.error("daemon did not respond to the wake request.");
+      } else {
+        cli.error(result.message);
+      }
+      return 1;
     },
     init: async () => {
       if (!args[0]) {

--- a/products/outpost/src/socket-server.js
+++ b/products/outpost/src/socket-server.js
@@ -324,6 +324,71 @@ export class SocketServer {
 }
 
 /**
+ * Connect to the running daemon and ask it to wake an agent.
+ *
+ * The wake runs inside the daemon process, which is the only spawn site that
+ * descends from fit-outpost.app — so the spawned `claude` inherits the app as
+ * its TCC responsible process. Routing every wake through the daemon is what
+ * keeps the single-grant model intact; a wake spawned from this CLI process
+ * would be attributed to the terminal instead. The daemon acknowledges
+ * (`ack`) once it has accepted the request and then runs the wake
+ * asynchronously, so this resolves on the ack rather than on completion.
+ *
+ * @param {string} socketPath
+ * @param {string} agent - Agent name to wake.
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
+ *   Injected runtime bag (uses `fsSync` and `clock`).
+ * @returns {Promise<{ ok: boolean, reason?: "not-running"|"timeout"|"error", message?: string }>}
+ */
+export async function requestWake(socketPath, agent, runtime) {
+  if (!runtime?.fsSync) throw new Error("runtime.fsSync is required");
+  if (!runtime?.clock) throw new Error("runtime.clock is required");
+  if (!runtime.fsSync.existsSync(socketPath)) {
+    return { ok: false, reason: "not-running" };
+  }
+
+  return new Promise((resolve) => {
+    const timeout = runtime.clock.setTimeout(() => {
+      socket.destroy();
+      resolve({ ok: false, reason: "timeout" });
+    }, 5000);
+
+    const socket = createConnection(socketPath, () => {
+      socket.write(JSON.stringify({ type: "wake", agent }) + "\n");
+    });
+
+    let buffer = "";
+    socket.on("data", (data) => {
+      buffer += data.toString();
+      const idx = buffer.indexOf("\n");
+      if (idx === -1) return;
+      runtime.clock.clearTimeout(timeout);
+      let msg = null;
+      try {
+        msg = JSON.parse(buffer.slice(0, idx));
+      } catch {}
+      socket.destroy();
+      if (msg && msg.type === "ack" && msg.command === "wake") {
+        resolve({ ok: true });
+      } else {
+        resolve({
+          ok: false,
+          reason: "error",
+          message: msg?.message || "daemon rejected wake request",
+        });
+      }
+    });
+
+    // A stale socket file (daemon crashed) refuses the connection; treat it
+    // the same as a missing daemon.
+    socket.on("error", () => {
+      runtime.clock.clearTimeout(timeout);
+      resolve({ ok: false, reason: "not-running" });
+    });
+  });
+}
+
+/**
  * Connect to the daemon socket and request graceful shutdown.
  * @param {string} socketPath
  * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime

--- a/websites/fit/docs/getting-started/engineers/outpost/index.md
+++ b/websites/fit/docs/getting-started/engineers/outpost/index.md
@@ -76,7 +76,7 @@ Outpost agents need access to specific folders (Documents, Mail, Calendar). When
 macOS prompts, grant only the folders each process needs via **System Settings >
 Privacy & Security > Files & Folders**:
 
-- **Outpost.app** — the TCC responsible process (Swift launcher)
+- **fit-outpost.app** — the TCC responsible process (Swift launcher)
 - **node** — runs skill scripts with `#!/usr/bin/env node` shebangs
 - **"2.1.72"** (or another version number) — this is the **Claude Code CLI**.
   macOS shows its version string instead of a name. Safe to grant per-folder

--- a/websites/fit/outpost/index.md
+++ b/websites/fit/outpost/index.md
@@ -161,7 +161,7 @@ Outpost agents need access to specific folders (Documents, Mail, Calendar). When
 macOS prompts, grant only the folders each process needs via **System Settings >
 Privacy & Security > Files & Folders**:
 
-- **Outpost.app** — the TCC responsible process (Swift launcher)
+- **fit-outpost.app** — the TCC responsible process (Swift launcher)
 - **node** — runs skill scripts with `#!/usr/bin/env node` shebangs
 - **"2.1.72"** (or another version number) — this is the **Claude Code CLI**.
   macOS shows its version string instead of a name. Safe to grant per-folder


### PR DESCRIPTION
## Summary

- Fix the Outpost TCC permission chain so a single grant to `fit-outpost.app` covers the spawned `claude` agent (implements spec 2100).
- **Disclaim flip:** both spawn sites (`ProcessManager.swift`, `posix-spawn.js`) passed `disclaim=1`, making each child its own TCC responsible process — the `claude` agent never inherited the app, so the grant didn't apply. Flipped to `disclaim=0` so the responsible process chains up to `fit-outpost.app`.
- **Wake routing:** `fit-outpost wake` spawned `claude` locally from the CLI (a child of the terminal), so the app was never in the chain. Added a `requestWake` socket client; the CLI now forwards the wake to the running daemon (which descends from `fit-outpost.app`) and **errors if no daemon is running** instead of spawning locally.
- **Rename:** stale `Outpost.app` references → the actual produced bundle `fit-outpost.app` across code, build helper, runbook, CLAUDE.md, and end-user docs. Frozen `specs/` history left as-is.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- Hardware (manual, per `products/outpost/macos/TCC-VERIFICATION.md`): the Swift `disclaim` change needs a re-sign + reinstall and a runbook re-run to confirm Axis 1 passes — not exercisable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)