### PR TITLE
feat(outpost): default `update` path to current directory

### DIFF
--- a/.claude/skills/fit-outpost/SKILL.md
+++ b/.claude/skills/fit-outpost/SKILL.md
@@ -153,7 +153,9 @@ stop the scheduler from waking it. Set back to `true` to re-enable.
 3. Write the skill workflow (trigger, prerequisites, inputs, outputs, steps)
 4. Update `template/CLAUDE.md` to list the new skill
 5. If scheduled, add a default task entry to `config/scheduler.json`
-6. Run `npx fit-outpost update` to push the new skill to existing KBs
+6. Run `npx fit-outpost update <kb-path>` for each existing KB to push the new
+   skill (or run `npx fit-outpost update` from inside the KB to update the
+   current directory)
 
 ## Verification
 

--- a/.claude/skills/fit-outpost/references/cli.md
+++ b/.claude/skills/fit-outpost/references/cli.md
@@ -15,7 +15,7 @@ npx fit-outpost validate                # Validate agent definitions exist
 
 ```sh
 npx fit-outpost init <path>             # Initialize a new knowledge base
-npx fit-outpost update [path]           # Update KB with latest CLAUDE.md, agents, skills
+npx fit-outpost update [path]           # Update KB at [path] (default: current dir)
 ```
 
 ### Key Paths

--- a/products/outpost/src/outpost.js
+++ b/products/outpost/src/outpost.js
@@ -5,7 +5,7 @@
 //   fit-outpost daemon              Run continuously (poll every 60s)
 //   fit-outpost wake <agent>        Wake a specific agent immediately
 //   fit-outpost init <path>         Initialize a new knowledge base
-//   fit-outpost update [path]       Update KB with latest CLAUDE.md, agents and skills
+//   fit-outpost update [path]       Update KB with latest CLAUDE.md, agents and skills (defaults to current directory)
 //   fit-outpost stop                Gracefully stop daemon and all running agents
 //   fit-outpost validate            Validate agent definitions exist
 //   fit-outpost status              Show agent status
@@ -64,7 +64,8 @@ function buildDefinition(version) {
       {
         name: "update",
         args: "[path]",
-        description: "Update KB with latest CLAUDE.md, agents and skills",
+        description:
+          "Update KB with latest CLAUDE.md, agents and skills (defaults to current directory)",
       },
       {
         name: "stop",
@@ -302,39 +303,11 @@ export async function run(runtime, version) {
     const tpl = await requireTemplateDir();
     if (tpl === null) return 1;
 
-    if (args[0]) {
-      const result = await kbManager.update(args[0], tpl);
-      if (!result.ok) {
-        proc.stderr.write(result.error + "\n");
-        return result.code;
-      }
-      return 0;
-    }
-
-    const config = await loadConfig();
-    const kbPaths = [
-      ...new Set(
-        Object.values(config.agents)
-          .filter((a) => a.kb)
-          .map((a) => expandPath(a.kb)),
-      ),
-    ];
-
-    if (kbPaths.length === 0) {
-      proc.stderr.write(
-        "No knowledge bases configured and no path given.\n" +
-          "Usage: fit-outpost update [path]\n",
-      );
-      return 1;
-    }
-
-    for (const kb of kbPaths) {
-      logger.info(`\nUpdating ${kb}...`);
-      const result = await kbManager.update(kb, tpl);
-      if (!result.ok) {
-        proc.stderr.write(result.error + "\n");
-        return result.code;
-      }
+    const target = args[0] ?? proc.cwd();
+    const result = await kbManager.update(target, tpl);
+    if (!result.ok) {
+      proc.stderr.write(result.error + "\n");
+      return result.code;
     }
     return 0;
   }

--- a/products/outpost/test/golden/fit-outpost/help.stdout
+++ b/products/outpost/test/golden/fit-outpost/help.stdout
@@ -6,7 +6,7 @@ Commands:
   daemon                       Run continuously (poll every 60s)
   wake <agent>                 Wake a specific agent immediately
   init <path>                  Initialize a new knowledge base
-  update [path]                Update KB with latest CLAUDE.md, agents and skills
+  update [path]                Update KB with latest CLAUDE.md, agents and skills (defaults to current directory)
   stop                         Gracefully stop daemon and all running agents
   validate                     Validate agent definitions exist
   status                       Show agent status

--- a/products/outpost/test/outpost-cli.test.js
+++ b/products/outpost/test/outpost-cli.test.js
@@ -54,7 +54,8 @@ const definition = {
     {
       name: "update",
       args: "[path]",
-      description: "Update KB with latest CLAUDE.md, agents and skills",
+      description:
+        "Update KB with latest CLAUDE.md, agents and skills (defaults to current directory)",
     },
     {
       name: "stop",

--- a/websites/fit/docs/products/knowledge-systems/index.md
+++ b/websites/fit/docs/products/knowledge-systems/index.md
@@ -219,10 +219,11 @@ Updating ~/Documents/Personal...
   Done.
 ```
 
-If you have multiple knowledge bases configured, omit the path to update all
-of them:
+Omit the path to update the knowledge base in the current directory, so you
+can run it from inside the KB itself:
 
 ```sh
+cd ~/Documents/Personal
 npx fit-outpost update
 ```
 
@@ -257,7 +258,8 @@ All OK.
 The validator checks that each configured agent has a matching agent definition
 file in `.claude/agents/` (either in the knowledge base or in your global
 `~/.claude/agents/` directory). A `[FAIL]` result means the agent definition
-is missing -- run `npx fit-outpost update` to restore it.
+is missing -- run `npx fit-outpost update <path>` (or `npx fit-outpost update`
+from inside the knowledge base) to restore it.
 
 ## Verify
 


### PR DESCRIPTION
## Summary

- `fit-outpost update` with no path now updates the knowledge base in the **current working directory** instead of scanning the scheduler config to update every configured KB.
- The path argument stays optional (`[path]`); an explicit path still targets that KB. A missing KB at the resolved path surfaces KBManager's `No knowledge base found at <dest>` error (exit 1).
- Updates CLI help text + golden snapshot, the `fit-outpost` skill (`SKILL.md`, `references/cli.md`), and the knowledge-systems website docs.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`
- Manual: `fit-outpost update` from inside a KB updates cwd; from a non-KB dir errors with exit 1; explicit path still works; `--help` shows "(defaults to current directory)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)