### PR TITLE
docs(outpost): grant macOS permissions to fit-outpost.app only

### DIFF
--- a/products/outpost/macos/TCC-VERIFICATION.md
+++ b/products/outpost/macos/TCC-VERIFICATION.md
@@ -1,11 +1,9 @@
 # Outpost TCC Verification Runbook
 
-A manual macOS hardware procedure that both **diagnoses** whether Outpost's
-spawned agents need more than one TCC grant and **re-checks** that a single
-grant to `fit-outpost.app` still covers them after any change. There is no CI
-equivalent — TCC state cannot be exercised on Linux or in a headless runner — so
-this runbook is the durable guard, run once to diagnose and once per release to
-re-check.
+A manual macOS hardware procedure that **re-checks** that a single grant to
+`fit-outpost.app` covers Outpost's spawned agents after any change. There is no
+CI equivalent — TCC state cannot be exercised on Linux or in a headless runner —
+so this runbook is the durable guard, run once per release.
 
 ## What this measures
 
@@ -154,9 +152,8 @@ ad-hoc build with a deterministic cdhash survives a `brew upgrade`).
 
 ## Interpreting the result
 
-- **All axes pass with one grant, no change made** → the three-grant
-  documentation was stale; only the docs and spawn-site comments change, and the
-  work is internal.
+- **All axes pass with one grant, no change made** → the single-grant model
+  holds; nothing to change.
 - **Axis 1 fails (a hop resolves to its child)** → the disclaim setting at that
   hop misattributes; apply the recorded attribution-preserving setting to both
   hops and re-run.
@@ -189,6 +186,6 @@ Axis 2 — per-service honoring (under one fit-outpost.app grant)
 Axis 3 — persistence across re-signed upgrade
   grant survived, no re-prompt:             PASS/FAIL
 
-Diagnosed root cause:    <stale docs | disclaim setting | non-inherited service | persistence | combination>
-Fixes applied:           <none | Step 3 | Step 4 | Step 5 | combination>
+Finding:                 <single-grant holds | disclaim setting | non-inherited service | persistence | combination>
+Fixes applied:           <none | Step (g) | re-sign | combination>
 ```

--- a/products/outpost/pkg/macos/conclusion.html
+++ b/products/outpost/pkg/macos/conclusion.html
@@ -55,56 +55,29 @@
     </p>
     <p><strong>Grant privacy access:</strong></p>
     <p>
-      Outpost reads from Apple Mail, Calendar, and Contacts. macOS requires
-      three separate grants on first launch:
+      Outpost reads from Apple Mail, Calendar, and Contacts. Grant every
+      permission to one app &mdash; <strong>Outpost</strong>, from
+      <code>/Applications/Forward Impact/</code> &mdash; and the scheduler and
+      the agents it runs are covered. You never grant access to
+      <code>node</code>, <code>claude</code>, or any other helper process.
     </p>
     <p>
       <strong>1. Files &amp; Folders</strong> &mdash;
       <code
         >System Settings &rarr; Privacy &amp; Security &rarr; Files &amp;
         Folders</code
-      >. When macOS prompts for Documents / Mail / Calendar folders, grant
-      access to each of these processes:
-    </p>
-    <ul>
-      <li>
-        <strong>Outpost</strong> &mdash; the TCC responsible process (Swift
-        launcher)
-      </li>
-      <li>
-        <strong>node</strong> &mdash; runs skill scripts with
-        <code>#!/usr/bin/env node</code> shebangs
-      </li>
-      <li>
-        A version number like <strong>&ldquo;2.1.72&rdquo;</strong> &mdash; this
-        is the Claude Code CLI. macOS shows its version string instead of a
-        name. Safe to grant per-folder access.
-      </li>
-    </ul>
-    <p>
-      <strong>2. Full Disk Access</strong> &mdash;
-      <code
-        >System Settings &rarr; Privacy &amp; Security &rarr; Full Disk
-        Access</code
-      >. The <code>sync-apple-mail</code> and <code>sync-apple-calendar</code>
-      skills read the macOS Mail and Calendar SQLite databases directly. Click
-      <strong>+</strong> and add <strong>Outpost</strong> from
-      <code>/Applications/Forward Impact/</code>. Without this, calendar and mail
-      sync fail silently.
+      >. Prefer this over Full Disk Access: grant <strong>Outpost</strong> only
+      the folders it needs. When macOS prompts, allow access to your knowledge
+      base folder and to Mail and Calendar as each sync first reads them.
+      Without these grants, calendar and mail sync fail silently.
     </p>
     <p>
-      <strong>3. Automation</strong> &mdash;
+      <strong>2. Automation</strong> &mdash;
       <code
         >System Settings &rarr; Privacy &amp; Security &rarr; Automation</code
       >. The <code>draft-emails</code> skill sends mail by driving Apple Mail
       through AppleScript. On first send attempt macOS will prompt &ldquo;allow
       Outpost to control Mail&rdquo; &mdash; click <strong>Allow</strong>.
-    </p>
-    <p>
-      If you are upgrading from a previous Outpost version and a process stops
-      working, toggle its entry <strong>off</strong> then <strong>on</strong>
-      again in the same panel &mdash; macOS revokes the permission when the
-      binary changes.
     </p>
     <p><strong>Next steps:</strong></p>
     <p>1. Populate your identity from the corporate directory:</p>

--- a/websites/fit/docs/getting-started/engineers/outpost/index.md
+++ b/websites/fit/docs/getting-started/engineers/outpost/index.md
@@ -72,15 +72,20 @@ background work. The CLI scheduler works on any platform.
 
 ## macOS Privacy & Security
 
-Outpost agents need access to specific folders (Documents, Mail, Calendar). When
-macOS prompts, grant only the folders each process needs via **System Settings >
-Privacy & Security > Files & Folders**:
+Outpost needs access to the folders it reads — your knowledge base, Mail, and
+Calendar. Grant every permission to a single app, **fit-outpost.app**, and the
+whole scheduler and the agents it runs are covered. You never grant access to
+`node`, `claude`, or any other helper process.
 
-- **fit-outpost.app** — the TCC responsible process (Swift launcher)
-- **node** — runs skill scripts with `#!/usr/bin/env node` shebangs
-- **"2.1.72"** (or another version number) — this is the **Claude Code CLI**.
-  macOS shows its version string instead of a name. Safe to grant per-folder
-  access.
+When macOS prompts, prefer specific **Files & Folders** access over **Full Disk
+Access**. Open **System Settings > Privacy & Security > Files & Folders** and
+grant `fit-outpost.app` only the folders it needs:
+
+- Your knowledge base folder (for example, `~/Documents/Personal`)
+- Mail and Calendar, when a sync first reads them
+
+If a draft-side skill sends mail, macOS also prompts once under **Automation** to
+let `fit-outpost.app` control Mail — click **Allow**.
 
 ---
 

--- a/websites/fit/outpost/index.md
+++ b/websites/fit/outpost/index.md
@@ -157,15 +157,20 @@ npx fit-outpost status                  # Check what's happening
 
 ### macOS Privacy & Security
 
-Outpost agents need access to specific folders (Documents, Mail, Calendar). When
-macOS prompts, grant only the folders each process needs via **System Settings >
-Privacy & Security > Files & Folders**:
+Outpost needs access to the folders it reads — your knowledge base, Mail, and
+Calendar. Grant every permission to a single app, **fit-outpost.app**, and the
+whole scheduler and the agents it runs are covered. You never grant access to
+`node`, `claude`, or any other helper process.
 
-- **fit-outpost.app** — the TCC responsible process (Swift launcher)
-- **node** — runs skill scripts with `#!/usr/bin/env node` shebangs
-- **"2.1.72"** (or another version number) — this is the **Claude Code CLI**.
-  macOS shows its version string instead of a name. Safe to grant per-folder
-  access.
+When macOS prompts, prefer specific **Files & Folders** access over **Full Disk
+Access**. Open **System Settings > Privacy & Security > Files & Folders** and
+grant `fit-outpost.app` only the folders it needs:
+
+- Your knowledge base folder (for example, `~/Documents/Team`)
+- Mail and Calendar, when a sync first reads them
+
+If a draft-side skill sends mail, macOS also prompts once under **Automation** to
+let `fit-outpost.app` control Mail — click **Allow**.
 
 <div class="grid">
 


### PR DESCRIPTION
## Summary

- Present the single-app macOS TCC grant model as how Outpost works: all permissions go to the `fit-outpost.app` bundle, covering the scheduler and the agents it spawns — no separate grants to `node` or `claude`.
- Recommend specific **Files & Folders** access over **Full Disk Access** across the product page, the engineers getting-started guide, and the pkg installer note (`conclusion.html`).
- Reframe `TCC-VERIFICATION.md` from a one-time diagnosis into an evergreen per-release re-check that one grant still covers the spawn subtree; technical TCC service mapping kept accurate.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`