### PR TITLE
spec+design(2120): per-agent least-privilege for Outpost (clean break)

### DIFF
--- a/specs/2120-outpost-agent-least-privilege/design-a.md
+++ b/specs/2120-outpost-agent-least-privilege/design-a.md
@@ -1,0 +1,104 @@
+# Design 2120-a — Per-agent least-privilege execution for Outpost
+
+Spec 2120 keeps the verified single-grant model (one grant to `fit-outpost.app`
+covers the spawned subtree) for agents that sync the live mail/calendar stores
+or send mail, while making that grant **not** flow to an agent whose job only
+touches already-synced, non-protected substrate. A `restricted` agent must be
+denied Full Disk Access and Automation even when fully prompt-injected, yet
+complete its knowledge-base work with no TCC grant and no `node`/`claude`
+prompt. The level is declared per agent in `scheduler.json`, daemon-enforced,
+agent-immutable, secure-by-default for new agents, and back-compatible for
+existing installs.
+
+The architecture reuses the one attribution seam spec 2100 verified — the
+`responsibility_spawnattrs_setdisclaim` call on the daemon→`claude` hop — rather
+than adding a new isolation mechanism. `full` keeps today's `disclaim = 0`
+(child inherits `fit-outpost.app` as responsible process); `restricted` passes
+`disclaim = 1` (child is responsible for itself, so the app's grants are not
+extended and `node`/`claude` holds no grant of its own). Substrate relocation,
+not a new grant, is what lets a self-responsible `restricted` child still work.
+
+## Data flow
+
+```mermaid
+flowchart LR
+  CFG["scheduler.json (user-only trust root)<br/>agent.privilege ∈ {full, restricted} | undeclared<br/>config.defaultPrivilege (new installs: restricted)"]
+    --> RES["resolvePrivilege(agent, config)<br/>explicit → that · undeclared → defaultPrivilege ?? full<br/>invalid → throw"]
+  RES --> WAKE["AgentRunner.wake (single chokepoint;<br/>both spawn paths route here)<br/>catch invalid → log+skip · log level → disclaimFor(level)"]
+  WAKE -->|"hop 2: posix_spawn(…, disclaim)"| CLAUDE["claude (node)"]
+  CLAUDE -->|full: disclaim 0| APP[("fit-outpost.app grants<br/>FDA · Automation · live stores")]
+  CLAUDE -->|restricted: disclaim 1| SUB[("self-responsible: synced cache +<br/>relocated KB (non-TCC) only ·<br/>FDA/Automation denied")]
+```
+
+Hop 1 (`fit-outpost.app` → daemon, `ProcessManager.swift`) is unchanged and
+stays `disclaim = 0`: the daemon must always remain the app's child. Only hop 2
+varies by level.
+
+## Components
+
+| Component | Where | Role |
+| --- | --- | --- |
+| Privilege resolver | `products/outpost/src/privilege.js` (new) | `PRIVILEGE_LEVELS = ["full","restricted"]`, `resolvePrivilege(agent, config)`, `disclaimFor(level)`. Validates the declared value, applies the config-level default. Patterned on `posture.js` but **rejects** an invalid value rather than coercing it. |
+| Wake chokepoint | `products/outpost/src/agent-runner.js` (`AgentRunner.wake`) | Resolves the level once, catches an invalid level (log + skip, mirroring how callers handle `UnsafeAgentNameError`), logs the resolved level, threads the disclaim flag into the direct `posix-spawn.spawn` call. `wake` today receives only `config.env`; its signature widens so the resolver sees `config.defaultPrivilege`. The one site both the scheduler tick and the socket wake already funnel through. |
+| Spawn primitive | `libraries/libmacos/src/posix-spawn.js` (`spawn`) | The hardcoded `setDisclaim(attr, 0)` becomes a `disclaim` parameter appended after `runtime` (default `0`, preserving every current caller incl. the `tcc-responsibility.js` wrapper); `restricted` passes `1`. **Released separately → coupled libmacos release.** |
+| Default config + KB path | `products/outpost/config/scheduler.json` (bundled), `products/outpost/pkg/macos/postinstall` (`DEFAULT_KB`, and the copy of the bundled config into the trust root) | Ship per-agent levels, `defaultPrivilege: "restricted"`, and the relocated non-TCC `kb` path so new installs are least-privilege by default. |
+| Verification runbook | `products/outpost/macos/TCC-VERIFICATION.md` | New axis: a `restricted` probe shows an explicit `SystemPolicyAllFiles` **Denied**, a `full` agent **Allowed**, in one install; the service table's KB row is updated for the relocated non-TCC path. |
+| End-user docs | `websites/fit/outpost/index.md`, `websites/fit/docs/getting-started/engineers/outpost/index.md`, installer copy (`pkg/macos/{welcome,conclusion}.html`, `uninstall.sh`) | Which agents need which macOS permissions; the relocated KB path everywhere `~/Documents/Personal` is named today. |
+
+## Privilege resolution
+
+`resolvePrivilege(agent, config)` is a pure function. An **explicit**
+`full`/`restricted` is honored; any other declared value is rejected (it throws,
+the wake catches and logs `outpost.privilege.rejected`, then skips — the same
+fail-and-skip shape the state-path validator's callers use). An **undeclared**
+level falls back to `config.defaultPrivilege` when present and valid, else
+`full`.
+
+That config-level default is how requirement 6's two halves hold at once. The
+bundled `config/scheduler.json` ships `defaultPrivilege: "restricted"` and pins
+each shipped agent's level **explicitly** — the mail/calendar sync and send
+agents as `full`, the rest as `restricted` — so a fresh install never loses live
+reach to the new default; `defaultPrivilege` governs only an agent the user
+later hand-adds without a level, which is then `restricted`.
+An existing install's `scheduler.json` — copied at its own install time — has no
+`defaultPrivilege` key and no per-agent levels, so every agent resolves to
+`full` and behaves exactly as today. The level lives in the same user-only trust
+root as the spawn-env allow-set and state roots, so "agent-immutable" needs no
+new mechanism: a spawned agent already cannot write `scheduler.json`.
+
+## Knowledge-base relocation and migration
+
+The default knowledge base moves from `~/Documents/Personal` (TCC
+`SystemPolicyDocumentsFolder`) to `~/.local/share/fit/outpost/kb`, a non-TCC
+path under the XDG data home, set in the bundled config's `kb` entries and in
+the installer's `DEFAULT_KB`. A `restricted`, self-responsible child reads the
+synced cache (`~/.cache/fit/outpost/`, already non-protected) and writes the KB
+under that relocated path with no grant and no Documents prompt; the daemon
+still writes its briefing to `~/.cache/fit/outpost/state/<agent>_last_output.md`
+(non-TCC, so no grant is needed there either).
+
+Migration is **continue-to-serve**, not move: an upgrade never rewrites the
+user-owned `scheduler.json`, so an install that already names
+`~/Documents/Personal` keeps that path, and its agents — undeclared, therefore
+`full` — keep reading Documents under the app grant exactly as today. Only the
+bundled config, the installer default, and the docs change. No directory is
+relocated on disk, so nothing is stranded or duplicated.
+
+## Key decisions
+
+| Decision | Why | Rejected alternative |
+| --- | --- | --- |
+| Reuse the hop-2 disclaim seam to express both levels | One verified primitive already steers attribution; `restricted` is its `disclaim = 1` branch | A second (helper/two-bundle) identity holding its own narrow grant — explicitly deferred by the spec |
+| Resolve and apply the level at the single `AgentRunner.wake` chokepoint | Both spawn paths already funnel through it; one resolution site cannot drift between paths | Branch inside `posix-spawn.js`, or duplicate the logic in `socket-server.js` — two sites that can disagree |
+| Config-level `defaultPrivilege` marker, absent in pre-upgrade configs | Distinguishes a new install (undeclared→`restricted`) from an existing one (undeclared→`full`) without a runtime default that means two things | A single runtime default — `full` leaves new hand-added agents over-privileged, `restricted` silently breaks existing installs |
+| Invalid level throws → wake logs and skips (fail-closed) | "Schema accepts no other values"; a typo must not silently run with the wrong reach | Coerce an unknown value to `restricted` (the `posture.js` shape) — hides the config error and runs anyway |
+| Relocate the default KB by changing the bundled config + installer default; continue-to-serve existing paths | The user-owned config is never rewritten, so no KB is orphaned (requirement 5) with zero on-disk risk | Move the directory on upgrade — risks stranding, duplication, and a race with an in-flight sync |
+| Relocated path `~/.local/share/fit/outpost/kb` | Unambiguously outside every TCC-protected folder; durable, namespaced with the cache | `~/Library/Application Support/…` (FDA-ambiguous on some macOS versions); `~/.cache/…` (reserved for ephemeral synced content, not the durable KB) |
+| Add a positive `restricted`-denial probe to the runbook | Denial must be distinguishable from "never attempted"; TCC state is unexercisable in CI | A code-level/CI assertion — impossible without macOS TCC state |
+
+## Out of scope (unchanged from spec)
+
+OS-sandboxing the spawned child (the `writeFileSync`/redirect write escape,
+tracked under § Template Write Deny); a two-bundle or helper-bundle identity;
+adding the missing Automation/Calendar entitlements so those services can
+prompt; and any change to the spawn-env allow-set.

--- a/specs/2120-outpost-agent-least-privilege/design-a.md
+++ b/specs/2120-outpost-agent-least-privilege/design-a.md
@@ -7,8 +7,8 @@ touches already-synced, non-protected substrate. A `restricted` agent must be
 denied Full Disk Access and Automation even when fully prompt-injected, yet
 complete its knowledge-base work with no TCC grant and no `node`/`claude`
 prompt. The level is declared per agent in `scheduler.json`, daemon-enforced,
-agent-immutable, secure-by-default for new agents, and back-compatible for
-existing installs.
+agent-immutable, and **mandatory** — a clean break, with no implicit default,
+no shim, and no back-compatible fallback for existing installs.
 
 The architecture reuses the one attribution seam spec 2100 verified — the
 `responsibility_spawnattrs_setdisclaim` call on the daemon→`claude` hop — rather
@@ -22,12 +22,12 @@ not a new grant, is what lets a self-responsible `restricted` child still work.
 
 ```mermaid
 flowchart LR
-  CFG["scheduler.json (user-only trust root)<br/>agent.privilege ∈ {full, restricted} | undeclared<br/>config.defaultPrivilege (new installs: restricted)"]
-    --> RES["resolvePrivilege(agent, config)<br/>explicit → that · undeclared → defaultPrivilege ?? full<br/>invalid → throw"]
-  RES --> WAKE["AgentRunner.wake (single chokepoint;<br/>both spawn paths route here)<br/>catch invalid → log+skip · log level → disclaimFor(level)"]
+  CFG["scheduler.json (user-only trust root)<br/>agent.privilege ∈ {full, restricted} (mandatory)"]
+    --> RES["resolvePrivilege(agent)<br/>full | restricted → that<br/>missing | invalid → throw"]
+  RES --> WAKE["AgentRunner.wake (single chokepoint;<br/>both spawn paths route here)<br/>catch → log+skip · log level → disclaimFor(level)"]
   WAKE -->|"hop 2: posix_spawn(…, disclaim)"| CLAUDE["claude (node)"]
   CLAUDE -->|full: disclaim 0| APP[("fit-outpost.app grants<br/>FDA · Automation · live stores")]
-  CLAUDE -->|restricted: disclaim 1| SUB[("self-responsible: synced cache +<br/>relocated KB (non-TCC) only ·<br/>FDA/Automation denied")]
+  CLAUDE -->|restricted: disclaim 1| SUB[("self-responsible: synced cache + relocated KB<br/>+ briefing cache (all non-TCC) only ·<br/>FDA/Automation denied")]
 ```
 
 Hop 1 (`fit-outpost.app` → daemon, `ProcessManager.swift`) is unchanged and
@@ -38,51 +38,46 @@ varies by level.
 
 | Component | Where | Role |
 | --- | --- | --- |
-| Privilege resolver | `products/outpost/src/privilege.js` (new) | `PRIVILEGE_LEVELS = ["full","restricted"]`, `resolvePrivilege(agent, config)`, `disclaimFor(level)`. Validates the declared value, applies the config-level default. Patterned on `posture.js` but **rejects** an invalid value rather than coercing it. |
-| Wake chokepoint | `products/outpost/src/agent-runner.js` (`AgentRunner.wake`) | Resolves the level once, catches an invalid level (log + skip, mirroring how callers handle `UnsafeAgentNameError`), logs the resolved level, threads the disclaim flag into the direct `posix-spawn.spawn` call. `wake` today receives only `config.env`; its signature widens so the resolver sees `config.defaultPrivilege`. The one site both the scheduler tick and the socket wake already funnel through. |
-| Spawn primitive | `libraries/libmacos/src/posix-spawn.js` (`spawn`) | The hardcoded `setDisclaim(attr, 0)` becomes a `disclaim` parameter appended after `runtime` (default `0`, preserving every current caller incl. the `tcc-responsibility.js` wrapper); `restricted` passes `1`. **Released separately → coupled libmacos release.** |
-| Default config + KB path | `products/outpost/config/scheduler.json` (bundled), `products/outpost/pkg/macos/postinstall` (`DEFAULT_KB`, and the copy of the bundled config into the trust root) | Ship per-agent levels, `defaultPrivilege: "restricted"`, and the relocated non-TCC `kb` path so new installs are least-privilege by default. |
+| Privilege resolver | `products/outpost/src/privilege.js` (new) | `PRIVILEGE_LEVELS = ["full","restricted"]`, `resolvePrivilege(agent)`, `disclaimFor(level)`. The level is mandatory: a missing or invalid value **throws**, there is no default. Patterned on `posture.js` but with no `effective*` coercion. |
+| Wake chokepoint | `products/outpost/src/agent-runner.js` (`AgentRunner.wake`) | Resolves the level once from `agent.privilege`, catches a missing/invalid level (log + skip), logs the resolved level, threads the disclaim flag into its spawn-primitive call. The one site both the scheduler tick and the socket wake already funnel through; it needs no config beyond the `agent` object it already receives. |
+| Spawn primitive | `libraries/libmacos/src/posix-spawn.js` (`spawn`) | The hardcoded `setDisclaim(attr, 0)` becomes a `disclaim` input (default `0`, so the `tcc-responsibility.js` wrapper and every other present caller keep the inherited setting unchanged); the `restricted` wake passes `1`. Exact arg shape (options field vs. positional) is a plan call. **Released separately → coupled libmacos release.** |
+| Default config + KB path | `products/outpost/config/scheduler.json` (bundled), `products/outpost/pkg/macos/postinstall` (`DEFAULT_KB`, and the copy of the bundled config into the trust root) | Ship an explicit level on every agent (sync/send → `full`, the rest → `restricted`) and the relocated non-TCC `kb` path. No default-level key exists. |
 | Verification runbook | `products/outpost/macos/TCC-VERIFICATION.md` | New axis: a `restricted` probe shows an explicit `SystemPolicyAllFiles` **Denied**, a `full` agent **Allowed**, in one install; the service table's KB row is updated for the relocated non-TCC path. |
-| End-user docs | `websites/fit/outpost/index.md`, `websites/fit/docs/getting-started/engineers/outpost/index.md`, installer copy (`pkg/macos/{welcome,conclusion}.html`, `uninstall.sh`) | Which agents need which macOS permissions; the relocated KB path everywhere `~/Documents/Personal` is named today. |
+| End-user docs + installer paths | `websites/fit/outpost/index.md`, `websites/fit/docs/getting-started/engineers/outpost/index.md`, installer copy (`pkg/macos/{welcome,conclusion}.html`, `uninstall.sh`) | Which agents need which macOS permissions; relocate every `~/Documents` KB-path reference (the `/Personal` and `/Team` examples, including the literal data paths in `uninstall.sh`) to the new path. |
 
 ## Privilege resolution
 
-`resolvePrivilege(agent, config)` is a pure function. An **explicit**
-`full`/`restricted` is honored; any other declared value is rejected (it throws,
-the wake catches and logs `outpost.privilege.rejected`, then skips — the same
-fail-and-skip shape the state-path validator's callers use). An **undeclared**
-level falls back to `config.defaultPrivilege` when present and valid, else
-`full`.
+`resolvePrivilege(agent)` is a pure function over one agent's config. A declared
+`full`/`restricted` is honored; **any other state — a missing level included —
+throws**. The wake catches the throw, logs `outpost.privilege.rejected`, and
+skips the agent (the same fail-and-skip shape the state-path validator's callers
+use). There is no default, no coercion, and no second argument: the resolver
+reads `agent.privilege` alone. The level lives in the same user-only trust root
+as the spawn-env allow-set and state roots, so "agent-immutable" needs no new
+mechanism — a spawned agent already cannot write `scheduler.json`.
 
-That config-level default is how requirement 6's two halves hold at once. The
-bundled `config/scheduler.json` ships `defaultPrivilege: "restricted"` and pins
-each shipped agent's level **explicitly** — the mail/calendar sync and send
-agents as `full`, the rest as `restricted` — so a fresh install never loses live
-reach to the new default; `defaultPrivilege` governs only an agent the user
-later hand-adds without a level, which is then `restricted`.
-An existing install's `scheduler.json` — copied at its own install time — has no
-`defaultPrivilege` key and no per-agent levels, so every agent resolves to
-`full` and behaves exactly as today. The level lives in the same user-only trust
-root as the spawn-env allow-set and state roots, so "agent-immutable" needs no
-new mechanism: a spawned agent already cannot write `scheduler.json`.
+The bundled `config/scheduler.json` therefore pins an explicit level on every
+shipped agent: the mail/calendar sync and send agents as `full`, the rest as
+`restricted`. A user who hand-adds an agent must declare its level too; an entry
+that omits it is refused at wake rather than run with a guessed privilege.
 
-## Knowledge-base relocation and migration
+## Knowledge-base relocation
 
-The default knowledge base moves from `~/Documents/Personal` (TCC
-`SystemPolicyDocumentsFolder`) to `~/.local/share/fit/outpost/kb`, a non-TCC
-path under the XDG data home, set in the bundled config's `kb` entries and in
-the installer's `DEFAULT_KB`. A `restricted`, self-responsible child reads the
-synced cache (`~/.cache/fit/outpost/`, already non-protected) and writes the KB
-under that relocated path with no grant and no Documents prompt; the daemon
-still writes its briefing to `~/.cache/fit/outpost/state/<agent>_last_output.md`
-(non-TCC, so no grant is needed there either).
+The default knowledge base moves **unconditionally** from `~/Documents/Personal`
+(TCC `SystemPolicyDocumentsFolder`) to `~/.local/share/fit/outpost/kb`, a
+non-TCC path under the XDG data home, set in the bundled config's `kb` entries
+and in the installer's `DEFAULT_KB`. A `restricted`, self-responsible child
+reads the synced cache (`~/.cache/fit/outpost/`, already non-protected) and
+writes the KB under that relocated path with no grant and no Documents prompt;
+the daemon still writes its briefing to
+`~/.cache/fit/outpost/state/<agent>_last_output.md` (non-TCC, so no grant is
+needed there either).
 
-Migration is **continue-to-serve**, not move: an upgrade never rewrites the
-user-owned `scheduler.json`, so an install that already names
-`~/Documents/Personal` keeps that path, and its agents — undeclared, therefore
-`full` — keep reading Documents under the app grant exactly as today. Only the
-bundled config, the installer default, and the docs change. No directory is
-relocated on disk, so nothing is stranded or duplicated.
+There is no continue-to-serve path and no in-place migration: the code knows
+only the relocated location. The small number of existing installs are migrated
+by hand — move the KB directory and add explicit levels to their
+`scheduler.json` — which keeps the codebase free of a legacy default or a
+dual-path read (see § Out of scope).
 
 ## Key decisions
 
@@ -90,9 +85,8 @@ relocated on disk, so nothing is stranded or duplicated.
 | --- | --- | --- |
 | Reuse the hop-2 disclaim seam to express both levels | One verified primitive already steers attribution; `restricted` is its `disclaim = 1` branch | A second (helper/two-bundle) identity holding its own narrow grant — explicitly deferred by the spec |
 | Resolve and apply the level at the single `AgentRunner.wake` chokepoint | Both spawn paths already funnel through it; one resolution site cannot drift between paths | Branch inside `posix-spawn.js`, or duplicate the logic in `socket-server.js` — two sites that can disagree |
-| Config-level `defaultPrivilege` marker, absent in pre-upgrade configs | Distinguishes a new install (undeclared→`restricted`) from an existing one (undeclared→`full`) without a runtime default that means two things | A single runtime default — `full` leaves new hand-added agents over-privileged, `restricted` silently breaks existing installs |
-| Invalid level throws → wake logs and skips (fail-closed) | "Schema accepts no other values"; a typo must not silently run with the wrong reach | Coerce an unknown value to `restricted` (the `posture.js` shape) — hides the config error and runs anyway |
-| Relocate the default KB by changing the bundled config + installer default; continue-to-serve existing paths | The user-owned config is never rewritten, so no KB is orphaned (requirement 5) with zero on-disk risk | Move the directory on upgrade — risks stranding, duplication, and a race with an in-flight sync |
+| Level is mandatory; a missing or invalid value throws and the wake skips (fail-closed) | A clean break with no implicit behavior: every agent's reach is declared, and a typo or omission cannot silently run with the wrong privilege | Any implicit default (a runtime `?? full`/`restricted`, or a `defaultPrivilege` marker) — a fallback the clean break forbids and a path the user must hand-migrate off anyway |
+| Relocate the default KB unconditionally; existing installs migrated by hand | Keeps one KB location in the code — no legacy default, dual-path read, or in-place move logic | Continue-to-serve the old `~/Documents` path, or auto-migrate the directory on upgrade — legacy the user explicitly rejected, and an upgrade-time move races an in-flight sync |
 | Relocated path `~/.local/share/fit/outpost/kb` | Unambiguously outside every TCC-protected folder; durable, namespaced with the cache | `~/Library/Application Support/…` (FDA-ambiguous on some macOS versions); `~/.cache/…` (reserved for ephemeral synced content, not the durable KB) |
 | Add a positive `restricted`-denial probe to the runbook | Denial must be distinguishable from "never attempted"; TCC state is unexercisable in CI | A code-level/CI assertion — impossible without macOS TCC state |
 
@@ -101,4 +95,7 @@ relocated on disk, so nothing is stranded or duplicated.
 OS-sandboxing the spawned child (the `writeFileSync`/redirect write escape,
 tracked under § Template Write Deny); a two-bundle or helper-bundle identity;
 adding the missing Automation/Calendar entitlements so those services can
-prompt; and any change to the spawn-env allow-set.
+prompt; any change to the spawn-env allow-set; and any automated migration or
+back-compatible fallback for existing installs — the few current installs move
+their KB and declare levels by hand, and no legacy default or dual-path read
+lives in the code.

--- a/specs/2120-outpost-agent-least-privilege/spec.md
+++ b/specs/2120-outpost-agent-least-privilege/spec.md
@@ -67,9 +67,10 @@ content for others, privilege governs the macOS reach the daemon grants it.
 
 ## Requirements (WHAT)
 
-1. **Declared privilege level per agent.** Each agent in `scheduler.json`
-   declares its level as exactly one of `full` or `restricted`. The schema
-   accepts no other values.
+1. **Mandatory privilege level per agent.** Each agent in `scheduler.json`
+   declares its level as exactly one of `full` or `restricted`. The level is
+   required: a missing level, or any other value, is rejected. There is no
+   implicit default and no fallback.
 2. **Daemon-enforced, agent-immutable.** The daemon applies the level when it
    wakes an agent. An agent cannot raise its own level — the level is owned by
    the same user-only trust root as the spawn-env allow-set and the state roots.
@@ -80,18 +81,12 @@ content for others, privilege governs the macOS reach the daemon grants it.
 4. **`restricted` agents need no TCC grant to do their work.** The substrate a
    `restricted` agent reads and writes — the synced cache and the knowledge base
    — must sit outside TCC-protected folders. The cache already qualifies; the
-   default knowledge-base location must move out of `~/Documents` to a
+   default knowledge-base location moves out of `~/Documents` to a
    non-protected path so a `restricted` agent reaches it without any grant and
-   without triggering a `node`/`claude` Documents prompt.
-5. **Existing knowledge bases are not orphaned.** Changing the default
-   knowledge-base location must not strand a knowledge base an existing user
-   already created under the old default; the upgrade either migrates it or
-   continues to serve it.
-6. **Secure default for new agents; back-compatible for old.** A newly scheduled
-   agent defaults to `restricted`. An existing `scheduler.json` whose agents
-   declare no level keeps today's behavior (`full`), so the verified single-grant
-   model is unchanged for current installs.
-7. **Observable.** Each wake records, in the scheduler log, the privilege level
+   without triggering a `node`/`claude` Documents prompt. This is an
+   unconditional move — the old `~/Documents` location is not retained as a
+   fallback.
+5. **Observable.** Each wake records, in the scheduler log, the privilege level
    resolved for that agent, so an operator and the verification runbook can
    confirm a `restricted` agent was in fact denied the elevated grant.
 
@@ -114,6 +109,7 @@ the privilege levels and the substrate location.
 | Two-bundle or helper-bundle architecture. | A deliberately deferred alternative; revisit only if a `restricted` identity must hold its own persistent narrow grant. |
 | Adding the missing Automation / Calendar entitlements so those services can prompt. | Separate native-distribution issue surfaced by the same verification run. |
 | Changes to the spawn-env allow-set. | The env trust boundary is already closed and unchanged here. |
+| Automated migration or any back-compatible fallback for existing installs (undeclared levels, the old `~/Documents` knowledge-base path). | Clean break. The small number of existing installs are migrated by hand; no legacy default, shim, or fallback path lives in the code. |
 
 ## Success Criteria
 
@@ -121,7 +117,7 @@ the privilege levels and the substrate location.
 | --- | --- | --- |
 | 1 | A `restricted` agent that deliberately attempts a protected read is denied, while a `full` agent in the same install reads the live mail/calendar stores. | TCC verification runbook (extended): the `com.apple.TCC` stream shows an explicit `SystemPolicyAllFiles` **Denied** decision for the `restricted` agent's probe, and **Allowed** for the `full` agent. A positive probe is required so denial is distinguishable from "never attempted." |
 | 2 | A `restricted` agent completes its knowledge-base work with no TCC grant present, and no `node`/`claude` Documents prompt appears. | With only the app's grants present and the knowledge base on the relocated non-protected path, the `restricted` agent's wake writes its briefing at `~/.cache/fit/outpost/state/<agent>_last_output.md`; the privacy panes show no `node`/`claude` entry. |
-| 3 | A default-config sync agent with no level declared behaves as today. | Runbook Axis 1/2 for an undeclared-level agent: access attributes to `fit-outpost.app`, live mail/calendar read succeeds under the one app grant, no `node`/`claude` grant required. |
+| 3 | A sync agent declared `full` reads the live mail/calendar stores under the one app grant. | Runbook Axis 1/2 for a `full` agent: access attributes to `fit-outpost.app`, live mail/calendar read succeeds under the one app grant, no `node`/`claude` grant required. |
 | 4 | Each wake records the resolved privilege level for the agent. | The scheduler log line for a wake contains the agent's resolved level (`full` or `restricted`). |
 | 5 | Documentation states which agents need which macOS permissions, and the substrate location a `restricted` agent uses. | The Outpost product page and engineers getting-started guide describe `full` vs `restricted` agents and the relocated knowledge-base path. |
-| 6 | Upgrading an install that has a knowledge base under the old `~/Documents` default does not orphan it. | After upgrade, the pre-existing knowledge base is still read by its agent (migrated or still served at the old path). |
+| 6 | An agent whose entry omits the level (or declares an invalid one) is refused, not woken — there is no implicit default. | The scheduler log records an `outpost.privilege.rejected` event and no agent process is spawned for that entry. |


### PR DESCRIPTION
## Spec + design for 2120

Architectural design **and** a scope revision for spec 2120 — per-agent least-privilege execution for Outpost.

> ⚠️ **This reduces the scope of a previously-approved spec.** Per maintainer direction the feature drops all backward compatibility (no shims, no fallbacks, no implicit default). Removing requirements from an approved spec returns 2120 to `draft`: both the spec and the design need fresh human approval. This PR does not request or imply any approval signal.

### Approach

Two privilege levels per agent (`full` / `restricted`), declared in `scheduler.json`, mapped onto the **one attribution seam spec 2100 verified** rather than a new isolation mechanism:

- **`full`** → `disclaim = 0` (child inherits `fit-outpost.app` — today's single-grant behaviour; mail/calendar sync and send agents).
- **`restricted`** → `disclaim = 1` (child responsible for itself; Full Disk Access and Automation not extended, denied even when prompt-injected).

Resolution and application happen at the single `AgentRunner.wake` chokepoint both spawn paths funnel through. Substrate relocation, not a new grant, lets a self-responsible `restricted` child work: the default knowledge base moves off TCC-protected `~/Documents` to a non-protected XDG data path.

### Clean break (this revision)

- **Privilege level is mandatory.** A missing or invalid level is rejected (logged, not woken) — no implicit default, no `defaultPrivilege` marker, no fallback.
- **KB relocation is unconditional.** No continue-to-serve, no dual-path read, no auto-migration. The code knows only the new location.
- **Existing installs are migrated by hand** (out of scope) — the small number of current installs move their KB and declare levels manually, so no legacy lives in the code.

Removed from the prior approved spec: the "secure default for new / back-compatible for old" requirement, the "existing KBs not orphaned" requirement, and the upgrade-no-orphan success criterion.

### Review

Clean sub-agent technical review panel (size 3) run on each revision; every consensus blocker/high/medium finding addressed. Design 101 lines, spec 123 (limit 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya5grpCHMB4nmFthDxdFkJ