### PR TITLE
feat(outpost): per-agent least-privilege execution (#2120)

### DIFF
--- a/libraries/libmacos/src/posix-spawn.js
+++ b/libraries/libmacos/src/posix-spawn.js
@@ -128,9 +128,14 @@ export function readOutput(filePath, runtime) {
  * @param {Record<string, string>} [env] - Environment (defaults to current)
  * @param {string} [cwd] - Working directory for the child process
  * @param {object} [runtime] - Runtime collaborator bag
+ * @param {0|1} [disclaim=0] - TCC responsibility for the child. `0` keeps the
+ *   parent chain's responsible process (the child's access attributes to that
+ *   process, e.g. fit-outpost.app, so one grant covers the subtree); `1` makes
+ *   the child responsible for itself, so the parent's grants are not extended
+ *   to it.
  * @returns {{ pid: number, stdoutFile: string, stderrFile: string }}
  */
-export function spawn(executable, args, env, cwd, runtime) {
+export function spawn(executable, args, env, cwd, runtime, disclaim = 0) {
   const { proc, clock, fsSync } = runtime;
   const argv = buildStringArray([executable, ...args]);
   const envObj = env ?? { ...proc.env };
@@ -157,12 +162,13 @@ export function spawn(executable, args, env, cwd, runtime) {
 
   libc.symbols.posix_spawnattr_init(attr);
 
-  // Do NOT disclaim TCC responsibility: with disclaim = 0 the child keeps the
-  // parent chain's responsible process, so its access is attributed to
-  // fit-outpost.app and a single grant to the app covers the whole subtree.
-  // (disclaim = 1 makes the child responsible for itself, defeating the
-  // single-grant model — see products/outpost/macos/TCC-VERIFICATION.md.)
-  setDisclaim(attr, 0);
+  // Apply the per-wake TCC responsibility setting. With disclaim = 0 the child
+  // keeps the parent chain's responsible process, so its access is attributed
+  // to fit-outpost.app and a single grant to the app covers the whole subtree.
+  // With disclaim = 1 the child is responsible for itself, so the app's grants
+  // are not extended to it (used for least-privilege agents — see
+  // products/outpost/macos/TCC-VERIFICATION.md).
+  setDisclaim(attr, disclaim);
 
   libc.symbols.posix_spawn_file_actions_init(fa);
 

--- a/products/outpost/config/scheduler.json
+++ b/products/outpost/config/scheduler.json
@@ -1,32 +1,38 @@
 {
   "agents": {
     "postman": {
-      "kb": "~/Documents/Personal",
+      "kb": "~/.local/share/fit/outpost/personal",
+      "privilege": "full",
       "schedule": { "type": "cron", "expression": "*/15 8-18 * * 1-5" },
       "enabled": true
     },
     "concierge": {
-      "kb": "~/Documents/Personal",
+      "kb": "~/.local/share/fit/outpost/personal",
+      "privilege": "full",
       "schedule": { "type": "cron", "expression": "*/30 8-18 * * 1-5" },
       "enabled": true
     },
     "librarian": {
-      "kb": "~/Documents/Personal",
+      "kb": "~/.local/share/fit/outpost/personal",
+      "privilege": "restricted",
       "schedule": { "type": "cron", "expression": "0 9,12,15,18 * * 1-5" },
       "enabled": true
     },
     "chief-of-staff": {
-      "kb": "~/Documents/Personal",
+      "kb": "~/.local/share/fit/outpost/personal",
+      "privilege": "restricted",
       "schedule": { "type": "cron", "expression": "0 7,18 * * 1-5" },
       "enabled": true
     },
     "recruiter": {
-      "kb": "~/Documents/Personal",
+      "kb": "~/.local/share/fit/outpost/personal",
+      "privilege": "restricted",
       "schedule": { "type": "cron", "expression": "0 8,12,17 * * 1-5" },
       "enabled": true
     },
     "head-hunter": {
-      "kb": "~/Documents/Personal",
+      "kb": "~/.local/share/fit/outpost/personal",
+      "privilege": "restricted",
       "schedule": { "type": "cron", "expression": "0 9 * * 1-5" },
       "enabled": true
     }

--- a/products/outpost/macos/TCC-VERIFICATION.md
+++ b/products/outpost/macos/TCC-VERIFICATION.md
@@ -16,14 +16,27 @@ fit-outpost.app  --hop 1-->  fit-outpost daemon  --hop 2-->  claude (node)
    (signed bundle)        ProcessManager.swift            posix-spawn.js
 ```
 
-The goal is that a single grant to `fit-outpost.app` covers the whole subtree.
-Both spawn sites achieve this by passing `disclaim = 0`
-(`ProcessManager.swift`, `posix-spawn.js`): the child keeps the parent chain's
-responsible process rather than becoming responsible for itself, so attribution
-flows up to `fit-outpost.app`. This runbook re-measures the responsible-process
-lookup at **each hop** per release to confirm that setting still holds — an
-inverted `disclaim = 1` would make each child responsible for itself and
-silently break the single-grant model.
+Hop 1 (`ProcessManager.swift`) always passes `disclaim = 0`: the daemon stays a
+child of `fit-outpost.app`. Hop 2 (`posix-spawn.js`) carries a **per-agent**
+disclaim derived from the agent's declared privilege level, so an agent runs
+with only the macOS reach its job requires:
+
+- A `full` agent (mail/calendar sync, mail send) keeps `disclaim = 0`, so its
+  `claude` child inherits `fit-outpost.app` as its responsible process and a
+  single grant to the app covers it — the model this runbook has always
+  measured.
+- A `restricted` agent (synced cache → knowledge base only) passes
+  `disclaim = 1`, so its `claude` child is **responsible for itself**. The app's
+  Full Disk Access and Automation are deliberately **not** extended to it; it
+  operates only on non-TCC-protected substrate (the synced cache and the
+  relocated knowledge base) and is denied a protected read even if fully
+  prompt-injected.
+
+This runbook re-measures the responsible-process lookup at **each hop** per
+release. For a `full` agent both hops must attribute to `fit-outpost.app` — an
+inverted `disclaim = 1` would silently break the single-grant model. For a
+`restricted` agent hop 2 must be self-responsible and the protected read
+**denied** — an inverted `disclaim = 0` would silently grant it the app's reach.
 
 ## TCC services and their `tccutil` identifiers
 
@@ -31,7 +44,7 @@ silently break the single-grant model.
 | -------------------- | --------------------------------- | --------------------------- | ----------------------------- |
 | Mail store read      | `~/Library/Mail/…/Envelope Index` | Full Disk Access            | `SystemPolicyAllFiles`        |
 | Calendar store read  | `~/Library/Calendars/`            | Full Disk Access            | `SystemPolicyAllFiles`        |
-| Knowledge base       | `~/Documents/<kb>`                | Files & Folders (Documents) | `SystemPolicyDocumentsFolder` |
+| Knowledge base       | `~/.local/share/fit/outpost/<kb>` | none (non-TCC location)     | n/a — a restricted agent reaches it with no grant |
 | Draft-side Mail send | Mail via AppleScript              | Automation (AppleEvents)    | `AppleEvents`                 |
 
 The Calendar store is read **as files** (Full Disk Access); this runbook does
@@ -46,8 +59,9 @@ result here does not prove Calendar-API coverage.
 - `claude` installed and resolvable by the daemon. The daemon searches
   `/usr/local/bin`, `~/.claude/bin`, `~/.local/bin`, `/opt/homebrew/bin` in that
   order — confirm which binary it will spawn.
-- At least one agent configured in `~/.fit/outpost/scheduler.json` with a `kb`
-  that exists.
+- At least one `full` and one `restricted` agent configured in
+  `~/.fit/outpost/scheduler.json`, each with a declared `privilege` level and a
+  `kb` that exists (Axis 4 exercises both levels).
 - **The daemon must be running and must have been launched by
   `fit-outpost.app`** (open the app or enable it as a login item) — not started
   with `fit-outpost daemon` from a terminal. `fit-outpost wake` forwards the
@@ -66,17 +80,18 @@ Run each step in order. Record outcomes in the **Results** block at the bottom.
 
 ```sh
 tccutil reset SystemPolicyAllFiles
-tccutil reset SystemPolicyDocumentsFolder
 tccutil reset AppleEvents
 ```
 
 Then in **System Settings → Privacy & Security**, remove any existing `node` or
-Claude-CLI (version-string) entries under Full Disk Access, Files & Folders, and
-Automation.
+Claude-CLI (version-string) entries under Full Disk Access and Automation. (The
+knowledge base is no longer in a TCC-protected folder, so there is no
+Files & Folders state to reset.)
 
 **(b) Grant only `fit-outpost.app`.** Grant `fit-outpost.app` Full Disk Access and, if
-prompted, Files & Folders (Documents) and Automation for Mail. Grant **nothing**
-to `node` or the Claude CLI.
+prompted, Automation for Mail. Grant **nothing** to `node` or the Claude CLI.
+The relocated knowledge base (`~/.local/share/fit/outpost/<kb>`) is outside every
+TCC-protected folder, so no Files & Folders grant is involved.
 
 **(c) Start the attribution stream, then wake an agent.** The spawned `claude`
 is short-lived, so begin capturing before the wake. In a second terminal, the
@@ -134,12 +149,40 @@ the read to succeed.
 single `fit-outpost.app` Automation grant, with no separate `node`/CLI Automation
 entry.
 
-**(g) Fix C — conditional direct grant.** If any single service still fails
+**(g) Assert per-agent privilege denial (Axis 4).** With the same single
+`fit-outpost.app` grant in place, wake one `restricted` agent and one `full`
+agent. The `restricted` agent must deliberately attempt a Full Disk
+Access-protected read (a **positive probe** — e.g. reading
+`~/Library/Mail/…/Envelope Index` — so a denial is distinguishable from "never
+attempted"). In the TCC stream from step (c), confirm:
+
+- the `restricted` agent's probe shows an explicit `SystemPolicyAllFiles`
+  **Denied** decision, with `responsible=` resolving to the self-responsible
+  `claude` child (not `fit-outpost.app`);
+- the `full` agent's live-store read shows `SystemPolicyAllFiles` **Allowed**
+  with `responsible=…/fit-outpost.app`.
+
+Then confirm the `restricted` agent still completed its knowledge-base work with
+**no** grant present — its KB is under `~/.local/share/fit/outpost/<kb>`, a
+non-TCC location, and its briefing lands at
+`~/.cache/fit/outpost/state/<agent>_last_output.md` — and that **no**
+`node`/`claude` entry appears in any privacy pane. Finally, grep the scheduler
+log to confirm each wake recorded its resolved level:
+
+```sh
+grep outpost.privilege.resolved ~/.fit/outpost/logs/scheduler-*.log
+```
+
+Expect one `level: "restricted"` and one `level: "full"` line for the two
+agents. An agent whose entry omits the level logs `outpost.privilege.rejected`
+and is not woken.
+
+**(h) Fix C — conditional direct grant.** If any single service still fails
 under the `fit-outpost.app`-only grant, grant **that one service** (per the table
-above) to `fit-outpost.app` directly, re-run (c)–(f), and record which service
+above) to `fit-outpost.app` directly, re-run (c)–(g), and record which service
 needed it. The remedy is still one process — never a grant to `node` or the CLI.
 
-**(h) Persistence across upgrade (Axis 3).** Rebuild and re-sign `fit-outpost.app`,
+**(i) Persistence across upgrade (Axis 3).** Rebuild and re-sign `fit-outpost.app`,
 reinstall it over the existing grant, and re-wake:
 
 ```sh
@@ -159,6 +202,11 @@ ad-hoc build with a deterministic cdhash survives a `brew upgrade`).
   hops and re-run.
 - **A service fails (Axis 2)** → document the single direct grant for that
   service on `fit-outpost.app`.
+- **A `restricted` agent's probe is Allowed, or a `full` agent's read is Denied
+  (Axis 4)** → hop 2's per-agent disclaim is inverted; check
+  `resolvePrivilege`/`disclaimFor` and the spawn-call threading in
+  `agent-runner.js`. A `restricted` probe that is **never attempted** is not a
+  pass — re-run with the positive probe so denial is observed.
 - **Grant lost on upgrade (Axis 3)** → ship a Developer ID-signed bundle so the
   grant pins to the designated requirement.
 
@@ -179,13 +227,18 @@ Axis 1 — per-hop attribution
 
 Axis 2 — per-service honoring (under one fit-outpost.app grant)
   Full Disk Access (Mail/Calendar read):   PASS/FAIL
-  Files & Folders (Documents KB):           PASS/FAIL
   Automation (draft-side Mail):             PASS/FAIL
   service(s) needing a direct grant:        <none | service name(s)>
 
 Axis 3 — persistence across re-signed upgrade
   grant survived, no re-prompt:             PASS/FAIL
 
-Finding:                 <single-grant holds | disclaim setting | non-inherited service | persistence | combination>
-Fixes applied:           <none | Step (g) | re-sign | combination>
+Axis 4 — per-agent privilege denial (under one fit-outpost.app grant)
+  restricted agent FDA probe:  <SystemPolicyAllFiles Denied | other>   PASS/FAIL
+  full agent live-store read:  <SystemPolicyAllFiles Allowed | other>  PASS/FAIL
+  restricted KB work completed with no grant (non-TCC KB):             PASS/FAIL
+  scheduler log records outpost.privilege.resolved per wake:           PASS/FAIL
+
+Finding:                 <single-grant holds | disclaim setting | non-inherited service | privilege denial | persistence | combination>
+Fixes applied:           <none | Step (h) | re-sign | combination>
 ```

--- a/products/outpost/pkg/macos/conclusion.html
+++ b/products/outpost/pkg/macos/conclusion.html
@@ -81,7 +81,7 @@
     </p>
     <p><strong>Next steps:</strong></p>
     <p>1. Populate your identity from the corporate directory:</p>
-    <p class="cmd"><code>bash ~/Documents/Personal/.claude/skills/person-identify/scripts/identify.sh</code></p>
+    <p class="cmd"><code>bash ~/.local/share/fit/outpost/personal/.claude/skills/person-identify/scripts/identify.sh</code></p>
     <p>2. Configure scheduled tasks:</p>
     <p class="cmd"><code>vim ~/.fit/outpost/scheduler.json</code></p>
     <p>3. Check scheduler status:</p>
@@ -97,7 +97,7 @@
       <code>fit-outpost update</code>
     </p>
     <p>6. Open your knowledge base interactively:</p>
-    <p class="cmd"><code>cd ~/Documents/Personal &amp;&amp; claude</code></p>
+    <p class="cmd"><code>cd ~/.local/share/fit/outpost/personal &amp;&amp; claude</code></p>
     <p class="note">
       The installer runs <code>update</code> automatically on all configured
       knowledge bases. You can also run it manually at any time to push the

--- a/products/outpost/pkg/macos/postinstall
+++ b/products/outpost/pkg/macos/postinstall
@@ -9,7 +9,7 @@ REAL_USER=$(/usr/bin/stat -f "%Su" /dev/console)
 REAL_HOME=$(/usr/bin/dscl . -read "/Users/$REAL_USER" NFSHomeDirectory | /usr/bin/awk '{print $2}')
 
 OUTPOST_HOME="$REAL_HOME/.fit/outpost"
-DEFAULT_KB="$REAL_HOME/Documents/Personal"
+DEFAULT_KB="$REAL_HOME/.local/share/fit/outpost/personal"
 APP_PATH="/Applications/Forward Impact/fit-outpost.app"
 
 # --- Stop running instance gracefully ----------------------------------------
@@ -46,7 +46,10 @@ SCHEDULER="$APP_PATH/Contents/MacOS/fit-outpost"
 
 if [ ! -d "$DEFAULT_KB" ]; then
   if [ -f "$SCHEDULER" ]; then
-    /usr/bin/sudo -u "$REAL_USER" "$SCHEDULER" init "$DEFAULT_KB" 2>/dev/null || true
+    # `init personal` resolves to $DEFAULT_KB under the data home and creates
+    # the directory tree there (a non-TCC location a restricted agent reaches
+    # without any grant).
+    /usr/bin/sudo -u "$REAL_USER" "$SCHEDULER" init personal 2>/dev/null || true
   fi
 fi
 

--- a/products/outpost/pkg/macos/uninstall.sh
+++ b/products/outpost/pkg/macos/uninstall.sh
@@ -3,8 +3,8 @@ set -e
 
 # Outpost Uninstaller
 #
-# Removes fit-outpost.app. User data at ~/Documents/Personal/ and config at
-# ~/.fit/outpost/ are preserved.
+# Removes fit-outpost.app. User data at ~/.local/share/fit/outpost/ and config
+# at ~/.fit/outpost/ are preserved.
 
 APP_PATH="/Applications/Forward Impact/fit-outpost.app"
 
@@ -51,9 +51,9 @@ fi
 
 echo ""
 echo "Outpost uninstalled."
-echo "Your data at ~/Documents/Personal/ has been preserved."
+echo "Your data at ~/.local/share/fit/outpost/ has been preserved."
 echo "Your config at ~/.fit/outpost/ has been preserved."
 echo ""
-echo "To remove all data:   rm -rf ~/Documents/Personal/"
+echo "To remove all data:   rm -rf ~/.local/share/fit/outpost/"
 echo "To remove all config: rm -rf ~/.fit/outpost/"
 echo ""

--- a/products/outpost/pkg/macos/welcome.html
+++ b/products/outpost/pkg/macos/welcome.html
@@ -50,7 +50,7 @@
       </li>
       <li>
         Initialize a default knowledge base at
-        <code>~/Documents/Personal/</code>
+        <code>~/.local/share/fit/outpost/personal/</code>
       </li>
     </ul>
     <p class="note">

--- a/products/outpost/src/agent-runner.js
+++ b/products/outpost/src/agent-runner.js
@@ -11,6 +11,7 @@ import {
   loadManifest,
   draftSkills,
 } from "./posture.js";
+import { resolvePrivilege, disclaimFor } from "./privilege.js";
 import { buildSpawnEnv } from "./spawn-env.js";
 
 /**
@@ -176,6 +177,24 @@ export class AgentRunner {
    * @param {Record<string, string>} [configEnv] - Extra env vars from config
    */
   async wake(agentName, agent, state, configEnv) {
+    // Resolve the mandatory privilege level before any work. A missing or
+    // invalid level is fail-closed: log and skip the wake — no agent process is
+    // spawned with a guessed privilege. The level lives in the user-only trust
+    // root, so a spawned agent cannot raise its own.
+    let level;
+    try {
+      level = resolvePrivilege(agent);
+    } catch (err) {
+      this.#log(
+        JSON.stringify({
+          event: "outpost.privilege.rejected",
+          agent: agentName,
+          error: err.message,
+        }),
+      );
+      return;
+    }
+
     if (!agent.kb) {
       this.#log(`Agent ${agentName}: no "kb" specified, skipping.`);
       return;
@@ -191,6 +210,13 @@ export class AgentRunner {
     const claude = await this.#findClaude();
 
     this.#log(`Waking agent: ${agentName} (kb: ${agent.kb})`);
+    this.#log(
+      JSON.stringify({
+        event: "outpost.privilege.resolved",
+        agent: agentName,
+        level,
+      }),
+    );
 
     const as = (state.agents[agentName] ||= {});
     as.status = "active";
@@ -226,6 +252,7 @@ export class AgentRunner {
         env,
         kbPath,
         this.#runtime,
+        disclaimFor(level),
       );
       this.#activeChildren.add(pid);
 

--- a/products/outpost/src/kb-manager.js
+++ b/products/outpost/src/kb-manager.js
@@ -24,6 +24,33 @@ export class KBManager {
   }
 
   /**
+   * Resolve a knowledge-base name to its path under the XDG data home,
+   * `~/.local/share/fit/outpost/<name>`. The argument is a single path segment,
+   * never an arbitrary filesystem path, so a provisioned KB always lands outside
+   * TCC-protected folders. The name is validated — not sanitised — against the
+   * same rule as `agent-path.js`: a name carrying `/`, `\`, `..`, NUL, or a
+   * leading `~` could steer the KB back inside `~/Documents`, reopening the TCC
+   * hole, so it is rejected rather than rewritten.
+   * @param {string} name - The KB name (e.g. `personal`, `team`).
+   * @returns {string} Absolute path under the data home.
+   * @throws {Error} when `name` is empty, non-string, or an unsafe segment.
+   */
+  static kbPathForName(name) {
+    if (
+      typeof name !== "string" ||
+      name.length === 0 ||
+      name.includes("/") ||
+      name.includes("\\") ||
+      name.includes("..") ||
+      name.includes("\0") ||
+      name.startsWith("~")
+    ) {
+      throw new Error(`unsafe KB name: ${JSON.stringify(name)}`);
+    }
+    return join(homedir(), ".local/share/fit/outpost", name);
+  }
+
+  /**
    * Test whether a path exists, via the async fs surface.
    * @param {string} p
    * @returns {Promise<boolean>}

--- a/products/outpost/src/outpost.js
+++ b/products/outpost/src/outpost.js
@@ -4,7 +4,7 @@
 //   fit-outpost                     Wake due agents once and exit
 //   fit-outpost daemon              Run continuously (poll every 60s)
 //   fit-outpost wake <agent>        Wake a specific agent immediately
-//   fit-outpost init <path>         Initialize a new knowledge base
+//   fit-outpost init [name]         Initialize a knowledge base by name (default: personal)
 //   fit-outpost update [path]       Update KB with latest CLAUDE.md, agents and skills (defaults to current directory)
 //   fit-outpost stop                Gracefully stop daemon and all running agents
 //   fit-outpost validate            Validate agent definitions exist
@@ -58,7 +58,7 @@ function buildDefinition(version) {
       },
       {
         name: "init",
-        args: "<path>",
+        args: "[name]",
         description: "Initialize a new knowledge base",
       },
       {
@@ -433,13 +433,20 @@ export async function run(runtime, version) {
       return 1;
     },
     init: async () => {
-      if (!args[0]) {
-        cli.usageError("missing required argument <path>");
+      // `init [name]` provisions a KB by name under the data home (default
+      // `personal`), never an arbitrary path — so the substrate cannot be
+      // steered back into a TCC-protected folder. An unsafe name is refused.
+      const name = args[0] ?? "personal";
+      let target;
+      try {
+        target = KBManager.kbPathForName(name);
+      } catch {
+        cli.usageError(`invalid KB name "${name}"`);
         return 2;
       }
       const tpl = await requireTemplateDir();
       if (tpl === null) return 1;
-      const result = await kbManager.init(args[0], tpl);
+      const result = await kbManager.init(target, tpl);
       if (!result.ok) {
         proc.stderr.write(result.error + "\n");
         return result.code;

--- a/products/outpost/src/privilege.js
+++ b/products/outpost/src/privilege.js
@@ -1,0 +1,45 @@
+/**
+ * Privilege — resolve an agent's least-privilege execution level and map it to
+ * the hop-2 spawn disclaim flag.
+ *
+ * The level governs the macOS reach the daemon grants a woken agent. `full`
+ * keeps today's single-grant model (the child inherits `fit-outpost.app` as its
+ * responsible process, so Full Disk Access and Automation flow to it); a
+ * `restricted` agent is held responsible for itself, so those grants are not
+ * extended and it can reach only non-TCC-protected substrate.
+ *
+ * The level is mandatory and lives in the same user-only trust root as the
+ * spawn-env allow-set and the state roots, so an agent cannot raise its own
+ * level. Patterned on `posture.js` but with no `effective*` coercion and no
+ * default — a missing or unrecognised value throws.
+ */
+
+/** The two privilege levels, in declaration order. */
+export const PRIVILEGE_LEVELS = ["full", "restricted"];
+
+/**
+ * Resolve an agent's declared privilege level. The level is mandatory: a
+ * missing or unrecognised value throws — there is no default.
+ * @param {{ privilege?: string }} agent - One agent's config.
+ * @returns {"full"|"restricted"} The declared level.
+ * @throws {Error} when `agent.privilege` is not one of {@link PRIVILEGE_LEVELS}.
+ */
+export function resolvePrivilege(agent) {
+  const level = agent?.privilege;
+  if (!PRIVILEGE_LEVELS.includes(level)) {
+    throw new Error(
+      `invalid privilege "${level}"; expected one of ${PRIVILEGE_LEVELS.join(", ")}`,
+    );
+  }
+  return level;
+}
+
+/**
+ * Map a level to the hop-2 disclaim flag: `restricted` self-disclaims (`1`),
+ * `full` keeps the inherited responsible process (`0`).
+ * @param {"full"|"restricted"} level
+ * @returns {0|1}
+ */
+export function disclaimFor(level) {
+  return level === "restricted" ? 1 : 0;
+}

--- a/products/outpost/test/agent-runner-privilege.test.js
+++ b/products/outpost/test/agent-runner-privilege.test.js
@@ -1,0 +1,121 @@
+/**
+ * AgentRunner privilege-gate tests
+ *
+ * The wake path resolves a mandatory privilege level, logs it, threads the
+ * disclaim flag into the spawn call, and fail-closes a missing/invalid level
+ * (logs `outpost.privilege.rejected` and spawns nothing).
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { AgentRunner } from "../src/agent-runner.js";
+import {
+  TEST_KB,
+  postureCfg,
+  createMockSpawn,
+  createMockStateManager,
+  makeRuntime,
+} from "./helpers.js";
+
+/** Parse logged lines, keeping only the JSON objects matching `event`. */
+function eventsOf(logged, event) {
+  return logged
+    .map((l) => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .filter((r) => r && r.event === event);
+}
+
+/**
+ * Build a runner whose log lines are collected into `logged`.
+ * @param {string[]} logged
+ * @param {{ module: Object }} spawn
+ */
+function makeRunner(logged, spawn) {
+  return new AgentRunner(
+    spawn.module,
+    createMockStateManager(),
+    (line) => logged.push(line),
+    "/tmp/cache",
+    makeRuntime({ HOME: "/home/u" }),
+    postureCfg(),
+  );
+}
+
+describe("AgentRunner privilege gate (via wake)", () => {
+  test("a full agent passes disclaim 0 and logs level full", async () => {
+    const spawn = createMockSpawn();
+    const logged = [];
+    const runner = makeRunner(logged, spawn);
+
+    await runner.wake(
+      "sync-agent",
+      { kb: TEST_KB, privilege: "full" },
+      { agents: {} },
+    );
+
+    assert.strictEqual(spawn.calls.length, 1);
+    assert.strictEqual(spawn.calls[0].disclaim, 0);
+    const resolved = eventsOf(logged, "outpost.privilege.resolved");
+    assert.strictEqual(resolved.length, 1);
+    assert.strictEqual(resolved[0].level, "full");
+    assert.strictEqual(resolved[0].agent, "sync-agent");
+  });
+
+  test("a restricted agent passes disclaim 1 and logs level restricted", async () => {
+    const spawn = createMockSpawn();
+    const logged = [];
+    const runner = makeRunner(logged, spawn);
+
+    await runner.wake(
+      "kb-agent",
+      { kb: TEST_KB, privilege: "restricted" },
+      { agents: {} },
+    );
+
+    assert.strictEqual(spawn.calls.length, 1);
+    assert.strictEqual(spawn.calls[0].disclaim, 1);
+    const resolved = eventsOf(logged, "outpost.privilege.resolved");
+    assert.strictEqual(resolved.length, 1);
+    assert.strictEqual(resolved[0].level, "restricted");
+  });
+
+  test("a missing level is rejected and nothing is spawned", async () => {
+    const spawn = createMockSpawn();
+    const logged = [];
+    const runner = makeRunner(logged, spawn);
+
+    await runner.wake("no-level", { kb: TEST_KB }, { agents: {} });
+
+    assert.strictEqual(spawn.calls.length, 0);
+    const rejected = eventsOf(logged, "outpost.privilege.rejected");
+    assert.strictEqual(rejected.length, 1);
+    assert.strictEqual(rejected[0].agent, "no-level");
+    assert.match(rejected[0].error, /invalid privilege/);
+    // The wake never reached the resolved-level log.
+    assert.strictEqual(
+      eventsOf(logged, "outpost.privilege.resolved").length,
+      0,
+    );
+  });
+
+  test("an invalid level is rejected and nothing is spawned", async () => {
+    const spawn = createMockSpawn();
+    const logged = [];
+    const runner = makeRunner(logged, spawn);
+
+    await runner.wake(
+      "bad-level",
+      { kb: TEST_KB, privilege: "elevated" },
+      { agents: {} },
+    );
+
+    assert.strictEqual(spawn.calls.length, 0);
+    const rejected = eventsOf(logged, "outpost.privilege.rejected");
+    assert.strictEqual(rejected.length, 1);
+    assert.strictEqual(rejected[0].agent, "bad-level");
+  });
+});

--- a/products/outpost/test/agent-runner.test.js
+++ b/products/outpost/test/agent-runner.test.js
@@ -8,77 +8,14 @@ import { test, describe } from "node:test";
 import assert from "node:assert";
 import { AgentRunner } from "../src/agent-runner.js";
 import {
-  spy,
-  createTestRuntime,
-  createMockFs,
-  createMockProcess,
-} from "@forwardimpact/libmock";
-
-const TEST_KB = "/work/outpost-test-kb";
-const POSTURE_PATH = "/home/u/.fit/outpost/posture.json";
-const MANIFEST_PATH = "/pkg/config/skill-postures.json";
-const MANIFEST = {
-  "draft-emails": "draft",
-  "organize-files": "draft",
-  "send-chat": "draft",
-  "meeting-prep": "brief",
-  "extract-entities": "brief",
-};
-const DRAFT_TOKENS =
-  "Skill(draft-emails) Skill(organize-files) Skill(send-chat)";
-
-/** The posture-config object every AgentRunner construction needs. */
-const postureCfg = () => ({
-  posturePath: POSTURE_PATH,
-  manifestPath: MANIFEST_PATH,
-});
-
-/**
- * Create a mock spawn module that records calls and returns a successful result.
- * @param {Object} [options]
- * @param {number} [options.exitCode=0]
- * @param {string} [options.stdout="ok"]
- * @returns {{ module: Object, calls: Array }}
- */
-function createMockSpawn({ exitCode = 0, stdout = "ok" } = {}) {
-  const calls = [];
-  return {
-    calls,
-    module: {
-      spawn(executable, args, env, cwd) {
-        calls.push({ executable, args, env, cwd });
-        return {
-          pid: 999,
-          stdoutFile: "/tmp/mock-stdout",
-          stderrFile: "/tmp/mock-stderr",
-        };
-      },
-      readOutput: () => stdout,
-      waitForExit: async () => exitCode,
-    },
-  };
-}
-
-function createMockStateManager() {
-  return {
-    save: spy(async () => {}),
-    updateAgentState: spy(async () => {}),
-  };
-}
-
-/**
- * Build a runtime whose mock fs reports TEST_KB as existing and whose proc env
- * carries the supplied vars.
- * @param {Record<string,string>} env
- */
-function makeRuntime(env, files = {}) {
-  const fs = createMockFs({
-    [MANIFEST_PATH]: JSON.stringify(MANIFEST),
-    ...files,
-  });
-  fs.dirs.add(TEST_KB);
-  return createTestRuntime({ fs, proc: createMockProcess({ env }) });
-}
+  TEST_KB,
+  POSTURE_PATH,
+  DRAFT_TOKENS,
+  postureCfg,
+  createMockSpawn,
+  createMockStateManager,
+  makeRuntime,
+} from "./helpers.js";
 
 describe("AgentRunner", () => {
   describe("constructor validation", () => {
@@ -108,7 +45,11 @@ describe("AgentRunner", () => {
         postureCfg(),
       );
 
-      await runner.wake("test-agent", { kb: TEST_KB }, { agents: {} });
+      await runner.wake(
+        "test-agent",
+        { kb: TEST_KB, privilege: "full" },
+        { agents: {} },
+      );
 
       assert.strictEqual(calls.length, 1);
       assert.strictEqual(calls[0].env.HOME, "/home/u");
@@ -129,7 +70,7 @@ describe("AgentRunner", () => {
       const configEnv = { ANTHROPIC_API_KEY: "sk-test-123" };
       await runner.wake(
         "test-agent",
-        { kb: TEST_KB },
+        { kb: TEST_KB, privilege: "full" },
         { agents: {} },
         configEnv,
       );
@@ -154,7 +95,7 @@ describe("AgentRunner", () => {
       const configEnv = { NODE_EXTRA_CA_CERTS: "/etc/ssl/custom-ca.pem" };
       await runner.wake(
         "test-agent",
-        { kb: TEST_KB },
+        { kb: TEST_KB, privilege: "full" },
         { agents: {} },
         configEnv,
       );
@@ -178,7 +119,7 @@ describe("AgentRunner", () => {
       const configEnv = { ANTHROPIC_API_KEY: "sk-from-config" };
       await runner.wake(
         "test-agent",
-        { kb: TEST_KB },
+        { kb: TEST_KB, privilege: "full" },
         { agents: {} },
         configEnv,
       );
@@ -199,7 +140,7 @@ describe("AgentRunner", () => {
 
       await runner.wake(
         "test-agent",
-        { kb: TEST_KB },
+        { kb: TEST_KB, privilege: "full" },
         { agents: {} },
         { ANTHROPIC_API_KEY: "~/certs/ca-bundle.pem" },
       );
@@ -224,7 +165,7 @@ describe("AgentRunner", () => {
         postureCfg(),
       );
 
-      const agent = { kb: TEST_KB };
+      const agent = { kb: TEST_KB, privilege: "full" };
       const state = { agents: {} };
       const configEnv = { NODE_OPTIONS: "--require=/tmp/evil.js" };
       await runner.wake("test-agent", agent, state, configEnv);
@@ -262,7 +203,7 @@ describe("AgentRunner", () => {
 
       await runner.wake(
         "test-agent",
-        { kb: TEST_KB },
+        { kb: TEST_KB, privilege: "full" },
         { agents: {} },
         undefined,
       );
@@ -285,7 +226,11 @@ describe("AgentRunner", () => {
         postureCfg(),
       );
 
-      await runner.wake("test-agent", { kb: TEST_KB }, { agents: {} });
+      await runner.wake(
+        "test-agent",
+        { kb: TEST_KB, privilege: "full" },
+        { agents: {} },
+      );
       // pid 999 was tracked during wake but removed on exit; force one in.
       runner.activeChildren.add(4242);
       runner.killActiveChildren();
@@ -312,7 +257,11 @@ describe("AgentRunner", () => {
         postureCfg(),
       );
 
-      await runner.wake("test-agent", { kb: TEST_KB }, { agents: {} });
+      await runner.wake(
+        "test-agent",
+        { kb: TEST_KB, privilege: "full" },
+        { agents: {} },
+      );
 
       const args = calls[0].args;
       const denyIdx = args.indexOf("--disallowedTools");
@@ -336,7 +285,11 @@ describe("AgentRunner", () => {
         postureCfg(),
       );
 
-      await runner.wake("test-agent", { kb: TEST_KB }, { agents: {} });
+      await runner.wake(
+        "test-agent",
+        { kb: TEST_KB, privilege: "full" },
+        { agents: {} },
+      );
 
       assert.ok(calls[0].args.includes("--disallowedTools"));
     });
@@ -355,7 +308,11 @@ describe("AgentRunner", () => {
         postureCfg(),
       );
 
-      await runner.wake("test-agent", { kb: TEST_KB }, { agents: {} });
+      await runner.wake(
+        "test-agent",
+        { kb: TEST_KB, privilege: "full" },
+        { agents: {} },
+      );
 
       const args = calls[0].args;
       assert.ok(!args.includes("--disallowedTools"));
@@ -377,7 +334,11 @@ describe("AgentRunner", () => {
         postureCfg(),
       );
 
-      await runner.wake("test-agent", { kb: TEST_KB }, { agents: {} });
+      await runner.wake(
+        "test-agent",
+        { kb: TEST_KB, privilege: "full" },
+        { agents: {} },
+      );
 
       const wrotePosture = runtime.fs.writeFile.mock.calls.some(
         (c) => c.arguments[0] === POSTURE_PATH,

--- a/products/outpost/test/config-shape.test.js
+++ b/products/outpost/test/config-shape.test.js
@@ -1,0 +1,55 @@
+/**
+ * Config-shape guard on the shipped `config/scheduler.json`.
+ *
+ * Every bundled agent must declare a valid privilege level and a knowledge base
+ * outside every TCC-protected folder. This asserts the shipped file only — it
+ * adds no runtime path constraint in the code. Paths are stored `~`-prefixed
+ * and unexpanded, so the checks are literal `startsWith`.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { PRIVILEGE_LEVELS } from "../src/privilege.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG = JSON.parse(
+  readFileSync(join(__dirname, "..", "config", "scheduler.json"), "utf8"),
+);
+
+const TCC_PREFIXES = ["~/Documents", "~/Desktop", "~/Downloads", "~/Library"];
+const DATA_HOME_PREFIX = "~/.local/share/fit/outpost/";
+
+describe("bundled scheduler.json shape", () => {
+  const agents = Object.entries(CONFIG.agents || {});
+
+  test("ships at least one agent", () => {
+    assert.ok(agents.length > 0, "no agents in bundled config");
+  });
+
+  for (const [name, agent] of agents) {
+    test(`${name} declares a valid privilege level`, () => {
+      assert.ok(
+        PRIVILEGE_LEVELS.includes(agent.privilege),
+        `${name}.privilege "${agent.privilege}" not in ${PRIVILEGE_LEVELS.join(", ")}`,
+      );
+    });
+
+    test(`${name} kb is not in a TCC-protected folder`, () => {
+      for (const prefix of TCC_PREFIXES) {
+        assert.ok(
+          !agent.kb.startsWith(prefix),
+          `${name}.kb "${agent.kb}" is under TCC-protected ${prefix}`,
+        );
+      }
+    });
+
+    test(`${name} kb is under the data home`, () => {
+      assert.ok(
+        agent.kb.startsWith(DATA_HOME_PREFIX),
+        `${name}.kb "${agent.kb}" is not under ${DATA_HOME_PREFIX}`,
+      );
+    });
+  }
+});

--- a/products/outpost/test/golden/fit-outpost/help.stdout
+++ b/products/outpost/test/golden/fit-outpost/help.stdout
@@ -5,7 +5,7 @@ Usage: fit-outpost <command> [options]
 Commands:
   daemon                       Run continuously (poll every 60s)
   wake <agent>                 Wake a specific agent immediately
-  init <path>                  Initialize a new knowledge base
+  init [name]                  Initialize a new knowledge base
   update [path]                Update KB with latest CLAUDE.md, agents and skills (defaults to current directory)
   stop                         Gracefully stop daemon and all running agents
   validate                     Validate agent definitions exist

--- a/products/outpost/test/helpers.js
+++ b/products/outpost/test/helpers.js
@@ -1,0 +1,84 @@
+/**
+ * Shared AgentRunner test setup, lifted so `agent-runner.test.js` and its
+ * `agent-runner-privilege.test.js` sibling reuse one set of mock collaborators
+ * (per .claude/rules/test-file-shape.md).
+ */
+import {
+  spy,
+  createTestRuntime,
+  createMockFs,
+  createMockProcess,
+} from "@forwardimpact/libmock";
+
+export const TEST_KB = "/work/outpost-test-kb";
+export const POSTURE_PATH = "/home/u/.fit/outpost/posture.json";
+export const MANIFEST_PATH = "/pkg/config/skill-postures.json";
+export const MANIFEST = {
+  "draft-emails": "draft",
+  "organize-files": "draft",
+  "send-chat": "draft",
+  "meeting-prep": "brief",
+  "extract-entities": "brief",
+};
+export const DRAFT_TOKENS =
+  "Skill(draft-emails) Skill(organize-files) Skill(send-chat)";
+
+/** The posture-config object every AgentRunner construction needs. */
+export const postureCfg = () => ({
+  posturePath: POSTURE_PATH,
+  manifestPath: MANIFEST_PATH,
+});
+
+/**
+ * Create a mock spawn module that records calls and returns a successful result.
+ * Captures all six positional args, including the 5th (`runtime`) and 6th
+ * (`disclaim`) so the privilege tests can assert the disclaim value.
+ * @param {Object} [options]
+ * @param {number} [options.exitCode=0]
+ * @param {string} [options.stdout="ok"]
+ * @returns {{ module: Object, calls: Array }}
+ */
+export function createMockSpawn({ exitCode = 0, stdout = "ok" } = {}) {
+  const calls = [];
+  return {
+    calls,
+    module: {
+      spawn(executable, args, env, cwd, runtime, disclaim) {
+        calls.push({ executable, args, env, cwd, runtime, disclaim });
+        return {
+          pid: 999,
+          stdoutFile: "/tmp/mock-stdout",
+          stderrFile: "/tmp/mock-stderr",
+        };
+      },
+      readOutput: () => stdout,
+      waitForExit: async () => exitCode,
+    },
+  };
+}
+
+/**
+ * Create a mock StateManager whose `save`/`updateAgentState` are spies.
+ * @returns {{ save: Function, updateAgentState: Function }}
+ */
+export function createMockStateManager() {
+  return {
+    save: spy(async () => {}),
+    updateAgentState: spy(async () => {}),
+  };
+}
+
+/**
+ * Build a runtime whose mock fs reports TEST_KB as existing and whose proc env
+ * carries the supplied vars.
+ * @param {Record<string,string>} env
+ * @param {Record<string,string>} [files]
+ */
+export function makeRuntime(env, files = {}) {
+  const fs = createMockFs({
+    [MANIFEST_PATH]: JSON.stringify(MANIFEST),
+    ...files,
+  });
+  fs.dirs.add(TEST_KB);
+  return createTestRuntime({ fs, proc: createMockProcess({ env }) });
+}

--- a/products/outpost/test/kb-name.test.js
+++ b/products/outpost/test/kb-name.test.js
@@ -1,0 +1,48 @@
+/**
+ * KBManager.kbPathForName — resolve a KB name to a data-home path, validating
+ * (not sanitising) the name as a safe single segment.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { KBManager } from "../src/kb-manager.js";
+
+const DATA_HOME = join(homedir(), ".local/share/fit/outpost");
+
+describe("KBManager.kbPathForName", () => {
+  test("resolves a name under the data home", () => {
+    assert.strictEqual(
+      KBManager.kbPathForName("personal"),
+      join(DATA_HOME, "personal"),
+    );
+  });
+
+  test("the default name personal resolves under the data home", () => {
+    // The dispatch layer defaults an absent name to `personal`; the resolved
+    // path must sit under the non-TCC data home.
+    assert.ok(KBManager.kbPathForName("personal").startsWith(DATA_HOME + "/"));
+  });
+
+  test("a second named KB resolves beside the first", () => {
+    assert.strictEqual(
+      KBManager.kbPathForName("team"),
+      join(DATA_HOME, "team"),
+    );
+  });
+
+  for (const unsafe of ["a/b", "a\\b", "..", "../escape", "x\0y", "~evil"]) {
+    test(`rejects unsafe name ${JSON.stringify(unsafe)}`, () => {
+      assert.throws(() => KBManager.kbPathForName(unsafe), /unsafe KB name/);
+    });
+  }
+
+  test("rejects an empty name", () => {
+    assert.throws(() => KBManager.kbPathForName(""), /unsafe KB name/);
+  });
+
+  test("rejects a non-string name", () => {
+    assert.throws(() => KBManager.kbPathForName(undefined), /unsafe KB name/);
+    assert.throws(() => KBManager.kbPathForName(42), /unsafe KB name/);
+  });
+});

--- a/products/outpost/test/outpost-cli.test.js
+++ b/products/outpost/test/outpost-cli.test.js
@@ -48,7 +48,7 @@ const definition = {
     },
     {
       name: "init",
-      args: "<path>",
+      args: "[name]",
       description: "Initialize a new knowledge base",
     },
     {
@@ -118,11 +118,11 @@ describe("fit-outpost CLI parsing", () => {
     assert.deepStrictEqual(result.positionals, []);
   });
 
-  test('parse(["init", "/tmp/kb"]) returns correct positionals', () => {
+  test('parse(["init", "personal"]) returns correct positionals', () => {
     const proc = createProc();
     const cli = createCli(proc);
-    const result = cli.parse(["init", "/tmp/kb"]);
-    assert.deepStrictEqual(result.positionals, ["init", "/tmp/kb"]);
+    const result = cli.parse(["init", "personal"]);
+    assert.deepStrictEqual(result.positionals, ["init", "personal"]);
   });
 
   test('parse(["--version"]) returns null (version handled)', () => {

--- a/products/outpost/test/posture-cli.integration.test.js
+++ b/products/outpost/test/posture-cli.integration.test.js
@@ -46,7 +46,7 @@ describe("fit-outpost posture CLI (subprocess integration)", () => {
   });
 
   test("init records the default brief posture", () => {
-    const r = runCli(["init", join(home, "kb")], home);
+    const r = runCli(["init", "personal"], home);
     assert.strictEqual(r.status, 0, r.stderr);
     const record = JSON.parse(
       readFileSync(join(home, ".fit", "outpost", "posture.json"), "utf8"),

--- a/products/outpost/test/privilege.test.js
+++ b/products/outpost/test/privilege.test.js
@@ -1,0 +1,58 @@
+/**
+ * privilege unit tests — the mandatory-level resolver and its disclaim mapping.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import {
+  PRIVILEGE_LEVELS,
+  resolvePrivilege,
+  disclaimFor,
+} from "../src/privilege.js";
+
+describe("PRIVILEGE_LEVELS", () => {
+  test("is exactly [full, restricted]", () => {
+    assert.deepStrictEqual(PRIVILEGE_LEVELS, ["full", "restricted"]);
+  });
+});
+
+describe("resolvePrivilege", () => {
+  test("each declared level resolves to itself", () => {
+    assert.strictEqual(resolvePrivilege({ privilege: "full" }), "full");
+    assert.strictEqual(
+      resolvePrivilege({ privilege: "restricted" }),
+      "restricted",
+    );
+  });
+
+  test("a missing level throws", () => {
+    assert.throws(() => resolvePrivilege({}), /invalid privilege/);
+  });
+
+  test("an explicit undefined level throws", () => {
+    assert.throws(
+      () => resolvePrivilege({ privilege: undefined }),
+      /invalid privilege/,
+    );
+  });
+
+  test("a null agent throws", () => {
+    assert.throws(() => resolvePrivilege(null), /invalid privilege/);
+  });
+
+  test("an unrecognised string throws", () => {
+    assert.throws(
+      () => resolvePrivilege({ privilege: "elevated" }),
+      /invalid privilege/,
+    );
+  });
+});
+
+describe("disclaimFor", () => {
+  test("full keeps the inherited responsible process (0)", () => {
+    assert.strictEqual(disclaimFor("full"), 0);
+  });
+
+  test("restricted self-disclaims (1)", () => {
+    assert.strictEqual(disclaimFor("restricted"), 1);
+  });
+});

--- a/websites/fit/docs/getting-started/engineers/outpost/index.md
+++ b/websites/fit/docs/getting-started/engineers/outpost/index.md
@@ -52,8 +52,12 @@ package degrades cleanly off-Apple yet. Switch to a Mac to continue.
 ## Initialize a knowledge base
 
 ```sh
-npx fit-outpost init ~/Documents/Personal
+npx fit-outpost init
 ```
+
+This provisions the default `personal` knowledge base at
+`~/.local/share/fit/outpost/personal`. Pass a name (for example,
+`npx fit-outpost init team`) to provision a second one beside it.
 
 ## Check status
 
@@ -72,20 +76,24 @@ background work. The CLI scheduler works on any platform.
 
 ## macOS Privacy & Security
 
-Outpost needs access to the folders it reads — your knowledge base, Mail, and
-Calendar. Grant every permission to a single app, **fit-outpost.app**, and the
-whole scheduler and the agents it runs are covered. You never grant access to
-`node`, `claude`, or any other helper process.
+Outpost needs access to the live Mail and Calendar stores it reads. Grant every
+permission to a single app, **fit-outpost.app**, and the whole scheduler and the
+agents it runs are covered. You never grant access to `node`, `claude`, or any
+other helper process.
 
-When macOS prompts, prefer specific **Files & Folders** access over **Full Disk
-Access**. Open **System Settings > Privacy & Security > Files & Folders** and
-grant `fit-outpost.app` only the folders it needs:
+Outpost runs two kinds of agent, and they need different access:
 
-- Your knowledge base folder (for example, `~/Documents/Personal`)
-- Mail and Calendar, when a sync first reads them
+- **`full` agents** sync the live Mail and Calendar stores or send mail. They
+  read those stores and drive Mail under the one `fit-outpost.app` grant.
+- **`restricted` agents** only process already-synced content and your knowledge
+  base, which lives outside every protected folder
+  (`~/.local/share/fit/outpost/`). They need **no** macOS grant — even if
+  compromised, a `restricted` agent cannot reach protected files.
 
-If a draft-side skill sends mail, macOS also prompts once under **Automation** to
-let `fit-outpost.app` control Mail — click **Allow**.
+When macOS prompts for the Mail and Calendar stores, grant **Full Disk Access**
+to `fit-outpost.app`. If a draft-side skill sends mail, macOS also prompts once
+under **Automation** to let `fit-outpost.app` control Mail — click **Allow**.
+Your knowledge base needs no grant.
 
 ---
 

--- a/websites/fit/docs/products/knowledge-systems/index.md
+++ b/websites/fit/docs/products/knowledge-systems/index.md
@@ -40,26 +40,26 @@ Outpost Scheduler
 
 Agents:
   + postman
-    KB: ~/Documents/Personal  Schedule: {"type":"cron","expression":"*/15 8-18 * * 1-5"}
+    KB: ~/.local/share/fit/outpost/personal  Schedule: {"type":"cron","expression":"*/15 8-18 * * 1-5"}
     Status: idle  Last wake: 5/4/2026, 9:15:00 AM  Wakes: 12
     Last action: Synced 3 new mail threads
   + concierge
-    KB: ~/Documents/Personal  Schedule: {"type":"cron","expression":"*/30 8-18 * * 1-5"}
+    KB: ~/.local/share/fit/outpost/personal  Schedule: {"type":"cron","expression":"*/30 8-18 * * 1-5"}
     Status: idle  Last wake: 5/4/2026, 9:00:00 AM  Wakes: 6
     Last action: Prepared briefing for 10:00 AM standup
   + librarian
-    KB: ~/Documents/Personal  Schedule: {"type":"cron","expression":"0 9,12,15,18 * * 1-5"}
+    KB: ~/.local/share/fit/outpost/personal  Schedule: {"type":"cron","expression":"0 9,12,15,18 * * 1-5"}
     Status: idle  Last wake: 5/4/2026, 9:00:00 AM  Wakes: 3
     Last action: Extracted 5 entities from recent mail
   + chief-of-staff
-    KB: ~/Documents/Personal  Schedule: {"type":"cron","expression":"0 7,18 * * 1-5"}
+    KB: ~/.local/share/fit/outpost/personal  Schedule: {"type":"cron","expression":"0 7,18 * * 1-5"}
     Status: idle  Last wake: 5/4/2026, 7:00:00 AM  Wakes: 2
     Last action: Compiled daily briefing
   + recruiter
-    KB: ~/Documents/Personal  Schedule: {"type":"cron","expression":"0 8,12,17 * * 1-5"}
+    KB: ~/.local/share/fit/outpost/personal  Schedule: {"type":"cron","expression":"0 8,12,17 * * 1-5"}
     Status: never-woken  Last wake: never  Wakes: 0
   + head-hunter
-    KB: ~/Documents/Personal  Schedule: {"type":"cron","expression":"0 9 * * 1-5"}
+    KB: ~/.local/share/fit/outpost/personal  Schedule: {"type":"cron","expression":"0 9 * * 1-5"}
     Status: never-woken  Last wake: never  Wakes: 0
 ```
 
@@ -86,7 +86,7 @@ a knowledge graph -- plain markdown files organized by entity type. Only the
 OneDrive); the rest of the workspace stays personal and local:
 
 ```text
-~/Documents/Personal/          # Your personal root -- NOT shared
+~/.local/share/fit/outpost/personal/          # Your personal root -- NOT shared
 ├── Knowledge/                 # The knowledge graph -- SHARED with the team
 │   ├── People/                # One note per person you interact with
 │   ├── Organizations/         # Companies, teams, departments
@@ -108,7 +108,7 @@ background you would otherwise reconstruct from memory before a meeting.
 You can search the graph directly:
 
 ```sh
-rg "Sarah Chen" ~/Documents/Personal/Knowledge/
+rg "Sarah Chen" ~/.local/share/fit/outpost/personal/Knowledge/
 ```
 
 ```text
@@ -129,18 +129,22 @@ briefings earlier.
 
 Agent schedules live in the Outpost configuration file at
 `~/.fit/outpost/scheduler.json`. Each agent entry specifies a knowledge base
-path, a schedule, and whether the agent is enabled:
+path, a required `privilege` level (`full` for agents that sync the live
+mail/calendar stores or send mail, `restricted` for agents that only process
+already-synced content), a schedule, and whether the agent is enabled:
 
 ```json
 {
   "agents": {
     "postman": {
-      "kb": "~/Documents/Personal",
+      "kb": "~/.local/share/fit/outpost/personal",
+      "privilege": "full",
       "schedule": { "type": "cron", "expression": "*/15 8-18 * * 1-5" },
       "enabled": true
     },
     "chief-of-staff": {
-      "kb": "~/Documents/Personal",
+      "kb": "~/.local/share/fit/outpost/personal",
+      "privilege": "restricted",
       "schedule": { "type": "cron", "expression": "0 7,18 * * 1-5" },
       "enabled": true
     }
@@ -207,11 +211,11 @@ Outpost ships updated agent definitions and skills with each release. To
 fetch the latest into your knowledge base:
 
 ```sh
-npx fit-outpost update ~/Documents/Personal
+npx fit-outpost update ~/.local/share/fit/outpost/personal
 ```
 
 ```text
-Updating ~/Documents/Personal...
+Updating ~/.local/share/fit/outpost/personal...
   CLAUDE.md              updated
   agents/postman.md      updated
   skills/sync-apple-mail unchanged
@@ -223,7 +227,7 @@ Omit the path to update the knowledge base in the current directory, so you
 can run it from inside the KB itself:
 
 ```sh
-cd ~/Documents/Personal
+cd ~/.local/share/fit/outpost/personal
 npx fit-outpost update
 ```
 

--- a/websites/fit/docs/products/knowledge-systems/meeting-prep/index.md
+++ b/websites/fit/docs/products/knowledge-systems/meeting-prep/index.md
@@ -41,7 +41,7 @@ Before generating a briefing, search the knowledge graph for each attendee.
 This is the step that turns a generic calendar entry into useful preparation:
 
 ```sh
-rg "Sarah Chen" ~/Documents/Personal/Knowledge/
+rg "Sarah Chen" ~/.local/share/fit/outpost/personal/Knowledge/
 ```
 
 ```text
@@ -61,7 +61,7 @@ file.
 Read the person note for the full picture:
 
 ```sh
-cat ~/Documents/Personal/Knowledge/People/Sarah\ Chen.md
+cat ~/.local/share/fit/outpost/personal/Knowledge/People/Sarah\ Chen.md
 ```
 
 The note contains context (role, what they focus on), a reverse-chronological
@@ -116,7 +116,7 @@ When you want to go deeper than the scheduled briefing, ask for meeting prep
 directly in your knowledge base:
 
 ```sh
-cd ~/Documents/Personal && claude "prep me for my 10am meeting"
+cd ~/.local/share/fit/outpost/personal && claude "prep me for my 10am meeting"
 ```
 
 The meeting-prep skill identifies the meeting from your calendar, looks up every

--- a/websites/fit/outpost/index.md
+++ b/websites/fit/outpost/index.md
@@ -150,27 +150,31 @@ trust contract is something you turn on, not something you discover later.
 ```sh
 brew install claude                     # Runtime: Outpost spawns claude as a subprocess
 npm install @forwardimpact/outpost      # macOS only
-npx fit-outpost init ~/Documents/Team   # Initialize knowledge base
+npx fit-outpost init team               # Initialize a knowledge base named "team" (omit for default "personal")
 npx fit-outpost daemon                  # Start the scheduler
 npx fit-outpost status                  # Check what's happening
 ```
 
 ### macOS Privacy & Security
 
-Outpost needs access to the folders it reads — your knowledge base, Mail, and
-Calendar. Grant every permission to a single app, **fit-outpost.app**, and the
-whole scheduler and the agents it runs are covered. You never grant access to
-`node`, `claude`, or any other helper process.
+Outpost needs access to the live Mail and Calendar stores it reads. Grant every
+permission to a single app, **fit-outpost.app**, and the whole scheduler and the
+agents it runs are covered. You never grant access to `node`, `claude`, or any
+other helper process.
 
-When macOS prompts, prefer specific **Files & Folders** access over **Full Disk
-Access**. Open **System Settings > Privacy & Security > Files & Folders** and
-grant `fit-outpost.app` only the folders it needs:
+Outpost runs two kinds of agent, and they need different access:
 
-- Your knowledge base folder (for example, `~/Documents/Team`)
-- Mail and Calendar, when a sync first reads them
+- **`full` agents** sync the live Mail and Calendar stores or send mail. They
+  read those stores and drive Mail under the one `fit-outpost.app` grant.
+- **`restricted` agents** only process already-synced content and your knowledge
+  base, which lives outside every protected folder
+  (`~/.local/share/fit/outpost/`). They need **no** macOS grant — even if
+  compromised, a `restricted` agent cannot reach protected files.
 
-If a draft-side skill sends mail, macOS also prompts once under **Automation** to
-let `fit-outpost.app` control Mail — click **Allow**.
+When macOS prompts for the Mail and Calendar stores, grant **Full Disk Access**
+to `fit-outpost.app`. If a draft-side skill sends mail, macOS also prompts once
+under **Automation** to let `fit-outpost.app` control Mail — click **Allow**.
+Your knowledge base needs no grant.
 
 <div class="grid">
 


### PR DESCRIPTION
## Spec 2120 — Per-agent least-privilege execution for Outpost

Implements [spec.md](specs/2120-outpost-agent-least-privilege/spec.md) per
[design-a.md](specs/2120-outpost-agent-least-privilege/design-a.md) and
[plan-a.md](specs/2120-outpost-agent-least-privilege/plan-a.md).

Each agent now runs with the least macOS privilege its job needs. An agent that
neither syncs the live mail/calendar stores nor sends mail cannot read Full Disk
Access-protected locations even if fully prompt-injected; sync/send agents keep
the verified single-grant behavior.

### What changed

- **libmacos spawn** gains a trailing `disclaim` arg (default `0`, so every
  present caller is unchanged). Released separately → a coupled libmacos release
  is required before npm consumers resolve the new signature.
- **Mandatory `privilege` level** (`full` | `restricted`) resolved once at the
  `AgentRunner.wake` chokepoint and threaded to the hop-2 disclaim flag
  (`full`→0 inherits the app; `restricted`→1 self-responsible). A missing or
  invalid level is fail-closed: logged `outpost.privilege.rejected`, wake
  skipped, no spawn. Each spawned wake logs `outpost.privilege.resolved`.
- **KB relocated** unconditionally from `~/Documents/Personal` (TCC-protected)
  to `~/.local/share/fit/outpost/personal` (non-TCC). `fit-outpost init [name]`
  provisions by validated name under the data home (default `personal`), never
  an arbitrary path. No back-compat fallback — the few existing installs migrate
  by hand.
- **TCC runbook** gains a per-agent privilege-denial axis (positive
  `restricted` FDA probe → Denied; `full` read → Allowed) and drops the obsolete
  Documents artifacts.
- **Docs + installer copy** relocate every `~/Documents` KB reference and
  describe which agents need which macOS permissions.

### Success criteria

All six are satisfied: TCC denial/allow (1, 3) via the disclaim threading +
runbook Axis 4; no-grant KB work (2) via the relocation; resolved-level log (4);
docs (5); undeclared-level refusal (6) with tests.

### Verification

- `bun run check` — pass (format, lint, jsdoc, invariants, context, instructions, jtbd)
- `node --test products/outpost/**` (blocking gate) — 178 pass
- `bun test products/outpost libraries/libmacos` — 181 pass
- `bunx fit-doc build --src=websites/fit` — clean
- TCC denial (criteria 1–3) is CI-unverifiable; it rests on the manual runbook.

### Review panel

Clean 5-reviewer panel (`kata-review`): zero blocker, zero high, zero in-scope
consensus medium. Dismissed with rationale:

- **Agent template staleness** (minority, 2/5) — `templates/.claude/settings.json`
  still grants `~/Documents` read/edit and `templates/CLAUDE.md` says "full
  filesystem access." `templates/` is **out of this spec's declared scope** and
  governed by a separate trust-boundary change contract; the restricted model is
  TCC-enforced regardless of these Claude Code-layer grants. **Recommended
  follow-up:** a separate spec to tighten the template grants and correct the
  capability prose for `restricted` agents.
- **kb-manager mirrors the agent-path.js safe-segment rule** (Low) — explicitly
  permitted by the plan; agent-path.js is load-bearing and outside this plan's
  file set.
- **`outpost.privilege.resolved` logged after the kb guard** (Low) — faithful to
  plan-a.md (a kb-skip is not a wake).
- **`librarian` is `restricted`** though `organize-files` can touch
  Desktop/Downloads (Low) — per the approved plan's classification; a known,
  intended limitation for hand-migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
