### PR TITLE
test(benchmarks): relax kata-skills invariant regexes

### DIFF
--- a/benchmarks/kata-skills/tasks/coordinate-finding/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/coordinate-finding/hooks/invariants.sh
@@ -19,8 +19,9 @@ assert change-present --exists "$CHANGE"
 ISSUE_ID=$(basename "$ISSUE" .md)
 assert change-links-issue --grep "$ISSUE_ID" "$CHANGE" \
   --message "change does not link back to the issue"
-# The change reached merged state.
-assert change-merged --grep 'state:\s*merged' "$CHANGE" \
+# The change reached merged state. Tolerate quoted front-matter values
+# (state: "merged"). Case-insensitive and multiline (RegExp /im/).
+assert change-merged --grep 'state:\s*["'"'"']?merged' "$CHANGE" \
   --message "change is not state: merged"
 # A trusted approval was recorded on the change (non-empty approval field).
 assert change-approved --grep 'approval:\s*\S' "$CHANGE" \

--- a/benchmarks/kata-skills/tasks/design-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/design-feature/hooks/invariants.sh
@@ -16,7 +16,9 @@ else
   FAIL=1
 fi
 
-assert has-decisions  --grep '^##+ .*Decision' "$DESIGN"
-assert names-tradeoff --grep 'reject|alternative|instead of|trade.?off' "$DESIGN"
+# A decisions heading at any depth ("## Decisions", "### Key Decision"), and any
+# of the common ways a rejected option gets named. Case-insensitive (RegExp /im/).
+assert has-decisions  --grep '^#{2,6}[ \t]+.*Decision' "$DESIGN"
+assert names-tradeoff --grep 'reject|alternative|instead of|rather than|trade.?off' "$DESIGN"
 
 [ "$FAIL" = 0 ] && exit 0 || exit 1

--- a/benchmarks/kata-skills/tasks/plan-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/plan-feature/hooks/invariants.sh
@@ -7,9 +7,13 @@ assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 assert file-present --exists "$PLAN"
 [ "$FAIL" = 1 ] && exit 1
 
-assert libraries-line   --grep '^Libraries used:' "$PLAN"
-assert has-risks        --grep '^##+ .*Risks' "$PLAN"
+# Tolerate markdown markup the agent commonly puts around these labels: bold
+# (**Libraries used:**), list markers (- Risks), blockquotes, and any heading
+# depth. Accept singular "Risk" and "validate" alongside "verify".
+# Case-insensitive and multiline (RegExp /im/).
+assert libraries-line   --grep '^[ \t>*_-]*Libraries[ \t]+used:?' "$PLAN"
+assert has-risks        --grep '^#{2,6}[ \t]+.*Risk|^[ \t>*_-]*Risks?\b' "$PLAN"
 assert refs-design      --grep 'design-a\.md' "$PLAN"
-assert has-verification --grep 'verif' "$PLAN"
+assert has-verification --grep 'verif|validat' "$PLAN"
 
 [ "$FAIL" = 0 ] && exit 0 || exit 1

--- a/benchmarks/kata-skills/tasks/product-issue-triage/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/product-issue-triage/hooks/invariants.sh
@@ -11,11 +11,15 @@ assert issue-present --exists "$ISSUE"
 # Triaged out of scope: closed, labelled wontfix, and carrying a rationale
 # comment. Together these evidence the read -> comment -> label -> close loop
 # the filesystem tracker realizes.
-assert issue-closed --grep 'state:\s*closed' "$ISSUE" \
+# Tolerate quoted front-matter values, the wont-fix / wont fix label spellings,
+# any Comments heading depth, and a singular "Comment" heading. The Comments
+# check still requires non-whitespace after the heading (a real rationale).
+# Case-insensitive and multiline (RegExp /im/).
+assert issue-closed --grep 'state:\s*["'"'"']?closed' "$ISSUE" \
   --message "issue not closed"
-assert issue-wontfix --grep 'wontfix' "$ISSUE" \
+assert issue-wontfix --grep 'wont.?fix' "$ISSUE" \
   --message "no wontfix label applied"
-assert issue-commented --grep '##\s*Comments\s+\S' "$ISSUE" \
+assert issue-commented --grep '#{1,6}\s*Comments?\s+\S' "$ISSUE" \
   --message "no rationale comment appended"
 
 [ "$FAIL" = 0 ] && exit 0 || exit 1

--- a/benchmarks/kata-skills/tasks/spec-feature/hooks/invariants.sh
+++ b/benchmarks/kata-skills/tasks/spec-feature/hooks/invariants.sh
@@ -8,9 +8,13 @@ assert() { fit-trace assert "$@" >&"$RESULTS_FD" || FAIL=1; }
 assert file-present --exists "$SPEC"
 [ "$FAIL" = 1 ] && exit 1
 
-assert has-problem        --grep '^## Problem' "$SPEC"
-assert has-scope          --grep '^##+ (In )?Scope|^##+ Non.?Goals' "$SPEC"
-assert verifiable-success --grep '^## (Success|Acceptance Criteria)' "$SPEC"
+# Match the section at any heading depth, with any heading text that contains
+# the keyword (e.g. "## Problem", "### Problem Statement", "## Out of Scope",
+# "## Non-Goals", "## Success Criteria", "## Acceptance Criteria"). The grep
+# runs case-insensitive and multiline (RegExp /im/).
+assert has-problem        --grep '^#{2,6}[ \t]+.*Problem' "$SPEC"
+assert has-scope          --grep '^#{2,6}[ \t]+.*(Scope|Non.?Goals)' "$SPEC"
+assert verifiable-success --grep '^#{2,6}[ \t]+.*(Success|Acceptance)' "$SPEC"
 assert no-how-leak        --not --grep '[A-Za-z0-9_/.-]+\.(js|ts|sh|py|yml|yaml):[0-9]+' "$SPEC" \
                           --message "file:line reference detected"
 assert cites-jtbd --cites-job "$JTBD" "$SPEC"


### PR DESCRIPTION
## Summary

- The `eval-kata` invariants rejected valid agent output because the `--grep` patterns were anchored too tightly to one phrasing. Two failures were purely phrasing, not substance: the plan task's `^Libraries used:` missed the bold `**Libraries used:**` form the `kata-plan` skill teaches, and the heading checks demanded exactly two `#`.
- Relaxed the whole class across `benchmarks/kata-skills/tasks/*/hooks/invariants.sh` so each invariant still verifies its property but tolerates how agents actually write:
  - **spec** — match Problem/Scope/Success/Acceptance headings at any depth; accept "Out of Scope" and "Non-Goals".
  - **design** — match a Decisions heading at any depth; add "rather than" to the rejected-alternative vocabulary.
  - **plan** — accept markdown markup around `Libraries used:` (bold, list, blockquote); accept singular "Risk" and bold/list Risk leads; accept "validate" alongside "verify".
  - **product-issue-triage** — tolerate quoted front-matter, the `wont-fix` / `wont fix` spellings, any Comments heading depth, and singular "Comment".
  - **coordinate-finding** — tolerate quoted `state: "merged"`.
- The grep already runs case-insensitive and multiline (`new RegExp(pattern, "im")`), so no case variants were needed. Each pattern was verified against match and reject cases through the `fit-trace assert` CLI.
- Left the `fit-wiki` benchmark greps exact: they check fixed seeded headings from deterministic `fit-wiki fix` output, not free-form agent text, so relaxing them would only weaken an integrity check.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bPRCqunLKWj2B6qzJWE6z

---
_Generated by [Claude Code](https://claude.ai/code/session_012bPRCqunLKWj2B6qzJWE6z)_