### PR TITLE
design(2130): parallel benchmark execution (concurrency + sharding)

### DIFF
--- a/specs/2130-parallel-benchmark-execution/design-a.md
+++ b/specs/2130-parallel-benchmark-execution/design-a.md
@@ -1,0 +1,139 @@
+# Design 2130-a — Parallel Benchmark Execution
+
+Implements spec 2130. The serial nested loop in `BenchmarkRunner.run()` becomes a
+bounded concurrent scheduler (Layer 1), and the runner gains a deterministic
+shard selector plus a multi-input merge in `report`, fanned across CI by a new
+reusable workflow (Layer 2). A record's verdict, schema, and the per-cell
+lifecycle (`#runOne`: setup → supervised agent → invariants → judge → teardown)
+are unchanged; only *how many cells run at once* and *how the ledger is
+assembled* change.
+
+## Architecture
+
+```mermaid
+flowchart TB
+  subgraph runner["BenchmarkRunner.run() (one process)"]
+    EN[enumerateCells] --> SH{shard selector}
+    SH -->|cells for this shard| SCHED[CellScheduler pool size C]
+    SCHED -->|"#runOne (unchanged)"| W1[cell]
+    SCHED --> W2[cell]
+    SCHED --> W3[cell]
+    W1 & W2 & W3 -->|completed record| CH[(completion channel)]
+    CH --> DRAIN[single-writer drain loop]
+    DRAIN -->|append| JSONL[(results.jsonl)]
+    DRAIN -->|yield| OUT[CLI stdout / iterator]
+    W1 & W2 & W3 -.acquire/release.-> PR[PortRegistry]
+    W1 & W2 & W3 -.crash-safe.-> RF[(per-cell result.json)]
+  end
+```
+
+Concurrency lives in execution (`CellScheduler` runs `C` cells at once); the
+ledger stays **single-writer** because only the drain loop appends to
+`results.jsonl` and yields. Workers communicate completions through a channel,
+never touch the shared stream. This keeps Layer 1's durability guarantee without
+a write mutex.
+
+## Layer 1 — in-process concurrency
+
+| Component | Where | Responsibility |
+| --- | --- | --- |
+| `enumerateCells(tasks, runs)` | `benchmark/runner.js` | Flatten the grid into a stable ordered `{taskId, runIndex}` list, **task-major / runIndex-minor**. This exact ordering is a load-bearing contract: Layer 2's round-robin balance depends on a task's runIndexes being adjacent in the list. Single source of the cell list for both the scheduler and the shard selector. |
+| `CellScheduler` | new `benchmark/scheduler.js` | Bounded pool: keep ≤ `C` `#runOne` calls in flight; as one settles, start the next; push each settled record onto the completion channel. Built on a small permit semaphore (no new dependency). |
+| completion channel + drain loop | `runner.js` `run()` | Async queue the scheduler pushes settled records into; the generator drains it, appends each record to the shard's `results.jsonl`, and yields. Sole writer of the ledger. |
+| `PortRegistry` | `benchmark/workdir.js` | Replaces `allocatePort()`: hand out distinct, bindable ports under a lock with a live in-use set; re-probe if the OS returns an already-reserved number; release on teardown. |
+| per-cell `result.json` | written by `#runOne`, under `WorkdirManager`'s run dir | After `#runOne` builds and validates a cell's record (before `wm.teardown`), it writes that record to `runs/<slug>/<i>/result.json`. This is the **crash-recovery** unit: a killed run can reconstruct `results.jsonl` from the per-cell files it already wrote. It is *not* the merge target — Layer 2 merges shard-level `results.jsonl` files (below). |
+| `resolveConcurrency` | `commands/benchmark-run.js` | `--concurrency` flag > `LIBHARNESS_BENCHMARK_CONCURRENCY` env > default `min(CONCURRENCY_CEILING, max(2, ⌊cores/2⌋))` (where `CONCURRENCY_CEILING` is a plan-time constant, conservative because each cell spawns ~3 agent subprocesses). |
+| `retryRateLimited` | `benchmark/runner.js` (`#runAgentSafe`) | Wrap the agent session: a 429/rate-limit-class failure retries with bounded exponential backoff inside the cell (under the 20-min watchdog) instead of immediately recording an `agentError`. |
+
+**Streaming contract change.** `run()` now yields in **completion order**, not
+grid order. The CLI consumer already treats records order-independently
+(`stdout` mirror, `anyFail`, zero-record guard), and `report` groups by `taskId`,
+so pass@k is unaffected. This is the one observable behavior change and is called
+out in the spec.
+
+**Port hand-off, honestly.** A truly held socket cannot be bound by the agent
+later, so `PortRegistry` reserves the *number* (lock + in-use set + re-probe),
+not the socket — closing the OS race window that the close-then-return allocator
+left open. The reservation lives for the cell and is released at teardown
+alongside the existing process-group kill and port-free probe.
+
+## Layer 2 — sharding and distribution (Playwright-inspired)
+
+Playwright's model: `--shard=i/N` runs a slice locally, each slice writes a blob
+report, and `merge-reports` stitches the blobs into one. We mirror it.
+
+| Component | Where | Responsibility |
+| --- | --- | --- |
+| `--shard=<i>/<N>` | `commands/benchmark-run.js` → runner | 1-based like Playwright. Parsed to `{index, total}`; validate `1 ≤ i ≤ N`. The runner applies `selectShard` to the enumerated cells before scheduling. When `N > cell count`, the high-index shards select **zero** cells — a valid empty run that writes an empty (header-less) `results.jsonl` the merge tolerates. |
+| `selectShard(cells, i, N)` | `benchmark/runner.js` | Round-robin partition: cell at position `p` runs iff `p % N === i-1`. Deterministic; the union over `i∈1..N` is the exact grid, each cell once; some shards may be empty (above). |
+| multi-input merge | `loadRecords` in `benchmark/report.js` | The recursion lives in `loadRecords`: `report --input=<dir>` discovers **every** `results.jsonl` under the tree (not just `<dir>/results.jsonl`) and unions the records before grouping. The per-cell `result.json` files are ignored by the merge — shards are the merge unit. A single top-level ledger (today's shape) still works as the one-file case. |
+| reusable workflow | **new** sibling artifact `forwardimpact/fit-benchmark/.github/workflows/benchmark.yml` (`on: workflow_call`) | Owns the matrix a step-level composite action cannot. Inputs mirror the action plus `shard-total`; `ANTHROPIC_API_KEY` as a secret. External consumers reference it `@v1`; the monorepo's own `eval-kata.yml` SHA-pins it per `.github/CLAUDE.md`. |
+| `mode: run\|merge` | `forwardimpact/fit-benchmark` composite action | **Additive, default-preserving:** with no new inputs the action behaves exactly as today (`mode: run`, single job, now Layer-1 concurrent). `merge` runs `report` over a download dir and writes the step summary + combined artifact, keeping both halves behind one SHA-pinned action. |
+
+```mermaid
+flowchart LR
+  D[workflow_call: shard-total=N] --> P[prepare: emit shards JSON 1..N]
+  P --> M{{matrix: shard in 1..N}}
+  M --> S1["shard 1: fit-bootstrap + action run --shard=1/N → upload benchmark-shard-1"]
+  M --> S2["shard 2: … → benchmark-shard-2"]
+  M --> SN["shard N: … → benchmark-shard-N"]
+  S1 & S2 & SN --> MG["merge (needs: shard): download benchmark-shard-* → action mode=merge → report + summary"]
+```
+
+The shard count is dynamic, so a `prepare` job emits `[1..N]` as JSON and the
+shard job consumes `matrix: fromJSON(needs.prepare.outputs.shards)`. Each shard
+uploads a **shard-scoped** artifact name (`benchmark-shard-<i>`, the shard index
+playing the disambiguating role that `case:` plays for matrix trace artifacts in
+`.github/CLAUDE.md`) so `N` concurrent uploads never collide and `merge` — via
+`download-artifact` with a `benchmark-shard-*` pattern — collects all of them.
+
+### `fit-bootstrap` and the matrix
+
+| Job | Bootstrap | Why |
+| --- | --- | --- |
+| shard ×N | `fit-bootstrap@<sha>` (full env) | Each shard runs real agent sessions; it needs the same env eval runs today. New sibling→sibling `uses:` edge, governed by the sibling. Must be **parallel-safe**: cache keys shard-independent (reads only), and `N` concurrent wiki-token mints tolerated. |
+| merge ×1 | **none** — minimal `setup-node` only | `report` reads JSONL and computes pass@k; it touches no wiki, no agent runtime, no apm staging. Paying for `fit-bootstrap` here would provision an environment the merge never uses. |
+
+`IS_SANDBOX=1` stays on each shard's agent-spawning step (the action sets it);
+the merge job spawns no agent and needs none. The monorepo's own `eval-kata.yml`
+migrates to call the reusable workflow with a `shard-total`, dogfooding the path;
+the single-job composite-action entry remains for consumers who want one box.
+
+## Key Decisions
+
+| Decision | Choice | Rejected alternative |
+| --- | --- | --- |
+| Ledger safety under concurrency | Single-writer drain loop fed by a completion channel; workers never write the shared stream | A write mutex around `results.jsonl` — serializes I/O on the hot path and still needs the channel to preserve yield semantics |
+| Crash safety | Per-cell `result.json` as a crash-recovery unit, plus the assembled shard `results.jsonl` | Only the append stream — a killed run loses all completed cells |
+| Port collisions | `PortRegistry`: reserve the number under a lock + re-probe | Hold the listening socket (agent then can't bind it) or per-slot static port ranges (brittle across families/hosts) |
+| Shard balance | Round-robin `p % N` at **cell** granularity | Playwright's contiguous blocks — cell durations are highly skewed (`implement-feature`, stall-prone `coordinate-finding`), so contiguous risks one shard owning a slow task's whole run block |
+| Merge surface | Recursive `results.jsonl` discovery under `--input` | A new `merge` subcommand — `report` already aggregates; recursive discovery makes the one-file and many-shard cases one code path |
+| Merge in CI | Reuse the composite action via `mode: merge` | A raw `npx fit-benchmark report` step — leaves an unpinned invocation outside the SHA-pinned action surface |
+| Merge-job env | No `fit-bootstrap`; minimal node setup | Add a minimal mode to `fit-bootstrap` — extra coupling for a job with no wiki/agent/monorepo deps |
+| Default concurrency | On by default, flag+env override (formula in the Layer-1 table) | Opt-in flag defaulting to 1 — fails the spec's transparency requirement (consumers get no speedup unchanged) |
+
+## Interfaces
+
+- `BenchmarkRunner` gains `concurrency` and `shard?: {index, total}` opts;
+  `run()`'s yield order becomes completion order (documented contract).
+- `CellScheduler({concurrency, runCell})` → async iterable of settled records.
+- `PortRegistry.acquire(): Promise<number>` / `release(port): void`.
+- `aggregate({inputDir, …})` / `loadRecords` discover `**/results.jsonl`
+  recursively (added behavior — `loadRecords` reads a single file today); an
+  unexpected duplicate `(taskId, runIndex)` is warned and counted, not silently
+  merged (the partition guarantees none, so a duplicate signals misconfiguration).
+- CLI: `fit-benchmark run --concurrency=<n> --shard=<i>/<N>`;
+  `fit-benchmark report --input=<dir>` (now recursive).
+- Action inputs: `concurrency`, `shard-index`, `shard-total`, `mode`.
+- Reusable workflow inputs: family, runs, max-turns, judge-profile, concurrency,
+  `shard-total`; secret `ANTHROPIC_API_KEY`.
+
+## Verification surface
+
+Layer-1 criteria use the runner's existing fake-agent + clock seams (max-in-flight
+≤ C, `ceil(M/C)` batches, `C=1` vs `C=8` identical pass@k, port distinctness,
+one-record-per-cell, stall isolates to one slot) — no live LLM spend. Layer-2
+criteria check `selectShard` is an exact partition, recursive merge equals a
+single run, and a `shard-total=K` dispatch yields `K` shard jobs + 1 merge job.
+
+— Staff Engineer 🛠️

--- a/specs/2130-parallel-benchmark-execution/design-a.md
+++ b/specs/2130-parallel-benchmark-execution/design-a.md
@@ -8,6 +8,15 @@ lifecycle (`#runOne`: setup → supervised agent → invariants → judge → te
 are unchanged; only *how many cells run at once* and *how the ledger is
 assembled* change.
 
+**Clean break — no shims, no fallbacks, no dual representations.** With few
+consumers today, this replaces the obsolete paths outright rather than wrapping
+them: the serial loop, the `allocatePort` allocator, and the single-file
+`loadRecords` read are **deleted**, not flagged or branched. There is one
+scheduler, one durable ledger (the incrementally-appended `results.jsonl` — no
+sidecar copy), one port mechanism, one merge path (always recursive), and one
+sharded primitive where an unsharded run is simply shard `1/1`. No
+`--legacy`/compat flag exists, and no old behavior is preserved "for safety."
+
 ## Architecture
 
 ```mermaid
@@ -20,18 +29,19 @@ flowchart TB
     SCHED --> W3[cell]
     W1 & W2 & W3 -->|completed record| CH[(completion channel)]
     CH --> DRAIN[single-writer drain loop]
-    DRAIN -->|append| JSONL[(results.jsonl)]
+    DRAIN -->|append per completion| JSONL[(results.jsonl)]
     DRAIN -->|yield| OUT[CLI stdout / iterator]
     W1 & W2 & W3 -.acquire/release.-> PR[PortRegistry]
-    W1 & W2 & W3 -.crash-safe.-> RF[(per-cell result.json)]
   end
 ```
 
 Concurrency lives in execution (`CellScheduler` runs `C` cells at once); the
 ledger stays **single-writer** because only the drain loop appends to
 `results.jsonl` and yields. Workers communicate completions through a channel,
-never touch the shared stream. This keeps Layer 1's durability guarantee without
-a write mutex.
+never touch the shared stream. The append is incremental — each cell lands in
+`results.jsonl` the moment it settles — so a killed run keeps every completed
+cell with no second on-disk copy. This is Layer 1's durability guarantee without
+a write mutex and without a sidecar ledger.
 
 ## Layer 1 — in-process concurrency
 
@@ -39,9 +49,8 @@ a write mutex.
 | --- | --- | --- |
 | `enumerateCells(tasks, runs)` | `benchmark/runner.js` | Flatten the grid into a stable ordered `{taskId, runIndex}` list, **task-major / runIndex-minor**. This exact ordering is a load-bearing contract: Layer 2's round-robin balance depends on a task's runIndexes being adjacent in the list. Single source of the cell list for both the scheduler and the shard selector. |
 | `CellScheduler` | new `benchmark/scheduler.js` | Bounded pool: keep ≤ `C` `#runOne` calls in flight; as one settles, start the next; push each settled record onto the completion channel. Built on a small permit semaphore (no new dependency). |
-| completion channel + drain loop | `runner.js` `run()` | Async queue the scheduler pushes settled records into; the generator drains it, appends each record to the shard's `results.jsonl`, and yields. Sole writer of the ledger. |
-| `PortRegistry` | `benchmark/workdir.js` | Replaces `allocatePort()`: hand out distinct, bindable ports under a lock with a live in-use set; re-probe if the OS returns an already-reserved number; release on teardown. |
-| per-cell `result.json` | written by `#runOne`, under `WorkdirManager`'s run dir | After `#runOne` builds and validates a cell's record (before `wm.teardown`), it writes that record to `runs/<slug>/<i>/result.json`. This is the **crash-recovery** unit: a killed run can reconstruct `results.jsonl` from the per-cell files it already wrote. It is *not* the merge target — Layer 2 merges shard-level `results.jsonl` files (below). |
+| completion channel + drain loop | `runner.js` `run()` | Async queue the scheduler pushes settled records into; the generator drains it, appends each record to the shard's `results.jsonl` **as it settles**, and yields. Sole writer of the ledger and its only on-disk form — incremental append is the crash-safety mechanism, so there is no per-cell sidecar file. |
+| `PortRegistry` | `benchmark/workdir.js` | Replaces `allocatePort()` (deleted): hand out distinct, bindable ports under a lock with a live in-use set; re-probe if the OS returns an already-reserved number; release on teardown. |
 | `resolveConcurrency` | `commands/benchmark-run.js` | `--concurrency` flag > `LIBHARNESS_BENCHMARK_CONCURRENCY` env > default `min(CONCURRENCY_CEILING, max(2, ⌊cores/2⌋))` (where `CONCURRENCY_CEILING` is a plan-time constant, conservative because each cell spawns ~3 agent subprocesses). |
 | `retryRateLimited` | `benchmark/runner.js` (`#runAgentSafe`) | Wrap the agent session: a 429/rate-limit-class failure retries with bounded exponential backoff inside the cell (under the 20-min watchdog) instead of immediately recording an `agentError`. |
 
@@ -64,11 +73,11 @@ report, and `merge-reports` stitches the blobs into one. We mirror it.
 
 | Component | Where | Responsibility |
 | --- | --- | --- |
-| `--shard=<i>/<N>` | `commands/benchmark-run.js` → runner | 1-based like Playwright. Parsed to `{index, total}`; validate `1 ≤ i ≤ N`. The runner applies `selectShard` to the enumerated cells before scheduling. When `N > cell count`, the high-index shards select **zero** cells — a valid empty run that writes an empty (header-less) `results.jsonl` the merge tolerates. |
+| `--shard=<i>/<N>` | `commands/benchmark-run.js` → runner | 1-based like Playwright. Parsed to `{index, total}`; validate `1 ≤ i ≤ N`. The runner applies `selectShard` to the enumerated cells before scheduling. An unsharded run is the identity `1/1`. When `N > cell count`, the high-index shards select **zero** cells — a valid run whose `results.jsonl` has zero records, which `loadRecords` unions as the empty set. |
 | `selectShard(cells, i, N)` | `benchmark/runner.js` | Round-robin partition: cell at position `p` runs iff `p % N === i-1`. Deterministic; the union over `i∈1..N` is the exact grid, each cell once; some shards may be empty (above). |
-| multi-input merge | `loadRecords` in `benchmark/report.js` | The recursion lives in `loadRecords`: `report --input=<dir>` discovers **every** `results.jsonl` under the tree (not just `<dir>/results.jsonl`) and unions the records before grouping. The per-cell `result.json` files are ignored by the merge — shards are the merge unit. A single top-level ledger (today's shape) still works as the one-file case. |
+| recursive merge | `loadRecords` in `benchmark/report.js` | `loadRecords` is **rewritten** to discover every `results.jsonl` under `--input` recursively and union the records before grouping; the old single-file read (`<dir>/results.jsonl` only) is **deleted**, not branched. A lone root-level ledger is just the trivial one-match case of the same walk — one code path for both. |
 | reusable workflow | **new** sibling artifact `forwardimpact/fit-benchmark/.github/workflows/benchmark.yml` (`on: workflow_call`) | Owns the matrix a step-level composite action cannot. Inputs mirror the action plus `shard-total`; `ANTHROPIC_API_KEY` as a secret. External consumers reference it `@v1`; the monorepo's own `eval-kata.yml` SHA-pins it per `.github/CLAUDE.md`. |
-| `mode: run\|merge` | `forwardimpact/fit-benchmark` composite action | **Additive, default-preserving:** with no new inputs the action behaves exactly as today (`mode: run`, single job, now Layer-1 concurrent). `merge` runs `report` over a download dir and writes the step summary + combined artifact, keeping both halves behind one SHA-pinned action. |
+| `mode: run\|merge` | `forwardimpact/fit-benchmark` composite action | One action, two operations: `run` (default) executes a shard; `merge` runs `report` over the downloaded shard artifacts and writes the step summary + combined artifact. No legacy path — an unsharded run is `shard-index: 1, shard-total: 1` (the identity case of the same code), and both operations live behind one SHA-pinned action. |
 
 ```mermaid
 flowchart LR
@@ -95,19 +104,23 @@ playing the disambiguating role that `case:` plays for matrix trace artifacts in
 | merge ×1 | **none** — minimal `setup-node` only | `report` reads JSONL and computes pass@k; it touches no wiki, no agent runtime, no apm staging. Paying for `fit-bootstrap` here would provision an environment the merge never uses. |
 
 `IS_SANDBOX=1` stays on each shard's agent-spawning step (the action sets it);
-the merge job spawns no agent and needs none. The monorepo's own `eval-kata.yml`
-migrates to call the reusable workflow with a `shard-total`, dogfooding the path;
-the single-job composite-action entry remains for consumers who want one box.
+the merge job spawns no agent and needs none. The composite action is the
+**per-shard primitive**; the reusable workflow composes it across the matrix.
+There is no separate single-job entry point to maintain — `shard-total: 1` runs
+the whole family in one shard job (its merge is the identity over one ledger).
+The monorepo's own `eval-kata.yml` migrates to call the reusable workflow and its
+bespoke single-job invocation is deleted, not kept alongside.
 
 ## Key Decisions
 
 | Decision | Choice | Rejected alternative |
 | --- | --- | --- |
 | Ledger safety under concurrency | Single-writer drain loop fed by a completion channel; workers never write the shared stream | A write mutex around `results.jsonl` — serializes I/O on the hot path and still needs the channel to preserve yield semantics |
-| Crash safety | Per-cell `result.json` as a crash-recovery unit, plus the assembled shard `results.jsonl` | Only the append stream — a killed run loses all completed cells |
+| Durability | Incremental append — the drain loop writes each record to `results.jsonl` the moment its cell settles (one on-disk form) | Buffer records and write at the end (a killed run loses everything) — or per-cell sidecar files (a second representation to keep in sync, redundant with the incremental append) |
 | Port collisions | `PortRegistry`: reserve the number under a lock + re-probe | Hold the listening socket (agent then can't bind it) or per-slot static port ranges (brittle across families/hosts) |
 | Shard balance | Round-robin `p % N` at **cell** granularity | Playwright's contiguous blocks — cell durations are highly skewed (`implement-feature`, stall-prone `coordinate-finding`), so contiguous risks one shard owning a slow task's whole run block |
-| Merge surface | Recursive `results.jsonl` discovery under `--input` | A new `merge` subcommand — `report` already aggregates; recursive discovery makes the one-file and many-shard cases one code path |
+| Merge surface | Recursive `results.jsonl` discovery under `--input`, replacing the single-file read | A new `merge` subcommand, or branching one-file vs many — recursive discovery is the single path for both, with nothing kept for the old shape |
+| Compatibility | **Clean break** — delete the serial loop, `allocatePort`, and the single-file read; no flags, shims, or dual representations | Keep the old paths behind a `--legacy`/compat flag "for safety" — accrues tech debt now for consumers we do not yet have |
 | Merge in CI | Reuse the composite action via `mode: merge` | A raw `npx fit-benchmark report` step — leaves an unpinned invocation outside the SHA-pinned action surface |
 | Merge-job env | No `fit-bootstrap`; minimal node setup | Add a minimal mode to `fit-bootstrap` — extra coupling for a job with no wiki/agent/monorepo deps |
 | Default concurrency | On by default, flag+env override (formula in the Layer-1 table) | Opt-in flag defaulting to 1 — fails the spec's transparency requirement (consumers get no speedup unchanged) |
@@ -119,8 +132,8 @@ the single-job composite-action entry remains for consumers who want one box.
 - `CellScheduler({concurrency, runCell})` → async iterable of settled records.
 - `PortRegistry.acquire(): Promise<number>` / `release(port): void`.
 - `aggregate({inputDir, …})` / `loadRecords` discover `**/results.jsonl`
-  recursively (added behavior — `loadRecords` reads a single file today); an
-  unexpected duplicate `(taskId, runIndex)` is warned and counted, not silently
+  recursively, **replacing** the single-file read (no one-file branch retained);
+  an unexpected duplicate `(taskId, runIndex)` is warned and counted, not silently
   merged (the partition guarantees none, so a duplicate signals misconfiguration).
 - CLI: `fit-benchmark run --concurrency=<n> --shard=<i>/<N>`;
   `fit-benchmark report --input=<dir>` (now recursive).

--- a/specs/2130-parallel-benchmark-execution/spec.md
+++ b/specs/2130-parallel-benchmark-execution/spec.md
@@ -121,7 +121,7 @@ so effective parallelism is `N × C`.
 | Cell-granular, balanced assignment | Assignment is at `(task, runIndex)` granularity, not per-task, so a long task's runs spread across shards (interleaved/round-robin), avoiding the "one slow task monopolizes one job" imbalance. Deterministic and stable across invocations. |
 | Multi-input merge in `report` | `report` aggregates across **multiple shard partial ledgers** into one pass@k, equal to reporting a single non-sharded run over the same cells. (Today it reads one `results.jsonl` from one directory.) |
 | Reusable workflow (new sibling artifact) | A `workflow_call` reusable workflow shipped by the `forwardimpact/fit-benchmark` sibling lets a consumer get cross-machine parallelism from a single `shard-total` input: it fans the shards across CI machines, then merges their partial ledgers into one combined report. Inputs mirror the composite action plus `shard-total`. The internal job topology (matrix, shard-scoped artifact hand-off, dependent merge job) is a design concern. |
-| Composite action retained and unchanged for single-job use | The existing `forwardimpact/fit-benchmark@v1` action keeps working with no new inputs, now faster via Layer 1. It additionally exposes shard inputs (`shard-index`/`shard-total`) so an advanced consumer can hand-roll a matrix without the reusable workflow. |
+| Composite action becomes the per-shard primitive | The action gains `concurrency`, `shard-index`, `shard-total`, and `mode` inputs. An unsharded run is the identity case `shard-index: 1, shard-total: 1` — not a preserved legacy path. The reusable workflow composes this one primitive across the matrix; a consumer may also invoke it directly in their own job. |
 
 ### `fit-bootstrap` and the matrix (the distribution consideration)
 
@@ -154,6 +154,11 @@ and it changes how `fit-bootstrap` is consumed:
   input; deriving an optimal `N` automatically is a later concern.
 - **Provider rate-limit raising.** The run must tolerate existing limits via
   backoff; negotiating higher limits is operational, not in scope.
+- **Backward-compatibility shims or fallback flags.** This is a **clean break**:
+  the serial loop, the old port allocator, and the single-file report read are
+  replaced outright and deleted, not kept behind a `--legacy`/compat flag or a
+  dual ledger representation (see design § Clean break). Layer 1's transparency
+  is a default-value choice, not a compat shim.
 
 ## Success criteria
 
@@ -176,7 +181,7 @@ distribution).
 | Each shard emits a self-contained partial ledger. | L2 | A `--shard` run writes a partial `results.jsonl` containing only its assigned cells, valid on its own. |
 | `report` merges shard partials into one pass@k. | L2 | Aggregating the `N` shard partials yields pass@k identical to a single non-sharded run over the same cells (and identical to the `C`-only run of the same fixture). |
 | The reusable workflow fans out and merges. | L2 | A dispatch of the reusable workflow with `shard-total = K` produces `K` shard jobs plus one dependent merge job; the merge job downloads all `K` shard-scoped artifacts and emits a single combined report and results artifact. |
-| Single-job consumers are unaffected. | L2 | The `forwardimpact/fit-benchmark@v1` action invoked with **no** shard inputs runs the whole family in one job and produces the same report shape as before, now under Layer-1 concurrency. |
+| An unsharded invocation runs the whole family in one job. | L2 | The action with `shard-total` unset (≡ `1/1`) runs every cell in one job and produces the same report shape, now under Layer-1 concurrency — the identity case of the shard primitive, not a separate code path. |
 | The merge job carries no agent scaffold. | L2 | The merge job provisions only what `report` needs (a minimal Node setup — no apm/skill staging, no wiki checkout, no agent runtime). |
 | Shards run concurrently without cross-job contention. | L2 | A `shard-total = K` dispatch runs the `K` shard jobs in parallel; each provisions its own independent environment and writes its own shard-scoped artifact, and the run does not serialize the shards. |
 

--- a/specs/2130-parallel-benchmark-execution/spec.md
+++ b/specs/2130-parallel-benchmark-execution/spec.md
@@ -1,0 +1,207 @@
+# Spec 2130 — Parallel Benchmark Execution: In-Process Concurrency + Cross-Machine Sharding
+
+`fit-benchmark` runs a task family strictly serially. The `kata-skills` eval
+(`eval-kata.yml`, run 28264945754) ran for **six hours and was cancelled at the
+GitHub Actions ceiling** without producing a verdict. The benchmark's value —
+proving a skill change made agents better — is worthless if a run cannot finish
+inside CI. This spec makes a benchmark run fast enough to complete, by executing
+independent work concurrently on one machine **and** across many.
+
+Serves **Platform Builders** — the persona who hires `fit-benchmark` to *prove
+a skill change improved outcomes* (see
+[libraries/README.md § Jobs To Be Done](../../libraries/README.md#jobs-to-be-done)).
+A pass@k verdict is worthless if the run cannot finish inside a CI budget. The
+cancelled `kata-skills` eval is the *triggering consumer* (Teams Using Agents —
+run a continuously improving agent team), but the job-to-be-done belongs to the
+Platform Builder running the benchmark.
+
+**Classification: internal.** The change lands in `libraries/libharness` and in
+`.github/` (a new reusable workflow) — both internal trees. The shared rubric
+keys classification on **where the change lands**, not on whether the tool is
+later published; this is internal infrastructure that serves a Platform Builder
+job, not a change under `products/` or `services/`.
+
+## Problem
+
+**The runner is serial by construction.** The benchmark runner walks a nested
+loop — for every task, for every run index — and awaits each cell
+(`(task, runIndex)`) end-to-end before starting the next: setup → supervised
+agent session → invariants → judge → teardown. Wall-clock is therefore the
+**sum of all cells**.
+
+**The magnitude.** The `kata-skills` family is 6 tasks × `runs: 5` = **30
+cells**. Each cell carries a supervised agent session (lead + agent-under-test)
+plus a judge session, bounded only by a **20-minute per-agent watchdog**. Thirty
+cells in series against that bound is multi-hour by design; the observed run hit
+360 minutes and was cancelled. The workflow already carries scar tissue from
+this: `eval-kata.yml` notes a *prior* timeout (run 27922619997) where "5
+coordinate-finding stalls exhausted it," and raised the job budget to the
+360-minute hard ceiling — which the next run then also exhausted. Raising the
+timeout is not a fix; the ceiling is fixed and the work grows with
+tasks × runs.
+
+**Stall amplification.** Because cells run in series, one stalled cell riding its
+full 20-minute watchdog delays *every* cell behind it. A single pathological
+task (the family's `coordinate-finding` is the documented offender) can consume
+a third of the entire budget before its own watchdog even fires.
+
+**The work is already independent — the architecture just doesn't exploit it.**
+Each cell is allocated its own per-task working directory, its own TCP port, and
+its own process group for teardown. The only state shared across cells is the
+**one-time apm/skill staging directory** (built once before the loop, read-only
+during runs) and the **single `results.jsonl` append stream**. Cells do not
+depend on each other's outcomes; pass@k is computed from per-cell verdicts whose
+values do not depend on execution order. This is embarrassingly parallel work
+running one-at-a-time.
+
+**Three latent hazards block naive concurrency.** The serial loop gets these for
+free; any concurrency layer must solve them or it will corrupt results:
+
+| Hazard | Today | Under concurrency |
+| --- | --- | --- |
+| **Port allocation** | The port allocator opens a listener on port 0, reads the assigned port, **closes the listener, then returns the bare number**. | Two cells racing the allocate→bind window can be handed the **same** port; a real allocate-and-hold contract is required. |
+| **Results durability** | A single append stream is written one awaited line at a time. | Concurrent writers can interleave or lose lines; the verdict ledger must stay one-valid-record-per-cell. |
+| **API rate / cost** | One agent session at a time naturally rate-limits itself. | `concurrency × shards` simultaneous agent sessions can trip provider 429s; the run must degrade with backoff, not fail. |
+
+**The single-machine ceiling is real.** Even perfect in-process concurrency is
+bounded by one runner's CPU, memory, file descriptors, and the per-job timeout.
+Each cell spawns ~3 agent subprocesses, so one `ubuntu-latest` box holds only a
+handful before contention. Beating the **per-job** ceiling requires more than one
+machine — which a step-level composite action cannot orchestrate on its own.
+
+## Goal
+
+Make a `fit-benchmark` run complete well within a CI budget by running
+independent cells concurrently, on two composable axes — **many cells per
+machine** and **many machines per run** — without changing the pass@k a
+consumer would have gotten from the serial runner, and without requiring any
+consumer to opt in for the first axis.
+
+## Solution shape (two composable layers)
+
+Adopt the model proven by parallel test runners (Playwright): **workers within a
+machine, shards across machines, then a merge.**
+
+- **Layer 1 — In-process concurrency (Option 1).** A bounded worker pool runs up
+  to `C` cells concurrently inside one runner process. Native to the runner,
+  **on by default**, transparent to every consumer. Divides single-job
+  wall-clock by what one machine holds, and converts a stall from a
+  whole-run tax into a single occupied slot.
+
+- **Layer 2 — Cross-machine sharding (Option 3, Playwright-inspired).** A
+  first-class `--shard=<i>/<N>` selector runs a deterministic, balanced subset of
+  the grid; each shard emits a partial result ledger; `report` merges partials
+  into one pass@k. A **reusable workflow** (new sibling artifact) fans the shards
+  across a CI matrix and runs a dependent merge job, so a consumer gets
+  cross-machine parallelism from a single `shard-total` input. Beats the
+  per-job ceiling by using `N` jobs.
+
+The layers compose: each of `N` shard jobs runs Layer-1 concurrency internally,
+so effective parallelism is `N × C`.
+
+## Scope
+
+### In scope — Layer 1 (libharness / `fit-benchmark` CLI)
+
+| Change | Detail |
+| --- | --- |
+| Bounded concurrent execution of cells | The runner executes up to `C` cells concurrently, replacing the serial nested loop. `C` is **>1 by default** (transparent speedup) and overridable by a `--concurrency` flag and a matching action input. The default value (CPU/rate-limit aware) and the scheduling mechanism are design concerns; default-on is not. |
+| Concurrency-safe port allocation | Each in-flight cell receives a **distinct, bindable** port; the current close-then-return allocator's TOCTOU race (two cells handed the same number) is eliminated. The reservation mechanism is a design concern. |
+| Durable, concurrency-safe result ledger | One valid `ResultRecord` per cell regardless of `C` — no interleaved, lost, or truncated lines — and a killed run **retains the cells already completed** (crash-safe). The on-disk shape that achieves both is a design concern. |
+| Order-independent verdict contract | `run()` may yield records in completion order rather than grid order. Every consumer of the record stream — the CLI's stdout mirror, `anyFail`, the zero-record guard, and `report`'s aggregation — must be order-independent; `report` groups by `taskId`, so pass@k does not depend on order. This contract change is stated, not hidden. |
+| Rate-limit backpressure | Concurrent agent sessions that hit provider 429s back off and retry rather than failing the cell or the run. Mechanism is a design concern; graceful degradation is required. |
+| Per-cell isolation preserved | The existing per-task CWD, process group, watchdog, and teardown-with-port-verification continue to bound each cell independently; concurrent teardown of disjoint process groups must not collide. |
+| Staging stays a one-time prelude | apm/skill staging runs once before fan-out and is read-only during runs; it is not duplicated per cell. |
+
+### In scope — Layer 2 (sharding + distribution)
+
+| Change | Detail |
+| --- | --- |
+| `--shard=<i>/<N>` selector | The runner flattens the family into a stable, ordered list of cells and runs only the cells assigned to shard `i` of `N`. The N shards form an exact **partition** of the grid — every cell runs on exactly one shard, none twice, none dropped. |
+| Cell-granular, balanced assignment | Assignment is at `(task, runIndex)` granularity, not per-task, so a long task's runs spread across shards (interleaved/round-robin), avoiding the "one slow task monopolizes one job" imbalance. Deterministic and stable across invocations. |
+| Multi-input merge in `report` | `report` aggregates across **multiple shard partial ledgers** into one pass@k, equal to reporting a single non-sharded run over the same cells. (Today it reads one `results.jsonl` from one directory.) |
+| Reusable workflow (new sibling artifact) | A `workflow_call` reusable workflow shipped by the `forwardimpact/fit-benchmark` sibling lets a consumer get cross-machine parallelism from a single `shard-total` input: it fans the shards across CI machines, then merges their partial ledgers into one combined report. Inputs mirror the composite action plus `shard-total`. The internal job topology (matrix, shard-scoped artifact hand-off, dependent merge job) is a design concern. |
+| Composite action retained and unchanged for single-job use | The existing `forwardimpact/fit-benchmark@v1` action keeps working with no new inputs, now faster via Layer 1. It additionally exposes shard inputs (`shard-index`/`shard-total`) so an advanced consumer can hand-roll a matrix without the reusable workflow. |
+
+### `fit-bootstrap` and the matrix (the distribution consideration)
+
+A composite action is a **step**; a matrix is a **job** construct. So
+cross-machine parallelism cannot be delivered by the composite action alone — it
+requires either the consumer authoring a matrix or a `workflow_call` reusable
+workflow that owns the matrix. The reusable workflow is the transparent path,
+and it changes how `fit-bootstrap` is consumed:
+
+| Concern | Requirement |
+| --- | --- |
+| Per-shard environment | Each matrix shard job sets up its own benchmark environment via `fit-bootstrap` (a new sibling→sibling `uses:` edge from the fit-benchmark reusable workflow to `fit-bootstrap`, governed by the sibling per `.github/CLAUDE.md`). `fit-bootstrap` must be safe to run in `N` parallel jobs: cache reads, wiki-checkout token minting, and any workspace setup must be shard-independent with no cross-job write contention. |
+| Merge-job environment | The merge job needs only the `report` CLI and the shard artifacts — **not** a per-run agent scaffold. Either `fit-bootstrap` supports a setup sufficient for `report` without the full benchmark environment, or the reusable workflow provisions the merge job's minimal environment directly. Which one is a design decision; the requirement is that merge does not pay for a benchmark env it never uses. |
+| Artifact-name collisions | Per-shard partial artifacts must carry shard-unique names (the established matrix `case:`/shard-index disambiguation in `.github/CLAUDE.md`), so `N` concurrent uploads do not collide and the merge job can collect them all. |
+| Sandbox flag | Each shard's agent-spawning step still sets `IS_SANDBOX=1` (per `.github/CLAUDE.md`); sharding does not change the bypass-permissions requirement. |
+
+### Excluded
+
+- **Cross-job work-stealing / dynamic load balancing.** Static cell-granular
+  sharding is the 80/20; a shared queue across CI jobs needs external
+  coordination and is out of scope.
+- **Changing what a cell does** — the supervised agent + invariants + judge
+  lifecycle, the watchdog duration, grading surfaces, and the result schema's
+  meaning are unchanged. (The ledger's *storage shape* may change; a record's
+  fields do not.)
+- **Reducing per-cell cost or token usage.** This spec compresses wall-clock;
+  total spend across a run is unchanged but is incurred faster, so a consumer's
+  budget or rate ceiling may surface sooner — acknowledged, not addressed here.
+- **Auto-scaling shard count to family size.** `shard-total` is a consumer
+  input; deriving an optimal `N` automatically is a later concern.
+- **Provider rate-limit raising.** The run must tolerate existing limits via
+  backoff; negotiating higher limits is operational, not in scope.
+
+## Success criteria
+
+Verifiable at merge time. Layer-1 criteria are testable with the runner's
+existing fake-agent test seam against the injected clock, so they need no live
+LLM spend. Tagged **[L1]** (in-process concurrency) or **[L2]** (sharding +
+distribution).
+
+| Criterion | Layer | Verification |
+| --- | --- | --- |
+| Cells execute concurrently, bounded by `C`. | L1 | With the fake-agent seam, a run of `M` cells at concurrency `C` records a **max-in-flight ≤ C** and completes in ≈ `ceil(M/C)` batch-durations against the clock seam — not `M`. |
+| Concurrency is on by default. | L1 | A run invoked with no concurrency flag uses `C > 1`; the default is exercised by a test asserting parallel execution without passing `--concurrency`. |
+| The verdict is unchanged by concurrency. | L1 | The same fixture run at `C = 1` and `C = 8` produces byte-identical pass@k and identical per-task `n`/`c`. |
+| Port allocation is collision-free under concurrency. | L1 | `K` cells allocated concurrently receive `K` distinct ports, each actually bindable at hand-off (the allocate-and-hold contract); a test that previously could collide under the close-then-return allocator now cannot. |
+| The result ledger is one valid record per cell under concurrency. | L1 | After a concurrent run of `tasks × runs` cells, `results.jsonl` parses with exactly that many records, every one schema-valid, none truncated or interleaved. |
+| A stall costs one slot, not the run. | L1 | With one cell forced to stall to its watchdog and `C > 1`, the other cells produce records and the run completes; the stalled cell is recorded as an `agentError`, and total wall-clock is bounded by `ceil(M/C)` batches, not `M`. |
+| Rate-limit failures back off, they don't fail the run. | L1 | With the fake-agent seam injecting a 429-class failure, the cell retries with bounded backoff (within its watchdog) rather than failing immediately; the run does not abort, and a cell only records an `agentError` after the backoff budget is exhausted. |
+| `--shard=i/N` runs an exact partition. | L2 | For representative `N`, the union of all shards' executed cell-sets equals the full grid with **no overlap and no gaps** — each `(task, runIndex)` runs on exactly one shard. |
+| Shard assignment is balanced and deterministic. | L2 | Each task's run indexes are distributed across shards (no shard gets a whole task while another gets none for `N ≤ runs`), and the same `(family, runs, N)` yields the same partition on repeat invocations. |
+| Each shard emits a self-contained partial ledger. | L2 | A `--shard` run writes a partial `results.jsonl` containing only its assigned cells, valid on its own. |
+| `report` merges shard partials into one pass@k. | L2 | Aggregating the `N` shard partials yields pass@k identical to a single non-sharded run over the same cells (and identical to the `C`-only run of the same fixture). |
+| The reusable workflow fans out and merges. | L2 | A dispatch of the reusable workflow with `shard-total = K` produces `K` shard jobs plus one dependent merge job; the merge job downloads all `K` shard-scoped artifacts and emits a single combined report and results artifact. |
+| Single-job consumers are unaffected. | L2 | The `forwardimpact/fit-benchmark@v1` action invoked with **no** shard inputs runs the whole family in one job and produces the same report shape as before, now under Layer-1 concurrency. |
+| The merge job carries no agent scaffold. | L2 | The merge job provisions only what `report` needs (a minimal Node setup — no apm/skill staging, no wiki checkout, no agent runtime). |
+| Shards run concurrently without cross-job contention. | L2 | A `shard-total = K` dispatch runs the `K` shard jobs in parallel; each provisions its own independent environment and writes its own shard-scoped artifact, and the run does not serialize the shards. |
+
+**Outcome criterion (go-see)** — the durable target, measured on the live eval
+*after* merge, tracked rather than gating: a representative `kata-skills` run
+(6 tasks × `runs: 5`) completes and produces a pass@k report **well within the
+GitHub Actions per-job ceiling** — the six-hour cancellation does not recur.
+Initial go-see: the first post-merge dispatch finishes with a verdict instead of
+a timeout.
+
+## Path to approval
+
+Approval is human-only: the spec advances when `wiki/STATUS.md` shows the `2130`
+row at `spec approved`, written from a trusted human signal (`spec:approved`
+label, APPROVED review, approval comment, or in-session approval). On approval
+the spec proceeds to `kata-design` (WHICH/WHERE — the worker-pool placement and
+the streaming-contract change in the runner, the port-reservation mechanism, the
+durable ledger shape and its merge primitive, the cell-flattening and partition
+function for `--shard`, the multi-input `report` merge, the reusable workflow
+topology and its `fit-bootstrap` consumption, and the backpressure mechanism)
+and then `kata-plan`.
+
+The new `forwardimpact/fit-benchmark` → `fit-bootstrap` sibling edge and the
+requirement that `fit-bootstrap` be safe under matrix fan-out touch a shared CI
+artifact governed by `.github/CLAUDE.md`; that cross-sibling change is
+coordinated with the owners of those siblings before the dependent work lands.
+
+— Staff Engineer 🛠️


### PR DESCRIPTION
## Summary

- Spec 2130 — make a `fit-benchmark` run finish inside a CI budget. The serial nested loop runs every `(task, runIndex)` cell one at a time; the `kata-skills` eval ran ~6h and was cancelled at the GitHub Actions ceiling. Proposes two composable layers.
- **Layer 1 (in-process concurrency)** — a bounded scheduler runs up to `C` cells concurrently, on by default and transparent to consumers; a single-writer drain loop keeps `results.jsonl` durable, a `PortRegistry` removes the `allocatePort` TOCTOU race, and the verdict (pass@k) is unchanged.
- **Layer 2 (cross-machine sharding, Playwright-inspired)** — a `--shard=i/N` selector partitions the grid (round-robin, cell-granular), `report` merges shard partials recursively, and a new `workflow_call` reusable workflow fans the shards across a CI matrix and merges them; `fit-bootstrap` runs per shard, the merge job carries no agent scaffold.
- **Clean break** — the serial loop, the old port allocator, and the single-file report read are deleted, not flagged: no shims, fallbacks, compat flags, or dual ledger representation.
- Adds `design-a.md` (137→152 lines, under the 200 cap) alongside the spec. STATUS row set to `2130 design approved`.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ara9gWBh9gLoxbqtMj7VMY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ara9gWBh9gLoxbqtMj7VMY)_