### PR TITLE
docs(kata): add lockstep co-execution for spec+design in one PR

### DIFF
--- a/.claude/agents/references/approval-signals.md
+++ b/.claude/agents/references/approval-signals.md
@@ -87,7 +87,10 @@ update a row, locate the line in the code block and replace it in place.
 Format: `{id}\t{phase}\t{status}`. Phases: `spec`, `design`, `plan`.
 Statuses: `draft`, `approved`, `implemented` (plan only), `cancelled`.
 Lifecycle: `spec draft → spec approved → design draft → design approved →
-plan draft → plan approved → plan implemented`. Cancelled is terminal.
+plan draft → plan approved → plan implemented`. Cancelled is terminal. A
+lockstep spec+design PR (both artifacts in one `design(NNN)` PR) skips the
+`spec approved` state: the row moves `spec draft → design draft → design
+approved`, and reaching `design approved` subsumes spec approval.
 
 Commit the wiki edit alongside any other wiki updates from the same
 session; the Stop hook pushes wiki commits.

--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -28,8 +28,7 @@ is no commitment to implement, and a design has nothing to shape.
 - Reviewing a design before approval ("review design NNN", "is design NNN
   ready?")
 - Revisiting a design whose direction needs rethinking before planning
-- Co-running with `kata-spec` when one prompt asks for both and the session
-  holds the technical direction — see
+- Co-running with `kata-spec` when one prompt asks for both — see
   [lockstep co-execution](references/lockstep-co-execution.md)
 
 ## Checklists

--- a/.claude/skills/kata-design/SKILL.md
+++ b/.claude/skills/kata-design/SKILL.md
@@ -28,14 +28,18 @@ is no commitment to implement, and a design has nothing to shape.
 - Reviewing a design before approval ("review design NNN", "is design NNN
   ready?")
 - Revisiting a design whose direction needs rethinking before planning
+- Co-running with `kata-spec` when one prompt asks for both and the session
+  holds the technical direction — see
+  [lockstep co-execution](references/lockstep-co-execution.md)
 
 ## Checklists
 
 <read_do_checklist goal="Internalize design-writing boundaries before starting">
 
-- [ ] Confirm `specs/NNN/spec.md` exists on `origin/main` after
-      `git fetch origin main` — wait for the spec PR to merge before
-      starting a design.
+- [ ] Confirm `specs/NNN/spec.md` exists on `origin/main`
+      (`git fetch origin main`) before designing — except under
+      [lockstep co-execution](references/lockstep-co-execution.md), which drafts
+      against the same-branch spec.
 - [ ] Do not write or revise the spec — return it to `draft` if it needs
       changes.
 - [ ] Do not write the plan — this skill writes the design; `kata-plan`
@@ -140,7 +144,9 @@ from prior entries.
 ### Step 1: Find the spec
 
 Run `git fetch origin main`, then confirm `specs/NNN/spec.md` exists on
-`origin/main` — wait for the spec PR to merge before starting a design.
+`origin/main` — wait for the spec PR to merge before starting a design. Under
+[lockstep co-execution](references/lockstep-co-execution.md) the spec is drafted
+in this session instead; skip the wait.
 
 ### Step 2: Study the spec
 
@@ -170,7 +176,9 @@ Before pushing, verify identifiers the design names still exist on
 
 The PR title carries the spec id: `design(NNN): …`. Do not apply the
 `design:approved` label and do not recommend approval — those are human-only
-actions; see § Approval.
+actions; see § Approval. Under
+[lockstep co-execution](references/lockstep-co-execution.md) this single
+`design(NNN)` PR also carries `spec.md`; no separate spec PR is opened.
 
 [Citation integrity](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/citation-integrity.md): every cited SHA must resolve on its referenced repo, or the body is not published.
 

--- a/.claude/skills/kata-design/references/lockstep-co-execution.md
+++ b/.claude/skills/kata-design/references/lockstep-co-execution.md
@@ -1,28 +1,13 @@
 # Lockstep Co-Execution (spec + design together)
 
-Shared protocol for when **one prompt asks for both the spec and the design**
-and the session already holds enough context to commit to a technical
-direction. Used by [`kata-spec`](../../kata-spec/SKILL.md) and
-[`kata-design`](../SKILL.md).
+Shared protocol for when **one prompt asks for both the spec and the design**.
+Used by [`kata-spec`](../../kata-spec/SKILL.md) and [`kata-design`](../SKILL.md).
+Both pipelines advance one phase at a time, with a barrier at each phase
+boundary, and ship in a single PR.
 
-Default behaviour is serial: write the spec, ship and approve it, then start the
-design. Lockstep is the opt-in alternative — both pipelines advance one phase at
-a time, with a barrier at each phase boundary, and ship in a **single PR**.
-
-## When lockstep is appropriate
-
-- The same prompt requests both artifacts.
-- You are confident the architecture will not need an independent redirect — the
-  separate design approval exists as a redirection checkpoint, and lockstep
-  collapses it into the spec approval. If you want the design scrutinized as its
-  own gate, run the skills serially instead.
-
-## Why
-
-Run fully serial, the spec review panel and its triage fill the context window
-before the design is ever drafted, so the design is authored from a saturated
-context. Lockstep authors **both artifacts from the same fresh context**, before
-any review-triage detour, then reviews and ships them as one unit.
+Author both artifacts from the same fresh context before reviewing either —
+running fully serial fills the context with spec-review triage before the design
+is drafted.
 
 ## The barrier sequence
 
@@ -59,8 +44,7 @@ spec draft → design draft → design approved
 - `design draft` — once both artifacts are reviewed and pushed in the combined
   PR (a draft→draft bookkeeping move, no approval).
 - `design approved` — the human's single design-class approval signal on the
-  combined PR; a normal single-step approval transition. Approval stays
-  human-only and serial in the sense that one signal still gates the merge.
+  combined PR; a normal single-step approval transition.
 
 ## Metrics
 

--- a/.claude/skills/kata-design/references/lockstep-co-execution.md
+++ b/.claude/skills/kata-design/references/lockstep-co-execution.md
@@ -1,0 +1,68 @@
+# Lockstep Co-Execution (spec + design together)
+
+Shared protocol for when **one prompt asks for both the spec and the design**
+and the session already holds enough context to commit to a technical
+direction. Used by [`kata-spec`](../../kata-spec/SKILL.md) and
+[`kata-design`](../SKILL.md).
+
+Default behaviour is serial: write the spec, ship and approve it, then start the
+design. Lockstep is the opt-in alternative — both pipelines advance one phase at
+a time, with a barrier at each phase boundary, and ship in a **single PR**.
+
+## When lockstep is appropriate
+
+- The same prompt requests both artifacts.
+- You are confident the architecture will not need an independent redirect — the
+  separate design approval exists as a redirection checkpoint, and lockstep
+  collapses it into the spec approval. If you want the design scrutinized as its
+  own gate, run the skills serially instead.
+
+## Why
+
+Run fully serial, the spec review panel and its triage fill the context window
+before the design is ever drafted, so the design is authored from a saturated
+context. Lockstep authors **both artifacts from the same fresh context**, before
+any review-triage detour, then reviews and ships them as one unit.
+
+## The barrier sequence
+
+Both skills advance together; neither races ahead to its own review while the
+other is still drafting.
+
+1. **Claim once.** `kata-spec` claims the id and writes `{NNN}\tspec\tdraft` as
+   normal. The design reuses the same `NNN`; no second claim.
+2. **Clarify + research once** — one pass serves both artifacts.
+3. **Draft both** — write `spec.md`, then `design-a.md`, in the same session
+   before reviewing either. The design is drafted against the same-branch spec;
+   it does not wait for the spec to reach `origin/main`.
+4. **One combined review batch.** Launch every panel for both artifacts in a
+   single message per the [`kata-review` caller
+   protocol](../../kata-review/references/caller-protocol.md) — the two spec
+   panels and the design panel together. Triage once. If spec triage shifts
+   scope, re-touch `design-a.md` before opening the PR.
+5. **One PR.** Open a single PR titled `design(NNN): …` carrying both
+   `spec.md` and `design-a.md`. Do **not** open a separate `spec(NNN)` PR. The
+   merge gate classifies it as a design-phase PR; bundling the spec is invisible
+   to the gate.
+
+## STATUS lifecycle
+
+The row skips the `spec approved` state — reaching `design approved` subsumes it
+(one human signal approves both stages). See
+[`approval-signals.md`](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/approval-signals.md).
+
+```
+spec draft → design draft → design approved
+```
+
+- `spec draft` — at claim (Step 1).
+- `design draft` — once both artifacts are reviewed and pushed in the combined
+  PR (a draft→draft bookkeeping move, no approval).
+- `design approved` — the human's single design-class approval signal on the
+  combined PR; a normal single-step approval transition. Approval stays
+  human-only and serial in the sense that one signal still gates the merge.
+
+## Metrics
+
+The combined PR has no separate spec PR, so count it for **both**
+`specs_drafted` and `designs_drafted`.

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -27,8 +27,7 @@ asked for. If they ask for a spec, write the spec and stop.
 - Documenting a proposed feature, change, or improvement with rationale
 - Reviewing a spec before it advances to planning ("review spec NNN", "is spec
   NNN ready?")
-- Co-running with `kata-design` when one prompt asks for both and the session
-  holds the technical direction — see
+- Co-running with `kata-design` when one prompt asks for both — see
   [lockstep co-execution](../kata-design/references/lockstep-co-execution.md)
 
 ## Checklists

--- a/.claude/skills/kata-spec/SKILL.md
+++ b/.claude/skills/kata-spec/SKILL.md
@@ -27,6 +27,9 @@ asked for. If they ask for a spec, write the spec and stop.
 - Documenting a proposed feature, change, or improvement with rationale
 - Reviewing a spec before it advances to planning ("review spec NNN", "is spec
   NNN ready?")
+- Co-running with `kata-design` when one prompt asks for both and the session
+  holds the technical direction — see
+  [lockstep co-execution](../kata-design/references/lockstep-co-execution.md)
 
 ## Checklists
 
@@ -35,8 +38,9 @@ asked for. If they ask for a spec, write the spec and stop.
 - [ ] Claim the spec number in `wiki/STATUS.md` as the first action — append a
       `{NNN}\tspec\tdraft` row before writing, so parallel sessions cannot
       claim the same id.
-- [ ] Only produce the deliverable asked for — if asked for a spec, stop after
-      the spec. Do not also write a plan.
+- [ ] Only produce the deliverable(s) asked for — never auto-advance to the
+      plan. Spec+design in one prompt is a valid pairing: run
+      [lockstep co-execution](../kata-design/references/lockstep-co-execution.md).
 - [ ] No implementation details in the spec — file paths, function signatures,
       and code patterns belong in the plan.
 - [ ] When reviewing: evaluate, do not rewrite. If changes are needed, return to
@@ -167,6 +171,10 @@ The PR title carries the spec id: `spec(NNN): …`. Merge of that PR is what
 advances the phase. Apply the matching `product` / `internal` label per the
 shared rubric when opening the PR. Do not apply the `spec:approved` label and
 do not recommend approval — those are human-only actions; see § Approval.
+
+Under [lockstep co-execution](../kata-design/references/lockstep-co-execution.md),
+do **not** open a separate spec PR — the spec ships inside the single combined
+PR opened at the design stage.
 
 [Citation integrity](https://github.com/forwardimpact/monorepo/blob/main/.claude/agents/references/citation-integrity.md): every cited SHA must resolve on its referenced repo, or the body is not published.
 


### PR DESCRIPTION
## Summary

- When one prompt asks for both a spec and a design, running `kata-spec` then `kata-design` fully serial saturates the context with spec-review triage before the design is drafted, degrading the design. This adds a **lockstep** mode: draft both artifacts from the same fresh context, review them in one combined panel batch, and ship them in a single `design(NNN)` PR.
- New shared reference `.claude/skills/kata-design/references/lockstep-co-execution.md` defines the barrier sequence, the single-PR rule, and the STATUS lifecycle (`spec draft → design draft → design approved`, where `design approved` subsumes spec approval).
- `kata-spec`: the spec+design pairing is a valid request; no separate spec PR is opened in lockstep.
- `kata-design`: the `origin/main` precondition is relaxed for the same-branch in-session spec.
- `approval-signals.md`: documents that the lockstep row skips the `spec approved` state.
- The combined PR is classified as a design PR, so the release-merge gate needs no change.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TFNEKZNnvfYfMyRXZqsir7)_