### PR TITLE
plan(2130): parallel benchmark execution — Layers 1 + 2 (backpressure descoped)

### DIFF
--- a/specs/2130-parallel-benchmark-execution/design-a.md
+++ b/specs/2130-parallel-benchmark-execution/design-a.md
@@ -52,7 +52,6 @@ a write mutex and without a sidecar ledger.
 | completion channel + drain loop | `runner.js` `run()` | Async queue the scheduler pushes settled records into; the generator drains it, appends each record to the shard's `results.jsonl` **as it settles**, and yields. Sole writer of the ledger and its only on-disk form — incremental append is the crash-safety mechanism, so there is no per-cell sidecar file. |
 | `PortRegistry` | `benchmark/workdir.js` | Replaces `allocatePort()` (deleted): hand out distinct, bindable ports under a lock with a live in-use set; re-probe if the OS returns an already-reserved number; release on teardown. |
 | `resolveConcurrency` | `commands/benchmark-run.js` | `--concurrency` flag > `LIBHARNESS_BENCHMARK_CONCURRENCY` env > default `min(CONCURRENCY_CEILING, max(2, ⌊cores/2⌋))` (where `CONCURRENCY_CEILING` is a plan-time constant, conservative because each cell spawns ~3 agent subprocesses). |
-| `retryRateLimited` | `benchmark/runner.js` (`#runAgentSafe`) | Wrap the agent session: a 429/rate-limit-class failure retries with bounded exponential backoff inside the cell (under the 20-min watchdog) instead of immediately recording an `agentError`. |
 
 **Streaming contract change.** `run()` now yields in **completion order**, not
 grid order. The CLI consumer already treats records order-independently

--- a/specs/2130-parallel-benchmark-execution/plan-a-01.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a-01.md
@@ -151,7 +151,7 @@ export function resolveConcurrency(values, env = {}) {
       throw new Error("--concurrency must be a positive integer");
     return n;
   }
-  const cores = availableParallelism?.() ?? 1;
+  const cores = availableParallelism(); // node:os, present on supported Node
   return Math.min(CONCURRENCY_CEILING, Math.max(2, Math.floor(cores / 2)));
 }
 ```

--- a/specs/2130-parallel-benchmark-execution/plan-a-01.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a-01.md
@@ -110,40 +110,27 @@ Verification: with a `runCell` stub that records concurrent entry/exit, a run of
 `M` cells at `C` reports max-in-flight ≤ `C`; all `M` records are yielded
 exactly once.
 
-## Step 4 — Rate-limit backpressure — BLOCKED ON DESIGN REVISION
+## Step 4 — Rate-limit backpressure — DESCOPED (moved to a follow-up spec)
 
-> **Do not implement this step as the design currently specifies it.** The
-> review panel confirmed a blocker: design-a.md § Layer 1 places
-> `retryRateLimited` in `#runAgentSafe` and assumes a 429 surfaces as a **thrown
-> error** at the agent-session boundary. It does not. `AgentRunner.#consumeQuery`
-> (agent-runner.js:190-196) **catches** the query iterator's error and **returns**
-> it as a `{success:false, error}` field; `supervisor.run` then resolves (does
-> not reject), so a `try/catch` retry at any benchmark-runner site is dead code.
-> A correct, robust retry must (a) **detect** the rate limit from the returned
-> `error`/`success` result, not a throw, and (b) sit at a seam that can re-issue
-> the failing **SDK call** with a fresh trace stream — re-running the whole
-> supervised `#runAgent` session on a mid-session 429 both double-writes the
-> reused `combinedStream` (double-counting cost via `sumTraceCost`) and restarts
-> partial agent work. The natural seam is inside `AgentRunner` around the `query`
-> iterator, which is **shared by every harness consumer** (supervise, facilitate,
-> benchmark) — a cross-cutting choice with blast radius, i.e. a WHICH/WHERE
-> decision that belongs in the design, not the plan.
+Rate-limit backpressure is **out of scope for spec 2130** (descope decision,
+2026-06-27). The review panel established it is not a thin implementation detail:
+a 429 does not throw at the agent-session boundary — `AgentRunner.#consumeQuery`
+(agent-runner.js:190-196) catches the query error and returns it as a
+`{success:false, error}` field — and a robust retry seam (the shared `AgentRunner`
+query call, used by supervise/facilitate/benchmark) is cross-cutting, with a
+trace/cost-correctness contract under retry. That is a WHICH/WHERE decision the
+design must own, so it is split to its own spec rather than wedged into this one.
 
-**Action:** return spec 2130 to `kata-design` to revise the § Layer 1
-backpressure row — name the detection signal (returned `error`, not a throw),
-the owning component (`AgentRunner` query seam vs benchmark cell vs scheduler
-admission control), and the trace/cost-correctness contract under retry. The
-other Layer-1 steps (1–3, 5–7) do not depend on backpressure and can proceed;
-this step lands only after the design is amended and re-approved.
+Nothing else in this plan depends on it. Under concurrency, a cell that hits a
+429 records an `agentError` (today's behavior, unchanged) and — thanks to Layer 1
+— costs one slot, not the run; the run still completes. The follow-up spec adds
+the retry on top of this scheduler.
 
-Once the design names the mechanism, this step's shape will be: detect the
-rate-limit class from the result, back off via `this.runtime.clock.sleep(
-RATE_LIMIT_BASE_MS · 2^attempt)` up to `RATE_LIMIT_MAX_RETRIES`, all inside the
-existing watchdog window (the watchdog race, not a second elapsed-time clock,
-bounds total wall-clock), with each attempt re-issuing against a clean trace so
-cost is counted once. The verification must drive the 429 through the real
-result path (a `query` whose iterator errors once then succeeds) and assert both
-a single normal record **and** un-doubled `costUsd`/`turns`.
+**Companion action (outside kata-plan):** trim spec 2130 to match — remove the
+"Rate-limit backpressure" in-scope row and the "Rate-limit failures back off"
+[L1] success criterion (via `kata-spec`), and remove the § Layer 1
+`retryRateLimited` row from design-a (via `kata-design`) — then open the
+follow-up spec for the backpressure mechanism.
 
 ## Step 5 — `resolveConcurrency` + `--concurrency` flag
 
@@ -240,7 +227,7 @@ Each row maps to a spec § Success criteria [L1] line:
 | Port collision-free | Step 2's `PortRegistry` concurrent-acquire test |
 | One record per cell | concurrent run of `tasks×runs` → `results.jsonl` parses to exactly that many schema-valid records, none interleaved/truncated |
 | Stall costs one slot | one cell forced to the watchdog with `C>1` (inject a short `watchdogMs`): others produce records, run completes, stalled cell is `agentError` |
-| Rate-limit backoff | **deferred** — covered when Step 4 lands after the design revision; the spec's "rate-limit failures back off" [L1] criterion is not met until then |
+| Rate-limit backoff | **descoped** — moved to a follow-up spec (Step 4); not a 2130 criterion once the spec is trimmed |
 
 **Substituted verification method (called out).** The spec and design phrase the
 bound as "completes in ≈ `ceil(M/C)` batch-durations against the clock seam." The

--- a/specs/2130-parallel-benchmark-execution/plan-a-01.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a-01.md
@@ -1,0 +1,260 @@
+# Plan 2130-a Part 01 — Layer 1: in-process concurrency
+
+In-process bounded concurrency for `BenchmarkRunner`, per
+[design 2130-a § Layer 1](design-a.md#layer-1--in-process-concurrency). All
+changes in `libraries/libharness`. Run from the `libharness` package root.
+
+Libraries used: libharness, libutil (runtime clock), libmock (test runtime/clock).
+
+## Step 1 — Add `enumerateCells`
+
+Introduce the single, stable cell ordering both the scheduler and (Part 02) the
+shard selector consume.
+
+- **Modified:** `src/benchmark/runner.js`
+
+Add an exported pure function:
+
+```js
+/**
+ * Flatten the grid into a stable ordered cell list, task-major /
+ * runIndex-minor. Load-bearing ordering: Part 02's round-robin shard balance
+ * depends on a task's runIndexes being adjacent in this list.
+ * @returns {{task: import("./task-family.js").Task, runIndex: number}[]}
+ */
+export function enumerateCells(tasks, runs) {
+  const cells = [];
+  for (const task of tasks)
+    for (let runIndex = 0; runIndex < runs; runIndex++)
+      cells.push({ task, runIndex });
+  return cells;
+}
+```
+
+Verification: a unit test asserts `enumerateCells([a,b], 2)` yields
+`[a/0, a/1, b/0, b/1]` (task-major).
+
+## Step 2 — `PortRegistry` replaces `allocatePort`
+
+Give each in-flight cell a distinct, bindable port under a lock, closing the
+close-then-return TOCTOU race.
+
+- **Modified:** `src/benchmark/workdir.js`
+- **Deleted:** the `allocatePort()` function in `src/benchmark/workdir.js`
+  (the separate copy in `commands/benchmark-invariants.js` is single-task,
+  non-concurrent, and stays).
+
+Add a `PortRegistry` class: an `acquire(): Promise<number>` that probes a free
+port (listen on 0 → read number → close), and **re-probes if the number is
+already in its live in-use `Set`**; `release(port)` removes it. Serialize
+`acquire` through a one-slot promise chain so two concurrent acquires cannot
+read the same number before either is recorded.
+
+```js
+export class PortRegistry {
+  #inUse = new Set();
+  #tail = Promise.resolve();
+  acquire() {
+    const next = this.#tail.then(async () => {
+      let port;
+      do { port = await probeFreePort(); } while (this.#inUse.has(port));
+      this.#inUse.add(port);
+      return port;
+    });
+    this.#tail = next.catch(() => {});
+    return next;
+  }
+  release(port) { this.#inUse.delete(port); }
+}
+```
+
+`WorkdirManager` constructs one `PortRegistry` and uses it: `start()` calls
+`this.ports.acquire()` (replacing `await allocatePort()`); `teardown()` calls
+`this.ports.release(workdir.port)` after the existing process-group kill and
+`isPortFree` probe. `probeFreePort` is the old `allocatePort` body, renamed.
+
+Verification: a test acquiring `K` ports concurrently from one registry gets
+`K` distinct numbers, each bindable at hand-off; releasing then re-acquiring
+reuses freed numbers.
+
+## Step 3 — `CellScheduler`
+
+Run up to `C` cells concurrently and stream settled records in completion order.
+
+- **Created:** `src/benchmark/scheduler.js`
+
+A bounded pool built on a local permit semaphore (no new dependency). Given
+`{concurrency, runCell}` and an array of cells, it keeps ≤ `C` `runCell(cell)`
+calls in flight; as each settles it pushes the record onto an internal async
+queue that the class exposes as an async iterable. The async-iterable drain is
+what the runner consumes.
+
+```js
+export class CellScheduler {
+  constructor({ concurrency, runCell }) { /* store; validate C >= 1 */ }
+  /** @param {{task, runIndex}[]} cells @returns {AsyncGenerator<object>} */
+  async *run(cells) {
+    // permit semaphore size C; launch up to C, await Promise.race on the
+    // in-flight set, yield each settled record, refill, until all cells done.
+  }
+}
+```
+
+Maintain an explicit in-flight `Set<Promise>`; `Promise.race` it, yield the
+settled value, remove it, and launch the next cell while permits remain. A
+`runCell` rejection is impossible by contract — `#runOne` already returns an
+`agentError`/`schemaError` record rather than throwing — but guard defensively
+so one bad cell cannot wedge the drain.
+
+Verification: with a `runCell` stub that records concurrent entry/exit, a run of
+`M` cells at `C` reports max-in-flight ≤ `C`; all `M` records are yielded
+exactly once.
+
+## Step 4 — Rate-limit backpressure — BLOCKED ON DESIGN REVISION
+
+> **Do not implement this step as the design currently specifies it.** The
+> review panel confirmed a blocker: design-a.md § Layer 1 places
+> `retryRateLimited` in `#runAgentSafe` and assumes a 429 surfaces as a **thrown
+> error** at the agent-session boundary. It does not. `AgentRunner.#consumeQuery`
+> (agent-runner.js:190-196) **catches** the query iterator's error and **returns**
+> it as a `{success:false, error}` field; `supervisor.run` then resolves (does
+> not reject), so a `try/catch` retry at any benchmark-runner site is dead code.
+> A correct, robust retry must (a) **detect** the rate limit from the returned
+> `error`/`success` result, not a throw, and (b) sit at a seam that can re-issue
+> the failing **SDK call** with a fresh trace stream — re-running the whole
+> supervised `#runAgent` session on a mid-session 429 both double-writes the
+> reused `combinedStream` (double-counting cost via `sumTraceCost`) and restarts
+> partial agent work. The natural seam is inside `AgentRunner` around the `query`
+> iterator, which is **shared by every harness consumer** (supervise, facilitate,
+> benchmark) — a cross-cutting choice with blast radius, i.e. a WHICH/WHERE
+> decision that belongs in the design, not the plan.
+
+**Action:** return spec 2130 to `kata-design` to revise the § Layer 1
+backpressure row — name the detection signal (returned `error`, not a throw),
+the owning component (`AgentRunner` query seam vs benchmark cell vs scheduler
+admission control), and the trace/cost-correctness contract under retry. The
+other Layer-1 steps (1–3, 5–7) do not depend on backpressure and can proceed;
+this step lands only after the design is amended and re-approved.
+
+Once the design names the mechanism, this step's shape will be: detect the
+rate-limit class from the result, back off via `this.runtime.clock.sleep(
+RATE_LIMIT_BASE_MS · 2^attempt)` up to `RATE_LIMIT_MAX_RETRIES`, all inside the
+existing watchdog window (the watchdog race, not a second elapsed-time clock,
+bounds total wall-clock), with each attempt re-issuing against a clean trace so
+cost is counted once. The verification must drive the 429 through the real
+result path (a `query` whose iterator errors once then succeeds) and assert both
+a single normal record **and** un-doubled `costUsd`/`turns`.
+
+## Step 5 — `resolveConcurrency` + `--concurrency` flag
+
+Concurrency is on by default with a flag/env override.
+
+- **Modified:** `src/commands/benchmark-run.js`, `src/commands/benchmark-definition.js`
+
+In `benchmark-run.js` add:
+
+```js
+import { availableParallelism } from "node:os";
+const CONCURRENCY_CEILING = 4; // each cell spawns ~3 agent subprocesses
+export function resolveConcurrency(values, env = {}) {
+  const raw = values.concurrency ?? env.LIBHARNESS_BENCHMARK_CONCURRENCY;
+  if (raw != null) {
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 1)
+      throw new Error("--concurrency must be a positive integer");
+    return n;
+  }
+  const cores = availableParallelism?.() ?? 1;
+  return Math.min(CONCURRENCY_CEILING, Math.max(2, Math.floor(cores / 2)));
+}
+```
+
+Thread `concurrency: resolveConcurrency(values, env)` into the object
+`parseRunOptions` returns. Add a `concurrency` option to the `run` command in
+`benchmark-definition.js` (`type: "string"`, description naming the default
+formula and `LIBHARNESS_BENCHMARK_CONCURRENCY` env).
+
+**Default on the CI runner (recorded rationale).** On `ubuntu-latest` (2 vCPU)
+the formula resolves to `2` (`max(2, ⌊2/2⌋)`), and each cell spawns ~3 agent
+subprocesses — but those sessions are API-I/O-bound (waiting on the provider),
+not CPU-bound, so 2-way overlap on 2 cores is intentionally conservative and
+survivable. Layer-1 on the existing runner roughly halves single-job wall-clock;
+the bulk of the CI speedup for the outcome go-see comes from **Layer 2 sharding
+across machines** (Part 03), not from raising this in-job default. The
+`CONCURRENCY_CEILING` constant stays low for the same subprocess-fan-out reason.
+
+Verification: `resolveConcurrency({})` returns `> 1`;
+`resolveConcurrency({concurrency: "8"})` returns `8`; env fallback honored; the
+`run --help` golden (Step 7) shows `--concurrency`.
+
+## Step 6 — Rewire `run()` to the scheduler + single-writer drain
+
+Replace the serial nested loop with enumerate → schedule → single-writer drain;
+`run()` yields in completion order.
+
+- **Modified:** `src/benchmark/runner.js`
+
+- Accept `concurrency` in the constructor (default `1` only as a defensive
+  floor; the CLI always passes a resolved value).
+- Accept an optional `watchdogMs` constructor opt (default `AGENT_WATCHDOG_MS`)
+  and thread it to **both** sites that read the constant in `#runAgent` — the
+  cosmetic message (runner.js:372) and the `setTimeout` arg (runner.js:375) — so
+  the injection is not half-applied. The 20-min real-timer constant cannot fire
+  inside a unit test, so the "stall costs one slot" test (Step 7) depends on this
+  override; mirror the existing injectable `termGraceMs` pattern.
+- In `run()`, after staging and task filtering, build
+  `const cells = enumerateCells(tasks, this.runs)`.
+- Construct `new CellScheduler({ concurrency: this.concurrency, runCell: (cell) =>
+  this.#runOne(family, wm, cell.task, cell.runIndex, skillSetHash,
+  judgeProfilesDir) })`.
+- The drain loop is the **sole writer** of `results.jsonl`: `for await (const
+  record of scheduler.run(cells)) { await writeRecord(resultsStream, record);
+  yield record; }`. Delete the `for (task) for (runIndex)` loop. Keep the
+  `finally { resultsStream.end }`.
+- Update the file header comment: results stream in **completion order**, and
+  the single-writer drain is the durability + crash-safety mechanism (each
+  record appended the moment its cell settles; no sidecar).
+
+Verification: covered by Step 7's concurrency, parity, durability, and stall
+tests; existing `benchmark-e2e.integration.test.js` still passes at the default
+concurrency.
+
+## Step 7 — Tests for every L1 criterion
+
+Cover the Layer-1 success criteria with the fake-agent seam; no live LLM spend.
+
+- **Created:** `test/benchmark-scheduler.test.js`,
+  `test/benchmark-runner-concurrency.test.js`,
+  `test/benchmark-port-registry.test.js`
+- **Modified:** `test/golden/fit-benchmark/run-help.stdout.txt` (regenerated),
+  `test/work-tracker.test.js` (the existing host of the `parseRunOptions` option
+  tests) for `resolveConcurrency`.
+
+Each row maps to a spec § Success criteria [L1] line:
+
+| Criterion | Test |
+| --- | --- |
+| Bounded by `C` | fake seam records max-in-flight high-water-mark ≤ `C` over `M` cells |
+| On by default | a run with no `--concurrency` executes cells in parallel (high-water-mark > 1) |
+| Verdict unchanged | same fixture at `C=1` and `C=8` → byte-identical pass@k + per-task `n`/`c` |
+| Port collision-free | Step 2's `PortRegistry` concurrent-acquire test |
+| One record per cell | concurrent run of `tasks×runs` → `results.jsonl` parses to exactly that many schema-valid records, none interleaved/truncated |
+| Stall costs one slot | one cell forced to the watchdog with `C>1` (inject a short `watchdogMs`): others produce records, run completes, stalled cell is `agentError` |
+| Rate-limit backoff | **deferred** — covered when Step 4 lands after the design revision; the spec's "rate-limit failures back off" [L1] criterion is not met until then |
+
+**Substituted verification method (called out).** The spec and design phrase the
+bound as "completes in ≈ `ceil(M/C)` batch-durations against the clock seam." The
+mock clock advances a single shared virtual `now` and resolves `sleep` on the
+next microtask, so concurrent cells do not overlap in virtual time — a
+`ceil(M/C)` virtual-wall-clock assertion is not meaningful. These tests instead
+assert a **max-in-flight high-water-mark = `C`** and a **logical batch index**
+(`floor(completionOrder / C)`), which verify the same boundedness property. The
+fake-agent seam increments a shared counter on entry and decrements on exit
+around an `await` tick to record the high-water-mark. The "stall costs one slot"
+test injects a short `watchdogMs` (Step 6) so the stalled cell's watchdog fires
+in-test rather than at 20 min. Regenerate the `run-help` golden by running, from
+the `libharness` package root, `node ../../scripts/capture-cli-golden.mjs --bin
+fit-benchmark` (the script lives at the monorepo root; the default golden dir
+resolves against the package cwd), then confirm the `--verify` run is clean.
+
+Verification: `bun test test/*.test.js` green from `libraries/libharness`.

--- a/specs/2130-parallel-benchmark-execution/plan-a-01.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a-01.md
@@ -126,11 +126,12 @@ Nothing else in this plan depends on it. Under concurrency, a cell that hits a
 — costs one slot, not the run; the run still completes. The follow-up spec adds
 the retry on top of this scheduler.
 
-**Companion action (outside kata-plan):** trim spec 2130 to match — remove the
-"Rate-limit backpressure" in-scope row and the "Rate-limit failures back off"
-[L1] success criterion (via `kata-spec`), and remove the § Layer 1
-`retryRateLimited` row from design-a (via `kata-design`) — then open the
-follow-up spec for the backpressure mechanism.
+**Upstream trims (applied in this change):** spec 2130's "Rate-limit
+backpressure" in-scope row and "Rate-limit failures back off" [L1] criterion are
+removed, and design-a's § Layer 1 `retryRateLimited` row is deleted, so plan,
+spec, and design agree. A follow-up spec owns the backpressure mechanism (the
+detection signal, the owning component, and the trace/cost contract under
+retry).
 
 ## Step 5 — `resolveConcurrency` + `--concurrency` flag
 

--- a/specs/2130-parallel-benchmark-execution/plan-a-02.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a-02.md
@@ -1,0 +1,140 @@
+# Plan 2130-a Part 02 — Layer 2 (runner/report): sharding + recursive merge
+
+The runner gains a deterministic cell-granular shard selector and `report`'s
+record loader is rewritten to discover ledgers recursively, per
+[design 2130-a § Layer 2](design-a.md#layer-2--sharding-and-distribution-playwright-inspired).
+All changes in `libraries/libharness`; **depends on Part 01** (`enumerateCells`,
+completion-order `run()`). Run from the `libharness` package root.
+
+Libraries used: libharness. No new dependency.
+
+## Step 1 — `selectShard`
+
+Partition the enumerated cells round-robin at `(task, runIndex)` granularity.
+
+- **Modified:** `src/benchmark/runner.js`
+
+```js
+/**
+ * Round-robin partition: cell at position p runs iff p % N === i-1.
+ * 1-based i. Union over i∈1..N is the exact grid, each cell once; some
+ * shards may be empty when N > cells.length.
+ */
+export function selectShard(cells, i, total) {
+  return cells.filter((_, p) => p % total === i - 1);
+}
+```
+
+Verification: for `N ∈ {1,2,3,5}` over the fixture grid, the union of all
+shards equals `enumerateCells(...)` with no overlap and no gaps; `selectShard(c,
+i, N)` is empty for `i > c.length`.
+
+## Step 2 — `--shard=<i>/<N>` parsing and runner wiring
+
+A first-class shard selector applied before scheduling; an unsharded run is the
+identity `1/1`.
+
+- **Modified:** `src/commands/benchmark-run.js`, `src/commands/benchmark-definition.js`,
+  `src/benchmark/runner.js`
+
+- Add a `parseShard(raw)` helper in `benchmark-run.js`: parse `"<i>/<N>"` to
+  `{index, total}`, validate integers with `1 ≤ index ≤ total`; absent → `null`
+  (identity). Thread `shard` into `parseRunOptions`' result.
+- Add the `shard` option to the `run` command in `benchmark-definition.js`
+  (`type: "string"`, description: `i/N`, default whole family).
+- In `runner.js` `run()`: accept `shard` in the constructor; after
+  `enumerateCells`, apply `const selected = this.shard ? selectShard(cells,
+  this.shard.index, this.shard.total) : cells;` and pass `selected` to the
+  `CellScheduler`. A zero-cell selection writes an empty `results.jsonl` and
+  yields nothing — a valid run.
+- **Relax the run command's zero-record guard for deliberately-empty shards.**
+  Today `benchmark-run.js:57-64` returns exit 1 when zero records stream — the
+  correct signal for "nothing ran" on a normal run, but wrong for a high-index
+  shard that legitimately selects zero cells (design § Layer 2: "high-index
+  shards select **zero** cells — a valid run"). In `benchmark-run.js`, when
+  `opts.shard` is set and `count === 0`, exit `0` with a one-line stderr note
+  (`shard i/N selected no cells`) instead of the failure. An unsharded run, or a
+  sharded run that *should* have had cells, keeps the exit-1 guard. This is the
+  only consumer change the completion-order/shard contract forces on the guard.
+
+Verification: a `--shard=1/3` fixture run writes a partial `results.jsonl`
+containing only its assigned cells, each schema-valid; a `--shard=9/3`
+(`index > total`) is rejected at parse time; and an end-to-end
+`runBenchmarkRunCommand` call for a high-index shard that selects **zero** cells
+returns exit `0` with the stderr note (asserting the relaxed guard, not just the
+runner).
+
+## Step 3 — Recursive `loadRecords` merge in `report`
+
+`report` discovers every `results.jsonl` under `--input` recursively and unions
+records before grouping; the single-file read is deleted.
+
+- **Modified:** `src/benchmark/report.js`, `src/commands/benchmark-run.js`
+  (zero-record guard), `test/golden/fit-benchmark/cases.json` +
+  `report-empty.*` goldens
+
+- Rewrite `loadRecords(inputDir, runtime)` to walk `inputDir` recursively with a
+  **purpose-built generator** (skip `.git`/`node_modules`, match files named
+  `results.jsonl`), then parse/validate/union their lines exactly as today (same
+  skip-and-count-on-malformed behavior). Do **not** reuse `task-family.js`'s
+  private `walkFiles` — it resolves symlinks and is unexported; `report` wants a
+  plain `readdir`-recurse with no symlink following, so write a small local
+  walker. A lone root-level ledger is the trivial one-match case — one code path.
+  Delete the `join(inputDir, "results.jsonl")` single read.
+- An unexpected duplicate `(taskId, runIndex)` across shards is **warned and
+  counted** to stderr (the partition guarantees none, so a duplicate signals
+  misconfiguration), not silently merged — surface it; still include both in
+  the group so the count is honest.
+- **Pinned empty/missing contract (two distinct cases — do not conflate):**
+  - *Input dir exists but contains no `results.jsonl`* → zero records, empty
+    union, **exit 0** with an empty report. This is the design's "unions as the
+    empty set" (design-a.md:76) and the valid high-index-shard outcome.
+  - *Input dir is missing* → the recursive `readdir` ENOENT must propagate so
+    `report` still **errors (exit 1)** as today. Two implementer-blind details:
+    (a) do **not** wrap the top-level `readdir` in a defensive `try/catch` that
+    returns `[]` — that would silently flip the missing-dir case to exit 0 and
+    break the retained golden; only an *existing* empty dir yields the empty
+    union. (b) Preserve the deliberate stack collapse the current `loadRecords`
+    applies (report.js:445-448: `err.stack = \`Error: ${e.message}\``) so the CLI
+    error stays free of node-internal async frames; a raw `readdir` ENOENT would
+    regenerate to a noisier golden that passes `--verify` while regressing error
+    presentation. The existing `report-empty` golden points `--input` at
+    `test/golden/fit-benchmark/empty-runs`, **which does not exist on disk** — so
+    it stays the missing-dir error case. The error now originates from `readdir`
+    (not the old `readFile`); **regenerate `report-empty.*` and keep the `ENOENT`
+    transform** in `cases.json`; the exit code stays `1`.
+  - Cover the *exists-but-empty → exit 0* path with a new `report` unit test
+    (Step 4), since no golden exercises it.
+
+Verification: aggregating `N` shard partials (each from Step 2) yields pass@k
+**identical** to a single non-sharded run over the same cells and to the
+Part 01 `C`-only run of the same fixture; the regenerated `report-empty` golden
+is `--verify` clean.
+
+## Step 4 — Tests for the Layer-2 (runner/report) criteria
+
+- **Created:** `test/benchmark-shard.test.js`,
+  `test/benchmark-report-merge.test.js` (recursive discovery, nested-subdir
+  union, duplicate-warning, and exists-but-empty cases — split into its own
+  sibling because `benchmark-report.test.js` is already 389 LOC and these cases
+  would push it past the 400-LOC `test-file-shape` ceiling)
+- **Modified:** `test/work-tracker.test.js` (`parseShard` — this file already
+  hosts the `parseRunOptions` option tests), `test/golden/fit-benchmark/run-help.*`
+  (re-regenerated after Part 01: `--shard` lands in the same definition, so
+  this part re-runs the golden capture — see Part 01 Step 7 for the exact
+  package-root invocation)
+
+| Criterion | Test |
+| --- | --- |
+| Exact partition | Step 1's union/overlap/gap assertions for representative `N` |
+| Balanced + deterministic | each task's run indexes spread across shards for `N ≤ runs`; same `(family, runs, N)` → same partition on repeat |
+| Self-contained partial ledger | Step 2's per-shard `results.jsonl` validity |
+| `report` merges to one pass@k | Step 3's identical-pass@k assertion across `N` partials in nested subdirs |
+
+In `benchmark-report-merge.test.js`, seed `results.jsonl` in **nested
+subdirectories** (`shard-1/results.jsonl`, `shard-2/results.jsonl`) and assert
+the union groups correctly and the duplicate path warns; add a case for an
+**existing dir with no `results.jsonl`** asserting zero tasks / exit 0 (the
+pinned empty-union contract from Step 3, which no golden covers).
+
+Verification: `bun test test/*.test.js` green from `libraries/libharness`.

--- a/specs/2130-parallel-benchmark-execution/plan-a-02.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a-02.md
@@ -95,7 +95,7 @@ records before grouping; the single-file read is deleted.
     returns `[]` — that would silently flip the missing-dir case to exit 0 and
     break the retained golden; only an *existing* empty dir yields the empty
     union. (b) Preserve the deliberate stack collapse the current `loadRecords`
-    applies (report.js:445-448: `err.stack = \`Error: ${e.message}\``) so the CLI
+    applies (report.js:442-448: `err.stack = \`Error: ${e.message}\``) so the CLI
     error stays free of node-internal async frames; a raw `readdir` ENOENT would
     regenerate to a noisier golden that passes `--verify` while regressing error
     presentation. The existing `report-empty` golden points `--input` at

--- a/specs/2130-parallel-benchmark-execution/plan-a-03.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a-03.md
@@ -1,0 +1,120 @@
+# Plan 2130-a Part 03 — Layer 2 (distribution): action, reusable workflow, migration, docs
+
+Composes the Part 01/02 CLI surfaces into cross-machine sharding, per
+[design 2130-a § Layer 2](design-a.md#layer-2--sharding-and-distribution-playwright-inspired)
+and § `fit-bootstrap` and the matrix. **Depends on Parts 01 and 02** — the
+`--concurrency`, `--shard`, and recursive-`report` surfaces must be merged and
+green first. Spans the `forwardimpact/fit-benchmark` sibling, `.github/`, and
+`websites/`.
+
+Libraries used: none (CI + docs).
+
+## Cross-sibling coordination (precondition)
+
+The composite action and the reusable workflow live in the
+`forwardimpact/fit-benchmark` **sibling repo**, not this tree. The new
+`fit-benchmark → fit-bootstrap` `uses:` edge and the `fit-bootstrap`
+parallel-safety requirement touch shared CI governed by
+[`.github/CLAUDE.md`](../../.github/CLAUDE.md). Per
+[spec § Path to approval](spec.md): coordinate with the sibling owners, land the
+sibling changes as **append-only patch tags**, and consume them here via a
+SHA-pinned `uses:` bumped through Dependabot — `v1` is never moved to deliver
+this. Steps 1–2 below state the required sibling interface; Steps 3–5 are the
+monorepo-side changes that consume it.
+
+## Step 1 — Composite action gains `mode` + shard inputs (sibling)
+
+One action, two operations, no legacy path.
+
+- **Sibling:** `forwardimpact/fit-benchmark/action.yml` (+ its action script)
+
+Add inputs: `concurrency`, `shard-index`, `shard-total`, `mode` (`run`|`merge`,
+default `run`). `mode: run` executes one shard —
+`fit-benchmark run --concurrency=<c> --shard=<shard-index>/<shard-total>` — and
+uploads a **shard-scoped** artifact `benchmark-shard-<shard-index>` (the shard
+index plays the `case:` disambiguation role from `.github/CLAUDE.md`). `mode:
+merge` runs `fit-benchmark report` over the downloaded shard artifacts and writes
+the step summary + combined artifact. An unsharded run is the identity
+`shard-index: 1, shard-total: 1`. `IS_SANDBOX=1` stays on the `run` agent step;
+`merge` spawns no agent.
+
+Verification (sibling CI): action smoke for `mode: run --shard=1/2` produces
+`benchmark-shard-1`; `mode: merge` over two shard artifacts emits one report.
+
+## Step 2 — Reusable workflow `benchmark.yml` (sibling)
+
+A `workflow_call` workflow owns the matrix a step-level action cannot.
+
+- **Sibling (new):** `forwardimpact/fit-benchmark/.github/workflows/benchmark.yml`
+
+Topology: a `prepare` job emits `[1..N]` as JSON from the `shard-total` input; a
+`shard` matrix job (`matrix: fromJSON(needs.prepare.outputs.shards)`) runs
+`fit-bootstrap@<sha>` (full env) then the action `mode: run
+--shard=<i>/<shard-total>`, uploading `benchmark-shard-<i>`; a `merge` job
+(`needs: shard`) uses **minimal `setup-node` only — no `fit-bootstrap`**,
+downloads `benchmark-shard-*`, and runs the action `mode: merge`. Inputs mirror
+the action plus `shard-total`; `ANTHROPIC_API_KEY` is a `secret`. External
+consumers reference `@v1`; the monorepo SHA-pins it (Step 3).
+
+`fit-bootstrap` parallel-safety (coordinated with its owner): cache keys are
+shard-independent (reads only) and `N` concurrent wiki-token mints are
+tolerated — confirmed before `eval-kata.yml` migrates.
+
+Verification (sibling CI): a `shard-total=3` dispatch produces 3 shard jobs + 1
+merge job; the merge downloads all 3 artifacts and emits one combined report.
+
+## Step 3 — Migrate `eval-kata.yml` to the reusable workflow
+
+The monorepo's own eval calls the reusable workflow; its bespoke single-job
+invocation is deleted, not kept alongside.
+
+- **Modified:** `.github/workflows/eval-kata.yml`
+
+Replace the `benchmark` job's `steps:` (checkout + `fit-bootstrap` +
+`fit-benchmark` action) with a job-level
+`uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@<sha>` (SHA
+of the patch-tagged sibling release, `# v1` marker), passing `with:` (family,
+runs, max-turns, judge-profile, `shard-total`, optional `concurrency`) and
+`secrets: { ANTHROPIC_API_KEY }`. Carry the `filesystem` work-tracker as a
+workflow input or document it as the reusable workflow's env contract. Drop the
+`timeout-minutes: "360"` workaround — sharding, not a raised ceiling, is the
+fix. **Refresh the stale `env:`/budget comment** (eval-kata.yml:18-36) which
+still says "runs:5 × 4 tasks": the family is 6 tasks, and the cancellation
+narrative is superseded by the sharding fix — replace it with a one-line pointer
+to the reusable-workflow fan-out.
+
+`.github/CLAUDE.md` needs **no enumeration edit**: the
+`enum:sibling-composite-actions` count (`Five`) is unchanged — `fit-benchmark`
+is still one sibling, now also shipping a reusable workflow. Confirm only that
+the `# v1` SHA-pin note still describes the new job-level `uses:` line.
+
+Verification: `actionlint` clean; `bunx coaligned` / context checks pass and the
+enum markers resolve; a manual `workflow_dispatch` fans out the configured
+shards and finishes with a verdict (the outcome go-see in spec § Success
+criteria).
+
+## Step 4 — Documentation (technical-writer)
+
+Document the two new axes and the reusable-workflow path for external readers.
+
+- **Modified:**
+  `websites/fit/docs/libraries/prove-changes/run-benchmark/ci-workflow/index.md`,
+  `websites/fit/docs/libraries/prove-changes/run-benchmark/index.md`
+
+- `run-benchmark/index.md`: document `--concurrency` (on by default, the
+  resolution order flag > `LIBHARNESS_BENCHMARK_CONCURRENCY` > CPU-aware
+  default) and `--shard=<i>/<N>` (per-shard partial ledger; `report --input`
+  merges recursively across shard dirs).
+- `ci-workflow/index.md`: add the reusable-workflow usage (`uses:
+  forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@v1` with
+  `shard-total`) alongside the existing single-job action usage; explain the
+  fan-out + merge model and that the merge job carries no agent scaffold. Use
+  fully-qualified public URLs and `npx`/external phrasing per
+  [libraries/CLAUDE.md](../../libraries/CLAUDE.md).
+
+No new doc slug, so the skill↔CLI documentation-parity test
+(`benchmark-parity.test.js`) needs no change unless a new `documentation` entry
+is added; if one is, mirror it in `benchmark-definition.js` and the
+`fit-benchmark` SKILL.md in the same order.
+
+Verification: `fit-doc` build clean; links resolve; parity test green.

--- a/specs/2130-parallel-benchmark-execution/plan-a-03.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a-03.md
@@ -1,26 +1,35 @@
-# Plan 2130-a Part 03 — Layer 2 (distribution): action, reusable workflow, migration, docs
+# Plan 2130-a Part 03 — Layer 2 (distribution): sibling action + workflow, migration, skill, docs
 
 Composes the Part 01/02 CLI surfaces into cross-machine sharding, per
 [design 2130-a § Layer 2](design-a.md#layer-2--sharding-and-distribution-playwright-inspired)
 and § `fit-bootstrap` and the matrix. **Depends on Parts 01 and 02** — the
 `--concurrency`, `--shard`, and recursive-`report` surfaces must be merged and
-green first. Spans the `forwardimpact/fit-benchmark` sibling, `.github/`, and
-`websites/`.
+green first. Spans the `forwardimpact/fit-benchmark` sibling, `.github/`,
+`.claude/skills/`, and `websites/`.
 
 Libraries used: none (CI + docs).
 
-## Cross-sibling coordination (precondition)
+## Sibling-edit mechanics (how Steps 1–3 land)
 
-The composite action and the reusable workflow live in the
-`forwardimpact/fit-benchmark` **sibling repo**, not this tree. The new
-`fit-benchmark → fit-bootstrap` `uses:` edge and the `fit-bootstrap`
-parallel-safety requirement touch shared CI governed by
-[`.github/CLAUDE.md`](../../.github/CLAUDE.md). Per
-[spec § Path to approval](spec.md): coordinate with the sibling owners, land the
-sibling changes as **append-only patch tags**, and consume them here via a
-SHA-pinned `uses:` bumped through Dependabot — `v1` is never moved to deliver
-this. Steps 1–2 below state the required sibling interface; Steps 3–5 are the
-monorepo-side changes that consume it.
+The composite action and reusable workflow live in the
+`forwardimpact/fit-benchmark` sibling repo. Per
+[`.github/CLAUDE.md`](../../.github/CLAUDE.md), the environment's `GH_TOKEN` +
+`gh` CLI carry **content read/write**, so these edits are made directly against
+the sibling — not delegated:
+
+1. Edit the sibling on a branch and merge to its `main` through the sibling's
+   branch protection (`gh` API / a PR on the sibling).
+2. **Tag the interface before the consumer uses it** — cut an **append-only**
+   `v1.0.x` patch tag on the sibling release commit (`gh release`/`git tag`;
+   tags are content-level, no admin write). Never move `v1` — it is advisory for
+   external consumers only.
+3. Consume in the monorepo by **SHA-pinning** the new tag's commit on the
+   `uses:` line with a `# v1` marker (Step 5). Dependabot's weekly sweep would
+   also open this bump; doing it inline keeps the migration atomic.
+
+Token scope is content-level only: if any step needs admin write (e.g. changing
+sibling branch-protection), stop and route to `security-engineer` — do not widen
+the standing token.
 
 ## Step 1 — Composite action gains `mode` + shard inputs (sibling)
 
@@ -36,7 +45,8 @@ index plays the `case:` disambiguation role from `.github/CLAUDE.md`). `mode:
 merge` runs `fit-benchmark report` over the downloaded shard artifacts and writes
 the step summary + combined artifact. An unsharded run is the identity
 `shard-index: 1, shard-total: 1`. `IS_SANDBOX=1` stays on the `run` agent step;
-`merge` spawns no agent.
+`merge` spawns no agent. Existing inputs (`summary`, `upload-results`,
+`artifact-name`, `timeout-minutes`, `k`, `format`) are preserved.
 
 Verification (sibling CI): action smoke for `mode: run --shard=1/2` produces
 `benchmark-shard-1`; `mode: merge` over two shard artifacts emits one report.
@@ -53,17 +63,56 @@ Topology: a `prepare` job emits `[1..N]` as JSON from the `shard-total` input; a
 --shard=<i>/<shard-total>`, uploading `benchmark-shard-<i>`; a `merge` job
 (`needs: shard`) uses **minimal `setup-node` only — no `fit-bootstrap`**,
 downloads `benchmark-shard-*`, and runs the action `mode: merge`. Inputs mirror
-the action plus `shard-total`; `ANTHROPIC_API_KEY` is a `secret`. External
-consumers reference `@v1`; the monorepo SHA-pins it (Step 3).
-
-`fit-bootstrap` parallel-safety (coordinated with its owner): cache keys are
-shard-independent (reads only) and `N` concurrent wiki-token mints are
-tolerated — confirmed before `eval-kata.yml` migrates.
+the action plus `shard-total`; `ANTHROPIC_API_KEY` is a `secret`. The internal
+`fit-bootstrap@<sha>` pin is the sibling's own (a sibling's internal `uses:` is
+governed by the sibling per `.github/CLAUDE.md`). External consumers reference
+`@v1`; the monorepo SHA-pins it (Step 5).
 
 Verification (sibling CI): a `shard-total=3` dispatch produces 3 shard jobs + 1
 merge job; the merge downloads all 3 artifacts and emits one combined report.
 
-## Step 3 — Migrate `eval-kata.yml` to the reusable workflow
+## Step 3 — Confirm (or harden) `fit-bootstrap` parallel-safety (sibling)
+
+`benchmark.yml` runs `fit-bootstrap` in `N` concurrent shard jobs, so it must be
+shard-independent.
+
+- **Sibling:** `forwardimpact/fit-bootstrap` (read; edit only if unsafe)
+
+Read-only confirmation against the live `fit-bootstrap`: cache keys are
+read-only/shard-stable (no per-run cache *writes* that collide) and `N`
+concurrent wiki-checkout token mints are tolerated. If already safe, no edit is
+needed — record the confirmation and proceed.
+
+If a collision exists (e.g. a shared cache-write key), **do not edit
+`fit-bootstrap` inline.** Spec § Path to approval (spec.md:207-210) reserves
+cross-sibling `fit-bootstrap` changes for coordination "with the owners of those
+siblings." Route the fix to its owner; it lands as that sibling's own
+append-only patch tag, then the ordered sub-sequence is: (1) tag fit-bootstrap,
+(2) bump `benchmark.yml`'s internal `fit-bootstrap@<sha>` pin (Step 2), (3) tag
+fit-benchmark (Step 4). This dependency gates Step 4 only when a fix is needed.
+
+Verification: a `shard-total=3` dispatch shows three independent bootstrap setups
+with no cache-write contention or token-mint failure in the job logs.
+
+## Step 4 — Tag the sibling and pin it
+
+Make the new interface consumable.
+
+- **Sibling:** the next append-only `v1.0.N` patch tag on the fit-benchmark
+  release commit (after Steps 1–3 merge to its `main`).
+
+Resolve the concrete version: list existing `v1.0.*` tags on the sibling and cut
+`N+1` (do **not** use a literal `v1.0.x`). Record the new tag's commit SHA for
+Step 5. Do this **before** Step 5 references it (interface tagged before the
+consumer). Do not touch the `v1` tag — it is human-only and moving it is never
+how a change reaches the monorepo (`.github/CLAUDE.md`).
+
+Verification: `gh api repos/forwardimpact/fit-benchmark/git/refs/tags/v1.0.<N>`
+resolves to the release commit, and that commit is **reachable from the
+sibling's `main`** (the append-only-tag check — *not* the `v1`-descendant
+relation, which is the separate human-only `v1`-move check).
+
+## Step 5 — Migrate `eval-kata.yml` to the reusable workflow
 
 The monorepo's own eval calls the reusable workflow; its bespoke single-job
 invocation is deleted, not kept alongside.
@@ -72,19 +121,22 @@ invocation is deleted, not kept alongside.
 
 Replace the `benchmark` job's `steps:` (checkout + `fit-bootstrap` +
 `fit-benchmark` action) with a job-level
-`uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@<sha>` (SHA
-of the patch-tagged sibling release, `# v1` marker), passing `with:` (family,
-runs, max-turns, judge-profile, `shard-total`, optional `concurrency`) and
-`secrets: { ANTHROPIC_API_KEY }`. Carry the `filesystem` work-tracker as a
-workflow input or document it as the reusable workflow's env contract. Drop the
-`timeout-minutes: "360"` workaround — sharding, not a raised ceiling, is the
-fix. **Refresh the stale `env:`/budget comment** (eval-kata.yml:18-36) which
-still says "runs:5 × 4 tasks": the family is 6 tasks, and the cancellation
-narrative is superseded by the sharding fix — replace it with a one-line pointer
-to the reusable-workflow fan-out.
+`uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@<sha>` (the
+Step 4 SHA, `# v1` marker), passing `with:` (family, runs, max-turns,
+judge-profile, `shard-total`, optional `concurrency` — the design's input list,
+design-a.md:141-142) and `secrets: { ANTHROPIC_API_KEY }`. The `filesystem`
+work-tracker is **not** a new workflow input (the design's input list omits it);
+set it as the job's `env:` (the reusable workflow's env contract), matching how
+`eval-kata.yml` carries it today. Drop the `timeout-minutes: "360"` workaround —
+sharding, not a raised ceiling, is the fix. **Refresh the stale `env:`/budget
+comment** (eval-kata.yml:18-36) which still says "runs:5 × 4 tasks": the family
+is 6 tasks and the cancellation narrative is superseded — replace it with a
+one-line pointer to the reusable-workflow fan-out.
 
-`.github/CLAUDE.md` needs **no enumeration edit**: the
-`enum:sibling-composite-actions` count (`Five`) is unchanged — `fit-benchmark`
+The inline SHA pin makes the next Dependabot SHA-bump PR for this `uses:` a
+no-op against the same target; let it close itself or close it manually — do not
+leave it dangling. `.github/CLAUDE.md` needs **no enumeration edit**: the
+`enum:sibling-composite-actions:count` (`Five`) is unchanged — `fit-benchmark`
 is still one sibling, now also shipping a reusable workflow. Confirm only that
 the `# v1` SHA-pin note still describes the new job-level `uses:` line.
 
@@ -93,7 +145,39 @@ enum markers resolve; a manual `workflow_dispatch` fans out the configured
 shards and finishes with a verdict (the outcome go-see in spec § Success
 criteria).
 
-## Step 4 — Documentation (technical-writer)
+## Step 6 — Update the `fit-benchmark` skill (action + workflow)
+
+Keep the published skill's CI coverage current with the new surfaces.
+
+- **Modified:** `.claude/skills/fit-benchmark/SKILL.md`
+
+Extend the existing `## GitHub Action` section: note the new action inputs
+(`concurrency`, `shard-index`, `shard-total`, `mode`), and add a short
+**reusable-workflow** snippet showing cross-machine sharding from one input:
+
+```yaml
+jobs:
+  benchmark:
+    uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@v1
+    with:
+      family: ./benchmarks/my-family
+      shard-total: 4
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+Keep it brief and generic per `.claude/skills/CLAUDE.md` (no monorepo paths;
+`@v1` form is allowed; one or two lines on the fan-out → merge model and that
+`report --input` merges shard ledgers recursively). This edits the prose body
+only, not the `## Documentation` list, so the `benchmark-parity.test.js`
+documentation-parity gate is unaffected (it checks only the Documentation
+list ↔ CLI `documentation` array). The skill-genericity invariant does not gate
+`fit-*` skills, so the only mechanical gate here is parity — leave it untouched.
+
+Verification: `benchmark-parity.test.js` green; the snippet uses only
+externally-valid references.
+
+## Step 7 — Documentation (technical-writer)
 
 Document the two new axes and the reusable-workflow path for external readers.
 
@@ -112,9 +196,16 @@ Document the two new axes and the reusable-workflow path for external readers.
   fully-qualified public URLs and `npx`/external phrasing per
   [libraries/CLAUDE.md](../../libraries/CLAUDE.md).
 
-No new doc slug, so the skill↔CLI documentation-parity test
-(`benchmark-parity.test.js`) needs no change unless a new `documentation` entry
-is added; if one is, mirror it in `benchmark-definition.js` and the
-`fit-benchmark` SKILL.md in the same order.
+Both target guides already exist (and are already listed in SKILL.md's
+`## Documentation` and `benchmark-definition.js`), so this updates existing pages
+— no new slug, no parity change. Keep the same two `## Documentation` entries.
 
-Verification: `fit-doc` build clean; links resolve; parity test green.
+Verification: `fit-doc` build clean; links resolve; `benchmark-parity.test.js`
+green.
+
+## Execution within Part 03
+
+Steps 1–4 are sibling-side and sequential (action + workflow + bootstrap check →
+tag). Step 5 (eval-kata migration) consumes the Step 4 tag. Steps 6–7 (skill +
+docs) depend only on the finished input/flag surface and can run in parallel with
+5 — route Step 7 to `technical-writer`, Steps 1–6 to an engineering agent.

--- a/specs/2130-parallel-benchmark-execution/plan-a.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a.md
@@ -6,25 +6,18 @@ three independently executable parts; each part is a clean break per
 `allocatePort`, and the single-file `loadRecords` read are deleted, not branched.
 
 > **Scope note — rate-limit backpressure descoped (2026-06-27).** The review
-> panel established that the design's Layer-1 backpressure directive is not
-> executable as written (a 429 does not throw — `AgentRunner.#consumeQuery`
-> returns it as a `{success:false, error}` field — and the robust retry seam is
-> the cross-cutting shared `AgentRunner` query call). By decision, backpressure is
-> **split to a follow-up spec**; this plan ships Layer 1 (concurrency, ports,
-> ledger, scheduler) and Layer 2 (sharding, merge, distribution). Under
-> concurrency a 429'd cell records an `agentError` and costs one slot, not the
-> run — the run still completes.
->
-> **Hard precondition on approval.** Until the companion trims land, the on-disk
-> spec.md (the "Rate-limit backpressure" in-scope row + the "rate-limit failures
-> back off" [L1] criterion) and design-a.md (§ Layer 1 `retryRateLimited` row)
-> still assert the descoped items, so this plan **contradicts its still-current
-> spec/design** and **must not be approved** (no `plan approved` STATUS write)
-> in that state. The companion edits — outside kata-plan — are: return spec 2130
-> to draft and trim those two spec items (`kata-spec`), remove the design's
-> § Layer 1 `retryRateLimited` row (`kata-design`), and open the follow-up
-> backpressure spec. Only once spec/design no longer carry backpressure is this
-> plan internally consistent and approvable. See [Part 01 Step 4](plan-a-01.md).
+> panel established that the design's Layer-1 backpressure directive was not
+> executable as written (a 429 does not throw — the agent runner returns it as a
+> result field — and the robust retry seam is the cross-cutting shared
+> agent-runner query call). By decision, backpressure is **split to a follow-up
+> spec**; this plan ships Layer 1 (concurrency, ports, ledger, scheduler) and
+> Layer 2 (sharding, merge, distribution). Under concurrency a 429'd cell records
+> an `agentError` and costs one slot, not the run — the run still completes.
+> **This change applies the descope to the upstream artifacts** in the same
+> branch: spec.md (the in-scope backpressure row + the "rate-limit failures back
+> off" [L1] criterion) and design-a.md (§ Layer 1 `retryRateLimited` row) are
+> trimmed, so plan, spec, and design agree. A follow-up spec adds backpressure on
+> top of this scheduler. See [Part 01 Step 4](plan-a-01.md).
 
 ## Approach
 

--- a/specs/2130-parallel-benchmark-execution/plan-a.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a.md
@@ -5,18 +5,19 @@ three independently executable parts; each part is a clean break per
 [CONTRIBUTING § Clean breaks](../../CONTRIBUTING.md#read-do) — the serial loop,
 `allocatePort`, and the single-file `loadRecords` read are deleted, not branched.
 
-> **Open blocker — design revision required before full approval.** The review
-> panel confirmed that the design's Layer-1 **rate-limit backpressure** directive
-> rests on a false premise: a 429 does not throw at the agent-session boundary —
-> `AgentRunner.#consumeQuery` (agent-runner.js:190-196) catches it and returns a
-> `{success:false, error}` field — and the robust retry seam (the shared
-> `AgentRunner` query call) is cross-cutting, a WHICH/WHERE decision the design
-> must own. **Spec 2130 returns to `kata-design`** to revise the § Layer 1
-> backpressure row (detection signal, owning component, trace/cost contract under
-> retry). Every other step in this plan is independent of backpressure and is
-> execution-ready; only [Part 01 Step 4](plan-a-01.md) waits on the amended
-> design. Until then the spec's "rate-limit failures back off" [L1] criterion is
-> unmet, so this plan is not yet approvable.
+> **Scope note — rate-limit backpressure descoped (2026-06-27).** The review
+> panel established that the design's Layer-1 backpressure directive is not
+> executable as written (a 429 does not throw — `AgentRunner.#consumeQuery`
+> returns it as a `{success:false, error}` field — and the robust retry seam is
+> the cross-cutting shared `AgentRunner` query call). By decision, backpressure is
+> **split to a follow-up spec**; this plan ships Layer 1 (concurrency, ports,
+> ledger, scheduler) and Layer 2 (sharding, merge, distribution). Under
+> concurrency a 429'd cell records an `agentError` and costs one slot, not the
+> run — the run still completes. **Companion edits, outside kata-plan:** trim
+> spec 2130's backpressure in-scope row + "rate-limit failures back off" [L1]
+> criterion (`kata-spec`) and design-a's § Layer 1 `retryRateLimited` row
+> (`kata-design`), then open the follow-up spec. This plan is approvable once
+> those trims land. See [Part 01 Step 4](plan-a-01.md).
 
 ## Approach
 
@@ -33,7 +34,7 @@ schema, and pass@k math are untouched throughout.
 
 | Part | Scope | Tree | Depends on |
 | --- | --- | --- | --- |
-| [01](plan-a-01.md) | Layer 1 — in-process concurrency: `enumerateCells`, `CellScheduler`, single-writer drain, `PortRegistry`, `resolveConcurrency` (Step 4 rate-limit backpressure **blocked on design revision**) | `libraries/libharness` | — |
+| [01](plan-a-01.md) | Layer 1 — in-process concurrency: `enumerateCells`, `CellScheduler`, single-writer drain, `PortRegistry`, `resolveConcurrency` (Step 4 rate-limit backpressure **descoped** → follow-up spec) | `libraries/libharness` | — |
 | [02](plan-a-02.md) | Layer 2 (runner/report) — `selectShard`, `--shard` parsing, recursive `loadRecords` merge | `libraries/libharness` | 01 (`enumerateCells`) |
 | [03](plan-a-03.md) | Layer 2 (distribution) — composite-action `mode`/shard inputs, reusable workflow, `eval-kata.yml` migration, `fit-bootstrap` parallel-safety coordination, docs | `forwardimpact/fit-benchmark` sibling, `.github/`, `websites/` | 01, 02 (CLI flags) |
 

--- a/specs/2130-parallel-benchmark-execution/plan-a.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a.md
@@ -1,0 +1,88 @@
+# Plan 2130-a — Parallel Benchmark Execution
+
+Executes [design 2130-a](design-a.md) for [spec 2130](spec.md). Decomposed into
+three independently executable parts; each part is a clean break per
+[CONTRIBUTING § Clean breaks](../../CONTRIBUTING.md#read-do) — the serial loop,
+`allocatePort`, and the single-file `loadRecords` read are deleted, not branched.
+
+> **Open blocker — design revision required before full approval.** The review
+> panel confirmed that the design's Layer-1 **rate-limit backpressure** directive
+> rests on a false premise: a 429 does not throw at the agent-session boundary —
+> `AgentRunner.#consumeQuery` (agent-runner.js:190-196) catches it and returns a
+> `{success:false, error}` field — and the robust retry seam (the shared
+> `AgentRunner` query call) is cross-cutting, a WHICH/WHERE decision the design
+> must own. **Spec 2130 returns to `kata-design`** to revise the § Layer 1
+> backpressure row (detection signal, owning component, trace/cost contract under
+> retry). Every other step in this plan is independent of backpressure and is
+> execution-ready; only [Part 01 Step 4](plan-a-01.md) waits on the amended
+> design. Until then the spec's "rate-limit failures back off" [L1] criterion is
+> unmet, so this plan is not yet approvable.
+
+## Approach
+
+Land Layer 1 (in-process concurrency) first because it introduces
+`enumerateCells` — the load-bearing task-major/runIndex-minor ordering that
+Layer 2's shard partition depends on — and converts `run()` to completion-order
+streaming. Layer 2's runner/report work (shard selector + recursive merge) then
+builds on that enumeration. The CI distribution layer (composite-action `mode`,
+reusable workflow, `eval-kata.yml` migration) lands last because it composes the
+finished CLI flags. The per-cell lifecycle (`#runOne`), the `ResultRecord`
+schema, and pass@k math are untouched throughout.
+
+## Part index
+
+| Part | Scope | Tree | Depends on |
+| --- | --- | --- | --- |
+| [01](plan-a-01.md) | Layer 1 — in-process concurrency: `enumerateCells`, `CellScheduler`, single-writer drain, `PortRegistry`, `resolveConcurrency` (Step 4 rate-limit backpressure **blocked on design revision**) | `libraries/libharness` | — |
+| [02](plan-a-02.md) | Layer 2 (runner/report) — `selectShard`, `--shard` parsing, recursive `loadRecords` merge | `libraries/libharness` | 01 (`enumerateCells`) |
+| [03](plan-a-03.md) | Layer 2 (distribution) — composite-action `mode`/shard inputs, reusable workflow, `eval-kata.yml` migration, `fit-bootstrap` parallel-safety coordination, docs | `forwardimpact/fit-benchmark` sibling, `.github/`, `websites/` | 01, 02 (CLI flags) |
+
+## Execution
+
+- **Sequencing.** 01 → 02 are sequential (02 consumes `enumerateCells` and the
+  completion-order contract). 03 is sequential after 02 — it requires the
+  `--concurrency`, `--shard`, and recursive-`report` surfaces to exist and be
+  green before the action and workflow can compose them.
+- **Within a part**, steps are sequential as listed.
+- **Agent routing.** 01 and 02 → an engineering agent (`staff-engineer` or a
+  delegate); they are pure `libharness` code + tests. 03 splits: the
+  action/workflow/`eval-kata.yml` changes → an engineering agent who coordinates
+  the cross-sibling edge per § Cross-sibling coordination below; the
+  `websites/` guide updates → `technical-writer`.
+- **Cross-sibling coordination (gates 03).** The composite action and the new
+  `benchmark.yml` reusable workflow live in the `forwardimpact/fit-benchmark`
+  sibling, and the new `fit-benchmark → fit-bootstrap` `uses:` edge plus the
+  `fit-bootstrap` parallel-safety requirement touch shared CI governed by
+  [`.github/CLAUDE.md`](../../.github/CLAUDE.md). Per spec § Path to approval,
+  these are coordinated with the sibling owners and land as append-only patch
+  tags on the siblings, consumed here via SHA-pinned `uses:` (Dependabot bump),
+  before `eval-kata.yml` migrates. Part 03 states the required interface; the
+  sibling edits themselves are out of this monorepo's tree.
+
+## Risks
+
+- **Clock seam can't model wall-clock parallelism.** `createMockClock`'s
+  `setTimeout`/`sleep` advance a single shared virtual `now` and resolve on the
+  next microtask, so concurrent fake cells do not "overlap" in virtual time.
+  Verifying "bounded by `C`" must therefore assert a **max-in-flight counter**
+  maintained by the fake-agent seam (high-water-mark ≤ `C`) and a logical batch
+  index, not a virtual-clock wall time. Part 01 specifies this seam.
+- **`report` input-dir behavior splits into two pinned cases.** Recursive
+  discovery replaces the `<dir>/results.jsonl` `readFile`: an *existing* dir with
+  no ledger now yields the empty union (exit 0), while a *missing* dir still
+  errors (exit 1) via an uncaught `readdir` ENOENT. The `report-empty` golden
+  (a missing dir) keeps exit 1 but its error shape changes — Part 02 regenerates
+  it, preserves the deliberate stack-collapse, and covers the existing-empty
+  exit-0 path with a unit test.
+- **Concurrent teardown of disjoint process groups.** `WorkdirManager.teardown`
+  signals `-pgid` and probes the port; under concurrency several teardowns run
+  at once. They target disjoint process groups and distinct ports, but Part 01
+  must confirm no shared mutable state in the teardown path (it currently uses
+  only locals + `runtime`).
+
+Libraries used: libharness (benchmark runner, report, workdir, result schema),
+libutil (production runtime clock), libmock (`createMockClock` test seam),
+libconfig (benchmark config). No new dependency — the permit semaphore is local
+to `scheduler.js`.
+
+— Staff Engineer 🛠️

--- a/specs/2130-parallel-benchmark-execution/plan-a.md
+++ b/specs/2130-parallel-benchmark-execution/plan-a.md
@@ -13,11 +13,18 @@ three independently executable parts; each part is a clean break per
 > **split to a follow-up spec**; this plan ships Layer 1 (concurrency, ports,
 > ledger, scheduler) and Layer 2 (sharding, merge, distribution). Under
 > concurrency a 429'd cell records an `agentError` and costs one slot, not the
-> run — the run still completes. **Companion edits, outside kata-plan:** trim
-> spec 2130's backpressure in-scope row + "rate-limit failures back off" [L1]
-> criterion (`kata-spec`) and design-a's § Layer 1 `retryRateLimited` row
-> (`kata-design`), then open the follow-up spec. This plan is approvable once
-> those trims land. See [Part 01 Step 4](plan-a-01.md).
+> run — the run still completes.
+>
+> **Hard precondition on approval.** Until the companion trims land, the on-disk
+> spec.md (the "Rate-limit backpressure" in-scope row + the "rate-limit failures
+> back off" [L1] criterion) and design-a.md (§ Layer 1 `retryRateLimited` row)
+> still assert the descoped items, so this plan **contradicts its still-current
+> spec/design** and **must not be approved** (no `plan approved` STATUS write)
+> in that state. The companion edits — outside kata-plan — are: return spec 2130
+> to draft and trim those two spec items (`kata-spec`), remove the design's
+> § Layer 1 `retryRateLimited` row (`kata-design`), and open the follow-up
+> backpressure spec. Only once spec/design no longer carry backpressure is this
+> plan internally consistent and approvable. See [Part 01 Step 4](plan-a-01.md).
 
 ## Approach
 
@@ -36,7 +43,7 @@ schema, and pass@k math are untouched throughout.
 | --- | --- | --- | --- |
 | [01](plan-a-01.md) | Layer 1 — in-process concurrency: `enumerateCells`, `CellScheduler`, single-writer drain, `PortRegistry`, `resolveConcurrency` (Step 4 rate-limit backpressure **descoped** → follow-up spec) | `libraries/libharness` | — |
 | [02](plan-a-02.md) | Layer 2 (runner/report) — `selectShard`, `--shard` parsing, recursive `loadRecords` merge | `libraries/libharness` | 01 (`enumerateCells`) |
-| [03](plan-a-03.md) | Layer 2 (distribution) — composite-action `mode`/shard inputs, reusable workflow, `eval-kata.yml` migration, `fit-bootstrap` parallel-safety coordination, docs | `forwardimpact/fit-benchmark` sibling, `.github/`, `websites/` | 01, 02 (CLI flags) |
+| [03](plan-a-03.md) | Layer 2 (distribution) — sibling action `mode`/shard inputs + reusable workflow (edited via `gh`/`GH_TOKEN`, append-only patch tag), `fit-bootstrap` parallel-safety check, `eval-kata.yml` migration, `fit-benchmark` SKILL.md, docs | `forwardimpact/fit-benchmark`(+`fit-bootstrap`) siblings, `.github/`, `.claude/skills/`, `websites/` | 01, 02 (CLI flags) |
 
 ## Execution
 
@@ -46,19 +53,24 @@ schema, and pass@k math are untouched throughout.
   green before the action and workflow can compose them.
 - **Within a part**, steps are sequential as listed.
 - **Agent routing.** 01 and 02 → an engineering agent (`staff-engineer` or a
-  delegate); they are pure `libharness` code + tests. 03 splits: the
-  action/workflow/`eval-kata.yml` changes → an engineering agent who coordinates
-  the cross-sibling edge per § Cross-sibling coordination below; the
-  `websites/` guide updates → `technical-writer`.
-- **Cross-sibling coordination (gates 03).** The composite action and the new
+  delegate); they are pure `libharness` code + tests. 03: the sibling
+  action/workflow edits, the `fit-bootstrap` parallel-safety check, the
+  `eval-kata.yml` migration, and the `fit-benchmark` SKILL.md → an engineering
+  agent; the `websites/` guide updates → `technical-writer`.
+- **Cross-sibling edits (in Part 03's scope).** The composite action and the new
   `benchmark.yml` reusable workflow live in the `forwardimpact/fit-benchmark`
-  sibling, and the new `fit-benchmark → fit-bootstrap` `uses:` edge plus the
+  sibling; the new `fit-benchmark → fit-bootstrap` internal `uses:` edge and the
   `fit-bootstrap` parallel-safety requirement touch shared CI governed by
-  [`.github/CLAUDE.md`](../../.github/CLAUDE.md). Per spec § Path to approval,
-  these are coordinated with the sibling owners and land as append-only patch
-  tags on the siblings, consumed here via SHA-pinned `uses:` (Dependabot bump),
-  before `eval-kata.yml` migrates. Part 03 states the required interface; the
-  sibling edits themselves are out of this monorepo's tree.
+  [`.github/CLAUDE.md`](../../.github/CLAUDE.md). These edits are **executable in
+  this environment** — `GH_TOKEN` + `gh` carry content read/write, enough to
+  edit a sibling and cut an append-only `v1.0.x` patch tag (admin write is not
+  needed; if it ever is, route to `security-engineer`). The monorepo consumes
+  the tag via a SHA-pinned `uses:` with a `# v1` marker, per `.github/CLAUDE.md`
+  (the `enum:sibling-composite-actions:count` stays `Five` — no new sibling).
+  Part 03 § Sibling-edit mechanics gives the concrete procedure and sequencing
+  (interface tagged before the consumer migrates). A `fit-bootstrap` change, if
+  the parallel-safety check finds one is needed, is coordinated with its owner
+  as that sibling's own patch tag.
 
 ## Risks
 

--- a/specs/2130-parallel-benchmark-execution/spec.md
+++ b/specs/2130-parallel-benchmark-execution/spec.md
@@ -61,7 +61,7 @@ free; any concurrency layer must solve them or it will corrupt results:
 | --- | --- | --- |
 | **Port allocation** | The port allocator opens a listener on port 0, reads the assigned port, **closes the listener, then returns the bare number**. | Two cells racing the allocate→bind window can be handed the **same** port; a real allocate-and-hold contract is required. |
 | **Results durability** | A single append stream is written one awaited line at a time. | Concurrent writers can interleave or lose lines; the verdict ledger must stay one-valid-record-per-cell. |
-| **API rate / cost** | One agent session at a time naturally rate-limits itself. | `concurrency × shards` simultaneous agent sessions can trip provider 429s; the run must degrade with backoff, not fail. |
+| **API rate / cost** | One agent session at a time naturally rate-limits itself. | `concurrency × shards` simultaneous agent sessions can trip provider 429s. Graceful 429 backoff is **deferred to a follow-up spec** (see § Excluded); under this spec a 429'd cell records an `agentError` and costs one slot, not the run. |
 
 **The single-machine ceiling is real.** Even perfect in-process concurrency is
 bounded by one runner's CPU, memory, file descriptors, and the per-job timeout.
@@ -109,7 +109,6 @@ so effective parallelism is `N × C`.
 | Concurrency-safe port allocation | Each in-flight cell receives a **distinct, bindable** port; the current close-then-return allocator's TOCTOU race (two cells handed the same number) is eliminated. The reservation mechanism is a design concern. |
 | Durable, concurrency-safe result ledger | One valid `ResultRecord` per cell regardless of `C` — no interleaved, lost, or truncated lines — and a killed run **retains the cells already completed** (crash-safe). The on-disk shape that achieves both is a design concern. |
 | Order-independent verdict contract | `run()` may yield records in completion order rather than grid order. Every consumer of the record stream — the CLI's stdout mirror, `anyFail`, the zero-record guard, and `report`'s aggregation — must be order-independent; `report` groups by `taskId`, so pass@k does not depend on order. This contract change is stated, not hidden. |
-| Rate-limit backpressure | Concurrent agent sessions that hit provider 429s back off and retry rather than failing the cell or the run. Mechanism is a design concern; graceful degradation is required. |
 | Per-cell isolation preserved | The existing per-task CWD, process group, watchdog, and teardown-with-port-verification continue to bound each cell independently; concurrent teardown of disjoint process groups must not collide. |
 | Staging stays a one-time prelude | apm/skill staging runs once before fan-out and is read-only during runs; it is not duplicated per cell. |
 
@@ -152,8 +151,14 @@ and it changes how `fit-bootstrap` is consumed:
   budget or rate ceiling may surface sooner — acknowledged, not addressed here.
 - **Auto-scaling shard count to family size.** `shard-total` is a consumer
   input; deriving an optimal `N` automatically is a later concern.
-- **Provider rate-limit raising.** The run must tolerate existing limits via
-  backoff; negotiating higher limits is operational, not in scope.
+- **Rate-limit backpressure (429 backoff/retry).** Deferred to a follow-up spec.
+  A 429 does not throw at the agent-session boundary — the agent runner returns
+  it as a result field — and a robust retry seam is the cross-cutting shared
+  agent-runner query call, a design-owned decision better made on its own. Under
+  this spec a 429'd cell records an `agentError` and, thanks to Layer-1
+  concurrency, costs one slot rather than the run.
+- **Provider rate-limit raising.** The run must tolerate existing limits;
+  negotiating higher limits is operational, not in scope.
 - **Backward-compatibility shims or fallback flags.** This is a **clean break**:
   the serial loop, the old port allocator, and the single-file report read are
   replaced outright and deleted, not kept behind a `--legacy`/compat flag or a
@@ -175,7 +180,6 @@ distribution).
 | Port allocation is collision-free under concurrency. | L1 | `K` cells allocated concurrently receive `K` distinct ports, each actually bindable at hand-off (the allocate-and-hold contract); a test that previously could collide under the close-then-return allocator now cannot. |
 | The result ledger is one valid record per cell under concurrency. | L1 | After a concurrent run of `tasks × runs` cells, `results.jsonl` parses with exactly that many records, every one schema-valid, none truncated or interleaved. |
 | A stall costs one slot, not the run. | L1 | With one cell forced to stall to its watchdog and `C > 1`, the other cells produce records and the run completes; the stalled cell is recorded as an `agentError`, and total wall-clock is bounded by `ceil(M/C)` batches, not `M`. |
-| Rate-limit failures back off, they don't fail the run. | L1 | With the fake-agent seam injecting a 429-class failure, the cell retries with bounded backoff (within its watchdog) rather than failing immediately; the run does not abort, and a cell only records an `agentError` after the backoff budget is exhausted. |
 | `--shard=i/N` runs an exact partition. | L2 | For representative `N`, the union of all shards' executed cell-sets equals the full grid with **no overlap and no gaps** — each `(task, runIndex)` runs on exactly one shard. |
 | Shard assignment is balanced and deterministic. | L2 | Each task's run indexes are distributed across shards (no shard gets a whole task while another gets none for `N ≤ runs`), and the same `(family, runs, N)` yields the same partition on repeat invocations. |
 | Each shard emits a self-contained partial ledger. | L2 | A `--shard` run writes a partial `results.jsonl` containing only its assigned cells, valid on its own. |
@@ -200,8 +204,8 @@ label, APPROVED review, approval comment, or in-session approval). On approval
 the spec proceeds to `kata-design` (WHICH/WHERE — the worker-pool placement and
 the streaming-contract change in the runner, the port-reservation mechanism, the
 durable ledger shape and its merge primitive, the cell-flattening and partition
-function for `--shard`, the multi-input `report` merge, the reusable workflow
-topology and its `fit-bootstrap` consumption, and the backpressure mechanism)
+function for `--shard`, the multi-input `report` merge, and the reusable workflow
+topology and its `fit-bootstrap` consumption)
 and then `kata-plan`.
 
 The new `forwardimpact/fit-benchmark` → `fit-bootstrap` sibling edge and the


### PR DESCRIPTION
## Summary

- Adds the execution-ready plan for spec 2130 (parallel benchmark execution) over the approved design 2130-a, decomposed into three independently executable parts:
  - **Part 01 — Layer 1 (in-process concurrency):** `enumerateCells`, `CellScheduler` (permit semaphore), single-writer drain loop, `PortRegistry` replacing `allocatePort`, `resolveConcurrency` (on-by-default), and the completion-order streaming contract.
  - **Part 02 — Layer 2 (runner/report):** `selectShard` round-robin partition, `--shard=i/N` parsing, and the recursive `loadRecords` merge (with the pinned empty-vs-missing input-dir contract).
  - **Part 03 — Layer 2 (distribution):** the `forwardimpact/fit-benchmark` sibling action `mode`/shard inputs and new `benchmark.yml` reusable workflow (edited via `gh`/`GH_TOKEN`, append-only `v1.0.N` patch tag), a `fit-bootstrap` parallel-safety check, the `eval-kata.yml` migration, the `fit-benchmark` SKILL.md update, and docs.
- **Descopes rate-limit backpressure to a follow-up spec** and applies the trim to the upstream artifacts in the same change so plan, spec, and design agree: spec.md drops the backpressure in-scope row + the "rate-limit failures back off" [L1] criterion (deferral noted in the hazard row and § Excluded); design-a.md drops the § Layer 1 `retryRateLimited` row. A 429 surfaces as a returned result field (not a throw) and the robust retry seam is the cross-cutting shared agent-runner query call — a design-owned decision deferred to its own spec. Under this spec a 429'd cell records an `agentError` and costs one slot, not the run.
- The plan was developed through three clean kata-review panels (3 reviewers each); all confirmed blocker/high/medium findings were addressed.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5MiciyWkxfGBQ4Ej636rc)_