### PR TITLE
feat(libharness): parallel benchmark execution — concurrency + sharding (#2130)

### DIFF
--- a/.claude/skills/fit-benchmark/SKILL.md
+++ b/.claude/skills/fit-benchmark/SKILL.md
@@ -125,27 +125,12 @@ uploads `results.jsonl`.
 
 All CLI `run` flags are action inputs, plus CI extras (`summary`,
 `upload-results`, `artifact-name`, `timeout-minutes`, `k`, `format`) and a
-`results-path` output — see the action README. For parallelism the action also
-takes `concurrency` (in-process, on by default) and `shard-index`/`shard-total`
-with `mode` (`run` a shard, or `merge` every shard's partial ledger).
-
-For cross-machine sharding from one input, call the bundled reusable workflow —
-it fans `shard-total` shard jobs out and runs a dependent merge job:
-
-```yaml
-jobs:
-  benchmark:
-    uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@v1
-    with:
-      family: ./benchmarks/my-family
-      shard-total: 4
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-```
-
-Each shard runs in-process concurrency internally; the merge job carries no
-agent scaffold and aggregates via `report --input`, which merges shard ledgers
-recursively.
+`results-path` output — see the action README. For parallelism the action takes
+`concurrency` (in-process, on by default) and `shard-index`/`shard-total` with
+`mode` (`run` a shard, or `merge` every shard's partial ledger). For
+cross-machine sharding from one `shard-total` input, the action ships a
+`benchmark.yml` reusable workflow that fans shards out and runs an
+agent-scaffold-free merge job — see the CI guide below.
 
 | Command | Purpose |
 | --- | --- |

--- a/.claude/skills/fit-benchmark/SKILL.md
+++ b/.claude/skills/fit-benchmark/SKILL.md
@@ -125,7 +125,27 @@ uploads `results.jsonl`.
 
 All CLI `run` flags are action inputs, plus CI extras (`summary`,
 `upload-results`, `artifact-name`, `timeout-minutes`, `k`, `format`) and a
-`results-path` output — see the action README.
+`results-path` output — see the action README. For parallelism the action also
+takes `concurrency` (in-process, on by default) and `shard-index`/`shard-total`
+with `mode` (`run` a shard, or `merge` every shard's partial ledger).
+
+For cross-machine sharding from one input, call the bundled reusable workflow —
+it fans `shard-total` shard jobs out and runs a dependent merge job:
+
+```yaml
+jobs:
+  benchmark:
+    uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@v1
+    with:
+      family: ./benchmarks/my-family
+      shard-total: 4
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+Each shard runs in-process concurrency internally; the merge job carries no
+agent scaffold and aggregates via `report --input`, which merges shard ledgers
+recursively.
 
 | Command | Purpose |
 | --- | --- |

--- a/.github/workflows/eval-kata.yml
+++ b/.github/workflows/eval-kata.yml
@@ -11,27 +11,18 @@ permissions:
   contents: read
 
 jobs:
+  # Fan the kata-skills family (6 tasks × runs:5 = 30 cells) across machines via
+  # the fit-benchmark reusable workflow, then merge the shard ledgers into one
+  # pass@k. Sharding — not a raised per-job timeout — keeps the run inside the
+  # GitHub Actions ceiling. The filesystem work-tracker is the reusable
+  # workflow's env contract; this caller only picks the family and shard count.
   benchmark:
-    runs-on: ubuntu-latest
-    env:
+    uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@4c58597fabea5260e3fad2c4855703061df66684 # v1
+    with:
+      family: ./benchmarks/kata-skills
+      runs: "5"
+      max-turns: "25"
+      judge-profile: judge
+      shard-total: "6"
+    secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      # The kata-skills family's work-tracking tasks (coordinate-finding,
-      # product-issue-triage) coordinate through the filesystem tracker; the
-      # artifact-spine tasks ignore it. The agent SDK inherits this from the
-      # job env, and fit-benchmark resolves it (flag > env > github default).
-      LIBHARNESS_WORK_TRACKER: filesystem
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@6499f90c122c47da6db9bd6e26bf83c572a0a036 # v1.0.1
-      - uses: forwardimpact/fit-benchmark@c5764e7213832cbe28978517aa8547c4834ad50a # v1
-        with:
-          family: ./benchmarks/kata-skills
-          runs: "5"
-          max-turns: "25"
-          judge-profile: judge
-          # Use the full GitHub-hosted job budget (360 min is the hard
-          # per-job ceiling). runs:5 × 4 tasks is long, and a single stalled
-          # agent run can burn ~20 min before its per-agent timeout fires;
-          # 120 min left no margin and timed out mid-run (see run
-          # 27922619997, where 5 coordinate-finding stalls exhausted it).
-          timeout-minutes: "360"

--- a/libraries/libharness/src/benchmark/report.js
+++ b/libraries/libharness/src/benchmark/report.js
@@ -433,21 +433,55 @@ function median(arr) {
 // Record loading
 // ---------------------------------------------------------------------------
 
+// Directories never worth descending for a `results.jsonl`.
+const SKIP_DIRS = new Set([".git", "node_modules"]);
+
+/**
+ * Load and union every `results.jsonl` found recursively under `inputDir`.
+ *
+ * A single non-sharded run has one root-level ledger — the trivial one-match
+ * case of the same walk. A sharded run lays each shard's partial ledger in its
+ * own subdirectory; merging them equals reporting a single run over the same
+ * cells. An *existing* dir with no ledger yields the empty union (exit 0); a
+ * *missing* dir lets `readdir`'s ENOENT propagate so `report` still errors.
+ * @param {string} inputDir
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
+ * @returns {Promise<{records: object[], skipped: number}>}
+ */
 async function loadRecords(inputDir, runtime) {
-  const path = join(inputDir, "results.jsonl");
-  let content;
+  let files;
   try {
-    content = await runtime.fs.readFile(path, "utf8");
+    files = await collectResultsFiles(inputDir, runtime);
   } catch (e) {
     // Re-throw with the stack collapsed to the message line so the CLI's
-    // error rendering stays free of node-internal async `readFile` frames
-    // (matching the pre-1370 stream-error shape the golden captured).
+    // error rendering stays free of node-internal async `readdir` frames
+    // (a missing --input dir surfaces its ENOENT as exit 1, matching the
+    // pre-1370 stream-error shape the golden captured).
     const err = new Error(e.message);
     if (e.code) err.code = e.code;
     err.stack = `Error: ${e.message}`;
     throw err;
   }
   const records = [];
+  let skipped = 0;
+  for (const file of files) {
+    const content = await runtime.fs.readFile(file, "utf8");
+    skipped += parseLedgerInto(content, records, runtime);
+  }
+  warnOnDuplicateCells(records, runtime);
+  return { records, skipped };
+}
+
+/**
+ * Parse one ledger's JSONL into `records`, skipping malformed or schema-invalid
+ * lines with a stderr warning. Returns the skipped count. Extracted from
+ * `loadRecords` to keep its cognitive complexity under the lint ceiling.
+ * @param {string} content
+ * @param {object[]} records - Accumulator, appended in place.
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
+ * @returns {number} Skipped line count.
+ */
+function parseLedgerInto(content, records, runtime) {
   let skipped = 0;
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
@@ -473,7 +507,55 @@ async function loadRecords(inputDir, runtime) {
     }
     records.push(record);
   }
-  return { records, skipped };
+  return skipped;
+}
+
+/**
+ * Recursively collect paths of every file named `results.jsonl` under `dir`,
+ * skipping `.git`/`node_modules` and never following symlinks. A purpose-built
+ * `readdir` walk — `task-family.js`'s private `walkFiles` resolves symlinks and
+ * is unexported, which is the wrong contract here.
+ * @param {string} dir
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
+ * @returns {Promise<string[]>}
+ */
+async function collectResultsFiles(dir, runtime) {
+  const entries = await runtime.fs.readdir(dir, { withFileTypes: true });
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const out = [];
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      out.push(...(await collectResultsFiles(full, runtime)));
+    } else if (entry.isFile() && entry.name === "results.jsonl") {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Warn (do not silently merge) when a `(taskId, runIndex)` cell appears more
+ * than once across shard ledgers. The shard partition guarantees uniqueness, so
+ * a duplicate signals misconfiguration; both copies stay in the group so the
+ * count is honest.
+ * @param {object[]} records
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
+ */
+function warnOnDuplicateCells(records, runtime) {
+  const counts = new Map();
+  for (const r of records) {
+    const key = `${r.taskId}#${r.runIndex}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  for (const [key, n] of counts) {
+    if (n > 1)
+      runtime.proc.stderr.write(
+        `benchmark report: duplicate cell ${key} appears ${n} times across shard ledgers — the shard partition should make each cell unique\n`,
+      );
+  }
 }
 
 function describeError(e) {

--- a/libraries/libharness/src/benchmark/runner.js
+++ b/libraries/libharness/src/benchmark/runner.js
@@ -8,10 +8,13 @@
  *   4. Judge.runJudge → Conclude-driven verdict mapped to pass/fail
  *   5. WorkdirManager.teardown → process-group cleanup
  *
- * Results stream as an async iterable AND are appended to
- * `<output>/results.jsonl` for durability. The two paths are different
- * consumers of the same record — the iterator drives CLI stdout mirroring,
- * the JSONL append is the system of record.
+ * Cells run with bounded in-process concurrency (`CellScheduler`); `run()`
+ * yields records in **completion order**, not grid order. A single drain loop
+ * is the sole writer of `<output>/results.jsonl`, appending each record the
+ * moment its cell settles — that incremental append is the durability and
+ * crash-safety mechanism, so a killed run keeps every completed cell and there
+ * is no sidecar ledger. The iterator drives CLI stdout mirroring off the same
+ * stream.
  */
 
 import { createInterface } from "node:readline";
@@ -27,6 +30,7 @@ import { validateResultRecord } from "./result.js";
 import { runInvariants } from "./invariants.js";
 import { assertJudgeProfileStaged, loadTaskFamily } from "./task-family.js";
 import { createWorkdirManager } from "./workdir.js";
+import { CellScheduler } from "./scheduler.js";
 
 const BASE_TOOLS = [
   "Bash",
@@ -42,6 +46,8 @@ const BASE_TOOLS = [
 // Upper bound on a single supervised agent run. A run that produces no terminal
 // message within this window is treated as a stall and recorded as an
 // agentError, so the benchmark never hangs the event loop into a silent exit.
+// Overridable per-runner via `watchdogMs` so a test can force a stall to fire
+// without waiting the full 20 minutes.
 const AGENT_WATCHDOG_MS = 20 * 60 * 1000;
 
 /** Sole orchestrator for a task-family benchmark run. */
@@ -58,6 +64,10 @@ export class BenchmarkRunner {
    * @param {Function} opts.query - SDK query (injected for testability).
    * @param {string[]} [opts.allowedTools] - Agent tool allowlist (default: BASE_TOOLS).
    * @param {number} [opts.maxTurns] - Agent-under-test turn budget.
+   * @param {number} [opts.concurrency] - Max cells in flight (integer ≥ 1).
+   *   Defaults to 1 as a defensive floor; the CLI always passes a resolved value.
+   * @param {number} [opts.watchdogMs] - Per-agent stall watchdog (ms). Defaults
+   *   to `AGENT_WATCHDOG_MS`; injectable so tests can force a stall in-test.
    * @param {number} [opts.termGraceMs] - SIGTERM→SIGKILL grace (ms) for the per-task process group.
    * @param {Function} [opts.runAgent] - Test seam: replaces the agent-under-test
    *   session. Must return `{costUsd, turns, submission, agentError?}` and
@@ -91,6 +101,8 @@ export class BenchmarkRunner {
     query,
     allowedTools,
     maxTurns,
+    concurrency,
+    watchdogMs,
     task,
     skillsFrom,
     termGraceMs,
@@ -117,6 +129,8 @@ export class BenchmarkRunner {
     };
     this.query = query;
     this.maxTurns = maxTurns;
+    this.concurrency = concurrency ?? 1;
+    this.watchdogMs = watchdogMs ?? AGENT_WATCHDOG_MS;
     this.taskFilter = task ?? null;
     this.skillsFrom = skillsFrom ?? null;
     this.termGraceMs = termGraceMs;
@@ -173,24 +187,32 @@ export class BenchmarkRunner {
       runtime,
     });
 
+    const cells = enumerateCells(tasks, this.runs);
+    const scheduler = new CellScheduler({
+      concurrency: this.concurrency,
+      runCell: (cell) =>
+        this.#runOne(
+          family,
+          wm,
+          cell.task,
+          cell.runIndex,
+          skillSetHash,
+          judgeProfilesDir,
+        ),
+    });
+
     const resultsPath = join(this.output, "results.jsonl");
     const resultsStream = runtime.fs.createWriteStream(resultsPath, {
       flags: "a",
     });
+    // Single-writer drain: the scheduler runs up to `concurrency` cells at
+    // once and pushes each settled record here in completion order. This loop
+    // is the sole writer of `results.jsonl` — workers never touch the stream —
+    // and the per-completion append is the crash-safety mechanism.
     try {
-      for (const task of tasks) {
-        for (let runIndex = 0; runIndex < this.runs; runIndex++) {
-          const record = await this.#runOne(
-            family,
-            wm,
-            task,
-            runIndex,
-            skillSetHash,
-            judgeProfilesDir,
-          );
-          await writeRecord(resultsStream, record);
-          yield record;
-        }
+      for await (const record of scheduler.run(cells)) {
+        await writeRecord(resultsStream, record);
+        yield record;
       }
     } finally {
       await new Promise((r) => resultsStream.end(r));
@@ -369,10 +391,10 @@ export class BenchmarkRunner {
             () =>
               reject(
                 new Error(
-                  `agent run produced no result within ${AGENT_WATCHDOG_MS}ms (possible stall)`,
+                  `agent run produced no result within ${this.watchdogMs}ms (possible stall)`,
                 ),
               ),
-            AGENT_WATCHDOG_MS,
+            this.watchdogMs,
           );
         }),
       ]);
@@ -475,6 +497,23 @@ export class BenchmarkRunner {
       };
     }
   }
+}
+
+/**
+ * Flatten the grid into a stable ordered cell list, task-major /
+ * runIndex-minor. Load-bearing ordering: Part 02's round-robin shard balance
+ * depends on a task's runIndexes being adjacent in this list. Single source of
+ * the cell list for both the scheduler and the shard selector.
+ * @param {import("./task-family.js").Task[]} tasks
+ * @param {number} runs
+ * @returns {{task: import("./task-family.js").Task, runIndex: number}[]}
+ */
+export function enumerateCells(tasks, runs) {
+  const cells = [];
+  for (const task of tasks)
+    for (let runIndex = 0; runIndex < runs; runIndex++)
+      cells.push({ task, runIndex });
+  return cells;
 }
 
 /**

--- a/libraries/libharness/src/benchmark/runner.js
+++ b/libraries/libharness/src/benchmark/runner.js
@@ -232,22 +232,62 @@ export class BenchmarkRunner {
 
   async #runOne(family, wm, task, runIndex, skillSetHash, judgeProfilesDir) {
     const t0 = this.runtime.clock.now();
-    const workdir = await wm.start(task, runIndex);
+    let workdir;
     try {
-      if (workdir.preflightError) {
-        const record = this.#buildPreflightFailureRecord({
-          task,
-          runIndex,
-          workdir,
-          skillSetHash,
-          familyRevision: family.familyRevision,
-          durationMs: this.runtime.clock.now() - t0,
-        });
-        return this.#validateOrFallback(
-          record,
-          resultsRecordKey(task, runIndex),
-        );
-      }
+      workdir = await wm.start(task, runIndex);
+      return await this.#executeCell({
+        family,
+        workdir,
+        task,
+        runIndex,
+        skillSetHash,
+        judgeProfilesDir,
+        t0,
+      });
+    } catch (e) {
+      // `wm.start()` (port acquire + workdir/env seeding) is the one throw site
+      // not caught inside `#executeCell`. Turn it into the runner's own fallback
+      // record so `#runOne` never rejects — the scheduler's one-record-per-cell
+      // contract depends on that. The fallback is schema-skipped by `report`,
+      // the same as any other runner-side schema failure.
+      return {
+        taskId: task.id,
+        runIndex,
+        verdict: "fail",
+        schemaError: `cell setup failed: ${e.message ?? String(e)}`,
+      };
+    } finally {
+      if (workdir) await wm.teardown(workdir).catch(() => {});
+    }
+  }
+
+  /**
+   * Run one cell's lifecycle against an already-started workdir: preflight
+   * gate → supervised agent → invariants → judge → assembled record. Extracted
+   * from `#runOne` so the start/teardown/error wrapper stays under the
+   * complexity ceiling.
+   */
+  async #executeCell({
+    family,
+    workdir,
+    task,
+    runIndex,
+    skillSetHash,
+    judgeProfilesDir,
+    t0,
+  }) {
+    if (workdir.preflightError) {
+      const record = this.#buildPreflightFailureRecord({
+        task,
+        runIndex,
+        workdir,
+        skillSetHash,
+        familyRevision: family.familyRevision,
+        durationMs: this.runtime.clock.now() - t0,
+      });
+      return this.#validateOrFallback(record, resultsRecordKey(task, runIndex));
+    }
+    {
       const agentRun = await this.#runAgentSafe(task, workdir);
       const { costUsd, turns, submission, agentError } = agentRun;
       const breakdown = agentRun.costBreakdown ?? { agent: 0, supervisor: 0 };
@@ -328,8 +368,6 @@ export class BenchmarkRunner {
         ...(agentError && { agentError }),
       };
       return this.#validateOrFallback(record, resultsRecordKey(task, runIndex));
-    } finally {
-      await wm.teardown(workdir).catch(() => {});
     }
   }
 

--- a/libraries/libharness/src/benchmark/runner.js
+++ b/libraries/libharness/src/benchmark/runner.js
@@ -66,6 +66,9 @@ export class BenchmarkRunner {
    * @param {number} [opts.maxTurns] - Agent-under-test turn budget.
    * @param {number} [opts.concurrency] - Max cells in flight (integer ≥ 1).
    *   Defaults to 1 as a defensive floor; the CLI always passes a resolved value.
+   * @param {{index: number, total: number}} [opts.shard] - Run only the cells
+   *   assigned to shard `index` of `total` (1-based). Absent ≡ the whole grid
+   *   (identity `1/1`).
    * @param {number} [opts.watchdogMs] - Per-agent stall watchdog (ms). Defaults
    *   to `AGENT_WATCHDOG_MS`; injectable so tests can force a stall in-test.
    * @param {number} [opts.termGraceMs] - SIGTERM→SIGKILL grace (ms) for the per-task process group.
@@ -103,6 +106,7 @@ export class BenchmarkRunner {
     maxTurns,
     concurrency,
     watchdogMs,
+    shard,
     task,
     skillsFrom,
     termGraceMs,
@@ -131,6 +135,7 @@ export class BenchmarkRunner {
     this.maxTurns = maxTurns;
     this.concurrency = concurrency ?? 1;
     this.watchdogMs = watchdogMs ?? AGENT_WATCHDOG_MS;
+    this.shard = shard ?? null;
     this.taskFilter = task ?? null;
     this.skillsFrom = skillsFrom ?? null;
     this.termGraceMs = termGraceMs;
@@ -187,7 +192,13 @@ export class BenchmarkRunner {
       runtime,
     });
 
-    const cells = enumerateCells(tasks, this.runs);
+    const allCells = enumerateCells(tasks, this.runs);
+    // Sharding selects a deterministic subset of the grid; an unsharded run is
+    // the identity 1/1. A high-index shard may select zero cells — a valid run
+    // whose results.jsonl ends up empty.
+    const cells = this.shard
+      ? selectShard(allCells, this.shard.index, this.shard.total)
+      : allCells;
     const scheduler = new CellScheduler({
       concurrency: this.concurrency,
       runCell: (cell) =>
@@ -514,6 +525,23 @@ export function enumerateCells(tasks, runs) {
     for (let runIndex = 0; runIndex < runs; runIndex++)
       cells.push({ task, runIndex });
   return cells;
+}
+
+/**
+ * Round-robin partition of the enumerated cells: the cell at position `p` runs
+ * iff `p % total === i - 1`. `i` is 1-based (Playwright-style). The union over
+ * `i ∈ 1..total` is the exact grid, each cell once; when `total > cells.length`
+ * the high-index shards select **zero** cells — a valid run. Because
+ * `enumerateCells` is task-major, a task's run indexes are adjacent, so
+ * round-robin spreads them across shards rather than handing one shard a slow
+ * task's whole run block.
+ * @param {{task: object, runIndex: number}[]} cells
+ * @param {number} i - 1-based shard index.
+ * @param {number} total - Shard count.
+ * @returns {{task: object, runIndex: number}[]}
+ */
+export function selectShard(cells, i, total) {
+  return cells.filter((_, p) => p % total === i - 1);
 }
 
 /**

--- a/libraries/libharness/src/benchmark/scheduler.js
+++ b/libraries/libharness/src/benchmark/scheduler.js
@@ -1,0 +1,78 @@
+/**
+ * CellScheduler — bounded concurrent execution of benchmark cells.
+ *
+ * Keeps at most `concurrency` `runCell(cell)` calls in flight at once and
+ * yields each settled record in **completion order** (not grid order). The
+ * runner's drain loop consumes this async iterable as the sole writer of
+ * `results.jsonl`, so concurrency lives here in execution while the ledger
+ * stays single-writer (design 2130-a § Layer 1).
+ */
+
+/** Bounded pool that streams settled cell records in completion order. */
+export class CellScheduler {
+  /**
+   * @param {object} opts
+   * @param {number} opts.concurrency - Max cells in flight (integer ≥ 1).
+   * @param {(cell: {task: object, runIndex: number}) => Promise<object>} opts.runCell -
+   *   Runs one cell to a settled record. By contract `runCell` never rejects —
+   *   the runner's `#runOne` returns an `agentError`/`schemaError` record rather
+   *   than throwing — but a rejection is guarded so one bad cell cannot wedge
+   *   the drain.
+   */
+  constructor({ concurrency, runCell }) {
+    if (!Number.isInteger(concurrency) || concurrency < 1)
+      throw new Error("concurrency must be an integer ≥ 1");
+    if (typeof runCell !== "function")
+      throw new Error("runCell must be a function");
+    this.concurrency = concurrency;
+    this.runCell = runCell;
+  }
+
+  /**
+   * Run every cell with bounded concurrency, yielding each settled record the
+   * moment its cell completes.
+   * @param {{task: object, runIndex: number}[]} cells
+   * @returns {AsyncGenerator<object>}
+   */
+  async *run(cells) {
+    let next = 0;
+    /** @type {Set<Promise<{p: Promise<*>, record: object}>>} */
+    const inFlight = new Set();
+
+    const launch = () => {
+      const cell = cells[next++];
+      // The wrapper resolves to its own handle (for O(1) removal) plus the
+      // settled record, and never rejects — a thrown runCell becomes a fail
+      // record so the drain keeps consuming.
+      const p = Promise.resolve()
+        .then(() => this.runCell(cell))
+        .then(
+          (record) => ({ p, record }),
+          (error) => ({ p, record: schedulerFailRecord(cell, error) }),
+        );
+      inFlight.add(p);
+    };
+
+    while (next < cells.length && inFlight.size < this.concurrency) launch();
+    while (inFlight.size > 0) {
+      const { p, record } = await Promise.race(inFlight);
+      inFlight.delete(p);
+      yield record;
+      if (next < cells.length) launch();
+    }
+  }
+}
+
+/**
+ * Defensive fallback when `runCell` rejects (contract says it cannot). Keeps
+ * the drain consumable; the record is intentionally minimal and will be
+ * skipped by `report`'s schema validation, counted as skipped.
+ */
+function schedulerFailRecord(cell, error) {
+  return {
+    taskId: cell.task?.id,
+    runIndex: cell.runIndex,
+    verdict: "fail",
+    schedulerError: error?.message ?? String(error),
+  };
+}

--- a/libraries/libharness/src/benchmark/scheduler.js
+++ b/libraries/libharness/src/benchmark/scheduler.js
@@ -5,7 +5,7 @@
  * yields each settled record in **completion order** (not grid order). The
  * runner's drain loop consumes this async iterable as the sole writer of
  * `results.jsonl`, so concurrency lives here in execution while the ledger
- * stays single-writer (design 2130-a § Layer 1).
+ * stays single-writer — no write mutex on the hot path.
  */
 
 /** Bounded pool that streams settled cell records in completion order. */

--- a/libraries/libharness/src/benchmark/scheduler.js
+++ b/libraries/libharness/src/benchmark/scheduler.js
@@ -15,9 +15,9 @@ export class CellScheduler {
    * @param {number} opts.concurrency - Max cells in flight (integer ≥ 1).
    * @param {(cell: {task: object, runIndex: number}) => Promise<object>} opts.runCell -
    *   Runs one cell to a settled record. By contract `runCell` never rejects —
-   *   the runner's `#runOne` returns an `agentError`/`schemaError` record rather
-   *   than throwing — but a rejection is guarded so one bad cell cannot wedge
-   *   the drain.
+   *   the runner's `#runOne` catches setup, agent, and schema failures and
+   *   returns a record rather than throwing — but a rejection is still guarded
+   *   so one bad cell cannot wedge the drain.
    */
   constructor({ concurrency, runCell }) {
     if (!Number.isInteger(concurrency) || concurrency < 1)

--- a/libraries/libharness/src/benchmark/workdir.js
+++ b/libraries/libharness/src/benchmark/workdir.js
@@ -178,12 +178,16 @@ export class WorkdirManager {
         2_000,
       );
     }
-    const portFree = await isPortFree(workdir.port);
-    const descendants = await countDescendants(this.runtime, workdir.pgid);
-    // Release the reservation after the port-free probe so a freed number can
-    // be re-handed to a waiting cell.
-    this.ports.release(workdir.port);
-    return { portFree, descendants };
+    // Release the reservation in a finally so a throwing probe cannot leak the
+    // number from the in-use set; release after the port-free probe so a freed
+    // number can be re-handed to a waiting cell.
+    try {
+      const portFree = await isPortFree(workdir.port);
+      const descendants = await countDescendants(this.runtime, workdir.pgid);
+      return { portFree, descendants };
+    } finally {
+      this.ports.release(workdir.port);
+    }
   }
 }
 

--- a/libraries/libharness/src/benchmark/workdir.js
+++ b/libraries/libharness/src/benchmark/workdir.js
@@ -190,7 +190,7 @@ export class WorkdirManager {
 /**
  * Hands out distinct, bindable TCP ports under a lock. Replaces the bare
  * close-then-return allocator whose allocate→bind window let two concurrent
- * cells receive the same number (design 2130-a § Layer 1 "Port hand-off").
+ * cells receive the same number.
  *
  * The reservation is the *number*, not a held socket — a held socket could not
  * be bound by the agent later. `acquire` serializes through a one-slot promise

--- a/libraries/libharness/src/benchmark/workdir.js
+++ b/libraries/libharness/src/benchmark/workdir.js
@@ -59,6 +59,9 @@ export class WorkdirManager {
     this.termGraceMs = termGraceMs ?? DEFAULT_TERM_GRACE_MS;
     this.familyRootPath = familyRootPath ?? null;
     this.runtime = runtime;
+    // One registry per manager: hands out distinct, bindable ports under a lock
+    // so concurrent cells can never be handed the same number.
+    this.ports = new PortRegistry();
   }
 
   /**
@@ -120,7 +123,7 @@ export class WorkdirManager {
     const envNames =
       envDirs.length > 0 ? await loadEnv(envDirs, cwd, this.runtime) : [];
 
-    const port = await allocatePort();
+    const port = await this.ports.acquire();
     const agentTracePath = join(runDir, "agent.ndjson");
     const supervisorTracePath = join(runDir, "supervisor.ndjson");
     const judgeTracePath = join(runDir, "judge.ndjson");
@@ -177,7 +180,46 @@ export class WorkdirManager {
     }
     const portFree = await isPortFree(workdir.port);
     const descendants = await countDescendants(this.runtime, workdir.pgid);
+    // Release the reservation after the port-free probe so a freed number can
+    // be re-handed to a waiting cell.
+    this.ports.release(workdir.port);
     return { portFree, descendants };
+  }
+}
+
+/**
+ * Hands out distinct, bindable TCP ports under a lock. Replaces the bare
+ * close-then-return allocator whose allocate→bind window let two concurrent
+ * cells receive the same number (design 2130-a § Layer 1 "Port hand-off").
+ *
+ * The reservation is the *number*, not a held socket — a held socket could not
+ * be bound by the agent later. `acquire` serializes through a one-slot promise
+ * chain and re-probes if the OS hands back a number already in the live in-use
+ * set, so no two in-flight cells share a port.
+ */
+export class PortRegistry {
+  #inUse = new Set();
+  #tail = Promise.resolve();
+
+  /** @returns {Promise<number>} A distinct, currently-bindable port. */
+  acquire() {
+    const next = this.#tail.then(async () => {
+      let port;
+      do {
+        port = await probeFreePort();
+      } while (this.#inUse.has(port));
+      this.#inUse.add(port);
+      return port;
+    });
+    // Keep the chain alive even if one acquire rejects, so later acquires
+    // still run; swallow here, surface the rejection on `next`.
+    this.#tail = next.catch(() => {});
+    return next;
+  }
+
+  /** @param {number} port */
+  release(port) {
+    this.#inUse.delete(port);
   }
 }
 
@@ -222,7 +264,7 @@ async function runPreflight(runtime, script, cwd, port, vars) {
   };
 }
 
-function allocatePort() {
+function probeFreePort() {
   return new Promise((res, rej) => {
     const server = createServer();
     server.unref();

--- a/libraries/libharness/src/commands/benchmark-definition.js
+++ b/libraries/libharness/src/commands/benchmark-definition.js
@@ -82,6 +82,11 @@ export const definition = {
           description:
             "Max cells run concurrently (positive integer; default: CPU-aware min(4, max(2, cores/2)); env: LIBHARNESS_BENCHMARK_CONCURRENCY)",
         },
+        shard: {
+          type: "string",
+          description:
+            "Run only shard i of N as i/N (1-based; default: the whole family). Each shard writes a partial results.jsonl; report --input merges them.",
+        },
         "allowed-tools": {
           type: "string",
           description:

--- a/libraries/libharness/src/commands/benchmark-definition.js
+++ b/libraries/libharness/src/commands/benchmark-definition.js
@@ -77,6 +77,11 @@ export const definition = {
           description:
             "Agent-under-test turn budget (default: 50, 0 = unlimited)",
         },
+        concurrency: {
+          type: "string",
+          description:
+            "Max cells run concurrently (positive integer; default: CPU-aware min(4, max(2, cores/2)); env: LIBHARNESS_BENCHMARK_CONCURRENCY)",
+        },
         "allowed-tools": {
           type: "string",
           description:

--- a/libraries/libharness/src/commands/benchmark-run.js
+++ b/libraries/libharness/src/commands/benchmark-run.js
@@ -52,27 +52,35 @@ export async function runBenchmarkRunCommand(ctx) {
     runtime.proc.stdout.write(JSON.stringify(record) + "\n");
     if (record.verdict !== "pass") anyFail = true;
   }
-  // A run that emits zero records did nothing (no tasks discovered, or the
-  // agent never produced output). That is a failure, not a silent success —
-  // surface it loudly so CI does not go green on an empty benchmark. The one
-  // exception is a deliberately-empty shard: a high-index `--shard=i/N` with
-  // `N > cell count` legitimately selects zero cells (design § Layer 2), so it
-  // exits 0 with a note rather than failing the run.
-  if (count === 0) {
-    if (opts.shard) {
-      runtime.proc.stderr.write(
-        `shard ${opts.shard.index}/${opts.shard.total} selected no cells\n`,
-      );
-      return { ok: true };
-    }
-    return {
-      ok: false,
-      code: 1,
-      error:
-        "benchmark produced no result records — no task ran to completion; check the family's tasks/, apm install, and agent availability (ANTHROPIC_API_KEY / claude CLI / IS_SANDBOX)",
-    };
-  }
+  if (count === 0) return resolveZeroRecordOutcome(opts, runtime);
   return anyFail ? { ok: false, code: 1, error: "" } : { ok: true };
+}
+
+/**
+ * Decide the exit outcome when a run streamed zero records. A run that emits no
+ * records normally did nothing (no tasks discovered, or the agent never
+ * produced output) — a failure, surfaced loudly so CI does not go green on an
+ * empty benchmark. The one exception is a deliberately-empty shard: a
+ * high-index `--shard=i/N` with `N > cell count` legitimately selects zero
+ * cells, so it exits 0 with a stderr note. Exported so the relaxed-guard branch
+ * is testable without the full handler's config/SDK setup.
+ * @param {{shard: {index: number, total: number} | null}} opts
+ * @param {import("@forwardimpact/libutil/runtime").Runtime} runtime
+ * @returns {{ok: true} | {ok: false, code: number, error: string}}
+ */
+export function resolveZeroRecordOutcome(opts, runtime) {
+  if (opts.shard) {
+    runtime.proc.stderr.write(
+      `shard ${opts.shard.index}/${opts.shard.total} selected no cells\n`,
+    );
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    code: 1,
+    error:
+      "benchmark produced no result records — no task ran to completion; check the family's tasks/, apm install, and agent availability (ANTHROPIC_API_KEY / claude CLI / IS_SANDBOX)",
+  };
 }
 
 /**

--- a/libraries/libharness/src/commands/benchmark-run.js
+++ b/libraries/libharness/src/commands/benchmark-run.js
@@ -5,6 +5,7 @@
  */
 
 import { resolve } from "node:path";
+import { availableParallelism } from "node:os";
 
 import { createConfig } from "@forwardimpact/libconfig";
 import { createBenchmarkRunner } from "../benchmark/runner.js";
@@ -95,6 +96,7 @@ export function parseRunOptions(values, env = {}) {
       judge: values["judge-profile"] ?? null,
     },
     maxTurns: parseMaxTurns(values["max-turns"]),
+    concurrency: resolveConcurrency(values, env),
     allowedTools: values["allowed-tools"]
       ? values["allowed-tools"]
           .split(",")
@@ -108,4 +110,31 @@ function parseMaxTurns(raw) {
   if (raw === undefined) return undefined;
   if (raw === "0") return 0;
   return Number.parseInt(raw, 10);
+}
+
+// Conservative because each cell spawns ~3 agent subprocesses (lead +
+// agent-under-test + judge); a low ceiling keeps a single runner from
+// thrashing. The bulk of the CI speedup comes from Layer-2 sharding across
+// machines, not from raising this in-job default.
+const CONCURRENCY_CEILING = 4;
+
+/**
+ * Resolve the cell concurrency: `--concurrency` flag > the
+ * `LIBHARNESS_BENCHMARK_CONCURRENCY` env var > a CPU-aware default of
+ * `min(CONCURRENCY_CEILING, max(2, ⌊cores/2⌋))`. The default is `> 1` so
+ * concurrency is on transparently without any consumer opting in.
+ * @param {Record<string, string|undefined>} values
+ * @param {Record<string, string|undefined>} [env]
+ * @returns {number}
+ */
+export function resolveConcurrency(values, env = {}) {
+  const raw = values.concurrency ?? env.LIBHARNESS_BENCHMARK_CONCURRENCY;
+  if (raw != null && raw !== "") {
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 1)
+      throw new Error("--concurrency must be a positive integer");
+    return n;
+  }
+  const cores = availableParallelism();
+  return Math.min(CONCURRENCY_CEILING, Math.max(2, Math.floor(cores / 2)));
 }

--- a/libraries/libharness/src/commands/benchmark-run.js
+++ b/libraries/libharness/src/commands/benchmark-run.js
@@ -54,8 +54,17 @@ export async function runBenchmarkRunCommand(ctx) {
   }
   // A run that emits zero records did nothing (no tasks discovered, or the
   // agent never produced output). That is a failure, not a silent success —
-  // surface it loudly so CI does not go green on an empty benchmark.
+  // surface it loudly so CI does not go green on an empty benchmark. The one
+  // exception is a deliberately-empty shard: a high-index `--shard=i/N` with
+  // `N > cell count` legitimately selects zero cells (design § Layer 2), so it
+  // exits 0 with a note rather than failing the run.
   if (count === 0) {
+    if (opts.shard) {
+      runtime.proc.stderr.write(
+        `shard ${opts.shard.index}/${opts.shard.total} selected no cells\n`,
+      );
+      return { ok: true };
+    }
     return {
       ok: false,
       code: 1,
@@ -97,6 +106,7 @@ export function parseRunOptions(values, env = {}) {
     },
     maxTurns: parseMaxTurns(values["max-turns"]),
     concurrency: resolveConcurrency(values, env),
+    shard: parseShard(values.shard),
     allowedTools: values["allowed-tools"]
       ? values["allowed-tools"]
           .split(",")
@@ -110,6 +120,23 @@ function parseMaxTurns(raw) {
   if (raw === undefined) return undefined;
   if (raw === "0") return 0;
   return Number.parseInt(raw, 10);
+}
+
+/**
+ * Parse a `--shard=<i>/<N>` selector into `{index, total}` (1-based), or `null`
+ * for an unsharded run. Validates `1 ≤ index ≤ total` with integer parts.
+ * @param {string|undefined} raw
+ * @returns {{index: number, total: number} | null}
+ */
+export function parseShard(raw) {
+  if (raw == null || raw === "") return null;
+  const m = /^(\d+)\/(\d+)$/.exec(raw.trim());
+  if (!m) throw new Error("--shard must be in the form i/N (e.g. 1/4)");
+  const index = Number.parseInt(m[1], 10);
+  const total = Number.parseInt(m[2], 10);
+  if (total < 1 || index < 1 || index > total)
+    throw new Error("--shard requires 1 ≤ i ≤ N");
+  return { index, total };
 }
 
 // Conservative because each cell spawns ~3 agent subprocesses (lead +

--- a/libraries/libharness/test/benchmark-port-registry.test.js
+++ b/libraries/libharness/test/benchmark-port-registry.test.js
@@ -1,0 +1,59 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { createServer } from "node:net";
+
+import { PortRegistry } from "../src/benchmark/workdir.js";
+
+/** Resolve once the given port can be bound on 127.0.0.1, then release it. */
+function isBindable(port) {
+  return new Promise((res) => {
+    const server = createServer();
+    server.once("error", () => res(false));
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => res(true));
+    });
+  });
+}
+
+describe("PortRegistry", () => {
+  test("K concurrent acquires return K distinct, bindable ports", async () => {
+    const K = 16;
+    const reg = new PortRegistry();
+    const ports = await Promise.all(
+      Array.from({ length: K }, () => reg.acquire()),
+    );
+
+    assert.strictEqual(ports.length, K);
+    assert.strictEqual(
+      new Set(ports).size,
+      K,
+      "every concurrent acquire must get a distinct number",
+    );
+    for (const p of ports) {
+      assert.ok(Number.isInteger(p) && p > 0, `not a valid port: ${p}`);
+      assert.strictEqual(await isBindable(p), true, `port ${p} not bindable`);
+    }
+  });
+
+  test("a released port can be re-handed out", async () => {
+    const reg = new PortRegistry();
+    const a = await reg.acquire();
+    reg.release(a);
+    // With `a` released, repeated acquires are free to reuse it; the registry
+    // must not consider it permanently taken.
+    const seen = new Set();
+    for (let i = 0; i < 5; i++) {
+      const p = await reg.acquire();
+      seen.add(p);
+      reg.release(p);
+    }
+    assert.ok(seen.size >= 1);
+  });
+
+  test("held ports are never duplicated across sequential acquires", async () => {
+    const reg = new PortRegistry();
+    const held = [];
+    for (let i = 0; i < 8; i++) held.push(await reg.acquire());
+    assert.strictEqual(new Set(held).size, held.length);
+  });
+});

--- a/libraries/libharness/test/benchmark-report-merge.test.js
+++ b/libraries/libharness/test/benchmark-report-merge.test.js
@@ -1,0 +1,157 @@
+/**
+ * Layer-2 recursive-merge coverage for `report` (spec 2130 § Success criteria
+ * [L2]). `loadRecords` discovers every `results.jsonl` under `--input`
+ * recursively and unions the records; merging shard partials equals reporting a
+ * single non-sharded run over the same cells. Split from `benchmark-report.test.js`
+ * (already 389 LOC) to stay under the test-file-shape ceiling.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert";
+
+import { createMockFs, createTestRuntime } from "@forwardimpact/libmock";
+
+import { aggregate } from "../src/benchmark/report.js";
+
+const ROOT = "/merge-input";
+
+function baseRecord(overrides) {
+  return {
+    taskId: "sample",
+    runIndex: 0,
+    verdict: "pass",
+    invariants: { verdict: "pass", details: [], exitCode: 0 },
+    submission: "x",
+    judgeVerdict: { verdict: "pass", summary: "ok" },
+    costUsd: 0,
+    turns: 1,
+    agentTracePath: "/tmp/a.ndjson",
+    supervisorTracePath: "/tmp/s.ndjson",
+    judgeTracePath: "/tmp/j.ndjson",
+    profiles: { agent: null, supervisor: null, judge: null },
+    model: { agent: "a", supervisor: "s", judge: "j" },
+    skillSetHash: "sha256:a",
+    familyRevision: "sha256:b",
+    durationMs: 10,
+    ...overrides,
+  };
+}
+
+const jsonl = (records) =>
+  records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+
+/** Build a runtime whose mock fs holds the given `{path: records[]}` map. */
+function runtimeWith(files, { captureStderr } = {}) {
+  const fsMap = {};
+  for (const [path, records] of Object.entries(files))
+    fsMap[path] = jsonl(records);
+  const errs = [];
+  const rt = createTestRuntime({ fs: createMockFs(fsMap) });
+  if (captureStderr) rt.proc.stderr = { write: (s) => (errs.push(s), true) };
+  return { rt, errs };
+}
+
+describe("report recursive merge", () => {
+  test("unions results.jsonl across nested shard subdirectories", async () => {
+    const { rt } = runtimeWith({
+      [`${ROOT}/shard-1/results.jsonl`]: [
+        baseRecord({ taskId: "x", runIndex: 0, verdict: "pass" }),
+        baseRecord({ taskId: "x", runIndex: 3, verdict: "fail" }),
+      ],
+      [`${ROOT}/shard-2/results.jsonl`]: [
+        baseRecord({ taskId: "x", runIndex: 1, verdict: "pass" }),
+        baseRecord({ taskId: "x", runIndex: 4, verdict: "pass" }),
+      ],
+      [`${ROOT}/shard-3/results.jsonl`]: [
+        baseRecord({ taskId: "x", runIndex: 2, verdict: "fail" }),
+      ],
+    });
+    const report = await aggregate({
+      inputDir: ROOT,
+      kValues: [1],
+      runtime: rt,
+    });
+    assert.strictEqual(report.tasks.length, 1);
+    assert.strictEqual(report.tasks[0].n, 5);
+    assert.strictEqual(report.tasks[0].c, 3);
+    assert.strictEqual(report.totals.runs, 5);
+  });
+
+  test("merged shard partials yield pass@k identical to a single full run", async () => {
+    const verdicts = ["pass", "fail", "pass", "pass", "fail", "pass"];
+    const records = verdicts.map((v, i) =>
+      baseRecord({ taskId: "t", runIndex: i, verdict: v }),
+    );
+    // Single run: one root-level ledger.
+    const single = runtimeWith({ [`${ROOT}/results.jsonl`]: records });
+    const singleReport = await aggregate({
+      inputDir: ROOT,
+      kValues: [1, 3, 5],
+      runtime: single.rt,
+    });
+    // Sharded: round-robin the same records into 3 subdir ledgers.
+    const sharded = runtimeWith({
+      [`${ROOT}/shard-1/results.jsonl`]: records.filter((_, p) => p % 3 === 0),
+      [`${ROOT}/shard-2/results.jsonl`]: records.filter((_, p) => p % 3 === 1),
+      [`${ROOT}/shard-3/results.jsonl`]: records.filter((_, p) => p % 3 === 2),
+    });
+    const shardedReport = await aggregate({
+      inputDir: ROOT,
+      kValues: [1, 3, 5],
+      runtime: sharded.rt,
+    });
+    assert.deepStrictEqual(
+      shardedReport.tasks.map((t) => ({
+        id: t.taskId,
+        n: t.n,
+        c: t.c,
+        p: t.passAtK,
+      })),
+      singleReport.tasks.map((t) => ({
+        id: t.taskId,
+        n: t.n,
+        c: t.c,
+        p: t.passAtK,
+      })),
+    );
+  });
+
+  test("a duplicate (taskId, runIndex) across shards warns and keeps both", async () => {
+    const { rt, errs } = runtimeWith(
+      {
+        [`${ROOT}/shard-1/results.jsonl`]: [
+          baseRecord({ taskId: "x", runIndex: 0, verdict: "pass" }),
+        ],
+        [`${ROOT}/shard-2/results.jsonl`]: [
+          baseRecord({ taskId: "x", runIndex: 0, verdict: "fail" }),
+        ],
+      },
+      { captureStderr: true },
+    );
+    const report = await aggregate({
+      inputDir: ROOT,
+      kValues: [1],
+      runtime: rt,
+    });
+    // Both copies counted (honest count), not silently merged.
+    assert.strictEqual(report.tasks[0].n, 2);
+    assert.ok(
+      errs.some((e) => /duplicate cell x#0/.test(e)),
+      "should warn on the duplicate cell",
+    );
+  });
+
+  test("an existing dir with no results.jsonl is the empty union (zero tasks)", async () => {
+    // A directory that exists (registered via mkdir) but holds no ledger.
+    const rt = createTestRuntime({ fs: createMockFs({}) });
+    await rt.fs.mkdir(`${ROOT}/empty`, { recursive: true });
+    const report = await aggregate({
+      inputDir: `${ROOT}/empty`,
+      kValues: [1],
+      runtime: rt,
+    });
+    assert.strictEqual(report.tasks.length, 0);
+    assert.strictEqual(report.totals.runs, 0);
+    assert.strictEqual(report.totals.skipped, 0);
+  });
+});

--- a/libraries/libharness/test/benchmark-report-merge.test.js
+++ b/libraries/libharness/test/benchmark-report-merge.test.js
@@ -1,9 +1,9 @@
 /**
- * Layer-2 recursive-merge coverage for `report` (spec 2130 § Success criteria
- * [L2]). `loadRecords` discovers every `results.jsonl` under `--input`
- * recursively and unions the records; merging shard partials equals reporting a
- * single non-sharded run over the same cells. Split from `benchmark-report.test.js`
- * (already 389 LOC) to stay under the test-file-shape ceiling.
+ * Recursive-merge coverage for `report`: `loadRecords` discovers every
+ * `results.jsonl` under `--input` recursively and unions the records, so
+ * merging shard partials equals reporting a single non-sharded run over the
+ * same cells. Split from `benchmark-report.test.js` (near the LOC ceiling) to
+ * keep each file under the test-file-shape ceiling.
  */
 
 import { describe, test } from "node:test";

--- a/libraries/libharness/test/benchmark-runner-concurrency.test.js
+++ b/libraries/libharness/test/benchmark-runner-concurrency.test.js
@@ -1,16 +1,16 @@
 /**
- * Layer-1 concurrency coverage for `BenchmarkRunner` (spec 2130 § Success
- * criteria [L1]). The agent-under-test and judge are injected seams so no SDK
- * runs; the fixture family supplies real tasks + preflight scripts.
+ * In-process concurrency coverage for `BenchmarkRunner`. The agent-under-test
+ * and judge are injected seams so no SDK runs; the fixture family supplies real
+ * tasks + preflight scripts.
  *
- * Substituted verification (called out in plan 2130-a Part 01 Step 7): the mock
- * clock advances one shared virtual `now` and resolves `sleep` on the next
- * microtask, so concurrent cells do not overlap in virtual time. Boundedness is
- * therefore asserted via a **max-in-flight high-water-mark** maintained by the
- * fake-agent seam, not a virtual wall-clock. The "stall costs one slot" property
- * splits into two faithful checks: an injected short `watchdogMs` proves a hung
- * agent session becomes an `agentError` (real watchdog path), and a hook-based
- * slow cell proves a stall occupies one slot while others complete.
+ * Why a high-water-mark instead of a wall-clock assertion: the mock clock
+ * advances one shared virtual `now` and resolves `sleep` on the next microtask,
+ * so concurrent cells do not overlap in virtual time. Boundedness is therefore
+ * asserted via a **max-in-flight high-water-mark** maintained by the fake-agent
+ * seam. The "stall costs one slot" property splits into two checks: an injected
+ * short `watchdogMs` proves a hung agent session becomes an `agentError` (real
+ * watchdog path), and a hook-based slow cell proves a stall occupies one slot
+ * while others complete.
  */
 
 import { describe, test, before } from "node:test";

--- a/libraries/libharness/test/benchmark-runner-concurrency.test.js
+++ b/libraries/libharness/test/benchmark-runner-concurrency.test.js
@@ -1,0 +1,241 @@
+/**
+ * Layer-1 concurrency coverage for `BenchmarkRunner` (spec 2130 § Success
+ * criteria [L1]). The agent-under-test and judge are injected seams so no SDK
+ * runs; the fixture family supplies real tasks + preflight scripts.
+ *
+ * Substituted verification (called out in plan 2130-a Part 01 Step 7): the mock
+ * clock advances one shared virtual `now` and resolves `sleep` on the next
+ * microtask, so concurrent cells do not overlap in virtual time. Boundedness is
+ * therefore asserted via a **max-in-flight high-water-mark** maintained by the
+ * fake-agent seam, not a virtual wall-clock. The "stall costs one slot" property
+ * splits into two faithful checks: an injected short `watchdogMs` proves a hung
+ * agent session becomes an `agentError` (real watchdog path), and a hook-based
+ * slow cell proves a stall occupies one slot while others complete.
+ */
+
+import { describe, test, before } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+import { createApmInstaller } from "../src/benchmark/apm-installer.js";
+import { aggregate } from "../src/benchmark/report.js";
+import { BenchmarkRunner } from "../src/benchmark/runner.js";
+import { validateResultRecord } from "../src/benchmark/result.js";
+import { resolveConcurrency } from "../src/commands/benchmark-run.js";
+import { realRuntimeWithSubprocess } from "./real-runtime.js";
+
+const RT = createDefaultRuntime();
+const FIXTURE = new URL("./fixtures/benchmark-family/", import.meta.url)
+  .pathname;
+
+const mockInstallApm = (family, outputDir) =>
+  createApmInstaller({ runtime: realRuntimeWithSubprocess() }).install(
+    family,
+    outputDir,
+  );
+
+/** A passing agent seam that writes a minimal trace. */
+async function passingAgent(_task, workdir) {
+  const submission = "done";
+  await writeFile(workdir.agentTracePath, "");
+  await writeFile(workdir.supervisorTracePath, "");
+  return { costUsd: 0.01, turns: 1, submission };
+}
+
+async function mockRunJudge(_task, workdir, invariants) {
+  await writeFile(workdir.judgeTracePath, "");
+  return {
+    verdict: invariants.verdict === "pass" ? "pass" : "fail",
+    summary: "ok",
+  };
+}
+
+async function newRunner(overrides = {}) {
+  const out = await mkdtemp(join(tmpdir(), "benchmark-conc-"));
+  const runner = new BenchmarkRunner({
+    family: FIXTURE,
+    runs: overrides.runs ?? 2,
+    output: out,
+    agentModel: "claude-sonnet-4-6",
+    supervisorModel: "claude-fable-5",
+    judgeModel: "claude-fable-5",
+    profiles: { agent: null, judge: "judge" },
+    query: overrides.query ?? async function* () {},
+    runtime: RT,
+    runJudge: mockRunJudge,
+    installApm: mockInstallApm,
+    installNpm: async () => {},
+    termGraceMs: 100,
+    ...overrides,
+  });
+  return { runner, out };
+}
+
+async function collect(runner) {
+  const records = [];
+  for await (const r of runner.run()) records.push(r);
+  return records;
+}
+
+describe("BenchmarkRunner Layer-1 concurrency", () => {
+  test("on by default: the resolved default concurrency runs cells in parallel", {
+    timeout: 30_000,
+  }, async () => {
+    let inFlight = 0;
+    let highWater = 0;
+    const trackingAgent = async (task, workdir) => {
+      inFlight++;
+      highWater = Math.max(highWater, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return passingAgent(task, workdir);
+    };
+    const concurrency = resolveConcurrency({});
+    assert.ok(concurrency > 1, "default concurrency must be > 1");
+    const { runner } = await newRunner({
+      runs: 3,
+      concurrency,
+      runAgent: trackingAgent,
+    });
+    await collect(runner);
+    assert.ok(highWater > 1, `expected parallel execution, got ${highWater}`);
+  });
+
+  test("bounded by C: max-in-flight never exceeds the configured concurrency", {
+    timeout: 30_000,
+  }, async () => {
+    const C = 2;
+    let inFlight = 0;
+    let highWater = 0;
+    const trackingAgent = async (task, workdir) => {
+      inFlight++;
+      highWater = Math.max(highWater, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return passingAgent(task, workdir);
+    };
+    const { runner } = await newRunner({
+      runs: 3,
+      concurrency: C,
+      runAgent: trackingAgent,
+    });
+    await collect(runner);
+    assert.ok(highWater <= C, `max-in-flight ${highWater} exceeded C=${C}`);
+    assert.strictEqual(highWater, C, "the bound should be reached");
+  });
+
+  test("verdict unchanged: C=1 and C=8 produce identical pass@k and per-task n/c", {
+    timeout: 60_000,
+  }, async () => {
+    const reportFor = async (concurrency) => {
+      const { runner, out } = await newRunner({
+        runs: 3,
+        concurrency,
+        runAgent: passingAgent,
+      });
+      await collect(runner);
+      return aggregate({ inputDir: out, kValues: [1, 3], runtime: RT });
+    };
+    const r1 = await reportFor(1);
+    const r8 = await reportFor(8);
+    const shape = (r) =>
+      r.tasks.map((t) => ({
+        taskId: t.taskId,
+        n: t.n,
+        c: t.c,
+        passAtK: t.passAtK,
+      }));
+    assert.deepStrictEqual(shape(r1), shape(r8));
+  });
+
+  test("one valid record per cell under concurrency, none interleaved", {
+    timeout: 30_000,
+  }, async () => {
+    const { runner, out } = await newRunner({
+      runs: 2,
+      concurrency: 8,
+      runAgent: passingAgent,
+    });
+    const records = await collect(runner);
+    // 4 fixture tasks × 2 runs = 8 cells.
+    assert.strictEqual(records.length, 8);
+    for (const r of records) assert.doesNotThrow(() => validateResultRecord(r));
+    const jsonl = await readFile(join(out, "results.jsonl"), "utf8");
+    const lines = jsonl.split("\n").filter(Boolean);
+    assert.strictEqual(lines.length, 8, "one ledger line per cell");
+    for (const line of lines) {
+      const parsed = JSON.parse(line); // none truncated/interleaved
+      assert.doesNotThrow(() => validateResultRecord(parsed));
+    }
+    const keys = records.map((r) => `${r.taskId}#${r.runIndex}`);
+    assert.strictEqual(new Set(keys).size, keys.length);
+  });
+
+  test("an injected short watchdogMs turns a hung agent session into an agentError", {
+    timeout: 30_000,
+  }, async () => {
+    // No runAgent hook → the real #runAgent runs; a query whose iterator never
+    // settles hangs supervisor.run(), so the watchdog (50 ms here) fires.
+    const hangingQuery = () => ({
+      async *[Symbol.asyncIterator]() {
+        await new Promise(() => {});
+      },
+    });
+    const { runner } = await newRunner({
+      runs: 1,
+      concurrency: 2,
+      watchdogMs: 50,
+      query: hangingQuery,
+      task: "pass",
+    });
+    const records = await collect(runner);
+    assert.strictEqual(records.length, 1);
+    assert.ok(records[0].agentError, "expected an agentError from the stall");
+    assert.match(records[0].agentError.message, /no result within 50ms/);
+  });
+
+  test("a stalled cell costs one slot, not the run", {
+    timeout: 30_000,
+  }, async () => {
+    // One task's agent stalls (resolves slowly to an agentError); the others
+    // resolve fast. With C>1 the run still completes, the stalled cell is an
+    // agentError, and a fast cell completes before the slow one.
+    const completionOrder = [];
+    const stallingAgent = async (task, workdir) => {
+      await writeFile(workdir.agentTracePath, "");
+      await writeFile(workdir.supervisorTracePath, "");
+      if (task.id === "repo-state") {
+        await new Promise((r) => setTimeout(r, 80));
+        completionOrder.push(task.id);
+        return {
+          costUsd: 0,
+          turns: 0,
+          submission: "",
+          agentError: { message: "simulated stall", aborted: false },
+        };
+      }
+      await new Promise((r) => setTimeout(r, 5));
+      completionOrder.push(task.id);
+      return passingAgent(task, workdir);
+    };
+    const { runner } = await newRunner({
+      runs: 1,
+      concurrency: 4,
+      runAgent: stallingAgent,
+    });
+    const records = await collect(runner);
+    const stalled = records.find((r) => r.taskId === "repo-state");
+    assert.ok(stalled.agentError, "stalled cell must record an agentError");
+    // The run completed: every task produced a record.
+    assert.ok(records.length >= 4);
+    // A fast cell finished before the slow one — the stall held one slot only.
+    assert.ok(
+      completionOrder.indexOf("repo-state") > 0,
+      "a non-stalled cell should complete before the stalled one",
+    );
+  });
+});

--- a/libraries/libharness/test/benchmark-runner-concurrency.test.js
+++ b/libraries/libharness/test/benchmark-runner-concurrency.test.js
@@ -81,51 +81,81 @@ async function collect(runner) {
   return records;
 }
 
+/**
+ * Deterministic overlap barrier. Each `enter()` bumps the in-flight count,
+ * records the high-water mark, and blocks until `target` calls are
+ * simultaneously in flight (then all release) or a safety timeout fires. A
+ * blocked agent holds its scheduler slot, so the scheduler fills up to its
+ * bound and `target` overlap is reached without racing a fixed sleep against
+ * CI-variable setup/teardown I/O — the source of the earlier flakiness.
+ */
+function overlapBarrier(target) {
+  let inFlight = 0;
+  let highWater = 0;
+  let release;
+  const gate = new Promise((r) => {
+    release = r;
+  });
+  const safety = setTimeout(() => release(), 5000);
+  safety.unref?.();
+  return {
+    get highWater() {
+      return highWater;
+    },
+    async enter() {
+      inFlight++;
+      highWater = Math.max(highWater, inFlight);
+      if (inFlight >= target) {
+        clearTimeout(safety);
+        release();
+      }
+      await gate;
+      inFlight--;
+    },
+  };
+}
+
 describe("BenchmarkRunner Layer-1 concurrency", () => {
   test("on by default: the resolved default concurrency runs cells in parallel", {
     timeout: 30_000,
   }, async () => {
-    let inFlight = 0;
-    let highWater = 0;
-    const trackingAgent = async (task, workdir) => {
-      inFlight++;
-      highWater = Math.max(highWater, inFlight);
-      await new Promise((r) => setTimeout(r, 5));
-      inFlight--;
-      return passingAgent(task, workdir);
-    };
     const concurrency = resolveConcurrency({});
     assert.ok(concurrency > 1, "default concurrency must be > 1");
+    const bar = overlapBarrier(2); // prove ≥2 cells overlap
+    const trackingAgent = (task, workdir) =>
+      bar.enter().then(() => passingAgent(task, workdir));
     const { runner } = await newRunner({
       runs: 3,
       concurrency,
       runAgent: trackingAgent,
     });
     await collect(runner);
-    assert.ok(highWater > 1, `expected parallel execution, got ${highWater}`);
+    assert.ok(
+      bar.highWater > 1,
+      `expected parallel execution, got ${bar.highWater}`,
+    );
   });
 
   test("bounded by C: max-in-flight never exceeds the configured concurrency", {
     timeout: 30_000,
   }, async () => {
     const C = 2;
-    let inFlight = 0;
-    let highWater = 0;
-    const trackingAgent = async (task, workdir) => {
-      inFlight++;
-      highWater = Math.max(highWater, inFlight);
-      await new Promise((r) => setTimeout(r, 5));
-      inFlight--;
-      return passingAgent(task, workdir);
-    };
+    // Barrier target = C: blocked agents hold their slots until exactly C
+    // overlap, so the bound is both reached and never exceeded — deterministic.
+    const bar = overlapBarrier(C);
+    const trackingAgent = (task, workdir) =>
+      bar.enter().then(() => passingAgent(task, workdir));
     const { runner } = await newRunner({
       runs: 3,
       concurrency: C,
       runAgent: trackingAgent,
     });
     await collect(runner);
-    assert.ok(highWater <= C, `max-in-flight ${highWater} exceeded C=${C}`);
-    assert.strictEqual(highWater, C, "the bound should be reached");
+    assert.ok(
+      bar.highWater <= C,
+      `max-in-flight ${bar.highWater} exceeded C=${C}`,
+    );
+    assert.strictEqual(bar.highWater, C, "the bound should be reached");
   });
 
   test("verdict unchanged: C=1 and C=8 produce identical pass@k and per-task n/c", {
@@ -201,15 +231,24 @@ describe("BenchmarkRunner Layer-1 concurrency", () => {
   test("a stalled cell costs one slot, not the run", {
     timeout: 30_000,
   }, async () => {
-    // One task's agent stalls (resolves slowly to an agentError); the others
-    // resolve fast. With C>1 the run still completes, the stalled cell is an
-    // agentError, and a fast cell completes before the slow one.
+    // One task's agent stalls until a healthy cell has completed, then records
+    // an agentError; the rest resolve immediately. With C>1 the stalled cell
+    // holds one slot while the others finish and the run completes —
+    // deterministic via a completion signal, not a fixed sleep.
     const completionOrder = [];
+    let signalFast;
+    const aFastCellDone = new Promise((r) => {
+      signalFast = r;
+    });
     const stallingAgent = async (task, workdir) => {
       await writeFile(workdir.agentTracePath, "");
       await writeFile(workdir.supervisorTracePath, "");
       if (task.id === "repo-state") {
-        await new Promise((r) => setTimeout(r, 80));
+        // Hold this slot until a fast cell has finished (safety-capped).
+        await Promise.race([
+          aFastCellDone,
+          new Promise((r) => setTimeout(r, 5000)),
+        ]);
         completionOrder.push(task.id);
         return {
           costUsd: 0,
@@ -218,8 +257,8 @@ describe("BenchmarkRunner Layer-1 concurrency", () => {
           agentError: { message: "simulated stall", aborted: false },
         };
       }
-      await new Promise((r) => setTimeout(r, 5));
       completionOrder.push(task.id);
+      signalFast();
       return passingAgent(task, workdir);
     };
     const { runner } = await newRunner({

--- a/libraries/libharness/test/benchmark-scheduler.test.js
+++ b/libraries/libharness/test/benchmark-scheduler.test.js
@@ -1,0 +1,103 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+
+import { CellScheduler } from "../src/benchmark/scheduler.js";
+
+/** Build `m` trivial cells with a distinct task id per cell. */
+function makeCells(m) {
+  return Array.from({ length: m }, (_, i) => ({
+    task: { id: `t${i}` },
+    runIndex: 0,
+  }));
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 5));
+
+describe("CellScheduler", () => {
+  test("keeps at most C cells in flight (max-in-flight high-water-mark = C)", async () => {
+    const C = 3;
+    const M = 11;
+    let inFlight = 0;
+    let highWater = 0;
+    const runCell = async (cell) => {
+      inFlight++;
+      highWater = Math.max(highWater, inFlight);
+      await tick();
+      inFlight--;
+      return { taskId: cell.task.id, runIndex: cell.runIndex, verdict: "pass" };
+    };
+    const scheduler = new CellScheduler({ concurrency: C, runCell });
+    const records = [];
+    for await (const r of scheduler.run(makeCells(M))) records.push(r);
+
+    assert.strictEqual(records.length, M);
+    assert.strictEqual(highWater, C, "high-water-mark must equal the bound");
+    assert.strictEqual(inFlight, 0, "all cells must drain");
+  });
+
+  test("yields every cell record exactly once", async () => {
+    const M = 7;
+    const runCell = async (cell) => ({
+      taskId: cell.task.id,
+      runIndex: cell.runIndex,
+      verdict: "pass",
+    });
+    const scheduler = new CellScheduler({ concurrency: 2, runCell });
+    const seen = [];
+    for await (const r of scheduler.run(makeCells(M))) seen.push(r.taskId);
+
+    assert.strictEqual(seen.length, M);
+    assert.strictEqual(new Set(seen).size, M, "no record yielded twice");
+  });
+
+  test("a high concurrency over few cells caps in-flight at the cell count", async () => {
+    const M = 2;
+    let inFlight = 0;
+    let highWater = 0;
+    const runCell = async (cell) => {
+      inFlight++;
+      highWater = Math.max(highWater, inFlight);
+      await tick();
+      inFlight--;
+      return { taskId: cell.task.id, runIndex: cell.runIndex, verdict: "pass" };
+    };
+    const scheduler = new CellScheduler({ concurrency: 8, runCell });
+    const records = [];
+    for await (const r of scheduler.run(makeCells(M))) records.push(r);
+
+    assert.strictEqual(records.length, M);
+    assert.strictEqual(highWater, M);
+  });
+
+  test("a rejecting runCell cannot wedge the drain (defensive guard)", async () => {
+    const runCell = async (cell) => {
+      if (cell.task.id === "t1") throw new Error("boom");
+      return { taskId: cell.task.id, runIndex: cell.runIndex, verdict: "pass" };
+    };
+    const scheduler = new CellScheduler({ concurrency: 2, runCell });
+    const records = [];
+    for await (const r of scheduler.run(makeCells(3))) records.push(r);
+
+    assert.strictEqual(records.length, 3, "every cell still produces a record");
+    const failed = records.find((r) => r.taskId === "t1");
+    assert.strictEqual(failed.verdict, "fail");
+    assert.match(failed.schedulerError, /boom/);
+  });
+
+  test("an empty cell list yields nothing", async () => {
+    const scheduler = new CellScheduler({
+      concurrency: 4,
+      runCell: async () => ({ verdict: "pass" }),
+    });
+    const records = [];
+    for await (const r of scheduler.run([])) records.push(r);
+    assert.strictEqual(records.length, 0);
+  });
+
+  test("rejects a non-positive concurrency", () => {
+    assert.throws(
+      () => new CellScheduler({ concurrency: 0, runCell: async () => ({}) }),
+      /concurrency must be an integer ≥ 1/,
+    );
+  });
+});

--- a/libraries/libharness/test/benchmark-shard.test.js
+++ b/libraries/libharness/test/benchmark-shard.test.js
@@ -18,6 +18,7 @@ import {
   enumerateCells,
   selectShard,
 } from "../src/benchmark/runner.js";
+import { resolveZeroRecordOutcome } from "../src/commands/benchmark-run.js";
 import { validateResultRecord } from "../src/benchmark/result.js";
 import { realRuntimeWithSubprocess } from "./real-runtime.js";
 
@@ -158,5 +159,36 @@ describe("BenchmarkRunner --shard partial ledger", () => {
     assert.ok(names.includes("results.jsonl"), "an empty ledger still exists");
     const body = await readFile(join(out, "results.jsonl"), "utf8");
     assert.strictEqual(body.trim(), "", "ledger is empty");
+  });
+});
+
+describe("zero-record exit guard (the relaxed-shard branch)", () => {
+  // resolveZeroRecordOutcome is the exact decision runBenchmarkRunCommand makes
+  // when a run streams zero records — exercised directly so the exit-0-vs-exit-1
+  // fork is covered without the handler's config/SDK setup.
+  function fakeRuntime() {
+    const errs = [];
+    return {
+      runtime: { proc: { stderr: { write: (s) => errs.push(s) } } },
+      errs,
+    };
+  }
+
+  test("a deliberately-empty shard exits 0 with a stderr note", () => {
+    const { runtime, errs } = fakeRuntime();
+    const outcome = resolveZeroRecordOutcome(
+      { shard: { index: 50, total: 50 } },
+      runtime,
+    );
+    assert.deepStrictEqual(outcome, { ok: true });
+    assert.ok(errs.some((e) => /shard 50\/50 selected no cells/.test(e)));
+  });
+
+  test("an unsharded zero-record run still fails (exit 1)", () => {
+    const { runtime } = fakeRuntime();
+    const outcome = resolveZeroRecordOutcome({ shard: null }, runtime);
+    assert.strictEqual(outcome.ok, false);
+    assert.strictEqual(outcome.code, 1);
+    assert.match(outcome.error, /produced no result records/);
   });
 });

--- a/libraries/libharness/test/benchmark-shard.test.js
+++ b/libraries/libharness/test/benchmark-shard.test.js
@@ -1,8 +1,7 @@
 /**
- * Layer-2 sharding coverage (spec 2130 § Success criteria [L2]): `selectShard`
- * is an exact, balanced, deterministic partition, and a `--shard` runner pass
- * writes a self-contained partial ledger (including the deliberately-empty
- * high-index shard).
+ * Sharding coverage: `selectShard` is an exact, balanced, deterministic
+ * partition, and a `--shard` runner pass writes a self-contained partial ledger
+ * (including the deliberately-empty high-index shard).
  */
 
 import { describe, test } from "node:test";

--- a/libraries/libharness/test/benchmark-shard.test.js
+++ b/libraries/libharness/test/benchmark-shard.test.js
@@ -1,0 +1,163 @@
+/**
+ * Layer-2 sharding coverage (spec 2130 § Success criteria [L2]): `selectShard`
+ * is an exact, balanced, deterministic partition, and a `--shard` runner pass
+ * writes a self-contained partial ledger (including the deliberately-empty
+ * high-index shard).
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, writeFile, readFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createDefaultRuntime } from "@forwardimpact/libutil/runtime";
+
+import { createApmInstaller } from "../src/benchmark/apm-installer.js";
+import {
+  BenchmarkRunner,
+  enumerateCells,
+  selectShard,
+} from "../src/benchmark/runner.js";
+import { validateResultRecord } from "../src/benchmark/result.js";
+import { realRuntimeWithSubprocess } from "./real-runtime.js";
+
+const RT = createDefaultRuntime();
+const FIXTURE = new URL("./fixtures/benchmark-family/", import.meta.url)
+  .pathname;
+
+const mockInstallApm = (family, outputDir) =>
+  createApmInstaller({ runtime: realRuntimeWithSubprocess() }).install(
+    family,
+    outputDir,
+  );
+
+async function passingAgent(_task, workdir) {
+  await writeFile(workdir.agentTracePath, "");
+  await writeFile(workdir.supervisorTracePath, "");
+  return { costUsd: 0, turns: 1, submission: "done" };
+}
+async function mockRunJudge(_task, workdir, invariants) {
+  await writeFile(workdir.judgeTracePath, "");
+  return {
+    verdict: invariants.verdict === "pass" ? "pass" : "fail",
+    summary: "",
+  };
+}
+
+async function runShard(shard) {
+  const out = await mkdtemp(join(tmpdir(), "benchmark-shard-"));
+  const runner = new BenchmarkRunner({
+    family: FIXTURE,
+    runs: 2,
+    output: out,
+    agentModel: "claude-sonnet-4-6",
+    supervisorModel: "claude-fable-5",
+    judgeModel: "claude-fable-5",
+    profiles: { agent: null, judge: "judge" },
+    query: async function* () {},
+    runtime: RT,
+    concurrency: 4,
+    shard,
+    runAgent: passingAgent,
+    runJudge: mockRunJudge,
+    installApm: mockInstallApm,
+    installNpm: async () => {},
+    termGraceMs: 100,
+  });
+  const records = [];
+  for await (const r of runner.run()) records.push(r);
+  return { records, out };
+}
+
+const cellKey = (c) => `${c.task.id}#${c.runIndex}`;
+const recKey = (r) => `${r.taskId}#${r.runIndex}`;
+
+describe("selectShard — exact partition", () => {
+  const tasks = [{ id: "a" }, { id: "b" }, { id: "c" }];
+  const cells = enumerateCells(tasks, 5); // 15 cells, task-major
+
+  for (const N of [1, 2, 3, 5]) {
+    test(`N=${N}: union is the whole grid, no overlap, no gaps`, () => {
+      const union = [];
+      for (let i = 1; i <= N; i++) union.push(...selectShard(cells, i, N));
+      assert.strictEqual(union.length, cells.length, "no overlap, no gaps");
+      assert.deepStrictEqual(
+        new Set(union.map(cellKey)),
+        new Set(cells.map(cellKey)),
+      );
+    });
+  }
+
+  test("balanced: each task's run indexes spread across shards (N ≤ runs)", () => {
+    const N = 5;
+    // For each shard, which tasks contributed a cell. With task-major ordering
+    // and p%N, a task's 5 runs land on 5 distinct shards — no shard owns a whole
+    // task while another gets none.
+    for (let i = 1; i <= N; i++) {
+      const shard = selectShard(cells, i, N);
+      const taskIds = new Set(shard.map((c) => c.task.id));
+      assert.strictEqual(taskIds.size, 3, `shard ${i} should touch all tasks`);
+    }
+  });
+
+  test("deterministic: same (cells, i, N) yields the same partition", () => {
+    assert.deepStrictEqual(
+      selectShard(cells, 2, 3).map(cellKey),
+      selectShard(cells, 2, 3).map(cellKey),
+    );
+  });
+
+  test("high-index shard selects zero cells when N > cell count", () => {
+    const few = enumerateCells([{ id: "x" }], 3); // 3 cells
+    assert.strictEqual(selectShard(few, 5, 5).length, 0);
+    assert.strictEqual(selectShard(few, 4, 5).length, 0);
+    assert.strictEqual(selectShard(few, 1, 5).length, 1);
+  });
+});
+
+describe("BenchmarkRunner --shard partial ledger", () => {
+  test("a shard writes a self-contained partial ledger of only its cells", {
+    timeout: 30_000,
+  }, async () => {
+    const { records, out } = await runShard({ index: 1, total: 3 });
+    // Every record validates and is unique.
+    for (const r of records) assert.doesNotThrow(() => validateResultRecord(r));
+    assert.strictEqual(new Set(records.map(recKey)).size, records.length);
+    // The partial ledger on disk matches the streamed records exactly.
+    const jsonl = await readFile(join(out, "results.jsonl"), "utf8");
+    const lines = jsonl.split("\n").filter(Boolean);
+    assert.strictEqual(lines.length, records.length);
+    // Its cells are a subset of shard 1/3 of the full grid (no foreign cells).
+    assert.ok(records.length > 0 && records.length < 8, "a strict subset");
+  });
+
+  test("three shards partition the grid: union equals a single full run", {
+    timeout: 60_000,
+  }, async () => {
+    const N = 3;
+    const all = [];
+    for (let i = 1; i <= N; i++) {
+      const { records } = await runShard({ index: i, total: N });
+      all.push(...records);
+    }
+    const full = await runShard(null); // unsharded ≡ whole grid
+    assert.strictEqual(all.length, full.records.length, "no overlap, no gaps");
+    assert.deepStrictEqual(
+      new Set(all.map(recKey)),
+      new Set(full.records.map(recKey)),
+    );
+  });
+
+  test("a deliberately-empty high-index shard writes an empty ledger, yields nothing", {
+    timeout: 30_000,
+  }, async () => {
+    // 4 tasks × 2 runs = 8 cells; shard 50/50 selects none.
+    const { records, out } = await runShard({ index: 50, total: 50 });
+    assert.strictEqual(records.length, 0);
+    const names = await readdir(out);
+    assert.ok(names.includes("results.jsonl"), "an empty ledger still exists");
+    const body = await readFile(join(out, "results.jsonl"), "utf8");
+    assert.strictEqual(body.trim(), "", "ledger is empty");
+  });
+});

--- a/libraries/libharness/test/golden/fit-benchmark/run-help.stdout.txt
+++ b/libraries/libharness/test/golden/fit-benchmark/run-help.stdout.txt
@@ -16,6 +16,7 @@ Options:
   --work-tracker=<string>   Active work-item tracker (github|filesystem, default: github)
   --max-turns=<string>      Agent-under-test turn budget (default: 50, 0 = unlimited)
   --concurrency=<string>    Max cells run concurrently (positive integer; default: CPU-aware min(4, max(2, cores/2)); env: LIBHARNESS_BENCHMARK_CONCURRENCY)
+  --shard=<string>          Run only shard i of N as i/N (1-based; default: the whole family). Each shard writes a partial results.jsonl; report --input merges them.
   --allowed-tools=<string>  Comma-separated tool allowlist for the agent-under-test (default: Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite)
 
 Global options:

--- a/libraries/libharness/test/golden/fit-benchmark/run-help.stdout.txt
+++ b/libraries/libharness/test/golden/fit-benchmark/run-help.stdout.txt
@@ -15,6 +15,7 @@ Options:
   --judge-profile=<string>  Judge profile name
   --work-tracker=<string>   Active work-item tracker (github|filesystem, default: github)
   --max-turns=<string>      Agent-under-test turn budget (default: 50, 0 = unlimited)
+  --concurrency=<string>    Max cells run concurrently (positive integer; default: CPU-aware min(4, max(2, cores/2)); env: LIBHARNESS_BENCHMARK_CONCURRENCY)
   --allowed-tools=<string>  Comma-separated tool allowlist for the agent-under-test (default: Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite)
 
 Global options:

--- a/libraries/libharness/test/work-tracker.test.js
+++ b/libraries/libharness/test/work-tracker.test.js
@@ -10,6 +10,7 @@ import { parseFacilitateOptions } from "../src/commands/facilitate.js";
 import {
   parseRunOptions as parseBenchmarkRunOptions,
   resolveConcurrency,
+  parseShard,
 } from "../src/commands/benchmark-run.js";
 
 // Every agent-running entry point resolves --work-tracker (default "github")
@@ -243,5 +244,34 @@ describe("fit-benchmark run resolves --concurrency", () => {
       concurrency: "6",
     });
     assert.strictEqual(opts.concurrency, 6);
+  });
+});
+
+describe("fit-benchmark run parses --shard", () => {
+  test("absent shard is null (whole family)", () => {
+    assert.strictEqual(parseShard(undefined), null);
+    assert.strictEqual(parseShard(""), null);
+  });
+
+  test("i/N parses to a 1-based {index, total}", () => {
+    assert.deepStrictEqual(parseShard("1/4"), { index: 1, total: 4 });
+    assert.deepStrictEqual(parseShard("3/3"), { index: 3, total: 3 });
+  });
+
+  test("index > total is rejected", () => {
+    assert.throws(() => parseShard("9/3"), /1 ≤ i ≤ N/);
+  });
+
+  test("a non-i/N form is rejected", () => {
+    assert.throws(() => parseShard("4"), /i\/N/);
+    assert.throws(() => parseShard("a/b"), /i\/N/);
+  });
+
+  test("parseRunOptions threads the parsed shard", () => {
+    const opts = parseBenchmarkRunOptions({
+      family: "./families/coding",
+      shard: "2/5",
+    });
+    assert.deepStrictEqual(opts.shard, { index: 2, total: 5 });
   });
 });

--- a/libraries/libharness/test/work-tracker.test.js
+++ b/libraries/libharness/test/work-tracker.test.js
@@ -7,7 +7,10 @@ import { parseRunOptions as parseRunOptionsEval } from "../src/commands/run.js";
 import { parseSuperviseOptions } from "../src/commands/supervise.js";
 import { parseDiscussOptions } from "../src/commands/discuss.js";
 import { parseFacilitateOptions } from "../src/commands/facilitate.js";
-import { parseRunOptions as parseBenchmarkRunOptions } from "../src/commands/benchmark-run.js";
+import {
+  parseRunOptions as parseBenchmarkRunOptions,
+  resolveConcurrency,
+} from "../src/commands/benchmark-run.js";
 
 // Every agent-running entry point resolves --work-tracker (default "github")
 // so the handler can write it unconditionally to
@@ -198,5 +201,47 @@ describe("fit-benchmark run resolves --work-tracker", () => {
     });
     runtime.proc.env.LIBHARNESS_WORK_TRACKER = opts.workTracker;
     assert.strictEqual(runtime.proc.env.LIBHARNESS_WORK_TRACKER, "filesystem");
+  });
+});
+
+describe("fit-benchmark run resolves --concurrency", () => {
+  test("defaults to a value > 1 (on by default, no flag)", () => {
+    assert.ok(resolveConcurrency({}) > 1);
+  });
+
+  test("an explicit --concurrency flag is honored", () => {
+    assert.strictEqual(resolveConcurrency({ concurrency: "8" }), 8);
+  });
+
+  test("falls back to LIBHARNESS_BENCHMARK_CONCURRENCY env", () => {
+    assert.strictEqual(
+      resolveConcurrency({}, { LIBHARNESS_BENCHMARK_CONCURRENCY: "3" }),
+      3,
+    );
+  });
+
+  test("the flag overrides the env fallback", () => {
+    assert.strictEqual(
+      resolveConcurrency(
+        { concurrency: "5" },
+        { LIBHARNESS_BENCHMARK_CONCURRENCY: "3" },
+      ),
+      5,
+    );
+  });
+
+  test("a non-positive concurrency is rejected", () => {
+    assert.throws(
+      () => resolveConcurrency({ concurrency: "0" }),
+      /--concurrency must be a positive integer/,
+    );
+  });
+
+  test("parseRunOptions threads the resolved concurrency", () => {
+    const opts = parseBenchmarkRunOptions({
+      family: "./families/coding",
+      concurrency: "6",
+    });
+    assert.strictEqual(opts.concurrency, 6);
   });
 });

--- a/websites/fit/docs/libraries/prove-changes/run-benchmark/ci-workflow/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-benchmark/ci-workflow/index.md
@@ -74,11 +74,16 @@ CI-specific inputs that have no CLI equivalent:
 | `judge-profile` | | Judge profile name |
 | `max-turns` | `"50"` | Agent turn budget (`0` = unlimited) |
 | `allowed-tools` | `"Bash,Read,Glob,Grep,Write,Edit,Agent,TodoWrite"` | Agent tool allowlist |
+| `concurrency` | *(CLI default)* | Max cells run concurrently in-process; empty uses the CPU-aware CLI default (on by default) |
+| `shard-index` | `"1"` | 1-based shard index (run mode) |
+| `shard-total` | `"1"` | Total shard count; `"1"` runs the whole family |
+| `mode` | `"run"` | `run` executes one shard; `merge` aggregates every shard's partial ledger |
+| `merge-input` | `"benchmark-merge"` | Directory shard ledgers download into (merge mode) |
 | `k` | `"1,3,5"` | Comma-separated k values for pass@k |
 | `format` | `"text"` | Report output format |
 | `summary` | `"true"` | Append report to `GITHUB_STEP_SUMMARY` |
 | `upload-results` | `"true"` | Upload `results.jsonl` as artifact |
-| `artifact-name` | `"benchmark-results"` | Name for the uploaded artifact |
+| `artifact-name` | `"benchmark-results"` | Name for the uploaded artifact (run mode with `shard-total` > `"1"` uploads `benchmark-shard-<i>`) |
 | `timeout-minutes` | `"60"` | Maximum minutes before cancellation |
 
 ## Outputs
@@ -161,6 +166,35 @@ steps:
       family: ${{ matrix.family.path }}
       artifact-name: benchmark-${{ matrix.family.name }}
 ```
+
+## Scale One Family Across Machines
+
+A single machine has a CPU and a per-job time ceiling. When one family is too
+large to finish in one job — the run hits the timeout — fan it across machines
+with the bundled reusable workflow. A single `shard-total` input runs a
+deterministic, balanced subset of the cells on each machine and merges the
+partial ledgers into one pass@k:
+
+```yaml
+jobs:
+  benchmark:
+    uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@v1
+    with:
+      family: ./benchmarks/my-family
+      runs: "5"
+      shard-total: 4
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+The workflow runs three stages: a `prepare` job emits the shard list, four
+parallel `shard` jobs each run their slice (with in-process concurrency) and
+upload a `benchmark-shard-<i>` partial ledger, and a dependent `merge` job
+aggregates the combined report. The merge job carries **no agent scaffold** —
+it provisions only the report CLI, since `report --input` discovers and unions
+every shard's `results.jsonl` recursively. Effective parallelism is
+`shard-total` × the per-machine concurrency. Leaving `shard-total` unset runs
+the whole family in one shard job — the identity case.
 
 ## Verify
 

--- a/websites/fit/docs/libraries/prove-changes/run-benchmark/index.md
+++ b/websites/fit/docs/libraries/prove-changes/run-benchmark/index.md
@@ -271,6 +271,24 @@ count, and the absolute paths to both NDJSON traces. The record's
 schema is validated at write time, so a malformed write is caught
 before the report stage trips over it.
 
+### Run Cells Concurrently
+
+Cells — each `(task, runIndex)` pair — run concurrently by default, so a
+family no longer takes the *sum* of every cell's wall-clock. Concurrency is
+on without any flag: the default is CPU-aware (`min(4, max(2, cores/2))`).
+Override it with `--concurrency=<n>` or the
+`LIBHARNESS_BENCHMARK_CONCURRENCY` environment variable (the flag wins):
+
+```sh
+npx fit-benchmark run --family=./my-coding-family --runs=5 --concurrency=4
+```
+
+Concurrency does not change the pass@k a serial run would have produced —
+records simply stream in completion order instead of grid order, and each
+cell still lands in `results.jsonl` the moment it settles, so a cancelled
+run keeps every completed cell. One stalled cell now occupies a single slot
+instead of blocking the whole run.
+
 ## Check One Task's Invariants at a Time
 
 For ad-hoc grading without an agent run:
@@ -310,6 +328,43 @@ data only — suitable for machine consumption and before/after diffs.
 
 A `k > n` value emits a structured error row rather than a misleading
 number.
+
+`report --input` discovers every `results.jsonl` **recursively** under the
+directory and unions the records before computing pass@k. A single run with
+one `results.jsonl` is the trivial case; the same command merges the partial
+ledgers produced by sharding (below) when you point it at a directory holding
+each shard's output.
+
+## Shard Across Machines
+
+One machine has a ceiling — CPU, memory, and the CI per-job time limit. For a
+large family, split the grid across machines with `--shard=<i>/<N>`: shard `i`
+of `N` runs a deterministic, balanced subset of the cells and writes a partial
+`results.jsonl` containing only its cells.
+
+```sh
+# On machine 1 of 3:
+npx fit-benchmark run --family=./my-coding-family --runs=5 \
+  --shard=1/3 --output=./runs/shard-1
+# ...machines 2 and 3 run --shard=2/3 and --shard=3/3 into ./runs/shard-2, ./runs/shard-3
+```
+
+The `N` shards form an exact partition: every cell runs on exactly one shard,
+none twice, none dropped. Assignment is at `(task, runIndex)` granularity and
+round-robins across shards, so a slow task's runs spread out rather than
+landing one whole task on a single machine. When `N` exceeds the cell count the
+high-index shards select zero cells — a valid run with an empty ledger.
+
+Collect the shard outputs under one directory and merge them into a single
+pass@k — identical to what a non-sharded run over the same cells would
+report — with the recursive `report --input`:
+
+```sh
+npx fit-benchmark report --input=./runs --k=1,3,5 --format=text
+```
+
+Each shard run also uses in-process concurrency internally, so effective
+parallelism is `N` machines × the per-machine concurrency.
 
 ## Compare Before and After
 


### PR DESCRIPTION
## Summary

Implements spec 2130 — make a `fit-benchmark` run finish inside a CI budget by running independent cells concurrently, on two composable axes.

- **Layer 1 (in-process concurrency)** — `CellScheduler` runs up to `C` cells at once and streams settled records in completion order; a single drain loop is the sole writer of `results.jsonl` (per-completion append = crash-safety). `PortRegistry` replaces the close-then-return `allocatePort`, handing out distinct bindable ports under a lock. `--concurrency` is on by default (CPU-aware), overridable by flag/env. Injectable `watchdogMs`.
- **Layer 2 (sharding + merge)** — `selectShard` round-robin-partitions the grid at `(task, runIndex)` granularity; `--shard=i/N` runs one shard's partial ledger; `report --input` now discovers and unions every `results.jsonl` recursively. A high-index shard selecting zero cells is a valid run (exit 0); a missing report dir still errors (exit 1).
- **Distribution** — the `forwardimpact/fit-benchmark` sibling gained `mode`/`concurrency`/`shard-*` action inputs and a `benchmark.yml` reusable workflow (merged, tagged `v1.0.2`); `eval-kata.yml` migrates to the SHA-pinned reusable workflow with `shard-total: 6`, dropping the 360-min ceiling workaround. SKILL.md + run-benchmark/ci-workflow guides updated.

A clean 5-reviewer `kata-review` panel found zero blocker/high; the one minority medium and two recurring lows were addressed. The verdict (pass@k) is unchanged by concurrency or sharding.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9MyrMc58dznW8x42Kb8Wf)_