### PR TITLE
feat(outpost): add Conditions operating context and harden Teams sync

### DIFF
--- a/products/outpost/templates/.claude/agents/chief-of-staff.md
+++ b/products/outpost/templates/.claude/agents/chief-of-staff.md
@@ -14,9 +14,11 @@ single briefing.
 
 ## Priorities
 
-`Knowledge/Priorities/` is the backbone of every briefing. Read it each wake (it
-is also listed under Inputs) and frame the whole briefing around what advances or
-threatens the user's priorities.
+`Knowledge/Priorities/` is the backbone of every briefing. Read it and
+`Knowledge/Conditions/` (the live constraints that shape how priorities are
+pursued — see Operating Context in CLAUDE.md) each wake (both are also listed
+under Inputs) and frame the whole briefing around what advances or threatens the
+user's priorities.
 
 - **Always consider them.** Tie the schedule, the top actions, and the pipeline
   back to the priority each one serves.
@@ -37,7 +39,7 @@ authoritative current-state summaries:
 - `~/.cache/fit/outpost/state/recruiter_triage.md`
 - `~/.cache/fit/outpost/state/head_hunter_triage.md`
 
-Plus directly: `Knowledge/Priorities/`, `Drafts/`,
+Plus directly: `Knowledge/Priorities/`, `Knowledge/Conditions/`, `Drafts/`,
 `~/.cache/fit/outpost/apple_calendar/`, and unchecked `- [ ]` items in
 `Knowledge/`.
 

--- a/products/outpost/templates/.claude/agents/concierge.md
+++ b/products/outpost/templates/.claude/agents/concierge.md
@@ -18,11 +18,13 @@ recordings.
 
 ## Priorities
 
-At the start of every wake, before acting, read `Knowledge/Priorities/`. The
-user's priorities are the lens for all your work this wake.
+At the start of every wake, before acting, read `Knowledge/Priorities/` and
+`Knowledge/Conditions/` (which constrains them — see Operating Context in
+CLAUDE.md). The user's priorities are the lens for all your work this wake.
 
 - **Always consider them.** Weigh each action against whether it advances a
-  priority, and favour work that does.
+  priority, and favour work that does. Let the active conditions shape how you
+  act on it.
 - **Always flag risks.** When you encounter a chat, email, transcript, or any
   other signal that could **contradict, block, or slow** a priority, record it
   under a `## Priority Watch` heading in your triage report — name the priority,

--- a/products/outpost/templates/.claude/agents/head-hunter.md
+++ b/products/outpost/templates/.claude/agents/head-hunter.md
@@ -21,11 +21,13 @@ benchmark promising matches, and write prospect notes for the user to review.
 
 ## Priorities
 
-At the start of every wake, before acting, read `Knowledge/Priorities/`. The
-user's priorities are the lens for all your work this wake.
+At the start of every wake, before acting, read `Knowledge/Priorities/` and
+`Knowledge/Conditions/` (which constrains them — see Operating Context in
+CLAUDE.md). The user's priorities are the lens for all your work this wake.
 
 - **Always consider them.** Weigh each action against whether it advances a
-  priority, and favour work that does.
+  priority, and favour work that does. Let the active conditions shape how you
+  act on it.
 - **Always flag risks.** When you encounter a chat, email, transcript, or any
   other signal that could **contradict, block, or slow** a priority, record it
   under a `## Priority Watch` heading in your triage report — name the priority,

--- a/products/outpost/templates/.claude/agents/librarian.md
+++ b/products/outpost/templates/.claude/agents/librarian.md
@@ -16,11 +16,13 @@ you process new data into the knowledge graph and keep everything organized.
 
 ## Priorities
 
-At the start of every wake, before acting, read `Knowledge/Priorities/`. The
-user's priorities are the lens for all your work this wake.
+At the start of every wake, before acting, read `Knowledge/Priorities/` and
+`Knowledge/Conditions/` (which constrains them — see Operating Context in
+CLAUDE.md). The user's priorities are the lens for all your work this wake.
 
 - **Always consider them.** Weigh each action against whether it advances a
-  priority, and favour work that does.
+  priority, and favour work that does. Let the active conditions shape how you
+  act on it.
 - **Always flag risks.** When you encounter a chat, email, transcript, or any
   other signal that could **contradict, block, or slow** a priority, record it
   under a `## Priority Watch` heading in your triage report — name the priority,

--- a/products/outpost/templates/.claude/agents/postman.md
+++ b/products/outpost/templates/.claude/agents/postman.md
@@ -17,11 +17,13 @@ and Teams, triage what's new, take the most valuable action.
 
 ## Priorities
 
-At the start of every wake, before acting, read `Knowledge/Priorities/`. The
-user's priorities are the lens for all your work this wake.
+At the start of every wake, before acting, read `Knowledge/Priorities/` and
+`Knowledge/Conditions/` (which constrains them — see Operating Context in
+CLAUDE.md). The user's priorities are the lens for all your work this wake.
 
 - **Always consider them.** Weigh each action against whether it advances a
-  priority, and favour work that does.
+  priority, and favour work that does. Let the active conditions shape how you
+  act on it.
 - **Always flag risks.** When you encounter a chat, email, transcript, or any
   other signal that could **contradict, block, or slow** a priority, record it
   under a `## Priority Watch` heading in your triage report — name the priority,

--- a/products/outpost/templates/.claude/agents/recruiter.md
+++ b/products/outpost/templates/.claude/agents/recruiter.md
@@ -22,11 +22,13 @@ assessment and recommendation references the standard.
 
 ## Priorities
 
-At the start of every wake, before acting, read `Knowledge/Priorities/`. The
-user's priorities are the lens for all your work this wake.
+At the start of every wake, before acting, read `Knowledge/Priorities/` and
+`Knowledge/Conditions/` (which constrains them — see Operating Context in
+CLAUDE.md). The user's priorities are the lens for all your work this wake.
 
 - **Always consider them.** Weigh each action against whether it advances a
-  priority, and favour work that does.
+  priority, and favour work that does. Let the active conditions shape how you
+  act on it.
 - **Always flag risks.** When you encounter a chat, email, transcript, or any
   other signal that could **contradict, block, or slow** a priority, record it
   under a `## Priority Watch` heading in your triage report — name the priority,

--- a/products/outpost/templates/.claude/skills/sync-teams/SKILL.md
+++ b/products/outpost/templates/.claude/skills/sync-teams/SKILL.md
@@ -144,6 +144,12 @@ Key conventions:
 - **Normalize names** from Teams format ("Last, First") to "First Last"
 - **Platform** line distinguishes Teams from email in downstream processing
 - **Plain text only** — HTML is stripped, mentions are preserved as plain text
+- **Attachments are not extracted** — files/images on a message are dropped from
+  the markdown. They are hosted on SharePoint/OneDrive, not in the local cache.
+  However, the user has **often manually downloaded** them, so an attachment
+  usually exists under `~/Downloads/` with the **same file name** shown in Teams.
+  When a message references an attachment and you need its contents, look there
+  first.
 - Skip system messages (calls, member adds/removes, topic changes)
 
 ## Error Handling
@@ -175,3 +181,7 @@ Key conventions:
 - Some V8-serialized records (~17% in testing) use formats that
   `v8.deserialize()` cannot decode. These are silently skipped — they are
   typically IndexedDB metadata, not conversation or message records.
+- **Attachments (files/images) are never synced into the markdown** — only the
+  message text is captured. The binaries live on SharePoint/OneDrive, but the
+  user frequently downloads them, so the same-named file is usually already in
+  `~/Downloads/`. Check there before trying to fetch from SharePoint.

--- a/products/outpost/templates/.claude/skills/sync-teams/scripts/idb-reader.mjs
+++ b/products/outpost/templates/.claude/skills/sync-teams/scripts/idb-reader.mjs
@@ -31,21 +31,64 @@ function readIdbVarint(buf, offset) {
   return { value: result, bytesRead: pos - offset };
 }
 
+// Highest V8 serialization wire-format version Node's bundled v8.deserialize
+// accepts. Newer Teams/WebView2 builds write version 16, which Node rejects
+// outright even though the payload itself is wire-compatible. We patch the
+// version byte down to this value before deserializing. Bump if Node's V8
+// starts emitting/accepting a higher version natively.
+const V8_MAX_SUPPORTED_VERSION = 15;
+
+// Plausible V8 top-level value tags that immediately follow the
+// [0xFF <version>] header. Used to locate the real V8 payload start inside the
+// Blink envelope without relying on a fixed byte offset (newer envelopes carry
+// a 0xFE trailer that shifts the payload further in). We only ever ACT on a
+// candidate by attempting a deserialize, which validates it — so a stray match
+// just gets skipped.
+const V8_TOP_LEVEL_TAGS = new Set([
+  0x6f, // 'o' begin JS object
+  0x22, // '"' one-byte string
+  0x63, // 'c' two-byte string
+  0x44, // 'D' utf8 string
+  0x49, // 'I' int32
+  0x55, // 'U' uint32
+  0x4e, // 'N' number (double)
+  0x6c, // 'l' bigint
+  0x7b, // '{' begin map
+  0x41, // 'A' begin dense array
+  0x61, // 'a' begin sparse array
+  0x5f, // '_' undefined
+  0x54, // 'T' true
+  0x46, // 'F' false
+  0x30, // '0' null
+]);
+
+// Only the Blink envelope precedes the V8 payload, and it is always small.
+// Scanning a generous prefix keeps non-message records (which never decode)
+// cheap while comfortably covering every real envelope/trailer layout.
+const V8_START_SCAN_LIMIT = 256;
+
 /**
- * Try to deserialize from the second 0xFF marker within the first `limit` bytes.
- * The Blink envelope has: [varint wire_size] [0xFF blink_ver] [envelope...] [0xFF v8_ver] [V8 data]
- * We want the second 0xFF that starts valid V8 data.
+ * Deserialize the V8 payload starting at `off`. Tries the bytes as-is first,
+ * then — for records whose version byte is newer than Node supports — retries
+ * with the version patched down. The wire format is backward-compatible, so a
+ * supported version reads the newer payload correctly.
  */
-function deserializeFromSecondMarker(rawValue, limit) {
-  let ffCount = 0;
-  for (let i = 0; i < limit; i++) {
-    if (rawValue[i] !== 0xff) continue;
-    ffCount++;
-    if (ffCount >= 2) {
+function deserializeAt(rawValue, off) {
+  try {
+    return v8.deserialize(rawValue.subarray(off));
+  } catch {
+    // fall through to version patching
+  }
+
+  const version = rawValue[off + 1];
+  if (version > V8_MAX_SUPPORTED_VERSION) {
+    const patched = Buffer.from(rawValue.subarray(off));
+    for (let v = V8_MAX_SUPPORTED_VERSION; v >= 13; v--) {
+      patched[1] = v;
       try {
-        return v8.deserialize(rawValue.subarray(i));
+        return v8.deserialize(patched);
       } catch {
-        // keep scanning
+        // try the next-lower version
       }
     }
   }
@@ -53,34 +96,24 @@ function deserializeFromSecondMarker(rawValue, limit) {
 }
 
 /**
- * Fallback: try deserializing from every 0xFF position within `limit` bytes.
- */
-function deserializeFromAnyMarker(rawValue, limit) {
-  for (let i = 0; i < limit; i++) {
-    if (rawValue[i] !== 0xff) continue;
-    try {
-      return v8.deserialize(rawValue.subarray(i));
-    } catch {
-      continue;
-    }
-  }
-  return null;
-}
-
-/**
  * Try to deserialize a Chromium IndexedDB value.
- * Values have a Blink envelope before the V8 payload.
- * Scans for the V8 version tag (0xFF) and attempts deserialization.
+ *
+ * Values have a Blink envelope (and, in newer WebView2 builds, a 0xFE trailer)
+ * before the V8 payload. Locate the payload by scanning for a [0xFF <version>
+ * <top-level tag>] header, then decode it — patching the version byte down for
+ * records written with a V8 wire version newer than Node accepts.
  */
 function tryDeserialize(rawValue) {
   if (!rawValue || rawValue.length < 4) return null;
 
-  const headerLimit = Math.min(rawValue.length, 60);
-  const result = deserializeFromSecondMarker(rawValue, headerLimit);
-  if (result !== null) return result;
-
-  const fallbackLimit = Math.min(rawValue.length, 100);
-  return deserializeFromAnyMarker(rawValue, fallbackLimit);
+  const limit = Math.min(rawValue.length - 2, V8_START_SCAN_LIMIT);
+  for (let i = 0; i <= limit; i++) {
+    if (rawValue[i] !== 0xff) continue;
+    if (!V8_TOP_LEVEL_TAGS.has(rawValue[i + 2])) continue;
+    const obj = deserializeAt(rawValue, i);
+    if (obj !== null) return obj;
+  }
+  return null;
 }
 
 /**

--- a/products/outpost/templates/CLAUDE.md
+++ b/products/outpost/templates/CLAUDE.md
@@ -26,15 +26,22 @@ never a "black book". These rules override all other instructions:
 
 When in doubt, err toward discretion.
 
-## Voice
+## Operating Context
 
-Be supportive and direct. Explain complex things clearly without hedging. When
-the next step is obvious, take it. Ask at most one clarifying question, at the
-start. Reference files by full path. Confirm before destructive actions.
+Two folders in the knowledge graph frame your work:
 
-## Dependencies
+- **`Knowledge/Priorities/`** — the backbone of every decision: what the user is
+  trying to advance. Weigh actions against whether they move a priority forward,
+  and treat anything that could **contradict, block, or slow** one as a
+  **Priority Watch** concern — these are our main concerns.
+- **`Knowledge/Conditions/`** — the live operating environment (e.g. a hiring
+  freeze, a reorg, a contract transition). Conditions don't set goals; they
+  **constrain how** we pursue the priorities. Let them shape what you propose
+  and how you phrase it.
 
-- **ripgrep** (`rg`) for fast knowledge graph searches — `brew install ripgrep`.
+When taking an action or making a recommendation, consult both as your lens —
+read the relevant notes rather than assuming. Skip this only for general
+knowledge or brainstorming.
 
 ## Workspace Layout & Sharing
 
@@ -54,6 +61,10 @@ CLI to install or update the standard instruction set.
 ├── Briefings/          # Daily briefings (personal)
 └── .mcp.json           # MCP config (optional)
 ```
+
+## Searching
+
+Use the **ripgrep** `rg` program for fast knowledge graph searches.
 
 ## Agents
 
@@ -91,31 +102,8 @@ meetings, emails, and messages directly from the source dirs below.
 - `state/` — per-source last-sync timestamps, processed-file index, and
   `{agent}_triage.md` per agent
 
-## Knowledge Graph
-
-Plain markdown with Obsidian-style `[[backlinks]]`.
-
-```bash
-rg "Sarah Chen" Knowledge/               # Search by name
-cat "Knowledge/People/Sarah Chen.md"     # Read a note
-```
-
-**Always search broadly first.** When the user mentions any person, org, project,
-or topic, run `rg "keyword" Knowledge/` to surface every note — one note is never
-the full story. Skip it only for general knowledge and brainstorming.
-
-## Skills
-
-Skills auto-discover from `.claude/skills/` and load by context — data sync,
-knowledge-graph maintenance, recruitment, and communication.
-
 ## User Identity
 
 The current user's identity is cached at
 `~/.cache/fit/outpost/state/identity.md` — read it directly. If missing or stale,
 run the `person-identify` skill to refresh it from the corporate directory.
-
-## Working Outside This Directory
-
-You have full filesystem access (macOS). For tasks outside this KB, use shell
-commands directly.


### PR DESCRIPTION
## Summary

- Introduce `Knowledge/Conditions/` alongside `Knowledge/Priorities/` as the
  operating lens across the root `CLAUDE.md` and all six agent profiles:
  priorities set goals, conditions constrain how they are pursued.
- Restructure `CLAUDE.md` into an Operating Context section and fold the old
  dependencies/knowledge-graph guidance into a leaner Searching section.
- Harden the `sync-teams` `idb-reader`: locate the V8 payload by scanning for a
  `[0xFF version top-level-tag]` header instead of a fixed offset, and patch
  down wire versions newer than Node accepts (e.g. v16 from newer WebView2
  builds).
- Document that Teams attachments are not synced and usually live in
  `~/Downloads/` under the same file name.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`