### PR TITLE
docs(libraries): align descriptions and JTBD with what libraries actually do

### DIFF
--- a/libraries/README.md
+++ b/libraries/README.md
@@ -10,47 +10,47 @@ can read and tune via JSON.
 
 <!-- BEGIN:catalog — Do not edit. Generated from each library's package.json. -->
 
-| Library                | Description                                                                                                                                     |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| **libbridge**          | Threaded-channel bridge primitives — relay messages between human channels (GitHub Discussions, Microsoft Teams) and the Kata agent team.       |
-| **libcli**             | Agent-friendly CLIs — self-documenting entry points that humans and agents reach through the same interface.                                    |
-| **libcoaligned**       | Co-Aligned architecture checks — enforce instruction-layer length caps, JTBD invariants, and the repo's own declarative invariant rule modules. |
-| **libcodegen**         | Protobuf code generation — keep types in sync with proto definitions without hand-writing.                                                      |
-| **libconfig**          | Environment-aware application settings — services and CLIs load configuration without custom plumbing.                                          |
-| **libdoc**             | Static documentation sites from markdown — publish docs without a framework.                                                                    |
-| **libformat**          | Render markdown to ANSI or HTML — formatted output in any surface without losing structure.                                                     |
-| **libgraph**           | RDF triple store with named ontologies — answer relationship questions without writing join logic.                                              |
-| **libharness**         | Agent evaluation framework — prove whether agent changes improved outcomes with reproducible evidence.                                          |
-| **libhttp**            | HTTP service framework — ship a Hono service endpoint without reimplementing lifecycle, security headers, or health checks.                     |
-| **libindex**           | JSONL-backed indexes with filtering and buffered writes — fast context lookup without an external search engine.                                |
-| **libmacos**           | macOS bundle assembly, code signing, and OS permission helpers — desktop delivery without platform ceremony.                                    |
-| **libmcp**             | Config-driven gRPC-to-MCP tool registration — expose protobuf services as agent tools without glue code.                                        |
-| **libmock**            | Shared mocks and test fixtures so every library and service tests the same way.                                                                 |
-| **libpack**            | Pack distribution — tarballs, bare git repos, and skill discovery indices                                                                       |
-| **libpolicy**          | Access-control policy evaluation — scoped context access without per-service authorization logic.                                               |
-| **libpreflight**       | Fail fast at process start with product-authored errors — runtime-floor checks and required-config assertions before heavy imports resolve.     |
-| **libprompt**          | Prompt templates from .prompt.md files — structured prompts without string concatenation.                                                       |
-| **libproto**           | Shared protobuf schemas — one editable source for the service contracts every product imports.                                                  |
-| **librc**              | Service lifecycle management — start, stop, and check services without manual oversight.                                                        |
-| **librepl**            | Agent-friendly interactive REPL — exploratory interfaces that humans and agents navigate the same way.                                          |
-| **libresource**        | Typed resources with identifiers and rich context chunks — trustworthy, retrievable knowledge for agent grounding.                              |
-| **librpc**             | gRPC server and client framework — ship service endpoints without reimplementing transport.                                                     |
-| **libsecret**          | Secret generation, JWT signing, and .env file management for services and CLIs.                                                                 |
-| **libskill**           | Derive skill matrices, agent profiles, and job definitions from standard data — the engineering standard made queryable.                        |
-| **libstorage**         | Pluggable file storage — local, S3, or Supabase behind a single interface.                                                                      |
-| **libsupervise**       | Process supervision driven by JSON daemon manifests — services stay running and recoverable without manual intervention.                        |
-| **libsyntheticgen**    | DSL parser and deterministic entity graph generator — repeatable eval fixtures so results are reproducible.                                     |
-| **libsyntheticprose**  | LLM-generated prose and YAML — realistic evaluation content so agent improvements are tested against lifelike data.                             |
-| **libsyntheticrender** | Multi-format rendering of synthetic evaluation data — validate fixtures before they enter the eval pipeline.                                    |
-| **libtelemetry**       | Structured logging and trace spans — observable operations so problems surface before they escalate.                                            |
-| **libtemplate**        | Mustache template loader with project-level overrides — consistent rendered output across surfaces.                                             |
-| **libterrain**         | Full synthetic data pipeline — generate, render, and validate evaluation datasets end to end.                                                   |
-| **libtype**            | Generated protobuf types and namespaces — one source of truth for service contracts.                                                            |
-| **libui**              | Agent-friendly web surfaces — share handler logic across web and terminal so capabilities ship once, not twice.                                 |
-| **libutil**            | Cross-cutting utilities: retry, hashing, token counting, and project discovery.                                                                 |
-| **libvector**          | Vector dot-product scoring — find semantically related content without a dedicated database.                                                    |
-| **libwiki**            | Wiki lifecycle primitives — stable memory for agent teams so coordination persists across sessions.                                             |
-| **libxmr**             | Wheeler/Vacanti XmR control charts — distinguish signal from noise so agent teams act on real changes, not fluctuations.                        |
+| Library                | Description                                                                                                                                                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **libbridge**          | Channel-to-agent-team bridge — relay messages between human channels (GitHub Discussions, Microsoft Teams) and the agent team, with thread state, multi-tenant routing, rate limits, and resume scheduling handled once. |
+| **libcli**             | Agent-friendly CLIs — self-documenting entry points that humans and agents reach through the same interface.                                                                                                             |
+| **libcoaligned**       | Co-Aligned architecture checks — enforce instruction-layer length caps, JTBD invariants, and the repo's own declarative invariant rule modules.                                                                          |
+| **libcodegen**         | Protobuf code generation — keep types in sync with proto definitions without hand-writing.                                                                                                                               |
+| **libconfig**          | Environment-aware application settings — services and CLIs load configuration without custom plumbing.                                                                                                                   |
+| **libdoc**             | Static documentation sites from markdown — publish docs without a framework.                                                                                                                                             |
+| **libformat**          | Render markdown to ANSI or HTML — formatted output in any surface without losing structure.                                                                                                                              |
+| **libgraph**           | RDF triple store with named ontologies — answer relationship questions without writing join logic.                                                                                                                       |
+| **libharness**         | Autonomous agent team harness — coordinate a lead and participant agents in one async session, with eval, benchmark, and trace tooling to prove the changes worked.                                                      |
+| **libhttp**            | HTTP service framework — ship a Hono service endpoint without reimplementing lifecycle, security headers, or health checks.                                                                                              |
+| **libindex**           | JSONL-backed indexes with filtering and buffered writes — fast context lookup without an external search engine.                                                                                                         |
+| **libmacos**           | macOS bundle assembly, code signing, and OS permission helpers — desktop delivery without platform ceremony.                                                                                                             |
+| **libmcp**             | Config-driven gRPC-to-MCP tool registration — expose protobuf services as agent tools without glue code.                                                                                                                 |
+| **libmock**            | Shared mocks and test fixtures so every library and service tests the same way.                                                                                                                                          |
+| **libpack**            | Pack distribution — tarballs, bare git repos, and skill discovery indices                                                                                                                                                |
+| **libpolicy**          | Access-control policy evaluation — scoped context access without per-service authorization logic.                                                                                                                        |
+| **libpreflight**       | Fail fast at process start with product-authored errors — runtime-floor checks and required-config assertions before heavy imports resolve.                                                                              |
+| **libprompt**          | Prompt templates from .prompt.md files — structured prompts without string concatenation.                                                                                                                                |
+| **libproto**           | Shared protobuf schemas — one editable source for the service contracts every product imports.                                                                                                                           |
+| **librc**              | Service lifecycle management — start, stop, and check services without manual oversight.                                                                                                                                 |
+| **librepl**            | Agent-friendly interactive REPL — exploratory interfaces that humans and agents navigate the same way.                                                                                                                   |
+| **libresource**        | Typed resources with identifiers and rich context chunks — trustworthy, retrievable knowledge for agent grounding.                                                                                                       |
+| **librpc**             | gRPC server and client framework — ship service endpoints without reimplementing transport.                                                                                                                              |
+| **libsecret**          | Secret generation, JWT signing, and .env file management for services and CLIs.                                                                                                                                          |
+| **libskill**           | The engineering standard made queryable — derive skill matrices, job definitions, agent profiles, career paths, and interview plans from standard data.                                                                  |
+| **libstorage**         | Pluggable file storage — local, S3, or Supabase behind a single interface.                                                                                                                                               |
+| **libsupervise**       | Process supervision driven by JSON daemon manifests — services stay running and recoverable without manual intervention.                                                                                                 |
+| **libsyntheticgen**    | DSL parser and deterministic entity graph generator — repeatable eval fixtures so results are reproducible.                                                                                                              |
+| **libsyntheticprose**  | LLM-generated prose and YAML — realistic evaluation content so agent improvements are tested against lifelike data.                                                                                                      |
+| **libsyntheticrender** | Multi-format rendering of synthetic evaluation data — validate fixtures before they enter the eval pipeline.                                                                                                             |
+| **libtelemetry**       | Structured logging and trace spans — observable operations so problems surface before they escalate.                                                                                                                     |
+| **libtemplate**        | Mustache template loader with project-level overrides — consistent rendered output across surfaces.                                                                                                                      |
+| **libterrain**         | Full synthetic data pipeline — generate, render, and validate evaluation datasets end to end.                                                                                                                            |
+| **libtype**            | Generated protobuf types and namespaces — one source of truth for service contracts.                                                                                                                                     |
+| **libui**              | Agent-friendly web surfaces — share handler logic across web and terminal so capabilities ship once, not twice.                                                                                                          |
+| **libutil**            | Cross-cutting utilities: retry, hashing, token counting, and project discovery.                                                                                                                                          |
+| **libvector**          | Vector dot-product scoring — find semantically related content without a dedicated database.                                                                                                                             |
+| **libwiki**            | Wiki lifecycle for agent teams — persistent memory, declarative integrity audits, and a collision ledger so coordination survives across sessions and parallel work.                                                     |
+| **libxmr**             | Wheeler/Vacanti XmR control charts — distinguish signal from noise so agent teams act on real changes, not fluctuations.                                                                                                 |
 
 <!-- END:catalog -->
 
@@ -70,9 +70,9 @@ whether it is a real shift or just noise.
 sessions; distinguish signal from noise so the team acts on real changes, not
 fluctuations. → **libwiki, libxmr**
 
-**Little Hire:** Help me send a memo or update a storyboard without managing the
-wiki infrastructure; chart a metric and see whether the latest point is within
-expected variation. → **libwiki, libxmr**
+**Little Hire:** Help me send a memo, run an integrity audit, or refresh a
+storyboard without managing the wiki infrastructure; chart a metric and see
+whether the latest point is within expected variation. → **libwiki, libxmr**
 
 **Competes With:** git commit messages as memory; ephemeral conversation
 context; starting every session from scratch; eyeballing trend lines; arbitrary
@@ -80,24 +80,31 @@ thresholds; ignoring metrics because no one trusts them.
 
 </job>
 
-<job user="Platform Builders" goal="Bridge Conversations to the Agent Team">
+<job user="Platform Builders" goal="Coordinate an Agent Team">
 
-## Platform Builders: Bridge Conversations to the Agent Team
+## Platform Builders: Coordinate an Agent Team
 
 **Trigger:** Engineers discuss work in chat and GitHub Discussions while the
 agent team is reachable only from GitHub, and every new channel adapter
-re-solves intake, thread state, and tenant routing.
+re-solves intake, thread state, and tenant routing; coordinating several agents
+in one session means hand-rolling message passing, turn-taking, and termination,
+and every orchestration script re-solves it.
 
 **Big Hire:** Help me relay conversations between the channels engineers already
-use and the agent team, with thread state and tenant resolution handled once. →
-**libbridge**
+use and the agent team, with thread state, multi-tenant routing, and resume
+scheduling handled once; coordinate a lead and participant agents over async
+messages in one session. → **libbridge, libharness**
 
 **Little Hire:** Help me register a callback token, build a bounded prompt, and
-dispatch a workflow without managing each piece directly. → **libbridge**
+dispatch a workflow without managing each piece directly; run a supervised pair,
+a facilitated meeting, or a multi-agent discussion without writing the message
+bus and turn loop. → **libbridge, libharness**
 
 **Competes With:** manually creating GitHub issues; copy-pasting between chat
 and GitHub; per-channel duplication of intake skeletons; ephemeral thread state
-that vanishes on restart.
+that vanishes on restart; manual orchestration scripts; hand-rolled message
+passing and turn-taking; sequential single-agent calls; running one agent at a
+time.
 
 </job>
 
@@ -174,8 +181,8 @@ them through their preferred tool; turn engineering standard definitions into
 queryable, derivable data. → **libpack, libskill**
 
 **Little Hire:** Help me add a distribution format without reimplementing the
-staging and orchestration loop; derive a skill matrix or agent profile without
-parsing YAML by hand. → **libpack, libskill**
+staging and orchestration loop; derive a skill matrix, agent profile, career
+path, or interview plan without parsing YAML by hand. → **libpack, libskill**
 
 **Competes With:** inlining pack logic in each product command; hand-rolling tar
 and git plumbing per consumer; maintaining parallel format-specific scripts;
@@ -214,21 +221,38 @@ agree.
 ## Platform Builders: Prove Agent Changes
 
 **Trigger:** An eval passes locally but fails in CI and the only output is
-'assertion failed.'; setting up an eval and realizing you need to coordinate
-generation, rendering, and validation across three libraries.
+'assertion failed.'; an eval needs a populated world to run against and
+hand-built fixtures drift out of sync with the schema; eval fixtures read like
+lorem ipsum and agents are tested against content nothing like what they meet in
+production; generated fixtures reach the eval in the wrong shape, or with broken
+cross-links, and the failure surfaces mid-run; setting up an eval and realizing
+you need to coordinate generation, rendering, and validation across three
+libraries.
 
 **Big Hire:** Help me prove whether agent changes improved outcomes with
-reproducible evidence; produce a complete eval dataset from a single DSL file. →
-**libharness, libterrain**
+reproducible evidence; generate a deterministic entity graph from a DSL so eval
+fixtures are repeatable; fill the entity graph with realistic LLM-generated
+prose and YAML so agents are tested against lifelike data; render synthetic data
+to every format the eval consumes and validate it before it enters the pipeline;
+produce a complete eval dataset from a single DSL file. → **libharness,
+libsyntheticgen, libsyntheticprose, libsyntheticrender, libterrain**
 
-**Little Hire:** Help me run an eval and get a trace that shows exactly what the
-agent did; regenerate a dataset after a schema change and trust the pipeline
-handles the rest. → **libharness, libterrain**
+**Little Hire:** Help me run an eval or benchmark and get a trace that shows
+exactly what the agent did; regenerate the entity graph after a schema change
+and get the same world every run; generate realistic content for an entity
+without writing prompts or cleaning up the output by hand; render an entity to
+HTML, markdown, or JSON and catch a broken link before the eval runs; regenerate
+a dataset after a schema change and trust the pipeline handles the rest. →
+**libharness, libsyntheticgen, libsyntheticprose, libsyntheticrender,
+libterrain**
 
 **Competes With:** manual before/after comparison; trusting gut feeling over
-evidence; skipping evaluation entirely; scripting the pipeline by hand;
-coordinating libraries manually; using stale fixtures and hoping they still
-apply.
+evidence; skipping evaluation entirely; hand-built fixtures; random data that
+differs every run; copying a production snapshot; lorem ipsum fixtures;
+hand-written sample content; testing against unrealistic data; per-format
+rendering code; validating fixtures by eye; discovering broken fixtures
+mid-eval; scripting the pipeline by hand; coordinating libraries manually; using
+stale fixtures and hoping they still apply.
 
 </job>
 

--- a/libraries/libbridge/README.md
+++ b/libraries/libbridge/README.md
@@ -2,8 +2,9 @@
 
 <!-- BEGIN:description — Do not edit. Generated from package.json. -->
 
-Threaded-channel bridge primitives — relay messages between human channels
-(GitHub Discussions, Microsoft Teams) and the Kata agent team.
+Channel-to-agent-team bridge — relay messages between human channels (GitHub
+Discussions, Microsoft Teams) and the agent team, with thread state,
+multi-tenant routing, rate limits, and resume scheduling handled once.
 
 <!-- END:description -->
 

--- a/libraries/libbridge/package.json
+++ b/libraries/libbridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libbridge",
   "version": "0.1.18",
-  "description": "Threaded-channel bridge primitives — relay messages between human channels (GitHub Discussions, Microsoft Teams) and the Kata agent team.",
+  "description": "Channel-to-agent-team bridge — relay messages between human channels (GitHub Discussions, Microsoft Teams) and the agent team, with thread state, multi-tenant routing, rate limits, and resume scheduling handled once.",
   "keywords": [
     "bridge",
     "discussions",
@@ -20,9 +20,9 @@
   "jobs": [
     {
       "user": "Platform Builders",
-      "goal": "Bridge Conversations to the Agent Team",
+      "goal": "Coordinate an Agent Team",
       "trigger": "Engineers discuss work in chat and GitHub Discussions while the agent team is reachable only from GitHub, and every new channel adapter re-solves intake, thread state, and tenant routing.",
-      "bigHire": "relay conversations between the channels engineers already use and the agent team, with thread state and tenant resolution handled once.",
+      "bigHire": "relay conversations between the channels engineers already use and the agent team, with thread state, multi-tenant routing, and resume scheduling handled once.",
       "littleHire": "register a callback token, build a bounded prompt, and dispatch a workflow without managing each piece directly.",
       "competesWith": "manually creating GitHub issues; copy-pasting between chat and GitHub; per-channel duplication of intake skeletons; ephemeral thread state that vanishes on restart"
     }

--- a/libraries/libharness/README.md
+++ b/libraries/libharness/README.md
@@ -2,8 +2,9 @@
 
 <!-- BEGIN:description — Do not edit. Generated from package.json. -->
 
-Agent evaluation framework — prove whether agent changes improved outcomes with
-reproducible evidence.
+Autonomous agent team harness — coordinate a lead and participant agents in one
+async session, with eval, benchmark, and trace tooling to prove the changes
+worked.
 
 <!-- END:description -->
 

--- a/libraries/libharness/package.json
+++ b/libraries/libharness/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@forwardimpact/libharness",
   "version": "1.1.0",
-  "description": "Agent evaluation framework — prove whether agent changes improved outcomes with reproducible evidence.",
+  "description": "Autonomous agent team harness — coordinate a lead and participant agents in one async session, with eval, benchmark, and trace tooling to prove the changes worked.",
   "keywords": [
+    "orchestration",
+    "supervisor",
+    "facilitator",
     "eval",
-    "agent",
     "trace",
-    "claude-code",
-    "supervisor"
+    "agent"
   ],
   "homepage": "https://www.forwardimpact.team",
   "repository": {
@@ -20,10 +21,18 @@
   "jobs": [
     {
       "user": "Platform Builders",
+      "goal": "Coordinate an Agent Team",
+      "trigger": "Coordinating several agents in one session means hand-rolling message passing, turn-taking, and termination, and every orchestration script re-solves it.",
+      "bigHire": "coordinate a lead and participant agents over async messages in one session.",
+      "littleHire": "run a supervised pair, a facilitated meeting, or a multi-agent discussion without writing the message bus and turn loop.",
+      "competesWith": "manual orchestration scripts; hand-rolled message passing and turn-taking; sequential single-agent calls; running one agent at a time"
+    },
+    {
+      "user": "Platform Builders",
       "goal": "Prove Agent Changes",
       "trigger": "An eval passes locally but fails in CI and the only output is 'assertion failed.'",
       "bigHire": "prove whether agent changes improved outcomes with reproducible evidence.",
-      "littleHire": "run an eval and get a trace that shows exactly what the agent did.",
+      "littleHire": "run an eval or benchmark and get a trace that shows exactly what the agent did.",
       "competesWith": "manual before/after comparison; trusting gut feeling over evidence; skipping evaluation entirely"
     }
   ],

--- a/libraries/libskill/README.md
+++ b/libraries/libskill/README.md
@@ -2,8 +2,9 @@
 
 <!-- BEGIN:description — Do not edit. Generated from package.json. -->
 
-Derive skill matrices, agent profiles, and job definitions from standard data —
-the engineering standard made queryable.
+The engineering standard made queryable — derive skill matrices, job
+definitions, agent profiles, career paths, and interview plans from standard
+data.
 
 <!-- END:description -->
 

--- a/libraries/libskill/package.json
+++ b/libraries/libskill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libskill",
   "version": "6.0.1",
-  "description": "Derive skill matrices, agent profiles, and job definitions from standard data — the engineering standard made queryable.",
+  "description": "The engineering standard made queryable — derive skill matrices, job definitions, agent profiles, career paths, and interview plans from standard data.",
   "keywords": [
     "skill",
     "agent",
@@ -23,7 +23,7 @@
       "goal": "Integrate with the Engineering Standard",
       "trigger": "Building a product feature that needs skill matrices or job definitions and realizing the YAML is raw data, not queryable structure.",
       "bigHire": "turn engineering standard definitions into queryable, derivable data.",
-      "littleHire": "derive a skill matrix or agent profile without parsing YAML by hand.",
+      "littleHire": "derive a skill matrix, agent profile, career path, or interview plan without parsing YAML by hand.",
       "competesWith": "parsing YAML files directly; hardcoding role definitions; skipping derivation and displaying raw data"
     }
   ],

--- a/libraries/libsyntheticgen/package.json
+++ b/libraries/libsyntheticgen/package.json
@@ -17,6 +17,16 @@
   },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Platform Builders",
+      "goal": "Prove Agent Changes",
+      "trigger": "An eval needs a populated world to run against and hand-built fixtures drift out of sync with the schema.",
+      "bigHire": "generate a deterministic entity graph from a DSL so eval fixtures are repeatable.",
+      "littleHire": "regenerate the entity graph after a schema change and get the same world every run.",
+      "competesWith": "hand-built fixtures; random data that differs every run; copying a production snapshot"
+    }
+  ],
   "type": "module",
   "main": "./src/index.js",
   "exports": {

--- a/libraries/libsyntheticprose/package.json
+++ b/libraries/libsyntheticprose/package.json
@@ -17,6 +17,16 @@
   },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Platform Builders",
+      "goal": "Prove Agent Changes",
+      "trigger": "Eval fixtures read like lorem ipsum and agents are tested against content nothing like what they meet in production.",
+      "bigHire": "fill the entity graph with realistic LLM-generated prose and YAML so agents are tested against lifelike data.",
+      "littleHire": "generate realistic content for an entity without writing prompts or cleaning up the output by hand.",
+      "competesWith": "lorem ipsum fixtures; hand-written sample content; testing against unrealistic data"
+    }
+  ],
   "type": "module",
   "main": "./src/index.js",
   "exports": {

--- a/libraries/libsyntheticrender/package.json
+++ b/libraries/libsyntheticrender/package.json
@@ -17,6 +17,16 @@
   },
   "license": "Apache-2.0",
   "author": "D. Olsson <hi@senzilla.io>",
+  "jobs": [
+    {
+      "user": "Platform Builders",
+      "goal": "Prove Agent Changes",
+      "trigger": "Generated fixtures reach the eval in the wrong shape, or with broken cross-links, and the failure surfaces mid-run.",
+      "bigHire": "render synthetic data to every format the eval consumes and validate it before it enters the pipeline.",
+      "littleHire": "render an entity to HTML, markdown, or JSON and catch a broken link before the eval runs.",
+      "competesWith": "per-format rendering code; validating fixtures by eye; discovering broken fixtures mid-eval"
+    }
+  ],
   "type": "module",
   "main": "./src/index.js",
   "exports": {

--- a/libraries/libwiki/README.md
+++ b/libraries/libwiki/README.md
@@ -2,8 +2,9 @@
 
 <!-- BEGIN:description — Do not edit. Generated from package.json. -->
 
-Wiki lifecycle primitives — stable memory for agent teams so coordination
-persists across sessions.
+Wiki lifecycle for agent teams — persistent memory, declarative integrity
+audits, and a collision ledger so coordination survives across sessions and
+parallel work.
 
 <!-- END:description -->
 

--- a/libraries/libwiki/package.json
+++ b/libraries/libwiki/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@forwardimpact/libwiki",
   "version": "0.2.31",
-  "description": "Wiki lifecycle primitives — stable memory for agent teams so coordination persists across sessions.",
+  "description": "Wiki lifecycle for agent teams — persistent memory, declarative integrity audits, and a collision ledger so coordination survives across sessions and parallel work.",
   "keywords": [
     "wiki",
     "memo",
@@ -23,7 +23,7 @@
       "goal": "Operate a Predictable Agent Team",
       "trigger": "An agent finishes a session and its findings vanish because there is no shared memory to write them to.",
       "bigHire": "give agent teams stable memory that persists across sessions.",
-      "littleHire": "send a memo or update a storyboard without managing the wiki infrastructure.",
+      "littleHire": "send a memo, run an integrity audit, or refresh a storyboard without managing the wiki infrastructure.",
       "competesWith": "git commit messages as memory; ephemeral conversation context; starting every session from scratch"
     }
   ],


### PR DESCRIPTION
## Summary

- Reframe **libharness** from an eval framework to an **autonomous agent team harness** (coordination runtime), with eval/benchmark/trace tooling as secondary. The rename from `libeval` (#2110) had landed but `.description`/`.jobs` were still eval-shaped.
- New **Coordinate an Agent Team** job (Platform Builders) binds **libharness** + **libbridge**, retiring libbridge's solo "Bridge Conversations to the Agent Team" goal — net zero new job goals.
- Widen **Prove Agent Changes** to **libharness + libterrain + libsyntheticgen/prose/render** (the three synthetic libs had no `.jobs` before, so were undiscoverable).
- Sharpen **libwiki**, **libskill**, and **libbridge** descriptions to match real scope (integrity audits + collision ledger; career paths + interview plans; multi-tenant routing + rate limits + resume).
- Regenerate catalog, merged job blocks, and per-library description blocks via `bun run context:fix`.

Grounding cluster (libgraph/libindex/libresource/libvector), libterrain's description, and libxmr were reviewed and left unchanged — already aligned.

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`