### PR TITLE
docs(website): align library guides with the Coordinate an Agent Team job

### DIFF
--- a/libraries/libharness/README.md
+++ b/libraries/libharness/README.md
@@ -210,6 +210,7 @@ lists the `Edit()` rules that were tried.
 
 ## Documentation
 
-- [Agent Evaluations Guide](https://www.forwardimpact.team/docs/libraries/agent-evaluations/index.md) — how to run an eval and read its trace.
-- [Agent Collaboration Guide](https://www.forwardimpact.team/docs/libraries/agent-collaboration/index.md) — supervise / facilitate / discuss in depth.
-- [Trace Analysis Guide](https://www.forwardimpact.team/docs/libraries/trace-analysis/index.md) — analysing NDJSON traces with `fit-trace`.
+- [Run an Eval](https://www.forwardimpact.team/docs/libraries/prove-changes/run-eval/index.md) — author a judge profile, run an eval locally, wire it into CI, and inspect the resulting trace.
+- [Prove Agent Changes](https://www.forwardimpact.team/docs/libraries/prove-changes/index.md) — end-to-end workflow from dataset generation through evaluation to trace analysis, including multi-agent collaboration sessions.
+- [Analyze Traces](https://www.forwardimpact.team/docs/libraries/prove-changes/trace-analysis/index.md) — read the NDJSON traces produced by `fit-harness` with `fit-trace`.
+- [Agent Teams](https://www.forwardimpact.team/docs/products/agent-teams/index.md) — author the profiles consumed by `--agent-profile`, `--lead-profile`, and `--agent-profiles`.

--- a/websites/README.md
+++ b/websites/README.md
@@ -83,7 +83,7 @@ keeps multiple Big Hire trees — slugs are published URLs and do not move
 | Little | `predictable-team/wiki-operations/` | Send a Memo or Update a Storyboard |
 | Little | `predictable-team/xmr-analysis/` | Chart a Metric and Check Variation |
 
-**Bridge Conversations to the Agent Team** (Builders → libbridge)
+**Coordinate an Agent Team** (Builders → libbridge, libharness)
 
 | Hire | Path | Title |
 | ---- | ---- | ----- |

--- a/websites/fit/docs/libraries/index.md
+++ b/websites/fit/docs/libraries/index.md
@@ -1,6 +1,6 @@
 ---
 title: Library Guides
-description: Workflow guides for the shared libraries that give humans and agents the same capabilities — memory, interfaces, knowledge, contracts, lifecycle, and evals.
+description: Workflow guides for the shared libraries that give humans and agents the same capabilities — memory, coordination, interfaces, knowledge, contracts, lifecycle, and evals.
 layout: product
 toc: false
 ---
@@ -17,7 +17,7 @@ toc: false
 
 </div>
 
-## Bridge Conversations to the Agent Team (Builders)
+## Coordinate an Agent Team (Builders)
 
 <div class="grid">
 


### PR DESCRIPTION
## Summary

- Align the library guide tier with the renamed **Coordinate an Agent Team** job, following the libharness reframing (PR #1834).

## Test plan

- [ ] `bun run check`
- [ ] `bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)