### PR TITLE
fix: repair CI regressions introduced by #1837

### DIFF
--- a/.coaligned/invariants/temporal.rules.mjs
+++ b/.coaligned/invariants/temporal.rules.mjs
@@ -101,6 +101,10 @@ const BASE_GLOBS = [
   // Its inline CSS hex colours (` #000`, ` #111`) trip the space-prefixed
   // numeric pattern; it is not authored monorepo source where references rot.
   "!products/outpost/templates/.claude/skills/deck-review/assets/**",
+  // The collision-ledger guide shows example CLI output whose anchor ids
+  // (` #97`, ` #44`) are runtime identifiers, not issue references; they trip
+  // the space-prefixed numeric pattern.
+  "!websites/fit/docs/libraries/predictable-team/collision-ledger/index.md",
 ];
 
 export default {

--- a/launchers/fit-logger/bin/fit-logger.js
+++ b/launchers/fit-logger/bin/fit-logger.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "@forwardimpact/libsupervise/bin/fit-logger.js";

--- a/launchers/fit-logger/package.json
+++ b/launchers/fit-logger/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "fit-logger",
+  "version": "0.0.0",
+  "description": "Run fit-logger from the npm registry — launcher for @forwardimpact/libsupervise",
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "launchers/fit-logger"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "type": "module",
+  "bin": {
+    "fit-logger": "./bin/fit-logger.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "dependencies": {
+    "@forwardimpact/libsupervise": "0.0.0"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/launchers/fit-svscan/bin/fit-svscan.js
+++ b/launchers/fit-svscan/bin/fit-svscan.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "@forwardimpact/libsupervise/bin/fit-svscan.js";

--- a/launchers/fit-svscan/package.json
+++ b/launchers/fit-svscan/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "fit-svscan",
+  "version": "0.0.0",
+  "description": "Run fit-svscan from the npm registry — launcher for @forwardimpact/libsupervise",
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "launchers/fit-svscan"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "type": "module",
+  "bin": {
+    "fit-svscan": "./bin/fit-svscan.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "dependencies": {
+    "@forwardimpact/libsupervise": "0.0.0"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/launchers/fit-visualize/bin/fit-visualize.js
+++ b/launchers/fit-visualize/bin/fit-visualize.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "@forwardimpact/libtelemetry/bin/fit-visualize.js";

--- a/launchers/fit-visualize/package.json
+++ b/launchers/fit-visualize/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "fit-visualize",
+  "version": "0.0.0",
+  "description": "Run fit-visualize from the npm registry — launcher for @forwardimpact/libtelemetry",
+  "homepage": "https://www.forwardimpact.team",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forwardimpact/monorepo.git",
+    "directory": "launchers/fit-visualize"
+  },
+  "license": "Apache-2.0",
+  "author": "D. Olsson <hi@senzilla.io>",
+  "type": "module",
+  "bin": {
+    "fit-visualize": "./bin/fit-visualize.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "dependencies": {
+    "@forwardimpact/libtelemetry": "0.0.0"
+  },
+  "engines": {
+    "bun": ">=1.2.0",
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libraries/libtelemetry/package.json
+++ b/libraries/libtelemetry/package.json
@@ -33,7 +33,8 @@
     ".": "./src/index.js",
     "./tracer.js": "./src/tracer.js",
     "./visualizer.js": "./src/visualizer.js",
-    "./index/trace.js": "./src/index/trace.js"
+    "./index/trace.js": "./src/index/trace.js",
+    "./bin/fit-visualize.js": "./bin/fit-visualize.js"
   },
   "bin": {
     "fit-visualize": "./bin/fit-visualize.js"

--- a/libraries/libwiki/test/golden/fit-wiki/help-flag.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/help-flag.stdout.txt
@@ -46,6 +46,12 @@ Documentation:
     End-to-end guide to wiki memory, XmR charts, and team coordination.
   Send a Memo or Update a Storyboard
     https://www.forwardimpact.team/docs/libraries/predictable-team/wiki-operations/index.md
-    Send cross-team memos, refresh storyboard charts, and sync the wiki.
+    Send cross-team memos, refresh storyboard charts, sync the wiki, and record the product-mix metric.
+  Audit and Auto-Fix the Wiki
+    https://www.forwardimpact.team/docs/libraries/predictable-team/wiki-integrity/index.md
+    Check the wiki against the rule catalogue, auto-fix what is safe, and flag the rest for a human.
+  Allocate Collision-Ledger Entries for Parallel Work
+    https://www.forwardimpact.team/docs/libraries/predictable-team/collision-ledger/index.md
+    Assign stable, collision-free ids to parallel work and rebuild the ledger projections.
 
 Use fit-wiki <command> --help for command-specific options.

--- a/libraries/libwiki/test/golden/fit-wiki/help.stdout.txt
+++ b/libraries/libwiki/test/golden/fit-wiki/help.stdout.txt
@@ -46,6 +46,12 @@ Documentation:
     End-to-end guide to wiki memory, XmR charts, and team coordination.
   Send a Memo or Update a Storyboard
     https://www.forwardimpact.team/docs/libraries/predictable-team/wiki-operations/index.md
-    Send cross-team memos, refresh storyboard charts, and sync the wiki.
+    Send cross-team memos, refresh storyboard charts, sync the wiki, and record the product-mix metric.
+  Audit and Auto-Fix the Wiki
+    https://www.forwardimpact.team/docs/libraries/predictable-team/wiki-integrity/index.md
+    Check the wiki against the rule catalogue, auto-fix what is safe, and flag the rest for a human.
+  Allocate Collision-Ledger Entries for Parallel Work
+    https://www.forwardimpact.team/docs/libraries/predictable-team/collision-ledger/index.md
+    Assign stable, collision-free ids to parallel work and rebuild the ledger projections.
 
 Use fit-wiki <command> --help for command-specific options.


### PR DESCRIPTION
## What

`main` went red after #1837 (`docs(libraries): close documentation gaps`). This
repairs the three regressions so CI is green again.

| Failing check | Cause | Fix |
|---|---|---|
| `invariants` (public-cli.drift) | #1837 added `fit-logger`/`fit-svscan` (libsupervise) and `fit-visualize` (libtelemetry) bins with no `launchers/` dir | Add the three launchers; export libtelemetry's `fit-visualize` bin so the launcher resolves |
| `gate` / `test` (fit-wiki golden) | #1837 expanded the fit-wiki `documentation` array without regenerating the goldens | Recapture `help.stdout.txt` + `help-flag.stdout.txt` |
| `invariants` (temporal.reference) | #1837's collision-ledger guide shows example CLI output with anchor ids (`#97`, `#44`) that trip the space-prefixed numeric pattern | Exclude that guide in `temporal.rules.mjs`, matching the existing deck-review CSS-hex precedent |

## Verification

- `coaligned invariants` passes.
- `fit-wiki` golden test: 19 pass, 0 fail.
- All three launchers resolve and run `--help`.

Unblocks the `workflow-reliability` PR (#1836), whose CI inherits `main` via
the bootstrap rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)