### PR TITLE
ci: run coaligned, fit-pack, fit-benchmark as gear binaries

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -79,7 +79,7 @@ Referenced as `./.github/actions/<name>`:
 | Action | Purpose |
 |---|---|
 | `audit` | `npm audit` + gitleaks secret scanning |
-| `coaligned-check` | `bunx coaligned` checks (instructions, jtbd, invariants) |
+| `coaligned-check` | `coaligned` checks (instructions, jtbd, invariants) |
 | `macos-signing` | Import Developer ID certs into a temp keychain |
 | `notarize` | Notarize + staple a `.app`/`.pkg` via the notary API |
 | `resolve-package` | npm name + workspace dir from a `<pkg>@v*` tag |

--- a/.github/actions/coaligned-check/action.yml
+++ b/.github/actions/coaligned-check/action.yml
@@ -7,10 +7,10 @@ description: |
   `command` is set to "instructions", "jtbd", or "invariants", only that
   subcommand runs.
 
-  Assumes the workspace has already been bootstrapped (Bun installed,
-  dependencies linked) so `bunx coaligned` resolves. When this action is
-  published as a third-party action, a setup step will be added so external
-  consumers do not need to install Bun separately.
+  Assumes the workspace has already been bootstrapped by
+  forwardimpact/fit-bootstrap, which installs `coaligned` as a pinned gear
+  binary on PATH (it is one of the default tools). The binary is required —
+  there is no bunx/npx fallback.
 
 inputs:
   command:
@@ -61,6 +61,12 @@ runs:
         COMMAND: ${{ inputs.command }}
         FIX: ${{ inputs.fix }}
       run: |
+        # coaligned is a pinned gear binary on PATH, installed by fit-bootstrap
+        # as a default tool. No bunx/npx fallback — fail hard if it is missing.
+        if ! command -v coaligned &>/dev/null; then
+          echo "::error::coaligned not found on PATH. Bootstrap with forwardimpact/fit-bootstrap (installs coaligned as a default gear binary) before this step. No bunx/npx fallback." >&2
+          exit 1
+        fi
         args=()
         if [ -n "$COMMAND" ]; then
           args+=("$COMMAND")
@@ -68,4 +74,4 @@ runs:
         if [ "$FIX" = "true" ]; then
           args+=("--fix")
         fi
-        bunx coaligned "${args[@]}"
+        coaligned "${args[@]}"

--- a/.github/actions/publish-skill-pack/action.yml
+++ b/.github/actions/publish-skill-pack/action.yml
@@ -75,7 +75,7 @@ runs:
         if [ "$SYNC_AGENTS" = "true" ]; then
           agents_flag="--with-agents"
         fi
-        bunx fit-pack stage \
+        fit-pack stage \
           --from .claude \
           --prefix "$PACK_PREFIX" \
           --into "$TARGET_DIR" \

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - name: Ensure codegen is current
         run: just codegen
       - name: Compile

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - name: Ensure codegen is current
         run: just codegen
       - name: Compile

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - name: Ensure codegen is current
         run: just codegen
       - name: Compile

--- a/.github/workflows/check-context.yml
+++ b/.github/workflows/check-context.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - uses: ./.github/actions/coaligned-check
         with:
           command: instructions
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - run: bun run context:check-metadata
 
   jtbd:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - uses: ./.github/actions/coaligned-check
         with:
           command: jtbd
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - uses: ./.github/actions/coaligned-check
         with:
           command: invariants
@@ -66,5 +66,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - run: bun run wiki:rules

--- a/.github/workflows/check-context.yml
+++ b/.github/workflows/check-context.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - uses: ./.github/actions/coaligned-check
         with:
           command: instructions
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - run: bun run context:check-metadata
 
   jtbd:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - uses: ./.github/actions/coaligned-check
         with:
           command: jtbd
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - uses: ./.github/actions/coaligned-check
         with:
           command: invariants
@@ -66,5 +66,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - run: bun run wiki:rules

--- a/.github/workflows/check-context.yml
+++ b/.github/workflows/check-context.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - uses: ./.github/actions/coaligned-check
         with:
           command: instructions
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - run: bun run context:check-metadata
 
   jtbd:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - uses: ./.github/actions/coaligned-check
         with:
           command: jtbd
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - uses: ./.github/actions/coaligned-check
         with:
           command: invariants
@@ -66,5 +66,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - run: bun run wiki:rules

--- a/.github/workflows/check-data.yml
+++ b/.github/workflows/check-data.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - run: bun run data:check-schema
 
   prose:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - run: bun run data:check-prose

--- a/.github/workflows/check-data.yml
+++ b/.github/workflows/check-data.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - run: bun run data:check-schema
 
   prose:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - run: bun run data:check-prose

--- a/.github/workflows/check-data.yml
+++ b/.github/workflows/check-data.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - run: bun run data:check-schema
 
   prose:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - run: bun run data:check-prose

--- a/.github/workflows/check-quality.yml
+++ b/.github/workflows/check-quality.yml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - run: bun run format
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - run: bun run lint
 
   jsdoc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - run: bun run jsdoc

--- a/.github/workflows/check-quality.yml
+++ b/.github/workflows/check-quality.yml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - run: bun run format
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - run: bun run lint
 
   jsdoc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - run: bun run jsdoc

--- a/.github/workflows/check-quality.yml
+++ b/.github/workflows/check-quality.yml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - run: bun run format
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - run: bun run lint
 
   jsdoc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - run: bun run jsdoc

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
@@ -37,5 +37,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - run: bun scripts/check-dependabot.mjs

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
@@ -37,5 +37,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - run: bun scripts/check-dependabot.mjs

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
@@ -37,5 +37,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - run: bun scripts/check-dependabot.mjs

--- a/.github/workflows/check-skill-refs.yml
+++ b/.github/workflows/check-skill-refs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - name: Skill ref lint
         run: bun run check-skill-refs
         env:
@@ -32,7 +32,7 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - name: Upsert or close the drift tracking issue
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/check-skill-refs.yml
+++ b/.github/workflows/check-skill-refs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - name: Skill ref lint
         run: bun run check-skill-refs
         env:
@@ -32,7 +32,7 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - name: Upsert or close the drift tracking issue
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/check-skill-refs.yml
+++ b/.github/workflows/check-skill-refs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - name: Skill ref lint
         run: bun run check-skill-refs
         env:
@@ -32,7 +32,7 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - name: Upsert or close the drift tracking issue
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           clis: fit-terrain
       # libwiki's push path secret-scans with gitleaks (fail-closed); the
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:

--- a/.github/workflows/curate-wiki.yml
+++ b/.github/workflows/curate-wiki.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           clis: fit-wiki
       - name: Checkout wiki (read-only)

--- a/.github/workflows/curate-wiki.yml
+++ b/.github/workflows/curate-wiki.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           clis: fit-wiki
       - name: Checkout wiki (read-only)

--- a/.github/workflows/curate-wiki.yml
+++ b/.github/workflows/curate-wiki.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           clis: fit-wiki
       - name: Checkout wiki (read-only)

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/eval-wiki.yml
+++ b/.github/workflows/eval-wiki.yml
@@ -17,7 +17,7 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           # fit-benchmark runs the benchmark binary straight off PATH.
           clis: fit-benchmark

--- a/.github/workflows/eval-wiki.yml
+++ b/.github/workflows/eval-wiki.yml
@@ -17,7 +17,7 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           # fit-benchmark runs the benchmark binary straight off PATH.
           clis: fit-benchmark

--- a/.github/workflows/eval-wiki.yml
+++ b/.github/workflows/eval-wiki.yml
@@ -17,7 +17,10 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+        with:
+          # fit-benchmark runs the benchmark binary straight off PATH.
+          clis: fit-benchmark
       - uses: forwardimpact/fit-benchmark@c5764e7213832cbe28978517aa8547c4834ad50a # v1
         with:
           family: ./benchmarks/fit-wiki

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -130,7 +130,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -130,7 +130,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -130,7 +130,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.ci-app.outputs.token }}
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           token: ${{ steps.ci-app.outputs.token }}
           app-slug: kata-agent-team

--- a/.github/workflows/outpost-determinism-probe.yml
+++ b/.github/workflows/outpost-determinism-probe.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
       - name: Install diffoscope
         run: brew install diffoscope
       - name: First build

--- a/.github/workflows/outpost-determinism-probe.yml
+++ b/.github/workflows/outpost-determinism-probe.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
       - name: Install diffoscope
         run: brew install diffoscope
       - name: First build

--- a/.github/workflows/outpost-determinism-probe.yml
+++ b/.github/workflows/outpost-determinism-probe.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
       - name: Install diffoscope
         run: brew install diffoscope
       - name: First build

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
 
       - uses: ./.github/actions/audit
 

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
 
       - uses: ./.github/actions/audit
 

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
 
       - uses: ./.github/actions/audit
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -101,7 +101,7 @@ jobs:
           vulnerability-scanning: "false"
           secret-scanning: "true"
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           clis: fit-pack
 

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -101,7 +101,9 @@ jobs:
           vulnerability-scanning: "false"
           secret-scanning: "true"
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+        with:
+          clis: fit-pack
 
       - name: Skill ref lint
         run: bun run check-skill-refs

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -101,7 +101,7 @@ jobs:
           vulnerability-scanning: "false"
           secret-scanning: "true"
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           clis: fit-pack
 

--- a/.github/workflows/website-coaligned.yaml
+++ b/.github/workflows/website-coaligned.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-coaligned.yaml
+++ b/.github/workflows/website-coaligned.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-coaligned.yaml
+++ b/.github/workflows/website-coaligned.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-fit.yaml
+++ b/.github/workflows/website-fit.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-fit.yaml
+++ b/.github/workflows/website-fit.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-fit.yaml
+++ b/.github/workflows/website-fit.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-kata.yaml
+++ b/.github/workflows/website-kata.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-kata.yaml
+++ b/.github/workflows/website-kata.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-kata.yaml
+++ b/.github/workflows/website-kata.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-monorepo.yaml
+++ b/.github/workflows/website-monorepo.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@7084c0a624f84ca714757c3a5d4a8f476b4c70ab # v1.0.3
+      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-monorepo.yaml
+++ b/.github/workflows/website-monorepo.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
+      - uses: forwardimpact/fit-bootstrap@75f15439f4d3d72f18f155ca51292d1bd3222a0b # v1.0.6
         with:
           clis: fit-doc
 

--- a/.github/workflows/website-monorepo.yaml
+++ b/.github/workflows/website-monorepo.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: forwardimpact/fit-bootstrap@4e63230e2a638296a6c201c91f724784e1958f5c # v1.0.4
+      - uses: forwardimpact/fit-bootstrap@93526d6c7d24dfcfbde60c3d7d436f6e305e35a0 # v1.0.5
         with:
           clis: fit-doc
 

--- a/scripts/fit-install.sh
+++ b/scripts/fit-install.sh
@@ -27,9 +27,10 @@ BIN_DIR="$PREFIX/bin"
 LIB_DIR="$PREFIX/lib"
 
 # Default dev/CI tool set, in install order — the third-party external tools
-# every job needs (scripts/bootstrap.sh runs `just`). This set is ALWAYS
-# installed; any named gear CLIs add to it. The same list drives `--paths`.
-DEFAULT_TOOLS=(apm just gh rg gitleaks)
+# every job needs (scripts/bootstrap.sh runs `just`) plus coaligned, our own
+# gear binary that the instruction checks run. This set is ALWAYS installed;
+# any named gear CLIs add to it. The same list drives `--paths`.
+DEFAULT_TOOLS=(apm just gh rg gitleaks coaligned)
 
 # ── gear binary release coordinates ──────────────────────────────
 # Every installable gear binary (fit-trace, fit-wiki, fit-harness, …, plus
@@ -37,7 +38,7 @@ DEFAULT_TOOLS=(apm just gh rg gitleaks)
 # publish step stamps the live tag into the released copy of this script; any
 # caller may override via the environment to pin a different release.
 FIT_RELEASE_REPO="${FIT_RELEASE_REPO:-forwardimpact/monorepo}"
-FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.7}"
+FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.8}"
 
 # Bun compile target for this platform. Binaries are built only for linux-x64
 # and darwin-arm64; any other platform is unsupported and fails hard — this is

--- a/scripts/fit-install.sh
+++ b/scripts/fit-install.sh
@@ -38,7 +38,7 @@ DEFAULT_TOOLS=(apm just gh rg gitleaks coaligned)
 # publish step stamps the live tag into the released copy of this script; any
 # caller may override via the environment to pin a different release.
 FIT_RELEASE_REPO="${FIT_RELEASE_REPO:-forwardimpact/monorepo}"
-FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.8}"
+FIT_GEAR_RELEASE="${FIT_GEAR_RELEASE:-gear@v0.1.9}"
 
 # Bun compile target for this platform. Binaries are built only for linux-x64
 # and darwin-arm64; any other platform is unsupported and fails hard — this is


### PR DESCRIPTION
Completes the deferral from #1836. Now that **gear@v0.1.8** publishes
`coaligned`, `fit-pack`, `fit-benchmark` and **fit-bootstrap v1.0.4** installs
`coaligned` as a default tool, the three deferred consumers run the binaries:

- `fit-install.sh`: `coaligned` joins `DEFAULT_TOOLS`; default → `gear@v0.1.8`.
- Repin `fit-bootstrap` v1.0.3 → **v1.0.4** across all workflows.
- `coaligned-check` runs the `coaligned` binary (no bunx fallback).
- `publish-skill-pack` runs `fit-pack`; `publish-skills` installs it via `clis:`.
- `eval-wiki` installs `fit-benchmark` via `clis:`.

After this, every workflow CLI is a gear binary except `fit-map` (ships in
`map@v*`, documented inline in kata-interview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)