### PR TITLE
chore: bump sibling action pins to no-fallback versions

### DIFF
--- a/.github/workflows/eval-guide.yml
+++ b/.github/workflows/eval-guide.yml
@@ -160,7 +160,7 @@ jobs:
         run: echo "dir=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
       - name: Run eval
-        uses: forwardimpact/fit-harness@6af713fe23701ed1001631c8d3118075561cc41e # v1
+        uses: forwardimpact/fit-harness@d7562330d565019252c45279124fdb1718c68497 # v1.0.2
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Push wiki changes
         if: always()
-        uses: forwardimpact/fit-wiki@269483d677d44834e23f85c79296b836fee8a59f # v1
+        uses: forwardimpact/fit-wiki@2dbe4b3bd46d93dab199172e9dff29214fa509ce # v1.0.0
         with:
           command: push
           app-id: ${{ secrets.KATA_APP_ID }}

--- a/.github/workflows/eval-kata.yml
+++ b/.github/workflows/eval-kata.yml
@@ -17,7 +17,7 @@ jobs:
   # GitHub Actions ceiling. The filesystem work-tracker is the reusable
   # workflow's env contract; this caller only picks the family and shard count.
   benchmark:
-    uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@4c58597fabea5260e3fad2c4855703061df66684 # v1
+    uses: forwardimpact/fit-benchmark/.github/workflows/benchmark.yml@66b7dad6715d32d64bdc81614cd7b2edad9b1cae # v1.0.3
     with:
       family: ./benchmarks/kata-skills
       runs: "5"

--- a/.github/workflows/eval-wiki.yml
+++ b/.github/workflows/eval-wiki.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           # fit-benchmark runs the benchmark binary straight off PATH.
           clis: fit-benchmark
-      - uses: forwardimpact/fit-benchmark@c5764e7213832cbe28978517aa8547c4834ad50a # v1
+      - uses: forwardimpact/fit-benchmark@66b7dad6715d32d64bdc81614cd7b2edad9b1cae # v1.0.3
         with:
           family: ./benchmarks/fit-wiki
           runs: "5"

--- a/.github/workflows/kata-dispatch.yml
+++ b/.github/workflows/kata-dispatch.yml
@@ -156,7 +156,7 @@ jobs:
       # this surface preserves the same template-injection-safe contract.
       - name: Assess and Act
         id: assess
-        uses: forwardimpact/fit-harness@6af713fe23701ed1001631c8d3118075561cc41e # v1
+        uses: forwardimpact/fit-harness@d7562330d565019252c45279124fdb1718c68497 # v1.0.2
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
@@ -193,7 +193,7 @@ jobs:
       # job start expires after an hour and this run can take up to five.
       - name: Push wiki changes
         if: always()
-        uses: forwardimpact/fit-wiki@269483d677d44834e23f85c79296b836fee8a59f # v1
+        uses: forwardimpact/fit-wiki@2dbe4b3bd46d93dab199172e9dff29214fa509ce # v1.0.0
         with:
           command: push
           app-id: ${{ secrets.KATA_APP_ID }}

--- a/.github/workflows/kata-interview.yml
+++ b/.github/workflows/kata-interview.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Run interview
         id: interview
-        uses: forwardimpact/fit-harness@6af713fe23701ed1001631c8d3118075561cc41e # v1
+        uses: forwardimpact/fit-harness@d7562330d565019252c45279124fdb1718c68497 # v1.0.2
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.ci-app.outputs.token }}
@@ -179,7 +179,7 @@ jobs:
 
       - name: Push wiki changes
         if: always()
-        uses: forwardimpact/fit-wiki@269483d677d44834e23f85c79296b836fee8a59f # v1
+        uses: forwardimpact/fit-wiki@2dbe4b3bd46d93dab199172e9dff29214fa509ce # v1.0.0
         with:
           command: push
           app-id: ${{ secrets.KATA_APP_ID }}


### PR DESCRIPTION
Adopts the hardened sibling actions (bunx/npx fallback removed; gear binary
required on PATH):

| Action | Old | New |
|---|---|---|
| `fit-wiki` | `@v1` | `@v1.0.0` |
| `fit-harness` | `@v1` | `@v1.0.2` |
| `fit-benchmark` (action) | `@v1` | `@v1.0.3` |
| `fit-benchmark/.github/workflows/benchmark.yml` | `@v1` | `@v1.0.3` |

Every consumer already installs the needed binaries via `fit-bootstrap` `clis:`
(kata-dispatch / kata-interview / eval-guide → fit-harness fit-trace fit-wiki;
eval-wiki → fit-benchmark; eval-kata via the benchmark reusable workflow's own
`clis:`), so the removed fallback is never hit.

Done manually at request rather than waiting for the Dependabot SHA-bump sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)