### PR TITLE
design(2140): subtree-split action publishing

### DIFF
--- a/specs/2140-subtree-split-actions/design-a.md
+++ b/specs/2140-subtree-split-actions/design-a.md
@@ -1,0 +1,140 @@
+# Design 2140-a: Co-located action sources + bidirectional subtree-split publishing
+
+Spec 2140 moves the five composite actions' canonical source into the monorepo,
+publishes each verbatim to its sibling `main` as a history-preserving subtree
+split on every push to `main`, defines a pull-back path for external sibling
+PRs, and records the pattern as a `MONOREPO.md` standard. Consumption stays
+SHA-pinned; no gitlink is introduced.
+
+This design fixes WHICH change-units exist, WHERE the publish boundary sits, and
+WHAT keeps sibling `main` a faithful projection. There is no new runtime
+architecture — the work is a one-time **history import**, a **stateless outbound
+split**, an **explicit inbound replay**, and a **projection invariant** that
+makes the two directions safe.
+
+## Components
+
+| Component                | Where                             | Responsibility                                                                                                       |
+| ------------------------ | --------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Action source homes      | the five prefixes in spec § Scope | Canonical, editable action source, mirroring each sibling's whole repo root                                          |
+| `seed-import` (one-time) | local/maintainer run              | `git subtree add` each sibling's history under its prefix so the first publish continues sibling history             |
+| `publish-actions.yml`    | `.github/workflows/`              | Outbound: on push to `main` (paths-filtered), split each touched prefix and push to its sibling `main`               |
+| `actions/split-and-push` | `.github/actions/`                | Composite action wrapping the split+push step, one tested code path across the matrix (mirrors `publish-skill-pack`) |
+| Pull-back recipe         | `justfile` / maintainer doc       | Inbound: replay a sibling PR's commits into the prefix as a monorepo PR                                              |
+| Projection guard         | inside `publish-actions.yml`      | Refuse to publish if sibling `main` holds a commit not produced by the monorepo                                      |
+
+## Outbound: stateless split on push to main
+
+`splitsh-lite`, not `git subtree split`. The monorepo history is large and
+`git subtree split` re-walks all of it every run; `splitsh-lite` is a
+deterministic, cache-friendly `history → projection` function (the tool Symfony
+and Laravel run in CI). The split output for a prefix is a pure function of
+monorepo history, so re-runs are idempotent and the push is a fast-forward of
+the seeded history.
+
+```mermaid
+graph LR
+  P["push to main<br/>(touches a prefix)"] --> T["mint App token<br/>(scoped to that sibling)"]
+  T --> G["projection guard:<br/>sibling main ⊆ last split?"]
+  G -->|ok| S["splitsh-lite --prefix=…"]
+  S --> U["push sha → sibling main<br/>(fast-forward)"]
+  G -->|drift| F["fail: external commit on sibling main"]
+```
+
+- **Matrix** over the five `{prefix, repo}` pairs, paths-filtered so only
+  touched actions republish (+ `workflow_dispatch`).
+- **Auth** reuses `actions/create-github-app-token@v3` with
+  `repositories: <sibling>` — the exact per-repo scoping `publish-skills.yml`
+  uses; the default `GITHUB_TOKEN` cannot push cross-repo.
+- **Checkout** with `fetch-depth: 0` (split needs full history).
+- **No tags.** The workflow mirrors `main`; append-only `v1.0.x` tags stay
+  human-gated per `.github/CLAUDE.md`.
+
+## Inbound: explicit replay, not `git subtree pull`
+
+External PRs land on the standalone sibling repo (the benefit of it being a
+real, buildable repo). Pull-back replays the PR's commits **into the prefix**:
+
+```sh
+git -C <sibling-clone> format-patch origin/main..<pr-head> --stdout \
+  | git am --directory=<prefix>
+```
+
+`--directory` rewrites paths into the prefix; `git am` preserves the original
+author. The result is a normal monorepo PR under the usual gates; merging it
+makes the next outbound split republish the change, closing the sibling PR as
+"landed via monorepo #NNN."
+
+Native `git subtree pull` is rejected: it depends on subtree-join commits that
+`splitsh-lite` never creates (ancestry mismatch → fragile merge-base detection)
+and litters the monorepo with merge commits. Replay keeps one canonical history
+and pairs cleanly with a stateless outbound split.
+
+```mermaid
+sequenceDiagram
+  participant E as External PR (sibling)
+  participant M as Maintainer / recipe
+  participant R as Monorepo PR
+  E->>M: format-patch origin/main..pr-head
+  M->>R: git am --directory=<prefix> (author preserved)
+  R->>R: review gates + merge
+  R-->>E: next split republishes; close as landed via #NNN
+```
+
+## Projection invariant
+
+Sibling `main` is always a projection of the monorepo. PRs are reviewed on the
+sibling but **never merged there** — they land via replay. With that rule every
+outbound push is a fast-forward, so the force-vs-external-commit hazard never
+arises. The projection guard enforces it: before pushing, verify sibling `main`
+is an ancestor of (or equal to) the freshly computed split; drift means someone
+merged on the sibling, and the run fails loudly rather than clobbering.
+
+## `MONOREPO.md` standard
+
+A new **optional** top-level concern, distinct from the three shippable and
+three support directories: _co-developed action repositories may keep canonical
+source in the monorepo, co-located with their owning unit, and publish verbatim
+to a sibling via history-preserving subtree split._ States the inclusion test —
+**only repos with no other home in the monorepo and no publish-time transform**
+(skill packs/npm packages are excluded: they transform or already have a home).
+
+## Key Decisions
+
+| Decision             | Choice                                          | Rejected alternative                                                                                                        |
+| -------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Track siblings       | Co-located source + split                       | Submodule/`vendor/` — gitlink competes with the SHA-pin and is unfetchable in single-repo proxy envs                        |
+| Publish mechanism    | History-preserving subtree split                | Content-copy (`fit-pack stage` style) — loses history, blocks pull-back; correct only for the transform-needing skill packs |
+| Split tool           | `splitsh-lite`                                  | `git subtree split` — re-walks full history every CI run, cache-cold and slow                                               |
+| Inbound              | Replay via `git am --directory` into the prefix | `git subtree pull` — ancestry mismatch with `splitsh-lite`, merge-commit noise                                              |
+| Outbound trigger     | Every push to `main` (continuous mirror)        | Tag-only — siblings drift stale between releases                                                                            |
+| `fit-bootstrap` home | `.github/actions/fit-bootstrap/`                | A forced `libraries/libbootstrap` — it is CI glue, not a shipped library                                                    |
+| Safety model         | Projection invariant + guard                    | Force-push always — silently destroys externally-merged commits                                                             |
+
+## Verification mapping
+
+| Criterion               | Where satisfied                                       |
+| ----------------------- | ----------------------------------------------------- |
+| 1 homes populated       | seed-import + source move                             |
+| 2 faithful projection   | `splitsh-lite` determinism + push                     |
+| 3 continuous history    | `git subtree add` seed → fast-forward                 |
+| 4 consumption unchanged | no `.gitmodules`; `uses:` pins + Dependabot untouched |
+| 5 authored pull-back    | replay recipe (`git am --directory`)                  |
+| 6 projection guarded    | projection guard in `publish-actions.yml`             |
+| 7 standard documented   | `MONOREPO.md` section + `.github/CLAUDE.md` rewrite   |
+| 8 suite green           | unchanged action behavior; workflow lint              |
+
+## Risks
+
+- **Seed import done wrong → first publish force-clobbers the sibling.**
+  Mitigation: `git subtree add` from each sibling's current `main` before the
+  first run; criterion 3 asserts a fast-forward.
+- **`splitsh-lite` supply chain.** It is a third-party binary on the publish
+  path. Mitigation: pin by SHA and stage it through the security-engineer review
+  the dependency policy already requires.
+- **Someone merges a PR on the sibling.** Mitigation: the projection guard fails
+  the run; recovery is to replay that commit into the monorepo, then republish.
+- **Reusable-workflow / sub-action paths.** `fit-benchmark`'s
+  `.github/workflows/benchmark.yml` and `fit-bootstrap`'s sub-actions must sit
+  inside the prefix or consumers break. Mitigation: criterion 1 checks for them
+  explicitly.

--- a/specs/2140-subtree-split-actions/design-a.md
+++ b/specs/2140-subtree-split-actions/design-a.md
@@ -1,74 +1,117 @@
 # Design 2140-a: Co-located action sources + bidirectional subtree-split publishing
 
 Spec 2140 moves the five composite actions' canonical source into the monorepo,
-publishes each verbatim to its sibling `main` as a history-preserving subtree
-split on every push to `main`, defines a pull-back path for external sibling
-PRs, and records the pattern as a `MONOREPO.md` standard. Consumption stays
-SHA-pinned; no gitlink is introduced.
+publishes each verbatim to its sibling `main` as a deterministic subtree split,
+defines a pull-back path for external sibling PRs, and records the pattern as a
+`MONOREPO.md` standard. Consumption stays SHA-pinned; no gitlink is introduced.
 
 This design fixes WHICH change-units exist, WHERE the publish boundary sits, and
 WHAT keeps sibling `main` a faithful projection. There is no new runtime
-architecture — the work is a one-time **history import**, a **stateless outbound
-split**, an **explicit inbound replay**, and a **projection invariant** that
-makes the two directions safe.
+architecture — the work is a one-time **lineage seed**, a **deterministic
+outbound split**, an **explicit inbound replay**, and a **non-force push** that
+makes drift detectable on the next publish.
 
 ## Components
 
-| Component                | Where                             | Responsibility                                                                                                       |
-| ------------------------ | --------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| Action source homes      | the five prefixes in spec § Scope | Canonical, editable action source, mirroring each sibling's whole repo root                                          |
-| `seed-import` (one-time) | local/maintainer run              | `git subtree add` each sibling's history under its prefix so the first publish continues sibling history             |
-| `publish-actions.yml`    | `.github/workflows/`              | Outbound: on push to `main` (paths-filtered), split each touched prefix and push to its sibling `main`               |
-| `actions/split-and-push` | `.github/actions/`                | Composite action wrapping the split+push step, one tested code path across the matrix (mirrors `publish-skill-pack`) |
-| Pull-back recipe         | `justfile` / maintainer doc       | Inbound: replay a sibling PR's commits into the prefix as a monorepo PR                                              |
-| Projection guard         | inside `publish-actions.yml`      | Refuse to publish if sibling `main` holds a commit not produced by the monorepo                                      |
+| Component                | Where                             | Responsibility                                                                                                                                                                                                    |
+| ------------------------ | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Action source homes      | the five prefixes in spec § Scope | Canonical, editable action source, mirroring each sibling's whole repo root                                                                                                                                       |
+| `seed` (one-time)        | maintainer run                    | Establish the split lineage on each sibling `main` once, replacing the old `main` tip; existing `v1.0.x` tags retain pre-migration history                                                                        |
+| `publish-actions.yml`    | `.github/workflows/`              | Outbound: on push to `main` (paths-filtered), split each touched prefix and **non-force** push to its sibling `main`                                                                                              |
+| `actions/split-and-push` | `.github/actions/`                | Composite action wrapping split + push, one tested path across the matrix — reuses the **matrix + per-repo App-token pattern** of `publish-skills.yml` (via `publish-skill-pack`), not its content-copy transform |
+| Pull-back recipe         | `justfile` (named target)         | Inbound: replay a sibling PR's commits into the prefix as a monorepo PR                                                                                                                                           |
 
-## Outbound: stateless split on push to main
+## Outbound: deterministic split, non-force push
 
 `splitsh-lite`, not `git subtree split`. The monorepo history is large and
 `git subtree split` re-walks all of it every run; `splitsh-lite` is a
-deterministic, cache-friendly `history → projection` function (the tool Symfony
-and Laravel run in CI). The split output for a prefix is a pure function of
-monorepo history, so re-runs are idempotent and the push is a fast-forward of
-the seeded history.
+**deterministic** `history → projection` function (the tool Symfony and Laravel
+run in CI), **pinned by SHA** so its output commit identities are stable
+run-to-run.
+
+Determinism is what makes the published lineage append-only: given the same
+monorepo prefix history, `splitsh-lite` re-emits the identical earlier split
+commits plus one new commit per new monorepo commit that touched the prefix. So
+each run's output is a **superset** of the last — a fast-forward — and the push
+needs no `--force`.
 
 ```mermaid
 graph LR
   P["push to main<br/>(touches a prefix)"] --> T["mint App token<br/>(scoped to that sibling)"]
-  T --> G["projection guard:<br/>sibling main ⊆ last split?"]
-  G -->|ok| S["splitsh-lite --prefix=…"]
-  S --> U["push sha → sibling main<br/>(fast-forward)"]
-  G -->|drift| F["fail: external commit on sibling main"]
+  T --> S["splitsh-lite --prefix=…<br/>(pinned, deterministic)"]
+  S --> U["git push (no --force)<br/>sha → sibling main"]
+  U -->|fast-forward| OK["published"]
+  U -->|rejected| F["drift: external commit<br/>on sibling main → fail run"]
 ```
 
-- **Matrix** over the five `{prefix, repo}` pairs, paths-filtered so only
-  touched actions republish (+ `workflow_dispatch`).
-- **Auth** reuses `actions/create-github-app-token@v3` with
-  `repositories: <sibling>` — the exact per-repo scoping `publish-skills.yml`
-  uses; the default `GITHUB_TOKEN` cannot push cross-repo.
+- **Matrix** over the five `{prefix, repo}` pairs; the workflow `paths:` gate
+  runs it only when an action source is touched (+ `workflow_dispatch`).
+  Untouched legs re-split unchanged history and no-op fast-forward — harmless.
+- **Auth** reuses `actions/create-github-app-token` (SHA-pinned `# v3`) with
+  `repositories: <sibling>` — the per-repo scoping `publish-skills.yml` uses;
+  the default `GITHUB_TOKEN` cannot push cross-repo. The App must be installed
+  on **all five** sibling repos or that matrix leg fails.
 - **Checkout** with `fetch-depth: 0` (split needs full history).
 - **No tags.** The workflow mirrors `main`; append-only `v1.0.x` tags stay
   human-gated per `.github/CLAUDE.md`.
 
+## One-time seed
+
+The first publish cannot fast-forward: sibling `main` holds pre-migration
+history that is not in the `splitsh-lite` lineage. The seed is the **only**
+force update — a maintainer runs the split once, **with the same SHA-pinned
+`splitsh-lite` the workflow uses** (a different version emits divergent SHAs and
+breaks the very first non-force push), and force-replaces each sibling `main`
+with the lineage tip. Pre-migration history is not lost: the existing `v1.0.x`
+release tags still point at the old commits, so blame and releases survive.
+
+**Ordering matters:** the seed must precede the first CI publish. The migration
+PR therefore lands `publish-actions.yml` disabled (or `workflow_dispatch`-only);
+the maintainer seeds all five siblings, then enables the push trigger. A CI push
+firing before the seed would be rejected against the pre-migration `main`. After
+the seed, every run is a plain non-force push forever.
+
+## Projection invariant — enforced by the push, not by prose
+
+Sibling `main` is always a projection of the monorepo. PRs are reviewed on the
+sibling but **never merged there** — they land via replay. The enforcement is
+the non-force push itself: the workflow runs
+`git push origin <tip>:refs/heads/main` with **no** `+`/`--force`, so a
+non-fast-forward is rejected and the non-zero exit fails the run. Because the
+lineage is append-only, sibling `main` is normally the previous split tip and
+the new split fast-forwards it. If someone merged a commit on the sibling, that
+commit is not in the new split, the push is **rejected**, and the run fails. No
+durable "last split" record is needed — the remote ref _is_ the record.
+
+This guard is **lazy**, not continuous: drift is caught at the next push that
+touches that prefix, not the moment it happens. Recovery then needs two steps —
+replay the foreign commit into the monorepo (so it is not lost), **and** re-seed
+that one sibling (a deliberate force) to drop the orphaned tip from `main`.
+Re-seed is the only sanctioned force besides the initial seed.
+
 ## Inbound: explicit replay, not `git subtree pull`
 
-External PRs land on the standalone sibling repo (the benefit of it being a
-real, buildable repo). Pull-back replays the PR's commits **into the prefix**:
+External PRs land on the standalone sibling repo. Pull-back replays the PR's
+commits **into the prefix**:
 
 ```sh
 git -C <sibling-clone> format-patch origin/main..<pr-head> --stdout \
-  | git am --directory=<prefix>
+  | git am -3 --directory=<prefix>
 ```
 
 `--directory` rewrites paths into the prefix; `git am` preserves the original
-author. The result is a normal monorepo PR under the usual gates; merging it
-makes the next outbound split republish the change, closing the sibling PR as
-"landed via monorepo #NNN."
+author; `-3` (and `--binary`) handle merge fallback and binary hunks. The result
+is a normal monorepo PR under the usual gates; merging it makes the next
+outbound split republish the change, closing the sibling PR as "landed via
+monorepo #NNN." Failure handling: a sibling PR touching files at the sibling
+root maps cleanly; a `git am` conflict aborts (`git am --abort`) and the
+maintainer re-applies by hand, and a PR nested under a path the prefix
+duplicates is resolved by adjusting `--directory` depth — neither blocks the
+happy path criterion 5 verifies.
 
 Native `git subtree pull` is rejected: it depends on subtree-join commits that
 `splitsh-lite` never creates (ancestry mismatch → fragile merge-base detection)
-and litters the monorepo with merge commits. Replay keeps one canonical history
-and pairs cleanly with a stateless outbound split.
+and litters the monorepo with merge commits.
 
 ```mermaid
 sequenceDiagram
@@ -76,65 +119,61 @@ sequenceDiagram
   participant M as Maintainer / recipe
   participant R as Monorepo PR
   E->>M: format-patch origin/main..pr-head
-  M->>R: git am --directory=<prefix> (author preserved)
+  M->>R: git am -3 --directory=<prefix> (author preserved)
   R->>R: review gates + merge
   R-->>E: next split republishes; close as landed via #NNN
 ```
-
-## Projection invariant
-
-Sibling `main` is always a projection of the monorepo. PRs are reviewed on the
-sibling but **never merged there** — they land via replay. With that rule every
-outbound push is a fast-forward, so the force-vs-external-commit hazard never
-arises. The projection guard enforces it: before pushing, verify sibling `main`
-is an ancestor of (or equal to) the freshly computed split; drift means someone
-merged on the sibling, and the run fails loudly rather than clobbering.
 
 ## `MONOREPO.md` standard
 
 A new **optional** top-level concern, distinct from the three shippable and
 three support directories: _co-developed action repositories may keep canonical
 source in the monorepo, co-located with their owning unit, and publish verbatim
-to a sibling via history-preserving subtree split._ States the inclusion test —
+to a sibling via deterministic subtree split._ States the inclusion test —
 **only repos with no other home in the monorepo and no publish-time transform**
 (skill packs/npm packages are excluded: they transform or already have a home).
 
 ## Key Decisions
 
-| Decision             | Choice                                          | Rejected alternative                                                                                                        |
-| -------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Track siblings       | Co-located source + split                       | Submodule/`vendor/` — gitlink competes with the SHA-pin and is unfetchable in single-repo proxy envs                        |
-| Publish mechanism    | History-preserving subtree split                | Content-copy (`fit-pack stage` style) — loses history, blocks pull-back; correct only for the transform-needing skill packs |
-| Split tool           | `splitsh-lite`                                  | `git subtree split` — re-walks full history every CI run, cache-cold and slow                                               |
-| Inbound              | Replay via `git am --directory` into the prefix | `git subtree pull` — ancestry mismatch with `splitsh-lite`, merge-commit noise                                              |
-| Outbound trigger     | Every push to `main` (continuous mirror)        | Tag-only — siblings drift stale between releases                                                                            |
-| `fit-bootstrap` home | `.github/actions/fit-bootstrap/`                | A forced `libraries/libbootstrap` — it is CI glue, not a shipped library                                                    |
-| Safety model         | Projection invariant + guard                    | Force-push always — silently destroys externally-merged commits                                                             |
+| Decision             | Choice                                                                          | Rejected alternative                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Track siblings       | Co-located source + split                                                       | Submodule/`vendor/` — gitlink competes with the SHA-pin; unfetchable in single-repo proxy envs                  |
+| Publish mechanism    | Verbatim subtree split                                                          | Content-copy (`fit-pack stage`) — loses history, blocks pull-back; right only for transform-needing skill packs |
+| Split tool           | `splitsh-lite`, SHA-pinned                                                      | `git subtree split` — re-walks full history each CI run; slower and cache-cold                                  |
+| Lineage continuity   | One-time force seed, then non-force forever                                     | Force every push — destroys externally-merged commits and hides drift                                           |
+| Drift detection      | The non-force push (rejection = drift)                                          | Ancestry check against a stored "last split" — needs durable state splitsh-lite has not                         |
+| Inbound              | Replay via `git am --directory`                                                 | `git subtree pull` — ancestry mismatch with splitsh-lite, merge-commit noise                                    |
+| Outbound trigger     | Every push to `main` (continuous mirror)                                        | Tag-only — siblings drift stale between releases                                                                |
+| `fit-bootstrap` home | `.github/actions/fit-bootstrap/` (prefix == sibling root; not consumed locally) | A forced `libraries/libbootstrap` — it is CI glue, not a shipped library                                        |
 
 ## Verification mapping
 
-| Criterion               | Where satisfied                                       |
-| ----------------------- | ----------------------------------------------------- |
-| 1 homes populated       | seed-import + source move                             |
-| 2 faithful projection   | `splitsh-lite` determinism + push                     |
-| 3 continuous history    | `git subtree add` seed → fast-forward                 |
-| 4 consumption unchanged | no `.gitmodules`; `uses:` pins + Dependabot untouched |
-| 5 authored pull-back    | replay recipe (`git am --directory`)                  |
-| 6 projection guarded    | projection guard in `publish-actions.yml`             |
-| 7 standard documented   | `MONOREPO.md` section + `.github/CLAUDE.md` rewrite   |
-| 8 suite green           | unchanged action behavior; workflow lint              |
+| Criterion                          | Where satisfied                                                                                |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1 homes populated                  | source move; `fit-benchmark` reusable workflow + `fit-bootstrap` sub-actions inside the prefix |
+| 2 faithful projection              | `splitsh-lite` determinism + push                                                              |
+| 3 non-force after seed             | § One-time seed + workflow passes no `--force`                                                 |
+| 4 consumption unchanged            | no `.gitmodules`; `uses:` `# v1` pins + Dependabot bumps untouched                             |
+| 5 authored pull-back               | replay recipe (`git am -3 --directory`) on a synthetic sample                                  |
+| 6 drift guarded                    | non-force push rejection (§ Projection invariant)                                              |
+| 7 standard documented              | `MONOREPO.md` section + `.github/CLAUDE.md` rewrite                                            |
+| 8 suite green over relocated trees | check/test/format/invariant run after the five sources move                                    |
 
 ## Risks
 
-- **Seed import done wrong → first publish force-clobbers the sibling.**
-  Mitigation: `git subtree add` from each sibling's current `main` before the
-  first run; criterion 3 asserts a fast-forward.
-- **`splitsh-lite` supply chain.** It is a third-party binary on the publish
-  path. Mitigation: pin by SHA and stage it through the security-engineer review
-  the dependency policy already requires.
-- **Someone merges a PR on the sibling.** Mitigation: the projection guard fails
-  the run; recovery is to replay that commit into the monorepo, then republish.
+- **Seed force-replace done on the wrong ref → published lineage broken.**
+  Mitigation: the seed is a single, reviewed maintainer step; thereafter the
+  workflow can never force-push (it passes no `--force`).
+- **`splitsh-lite` version drift breaks the fast-forward.** A different binary
+  version can emit different commit SHAs, turning the next push into a
+  non-fast-forward. Mitigation: pin `splitsh-lite` by SHA; treat a bump as a
+  re-seed, staged through security-engineer review per dependency policy.
+- **App not installed on every sibling.** With `fail-fast: false` one matrix leg
+  fails silently. Mitigation: criterion checks all five publish; document the
+  install set.
+- **Someone merges a PR on the sibling.** The non-force push is rejected and the
+  run fails; recovery is to replay that commit into the monorepo, then
+  republish.
 - **Reusable-workflow / sub-action paths.** `fit-benchmark`'s
   `.github/workflows/benchmark.yml` and `fit-bootstrap`'s sub-actions must sit
-  inside the prefix or consumers break. Mitigation: criterion 1 checks for them
-  explicitly.
+  inside the prefix or consumers break. Mitigation: criterion 1 checks for them.

--- a/specs/2140-subtree-split-actions/spec.md
+++ b/specs/2140-subtree-split-actions/spec.md
@@ -1,0 +1,124 @@
+# Spec 2140: Publish composite actions as bidirectional subtree splits from monorepo-canonical sources
+
+**Classification:** Internal. The change moves composite-action source into the
+monorepo (`libraries/`, `products/kata/`, `.github/`), adds a publish workflow,
+and adds a section to the `MONOREPO.md` structure standard. Consumption is
+unchanged — workflows keep SHA-pinning the published sibling repos — so there is
+no external break: the
+`forwardimpact/{fit-bootstrap,fit-wiki,fit-benchmark,fit-harness,kata-agent}`
+repos keep their names, tags, and `@v1` markers.
+
+## Problem
+
+The monorepo is "the source of truth for `forwardimpact/*` sibling repos." Two
+of the three sibling classes already live by that rule: **skill packs** and
+**npm packages** are authored in the monorepo and published outward (skill packs
+by `publish-skills.yml`, npm by `publish-npm.yml`). The third class — the five
+**composite actions** — is the lone exception. Their source exists only in the
+sibling repos; they are edited _on the sibling_, then consumed back through
+SHA-pinned `uses:` lines bumped by Dependabot.
+
+That exception costs three things:
+
+- **No shared context when editing.** Editing an action means leaving the
+  monorepo, so the contributor (human or agent) loses the monorepo's
+  `CLAUDE.md`, `CONTRIBUTING.md`, checklists, and quality commands — the very
+  context that defines how work here is done.
+- **Hostile to restricted environments.** Some environments (for example
+  network-proxied agent runners) can reach only a single repository's remote.
+  Today this is worked around ad hoc with `GH_TOKEN` and the `gh` CLI per
+  [`.github/CLAUDE.md`](../../.github/CLAUDE.md). Source that lives only on the
+  sibling is unreachable there; source that travels with the monorepo is not.
+- **Two mechanisms for one job.** "Publish a monorepo subtree to a sibling repo"
+  already exists for skill packs, but the actions don't use it, so the model a
+  contributor must hold is inconsistent across otherwise-identical siblings.
+
+The actions are also **open source**, so external contributors can and do open
+PRs against the standalone action repos. Today there is no defined path to bring
+those contributions back; they land on the sibling and risk being overwritten by
+the next change pushed from the monorepo.
+
+## Why this is separate from skill-pack publishing
+
+Skill packs need a **transform**: their monorepo form under `.claude/skills/` is
+not their published form (`fit-pack stage` rewrites them into the `.apm/` layout
+with generated `apm.yml`/`README.md`). A content-copy publisher is correct for
+them.
+
+The actions need **no transform**: an action's form in the monorepo _is_ its
+published form — `action.yml` and its files, verbatim at the repo root. Combined
+with the open-source pull-back requirement, this calls for a
+**history-preserving, bidirectional split**, not a content-copy. The two sibling
+classes have different requirements and keep different mechanisms.
+
+## Scope
+
+In scope:
+
+| Item                   | What changes                                                                                                                                                                                                                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Action source homes    | Each action's canonical source moves into the monorepo, co-located with its owning unit (homes enumerated below). History is imported from the existing sibling so the first publish continues, not replaces, sibling history                                                   |
+| Outbound publish       | A new workflow publishes each action verbatim to its sibling's `main` as a history-preserving subtree split, on every push to `main` that touches its source (continuous mirror). Cross-repo auth uses a per-repo scoped GitHub App token, as `publish-skills.yml` already does |
+| Inbound pull-back      | A defined, repeatable procedure brings an external sibling PR's commits back into the monorepo prefix, preserving authorship, as a normal monorepo PR subject to the usual gates                                                                                                |
+| Projection invariant   | Sibling `main` is always a projection of the monorepo: external PRs are reviewed on the sibling but never merged there — they land via the monorepo and reappear on the next publish                                                                                            |
+| `MONOREPO.md` standard | A new section documents co-located action sources + subtree-split publishing as an optional repository-structure standard                                                                                                                                                       |
+| `.github/CLAUDE.md`    | The "Editing a published action" guidance is replaced: actions are now edited in the monorepo and published outward; the "edit on the sibling" exception is retired                                                                                                             |
+
+Action homes:
+
+| Action          | Sibling repo                  | Monorepo home                                 |
+| --------------- | ----------------------------- | --------------------------------------------- |
+| `fit-harness`   | `forwardimpact/fit-harness`   | `libraries/libharness/actions/fit-harness/`   |
+| `fit-benchmark` | `forwardimpact/fit-benchmark` | `libraries/libharness/actions/fit-benchmark/` |
+| `fit-wiki`      | `forwardimpact/fit-wiki`      | `libraries/libwiki/actions/fit-wiki/`         |
+| `kata-agent`    | `forwardimpact/kata-agent`    | `products/kata/actions/kata-agent/`           |
+| `fit-bootstrap` | `forwardimpact/fit-bootstrap` | `.github/actions/fit-bootstrap/`              |
+
+Each home mirrors the **whole sibling repo root**, not just `action.yml`:
+`fit-benchmark` ships a reusable workflow (`.github/workflows/benchmark.yml`,
+pinned by `eval-kata.yml`) and `fit-bootstrap` ships sub-actions; both travel
+inside the prefix.
+
+Out of scope:
+
+- **Consumption model.** Workflows keep SHA-pinning the siblings with the `# v1`
+  marker; Dependabot keeps bumping them. No submodule/gitlink is introduced. The
+  pinning, trust, and tag-move policies in `.github/CLAUDE.md` are unchanged.
+- **Release tagging.** Append-only `v1.0.x` tags stay human-gated; the publish
+  workflow mirrors `main` only and never creates or moves tags.
+- **Skill-pack and npm publishing.** `publish-skills.yml` / `publish-npm.yml`
+  and `fit-pack stage` are untouched.
+- **Sibling repo identities.** No sibling is renamed, created, or deleted.
+- **Action behavior.** Moving source changes no action's runtime behavior.
+
+## Success Criteria
+
+| #   | Criterion                                                                                                                                           | Verified by                                                                                                                                 |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Each of the five actions has its canonical source at its mapped monorepo home, with `action.yml` (and any sub-actions / reusable workflows) present | `test -f` each `action.yml`; `fit-benchmark` home contains `.github/workflows/benchmark.yml`; `fit-bootstrap` home contains its sub-actions |
+| 2   | A push to `main` touching an action's source republishes its sibling `main` as a byte-faithful projection of the prefix at that commit              | publish workflow run is green; sibling `main` tree equals the monorepo prefix tree                                                          |
+| 3   | Imported history is continuous — the first publish fast-forwards the sibling rather than force-replacing it                                         | publish run reports a non-force update; sibling history retains pre-migration commits                                                       |
+| 4   | Consumption is unchanged and no gitlink is introduced                                                                                               | `uses:` lines still resolve to sibling SHAs with `# v1`; `test ! -f .gitmodules`; Dependabot config still targets the siblings              |
+| 5   | An external sibling PR can be replayed into the monorepo prefix preserving author identity, as a monorepo PR                                        | documented procedure executed on a sample PR; resulting monorepo commit shows the original author                                           |
+| 6   | The projection invariant is documented and guarded — sibling `main` carries no commit absent from the monorepo                                      | a check (or documented gate) compares sibling `main` against the latest publish output                                                      |
+| 7   | `MONOREPO.md` documents the standard and `.github/CLAUDE.md` no longer instructs editing actions on the sibling                                     | both sections present/updated; no remaining "edit on the sibling" instruction                                                               |
+| 8   | Full quality suite passes                                                                                                                           | repository check, test, format, and invariant commands all green                                                                            |
+
+## Persona and Job
+
+Serves **Internal contributors** — who gain the monorepo's full context, quality
+gates, and single-repo reachability when editing CI actions — and **Platform
+Builders** (the Gear audience), for whom composite actions are shared
+agent-capable building blocks now authored and proven in one place. It also lets
+**external contributors** improve the open-source action repos with a defined
+path back to canonical source.
+
+## Open decisions (resolved with the requester)
+
+| Decision                                             | Resolution                                                                                                                                       |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Track siblings as submodules at `vendor/<sibling>/`? | **No** — a gitlink is a second version reference competing with the SHA-pin (one home per policy) and is unfetchable in single-repo environments |
+| Publish mechanism                                    | **History-preserving subtree split**, not content-copy — actions publish verbatim and require bidirectional pull-back (open source)              |
+| Where each action lives                              | **Co-located with its owning unit**; `fit-bootstrap` (no owning library) homes at `.github/actions/fit-bootstrap/`                               |
+| Outbound trigger                                     | **Every push to `main`** touching an action's source — continuous mirror, matching `publish-skills.yml`; release tags laid separately            |
+| Canonical edit surface                               | **The monorepo.** Sibling `main` is a projection; PRs are reviewed on the sibling but land via the monorepo                                      |

--- a/specs/2140-subtree-split-actions/spec.md
+++ b/specs/2140-subtree-split-actions/spec.md
@@ -6,7 +6,7 @@ and adds a section to the `MONOREPO.md` structure standard. Consumption is
 unchanged — workflows keep SHA-pinning the published sibling repos — so there is
 no external break: the
 `forwardimpact/{fit-bootstrap,fit-wiki,fit-benchmark,fit-harness,kata-agent}`
-repos keep their names, tags, and `@v1` markers.
+repos keep their names, tags, and `# v1` SHA-pin markers.
 
 ## Problem
 
@@ -47,22 +47,22 @@ them.
 
 The actions need **no transform**: an action's form in the monorepo _is_ its
 published form — `action.yml` and its files, verbatim at the repo root. Combined
-with the open-source pull-back requirement, this calls for a
-**history-preserving, bidirectional split**, not a content-copy. The two sibling
-classes have different requirements and keep different mechanisms.
+with the open-source pull-back requirement, this calls for a **deterministic,
+bidirectional split**, not a content-copy. The two sibling classes have
+different requirements and keep different mechanisms.
 
 ## Scope
 
 In scope:
 
-| Item                   | What changes                                                                                                                                                                                                                                                                    |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Action source homes    | Each action's canonical source moves into the monorepo, co-located with its owning unit (homes enumerated below). History is imported from the existing sibling so the first publish continues, not replaces, sibling history                                                   |
-| Outbound publish       | A new workflow publishes each action verbatim to its sibling's `main` as a history-preserving subtree split, on every push to `main` that touches its source (continuous mirror). Cross-repo auth uses a per-repo scoped GitHub App token, as `publish-skills.yml` already does |
-| Inbound pull-back      | A defined, repeatable procedure brings an external sibling PR's commits back into the monorepo prefix, preserving authorship, as a normal monorepo PR subject to the usual gates                                                                                                |
-| Projection invariant   | Sibling `main` is always a projection of the monorepo: external PRs are reviewed on the sibling but never merged there — they land via the monorepo and reappear on the next publish                                                                                            |
-| `MONOREPO.md` standard | A new section documents co-located action sources + subtree-split publishing as an optional repository-structure standard                                                                                                                                                       |
-| `.github/CLAUDE.md`    | The "Editing a published action" guidance is replaced: actions are now edited in the monorepo and published outward; the "edit on the sibling" exception is retired                                                                                                             |
+| Item                   | What changes                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Action source homes    | Each action's canonical source moves into the monorepo, co-located with its owning unit (homes enumerated below)                                                                                                                                                                                                                                     |
+| Outbound publish       | A new workflow publishes each action verbatim to its sibling's `main` as a deterministic subtree split, on every push to `main` that touches its source (continuous mirror). A one-time seed establishes the lineage; subsequent pushes are non-force. Cross-repo auth uses a per-repo scoped GitHub App token, as `publish-skills.yml` already does |
+| Inbound pull-back      | A defined, repeatable procedure brings an external sibling PR's commits back into the monorepo prefix, preserving authorship, as a normal monorepo PR subject to the usual gates                                                                                                                                                                     |
+| Projection invariant   | Sibling `main` is always a projection of the monorepo: external PRs are reviewed on the sibling but never merged there — they land via the monorepo and reappear on the next publish                                                                                                                                                                 |
+| `MONOREPO.md` standard | A new section documents co-located action sources + subtree-split publishing as an optional repository-structure standard                                                                                                                                                                                                                            |
+| `.github/CLAUDE.md`    | The "Editing a published action" guidance is replaced: actions are now edited in the monorepo and published outward; the "edit on the sibling" exception is retired                                                                                                                                                                                  |
 
 Action homes:
 
@@ -74,10 +74,21 @@ Action homes:
 | `kata-agent`    | `forwardimpact/kata-agent`    | `products/kata/actions/kata-agent/`           |
 | `fit-bootstrap` | `forwardimpact/fit-bootstrap` | `.github/actions/fit-bootstrap/`              |
 
-Each home mirrors the **whole sibling repo root**, not just `action.yml`:
-`fit-benchmark` ships a reusable workflow (`.github/workflows/benchmark.yml`,
-pinned by `eval-kata.yml`) and `fit-bootstrap` ships sub-actions; both travel
-inside the prefix.
+Each home mirrors the **whole sibling repo root**, not just `action.yml` — every
+file a consumer or the sibling's own CI resolves: `fit-benchmark` ships a
+reusable workflow (`.github/workflows/benchmark.yml`, pinned by `eval-kata.yml`)
+and `fit-bootstrap` ships sub-actions, and each repo's root `LICENSE`, `README`,
+and any `.github/` meta (its own CI, `dependabot.yml`) travel inside the prefix
+so the projection is byte-faithful. `fit-bootstrap`'s home sits beside the
+repo-local composite actions under `.github/actions/`, but it is **not**
+consumed locally (`./.github/actions/...`) — it is still consumed SHA-pinned
+from the sibling, like the other four; its internal self-references already use
+the `{owner}/{repo}/{path}@{ref}` form per `.github/CLAUDE.md`, so they survive
+the projection unchanged.
+
+The migration is **seeded once**: the first publish establishes the split
+lineage on each sibling `main` (see design); pre-migration sibling history is
+preserved for blame as a best effort, not as a fast-forward guarantee.
 
 Out of scope:
 
@@ -93,16 +104,21 @@ Out of scope:
 
 ## Success Criteria
 
-| #   | Criterion                                                                                                                                           | Verified by                                                                                                                                 |
-| --- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Each of the five actions has its canonical source at its mapped monorepo home, with `action.yml` (and any sub-actions / reusable workflows) present | `test -f` each `action.yml`; `fit-benchmark` home contains `.github/workflows/benchmark.yml`; `fit-bootstrap` home contains its sub-actions |
-| 2   | A push to `main` touching an action's source republishes its sibling `main` as a byte-faithful projection of the prefix at that commit              | publish workflow run is green; sibling `main` tree equals the monorepo prefix tree                                                          |
-| 3   | Imported history is continuous — the first publish fast-forwards the sibling rather than force-replacing it                                         | publish run reports a non-force update; sibling history retains pre-migration commits                                                       |
-| 4   | Consumption is unchanged and no gitlink is introduced                                                                                               | `uses:` lines still resolve to sibling SHAs with `# v1`; `test ! -f .gitmodules`; Dependabot config still targets the siblings              |
-| 5   | An external sibling PR can be replayed into the monorepo prefix preserving author identity, as a monorepo PR                                        | documented procedure executed on a sample PR; resulting monorepo commit shows the original author                                           |
-| 6   | The projection invariant is documented and guarded — sibling `main` carries no commit absent from the monorepo                                      | a check (or documented gate) compares sibling `main` against the latest publish output                                                      |
-| 7   | `MONOREPO.md` documents the standard and `.github/CLAUDE.md` no longer instructs editing actions on the sibling                                     | both sections present/updated; no remaining "edit on the sibling" instruction                                                               |
-| 8   | Full quality suite passes                                                                                                                           | repository check, test, format, and invariant commands all green                                                                            |
+| #   | Criterion                                                                                                                                           | Verified by                                                                                                                                                              |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Each of the five actions has its canonical source at its mapped monorepo home, with `action.yml` (and any sub-actions / reusable workflows) present | `test -f` each `action.yml`; `fit-benchmark` home contains `.github/workflows/benchmark.yml`; `fit-bootstrap` home contains its sub-actions                              |
+| 2   | A push to `main` touching an action's source republishes its sibling `main` as a byte-faithful projection of the prefix at that commit              | publish workflow run is green; sibling `main` tree equals the monorepo prefix tree                                                                                       |
+| 3   | After a one-time seed, every subsequent publish is a **non-force** push; a non-fast-forward push is rejected, never forced                          | seed run recorded once; later publish runs report non-force updates; the workflow passes no `--force`/`+` refspec                                                        |
+| 4   | Consumption is unchanged and no gitlink is introduced                                                                                               | `uses:` lines still resolve to sibling SHAs carrying the `# v1` marker; `test ! -f .gitmodules`; Dependabot still bumps the sibling SHA-pins in the monorepo's workflows |
+| 5   | An external sibling PR replays into the monorepo prefix preserving author identity, via a scripted recipe whose home is named in the design         | the pull-back recipe replays a synthetic sample PR; the resulting monorepo commit's author equals the sample's author                                                    |
+| 6   | The projection invariant is enforced by an **automated guard**, not prose — a divergent sibling `main` fails the publish run                        | a seeded drift case (a commit on sibling `main` absent from the monorepo) causes the non-force push to be rejected and the workflow to fail                              |
+| 7   | `MONOREPO.md` documents the standard and `.github/CLAUDE.md` no longer instructs editing actions on the sibling                                     | both sections present/updated; no remaining "edit on the sibling" instruction                                                                                            |
+| 8   | Full quality suite passes over the relocated source trees                                                                                           | repository check, test, format, and invariant commands all green after the five sources move                                                                             |
+
+Criteria 2, 3, and 6 are verified at **publish time** (the seed run and
+subsequent workflow runs), not inside the spec/design PR gate — they assert
+behavior of the publish workflow against live siblings, which the migration PR
+exercises once and every later push re-exercises.
 
 ## Persona and Job
 
@@ -115,10 +131,10 @@ path back to canonical source.
 
 ## Open decisions (resolved with the requester)
 
-| Decision                                             | Resolution                                                                                                                                       |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Track siblings as submodules at `vendor/<sibling>/`? | **No** — a gitlink is a second version reference competing with the SHA-pin (one home per policy) and is unfetchable in single-repo environments |
-| Publish mechanism                                    | **History-preserving subtree split**, not content-copy — actions publish verbatim and require bidirectional pull-back (open source)              |
-| Where each action lives                              | **Co-located with its owning unit**; `fit-bootstrap` (no owning library) homes at `.github/actions/fit-bootstrap/`                               |
-| Outbound trigger                                     | **Every push to `main`** touching an action's source — continuous mirror, matching `publish-skills.yml`; release tags laid separately            |
-| Canonical edit surface                               | **The monorepo.** Sibling `main` is a projection; PRs are reviewed on the sibling but land via the monorepo                                      |
+| Decision                                             | Resolution                                                                                                                                                                                                      |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Track siblings as submodules at `vendor/<sibling>/`? | **No** — a gitlink is a second version reference competing with the SHA-pin (one home per policy) and is unfetchable in single-repo environments                                                                |
+| Publish mechanism                                    | **Verbatim bidirectional subtree split**, not content-copy — actions publish unchanged and must accept external PRs pulled back (open source); the split establishes one append-only published lineage (design) |
+| Where each action lives                              | **Co-located with its owning unit**; `fit-bootstrap` (no owning library) homes at `.github/actions/fit-bootstrap/`                                                                                              |
+| Outbound trigger                                     | **Every push to `main`** touching an action's source — continuous mirror, matching `publish-skills.yml`; release tags laid separately                                                                           |
+| Canonical edit surface                               | **The monorepo.** Sibling `main` is a projection; PRs are reviewed on the sibling but land via the monorepo                                                                                                     |


### PR DESCRIPTION
Spec + design for **2140 — publish composite actions as bidirectional subtree splits from monorepo-canonical sources** (lockstep spec+design, single PR).

## What

Move the five composite actions' canonical source into the monorepo, co-located with their owning unit, and publish each verbatim to its sibling repo as a deterministic subtree split. Consumption stays SHA-pinned (`# v1`); no submodule/gitlink is introduced.

| Action | Monorepo home |
|---|---|
| `fit-harness` | `libraries/libharness/actions/fit-harness/` |
| `fit-benchmark` | `libraries/libharness/actions/fit-benchmark/` |
| `fit-wiki` | `libraries/libwiki/actions/fit-wiki/` |
| `kata-agent` | `products/kata/actions/kata-agent/` |
| `fit-bootstrap` | `.github/actions/fit-bootstrap/` |

## Why

The composite actions are the lone exception to "the monorepo is source of truth for `forwardimpact/*`" — they are edited on the sibling, losing monorepo context and breaking in single-repo-proxy environments. This brings them into the same edit-here/publish-outward model as skill packs and npm packages. They use a **subtree split** (not the skill-pack content-copy) because they publish verbatim and must accept external PRs pulled back.

## Mechanism (design)

- **Outbound:** SHA-pinned `splitsh-lite` produces an append-only lineage; a one-time seed establishes it, then every push is **non-force**. A rejected non-fast-forward push *is* the drift guard — no durable state.
- **Inbound:** external sibling PRs are replayed into the prefix via `git am --directory`, preserving authorship, landing as a normal monorepo PR.
- Adds an optional `MONOREPO.md` structure standard; retires the "edit on the sibling" guidance in `.github/CLAUDE.md`.

## Review

Combined lockstep panel (spec product ×3 + spec technical ×3, design technical ×3) plus a design re-review ×3 after the core mechanism was corrected. Re-review: no blockers; consensus high/medium findings addressed. STATUS row at `design draft`.

Approval is human-only — not requesting or applying it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
