### PR TITLE
chore(2140): one-time seed workflow for action lineage

### DIFF
--- a/.github/workflows/seed-actions.yml
+++ b/.github/workflows/seed-actions.yml
@@ -1,0 +1,75 @@
+name: "Seed: Actions (one-time)"
+
+# One-time lineage seed for the co-located composite actions. Force-replaces
+# each renamed sibling's main with the splitsh-lite projection of its monorepo
+# prefix, so every later non-force publish fast-forwards. This is the ONLY
+# sanctioned force push — dispatch it once, confirm each sibling main equals its
+# prefix tree, then delete this workflow. The permanent publish-actions.yml
+# never forces. The splitsh-lite version + digest match split-and-push exactly,
+# so the seed tip and the first CI publish agree.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  seed:
+    name: ${{ matrix.action.repo }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        action:
+          - prefix: libraries/libharness/actions/harness
+            repo: harness
+          - prefix: libraries/libharness/actions/benchmark
+            repo: benchmark
+          - prefix: libraries/libwiki/actions/wiki
+            repo: wiki
+          - prefix: products/kata/actions/kata-agent
+            repo: kata-agent
+          - prefix: .github/actions/bootstrap
+            repo: bootstrap
+    steps:
+      - name: Generate installation token
+        id: ci-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.KATA_APP_ID }}
+          private-key: ${{ secrets.KATA_APP_PRIVATE_KEY }}
+          repositories: ${{ matrix.action.repo }}
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Install splitsh-lite (pinned, SHA-verified)
+        shell: bash
+        run: |
+          SPLITSH_VERSION="1.0.1"
+          SPLITSH_SHA256="2539301ce5e21d0ca44b689d0dd2c1b20d9f9e996c1fe6c462afb8af4e7141cc"
+          curl -sSfL -o splitsh.tar.gz \
+            "https://github.com/splitsh/lite/releases/download/v${SPLITSH_VERSION}/lite_linux_amd64.tar.gz"
+          echo "${SPLITSH_SHA256}  splitsh.tar.gz" | sha256sum -c -
+          tar xzf splitsh.tar.gz
+          rm splitsh.tar.gz
+          chmod +x splitsh-lite
+          sudo mv splitsh-lite /usr/local/bin/
+
+      - name: Seed sibling main with the split lineage (sanctioned force)
+        shell: bash
+        env:
+          PREFIX: ${{ matrix.action.prefix }}
+          REPO: ${{ matrix.action.repo }}
+          TOKEN: ${{ steps.ci-app.outputs.token }}
+        run: |
+          SHA="$(splitsh-lite --prefix="$PREFIX")"
+          if [ -z "$SHA" ]; then
+            echo "splitsh-lite produced no SHA for prefix ${PREFIX}" >&2
+            exit 1
+          fi
+          echo "seed ${PREFIX} -> ${SHA} (force)"
+          git push --force \
+            "https://x-access-token:${TOKEN}@github.com/forwardimpact/${REPO}.git" \
+            "${SHA}:refs/heads/main"


### PR DESCRIPTION
Adds a dispatch-only `seed-actions.yml` that force-replaces each renamed sibling's `main` with the splitsh-lite projection of its monorepo prefix (the only sanctioned force push), establishing the append-only lineage so subsequent non-force publishes fast-forward. Same pinned splitsh-lite v1.0.1 + digest as split-and-push and same per-repo App-token scoping as publish-actions.yml. Removed once the lineage is seeded (paired with enabling the push trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)