### PR TITLE
fix(2140): cross-repo push uses App token (persist-credentials:false)

### DIFF
--- a/.github/workflows/publish-actions.yml
+++ b/.github/workflows/publish-actions.yml
@@ -47,6 +47,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          # Do not leave the default-token http.extraheader in git config; it
+          # would override the App token in the cross-repo push URL and the push
+          # would be denied as github-actions[bot].
+          persist-credentials: false
 
       - uses: ./.github/actions/audit
         with:

--- a/.github/workflows/seed-actions.yml
+++ b/.github/workflows/seed-actions.yml
@@ -43,6 +43,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          # Do not leave the default-token http.extraheader in git config; it
+          # would override the App token in the cross-repo push URL and the push
+          # would be denied as github-actions[bot].
+          persist-credentials: false
 
       - name: Install splitsh-lite (pinned, SHA-verified)
         shell: bash


### PR DESCRIPTION
The seed run failed: `Permission to forwardimpact/harness denied to github-actions[bot]`. `actions/checkout` leaves a global `http.https://github.com/.extraheader` with the default `GITHUB_TOKEN`, overriding the App token in the cross-repo push URL. `persist-credentials: false` drops that header after fetch so the push URL's App token is used. Applied to both `seed-actions.yml` and the permanent `publish-actions.yml` (which would fail its first publish identically). splitsh-lite worked — the run logged `2 commits created, 3302 traversed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)