### PR TITLE
docs(2140): reframe distribution model + enum for monorepo-canonical actions

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -6,8 +6,8 @@ actions (`actions/`) they consume.
 ## Third-party actions
 
 <!-- enum:sibling-composite-actions:count -->Five<!-- /enum --> composite
-actions are published under `forwardimpact/` and SHA-pinned with a `# v1`
-marker on `uses:` lines — sibling repos this monorepo maintains:
+actions are co-located in this monorepo and published to `forwardimpact/`
+siblings, SHA-pinned with a `# v1` marker on `uses:` lines:
 
 | Action (`@v1`) | Purpose |
 |---|---|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,13 +89,14 @@ npm. It is the source of truth for `forwardimpact/*` sibling repos:
 - **Skill packs** — `forwardimpact/{fit-skills,kata-skills,coaligned-skills}`
   sync on push to `main`; install with `apm install forwardimpact/<pack>`.
   Internal skills (`libs-*`, product internals) never publish.
-- **Composite actions** —
+- **Composite actions** — co-located with their owning unit
+  (`libraries/*/actions/`, `products/*/actions/`, `.github/actions/`), published
+  verbatim to siblings by subtree split and consumed SHA-pinned via append-only
+  `v1.0.x` tags. Edit in-repo ([`.github/CLAUDE.md`](.github/CLAUDE.md)):
 
   <!-- enum:sibling-composite-actions:list -->
-  `forwardimpact/{benchmark,bootstrap,harness,kata-agent,wiki}`
+  `{benchmark,bootstrap,harness,kata-agent,wiki}`
   <!-- /enum -->
-  released via append-only `v1.0.x` tags. Edit procedure in
-  [`.github/CLAUDE.md`](.github/CLAUDE.md).
 
 Published skills teach how products **work** and **use**, not how they're
 implemented. Use fully qualified URLs, e.g.

--- a/KATA.md
+++ b/KATA.md
@@ -37,16 +37,16 @@ surfaces and sessions.
 Local composite actions under `.github/actions/` encapsulate shared CI steps:
 `audit/` and `coaligned-check/`.
 <!-- enum:sibling-composite-actions:count -->
-Five external composite actions are published
-under `forwardimpact/`:
+Five composite actions are co-located here and
+published to `forwardimpact/` siblings:
 <!-- /enum -->
 
 <!-- enum:sibling-composite-actions:list -->
-- `forwardimpact/benchmark` — coding-agent benchmarks
-- `forwardimpact/bootstrap` — the FIT CI environment
-- `forwardimpact/harness` — agent task execution
-- `forwardimpact/wiki` — agent-memory commands with fresh App token
-- `forwardimpact/kata-agent` — full Kata workflow (auth, checkout, bootstrap,
+- `benchmark` — coding-agent benchmarks
+- `bootstrap` — the FIT CI environment
+- `harness` — agent task execution
+- `wiki` — agent-memory commands with fresh App token
+- `kata-agent` — full Kata workflow (auth, checkout, bootstrap,
   eval, wiki push)
 <!-- /enum -->
 


### PR DESCRIPTION
## Summary

- Composite-action sources now live in the monorepo (co-located with their owning unit), so the docs + the `sibling-composite-actions` enum center the canonical homes rather than presenting the actions as external `forwardimpact/` repos.
- **Root `CLAUDE.md` § Distribution Model:** rewrite the composite-actions bullet to state the model — co-located sources (`libraries/*/actions`, `products/*/actions`, `.github/actions`) published verbatim to siblings by subtree split, consumed SHA-pinned — parity with the npm/skill-pack bullets. Enum brace drops the `forwardimpact/` scope.
- **`KATA.md`:** reframe the count sentence; drop `forwardimpact/` from the list (the enumerated identity is the action, co-located here).
- **`.github/CLAUDE.md` § Third-party actions:** intro now leads with "co-located in this monorepo and published to `forwardimpact/` siblings".

The enum-drift invariant compares parsed sets and `normalizeToken`/`bareSlug` both strip `forwardimpact/`, so the set is unchanged and the invariant stays green. Full home-path enumeration was rejected: it cannot fit the root `CLAUDE.md` budget (190/192 lines, 893/896 words) and the homes sit at three different roots, so the bare action name stays the stable identifier; the homes are documented in `.github/CLAUDE.md` and `MONOREPO.md`.

## Test plan

- [x] `bun run check` (incl. enumeration-drift invariant + coaligned instructions layer budgets)
- [x] root `CLAUDE.md` 190/192 lines, 893/896 words; `.github/CLAUDE.md` 113/128 lines, 766/768 words

🤖 Generated with [Claude Code](https://claude.com/claude-code)